### PR TITLE
Change CesiumViewerWidget to default to a single left-click for zoom

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@ Beta Releases
 * Added `QuadraticRealPolynomial`, `CubicRealPolynomial`, and `QuarticRealPolynomial` for finding the roots of quadratic, cubic, and quartic polynomials.
 * Added `IntersectionTests.grazingAltitudeLocation` for finding a point on a ray nearest to an ellipsoid.
 * Added `mostOrthogonalAxis` function to `Cartesian2`, `Cartesian3`, and `Cartesian4`.
+* Changed CesiumViewerWidget default behavior so that zooming to an object now requires a single left-click, rather than a double-click. 
 
 ### b10 - 11/02/2012
 

--- a/Source/Widgets/Dojo/CesiumViewerWidget.js
+++ b/Source/Widgets/Dojo/CesiumViewerWidget.js
@@ -697,8 +697,8 @@ define([
                 this.highlightMaterial.uniforms.color = this.highlightColor;
             }
 
-            if (typeof this.onObjectLeftDoubleClickSelected === 'undefined') {
-                this.onObjectLeftDoubleClickSelected = function(selectedObject) {
+            if (typeof this.onObjectSelected === 'undefined') {
+                this.onObjectSelected = function(selectedObject) {
                     if (typeof selectedObject !== 'undefined' && typeof selectedObject.dynamicObject !== 'undefined') {
                         this.centerCameraOnPick(selectedObject);
                     }


### PR DESCRIPTION
rather than a double click.  This improves mobile support and discover-ability.
