### PR TITLE
Tweak CZML reference frame handling

### DIFF
--- a/Source/DynamicScene/CzmlDataSource.js
+++ b/Source/DynamicScene/CzmlDataSource.js
@@ -487,7 +487,7 @@ define([
             combinedInterval = constrainedInterval;
         }
 
-        var referenceFrame = ReferenceFrame[defaultValue(packetData.referenceFrame, "FIXED")];
+        var referenceFrame = defaultValue(ReferenceFrame[packetData.referenceFrame], undefined);
         var unwrappedInterval = unwrapCartesianInterval(packetData);
         var hasInterval = defined(combinedInterval) && !combinedInterval.equals(Iso8601.MAXIMUM_INTERVAL);
         var packedLength = Cartesian3.packedLength;
@@ -506,7 +506,7 @@ define([
         //Without an interval, any sampled value is infinite, meaning it completely
         //replaces any non-sampled property that may exist.
         if (isSampled && !hasInterval) {
-            if (!(property instanceof SampledPositionProperty) || property.referenceFrame !== referenceFrame) {
+            if (!(property instanceof SampledPositionProperty) || (defined(referenceFrame) && property.referenceFrame !== referenceFrame)) {
                 property = new SampledPositionProperty(referenceFrame);
                 object[propertyName] = property;
                 propertyCreated = true;
@@ -538,7 +538,7 @@ define([
                 propertyCreated = true;
             }
 
-            if (property instanceof TimeIntervalCollectionPositionProperty && property.referenceFrame === referenceFrame) {
+            if (property instanceof TimeIntervalCollectionPositionProperty && (defined(referenceFrame) && property.referenceFrame === referenceFrame)) {
                 //If we create a collection, or it already existed, use it.
                 property.intervals.addInterval(combinedInterval);
             } else if (property instanceof CompositePositionProperty) {
@@ -591,7 +591,7 @@ define([
         //Check if the interval already exists in the composite
         var intervals = property.intervals;
         interval = intervals.findInterval(combinedInterval.start, combinedInterval.stop, combinedInterval.isStartIncluded, combinedInterval.isStopIncluded);
-        if (!defined(interval) || !(interval.data instanceof SampledPositionProperty) || interval.data.referenceFrame !== referenceFrame) {
+        if (!defined(interval) || !(interval.data instanceof SampledPositionProperty) || (defined(referenceFrame) && interval.data.referenceFrame !== referenceFrame)) {
             //If not, create a SampledPositionProperty for it.
             interval = combinedInterval.clone();
             interval.data = new SampledPositionProperty(referenceFrame);

--- a/Specs/DynamicScene/CzmlDataSourceSpec.js
+++ b/Specs/DynamicScene/CzmlDataSourceSpec.js
@@ -11,6 +11,7 @@ defineSuite([
         'Core/defined',
         'Core/Ellipsoid',
         'Core/Quaternion',
+        'Core/ReferenceFrame',
         'Core/Spherical',
         'DynamicScene/DynamicBillboard',
         'DynamicScene/DynamicObject',
@@ -35,6 +36,7 @@ defineSuite([
         defined,
         Ellipsoid,
         Quaternion,
+        ReferenceFrame,
         Spherical,
         DynamicBillboard,
         DynamicObject,
@@ -769,6 +771,62 @@ defineSuite([
         var dynamicObject = dataSource.getDynamicObjectCollection().getObjects()[0];
         var resultCartesian = dynamicObject.position.getValue(new JulianDate());
         expect(resultCartesian).toEqual(Ellipsoid.WGS84.cartographicToCartesian(cartographic));
+    });
+
+    it('Can set reference frame', function() {
+        var epoch = new JulianDate();
+        var dataSource = new CzmlDataSource();
+
+        var czml = {
+            position : {
+                referenceFrame : "INERTIAL",
+                epoch : epoch.toIso8601(),
+                cartesian : [1.0, 2.0, 3.0]
+            }
+        };
+
+        dataSource.load(czml);
+        var dynamicObject = dataSource.getDynamicObjectCollection().getObjects()[0];
+        expect(dynamicObject.position.referenceFrame).toBe(ReferenceFrame.INERTIAL);
+
+        czml = {
+            position : {
+                referenceFrame : "FIXED",
+                epoch : epoch.toIso8601(),
+                cartesian : [1.0, 2.0, 3.0]
+            }
+        };
+
+        dataSource.load(czml);
+        dynamicObject = dataSource.getDynamicObjectCollection().getObjects()[0];
+        expect(dynamicObject.position.referenceFrame).toBe(ReferenceFrame.FIXED);
+    });
+
+    it('Default reference frame on existing interval does not reset value to FIXED.', function() {
+        var epoch = new JulianDate();
+        var dataSource = new CzmlDataSource();
+
+        var czml = {
+            position : {
+                referenceFrame : "INERTIAL",
+                epoch : epoch.toIso8601(),
+                cartesian : [1.0, 2.0, 3.0]
+            }
+        };
+
+        dataSource.process(czml);
+        var dynamicObject = dataSource.getDynamicObjectCollection().getObjects()[0];
+        expect(dynamicObject.position.referenceFrame).toBe(ReferenceFrame.INERTIAL);
+
+        var czml2 = {
+            position : {
+                epoch : epoch.toIso8601(),
+                cartesian : [1.0, 2.0, 3.0]
+            }
+        };
+        dataSource.process(czml2);
+
+        expect(dynamicObject.position.referenceFrame).toBe(ReferenceFrame.INERTIAL);
     });
 
     it('CZML sampled cartographicRadians positions work.', function() {


### PR DESCRIPTION
Not specifying a reference frame usually defaults to FIXED, however if you specified the INERTIAL frame in a previous packet, we should not overwrite that with FIXED if it is left out of subsequent packets for the same interval.

CC @kring @mrmattf 
