### PR TITLE
Fix firefox warning caused by invalid max anisotropy setting.

### DIFF
--- a/Source/Renderer/Texture.js
+++ b/Source/Renderer/Texture.js
@@ -246,7 +246,7 @@ define([
         gl.texParameteri(target, gl.TEXTURE_WRAP_S, s.wrapS);
         gl.texParameteri(target, gl.TEXTURE_WRAP_T, s.wrapT);
         if (this._textureFilterAnisotropic) {
-            gl.texParameteri(target, this._textureFilterAnisotropic.TEXTURE_MAX_ANISOTROPY_EXT, s.maximumAnisotropy);
+            gl.texParameteri(target, this._textureFilterAnisotropic.TEXTURE_MAX_ANISOTROPY_EXT, s.maximumAnisotropy || 1);
         }
         gl.bindTexture(target, null);
 


### PR DESCRIPTION
From the terrain branch...

If the `maximumAnisotropy` property was not specified in a call to `Texture.setSampler`, Cesium would end up calling this with a value of undefined:

`gl.texParameteri(target, this._textureFilterAnisotropic.TEXTURE_MAX_ANISOTROPY_EXT, s.maximumAnisotropy);`

In Chrome, this is silently ignored.  In Firefox, it prints a warning to the error console.

My simple fix is to use a value of 1 if `s.maximumAnisotropy` is falsy.
