### PR TITLE
Update Custom Rendering Example

### DIFF
--- a/Apps/Sandcastle/gallery/Custom Rendering.html
+++ b/Apps/Sandcastle/gallery/Custom Rendering.html
@@ -127,6 +127,10 @@ require([
     
     Box.prototype.update = function(context, frameState) {
         // Only supports 3D, not 2D or Columbus view.
+        if (frameState.mode !== Cesium.SceneMode.SCENE3D) {
+            return undefined;
+        }
+        
         if (typeof this._va === 'undefined') {
             var vs = '';
             vs += 'attribute vec4 position;';


### PR DESCRIPTION
Update custom rendering across scene modes sandcastle example to use a bounding sphere in 2D. Fixes issue #213.
