### PR TITLE
Add an ANT target to sort the list of modules in all js files

### DIFF
--- a/Tools/buildTasks/sortRequires.js
+++ b/Tools/buildTasks/sortRequires.js
@@ -9,6 +9,7 @@ load(project.getProperty('tasksDirectory') + '/shared.js'); /*global forEachFile
 var window = window || {};
 
 var jsFileRegex = /\.js$/i;
+var noModulesRegex = /[\s\S]*?define\(function\(\)/;
 var requiresRegex = /([\s\S]*?(define|defineSuite|require)\((?:{[\s\S]*}, )?\[)([\S\s]*?)\]([\s\S]*?function\s*)\(([\S\s]*?)\) {([\s\S]*)/;
 var splitRegex = /,\s*/;
 
@@ -28,7 +29,9 @@ forEachFile('sourcefiles', function(relativePath, file) {
     var contents = readFileContents(file);
     var result = requiresRegex.exec(contents);
     if (result === null) {
-        self.log(relativePath + ' does not have the expected syntax.');
+        if(!noModulesRegex.test(contents)){
+            self.log(relativePath + ' does not have the expected syntax.');
+        }
         return;
     }
 

--- a/build.xml
+++ b/build.xml
@@ -236,10 +236,10 @@
 		<attribute name="pathsoutput" />
 		<element name="sourcefiles" type="resources" />
 	</scriptdef>
-	
-    <scriptdef name="sortRequires" language="javascript" src="${tasksDirectory}/sortRequires.js" manager="bsf" classpathref="javascriptClassPath" loaderref="javascript.loader">
-        <element name="sourcefiles" type="fileset" />
-    </scriptdef>
+
+	<scriptdef name="sortRequires" language="javascript" src="${tasksDirectory}/sortRequires.js" manager="bsf" classpathref="javascriptClassPath" loaderref="javascript.loader">
+		<element name="sourcefiles" type="fileset" />
+	</scriptdef>
 
 	<target name="jsHint" depends="build" description="Runs JSHint on the entire source tree.">
 		<runJsHint jshintpath="${jsHintPath}" jshintoptionspath="${jsHintOptionsPath}" sandcastlejshintoptionspath="${sandcastleDirectory}/jsHintOptions.js" failureproperty="jsHint.failure">
@@ -262,22 +262,33 @@
 		<fail if="jsHint.failure" message="JSHint failed!" />
 	</target>
 
-    <target name="sortRequires" description="Sorts the list of requires in all source files">
-    	<sortRequires>
-    		<sourcefiles dir="${basedir}">
-                <include name="Source/**/*.js" />
-                <exclude name="Source/Shaders/**" />
-                <exclude name="Source/ThirdParty/**" />
-                <exclude name="Source/Workers/cesiumWorkerBootstrapper.js" />
+	<target name="sortRequires" description="Sorts the list of requires in all source files">
+		<sortRequires>
+			<sourcefiles dir="${basedir}">
+				<include name="Source/**/*.js" />
+				<exclude name="Source/Shaders/**" />
+				<exclude name="Source/ThirdParty/**" />
+				<exclude name="Source/Workers/cesiumWorkerBootstrapper.js" />
+				<exclude name="Source/copyrightHeader.js" />
+				<exclude name="Source/Workers/transferTypedArrayTest.js" />
 
-                <include name="Apps/**/*.js" />
+				<include name="Apps/**/*.js" />
+				<exclude name="Apps/Sandcastle/ThirdParty/**" />
+				<exclude name="Apps/server.js" />
 
-                <exclude name="Apps/Sandcastle/ThirdParty/**" />
+				<include name="Specs/**/*.js" />
+				<exclude name="Specs/SpecList.js" />
 
-                <include name="Specs/**/*.js" />
-    		</sourcefiles>
-    	</sortRequires>
-    </target>
+				<exclude name="Apps\Sandcastle\Sandcastle-client.js" />
+				<exclude name="Apps\Sandcastle\Sandcastle-header.js" />
+				<exclude name="Apps\Sandcastle\Sandcastle-warn.js" />
+				<exclude name="Apps\Sandcastle\gallery\gallery-index.js" />
+				<exclude name="Apps\Sandcastle\jsHintOptions.js" />
+
+				<exclude name="**/*.profile.js" />
+			</sourcefiles>
+		</sortRequires>
+	</target>
 
 	<target name="cloc" depends="build" description="Runs cloc to count lines of code for Source and Specs directories.">
 		<echo message="Source:" />


### PR DESCRIPTION
I got sick of doing this by hand while moving `TerrainProvider` to `Core`, so I wrote a script to do it.  It turned out to be a lot more fiddly than I expected, but it works.  It would probably be less fiddly if I spent more time on it or if I were better at regular expressions, but you know how it goes.  Anyway, here's what it gets right:
- The topmost module is kept in that position for defineSuites that don't specify a spec name explicitly.
- It doesn't break when the module name is different from the function parameter name (e.g. CesiumMath).
- It doesn't break anything, at least not anything that's tested by our unit tests.

And what it gets wrong:
- It bails on the one source file that has a comment embedded in the list of modules (`LinkButton`) because I couldn't be bothered to make it work right.
- It complains about lots of files not having the expected syntax.  Some of them don't use AMD, so this is maybe expected.  Others use AMD but don't have any dependencies, so it would be nice if it didn't complain for those.
- The regular expression used to parse the list of requires is kind of nuts and can undoubtedly be simplified.
