### PR TITLE
Improvements to glslToJavascript

### DIFF
--- a/.project
+++ b/.project
@@ -32,7 +32,7 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1336749948404</id>
+			<id>1348681628761</id>
 			<name></name>
 			<type>10</type>
 			<matcher>
@@ -41,7 +41,7 @@
 			</matcher>
 		</filter>
 		<filter>
-			<id>1336749948413</id>
+			<id>1348681628764</id>
 			<name></name>
 			<type>10</type>
 			<matcher>
@@ -50,16 +50,7 @@
 			</matcher>
 		</filter>
 		<filter>
-			<id>1336749948416</id>
-			<name></name>
-			<type>10</type>
-			<matcher>
-				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-Tools</arguments>
-			</matcher>
-		</filter>
-		<filter>
-			<id>1336749948422</id>
+			<id>1348681628769</id>
 			<name></name>
 			<type>6</type>
 			<matcher>
@@ -83,6 +74,15 @@
 			<matcher>
 				<id>org.eclipse.ui.ide.multiFilter</id>
 				<arguments>1.0-name-matches-false-false-SpecList.js</arguments>
+			</matcher>
+		</filter>
+		<filter>
+			<id>1348694184349</id>
+			<name>Tools</name>
+			<type>9</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-buildTasks</arguments>
 			</matcher>
 		</filter>
 		<filter>

--- a/Tools/buildTasks/createCesiumJs.js
+++ b/Tools/buildTasks/createCesiumJs.js
@@ -1,0 +1,61 @@
+/*global importClass,project,attributes,elements,java,Packages*/
+/*jshint multistr:true*/
+importClass(java.io.File); /*global File*/
+importClass(java.io.FileReader); /*global FileReader*/
+importClass(java.io.FileWriter); /*global FileWriter*/
+importClass(Packages.org.apache.tools.ant.util.FileUtils); /*global FileUtils*/
+
+var moduleIds = [];
+var parameters = [];
+var assignments = [];
+
+var sourceFilesets = elements.get('sourcefiles');
+for ( var i = 0, len = sourceFilesets.size(); i < len; ++i) {
+    var sourceFileset = sourceFilesets.get(i);
+    var basedir = sourceFileset.getDir(project);
+    var sourceFilenames = sourceFileset.getDirectoryScanner(project).getIncludedFiles();
+
+    for ( var j = 0; j < sourceFilenames.length; ++j) {
+        var relativePath = sourceFilenames[j];
+        var file = new File(basedir, relativePath);
+
+        var moduleId = relativePath.replace('\\', '/');
+        moduleId = moduleId.substring(0, moduleId.lastIndexOf('.'));
+
+        var baseName = file.getName();
+        var assignmentName = baseName.substring(0, baseName.lastIndexOf('.'));
+        if (/Shaders\//.test(moduleId)) {
+            assignmentName = '_shaders.' + assignmentName;
+        }
+
+        var parameterName = moduleId.replace('/', '_');
+
+        moduleIds.push("'" + moduleId + "'");
+        parameters.push(parameterName);
+        assignments.push('Cesium.' + assignmentName + ' = ' + parameterName + ';');
+    }
+}
+
+var output = attributes.get('output');
+if (new File(output).exists()) {
+    var reader = new FileReader(output);
+    var oldContents = String(FileUtils.readFully(reader));
+    reader.close();
+}
+
+var contents = '\
+/*global define*/\n\
+define([' + moduleIds.join(', ') + '], function(' + parameters.join(', ') + ') {\n\
+  "use strict";\n\
+  var Cesium = {\n\
+    _shaders : {}\n\
+  };\n\
+  ' + assignments.join('\n  ') + '\n\
+  return Cesium;\n\
+});';
+
+if (oldContents !== contents) {
+    var writer = new FileWriter(output);
+    writer.write(contents);
+    writer.close();
+}

--- a/Tools/buildTasks/createGalleryList.js
+++ b/Tools/buildTasks/createGalleryList.js
@@ -1,0 +1,51 @@
+/*global importClass,project,attributes,elements,java,Packages*/
+/*jshint multistr:true*/
+importClass(java.io.File); /*global File*/
+importClass(java.io.FileReader); /*global FileReader*/
+importClass(java.io.FileWriter); /*global FileWriter*/
+importClass(Packages.org.apache.tools.ant.util.FileUtils); /*global FileUtils*/
+
+var demos = [];
+
+var demoFilesets = elements.get('demos');
+for ( var i = 0, len = demoFilesets.size(); i < len; ++i) {
+    var demoFileset = demoFilesets.get(i);
+    var basedir = demoFileset.getDir(project);
+    var demoFilenames = demoFileset.getDirectoryScanner(project).getIncludedFiles();
+
+    for ( var j = 0, len2 = demoFilenames.length; j < len2; ++j) {
+        var relativePath = demoFilenames[j];
+        var demo = relativePath.substring(0, relativePath.lastIndexOf('.')).replace('\\', '/');
+        var thumbnail = '';
+        if (new File(basedir, demo + '.jpg').exists()) {
+            thumbnail = "'img' : '" + demo + ".jpg',";
+        }
+        var fileDate = new File(basedir, demo + '.html').lastModified().toString();
+        var demoContent = "\
+  {\n\
+    'name' : '" + demo + "',\n\
+    " + thumbnail + "\n\
+    'date' : " + fileDate + '\n\
+  }';
+        demos.push(demoContent);
+    }
+}
+
+var output = attributes.get("output");
+if (new File(output).exists()) {
+    var reader = new FileReader(output);
+    var oldContents = String(FileUtils.readFully(reader));
+    reader.close();
+}
+
+var contents = '\
+// This file is automatically rebuilt by the Cesium build process.\n\
+var gallery_demos = [\n\
+' + demos.join(',\n') + '\n\
+];';
+
+if (oldContents !== contents) {
+    var writer = new FileWriter(output);
+    writer.write(contents);
+    writer.close();
+}

--- a/Tools/buildTasks/createSpecList.js
+++ b/Tools/buildTasks/createSpecList.js
@@ -1,0 +1,36 @@
+/*global importClass,project,attributes,elements,java,Packages*/
+/*jshint multistr:true*/
+importClass(java.io.File); /*global File*/
+importClass(java.io.FileReader); /*global FileReader*/
+importClass(java.io.FileWriter); /*global FileWriter*/
+importClass(Packages.org.apache.tools.ant.util.FileUtils); /*global FileUtils*/
+
+var specs = [];
+
+var specFilesets = elements.get('specs');
+for ( var i = 0, len = specFilesets.size(); i < len; ++i) {
+    var specFileset = specFilesets.get(i);
+    var basedir = specFileset.getDir(project);
+    var specFilenames = specFileset.getDirectoryScanner(project).getIncludedFiles();
+
+    for ( var j = 0, len2 = specFilenames.length; j < len2; ++j) {
+        var relativePath = specFilenames[j];
+        var spec = relativePath.substring(0, relativePath.lastIndexOf('.')).replace('\\', '/');
+        specs.push("'Specs/" + spec + "'");
+    }
+}
+
+var output = attributes.get('output');
+if (new File(output).exists()) {
+    var reader = new FileReader(output);
+    var oldContents = String(FileUtils.readFully(reader));
+    reader.close();
+}
+
+var contents = 'var specs = [' + specs.join(',') + '];';
+
+if (oldContents !== contents) {
+    var writer = new FileWriter(output);
+    writer.write(contents);
+    writer.close();
+}

--- a/Tools/buildTasks/extractShaderComments.js
+++ b/Tools/buildTasks/extractShaderComments.js
@@ -1,0 +1,36 @@
+/*global importClass,project,attributes,elements,java,Packages*/
+/*jshint multistr:true*/
+importClass(java.io.File); /*global File*/
+importClass(java.io.FileReader); /*global FileReader*/
+importClass(java.io.FileWriter); /*global FileWriter*/
+importClass(Packages.org.apache.tools.ant.util.FileUtils); /*global FileUtils*/
+
+var glslFilesets = elements.get('glslfiles');
+for ( var i = 0, len = glslFilesets.size(); i < len; ++i) {
+    var glslFileset = glslFilesets.get(i);
+    var basedir = glslFileset.getDir(project);
+    var glslFilenames = glslFileset.getDirectoryScanner(project).getIncludedFiles();
+
+    var glslDocComments = '';
+
+    for ( var j = 0; j < glslFilenames.length; j++) {
+        var glslFilename = glslFilenames[j];
+
+        var glslFile = new File(basedir, glslFilename);
+        var reader = new FileReader(glslFile);
+        var contents = String(FileUtils.readFully(reader));
+        reader.close();
+
+        contents = contents.replace(/\r\n/gm, '\n');
+
+        var docComments = contents.match(/\/\*\*[\s\S]*?\*\//gm);
+        if (docComments) {
+            glslDocComments += docComments.join('\n') + '\n';
+        }
+    }
+
+    var glslDocFile = new File(basedir, 'glslComments.js');
+    var glslDocWriter = new FileWriter(glslDocFile);
+    glslDocWriter.write(glslDocComments);
+    glslDocWriter.close();
+}

--- a/Tools/buildTasks/glslToJavaScript.js
+++ b/Tools/buildTasks/glslToJavaScript.js
@@ -1,0 +1,82 @@
+/*global importClass,project,attributes,elements,java,Packages*/
+/*jshint multistr:true*/
+importClass(java.io.File); /*global File*/
+importClass(java.io.FileReader); /*global FileReader*/
+importClass(java.io.FileWriter); /*global FileWriter*/
+importClass(java.io.StringReader); /*global StringReader*/
+importClass(java.util.HashSet); /*global HashSet*/
+importClass(Packages.org.apache.tools.ant.util.FileUtils); /*global FileUtils*/
+importClass(Packages.org.apache.tools.ant.filters.StripJavaComments); /*global StripJavaComments*/
+
+var stripComments = String('true').equals(attributes.get('stripcomments'));
+
+// collect all currently existing JS files into a set, later we will remove the ones
+// we still are using from the set, then delete any files remaining in the set.
+var leftOverJsFiles = new HashSet();
+var existingJsFilesets = elements.get('existingjsfiles');
+for ( var i = 0, len = existingJsFilesets.size(); i < len; ++i) {
+    var existingJsFileset = existingJsFilesets.get(i);
+
+    var basedir = existingJsFileset.getDir(project);
+    var existingJsFilenames = existingJsFileset.getDirectoryScanner(project).getIncludedFiles();
+
+    for ( var j = 0; j < existingJsFilenames.length; ++j) {
+        leftOverJsFiles.add(new File(basedir, existingJsFilenames[j]).getAbsolutePath());
+    }
+}
+
+var glslFilesets = elements.get('glslfiles');
+for ( var i = 0, len = glslFilesets.size(); i < len; ++i) {
+    var glslFileset = glslFilesets.get(i);
+
+    var basedir = glslFileset.getDir(project);
+    var glslFilenames = glslFileset.getDirectoryScanner(project).getIncludedFiles();
+
+    for ( var j = 0; j < glslFilenames.length; ++j) {
+        var glslFilename = glslFilenames[j];
+
+        var glslFile = new File(basedir, glslFilename);
+        var jsFile = new File(basedir, glslFilename.replace('.glsl', '.js'));
+        leftOverJsFiles.remove(jsFile.getAbsolutePath());
+
+        if (glslFile.lastModified() < jsFile.lastModified()) {
+            continue;
+        }
+
+        var reader = new FileReader(glslFile);
+        var contents = String(FileUtils.readFully(reader));
+        reader.close();
+
+        contents = contents.replace(/\r\n/gm, '\n');
+
+        var copyrightComments = '';
+        var extractedCopyrightComments = contents.match(/\/\*\!(?:.|\n)*?\*\//gm);
+        if (extractedCopyrightComments) {
+            copyrightComments = extractedCopyrightComments.join('\n') + '\n';
+        }
+
+        if (stripComments) {
+            contents = String(FileUtils.readFully(new StripJavaComments(new StringReader(contents))));
+            contents = contents.replace(/\s+$/gm, '').replace(/^\s+/gm, '').replace(/\n+/gm, '\n');
+            contents += '\n';
+        }
+
+        contents = contents.split('"').join('\\"').replace(/\n/gm, '\\n\\\n');
+        contents = copyrightComments + '\
+// This file is automatically rebuilt by the Cesium build process.\n\
+/*global define*/\n\
+define(function() {\n\
+    "use strict";\n\
+    return "' + contents + '";\n\
+});';
+
+        var writer = new FileWriter(jsFile);
+        writer.write(contents);
+        writer.close();
+    }
+}
+
+// delete any left over JS files from old shaders
+for ( var it = leftOverJsFiles.iterator(); it.hasNext();) {
+    new File(it.next())['delete']();
+}

--- a/build.xml
+++ b/build.xml
@@ -1,25 +1,27 @@
 <project name="Cesium" default="combine">
 	<target name="build" description="A developer build that runs in-place.">
 		<glslToJavascript stripcomments="${build.minification}">
-			<fileset dir="${shadersDirectory}" includes="**/*.glsl" />
+			<glslfiles dir="${shadersDirectory}" includes="**/*.glsl" />
+			<existingjsfiles dir="${shadersDirectory}" includes="**/*.js" excludes="*.profile.js" />
 		</glslToJavascript>
+
 		<parallel>
 			<createCesiumJs output="${sourceDirectory}/Cesium.js">
-				<fileset dir="${sourceDirectory}">
+				<sourcefiles dir="${sourceDirectory}">
 					<include name="**/*.js" />
 					<exclude name="Widgets/**" />
 					<exclude name="Cesium.js" />
 					<exclude name="main.js" />
 					<exclude name="**/*.profile.js" />
-				</fileset>
+				</sourcefiles>
 			</createCesiumJs>
 
 			<createSpecList output="${specsDirectory}/SpecList.js">
-				<fileset dir="${specsDirectory}" includes="**/*.js" excludes="*.js" />
+				<specs dir="${specsDirectory}" includes="**/*.js" excludes="*.js" />
 			</createSpecList>
 
 			<createGalleryList output="${galleryDirectory}/gallery-index.js">
-				<fileset dir="${galleryDirectory}" includes="**/*.html" />
+				<demos dir="${galleryDirectory}" includes="**/*.html" />
 			</createGalleryList>
 		</parallel>
 	</target>
@@ -27,6 +29,9 @@
 	<target name="combine" description="Combines all source files into a single stand-alone script." depends="build, combineJavaScript" />
 
 	<target name="minify" description="Combines all source files into a single stand-alone, minified script.">
+		<delete includeEmptyDirs="true" failonerror="false">
+			<fileset dir="${shadersDirectory}" includes="**/*.js" excludes="*.profile.js" />
+		</delete>
 		<antcall target="combine">
 			<param name="build.minification" value="true" />
 		</antcall>
@@ -86,6 +91,7 @@
 	<property name="specsDirectory" location="Specs" />
 	<property name="imagesDirectory" location="Images" />
 	<property name="toolsDirectory" location="Tools" />
+	<property name="tasksDirectory" location="${toolsDirectory}/buildTasks" />
 	<property name="thirdPartyDirectory" location="ThirdParty" />
 	<property name="rjsPath" location="${thirdPartyDirectory}/requirejs-1.0.8/r.js" />
 	<property name="almondPath" location="${thirdPartyDirectory}/almond-0.0.3/almond.js" />
@@ -103,252 +109,29 @@
 	<property name="buildDocumentationImagesDirectory" location="${buildDocumentationDirectory}/images" />
 	<property name="builtCesiumFile" location="${buildDirectory}/Cesium.js" />
 
-	<!-- ********************************************************************** -->
-
-	<scriptdef name="glslToJavascript" language="javascript">
-		<!-- Scott Hunter is my hero. - Cozzi -->
+	<scriptdef name="glslToJavascript" language="javascript" src="${tasksDirectory}/glslToJavaScript.js">
 		<attribute name="stripcomments" />
-		<element name="fileset" type="fileset" />
-		<![CDATA[
-importClass(java.io.File);
-importClass(java.io.FileReader);
-importClass(java.io.FileWriter);
-importClass(java.io.StringReader);
-importClass(Packages.org.apache.tools.ant.util.FileUtils);
-importClass(Packages.org.apache.tools.ant.filters.StripJavaComments);
-
-var stripComments = attributes.get("stripcomments");
-var filesets = elements.get("fileset");
-for (var i = 0; i < filesets.size(); i++) {
-  var fileset = filesets.get(i);
-  var basedir  = fileset.getDir(project);
-  var filenames = fileset.getDirectoryScanner(project).getIncludedFiles();
-
-  for (var j = 0; j < filenames.length; j++) {
-    var filename = filenames[j];
-
-    var file = new File(basedir, filename);
-    var targetFile = new File(basedir, filename.replace('.glsl', '.js'));
-    if (file.lastModified() < targetFile.lastModified()) {
-      continue;
-    }
-
-    var reader = new FileReader(file);
-    var contents = String(FileUtils.readFully(reader));
-    reader.close();
-
-    contents = contents.replace(/\r\n/gm, '\n');
-
-    var copyrightComments = contents.match(/\/\*\!(?:.|\n)*?\*\//gm) || [];
-
-    if (stripComments) {
-      contents = String(FileUtils.readFully(new StripJavaComments(new StringReader(contents))));
-      contents = contents.replace(/\s+$/gm, '').replace(/^\s+/gm, '').replace(/\n+/gm, '\n');
-      contents += '\n';
-    }
-
-    contents = contents.split('"').join('\\"').replace(/\n/gm, '\\n" +\n"');
-    contents = copyrightComments.join('\n') + '\n' +
-               '/*global define*/\n' +
-               'define(function() {\n' +
-               '  "use strict";\n' +
-               '  return "' + contents + '";\n' +
-               '});'
-
-    var writer = new FileWriter(targetFile);
-    writer.write(contents);
-    writer.close();
-  }
-}
-]]>
+		<element name="glslfiles" type="fileset" />
+		<element name="existingjsfiles" type="fileset" />
 	</scriptdef>
 
-	<scriptdef name="extractShaderComments" language="javascript">
-		<element name="fileset" type="fileset" />
-		<![CDATA[
-importClass(java.io.File);
-importClass(java.io.FileReader);
-importClass(java.io.FileWriter);
-importClass(Packages.org.apache.tools.ant.util.FileUtils);
-
-var filesets = elements.get("fileset");
-for (var i = 0; i < filesets.size(); i++) {
-  var fileset = filesets.get(i);
-  var basedir  = fileset.getDir(project);
-  var filenames = fileset.getDirectoryScanner(project).getIncludedFiles();
-
-  var glslDoc = "";
-
-  for (var j = 0; j < filenames.length; j++) {
-    var filename = filenames[j];
-
-    var file = new File(basedir, filename);
-    var reader = new FileReader(file);
-    var contents = String(FileUtils.readFully(reader));
-    reader.close();
-
-    contents = contents.replace(/\r\n/gm, '\n');
-
-    var docComments = contents.match(/\/\*\*[\s\S]*?\*\//gm) || [];
-    if (docComments.length > 0) {
-        glslDoc = glslDoc + docComments.join('\n');
-    }
-  }
-
-  var glslDocFile = new File(basedir, 'glslComments.js');
-  var glslDocWriter = new FileWriter(glslDocFile);
-  glslDocWriter.write(glslDoc);
-  glslDocWriter.close();
-}
-]]>
+	<scriptdef name="extractShaderComments" language="javascript" src="${tasksDirectory}/extractShaderComments.js">
+		<element name="glslfiles" type="fileset" />
 	</scriptdef>
 
-	<scriptdef name="createCesiumJs" language="javascript">
+	<scriptdef name="createCesiumJs" language="javascript" src="${tasksDirectory}/createCesiumJs.js">
 		<attribute name="output" />
-		<element name="fileset" type="fileset" />
-		<![CDATA[
-importClass(java.io.File);
-importClass(java.io.FileReader);
-importClass(java.io.FileWriter);
-importClass(Packages.org.apache.tools.ant.util.FileUtils);
-
-var moduleIds = [];
-var parameters = [];
-var assignments = [];
-
-var filesets = elements.get("fileset");
-for (var i = 0, len = filesets.size(); i < len; i++) {
-  var fileset = filesets.get(i);
-  var basedir = fileset.getDir(project);
-  var filenames = fileset.getDirectoryScanner(project).getIncludedFiles();
-
-  for (var j = 0, len2 = filenames.length; j < len2; j++) {
-    var relativePath = filenames[j];
-    var file = new File(basedir, relativePath);
-
-    var moduleId = relativePath.replace('\\', '/');
-    moduleId = moduleId.substring(0, moduleId.lastIndexOf('.'));
-
-    var baseName = file.getName();
-	var assignmentName = baseName.substring(0, baseName.lastIndexOf('.'));
-    if (/Shaders\//.test(moduleId)) {
-      assignmentName = '_shaders.' + assignmentName;
-    }
-
-    var parameterName = moduleId.replace('/', '_');
-
-    moduleIds.push("'" + moduleId + "'");
-    parameters.push(parameterName);
-    assignments.push('Cesium.' + assignmentName + ' = ' + parameterName + ';');
-  }
-}
-
-var output = attributes.get("output");
-if (new File(output).exists()) {
-  var reader = new FileReader(output);
-  var oldContents = String(FileUtils.readFully(reader));
-  reader.close();
-}
-
-var contents = '/*global define*/\n' +
-               'define([' + moduleIds.join(', ') + '], function (' + parameters.join(', ') + ') {\n' +
-               '  "use strict";\n' +
-               '  var Cesium = { _shaders : {} };\n  ' +
-               assignments.join('\n  ') + '\n' +
-               '  return Cesium;\n' +
-               '});';
-
-if (oldContents !== contents) {
-  var writer = new FileWriter(output);
-  writer.write(contents);
-  writer.close();
-}
-]]>
+		<element name="sourcefiles" type="fileset" />
 	</scriptdef>
 
-	<scriptdef name="createSpecList" language="javascript">
+	<scriptdef name="createSpecList" language="javascript" src="${tasksDirectory}/createSpecList.js">
 		<attribute name="output" />
-		<element name="fileset" type="fileset" />
-		<![CDATA[
-importClass(java.io.File);
-importClass(java.io.FileReader);
-importClass(java.io.FileWriter);
-importClass(Packages.org.apache.tools.ant.util.FileUtils);
-
-var specs = [];
-
-var filesets = elements.get("fileset");
-for (var i = 0, len = filesets.size(); i < len; i++) {
-  var fileset = filesets.get(i);
-  var basedir  = fileset.getDir(project);
-  var filenames = fileset.getDirectoryScanner(project).getIncludedFiles();
-
-  for (var j = 0, len2 = filenames.length; j < len2; j++) {
-    var relativePath = filenames[j];
-    var spec = relativePath.substring(0, relativePath.lastIndexOf('.')).replace('\\', '/');
-    specs.push("'Specs/" + spec + "'");
-  }
-}
-
-var output = attributes.get("output");
-if (new File(output).exists()) {
-  var reader = new FileReader(output);
-  var oldContents = String(FileUtils.readFully(reader));
-  reader.close();
-}
-
-var contents = 'var specs = [' + specs.join(',') + '];';
-
-if (oldContents !== contents) {
-  var writer = new FileWriter(output);
-  writer.write(contents);
-  writer.close();
-}
-]]>
+		<element name="specs" type="fileset" />
 	</scriptdef>
 
-	<scriptdef name="createGalleryList" language="javascript">
+	<scriptdef name="createGalleryList" language="javascript" src="${tasksDirectory}/createGalleryList.js">
 		<attribute name="output" />
-		<element name="fileset" type="fileset" />
-		<![CDATA[
-importClass(java.io.File);
-importClass(java.io.FileReader);
-importClass(java.io.FileWriter);
-importClass(Packages.org.apache.tools.ant.util.FileUtils);
-
-var demos = [];
-
-var filesets = elements.get("fileset");
-for (var i = 0, len = filesets.size(); i < len; i++) {
-  var fileset = filesets.get(i);
-  var basedir  = fileset.getDir(project);
-  var filenames = fileset.getDirectoryScanner(project).getIncludedFiles();
-
-  for (var j = 0, len2 = filenames.length; j < len2; j++) {
-    var relativePath = filenames[j];
-    var demo = relativePath.substring(0, relativePath.lastIndexOf('.')).replace('\\', '/');
-    var thumbnail = new File(basedir, demo + '.jpg').exists() ? (", 'img':'" + demo + ".jpg'") : '';
-    var fileDate = new File(basedir, demo + '.html').lastModified().toString();
-    demos.push("\n\t{'name':'" + demo + "'" + thumbnail + ", 'date':" + fileDate + '}');
-  }
-}
-
-var output = attributes.get("output");
-if (new File(output).exists()) {
-  var reader = new FileReader(output);
-  var oldContents = String(FileUtils.readFully(reader));
-  reader.close();
-}
-
-var contents = '// This file is automatically rebuilt by the Cesium build process.\n' +
-    'var gallery_demos = [' + demos.join(',') + '\n];';
-
-if (oldContents !== contents) {
-  var writer = new FileWriter(output);
-  writer.write(contents);
-  writer.close();
-}
-]]>
+		<element name="demos" type="fileset" />
 	</scriptdef>
 
 	<target name="combineJavaScript.setNodePathValue">
@@ -432,7 +215,7 @@ if (oldContents !== contents) {
 
 	<target name="generateDocumentation">
 		<extractShaderComments>
-			<fileset dir="${shadersDirectory}" includes="**/*.glsl" />
+			<glslfiles dir="${shadersDirectory}" includes="**/*.glsl" />
 		</extractShaderComments>
 
 		<!--


### PR DESCRIPTION
I suggest two improvements to glslToJavascript:
- Delete old js files corresponding to glsl files that no longer exist.
- In the generated js file, don't separate each line into a separate string and concatenate it at runtime.

Both of these suggestions come out of looking at a heap dump in Chrome.  I noticed that strings were taking a lot of memory, and the strings at the top of the list had "agi_" names.  But we got rid of those, right?  Well it turned out to be an old generated js file that Chrome was still loading.  Once I deleted the old files, the heap profiler still reported 26k strings with all the ones on the first page being different levels of concatenation of a shader string.  So I think changing how the files are generated a bit will reduce memory usage and shader building time by a decent amount.
