### PR TITLE
Fix typo in documentation for `EarthOrientationParameters` class

### DIFF
--- a/Source/Core/EarthOrientationParameters.js
+++ b/Source/Core/EarthOrientationParameters.js
@@ -30,7 +30,7 @@ define([
     /**
      * Specifies Earth polar motion coordinates and the difference between UT1 and UTC.
      * These Earth Orientation Parameters (EOP) are primarily used in the transformation from
-     * the International Celestial Reference Frame (ITRF) to the International Terrestrial
+     * the International Celestial Reference Frame (ICRF) to the International Terrestrial
      * Reference Frame (ITRF).
      *
      * @alias EarthOrientationParameters


### PR DESCRIPTION
 Abbreviation for the International Celestial Reference Frame is ICRF, not ITRF.
