### PR TITLE
Keep Norton from hiding the globe.

### DIFF
--- a/Apps/CesiumViewer/CesiumViewer.css
+++ b/Apps/CesiumViewer/CesiumViewer.css
@@ -1,6 +1,10 @@
 @import url(../../Source/Widgets/widgets.css);
 @import url(../../Source/Widgets/lighter.css);
 
+html {
+    height: 100%;
+}
+
 body {
     height: 100%;
     width: 100%;

--- a/Apps/HelloWorld.html
+++ b/Apps/HelloWorld.html
@@ -24,10 +24,15 @@
           font-family: sans-serif;
       }
 
+      html {
+        height: 100%;
+      }
+
       body {
           padding: 0;
           margin: 0;
           overflow: hidden;
+          height: 100%;
       }
   </style>
 </head>

--- a/Apps/Sandcastle/templates/bucket.css
+++ b/Apps/Sandcastle/templates/bucket.css
@@ -1,6 +1,10 @@
 @import url(../../../Source/Widgets/widgets.css);
 @import url(../../../Source/Widgets/lighter.css);
 
+html {
+    height: 100%;
+}
+
 body {
     background: #000;
     color: #eee;


### PR DESCRIPTION
We had an important user of National Map complain that the globe didn't appear at all, and after some investigation he found that most Cesium apps didn't work for him, either.  He eventually tracked it down to an app plus Chrome extension called "Norton Internet Safe".  When enabled, the extension would put a banner at the top of the page and the globe would disappear.  Apparently the extension adds styles to the body tag of the page such that setting `height: 100%` on the body results in a height of 0px.  I was able to work around this in National Map by adding `height: 100%` to the `<html>` element as well, which I think may be a good idea anyway.  So this pull request does that for the various Cesium apps.
