### PR TITLE
Add a clearState property to renderer commands.

### DIFF
--- a/Apps/Sandcastle/gallery/Custom Rendering.html
+++ b/Apps/Sandcastle/gallery/Custom Rendering.html
@@ -81,8 +81,8 @@ require([
         var ellipsoid = Cesium.Ellipsoid.WGS84;
         this._pickId = undefined;
         
-        this._colorCommand = new Cesium.Command();
-        this._pickCommand = new Cesium.Command();
+        this._colorCommand = new Cesium.DrawCommand();
+        this._pickCommand = new Cesium.DrawCommand();
         this._colorCommand.primitiveType = this._pickCommand.primitiveType = Cesium.PrimitiveType.LINES;
         this._colorCommand.boundingVolume = this._pickCommand.boundingVolume = new Cesium.BoundingSphere();
         this._colorCommand.modelMatrix = this._pickCommand.modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(position);

--- a/Source/Renderer/ClearCommand.js
+++ b/Source/Renderer/ClearCommand.js
@@ -1,0 +1,40 @@
+/*global define*/
+define(['../Core/DeveloperError'], function(DeveloperError) {
+    "use strict";
+
+    /**
+     * Represents a command to the renderer for clearing.
+     *
+     * @alias Command
+     * @constructor
+     *
+     * @param {ClearState} [clearState] The clear state.
+     */
+    var ClearCommand = function(clearState) {
+        /**
+         * The clear state.  If this property is undefined, a default clear state is used.
+         * @type Object
+         */
+        this.clearState = clearState;
+
+        /**
+         * The framebuffer to clear.
+         * @type Framebuffer
+         */
+        this.framebuffer = undefined;
+    };
+
+    /**
+     * Executes the clear command.
+     *
+     * @memberof ClearCommand
+     *
+     * @param {Context} context The renderer context in which to clear.
+     * @param {Framebuffer} [framebuffer] The framebuffer to clear if one is not specified by the command.
+     */
+    ClearCommand.prototype.execute = function(context, framebuffer) {
+        context.clear(this, framebuffer);
+    };
+
+    return ClearCommand;
+});

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -2171,15 +2171,26 @@ define([
     };
 
     /**
-     * DOC_TBA.
+     * Executes the specified clear command.
      *
-     * clearState is optional.
+     * @memberof Context
+     *
+     * @param {ClearCommand} [clearCommand] The command with which to clear.  If this parameter is undefined
+     *        or its clearState property is undefined, a default clear state is used.
+     * @param {Framebuffer} [framebuffer] The framebuffer to clear if one is not specified by the command.
      *
      * @memberof Context
      *
      * @see Context#createClearState
      */
-    Context.prototype.clear = function(clearState) {
+    Context.prototype.clear = function(clearCommand, framebuffer) {
+        var clearState;
+        if (typeof clearCommand !== 'undefined' && typeof clearCommand.clearState !== 'undefined') {
+            clearState = clearCommand.clearState;
+        } else {
+            clearState = this.createClearState();
+        }
+
         var gl = this._gl;
         var bitmask = 0;
 
@@ -2218,7 +2229,7 @@ define([
         this._applyStencilMask(clearState.stencilMask);
         this._applyDither(clearState.dither);
 
-        var framebuffer = clearState.framebuffer;
+        framebuffer = defaultValue(clearState.framebuffer, framebuffer);
 
         if (framebuffer) {
             framebuffer._bind();
@@ -2233,16 +2244,20 @@ define([
     };
 
     /**
-     * DOC_TBA
+     * Executes the specified draw command.
+     *
      * @memberof Context
      *
-     * @param {Command} command The command to execute.
+     * @param {DrawCommand} drawCommand The command with which to draw.
+     * @param {Framebuffer} [framebuffer] The framebuffer to which to draw if one is not specified by the command.
      *
-     * @exception {DeveloperError} command is required.
-     * @exception {DeveloperError} command.primitiveType is required and must be valid.
-     * @exception {DeveloperError} command.shaderProgram is required.
-     * @exception {DeveloperError} command.vertexArray is required.
-     * @exception {DeveloperError} command.offset must be omitted or greater than or equal to zero.
+     * @memberof Context
+     *
+     * @exception {DeveloperError} drawCommand is required.
+     * @exception {DeveloperError} drawCommand.primitiveType is required and must be valid.
+     * @exception {DeveloperError} drawCommand.shaderProgram is required.
+     * @exception {DeveloperError} drawCommand.vertexArray is required.
+     * @exception {DeveloperError} drawCommand.offset must be omitted or greater than or equal to zero.
      * @exception {DeveloperError} Program validation failed.
      * @exception {DeveloperError} Framebuffer is not complete.
      *
@@ -2272,14 +2287,10 @@ define([
      * @see Context#createFramebuffer
      * @see Context#createRenderState
      */
-    Context.prototype.draw = function(command) {
-        if (typeof command.clearState !== 'undefined') {
-            this.clear(command.clearState);
-        } else {
-            this.beginDraw(command);
-            this.continueDraw(command);
-            this.endDraw();
-        }
+    Context.prototype.draw = function(drawCommand, framebuffer) {
+        this.beginDraw(drawCommand, framebuffer);
+        this.continueDraw(drawCommand);
+        this.endDraw();
     };
 
     /**
@@ -2287,7 +2298,7 @@ define([
      *
      * @memberof Context
      */
-    Context.prototype.beginDraw = function(command) {
+    Context.prototype.beginDraw = function(command, framebuffer) {
         if (typeof command === 'undefined') {
             throw new DeveloperError('command is required.');
         }
@@ -2296,7 +2307,7 @@ define([
             throw new DeveloperError('command.shaderProgram is required.');
         }
 
-        var framebuffer = command.framebuffer;
+        framebuffer = defaultValue(command.framebuffer, framebuffer);
         var sp = command.shaderProgram;
         var rs = command.renderState || this.createRenderState();
 

--- a/Source/Renderer/DrawCommand.js
+++ b/Source/Renderer/DrawCommand.js
@@ -8,7 +8,7 @@ define(['../Core/DeveloperError'], function(DeveloperError) {
      * @alias Command
      * @constructor
      */
-    var Command = function() {
+    var DrawCommand = function() {
         /**
          * The bounding volume of the geometry.
          * @type DOC_TBA
@@ -67,18 +67,23 @@ define(['../Core/DeveloperError'], function(DeveloperError) {
         this.renderState = undefined;
 
         /**
-         * The clear state.  If this property is not undefined, this command is a clear only and any
-         * draw-related properties are ignored.
-         * @type Object
-         */
-        this.clearState = undefined;
-
-        /**
          * The framebuffer to draw to.
          * @type Framebuffer
          */
         this.framebuffer = undefined;
     };
 
-    return Command;
+    /**
+     * Executes the draw command.
+     *
+     * @memberof DrawCommand
+     *
+     * @param {Context} context The renderer context in which to draw.
+     * @param {Framebuffer} [framebuffer] The framebuffer to which to draw if one is not specified by the command.
+     */
+    DrawCommand.prototype.execute = function(context, framebuffer) {
+        context.draw(this, framebuffer);
+    };
+
+    return DrawCommand;
 });

--- a/Source/Renderer/PickFramebuffer.js
+++ b/Source/Renderer/PickFramebuffer.js
@@ -4,12 +4,14 @@ define([
         '../Core/destroyObject',
         '../Core/Color',
         '../Core/DeveloperError',
+        './ClearCommand',
         './RenderbufferFormat'
     ], function(
         defaultValue,
         destroyObject,
         Color,
         DeveloperError,
+        ClearCommand,
         RenderbufferFormat) {
     "use strict";
 
@@ -27,6 +29,14 @@ define([
         this._fb = null;
         this._width = 0;
         this._height = 0;
+
+        // Clear to black.  Since this is the background color, no objects will be black
+        this._clearCommand = new ClearCommand();
+        this._clearCommand.clearState = context.createClearState({
+            color : new Color(0.0, 0.0, 0.0, 1.0),
+            depth : 1.0,
+            stencil : 0
+        });
     };
 
     /**
@@ -52,13 +62,7 @@ define([
             });
         }
 
-        // Clear to black.  Since this is the background color, no objects will be black
-        context.clear(context.createClearState({
-            framebuffer : this._fb,
-            color : new Color(0.0, 0.0, 0.0, 1.0),
-            depth : 1.0,
-            stencil : 0
-        }));
+        this._clearCommand.execute(context, this._fb);
 
         return this._fb;
     };

--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -14,8 +14,8 @@ define([
         '../Core/BoundingSphere',
         '../Renderer/BlendingState',
         '../Renderer/BufferUsage',
-        '../Renderer/Command',
         '../Renderer/CommandLists',
+        '../Renderer/DrawCommand',
         '../Renderer/VertexArrayFacade',
         './SceneMode',
         './Billboard',
@@ -37,8 +37,8 @@ define([
         BoundingSphere,
         BlendingState,
         BufferUsage,
-        Command,
         CommandLists,
+        DrawCommand,
         VertexArrayFacade,
         SceneMode,
         Billboard,
@@ -1039,7 +1039,7 @@ define([
             for (j = 0; j < vaLength; ++j) {
                 command = commands[j];
                 if (typeof command === 'undefined') {
-                    command = commands[j] = new Command();
+                    command = commands[j] = new DrawCommand();
                 }
 
                 command.boundingVolume = boundingVolume;
@@ -1071,7 +1071,7 @@ define([
             for (j = 0; j < vaLength; ++j) {
                 command = commands[j];
                 if (typeof command === 'undefined') {
-                    command = commands[j] = new Command();
+                    command = commands[j] = new DrawCommand();
                 }
 
                 command.boundingVolume = boundingVolume;

--- a/Source/Scene/CentralBody.js
+++ b/Source/Scene/CentralBody.js
@@ -30,10 +30,10 @@ define([
         '../Core/JulianDate',
         '../Core/Transforms',
         '../Renderer/BufferUsage',
-        '../Renderer/Command',
         '../Renderer/CommandLists',
         '../Renderer/CullFace',
         '../Renderer/DepthFunction',
+        '../Renderer/DrawCommand',
         '../Renderer/PixelFormat',
         '../Renderer/MipmapHint',
         '../Renderer/TextureMagnificationFilter',
@@ -86,10 +86,10 @@ define([
         JulianDate,
         Transforms,
         BufferUsage,
-        Command,
         CommandLists,
         CullFace,
         DepthFunction,
+        DrawCommand,
         PixelFormat,
         MipmapHint,
         TextureMagnificationFilter,
@@ -256,20 +256,20 @@ define([
         this._rsColor = undefined;
         this._tileCommandList = [];
 
-        this._skyCommand = new Command();
+        this._skyCommand = new DrawCommand();
         this._skyCommand.primitiveType = PrimitiveType.TRIANGLES;
 
         // this._skyCommand.shaderProgram references sky-from-space or sky-from-atmosphere
         this._spSkyFromSpace = undefined;
         this._spSkyFromAtmosphere = undefined;
 
-        this._depthCommand = new Command();
+        this._depthCommand = new DrawCommand();
         this._depthCommand.primitiveType = PrimitiveType.TRIANGLES;
         this._depthCommand.boundingVolume = new BoundingSphere(Cartesian3.ZERO, ellipsoid.getMaximumRadius());
 
-        this._northPoleCommand = new Command();
+        this._northPoleCommand = new DrawCommand();
         this._northPoleCommand.primitiveType = PrimitiveType.TRIANGLE_FAN;
-        this._southPoleCommand = new Command();
+        this._southPoleCommand = new DrawCommand();
         this._southPoleCommand.primitiveType = PrimitiveType.TRIANGLE_FAN;
 
         // this._northPoleCommand.shaderProgram and this.southPoleCommand.shaderProgram reference
@@ -1969,7 +1969,7 @@ define([
 
                     var command = tileCommands[j++];
                     if (typeof command === 'undefined') {
-                        command = tileCommands[j - 1] = new Command();
+                        command = tileCommands[j - 1] = new DrawCommand();
                     }
 
                     command.shaderProgram = this._sp;

--- a/Source/Scene/ComplexConicSensorVolume.js
+++ b/Source/Scene/ComplexConicSensorVolume.js
@@ -13,9 +13,9 @@ define([
         '../Core/BoxTessellator',
         '../Core/BoundingSphere',
         '../Renderer/BufferUsage',
-        '../Renderer/Command',
         '../Renderer/CommandLists',
         '../Renderer/CullFace',
+        '../Renderer/DrawCommand',
         '../Renderer/BlendingState',
         './Material',
         '../Shaders/Noise',
@@ -39,9 +39,9 @@ define([
         BoxTessellator,
         BoundingSphere,
         BufferUsage,
-        Command,
         CommandLists,
         CullFace,
+        DrawCommand,
         BlendingState,
         Material,
         ShadersNoise,
@@ -70,8 +70,8 @@ define([
 
         this._pickId = undefined;
 
-        this._colorCommand = new Command();
-        this._pickCommand = new Command();
+        this._colorCommand = new DrawCommand();
+        this._pickCommand = new DrawCommand();
         this._commandLists = new CommandLists();
 
         this._colorCommand.primitiveType = this._pickCommand.primitiveType = PrimitiveType.TRIANGLES;

--- a/Source/Scene/CustomSensorVolume.js
+++ b/Source/Scene/CustomSensorVolume.js
@@ -13,8 +13,8 @@ define([
         '../Core/BoundingSphere',
         '../Renderer/BufferUsage',
         '../Renderer/BlendingState',
-        '../Renderer/Command',
         '../Renderer/CommandLists',
+        '../Renderer/DrawCommand',
         './Material',
         '../Shaders/Noise',
         '../Shaders/SensorVolume',
@@ -35,8 +35,8 @@ define([
         BoundingSphere,
         BufferUsage,
         BlendingState,
-        Command,
         CommandLists,
+        DrawCommand,
         Material,
         ShadersNoise,
         ShadersSensorVolume,
@@ -64,8 +64,8 @@ define([
         this._pickId = undefined;
         this._pickIdThis = t._pickIdThis || this;
 
-        this._colorCommand = new Command();
-        this._pickCommand = new Command();
+        this._colorCommand = new DrawCommand();
+        this._pickCommand = new DrawCommand();
         this._commandLists = new CommandLists();
 
         this._colorCommand.primitiveType = this._pickCommand.primitiveType = PrimitiveType.TRIANGLES;

--- a/Source/Scene/EllipsoidPrimitive.js
+++ b/Source/Scene/EllipsoidPrimitive.js
@@ -16,8 +16,8 @@ define([
         '../Renderer/CullFace',
         '../Renderer/BlendingState',
         '../Renderer/BufferUsage',
-        '../Renderer/Command',
         '../Renderer/CommandLists',
+        '../Renderer/DrawCommand',
         './Material',
         './SceneMode',
         '../Shaders/Noise',
@@ -40,8 +40,8 @@ define([
         CullFace,
         BlendingState,
         BufferUsage,
-        Command,
         CommandLists,
+        DrawCommand,
         Material,
         SceneMode,
         Noise,
@@ -189,8 +189,8 @@ define([
         this._pickMaterial = undefined;
         this._pickId = undefined;
 
-        this._colorCommand = new Command();
-        this._pickCommand = new Command();
+        this._colorCommand = new DrawCommand();
+        this._pickCommand = new DrawCommand();
         this._commandLists = new CommandLists();
 
         var that = this;

--- a/Source/Scene/Polygon.js
+++ b/Source/Scene/Polygon.js
@@ -21,9 +21,9 @@ define([
         '../Core/Queue',
         '../Renderer/BlendingState',
         '../Renderer/BufferUsage',
-        '../Renderer/Command',
         '../Renderer/CommandLists',
         '../Renderer/CullFace',
+        '../Renderer/DrawCommand',
         '../Renderer/VertexLayout',
         './Material',
         './SceneMode',
@@ -54,9 +54,9 @@ define([
         Queue,
         BlendingState,
         BufferUsage,
-        Command,
         CommandLists,
         CullFace,
+        DrawCommand,
         VertexLayout,
         Material,
         SceneMode,
@@ -723,7 +723,7 @@ define([
             for (var i = 0; i < length; ++i) {
                 command = commands[i];
                 if (typeof command === 'undefined') {
-                    command = commands[i] = new Command();
+                    command = commands[i] = new DrawCommand();
                 }
 
                 command.boundingVolume = boundingVolume;
@@ -769,7 +769,7 @@ define([
             for (var j = 0; j < length; ++j) {
                 command = commands[j];
                 if (typeof command === 'undefined') {
-                    command = commands[j] = new Command();
+                    command = commands[j] = new DrawCommand();
                 }
 
                 command.boundingVolume = boundingVolume;

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -14,8 +14,8 @@ define([
         '../Core/Intersect',
         '../Renderer/BlendingState',
         '../Renderer/BufferUsage',
-        '../Renderer/Command',
         '../Renderer/CommandLists',
+        '../Renderer/DrawCommand',
         './SceneMode',
         './Polyline',
         '../Shaders/PolylineVS',
@@ -37,8 +37,8 @@ define([
         Intersect,
         BlendingState,
         BufferUsage,
-        Command,
         CommandLists,
+        DrawCommand,
         SceneMode,
         Polyline,
         PolylineVS,
@@ -488,7 +488,7 @@ define([
 
                         command = commands[p];
                         if (typeof command === 'undefined') {
-                            command = commands[p] = new Command();
+                            command = commands[p] = new DrawCommand();
                         }
 
                         command.boundingVolume = boundingVolume;
@@ -503,7 +503,7 @@ define([
 
                         command = commands[p + 1];
                         if (typeof command === 'undefined') {
-                            command = commands[p + 1] = new Command();
+                            command = commands[p + 1] = new DrawCommand();
                         }
 
                         command.boundingVolume = boundingVolume;
@@ -518,7 +518,7 @@ define([
 
                         command = commands[p + 2];
                         if (typeof command === 'undefined') {
-                            command = commands[p + 2] = new Command();
+                            command = commands[p + 2] = new DrawCommand();
                         }
 
                         command.boundingVolume = boundingVolume;
@@ -546,7 +546,7 @@ define([
 
                         command = commands[b];
                         if (typeof command === 'undefined') {
-                            command = commands[b] = new Command();
+                            command = commands[b] = new DrawCommand();
                         }
 
                         command.boundingVolume = boundingVolume;

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -17,7 +17,7 @@ define([
         '../Core/Interval',
         '../Core/Matrix4',
         '../Renderer/Context',
-        '../Renderer/Command',
+        '../Renderer/ClearCommand',
         './Camera',
         './CompositePrimitive',
         './CullingVolume',
@@ -45,7 +45,7 @@ define([
         Interval,
         Matrix4,
         Context,
-        Command,
+        ClearCommand,
         Camera,
         CompositePrimitive,
         CullingVolume,
@@ -80,6 +80,16 @@ define([
 
         this._commandList = [];
         this._frustumCommandsList = [];
+
+        this._clearColorCommand = new ClearCommand();
+        this._clearColorCommand.clearState = context.createClearState({
+            color : Color.BLACK
+        });
+        this._clearDepthStencilCommand = new ClearCommand();
+        this._clearDepthStencilCommand.clearState = context.createClearState({
+            depth : 1.0,
+            stencil : 0.0
+        });
 
         /**
          * The current mode of the scene.
@@ -361,7 +371,7 @@ define([
                     // Clear commands don't need a bounding volume - just add the clear to all frustums.
                     // If another command has no bounding volume, though, we need to use the camera's
                     // worst-case near and far planes to avoid clipping something important.
-                    undefBV = typeof command.clearState === 'undefined';
+                    undefBV = !(command instanceof ClearCommand);
                     insertIntoBin(scene, command);
                 }
             }
@@ -386,46 +396,20 @@ define([
         }
     }
 
-    var scratchCommand = new Command();
-
-    function getFinalCommand(command, framebuffer) {
-        // Shadow copy to potentially replace framebuffer
-        scratchCommand.primitiveType = command.primitiveType;
-        scratchCommand.vertexArray = command.vertexArray;
-        scratchCommand.count = command.count;
-        scratchCommand.offset = command.offset;
-        scratchCommand.shaderProgram = command.shaderProgram;
-        scratchCommand.uniformMap = command.uniformMap;
-        scratchCommand.renderState = command.renderState;
-        scratchCommand.framebuffer = defaultValue(command.framebuffer, framebuffer);
-        scratchCommand.boundingVolume = command.boundingVolume;
-        scratchCommand.modelMatrix = command.modelMatrix;
-        scratchCommand.clearState = command.clearState;
-
-        return scratchCommand;
-    }
-
     function executeCommands(scene, framebuffer) {
         var camera = scene._camera;
         var frustum = camera.frustum.clone();
 
         var context = scene._context;
         var us = context.getUniformState();
-        var clearColor = context.createClearState({
-            framebuffer : framebuffer,
-            color : Color.BLACK
-        });
-        var clearDepthStencil = context.createClearState({
-            framebuffer : framebuffer,
-            depth : 1.0,
-            stencil : 0.0
-        });
-        context.clear(clearColor);
+        scene._clearColorCommand.execute(context, framebuffer);
+
+        var clearDepthStencil = scene._clearDepthStencilCommand;
 
         var frustumCommandsList = scene._frustumCommandsList;
         var numFrustums = frustumCommandsList.length;
         for (var i = 0; i < numFrustums; ++i) {
-            context.clear(clearDepthStencil);
+            clearDepthStencil.execute(context, framebuffer);
 
             var index = numFrustums - i - 1.0;
             var frustumCommands = frustumCommandsList[index];
@@ -440,7 +424,7 @@ define([
             var commands = frustumCommands.commands;
             var length = commands.length;
             for (var j = 0; j < length; ++j) {
-                context.draw(getFinalCommand(commands[j], framebuffer));
+                commands[j].execute(context, framebuffer);
             }
         }
     }
@@ -453,7 +437,7 @@ define([
             var commandList = commandLists[i].overlayList;
             var commandListLength = commandList.length;
             for (var j = 0; j < commandListLength; ++j) {
-                context.draw(commandList[j]);
+                commandList[j].execute(context);
             }
         }
     }

--- a/Source/Scene/ViewportQuad.js
+++ b/Source/Scene/ViewportQuad.js
@@ -8,8 +8,8 @@ define([
         '../Renderer/BufferUsage',
         '../Renderer/BlendEquation',
         '../Renderer/BlendFunction',
-        '../Renderer/Command',
         '../Renderer/CommandLists',
+        '../Renderer/DrawCommand',
         '../Shaders/ViewportQuadVS',
         '../Shaders/ViewportQuadFS'
     ], function(
@@ -21,8 +21,8 @@ define([
         BufferUsage,
         BlendEquation,
         BlendFunction,
-        Command,
         CommandLists,
+        DrawCommand,
         ViewportQuadVS,
         ViewportQuadFS) {
     "use strict";
@@ -45,7 +45,7 @@ define([
         this.enableBlending = false;
 
         this._va = undefined;
-        this._overlayCommand = new Command();
+        this._overlayCommand = new DrawCommand();
         this._overlayCommand.primitiveType = PrimitiveType.TRIANGLE_FAN;
         this._commandLists = new CommandLists();
         this._commandLists.overlayList.push(this._overlayCommand);

--- a/Specs/Renderer/ClearSpec.js
+++ b/Specs/Renderer/ClearSpec.js
@@ -1,10 +1,12 @@
 /*global defineSuite*/
 defineSuite([
          'Specs/createContext',
-         'Specs/destroyContext'
+         'Specs/destroyContext',
+         'Renderer/ClearCommand'
      ], 'Renderer/Clear', function(
          createContext,
-         destroyContext) {
+         destroyContext,
+         ClearCommand) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
@@ -27,7 +29,22 @@ defineSuite([
         context.clear();
         expect(context.readPixels()).toEqual([0, 0, 0, 0]);
 
-        context.clear(context.createClearState({
+        context.clear(new ClearCommand(context.createClearState({
+            color : {
+                red : 1.0,
+                green : 1.0,
+                blue : 1.0,
+                alpha : 1.0
+            }
+        })));
+        expect(context.readPixels()).toEqual([255, 255, 255, 255]);
+    });
+
+    it('clears to white by executing a clear command', function() {
+        context.clear();
+        expect(context.readPixels()).toEqual([0, 0, 0, 0]);
+
+        var command = new ClearCommand(context.createClearState({
             color : {
                 red : 1.0,
                 green : 1.0,
@@ -35,23 +52,8 @@ defineSuite([
                 alpha : 1.0
             }
         }));
-        expect(context.readPixels()).toEqual([255, 255, 255, 255]);
-    });
 
-    it('clears to white by drawing a command with a clearState', function() {
-        context.clear();
-        expect(context.readPixels()).toEqual([0, 0, 0, 0]);
-
-        context.draw({
-            clearState : context.createClearState({
-                color : {
-                    red : 1.0,
-                    green : 1.0,
-                    blue : 1.0,
-                    alpha : 1.0
-                }
-            })
-        });
+        command.execute(context);
         expect(context.readPixels()).toEqual([255, 255, 255, 255]);
     });
 
@@ -59,7 +61,7 @@ defineSuite([
         context.clear();
         expect(context.readPixels()).toEqual([0, 0, 0, 0]);
 
-        context.clear(context.createClearState({
+        context.clear(new ClearCommand(context.createClearState({
             color : {
                 red : 1.0,
                 green : 1.0,
@@ -72,22 +74,22 @@ defineSuite([
                 blue : true,
                 alpha : false
             }
-        }));
+        })));
         expect(context.readPixels()).toEqual([255, 0, 255, 0]);
     });
 
     it('clears with scissor test', function() {
-        context.clear(context.createClearState({
+        context.clear(new ClearCommand(context.createClearState({
             color : {
                 red : 1.0,
                 green : 1.0,
                 blue : 1.0,
                 alpha : 1.0
             }
-        }));
+        })));
         expect(context.readPixels()).toEqual([255, 255, 255, 255]);
 
-        context.clear(context.createClearState({
+        context.clear(new ClearCommand(context.createClearState({
             color : {
                 red : 0.0,
                 green : 0.0,
@@ -103,10 +105,10 @@ defineSuite([
                     height : 0
                 }
             }
-        }));
+        })));
         expect(context.readPixels()).toEqual([255, 255, 255, 255]);
 
-        context.clear(context.createClearState({
+        context.clear(new ClearCommand(context.createClearState({
             color : {
                 red : 0.0,
                 green : 0.0,
@@ -122,7 +124,7 @@ defineSuite([
                     height : 1
                 }
             }
-        }));
+        })));
         expect(context.readPixels()).toEqual([0, 0, 0, 0]);
     });
 
@@ -135,7 +137,7 @@ defineSuite([
             colorTexture : colorTexture
         });
 
-        context.clear(context.createClearState({
+        context.clear(new ClearCommand(context.createClearState({
             framebuffer : framebuffer,
             color : {
                 red : 0.0,
@@ -143,7 +145,7 @@ defineSuite([
                 blue : 0.0,
                 alpha : 1.0
             }
-        }));
+        })));
 
         expect(context.readPixels({
             framebuffer : framebuffer
@@ -156,7 +158,7 @@ defineSuite([
         context.clear();
         expect(context.readPixels()).toEqual([0, 0, 0, 0]);
 
-        context.clear(context.createClearState({
+        context.clear(new ClearCommand(context.createClearState({
             color : {
                 red : 1.0,
                 green : 1.0,
@@ -164,10 +166,10 @@ defineSuite([
                 alpha : 1.0
             },
             dither : false
-        }));
+        })));
         expect(context.readPixels()).toEqual([255, 255, 255, 255]);
 
-        context.clear(context.createClearState({
+        context.clear(new ClearCommand(context.createClearState({
             color : {
                 red : 0.0,
                 green : 0.0,
@@ -175,7 +177,7 @@ defineSuite([
                 alpha : 0.0
             },
             dither : true
-        }));
+        })));
         expect(context.readPixels()).toEqual([0, 0, 0, 0]);
     });
 

--- a/Specs/Renderer/CommandListsSpec.js
+++ b/Specs/Renderer/CommandListsSpec.js
@@ -1,10 +1,10 @@
 /*global defineSuite*/
 defineSuite([
          'Renderer/CommandLists',
-         'Renderer/Command'
+         'Renderer/DrawCommand'
      ], function(
          CommandLists,
-         Command) {
+         DrawCommand) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
@@ -12,7 +12,7 @@ defineSuite([
         var list = new CommandLists();
         expect(list.empty()).toEqual(true);
 
-        list.colorList.push(new Command());
+        list.colorList.push(new DrawCommand());
         expect(list.empty()).toEqual(false);
     });
 
@@ -20,7 +20,7 @@ defineSuite([
         var list = new CommandLists();
         expect(list.empty()).toEqual(true);
 
-        list.colorList.push(new Command());
+        list.colorList.push(new DrawCommand());
         expect(list.empty()).toEqual(false);
 
         list.removeAll();

--- a/Specs/Renderer/CommandSpec.js
+++ b/Specs/Renderer/CommandSpec.js
@@ -1,13 +1,13 @@
 /*global defineSuite*/
 defineSuite([
-         'Renderer/Command'
+         'Renderer/DrawCommand'
      ], function(
-         Command) {
+         DrawCommand) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     it('constructs', function() {
-        var c = new Command();
+        var c = new DrawCommand();
         expect(c.boundingVolume).toBeUndefined();
         expect(c.modelMatrix).toBeUndefined();
         expect(c.offset).toBeUndefined();

--- a/Specs/Renderer/CubeMapSpec.js
+++ b/Specs/Renderer/CubeMapSpec.js
@@ -6,6 +6,7 @@ defineSuite([
          'Core/PrimitiveType',
          'Core/Color',
          'Renderer/BufferUsage',
+         'Renderer/ClearCommand',
          'Renderer/PixelDatatype',
          'Renderer/PixelFormat',
          'Renderer/TextureWrap',
@@ -18,6 +19,7 @@ defineSuite([
          PrimitiveType,
          Color,
          BufferUsage,
+         ClearCommand,
          PixelDatatype,
          PixelFormat,
          TextureWrap,
@@ -655,9 +657,9 @@ defineSuite([
         expect(context.readPixels()).toEqual([0, 0, 255, 255]);
 
         // Clear framebuffer to red and copy to +X face
-        context.clear(context.createClearState({
+        context.clear(new ClearCommand(context.createClearState({
             color : new Color (1.0, 0.0, 0.0, 1.0)
-        }));
+        })));
         expect(context.readPixels()).toEqual([255, 0, 0, 255]);
         cubeMap.getPositiveX().copyFromFramebuffer();
 

--- a/Specs/Renderer/DrawSpec.js
+++ b/Specs/Renderer/DrawSpec.js
@@ -8,6 +8,7 @@ defineSuite([
          'Renderer/BufferUsage',
          'Renderer/BlendEquation',
          'Renderer/BlendFunction',
+         'Renderer/ClearCommand',
          'Renderer/CullFace',
          'Renderer/DepthFunction',
          'Renderer/StencilFunction',
@@ -21,6 +22,7 @@ defineSuite([
          BufferUsage,
          BlendEquation,
          BlendFunction,
+         ClearCommand,
          CullFace,
          DepthFunction,
          StencilFunction,
@@ -523,7 +525,7 @@ defineSuite([
         };
 
         // 1 of 2.  Triangle fan passes the depth test.
-        context.clear(context.createClearState({
+        context.clear(new ClearCommand(context.createClearState({
             color : {
                 red : 0.0,
                 green : 0.0,
@@ -531,14 +533,14 @@ defineSuite([
                 alpha : 0.0
             },
             depth : 1.0
-        }));
+        })));
         expect(context.readPixels()).toEqual([0, 0, 0, 0]);
 
         context.draw(da);
         expect(context.readPixels()).toEqual([255, 255, 255, 255]);
 
         // 2 of 2.  Triangle fan fails the depth test.
-        context.clear(context.createClearState({
+        context.clear(new ClearCommand(context.createClearState({
             color : {
                 red : 0.0,
                 green : 0.0,
@@ -546,7 +548,7 @@ defineSuite([
                 alpha : 0.0
             },
             depth : 0.0
-        }));
+        })));
         expect(context.readPixels()).toEqual([0, 0, 0, 0]);
 
         context.draw(da);

--- a/Specs/Renderer/FramebufferSpec.js
+++ b/Specs/Renderer/FramebufferSpec.js
@@ -7,6 +7,7 @@ defineSuite([
          'Renderer/PixelFormat',
          'Renderer/PixelDatatype',
          'Renderer/BufferUsage',
+         'Renderer/ClearCommand',
          'Renderer/DepthFunction',
          'Renderer/RenderbufferFormat',
          'Renderer/StencilFunction',
@@ -19,6 +20,7 @@ defineSuite([
          PixelFormat,
          PixelDatatype,
          BufferUsage,
+         ClearCommand,
          DepthFunction,
          RenderbufferFormat,
          StencilFunction,
@@ -154,7 +156,7 @@ defineSuite([
             colorTexture : colorTexture
         });
 
-        context.clear(context.createClearState({
+        context.clear(new ClearCommand(context.createClearState({
             framebuffer : framebuffer,
             color : {
                 red : 0.0,
@@ -162,7 +164,7 @@ defineSuite([
                 blue : 0.0,
                 alpha : 1.0
             }
-        }));
+        })));
 
         // 3 of 4.  Verify default color buffer is still black.
         expect(context.readPixels()).toEqual([0, 0, 0, 0]);
@@ -205,7 +207,7 @@ defineSuite([
             colorTexture : cubeMap.getPositiveX()
         });
 
-        context.clear(context.createClearState({
+        context.clear(new ClearCommand(context.createClearState({
             framebuffer : framebuffer,
             color : {
                 red : 0.0,
@@ -213,7 +215,7 @@ defineSuite([
                 blue : 0.0,
                 alpha : 1.0
             }
-        }));
+        })));
 
         framebuffer.setColorTexture(undefined);
 

--- a/Specs/Renderer/TextureSpec.js
+++ b/Specs/Renderer/TextureSpec.js
@@ -5,6 +5,7 @@ defineSuite([
          'Core/Cartesian2',
          'Core/PrimitiveType',
          'Renderer/BufferUsage',
+         'Renderer/ClearCommand',
          'Renderer/PixelFormat',
          'Renderer/PixelDatatype',
          'Renderer/TextureWrap',
@@ -16,6 +17,7 @@ defineSuite([
          Cartesian2,
          PrimitiveType,
          BufferUsage,
+         ClearCommand,
          PixelFormat,
          PixelDatatype,
          TextureWrap,
@@ -101,28 +103,28 @@ defineSuite([
     });
 
     it('creates from the framebuffer', function() {
-        context.clear(context.createClearState({
+        context.clear(new ClearCommand(context.createClearState({
             color : {
                 red : 1.0,
                 green : 0.0,
                 blue : 0.0,
                 alpha : 1.0
             }
-        }));
+        })));
         expect(context.readPixels()).toEqual([255, 0, 0, 255]);
 
         texture = context.createTexture2DFromFramebuffer();
         expect(texture.getWidth()).toEqual(context.getCanvas().clientWidth);
         expect(texture.getHeight()).toEqual(context.getCanvas().clientHeight);
 
-        context.clear(context.createClearState({
+        context.clear(new ClearCommand(context.createClearState({
             color : {
                 red : 1.0,
                 green : 1.0,
                 blue : 1.0,
                 alpha : 1.0
             }
-        }));
+        })));
         expect(context.readPixels()).toEqual([255, 255, 255, 255]);
 
         expect(renderFragment(context)).toEqual([255, 0, 0, 255]);
@@ -138,27 +140,27 @@ defineSuite([
         expect(renderFragment(context)).toEqual([0, 0, 255, 255]);
 
         // Clear to red
-        context.clear(context.createClearState({
+        context.clear(new ClearCommand(context.createClearState({
             color : {
                 red : 1.0,
                 green : 0.0,
                 blue : 0.0,
                 alpha : 1.0
             }
-        }));
+        })));
         expect(context.readPixels()).toEqual([255, 0, 0, 255]);
 
         texture.copyFromFramebuffer();
 
         // Clear to white
-        context.clear(context.createClearState({
+        context.clear(new ClearCommand(context.createClearState({
             color : {
                 red : 1.0,
                 green : 1.0,
                 blue : 1.0,
                 alpha : 1.0
             }
-        }));
+        })));
         expect(context.readPixels()).toEqual([255, 255, 255, 255]);
 
         // Render red

--- a/Specs/Scene/MultifrustumSpec.js
+++ b/Specs/Scene/MultifrustumSpec.js
@@ -11,8 +11,8 @@ defineSuite([
          'Core/MeshFilters',
          'Core/PrimitiveType',
          'Renderer/BufferUsage',
-         'Renderer/Command',
          'Renderer/CommandLists',
+         'Renderer/DrawCommand',
          'Renderer/TextureMinificationFilter',
          'Renderer/TextureMagnificationFilter',
          'Scene/BillboardCollection'
@@ -28,8 +28,8 @@ defineSuite([
          MeshFilters,
          PrimitiveType,
          BufferUsage,
-         Command,
          CommandLists,
+         DrawCommand,
          TextureMinificationFilter,
          TextureMagnificationFilter,
          BillboardCollection) {
@@ -210,7 +210,7 @@ defineSuite([
                 this._rs = context.createRenderState();
             }
 
-            var command = new Command();
+            var command = new DrawCommand();
             command.primitiveType = PrimitiveType.TRIANGLES;
             command.renderState = this._rs;
             command.shaderProgram = this._sp;


### PR DESCRIPTION
If the property is set, the command acts as a clear and draw-related
properties are ignored.  A clear command is not required to have a
bounding volume.  If it does, the bounding volume controls the frustums in
which the clear occurs.  If it does not have one, the clear happens in all
frustums but it does NOT force the use of the camera's worst-case near and
far planes.

This is needed to avoid depth-fighting artifacts in the imagery_layers branch.
