### PR TITLE
add settings to get out through local proxy

### DIFF
--- a/Tools/proxy/build.xml
+++ b/Tools/proxy/build.xml
@@ -32,6 +32,13 @@
 			</classpath>
 		</taskdef>
 
-		<server contextPath="/proxy" allowedHostList="dev.virtualearth.net" port="8080" baseDir="." />
+		<!-- lanNoProxyHosts is a comma delimited string of servers
+			that should not be sent through the LAN Proxy (ex: localhost,myserver) -->
+		<server contextPath="/proxy"
+			allowedHostList="dev.virtualearth.net"
+			port="8080"
+			baseDir="."
+			lanProxy=""
+			lanNoProxyHosts=""/>
 	</target>
 </project>

--- a/Tools/proxy/src/com/agi/ServerTask.java
+++ b/Tools/proxy/src/com/agi/ServerTask.java
@@ -15,6 +15,8 @@ import org.eclipse.jetty.server.nio.SelectChannelConnector;
 public class ServerTask extends Task {
 	private String proxyContextPath;
 	private String allowedHostList;
+	private String lanProxy;
+	private String lanNoProxyHosts;
 	private int port;
 	private File baseDir;
 
@@ -26,7 +28,7 @@ public class ServerTask extends Task {
 			connector.setPort(this.port);
 			server.addConnector(connector);
 
-			ProxyHandler proxyHandler = new ProxyHandler(this.allowedHostList);
+			ProxyHandler proxyHandler = new ProxyHandler(this.allowedHostList, this.lanProxy, this.lanNoProxyHosts);
 			ContextHandler proxyContextHandler = new ContextHandler(this.proxyContextPath);
 			proxyContextHandler.setHandler(proxyHandler);
 
@@ -72,4 +74,13 @@ public class ServerTask extends Task {
 	public void setBaseDir(File value) {
 		this.baseDir = value;
 	}
+
+	public void setLanProxy(String host){
+		this.lanProxy = host;
+	}
+
+	public void setLanNoProxyHosts(String hosts){
+		this.lanNoProxyHosts = hosts;
+	}
+
 }

--- a/build.xml
+++ b/build.xml
@@ -371,7 +371,14 @@ if (oldContents !== contents) {
 				<fileset dir="${webProxyDirectory}" includes="**/*.jar" />
 			</classpath>
 		</taskdef>
-
-		<server proxyContextPath="/proxy" allowedHostList="server.arcgisonline.com,tile.openstreetmap.org,otile1.mqcdn.com,oatile1.mqcdn.com,tile.stamen.com,*.virtualearth.net" port="8080" baseDir="${basedir}" />
+		<!-- lanProxy is used to get out from behind a proxy on your network. (ex: proxy.company.com:80) -->
+		<!-- lanNoProxyHosts is a comma delimited string of servers
+			that should not be sent through the LAN Proxy (ex: localhost,myserver) -->
+		<server proxyContextPath="/proxy"
+			allowedHostList="localhost,server.arcgisonline.com,tile.openstreetmap.org,otile1.mqcdn.com,oatile1.mqcdn.com,dev.virtualearth.net,www2.demis.nl"
+			port="8080"
+			baseDir="${basedir}"
+			lanProxy=""
+			lanNoProxyHosts=""/>
 	</target>
 </project>

--- a/launches/runServer.launch
+++ b/launches/runServer.launch
@@ -16,6 +16,7 @@
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.ant.internal.launching.remote.InternalAntRunner"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="Cesium"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.ant.ui.AntClasspathProvider"/>
+<!--stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,address=6789,server=y,suspend=n"/-->
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_ANT_TARGETS" value="runServer,"/>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${workspace_loc:/Cesium/build.xml}"/>
 <stringAttribute key="process_factory_id" value="org.eclipse.ant.ui.remoteAntProcessFactory"/>


### PR DESCRIPTION
This is useful in the case where a user is behind a corporate network
    proxy blocking access to the internet and they need to test against a
    server that's on the internet (ex: a public WMS server).

```
<server proxyContextPath="/proxy"
  allowedHostList="localhost,server.arcgisonline.com,tile.openstreetmap.org,otile1.mqcdn.com,oatile1.mqcdn.com,dev.virtualearth.net,www2.demis.nl"
  port="8080"
  baseDir="${basedir}"
  lanProxy="proxy.ibm.com:80"
  lanNoProxyHosts="localhost"/>
```
