### PR TITLE
Camera Constrained Axis

### DIFF
--- a/Source/DynamicScene/DynamicObjectView.js
+++ b/Source/DynamicScene/DynamicObjectView.js
@@ -187,8 +187,6 @@ define([
             controller.setEllipsoid(Ellipsoid.UNIT_SPHERE);
             controller.columbusViewMode = CameraColumbusViewMode.LOCKED;
 
-            camera.controller.constrainedAxis = Cartesian3.UNIT_Z;
-
             var position = camera.position;
             Cartesian3.clone(position, that._lastOffset);
             that._lastDistance = Cartesian3.magnitude(position);
@@ -200,7 +198,6 @@ define([
 
     function update3DController(that, camera, objectChanged, offset) {
         var scene = that.scene;
-        camera.controller.constrainedAxis = Cartesian3.UNIT_Z;
 
         if (objectChanged) {
             camera.controller.lookAt(offset, Cartesian3.ZERO, Cartesian3.UNIT_Z);

--- a/Source/Widgets/HomeButton/HomeButtonViewModel.js
+++ b/Source/Widgets/HomeButton/HomeButtonViewModel.js
@@ -37,8 +37,6 @@ define([
         var mode = scene.mode;
 
         var camera = scene.camera;
-        camera.controller.constrainedAxis = Cartesian3.UNIT_Z;
-
         var controller = scene.screenSpaceCameraController;
 
         controller.setEllipsoid(ellipsoid);


### PR DESCRIPTION
Remove setting camera constrained axis every frame when following an object or after a home flight. It's a global setting and only needs to be set once.

CC @emackey @mramato 
