### PR TITLE
Added Timeline.smallestTicInPixels suggested by @balefrost.

### DIFF
--- a/Source/Widgets/Timeline.js
+++ b/Source/Widgets/Timeline.js
@@ -237,6 +237,8 @@ define(['./TimelineTrack',
                 twoDigits(date.getUTCSeconds()) + milString + ampm;
     };
 
+    Timeline.prototype.smallestTicInPixels = 7.0;
+
     Timeline.prototype._makeTics = function() {
         var timeBar = this._timeBarEle;
 
@@ -351,7 +353,7 @@ define(['./TimelineTrack',
             if ((sc > idealTic) && (sc > minSize)) {
                 break;
             }
-            if ((smallestIndex < 0) && ((timeBarWidth * (sc / this._timeBarSecondsSpan)) >= 3.0)) {
+            if ((smallestIndex < 0) && ((timeBarWidth * (sc / this._timeBarSecondsSpan)) >= this.smallestTicInPixels)) {
                 smallestIndex = ticIndex;
             }
         }


### PR DESCRIPTION
  Also changed default from 3 to 7 pixels, for cleaner looking timelines.
