### PR TITLE
Eliminated allocations when setting matrix uniforms

### DIFF
--- a/Source/Renderer/ShaderProgram.js
+++ b/Source/Renderer/ShaderProgram.js
@@ -1245,9 +1245,9 @@ define([
         }
     }
 
-    var scratchUniformMatrix2 = new Float32Array(4);
-    var scratchUniformMatrix3 = new Float32Array(9);
-    var scratchUniformMatrix4 = new Float32Array(16);
+    var scratchUniformMatrix2 = (typeof Float32Array !== 'undefined') ? new Float32Array(4) : undefined;
+    var scratchUniformMatrix3 = (typeof Float32Array !== 'undefined') ? new Float32Array(9) : undefined;
+    var scratchUniformMatrix4 = (typeof Float32Array !== 'undefined') ? new Float32Array(16) : undefined;
 
     /**
      * A shader program's uniform, including the uniform's value.  This is most commonly used to change


### PR DESCRIPTION
This eliminates allocating arrays when setting matrix uniforms, which happens a lot - 100s of times per frame.

If we can masquerade our matrices as typed arrays or `sequence<GLfloat>`, we can also avoid the copy.  Currently, passing our matrices directly to `uniformMatrix4fv` yields a `TypeError`.  No rush, this is a nice win in the meantime.

Did not update CHANGES.md intentionally.
