### PR TITLE
Fix faulty logic in Extent.isEmpty.

### DIFF
--- a/Source/Core/Extent.js
+++ b/Source/Core/Extent.js
@@ -306,15 +306,15 @@ define([
     };
 
     /**
-     * Determines if the extent is empty, i.e., if <code>west === east</code>
-     * and <code>south === north</code>.
+     * Determines if the extent is empty, i.e., if <code>west >= east</code>
+     * or <code>south >= north</code>.
      *
      * @memberof Extent
      *
      * @return {Boolean} True if the extent is empty; otherwise, false.
      */
     Extent.prototype.isEmpty = function() {
-        return (this.west >= this.east) && (this.south >= this.north);
+        return this.west >= this.east || this.south >= this.north;
     };
 
     var subsampleLlaScratch = new Cartographic();

--- a/Specs/Core/ExtentSpec.js
+++ b/Specs/Core/ExtentSpec.js
@@ -256,14 +256,34 @@ defineSuite([
         expect(extent.contains(new Cartographic(east + 0.1, north))).toEqual(false);
     });
 
-    it('isEmpty reports an empty extent', function() {
+    it('isEmpty reports a non-empty extent', function() {
+        var extent = new Extent(1.0, 1.0, 2.0, 2.0);
+        expect(extent.isEmpty()).toEqual(false);
+    });
+
+    it('isEmpty reports true for a point', function() {
         var extent = new Extent(2.0, 2.0, 2.0, 2.0);
         expect(extent.isEmpty()).toEqual(true);
     });
 
-    it('isEmpty reports a non-empty extent', function() {
-        var extent = new Extent(1.0, 1.0, 2.0, 2.0);
-        expect(extent.isEmpty()).toEqual(false);
+    it('isEmpty reports true for a north-south line', function() {
+        var extent = new Extent(2.0, 2.0, 2.0, 2.1);
+        expect(extent.isEmpty()).toEqual(true);
+    });
+
+    it('isEmpty reports true for an east-west line', function() {
+        var extent = new Extent(2.0, 2.0, 2.1, 2.0);
+        expect(extent.isEmpty()).toEqual(true);
+    });
+
+    it('isEmpty reports true if north-south direction is degenerate', function() {
+        var extent = new Extent(1.0, 1.1, 2.0, 1.0);
+        expect(extent.isEmpty()).toEqual(true);
+    });
+
+    it('isEmpty reports true if east-west direction is degenerate', function() {
+        var extent = new Extent(1.1, 1.0, 1.0, 2.0);
+        expect(extent.isEmpty()).toEqual(true);
     });
 
     it('subsample works south of the equator', function() {


### PR DESCRIPTION
An extent should be considered empty if either `west >= east` OR `south >= north`.  Both need not be true.

I considered requiring that `west > east`, so a point or a line is considered a valid extent.  This would be break the only user of this method though, `Polygon`, and I can argue this either way, so I ended up bailing on it.
