### PR TITLE
Make sure CZML and GeoJSON errors propagate properly

### DIFF
--- a/Source/DynamicScene/CzmlDataSource.js
+++ b/Source/DynamicScene/CzmlDataSource.js
@@ -1820,7 +1820,7 @@ define([
         return when(loadJson(url), function(czml) {
             dataSource.process(czml, url);
             setLoading(dataSource, false);
-        }, function(error) {
+        }).otherwise(function(error) {
             setLoading(dataSource, false);
             dataSource._error.raiseEvent(dataSource, error);
             return when.reject(error);
@@ -1846,7 +1846,7 @@ define([
         return when(loadJson(url), function(czml) {
             dataSource.load(czml, url);
             setLoading(dataSource, false);
-        }, function(error) {
+        }).otherwise(function(error) {
             setLoading(dataSource, false);
             dataSource._error.raiseEvent(dataSource, error);
             return when.reject(error);

--- a/Source/DynamicScene/GeoJsonDataSource.js
+++ b/Source/DynamicScene/GeoJsonDataSource.js
@@ -433,7 +433,7 @@ define([
         var dataSource = this;
         return when(loadJson(url), function(geoJson) {
             return dataSource.load(geoJson, url);
-        }, function(error) {
+        }).otherwise(function(error) {
             setLoading(dataSource, false);
             dataSource._error.raiseEvent(dataSource, error);
             return when.reject(error);
@@ -523,7 +523,7 @@ define([
             typeHandler(dataSource, geoJson, geoJson, crsFunction, sourceUri);
             dataSource._changed.raiseEvent(dataSource);
             setLoading(dataSource, false);
-        }, function(error) {
+        }).otherwise(function(error) {
             setLoading(dataSource, false);
             dataSource._error.raiseEvent(dataSource, error);
             return when.reject(error);


### PR DESCRIPTION
I noticed this the other day but forgot to fix it.  This should go into b30

We need to use `otherwise` instead of a second argument to `when` so that exceptions thrown by invalid CZML propagate properly.  Without this change, Cesium Viewer would freeze without an error dialog if anything went wrong during loading of CZML or GeoJSON, with this change you now get the proper error popup.
