### PR TITLE
Cache DrawCommands in BillboardCollection.

### DIFF
--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -79,7 +79,7 @@ define([
     var allPassPurpose = 'all';
     var colorPassPurpose = 'color';
     var pickPassPurpose = 'pick';
-    var emptArray = [];
+    var emptyArray = [];
 
     /**
      * A renderable collection of billboards.  Billboards are viewport-aligned
@@ -1068,8 +1068,8 @@ define([
         var command;
         var j;
         var commandLists = this._commandLists;
-        commandLists.colorList = emptArray;
-        commandLists.pickList = emptArray;
+        commandLists.colorList = emptyArray;
+        commandLists.pickList = emptyArray;
         if (pass.color) {
             var colorList = this._colorCommands;
             commandLists.colorList = colorList;


### PR DESCRIPTION
Addressed issue #550

This seemed easy enough so I took a stab at it.  I kept it simple so we cache only as many as we need and discard them when we don't.
We could have a separte pool (or a generic ObjectPool) implementation if we want something more sphisticated, but I wasn't sure if the overhead was worth it.

What do you think @pjcozzi ?
