### PR TITLE
Fix bugs with label and billboard properties.

### DIFF
--- a/Source/Scene/Billboard.js
+++ b/Source/Scene/Billboard.js
@@ -69,12 +69,10 @@ define([
         if (defined(options.scaleByDistance) && options.scaleByDistance.far <= options.scaleByDistance.near) {
             throw new DeveloperError('scaleByDistance.far must be greater than scaleByDistance.near.');
         }
-        if (defined(options.translucencyByDistance) &&
-                options.translucencyByDistance.far <= options.translucencyByDistance.near) {
+        if (defined(options.translucencyByDistance) && options.translucencyByDistance.far <= options.translucencyByDistance.near) {
             throw new DeveloperError('translucencyByDistance.far must be greater than translucencyByDistance.near.');
         }
-        if (defined(options.pixelOffsetScaleByDistance) &&
-                options.pixelOffsetScaleByDistance.far <= options.pixelOffsetScaleByDistance.near) {
+        if (defined(options.pixelOffsetScaleByDistance) && options.pixelOffsetScaleByDistance.far <= options.pixelOffsetScaleByDistance.near) {
             throw new DeveloperError('pixelOffsetScaleByDistance.far must be greater than pixelOffsetScaleByDistance.near.');
         }
         //>>includeEnd('debug');
@@ -138,18 +136,18 @@ define([
          * @memberof Billboard.prototype
          * @type {Boolean}
          */
-        show: {
-            get: function() {
+        show : {
+            get : function() {
                 return this._show;
             },
-            set: function(value) {
+            set : function(value) {
                 //>>includeStart('debug', pragmas.debug);
                 if (!defined(value)) {
                     throw new DeveloperError('value is required.');
                 }
                 //>>includeEnd('debug');
 
-                if (value !== this._show) {
+                if (this._show !== value) {
                     this._show = value;
                     makeDirty(this, SHOW_INDEX);
                 }
@@ -161,11 +159,11 @@ define([
         * @memberof Billboard.prototype
         * @type {Cartesian3}
         */
-        position: {
-            get: function() {
+        position : {
+            get : function() {
                 return this._position;
             },
-            set: function(value) {
+            set : function(value) {
                 //>>includeStart('debug', pragmas.debug)
                 if (!defined(value)) {
                     throw new DeveloperError('value is required.');
@@ -198,11 +196,11 @@ define([
          * @memberof Billboard.prototype
          * @type {Cartesian2}
          */
-        pixelOffset: {
-            get: function() {
+        pixelOffset : {
+            get : function() {
                 return this._pixelOffset;
             },
-            set: function(value) {
+            set : function(value) {
                 //>>includeStart('debug', pragmas.debug);
                 if (!defined(value)) {
                     throw new DeveloperError('value is required.');
@@ -239,23 +237,22 @@ define([
          * // disable scaling by distance
          * b.scaleByDistance = undefined;
          */
-        scaleByDistance: {
-            get: function() {
+        scaleByDistance : {
+            get : function() {
                 return this._scaleByDistance;
             },
-            set: function(scale) {
-                if (NearFarScalar.equals(this._scaleByDistance, scale)) {
-                    return;
-                }
-
+            set : function(value) {
                 //>>includeStart('debug', pragmas.debug);
-                if (scale.far <= scale.near) {
+                if (defined(value) && value.far <= value.near) {
                     throw new DeveloperError('far distance must be greater than near distance.');
                 }
                 //>>includeEnd('debug');
 
-                makeDirty(this, SCALE_BY_DISTANCE_INDEX);
-                this._scaleByDistance = NearFarScalar.clone(scale, this._scaleByDistance);
+                var scaleByDistance = this._scaleByDistance;
+                if (!NearFarScalar.equals(scaleByDistance, value)) {
+                    this._scaleByDistance = NearFarScalar.clone(value, scaleByDistance);
+                    makeDirty(this, SCALE_BY_DISTANCE_INDEX);
+                }
             }
         },
 
@@ -281,23 +278,22 @@ define([
          * // disable translucency by distance
          * b.translucencyByDistance = undefined;
          */
-        translucencyByDistance: {
-            get: function() {
+        translucencyByDistance : {
+            get : function() {
                 return this._translucencyByDistance;
             },
-            set: function(translucency) {
-                if (NearFarScalar.equals(this._translucencyByDistance, translucency)) {
-                    return;
-                }
-
+            set : function(value) {
                 //>>includeStart('debug', pragmas.debug);
-                if (translucency.far <= translucency.near) {
+                if (defined(value) && value.far <= value.near) {
                     throw new DeveloperError('far distance must be greater than near distance.');
                 }
                 //>>includeEnd('debug');
 
-                makeDirty(this, TRANSLUCENCY_BY_DISTANCE_INDEX);
-                this._translucencyByDistance = NearFarScalar.clone(translucency, this._translucencyByDistance);
+                var translucencyByDistance = this._translucencyByDistance;
+                if (!NearFarScalar.equals(translucencyByDistance, value)) {
+                    this._translucencyByDistance = NearFarScalar.clone(value, translucencyByDistance);
+                    makeDirty(this, TRANSLUCENCY_BY_DISTANCE_INDEX);
+                }
             }
         },
 
@@ -324,23 +320,22 @@ define([
          * // disable pixel offset by distance
          * b.pixelOffsetScaleByDistance = undefined;
          */
-        pixelOffsetScaleByDistance: {
-            get: function() {
+        pixelOffsetScaleByDistance : {
+            get : function() {
                 return this._pixelOffsetScaleByDistance;
             },
-            set: function(pixelOffsetScale) {
-                if (NearFarScalar.equals(this._pixelOffsetScaleByDistance, pixelOffsetScale)) {
-                    return;
-                }
-
+            set : function(value) {
                 //>>includeStart('debug', pragmas.debug);
-                if (pixelOffsetScale.far <= pixelOffsetScale.near) {
+                if (defined(value) && value.far <= value.near) {
                     throw new DeveloperError('far distance must be greater than near distance.');
                 }
                 //>>includeEnd('debug');
 
-                makeDirty(this, PIXEL_OFFSET_SCALE_BY_DISTANCE_INDEX);
-                this._pixelOffsetScaleByDistance = NearFarScalar.clone(pixelOffsetScale, this._pixelOffsetScaleByDistance);
+                var pixelOffsetScaleByDistance = this._pixelOffsetScaleByDistance;
+                if (!NearFarScalar.equals(pixelOffsetScaleByDistance, value)) {
+                    this._pixelOffsetScaleByDistance = NearFarScalar.clone(value, pixelOffsetScaleByDistance);
+                    makeDirty(this, PIXEL_OFFSET_SCALE_BY_DISTANCE_INDEX);
+                }
             }
         },
 
@@ -366,11 +361,11 @@ define([
          * @memberof Billboard.prototype
          * @type {Cartesian3}
          */
-        eyeOffset: {
-            get: function() {
+        eyeOffset : {
+            get : function() {
                 return this._eyeOffset;
             },
-            set: function(value) {
+            set : function(value) {
                 //>>includeStart('debug', pragmas.debug);
                 if (!defined(value)) {
                     throw new DeveloperError('value is required.');
@@ -399,11 +394,11 @@ define([
          * b.horizontalOrigin = Cesium.HorizontalOrigin.LEFT;
          * b.verticalOrigin = Cesium.VerticalOrigin.BOTTOM;
          */
-        horizontalOrigin: {
-            get: function() {
+        horizontalOrigin : {
+            get : function() {
                 return this._horizontalOrigin;
             },
-            set: function(value) {
+            set : function(value) {
                 //>>includeStart('debug', pragmas.debug);
                 if (!defined(value)) {
                     throw new DeveloperError('value is required.');
@@ -432,10 +427,10 @@ define([
          * b.verticalOrigin = Cesium.VerticalOrigin.BOTTOM;
          */
         verticalOrigin : {
-            get: function() {
+            get : function() {
                 return this._verticalOrigin;
             },
-            set: function(value) {
+            set : function(value) {
                 //>>includeStart('debug', pragmas.debug);
                 if (!defined(value)) {
                     throw new DeveloperError('value is required.');
@@ -463,11 +458,11 @@ define([
          * @memberof Billboard.prototype
          * @type {Number}
          */
-        scale: {
-            get: function() {
+        scale : {
+            get : function() {
                 return this._scale;
             },
-            set: function(value) {
+            set : function(value) {
                 //>>includeStart('debug', pragmas.debug);
                 if (!defined(value)) {
                     throw new DeveloperError('value is required.');
@@ -486,11 +481,11 @@ define([
          * @memberof Billboard.prototype
          * @type {Number}
          */
-        imageIndex: {
-            get: function(){
+        imageIndex : {
+            get : function() {
                 return this._imageIndex;
             },
-            set: function(value) {
+            set : function(value) {
                 //>>includeStart('debug', pragmas.debug);
                 if (typeof value !== 'number') {
                     throw new DeveloperError('value is required and must be a number.');
@@ -503,7 +498,6 @@ define([
                 }
             }
         },
-
 
         /**
          * Gets and sets the color that is multiplied with the billboard's texture.  This has two common use cases.  First,
@@ -532,11 +526,11 @@ define([
          * // Example 2. Make a billboard 50% translucent.
          * b.color = new Cesium.Color(1.0, 1.0, 1.0, 0.5);
          */
-        color: {
-            get: function() {
+        color : {
+            get : function() {
                 return this._color;
             },
-            set: function(value) {
+            set : function(value) {
                 //>>includeStart('debug', pragmas.debug);
                 if (!defined(value)) {
                     throw new DeveloperError('value is required.');
@@ -556,11 +550,11 @@ define([
          * @memberof Billboard.prototype
          * @type {Number}
          */
-        rotation: {
-            get: function() {
+        rotation : {
+            get : function() {
                 return this._rotation;
             },
-            set: function(value) {
+            set : function(value) {
                 //>>includeStart('debug', pragmas.debug);
                 if (!defined(value)) {
                     throw new DeveloperError('value is required.');
@@ -595,20 +589,20 @@ define([
          * // Reset the aligned axis
          * billboard.alignedAxis = Cesium.Cartesian3.ZERO;
          */
-        alignedAxis: {
-            get: function() {
+        alignedAxis : {
+            get : function() {
                 return this._alignedAxis;
             },
-            set: function(value) {
+            set : function(value) {
                 //>>includeStart('debug', pragmas.debug);
                 if (!defined(value)) {
                     throw new DeveloperError('value is required.');
                 }
                 //>>includeEnd('debug');
 
-                var axis = this._alignedAxis;
-                if (!Cartesian3.equals(axis, value)) {
-                    Cartesian3.clone(value, axis);
+                var alignedAxis = this._alignedAxis;
+                if (!Cartesian3.equals(alignedAxis, value)) {
+                    Cartesian3.clone(value, alignedAxis);
                     makeDirty(this, ALIGNED_AXIS_INDEX);
                 }
             }
@@ -619,11 +613,11 @@ define([
          * @memberof Billboard.prototype
          * @type {Number}
          */
-        width: {
-            get: function() {
+        width : {
+            get : function() {
                 return this._width;
             },
-            set: function(value) {
+            set : function(value) {
                 if (this._width !== value) {
                     this._width = value;
                     makeDirty(this, IMAGE_INDEX_INDEX);
@@ -636,11 +630,11 @@ define([
          * @memberof Billboard.prototype
          * @type {Number}
          */
-        height: {
-            get: function() {
+        height : {
+            get : function() {
                 return this._height;
             },
-            set: function(value) {
+            set : function(value) {
                 if (this._height !== value) {
                     this._height = value;
                     makeDirty(this, IMAGE_INDEX_INDEX);
@@ -718,7 +712,6 @@ define([
         makeDirty(this, POSITION_INDEX);
     };
 
-
     var tempCartesian3 = new Cartesian4();
     Billboard._computeActualPosition = function(position, frameState, modelMatrix) {
         if (frameState.mode === SceneMode.SCENE3D) {
@@ -729,7 +722,7 @@ define([
         return SceneTransforms.computeActualWgs84Position(frameState, tempCartesian3);
     };
 
-    var scracthMatrix4 = new Matrix4();
+    var scratchMatrix4 = new Matrix4();
     var scratchCartesian4 = new Cartesian4();
     var scrachEyeOffset = new Cartesian3();
     var scratchCartesian2 = new Cartesian2();
@@ -740,7 +733,7 @@ define([
         var projection = camera.frustum.projectionMatrix;
 
         // Model to eye coordinates
-        var mv = Matrix4.multiplyTransformation(view, modelMatrix, scracthMatrix4);
+        var mv = Matrix4.multiplyTransformation(view, modelMatrix, scratchMatrix4);
         var positionEC = Matrix4.multiplyByVector(mv, Cartesian4.fromElements(position.x, position.y, position.z, 1, scratchCartesian4), scratchCartesian4);
 
         // Apply eye offset, e.g., czm_eyeOffset

--- a/Source/Scene/Label.js
+++ b/Source/Scene/Label.js
@@ -62,12 +62,10 @@ define([
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         //>>includeStart('debug', pragmas.debug);
-        if (defined(options.translucencyByDistance) &&
-                options.translucencyByDistance.far <= options.translucencyByDistance.near) {
+        if (defined(options.translucencyByDistance) && options.translucencyByDistance.far <= options.translucencyByDistance.near) {
             throw new DeveloperError('translucencyByDistance.far must be greater than translucencyByDistance.near.');
         }
-        if (defined(options.pixelOffsetScaleByDistance) &&
-                options.pixelOffsetScaleByDistance.far <= options.pixelOffsetScaleByDistance.near) {
+        if (defined(options.pixelOffsetScaleByDistance) && options.pixelOffsetScaleByDistance.far <= options.pixelOffsetScaleByDistance.near) {
             throw new DeveloperError('pixelOffsetScaleByDistance.far must be greater than pixelOffsetScaleByDistance.near.');
         }
         //>>includeEnd('debug');
@@ -103,22 +101,22 @@ define([
          * @memberof Label.prototype
          * @type {Boolean}
          */
-        show: {
-            get: function() {
+        show : {
+            get : function() {
                 return this._show;
             },
-            set: function(value) {
+            set : function(value) {
                 //>>includeStart('debug', pragmas.debug);
                 if (!defined(value)) {
                     throw new DeveloperError('value is required.');
                 }
                 //>>includeEnd('debug');
 
-                if (value !== this._show) {
+                if (this._show !== value) {
                     this._show = value;
 
                     var glyphs = this._glyphs;
-                    for ( var i = 0, len = glyphs.length; i < len; i++) {
+                    for (var i = 0, len = glyphs.length; i < len; i++) {
                         var glyph = glyphs[i];
                         if (defined(glyph.billboard)) {
                             glyph.billboard.show = value;
@@ -133,11 +131,11 @@ define([
          * @memberof Label.prototype
          * @type {Cartesian3}
          */
-        position: {
+        position : {
             get : function() {
                 return this._position;
             },
-            set: function(value) {
+            set : function(value) {
                 //>>includeStart('debug', pragmas.debug);
                 if (!defined(value)) {
                     throw new DeveloperError('value is required.');
@@ -149,7 +147,7 @@ define([
                     Cartesian3.clone(value, position);
 
                     var glyphs = this._glyphs;
-                    for ( var i = 0, len = glyphs.length; i < len; i++) {
+                    for (var i = 0, len = glyphs.length; i < len; i++) {
                         var glyph = glyphs[i];
                         if (defined(glyph.billboard)) {
                             glyph.billboard.position = value;
@@ -164,18 +162,18 @@ define([
          * @memberof Label.prototype
          * @type {String}
          */
-        text: {
-            get: function() {
+        text : {
+            get : function() {
                 return this._text;
             },
-            set: function(value) {
+            set : function(value) {
                 //>>includeStart('debug', pragmas.debug);
                 if (!defined(value)) {
                     throw new DeveloperError('value is required.');
                 }
                 //>>includeEnd('debug');
 
-                if (value !== this._text) {
+                if (this._text !== value) {
                     this._text = value;
                     rebindAllGlyphs(this);
                 }
@@ -188,11 +186,11 @@ define([
          * @type {String}
          * @see {@link http://www.whatwg.org/specs/web-apps/current-work/multipage/the-canvas-element.html#text-styles|HTML canvas 2D context text styles}
          */
-        font: {
+        font : {
             get : function() {
                 return this._font;
             },
-            set: function(value) {
+            set : function(value) {
                 //>>includeStart('debug', pragmas.debug);
                 if (!defined(value)) {
                     throw new DeveloperError('value is required.');
@@ -262,7 +260,7 @@ define([
          * @type {Number}
          * @see {@link http://www.whatwg.org/specs/web-apps/current-work/multipage/the-canvas-element.html#fill-and-stroke-styles|HTML canvas 2D context fill and stroke styles}
          */
-        outlineWidth: {
+        outlineWidth : {
             get : function() {
                 return this._outlineWidth;
             },
@@ -285,7 +283,7 @@ define([
          * @memberof Label.prototype
          * @type {LabelStyle}
          */
-        style: {
+        style : {
             get : function() {
                 return this._style;
             },
@@ -319,7 +317,7 @@ define([
          * @memberof Label.prototype
          * @type {Cartesian2}
          */
-        pixelOffset: {
+        pixelOffset : {
             get : function() {
                 return this._pixelOffset;
             },
@@ -332,8 +330,15 @@ define([
 
                 var pixelOffset = this._pixelOffset;
                 if (!Cartesian2.equals(pixelOffset, value)) {
-                    pixelOffset = Cartesian2.clone(value, pixelOffset);
-                    repositionAllGlyphs(this);
+                    Cartesian2.clone(value, pixelOffset);
+
+                    var glyphs = this._glyphs;
+                    for (var i = 0, len = glyphs.length; i < len; i++) {
+                        var glyph = glyphs[i];
+                        if (defined(glyph.billboard)) {
+                            glyph.billboard.pixelOffset = value;
+                        }
+                    }
                 }
             }
         },
@@ -365,18 +370,24 @@ define([
                 return this._translucencyByDistance;
             },
             set : function(value) {
-                if (NearFarScalar.equals(this._translucencyByDistance, value)) {
-                    return;
-                }
-
                 //>>includeStart('debug', pragmas.debug);
-                if (value.far <= value.near) {
+                if (defined(value) && value.far <= value.near) {
                     throw new DeveloperError('far distance must be greater than near distance.');
                 }
                 //>>includeEnd('debug');
 
-                this._translucencyByDistance = NearFarScalar.clone(value, this._translucencyByDistance);
-                rebindAllGlyphs(this);
+                var translucencyByDistance = this._translucencyByDistance;
+                if (!NearFarScalar.equals(translucencyByDistance, value)) {
+                    this._translucencyByDistance = NearFarScalar.clone(value, translucencyByDistance);
+
+                    var glyphs = this._glyphs;
+                    for (var i = 0, len = glyphs.length; i < len; i++) {
+                        var glyph = glyphs[i];
+                        if (defined(glyph.billboard)) {
+                            glyph.billboard.translucencyByDistance = value;
+                        }
+                    }
+                }
             }
         },
 
@@ -408,18 +419,24 @@ define([
                 return this._pixelOffsetScaleByDistance;
             },
             set : function(value) {
-                if (NearFarScalar.equals(this._pixelOffsetScaleByDistance, value)) {
-                    return;
-                }
-
                 //>>includeStart('debug', pragmas.debug);
-                if (value.far <= value.near) {
+                if (defined(value) && value.far <= value.near) {
                     throw new DeveloperError('far distance must be greater than near distance.');
                 }
                 //>>includeEnd('debug');
 
-                this._pixelOffsetScaleByDistance = NearFarScalar.clone(value, this._pixelOffsetScaleByDistance);
-                rebindAllGlyphs(this);
+                var pixelOffsetScaleByDistance = this._pixelOffsetScaleByDistance;
+                if (!NearFarScalar.equals(pixelOffsetScaleByDistance, value)) {
+                    this._pixelOffsetScaleByDistance = NearFarScalar.clone(value, pixelOffsetScaleByDistance);
+
+                    var glyphs = this._glyphs;
+                    for (var i = 0, len = glyphs.length; i < len; i++) {
+                        var glyph = glyphs[i];
+                        if (defined(glyph.billboard)) {
+                            glyph.billboard.pixelOffsetScaleByDistance = value;
+                        }
+                    }
+                }
             }
         },
 
@@ -461,7 +478,7 @@ define([
                     Cartesian3.clone(value, eyeOffset);
 
                     var glyphs = this._glyphs;
-                    for ( var i = 0, len = glyphs.length; i < len; i++) {
+                    for (var i = 0, len = glyphs.length; i < len; i++) {
                         var glyph = glyphs[i];
                         if (defined(glyph.billboard)) {
                             glyph.billboard.eyeOffset = value;
@@ -485,7 +502,7 @@ define([
          * l.horizontalOrigin = Cesium.HorizontalOrigin.RIGHT;
          * l.verticalOrigin = Cesium.VerticalOrigin.TOP;
          */
-        horizontalOrigin: {
+        horizontalOrigin : {
             get : function() {
                 return this._horizontalOrigin;
             },
@@ -517,7 +534,7 @@ define([
          * l.horizontalOrigin = Cesium.HorizontalOrigin.RIGHT;
          * l.verticalOrigin = Cesium.VerticalOrigin.TOP;
          */
-        verticalOrigin: {
+        verticalOrigin : {
             get : function() {
                 return this._verticalOrigin;
             },
@@ -530,6 +547,15 @@ define([
 
                 if (this._verticalOrigin !== value) {
                     this._verticalOrigin = value;
+
+                    var glyphs = this._glyphs;
+                    for (var i = 0, len = glyphs.length; i < len; i++) {
+                        var glyph = glyphs[i];
+                        if (defined(glyph.billboard)) {
+                            glyph.billboard.verticalOrigin = value;
+                        }
+                    }
+
                     repositionAllGlyphs(this);
                 }
             }
@@ -556,7 +582,7 @@ define([
             get : function() {
                 return this._scale;
             },
-            set: function(value) {
+            set : function(value) {
                 //>>includeStart('debug', pragmas.debug);
                 if (!defined(value)) {
                     throw new DeveloperError('value is required.');
@@ -567,7 +593,7 @@ define([
                     this._scale = value;
 
                     var glyphs = this._glyphs;
-                    for ( var i = 0, len = glyphs.length; i < len; i++) {
+                    for (var i = 0, len = glyphs.length; i < len; i++) {
                         var glyph = glyphs[i];
                         if (defined(glyph.billboard)) {
                             glyph.billboard.scale = value;
@@ -589,12 +615,15 @@ define([
                 return this._id;
             },
             set : function(value) {
-                this._id = value;
-                var glyphs = this._glyphs;
-                for (var i = 0, len = glyphs.length; i < len; i++) {
-                    var glyph = glyphs[i];
-                    if (defined(glyph.billboard)) {
-                        glyph.billboard.id = value;
+                if (this._id !== value) {
+                    this._id = value;
+
+                    var glyphs = this._glyphs;
+                    for (var i = 0, len = glyphs.length; i < len; i++) {
+                        var glyph = glyphs[i];
+                        if (defined(glyph.billboard)) {
+                            glyph.billboard.id = value;
+                        }
                     }
                 }
             }

--- a/Specs/Scene/BillboardCollectionSpec.js
+++ b/Specs/Scene/BillboardCollectionSpec.js
@@ -228,19 +228,25 @@ defineSuite([
     });
 
     it('disable billboard scaleByDistance', function() {
-        var b = billboards.add();
+        var b = billboards.add({
+            scaleByDistance : new NearFarScalar(1.0, 3.0, 1.0e6, 0.0)
+        });
         b.scaleByDistance = undefined;
         expect(b.scaleByDistance).not.toBeDefined();
     });
 
     it('disable billboard translucencyByDistance', function() {
-        var b = billboards.add();
+        var b = billboards.add({
+            translucencyByDistance : new NearFarScalar(1.0, 1.0, 1.0e6, 0.0)
+        });
         b.translucencyByDistance = undefined;
         expect(b.translucencyByDistance).not.toBeDefined();
     });
 
     it('disable billboard pixelOffsetScaleByDistance', function() {
-        var b = billboards.add();
+        var b = billboards.add({
+            pixelOffsetScaleByDistance : new NearFarScalar(1.0, 1.0, 1.0e6, 0.0)
+        });
         b.pixelOffsetScaleByDistance = undefined;
         expect(b.pixelOffsetScaleByDistance).not.toBeDefined();
     });

--- a/Specs/Scene/LabelCollectionSpec.js
+++ b/Specs/Scene/LabelCollectionSpec.js
@@ -1066,6 +1066,142 @@ defineSuite([
             }
         });
 
+        describe('sets individual billboard properties properly when they change on the label', function() {
+            var label;
+            beforeEach(function() {
+                label = labels.add({
+                    position : new Cartesian3(1.0, 2.0, 3.0),
+                    text : 'abc',
+                    pixelOffset : new Cartesian2(4.0, 5.0),
+                    eyeOffset : new Cartesian3(6.0, 7.0, 8.0),
+                    verticalOrigin : VerticalOrigin.TOP,
+                    scale : 2.0,
+                    id : 'id1',
+                    translucencyByDistance : new NearFarScalar(1.0e4, 1.0, 1.0e6, 0.0),
+                    pixelOffsetScaleByDistance : new NearFarScalar(1.0e4, 1.0, 1.0e6, 0.0)
+                });
+                labels.update(context, frameState, []);
+            });
+
+            function getGlyphBillboards() {
+                return label._glyphs.map(function(glyph) {
+                    return glyph.billboard;
+                });
+            }
+
+            it('position', function() {
+                var newValue = new Cartesian3(4.0, 5.0, 6.0);
+                expect(label.position).not.toEqual(newValue);
+                label.position = newValue;
+                labels.update(context, frameState, []);
+
+                getGlyphBillboards().forEach(function(billboard) {
+                    expect(billboard.position).toEqual(label.position);
+                });
+            });
+
+            it('eyeOffset', function() {
+                var newValue = new Cartesian3(16.0, 17.0, 18.0);
+                expect(label.eyeOffset).not.toEqual(newValue);
+                label.eyeOffset = newValue;
+                labels.update(context, frameState, []);
+
+                getGlyphBillboards().forEach(function(billboard) {
+                    expect(billboard.eyeOffset).toEqual(label.eyeOffset);
+                });
+            });
+
+            it('pixelOffset', function() {
+                var newValue = new Cartesian3(16.0, 17.0, 18.0);
+                expect(label.pixelOffset).not.toEqual(newValue);
+                label.pixelOffset = newValue;
+                labels.update(context, frameState, []);
+
+                getGlyphBillboards().forEach(function(billboard) {
+                    expect(billboard.pixelOffset).toEqual(label.pixelOffset);
+                });
+            });
+
+            it('verticalOrigin', function() {
+                var newValue = VerticalOrigin.BOTTOM;
+                expect(label.verticalOrigin).not.toEqual(newValue);
+                label.verticalOrigin = newValue;
+                labels.update(context, frameState, []);
+
+                getGlyphBillboards().forEach(function(billboard) {
+                    expect(billboard.verticalOrigin).toEqual(label.verticalOrigin);
+                });
+            });
+
+            // glyph horizontal origin is always LEFT
+
+            it('scale', function() {
+                var newValue = 3.0;
+                expect(label.scale).not.toEqual(newValue);
+                label.scale = newValue;
+                labels.update(context, frameState, []);
+
+                getGlyphBillboards().forEach(function(billboard) {
+                    expect(billboard.scale).toEqual(label.scale);
+                });
+            });
+
+            it('id', function() {
+                var newValue = 'id2';
+                expect(label.id).not.toEqual(newValue);
+                label.id = newValue;
+                labels.update(context, frameState, []);
+
+                getGlyphBillboards().forEach(function(billboard) {
+                    expect(billboard.id).toEqual(label.id);
+                });
+            });
+
+            it('translucencyByDistance', function() {
+                var newValue = new NearFarScalar(1.1e4, 1.2, 1.3e6, 4.0);
+                expect(label.translucencyByDistance).not.toEqual(newValue);
+                label.translucencyByDistance = newValue;
+                labels.update(context, frameState, []);
+
+                getGlyphBillboards().forEach(function(billboard) {
+                    expect(billboard.translucencyByDistance).toEqual(label.translucencyByDistance);
+                });
+            });
+
+            it('pixelOffsetScaleByDistance', function() {
+                var newValue = new NearFarScalar(1.5e4, 1.6, 1.7e6, 8.0);
+                expect(label.pixelOffsetScaleByDistance).not.toEqual(newValue);
+                label.pixelOffsetScaleByDistance = newValue;
+                labels.update(context, frameState, []);
+
+                getGlyphBillboards().forEach(function(billboard) {
+                    expect(billboard.pixelOffsetScaleByDistance).toEqual(label.pixelOffsetScaleByDistance);
+                });
+            });
+
+            it('translucencyByDistance to undefined', function() {
+                var newValue;
+                expect(label.translucencyByDistance).not.toEqual(newValue);
+                label.translucencyByDistance = newValue;
+                labels.update(context, frameState, []);
+
+                getGlyphBillboards().forEach(function(billboard) {
+                    expect(billboard.translucencyByDistance).toEqual(label.translucencyByDistance);
+                });
+            });
+
+            it('pixelOffsetScaleByDistance to undefined', function() {
+                var newValue;
+                expect(label.pixelOffsetScaleByDistance).not.toEqual(newValue);
+                label.pixelOffsetScaleByDistance = newValue;
+                labels.update(context, frameState, []);
+
+                getGlyphBillboards().forEach(function(billboard) {
+                    expect(billboard.pixelOffsetScaleByDistance).toEqual(label.pixelOffsetScaleByDistance);
+                });
+            });
+        });
+
         it('should set vertexTranslate of billboards correctly when vertical origin is changed', function() {
             var label = labels.add({
                 text : 'apl',


### PR DESCRIPTION
- Setting pixelOffset on a label did not always update the glyphs.  Fixes #1838.  Similar problem with vertical origin.
  - Previous tests changed all label properties at once, which triggered rebindAllGlyphs, hiding the problem.
- Fixed Billboard/Label crash when setting scaleByDistance/translucencyByDistance/pixelOffsetScaleByDistance to undefined.
  - Previous tests created billboard with undefined, then assigned undefined, which hid the problem.
- Minor Label performance improvements:
  - Setting pixelOffset does not need to repositionAllGlyphs, since it does not affect the glyph transforms.
  - translucencyByDistance/pixelOffsetScaleByDistance do not need to rebindAllGlyphs, they do not affect the glyph appearance or transforms.
