### PR TITLE
Fix Fullscreen events on IE 11.

### DIFF
--- a/Source/Core/Fullscreen.js
+++ b/Source/Core/Fullscreen.js
@@ -103,11 +103,19 @@ define(['./defined'], function(defined) {
             name = prefix + 'fullscreenchange';
             // event names do not have 'on' in the front, but the property on the document does
             if (defined(document['on' + name])) {
+                //except on IE
+                if (prefix === 'ms') {
+                    name = 'MSFullscreenChange';
+                }
                 _names.fullscreenchange = name;
             }
 
             name = prefix + 'fullscreenerror';
             if (defined(document['on' + name])) {
+                //except on IE
+                if (prefix === 'ms') {
+                    name = 'MSFullscreenError';
+                }
                 _names.fullscreenerror = name;
             }
         }


### PR DESCRIPTION
From http://msdn.microsoft.com/en-us/library/ie/dn265028(v=vs.85).aspx

the prefixed event names are cased differently than other browsers.
