### PR TITLE
Minor Sandcastle improvements.

### DIFF
--- a/Apps/Sandcastle/gallery/Black Marble.html
+++ b/Apps/Sandcastle/gallery/Black Marble.html
@@ -22,6 +22,7 @@
 </style>
 <div id="cesiumContainer" class="fullSize"></div>
 <div id="loadingOverlay"><h1>Loading...</h1></div>
+<div id="toolbar"></div>
 <script id="cesium_sandcastle_script">
 require(['Cesium'], function(Cesium) {
     "use strict";

--- a/Apps/Sandcastle/gallery/CZML.html
+++ b/Apps/Sandcastle/gallery/CZML.html
@@ -16,7 +16,7 @@
     });
     </script>
 </head>
-<body class="sandcastle-loading" data-sandcastle-bucket="bucket-requirejs.html" data-sandcastle-title="Cesium">
+<body class="sandcastle-loading" data-sandcastle-bucket="bucket-requirejs.html" data-sandcastle-title="Cesium + require.js">
 <style>
     @import url(../templates/bucket.css);
 </style>

--- a/Apps/Sandcastle/gallery/Cesium Widget.html
+++ b/Apps/Sandcastle/gallery/Cesium Widget.html
@@ -22,6 +22,7 @@
 </style>
 <div id="cesiumContainer" class="fullSize"></div>
 <div id="loadingOverlay"><h1>Loading...</h1></div>
+<div id="toolbar"></div>
 <script id="cesium_sandcastle_script">
 require(['Cesium'], function(Cesium) {
     "use strict";

--- a/Apps/Sandcastle/gallery/Imagery Layers.html
+++ b/Apps/Sandcastle/gallery/Imagery Layers.html
@@ -22,6 +22,7 @@
 </style>
 <div id="cesiumContainer" class="fullSize"></div>
 <div id="loadingOverlay"><h1>Loading...</h1></div>
+<div id="toolbar"></div>
 <script id="cesium_sandcastle_script">
 require(['Cesium'], function(Cesium) {
     "use strict";

--- a/Apps/Sandcastle/gallery/Map Projections.html
+++ b/Apps/Sandcastle/gallery/Map Projections.html
@@ -16,7 +16,7 @@
     });
     </script>
 </head>
-<body class="sandcastle-loading" data-sandcastle-bucket="bucket-requirejs.html" data-sandcastle-title="Cesium">
+<body class="sandcastle-loading" data-sandcastle-bucket="bucket-requirejs.html" data-sandcastle-title="Cesium + require.js">
 <style>
     @import url(../templates/bucket.css);
 </style>

--- a/Apps/Sandcastle/index.html
+++ b/Apps/Sandcastle/index.html
@@ -106,7 +106,7 @@
             <input data-dojo-type="dijit.form.TextBox" type="text" id="search" name="search" data-dojo-props="trim:true, placeHolder:'Search Gallery', intermediateChanges:true"/>            
         </div>
         <div id="codeContainer" data-dojo-type="dijit.layout.TabContainer" data-dojo-props="region: 'leading', splitter: true">
-            <script type='dojo/method' event='_onKeyPress'></script>
+            <script type='dojo/method' event='_onKeyDown'></script>
             <div id="jsContainer" data-dojo-type="dijit.layout.ContentPane" data-dojo-props="title: 'JavaScript code'">
                 <textarea id="code" name="code">// Select a demo from the gallery to load.
                 </textarea>


### PR DESCRIPTION
- Add a toolbar element to most examples to make it easier to copy/paste from one example to another.
- Make CTRL-Home and End work properly again.  A Dojo upgrade changed the method we have to hack out to disable the TabContainer key binding.
