### PR TITLE
Allow SelectionIndicator to move offscreen with an object.

### DIFF
--- a/Source/Scene/SceneTransforms.js
+++ b/Source/Scene/SceneTransforms.js
@@ -68,7 +68,6 @@ define([
         SceneTransforms.computeActualWgs84Position(scene.frameState, position, actualPosition);
 
         if (!defined(actualPosition)) {
-            result = undefined;
             return undefined;
         }
 
@@ -76,6 +75,10 @@ define([
         var camera = scene.camera;
         viewProjectionScratch = Matrix4.multiply(camera.frustum.projectionMatrix, camera.viewMatrix, viewProjectionScratch);
         Matrix4.multiplyByVector(viewProjectionScratch, actualPosition, positionCC);
+
+        if (positionCC.z < 0) {
+            return undefined;
+        }
 
         result = SceneTransforms.clipToGLWindowCoordinates(scene, positionCC, result);
         result.y = scene.canvas.clientHeight - result.y;

--- a/Source/Widgets/SelectionIndicator/SelectionIndicatorViewModel.js
+++ b/Source/Widgets/SelectionIndicator/SelectionIndicatorViewModel.js
@@ -20,6 +20,7 @@ define([
     "use strict";
 
     var screenSpacePos = new Cartesian2();
+    var offScreen = '-1000px';
 
     /**
      * The view model for {@link SelectionIndicator}.
@@ -46,8 +47,8 @@ define([
         //>>includeEnd('debug')
 
         this._scene = scene;
-        this._screenPositionX = '-1000px';
-        this._screenPositionY = '0';
+        this._screenPositionX = offScreen;
+        this._screenPositionY = offScreen;
         this._tweens = scene.tweens;
         this._container = defaultValue(container, document.body);
         this._selectionIndicatorElement = selectionIndicatorElement;
@@ -109,17 +110,22 @@ define([
     SelectionIndicatorViewModel.prototype.update = function() {
         if (this.showSelection && defined(this.position)) {
             var screenPosition = this.computeScreenSpacePosition(this.position, screenSpacePos);
-            var container = this._container;
-            var containerWidth = container.parentNode.clientWidth;
-            var containerHeight = container.parentNode.clientHeight;
-            var indicatorSize = this._selectionIndicatorElement.clientWidth;
-            var halfSize = indicatorSize * 0.5;
+            if (!defined(screenPosition)) {
+                this._screenPositionX = offScreen;
+                this._screenPositionY = offScreen;
+            } else {
+                var container = this._container;
+                var containerWidth = container.parentNode.clientWidth;
+                var containerHeight = container.parentNode.clientHeight;
+                var indicatorSize = this._selectionIndicatorElement.clientWidth;
+                var halfSize = indicatorSize * 0.5;
 
-            screenPosition.x = Math.min(Math.max(screenPosition.x, 0), containerWidth) - halfSize;
-            screenPosition.y = Math.min(Math.max(screenPosition.y, 0), containerHeight) - halfSize;
+                screenPosition.x = Math.min(Math.max(screenPosition.x, -indicatorSize), containerWidth + indicatorSize) - halfSize;
+                screenPosition.y = Math.min(Math.max(screenPosition.y, -indicatorSize), containerHeight + indicatorSize) - halfSize;
 
-            this._screenPositionX = Math.floor(screenPosition.x + 0.25) + 'px';
-            this._screenPositionY = Math.floor(screenPosition.y + 0.25) + 'px';
+                this._screenPositionX = Math.floor(screenPosition.x + 0.25) + 'px';
+                this._screenPositionY = Math.floor(screenPosition.y + 0.25) + 'px';
+            }
         }
     };
 

--- a/Specs/Widgets/SelectionIndicator/SelectionIndicatorViewModelSpec.js
+++ b/Specs/Widgets/SelectionIndicator/SelectionIndicatorViewModelSpec.js
@@ -75,7 +75,7 @@ defineSuite([
         document.body.removeChild(container);
     });
 
-    it('Hides the indicator when position is unknown', function() {
+    it('hides the indicator when position is unknown', function() {
         var viewModel = new SelectionIndicatorViewModel(scene, selectionIndicatorElement, container);
         expect(viewModel.isVisible).toBe(false);
         viewModel.showSelection = true;
@@ -84,5 +84,20 @@ defineSuite([
         expect(viewModel.isVisible).toBe(true);
         viewModel.showSelection = false;
         expect(viewModel.isVisible).toBe(false);
+    });
+
+    it('can move the indicator off screen', function() {
+        document.body.appendChild(container);
+        var viewModel = new SelectionIndicatorViewModel(scene, selectionIndicatorElement, container);
+        viewModel.showSelection = true;
+        viewModel.position = new Cartesian3(1.0, 2.0, 3.0);
+        viewModel.computeScreenSpacePosition = function(position, result) {
+            return undefined;
+        };
+        viewModel.update();
+        expect(viewModel._screenPositionX).toBe('-1000px');
+        expect(viewModel._screenPositionY).toBe('-1000px');
+
+        document.body.removeChild(container);
     });
 }, 'WebGL');


### PR DESCRIPTION
This fixes #1923 for the SelectionIndicator.  Turns out this fix didn't affect the behavior of Billboard.computeScreenSpacePosition or Label.computeScreenSpacePosition, those two remain unchanged.
