### PR TITLE
Improved subsequent build speed

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -329,7 +329,6 @@
 					<include name="*.js" />
 					<exclude name="*.profile.js" />
 					<exclude name="cesiumWorkerBootstrapper.js" />
-					<exclude name="transferGeometry.js" />
 					<exclude name="createTaskProcessorWorker.js" />
 				</fileset>
 				<chainedmapper>


### PR DESCRIPTION
The build speed has increased substantially after the number of workers in Cesium was increased. This change makes it so that the workers are only built if a source file has been modified. It's kind of a brute force way to do this since any source file that's been modified will cause the workers to be rebuilt, even if they don't depend on that file. But, it does seem to work pretty well for the time being.
