### PR TITLE
Turn off antialiasing for test robustness.

### DIFF
--- a/Specs/createContext.js
+++ b/Specs/createContext.js
@@ -44,6 +44,7 @@ define([
         // clone options so we can change properties
         options = clone(defaultValue(options, {}));
         options.alpha = defaultValue(options.alpha, true);
+        options.antialias = defaultValue(options.antialias, false);
 
         var canvas = createCanvas(canvasWidth, canvasHeight);
         var context = new Context(canvas, options);

--- a/Specs/createScene.js
+++ b/Specs/createScene.js
@@ -1,13 +1,19 @@
 /*global define*/
 define([
+        'Core/clone',
+        'Core/defaultValue',
         'Scene/Scene',
         'Specs/createCanvas'
     ], function(
+        clone,
+        defaultValue,
         Scene,
         createCanvas) {
     "use strict";
 
     function createScene(options) {
+        options = clone(defaultValue(options, {}));
+        options.antialias = defaultValue(options.antialias, false);
         return new Scene(createCanvas(), options);
     }
 


### PR DESCRIPTION
This clears up 158 test failures on my system where explicit comparison of colors to results obtained from readPixels did not match ({0, 0, 64, 64} instead of {0, 0, 255, 255} RGBA values for example).
