### PR TITLE
Fix morph crash.

### DIFF
--- a/Source/Scene/SceneTransitioner.js
+++ b/Source/Scene/SceneTransitioner.js
@@ -492,8 +492,8 @@ define([
         }
 
         var partialDuration = (endTime - startTime) * duration;
-        if (partialDuration === 0) {
-            if (Cartesian2.magnitude(Cartesian2.subtract(startPos, endPos2D)) !== 0) {
+        if (partialDuration < CesiumMath.EPSILON6) {
+            if (!startPos.equalsEpsilon(endPos2D, CesiumMath.EPSILON6)) {
                 partialDuration = duration;
                 startTime = 0.0;
                 endTime = 1.0;


### PR DESCRIPTION
Prevent an animation duration of 0ms. In Tween.js, the elapsed time is computed as `(time - startTime) / duration` and clamped at one. This is fine for the most common case where `time > startTime` which gets divided by zero to equal infinity and clamped to one. In the case where `time == startTime` (which explains why it was so hard to reproduce), the elapsed time will be `NaN` and cause a crash.

This fixes the original problem in #319.
#338 is unrelated.
