### PR TITLE
Make "projectTo2D throws without attribute" throw for the right reason

### DIFF
--- a/Specs/Core/GeometryPipelineSpec.js
+++ b/Specs/Core/GeometryPipelineSpec.js
@@ -635,7 +635,7 @@ defineSuite([
         expect(function() {
             GeometryPipeline.projectTo2D(new Geometry({
                 attributes : {
-                    position : new GeometryAttribute({
+                    normal : new GeometryAttribute({
                         componentDatatype : ComponentDatatype.DOUBLE,
                         componentsPerAttribute : 3,
                         values : [0.0, 0.0, 0.0]


### PR DESCRIPTION
Needed in order to merge #1201
