### PR TITLE
Fix memory pressure issue with StaticGeometryPerMaterialBatch

### DIFF
--- a/Source/DynamicScene/StaticGeometryPerMaterialBatch.js
+++ b/Source/DynamicScene/StaticGeometryPerMaterialBatch.js
@@ -25,7 +25,7 @@ define(['../Core/defined',
         this.createPrimitive = true;
         this.primitive = undefined;
         this.geometry = new AssociativeArray();
-        this.material = Material.fromType('Color');
+        this.material = undefined;
         this.updatersWithAttributes = new AssociativeArray();
         this.attributes = new AssociativeArray();
         this.invalidated = false;


### PR DESCRIPTION
We were never assigning the scratch variable we use to store the material in `StaticGeometryPerMaterialBatch`, which caused us to create a new material every frame.
