### PR TITLE
Fullscreen default fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Change Log
 Beta Releases
 -------------
 
+### b25 - 2014-02-03
+* Breaking changes:
+  * The `Viewer` constructor argument `options.fullscreenElement` now matches the `FullscreenButton` default of `document.body`, it was previously the `Viewer` container itself. 
+  
 ### b24 - 2014-01-06
 
 * Breaking changes:

--- a/Source/DynamicScene/DynamicObjectView.js
+++ b/Source/DynamicScene/DynamicObjectView.js
@@ -239,7 +239,7 @@ define([
 
     /**
      * A utility object for tracking an object with the camera.
-     * @alias DynamicObject
+     * @alias DynamicObjectView
      * @constructor
      *
      * @param {DynamicObject} dynamicObject The object to track with the camera.

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -107,7 +107,7 @@ define([
      * @param {ImageryProvider} [options.imageryProvider=new BingMapsImageryProvider()] The imagery provider to use.  This value is only valid if options.baseLayerPicker is set to false.
      * @param {TerrainProvider} [options.terrainProvider=new EllipsoidTerrainProvider()] The terrain provider to use
      * @param {SkyBox} [options.skyBox] The skybox used to render the stars.  When <code>undefined</code>, the default stars are used.
-     * @param {Element} [options.fullscreenElement=container] The element to make full screen when the full screen button is pressed.
+     * @param {Element} [options.fullscreenElement=document.body] The element to make full screen when the full screen button is pressed.
      * @param {Boolean} [options.useDefaultRenderLoop=true] True if this widget should control the render loop, false otherwise.
      * @param {Boolean} [options.showRenderLoopErrors=true] If true, this widget will automatically display an HTML panel to the user containing the error, if a render loop error occurs.
      * @param {Object} [options.contextOptions=undefined] Context and WebGL creation properties corresponding to {@link Context#options}.
@@ -291,7 +291,7 @@ Either specify options.imageryProvider instead or set options.baseLayerPicker to
             var fullscreenContainer = document.createElement('div');
             fullscreenContainer.className = 'cesium-viewer-fullscreenContainer';
             viewerContainer.appendChild(fullscreenContainer);
-            fullscreenButton = new FullscreenButton(fullscreenContainer, defaultValue(options.fullscreenElement, container));
+            fullscreenButton = new FullscreenButton(fullscreenContainer, options.fullscreenElement);
 
             //Subscribe to fullscreenButton.viewModel.isFullscreenEnabled so
             //that we can hide/show the button as well as size the timeline.


### PR DESCRIPTION
The `Viewer` constructor argument `options.fullscreenElement` now matches the `FullscreenButton` default of `document.body`, it was previously the `Viewer.container` itself.

This fixes #1305

This also fixes a copy/paste error in `DynamicObjectView` which was causing it to not show up in documentation.
