### PR TITLE
Renamed attributeIndices to attributeLocations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ Beta Releases
   * The `Viewer` constructor argument `options.fullscreenElement` now matches the `FullscreenButton` default of `document.body`, it was previously the `Viewer` container itself.
   * `Asphalt`, `Blob`, `Brick`, `Cement`, `Erosion`, `Facet`, `Grass`, `TieDye`, and `Wood` materials were moved to the [Materials Pack Plugin](https://github.com/AnalyticalGraphicsInc/cesium-materials-pack).
   * Removed `Viewer.objectTracked` event; `Viewer.trackedObject` is now an ES5 Knockout observable that can be subscribed to directly.
+  * Renamed `GeometryPipeline.createAttributeIndices` to `GeometryPipeline.createAttributeLocations`.
+  * Renamed `attributeIndices` property to `attributeLocations` when calling `Context.createVertexArrayFromGeometry`.
 * Fixed globe rendering in the current Canary version of Google Chrome.
 * `Viewer` now monitors the clock settings of the first added `DataSource` for changes, and also now has a constructor option `automaticallyTrackFirstDataSourceClock` which will turn off this behavior.
 * The `DynamicObjectCollection` created by `CzmlDataSource` now sends a single `collectionChanged` event after CZML is loaded; previously it was sending an event every time an object was created or removed during the load process.

--- a/Source/Core/GeometryPipeline.js
+++ b/Source/Core/GeometryPipeline.js
@@ -239,8 +239,8 @@ define([
     };
 
     /**
-     * Creates an object that maps attribute names to unique indices for matching
-     * vertex attributes and shader programs.
+     * Creates an object that maps attribute names to unique locations (indices)
+     * for matching vertex attributes and shader programs.
      *
      * @param {Geometry} geometry The geometry, which is not modified, to create the object for.
      *
@@ -249,7 +249,7 @@ define([
      * @exception {DeveloperError} geometry is required.
      *
      * @example
-     * var attributeIndices = Cesium.GeometryPipeline.createAttributeIndices(geometry);
+     * var attributeLocations = Cesium.GeometryPipeline.createAttributeLocations(geometry);
      * // Example output
      * // {
      * //   'position' : 0,
@@ -259,7 +259,7 @@ define([
      * @see Context#createVertexArrayFromGeometry
      * @see ShaderCache
      */
-    GeometryPipeline.createAttributeIndices = function(geometry) {
+    GeometryPipeline.createAttributeLocations = function(geometry) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(geometry)) {
             throw new DeveloperError('geometry is required.');

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -2506,7 +2506,7 @@ define([
      * <code>creationArguments</code> can have four properties:
      * <ul>
      *   <li><code>geometry</code>:  The source geometry containing data used to create the vertex array.</li>
-     *   <li><code>attributeIndices</code>:  An object that maps geometry attribute names to vertex shader attribute indices.</li>
+     *   <li><code>attributeLocations</code>:  An object that maps geometry attribute names to vertex shader attribute locations.</li>
      *   <li><code>bufferUsage</code>:  The expected usage pattern of the vertex array's buffers.  On some WebGL implementations, this can significantly affect performance.  See {@link BufferUsage}.  Default: <code>BufferUsage.DYNAMIC_DRAW</code>.</li>
      *   <li><code>vertexLayout</code>:  Determines if all attributes are interleaved in a single vertex buffer or if each attribute is stored in a separate vertex buffer.  Default: <code>VertexLayout.SEPARATE</code>.</li>
      * </ul>
@@ -2524,7 +2524,7 @@ define([
      * @see Context#createVertexArray
      * @see Context#createVertexBuffer
      * @see Context#createIndexBuffer
-     * @see GeometryPipeline.createAttributeIndices
+     * @see GeometryPipeline.createAttributeLocations
      * @see ShaderProgram
      *
      * @example
@@ -2533,8 +2533,8 @@ define([
      * // interleaved by default.
      * var geometry = new BoxGeometry();
      * var va = context.createVertexArrayFromGeometry({
-     *     geometry             : geometry,
-     *     attributeIndices : GeometryPipeline.createAttributeIndices(geometry),
+     *     geometry           : geometry,
+     *     attributeLocations : GeometryPipeline.createAttributeLocations(geometry),
      * });
      *
      * ////////////////////////////////////////////////////////////////////////////////
@@ -2542,10 +2542,10 @@ define([
      * // Example 2. Creates a vertex array with interleaved attributes in a
      * // single vertex buffer.  The vertex and index buffer have static draw usage.
      * var va = context.createVertexArrayFromGeometry({
-     *     geometry             : geometry,
-     *     attributeIndices : GeometryPipeline.createAttributeIndices(geometry),
-     *     bufferUsage      : BufferUsage.STATIC_DRAW,
-     *     vertexLayout     : VertexLayout.INTERLEAVED
+     *     geometry           : geometry,
+     *     attributeLocations : GeometryPipeline.createAttributeLocations(geometry),
+     *     bufferUsage        : BufferUsage.STATIC_DRAW,
+     *     vertexLayout       : VertexLayout.INTERLEAVED
      * });
      *
      * ////////////////////////////////////////////////////////////////////////////////
@@ -2560,7 +2560,7 @@ define([
 
         var bufferUsage = defaultValue(ca.bufferUsage, BufferUsage.DYNAMIC_DRAW);
 
-        var attributeIndices = defaultValue(ca.attributeIndices, defaultValue.EMPTY_OBJECT);
+        var attributeLocations = defaultValue(ca.attributeLocations, defaultValue.EMPTY_OBJECT);
         var interleave = (defined(ca.vertexLayout)) && (ca.vertexLayout === VertexLayout.INTERLEAVED);
         var createdVAAttributes = ca.vertexArrayAttributes;
 
@@ -2585,7 +2585,7 @@ define([
                         if (defined(attribute.values)) {
                             // Common case: per-vertex attributes
                             vaAttributes.push({
-                                index : attributeIndices[name],
+                                index : attributeLocations[name],
                                 vertexBuffer : vertexBuffer,
                                 componentDatatype : attribute.componentDatatype,
                                 componentsPerAttribute : attribute.componentsPerAttribute,
@@ -2596,7 +2596,7 @@ define([
                         } else {
                             // Constant attribute for all vertices
                             vaAttributes.push({
-                                index : attributeIndices[name],
+                                index : attributeLocations[name],
                                 value : attribute.value,
                                 componentDatatype : attribute.componentDatatype,
                                 normalize : attribute.normalize
@@ -2622,7 +2622,7 @@ define([
                     }
 
                     vaAttributes.push({
-                        index : attributeIndices[name],
+                        index : attributeLocations[name],
                         vertexBuffer : vertexBuffer,
                         value : attribute.value,
                         componentDatatype : componentDatatype,

--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -69,7 +69,7 @@ define([
 
     // PERFORMANCE_IDEA:  Use vertex compression so we don't run out of
     // vec4 attributes (WebGL minimum: 8)
-    var attributeIndices = {
+    var attributeLocations = {
         positionHigh : 0,
         positionLow : 1,
         pixelOffsetAndTranslate : 2,
@@ -659,72 +659,72 @@ define([
         var directionVertexBuffer = getDirectionsVertexBuffer(context);
 
         return new VertexArrayFacade(context, [{
-            index : attributeIndices.positionHigh,
+            index : attributeLocations.positionHigh,
             componentsPerAttribute : 3,
             componentDatatype : ComponentDatatype.FLOAT,
             usage : buffersUsage[POSITION_INDEX]
         }, {
-            index : attributeIndices.positionLow,
+            index : attributeLocations.positionLow,
             componentsPerAttribute : 3,
             componentDatatype : ComponentDatatype.FLOAT,
             usage : buffersUsage[POSITION_INDEX]
         }, {
-            index : attributeIndices.pixelOffsetAndTranslate,
+            index : attributeLocations.pixelOffsetAndTranslate,
             componentsPerAttribute : 4,
             componentDatatype : ComponentDatatype.FLOAT,
             usage : buffersUsage[PIXEL_OFFSET_INDEX]
         }, {
-            index : attributeIndices.eyeOffsetAndScale,
+            index : attributeLocations.eyeOffsetAndScale,
             componentsPerAttribute : 4,
             componentDatatype : ComponentDatatype.FLOAT,
             usage : buffersUsage[SCALE_INDEX] // buffersUsage[EYE_OFFSET_INDEX] ignored
         }, {
-            index : attributeIndices.textureCoordinatesAndImageSize,
+            index : attributeLocations.textureCoordinatesAndImageSize,
             componentsPerAttribute : 4,
             componentDatatype : ComponentDatatype.FLOAT,
             usage : buffersUsage[IMAGE_INDEX_INDEX]
         }, {
-            index : attributeIndices.pickColor,
+            index : attributeLocations.pickColor,
             componentsPerAttribute : 4,
             normalize : true,
             componentDatatype : ComponentDatatype.UNSIGNED_BYTE,
             usage : BufferUsage.STATIC_DRAW,
             purpose : pickPassPurpose
         }, {
-            index : attributeIndices.color,
+            index : attributeLocations.color,
             componentsPerAttribute : 4,
             normalize : true,
             componentDatatype : ComponentDatatype.UNSIGNED_BYTE,
             usage : buffersUsage[COLOR_INDEX],
             purpose : colorPassPurpose
         }, {
-            index : attributeIndices.originAndShow,
+            index : attributeLocations.originAndShow,
             componentsPerAttribute : 3,
             componentDatatype : ComponentDatatype.BYTE,
             usage : buffersUsage[SHOW_INDEX] // buffersUsage[HORIZONTAL_ORIGIN_INDEX] and buffersUsage[VERTICAL_ORIGIN_INDEX] ignored
         }, {
-            index : attributeIndices.direction,
+            index : attributeLocations.direction,
             vertexBuffer : directionVertexBuffer,
             componentsPerAttribute : 2,
             normalize : true,
             componentDatatype : ComponentDatatype.UNSIGNED_BYTE
         }, {
-            index : attributeIndices.rotationAndAlignedAxis,
+            index : attributeLocations.rotationAndAlignedAxis,
             componentsPerAttribute : 4,
             componentDatatype : ComponentDatatype.FLOAT,
             usage : buffersUsage[ROTATION_INDEX] // buffersUsage[ALIGNED_AXIS_INDEX] ignored
         }, {
-            index : attributeIndices.scaleByDistance,
+            index : attributeLocations.scaleByDistance,
             componentsPerAttribute : 4,
             componentDatatype : ComponentDatatype.FLOAT,
             usage : buffersUsage[SCALE_BY_DISTANCE_INDEX]
         }, {
-            index : attributeIndices.translucencyByDistance,
+            index : attributeLocations.translucencyByDistance,
             componentsPerAttribute : 4,
             componentDatatype : ComponentDatatype.FLOAT,
             usage : buffersUsage[TRANSLUCENCY_BY_DISTANCE_INDEX]
         }, {
-            index : attributeIndices.pixelOffsetScaleByDistance,
+            index : attributeLocations.pixelOffsetScaleByDistance,
             componentsPerAttribute : 4,
             componentDatatype : ComponentDatatype.FLOAT,
             usage : buffersUsage[PIXEL_OFFSET_SCALE_BY_DISTANCE_INDEX]
@@ -752,14 +752,14 @@ define([
         EncodedCartesian3.fromCartesian(position, writePositionScratch);
 
         var allPurposeWriters = vafWriters[allPassPurpose];
-        var positionHighWriter = allPurposeWriters[attributeIndices.positionHigh];
+        var positionHighWriter = allPurposeWriters[attributeLocations.positionHigh];
         var high = writePositionScratch.high;
         positionHighWriter(i + 0, high.x, high.y, high.z);
         positionHighWriter(i + 1, high.x, high.y, high.z);
         positionHighWriter(i + 2, high.x, high.y, high.z);
         positionHighWriter(i + 3, high.x, high.y, high.z);
 
-        var positionLowWriter = allPurposeWriters[attributeIndices.positionLow];
+        var positionLowWriter = allPurposeWriters[attributeLocations.positionLow];
         var low = writePositionScratch.low;
         positionLowWriter(i + 0, low.x, low.y, low.z);
         positionLowWriter(i + 1, low.x, low.y, low.z);
@@ -774,7 +774,7 @@ define([
         billboardCollection._maxPixelOffset = Math.max(billboardCollection._maxPixelOffset, pixelOffset.x + translate.x, pixelOffset.y + translate.y);
         var allPurposeWriters = vafWriters[allPassPurpose];
 
-        var writer = allPurposeWriters[attributeIndices.pixelOffsetAndTranslate];
+        var writer = allPurposeWriters[attributeLocations.pixelOffsetAndTranslate];
         writer(i + 0, pixelOffset.x, pixelOffset.y, translate.x, translate.y);
         writer(i + 1, pixelOffset.x, pixelOffset.y, translate.x, translate.y);
         writer(i + 2, pixelOffset.x, pixelOffset.y, translate.x, translate.y);
@@ -789,7 +789,7 @@ define([
         billboardCollection._maxScale = Math.max(billboardCollection._maxScale, scale);
 
         var allPurposeWriters = vafWriters[allPassPurpose];
-        var writer = allPurposeWriters[attributeIndices.eyeOffsetAndScale];
+        var writer = allPurposeWriters[attributeLocations.eyeOffsetAndScale];
         writer(i + 0, eyeOffset.x, eyeOffset.y, eyeOffset.z, scale);
         writer(i + 1, eyeOffset.x, eyeOffset.y, eyeOffset.z, scale);
         writer(i + 2, eyeOffset.x, eyeOffset.y, eyeOffset.z, scale);
@@ -800,7 +800,7 @@ define([
         var i = billboard._index * 4;
 
         var pickWriters = vafWriters[pickPassPurpose];
-        var writer = pickWriters[attributeIndices.pickColor];
+        var writer = pickWriters[attributeLocations.pickColor];
 
         var pickColor = billboard.getPickId(context).color;
         var red = Color.floatToByte(pickColor.red);
@@ -818,7 +818,7 @@ define([
         var i = billboard._index * 4;
 
         var colorWriters = vafWriters[colorPassPurpose];
-        var writer = colorWriters[attributeIndices.color];
+        var writer = colorWriters[attributeLocations.color];
 
         var color = billboard.getColor();
         var red = Color.floatToByte(color.red);
@@ -847,7 +847,7 @@ define([
         billboardCollection._allHorizontalCenter = billboardCollection._allHorizontalCenter && horizontalOrigin === HorizontalOrigin.CENTER.value;
 
         var allPurposeWriters = vafWriters[allPassPurpose];
-        var writer = allPurposeWriters[attributeIndices.originAndShow];
+        var writer = allPurposeWriters[attributeLocations.originAndShow];
         writer(i + 0, horizontalOrigin, verticalOrigin, show);
         writer(i + 1, horizontalOrigin, verticalOrigin, show);
         writer(i + 2, horizontalOrigin, verticalOrigin, show);
@@ -885,7 +885,7 @@ define([
         billboardCollection._maxSize = Math.max(billboardCollection._maxSize, imageWidth, imageHeight);
 
         var allPurposeWriters = vafWriters[allPassPurpose];
-        var writer = allPurposeWriters[attributeIndices.textureCoordinatesAndImageSize];
+        var writer = allPurposeWriters[attributeLocations.textureCoordinatesAndImageSize];
         writer(i + 0, bottomLeftX, bottomLeftY, imageWidth, imageHeight); // Lower Left
         writer(i + 1, topRightX, bottomLeftY, imageWidth, imageHeight); // Lower Right
         writer(i + 2, topRightX, topRightY, imageWidth, imageHeight); // Upper Right
@@ -906,7 +906,7 @@ define([
         var z = alignedAxis.z;
 
         var allPurposeWriters = vafWriters[allPassPurpose];
-        var writer = allPurposeWriters[attributeIndices.rotationAndAlignedAxis];
+        var writer = allPurposeWriters[attributeLocations.rotationAndAlignedAxis];
         writer(i + 0, rotation, x, y, z);
         writer(i + 1, rotation, x, y, z);
         writer(i + 2, rotation, x, y, z);
@@ -916,7 +916,7 @@ define([
     function writeScaleByDistance(billboardCollection, context, textureAtlasCoordinates, vafWriters, billboard) {
         var i = billboard._index * 4;
         var allPurposeWriters = vafWriters[allPassPurpose];
-        var writer = allPurposeWriters[attributeIndices.scaleByDistance];
+        var writer = allPurposeWriters[attributeLocations.scaleByDistance];
         var near = 0.0;
         var nearValue = 1.0;
         var far = 1.0;
@@ -945,7 +945,7 @@ define([
     function writeTranslucencyByDistance(billboardCollection, context, textureAtlasCoordinates, vafWriters, billboard) {
         var i = billboard._index * 4;
         var allPurposeWriters = vafWriters[allPassPurpose];
-        var writer = allPurposeWriters[attributeIndices.translucencyByDistance];
+        var writer = allPurposeWriters[attributeLocations.translucencyByDistance];
         var near = 0.0;
         var nearValue = 1.0;
         var far = 1.0;
@@ -974,7 +974,7 @@ define([
     function writePixelOffsetScaleByDistance(billboardCollection, context, textureAtlasCoordinates, vafWriters, billboard) {
         var i = billboard._index * 4;
         var allPurposeWriters = vafWriters[allPassPurpose];
-        var writer = allPurposeWriters[attributeIndices.pixelOffsetScaleByDistance];
+        var writer = allPurposeWriters[attributeLocations.pixelOffsetScaleByDistance];
         var near = 0.0;
         var nearValue = 1.0;
         var far = 1.0;
@@ -1300,7 +1300,7 @@ define([
                         sources : [BillboardCollectionVS]
                     }),
                     BillboardCollectionFS,
-                    attributeIndices);
+                    attributeLocations);
                 this._compiledShaderRotation = this._shaderRotation;
                 this._compiledShaderScaleByDistance = this._shaderScaleByDistance;
                 this._compiledShaderTranslucencyByDistance = this._shaderTranslucencyByDistance;
@@ -1356,7 +1356,7 @@ define([
                         defines : ['RENDER_FOR_PICK'],
                         sources : [BillboardCollectionFS]
                     }),
-                    attributeIndices);
+                    attributeLocations);
                 this._compiledShaderRotationPick = this._shaderRotation;
                 this._compiledShaderScaleByDistancePick = this._shaderScaleByDistance;
                 this._compiledShaderTranslucencyByDistancePick = this._shaderTranslucencyByDistance;

--- a/Source/Scene/CentralBody.js
+++ b/Source/Scene/CentralBody.js
@@ -118,7 +118,7 @@ define([
 
         this._occluder = new Occluder(new BoundingSphere(Cartesian3.ZERO, ellipsoid.getMinimumRadius()), Cartesian3.ZERO);
 
-        this._surfaceShaderSet = new CentralBodySurfaceShaderSet(TerrainProvider.attributeIndices);
+        this._surfaceShaderSet = new CentralBodySurfaceShaderSet(TerrainProvider.attributeLocations);
 
         this._rsColor = undefined;
         this._rsColorWithoutDepthTest = undefined;
@@ -442,7 +442,7 @@ define([
                     });
                     centralBody._northPoleCommand.vertexArray = context.createVertexArrayFromGeometry({
                         geometry : geometry,
-                        attributeIndices : {
+                        attributeLocations : {
                             position : 0
                         },
                         bufferUsage : BufferUsage.STREAM_DRAW
@@ -491,7 +491,7 @@ define([
                      });
                      centralBody._southPoleCommand.vertexArray = context.createVertexArrayFromGeometry({
                          geometry : geometry,
-                         attributeIndices : {
+                         attributeLocations : {
                              position : 0
                          },
                          bufferUsage : BufferUsage.STREAM_DRAW
@@ -624,7 +624,7 @@ define([
             });
             this._depthCommand.vertexArray = context.createVertexArrayFromGeometry({
                 geometry : geometry,
-                attributeIndices : {
+                attributeLocations : {
                     position : 0
                 },
                 bufferUsage : BufferUsage.DYNAMIC_DRAW
@@ -726,7 +726,7 @@ define([
             this._surfaceShaderSet.invalidateShaders();
 
             var poleShaderProgram = shaderCache.replaceShaderProgram(this._northPoleCommand.shaderProgram,
-                CentralBodyVSPole, CentralBodyFSPole, TerrainProvider.attributeIndices);
+                CentralBodyVSPole, CentralBodyFSPole, TerrainProvider.attributeLocations);
 
             this._northPoleCommand.shaderProgram = poleShaderProgram;
             this._southPoleCommand.shaderProgram = poleShaderProgram;

--- a/Source/Scene/CentralBodySurfaceShaderSet.js
+++ b/Source/Scene/CentralBodySurfaceShaderSet.js
@@ -15,10 +15,10 @@ define([
      * @alias CentralBodySurfaceShaderSet
      * @private
      */
-    function CentralBodySurfaceShaderSet(attributeIndices) {
+    function CentralBodySurfaceShaderSet(attributeLocations) {
         this.baseVertexShaderString = undefined;
         this.baseFragmentShaderString = undefined;
-        this._attributeIndices = attributeIndices;
+        this._attributeLocations = attributeLocations;
         this._shaders = {};
     }
 
@@ -105,7 +105,7 @@ define([
             shader = context.getShaderCache().getShaderProgram(
                 vs,
                 fs,
-                this._attributeIndices);
+                this._attributeLocations);
             this._shaders[key] = shader;
         }
         return shader;

--- a/Source/Scene/CustomSensorVolume.js
+++ b/Source/Scene/CustomSensorVolume.js
@@ -49,7 +49,7 @@ define([
         SceneMode) {
     "use strict";
 
-    var attributeIndices = {
+    var attributeLocations = {
         position : 0,
         normal : 1
     };
@@ -338,14 +338,14 @@ define([
         var stride = 2 * 3 * Float32Array.BYTES_PER_ELEMENT;
 
         var attributes = [{
-            index : attributeIndices.position,
+            index : attributeLocations.position,
             vertexBuffer : vertexBuffer,
             componentsPerAttribute : 3,
             componentDatatype : ComponentDatatype.FLOAT,
             offsetInBytes : 0,
             strideInBytes : stride
         }, {
-            index : attributeIndices.normal,
+            index : attributeLocations.normal,
             vertexBuffer : vertexBuffer,
             componentsPerAttribute : 3,
             componentDatatype : ComponentDatatype.FLOAT,
@@ -500,7 +500,7 @@ define([
                 var fsSource = createShaderSource({ sources : [ShadersSensorVolume, this._material.shaderSource, CustomSensorVolumeFS] });
 
                 frontFaceColorCommand.shaderProgram = context.getShaderCache().replaceShaderProgram(
-                        frontFaceColorCommand.shaderProgram, CustomSensorVolumeVS, fsSource, attributeIndices);
+                        frontFaceColorCommand.shaderProgram, CustomSensorVolumeVS, fsSource, attributeLocations);
                 frontFaceColorCommand.uniformMap = combine([this._uniforms, this._material._uniforms], false, false);
 
                 backFaceColorCommand.shaderProgram = frontFaceColorCommand.shaderProgram;
@@ -537,7 +537,7 @@ define([
                 });
 
                 pickCommand.shaderProgram = context.getShaderCache().replaceShaderProgram(
-                    pickCommand.shaderProgram, CustomSensorVolumeVS, pickFS, attributeIndices);
+                    pickCommand.shaderProgram, CustomSensorVolumeVS, pickFS, attributeLocations);
 
                 var that = this;
                 pickCommand.uniformMap = combine([this._uniforms, this._material._uniforms, {

--- a/Source/Scene/EllipsoidPrimitive.js
+++ b/Source/Scene/EllipsoidPrimitive.js
@@ -43,7 +43,7 @@ define([
         EllipsoidFS) {
     "use strict";
 
-    var attributeIndices = {
+    var attributeLocations = {
         position : 0
     };
 
@@ -249,7 +249,7 @@ define([
 
         vertexArray = context.createVertexArrayFromGeometry({
             geometry: geometry,
-            attributeIndices: attributeIndices,
+            attributeLocations: attributeLocations,
             bufferUsage: BufferUsage.STATIC_DRAW
         });
 
@@ -352,7 +352,7 @@ define([
                 sources : [this.material.shaderSource, EllipsoidFS] }
             );
 
-            this._sp = context.getShaderCache().replaceShaderProgram(this._sp, EllipsoidVS, colorFS, attributeIndices);
+            this._sp = context.getShaderCache().replaceShaderProgram(this._sp, EllipsoidVS, colorFS, attributeLocations);
 
             colorCommand.primitiveType = PrimitiveType.TRIANGLES;
             colorCommand.vertexArray = this._va;
@@ -397,7 +397,7 @@ define([
                     pickColorQualifier : 'uniform'
                 });
 
-                this._pickSP = context.getShaderCache().replaceShaderProgram(this._pickSP, EllipsoidVS, pickFS, attributeIndices);
+                this._pickSP = context.getShaderCache().replaceShaderProgram(this._pickSP, EllipsoidVS, pickFS, attributeLocations);
 
                 pickCommand.primitiveType = PrimitiveType.TRIANGLES;
                 pickCommand.vertexArray = this._va;

--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -848,7 +848,7 @@ define([
 
             reproject.vertexArray = context.createVertexArrayFromGeometry({
                 geometry : reprojectGeometry,
-                attributeIndices : reprojectAttribInds,
+                attributeLocations : reprojectAttribInds,
                 bufferUsage : BufferUsage.STATIC_DRAW
             });
 

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -64,7 +64,7 @@ define([
     var POSITION_SIZE_INDEX = Polyline.POSITION_SIZE_INDEX;
     var NUMBER_OF_PROPERTIES = Polyline.NUMBER_OF_PROPERTIES;
 
-    var attributeIndices = {
+    var attributeLocations = {
         texCoordExpandWidthAndShow : 0,
         position3DHigh : 1,
         position3DLow : 2,
@@ -799,85 +799,85 @@ define([
                     var vertexTexCoordExpandWidthAndShowBufferOffset = k * (texCoordExpandWidthAndShowSizeInBytes * CesiumMath.SIXTY_FOUR_KILOBYTES) - vbo * texCoordExpandWidthAndShowSizeInBytes;
 
                     var attributes = [{
-                        index : attributeIndices.position3DHigh,
+                        index : attributeLocations.position3DHigh,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : positionHighOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.position3DLow,
+                        index : attributeLocations.position3DLow,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : positionLowOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.position2DHigh,
+                        index : attributeLocations.position2DHigh,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : positionHighOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.position2DLow,
+                        index : attributeLocations.position2DLow,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : positionLowOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.prevPosition3DHigh,
+                        index : attributeLocations.prevPosition3DHigh,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : prevPositionHighOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.prevPosition3DLow,
+                        index : attributeLocations.prevPosition3DLow,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : prevPositionLowOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.prevPosition2DHigh,
+                        index : attributeLocations.prevPosition2DHigh,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : prevPositionHighOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.prevPosition2DLow,
+                        index : attributeLocations.prevPosition2DLow,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : prevPositionLowOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.nextPosition3DHigh,
+                        index : attributeLocations.nextPosition3DHigh,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : nextPositionHighOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.nextPosition3DLow,
+                        index : attributeLocations.nextPosition3DLow,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : nextPositionLowOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.nextPosition2DHigh,
+                        index : attributeLocations.nextPosition2DHigh,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : nextPositionHighOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.nextPosition2DLow,
+                        index : attributeLocations.nextPosition2DLow,
                         componentsPerAttribute : 3,
                         componentDatatype : ComponentDatatype.FLOAT,
                         offsetInBytes : nextPositionLowOffset,
                         strideInBytes : 6 * positionSizeInBytes
                     }, {
-                        index : attributeIndices.texCoordExpandWidthAndShow,
+                        index : attributeLocations.texCoordExpandWidthAndShow,
                         componentsPerAttribute : 4,
                         componentDatatype : ComponentDatatype.FLOAT,
                         vertexBuffer : collection._texCoordExpandWidthAndShowBuffer,
                         offsetInBytes : vertexTexCoordExpandWidthAndShowBufferOffset
                     }, {
-                        index : attributeIndices.pickColor,
+                        index : attributeLocations.pickColor,
                         componentsPerAttribute : 4,
                         componentDatatype : ComponentDatatype.UNSIGNED_BYTE,
                         vertexBuffer : collection._pickColorBuffer,
@@ -1071,8 +1071,8 @@ define([
         var vsSource = createShaderSource({ sources : [PolylineCommon, PolylineVS] });
         var fsSource = createShaderSource({ sources : [this.material.shaderSource, PolylineFS] });
         var fsPick = createShaderSource({ sources : [fsSource], pickColorQualifier : 'varying' });
-        this.shaderProgram = context.getShaderCache().getShaderProgram(vsSource, fsSource, attributeIndices);
-        this.pickShaderProgram = context.getShaderCache().getShaderProgram(vsSource, fsPick, attributeIndices);
+        this.shaderProgram = context.getShaderCache().getShaderProgram(vsSource, fsSource, attributeLocations);
+        this.pickShaderProgram = context.getShaderCache().getShaderProgram(vsSource, fsPick, attributeLocations);
     };
 
     function intersectsIDL(polyline) {

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -308,13 +308,13 @@ define([
         this._boundingSphereWC = undefined;
         this._boundingSphereCV = undefined;
         this._boundingSphere2D = undefined;
-        this._perInstanceAttributeIndices = undefined;
+        this._perInstanceAttributeLocations = undefined;
         this._instanceIds = [];
         this._lastPerInstanceAttributeIndex = 0;
         this._dirtyAttributes = [];
 
         this._va = [];
-        this._attributeIndices = undefined;
+        this._attributeLocations = undefined;
         this._primitiveType = undefined;
 
         this._frontFaceRS = undefined;
@@ -454,7 +454,7 @@ define([
     }
 
     function appendShow(primitive, vertexShaderSource) {
-        if (!defined(primitive._attributeIndices.show)) {
+        if (!defined(primitive._attributeLocations.show)) {
             return vertexShaderSource;
         }
 
@@ -470,7 +470,7 @@ define([
         return renamedVS + '\n' + showMain;
     }
 
-    function validateShaderMatching(shaderProgram, attributeIndices) {
+    function validateShaderMatching(shaderProgram, attributeLocations) {
         // For a VAO and shader program to be compatible, the VAO must have
         // all active attribute in the shader program.  The VAO may have
         // extra attributes with the only concern being a potential
@@ -485,7 +485,7 @@ define([
         //>>includeStart('debug', pragmas.debug);
         for (var name in shaderAttributes) {
             if (shaderAttributes.hasOwnProperty(name)) {
-                if (!defined(attributeIndices[name])) {
+                if (!defined(attributeLocations[name])) {
                     throw new DeveloperError('Appearance/Geometry mismatch.  The appearance requires vertex shader attribute input \'' + name +
                         '\', which was not computed as part of the Geometry.  Use the appearance\'s vertexFormat property when constructing the geometry.');
                 }
@@ -622,9 +622,9 @@ define([
                         PrimitivePipeline.receivePerInstanceAttributes(result.vaAttributes);
 
                         that._geometries = result.geometries;
-                        that._attributeIndices = result.attributeIndices;
+                        that._attributeLocations = result.attributeLocations;
                         that._vaAttributes = result.vaAttributes;
-                        that._perInstanceAttributeIndices = result.vaAttributeIndices;
+                        that._perInstanceAttributeLocations = result.vaAttributeLocations;
                         Matrix4.clone(result.modelMatrix, that.modelMatrix);
                         that._state = PrimitiveState.COMBINED;
                     }, function(error) {
@@ -675,16 +675,16 @@ define([
                 });
 
                 this._geometries = result.geometries;
-                this._attributeIndices = result.attributeIndices;
+                this._attributeLocations = result.attributeLocations;
                 this._vaAttributes = result.vaAttributes;
-                this._perInstanceAttributeIndices = result.vaAttributeIndices;
+                this._perInstanceAttributeLocations = result.vaAttributeLocations;
                 Matrix4.clone(result.modelMatrix, this.modelMatrix);
 
                 this._state = PrimitiveState.COMBINED;
             }
         }
 
-        var attributeIndices = this._attributeIndices;
+        var attributeLocations = this._attributeLocations;
 
         if (this._state === PrimitiveState.COMBINED) {
             geometries = this._geometries;
@@ -707,7 +707,7 @@ define([
 
                 va.push(context.createVertexArrayFromGeometry({
                     geometry : geometry,
-                    attributeIndices : attributeIndices,
+                    attributeLocations : attributeLocations,
                     bufferUsage : BufferUsage.STATIC_DRAW,
                     vertexLayout : VertexLayout.INTERLEAVED,
                     vertexArrayAttributes : attributes
@@ -798,17 +798,17 @@ define([
             vs = appendShow(this, vs);
             var fs = appearance.getFragmentShaderSource();
 
-            this._sp = shaderCache.replaceShaderProgram(this._sp, vs, fs, attributeIndices);
-            validateShaderMatching(this._sp, attributeIndices);
+            this._sp = shaderCache.replaceShaderProgram(this._sp, vs, fs, attributeLocations);
+            validateShaderMatching(this._sp, attributeLocations);
 
             if (allowPicking) {
                 var pickFS = createShaderSource({ sources : [fs], pickColorQualifier : 'varying' });
-                this._pickSP = shaderCache.replaceShaderProgram(this._pickSP, createPickVertexShaderSource(vs), pickFS, attributeIndices);
+                this._pickSP = shaderCache.replaceShaderProgram(this._pickSP, createPickVertexShaderSource(vs), pickFS, attributeLocations);
             } else {
-                this._pickSP = shaderCache.getShaderProgram(vs, fs, attributeIndices);
+                this._pickSP = shaderCache.getShaderProgram(vs, fs, attributeLocations);
             }
 
-            validateShaderMatching(this._pickSP, attributeIndices);
+            validateShaderMatching(this._pickSP, attributeLocations);
         }
 
         var colorCommands = this._colorCommands;
@@ -989,7 +989,7 @@ define([
         if (!defined(id)) {
             throw new DeveloperError('id is required');
         }
-        if (!defined(this._perInstanceAttributeIndices)) {
+        if (!defined(this._perInstanceAttributeLocations)) {
             throw new DeveloperError('must call update before calling getGeometryInstanceAttributes');
         }
         //>>includeEnd('debug');
@@ -1010,7 +1010,7 @@ define([
             return undefined;
         }
 
-        var perInstanceAttributes = this._perInstanceAttributeIndices[index];
+        var perInstanceAttributes = this._perInstanceAttributeLocations[index];
         var attributes = {};
         var properties = {};
         var hasProperties = false;

--- a/Source/Scene/PrimitivePipeline.js
+++ b/Source/Scene/PrimitivePipeline.js
@@ -239,7 +239,7 @@ define([
         return [geometry];
     }
 
-    function createPerInstanceVAAttributes(geometry, attributeIndices, names) {
+    function createPerInstanceVAAttributes(geometry, attributeLocations, names) {
         var vaAttributes = [];
         var attributes = geometry.attributes;
 
@@ -255,7 +255,7 @@ define([
 
             var typedArray = ComponentDatatype.createTypedArray(componentDatatype, attribute.values);
             vaAttributes.push({
-                index : attributeIndices[name],
+                index : attributeLocations[name],
                 componentDatatype : componentDatatype,
                 componentsPerAttribute : attribute.componentsPerAttribute,
                 normalize : attribute.normalize,
@@ -268,7 +268,7 @@ define([
         return vaAttributes;
     }
 
-    function computePerInstanceAttributeIndices(instances, vertexArrays, attributeIndices) {
+    function computePerInstanceAttributeLocations(instances, vertexArrays, attributeLocations) {
         var indices = [];
 
         var names = getCommonPerInstanceAttributeNames(instances);
@@ -283,7 +283,7 @@ define([
             var namesLength = names.length;
             for (var j = 0; j < namesLength; ++j) {
                 var name = names[j];
-                var index = attributeIndices[name];
+                var index = attributeLocations[name];
 
                 var tempVertexCount = numberOfVertices;
                 while (tempVertexCount > 0) {
@@ -363,7 +363,7 @@ define([
             modelMatrix : Matrix4.clone(parameters.modelMatrix)
         };
         var geometries = geometryPipeline(clonedParameters);
-        var attributeIndices = GeometryPipeline.createAttributeIndices(geometries[0]);
+        var attributeLocations = GeometryPipeline.createAttributeLocations(geometries[0]);
 
         var instances = clonedParameters.instances;
         var perInstanceAttributeNames = getCommonPerInstanceAttributeNames(instances);
@@ -372,17 +372,17 @@ define([
         var length = geometries.length;
         for (var i = 0; i < length; ++i) {
             var geometry = geometries[i];
-            perInstanceAttributes.push(createPerInstanceVAAttributes(geometry, attributeIndices, perInstanceAttributeNames));
+            perInstanceAttributes.push(createPerInstanceVAAttributes(geometry, attributeLocations, perInstanceAttributeNames));
         }
 
-        var indices = computePerInstanceAttributeIndices(instances, perInstanceAttributes, attributeIndices);
+        var indices = computePerInstanceAttributeLocations(instances, perInstanceAttributes, attributeLocations);
 
         return {
             geometries : geometries,
             modelMatrix : clonedParameters.modelMatrix,
-            attributeIndices : attributeIndices,
+            attributeLocations : attributeLocations,
             vaAttributes : perInstanceAttributes,
-            vaAttributeIndices : indices
+            vaAttributeLocations : indices
         };
     };
 

--- a/Source/Scene/SkyAtmosphere.js
+++ b/Source/Scene/SkyAtmosphere.js
@@ -145,7 +145,7 @@ define([
             }));
             command.vertexArray = context.createVertexArrayFromGeometry({
                 geometry : geometry,
-                attributeIndices : GeometryPipeline.createAttributeIndices(geometry),
+                attributeLocations : GeometryPipeline.createAttributeLocations(geometry),
                 bufferUsage : BufferUsage.STATIC_DRAW
             });
             command.primitiveType = PrimitiveType.TRIANGLES;

--- a/Source/Scene/SkyBox.js
+++ b/Source/Scene/SkyBox.js
@@ -163,16 +163,16 @@ define([
                 dimensions : new Cartesian3(2.0, 2.0, 2.0),
                 vertexFormat : VertexFormat.POSITION_ONLY
             }));
-            var attributeIndices = GeometryPipeline.createAttributeIndices(geometry);
+            var attributeLocations = GeometryPipeline.createAttributeLocations(geometry);
 
             command.primitiveType = PrimitiveType.TRIANGLES;
             command.modelMatrix = Matrix4.clone(Matrix4.IDENTITY);
             command.vertexArray = context.createVertexArrayFromGeometry({
                 geometry: geometry,
-                attributeIndices: attributeIndices,
+                attributeLocations: attributeLocations,
                 bufferUsage: BufferUsage.STATIC_DRAW
             });
-            command.shaderProgram = context.getShaderCache().getShaderProgram(SkyBoxVS, SkyBoxFS, attributeIndices);
+            command.shaderProgram = context.getShaderCache().getShaderProgram(SkyBoxVS, SkyBoxFS, attributeLocations);
             command.renderState = context.createRenderState({
                 blending : BlendingState.ALPHA_BLEND
             });

--- a/Source/Scene/Sun.js
+++ b/Source/Scene/Sun.js
@@ -120,7 +120,7 @@ define([
         }
     });
 
-    var viewportAttributeIndices = {
+    var viewportAttributeLocations = {
         position : 0,
         textureCoordinates : 1
     };
@@ -162,7 +162,7 @@ define([
 
         vertexArray = context.createVertexArrayFromGeometry({
             geometry : geometry,
-            attributeIndices : viewportAttributeIndices,
+            attributeLocations : viewportAttributeLocations,
             bufferUsage : BufferUsage.STATIC_DRAW
         });
 
@@ -226,7 +226,7 @@ define([
             drawCommand.owner = this;
             drawCommand.primitiveType = PrimitiveType.TRIANGLE_FAN;
             drawCommand.vertexArray = getVertexArray(context);
-            drawCommand.shaderProgram = context.getShaderCache().getShaderProgram(ViewportQuadVS, SunTextureFS, viewportAttributeIndices);
+            drawCommand.shaderProgram = context.getShaderCache().getShaderProgram(ViewportQuadVS, SunTextureFS, viewportAttributeLocations);
             drawCommand.framebuffer = fbo;
             drawCommand.renderState = context.createRenderState({
                 viewport : new BoundingRectangle(0.0, 0.0, size, size)
@@ -255,7 +255,7 @@ define([
         var command = this._command;
 
         if (!defined(command.vertexArray)) {
-            var attributeIndices = {
+            var attributeLocations = {
                 direction : 0
             };
 
@@ -274,7 +274,7 @@ define([
 
             var vertexBuffer = context.createVertexBuffer(directions, BufferUsage.STATIC_DRAW);
             var attributes = [{
-                index : attributeIndices.direction,
+                index : attributeLocations.direction,
                 vertexBuffer : vertexBuffer,
                 componentsPerAttribute : 2,
                 normalize : true,
@@ -283,7 +283,7 @@ define([
             command.vertexArray = context.createVertexArray(attributes);
             command.primitiveType = PrimitiveType.TRIANGLE_FAN;
 
-            command.shaderProgram = context.getShaderCache().getShaderProgram(SunVS, SunFS, attributeIndices);
+            command.shaderProgram = context.getShaderCache().getShaderProgram(SunVS, SunFS, attributeLocations);
             command.renderState = context.createRenderState({
                 blending : BlendingState.ALPHA_BLEND
             });

--- a/Source/Scene/SunPostProcess.js
+++ b/Source/Scene/SunPostProcess.js
@@ -108,7 +108,7 @@ define([
         this._blendCommand.execute(context, this._upSamplePassState);
     };
 
-    var attributeIndices = {
+    var attributeLocations = {
         position : 0,
         textureCoordinates : 1
     };
@@ -150,7 +150,7 @@ define([
 
         vertexArray = context.createVertexArrayFromGeometry({
             geometry : geometry,
-            attributeIndices : attributeIndices,
+            attributeLocations : attributeLocations,
             bufferUsage : BufferUsage.STATIC_DRAW
         });
 
@@ -184,14 +184,14 @@ define([
             downSampleCommand.owner = this;
             downSampleCommand.primitiveType = primitiveType;
             downSampleCommand.vertexArray = vertexArray;
-            downSampleCommand.shaderProgram = context.getShaderCache().getShaderProgram(ViewportQuadVS, PassThrough, attributeIndices);
+            downSampleCommand.shaderProgram = context.getShaderCache().getShaderProgram(ViewportQuadVS, PassThrough, attributeLocations);
             downSampleCommand.uniformMap = {};
 
             var brightPassCommand = this._brightPassCommand = new DrawCommand();
             brightPassCommand.owner = this;
             brightPassCommand.primitiveType = primitiveType;
             brightPassCommand.vertexArray = vertexArray;
-            brightPassCommand.shaderProgram = context.getShaderCache().getShaderProgram(ViewportQuadVS, BrightPass, attributeIndices);
+            brightPassCommand.shaderProgram = context.getShaderCache().getShaderProgram(ViewportQuadVS, BrightPass, attributeLocations);
             brightPassCommand.uniformMap = {
                 u_avgLuminance : function() {
                     // A guess at the average luminance across the entire scene
@@ -212,7 +212,7 @@ define([
             blurXCommand.owner = this;
             blurXCommand.primitiveType = primitiveType;
             blurXCommand.vertexArray = vertexArray;
-            blurXCommand.shaderProgram = context.getShaderCache().getShaderProgram(ViewportQuadVS, GaussianBlur1D, attributeIndices);
+            blurXCommand.shaderProgram = context.getShaderCache().getShaderProgram(ViewportQuadVS, GaussianBlur1D, attributeLocations);
             blurXCommand.uniformMap = {
                 delta : function() {
                     return delta;
@@ -229,7 +229,7 @@ define([
             blurYCommand.owner = this;
             blurYCommand.primitiveType = primitiveType;
             blurYCommand.vertexArray = vertexArray;
-            blurYCommand.shaderProgram = context.getShaderCache().getShaderProgram(ViewportQuadVS, GaussianBlur1D, attributeIndices);
+            blurYCommand.shaderProgram = context.getShaderCache().getShaderProgram(ViewportQuadVS, GaussianBlur1D, attributeLocations);
             blurYCommand.uniformMap = {
                 delta : function() {
                     return delta;
@@ -246,7 +246,7 @@ define([
             additiveBlendCommand.owner = this;
             additiveBlendCommand.primitiveType = primitiveType;
             additiveBlendCommand.vertexArray = vertexArray;
-            additiveBlendCommand.shaderProgram = context.getShaderCache().getShaderProgram(ViewportQuadVS, AdditiveBlend, attributeIndices);
+            additiveBlendCommand.shaderProgram = context.getShaderCache().getShaderProgram(ViewportQuadVS, AdditiveBlend, attributeLocations);
             additiveBlendCommand.uniformMap = {
                 u_center : function() {
                     return that._uCenter;
@@ -260,7 +260,7 @@ define([
             fullScreenCommand.owner = this;
             fullScreenCommand.primitiveType = primitiveType;
             fullScreenCommand.vertexArray = vertexArray;
-            fullScreenCommand.shaderProgram = context.getShaderCache().getShaderProgram(ViewportQuadVS, PassThrough, attributeIndices);
+            fullScreenCommand.shaderProgram = context.getShaderCache().getShaderProgram(ViewportQuadVS, PassThrough, attributeLocations);
             fullScreenCommand.uniformMap = {};
         }
 

--- a/Source/Scene/TerrainProvider.js
+++ b/Source/Scene/TerrainProvider.js
@@ -34,7 +34,7 @@ define([
      *
      * @memberof TerrainProvider
      */
-    TerrainProvider.attributeIndices = {
+    TerrainProvider.attributeLocations = {
         position3DAndHeight : 0,
         textureCoordinates : 1
     };
@@ -113,14 +113,14 @@ define([
         }
 
         var attributes = [{
-            index : TerrainProvider.attributeIndices.position3DAndHeight,
+            index : TerrainProvider.attributeLocations.position3DAndHeight,
             vertexBuffer : buffer,
             componentDatatype : datatype,
             componentsPerAttribute : position3DAndHeightLength,
             offsetInBytes : 0,
             strideInBytes : stride
         }, {
-            index : TerrainProvider.attributeIndices.textureCoordinates,
+            index : TerrainProvider.attributeLocations.textureCoordinates,
             vertexBuffer : buffer,
             componentDatatype : datatype,
             componentsPerAttribute : 2,

--- a/Source/Scene/ViewportQuad.js
+++ b/Source/Scene/ViewportQuad.js
@@ -107,7 +107,7 @@ define([
         this._material = undefined;
     };
 
-    var attributeIndices = {
+    var attributeLocations = {
         position : 0,
         textureCoordinates : 1
     };
@@ -149,7 +149,7 @@ define([
 
         vertexArray = context.createVertexArrayFromGeometry({
             geometry : geometry,
-            attributeIndices : attributeIndices,
+            attributeLocations : attributeLocations,
             bufferUsage : BufferUsage.STATIC_DRAW
         });
 
@@ -200,7 +200,7 @@ define([
 
                 var fsSource = createShaderSource({ sources : [this._material.shaderSource, ViewportQuadFS] });
                 this._overlayCommand.shaderProgram = context.getShaderCache().replaceShaderProgram(
-                    this._overlayCommand.shaderProgram, ViewportQuadVS, fsSource, attributeIndices);
+                    this._overlayCommand.shaderProgram, ViewportQuadVS, fsSource, attributeLocations);
             }
 
             this._material.update(context);

--- a/Specs/Core/GeometryPipelineSpec.js
+++ b/Specs/Core/GeometryPipelineSpec.js
@@ -214,7 +214,7 @@ defineSuite([
             primitiveType : PrimitiveType.TRIANGLES
         });
 
-        var indices = GeometryPipeline.createAttributeIndices(geometry);
+        var indices = GeometryPipeline.createAttributeLocations(geometry);
 
         var validIndices = [0, 1, 2];
         expect(validIndices).toContain(indices.position);
@@ -224,9 +224,9 @@ defineSuite([
         expect(indices.position).not.toEqual(indices.color);
     });
 
-    it('createAttributeIndices throws without a geometry', function() {
+    it('createAttributeLocations throws without a geometry', function() {
         expect(function() {
-            GeometryPipeline.createAttributeIndices(undefined);
+            GeometryPipeline.createAttributeLocations(undefined);
         }).toThrowDeveloperError();
     });
 

--- a/Specs/Renderer/VertexArrayFactorySpec.js
+++ b/Specs/Renderer/VertexArrayFactorySpec.js
@@ -71,7 +71,7 @@ defineSuite([
 
         var va = context.createVertexArrayFromGeometry({
             geometry : geometry,
-            attributeIndices : GeometryPipeline.createAttributeIndices(geometry)
+            attributeLocations : GeometryPipeline.createAttributeLocations(geometry)
         });
 
         expect(va.getNumberOfAttributes()).toEqual(1);
@@ -101,7 +101,7 @@ defineSuite([
 
         var va = context.createVertexArrayFromGeometry({
             geometry : geometry,
-            attributeIndices : GeometryPipeline.createAttributeIndices(geometry),
+            attributeLocations : GeometryPipeline.createAttributeLocations(geometry),
             vertexLayout : VertexLayout.INTERLEAVED,
             bufferUsage : BufferUsage.STATIC_DRAW
         });
@@ -138,7 +138,7 @@ defineSuite([
 
         var va = context.createVertexArrayFromGeometry({
             geometry : geometry,
-            attributeIndices : GeometryPipeline.createAttributeIndices(geometry)
+            attributeLocations : GeometryPipeline.createAttributeLocations(geometry)
         });
 
         expect(va.getNumberOfAttributes()).toEqual(2);
@@ -180,7 +180,7 @@ defineSuite([
 
         var va = context.createVertexArrayFromGeometry({
             geometry : geometry,
-            attributeIndices : GeometryPipeline.createAttributeIndices(geometry),
+            attributeLocations : GeometryPipeline.createAttributeLocations(geometry),
             vertexLayout : VertexLayout.INTERLEAVED
         });
 
@@ -225,7 +225,7 @@ defineSuite([
 
         var va = context.createVertexArrayFromGeometry({
             geometry : geometry,
-            attributeIndices : GeometryPipeline.createAttributeIndices(geometry),
+            attributeLocations : GeometryPipeline.createAttributeLocations(geometry),
             vertexLayout : VertexLayout.INTERLEAVED
         });
 
@@ -273,10 +273,10 @@ defineSuite([
             primitiveType : PrimitiveType.POINTS
         });
 
-        var attributeIndices = GeometryPipeline.createAttributeIndices(geometry);
+        var attributeLocations = GeometryPipeline.createAttributeLocations(geometry);
         var va = context.createVertexArrayFromGeometry({
             geometry : geometry,
-            attributeIndices : attributeIndices,
+            attributeLocations : attributeLocations,
             vertexLayout : VertexLayout.INTERLEAVED
         });
 
@@ -303,7 +303,7 @@ defineSuite([
             'void main() { ' +
             '  gl_FragColor = fsColor; ' +
             '}';
-        sp = context.createShaderProgram(vs, fs, attributeIndices);
+        sp = context.createShaderProgram(vs, fs, attributeLocations);
 
         ClearCommand.ALL.execute(context);
         expect(context.readPixels()).toEqual([0, 0, 0, 0]);
@@ -334,10 +334,10 @@ defineSuite([
             primitiveType : PrimitiveType.POINTS
         });
 
-        var attributeIndices = GeometryPipeline.createAttributeIndices(geometry);
+        var attributeLocations = GeometryPipeline.createAttributeLocations(geometry);
         var va = context.createVertexArrayFromGeometry({
             geometry : geometry,
-            attributeIndices : attributeIndices,
+            attributeLocations : attributeLocations,
             vertexLayout : VertexLayout.INTERLEAVED
         });
 
@@ -358,7 +358,7 @@ defineSuite([
             'void main() { ' +
             '  gl_FragColor = fsColor; ' +
             '}';
-        sp = context.createShaderProgram(vs, fs, attributeIndices);
+        sp = context.createShaderProgram(vs, fs, attributeLocations);
 
         ClearCommand.ALL.execute(context);
         expect(context.readPixels()).toEqual([0, 0, 0, 0]);
@@ -409,10 +409,10 @@ defineSuite([
             primitiveType : PrimitiveType.POINTS
         });
 
-        var attributeIndices = GeometryPipeline.createAttributeIndices(geometry);
+        var attributeLocations = GeometryPipeline.createAttributeLocations(geometry);
         var va = context.createVertexArrayFromGeometry({
             geometry : geometry,
-            attributeIndices : attributeIndices,
+            attributeLocations : attributeLocations,
             vertexLayout : VertexLayout.INTERLEAVED
         });
 
@@ -436,7 +436,7 @@ defineSuite([
             'void main() { ' +
             '  gl_FragColor = fsColor; ' +
             '}';
-        sp = context.createShaderProgram(vs, fs, attributeIndices);
+        sp = context.createShaderProgram(vs, fs, attributeLocations);
 
         ClearCommand.ALL.execute(context);
         expect(context.readPixels()).toEqual([0, 0, 0, 0]);
@@ -477,10 +477,10 @@ defineSuite([
             primitiveType : PrimitiveType.POINTS
         });
 
-        var attributeIndices = GeometryPipeline.createAttributeIndices(geometry);
+        var attributeLocations = GeometryPipeline.createAttributeLocations(geometry);
         var va = context.createVertexArrayFromGeometry({
             geometry : geometry,
-            attributeIndices : attributeIndices,
+            attributeLocations : attributeLocations,
             vertexLayout : VertexLayout.INTERLEAVED
         });
 
@@ -508,7 +508,7 @@ defineSuite([
             'void main() { ' +
             '  gl_FragColor = fsColor; ' +
             '}';
-        sp = context.createShaderProgram(vs, fs, attributeIndices);
+        sp = context.createShaderProgram(vs, fs, attributeLocations);
 
         ClearCommand.ALL.execute(context);
         expect(context.readPixels()).toEqual([0, 0, 0, 0]);
@@ -539,7 +539,7 @@ defineSuite([
             '  }' +
             '}';
         sp = sp.destroy();
-        sp = context.createShaderProgram(vs2, fs, attributeIndices);
+        sp = context.createShaderProgram(vs2, fs, attributeLocations);
 
         context.draw({
             primitiveType : PrimitiveType.POINTS,
@@ -614,7 +614,7 @@ defineSuite([
         expect(function() {
             return context.createVertexArrayFromGeometry({
                 geometry : geometry,
-                attributeIndices : {
+                attributeLocations : {
                     position : 0,
                     normal : 0
                 }

--- a/Specs/Scene/MultifrustumSpec.js
+++ b/Specs/Scene/MultifrustumSpec.js
@@ -245,14 +245,14 @@ defineSuite([
                     minimumCorner: minimumCorner,
                     maximumCorner: maximumCorner
                 }));
-                var attributeIndices = GeometryPipeline.createAttributeIndices(geometry);
+                var attributeLocations = GeometryPipeline.createAttributeLocations(geometry);
                 this._va = context.createVertexArrayFromGeometry({
                     geometry: geometry,
-                    attributeIndices: attributeIndices,
+                    attributeLocations: attributeLocations,
                     bufferUsage: BufferUsage.STATIC_DRAW
                 });
 
-                this._sp = context.getShaderCache().getShaderProgram(vs, fs, attributeIndices);
+                this._sp = context.getShaderCache().getShaderProgram(vs, fs, attributeLocations);
                 this._rs = context.createRenderState({
                     blending : BlendingState.ALPHA_BLEND
                 });


### PR DESCRIPTION
To better match WebGL and other parts of the code that were already using `attributeLocations`.
