### PR TITLE
Fix isCrossOriginUrl in IE for real

### DIFF
--- a/Source/Core/isCrossOriginUrl.js
+++ b/Source/Core/isCrossOriginUrl.js
@@ -14,12 +14,18 @@ define(function() {
             a = document.createElement('a');
         }
 
-        var location = window.location;
+        // copy window location into the anchor to get consistent results
+        // when the port is default for the protocol (e.g. 80 for HTTP)
+        a.href = window.location.href;
+
+        // host includes both hostname and port if the port is not standard
+        var host = a.host;
+        var protocol = a.protocol;
+
         a.href = url;
         a.href = a.href; // IE only absolutizes href on get, not set
 
-        // host includes both hostname and port if the port is not standard
-        return a.protocol !== location.protocol || a.host !== location.host;
+        return protocol !== a.protocol || host !== a.host;
     };
 
     return isCrossOriginUrl;


### PR DESCRIPTION
The tests I meticulously added failed in IE8 if you ran the tests on port 80 instead of 8080.

Put both the window URL and the test URL through an anchor.  Fixes an inconsistency in IE between a.href and window.location about whether default ports are included or not.
