### PR TITLE
Added DCO and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We love pull requests.  We promptly [review](https://github.com/AnalyticalGraphi
 
 or
 
-* Every commit is signed-off on to indicate agreement to the Developer Certificate of Origin (DCO).  The DCO was originally developed for the Linux kernel, and its text is here: [SubmittingPatches](https://github.com/wking/signed-off-by/blob/ab5bce80ad2259b47202b28905efff0d04032709/Documentation/SubmittingPatches).  Like the CLA, you retain copyright to your contributions, and we have the right to use them and incorporate them into Cesium.  A comment with a sign-off has a line like the following at the bottom:
+* Every commit is signed-off on to indicate agreement to the Developer Certificate of Origin (DCO).  The DCO was originally developed for the Linux kernel, and its text is here: [SubmittingPatches](https://github.com/wking/signed-off-by/blob/ab5bce80ad2259b47202b28905efff0d04032709/Documentation/SubmittingPatches).  Like the CLA, you retain copyright to your contributions, and we have the right to use them and incorporate them into Cesium.  A commit with a sign-off has a line like the following at the bottom:
 
 ```
 Signed-off-by: First-name Last-name <email-address>


### PR DESCRIPTION
The DCO is for #290.  Also see [signed-off-by](https://github.com/wking/signed-off-by).

Once in master, CONTRIBUTING.md should show up in pull requests as described [here](https://github.com/blog/1184-contributing-guidelines).

When this gets into master, I'll email the dev list and update the [Contributor's Guide](https://github.com/AnalyticalGraphicsInc/cesium/wiki/Contributor%27s-Guide) to link to it.  In the meantime, I'm going to cleanup the Contributor's Guide.
