### PR TITLE
Make sure root tiles are always marked rendered so they're not unloaded.

### DIFF
--- a/Source/Scene/CentralBodySurface.js
+++ b/Source/Scene/CentralBodySurface.js
@@ -387,6 +387,7 @@ define([
         var levelZeroTiles = surface._levelZeroTiles;
         for (i = 0, len = levelZeroTiles.length; i < len; ++i) {
             tile = levelZeroTiles[i];
+            surface._tileReplacementQueue.markTileRendered(tile);
             if (tile.state !== TileState.READY) {
                 queueTileLoad(surface, tile);
             }


### PR DESCRIPTION
This fixes the problem reported here:
https://groups.google.com/d/msg/cesium-dev/AfpgxJgpEiY/QRy9asxCKXcJ

The problem is that root tiles are always loaded if not present, but they weren't being locked in the cache.  So if they weren't rendered they could be unloaded.  And then next frame they would be loaded.  And so on.

We probably just started seeing the problem due to improvements in the horizon culling.  Previously, both root tiles were being rendered even though one of them wasn't really needed.

It was easy to reproduce in Peter's app, but hard otherwise because it's very sensitive to view parameters.  He confirmed that it fixes the problem in his app, however.
