### PR TITLE
GeoJSON: don't use the name/title property as the object name if its value is null

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,7 @@ Beta Releases
 * Added `PerformanceWatchdog` widget and `viewerPerformanceWatchdogMixin`.
 * Fixed a problem that could rarely lead to the camera's `tilt` property being `NaN`.
 * Updated third-party [Tween.js](https://github.com/sole/tween.js/) from r7 to r13.
+* `GeoJsonDataSource` no longer uses the `name` or `title` property of the feature as the dynamic object's name if the value of the property is null.
 
 ### b29 - 2014-06-02
 

--- a/Source/DynamicScene/GeoJsonDataSource.js
+++ b/Source/DynamicScene/GeoJsonDataSource.js
@@ -89,7 +89,7 @@ define([
             var key;
             var nameProperty;
             for (key in properties) {
-                if (properties.hasOwnProperty(key)) {
+                if (properties.hasOwnProperty(key) && properties[key]) {
                     var upperKey = key.toUpperCase();
                     if (upperKey === 'NAME' || upperKey === 'TITLE') {
                         nameProperty = key;
@@ -100,7 +100,7 @@ define([
             }
             if (!defined(nameProperty)) {
                 for (key in properties) {
-                    if (properties.hasOwnProperty(key)) {
+                    if (properties.hasOwnProperty(key) && properties[key]) {
                         if (/name/i.test(key) || /title/i.test(key)) {
                             nameProperty = key;
                             dynamicObject.name = properties[key];

--- a/Specs/DynamicScene/GeoJsonDataSourceSpec.js
+++ b/Specs/DynamicScene/GeoJsonDataSourceSpec.js
@@ -137,6 +137,14 @@ defineSuite([
         geometry : point
     };
 
+    var featureWithNullName = {
+        type : 'Feature',
+        geometry : point,
+        properties : {
+            name : null
+        }
+    };
+
     var featureWithId = {
         id : 'myId',
         type : 'Feature',
@@ -229,6 +237,23 @@ defineSuite([
             var pointObject = dynamicObjectCollection.getObjects()[0];
             expect(pointObject.geoJson).toBe(feature);
             expect(pointObject.position.getValue()).toEqual(coordinatesToCartesian(feature.geometry.coordinates));
+            expect(pointObject.point).toBeDefined();
+        });
+    });
+
+    it('Does not use "name" property as the object\'s name if it is null', function() {
+        var dataSource = new GeoJsonDataSource();
+        dataSource.load(featureWithNullName);
+
+        var dynamicObjectCollection = dataSource.dynamicObjects;
+        waitsFor(function() {
+            return dynamicObjectCollection.getObjects().length === 1;
+        });
+        runs(function() {
+            var pointObject = dynamicObjectCollection.getObjects()[0];
+            expect(pointObject.name).toBeUndefined();
+            expect(pointObject.geoJson).toBe(featureWithNullName);
+            expect(pointObject.position.getValue()).toEqual(coordinatesToCartesian(featureWithNullName.geometry.coordinates));
             expect(pointObject.point).toBeDefined();
         });
     });


### PR DESCRIPTION
I ran into some GeoJSON (from WFS server http://data.gov.au/geoserver/ows, Buildings layer, if you're interested) that has a null `name` property.  GeoJsonDataSource would use this property value as the object's name.  This may not be a huge problem in general, but in the `dataSourceBrowser` branch, `DataSourceItemViewModel` passes the name through `defaultValue`, which only checks for undefined and so still returns null, and then crashes when it calls `.replace` on that null.  Rather than fix `DataSourceItemViewModel`, I assumed that a null name would cause other problems in Cesium.  Plus, we'd probably like to fall back on the `title` property if one exists rather than using the null name property.  So my fix here is to avoid using `name` or `title` as the object name if it is falsy in any way.

Yeah, there are more words in this explanation than in the actual change.
