### PR TITLE
Fix extractVersion function.

### DIFF
--- a/Source/Core/FeatureDetection.js
+++ b/Source/Core/FeatureDetection.js
@@ -12,6 +12,7 @@ define([
         for ( var i = 0, len = parts.length; i < len; ++i) {
             parts[i] = parseInt(parts[i], 10);
         }
+        return parts;
     }
 
     var isChromeResult;


### PR DESCRIPTION
Turns out you have to actually return variables that you want to be the result of a function.  Who knew?!?

This fixes Cesium on Safari 7 on OS X Mavericks, and probably other versions of Safari.
