### PR TITLE
Add BoundingSphere.fromExtentWithHeights2D

### DIFF
--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -218,6 +218,7 @@ define([
 
     /**
      * Computes a bounding sphere from an extent projected in 2D.
+     *
      * @memberof BoundingSphere
      *
      * @param {Extent} extent The extent around which to create a bounding sphere.
@@ -232,6 +233,7 @@ define([
     /**
      * Computes a bounding sphere from an extent projected in 2D.  The bounding sphere accounts for the
      * object's minimum and maximum heights over the extent.
+     *
      * @memberof BoundingSphere
      *
      * @param {Extent} extent The extent around which to create a bounding sphere.
@@ -275,6 +277,7 @@ define([
     };
 
     var fromExtent3DScratch = [];
+
     /**
      * Computes a bounding sphere from an extent in 3D. The bounding sphere is created using a subsample of points
      * on the ellipsoid and contained in the extent. It may not be accurate for all extents on all types of ellipsoids.

--- a/Specs/Core/BoundingSphereSpec.js
+++ b/Specs/Core/BoundingSphereSpec.js
@@ -4,6 +4,7 @@ defineSuite([
          'Core/Cartesian2',
          'Core/Cartesian3',
          'Core/Cartesian4',
+         'Core/Cartographic',
          'Core/Ellipsoid',
          'Core/GeographicProjection',
          'Core/Extent',
@@ -16,6 +17,7 @@ defineSuite([
          Cartesian2,
          Cartesian3,
          Cartesian4,
+         Cartographic,
          Ellipsoid,
          GeographicProjection,
          Extent,
@@ -423,5 +425,93 @@ defineSuite([
         expect(function() {
             BoundingSphere.getPlaneDistances(new BoundingSphere(), new Cartesian3());
         }).toThrow();
+    });
+
+    function expectBoundingSphereToContainPoint(boundingSphere, point, projection) {
+        var pointInCartesian = projection.project(point);
+        var distanceFromCenter = pointInCartesian.subtract(boundingSphere.center).magnitude();
+
+        // The distanceFromCenter for corner points at the height extreme should equal the
+        // bounding sphere's radius.  But due to rounding errors it can end up being
+        // very slightly greater.  Pull in the distanceFromCenter slightly to
+        // account for this possibility.
+        distanceFromCenter -= CesiumMath.EPSILON9;
+
+        expect(distanceFromCenter).toBeLessThanOrEqualTo(boundingSphere.radius);
+    }
+
+    it('fromExtentWithHeights2D includes specified min and max heights', function() {
+        var extent = new Extent(0.1, 0.5, 0.2, 0.6);
+        var projection = new GeographicProjection();
+        var minHeight = -327.0;
+        var maxHeight = 2456.0;
+        var boundingSphere = BoundingSphere.fromExtentWithHeights2D(extent, projection, minHeight, maxHeight);
+
+        // Test that the corners are inside the bounding sphere.
+        var point = extent.getSouthwest().clone();
+        point.height = minHeight;
+        expectBoundingSphereToContainPoint(boundingSphere, point, projection);
+
+        point = extent.getSouthwest().clone();
+        point.height = maxHeight;
+        expectBoundingSphereToContainPoint(boundingSphere, point, projection);
+
+        point = extent.getNortheast().clone();
+        point.height = minHeight;
+        expectBoundingSphereToContainPoint(boundingSphere, point, projection);
+
+        point = extent.getNortheast().clone();
+        point.height = maxHeight;
+        expectBoundingSphereToContainPoint(boundingSphere, point, projection);
+
+        point = extent.getSoutheast().clone();
+        point.height = minHeight;
+        expectBoundingSphereToContainPoint(boundingSphere, point, projection);
+
+        point = extent.getSoutheast().clone();
+        point.height = maxHeight;
+        expectBoundingSphereToContainPoint(boundingSphere, point, projection);
+
+        point = extent.getNorthwest().clone();
+        point.height = minHeight;
+        expectBoundingSphereToContainPoint(boundingSphere, point, projection);
+
+        point = extent.getNorthwest().clone();
+        point.height = maxHeight;
+        expectBoundingSphereToContainPoint(boundingSphere, point, projection);
+
+        // Test that the center is inside the bounding sphere
+        point = extent.getCenter().clone();
+        point.height = minHeight;
+        expectBoundingSphereToContainPoint(boundingSphere, point, projection);
+
+        point = extent.getCenter().clone();
+        point.height = maxHeight;
+        expectBoundingSphereToContainPoint(boundingSphere, point, projection);
+
+        // Test that the edge midpoints are inside the bounding sphere.
+        point = new Cartographic(extent.getCenter().longitude, extent.south, minHeight);
+        expectBoundingSphereToContainPoint(boundingSphere, point, projection);
+
+        point = new Cartographic(extent.getCenter().longitude, extent.south, maxHeight);
+        expectBoundingSphereToContainPoint(boundingSphere, point, projection);
+
+        point = new Cartographic(extent.getCenter().longitude, extent.north, minHeight);
+        expectBoundingSphereToContainPoint(boundingSphere, point, projection);
+
+        point = new Cartographic(extent.getCenter().longitude, extent.north, maxHeight);
+        expectBoundingSphereToContainPoint(boundingSphere, point, projection);
+
+        point = new Cartographic(extent.west, extent.getCenter().latitude, minHeight);
+        expectBoundingSphereToContainPoint(boundingSphere, point, projection);
+
+        point = new Cartographic(extent.west, extent.getCenter().latitude, maxHeight);
+        expectBoundingSphereToContainPoint(boundingSphere, point, projection);
+
+        point = new Cartographic(extent.east, extent.getCenter().latitude, minHeight);
+        expectBoundingSphereToContainPoint(boundingSphere, point, projection);
+
+        point = new Cartographic(extent.east, extent.getCenter().latitude, maxHeight);
+        expectBoundingSphereToContainPoint(boundingSphere, point, projection);
     });
 });


### PR DESCRIPTION
This is coming from the terrain branch, and is used there to create a bounding sphere for terrain tile culling in Columbus View.  I'm creating separate pull requests for stuff that can go into master ahead of the terrain support itself.
