### PR TITLE
PolylineCollection and Polygon culling.

### DIFF
--- a/Source/Scene/Polygon.js
+++ b/Source/Scene/Polygon.js
@@ -633,6 +633,10 @@ define([
             this._vertices.update(context, this._createMeshes(), this.bufferUsage);
         }
 
+        if (typeof this._vertices.getVertexArrays() === 'undefined') {
+            return undefined;
+        }
+
         if (!this._rs) {
             // TODO: Should not need this in 2D/columbus view, but is hiding a triangulation issue.
             this._rs = context.createRenderState({
@@ -697,10 +701,6 @@ define([
      */
     Polygon.prototype.render = function(context) {
         var vas = this._vertices.getVertexArrays();
-        if (typeof vas === 'undefined') {
-            return;
-        }
-
         var length = vas.length;
         for ( var j = 0; j < length; ++j) {
             context.draw({
@@ -759,10 +759,6 @@ define([
      */
     Polygon.prototype.renderForPick = function(context, framebuffer) {
         var vas = this._vertices.getVertexArrays();
-        if (typeof vas === 'undefined') {
-            return;
-        }
-
         var length = vas.length;
         for ( var j = 0; j < length; ++j) {
             context.draw({

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -1135,11 +1135,6 @@ define([
     };
 
     function intersectsIDL(polyline) {
-        if (typeof polyline._boundingVolume === 'undefined') {
-            // This can only happen when the polyline has no positions, so its not intersecting.
-            return false;
-        }
-
         return Cartesian3.dot(Cartesian3.UNIT_X, polyline._boundingVolume.center) < 0 ||
             polyline._boundingVolume.intersect(Cartesian4.UNIT_Y) === Intersect.INTERSECTING;
     }

--- a/Specs/Scene/PolygonSpec.js
+++ b/Specs/Scene/PolygonSpec.js
@@ -286,7 +286,7 @@ defineSuite([
         expect(context.readPixels()).not.toEqual([0, 0, 0, 0]);
     });
 
-    it('does not renders', function() {
+    it('does not render', function() {
         polygon = createPolygon();
         polygon.material.uniforms.color = {
             red : 1.0,
@@ -296,12 +296,14 @@ defineSuite([
         };
         polygon.show = false;
 
-        context.clear();
-        expect(context.readPixels()).toEqual([0, 0, 0, 0]);
+        expect(typeof polygon.update(context, sceneState) === 'undefined').toEqual(true);
+    });
 
-        polygon.update(context, sceneState);
-        polygon.render(context, us);
-        expect(context.readPixels()).toEqual([0, 0, 0, 0]);
+    it('does not render without positions', function() {
+        polygon = new Polygon();
+        polygon.ellipsoid = Ellipsoid.UNIT_SPHERE;
+        polygon.granularity = CesiumMath.toRadians(20.0);
+        expect(typeof polygon.update(context, sceneState) === 'undefined').toEqual(true);
     });
 
     it('is picked', function() {
@@ -317,10 +319,7 @@ defineSuite([
         polygon = createPolygon();
         polygon.show = false;
 
-        polygon.update(context, sceneState);
-
-        var pickedObject = pick(context, polygon, 0, 0);
-        expect(pickedObject).not.toBeDefined();
+        expect(typeof polygon.update(context, sceneState) === 'undefined').toEqual(true);
     });
 
     it('test 3D bounding sphere from positions', function() {


### PR DESCRIPTION
Remove unneeded code that checks for undefined array of array of length zero before constructing a bounding volume. Remove test for undefined vertex array in polygon render functions. Add tests.
