### PR TITLE
Remove unnecessary `../` paths for modules.

### DIFF
--- a/Source/Core/Packable.js
+++ b/Source/Core/Packable.js
@@ -1,6 +1,6 @@
 /*global define*/
 define([
-        '../Core/DeveloperError'
+        './DeveloperError'
     ], function(
         DeveloperError) {
     "use strict";

--- a/Source/Core/PackableForInterpolation.js
+++ b/Source/Core/PackableForInterpolation.js
@@ -1,6 +1,6 @@
 /*global define*/
 define([
-        '../Core/DeveloperError'
+        './DeveloperError'
     ], function(
         DeveloperError) {
     "use strict";

--- a/Source/Core/Spline.js
+++ b/Source/Core/Spline.js
@@ -1,8 +1,8 @@
 /*global define*/
 define([
-        '../Core/defaultValue',
-        '../Core/defined',
-        '../Core/DeveloperError'
+        './defaultValue',
+        './defined',
+        './DeveloperError'
     ], function(
         defaultValue,
         defined,

--- a/Source/DynamicScene/EllipseGeometryUpdater.js
+++ b/Source/DynamicScene/EllipseGeometryUpdater.js
@@ -13,13 +13,13 @@ define([
         '../Core/GeometryInstance',
         '../Core/Iso8601',
         '../Core/ShowGeometryInstanceAttribute',
-        '../DynamicScene/ColorMaterialProperty',
-        '../DynamicScene/ConstantProperty',
-        '../DynamicScene/MaterialProperty',
-        '../DynamicScene/Property',
         '../Scene/MaterialAppearance',
         '../Scene/PerInstanceColorAppearance',
-        '../Scene/Primitive'
+        '../Scene/Primitive',
+        './ColorMaterialProperty',
+        './ConstantProperty',
+        './MaterialProperty',
+        './Property'
     ], function(
         Color,
         ColorGeometryInstanceAttribute,
@@ -34,13 +34,13 @@ define([
         GeometryInstance,
         Iso8601,
         ShowGeometryInstanceAttribute,
+        MaterialAppearance,
+        PerInstanceColorAppearance,
+        Primitive,
         ColorMaterialProperty,
         ConstantProperty,
         MaterialProperty,
-        Property,
-        MaterialAppearance,
-        PerInstanceColorAppearance,
-        Primitive) {
+        Property) {
     "use strict";
 
     var defaultMaterial = ColorMaterialProperty.fromColor(Color.WHITE);

--- a/Source/DynamicScene/EllipsoidGeometryUpdater.js
+++ b/Source/DynamicScene/EllipsoidGeometryUpdater.js
@@ -16,15 +16,15 @@ define([
         '../Core/Matrix3',
         '../Core/Matrix4',
         '../Core/ShowGeometryInstanceAttribute',
-        '../DynamicScene/ColorMaterialProperty',
-        '../DynamicScene/ConstantProperty',
-        '../DynamicScene/MaterialProperty',
-        '../DynamicScene/Property',
         '../Scene/MaterialAppearance',
         '../Scene/PerInstanceColorAppearance',
         '../Scene/Primitive',
         '../Scene/PrimitiveState',
-        '../Scene/SceneMode'
+        '../Scene/SceneMode',
+        './ColorMaterialProperty',
+        './ConstantProperty',
+        './MaterialProperty',
+        './Property'
     ], function(
         Cartesian3,
         Color,
@@ -42,15 +42,15 @@ define([
         Matrix3,
         Matrix4,
         ShowGeometryInstanceAttribute,
-        ColorMaterialProperty,
-        ConstantProperty,
-        MaterialProperty,
-        Property,
         MaterialAppearance,
         PerInstanceColorAppearance,
         Primitive,
         PrimitiveState,
-        SceneMode) {
+        SceneMode,
+        ColorMaterialProperty,
+        ConstantProperty,
+        MaterialProperty,
+        Property) {
     "use strict";
 
     var defaultMaterial = ColorMaterialProperty.fromColor(Color.WHITE);

--- a/Source/DynamicScene/PolygonGeometryUpdater.js
+++ b/Source/DynamicScene/PolygonGeometryUpdater.js
@@ -13,13 +13,13 @@ define([
         '../Core/PolygonGeometry',
         '../Core/PolygonOutlineGeometry',
         '../Core/ShowGeometryInstanceAttribute',
-        '../DynamicScene/ColorMaterialProperty',
-        '../DynamicScene/ConstantProperty',
-        '../DynamicScene/MaterialProperty',
-        '../DynamicScene/Property',
         '../Scene/MaterialAppearance',
         '../Scene/PerInstanceColorAppearance',
-        '../Scene/Primitive'
+        '../Scene/Primitive',
+        './ColorMaterialProperty',
+        './ConstantProperty',
+        './MaterialProperty',
+        './Property'
     ], function(
         Color,
         ColorGeometryInstanceAttribute,
@@ -34,13 +34,13 @@ define([
         PolygonGeometry,
         PolygonOutlineGeometry,
         ShowGeometryInstanceAttribute,
+        MaterialAppearance,
+        PerInstanceColorAppearance,
+        Primitive,
         ColorMaterialProperty,
         ConstantProperty,
         MaterialProperty,
-        Property,
-        MaterialAppearance,
-        PerInstanceColorAppearance,
-        Primitive) {
+        Property) {
     "use strict";
 
     var defaultMaterial = ColorMaterialProperty.fromColor(Color.WHITE);

--- a/Source/DynamicScene/PolylineGeometryUpdater.js
+++ b/Source/DynamicScene/PolylineGeometryUpdater.js
@@ -12,13 +12,13 @@ define([
         '../Core/Iso8601',
         '../Core/PolylineGeometry',
         '../Core/ShowGeometryInstanceAttribute',
-        '../DynamicScene/ColorMaterialProperty',
-        '../DynamicScene/ConstantProperty',
-        '../DynamicScene/MaterialProperty',
-        '../DynamicScene/Property',
         '../Scene/PolylineColorAppearance',
         '../Scene/PolylineMaterialAppearance',
-        '../Scene/Primitive'
+        '../Scene/Primitive',
+        './ColorMaterialProperty',
+        './ConstantProperty',
+        './MaterialProperty',
+        './Property'
     ], function(
         Color,
         ColorGeometryInstanceAttribute,
@@ -32,13 +32,13 @@ define([
         Iso8601,
         PolylineGeometry,
         ShowGeometryInstanceAttribute,
+        PolylineColorAppearance,
+        PolylineMaterialAppearance,
+        Primitive,
         ColorMaterialProperty,
         ConstantProperty,
         MaterialProperty,
-        Property,
-        PolylineColorAppearance,
-        PolylineMaterialAppearance,
-        Primitive) {
+        Property) {
     "use strict";
 
     var defaultMaterial = ColorMaterialProperty.fromColor(Color.WHITE);

--- a/Source/DynamicScene/RectangleGeometryUpdater.js
+++ b/Source/DynamicScene/RectangleGeometryUpdater.js
@@ -13,13 +13,13 @@ define([
         '../Core/RectangleGeometry',
         '../Core/RectangleOutlineGeometry',
         '../Core/ShowGeometryInstanceAttribute',
-        '../DynamicScene/ColorMaterialProperty',
-        '../DynamicScene/ConstantProperty',
-        '../DynamicScene/MaterialProperty',
-        '../DynamicScene/Property',
         '../Scene/MaterialAppearance',
         '../Scene/PerInstanceColorAppearance',
-        '../Scene/Primitive'
+        '../Scene/Primitive',
+        './ColorMaterialProperty',
+        './ConstantProperty',
+        './MaterialProperty',
+        './Property'
     ], function(
         Color,
         ColorGeometryInstanceAttribute,
@@ -34,13 +34,13 @@ define([
         RectangleGeometry,
         RectangleOutlineGeometry,
         ShowGeometryInstanceAttribute,
+        MaterialAppearance,
+        PerInstanceColorAppearance,
+        Primitive,
         ColorMaterialProperty,
         ConstantProperty,
         MaterialProperty,
-        Property,
-        MaterialAppearance,
-        PerInstanceColorAppearance,
-        Primitive) {
+        Property) {
     "use strict";
 
     var defaultMaterial = ColorMaterialProperty.fromColor(Color.WHITE);

--- a/Source/DynamicScene/ReferenceProperty.js
+++ b/Source/DynamicScene/ReferenceProperty.js
@@ -4,7 +4,7 @@ define([
         '../Core/defineProperties',
         '../Core/DeveloperError',
         '../Core/Event',
-        '../DynamicScene/Property'
+        './Property'
     ], function(
         defined,
         defineProperties,

--- a/Source/DynamicScene/WallGeometryUpdater.js
+++ b/Source/DynamicScene/WallGeometryUpdater.js
@@ -13,13 +13,13 @@ define([
         '../Core/ShowGeometryInstanceAttribute',
         '../Core/WallGeometry',
         '../Core/WallOutlineGeometry',
-        '../DynamicScene/ColorMaterialProperty',
-        '../DynamicScene/ConstantProperty',
-        '../DynamicScene/MaterialProperty',
-        '../DynamicScene/Property',
         '../Scene/MaterialAppearance',
         '../Scene/PerInstanceColorAppearance',
-        '../Scene/Primitive'
+        '../Scene/Primitive',
+        './ColorMaterialProperty',
+        './ConstantProperty',
+        './MaterialProperty',
+        './Property'
     ], function(
         Color,
         ColorGeometryInstanceAttribute,
@@ -34,13 +34,13 @@ define([
         ShowGeometryInstanceAttribute,
         WallGeometry,
         WallOutlineGeometry,
+        MaterialAppearance,
+        PerInstanceColorAppearance,
+        Primitive,
         ColorMaterialProperty,
         ConstantProperty,
         MaterialProperty,
-        Property,
-        MaterialAppearance,
-        PerInstanceColorAppearance,
-        Primitive) {
+        Property) {
     "use strict";
 
     var defaultMaterial = ColorMaterialProperty.fromColor(Color.WHITE);

--- a/Source/Renderer/ShaderCache.js
+++ b/Source/Renderer/ShaderCache.js
@@ -2,7 +2,7 @@
 define([
         '../Core/defined',
         '../Core/destroyObject',
-        '../Renderer/ShaderProgram'
+        './ShaderProgram'
     ], function(
         defined,
         destroyObject,

--- a/Source/Scene/CameraFlightPath.js
+++ b/Source/Scene/CameraFlightPath.js
@@ -14,10 +14,10 @@ define([
         '../Core/Matrix4',
         '../Core/Quaternion',
         '../Core/QuaternionSpline',
-        '../Scene/PerspectiveFrustum',
-        '../Scene/PerspectiveOffCenterFrustum',
-        '../Scene/SceneMode',
-        '../ThirdParty/Tween'
+        '../ThirdParty/Tween',
+        './PerspectiveFrustum',
+        './PerspectiveOffCenterFrustum',
+        './SceneMode'
     ], function(
         Cartesian2,
         Cartesian3,
@@ -33,10 +33,10 @@ define([
         Matrix4,
         Quaternion,
         QuaternionSpline,
+        Tween,
         PerspectiveFrustum,
         PerspectiveOffCenterFrustum,
-        SceneMode,
-        Tween) {
+        SceneMode) {
     "use strict";
 
     /**

--- a/Source/Scene/OIT.js
+++ b/Source/Scene/OIT.js
@@ -8,10 +8,10 @@ define([
         '../Renderer/createShaderSource',
         '../Renderer/PixelDatatype',
         '../Renderer/RenderState',
-        '../Scene/BlendEquation',
-        '../Scene/BlendFunction',
         '../Shaders/AdjustTranslucentFS',
-        '../Shaders/CompositeOITFS'
+        '../Shaders/CompositeOITFS',
+        './BlendEquation',
+        './BlendFunction'
     ], function(
         Color,
         defined,
@@ -21,10 +21,10 @@ define([
         createShaderSource,
         PixelDatatype,
         RenderState,
-        BlendEquation,
-        BlendFunction,
         AdjustTranslucentFS,
-        CompositeOITFS) {
+        CompositeOITFS,
+        BlendEquation,
+        BlendFunction) {
     "use strict";
     /*global WebGLRenderingContext*/
 

--- a/Source/Scene/OrthographicFrustum.js
+++ b/Source/Scene/OrthographicFrustum.js
@@ -7,7 +7,7 @@ define([
         '../Core/defineProperties',
         '../Core/DeveloperError',
         '../Core/Matrix4',
-        '../Scene/CullingVolume'
+        './CullingVolume'
     ], function(
         Cartesian2,
         Cartesian3,

--- a/Source/Scene/PerspectiveFrustum.js
+++ b/Source/Scene/PerspectiveFrustum.js
@@ -3,7 +3,7 @@ define([
         '../Core/defined',
         '../Core/defineProperties',
         '../Core/DeveloperError',
-        '../Scene/PerspectiveOffCenterFrustum'
+        './PerspectiveOffCenterFrustum'
     ], function(
         defined,
         defineProperties,

--- a/Source/Scene/PerspectiveOffCenterFrustum.js
+++ b/Source/Scene/PerspectiveOffCenterFrustum.js
@@ -8,7 +8,7 @@ define([
         '../Core/defineProperties',
         '../Core/DeveloperError',
         '../Core/Matrix4',
-        '../Scene/CullingVolume'
+        './CullingVolume'
     ], function(
         Cartesian2,
         Cartesian3,

--- a/Source/Scene/PolylineMaterialAppearance.js
+++ b/Source/Scene/PolylineMaterialAppearance.js
@@ -1,8 +1,8 @@
 /*global define*/
 define([
         '../Core/defaultValue',
-        '../Core/defineProperties',
         '../Core/defined',
+        '../Core/defineProperties',
         '../Core/VertexFormat',
         '../Renderer/createShaderSource',
         '../Shaders/Appearances/PolylineMaterialAppearanceVS',
@@ -12,8 +12,8 @@ define([
         './Material'
     ], function(
         defaultValue,
-        defineProperties,
         defined,
+        defineProperties,
         VertexFormat,
         createShaderSource,
         PolylineMaterialAppearanceVS,


### PR DESCRIPTION
e.g. modules in Core should not use `../Core` as a prefix.
