### PR TITLE
Fix the rim lighting in GridMaterial to accept backface normals.

### DIFF
--- a/Source/Shaders/Materials/GridMaterial.glsl
+++ b/Source/Shaders/Materials/GridMaterial.glsl
@@ -43,7 +43,7 @@ czm_material czm_getMaterial(czm_materialInput materialInput)
 
     // Edges taken from RimLightingMaterial.glsl
     // See http://www.fundza.com/rman_shaders/surface/fake_rim/fake_rim1.html
-    float dRim = 1.0 - dot(materialInput.normalEC, normalize(materialInput.positionToEyeEC));
+    float dRim = 1.0 - abs(dot(materialInput.normalEC, normalize(materialInput.positionToEyeEC)));
     float sRim = smoothstep(0.8, 1.0, dRim);
     value *= (1.0 - sRim);
 


### PR DESCRIPTION
This is what it looked like before.  The dividing line between good & bad is actually a separate issue with `faceForward` that will be addressed in a separate pull.  This pull just fixes the bad side to look like the good side.

![badbackfacenormals](https://f.cloud.github.com/assets/1235080/2263132/0ed978c8-9e62-11e3-82b1-52e8aca2a788.png)
