### PR TITLE
Fix CentralBody culling during transitions.

### DIFF
--- a/Source/Scene/CentralBody.js
+++ b/Source/Scene/CentralBody.js
@@ -544,11 +544,7 @@ define([
             boundingVolume = tile.get2DBoundingSphere(projection).clone();
             boundingVolume.center = new Cartesian3(0.0, boundingVolume.center.x, boundingVolume.center.y);
         } else {
-            var bv3D = tile.get3DBoundingSphere();
-            var bv2D = tile.get2DBoundingSphere(projection);
-            boundingVolume = new BoundingSphere(
-                    bv2D.center.lerp(bv3D, this.morphTime),
-                    Math.max(bv2D.radius, bv3D.radius));
+            boundingVolume = tile.computeMorphBounds(this.morphTime, projection);
         }
         return boundingVolume;
     };

--- a/Source/Scene/Tile.js
+++ b/Source/Scene/Tile.js
@@ -227,6 +227,58 @@ define([
         return this.children;
     };
 
+    Tile.prototype.computeMorphBounds = function(morphTime, projection) {
+        var positions = [];
+
+        var lla = new Cartographic3(this.extent.west, this.extent.north, 0.0);
+        var twod = projection.project(lla);
+        twod = new Cartesian3(0.0, twod.x, twod.y);
+        positions.push(twod.lerp(this.ellipsoid.toCartesian(lla), morphTime));
+        lla.longitude = this.extent.east;
+        twod = projection.project(lla);
+        twod = new Cartesian3(0.0, twod.x, twod.y);
+        positions.push(twod.lerp(this.ellipsoid.toCartesian(lla), morphTime));
+        lla.latitude = this.extent.south;
+        twod = projection.project(lla);
+        twod = new Cartesian3(0.0, twod.x, twod.y);
+        positions.push(twod.lerp(this.ellipsoid.toCartesian(lla), morphTime));
+        lla.longitude = this.extent.west;
+        twod = projection.project(lla);
+        twod = new Cartesian3(0.0, twod.x, twod.y);
+        positions.push(twod.lerp(this.ellipsoid.toCartesian(lla), morphTime));
+
+        if (this.extent.north < 0.0) {
+            lla.latitude = this.extent.north;
+        } else if (this.extent.south > 0.0) {
+            lla.latitude = this.extent.south;
+        } else {
+            lla.latitude = 0.0;
+        }
+
+        for ( var i = 1; i < 8; ++i) {
+            var temp = -Math.PI + i * CesiumMath.PI_OVER_TWO;
+            if (this.extent.west < temp && temp < this.extent.east) {
+                lla.longitude = temp;
+                twod = projection.project(lla);
+                twod = new Cartesian3(0.0, twod.x, twod.y);
+                positions.push(twod.lerp(this.ellipsoid.toCartesian(lla), morphTime));
+            }
+        }
+
+        if (lla.latitude === 0.0) {
+            lla.longitude = this.extent.west;
+            twod = projection.project(lla);
+            twod = new Cartesian3(0.0, twod.x, twod.y);
+            positions.push(twod.lerp(this.ellipsoid.toCartesian(lla), morphTime));
+            lla.longitude = this.extent.east;
+            twod = projection.project(lla);
+            twod = new Cartesian3(0.0, twod.x, twod.y);
+            positions.push(twod.lerp(this.ellipsoid.toCartesian(lla), morphTime));
+        }
+
+        return new BoundingSphere(positions);
+    };
+
     Tile.prototype._compute3DBounds = function() {
         var positions = [];
 


### PR DESCRIPTION
The tile bounding spheres were not accurate during the morphs and were removed by frustum culling.
