### PR TITLE
Changed Scene.globe to scene.globe in b28 changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -72,7 +72,7 @@ Beta Releases
 
 * Breaking changes ([why so many?](https://groups.google.com/forum/#!topic/cesium-dev/CQ0wCHjJ9x4)):
   * Renamed and moved `Scene.primitives.centralBody` moved to `Scene.globe`.
-  * Removed `CesiumWidget.centralBody` and `Viewer.centralBody`.  Use `Scene.globe`.
+  * Removed `CesiumWidget.centralBody` and `Viewer.centralBody`.  Use `scene.globe`.
   * Renamed `CentralBody` to `Globe`.
   * Replaced `Model.computeWorldBoundingSphere` with `Model.boundingSphere`.
   * Refactored visualizers, removing `setDynamicObjectCollection`, `getDynamicObjectCollection`, `getScene`, and `removeAllPrimitives` which are all superfluous after the introduction of `DataSourceDisplay`.  The affected classes are:


### PR DESCRIPTION
Changed the capitalization in the changelog to match how it is in CesiumWidget and Viewer. I found this difference somewhat confusing when updating my code to work with these API changes.
