### PR TITLE
Fix writeTextToCanvas to set canvas styles correctly.

### DIFF
--- a/Source/Core/writeTextToCanvas.js
+++ b/Source/Core/writeTextToCanvas.js
@@ -54,7 +54,6 @@ define([
 
         // in order for measureText to calculate style, the canvas has to be
         // (temporarily) added to the DOM.
-        canvas.style.display = 'inline';
         canvas.style.visibility = 'hidden';
         document.body.appendChild(canvas);
 
@@ -62,7 +61,7 @@ define([
         canvas.dimensions = dimensions;
 
         document.body.removeChild(canvas);
-        canvas.style.display = 'none';
+        canvas.style.visibility = undefined;
 
         var baseline = dimensions.height - dimensions.ascent;
         canvas.width = dimensions.width;


### PR DESCRIPTION
While the changes seem to have no affect, they are now at least technically correct (the best kind of correct). See #346
