### PR TITLE
removeDuplicates select correct height for duplicate lat/lon positions in WallGeometry

### DIFF
--- a/Source/Core/WallGeometryLibrary.js
+++ b/Source/Core/WallGeometryLibrary.js
@@ -78,6 +78,7 @@ define([
         if (hasBottomHeights) {
             cleanedBottomHeights.push(bottomHeights[0]);
         }
+
         for (var i = 1; i < length; ++i) {
             var v1 = positions[i];
             var c1 = ellipsoid.cartesianToCartographic(v1, scratchCartographic2);
@@ -91,7 +92,7 @@ define([
                     cleanedBottomHeights.push(bottomHeights[i]);
                 }
             } else if (c0.height < c1.height) {
-                cleanedTopHeights[i-1] = c1.height;
+                cleanedTopHeights[cleanedTopHeights.length-1] = c1.height;
             }
 
             Cartographic.clone(c1, c0);

--- a/Specs/Core/WallGeometrySpec.js
+++ b/Specs/Core/WallGeometrySpec.js
@@ -141,6 +141,30 @@ defineSuite([
         expect(cartographic.height).toEqualEpsilon(2000.0, CesiumMath.EPSILON8);
     });
 
+    it('cleans selects maximum height from duplicates', function() {
+        var coords = [
+                      Cartographic.fromDegrees(49.0, 18.0, 1000.0),
+                      Cartographic.fromDegrees(50.0, 18.0, 1000.0),
+                      Cartographic.fromDegrees(50.0, 18.0, 6000.0),
+                      Cartographic.fromDegrees(50.0, 18.0, 10000.0),
+                      Cartographic.fromDegrees(51.0, 18.0, 1000.0)
+                  ];
+        var w = WallGeometry.createGeometry(new WallGeometry({
+            vertexFormat : VertexFormat.POSITION_ONLY,
+            positions    : ellipsoid.cartographicArrayToCartesianArray(coords)
+        }));
+
+        var positions = w.attributes.position.values;
+        expect(positions.length).toEqual(4 * 2 * 3);
+        expect(w.indices.length).toEqual((4 * 2 - 2) * 3);
+
+        var cartographic = ellipsoid.cartesianToCartographic(Cartesian3.fromArray(positions, 0));
+        expect(cartographic.height).toEqualEpsilon(0.0, CesiumMath.EPSILON8);
+
+        cartographic = ellipsoid.cartesianToCartographic(Cartesian3.fromArray(positions, 9));
+        expect(cartographic.height).toEqualEpsilon(10000.0, CesiumMath.EPSILON8);
+    });
+
     it('creates all attributes', function() {
         var coords = [
             Cartographic.fromDegrees(49.0, 18.0, 1000.0),


### PR DESCRIPTION
Fixes Issue #1192
