### PR TITLE
Make the module IDs required by the Cesium module relative.

### DIFF
--- a/Tools/buildTasks/createCesiumJs.js
+++ b/Tools/buildTasks/createCesiumJs.js
@@ -26,7 +26,7 @@ forEachFile('sourcefiles', function(relativePath, file) {
 
     var parameterName = String(moduleId).replace(nonIdentifierRegexp, '_');
 
-    moduleIds.push("'" + moduleId + "'");
+    moduleIds.push("'./" + moduleId + "'");
     parameters.push(parameterName);
     assignments.push('Cesium.' + assignmentName + ' = ' + parameterName + ';');
 });


### PR DESCRIPTION
This is consistent with the rest of the modules, and makes the entire source tree relocatable.
