### PR TITLE
Update jsdoc to 3.3.0-alpha8

### DIFF
--- a/Tools/jsdoc/cesium_template/publish.js
+++ b/Tools/jsdoc/cesium_template/publish.js
@@ -5,7 +5,7 @@ var fs = require('jsdoc/fs');
 var helper = require('jsdoc/util/templateHelper');
 var logger = require('jsdoc/util/logger');
 var path = require('jsdoc/path');
-var taffy = require('jsdoc/node_modules/taffydb').taffy;
+var taffy = require('taffydb').taffy;
 var template = require('jsdoc/template');
 var util = require('util');
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
         "url": "https://github.com/AnalyticalGraphicsInc/cesium.git"
     },
     "devDependencies": {
-        "jsdoc": "3.3.0-alpha7"
+        "jsdoc": "3.3.0-alpha8"
     }
 }


### PR DESCRIPTION
This resolves issues with `npm install` on some Windows machines.

@shunter I'm guessing I'm not supposed to reference directly into node_modules like I had to for taffydb; any help/advice here?
