### PR TITLE
Fix SVG path regression with FullscreenButton.

### DIFF
--- a/Source/Widgets/Animation/Animation.js
+++ b/Source/Widgets/Animation/Animation.js
@@ -7,6 +7,7 @@ define([
         '../../Core/DeveloperError',
         '../../Core/Color',
         '../getElement',
+        '../subscribeAndEvaluate',
         '../../ThirdParty/knockout'
     ], function(
         defaultValue,
@@ -16,6 +17,7 @@ define([
         DeveloperError,
         Color,
         getElement,
+        subscribeAndEvaluate,
         knockout) {
     "use strict";
 
@@ -37,11 +39,6 @@ define([
 
     function getElementColor(element) {
         return Color.fromCssColorString(window.getComputedStyle(element).getPropertyValue('color'));
-    }
-
-    function subscribeAndEvaluate(owner, observablePropertyName, callback, target) {
-        callback.call(target, owner[observablePropertyName]);
-        return knockout.getObservable(owner, observablePropertyName).subscribe(callback, target);
     }
 
     //Dynamically builds an SVG element from a JSON object.

--- a/Source/Widgets/FullscreenButton/FullscreenButton.js
+++ b/Source/Widgets/FullscreenButton/FullscreenButton.js
@@ -6,6 +6,7 @@ define([
         '../../Core/destroyObject',
         '../SvgPath/SvgPath',
         '../getElement',
+        '../subscribeAndEvaluate',
         './FullscreenButtonViewModel',
         '../../ThirdParty/knockout'
     ], function(
@@ -15,6 +16,7 @@ define([
         destroyObject,
         SvgPath,
         getElement,
+        subscribeAndEvaluate,
         FullscreenButtonViewModel,
         knockout) {
     "use strict";
@@ -59,7 +61,7 @@ enable: isFullscreenEnabled');
         knockout.applyBindings(this._viewModel, this._element);
 
         var that = this;
-        this._subscription = knockout.getObservable(this._viewModel, 'isFullscreen').subscribe(function (isFullscreen) {
+        this._subscription = subscribeAndEvaluate(this._viewModel, 'isFullscreen', function(isFullscreen) {
             that._svgPath.path = isFullscreen ? exitFullScreenPath : enterFullScreenPath;
         });
     };

--- a/Source/Widgets/Geocoder/Geocoder.js
+++ b/Source/Widgets/Geocoder/Geocoder.js
@@ -6,6 +6,7 @@ define([
         '../../Core/DeveloperError',
         '../SvgPath/SvgPath',
         '../getElement',
+        '../subscribeAndEvaluate',
         './GeocoderViewModel',
         '../../ThirdParty/knockout'
     ], function(
@@ -15,6 +16,7 @@ define([
         DeveloperError,
         SvgPath,
         getElement,
+        subscribeAndEvaluate,
         GeocoderViewModel,
         knockout) {
     "use strict";
@@ -78,7 +80,7 @@ define([
         knockout.applyBindings(this._viewModel, this._container);
 
         var that = this;
-        this._subscription = knockout.getObservable(this._viewModel, 'isSearchInProgress').subscribe(function(isSearchInProgress) {
+        this._subscription = subscribeAndEvaluate(this._viewModel, 'isSearchInProgress', function(isSearchInProgress) {
             that._svgPath.path = isSearchInProgress ? stopSearchPath : startSearchPath;
         });
 

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -21,6 +21,7 @@ define([
         '../FullscreenButton/FullscreenButton',
         '../Geocoder/Geocoder',
         '../getElement',
+        '../subscribeAndEvaluate',
         '../HomeButton/HomeButton',
         '../SceneModePicker/SceneModePicker',
         '../Timeline/Timeline',
@@ -47,6 +48,7 @@ define([
         FullscreenButton,
         Geocoder,
         getElement,
+        subscribeAndEvaluate,
         HomeButton,
         SceneModePicker,
         Timeline,
@@ -289,19 +291,13 @@ Either specify options.imageryProvider instead or set options.baseLayerPicker to
 
             //Subscribe to fullscreenButton.viewModel.isFullscreenEnabled so
             //that we can hide/show the button as well as size the timeline.
-            var fullScreenEnabledCallback = function(value) {
-                if (value) {
-                    fullscreenContainer.style.display = 'block';
-                } else {
-                    fullscreenContainer.style.display = 'none';
-                }
+            this._fullscreenSubscription = subscribeAndEvaluate(fullscreenButton.viewModel, 'isFullscreenEnabled', function(isFullscreenEnabled) {
+                fullscreenContainer.style.display = isFullscreenEnabled ? 'block' : 'none';
                 if (defined(timeline)) {
                     timeline.container.style.right = fullscreenContainer.clientWidth + 'px';
                     timeline.resize();
                 }
-            };
-            this._fullscreenSubscription = knockout.getObservable(fullscreenButton.viewModel, 'isFullscreenEnabled').subscribe(fullScreenEnabledCallback);
-            fullScreenEnabledCallback(fullscreenButton.viewModel.isFullscreenEnabled);
+            });
         } else if (defined(timeline)) {
             timeline.container.style.right = 0;
         }

--- a/Source/Widgets/subscribeAndEvaluate.js
+++ b/Source/Widgets/subscribeAndEvaluate.js
@@ -1,0 +1,30 @@
+/*global define*/
+define([
+        '../ThirdParty/knockout'
+    ], function(
+        knockout) {
+    "use strict";
+
+    /**
+     * Subscribe to a Knockout observable ES5 property, and immediately fire
+     * the callback with the current value of the property.
+     *
+     * @private
+     *
+     * @exports subscribeAndEvaluate
+     *
+     * @param {Object} owner The object containing the observable property.
+     * @param {String} observablePropertyName The name of the observable property.
+     * @param {Function} callback The callback function.
+     * @param {Object} [target] The value of this in the callback function.
+     * @param {Function} [event='change'] The name of the event to receive notification for.
+     *
+     * @returns The subscription object from Knockout which can be used to dispose the subscription later.
+     */
+    var subscribeAndEvaluate = function(owner, observablePropertyName, callback, target, event) {
+        callback.call(target, owner[observablePropertyName]);
+        return knockout.getObservable(owner, observablePropertyName).subscribe(callback, target, event);
+    };
+
+    return subscribeAndEvaluate;
+});


### PR DESCRIPTION
Simply subscribing to a computed observable does not force the computed observable to be evaluated.  If it's never otherwise evaluated, the subscription will never fire.  To work around this, extract the subscribeAndEvaluate helper function from within Animation, and use it everywhere we add a subscriber, to ensure correct behavior no matter what by forcing the evaluation to occur.
