### PR TITLE
Timeline destroy cleanup

### DIFF
--- a/Specs/Widgets/Timeline/TimelineSpec.js
+++ b/Specs/Widgets/Timeline/TimelineSpec.js
@@ -1,0 +1,30 @@
+/*global defineSuite*/
+defineSuite(['Widgets/Timeline/Timeline',
+             'Core/Clock'
+             ], function(
+                     Timeline,
+                     Clock) {
+    "use strict";
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
+
+    var container;
+    beforeEach(function(){
+        container = document.createElement('span');
+        container.id = 'container';
+        container.style.width = '1px';
+        container.style.height = '1px';
+        document.body.appendChild(container);
+    });
+
+    afterEach(function(){
+        document.body.removeChild(container);
+    });
+
+    it('sanity check', function() {
+        var timeline = new Timeline(container, new Clock());
+        timeline.resize();
+        expect(timeline.isDestroyed()).toEqual(false);
+        timeline.destroy();
+        expect(timeline.isDestroyed()).toEqual(true);
+    });
+});


### PR DESCRIPTION
1. Properly implement Timeline destroy to make sure everyting cleans up after itself
2. Add a sanity check spec that creates/destroys the Timeline as a stopgap until we write complete specs.
3. Fix a bug introduced in #870 that caused the Timeline to not redraw properly on scroll/zoom.

This change does not attempt to fix the myriad of other issues with the Timeline, so please don't review it with our normal rigor.  I'm hoping to carve out some time soon to finally get around to #754.
