### PR TITLE
BoundingSphere union

### DIFF
--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -287,6 +287,7 @@ define([
     };
 
     var unionScratch = new Cartesian3();
+    var unionScratchCenter = new Cartesian3();
     /**
      * Computes a bounding sphere that contains both the left and right bounding spheres.
      * @memberof BoundingSphere
@@ -315,12 +316,15 @@ define([
         var leftCenter = left.center;
         var rightCenter = right.center;
 
-        var center = Cartesian3.add(leftCenter, rightCenter, result.center);
-        result.center = Cartesian3.multiplyByScalar(center, 0.5, center);
+        Cartesian3.add(leftCenter, rightCenter, unionScratchCenter);
+        var center = Cartesian3.multiplyByScalar(unionScratchCenter, 0.5, unionScratchCenter);
 
         var radius1 = Cartesian3.subtract(leftCenter, center, unionScratch).magnitude() + left.radius;
         var radius2 = Cartesian3.subtract(rightCenter, center, unionScratch).magnitude() + right.radius;
+
         result.radius = Math.max(radius1, radius2);
+        Cartesian3.clone(center, result.center);
+
         return result;
     };
 

--- a/Specs/Core/BoundingSphereSpec.js
+++ b/Specs/Core/BoundingSphereSpec.js
@@ -202,6 +202,14 @@ defineSuite([
         expect(bs1.union(bs2)).toEqual(expected);
     });
 
+    it('union result parameter is caller', function() {
+        var bs1 = new BoundingSphere(Cartesian3.UNIT_X.negate().multiplyByScalar(3.0), 3.0);
+        var bs2 = new BoundingSphere(Cartesian3.UNIT_X, 1.0);
+        var expected = new BoundingSphere(Cartesian3.UNIT_X.negate(), 5.0);
+        bs1.union(bs2, bs1);
+        expect(bs1).toEqual(expected);
+    });
+
     it('expands to contain another point', function() {
         var bs = new BoundingSphere(Cartesian3.UNIT_X.negate(), 1.0);
         var point = Cartesian3.UNIT_X;


### PR DESCRIPTION
Fix `BoundingSphere.union` where the result parameter is the same as another argument, like:

``` javascript
BoundingSphere.union(bs1, bs2, bs1);
BoundingSphere.union(bs1, bs2, bs2);
```

This fixes #274.
