### PR TITLE
Fix CZML CompositeMaterialProperty processing

### DIFF
--- a/Source/DynamicScene/CzmlDataSource.js
+++ b/Source/DynamicScene/CzmlDataSource.js
@@ -695,18 +695,18 @@ define(['../Core/Cartesian2',
             if (!(property instanceof CompositeMaterialProperty)) {
                 property = new CompositeMaterialProperty();
                 object[propertyName] = property;
-                //See if we already have data at that interval.
-                var thisIntervals = property.intervals;
-                existingInterval = thisIntervals.findInterval(combinedInterval.start, combinedInterval.stop);
-                if (defined(existingInterval)) {
-                    //We have an interval, but we need to make sure the
-                    //new data is the same type of material as the old data.
-                    existingMaterial = existingInterval.data;
-                } else {
-                    //If not, create it.
-                    existingInterval = combinedInterval.clone();
-                    thisIntervals.addInterval(existingInterval);
-                }
+            }
+            //See if we already have data at that interval.
+            var thisIntervals = property.intervals;
+            existingInterval = thisIntervals.findInterval(combinedInterval.start, combinedInterval.stop);
+            if (defined(existingInterval)) {
+                //We have an interval, but we need to make sure the
+                //new data is the same type of material as the old data.
+                existingMaterial = existingInterval.data;
+            } else {
+                //If not, create it.
+                existingInterval = combinedInterval.clone();
+                thisIntervals.addInterval(existingInterval);
             }
         } else {
             existingMaterial = property;

--- a/Specs/DynamicScene/CzmlDataSourceSpec.js
+++ b/Specs/DynamicScene/CzmlDataSourceSpec.js
@@ -1756,4 +1756,53 @@ defineSuite([
 
         expect(spy.callCount).toEqual(1);
     });
+
+    it('CZML materials work with composite interval', function() {
+        var before = JulianDate.fromIso8601("2012-03-15T09:23:59Z");
+        var solid = JulianDate.fromIso8601("2012-03-15T10:00:00Z");
+        var grid1 = JulianDate.fromIso8601("2012-03-15T11:00:00Z");
+        var grid2 = JulianDate.fromIso8601("2012-03-15T12:00:00Z");
+        var after = JulianDate.fromIso8601("2012-03-15T12:00:01Z");
+
+        var packet = {
+            polygon : {
+                material : [{
+                    interval : '2012-03-15T10:00:00Z/2012-03-15T11:00:00Z',
+                    interpolationAlgorithm : 'LINEAR',
+                    interpolationDegree : 1,
+                    epoch : '2012-03-15T10:00:00Z',
+                    solidColor : {
+                        color : {
+                            rgba : [240, 0, 0, 0]
+                        }
+                    }
+                }, {
+                    interval : '2012-03-15T11:00:00Z/2012-03-15T12:00:00Z',
+                    interpolationAlgorithm : 'LINEAR',
+                    interpolationDegree : 1,
+                    epoch : '2012-03-15T11:00:00Z',
+                    grid : {
+                        color : {
+                            rgba : [240, 255, 255, 255]
+                        },
+                        cellAlpha : 0,
+                        rowCount : 36,
+                        rowThickness : 1,
+                        columnCount : 9,
+                        columnThickness : 1
+                    }
+                }]
+            }
+        };
+
+        var dataSource = new CzmlDataSource();
+        dataSource.load(packet);
+        var dynamicObject = dataSource.getDynamicObjectCollection().getObjects()[0];
+        expect(dynamicObject.polygon.material.getType(solid)).toBe('Color');
+        expect(dynamicObject.polygon.material.getType(grid1)).toBe('Grid');
+        expect(dynamicObject.polygon.material.getType(grid2)).toBe('Grid');
+        expect(dynamicObject.polygon.material.getType(before)).toBeUndefined();
+        expect(dynamicObject.polygon.material.getType(after)).toBeUndefined();
+
+    });
 });


### PR DESCRIPTION
Rather than compositing multiple material intervals properly, we were overwriting the last interval with a new constant material property.

The new unit tests shows the problem clearly and fails without the fix to CzmlDataSource.
