### PR TITLE
Specs performance

### DIFF
--- a/Specs/Core/AxisAlignedBoundingBoxSpec.js
+++ b/Specs/Core/AxisAlignedBoundingBoxSpec.js
@@ -8,7 +8,7 @@ defineSuite([
          Cartesian3,
          CesiumMath) {
     "use strict";
-    /*global it,expect,describe*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var positions = [
                      new Cartesian3(3, -1, -3),

--- a/Specs/Core/BoundingSphereSpec.js
+++ b/Specs/Core/BoundingSphereSpec.js
@@ -8,7 +8,7 @@ defineSuite([
          Cartesian3,
          CesiumMath) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     function getPositions() {
         return [

--- a/Specs/Core/BoxTessellatorSpec.js
+++ b/Specs/Core/BoxTessellatorSpec.js
@@ -6,7 +6,7 @@ defineSuite([
          BoxTessellator,
          Cartesian3) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('compute0', function() {
         expect(function() {

--- a/Specs/Core/CachePoliciesSpec.js
+++ b/Specs/Core/CachePoliciesSpec.js
@@ -6,7 +6,7 @@ defineSuite([
          CachePolicy,
          Cache) {
     "use strict";
-    /*global it,expect,describe,beforeEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     describe('LRU', function() {
         var LRU = CachePolicy.LRU;

--- a/Specs/Core/CacheSpec.js
+++ b/Specs/Core/CacheSpec.js
@@ -6,7 +6,7 @@ defineSuite([
          Cache,
          Cartesian3) {
     "use strict";
-    /*global it,expect,beforeEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var AddAlways = function(fetchFunc) {
         this._fetchFunc = fetchFunc;

--- a/Specs/Core/Cartesian2Spec.js
+++ b/Specs/Core/Cartesian2Spec.js
@@ -6,7 +6,7 @@ defineSuite([
               Cartesian2,
               CesiumMath) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('construct with default values', function() {
         var cartesian = new Cartesian2();

--- a/Specs/Core/Cartesian3Spec.js
+++ b/Specs/Core/Cartesian3Spec.js
@@ -6,7 +6,7 @@ defineSuite([
                     Cartesian3,
               CesiumMath) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('construct with default values', function() {
         var cartesian = new Cartesian3();

--- a/Specs/Core/Cartesian4Spec.js
+++ b/Specs/Core/Cartesian4Spec.js
@@ -6,7 +6,7 @@ defineSuite([
               Cartesian4,
               CesiumMath) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('construct with default values', function() {
         var cartesian = new Cartesian4();

--- a/Specs/Core/CartographicSpec.js
+++ b/Specs/Core/CartographicSpec.js
@@ -4,7 +4,7 @@ defineSuite([
      ], function(
          Cartographic) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('default constructor sets expected properties', function() {
         var c = new Cartographic();

--- a/Specs/Core/CatmullRomSplineSpec.js
+++ b/Specs/Core/CatmullRomSplineSpec.js
@@ -10,7 +10,7 @@ defineSuite([
          HermiteSpline,
          CesiumMath) {
     "use strict";
-    /*global it,expect,beforeEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var points;
     beforeEach(function() {

--- a/Specs/Core/ClockSpec.js
+++ b/Specs/Core/ClockSpec.js
@@ -10,7 +10,7 @@ defineSuite([
               ClockRange,
               JulianDate) {
     "use strict";
-    /*global it,expect,waitsFor*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('constructor sets default parameters', function() {
         var clock = new Clock();

--- a/Specs/Core/ColorSpec.js
+++ b/Specs/Core/ColorSpec.js
@@ -1,7 +1,7 @@
 /*global defineSuite*/
 defineSuite(['Core/Color'], function(Color) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('Constructing without arguments produces expected defaults', function() {
         var v = new Color();

--- a/Specs/Core/CubeMapEllipsoidTessellatorSpec.js
+++ b/Specs/Core/CubeMapEllipsoidTessellatorSpec.js
@@ -10,7 +10,7 @@ defineSuite([
          Ellipsoid,
          CesiumMath) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('compute0', function() {
         expect(function() {

--- a/Specs/Core/DeveloperErrorSpec.js
+++ b/Specs/Core/DeveloperErrorSpec.js
@@ -5,7 +5,7 @@ defineSuite([
     DeveloperError
 ) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var name = 'DeveloperError';
     var testMessage = 'Testing';

--- a/Specs/Core/EllipsoidSpec.js
+++ b/Specs/Core/EllipsoidSpec.js
@@ -10,7 +10,7 @@ defineSuite([
          Cartographic,
          CesiumMath) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('construct', function() {
         var e = new Ellipsoid(new Cartesian3(1, 2, 3));

--- a/Specs/Core/EllipsoidTangentPlaneSpec.js
+++ b/Specs/Core/EllipsoidTangentPlaneSpec.js
@@ -10,7 +10,7 @@ defineSuite([
          Cartesian3,
          CesiumMath) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('projectPointsOntoEllipsoid', function () {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;

--- a/Specs/Core/EquidistantCylindricalProjectionSpec.js
+++ b/Specs/Core/EquidistantCylindricalProjectionSpec.js
@@ -12,7 +12,7 @@ defineSuite([
          Ellipsoid,
          CesiumMath) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('construct0', function() {
         var projection = new EquidistantCylindricalProjection();

--- a/Specs/Core/EventHandlerSpec.js
+++ b/Specs/Core/EventHandlerSpec.js
@@ -10,7 +10,7 @@ defineSuite([
          MouseEventType,
          Cartesian2) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     // create a mock document object to add events to so they are callable.
     var MockDoc = function() {

--- a/Specs/Core/EventSpec.js
+++ b/Specs/Core/EventSpec.js
@@ -4,7 +4,7 @@ defineSuite([
      ], function(
          Event) {
     "use strict";
-    /*global it expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('Event works with no scope', function() {
         var e = new Event();

--- a/Specs/Core/ExtentSpec.js
+++ b/Specs/Core/ExtentSpec.js
@@ -6,7 +6,7 @@ defineSuite([
          Extent,
          CesiumMath) {
     "use strict";
-    /*global it,expect,describe*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('constructor checks for a valid extent.', function() {
         expect(function() {

--- a/Specs/Core/ExtentTessellatorSpec.js
+++ b/Specs/Core/ExtentTessellatorSpec.js
@@ -8,7 +8,7 @@ defineSuite([
          Extent,
          CesiumMath) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('compute 0', function() {
         var m = ExtentTessellator.compute({

--- a/Specs/Core/FeatureDetectionSpec.js
+++ b/Specs/Core/FeatureDetectionSpec.js
@@ -1,7 +1,7 @@
 /*global defineSuite*/
 defineSuite(['Core/FeatureDetection'], function(FeatureDetection) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('detects cross-origin imagery', function() {
         //just make sure the function runs, the test can't expect a value of true or false

--- a/Specs/Core/FullScreenSpec.js
+++ b/Specs/Core/FullScreenSpec.js
@@ -3,7 +3,7 @@ defineSuite(['Core/FullScreen'
             ],function(
               FullScreen) {
     "use strict";
-    /*global it,expect,document*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('Methods execute', function() {
         //Just make sure the functions run.

--- a/Specs/Core/HermitePolynomialApproximationSpec.js
+++ b/Specs/Core/HermitePolynomialApproximationSpec.js
@@ -4,7 +4,7 @@ defineSuite([
             ], function(
              HermitePolynomialApproximation) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     //The results of these specs were validated against STK Components
     //an aerospace SDK available from Analytical Graphics. www.agi.com/components/

--- a/Specs/Core/HermiteSplineSpec.js
+++ b/Specs/Core/HermiteSplineSpec.js
@@ -8,7 +8,7 @@ defineSuite([
          Cartesian3,
          CesiumMath) {
     "use strict";
-    /*global it,expect,beforeEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var points;
     beforeEach(function() {

--- a/Specs/Core/IntersectionTestsSpec.js
+++ b/Specs/Core/IntersectionTestsSpec.js
@@ -12,7 +12,7 @@ defineSuite([
          CesiumMath,
          Ray) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('rayPlane intersects', function() {
         var ray = new Ray(new Cartesian3(2.0, 0.0, 0.0), new Cartesian3(-1.0, 0.0, 0.0));

--- a/Specs/Core/JulianDateSpec.js
+++ b/Specs/Core/JulianDateSpec.js
@@ -8,7 +8,7 @@ function(JulianDate,
          TimeConstants,
          CesiumMath) {
     "use strict";
-    /*global it, expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     // All exact Julian Dates found using NASA's Time Conversion Tool: http://ssd.jpl.nasa.gov/tc.cgi
     it('Construct a default date', function() {

--- a/Specs/Core/LagrangePolynomialApproximationSpec.js
+++ b/Specs/Core/LagrangePolynomialApproximationSpec.js
@@ -4,7 +4,7 @@ defineSuite([
             ], function(
              LagrangePolynomialApproximation) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     //The results of these specs were validated against STK Components
     //an aerospace SDK available from Analytical Graphics. www.agi.com/components/

--- a/Specs/Core/LeapSecondSpec.js
+++ b/Specs/Core/LeapSecondSpec.js
@@ -10,7 +10,7 @@ defineSuite([
          TimeStandard,
          binarySearch) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('throws an exception if constructed without a julian date', function() {
         expect(function() {

--- a/Specs/Core/LinearApproximationSpec.js
+++ b/Specs/Core/LinearApproximationSpec.js
@@ -4,8 +4,8 @@ defineSuite([
             ], function(
              LinearApproximation) {
     "use strict";
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
-    /*global it,expect*/
     it('should produce correct results', function() {
         var xTable = [2.0, 4.0];
         var yTable = [2.0, 3.0, 4.0, 34.0];

--- a/Specs/Core/MathSpec.js
+++ b/Specs/Core/MathSpec.js
@@ -8,7 +8,7 @@ defineSuite([
          Cartesian3,
          Cartographic) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('sign of -2', function() {
         expect(CesiumMath.sign(-2)).toEqual(-1);

--- a/Specs/Core/Matrix2Spec.js
+++ b/Specs/Core/Matrix2Spec.js
@@ -6,7 +6,7 @@ defineSuite([
          Matrix2,
          Cartesian2) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('default constructor creates values array with all zeros.', function() {
         var matrix = new Matrix2();

--- a/Specs/Core/Matrix3Spec.js
+++ b/Specs/Core/Matrix3Spec.js
@@ -10,7 +10,7 @@ defineSuite([
          CesiumMath,
          Quaternion) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('default constructor creates values array with all zeros.', function() {
         var matrix = new Matrix3();

--- a/Specs/Core/Matrix4Spec.js
+++ b/Specs/Core/Matrix4Spec.js
@@ -12,7 +12,7 @@ defineSuite([
               Cartesian4,
               CesiumMath) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('default constructor creates values array with all zeros.', function() {
         var matrix = new Matrix4();

--- a/Specs/Core/MercatorProjectionSpec.js
+++ b/Specs/Core/MercatorProjectionSpec.js
@@ -6,13 +6,13 @@ defineSuite([
          'Core/Ellipsoid',
          'Core/Math'
      ], function(
-             MercatorProjection,
+         MercatorProjection,
          Cartesian3,
          Cartographic,
          Ellipsoid,
          CesiumMath) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('construct0', function() {
         var projection = new MercatorProjection();

--- a/Specs/Core/MeshFiltersSpec.js
+++ b/Specs/Core/MeshFiltersSpec.js
@@ -18,7 +18,7 @@ defineSuite([
          Tipsify,
          EquidistantCylindricalProjection) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('converts triangles to wireframe in place', function() {
         var mesh = MeshFilters.toWireframeInPlace({

--- a/Specs/Core/OccluderSpec.js
+++ b/Specs/Core/OccluderSpec.js
@@ -12,7 +12,7 @@ defineSuite([
          Visibility,
          CesiumMath) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('throws an exception during construction (1 of 3)', function() {
         expect(function() {

--- a/Specs/Core/OrientationInterpolationSpec.js
+++ b/Specs/Core/OrientationInterpolationSpec.js
@@ -8,7 +8,7 @@ defineSuite([
          Quaternion,
          CesiumMath) {
     "use strict";
-    /*global it,expect,beforeEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
    var points;
     beforeEach(function() {

--- a/Specs/Core/PlaneTessellatorSpec.js
+++ b/Specs/Core/PlaneTessellatorSpec.js
@@ -1,7 +1,7 @@
 /*global defineSuite*/
 defineSuite(['Core/PlaneTessellator'], function(PlaneTessellator) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('compute with default arguments', function() {
         var m = PlaneTessellator.compute();

--- a/Specs/Core/PolygonPipelineSpec.js
+++ b/Specs/Core/PolygonPipelineSpec.js
@@ -16,7 +16,7 @@ defineSuite([
          EllipsoidTangentPlane,
          WindingOrder) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('cleanUp removes duplicate points', function() {
         var positions = PolygonPipeline.cleanUp([

--- a/Specs/Core/PolylinePipelineSpec.js
+++ b/Specs/Core/PolylinePipelineSpec.js
@@ -8,7 +8,7 @@ defineSuite([
          Cartographic,
          Ellipsoid) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('wrapLongitude', function() {
         var ellipsoid = Ellipsoid.WGS84;

--- a/Specs/Core/QuaternionSpec.js
+++ b/Specs/Core/QuaternionSpec.js
@@ -12,7 +12,7 @@ defineSuite([
          Matrix3,
          CesiumMath) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('construct0', function() {
         var q = new Quaternion();

--- a/Specs/Core/QueueSpec.js
+++ b/Specs/Core/QueueSpec.js
@@ -1,7 +1,7 @@
 /*global defineSuite*/
 defineSuite(['Core/Queue'], function(Queue) {
     "use strict";
-    /*global it,expect,beforeEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var queue;
     beforeEach(function() {

--- a/Specs/Core/RaySpec.js
+++ b/Specs/Core/RaySpec.js
@@ -6,7 +6,7 @@ defineSuite([
          Ray,
          Cartesian3) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('constructor throws without a position', function() {
         expect(function() {

--- a/Specs/Core/RectangleSpec.js
+++ b/Specs/Core/RectangleSpec.js
@@ -6,7 +6,7 @@ defineSuite([
          Rectangle,
          Cartesian2) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var positions = [
                      new Cartesian2(3, -1),

--- a/Specs/Core/RuntimeErrorSpec.js
+++ b/Specs/Core/RuntimeErrorSpec.js
@@ -5,7 +5,7 @@ defineSuite([
     RuntimeError
 ) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var name = 'RuntimeError';
     var testMessage = 'Testing';

--- a/Specs/Core/ShapesSpec.js
+++ b/Specs/Core/ShapesSpec.js
@@ -10,7 +10,7 @@ defineSuite([
          Ellipsoid,
          CesiumMath) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('computeCircleBoundary computes a closed loop', function() {
         var ellipsoid = Ellipsoid.WGS84;

--- a/Specs/Core/SphericalSpec.js
+++ b/Specs/Core/SphericalSpec.js
@@ -8,7 +8,7 @@ defineSuite([
          Cartesian3,
          CesiumMath) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     //Mock object to make sure methods take non-sphericals.
     function NotSpherical(clock, cone, magnitude) {

--- a/Specs/Core/SunPositionSpec.js
+++ b/Specs/Core/SunPositionSpec.js
@@ -10,7 +10,7 @@ defineSuite([
          Ellipsoid,
          CesiumMath) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var date1 = new Date('January 15, 2012');
     date1.setUTCHours(12, 0, 0, 0);

--- a/Specs/Core/TimeIntervalCollectionSpec.js
+++ b/Specs/Core/TimeIntervalCollectionSpec.js
@@ -8,7 +8,7 @@ defineSuite([
          JulianDate,
          TimeInterval) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     function TestObject(value) {
         this.value = value;

--- a/Specs/Core/TimeIntervalSpec.js
+++ b/Specs/Core/TimeIntervalSpec.js
@@ -6,7 +6,7 @@ defineSuite([
          TimeInterval,
          JulianDate) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     function mergeByAdd(left, right) {
         return left + right;

--- a/Specs/Core/TipsifySpec.js
+++ b/Specs/Core/TipsifySpec.js
@@ -4,7 +4,7 @@ defineSuite([
      ], function(
          Tipsify) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('can calculate the ACMR', function() {
         //Hexagon formed from 6 triangles, 7 vertices

--- a/Specs/Core/TransformsSpec.js
+++ b/Specs/Core/TransformsSpec.js
@@ -16,7 +16,7 @@ defineSuite([
          Matrix4,
          CesiumMath) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('creates an east-north-up-to-fixed-frame matrix', function() {
         var m = Transforms.eastNorthUpToFixedFrame(new Cartesian3(1.0, 0.0, 0.0), Ellipsoid.UNIT_SPHERE);

--- a/Specs/Core/TridiagonalSystemSolverSpec.js
+++ b/Specs/Core/TridiagonalSystemSolverSpec.js
@@ -8,7 +8,7 @@ defineSuite([
          Cartesian3,
          CesiumMath) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
    it('solve throws exception without lower diagonal', function() {
         expect(function() {

--- a/Specs/Core/binarySearchSpec.js
+++ b/Specs/Core/binarySearchSpec.js
@@ -1,7 +1,7 @@
 /*global defineSuite*/
 defineSuite(['Core/binarySearch'], function(binarySearch) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('can perform a binary search (1)', function() {
         var array = [0, 1, 2, 3, 4, 5, 6, 7];

--- a/Specs/Core/combineSpec.js
+++ b/Specs/Core/combineSpec.js
@@ -4,7 +4,7 @@ defineSuite([
      ], function(
          combine) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('combine throws with duplicate member', function() {
         expect(function() {

--- a/Specs/Core/createGuidSpec.js
+++ b/Specs/Core/createGuidSpec.js
@@ -1,7 +1,7 @@
 /*global defineSuite*/
 defineSuite(['Core/createGuid'], function(createGuid) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('creates GUIDs', function() {
         var isGuidRegex = /^(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}$/;

--- a/Specs/Core/isLeapYearSpec.js
+++ b/Specs/Core/isLeapYearSpec.js
@@ -1,7 +1,7 @@
 /*global defineSuite*/
 defineSuite(['Core/isLeapYear'], function(isLeapYear) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('Check for valid leap years', function() {
         expect(isLeapYear(2000)).toEqual(true);

--- a/Specs/Core/loadImageSpec.js
+++ b/Specs/Core/loadImageSpec.js
@@ -6,7 +6,7 @@ defineSuite([
              loadImage,
              when) {
     "use strict";
-    /*global it,expect,waitsFor,runs,spyOn*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var dataUri = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2Nk+M/wHwAEBgIA5agATwAAAABJRU5ErkJggg==';
 

--- a/Specs/Core/pointInsideTriangle2DSpec.js
+++ b/Specs/Core/pointInsideTriangle2DSpec.js
@@ -6,7 +6,7 @@ defineSuite([
          pointInsideTriangle2D,
          Cartesian2) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('pointInsideTriangle2D has point inside', function() {
         expect(pointInsideTriangle2D(new Cartesian2(0.25, 0.25), Cartesian2.ZERO, new Cartesian2(1.0, 0.0), new Cartesian2(0.0, 1.0))).toEqual(true);

--- a/Specs/Core/shallowEqualsSpec.js
+++ b/Specs/Core/shallowEqualsSpec.js
@@ -1,7 +1,7 @@
 /*global defineSuite*/
 defineSuite(['Core/shallowEquals'], function(shallowEquals) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('returns false if left is undefined', function() {
         expect(shallowEquals(undefined, {

--- a/Specs/DynamicScene/CompositeDynamicObjectCollectionSpec.js
+++ b/Specs/DynamicScene/CompositeDynamicObjectCollectionSpec.js
@@ -28,7 +28,7 @@ defineSuite([
          CzmlDefaults,
          HorizontalOrigin) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var czml1 = {
         'id' : 'testBillboard',

--- a/Specs/DynamicScene/CzmlBooleanSpec.js
+++ b/Specs/DynamicScene/CzmlBooleanSpec.js
@@ -4,7 +4,7 @@ defineSuite([
             ], function(
               CzmlBoolean) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var simpleBoolean = true;
 

--- a/Specs/DynamicScene/CzmlCartesian2Spec.js
+++ b/Specs/DynamicScene/CzmlCartesian2Spec.js
@@ -6,7 +6,7 @@ defineSuite([
               CzmlCartesian2,
               Cartesian2) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var cartesian1 = new Cartesian2(123.456, 789.101112);
     var cartesian2 = new Cartesian2(789.101112, 123.456);

--- a/Specs/DynamicScene/CzmlCartesian3Spec.js
+++ b/Specs/DynamicScene/CzmlCartesian3Spec.js
@@ -6,7 +6,7 @@ defineSuite([
               CzmlCartesian3,
               Cartesian3) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var cartesian1 = new Cartesian3(123.456, 789.101112, 321.312);
     var cartesian2 = new Cartesian3(789.101112, 123.456, 521.312);

--- a/Specs/DynamicScene/CzmlCartographicSpec.js
+++ b/Specs/DynamicScene/CzmlCartographicSpec.js
@@ -8,7 +8,7 @@ defineSuite([
               Cartographic,
               CesiumMath) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var cartographic1 = new Cartographic(123.456, 789.101112, 321.312);
     var cartographic2 = new Cartographic(789.101112, 123.456, 521.312);

--- a/Specs/DynamicScene/CzmlColorSpec.js
+++ b/Specs/DynamicScene/CzmlColorSpec.js
@@ -6,7 +6,7 @@ defineSuite([
               CzmlColor,
               Color) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var constantRgbaInterval = {
         rgba : [1, 2, 3, 4]

--- a/Specs/DynamicScene/CzmlHorizontalOriginSpec.js
+++ b/Specs/DynamicScene/CzmlHorizontalOriginSpec.js
@@ -6,7 +6,7 @@ defineSuite([
               CzmlHorizontalOrigin,
               HorizontalOrigin) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var simpleHorizontalOrigin = 'CENTER';
 

--- a/Specs/DynamicScene/CzmlImageSpec.js
+++ b/Specs/DynamicScene/CzmlImageSpec.js
@@ -4,7 +4,7 @@ defineSuite([
             ], function(
               CzmlImage) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var simpleImage = 'foo.png';
 

--- a/Specs/DynamicScene/CzmlLabelStyleSpec.js
+++ b/Specs/DynamicScene/CzmlLabelStyleSpec.js
@@ -6,7 +6,7 @@ defineSuite([
               CzmlLabelStyle,
               LabelStyle) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var simpleLabelStyle = 'FILL';
 

--- a/Specs/DynamicScene/CzmlNumberSpec.js
+++ b/Specs/DynamicScene/CzmlNumberSpec.js
@@ -4,7 +4,7 @@ defineSuite([
             ], function(
               CzmlNumber) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var simpleNumber = 0.5;
 

--- a/Specs/DynamicScene/CzmlStringSpec.js
+++ b/Specs/DynamicScene/CzmlStringSpec.js
@@ -4,7 +4,7 @@ defineSuite([
             ], function(
               CzmlString) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var simpleString = 'some Value';
 

--- a/Specs/DynamicScene/CzmlUnitCartesian3Spec.js
+++ b/Specs/DynamicScene/CzmlUnitCartesian3Spec.js
@@ -8,7 +8,7 @@ defineSuite([
               Cartesian3,
               CesiumMath) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var cartesian1 = new Cartesian3(1, 2, 3).normalize();
     var cartesian2 = new Cartesian3(4, 5, 6).normalize();

--- a/Specs/DynamicScene/CzmlUnitQuaternionSpec.js
+++ b/Specs/DynamicScene/CzmlUnitQuaternionSpec.js
@@ -8,7 +8,7 @@ defineSuite([
               Quaternion,
               CesiumMath) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var quaternion1 = new Quaternion(1, 2, 3, 4).normalize();
     var quaternion2 = new Quaternion(4, 5, 6, 7).normalize();

--- a/Specs/DynamicScene/CzmlUnitSphericalSpec.js
+++ b/Specs/DynamicScene/CzmlUnitSphericalSpec.js
@@ -8,7 +8,7 @@ defineSuite([
               Spherical,
               CesiumMath) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var spherical1 = new Spherical(2, 3, 1.0);
     var spherical2 = new Spherical(4, 5, 1.0);

--- a/Specs/DynamicScene/CzmlVerticalOriginSpec.js
+++ b/Specs/DynamicScene/CzmlVerticalOriginSpec.js
@@ -6,7 +6,7 @@ defineSuite([
               CzmlVerticalOrigin,
               VerticalOrigin) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var simpleVerticalOrigin = 'CENTER';
 

--- a/Specs/DynamicScene/DynamicBillboardSpec.js
+++ b/Specs/DynamicScene/DynamicBillboardSpec.js
@@ -22,7 +22,7 @@ defineSuite([
               HorizontalOrigin,
               VerticalOrigin) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('processCzmlPacket adds data for infinite billboard.', function() {
         var sourceUri = 'http://someImage.com/';

--- a/Specs/DynamicScene/DynamicBillboardVisualizerSpec.js
+++ b/Specs/DynamicScene/DynamicBillboardVisualizerSpec.js
@@ -32,13 +32,17 @@ defineSuite([
               HorizontalOrigin,
               VerticalOrigin) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach,waitsFor,runs*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var scene;
     var visualizer;
 
-    beforeEach(function() {
-        scene = scene || createScene();
+    beforeAll(function() {
+        scene = createScene();
+    });
+
+    afterAll(function() {
+        destroyScene(scene);
     });
 
     afterEach(function() {
@@ -285,9 +289,5 @@ defineSuite([
         expect(billboardCollection.getLength()).toEqual(1);
         bb = billboardCollection.get(0);
         expect(bb.dynamicObject).toEqual(testObject2);
-    });
-
-    it('destroy scene', function() {
-        destroyScene(scene);
     });
 });

--- a/Specs/DynamicScene/DynamicConeSpec.js
+++ b/Specs/DynamicScene/DynamicConeSpec.js
@@ -22,7 +22,7 @@ defineSuite([
               HorizontalOrigin,
               VerticalOrigin) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('processCzmlPacket adds data for infinite cone.', function() {
         var conePacket = {

--- a/Specs/DynamicScene/DynamicConeVisualizerSpec.js
+++ b/Specs/DynamicScene/DynamicConeVisualizerSpec.js
@@ -32,13 +32,17 @@ defineSuite([
               Matrix4,
               Scene) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach,waitsFor,runs*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var scene;
     var visualizer;
 
-    beforeEach(function() {
-        scene = scene || createScene();
+    beforeAll(function() {
+        scene = createScene();
+    });
+
+    afterAll(function() {
+        destroyScene(scene);
     });
 
     afterEach(function() {
@@ -230,9 +234,5 @@ defineSuite([
         expect(scene.getPrimitives().getLength()).toEqual(1);
         conePrimitive = scene.getPrimitives().get(0);
         expect(conePrimitive.dynamicObject).toEqual(testObject2);
-    });
-
-    it('destroy scene', function() {
-        destroyScene(scene);
     });
 });

--- a/Specs/DynamicScene/DynamicConeVisualizerUsingCustomSensorSpec.js
+++ b/Specs/DynamicScene/DynamicConeVisualizerUsingCustomSensorSpec.js
@@ -32,13 +32,17 @@ defineSuite([
               Color,
               Scene) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach,waitsFor,runs*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var scene;
     var visualizer;
 
-    beforeEach(function() {
-        scene = scene || createScene();
+    beforeAll(function() {
+        scene = createScene();
+    });
+
+    afterAll(function() {
+        destroyScene(scene);
     });
 
     afterEach(function() {
@@ -227,9 +231,5 @@ defineSuite([
         expect(scene.getPrimitives().getLength()).toEqual(1);
         conePrimitive = scene.getPrimitives().get(0);
         expect(conePrimitive.dynamicObject).toEqual(testObject2);
-    });
-
-    it('destroy scene', function() {
-        destroyScene(scene);
     });
 });

--- a/Specs/DynamicScene/DynamicDirectionsPropertySpec.js
+++ b/Specs/DynamicScene/DynamicDirectionsPropertySpec.js
@@ -18,7 +18,7 @@ defineSuite([
           Spherical,
           CesiumMath) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var sphericalInterval = {
         unitSpherical : [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]

--- a/Specs/DynamicScene/DynamicLabelSpec.js
+++ b/Specs/DynamicScene/DynamicLabelSpec.js
@@ -24,7 +24,7 @@ defineSuite([
               VerticalOrigin,
               LabelStyle) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('processCzmlPacket adds data for infinite label.', function() {
         var labelPacket = {

--- a/Specs/DynamicScene/DynamicLabelVisualizerSpec.js
+++ b/Specs/DynamicScene/DynamicLabelVisualizerSpec.js
@@ -34,13 +34,17 @@ defineSuite([
               VerticalOrigin,
               LabelStyle) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach,waitsFor,runs*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var scene;
     var visualizer;
 
-    beforeEach(function() {
-        scene = scene || createScene();
+    beforeAll(function() {
+        scene = createScene();
+    });
+
+    afterAll(function() {
+        destroyScene(scene);
     });
 
     afterEach(function() {
@@ -278,9 +282,5 @@ defineSuite([
         expect(labelCollection.getLength()).toEqual(1);
         l = labelCollection.get(0);
         expect(l.dynamicObject).toEqual(testObject2);
-    });
-
-    it('destroy scene', function() {
-        destroyScene(scene);
     });
 });

--- a/Specs/DynamicScene/DynamicObjectCollectionSpec.js
+++ b/Specs/DynamicScene/DynamicObjectCollectionSpec.js
@@ -12,7 +12,7 @@ defineSuite([
          TimeInterval,
          DynamicObject) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('getObject throws if no id specified', function() {
         var dynamicObjectCollection = new DynamicObjectCollection();

--- a/Specs/DynamicScene/DynamicObjectSpec.js
+++ b/Specs/DynamicScene/DynamicObjectSpec.js
@@ -14,7 +14,7 @@ defineSuite([
               Iso8601,
               TimeInterval) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('constructor sets id.', function() {
         var dynamicObject = new DynamicObject('someId');

--- a/Specs/DynamicScene/DynamicPointSpec.js
+++ b/Specs/DynamicScene/DynamicPointSpec.js
@@ -14,7 +14,7 @@ defineSuite([
               Iso8601,
               TimeInterval) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('processCzmlPacket adds data for infinite point.', function() {
         var pointPacket = {

--- a/Specs/DynamicScene/DynamicPointVisualizerSpec.js
+++ b/Specs/DynamicScene/DynamicPointVisualizerSpec.js
@@ -26,13 +26,17 @@ defineSuite([
               Scene,
               BillboardCollection) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach,waitsFor,runs*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var scene;
     var visualizer;
 
-    beforeEach(function() {
-        scene = scene || createScene();
+    beforeAll(function() {
+        scene = createScene();
+    });
+
+    afterAll(function() {
+        destroyScene(scene);
     });
 
     afterEach(function() {
@@ -224,9 +228,5 @@ defineSuite([
         expect(billboardCollection.getLength()).toEqual(1);
         bb = billboardCollection.get(0);
         expect(bb.dynamicObject).toEqual(testObject2);
-    });
-
-    it('destroy scene', function() {
-        destroyScene(scene);
     });
 });

--- a/Specs/DynamicScene/DynamicPolygonSpec.js
+++ b/Specs/DynamicScene/DynamicPolygonSpec.js
@@ -14,7 +14,7 @@ defineSuite([
               Iso8601,
               TimeInterval) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('processCzmlPacket adds data for infinite polygon.', function() {
         var polygonPacket = {

--- a/Specs/DynamicScene/DynamicPolygonVisualizerSpec.js
+++ b/Specs/DynamicScene/DynamicPolygonVisualizerSpec.js
@@ -26,13 +26,17 @@ defineSuite([
               Color,
               Scene) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach,waitsFor,runs*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var scene;
     var visualizer;
 
-    beforeEach(function() {
-        scene = scene || createScene();
+    beforeAll(function() {
+        scene = createScene();
+    });
+
+    afterAll(function() {
+        destroyScene(scene);
     });
 
     afterEach(function() {
@@ -202,9 +206,5 @@ defineSuite([
         expect(scene.getPrimitives().getLength()).toEqual(1);
         primitive = scene.getPrimitives().get(0);
         expect(primitive.dynamicObject).toEqual(testObject2);
-    });
-
-    it('destroy scene', function() {
-        destroyScene(scene);
     });
 });

--- a/Specs/DynamicScene/DynamicPolylineSpec.js
+++ b/Specs/DynamicScene/DynamicPolylineSpec.js
@@ -14,7 +14,7 @@ defineSuite([
               Iso8601,
               TimeInterval) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('processCzmlPacket adds data for infinite polyline.', function() {
         var polylinePacket = {

--- a/Specs/DynamicScene/DynamicPolylineVisualizerSpec.js
+++ b/Specs/DynamicScene/DynamicPolylineVisualizerSpec.js
@@ -26,13 +26,17 @@ defineSuite([
               Color,
               Scene) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach,waitsFor,runs*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var scene;
     var visualizer;
 
-    beforeEach(function() {
-        scene = scene || createScene();
+    beforeAll(function() {
+        scene = createScene();
+    });
+
+    afterAll(function() {
+        destroyScene(scene);
     });
 
     afterEach(function() {
@@ -216,9 +220,5 @@ defineSuite([
         expect(scene.getPrimitives().getLength()).toEqual(1);
         primitive = scene.getPrimitives().get(0);
         expect(primitive.dynamicObject).toEqual(testObject2);
-    });
-
-    it('destroy scene', function() {
-        destroyScene(scene);
     });
 });

--- a/Specs/DynamicScene/DynamicPositionPropertySpec.js
+++ b/Specs/DynamicScene/DynamicPositionPropertySpec.js
@@ -8,7 +8,7 @@ defineSuite([
           JulianDate,
           Ellipsoid) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var cartesianInterval = {
         epoch : '2012-04-18T15:59:00Z',

--- a/Specs/DynamicScene/DynamicPropertySpec.js
+++ b/Specs/DynamicScene/DynamicPropertySpec.js
@@ -22,7 +22,7 @@ defineSuite([
          HermitePolynomialApproximation,
          LagrangePolynomialApproximation) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('Works with uninterpolatable value types.', function() {
         var dynamicProperty = new DynamicProperty(CzmlBoolean);

--- a/Specs/DynamicScene/DynamicPyramidSpec.js
+++ b/Specs/DynamicScene/DynamicPyramidSpec.js
@@ -16,7 +16,7 @@ defineSuite([
               Iso8601,
               TimeInterval) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('processCzmlPacket adds data for infinite pyramid.', function() {
         var pyramidPacket = {

--- a/Specs/DynamicScene/DynamicPyramidVisualizerSpec.js
+++ b/Specs/DynamicScene/DynamicPyramidVisualizerSpec.js
@@ -34,13 +34,17 @@ defineSuite([
               Color,
               Scene) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach,waitsFor,runs*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var scene;
     var visualizer;
 
-    beforeEach(function() {
-        scene = scene || createScene();
+    beforeAll(function() {
+        scene = createScene();
+    });
+
+    afterAll(function() {
+        destroyScene(scene);
     });
 
     afterEach(function() {
@@ -213,9 +217,5 @@ defineSuite([
         expect(scene.getPrimitives().getLength()).toEqual(1);
         pyramidPrimitive = scene.getPrimitives().get(0);
         expect(pyramidPrimitive.dynamicObject).toEqual(testObject2);
-    });
-
-    it('destroy scene', function() {
-        destroyScene(scene);
     });
 });

--- a/Specs/DynamicScene/DynamicVertexPositionsPropertySpec.js
+++ b/Specs/DynamicScene/DynamicVertexPositionsPropertySpec.js
@@ -14,7 +14,7 @@ defineSuite([
           CesiumMath,
           Ellipsoid) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var cartographicRadiansInterval = {
         cartographicRadians : [1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9]

--- a/Specs/DynamicScene/ReferencePropertySpec.js
+++ b/Specs/DynamicScene/ReferencePropertySpec.js
@@ -10,7 +10,7 @@ defineSuite([
               DynamicObject,
               Iso8601) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var testObjectLink = 'testObject.property';
     function createTestObject(dynamicObjectCollection, methodName) {

--- a/Specs/DynamicScene/VisualizerCollectionSpec.js
+++ b/Specs/DynamicScene/VisualizerCollectionSpec.js
@@ -14,7 +14,7 @@ defineSuite([
               createScene,
               destroyScene) {
     "use strict";
-    /*global it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     function MockVisualizer() {
         this.updateTime = undefined;

--- a/Specs/DynamicScene/processCzmlSpec.js
+++ b/Specs/DynamicScene/processCzmlSpec.js
@@ -10,7 +10,7 @@ defineSuite([
               DynamicBillboard,
               JulianDate) {
     "use strict";
-    /*global it,expect,waitsFor*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var czml = {
         'id' : 'test',

--- a/Specs/Renderer/AutomaticUniformSpec.js
+++ b/Specs/Renderer/AutomaticUniformSpec.js
@@ -12,12 +12,16 @@ defineSuite([
          PrimitiveType,
          BufferUsage) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
+
+    afterAll(function() {
+        destroyContext(context);
     });
 
     function verifyDraw(fs) {
@@ -365,9 +369,5 @@ defineSuite([
 
         var fs = 'void main() { gl_FragColor = vec4(agi_viewerPositionWC == vec3(0.0)); }';
         verifyDraw(fs);
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Renderer/BufferSpec.js
+++ b/Specs/Renderer/BufferSpec.js
@@ -12,13 +12,17 @@ defineSuite([
          IndexDatatype,
          BufferUsage) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
     var buffer;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
+
+    afterAll(function() {
+        destroyContext(context);
     });
 
     afterEach(function() {
@@ -146,9 +150,5 @@ defineSuite([
         expect(function() {
             b.destroy();
         }).toThrow();
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Renderer/BuiltinFunctionsSpec.js
+++ b/Specs/Renderer/BuiltinFunctionsSpec.js
@@ -14,12 +14,16 @@ defineSuite([
          PrimitiveType,
          BufferUsage) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
+
+    afterAll(function() {
+        destroyContext(context);
     });
 
     var verifyDraw = function(fs) {
@@ -118,9 +122,5 @@ defineSuite([
             '}';
 
         verifyDraw(fs);
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Renderer/ClearSpec.js
+++ b/Specs/Renderer/ClearSpec.js
@@ -6,12 +6,16 @@ defineSuite([
          createContext,
          destroyContext) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
+
+    afterAll(function() {
+        destroyContext(context);
     });
 
     it('default clear', function() {
@@ -172,9 +176,5 @@ defineSuite([
                 height : -1
             })).toEqual([0, 0, 0, 0]);
         }).toThrow();
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Renderer/ClearStateSpec.js
+++ b/Specs/Renderer/ClearStateSpec.js
@@ -6,12 +6,16 @@ defineSuite([
          createContext,
          destroyContext) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
+
+    afterAll(function() {
+        destroyContext(context);
     });
 
     it('creates with defaults', function() {
@@ -186,9 +190,5 @@ defineSuite([
                 }
             });
         }).toThrow();
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Renderer/ConstructiveSolidGeometrySpec.js
+++ b/Specs/Renderer/ConstructiveSolidGeometrySpec.js
@@ -12,12 +12,16 @@ defineSuite([
          ShadersRay,
          ShadersConstructiveSolidGeometry) {
     "use strict";
-    /*global xit,it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
+
+    afterAll(function() {
+        destroyContext(context);
     });
 
     renderFragment = (function(renderFragment) {
@@ -636,9 +640,5 @@ defineSuite([
             '  gl_FragColor = vec4(agi_equalsEpsilon(i.start, 0.0) && agi_equalsEpsilon(i.stop, agi_infinity)); ' +
             '}';
         expect(renderFragment(context, fs)).toEqual([255, 255, 255, 255]);
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Renderer/ContextSpec.js
+++ b/Specs/Renderer/ContextSpec.js
@@ -10,12 +10,16 @@ defineSuite([
          destroyContext,
          renderFragment) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
+
+    afterAll(function() {
+        destroyContext(context);
     });
 
     it('getCanvas', function() {
@@ -293,9 +297,5 @@ defineSuite([
         expect(c.isDestroyed()).toEqual(false);
         c.destroy();
         expect(c.isDestroyed()).toEqual(true);
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Renderer/CubeMapSpec.js
+++ b/Specs/Renderer/CubeMapSpec.js
@@ -22,7 +22,7 @@ defineSuite([
          TextureMinificationFilter,
          TextureMagnificationFilter) {
     "use strict";
-    /*global xit,it,expect,beforeEach,afterEach,waitsFor*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
     var sp;
@@ -34,22 +34,18 @@ defineSuite([
     var blueAlphaImage;
     var blueOverRedImage;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
+
+    afterAll(function() {
+        destroyContext(context);
     });
 
     afterEach(function() {
-        if (sp) {
-            sp = sp.destroy();
-        }
-
-        if (va) {
-            va = va.destroy();
-        }
-
-        if (cubeMap) {
-            cubeMap = cubeMap.destroy();
-        }
+        sp = sp && sp.destroy();
+        va = va && va.destroy();
+        cubeMap = cubeMap && cubeMap.destroy();
     });
 
     it('create images', function() {
@@ -910,9 +906,5 @@ defineSuite([
         expect(function() {
             c.destroy();
         }).toThrow();
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Renderer/DrawSpec.js
+++ b/Specs/Renderer/DrawSpec.js
@@ -26,24 +26,23 @@ defineSuite([
          StencilFunction,
          StencilOperation) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
     var sp;
     var va;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
+
+    afterAll(function() {
+        destroyContext(context);
     });
 
     afterEach(function() {
-        if (sp) {
-            sp = sp.destroy();
-        }
-
-        if (va) {
-            va = va.destroy();
-        }
+        sp = sp && sp.destroy();
+        va = va && va.destroy();
     });
 
     it('draws a white point', function() {
@@ -921,9 +920,5 @@ defineSuite([
                 count : 1
             });
         }).toThrow();
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Renderer/FramebufferSpec.js
+++ b/Specs/Renderer/FramebufferSpec.js
@@ -20,29 +20,25 @@ defineSuite([
          StencilFunction,
          StencilOperation) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
     var sp;
     var va;
     var framebuffer;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
+
+    afterAll(function() {
+        destroyContext(context);
     });
 
     afterEach(function() {
-        if (sp) {
-            sp = sp.destroy();
-        }
-
-        if (va) {
-            va = va.destroy();
-        }
-
-        if (framebuffer) {
-            framebuffer = framebuffer.destroy();
-        }
+        sp = sp && sp.destroy();
+        va = va && va.destroy();
+        framebuffer = framebuffer && framebuffer.destroy();
     });
 
     it('has a color attachment', function() {
@@ -473,9 +469,5 @@ defineSuite([
         expect(function() {
             f.destroy();
         }).toThrow();
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Renderer/RaySpec.js
+++ b/Specs/Renderer/RaySpec.js
@@ -10,12 +10,16 @@ defineSuite([
          renderFragment,
          ShadersRay) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
+
+    afterAll(function() {
+        destroyContext(context);
     });
 
     renderFragment = (function(renderFragment) {
@@ -396,9 +400,5 @@ defineSuite([
             '    && (intersection.intervals[0].start == 2.0) && (intersection.intervals[0].stop == 4.0)); ' +
             '}';
         expect(renderFragment(context, fs)).toEqual([255, 255, 255, 255]);
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Renderer/RenderStateSpec.js
+++ b/Specs/Renderer/RenderStateSpec.js
@@ -20,12 +20,16 @@ defineSuite([
          StencilFunction,
          StencilOperation) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
+
+    afterAll(function() {
+        destroyContext(context);
     });
 
     it('creates with defaults', function() {
@@ -635,9 +639,5 @@ defineSuite([
                 }
             });
         }).toThrow();
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Renderer/RenderbufferSpec.js
+++ b/Specs/Renderer/RenderbufferSpec.js
@@ -8,19 +8,21 @@ defineSuite([
          destroyContext,
          RenderbufferFormat) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
     var renderbuffer;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
+
+    afterAll(function() {
+        destroyContext(context);
     });
 
     afterEach(function() {
-        if (renderbuffer) {
-            renderbuffer = renderbuffer.destroy();
-        }
+        renderbuffer = renderbuffer && renderbuffer.destroy();
     });
 
     it('creates', function() {
@@ -97,9 +99,5 @@ defineSuite([
         expect(function() {
             r.destroy();
         }).toThrow();
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Renderer/ShaderCacheSpec.js
+++ b/Specs/Renderer/ShaderCacheSpec.js
@@ -8,12 +8,16 @@ defineSuite([
          createContext,
          destroyContext) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
+
+    afterAll(function() {
+        destroyContext(context);
     });
 
     it('adds and removes', function() {
@@ -122,9 +126,5 @@ defineSuite([
     it('is not destroyed', function() {
         var cache = new ShaderCache(context);
         expect(cache.isDestroyed()).toEqual(false);
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Renderer/ShaderProgramSpec.js
+++ b/Specs/Renderer/ShaderProgramSpec.js
@@ -24,14 +24,18 @@ defineSuite([
          BufferUsage,
          UniformDatatype) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
     var sp;
     var va;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
+
+    afterAll(function() {
+        destroyContext(context);
     });
 
     it('has a position vertex attribute', function() {
@@ -508,9 +512,5 @@ defineSuite([
         expect(function() {
             s.destroy();
         }).toThrow();
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Renderer/TextureAtlasBuilderSpec.js
+++ b/Specs/Renderer/TextureAtlasBuilderSpec.js
@@ -16,7 +16,7 @@ defineSuite([
          BufferUsage,
          PixelFormat) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach,waitsFor*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
     var atlas;
@@ -28,8 +28,12 @@ defineSuite([
     var bigGreenImage;
     var whiteImage;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
+
+    afterAll(function() {
+        destroyContext(context);
     });
 
     afterEach(function() {
@@ -189,9 +193,5 @@ defineSuite([
             atlasBuilder.addTextureFromFunction('./Data/Images/Blue.png', function(loadedCallback) {
             }, undefined);
         }).toThrow();
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Renderer/TextureAtlasSpec.js
+++ b/Specs/Renderer/TextureAtlasSpec.js
@@ -16,7 +16,7 @@ defineSuite([
          BufferUsage,
          PixelFormat) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach,waitsFor*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
     var atlas;
@@ -27,8 +27,12 @@ defineSuite([
     var bigBlueImage;
     var bigGreenImage;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
+
+    afterAll(function() {
+        destroyContext(context);
     });
 
     afterEach(function() {
@@ -1016,9 +1020,5 @@ defineSuite([
         expect(function() {
             return new TextureAtlas();
         }).toThrow();
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Renderer/TextureSpec.js
+++ b/Specs/Renderer/TextureSpec.js
@@ -22,7 +22,7 @@ defineSuite([
          TextureMinificationFilter,
          TextureMagnificationFilter) {
     "use strict";
-    /*global xit,it,expect,beforeEach,afterEach,waitsFor*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
     var sp;
@@ -34,22 +34,18 @@ defineSuite([
     var blueAlphaImage;
     var blueOverRedImage;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
+
+    afterAll(function() {
+        destroyContext(context);
     });
 
     afterEach(function() {
-        if (sp) {
-            sp = sp.destroy();
-        }
-
-        if (va) {
-            va = va.destroy();
-        }
-
-        if (texture) {
-            texture = texture.destroy();
-        }
+        sp = sp && sp.destroy();
+        va = va && va.destroy();
+        texture = texture && texture.destroy();
     });
 
     function renderFragment(context) {
@@ -691,9 +687,5 @@ defineSuite([
         expect(function() {
             t.destroy();
         }).toThrow();
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Renderer/UniformDatatypeSpec.js
+++ b/Specs/Renderer/UniformDatatypeSpec.js
@@ -4,7 +4,7 @@ defineSuite([
      ], function(
          UniformDatatype) {
     "use strict";
-    /*global it, expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('FLOAT', function() {
         expect(UniformDatatype.FLOAT.getGLSL()).toEqual('float');

--- a/Specs/Renderer/VertexArrayFacadeSpec.js
+++ b/Specs/Renderer/VertexArrayFacadeSpec.js
@@ -12,12 +12,16 @@ defineSuite([
          ComponentDatatype,
          BufferUsage) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
+
+    afterAll(function() {
+        destroyContext(context);
     });
 
     it('creates a vertex array with static floats', function() {
@@ -268,9 +272,5 @@ defineSuite([
                 componentsPerAttribute : 1
             }]);
         }).toThrow();
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Renderer/VertexArrayFactorySpec.js
+++ b/Specs/Renderer/VertexArrayFactorySpec.js
@@ -18,24 +18,23 @@ defineSuite([
          BufferUsage,
          VertexLayout) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
     var va;
     var sp;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
+
+    afterAll(function() {
+        destroyContext(context);
     });
 
     afterEach(function() {
-        if (va) {
-            va = va.destroy();
-        }
-
-        if (sp) {
-            sp = sp.destroy();
-        }
+        va = va && va.destroy();
+        sp = sp && sp.destroy();
     });
 
     it('creates with no arguments', function() {
@@ -624,9 +623,5 @@ defineSuite([
                 }
             });
         }).toThrow();
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Renderer/VertexArraySpec.js
+++ b/Specs/Renderer/VertexArraySpec.js
@@ -12,12 +12,16 @@ defineSuite([
          PrimitiveType,
          BufferUsage) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
+
+    afterAll(function() {
+        destroyContext(context);
     });
 
     it('binds', function() {
@@ -546,9 +550,5 @@ defineSuite([
         expect(function() {
             va.destroy();
         }).toThrow();
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Scene/BillboardCollectionSpec.js
+++ b/Specs/Scene/BillboardCollectionSpec.js
@@ -32,7 +32,7 @@ defineSuite([
          HorizontalOrigin,
          VerticalOrigin) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach,waitsFor*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
     var billboards;
@@ -42,21 +42,15 @@ defineSuite([
     var blueImage;
     var whiteImage;
 
-    function createTextureAtlas(images) {
-        var atlas = context.createTextureAtlas({images : images, borderWidthInPixels : 1, initialSize : new Cartesian2(3, 3)});
+    beforeAll(function() {
+        context = createContext();
+    });
 
-        // ANGLE Workaround
-        atlas.getTexture().setSampler(context.createSampler({
-            minificationFilter : TextureMinificationFilter.NEAREST,
-            magnificationFilter : TextureMagnificationFilter.NEAREST
-        }));
-
-        return atlas;
-    }
+    afterAll(function() {
+        destroyContext(context);
+    });
 
     beforeEach(function() {
-        context = context || createContext();
-
         billboards = new BillboardCollection();
 
         var camera = {
@@ -73,6 +67,18 @@ defineSuite([
     afterEach(function() {
         billboards = billboards && billboards.destroy();
     });
+
+    function createTextureAtlas(images) {
+        var atlas = context.createTextureAtlas({images : images, borderWidthInPixels : 1, initialSize : new Cartesian2(3, 3)});
+
+        // ANGLE Workaround
+        atlas.getTexture().setSampler(context.createSampler({
+            minificationFilter : TextureMinificationFilter.NEAREST,
+            magnificationFilter : TextureMagnificationFilter.NEAREST
+        }));
+
+        return atlas;
+    }
 
     it('initialize suite', function() {
         greenImage = new Image();
@@ -1053,9 +1059,5 @@ defineSuite([
         expect(function() {
             billboards.get();
         }).toThrow();
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Scene/Camera2DControllerSpec.js
+++ b/Specs/Scene/Camera2DControllerSpec.js
@@ -22,7 +22,7 @@ defineSuite([
          CesiumMath,
          Transforms) {
     "use strict";
-    /*global document,describe,it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var position;
     var up;

--- a/Specs/Scene/CameraColumbusViewControllerSpec.js
+++ b/Specs/Scene/CameraColumbusViewControllerSpec.js
@@ -10,7 +10,7 @@ defineSuite([
          Cartesian3,
          CesiumMath) {
     "use strict";
-    /*global document,describe,it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var controller;
     var camera;

--- a/Specs/Scene/CameraControllerCollectionSpec.js
+++ b/Specs/Scene/CameraControllerCollectionSpec.js
@@ -14,7 +14,7 @@ defineSuite([
          Ellipsoid,
          MercatorProjection) {
     "use strict";
-    /*global document,describe,it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var camera;
     var collection;

--- a/Specs/Scene/CameraEventHandlerSpec.js
+++ b/Specs/Scene/CameraEventHandlerSpec.js
@@ -8,7 +8,7 @@ defineSuite([
          CameraEventType,
          MouseEventType) {
     "use strict";
-    /*global document,describe,it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var handler;
     var handler2;

--- a/Specs/Scene/CameraFreeLookControllerSpec.js
+++ b/Specs/Scene/CameraFreeLookControllerSpec.js
@@ -12,7 +12,7 @@ defineSuite([
          Camera,
          PerspectiveFrustum) {
     "use strict";
-    /*global it,expect,document,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var position;
     var up;

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -32,7 +32,7 @@ defineSuite([
          OrthographicFrustum,
          PerspectiveFrustum) {
     "use strict";
-    /*global describe,it,expect,document,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var camera;
     var canvas = {

--- a/Specs/Scene/CameraSpindleControllerSpec.js
+++ b/Specs/Scene/CameraSpindleControllerSpec.js
@@ -20,7 +20,7 @@ defineSuite([
          Camera,
          PerspectiveFrustum) {
     "use strict";
-    /*global it,expect,document,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var position;
     var up;

--- a/Specs/Scene/CompositePrimitiveSpec.js
+++ b/Specs/Scene/CompositePrimitiveSpec.js
@@ -32,16 +32,22 @@ defineSuite([
          VerticalOrigin,
          Polygon) {
     "use strict";
-    /*global describe,it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
     var primitives;
     var us;
     var camera;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
 
+    afterAll(function() {
+        destroyContext(context);
+    });
+
+    beforeEach(function() {
         primitives = new CompositePrimitive();
 
         camera = new Camera(context.getCanvas());
@@ -634,9 +640,5 @@ defineSuite([
         expect(function() {
             primitives.sendToBack(p);
         }).toThrow();
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Scene/LabelCollectionSpec.js
+++ b/Specs/Scene/LabelCollectionSpec.js
@@ -28,7 +28,7 @@ defineSuite([
          VerticalOrigin,
          LabelStyle) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     // TODO: rendering tests for pixel offset, eye offset, horizontal origin, vertical origin, font, style, outlineColor and fillColor properties
 
@@ -36,9 +36,15 @@ defineSuite([
     var labels;
     var us;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
 
+    afterAll(function() {
+        destroyContext(context);
+    });
+
+    beforeEach(function() {
         labels = new LabelCollection();
 
         var camera = {
@@ -1154,9 +1160,5 @@ defineSuite([
         expect(dimension.width).toBeLessThan(width);
         expect(dimension.height).toBeLessThan(height);
         expect(dimension.descent).toEqual(descent);
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Scene/OrthographicFrustumSpec.js
+++ b/Specs/Scene/OrthographicFrustumSpec.js
@@ -12,7 +12,7 @@ defineSuite([
          Matrix4,
          CesiumMath) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var frustum, planes;
 

--- a/Specs/Scene/PerspectiveFrustumSpec.js
+++ b/Specs/Scene/PerspectiveFrustumSpec.js
@@ -12,7 +12,7 @@ defineSuite([
          Matrix4,
          CesiumMath) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var frustum, planes;
 

--- a/Specs/Scene/PolygonSpec.js
+++ b/Specs/Scene/PolygonSpec.js
@@ -26,31 +26,21 @@ defineSuite([
          CesiumMath,
          BufferUsage) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
     var polygon;
     var us;
 
-    function createPolygon() {
-        var ellipsoid = Ellipsoid.UNIT_SPHERE;
+    beforeAll(function() {
+        context = createContext();
+    });
 
-        var p = new Polygon();
-        p.ellipsoid = ellipsoid;
-        p.granularity = CesiumMath.toRadians(20.0);
-        p.setPositions([
-            ellipsoid.cartographicToCartesian(Cartographic.fromDegrees(-50.0, -50.0, 0.0)),
-            ellipsoid.cartographicToCartesian(Cartographic.fromDegrees(50.0, -50.0, 0.0)),
-            ellipsoid.cartographicToCartesian(Cartographic.fromDegrees(50.0, 50.0, 0.0)),
-            ellipsoid.cartographicToCartesian(Cartographic.fromDegrees(-50.0, 50.0, 0.0))
-        ]);
-
-        return p;
-    }
+    afterAll(function() {
+        destroyContext(context);
+    });
 
     beforeEach(function() {
-        context = context || createContext();
-
         polygon = new Polygon();
 
         var camera = {
@@ -68,6 +58,22 @@ defineSuite([
         polygon = polygon && polygon.destroy();
         us = undefined;
     });
+
+    function createPolygon() {
+        var ellipsoid = Ellipsoid.UNIT_SPHERE;
+
+        var p = new Polygon();
+        p.ellipsoid = ellipsoid;
+        p.granularity = CesiumMath.toRadians(20.0);
+        p.setPositions([
+            ellipsoid.cartographicToCartesian(Cartographic.fromDegrees(-50.0, -50.0, 0.0)),
+            ellipsoid.cartographicToCartesian(Cartographic.fromDegrees(50.0, -50.0, 0.0)),
+            ellipsoid.cartographicToCartesian(Cartographic.fromDegrees(50.0, 50.0, 0.0)),
+            ellipsoid.cartographicToCartesian(Cartographic.fromDegrees(-50.0, 50.0, 0.0))
+        ]);
+
+        return p;
+    }
 
     it('gets default show', function() {
         expect(polygon.show).toEqual(true);
@@ -226,9 +232,5 @@ defineSuite([
 
         var pickedObject = pick(context, polygon, 0, 0);
         expect(pickedObject).not.toBeDefined();
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Scene/PolylineSpec.js
+++ b/Specs/Scene/PolylineSpec.js
@@ -20,15 +20,21 @@ defineSuite([
          CesiumMath,
          BufferUsage) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var context;
     var polyline;
     var us;
 
-    beforeEach(function() {
-        context = context || createContext();
+    beforeAll(function() {
+        context = createContext();
+    });
 
+    afterAll(function() {
+        destroyContext(context);
+    });
+
+    beforeEach(function() {
         polyline = new Polyline();
 
         var camera = {
@@ -166,9 +172,5 @@ defineSuite([
         expect(polyline.isDestroyed()).toEqual(false);
         polyline.destroy();
         expect(polyline.isDestroyed()).toEqual(true);
-    });
-
-    it('destroy context', function() {
-        destroyContext(context);
     });
 });

--- a/Specs/Scene/SceneSpec.js
+++ b/Specs/Scene/SceneSpec.js
@@ -22,12 +22,16 @@ defineSuite([
          createScene,
          destroyScene) {
     "use strict";
-    /*global it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var scene;
 
-    beforeEach(function() {
-        scene = scene || createScene();
+    beforeAll(function() {
+        scene = createScene();
+    });
+
+    afterAll(function() {
+        destroyScene(scene);
     });
 
     it('get canvas', function() {
@@ -134,9 +138,5 @@ defineSuite([
         expect(s.isDestroyed()).toEqual(false);
         destroyScene(s);
         expect(s.isDestroyed()).toEqual(true);
-    });
-
-    it('destroy scene', function() {
-        destroyScene(scene);
     });
 });

--- a/Specs/Scene/Texture2DPoolSpec.js
+++ b/Specs/Scene/Texture2DPoolSpec.js
@@ -6,7 +6,7 @@ defineSuite([
          Texture2DPool,
          destroyObject) {
     "use strict";
-    /*global jasmine,it,expect,beforeEach,afterEach*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var fakeContext;
     var pool;

--- a/Specs/Scene/TileSpec.js
+++ b/Specs/Scene/TileSpec.js
@@ -8,7 +8,7 @@ defineSuite([
          Extent,
          CesiumMath) {
     "use strict";
-    /*global document,it,expect*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
 
     it('throws without a description', function() {

--- a/Specs/SpecRunner.js
+++ b/Specs/SpecRunner.js
@@ -7,9 +7,119 @@
  */
 var defineSuite;
 
+/**
+ * Registers a function that is called before running all tests.
+ *
+ * @param {Function} beforeAllFunction The function to run before all tests.
+ */
+var beforeAll;
+
+/**
+ * Registers a function that is called after running all tests.
+ *
+ * @param {Function} afterAllFunction The function to run after all tests.
+ */
+var afterAll;
+
 (function() {
     "use strict";
     /*global require,describe,specs,jasmine*/
+
+    // patch in beforeAll/afterAll functions
+    // based on existing beforeEach/afterEach
+
+    jasmine.Env.prototype.beforeAll = function(beforeAllFunction) {
+        if (this.currentSuite) {
+            this.currentSuite.beforeAll(beforeAllFunction);
+        } else {
+            this.currentRunner_.beforeAll(beforeAllFunction);
+        }
+    };
+
+    jasmine.Env.prototype.afterAll = function(afterAllFunction) {
+        if (this.currentSuite) {
+            this.currentSuite.afterAll(afterAllFunction);
+        } else {
+            this.currentRunner_.afterAll(afterAllFunction);
+        }
+    };
+
+    jasmine.Runner.prototype.beforeAll = function(beforeAllFunction) {
+        beforeAllFunction.typeName = 'beforeAll';
+        if (typeof this.beforeAll_ === 'undefined') {
+            this.beforeAll_ = [];
+        }
+        this.beforeAll_.splice(0, 0, beforeAllFunction);
+    };
+
+    jasmine.Runner.prototype.afterAll = function(afterAllFunction) {
+        afterAllFunction.typeName = 'afterAll';
+        if (typeof this.afterAll_ === 'undefined') {
+            this.afterAll_ = [];
+        }
+        this.afterAll_.splice(0, 0, afterAllFunction);
+    };
+
+    jasmine.Suite.prototype.beforeAll = function(beforeAllFunction) {
+        beforeAllFunction.typeName = 'beforeAll';
+        if (typeof this.beforeAll_ === 'undefined') {
+            this.beforeAll_ = [];
+        }
+        this.beforeAll_.unshift(beforeAllFunction);
+    };
+
+    jasmine.Suite.prototype.afterAll = function(afterAllFunction) {
+        afterAllFunction.typeName = 'afterAll';
+        if (typeof this.afterAll_ === 'undefined') {
+            this.afterAll_ = [];
+        }
+        this.afterAll_.unshift(afterAllFunction);
+    };
+
+    var originalAddBeforesAndAftersToQueue = jasmine.Spec.prototype.addBeforesAndAftersToQueue;
+    jasmine.Spec.prototype.addBeforesAndAftersToQueue = function() {
+        originalAddBeforesAndAftersToQueue.apply(this);
+
+        var runner = this.env.currentRunner();
+        var i;
+
+        var suite = this.suite;
+        if (suite.queue.index === 0) {
+            if (typeof suite.beforeAll_ !== 'undefined') {
+                for (i = 0; i < suite.beforeAll_.length; i++) {
+                    this.queue.addBefore(new jasmine.Block(this.env, suite.beforeAll_[i], this));
+                }
+            }
+
+            if (typeof runner.beforeAll_ !== 'undefined' && runner.queue.index === 0) {
+                for (i = 0; i < runner.beforeAll_.length; i++) {
+                    this.queue.addBefore(new jasmine.Block(this.env, runner.beforeAll_[i], this));
+                }
+            }
+        }
+
+        if (suite.queue.index === suite.queue.blocks.length - 1) {
+            if (typeof suite.afterAll_ !== 'undefined') {
+                for (i = 0; i < suite.afterAll_.length; i++) {
+                    this.queue.add(new jasmine.Block(this.env, suite.afterAll_[i], this));
+                }
+            }
+
+            if (typeof runner.beforeAll_ !== 'undefined' && runner.queue.index === runner.queue.blocks.length - 1) {
+                for (i = 0; i < runner.afterAll_.length; i++) {
+                    this.queue.add(new jasmine.Block(this.env, runner.afterAll_[i], this));
+                }
+            }
+        }
+    };
+
+    beforeAll = function(beforeAllFunction) {
+        jasmine.getEnv().beforeAll(beforeAllFunction);
+    };
+
+    afterAll = function(afterAllFunction) {
+        jasmine.getEnv().afterAll(afterAllFunction);
+    };
 
     var tests = [];
     var readyToCreateTests = false;

--- a/Specs/ThirdParty/whenSpec.js
+++ b/Specs/ThirdParty/whenSpec.js
@@ -1,7 +1,7 @@
 /*global defineSuite */
 defineSuite(['ThirdParty/when'], function(when) {
     "use strict";
-    /*global it,expect,beforeEach,describe*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     // These tests are from my original attempt to write my own promise implementation.
     // When I switched to cujojs/when, I figured I may as well leave these here since


### PR DESCRIPTION
This moves context and scene creation from per-spec to per-suite to improve the performance and stability of our tests.

When running all tests, Firefox went from ~95 to ~30 seconds.  Chrome went from ~230 to ~28 with improved stability.  These numbers are on my laptop with an NVIDIA card and ANGLE on.

The trade-off is individual specs are not as well isolated; however, suites still are.  So the execution of one spec can - and did in several cases - affect the execution of another spec in the same suite.  Considering that this is an op-in trade-off, and the dramatic performance improvement, this is something I can live with.

The bottleneck is now compiling and linking shaders - taking ~56% of the total time.  We can improve this with a similar strategy if needed.

We should also consider adding `beforeAll`/`afterAll`to Jasmine (CC @shunter @kristiancalhoun).  This is something I've thought about for over a year, but now we could really use it.  It would avoid having to hackup `beforeEach` like I've done, and also avoid hacked specs for destroying resources.
