### PR TITLE
Clock tracking

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Beta Releases
 
 ### b26 - 2014-03-03
 
+* Breaking changes:
+  * Renamed `Viewer.automaticallyTrackFirstDataSourceClock` to `Viewer.automaticallyTrackDataSourceClocks`.
 * Added new `SelectionIndicator` and `InfoBox` widgets to `Viewer`, activated by `viewerDynamicObjectMixin`.
 
 ### b25 - 2014-02-03

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -24,7 +24,8 @@ define([
         '../SceneModePicker/SceneModePicker',
         '../SelectionIndicator/SelectionIndicator',
         '../subscribeAndEvaluate',
-        '../Timeline/Timeline'
+        '../Timeline/Timeline',
+        '../../ThirdParty/knockout'
     ], function(
         defaultValue,
         defined,
@@ -50,7 +51,8 @@ define([
         SceneModePicker,
         SelectionIndicator,
         subscribeAndEvaluate,
-        Timeline) {
+        Timeline,
+        knockout) {
     "use strict";
 
     function onTimelineScrubfunction(e) {
@@ -116,7 +118,7 @@ define([
      * @param {Element} [options.fullscreenElement=document.body] The element to make full screen when the full screen button is pressed.
      * @param {Boolean} [options.useDefaultRenderLoop=true] True if this widget should control the render loop, false otherwise.
      * @param {Boolean} [options.showRenderLoopErrors=true] If true, this widget will automatically display an HTML panel to the user containing the error, if a render loop error occurs.
-     * @param {Boolean} [options.automaticallyTrackFirstDataSourceClock=true] If true, this widget will automatically track the clock settings of the first DataSource that is added, updating if the DataSource's clock changes.  Set this to false if you want to configure the clock independently.
+     * @param {Boolean} [options.automaticallyTrackDataSourceClocks=true] If true, this widget will automatically track the clock settings of newly added DataSources, updating if the DataSource's clock changes.  Set this to false if you want to configure the clock independently.
      * @param {Object} [options.contextOptions=undefined] Context and WebGL creation properties corresponding to {@link Context#options}.
      * @param {SceneMode} [options.sceneMode=SceneMode.SCENE3D] The initial scene mode.
      *
@@ -341,11 +343,21 @@ Either specify options.imageryProvider instead or set options.baseLayerPicker to
             timeline.container.style.right = 0;
         }
 
-        if (defaultValue(options.automaticallyTrackFirstDataSourceClock, true)) {
-            var trackedDataSource;
-            var changedEventRemovalFunction;
+        /**
+         * Gets or sets the data source to track with the viewer's clock.
+         * @type {DataSource}
+         */
+        this.clockTrackedDataSource = undefined;
 
-            var onDataSourceChanged = function(dataSource) {
+        knockout.track(this, ['clockTrackedDataSource']);
+
+        this._dataSourceChangedListeners = {};
+        this._knockoutSubscriptions = [];
+        var automaticallyTrackDataSourceClocks = defaultValue(options.automaticallyTrackDataSourceClocks, true);
+        var that = this;
+
+        function trackDataSourceClock(dataSource) {
+            if (defined(dataSource)) {
                 var dataSourceClock = dataSource.getClock();
                 if (defined(dataSourceClock)) {
                     dataSourceClock.getValue(clock);
@@ -354,27 +366,45 @@ Either specify options.imageryProvider instead or set options.baseLayerPicker to
                         timeline.zoomTo(dataSourceClock.startTime, dataSourceClock.stopTime);
                     }
                 }
-            };
-
-            var onDataSourceAdded = function(dataSourceCollection, dataSource) {
-                if (dataSourceCollection.getLength() === 1) {
-                    onDataSourceChanged(dataSource);
-                    changedEventRemovalFunction = eventHelper.add(dataSource.getChangedEvent(), onDataSourceChanged);
-                    trackedDataSource = dataSource;
-                }
-            };
-
-            var onDataSourceRemoved = function(dataSourceCollection, dataSource) {
-                if (trackedDataSource === dataSource) {
-                    changedEventRemovalFunction();
-                    changedEventRemovalFunction = undefined;
-                    trackedDataSource = undefined;
-                }
-            };
-
-            eventHelper.add(dataSourceCollection.dataSourceAdded, onDataSourceAdded);
-            eventHelper.add(dataSourceCollection.dataSourceRemoved, onDataSourceRemoved);
+            }
         }
+
+        this._knockoutSubscriptions.push(subscribeAndEvaluate(this, 'clockTrackedDataSource', function(value) {
+            trackDataSourceClock(value);
+        }));
+
+        var onDataSourceChanged = function(dataSource) {
+            if (this.clockTrackedDataSource === dataSource) {
+                trackDataSourceClock(dataSource);
+            }
+        };
+
+        var onDataSourceAdded = function(dataSourceCollection, dataSource) {
+            if (automaticallyTrackDataSourceClocks) {
+                that.clockTrackedDataSource = dataSource;
+            }
+            var id = dataSource.getDynamicObjectCollection().id;
+            var removalFunc = eventHelper.add(dataSource.getChangedEvent(), onDataSourceChanged);
+            that._dataSourceChangedListeners[id] = removalFunc;
+        };
+
+        var onDataSourceRemoved = function(dataSourceCollection, dataSource) {
+            var resetClock = (that.clockTrackedDataSource === dataSource);
+            var id = dataSource.getDynamicObjectCollection().id;
+            that._dataSourceChangedListeners[id]();
+            that._dataSourceChangedListeners[id] = undefined;
+            if (resetClock) {
+                var numDataSources = dataSourceCollection.getLength();
+                if (automaticallyTrackDataSourceClocks && numDataSources > 0) {
+                    that.clockTrackedDataSource = dataSourceCollection.get(numDataSources - 1);
+                } else {
+                    that.clockTrackedDataSource = undefined;
+                }
+            }
+        };
+
+        eventHelper.add(dataSourceCollection.dataSourceAdded, onDataSourceAdded);
+        eventHelper.add(dataSourceCollection.dataSourceRemoved, onDataSourceRemoved);
 
         this._container = container;
         this._element = viewerContainer;
@@ -796,6 +826,12 @@ Either specify options.imageryProvider instead or set options.baseLayerPicker to
      * @memberof Viewer
      */
     Viewer.prototype.destroy = function() {
+        var i;
+        var numSubscriptions = this._knockoutSubscriptions.length;
+        for (i = 0; i < numSubscriptions; i++) {
+            this._knockoutSubscriptions[i].dispose();
+        }
+
         this._container.removeChild(this._element);
         this._element.removeChild(this._toolbar);
 

--- a/Specs/Widgets/Viewer/ViewerSpec.js
+++ b/Specs/Widgets/Viewer/ViewerSpec.js
@@ -433,6 +433,88 @@ defineSuite([
         expect(viewer.clock.multiplier).toEqual(dataSource.clock.multiplier);
     });
 
+    it('sets the clock for multiple data sources', function() {
+        var dataSource1 = new MockDataSource();
+        dataSource1.clock = new DynamicClock();
+        dataSource1.clock.startTime = JulianDate.fromIso8601('2013-08-01T18:00Z');
+        dataSource1.clock.stopTime = JulianDate.fromIso8601('2013-08-21T02:00Z');
+        dataSource1.clock.currentTime = JulianDate.fromIso8601('2013-08-02T00:00Z');
+
+        viewer = new Viewer(container);
+        viewer.dataSources.add(dataSource1);
+
+        expect(viewer.clockTrackedDataSource).toBe(dataSource1);
+        expect(viewer.clock.startTime).toEqual(dataSource1.clock.startTime);
+
+        var dataSource2 = new MockDataSource();
+        dataSource2.clock = new DynamicClock();
+        dataSource2.clock.startTime = JulianDate.fromIso8601('2014-08-01T18:00Z');
+        dataSource2.clock.stopTime = JulianDate.fromIso8601('2014-08-21T02:00Z');
+        dataSource2.clock.currentTime = JulianDate.fromIso8601('2014-08-02T00:00Z');
+
+        viewer.dataSources.add(dataSource2);
+        expect(viewer.clockTrackedDataSource).toBe(dataSource2);
+        expect(viewer.clock.startTime).toEqual(dataSource2.clock.startTime);
+
+        var dataSource3 = new MockDataSource();
+        dataSource3.clock = new DynamicClock();
+        dataSource3.clock.startTime = JulianDate.fromIso8601('2015-08-01T18:00Z');
+        dataSource3.clock.stopTime = JulianDate.fromIso8601('2015-08-21T02:00Z');
+        dataSource3.clock.currentTime = JulianDate.fromIso8601('2015-08-02T00:00Z');
+
+        viewer.dataSources.add(dataSource3);
+        expect(viewer.clockTrackedDataSource).toBe(dataSource3);
+        expect(viewer.clock.startTime).toEqual(dataSource3.clock.startTime);
+
+        // Removing the last dataSource moves the clock to second-last.
+        viewer.dataSources.remove(dataSource3);
+        expect(viewer.clockTrackedDataSource).toBe(dataSource2);
+        expect(viewer.clock.startTime).toEqual(dataSource2.clock.startTime);
+
+        // Removing the first data source has no effect, because it's not active.
+        viewer.dataSources.remove(dataSource1);
+        expect(viewer.clockTrackedDataSource).toBe(dataSource2);
+        expect(viewer.clock.startTime).toEqual(dataSource2.clock.startTime);
+    });
+
+    it('can manually control the clock tracking', function() {
+        var dataSource1 = new MockDataSource();
+        dataSource1.clock = new DynamicClock();
+        dataSource1.clock.startTime = JulianDate.fromIso8601('2013-08-01T18:00Z');
+        dataSource1.clock.stopTime = JulianDate.fromIso8601('2013-08-21T02:00Z');
+        dataSource1.clock.currentTime = JulianDate.fromIso8601('2013-08-02T00:00Z');
+
+        viewer = new Viewer(container, { automaticallyTrackDataSourceClocks : false });
+        viewer.dataSources.add(dataSource1);
+
+        // Because of the above Viewer option, data sources are not automatically
+        // selected for clock tracking.
+        expect(viewer.clockTrackedDataSource).not.toBeDefined();
+        // The mock data source time is in the past, so will not be the default time.
+        expect(viewer.clock.startTime).not.toEqual(dataSource1.clock.startTime);
+
+        // Manually set the first data source as the tracked data source.
+        viewer.clockTrackedDataSource = dataSource1;
+        expect(viewer.clockTrackedDataSource).toBe(dataSource1);
+        expect(viewer.clock.startTime).toEqual(dataSource1.clock.startTime);
+
+        var dataSource2 = new MockDataSource();
+        dataSource2.clock = new DynamicClock();
+        dataSource2.clock.startTime = JulianDate.fromIso8601('2014-08-01T18:00Z');
+        dataSource2.clock.stopTime = JulianDate.fromIso8601('2014-08-21T02:00Z');
+        dataSource2.clock.currentTime = JulianDate.fromIso8601('2014-08-02T00:00Z');
+
+        // Adding a second data source in manual mode still leaves the first one tracked.
+        viewer.dataSources.add(dataSource2);
+        expect(viewer.clockTrackedDataSource).toBe(dataSource1);
+        expect(viewer.clock.startTime).toEqual(dataSource1.clock.startTime);
+
+        // Removing the tracked data source in manual mode turns off tracking, even
+        // if other data sources remain available for tracking.
+        viewer.dataSources.remove(dataSource1);
+        expect(viewer.clockTrackedDataSource).not.toBeDefined();
+    });
+
     it('shows the error panel when render throws', function() {
         viewer = new Viewer(container);
 


### PR DESCRIPTION
Rather than only being able to handle a single DataSource, Viewer should be able to handle multiple data sources, and keep track of which one is in charge of the clock.  Unit tests have been added for the new behavior.
