### PR TITLE
Removed default credits when constructing the CesiumTerrainProvider.

### DIFF
--- a/Apps/Sandcastle/gallery/Terrain.html
+++ b/Apps/Sandcastle/gallery/Terrain.html
@@ -180,8 +180,7 @@ require(['Cesium'], function(Cesium) {
     });
 
     var cesiumTerrainProviderMeshes = new Cesium.CesiumTerrainProvider({
-        url : '//cesiumjs.org/stk-terrain/tilesets/world/tiles',
-        credit : 'Terrain data courtesy Analytical Graphics, Inc.'
+        url : '//cesiumjs.org/stk-terrain/tilesets/world/tiles'
     });
 
     var ellipsoidProvider = new Cesium.EllipsoidTerrainProvider();

--- a/Source/Widgets/BaseLayerPicker/createDefaultTerrainProviderViewModels.js
+++ b/Source/Widgets/BaseLayerPicker/createDefaultTerrainProviderViewModels.js
@@ -32,8 +32,7 @@ define([
             tooltip : 'High-resolution, mesh-based terrain for the entire globe. Free for use on the Internet. Closed-network options are available.\nhttp://www.agi.com',
             creationFunction : function() {
                 return new CesiumTerrainProvider({
-                    url : '//cesiumjs.org/stk-terrain/tilesets/world/tiles',
-                    credit : 'Terrain data courtesy Analytical Graphics, Inc.'
+                    url : '//cesiumjs.org/stk-terrain/tilesets/world/tiles'
                 });
             }
         }));


### PR DESCRIPTION
The Terrain Server will provide proper attribution.  See CesiumTerrainProvider.metadataSuccess
