### PR TITLE
Use context.createSampler to create samplers.

### DIFF
--- a/Source/Renderer/Texture.js
+++ b/Source/Renderer/Texture.js
@@ -219,13 +219,18 @@ define([
     };
 
     /**
-    * DOC_TBA
+    * Sets the sampler to use when sampling this texture.
     *
     * @memberof Texture
     *
-    * @param sampler optional.
+    * @param [sampler] The sampler to use.  Create a sampler by calling {@link Context#createSampler}.  If this
+    *                  parameter is not specified, a default sampler is used.  The default sampler clamps texture
+    *                  coordinates in both directions, uses linear filtering for both magnification and minifcation,
+    *                  and uses a maximum anisotropy of 1.0.
     *
     * @exception {DeveloperError} This texture was destroyed, i.e., destroy() was called.
+    *
+    * @see Context#createSampler
     */
     Texture.prototype.setSampler = function(sampler) {
         var s = sampler || {

--- a/Source/ThirdParty/Uri.js
+++ b/Source/ThirdParty/Uri.js
@@ -1,6 +1,6 @@
 /**
- * @license
  * @fileOverview
+ * @license
  *
  * Grauw URI utilities
  *
@@ -62,7 +62,6 @@ define(function() {
 	/**
 	 * Returns the scheme part of the URI.
 	 * In "http://example.com:80/a/b?x#y" this is "http".
-	 * @return
 	 */
 	URI.prototype.getScheme = function() {
 		return this.scheme;
@@ -71,7 +70,6 @@ define(function() {
 	/**
 	 * Returns the authority part of the URI.
 	 * In "http://example.com:80/a/b?x#y" this is "example.com:80".
-	 * @return
 	 */
 	URI.prototype.getAuthority = function() {
 		return this.authority;
@@ -81,7 +79,6 @@ define(function() {
 	 * Returns the path part of the URI.
 	 * In "http://example.com:80/a/b?x#y" this is "/a/b".
 	 * In "mailto:mike@example.com" this is "mike@example.com".
-	 * @return
 	 */
 	URI.prototype.getPath = function() {
 		return this.path;
@@ -90,7 +87,6 @@ define(function() {
 	/**
 	 * Returns the query part of the URI.
 	 * In "http://example.com:80/a/b?x#y" this is "x".
-	 * @return
 	 */
 	URI.prototype.getQuery = function() {
 		return this.query;
@@ -99,7 +95,6 @@ define(function() {
 	/**
 	 * Returns the fragment part of the URI.
 	 * In "http://example.com:80/a/b?x#y" this is "y".
-	 * @return
 	 */
 	URI.prototype.getFragment = function() {
 		return this.fragment;


### PR DESCRIPTION
Previously, ImageryLayer was building the object literal manually.

As a bonus, this pull request also fixes some problems in Uri.js that prevented the doc build from completing successfully.
