### PR TITLE
Fix PolylineCollection WebGL warning

### DIFF
--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -504,7 +504,7 @@ define([
                     var polyline = polylines[s];
                     var mId = createMaterialId(polyline._material);
                     if (mId !== currentId) {
-                        if (defined(currentId)) {
+                        if (defined(currentId) && count > 0) {
                             if (commandIndex >= commandsLength) {
                                 command = new DrawCommand();
                                 command.owner = polylineCollection;


### PR DESCRIPTION
Fixes an index out of bounds WebGL error when the count argument to glDrawElements is zero. I can email a CZML file to whoever wants to review this.
