### PR TITLE
Rename HelloWorld variable

### DIFF
--- a/Apps/HelloWorld.html
+++ b/Apps/HelloWorld.html
@@ -34,7 +34,7 @@
 <body>
   <div id="cesiumContainer"></div>
   <script>
-    var cesiumWidget = new Cesium.CesiumWidget('cesiumContainer');
+    var widget = new Cesium.CesiumWidget('cesiumContainer');
   </script>
 </body>
 </html>


### PR DESCRIPTION
Fixes first bullet point of #1139 

"Inconsistent variable names makes it hard to copy and paste code. Sandcastle has `widget`, HelloWorld.html has `cesiumWidget`"
