### PR TITLE
Fix blob-based image loading in Firefox and IE11

### DIFF
--- a/Source/Core/loadImageViaBlob.js
+++ b/Source/Core/loadImageViaBlob.js
@@ -66,6 +66,7 @@ define([
     var xhrBlobSupported = (function() {
         try {
             var xhr = new XMLHttpRequest();
+            xhr.open('GET', '#', true);
             xhr.responseType = 'blob';
             return xhr.responseType === 'blob';
         } catch (e) {


### PR DESCRIPTION
Test responseType 'blob' after calling open.  Firefox and IE both throw when setting responseType before calling open, which seems to be not compliant with the spec, but whatever.  Because we never call send, this doesn't actually make any request.
