### PR TITLE
Heading Tilt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,12 +8,14 @@ Beta Releases
 
 * Breaking changes:
    * Renamed `TextureWrap.CLAMP` to `TextureWrap.CLAMP_TO_EDGE`.
+   * Removed `getViewMatrix`, `getInverseViewMatrix`, `getInverseTransform`, `getPositionWC`, `getDirectionWC`, `getUpWC` and `getRightWC` from `Camera`. Instead, use the `viewMatrix`, `inverseViewMatrix`, `inverseTransform`, `positionWC`, `directionWC`, `upWC`, and `rightWC` properties.
+   * Removed `getProjectionMatrix` and `getInfiniteProjectionMatrix` from `PerspectiveFrustum`, `PerspectiveOffCenterFrustum` and `OrthographicFrustum`. Instead, use the `projectionMatrix` and `infiniteProjectionMatrix` properties.
 * Added `CorridorOutlineGeometry`.
 * Added `PolylineGeometry`, `PolylineColorAppearance`, and `PolylineMaterialAppearance`.
 * Added `colors` option to `SimplePolylineGeometry` for per vertex or per segment colors.
 * Improved runtime generation of GLSL shaders.
 * Added new built-in GLSL functions `czm_getLambertDiffuse` and `czm_getSpecular`.
-* Added `getHeading`, `setHeading`, `getTilt` and `setTilt` to `CameraController`.
+* Added `heading` and `tilt` properties to `CameraController`.
 * Made sun size accurate.
 * Added `Scene.sunBloom` to enable/disable the bloom filter on the sun. The bloom filter should be disabled for better frame rates on mobile devices.
 

--- a/Source/Renderer/UniformState.js
+++ b/Source/Renderer/UniformState.js
@@ -173,10 +173,10 @@ define([
     }
 
     function setCamera(uniformState, camera) {
-        Cartesian3.clone(camera.getPositionWC(), uniformState._cameraPosition);
-        Cartesian3.clone(camera.getDirectionWC(), uniformState._cameraDirection);
-        Cartesian3.clone(camera.getRightWC(), uniformState._cameraRight);
-        Cartesian3.clone(camera.getUpWC(), uniformState._cameraUp);
+        Cartesian3.clone(camera.positionWC, uniformState._cameraPosition);
+        Cartesian3.clone(camera.directionWC, uniformState._cameraDirection);
+        Cartesian3.clone(camera.rightWC, uniformState._cameraRight);
+        Cartesian3.clone(camera.upWC, uniformState._cameraUp);
         uniformState._encodedCameraPositionMCDirty = true;
     }
 
@@ -216,9 +216,9 @@ define([
      * @param {Object} frustum The frustum to synchronize with.
      */
     UniformState.prototype.updateFrustum = function(frustum) {
-        setProjection(this, frustum.getProjectionMatrix());
-        if (defined(frustum.getInfiniteProjectionMatrix)) {
-            setInfiniteProjection(this, frustum.getInfiniteProjectionMatrix());
+        setProjection(this, frustum.projectionMatrix);
+        if (defined(frustum.infiniteProjectionMatrix)) {
+            setInfiniteProjection(this, frustum.infiniteProjectionMatrix);
         }
         this._currentFrustum.x = frustum.near;
         this._currentFrustum.y = frustum.far;
@@ -239,8 +239,8 @@ define([
 
         var camera = frameState.camera;
 
-        setView(this, camera.getViewMatrix());
-        setInverseView(this, camera.getInverseViewMatrix());
+        setView(this, camera.viewMatrix);
+        setInverseView(this, camera.inverseViewMatrix);
         setCamera(this, camera);
 
         if (frameState.mode === SceneMode.SCENE2D) {

--- a/Source/Scene/Billboard.js
+++ b/Source/Scene/Billboard.js
@@ -797,8 +797,8 @@ define([
     Billboard._computeScreenSpacePosition = function(modelMatrix, position, eyeOffset, pixelOffset, context, frameState) {
         // This function is basically a stripped-down JavaScript version of BillboardCollectionVS.glsl
         var camera = frameState.camera;
-        var view = camera.getViewMatrix();
-        var projection = camera.frustum.getProjectionMatrix();
+        var view = camera.viewMatrix;
+        var projection = camera.frustum.projectionMatrix;
 
         // Model to eye coordinates
         var mv = view.multiply(modelMatrix);

--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -973,8 +973,8 @@ define([
         var size;
         var offset;
 
-        var toCenter = camera.getPositionWC().subtract(boundingVolume.center, scratchToCenter);
-        var proj = camera.getDirectionWC().multiplyByScalar(toCenter.dot(camera.getDirectionWC()), scratchProj);
+        var toCenter = camera.positionWC.subtract(boundingVolume.center, scratchToCenter);
+        var proj = camera.directionWC.multiplyByScalar(toCenter.dot(camera.directionWC), scratchProj);
         var distance = Math.max(0.0, proj.magnitude() - boundingVolume.radius);
 
         var canvas = context.getCanvas();

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -1,6 +1,7 @@
 /*global define*/
 define([
         '../Core/defined',
+        '../Core/defineProperties',
         '../Core/DeveloperError',
         '../Core/Math',
         '../Core/Ellipsoid',
@@ -11,6 +12,7 @@ define([
         './PerspectiveFrustum'
     ], function(
         defined,
+        defineProperties,
         DeveloperError,
         CesiumMath,
         Ellipsoid,
@@ -63,6 +65,7 @@ define([
          * @default {@link Matrix4.IDENTITY}
          *
          * @see Transforms
+         * @see Camera#inverseTransform
          */
         this.transform = Matrix4.IDENTITY.clone();
         this._transform = this.transform.clone();
@@ -229,82 +232,109 @@ define([
         }
     }
 
-    /**
-     * DOC_TBA
-     *
-     * @memberof Camera
-     *
-     * @returns {Matrix4} DOC_TBA
-     */
-    Camera.prototype.getInverseTransform = function() {
-        update(this);
-        return this._invTransform;
-    };
+    defineProperties(Camera.prototype, {
+        /**
+         * Gets the inverse camera transform.
+         *
+         * @memberof Camera
+         * @type {Matrix4}
+         * @default {@link Matrix4.IDENTITY}
+         *
+         * @see Camera#transform
+         */
+        inverseTransform : {
+            get : function () {
+                update(this);
+                return this._invTransform;
+            }
+        },
 
-    /**
-     * Returns the view matrix.
-     *
-     * @memberof Camera
-     *
-     * @returns {Matrix4} The view matrix.
-     *
-     * @see UniformState#getView
-     * @see UniformState#setView
-     * @see czm_view
-     */
-    Camera.prototype.getViewMatrix = function() {
-        update(this);
-        return this._viewMatrix;
-    };
+        /**
+         * The view matrix.
+         *
+         * @memberof Camera
+         * @type {Matrix4}
+         *
+         * @see UniformState#getView
+         * @see czm_view
+         * @see Camera#inverseViewMatrix
+         */
+        viewMatrix : {
+            get : function () {
+                update(this);
+                return this._viewMatrix;
+            }
+        },
 
-    /**
-     * DOC_TBA
-     * @memberof Camera
-     */
-    Camera.prototype.getInverseViewMatrix = function() {
-        update(this);
-        return this._invViewMatrix;
-    };
+        /**
+         * The inverse view matrix.
+         *
+         * @memberof Camera
+         * @type {Matrix4}
+         *
+         * @see UniformState#getInverseView
+         * @see czm_inverseView
+         * @see Camera#viewMatrix
+         */
+        inverseViewMatrix : {
+            get : function () {
+                update(this);
+                return this._invViewMatrix;
+            }
+        },
 
-    /**
-     * The position of the camera in world coordinates.
-     *
-     * @type {Cartesian3}
-     */
-    Camera.prototype.getPositionWC = function() {
-        update(this);
-        return this._positionWC;
-    };
+        /**
+         * The position of the camera in world coordinates.
+         *
+         * @memberof Camera
+         * @type {Cartesian3}
+         */
+        positionWC : {
+            get : function() {
+                update(this);
+                return this._positionWC;
+            }
+        },
 
-    /**
-     * The view direction of the camera in world coordinates.
-     *
-     * @type {Cartesian3}
-     */
-    Camera.prototype.getDirectionWC = function() {
-        update(this);
-        return this._directionWC;
-    };
+        /**
+         * The view direction of the camera in world coordinates.
+         *
+         * @memberof Camera
+         * @type {Cartesian3}
+         */
+        directionWC : {
+            get : function() {
+                update(this);
+                return this._directionWC;
+            }
+        },
 
-    /**
-     * The up direction of the camera in world coordinates.
-     *
-     * @type {Cartesian3}
-     */
-    Camera.prototype.getUpWC = function() {
-        update(this);
-        return this._upWC;
-    };
+        /**
+         * The up direction of the camera in world coordinates.
+         *
+         * @memberof Camera
+         * @type {Cartesian3}
+         */
+        upWC : {
+            get : function() {
+                update(this);
+                return this._upWC;
+            }
+        },
 
-    /**
-     * The right direction of the camera in world coordinates.
-     *
-     * @type {Cartesian3}
-     */
-    Camera.prototype.getRightWC = function() {
-        update(this);
-        return this._rightWC;
-    };
+        /**
+         * The right direction of the camera in world coordinates.
+         *
+         * @memberof Camera
+         * @type {Cartesian3}
+         */
+        rightWC : {
+            get : function() {
+                update(this);
+                return this._rightWC;
+            }
+        }
+    });
 
     /**
      * Returns a duplicate of a Camera instance.
@@ -339,7 +369,7 @@ define([
         if (!defined(cartesian)) {
             throw new DeveloperError('cartesian is required.');
         }
-        return Matrix4.multiplyByVector(this.getInverseTransform(), cartesian, result);
+        return Matrix4.multiplyByVector(this.inverseTransform, cartesian, result);
     };
 
     /**

--- a/Source/Scene/CameraController.js
+++ b/Source/Scene/CameraController.js
@@ -2,6 +2,7 @@
 define([
         '../Core/defaultValue',
         '../Core/defined',
+        '../Core/defineProperties',
         '../Core/Cartesian2',
         '../Core/Cartesian3',
         '../Core/Cartesian4',
@@ -20,6 +21,7 @@ define([
     ], function(
         defaultValue,
         defined,
+        defineProperties,
         Cartesian2,
         Cartesian3,
         Cartesian4,
@@ -407,15 +409,15 @@ define([
         var camera = controller._camera;
         var oldTransform;
         if (defined(transform)) {
-            var position = Cartesian3.clone(camera.getPositionWC(), appendTransformPosition);
-            var up = Cartesian3.clone(camera.getUpWC(), appendTransformUp);
-            var right = Cartesian3.clone(camera.getRightWC(), appendTransformRight);
-            var direction = Cartesian3.clone(camera.getDirectionWC(), appendTransformDirection);
+            var position = Cartesian3.clone(camera.positionWC, appendTransformPosition);
+            var up = Cartesian3.clone(camera.upWC, appendTransformUp);
+            var right = Cartesian3.clone(camera.rightWC, appendTransformRight);
+            var direction = Cartesian3.clone(camera.directionWC, appendTransformDirection);
 
             oldTransform = camera.transform;
             camera.transform = transform.multiply(oldTransform);
 
-            var invTransform = camera.getInverseTransform();
+            var invTransform = camera.inverseTransform;
             Cartesian3.clone(Matrix4.multiplyByVector(invTransform, position, position), camera.position);
             Cartesian3.clone(Matrix4.multiplyByVector(invTransform, up, up), camera.up);
             Cartesian3.clone(Matrix4.multiplyByVector(invTransform, right, right), camera.right);
@@ -431,13 +433,13 @@ define([
     function revertTransform(controller, transform) {
         if (defined(transform)) {
             var camera = controller._camera;
-            var position = Cartesian3.clone(camera.getPositionWC(), revertTransformPosition);
-            var up = Cartesian3.clone(camera.getUpWC(), revertTransformUp);
-            var right = Cartesian3.clone(camera.getRightWC(), revertTransformRight);
-            var direction = Cartesian3.clone(camera.getDirectionWC(), revertTransformDirection);
+            var position = Cartesian3.clone(camera.positionWC, revertTransformPosition);
+            var up = Cartesian3.clone(camera.upWC, revertTransformUp);
+            var right = Cartesian3.clone(camera.rightWC, revertTransformRight);
+            var direction = Cartesian3.clone(camera.directionWC, revertTransformDirection);
 
             camera.transform = transform;
-            transform = camera.getInverseTransform();
+            transform = camera.inverseTransform;
 
             position = Cartesian3.clone(Matrix4.multiplyByVector(transform, position, position), camera.position);
             up = Cartesian3.clone(Matrix4.multiplyByVector(transform, up, up), camera.up);
@@ -757,25 +759,9 @@ define([
 
     function getHeading3D(controller) {
         var camera = controller._camera;
-        var z = Matrix4.multiplyByVector(camera.getViewMatrix(), Cartesian4.UNIT_Z, scratchHeadingCartesian4);
+        var z = Matrix4.multiplyByVector(camera.viewMatrix, Cartesian4.UNIT_Z, scratchHeadingCartesian4);
         return CesiumMath.PI_OVER_TWO - Math.atan2(z.y, z.x);
     }
-
-    /**
-     * Gets the camera heading.
-     * @memberof CameraController
-     *
-     * @returns {Number} The camera heading in radians.
-     */
-    CameraController.prototype.getHeading = function() {
-        if (this._mode === SceneMode.SCENE2D || this._mode === SceneMode.COLUMBUS_VIEW) {
-            return getHeading2D(this);
-        } else if (this._mode === SceneMode.SCENE3D) {
-            return getHeading3D(this);
-        }
-
-        return undefined;
-    };
 
     function setHeading2D(controller, angle) {
         var rightAngle = getHeading2D(controller);
@@ -793,26 +779,6 @@ define([
         angle = upAngle - angle;
         controller.look(axis, angle);
     }
-
-    /**
-     * Sets the camera heading.
-     * @memberof CameraController
-     *
-     * @param {Number} angle The heading in radians.
-     *
-     * @exception {DeveloperError} angle is required.
-     */
-    CameraController.prototype.setHeading = function(angle) {
-        if (!defined(angle)) {
-            throw new DeveloperError('angle is required.');
-        }
-
-        if (this._mode === SceneMode.SCENE2D || this._mode === SceneMode.COLUMBUS_VIEW) {
-            setHeading2D(this, angle);
-        } else if (this._mode === SceneMode.SCENE3D) {
-            setHeading3D(this, angle);
-        }
-    };
 
     function getTiltCV(controller) {
         var camera = controller._camera;
@@ -832,46 +798,72 @@ define([
         return CesiumMath.PI_OVER_TWO - Math.acos(Cartesian3.dot(camera.direction, direction));
     }
 
-    /**
-     * Gets the camera tilt.
-     * @memberof CameraController
-     *
-     * @returns {Number} The camera tilt in radians.
-     */
-    CameraController.prototype.getTilt = function() {
-        if (this._mode === SceneMode.COLUMBUS_VIEW) {
-            return getTiltCV(this);
-        } else if (this._mode === SceneMode.SCENE3D) {
-            return getTilt3D(this);
+    defineProperties(CameraController.prototype, {
+        /**
+         * The camera heading in radians.
+         * @memberof CameraController
+         *
+         * @type {Number}
+         */
+        heading : {
+            get : function () {
+                if (this._mode === SceneMode.SCENE2D || this._mode === SceneMode.COLUMBUS_VIEW) {
+                    return getHeading2D(this);
+                } else if (this._mode === SceneMode.SCENE3D) {
+                    return getHeading3D(this);
+                }
+
+                return undefined;
+            },
+            //TODO See https://github.com/AnalyticalGraphicsInc/cesium/issues/832
+            //* @exception {DeveloperError} angle is required.
+            set : function (angle) {
+                if (!defined(angle)) {
+                    throw new DeveloperError('angle is required.');
+                }
+
+                if (this._mode === SceneMode.SCENE2D || this._mode === SceneMode.COLUMBUS_VIEW) {
+                    setHeading2D(this, angle);
+                } else if (this._mode === SceneMode.SCENE3D) {
+                    setHeading3D(this, angle);
+                }
+            }
+        },
+
+        /**
+         * The the camera tilt in radians
+         * @memberof CameraController
+         *
+         * @type {Number}
+         */
+        tilt : {
+            get : function() {
+                if (this._mode === SceneMode.COLUMBUS_VIEW) {
+                    return getTiltCV(this);
+                } else if (this._mode === SceneMode.SCENE3D) {
+                    return getTilt3D(this);
+                }
+
+                return undefined;
+            },
+            //TODO See https://github.com/AnalyticalGraphicsInc/cesium/issues/832
+            //* @exception {DeveloperError} angle is required.
+            set : function(angle) {
+                if (!defined(angle)) {
+                    throw new DeveloperError('angle is required.');
+                }
+
+                if (this._mode === SceneMode.COLUMBUS_VIEW || this._mode === SceneMode.SCENE3D) {
+                    var camera = this._camera;
+
+                    angle = CesiumMath.clamp(angle, 0.0, CesiumMath.PI_OVER_TWO);
+                    angle = angle - this.tilt;
+
+                    this.look(camera.right, angle);
+                }
+            }
         }
-
-        return undefined;
-    };
-
-    /**
-     * Sets the camera tilt.
-     * @memberof CameraController
-     *
-     * @param {Number} angle The tilt in radians.
-     *
-     * @exception {DeveloperError} angle is required.
-     */
-    CameraController.prototype.setTilt = function(angle) {
-        if (!defined(angle)) {
-            throw new DeveloperError('angle is required.');
-        }
-
-        if (this._mode === SceneMode.COLUMBUS_VIEW || this._mode === SceneMode.SCENE3D) {
-            var camera = this._camera;
-
-            angle = CesiumMath.clamp(angle, 0.0, CesiumMath.PI_OVER_TWO);
-
-            var tilt = this.getTilt();
-            angle = angle - tilt;
-
-            this.look(camera.right, angle);
-        }
-    };
+    });
 
     /**
      * Sets the camera position and orientation with an eye position, target, and up vector.
@@ -986,7 +978,7 @@ define([
 
         var transform = Matrix4.clone(camera.transform, viewExtentCVTransform);
         transform.setColumn(3, Cartesian4.UNIT_W);
-        var invTransform = camera.getInverseTransform();
+        var invTransform = camera.inverseTransform;
 
         var cart = viewExtentCVCartographic;
         cart.longitude = east;
@@ -1224,13 +1216,13 @@ define([
         var x = (2.0 / width) * windowPosition.x - 1.0;
         var y = (2.0 / height) * (height - windowPosition.y) - 1.0;
 
-        var position = camera.getPositionWC();
+        var position = camera.positionWC;
         Cartesian3.clone(position, result.origin);
 
-        var nearCenter = Cartesian3.multiplyByScalar(camera.getDirectionWC(), near, pickPerspCenter);
+        var nearCenter = Cartesian3.multiplyByScalar(camera.directionWC, near, pickPerspCenter);
         Cartesian3.add(position, nearCenter, nearCenter);
-        var xDir = Cartesian3.multiplyByScalar(camera.getRightWC(), x * near * tanTheta, pickPerspXDir);
-        var yDir = Cartesian3.multiplyByScalar(camera.getUpWC(), y * near * tanPhi, pickPerspYDir);
+        var xDir = Cartesian3.multiplyByScalar(camera.rightWC, x * near * tanTheta, pickPerspXDir);
+        var yDir = Cartesian3.multiplyByScalar(camera.upWC, y * near * tanPhi, pickPerspYDir);
         var direction = Cartesian3.add(nearCenter, xDir, result.direction);
         Cartesian3.add(direction, yDir, direction);
         Cartesian3.subtract(direction, position, direction);
@@ -1253,7 +1245,7 @@ define([
         origin.x += x;
         origin.y += y;
 
-        Cartesian3.clone(camera.getDirectionWC(), result.direction);
+        Cartesian3.clone(camera.directionWC, result.direction);
 
         return result;
     }
@@ -1367,7 +1359,7 @@ define([
         var updateCV = function(value) {
             var interp = position.lerp(newPosition, value.time);
             var pos = new Cartesian4(interp.x, interp.y, interp.z, 1.0);
-            camera.position = Cartesian3.fromCartesian4(camera.getInverseTransform().multiplyByVector(pos));
+            camera.position = Cartesian3.fromCartesian4(camera.inverseTransform.multiplyByVector(pos));
         };
 
         return {
@@ -1388,7 +1380,7 @@ define([
         var position = camera.position;
         var direction = camera.direction;
 
-        var normal = Cartesian3.fromCartesian4(camera.getInverseTransform().multiplyByVector(Cartesian4.UNIT_X));
+        var normal = Cartesian3.fromCartesian4(camera.inverseTransform.multiplyByVector(Cartesian4.UNIT_X));
         var scalar = -normal.dot(position) / normal.dot(direction);
         var center = position.add(direction.multiplyByScalar(scalar));
         center = new Cartesian4(center.x, center.y, center.z, 1.0);

--- a/Source/Scene/CentralBody.js
+++ b/Source/Scene/CentralBody.js
@@ -257,7 +257,7 @@ define([
 
     function computeDepthQuad(centralBody, frameState) {
         var radii = centralBody._ellipsoid.getRadii();
-        var p = frameState.camera.getPositionWC();
+        var p = frameState.camera.positionWC;
 
         // Find the corresponding position in the scaled space of the ellipsoid.
         var q = centralBody._ellipsoid.getOneOverRadii().multiplyComponents(p);
@@ -687,7 +687,7 @@ define([
             this._hasWaterMask = hasWaterMask;
         }
 
-        var cameraPosition = frameState.camera.getPositionWC();
+        var cameraPosition = frameState.camera.positionWC;
 
         this._occluder.setCameraPosition(cameraPosition);
 

--- a/Source/Scene/CentralBodySurface.js
+++ b/Source/Scene/CentralBodySurface.js
@@ -358,7 +358,7 @@ define([
             }
         }
 
-        var cameraPosition = frameState.camera.getPositionWC();
+        var cameraPosition = frameState.camera.positionWC;
 
         var ellipsoid = surface._terrainProvider.getTilingScheme().getEllipsoid();
         var cameraPositionCartographic = ellipsoid.cartesianToCartographic(cameraPosition);
@@ -797,7 +797,7 @@ define([
     var centerEyeScratch = new Cartesian4();
 
     function createRenderCommandsForSelectedTiles(surface, context, frameState, shaderSet, projection, centralBodyUniformMap, colorCommandList, renderState) {
-        var viewMatrix = frameState.camera.getViewMatrix();
+        var viewMatrix = frameState.camera.viewMatrix;
 
         var maxTextures = context.getMaximumTextureImageUnits();
 

--- a/Source/Scene/OrthographicFrustum.js
+++ b/Source/Scene/OrthographicFrustum.js
@@ -1,6 +1,7 @@
 /*global define*/
 define([
         '../Core/defined',
+        '../Core/defineProperties',
         '../Core/DeveloperError',
         '../Core/destroyObject',
         '../Core/Cartesian2',
@@ -10,6 +11,7 @@ define([
         '../Scene/CullingVolume'
     ], function(
         defined,
+        defineProperties,
         DeveloperError,
         destroyObject,
         Cartesian2,
@@ -92,18 +94,6 @@ define([
         this._orthographicMatrix = undefined;
     };
 
-    /**
-     * Returns the orthographic projection matrix computed from the view frustum.
-     *
-     * @memberof OrthographicFrustum
-     *
-     * @returns {Matrix4} The orthographic projection matrix.
-     */
-    OrthographicFrustum.prototype.getProjectionMatrix = function() {
-        update(this);
-        return this._orthographicMatrix;
-    };
-
     function update(frustum) {
         if (!defined(frustum.right) || !defined(frustum.left) ||
             !defined(frustum.top) || !defined(frustum.bottom) ||
@@ -136,6 +126,20 @@ define([
             frustum._orthographicMatrix = Matrix4.computeOrthographicOffCenter(frustum.left, frustum.right, frustum.bottom, frustum.top, frustum.near, frustum.far);
         }
     }
+
+    defineProperties(OrthographicFrustum.prototype, {
+        /**
+         * The orthographic projection matrix computed from the view frustum.
+         * @memberof OrthographicFrustum
+         * @type {Matrix4}
+         */
+        projectionMatrix : {
+            get : function() {
+                update(this);
+                return this._orthographicMatrix;
+            }
+        }
+    });
 
     var getPlanesRight = new Cartesian3();
     var getPlanesNearCenter = new Cartesian3();

--- a/Source/Scene/PerspectiveFrustum.js
+++ b/Source/Scene/PerspectiveFrustum.js
@@ -1,10 +1,12 @@
 /*global define*/
 define([
         '../Core/defined',
+        '../Core/defineProperties',
         '../Core/DeveloperError',
         '../Scene/PerspectiveOffCenterFrustum'
     ], function(
         defined,
+        defineProperties,
         DeveloperError,
         PerspectiveOffCenterFrustum) {
     "use strict";
@@ -63,34 +65,6 @@ define([
         this._far = this.far;
     };
 
-    /**
-     * Returns the perspective projection matrix computed from the view frustum.
-     *
-     * @memberof PerspectiveFrustum
-     *
-     * @returns {Matrix4} The perspective projection matrix.
-     *
-     * @see PerspectiveFrustum#getInfiniteProjectionMatrix
-     */
-    PerspectiveFrustum.prototype.getProjectionMatrix = function() {
-        update(this);
-        return this._offCenterFrustum.getProjectionMatrix();
-    };
-
-    /**
-     * Returns the perspective projection matrix computed from the view frustum with an infinite far plane.
-     *
-     * @memberof PerspectiveFrustum
-     *
-     * @returns {Matrix4} The infinite perspective projection matrix.
-     *
-     * @see PerspectiveFrustum#getProjectionMatrix
-     */
-    PerspectiveFrustum.prototype.getInfiniteProjectionMatrix = function() {
-        update(this);
-        return this._offCenterFrustum.getInfiniteProjectionMatrix();
-    };
-
     function update(frustum) {
         if (!defined(frustum.fovy) || !defined(frustum.aspectRatio) || !defined(frustum.near) || !defined(frustum.far)) {
             throw new DeveloperError('fovy, aspectRatio, near, or far parameters are not set.');
@@ -125,6 +99,36 @@ define([
             f.far = frustum.far;
         }
     }
+
+    defineProperties(PerspectiveFrustum.prototype, {
+        /**
+         * The perspective projection matrix computed from the view frustum.
+         * @memberof PerspectiveFrustum
+         * @type {Matrix4}
+         *
+         * @see PerspectiveFrustum#infiniteProjectionMatrix
+         */
+        projectionMatrix : {
+            get : function() {
+                update(this);
+                return this._offCenterFrustum.projectionMatrix;
+            }
+        },
+
+        /**
+         * The perspective projection matrix computed from the view frustum with an infinite far plane.
+         * @memberof PerspectiveFrustum
+         * @type {Matrix4}
+         *
+         * @see PerspectiveFrustum#projectionMatrix
+         */
+        infiniteProjectionMatrix : {
+            get : function() {
+                update(this);
+                return this._offCenterFrustum.infiniteProjectionMatrix;
+            }
+        }
+    });
 
     /**
      * Creates a culling volume for this frustum.

--- a/Source/Scene/PerspectiveOffCenterFrustum.js
+++ b/Source/Scene/PerspectiveOffCenterFrustum.js
@@ -3,6 +3,7 @@ define([
         '../Core/DeveloperError',
         '../Core/defaultValue',
         '../Core/defined',
+        '../Core/defineProperties',
         '../Core/destroyObject',
         '../Core/Cartesian2',
         '../Core/Cartesian3',
@@ -13,6 +14,7 @@ define([
         DeveloperError,
         defaultValue,
         defined,
+        defineProperties,
         destroyObject,
         Cartesian2,
         Cartesian3,
@@ -95,34 +97,6 @@ define([
         this._infinitePerspective = undefined;
     };
 
-    /**
-     * Returns the perspective projection matrix computed from the view frustum.
-     *
-     * @memberof PerspectiveOffCenterFrustum
-     *
-     * @returns {Matrix4} The perspective projection matrix.
-     *
-     * @see PerspectiveOffCenterFrustum#getInfiniteProjectionMatrix
-     */
-    PerspectiveOffCenterFrustum.prototype.getProjectionMatrix = function() {
-        update(this);
-        return this._perspectiveMatrix;
-    };
-
-    /**
-     * Returns the perspective projection matrix computed from the view frustum with an infinite far plane.
-     *
-     * @memberof PerspectiveOffCenterFrustum
-     *
-     * @returns {Matrix4} The infinite perspective projection matrix.
-     *
-     * @see PerspectiveOffCenterFrustum#getProjectionMatrix
-     */
-    PerspectiveOffCenterFrustum.prototype.getInfiniteProjectionMatrix = function() {
-        update(this);
-        return this._infinitePerspective;
-    };
-
     function update(frustum) {
         if (!defined(frustum.right) || !defined(frustum.left) ||
             !defined(frustum.top) || !defined(frustum.bottom) ||
@@ -155,6 +129,36 @@ define([
             frustum._infinitePerspective = Matrix4.computeInfinitePerspectiveOffCenter(l, r, b, t, n);
         }
     }
+
+    defineProperties(PerspectiveOffCenterFrustum.prototype, {
+        /**
+         * The perspective projection matrix computed from the view frustum.
+         * @memberof PerspectiveOffCenterFrustum
+         * @type {Matrix4}
+         *
+         * @see PerspectiveOffCenterFrustum#infiniteProjectionMatrix
+         */
+        projectionMatrix : {
+            get : function() {
+                update(this);
+                return this._perspectiveMatrix;
+            }
+        },
+
+        /**
+         * The perspective projection matrix computed from the view frustum with an infinite far plane.
+         * @memberof PerspectiveOffCenterFrustum
+         * @type {Matrix4}
+         *
+         * @see PerspectiveOffCenterFrustum#projectionMatrix
+         */
+        infiniteProjectionMatrix : {
+            get : function() {
+                update(this);
+                return this._infinitePerspective;
+            }
+        }
+    });
 
     var getPlanesRight = new Cartesian3();
     var getPlanesNearCenter = new Cartesian3();

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -383,7 +383,7 @@ define([
         frameState.frameNumber = frameNumber;
         frameState.time = time;
         frameState.camera = camera;
-        frameState.cullingVolume = camera.frustum.computeCullingVolume(camera.getPositionWC(), camera.getDirectionWC(), camera.getUpWC());
+        frameState.cullingVolume = camera.frustum.computeCullingVolume(camera.positionWC, camera.directionWC, camera.upWC);
         frameState.occluder = undefined;
         frameState.canvasDimensions.x = scene._canvas.clientWidth;
         frameState.canvasDimensions.y = scene._canvas.clientHeight;
@@ -393,7 +393,7 @@ define([
         var cb = scene._primitives.getCentralBody();
         if (scene.mode === SceneMode.SCENE3D && defined(cb)) {
             var ellipsoid = cb.getEllipsoid();
-            var occluder = new Occluder(new BoundingSphere(Cartesian3.ZERO, ellipsoid.getMinimumRadius()), camera.getPositionWC());
+            var occluder = new Occluder(new BoundingSphere(Cartesian3.ZERO, ellipsoid.getMinimumRadius()), camera.positionWC);
             frameState.occluder = occluder;
         }
 
@@ -469,8 +469,8 @@ define([
         var cullingVolume = scene._frameState.cullingVolume;
         var camera = scene._camera;
 
-        var direction = camera.getDirectionWC();
-        var position = camera.getPositionWC();
+        var direction = camera.directionWC;
+        var position = camera.positionWC;
 
         if (scene.debugShowFrustums) {
             scene.debugFrustumStatistics = {
@@ -833,7 +833,7 @@ define([
         ortho.near = frustum.near;
         ortho.far = frustum.far;
 
-        return ortho.computeCullingVolume(position, camera.getDirectionWC(), camera.getUpWC());
+        return ortho.computeCullingVolume(position, camera.directionWC, camera.upWC);
     }
 
     var perspPickingFrustum = new PerspectiveOffCenterFrustum();
@@ -867,7 +867,7 @@ define([
         offCenter.near = near;
         offCenter.far = frustum.far;
 
-        return offCenter.computeCullingVolume(camera.getPositionWC(), camera.getDirectionWC(), camera.getUpWC());
+        return offCenter.computeCullingVolume(camera.positionWC, camera.directionWC, camera.upWC);
     }
 
     function getPickCullingVolume(scene, windowPosition, width, height) {

--- a/Source/Scene/ScreenSpaceCameraController.js
+++ b/Source/Scene/ScreenSpaceCameraController.js
@@ -724,7 +724,7 @@ define([
         cameraController.rotateUp(deltaTheta, transform);
 
         if (defined(restrictedAngle)) {
-            var direction = Cartesian3.clone(cameraController._camera.getDirectionWC(), rotate3DRestrictedDirection);
+            var direction = Cartesian3.clone(cameraController._camera.directionWC, rotate3DRestrictedDirection);
             var invTransform = transform.inverseTransformation();
             Matrix4.multiplyByVector(invTransform, direction, direction);
 

--- a/Source/Scene/SkyAtmosphere.js
+++ b/Source/Scene/SkyAtmosphere.js
@@ -169,7 +169,7 @@ define([
             this._spSkyFromAtmosphere = shaderCache.getShaderProgram(vs, SkyAtmosphereFS);
         }
 
-        var cameraPosition = frameState.camera.getPositionWC();
+        var cameraPosition = frameState.camera.positionWC;
 
         this._fCameraHeight2 = cameraPosition.magnitudeSquared();
         this._fCameraHeight = Math.sqrt(this._fCameraHeight2);

--- a/Specs/Renderer/AutomaticUniformSpec.js
+++ b/Specs/Renderer/AutomaticUniformSpec.js
@@ -44,22 +44,13 @@ defineSuite([
 
     function createMockCamera(view, projection, infiniteProjection, position, direction, right, up) {
         return {
-            getViewMatrix : function() {
-                return defaultValue(view, Matrix4.IDENTITY.clone());
-            },
-            getInverseViewMatrix : function() {
-                var m = defaultValue(view, Matrix4.IDENTITY.clone());
-                return Matrix4.inverseTransformation(m);
-            },
+            viewMatrix : defaultValue(view, Matrix4.IDENTITY.clone()),
+            inverseViewMatrix : Matrix4.inverseTransformation(defaultValue(view, Matrix4.IDENTITY.clone())),
             frustum : {
                 near : 1.0,
                 far : 1000.0,
-                getProjectionMatrix : function() {
-                    return defaultValue(projection, Matrix4.IDENTITY.clone());
-                },
-                getInfiniteProjectionMatrix : function() {
-                    return defaultValue(infiniteProjection, Matrix4.IDENTITY.clone());
-                },
+                projectionMatrix : defaultValue(projection, Matrix4.IDENTITY.clone()),
+                infiniteProjectionMatrix : defaultValue(infiniteProjection, Matrix4.IDENTITY.clone()),
                 computeCullingVolume : function() {
                     return undefined;
                 },
@@ -68,10 +59,10 @@ defineSuite([
                 }
             },
             position : defaultValue(position, Cartesian3.ZERO.clone()),
-            getPositionWC : function() { return this.position; },
-            getDirectionWC : function() { return defaultValue(direction, Cartesian3.UNIT_Z.clone()); },
-            getRightWC : function() { return defaultValue(right, Cartesian3.UNIT_X.clone()); },
-            getUpWC : function() { return defaultValue(up, Cartesian3.UNIT_Y.clone()); }
+            positionWC : defaultValue(position, Cartesian3.ZERO.clone()),
+            directionWC : defaultValue(direction, Cartesian3.UNIT_Z.clone()),
+            rightWC : defaultValue(right, Cartesian3.UNIT_X.clone()),
+            upWC : defaultValue(up, Cartesian3.UNIT_Y.clone())
         };
     }
 

--- a/Specs/Scene/CameraControllerSpec.js
+++ b/Specs/Scene/CameraControllerSpec.js
@@ -911,63 +911,63 @@ defineSuite([
         expect(camera.right).toEqual(camera.direction.cross(camera.up));
     });
 
-    it('getHeading returns undefined when morphing', function() {
+    it('get heading is undefined when morphing', function() {
         controller._mode = SceneMode.MORPHING;
-        expect(controller.getHeading()).not.toBeDefined();
+        expect(controller.heading).not.toBeDefined();
     });
 
-    it('getHeading in 2D', function() {
+    it('get heading in 2D', function() {
         controller._mode = SceneMode.SCENE2D;
 
         var heading = Math.atan2(camera.right.y, camera.right.x);
-        expect(controller.getHeading()).toEqual(heading);
+        expect(controller.heading).toEqual(heading);
     });
 
-    it('getHeading in CV', function() {
+    it('get heading in CV', function() {
         controller._mode = SceneMode.COLUMBUS_VIEW;
 
         var heading = Math.atan2(camera.right.y, camera.right.x);
-        expect(controller.getHeading()).toEqual(heading);
+        expect(controller.heading).toEqual(heading);
     });
 
-    it('getHeading in 3D', function() {
+    it('get heading in 3D', function() {
         controller._mode = SceneMode.SCENE3D;
 
-        var z = Matrix4.multiplyByVector(camera.getViewMatrix(), Cartesian4.UNIT_Z);
+        var z = Matrix4.multiplyByVector(camera.viewMatrix, Cartesian4.UNIT_Z);
         var heading = CesiumMath.PI_OVER_TWO - Math.atan2(z.y, z.x);
 
-        expect(controller.getHeading()).toEqual(heading);
+        expect(controller.heading).toEqual(heading);
     });
 
-    it('setHeading throws without angle', function() {
+    it('set heading throws without angle', function() {
         expect(function() {
-            controller.setHeading();
+            controller.heading = undefined;
         }).toThrow();
     });
 
-    it('setHeading in 2D', function() {
+    it('set heading in 2D', function() {
         controller._mode = SceneMode.SCENE2D;
 
-        var heading = controller.getHeading();
+        var heading = controller.heading;
         var newHeading = CesiumMath.toRadians(45.0);
-        controller.setHeading(newHeading);
+        controller.heading = newHeading;
 
-        expect(controller.getHeading()).not.toEqual(heading);
-        expect(controller.getHeading()).toEqualEpsilon(newHeading, CesiumMath.EPSILON14);
+        expect(controller.heading).not.toEqual(heading);
+        expect(controller.heading).toEqualEpsilon(newHeading, CesiumMath.EPSILON14);
     });
 
-    it('setHeading in CV', function() {
+    it('set heading in CV', function() {
         controller._mode = SceneMode.COLUMBUS_VIEW;
 
-        var heading = controller.getHeading();
+        var heading = controller.heading;
         var newHeading = CesiumMath.toRadians(45.0);
-        controller.setHeading(newHeading);
+        controller.heading = newHeading;
 
-        expect(controller.getHeading()).not.toEqual(heading);
-        expect(controller.getHeading()).toEqualEpsilon(newHeading, CesiumMath.EPSILON14);
+        expect(controller.heading).not.toEqual(heading);
+        expect(controller.heading).toEqualEpsilon(newHeading, CesiumMath.EPSILON14);
     });
 
-    it('setHeading in 3D', function() {
+    it('set heading in 3D', function() {
         controller._mode = SceneMode.SCENE3D;
 
         camera.position = Cartesian3.clone(Cartesian3.UNIT_X);
@@ -975,54 +975,54 @@ defineSuite([
         camera.up = Cartesian3.clone(Cartesian3.UNIT_Z);
         camera.right = Cartesian3.cross(camera.direction, camera.up);
 
-        var heading = controller.getHeading();
+        var heading = controller.heading;
         var newHeading = CesiumMath.toRadians(45.0);
-        controller.setHeading(newHeading);
+        controller.heading = newHeading;
 
-        expect(controller.getHeading()).not.toEqual(heading);
-        expect(controller.getHeading()).toEqualEpsilon(newHeading, CesiumMath.EPSILON14);
+        expect(controller.heading).not.toEqual(heading);
+        expect(controller.heading).toEqualEpsilon(newHeading, CesiumMath.EPSILON14);
     });
 
-    it('getTilt returns undefined when mode is not 3D or Columbus view', function() {
+    it('tilt is undefined when mode is not 3D or Columbus view', function() {
         controller._mode = SceneMode.MORPHING;
-        expect(controller.getTilt()).not.toBeDefined();
+        expect(controller.tilt).not.toBeDefined();
     });
 
-    it('getTilt in CV', function() {
+    it('get tilt in CV', function() {
         controller._mode = SceneMode.COLUMBUS_VIEW;
 
         var tilt = CesiumMath.PI_OVER_TWO - Math.acos(-camera.direction.z);
-        expect(controller.getTilt()).toEqual(tilt);
+        expect(controller.tilt).toEqual(tilt);
     });
 
-    it('getTilt in 3D', function() {
+    it('get tilt in 3D', function() {
         controller._mode = SceneMode.SCENE3D;
 
         var direction = Cartesian3.normalize(camera.position);
         Cartesian3.negate(direction, direction);
         var tilt = CesiumMath.PI_OVER_TWO - Math.acos(Cartesian3.dot(camera.direction, direction));
 
-        expect(controller.getTilt()).toEqual(tilt);
+        expect(controller.tilt).toEqual(tilt);
     });
 
-    it('setTilt throws without angle', function() {
+    it('set tilt throws without angle', function() {
         expect(function() {
-            controller.setTilt();
+            controller.tilt = undefined;
         }).toThrow();
     });
 
-    it('setTilt in CV', function() {
+    it('set tilt in CV', function() {
         controller._mode = SceneMode.COLUMBUS_VIEW;
 
-        var tilt = controller.getTilt();
+        var tilt = controller.tilt;
         var newTilt = CesiumMath.toRadians(45.0);
-        controller.setTilt(newTilt);
+        controller.tilt = newTilt;
 
-        expect(controller.getTilt()).not.toEqual(tilt);
-        expect(controller.getTilt()).toEqualEpsilon(newTilt, CesiumMath.EPSILON14);
+        expect(controller.tilt).not.toEqual(tilt);
+        expect(controller.tilt).toEqualEpsilon(newTilt, CesiumMath.EPSILON14);
     });
 
-    it('setTilt in 3D', function() {
+    it('set tilt in 3D', function() {
         controller._mode = SceneMode.SCENE3D;
 
         camera.position = Cartesian3.clone(Cartesian3.UNIT_X);
@@ -1030,12 +1030,12 @@ defineSuite([
         camera.up = Cartesian3.clone(Cartesian3.UNIT_Z);
         camera.right = Cartesian3.cross(camera.direction, camera.up);
 
-        var tilt = controller.getTilt();
+        var tilt = controller.tilt;
         var newTilt = CesiumMath.toRadians(45.0);
-        controller.setTilt(newTilt);
+        controller.tilt = newTilt;
 
-        expect(controller.getTilt()).not.toEqual(tilt);
-        expect(controller.getTilt()).toEqualEpsilon(newTilt, CesiumMath.EPSILON14);
+        expect(controller.tilt).not.toEqual(tilt);
+        expect(controller.tilt).toEqualEpsilon(newTilt, CesiumMath.EPSILON14);
     });
 
     it('get pick ray throws without a position', function() {

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -38,7 +38,7 @@ defineSuite([
     });
 
     it('get view matrix', function() {
-        var viewMatrix = camera.getViewMatrix();
+        var viewMatrix = camera.viewMatrix;
         var position = camera.position;
         var up = camera.up;
         var dir = camera.direction;
@@ -56,14 +56,14 @@ defineSuite([
     });
 
     it('get inverse view matrix', function() {
-        var expected = camera.getViewMatrix().inverse();
-        expect(expected).toEqualEpsilon(camera.getInverseViewMatrix(), CesiumMath.EPSILON15);
+        var expected = camera.viewMatrix.inverse();
+        expect(expected).toEqualEpsilon(camera.inverseViewMatrix, CesiumMath.EPSILON15);
     });
 
     it('get inverse transform', function() {
         camera.transform = new Matrix4(5.0, 0.0, 0.0, 1.0, 0.0, 5.0, 0.0, 2.0, 0.0, 0.0, 5.0, 3.0, 0.0, 0.0, 0.0, 1.0);
         var expected = camera.transform.inverseTransformation();
-        expect(expected).toEqual(camera.getInverseTransform());
+        expect(expected).toEqual(camera.inverseTransform);
     });
 
     it('worldToCameraCoordinates throws without cartesian', function() {

--- a/Specs/Scene/OrthographicFrustumSpec.js
+++ b/Specs/Scene/OrthographicFrustumSpec.js
@@ -32,51 +32,51 @@ defineSuite([
     it('left greater than right causes an exception', function() {
         frustum.left = frustum.right + 1.0;
         expect(function() {
-            frustum.getProjectionMatrix();
+            return frustum.projectionMatrix;
         }).toThrow();
     });
 
     it('bottom greater than top throws an exception', function() {
         frustum.bottom = frustum.top + 1.0;
         expect(function() {
-            frustum.getProjectionMatrix();
+            return frustum.projectionMatrix;
         }).toThrow();
     });
 
     it('out of range near plane throws an exception', function() {
         frustum.near = -1.0;
         expect(function() {
-            frustum.getProjectionMatrix();
+            return frustum.projectionMatrix;
         }).toThrow();
 
         frustum.far = 3.0;
         expect(function() {
-            frustum.getProjectionMatrix();
+            return frustum.projectionMatrix;
         }).toThrow();
     });
 
     it('negative far plane throws an exception', function() {
         frustum.far = -1.0;
         expect(function() {
-            frustum.getProjectionMatrix();
+            return frustum.projectionMatrix;
         }).toThrow();
     });
 
     it('computeCullingVolume with no position throws an exception', function() {
         expect(function() {
-            frustum.computeCullingVolume();
+            return frustum.computeCullingVolume();
         }).toThrow();
     });
 
     it('computeCullingVolume with no direction throws an exception', function() {
         expect(function() {
-            frustum.computeCullingVolume(new Cartesian3());
+            return frustum.computeCullingVolume(new Cartesian3());
         }).toThrow();
     });
 
     it('computeCullingVolume with no up throws an exception', function() {
         expect(function() {
-            frustum.computeCullingVolume(new Cartesian3(), new Cartesian3());
+            return frustum.computeCullingVolume(new Cartesian3(), new Cartesian3());
         }).toThrow();
     });
 
@@ -117,7 +117,7 @@ defineSuite([
     });
 
     it('get orthographic projection matrix', function() {
-        var projectionMatrix = frustum.getProjectionMatrix();
+        var projectionMatrix = frustum.projectionMatrix;
         var expected = Matrix4.computeOrthographicOffCenter(frustum.left, frustum.right, frustum.bottom, frustum.top, frustum.near, frustum.far);
         expect(projectionMatrix).toEqualEpsilon(expected, CesiumMath.EPSILON6);
     });
@@ -154,7 +154,7 @@ defineSuite([
     it('throws with undefined frustum parameters', function() {
         var frustum = new OrthographicFrustum();
         expect(function() {
-            frustum.getProjectionMatrix();
+            return frustum.projectionMatrix;
         }).toThrow();
     });
 });

--- a/Specs/Scene/PerspectiveFrustumSpec.js
+++ b/Specs/Scene/PerspectiveFrustumSpec.js
@@ -30,51 +30,51 @@ defineSuite([
     it('out of range fov causes an exception', function() {
         frustum.fovy = -1.0;
         expect(function() {
-            frustum.getProjectionMatrix();
+            return frustum.projectionMatrix;
         }).toThrow();
 
         frustum.fovy = CesiumMath.TWO_PI;
         expect(function() {
-            frustum.getProjectionMatrix();
+            return frustum.projectionMatrix;
         }).toThrow();
     });
 
     it('negative aspect ratio throws an exception', function() {
         frustum.aspectRatio = -1.0;
         expect(function() {
-            frustum.getProjectionMatrix();
+            return frustum.projectionMatrix;
         }).toThrow();
     });
 
     it('out of range near plane throws an exception', function() {
         frustum.near = -1.0;
         expect(function() {
-            frustum.getProjectionMatrix();
+            return frustum.projectionMatrix;
         }).toThrow();
     });
 
     it('negative far plane throws an exception', function() {
         frustum.far = -1.0;
         expect(function() {
-            frustum.getProjectionMatrix();
+            return frustum.projectionMatrix;
         }).toThrow();
     });
 
     it('computeCullingVolume with no position throws an exception', function() {
         expect(function() {
-            frustum.computeCullingVolume();
+            return frustum.computeCullingVolume();
         }).toThrow();
     });
 
     it('computeCullingVolume with no direction throws an exception', function() {
         expect(function() {
-            frustum.computeCullingVolume(new Cartesian3());
+            return frustum.computeCullingVolume(new Cartesian3());
         }).toThrow();
     });
 
     it('computeCullingVolume with no up throws an exception', function() {
         expect(function() {
-            frustum.computeCullingVolume(new Cartesian3(), new Cartesian3());
+            return frustum.computeCullingVolume(new Cartesian3(), new Cartesian3());
         }).toThrow();
     });
 
@@ -115,7 +115,7 @@ defineSuite([
     });
 
     it('get perspective projection matrix', function() {
-        var projectionMatrix = frustum.getProjectionMatrix();
+        var projectionMatrix = frustum.projectionMatrix;
         var expected = Matrix4.computePerspectiveFieldOfView(frustum.fovy, frustum.aspectRatio, frustum.near, frustum.far);
         expect(projectionMatrix).toEqualEpsilon(expected, CesiumMath.EPSILON6);
     });
@@ -128,7 +128,7 @@ defineSuite([
         var near = frustum.near;
 
         var expected = Matrix4.computeInfinitePerspectiveOffCenter(left, right, bottom, top, near);
-        expect(frustum.getInfiniteProjectionMatrix()).toEqual(expected);
+        expect(frustum.infiniteProjectionMatrix).toEqual(expected);
     });
 
     it('get pixel size throws without canvas dimensions', function() {
@@ -164,7 +164,7 @@ defineSuite([
     it('throws with undefined frustum parameters', function() {
         var frustum = new PerspectiveFrustum();
         expect(function() {
-            return frustum.getInfiniteProjectionMatrix();
+            return frustum.infiniteProjectionMatrix;
         }).toThrow();
     });
 });

--- a/Specs/Scene/PerspectiveOffCenterFrustumSpec.js
+++ b/Specs/Scene/PerspectiveOffCenterFrustumSpec.js
@@ -32,32 +32,32 @@ defineSuite([
     it('out of range near plane throws an exception', function() {
         frustum.near = -1.0;
         expect(function() {
-            frustum.getProjectionMatrix();
+            return frustum.projectionMatrix;
         }).toThrow();
     });
 
     it('negative far plane throws an exception', function() {
         frustum.far = -1.0;
         expect(function() {
-            frustum.getProjectionMatrix();
+            return frustum.projectionMatrix;
         }).toThrow();
     });
 
     it('computeCullingVolume with no position throws an exception', function() {
         expect(function() {
-            frustum.computeCullingVolume();
+            return frustum.computeCullingVolume();
         }).toThrow();
     });
 
     it('computeCullingVolume with no direction throws an exception', function() {
         expect(function() {
-            frustum.computeCullingVolume(new Cartesian3());
+            return frustum.computeCullingVolume(new Cartesian3());
         }).toThrow();
     });
 
     it('computeCullingVolume with no up throws an exception', function() {
         expect(function() {
-            frustum.computeCullingVolume(new Cartesian3(), new Cartesian3());
+            return frustum.computeCullingVolume(new Cartesian3(), new Cartesian3());
         }).toThrow();
     });
 
@@ -102,7 +102,7 @@ defineSuite([
     });
 
     it('get perspective projection matrix', function() {
-        var projectionMatrix = frustum.getProjectionMatrix();
+        var projectionMatrix = frustum.projectionMatrix;
 
         var top = frustum.top;
         var bottom = frustum.bottom;
@@ -123,7 +123,7 @@ defineSuite([
         var near = frustum.near;
 
         var expected = Matrix4.computeInfinitePerspectiveOffCenter(left, right, bottom, top, near);
-        expect(expected).toEqual(frustum.getInfiniteProjectionMatrix());
+        expect(expected).toEqual(frustum.infiniteProjectionMatrix);
     });
 
     it('get pixel size throws without canvas dimensions', function() {
@@ -168,7 +168,7 @@ defineSuite([
     it('throws with undefined frustum parameters', function() {
         var frustum = new PerspectiveOffCenterFrustum();
         expect(function() {
-            return frustum.getInfiniteProjectionMatrix();
+            return frustum.infiniteProjectionMatrix;
         }).toThrow();
     });
 });

--- a/Specs/Scene/ScreenSpaceCameraControllerSpec.js
+++ b/Specs/Scene/ScreenSpaceCameraControllerSpec.js
@@ -828,7 +828,7 @@ defineSuite([
         expect(camera.direction.cross(camera.up)).toEqualEpsilon(camera.right, CesiumMath.EPSILON14);
         expect(camera.right.cross(camera.direction)).toEqualEpsilon(camera.up, CesiumMath.EPSILON15);
 
-        var ray = new Ray(camera.getPositionWC(), camera.getDirectionWC());
+        var ray = new Ray(camera.positionWC, camera.directionWC);
         var intersection = IntersectionTests.rayEllipsoid(ray, frameState.scene2D.projection.getEllipsoid());
         expect(intersection).toBeDefined();
     });
@@ -840,7 +840,7 @@ defineSuite([
         var endPosition = new Cartesian2(canvas.clientWidth / 2, canvas.clientHeight / 4);
 
         camera.controller.lookRight(CesiumMath.PI_OVER_TWO);
-        var ray = new Ray(camera.getPositionWC(), camera.getDirectionWC());
+        var ray = new Ray(camera.positionWC, camera.directionWC);
         var intersection = IntersectionTests.rayEllipsoid(ray, frameState.scene2D.projection.getEllipsoid());
         expect(intersection).not.toBeDefined();
 


### PR DESCRIPTION
Added `getHeading`, `setHeading`, `getTilt` and `setTilt` to `CameraController` for #977 and #1111.

Roll was unneeded. It can be done with:
`camera.controller.look(camera.direction, angle);` 
