### PR TITLE
Initialize cached widget sizes to undefined.

### DIFF
--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -227,8 +227,8 @@ define([
             this._container = container;
             this._canvas = canvas;
             this._zoomDetector = zoomDetector;
-            this._canvasWidth = undefined;
-            this._canvasHeight = undefined;
+            this._canvasWidth = 0;
+            this._canvasHeight = 0;
             this._scene = scene;
             this._centralBody = centralBody;
             this._clock = defaultValue(options.clock, new Clock());

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -426,8 +426,8 @@ Either specify options.imageryProvider instead or set options.baseLayerPicker to
         this._fullscreenButton = fullscreenButton;
         this._geocoder = geocoder;
         this._eventHelper = eventHelper;
-        this._lastWidth = undefined;
-        this._lastHeight = undefined;
+        this._lastWidth = 0;
+        this._lastHeight = 0;
         this._useDefaultRenderLoop = undefined;
         this._renderLoopRunning = false;
         this._showRenderLoopErrors = defaultValue(options.showRenderLoopErrors, true);


### PR DESCRIPTION
If the canvas is never resized after creation of a Cesium widget, we would never render.  Rather than caching canvas size at creation time, this ensures that we always run through the resize code at least once.
