### PR TITLE
Renames for consistency

### DIFF
--- a/Apps/CesiumViewer/CesiumViewer.js
+++ b/Apps/CesiumViewer/CesiumViewer.js
@@ -159,7 +159,7 @@ define([
                             if (lastCameraCenteredObjectID !== cameraCenteredObjectID) {
                                 lastCameraCenteredObjectID = cameraCenteredObjectID;
                                 var camera = widget.scene.getCamera();
-                                camera.position = camera.position.normalize().multiplyWithScalar(5000.0);
+                                camera.position = camera.position.normalize().multiplyByScalar(5000.0);
 
                                 var controllers = camera.getControllers();
                                 controllers.removeAll();

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,8 @@ Beta Releases
    * `Ellipsoid.toCartographic3s` was renamed to `Ellipsoid.cartesianArrayToCartographicArray`.
    * `Ellipsoid.cartographicDegreesToCartesian` was removed.  Code that previously looked like `ellipsoid.cartographicDegreesToCartesian(new Cartographic(45, 50, 10))` should now look like `ellipsoid.cartographicToCartesian(Cartographic.fromDegrees(45, 50, 10))`.
    * `Math.cartographic3ToRadians`, `Math.cartographic2ToRadians`, `Math.cartographic2ToDegrees`, and `Math.cartographic3ToDegrees` were removed.  These functions are no longer needed because Cartographic instances are always represented in radians. 
+   * The `multiplyWithMatrix` function on each `Matrix` type was renamed to `multiply`. 
+   * All functions starting with `multiplyWith` now start with `multiplyBy` to be consistent with functions starting with `divideBy`. 
 * All `Cartesian2` operations now have static versions that work with any objects exposing `x` and `y` properties.
 * All `Cartesian2` operations now have static versions that work with any objects exposing `x`, `y`, and `z` properties.
 * All `Cartesian3` operations now have static versions that work with any objects exposing `x`, `y`, `z` and `w` properties.

--- a/Examples/Sandbox/CodeSnippets/Camera.js
+++ b/Examples/Sandbox/CodeSnippets/Camera.js
@@ -41,7 +41,7 @@
             xAxis.color = {red : 1.0, green : 0.0, blue : 0.0, alpha : 1.0 };
             xAxis.setPositions([
                 Cesium.Cartesian3.ZERO,
-                Cesium.Cartesian3.UNIT_X.multiplyWithScalar(100000.0)
+                Cesium.Cartesian3.UNIT_X.multiplyByScalar(100000.0)
             ]);
             primitives.add(xAxis);
 
@@ -51,7 +51,7 @@
             yAxis.color = {red : 0.0, green : 1.0, blue : 0.0, alpha : 1.0 };
             yAxis.setPositions([
                 Cesium.Cartesian3.ZERO,
-                Cesium.Cartesian3.UNIT_Y.multiplyWithScalar(100000.0)
+                Cesium.Cartesian3.UNIT_Y.multiplyByScalar(100000.0)
             ]);
             primitives.add(yAxis);
 
@@ -61,13 +61,13 @@
             zAxis.color = {red : 0.0, green : 0.0, blue : 1.0, alpha : 1.0 };
             zAxis.setPositions([
                 Cesium.Cartesian3.ZERO,
-                Cesium.Cartesian3.UNIT_Z.multiplyWithScalar(100000.0)
+                Cesium.Cartesian3.UNIT_Z.multiplyByScalar(100000.0)
             ]);
             primitives.add(zAxis);
         };
 
         this.camera = {
-            eye: new Cesium.Cartesian3(1.0, 1.0, 1.0).normalize().multiplyWithScalar(200000.0),
+            eye: new Cesium.Cartesian3(1.0, 1.0, 1.0).normalize().multiplyByScalar(200000.0),
             target: Cesium.Cartesian3.ZERO,
             up: Cesium.Cartesian3.UNIT_Z
         };

--- a/Examples/Sandbox/CodeSnippets/Picking.js
+++ b/Examples/Sandbox/CodeSnippets/Picking.js
@@ -308,7 +308,7 @@
 
             // Setup code
             var modelMatrix = Cesium.Transforms.northEastDownToFixedFrame(ellipsoid.cartographicToCartesian(Cesium.Cartographic.fromDegrees(-90.0, 0.0)));
-            modelMatrix = modelMatrix.multiplyWithMatrix(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
+            modelMatrix = modelMatrix.multiply(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
 
             sensors = new Cesium.SensorVolumeCollection(undefined);
             sensor = sensors.addRectangularPyramid({

--- a/Examples/Sandbox/CodeSnippets/SensorVolumes.js
+++ b/Examples/Sandbox/CodeSnippets/SensorVolumes.js
@@ -11,7 +11,7 @@
     Sandbox.RectangularPyramidSensorVolume = function (scene, ellipsoid, primitives) {
         this.code = function () {
             var modelMatrix = Cesium.Transforms.northEastDownToFixedFrame(ellipsoid.cartographicToCartesian(Cesium.Cartographic.fromDegrees(-90.0, 0.0)));
-            modelMatrix = modelMatrix.multiplyWithMatrix(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
+            modelMatrix = modelMatrix.multiply(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
 
             var sensors = new Cesium.SensorVolumeCollection(undefined);
             sensors.addRectangularPyramid({
@@ -31,7 +31,7 @@
     Sandbox.CustomSensorVolume = function (scene, ellipsoid, primitives) {
         this.code = function () {
             var modelMatrix = Cesium.Transforms.northEastDownToFixedFrame(ellipsoid.cartographicToCartesian(Cesium.Cartographic.fromDegrees(-90.0, 0.0)));
-            modelMatrix = modelMatrix.multiplyWithMatrix(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
+            modelMatrix = modelMatrix.multiply(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
 
             var directions = [];
             for (var i = 0; i < 20; ++i) {
@@ -58,7 +58,7 @@
     Sandbox.ConicSensorVolume = function (scene, ellipsoid, primitives) {
         this.code = function () {
             var modelMatrix = Cesium.Transforms.northEastDownToFixedFrame(ellipsoid.cartographicToCartesian(Cesium.Cartographic.fromDegrees(-90.0, 0.0)));
-            modelMatrix = modelMatrix.multiplyWithMatrix(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
+            modelMatrix = modelMatrix.multiply(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
 
             var sensors = new Cesium.SensorVolumeCollection(undefined);
             sensors.addComplexConic({
@@ -78,7 +78,7 @@
     Sandbox.ConicSensorVolumeClockAngles = function (scene, ellipsoid, primitives) {
         this.code = function () {
             var modelMatrix = Cesium.Transforms.northEastDownToFixedFrame(ellipsoid.cartographicToCartesian(Cesium.Cartographic.fromDegrees(-90.0, 0.0)));
-            modelMatrix = modelMatrix.multiplyWithMatrix(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
+            modelMatrix = modelMatrix.multiply(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
 
             var sensors = new Cesium.SensorVolumeCollection(undefined);
             sensors.addComplexConic({
@@ -147,7 +147,7 @@
     Sandbox.StripeSensorMaterial = function (scene, ellipsoid, primitives) {
         this.code = function () {
             var modelMatrix = Cesium.Transforms.northEastDownToFixedFrame(ellipsoid.cartographicToCartesian(Cesium.Cartographic.fromDegrees(-90.0, 0.0)));
-            modelMatrix = modelMatrix.multiplyWithMatrix(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
+            modelMatrix = modelMatrix.multiply(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
 
             // Also try HorizontalStripeMaterial
             var material = new Cesium.HorizontalStripeMaterial(undefined);    // Use default colors
@@ -171,7 +171,7 @@
     Sandbox.DistanceIntervalSensorMaterial = function (scene, ellipsoid, primitives) {
         this.code = function () {
             var modelMatrix = Cesium.Transforms.northEastDownToFixedFrame(ellipsoid.cartographicToCartesian(Cesium.Cartographic.fromDegrees(-90.0, 0.0)));
-            modelMatrix = modelMatrix.multiplyWithMatrix(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
+            modelMatrix = modelMatrix.multiply(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
 
             var material = new Cesium.DistanceIntervalMaterial({
                 intervals : [
@@ -224,7 +224,7 @@
     Sandbox.CheckerboardSensorMaterial = function (scene, ellipsoid, primitives) {
         this.code = function () {
             var modelMatrix = Cesium.Transforms.northEastDownToFixedFrame(ellipsoid.cartographicToCartesian(Cesium.Cartographic.fromDegrees(-90.0, 0.0)));
-            modelMatrix = modelMatrix.multiplyWithMatrix(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
+            modelMatrix = modelMatrix.multiply(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
 
             var material = new Cesium.CheckerboardMaterial({
                 lightColor : {
@@ -260,7 +260,7 @@
     Sandbox.DotSensorMaterial = function (scene, ellipsoid, primitives) {
         this.code = function () {
             var modelMatrix = Cesium.Transforms.northEastDownToFixedFrame(ellipsoid.cartographicToCartesian(Cesium.Cartographic.fromDegrees(-90.0, 0.0)));
-            modelMatrix = modelMatrix.multiplyWithMatrix(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
+            modelMatrix = modelMatrix.multiply(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
 
             var material = new Cesium.DotMaterial({
                 lightColor : {
@@ -296,7 +296,7 @@
     Sandbox.TieDyeSensorMaterial = function (scene, ellipsoid, primitives) {
         this.code = function () {
             var modelMatrix = Cesium.Transforms.northEastDownToFixedFrame(ellipsoid.cartographicToCartesian(Cesium.Cartographic.fromDegrees(-90.0, 0.0)));
-            modelMatrix = modelMatrix.multiplyWithMatrix(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
+            modelMatrix = modelMatrix.multiply(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
 
             var material = new Cesium.TieDyeMaterial(undefined);    // Use default colors
 
@@ -319,7 +319,7 @@
     Sandbox.FacetSensorMaterial = function (scene, ellipsoid, primitives) {
         this.code = function () {
             var modelMatrix = Cesium.Transforms.northEastDownToFixedFrame(ellipsoid.cartographicToCartesian(Cesium.Cartographic.fromDegrees(-90.0, 0.0)));
-            modelMatrix = modelMatrix.multiplyWithMatrix(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
+            modelMatrix = modelMatrix.multiply(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
 
             var material = new Cesium.FacetMaterial(undefined); // Use default colors
 
@@ -342,7 +342,7 @@
     Sandbox.BlobSensorMaterial = function (scene, ellipsoid, primitives) {
         this.code = function () {
             var modelMatrix = Cesium.Transforms.northEastDownToFixedFrame(ellipsoid.cartographicToCartesian(Cesium.Cartographic.fromDegrees(-90.0, 0.0)));
-            modelMatrix = modelMatrix.multiplyWithMatrix(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
+            modelMatrix = modelMatrix.multiply(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
 
             var material = new Cesium.BlobMaterial(undefined);  // Use default colors
 
@@ -370,7 +370,7 @@
             primitives.add(sensors);
 
             var modelMatrix = Cesium.Transforms.northEastDownToFixedFrame(ellipsoid.cartographicToCartesian(Cesium.Cartographic.fromDegrees(-90.0, 0.0)));
-            modelMatrix = modelMatrix.multiplyWithMatrix(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
+            modelMatrix = modelMatrix.multiply(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
 
             var lightColor = {
                 red : 1.0,
@@ -428,7 +428,7 @@
     Sandbox.ErosionSensorAnimation = function (scene, ellipsoid, primitives) {
         this.code = function () {
             var modelMatrix = Cesium.Transforms.northEastDownToFixedFrame(ellipsoid.cartographicToCartesian(Cesium.Cartographic.fromDegrees(-90.0, 0.0)));
-            modelMatrix = modelMatrix.multiplyWithMatrix(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
+            modelMatrix = modelMatrix.multiply(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
 
             var material = new Cesium.CheckerboardMaterial(undefined);
 
@@ -453,7 +453,7 @@
     Sandbox.AlphaSensorAnimation = function (scene, ellipsoid, primitives) {
         this.code = function () {
             var modelMatrix = Cesium.Transforms.northEastDownToFixedFrame(ellipsoid.cartographicToCartesian(Cesium.Cartographic.fromDegrees(-90.0, 0.0)));
-            modelMatrix = modelMatrix.multiplyWithMatrix(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
+            modelMatrix = modelMatrix.multiply(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
 
             var material = new Cesium.CheckerboardMaterial(undefined);
 
@@ -478,7 +478,7 @@
     Sandbox.AnimateSensorStripes = function (scene, ellipsoid, primitives) {
         this.code = function () {
             var modelMatrix = Cesium.Transforms.northEastDownToFixedFrame(ellipsoid.cartographicToCartesian(Cesium.Cartographic.fromDegrees(-90.0, 0.0)));
-            modelMatrix = modelMatrix.multiplyWithMatrix(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
+            modelMatrix = modelMatrix.multiply(Cesium.Matrix4.createTranslation(new Cesium.Cartesian3(3000000.0, 0.0, -3000000.0)));
 
             var material = new Cesium.HorizontalStripeMaterial(undefined);   // Use default colors
 

--- a/Examples/Sandbox/Sandbox.js
+++ b/Examples/Sandbox/Sandbox.js
@@ -45,7 +45,7 @@ var Sandbox = Sandbox || {};
         scene.setAnimation(function() {
             var camera = scene.getCamera();
             var cameraPosition = new Cesium.Cartesian4(camera.position.x, camera.position.y, camera.position.z, 1.0);
-            scene.setSunPosition(camera.transform.multiplyWithVector(cameraPosition));
+            scene.setSunPosition(camera.transform.multiplyByVector(cameraPosition));
 
             //  In case of canvas resize
             canvas.width = canvas.clientWidth;

--- a/Source/Core/AxisAlignedBoundingBox.js
+++ b/Source/Core/AxisAlignedBoundingBox.js
@@ -95,7 +95,7 @@ define([
              *
              * @type {Cartesian3}
              */
-            this.center = (min.add(max)).multiplyWithScalar(0.5);
+            this.center = (min.add(max)).multiplyByScalar(0.5);
         } else {
             this.minimum = undefined;
             this.maximum = undefined;

--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -142,7 +142,7 @@ define([
             // Find the center of the sphere found using the Naive method.
             var minBoxPt = new Cartesian3(xMin.x, yMin.y, zMin.z);
             var maxBoxPt = new Cartesian3(xMax.x, yMax.y, zMax.z);
-            var naiveCenter = (minBoxPt.add(maxBoxPt)).multiplyWithScalar(0.5);
+            var naiveCenter = (minBoxPt.add(maxBoxPt)).multiplyByScalar(0.5);
 
             // Begin 2nd pass to find naive radius and modify the ritter sphere.
             var naiveRadius = 0;

--- a/Source/Core/BoxTessellator.js
+++ b/Source/Core/BoxTessellator.js
@@ -41,7 +41,7 @@ define([
                     throw new DeveloperError('All dimensions components must be greater than or equal to zero.');
                 }
 
-                var corner = dimensions.multiplyWithScalar(0.5);
+                var corner = dimensions.multiplyByScalar(0.5);
                 minimumCorner = corner.negate();
                 maximumCorner = corner;
             }

--- a/Source/Core/Cartesian2.js
+++ b/Source/Core/Cartesian2.js
@@ -280,7 +280,7 @@ define([
      * @exception {DeveloperError} cartesian is required.
      * @exception {DeveloperError} scalar is required and must be a number.
      */
-    Cartesian2.multiplyWithScalar = function(cartesian, scalar, result) {
+    Cartesian2.multiplyByScalar = function(cartesian, scalar, result) {
         if (typeof cartesian === 'undefined') {
             throw new DeveloperError('cartesian is required');
         }
@@ -391,8 +391,8 @@ define([
         if (typeof t !== 'number') {
             throw new DeveloperError('t is required and must be a number.');
         }
-        Cartesian2.multiplyWithScalar(end, t, lerpScratch);
-        result = Cartesian2.multiplyWithScalar(start, 1.0 - t, result);
+        Cartesian2.multiplyByScalar(end, t, lerpScratch);
+        result = Cartesian2.multiplyByScalar(start, 1.0 - t, result);
         return Cartesian2.add(lerpScratch, result, result);
     };
 
@@ -623,8 +623,8 @@ define([
      *
      * @exception {DeveloperError} scalar is required and must be a number.
      */
-    Cartesian2.prototype.multiplyWithScalar = function(scalar, result) {
-        return Cartesian2.multiplyWithScalar(this, scalar, result);
+    Cartesian2.prototype.multiplyByScalar = function(scalar, result) {
+        return Cartesian2.multiplyByScalar(this, scalar, result);
     };
 
     /**

--- a/Source/Core/Cartesian3.js
+++ b/Source/Core/Cartesian3.js
@@ -299,7 +299,7 @@ define(['./DeveloperError'
      * @exception {DeveloperError} cartesian is required.
      * @exception {DeveloperError} scalar is required and must be a number.
      */
-    Cartesian3.multiplyWithScalar = function(cartesian, scalar, result) {
+    Cartesian3.multiplyByScalar = function(cartesian, scalar, result) {
         if (typeof cartesian === 'undefined') {
             throw new DeveloperError('cartesian is required');
         }
@@ -414,8 +414,8 @@ define(['./DeveloperError'
         if (typeof t !== 'number') {
             throw new DeveloperError('t is required and must be a number.');
         }
-        Cartesian3.multiplyWithScalar(end, t, lerpScratch);
-        result = Cartesian3.multiplyWithScalar(start, 1.0 - t, result);
+        Cartesian3.multiplyByScalar(end, t, lerpScratch);
+        result = Cartesian3.multiplyByScalar(start, 1.0 - t, result);
         return Cartesian3.add(lerpScratch, result, result);
     };
 
@@ -693,8 +693,8 @@ define(['./DeveloperError'
      *
      * @exception {DeveloperError} scalar is required and must be a number.
      */
-    Cartesian3.prototype.multiplyWithScalar = function(scalar, result) {
-        return Cartesian3.multiplyWithScalar(this, scalar, result);
+    Cartesian3.prototype.multiplyByScalar = function(scalar, result) {
+        return Cartesian3.multiplyByScalar(this, scalar, result);
     };
 
     /**

--- a/Source/Core/Cartesian4.js
+++ b/Source/Core/Cartesian4.js
@@ -276,7 +276,7 @@ define(['./DeveloperError'
      * @exception {DeveloperError} cartesian is required.
      * @exception {DeveloperError} scalar is required and must be a number.
      */
-    Cartesian4.multiplyWithScalar = function(cartesian, scalar, result) {
+    Cartesian4.multiplyByScalar = function(cartesian, scalar, result) {
         if (typeof cartesian === 'undefined') {
             throw new DeveloperError('cartesian is required');
         }
@@ -395,8 +395,8 @@ define(['./DeveloperError'
         if (typeof t !== 'number') {
             throw new DeveloperError('t is required and must be a number.');
         }
-        Cartesian4.multiplyWithScalar(end, t, lerpScratch);
-        result = Cartesian4.multiplyWithScalar(start, 1.0 - t, result);
+        Cartesian4.multiplyByScalar(end, t, lerpScratch);
+        result = Cartesian4.multiplyByScalar(start, 1.0 - t, result);
         return Cartesian4.add(lerpScratch, result, result);
     };
 
@@ -618,8 +618,8 @@ define(['./DeveloperError'
      *
      * @exception {DeveloperError} scalar is required and must be a number.
      */
-    Cartesian4.prototype.multiplyWithScalar = function(scalar, result) {
-        return Cartesian4.multiplyWithScalar(this, scalar, result);
+    Cartesian4.prototype.multiplyByScalar = function(scalar, result) {
+        return Cartesian4.multiplyByScalar(this, scalar, result);
     };
 
     /**

--- a/Source/Core/CatmullRomSpline.js
+++ b/Source/Core/CatmullRomSpline.js
@@ -60,10 +60,10 @@ define([
             var controlPoint2 = Cartesian3.clone(controlPoints[2].point);
 
             this._ti = controlPoint1
-                           .multiplyWithScalar(2.0)
+                           .multiplyByScalar(2.0)
                            .subtract(controlPoint2)
                            .subtract(controlPoint0)
-                           .multiplyWithScalar(0.5);
+                           .multiplyByScalar(0.5);
         }
 
         if (firstTangent) {
@@ -76,9 +76,9 @@ define([
             var controlPointn2 = Cartesian3.clone(controlPoints[n - 2].point);
 
             this._to = controlPointn0
-                           .subtract(controlPointn1.multiplyWithScalar(2.0))
+                           .subtract(controlPointn1.multiplyByScalar(2.0))
                            .add(controlPointn2)
-                           .multiplyWithScalar(0.5);
+                           .multiplyByScalar(0.5);
         }
     };
 
@@ -205,25 +205,25 @@ define([
             p0 = this._points[0].point;
             p1 = this._points[1].point;
             p2 = this._ti;
-            p3 = this._points[2].point.subtract(p0).multiplyWithScalar(0.5);
-            coefs = HermiteSpline.hermiteCoefficientMatrix.multiplyWithVector(timeVec);
+            p3 = this._points[2].point.subtract(p0).multiplyByScalar(0.5);
+            coefs = HermiteSpline.hermiteCoefficientMatrix.multiplyByVector(timeVec);
         } else if (i === this._points.length - 2) {
             p0 = this._points[i].point;
             p1 = this._points[i + 1].point;
-            p2 = p1.subtract(this._points[i - 1].point).multiplyWithScalar(0.5);
+            p2 = p1.subtract(this._points[i - 1].point).multiplyByScalar(0.5);
             p3 = this._to;
-            coefs = HermiteSpline.hermiteCoefficientMatrix.multiplyWithVector(timeVec);
+            coefs = HermiteSpline.hermiteCoefficientMatrix.multiplyByVector(timeVec);
         } else {
             p0 = this._points[i - 1].point;
             p1 = this._points[i].point;
             p2 = this._points[i + 1].point;
             p3 = this._points[i + 2].point;
-            coefs = CatmullRomSpline.catmullRomCoefficientMatrix.multiplyWithVector(timeVec);
+            coefs = CatmullRomSpline.catmullRomCoefficientMatrix.multiplyByVector(timeVec);
         }
-        p0 = p0.multiplyWithScalar(coefs.x);
-        p1 = p1.multiplyWithScalar(coefs.y);
-        p2 = p2.multiplyWithScalar(coefs.z);
-        p3 = p3.multiplyWithScalar(coefs.w);
+        p0 = p0.multiplyByScalar(coefs.x);
+        p1 = p1.multiplyByScalar(coefs.y);
+        p2 = p2.multiplyByScalar(coefs.z);
+        p3 = p3.multiplyByScalar(coefs.w);
 
         return p0.add(p1.add(p2.add(p3)));
     };

--- a/Source/Core/CubeMapEllipsoidTessellator.js
+++ b/Source/Core/CubeMapEllipsoidTessellator.js
@@ -51,7 +51,7 @@ define([
                 var delta = i / numberOfPartitions;
 
                 indices[i] = positions.length;
-                positions.push(origin.add(direction.multiplyWithScalar(delta)));
+                positions.push(origin.add(direction.multiplyByScalar(delta)));
             }
 
             return indices;
@@ -82,11 +82,11 @@ define([
                     topIndicesBuffer[numberOfPartitions] = rightBottomToTop[j];
 
                     var deltaY = j / numberOfPartitions;
-                    var offsetY = y.multiplyWithScalar(deltaY);
+                    var offsetY = y.multiplyByScalar(deltaY);
 
                     for ( var i = 1; i < numberOfPartitions; ++i) {
                         var deltaX = i / numberOfPartitions;
-                        var offsetX = x.multiplyWithScalar(deltaX);
+                        var offsetX = x.multiplyByScalar(deltaX);
 
                         topIndicesBuffer[i] = positions.length;
                         positions.push(origin.add(offsetX).add(offsetY));

--- a/Source/Core/Ellipsoid.js
+++ b/Source/Core/Ellipsoid.js
@@ -213,7 +213,7 @@ define([
         var gamma = Math.sqrt((k.x * n.x) + (k.y * n.y) + (k.z * n.z));
 
         var rSurface = k.divideByScalar(gamma);
-        return rSurface.add(n.multiplyWithScalar(position.height || 0.0));
+        return rSurface.add(n.multiplyByScalar(position.height || 0.0));
     };
 
     /**
@@ -366,7 +366,7 @@ define([
                 (positionY * positionY) * oneOverRadiiSquared.y +
                 (positionZ * positionZ) * oneOverRadiiSquared.z);
 
-        return pos.multiplyWithScalar(beta);
+        return pos.multiplyByScalar(beta);
     };
 
     /**

--- a/Source/Core/EllipsoidTangentPlane.js
+++ b/Source/Core/EllipsoidTangentPlane.js
@@ -103,8 +103,8 @@ define([
         var length = positions.length;
         for ( var i = 0; i < length; ++i) {
             var p = this.origin;
-            p = p.add(this.xAxis.multiplyWithScalar(positions[i].x));
-            p = p.add(this.yAxis.multiplyWithScalar(positions[i].y));
+            p = p.add(this.xAxis.multiplyByScalar(positions[i].x));
+            p = p.add(this.yAxis.multiplyByScalar(positions[i].y));
 
             positionsOnEllipsoid.push(this.ellipsoid.scaleToGeocentricSurface(p));
         }

--- a/Source/Core/HermiteSpline.js
+++ b/Source/Core/HermiteSpline.js
@@ -57,7 +57,7 @@ define([
      * // Add tangents
      * controlPoints[0].tangent = new Cartesian3(1125196, -161816, 270551);
      * for (var i = 1; i < controlPoints.length - 1; ++i) {
-     *     controlPoints[i].tangent = controlPoints[i + 1].point.subtract(controlPoints[i - 1].point).multiplyWithScalar(0.5);
+     *     controlPoints[i].tangent = controlPoints[i + 1].point.subtract(controlPoints[i - 1].point).multiplyByScalar(0.5);
      * }
      * controlPoints[controlPoints.length - 1].tangent = new Cartesian3(1165345, 112641, 47281);
      *
@@ -130,12 +130,12 @@ define([
         for (i = 1; i < l.length - 1; ++i) {
             l[i] = u[i] = 1.0;
             d[i] = 4.0;
-            r[i] = this._points[i + 1].point.subtract(this._points[i - 1].point).multiplyWithScalar(3.0);
+            r[i] = this._points[i + 1].point.subtract(this._points[i - 1].point).multiplyByScalar(3.0);
         }
         l[i] = 0.0;
         u[i] = 1.0;
         d[i] = 4.0;
-        r[i] = this._points[i + 1].point.subtract(this._points[i - 1].point).multiplyWithScalar(3.0);
+        r[i] = this._points[i + 1].point.subtract(this._points[i - 1].point).multiplyByScalar(3.0);
         d[i + 1] = 1.0;
         r[i + 1] = this._points[i + 1].tangent;
 
@@ -153,14 +153,14 @@ define([
         var i;
         l[0] = u[0] = 1.0;
         d[0] = 2.0;
-        r[0] = this._points[1].point.subtract(this._points[0].point).multiplyWithScalar(3.0);
+        r[0] = this._points[1].point.subtract(this._points[0].point).multiplyByScalar(3.0);
         for (i = 1; i < l.length; ++i) {
             l[i] = u[i] = 1.0;
             d[i] = 4.0;
-            r[i] = this._points[i + 1].point.subtract(this._points[i - 1].point).multiplyWithScalar(3.0);
+            r[i] = this._points[i + 1].point.subtract(this._points[i - 1].point).multiplyByScalar(3.0);
         }
         d[i] = 2.0;
-        r[i] = this._points[i].point.subtract(this._points[i - 1].point).multiplyWithScalar(3.0);
+        r[i] = this._points[i].point.subtract(this._points[i - 1].point).multiplyByScalar(3.0);
 
         var tangents = TridiagonalSystemSolver.solve(l, d, u, r);
         for (i = 0; i < this._points.length; ++i) {
@@ -221,11 +221,11 @@ define([
         var timeVec = new Cartesian4(0.0, u * u, u, 1.0);
         timeVec.x = timeVec.y * u;
 
-        var coefs = HermiteSpline.hermiteCoefficientMatrix.multiplyWithVector(timeVec);
-        var p0 = this._points[i].point.multiplyWithScalar(coefs.x);
-        var p1 = this._points[i + 1].point.multiplyWithScalar(coefs.y);
-        var p2 = this._points[i].tangent.multiplyWithScalar(coefs.z);
-        var p3 = this._points[i + 1].tangent.multiplyWithScalar(coefs.w);
+        var coefs = HermiteSpline.hermiteCoefficientMatrix.multiplyByVector(timeVec);
+        var p0 = this._points[i].point.multiplyByScalar(coefs.x);
+        var p1 = this._points[i + 1].point.multiplyByScalar(coefs.y);
+        var p2 = this._points[i].tangent.multiplyByScalar(coefs.z);
+        var p3 = this._points[i + 1].tangent.multiplyByScalar(coefs.w);
 
         return p0.add(p1.add(p2.add(p3)));
     };

--- a/Source/Core/IntersectionTests.js
+++ b/Source/Core/IntersectionTests.js
@@ -57,7 +57,7 @@ define([
                 return undefined;
             }
 
-            return origin.add(direction.multiplyWithScalar(t));
+            return origin.add(direction.multiplyByScalar(t));
         },
 
         /**

--- a/Source/Core/Matrix2.js
+++ b/Source/Core/Matrix2.js
@@ -116,7 +116,7 @@ define([
      *
      * @example
      * var m = Matrix2.createScale(2.0);
-     * var v = m.multiplyWithVector(new Cartesian2(1.0, 1.0));
+     * var v = m.multiplyByVector(new Cartesian2(1.0, 1.0));
      * // v is (2.0, 2.0)
      */
     Matrix2.createScale = function(scale) {
@@ -140,7 +140,7 @@ define([
      *
      * @example
      * var m = Matrix2.createNonUniformScale(new Cartesian2(1.0, 2.0));
-     * var v = m.multiplyWithVector(new Cartesian2(1.0, 1.0));
+     * var v = m.multiplyByVector(new Cartesian2(1.0, 1.0));
      * // v is (1.0, 2.0)
      */
     Matrix2.createNonUniformScale = function(scale) {

--- a/Source/Core/Matrix3.js
+++ b/Source/Core/Matrix3.js
@@ -179,7 +179,7 @@ define([
      *
      * @example
      * var m = Matrix3.createScale(2.0);
-     * var v = m.multiplyWithVector(new Cartesian3(1.0, 1.0, 1.0));
+     * var v = m.multiplyByVector(new Cartesian3(1.0, 1.0, 1.0));
      * // v is (2.0, 2.0, 2.0)
      */
     Matrix3.createScale = function(scale) {
@@ -204,7 +204,7 @@ define([
      *
      * @example
      * var m = Matrix3.createNonUniformScale(new Cartesian3(1.0, 2.0, 3.0));
-     * var v = m.multiplyWithVector(new Cartesian3(1.0, 1.0, 1.0));
+     * var v = m.multiplyByVector(new Cartesian3(1.0, 1.0, 1.0));
      * // v is (1.0, 2.0, 3.0)
      */
     Matrix3.createNonUniformScale = function(scale) {
@@ -506,7 +506,7 @@ define([
      * @param {Cartesian3} vector The vector that is multiplied with this.
      * @return {Cartesian3} The transformed vector.
      */
-    Matrix3.prototype.multiplyWithVector = function(vector) {
+    Matrix3.prototype.multiplyByVector = function(vector) {
         var vX = vector.x;
         var vY = vector.y;
         var vZ = vector.z;
@@ -533,7 +533,7 @@ define([
      * @param {Matrix3} matrix The matrix that is on the right hand side of the multiplication.
      * @return {Matrix3} The multipled matrix.
      */
-    Matrix3.prototype.multiplyWithMatrix = function(matrix) {
+    Matrix3.prototype.multiply = function(matrix) {
         var col0row0 =
             this.getColumnMajorValue(0) * matrix.getColumnMajorValue(0) +
             this.getColumnMajorValue(3) * matrix.getColumnMajorValue(1) +

--- a/Source/Core/Matrix4.js
+++ b/Source/Core/Matrix4.js
@@ -647,7 +647,7 @@ define([
      *
      * @example
      * var m = Matrix4.createScale(2.0);
-     * var v = m.multiplyWithVector(new Cartesian4(1.0, 1.0, 1.0, 1.0));
+     * var v = m.multiplyByVector(new Cartesian4(1.0, 1.0, 1.0, 1.0));
      * // v is (2.0, 2.0, 2.0, 1.0)
      */
     Matrix4.createScale = function(scale) {
@@ -673,7 +673,7 @@ define([
      *
      * @example
      * var m = Matrix4.createNonUniformScale(new Cartesian3(1.0, 2.0, 3.0));
-     * var v = m.multiplyWithVector(new Cartesian4(1.0, 1.0, 1.0, 1.0));
+     * var v = m.multiplyByVector(new Cartesian4(1.0, 1.0, 1.0, 1.0));
      * // v is (1.0, 2.0, 3.0, 1.0)
      */
     Matrix4.createNonUniformScale = function(scale) {
@@ -905,7 +905,7 @@ define([
             0.0, 1.0, 0.0, -eye.y,
             0.0, 0.0, 1.0, -eye.z,
             0.0, 0.0, 0.0, 1.0);
-        return rotation.multiplyWithMatrix(translation);
+        return rotation.multiply(translation);
     };
 
     /**
@@ -987,7 +987,7 @@ define([
         var rT = this.getRotationTranspose();
 
         // T = translation, rTT = (-rT)(T)
-        var rTT = rT.negate().multiplyWithVector(this.getTranslation());
+        var rTT = rT.negate().multiplyByVector(this.getTranslation());
 
         // [ rT, rTT ]
         // [  0,  1  ]
@@ -1140,7 +1140,7 @@ define([
      * @param {Cartesian4} vector The vector that is multiplied with this.
      * @return {Cartesian4} The transformed vector.
      */
-    Matrix4.prototype.multiplyWithVector = function(vector) {
+    Matrix4.prototype.multiplyByVector = function(vector) {
         var vX = vector.x;
         var vY = vector.y;
         var vZ = vector.z;
@@ -1181,7 +1181,7 @@ define([
      * @param {Matrix4} matrix The matrix that is on the right hand side of the multiplication.
      * @return {Matrix4} The multipled matrix.
      */
-    Matrix4.prototype.multiplyWithMatrix = function(matrix) {
+    Matrix4.prototype.multiply = function(matrix) {
         var l = this.values;
         var r = matrix.values;
 

--- a/Source/Core/Occluder.js
+++ b/Source/Core/Occluder.js
@@ -91,9 +91,9 @@ define([
         if (invCameraToOccluderDistance > occluderRadiusSqrd) {
             horizonDistance = Math.sqrt(invCameraToOccluderDistance - occluderRadiusSqrd);
             invCameraToOccluderDistance = 1.0 / Math.sqrt(invCameraToOccluderDistance);
-            horizonPlaneNormal = cameraToOccluderVec.multiplyWithScalar(invCameraToOccluderDistance);
+            horizonPlaneNormal = cameraToOccluderVec.multiplyByScalar(invCameraToOccluderDistance);
             var nearPlaneDistance = horizonDistance * horizonDistance * invCameraToOccluderDistance;
-            horizonPlanePosition = cameraPosition.add(horizonPlaneNormal.multiplyWithScalar(nearPlaneDistance));
+            horizonPlanePosition = cameraPosition.add(horizonPlaneNormal.multiplyByScalar(nearPlaneDistance));
         } else {
             horizonDistance = Number.MAX_VALUE;
         }
@@ -314,7 +314,7 @@ define([
         }
 
         var distance = occluderRadius / dot;
-        var occludeePoint = occluderPosition.add(occluderPlaneNormal.multiplyWithScalar(distance));
+        var occludeePoint = occluderPosition.add(occluderPlaneNormal.multiplyByScalar(distance));
         return {
             occludeePoint : occludeePoint,
             valid : valid
@@ -345,7 +345,7 @@ define([
             tempVec1 = Cartesian3.UNIT_Z;
         }
         var u = ((occluderPlaneNormal.dot(tempVec0)) + occluderPlaneD) / -(occluderPlaneNormal.dot(tempVec1));
-        return ((tempVec0.add(tempVec1.multiplyWithScalar(u))).subtract(occluderPosition)).normalize();
+        return ((tempVec0.add(tempVec1.multiplyByScalar(u))).subtract(occluderPosition)).normalize();
     };
 
     Occluder._rotationVector = function(occluderPosition, occluderPlaneNormal, occluderPlaneD, position, anyRotationVector) {
@@ -385,7 +385,7 @@ define([
         var cosTheta = horizonDistance * invOccluderToPositionDistance;
         var horizonPlaneDistance = cosTheta * horizonDistance;
         positionToOccluder = positionToOccluder.normalize();
-        var horizonPlanePosition = pos.add(positionToOccluder.multiplyWithScalar(horizonPlaneDistance));
+        var horizonPlanePosition = pos.add(positionToOccluder.multiplyByScalar(horizonPlaneDistance));
         var horizonCrossDistance = Math.sqrt(horizonDistanceSquared - (horizonPlaneDistance * horizonPlaneDistance));
 
         //Rotate the position to occluder vector 90 degrees
@@ -397,7 +397,7 @@ define([
         horizonCrossDirection = horizonCrossDirection.normalize();
 
         //Horizon positions
-        var offset = horizonCrossDirection.multiplyWithScalar(horizonCrossDistance);
+        var offset = horizonCrossDirection.multiplyByScalar(horizonCrossDistance);
         tempVec = ((horizonPlanePosition.add(offset)).subtract(occluderPosition)).normalize();
         var dot0 = occluderPlaneNormal.dot(tempVec);
         tempVec = ((horizonPlanePosition.subtract(offset)).subtract(occluderPosition)).normalize();

--- a/Source/Core/PolygonPipeline.js
+++ b/Source/Core/PolygonPipeline.js
@@ -319,7 +319,7 @@ define([
 
                         i = edges[edge];
                         if (!i) {
-                            subdividedPositions.push(v0.add(v1).multiplyWithScalar(0.5));
+                            subdividedPositions.push(v0.add(v1).multiplyByScalar(0.5));
                             i = subdividedPositions.length - 1;
                             edges[edge] = i;
                         }
@@ -339,7 +339,7 @@ define([
 
                         i = edges[edge];
                         if (!i) {
-                            subdividedPositions.push(v1.add(v2).multiplyWithScalar(0.5));
+                            subdividedPositions.push(v1.add(v2).multiplyByScalar(0.5));
                             i = subdividedPositions.length - 1;
                             edges[edge] = i;
                         }
@@ -359,7 +359,7 @@ define([
 
                         i = edges[edge];
                         if (!i) {
-                            subdividedPositions.push(v2.add(v0).multiplyWithScalar(0.5));
+                            subdividedPositions.push(v2.add(v0).multiplyByScalar(0.5));
                             i = subdividedPositions.length - 1;
                             edges[edge] = i;
                         }
@@ -432,7 +432,7 @@ define([
                     p = ellipsoid.scaleToGeodeticSurface(p);
 
                     var n = ellipsoid.geodeticSurfaceNormal(p);
-                    n = n.multiplyWithScalar(height);
+                    n = n.multiplyByScalar(height);
 
                     // Translate from surface to height.
                     p = p.add(n);

--- a/Source/Core/Quaternion.js
+++ b/Source/Core/Quaternion.js
@@ -174,7 +174,7 @@ define([
      */
     Quaternion.prototype.inverse = function(result) {
         var normSquared = this.normSquared();
-        return this.conjugate(result).multiplyWithScalar(1.0 / normSquared, result);
+        return this.conjugate(result).multiplyByScalar(1.0 / normSquared, result);
     };
 
     /**
@@ -278,7 +278,7 @@ define([
      *
      * @see Quaternion#divideByScalar
      */
-    Quaternion.prototype.multiplyWithScalar = function(scalar, result) {
+    Quaternion.prototype.multiplyByScalar = function(scalar, result) {
         if (typeof result === 'undefined') {
             result = new Quaternion();
         }
@@ -298,7 +298,7 @@ define([
      *
      * @return {Quaternion} This quaternion divided by a scalar.
      *
-     * @see Quaternion#multiplyWithScalar
+     * @see Quaternion#multiplyByScalar
      */
     Quaternion.prototype.divideByScalar = function(scalar) {
         return new Quaternion(this.x / scalar, this.y / scalar, this.z / scalar, this.w / scalar);
@@ -416,7 +416,7 @@ define([
      */
     Quaternion.prototype.lerp = function(t, q) {
         var quaternion = Quaternion.clone(q);
-        return this.multiplyWithScalar(1.0 - t).add(quaternion.multiplyWithScalar(t));
+        return this.multiplyByScalar(1.0 - t).add(quaternion.multiplyByScalar(t));
     };
 
     /**
@@ -448,10 +448,10 @@ define([
         }
 
         var theta = Math.acos(dot);
-        var scaledP = this.multiplyWithScalar(Math.sin((1 - t) * theta));
-        var scaledR = r.multiplyWithScalar(Math.sin(t * theta));
+        var scaledP = this.multiplyByScalar(Math.sin((1 - t) * theta));
+        var scaledR = r.multiplyByScalar(Math.sin(t * theta));
         var sum = scaledP.add(scaledR);
-        var result = sum.multiplyWithScalar(1.0 / Math.sin(theta));
+        var result = sum.multiplyByScalar(1.0 / Math.sin(theta));
 
         return result;
     };
@@ -483,7 +483,7 @@ define([
      * @return {Quaternion} This quaternion raised to the <code>t</code> power.
      */
     Quaternion.prototype.power = function(t) {
-        return Quaternion.exp(this.log().multiplyWithScalar(t));
+        return Quaternion.exp(this.log().multiplyByScalar(t));
     };
 
     /**

--- a/Source/Core/Ray.js
+++ b/Source/Core/Ray.js
@@ -55,7 +55,7 @@ define(['./Cartesian3', './DeveloperError'], function(Cartesian3, DeveloperError
      */
     Ray.prototype.getPoint = function(t) {
         t = (typeof t === 'undefined') ? 0.0 : t;
-        return this.origin.add(this.direction.multiplyWithScalar(t));
+        return this.origin.add(this.direction.multiplyByScalar(t));
     };
 
     return Ray;

--- a/Source/Core/Shapes.js
+++ b/Source/Core/Shapes.js
@@ -33,10 +33,10 @@ define([
 
             temp = -Math.cos(azimuth);
 
-            rotAxis = eastVec.multiplyWithScalar(temp);
+            rotAxis = eastVec.multiplyByScalar(temp);
 
             temp = Math.sin(azimuth);
-            tempVec = northVec.multiplyWithScalar(temp);
+            tempVec = northVec.multiplyByScalar(temp);
 
             rotAxis = rotAxis.add(tempVec);
 
@@ -55,9 +55,9 @@ define([
             var unitQuat = (new Quaternion(rotAxis.x * temp, rotAxis.y * temp, rotAxis.z * temp, Math.cos(angle / 2.0))).normalize();
             var rotMtx = unitQuat.toRotationMatrix();
 
-            var tmpEllipsePts = rotMtx.multiplyWithVector(unitPos);
+            var tmpEllipsePts = rotMtx.multiplyByVector(unitPos);
             var unitCart = tmpEllipsePts.normalize();
-            tmpEllipsePts = unitCart.multiplyWithScalar(mag);
+            tmpEllipsePts = unitCart.multiplyByScalar(mag);
             ellipsePts[ellipsePtsIndex] = tmpEllipsePts;
         }
     }
@@ -187,7 +187,7 @@ define([
             var tempVec = new Cartesian3(0.0, 0.0, 1);
             var temp = 1.0 / mag;
 
-            var unitPos = surfPos.multiplyWithScalar(temp);
+            var unitPos = surfPos.multiplyByScalar(temp);
             var eastVec = tempVec.cross(surfPos).normalize();
             var northVec = unitPos.cross(eastVec);
 

--- a/Source/Core/SunPosition.js
+++ b/Source/Core/SunPosition.js
@@ -132,7 +132,7 @@ define([
                     0.0,                            1.0, 0.0,
                     -1.0 * Math.sin(latitudeAngle), 0.0, Math.cos(latitudeAngle));
 
-            var direction = transform.multiplyWithVector(new Cartesian3(x, y, z));
+            var direction = transform.multiplyByVector(new Cartesian3(x, y, z));
             var distance = distanceToSunInAU * AU_TO_METERS;
 
             /**
@@ -144,7 +144,7 @@ define([
                  *
                  * @type Cartesian3
                  */
-                position : direction.multiplyWithScalar(distance),
+                position : direction.multiplyByScalar(distance),
 
                 /**
                  * The cartographic position, in radians, of the sun's position projected onto Earth.  This is accurate to within less than a degree of the true position.

--- a/Source/Core/Transforms.js
+++ b/Source/Core/Transforms.js
@@ -168,9 +168,9 @@ define([
             }
 
             var pnt = new Cartesian4(point.x, point.y, point.z, 1.0);
-            pnt = modelViewProjectionMatrix.multiplyWithVector(pnt);
-            pnt = pnt.multiplyWithScalar(1.0 / pnt.w);
-            pnt = viewportTransformation.multiplyWithVector(pnt);
+            pnt = modelViewProjectionMatrix.multiplyByVector(pnt);
+            pnt = pnt.multiplyByScalar(1.0 / pnt.w);
+            pnt = viewportTransformation.multiplyByVector(pnt);
             return Cartesian2.fromCartesian4(pnt);
         }
     };

--- a/Source/Core/TridiagonalSystemSolver.js
+++ b/Source/Core/TridiagonalSystemSolver.js
@@ -76,23 +76,23 @@ define(['./DeveloperError'], function(DeveloperError) {
         d.length = x.length = right.length;
 
         c[0] = upper[0] / diagonal[0];
-        d[0] = right[0].multiplyWithScalar(1.0 / diagonal[0]);
+        d[0] = right[0].multiplyByScalar(1.0 / diagonal[0]);
 
         var scalar, i = 1;
         for (; i < c.length; ++i) {
             scalar = 1.0 / (diagonal[i] - c[i - 1] * lower[i - 1]);
             c[i] = upper[i] * scalar;
-            d[i] = right[i].subtract(d[i - 1].multiplyWithScalar(lower[i - 1]));
-            d[i] = d[i].multiplyWithScalar(scalar);
+            d[i] = right[i].subtract(d[i - 1].multiplyByScalar(lower[i - 1]));
+            d[i] = d[i].multiplyByScalar(scalar);
         }
 
         scalar = 1.0 / (diagonal[i] - c[i - 1] * lower[i - 1]);
-        d[i] = right[i].subtract(d[i - 1].multiplyWithScalar(lower[i - 1]));
-        d[i] = d[i].multiplyWithScalar(scalar);
+        d[i] = right[i].subtract(d[i - 1].multiplyByScalar(lower[i - 1]));
+        d[i] = d[i].multiplyByScalar(scalar);
 
         x[x.length - 1] = d[d.length - 1];
         for (i = x.length - 2; i >= 0; --i) {
-            x[i] = d[i].subtract(x[i + 1].multiplyWithScalar(c[i]));
+            x[i] = d[i].subtract(x[i + 1].multiplyByScalar(c[i]));
         }
 
         return x;

--- a/Source/DojoWidgets/CesiumWidget.js
+++ b/Source/DojoWidgets/CesiumWidget.js
@@ -210,7 +210,7 @@ define([
 
             var camera = scene.getCamera(), maxRadii = ellipsoid.getRadii().getMaximumComponent();
 
-            camera.position = camera.position.multiplyWithScalar(1.5);
+            camera.position = camera.position.multiplyByScalar(1.5);
             camera.frustum.near = 0.0002 * maxRadii;
             camera.frustum.far = 50.0 * maxRadii;
 

--- a/Source/Renderer/UniformState.js
+++ b/Source/Renderer/UniformState.js
@@ -295,7 +295,7 @@ define([
         if (this._modelViewDirty) {
             this._modelViewDirty = false;
 
-            var mv = this._view.multiplyWithMatrix(this._model);
+            var mv = this._view.multiply(this._model);
             this._modelView = mv;
         }
     };
@@ -341,7 +341,7 @@ define([
         if (this._viewProjectionDirty) {
             this._viewProjectionDirty = false;
 
-            var vp = this.getProjection().multiplyWithMatrix(this.getView());
+            var vp = this.getProjection().multiply(this.getView());
             this._viewProjection = vp;
         }
     };
@@ -364,7 +364,7 @@ define([
         if (this._modelViewProjectionDirty) {
             this._modelViewProjectionDirty = false;
 
-            var mvp = this._projection.multiplyWithMatrix(this.getModelView());
+            var mvp = this._projection.multiply(this.getModelView());
             this._modelViewProjection = mvp;
         }
     };
@@ -387,7 +387,7 @@ define([
         if (this._modelViewInfiniteProjectionDirty) {
             this._modelViewInfiniteProjectionDirty = false;
 
-            var mvp = this._infiniteProjection.multiplyWithMatrix(this.getModelView());
+            var mvp = this._infiniteProjection.multiply(this.getModelView());
             this._modelViewInfiniteProjection = mvp;
         }
     };
@@ -459,7 +459,7 @@ define([
             this._sunDirectionECDirty = false;
 
             var sunPosition = new Cartesian4(this._sunPosition.x, this._sunPosition.y, this._sunPosition.z, 0.0);
-            var sunEC = this.getView().multiplyWithVector(sunPosition);
+            var sunEC = this.getView().multiplyByVector(sunPosition);
             var p = new Cartesian3(sunEC.x, sunEC.y, sunEC.z).normalize();
 
             this._sunDirectionEC = p;

--- a/Source/Scene/Billboard.js
+++ b/Source/Scene/Billboard.js
@@ -521,8 +521,8 @@ define([
         // This function is basically a stripped-down JavaScript version of BillboardCollectionVS.glsl
 
         // Model to eye coordinates
-        var mv = uniformState.getView().multiplyWithMatrix(modelMatrix);
-        var positionEC = mv.multiplyWithVector(new Cartesian4(position.x, position.y, position.z, 1.0));
+        var mv = uniformState.getView().multiply(modelMatrix);
+        var positionEC = mv.multiplyByVector(new Cartesian4(position.x, position.y, position.z, 1.0));
 
         // Apply eye offset, e.g., agi_eyeOffset
         var zEyeOffset = eyeOffset.multiplyComponents(positionEC.normalize());
@@ -531,14 +531,14 @@ define([
         positionEC.z += zEyeOffset.z;
 
         // Eye to window coordinates, e.g., agi_eyeToWindowCoordinates
-        var q = uniformState.getProjection().multiplyWithVector(positionEC); // clip coordinates
+        var q = uniformState.getProjection().multiplyByVector(positionEC); // clip coordinates
         q.x /= q.w; // normalized device coordinates
         q.y /= q.w;
         q.z /= q.w;
-        var positionWC = uniformState.getViewportTransformation().multiplyWithVector(new Cartesian4(q.x, q.y, q.z, 1.0)); // window coordinates
+        var positionWC = uniformState.getViewportTransformation().multiplyByVector(new Cartesian4(q.x, q.y, q.z, 1.0)); // window coordinates
 
         // Apply pixel offset
-        var po = pixelOffset.multiplyWithScalar(uniformState.getHighResolutionSnapScale());
+        var po = pixelOffset.multiplyByScalar(uniformState.getHighResolutionSnapScale());
         positionWC.x += po.x;
         positionWC.y += po.y;
 

--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -816,7 +816,7 @@ define([
 
         for ( var i = 0; i < length; ++i) {
             var b = billboards[i];
-            var p = this.modelMatrix.multiplyWithVector(new Cartesian4(b.getPosition().x, b.getPosition().y, b.getPosition().z, 1.0));
+            var p = this.modelMatrix.multiplyByVector(new Cartesian4(b.getPosition().x, b.getPosition().y, b.getPosition().z, 1.0));
             var projectedPoint = projection.project(projection.getEllipsoid().cartesianToCartographic(new Cartesian3(p.x, p.y, p.z)));
             b._setActualPosition({
                 x : 0.0,
@@ -831,7 +831,7 @@ define([
 
         for ( var i = 0; i < length; ++i) {
             var b = billboards[i];
-            var p = this.modelMatrix.multiplyWithVector(new Cartesian4(b.getPosition().x, b.getPosition().y, b.getPosition().z, 1.0));
+            var p = this.modelMatrix.multiplyByVector(new Cartesian4(b.getPosition().x, b.getPosition().y, b.getPosition().z, 1.0));
             var projectedPoint = projection.project(projection.getEllipsoid().cartesianToCartographic(new Cartesian3(p.x, p.y, p.z)));
             b._setActualPosition({
                 x : projectedPoint.z,

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -71,7 +71,7 @@ define([
         this._invTransform = Matrix4.IDENTITY;
 
         var maxRadii = Ellipsoid.WGS84.getRadii().getMaximumComponent();
-        var position = new Cartesian3(0.0, -2.0, 1.0).normalize().multiplyWithScalar(2.0 * maxRadii);
+        var position = new Cartesian3(0.0, -2.0, 1.0).normalize().multiplyByScalar(2.0 * maxRadii);
 
         /**
          * The position of the camera.
@@ -247,7 +247,7 @@ define([
                                       u.x,  u.y,  u.z, -u.dot(e),
                                      -d.x, -d.y, -d.z,  d.dot(e),
                                       0.0,  0.0,  0.0,      1.0);
-        this._viewMatrix = viewMatrix.multiplyWithMatrix(this._invTransform);
+        this._viewMatrix = viewMatrix.multiply(this._invTransform);
 
         this._invViewMatrix = this._viewMatrix.inverseTransformation();
     };
@@ -286,19 +286,19 @@ define([
         }
 
         if (positionChanged || transformChanged) {
-            this._positionWC = Cartesian3.fromCartesian4(transform.multiplyWithVector(new Cartesian4(position.x, position.y, position.z, 1.0)));
+            this._positionWC = Cartesian3.fromCartesian4(transform.multiplyByVector(new Cartesian4(position.x, position.y, position.z, 1.0)));
         }
 
         if (directionChanged || transformChanged) {
-            this._directionWC = Cartesian3.fromCartesian4(transform.multiplyWithVector(new Cartesian4(direction.x, direction.y, direction.z, 0.0)));
+            this._directionWC = Cartesian3.fromCartesian4(transform.multiplyByVector(new Cartesian4(direction.x, direction.y, direction.z, 0.0)));
         }
 
         if (upChanged || transformChanged) {
-            this._upWC = Cartesian3.fromCartesian4(transform.multiplyWithVector(new Cartesian4(up.x, up.y, up.z, 0.0)));
+            this._upWC = Cartesian3.fromCartesian4(transform.multiplyByVector(new Cartesian4(up.x, up.y, up.z, 0.0)));
         }
 
         if (rightChanged || transformChanged) {
-            this._rightWC = Cartesian3.fromCartesian4(transform.multiplyWithVector(new Cartesian4(right.x, right.y, right.z, 0.0)));
+            this._rightWC = Cartesian3.fromCartesian4(transform.multiplyByVector(new Cartesian4(right.x, right.y, right.z, 0.0)));
         }
 
         if (positionChanged || directionChanged || upChanged || transformChanged) {
@@ -314,7 +314,7 @@ define([
 
                 var invUpMag = 1.0 / up.magnitudeSquared();
                 var scalar = up.dot(direction) * invUpMag;
-                var w0 = direction.multiplyWithScalar(scalar);
+                var w0 = direction.multiplyByScalar(scalar);
                 up = this._up = up.subtract(w0).normalize();
                 this.up = up.clone();
 
@@ -417,9 +417,9 @@ define([
         var y = (2.0 / height) * (height - windowPosition.y) - 1.0;
 
         var position = this.getPositionWC();
-        var nearCenter = position.add(this.getDirectionWC().multiplyWithScalar(near));
-        var xDir = this.getRightWC().multiplyWithScalar(x * near * tanTheta);
-        var yDir = this.getUpWC().multiplyWithScalar(y * near * tanPhi);
+        var nearCenter = position.add(this.getDirectionWC().multiplyByScalar(near));
+        var xDir = this.getRightWC().multiplyByScalar(x * near * tanTheta);
+        var yDir = this.getUpWC().multiplyByScalar(y * near * tanPhi);
         var direction = nearCenter.add(xDir).add(yDir).subtract(position).normalize();
 
         return new Ray(position.clone(), direction);

--- a/Source/Scene/Camera2DController.js
+++ b/Source/Scene/Camera2DController.js
@@ -403,7 +403,7 @@ define([
        var distance = start.subtract(end);
        if (distance.x !== 0) {
            position = camera.position;
-           newPosition = position.add(right.multiplyWithScalar(distance.x));
+           newPosition = position.add(right.multiplyByScalar(distance.x));
 
            var maxX = this._maxCoord.x * this._maxTranslateFactor;
            if (newPosition.x > maxX) {
@@ -417,7 +417,7 @@ define([
        }
        if (distance.y !== 0) {
            position = camera.position;
-           newPosition = position.add(up.multiplyWithScalar(distance.y));
+           newPosition = position.add(up.multiplyByScalar(distance.y));
 
            var maxY = this._maxCoord.y * this._maxTranslateFactor;
            if (newPosition.y > maxY) {
@@ -463,7 +463,7 @@ define([
 
        var camera = this._camera;
        var rotation = Quaternion.fromAxisAngle(camera.direction, theta).toRotationMatrix();
-       camera.up = rotation.multiplyWithVector(camera.up);
+       camera.up = rotation.multiplyByVector(camera.up);
        camera.right = camera.direction.cross(camera.up);
    };
 

--- a/Source/Scene/CameraCentralBodyController.js
+++ b/Source/Scene/CameraCentralBodyController.js
@@ -83,10 +83,10 @@ define([
         this._spindleController.constrainedAxis = Cartesian3.UNIT_Z;
 
         var invTransform = camera.getInverseTransform();
-        camera.position = Cartesian3.fromCartesian4(invTransform.multiplyWithVector(new Cartesian4(position.x, position.y, position.z, 1.0)));
-        camera.up = Cartesian3.fromCartesian4(invTransform.multiplyWithVector(new Cartesian4(up.x, up.y, up.z, 0.0)));
-        camera.right = Cartesian3.fromCartesian4(invTransform.multiplyWithVector(new Cartesian4(right.x, right.y, right.z, 0.0)));
-        camera.direction = Cartesian3.fromCartesian4(invTransform.multiplyWithVector(new Cartesian4(direction.x, direction.y, direction.z, 0.0)));
+        camera.position = Cartesian3.fromCartesian4(invTransform.multiplyByVector(new Cartesian4(position.x, position.y, position.z, 1.0)));
+        camera.up = Cartesian3.fromCartesian4(invTransform.multiplyByVector(new Cartesian4(up.x, up.y, up.z, 0.0)));
+        camera.right = Cartesian3.fromCartesian4(invTransform.multiplyByVector(new Cartesian4(right.x, right.y, right.z, 0.0)));
+        camera.direction = Cartesian3.fromCartesian4(invTransform.multiplyByVector(new Cartesian4(direction.x, direction.y, direction.z, 0.0)));
 
         this._spindleController._rotate(movement);
 
@@ -98,10 +98,10 @@ define([
         this._spindleController.setReferenceFrame(oldTransform, oldEllipsoid);
         this._spindleController.constrainedAxis = oldConstrainedZ;
 
-        camera.position = Cartesian3.fromCartesian4(transform.multiplyWithVector(new Cartesian4(position.x, position.y, position.z, 1.0)));
-        camera.up = Cartesian3.fromCartesian4(transform.multiplyWithVector(new Cartesian4(up.x, up.y, up.z, 0.0)));
-        camera.right = Cartesian3.fromCartesian4(transform.multiplyWithVector(new Cartesian4(right.x, right.y, right.z, 0.0)));
-        camera.direction = Cartesian3.fromCartesian4(transform.multiplyWithVector(new Cartesian4(direction.x, direction.y, direction.z, 0.0)));
+        camera.position = Cartesian3.fromCartesian4(transform.multiplyByVector(new Cartesian4(position.x, position.y, position.z, 1.0)));
+        camera.up = Cartesian3.fromCartesian4(transform.multiplyByVector(new Cartesian4(up.x, up.y, up.z, 0.0)));
+        camera.right = Cartesian3.fromCartesian4(transform.multiplyByVector(new Cartesian4(right.x, right.y, right.z, 0.0)));
+        camera.direction = Cartesian3.fromCartesian4(transform.multiplyByVector(new Cartesian4(direction.x, direction.y, direction.z, 0.0)));
     };
 
     /**

--- a/Source/Scene/CameraColumbusViewController.js
+++ b/Source/Scene/CameraColumbusViewController.js
@@ -121,7 +121,7 @@ define([
         var updateCV = function(value) {
             var interp = position.lerp(newPosition, value.time);
             var pos = new Cartesian4(interp.x, interp.y, interp.z, 1.0);
-            camera.position = Cartesian3.fromCartesian4(camera.getInverseTransform().multiplyWithVector(pos));
+            camera.position = Cartesian3.fromCartesian4(camera.getInverseTransform().multiplyByVector(pos));
         };
 
         this._translateAnimation = this._animationCollection.add({
@@ -144,18 +144,18 @@ define([
         var endRay = camera.getPickRay(movement.endPosition);
 
         var position = new Cartesian4(startRay.origin.x, startRay.origin.y, startRay.origin.z, 1.0);
-        position = Cartesian3.fromCartesian4(camera.getInverseTransform().multiplyWithVector(position));
+        position = Cartesian3.fromCartesian4(camera.getInverseTransform().multiplyByVector(position));
         var direction = new Cartesian4(startRay.direction.x, startRay.direction.y, startRay.direction.z, 0.0);
-        direction = Cartesian3.fromCartesian4(camera.getInverseTransform().multiplyWithVector(direction));
+        direction = Cartesian3.fromCartesian4(camera.getInverseTransform().multiplyByVector(direction));
         var scalar = sign * position.z / direction.z;
-        var startPlanePos = position.add(direction.multiplyWithScalar(scalar));
+        var startPlanePos = position.add(direction.multiplyByScalar(scalar));
 
         position = new Cartesian4(endRay.origin.x, endRay.origin.y, endRay.origin.z, 1.0);
-        position = Cartesian3.fromCartesian4(camera.getInverseTransform().multiplyWithVector(position));
+        position = Cartesian3.fromCartesian4(camera.getInverseTransform().multiplyByVector(position));
         direction = new Cartesian4(endRay.direction.x, endRay.direction.y, endRay.direction.z, 0.0);
-        direction = Cartesian3.fromCartesian4(camera.getInverseTransform().multiplyWithVector(direction));
+        direction = Cartesian3.fromCartesian4(camera.getInverseTransform().multiplyByVector(direction));
         scalar = sign * position.z / direction.z;
-        var endPlanePos = position.add(direction.multiplyWithScalar(scalar));
+        var endPlanePos = position.add(direction.multiplyByScalar(scalar));
 
         var diff = startPlanePos.subtract(endPlanePos);
         camera.position = camera.position.add(diff);
@@ -176,18 +176,18 @@ define([
             this._transform.setColumn3(centerWC);
 
             cameraPosition = new Cartesian4(camera.position.x, camera.position.y, camera.position.z, 1.0);
-            positionWC = camera.transform.multiplyWithVector(cameraPosition);
+            positionWC = camera.transform.multiplyByVector(cameraPosition);
 
             camera.transform = this._transform.clone();
         } else {
             var scalar = -position.z / direction.z;
-            var center = position.add(direction.multiplyWithScalar(scalar));
+            var center = position.add(direction.multiplyByScalar(scalar));
             center = new Cartesian4(center.x, center.y, center.z, 1.0);
-            centerWC = camera.transform.multiplyWithVector(center);
+            centerWC = camera.transform.multiplyByVector(center);
             this._transform.setColumn3(centerWC);
 
             cameraPosition = new Cartesian4(camera.position.x, camera.position.y, camera.position.z, 1.0);
-            positionWC = camera.transform.multiplyWithVector(cameraPosition);
+            positionWC = camera.transform.multiplyByVector(cameraPosition);
             camera.transform = this._transform.clone();
         }
 
@@ -225,7 +225,7 @@ define([
             }
         }
 
-        camera.position = Cartesian3.fromCartesian4(camera.getInverseTransform().multiplyWithVector(positionWC));
+        camera.position = Cartesian3.fromCartesian4(camera.getInverseTransform().multiplyByVector(positionWC));
     };
 
     /**

--- a/Source/Scene/CameraFlightController.js
+++ b/Source/Scene/CameraFlightController.js
@@ -81,12 +81,12 @@ define([
 
         maxStartAlt = ellipsoid.getMaximumRadius() + abovePercentage * altitude;
 
-        var aboveEnd = endPoint.normalize().multiplyWithScalar(maxStartAlt);
-        var afterStart = start.normalize().multiplyWithScalar(maxStartAlt);
+        var aboveEnd = endPoint.normalize().multiplyByScalar(maxStartAlt);
+        var afterStart = start.normalize().multiplyByScalar(maxStartAlt);
 
         var points, axis, angle, rotation;
         if (start.magnitude() > maxStartAlt && dot > 0) {
-            var middle = start.subtract(aboveEnd).multiplyWithScalar(0.5).add(aboveEnd);
+            var middle = start.subtract(aboveEnd).multiplyByScalar(0.5).add(aboveEnd);
 
             points = [{
                 point : start
@@ -110,7 +110,7 @@ define([
             for ( var i = startCondition; i > 0.0; i = i - increment) {
                 rotation = Quaternion.fromAxisAngle(axis, i).toRotationMatrix();
                 points.push({
-                    point : rotation.multiplyWithVector(aboveEnd)
+                    point : rotation.multiplyByVector(aboveEnd)
                 });
             }
 

--- a/Source/Scene/CameraFreeLookController.js
+++ b/Source/Scene/CameraFreeLookController.js
@@ -199,8 +199,8 @@ define([
 
     CameraFreeLookController.prototype._rotateTwoAxes = function(v0, v1, axis, angle) {
         var rotation = Quaternion.fromAxisAngle(axis, angle).toRotationMatrix();
-        var u0 = rotation.multiplyWithVector(v0);
-        var u1 = rotation.multiplyWithVector(v1);
+        var u0 = rotation.multiplyByVector(v0);
+        var u1 = rotation.multiplyByVector(v1);
         return [u0, u1];
     };
 
@@ -221,9 +221,9 @@ define([
         var a = Cartesian3.clone(axis);
         var turnAngle = angle || this._moveRate;
         var rotation = Quaternion.fromAxisAngle(a, turnAngle).toRotationMatrix();
-        var direction = rotation.multiplyWithVector(this._camera.direction);
-        var up = rotation.multiplyWithVector(this._camera.up);
-        var right = rotation.multiplyWithVector(this._camera.right);
+        var direction = rotation.multiplyByVector(this._camera.direction);
+        var up = rotation.multiplyByVector(this._camera.up);
+        var right = rotation.multiplyByVector(this._camera.right);
         this._camera.direction = direction;
         this._camera.up = up;
         this._camera.right = right;
@@ -253,11 +253,11 @@ define([
         var startNDC = new Cartesian2((2.0 / width) * movement.startPosition.x - 1.0, (2.0 / height) * (height - movement.startPosition.y) - 1.0);
         var endNDC = new Cartesian2((2.0 / width) * movement.endPosition.x - 1.0, (2.0 / height) * (height - movement.endPosition.y) - 1.0);
 
-        var nearCenter = camera.position.add(camera.direction.multiplyWithScalar(near));
+        var nearCenter = camera.position.add(camera.direction.multiplyByScalar(near));
 
-        var startX = camera.right.multiplyWithScalar(startNDC.x * near * tanTheta);
+        var startX = camera.right.multiplyByScalar(startNDC.x * near * tanTheta);
         startX = nearCenter.add(startX).subtract(camera.position).normalize();
-        var endX = camera.right.multiplyWithScalar(endNDC.x * near * tanTheta);
+        var endX = camera.right.multiplyByScalar(endNDC.x * near * tanTheta);
         endX = nearCenter.add(endX).subtract(camera.position).normalize();
 
         var dot = startX.dot(endX);
@@ -271,16 +271,16 @@ define([
         var rotation = Quaternion.fromAxisAngle(axis, angle).toRotationMatrix();
 
         if (1.0 - Math.abs(camera.direction.dot(axis)) > CesiumMath.EPSILON6) {
-            camera.direction = rotation.multiplyWithVector(camera.direction);
+            camera.direction = rotation.multiplyByVector(camera.direction);
         }
 
         if (1.0 - Math.abs(camera.up.dot(axis)) > CesiumMath.EPSILON6) {
-            camera.up = rotation.multiplyWithVector(camera.up);
+            camera.up = rotation.multiplyByVector(camera.up);
         }
 
-        var startY = camera.up.multiplyWithScalar(startNDC.y * near * tanPhi);
+        var startY = camera.up.multiplyByScalar(startNDC.y * near * tanPhi);
         startY = nearCenter.add(startY).subtract(camera.position).normalize();
-        var endY = camera.up.multiplyWithScalar(endNDC.y * near * tanPhi);
+        var endY = camera.up.multiplyByScalar(endNDC.y * near * tanPhi);
         endY = nearCenter.add(endY).subtract(camera.position).normalize();
 
         dot = startY.dot(endY);
@@ -294,11 +294,11 @@ define([
         rotation = Quaternion.fromAxisAngle(axis, angle).toRotationMatrix();
 
         if (1.0 - Math.abs(camera.direction.dot(axis)) > CesiumMath.EPSILON6) {
-            camera.direction = rotation.multiplyWithVector(camera.direction);
+            camera.direction = rotation.multiplyByVector(camera.direction);
         }
 
         if (1.0 - Math.abs(camera.up.dot(axis)) > CesiumMath.EPSILON6) {
-            camera.up = rotation.multiplyWithVector(camera.up);
+            camera.up = rotation.multiplyByVector(camera.up);
         }
 
         camera.right = camera.direction.cross(camera.up);

--- a/Source/Scene/CameraHelpers.js
+++ b/Source/Scene/CameraHelpers.js
@@ -9,7 +9,7 @@ define([
 
     function move(camera, direction, rate) {
         var position = camera.position;
-        var newPosition = position.add(direction.multiplyWithScalar(rate));
+        var newPosition = position.add(direction.multiplyByScalar(rate));
         camera.position = newPosition;
     }
 

--- a/Source/Scene/CameraSpindleController.js
+++ b/Source/Scene/CameraSpindleController.js
@@ -182,9 +182,9 @@ define([
         var rotation = Quaternion.fromAxisAngle(a, turnAngle).toRotationMatrix();
 
         var camera = this._camera;
-        camera.position = rotation.multiplyWithVector(camera.position);
-        camera.direction = rotation.multiplyWithVector(camera.direction);
-        camera.up = rotation.multiplyWithVector(camera.up);
+        camera.position = rotation.multiplyByVector(camera.position);
+        camera.direction = rotation.multiplyByVector(camera.direction);
+        camera.up = rotation.multiplyByVector(camera.up);
         camera.right = camera.direction.cross(camera.up);
     };
 

--- a/Source/Scene/CentralBody.js
+++ b/Source/Scene/CentralBody.js
@@ -683,7 +683,7 @@ define([
 
         this._fCameraHeight = undefined;
         this._fCameraHeight2 = undefined;
-        this._outerRadius = ellipsoid.getRadii().multiplyWithScalar(1.025).getMaximumComponent();
+        this._outerRadius = ellipsoid.getRadii().multiplyByScalar(1.025).getMaximumComponent();
 
         // TODO: Do we want to expose any of these atmosphere constants?
         var Kr = 0.0025;
@@ -902,11 +902,11 @@ define([
             var width = frustum.right - frustum.left;
             var height = frustum.top - frustum.bottom;
 
-            var lowerLeft = position.add(right.multiplyWithScalar(frustum.left));
-            lowerLeft = lowerLeft.add(up.multiplyWithScalar(frustum.bottom));
-            var upperLeft = lowerLeft.add(up.multiplyWithScalar(height));
-            var upperRight = upperLeft.add(right.multiplyWithScalar(width));
-            var lowerRight = upperRight.add(up.multiplyWithScalar(-height));
+            var lowerLeft = position.add(right.multiplyByScalar(frustum.left));
+            lowerLeft = lowerLeft.add(up.multiplyByScalar(frustum.bottom));
+            var upperLeft = lowerLeft.add(up.multiplyByScalar(height));
+            var upperRight = upperLeft.add(right.multiplyByScalar(width));
+            var lowerRight = upperRight.add(up.multiplyByScalar(-height));
 
             var x = Math.min(lowerLeft.x, lowerRight.x, upperLeft.x, upperRight.x);
             var y = Math.min(lowerLeft.y, lowerRight.y, upperLeft.y, upperRight.y);
@@ -1239,8 +1239,8 @@ define([
         var dmin = this._minTileDistance(tile.zoom, texturePixelError);
 
         var toCenter = boundingVolume.center.subtract(cameraPosition);
-        var toSphere = toCenter.normalize().multiplyWithScalar(toCenter.magnitude() - boundingVolume.radius);
-        var distance = direction.multiplyWithScalar(direction.dot(toSphere)).magnitude();
+        var toSphere = toCenter.normalize().multiplyByScalar(toCenter.magnitude() - boundingVolume.radius);
+        var distance = direction.multiplyByScalar(direction.dot(toSphere)).magnitude();
 
         if (distance > 0.0 && distance < dmin) {
             return true;
@@ -1310,14 +1310,14 @@ define([
         var mvp = description.modelViewProjection;
         var clip = description.viewportTransformation;
 
-        var center = upperLeft.add(lowerRight).multiplyWithScalar(0.5);
-        var centerScreen = mvp.multiplyWithVector(new Cartesian4(center.x, center.y, center.z, 1.0));
-        centerScreen = centerScreen.multiplyWithScalar(1.0 / centerScreen.w);
-        var centerClip = clip.multiplyWithVector(centerScreen);
+        var center = upperLeft.add(lowerRight).multiplyByScalar(0.5);
+        var centerScreen = mvp.multiplyByVector(new Cartesian4(center.x, center.y, center.z, 1.0));
+        centerScreen = centerScreen.multiplyByScalar(1.0 / centerScreen.w);
+        var centerClip = clip.multiplyByVector(centerScreen);
 
-        var surfaceScreen = mvp.multiplyWithVector(new Cartesian4(upperLeft.x, upperLeft.y, upperLeft.z, 1.0));
-        surfaceScreen = surfaceScreen.multiplyWithScalar(1.0 / surfaceScreen.w);
-        var surfaceClip = clip.multiplyWithVector(surfaceScreen);
+        var surfaceScreen = mvp.multiplyByVector(new Cartesian4(upperLeft.x, upperLeft.y, upperLeft.z, 1.0));
+        surfaceScreen = surfaceScreen.multiplyByScalar(1.0 / surfaceScreen.w);
+        var surfaceClip = clip.multiplyByVector(surfaceScreen);
 
         var radius = Math.ceil(Cartesian3.magnitude(surfaceClip.subtract(centerClip, surfaceClip)));
         var diameter = 2.0 * radius;
@@ -1338,7 +1338,7 @@ define([
         var p = sceneState.camera.getPositionWC();
 
         // Find the corresponding position in the scaled space of the ellipsoid.
-        var q = d.multiplyWithVector(p);
+        var q = d.multiplyByVector(p);
 
         var qMagnitude = q.magnitude();
         var qUnit = q.normalize();
@@ -1351,16 +1351,16 @@ define([
         var wMagnitude = Math.sqrt(q.magnitudeSquared() - 1.0);
 
         // Compute the center and offsets.
-        var center = qUnit.multiplyWithScalar(1.0 / qMagnitude);
+        var center = qUnit.multiplyByScalar(1.0 / qMagnitude);
         var scalar = wMagnitude / qMagnitude;
-        var eastOffset = eUnit.multiplyWithScalar(scalar);
-        var northOffset = nUnit.multiplyWithScalar(scalar);
+        var eastOffset = eUnit.multiplyByScalar(scalar);
+        var northOffset = nUnit.multiplyByScalar(scalar);
 
         // A conservative measure for the longitudes would be to use the min/max longitudes of the bounding frustum.
-        var upperLeft = dInverse.multiplyWithVector(center.add(northOffset).subtract(eastOffset));
-        var upperRight = dInverse.multiplyWithVector(center.add(northOffset).add(eastOffset));
-        var lowerLeft = dInverse.multiplyWithVector(center.subtract(northOffset).subtract(eastOffset));
-        var lowerRight = dInverse.multiplyWithVector(center.subtract(northOffset).add(eastOffset));
+        var upperLeft = dInverse.multiplyByVector(center.add(northOffset).subtract(eastOffset));
+        var upperRight = dInverse.multiplyByVector(center.add(northOffset).add(eastOffset));
+        var lowerLeft = dInverse.multiplyByVector(center.subtract(northOffset).subtract(eastOffset));
+        var lowerRight = dInverse.multiplyByVector(center.subtract(northOffset).add(eastOffset));
         return [upperLeft.x, upperLeft.y, upperLeft.z, lowerLeft.x, lowerLeft.y, lowerLeft.z, upperRight.x, upperRight.y, upperRight.z, lowerRight.x, lowerRight.y, lowerRight.z];
     };
 
@@ -1379,8 +1379,8 @@ define([
             right = dir.cross(Cartesian3.UNIT_Z).normalize();
         }
 
-        var screenRight = center.add(right.multiplyWithScalar(radius));
-        var screenUp = center.add(Cartesian3.UNIT_Z.cross(right).normalize().multiplyWithScalar(radius));
+        var screenRight = center.add(right.multiplyByScalar(radius));
+        var screenUp = center.add(Cartesian3.UNIT_Z.cross(right).normalize().multiplyByScalar(radius));
 
         center = Transforms.pointToWindowCoordinates(viewProjMatrix, viewportTransformation, center);
         screenRight = Transforms.pointToWindowCoordinates(viewProjMatrix, viewportTransformation, screenRight);
@@ -1670,7 +1670,7 @@ define([
         if (this.showSkyAtmosphere && !this._vaSky) {
             // PERFORMANCE_IDEA:  Is 60 the right amount to tessellate?  I think scaling the original
             // geometry in a vertex is a bad idea; at least, because it introduces a draw call per tile.
-            var skyMesh = CubeMapEllipsoidTessellator.compute(new Ellipsoid(this._ellipsoid.getRadii().multiplyWithScalar(1.025)), 60);
+            var skyMesh = CubeMapEllipsoidTessellator.compute(new Ellipsoid(this._ellipsoid.getRadii().multiplyByScalar(1.025)), 60);
             this._vaSky = context.createVertexArrayFromMesh({
                 mesh : skyMesh,
                 attributeIndices : MeshFilters.createAttributeIndices(skyMesh),
@@ -2083,7 +2083,7 @@ define([
                     rtc = Cartesian3.ZERO;
                     tile.mode = 2;
                 }
-                var centerEye = mv.multiplyWithVector(new Cartesian4(rtc.x, rtc.y, rtc.z, 1.0));
+                var centerEye = mv.multiplyByVector(new Cartesian4(rtc.x, rtc.y, rtc.z, 1.0));
                 var mvrtc = mv.clone();
                 mvrtc.setColumn3(centerEye);
                 tile.modelView = mvrtc;

--- a/Source/Scene/CustomSensorVolume.js
+++ b/Source/Scene/CustomSensorVolume.js
@@ -218,7 +218,7 @@ define([
             // Extend position so the volume encompasses the sensor's radius.
             var theta = Math.max(Cartesian3.angleBetween(n0, n1), Cartesian3.angleBetween(n1, n2));
             var distance = r / Math.cos(theta * 0.5);
-            var p = n1.multiplyWithScalar(distance);
+            var p = n1.multiplyByScalar(distance);
 
             positions[(j * 3) + 0] = p.x;
             positions[(j * 3) + 1] = p.y;

--- a/Source/Scene/OrthographicFrustum.js
+++ b/Source/Scene/OrthographicFrustum.js
@@ -168,29 +168,29 @@ define([
         planes.length = 6;
 
         var planePoint;
-        var nearCenter = pos.add(dir.multiplyWithScalar(this.near));
+        var nearCenter = pos.add(dir.multiplyByScalar(this.near));
 
         // Left plane
-        planePoint = nearCenter.add(right.multiplyWithScalar(this.left));
+        planePoint = nearCenter.add(right.multiplyByScalar(this.left));
         planes[0] = new Cartesian4(right.x, right.y, right.z, -right.dot(planePoint));
 
         // Right plane
-        planePoint = nearCenter.add(right.multiplyWithScalar(this.right));
+        planePoint = nearCenter.add(right.multiplyByScalar(this.right));
         planes[1] = new Cartesian4(-right.x, -right.y, -right.z, -right.negate().dot(planePoint));
 
         // Bottom plane
-        planePoint = nearCenter.add(u.multiplyWithScalar(this.bottom));
+        planePoint = nearCenter.add(u.multiplyByScalar(this.bottom));
         planes[2] = new Cartesian4(u.x, u.y, u.z, -u.dot(planePoint));
 
         // Top plane
-        planePoint = nearCenter.add(u.multiplyWithScalar(this.top));
+        planePoint = nearCenter.add(u.multiplyByScalar(this.top));
         planes[3] = new Cartesian4(-u.x, -u.y, -u.z, -u.negate().dot(planePoint));
 
         // Near plane
         planes[4] = new Cartesian4(direction.x, direction.y, direction.z, -direction.dot(nearCenter));
 
         // Far plane
-        planePoint = position.add(direction.multiplyWithScalar(this.far));
+        planePoint = position.add(direction.multiplyByScalar(this.far));
         planes[5] = new Cartesian4(-direction.x, -direction.y, -direction.z, -direction.negate().dot(planePoint));
 
         return planes;

--- a/Source/Scene/PerspectiveFrustum.js
+++ b/Source/Scene/PerspectiveFrustum.js
@@ -172,29 +172,29 @@ define([
         planes.length = 6;
 
         var normal, planeVec;
-        var nearCenter = pos.add(dir.multiplyWithScalar(n));
-        var farCenter = pos.add(dir.multiplyWithScalar(f));
+        var nearCenter = pos.add(dir.multiplyByScalar(n));
+        var farCenter = pos.add(dir.multiplyByScalar(f));
 
         //Left plane computation
-        planeVec = nearCenter.add(right.negate().multiplyWithScalar(r)).subtract(pos);
+        planeVec = nearCenter.add(right.negate().multiplyByScalar(r)).subtract(pos);
         planeVec = planeVec.normalize();
         normal = planeVec.cross(u);
         planes[0] = new Cartesian4(normal.x, normal.y, normal.z, -normal.dot(pos));
 
         //Right plane computation
-        planeVec = nearCenter.add(right.multiplyWithScalar(r)).subtract(pos);
+        planeVec = nearCenter.add(right.multiplyByScalar(r)).subtract(pos);
         planeVec = planeVec.normalize();
         normal = u.cross(planeVec);
         planes[1] = new Cartesian4(normal.x, normal.y, normal.z, -normal.dot(pos));
 
         //Bottom plane computation
-        planeVec = nearCenter.add(u.negate().multiplyWithScalar(t)).subtract(position);
+        planeVec = nearCenter.add(u.negate().multiplyByScalar(t)).subtract(position);
         planeVec = planeVec.normalize();
         normal = right.cross(planeVec);
         planes[2] = new Cartesian4(normal.x, normal.y, normal.z, -normal.dot(pos));
 
         //Top plane computation
-        planeVec = nearCenter.add(u.multiplyWithScalar(t)).subtract(pos);
+        planeVec = nearCenter.add(u.multiplyByScalar(t)).subtract(pos);
         planeVec = planeVec.normalize();
         normal = planeVec.cross(right);
         planes[3] = new Cartesian4(normal.x, normal.y, normal.z, -normal.dot(pos));

--- a/Source/Scene/Polyline.js
+++ b/Source/Scene/Polyline.js
@@ -831,7 +831,7 @@ define([
                     var i, p;
                     if (typeof positions2D !== 'undefined') {
                         for (i = 0; i < positions2D.length; ++i) {
-                            p = mv2D.multiplyWithVector(new Cartesian4(positions2D[i].x, positions2D[i].y, positions2D[i].z, 1.0));
+                            p = mv2D.multiplyByVector(new Cartesian4(positions2D[i].x, positions2D[i].y, positions2D[i].z, 1.0));
                             worldPositions2D.push(new Cartesian3(p.x, p.y, p.z));
                         }
                     }
@@ -840,7 +840,7 @@ define([
                     var worldPositions3D = [];
                     if (typeof positions3D !== 'undefined') {
                         for (i = 0; i < positions3D.length; ++i) {
-                            p = mv3D.multiplyWithVector(new Cartesian4(positions3D[i].x, positions3D[i].y, positions3D[i].z, 1.0));
+                            p = mv3D.multiplyByVector(new Cartesian4(positions3D[i].x, positions3D[i].y, positions3D[i].z, 1.0));
                             worldPositions3D.push(new Cartesian3(p.x, p.y, p.z));
                         }
                     }

--- a/Source/Scene/SceneTransitioner.js
+++ b/Source/Scene/SceneTransitioner.js
@@ -69,7 +69,7 @@ define([
             transform : transform
         };
 
-        position = new Cartesian3(0.0, -1.0, 1.0).normalize().multiplyWithScalar(5.0 * maxRadii);
+        position = new Cartesian3(0.0, -1.0, 1.0).normalize().multiplyByScalar(5.0 * maxRadii);
         direction = Cartesian3.ZERO.subtract(position).normalize();
         var right = direction.cross(Cartesian3.UNIT_Z).normalize();
         up = right.cross(direction);
@@ -88,7 +88,7 @@ define([
             transform : transform
         };
 
-        position = new Cartesian3(0.0, -2.0, 1.0).normalize().multiplyWithScalar(2.0 * maxRadii);
+        position = new Cartesian3(0.0, -2.0, 1.0).normalize().multiplyByScalar(2.0 * maxRadii);
         direction = Cartesian3.ZERO.subtract(position).normalize();
         right = direction.cross(Cartesian3.UNIT_Z).normalize();
         up = right.cross(direction);
@@ -307,12 +307,12 @@ define([
         var dir = new Cartesian4(camera.direction.x, camera.direction.y, camera.direction.z, 0.0);
         var up = new Cartesian4(camera.up.x, camera.up.y, camera.up.z, 0.0);
 
-        var frame = transform.inverseTransformation().multiplyWithMatrix(camera.transform);
+        var frame = transform.inverseTransformation().multiply(camera.transform);
         camera.transform = transform.clone();
 
-        camera.position = Cartesian3.fromCartesian4(frame.multiplyWithVector(pos));
-        camera.direction = Cartesian3.fromCartesian4(frame.multiplyWithVector(dir));
-        camera.up = Cartesian3.fromCartesian4(frame.multiplyWithVector(up));
+        camera.position = Cartesian3.fromCartesian4(frame.multiplyByVector(pos));
+        camera.direction = Cartesian3.fromCartesian4(frame.multiplyByVector(dir));
+        camera.up = Cartesian3.fromCartesian4(frame.multiplyByVector(up));
         camera.right = camera.direction.cross(camera.up);
     };
 
@@ -339,7 +339,7 @@ define([
             camera.frustum.fovy = CesiumMath.lerp(startFOVy, endFOVy, value.time);
 
             var distance = d / Math.tan(camera.frustum.fovy * 0.5);
-            camera.position = camera.position.normalize().multiplyWithScalar(distance);
+            camera.position = camera.position.normalize().multiplyByScalar(distance);
         };
 
         var animation = scene.getAnimations().add({
@@ -377,7 +377,7 @@ define([
         var tanTheta = this._cameraCV.frustum.aspectRatio * tanPhi;
         var d = (maxRadii * Math.PI) / tanTheta;
 
-        var endPos = this._camera2D.position.normalize().multiplyWithScalar(d);
+        var endPos = this._camera2D.position.normalize().multiplyByScalar(d);
         var endDir = that._camera2D.direction.clone();
         var endUp = that._camera2D.up.clone();
 
@@ -416,7 +416,7 @@ define([
         var d = (maxRadii * Math.PI) / tanTheta;
 
         var camera3DTo2D = {};
-        camera3DTo2D.position = this._camera2D.position.normalize().multiplyWithScalar(d);
+        camera3DTo2D.position = this._camera2D.position.normalize().multiplyByScalar(d);
         camera3DTo2D.direction = this._camera2D.direction.clone();
         camera3DTo2D.up = this._camera2D.up.clone();
 
@@ -436,7 +436,7 @@ define([
         var tanPhi = Math.tan(this._cameraCV.frustum.fovy * 0.5);
         var tanTheta = this._cameraCV.frustum.aspectRatio * tanPhi;
         var d = (maxRadii * Math.PI) / tanTheta;
-        var endPos2D = this._camera2D.position.normalize().multiplyWithScalar(d);
+        var endPos2D = this._camera2D.position.normalize().multiplyByScalar(d);
 
         var top = camera.frustum.top;
         var bottom = camera.frustum.bottom;
@@ -602,7 +602,7 @@ define([
 
         var maxRadii = this._ellipsoid.getMaximumRadius();
         var endPos = this._ellipsoid.cartographicToCartesian(new Cartographic(0.0, 0.0, 10.0));
-        endPos = endPos.normalize().multiplyWithScalar(2.0 * maxRadii);
+        endPos = endPos.normalize().multiplyByScalar(2.0 * maxRadii);
         var endDir = Cartesian3.ZERO.subtract(endPos).normalize();
         var endRight = endDir.cross(Cartesian3.UNIT_Z).normalize();
         var endUp = endRight.cross(endDir);

--- a/Source/Scene/SphericalRepulsionForce.js
+++ b/Source/Scene/SphericalRepulsionForce.js
@@ -42,7 +42,7 @@ define([
 
                 // Repel if particle is in sphere
                 if (magnitudeDifference > 0) {
-                    particle.force = particle.force.add(centerToPosition.normalize().multiplyWithScalar(magnitudeDifference));
+                    particle.force = particle.force.add(centerToPosition.normalize().multiplyByScalar(magnitudeDifference));
                 }
             }
         }

--- a/Specs/Core/Cartesian2Spec.js
+++ b/Specs/Core/Cartesian2Spec.js
@@ -191,29 +191,29 @@ defineSuite([
         expect(left).toEqual(expectedResult);
     });
 
-    it('multiplyWithScalar without a result parameter', function() {
+    it('multiplyByScalar without a result parameter', function() {
         var cartesian = new Cartesian2(1.0, 2.0);
         var scalar = 2;
         var expectedResult = new Cartesian2(2.0, 4.0);
-        var result = cartesian.multiplyWithScalar(scalar);
+        var result = cartesian.multiplyByScalar(scalar);
         expect(result).toEqual(expectedResult);
     });
 
-    it('multiplyWithScalar with a result parameter', function() {
+    it('multiplyByScalar with a result parameter', function() {
         var cartesian = new Cartesian2(1, 2);
         var result = new Cartesian2();
         var scalar = 2;
         var expectedResult = new Cartesian2(2, 4);
-        var returnedResult = cartesian.multiplyWithScalar(scalar, result);
+        var returnedResult = cartesian.multiplyByScalar(scalar, result);
         expect(result).toBe(returnedResult);
         expect(result).toEqual(expectedResult);
     });
 
-    it('multiplyWithScalar with "this" result parameter', function() {
+    it('multiplyByScalar with "this" result parameter', function() {
         var cartesian = new Cartesian2(1, 2);
         var scalar = 2;
         var expectedResult = new Cartesian2(2, 4);
-        var returnedResult = cartesian.multiplyWithScalar(scalar, cartesian);
+        var returnedResult = cartesian.multiplyByScalar(scalar, cartesian);
         expect(cartesian).toBe(returnedResult);
         expect(cartesian).toEqual(expectedResult);
     });
@@ -477,15 +477,15 @@ defineSuite([
         }).toThrow();
     });
 
-    it('static multiplyWithScalar throws with no cartesian parameter', function() {
+    it('static multiplyByScalar throws with no cartesian parameter', function() {
         expect(function() {
-            Cartesian2.multiplyWithScalar(undefined, 2.0);
+            Cartesian2.multiplyByScalar(undefined, 2.0);
         }).toThrow();
     });
 
-    it('static multiplyWithScalar throws with no scalar parameter', function() {
+    it('static multiplyByScalar throws with no scalar parameter', function() {
         expect(function() {
-            Cartesian2.multiplyWithScalar(new Cartesian2(), undefined);
+            Cartesian2.multiplyByScalar(new Cartesian2(), undefined);
         }).toThrow();
     });
 

--- a/Specs/Core/Cartesian3Spec.js
+++ b/Specs/Core/Cartesian3Spec.js
@@ -216,29 +216,29 @@ defineSuite([
         expect(left).toEqual(expectedResult);
     });
 
-    it('multiplyWithScalar without a result parameter', function() {
+    it('multiplyByScalar without a result parameter', function() {
         var cartesian = new Cartesian3(1.0, 2.0, 3.0);
         var scalar = 2;
         var expectedResult = new Cartesian3(2.0, 4.0, 6.0);
-        var result = cartesian.multiplyWithScalar(scalar);
+        var result = cartesian.multiplyByScalar(scalar);
         expect(result).toEqual(expectedResult);
     });
 
-    it('multiplyWithScalar with a result parameter', function() {
+    it('multiplyByScalar with a result parameter', function() {
         var cartesian = new Cartesian3(1.0, 2.0, 3.0);
         var result = new Cartesian3();
         var scalar = 2;
         var expectedResult = new Cartesian3(2.0, 4.0, 6.0);
-        var returnedResult = cartesian.multiplyWithScalar(scalar, result);
+        var returnedResult = cartesian.multiplyByScalar(scalar, result);
         expect(result).toBe(returnedResult);
         expect(result).toEqual(expectedResult);
     });
 
-    it('multiplyWithScalar with "this" result parameter', function() {
+    it('multiplyByScalar with "this" result parameter', function() {
         var cartesian = new Cartesian3(1.0, 2.0, 3.0);
         var scalar = 2;
         var expectedResult = new Cartesian3(2.0, 4.0, 6.0);
-        var returnedResult = cartesian.multiplyWithScalar(scalar, cartesian);
+        var returnedResult = cartesian.multiplyByScalar(scalar, cartesian);
         expect(cartesian).toBe(returnedResult);
         expect(cartesian).toEqual(expectedResult);
     });
@@ -532,15 +532,15 @@ defineSuite([
         }).toThrow();
     });
 
-    it('static multiplyWithScalar throws with no cartesian parameter', function() {
+    it('static multiplyByScalar throws with no cartesian parameter', function() {
         expect(function() {
-            Cartesian3.multiplyWithScalar(undefined, 2.0);
+            Cartesian3.multiplyByScalar(undefined, 2.0);
         }).toThrow();
     });
 
-    it('static multiplyWithScalar throws with no scalar parameter', function() {
+    it('static multiplyByScalar throws with no scalar parameter', function() {
         expect(function() {
-            Cartesian3.multiplyWithScalar(new Cartesian3(), undefined);
+            Cartesian3.multiplyByScalar(new Cartesian3(), undefined);
         }).toThrow();
     });
 

--- a/Specs/Core/Cartesian4Spec.js
+++ b/Specs/Core/Cartesian4Spec.js
@@ -209,29 +209,29 @@ defineSuite([
         expect(left).toEqual(expectedResult);
     });
 
-    it('multiplyWithScalar without a result parameter', function() {
+    it('multiplyByScalar without a result parameter', function() {
         var cartesian = new Cartesian4(1.0, 2.0, 3.0, 4.0);
         var scalar = 2;
         var expectedResult = new Cartesian4(2.0, 4.0, 6.0, 8.0);
-        var result = cartesian.multiplyWithScalar(scalar);
+        var result = cartesian.multiplyByScalar(scalar);
         expect(result).toEqual(expectedResult);
     });
 
-    it('multiplyWithScalar with a result parameter', function() {
+    it('multiplyByScalar with a result parameter', function() {
         var cartesian = new Cartesian4(1.0, 2.0, 3.0, 4.0);
         var result = new Cartesian4();
         var scalar = 2;
         var expectedResult = new Cartesian4(2.0, 4.0, 6.0, 8.0);
-        var returnedResult = cartesian.multiplyWithScalar(scalar, result);
+        var returnedResult = cartesian.multiplyByScalar(scalar, result);
         expect(result).toBe(returnedResult);
         expect(result).toEqual(expectedResult);
     });
 
-    it('multiplyWithScalar with "this" result parameter', function() {
+    it('multiplyByScalar with "this" result parameter', function() {
         var cartesian = new Cartesian4(1.0, 2.0, 3.0, 4.0);
         var scalar = 2;
         var expectedResult = new Cartesian4(2.0, 4.0, 6.0, 8.0);
-        var returnedResult = cartesian.multiplyWithScalar(scalar, cartesian);
+        var returnedResult = cartesian.multiplyByScalar(scalar, cartesian);
         expect(cartesian).toBe(returnedResult);
         expect(cartesian).toEqual(expectedResult);
     });
@@ -475,15 +475,15 @@ defineSuite([
         }).toThrow();
     });
 
-    it('static multiplyWithScalar throws with no cartesian parameter', function() {
+    it('static multiplyByScalar throws with no cartesian parameter', function() {
         expect(function() {
-            Cartesian4.multiplyWithScalar(undefined, 2.0);
+            Cartesian4.multiplyByScalar(undefined, 2.0);
         }).toThrow();
     });
 
-    it('static multiplyWithScalar throws with no scalar parameter', function() {
+    it('static multiplyByScalar throws with no scalar parameter', function() {
         expect(function() {
-            Cartesian4.multiplyWithScalar(new Cartesian4(), undefined);
+            Cartesian4.multiplyByScalar(new Cartesian4(), undefined);
         }).toThrow();
     });
 

--- a/Specs/Core/CatmullRomSplineSpec.js
+++ b/Specs/Core/CatmullRomSplineSpec.js
@@ -82,7 +82,7 @@ defineSuite([
 
         points[0].tangent = crs.getStartTangent();
         for ( var i = 1; i < points.length - 1; ++i) {
-            points[i].tangent = points[i + 1].point.subtract(points[i - 1].point).multiplyWithScalar(0.5);
+            points[i].tangent = points[i + 1].point.subtract(points[i - 1].point).multiplyByScalar(0.5);
         }
         points[points.length - 1].tangent = crs.getEndTangent();
 

--- a/Specs/Core/HermiteSplineSpec.js
+++ b/Specs/Core/HermiteSplineSpec.js
@@ -92,10 +92,10 @@ defineSuite([
             var c = u * u * u - 2.0 * u * u + u;
             var d = u * u * u - u * u;
 
-            var p0 = p.multiplyWithScalar(a);
-            var p1 = q.multiplyWithScalar(b);
-            var p2 = pT.multiplyWithScalar(c);
-            var p3 = qT.multiplyWithScalar(d);
+            var p0 = p.multiplyByScalar(a);
+            var p1 = q.multiplyByScalar(b);
+            var p2 = pT.multiplyByScalar(c);
+            var p3 = qT.multiplyByScalar(d);
 
             return p0.add(p1).add(p2).add(p3);
         };

--- a/Specs/Core/Matrix3Spec.js
+++ b/Specs/Core/Matrix3Spec.js
@@ -245,17 +245,17 @@ defineSuite([
         expect(m.transpose().transpose().equals(m)).toEqual(true);
     });
 
-    it('multiplyWithVector0', function() {
+    it('multiplyByVector0', function() {
         var m = new Matrix3(1);
         var v = new Cartesian3(1, 2, 3);
-        expect(m.multiplyWithVector(v).equals(v)).toEqual(true);
+        expect(m.multiplyByVector(v).equals(v)).toEqual(true);
     });
 
-    it('multiplyWithVector1', function() {
+    it('multiplyByVector1', function() {
         var m = new Matrix3(2);
         var v = new Cartesian3(1, 2, 3);
         var u = new Cartesian3(2, 4, 6);
-        expect(m.multiplyWithVector(v).equals(u)).toEqual(true);
+        expect(m.multiplyByVector(v).equals(u)).toEqual(true);
     });
 
     it('negate', function() {
@@ -270,14 +270,14 @@ defineSuite([
         expect(m.negate().negate().equals(m)).toEqual(true);
     });
 
-    it('multiplyWithMatrix', function() {
+    it('multiply', function() {
         var m = new Matrix3(1, 2, 3,
                             1, 2, 3,
                             1, 2, 3);
         var n = new Matrix3(6, 12, 18,
                             6, 12, 18,
                             6, 12, 18);
-        expect(m.multiplyWithMatrix(m).equals(n)).toEqual(true);
+        expect(m.multiply(m).equals(n)).toEqual(true);
     });
 
     it('rotates around Z', function() {

--- a/Specs/Core/Matrix4Spec.js
+++ b/Specs/Core/Matrix4Spec.js
@@ -390,8 +390,8 @@ defineSuite([
         var mInverse = m.inverseTransformation();
 
         var v = new Cartesian4(1, 2, 3, 1);
-        var vPrime = m.multiplyWithVector(v);
-        var vv = mInverse.multiplyWithVector(vPrime);
+        var vPrime = m.multiplyByVector(v);
+        var vv = mInverse.multiplyByVector(vPrime);
 
         expect(v.equals(vv)).toEqual(true);
     });
@@ -406,8 +406,8 @@ defineSuite([
         var mInverse = m.inverseTransformation();
 
         var v = new Cartesian4(1, 2, 3, 1);
-        var vPrime = m.multiplyWithVector(v);
-        var vv = mInverse.multiplyWithVector(vPrime);
+        var vPrime = m.multiplyByVector(v);
+        var vv = mInverse.multiplyByVector(vPrime);
 
         expect(v.equals(vv)).toEqual(true);
     });
@@ -421,21 +421,21 @@ defineSuite([
         var m = new Matrix4(rotation, translation);
         var mInverse = m.inverseTransformation();
 
-        expect(Matrix4.IDENTITY.equals(mInverse.multiplyWithMatrix(m))).toEqual(true);
+        expect(Matrix4.IDENTITY.equals(mInverse.multiply(m))).toEqual(true);
     });
 
     it('inverse0', function() {
         var m = new Matrix4(Matrix3.IDENTITY, Cartesian3.ZERO);
         var mInverse = m.inverse();
 
-        expect(Matrix4.IDENTITY.equals(mInverse.multiplyWithMatrix(m))).toEqual(true);
+        expect(Matrix4.IDENTITY.equals(mInverse.multiply(m))).toEqual(true);
     });
 
     it('inverse1', function() {
         var m = new Matrix4(Matrix3.IDENTITY, new Cartesian3(1, 2, 3));
         var mInverse = m.inverse();
 
-        expect(Matrix4.IDENTITY.equals(mInverse.multiplyWithMatrix(m))).toEqual(true);
+        expect(Matrix4.IDENTITY.equals(mInverse.multiply(m))).toEqual(true);
     });
 
     it('inverse2', function() {
@@ -445,7 +445,7 @@ defineSuite([
                              0.00,  0.00, 0.00,  1.00);
         var mInverse = m.inverse();
 
-        expect(Matrix4.IDENTITY.equalsEpsilon(mInverse.multiplyWithMatrix(m), CesiumMath.EPSILON10)).toEqual(true);
+        expect(Matrix4.IDENTITY.equalsEpsilon(mInverse.multiply(m), CesiumMath.EPSILON10)).toEqual(true);
     });
 
     it('inverse3', function() {
@@ -479,38 +479,38 @@ defineSuite([
         expect(m.transpose().transpose().equals(m)).toEqual(true);
     });
 
-    it('multiplyWithVector0', function() {
+    it('multiplyByVector0', function() {
         var m = new Matrix4(1);
         var v = new Cartesian4(1, 2, 3, 4);
-        expect(m.multiplyWithVector(v).equals(v)).toEqual(true);
+        expect(m.multiplyByVector(v).equals(v)).toEqual(true);
     });
 
-    it('multiplyWithVector1', function() {
+    it('multiplyByVector1', function() {
         var m = new Matrix4(2);
         var v = new Cartesian4(1, 2, 3, 4);
         var u = new Cartesian4(2, 4, 6, 8);
-        expect(m.multiplyWithVector(v).equals(u)).toEqual(true);
+        expect(m.multiplyByVector(v).equals(u)).toEqual(true);
     });
 
-    it('multiplyWithMatrix0', function() {
+    it('multiply0', function() {
         var zero = new Matrix4(0);
         var m = new Matrix4( 1,  2,  3,  4,
                              5,  6,  7,  8,
                              9, 10, 11, 12,
                             13, 14, 15, 16);
-        expect(zero.multiplyWithMatrix(m).equals(zero)).toEqual(true);
+        expect(zero.multiply(m).equals(zero)).toEqual(true);
     });
 
-    it('multiplyWithMatrix1', function() {
+    it('multiply1', function() {
         var i = Matrix4.IDENTITY;
         var m = new Matrix4( 1,  2,  3,  4,
                              5,  6,  7,  8,
                              9, 10, 11, 12,
                             13, 14, 15, 16);
-        expect(i.multiplyWithMatrix(m).equals(m)).toEqual(true);
+        expect(i.multiply(m).equals(m)).toEqual(true);
     });
 
-    it('multiplyWithMatrix2', function() {
+    it('multiply2', function() {
         var m = new Matrix4(1, 1, 1, 1,
                             1, 1, 1, 1,
                             1, 1, 1, 1,
@@ -519,7 +519,7 @@ defineSuite([
                                  4, 4, 4, 4,
                                  4, 4, 4, 4,
                                  4, 4, 4, 4);
-        expect(m.multiplyWithMatrix(m).equals(result)).toEqual(true);
+        expect(m.multiply(m).equals(result)).toEqual(true);
     });
 
     it('negate', function() {

--- a/Specs/Core/QuaternionSpec.js
+++ b/Specs/Core/QuaternionSpec.js
@@ -96,7 +96,7 @@ defineSuite([
     it('unitInverseEqualsConjugate', function() {
         var s = Math.sin(CesiumMath.PI_OVER_FOUR);
         var c = Math.cos(CesiumMath.PI_OVER_FOUR);
-        var cartesian = new Cartesian3(1.0, 1.0, 1.0).normalize().multiplyWithScalar(s);
+        var cartesian = new Cartesian3(1.0, 1.0, 1.0).normalize().multiplyByScalar(s);
         var q = new Quaternion(cartesian.x, cartesian.y, cartesian.z, c);
         expect(q.norm()).toEqual(1.0);
         expect(q.inverse().equals(q.conjugate())).toEqual(true);
@@ -127,8 +127,8 @@ defineSuite([
         expect(q.equals(new Quaternion(8.0, 16.0, 24.0, 2.0))).toEqual(true);
     });
 
-    it('multiplyWithScalar', function() {
-        var q = new Quaternion(1.0, 2.0, 3.0, 4.0).multiplyWithScalar(2.0);
+    it('multiplyByScalar', function() {
+        var q = new Quaternion(1.0, 2.0, 3.0, 4.0).multiplyByScalar(2.0);
         expect(q.equals(new Quaternion(2.0, 4.0, 6.0, 8.0))).toEqual(true);
     });
 
@@ -140,7 +140,7 @@ defineSuite([
     it('rotate', function() {
         var s = Math.sin(CesiumMath.PI_OVER_FOUR);
         var c = Math.cos(CesiumMath.PI_OVER_FOUR);
-        var cartesian = new Cartesian3(0.0, 0.0, 1.0).multiplyWithScalar(s);
+        var cartesian = new Cartesian3(0.0, 0.0, 1.0).multiplyByScalar(s);
         var q = new Quaternion(cartesian.x, cartesian.y, cartesian.z, c);
         var xAxis = new Cartesian4(1.0, 0.0, 0.0, 0.0);
         var yAxis = new Cartesian4(0.0, 1.0, 0.0, 0.0);
@@ -150,7 +150,7 @@ defineSuite([
     it('getAxis', function() {
         var s = Math.sin(CesiumMath.PI_OVER_FOUR);
         var c = Math.cos(CesiumMath.PI_OVER_FOUR);
-        var cartesian = new Cartesian3(0.0, 0.0, 1.0).multiplyWithScalar(s);
+        var cartesian = new Cartesian3(0.0, 0.0, 1.0).multiplyByScalar(s);
         var q = new Quaternion(cartesian.x, cartesian.y, cartesian.z, c);
         expect(q.getAxis().equals(new Cartesian3(0.0, 0.0, 1.0))).toEqual(true);
         q = new Quaternion(4.0, 3.0, 2.0, 1.0);
@@ -160,7 +160,7 @@ defineSuite([
     it('getAngle', function() {
         var s = Math.sin(CesiumMath.PI_OVER_FOUR);
         var c = Math.cos(CesiumMath.PI_OVER_FOUR);
-        var cartesian = new Cartesian3(0.0, 0.0, 1.0).multiplyWithScalar(s);
+        var cartesian = new Cartesian3(0.0, 0.0, 1.0).multiplyByScalar(s);
         var q = new Quaternion(cartesian.x, cartesian.y, cartesian.z, c);
         expect(q.getAngle()).toEqual(CesiumMath.PI_OVER_TWO);
         q = new Quaternion(4.0, 3.0, 2.0, 1.0);
@@ -172,7 +172,7 @@ defineSuite([
         var cPiOver4 = Math.cos(CesiumMath.PI_OVER_FOUR);
         var sPiOver2 = Math.sin(CesiumMath.PI_OVER_TWO);
         var cPiOver2 = Math.cos(CesiumMath.PI_OVER_TWO);
-        var q = new Quaternion(new Cartesian3(0.0, 0.0, 1.0).multiplyWithScalar(sPiOver4), cPiOver4);
+        var q = new Quaternion(new Cartesian3(0.0, 0.0, 1.0).multiplyByScalar(sPiOver4), cPiOver4);
         var rotation = new Matrix3(cPiOver2, -sPiOver2, 0.0,
                                    sPiOver2,  cPiOver2, 0.0,
                                         0.0,       0.0, 1.0);
@@ -183,7 +183,7 @@ defineSuite([
         var q = new Quaternion(1.0, 2.0, 3.0, 4.0);
         var r = new Quaternion(5.0, 6.0, 7.0, 8.0);
         var t = 0.75;
-        var s = q.multiplyWithScalar(1.0 - t).add(r.multiplyWithScalar(t));
+        var s = q.multiplyByScalar(1.0 - t).add(r.multiplyByScalar(t));
         expect(q.lerp(0.0, r).equals(q)).toEqual(true);
         expect(q.lerp(1.0, r).equals(r)).toEqual(true);
         expect(q.lerp(t, r).equals(s)).toEqual(true);
@@ -211,7 +211,7 @@ defineSuite([
     it('log', function() {
         var s = Math.sin(CesiumMath.PI_OVER_FOUR);
         var c = Math.cos(CesiumMath.PI_OVER_FOUR);
-        var cartesian = new Cartesian3(0.0, 0.0, 1.0).multiplyWithScalar(s);
+        var cartesian = new Cartesian3(0.0, 0.0, 1.0).multiplyByScalar(s);
         var q = new Quaternion(cartesian.x, cartesian.y, cartesian.z, c);
         expect(q.log().equals(new Cartesian3(0.0, 0.0, CesiumMath.PI_OVER_FOUR)));
     });
@@ -219,7 +219,7 @@ defineSuite([
     it('power', function() {
         var s = Math.sin(CesiumMath.PI_OVER_FOUR);
         var c = Math.cos(CesiumMath.PI_OVER_FOUR);
-        var cartesian = new Cartesian3(0.0, 0.0, 1.0).multiplyWithScalar(s);
+        var cartesian = new Cartesian3(0.0, 0.0, 1.0).multiplyByScalar(s);
         var t = new Quaternion(cartesian.x, cartesian.y, cartesian.z, c);
         var u = t.power(2.0);
         var v = t.multiply(t);
@@ -243,7 +243,7 @@ defineSuite([
 
         var s = Math.sin(theta / 2.0);
         var c = Math.cos(theta / 2.0);
-        var a = axis.multiplyWithScalar(s);
+        var a = axis.multiplyByScalar(s);
         var q = new Quaternion(a.x, a.y, a.z, c);
 
         var r = Quaternion.fromAxisAngle(axis, theta);
@@ -260,7 +260,7 @@ defineSuite([
         var cTheta = Math.cos(theta);
 
         var zAxis = new Cartesian3(0.0, 0.0, 1.0);
-        var z = zAxis.multiplyWithScalar(sHalfTheta);
+        var z = zAxis.multiplyByScalar(sHalfTheta);
         var q = new Quaternion(z.x, z.y, z.z, cHalfTheta);
         var zRotation = new Matrix3(cTheta, -sTheta, 0.0,
                                     sTheta,  cTheta, 0.0,
@@ -278,7 +278,7 @@ defineSuite([
         var cTheta = Math.cos(theta);
 
         var yAxis = new Cartesian3(0.0, 1.0, 0.0);
-        var y = yAxis.multiplyWithScalar(sHalfTheta);
+        var y = yAxis.multiplyByScalar(sHalfTheta);
         var q = new Quaternion(y.x, y.y, y.z, cHalfTheta);
         var yRotation = new Matrix3( cTheta, 0.0, sTheta,
                                         0.0, 1.0,    0.0,
@@ -296,7 +296,7 @@ defineSuite([
         var cTheta = Math.cos(theta);
 
         var xAxis = new Cartesian3(1.0, 0.0, 0.0);
-        var x = xAxis.multiplyWithScalar(sHalfTheta);
+        var x = xAxis.multiplyByScalar(sHalfTheta);
         var q = new Quaternion(x.x, x.y, x.z, cHalfTheta);
         var xRotation = new Matrix3(1.0,    0.0,     0.0,
                                     0.0, cTheta, -sTheta,
@@ -314,7 +314,7 @@ defineSuite([
         var cTheta = Math.cos(theta);
 
         var zAxis = new Cartesian3(0.0, 0.0, 1.0);
-        var z = zAxis.multiplyWithScalar(sHalfTheta);
+        var z = zAxis.multiplyByScalar(sHalfTheta);
         var q = new Quaternion(z.x, z.y, z.z, cHalfTheta);
         var zRotation = new Matrix3(cTheta, -sTheta, 0.0,
                                     sTheta,  cTheta, 0.0,
@@ -322,7 +322,7 @@ defineSuite([
         expect(Quaternion.fromRotationMatrix(zRotation).equalsEpsilon(q, CesiumMath.EPSILON15)).toEqual(true);
 
         var yAxis = new Cartesian3(0.0, 1.0, 0.0);
-        var y = yAxis.multiplyWithScalar(sHalfTheta);
+        var y = yAxis.multiplyByScalar(sHalfTheta);
         q = new Quaternion(y.x, y.y, y.z, cHalfTheta);
         var yRotation = new Matrix3( cTheta, 0.0, sTheta,
                                         0.0, 1.0,    0.0,
@@ -330,7 +330,7 @@ defineSuite([
         expect(Quaternion.fromRotationMatrix(yRotation).equalsEpsilon(q, CesiumMath.EPSILON15)).toEqual(true);
 
         var xAxis = new Cartesian3(1.0, 0.0, 0.0);
-        var x = xAxis.multiplyWithScalar(sHalfTheta);
+        var x = xAxis.multiplyByScalar(sHalfTheta);
         q = new Quaternion(x.x, x.y, x.z, cHalfTheta);
         var xRotation = new Matrix3(1.0,    0.0,     0.0,
                                     0.0, cTheta, -sTheta,
@@ -349,7 +349,7 @@ defineSuite([
     it('exp', function() {
         var s = Math.sin(CesiumMath.PI_OVER_FOUR);
         var c = Math.cos(CesiumMath.PI_OVER_FOUR);
-        var cartesian = new Cartesian3(0.0, 0.0, 1.0).multiplyWithScalar(s);
+        var cartesian = new Cartesian3(0.0, 0.0, 1.0).multiplyByScalar(s);
         var q = new Quaternion(cartesian.x, cartesian.y, cartesian.z, c);
         expect(Quaternion.exp(new Cartesian3(0.0, 0.0, CesiumMath.PI_OVER_FOUR)).equals(q)).toEqual(true);
     });

--- a/Specs/Core/RaySpec.js
+++ b/Specs/Core/RaySpec.js
@@ -31,6 +31,6 @@ defineSuite([
     it('get point along ray', function() {
         var t = 5.0;
         var ray = new Ray(Cartesian3.ZERO, Cartesian3.UNIT_X);
-        expect(ray.getPoint(t).equals(Cartesian3.UNIT_X.multiplyWithScalar(t))).toEqual(true);
+        expect(ray.getPoint(t).equals(Cartesian3.UNIT_X.multiplyByScalar(t))).toEqual(true);
     });
 });

--- a/Specs/Core/TransformsSpec.js
+++ b/Specs/Core/TransformsSpec.js
@@ -142,8 +142,8 @@ defineSuite([
         var width = 1024.0;
         var height = 768.0;
         var perspective = Matrix4.createPerspectiveFieldOfView(CesiumMath.toRadians(60.0), width / height, 1.0, 10.0);
-        var view = Matrix4.createLookAt(Cartesian3.UNIT_X.multiplyWithScalar(2.0), Cartesian3.ZERO, Cartesian3.UNIT_Z);
-        var mvpMatrix = perspective.multiplyWithMatrix(view);
+        var view = Matrix4.createLookAt(Cartesian3.UNIT_X.multiplyByScalar(2.0), Cartesian3.ZERO, Cartesian3.UNIT_Z);
+        var mvpMatrix = perspective.multiply(view);
         var vpTransform = Matrix4.createViewportTransformation(
             {
                 width : width,

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -116,7 +116,7 @@ defineSuite([
                                       0.0, 1.0, 0.0, -position.y,
                                       0.0, 0.0, 1.0, -position.z,
                                       0.0, 0.0, 0.0,         1.0);
-        var expected = rotation.multiplyWithMatrix(translation);
+        var expected = rotation.multiply(translation);
         expect(viewMatrix.equals(expected)).toEqual(true);
     });
 
@@ -189,7 +189,7 @@ defineSuite([
         var ellipsoid = Ellipsoid.WGS84;
         var maxRadii = ellipsoid.getMaximumRadius();
 
-        camera.position = Cartesian3.UNIT_X.multiplyWithScalar(2.0 * maxRadii);
+        camera.position = Cartesian3.UNIT_X.multiplyByScalar(2.0 * maxRadii);
         camera.direction = camera.position.negate().normalize();
         camera.up = Cartesian3.UNIT_Z;
         camera.right = camera.direction.cross(camera.up);
@@ -266,7 +266,7 @@ defineSuite([
         var projection = new EquidistantCylindricalProjection(ellipsoid);
         var maxRadii = ellipsoid.getMaximumRadius();
 
-        camera.position = new Cartesian3(0.0, -1.0, 1.0).normalize().multiplyWithScalar(5.0 * maxRadii);
+        camera.position = new Cartesian3(0.0, -1.0, 1.0).normalize().multiplyByScalar(5.0 * maxRadii);
         camera.direction = Cartesian3.ZERO.subtract(camera.position).normalize();
         camera.right = camera.direction.cross(Cartesian3.UNIT_Z).normalize();
         camera.up = camera.right.cross(camera.direction);


### PR DESCRIPTION
Rather than do these renames as part of the other refactoring going on, I thought it was easier to just do it in a seperate pull so that other requests aren't so noisy.  This was a simple find/replace, no other changes were made.
1. multiplyWithMatrix -> multiply
2. All functions starting with multiplyWith now start with multiplyBy, this makes it consistent with divideBy functions.
