### PR TITLE
Support crs.type of 'EPSG'

### DIFF
--- a/Source/DynamicScene/GeoJsonDataSource.js
+++ b/Source/DynamicScene/GeoJsonDataSource.js
@@ -410,6 +410,11 @@ define(['../Core/createGuid',
                 }
 
                 crsFunction = handler(properties);
+			} else if(crs.type === 'EPSG' && properties.code) {
+				crsFunction = GeoJsonDataSource.crsNames['EPSG:' + properties.code];
+				if(typeof crsFunction === 'undefined') {
+					throw new RuntimeError('Unknown EPSG code: ' + properties.code);
+				}
             } else {
                 throw new RuntimeError('Unknown crs type: ' + crs.type);
             }


### PR DESCRIPTION
It seems that this is the format that GeoServer uses for specifying the crs name. I haven't done extensive looking into the GeoJson specification though so not sure if this is valid or not. I welcome comments and suggestions.

Signed-off-by: Kyle Linden Kyle.Linden@appliedis.com
