### PR TITLE
Backout #1122

### DIFF
--- a/Source/DynamicScene/DynamicPolygonVisualizer.js
+++ b/Source/DynamicScene/DynamicPolygonVisualizer.js
@@ -210,6 +210,7 @@ define([
             } else {
                 polygonVisualizerIndex = dynamicPolygonVisualizer._polygonCollection.length;
                 polygon = new Polygon();
+                polygon.asynchronous = false;
                 dynamicPolygonVisualizer._polygonCollection.push(polygon);
                 dynamicPolygonVisualizer._primitives.add(polygon);
             }

--- a/Source/Scene/ExtentPrimitive.js
+++ b/Source/Scene/ExtentPrimitive.js
@@ -43,6 +43,7 @@ define([
      * @param {Number} [options.textureRotationAngle=0.0] The rotation of the texture coordinates, in radians. A positive rotation is counter-clockwise.
      * @param {Boolean} [options.show=true] Determines if this primitive will be shown.
      * @param {Material} [options.material=undefined] The surface appearance of the primitive.
+     * @param {Boolean} [options.asynchronous=true] Determines if the extent will be created asynchronously or block until ready.
      *
      * @example
      * var extentPrimitive = new ExtentPrimitive({
@@ -155,11 +156,9 @@ define([
          *
          * @type Boolean
          *
-         * @default false
-         *
-         * @private
+         * @default true
          */
-        this.asynchronous = defaultValue(options.asynchronous, false);
+        this.asynchronous = defaultValue(options.asynchronous, true);
 
         this._primitive = undefined;
     };

--- a/Source/Scene/Polygon.js
+++ b/Source/Scene/Polygon.js
@@ -138,10 +138,8 @@ define([
          * @type Boolean
          *
          * @default false
-         *
-         * @private
          */
-        this.asynchronous = defaultValue(options.asynchronous, false);
+        this.asynchronous = defaultValue(options.asynchronous, true);
 
         this._positions = options.positions;
         this._polygonHierarchy = options.polygonHierarchy;


### PR DESCRIPTION
As per @pjcozzi's request in #1122, make `Polygon` and `ExtentPrimitve` asynchronous by default again.

Make `DynamicPolygonVisualizer` set asynchonous to false to fix the original issue.
