### PR TITLE
open links not generated by jsdoc in new window

### DIFF
--- a/Tools/jsdoc3/rhino_modules/jsdoc/util/templateHelper.js
+++ b/Tools/jsdoc3/rhino_modules/jsdoc/util/templateHelper.js
@@ -117,7 +117,7 @@ function toLink(longname, content) {
         return content;
     }
     else {
-        return '<a href="'+url+'">'+content+'</a>';
+        return '<a href="'+url+'" target="_self">'+content+'</a>';
     }
 }
 

--- a/Tools/jsdoc3/templates/default/publish.js
+++ b/Tools/jsdoc3/templates/default/publish.js
@@ -186,7 +186,7 @@
         
         function linkto(longname, linktext) {
             var url = helper.longnameToUrl[longname];
-            return url? '<a href="'+url+'">'+(linktext || longname)+'</a>' : (linktext || longname);
+            return url? '<a href="'+url+'" target="_self">'+(linktext || longname)+'</a>' : (linktext || longname);
         }
         
         function tutoriallink(tutorial) {

--- a/Tools/jsdoc3/templates/default/tmpl/index.tmpl
+++ b/Tools/jsdoc3/templates/default/tmpl/index.tmpl
@@ -68,6 +68,7 @@
 	if (show) {
 	   document.getElementById("filterType").value = show;
 	} 
+    document.getElementById('ClassFilter').focus();
 	
 	if (searchTerm) {
 	    searchTerm = searchTerm.split('&')[0] || '';

--- a/Tools/jsdoc3/templates/default/tmpl/layout.tmpl
+++ b/Tools/jsdoc3/templates/default/tmpl/layout.tmpl
@@ -16,6 +16,7 @@
     <link rel="stylesheet" href="styles/shThemeDefault.css" media="all"></link>
     <script src="javascript/shCore.js"></script>
     <script src="javascript/shBrushJScript.js"></script>
+    <base target="_blank"/>
 </head>
 
 <body>
@@ -70,6 +71,7 @@
         ele.className = "back";
         ele.href = "index.html";
         ele.title = "Home";
+        ele.target = "_self";
         document.getElementById('main').appendChild(ele);
         
         


### PR DESCRIPTION
For "improve reference documentation page" pull request for the cesium website.
All links have a default of `target="_blank"` so links created by html written in the documentation will open in new pages.  I over-ride this default for links generated by jsdoc to have `target="_self"`.

This is the easiest way I could think of to force external links to open in a new window, which is needed when the reference documentation is embedded.
