### PR TITLE
Fix Geocoder flights part 2

### DIFF
--- a/Source/Widgets/Geocoder/GeocoderViewModel.js
+++ b/Source/Widgets/Geocoder/GeocoderViewModel.js
@@ -279,6 +279,7 @@ define([
                 Cartesian3.cross(camera.direction, camera.up, camera.right);
 
                 camera.transform = Matrix4.IDENTITY;
+                viewModel._scene.getScreenSpaceCameraController().setEllipsoid(viewModel._ellipsoid);
             }
 
             var flight = CameraFlightPath.createAnimation(viewModel._scene, description);


### PR DESCRIPTION
Reset the `ScreenSpaceCameraController` ellipsoid in the geocoder if the camera was following an object.
