### PR TITLE
Lower our max memory when generating documentation to 1GB.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -481,7 +481,7 @@
 		<property name="relativeDocOutputDirectory" location="${buildDocumentationDirectory}" relative="true" basedir="${jsdoc3Directory}" />
 		<property name="relativeSourceFilesPath" location="${sourceDirectory}" relative="true" basedir="${jsdoc3Directory}" />
 
-		<java jar="${jsdoc3Directory}/lib/js.jar" dir="${jsdoc3Directory}" fork="true" failonerror="true" maxmemory="1536m">
+		<java jar="${jsdoc3Directory}/lib/js.jar" dir="${jsdoc3Directory}" fork="true" failonerror="true" maxmemory="1024m">
 			<arg line="-modules node_modules" />
 			<arg line="-modules rhino_modules" />
 			<arg line="-modules ." />


### PR DESCRIPTION
It turns out that some 32-bit JVMs on Windows can't handle 1536MB (1.5GB), even though in practice, we're nowhere near the limit. The main reason for setting a maximum is to avoid system-dependent defaults which sometimes are way too low.
