### PR TITLE
More test workarounds for IE 11

### DIFF
--- a/Specs/Renderer/CubeMapSpec.js
+++ b/Specs/Renderer/CubeMapSpec.js
@@ -2,6 +2,7 @@
 defineSuite([
         'Core/Cartesian3',
         'Core/Color',
+        'Core/FeatureDetection',
         'Core/PixelFormat',
         'Core/PrimitiveType',
         'Renderer/BufferUsage',
@@ -16,6 +17,7 @@ defineSuite([
     ], 'Renderer/CubeMap', function(
         Cartesian3,
         Color,
+        FeatureDetection,
         PixelFormat,
         PrimitiveType,
         BufferUsage,
@@ -231,6 +233,11 @@ defineSuite([
     });
 
     it('draws with a cube map with premultiplied alpha', function() {
+        if (FeatureDetection.isInternetExplorer()) {
+            // Workaround IE 11.0.8, which does not support premultiplied alpha
+            return;
+        }
+
         cubeMap = context.createCubeMap({
             source : {
                 positiveX : blueAlphaImage,

--- a/Specs/Renderer/TextureSpec.js
+++ b/Specs/Renderer/TextureSpec.js
@@ -3,6 +3,7 @@ defineSuite([
         'Renderer/Texture',
         'Core/Cartesian2',
         'Core/Color',
+        'Core/FeatureDetection',
         'Core/loadImage',
         'Core/PixelFormat',
         'Core/PrimitiveType',
@@ -19,6 +20,7 @@ defineSuite([
         Texture,
         Cartesian2,
         Color,
+        FeatureDetection,
         loadImage,
         PixelFormat,
         PrimitiveType,
@@ -192,6 +194,11 @@ defineSuite([
     });
 
     it('renders with premultiplied alpha', function() {
+        if (FeatureDetection.isInternetExplorer()) {
+            // Workaround IE 11.0.8, which does not support premultiplied alpha
+            return;
+        }
+
         texture = context.createTexture2D({
             source : blueAlphaImage,
             pixelFormat : PixelFormat.RGBA,


### PR DESCRIPTION
Should fix these:

```
Renderer/CubeMap draws with a cube map with premultiplied alpha.
Renderer/Texture renders with premultiplied alpha.
```

Part of #1616
