### PR TITLE
Eliminate Ray and CSG shader source from CustomSensorVolume

### DIFF
--- a/Source/Scene/CentralBody.js
+++ b/Source/Scene/CentralBody.js
@@ -45,8 +45,6 @@ define([
         '../Shaders/CentralBodyFSDepth',
         '../Shaders/CentralBodyVSFilter',
         '../Shaders/CentralBodyFSFilter',
-        '../Shaders/Ray',
-        '../Shaders/ConstructiveSolidGeometry',
         '../Shaders/SkyAtmosphereFS',
         '../Shaders/SkyAtmosphereVS'
     ], function(
@@ -95,8 +93,6 @@ define([
         CentralBodyFSDepth,
         CentralBodyVSFilter,
         CentralBodyFSFilter,
-        ShadersRay,
-        ShadersConstructiveSolidGeometry,
         SkyAtmosphereFS,
         SkyAtmosphereVS) {
     "use strict";

--- a/Source/Scene/CustomSensorVolume.js
+++ b/Source/Scene/CustomSensorVolume.js
@@ -14,8 +14,6 @@ define([
         '../Renderer/BlendFunction',
         './ColorMaterial',
         '../Shaders/Noise',
-        '../Shaders/Ray',
-        '../Shaders/ConstructiveSolidGeometry',
         '../Shaders/SensorVolume',
         '../Shaders/CustomSensorVolumeVS',
         '../Shaders/CustomSensorVolumeFS'
@@ -34,8 +32,6 @@ define([
         BlendFunction,
         ColorMaterial,
         ShadersNoise,
-        ShadersRay,
-        ShadersConstructiveSolidGeometry,
         ShadersSensorVolume,
         CustomSensorVolumeVS,
         CustomSensorVolumeFS) {
@@ -324,10 +320,6 @@ define([
                     "#line 0\n" +
                     ShadersNoise +
                     "#line 0\n" +
-                    ShadersRay +
-                    "#line 0\n" +
-                    ShadersConstructiveSolidGeometry +
-                    "#line 0\n" +
                     ShadersSensorVolume +
                     "#line 0\n" +
                     this.material._getShaderSource() +
@@ -379,10 +371,6 @@ define([
             // Since this ignores all other materials, if a material does discard, the sensor will still be picked.
             var fsSource =
                 "#define RENDER_FOR_PICK 1\n" +
-                "#line 0\n" +
-                ShadersRay +
-                "#line 0\n" +
-                ShadersConstructiveSolidGeometry +
                 "#line 0\n" +
                 ShadersSensorVolume +
                 "#line 0\n" +


### PR DESCRIPTION
They're no longer needed and MacOS 10.6 can't handle them.  Also cleaned up CentralBody a bit so it no longer unnecessarily requires-in these shaders.
