### PR TITLE
Flip CZML pixel offset origin for billboard and label.

### DIFF
--- a/Source/DynamicScene/CzmlDataSource.js
+++ b/Source/DynamicScene/CzmlDataSource.js
@@ -996,7 +996,17 @@ define([
     // TODO: pixelOffset origin in CZML is bottom-left, Cesium is now top-left.
     // Remove this when CZML 1.0 changes this
     function flipPixelOffsetOrigin(pixelOffsetData) {
-        pixelOffsetData.cartesian2 = [pixelOffsetData.cartesian2[0], -pixelOffsetData.cartesian2[1]];
+        var cartesian2 = pixelOffsetData.cartesian2;
+        if (cartesian2.length === 2) {
+            cartesian2 = [cartesian2[0], -cartesian2[1]];
+        } else {
+            cartesian2 = cartesian2.slice(0);
+            for (var i = 0; i < cartesian2.length; i += 3) {
+                cartesian2[i + 2] = -cartesian2[i + 2];
+            }
+        }
+
+        pixelOffsetData.cartesian2 = cartesian2;
     }
 
     function processBillboard(dynamicObject, packet, dynamicObjectCollection, sourceUri) {

--- a/Specs/DynamicScene/CzmlDataSourceSpec.js
+++ b/Specs/DynamicScene/CzmlDataSourceSpec.js
@@ -553,6 +553,31 @@ defineSuite([
         expect(dynamicObject.billboard.show.getValue(invalidTime)).toBeUndefined();
     });
 
+    it('can handle sampled billboard pixelOffset.', function() {
+        var epoch = JulianDate.now();
+
+        var billboardPacket = {
+            billboard : {
+                pixelOffset : {
+                    epoch : JulianDate.toIso8601(epoch),
+                    cartesian2 : [0, 1, 2, 1, 3, 4]
+                }
+            }
+        };
+
+        var dataSource = new CzmlDataSource();
+        dataSource.load(billboardPacket);
+        var dynamicObject = dataSource.dynamicObjects.getObjects()[0];
+
+        expect(dynamicObject.billboard).toBeDefined();
+        // TODO: pixelOffset origin in CZML is bottom-left, Cesium is now top-left.
+        // When CZML 1.0 flips this, flip the value here to match the packet
+        var date1 = epoch;
+        var date2 = JulianDate.addSeconds(epoch, 1.0, new JulianDate());
+        expect(dynamicObject.billboard.pixelOffset.getValue(date1)).toEqual(new Cartesian2(1.0, -2.0));
+        expect(dynamicObject.billboard.pixelOffset.getValue(date2)).toEqual(new Cartesian2(3.0, -4.0));
+    });
+
     it('CZML adds clock data.', function() {
         var clockPacket = {
             id : 'document',
@@ -1164,6 +1189,31 @@ defineSuite([
         expect(dynamicObject.label.pixelOffset.getValue(invalidTime)).toBeUndefined();
         expect(dynamicObject.label.scale.getValue(invalidTime)).toBeUndefined();
         expect(dynamicObject.label.show.getValue(invalidTime)).toBeUndefined();
+    });
+
+    it('can handle sampled label pixelOffset.', function() {
+        var epoch = JulianDate.now();
+
+        var labelPacket = {
+            label : {
+                pixelOffset : {
+                    epoch : JulianDate.toIso8601(epoch),
+                    cartesian2 : [0, 1, 2, 1, 3, 4]
+                }
+            }
+        };
+
+        var dataSource = new CzmlDataSource();
+        dataSource.load(labelPacket);
+        var dynamicObject = dataSource.dynamicObjects.getObjects()[0];
+
+        expect(dynamicObject.label).toBeDefined();
+        // TODO: pixelOffset origin in CZML is bottom-left, Cesium is now top-left.
+        // When CZML 1.0 flips this, flip the value here to match the packet
+        var date1 = epoch;
+        var date2 = JulianDate.addSeconds(epoch, 1.0, new JulianDate());
+        expect(dynamicObject.label.pixelOffset.getValue(date1)).toEqual(new Cartesian2(1.0, -2.0));
+        expect(dynamicObject.label.pixelOffset.getValue(date2)).toEqual(new Cartesian2(3.0, -4.0));
     });
 
     it('CZML Position works.', function() {


### PR DESCRIPTION
Because CZML is not yet versioned, we can't distinguish new from old CZML.  So, until we implement all our breaking changes in CZML 1.0, keep the existing convention in CZML.
