### PR TITLE
Fix CZML availability computation.

### DIFF
--- a/Source/Core/Iso8601.js
+++ b/Source/Core/Iso8601.js
@@ -9,8 +9,8 @@ define([
         TimeInterval) {
     "use strict";
 
-    var MINIMUM_VALUE = freezeObject(JulianDate.fromDate(new Date(Date.UTC(-1, 0, 1, 0, 0, 0))));
-    var MAXIMUM_VALUE = freezeObject(JulianDate.fromDate(new Date(Date.UTC(10000, 0, 1, 0, 0, 0))));
+    var MINIMUM_VALUE = freezeObject(JulianDate.fromIso8601('0000-01-01T00:00:00Z'));
+    var MAXIMUM_VALUE = freezeObject(JulianDate.fromIso8601('9999-12-31T24:00:00Z'));
     var MAXIMUM_INTERVAL = freezeObject(new TimeInterval(MINIMUM_VALUE, MAXIMUM_VALUE, true, true));
 
     /**

--- a/Source/DynamicScene/CompositeDynamicObjectCollection.js
+++ b/Source/DynamicScene/CompositeDynamicObjectCollection.js
@@ -83,17 +83,23 @@ define([
         for (i = 0, len = collections.length; i < len; i++) {
             collection = collections[i];
             var availability = collection.computeAvailability();
-            if (availability.start.lessThan(startTime)) {
+            var start = availability.start;
+            var stop = availability.stop;
+            if (start.lessThan(startTime) && !start.equals(Iso8601.MINIMUM_VALUE)) {
                 startTime = availability.start;
             }
-            if (availability.stop.greaterThan(stopTime)) {
+            if (stop.greaterThan(stopTime) && !stop.equals(Iso8601.MAXIMUM_VALUE)) {
                 stopTime = availability.stop;
             }
         }
-        if (startTime !== Iso8601.MAXIMUM_VALUE && stopTime !== Iso8601.MINIMUM_VALUE) {
-            return new TimeInterval(startTime, stopTime, true, true);
+
+        if (startTime === Iso8601.MAXIMUM_VALUE) {
+            startTime = Iso8601.MINIMUM_VALUE;
         }
-        return new TimeInterval(Iso8601.MINIMUM_VALUE, Iso8601.MAXIMUM_VALUE, true, true);
+        if (stopTime === Iso8601.MINIMUM_VALUE) {
+            stopTime = Iso8601.MAXIMUM_VALUE;
+        }
+        return new TimeInterval(startTime, stopTime, true, true);
     };
 
     /**

--- a/Source/DynamicScene/DynamicObjectCollection.js
+++ b/Source/DynamicScene/DynamicObjectCollection.js
@@ -55,19 +55,26 @@ define([
         var dynamicObjects = this._array;
         for (i = 0, len = dynamicObjects.length; i < len; i++) {
             object = dynamicObjects[i];
-            if (typeof object.availability !== 'undefined') {
-                if (object.availability.start.lessThan(startTime)) {
+            var availability = object.availability;
+            if (typeof availability !== 'undefined') {
+                var start = availability.start;
+                var stop = availability.stop;
+                if (start.lessThan(startTime) && !start.equals(Iso8601.MINIMUM_VALUE)) {
                     startTime = object.availability.start;
                 }
-                if (object.availability.stop.greaterThan(stopTime)) {
+                if (stop.greaterThan(stopTime) && !stop.equals(Iso8601.MAXIMUM_VALUE)) {
                     stopTime = object.availability.stop;
                 }
             }
         }
-        if (startTime !== Iso8601.MAXIMUM_VALUE && stopTime !== Iso8601.MINIMUM_VALUE) {
-            return new TimeInterval(startTime, stopTime, true, true);
+
+        if (startTime === Iso8601.MAXIMUM_VALUE) {
+            startTime = Iso8601.MINIMUM_VALUE;
         }
-        return new TimeInterval(Iso8601.MINIMUM_VALUE, Iso8601.MAXIMUM_VALUE, true, true);
+        if (stopTime === Iso8601.MINIMUM_VALUE) {
+            stopTime = Iso8601.MAXIMUM_VALUE;
+        }
+        return new TimeInterval(startTime, stopTime, true, true);
     };
 
     /**

--- a/Specs/DynamicScene/CompositeDynamicObjectCollectionSpec.js
+++ b/Specs/DynamicScene/CompositeDynamicObjectCollectionSpec.js
@@ -111,6 +111,23 @@ defineSuite([
         expect(availability.stop).toEqual(JulianDate.fromIso8601('2012-08-06'));
     });
 
+    it('computeAvailability works if only start or stop time is infinite.', function() {
+        var collection1 = new DynamicObjectCollection();
+        var dynamicObject = collection1.getOrCreateObject('1');
+        dynamicObject._setAvailability(TimeInterval.fromIso8601('2012-08-01/9999-12-31T24:00:00Z'));
+        dynamicObject = collection1.getOrCreateObject('2');
+
+        var collection2 = new DynamicObjectCollection();
+        dynamicObject = collection2.getOrCreateObject('3');
+        dynamicObject._setAvailability(TimeInterval.fromIso8601('0000-01-01T00:00:00Z/2012-08-06'));
+
+        var compositeDynamicObjectCollection = new CompositeDynamicObjectCollection([collection1, collection2]);
+
+        var availability = compositeDynamicObjectCollection.computeAvailability();
+        expect(availability.start).toEqual(JulianDate.fromIso8601('2012-08-01'));
+        expect(availability.stop).toEqual(JulianDate.fromIso8601('2012-08-06'));
+    });
+
     it('setCollections works with existing dynamicObjectCollections', function() {
         var dynamicObjectCollection1 = new DynamicObjectCollection();
         processCzml(czml1, dynamicObjectCollection1);

--- a/Specs/DynamicScene/DynamicObjectCollectionSpec.js
+++ b/Specs/DynamicScene/DynamicObjectCollectionSpec.js
@@ -79,6 +79,22 @@ defineSuite([
         expect(availability.stop).toEqual(JulianDate.fromIso8601('2012-08-06'));
     });
 
+    it('computeAvailability works if only start or stop time is infinite.', function() {
+        var dynamicObjectCollection = new DynamicObjectCollection();
+
+        var dynamicObject = dynamicObjectCollection.getOrCreateObject('1');
+        dynamicObject._setAvailability(TimeInterval.fromIso8601('2012-08-01/9999-12-31T24:00:00Z'));
+
+        dynamicObject = dynamicObjectCollection.getOrCreateObject('2');
+
+        dynamicObject = dynamicObjectCollection.getOrCreateObject('3');
+        dynamicObject._setAvailability(TimeInterval.fromIso8601('0000-01-01T00:00:00Z/2012-08-06'));
+
+        var availability = dynamicObjectCollection.computeAvailability();
+        expect(availability.start).toEqual(JulianDate.fromIso8601('2012-08-01'));
+        expect(availability.stop).toEqual(JulianDate.fromIso8601('2012-08-06'));
+    });
+
     it('clear removes all objects', function() {
         var dynamicObjectCollection = new DynamicObjectCollection();
         dynamicObjectCollection.getOrCreateObject('1');


### PR DESCRIPTION
Niether `DynamicObjectCollection.computeAvailability` nor `CompositeDynamicObjectCollection.computeAvailability` properly accounted for intervals where only one end was the minimum or maximum IS08601 date.
