### PR TITLE
Fix CesiumWidget render loop

### DIFF
--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -395,8 +395,8 @@ define([
      * @memberof CesiumWidget
      */
     CesiumWidget.prototype.render = function() {
-        var currentTime = this._clock.tick();
         this._scene.initializeFrame();
+        var currentTime = this._clock.tick();
         if (this._canRender) {
             this._scene.render(currentTime);
         }


### PR DESCRIPTION
`scene.initializeFrame` needs to be called before anything else happens.  By calling `clock.tick` first, listeners to the tick even were seeing the system in a mismatched state (i.e. the camera could think you were in one scene mode while the scene thought you were in another.  This manifested itself in an easy to reproduce crash:
1. Load simple.czml in Viewer
2. Click on a satellite and follow it.
3. Morph to another mode and click to cancel the morph halfway through
4. Crash.

This change fixes that issue.
