### PR TITLE
Make Ellipsoids double-sided.

### DIFF
--- a/Source/Shaders/EllipsoidFS.glsl
+++ b/Source/Shaders/EllipsoidFS.glsl
@@ -3,6 +3,30 @@ uniform vec3 u_oneOverEllipsoidRadiiSquared;
 
 varying vec3 v_positionEC;
 
+vec4 computeEllipsoidColor(czm_ray ray, float intersection, float side)
+{
+    vec3 positionEC = czm_pointAlongRay(ray, intersection);
+    vec3 positionMC = (czm_inverseModelView * vec4(positionEC, 1.0)).xyz;
+    vec3 geodeticNormal = normalize(czm_geodeticSurfaceNormal(positionMC, vec3(0.0), u_oneOverEllipsoidRadiiSquared));
+    vec3 normalMC = geodeticNormal * side;              // normalized surface normal (always facing the viewer) in model coordinates
+    vec3 normalEC = normalize(czm_normal * normalMC);   // normalized surface normal in eye coordiantes
+
+    vec2 st = czm_ellipsoidWgs84TextureCoordinates(geodeticNormal);
+    vec3 positionToEyeEC = -positionEC;
+
+    czm_materialInput materialInput;
+    materialInput.s = st.s;
+    materialInput.st = st;
+    materialInput.str = (positionMC + u_radii) / u_radii;
+    materialInput.normalEC = normalEC;
+    materialInput.tangentToEyeMatrix = czm_eastNorthUpToEyeCoordinates(positionMC, normalEC);
+    materialInput.positionToEyeEC = positionToEyeEC;
+    materialInput.positionMC = positionMC;
+    czm_material material = czm_getMaterial(materialInput);
+
+    return czm_phong(normalize(positionToEyeEC), material);
+}
+
 void main()
 {
     czm_ellipsoid ellipsoid = czm_ellipsoidNew(czm_modelView[3].xyz, u_radii);
@@ -15,56 +39,12 @@ void main()
         discard;
     }
 
-    vec4 outsideFaceColor = vec4(0.0);
-    vec4 insideFaceColor = vec4(0.0);
+    // If the viewer is outside, compute outsideFaceColor, with normals facing outward.
+    vec4 outsideFaceColor = (intersection.start != 0.0) ? computeEllipsoidColor(ray, intersection.start, 1.0) : vec4(0.0);
 
-    if (intersection.start != 0.0) {
-        // Viewer is outside: compute outsideFaceColor.
-        vec3 positionEC = czm_pointAlongRay(ray, intersection.start);
-        vec3 positionMC = (czm_inverseModelView * vec4(positionEC, 1.0)).xyz;
-        vec3 geodeticNormal = normalize(czm_geodeticSurfaceNormal(positionMC, vec3(0.0), u_oneOverEllipsoidRadiiSquared));
-        vec3 normalMC = geodeticNormal;                     // normalized surface normal (always facing the viewer) in model coordinates
-        vec3 normalEC = normalize(czm_normal * normalMC);   // normalized surface normal in eye coordiantes
-
-        vec2 st = czm_ellipsoidWgs84TextureCoordinates(geodeticNormal);
-        vec3 positionToEyeEC = -positionEC;
-
-        czm_materialInput materialInput;
-        materialInput.s = st.s;
-        materialInput.st = st;
-        materialInput.str = (positionMC + u_radii) / u_radii;
-        materialInput.normalEC = normalEC;
-        materialInput.tangentToEyeMatrix = czm_eastNorthUpToEyeCoordinates(positionMC, normalEC);
-        materialInput.positionToEyeEC = positionToEyeEC;
-        materialInput.positionMC = positionMC;
-        czm_material material = czm_getMaterial(materialInput);
-
-        outsideFaceColor = czm_phong(normalize(positionToEyeEC), material);
-    }
-
-    if (outsideFaceColor.a < 1.0) {
-        // Viewer either is inside or can see inside: compute insideFaceColor.
-        vec3 positionEC = czm_pointAlongRay(ray, intersection.stop);
-        vec3 positionMC = (czm_inverseModelView * vec4(positionEC, 1.0)).xyz;
-        vec3 geodeticNormal = normalize(czm_geodeticSurfaceNormal(positionMC, vec3(0.0), u_oneOverEllipsoidRadiiSquared));
-        vec3 normalMC = -geodeticNormal;                    // normalized surface normal (always facing the viewer) in model coordinates
-        vec3 normalEC = normalize(czm_normal * normalMC);   // normalized surface normal in eye coordiantes
-
-        vec2 st = czm_ellipsoidWgs84TextureCoordinates(geodeticNormal);
-        vec3 positionToEyeEC = -positionEC;
-
-        czm_materialInput materialInput;
-        materialInput.s = st.s;
-        materialInput.st = st;
-        materialInput.str = (positionMC + u_radii) / u_radii;
-        materialInput.normalEC = normalEC;
-        materialInput.tangentToEyeMatrix = czm_eastNorthUpToEyeCoordinates(positionMC, normalEC);
-        materialInput.positionToEyeEC = positionToEyeEC;
-        materialInput.positionMC = positionMC;
-        czm_material material = czm_getMaterial(materialInput);
-
-        insideFaceColor = czm_phong(normalize(positionToEyeEC), material);
-    }
+    // If the viewer either is inside or can see inside, compute insideFaceColor, with normals facing inward.
+    vec4 insideFaceColor = (outsideFaceColor.a < 1.0) ? computeEllipsoidColor(ray, intersection.stop, -1.0) : vec4(0.0);
 
     gl_FragColor = mix(insideFaceColor, outsideFaceColor, outsideFaceColor.a);
+    gl_FragColor.a = 1.0 - (1.0 - insideFaceColor.a) * (1.0 - outsideFaceColor.a);
 }


### PR DESCRIPTION
NOTE: This pull request targets `grid-material` where ellipsoid grids are a work in progress.

Have I committed any crimes here?  I didn't implement the idea of separate materials for inside & outside, mostly because that idea doesn't have practical application for me, but I could imagine a future pull request for it if there's external demand.  I just need both sides of the ellipsoid to render.  Have I done that correctly here?
