### PR TITLE
View Extent

### DIFF
--- a/Source/Scene/CameraController.js
+++ b/Source/Scene/CameraController.js
@@ -1023,9 +1023,19 @@ define([
             result = new Cartesian3();
         }
 
-        var scalar = Cartesian3.magnitude(center) + d;
-        Cartesian3.negate(direction, result);
-        return Cartesian3.multiplyByScalar(result, scalar, result);
+        var mag = Cartesian3.magnitude(center);
+        var scalar = mag + d;
+
+        if (mag < CesiumMath.EPSILON6) {
+            cart.longitude = (east + west) * 0.5;
+            cart.latitude = (north + south) * 0.5;
+            ellipsoid.cartographicToCartesian(cart, center);
+            Cartesian3.normalize(center, center);
+        } else {
+            Cartesian3.normalize(center, center);
+        }
+
+        return Cartesian3.multiplyByScalar(center, scalar, result);
     }
 
     var viewExtentCVCartographic = new Cartographic();


### PR DESCRIPTION
Fixes #1413.

Change view extent back to using the geocentric normal instead of the geodetic normal, which explains why the error was increasing closer as the extents approached the poles. The code was changed to fix test failures in Canary when normalizing a vector near zero. All of the tests should still pass.
