### PR TITLE
Remove the "built" version of HelloWorld.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -24,12 +24,9 @@
 	<target name="combine" depends="build,combineJavaScript" description="Combines all source files into a single stand-alone script.">
 		<copy todir="${buildDirectory}">
 			<fileset dir="Apps/">
-				<include name="HelloWorld.html" />
 				<include name="server.js" />
 			</fileset>
 		</copy>
-
-		<replace file="${buildDirectory}/HelloWorld.html" token="../Build/" value="" />
 	</target>
 
 	<target name="minify" description="Combines all source files into a single stand-alone, minified script.">
@@ -71,19 +68,16 @@
 	<target name="makeZipFile" depends="release" description="Builds zip files containing all release files.">
 		<zip destfile="Cesium-${version}.zip" basedir="${basedir}">
 			<zipfileset dir="${buildDirectory}" prefix="Build">
+				<include name="Apps/**" />
+				<exclude name="Apps/TimelineDemo/**" />
 				<include name="Cesium/**" />
 				<include name="CesiumUnminified/**" />
 				<include name="Documentation/**" />
-				<include name="Apps/**" />
-				<exclude name="Apps/TimelineDemo/**" />
-				<include name="*.html" />
 			</zipfileset>
 			<include name="Apps/**" />
-			<include name="Examples/**" />
 			<include name="Source/**" />
 			<include name="Specs/**" />
 			<include name="ThirdParty/**" />
-			<include name="HelloWorld.html" />
 			<include name="logo.png" />
 			<include name="favicon.ico" />
 			<include name="server.js" />

--- a/index.html
+++ b/index.html
@@ -24,7 +24,6 @@
             </li>
             <li>
                 <a href="Apps/HelloWorld.html">Hello World</a>
-                (<a href="Build/HelloWorld.html">built version</a>)
             </li>
             <li>
                 <a href="Apps/Sandcastle/index.html">Sandcastle</a>

--- a/index.release.html
+++ b/index.release.html
@@ -39,8 +39,7 @@ ul {
             <a href="Apps/HelloWorld.html">Hello World</a>
           </dt>
           <dd>
-            The simplest possible Cesium application. There is also a <a href="Build/HelloWorld.html">built version</a> which uses the
-            minified version of Cesium.js.
+            The simplest possible Cesium application.
           </dd>
           <dt>
             <a href="Apps/CesiumViewer/index.html">Cesium Viewer</a>


### PR DESCRIPTION
This only made sense when we had two zip files.  The "built" version only changed the path to Cesium.js.
