### PR TITLE
Fix Cesium.js generated file.

### DIFF
--- a/Tools/buildTasks/generateStubs.js
+++ b/Tools/buildTasks/generateStubs.js
@@ -35,7 +35,7 @@ contents += '})();';
 var paths = '\
 /*global define*/\n\
 define(function() {\n\
-    "use strict";\
+    "use strict";\n\
     return {\n' + modulePathMappings.join(',\n') + '\n\
     };\n\
 });';

--- a/Tools/buildTasks/shared.js
+++ b/Tools/buildTasks/shared.js
@@ -4,20 +4,16 @@ importClass(java.io.FileReader); /*global FileReader*/
 importClass(java.io.FileWriter); /*global FileWriter*/
 importClass(Packages.org.apache.tools.ant.util.FileUtils); /*global FileUtils*/
 
-function forEachFile(filesetName, func) {
+function forEachFile(elementName, func) {
     "use strict";
 
-    var filesets = elements.get(filesetName);
-    for (var i = 0, filesetsLen = filesets.size(); i < filesetsLen; ++i) {
-        var fileset = filesets.get(i);
-        var basedir = fileset.getDir(project);
-        var filenames = fileset.getDirectoryScanner(project).getIncludedFiles();
-
-        for (var j = 0, filenamesLen = filenames.length; j < filenamesLen; ++j) {
-            var relativePath = filenames[j];
-            var file = new File(basedir, relativePath);
-
-            func(relativePath, file);
+    var resourceCollections = elements.get(elementName);
+    for (var i = 0, len = resourceCollections.size(); i < len; ++i) {
+        var resourceCollection = resourceCollections.get(i);
+        var iterator = resourceCollection.iterator();
+        while (iterator.hasNext()) {
+            var resource = iterator.next();
+            func(resource.getName(), resource.getFile());
         }
     }
 }

--- a/build.xml
+++ b/build.xml
@@ -7,7 +7,7 @@
 		</glslToJavascript>
 
 		<createCesiumJs output="${sourceDirectory}/Cesium.js">
-			<sourcefiles refid="cesiumJsFileSet" />
+			<sourcefiles refid="cesiumJsFiles" />
 		</createCesiumJs>
 
 		<createSpecList output="${specsDirectory}/SpecList.js">
@@ -158,7 +158,6 @@
 	<property name="githubRepoLink" value="https://github.com/AnalyticalGraphicsInc/cesium/" />
 	<property name="githubLinkExt" value="blob/" />
 
-
 	<!-- Outputs -->
 	<property name="buildDirectory" location="Build" />
 	<property name="buildOutputDirectory" location="${buildDirectory}/Cesium" />
@@ -174,22 +173,17 @@
 		<pathelement path="${toolsDirectory}/commons-logging-1.1.1/commons-logging-1.1.1.jar" />
 	</path>
 
-	<pathconvert property="cesiumJsFileSetPath" pathsep=",">
-		<union>
-			<fileset dir="${sourceDirectory}">
-				<include name="**/*.js" />
-				<exclude name="*.js" />
-				<exclude name="Workers/**" />
-				<exclude name="**/*.profile.js" />
-			</fileset>
-			<fileset dir="${sourceDirectory}">
-				<include name="Workers/createTaskProcessorWorker.js" />
-			</fileset>
-		</union>
-		<globmapper from="${sourceDirectory}/*" to="*" handledirsep="true" />
-	</pathconvert>
-
-	<fileset dir="${sourceDirectory}" id="cesiumJsFileSet" includes="${cesiumJsFileSetPath}" />
+	<union id="cesiumJsFiles">
+		<fileset dir="${sourceDirectory}">
+			<include name="**/*.js" />
+			<exclude name="*.js" />
+			<exclude name="Workers/**" />
+			<exclude name="**/*.profile.js" />
+		</fileset>
+		<fileset dir="${sourceDirectory}">
+			<include name="Workers/createTaskProcessorWorker.js" />
+		</fileset>
+	</union>
 
 	<fileset dir="${sourceDirectory}" id="cesiumWorkersJsFileSet">
 		<include name="**/*.js" />
@@ -211,7 +205,7 @@
 
 	<scriptdef name="createCesiumJs" language="javascript" src="${tasksDirectory}/createCesiumJs.js" manager="bsf" classpathref="javascriptClassPath" loaderref="javascript.loader">
 		<attribute name="output" />
-		<element name="sourcefiles" type="fileset" />
+		<element name="sourcefiles" type="resources" />
 	</scriptdef>
 
 	<scriptdef name="createSpecList" language="javascript" src="${tasksDirectory}/createSpecList.js" manager="bsf" classpathref="javascriptClassPath" loaderref="javascript.loader">
@@ -240,7 +234,7 @@
 	<scriptdef name="generateStubs" language="javascript" src="${tasksDirectory}/generateStubs.js" manager="bsf" classpathref="javascriptClassPath" loaderref="javascript.loader">
 		<attribute name="stuboutput" />
 		<attribute name="pathsoutput" />
-		<element name="sourcefiles" type="fileset" />
+		<element name="sourcefiles" type="resources" />
 	</scriptdef>
 
 	<target name="jsHint" depends="build" description="Runs JSHint on the entire source tree.">
@@ -328,7 +322,7 @@
 
 		<mkdir dir="${buildStubsDirectory}" />
 		<generateStubs stuboutput="${buildStubsDirectory}/Cesium.js" pathsoutput="${buildStubsDirectory}/paths.js">
-			<sourcefiles refid="cesiumJsFileSet" />
+			<sourcefiles refid="cesiumJsFiles" />
 		</generateStubs>
 
 		<!-- create combined Cesium.js workers -->
@@ -414,7 +408,7 @@
 
 	<target name="combineJavaScript.combineCesium.check">
 		<uptodate property="no.combineCesium.create" targetfile="${outputDirectory}/Cesium.js">
-			<srcfiles refid="cesiumJsFileSet" />
+			<srcfiles refid="cesiumJsFiles" />
 		</uptodate>
 	</target>
 


### PR DESCRIPTION
My recent changes to generate stubs caused the fileset for Cesium.js to be created too early, meaning that shader files could get left out if they were not present on disk before the build started.

Instead of the pathconvert hackery I was using before, I fixed our custom scriptdef tasks to work with file-based ResourceCollections instead of requiring a FileSet, so that we can use the `<union>` directly.
