### PR TITLE
Make the default timeline labels look like the default Animation widget labels

### DIFF
--- a/Source/Widgets/Timeline/Timeline.js
+++ b/Source/Widgets/Timeline/Timeline.js
@@ -260,14 +260,7 @@ define([
 
     Timeline.prototype.makeLabel = function(julianDate) {
         var gregorian = julianDate.toGregorianDate();
-        var hour = gregorian.hour;
-        var ampm = (hour < 12) ? ' AM' : ' PM';
-        if (hour >= 13) {
-            hour -= 12;
-        } else if (hour === 0) {
-            hour = 12;
-        }
-        var millisecond = gregorian.millisecond, millisecondString = '';
+        var millisecond = gregorian.millisecond, millisecondString = ' UTC';
         if ((millisecond > 0) && (this._timeBarSecondsSpan < 3600)) {
             millisecondString = Math.floor(millisecond).toString();
             while (millisecondString.length < 3) {
@@ -276,8 +269,8 @@ define([
             millisecondString = '.' + millisecondString;
         }
 
-        return timelineMonthNames[gregorian.month - 1] + ' ' + gregorian.day + ' ' + gregorian.year + ' ' + twoDigits(hour) + ':' +
-            twoDigits(gregorian.minute) + ':' + twoDigits(gregorian.second) + millisecondString + ampm;
+        return timelineMonthNames[gregorian.month - 1] + ' ' + gregorian.day + ' ' + gregorian.year + ' ' + twoDigits(gregorian.hour) +
+            ':' + twoDigits(gregorian.minute) + ':' + twoDigits(gregorian.second) + millisecondString;
     };
 
     Timeline.prototype.smallestTicInPixels = 7.0;


### PR DESCRIPTION
This is a quick fix to bring the old timeline's default date labels in sync with where the Animation widget's default date labels have been.

I know the whole timeline is in need of rewrite, and this doesn't address that at all.  The labels are customizable, but the defaults didn't match, and it was troubling to certain users.
