### PR TITLE
Fix typos in DynamicObjectView

### DIFF
--- a/Source/DynamicScene/DynamicObjectView.js
+++ b/Source/DynamicScene/DynamicObjectView.js
@@ -99,7 +99,7 @@ define([
                 var toInertialDelta = Transforms.computeFixedToIcrfMatrix(deltaTime, update3DMatrix3Scratch2);
                 var toFixed;
 
-                if (!defined(toInertial) || defined(toInertialDelta)) {
+                if (!defined(toInertial) || !defined(toInertialDelta)) {
                     toFixed = Transforms.computeTemeToPseudoFixedMatrix(time, update3DMatrix3Scratch3);
                     toInertial = Matrix3.transpose(toFixed, update3DMatrix3Scratch1);
                     toInertialDelta = Transforms.computeTemeToPseudoFixedMatrix(deltaTime, update3DMatrix3Scratch2);
@@ -339,7 +339,7 @@ define([
             this._lastDynamicObject = dynamicObject;
 
             var viewFromProperty = this.dynamicObject.viewFrom;
-            if (!defined(viewFromProperty) || defined(viewFromProperty.getValue(time, offset))) {
+            if (!defined(viewFromProperty) || !defined(viewFromProperty.getValue(time, offset))) {
                 Cartesian3.clone(dynamicObjectViewDefaultOffset, offset);
             }
 


### PR DESCRIPTION
The typos were introduced by [this commit](https://github.com/AnalyticalGraphicsInc/cesium/commit/f3d64d3a59695b6f990135e0ecaa51517e5a4b26) ([first one](https://github.com/AnalyticalGraphicsInc/cesium/commit/f3d64d3a59695b6f990135e0ecaa51517e5a4b26#L119L99) , [second one](https://github.com/AnalyticalGraphicsInc/cesium/commit/f3d64d3a59695b6f990135e0ecaa51517e5a4b26#L119L337))
