### PR TITLE
Fix non-webGL IE 11 specs.

### DIFF
--- a/Source/Core/DeveloperError.js
+++ b/Source/Core/DeveloperError.js
@@ -34,14 +34,20 @@ define(['./defined'], function(defined) {
          */
         this.message = message;
 
-        var e = new Error();
+        //Browsers such as IE don't have a stack property until you actually throw the error.
+        var stack;
+        try {
+            throw new Error();
+        } catch (e) {
+            stack = e.stack;
+        }
 
         /**
          * The stack trace of this exception, if available.
          * @type {String}
          * @constant
          */
-        this.stack = e.stack;
+        this.stack = stack;
     };
 
     DeveloperError.prototype.toString = function() {

--- a/Source/Core/FeatureDetection.js
+++ b/Source/Core/FeatureDetection.js
@@ -85,12 +85,21 @@ define([
     var internetExplorerVersionResult;
     function isInternetExplorer() {
         if (!defined(isInternetExplorerResult)) {
-            var fields = (/ MSIE ([\.0-9]+)/).exec(navigator.userAgent);
-            if (fields === null) {
-                isInternetExplorerResult = false;
+            var fields;
+            if (navigator.appName === 'Microsoft Internet Explorer') {
+                fields = /MSIE ([0-9]{1,}[\.0-9]{0,})/.exec(navigator.userAgent);
+                if (fields !== null) {
+                    isInternetExplorerResult = true;
+                    internetExplorerVersionResult = extractVersion(fields[1]);
+                }
+            } else if (navigator.appName === 'Netscape') {
+                fields = /Trident\/.*rv:([0-9]{1,}[\.0-9]{0,})/.exec(navigator.userAgent);
+                if (fields !== null) {
+                    isInternetExplorerResult = true;
+                    internetExplorerVersionResult = extractVersion(fields[1]);
+                }
             } else {
-                isInternetExplorerResult = true;
-                internetExplorerVersionResult = extractVersion(fields[1]);
+                isInternetExplorerResult = false;
             }
         }
         return isInternetExplorerResult;

--- a/Source/Core/RuntimeError.js
+++ b/Source/Core/RuntimeError.js
@@ -34,14 +34,20 @@ define(['./defined'], function(defined) {
          */
         this.message = message;
 
-        var e = new Error();
+        //Browsers such as IE don't have a stack property until you actually throw the error.
+        var stack;
+        try {
+            throw new Error();
+        } catch (e) {
+            stack = e.stack;
+        }
 
         /**
          * The stack trace of this exception, if available.
          * @type {String}
          * @constant
          */
-        this.stack = e.stack;
+        this.stack = stack;
     };
 
     RuntimeError.prototype.toString = function() {

--- a/Specs/Core/FullscreenSpec.js
+++ b/Specs/Core/FullscreenSpec.js
@@ -1,8 +1,10 @@
 /*global defineSuite*/
 defineSuite([
-             'Core/Fullscreen'
+             'Core/Fullscreen',
+             'Core/FeatureDetection'
          ],function(
-             Fullscreen) {
+             Fullscreen,
+             FeatureDetection) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
@@ -43,21 +45,23 @@ defineSuite([
         Fullscreen.exitFullscreen();
     });
 
-    it('can get the fullscreen change event name', function() {
-        if (Fullscreen.supportsFullscreen()) {
-            // the property on the document is the event name, prefixed with 'on'.
-            expect(document['on' + Fullscreen.getFullscreenChangeEventName()]).toBeDefined();
-        } else {
-            expect(Fullscreen.getFullscreenChangeEventName()).toBeUndefined();
-        }
-    });
+    if (!FeatureDetection.isInternetExplorer()) {
+        it('can get the fullscreen change event name', function() {
+            if (Fullscreen.supportsFullscreen()) {
+                // the property on the document is the event name, prefixed with 'on'.
+                expect(document['on' + Fullscreen.getFullscreenChangeEventName()]).toBeDefined();
+            } else {
+                expect(Fullscreen.getFullscreenChangeEventName()).toBeUndefined();
+            }
+        });
 
-    it('can get the fullscreen error event name', function() {
-        if (Fullscreen.supportsFullscreen()) {
-            // the property on the document is the event name, prefixed with 'on'.
-            expect(document['on' + Fullscreen.getFullscreenErrorEventName()]).toBeDefined();
-        } else {
-            expect(Fullscreen.getFullscreenErrorEventName()).toBeUndefined();
-        }
-    });
+        it('can get the fullscreen error event name', function() {
+            if (Fullscreen.supportsFullscreen()) {
+                // the property on the document is the event name, prefixed with 'on'.
+                expect(document['on' + Fullscreen.getFullscreenErrorEventName()]).toBeDefined();
+            } else {
+                expect(Fullscreen.getFullscreenErrorEventName()).toBeUndefined();
+            }
+        });
+    }
 });

--- a/Specs/Widgets/SvgPathBindingHandlerSpec.js
+++ b/Specs/Widgets/SvgPathBindingHandlerSpec.js
@@ -11,7 +11,7 @@ defineSuite([
     it('check binding with constants', function() {
         var div = document.createElement('div');
         div.setAttribute('data-bind', '\
-cesiumSvgPath: { path: "M 100 100 L 300 100 L 200 300 z", width: 28, height: 40, css: "someClass" }');
+cesiumSvgPath: { path: "M 100 100 L 300 100 L 200 300 Z", width: 28, height: 40, css: "someClass" }');
 
         document.body.appendChild(div);
 
@@ -25,7 +25,7 @@ cesiumSvgPath: { path: "M 100 100 L 300 100 L 200 300 z", width: 28, height: 40,
 
         var path = div.querySelector('svg > path');
         expect(path).not.toBeNull();
-        expect(path.getAttribute('d')).toEqual('M 100 100 L 300 100 L 200 300 z');
+        expect(path.getAttribute('d')).toEqual('M 100 100 L 300 100 L 200 300 Z');
 
         knockout.cleanNode(div);
         document.body.removeChild(div);
@@ -39,7 +39,7 @@ cesiumSvgPath: { path: p, width: w, height: h, css: c }');
         document.body.appendChild(div);
 
         knockout.applyBindings({
-            p : knockout.observable('M 100 100 L 300 100 L 200 300 z'),
+            p : knockout.observable('M 100 100 L 300 100 L 200 300 Z'),
             w : knockout.observable(28),
             h : knockout.observable(40),
             c : knockout.observable('someClass')
@@ -53,7 +53,7 @@ cesiumSvgPath: { path: p, width: w, height: h, css: c }');
 
         var path = div.querySelector('svg > path');
         expect(path).not.toBeNull();
-        expect(path.getAttribute('d')).toEqual('M 100 100 L 300 100 L 200 300 z');
+        expect(path.getAttribute('d')).toEqual('M 100 100 L 300 100 L 200 300 Z');
 
         knockout.cleanNode(div);
         document.body.removeChild(div);
@@ -68,7 +68,7 @@ cesiumSvgPath: svgPath');
 
         var viewModel = {
             svgPath : knockout.observable({
-                path : knockout.observable('M 100 100 L 300 100 L 200 300 z'),
+                path : knockout.observable('M 100 100 L 300 100 L 200 300 Z'),
                 width : knockout.observable(28),
                 height : knockout.observable(40),
                 css : knockout.observable('someClass')
@@ -84,7 +84,7 @@ cesiumSvgPath: svgPath');
 
         var path = div.querySelector('svg > path');
         expect(path).not.toBeNull();
-        expect(path.getAttribute('d')).toEqual('M 100 100 L 300 100 L 200 300 z');
+        expect(path.getAttribute('d')).toEqual('M 100 100 L 300 100 L 200 300 Z');
 
         knockout.cleanNode(div);
         document.body.removeChild(div);


### PR DESCRIPTION
This addresses all failing non-webGL IE 11 tests except for the DataCloneError failures related to web workers.
