### PR TITLE
Adjust default camera position and make consistent.

### DIFF
--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -65,7 +65,7 @@ define([
         this._invTransform = Matrix4.IDENTITY.clone();
 
         var maxRadii = Ellipsoid.WGS84.getMaximumRadius();
-        var position = new Cartesian3(0.0, -2.0, 1.0).normalize().multiplyByScalar(2.0 * maxRadii);
+        var position = new Cartesian3(0.0, -2.0, 1.0).normalize().multiplyByScalar(2.5 * maxRadii);
 
         /**
          * The position of the camera.

--- a/Source/Widgets/Dojo/CesiumViewerWidget.js
+++ b/Source/Widgets/Dojo/CesiumViewerWidget.js
@@ -672,7 +672,6 @@ define([
             scene.skyAtmosphere = new SkyAtmosphere(ellipsoid);
 
             var camera = scene.getCamera();
-            camera.position = camera.position.multiplyByScalar(1.5);
             camera.controller.constrainedAxis = Cartesian3.UNIT_Z;
 
             var handler = new ScreenSpaceEventHandler(canvas);

--- a/Source/Widgets/Dojo/CesiumWidget.js
+++ b/Source/Widgets/Dojo/CesiumWidget.js
@@ -230,7 +230,6 @@ define([
             scene.skyAtmosphere = new SkyAtmosphere(ellipsoid);
 
             var camera = scene.getCamera();
-            camera.position = camera.position.multiplyByScalar(1.5);
             camera.controller.constrainedAxis = Cartesian3.UNIT_Z;
 
             var handler = new ScreenSpaceEventHandler(canvas);

--- a/Specs/Scene/ScreenSpaceCameraControllerSpec.js
+++ b/Specs/Scene/ScreenSpaceCameraControllerSpec.js
@@ -860,7 +860,7 @@ defineSuite([
 
         moveMouse(MouseButtons.MIDDLE, startPosition, endPosition);
         updateController(frameState);
-        expect(camera.position).toEqual(position);
+        expect(camera.position).toEqualEpsilon(position, CesiumMath.EPSILON8);
         expect(camera.direction).toEqualEpsilon(camera.position.negate().normalize(), CesiumMath.EPSILON15);
         expect(camera.direction.cross(camera.up)).toEqualEpsilon(camera.right, CesiumMath.EPSILON14);
         expect(camera.right.cross(camera.direction)).toEqualEpsilon(camera.up, CesiumMath.EPSILON15);
@@ -933,7 +933,7 @@ defineSuite([
         moveMouse(MouseButtons.LEFT, startPosition, endPosition);
         updateController(frameState);
 
-        expect(camera.position).toEqualEpsilon(axis.multiplyByScalar(camera.position.magnitude()), CesiumMath.EPSILON9);
+        expect(camera.position).toEqualEpsilon(axis.multiplyByScalar(camera.position.magnitude()), CesiumMath.EPSILON8);
         expect(camera.direction).toEqualEpsilon(axis.negate(), CesiumMath.EPSILON15);
         expect(Cartesian3.dot(camera.up, axis)).toBeLessThan(CesiumMath.EPSILON2);
         expect(camera.right).toEqualEpsilon(camera.direction.cross(camera.up), CesiumMath.EPSILON15);


### PR DESCRIPTION
Previously the widgets adjusted the default camera position after constructing the scene, meaning that users had inconsistent defaults depending on whether they used a widget or not.
