### PR TITLE
Make Viewer.trackedObject an observable.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Beta Releases
 * Breaking changes:
   * The `Viewer` constructor argument `options.fullscreenElement` now matches the `FullscreenButton` default of `document.body`, it was previously the `Viewer` container itself.
   * `Asphalt`, `Blob`, `Brick`, `Cement`, `Erosion`, `Facet`, `Grass`, `TieDye`, and `Wood` materials were moved to the [Materials Pack Plugin](https://github.com/AnalyticalGraphicsInc/cesium-materials-pack).
+  * Removed `Viewer.objectTracked` event; `Viewer.trackedObject` is now an ES5 Knockout observable that can be subscribed to directly.
 * Fixed globe rendering in the current Canary version of Google Chrome.
 * `Viewer` now monitors the clock settings of the first added `DataSource` for changes, and also now has a constructor option `automaticallyTrackFirstDataSourceClock` which will turn off this behavior.
 * The `DynamicObjectCollection` created by `CzmlDataSource` now sends a single `collectionChanged` event after CZML is loaded; previously it was sending an event every time an object was created or removed during the load process.

--- a/Source/Widgets/Viewer/viewerDynamicObjectMixin.js
+++ b/Source/Widgets/Viewer/viewerDynamicObjectMixin.js
@@ -8,7 +8,8 @@ define([
         '../../Core/ScreenSpaceEventType',
         '../../Core/wrapFunction',
         '../../Scene/SceneMode',
-        '../../DynamicScene/DynamicObjectView'
+        '../../DynamicScene/DynamicObjectView',
+        '../../ThirdParty/knockout'
     ], function(
         defined,
         DeveloperError,
@@ -18,7 +19,8 @@ define([
         ScreenSpaceEventType,
         wrapFunction,
         SceneMode,
-        DynamicObjectView) {
+        DynamicObjectView,
+        knockout) {
     "use strict";
 
     /**
@@ -49,14 +51,10 @@ define([
         if (viewer.hasOwnProperty('trackedObject')) {
             throw new DeveloperError('trackedObject is already defined by another mixin.');
         }
-        if (viewer.hasOwnProperty('objectTracked')) {
-            throw new DeveloperError('objectTracked is already defined by another mixin.');
-        }
         //>>includeEnd('debug');
 
         var eventHelper = new EventHelper();
-        var objectTracked = new Event();
-        var trackedObject;
+        var trackedObjectObservable = knockout.observable();
         var dynamicObjectView;
 
         //Subscribe to onTick so that we can update the view each update.
@@ -110,7 +108,7 @@ define([
         function dataSourceRemoved(dataSourceCollection, dataSource) {
             dataSource.getDynamicObjectCollection().collectionChanged.removeEventListener(onDynamicCollectionChanged);
 
-            if (defined(trackedObject)) {
+            if (defined(viewer.trackedObject)) {
                 if (dataSource.getDynamicObjectCollection().getById(viewer.trackedObject.id) === viewer.trackedObject) {
                     viewer.homeButton.viewModel.command();
                 }
@@ -131,45 +129,30 @@ define([
         //Subscribe to left clicks and zoom to the picked object.
         viewer.screenSpaceEventHandler.setInputAction(pickAndTrackObject, ScreenSpaceEventType.LEFT_CLICK);
 
-        defineProperties(viewer, {
-            /**
-             * Gets or sets the DynamicObject instance currently being tracked by the camera.
-             * @memberof viewerDynamicObjectMixin.prototype
-             * @type {DynamicObject}
-             */
-            trackedObject : {
-                get : function() {
-                    return trackedObject;
-                },
-                set : function(value) {
-                    var sceneMode = viewer.scene.getFrameState().mode;
-
-                    if (sceneMode === SceneMode.COLUMBUS_VIEW || sceneMode === SceneMode.SCENE2D) {
-                        viewer.scene.getScreenSpaceCameraController().enableTranslate = !defined(value);
-                    }
-
-                    if (sceneMode === SceneMode.COLUMBUS_VIEW || sceneMode === SceneMode.SCENE3D) {
-                        viewer.scene.getScreenSpaceCameraController().enableTilt = !defined(value);
-                    }
-
-                    if (trackedObject !== value) {
-                        trackedObject = value;
-                        dynamicObjectView = defined(value) ? new DynamicObjectView(value, viewer.scene, viewer.centralBody.getEllipsoid()) : undefined;
-                        objectTracked.raiseEvent(viewer, value);
-                    }
-                }
+        /**
+         * Gets or sets the DynamicObject instance currently being tracked by the camera.
+         * @memberof viewerDynamicObjectMixin.prototype
+         * @type {DynamicObject}
+         */
+        viewer.trackedObject = undefined;
+        knockout.defineProperty(viewer, 'trackedObject', {
+            get : function() {
+                return trackedObjectObservable();
             },
+            set : function(value) {
+                var sceneMode = viewer.scene.getFrameState().mode;
 
-            /**
-             * Gets an event that will be raised when an object is tracked by the camera.  The event
-             * has two parameters: a reference to the viewer instance, and the newly tracked object.
-             *
-             * @memberof viewerDynamicObjectMixin.prototype
-             * @type {Event}
-             */
-            objectTracked : {
-                get : function() {
-                    return objectTracked;
+                if (sceneMode === SceneMode.COLUMBUS_VIEW || sceneMode === SceneMode.SCENE2D) {
+                    viewer.scene.getScreenSpaceCameraController().enableTranslate = !defined(value);
+                }
+
+                if (sceneMode === SceneMode.COLUMBUS_VIEW || sceneMode === SceneMode.SCENE3D) {
+                    viewer.scene.getScreenSpaceCameraController().enableTilt = !defined(value);
+                }
+
+                if (trackedObjectObservable() !== value) {
+                    dynamicObjectView = defined(value) ? new DynamicObjectView(value, viewer.scene, viewer.centralBody.getEllipsoid()) : undefined;
+                    trackedObjectObservable(value);
                 }
             }
         });

--- a/Specs/Widgets/Viewer/viewerDynamicObjectMixinSpec.js
+++ b/Specs/Widgets/Viewer/viewerDynamicObjectMixinSpec.js
@@ -88,35 +88,6 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('adds objectTracked event', function() {
-        viewer = new Viewer(container);
-        viewer.extend(viewerDynamicObjectMixin);
-        expect(viewer.hasOwnProperty('objectTracked')).toEqual(true);
-    });
-
-    it('objectTracked is raised by trackObject', function() {
-        viewer = new Viewer(container);
-        viewer.extend(viewerDynamicObjectMixin);
-
-        var dynamicObject = new DynamicObject();
-        dynamicObject.position = new ConstantProperty(new Cartesian3(123456, 123456, 123456));
-
-        var spyListener = jasmine.createSpy('listener');
-        viewer.objectTracked.addEventListener(spyListener);
-
-        viewer.trackedObject = dynamicObject;
-
-        waitsFor(function() {
-            return spyListener.wasCalled;
-        });
-
-        runs(function() {
-            expect(spyListener).toHaveBeenCalledWith(viewer, dynamicObject);
-
-            viewer.objectTracked.removeEventListener(spyListener);
-        });
-    });
-
     it('returns to home when a tracked object is removed', function() {
         viewer = new Viewer(container);
 


### PR DESCRIPTION
Removed `Viewer.objectTracked` event which is no longer needed.

I'm bringing these changes in ahead of some additional awesome work @emackey has going on in the `selection` branch.  Should make the review of that branch easier.
