### PR TITLE
Fix new billboards added in 2D/CV

### DIFF
--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -383,7 +383,6 @@ define([
 
         this._billboards.push(b);
         this._createVertexArray = true;
-        this._billboardsToUpdate[this._billboardsToUpdateIndex++] = b;
 
         return b;
     };
@@ -1007,7 +1006,8 @@ define([
         var billboardsToUpdate = billboardCollection._billboardsToUpdate;
         var modelMatrix = billboardCollection._modelMatrix;
 
-        if (billboardCollection._mode !== mode ||
+        if (billboardCollection._createVertexArray ||
+            billboardCollection._mode !== mode ||
             billboardCollection._projection !== projection ||
             mode !== SceneMode.SCENE3D &&
             !Matrix4.equals(modelMatrix, billboardCollection.modelMatrix)) {


### PR DESCRIPTION
New billboards were not added to the `_billboardsToUpdate` array, which meant that `recomputeActualPositions` would not initially update them for CV or 2D mode.  This fixes #1691 by always adding new billboards to the `_billboardsToUpdate` array.
