### PR TITLE
Tentative fix for issue 416: TileMapServiceImageryProvider extent 

### DIFF
--- a/Apps/Sandcastle/gallery/Test Imagery Layers.html
+++ b/Apps/Sandcastle/gallery/Test Imagery Layers.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">  <!-- Use Chrome Frame in IE -->
+    <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
+    <meta name="description" content="Create imagery layers from multiple sources.">
+    <meta name="cesium-sandcastle-labels" content="Beginner, Tutorial">
+    <title>Cesium Demo</title>
+    <script type="text/javascript" src="../Sandcastle-header.js"></script>
+    <script type="text/javascript" src="../../../ThirdParty/requirejs-2.1.6/require.js"></script>
+    <script type="text/javascript">
+    require.config({
+        baseUrl : '../../../Source',
+        waitSeconds : 60
+    });
+    </script>
+</head>
+<body class="sandcastle-loading" data-sandcastle-bucket="bucket-requirejs.html" data-sandcastle-title="Cesium + require.js">
+<style>
+    @import url(../templates/bucket.css);
+</style>
+<div id="cesiumContainer" class="fullSize"></div>
+<div id="loadingOverlay"><h1>Loading...</h1></div>
+<script id="cesium_sandcastle_script">
+require(['Cesium'], function(Cesium) {
+    "use strict";
+
+    var widget = new Cesium.CesiumWidget('cesiumContainer');
+
+    var layers = widget.centralBody.getImageryLayers();
+    //layers.removeAll();
+/*    
+    layers.addImageryProvider(new Cesium.TileMapServiceImageryProvider({
+        url : 'http://cesium.agi.com/blackmarble',
+        maximumLevel : 8,
+        extent : new Cesium.Extent(
+            Cesium.Math.toRadians(-75.0),
+            Cesium.Math.toRadians(28.0),
+            Cesium.Math.toRadians(-67.0),
+            Cesium.Math.toRadians(29.75)),
+        credit : 'Black Marble imagery courtesy NASA Earth Observatory'
+    }));
+*/
+
+    layers.addImageryProvider(new Cesium.TileMapServiceImageryProvider({
+        url : '../images/cesium_maptiler/Cesium_Logo_Color',
+        maximumLevel : 4,
+        extent : new Cesium.Extent(
+            Cesium.Math.toRadians(-75.0),
+            Cesium.Math.toRadians(28.0),
+            Cesium.Math.toRadians(-67.0),
+            Cesium.Math.toRadians(29.75)),
+        credit : 'Black Marble imagery courtesy NASA Earth Observatory'
+    }));
+
+    
+    layers.addImageryProvider(new Cesium.SingleTileImageryProvider({
+        url : '../images/Cesium_Logo_overlay.png',
+        extent : new Cesium.Extent(
+            Cesium.Math.toRadians(-75.0),
+            Cesium.Math.toRadians(28.0),
+            Cesium.Math.toRadians(-67.0),
+            Cesium.Math.toRadians(29.75))
+    }));
+
+    
+    layers.addImageryProvider(new Cesium.TileCoordinatesImageryProvider());
+    
+    
+    
+    Sandcastle.finishedLoading();
+});
+</script>
+</body>
+</html>

--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -473,6 +473,7 @@ define([
 
         var terrainExtent = tile.extent;
         var imageryExtent = imageryTilingScheme.tileXYToExtent(northwestTileCoordinates.x, northwestTileCoordinates.y, imageryLevel);
+        imageryExtent = imageryExtent.intersectWith(extent);
 
         var minU;
         var maxU = 0.0;
@@ -497,6 +498,7 @@ define([
             minU = maxU;
 
             imageryExtent = imageryTilingScheme.tileXYToExtent(i, northwestTileCoordinates.y, imageryLevel);
+            imageryExtent = imageryExtent.intersectWith(extent);
             maxU = Math.min(1.0, (imageryExtent.east - terrainExtent.west) / (terrainExtent.east - terrainExtent.west));
 
             // If this is the eastern-most imagery tile mapped to this terrain tile,
@@ -513,6 +515,8 @@ define([
                 maxV = minV;
 
                 imageryExtent = imageryTilingScheme.tileXYToExtent(i, j, imageryLevel);
+                var imageryTileExtent = imageryExtent.clone();
+                imageryExtent = imageryExtent.intersectWith(extent);
                 minV = Math.max(0.0, (imageryExtent.south - terrainExtent.south) / (terrainExtent.north - terrainExtent.south));
 
                 // If this is the southern-most imagery tile mapped to this terrain tile,
@@ -524,7 +528,7 @@ define([
                 }
 
                 var texCoordsExtent = new Cartesian4(minU, minV, maxU, maxV);
-                var imagery = this.getImageryFromCache(i, j, imageryLevel, imageryExtent);
+                var imagery = this.getImageryFromCache(i, j, imageryLevel, imageryTileExtent);
                 tile.imagery.splice(insertionPoint, 0, new TileImagery(imagery, texCoordsExtent));
                 ++insertionPoint;
             }


### PR DESCRIPTION
The fix I implemented intersect
the extent of each tile (of the imagery service provider tiling scheme) which
contains some part of the imagery with the imagery extent.
However I noticed that the extent of each cached imagery (an imagery for each
tile) has to be the extent of the tile and not the extent of the intersection.
I committed also a Sandcastle example (Test Imagery Layer) that I utilized for
testing. 
