### PR TITLE
Fix Sandcastle regression

### DIFF
--- a/Apps/Sandcastle/Sandcastle-header.js
+++ b/Apps/Sandcastle/Sandcastle-header.js
@@ -54,6 +54,10 @@
             };
             document.getElementById(toolbarID || 'toolbar').appendChild(menu);
 
+            if (!defaultAction && typeof options[0].onselect === 'function') {
+                defaultAction = options[0].onselect;
+            }
+
             for (var i = 0, len = options.length; i < len; ++i) {
                 var option = document.createElement('option');
                 option.textContent = options[i].text;

--- a/Apps/Sandcastle/gallery/3D Models.html
+++ b/Apps/Sandcastle/gallery/3D Models.html
@@ -91,7 +91,6 @@ text : 'Ground vehicle',
 }];
 
 Sandcastle.addToolbarMenu(options);
-options[0].onselect();
 //Sandcastle_End
 Sandcastle.finishedLoading();
 }

--- a/Apps/Sandcastle/gallery/Billboards.html
+++ b/Apps/Sandcastle/gallery/Billboards.html
@@ -326,13 +326,10 @@ Sandcastle.addToolbarMenu([{
     }
 }]);
 
-
 Sandcastle.reset = function () {
     primitives.removeAll();
 };
 
-addBillboard();
-Sandcastle.highlight(addBillboard);
 //Sandcastle_End
 Sandcastle.finishedLoading();
 }

--- a/Apps/Sandcastle/gallery/Labels.html
+++ b/Apps/Sandcastle/gallery/Labels.html
@@ -180,9 +180,6 @@ Sandcastle.addToolbarMenu([{
         Sandcastle.highlight(fadeByDistance);
     }
 }]);
-
-addLabel(scene);
-Sandcastle.highlight(addLabel);
 //Sandcastle_End
     Sandcastle.finishedLoading();
 }


### PR DESCRIPTION
`Sandcastle.addToolbarMenu` will make the first option a default if it has an `onselect` function and a default action is not already set.

This fixes a problem with the billboards and label examples where they were manually calling the first command and then it would get reset at the end of loading.

CC @hpinkos
