### PR TITLE
Added showThroughEllipsoid to CustomSensorVolume and RectangularPyramidS...

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Beta Releases
     * Changed `Tipsify.tipsify` and `Tipsify.calculateACMR` to accept an object literal instead of three separate arguments. Supplying a maximum index and cache size is now optional.
 * Added `CentralBody.northPoleColor` and `CentralBody.southPoleColor` to fill in the poles if they are not covered by a texture.
 * Added `Polygon.configureExtent` to create a polygon defined by west, south, east, and north values.
+* Added `showThroughEllipsoid` to `CustomSensorVolume` and `RectangularPyramidSensorVolume` to allow sensors to draw through Earth.
 
 ### b5 - 05/15/2012
 

--- a/Source/Scene/CustomSensorVolume.js
+++ b/Source/Scene/CustomSensorVolume.js
@@ -67,8 +67,6 @@ define([
          * <code>true</code> if this sensor will be shown; otherwise, <code>false</code>
          *
          * @type Boolean
-         *
-         * @see CustomSensorVolume#showIntersection
          */
         this.show = (typeof t.show === "undefined") ? true : t.show;
 
@@ -76,10 +74,21 @@ define([
          * DOC_TBA
          *
          * @type Boolean
-         *
-         * @see CustomSensorVolume#show
          */
         this.showIntersection = (typeof t.showIntersection === "undefined") ? true : t.showIntersection;
+
+        /**
+         * <p>
+         * Determines if a sensor intersecting the ellipsoid is drawn through the ellipsoid and potentially out
+         * to the other side, or if the part of the sensor intersecting the ellipsoid stops at the ellipsoid.
+         * </p>
+         * <p>
+         * The default is <code>false</code>, meaning the sensor will not go through the ellipsoid.
+         * </p>
+         *
+         * @type Boolean
+         */
+        this.showThroughEllipsoid = (typeof t.showThroughEllipsoid === "undefined") ? false : t.showThroughEllipsoid;
 
         /**
          * The 4x4 transformation matrix that transforms this sensor from model to world coordinates.  In it's model
@@ -152,6 +161,9 @@ define([
         this._uniforms = {
             u_model : function() {
                 return that.modelMatrix;
+            },
+            u_showThroughEllipsoid : function() {
+                return that.showThroughEllipsoid;
             },
             u_showIntersection : function() {
                 return that.showIntersection;
@@ -319,6 +331,10 @@ define([
                     depthMask : false
                 });
             }
+            // This would be better served by depth testing with a depth buffer that does not
+            // include the ellipsoid depth - or a g-buffer containing an ellipsoid mask
+            // so we can selectively depth test.
+            this._rs.depthTest.enabled = !this.showThroughEllipsoid;
 
             // Recompile shader when material changes
             if (!this._material || (this._material !== this.material)) {

--- a/Source/Scene/RectangularPyramidSensorVolume.js
+++ b/Source/Scene/RectangularPyramidSensorVolume.js
@@ -32,8 +32,6 @@ define([
          * <code>true</code> if this sensor will be shown; otherwise, <code>false</code>
          *
          * @type Boolean
-         *
-         * @see RectangularPyramidSensorVolume#showIntersection
          */
         this.show = (typeof t.show === "undefined") ? true : t.show;
 
@@ -41,10 +39,21 @@ define([
          * DOC_TBA
          *
          * @type Boolean
-         *
-         * @see RectangularPyramidSensorVolume#show
          */
         this.showIntersection = (typeof t.showIntersection === "undefined") ? true : t.showIntersection;
+
+        /**
+         * <p>
+         * Determines if a sensor intersecting the ellipsoid is drawn through the ellipsoid and potentially out
+         * to the other side, or if the part of the sensor intersecting the ellipsoid stops at the ellipsoid.
+         * </p>
+         * <p>
+         * The default is <code>false</code>, meaning the sensor will not go through the ellipsoid.
+         * </p>
+         *
+         * @type Boolean
+         */
+        this.showThroughEllipsoid = (typeof t.showThroughEllipsoid === "undefined") ? false : t.showThroughEllipsoid;
 
         /**
          * The 4x4 transformation matrix that transforms this sensor from model to world coordinates.  In it's model
@@ -147,6 +156,7 @@ define([
 
         s.show = this.show;
         s.showIntersection = this.showIntersection;
+        s.showThroughEllipsoid = this.showThroughEllipsoid;
         s.modelMatrix = this.modelMatrix;
         s.bufferUsage = this.bufferUsage;
         s.radius = this.radius;

--- a/Source/Shaders/CustomSensorVolumeFS.glsl
+++ b/Source/Shaders/CustomSensorVolumeFS.glsl
@@ -3,6 +3,8 @@
 #endif  
 
 uniform bool u_showIntersection;
+uniform bool u_showThroughEllipsoid;
+
 uniform float u_sensorRadius;
 uniform vec4 u_pickColor;
 
@@ -92,19 +94,23 @@ void main()
 {
     agi_ellipsoid ellipsoid = agi_getWgs84EllipsoidEC();
 
-    // Discard if in the ellipsoid    
-    // PERFORMANCE_IDEA: A coarse check for ellipsoid intersection could be done on the CPU first.
-    if (agi_pointInEllipsoid(ellipsoid, v_positionWC))
-    {
-        discard;
+    // Occluded by the ellipsoid?
+	if (!u_showThroughEllipsoid)
+	{
+	    // Discard if in the ellipsoid    
+	    // PERFORMANCE_IDEA: A coarse check for ellipsoid intersection could be done on the CPU first.
+	    if (agi_pointInEllipsoid(ellipsoid, v_positionWC))
+	    {
+	        discard;
+	    }
+	
+	    // Discard if in the sensor's shadow
+	    if (inSensorShadow(v_sensorVertexWC, ellipsoid, v_positionEC))
+	    {
+	        discard;
+	    }
     }
-
-    // Discard if in the sensor's shadow
-    if (inSensorShadow(v_sensorVertexWC, ellipsoid, v_positionEC))
-    {
-        discard;
-    }
-
+    
     // Discard if not in the sensor's sphere
     // PERFORMANCE_IDEA: We can omit this check if the radius is Number.POSITIVE_INFINITY.
     if (distance(v_positionEC, v_sensorVertexEC) > u_sensorRadius)


### PR DESCRIPTION
...ensorVolume to allow sensors to draw through Earth.

We don't have sensor tests yet (I know; shame on me), so test with the Sandbox.  For fun, leave `showIntersection` set to `true`.

We can also add this to complex conic sensors, but I won't be able to do it in the next two weeks.  Someone else is welcome to using this commit as an example.
