### PR TITLE
Fix `JulianDate.fromDate` input validation.

### DIFF
--- a/Source/Core/JulianDate.js
+++ b/Source/Core/JulianDate.js
@@ -339,7 +339,7 @@ define([
      * var julianDate = JulianDate.fromDate(date, TimeStandard.UTC);
      */
     JulianDate.fromDate = function(date, timeStandard) {
-        if (!defined(date) || date === null || isNaN(date.getTime())) {
+        if (!(date instanceof Date) || isNaN(date.getTime())) {
             throw new DeveloperError('date must be a valid JavaScript Date.');
         }
 

--- a/Specs/Core/JulianDateSpec.js
+++ b/Specs/Core/JulianDateSpec.js
@@ -214,27 +214,9 @@ function(JulianDate,
         }).toThrow();
     });
 
-    it('Fail to construct from a null JavaScript Date', function() {
-        expect(function() {
-            return JulianDate.fromDate(null);
-        }).toThrow();
-    });
-
     it('Fail to construct from an invalid JavaScript Date', function() {
         expect(function() {
             return JulianDate.fromDate(new Date(Date.parse('garbage')));
-        }).toThrow();
-    });
-
-    it('Fail to construct from a non-date JavaScript Date', function() {
-        expect(function() {
-            return JulianDate.fromDate(0);
-        }).toThrow();
-    });
-
-    it('Fail to construct from a JavaScript Date with null time standard', function() {
-        expect(function() {
-            return JulianDate.fromDate(new Date(), null);
         }).toThrow();
     });
 


### PR DESCRIPTION
Also remove a few old redunant specs.

JulianDate still needs a full clean-up pass at some point, but I resisted the urge to do any more for now.
