### PR TITLE
Cleanup bad DynamicScene tests

### DIFF
--- a/Specs/DynamicScene/DynamicBillboardSpec.js
+++ b/Specs/DynamicScene/DynamicBillboardSpec.js
@@ -115,6 +115,15 @@ defineSuite([
     });
 
     it('mergeProperties does not change a fully configured billboard', function() {
+        var expectedImage = 'image';
+        var expectedScale = 'scale';
+        var expectedHorizontalOrigin = 'horizontalOrigin';
+        var expectedVerticalOrigin = 'verticalOrigin';
+        var expectedColor = 'color';
+        var expectedEyeOffset = 'eyeOffset';
+        var expectedPixelOffset = 'pixelOffset';
+        var expectedShow = 'show';
+
         var objectToMerge = new DynamicObject('objectToMerge');
         objectToMerge.billboard = new DynamicBillboard();
         objectToMerge.billboard.image = 1;
@@ -128,25 +137,25 @@ defineSuite([
 
         var targetObject = new DynamicObject('targetObject');
         targetObject.billboard = new DynamicBillboard();
-        targetObject.billboard.image = 'image';
-        targetObject.billboard.scale = 'scale';
-        targetObject.billboard.horizontalOrigin = 'horizontalOrigin';
-        targetObject.billboard.verticalOrigin = 'verticalOrigin';
-        targetObject.billboard.color = 'color';
-        targetObject.billboard.eyeOffset = 'eyeOffset';
-        targetObject.billboard.pixelOffset = 'pixelOffset';
-        targetObject.billboard.show = 'show';
+        targetObject.billboard.image = expectedImage;
+        targetObject.billboard.scale = expectedScale;
+        targetObject.billboard.horizontalOrigin = expectedHorizontalOrigin;
+        targetObject.billboard.verticalOrigin = expectedVerticalOrigin;
+        targetObject.billboard.color = expectedColor;
+        targetObject.billboard.eyeOffset = expectedEyeOffset;
+        targetObject.billboard.pixelOffset = expectedPixelOffset;
+        targetObject.billboard.show = expectedShow;
 
         DynamicBillboard.mergeProperties(targetObject, objectToMerge);
 
-        expect(targetObject.billboard.image).toEqual(targetObject.billboard.image);
-        expect(targetObject.billboard.scale).toEqual(targetObject.billboard.scale);
-        expect(targetObject.billboard.horizontalOrigin).toEqual(targetObject.billboard.horizontalOrigin);
-        expect(targetObject.billboard.verticalOrigin).toEqual(targetObject.billboard.verticalOrigin);
-        expect(targetObject.billboard.color).toEqual(targetObject.billboard.color);
-        expect(targetObject.billboard.eyeOffset).toEqual(targetObject.billboard.eyeOffset);
-        expect(targetObject.billboard.pixelOffset).toEqual(targetObject.billboard.pixelOffset);
-        expect(targetObject.billboard.show).toEqual(targetObject.billboard.show);
+        expect(targetObject.billboard.image).toEqual(expectedImage);
+        expect(targetObject.billboard.scale).toEqual(expectedScale);
+        expect(targetObject.billboard.horizontalOrigin).toEqual(expectedHorizontalOrigin);
+        expect(targetObject.billboard.verticalOrigin).toEqual(expectedVerticalOrigin);
+        expect(targetObject.billboard.color).toEqual(expectedColor);
+        expect(targetObject.billboard.eyeOffset).toEqual(expectedEyeOffset);
+        expect(targetObject.billboard.pixelOffset).toEqual(expectedPixelOffset);
+        expect(targetObject.billboard.show).toEqual(expectedShow);
     });
 
     it('mergeProperties creates and configures an undefined billboard', function() {
@@ -176,29 +185,38 @@ defineSuite([
     });
 
     it('mergeProperties does not change when used with an undefined billboard', function() {
+        var expectedImage = 'image';
+        var expectedScale = 'scale';
+        var expectedHorizontalOrigin = 'horizontalOrigin';
+        var expectedVerticalOrigin = 'verticalOrigin';
+        var expectedColor = 'color';
+        var expectedEyeOffset = 'eyeOffset';
+        var expectedPixelOffset = 'pixelOffset';
+        var expectedShow = 'show';
+
         var objectToMerge = new DynamicObject('objectToMerge');
 
         var targetObject = new DynamicObject('targetObject');
         targetObject.billboard = new DynamicBillboard();
-        targetObject.billboard.image = 'image';
-        targetObject.billboard.scale = 'scale';
-        targetObject.billboard.horizontalOrigin = 'horizontalOrigin';
-        targetObject.billboard.verticalOrigin = 'verticalOrigin';
-        targetObject.billboard.color = 'color';
-        targetObject.billboard.eyeOffset = 'eyeOffset';
-        targetObject.billboard.pixelOffset = 'pixelOffset';
-        targetObject.billboard.show = 'show';
+        targetObject.billboard.image = expectedImage;
+        targetObject.billboard.scale = expectedScale;
+        targetObject.billboard.horizontalOrigin = expectedHorizontalOrigin;
+        targetObject.billboard.verticalOrigin = expectedVerticalOrigin;
+        targetObject.billboard.color = expectedColor;
+        targetObject.billboard.eyeOffset = expectedEyeOffset;
+        targetObject.billboard.pixelOffset = expectedPixelOffset;
+        targetObject.billboard.show = expectedShow;
 
         DynamicBillboard.mergeProperties(targetObject, objectToMerge);
 
-        expect(targetObject.billboard.image).toEqual(targetObject.billboard.image);
-        expect(targetObject.billboard.scale).toEqual(targetObject.billboard.scale);
-        expect(targetObject.billboard.horizontalOrigin).toEqual(targetObject.billboard.horizontalOrigin);
-        expect(targetObject.billboard.verticalOrigin).toEqual(targetObject.billboard.verticalOrigin);
-        expect(targetObject.billboard.color).toEqual(targetObject.billboard.color);
-        expect(targetObject.billboard.eyeOffset).toEqual(targetObject.billboard.eyeOffset);
-        expect(targetObject.billboard.pixelOffset).toEqual(targetObject.billboard.pixelOffset);
-        expect(targetObject.billboard.show).toEqual(targetObject.billboard.show);
+        expect(targetObject.billboard.image).toEqual(expectedImage);
+        expect(targetObject.billboard.scale).toEqual(expectedScale);
+        expect(targetObject.billboard.horizontalOrigin).toEqual(expectedHorizontalOrigin);
+        expect(targetObject.billboard.verticalOrigin).toEqual(expectedVerticalOrigin);
+        expect(targetObject.billboard.color).toEqual(expectedColor);
+        expect(targetObject.billboard.eyeOffset).toEqual(expectedEyeOffset);
+        expect(targetObject.billboard.pixelOffset).toEqual(expectedPixelOffset);
+        expect(targetObject.billboard.show).toEqual(expectedShow);
     });
 
     it('undefineProperties works', function() {

--- a/Specs/DynamicScene/DynamicConeSpec.js
+++ b/Specs/DynamicScene/DynamicConeSpec.js
@@ -173,50 +173,63 @@ defineSuite([
     });
 
     it('mergeProperties does not change a fully configured cone', function() {
+        var expectedCapMaterial = 13;
+        var expectedInnerHalfAngle = 14;
+        var expectedInnerMaterial = 15;
+        var expectedIntersectionColor = 16;
+        var expectedMaximumClockAngle = 17;
+        var expectedMinimumClockAngle = 18;
+        var expectedOuterHalfAngle = 19;
+        var expectedOuterMaterial = 20;
+        var expectedRadius = 21;
+        var expectedShow = 22;
+        var expectedShowIntersection = 23;
+        var expectedSilhouetteMaterial = 24;
+
         var objectToMerge = new DynamicObject('objectToMerge');
         objectToMerge.cone = new DynamicCone();
-        objectToMerge.capMaterial = 1;
-        objectToMerge.innerHalfAngle = 2;
-        objectToMerge.innerMaterial = 3;
-        objectToMerge.intersectionColor = 4;
-        objectToMerge.maximumClockAngle = 5;
-        objectToMerge.minimumClockAngle = 6;
-        objectToMerge.outerHalfAngle = 7;
-        objectToMerge.outerMaterial = 8;
-        objectToMerge.radius = 9;
-        objectToMerge.show = 10;
-        objectToMerge.showIntersection = 11;
-        objectToMerge.silhouetteMaterial = 12;
+        objectToMerge.cone.capMaterial = 1;
+        objectToMerge.cone.innerHalfAngle = 2;
+        objectToMerge.cone.innerMaterial = 3;
+        objectToMerge.cone.intersectionColor = 4;
+        objectToMerge.cone.maximumClockAngle = 5;
+        objectToMerge.cone.minimumClockAngle = 6;
+        objectToMerge.cone.outerHalfAngle = 7;
+        objectToMerge.cone.outerMaterial = 8;
+        objectToMerge.cone.radius = 9;
+        objectToMerge.cone.show = 10;
+        objectToMerge.cone.showIntersection = 11;
+        objectToMerge.cone.silhouetteMaterial = 12;
 
         var targetObject = new DynamicObject('targetObject');
         targetObject.cone = new DynamicCone();
-        targetObject.capMaterial = 13;
-        targetObject.innerHalfAngle = 14;
-        targetObject.innerMaterial = 15;
-        targetObject.intersectionColor = 16;
-        targetObject.maximumClockAngle = 17;
-        targetObject.minimumClockAngle = 18;
-        targetObject.outerHalfAngle = 19;
-        targetObject.outerMaterial = 20;
-        targetObject.radius = 21;
-        targetObject.show = 22;
-        targetObject.showIntersection = 23;
-        targetObject.silhouetteMaterial = 24;
+        targetObject.cone.capMaterial = expectedCapMaterial;
+        targetObject.cone.innerHalfAngle = expectedInnerHalfAngle;
+        targetObject.cone.innerMaterial = expectedInnerMaterial;
+        targetObject.cone.intersectionColor = expectedIntersectionColor;
+        targetObject.cone.maximumClockAngle = expectedMaximumClockAngle;
+        targetObject.cone.minimumClockAngle = expectedMinimumClockAngle;
+        targetObject.cone.outerHalfAngle = expectedOuterHalfAngle;
+        targetObject.cone.outerMaterial = expectedOuterMaterial;
+        targetObject.cone.radius = expectedRadius;
+        targetObject.cone.show = expectedShow;
+        targetObject.cone.showIntersection = expectedShowIntersection;
+        targetObject.cone.silhouetteMaterial = expectedSilhouetteMaterial;
 
         DynamicCone.mergeProperties(targetObject, objectToMerge);
 
-        expect(targetObject.cone.capMaterial).toEqual(targetObject.cone.capMaterial);
-        expect(targetObject.cone.innerHalfAngle).toEqual(targetObject.cone.innerHalfAngle);
-        expect(targetObject.cone.innerMaterial).toEqual(targetObject.cone.innerMaterial);
-        expect(targetObject.cone.intersectionColor).toEqual(targetObject.cone.intersectionColor);
-        expect(targetObject.cone.maximumClockAngle).toEqual(targetObject.cone.maximumClockAngle);
-        expect(targetObject.cone.minimumClockAngle).toEqual(targetObject.cone.minimumClockAngle);
-        expect(targetObject.cone.outerHalfAngle).toEqual(targetObject.cone.outerHalfAngle);
-        expect(targetObject.cone.outerMaterial).toEqual(targetObject.cone.outerMaterial);
-        expect(targetObject.cone.radius).toEqual(targetObject.cone.radius);
-        expect(targetObject.cone.show).toEqual(targetObject.cone.show);
-        expect(targetObject.cone.showIntersection).toEqual(targetObject.cone.showIntersection);
-        expect(targetObject.cone.silhouetteMaterial).toEqual(targetObject.cone.silhouetteMaterial);
+        expect(targetObject.cone.capMaterial).toEqual(expectedCapMaterial);
+        expect(targetObject.cone.innerHalfAngle).toEqual(expectedInnerHalfAngle);
+        expect(targetObject.cone.innerMaterial).toEqual(expectedInnerMaterial);
+        expect(targetObject.cone.intersectionColor).toEqual(expectedIntersectionColor);
+        expect(targetObject.cone.maximumClockAngle).toEqual(expectedMaximumClockAngle);
+        expect(targetObject.cone.minimumClockAngle).toEqual(expectedMinimumClockAngle);
+        expect(targetObject.cone.outerHalfAngle).toEqual(expectedOuterHalfAngle);
+        expect(targetObject.cone.outerMaterial).toEqual(expectedOuterMaterial);
+        expect(targetObject.cone.radius).toEqual(expectedRadius);
+        expect(targetObject.cone.show).toEqual(expectedShow);
+        expect(targetObject.cone.showIntersection).toEqual(expectedShowIntersection);
+        expect(targetObject.cone.silhouetteMaterial).toEqual(expectedSilhouetteMaterial);
     });
 
     it('mergeProperties creates and configures an undefined cone', function() {
@@ -254,33 +267,50 @@ defineSuite([
     });
 
     it('mergeProperties does not change when used with an undefined cone', function() {
+        var expectedCapMaterial = 13;
+        var expectedInnerHalfAngle = 14;
+        var expectedInnerMaterial = 15;
+        var expectedIntersectionColor = 16;
+        var expectedMaximumClockAngle = 17;
+        var expectedMinimumClockAngle = 18;
+        var expectedOuterHalfAngle = 19;
+        var expectedOuterMaterial = 20;
+        var expectedRadius = 21;
+        var expectedShow = 22;
+        var expectedShowIntersection = 23;
+        var expectedSilhouetteMaterial = 24;
+
         var objectToMerge = new DynamicObject('objectToMerge');
 
         var targetObject = new DynamicObject('targetObject');
         targetObject.cone = new DynamicCone();
-        targetObject.cone.image = 'image';
-        targetObject.cone.scale = 'scale';
-        targetObject.cone.horizontalOrigin = 'horizontalOrigin';
-        targetObject.cone.verticalOrigin = 'verticalOrigin';
-        targetObject.cone.color = 'color';
-        targetObject.cone.eyeOffset = 'eyeOffset';
-        targetObject.cone.pixelOffset = 'pixelOffset';
-        targetObject.cone.show = 'show';
+        targetObject.cone.capMaterial = expectedCapMaterial;
+        targetObject.cone.innerHalfAngle = expectedInnerHalfAngle;
+        targetObject.cone.innerMaterial = expectedInnerMaterial;
+        targetObject.cone.intersectionColor = expectedIntersectionColor;
+        targetObject.cone.maximumClockAngle = expectedMaximumClockAngle;
+        targetObject.cone.minimumClockAngle = expectedMinimumClockAngle;
+        targetObject.cone.outerHalfAngle = expectedOuterHalfAngle;
+        targetObject.cone.outerMaterial = expectedOuterMaterial;
+        targetObject.cone.radius = expectedRadius;
+        targetObject.cone.show = expectedShow;
+        targetObject.cone.showIntersection = expectedShowIntersection;
+        targetObject.cone.silhouetteMaterial = expectedSilhouetteMaterial;
 
         DynamicCone.mergeProperties(targetObject, objectToMerge);
 
-        expect(targetObject.cone.capMaterial).toEqual(targetObject.cone.capMaterial);
-        expect(targetObject.cone.innerHalfAngle).toEqual(targetObject.cone.innerHalfAngle);
-        expect(targetObject.cone.innerMaterial).toEqual(targetObject.cone.innerMaterial);
-        expect(targetObject.cone.intersectionColor).toEqual(targetObject.cone.intersectionColor);
-        expect(targetObject.cone.maximumClockAngle).toEqual(targetObject.cone.maximumClockAngle);
-        expect(targetObject.cone.minimumClockAngle).toEqual(targetObject.cone.minimumClockAngle);
-        expect(targetObject.cone.outerHalfAngle).toEqual(targetObject.cone.outerHalfAngle);
-        expect(targetObject.cone.outerMaterial).toEqual(targetObject.cone.outerMaterial);
-        expect(targetObject.cone.radius).toEqual(targetObject.cone.radius);
-        expect(targetObject.cone.show).toEqual(targetObject.cone.show);
-        expect(targetObject.cone.showIntersection).toEqual(targetObject.cone.showIntersection);
-        expect(targetObject.cone.silhouetteMaterial).toEqual(targetObject.cone.silhouetteMaterial);
+        expect(targetObject.cone.capMaterial).toEqual(expectedCapMaterial);
+        expect(targetObject.cone.innerHalfAngle).toEqual(expectedInnerHalfAngle);
+        expect(targetObject.cone.innerMaterial).toEqual(expectedInnerMaterial);
+        expect(targetObject.cone.intersectionColor).toEqual(expectedIntersectionColor);
+        expect(targetObject.cone.maximumClockAngle).toEqual(expectedMaximumClockAngle);
+        expect(targetObject.cone.minimumClockAngle).toEqual(expectedMinimumClockAngle);
+        expect(targetObject.cone.outerHalfAngle).toEqual(expectedOuterHalfAngle);
+        expect(targetObject.cone.outerMaterial).toEqual(expectedOuterMaterial);
+        expect(targetObject.cone.radius).toEqual(expectedRadius);
+        expect(targetObject.cone.show).toEqual(expectedShow);
+        expect(targetObject.cone.showIntersection).toEqual(expectedShowIntersection);
+        expect(targetObject.cone.silhouetteMaterial).toEqual(expectedSilhouetteMaterial);
     });
 
     it('undefineProperties works', function() {

--- a/Specs/DynamicScene/DynamicLabelSpec.js
+++ b/Specs/DynamicScene/DynamicLabelSpec.js
@@ -132,47 +132,59 @@ defineSuite([
     });
 
     it('mergeProperties does not change a fully configured label', function() {
+        var expectedText = 12;
+        var expectedFont = 13;
+        var expectedStyle = 14;
+        var expectedFillColor = 15;
+        var expectedOutlineColor = 16;
+        var expectedHorizontalOrigin = 17;
+        var expectedVerticalOrigin = 18;
+        var expectedEyeOffset = 19;
+        var expectedPixelOffset = 20;
+        var expectedScale = 21;
+        var expectedShow = 22;
+
         var objectToMerge = new DynamicObject('objectToMerge');
         objectToMerge.label = new DynamicLabel();
-        objectToMerge.text = 1;
-        objectToMerge.font = 2;
-        objectToMerge.style = 3;
-        objectToMerge.fillColor = 4;
-        objectToMerge.outlineColor = 5;
-        objectToMerge.horizontalOrigin = 6;
-        objectToMerge.verticalOrigin = 7;
-        objectToMerge.eyeOffset = 8;
-        objectToMerge.pixelOffset = 9;
-        objectToMerge.scale = 10;
-        objectToMerge.show = 11;
+        objectToMerge.label.text = 1;
+        objectToMerge.label.font = 2;
+        objectToMerge.label.style = 3;
+        objectToMerge.label.fillColor = 4;
+        objectToMerge.label.outlineColor = 5;
+        objectToMerge.label.horizontalOrigin = 6;
+        objectToMerge.label.verticalOrigin = 7;
+        objectToMerge.label.eyeOffset = 8;
+        objectToMerge.label.pixelOffset = 9;
+        objectToMerge.label.scale = 10;
+        objectToMerge.label.show = 11;
 
         var targetObject = new DynamicObject('targetObject');
         targetObject.label = new DynamicLabel();
-        targetObject.text = 12;
-        targetObject.font = 13;
-        targetObject.style = 14;
-        targetObject.fillColor = 15;
-        targetObject.outlineColor = 16;
-        targetObject.horizontalOrigin = 17;
-        targetObject.verticalOrigin = 18;
-        targetObject.eyeOffset = 19;
-        targetObject.pixelOffset = 20;
-        targetObject.scale = 21;
-        targetObject.show = 22;
+        targetObject.label.text = expectedText;
+        targetObject.label.font = expectedFont;
+        targetObject.label.style = expectedStyle;
+        targetObject.label.fillColor = expectedFillColor;
+        targetObject.label.outlineColor = expectedOutlineColor;
+        targetObject.label.horizontalOrigin = expectedHorizontalOrigin;
+        targetObject.label.verticalOrigin = expectedVerticalOrigin;
+        targetObject.label.eyeOffset = expectedEyeOffset;
+        targetObject.label.pixelOffset = expectedPixelOffset;
+        targetObject.label.scale = expectedScale;
+        targetObject.label.show = expectedShow;
 
         DynamicLabel.mergeProperties(targetObject, objectToMerge);
 
-        expect(targetObject.label.text).toEqual(targetObject.label.text);
-        expect(targetObject.label.font).toEqual(targetObject.label.font);
-        expect(targetObject.label.style).toEqual(targetObject.label.style);
-        expect(targetObject.label.fillColor).toEqual(targetObject.label.fillColor);
-        expect(targetObject.label.outlineColor).toEqual(targetObject.label.outlineColor);
-        expect(targetObject.label.horizontalOrigin).toEqual(targetObject.label.horizontalOrigin);
-        expect(targetObject.label.verticalOrigin).toEqual(targetObject.label.verticalOrigin);
-        expect(targetObject.label.eyeOffset).toEqual(targetObject.label.eyeOffset);
-        expect(targetObject.label.pixelOffset).toEqual(targetObject.label.pixelOffset);
-        expect(targetObject.label.scale).toEqual(targetObject.label.scale);
-        expect(targetObject.label.show).toEqual(targetObject.label.show);
+        expect(targetObject.label.text).toEqual(expectedText);
+        expect(targetObject.label.font).toEqual(expectedFont);
+        expect(targetObject.label.style).toEqual(expectedStyle);
+        expect(targetObject.label.fillColor).toEqual(expectedFillColor);
+        expect(targetObject.label.outlineColor).toEqual(expectedOutlineColor);
+        expect(targetObject.label.horizontalOrigin).toEqual(expectedHorizontalOrigin);
+        expect(targetObject.label.verticalOrigin).toEqual(expectedVerticalOrigin);
+        expect(targetObject.label.eyeOffset).toEqual(expectedEyeOffset);
+        expect(targetObject.label.pixelOffset).toEqual(expectedPixelOffset);
+        expect(targetObject.label.scale).toEqual(expectedScale);
+        expect(targetObject.label.show).toEqual(expectedShow);
     });
 
     it('mergeProperties creates and configures an undefined label', function() {
@@ -208,35 +220,47 @@ defineSuite([
     });
 
     it('mergeProperties does not change when used with an undefined label', function() {
+        var expectedText = 12;
+        var expectedFont = 13;
+        var expectedStyle = 14;
+        var expectedFillColor = 15;
+        var expectedOutlineColor = 16;
+        var expectedHorizontalOrigin = 17;
+        var expectedVerticalOrigin = 18;
+        var expectedEyeOffset = 19;
+        var expectedPixelOffset = 20;
+        var expectedScale = 21;
+        var expectedShow = 22;
+
         var objectToMerge = new DynamicObject('objectToMerge');
 
         var targetObject = new DynamicObject('targetObject');
         targetObject.label = new DynamicLabel();
-        targetObject.text = 1;
-        targetObject.font = 2;
-        targetObject.style = 3;
-        targetObject.fillColor = 4;
-        targetObject.outlineColor = 5;
-        targetObject.horizontalOrigin = 6;
-        targetObject.verticalOrigin = 7;
-        targetObject.eyeOffset = 8;
-        targetObject.pixelOffset = 9;
-        targetObject.scale = 10;
-        targetObject.show = 11;
+        targetObject.label.text = expectedText;
+        targetObject.label.font = expectedFont;
+        targetObject.label.style = expectedStyle;
+        targetObject.label.fillColor = expectedFillColor;
+        targetObject.label.outlineColor = expectedOutlineColor;
+        targetObject.label.horizontalOrigin = expectedHorizontalOrigin;
+        targetObject.label.verticalOrigin = expectedVerticalOrigin;
+        targetObject.label.eyeOffset = expectedEyeOffset;
+        targetObject.label.pixelOffset = expectedPixelOffset;
+        targetObject.label.scale = expectedScale;
+        targetObject.label.show = expectedShow;
 
         DynamicLabel.mergeProperties(targetObject, objectToMerge);
 
-        expect(targetObject.label.text).toEqual(targetObject.label.text);
-        expect(targetObject.label.font).toEqual(targetObject.label.font);
-        expect(targetObject.label.style).toEqual(targetObject.label.style);
-        expect(targetObject.label.fillColor).toEqual(targetObject.label.fillColor);
-        expect(targetObject.label.outlineColor).toEqual(targetObject.label.outlineColor);
-        expect(targetObject.label.horizontalOrigin).toEqual(targetObject.label.horizontalOrigin);
-        expect(targetObject.label.verticalOrigin).toEqual(targetObject.label.verticalOrigin);
-        expect(targetObject.label.eyeOffset).toEqual(targetObject.label.eyeOffset);
-        expect(targetObject.label.pixelOffset).toEqual(targetObject.label.pixelOffset);
-        expect(targetObject.label.scale).toEqual(targetObject.label.scale);
-        expect(targetObject.label.show).toEqual(targetObject.label.show);
+        expect(targetObject.label.text).toEqual(expectedText);
+        expect(targetObject.label.font).toEqual(expectedFont);
+        expect(targetObject.label.style).toEqual(expectedStyle);
+        expect(targetObject.label.fillColor).toEqual(expectedFillColor);
+        expect(targetObject.label.outlineColor).toEqual(expectedOutlineColor);
+        expect(targetObject.label.horizontalOrigin).toEqual(expectedHorizontalOrigin);
+        expect(targetObject.label.verticalOrigin).toEqual(expectedVerticalOrigin);
+        expect(targetObject.label.eyeOffset).toEqual(expectedEyeOffset);
+        expect(targetObject.label.pixelOffset).toEqual(expectedPixelOffset);
+        expect(targetObject.label.scale).toEqual(expectedScale);
+        expect(targetObject.label.show).toEqual(expectedShow);
     });
 
     it('undefineProperties works', function() {

--- a/Specs/DynamicScene/DynamicPointSpec.js
+++ b/Specs/DynamicScene/DynamicPointSpec.js
@@ -96,19 +96,19 @@ defineSuite([
 
         var targetObject = new DynamicObject('targetObject');
         targetObject.point = new DynamicPoint();
-        objectToMerge.point.color = 6;
-        objectToMerge.point.pixelSize = 7;
-        objectToMerge.point.outlineColor = 8;
-        objectToMerge.point.outlineWidth = 9;
-        objectToMerge.point.show = 10;
+        targetObject.point.color = 6;
+        targetObject.point.pixelSize = 7;
+        targetObject.point.outlineColor = 8;
+        targetObject.point.outlineWidth = 9;
+        targetObject.point.show = 10;
 
         DynamicPoint.mergeProperties(targetObject, objectToMerge);
 
-        expect(targetObject.point.color).toEqual(targetObject.point.color);
-        expect(targetObject.point.pixelSize).toEqual(targetObject.point.pixelSize);
-        expect(targetObject.point.outlineColor).toEqual(targetObject.point.outlineColor);
-        expect(targetObject.point.outlineWidth).toEqual(targetObject.point.outlineWidth);
-        expect(targetObject.point.show).toEqual(targetObject.point.show);
+        expect(targetObject.point.color).toEqual(6);
+        expect(targetObject.point.pixelSize).toEqual(7);
+        expect(targetObject.point.outlineColor).toEqual(8);
+        expect(targetObject.point.outlineWidth).toEqual(9);
+        expect(targetObject.point.show).toEqual(10);
     });
 
     it('mergeProperties creates and configures an undefined point', function() {
@@ -136,22 +136,19 @@ defineSuite([
 
         var targetObject = new DynamicObject('targetObject');
         targetObject.point = new DynamicPoint();
-        targetObject.point = new DynamicPoint();
-        targetObject.point.color = 1;
-        targetObject.point.pixelSize = 2;
-        targetObject.point.outlineColor = 3;
-        targetObject.point.outlineWidth = 4;
-        targetObject.point.show = 5;
+        targetObject.point.color = 6;
+        targetObject.point.pixelSize = 7;
+        targetObject.point.outlineColor = 8;
+        targetObject.point.outlineWidth = 9;
+        targetObject.point.show = 10;
 
         DynamicPoint.mergeProperties(targetObject, objectToMerge);
 
-        expect(targetObject.point.scale).toEqual(targetObject.point.scale);
-        expect(targetObject.point.horizontalOrigin).toEqual(targetObject.point.horizontalOrigin);
-        expect(targetObject.point.verticalOrigin).toEqual(targetObject.point.verticalOrigin);
-        expect(targetObject.point.color).toEqual(targetObject.point.color);
-        expect(targetObject.point.eyeOffset).toEqual(targetObject.point.eyeOffset);
-        expect(targetObject.point.pixelOffset).toEqual(targetObject.point.pixelOffset);
-        expect(targetObject.point.show).toEqual(targetObject.point.show);
+        expect(targetObject.point.color).toEqual(6);
+        expect(targetObject.point.pixelSize).toEqual(7);
+        expect(targetObject.point.outlineColor).toEqual(8);
+        expect(targetObject.point.outlineWidth).toEqual(9);
+        expect(targetObject.point.show).toEqual(10);
     });
 
     it('undefineProperties works', function() {

--- a/Specs/DynamicScene/DynamicPolygonSpec.js
+++ b/Specs/DynamicScene/DynamicPolygonSpec.js
@@ -82,13 +82,13 @@ defineSuite([
 
         var targetObject = new DynamicObject('targetObject');
         targetObject.polygon = new DynamicPolygon();
-        objectToMerge.polygon.material = 3;
-        objectToMerge.polygon.show = 4;
+        targetObject.polygon.material = 3;
+        targetObject.polygon.show = 4;
 
         DynamicPolygon.mergeProperties(targetObject, objectToMerge);
 
-        expect(targetObject.polygon.material).toEqual(targetObject.polygon.material);
-        expect(targetObject.polygon.show).toEqual(targetObject.polygon.show);
+        expect(targetObject.polygon.material).toEqual(3);
+        expect(targetObject.polygon.show).toEqual(4);
     });
 
     it('mergeProperties creates and configures an undefined polygon', function() {
@@ -110,14 +110,13 @@ defineSuite([
 
         var targetObject = new DynamicObject('targetObject');
         targetObject.polygon = new DynamicPolygon();
-        targetObject.polygon = new DynamicPolygon();
-        targetObject.polygon.material = 1;
-        targetObject.polygon.show = 2;
+        targetObject.polygon.material = 3;
+        targetObject.polygon.show = 4;
 
         DynamicPolygon.mergeProperties(targetObject, objectToMerge);
 
-        expect(targetObject.polygon.image).toEqual(targetObject.polygon.image);
-        expect(targetObject.polygon.show).toEqual(targetObject.polygon.show);
+        expect(targetObject.polygon.material).toEqual(3);
+        expect(targetObject.polygon.show).toEqual(4);
     });
 
     it('undefineProperties works', function() {

--- a/Specs/DynamicScene/DynamicPolylineSpec.js
+++ b/Specs/DynamicScene/DynamicPolylineSpec.js
@@ -96,19 +96,19 @@ defineSuite([
 
         var targetObject = new DynamicObject('targetObject');
         targetObject.polyline = new DynamicPolyline();
-        objectToMerge.polyline.color = 6;
-        objectToMerge.polyline.width = 7;
-        objectToMerge.polyline.outlineColor = 8;
-        objectToMerge.polyline.outlineWidth = 9;
-        objectToMerge.polyline.show = 10;
+        targetObject.polyline.color = 6;
+        targetObject.polyline.width = 7;
+        targetObject.polyline.outlineColor = 8;
+        targetObject.polyline.outlineWidth = 9;
+        targetObject.polyline.show = 10;
 
         DynamicPolyline.mergeProperties(targetObject, objectToMerge);
 
-        expect(targetObject.polyline.color).toEqual(targetObject.polyline.color);
-        expect(targetObject.polyline.width).toEqual(targetObject.polyline.width);
-        expect(targetObject.polyline.outlineColor).toEqual(targetObject.polyline.outlineColor);
-        expect(targetObject.polyline.outlineWidth).toEqual(targetObject.polyline.outlineWidth);
-        expect(targetObject.polyline.show).toEqual(targetObject.polyline.show);
+        expect(targetObject.polyline.color).toEqual(6);
+        expect(targetObject.polyline.width).toEqual(7);
+        expect(targetObject.polyline.outlineColor).toEqual(8);
+        expect(targetObject.polyline.outlineWidth).toEqual(9);
+        expect(targetObject.polyline.show).toEqual(10);
     });
 
     it('mergeProperties creates and configures an undefined polyline', function() {
@@ -136,22 +136,19 @@ defineSuite([
 
         var targetObject = new DynamicObject('targetObject');
         targetObject.polyline = new DynamicPolyline();
-        targetObject.polyline = new DynamicPolyline();
-        targetObject.polyline.color = 1;
-        targetObject.polyline.width = 2;
-        targetObject.polyline.outlineColor = 3;
-        targetObject.polyline.outlineWidth = 4;
-        targetObject.polyline.show = 5;
+        targetObject.polyline.color = 6;
+        targetObject.polyline.width = 7;
+        targetObject.polyline.outlineColor = 8;
+        targetObject.polyline.outlineWidth = 9;
+        targetObject.polyline.show = 10;
 
         DynamicPolyline.mergeProperties(targetObject, objectToMerge);
 
-        expect(targetObject.polyline.scale).toEqual(targetObject.polyline.scale);
-        expect(targetObject.polyline.horizontalOrigin).toEqual(targetObject.polyline.horizontalOrigin);
-        expect(targetObject.polyline.verticalOrigin).toEqual(targetObject.polyline.verticalOrigin);
-        expect(targetObject.polyline.color).toEqual(targetObject.polyline.color);
-        expect(targetObject.polyline.eyeOffset).toEqual(targetObject.polyline.eyeOffset);
-        expect(targetObject.polyline.pixelOffset).toEqual(targetObject.polyline.pixelOffset);
-        expect(targetObject.polyline.show).toEqual(targetObject.polyline.show);
+        expect(targetObject.polyline.color).toEqual(6);
+        expect(targetObject.polyline.width).toEqual(7);
+        expect(targetObject.polyline.outlineColor).toEqual(8);
+        expect(targetObject.polyline.outlineWidth).toEqual(9);
+        expect(targetObject.polyline.show).toEqual(10);
     });
 
     it('undefineProperties works', function() {

--- a/Specs/DynamicScene/DynamicPyramidSpec.js
+++ b/Specs/DynamicScene/DynamicPyramidSpec.js
@@ -111,30 +111,30 @@ defineSuite([
     it('mergeProperties does not change a fully configured pyramid', function() {
         var objectToMerge = new DynamicObject('objectToMerge');
         objectToMerge.pyramid = new DynamicPyramid();
-        objectToMerge.material = 1;
-        objectToMerge.directions = 2;
-        objectToMerge.intersectionColor = 3;
-        objectToMerge.radius = 4;
-        objectToMerge.show = 5;
-        objectToMerge.showIntersection = 6;
+        objectToMerge.pyramid.material = 1;
+        objectToMerge.pyramid.directions = 2;
+        objectToMerge.pyramid.intersectionColor = 3;
+        objectToMerge.pyramid.radius = 4;
+        objectToMerge.pyramid.show = 5;
+        objectToMerge.pyramid.showIntersection = 6;
 
         var targetObject = new DynamicObject('targetObject');
         targetObject.pyramid = new DynamicPyramid();
-        targetObject.material = 7;
-        targetObject.directions = 8;
-        targetObject.intersectionColor = 9;
-        targetObject.radius = 10;
-        targetObject.show = 11;
-        targetObject.showIntersection = 12;
+        targetObject.pyramid.material = 7;
+        targetObject.pyramid.directions = 8;
+        targetObject.pyramid.intersectionColor = 9;
+        targetObject.pyramid.radius = 10;
+        targetObject.pyramid.show = 11;
+        targetObject.pyramid.showIntersection = 12;
 
         DynamicPyramid.mergeProperties(targetObject, objectToMerge);
 
-        expect(targetObject.pyramid.material).toEqual(targetObject.pyramid.material);
-        expect(targetObject.pyramid.directions).toEqual(targetObject.pyramid.directions);
-        expect(targetObject.pyramid.intersectionColor).toEqual(targetObject.pyramid.intersectionColor);
-        expect(targetObject.pyramid.radius).toEqual(targetObject.pyramid.radius);
-        expect(targetObject.pyramid.show).toEqual(targetObject.pyramid.show);
-        expect(targetObject.pyramid.showIntersection).toEqual(targetObject.pyramid.showIntersection);
+        expect(targetObject.pyramid.material).toEqual(7);
+        expect(targetObject.pyramid.directions).toEqual(8);
+        expect(targetObject.pyramid.intersectionColor).toEqual(9);
+        expect(targetObject.pyramid.radius).toEqual(10);
+        expect(targetObject.pyramid.show).toEqual(11);
+        expect(targetObject.pyramid.showIntersection).toEqual(12);
     });
 
     it('mergeProperties creates and configures an undefined pyramid', function() {
@@ -164,21 +164,21 @@ defineSuite([
 
         var targetObject = new DynamicObject('targetObject');
         targetObject.pyramid = new DynamicPyramid();
-        objectToMerge.material = 1;
-        objectToMerge.directions = 2;
-        objectToMerge.intersectionColor = 3;
-        objectToMerge.radius = 4;
-        objectToMerge.show = 5;
-        objectToMerge.showIntersection = 6;
+        targetObject.pyramid.material = 7;
+        targetObject.pyramid.directions = 8;
+        targetObject.pyramid.intersectionColor = 9;
+        targetObject.pyramid.radius = 10;
+        targetObject.pyramid.show = 11;
+        targetObject.pyramid.showIntersection = 12;
 
         DynamicPyramid.mergeProperties(targetObject, objectToMerge);
 
-        expect(targetObject.pyramid.material).toEqual(targetObject.pyramid.material);
-        expect(targetObject.pyramid.directions).toEqual(targetObject.pyramid.directions);
-        expect(targetObject.pyramid.intersectionColor).toEqual(targetObject.pyramid.intersectionColor);
-        expect(targetObject.pyramid.radius).toEqual(targetObject.pyramid.radius);
-        expect(targetObject.pyramid.show).toEqual(targetObject.pyramid.show);
-        expect(targetObject.pyramid.showIntersection).toEqual(targetObject.pyramid.showIntersection);
+        expect(targetObject.pyramid.material).toEqual(7);
+        expect(targetObject.pyramid.directions).toEqual(8);
+        expect(targetObject.pyramid.intersectionColor).toEqual(9);
+        expect(targetObject.pyramid.radius).toEqual(10);
+        expect(targetObject.pyramid.show).toEqual(11);
+        expect(targetObject.pyramid.showIntersection).toEqual(12);
     });
 
     it('undefineProperties works', function() {


### PR DESCRIPTION
There were a handful of tests in DynamicScene that weren't actually testing what they claimed to be.  This was a bad copy/past job on my part back when I did the initial DynamicScene implementation.  All of the tests now actually test the code they are supposed to (though no new bugs were found, which I'll take as a good thing).  This addresses #248
