### PR TITLE
Remove explicit termination of the worker used to test transferring arrays

### DIFF
--- a/Source/Core/TaskProcessor.js
+++ b/Source/Core/TaskProcessor.js
@@ -49,8 +49,6 @@ define([
                 var result = defined(array) && array[0] === value;
                 deferred.resolve(result);
 
-                worker.terminate();
-
                 TaskProcessor._canTransferArrayBuffer = result;
             };
 


### PR DESCRIPTION
This is causing the tab to completely freeze with the newly released Chrome 34.

We don't really need to terminate the worker explicitly.  It gets GCed anyway.
