### PR TITLE
Fix an off by one error in CZML handling

### DIFF
--- a/Source/DynamicScene/DynamicProperty.js
+++ b/Source/DynamicScene/DynamicProperty.js
@@ -241,7 +241,7 @@ define([
         return thisValueType.getValue(intervalData.values, result);
     };
 
-    DynamicProperty._mergeNewSamples = function(epoch, times, values, newData, doublesPerValue, valueType) {
+    DynamicProperty._mergeNewSamples = function(epoch, times, values, newData, doublesPerValue) {
         var newDataIndex = 0, i, prevItem, timesInsertionPoint, valuesInsertionPoint, timesSpliceArgs, valuesSpliceArgs, currentTime, nextTime;
         while (newDataIndex < newData.length) {
             currentTime = czmlDateToJulianDate(newData[newDataIndex], epoch);
@@ -255,7 +255,7 @@ define([
                 valuesInsertionPoint = timesInsertionPoint * doublesPerValue;
                 valuesSpliceArgs = [valuesInsertionPoint, 0];
                 prevItem = undefined;
-                nextTime = times[timesInsertionPoint + 1];
+                nextTime = times[timesInsertionPoint];
                 while (newDataIndex < newData.length) {
                     currentTime = czmlDateToJulianDate(newData[newDataIndex], epoch);
                     if ((typeof prevItem !== 'undefined' && JulianDate.compare(prevItem, currentTime) >= 0) ||

--- a/Specs/DynamicScene/DynamicPropertySpec.js
+++ b/Specs/DynamicScene/DynamicPropertySpec.js
@@ -273,4 +273,40 @@ defineSuite([
         expect(times).toEqual(expectedTimes, JulianDate.compare);
         expect(values).toEqual(expectedValues);
     });
+
+    var interwovenData = [{
+        epoch : JulianDate.fromIso8601("20130205T150405.704999999999927Z"),
+        values : [0.0, 1,
+                   120.0, 2,
+                   240.0, 3,
+                   360.0, 4,
+                   480.0, 6,
+                   600.0, 8,
+                   720.0, 10,
+                   840.0, 12,
+                   960.0, 14,
+                   1080.0, 16]
+    }, {
+        epoch : JulianDate.fromIso8601("20130205T151151.60499999999956Z"),
+         values : [0.0, 5,
+                   120.0, 7,
+                   240.0, 9,
+                   360.0, 11,
+                   480.0, 13,
+                   600.0, 15,
+                   720.0, 17,
+                   840.0, 18,
+                   960.0, 19,
+                   1080.0, 20]
+    }];
+
+    it('_mergeNewSamples works with interwoven data', function() {
+        var times = [];
+        var values = [];
+        DynamicProperty._mergeNewSamples(interwovenData[0].epoch, times, values, interwovenData[0].values, 1);
+        DynamicProperty._mergeNewSamples(interwovenData[1].epoch, times, values, interwovenData[1].values, 1);
+        for ( var i = 0; i < values.length; i++) {
+            expect(values[i]).toBe(i + 1);
+        }
+    });
 });


### PR DESCRIPTION
When CZML packets have overlapping data within the same interval, we were improperly merging them together, resulting in out of order data.  I fixed the issue and added a unit test to cover it.
