### PR TITLE
Fix polylines disapperaing in 2D.

### DIFF
--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -141,6 +141,7 @@ define([
 
         this._boundingVolume = undefined;
         this._boundingVolume2D = undefined;
+        this._boundingVolumeScratch = new BoundingSphere();
 
         this._commandLists = new CommandLists();
         this._colorCommands = [];
@@ -438,11 +439,11 @@ define([
             boundingVolume = this._boundingVolume2D;
         } else if (frameState.mode === SceneMode.SCENE2D) {
             if (typeof this._boundingVolume2D !== 'undefined') {
-                boundingVolume = BoundingSphere.clone(this._boundingVolume2D);
+                boundingVolume = BoundingSphere.clone(this._boundingVolume2D, this._boundingVolumeScratch);
                 boundingVolume.center.x = 0.0;
             }
         } else if (typeof this._boundingVolume !== 'undefined' && typeof this._boundingVolume2D !== 'undefined') {
-            boundingVolume = BoundingSphere.union(this._boundingVolume, this._boundingVolume2D);
+            boundingVolume = BoundingSphere.union(this._boundingVolume, this._boundingVolume2D, this._boundingVolumeScratch);
         }
 
         if (typeof boundingVolume === 'undefined') {


### PR DESCRIPTION
Removes the scratch bounding sphere for 2D that made the last computed bounding sphere the same for all polylines.

Fixes #854.
