### PR TITLE
Clear the provided framebuffer when rendering.

### DIFF
--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -557,6 +557,7 @@ define([
         var fb = this._pickFramebuffer.begin();
 
         updateFrameState(this);
+        frameState.cullingVolume = getPickCullingVolume(this, windowPosition, rectangleWidth, rectangleHeight);
         frameState.passes.pick = true;
 
         var commandLists = this._commandList;


### PR DESCRIPTION
Fixes #280. Clears the pick framebuffer.
