### PR TITLE
Add affectedByLighting properties to sensors.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,8 @@ Beta Releases
 * Added support for CZML path visualization via the `DynamicPath` and `DynamicPathVisualizer` objects.  See the [CZML wiki](https://github.com/AnalyticalGraphicsInc/cesium/wiki/CZML-Guide) for more details.
 * Added support for [WEBGL_depth_texture](http://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/).  See `Framebuffer.setDepthTexture`.
 * Added `CesiumMath.isPowerOfTwo`.
+* Added `affectedByLighting` to `ComplexConicSensorVolume`, `CustomSensorVolume`, and `RectangularPyramidSensorVolume` to turn lighting on/off for these objects.
+* CZML `Polygon`, `Cone`, and `Pyramid` objects are no longer affected by lighting.
 
 ### b7 - 08/01/2012
 

--- a/Source/DynamicScene/DynamicConeVisualizer.js
+++ b/Source/DynamicScene/DynamicConeVisualizer.js
@@ -221,6 +221,7 @@ define([
             } else {
                 coneVisualizerIndex = this._coneCollection.length;
                 cone = new ComplexConicSensorVolume();
+                cone.affectedByLighting = false;
                 this._coneCollection.push(cone);
                 this._primitives.add(cone);
             }

--- a/Source/DynamicScene/DynamicConeVisualizerUsingCustomSensor.js
+++ b/Source/DynamicScene/DynamicConeVisualizerUsingCustomSensor.js
@@ -269,6 +269,7 @@ define([
             } else {
                 coneVisualizerIndex = this._coneCollection.length;
                 cone = new CustomSensorVolume();
+                cone.affectedByLighting = false;
                 this._coneCollection.push(cone);
                 this._primitives.add(cone);
             }

--- a/Source/DynamicScene/DynamicPyramid.js
+++ b/Source/DynamicScene/DynamicPyramid.js
@@ -55,7 +55,6 @@ define([
          * @type DynamicProperty
          */
         this.showIntersection = undefined;
-        this.showIntersection = undefined;
         /**
          * A DynamicProperty of type CzmlColor which determines the color of the line formed by the intersection of the cone and other central bodies.
          * @type DynamicProperty

--- a/Source/DynamicScene/DynamicPyramidVisualizer.js
+++ b/Source/DynamicScene/DynamicPyramidVisualizer.js
@@ -223,6 +223,8 @@ define([
             } else {
                 pyramidVisualizerIndex = this._pyramidCollection.length;
                 pyramid = new CustomSensorVolume();
+                pyramid.affectedByLighting = false;
+
                 this._pyramidCollection.push(pyramid);
                 this._primitives.add(pyramid);
             }

--- a/Source/Scene/ComplexConicSensorVolume.js
+++ b/Source/Scene/ComplexConicSensorVolume.js
@@ -203,6 +203,19 @@ define([
         this.intersectionColor = (typeof t.intersectionColor !== 'undefined') ? Color.clone(t.intersectionColor) : new Color(1.0, 1.0, 0.0, 1.0);
 
         /**
+         * <p>
+         * Determines if the sensor is affected by lighting, i.e., if the sensor is bright on the
+         * day side of the globe, and dark on the night side.  When <code>true</code>, the sensor
+         * is affected by lighting; when <code>false</code>, the sensor is uniformly shaded regardless
+         * of the sun position.
+         * </p>
+         * <p>
+         * The default is <code>true</code>.
+         * </p>
+         */
+        this.affectedByLighting = this._affectedByLighting = (typeof t.affectedByLighting !== 'undefined') ? t.affectedByLighting : true;
+
+        /**
          * DOC_TBA
          *
          * @type Number
@@ -397,12 +410,14 @@ define([
         if ((!this._outerMaterial || (this._outerMaterial !== this.outerMaterial)) ||
             (!this._innerMaterial || (this._innerMaterial !== this.innerMaterial)) ||
             (!this._capMaterial || (this._capMaterial !== this.capMaterial)) ||
-            (!this._silhouetteMaterial || (this._silhouetteMaterial !== this.silhouetteMaterial))) {
+            (!this._silhouetteMaterial || (this._silhouetteMaterial !== this.silhouetteMaterial)) ||
+            this._affectedByLighting !== this.affectedByLighting) {
 
             this._outerMaterial = (typeof this.outerMaterial !== 'undefined') ? this.outerMaterial : Material.fromType(context, Material.ColorType);
             this._innerMaterial = (typeof this.innerMaterial !== 'undefined') ? this.innerMaterial : Material.fromType(context, Material.ColorType);
             this._capMaterial = (typeof this.capMaterial !== 'undefined') ? this.capMaterial : Material.fromType(context, Material.ColorType);
             this._silhouetteMaterial = (typeof this.silhouetteMaterial !== 'undefined') ? this.silhouetteMaterial : Material.fromType(context, Material.ColorType);
+            this._affectedByLighting = this.affectedByLighting;
 
             var material = this._combineMaterials();
             this._drawUniforms = combine([this._uniforms, material._uniforms], false, false);
@@ -418,6 +433,7 @@ define([
                 ShadersSensorVolume +
                 '#line 0\n' +
                 material.shaderSource +
+                (this._affectedByLighting ? '#define AFFECTED_BY_LIGHTING 1\n' : '') +
                 '#line 0\n' +
                 ComplexConicSensorVolumeFS;
 

--- a/Source/Scene/CustomSensorVolume.js
+++ b/Source/Scene/CustomSensorVolume.js
@@ -122,6 +122,19 @@ define([
         this.modelMatrix = t.modelMatrix || Matrix4.IDENTITY.clone();
 
         /**
+         * <p>
+         * Determines if the sensor is affected by lighting, i.e., if the sensor is bright on the
+         * day side of the globe, and dark on the night side.  When <code>true</code>, the sensor
+         * is affected by lighting; when <code>false</code>, the sensor is uniformly shaded regardless
+         * of the sun position.
+         * </p>
+         * <p>
+         * The default is <code>true</code>.
+         * </p>
+         */
+        this.affectedByLighting = this._affectedByLighting = (typeof t.affectedByLighting !== 'undefined') ? t.affectedByLighting : true;
+
+        /**
          * DOC_TBA
          *
          * @type BufferUsage
@@ -340,11 +353,13 @@ define([
         this._rs.depthTest.enabled = !this.showThroughEllipsoid;
 
         // Recompile shader when material changes
-        if (!this._material || (this._material !== this.material)) {
-
+        if (typeof this._material === 'undefined' ||
+            this._material !== this.material ||
+            this._affectedByLighting !== this.affectedByLighting) {
 
             this.material = (typeof this.material !== 'undefined') ? this.material : Material.fromType(context, Material.ColorType);
             this._material = this.material;
+            this._affectedByLighting = this.affectedByLighting;
 
             var fsSource =
                 '#line 0\n' +
@@ -353,6 +368,7 @@ define([
                 ShadersSensorVolume +
                 '#line 0\n' +
                 this._material.shaderSource +
+                (this._affectedByLighting ? '#define AFFECTED_BY_LIGHTING 1\n' : '') +
                 '#line 0\n' +
                 CustomSensorVolumeFS;
 

--- a/Source/Scene/RectangularPyramidSensorVolume.js
+++ b/Source/Scene/RectangularPyramidSensorVolume.js
@@ -116,6 +116,19 @@ define([
         this._yHalfAngle = undefined;
 
         /**
+         * <p>
+         * Determines if the sensor is affected by lighting, i.e., if the sensor is bright on the
+         * day side of the globe, and dark on the night side.  When <code>true</code>, the sensor
+         * is affected by lighting; when <code>false</code>, the sensor is uniformly shaded regardless
+         * of the sun position.
+         * </p>
+         * <p>
+         * The default is <code>true</code>.
+         * </p>
+         */
+        this.affectedByLighting = this._affectedByLighting = (typeof t.affectedByLighting !== 'undefined') ? t.affectedByLighting : true;
+
+        /**
          * DOC_TBA
          */
         this.material = (typeof t.material !== 'undefined') ? t.material : Material.fromType(undefined, Material.ColorType);
@@ -160,6 +173,7 @@ define([
         s.material = this.material;
         s.intersectionColor = this.intersectionColor;
         s.erosion = this.erosion;
+        s.affectedByLighting = this.affectedByLighting;
 
         if ((this._xHalfAngle !== this.xHalfAngle) || (this._yHalfAngle !== this.yHalfAngle)) {
 

--- a/Source/Shaders/ComplexConicSensorVolumeFS.glsl
+++ b/Source/Shaders/ComplexConicSensorVolumeFS.glsl
@@ -41,7 +41,15 @@ vec4 getOuterColor(float sensorRadius, vec3 pointEC, vec3 normalEC)
     
     //Final
     vec3 positionToEyeEC = normalize(-v_positionEC);
-    return czm_lightValuePhong(czm_sunDirectionEC, positionToEyeEC, material);
+    
+    vec4 color; 
+    #ifdef AFFECTED_BY_LIGHTING    
+    color = czm_lightValuePhong(czm_sunDirectionEC, positionToEyeEC, material);
+    #else
+    color = vec4(material.diffuse, material.alpha);
+    #endif
+    
+    return color;        
 }
 
 vec4 getInnerColor(float sensorRadius, vec3 pointEC, vec3 normalEC)
@@ -53,7 +61,15 @@ vec4 getInnerColor(float sensorRadius, vec3 pointEC, vec3 normalEC)
     
     //Final
     vec3 positionToEyeEC = normalize(-v_positionEC);
-    return czm_lightValuePhong(czm_sunDirectionEC, positionToEyeEC, material);
+
+    vec4 color; 
+    #ifdef AFFECTED_BY_LIGHTING    
+    color = czm_lightValuePhong(czm_sunDirectionEC, positionToEyeEC, material);
+    #else
+    color = vec4(material.diffuse, material.alpha);
+    #endif
+    
+    return color;        
 }
 
 vec4 getCapColor(float sensorRadius, vec3 pointEC, vec3 normalEC)
@@ -65,7 +81,15 @@ vec4 getCapColor(float sensorRadius, vec3 pointEC, vec3 normalEC)
     
     //Final
     vec3 positionToEyeEC = normalize(-v_positionEC);
-    return czm_lightValuePhong(czm_sunDirectionEC, positionToEyeEC, material);
+
+    vec4 color; 
+    #ifdef AFFECTED_BY_LIGHTING    
+    color = czm_lightValuePhong(czm_sunDirectionEC, positionToEyeEC, material);
+    #else
+    color = vec4(material.diffuse, material.alpha);
+    #endif
+    
+    return color;        
 }
 
 vec4 getSilhouetteColor(float sensorRadius, vec3 pointEC, vec3 normalEC)
@@ -77,7 +101,15 @@ vec4 getSilhouetteColor(float sensorRadius, vec3 pointEC, vec3 normalEC)
     
     //Final
     vec3 positionToEyeEC = normalize(-v_positionEC);
-    return czm_lightValuePhong(czm_sunDirectionEC, positionToEyeEC, material);
+
+    vec4 color; 
+    #ifdef AFFECTED_BY_LIGHTING    
+    color = czm_lightValuePhong(czm_sunDirectionEC, positionToEyeEC, material);
+    #else
+    color = vec4(material.diffuse, material.alpha);
+    #endif
+    
+    return color;        
 }
 
 #endif

--- a/Source/Shaders/CustomSensorVolumeFS.glsl
+++ b/Source/Shaders/CustomSensorVolumeFS.glsl
@@ -35,7 +35,15 @@ vec4 getColor(float sensorRadius, vec3 pointEC)
     materialInput.normalEC = normalEC;
     
     czm_material material = czm_getMaterial(materialInput);
-    return czm_lightValuePhong(czm_sunDirectionEC, positionToEyeEC, material);
+    
+    vec4 color; 
+    #ifdef AFFECTED_BY_LIGHTING    
+    color = czm_lightValuePhong(czm_sunDirectionEC, positionToEyeEC, material);
+    #else
+    color = vec4(material.diffuse, material.alpha);
+    #endif
+    
+    return color;        
 }
 
 #endif


### PR DESCRIPTION
1. Add `affectedByLighting` to `ComplexConicSensorVolume`, `CustomSensorVolume`, and `RectangularPyramidSensorVolume`.
2. Updated CZML processing to turn off lighting for these objects by default (ability to turn it back on via CZML will come later if we need it).
3. Update CHANGES.
4. No new tests because we don't have any sensor tests yet.
