### PR TITLE
Don't rotate 2D in DynamicObjectView

### DIFF
--- a/Source/DynamicScene/DynamicObjectView.js
+++ b/Source/DynamicScene/DynamicObjectView.js
@@ -53,11 +53,6 @@ define([
             if (objectChanged || modeChanged) {
                 camera.controller.setPositionCartographic(cartographic);
 
-                //Set rotation to match offset.
-                Cartesian3.normalize(offset, camera.up);
-                Cartesian3.negate(camera.up, camera.up);
-                Cartesian3.cross(camera.direction, camera.up, camera.right);
-
                 //z is always zero in 2D for up and right
                 camera.up.z = 0;
                 Cartesian3.normalize(camera.up, camera.up);


### PR DESCRIPTION
When switching between scene modes in DynamicObjectView, the camera offset is maintained across modes.  Several people have been confused by this behavior in 2D, since it rotated the map.  This change eliminates the 2D rotation but maintains everything else.

See: https://groups.google.com/d/msg/cesium-dev/BEagEreTQ6A/aAfULgveI1oJ for a recent example.

If anyone complains about it going away, we'll put it back in as an option, but I didn't want to turn it into an option is no one likes it to begin with.
