### PR TITLE
Avoid dot notation for CZML properties `number`, `boolean`, and `string`

### DIFF
--- a/Source/DynamicScene/CzmlDataSource.js
+++ b/Source/DynamicScene/CzmlDataSource.js
@@ -252,9 +252,10 @@ define([
     }
 
     function unwrapInterval(type, czmlInterval, sourceUri) {
+        /*jshint sub:true*/
         switch (type) {
         case Boolean:
-            return defaultValue(czmlInterval.boolean, czmlInterval);
+            return defaultValue(czmlInterval['boolean'], czmlInterval);
         case Cartesian2:
             return czmlInterval.cartesian2;
         case Cartesian3:
@@ -268,9 +269,9 @@ define([
         case LabelStyle:
             return LabelStyle[defaultValue(czmlInterval.labelStyle, czmlInterval)];
         case Number:
-            return defaultValue(czmlInterval.number, czmlInterval);
+            return defaultValue(czmlInterval['number'], czmlInterval);
         case String:
-            return defaultValue(czmlInterval.string, czmlInterval);
+            return defaultValue(czmlInterval['string'], czmlInterval);
         case Quaternion:
             return czmlInterval.unitQuaternion;
         case VerticalOrigin:


### PR DESCRIPTION
While not officially [JavaScript reservered words](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Reserved_Words); some tools can't handle JavaScript properties named `boolean`, `number`, or `string`, which we use in CZML.  Changing them from dot notation to string based lookups works around these issues and has no affect on performance.
