### PR TITLE
Add min/max terrain level option to ImageryLayer.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Beta Releases
 * Added `PolylinePipeline.scaleToSurface`.
 * Added `PolylinePipeline.scaleToGeodeticHeight`.
 * `Viewer` now automatically sets its clock to that of the first added `DataSource`, regardless of how it was added to the `DataSourceCollection`.  Previously, this was only done for dropped files by `viewerDragDropMixin`.
+* Added the ability to specify a `minimumTerrainLevel` and `maximumTerrainLevel` when constructing an `ImageryLayer`.  The layer will only be shown for terrain tiles within the specified range.
 
 ### b19 - 2013-08-01
 

--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -122,6 +122,10 @@ define([
      *        for texture filtering.  If this parameter is not specified, the maximum anisotropy supported
      *        by the WebGL stack will be used.  Larger values make the imagery look better in horizon
      *        views.
+     * @param {Number} [description.minimumTerrainLevel] The minimum terrain level-of-detail at which to show this imagery layer,
+     *                 or undefined to show it at all levels.  Level zero is the least-detailed level.
+     * @param {Number} [description.maximumTerrainLevel] The maximum terrain level-of-detail at which to show this imagery layer,
+     *                 or undefined to show it at all levels.  Level zero is the least-detailed level.
      */
     var ImageryLayer = function ImageryLayer(imageryProvider, description) {
         this._imageryProvider = imageryProvider;
@@ -220,6 +224,9 @@ define([
          * @default true
          */
         this.show = defaultValue(description.show, true);
+
+        this._minimumTerrainLevel = description.minimumTerrainLevel;
+        this._maximumTerrainLevel = description.maximumTerrainLevel;
 
         this._extent = defaultValue(description.extent, Extent.MAX_VALUE);
         this._maximumAnisotropy = description.maximumAnisotropy;
@@ -369,6 +376,13 @@ define([
      * @returns {Boolean} true if this layer overlaps any portion of the terrain tile; otherwise, false.
      */
     ImageryLayer.prototype._createTileImagerySkeletons = function(tile, terrainProvider, insertionPoint) {
+        if (defined(this._minimumTerrainLevel) && tile.level < this._minimumTerrainLevel) {
+            return false;
+        }
+        if (defined(this._maximumTerrainLevel) && tile.level > this._maximumTerrainLevel) {
+            return false;
+        }
+
         var imageryProvider = this._imageryProvider;
 
         if (!defined(insertionPoint)) {

--- a/Specs/Scene/ImageryLayerSpec.js
+++ b/Specs/Scene/ImageryLayerSpec.js
@@ -287,4 +287,51 @@ defineSuite([
             expect(tiles[1].imagery.length).toBe(0);
         });
     });
+
+    it('createTileImagerySkeletons honors the minimumTerrainLevel and maximumTerrainLevel properties', function() {
+        var provider = new SingleTileImageryProvider({
+            url : 'Data/Images/Green4x4.png'
+        });
+
+        var layer = new ImageryLayer(provider, {
+            minimumTerrainLevel : 2,
+            maximumTerrainLevel : 4
+        });
+
+        var layers = new ImageryLayerCollection();
+        layers.add(layer);
+
+        var terrainProvider = new EllipsoidTerrainProvider();
+
+        waitsFor(function() {
+            return provider.isReady() && terrainProvider.isReady();
+        }, 'imagery provider to become ready');
+
+        runs(function() {
+            var level0 = terrainProvider.getTilingScheme().createLevelZeroTiles();
+            var level1 = level0[0].getChildren();
+            var level2 = level1[0].getChildren();
+            var level3 = level2[0].getChildren();
+            var level4 = level3[0].getChildren();
+            var level5 = level4[0].getChildren();
+
+            layer._createTileImagerySkeletons(level0[0], terrainProvider);
+            expect(level0[0].imagery.length).toBe(0);
+
+            layer._createTileImagerySkeletons(level1[0], terrainProvider);
+            expect(level1[0].imagery.length).toBe(0);
+
+            layer._createTileImagerySkeletons(level2[0], terrainProvider);
+            expect(level2[0].imagery.length).toBe(1);
+
+            layer._createTileImagerySkeletons(level3[0], terrainProvider);
+            expect(level3[0].imagery.length).toBe(1);
+
+            layer._createTileImagerySkeletons(level4[0], terrainProvider);
+            expect(level4[0].imagery.length).toBe(1);
+
+            layer._createTileImagerySkeletons(level5[0], terrainProvider);
+            expect(level5[0].imagery.length).toBe(0);
+        });
+    });
 }, 'WebGL');


### PR DESCRIPTION
Add a simple construction-time option to limit the range of terrain tile levels to which an imagery layer applies.  This was requested in this thread:
https://groups.google.com/d/topic/cesium-dev/VkUB3cMn7dg/discussion
