### PR TITLE
Label improvements

### DIFF
--- a/Source/Scene/LabelCollection.js
+++ b/Source/Scene/LabelCollection.js
@@ -619,9 +619,9 @@ define([
      * labels = labels && labels.destroy();
      */
     LabelCollection.prototype.destroy = function() {
-        // removeAll destroys the texture atlas
         this.removeAll();
-        this._billboardCollection.destroy();
+        this._billboardCollection = this._billboardCollection.destroy();
+        this._textureAtlas = this._textureAtlas && this._textureAtlas.destroy();
         return destroyObject(this);
     };
 

--- a/Specs/Scene/LabelCollectionSpec.js
+++ b/Specs/Scene/LabelCollectionSpec.js
@@ -1507,4 +1507,19 @@ defineSuite([
             label.computeScreenSpacePosition(context, undefined);
         }).toThrow();
     });
+
+    it('destroys texture atlas when destroying', function() {
+        labels.add({
+            text : 'a'
+        });
+        labels.update(context, frameState, []);
+
+        var textureAtlas = labels._textureAtlas;
+        expect(textureAtlas.isDestroyed()).toBe(false);
+
+        labels = labels.destroy();
+
+        expect(textureAtlas.isDestroyed()).toBe(true);
+    });
+
 }, 'WebGL');


### PR DESCRIPTION
One improvement and one bugfix I noticed while reviewing another pull request:
- The ID strings used for glyphs can be made smaller by representing colors as RGBA and by using the numeric value of the enumerations instead of the string name.
- LabelCollection leaked its texture atlas when being destroyed.
