### PR TITLE
Fix Polylines disappearing in 2D and Columbus view.

### DIFF
--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -61,18 +61,18 @@ define([
     var NUMBER_OF_PROPERTIES = Polyline.NUMBER_OF_PROPERTIES;
 
     var attributeIndices = {
-        position3DHigh : 0,
-        position3DLow : 1,
-        position2DHigh : 2,
-        position2DLow : 3,
-        prevPosition3DHigh : 4,
-        prevPosition3DLow : 5,
-        prevPosition2DHigh : 6,
-        prevPosition2DLow : 7,
-        nextPosition3DHigh : 8,
-        nextPosition3DLow : 9,
-        nextPosition2DHigh : 10,
-        nextPosition2DLow : 11,
+        positionHigh : 0,
+        positionLow : 1,
+        positionMorphHigh : 2,
+        positionMorphLow : 3,
+        prevPositionHigh : 4,
+        prevPositionLow : 5,
+        prevPositionMorphHigh : 6,
+        prevPositionMorphLow : 7,
+        nextPositionHigh : 8,
+        nextPositionLow : 9,
+        nextPositionMorphHigh : 10,
+        nextPositionMorphLow : 11,
         texCoordExpandWidthAndShow : 12,
         pickColor : 13
     };
@@ -755,73 +755,73 @@ define([
                     var vertexTexCoordExpandWidthAndShowBufferOffset = k * (texCoordExpandWidthAndShowSizeInBytes * CesiumMath.SIXTY_FOUR_KILOBYTES) - vbo * texCoordExpandWidthAndShowSizeInBytes;
 
                     var attributes = [{
-                        index : attributeIndices.position3DHigh,
+                        index : attributeIndices.positionHigh,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : positionHighOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.position3DLow,
+                        index : attributeIndices.positionLow,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : positionLowOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.position2DHigh,
+                        index : attributeIndices.positionMorphHigh,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : positionHighOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.position2DLow,
+                        index : attributeIndices.positionMorphLow,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : positionLowOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.prevPosition3DHigh,
+                        index : attributeIndices.prevPositionHigh,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : prevPositionHighOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.prevPosition3DLow,
+                        index : attributeIndices.prevPositionLow,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : prevPositionLowOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.prevPosition2DHigh,
+                        index : attributeIndices.prevPositionMorphHigh,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : prevPositionHighOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.prevPosition2DLow,
+                        index : attributeIndices.prevPositionMorphLow,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : prevPositionLowOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.nextPosition3DHigh,
+                        index : attributeIndices.nextPositionHigh,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : nextPositionHighOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.nextPosition3DLow,
+                        index : attributeIndices.nextPositionLow,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : nextPositionLowOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.nextPosition2DHigh,
+                        index : attributeIndices.nextPositionMorphHigh,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : nextPositionHighOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.nextPosition2DLow,
+                        index : attributeIndices.nextPositionMorphLow,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : nextPositionLowOffset,
@@ -841,40 +841,35 @@ define([
                         normalize : true
                     }];
 
-                    var buffer3D;
-                    var bufferProperty3D;
-                    var buffer2D;
-                    var bufferProperty2D;
+                    var buffer;
+                    var bufferProperty;
+                    var bufferMorph;
+                    var bufferPropertyMorph;
 
-                    if (mode === SceneMode.SCENE3D) {
-                        buffer3D = collection._positionBuffer;
-                        bufferProperty3D = 'vertexBuffer';
-                        buffer2D = emptyVertexBuffer;
-                        bufferProperty2D = 'value';
-                    } else if (mode === SceneMode.SCENE2D || mode === SceneMode.COLUMBUS_VIEW) {
-                        buffer3D = emptyVertexBuffer;
-                        bufferProperty3D = 'value';
-                        buffer2D = collection._positionBuffer;
-                        bufferProperty2D = 'vertexBuffer';
+                    if (typeof position3DBuffer === 'undefined') {
+                        buffer = collection._positionBuffer;
+                        bufferProperty = 'vertexBuffer';
+                        bufferMorph = emptyVertexBuffer;
+                        bufferPropertyMorph = 'value';
                     } else {
-                        buffer3D = position3DBuffer;
-                        bufferProperty3D = 'vertexBuffer';
-                        buffer2D = collection._positionBuffer;
-                        bufferProperty2D = 'vertexBuffer';
+                        buffer = collection._positionBuffer;
+                        bufferProperty = 'vertexBuffer';
+                        bufferMorph = position3DBuffer;
+                        bufferPropertyMorph = 'vertexBuffer';
                     }
 
-                    attributes[0][bufferProperty3D] = buffer3D;
-                    attributes[1][bufferProperty3D] = buffer3D;
-                    attributes[2][bufferProperty2D] = buffer2D;
-                    attributes[3][bufferProperty2D] = buffer2D;
-                    attributes[4][bufferProperty3D] = buffer3D;
-                    attributes[5][bufferProperty3D] = buffer3D;
-                    attributes[6][bufferProperty2D] = buffer2D;
-                    attributes[7][bufferProperty2D] = buffer2D;
-                    attributes[8][bufferProperty3D] = buffer3D;
-                    attributes[9][bufferProperty3D] = buffer3D;
-                    attributes[10][bufferProperty2D] = buffer2D;
-                    attributes[11][bufferProperty2D] = buffer2D;
+                    attributes[0][bufferProperty] = buffer;
+                    attributes[1][bufferProperty] = buffer;
+                    attributes[2][bufferPropertyMorph] = bufferMorph;
+                    attributes[3][bufferPropertyMorph] = bufferMorph;
+                    attributes[4][bufferProperty] = buffer;
+                    attributes[5][bufferProperty] = buffer;
+                    attributes[6][bufferPropertyMorph] = bufferMorph;
+                    attributes[7][bufferPropertyMorph] = bufferMorph;
+                    attributes[8][bufferProperty] = buffer;
+                    attributes[9][bufferProperty] = buffer;
+                    attributes[10][bufferPropertyMorph] = bufferMorph;
+                    attributes[11][bufferPropertyMorph] = bufferMorph;
 
                     var va = context.createVertexArray(attributes, indexBuffer);
                     collection._vertexArrays.push({

--- a/Source/Shaders/PolylineVS.glsl
+++ b/Source/Shaders/PolylineVS.glsl
@@ -1,15 +1,15 @@
-attribute vec3 position3DHigh;
-attribute vec3 position3DLow;
-attribute vec3 position2DHigh;
-attribute vec3 position2DLow;
-attribute vec3 prevPosition3DHigh;
-attribute vec3 prevPosition3DLow;
-attribute vec3 prevPosition2DHigh;
-attribute vec3 prevPosition2DLow;
-attribute vec3 nextPosition3DHigh;
-attribute vec3 nextPosition3DLow;
-attribute vec3 nextPosition2DHigh;
-attribute vec3 nextPosition2DLow;
+attribute vec3 positionHigh;
+attribute vec3 positionLow;
+attribute vec3 positionMorphHigh;
+attribute vec3 positionMorphLow;
+attribute vec3 prevPositionHigh;
+attribute vec3 prevPositionLow;
+attribute vec3 prevPositionMorphHigh;
+attribute vec3 prevPositionMorphLow;
+attribute vec3 nextPositionHigh;
+attribute vec3 nextPositionLow;
+attribute vec3 nextPositionMorphHigh;
+attribute vec3 nextPositionMorphLow;
 attribute vec4 texCoordExpandWidthAndShow;
 attribute vec4 pickColor;
 
@@ -68,29 +68,29 @@ void main()
     vec4 p, prev, next;
     if (czm_morphTime == 1.0)
     {
-        p = czm_translateRelativeToEye(position3DHigh.xyz, position3DLow.xyz);
-        prev = czm_translateRelativeToEye(prevPosition3DHigh.xyz, prevPosition3DLow.xyz);
-        next = czm_translateRelativeToEye(nextPosition3DHigh.xyz, nextPosition3DLow.xyz);
+        p = czm_translateRelativeToEye(positionHigh.xyz, positionLow.xyz);
+        prev = czm_translateRelativeToEye(prevPositionHigh.xyz, prevPositionLow.xyz);
+        next = czm_translateRelativeToEye(nextPositionHigh.xyz, nextPositionLow.xyz);
     }
     else if (czm_morphTime == 0.0)
     {
-        p = czm_translateRelativeToEye(position2DHigh.zxy, position2DLow.zxy);
-        prev = czm_translateRelativeToEye(prevPosition2DHigh.zxy, prevPosition2DLow.zxy);
-        next = czm_translateRelativeToEye(nextPosition2DHigh.zxy, nextPosition2DLow.zxy);
+        p = czm_translateRelativeToEye(positionHigh.zxy, positionLow.zxy);
+        prev = czm_translateRelativeToEye(prevPositionHigh.zxy, prevPositionLow.zxy);
+        next = czm_translateRelativeToEye(nextPositionHigh.zxy, nextPositionLow.zxy);
     }
     else
     {
         p = czm_columbusViewMorph(
-                czm_translateRelativeToEye(position2DHigh.zxy, position2DLow.zxy),
-                czm_translateRelativeToEye(position3DHigh.xyz, position3DLow.xyz),
+                czm_translateRelativeToEye(positionHigh.zxy, positionLow.zxy),
+                czm_translateRelativeToEye(positionMorphHigh.xyz, positionMorphLow.xyz),
                 czm_morphTime);
         prev = czm_columbusViewMorph(
-                czm_translateRelativeToEye(prevPosition2DHigh.zxy, prevPosition2DLow.zxy),
-                czm_translateRelativeToEye(prevPosition3DHigh.xyz, prevPosition3DLow.xyz),
+                czm_translateRelativeToEye(prevPositionHigh.zxy, prevPositionLow.zxy),
+                czm_translateRelativeToEye(prevPositionMorphHigh.xyz, prevPositionMorphLow.xyz),
                 czm_morphTime);
         next = czm_columbusViewMorph(
-                czm_translateRelativeToEye(nextPosition2DHigh.zxy, nextPosition2DLow.zxy),
-                czm_translateRelativeToEye(nextPosition3DHigh.xyz, nextPosition3DLow.xyz),
+                czm_translateRelativeToEye(nextPositionHigh.zxy, nextPositionLow.zxy),
+                czm_translateRelativeToEye(nextPositionMorphHigh.xyz, nextPositionMorphLow.xyz),
                 czm_morphTime);
     }
     


### PR DESCRIPTION
Modifies `PolylineCollection` to always back vertex array attribute at index zero with a vertex buffer. Fixes #945.
