### PR TITLE
Rotation matrix creation functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ Beta Releases
 * Added `fromCssColorString` to `Color` to create a `Color` instance from any CSS value.
 * Added `fromHsl` to `Color` to create a `Color` instance from H, S, L values.
 * Added `Scene.backgroundColor`.
-* Added `Matrix2.fromRotation`.
+* Added `Matrix3.fromRotationX`, `Matrix3.fromRotationY`, `Matrix3.fromRotationZ`, and `Matrix2.fromRotation`.
 * Fixed camera tilt close to the `minimumZoomDistance`.
 * Fixed a bug that could lead to blue tiles when zoomed in close to the North and South poles.
 * Fixed a bug where removing labels would remove the wrong label and ultimately cause a crash.

--- a/Source/Core/Matrix2.js
+++ b/Source/Core/Matrix2.js
@@ -101,7 +101,7 @@ define([
     /**
      * Creates a rotation matrix.
      *
-     * @param {Number} angle The angle, in radians, of the counterclockwise rotation.
+     * @param {Number} angle The angle, in radians, of the rotation.  Positive angles are counterclockwise.
      * @param {Matrix2} [result] The object in which the result will be stored, if undefined a new instance will be created.
      *
      * @returns The modified result parameter, or a new Matrix2 instance if one was not provided.
@@ -115,7 +115,7 @@ define([
      * var rotated = m.multiplyByVector(p);
      */
     Matrix2.fromRotation = function(angle, result) {
-        if (typeof values === 'angle') {
+        if (typeof angle === 'undefined') {
             throw new DeveloperError('angle is required.');
         }
 

--- a/Source/Core/Matrix3.js
+++ b/Source/Core/Matrix3.js
@@ -219,6 +219,138 @@ define([
     };
 
     /**
+     * Creates a rotation matrix around the x-axis.
+     *
+     * @param {Number} angle The angle, in radians, of the rotation.  Positive angles are counterclockwise.
+     * @param {Matrix3} [result] The object in which the result will be stored, if undefined a new instance will be created.
+     *
+     * @returns The modified result parameter, or a new Matrix3 instance if one was not provided.
+     *
+     * @exception {DeveloperError} angle is required.
+     *
+     * @example
+     * // Rotate a point 45 degrees counterclockwise around the x-axis.
+     * var p = new Cartesian3(5, 6, 7);
+     * var m = Matrix3.fromRotationX(CesiumMath.toRadians(45.0));
+     * var rotated = m.multiplyByVector(p);
+     */
+    Matrix3.fromRotationX = function(angle, result) {
+        if (typeof angle === 'undefined') {
+            throw new DeveloperError('angle is required.');
+        }
+
+        var cosAngle = Math.cos(angle);
+        var sinAngle = Math.sin(angle);
+
+        if (typeof result === 'undefined') {
+            return new Matrix3(
+                1.0, 0.0, 0.0,
+                0.0, cosAngle, -sinAngle,
+                0.0, sinAngle, cosAngle);
+        }
+
+        result[0] = 1.0;
+        result[1] = 0.0;
+        result[2] = 0.0;
+        result[3] = 0.0;
+        result[4] = cosAngle;
+        result[5] = sinAngle;
+        result[6] = 0.0;
+        result[7] = -sinAngle;
+        result[8] = cosAngle;
+
+        return result;
+    };
+
+    /**
+     * Creates a rotation matrix around the y-axis.
+     *
+     * @param {Number} angle The angle, in radians, of the rotation.  Positive angles are counterclockwise.
+     * @param {Matrix3} [result] The object in which the result will be stored, if undefined a new instance will be created.
+     *
+     * @returns The modified result parameter, or a new Matrix3 instance if one was not provided.
+     *
+     * @exception {DeveloperError} angle is required.
+     *
+     * @example
+     * // Rotate a point 45 degrees counterclockwise around the y-axis.
+     * var p = new Cartesian3(5, 6, 7);
+     * var m = Matrix3.fromRotationY(CesiumMath.toRadians(45.0));
+     * var rotated = m.multiplyByVector(p);
+     */
+    Matrix3.fromRotationY = function(angle, result) {
+        if (typeof angle === 'undefined') {
+            throw new DeveloperError('angle is required.');
+        }
+
+        var cosAngle = Math.cos(angle);
+        var sinAngle = Math.sin(angle);
+
+        if (typeof result === 'undefined') {
+            return new Matrix3(
+                cosAngle, 0.0, sinAngle,
+                0.0, 1.0, 0.0,
+                -sinAngle, 0.0, cosAngle);
+        }
+
+        result[0] = cosAngle;
+        result[1] = 0.0;
+        result[2] = -sinAngle;
+        result[3] = 0.0;
+        result[4] = 1.0;
+        result[5] = 0.0;
+        result[6] = sinAngle;
+        result[7] = 0.0;
+        result[8] = cosAngle;
+
+        return result;
+    };
+
+    /**
+     * Creates a rotation matrix around the z-axis.
+     *
+     * @param {Number} angle The angle, in radians, of the rotation.  Positive angles are counterclockwise.
+     * @param {Matrix3} [result] The object in which the result will be stored, if undefined a new instance will be created.
+     *
+     * @returns The modified result parameter, or a new Matrix3 instance if one was not provided.
+     *
+     * @exception {DeveloperError} angle is required.
+     *
+     * @example
+     * // Rotate a point 45 degrees counterclockwise around the z-axis.
+     * var p = new Cartesian3(5, 6, 7);
+     * var m = Matrix3.fromRotationZ(CesiumMath.toRadians(45.0));
+     * var rotated = m.multiplyByVector(p);
+     */
+    Matrix3.fromRotationZ = function(angle, result) {
+        if (typeof angle === 'undefined') {
+            throw new DeveloperError('angle is required.');
+        }
+
+        var cosAngle = Math.cos(angle);
+        var sinAngle = Math.sin(angle);
+
+        if (typeof result === 'undefined') {
+            return new Matrix3(
+                cosAngle, -sinAngle, 0.0,
+                sinAngle, cosAngle, 0.0,
+                0.0, 0.0, 1.0);
+        }
+
+        result[0] = cosAngle;
+        result[1] = sinAngle;
+        result[2] = 0.0;
+        result[3] = -sinAngle;
+        result[4] = cosAngle;
+        result[5] = 0.0;
+        result[6] = 0.0;
+        result[7] = 0.0;
+        result[8] = 1.0;
+
+        return result;
+    };
+
+    /**
      * Creates an Array from the provided Matrix3 instance.
      * The array will be in column-major order.
      * @memberof Matrix3

--- a/Specs/Core/Matrix2Spec.js
+++ b/Specs/Core/Matrix2Spec.js
@@ -54,17 +54,23 @@ defineSuite([
         expect(matrix).toEqual(expected);
     });
 
-    it('Matrix2.fromRotation works without a result parameter', function() {
+    it('fromRotation works without a result parameter', function() {
         var matrix = Matrix2.fromRotation(0.0);
         expect(matrix).toEqual(Matrix2.IDENTITY);
     });
 
-    it('Matrix2.fromRotation works with a result parameter', function() {
+    it('fromRotation works with a result parameter', function() {
         var expected = new Matrix2(0.0, -1.0, 1.0, 0.0);
         var result = new Matrix2();
         var matrix = Matrix2.fromRotation(CesiumMath.toRadians(90.0), result);
         expect(matrix).toBe(result);
         expect(matrix).toEqualEpsilon(expected, CesiumMath.EPSILON15);
+    });
+
+    it('fromRotation throws without angle', function() {
+        expect(function() {
+            Matrix2.fromRotation();
+        }).toThrow();
     });
 
     it('clone works without a result parameter', function() {

--- a/Specs/Core/Matrix3Spec.js
+++ b/Specs/Core/Matrix3Spec.js
@@ -117,6 +117,72 @@ defineSuite([
         expect(matrix).toEqual(expected);
     });
 
+    it('fromRotationX works without a result parameter', function() {
+        var matrix = Matrix3.fromRotationX(0.0);
+        expect(matrix).toEqual(Matrix3.IDENTITY);
+    });
+
+    it('fromRotationX works with a result parameter', function() {
+        var expected = new Matrix3(
+                1.0, 0.0,  0.0,
+                0.0, 0.0, -1.0,
+                0.0, 1.0,  0.0);
+        var result = new Matrix3();
+        var matrix = Matrix3.fromRotationX(CesiumMath.toRadians(90.0), result);
+        expect(matrix).toBe(result);
+        expect(matrix).toEqualEpsilon(expected, CesiumMath.EPSILON15);
+    });
+
+    it('fromRotationX throws without angle', function() {
+        expect(function() {
+            Matrix3.fromRotationX();
+        }).toThrow();
+    });
+
+    it('fromRotationY works without a result parameter', function() {
+        var matrix = Matrix3.fromRotationY(0.0);
+        expect(matrix).toEqual(Matrix3.IDENTITY);
+    });
+
+    it('fromRotationY works with a result parameter', function() {
+        var expected = new Matrix3(
+                 0.0, 0.0, 1.0,
+                 0.0, 1.0, 0.0,
+                -1.0, 0.0, 0.0);
+        var result = new Matrix3();
+        var matrix = Matrix3.fromRotationY(CesiumMath.toRadians(90.0), result);
+        expect(matrix).toBe(result);
+        expect(matrix).toEqualEpsilon(expected, CesiumMath.EPSILON15);
+    });
+
+    it('fromRotationY throws without angle', function() {
+        expect(function() {
+            Matrix3.fromRotationY();
+        }).toThrow();
+    });
+
+    it('fromRotationZ works without a result parameter', function() {
+        var matrix = Matrix3.fromRotationZ(0.0);
+        expect(matrix).toEqual(Matrix3.IDENTITY);
+    });
+
+    it('fromRotationZ works with a result parameter', function() {
+        var expected = new Matrix3(
+                0.0, -1.0, 0.0,
+                1.0,  0.0, 0.0,
+                0.0,  0.0, 1.0);
+        var result = new Matrix3();
+        var matrix = Matrix3.fromRotationZ(CesiumMath.toRadians(90.0), result);
+        expect(matrix).toBe(result);
+        expect(matrix).toEqualEpsilon(expected, CesiumMath.EPSILON15);
+    });
+
+    it('fromRotationZ throws without angle', function() {
+        expect(function() {
+            Matrix3.fromRotationZ();
+        }).toThrow();
+    });
+
     it('clone works without a result parameter', function() {
         var expected = new Matrix3(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
         var returnedResult = expected.clone();


### PR DESCRIPTION
Added functions for creating rotation matrices around major axes to `Matrix2` and `Matrix3`.  This is part of a bigger change to be able to orient textures on polygons, instead of them always orienting north.  However, that change is not as trivial as I thought so these are coming in separately.
