### PR TITLE
expose WebGL context options in Scene constructor

### DIFF
--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -169,9 +169,6 @@ define([
         if (typeof options === 'undefined') {
             options = {};
         }
-        if (typeof options.stencil === 'undefined') {
-            options.stencil = false;
-        }
         if (typeof options.alpha === 'undefined') {
             options.alpha = false;
         }

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -62,10 +62,28 @@ define([
     "use strict";
 
     /**
-     * DOC_TBA
+     * The container for all 3D graphical objects and state in a Cesium virtual scene.  Generally,
+     * a scene is not created directly; instead, it is implicitly created by {@link CesiumWidget}.
      *
      * @alias Scene
      * @constructor
+     *
+     * @param {HTMLCanvasElement} canvas The HTML canvas element to create the scene for.
+     * @param {Object} [contextOptions=undefined] Properties corresponding to <a href='http://www.khronos.org/registry/webgl/specs/latest/#5.2'>WebGLContextAttributes</a> used to create the WebGL context.  Default values are shown in the code example below.
+     *
+     * @see CesiumWidget
+     * @see <a href='http://www.khronos.org/registry/webgl/specs/latest/#5.2'>WebGLContextAttributes</a>
+     *
+     * @example
+     * // Create scene with default context options.
+     * var scene = new Scene(canvas, {
+     *     alpha : false,
+     *     depth : true,
+     *     stencil : false,
+     *     antialias : true,
+     *     premultipliedAlpha : true,
+     *     preserveDrawingBuffer : false
+     * });
      */
     var Scene = function(canvas, contextOptions) {
         var context = new Context(canvas, contextOptions);


### PR DESCRIPTION
In order to capture a WebGL canvas using canvas.toDataURL() in Chrome the option preserveDrawingBuffer is required to be set on WebGL context creation [1].  This pull request exposes context options via the Scene constructor.  Feel free to discard if you have alternate solutions in mind.

[1] http://code.google.com/p/chromium/issues/detail?id=82086
