### PR TITLE
Material uniforms tweak.

### DIFF
--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -666,10 +666,13 @@ define([
         'mat4' : Matrix4
     };
     function returnUniform(material, uniformId, originalUniformType) {
+        var uniformType;
         return function() {
             var uniforms = material.uniforms;
             var uniformValue = uniforms[uniformId];
-            var uniformType = getUniformType(uniformValue);
+            if (typeof uniformType === 'undefined') {
+                uniformType = getUniformType(uniformValue);
+            }
 
             if (originalUniformType === 'sampler2D' && (uniformType === originalUniformType || uniformValue instanceof Texture)) {
                 if (uniformType === originalUniformType) {


### PR DESCRIPTION
While the way Material deals with uniforms needs to be completely refactored (for a variety of reasons which I won't go into here but will write up an issue for later), a small tweak to the current architecture can provide a huge performance boost.  The tweak here is that getUniformType goes through an incredibly slow process to determine what type of variable a uniform value is and it does this for every uniform every frame.  This change simply caches the result.  As far as I know this change has no ill affects and everything looks good to me.

Here's how I profiled.
1. Download http://bl.ocks.org/mbostock/raw/4090846/us.json and load it into Cesium Viewer.
2. Profile in master, on my machine getUniformType takes up ~33.0% of the time and frame rate is about 4.5 fps.
3. Profile in this branch, on my machine getUniformType takes up ~0.01% of the time and frame rate is about 7.0 fps.
