### PR TITLE
Fix getBootstrapperUrl with src="Cesium.js".

### DIFF
--- a/Source/Core/TaskProcessor.js
+++ b/Source/Core/TaskProcessor.js
@@ -26,7 +26,7 @@ define([
         delete deferreds[id];
     }
 
-    var cesiumScriptRegex = /(.*)\/?Cesium\w*\.js(?:\W|$)/i;
+    var cesiumScriptRegex = /(.*\/?)Cesium\w*\.js(?:\W|$)/i;
     var bootstrapperScript = 'cesiumWorkerBootstrapper.js';
     var bootstrapperUrl;
     function getBootstrapperUrl() {
@@ -42,7 +42,7 @@ define([
                     var src = scripts[i].getAttribute('src');
                     var result = cesiumScriptRegex.exec(src);
                     if (result !== null) {
-                        bootstrapperUrl = result[1] + '/' + bootstrapperScript;
+                        bootstrapperUrl = result[1] + bootstrapperScript;
                         break;
                     }
                 }


### PR DESCRIPTION
Reported on the dev list: https://groups.google.com/d/msg/cesium-dev/Kf234hjGibw/bHWQw6wpAh4J

Adjust the regex to capture and use the (optional) slash within the capture group instead of always concating one.
