### PR TITLE
Fix Polyline Jitter

### DIFF
--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -61,19 +61,19 @@ define([
     var NUMBER_OF_PROPERTIES = Polyline.NUMBER_OF_PROPERTIES;
 
     var attributeIndices = {
-        positionHigh : 0,
-        positionLow : 1,
-        positionMorphHigh : 2,
-        positionMorphLow : 3,
-        prevPositionHigh : 4,
-        prevPositionLow : 5,
-        prevPositionMorphHigh : 6,
-        prevPositionMorphLow : 7,
-        nextPositionHigh : 8,
-        nextPositionLow : 9,
-        nextPositionMorphHigh : 10,
-        nextPositionMorphLow : 11,
-        texCoordExpandWidthAndShow : 12,
+        texCoordExpandWidthAndShow : 0,
+        position3DHigh : 1,
+        position3DLow : 2,
+        position2DHigh : 3,
+        position2DLow : 4,
+        prevPosition3DHigh : 5,
+        prevPosition3DLow : 6,
+        prevPosition2DHigh : 7,
+        prevPosition2DLow : 8,
+        nextPosition3DHigh : 9,
+        nextPosition3DLow : 10,
+        nextPosition2DHigh : 11,
+        nextPosition2DLow : 12,
         pickColor : 13
     };
 
@@ -757,73 +757,73 @@ define([
                     var vertexTexCoordExpandWidthAndShowBufferOffset = k * (texCoordExpandWidthAndShowSizeInBytes * CesiumMath.SIXTY_FOUR_KILOBYTES) - vbo * texCoordExpandWidthAndShowSizeInBytes;
 
                     var attributes = [{
-                        index : attributeIndices.positionHigh,
+                        index : attributeIndices.position3DHigh,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : positionHighOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.positionLow,
+                        index : attributeIndices.position3DLow,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : positionLowOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.positionMorphHigh,
+                        index : attributeIndices.position2DHigh,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : positionHighOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.positionMorphLow,
+                        index : attributeIndices.position2DLow,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : positionLowOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.prevPositionHigh,
+                        index : attributeIndices.prevPosition3DHigh,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : prevPositionHighOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.prevPositionLow,
+                        index : attributeIndices.prevPosition3DLow,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : prevPositionLowOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.prevPositionMorphHigh,
+                        index : attributeIndices.prevPosition2DHigh,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : prevPositionHighOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.prevPositionMorphLow,
+                        index : attributeIndices.prevPosition2DLow,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : prevPositionLowOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.nextPositionHigh,
+                        index : attributeIndices.nextPosition3DHigh,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : nextPositionHighOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.nextPositionLow,
+                        index : attributeIndices.nextPosition3DLow,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : nextPositionLowOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.nextPositionMorphHigh,
+                        index : attributeIndices.nextPosition2DHigh,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : nextPositionHighOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.nextPositionMorphLow,
+                        index : attributeIndices.nextPosition2DLow,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : nextPositionLowOffset,
@@ -843,35 +843,40 @@ define([
                         normalize : true
                     }];
 
-                    var buffer;
-                    var bufferProperty;
-                    var bufferMorph;
-                    var bufferPropertyMorph;
+                    var buffer3D;
+                    var bufferProperty3D;
+                    var buffer2D;
+                    var bufferProperty2D;
 
-                    if (typeof position3DBuffer === 'undefined') {
-                        buffer = collection._positionBuffer;
-                        bufferProperty = 'vertexBuffer';
-                        bufferMorph = emptyVertexBuffer;
-                        bufferPropertyMorph = 'value';
+                    if (mode === SceneMode.SCENE3D) {
+                        buffer3D = collection._positionBuffer;
+                        bufferProperty3D = 'vertexBuffer';
+                        buffer2D = emptyVertexBuffer;
+                        bufferProperty2D = 'value';
+                    } else if (mode === SceneMode.SCENE2D || mode === SceneMode.COLUMBUS_VIEW) {
+                        buffer3D = emptyVertexBuffer;
+                        bufferProperty3D = 'value';
+                        buffer2D = collection._positionBuffer;
+                        bufferProperty2D = 'vertexBuffer';
                     } else {
-                        buffer = collection._positionBuffer;
-                        bufferProperty = 'vertexBuffer';
-                        bufferMorph = position3DBuffer;
-                        bufferPropertyMorph = 'vertexBuffer';
+                        buffer3D = position3DBuffer;
+                        bufferProperty3D = 'vertexBuffer';
+                        buffer2D = collection._positionBuffer;
+                        bufferProperty2D = 'vertexBuffer';
                     }
 
-                    attributes[0][bufferProperty] = buffer;
-                    attributes[1][bufferProperty] = buffer;
-                    attributes[2][bufferPropertyMorph] = bufferMorph;
-                    attributes[3][bufferPropertyMorph] = bufferMorph;
-                    attributes[4][bufferProperty] = buffer;
-                    attributes[5][bufferProperty] = buffer;
-                    attributes[6][bufferPropertyMorph] = bufferMorph;
-                    attributes[7][bufferPropertyMorph] = bufferMorph;
-                    attributes[8][bufferProperty] = buffer;
-                    attributes[9][bufferProperty] = buffer;
-                    attributes[10][bufferPropertyMorph] = bufferMorph;
-                    attributes[11][bufferPropertyMorph] = bufferMorph;
+                    attributes[0][bufferProperty3D] = buffer3D;
+                    attributes[1][bufferProperty3D] = buffer3D;
+                    attributes[2][bufferProperty2D] = buffer2D;
+                    attributes[3][bufferProperty2D] = buffer2D;
+                    attributes[4][bufferProperty3D] = buffer3D;
+                    attributes[5][bufferProperty3D] = buffer3D;
+                    attributes[6][bufferProperty2D] = buffer2D;
+                    attributes[7][bufferProperty2D] = buffer2D;
+                    attributes[8][bufferProperty3D] = buffer3D;
+                    attributes[9][bufferProperty3D] = buffer3D;
+                    attributes[10][bufferProperty2D] = buffer2D;
+                    attributes[11][bufferProperty2D] = buffer2D;
 
                     var va = context.createVertexArray(attributes, indexBuffer);
                     collection._vertexArrays.push({

--- a/Source/Shaders/PolylineVS.glsl
+++ b/Source/Shaders/PolylineVS.glsl
@@ -1,15 +1,15 @@
-attribute vec3 positionHigh;
-attribute vec3 positionLow;
-attribute vec3 positionMorphHigh;
-attribute vec3 positionMorphLow;
-attribute vec3 prevPositionHigh;
-attribute vec3 prevPositionLow;
-attribute vec3 prevPositionMorphHigh;
-attribute vec3 prevPositionMorphLow;
-attribute vec3 nextPositionHigh;
-attribute vec3 nextPositionLow;
-attribute vec3 nextPositionMorphHigh;
-attribute vec3 nextPositionMorphLow;
+attribute vec3 position3DHigh;
+attribute vec3 position3DLow;
+attribute vec3 position2DHigh;
+attribute vec3 position2DLow;
+attribute vec3 prevPosition3DHigh;
+attribute vec3 prevPosition3DLow;
+attribute vec3 prevPosition2DHigh;
+attribute vec3 prevPosition2DLow;
+attribute vec3 nextPosition3DHigh;
+attribute vec3 nextPosition3DLow;
+attribute vec3 nextPosition2DHigh;
+attribute vec3 nextPosition2DLow;
 attribute vec4 texCoordExpandWidthAndShow;
 attribute vec4 pickColor;
 
@@ -68,29 +68,29 @@ void main()
     vec4 p, prev, next;
     if (czm_morphTime == 1.0)
     {
-        p = czm_translateRelativeToEye(positionHigh.xyz, positionLow.xyz);
-        prev = czm_translateRelativeToEye(prevPositionHigh.xyz, prevPositionLow.xyz);
-        next = czm_translateRelativeToEye(nextPositionHigh.xyz, nextPositionLow.xyz);
+        p = czm_translateRelativeToEye(position3DHigh.xyz, position3DLow.xyz);
+        prev = czm_translateRelativeToEye(prevPosition3DHigh.xyz, prevPosition3DLow.xyz);
+        next = czm_translateRelativeToEye(nextPosition3DHigh.xyz, nextPosition3DLow.xyz);
     }
     else if (czm_morphTime == 0.0)
     {
-        p = czm_translateRelativeToEye(positionHigh.zxy, positionLow.zxy);
-        prev = czm_translateRelativeToEye(prevPositionHigh.zxy, prevPositionLow.zxy);
-        next = czm_translateRelativeToEye(nextPositionHigh.zxy, nextPositionLow.zxy);
+        p = czm_translateRelativeToEye(position2DHigh.zxy, position2DLow.zxy);
+        prev = czm_translateRelativeToEye(prevPosition2DHigh.zxy, prevPosition2DLow.zxy);
+        next = czm_translateRelativeToEye(nextPosition2DHigh.zxy, nextPosition2DLow.zxy);
     }
     else
     {
         p = czm_columbusViewMorph(
-                czm_translateRelativeToEye(positionHigh.zxy, positionLow.zxy),
-                czm_translateRelativeToEye(positionMorphHigh.xyz, positionMorphLow.xyz),
+                czm_translateRelativeToEye(position2DHigh.zxy, position2DLow.zxy),
+                czm_translateRelativeToEye(position3DHigh.xyz, position3DLow.xyz),
                 czm_morphTime);
         prev = czm_columbusViewMorph(
-                czm_translateRelativeToEye(prevPositionHigh.zxy, prevPositionLow.zxy),
-                czm_translateRelativeToEye(prevPositionMorphHigh.xyz, prevPositionMorphLow.xyz),
+                czm_translateRelativeToEye(prevPosition2DHigh.zxy, prevPosition2DLow.zxy),
+                czm_translateRelativeToEye(prevPosition3DHigh.xyz, prevPosition3DLow.xyz),
                 czm_morphTime);
         next = czm_columbusViewMorph(
-                czm_translateRelativeToEye(nextPositionHigh.zxy, nextPositionLow.zxy),
-                czm_translateRelativeToEye(nextPositionMorphHigh.xyz, nextPositionMorphLow.xyz),
+                czm_translateRelativeToEye(nextPosition2DHigh.zxy, nextPosition2DLow.zxy),
+                czm_translateRelativeToEye(nextPosition3DHigh.xyz, nextPosition3DLow.xyz),
                 czm_morphTime);
     }
     
@@ -117,31 +117,31 @@ void main()
     float expandWidth = width * 0.5;
     vec2 direction;
 
-	if (czm_equalsEpsilon(normalize(prev.xyz - p.xyz), vec3(0.0), czm_epsilon1) || czm_equalsEpsilon(prevWC, -nextWC, czm_epsilon1))
-	{
-	    direction = vec2(-nextWC.y, nextWC.x);
+    if (czm_equalsEpsilon(normalize(prev.xyz - p.xyz), vec3(0.0), czm_epsilon1) || czm_equalsEpsilon(prevWC, -nextWC, czm_epsilon1))
+    {
+        direction = vec2(-nextWC.y, nextWC.x);
     }
-	else if (czm_equalsEpsilon(normalize(next.xyz - p.xyz), vec3(0.0), czm_epsilon1) || clipped)
-	{
+    else if (czm_equalsEpsilon(normalize(next.xyz - p.xyz), vec3(0.0), czm_epsilon1) || clipped)
+    {
         direction = vec2(prevWC.y, -prevWC.x);
     }
     else
     {
-	    vec2 normal = vec2(-nextWC.y, nextWC.x);
-	    direction = normalize((nextWC + prevWC) * 0.5);
-	    if (dot(direction, normal) < 0.0)
-	    {
-	        direction = -direction;
-	    }
-	    
-	    // The sine of the angle between the two vectors is given by the formula
-	    //         |a x b| = |a||b|sin(theta)
-	    // which is
-	    //     float sinAngle = length(cross(vec3(direction, 0.0), vec3(nextWC, 0.0)));
-	    // Because the z components of both vectors are zero, the x and y coordinate will be zero.
-	    // Therefore, the sine of the angle is just the z component of the cross product.
-	    float sinAngle = abs(direction.x * nextWC.y - direction.y * nextWC.x);
-	    expandWidth = clamp(expandWidth / sinAngle, 0.0, width * 2.0);
+        vec2 normal = vec2(-nextWC.y, nextWC.x);
+        direction = normalize((nextWC + prevWC) * 0.5);
+        if (dot(direction, normal) < 0.0)
+        {
+            direction = -direction;
+        }
+
+        // The sine of the angle between the two vectors is given by the formula
+        //         |a x b| = |a||b|sin(theta)
+        // which is
+        //     float sinAngle = length(cross(vec3(direction, 0.0), vec3(nextWC, 0.0)));
+        // Because the z components of both vectors are zero, the x and y coordinate will be zero.
+        // Therefore, the sine of the angle is just the z component of the cross product.
+        float sinAngle = abs(direction.x * nextWC.y - direction.y * nextWC.x);
+        expandWidth = clamp(expandWidth / sinAngle, 0.0, width * 2.0);
     }
 
     vec2 offset = direction * expandDir * expandWidth * czm_highResolutionSnapScale;


### PR DESCRIPTION
Fixes issues #990 and #951.

Issues were introduced in #950. Reverts attribute changes, but still back vertex attribute 0 by a buffer. Please also test with a Mac before merging.
