### PR TITLE
Fix failing specs by properly isolating and cleaning up animations.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Beta Releases
 * Fixed picking in 2D with rotated map. [#1337](https://github.com/AnalyticalGraphicsInc/cesium/issues/1337)
 * `TileMapServiceImageryProvider` can now handle casing differences in tilemapresource.xml.
 * Added `Quaternion.fastSlerp` and `Quaternion.fastSquad`.
+* Upgraded Tween.js to version r12.
 
 ### b24 - 2014-01-06
 

--- a/Source/Scene/AnimationCollection.js
+++ b/Source/Scene/AnimationCollection.js
@@ -13,6 +13,18 @@ define([
         defaultValue) {
     "use strict";
 
+    // this logic should match the logic in TWEEN.update and TWEEN.Tween.start
+    var getTime;
+    if (defined(window) && defined(window.performance) && defined(window.performance.now)) {
+        getTime = function() {
+            return window.performance.now();
+        };
+    } else {
+        getTime = function() {
+            return Date.now();
+        };
+    }
+
     /**
      * DOC_TBA
      *
@@ -22,6 +34,15 @@ define([
      * @demo <a href="http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Animations.html">Cesium Sandcastle Animation Demo</a>
      */
     var AnimationCollection = function() {
+        this._tweens = [];
+    };
+
+    /**
+     * DOC_TBA
+     * @memberof AnimationCollection
+     */
+    AnimationCollection.prototype.getAll = function() {
+        return this._tweens;
     };
 
     /**
@@ -57,7 +78,10 @@ define([
                 });
             }
             tween.onComplete(defaultValue(options.onComplete, null));
-            tween.start();
+
+            // start then stop to remove the tween from the global array
+            tween.start().stop();
+            this._tweens.push(tween);
 
             return {
                 _tween : tween
@@ -122,7 +146,10 @@ define([
             }
         });
         tween.onComplete(defaultValue(options.onComplete, null));
-        tween.start();
+
+        // start then stop to remove the tween from the global array
+        tween.start().stop();
+        this._tweens.push(tween);
 
         return {
             _tween : tween
@@ -168,7 +195,10 @@ define([
             object[property] = value.value;
         });
         tween.onComplete(defaultValue(options.onComplete, null));
-        tween.start();
+
+        // start then stop to remove the tween from the global array
+        tween.start().stop();
+        this._tweens.push(tween);
 
         return {
             _tween : tween
@@ -210,13 +240,11 @@ define([
             material.uniforms.offset = value.offset;
         });
         // options.onComplete is ignored.
-        tween.onComplete(function() {
-            tween.to({
-                offset : material.uniforms.offset + 1.0
-            }, duration);
-            tween.start();
-        });
-        tween.start();
+        tween.repeat(Infinity);
+
+        // start then stop to remove the tween from the global array
+        tween.start().stop();
+        this._tweens.push(tween);
 
         return {
             _tween : tween
@@ -228,11 +256,18 @@ define([
      * @memberof AnimationCollection
      */
     AnimationCollection.prototype.remove = function(animation) {
-        if (defined(animation)) {
-            var count = Tween.getAll().length;
-            Tween.remove(animation._tween);
+        if (!defined(animation)) {
+            return false;
+        }
 
-            return Tween.getAll().length === (count - 1);
+        var tween = animation._tween;
+        var index = this._tweens.indexOf(tween);
+        if (index !== -1) {
+            if (typeof tween.onCancel === 'function') {
+                tween.onCancel();
+            }
+            this._tweens.splice(index, 1);
+            return true;
         }
 
         return false;
@@ -243,16 +278,13 @@ define([
      * @memberof AnimationCollection
      */
     AnimationCollection.prototype.removeAll = function() {
-        var tweens = Tween.getAll();
-        var n = tweens.length;
-        var i = -1;
-        while (++i < n) {
-            var t = tweens[i];
-            if (typeof t.onCancel === 'function') {
-                t.onCancel();
+        for (var i = 0; i < this._tweens.length; ++i) {
+            var tween = this._tweens[i];
+            if (typeof tween.onCancel === 'function') {
+                tween.onCancel();
             }
         }
-        Tween.removeAll();
+        this._tweens.length = 0;
     };
 
     /**
@@ -260,10 +292,11 @@ define([
      * @memberof Animationcollection
      */
     AnimationCollection.prototype.contains = function(animation) {
-        if (defined(animation)) {
-            return Tween.getAll().indexOf(animation._tween) !== -1;
+        if (!defined(animation)) {
+            return false;
         }
-        return false;
+
+        return this._tweens.indexOf(animation._tween) !== -1;
     };
 
     /**
@@ -271,7 +304,22 @@ define([
      * @memberof AnimationCollection
      */
     AnimationCollection.prototype.update = function() {
-        Tween.update();
+        var tweens = this._tweens;
+        if (tweens.length === 0) {
+            return false;
+        }
+
+        var i = 0;
+        var time = getTime();
+        while (i < tweens.length) {
+            if (tweens[i].update(time)) {
+                i++;
+            } else {
+                tweens.splice(i, 1);
+            }
+        }
+
+        return true;
     };
 
     return AnimationCollection;

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1133,6 +1133,7 @@ define([
      * @memberof Scene
      */
     Scene.prototype.destroy = function() {
+        this._animations.removeAll();
         this._screenSpaceCameraController = this._screenSpaceCameraController && this._screenSpaceCameraController.destroy();
         this._pickFramebuffer = this._pickFramebuffer && this._pickFramebuffer.destroy();
         this._primitives = this._primitives && this._primitives.destroy();

--- a/Source/Scene/ScreenSpaceCameraController.js
+++ b/Source/Scene/ScreenSpaceCameraController.js
@@ -1008,6 +1008,7 @@ define([
      * controller = controller && controller.destroy();
      */
     ScreenSpaceCameraController.prototype.destroy = function() {
+        this._animationCollection.removeAll();
         this._spinHandler = this._spinHandler && this._spinHandler.destroy();
         this._translateHandler = this._translateHandler && this._translateHandler.destroy();
         this._lookHandler = this._lookHandler && this._lookHandler.destroy();

--- a/Source/ThirdParty/Tween.js
+++ b/Source/ThirdParty/Tween.js
@@ -35,6 +35,8 @@ THE SOFTWARE.
  * @author lechecacharro
  * @author Josh Faul / http://jocafa.com/
  * @author egraether / http://egraether.com/
+ * @author endel / http://endel.me
+ * @author Ben Delarre / http://delarre.net
  */
 
 /*global define*/
@@ -46,7 +48,7 @@ var TWEEN = TWEEN || ( function () {
 
 	return {
 
-		REVISION: '7',
+		REVISION: '12',
 
 		getAll: function () {
 
@@ -82,21 +84,19 @@ var TWEEN = TWEEN || ( function () {
 
 			if ( _tweens.length === 0 ) return false;
 
-			var i = 0, l = _tweens.length;
+			var i = 0;
 
-			time = time !== undefined ? time : Date.now();
+			time = time !== undefined ? time : ( typeof window !== 'undefined' && window.performance !== undefined && window.performance.now !== undefined ? window.performance.now() : Date.now() );
 
-			while ( i < l ) {
+			while ( i < _tweens.length ) {
 
 				if ( _tweens[ i ].update( time ) ) {
 
-					i ++;
+					i++;
 
 				} else {
 
 					_tweens.splice( i, 1 );
-
-					l --;
 
 				}
 
@@ -105,7 +105,6 @@ var TWEEN = TWEEN || ( function () {
 			return true;
 
 		}
-
 	};
 
 } )();
@@ -115,7 +114,12 @@ TWEEN.Tween = function ( object ) {
 	var _object = object;
 	var _valuesStart = {};
 	var _valuesEnd = {};
+	var _valuesStartRepeat = {};
 	var _duration = 1000;
+	var _repeat = 0;
+	var _yoyo = false;
+	var _isPlaying = false;
+	var _reversed = false;
 	var _delayTime = 0;
 	var _startTime = null;
 	var _easingFunction = TWEEN.Easing.Linear.None;
@@ -125,6 +129,13 @@ TWEEN.Tween = function ( object ) {
 	var _onStartCallbackFired = false;
 	var _onUpdateCallback = null;
 	var _onCompleteCallback = null;
+
+	// Set all starting values present on the target object
+	for ( var field in object ) {
+
+		_valuesStart[ field ] = parseFloat(object[field], 10);
+
+	}
 
 	this.to = function ( properties, duration ) {
 
@@ -144,19 +155,14 @@ TWEEN.Tween = function ( object ) {
 
 		TWEEN.add( this );
 
+		_isPlaying = true;
+
 		_onStartCallbackFired = false;
 
-		_startTime = time !== undefined ? time : Date.now();
+		_startTime = time !== undefined ? time : ( typeof window !== 'undefined' && window.performance !== undefined && window.performance.now !== undefined ? window.performance.now() : Date.now() );
 		_startTime += _delayTime;
 
 		for ( var property in _valuesEnd ) {
-
-			// This prevents the engine from interpolating null values
-			if ( _object[ property ] === null ) {
-
-				continue;
-
-			}
 
 			// check if an Array was provided as property value
 			if ( _valuesEnd[ property ] instanceof Array ) {
@@ -174,6 +180,12 @@ TWEEN.Tween = function ( object ) {
 
 			_valuesStart[ property ] = _object[ property ];
 
+			if( ( _valuesStart[ property ] instanceof Array ) === false ) {
+				_valuesStart[ property ] *= 1.0; // Ensures we're using numbers, not strings
+			}
+
+			_valuesStartRepeat[ property ] = _valuesStart[ property ] || 0;
+
 		}
 
 		return this;
@@ -182,8 +194,24 @@ TWEEN.Tween = function ( object ) {
 
 	this.stop = function () {
 
+		if ( !_isPlaying ) {
+			return this;
+		}
+
 		TWEEN.remove( this );
+		_isPlaying = false;
+		this.stopChainedTweens();
 		return this;
+
+	};
+
+	this.stopChainedTweens = function () {
+
+		for ( var i = 0, numChainedTweens = _chainedTweens.length; i < numChainedTweens; i++ ) {
+
+			_chainedTweens[ i ].stop();
+
+		}
 
 	};
 
@@ -193,6 +221,21 @@ TWEEN.Tween = function ( object ) {
 		return this;
 
 	};
+
+	this.repeat = function ( times ) {
+
+		_repeat = times;
+		return this;
+
+	};
+
+	this.yoyo = function( yoyo ) {
+
+		_yoyo = yoyo;
+		return this;
+
+	};
+
 
 	this.easing = function ( easing ) {
 
@@ -238,6 +281,8 @@ TWEEN.Tween = function ( object ) {
 
 	this.update = function ( time ) {
 
+		var property;
+
 		if ( time < _startTime ) {
 
 			return true;
@@ -261,9 +306,9 @@ TWEEN.Tween = function ( object ) {
 
 		var value = _easingFunction( elapsed );
 
-		for ( var property in _valuesStart ) {
+		for ( property in _valuesEnd ) {
 
-			var start = _valuesStart[ property ];
+			var start = _valuesStart[ property ] || 0;
 			var end = _valuesEnd[ property ];
 
 			if ( end instanceof Array ) {
@@ -272,7 +317,15 @@ TWEEN.Tween = function ( object ) {
 
 			} else {
 
-				_object[ property ] = start + ( end - start ) * value;
+                // Parses relative end values with start as base (e.g.: +10, -3)
+				if ( typeof(end) === "string" ) {
+					end = start + parseFloat(end, 10);
+				}
+
+				// protect against non numeric properties.
+                if ( typeof(end) === "number" ) {
+					_object[ property ] = start + ( end - start ) * value;
+				}
 
 			}
 
@@ -286,19 +339,50 @@ TWEEN.Tween = function ( object ) {
 
 		if ( elapsed == 1 ) {
 
-			if ( _onCompleteCallback !== null ) {
+			if ( _repeat > 0 ) {
 
-				_onCompleteCallback.call( _object );
+				if( isFinite( _repeat ) ) {
+					_repeat--;
+				}
+
+				// reassign starting values, restart by making startTime = now
+				for( property in _valuesStartRepeat ) {
+
+					if ( typeof( _valuesEnd[ property ] ) === "string" ) {
+						_valuesStartRepeat[ property ] = _valuesStartRepeat[ property ] + parseFloat(_valuesEnd[ property ], 10);
+					}
+
+					if (_yoyo) {
+						var tmp = _valuesStartRepeat[ property ];
+						_valuesStartRepeat[ property ] = _valuesEnd[ property ];
+						_valuesEnd[ property ] = tmp;
+						_reversed = !_reversed;
+					}
+					_valuesStart[ property ] = _valuesStartRepeat[ property ];
+
+				}
+
+				_startTime = time + _delayTime;
+
+				return true;
+
+			} else {
+
+				if ( _onCompleteCallback !== null ) {
+
+					_onCompleteCallback.call( _object );
+
+				}
+
+				for ( var i = 0, numChainedTweens = _chainedTweens.length; i < numChainedTweens; i++ ) {
+
+					_chainedTweens[ i ].start( time );
+
+				}
+
+				return false;
 
 			}
-
-			for ( var i = 0, l = _chainedTweens.length; i < l; i ++ ) {
-
-				_chainedTweens[ i ].start( time );
-
-			}
-
-			return false;
 
 		}
 
@@ -307,6 +391,7 @@ TWEEN.Tween = function ( object ) {
 	};
 
 };
+
 
 TWEEN.Easing = {
 

--- a/Specs/Scene/ScreenSpaceCameraControllerSpec.js
+++ b/Specs/Scene/ScreenSpaceCameraControllerSpec.js
@@ -383,9 +383,6 @@ defineSuite([
     });
 
     it('adds an animation to correct position or zoom in 2D', function() {
-        Tween.removeAll();
-        expect(Tween.getAll().length).toEqual(0);
-
         var frameState = setUp2D();
         var position = Cartesian3.clone(camera.position);
         var startPosition = new Cartesian2(0, canvas.clientHeight / 2);
@@ -397,7 +394,7 @@ defineSuite([
         expect(position.y).toEqual(camera.position.y);
         expect(position.z).toEqual(camera.position.z);
 
-        expect(Tween.getAll().length).toEqual(1);
+        expect(controller._animationCollection.getAll().length).toEqual(1);
     });
 
     function setUpCV() {
@@ -603,9 +600,6 @@ defineSuite([
     });
 
     it('adds an animation to correct position or zoom in Columbus view', function() {
-        Tween.removeAll();
-        expect(Tween.getAll().length).toEqual(0);
-
         var frameState = setUpCV();
         var position = Cartesian3.clone(camera.position);
         var startPosition = new Cartesian2(0, canvas.clientHeight / 2);
@@ -617,7 +611,7 @@ defineSuite([
         expect(position.y).toEqual(camera.position.y);
         expect(position.z).toEqual(camera.position.z);
 
-        expect(Tween.getAll().length).toEqual(1);
+        expect(controller._animationCollection.getAll().length).toEqual(1);
     });
 
     function setUp3D() {


### PR DESCRIPTION
Each AnimationCollection instance now manages its own list of animations.  Previously all instances would share global state.  Also upgrade Tween to latest version.
