### PR TITLE
Don't used defined(window) because window is not declared.

### DIFF
--- a/Source/Core/getTimestamp.js
+++ b/Source/Core/getTimestamp.js
@@ -1,4 +1,4 @@
-/*global define*/
+/*global define,performance*/
 define([
         './defined'
     ], function(
@@ -17,9 +17,9 @@ define([
      */
     var getTimestamp;
 
-    if (defined(window) && defined(window.performance) && defined(window.performance.now)) {
+    if (typeof performance !== 'undefined' && defined(performance.now)) {
         getTimestamp = function() {
-            return window.performance.now();
+            return performance.now();
         };
     } else {
         getTimestamp = function() {


### PR DESCRIPTION
In fact, avoid `window` entirely and just check for the existence of a global `performance` property.

I didn't find any other cases where we did something similar.

This fixes issue #1457.
