### PR TITLE
Bugfix for #16 "Can't hide Cesium"

### DIFF
--- a/Source/Scene/CentralBody.js
+++ b/Source/Scene/CentralBody.js
@@ -1320,12 +1320,17 @@ define([
      * @private
      */
     CentralBody.prototype.update = function(context, sceneState) {
+        var width = context.getCanvas().clientWidth;
+        var height = context.getCanvas().clientHeight;
+
+        if (width === 0 && height === 0) {
+            return;
+        }
+
         var mode = sceneState.mode;
         var projection = sceneState.scene2D.projection;
 
         this._syncMorphTime(mode);
-
-        var width, height;
 
         if (this._dayTileProvider !== this.dayTileProvider) {
             this._dayTileProvider = this.dayTileProvider;
@@ -1380,9 +1385,6 @@ define([
         if (!this._textureCache || this._textureCache.isDestroyed()) {
             this._createTextureCache(context);
         }
-
-        width = context.getCanvas().clientWidth;
-        height = context.getCanvas().clientHeight;
 
         var createFBO = !this._fb || this._fb.isDestroyed();
         var fboDimensionsChanged = this._fb && (this._fb.getColorTexture().getWidth() !== width || this._fb.getColorTexture().getHeight() !== height);


### PR DESCRIPTION
Fix a bug in CentralBody where, if the canvas width and height are both zero, a DeveloperError was thrown when resizing the FBO attachment. If this is the case, don't update anything.
