### PR TITLE
Model compute world bounding sphere

### DIFF
--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -513,22 +513,20 @@ define([
         if (spheres.length > 0) {
             // Compute bounding sphere around the model
             var radiusSquared = 0;
-            var index = 0;
 
             length = spheres.length;
             Cartesian3.divideByScalar(scratchSphereCenter, length, scratchSphereCenter);
             for (i = 0; i < length; ++i) {
                 var bbs = spheres[i];
-                var r = Cartesian3.magnitudeSquared(Cartesian3.subtract(bbs.center, scratchSphereCenter, scratchSubtract));
+                var r = Cartesian3.magnitudeSquared(Cartesian3.subtract(bbs.center, scratchSphereCenter, scratchSubtract)) + bbs.radius * bbs.radius;
 
                 if (r > radiusSquared) {
                     radiusSquared = r;
-                    index = i;
                 }
             }
 
             Cartesian3.clone(scratchSphereCenter, result.center);
-            result.radius = Math.sqrt(radiusSquared) + spheres[index].radius;
+            result.radius = Math.sqrt(radiusSquared);
         }
 
         return result;


### PR DESCRIPTION
NOTE: This is a pull request into the `gltf` branch.

Its possible that max{length(sphere[i].center - center) + sphere[i].radius} > max{length(sphere[i].center - center)} + sphere[i].radius. For example, if the model has two bounding spheres that have centers an equal distance apart, the first one has a radius 2m and the second has a radius 2km, then we should choose the second instead of the first.
