### PR TITLE
Expose CentralBodyController member variables.

### DIFF
--- a/Source/Scene/CameraCentralBodyController.js
+++ b/Source/Scene/CameraCentralBodyController.js
@@ -24,20 +24,41 @@ define([
     "use strict";
 
     /**
-     * DOC_TBD
-     * @name CameraCentralBodyController
-     * @constructor
+     * Defines camera movement and handles mouse events that move the camera. Moves the camera
+     * position around the center of an ellipsoid or a point on the surface. Also, moves the camera viewing
+     * direction.
+     *
+     * @alias CameraCentralBodyController
+     *
+     * @param {HTMLCanvasElement} canvas An HTML canvas element used for its dimensions
+     * and for listening on user events.
+     * @param {Camera} camera The camera to use.
+     * @param {Ellipsoid} ellipsoid The ellipsoid to move around.
+     *
+     * @internalConstructor
+     *
+     * @see CameraSpindleController
+     * @see CameraFreeLookController
      */
     function CameraCentralBodyController(canvas, camera, ellipsoid) {
         this._canvas = canvas;
         this._camera = camera;
-
-        this._spindleController = new CameraSpindleController(canvas, camera, ellipsoid);
-        this._freeLookController = new CameraFreeLookController(canvas, camera);
-
+        this._transform = Matrix4.IDENTITY;
         this._rotateHandler = new CameraEventHandler(canvas, CameraEventType.MIDDLE_DRAG);
 
-        this._transform = Matrix4.IDENTITY;
+        /**
+         * Rotates the camera's position and axes around the center of the ellipsoid.
+         *
+         * @type {CameraSpindleController}
+         */
+        this.spindleController = new CameraSpindleController(canvas, camera, ellipsoid);
+
+        /**
+         * Rotates the view direction about the camera's other axes. The camera's position is stationary.
+         *
+         * @type {CameraFreeLookController}
+         */
+        this.freeLookController = new CameraFreeLookController(canvas, camera);
     }
 
     /**
@@ -49,7 +70,7 @@ define([
 
         var rotateMovement = rotate.getMovement();
         if (rotate.isButtonDown() && typeof this._transform === 'undefined' && rotateMovement) {
-            var center = this._camera.pickEllipsoid(rotateMovement.startPosition, this._spindleController.getEllipsoid());
+            var center = this._camera.pickEllipsoid(rotateMovement.startPosition, this.spindleController.getEllipsoid());
             if (typeof center !== 'undefined') {
                 this._transform = Transforms.eastNorthUpToFixedFrame(center);
             }
@@ -61,8 +82,8 @@ define([
                 this._rotate(rotateMovement);
         }
 
-        this._spindleController.update();
-        this._freeLookController.update();
+        this.spindleController.update();
+        this.freeLookController.update();
 
         return true;
     };
@@ -76,11 +97,11 @@ define([
         var direction = camera.direction;
 
         var oldTransform = camera.transform;
-        var oldEllipsoid = this._spindleController.getEllipsoid();
-        var oldConstrainedZ = this._spindleController.constrainedAxis;
+        var oldEllipsoid = this.spindleController.getEllipsoid();
+        var oldConstrainedZ = this.spindleController.constrainedAxis;
 
-        this._spindleController.setReferenceFrame(transform, Ellipsoid.UNIT_SPHERE);
-        this._spindleController.constrainedAxis = Cartesian3.UNIT_Z;
+        this.spindleController.setReferenceFrame(transform, Ellipsoid.UNIT_SPHERE);
+        this.spindleController.constrainedAxis = Cartesian3.UNIT_Z;
 
         var invTransform = camera.getInverseTransform();
         camera.position = Cartesian3.fromCartesian4(invTransform.multiplyByVector(new Cartesian4(position.x, position.y, position.z, 1.0)));
@@ -88,35 +109,20 @@ define([
         camera.right = Cartesian3.fromCartesian4(invTransform.multiplyByVector(new Cartesian4(right.x, right.y, right.z, 0.0)));
         camera.direction = Cartesian3.fromCartesian4(invTransform.multiplyByVector(new Cartesian4(direction.x, direction.y, direction.z, 0.0)));
 
-        this._spindleController._rotate(movement);
+        this.spindleController._rotate(movement);
 
         position = camera.position;
         up = camera.up;
         right = camera.right;
         direction = camera.direction;
 
-        this._spindleController.setReferenceFrame(oldTransform, oldEllipsoid);
-        this._spindleController.constrainedAxis = oldConstrainedZ;
+        this.spindleController.setReferenceFrame(oldTransform, oldEllipsoid);
+        this.spindleController.constrainedAxis = oldConstrainedZ;
 
         camera.position = Cartesian3.fromCartesian4(transform.multiplyByVector(new Cartesian4(position.x, position.y, position.z, 1.0)));
         camera.up = Cartesian3.fromCartesian4(transform.multiplyByVector(new Cartesian4(up.x, up.y, up.z, 0.0)));
         camera.right = Cartesian3.fromCartesian4(transform.multiplyByVector(new Cartesian4(right.x, right.y, right.z, 0.0)));
         camera.direction = Cartesian3.fromCartesian4(transform.multiplyByVector(new Cartesian4(direction.x, direction.y, direction.z, 0.0)));
-    };
-
-    //TODO: Find a better solution for this
-    CameraCentralBodyController.prototype.moveLeftWithConstrainedZ = function(angle) {
-        var oldConstrainedZ = this._spindleController.constrainedAxis;
-        this._spindleController.constrainedAxis = Cartesian3.UNIT_Z;
-        this._spindleController.moveLeft(angle);
-        this._spindleController.constrainedAxis = oldConstrainedZ;
-    };
-
-    CameraCentralBodyController.prototype.moveRightWithConstrainedZ = function(angle) {
-        var oldConstrainedZ = this._spindleController.constrainedAxis;
-        this._spindleController.constrainedAxis = Cartesian3.UNIT_Z;
-        this._spindleController.moveRight(angle);
-        this._spindleController.constrainedAxis = oldConstrainedZ;
     };
 
     /**
@@ -155,8 +161,8 @@ define([
      */
     CameraCentralBodyController.prototype.destroy = function() {
         this._rotateHandler = this._rotateHandler && this._rotateHandler.destroy();
-        this._spindleController = this._spindleController && this._spindleController.destroy();
-        this._freeLookController = this._freeLookController && this._freeLookController.destroy();
+        this.spindleController = this.spindleController && this.spindleController.destroy();
+        this.freeLookController = this.freeLookController && this.freeLookController.destroy();
         return destroyObject(this);
     };
 


### PR DESCRIPTION
The CentralBodyController contains contains other controllers to handle the different types of mouse input. This will expose the contained controllers so the camera can be moved without the need for mouse events.
