### PR TITLE
[CC-DRY] Use anonymous function where applicable

### DIFF
--- a/Source/Core/EarthOrientationParameters.js
+++ b/Source/Core/EarthOrientationParameters.js
@@ -64,7 +64,7 @@ define([
      * var eop = new EarthOrientationParameters({ url : 'Data/EOP.json' });
      * Transforms.earthOrientationParameters = eop;
      */
-    var EarthOrientationParameters = function EarthOrientationParameters(description) {
+    var EarthOrientationParameters = function(description) {
         description = defaultValue(description, {});
 
         this._dates = undefined;

--- a/Source/Core/EarthOrientationParametersSample.js
+++ b/Source/Core/EarthOrientationParametersSample.js
@@ -14,7 +14,7 @@ define(function() {
      * @param {Number} yPoleOffset The offset to the Celestial Intermediate Pole (CIP) about the Y axis, in radians.
      * @param {Number} ut1MinusUtc The difference in time standards, UT1 - UTC, in seconds.
      */
-    var EarthOrientationParametersSample = function EarthOrientationParametersSample(xPoleWander, yPoleWander, xPoleOffset, yPoleOffset, ut1MinusUtc) {
+    var EarthOrientationParametersSample = function(xPoleWander, yPoleWander, xPoleOffset, yPoleOffset, ut1MinusUtc) {
         /**
          * The pole wander about the X axis, in radians.
          * @type {Number}

--- a/Source/Core/Iau2006XysData.js
+++ b/Source/Core/Iau2006XysData.js
@@ -34,7 +34,7 @@ define([
      * @param {Number} [description.samplesPerXysFile=1000] The number of samples in each XYS file.
      * @param {Number} [description.totalSamples=27426] The total number of samples in all XYS files.
      */
-    var Iau2006XysData = function Iau2006XysData(description) {
+    var Iau2006XysData = function(description) {
         description = description || {};
 
         this._xysFileUrlTemplate = defaultValue(description.xysFileUrlTemplate, buildModuleUrl('Assets/IAU2006_XYS/IAU2006_XYS_{0}.json'));

--- a/Source/Core/Iau2006XysSample.js
+++ b/Source/Core/Iau2006XysSample.js
@@ -12,7 +12,7 @@ define(function() {
      * @param {Number} y The Y value.
      * @param {Number} s The S value.
      */
-    var Iau2006XysSample = function Iau2006XysSample(x, y, s) {
+    var Iau2006XysSample = function(x, y, s) {
         /**
          * The X value.
          * @type {Number}

--- a/Source/Core/RequestErrorEvent.js
+++ b/Source/Core/RequestErrorEvent.js
@@ -13,7 +13,7 @@ define([
      * @param {Number} [statusCode] The HTTP error status code, such as 404.
      * @param {Object} [response] The response included along with the error.
      */
-    var RequestErrorEvent = function RequestErrorEvent(statusCode, response) {
+    var RequestErrorEvent = function(statusCode, response) {
         /**
          * The HTTP error status code, such as 404.  If the error does not have a particular
          * HTTP code, this property will be undefined.

--- a/Source/Core/loadJson.js
+++ b/Source/Core/loadJson.js
@@ -37,7 +37,7 @@ define([
      * @see <a href='http://www.w3.org/TR/cors/'>Cross-Origin Resource Sharing</a>
      * @see <a href='http://wiki.commonjs.org/wiki/Promises/A'>CommonJS Promises/A</a>
      */
-    var loadJson = function loadJson(url, headers) {
+    var loadJson = function(url, headers) {
         if (typeof url === 'undefined') {
             throw new DeveloperError('url is required.');
         }

--- a/Source/Scene/ArcGisImageServerTerrainProvider.js
+++ b/Source/Scene/ArcGisImageServerTerrainProvider.js
@@ -57,7 +57,7 @@ define([
      * });
      * centralBody.terrainProvider = terrainProvider;
      */
-    var ArcGisImageServerTerrainProvider = function ArcGisImageServerTerrainProvider(description) {
+    var ArcGisImageServerTerrainProvider = function(description) {
         if (typeof description === 'undefined' || typeof description.url === 'undefined') {
             throw new DeveloperError('description.url is required.');
         }

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -70,7 +70,7 @@ define([
      *     url: 'http://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer'
      * });
      */
-    var ArcGisMapServerImageryProvider = function ArcGisMapServerImageryProvider(description) {
+    var ArcGisMapServerImageryProvider = function(description) {
         description = defaultValue(description, {});
 
         if (typeof description.url === 'undefined') {

--- a/Source/Scene/BingMapsImageryProvider.js
+++ b/Source/Scene/BingMapsImageryProvider.js
@@ -66,7 +66,7 @@ define([
      *     mapStyle : BingMapsStyle.AERIAL
      * });
      */
-    var BingMapsImageryProvider = function BingMapsImageryProvider(description) {
+    var BingMapsImageryProvider = function(description) {
         description = defaultValue(description, {});
 
         if (typeof description.url === 'undefined') {

--- a/Source/Scene/CesiumTerrainProvider.js
+++ b/Source/Scene/CesiumTerrainProvider.js
@@ -37,7 +37,7 @@ define([
      *
      * @see TerrainProvider
      */
-    var CesiumTerrainProvider = function CesiumTerrainProvider(description) {
+    var CesiumTerrainProvider = function(description) {
         if (typeof description === 'undefined' || typeof description.url === 'undefined') {
             throw new DeveloperError('description.url is required.');
         }

--- a/Source/Scene/EllipsoidTerrainProvider.js
+++ b/Source/Scene/EllipsoidTerrainProvider.js
@@ -31,7 +31,7 @@ define([
      *
      * @see TerrainProvider
      */
-    var EllipsoidTerrainProvider = function EllipsoidTerrainProvider(description) {
+    var EllipsoidTerrainProvider = function(description) {
         description = defaultValue(description, {});
 
         this._tilingScheme = description.tilingScheme;

--- a/Source/Scene/GeographicTilingScheme.js
+++ b/Source/Scene/GeographicTilingScheme.js
@@ -35,7 +35,7 @@ define([
      * @param {Number} [description.numberOfLevelZeroTilesY=1] The number of tiles in the Y direction at level zero of
      * the tile tree.
      */
-    var GeographicTilingScheme = function GeographicTilingScheme(description) {
+    var GeographicTilingScheme = function(description) {
         description = defaultValue(description, {});
 
         this._ellipsoid = defaultValue(description.ellipsoid, Ellipsoid.WGS84);

--- a/Source/Scene/HeightmapTerrainData.js
+++ b/Source/Scene/HeightmapTerrainData.js
@@ -90,7 +90,7 @@ define([
      *   waterMask : waterMask
      * });
      */
-    var HeightmapTerrainData = function HeightmapTerrainData(description) {
+    var HeightmapTerrainData = function(description) {
         if (typeof description === 'undefined' || typeof description.buffer === 'undefined') {
             throw new DeveloperError('description.buffer is required.');
         }

--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -117,7 +117,7 @@ define([
      *        by the WebGL stack will be used.  Larger values make the imagery look better in horizon
      *        views.
      */
-    var ImageryLayer = function ImageryLayer(imageryProvider, description) {
+    var ImageryLayer = function(imageryProvider, description) {
         this._imageryProvider = imageryProvider;
 
         description = defaultValue(description, {});

--- a/Source/Scene/ImageryLayerCollection.js
+++ b/Source/Scene/ImageryLayerCollection.js
@@ -24,7 +24,7 @@ define([
      * @demo <a href="http://cesium.agi.com/Cesium/Apps/Sandcastle/index.html?src=Imagery%20Adjustment.html">Cesium Sandcastle Imagery Adjustment Demo</a>
      * @demo <a href="http://cesium.agi.com/Cesium/Apps/Sandcastle/index.html?src=Imagery%20Layers%20Manipulation.html">Cesium Sandcastle Imagery Manipulation Demo</a>
      */
-    var ImageryLayerCollection = function ImageryLayerCollection() {
+    var ImageryLayerCollection = function() {
         this._layers = [];
 
         /**

--- a/Source/Scene/ImageryProvider.js
+++ b/Source/Scene/ImageryProvider.js
@@ -25,7 +25,7 @@ define([
      * @demo <a href="http://cesium.agi.com/Cesium/Apps/Sandcastle/index.html?src=Imagery%20Layers.html">Cesium Sandcastle Imagery Layers Demo</a>
      * @demo <a href="http://cesium.agi.com/Cesium/Apps/Sandcastle/index.html?src=Imagery%20Layers%20Manipulation.html">Cesium Sandcastle Imagery Manipulation Demo</a>
      */
-    var ImageryProvider = function ImageryProvider() {
+    var ImageryProvider = function() {
         throw new DeveloperError('This type should not be instantiated directly.');
     };
 

--- a/Source/Scene/OpenStreetMapImageryProvider.js
+++ b/Source/Scene/OpenStreetMapImageryProvider.js
@@ -48,7 +48,7 @@ define([
      *     url : 'http://tile.openstreetmap.org/'
      * });
      */
-    var OpenStreetMapImageryProvider = function OpenStreetMapImageryProvider(description) {
+    var OpenStreetMapImageryProvider = function(description) {
         description = defaultValue(description, {});
 
         var url = defaultValue(description.url, 'http://tile.openstreetmap.org/');

--- a/Source/Scene/TerrainData.js
+++ b/Source/Scene/TerrainData.js
@@ -12,7 +12,7 @@ define([
      * @alias TerrainData
      * @constructor
      */
-    var TerrainData = function TerrainData() {
+    var TerrainData = function() {
         throw new DeveloperError('This type should not be instantiated directly.');
     };
 

--- a/Source/Scene/TerrainMesh.js
+++ b/Source/Scene/TerrainMesh.js
@@ -22,7 +22,7 @@ define(function() {
       *                     scaled space, and used for horizon culling.  If this point is below the horizon,
       *                     the tile is considered to be entirely below the horizon.
       */
-    var TerrainMesh = function TerrainMesh(center, vertices, indices, minimumHeight, maximumHeight, boundingSphere3D, occludeePointInScaledSpace) {
+    var TerrainMesh = function(center, vertices, indices, minimumHeight, maximumHeight, boundingSphere3D, occludeePointInScaledSpace) {
         /**
          * The center of the tile.  Vertex positions are specified relative to this center.
          * @type {Cartesian3}

--- a/Source/Scene/TileCoordinatesImageryProvider.js
+++ b/Source/Scene/TileCoordinatesImageryProvider.js
@@ -24,7 +24,7 @@ define([
      * @param {Number} [description.tileWidth=256] The width of the tile for level-of-detail selection purposes.
      * @param {Number} [description.tileHeight=256] The height of the tile for level-of-detail selection purposes.
      */
-    var TileCoordinatesImageryProvider = function TileCoordinatesImageryProvider(description) {
+    var TileCoordinatesImageryProvider = function(description) {
         description = defaultValue(description, {});
 
         this._tilingScheme = defaultValue(description.tilingScheme, new GeographicTilingScheme());

--- a/Source/Scene/TileLoadQueue.js
+++ b/Source/Scene/TileLoadQueue.js
@@ -8,7 +8,7 @@ define(function() {
      * @alias TileLoadQueue
      * @private
      */
-    var TileLoadQueue = function TileLoadQueue() {
+    var TileLoadQueue = function() {
         this.head = undefined;
         this.tail = undefined;
         this._insertionPoint = undefined;

--- a/Source/Scene/TileMapServiceImageryProvider.js
+++ b/Source/Scene/TileMapServiceImageryProvider.js
@@ -66,7 +66,7 @@ define([
      *        Cesium.Math.toRadians(40.0))
      * });
      */
-    var TileMapServiceImageryProvider = function TileMapServiceImageryProvider(description) {
+    var TileMapServiceImageryProvider = function(description) {
         description = defaultValue(description, {});
 
         if (typeof description.url === 'undefined') {

--- a/Source/Scene/TileProviderError.js
+++ b/Source/Scene/TileProviderError.js
@@ -27,7 +27,7 @@ define([
      *        is not specific to a particular tile.
      * @param {Number} [timesRetried=0] The number of times this operation has been retried.
      */
-    var TileProviderError = function TileProviderError(provider, message, x, y, level, timesRetried) {
+    var TileProviderError = function(provider, message, x, y, level, timesRetried) {
         /**
          * The {@link ImageryProvider} or {@link TerrainProvider} that experienced the error.
          * @type {ImageryProvider|TerainProvider}

--- a/Source/Scene/TileReplacementQueue.js
+++ b/Source/Scene/TileReplacementQueue.js
@@ -14,7 +14,7 @@ define([
      * @alias TileReplacementQueue
      * @private
      */
-    var TileReplacementQueue = function TileReplacementQueue() {
+    var TileReplacementQueue = function() {
         this.head = undefined;
         this.tail = undefined;
         this.count = 0;

--- a/Source/Scene/TileTerrain.js
+++ b/Source/Scene/TileTerrain.js
@@ -29,7 +29,7 @@ define([
      * @param {Number} [upsampleDetails.y] The Y coordinate of the tile being upsampled.
      * @param {Number} [upsampleDetails.level] The level coordinate of the tile being upsampled.
      */
-    var TileTerrain = function TileTerrain(upsampleDetails) {
+    var TileTerrain = function(upsampleDetails) {
         /**
          * The current state of the terrain in the terrain processing pipeline.
          * @type TerrainState

--- a/Source/Scene/TilingScheme.js
+++ b/Source/Scene/TilingScheme.js
@@ -20,7 +20,7 @@ define([
      * @see WebMercatorTilingScheme
      * @see GeographicTilingScheme
      */
-    var TilingScheme = function TilingScheme(description) {
+    var TilingScheme = function(description) {
         throw new DeveloperError('This type should not be instantiated directly.  Instead, use WebMercatorTilingScheme or GeographicTilingScheme.');
     };
 

--- a/Source/Scene/VRTheWorldTerrainProvider.js
+++ b/Source/Scene/VRTheWorldTerrainProvider.js
@@ -63,7 +63,7 @@ define([
      * });
      * centralBody.terrainProvider = terrainProvider;
      */
-    var VRTheWorldTerrainProvider = function VRTheWorldTerrainProvider(description) {
+    var VRTheWorldTerrainProvider = function(description) {
         if (typeof description === 'undefined' || typeof description.url === 'undefined') {
             throw new DeveloperError('description.url is required.');
         }

--- a/Source/Scene/WebMapServiceImageryProvider.js
+++ b/Source/Scene/WebMapServiceImageryProvider.js
@@ -58,7 +58,7 @@ define([
      *     proxy: new Cesium.DefaultProxy('/proxy/')
      * });
      */
-    var WebMapServiceImageryProvider = function WebMapServiceImageryProvider(description) {
+    var WebMapServiceImageryProvider = function(description) {
         description = defaultValue(description, {});
 
         if (typeof description.url === 'undefined') {

--- a/Source/Scene/WebMercatorTilingScheme.js
+++ b/Source/Scene/WebMercatorTilingScheme.js
@@ -43,7 +43,7 @@ define([
      *        globe is covered in the longitude direction and an equal distance is covered in the latitude
      *        direction, resulting in a square projection.
      */
-    var WebMercatorTilingScheme = function WebMercatorTilingScheme(description) {
+    var WebMercatorTilingScheme = function(description) {
         description = defaultValue(description, {});
 
         this._ellipsoid = defaultValue(description.ellipsoid, Ellipsoid.WGS84);

--- a/Source/Widgets/Observable.js
+++ b/Source/Widgets/Observable.js
@@ -21,7 +21,7 @@ define(['../Core/DeveloperError'], function(DeveloperError) {
      * @see <a href='http://knockoutjs.com/'>Knockout homepage</a>.
      * @see <a href='https://github.com/AnalyticalGraphicsInc/cesium/wiki/Architecture'>Widget Architecture</a>.
      */
-    var Observable = function Observable() {
+    var Observable = function() {
         throw new DeveloperError('This type should not be instantiated directly.');
     };
 


### PR DESCRIPTION
refs https://groups.google.com/d/msg/cesium-dev/nm-QWU5sppI/VeA4GmJtC6kJ

This PR replaces `var X = function X(){};` by `var X = function(params) {};`

The only reason why the old syntax could be usefull is when displaying a call stack (to see the function name rather than "anonymous function". I don't expect this this to be really frequent as modified functions are mainly constructor.

The benefit are:
- shorter / simpler code,
- consistency (both syntax were in use).
