### PR TITLE
Ensure camera objects are destroyed in tests.

### DIFF
--- a/Specs/Scene/Camera2DControllerSpec.js
+++ b/Specs/Scene/Camera2DControllerSpec.js
@@ -30,8 +30,9 @@ defineSuite([
     var frustum;
     var moverate;
     var zoomrate;
-    var controller;
     var ellipsoid;
+    var controller;
+    var controller2;
 
     beforeEach(function() {
         ellipsoid = Ellipsoid.WGS84;
@@ -64,6 +65,7 @@ defineSuite([
 
     afterEach(function() {
         controller = controller && !controller.isDestroyed() && controller.destroy();
+        controller2 = controller2 && !controller2.isDestroyed() && controller2.destroy();
     });
 
     it("setReferenceFrame", function() {
@@ -138,9 +140,9 @@ defineSuite([
     it("zoomIn throws with null OrthogrphicFrustum properties", function() {
         var camera = new Camera(document);
         camera.frustum = new OrthographicFrustum();
-        var c2dc = new Camera2DController(document, camera, ellipsoid);
+        controller2 = new Camera2DController(document, camera, ellipsoid);
         expect(function () {
-            c2dc.zoomIn(moverate);
+            controller2.zoomIn(moverate);
         }).toThrow();
     });
 

--- a/Specs/Scene/CameraEventHandlerSpec.js
+++ b/Specs/Scene/CameraEventHandlerSpec.js
@@ -8,35 +8,41 @@ defineSuite([
          CameraEventType,
          MouseEventType) {
     "use strict";
-    /*global document,describe,it,expect,beforeEach*/
+    /*global document,describe,it,expect,beforeEach,afterEach*/
 
     var handler;
+    var handler2;
 
     beforeEach(function() {
         handler = new CameraEventHandler(document, CameraEventType.LEFT_DRAG);
     });
 
+    afterEach(function() {
+        handler = handler && !handler.isDestroyed() && handler.destroy();
+        handler2 = handler2 && !handler2.isDestroyed() && handler2.destroy();
+    });
+
     it("throws without a canvas", function() {
         expect(function() {
-            return new CameraEventHandler();
+            handler2 = new CameraEventHandler();
         }).toThrow();
     });
 
     it("throws without a moveType", function() {
         expect(function() {
-            return new CameraEventHandler(document);
+            handler2 = new CameraEventHandler(document);
         }).toThrow();
     });
 
     it("throws if the event type is not of CameraEventType", function() {
         expect(function() {
-            return new CameraEventHandler(document, MouseEventType.LEFT_CLICK);
+            handler2 = new CameraEventHandler(document, MouseEventType.LEFT_CLICK);
         }).toThrow();
     });
 
     it("can be constructed using the middle drag event type", function() {
         expect(function(){
-            return new CameraEventHandler(document, CameraEventType.MIDDLE_DRAG);
+            handler2 = new CameraEventHandler(document, CameraEventType.MIDDLE_DRAG);
         }).not.toThrow();
     });
 


### PR DESCRIPTION
This avoids mouse stealing after the tests are run.
