### PR TITLE
Change SVG colors to not use RGBA (technically not allowed).

### DIFF
--- a/Source/Core/Color.js
+++ b/Source/Core/Color.js
@@ -302,27 +302,16 @@ define([
      * @memberof Color
      *
      * @return {String} The CSS equivalent of this color.
-     * @see <a href="http://www.w3.org/TR/css3-color/#rgba-color">CSS RGBA color values</a>
+     * @see <a href="http://www.w3.org/TR/css3-color/#rgba-color">CSS RGB or RGBA color values</a>
      */
     Color.prototype.toCssColorString = function() {
         var red = Color.floatToByte(this.red);
         var green = Color.floatToByte(this.green);
         var blue = Color.floatToByte(this.blue);
+        if (this.alpha === 1) {
+            return 'rgb(' + red + ',' + green + ',' + blue + ')';
+        }
         return 'rgba(' + red + ',' + green + ',' + blue + ',' + this.alpha + ')';
-    };
-
-    /**
-     * Creates a string containing only the RGB portion of the CSS color value for this color.
-     * @memberof Color
-     *
-     * @return {String} The CSS equivalent of this color, minus its Alpha.
-     * @see <a href="http://www.w3.org/TR/css3-color/#rgb-color">CSS RGB color values</a>
-     */
-    Color.prototype.toCssColorStringNoAlpha = function() {
-        var red = Color.floatToByte(this.red);
-        var green = Color.floatToByte(this.green);
-        var blue = Color.floatToByte(this.blue);
-        return 'rgb(' + red + ',' + green + ',' + blue + ')';
     };
 
     /**

--- a/Source/Widgets/Animation/Animation.js
+++ b/Source/Widgets/Animation/Animation.js
@@ -86,7 +86,7 @@ define(['../../Core/destroyObject',
         makeColorStringScratch.red = (background.red * backgroundAlpha) + (gradient.red * gradientAlpha);
         makeColorStringScratch.green = (background.green * backgroundAlpha) + (gradient.green * gradientAlpha);
         makeColorStringScratch.blue = (background.blue * backgroundAlpha) + (gradient.blue * gradientAlpha);
-        return makeColorStringScratch.toCssColorStringNoAlpha();
+        return makeColorStringScratch.toCssColorString();
     }
 
     function rectButton(x, y, path) {
@@ -797,17 +797,17 @@ define(['../../Core/destroyObject',
                     tagName : 'stop',
                     offset : '0%',
                     'stop-opacity' : 0.2,
-                    'stop-color' : swooshColor.toCssColorStringNoAlpha()
+                    'stop-color' : swooshColor.toCssColorString()
                 }, {
                     tagName : 'stop',
                     offset : '85%',
                     'stop-opacity' : 0.85,
-                    'stop-color' : swooshColor.toCssColorStringNoAlpha()
+                    'stop-color' : swooshColor.toCssColorString()
                 }, {
                     tagName : 'stop',
                     offset : '95%',
                     'stop-opacity' : 0.05,
-                    'stop-color' : swooshColor.toCssColorStringNoAlpha()
+                    'stop-color' : swooshColor.toCssColorString()
                 }]
             }, {
                 id : 'animation_shuttleRingSwooshHovered',
@@ -820,17 +820,17 @@ define(['../../Core/destroyObject',
                     tagName : 'stop',
                     offset : '0%',
                     'stop-opacity' : 0.2,
-                    'stop-color' : swooshHoverColor.toCssColorStringNoAlpha()
+                    'stop-color' : swooshHoverColor.toCssColorString()
                 }, {
                     tagName : 'stop',
                     offset : '85%',
                     'stop-opacity' : 0.85,
-                    'stop-color' : swooshHoverColor.toCssColorStringNoAlpha()
+                    'stop-color' : swooshHoverColor.toCssColorString()
                 }, {
                     tagName : 'stop',
                     offset : '95%',
                     'stop-opacity' : 0.05,
-                    'stop-color' : swooshHoverColor.toCssColorStringNoAlpha()
+                    'stop-color' : swooshHoverColor.toCssColorString()
                 }]
             }, {
                 id : 'animation_shuttleRingPointerGradient',
@@ -842,11 +842,11 @@ define(['../../Core/destroyObject',
                 children : [{
                     tagName : 'stop',
                     offset : '0%',
-                    'stop-color' : pointerColor.toCssColorStringNoAlpha()
+                    'stop-color' : pointerColor.toCssColorString()
                 }, {
                     tagName : 'stop',
                     offset : '40%',
-                    'stop-color' : pointerColor.toCssColorStringNoAlpha()
+                    'stop-color' : pointerColor.toCssColorString()
                 }, {
                     tagName : 'stop',
                     offset : '60%',

--- a/Specs/Core/ColorSpec.js
+++ b/Specs/Core/ColorSpec.js
@@ -111,11 +111,11 @@ defineSuite(['Core/Color',
     });
 
     it('toCssColorString produces expected output', function() {
-        expect(Color.WHITE.toCssColorString()).toEqual('rgba(255,255,255,1)');
-        expect(Color.RED.toCssColorString()).toEqual('rgba(255,0,0,1)');
-        expect(Color.BLUE.toCssColorString()).toEqual('rgba(0,0,255,1)');
-        expect(Color.LIME.toCssColorString()).toEqual('rgba(0,255,0,1)');
-        expect(new Color(0.0, 0.0, 0.0, 1.0).toCssColorString()).toEqual('rgba(0,0,0,1)');
+        expect(Color.WHITE.toCssColorString()).toEqual('rgb(255,255,255)');
+        expect(Color.RED.toCssColorString()).toEqual('rgb(255,0,0)');
+        expect(Color.BLUE.toCssColorString()).toEqual('rgb(0,0,255)');
+        expect(Color.LIME.toCssColorString()).toEqual('rgb(0,255,0)');
+        expect(new Color(0.0, 0.0, 0.0, 1.0).toCssColorString()).toEqual('rgb(0,0,0)');
         expect(new Color(0.1, 0.2, 0.3, 0.4).toCssColorString()).toEqual('rgba(25,51,76,0.4)');
     });
 


### PR DESCRIPTION
All our target browsers allowed us to use RGBA for a `linearGradient: stop-color`, but technically it's not in the SVG spec.  SVG defines `stop-opacity` and `stop-color` separately, and the `stop-opacity` is the only place where alpha values work.

When I tried to export a new copy of the Animation widget into Inkscape (which hasn't happened in a long time), the colors came out black because we're not following the SVG spec.

So, this pull request brings us back into compliance, but there should be no visible changes in the browser as a result.  In particular, the translucent parts of the Animation widget should be completely un-changed by this pull.
