### PR TITLE
Add new property, `CesiumViewerWidget.fullscreenElement`

### DIFF
--- a/Source/Widgets/Dojo/CesiumViewerWidget.js
+++ b/Source/Widgets/Dojo/CesiumViewerWidget.js
@@ -15,6 +15,7 @@ define([
         'dijit/form/DropDownButton',
         'dijit/TooltipDialog',
         './TimelineWidget',
+        '../../Core/defaultValue',
         '../../Core/loadJson',
         '../../Core/BoundingRectangle',
         '../../Core/Clock',
@@ -69,6 +70,7 @@ define([
         DropDownButton,
         TooltipDialog,
         TimelineWidget,
+        defaultValue,
         loadJson,
         BoundingRectangle,
         Clock,
@@ -236,6 +238,18 @@ define([
          * @see CesiumViewerWidget#resize
          */
         resizeWidgetOnWindowResize: true,
+        /**
+         * The HTML element to place into fullscreen mode when the corresponding
+         * button is pressed.  If undefined, only the widget itself will
+         * go into fullscreen mode.  By specifying another container, such
+         * as document.body, this property allows an application to retain
+         * any overlaid or surrounding elements when in fullscreen.
+         *
+         * @type {Object}
+         * @memberof CesiumViewerWidget.prototype
+         * @default undefined
+         */
+        fullscreenElement : undefined,
 
         // for Dojo use only
         constructor : function() {
@@ -829,7 +843,7 @@ define([
                     if (Fullscreen.isFullscreen()) {
                         Fullscreen.exitFullscreen();
                     } else {
-                        Fullscreen.requestFullscreen(widget.cesiumNode);
+                        Fullscreen.requestFullscreen(defaultValue(widget.fullscreenElement, widget.cesiumNode));
                     }
                 });
             } else {


### PR DESCRIPTION
I have an application that overlays additional widgets on top of the viewer widget. I added a `fullscreenElement` property to CesiumViewerWidget in order to allow an application to specify which element is used to enter fullscreen mode.  By specifying my application container, I can retain my additional ui.

@emackey or @shunter, is there anything wrong with this approach?
