### PR TITLE
Fix issue #356

### DIFF
--- a/Source/Scene/LabelCollection.js
+++ b/Source/Scene/LabelCollection.js
@@ -41,27 +41,7 @@ define([
         this.labelCollection = labelCollection;
         this.index = index;
         this.dimensions = dimensions;
-        this.referenceCount = 1;
-
-        ++labelCollection._textureCount;
     }
-
-    GlyphTextureInfo.prototype.addReference = function() {
-        if (this.referenceCount === 0) {
-            // was fully released, now has references, so no longer unused
-            --this.labelCollection._unusedTextureCount;
-        }
-
-        ++this.referenceCount;
-    };
-
-    GlyphTextureInfo.prototype.releaseReference = function() {
-        --this.referenceCount;
-
-        if (this.referenceCount === 0) {
-            ++this.labelCollection._unusedTextureCount;
-        }
-    };
 
     // reusable object for calling writeTextToCanvas
     var writeTextToCanvasParameters = {};
@@ -87,10 +67,6 @@ define([
     }
 
     function unbindGlyph(labelCollection, glyph) {
-        if (typeof glyph.textureInfo !== 'undefined') {
-            glyph.textureInfo.releaseReference();
-        }
-
         glyph.textureInfo = undefined;
         glyph.dimensions = undefined;
 
@@ -157,8 +133,6 @@ define([
 
                 glyphTextureInfo = new GlyphTextureInfo(labelCollection, index, canvas.dimensions);
                 glyphTextureCache[id] = glyphTextureInfo;
-            } else {
-                glyphTextureInfo.addReference();
             }
 
             glyph = glyphs[textIndex];
@@ -173,7 +147,6 @@ define([
                     // we have a texture and billboard.  If we had one before, release
                     // our reference to that texture info, but reuse the billboard.
                     if (typeof glyph.textureInfo !== 'undefined') {
-                        glyph.textureInfo.releaseReference();
                         glyph.textureInfo = undefined;
                     }
                 }
@@ -324,11 +297,8 @@ define([
 
         this._spareBillboards = [];
         this._glyphTextureCache = {};
-        this._textureCount = 0;
-        this._unusedTextureCount = 0;
         this._labels = [];
         this._labelsToUpdate = [];
-        this._frameCount = 0;
         this._totalGlyphCount = 0;
 
         /**
@@ -581,27 +551,6 @@ define([
 
         billboardCollection.modelMatrix = this.modelMatrix;
 
-        var rebindAllGlyphsInAllLabels = false;
-        if (++this._frameCount % 100 === 0) {
-            this._frameCount = 0;
-            // clear and rebuild texture atlas to compact it when we have more than 25% unused textures
-            if (this._unusedTextureCount > 0.25 * this._textureCount) {
-                this._textureAtlas = this._textureAtlas.destroy();
-                this._glyphTextureCache = {};
-                this._textureCount = 0;
-                this._unusedTextureCount = 0;
-
-                // rebind and update all labels to repopulate the textures
-                rebindAllGlyphsInAllLabels = true;
-                this._labelsToUpdate = this._labels.slice(0);
-            }
-
-            // prune spare billboards to 10% of total glyph count
-            while (this._spareBillboards.length > this._totalGlyphCount * 0.1) {
-                billboardCollection.remove(this._spareBillboards.pop());
-            }
-        }
-
         if (typeof this._textureAtlas === 'undefined') {
             this._textureAtlas = context.createTextureAtlas();
             billboardCollection.setTextureAtlas(this._textureAtlas);
@@ -616,7 +565,7 @@ define([
 
             var preUpdateGlyphCount = label._glyphs.length;
 
-            if (rebindAllGlyphsInAllLabels || label._rebindAllGlyphs) {
+            if (label._rebindAllGlyphs) {
                 rebindAllGlyphs(this, label);
                 label._rebindAllGlyphs = false;
             }

--- a/Specs/Scene/LabelCollectionSpec.js
+++ b/Specs/Scene/LabelCollectionSpec.js
@@ -679,39 +679,39 @@ defineSuite([
             text : 'a'
         });
         labels.update(context, frameState, []);
-        expect(labels._textureCount).toEqual(1);
+        expect(Object.keys(labels._glyphTextureCache).length).toEqual(1);
 
         labels.add({
             text : 'a'
         });
         labels.update(context, frameState, []);
-        expect(labels._textureCount).toEqual(1);
+        expect(Object.keys(labels._glyphTextureCache).length).toEqual(1);
 
         labels.add({
             text : 'abcd'
         });
         labels.update(context, frameState, []);
-        expect(labels._textureCount).toEqual(4);
+        expect(Object.keys(labels._glyphTextureCache).length).toEqual(4);
 
         labels.add({
             text : 'abc'
         });
         labels.update(context, frameState, []);
-        expect(labels._textureCount).toEqual(4);
+        expect(Object.keys(labels._glyphTextureCache).length).toEqual(4);
 
         var label = labels.add({
             text : 'de'
         });
         labels.update(context, frameState, []);
-        expect(labels._textureCount).toEqual(5);
+        expect(Object.keys(labels._glyphTextureCache).length).toEqual(5);
 
         label.setFont('30px "Open Sans"');
         labels.update(context, frameState, []);
-        expect(labels._textureCount).toEqual(7);
+        expect(Object.keys(labels._glyphTextureCache).length).toEqual(7);
 
         label.setStyle(LabelStyle.OUTLINE);
         labels.update(context, frameState, []);
-        expect(labels._textureCount).toEqual(9);
+        expect(Object.keys(labels._glyphTextureCache).length).toEqual(9);
 
         label.setFillColor({
             red : 1.0,
@@ -720,7 +720,7 @@ defineSuite([
             alpha : 1.0
         });
         labels.update(context, frameState, []);
-        expect(labels._textureCount).toEqual(11);
+        expect(Object.keys(labels._glyphTextureCache).length).toEqual(11);
 
         label.setOutlineColor({
             red : 1.0,
@@ -729,25 +729,25 @@ defineSuite([
             alpha : 1.0
         });
         labels.update(context, frameState, []);
-        expect(labels._textureCount).toEqual(13);
+        expect(Object.keys(labels._glyphTextureCache).length).toEqual(13);
 
         // vertical origin only affects glyph positions, not glyphs themselves.
         label.setVerticalOrigin(VerticalOrigin.CENTER);
         labels.update(context, frameState, []);
-        expect(labels._textureCount).toEqual(13);
+        expect(Object.keys(labels._glyphTextureCache).length).toEqual(13);
         label.setVerticalOrigin(VerticalOrigin.TOP);
         labels.update(context, frameState, []);
-        expect(labels._textureCount).toEqual(13);
+        expect(Object.keys(labels._glyphTextureCache).length).toEqual(13);
 
         //even though we originally started with 30px sans-serif, other properties used to create the id have changed
         label.setFont('30px sans-serif');
         labels.update(context, frameState, []);
-        expect(labels._textureCount).toEqual(15);
+        expect(Object.keys(labels._glyphTextureCache).length).toEqual(15);
 
         //Changing thickness requires new glyphs
         label.setOutlineWidth(3);
         labels.update(context, frameState, []);
-        expect(labels._textureCount).toEqual(17);
+        expect(Object.keys(labels._glyphTextureCache).length).toEqual(17);
     });
 
     it('should reuse billboards that are not needed any more', function() {
@@ -764,43 +764,6 @@ defineSuite([
         label.setText('def');
         labels.update(context, frameState, []);
         expect(labels._billboardCollection.getLength()).toEqual(3);
-    });
-
-    it('should compact unused billboards after several frames', function() {
-        var label = labels.add({
-            text : 'abc'
-        });
-        labels.update(context, frameState, []);
-        expect(labels._billboardCollection.getLength()).toEqual(3);
-
-        label.setText('a');
-        labels.update(context, frameState, []);
-        expect(labels._billboardCollection.getLength()).toEqual(3);
-
-        for ( var i = 0; i < 150; ++i) {
-            labels.update(context, frameState, []);
-        }
-
-        expect(labels._billboardCollection.getLength()).toEqual(1);
-    });
-
-    it('should remove all glyphs several frames after calling remove', function() {
-        var label = labels.add({
-            text : 'blah blah'
-        });
-        labels.update(context, frameState, []);
-
-        expect(labels._textureCount).toEqual(5);
-        expect(labels._billboardCollection.getLength()).toEqual(8);
-
-        labels.remove(label);
-
-        for ( var i = 0; i < 150; ++i) {
-            labels.update(context, frameState, []);
-        }
-
-        expect(labels._textureCount).toEqual(0);
-        expect(labels._billboardCollection.getLength()).toEqual(0);
     });
 
     describe('Label', function() {


### PR DESCRIPTION
This removes the logic from the LabelCollection that attempt to prevent the texture atlas used from growing unbounded. This code negatively impacts performance and can create a hiccup affect during animation. The problem it is attempting to address is most likely not to be encountered in the real world and if we ever run into it, we can revisit this issue.
