### PR TITLE
Make Transforms show up in the doc

### DIFF
--- a/Source/Core/Transforms.js
+++ b/Source/Core/Transforms.js
@@ -335,8 +335,8 @@ define([
      *
      * @memberof Transforms
      *
-     * @see Transforms#computeIcrfToFixedMatrix
-     * @see Transforms#computeFixedToIcrfMatrix
+     * @see Transforms.computeIcrfToFixedMatrix
+     * @see Transforms.computeFixedToIcrfMatrix
      */
     Transforms.iau2006XysData = new Iau2006XysData();
 
@@ -348,8 +348,8 @@ define([
      *
      * @memberof Transforms
      *
-     * @see Transforms#computeIcrfToFixedMatrix
-     * @see Transforms#computeFixedToIcrfMatrix
+     * @see Transforms.computeIcrfToFixedMatrix
+     * @see Transforms.computeFixedToIcrfMatrix
      */
     Transforms.earthOrientationParameters = EarthOrientationParameters.NONE;
 
@@ -368,8 +368,8 @@ define([
      *          and evaluation of the transformation between the fixed and ICRF axes will
      *          no longer return undefined for a time inside the interval.
      *
-     * @see Transforms#computeIcrfToFixedMatrix
-     * @see Transforms#computeFixedToIcrfMatrix
+     * @see Transforms.computeIcrfToFixedMatrix
+     * @see Transforms.computeFixedToIcrfMatrix
      * @see when
      *
      * @example
@@ -406,7 +406,7 @@ define([
      *
      * @exception {DeveloperError} date is required.
      *
-     * @see Transforms#preloadIcrfFixed
+     * @see Transforms.preloadIcrfFixed
      *
      * @example
      * //Set the view to the inertial frame.
@@ -457,7 +457,7 @@ define([
      *
      * @exception {DeveloperError} date is required.
      *
-     * @see Transforms#preloadIcrfFixed
+     * @see Transforms.preloadIcrfFixed
      *
      * @example
      * // Transform a point from the ICRF axes to the Fixed axes.


### PR DESCRIPTION
I noticed while reviewing another pull request that `Transforms` isn't showing up in the documentation because JSDoc is hard.  This pull request fixes that.
