### PR TITLE
Material exceptions

### DIFF
--- a/Source/Scene/Billboard.js
+++ b/Source/Scene/Billboard.js
@@ -624,7 +624,7 @@ define([
      *
      * @memberof Billboard
      *
-     * @param {UniformState} uniformState The same state object passed to {@link BillboardCollection#render}.
+     * @param {UniformState} uniformState The same state object passed to {@link BillboardCollection#update}.
      *
      * @return {Cartesian2} The screen-space position of the billboard.
      *
@@ -633,7 +633,6 @@ define([
      *
      * @see Billboard#setEyeOffset
      * @see Billboard#setPixelOffset
-     * @see BillboardCollection#render
      *
      * @example
      * console.log(b.computeScreenSpacePosition(scene.getUniformState()).toString());

--- a/Source/Scene/ComplexConicSensorVolume.js
+++ b/Source/Scene/ComplexConicSensorVolume.js
@@ -381,6 +381,10 @@ define([
      *
      * @exception {DeveloperError} this.innerHalfAngle cannot be greater than this.outerHalfAngle.
      * @exception {DeveloperError} this.radius must be greater than or equal to zero.
+     * @exception {DeveloperError} this.outerMaterial must be defined.
+     * @exception {DeveloperError} this.innerMaterial must be defined.
+     * @exception {DeveloperError} this.capMaterial must be defined.
+     * @exception {DeveloperError} this.silhouetteMaterial must be defined.
      */
     ComplexConicSensorVolume.prototype.update = function(context, frameState, commandList) {
         this._mode = frameState.mode;
@@ -394,6 +398,22 @@ define([
 
         if (this.radius < 0.0) {
             throw new DeveloperError('this.radius must be greater than or equal to zero.');
+        }
+
+        if (typeof this.outerMaterial === 'undefined') {
+            throw new DeveloperError('this.outerMaterial must be defined.');
+        }
+
+        if (typeof this.innerMaterial === 'undefined') {
+            throw new DeveloperError('this.innerMaterial must be defined.');
+        }
+
+        if (typeof this.capMaterial === 'undefined') {
+            throw new DeveloperError('this.capMaterial must be defined.');
+        }
+
+        if (typeof this.silhouetteMaterial === 'undefined') {
+            throw new DeveloperError('this.silhouetteMaterial must be defined.');
         }
 
         // Recreate vertex array when proxy geometry needs to change
@@ -424,18 +444,18 @@ define([
 
         this._commandLists.removeAll();
         if (pass.color) {
-            var outerChanged = typeof this._outerMaterial === 'undefined' || this._outerMaterial !== this.outerMaterial;
-            var innerChanged = typeof this._innerMaterial === 'undefined' || this._innerMaterial !== this.innerMaterial;
-            var capChanged = typeof this._capMaterial === 'undefined' || this._capMaterial !== this.capMaterial;
-            var silhouetteChanged = typeof this._silhouetteMaterial === 'undefined' || this._silhouetteMaterial !== this.silhouetteMaterial;
+            var outerChanged = this._outerMaterial !== this.outerMaterial;
+            var innerChanged = this._innerMaterial !== this.innerMaterial;
+            var capChanged = this._capMaterial !== this.capMaterial;
+            var silhouetteChanged = this._silhouetteMaterial !== this.silhouetteMaterial;
             var affectedByLightingChanged = this._affectedByLighting !== this.affectedByLighting;
             var materialChanged = outerChanged || innerChanged || capChanged || silhouetteChanged || affectedByLightingChanged;
 
             if (materialChanged) {
-                this._outerMaterial = (typeof this.outerMaterial !== 'undefined') ? this.outerMaterial : Material.fromType(context, Material.ColorType);
-                this._innerMaterial = (typeof this.innerMaterial !== 'undefined') ? this.innerMaterial : Material.fromType(context, Material.ColorType);
-                this._capMaterial = (typeof this.capMaterial !== 'undefined') ? this.capMaterial : Material.fromType(context, Material.ColorType);
-                this._silhouetteMaterial = (typeof this.silhouetteMaterial !== 'undefined') ? this.silhouetteMaterial : Material.fromType(context, Material.ColorType);
+                this._outerMaterial = this.outerMaterial;
+                this._innerMaterial = this.innerMaterial;
+                this._capMaterial = this.capMaterial;
+                this._silhouetteMaterial = this.silhouetteMaterial;
                 this._affectedByLighting = this.affectedByLighting;
 
                 var material = this._combineMaterials();
@@ -462,6 +482,7 @@ define([
 
             this._commandLists.colorList.push(this._colorCommand);
         }
+
         if (pass.pick) {
             if (typeof this._pickId === 'undefined') {
                 // Since this ignores all other materials, if a material does discard, the sensor will still be picked.

--- a/Source/Scene/CustomSensorVolume.js
+++ b/Source/Scene/CustomSensorVolume.js
@@ -335,6 +335,7 @@ define([
      * @memberof CustomSensorVolume
      *
      * @exception {DeveloperError} this.radius must be greater than or equal to zero.
+     * @exception {DeveloperError} this.material must be defined.
      */
     CustomSensorVolume.prototype.update = function(context, frameState, commandList) {
         this._mode = frameState.mode;
@@ -344,6 +345,10 @@ define([
 
         if (this.radius < 0.0) {
             throw new DeveloperError('this.radius must be greater than or equal to zero.');
+        }
+
+        if (typeof this.material === 'undefined') {
+            throw new DeveloperError('this.material must be defined.');
         }
 
         // Initial render state creation
@@ -380,14 +385,14 @@ define([
         var pass = frameState.passes;
         this._colorCommand.modelMatrix = this._pickCommand.modelMatrix = this.modelMatrix;
         this._commandLists.removeAll();
+
         if (pass.color) {
             var materialChanged = typeof this._material === 'undefined' ||
-            this._material !== this.material ||
-            this._affectedByLighting !== this.affectedByLighting;
+                this._material !== this.material ||
+                this._affectedByLighting !== this.affectedByLighting;
 
             // Recompile shader when material changes
             if (materialChanged) {
-                this.material = (typeof this.material !== 'undefined') ? this.material : Material.fromType(context, Material.ColorType);
                 this._material = this.material;
                 this._affectedByLighting = this.affectedByLighting;
 
@@ -410,6 +415,7 @@ define([
 
             this._commandLists.colorList.push(this._colorCommand);
         }
+
         if (pass.pick) {
             if (typeof this._pickId === 'undefined') {
                 // Since this ignores all other materials, if a material does discard, the sensor will still be picked.

--- a/Source/Scene/EllipsoidPrimitive.js
+++ b/Source/Scene/EllipsoidPrimitive.js
@@ -252,6 +252,8 @@ define([
 
     /**
      * @private
+     *
+     * @exception {DeveloperError} this.material must be defined.
      */
     EllipsoidPrimitive.prototype.update = function(context, frameState, commandList) {
         if (!this.show ||
@@ -259,6 +261,10 @@ define([
             (typeof this.center === 'undefined') ||
             (typeof this.radii === 'undefined')) {
             return;
+        }
+
+        if (typeof this.material === 'undefined') {
+            throw new DeveloperError('this.material must be defined.');
         }
 
         if (typeof this._rs === 'undefined') {
@@ -312,7 +318,6 @@ define([
                 this._material !== this.material ||
                 this._affectedByLighting !== this.affectedByLighting) {
 
-                this.material = (typeof this.material !== 'undefined') ? this.material : Material.fromType(context, Material.ColorType);
                 this._material = this.material;
                 this._affectedByLighting = this.affectedByLighting;
 

--- a/Source/Scene/Label.js
+++ b/Source/Scene/Label.js
@@ -633,7 +633,7 @@ define([
      *
      * @memberof Label
      *
-     * @param {UniformState} uniformState The same state object passed to {@link LabelCollection#render}.
+     * @param {UniformState} uniformState The same state object passed to {@link LabelCollection#update}.
      * @param {FrameState} frameState The same state object passed to {@link LabelCollection#update}.
      *
      * @return {Cartesian2} The screen-space position of the label.

--- a/Source/Scene/Polygon.js
+++ b/Source/Scene/Polygon.js
@@ -591,20 +591,21 @@ define([
 
     /**
      * Commits changes to properties before rendering by updating the object's WebGL resources.
-     * This must be called before calling {@link Polygon#render} in order to realize
-     * changes to polygon's positions and properties.
      *
      * @memberof Polygon
      *
      * @exception {DeveloperError} this.ellipsoid must be defined.
+     * @exception {DeveloperError} this.material must be defined.
      * @exception {DeveloperError} this.granularity must be greater than zero.
      * @exception {DeveloperError} This object was destroyed, i.e., destroy() was called.
-     *
-     * @see Polygon#render
      */
     Polygon.prototype.update = function(context, frameState, commandList) {
-        if (!this.ellipsoid) {
+        if (typeof this.ellipsoid === 'undefined') {
             throw new DeveloperError('this.ellipsoid must be defined.');
+        }
+
+        if (typeof this.material === 'undefined') {
+            throw new DeveloperError('this.material must be defined.');
         }
 
         var mode = frameState.mode;
@@ -693,12 +694,11 @@ define([
             }
 
             var materialChanged = typeof this._material === 'undefined' ||
-            this._material !== this.material ||
-            this._affectedByLighting !== this.affectedByLighting;
+                this._material !== this.material ||
+                this._affectedByLighting !== this.affectedByLighting;
 
             // Recompile shader when material or lighting changes
             if (materialChanged) {
-                this.material = (typeof this.material !== 'undefined') ? this.material : Material.fromType(context, Material.ColorType);
                 this._material = this.material;
                 this._affectedByLighting = this.affectedByLighting;
 
@@ -734,6 +734,7 @@ define([
                 command.renderState = this._rs;
             }
         }
+
         if (pass.pick) {
             if (typeof this._pickId === 'undefined') {
                 this._spPick = context.getShaderCache().getShaderProgram(PolygonVSPick, PolygonFSPick, attributeIndices);

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -431,12 +431,8 @@ define([
 
     /**
      * Commits changes to properties before rendering by updating the object's WebGL resources.
-     * This must be called before calling {@link PolylineCollection#render} in order to realize
-     * changes to PolylineCollection positions and properties.
-     *
      *
      * @memberof PolylineCollection
-     *
      */
     PolylineCollection.prototype.update = function(context, frameState, commandList) {
         if (typeof this._sp === 'undefined') {

--- a/Specs/Scene/EllipsoidPrimitiveSpec.js
+++ b/Specs/Scene/EllipsoidPrimitiveSpec.js
@@ -115,17 +115,6 @@ defineSuite([
         e1 = e1 && e1.destroy();
     });
 
-    it('renders without a material', function() {
-        ellipsoid = createEllipsoid();
-        ellipsoid.material = undefined;
-
-        context.clear();
-        expect(context.readPixels()).toEqual([0, 0, 0, 0]);
-
-        render(context, frameState, ellipsoid);
-        expect(context.readPixels()).not.toEqual([0, 0, 0, 0]);
-    });
-
     it('renders without lighting', function() {
         ellipsoid = createEllipsoid();
         ellipsoid.affectedByLighting = false;
@@ -180,5 +169,14 @@ defineSuite([
         expect(p.isDestroyed()).toEqual(false);
         p.destroy();
         expect(p.isDestroyed()).toEqual(true);
+    });
+
+    it('throws when rendered without a material', function() {
+        ellipsoid = createEllipsoid();
+        ellipsoid.material = undefined;
+
+        expect(function() {
+            render(context, frameState, ellipsoid);
+        }).toThrow();
     });
 });

--- a/Specs/Scene/PolygonSpec.js
+++ b/Specs/Scene/PolygonSpec.js
@@ -234,18 +234,6 @@ defineSuite([
         expect(context.readPixels()).not.toEqual([0, 0, 0, 0]);
     });
 
-    it('renders without a material', function() {
-        // This test fails in Chrome if a breakpoint is set inside this function.  Strange.
-        polygon = createPolygon();
-        polygon.material = undefined;
-
-        context.clear();
-        expect(context.readPixels()).toEqual([0, 0, 0, 0]);
-
-        render(context, frameState, polygon);
-        expect(context.readPixels()).not.toEqual([0, 0, 0, 0]);
-    });
-
     it('renders without lighting', function() {
         // This test fails in Chrome if a breakpoint is set inside this function.  Strange.
         polygon = createPolygon();
@@ -440,6 +428,15 @@ defineSuite([
 
         expect(function() {
             polygon.update(context, frameState);
+        }).toThrow();
+    });
+
+    it('throws when rendered without a material', function() {
+        polygon = createPolygon();
+        polygon.material = undefined;
+
+        expect(function() {
+            render(context, frameState, polygon);
         }).toThrow();
     });
 });


### PR DESCRIPTION
Previously, if a user changed the `material` property of a primitive to `undefined`, we silently changed it to the default material.  I don't think this is the right behavior; we don't do it with other properties.  I changed `update` to throw an exception instead.

I don't think this is important enough to update CHANGES.md, but I can if folks want.

Sensors still don't have tests, I know.  `update` needs better doc throughout, but that is dependent on the DDR.
