### PR TITLE
Terrain performance improvement

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,13 @@ Change Log
 
 Beta Releases
 -------------
+
+### b17 - 2013-06-03
+
+* Breaking changes:
+   *
+* Added `DrawCommand.cull` to avoid redundant visibility checks.
+
 ### b16 - 2013-05-01
 * Breaking changes:
    * Removed the color, outline color, and outline width properties of polylines. Instead, use materials for polyline color and outline properties. Code that looked like:

--- a/Source/Renderer/DrawCommand.js
+++ b/Source/Renderer/DrawCommand.js
@@ -19,6 +19,15 @@ define(['../Core/DeveloperError'], function(DeveloperError) {
         this.boundingVolume = undefined;
 
         /**
+         * When <code>true</code>, the renderer frustum and horizon culls the command based on its {@link DrawCommand#boundingVolume}.
+         * If the command was already culled, set this to <code>false</code> for a performance improvement.
+         *
+         * @type Boolean
+         * @default true
+         */
+        this.cull = true;
+
+        /**
          * The transformation from the geometry in model space to world space.
          * @type Matrix4
          */

--- a/Source/Scene/CentralBodySurface.js
+++ b/Source/Scene/CentralBodySurface.js
@@ -955,6 +955,7 @@ define([
                     var command = tileCommands[tileCommandIndex];
                     if (typeof command === 'undefined') {
                         command = new DrawCommand();
+                        command.cull = false;
                         tileCommands[tileCommandIndex] = command;
                         tileCommandUniformMaps[tileCommandIndex] = createTileUniformMap();
                     }

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -355,8 +355,9 @@ define([
                 if (typeof boundingVolume !== 'undefined') {
                     var modelMatrix = defaultValue(command.modelMatrix, Matrix4.IDENTITY);
                     var transformedBV = boundingVolume.transform(modelMatrix);               //TODO: Remove this allocation.
-                    if (cullingVolume.getVisibility(transformedBV) === Intersect.OUTSIDE ||
-                            (typeof occluder !== 'undefined' && !occluder.isBoundingSphereVisible(transformedBV))) {
+                    if (command.cull &&
+                            ((cullingVolume.getVisibility(transformedBV) === Intersect.OUTSIDE) ||
+                             (typeof occluder !== 'undefined' && !occluder.isBoundingSphereVisible(transformedBV)))) {
                         continue;
                     }
 

--- a/Specs/Renderer/DrawCommandSpec.js
+++ b/Specs/Renderer/DrawCommandSpec.js
@@ -9,6 +9,7 @@ defineSuite([
     it('constructs', function() {
         var c = new DrawCommand();
         expect(c.boundingVolume).toBeUndefined();
+        expect(c.cull).toEqual(true);
         expect(c.modelMatrix).toBeUndefined();
         expect(c.offset).toBeUndefined();
         expect(c.count).toBeUndefined();


### PR DESCRIPTION
Don't get too excited.  This is small.

For the Everest [terrain example](http://localhost:8080/Apps/Sandcastle/index.html?src=Terrain.html), this brings `createPotentiallyVisibleSet()` from 1.04% to 0.42% by avoiding redundant frustum and horizon culling.

Later, hierarchical commands may help even more, but I don't have them thought through yet.  Oh, and I'll think about making `DrawCommand` more cache-friendly.
