### PR TITLE
Fix issue #1024 and #1052.

### DIFF
--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -668,13 +668,10 @@ define([
         'mat4' : Matrix4
     };
     function returnUniform(material, uniformId, originalUniformType) {
-        var uniformType;
         return function() {
             var uniforms = material.uniforms;
             var uniformValue = uniforms[uniformId];
-            if (!defined(uniformType)) {
-                uniformType = getUniformType(uniformValue);
-            }
+            var uniformType = getUniformType(uniformValue);
 
             if (originalUniformType === 'sampler2D' && (uniformType === originalUniformType || uniformValue instanceof Texture)) {
                 if (uniformType === originalUniformType) {


### PR DESCRIPTION
After a cube map uniform is bound through a material, any render call after that would try to reload the cub map when the uniform was bound.

@mramato Can you review this?
