### PR TITLE
Fix doc for Scene.globe

### DIFF
--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -518,7 +518,6 @@ define([
          * @memberof Scene.prototype
          *
          * @type {Globe}
-         * @readonly
          */
         globe : {
             get: function() {


### PR DESCRIPTION
Was marked as "readonly" but the description says "gets or sets" and there is a setter.
