### PR TITLE
Add an emission parameter to the solid color material

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ Change Log
 Beta Releases
 -------------
 
+### b19 - 2013-08-XX
+
+* Breaking changes:
+   * The solid color Material now takes an `emission` uniform to enable visibility in low light conditions.
+
 ### b18 - 2013-07-01
 
 * Breaking changes:

--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -118,6 +118,7 @@ define([
      *  <li>Color</li>
      *  <ul>
      *      <li><code>color</code>:  rgba color object.</li>
+     *      <li><code>emission</code>:  percent of the color that is visible regardless of lighting.</li>
      *  </ul>
      *  <li>Image</li>
      *  <ul>
@@ -918,10 +919,12 @@ define([
     Material._materialCache.addMaterial(Material.ColorType, {
         type : Material.ColorType,
         uniforms : {
-            color : new Color(1.0, 0.0, 0.0, 0.5)
+            color : new Color(1.0, 0.0, 0.0, 0.5),
+            emission : 0.4
         },
         components : {
-            diffuse : 'color.rgb',
+            emission : 'color.rgb * emission',
+            diffuse : 'color.rgb * (1.0 - emission)',
             alpha : 'color.a'
         }
     });

--- a/Specs/Scene/MaterialSpec.js
+++ b/Specs/Scene/MaterialSpec.js
@@ -504,13 +504,15 @@ defineSuite([
                     color1 : {
                         type : 'Color',
                         uniforms : {
-                            color : new Color(0.0, 1.0, 0.0, 1.0)
+                            color : new Color(0.0, 1.0, 0.0, 1.0),
+                            emission : 0.0
                         }
                     },
                     color2 : {
                         type : 'Color',
                         uniforms : {
-                            color : new Color(0.0, 0.0, 1.0, 1.0)
+                            color : new Color(0.0, 0.0, 1.0, 1.0),
+                            emission : 0.0
                         }
                     }
                 },


### PR DESCRIPTION
Is this worth doing?  Basically our default solid color can become complete black depending on lighting conditions, and this introduces an emission percentage that acts as ambient light, preserving visibility of the color.

This does add some complexity to our simplest material, and only fixes the one material.  The `GridMaterial` has a similar fix hard-coded into it.  Is there some better way to fix it for all materials?

If we do decide to accept this, we should add CZML & DynamicScene support for the new parameter before this gets merged.
