### PR TITLE
Replace FrameState.events with FrameState.afterRender.

### DIFF
--- a/Source/Scene/FrameState.js
+++ b/Source/Scene/FrameState.js
@@ -98,8 +98,8 @@ define([
         this.creditDisplay = creditDisplay;
 
         /**
-         * An array of objects with {@link Event} instances to raise at the end
-         * of the frame and arguments to pass to the event.
+         * An array of functions to be called at the end of the frame.  This array
+         * will be cleared after each frame.
          * <p>
          * This allows queueing up events in <code>update</code> functions and
          * firing them at a time when the subscribers are free to change the
@@ -108,15 +108,13 @@ define([
          * </p>
          *
          * @type {Array}
-         * @default []
          *
          * @example
-         * frameState.events.push({
-         *   event : animationRemoved,
-         *   eventArguments : [removedAnimation]
+         * frameState.afterRender.push(function() {
+         *   // take some action, raise an event, etc.
          * });
          */
-        this.events = [];
+        this.afterRender = [];
     };
 
     return FrameState;

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -475,7 +475,7 @@ define([
      * Computes the bounding sphere around the entire model in world coordinates using the
      * previous frame's {@link Model#modelMatrix} and node transforms.  This can be used in
      * {@link readyToRender} to zoom to the model.  This can't be called before the
-     * {@link readyToRender} event fires because it requires that the glTF nodes are loaded.
+     * {@link readyToRender} event is raised because it requires that the glTF nodes are loaded.
      *
      * @memberof Model
      *
@@ -1881,9 +1881,9 @@ define([
 
         if (justLoaded) {
             // Called after modelMatrix update.
-            frameState.events.push({
-                event : this.readyToRender,
-                eventArguments : [this]
+            var model = this;
+            frameState.afterRender.push(function() {
+                model.readyToRender.raiseEvent(model);
             });
             return;
         }

--- a/Source/Scene/ModelAnimation.js
+++ b/Source/Scene/ModelAnimation.js
@@ -172,17 +172,16 @@ define([
         this._duration = undefined;
 
         // To avoid allocations in ModelAnimationCollection.update
-        this._startEvent = {
-            event : undefined,
-            eventArguments : [model, this]
+        var that = this;
+        this._raiseStartEvent = function() {
+            that.start.raiseEvent(model, that);
         };
-        this._updateEvent = {
-            event : undefined,
-            eventArguments : [model, this, 0.0]
+        this._updateEventTime = 0.0;
+        this._raiseUpdateEvent = function() {
+            that.update.raiseEvent(model, that, that._updateEventTime);
         };
-        this._stopEvent = {
-            event : undefined,
-            eventArguments : [model, this]
+        this._raiseStopEvent = function() {
+            that.stop.raiseEvent(model, that);
         };
     };
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -461,7 +461,7 @@ define([
         frameState.camera = camera;
         frameState.cullingVolume = camera.frustum.computeCullingVolume(camera.positionWC, camera.directionWC, camera.upWC);
         frameState.occluder = getOccluder(scene);
-        frameState.events.length = 0;
+        frameState.afterRender.length = 0;
 
         clearPasses(frameState.passes);
     }
@@ -874,15 +874,14 @@ define([
         }
     }
 
-    function executeEvents(frameState) {
-        // Events are queued up during primitive update and executed here in case
-        // the callback modifies scene state that should remain constant over the frame.
-        var events = frameState.events;
-        var length = events.length;
-        for (var i = 0; i < length; ++i) {
-            var event = events[i].event;
-            event.raiseEvent.apply(event, events[i].eventArguments);
+    function callAfterRenderFunctions(frameState) {
+        // Functions are queued up during primitive update and executed here in case
+        // the function modifies scene state that should remain constant over the frame.
+        var functions = frameState.afterRender;
+        for (var i = 0, length = functions.length; i < length; ++i) {
+            functions[i]();
         }
+        functions.length = 0;
     }
 
     /**
@@ -954,7 +953,7 @@ define([
         }
 
         context.endFrame();
-        executeEvents(frameState);
+        callAfterRenderFunctions(frameState);
     };
 
     var orthoPickingFrustum = new OrthographicFrustum();
@@ -1100,7 +1099,7 @@ define([
         executeCommands(this, this._pickFramebuffer.begin(scratchRectangle), scratchColorZero);
         var object = this._pickFramebuffer.end(scratchRectangle);
         context.endFrame();
-        executeEvents(frameState);
+        callAfterRenderFunctions(frameState);
         return object;
     };
 

--- a/Specs/Scene/SceneSpec.js
+++ b/Specs/Scene/SceneSpec.js
@@ -110,41 +110,30 @@ defineSuite([
         expect(scene.context.readPixels()).toEqual([0, 0, 255, 255]);
     });
 
-    function getMockPrimitive(options) {
-        return {
+    it('calls afterRender functions', function() {
+        var spyListener = jasmine.createSpy('listener');
+
+        var primitive = {
             update : function(context, frameState, commandList) {
-                options = defaultValue(options, defaultValue.EMPTY_OBJECT);
-
-                if (defined(options.command)) {
-                    commandList.push(options.command);
-                }
-
-                if (defined(options.event)) {
-                    frameState.events.push({
-                        event : options.event,
-                        eventArguments : options.eventArguments
-                    });
-                }
+                frameState.afterRender.push(spyListener);
             },
             destroy : function() {
             }
         };
-    }
-
-    it('fires FrameState events', function() {
-        var spyListener = jasmine.createSpy('listener');
-        var event = new Event();
-        event.addEventListener(spyListener);
-
-        scene.primitives.add(getMockPrimitive({
-            event : event,
-            eventArguments : ['argument']
-        }));
+        scene.primitives.add(primitive);
 
         scene.initializeFrame();
         scene.render();
-        expect(spyListener).toHaveBeenCalledWith('argument');
+        expect(spyListener).toHaveBeenCalled();
     });
+
+    function CommandMockPrimitive(command) {
+        this.update = function(context, frameState, commandList) {
+            commandList.push(command);
+        };
+        this.destroy = function() {
+        };
+    }
 
     it('debugCommandFilter filters commands', function() {
         var c = new DrawCommand();
@@ -152,9 +141,7 @@ defineSuite([
         c.pass = Pass.OPAQUE;
         spyOn(c, 'execute');
 
-        scene.primitives.add(getMockPrimitive({
-            command : c
-        }));
+        scene.primitives.add(new CommandMockPrimitive(c));
 
         scene.debugCommandFilter = function(command) {
             return command !== c;   // Do not execute command
@@ -171,9 +158,7 @@ defineSuite([
         c.pass = Pass.OPAQUE;
         spyOn(c, 'execute');
 
-        scene.primitives.add(getMockPrimitive({
-            command : c
-        }));
+        scene.primitives.add(new CommandMockPrimitive(c));
 
         expect(scene.debugCommandFilter).toBeUndefined();
         scene.initializeFrame();
@@ -188,9 +173,7 @@ defineSuite([
         c.debugShowBoundingVolume = true;
         c.boundingVolume = new BoundingSphere(Cartesian3.ZERO, 7000000.0);
 
-        scene.primitives.add(getMockPrimitive({
-            command : c
-        }));
+        scene.primitives.add(new CommandMockPrimitive(c));
 
         scene.initializeFrame();
         scene.render();
@@ -205,9 +188,7 @@ defineSuite([
             'void main() { gl_Position = vec4(1.0); }',
             'void main() { gl_FragColor = vec4(1.0); }');
 
-        scene.primitives.add(getMockPrimitive({
-            command : c
-        }));
+        scene.primitives.add(new CommandMockPrimitive(c));
 
         scene.debugShowCommands = true;
         scene.initializeFrame();


### PR DESCRIPTION
NOTE: this is a pull request into the `gltf` branch.

Instead of deferring raising events, primitives can push functions into afterRender to defer any kind of work until after rendering.
