### PR TITLE
More fixes for MacOS X 10.6

### DIFF
--- a/Source/Shaders/CentralBodyFS.glsl
+++ b/Source/Shaders/CentralBodyFS.glsl
@@ -38,6 +38,9 @@
 
 uniform sampler2D u_dayTexture;
 
+// This #ifdef is required due to a bug in Mac OS X 10.6.  It doesn't realize that
+// the uniform is unused when SHOW_NIGHT is not defined, and so it doesn't get
+// optimized out.
 #ifdef SHOW_NIGHT
 uniform sampler2D u_nightTexture;
 #endif


### PR DESCRIPTION
Added #IFDEF SHOW_NIGHT around the declaration of u_nightTexture and
nightColor().  These should be optimized out automatically since they're
only used when SHOW_NIGHT is set, but an apparent bug on this OS prevents
that from happening.
