### PR TITLE
Dynamic position issue

### DIFF
--- a/Source/DynamicScene/DynamicPositionProperty.js
+++ b/Source/DynamicScene/DynamicPositionProperty.js
@@ -331,8 +331,7 @@ define([
 
         //We could handle the data, add it to the property.
         if (typeof unwrappedInterval !== 'undefined') {
-            property._addCzmlIntervalUnwrapped(iso8601Interval.start, iso8601Interval.stop, unwrappedInterval, czmlInterval.epoch, czmlInterval.interpolationAlgorithm,
-                    czmlInterval.interpolationDegree);
+            property._addCzmlIntervalUnwrapped(iso8601Interval.start, iso8601Interval.stop, unwrappedInterval, czmlInterval.epoch, czmlInterval.interpolationAlgorithm, czmlInterval.interpolationDegree);
         }
     };
 

--- a/Source/DynamicScene/DynamicProperty.js
+++ b/Source/DynamicScene/DynamicProperty.js
@@ -21,6 +21,7 @@ define([
         LagrangePolynomialApproximation) {
     "use strict";
 
+
     //CZML_TODO This is more of an idea than a to-do, but currently DynamicProperty requires
     //you know the type of data being loaded up-front by passing valueType.  We could take
     //a similar approach to DynamicMaterialProperty and have a list of potential valueTypes
@@ -33,10 +34,10 @@ define([
 
     //Map CZML interval types to their implementation.
     var interpolators = {
-            HERMITE : HermitePolynomialApproximation,
-            LAGRANGE : LagrangePolynomialApproximation,
-            LINEAR : LinearApproximation
-        };
+        HERMITE : HermitePolynomialApproximation,
+        LAGRANGE : LagrangePolynomialApproximation,
+        LINEAR : LinearApproximation
+    };
 
     //The data associated with each DynamicProperty interval.
     function IntervalData() {
@@ -160,7 +161,7 @@ define([
         if (intervalData.isSampled && times.length >= 0 && values.length > 0) {
             var index = binarySearch(times, time, JulianDate.compare);
             if (index < 0) {
-                if(intervalData.numberOfPoints < 2){
+                if (intervalData.numberOfPoints < 2) {
                     return undefined;
                 }
                 index = ~index;
@@ -323,7 +324,7 @@ define([
                 interpolationAlgorithm = interpolators[interpolationAlgorithmType];
                 intervalData.interpolationAlgorithm = interpolationAlgorithm;
             }
-            if (typeof interpolationAlgorithm !== 'undefined '&& typeof interpolationDegree !== 'undefined') {
+            if (typeof interpolationAlgorithm !== 'undefined' && typeof interpolationDegree !== 'undefined') {
                 intervalData.interpolationDegree = interpolationDegree;
                 intervalData.xTable = undefined;
                 intervalData.yTable = undefined;

--- a/Specs/DynamicScene/DynamicPropertySpec.js
+++ b/Specs/DynamicScene/DynamicPropertySpec.js
@@ -173,6 +173,21 @@ defineSuite([
         expect(result.w).toEqual(0);
     });
 
+    it('Returns undefined if trying to interpolate with less than two samples.', function() {
+        var iso8601Epoch = '2012-04-18T15:59:00Z';
+        var epoch = JulianDate.fromIso8601(iso8601Epoch);
+
+        var property = new DynamicProperty(CzmlNumber);
+        var czmlInterval = {
+            epoch : iso8601Epoch,
+            number : [0, 0]
+        };
+        property.processCzmlIntervals(czmlInterval);
+
+        expect(property.getValue(epoch)).toEqual(0);
+        expect(property.getValue(epoch.addSeconds(4))).toBeUndefined();
+    });
+
     it('_mergeNewSamples works for sorted non-intersecting data.', function() {
         var times = [];
         var values = [];

--- a/Specs/Renderer/CommandSpec.js
+++ b/Specs/Renderer/CommandSpec.js
@@ -1,6 +1,6 @@
 /*global defineSuite*/
 defineSuite([
-         'Renderer/Command',
+         'Renderer/Command'
      ], function(
          Command) {
     "use strict";


### PR DESCRIPTION
If I'm streaming an individual point in time and using linear interpolation to the viewer and want to use the path visualizer two things happen. This first point that is as it's processed it goes through linearapproximation.interpolateOrderZero function and the function throws a developer exception because the xTable only had one element. The second is the dynamicPositionProperty can set undefined an undefined into an array for the polyline. This causes an exception down in the polyline class. This pull request tries to fix those issues.
