### PR TITLE
Fix #1633, SceneModePicker problems with non-default mode on startup.

### DIFF
--- a/Source/Scene/SceneTransitioner.js
+++ b/Source/Scene/SceneTransitioner.js
@@ -134,6 +134,10 @@ define([
         } else {
             morphFrom3DTo2D(this, duration, ellipsoid, complete2DCallback);
         }
+
+        if (duration === 0 && defined(this._completeMorph)) {
+            this._completeMorph();
+        }
     };
 
     SceneTransitioner.prototype.morphToColumbusView = function(duration, ellipsoid) {
@@ -158,6 +162,10 @@ define([
         } else {
             morphFrom3DToColumbusView(this, duration, this._cameraCV, completeColumbusViewCallback);
         }
+
+        if (duration === 0 && defined(this._completeMorph)) {
+            this._completeMorph();
+        }
     };
 
     SceneTransitioner.prototype.morphTo3D = function(duration, ellipsoid) {
@@ -181,6 +189,10 @@ define([
             morphFrom2DTo3D(this, duration, ellipsoid, complete3DCallback);
         } else {
             morphFromColumbusViewTo3D(this, duration, ellipsoid, complete3DCallback);
+        }
+
+        if (duration === 0 && defined(this._completeMorph)) {
+            this._completeMorph();
         }
     };
 

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -239,13 +239,9 @@ define([
             if (options.sceneMode) {
                 if (options.sceneMode === SceneMode.SCENE2D) {
                     this._scene.morphTo2D(0);
-                    // Scene.completeMorph() is needed, even with duration zero, to ensure
-                    // that Scene.mode !== MORPHING during construction.
-                    this._scene.completeMorph();
                 }
                 if (options.sceneMode === SceneMode.COLUMBUS_VIEW) {
                     this._scene.morphToColumbusView(0);
-                    this._scene.completeMorph();
                 }
             }
 


### PR DESCRIPTION
This also fixes an issue where non-3D modes would start by "morphing" from 3D.  Now you can start directly in 2D or CV without the morph-on-startup effect.
