### PR TITLE
Fixes #864

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@ Beta Releases
 * Fix resizing issues in `CesiumWidget` ([#608](https://github.com/AnalyticalGraphicsInc/cesium/issues/608)) by having the default render loop force a resize event every 60 frames.
 * Added `CesiumWidget.onRenderLoopError` which is an `Event` that is raised if an exception is generated inside of the default render loop.
 * `ImageryProviderViewModel.creationCommand` can now return an array of ImageryProvider instances, which allows adding multiple layers when a single item is selected in the `BaseLayerPicker` widget.
+* Changed static `clone` functions in all objects such that if the object being cloned is undefined, the function will return undefined instead of throwing an exception
 
 ### b17 - 2013-06-03
 

--- a/Source/Core/AxisAlignedBoundingBox.js
+++ b/Source/Core/AxisAlignedBoundingBox.js
@@ -120,13 +120,11 @@ define([
      *
      * @param {AxisAlignedBoundingBox} box The bounding box to duplicate.
      * @param {AxisAlignedBoundingBox} [result] The object onto which to store the result.
-     * @return {AxisAlignedBoundingBox} The modified result parameter or a new AxisAlignedBoundingBox instance if none was provided.
-     *
-     * @exception {DeveloperError} box is required.
+     * @return {AxisAlignedBoundingBox} The modified result parameter or a new AxisAlignedBoundingBox instance if none was provided. (Returns undefined if box is undefined)
      */
     AxisAlignedBoundingBox.clone = function(box, result) {
         if (typeof box === 'undefined') {
-            throw new DeveloperError('box is required');
+            return undefined;
         }
 
         if (typeof result === 'undefined') {

--- a/Source/Core/BoundingRectangle.js
+++ b/Source/Core/BoundingRectangle.js
@@ -144,13 +144,11 @@ define([
      *
      * @param {BoundingRectangle} rectangle The bounding rectangle to duplicate.
      * @param {BoundingRectangle} [result] The object onto which to store the result.
-     * @return {BoundingRectangle} The modified result parameter or a new BoundingRectangle instance if one was not provided.
-     *
-     * @exception {DeveloperError} rectangle is required.
+     * @return {BoundingRectangle} The modified result parameter or a new BoundingRectangle instance if one was not provided. (Returns undefined if rectangle is undefined)
      */
     BoundingRectangle.clone = function(rectangle, result) {
         if (typeof rectangle === 'undefined') {
-            throw new DeveloperError('rectangle is required');
+            return undefined;
         }
 
         if (typeof result === 'undefined') {

--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -525,13 +525,11 @@ define([
      *
      * @param {BoundingSphere} sphere The bounding sphere to duplicate.
      * @param {BoundingSphere} [result] The object onto which to store the result.
-     * @return {BoundingSphere} The modified result parameter or a new BoundingSphere instance if none was provided.
-     *
-     * @exception {DeveloperError} sphere is required.
+     * @return {BoundingSphere} The modified result parameter or a new BoundingSphere instance if none was provided. (Returns undefined if sphere is undefined)
      */
     BoundingSphere.clone = function(sphere, result) {
         if (typeof sphere === 'undefined') {
-            throw new DeveloperError('sphere is required');
+            return undefined;
         }
 
         if (typeof result === 'undefined') {

--- a/Source/Core/Cartesian2.js
+++ b/Source/Core/Cartesian2.js
@@ -101,13 +101,11 @@ define([
      *
      * @param {Cartesian2} cartesian The Cartesian to duplicate.
      * @param {Cartesian2} [result] The object onto which to store the result.
-     * @return {Cartesian2} The modified result parameter or a new Cartesian2 instance if one was not provided.
-     *
-     * @exception {DeveloperError} cartesian is required.
+     * @return {Cartesian2} The modified result parameter or a new Cartesian2 instance if one was not provided. (Returns undefined if cartesian is undefined)
      */
     Cartesian2.clone = function(cartesian, result) {
         if (typeof cartesian === 'undefined') {
-            throw new DeveloperError('cartesian is required');
+            return undefined;
         }
 
         if (typeof result === 'undefined') {

--- a/Source/Core/Cartesian3.js
+++ b/Source/Core/Cartesian3.js
@@ -138,13 +138,11 @@ define([
      *
      * @param {Cartesian3} cartesian The Cartesian to duplicate.
      * @param {Cartesian3} [result] The object onto which to store the result.
-     * @return {Cartesian3} The modified result parameter or a new Cartesian3 instance if one was not provided.
-     *
-     * @exception {DeveloperError} cartesian is required.
+     * @return {Cartesian3} The modified result parameter or a new Cartesian3 instance if one was not provided. (Returns undefined if cartesian is undefined)
      */
     Cartesian3.clone = function(cartesian, result) {
         if (typeof cartesian === 'undefined') {
-            throw new DeveloperError('cartesian is required');
+            return undefined;
         }
 
         if (typeof result === 'undefined') {

--- a/Source/Core/Cartesian4.js
+++ b/Source/Core/Cartesian4.js
@@ -121,13 +121,11 @@ define([
      *
      * @param {Cartesian4} cartesian The Cartesian to duplicate.
      * @param {Cartesian4} [result] The object onto which to store the result.
-     * @return {Cartesian4} The modified result parameter or a new Cartesian4 instance if one was not provided.
-     *
-     * @exception {DeveloperError} cartesian is required.
+     * @return {Cartesian4} The modified result parameter or a new Cartesian4 instance if one was not provided. (Returns undefined if cartesian is undefined)
      */
     Cartesian4.clone = function(cartesian, result) {
         if (typeof cartesian === 'undefined') {
-            throw new DeveloperError('cartesian is required');
+            return undefined;
         }
 
         if (typeof result === 'undefined') {

--- a/Source/Core/Cartographic.js
+++ b/Source/Core/Cartographic.js
@@ -75,13 +75,11 @@ define([
      *
      * @param {Cartographic} cartographic The cartographic to duplicate.
      * @param {Cartographic} [result] The object onto which to store the result.
-     * @return {Cartographic} The modified result parameter or a new Cartographic instance if one was not provided.
-     *
-     * @exception {DeveloperError} cartographic is required.
+     * @return {Cartographic} The modified result parameter or a new Cartographic instance if one was not provided. (Returns undefined if cartographic is undefined)
      */
     Cartographic.clone = function(cartographic, result) {
         if (typeof cartographic === 'undefined') {
-            throw new DeveloperError('cartographic is required');
+            return undefined;
         }
         if (typeof result === 'undefined') {
             return new Cartographic(cartographic.longitude, cartographic.latitude, cartographic.height);

--- a/Source/Core/Color.js
+++ b/Source/Core/Color.js
@@ -246,9 +246,12 @@ define([
      *
      * @param {Color} color The Color to duplicate.
      * @param {Color} [result] The object to store the result in, if undefined a new instance will be created.
-     * @return {Color} The modified result parameter or a new instance if result was undefined.
+     * @return {Color} The modified result parameter or a new instance if result was undefined. (Returns undefined if color is undefined)
      */
     Color.clone = function(color, result) {
+        if (typeof color === 'undefined'){
+            return undefined;
+        }
         if (typeof result === 'undefined') {
             return new Color(color.red, color.green, color.blue, color.alpha);
         }

--- a/Source/Core/Ellipsoid.js
+++ b/Source/Core/Ellipsoid.js
@@ -78,9 +78,12 @@ define([
      * @param {Ellipsoid} ellipsoid The ellipsoid to duplicate.
      * @param {Ellipsoid} [result] The object onto which to store the result, or undefined if a new
      *                    instance should be created.
-     * @returns {Ellipsoid} The cloned Ellipsoid.
+     * @returns {Ellipsoid} The cloned Ellipsoid. (Returns undefined if ellipsoid is undefined)
      */
     Ellipsoid.clone = function(ellipsoid, result) {
+        if (typeof ellipsoid === 'undefined') {
+            return undefined;
+        }
         var radii = ellipsoid._radii;
 
         if (typeof result === 'undefined') {
@@ -185,6 +188,19 @@ define([
      */
     Ellipsoid.prototype.getMaximumRadius = function() {
         return this._maximumRadius;
+    };
+
+    /**
+     * Duplicates an Ellipsoid instance.
+     *
+     * @memberof Ellipsoid
+     *
+     * @param {Ellipsoid} [result] The object onto which to store the result, or undefined if a new
+     *                    instance should be created.
+     * @returns {Ellipsoid} The cloned Ellipsoid.
+     */
+    Ellipsoid.prototype.clone = function(result) {
+        return Ellipsoid.clone(this, result);
     };
 
     /**

--- a/Source/Core/Extent.js
+++ b/Source/Core/Extent.js
@@ -95,9 +95,12 @@ define([
      *
      * @param {Extent} extent The extent to clone.
      * @param {Extent} [result] The object onto which to store the result, or undefined if a new instance should be created.
-     * @return {Extent} The modified result parameter or a new Extent instance if none was provided.
+     * @return {Extent} The modified result parameter or a new Extent instance if none was provided. (Returns undefined if extent is undefined)
      */
     Extent.clone = function(extent, result) {
+        if (typeof extent === 'undefined') {
+            return undefined;
+        }
         if (typeof result === 'undefined') {
             return new Extent(extent.west, extent.south, extent.east, extent.north);
         }

--- a/Source/Core/JulianDate.js
+++ b/Source/Core/JulianDate.js
@@ -295,13 +295,11 @@ define([
      *
      * @param {Cartesian3} date The JulianDate to duplicate.
      * @param {Cartesian3} [result] The object onto which to store the JulianDate.
-     * @return {Cartesian3} The modified result parameter or a new Cartesian3 instance if one was not provided.
-     *
-     * @exception {DeveloperError} date is required.
+     * @return {Cartesian3} The modified result parameter or a new Cartesian3 instance if one was not provided. (Returns undefined if date is undefined)
      */
     JulianDate.clone = function(date, result) {
         if (typeof date === 'undefined') {
-            throw new DeveloperError('date is required.');
+            return undefined;
         }
         if (typeof result === 'undefined') {
             return new JulianDate(date._julianDayNumber, date._secondsOfDay, TimeStandard.TAI);

--- a/Source/Core/Matrix2.js
+++ b/Source/Core/Matrix2.js
@@ -42,13 +42,11 @@ define([
      *
      * @param {Matrix2} matrix The matrix to duplicate.
      * @param {Matrix2} [result] The object onto which to store the result.
-     * @return {Matrix2} The modified result parameter or a new Matrix2 instance if one was not provided.
-     *
-     * @exception {DeveloperError} matrix is required.
+     * @return {Matrix2} The modified result parameter or a new Matrix2 instance if one was not provided. (Returns undefined if matrix is undefined)
      */
     Matrix2.clone = function(values, result) {
         if (typeof values === 'undefined') {
-            throw new DeveloperError('values is required');
+            return undefined;
         }
         if (typeof result === 'undefined') {
             return new Matrix2(values[0], values[2],
@@ -72,7 +70,12 @@ define([
      *
      * @exception {DeveloperError} values is required.
      */
-    Matrix2.fromColumnMajorArray = Matrix2.clone;
+    Matrix2.fromColumnMajorArray = function(values, result) {
+        if (typeof values === 'undefined') {
+            throw new DeveloperError('values parameter is required');
+        }
+        return Matrix2.clone(values, result);
+    };
 
     /**
      * Creates a Matrix2 instance from a row-major order array.

--- a/Source/Core/Matrix3.js
+++ b/Source/Core/Matrix3.js
@@ -55,13 +55,11 @@ define([
      *
      * @param {Matrix3} matrix The matrix to duplicate.
      * @param {Matrix3} [result] The object onto which to store the result.
-     * @return {Matrix3} The modified result parameter or a new Matrix3 instance if one was not provided.
-     *
-     * @exception {DeveloperError} matrix is required.
+     * @return {Matrix3} The modified result parameter or a new Matrix3 instance if one was not provided. (Returns undefined if matrix is undefined)
      */
     Matrix3.clone = function(values, result) {
         if (typeof values === 'undefined') {
-            throw new DeveloperError('values is required');
+            return undefined;
         }
         if (typeof result === 'undefined') {
             return new Matrix3(values[0], values[3], values[6],
@@ -91,7 +89,12 @@ define([
      *
      * @exception {DeveloperError} values is required.
      */
-    Matrix3.fromColumnMajorArray = Matrix3.clone;
+    Matrix3.fromColumnMajorArray = function(values, result) {
+        if (typeof values === 'undefined') {
+            throw new DeveloperError('values parameter is required');
+        }
+        return Matrix3.clone(values, result);
+    };
 
     /**
      * Creates a Matrix3 instance from a row-major order array.

--- a/Source/Core/Matrix4.js
+++ b/Source/Core/Matrix4.js
@@ -85,13 +85,11 @@ define([
      *
      * @param {Matrix4} matrix The matrix to duplicate.
      * @param {Matrix4} [result] The object onto which to store the result.
-     * @return {Matrix4} The modified result parameter or a new Matrix4 instance if one was not provided.
-     *
-     * @exception {DeveloperError} matrix is required.
+     * @return {Matrix4} The modified result parameter or a new Matrix4 instance if one was not provided. (Returns undefined if matrix is undefined)
      */
     Matrix4.clone = function(values, result) {
         if (typeof values === 'undefined') {
-            throw new DeveloperError('values is required');
+            return undefined;
         }
         if (typeof result === 'undefined') {
             return new Matrix4(values[0], values[4], values[8], values[12],
@@ -129,7 +127,12 @@ define([
      *
      * @exception {DeveloperError} values is required.
      */
-    Matrix4.fromColumnMajorArray = Matrix4.clone;
+    Matrix4.fromColumnMajorArray = function(values, result) {
+        if (typeof values === 'undefined') {
+            throw new DeveloperError('values parameter is required');
+        }
+        return Matrix4.clone(values, result);
+    };
 
     /**
      * Computes a Matrix4 instance from a row-major order array.

--- a/Source/Core/Quaternion.js
+++ b/Source/Core/Quaternion.js
@@ -174,13 +174,11 @@ define([
      *
      * @param {Quaternion} quaternion The quaternion to duplicate.
      * @param {Quaternion} [result] The object onto which to store the result.
-     * @return {Quaternion} The modified result parameter or a new Quaternion instance if one was not provided.
-     *
-     * @exception {DeveloperError} quaternion is required.
+     * @return {Quaternion} The modified result parameter or a new Quaternion instance if one was not provided. (Returns undefined if quaternion is undefined)
      */
     Quaternion.clone = function(quaternion, result) {
         if (typeof quaternion === 'undefined') {
-            throw new DeveloperError('quaternion is required');
+            return undefined;
         }
 
         if (typeof result === 'undefined') {

--- a/Source/Core/Spherical.js
+++ b/Source/Core/Spherical.js
@@ -61,13 +61,11 @@ define([
      * @param {Spherical} spherical The spherical to clone.
      * @param {Spherical} [result] The object to store the result into, if undefined a new instance will be created.
      *
-     * @return The modified result parameter or a new instance if result was undefined.
-     *
-     * @exception {DeveloperError} spherical is required.
+     * @return The modified result parameter or a new instance if result was undefined. (Returns undefined if spherical is undefined)
      */
     Spherical.clone = function(spherical, result) {
         if (typeof spherical === 'undefined') {
-            throw new DeveloperError('spherical is required');
+            return undefined;
         }
 
         if (typeof result === 'undefined') {

--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -1089,7 +1089,7 @@ define([
         if (frameState.mode === SceneMode.SCENE3D) {
             modelMatrix = this.modelMatrix;
             boundingVolume = BoundingSphere.clone(this._baseVolume, this._boundingVolume);
-        } else if (typeof this._baseVolume2D !== 'undefined') {
+        } else {
             boundingVolume = BoundingSphere.clone(this._baseVolume2D, this._boundingVolume);
         }
         updateBoundingVolume(this, context, frameState, boundingVolume);

--- a/Source/Scene/TileTerrain.js
+++ b/Source/Scene/TileTerrain.js
@@ -68,11 +68,7 @@ define([
         tile.maximumHeight = mesh.maximumHeight;
         BoundingSphere.clone(mesh.boundingSphere3D, tile.boundingSphere3D);
 
-        if (typeof mesh.occludeePointInScaledSpace !== 'undefined') {
-            Cartesian3.clone(mesh.occludeePointInScaledSpace, tile.occludeePointInScaledSpace);
-        } else {
-            tile.occludeePointInScaledSpace = undefined;
-        }
+        Cartesian3.clone(mesh.occludeePointInScaledSpace, tile.occludeePointInScaledSpace);
 
         // Free the tile's existing vertex array, if any.
         tile.freeVertexArray();

--- a/Specs/Core/AxisAlignedBoundingBoxSpec.js
+++ b/Specs/Core/AxisAlignedBoundingBoxSpec.js
@@ -139,10 +139,8 @@ defineSuite([
         expect(box.intersect(plane)).toEqual(Intersect.INTERSECTING);
     });
 
-    it('static clone throws with no parameter', function() {
-        expect(function() {
-            AxisAlignedBoundingBox.clone();
-        }).toThrow();
+    it('static clone returns undefined with no parameter', function() {
+        expect(typeof AxisAlignedBoundingBox.clone()).toEqual('undefined');
     });
 
     it('static intersect throws without a box', function() {

--- a/Specs/Core/BoundingRectangleSpec.js
+++ b/Specs/Core/BoundingRectangleSpec.js
@@ -224,10 +224,8 @@ defineSuite([
         expect(result).toEqual(expected);
     });
 
-    it('static clone throws with no parameter', function() {
-        expect(function() {
-            BoundingRectangle.clone();
-        }).toThrow();
+    it('static clone returns undefined with no parameter', function() {
+        expect(typeof BoundingRectangle.clone()).toEqual('undefined');
     });
 
     it('static union throws with no left parameter', function() {

--- a/Specs/Core/BoundingSphereSpec.js
+++ b/Specs/Core/BoundingSphereSpec.js
@@ -370,10 +370,8 @@ defineSuite([
         expect(bs.getPlaneDistances(position, direction)).toEqual(expected);
     });
 
-    it('static clone throws with no parameter', function() {
-        expect(function() {
-            BoundingSphere.clone();
-        }).toThrow();
+    it('static clone returns undefined with no parameter', function() {
+        expect(typeof BoundingSphere.clone()).toEqual('undefined');
     });
 
     it('static union throws with no left parameter', function() {

--- a/Specs/Core/Cartesian2Spec.js
+++ b/Specs/Core/Cartesian2Spec.js
@@ -447,10 +447,8 @@ defineSuite([
         expect(cartesian.toString()).toEqual('(1.123, 2.345)');
     });
 
-    it('static clone throws with no parameter', function() {
-        expect(function() {
-            Cartesian2.clone();
-        }).toThrow();
+    it('static clone returns undefined with no parameter', function() {
+        expect(typeof Cartesian2.clone()).toEqual('undefined');
     });
 
     it('static getMaximumComponent throws with no parameter', function() {

--- a/Specs/Core/Cartesian3Spec.js
+++ b/Specs/Core/Cartesian3Spec.js
@@ -517,10 +517,8 @@ defineSuite([
     });
 
 
-    it('static clone throws with no parameter', function() {
-        expect(function() {
-            Cartesian3.clone();
-        }).toThrow();
+    it('static clone returns undefined with no parameter', function() {
+        expect(typeof Cartesian3.clone()).toEqual('undefined');
     });
 
     it('static getMaximumComponent throws with no parameter', function() {

--- a/Specs/Core/Cartesian4Spec.js
+++ b/Specs/Core/Cartesian4Spec.js
@@ -465,10 +465,8 @@ defineSuite([
         expect(cartesian.toString()).toEqual('(1.123, 2.345, 6.789, 6.123)');
     });
 
-    it('static clone throws with no parameter', function() {
-        expect(function() {
-            Cartesian4.clone();
-        }).toThrow();
+    it('static clone returns undefined with no parameter', function() {
+        expect(typeof Cartesian4.clone()).toEqual('undefined');
     });
 
     it('static getMaximumComponent throws with no parameter', function() {

--- a/Specs/Core/CartographicSpec.js
+++ b/Specs/Core/CartographicSpec.js
@@ -92,10 +92,8 @@ defineSuite([
         expect(cartographic.toString()).toEqual('(1.123, 2.345, 6.789)');
     });
 
-    it('static clone throws without cartographic parameter', function() {
-        expect(function() {
-            Cartographic.clone(undefined);
-        }).toThrow();
+    it('static clone returns undefined without cartographic parameter', function() {
+        expect(typeof Cartographic.clone(undefined)).toEqual('undefined');
     });
 
     it('static toString throws without cartographic parameter', function() {

--- a/Specs/Core/Matrix2Spec.js
+++ b/Specs/Core/Matrix2Spec.js
@@ -464,10 +464,8 @@ defineSuite([
         }).toThrow();
     });
 
-    it('static clone throws without matrix parameter', function() {
-        expect(function() {
-            Matrix2.clone(undefined);
-        }).toThrow();
+    it('static clone returns undefined without matrix parameter', function() {
+        expect(typeof Matrix2.clone(undefined)).toEqual('undefined');
     });
 
     it('static toArray throws without matrix parameter', function() {

--- a/Specs/Core/Matrix3Spec.js
+++ b/Specs/Core/Matrix3Spec.js
@@ -624,10 +624,8 @@ defineSuite([
         }).toThrow();
     });
 
-    it('static clone throws without matrix parameter', function() {
-        expect(function() {
-            Matrix3.clone(undefined);
-        }).toThrow();
+    it('static clone returns undefined without matrix parameter', function() {
+        expect(typeof Matrix3.clone(undefined)).toEqual('undefined');
     });
 
     it('static toArray throws without matrix parameter', function() {

--- a/Specs/Core/Matrix4Spec.js
+++ b/Specs/Core/Matrix4Spec.js
@@ -1142,10 +1142,8 @@ defineSuite([
         }).toThrow();
     });
 
-    it('static clone throws without matrix parameter', function() {
-        expect(function() {
-            Matrix4.clone(undefined);
-        }).toThrow();
+    it('static clone returns undefined without matrix parameter', function() {
+        expect(typeof Matrix4.clone(undefined)).toEqual('undefined');
     });
 
     it('static toArray throws without matrix parameter', function() {

--- a/Specs/Core/QuaternionSpec.js
+++ b/Specs/Core/QuaternionSpec.js
@@ -581,10 +581,8 @@ defineSuite([
         }).toThrow();
     });
 
-    it('static clone throws with no parameter', function() {
-        expect(function() {
-            Quaternion.clone();
-        }).toThrow();
+    it('static clone returns undefined with no parameter', function() {
+        expect(typeof Quaternion.clone()).toEqual('undefined');
     });
 
     it('static conjugate throws with no parameter', function() {


### PR DESCRIPTION
I modified all clone functions to return undefined if the object being cloned is undefined.  
I also searched through the code to remove `if (xxxxx !== 'undefined')` statements wrapped around clone function calls where they were no longer needed, and I updated tests and documentation to reflect the new behavior.
