### PR TITLE
Can't use CesiumViewer when not connected to the network

### DIFF
--- a/Source/Widgets/Dojo/checkForChromeFrame.js
+++ b/Source/Widgets/Dojo/checkForChromeFrame.js
@@ -1,9 +1,11 @@
 /*global define*/
 define([
         'dojo/dom-construct',
+        'dojo/io/script',
         'dijit/Dialog'
        ], function(
          domConstruct,
+         script,
          Dialog) {
     "use strict";
     /*global require,CFInstall*/
@@ -53,7 +55,10 @@ define([
     }
 
     return function() {
-        require(['http://ajax.googleapis.com/ajax/libs/chrome-frame/1/CFInstall.min.js'], function() {
+        script.get({
+            url : 'http://ajax.googleapis.com/ajax/libs/chrome-frame/1/CFInstall.min.js',
+            checkString : 'CFInstall'
+        }).then(function() {
             CFInstall.check({
                 mode : 'overlay',
                 preventPrompt : true,


### PR DESCRIPTION
in source->widgets->dojo->checkforChromeFrame, there's a require for http://ajax.googleapis.com/ajax/libs/chrome-frame/1/CFInstall.min.js. If you're aren't connected to the network, this fails and stops everything else from loading up. We should fail gracefully here and if chrome frame isn't needed, continue loading up Cesium.
