### PR TITLE
Minor doc fix

### DIFF
--- a/Source/Scene/CullingVolume.js
+++ b/Source/Scene/CullingVolume.js
@@ -14,7 +14,7 @@ define([
     /**
      * The culling volume defined by planes.
      *
-     * @alias OrthographicFrustum
+     * @alias CullingVolume
      * @constructor
      *
      * @param Array planes An array of clipping planes.


### PR DESCRIPTION
I noticed that the `CullingVolume` doc was missing from the reference doc when answering this [question](https://groups.google.com/forum/#!topic/cesium-dev/lXomic5tSKo).
