### PR TITLE
Clean up usage of defaultValue.

### DIFF
--- a/Source/Core/BoundingRectangle.js
+++ b/Source/Core/BoundingRectangle.js
@@ -124,7 +124,7 @@ define([
             return result;
         }
 
-        projection = (typeof projection !== 'undefined') ? projection : defaultProjection;
+        projection = defaultValue(projection, defaultProjection);
 
         var lowerLeft = projection.project(extent.getSouthwest(fromExtentLowerLeft));
         var upperRight = projection.project(extent.getNortheast(fromExtentUpperRight));

--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -43,7 +43,8 @@ define([
          * The center point of the sphere.
          * @type {Cartesian3}
          */
-        this.center = (typeof center !== 'undefined') ? Cartesian3.clone(center) : Cartesian3.ZERO.clone();
+        this.center = Cartesian3.clone(defaultValue(center, Cartesian3.ZERO));
+
         /**
          * The radius of the sphere.
          * @type {Number}
@@ -255,7 +256,7 @@ define([
             return result;
         }
 
-        projection = (typeof projection !== 'undefined') ? projection : defaultProjection;
+        projection = defaultValue(projection, defaultProjection);
 
         extent.getSouthwest(fromExtent2DSouthwest);
         fromExtent2DSouthwest.height = minimumHeight;
@@ -291,7 +292,12 @@ define([
      */
     BoundingSphere.fromExtent3D = function(extent, ellipsoid, result) {
         ellipsoid = defaultValue(ellipsoid, Ellipsoid.WGS84);
-        var positions = typeof extent !== 'undefined' ? extent.subsample(ellipsoid, fromExtent3DScratch) : undefined;
+
+        var positions;
+        if (typeof extent !== 'undefined') {
+            positions = extent.subsample(ellipsoid, fromExtent3DScratch);
+        }
+
         return BoundingSphere.fromPoints(positions, result);
     };
 

--- a/Source/Core/BoxTessellator.js
+++ b/Source/Core/BoxTessellator.js
@@ -28,17 +28,17 @@ define([
          *
          * @exception {DeveloperError} All dimensions' components must be greater than or equal to zero.
          */
-        compute : function(template) {
-            template = defaultValue(template, {});
+        compute : function(options) {
+            options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
             var minimumCorner;
             var maximumCorner;
 
-            if (typeof template.minimumCorner !== 'undefined' && typeof template.maximumCorner !== 'undefined') {
-                minimumCorner = template.minimumCorner;
-                maximumCorner = template.maximumCorner;
+            if (typeof options.minimumCorner !== 'undefined' && typeof options.maximumCorner !== 'undefined') {
+                minimumCorner = options.minimumCorner;
+                maximumCorner = options.maximumCorner;
             } else {
-                var dimensions = (typeof template.dimensions !== 'undefined') ? template.dimensions : new Cartesian3(1.0, 1.0, 1.0);
+                var dimensions = typeof options.dimensions !== 'undefined' ? options.dimensions : new Cartesian3(1.0, 1.0, 1.0);
 
                 if (dimensions.x < 0 || dimensions.y < 0 || dimensions.z < 0) {
                     throw new DeveloperError('All dimensions components must be greater than or equal to zero.');

--- a/Source/Core/Clock.js
+++ b/Source/Core/Clock.js
@@ -46,7 +46,7 @@ define([
      * });
      */
     var Clock = function(description) {
-        description = defaultValue(description, {});
+        description = defaultValue(description, defaultValue.EMPTY_OBJECT);
 
         var startTime = description.startTime;
         var startTimeUndefined = typeof startTime === 'undefined';

--- a/Source/Core/EarthOrientationParameters.js
+++ b/Source/Core/EarthOrientationParameters.js
@@ -65,7 +65,7 @@ define([
      * Transforms.earthOrientationParameters = eop;
      */
     var EarthOrientationParameters = function EarthOrientationParameters(description) {
-        description = defaultValue(description, {});
+        description = defaultValue(description, defaultValue.EMPTY_OBJECT);
 
         this._dates = undefined;
         this._samples = undefined;

--- a/Source/Core/ExtentTessellator.js
+++ b/Source/Core/ExtentTessellator.js
@@ -1,5 +1,6 @@
 /*global define*/
 define([
+        './clone',
         './defaultValue',
         './DeveloperError',
         './Math',
@@ -9,6 +10,7 @@ define([
         './ComponentDatatype',
         './PrimitiveType'
     ], function(
+        clone,
         defaultValue,
         DeveloperError,
         CesiumMath,
@@ -51,7 +53,7 @@ define([
      * @param {Array|Float32Array} [description.indices] The array to use to store computed indices.  If undefined, indices will be not computed.
      */
     ExtentTessellator.computeVertices = function(description) {
-        description = defaultValue(description, {});
+        description = defaultValue(description, defaultValue.EMPTY_OBJECT);
 
         var extent = description.extent;
         var surfaceHeight = description.surfaceHeight;
@@ -200,32 +202,35 @@ define([
      * });
      */
     ExtentTessellator.compute = function(description) {
-        description = defaultValue(description, {});
+        description = defaultValue(description, defaultValue.EMPTY_OBJECT);
+
+        // make a copy of description to allow us to change values before passing to computeVertices
+        var computeVerticesDescription = clone(description);
 
         var extent = description.extent;
         extent.validate();
 
         var ellipsoid = defaultValue(description.ellipsoid, Ellipsoid.WGS84);
-        description.radiiSquared = ellipsoid.getRadiiSquared();
-        description.relativeToCenter = defaultValue(description.relativeToCenter, Cartesian3.ZERO);
+        computeVerticesDescription.radiiSquared = ellipsoid.getRadiiSquared();
+        computeVerticesDescription.relativeToCenter = defaultValue(description.relativeToCenter, Cartesian3.ZERO);
 
         var granularity = defaultValue(description.granularity, 0.1);
-        description.surfaceHeight = defaultValue(description.surfaceHeight, 0.0);
+        computeVerticesDescription.surfaceHeight = defaultValue(description.surfaceHeight, 0.0);
 
-        description.width = Math.ceil((extent.east - extent.west) / granularity) + 1;
-        description.height = Math.ceil((extent.north - extent.south) / granularity) + 1;
+        computeVerticesDescription.width = Math.ceil((extent.east - extent.west) / granularity) + 1;
+        computeVerticesDescription.height = Math.ceil((extent.north - extent.south) / granularity) + 1;
 
         var vertices = [];
         var indices = [];
         var textureCoordinates = [];
 
-        description.generateTextureCoordinates = defaultValue(description.generateTextureCoordinates, false);
-        description.interleaveTextureCoordinates = false;
-        description.vertices = vertices;
-        description.textureCoordinates = textureCoordinates;
-        description.indices = indices;
+        computeVerticesDescription.generateTextureCoordinates = defaultValue(computeVerticesDescription.generateTextureCoordinates, false);
+        computeVerticesDescription.interleaveTextureCoordinates = false;
+        computeVerticesDescription.vertices = vertices;
+        computeVerticesDescription.textureCoordinates = textureCoordinates;
+        computeVerticesDescription.indices = indices;
 
-        ExtentTessellator.computeVertices(description);
+        ExtentTessellator.computeVertices(computeVerticesDescription);
 
         var mesh = {
             attributes : {},
@@ -338,32 +343,35 @@ define([
      * var vacontext.createVertexArray(attributes, indexBuffer);
      */
     ExtentTessellator.computeBuffers = function(description) {
-        description = defaultValue(description, {});
+        description = defaultValue(description, defaultValue.EMPTY_OBJECT);
+
+        // make a copy of description to allow us to change values before passing to computeVertices
+        var computeVerticesDescription = clone(description);
 
         var extent = description.extent;
         extent.validate();
 
         var ellipsoid = defaultValue(description.ellipsoid, Ellipsoid.WGS84);
-        description.radiiSquared = ellipsoid.getRadiiSquared();
-        description.relativeToCenter = defaultValue(description.relativeToCenter, Cartesian3.ZERO);
+        computeVerticesDescription.radiiSquared = ellipsoid.getRadiiSquared();
+        computeVerticesDescription.relativeToCenter = defaultValue(description.relativeToCenter, Cartesian3.ZERO);
 
         var granularity = defaultValue(description.granularity, 0.1);
-        description.surfaceHeight = defaultValue(description.surfaceHeight, 0.0);
+        computeVerticesDescription.surfaceHeight = defaultValue(description.surfaceHeight, 0.0);
 
-        description.width = Math.ceil((extent.east - extent.west) / granularity) + 1;
-        description.height = Math.ceil((extent.north - extent.south) / granularity) + 1;
+        computeVerticesDescription.width = Math.ceil((extent.east - extent.west) / granularity) + 1;
+        computeVerticesDescription.height = Math.ceil((extent.north - extent.south) / granularity) + 1;
 
         var vertices = [];
         var indices = [];
         var textureCoordinates = [];
 
-        description.generateTextureCoordinates = defaultValue(description.generateTextureCoordinates, false);
-        description.interleaveTextureCoordinates = defaultValue(description.interleaveTextureCoordinates, false);
-        description.vertices = vertices;
-        description.textureCoordinates = textureCoordinates;
-        description.indices = indices;
+        computeVerticesDescription.generateTextureCoordinates = defaultValue(description.generateTextureCoordinates, false);
+        computeVerticesDescription.interleaveTextureCoordinates = defaultValue(description.interleaveTextureCoordinates, false);
+        computeVerticesDescription.vertices = vertices;
+        computeVerticesDescription.textureCoordinates = textureCoordinates;
+        computeVerticesDescription.indices = indices;
 
-        ExtentTessellator.computeVertices(description);
+        ExtentTessellator.computeVertices(computeVerticesDescription);
 
         var result = {
             indices : indices

--- a/Source/Core/Iau2006XysData.js
+++ b/Source/Core/Iau2006XysData.js
@@ -2,18 +2,17 @@
 define([
         './buildModuleUrl',
         './defaultValue',
-        './loadJson',
         './Iau2006XysSample',
         './JulianDate',
+        './loadJson',
         './TimeStandard',
         '../ThirdParty/when'
-    ],
-    function(
+    ], function(
         buildModuleUrl,
         defaultValue,
-        loadJson,
         Iau2006XysSample,
         JulianDate,
+        loadJson,
         TimeStandard,
         when) {
     "use strict";
@@ -35,7 +34,7 @@ define([
      * @param {Number} [description.totalSamples=27426] The total number of samples in all XYS files.
      */
     var Iau2006XysData = function Iau2006XysData(description) {
-        description = description || {};
+        description = defaultValue(description, defaultValue.EMPTY_OBJECT);
 
         this._xysFileUrlTemplate = defaultValue(description.xysFileUrlTemplate, buildModuleUrl('Assets/IAU2006_XYS/IAU2006_XYS_{0}.json'));
         this._interpolationOrder = defaultValue(description.interpolationOrder, 9);

--- a/Source/Core/Matrix4.js
+++ b/Source/Core/Matrix4.js
@@ -715,7 +715,6 @@ define([
         return result;
     };
 
-    var EMPTY_OBJECT = {};
     /**
      * Computes a Matrix4 instance that transforms from normalized device coordinates to window coordinates.
      * @memberof Matrix4
@@ -742,7 +741,7 @@ define([
      * var m = Matrix4.computeViewportTransformation(context.getViewport());
      */
     Matrix4.computeViewportTransformation = function(viewport, nearDepthRange, farDepthRange, result) {
-        viewport = defaultValue(viewport, EMPTY_OBJECT);
+        viewport = defaultValue(viewport, defaultValue.EMPTY_OBJECT);
         var x = defaultValue(viewport.x, 0.0);
         var y = defaultValue(viewport.y, 0.0);
         var width = defaultValue(viewport.width, 0.0);

--- a/Source/Core/PlaneTessellator.js
+++ b/Source/Core/PlaneTessellator.js
@@ -25,10 +25,10 @@ define([
          *
          * @exception {DeveloperError} Resolution must be greater than one in both the x and y directions.
          */
-        compute : function(template) {
-            template = defaultValue(template, {});
-            var resolution = (typeof template.resolution === "undefined") ?  new Cartesian2(2, 2) : template.resolution;
-            var onInterpolation = template.onInterpolation; // Can be undefined
+        compute : function(options) {
+            options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+            var resolution = typeof options.resolution !== "undefined" ? options.resolution : new Cartesian2(2, 2);
+            var onInterpolation = options.onInterpolation; // Can be undefined
 
             if (resolution.x <= 1 || resolution.y <= 1) {
                 throw new DeveloperError('Resolution must be greater than one in both the x and y directions.');

--- a/Source/Core/Spherical.js
+++ b/Source/Core/Spherical.js
@@ -1,5 +1,10 @@
 /*global define*/
-define(['./defaultValue'], function(defaultValue) {
+define([
+        './DeveloperError',
+        './defaultValue'
+    ], function(
+        DeveloperError,
+        defaultValue) {
     "use strict";
 
     /**
@@ -26,13 +31,23 @@ define(['./defaultValue'], function(defaultValue) {
      * @param {Spherical} [spherical] The object in which the result will be stored, if undefined a new instance will be created.
      *
      * @returns The modified result parameter, or a new instance if one was not provided.
+     *
+     * @exception {DeveloperError} cartesian3 is required.
      */
     Spherical.fromCartesian3 = function(cartesian3, result) {
-        result = (typeof result === 'undefined') ? new Spherical() : result;
+        if (typeof cartesian3 === 'undefined') {
+            throw new DeveloperError('cartesian3 is required');
+        }
+
         var x = cartesian3.x;
         var y = cartesian3.y;
         var z = cartesian3.z;
         var radialSquared = x * x + y * y;
+
+        if (typeof result === 'undefined') {
+            result = new Spherical();
+        }
+
         result.clock = Math.atan2(y, x);
         result.cone = Math.atan2(Math.sqrt(radialSquared), z);
         result.magnitude = Math.sqrt(radialSquared + z * z);
@@ -47,9 +62,18 @@ define(['./defaultValue'], function(defaultValue) {
      * @param {Spherical} [result] The object to store the result into, if undefined a new instance will be created.
      *
      * @return The modified result parameter or a new instance if result was undefined.
+     *
+     * @exception {DeveloperError} spherical is required.
      */
     Spherical.clone = function(spherical, result) {
-        result = (typeof result === 'undefined') ? new Spherical() : result;
+        if (typeof spherical === 'undefined') {
+            throw new DeveloperError('spherical is required');
+        }
+
+        if (typeof result === 'undefined') {
+            return new Spherical(spherical.clock, spherical.cone, spherical.magnitude);
+        }
+
         result.clock = spherical.clock;
         result.cone = spherical.cone;
         result.magnitude = spherical.magnitude;
@@ -64,9 +88,18 @@ define(['./defaultValue'], function(defaultValue) {
      * @param {Spherical} [result] The object to store the result into, if undefined a new instance will be created.
      *
      * @return The modified result parameter or a new instance if result was undefined.
+     *
+     * @exception {DeveloperError} spherical is required.
      */
     Spherical.normalize = function(spherical, result) {
-        result = (typeof result === 'undefined') ? new Spherical() : result;
+        if (typeof spherical === 'undefined') {
+            throw new DeveloperError('spherical is required');
+        }
+
+        if (typeof result === 'undefined') {
+            return new Spherical(spherical.clock, spherical.cone, 1.0);
+        }
+
         result.clock = spherical.clock;
         result.cone = spherical.cone;
         result.magnitude = 1.0;

--- a/Source/Core/Tipsify.js
+++ b/Source/Core/Tipsify.js
@@ -40,10 +40,10 @@ define([
      * var indices = [0, 1, 2, 3, 4, 5];
      * var maxIndex = 5;
      * var cacheSize = 3;
-     * var acmr = Tipsify.calculateACMR({"indices":indices, "maxIndex":maxIndex, "cacheSize":cacheSize});
+     * var acmr = Tipsify.calculateACMR({indices : indices, maxIndex : maxIndex, cacheSize : cacheSize});
      */
     Tipsify.calculateACMR = function(description) {
-        description = defaultValue(description, {});
+        description = defaultValue(description, defaultValue.EMPTY_OBJECT);
         var indices = description.indices;
         var maximumIndex = description.maximumIndex;
         var cacheSize = defaultValue(description.cacheSize, 24);
@@ -54,7 +54,7 @@ define([
 
         var numIndices = indices.length;
 
-        if ((numIndices < 3) || (numIndices % 3 !== 0)) {
+        if (numIndices < 3 || numIndices % 3 !== 0) {
             throw new DeveloperError('indices length must be a multiple of three.');
         }
         if (maximumIndex <= 0) {
@@ -65,7 +65,7 @@ define([
         }
 
         // Compute the maximumIndex if not given
-        if(typeof maximumIndex === 'undefined') {
+        if (typeof maximumIndex === 'undefined') {
             maximumIndex = 0;
             var currentIndex = 0;
             var intoIndices = indices[currentIndex];
@@ -115,10 +115,10 @@ define([
      * var indices = [0, 1, 2, 3, 4, 5];
      * var maxIndex = 5;
      * var cacheSize = 3;
-     * var reorderedIndices = Tipsify.tipsify({"indices":indices, "maxIndex":maxIndex, "cacheSize":cacheSize});
+     * var reorderedIndices = Tipsify.tipsify({indices : indices, maxIndex : maxIndex, cacheSize : cacheSize});
      */
     Tipsify.tipsify = function(description) {
-        description = defaultValue(description, {});
+        description = defaultValue(description, defaultValue.EMPTY_OBJECT);
         var indices = description.indices;
         var maximumIndex = description.maximumIndex;
         var cacheSize = defaultValue(description.cacheSize, 24);
@@ -176,7 +176,7 @@ define([
         }
         var numIndices = indices.length;
 
-        if ((numIndices < 3) || (numIndices % 3 !== 0)) {
+        if (numIndices < 3 || numIndices % 3 !== 0) {
             throw new DeveloperError('indices length must be a multiple of three.');
         }
         if (maximumIndex <= 0) {
@@ -219,11 +219,11 @@ define([
         currentIndex = 0;
         var triangle = 0;
         while (currentIndex < endIndex) {
-            (vertices[indices[currentIndex]]).vertexTriangles.push(triangle);
+            vertices[indices[currentIndex]].vertexTriangles.push(triangle);
             ++(vertices[indices[currentIndex]]).numLiveTriangles;
-            (vertices[indices[currentIndex + 1]]).vertexTriangles.push(triangle);
+            vertices[indices[currentIndex + 1]].vertexTriangles.push(triangle);
             ++(vertices[indices[currentIndex + 1]]).numLiveTriangles;
-            (vertices[indices[currentIndex + 2]]).vertexTriangles.push(triangle);
+            vertices[indices[currentIndex + 2]].vertexTriangles.push(triangle);
             ++(vertices[indices[currentIndex + 2]]).numLiveTriangles;
             ++triangle;
             currentIndex += 3;

--- a/Source/Core/clone.js
+++ b/Source/Core/clone.js
@@ -1,21 +1,38 @@
 /*global define*/
-define(function() {
+define([
+        './defaultValue'
+    ], function(
+        defaultValue) {
     "use strict";
 
-    function clone(object) {
+    /**
+     * Clones an object, returning a new object containing the same properties.
+     *
+     * @exports clone
+     *
+     * @param {Object} object The object to clone.
+     * @param {Boolean} [deep=false] If true, all properties will be deep cloned recursively.
+     */
+    var clone = function(object, deep) {
         if (object === null || typeof object !== 'object') {
             return object;
         }
 
-        var temp = new object.constructor();
-        for ( var key in object) {
-            if (object.hasOwnProperty(key)) {
-                temp[key] = clone(object[key]);
+        deep = defaultValue(deep, false);
+
+        var result = new object.constructor();
+        for ( var propertyName in object) {
+            if (object.hasOwnProperty(propertyName)) {
+                var value = object[propertyName];
+                if (deep) {
+                    value = clone(value, deep);
+                }
+                result[propertyName] = value;
             }
         }
 
-        return temp;
-    }
+        return result;
+    };
 
     return clone;
 });

--- a/Source/Core/defaultValue.js
+++ b/Source/Core/defaultValue.js
@@ -1,5 +1,8 @@
 /*global define*/
-define(function() {
+define([
+        './freezeObject'
+    ], function(
+        freezeObject) {
     "use strict";
 
     /**
@@ -17,6 +20,12 @@ define(function() {
         }
         return b;
     };
+
+    /**
+     * A frozen empty object that can be used as the default value for options passed as
+     * an object literal.
+     */
+    defaultValue.EMPTY_OBJECT = freezeObject({});
 
     return defaultValue;
 });

--- a/Source/Core/jsonp.js
+++ b/Source/Core/jsonp.js
@@ -40,7 +40,7 @@ define([
             throw new DeveloperError('url is required.');
         }
 
-        options = defaultValue(options, {});
+        options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var deferred = when.defer();
 
@@ -65,7 +65,7 @@ define([
         var queryParts = [];
         pushQueryParameter(queryParts, callbackParameterName, functionName);
 
-        var parameters = defaultValue(options.parameters, {});
+        var parameters = defaultValue(options.parameters, defaultValue.EMPTY_OBJECT);
         for ( var name in parameters) {
             if (parameters.hasOwnProperty(name)) {
                 pushQueryParameter(queryParts, name, parameters[name]);

--- a/Source/Core/loadJson.js
+++ b/Source/Core/loadJson.js
@@ -1,9 +1,11 @@
 /*global define*/
 define([
+        './clone',
         './defaultValue',
         './loadText',
         './DeveloperError'
     ], function(
+        clone,
         defaultValue,
         loadText,
         DeveloperError) {
@@ -42,7 +44,8 @@ define([
             throw new DeveloperError('url is required.');
         }
 
-        headers = defaultValue(headers, {});
+        // make a copy of headers to allow us to change values before passing to computeVertices
+        headers = clone(defaultValue(headers, defaultValue.EMPTY_OBJECT));
         headers.Accept = 'application/json';
 
         return loadText(url, headers).then(function(value) {

--- a/Source/Core/writeTextToCanvas.js
+++ b/Source/Core/writeTextToCanvas.js
@@ -11,8 +11,6 @@ define([
         measureText) {
     "use strict";
 
-    var EMPTY_OBJECT = {};
-
     /**
      * Writes the given text into a new canvas.  The canvas will be sized to fit the text.
      * If text is blank, returns undefined.
@@ -39,7 +37,7 @@ define([
             return undefined;
         }
 
-        description = defaultValue(description, EMPTY_OBJECT);
+        description = defaultValue(description, defaultValue.EMPTY_OBJECT);
         var font = defaultValue(description.font, '10px sans-serif');
 
         var canvas = document.createElement('canvas');

--- a/Source/DynamicScene/CzmlBoolean.js
+++ b/Source/DynamicScene/CzmlBoolean.js
@@ -1,5 +1,8 @@
 /*global define*/
-define(function() {
+define([
+        '../Core/defaultValue'
+    ], function(
+        defaultValue) {
     "use strict";
 
     /**
@@ -30,8 +33,8 @@ define(function() {
          */
         unwrapInterval : function(czmlInterval) {
             /*jshint sub:true*/
-            var result = czmlInterval['boolean']; // boolean is a JS reserved word
-            return typeof result === 'undefined' ? czmlInterval : result;
+            // boolean is a JS reserved word
+            return defaultValue(czmlInterval['boolean'], czmlInterval);
         },
 
         /**

--- a/Source/DynamicScene/CzmlHorizontalOrigin.js
+++ b/Source/DynamicScene/CzmlHorizontalOrigin.js
@@ -1,8 +1,10 @@
 /*global define*/
 define([
+        '../Core/defaultValue',
         '../Scene/HorizontalOrigin'
-       ], function(
-         HorizontalOrigin) {
+    ], function(
+        defaultValue,
+        HorizontalOrigin) {
     "use strict";
 
     /**
@@ -33,8 +35,7 @@ define([
          * @param {Object} czmlInterval The CZML interval to unwrap.
          */
         unwrapInterval : function(czmlInterval) {
-            var result = czmlInterval.horizontalOrigin;
-            return typeof result === 'undefined' ? czmlInterval : result;
+            return defaultValue(czmlInterval.horizontalOrigin, czmlInterval);
         },
 
         /**

--- a/Source/DynamicScene/CzmlImage.js
+++ b/Source/DynamicScene/CzmlImage.js
@@ -1,5 +1,10 @@
 /*global define*/
-define(['../ThirdParty/Uri'], function(Uri) {
+define([
+        '../Core/defaultValue',
+        '../ThirdParty/Uri'
+    ], function(
+        defaultValue,
+        Uri) {
     "use strict";
 
     /**
@@ -29,7 +34,7 @@ define(['../ThirdParty/Uri'], function(Uri) {
          * @param {Object} czmlInterval The CZML interval to unwrap.
          */
         unwrapInterval : function(czmlInterval, sourceUri) {
-            var result = typeof czmlInterval.image === 'undefined' ? czmlInterval : czmlInterval.image;
+            var result = defaultValue(czmlInterval.image, czmlInterval);
             if (typeof sourceUri !== 'undefined') {
                 var baseUri = new Uri(document.location.href);
                 sourceUri = new Uri(sourceUri);

--- a/Source/DynamicScene/CzmlLabelStyle.js
+++ b/Source/DynamicScene/CzmlLabelStyle.js
@@ -1,8 +1,10 @@
 /*global define*/
 define([
+        '../Core/defaultValue',
         '../Scene/LabelStyle'
-       ], function(
-         LabelStyle) {
+    ], function(
+        defaultValue,
+        LabelStyle) {
     "use strict";
 
     /**
@@ -33,8 +35,7 @@ define([
          * @param {Object} czmlInterval The CZML interval to unwrap.
          */
         unwrapInterval : function(czmlInterval) {
-            var result = czmlInterval.labelStyle;
-            return typeof result === 'undefined' ? czmlInterval : result;
+            return defaultValue(czmlInterval.labelStyle, czmlInterval);
         },
 
         /**

--- a/Source/DynamicScene/CzmlNumber.js
+++ b/Source/DynamicScene/CzmlNumber.js
@@ -1,5 +1,8 @@
 /*global define*/
-define(function() {
+define([
+        '../Core/defaultValue'
+    ], function(
+        defaultValue) {
     "use strict";
 
     var doublesPerValue = 1;
@@ -41,8 +44,7 @@ define(function() {
          * @param {Object} czmlInterval The CZML interval to unwrap.
          */
         unwrapInterval : function(czmlInterval) {
-            var result = czmlInterval.number;
-            return typeof result === 'undefined' ? czmlInterval : result;
+            return defaultValue(czmlInterval.number, czmlInterval);
         },
 
         /**

--- a/Source/DynamicScene/CzmlString.js
+++ b/Source/DynamicScene/CzmlString.js
@@ -1,5 +1,8 @@
 /*global define*/
-define(function() {
+define([
+        '../Core/defaultValue'
+    ], function(
+        defaultValue) {
     "use strict";
 
     /**
@@ -29,8 +32,7 @@ define(function() {
          * @param {Object} czmlInterval The CZML interval to unwrap.
          */
         unwrapInterval : function(czmlInterval) {
-            var result = czmlInterval.string;
-            return typeof result === 'undefined' ? czmlInterval : result;
+            return defaultValue(czmlInterval.string, czmlInterval);
         },
 
         /**

--- a/Source/DynamicScene/CzmlVerticalOrigin.js
+++ b/Source/DynamicScene/CzmlVerticalOrigin.js
@@ -1,8 +1,10 @@
 /*global define*/
 define([
+        '../Core/defaultValue',
         '../Scene/VerticalOrigin'
-       ], function(
-         VerticalOrigin) {
+    ], function(
+        defaultValue,
+        VerticalOrigin) {
     "use strict";
 
     /**
@@ -33,8 +35,7 @@ define([
          * @param {Object} czmlInterval The CZML interval to unwrap.
          */
         unwrapInterval : function(czmlInterval) {
-            var result = czmlInterval.verticalOrigin;
-            return typeof result === 'undefined' ? czmlInterval : result;
+            return defaultValue(czmlInterval.verticalOrigin, czmlInterval);
         },
 
         /**

--- a/Source/DynamicScene/DynamicPathVisualizer.js
+++ b/Source/DynamicScene/DynamicPathVisualizer.js
@@ -64,7 +64,7 @@ define([
         var sampleStop;
         var showProperty = dynamicPath.show;
         var pathVisualizerIndex = dynamicObject._pathVisualizerIndex;
-        var show = (typeof showProperty === 'undefined' || showProperty.getValue(time));
+        var show = typeof showProperty === 'undefined' || showProperty.getValue(time);
 
         //While we want to show the path, there may not actually be anything to show
         //depending on lead/trail settings.  Compute the interval of the path to

--- a/Source/DynamicScene/DynamicPointVisualizer.js
+++ b/Source/DynamicScene/DynamicPointVisualizer.js
@@ -1,16 +1,18 @@
 /*global define*/
 define([
-        '../Core/Event',
-        '../Core/DeveloperError',
-        '../Core/destroyObject',
         '../Core/Color',
+        '../Core/defaultValue',
+        '../Core/destroyObject',
+        '../Core/DeveloperError',
+        '../Core/Event',
         '../Scene/BillboardCollection',
         '../Renderer/TextureAtlasBuilder'
        ], function(
-         Event,
-         DeveloperError,
-         destroyObject,
          Color,
+         defaultValue,
+         destroyObject,
+         DeveloperError,
+         Event,
          BillboardCollection,
          TextureAtlasBuilder) {
     "use strict";
@@ -267,10 +269,10 @@ define([
         }
 
         if (needRedraw) {
-            var cssColor = typeof billboard._visualizerColor !== 'undefined' ? billboard._visualizerColor.toCssColorString() : '#FFFFFF';
-            var cssOutlineColor = typeof billboard._visualizerOutlineColor !== 'undefined' ? billboard._visualizerOutlineColor.toCssColorString() : '#000000';
-            var cssPixelSize = typeof billboard._visualizerPixelSize !== 'undefined' ? billboard._visualizerPixelSize : 3;
-            var cssOutlineWidth = typeof billboard._visualizerOutlineWidth !== 'undefined' ? billboard._visualizerOutlineWidth : 2;
+            var cssColor = defaultValue(billboard._visualizerColor, Color.WHITE).toCssColorString();
+            var cssOutlineColor = defaultValue(billboard._visualizerOutlineColor, Color.BLACK).toCssColorString();
+            var cssPixelSize = defaultValue(billboard._visualizerPixelSize, 3);
+            var cssOutlineWidth = defaultValue(billboard._visualizerOutlineWidth, 2);
             var textureId = JSON.stringify([cssColor, cssPixelSize, cssOutlineColor, cssOutlineWidth]);
 
             this._textureAtlasBuilder.addTextureFromFunction(textureId, function(id, loadedCallback) {

--- a/Source/DynamicScene/DynamicPositionProperty.js
+++ b/Source/DynamicScene/DynamicPositionProperty.js
@@ -178,8 +178,8 @@ define([
 
         var propertyIntervals = this._propertyIntervals;
 
-        var startIndex = typeof start === 'undefined' ? 0 : propertyIntervals.indexOf(start);
-        var stopIndex = typeof stop === 'undefined' ? propertyIntervals.length - 1 : propertyIntervals.indexOf(stop);
+        var startIndex = typeof start !== 'undefined' ? propertyIntervals.indexOf(start) : 0;
+        var stopIndex = typeof stop !== 'undefined' ? propertyIntervals.indexOf(stop) : propertyIntervals.length - 1;
         if (startIndex < 0) {
             startIndex = ~startIndex;
         }
@@ -380,8 +380,8 @@ define([
 
         var propertyIntervals = this._propertyIntervals;
 
-        var startIndex = typeof start === 'undefined' ? 0 : propertyIntervals.indexOf(start);
-        var stopIndex = typeof stop === 'undefined' ? propertyIntervals.length - 1 : propertyIntervals.indexOf(stop);
+        var startIndex = typeof start !== 'undefined' ? propertyIntervals.indexOf(start) : 0;
+        var stopIndex = typeof stop !== 'undefined' ? propertyIntervals.indexOf(stop) : propertyIntervals.length - 1;
         if (startIndex < 0) {
             startIndex = ~startIndex;
         }

--- a/Source/DynamicScene/VisualizerCollection.js
+++ b/Source/DynamicScene/VisualizerCollection.js
@@ -1,12 +1,14 @@
 /*global define*/
 define([
-        '../Core/DeveloperError',
+        '../Core/defaultValue',
         '../Core/destroyObject',
+        '../Core/DeveloperError',
         './CzmlDefaults'
-       ], function(
-         DeveloperError,
-         destroyObject,
-         CzmlDefaults) {
+    ], function(
+        defaultValue,
+        destroyObject,
+        DeveloperError,
+        CzmlDefaults) {
     "use strict";
 
     /**
@@ -21,10 +23,7 @@ define([
      * @see CzmlDefaults#createVisualizers
      */
     var VisualizerCollection = function(visualizers, dynamicObjectCollection) {
-        if (typeof visualizers === 'undefined') {
-            visualizers = [];
-        }
-        this._visualizers = visualizers;
+        this._visualizers = typeof visualizers !== 'undefined' ? visualizers : [];
         this._dynamicObjectCollection = undefined;
         this.setDynamicObjectCollection(dynamicObjectCollection);
     };
@@ -63,7 +62,7 @@ define([
      * @param {Boolean} destroyOldVisualizers If true, visualizers no longer in the collection will be destroyed.
      */
     VisualizerCollection.prototype.setVisualizers = function(visualizers, destroyOldVisualizers) {
-        destroyOldVisualizers = (typeof destroyOldVisualizers !== 'undefined') ? destroyOldVisualizers : true;
+        destroyOldVisualizers = defaultValue(destroyOldVisualizers, true);
 
         var i;
         var thisVisualizers = this._visualizers;
@@ -166,7 +165,7 @@ define([
      * visualizerCollection = visualizerCollection && visualizerCollection.destroy();
      */
     VisualizerCollection.prototype.destroy = function(destroyVisualizers) {
-        destroyVisualizers = (typeof destroyVisualizers !== 'undefined') ? destroyVisualizers : true;
+        destroyVisualizers = defaultValue(destroyVisualizers, true);
         this.removeAllPrimitives();
         if (destroyVisualizers) {
             var visualizers = this._visualizers;

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -1502,7 +1502,7 @@ define([
      * var t = context.createTexture2DFromFramebuffer();
      */
     Context.prototype.createTexture2DFromFramebuffer = function(pixelFormat, framebufferXOffset, framebufferYOffset, width, height) {
-        pixelFormat = pixelFormat || PixelFormat.RGB;
+        pixelFormat = defaultValue(pixelFormat, PixelFormat.RGB);
         framebufferXOffset = defaultValue(framebufferXOffset, 0);
         framebufferYOffset = defaultValue(framebufferYOffset, 0);
         width = defaultValue(width, this._canvas.clientWidth);
@@ -1769,11 +1769,10 @@ define([
      * @see Context#createFramebuffer
      */
     Context.prototype.createRenderbuffer = function(description) {
-        description = description || {};
-        var format = description.format || RenderbufferFormat.RGBA4;
-        var width = (typeof description.width === 'undefined') ? this._canvas.clientWidth : description.width;
-        var height = (typeof description.height === 'undefined') ? this._canvas.clientHeight : description.height;
-
+        description = defaultValue(description, defaultValue.EMPTY_OBJECT);
+        var format = defaultValue(description.format, RenderbufferFormat.RGBA4);
+        var width = typeof description.width !== 'undefined' ? description.width : this._canvas.clientWidth;
+        var height = typeof description.height !== 'undefined' ? description.height : this._canvas.clientHeight;
 
         var gl = this._gl;
         if (!RenderbufferFormat.validate(format)) {

--- a/Source/Renderer/ShaderProgram.js
+++ b/Source/Renderer/ShaderProgram.js
@@ -1631,9 +1631,14 @@ define([
         }
     }
 
-    var scratchUniformMatrix2 = (typeof Float32Array !== 'undefined') ? new Float32Array(4) : undefined;
-    var scratchUniformMatrix3 = (typeof Float32Array !== 'undefined') ? new Float32Array(9) : undefined;
-    var scratchUniformMatrix4 = (typeof Float32Array !== 'undefined') ? new Float32Array(16) : undefined;
+    var scratchUniformMatrix2;
+    var scratchUniformMatrix3;
+    var scratchUniformMatrix4;
+    if (typeof Float32Array !== 'undefined') {
+        scratchUniformMatrix2 = new Float32Array(4);
+        scratchUniformMatrix3 = new Float32Array(9);
+        scratchUniformMatrix4 = new Float32Array(16);
+    }
 
     /**
      * A shader program's uniform, including the uniform's value.  This is most commonly used to change
@@ -2519,7 +2524,7 @@ define([
         return attributes;
     }
 
-    function findUniforms(gl ,program) {
+    function findUniforms(gl, program) {
         var allUniforms = {};
         var uniforms = [];
         var samplerUniforms = [];

--- a/Source/Renderer/VertexArray.js
+++ b/Source/Renderer/VertexArray.js
@@ -1,11 +1,13 @@
 /*global define*/
 define([
-        '../Core/DeveloperError',
+        '../Core/defaultValue',
         '../Core/destroyObject',
+        '../Core/DeveloperError',
         '../Core/ComponentDatatype'
     ], function(
-        DeveloperError,
+        defaultValue,
         destroyObject,
+        DeveloperError,
         ComponentDatatype) {
     "use strict";
 
@@ -82,8 +84,8 @@ define([
 
         // Shallow copy the attribute; we do not want to copy the vertex buffer.
         var attr = {
-            index : (typeof attribute.index === 'undefined') ? index : attribute.index,
-            enabled : (typeof attribute.enabled === 'undefined') ? true : attribute.enabled,
+            index : defaultValue(attribute.index, index),
+            enabled : defaultValue(attribute.enabled, true),
             vertexBuffer : attribute.vertexBuffer,
             value : attribute.value ? attribute.value.slice(0) : undefined,
             componentsPerAttribute : componentsPerAttribute,
@@ -180,7 +182,7 @@ define([
     VertexArray.prototype.addAttribute = function(attribute) {
         if (attribute) {
             var attributes = this._attributes;
-            var index = (typeof attribute.index === 'undefined') ? attributes.length : attribute.index;
+            var index = defaultValue(attribute.index, attributes.length);
             for ( var i = 0; i < attributes.length; ++i) {
                 if (index === attributes[i].index) {
                     throw new DeveloperError('Index ' + index + ' is already in use.');

--- a/Source/Renderer/VertexArrayFacade.js
+++ b/Source/Renderer/VertexArrayFacade.js
@@ -1,15 +1,15 @@
 /*global define*/
 define([
-        '../Core/DeveloperError',
+        '../Core/ComponentDatatype',
         '../Core/defaultValue',
         '../Core/destroyObject',
-        '../Core/ComponentDatatype',
+        '../Core/DeveloperError',
         './BufferUsage'
     ], function(
-        DeveloperError,
+        ComponentDatatype,
         defaultValue,
         destroyObject,
-        ComponentDatatype,
+        DeveloperError,
         BufferUsage) {
     "use strict";
 
@@ -159,8 +159,8 @@ define([
             var attribute = attributes[i];
 
             var attr = {
-                index : (typeof attribute.index === 'undefined') ? i : attribute.index,
-                enabled : (typeof attribute.enabled === 'undefined') ? true : attribute.enabled,
+                index : defaultValue(attribute.index, i),
+                enabled : defaultValue(attribute.enabled, true),
                 componentsPerAttribute : attribute.componentsPerAttribute,
                 componentDatatype : attribute.componentDatatype || ComponentDatatype.FLOAT,
                 normalize : attribute.normalize || false,

--- a/Source/Scene/AnimationCollection.js
+++ b/Source/Scene/AnimationCollection.js
@@ -28,27 +28,27 @@ define([
      *
      * @exception {DeveloperError} duration is required.
      */
-    AnimationCollection.prototype.add = function(template) {
-        var t = defaultValue(template, {});
+    AnimationCollection.prototype.add = function(options) {
+        options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
-        if (typeof t.duration === 'undefined') {
+        if (typeof options.duration === 'undefined') {
             throw new DeveloperError('duration is required.');
         }
 
-        t.delayDuration = defaultValue(t.delayDuration, 0);
-        t.easingFunction = (typeof t.easingFunction === 'undefined') ? Tween.Easing.Linear.None : t.easingFunction;
+        var delayDuration = defaultValue(options.delayDuration, 0);
+        var easingFunction = defaultValue(options.easingFunction, Tween.Easing.Linear.None);
 
-        var value = clone(t.startValue);
+        var value = clone(options.startValue);
         var tween = new Tween.Tween(value);
-        tween.to(t.stopValue, t.duration);
-        tween.delay(t.delayDuration);
-        tween.easing(t.easingFunction);
-        if (t.onUpdate) {
+        tween.to(options.stopValue, options.duration);
+        tween.delay(delayDuration);
+        tween.easing(easingFunction);
+        if (typeof options.onUpdate === 'function') {
             tween.onUpdate(function() {
-                t.onUpdate(value);
+                options.onUpdate(value);
             });
         }
-        tween.onComplete(defaultValue(t.onComplete, null));
+        tween.onComplete(defaultValue(options.onComplete, null));
         tween.start();
 
         return {
@@ -63,7 +63,7 @@ define([
      * @exception {DeveloperError} material is required.
      * @exception {DeveloperError} material has no properties with alpha components.
      */
-    AnimationCollection.prototype.addAlpha = function(material, start, stop, template) {
+    AnimationCollection.prototype.addAlpha = function(material, start, stop, options) {
         if (typeof material === 'undefined') {
             throw new DeveloperError('material is required.');
         }
@@ -86,10 +86,10 @@ define([
         start = defaultValue(start, 0.0);
         stop = defaultValue(stop, 1.0);
 
-        var t = defaultValue(template, {});
-        t.duration = defaultValue(t.duration, 3000);
-        t.delayDuration = defaultValue(t.delayDuration, 0);
-        t.easingFunction = (typeof t.easingFunction === 'undefined') ? Tween.Easing.Linear.None : t.easingFunction;
+        options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+        var duration = defaultValue(options.duration, 3000);
+        var delayDuration = defaultValue(options.delayDuration, 0);
+        var easingFunction = defaultValue(options.easingFunction, Tween.Easing.Linear.None);
 
         var value = {
             alpha : start
@@ -97,16 +97,16 @@ define([
         var tween = new Tween.Tween(value);
         tween.to({
             alpha : stop
-        }, t.duration);
-        tween.delay(t.delayDuration);
-        tween.easing(t.easingFunction);
+        }, duration);
+        tween.delay(delayDuration);
+        tween.easing(easingFunction);
         tween.onUpdate(function() {
             var length = properties.length;
             for ( var i = 0; i < length; ++i) {
                 material.uniforms[properties[i]].alpha = value.alpha;
             }
         });
-        tween.onComplete(defaultValue(t.onComplete, null));
+        tween.onComplete(defaultValue(options.onComplete, null));
         tween.start();
 
         return {
@@ -122,7 +122,7 @@ define([
      * @exception {DeveloperError} property is required.
      * @exception {DeveloperError} pbject must have the specified property.
      */
-    AnimationCollection.prototype.addProperty = function(object, property, start, stop, template) {
+    AnimationCollection.prototype.addProperty = function(object, property, start, stop, options) {
         if (typeof object === 'undefined') {
             throw new DeveloperError('object is required.');
         }
@@ -135,10 +135,10 @@ define([
             throw new DeveloperError('object must have the specified property.');
         }
 
-        var t = defaultValue(template, {});
-        t.duration = defaultValue(t.duration, 3000);
-        t.delayDuration = defaultValue(t.delayDuration, 0);
-        t.easingFunction = (typeof t.easingFunction === 'undefined') ? Tween.Easing.Linear.None : t.easingFunction;
+        options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+        var duration = defaultValue(options.duration, 3000);
+        var delayDuration = defaultValue(options.delayDuration, 0);
+        var easingFunction = defaultValue(options.easingFunction, Tween.Easing.Linear.None);
 
         var value = {
             value : start
@@ -146,13 +146,13 @@ define([
         var tween = new Tween.Tween(value);
         tween.to({
             value : stop
-        }, t.duration);
-        tween.delay(t.delayDuration);
-        tween.easing(t.easingFunction);
+        }, duration);
+        tween.delay(delayDuration);
+        tween.easing(easingFunction);
         tween.onUpdate(function() {
             object[property] = value.value;
         });
-        tween.onComplete(defaultValue(t.onComplete, null));
+        tween.onComplete(defaultValue(options.onComplete, null));
         tween.start();
 
         return {
@@ -167,7 +167,7 @@ define([
      * @exception {DeveloperError} material is required.
      * @exception {DeveloperError} material must have an offset property.
      */
-    AnimationCollection.prototype.addOffsetIncrement = function(material, template) {
+    AnimationCollection.prototype.addOffsetIncrement = function(material, options) {
         if (typeof material === 'undefined') {
             throw new DeveloperError('material is required.');
         }
@@ -176,10 +176,10 @@ define([
             throw new DeveloperError('material must have an offset property.');
         }
 
-        var t = defaultValue(template, {});
-        t.duration = defaultValue(t.duration, 3000);
-        t.delayDuration = defaultValue(t.delayDuration, 0);
-        t.easingFunction = (typeof t.easingFunction === 'undefined') ? Tween.Easing.Linear.None : t.easingFunction;
+        options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+        var duration = defaultValue(options.duration, 3000);
+        var delayDuration = defaultValue(options.delayDuration, 0);
+        var easingFunction = defaultValue(options.easingFunction, Tween.Easing.Linear.None);
 
         var value = {
             offset : material.uniforms.offset
@@ -187,17 +187,17 @@ define([
         var tween = new Tween.Tween(value);
         tween.to({
             offset : material.uniforms.offset + 1.0
-        }, t.duration);
-        tween.delay(t.delayDuration);
-        tween.easing(t.easingFunction);
+        }, duration);
+        tween.delay(delayDuration);
+        tween.easing(easingFunction);
         tween.onUpdate(function() {
             material.uniforms.offset = value.offset;
         });
-        // t.onComplete is ignored.
+        // options.onComplete is ignored.
         tween.onComplete(function() {
             tween.to({
                 offset : material.uniforms.offset + 1.0
-            }, t.duration);
+            }, duration);
             tween.start();
         });
         tween.start();

--- a/Source/Scene/Billboard.js
+++ b/Source/Scene/Billboard.js
@@ -103,7 +103,10 @@ define([
     }
 
     Billboard.prototype.getPickId = function(context) {
-        this._pickId = (typeof this._pickId === 'undefined') ? context.createPickId(defaultValue(this._pickIdThis, this)) : this._pickId;
+        if (typeof this._pickId === 'undefined') {
+            this._pickId = context.createPickId(defaultValue(this._pickIdThis, this));
+        }
+
         return this._pickId;
     };
 

--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -246,14 +246,14 @@ define([
      * // Example 1:  Add a billboard, specifying all the default values.
      * var b = billboards.add({
      *   show : true,
-     *   position : new Cartesian3(0.0, 0.0, 0.0),
-     *   pixelOffset : new Cartesian2(0.0, 0.0),
-     *   eyeOffset : new Cartesian3(0.0, 0.0, 0.0),
+     *   position : Cartesian3.ZERO,
+     *   pixelOffset : Cartesian2.ZERO,
+     *   eyeOffset : Cartesian3.ZERO,
      *   horizontalOrigin : HorizontalOrigin.CENTER,
      *   verticalOrigin : VerticalOrigin.CENTER,
      *   scale : 1.0,
      *   imageIndex : 0,
-     *   color : new Color(1.0, 1.0, 1.0, 1.0)
+     *   color : Color.WHITE
      * });
      *
      * // Example 2:  Specify only the billboard's cartographic position.

--- a/Source/Scene/CameraController.js
+++ b/Source/Scene/CameraController.js
@@ -934,7 +934,7 @@ define([
         if (typeof extent === 'undefined') {
             throw new DeveloperError('extent is required.');
         }
-        ellipsoid = (typeof ellipsoid === 'undefined') ? Ellipsoid.WGS84 : ellipsoid;
+        ellipsoid = defaultValue(ellipsoid, Ellipsoid.WGS84);
 
         if (this._mode === SceneMode.SCENE3D) {
             viewExtent3D(this._camera, extent, ellipsoid);
@@ -947,7 +947,7 @@ define([
 
     var pickEllipsoid3DRay = new Ray();
     function pickEllipsoid3D(controller, windowPosition, ellipsoid, result) {
-        ellipsoid = (typeof ellipsoid === 'undefined') ? Ellipsoid.WGS84 : ellipsoid;
+        ellipsoid = defaultValue(ellipsoid, Ellipsoid.WGS84);
         var ray = controller.getPickRay(windowPosition, pickEllipsoid3DRay);
         var intersection = IntersectionTests.rayEllipsoid(ray, ellipsoid);
         if (!intersection) {
@@ -1010,7 +1010,7 @@ define([
             result = new Cartesian3();
         }
 
-        ellipsoid = (typeof ellipsoid === 'undefined') ? Ellipsoid.WGS84 : ellipsoid;
+        ellipsoid = defaultValue(ellipsoid, Ellipsoid.WGS84);
 
         if (this._mode === SceneMode.SCENE3D) {
             result = pickEllipsoid3D(this, windowPosition, ellipsoid, result);

--- a/Source/Scene/CameraFlightPath.js
+++ b/Source/Scene/CameraFlightPath.js
@@ -1,8 +1,9 @@
 /*global define*/
 define([
-        '../Core/defaultValue',
         '../Core/Cartesian3',
         '../Core/Cartographic',
+        '../Core/clone',
+        '../Core/defaultValue',
         '../Core/DeveloperError',
         '../Core/Ellipsoid',
         '../Core/HermiteSpline',
@@ -17,9 +18,10 @@ define([
         '../Scene/SceneMode',
         '../ThirdParty/Tween'
     ], function(
-        defaultValue,
         Cartesian3,
         Cartographic,
+        clone,
+        defaultValue,
         DeveloperError,
         Ellipsoid,
         HermiteSpline,
@@ -407,7 +409,7 @@ define([
      * @see CameraFlightPath#createAnimationCartographic
      */
     CameraFlightPath.createAnimation = function(frameState, description) {
-        description = defaultValue(description, {});
+        description = defaultValue(description, defaultValue.EMPTY_OBJECT);
         var destination = description.destination;
         var direction = description.direction;
         var up = description.up;
@@ -467,7 +469,7 @@ define([
      * @see CameraFlightPath#createAnimationCartographic
      */
     CameraFlightPath.createAnimationCartographic = function(frameState, description) {
-        description = defaultValue(description, {});
+        description = defaultValue(description, defaultValue.EMPTY_OBJECT);
         var destination = description.destination;
 
         if (typeof frameState === 'undefined') {
@@ -487,8 +489,9 @@ define([
             end = projection.project(destination);
         }
 
-        description.destination = end;
-        return this.createAnimation(frameState, description);
+        var createAnimationDescription = clone(description);
+        createAnimationDescription.destination = end;
+        return this.createAnimation(frameState, createAnimationDescription);
     };
 
     return CameraFlightPath;

--- a/Source/Scene/CustomSensorVolume.js
+++ b/Source/Scene/CustomSensorVolume.js
@@ -60,11 +60,11 @@ define([
      *
      * @see SensorVolumeCollection#addCustom
      */
-    var CustomSensorVolume = function(template) {
-        var t = defaultValue(template, {});
+    var CustomSensorVolume = function(options) {
+        options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         this._pickId = undefined;
-        this._pickIdThis = defaultValue(t._pickIdThis, this);
+        this._pickIdThis = defaultValue(options._pickIdThis, this);
 
         this._colorCommand = new DrawCommand();
         this._pickCommand = new DrawCommand();
@@ -78,7 +78,7 @@ define([
          *
          * @type Boolean
          */
-        this.show = (typeof t.show === 'undefined') ? true : t.show;
+        this.show = defaultValue(options.show, true);
 
         /**
          * When <code>true</code>, a polyline is shown where the sensor outline intersections the central body.  The default is <code>true</code>.
@@ -87,7 +87,7 @@ define([
          *
          * @see CustomSensorVolume#intersectionColor
          */
-        this.showIntersection = (typeof t.showIntersection === 'undefined') ? true : t.showIntersection;
+        this.showIntersection = defaultValue(options.showIntersection, true);
 
         /**
          * <p>
@@ -100,7 +100,7 @@ define([
          *
          * @type Boolean
          */
-        this.showThroughEllipsoid = (typeof t.showThroughEllipsoid === 'undefined') ? false : t.showThroughEllipsoid;
+        this.showThroughEllipsoid = defaultValue(options.showThroughEllipsoid, false);
 
         /**
          * The 4x4 transformation matrix that transforms this sensor from model to world coordinates.  In it's model
@@ -125,14 +125,14 @@ define([
          * var center = ellipsoid.cartographicToCartesian(Cartographic.fromDegrees(-75.59777, 40.03883));
          * sensor.modelMatrix = Transforms.eastNorthUpToFixedFrame(center);
          */
-        this.modelMatrix = (typeof t.modelMatrix === 'undefined' ) ? Matrix4.IDENTITY.clone() : t.modelMatrix;
+        this.modelMatrix = Matrix4.clone(defaultValue(options.modelMatrix, Matrix4.IDENTITY));
 
         /**
          * DOC_TBA
          *
          * @type BufferUsage
          */
-        this.bufferUsage = (typeof t.bufferUsage === 'undefined') ? BufferUsage.STATIC_DRAW : t.bufferUsage;
+        this.bufferUsage = defaultValue(options.bufferUsage, BufferUsage.STATIC_DRAW);
         this._bufferUsage = this.bufferUsage;
 
         /**
@@ -140,11 +140,11 @@ define([
          *
          * @type Number
          */
-        this.radius = (typeof t.radius === 'undefined') ? Number.POSITIVE_INFINITY : t.radius;
+        this.radius = defaultValue(options.radius, Number.POSITIVE_INFINITY);
 
         this._directions = undefined;
         this._directionsDirty = false;
-        this.setDirections(t.directions);
+        this.setDirections(options.directions);
 
         /**
          * The surface appearance of the sensor.  This can be one of several built-in {@link Material} objects or a custom material, scripted with
@@ -164,7 +164,7 @@ define([
          *
          * @see <a href='https://github.com/AnalyticalGraphicsInc/cesium/wiki/Fabric'>Fabric</a>
          */
-        this.material = (typeof t.material !== 'undefined') ? t.material : Material.fromType(undefined, Material.ColorType);
+        this.material = typeof options.material !== 'undefined' ? options.material : Material.fromType(undefined, Material.ColorType);
         this._material = undefined;
 
         /**
@@ -174,7 +174,7 @@ define([
          *
          * @see CustomSensorVolume#showIntersection
          */
-        this.intersectionColor = (typeof t.intersectionColor !== 'undefined') ? Color.clone(t.intersectionColor) : Color.clone(Color.WHITE);
+        this.intersectionColor = Color.clone(defaultValue(options.intersectionColor, Color.WHITE));
 
         var that = this;
         this._uniforms = {

--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -750,7 +750,7 @@ define([
         oneOverMercatorHeight : 0
     };
 
-    var float32ArrayScratch = typeof Float32Array === 'undefined' ? undefined : new Float32Array(1);
+    var float32ArrayScratch = typeof Float32Array !== 'undefined' ? new Float32Array(1) : undefined;
 
     function reprojectToGeographic(imageryLayer, context, texture, extent) {
         var reproject = context.cache.imageryLayer_reproject;

--- a/Source/Scene/Label.js
+++ b/Source/Scene/Label.js
@@ -21,8 +21,6 @@ define([
         VerticalOrigin) {
     "use strict";
 
-    var EMPTY_OBJECT = {};
-
     function rebindAllGlyphs(label) {
         if (!label._rebindAllGlyphs && !label._repositionAllGlyphs) {
             // only push label if it's not already been marked dirty
@@ -52,7 +50,7 @@ define([
      * @demo <a href="http://cesium.agi.com/Cesium/Apps/Sandcastle/index.html?src=Labels.html">Cesium Sandcastle Labels Demo</a>
      */
     var Label = function(description, labelCollection) {
-        description = defaultValue(description, EMPTY_OBJECT);
+        description = defaultValue(description, defaultValue.EMPTY_OBJECT);
 
         this._text = defaultValue(description.text, '');
         this._show = defaultValue(description.show, true);

--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -480,15 +480,15 @@ define([
     };
 
     function initializeMaterial(description, result) {
-        description = defaultValue(description, {});
+        description = defaultValue(description, defaultValue.EMPTY_OBJECT);
         result._context = description.context;
         result._strict = defaultValue(description.strict, false);
         result._count = defaultValue(description.count, 0);
-        result._template = defaultValue(description.fabric, {});
-        result._template.uniforms = defaultValue(result._template.uniforms, {});
-        result._template.materials = defaultValue(result._template.materials, {});
+        result._template = clone(defaultValue(description.fabric, defaultValue.EMPTY_OBJECT));
+        result._template.uniforms = clone(defaultValue(result._template.uniforms, defaultValue.EMPTY_OBJECT));
+        result._template.materials = clone(defaultValue(result._template.materials, defaultValue.EMPTY_OBJECT));
 
-        result.type = (typeof result._template.type !== 'undefined') ? result._template.type : createGuid();
+        result.type = typeof result._template.type !== 'undefined' ? result._template.type : createGuid();
 
         result.shaderSource = '';
         result.materials = {};
@@ -498,7 +498,7 @@ define([
         // If the cache contains this material type, build the material template off of the stored template.
         var cachedTemplate = Material._materialCache.getMaterial(result.type);
         if (typeof cachedTemplate !== 'undefined') {
-            var template = clone(cachedTemplate);
+            var template = clone(cachedTemplate, true);
             result._template = combine([result._template, template]);
         }
 

--- a/Source/Scene/PerformanceDisplay.js
+++ b/Source/Scene/PerformanceDisplay.js
@@ -1,17 +1,26 @@
 /*global define*/
 define([
-        '../Core/destroyObject',
         '../Core/BoundingRectangle',
+        '../Core/Color',
+        '../Core/defaultValue',
+        '../Core/destroyObject',
         '../Renderer/PixelFormat',
         './Material',
         './ViewportQuad'
     ], function(
-        destroyObject,
         BoundingRectangle,
+        Color,
+        defaultValue,
+        destroyObject,
         PixelFormat,
         Material,
         ViewportQuad) {
     "use strict";
+
+    var defaultFpsColor = Color.fromCssColorString('#e52');
+    var defaultFrameTimeColor = Color.fromCssColorString('#de3');
+    var defaultBackgroundColor = Color.fromCssColorString('rgba(0, 0, 30, 0.9)');
+    var defaultRectangle = new BoundingRectangle(0, 0, 80, 40);
 
     /**
      * Draws a display in the top left corner of the scene displaying FPS (frames per second),
@@ -30,15 +39,13 @@ define([
      * scene.getPrimitives().add(new PerformanceDisplay());
      */
     var PerformanceDisplay = function(description) {
-        if (typeof description === 'undefined') {
-            description = {};
-        }
+        description = defaultValue(description, defaultValue.EMPTY_OBJECT);
 
-        this._fpsColor = typeof description.fpsColor !== 'undefined' ? description.fpsColor.toCssColorString() : '#e52';
-        this._frameTimeColor = typeof description.frameTimeColor !== 'undefined' ? description.frameTimeColor.toCssColorString() : '#de3';
-        this._backgroundColor = typeof description.backgroundColor !== 'undefined' ? description.backgroundColor.toCssColorString() : 'rgba(0, 0, 30, 0.9)';
-        this._font = typeof description.font !== 'undefined' ? description.font : 'bold 10px Helvetica,Arial,sans-serif';
-        this._rectangle = typeof description.rectangle !== 'undefined' ? description.rectangle : new BoundingRectangle(0, 0, 80, 40);
+        this._fpsColor = defaultValue(description.fpsColor, defaultFpsColor).toCssColorString();
+        this._frameTimeColor = defaultValue(description.frameTimeColor, defaultFrameTimeColor).toCssColorString();
+        this._backgroundColor = defaultValue(description.backgroundColor, defaultBackgroundColor).toCssColorString();
+        this._font = defaultValue(description.font, 'bold 10px Helvetica,Arial,sans-serif');
+        this._rectangle = defaultValue(description.rectangle, defaultRectangle);
 
         this._canvas = document.createElement('canvas');
         this._canvas.width = this._rectangle.width;

--- a/Source/Scene/Polyline.js
+++ b/Source/Scene/Polyline.js
@@ -283,7 +283,9 @@ define([
     };
 
     Polyline.prototype.getPickId = function(context) {
-        this._pickId = (typeof this._pickId === 'undefined') ? (context.createPickId(defaultValue(this._pickIdThis, this))) : this._pickId;
+        if (typeof this._pickId === 'undefined') {
+            this._pickId = context.createPickId(defaultValue(this._pickIdThis, this));
+        }
         return this._pickId;
     };
 

--- a/Source/Scene/RectangularPyramidSensorVolume.js
+++ b/Source/Scene/RectangularPyramidSensorVolume.js
@@ -1,19 +1,21 @@
 /*global define*/
 define([
-        '../Core/defaultValue',
-        '../Core/DeveloperError',
+        '../Core/clone',
         '../Core/Color',
+        '../Core/defaultValue',
         '../Core/destroyObject',
+        '../Core/DeveloperError',
         '../Core/Math',
         '../Core/Matrix4',
         '../Renderer/BufferUsage',
         './Material',
         './CustomSensorVolume'
     ], function(
-        defaultValue,
-        DeveloperError,
+        clone,
         Color,
+        defaultValue,
         destroyObject,
+        DeveloperError,
         CesiumMath,
         Matrix4,
         BufferUsage,
@@ -29,15 +31,15 @@ define([
      *
      * @see SensorVolumeCollection#addRectangularPyramid
      */
-    var RectangularPyramidSensorVolume = function(template) {
-        var t = defaultValue(template, {});
+    var RectangularPyramidSensorVolume = function(options) {
+        options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         /**
          * <code>true</code> if this sensor will be shown; otherwise, <code>false</code>
          *
          * @type Boolean
          */
-        this.show = (typeof t.show === 'undefined') ? true : t.show;
+        this.show = defaultValue(options.show, true);
 
         /**
          * When <code>true</code>, a polyline is shown where the sensor outline intersections the central body.  The default is <code>true</code>.
@@ -46,7 +48,7 @@ define([
          *
          * @see RectangularPyramidSensorVolume#intersectionColor
          */
-        this.showIntersection = (typeof t.showIntersection === 'undefined') ? true : t.showIntersection;
+        this.showIntersection = defaultValue(options.showIntersection, true);
 
         /**
          * <p>
@@ -59,7 +61,7 @@ define([
          *
          * @type Boolean
          */
-        this.showThroughEllipsoid = (typeof t.showThroughEllipsoid === 'undefined') ? false : t.showThroughEllipsoid;
+        this.showThroughEllipsoid = defaultValue(options.showThroughEllipsoid, false);
 
         /**
          * The 4x4 transformation matrix that transforms this sensor from model to world coordinates.  In it's model
@@ -83,21 +85,21 @@ define([
          * var center = ellipsoid.cartographicToCartesian(Cartographic.fromDegrees(-75.59777, 40.03883));
          * sensor.modelMatrix = Transforms.eastNorthUpToFixedFrame(center);
          */
-        this.modelMatrix = (typeof t.modelMatrix === 'undefined') ? Matrix4.IDENTITY.clone() : t.modelMatrix;
+        this.modelMatrix = Matrix4.clone(defaultValue(options.modelMatrix, Matrix4.IDENTITY));
 
         /**
          * DOC_TBA
          *
          * @type BufferUsage
          */
-        this.bufferUsage = (typeof t.bufferUsage === 'undefined')? BufferUsage.STATIC_DRAW : t.bufferUsage;
+        this.bufferUsage = defaultValue(options.bufferUsage, BufferUsage.STATIC_DRAW);
 
         /**
          * DOC_TBA
          *
          * @type Number
          */
-        this.radius = (typeof t.radius === 'undefined') ? Number.POSITIVE_INFINITY : t.radius;
+        this.radius = defaultValue(options.radius, Number.POSITIVE_INFINITY);
 
         /**
          * DOC_TBA
@@ -106,7 +108,7 @@ define([
          *
          * @see RectangularPyramidSensorVolume#yHalfAngle
          */
-        this.xHalfAngle = (typeof t.xHalfAngle === 'undefined') ? CesiumMath.PI_OVER_TWO : t.xHalfAngle;
+        this.xHalfAngle = defaultValue(options.xHalfAngle, CesiumMath.PI_OVER_TWO);
         this._xHalfAngle = undefined;
 
         /**
@@ -116,7 +118,7 @@ define([
          *
          * @see RectangularPyramidSensorVolume#xHalfAngle
          */
-        this.yHalfAngle = (typeof t.yHalfAngle === 'undefined') ? CesiumMath.PI_OVER_TWO : t.yHalfAngle;
+        this.yHalfAngle = defaultValue(options.yHalfAngle, CesiumMath.PI_OVER_TWO);
         this._yHalfAngle = undefined;
 
         /**
@@ -137,7 +139,7 @@ define([
          *
          * @see <a href='https://github.com/AnalyticalGraphicsInc/cesium/wiki/Fabric'>Fabric</a>
          */
-        this.material = (typeof t.material !== 'undefined') ? t.material : Material.fromType(undefined, Material.ColorType);
+        this.material = typeof options.material !== 'undefined' ? options.material : Material.fromType(undefined, Material.ColorType);
 
         /**
          * The color of the polyline where the sensor outline intersects the central body.  The default is {@link Color.WHITE}.
@@ -146,10 +148,11 @@ define([
          *
          * @see RectangularPyramidSensorVolume#showIntersection
          */
-        this.intersectionColor = (typeof t.intersectionColor !== 'undefined') ? Color.clone(t.intersectionColor) : Color.clone(Color.WHITE);
+        this.intersectionColor = Color.clone(defaultValue(options.intersectionColor, Color.WHITE));
 
-        t._pickIdThis = defaultValue(t._pickIdThis, this);
-        this._customSensor = new CustomSensorVolume(t);
+        var customSensorOptions = clone(options);
+        customSensorOptions._pickIdThis = defaultValue(options._pickIdThis, this);
+        this._customSensor = new CustomSensorVolume(customSensorOptions);
     };
 
     /**

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -404,8 +404,8 @@ define([
         var frustum = camera.frustum.clone();
         var context = scene._context;
         var us = context.getUniformState();
-        var skyBoxCommand = (typeof scene.skyBox !== 'undefined') ? scene.skyBox.update(context, scene._frameState) : undefined;
-        var skyAtmosphereCommand = (typeof scene.skyAtmosphere !== 'undefined') ? scene.skyAtmosphere.update(context, scene._frameState) : undefined;
+        var skyBoxCommand = typeof scene.skyBox !== 'undefined' ? scene.skyBox.update(context, scene._frameState) : undefined;
+        var skyAtmosphereCommand = typeof scene.skyAtmosphere !== 'undefined' ? scene.skyAtmosphere.update(context, scene._frameState) : undefined;
 
         var clear = scene._clearColorCommand;
         Color.clone(defaultValue(scene.backgroundColor, Color.BLACK), clear.clearState.color);

--- a/Source/Scene/SceneTransitioner.js
+++ b/Source/Scene/SceneTransitioner.js
@@ -83,7 +83,7 @@ define([
         this.onTransitionComplete = new Event();
 
         this._scene = scene;
-        this._ellipsoid = (typeof ellipsoid === 'undefined') ? Ellipsoid.WGS84 : ellipsoid;
+        this._ellipsoid = defaultValue(ellipsoid, Ellipsoid.WGS84);
         var canvas = scene.getCanvas();
 
         // Position camera and size frustum so the entire 2D map is visible

--- a/Source/Scene/SensorVolumeCollection.js
+++ b/Source/Scene/SensorVolumeCollection.js
@@ -45,8 +45,8 @@ define([
      * @see SensorVolumeCollection#addCustom
      * @see SensorVolumeCollection#addComplexConic
      */
-    SensorVolumeCollection.prototype.addRectangularPyramid = function(template) {
-        var sensor = new RectangularPyramidSensorVolume(template);
+    SensorVolumeCollection.prototype.addRectangularPyramid = function(options) {
+        var sensor = new RectangularPyramidSensorVolume(options);
         this._sensors.push(sensor);
         return sensor;
     };
@@ -59,8 +59,8 @@ define([
      * @see SensorVolumeCollection#addRectangularPyramid
      * @see SensorVolumeCollection#addComplexConic
      */
-    SensorVolumeCollection.prototype.addCustom = function(template) {
-        var sensor = new CustomSensorVolume(template);
+    SensorVolumeCollection.prototype.addCustom = function(options) {
+        var sensor = new CustomSensorVolume(options);
         this._sensors.push(sensor);
         return sensor;
     };

--- a/Source/Scene/VRTheWorldTerrainProvider.js
+++ b/Source/Scene/VRTheWorldTerrainProvider.js
@@ -64,7 +64,8 @@ define([
      * centralBody.terrainProvider = terrainProvider;
      */
     var VRTheWorldTerrainProvider = function VRTheWorldTerrainProvider(description) {
-        if (typeof description === 'undefined' || typeof description.url === 'undefined') {
+        description = defaultValue(description, defaultValue.EMPTY_OBJECT);
+        if (typeof description.url === 'undefined') {
             throw new DeveloperError('description.url is required.');
         }
 
@@ -133,7 +134,7 @@ define([
         }
 
         function metadataFailure(e) {
-            var message = typeof e === 'undefined' ? 'An error occurred while accessing ' + that._url + '.' : e;
+            var message = defaultValue(e, 'An error occurred while accessing ' + that._url + '.');
             metadataError = TileProviderError.handleError(metadataError, that, that._errorEvent, message, undefined, undefined, undefined, requestMetadata);
         }
 

--- a/Specs/Core/cloneSpec.js
+++ b/Specs/Core/cloneSpec.js
@@ -1,0 +1,47 @@
+/*global defineSuite*/
+defineSuite(['Core/clone'], function(clone) {
+    "use strict";
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
+
+    it('can make shallow clones', function() {
+        var obj = {
+            a : 1,
+            b : 's',
+            c : {
+                d : 0
+            }
+        };
+
+        var clonedObj = clone(obj);
+        expect(clonedObj).not.toBe(obj);
+        expect(clonedObj.a).toEqual(obj.a);
+        expect(clonedObj.b).toEqual(obj.b);
+        expect(clonedObj.c).toBe(obj.c);
+        expect(clonedObj.c.d).toEqual(obj.c.d);
+    });
+
+    it('can make deep clones', function() {
+        var obj = {
+            a : 1,
+            b : 's',
+            c : {
+                d : 0,
+                e : {
+                    f : {
+                        g : 1
+                    }
+                }
+            }
+        };
+
+        var clonedObj = clone(obj, true);
+        expect(clonedObj).not.toBe(obj);
+        expect(clonedObj.a).toEqual(obj.a);
+        expect(clonedObj.b).toEqual(obj.b);
+        expect(clonedObj.c).not.toBe(obj.c);
+        expect(clonedObj.c.d).toEqual(obj.c.d);
+        expect(clonedObj.c.e).not.toBe(obj.c.e);
+        expect(clonedObj.c.e.f).not.toBe(obj.c.e.f);
+        expect(clonedObj.c.e.f.g).toEqual(obj.c.e.f.g);
+    });
+});

--- a/Specs/Scene/CompositePrimitiveSpec.js
+++ b/Specs/Scene/CompositePrimitiveSpec.js
@@ -11,6 +11,7 @@ defineSuite([
          'Specs/render',
          'Core/Cartesian3',
          'Core/Cartographic',
+         'Core/defaultValue',
          'Core/Ellipsoid',
          'Core/Math',
          'Scene/Camera',
@@ -31,6 +32,7 @@ defineSuite([
          render,
          Cartesian3,
          Cartographic,
+         defaultValue,
          Ellipsoid,
          CesiumMath,
          Camera,
@@ -73,7 +75,11 @@ defineSuite([
     });
 
     function createLabels(position) {
-        position = position || { x : -1.0, y : 0.0, z : 0.0 };
+        position = defaultValue(position, {
+            x : -1.0,
+            y : 0.0,
+            z : 0.0
+        });
         var labels = new LabelCollection();
         labels.add({
             position : position,
@@ -85,8 +91,8 @@ defineSuite([
     }
 
     function createPolygon(degree, ellipsoid) {
-        degree = (typeof degree !== 'undefined') ? degree : 50.0;
-        ellipsoid = ellipsoid || Ellipsoid.UNIT_SPHERE;
+        degree = defaultValue(degree, 50.0);
+        ellipsoid = defaultValue(ellipsoid, Ellipsoid.UNIT_SPHERE);
         var polygon = new Polygon();
         polygon.ellipsoid = ellipsoid;
         polygon.granularity = CesiumMath.toRadians(20.0);

--- a/Specs/Scene/MaterialSpec.js
+++ b/Specs/Scene/MaterialSpec.js
@@ -357,7 +357,7 @@ defineSuite([
         expect(pixel).not.toEqual([0, 0, 0, 0]);
     });
 
-    it('creates a material with a cube map uniform' , function () {
+    it('creates a material with a cube map uniform', function() {
         var material = new Material({
             context : context,
             strict : true,

--- a/Specs/Scene/MultifrustumSpec.js
+++ b/Specs/Scene/MultifrustumSpec.js
@@ -8,6 +8,7 @@ defineSuite([
          'Core/Cartesian2',
          'Core/Cartesian3',
          'Core/Color',
+         'Core/defaultValue',
          'Core/Math',
          'Core/Matrix4',
          'Core/MeshFilters',
@@ -29,6 +30,7 @@ defineSuite([
          Cartesian2,
          Cartesian3,
          Color,
+         defaultValue,
          CesiumMath,
          Matrix4,
          MeshFilters,
@@ -169,8 +171,8 @@ defineSuite([
     });
 
     function createPrimitive(bounded, closestFrustum) {
-        bounded = (typeof bounded === 'undefined') ? true : bounded;
-        closestFrustum = (typeof closestFrustum === 'undefined') ? false : closestFrustum;
+        bounded = defaultValue(bounded, true);
+        closestFrustum = defaultValue(closestFrustum, false);
 
         var Primitive = function() {
             this._va = undefined;

--- a/Specs/Scene/PrimitiveCullingSpec.js
+++ b/Specs/Scene/PrimitiveCullingSpec.js
@@ -10,6 +10,7 @@ defineSuite([
          'Core/Cartesian2',
          'Core/Cartesian3',
          'Core/Cartographic',
+         'Core/defaultValue',
          'Core/Ellipsoid',
          'Core/Math',
          'Core/Occluder',
@@ -35,6 +36,7 @@ defineSuite([
          Cartesian2,
          Cartesian3,
          Cartographic,
+         defaultValue,
          Ellipsoid,
          CesiumMath,
          Occluder,
@@ -291,8 +293,8 @@ defineSuite([
     }
 
     function createPolygon(degree, ellipsoid) {
-        degree = (typeof degree !== 'undefined') ? degree : 50.0;
-        ellipsoid = ellipsoid || Ellipsoid.UNIT_SPHERE;
+        degree = defaultValue(degree, 50.0);
+        ellipsoid = defaultValue(ellipsoid, Ellipsoid.UNIT_SPHERE);
         var polygon = new Polygon();
         polygon.ellipsoid = ellipsoid;
         polygon.granularity = CesiumMath.toRadians(20.0);
@@ -326,7 +328,11 @@ defineSuite([
     });
 
     function createLabels(position) {
-        position = position || { x : -1.0, y : 0.0, z : 0.0 };
+        position = defaultValue(position, {
+            x : -1.0,
+            y : 0.0,
+            z : 0.0
+        });
         var labels = new LabelCollection();
         labels.add({
             position : position,

--- a/Specs/createCanvas.js
+++ b/Specs/createCanvas.js
@@ -1,10 +1,13 @@
 /*global define*/
-define(function() {
+define([
+        'Core/defaultValue'
+    ], function(
+        defaultValue) {
     "use strict";
 
     function createCanvas(width, height) {
-        width = (typeof width === 'undefined') ? 1 : width;
-        height = (typeof height === 'undefined') ? 1 : height;
+        width = defaultValue(width, 1);
+        height = defaultValue(height, 1);
 
         var canvas = document.createElement('canvas');
         canvas.id = 'glCanvas';

--- a/Specs/createContext.js
+++ b/Specs/createContext.js
@@ -1,15 +1,20 @@
 /*global define*/
 define([
+        'Core/clone',
+        'Core/defaultValue',
         'Renderer/Context',
         'Specs/createCanvas'
     ], function(
+        clone,
+        defaultValue,
         Context,
         createCanvas) {
     "use strict";
 
     function createContext(options) {
-        options = (typeof options !== 'undefined') ? options : {};
-        options.alpha = (typeof options.alpha !== 'undefined') ? options.alpha : true;
+        // clone options so we can change properties
+        options = clone(defaultValue(options, {}));
+        options.alpha = defaultValue(options.alpha, true);
 
         var canvas = createCanvas();
         var context = new Context(canvas, options);

--- a/Specs/pick.js
+++ b/Specs/pick.js
@@ -1,10 +1,8 @@
 /*global define*/
 define([
-        'Core/defaultValue',
         'Core/BoundingRectangle',
         'Scene/FrameState'
     ], function(
-        defaultValue,
         BoundingRectangle,
         FrameState) {
     "use strict";


### PR DESCRIPTION
- Add a reusable defaultValue.EMPTY_OBJECT instance for convenience without allocations.
- Prefer `typeof a !== 'undefined' ? a : b` when not using defaultValue, to have a consistent order of values.
- Make `clone` not deep copy by default.  Use `clone` to avoid modifying passed-in option hashes.  Add tests.
