### PR TITLE
Properly terminate web workers

### DIFF
--- a/Source/Core/TaskProcessor.js
+++ b/Source/Core/TaskProcessor.js
@@ -49,6 +49,8 @@ define([
                 var result = defined(array) && array[0] === value;
                 deferred.resolve(result);
 
+                worker.terminate();
+
                 TaskProcessor._canTransferArrayBuffer = result;
             };
 


### PR DESCRIPTION
Now that `Chrome 34.0.1847.131 m` is out and fixes [361792](https://code.google.com/p/chromium/issues/detail?id=361792), we can put back the code removed in #1604 and properly terminate the worker.
