### PR TITLE
Disable default near/far scaling of DynamicBillboards

### DIFF
--- a/Source/DynamicScene/DynamicBillboardVisualizer.js
+++ b/Source/DynamicScene/DynamicBillboardVisualizer.js
@@ -6,8 +6,6 @@ define([
         '../Core/Color',
         '../Core/Cartesian2',
         '../Core/Cartesian3',
-        '../Core/Ellipsoid',
-        '../Core/NearFarScalar',
         '../Scene/BillboardCollection',
         '../Scene/HorizontalOrigin',
         '../Scene/VerticalOrigin',
@@ -19,8 +17,6 @@ define([
         Color,
         Cartesian2,
         Cartesian3,
-        Ellipsoid,
-        NearFarScalar,
         BillboardCollection,
         HorizontalOrigin,
         VerticalOrigin,
@@ -200,7 +196,6 @@ define([
     };
 
     var position;
-    var lla;
     var color;
     var eyeOffset;
     var pixelOffset;
@@ -261,15 +256,6 @@ define([
             billboard.setScale(1.0);
             billboard.setHorizontalOrigin(HorizontalOrigin.CENTER);
             billboard.setVerticalOrigin(VerticalOrigin.CENTER);
-
-            // set default Billboard scaleByDistance based on altitude
-            position = positionProperty.getValue(time, position);
-            lla = Ellipsoid.WGS84.cartesianToCartographic(position);
-            if (lla.height < 8.0e5) {
-                billboard.setScaleByDistance(new NearFarScalar(1.5e2, 1.0, 8.0e6, 0.2));
-            } else {
-                billboard.setScaleByDistance(new NearFarScalar(1.0e2, 2.0, 3.2e7, 0.2));
-            }
         } else {
             billboard = dynamicBillboardVisualizer._billboardCollection.get(billboardVisualizerIndex);
         }


### PR DESCRIPTION
...  for now, until better defaults are identified or improved control over this feature can be defined.

My thought process here is that there is no clean way to reconfigure or disable the default DynamicBillboard near/far scaling.  Rather than forcing this onto all Cesium users, there should be a simple methodology for controlling this feature.  This will also provide time to identify better default settings, given the broad (and unknown) range of Cesium applications.
