### PR TITLE
Fix nested suite filtering.

### DIFF
--- a/ThirdParty/jasmine-1.3.1/jasmine-html.js
+++ b/ThirdParty/jasmine-1.3.1/jasmine-html.js
@@ -320,7 +320,19 @@ jasmine.HtmlReporter = function(_doc) {
       return matchedCategory;
     }
 
-    return (spec.getFullName() === focusedSpecName) || (spec.suite.getFullName() === focusedSpecName);
+    if (spec.getFullName() === focusedSpecName) {
+        return true;
+    }
+
+    var suite = spec.suite;
+    while (suite) {
+        if (suite.getFullName() === focusedSpecName) {
+            return true;
+        }
+        suite = suite.parentSuite;
+    }
+
+    return false;
   };
 
   return self;


### PR DESCRIPTION
A spec should be run if:
- The spec is focused.
- The spec's suite is focused.
- Any of the spec's suite's parentSuites are focused.
