### PR TITLE
Improvements to CentralBody fragment shader.

### DIFF
--- a/Source/Scene/CentralBodySurface.js
+++ b/Source/Scene/CentralBodySurface.js
@@ -977,6 +977,7 @@ define([
                     var applyHue = false;
                     var applySaturation = false;
                     var applyGamma = false;
+                    var applyAlpha = false;
 
                     while (numberOfDayTextures < maxTextures && imageryIndex < imageryLen) {
                         var tileImagery = tileImageryCollection[imageryIndex];
@@ -1001,6 +1002,7 @@ define([
                         } else {
                             uniformMap.dayTextureAlpha[numberOfDayTextures] = imageryLayer.alpha;
                         }
+                        applyAlpha = applyAlpha || uniformMap.dayTextureAlpha[numberOfDayTextures] !== 1.0;
 
                         if (typeof imageryLayer.brightness === 'function') {
                             uniformMap.dayTextureBrightness[numberOfDayTextures] = imageryLayer.brightness(frameState, imageryLayer, imagery.x, imagery.y, imagery.level);
@@ -1048,7 +1050,7 @@ define([
 
                     colorCommandList.push(command);
 
-                    command.shaderProgram = shaderSet.getShaderProgram(context, tileSetIndex, applyBrightness, applyContrast, applyHue, applySaturation, applyGamma);
+                    command.shaderProgram = shaderSet.getShaderProgram(context, tileSetIndex, applyBrightness, applyContrast, applyHue, applySaturation, applyGamma, applyAlpha);
                     command.renderState = renderState;
                     command.primitiveType = TerrainProvider.wireframe ? PrimitiveType.LINES : PrimitiveType.TRIANGLES;
                     command.vertexArray = tile.vertexArray;

--- a/Source/Scene/CentralBodySurfaceShaderSet.js
+++ b/Source/Scene/CentralBodySurfaceShaderSet.js
@@ -31,7 +31,7 @@ define([
         this._shaders = {};
     };
 
-    function getShaderKey(textureCount, applyBrightness, applyContrast, applyHue, applySaturation, applyGamma) {
+    function getShaderKey(textureCount, applyBrightness, applyContrast, applyHue, applySaturation, applyGamma, applyAlpha) {
         var key = '';
         key += textureCount;
         key += applyBrightness ? '_brightness' : '';
@@ -39,18 +39,13 @@ define([
         key += applyHue ? '_hue' : '';
         key += applySaturation ? '_saturation' : '';
         key += applyGamma ? '_gamma' : '';
+        key += applyAlpha ? '_alpha' : '';
 
         return key;
     }
 
-    CentralBodySurfaceShaderSet.prototype.getShaderProgram = function(context, textureCount, applyBrightness, applyContrast, applyHue, applySaturation, applyGamma) {
-        applyBrightness = defaultValue(applyBrightness, false);
-        applyContrast = defaultValue(applyContrast, false);
-        applyHue = defaultValue(applyHue, false);
-        applySaturation = defaultValue(applySaturation, false);
-        applyGamma = defaultValue(applyGamma, false);
-
-        var key = getShaderKey(textureCount, applyBrightness, applyContrast, applyHue, applySaturation, applyGamma);
+    CentralBodySurfaceShaderSet.prototype.getShaderProgram = function(context, textureCount, applyBrightness, applyContrast, applyHue, applySaturation, applyGamma, applyAlpha) {
+        var key = getShaderKey(textureCount, applyBrightness, applyContrast, applyHue, applySaturation, applyGamma, applyAlpha);
         var shader = this._shaders[key];
         if (typeof shader === 'undefined') {
             var vs = this.baseVertexShaderString;
@@ -60,6 +55,7 @@ define([
                 (applyHue ? '#define APPLY_HUE\n' : '') +
                 (applySaturation ? '#define APPLY_SATURATION\n' : '') +
                 (applyGamma ? '#define APPLY_GAMMA\n' : '') +
+                (applyAlpha ? '#define APPLY_ALPHA\n' : '') +
                 '#define TEXTURE_UNITS ' + textureCount + '\n' +
                 this.baseFragmentShaderString + '\n' +
                 'vec3 computeDayColor(vec3 initialColor, vec2 textureCoordinates)\n' +


### PR DESCRIPTION
Use an if statement instead of the crazy two-step-alpha-zeroing for
excluding a texture outside its extent of applicability.  Avoiding ifs is
sometimes good, but here it just overcomplicates the shader.  In theory,
with dynamic branching, the if could be faster, too.  I wasn't able to
measure any performance difference one way or the other from this change.

Treat alpha like the other properties (hue, gamma, etc.).  Only apply it
if it is not 1.0.

Remove debugging feature of showing texture boundaries.
`TileCoordinatesImageryProvider` does a better job of that anyway.
