### PR TITLE
Make Sandcastle.addToolbarButton hide the highlight logic.

### DIFF
--- a/Apps/Sandcastle/Sandcastle-header.js
+++ b/Apps/Sandcastle/Sandcastle-header.js
@@ -18,9 +18,13 @@
             document.body.className = document.body.className.replace(/(?:\s|^)sandcastle-loading(?:\s|$)/, ' ');
         },
         addToolbarButton : function(text, onclick, toolbarID) {
+            window.Sandcastle.declare(onclick);
             var button = document.createElement('button');
             button.className = 'sandcastle-button';
-            button.onclick = onclick;
+            button.onclick = function() {
+                window.Sandcastle.highlight(onclick);
+                onclick();
+            };
             button.textContent = text;
             document.getElementById(toolbarID || 'toolbar').appendChild(button);
         },

--- a/Apps/Sandcastle/gallery/Animations.html
+++ b/Apps/Sandcastle/gallery/Animations.html
@@ -27,25 +27,13 @@
 require(['Cesium'], function(Cesium) {
     "use strict";
 
+    var viewer = new Cesium.Viewer('cesiumContainer');
+    var scene = viewer.scene;
+
     var rectangle;
     var rectangularSensor;
 
-    function addAlphaAnimation(primitive, scene) {
-        Sandcastle.declare(addAlphaAnimation); // For highlighting in Sandcastle.
-        scene.animations.addAlpha(primitive.material, 0.0, 0.5);
-    }
-
-    function addStripeAnimation(primitive, scene) {
-        Sandcastle.declare(addStripeAnimation); // For highlighting in Sandcastle.
-        scene.animations.addOffsetIncrement(primitive.material);
-    }
-
-    function resetRectanglePropeties(rectangle) {
-        rectangle.material.uniforms.time = 1.0;
-        rectangle.material.uniforms.color = new Cesium.Color(1.0, 0.0, 0.0, 0.5);
-    }
-
-    function createPrimitives(scene) {
+    function createPrimitives() {
         var primitives = scene.primitives;
 
         rectangle = new Cesium.RectanglePrimitive({
@@ -72,23 +60,22 @@ require(['Cesium'], function(Cesium) {
         });
         primitives.add(sensors);
     }
+    createPrimitives();
 
-    var viewer = new Cesium.Viewer('cesiumContainer');
-    var scene = viewer.scene;
-
-    createPrimitives(scene);
+    function reset() {
+        scene.animations.removeAll();
+        rectangle.material.uniforms.time = 1.0;
+        rectangle.material.uniforms.color = new Cesium.Color(1.0, 0.0, 0.0, 0.5);
+    }
 
     Sandcastle.addToolbarButton('Alpha Animation', function() {
-        scene.animations.removeAll();
-        resetRectanglePropeties(rectangle);
-        addAlphaAnimation(rectangle, scene);
-        Sandcastle.highlight(addAlphaAnimation);
+        reset();
+        scene.animations.addAlpha(rectangle.material, 0.0, 0.5);
     });
 
     Sandcastle.addToolbarButton('Stripe Animation', function() {
-        scene.animations.removeAll();
-        addStripeAnimation(rectangularSensor, scene);
-        Sandcastle.highlight(addStripeAnimation);
+        reset();
+        scene.animations.addOffsetIncrement(rectangularSensor.material);
     });
 
     Sandcastle.finishedLoading();

--- a/Apps/Sandcastle/gallery/Billboards.html
+++ b/Apps/Sandcastle/gallery/Billboards.html
@@ -27,8 +27,15 @@
 require(['Cesium'], function(Cesium) {
     "use strict";
 
-    function addBillboard(scene) {
-        Sandcastle.declare(addBillboard); // For highlighting in Sandcastle.
+    var viewer = new Cesium.Viewer('cesiumContainer');
+    var scene = viewer.scene;
+    var primitives = scene.primitives;
+
+    function reset() {
+        primitives.removeAll();
+    }
+
+    function addBillboard() {
         var image = new Image();
         image.onload = function() {
             var billboards = new Cesium.BillboardCollection();
@@ -46,9 +53,16 @@ require(['Cesium'], function(Cesium) {
         };
         image.src = '../images/Cesium_Logo_overlay.png';
     }
+    addBillboard();
 
-    function setBillboardPropertiesAtCreation(scene) {
-        Sandcastle.declare(setBillboardPropertiesAtCreation); // For highlighting in Sandcastle.
+    Sandcastle.addToolbarButton('Add billboard', function() {
+        reset();
+        addBillboard();
+    });
+
+    Sandcastle.addToolbarButton('Set billboard properties at creation', function() {
+        reset();
+
         var image = new Image();
         image.onload = function() {
             var billboards = new Cesium.BillboardCollection();
@@ -76,10 +90,11 @@ require(['Cesium'], function(Cesium) {
             scene.primitives.add(billboards);
         };
         image.src = '../images/Cesium_Logo_overlay.png';
-    }
+    });
 
-    function setBillboardProperties(scene) {
-        Sandcastle.declare(setBillboardProperties); // For highlighting in Sandcastle.
+    Sandcastle.addToolbarButton('Change billboard properties', function() {
+        reset();
+
         var image = new Image();
         image.onload = function() {
             var billboards = new Cesium.BillboardCollection();
@@ -103,10 +118,11 @@ require(['Cesium'], function(Cesium) {
             scene.primitives.add(billboards);
         };
         image.src = '../images/Cesium_Logo_overlay.png';
-    }
+    });
 
-    function addMultipleBillboards(scene) {
-        Sandcastle.declare(addMultipleBillboards); // For highlighting in Sandcastle.
+    Sandcastle.addToolbarButton('Add multiple billboards', function() {
+        reset();
+
         Cesium.when.all([
                          Cesium.loadImage('../images/Cesium_Logo_overlay.png'),
                          Cesium.loadImage('../images/facility.gif')
@@ -144,10 +160,11 @@ require(['Cesium'], function(Cesium) {
 
             scene.primitives.add(billboards);
         });
-    }
+    });
 
-    function scaleBillboardByDistance(scene) {
-        Sandcastle.declare(scaleBillboardByDistance); // For highlighting in Sandcastle.
+    Sandcastle.addToolbarButton('Scale by viewer distance', function() {
+        reset();
+
         var image = new Image();
         image.onload = function() {
             var billboards = new Cesium.BillboardCollection();
@@ -165,10 +182,11 @@ require(['Cesium'], function(Cesium) {
             scene.primitives.add(billboards);
         };
         image.src = '../images/facility.gif';
-    }
+    });
 
-    function billboardTranslucencyByDistance(scene) {
-        Sandcastle.declare(billboardTranslucencyByDistance); // For highlighting in Sandcastle.
+    Sandcastle.addToolbarButton('Fade by viewer distance', function() {
+        reset();
+
         var image = new Image();
         image.onload = function() {
             var billboards = new Cesium.BillboardCollection();
@@ -186,10 +204,10 @@ require(['Cesium'], function(Cesium) {
             scene.primitives.add(billboards);
         };
         image.src = '../images/Cesium_Logo_overlay.png';
-    }
+    });
 
-    function billboardPixelOffsetScaleByDistance(scene) {
-        Sandcastle.declare(billboardPixelOffsetScaleByDistance); // For highlighting in Sandcastle.
+    Sandcastle.addToolbarButton('Offset by viewer distance', function() {
+        reset();
 
         Cesium.when.all([
                          Cesium.loadImage('../images/Cesium_Logo_overlay.png'),
@@ -225,10 +243,11 @@ require(['Cesium'], function(Cesium) {
             });
             scene.primitives.add(billboards);
         });
-    }
+    });
 
-    function addPointBillboards(scene) {
-        Sandcastle.declare(addPointBillboards); // For highlighting in Sandcastle.
+    Sandcastle.addToolbarButton('Add point billboards', function() {
+        reset();
+
         // A white circle is drawn into a 2D canvas.  The canvas is used as
         // a texture for billboards, each of which applies a different color
         // and scale to change the point's appearance.
@@ -273,10 +292,11 @@ require(['Cesium'], function(Cesium) {
         });
 
         scene.primitives.add(billboards);
-    }
+    });
 
-    function addMarkerBillboards(scene) {
-        Sandcastle.declare(addMarkerBillboards); // For highlighting in Sandcastle.
+    Sandcastle.addToolbarButton('Add marker billboards', function() {
+        reset();
+
         var image = new Image();
         image.onload = function() {
             var billboards = new Cesium.BillboardCollection();
@@ -373,10 +393,11 @@ require(['Cesium'], function(Cesium) {
             scene.primitives.add(billboards);
         };
         image.src = '../images/whiteShapes.png';
-    }
+    });
 
-    function addBillboardsInReferenceframe(scene) {
-        Sandcastle.declare(addBillboardsInReferenceframe); // For highlighting in Sandcastle.
+    Sandcastle.addToolbarButton('Add billboards in reference frame', function() {
+        reset();
+
         var image = new Image();
         image.onload = function() {
             var billboards = new Cesium.BillboardCollection();
@@ -411,72 +432,6 @@ require(['Cesium'], function(Cesium) {
             scene.primitives.add(billboards);
         };
         image.src = '../images/facility.gif';
-    }
-
-    var viewer = new Cesium.Viewer('cesiumContainer');
-    var scene = viewer.scene;
-    var primitives = scene.primitives;
-
-    addBillboard(scene);
-
-    Sandcastle.addToolbarButton('Add billboard', function() {
-        primitives.removeAll();
-        addBillboard(scene);
-        Sandcastle.highlight(addBillboard);
-    });
-
-    Sandcastle.addToolbarButton('Set billboard properties at creation', function() {
-        primitives.removeAll();
-        setBillboardPropertiesAtCreation(scene);
-        Sandcastle.highlight(setBillboardPropertiesAtCreation);
-    });
-
-    Sandcastle.addToolbarButton('Change billboard properties', function() {
-        primitives.removeAll();
-        setBillboardProperties(scene);
-        Sandcastle.highlight(setBillboardProperties);
-    });
-
-    Sandcastle.addToolbarButton('Add multiple billboards', function() {
-        primitives.removeAll();
-        addMultipleBillboards(scene);
-        Sandcastle.highlight(addMultipleBillboards);
-    });
-
-    Sandcastle.addToolbarButton('Add point billboards', function() {
-        primitives.removeAll();
-        addPointBillboards(scene);
-        Sandcastle.highlight(addPointBillboards);
-    });
-
-    Sandcastle.addToolbarButton('Add marker billboards', function() {
-        primitives.removeAll();
-        addMarkerBillboards(scene);
-        Sandcastle.highlight(addMarkerBillboards);
-    });
-
-    Sandcastle.addToolbarButton('Add billboards in reference frame', function() {
-        primitives.removeAll();
-        addBillboardsInReferenceframe(scene);
-        Sandcastle.highlight(addBillboardsInReferenceframe);
-    });
-
-    Sandcastle.addToolbarButton('Scale by viewer distance', function() {
-        primitives.removeAll();
-        scaleBillboardByDistance(scene);
-        Sandcastle.highlight(scaleBillboardByDistance);
-    });
-
-    Sandcastle.addToolbarButton('Fade by viewer distance', function() {
-        primitives.removeAll();
-        billboardTranslucencyByDistance(scene);
-        Sandcastle.highlight(billboardTranslucencyByDistance);
-    });
-    
-    Sandcastle.addToolbarButton('Offset by viewer distance', function() {
-        primitives.removeAll();
-        billboardPixelOffsetScaleByDistance(scene);
-        Sandcastle.highlight(billboardPixelOffsetScaleByDistance);
     });
 
     Sandcastle.finishedLoading();

--- a/Apps/Sandcastle/gallery/CZML.html
+++ b/Apps/Sandcastle/gallery/CZML.html
@@ -29,9 +29,10 @@ require(['Cesium'], function(Cesium) {
 
     var gallery = '../../CesiumViewer/Gallery/';
 
-    function czmlSatellites() {
-        Sandcastle.declare(czmlSatellites); // For highlighting in Sandcastle.
+    var viewer = new Cesium.Viewer('cesiumContainer');
+    viewer.extend(Cesium.viewerDynamicObjectMixin);
 
+    function czmlSatellites() {
         viewer.dataSources.removeAll();
 
         var czmlDataSource = new Cesium.CzmlDataSource();
@@ -40,10 +41,13 @@ require(['Cesium'], function(Cesium) {
             viewer.homeButton.viewModel.command();
         });
     }
+    czmlSatellites();
 
-    function czmlSensors() {
-        Sandcastle.declare(czmlSensors); // For highlighting in Sandcastle.
+    Sandcastle.addToolbarButton('Satellites', function() {
+        czmlSatellites();
+    });
 
+    Sandcastle.addToolbarButton('Sensors', function() {
         viewer.dataSources.removeAll();
 
         var czmlDataSource = new Cesium.CzmlDataSource();
@@ -51,11 +55,9 @@ require(['Cesium'], function(Cesium) {
             viewer.dataSources.add(czmlDataSource);
             viewer.homeButton.viewModel.command();
         });
-    }
+    });
 
-    function czmlVehicle() {
-        Sandcastle.declare(czmlVehicle); // For highlighting in Sandcastle.
-
+    Sandcastle.addToolbarButton('Vehicle', function() {
         viewer.dataSources.removeAll();
 
         var czmlDataSource = new Cesium.CzmlDataSource();
@@ -63,7 +65,7 @@ require(['Cesium'], function(Cesium) {
             viewer.dataSources.add(czmlDataSource);
             viewer.homeButton.viewModel.command();
         });
-    }
+    });
 
     var builtInCzml = [{
         "id" : "Vehicle",
@@ -131,9 +133,7 @@ require(['Cesium'], function(Cesium) {
         }
     }];
 
-    function useBuiltInCzml() {
-        Sandcastle.declare(useBuiltInCzml); // For highlighting in Sandcastle.
-
+    Sandcastle.addToolbarButton('Built-in CZML', function() {
         viewer.dataSources.removeAll();
 
         var czmlDataSource = new Cesium.CzmlDataSource();
@@ -143,31 +143,6 @@ require(['Cesium'], function(Cesium) {
         // Zoom in a little closer...
         var rectangle = new Cesium.Rectangle(-2.056, 0.587, -2.010, 0.633);
         viewer.scene.camera.viewRectangle(rectangle);
-    }
-
-    var viewer = new Cesium.Viewer('cesiumContainer');
-    viewer.extend(Cesium.viewerDynamicObjectMixin);
-
-    czmlSatellites();
-
-    Sandcastle.addToolbarButton('Satellites', function() {
-        czmlSatellites();
-        Sandcastle.highlight(czmlSatellites);
-    });
-
-    Sandcastle.addToolbarButton('Sensors', function() {
-        czmlSensors();
-        Sandcastle.highlight(czmlSensors);
-    });
-
-    Sandcastle.addToolbarButton('Vehicle', function() {
-        czmlVehicle();
-        Sandcastle.highlight(czmlVehicle);
-    });
-
-    Sandcastle.addToolbarButton('Built-in CZML', function() {
-        useBuiltInCzml();
-        Sandcastle.highlight(useBuiltInCzml);
     });
 
     Sandcastle.finishedLoading();

--- a/Apps/Sandcastle/gallery/Camera.html
+++ b/Apps/Sandcastle/gallery/Camera.html
@@ -31,27 +31,50 @@ require(['Cesium'], function(Cesium) {
     var scene = viewer.scene;
     var clock = viewer.clock;
 
-    function flyToSanDiego() {
-        Sandcastle.declare(flyToSanDiego); // For highlighting in Sandcastle.
-        
+    function reset() {
+        var ellipsoid = scene.globe.ellipsoid;
+        scene.primitives.removeAll();
+        scene.animations.removeAll();
+
+        var controller = scene.screenSpaceCameraController;
+        controller.ellipsoid = ellipsoid;
+        controller.enableTilt = true;
+
+        scene.camera.setTransform(Cesium.Matrix4.IDENTITY);
+
+        clock.multiplier = 1.0;
+        scene.preRender.removeEventListener(icrf);
+        scene.globe.enableLighting = false;
+    }
+
+    scene.morphComplete.addEventListener(function() {
+        reset();
+    });
+
+    Sandcastle.addToolbarButton('Fly to San Diego', function() {
+        reset();
         scene.camera.flyTo({
             destination : Cesium.Cartesian3.fromDegrees(-117.16, 32.71, 15000.0)
         });
-    }
+    });
 
-    function flyToMyLocation() {
-        Sandcastle.declare(flyToMyLocation); // For highlighting in Sandcastle.
+    Sandcastle.addToolbarButton('Fly to My Location', function() {
+        reset();
+
+        // Create callback for browser's geolocation
         function fly(position) {
             scene.camera.flyTo({
                 destination : Cesium.Cartesian3.fromDegrees(position.coords.longitude, position.coords.latitude, 1000.0)
             });
         }
 
+        // Ask browser for location, and fly there.
         navigator.geolocation.getCurrentPosition(fly);
-    }
+    });
 
-    function viewARectangle() {
-        Sandcastle.declare(viewARectangle); // For highlighting in Sandcastle.
+    Sandcastle.addToolbarButton('View a Rectangle', function() {
+        reset();
+
         var west = -77.0;
         var south = 38.0;
         var east = -72.0;
@@ -70,10 +93,11 @@ require(['Cesium'], function(Cesium) {
                 west, south
             ])
         });
-    }
+    });
 
-    function flyToRectangle() {
-        Sandcastle.declare(flyToRectangle); // For highlighting in Sandcastle.
+    Sandcastle.addToolbarButton('Fly to Rectangle', function() {
+        reset();
+
         var west = -90.0;
         var south = 38.0;
         var east = -87.0;
@@ -94,10 +118,11 @@ require(['Cesium'], function(Cesium) {
                 west, south
             ])
         });
-    }
+    });
 
-    function eastNorthUp() {
-        Sandcastle.declare(eastNorthUp); // For highlighting in Sandcastle.
+    Sandcastle.addToolbarButton('Set camera reference frame', function() {
+        reset();
+
         var center = Cesium.Cartesian3.fromDegrees(-75.59777, 40.03883);
         var transform = Cesium.Transforms.eastNorthUpToFixedFrame(center);
 
@@ -121,7 +146,7 @@ require(['Cesium'], function(Cesium) {
             modelMatrix : transform,
             length : 100000.0
         }));
-    }
+    });
 
     function icrf(scene, time) {
         if (scene.mode !== Cesium.SceneMode.SCENE3D) {
@@ -134,8 +159,9 @@ require(['Cesium'], function(Cesium) {
         }
     }
 
-    function viewIcrf() {
-        Sandcastle.declare(viewIcrf); // For highlighting in Sandcastle.
+    Sandcastle.addToolbarButton('View in ICRF', function() {
+        reset();
+
         var vm = viewer.homeButton.viewModel;
         vm.duration = 0.0;
         vm.command();
@@ -144,62 +170,6 @@ require(['Cesium'], function(Cesium) {
         clock.multiplier = 3 * 60 * 60;
         scene.preRender.addEventListener(icrf);
         scene.globe.enableLighting = true;
-    }
-
-    function reset() {
-        var ellipsoid = scene.globe.ellipsoid;
-        scene.primitives.removeAll();
-        scene.animations.removeAll();
-        
-        var controller = scene.screenSpaceCameraController;
-        controller.ellipsoid = ellipsoid;
-        controller.enableTilt = true;
-        
-        scene.camera.setTransform(Cesium.Matrix4.IDENTITY);
-
-        clock.multiplier = 1.0;
-        scene.preRender.removeEventListener(icrf);
-        scene.globe.enableLighting = false;
-    }
-
-    scene.morphComplete.addEventListener(function() {
-        reset();
-    });
-
-    Sandcastle.addToolbarButton('Fly to San Diego', function() {
-        reset();
-        flyToSanDiego();
-        Sandcastle.highlight(flyToSanDiego);
-    });
-
-    Sandcastle.addToolbarButton('Fly to My Location', function() {
-        reset();
-        flyToMyLocation();
-        Sandcastle.highlight(flyToMyLocation);
-    });
-
-    Sandcastle.addToolbarButton('Fly to Rectangle', function() {
-        reset();
-        flyToRectangle();
-        Sandcastle.highlight(flyToRectangle);
-    });
-
-    Sandcastle.addToolbarButton('View a Rectangle', function() {
-        reset();
-        viewARectangle();
-        Sandcastle.highlight(viewARectangle);
-    });
-
-    Sandcastle.addToolbarButton('Set camera reference frame', function() {
-        reset();
-        eastNorthUp();
-        Sandcastle.highlight(eastNorthUp);
-    });
-
-    Sandcastle.addToolbarButton('View in ICRF', function() {
-        reset();
-        viewIcrf();
-        Sandcastle.highlight(viewIcrf);
     });
 
     Sandcastle.finishedLoading();

--- a/Apps/Sandcastle/gallery/Labels.html
+++ b/Apps/Sandcastle/gallery/Labels.html
@@ -27,8 +27,11 @@
 require(['Cesium'], function(Cesium) {
     "use strict";
 
-    function addLabel(scene) {
-        Sandcastle.declare(addLabel);   // For highlighting in Sandcastle.
+    var viewer = new Cesium.Viewer('cesiumContainer');
+    var scene = viewer.scene;
+    var primitives = scene.primitives;
+
+    function addLabel() {
         var labels = new Cesium.LabelCollection();
         labels.add({
             position : Cesium.Cartesian3.fromDegrees(-75.10, 39.57),
@@ -36,9 +39,16 @@ require(['Cesium'], function(Cesium) {
         });
         scene.primitives.add(labels);
     }
+    addLabel(scene);
 
-    function setLabelFont(scene) {
-        Sandcastle.declare(setLabelFont);   // For highlighting in Sandcastle.
+    Sandcastle.addToolbarButton('Add label', function() {
+        primitives.removeAll();
+        addLabel();
+    });
+
+    Sandcastle.addToolbarButton('Set font', function() {
+        primitives.removeAll();
+
         var labels = new Cesium.LabelCollection();
         labels.add({
             position  : Cesium.Cartesian3.fromDegrees(-75.10, 39.57),
@@ -51,10 +61,11 @@ require(['Cesium'], function(Cesium) {
             style : Cesium.LabelStyle.FILL_AND_OUTLINE
         });
         scene.primitives.add(labels);
-    }
+    });
 
-    function setLabelProperties(scene) {
-        Sandcastle.declare(setLabelProperties); // For highlighting in Sandcastle.
+    Sandcastle.addToolbarButton('Set properties', function() {
+        primitives.removeAll();
+
         var labels = new Cesium.LabelCollection();
         var l = labels.add({
             position : Cesium.Cartesian3.fromDegrees(-75.10, 39.57),
@@ -64,10 +75,11 @@ require(['Cesium'], function(Cesium) {
         l.position = Cesium.Cartesian3.fromDegrees(-75.10, 39.57, 300000.0);
         l.scale = 2.0;
         scene.primitives.add(labels);
-    }
+    });
 
-    function addLabelsInReferenceFrame(scene) {
-        Sandcastle.declare(addLabelsInReferenceFrame);  // For highlighting in Sandcastle.
+    Sandcastle.addToolbarButton('Add labels in reference frame', function() {
+        primitives.removeAll();
+
         var center = Cesium.Cartesian3.fromDegrees(-75.59777, 40.03883);
         var labels = new Cesium.LabelCollection(undefined);
         labels.modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(center);
@@ -88,10 +100,10 @@ require(['Cesium'], function(Cesium) {
             text     : 'Up'
         });
         scene.primitives.add(labels);
-    }
+    });
 
-    function labelPixelOffsetByDistance(scene) {
-        Sandcastle.declare(labelPixelOffsetByDistance); // For highlighting in Sandcastle.
+    Sandcastle.addToolbarButton('Offset label by distance', function() {
+        primitives.removeAll();
 
         var image = new Image();
         image.onload = function() {
@@ -122,10 +134,11 @@ require(['Cesium'], function(Cesium) {
             scene.primitives.add(labels);
         };
         image.src = '../images/facility.gif';
-    }
+    });
 
-    function labelTranslucencyByDistance(scene) {
-        Sandcastle.declare(labelTranslucencyByDistance); // For highlighting in Sandcastle.
+    Sandcastle.addToolbarButton('Fade label by distance', function() {
+        primitives.removeAll();
+
         var labels = new Cesium.LabelCollection();
         labels.add({
             position : Cesium.Cartesian3.fromDegrees(-73.94, 40.67),
@@ -138,48 +151,6 @@ require(['Cesium'], function(Cesium) {
             translucencyByDistance : new Cesium.NearFarScalar(1.5e5, 1.0, 1.5e7, 0.0)
         });
         scene.primitives.add(labels);
-    }
-
-    var viewer = new Cesium.Viewer('cesiumContainer');
-    var scene = viewer.scene;
-    var primitives = scene.primitives;
-
-    addLabel(scene);
-
-    Sandcastle.addToolbarButton('Add label', function() {
-        primitives.removeAll();
-        addLabel(scene);
-        Sandcastle.highlight(addLabel);
-    });
-
-    Sandcastle.addToolbarButton('Set font', function() {
-        primitives.removeAll();
-        setLabelFont(scene);
-        Sandcastle.highlight(setLabelFont);
-    });
-
-    Sandcastle.addToolbarButton('Set properties', function() {
-        primitives.removeAll();
-        setLabelProperties(scene);
-        Sandcastle.highlight(setLabelProperties);
-    });
-
-    Sandcastle.addToolbarButton('Add labels in reference frame', function() {
-        primitives.removeAll();
-        addLabelsInReferenceFrame(scene);
-        Sandcastle.highlight(addLabelsInReferenceFrame);
-    });
-
-    Sandcastle.addToolbarButton('Fade label by distance', function() {
-        primitives.removeAll();
-        labelTranslucencyByDistance(scene);
-        Sandcastle.highlight(labelTranslucencyByDistance);
-    });
-    
-    Sandcastle.addToolbarButton('Offset label by distance', function() {
-        primitives.removeAll();
-        labelPixelOffsetByDistance(scene);
-        Sandcastle.highlight(labelPixelOffsetByDistance);
     });
 
     Sandcastle.finishedLoading();

--- a/Apps/Sandcastle/gallery/Picking.html
+++ b/Apps/Sandcastle/gallery/Picking.html
@@ -27,6 +27,9 @@
 require(['Cesium'], function(Cesium) {
     "use strict";
 
+    var viewer = new Cesium.Viewer('cesiumContainer');
+    var scene = viewer.scene;
+
     var handler;
     var label;
     var billboard;
@@ -96,12 +99,11 @@ require(['Cesium'], function(Cesium) {
     }
 
     function cleanup() {
-        viewer.scene.primitives.removeAll();
+        scene.primitives.removeAll();
         handler = handler && handler.destroy();
     }
 
-    function pickCartographicPosition(scene) {
-        Sandcastle.declare(pickCartographicPosition);   // For highlighting in Sandcastle.
+    function pickCartographicPosition() {
         var ellipsoid = scene.globe.ellipsoid;
         var labels = new Cesium.LabelCollection();
         label = labels.add();
@@ -121,9 +123,16 @@ require(['Cesium'], function(Cesium) {
             }
         }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
     }
+    pickCartographicPosition();
 
-    function pickBillboard(scene) {
-        Sandcastle.declare(pickBillboard);  // For highlighting in Sandcastle.
+    Sandcastle.addToolbarButton('Show Cartographic Position on Mouse Over', function() {
+        cleanup();
+        pickCartographicPosition();
+    });
+
+    Sandcastle.addToolbarButton('Pick Billboard', function() {
+        cleanup();
+
         addBillboard(scene);
 
         // If the mouse is over the billboard, change its scale and color
@@ -143,10 +152,11 @@ require(['Cesium'], function(Cesium) {
             },
             Cesium.ScreenSpaceEventType.MOUSE_MOVE
         );
-    }
+    });
 
-    function animateBillboardOnPick(scene) {
-        Sandcastle.declare(animateBillboardOnPick); // For highlighting in Sandcastle.
+    Sandcastle.addToolbarButton('Animate Billboard on Pick', function() {
+        cleanup();
+
         addBillboard(scene);
 
         var animation;
@@ -215,85 +225,56 @@ require(['Cesium'], function(Cesium) {
             }
         },
         Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-    }
+    });
 
     var originalColor = {};
-    function multiPickPrimitives(scene) {
-        Sandcastle.declare(multiPickPrimitives);    // For highlighting in Sandcastle.
-        addOverlappingPolygons(scene);
-
-        var primitives = scene.primitives;
-        // Move the primitive that the mouse is over to the top.
-        handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
-            handler.setInputAction(function(movement) {
-                // clear picked flags
-                var numberOfPrimitves = primitives.length;
-                for (var i = 0; i < numberOfPrimitves; ++i) {
-                    var p = primitives.get(i);
-                    p.processedPick = false;
-                }
-
-                // get an array of all primitives at the mouse position
-                var pickedObjects = scene.drillPick(movement.endPosition);
-                if(Cesium.defined(pickedObjects)) {
-                    for( i=0; i<pickedObjects.length; ++i) {
-                        var polygon = pickedObjects[i].primitive;
-
-                        if(polygon.picked === false) {
-                            originalColor[polygon.id] = polygon.material.uniforms.color;
-                            polygon.material.uniforms.color = {
-                                red : 1.0,
-                                green : 1.0,
-                                blue : 0.0,
-                                alpha : 0.5
-                            };
-                            polygon.picked = true;
-                        }
-
-                        polygon.processedPick = true;
-                    }
-                }
-
-                // return unpicked primitives to their original color
-                for (i = 0; i < numberOfPrimitves; ++i) {
-                    var primitive = primitives.get(i);
-
-                    if(primitive.processedPick === false && Cesium.defined(originalColor[primitive.id])) {
-                        primitive.material.uniforms.color = originalColor[primitive.id];
-                        primitive.picked = false;
-                    }
-                }
-            }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-
-    }
-
-    var viewer = new Cesium.Viewer('cesiumContainer');
-    var scene = viewer.scene;
-
-    pickCartographicPosition(scene);
-
-    Sandcastle.addToolbarButton('Show Cartographic Position on Mouse Over', function() {
-        cleanup();
-        pickCartographicPosition(scene);
-        Sandcastle.highlight(pickCartographicPosition);
-    });
-
-    Sandcastle.addToolbarButton('Pick Billboard', function() {
-        cleanup();
-        pickBillboard(scene);
-        Sandcastle.highlight(pickBillboard);
-    });
-
-    Sandcastle.addToolbarButton('Animate Billboard on Pick', function() {
-        cleanup();
-        animateBillboardOnPick(scene);
-        Sandcastle.highlight(animateBillboardOnPick);
-    });
-
     Sandcastle.addToolbarButton('Drill-Down Picking', function() {
         cleanup();
-        multiPickPrimitives(scene);
-        Sandcastle.highlight(multiPickPrimitives);
+
+        var primitives = scene.primitives;
+        addOverlappingPolygons(scene);
+
+        // Move the primitive that the mouse is over to the top.
+        handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
+        handler.setInputAction(function(movement) {
+            // clear picked flags
+            var numberOfPrimitves = primitives.length;
+            for (var i = 0; i < numberOfPrimitves; ++i) {
+                var p = primitives.get(i);
+                p.processedPick = false;
+            }
+
+            // get an array of all primitives at the mouse position
+            var pickedObjects = scene.drillPick(movement.endPosition);
+            if(Cesium.defined(pickedObjects)) {
+                for( i=0; i<pickedObjects.length; ++i) {
+                    var polygon = pickedObjects[i].primitive;
+
+                    if(polygon.picked === false) {
+                        originalColor[polygon.id] = polygon.material.uniforms.color;
+                        polygon.material.uniforms.color = {
+                            red : 1.0,
+                            green : 1.0,
+                            blue : 0.0,
+                            alpha : 0.5
+                        };
+                        polygon.picked = true;
+                    }
+
+                    polygon.processedPick = true;
+                }
+            }
+
+            // return unpicked primitives to their original color
+            for (i = 0; i < numberOfPrimitves; ++i) {
+                var primitive = primitives.get(i);
+
+                if(primitive.processedPick === false && Cesium.defined(originalColor[primitive.id])) {
+                    primitive.material.uniforms.color = originalColor[primitive.id];
+                    primitive.picked = false;
+                }
+            }
+        }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
     });
 
     Sandcastle.finishedLoading();


### PR DESCRIPTION
This gets rid of most Sandcastle highlight code, moving it into our standard button wireup.  The primitive-based and dropdown-based highlights remain.

Note the "Terrain" demo needed no changes to take advantage of this.
