### PR TITLE
Remove unnecessary code that moved focused suites to be first.

### DIFF
--- a/Specs/SpecRunner.js
+++ b/Specs/SpecRunner.js
@@ -38,6 +38,10 @@ var afterAll;
         return match && decodeURIComponent(match[1].replace(/\+/g, ' '));
     }
 
+    function defined(value) {
+        return value !== undefined;
+    }
+
     // patch in beforeAll/afterAll functions
     // based on existing beforeEach/afterEach
 
@@ -59,7 +63,7 @@ var afterAll;
 
     jasmine.Suite.prototype.beforeAll = function(beforeAllFunction) {
         beforeAllFunction.typeName = 'beforeAll';
-        if (typeof this.beforeAll_ === 'undefined') {
+        if (!defined(this.beforeAll_)) {
             this.beforeAll_ = [];
         }
         this.beforeAll_.unshift(beforeAllFunction);
@@ -67,7 +71,7 @@ var afterAll;
 
     jasmine.Suite.prototype.afterAll = function(afterAllFunction) {
         afterAllFunction.typeName = 'afterAll';
-        if (typeof this.afterAll_ === 'undefined') {
+        if (!defined(this.afterAll_)) {
             this.afterAll_ = [];
         }
         this.afterAll_.unshift(afterAllFunction);
@@ -105,7 +109,7 @@ var afterAll;
                 var results;
 
                 var beforeAll = this.beforeAll_;
-                if (typeof beforeAll !== 'undefined') {
+                if (defined(beforeAll)) {
                     var beforeSpec = new jasmine.Spec(this.env, this, 'beforeAll');
                     this.beforeSpec_ = beforeSpec;
                     results = function() {
@@ -119,7 +123,7 @@ var afterAll;
                 }
 
                 var afterAll = this.afterAll_;
-                if (typeof afterAll !== 'undefined') {
+                if (defined(afterAll)) {
                     var afterSpec = new jasmine.Spec(this.env, this, 'afterAll');
                     this.afterSpec_ = afterSpec;
                     results = function() {
@@ -195,12 +199,7 @@ var afterAll;
             }
         });
 
-        require([
-        'Cesium',
-        'Stubs/paths'
-    ], function(
-        BuiltCesium,
-        paths) {
+        require(['Cesium', 'Stubs/paths'], function(BuiltCesium, paths) {
             paths.Specs = '../../Specs';
 
             require.config({
@@ -280,12 +279,8 @@ var afterAll;
 
     function requireTests() {
         //specs is an array defined by SpecList.js
-        require([
-                 'Specs/addDefaultMatchers',
-                 'Specs/equalsMethodEqualityTester'
-             ].concat(specs), function(
-                 addDefaultMatchers,
-                 equalsMethodEqualityTester) {
+        var modules = ['Specs/addDefaultMatchers', 'Specs/equalsMethodEqualityTester'].concat(specs);
+        require(modules, function(addDefaultMatchers, equalsMethodEqualityTester) {
             var env = jasmine.getEnv();
 
             env.beforeEach(addDefaultMatchers(!release));
@@ -293,19 +288,6 @@ var afterAll;
 
             createTests = function() {
                 var reporter = new jasmine.HtmlReporter();
-                var isSuiteFocused = jasmine.HtmlReporterHelpers.isSuiteFocused;
-                var suites = jasmine.getEnv().currentRunner().suites();
-
-                for ( var i = 1, insertPoint = 0, len = suites.length; i < len; i++) {
-                    var suite = suites[i];
-                    if (isSuiteFocused(suite)) {
-                        suites.splice(i, 1);
-                        suites.splice(insertPoint, 0, suite);
-                        insertPoint++;
-                        i--;
-                    }
-                }
-
                 env.addReporter(reporter);
                 env.specFilter = reporter.specFilter;
                 env.execute();

--- a/build.xml
+++ b/build.xml
@@ -268,6 +268,7 @@
 				<exclude name="Apps/server.js" />
 
 				<include name="Specs/**/*.js" />
+				<exclude name="Specs/SpecRunner.js" />
 				<exclude name="Specs/SpecList.js" />
 
 				<exclude name="Apps/Sandcastle/Sandcastle-client.js" />


### PR DESCRIPTION
This is not needed in the current version, and actually had a bug in the logic that locked up the browser when running the first suite in the list.
