### PR TITLE
Produce a built version of CesiumViewerWidget.

### DIFF
--- a/Apps/CesiumViewer/CesiumViewer.js
+++ b/Apps/CesiumViewer/CesiumViewer.js
@@ -1,7 +1,6 @@
 /*global define*/
 define([
         'dojo/_base/window',
-        'dojo/dom',
         'dojo/dom-class',
         'dojo/io-query',
         'dojo/parser',
@@ -10,7 +9,6 @@ define([
         'Widgets/Dojo/CesiumViewerWidget'
     ], function(
         win,
-        dom,
         domClass,
         ioQuery,
         parser,
@@ -34,7 +32,7 @@ define([
             endUserOptions : endUserOptions,
             enableDragDrop : true
         });
-        widget.placeAt(dom.byId('cesiumContainer'));
+        widget.placeAt('cesiumContainer');
         widget.startup();
 
         domClass.remove(win.body(), 'loading');

--- a/Apps/CesiumViewer/CesiumViewer.profile.js
+++ b/Apps/CesiumViewer/CesiumViewer.profile.js
@@ -18,6 +18,10 @@ var profile = {
         'CesiumViewer/CesiumViewerStartup' : {
             include : ['CesiumViewer/CesiumViewer', 'CesiumViewer/CesiumViewerStartup'],
             copyright : 'Source/copyrightHeader.js'
+        },
+        'Widgets/Dojo/CesiumViewerWidget' : {
+            include : ['Widgets/Dojo/CesiumViewerWidget'],
+            copyright : 'Source/copyrightHeader.js'
         }
     },
 

--- a/build.xml
+++ b/build.xml
@@ -327,6 +327,7 @@
 				<exclude name="*.html" />
 				<exclude name="*.ico" />
 				<exclude name="dojo/dojo.js" />
+				<exclude name="Widgets/Dojo/CesiumViewerWidget.js" />
 				<exclude name="${app.name}.js" />
 				<exclude name="${appStartupScript}" />
 


### PR DESCRIPTION
The "Cesium Viewer" application is not what people should be using in their own "applications" (simple though those applications may be) that want to use the widget.  So, create a built layer for the CesiumViewerWidget, allowing clients to require that in and recieve all dependencies, allowing them to construct a CesiumViewerWidget instance however they like and put it whereever.
