### PR TITLE
Removed positionMC from czm_materialInput.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@ Beta Releases
    * Replaced `computeSunPosition` with `Simon1994PlanetaryPosition`, which has functions to calculate the position of the sun and the moon more accurately.
    * Removed `Context.createClearState`.  These properties are now part of `ClearCommand`.
    * `RenderState` objects returned from `Context.createRenderState` are now immutable.
+   * Removed `positionMC` from `czm_materialInput`.  It is no longer used by any materials.
 * Added wide polylines that work with and without ANGLE.
 * Polylines now use materials to describe their surface appearance. See the [Fabric](https://github.com/AnalyticalGraphicsInc/cesium/wiki/Fabric) wiki page for more details on how to create materials.
 * Added new `PolylineOutline`, `PolylineArrow`, and `Fade` materials.

--- a/Source/Shaders/BuiltinFunctions.glsl
+++ b/Source/Shaders/BuiltinFunctions.glsl
@@ -362,7 +362,6 @@ mat3 czm_eastNorthUpToEyeCoordinates(vec3 positionMC, vec3 normalEC)
  * @property {vec3} normalEC Unperturbed surface normal in eye coordinates.
  * @property {mat3} tangentToEyeMatrix Matrix for converting a tangent space normal to eye space.
  * @property {vec3} positionToEyeEC Vector from the fragment to the eye in eye coordinates.  The magnitude is the distance in meters from the fragment to the eye.
- * @property {vec3} positionMC Position in model coordinates.
  */
 struct czm_materialInput
 {
@@ -372,7 +371,6 @@ struct czm_materialInput
     vec3 normalEC;
     mat3 tangentToEyeMatrix;
     vec3 positionToEyeEC;
-    vec3 positionMC;
 };
 
 /**

--- a/Source/Shaders/CustomSensorVolumeFS.glsl
+++ b/Source/Shaders/CustomSensorVolumeFS.glsl
@@ -18,7 +18,6 @@ vec4 getColor(float sensorRadius, vec3 pointEC)
     vec3 pointMC = (czm_inverseModelView * vec4(pointEC, 1.0)).xyz;                                
     materialInput.st = sensor2dTextureCoordinates(sensorRadius, pointMC);   
     materialInput.str = pointMC / sensorRadius;
-    materialInput.positionMC = pointMC;               
     
     vec3 positionToEyeEC = -v_positionEC;
     materialInput.positionToEyeEC = positionToEyeEC;

--- a/Source/Shaders/EllipsoidFS.glsl
+++ b/Source/Shaders/EllipsoidFS.glsl
@@ -22,7 +22,6 @@ vec4 computeEllipsoidColor(czm_ray ray, float intersection, float side)
     materialInput.normalEC = normalEC;
     materialInput.tangentToEyeMatrix = czm_eastNorthUpToEyeCoordinates(positionMC, normalEC);
     materialInput.positionToEyeEC = positionToEyeEC;
-    materialInput.positionMC = positionMC;
     czm_material material = czm_getMaterial(materialInput);
 
     return czm_phong(normalize(positionToEyeEC), material);

--- a/Source/Shaders/PolygonFS.glsl
+++ b/Source/Shaders/PolygonFS.glsl
@@ -11,7 +11,6 @@ void main()
     // TODO: Real 1D distance, and better 3D coordinate
     materialInput.st = v_textureCoordinates;
     materialInput.str = vec3(v_textureCoordinates, 0.0);
-    materialInput.positionMC = v_positionMC;
     
     //Convert tangent space material normal to eye space
     materialInput.normalEC = normalize(czm_normal3D * czm_geodeticSurfaceNormal(v_positionMC, vec3(0.0), vec3(1.0)));


### PR DESCRIPTION
It is no longer used by any materials and is not potentially useful enough to material authors to keep it.

Surface shaders will, of course, allow for custom material inputs, and may happen sooner than I thought now that I am looking more carefully at batching.

Also updated the [Fabric wiki](https://github.com/AnalyticalGraphicsInc/cesium/wiki/Fabric).
