### PR TITLE
Fixed ISO8601 date parsing when UTC offset is specified as 00:00

### DIFF
--- a/Source/Core/JulianDate.js
+++ b/Source/Core/JulianDate.js
@@ -481,7 +481,7 @@ define([
             tokens = time.match(matchHoursMinutesSeconds);
             if (tokens !== null) {
                 dashCount = time.split(':').length - 1;
-                if (dashCount > 0 && dashCount !== 2) {
+                if (dashCount > 0 && !(dashCount == 2 || dashCount == 3)) {
                     throw new DeveloperError(iso8601ErrorMessage);
                 }
 


### PR DESCRIPTION
One line change in JulianDate.js.  Everything else seems to support the format, but line 484 was too strict in its checks.
