### PR TITLE
Destroy sub-materials.

### DIFF
--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -344,8 +344,9 @@ define([
         this._context = undefined;
         this._strict = undefined;
         this._template = undefined;
+        this._count = undefined;
 
-        initializeMaterial(description, 0, this);
+        initializeMaterial(description, this);
         Object.defineProperty(this, 'type', {
             value : this.type,
             writable : false
@@ -428,16 +429,17 @@ define([
         }
         for ( var material in materials) {
             if (materials.hasOwnProperty(material)) {
-                material.destroy();
+                materials[material].destroy();
             }
         }
         return destroyObject(this);
     };
 
-    function initializeMaterial(description, count, result) {
+    function initializeMaterial(description, result) {
         description = defaultValue(description, {});
         result._context = description.context;
         result._strict = defaultValue(description.strict, false);
+        result._count = defaultValue(description.count, 0);
         result._template = defaultValue(description.fabric, {});
         result._template.uniforms = defaultValue(result._template.uniforms, {});
         result._template.materials = defaultValue(result._template.materials, {});
@@ -465,9 +467,8 @@ define([
         }
 
         createMethodDefinition(result);
-        count = createUniforms(result, count);
-        count = createSubMaterials(result, count);
-        return count;
+        createUniforms(result);
+        createSubMaterials(result);
     }
 
     function checkForValidProperties(object, properties, result, throwNotFound) {
@@ -545,19 +546,18 @@ define([
         }
     }
 
-    function createUniforms(material, count) {
+    function createUniforms(material) {
         var uniforms = material._template.uniforms;
         for ( var uniformId in uniforms) {
             if (uniforms.hasOwnProperty(uniformId)) {
-                count = createUniform(material, uniformId, count);
+                createUniform(material, uniformId);
             }
         }
-        return count;
     }
 
     // Writes uniform declarations to the shader file and connects uniform values with
     // corresponding material properties through the returnUniforms function.
-    function createUniform(material, uniformId, count) {
+    function createUniform(material, uniformId) {
         var strict = material._strict;
         var materialUniforms = material._template.uniforms;
         var uniformValue = materialUniforms[uniformId];
@@ -594,7 +594,7 @@ define([
                 material.shaderSource = uniformPhrase + material.shaderSource;
             }
 
-            var newUniformId = uniformId + '_' + count++;
+            var newUniformId = uniformId + '_' + material._count++;
             if (replaceToken(material, uniformId, newUniformId) === 1 && strict) {
                 throw new DeveloperError('strict: shader source does not use uniform \'' + uniformId + '\'.');
             }
@@ -602,8 +602,6 @@ define([
             material.uniforms[uniformId] = uniformValue;
             material._uniforms[newUniformId] = returnUniform(material, uniformId, uniformType);
         }
-
-        return count;
     }
 
     // Checks for updates to material values to refresh the uniforms.
@@ -686,26 +684,27 @@ define([
     }
 
     // Create all sub-materials by combining source and uniforms together.
-    function createSubMaterials(material, count) {
+    function createSubMaterials(material) {
         var context = material._context;
         var strict = material._strict;
         var subMaterialTemplates = material._template.materials;
         for ( var subMaterialId in subMaterialTemplates) {
             if (subMaterialTemplates.hasOwnProperty(subMaterialId)) {
                 // Construct the sub-material.
-                var subMaterial = {};
-                count = initializeMaterial({
+                var subMaterial = new Material({
                     context : context,
                     strict : strict,
-                    fabric : subMaterialTemplates[subMaterialId]
-                }, count, subMaterial);
+                    fabric : subMaterialTemplates[subMaterialId],
+                    count : material._count
+                });
 
+                material._count = subMaterial._count;
                 material._uniforms = combine([material._uniforms, subMaterial._uniforms]);
                 material.materials[subMaterialId] = subMaterial;
 
                 // Make the material's czm_getMaterial unique by appending the sub-material type.
                 var originalMethodName = 'czm_getMaterial';
-                var newMethodName = originalMethodName + '_' + count++;
+                var newMethodName = originalMethodName + '_' + material._count++;
                 replaceToken(subMaterial, originalMethodName, newMethodName);
                 material.shaderSource = subMaterial.shaderSource + material.shaderSource;
 
@@ -716,7 +715,6 @@ define([
                 }
             }
         }
-        return count;
     }
 
     // Used for searching or replacing a token in a material's shader source with something else.

--- a/Specs/Scene/MaterialSpec.js
+++ b/Specs/Scene/MaterialSpec.js
@@ -709,7 +709,40 @@ defineSuite([
         material.uniforms.image = './Data/Images/Green.png';
         var pixel = renderMaterial(material);
         expect(pixel).not.toEqual([0, 0, 0, 0]);
-        material = material && material.destroy();
-        expect(material).toEqual(undefined);
+        material.destroy();
+        expect(material.isDestroyed()).toEqual(true);
+    });
+
+    it('destroys sub-materials', function() {
+        var material = new Material({
+            context : context,
+            strict : true,
+            fabric : {
+                materials : {
+                    diffuseMap : {
+                        type : 'DiffuseMap'
+                    }
+                },
+                uniforms : {
+                    value : {
+                        x : 0.0,
+                        y : 0.0,
+                        z : 0.0
+                    }
+                },
+                components : {
+                    diffuse : 'value + diffuseMap.diffuse'
+                }
+            }
+        });
+        material.materials.diffuseMap.uniforms.image = './Data/Images/Green.png';
+
+        var pixel = renderMaterial(material);
+        expect(pixel).not.toEqual([0, 0, 0, 0]);
+
+        var diffuseMap = material.materials.diffuseMap;
+        material.destroy();
+        expect(material.isDestroyed()).toEqual(true);
+        expect(diffuseMap.isDestroyed()).toEqual(true);
     });
 }, 'WebGL');


### PR DESCRIPTION
Sub-materials were created with `initializeMaterial` instead of the `Material` constructor so the `isDestroyed` and `destroy` methods were not on sub-material prototypes. It's important to destroy all materials that may create WebGL resources when finished.
