### PR TITLE
Set console container to overflow auto so all logged text is visible.

### DIFF
--- a/Apps/Sandcastle/CesiumSandcastle.css
+++ b/Apps/Sandcastle/CesiumSandcastle.css
@@ -113,7 +113,8 @@ html, body {
 	display: block;
 	width: 100%;
 	height: 100%;
-	overflow: auto;
+	overflow-x: auto;
+	overflow-y: scroll;
 }
 
 #logOutput {


### PR DESCRIPTION
Noticed while testing another issue.  Long console lines, such as error stack traces, were clipped horizontally due to `overflow-x: hidden`.
