### PR TITLE
initial draw poly example

### DIFF
--- a/Apps/Sandcastle/gallery/Picking.html
+++ b/Apps/Sandcastle/gallery/Picking.html
@@ -335,12 +335,7 @@ require([
             if (cartesian) {
                 this._click2 = this._ellipsoid.cartesianToCartographic(cartesian);
             }
-            this._mouseHandler.setInputAction(function(movement) {
-            }, Cesium.ScreenSpaceEventType.LEFT_DOWN);
-            this._mouseHandler.setInputAction(function(movement) {
-            }, Cesium.ScreenSpaceEventType.LEFT_UP);
-            this._mouseHandler.setInputAction(function(movement) {
-            }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+            this._mouseHandler.destroy();
 
             this._finishHandler(this.getExtent(this._click1, this._click2));
         };

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Beta Releases
 * Added a line segment-plane intersection test to `IntersectionTests`.
 * Fixed an issue where a `PolylineCollection` with a model matrix other than the identity would be incorrectly rendered in 2D and Columbus view.
 * Fixed an issue in the `ScreenSpaceCameraController` where disabled mouse events can cause the camera to be moved after being re-enabled.
+* Added interactive extent drawing to the `Picking` Sandcastle example.
 
 ### b13 - 2013-02-01
 


### PR DESCRIPTION
As per this thread...
https://groups.google.com/forum/#!topic/cesium-dev/WqTPARFnAwU/discussion

This code mostly works, but there is a mouse interaction issue.  I think SelectPoly.prototype.enableInput() is insufficient as it doesn't cancel inertia etc.  It would be great to see disableInput() and enableInput() centralized in Cesium (they also appear in Camera.html example).  Might even be worth considering incorporating selection helpers such as SelectPoly into Cesium?

I'm happy for this code to be cannibalised as required.  For our own use, it would be helpful to know how to fix the interaction issue.
