### PR TITLE
Don't delete SVGs from built apps.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -382,8 +382,10 @@
 				<exclude name="dojo/resources/blank.gif" />
 				<exclude name="dijit/**/*.png" />
 				<exclude name="dijit/**/*.gif" />
+				<exclude name="dijit/**/*.svg" />
 				<exclude name="Widgets/**/*.png" />
 				<exclude name="Widgets/**/*.gif" />
+				<exclude name="Widgets/**/*.svg" />
 
 				<!-- always keep assets -->
 				<exclude name="Assets/**" />


### PR DESCRIPTION
I think this is the actual fix we need to make the full screen button show up in Cesium Viewer on cesium.agi.com
