### PR TITLE
Add CSS rules for printing the documentation.

### DIFF
--- a/Tools/jsdoc3/templates/default/static/styles/jsdoc-default.css
+++ b/Tools/jsdoc3/templates/default/static/styles/jsdoc-default.css
@@ -486,3 +486,24 @@ h6
 .disabled {
     color: #454545;
 }
+
+/* For printing out the documentation */
+@media print {
+    body {
+        background: #fff;
+    }
+    .nav {
+        display: none;
+    }
+    #mainIndex .nav {
+        display: block;
+    }
+    #main {
+        float: none;
+        width: auto;
+        margin-right: 25px;
+    }
+    footer {
+        padding: 6px;
+    }
+}


### PR DESCRIPTION
To debug this without wasting trees, I recommend the "print preview" function in Firefox.  Looks like recent versions of Chrome also have print-preview as well now, not labeled as such but it pops up when you hit the "Print..." menu option.
