### PR TITLE
Add FeatureDetection.hardwareConcurrency

### DIFF
--- a/Source/Core/FeatureDetection.js
+++ b/Source/Core/FeatureDetection.js
@@ -1,8 +1,10 @@
 /*global define*/
 define([
+        './defaultValue',
         './defined',
         './Fullscreen'
     ], function(
+        defaultValue,
         defined,
         Fullscreen) {
     "use strict";
@@ -123,7 +125,8 @@ define([
         isWebkit : isWebkit,
         webkitVersion : webkitVersion,
         isInternetExplorer : isInternetExplorer,
-        internetExplorerVersion : internetExplorerVersion
+        internetExplorerVersion : internetExplorerVersion,
+        hardwareConcurrency : defaultValue(navigator.hardwareConcurrency, 3)
     };
 
     /**

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -8,6 +8,7 @@ define([
         '../Core/defineProperties',
         '../Core/destroyObject',
         '../Core/DeveloperError',
+        '../Core/FeatureDetection',
         '../Core/Geometry',
         '../Core/GeometryAttribute',
         '../Core/GeometryAttributes',
@@ -35,6 +36,7 @@ define([
         defineProperties,
         destroyObject,
         DeveloperError,
+        FeatureDetection,
         Geometry,
         GeometryAttribute,
         GeometryAttributes,
@@ -565,7 +567,7 @@ define([
         return pickColors;
     }
 
-    var numberOfCreationWorkers = 3;
+    var numberOfCreationWorkers = Math.max(FeatureDetection.hardwareConcurrency - 1, 1);
     var createGeometryTaskProcessors;
     var combineGeometryTaskProcessor = new TaskProcessor('combineGeometry', Number.POSITIVE_INFINITY);
 


### PR DESCRIPTION
Chrome Canary recently added `navigator.hardwareConcurrency` which exposes the number of physical cores on the client.  This is a simple change to expose that value (or a default if not defined) on `FeatureDetection`.

I chose 3 as the fallback based on [Steam's hardware survey](http://store.steampowered.com/hwsurvey/), which shows 2 cpus 47.26% of the time and 4 cpus 44.94%.

This will be handy when we do #1487 (probably post 1.0), but is useful immediately for `Primitive` creation.

On a related note, is `FeatureDetection` going to be public or private, because if it's public, it's missing a bunch of documentation.
