### PR TITLE
Turn off sky atmosphere in Black Marble example.

### DIFF
--- a/Apps/Sandcastle/gallery/Black Marble.html
+++ b/Apps/Sandcastle/gallery/Black Marble.html
@@ -86,6 +86,7 @@ require([
     });
     widget.placeAt(dom.byId('cesiumContainer'));
     widget.startup();
+    widget.showSkyAtmosphere(false);
 
     var scene = widget.scene;
     var centralBody = widget.centralBody;


### PR DESCRIPTION
It's always night, so we might as well show the stars.
