### PR TITLE
Fix EllipsoidGeometryUpdater crash for ellipsoid with a 0 radii component

### DIFF
--- a/Source/DynamicScene/EllipsoidGeometryUpdater.js
+++ b/Source/DynamicScene/EllipsoidGeometryUpdater.js
@@ -644,6 +644,13 @@ define(['../Core/Cartesian3',
         }
 
         if (in3D) {
+            //Since we are scaling a unit sphere, we can't let any of the values go to zero.
+            //Instead we clamp them to a small value.  To the naked eye, this produces the same results
+            //that you get passing EllipsoidGeometry a radii with a zero component.
+            radiiScratch.x = Math.max(radiiScratch.x, 0.001);
+            radiiScratch.y = Math.max(radiiScratch.y, 0.001);
+            radiiScratch.z = Math.max(radiiScratch.z, 0.001);
+
             modelMatrix = Matrix4.multiplyByScale(modelMatrix, radiiScratch, modelMatrix);
             this._primitive.modelMatrix = modelMatrix;
             this._outlinePrimitive.modelMatrix = modelMatrix;


### PR DESCRIPTION
EllipsoidGeometryUpdater has a fast path that scales a unit sphere rather than recreate geometry every frame.  It was crashing due to a bad model matrix if the radii ever went to zero.  This change simply clamps values to 0.001, which visually has the same affect.
