### PR TITLE
ReferenceProperty availability

### DIFF
--- a/Source/DynamicScene/ReferenceProperty.js
+++ b/Source/DynamicScene/ReferenceProperty.js
@@ -15,6 +15,7 @@ define([
             if (typeof targetObject !== 'undefined') {
                 targetProperty = targetObject[referenceProperty._targetPropertyName];
                 referenceProperty._targetProperty = targetProperty;
+                referenceProperty._targetObject = targetObject;
             }
         }
         return targetProperty;
@@ -58,6 +59,7 @@ define([
         this._targetProperty = undefined;
         this._dynamicObjectCollection = dynamicObjectCollection;
         this._targetObjectId = targetObjectId;
+        this._targetObject = undefined;
         this._targetPropertyName = targetPropertyName;
     };
 
@@ -109,7 +111,7 @@ define([
      */
     ReferenceProperty.prototype.getValue = function(time, result) {
         var targetProperty = resolve(this);
-        return typeof targetProperty !== 'undefined' ? targetProperty.getValue(time, result) : undefined;
+        return typeof targetProperty !== 'undefined' && this._targetObject.isAvailable(time) ? targetProperty.getValue(time, result) : undefined;
     };
 
     /**
@@ -122,7 +124,7 @@ define([
      */
     ReferenceProperty.prototype.getValueCartographic = function(time, result) {
         var targetProperty = resolve(this);
-        return typeof targetProperty !== 'undefined' ? targetProperty.getValueCartographic(time, result) : undefined;
+        return typeof targetProperty !== 'undefined' && this._targetObject.isAvailable(time) ? targetProperty.getValueCartographic(time, result) : undefined;
     };
 
     /**
@@ -135,7 +137,7 @@ define([
      */
     ReferenceProperty.prototype.getValueCartesian = function(time, result) {
         var targetProperty = resolve(this);
-        return typeof targetProperty !== 'undefined' ? targetProperty.getValueCartesian(time, result) : undefined;
+        return typeof targetProperty !== 'undefined' && this._targetObject.isAvailable(time) ? targetProperty.getValueCartesian(time, result) : undefined;
     };
 
     /**
@@ -148,7 +150,7 @@ define([
      */
     ReferenceProperty.prototype.getValueSpherical = function(time, result) {
         var targetProperty = resolve(this);
-        return typeof targetProperty !== 'undefined' ? targetProperty.getValueSpherical(time, result) : undefined;
+        return typeof targetProperty !== 'undefined' && this._targetObject.isAvailable(time) ? targetProperty.getValueSpherical(time, result) : undefined;
     };
 
     return ReferenceProperty;

--- a/Specs/DynamicScene/ReferencePropertySpec.js
+++ b/Specs/DynamicScene/ReferencePropertySpec.js
@@ -3,18 +3,26 @@ defineSuite([
              'DynamicScene/ReferenceProperty',
              'DynamicScene/DynamicObjectCollection',
              'DynamicScene/DynamicObject',
+             'Core/JulianDate',
+             'Core/TimeInterval',
              'Core/Iso8601'
             ], function(
               ReferenceProperty,
               DynamicObjectCollection,
               DynamicObject,
+              JulianDate,
+              TimeInterval,
               Iso8601) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
+    var validTime = JulianDate.fromIso8601('2012');
+    var invalidTime = JulianDate.fromIso8601('2014');
+
     var testObjectLink = 'testObject.property';
     function createTestObject(dynamicObjectCollection, methodName) {
         var testObject = dynamicObjectCollection.getOrCreateObject('testObject');
+        testObject._setAvailability(TimeInterval.fromIso8601('2012/2013'));
         testObject.property = {};
         testObject.property[methodName] = function(time, result) {
             result.expectedTime = time;
@@ -85,9 +93,10 @@ defineSuite([
         createTestObject(dynamicObjectCollection, 'getValue');
         var property = ReferenceProperty.fromString(dynamicObjectCollection, testObjectLink);
         var result = {};
-        expect(property.getValue(Iso8601.MINIMUM_VALUE, result)).toEqual(result);
+        expect(property.getValue(validTime, result)).toEqual(result);
         expect(result.expectedValue).toEqual(true);
-        expect(result.expectedTime).toEqual(Iso8601.MINIMUM_VALUE);
+        expect(result.expectedTime).toEqual(validTime);
+        expect(property.getValue(invalidTime, result)).toBeUndefined();
     });
 
     it('Resolves getValue property on parent collection', function() {
@@ -97,9 +106,10 @@ defineSuite([
         createTestObject(parent, 'getValue');
         var property = ReferenceProperty.fromString(dynamicObjectCollection, testObjectLink);
         var result = {};
-        expect(property.getValue(Iso8601.MINIMUM_VALUE, result)).toEqual(result);
+        expect(property.getValue(validTime, result)).toEqual(result);
         expect(result.expectedValue).toEqual(true);
-        expect(result.expectedTime).toEqual(Iso8601.MINIMUM_VALUE);
+        expect(result.expectedTime).toEqual(validTime);
+        expect(property.getValue(invalidTime, result)).toBeUndefined();
     });
 
     it('Resolves getValue property on direct collection', function() {
@@ -107,9 +117,10 @@ defineSuite([
         createTestObject(dynamicObjectCollection, 'getValue');
         var property = ReferenceProperty.fromString(dynamicObjectCollection, testObjectLink);
         var result = {};
-        expect(property.getValue(Iso8601.MINIMUM_VALUE, result)).toEqual(result);
+        expect(property.getValue(validTime, result)).toEqual(result);
         expect(result.expectedValue).toEqual(true);
-        expect(result.expectedTime).toEqual(Iso8601.MINIMUM_VALUE);
+        expect(result.expectedTime).toEqual(validTime);
+        expect(property.getValue(invalidTime, result)).toBeUndefined();
     });
 
     it('Resolves getValueCartographic property on direct collection', function() {
@@ -117,9 +128,10 @@ defineSuite([
         createTestObject(dynamicObjectCollection, 'getValueCartographic');
         var property = ReferenceProperty.fromString(dynamicObjectCollection, testObjectLink);
         var result = {};
-        expect(property.getValueCartographic(Iso8601.MINIMUM_VALUE, result)).toEqual(result);
+        expect(property.getValueCartographic(validTime, result)).toEqual(result);
         expect(result.expectedValue).toEqual(true);
-        expect(result.expectedTime).toEqual(Iso8601.MINIMUM_VALUE);
+        expect(result.expectedTime).toEqual(validTime);
+        expect(property.getValueCartographic(invalidTime, result)).toBeUndefined();
     });
 
     it('Resolves getValueCartesian property on direct collection', function() {
@@ -127,9 +139,10 @@ defineSuite([
         createTestObject(dynamicObjectCollection, 'getValueCartesian');
         var property = ReferenceProperty.fromString(dynamicObjectCollection, testObjectLink);
         var result = {};
-        expect(property.getValueCartesian(Iso8601.MINIMUM_VALUE, result)).toEqual(result);
+        expect(property.getValueCartesian(validTime, result)).toEqual(result);
         expect(result.expectedValue).toEqual(true);
-        expect(result.expectedTime).toEqual(Iso8601.MINIMUM_VALUE);
+        expect(result.expectedTime).toEqual(validTime);
+        expect(property.getValueCartesian(invalidTime, result)).toBeUndefined();
     });
 
     it('Resolves getValueSpherical property on direct collection', function() {
@@ -137,8 +150,9 @@ defineSuite([
         createTestObject(dynamicObjectCollection, 'getValueSpherical');
         var property = ReferenceProperty.fromString(dynamicObjectCollection, testObjectLink);
         var result = {};
-        expect(property.getValueSpherical(Iso8601.MINIMUM_VALUE, result)).toEqual(result);
+        expect(property.getValueSpherical(validTime, result)).toEqual(result);
         expect(result.expectedValue).toEqual(true);
-        expect(result.expectedTime).toEqual(Iso8601.MINIMUM_VALUE);
+        expect(result.expectedTime).toEqual(validTime);
+        expect(property.getValueSpherical(invalidTime, result)).toBeUndefined();
     });
 });


### PR DESCRIPTION
Make ReferenceProperty have the same availability as the DyanmicObject that the reference is on.  This addresses an issue @mrmattf while attempting to draw a line between two DynamicObjects, one of which becomes unavailable over time.
