### PR TITLE
Don't add "use strict" for all modules.

### DIFF
--- a/Tools/build.js
+++ b/Tools/build.js
@@ -1,9 +1,5 @@
 ({
-    wrap : {
-        start : '(function() {\n\
-"use strict";',
-        end : '}());'
-    },
+    wrap : true,
     useStrict : true,
     optimizeCss : 'standard'
 })


### PR DESCRIPTION
ThirdParty modules don't necessarily support it, so let each individual module control whether it's enabled.
