### PR TITLE
CesiumViewer: log unhandled exceptions from startup

### DIFF
--- a/Apps/CesiumViewer/CesiumViewer.js
+++ b/Apps/CesiumViewer/CesiumViewer.js
@@ -47,6 +47,7 @@ define([
         }
     }).otherwise(function(e) {
         console.error(e);
+        window.alert(e);
     });
 
     function startup() {


### PR DESCRIPTION
If CesiumViewer startup throws an exception, the promise will turn that exception into an overall rejected promise.  So, we need to explicitly handle and log that exception ourself.
