### PR TITLE
Add myself to CONTRIBUTORS.md under NICTA.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,6 +22,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
    * [Dan Yankowsky](https://github.com/balefrost)
 * [NICTA](http://www.nicta.com.au/)
    * [Chris Cooper](https://github.com/chris-cooper)
+   * [Kevin Ring](https://github.com/kring)
 * [EU Edge](http://euedge.com/)
    * [Ákos Maróy](https://github.com/akosmaroy)
 * [Raytheon Intelligence and Information Systems](http://www.raytheon.com/)


### PR DESCRIPTION
This seems to be a record of what CLAs people contributed code under.  So I guess I should stay in the AGI and Individual categories as well?

Also, it would be great if someone could update this page when you get a chance:
http://cesiumjs.org/contributors.html

It could say "NICTA (formerly AGI)" or just NICTA, up to you.

I was in a meeting yesterday where someone (outside NICTA) pointed out that this hadn't been updated yet.
