### PR TITLE
Fix #887

### DIFF
--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -45,6 +45,12 @@ define([
         knockout) {
     "use strict";
 
+    function createOnTick(dataSourceDisplay) {
+        return function(clock) {
+            dataSourceDisplay.update(clock.currentTime);
+        };
+    }
+
     function onTimelineScrubfunction(e) {
         var clock = e.clock;
         clock.currentTime = e.timeJulian;
@@ -198,11 +204,12 @@ Either specify options.imageryProvider instead or set options.baseLayerPicker to
         };
         window.addEventListener('resize', this._resizeCallback, false);
 
-        var clock = cesiumWidget.clock;
-
         //Data source display
         var dataSourceDisplay = new DataSourceDisplay(cesiumWidget.scene);
         this._dataSourceDisplay = dataSourceDisplay;
+
+        var clock = cesiumWidget.clock;
+        clock.onTick.addEventListener(createOnTick(dataSourceDisplay));
 
         var toolbar = document.createElement('div');
         toolbar.className = 'cesium-viewer-toolbar';
@@ -658,9 +665,7 @@ Either specify options.imageryProvider instead or set options.baseLayerPicker to
      * @memberof Viewer
      */
     Viewer.prototype.render = function() {
-        var cesiumWidget = this._cesiumWidget;
-        cesiumWidget.render();
-        this._dataSourceDisplay.update(cesiumWidget.clock.currentTime);
+        this._cesiumWidget.render();
     };
 
     /**


### PR DESCRIPTION
Viewer's dataSourceDisplay needs to be updated in onTick (which causes it to occur after the clock is ticked but before initializeFrame and render are called.

I tried writing a unit test for this, but it's actually hard to do without coding directly against the implementation.  It's one of those things that's obviously wrong and unlikely to break again (and if it does, I'll do whatever it takes to write a unit test next time).
