### PR TITLE
Fixes #961: pan disabled in Columbus View

### DIFF
--- a/Source/Widgets/Viewer/viewerDynamicObjectMixin.js
+++ b/Source/Widgets/Viewer/viewerDynamicObjectMixin.js
@@ -98,14 +98,13 @@ define([
                     }
                     var sceneMode = viewer.scene.getFrameState().mode;
 
-                    if( sceneMode === SceneMode.COLUMBUS_VIEW || sceneMode  === SceneMode.SCENE2D) {
+                    if (sceneMode === SceneMode.COLUMBUS_VIEW || sceneMode === SceneMode.SCENE2D) {
                         viewer.scene.getScreenSpaceCameraController().enableTranslate = typeof value === 'undefined';
                     }
 
-                    if (sceneMode === SceneMode.COLUMBUS_VIEW || sceneMode === SceneMode.SCENE3D){
+                    if (sceneMode === SceneMode.COLUMBUS_VIEW || sceneMode === SceneMode.SCENE3D) {
                         viewer.scene.getScreenSpaceCameraController().enableTilt = typeof value === 'undefined';
                     }
-
                 }
             }
         });


### PR DESCRIPTION
This enables pan (translate) after the home button is clicked in 2D and columbus view.
