### PR TITLE
Remove need to call Timeline.updateFromClock.

### DIFF
--- a/Apps/TimelineDemo/TimelineDemo.js
+++ b/Apps/TimelineDemo/TimelineDemo.js
@@ -101,7 +101,6 @@ define(['dojo',
 
         function tick() {
             var time = clock.tick();
-            timeline.updateFromClock();
             updateScrubTime(time);
             requestAnimationFrame(tick);
         }

--- a/Source/Widgets/Dojo/CesiumViewerWidget.js
+++ b/Source/Widgets/Dojo/CesiumViewerWidget.js
@@ -1059,7 +1059,6 @@ define([
             } else {
                 currentTime = this.clock.currentTime;
             }
-            this.timeline.updateFromClock();
             this.visualizers.update(currentTime);
 
             // Update the camera to stay centered on the selected object, if any.

--- a/Source/Widgets/Timeline/Timeline.js
+++ b/Source/Widgets/Timeline/Timeline.js
@@ -75,6 +75,7 @@ define([
         } else {
             this._topElement = id;
         }
+
         this._clock = clock;
         this._scrubJulian = clock.currentTime;
         this._mainTicSpan = -1;
@@ -138,6 +139,9 @@ define([
         this.addEventListener = function(type, listener, useCapture) {
             widget._topElement.addEventListener(type, listener, useCapture);
         };
+
+        clock.onTick.addEventListener(this.updateFromClock, this);
+        this.updateFromClock();
     }
 
     Timeline.prototype.addHighlightRange = function(color, heightInPx) {


### PR DESCRIPTION
Register for the `Clock.onTick` event instead, which was introduced with the animation branch.

This is a minor tweak to bring Timeline in line with other widgets (event driven rather than manual updates from the user).  I plan on looking into refactoring Timeline to use knockout/viewModels soon, but I thought this was a good simple change in the mean time.
