### PR TITLE
Change CZML polyline defaults

### DIFF
--- a/Source/DynamicScene/PolylineOutlineMaterialProperty.js
+++ b/Source/DynamicScene/PolylineOutlineMaterialProperty.js
@@ -32,9 +32,9 @@ define([
         /**
          * A Number {@link Property} which determines the polyline's outline width.
          * @type {Property}
-         * @default new ConstantProperty(1)
+         * @default new ConstantProperty(0)
          */
-        this.outlineWidth = new ConstantProperty(1);
+        this.outlineWidth = new ConstantProperty(0);
     };
 
     /**


### PR DESCRIPTION
The old default was 0 and I accidentally switched it to 1 in the last great refactor. 0 is the better choice.

Fixes #1249
