### PR TITLE
Only set crossorigin on images that are actually cross-origin.

### DIFF
--- a/Source/Core/TaskProcessor.js
+++ b/Source/Core/TaskProcessor.js
@@ -3,12 +3,14 @@ define([
         'require',
         './buildModuleUrl',
         './defaultValue',
+        './isCrossOriginUrl',
         '../ThirdParty/when',
         '../ThirdParty/Uri'
     ], function(
         require,
         buildModuleUrl,
         defaultValue,
+        isCrossOriginUrl,
         when,
         Uri) {
     "use strict";
@@ -36,13 +38,8 @@ define([
 
         _bootstrapperUrl = buildModuleUrl('Workers/cesiumWorkerBootstrapper.js');
 
-        var location = window.location;
-        var a = document.createElement('a');
-        a.href = _bootstrapperUrl;
-
-        // host includes both hostname and port if the port is not standard
-        if (a.protocol !== location.protocol || a.host !== location.host) {
-            //cross-origin, create a shim worker from a blob URL
+        if (isCrossOriginUrl(_bootstrapperUrl)) {
+            //to load cross-origin, create a shim worker from a blob URL
             var script = 'importScripts("' + _bootstrapperUrl + '");';
 
             var blob;

--- a/Source/Core/isCrossOriginUrl.js
+++ b/Source/Core/isCrossOriginUrl.js
@@ -1,0 +1,25 @@
+/*global define*/
+define(function() {
+    "use strict";
+
+    var a;
+
+    /**
+     * Given a URL, determine whether that URL is considered cross-origin to the current page.
+     *
+     * @private
+     */
+    var isCrossOriginUrl = function(url) {
+        if (typeof a === 'undefined') {
+            a = document.createElement('a');
+        }
+
+        var location = window.location;
+        a.href = url;
+
+        // host includes both hostname and port if the port is not standard
+        return a.protocol !== location.protocol || a.host !== location.host;
+    };
+
+    return isCrossOriginUrl;
+});

--- a/Source/Renderer/loadCubeMap.js
+++ b/Source/Renderer/loadCubeMap.js
@@ -1,11 +1,9 @@
 /*global define*/
 define([
-        '../Core/defaultValue',
         '../Core/DeveloperError',
         '../Core/loadImage',
         '../ThirdParty/when'
     ], function(
-        defaultValue,
         DeveloperError,
         loadImage,
         when) {
@@ -19,8 +17,9 @@ define([
      *
      * @param {Context} context The context to use to create the cube map.
      * @param {Object} urls The source of each image, or a promise for each URL.  See the example below.
-     * @param {Boolean} [crossOrigin=true] Whether to request images using Cross-Origin
-     *        Resource Sharing (CORS).  Data URIs are never requested using CORS.
+     * @param {Boolean} [allowCrossOrigin=true] Whether to request the image using Cross-Origin
+     *        Resource Sharing (CORS).  CORS is only actually used if the image URL is actually cross-origin.
+     *        Data URIs are never requested using CORS.
      *
      * @returns {Promise} a promise that will resolve to the requested {@link CubeMap} when loaded.
      *
@@ -44,7 +43,7 @@ define([
      * @see <a href='http://www.w3.org/TR/cors/'>Cross-Origin Resource Sharing</a>
      * @see <a href='http://wiki.commonjs.org/wiki/Promises/A'>CommonJS Promises/A</a>
      */
-    var loadCubeMap = function(context, urls, crossOrigin) {
+    var loadCubeMap = function(context, urls, allowCrossOrigin) {
         if (typeof context === 'undefined') {
             throw new DeveloperError('context is required.');
         }
@@ -66,12 +65,12 @@ define([
         // ideally, we would do it in the primitive's update function.
 
         var facePromises = [
-            loadImage(urls.positiveX, crossOrigin),
-            loadImage(urls.negativeX, crossOrigin),
-            loadImage(urls.positiveY, crossOrigin),
-            loadImage(urls.negativeY, crossOrigin),
-            loadImage(urls.positiveZ, crossOrigin),
-            loadImage(urls.negativeZ, crossOrigin)
+            loadImage(urls.positiveX, allowCrossOrigin),
+            loadImage(urls.negativeX, allowCrossOrigin),
+            loadImage(urls.positiveY, allowCrossOrigin),
+            loadImage(urls.negativeY, allowCrossOrigin),
+            loadImage(urls.positiveZ, allowCrossOrigin),
+            loadImage(urls.negativeZ, allowCrossOrigin)
         ];
 
         return when.all(facePromises, function(images) {

--- a/Source/Scene/CentralBody.js
+++ b/Source/Scene/CentralBody.js
@@ -614,7 +614,7 @@ define([
             this._lastOceanNormalMapUrl = this.oceanNormalMapUrl;
 
             var that = this;
-            when(loadImage(this.oceanNormalMapUrl, true), function(image) {
+            when(loadImage(this.oceanNormalMapUrl), function(image) {
                 that._oceanNormalMap = that._oceanNormalMap && that._oceanNormalMap.destroy();
                 that._oceanNormalMap = context.createTexture2D({
                     source : image

--- a/Specs/Core/loadImageSpec.js
+++ b/Specs/Core/loadImageSpec.js
@@ -48,13 +48,31 @@ defineSuite([
         }).toThrow();
     });
 
-    it('sets the crossOrigin property', function() {
+    it('sets the crossOrigin property for cross-origin images', function() {
         var fakeImage = {};
         var imageConstructorSpy = spyOn(window, 'Image').andReturn(fakeImage);
 
-        loadImage('./Data/Images/Green.png');
+        loadImage('http://example.com/someImage.png');
         expect(imageConstructorSpy).toHaveBeenCalled();
         expect(fakeImage.crossOrigin).toEqual('');
+    });
+
+    it('does not set the crossOrigin property for cross-origin images when allowCrossOrigin is false', function() {
+        var fakeImage = {};
+        var imageConstructorSpy = spyOn(window, 'Image').andReturn(fakeImage);
+
+        loadImage('http://example.com/someImage.png', false);
+        expect(imageConstructorSpy).toHaveBeenCalled();
+        expect(fakeImage.crossOrigin).toBeUndefined();
+    });
+
+    it('does not set the crossOrigin property for non-cross-origin images', function() {
+        var fakeImage = {};
+        var imageConstructorSpy = spyOn(window, 'Image').andReturn(fakeImage);
+
+        loadImage('./someImage.png', false);
+        expect(imageConstructorSpy).toHaveBeenCalled();
+        expect(fakeImage.crossOrigin).toBeUndefined();
     });
 
     it('does not set the crossOrigin property for data URIs', function() {

--- a/Specs/Scene/ArcGisImageServerTerrainProviderSpec.js
+++ b/Specs/Scene/ArcGisImageServerTerrainProviderSpec.js
@@ -118,7 +118,6 @@ defineSuite([
             loadImage.createImage = function(url, crossOrigin, deferred) {
                 expect(url.indexOf('exportImage?')).toBeGreaterThanOrEqualTo(0);
                 expect(url.indexOf('bbox=-181.40625%2C-91.40625%2C1.40625%2C91.40625')).toBeGreaterThanOrEqualTo(0);
-                expect(crossOrigin).toEqual(true);
 
                 // Just return any old image.
                 return loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
@@ -146,7 +145,6 @@ defineSuite([
             loadImage.createImage = function(url, crossOrigin, deferred) {
                 expect(url.indexOf('exportImage?')).toBeGreaterThanOrEqualTo(0);
                 expect(url.indexOf('token=foofoofoo')).toBeGreaterThanOrEqualTo(0);
-                expect(crossOrigin).toEqual(true);
 
                 // Just return any old image.
                 return loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
@@ -175,7 +173,6 @@ defineSuite([
             loadImage.createImage = function(url, crossOrigin, deferred) {
                 expect(url.indexOf('/proxy/?')).toBe(0);
                 expect(url.indexOf('exportImage%3F')).toBeGreaterThanOrEqualTo(0);
-                expect(crossOrigin).toEqual(true);
 
                 // Just return any old image.
                 return loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
@@ -203,7 +200,6 @@ defineSuite([
 
             loadImage.createImage = function(url, crossOrigin, deferred) {
                 expect(url.indexOf('exportImage?')).toBeGreaterThanOrEqualTo(0);
-                expect(crossOrigin).toEqual(true);
 
                 // Just return any old image.
                 return loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);

--- a/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
+++ b/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
@@ -97,7 +97,6 @@ defineSuite([
 
             loadImage.createImage = function(url, crossOrigin, deferred) {
                 expect(url).toEqual(baseUrl + '/tile/0/0/0');
-                expect(crossOrigin).toEqual(true);
 
                 // Just return any old image.
                 return loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
@@ -170,7 +169,6 @@ defineSuite([
 
             loadImage.createImage = function(url, crossOrigin, deferred) {
                 expect(url).toEqual(baseUrl + '/tile/0/0/0');
-                expect(crossOrigin).toEqual(true);
 
                 // Just return any old image.
                 return loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
@@ -233,7 +231,6 @@ defineSuite([
                 expect(url).toMatch('format=png');
                 expect(url).toMatch('transparent=true');
                 expect(url).toMatch('size=256%2C256');
-                expect(crossOrigin).toEqual(true);
 
                 // Just return any old image.
                 return loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
@@ -313,7 +310,6 @@ defineSuite([
 
             loadImage.createImage = function(url, crossOrigin, deferred) {
                 expect(url).toEqual(proxy.getURL(baseUrl + '/tile/0/0/0'));
-                expect(crossOrigin).toEqual(true);
 
                 // Just return any old image.
                 return loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);

--- a/Specs/Scene/BingMapsImageryProviderSpec.js
+++ b/Specs/Scene/BingMapsImageryProviderSpec.js
@@ -150,7 +150,6 @@ defineSuite([
 
             loadImage.createImage = function(url, crossOrigin, deferred) {
                 expect(url).toEqual('http://fake.t0.tiles.fake.net/tiles/r0?g=1062&lbl=l1&productSet=mmCB');
-                expect(crossOrigin).toEqual(true);
 
                 // Just return any old image.
                 return loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
@@ -223,7 +222,6 @@ defineSuite([
         runs(function() {
             loadImage.createImage = function(url, crossOrigin, deferred) {
                 expect(url).toEqual(proxy.getURL('http://ecn.t0.tiles.virtualearth.net/tiles/r0?g=1062&lbl=l1&productSet=mmCB'));
-                expect(crossOrigin).toEqual(true);
 
                 // Just return any old image.
                 return loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);

--- a/Specs/Scene/OpenStreetMapImageryProviderSpec.js
+++ b/Specs/Scene/OpenStreetMapImageryProviderSpec.js
@@ -115,8 +115,6 @@ defineSuite([
             expect(provider.getExtent()).toEqual(new WebMercatorTilingScheme().getExtent());
 
             loadImage.createImage = function(url, crossOrigin, deferred) {
-                expect(crossOrigin).toEqual(true);
-
                 // Just return any old image.
                 return loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             };
@@ -167,7 +165,6 @@ defineSuite([
             loadImage.createImage = function(url, crossOrigin, deferred) {
                 expect(url.indexOf(proxy.getURL('made/up/osm/server'))).toEqual(0);
                 expect(provider.getProxy()).toEqual(proxy);
-                expect(crossOrigin).toEqual(true);
 
                 // Just return any old image.
                 return loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);

--- a/Specs/Scene/SingleTileImageryProviderSpec.js
+++ b/Specs/Scene/SingleTileImageryProviderSpec.js
@@ -77,7 +77,6 @@ defineSuite([
         var calledCreateImage = false;
         loadImage.createImage = function(url, crossOrigin, deferred) {
             expect(url).toEqual(imageUrl);
-            expect(crossOrigin).toEqual(true);
             calledCreateImage = true;
             return loadImage.defaultCreateImage(url, crossOrigin, deferred);
         };
@@ -143,7 +142,6 @@ defineSuite([
 
         loadImage.createImage = function(url, crossOrigin, deferred) {
             expect(url.indexOf(proxy.getURL('Data/Images/Red16x16.png'))).toEqual(0);
-            expect(crossOrigin).toEqual(true);
 
             calledCreateImage = true;
             deferred.resolve();

--- a/Specs/Scene/TileMapServiceImageryProviderSpec.js
+++ b/Specs/Scene/TileMapServiceImageryProviderSpec.js
@@ -120,8 +120,6 @@ defineSuite([
             expect(provider.getExtent()).toEqual(new WebMercatorTilingScheme().getExtent());
 
             loadImage.createImage = function(url, crossOrigin, deferred) {
-                expect(crossOrigin).toEqual(true);
-
                 // Just return any old image.
                 return loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             };
@@ -172,7 +170,6 @@ defineSuite([
             loadImage.createImage = function(url, crossOrigin, deferred) {
                 expect(url.indexOf(proxy.getURL('made/up/tms/server'))).toEqual(0);
                 expect(provider.getProxy()).toEqual(proxy);
-                expect(crossOrigin).toEqual(true);
 
                 // Just return any old image.
                 return loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);

--- a/Specs/Scene/VRTheWorldTerrainProviderSpec.js
+++ b/Specs/Scene/VRTheWorldTerrainProviderSpec.js
@@ -208,7 +208,6 @@ defineSuite([
             loadImage.createImage = function(url, crossOrigin, deferred) {
                 expect(url.indexOf('/proxy/?')).toBe(0);
                 expect(url.indexOf(encodeURIComponent('.tif?cesium=true'))).toBeGreaterThanOrEqualTo(0);
-                expect(crossOrigin).toEqual(true);
 
                 // Just return any old image.
                 return loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
@@ -242,7 +241,6 @@ defineSuite([
 
             loadImage.createImage = function(url, crossOrigin, deferred) {
                 expect(url.indexOf('.tif?cesium=true')).toBeGreaterThanOrEqualTo(0);
-                expect(crossOrigin).toEqual(true);
 
                 // Just return any old image.
                 return loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);

--- a/Specs/Scene/WebMapServiceImageryProviderSpec.js
+++ b/Specs/Scene/WebMapServiceImageryProviderSpec.js
@@ -200,8 +200,6 @@ defineSuite([
             expect(provider.getExtent()).toEqual(new GeographicTilingScheme().getExtent());
 
             loadImage.createImage = function(url, crossOrigin, deferred) {
-                expect(crossOrigin).toEqual(true);
-
                 // Just return any old image.
                 return loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             };
@@ -281,7 +279,6 @@ defineSuite([
             loadImage.createImage = function(url, crossOrigin, deferred) {
                 expect(url.indexOf(proxy.getURL('made/up/wms/server'))).toEqual(0);
                 expect(provider.getProxy()).toEqual(proxy);
-                expect(crossOrigin).toEqual(true);
 
                 // Just return any old image.
                 return loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);


### PR DESCRIPTION
Cross-origin URLs are detected automatically by comparing the URL to the document location.

This addresses the issue raised on the dev list:

https://groups.google.com/d/topic/cesium-dev/HiJ2Vedkd2M/discussion
