### PR TITLE
Fix tests that use WebGL extensions

### DIFF
--- a/Specs/Renderer/CubeMapSpec.js
+++ b/Specs/Renderer/CubeMapSpec.js
@@ -957,7 +957,7 @@ defineSuite([
                     height : 16,
                     pixelDatatype : PixelDatatype.FLOAT
                 });
-            }).toThrowDeveloperError();
+            }).toThrow();
         }
     });
 

--- a/Specs/Renderer/FramebufferSpec.js
+++ b/Specs/Renderer/FramebufferSpec.js
@@ -562,16 +562,18 @@ defineSuite([
     });
 
     it('throws when created with a color texture with a non-color pixel format', function() {
-        expect(function() {
-            framebuffer = context.createFramebuffer({
-                colorTextures : [context.createTexture2D({
-                    width : 1,
-                    height : 1,
-                    pixelFormat : PixelFormat.DEPTH_COMPONENT,
-                    pixelDatatype : PixelDatatype.UNSIGNED_SHORT
-                })]
-            });
-        }).toThrowDeveloperError();
+        if (context.getDepthTexture()) {
+            expect(function() {
+                framebuffer = context.createFramebuffer({
+                    colorTextures : [context.createTexture2D({
+                        width : 1,
+                        height : 1,
+                        pixelFormat : PixelFormat.DEPTH_COMPONENT,
+                        pixelDatatype : PixelDatatype.UNSIGNED_SHORT
+                    })]
+                });
+            }).toThrowDeveloperError();
+        }
     });
 
     it('throws when created with a depth texture without a DEPTH_COMPONENT pixel format', function() {

--- a/Specs/Renderer/TextureSpec.js
+++ b/Specs/Renderer/TextureSpec.js
@@ -569,7 +569,7 @@ defineSuite([
                     pixelFormat : PixelFormat.RGBA,
                     pixelDatatype : PixelDatatype.FLOAT
                 });
-            }).toThrowDeveloperError();
+            }).toThrow();
         }
     });
 


### PR DESCRIPTION
Fix tests that assume an extension is available or have a `DeveloperError`/`RuntimeError` mismatch.

Fixes #1501.
