### PR TITLE
Fix GeometryInstanceAttribute memory pressure

### DIFF
--- a/Source/Core/Color.js
+++ b/Source/Core/Color.js
@@ -528,14 +528,23 @@ define([
      * that are in the range of 0 to 255.
      * @memberof Color
      *
-     * @returns {Array} An array containing the red, green, blue, alpha values in the range 0 to 255.
+     * @param {Array} [result] The array to store the result in, if undefined a new instance will be created.
+     * @returns {Array} The modified result parameter or a new instance if result was undefined.
      */
-    Color.prototype.toBytes = function() {
+    Color.prototype.toBytes = function(result) {
         var red = Color.floatToByte(this.red);
         var green = Color.floatToByte(this.green);
         var blue = Color.floatToByte(this.blue);
         var alpha = Color.floatToByte(this.alpha);
-        return [red, green, blue, alpha];
+
+        if (!defined(result)) {
+            return [red, green, blue, alpha];
+        }
+        result[0] = red;
+        result[1] = green;
+        result[2] = blue;
+        result[3] = alpha;
+        return result;
     };
 
     /**

--- a/Source/Core/ColorGeometryInstanceAttribute.js
+++ b/Source/Core/ColorGeometryInstanceAttribute.js
@@ -126,21 +126,25 @@ define([
      * Converts a color to a typed array that can be used to assign a color attribute.
      *
      * @param {Color} color The color.
+     * @param {Uint8Array} [result] The array to store the result in, if undefined a new instance will be created.
      *
-     * @returns {Uint8Array} The typed array in the attribute's format.
+     * @returns {Uint8Array} The modified result parameter or a new instance if result was undefined.
      *
      * @exception {DeveloperError} color is required.
      *
      * @example
      * var attributes = primitive.getGeometryInstanceAttributes('an id');
-     * attributes.color = ColorGeometryInstanceAttribute.toValue(Color.AQUA);
+     * attributes.color = ColorGeometryInstanceAttribute.toValue(Color.AQUA, attributes.color);
      */
-    ColorGeometryInstanceAttribute.toValue = function(color) {
+    ColorGeometryInstanceAttribute.toValue = function(color, result) {
         if (!defined(color)) {
             throw new DeveloperError('color is required.');
         }
 
-        return new Uint8Array(color.toBytes());
+        if (!defined(result)) {
+            return new Uint8Array(color.toBytes());
+        }
+        return color.toBytes(result);
     };
 
     return ColorGeometryInstanceAttribute;

--- a/Source/Core/ShowGeometryInstanceAttribute.js
+++ b/Source/Core/ShowGeometryInstanceAttribute.js
@@ -89,21 +89,26 @@ define([
      * Converts a boolean show to a typed array that can be used to assign a show attribute.
      *
      * @param {Boolean} show The show value.
+     * @param {Uint8Array} [result] The array to store the result in, if undefined a new instance will be created.
      *
-     * @returns {Uint8Array} The typed array in the attribute's format.
+     * @returns {Uint8Array} The modified result parameter or a new instance if result was undefined.
      *
      * @exception {DeveloperError} show is required.
      *
      * @example
      * var attributes = primitive.getGeometryInstanceAttributes('an id');
-     * attributes.show = ShowGeometryInstanceAttribute.toValue(true);
+     * attributes.show = ShowGeometryInstanceAttribute.toValue(true, attributes.show);
      */
-    ShowGeometryInstanceAttribute.toValue = function(show) {
+    ShowGeometryInstanceAttribute.toValue = function(show, result) {
         if (!defined(show)) {
             throw new DeveloperError('show is required.');
         }
 
-        return new Uint8Array([show]);
+        if (!defined(result)) {
+            return new Uint8Array([show]);
+        }
+        result[0] = show;
+        return result;
     };
 
     return ShowGeometryInstanceAttribute;

--- a/Specs/Core/ColorGeometryInstanceAttributeSpec.js
+++ b/Specs/Core/ColorGeometryInstanceAttributeSpec.js
@@ -39,7 +39,17 @@ defineSuite([
 
     it('toValue', function() {
         var color = Color.AQUA;
-        expect(ColorGeometryInstanceAttribute.toValue(color)).toEqual(new Uint8Array(color.toBytes()));
+        var expectedResult = new Uint8Array(color.toBytes());
+        expect(ColorGeometryInstanceAttribute.toValue(color)).toEqual(expectedResult);
+    });
+
+    it('toValue works with result parameter', function() {
+        var color = Color.AQUA;
+        var expectedResult = new Uint8Array(color.toBytes());
+        var result = new Uint8Array(4);
+        var returnedResult = ColorGeometryInstanceAttribute.toValue(color, result);
+        expect(returnedResult).toBe(result);
+        expect(returnedResult).toEqual(expectedResult);
     });
 
     it('toValue throws without a color', function() {

--- a/Specs/Core/ColorSpec.js
+++ b/Specs/Core/ColorSpec.js
@@ -51,6 +51,15 @@ defineSuite(['Core/Color',
         expect(bytes).toEqual([r, g, b, a]);
     });
 
+    it('toBytes works with a result parameter', function() {
+        var color = new Color(0.1, 0.2, 0.3, 0.4);
+        var result = [];
+        var expectedResult = [25, 51, 76, 102];
+        var returnedResult = color.toBytes(result);
+        expect(returnedResult).toBe(result);
+        expect(returnedResult).toEqual(expectedResult);
+    });
+
     it('byteToFloat works in all cases', function() {
         expect(Color.byteToFloat(0)).toEqual(0);
         expect(Color.byteToFloat(255)).toEqual(1.0);

--- a/Specs/Core/ShowGeometryInstanceAttributeSpec.js
+++ b/Specs/Core/ShowGeometryInstanceAttributeSpec.js
@@ -18,7 +18,16 @@ defineSuite([
     });
 
     it('toValue', function() {
-        expect(ShowGeometryInstanceAttribute.toValue(true)).toEqual(new Uint8Array([true]));
+        var expectedResult = new Uint8Array([true]);
+        expect(ShowGeometryInstanceAttribute.toValue(true)).toEqual(expectedResult);
+    });
+
+    it('toValue works with a result parameter', function() {
+        var expectedResult = new Uint8Array([true]);
+        var result = new Uint8Array(1);
+        var returnedResult = ShowGeometryInstanceAttribute.toValue(true, result);
+        expect(returnedResult).toEqual(expectedResult);
+        expect(returnedResult).toBe(result);
     });
 
     it('toValue throws without a color', function() {


### PR DESCRIPTION
Make `Color.toBytes`, `ColorGeometryInstanceAttribute.toValue`, and `ShowGeometryInstanceAttribute.toValue` take an optional result parameter.  This avoids very costly TypedArray allocations each frame the attribute is modified.
