### PR TITLE
Ray-Ellipsoid Intersections

### DIFF
--- a/Source/Core/IntersectionTests.js
+++ b/Source/Core/IntersectionTests.js
@@ -76,7 +76,7 @@ define([
      *
      * @param {Ray} ray The ray.
      * @param {Ellipsoid} ellipsoid The ellipsoid.
-     * @returns {Array} An array of one or two intersection scalars for points along the ray or undefined if there are no intersections.
+     * @returns {Object} An object with the first (<code>start</code>) and the second (<code>stop</code>) intersection scalars for points along the ray or undefined if there are no intersections.
      *
      * @exception {DeveloperError} ray is required.
      * @exception {DeveloperError} ellipsoid is required.
@@ -145,30 +145,13 @@ define([
             difference = q2 - 1.0; // Negatively valued.
             w2 = w.magnitudeSquared();
             product = w2 * difference; // Negatively valued.
-            if (qw < 0.0) {
-                // Looking inward.
-                discriminant = qw * qw - product;
-                temp = qw - Math.sqrt(discriminant); // Avoid cancellation.  Negatively valued.
-                return {
-                    start : 0.0,
-                    stop : difference / temp
-                };
-            } else if (qw > 0.0) {
-                // Looking outward.
-                discriminant = qw * qw - product;
-                temp = qw + Math.sqrt(discriminant); // Avoid cancellation. Positively valued.
-                return {
-                    start : 0.0,
-                    stop : temp / w2
-                };
-            } else {
-                // qw == 0.0 // Looking tangent.
-                temp = Math.sqrt(-product);
-                return {
-                    start : 0.0,
-                    stop : temp / w2
-                };
-            }
+
+            discriminant = qw * qw - product;
+            temp = -qw + Math.sqrt(discriminant); // Positively valued.
+            return {
+                start : 0.0,
+                stop : temp / w2
+            };
         } else {
             // q2 == 1.0. On ellipsoid.
             if (qw < 0.0) {

--- a/Source/Shaders/BuiltinFunctions.glsl
+++ b/Source/Shaders/BuiltinFunctions.glsl
@@ -763,26 +763,10 @@ czm_raySegment czm_rayEllipsoidIntersectionInterval(czm_ray ray, czm_ellipsoid e
         float difference = q2 - 1.0; // Negatively valued.
         float w2 = dot(w, w);
         float product = w2 * difference; // Negatively valued.
-        if (qw < 0.0) // Looking inward.
-        {
-            float discriminant = qw * qw - product;
-            float temp = qw - sqrt(discriminant); // Avoid cancellation.  Negatively valued.
-            czm_raySegment i = czm_raySegment(0.0, difference / temp);
-            return i;
-        }
-        else if (qw > 0.0) // Looking outward.
-        {
-            float discriminant = qw * qw - product;
-            float temp = qw + sqrt(discriminant); // Avoid cancellation. Positively valued.
-            czm_raySegment i = czm_raySegment(0.0, temp / w2);
-            return i;
-        }
-        else // qw == 0.0 // Looking tangent.
-        {
-            float temp = sqrt(-product);
-            czm_raySegment i = czm_raySegment(0.0, temp / w2);
-            return i;
-        }
+        float discriminant = qw * qw - product;
+        float temp = -qw + sqrt(discriminant); // Positively valued.
+        czm_raySegment i = czm_raySegment(0.0, temp / w2);
+        return i;
     }
     else // q2 == 1.0. On ellipsoid.
     {

--- a/Specs/Core/IntersectionTestsSpec.js
+++ b/Specs/Core/IntersectionTestsSpec.js
@@ -128,13 +128,40 @@ defineSuite([
         expect(typeof intersections === 'undefined').toEqual(true);
     });
 
-    it('rayEllipsoid inside intersection', function() {
-        var unitSphere = Ellipsoid.UNIT_SPHERE;
+    it('rayEllipsoid ray inside pointing in intersection', function() {
+        var ellipsoid = Ellipsoid.WGS84;
 
-        var ray = new Ray(Cartesian3.ZERO, new Cartesian3(0.0, 0.0, 1.0));
-        var intersections = IntersectionTests.rayEllipsoid(ray, unitSphere);
-        expect(intersections.start).toEqualEpsilon(0.0, CesiumMath.EPSILON14);
-        expect(intersections.stop).toEqualEpsilon(1.0, CesiumMath.EPSILON14);
+        var origin = new Cartesian3(20000.0, 0.0, 0.0);
+        var direction = origin.normalize().negate();
+        var ray = new Ray(origin, direction);
+
+        var expected = {
+                start : 0.0,
+                stop : ellipsoid.getRadii().x + origin.x
+        };
+        var actual = IntersectionTests.rayEllipsoid(ray, ellipsoid);
+
+        expect(actual).toBeDefined();
+        expect(actual.start).toEqual(expected.start);
+        expect(actual.stop).toEqual(expected.stop);
+    });
+
+    it('rayEllipsoid ray inside pointing out intersection', function() {
+        var ellipsoid = Ellipsoid.WGS84;
+
+        var origin = new Cartesian3(20000.0, 0.0, 0.0);
+        var direction = origin.normalize();
+        var ray = new Ray(origin, direction);
+
+        var expected = {
+                start : 0.0,
+                stop : ellipsoid.getRadii().x - origin.x
+        };
+        var actual = IntersectionTests.rayEllipsoid(ray, ellipsoid);
+
+        expect(actual).toBeDefined();
+        expect(actual.start).toEqual(expected.start);
+        expect(actual.stop).toEqual(expected.stop);
     });
 
     it('rayEllipsoid tangent intersections', function() {


### PR DESCRIPTION
Fix ray-ellipsoid intersection when the ray origin is inside the ellipsoid. Modified both the GLSL and Javascript functions.

This fixes the second part of #390.
