### PR TITLE
Prevent geometry flashing when re-batching primitives

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,7 @@ Change Log
 * Added northUpEast transform to help support display of glTF models because Y is their up axis.
 * Cesium can now render an unlimited number of imagery layers, no matter how few texture units are supported by the hardware.
 * Added `Primitive.ready`.
+* Prevent primitives from flashing off and on when modifying static DataSources.
 
 Beta Releases
 -------------

--- a/Source/DataSources/EllipsoidGeometryUpdater.js
+++ b/Source/DataSources/EllipsoidGeometryUpdater.js
@@ -624,7 +624,7 @@ define([
                 asynchronous : false
             });
             this._primitives.add(this._outlinePrimitive);
-        } else if (this._primitive._state === PrimitiveState.COMPLETE) {
+        } else if (this._primitive.ready) {
             //Update attributes only.
             var primitive = this._primitive;
             appearance = primitive.appearance;

--- a/Source/DataSources/StaticOutlineGeometryBatch.js
+++ b/Source/DataSources/StaticOutlineGeometryBatch.js
@@ -25,6 +25,7 @@ define([
         this.primitives = primitives;
         this.createPrimitive = false;
         this.primitive = undefined;
+        this.oldPrimitive = undefined;
         this.geometry = new AssociativeArray();
         this.updaters = new AssociativeArray();
         this.updatersWithAttributes = new AssociativeArray();
@@ -51,6 +52,7 @@ define([
 
     var colorScratch = new Color();
     Batch.prototype.update = function(time) {
+        var show = true;
         var isUpdated = true;
         var removedCount = 0;
         var primitive = this.primitive;
@@ -58,7 +60,12 @@ define([
         if (this.createPrimitive) {
             this.attributes.removeAll();
             if (defined(primitive)) {
-                primitives.remove(primitive);
+                if (primitive.ready) {
+                    this.oldPrimitive = primitive;
+                } else {
+                    primitives.remove(primitive);
+                }
+                show = false;
             }
             var geometry = this.geometry.values;
             if (geometry.length > 0) {
@@ -73,10 +80,17 @@ define([
 
                 primitives.add(primitive);
                 isUpdated = false;
+                primitive.show = show;
             }
             this.primitive = primitive;
             this.createPrimitive = false;
-        } else if (defined(primitive) && primitive._state === PrimitiveState.COMPLETE) {
+        } else if (defined(primitive) && primitive.ready) {
+            if (defined(this.oldPrimitive)) {
+                primitives.remove(this.oldPrimitive);
+                this.oldPrimitive = undefined;
+                primitive.show = true;
+            }
+
             var updatersWithAttributes = this.updatersWithAttributes.values;
             var length = updatersWithAttributes.length;
             for (var i = 0; i < length; i++) {
@@ -102,14 +116,14 @@ define([
                 }
 
                 if (!updater.hasConstantOutline) {
-                    var show = updater.isOutlineVisible(time);
+                    show = updater.isOutlineVisible(time);
                     if (show !== attributes._lastShow) {
                         attributes._lastShow = show;
                         attributes.show = ShowGeometryInstanceAttribute.toValue(show, attributes.show);
                     }
                 }
             }
-        } else if (defined(primitive) && primitive._state !== PrimitiveState.COMPLETE) {
+        } else if (defined(primitive) && !primitive.ready) {
             isUpdated = false;
         }
 

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -598,8 +598,7 @@ define([
      * @exception {DeveloperError} All instance geometries must have the same primitiveType..
      */
     Primitive.prototype.update = function(context, frameState, commandList) {
-        if (!this.show ||
-            ((!defined(this.geometryInstances)) && (this._va.length === 0)) ||
+        if (((!defined(this.geometryInstances)) && (this._va.length === 0)) ||
             (defined(this.geometryInstances) && isArray(this.geometryInstances) && this.geometryInstances.length === 0) ||
             (!defined(this.appearance)) ||
             (frameState.mode !== SceneMode.SCENE3D && this.allow3DOnly) ||
@@ -783,7 +782,7 @@ define([
             this._state = PrimitiveState.COMPLETE;
         }
 
-        if (this._state !== PrimitiveState.COMPLETE) {
+        if (!this.show || this._state !== PrimitiveState.COMPLETE) {
             return;
         }
 

--- a/Specs/DataSources/GeometryVisualizerSpec.js
+++ b/Specs/DataSources/GeometryVisualizerSpec.js
@@ -90,12 +90,16 @@ defineSuite([
             expect(primitive.appearance.closed).toBe(false);
 
             objects.remove(entity);
+        });
+
+        waitsFor(function() {
             scene.initializeFrame();
             expect(visualizer.update(time)).toBe(true);
             scene.render(time);
+            return scene.primitives.length === 0;
+        });
 
-            expect(scene.primitives.length).toBe(0);
-
+        runs(function(){
             visualizer.destroy();
         });
     });
@@ -131,12 +135,16 @@ defineSuite([
             expect(primitive.appearance.closed).toBe(false);
 
             objects.remove(entity);
+        });
+
+        waitsFor(function() {
             scene.initializeFrame();
             expect(visualizer.update(time)).toBe(true);
             scene.render(time);
+            return scene.primitives.length === 0;
+        });
 
-            expect(scene.primitives.length).toBe(0);
-
+        runs(function(){
             visualizer.destroy();
         });
     });
@@ -173,12 +181,16 @@ defineSuite([
             expect(primitive.appearance.closed).toBe(true);
 
             objects.remove(entity);
+        });
+
+        waitsFor(function() {
             scene.initializeFrame();
             expect(visualizer.update(time)).toBe(true);
             scene.render(time);
+            return scene.primitives.length === 0;
+        });
 
-            expect(scene.primitives.length).toBe(0);
-
+        runs(function(){
             visualizer.destroy();
         });
     });
@@ -215,12 +227,16 @@ defineSuite([
             expect(primitive.appearance.closed).toBe(true);
 
             objects.remove(entity);
+        });
+
+        waitsFor(function() {
             scene.initializeFrame();
             expect(visualizer.update(time)).toBe(true);
             scene.render(time);
+            return scene.primitives.length === 0;
+        });
 
-            expect(scene.primitives.length).toBe(0);
-
+        runs(function(){
             visualizer.destroy();
         });
     });
@@ -257,12 +273,16 @@ defineSuite([
             expect(primitive.appearance).toBeInstanceOf(EllipseGeometryUpdater.perInstanceColorAppearanceType);
 
             objects.remove(entity);
+        });
+
+        waitsFor(function() {
             scene.initializeFrame();
             expect(visualizer.update(time)).toBe(true);
             scene.render(time);
+            return scene.primitives.length === 0;
+        });
 
-            expect(scene.primitives.length).toBe(0);
-
+        runs(function(){
             visualizer.destroy();
         });
     });


### PR DESCRIPTION
When we need to rebatch "static" primitives, for example because an object has gone from solid to translucent or the data sources performed an update; the old primitives would be removed but the new primitives would not show up until they were ready.  This caused it to look like the data was flashing on/off as it was being processed.

This change simply keeps the old primitive around until the new one is ready.  It also needed to tweak `Primitive.show` in order to actually cause geometry to be created when the show was set to false.

Also use `Primitive.ready` where appropriate instead of the private variable.

Here's some CZML to demonstrate this.  In `master`, if you start at the earliest time and then click anywhere else on the timeline (no need to animate) you'll see several of the primitives blink.  This no longer happens in this branch.

```
[
  {
    "id":"document",
    "clock":{
      "interval":"2010-11-12T17:00:00Z/2010-11-13T17:00:00Z",
      "currentTime":"2010-11-12T17:00:00Z",
      "range":"LOOP_STOP",
      "step":"SYSTEM_CLOCK_MULTIPLIER"
    }
  },
{
  "id":"solid",
    "position":{
      "cartographicDegrees":[0.0, 0.0, 0.0]
    },
    "label":{"text":"solid", "eyeOffset":{"cartesian":[0,0,-10000]}},
    "ellipse":{
        "semiMajorAxis":2000,
        "semiMinorAxis":1000,
        "material":{"solidColor":{"color":{"rgba":[255,255,0,255]}}},
        "outline":true,
        "outlineColor":{"rgba":[0,0,0,255]}
    }
},
{
  "id":"translucent",
    "position":{
      "cartographicDegrees":[0.05, 0.0, 0.0]
    },
    "label":{"text":"translucent", "eyeOffset":{"cartesian":[0,0,-10000]}},
   "ellipse":{
        "semiMajorAxis":2000,
        "semiMinorAxis":1000,
        "material":{"solidColor":{"color":{"rgba":[255,255,0,128]}}},
        "outline":true,
        "outlineColor":{"rgba":[0,0,0,128]}
    }
},
{
  "id":"extrudedsolid",
    "position":{
      "cartographicDegrees":[0.0, 0.05, 0.0]
    },
    "label":{"text":"solid", "eyeOffset":{"cartesian":[0,0,-10000]}},
    "ellipse":{
        "semiMajorAxis":2000,
        "semiMinorAxis":1000,
        "material":{"solidColor":{"color":{"rgba":[255,255,0,255]}}},
        "outline":true,
        "outlineColor":{"rgba":[0,0,0,255]},
        "extrudedHeight":1000
    }
},
{
  "id":"extrudedtranslucent",
    "position":{
      "cartographicDegrees":[0.05, 0.05, 0.0]
    },
    "label":{"text":"translucent", "eyeOffset":{"cartesian":[0,0,-10000]}},
   "ellipse":{
        "semiMajorAxis":2000,
        "semiMinorAxis":1000,
        "material":{"solidColor":{"color":{"rgba":[255,255,0,128]}}},
        "outline":true,
        "outlineColor":{"rgba":[0,0,0,255]},
        "extrudedHeight":1000
    }
},
{
  "id":"extrudedsolidNoOutline",
    "position":{
      "cartographicDegrees":[0.0, 0.1, 0.0]
    },
    "label":{"text":"solid no outline", "eyeOffset":{"cartesian":[0,0,-10000]}},
    "ellipse":{
        "semiMajorAxis":2000,
        "semiMinorAxis":1000,
        "material":{"solidColor":{"color":{"rgba":[255,255,0,255]}}},
        "outline":false,
        "extrudedHeight":1000
    }
},
{
  "id":"extrudedtranslucentNoOutline",
    "position":{
      "cartographicDegrees":[0.1, 0.1, 0.0]
    },
    "label":{"text":"translucent no outline", "eyeOffset":{"cartesian":[0,0,-10000]}},
   "ellipse":{
        "semiMajorAxis":2000,
        "semiMinorAxis":1000,
        "material":{"solidColor":{"color":{"rgba":[255,255,0,128]}}},
        "outline":false,
        "extrudedHeight":1000
    }
},
{
  "id":"solidToTranslucent",
    "position":{
      "cartographicDegrees":[0.1, 0.0, 0.0]
    },
    "label":{"text":"solid to translucent", "eyeOffset":{"cartesian":[0,0,-10000]}},
   "ellipse":{
        "semiMajorAxis":2000,
        "semiMinorAxis":1000,
        "material":{
          "solidColor":{
            "color":{
                "interval":"2010-11-12T17:00:00Z/2010-11-13T17:00:00Z",
                "interpolationAlgorithm":"LINEAR",
                "interpolationDegree":1,
                "rgba":["2010-11-12T17:00:00Z",0,128,0,255,
                        "2010-11-13T17:00:00Z",0,128,0,0]
            }
          }
        },
        "outline":true,
        "outlineColor":{
                "interval":"2010-11-12T17:00:00Z/2010-11-13T17:00:00Z",
                "interpolationAlgorithm":"LINEAR",
                "interpolationDegree":1,
                "rgba":["2010-11-12T17:00:00Z",0,128,0,255,
                        "2010-11-13T17:00:00Z",0,128,0,0]
          }
    }},
{
  "id":"dynamic",
    "position":{
      "cartographicDegrees":[0.1, 0.05, 0.0]
    },
    "label":{"text":"dynamic", "eyeOffset":{"cartesian":[0,0,-10000]}},
   "ellipse":{
        "semiMajorAxis":{
                "number":["2010-11-12T17:00:00Z",2000,"2010-11-13T17:00:00Z",1000]
          },
        "semiMinorAxis":{
                "number":["2010-11-12T17:00:00Z",1000,"2010-11-13T17:00:00Z",100]
          },
        "material":{"solidColor":{"color":{"rgba":[255,255,0,255]}}},
        "outline":true,
        "outlineColor":{"rgba":[0,0,0,255]},
        "height":{
                "number":["2010-11-12T17:00:00Z",0,"2010-11-13T17:00:00Z",5000]
          },
        "extrudedHeight":{
                "number":["2010-11-12T17:00:00Z",10000,"2010-11-13T17:00:00Z",5000]
          }
    }
    }
]
```
