### PR TITLE
Include VERSION property in Cesium object.

### DIFF
--- a/Tools/buildTasks/createCesiumJs.js
+++ b/Tools/buildTasks/createCesiumJs.js
@@ -31,12 +31,15 @@ forEachFile('sourcefiles', function(relativePath, file) {
     assignments.push('Cesium' + assignmentName + ' = ' + parameterName + ';');
 });
 
+var version = project.getProperty('version');
+
 var contents = '\
 /*global define*/\n\
 define([' + moduleIds.join(', ') + '], function(' + parameters.join(', ') + ') {\n\
   "use strict";\n\
   /*jshint sub:true*/\n\
   var Cesium = {\n\
+    VERSION : "' + version + '",\n\
     _shaders : {}\n\
   };\n\
   ' + assignments.join('\n  ') + '\n\


### PR DESCRIPTION
Accessible at `Cesium.VERSION`.

Fixes #1470.
