### PR TITLE
BaseLayerPicker improvements.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@ Beta Releases
 * Added `useDefaultRenderLoop` property to `CesiumWidget` that allows the default render loop to be disabled so that a custom render loop can be used.
 * Fix resizing issues in `CesiumWidget` ([#608](https://github.com/AnalyticalGraphicsInc/cesium/issues/608)) by having the default render loop force a resize event every 60 frames.
 * Added `CesiumWidget.onRenderLoopError` which is an `Event` that is raised if an exception is generated inside of the default render loop.
+* `ImageryProviderViewModel.creationCommand` can now return an array of ImageryProvider instances, which allows adding multiple layers when a single item is selected in the `BaseLayerPicker` widget.
 
 ### b17 - 2013-06-03
 

--- a/Source/Scene/ImageryProvider.js
+++ b/Source/Scene/ImageryProvider.js
@@ -28,6 +28,85 @@ define([
      * @demo <a href="http://cesium.agi.com/Cesium/Apps/Sandcastle/index.html?src=Imagery%20Layers%20Manipulation.html">Cesium Sandcastle Imagery Manipulation Demo</a>
      */
     var ImageryProvider = function ImageryProvider() {
+        /**
+         * The default alpha blending value of this provider, usually from 0.0 to 1.0.
+         * This can either be a simple number or a function with the signature
+         * <code>function(frameState, layer, x, y, level)</code>.  The function is passed the
+         * current {@link FrameState}, the layer, and the x, y, and level coordinates of the
+         * imagery tile for which the alpha is required, and it is expected to return
+         * the alpha value to use for the tile.  The function is executed for every
+         * frame and for every tile, so it must be fast.
+         *
+         * @type {Number}
+         */
+        this.defaultAlpha = undefined;
+
+        /**
+         * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
+         * makes the imagery darker while greater than 1.0 makes it brighter.
+         * This can either be a simple number or a function with the signature
+         * <code>function(frameState, layer, x, y, level)</code>.  The function is passed the
+         * current {@link FrameState}, the layer, and the x, y, and level coordinates of the
+         * imagery tile for which the brightness is required, and it is expected to return
+         * the brightness value to use for the tile.  The function is executed for every
+         * frame and for every tile, so it must be fast.
+         *
+         * @type {Number}
+         */
+        this.defaultBrightness = undefined;
+
+        /**
+         * The default contrast of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0 reduces
+         * the contrast while greater than 1.0 increases it.
+         * This can either be a simple number or a function with the signature
+         * <code>function(frameState, layer, x, y, level)</code>.  The function is passed the
+         * current {@link FrameState}, the layer, and the x, y, and level coordinates of the
+         * imagery tile for which the contrast is required, and it is expected to return
+         * the contrast value to use for the tile.  The function is executed for every
+         * frame and for every tile, so it must be fast.
+         *
+         * @type {Number}
+         */
+        this.defaultContrast = undefined;
+
+        /**
+         * The default hue of this provider in radians. 0.0 uses the unmodified imagery color. This can either be a
+         * simple number or a function with the signature <code>function(frameState, layer, x, y, level)</code>.
+         * The function is passed the current {@link FrameState}, the layer, and the x, y, and level
+         * coordinates of the imagery tile for which the hue is required, and it is expected to return
+         * the hue value to use for the tile.  The function is executed for every
+         * frame and for every tile, so it must be fast.
+         *
+         * @type {Number}
+         */
+        this.defaultHue = undefined;
+
+        /**
+         * The default saturation of this provider. 1.0 uses the unmodified imagery color. Less than 1.0 reduces the
+         * saturation while greater than 1.0 increases it. This can either be a simple number or a function
+         * with the signature <code>function(frameState, layer, x, y, level)</code>.  The function is passed the
+         * current {@link FrameState}, the layer, and the x, y, and level coordinates of the
+         * imagery tile for which the saturation is required, and it is expected to return
+         * the saturation value to use for the tile.  The function is executed for every
+         * frame and for every tile, so it must be fast.
+         *
+         * @type {Number}
+         */
+        this.defaultSaturation = undefined;
+
+        /**
+         * The default gamma correction to apply to this provider.  1.0 uses the unmodified imagery color.
+         * This can either be a simple number or a function with the signature
+         * <code>function(frameState, layer, x, y, level)</code>.  The function is passed the
+         * current {@link FrameState}, the layer, and the x, y, and level coordinates of the
+         * imagery tile for which the gamma is required, and it is expected to return
+         * the gamma value to use for the tile.  The function is executed for every
+         * frame and for every tile, so it must be fast.
+         *
+         * @type {Number}
+         */
+        this.defaultGamma = undefined;
+
         throw new DeveloperError('This type should not be instantiated directly.');
     };
 

--- a/Source/Widgets/BaseLayerPicker/BaseLayerPickerViewModel.js
+++ b/Source/Widgets/BaseLayerPicker/BaseLayerPickerViewModel.js
@@ -80,19 +80,42 @@ define([
          */
         this.selectedItem = undefined;
         var selectedViewModel = knockout.observable();
+
+        this._currentProviders = [];
         knockout.defineProperty(this, 'selectedItem', {
             get : function() {
                 return selectedViewModel();
             },
             set : function(value) {
-                if (imageryLayers.getLength() > 0) {
-                    imageryLayers.remove(imageryLayers.get(0));
+                var i;
+                var currentProviders = that._currentProviders;
+                var currentProvidersLength = currentProviders.length;
+                for (i = 0; i < currentProvidersLength; i++) {
+                    var layersLength = imageryLayers.getLength();
+                    for ( var x = 0; x < layersLength; x++) {
+                        var layer = imageryLayers.get(x);
+                        if (layer.getImageryProvider() === currentProviders[i]) {
+                            imageryLayers.remove(layer);
+                            break;
+                        }
+                    }
                 }
-                var newLayer = value.creationCommand();
-                if (typeof newLayer !== 'undefined') {
-                    imageryLayers.addImageryProvider(newLayer, 0);
+
+                if (typeof value !== 'undefined') {
+                    var newProviders = value.creationCommand();
+                    if (Array.isArray(newProviders)) {
+                        var newProvidersLength = newProviders.length;
+                        for (i = newProvidersLength - 1; i >= 0; i--) {
+                            imageryLayers.addImageryProvider(newProviders[i], 0);
+                        }
+                        that._currentProviders = newProviders.slice(0);
+                    } else {
+                        that._currentProviders = [newProviders];
+                        imageryLayers.addImageryProvider(newProviders, 0);
+                    }
+
+                    selectedViewModel(value);
                 }
-                selectedViewModel(value);
                 that.dropDownVisible = false;
             }
         });

--- a/Source/Widgets/BaseLayerPicker/ImageryProviderViewModel.js
+++ b/Source/Widgets/BaseLayerPicker/ImageryProviderViewModel.js
@@ -21,7 +21,7 @@ define([
      * @param {String|Observable} description.name The name of the layer.
      * @param {String|Observable} description.tooltip The tooltip to show when the item is moused over.
      * @param {String|Observable} description.iconUrl An icon representing the layer.
-     * @param {Function|Command} description.creationFunction A function or Command which creates the ImageryProvider to be added to the layers collection.
+     * @param {Function|Command} description.creationFunction A function or Command which creates the ImageryProvider or array of ImageryProviders to be added to the layers collection.
      *
      * @exception {DeveloperError} description.name is required.
      * @exception {DeveloperError} description.tooltip is required.
@@ -78,7 +78,8 @@ define([
 
     defineProperties(ImageryProviderViewModel.prototype, {
         /**
-         * Gets the Command called to create the imagery provider.
+         * Gets the Command called to create the imagery provider or array of
+         * imagery providers to be added to the bottom of the layer collection.
          * @memberof ImageryProviderViewModel.prototype
          *
          * @type Command

--- a/Specs/Widgets/BaseLayerPicker/BaseLayerPickerViewModelSpec.js
+++ b/Specs/Widgets/BaseLayerPicker/BaseLayerPickerViewModelSpec.js
@@ -16,6 +16,18 @@ defineSuite([
         }
     };
 
+    var testProvider2 = {
+        isReady : function() {
+            return false;
+        }
+    };
+
+    var testProvider3 = {
+        isReady : function() {
+            return false;
+        }
+    };
+
     var testProviderViewModel = new ImageryProviderViewModel({
         name : 'name',
         tooltip : 'tooltip',
@@ -25,18 +37,12 @@ defineSuite([
         }
     });
 
-    var testProvider2 = {
-        isReady : function() {
-            return false;
-        }
-    };
-
     var testProviderViewModel2 = new ImageryProviderViewModel({
         name : 'name',
         tooltip : 'tooltip',
         iconUrl : 'url',
         creationFunction : function() {
-            return testProvider2;
+            return [testProvider, testProvider2];
         }
     });
 
@@ -86,9 +92,32 @@ defineSuite([
         expect(imageryLayers.get(0).getImageryProvider()).toBe(testProvider);
 
         viewModel.selectedItem = testProviderViewModel2;
-        expect(imageryLayers.getLength()).toEqual(1);
-        expect(imageryLayers.get(0).getImageryProvider()).toBe(testProvider2);
+        expect(imageryLayers.getLength()).toEqual(2);
+        expect(imageryLayers.get(0).getImageryProvider()).toBe(testProvider);
+        expect(imageryLayers.get(1).getImageryProvider()).toBe(testProvider2);
     });
+
+    it('settings selectedItem only removes layers added by view model', function() {
+        var array = [testProviderViewModel];
+        var imageryLayers = new ImageryLayerCollection();
+        var viewModel = new BaseLayerPickerViewModel(imageryLayers, array);
+
+        expect(imageryLayers.getLength()).toEqual(0);
+
+        viewModel.selectedItem = testProviderViewModel2;
+        expect(imageryLayers.getLength()).toEqual(2);
+        expect(imageryLayers.get(0).getImageryProvider()).toBe(testProvider);
+        expect(imageryLayers.get(1).getImageryProvider()).toBe(testProvider2);
+
+        imageryLayers.addImageryProvider(testProvider3, 1);
+        imageryLayers.remove(imageryLayers.get(0));
+
+        viewModel.selectedItem = undefined;
+
+        expect(imageryLayers.getLength()).toEqual(1);
+        expect(imageryLayers.get(0).getImageryProvider()).toBe(testProvider3);
+    });
+
 
     it('dropDownVisible and toggleDropDown work', function() {
         var viewModel = new BaseLayerPickerViewModel(new ImageryLayerCollection());


### PR DESCRIPTION
1. Add ability for the BaseLayerPicker to have an item specify an array of imagery providers, instead of always using a single provider.
2. Added missing documentation to the ImageryProvider documentation.
3. Cleaned up the BaseLayerPicker code so that it only removes items originally added by the widget, rather than removing the layer at index 0.

Based on work started by @akosmaroy in #798
