### PR TITLE
Some sensor doc

### DIFF
--- a/Source/Renderer/PixelFormat.js
+++ b/Source/Renderer/PixelFormat.js
@@ -17,7 +17,7 @@ define(['../Core/Enumeration'], function(Enumeration) {
         DEPTH_COMPONENT : new Enumeration(0x1902, 'DEPTH_COMPONENT'),
 
         /**
-         * A pixel format containing a depth and stencil value, most often used with {@see PixelDatatype.UNSIGNED_INT_24_8_WEBGL}.
+         * A pixel format containing a depth and stencil value, most often used with {@link PixelDatatype.UNSIGNED_INT_24_8_WEBGL}.
          *
          * @constant
          * @type {Enumeration}

--- a/Source/Scene/ComplexConicSensorVolume.js
+++ b/Source/Scene/ComplexConicSensorVolume.js
@@ -83,9 +83,11 @@ define([
         this.show = (typeof t.show === 'undefined') ? true : t.show;
 
         /**
-         * DOC_TBA
+         * When <code>true</code>, a polyline is shown where the sensor outline intersections the central body.  The default is <code>true</code>.
          *
          * @type Boolean
+         *
+         * @see ComplexConicSensorVolume#intersectionColor
          */
         this.showIntersection = (typeof t.showIntersection === 'undefined') ? true : t.showIntersection;
 
@@ -198,9 +200,13 @@ define([
         this._silhouetteMaterial = undefined;
 
         /**
-         * DOC_TBA
+         * The color of the polyline where the sensor outline intersects the central body.  The default is {@link Color.WHITE}.
+         *
+         * @type Color
+         *
+         * @see ComplexConicSensorVolume#showIntersection
          */
-        this.intersectionColor = (typeof t.intersectionColor !== 'undefined') ? Color.clone(t.intersectionColor) : new Color(1.0, 1.0, 0.0, 1.0);
+        this.intersectionColor = (typeof t.intersectionColor !== 'undefined') ? Color.clone(t.intersectionColor) : Color.clone(Color.WHITE);
 
         /**
          * <p>
@@ -252,8 +258,8 @@ define([
                 return that.erosion;
             }
         };
-        this._drawUniforms = null;
-        this._pickUniforms = null;
+        this._drawUniforms = undefined;
+        this._pickUniforms = undefined;
         this._mode = SceneMode.SCENE3D;
     };
 

--- a/Source/Scene/CustomSensorVolume.js
+++ b/Source/Scene/CustomSensorVolume.js
@@ -77,9 +77,11 @@ define([
         this.show = (typeof t.show === 'undefined') ? true : t.show;
 
         /**
-         * DOC_TBA
+         * When <code>true</code>, a polyline is shown where the sensor outline intersections the central body.  The default is <code>true</code>.
          *
          * @type Boolean
+         *
+         * @see CustomSensorVolume#intersectionColor
          */
         this.showIntersection = (typeof t.showIntersection === 'undefined') ? true : t.showIntersection;
 
@@ -160,9 +162,13 @@ define([
         this._material = undefined;
 
         /**
-         * DOC_TBA
+         * The color of the polyline where the sensor outline intersects the central body.  The default is {@link Color.WHITE}.
+         *
+         * @type Color
+         *
+         * @see CustomSensorVolume#showIntersection
          */
-        this.intersectionColor = (typeof t.intersectionColor !== 'undefined') ? Color.clone(t.intersectionColor) : new Color(1.0, 1.0, 0.0, 1.0);
+        this.intersectionColor = (typeof t.intersectionColor !== 'undefined') ? Color.clone(t.intersectionColor) : Color.clone(Color.WHITE);
 
         /**
          * DOC_TBA
@@ -192,8 +198,8 @@ define([
                 return that.erosion;
             }
         };
-        this._drawUniforms = null;
-        this._pickUniforms = null;
+        this._drawUniforms = undefined;
+        this._pickUniforms = undefined;
 
         this._mode = SceneMode.SCENE3D;
     };

--- a/Source/Scene/RectangularPyramidSensorVolume.js
+++ b/Source/Scene/RectangularPyramidSensorVolume.js
@@ -38,9 +38,11 @@ define([
         this.show = (typeof t.show === 'undefined') ? true : t.show;
 
         /**
-         * DOC_TBA
+         * When <code>true</code>, a polyline is shown where the sensor outline intersections the central body.  The default is <code>true</code>.
          *
          * @type Boolean
+         *
+         * @see RectangularPyramidSensorVolume#intersectionColor
          */
         this.showIntersection = (typeof t.showIntersection === 'undefined') ? true : t.showIntersection;
 
@@ -134,9 +136,13 @@ define([
         this.material = (typeof t.material !== 'undefined') ? t.material : Material.fromType(undefined, Material.ColorType);
 
         /**
-         * DOC_TBA
+         * The color of the polyline where the sensor outline intersects the central body.  The default is {@link Color.WHITE}.
+         *
+         * @type Color
+         *
+         * @see RectangularPyramidSensorVolume#showIntersection
          */
-        this.intersectionColor = (typeof t.intersectionColor !== 'undefined') ? Color.clone(t.intersectionColor) : new Color(1.0, 1.0, 0.0, 1.0);
+        this.intersectionColor = (typeof t.intersectionColor !== 'undefined') ? Color.clone(t.intersectionColor) : Color.clone(Color.WHITE);
 
         /**
          * DOC_TBA


### PR DESCRIPTION
I was going to add a `showBody` property to sensors so we could only draw their intersection with the central body, but then I relized it is easy to do with the default material:

``` javascript
s.material.uniforms.color.alpha = 0.0;
```

so, once again, I provide a consolation prize of some reference doc.
