### PR TITLE
Fix embedded reference doc link targets.

### DIFF
--- a/Tools/jsdoc3/templates/default/tmpl/members.tmpl
+++ b/Tools/jsdoc3/templates/default/tmpl/members.tmpl
@@ -1,6 +1,6 @@
 
 <dt>
-    <h4 class="name" id="<?js= id ?>"><?js= data.attribs ?><a href="#<?js= id ?>" class="permalink"><?js= name ?></a><?js= data.signature ?></h4>
+    <h4 class="name" id="<?js= id ?>"><?js= data.attribs ?><a href="#<?js= id ?>" class="permalink" target="_self"><?js= name ?></a><?js= data.signature ?></h4>
     
     <?js if (data.summary) { ?>
     <p class="summary"><?js= summary ?></p>

--- a/Tools/jsdoc3/templates/default/tmpl/method.tmpl
+++ b/Tools/jsdoc3/templates/default/tmpl/method.tmpl
@@ -1,6 +1,6 @@
 <?js var self = this; ?>
 <dt>
-    <h4 class="name" id="<?js= id ?>"><?js= data.attribs + (kind == 'class'? 'new ':'') ?><a href="#<?js= id ?>" class="permalink"><?js= name ?></a><?js= data.signature ?></h4>
+    <h4 class="name" id="<?js= id ?>"><?js= data.attribs + (kind == 'class'? 'new ':'') ?><a href="#<?js= id ?>" class="permalink" target="_self"><?js= name ?></a><?js= data.signature ?></h4>
     
     <?js if (data.summary) { ?>
     <p class="summary"><?js= summary ?></p>


### PR DESCRIPTION
Clicking on a method or property name will now open the documentation in the same window, rather than a new one, when the documentation is embedded.
