### PR TITLE
Added deprecationWarning

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,6 @@ Beta Releases
 * Added `preRender` and `postRender` events to `Scene`.
 * Fixed dark lighting in 3D and Columbus View when viewing a primitive edge on. ([#592](https://github.com/AnalyticalGraphicsInc/cesium/issues/592))
 * Added `Viewer.targetFrameRate` and `CesiumWidget.targetFrameRate` to allow for throttling of the requestAnimationFrame rate.
-* Added `deprecationWarning`.
 
 ### b28 - 2014-05-01
 

--- a/Source/Core/deprecationWarning.js
+++ b/Source/Core/deprecationWarning.js
@@ -45,6 +45,8 @@ define([
      *         }
      *     }
      * });
+     *
+     * @private
      */
     var deprecationWarning = function(identifier, message) {
         //>>includeStart('debug', pragmas.debug);


### PR DESCRIPTION
To go along with the new [Deprecation Guide](https://github.com/AnalyticalGraphicsInc/cesium/wiki/Deprecation-Guide).

No bikeshedding please; we have big fish to fry.
