### PR TITLE
Throw a specific error when browser zoom is not 100%

### DIFF
--- a/Specs/createCanvas.js
+++ b/Specs/createCanvas.js
@@ -12,12 +12,12 @@ define([
         height = defaultValue(height, 1);
 
         var canvas = document.createElement('canvas');
-        canvas.setAttribute('width', width);
-        canvas.setAttribute('height', height);
-        canvas.innerHTML = 'To view this web page, upgrade your browser; it does not support the HTML5 canvas element.';
+        canvas.width = width;
+        canvas.height = height;
+
         document.body.appendChild(canvas);
 
-        if ((canvas.width !== canvas.clientWidth) || (canvas.height !== canvas.clientHeight)) {
+        if (canvas.width !== canvas.clientWidth || canvas.height !== canvas.clientHeight) {
             throw new RuntimeError('Canvas width and height do not match client width and height.  Perhaps the browser is not at 100% zoom?');
         }
 


### PR DESCRIPTION
Fixes #681.  This is @pjcozzi's change from 7 months ago, rebased onto PR #876, which makes the error actually display correctly.  Merge #876 first.

While testing this, I noticed that the problem only occurs in Chrome with a non-100% zoom.  Firefox seems to work normally regardless of zoom.
