### PR TITLE
Fix viewer timeline resize

### DIFF
--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -748,10 +748,6 @@ Either specify options.imageryProvider instead or set options.baseLayerPicker to
             this._infoBox.viewModel.maxHeight = panelMaxHeight;
         }
 
-        if (defined(this._dataSourceBrowser)) {
-            this._dataSourceBrowser.viewModel.maxHeight = panelMaxHeight;
-        }
-
         var timeline = this._timeline;
         var timelineExists = defined(timeline);
         var animationExists = defined(this._animation);


### PR DESCRIPTION
We size the timeline based on the existence of the animation widget and fullscreen button; however we were not handling the fullscreen button case on resize. If you created the Viewer widget vefore it's container was laid out, the timeline layout would use a width of 0 for the fullscreen button and not update correctly once layout occured.
