### PR TITLE
Improve DataSource geometry instance attribute performance

### DIFF
--- a/Source/DynamicScene/StaticGeometryColorBatch.js
+++ b/Source/DynamicScene/StaticGeometryColorBatch.js
@@ -89,14 +89,21 @@ define(['../Core/Color',
                 if (!updater.fillMaterialProperty.isConstant) {
                     var colorProperty = updater.fillMaterialProperty.color;
                     colorProperty.getValue(time, colorScratch);
-                    attributes.color = ColorGeometryInstanceAttribute.toValue(colorScratch, attributes.color);
-                    if ((this.translucent && attributes.color[3] === 255) || (!this.translucent && attributes.color[3] !== 255)) {
-                        this.itemsToRemove[removedCount++] = updater;
+                    if (!Color.equals(attributes._lastColor, colorScratch)) {
+                        attributes._lastColor = Color.clone(colorScratch, attributes._lastColor);
+                        attributes.color = ColorGeometryInstanceAttribute.toValue(colorScratch, attributes.color);
+                        if ((this.translucent && attributes.color[3] === 255) || (!this.translucent && attributes.color[3] !== 255)) {
+                            this.itemsToRemove[removedCount++] = updater;
+                        }
                     }
                 }
 
                 if (!updater.hasConstantFill) {
-                    attributes.show = ShowGeometryInstanceAttribute.toValue(updater.isFilled(time), attributes.show);
+                    var show = updater.isFilled(time);
+                    if (show !== attributes._lastShow) {
+                        attributes._lastShow = show;
+                        attributes.show = ShowGeometryInstanceAttribute.toValue(show, attributes.show);
+                    }
                 }
             }
         }

--- a/Source/DynamicScene/StaticGeometryPerMaterialBatch.js
+++ b/Source/DynamicScene/StaticGeometryPerMaterialBatch.js
@@ -107,7 +107,11 @@ define(['../Core/defined',
                 }
 
                 if (!updater.hasConstantFill) {
-                    attributes.show = ShowGeometryInstanceAttribute.toValue(updater.isFilled(time), attributes.show);
+                    var show = updater.isFilled(time);
+                    if (show !== attributes._lastShow) {
+                        attributes._lastShow = show;
+                        attributes.show = ShowGeometryInstanceAttribute.toValue(show, attributes.show);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Geometry instance attributes are much more expensive to set than I realized when I implemented DataSource geometry batching.  This modifies the batching code to cache the last attribute value and only set it if it's changed.  This improves performance by doing less work, but also greatly reduces the amount of garbage generated in scenarios with lots of geometry that change color or visibility over time.

There's no externally visible changes here other than improved performance.
