### PR TITLE
Fixed startup order in Cesium Viewer Widget

### DIFF
--- a/Apps/CesiumViewer/CesiumViewer.js
+++ b/Apps/CesiumViewer/CesiumViewer.js
@@ -23,13 +23,10 @@ define([
 
         var widget = new CesiumViewerWidget({
             endUserOptions : endUserOptions,
-            enableDragDrop : true,
-
-            postSetup : function(widget) {
-                widget.startRenderLoop();
-            }
+            enableDragDrop : true
         });
         widget.placeAt(dom.byId('cesiumContainer'));
-        widget.startup();
+        widget.startWidget();
+        widget.startRenderLoop();
     });
 });

--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -153,7 +153,7 @@ require({
             undef : true,
             unused : false,
             strict : true,
-            trailing : true,
+            trailing : false,
             asi : false,
             boss : false,
             debug : false,

--- a/Apps/Sandcastle/gallery/Animations.html
+++ b/Apps/Sandcastle/gallery/Animations.html
@@ -73,37 +73,37 @@ require([
     
     var polygon;
     var rectangularSensor;
-    
+
     function addAlphaAnimation(primitive, scene) {
         Sandcastle.declare(addAlphaAnimation);     // For highlighting in Sandcastle.
         scene.getAnimations().addAlpha(primitive.material, 0.0, 0.7);
     }
-    
+
     function addErosionAnimation(primitive, scene) {
         Sandcastle.declare(addErosionAnimation);   // For highlighting in Sandcastle.
-        scene.getAnimations().addProperty(primitive, 'erosion', 0.0, 1.0, { 
-            duration: 1000 
-        });
-    } 
-    
-    function addHeightAnimation(primitive, scene) {
-        Sandcastle.declare(addHeightAnimation);    // For highlighting in Sandcastle.
-        scene.getAnimations().addProperty(primitive, 'height', 5000000.0, 0.0, { 
+        scene.getAnimations().addProperty(primitive, 'erosion', 0.0, 1.0, {
             duration: 1000
         });
     }
-    
+
+    function addHeightAnimation(primitive, scene) {
+        Sandcastle.declare(addHeightAnimation);    // For highlighting in Sandcastle.
+        scene.getAnimations().addProperty(primitive, 'height', 5000000.0, 0.0, {
+            duration: 1000
+        });
+    }
+
     function addStripeAnimation(primitive, scene) {
         Sandcastle.declare(addStripeAnimation);    // For highlighting in Sandcastle.
         scene.getAnimations().addOffsetIncrement(primitive.material);
     }
-    
+
     function resetPolygonPropeties(polygon) {
         polygon.erosion = 1.0;
         polygon.height = 0.0;
         polygon.material.uniforms.color = new Cesium.Color(1.0, 0.0, 0.0, 0.5);
     }
-    
+
     function createPrimitives(widget) {
         var ellipsoid = widget.ellipsoid;
         var scene = widget.scene;
@@ -111,13 +111,13 @@ require([
         
         polygon = new Cesium.Polygon();
         polygon.configureExtent(new Cesium.Extent(
-                Cesium.Math.toRadians(-120.0), 
-                Cesium.Math.toRadians(20.0), 
-                Cesium.Math.toRadians(-80.0), 
+                Cesium.Math.toRadians(-120.0),
+                Cesium.Math.toRadians(20.0),
+                Cesium.Math.toRadians(-80.0),
                 Cesium.Math.toRadians(50.0)));
         polygon.material = new Cesium.Material.fromType(scene.getContext(), 'Color');
-        primitives.add(polygon);        
-        
+        primitives.add(polygon);
+
         var modelMatrix = Cesium.Transforms.northEastDownToFixedFrame(ellipsoid.cartographicToCartesian(Cesium.Cartographic.fromDegrees(-45.0, 45.0)));
         modelMatrix = modelMatrix.multiply(Cesium.Matrix4.fromTranslation(new Cesium.Cartesian3(200000.0, 0.0, -3000000.0)));
         var material = Cesium.Material.fromType(scene.getContext(), 'Stripe'); // Use default colors
@@ -132,57 +132,56 @@ require([
         });
         primitives.add(sensors);
     }
-    
+
     function createButtons(scene) {
         new Button({
             label: 'Alpha Animation',
             onClick: function() {
                 scene.getAnimations().removeAll();
                 resetPolygonPropeties(polygon);
-                addAlphaAnimation(polygon, scene); 
+                addAlphaAnimation(polygon, scene);
                 Sandcastle.highlight(addAlphaAnimation);
             }
         }).placeAt('toolbar');
-        
+
         new Button({
             label: 'Erosion Animation',
             onClick: function() {
                 scene.getAnimations().removeAll();
                 resetPolygonPropeties(polygon);
-                addErosionAnimation(polygon, scene); 
+                addErosionAnimation(polygon, scene);
                 Sandcastle.highlight(addErosionAnimation);
             }
         }).placeAt('toolbar');
-        
+
         new Button({
             label: 'Height Animation',
             onClick: function() {
                 scene.getAnimations().removeAll();
                 resetPolygonPropeties(polygon);
-                addHeightAnimation(polygon, scene); 
+                addHeightAnimation(polygon, scene);
                 Sandcastle.highlight(addHeightAnimation);
             }
         }).placeAt('toolbar');
-        
+
         new Button({
             label: 'Stripe Animation',
             onClick: function() {
                 scene.getAnimations().removeAll();
-                addStripeAnimation(rectangularSensor, scene); 
+                addStripeAnimation(rectangularSensor, scene);
                 Sandcastle.highlight(addStripeAnimation);
             }
         }).placeAt('toolbar');
     }
 
-    var cesiumWidget = new CesiumWidget({
-        postSetup : function(widget) {
-            createPrimitives(widget);
-            createButtons(widget.scene);
-            widget.startRenderLoop();
-        }
-    }).placeAt(dom.byId('cesiumContainer'));
-    
+    var widget = new CesiumWidget();
+    widget.placeAt(dom.byId('cesiumContainer'));
+    widget.startWidget();
     dom.byId('toolbar').innerHTML = '';
+
+    createPrimitives(widget);
+    createButtons(widget.scene);
+    widget.startRenderLoop();
 });
 </script>
 </body>

--- a/Apps/Sandcastle/gallery/Billboards.html
+++ b/Apps/Sandcastle/gallery/Billboards.html
@@ -398,15 +398,14 @@ require([
         }).placeAt('toolbar');        
     }
 
-    var cesiumWidget = new CesiumWidget({
-        postSetup : function(widget) {
-            createButtons(widget);
-            widget.startRenderLoop();
-            addBillboard(widget.scene, widget.ellipsoid);
-        }
-    }).placeAt(dom.byId('cesiumContainer'));
-    
+    var widget = new CesiumWidget();
+    widget.placeAt(dom.byId('cesiumContainer'));
+    widget.startWidget();
     dom.byId('toolbar').innerHTML = '';
+
+    createButtons(widget);
+    addBillboard(widget.scene, widget.ellipsoid);
+    widget.startRenderLoop();
 });
 </script>
 </body>

--- a/Apps/Sandcastle/gallery/Camera Reference Frames.html
+++ b/Apps/Sandcastle/gallery/Camera Reference Frames.html
@@ -124,14 +124,13 @@ require([
         primitives.add(polylines);        
     }
     
-    var cesiumWidget = new CesiumWidget({
-        postSetup : function(widget) {
-            widget.startRenderLoop();
-            eastNorthUp(widget.scene);
-        }
-    }).placeAt(dom.byId('cesiumContainer'));
-
+    var widget = new CesiumWidget();
+    widget.placeAt(dom.byId('cesiumContainer'));
+    widget.startWidget();
     dom.byId('toolbar').innerHTML = '';
+
+    eastNorthUp(widget.scene);
+    widget.startRenderLoop();
 });
 </script>
 </body>

--- a/Apps/Sandcastle/gallery/Camera.html
+++ b/Apps/Sandcastle/gallery/Camera.html
@@ -141,15 +141,14 @@ require([
             }
         }).placeAt('toolbar');
     }
-    
-    var cesiumWidget = new CesiumWidget({
-        postSetup : function(widget) {
-            createButtons(widget.scene);
-            widget.startRenderLoop();
-        }
-    }).placeAt(dom.byId('cesiumContainer'));
 
+    var widget = new CesiumWidget();
+    widget.placeAt(dom.byId('cesiumContainer'));
+    widget.startWidget();
     dom.byId('toolbar').innerHTML = '';
+
+    createButtons(widget.scene);
+    widget.startRenderLoop();
 });
 </script>
 </body>

--- a/Apps/Sandcastle/gallery/Cesium Viewer Widget.html
+++ b/Apps/Sandcastle/gallery/Cesium Viewer Widget.html
@@ -79,16 +79,15 @@ require([
 
     // Initialize a viewer capable of drag-and-drop
     // and user customizations.
-    var cesiumViewerWidget = new CesiumViewerWidget({
+    var widget = new CesiumViewerWidget({
         endUserOptions : endUserOptions,
-        enableDragDrop : true,
-
-        postSetup : function(widget) {
-            widget.startRenderLoop();
-        }
-    }).placeAt(dom.byId("cesiumContainer"));
-    
+        enableDragDrop : true
+    });
+    widget.placeAt(dom.byId('cesiumContainer'));
+    widget.startWidget();
     dom.byId('toolbar').innerHTML = '';
+
+    widget.startRenderLoop();
 });
 </script>
 </body>

--- a/Apps/Sandcastle/gallery/Cesium Widget.html
+++ b/Apps/Sandcastle/gallery/Cesium Widget.html
@@ -71,13 +71,12 @@ require([
 {
     "use strict";
 
-    var cesiumWidget = new CesiumWidget({
-        postSetup : function(widget) {
-            widget.startRenderLoop();
-        }
-    }).placeAt(dom.byId("cesiumContainer"));
-
+    var widget = new CesiumWidget();
+    widget.placeAt(dom.byId('cesiumContainer'));
+    widget.startWidget();
     dom.byId('toolbar').innerHTML = '';
+
+    widget.startRenderLoop();
 });
 </script>
 </body>

--- a/Apps/Sandcastle/gallery/Circles and Ellipses.html
+++ b/Apps/Sandcastle/gallery/Circles and Ellipses.html
@@ -115,18 +115,18 @@ require([
 
     }
 
-    var cesiumViewerWidget = new CesiumViewerWidget({
+    var widget = new CesiumViewerWidget({
         onObjectMousedOver : function(mousedOverObject) {
-            cesiumViewerWidget.highlightObject(mousedOverObject);
+            widget.highlightObject(mousedOverObject);
             Sandcastle.highlight(mousedOverObject);
-        },
-        postSetup : function(widget) {
-            createPrimitives(widget);
-            widget.startRenderLoop();
         }
-    }).placeAt(dom.byId("cesiumContainer"));
-    
+    });
+    widget.placeAt(dom.byId('cesiumContainer'));
+    widget.startWidget();
     dom.byId('toolbar').innerHTML = '';
+
+    createPrimitives(widget);
+    widget.startRenderLoop();
 });
 </script>
 </body>

--- a/Apps/Sandcastle/gallery/Custom Rendering.html
+++ b/Apps/Sandcastle/gallery/Custom Rendering.html
@@ -434,16 +434,15 @@ require([
             dropDown: sceneMenu
         }).placeAt('toolbar');
     }
-    
-    var cesiumWidget = new CesiumWidget({
-        postSetup : function(widget) {
-            createButtons(widget);
-            widget.startRenderLoop();
-            renderBox(widget.scene);
-        }
-    }).placeAt(dom.byId('cesiumContainer'));
 
+    var widget = new CesiumWidget();
+    widget.placeAt(dom.byId('cesiumContainer'));
+    widget.startWidget();
     dom.byId('toolbar').innerHTML = '';
+
+    createButtons(widget);
+    widget.startRenderLoop();
+    renderBox(widget.scene);
 });
 </script>
 </body>

--- a/Apps/Sandcastle/gallery/Imagery Layers.html
+++ b/Apps/Sandcastle/gallery/Imagery Layers.html
@@ -309,24 +309,23 @@ require([
         });
     }
 
-    var cesiumWidget = new CesiumWidget({
-        postSetup : function(widget) {
-            var scene = widget.scene;
-            var centralBody = scene.getPrimitives().getCentralBody();
-
-            centralBody.affectedByLighting = false;
-            
-            imageryLayerCollection = centralBody.getImageryLayers();            
-
-            setupLayers();
-
-            createLayerUserInterface();
-
-            widget.startRenderLoop();
-        }
-    }).placeAt(dom.byId("cesiumContainer"));
-    
+    var widget = new CesiumWidget();
+    widget.placeAt(dom.byId('cesiumContainer'));
+    widget.startWidget();
     dom.byId('toolbar').innerHTML = '';
+
+    var scene = widget.scene;
+    var centralBody = widget.centralBody;
+
+    centralBody.affectedByLighting = false;
+
+    imageryLayerCollection = centralBody.getImageryLayers();            
+
+    setupLayers();
+
+    createLayerUserInterface();
+
+    widget.startRenderLoop();
 });
 </script>
 </body>

--- a/Apps/Sandcastle/gallery/Labels.html
+++ b/Apps/Sandcastle/gallery/Labels.html
@@ -175,15 +175,14 @@ require([
         }).placeAt('toolbar');
     }
 
-    var cesiumWidget = new CesiumWidget({
-        postSetup : function(widget) {
-            createButtons(widget);
-            widget.startRenderLoop();
-            addLabel(widget.scene, widget.ellipsoid);
-        }
-    }).placeAt(dom.byId('cesiumContainer'));
-    
+    var widget = new CesiumWidget();
+    widget.placeAt(dom.byId('cesiumContainer'));
+    widget.startWidget();
     dom.byId('toolbar').innerHTML = '';
+
+    createButtons(widget);
+    widget.startRenderLoop();
+    addLabel(widget.scene, widget.ellipsoid);
 });
 </script>
 </body>

--- a/Apps/Sandcastle/gallery/Map Projections.html
+++ b/Apps/Sandcastle/gallery/Map Projections.html
@@ -99,20 +99,19 @@ require([
         webMercator.set('checked', false);
     }
     
-    var cesiumWidget = new CesiumViewerWidget({
-        postSetup : function(widget) {
-            widget.showSkyAtmosphere(false);
-            widget.showGroundAtmosphere(false);
-            widget.scene.getPrimitives().getCentralBody().affectedByLighting = false;
-            var transitioner = new Cesium.SceneTransitioner(widget.scene);
-            transitioner.to2D();
-            
-            createButtons(widget.scene);
-            widget.startRenderLoop();
-        }
-    }).placeAt(dom.byId('cesiumContainer'));
-
+    var widget = new CesiumViewerWidget();
+    widget.placeAt(dom.byId('cesiumContainer'));
+    widget.startWidget();
     dom.byId('toolbar').innerHTML = '';
+
+    widget.showSkyAtmosphere(false);
+    widget.showGroundAtmosphere(false);
+    widget.scene.getPrimitives().getCentralBody().affectedByLighting = false;
+    var transitioner = new Cesium.SceneTransitioner(widget.scene);
+    transitioner.to2D();
+
+    createButtons(widget.scene);
+    widget.startRenderLoop();
 });
 
 </script>

--- a/Apps/Sandcastle/gallery/Materials.html
+++ b/Apps/Sandcastle/gallery/Materials.html
@@ -741,16 +741,15 @@ require([
         worldPolygon.show = false;
         primitives.add(worldPolygon);
     }
-    
-    var cesiumWidget = new CesiumWidget({
-        postSetup : function(widget) {
-            createPrimitives(widget);
-            createButtons(widget);
-            widget.startRenderLoop();
-        }
-    }).placeAt(dom.byId('cesiumContainer'));
 
+    var widget = new CesiumWidget();
+    widget.placeAt(dom.byId('cesiumContainer'));
+    widget.startWidget();
     dom.byId('toolbar').innerHTML = '';
+
+    createPrimitives(widget);
+    createButtons(widget);
+    widget.startRenderLoop();
 });
 </script>
 </body>

--- a/Apps/Sandcastle/gallery/Picking.html
+++ b/Apps/Sandcastle/gallery/Picking.html
@@ -92,7 +92,7 @@ require([
     }
     
     function cleanup() {
-        cesiumWidget.scene.getPrimitives().removeAll();
+        widget.scene.getPrimitives().removeAll();
         handler = handler && handler.destroy();
     }
     
@@ -347,15 +347,14 @@ require([
         }).placeAt('toolbar');        
     }
 
-    var cesiumWidget = new CesiumWidget({
-        postSetup : function(widget) {
-            createButtons(widget);
-            widget.startRenderLoop();
-            pickCartographicPosition(widget.scene, widget.ellipsoid); 
-        }
-    }).placeAt(dom.byId('cesiumContainer'));
-
+    var widget = new CesiumWidget();
+    widget.placeAt(dom.byId('cesiumContainer'));
+    widget.startWidget();
     dom.byId('toolbar').innerHTML = '';
+
+    createButtons(widget);
+    widget.startRenderLoop();
+    pickCartographicPosition(widget.scene, widget.ellipsoid); 
 });
 </script>
 </body>

--- a/Apps/Sandcastle/gallery/Polygons.html
+++ b/Apps/Sandcastle/gallery/Polygons.html
@@ -132,18 +132,18 @@ require([
         primitives.add(checkeredPolygon);        
     }
 
-    var cesiumViewerWidget = new CesiumViewerWidget({
+    var widget = new CesiumViewerWidget({
         onObjectMousedOver : function(mousedOverObject) {
-            cesiumViewerWidget.highlightObject(mousedOverObject);
+            widget.highlightObject(mousedOverObject);
             Sandcastle.highlight(mousedOverObject);
-        },
-        postSetup : function(widget) {
-            createPrimitives(widget);
-            widget.startRenderLoop();
         }
-    }).placeAt(dom.byId('cesiumContainer'));
-    
+    });
+    widget.placeAt(dom.byId('cesiumContainer'));
+    widget.startWidget();
     dom.byId('toolbar').innerHTML = '';
+
+    createPrimitives(widget);
+    widget.startRenderLoop();
 });
 </script>
 </body>

--- a/Apps/Sandcastle/gallery/Polylines.html
+++ b/Apps/Sandcastle/gallery/Polylines.html
@@ -137,18 +137,18 @@ require([
         primitives.add(localPolylines);
     }
 
-    var cesiumViewerWidget = new CesiumViewerWidget({
+    var widget = new CesiumViewerWidget({
         onObjectMousedOver : function(mousedOverObject) {
-            cesiumViewerWidget.highlightObject(mousedOverObject);
+            widget.highlightObject(mousedOverObject);
             Sandcastle.highlight(mousedOverObject);
-        },
-        postSetup : function(widget) {
-            createPrimitives(widget);
-            widget.startRenderLoop();
         }
-    }).placeAt(dom.byId('cesiumContainer'));
-    
+    });
+    widget.placeAt(dom.byId('cesiumContainer'));
+    widget.startWidget();
     dom.byId('toolbar').innerHTML = '';
+
+    createPrimitives(widget);
+    widget.startRenderLoop();
 });
 </script>
 </body>

--- a/Apps/Sandcastle/gallery/Sensors.html
+++ b/Apps/Sandcastle/gallery/Sensors.html
@@ -142,20 +142,20 @@ require([
         }).placeAt('toolbar');
     }
 
-    var cesiumViewerWidget = new CesiumViewerWidget({
+    var widget = new CesiumViewerWidget({
         onObjectMousedOver : function(mousedOverObject) {
-            cesiumViewerWidget.highlightObject(mousedOverObject);
+            widget.highlightObject(mousedOverObject);
             Sandcastle.highlight(mousedOverObject);
-        },
-        postSetup : function(widget) {
-            var sensors = new Cesium.SensorVolumeCollection();
-            createButtons(widget, sensors);
-            widget.startRenderLoop();
-            addRectangularSensor(sensors, widget.ellipsoid, widget.scene);
         }
-    }).placeAt(dom.byId('cesiumContainer'));
-
+    });
+    widget.placeAt(dom.byId('cesiumContainer'));
+    widget.startWidget();
     dom.byId('toolbar').innerHTML = '';
+
+    var sensors = new Cesium.SensorVolumeCollection();
+    createButtons(widget, sensors);
+    widget.startRenderLoop();
+    addRectangularSensor(sensors, widget.ellipsoid, widget.scene);
 });
 </script>
 </body>

--- a/Apps/Sandcastle/gallery/Simple CZML Demo.html
+++ b/Apps/Sandcastle/gallery/Simple CZML Demo.html
@@ -77,16 +77,15 @@ require([
 
     // Initialize a viewer capable of drag-and-drop
     // and user customizations.
-    var cesiumViewerWidget = new CesiumViewerWidget({
+    var widget = new CesiumViewerWidget({
         endUserOptions : endUserOptions,
-        enableDragDrop : true,
-
-        postSetup : function(widget) {
-            widget.startRenderLoop();
-        }
-    }).placeAt(dom.byId("cesiumContainer"));
-
+        enableDragDrop : true
+    });
+    widget.placeAt(dom.byId('cesiumContainer'));
+    widget.startWidget();
     dom.byId('toolbar').innerHTML = '';
+
+    widget.startRenderLoop();
 });
 </script>
 </body>

--- a/Apps/Sandcastle/gallery/Two Viewer Widgets.html
+++ b/Apps/Sandcastle/gallery/Two Viewer Widgets.html
@@ -99,11 +99,35 @@ require([
     // separate animationControllers to show a scene at
     // different times.
 
-    var widget1, widget2, animationController;
     var endUserOptions = {
         'source' : '../../CesiumViewer/Gallery/simple.czml'
     };
 
+    // First, create widget1 (the top widget).
+    var widget1 = new CesiumViewerWidget({
+        endUserOptions : endUserOptions
+    });
+    widget1.placeAt(dom.byId("cesiumContainerTop"));
+    widget1.startWidget();
+    dom.byId('topbar').innerHTML = '';
+    
+    // Save off a copy of widget1's animationController
+    var animationController = widget1.animationController;
+
+    // Now create widget2, passing in the
+    // existing animationController to be shared.
+    var widget2 = new CesiumViewerWidget({
+        animationController : animationController,
+        endUserOptions : endUserOptions
+    });
+    widget2.placeAt(dom.byId("cesiumContainerBottom"));
+    widget2.startWidget();
+
+    // Switch widget2 to Columbus View.
+    widget2.viewColumbus.onClick();
+
+    // Now both widgets are created.  A custom render loop is
+    // needed to drive them both from requestAnimationFrame.
     function updateAndRender() {
         // Get the time from the shared controller, then
         // update and render both widgets.
@@ -115,34 +139,8 @@ require([
         requestAnimationFrame(updateAndRender);
     }
 
-    function createWidget2() {
-        // Save off a copy of widget1's animationController
-        animationController = widget1.animationController;
-
-        // Now create widget2, passing in the
-        // existing animationController to be shared.
-        widget2 = new CesiumViewerWidget({
-            animationController : animationController,
-            endUserOptions : endUserOptions,
-            postSetup : function(widget) {
-                // Switch to columbus view
-                widget2.viewColumbus.onClick();
-
-                // Once 2nd widget created, start loop.
-                updateAndRender();
-            }
-        }).placeAt(dom.byId("cesiumContainerBottom"));
-    }
-
-    // First thing: Create widget1 (the top widget).
-    widget1 = new CesiumViewerWidget({
-        endUserOptions : endUserOptions,
-        postSetup : function(widget) {
-            createWidget2();
-        }
-    }).placeAt(dom.byId("cesiumContainerTop"));
-
-    dom.byId('topbar').innerHTML = '';
+    // Call the render loop once manually, to prime the pump.
+    updateAndRender();
 });
 </script>
 </body>

--- a/Apps/Sandcastle/gallery/Volumes.html
+++ b/Apps/Sandcastle/gallery/Volumes.html
@@ -93,18 +93,18 @@ require([
         primitives.add(e2);
     }
 
-    var cesiumViewerWidget = new CesiumViewerWidget({
+    var widget = new CesiumViewerWidget({
         onObjectMousedOver : function(mousedOverObject) {
-            cesiumViewerWidget.highlightObject(mousedOverObject);
+            widget.highlightObject(mousedOverObject);
             Sandcastle.highlight(mousedOverObject);
-        },
-        postSetup : function(widget) {
-            createPrimitives(widget);
-            widget.startRenderLoop();
         }
-    }).placeAt(dom.byId("cesiumContainer"));
-    
+    });
+    widget.placeAt(dom.byId('cesiumContainer'));
+    widget.startWidget();
     dom.byId('toolbar').innerHTML = '';
+
+    createPrimitives(widget);
+    widget.startRenderLoop();
 });
 </script>
 </body>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Beta Releases
    * The `description.generateTextureCoords` parameter passed to `ExtentTessellator.compute` is now called `description.generateTextureCoordinates`.
    * Renamed `bringForward`, `sendBackward`, `bringToFront`, and `sendToBack` methods on `CompositePrimitive` to `raise`, `lower`, `raiseToTop`, and `lowerToBottom`, respectively.
    * `Cache` and `CachePolicy` are no longer used and have been removed.
+   * Fixed problem with Dojo widget startup, and removed "postSetup" callback in the process.  See Sandcastle examples and update your startup code.
 * `CentralBody` now allows imagery from multiple sources to be layered and alpha blended on the globe.  See the new `Imagery Layers` and `Map Projections` Sandcastle examples.
 * Added `WebMapServiceImageryProvider`.
 * Improved middle mouse click behavior to always tilt in the same direction.

--- a/Source/Widgets/Dojo/CesiumViewerWidget.js
+++ b/Source/Widgets/Dojo/CesiumViewerWidget.js
@@ -241,15 +241,6 @@ define([
         },
 
         /**
-         * If supplied, this function will be called at the end of widget setup.
-         *
-         * @function
-         * @memberof CesiumViewerWidget.prototype
-         * @see CesiumViewerWidget#startRenderLoop
-         */
-        postSetup : undefined,
-
-        /**
          * This function will get a callback in the event of setup failure, likely indicating
          * a problem with WebGL support or the availability of a GL context.
          *
@@ -560,7 +551,16 @@ define([
             reader.readAsText(f);
         },
 
-        startup : function() {
+        /**
+         * Call this after placing the widget in the DOM, to initialize the WebGL context,
+         * wire up event callbacks, begin requesting CZML, imagery, etc.  Note this does
+         * not start a render loop (because you may need a custom render loop).
+         *
+         * @function
+         * @memberof CesiumViewerWidget.prototype
+         * @see CesiumViewerWidget#startRenderLoop
+         */
+        startWidget : function() {
             var canvas = this.canvas, ellipsoid = this.ellipsoid, scene, widget = this;
 
             try {
@@ -849,10 +849,6 @@ define([
             }
 
             this._camera3D = this.scene.getCamera().clone();
-
-            if (typeof this.postSetup !== 'undefined') {
-                this.postSetup(this);
-            }
         },
 
         /**
@@ -1142,11 +1138,12 @@ define([
 
         /**
          * This is a simple render loop that can be started if there is only one <code>CesiumViewerWidget</code>
-         * on your page.  Typically it is started from {@link CesiumViewerWidget.postSetup}.  If you wish to
-         * customize your render loop, avoid this function and instead use code similar to the following example.
+         * on your page.  If you wish to customize your render loop, avoid this function and instead
+         * use code similar to one of the following examples.
          * @function
          * @memberof CesiumViewerWidget.prototype
          * @see requestAnimationFrame
+         * @see CesiumViewerWidget#startWidget
          * @example
          * // This takes the place of startRenderLoop for a single widget.
          *

--- a/Source/Widgets/Dojo/CesiumWidget.js
+++ b/Source/Widgets/Dojo/CesiumWidget.js
@@ -71,12 +71,6 @@ define([
             this.ellipsoid = Ellipsoid.WGS84;
         },
 
-        postCreate : function() {
-            ready(this, '_setupCesium');
-        },
-
-        postSetup : undefined,
-
         onSetupError : function(widget, error) {
             console.error(error);
         },
@@ -172,7 +166,7 @@ define([
             }
         },
 
-        _setupCesium : function() {
+        startWidget : function() {
             var canvas = this.canvas, ellipsoid = this.ellipsoid, scene, widget = this;
 
             try {
@@ -231,10 +225,6 @@ define([
                 on(window, 'resize', function() {
                     widget.resize();
                 });
-            }
-
-            if (typeof this.postSetup !== 'undefined') {
-                this.postSetup(this);
             }
 
             this.defaultCamera = camera.clone();


### PR DESCRIPTION
I'm submitting this on @shunter's behalf who can explain what is actually going on.

The `Scene` needs the canvas' `clientWidth` and `clientHeight` properties, but they were not initialized when the `Scene` was constructed, so we changed the initiliation order based on [this](http://dojotoolkit.org/documentation/tutorials/1.6/understanding_widget/).
