### PR TITLE
Tweak the look of GridMaterial based on user feedback.

### DIFF
--- a/Source/Shaders/Materials/GridMaterial.glsl
+++ b/Source/Shaders/Materials/GridMaterial.glsl
@@ -41,7 +41,15 @@ czm_material czm_getMaterial(czm_materialInput materialInput)
         1.0 - smoothstep(range.t, range.t + fuzz, scaledHeight));
 #endif
 
-    material.diffuse = color.rgb;
+    // Edges taken from RimLightingMaterial.glsl
+    // See http://www.fundza.com/rman_shaders/surface/fake_rim/fake_rim1.html
+    float dRim = 1.0 - dot(materialInput.normalEC, normalize(materialInput.positionToEyeEC));
+    float sRim = smoothstep(0.8, 1.0, dRim);
+    value *= (1.0 - sRim);
+
+    vec3 halfColor = color.rgb * 0.5;
+    material.diffuse = halfColor;
+    material.emission = halfColor;
     material.alpha = color.a * (1.0 - ((1.0 - cellAlpha) * value));
 
     return material;


### PR DESCRIPTION
This borrows a couple lines of code from RimLightingMaterial to resolve some sparkling along the tangent edges of GridMaterial.  Also the lighting on the grid is made softer.  Both of these requests came from end users following a demo.
