### PR TITLE
Fix #1603

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,7 @@ Beta Releases
     * `Camera` constructor takes `Scene` as parameter instead of `Context`
     * `Billboard.computeScreenSpacePosition`, `Label.computeScreenSpacePosition`, `SceneTransforms.clipToWindowCoordinates` and `SceneTransforms.clipToDrawingBufferCoordinates` take a `Scene` parameter instead of a `Context`.
   * Types implementing the `ImageryProvider` interface are now required to have a `hasAlphaChannel` property.
+  * Types implementing `DataSource` no longer need to implement `getIsTimeVarying`, since it is no longer needed.
 * Improved texture upload performance and reduced memory usage when using `BingMapsImageryProvider` and other imagery providers that return false from `hasAlphaChannel`.
 
 ### b27 - 2014-04-01

--- a/Source/DynamicScene/CzmlDataSource.js
+++ b/Source/DynamicScene/CzmlDataSource.js
@@ -1430,7 +1430,6 @@ define(['../Core/Cartesian2',
         this._error = new Event();
         this._clock = undefined;
         this._dynamicObjectCollection = new DynamicObjectCollection();
-        this._timeVarying = true;
         this._document = new DynamicObject();
     };
 
@@ -1461,8 +1460,7 @@ define(['../Core/Cartesian2',
     processAvailability];
 
     /**
-     * Gets an event that will be raised when non-time-varying data changes
-     * or if the return value of getIsTimeVarying changes.
+     * Gets an event that will be raised when new data is done loading.
      * @memberof CzmlDataSource
      *
      * @returns {Event} The event.
@@ -1513,17 +1511,6 @@ define(['../Core/Cartesian2',
      */
     CzmlDataSource.prototype.getClock = function() {
         return this._clock;
-    };
-
-    /**
-     * Gets a value indicating if the data varies with simulation time.  If the return value of
-     * this function changes, the changed event will be raised.
-     * @memberof CzmlDataSource
-     *
-     * @returns {Boolean} True if the data is varies with simulation time, false otherwise.
-     */
-    CzmlDataSource.prototype.getIsTimeVarying = function() {
-        return this._timeVarying;
     };
 
     /**

--- a/Source/DynamicScene/DataSource.js
+++ b/Source/DynamicScene/DataSource.js
@@ -17,8 +17,7 @@ define([
     };
 
     /**
-     * Gets an event that will be raised when non-time-varying data changes, such
-     * as the return value of getName, getClock, or getIsTimeVarying.
+     * Gets an event that will be raised when the underlying data changes.
      * @memberof DataSource
      * @function
      *
@@ -62,16 +61,6 @@ define([
      * @returns {DynamicClock} The clock associated with this data source, or undefined if none exists.
      */
     DataSource.prototype.getClock = DeveloperError.throwInstantiationError;
-
-    /**
-     * Gets a value indicating if the data varies with simulation time.  If the return value of
-     * this function changes, the changed event will be raised.
-     * @memberof DataSource
-     * @function
-     *
-     * @returns {Boolean} True if the data is varies with simulation time, false otherwise.
-     */
-    DataSource.prototype.getIsTimeVarying = DeveloperError.throwInstantiationError;
 
     return DataSource;
 });

--- a/Source/DynamicScene/DataSourceDisplay.js
+++ b/Source/DynamicScene/DataSourceDisplay.js
@@ -65,8 +65,6 @@ define(['../Core/defaultValue',
 
         this._dataSourceCollection = dataSourceCollection;
         this._scene = scene;
-        this._timeVaryingSources = [];
-        this._staticSourcesToUpdate = [];
         this._visualizersCallback = defaultValue(visualizersCallback, DataSourceDisplay.defaultVisualizersCallback);
 
         for (var i = 0, len = dataSourceCollection.length; i < len; i++) {
@@ -167,9 +165,7 @@ define(['../Core/defaultValue',
     };
 
     /**
-     * Updates time-varying data sources to the provided time and also
-     * updates static data sources that have changed since the last
-     * call to update.
+     * Updates the display to the provided time.
      *
      * @memberof DataSourceDisplay
      *
@@ -187,73 +183,28 @@ define(['../Core/defaultValue',
         var visualizers;
         var vLength;
 
-        var timeVaryingSources = this._timeVaryingSources;
-        var length = timeVaryingSources.length;
+        var dataSources = this._dataSourceCollection;
+        var length = dataSources.length;
         for (i = 0; i < length; i++) {
-            visualizers = timeVaryingSources[i]._visualizers;
+            visualizers = dataSources.get(i)._visualizers;
             vLength = visualizers.length;
             for (x = 0; x < vLength; x++) {
                 visualizers[x].update(time);
             }
         }
-
-        var staticSourcesToUpdate = this._staticSourcesToUpdate;
-        length = staticSourcesToUpdate.length;
-        for (i = 0; i < length; i++) {
-            visualizers = staticSourcesToUpdate[i]._visualizers;
-            vLength = visualizers.length;
-            for (x = 0; x < vLength; x++) {
-                visualizers[x].update(time);
-            }
-        }
-        staticSourcesToUpdate.length = 0;
     };
 
     DataSourceDisplay.prototype._onDataSourceAdded = function(dataSourceCollection, dataSource) {
         var visualizers = this._visualizersCallback(this._scene, dataSource);
         dataSource._visualizers = visualizers;
-        dataSource.getChangedEvent().addEventListener(this._onDataSourceChanged, this);
-        this._onDataSourceChanged(dataSource);
     };
 
     DataSourceDisplay.prototype._onDataSourceRemoved = function(dataSourceCollection, dataSource) {
-        dataSource.getChangedEvent().removeEventListener(this._onDataSourceChanged, this);
-
-        var timeVaryingIndex = this._timeVaryingSources.indexOf(dataSource);
-        if (timeVaryingIndex !== -1) {
-            this._timeVaryingSources.splice(timeVaryingIndex, 1);
-        }
-
-        var staticIndex = this._staticSourcesToUpdate.indexOf(dataSource);
-        if (staticIndex !== -1) {
-            this._staticSourcesToUpdate.splice(staticIndex, 1);
-        }
-
         var visualizers = dataSource._visualizers;
         var length = visualizers.length;
         for (var i = 0; i < length; i++) {
             visualizers[i].destroy();
             dataSource._visualizers = undefined;
-        }
-    };
-
-    DataSourceDisplay.prototype._onDataSourceChanged = function(dataSource) {
-        var timeVaryingIndex = this._timeVaryingSources.indexOf(dataSource);
-        var staticIndex = this._staticSourcesToUpdate.indexOf(dataSource);
-        if (dataSource.getIsTimeVarying()) {
-            if (timeVaryingIndex === -1) {
-                this._timeVaryingSources.push(dataSource);
-            }
-            if (staticIndex !== -1) {
-                this._staticSourcesToUpdate.splice(staticIndex, 1);
-            }
-        } else {
-            if (staticIndex === -1) {
-                this._staticSourcesToUpdate.push(dataSource);
-            }
-            if (timeVaryingIndex !== -1) {
-                this._timeVaryingSources.splice(staticIndex, 1);
-            }
         }
     };
 

--- a/Source/DynamicScene/GeoJsonDataSource.js
+++ b/Source/DynamicScene/GeoJsonDataSource.js
@@ -331,8 +331,7 @@ define([
     };
 
     /**
-     * Gets an event that will be raised when non-time-varying data changes
-     * or if the return value of getIsTimeVarying changes.
+     * Gets an event that will be raised when new data is done loading.
      * @memberof GeoJsonDataSource
      *
      * @returns {Event} The event.
@@ -378,17 +377,6 @@ define([
      */
     GeoJsonDataSource.prototype.getClock = function() {
         return undefined;
-    };
-
-    /**
-     * Gets a value indicating if the data varies with simulation time.  If the return value of
-     * this function changes, the changed event will be raised.
-     * @memberof GeoJsonDataSource
-     *
-     * @returns {Boolean} True if the data is varies with simulation time, false otherwise.
-     */
-    GeoJsonDataSource.prototype.getIsTimeVarying = function() {
-        return false;
     };
 
     /**

--- a/Specs/DynamicScene/CzmlDataSourceSpec.js
+++ b/Specs/DynamicScene/CzmlDataSourceSpec.js
@@ -118,7 +118,6 @@ defineSuite([
         expect(dataSource.getClock()).toBeUndefined();
         expect(dataSource.getDynamicObjectCollection()).toBeInstanceOf(DynamicObjectCollection);
         expect(dataSource.getDynamicObjectCollection().getObjects().length).toEqual(0);
-        expect(dataSource.getIsTimeVarying()).toEqual(true);
     });
 
     it('getName returns CZML defined name', function() {

--- a/Specs/DynamicScene/DataSourceDisplaySpec.js
+++ b/Specs/DynamicScene/DataSourceDisplaySpec.js
@@ -91,105 +91,30 @@ defineSuite([
         expect(display.isDestroyed()).toEqual(true);
     });
 
-    it('update identifies time-varying/non-time-varying sources and updates them accordingly', function() {
-        var staticSource = new MockDataSource();
-        var dynamicSource = new MockDataSource();
-        dynamicSource.isTimeVarying = true;
+    it('calling update updates data sources', function() {
+        var source1 = new MockDataSource();
+        var source2 = new MockDataSource();
 
         var display = new DataSourceDisplay(scene, dataSourceCollection, visualizerCallback);
-        dataSourceCollection.add(staticSource);
-        dataSourceCollection.add(dynamicSource);
+        dataSourceCollection.add(source1);
+        dataSourceCollection.add(source2);
 
-        var staticSourceVisualizer = staticSource._visualizers[0];
-        expect(staticSourceVisualizer).toBeInstanceOf(MockVisualizer);
+        var source1Visualizer = source1._visualizers[0];
+        expect(source1Visualizer).toBeInstanceOf(MockVisualizer);
 
-        var dynamicSourceVisualizer = dynamicSource._visualizers[0];
-        expect(dynamicSourceVisualizer).toBeInstanceOf(MockVisualizer);
-
-        //Nothing should have happened yet because we haven't called update.
-        expect(staticSourceVisualizer.updatesCalled).toEqual(0);
-        expect(dynamicSourceVisualizer.updatesCalled).toEqual(0);
-
-        //Update should call update on the visualizer
-        display.update(Iso8601.MINIMUM_VALUE);
-        expect(staticSourceVisualizer.lastUpdateTime).toEqual(Iso8601.MINIMUM_VALUE);
-        expect(staticSourceVisualizer.updatesCalled).toEqual(1);
-        expect(dynamicSourceVisualizer.lastUpdateTime).toEqual(Iso8601.MINIMUM_VALUE);
-        expect(dynamicSourceVisualizer.updatesCalled).toEqual(1);
-
-        //Calling update again should do nothing for staticSource, but will for the dynamic one
-        display.update(Iso8601.MAXIMUM_VALUE);
-        expect(staticSourceVisualizer.lastUpdateTime).toEqual(Iso8601.MINIMUM_VALUE);
-        expect(staticSourceVisualizer.updatesCalled).toEqual(1);
-        expect(dynamicSourceVisualizer.lastUpdateTime).toEqual(Iso8601.MAXIMUM_VALUE);
-        expect(dynamicSourceVisualizer.updatesCalled).toEqual(2);
-
-        staticSource.getChangedEvent().raiseEvent(staticSource);
-
-        //Calling update again should update both because staticSource raised it's changed event.
-        var newTime = new JulianDate();
-        display.update(newTime);
-        expect(staticSourceVisualizer.lastUpdateTime).toEqual(newTime);
-        expect(staticSourceVisualizer.updatesCalled).toEqual(2);
-        expect(dynamicSourceVisualizer.lastUpdateTime).toEqual(newTime);
-        expect(dynamicSourceVisualizer.updatesCalled).toEqual(3);
-
-        display.destroy();
-    });
-
-    it('a static source can become dynamic (and vice versa)', function() {
-        var source = new MockDataSource();
-        dataSourceCollection.add(source);
-
-        var display = new DataSourceDisplay(scene, dataSourceCollection, visualizerCallback);
-
-        var sourceVisualizer = source._visualizers[0];
-        expect(sourceVisualizer).toBeInstanceOf(MockVisualizer);
+        var source2Visualizer = source2._visualizers[0];
+        expect(source2Visualizer).toBeInstanceOf(MockVisualizer);
 
         //Nothing should have happened yet because we haven't called update.
-        expect(sourceVisualizer.updatesCalled).toEqual(0);
+        expect(source1Visualizer.updatesCalled).toEqual(0);
+        expect(source2Visualizer.updatesCalled).toEqual(0);
 
-        //Update should call update on the visualizer
+        //Update should call update on the visualizers
         display.update(Iso8601.MINIMUM_VALUE);
-        expect(sourceVisualizer.lastUpdateTime).toBe(Iso8601.MINIMUM_VALUE);
-        expect(sourceVisualizer.updatesCalled).toEqual(1);
-
-        //Calling update again should do nothing for source, but will for the dynamic one
-        display.update(Iso8601.MAXIMUM_VALUE);
-        expect(sourceVisualizer.lastUpdateTime).toBe(Iso8601.MINIMUM_VALUE);
-        expect(sourceVisualizer.updatesCalled).toEqual(1);
-
-        //Scheduling a static source for update, but then changing it to time-varying
-        //should only result in a single update
-        source.getChangedEvent().raiseEvent(source);
-        source.isTimeVarying = true;
-        source.getChangedEvent().raiseEvent(source);
-
-        //Every update should now result in the visualizer being updated
-        var newTime = new JulianDate();
-        display.update(newTime);
-        expect(sourceVisualizer.lastUpdateTime).toBe(newTime);
-        expect(sourceVisualizer.updatesCalled).toEqual(2);
-
-        newTime = new JulianDate();
-        display.update(newTime);
-        expect(sourceVisualizer.lastUpdateTime).toBe(newTime);
-        expect(sourceVisualizer.updatesCalled).toEqual(3);
-
-        //Switch back to static
-        source.isTimeVarying = false;
-        source.getChangedEvent().raiseEvent(source);
-
-        newTime = new JulianDate();
-        display.update(newTime);
-        expect(sourceVisualizer.lastUpdateTime).toBe(newTime);
-        expect(sourceVisualizer.updatesCalled).toEqual(4);
-
-        var oldTime = newTime;
-        newTime = new JulianDate();
-        display.update(newTime);
-        expect(sourceVisualizer.lastUpdateTime).toBe(oldTime);
-        expect(sourceVisualizer.updatesCalled).toEqual(4);
+        expect(source1Visualizer.lastUpdateTime).toEqual(Iso8601.MINIMUM_VALUE);
+        expect(source1Visualizer.updatesCalled).toEqual(1);
+        expect(source2Visualizer.lastUpdateTime).toEqual(Iso8601.MINIMUM_VALUE);
+        expect(source2Visualizer.updatesCalled).toEqual(1);
 
         display.destroy();
     });

--- a/Specs/DynamicScene/GeoJsonDataSourceSpec.js
+++ b/Specs/DynamicScene/GeoJsonDataSourceSpec.js
@@ -200,7 +200,6 @@ defineSuite([
         expect(dataSource.getName()).toBeUndefined();
         expect(dataSource.getDynamicObjectCollection()).toBeInstanceOf(DynamicObjectCollection);
         expect(dataSource.getDynamicObjectCollection().getObjects().length).toEqual(0);
-        expect(dataSource.getIsTimeVarying()).toEqual(false);
     });
 
     it('Works with null geometry', function() {

--- a/Specs/MockDataSource.js
+++ b/Specs/MockDataSource.js
@@ -33,10 +33,6 @@ define(['Core/Event',
             return that.dynamicObjectCollection;
         };
 
-        this.getIsTimeVarying = function() {
-            return that.isTimeVarying;
-        };
-
         this.destroy = function() {
             that.destroyed = true;
         };


### PR DESCRIPTION
#1603 only affected non-time-varying data sources.  After the last revamp of the Property system,  `DataSource.getIsTimeVarying` is actually no longer needed and removing it fixes a whole host of issues similar to #1603.
