### PR TITLE
Fix bad caching in DynamicPointVisualizer.

### DIFF
--- a/Source/DynamicScene/DynamicPointVisualizer.js
+++ b/Source/DynamicScene/DynamicPointVisualizer.js
@@ -216,8 +216,8 @@ define([
             // CZML_TODO Determine official defaults
             billboard._visualizerColor = Color.WHITE.clone(billboard._visualizerColor);
             billboard._visualizerOutlineColor = Color.BLACK.clone(billboard._visualizerOutlineColor);
-            billboard._visualizerOutlineWidth = 2;
-            billboard._visualizerPixelSize = 3;
+            billboard._visualizerOutlineWidth = 0;
+            billboard._visualizerPixelSize = 1;
             needRedraw = true;
         } else {
             billboard = this._billboardCollection.get(pointVisualizerIndex);
@@ -233,8 +233,8 @@ define([
         var property = dynamicPoint.color;
         if (typeof property !== 'undefined') {
             color = property.getValue(time, color);
-            if (billboard._visualizerColor !== color) {
-                billboard._visualizerColor = color;
+            if (!Color.equals(billboard._visualizerColor, color)) {
+                Color.clone(color, billboard._visualizerColor);
                 needRedraw = true;
             }
         }
@@ -242,8 +242,8 @@ define([
         property = dynamicPoint.outlineColor;
         if (typeof property !== 'undefined') {
             outlineColor = property.getValue(time, outlineColor);
-            if (billboard._visualizerOutlineColor !== outlineColor) {
-                billboard._visualizerOutlineColor = outlineColor;
+            if (!Color.equals(billboard._visualizerOutlineColor, outlineColor)) {
+                Color.clone(outlineColor, billboard._visualizerOutlineColor);
                 needRedraw = true;
             }
         }

--- a/Specs/DynamicScene/DynamicPointVisualizerSpec.js
+++ b/Specs/DynamicScene/DynamicPointVisualizerSpec.js
@@ -137,11 +137,14 @@ defineSuite([
         expect(bb._visualizerOutlineWidth).toEqual(testObject.point.outlineWidth.getValue(time));
         expect(bb._visualizerPixelSize).toEqual(testObject.point.pixelSize.getValue(time));
 
-        testObject.position = new MockProperty(new Cartesian3(5678, 1234, 1293434));
-        point.color = new MockProperty(new Color(0.1, 0.2, 0.3, 0.4));
-        point.pixelSize = new MockProperty(2.5);
-        point.outlineColor = new MockProperty(new Color(0.5, 0.6, 0.7, 0.8));
-        point.outlineWidth = new MockProperty(12.5);
+        //There used to be a caching but with point visualizers.
+        //In order to verify it actually detect changes properly, we modify existing values
+        //here rather than creating new ones.
+        new Cartesian3(5678, 1234, 1293434).clone(testObject.position.value);
+        new Color(0.1, 0.2, 0.3, 0.4).clone(point.color.value);
+        point.pixelSize.value = 2.5;
+        new Color(0.5, 0.6, 0.7, 0.8).clone(point.outlineColor.value);
+        point.outlineWidth.value = 12.5;
 
         visualizer.update(time);
         expect(bb.getShow()).toEqual(testObject.point.show.getValue(time));


### PR DESCRIPTION
We were not only performing a bad color comparison, we were also caching a reference instead of cloning.  This resulted in point textures never being udpated to reflect the underlying DynamicPoint changes.

@shunter this is the issue I was just discussing with you.
