### PR TITLE
Fix JSHint on Sandcastle examples

### DIFF
--- a/Tools/buildTasks/runJsHint.js
+++ b/Tools/buildTasks/runJsHint.js
@@ -26,7 +26,6 @@ var errors = [];
 
 var jsFileRegex = /\.js$/i;
 var htmlFileRegex = /\.html$/i;
-var sandcastleScriptRegex = /<script id="cesium_sandcastle_script">([\S\s]*?)<\/script>/img;
 
 var filesChecked = 0;
 forEachFile('sourcefiles', function(relativePath, file) {
@@ -45,6 +44,7 @@ forEachFile('sourcefiles', function(relativePath, file) {
         source = contents;
         options = jsHintOptions;
     } else if (htmlFileRegex.test(relativePath)) {
+        var sandcastleScriptRegex = /<script id="cesium_sandcastle_script">([\S\s]*?)<\/script>/img;
         var result = sandcastleScriptRegex.exec(contents);
         if (result === null) {
             return;


### PR DESCRIPTION
Because I apparently don't know how to use regexes, the Ant JSHint task would only check every other Sandcastle example.  Regexes with the global flag remember the last index they matched at and resume matching from that index the next time they're used.  To fix this, each match needs a new instance.
