### PR TITLE
Update the Widget examples to use the Cesium prefix

### DIFF
--- a/Source/Widgets/Animation/Animation.js
+++ b/Source/Widgets/Animation/Animation.js
@@ -324,10 +324,10 @@ define([
      * // In HTML head, include a link to Animation.css stylesheet,
      * // and in the body, include: &lt;div id="animationContainer"&gt;&lt;/div&gt;
      *
-     * var clock = new Clock();
-     * var clockViewModel = new ClockViewModel(clock);
-     * var viewModel = new AnimationViewModel(clockViewModel);
-     * var widget = new Animation('animationContainer', viewModel);
+     * var clock = new Cesium.Clock();
+     * var clockViewModel = new Cesium.ClockViewModel(clock);
+     * var viewModel = new Cesium.AnimationViewModel(clockViewModel);
+     * var widget = new Cesium.Animation('animationContainer', viewModel);
      *
      * function tick() {
      *     clock.tick();

--- a/Source/Widgets/BaseLayerPicker/BaseLayerPicker.js
+++ b/Source/Widgets/BaseLayerPicker/BaseLayerPicker.js
@@ -44,30 +44,31 @@ define([
      *
      * @example
      * // In HTML head, include a link to the BaseLayerPicker.css stylesheet,
-     * // and in the body, include: &lt;div id="baseLayerPickerContainer"&gt;&lt;/div&gt;
+     * // and in the body, include: &lt;div id="baseLayerPickerContainer"
+     * //   style="position:absolute;top:24px;right:24px;width:38px;height:38px;"&gt;&lt;/div&gt;
      *
      * //Create the list of available providers we would like the user to select from.
      * //This example uses 3, OpenStreetMap, The Black Marble, and a single, non-streaming world image.
      * var providerViewModels = [];
-     * providerViewModels.push(new ImageryProviderViewModel({
+     * providerViewModels.push(new Cesium.ImageryProviderViewModel({
      *      name : 'Open\u00adStreet\u00adMap',
-     *      iconUrl : require.toUrl('../Images/ImageryProviders/openStreetMap.png'),
+     *      iconUrl : Cesium.buildModuleUrl('Widgets/Images/ImageryProviders/openStreetMap.png'),
      *      tooltip : 'OpenStreetMap (OSM) is a collaborative project to create a free editable \
      *map of the world.\nhttp://www.openstreetmap.org',
      *      creationFunction : function() {
-     *          return new OpenStreetMapImageryProvider({
+     *          return new Cesium.OpenStreetMapImageryProvider({
      *              url : 'http://tile.openstreetmap.org/'
      *          });
      *      }
      *  }));
      *
-     *  providerViewModels.push(new ImageryProviderViewModel({
+     *  providerViewModels.push(new Cesium.ImageryProviderViewModel({
      *      name : 'Black Marble',
-     *      iconUrl : require.toUrl('../Images/ImageryProviders/blackMarble.png'),
+     *      iconUrl : Cesium.buildModuleUrl('Widgets/Images/ImageryProviders/blackMarble.png'),
      *      tooltip : 'The lights of cities and villages trace the outlines of civilization \
      *in this global view of the Earth at night as seen by NASA/NOAA\'s Suomi NPP satellite.',
      *      creationFunction : function() {
-     *          return new TileMapServiceImageryProvider({
+     *          return new Cesium.TileMapServiceImageryProvider({
      *              url : 'http://cesium.agi.com/blackmarble',
      *              maximumLevel : 8,
      *              credit : 'Black Marble imagery courtesy NASA Earth Observatory'
@@ -75,20 +76,23 @@ define([
      *      }
      *  }));
      *
-     *  providerViewModels.push(new ImageryProviderViewModel({
+     *  providerViewModels.push(new Cesium.ImageryProviderViewModel({
      *      name : 'Natural Earth\u00a0II',
-     *      iconUrl : buildModuleUrl('Widgets/Images/ImageryProviders/naturalEarthII.png'),
+     *      iconUrl : Cesium.buildModuleUrl('Widgets/Images/ImageryProviders/naturalEarthII.png'),
      *      tooltip : 'Natural Earth II, darkened for contrast.\nhttp://www.naturalearthdata.com/',
      *      creationFunction : function() {
-     *          return new TileMapServiceImageryProvider({
-     *              url : buildModuleUrl('Assets/Textures/NaturalEarthII')
+     *          return new Cesium.TileMapServiceImageryProvider({
+     *              url : Cesium.buildModuleUrl('Assets/Textures/NaturalEarthII')
      *          });
      *      }
      *  }));
      *
-     * //Finally, create the actual widget using our view models.
-     * var layers = centralBody.getImageryLayers();
-     * var baseLayerPicker = new BaseLayerPicker('baseLayerPickerContainer', layers, providerViewModels);
+     * //Create a CesiumWidget without imagery, if you haven't already done so.
+     * var cesiumWidget = new Cesium.CesiumWidget('cesiumContainer', { imageryProvider: false });
+     *
+     * //Finally, create the baseLayerPicker widget using our view models.
+     * var layers = cesiumWidget.centralBody.getImageryLayers();
+     * var baseLayerPicker = new Cesium.BaseLayerPicker('baseLayerPickerContainer', layers, providerViewModels);
      *
      * //Use the first item in the list as the current selection.
      * baseLayerPicker.viewModel.selectedItem = providerViewModels[0];

--- a/Source/Widgets/SceneModePicker/SceneModePicker.js
+++ b/Source/Widgets/SceneModePicker/SceneModePicker.js
@@ -39,8 +39,8 @@ define([
      * // and in the body, include: &lt;div id="sceneModePickerContainer"&gt;&lt;/div&gt;
      * // Note: This code assumed you already have a Scene instance.
      *
-     * var transitioner = new SceneTransitioner(scene);
-     * var sceneModePicker = new SceneModePicker('sceneModePickerContainer', transitioner);
+     * var transitioner = new Cesium.SceneTransitioner(scene);
+     * var sceneModePicker = new Cesium.SceneModePicker('sceneModePickerContainer', transitioner);
      */
     var SceneModePicker = function(container, transitioner) {
         if (typeof container === 'undefined') {

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -120,34 +120,27 @@ define([
      *
      * @example
      * //Initialize the viewer widget with several custom options and mixins.
-     * var viewer = new Viewer('cesiumContainer', {
+     * var viewer = new Cesium.Viewer('cesiumContainer', {
      *     //Start in Columbus Viewer
-     *     sceneMode : SceneMode.COLUMBUS_VIEW,
+     *     sceneMode : Cesium.SceneMode.COLUMBUS_VIEW,
      *     //Use standard Cesium terrain
-     *     terrainProvider : new CesiumTerrainProvider({
+     *     terrainProvider : new Cesium.CesiumTerrainProvider({
      *         url : 'http://cesium.agi.com/smallterrain',
      *         credit : 'Terrain data courtesy Analytical Graphics, Inc.'
      *     }),
      *     //Hide the base layer picker
      *     baseLayerPicker : false,
      *     //Use OpenStreetMaps
-     *     selectedImageryProviderViewModel : new ImageryProviderViewModel({
-     *         name : 'Open\u00adStreet\u00adMap',
-     *         iconUrl : buildModuleUrl('Widgets/Images/ImageryProviders/openStreetMap.png'),
-     *         tooltip : 'OpenStreetMap (OSM) is a collaborative project to create a free editable map',
-     *         creationFunction : function() {
-     *             return new OpenStreetMapImageryProvider({
-     *                 url : 'http://tile.openstreetmap.org/'
-     *             });
-     *         }
+     *     imageryProvider : new Cesium.OpenStreetMapImageryProvider({
+     *         url : 'http://tile.openstreetmap.org/'
      *     })
      * });
      *
      * //Add basic drag and drop functionality
-     * viewer.extend(viewerDragDropMixin);
+     * viewer.extend(Cesium.viewerDragDropMixin);
      *
      * //Allow users to zoom and follow objects loaded from CZML by clicking on it.
-     * viewer.extend(viewerDynamicObjectMixin);
+     * viewer.extend(Cesium.viewerDynamicObjectMixin);
      *
      * //Show a pop-up alert if we encounter an error when processing a dropped file
      * viewer.onDropError.addEventListener(function(dropHandler, name, error) {

--- a/Source/Widgets/Viewer/viewerDragDropMixin.js
+++ b/Source/Widgets/Viewer/viewerDragDropMixin.js
@@ -42,8 +42,8 @@ define([
      *
      * @example
      * // Add basic drag and drop support and pop up an alert window on error.
-     * var viewer = new Viewer('cesiumContainer');
-     * viewer.extend(viewerDragDropMixin);
+     * var viewer = new Cesium.Viewer('cesiumContainer');
+     * viewer.extend(Cesium.viewerDragDropMixin);
      * viewer.onDropError.addEventListener(function(viewerArg, source, error) {
      *     window.alert('Error processing ' + source + ':' + error);
      * });

--- a/Source/Widgets/Viewer/viewerDynamicObjectMixin.js
+++ b/Source/Widgets/Viewer/viewerDynamicObjectMixin.js
@@ -34,9 +34,9 @@ define([
      *
      * @example
      * // Add support for working with DynamicObject instances to the Viewer.
-     * var dynamicObject = ... //A DynamicObject instance
-     * var viewer = new Viewer('cesiumContainer');
-     * viewer.extend(viewerDynamicObjectMixin);
+     * var dynamicObject = ... //A Cesium.DynamicObject instance
+     * var viewer = new Cesium.Viewer('cesiumContainer');
+     * viewer.extend(Cesium.viewerDynamicObjectMixin);
      * viewer.trackedObject = dynamicObject; //Camera will now track dynamicObject
      */
     var viewerDynamicObjectMixin = function(viewer) {


### PR DESCRIPTION
This updates just the Source/Widgets folder, not the whole source tree.  The complete examples here were tested and fixed to work correctly when copied-and-pasted verbatim into Sandcastle's Hello World (and should work equally in the stand-alone Hello World).

This is to head off FAQs on our mailing list about how to use drag-and-drop etc.
