### PR TITLE
Consolidate .gitignore files in the root.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,14 @@
 /web.config
 .DS_Store
 Thumbs.db
+
+/Apps/Sandcastle/jsHintOptions.js
+/Apps/Sandcastle/gallery/gallery-index.js
+
+/Source/Cesium.js
+
+/Source/Shaders/*.js
+/Source/Shaders/*/*.js
+!/Source/Shaders/Shaders.profile.js
+
+/Specs/SpecList.js

--- a/Apps/Sandcastle/.gitignore
+++ b/Apps/Sandcastle/.gitignore
@@ -1,1 +1,0 @@
-/jsHintOptions.js

--- a/Apps/Sandcastle/gallery/.gitignore
+++ b/Apps/Sandcastle/gallery/.gitignore
@@ -1,1 +1,0 @@
-/gallery-index.js

--- a/Source/.gitignore
+++ b/Source/.gitignore
@@ -1,1 +1,0 @@
-/Cesium.js

--- a/Source/Shaders/.gitignore
+++ b/Source/Shaders/.gitignore
@@ -1,2 +1,0 @@
-*.js
-!/Shaders.profile.js

--- a/Specs/.gitignore
+++ b/Specs/.gitignore
@@ -1,1 +1,0 @@
-/SpecList.js


### PR DESCRIPTION
This makes it easier to copy various source folders for use in other projects without accidentally ignoring items.
