### PR TITLE
Bail out of render loop if CesiumWidget/Viewer is destroyed.

### DIFF
--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -57,6 +57,10 @@ define([
         widget._renderLoopRunning = true;
 
         function render() {
+            if (widget.isDestroyed()) {
+                return;
+            }
+
             try {
                 if (widget._useDefaultRenderLoop) {
                     widget.resize();

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -57,6 +57,10 @@ define([
         viewer._renderLoopRunning = true;
 
         function render() {
+            if (viewer.isDestroyed()) {
+                return;
+            }
+
             try {
                 if (viewer._useDefaultRenderLoop) {
                     viewer.resize();


### PR DESCRIPTION
This fixes a number of uncaught exceptions while running specs.  If the widget is destroyed, calling resize throws an exception, which is caught, but the exception handler then tries to raise onRenderLoopError, which has become undefined, which throws again.
