### PR TITLE
Fix max orthographic frustum computations in Camera2DController.

### DIFF
--- a/Source/Scene/Camera2DController.js
+++ b/Source/Scene/Camera2DController.js
@@ -106,13 +106,15 @@ define([
         this._zoomAnimation = undefined;
         this._translateAnimation = undefined;
 
-        var maxZoomOut = 2.0;
-        this._frustum.right *= maxZoomOut;
-        this._frustum.left *= maxZoomOut;
-        this._frustum.top *= maxZoomOut;
-        this._frustum.bottom *= maxZoomOut;
-
+        this._frustum = this._camera.frustum.clone();
         this._maxCoord = projection.project(new Cartographic(Math.PI, CesiumMath.PI_OVER_TWO, 0.0));
+
+        var maxZoomOut = 2.0;
+        var ratio = this._frustum.top / this._frustum.right;
+        this._frustum.right = this._maxCoord.x * maxZoomOut;
+        this._frustum.left = -this._frustum.right;
+        this._frustum.top = ratio * this._frustum.right;
+        this._frustum.bottom = -this._frustum.top;
 
         this._maxZoomFactor = 2.5;
         this._maxTranslateFactor = 1.5;


### PR DESCRIPTION
If the `Camera2DController` was added after a `scene.viewExtent`, the camera can get stuck there. For example:

``` javascript
var transitioner = new Cesium.SceneTransitioner(scene, ellipsoid);

var west = Cesium.Math.toRadians(-77.0);
var south = Cesium.Math.toRadians(38.0);
var east = Cesium.Math.toRadians(-72.0);
var north = Cesium.Math.toRadians(42.0);

var extent = new Cesium.Extent(west, south, east, north);
transitioner.to2D();
scene.getCamera().getControllers().removeAll();
scene.viewExtent(extent, ellipsoid);
scene.getCamera().getControllers().add2D(scene.scene2D.projection);
```

Fixed by computing the max frustum, instead of using the current frustum.
