### PR TITLE
Fix issue #148

### DIFF
--- a/Source/Core/Cartesian3.js
+++ b/Source/Core/Cartesian3.js
@@ -446,7 +446,9 @@ define(['./DeveloperError'
         }
         Cartesian3.normalize(left, angleBetweenScratch);
         Cartesian3.normalize(right, angleBetweenScratch2);
-        return Math.acos(Cartesian3.dot(angleBetweenScratch, angleBetweenScratch2));
+        var cosine = Cartesian3.dot(angleBetweenScratch, angleBetweenScratch2);
+        var sine = Cartesian3.cross(angleBetweenScratch, angleBetweenScratch2, angleBetweenScratch).magnitude();
+        return Math.atan2(sine, cosine);
     };
 
     /**

--- a/Source/Scene/CustomSensorVolume.js
+++ b/Source/Scene/CustomSensorVolume.js
@@ -209,12 +209,20 @@ define([
         var positions = new Float32Array(3 * length);
         var r = isFinite(radius) ? radius : FAR;
 
-        for (var inputIndex = 0, outputIndex = 0; inputIndex < length; ++inputIndex) {
-            var direction = Cartesian3.fromSpherical(directions[inputIndex]);
-            var p = direction.multiplyByScalar(r);
-            positions[outputIndex++] = p.x;
-            positions[outputIndex++] = p.y;
-            positions[outputIndex++] = p.z;
+        for ( var i = length - 2, j = length - 1, k = 0; k < length; i = j++, j = k++) {
+            // PERFORMANCE_IDEA:  We can avoid redundant operations for adjacent edges.
+            var n0 = Cartesian3.fromSpherical(directions[i]);
+            var n1 = Cartesian3.fromSpherical(directions[j]);
+            var n2 = Cartesian3.fromSpherical(directions[k]);
+
+            // Extend position so the volume encompasses the sensor's radius.
+            var theta = Math.max(Cartesian3.angleBetween(n0, n1), Cartesian3.angleBetween(n1, n2));
+            var distance = r / Math.cos(theta * 0.5);
+            var p = n1.multiplyByScalar(distance);
+
+            positions[(j * 3) + 0] = p.x;
+            positions[(j * 3) + 1] = p.y;
+            positions[(j * 3) + 2] = p.z;
         }
 
         return positions;


### PR DESCRIPTION
CustomSensorVolume._computePositions uses a strange algorithm for
computing the vertex positions that I can't quite explain, and that
algorithm generates NaNs when two directions are close together.  The NaN
vertex positions result in missing chunks of the sensor.

The algorithm is apparently trying to compute an appropriate distance
for the sensor vertex positions.  But that shouldn't be tricky - all
vertices at the radial limit are at the same distance, namely, the radial
limit.  So after this change, each direction is simply multiplied by the
radius and that's our vertex position.  It fixes issue #148 and doesn't
have any apparent bad side effects.

But I could easily be missing some subtlety, so @pjcozzi should take a look.
