### PR TITLE
Disable unused local variable warning in Eclipse.

### DIFF
--- a/.settings/org.eclipse.wst.jsdt.core.prefs
+++ b/.settings/org.eclipse.wst.jsdt.core.prefs
@@ -294,4 +294,4 @@ org.eclipse.wst.jsdt.core.formatter.tabulation.char=space
 org.eclipse.wst.jsdt.core.formatter.tabulation.size=4
 org.eclipse.wst.jsdt.core.formatter.use_tabs_only_for_leading_indentations=false
 org.eclipse.wst.jsdt.core.formatter.wrap_before_binary_operator=false
-semanticValidation=enabled
+semanticValidation=disabled


### PR DESCRIPTION
The latest version of Elipse claims ther are over 100 unread local variables in our code base, 0 of them appear to be accurate.  Since the warning is now useless, we should ignore it.

@shunter Any objections?
