### PR TITLE
Fixes #543.

### DIFF
--- a/Source/Scene/CentralBodySurface.js
+++ b/Source/Scene/CentralBodySurface.js
@@ -1006,35 +1006,35 @@ define([
                         } else {
                             uniformMap.dayTextureBrightness[numberOfDayTextures] = imageryLayer.brightness;
                         }
-                        applyBrightness = uniformMap.dayTextureBrightness[numberOfDayTextures] !== ImageryLayer.DEFAULT_BRIGHTNESS;
+                        applyBrightness = applyBrightness || uniformMap.dayTextureBrightness[numberOfDayTextures] !== ImageryLayer.DEFAULT_BRIGHTNESS;
 
                         if (typeof imageryLayer.contrast === 'function') {
                             uniformMap.dayTextureContrast[numberOfDayTextures] = imageryLayer.contrast(frameState, imageryLayer, imagery.x, imagery.y, imagery.level);
                         } else {
                             uniformMap.dayTextureContrast[numberOfDayTextures] = imageryLayer.contrast;
                         }
-                        applyContrast = uniformMap.dayTextureContrast[numberOfDayTextures] !== ImageryLayer.DEFAULT_CONTRAST;
+                        applyContrast = applyContrast || uniformMap.dayTextureContrast[numberOfDayTextures] !== ImageryLayer.DEFAULT_CONTRAST;
 
                         if (typeof imageryLayer.hue === 'function') {
                             uniformMap.dayTextureHue[numberOfDayTextures] = imageryLayer.hue(frameState, imageryLayer, imagery.x, imagery.y, imagery.level);
                         } else {
                             uniformMap.dayTextureHue[numberOfDayTextures] = imageryLayer.hue;
                         }
-                        applyHue = uniformMap.dayTextureHue[numberOfDayTextures] !== ImageryLayer.DEFAULT_HUE;
+                        applyHue = applyHue || uniformMap.dayTextureHue[numberOfDayTextures] !== ImageryLayer.DEFAULT_HUE;
 
                         if (typeof imageryLayer.saturation === 'function') {
                             uniformMap.dayTextureSaturation[numberOfDayTextures] = imageryLayer.saturation(frameState, imageryLayer, imagery.x, imagery.y, imagery.level);
                         } else {
                             uniformMap.dayTextureSaturation[numberOfDayTextures] = imageryLayer.saturation;
                         }
-                        applySaturation = uniformMap.dayTextureSaturation[numberOfDayTextures] !== ImageryLayer.DEFAULT_SATURATION;
+                        applySaturation = applySaturation || uniformMap.dayTextureSaturation[numberOfDayTextures] !== ImageryLayer.DEFAULT_SATURATION;
 
                         if (typeof imageryLayer.gamma === 'function') {
                             uniformMap.dayTextureOneOverGamma[numberOfDayTextures] = 1.0 / imageryLayer.gamma(frameState, imageryLayer, imagery.x, imagery.y, imagery.level);
                         } else {
                             uniformMap.dayTextureOneOverGamma[numberOfDayTextures] = 1.0 / imageryLayer.gamma;
                         }
-                        applyGamma = uniformMap.dayTextureOneOverGamma[numberOfDayTextures] !== 1.0 / ImageryLayer.DEFAULT_GAMMA;
+                        applyGamma = applyGamma || uniformMap.dayTextureOneOverGamma[numberOfDayTextures] !== 1.0 / ImageryLayer.DEFAULT_GAMMA;
 
                         ++numberOfDayTextures;
                     }


### PR DESCRIPTION
Only the last layer was being used to determine whether the fragment
shader should apply gamma correction, hue adjustment, etc.  In reality, if
any layer needs it, the fragment shader must do it.
