### PR TITLE
Remove the ability to specify a function for layer properties.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -101,6 +101,7 @@ Change Log
   * Sandcastle examples now automatically wrap the example code in RequireJS boilerplate.  To upgrade any custom examples, copy the code into an existing example (such as Hello World) and save a new file.
   * Removed `CustomSensorVolume`, `RectangularPyramidSensorVolume`, `DynamicCone`, `DynamicConeVisualizerUsingCustomSensor`, `DynamicPyramid` and `DynamicPyramidVisualizer`.  This will be moved to a plugin in early August.  [#1887](https://github.com/AnalyticalGraphicsInc/cesium/issues/1887)
   * If `Primitive.modelMatrix` is changed after creation, it only affects primitives with one instance and only in 3D mode.
+  * `ImageryLayer` properties `alpha`, `brightness`, `contrast`, `hue`, `saturation`, and `gamma` may no longer be functions.  If you need to change these values each frame, consider moving your logic to an event handler for `Scene.preRender`.
 * Added camera collision detection with terrain to the default mouse interaction.
 * Modified the default camera tilt mouse behavior to tilt about the point clicked taking into account terrain.
 * Modified the default camera mouse behavior to look about the camera's position when the sky is clicked.

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -923,46 +923,22 @@ define([
                 uniformMap.dayTextureTranslationAndScale[numberOfDayTextures] = tileImagery.textureTranslationAndScale;
                 uniformMap.dayTextureTexCoordsRectangle[numberOfDayTextures] = tileImagery.textureCoordinateRectangle;
 
-                if (typeof imageryLayer.alpha === 'function') {
-                    uniformMap.dayTextureAlpha[numberOfDayTextures] = imageryLayer.alpha(frameState, imageryLayer, imagery.x, imagery.y, imagery.level);
-                } else {
-                    uniformMap.dayTextureAlpha[numberOfDayTextures] = imageryLayer.alpha;
-                }
+                uniformMap.dayTextureAlpha[numberOfDayTextures] = imageryLayer.alpha;
                 applyAlpha = applyAlpha || uniformMap.dayTextureAlpha[numberOfDayTextures] !== 1.0;
 
-                if (typeof imageryLayer.brightness === 'function') {
-                    uniformMap.dayTextureBrightness[numberOfDayTextures] = imageryLayer.brightness(frameState, imageryLayer, imagery.x, imagery.y, imagery.level);
-                } else {
-                    uniformMap.dayTextureBrightness[numberOfDayTextures] = imageryLayer.brightness;
-                }
+                uniformMap.dayTextureBrightness[numberOfDayTextures] = imageryLayer.brightness;
                 applyBrightness = applyBrightness || uniformMap.dayTextureBrightness[numberOfDayTextures] !== ImageryLayer.DEFAULT_BRIGHTNESS;
 
-                if (typeof imageryLayer.contrast === 'function') {
-                    uniformMap.dayTextureContrast[numberOfDayTextures] = imageryLayer.contrast(frameState, imageryLayer, imagery.x, imagery.y, imagery.level);
-                } else {
-                    uniformMap.dayTextureContrast[numberOfDayTextures] = imageryLayer.contrast;
-                }
+                uniformMap.dayTextureContrast[numberOfDayTextures] = imageryLayer.contrast;
                 applyContrast = applyContrast || uniformMap.dayTextureContrast[numberOfDayTextures] !== ImageryLayer.DEFAULT_CONTRAST;
 
-                if (typeof imageryLayer.hue === 'function') {
-                    uniformMap.dayTextureHue[numberOfDayTextures] = imageryLayer.hue(frameState, imageryLayer, imagery.x, imagery.y, imagery.level);
-                } else {
-                    uniformMap.dayTextureHue[numberOfDayTextures] = imageryLayer.hue;
-                }
+                uniformMap.dayTextureHue[numberOfDayTextures] = imageryLayer.hue;
                 applyHue = applyHue || uniformMap.dayTextureHue[numberOfDayTextures] !== ImageryLayer.DEFAULT_HUE;
 
-                if (typeof imageryLayer.saturation === 'function') {
-                    uniformMap.dayTextureSaturation[numberOfDayTextures] = imageryLayer.saturation(frameState, imageryLayer, imagery.x, imagery.y, imagery.level);
-                } else {
-                    uniformMap.dayTextureSaturation[numberOfDayTextures] = imageryLayer.saturation;
-                }
+                uniformMap.dayTextureSaturation[numberOfDayTextures] = imageryLayer.saturation;
                 applySaturation = applySaturation || uniformMap.dayTextureSaturation[numberOfDayTextures] !== ImageryLayer.DEFAULT_SATURATION;
 
-                if (typeof imageryLayer.gamma === 'function') {
-                    uniformMap.dayTextureOneOverGamma[numberOfDayTextures] = 1.0 / imageryLayer.gamma(frameState, imageryLayer, imagery.x, imagery.y, imagery.level);
-                } else {
-                    uniformMap.dayTextureOneOverGamma[numberOfDayTextures] = 1.0 / imageryLayer.gamma;
-                }
+                uniformMap.dayTextureOneOverGamma[numberOfDayTextures] = 1.0 / imageryLayer.gamma;
                 applyGamma = applyGamma || uniformMap.dayTextureOneOverGamma[numberOfDayTextures] !== 1.0 / ImageryLayer.DEFAULT_GAMMA;
 
                 if (defined(imagery.credits)) {

--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -138,13 +138,8 @@ define([
         options = defaultValue(options, {});
 
         /**
-         * The alpha blending value of this layer, usually from 0.0 to 1.0.
-         * This can either be a simple number or a function with the signature
-         * <code>function(frameState, layer, x, y, level)</code>.  The function is passed the
-         * current frame state, this layer, and the x, y, and level coordinates of the
-         * imagery tile for which the alpha is required, and it is expected to return
-         * the alpha value to use for the tile.  The function is executed for every
-         * frame and for every tile, so it must be fast.
+         * The alpha blending value of this layer, with 0.0 representing fully transparent and 
+         * 1.0 representing fully opaque.
          *
          * @type {Number}
          * @default 1.0
@@ -154,12 +149,6 @@ define([
         /**
          * The brightness of this layer.  1.0 uses the unmodified imagery color.  Less than 1.0
          * makes the imagery darker while greater than 1.0 makes it brighter.
-         * This can either be a simple number or a function with the signature
-         * <code>function(frameState, layer, x, y, level)</code>.  The function is passed the
-         * current frame state, this layer, and the x, y, and level coordinates of the
-         * imagery tile for which the brightness is required, and it is expected to return
-         * the brightness value to use for the tile.  The function is executed for every
-         * frame and for every tile, so it must be fast.
          *
          * @type {Number}
          * @default {@link ImageryLayer.DEFAULT_BRIGHTNESS}
@@ -169,12 +158,6 @@ define([
         /**
          * The contrast of this layer.  1.0 uses the unmodified imagery color.  Less than 1.0 reduces
          * the contrast while greater than 1.0 increases it.
-         * This can either be a simple number or a function with the signature
-         * <code>function(frameState, layer, x, y, level)</code>.  The function is passed the
-         * current frame state, this layer, and the x, y, and level coordinates of the
-         * imagery tile for which the contrast is required, and it is expected to return
-         * the contrast value to use for the tile.  The function is executed for every
-         * frame and for every tile, so it must be fast.
          *
          * @type {Number}
          * @default {@link ImageryLayer.DEFAULT_CONTRAST}
@@ -182,12 +165,7 @@ define([
         this.contrast = defaultValue(options.contrast, defaultValue(imageryProvider.defaultContrast, ImageryLayer.DEFAULT_CONTRAST));
 
         /**
-         * The hue of this layer in radians. 0.0 uses the unmodified imagery color. This can either be a
-         * simple number or a function with the signature <code>function(frameState, layer, x, y, level)</code>.
-         * The function is passed the current frame state, this layer, and the x, y, and level
-         * coordinates of the imagery tile for which the hue is required, and it is expected to return
-         * the hue value to use for the tile.  The function is executed for every
-         * frame and for every tile, so it must be fast.
+         * The hue of this layer in radians. 0.0 uses the unmodified imagery color.
          *
          * @type {Number}
          * @default {@link ImageryLayer.DEFAULT_HUE}
@@ -196,12 +174,7 @@ define([
 
         /**
          * The saturation of this layer. 1.0 uses the unmodified imagery color. Less than 1.0 reduces the
-         * saturation while greater than 1.0 increases it. This can either be a simple number or a function
-         * with the signature <code>function(frameState, layer, x, y, level)</code>.  The function is passed the
-         * current frame state, this layer, and the x, y, and level coordinates of the
-         * imagery tile for which the saturation is required, and it is expected to return
-         * the saturation value to use for the tile.  The function is executed for every
-         * frame and for every tile, so it must be fast.
+         * saturation while greater than 1.0 increases it.
          *
          * @type {Number}
          * @default {@link ImageryLayer.DEFAULT_SATURATION}
@@ -210,12 +183,6 @@ define([
 
         /**
          * The gamma correction to apply to this layer.  1.0 uses the unmodified imagery color.
-         * This can either be a simple number or a function with the signature
-         * <code>function(frameState, layer, x, y, level)</code>.  The function is passed the
-         * current frame state, this layer, and the x, y, and level coordinates of the
-         * imagery tile for which the gamma is required, and it is expected to return
-         * the gamma value to use for the tile.  The function is executed for every
-         * frame and for every tile, so it must be fast.
          *
          * @type {Number}
          * @default {@link ImageryLayer.DEFAULT_GAMMA}

--- a/Source/Scene/ImageryProvider.js
+++ b/Source/Scene/ImageryProvider.js
@@ -34,13 +34,8 @@ define([
      */
     var ImageryProvider = function ImageryProvider() {
         /**
-         * The default alpha blending value of this provider, usually from 0.0 to 1.0.
-         * This can either be a simple number or a function with the signature
-         * <code>function(frameState, layer, x, y, level)</code>.  The function is passed the
-         * current frame state, the layer, and the x, y, and level coordinates of the
-         * imagery tile for which the alpha is required, and it is expected to return
-         * the alpha value to use for the tile.  The function is executed for every
-         * frame and for every tile, so it must be fast.
+         * The default alpha blending value of this provider, with 0.0 representing fully transparent and 
+         * 1.0 representing fully opaque.
          *
          * @type {Number}
          * @default undefined
@@ -50,12 +45,6 @@ define([
         /**
          * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
          * makes the imagery darker while greater than 1.0 makes it brighter.
-         * This can either be a simple number or a function with the signature
-         * <code>function(frameState, layer, x, y, level)</code>.  The function is passed the
-         * current frame state, the layer, and the x, y, and level coordinates of the
-         * imagery tile for which the brightness is required, and it is expected to return
-         * the brightness value to use for the tile.  The function is executed for every
-         * frame and for every tile, so it must be fast.
          *
          * @type {Number}
          * @default undefined
@@ -65,12 +54,6 @@ define([
         /**
          * The default contrast of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0 reduces
          * the contrast while greater than 1.0 increases it.
-         * This can either be a simple number or a function with the signature
-         * <code>function(frameState, layer, x, y, level)</code>.  The function is passed the
-         * current frame state, the layer, and the x, y, and level coordinates of the
-         * imagery tile for which the contrast is required, and it is expected to return
-         * the contrast value to use for the tile.  The function is executed for every
-         * frame and for every tile, so it must be fast.
          *
          * @type {Number}
          * @default undefined
@@ -78,12 +61,7 @@ define([
         this.defaultContrast = undefined;
 
         /**
-         * The default hue of this provider in radians. 0.0 uses the unmodified imagery color. This can either be a
-         * simple number or a function with the signature <code>function(frameState, layer, x, y, level)</code>.
-         * The function is passed the current frame state, the layer, and the x, y, and level
-         * coordinates of the imagery tile for which the hue is required, and it is expected to return
-         * the hue value to use for the tile.  The function is executed for every
-         * frame and for every tile, so it must be fast.
+         * The default hue of this provider in radians. 0.0 uses the unmodified imagery color.
          *
          * @type {Number}
          * @default undefined
@@ -92,12 +70,7 @@ define([
 
         /**
          * The default saturation of this provider. 1.0 uses the unmodified imagery color. Less than 1.0 reduces the
-         * saturation while greater than 1.0 increases it. This can either be a simple number or a function
-         * with the signature <code>function(frameState, layer, x, y, level)</code>.  The function is passed the
-         * current frame state, the layer, and the x, y, and level coordinates of the
-         * imagery tile for which the saturation is required, and it is expected to return
-         * the saturation value to use for the tile.  The function is executed for every
-         * frame and for every tile, so it must be fast.
+         * saturation while greater than 1.0 increases it.
          *
          * @type {Number}
          * @default undefined
@@ -106,12 +79,6 @@ define([
 
         /**
          * The default gamma correction to apply to this provider.  1.0 uses the unmodified imagery color.
-         * This can either be a simple number or a function with the signature
-         * <code>function(frameState, layer, x, y, level)</code>.  The function is passed the
-         * current frame state, the layer, and the x, y, and level coordinates of the
-         * imagery tile for which the gamma is required, and it is expected to return
-         * the gamma value to use for the tile.  The function is executed for every
-         * frame and for every tile, so it must be fast.
          *
          * @type {Number}
          * @default undefined

--- a/Specs/Scene/GlobeSurfaceTileProviderSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileProviderSpec.js
@@ -434,61 +434,6 @@ defineSuite([
         });
     });
 
-    it('passes functional layer adjustment values as uniforms', function() {
-        var layerCollection = globe.imageryLayers;
-        layerCollection.removeAll();
-        var layer = layerCollection.addImageryProvider(new SingleTileImageryProvider({url : 'Data/Images/Red16x16.png'}));
-
-        function createFunction(value) {
-            return function(functionFrameState, functionLayer, x, y, level) {
-                expect(functionFrameState).toBe(frameState);
-                expect(functionLayer).toBe(layer);
-                expect(typeof x).toBe('number');
-                expect(typeof y).toBe('number');
-                expect(typeof level).toBe('number');
-                return value;
-            };
-        }
-
-        layer.alpha = createFunction(0.123);
-        layer.brightness = createFunction(0.456);
-        layer.contrast = createFunction(0.654);
-        layer.gamma = createFunction(0.321);
-        layer.saturation = createFunction(0.123);
-        layer.hue = createFunction(0.456);
-
-        frameState.camera.viewRectangle(new Rectangle(0.0001, 0.0001, 0.0025, 0.0025), Ellipsoid.WGS84);
-
-        updateUntilDone(globe);
-
-        runs(function() {
-            var commandList = [];
-            expect(render(context, frameState, globe, commandList)).toBeGreaterThan(0);
-
-            var tileCommandCount = 0;
-
-            for (var i = 0; i < commandList.length; ++i) {
-                var command = commandList[i];
-
-                var uniforms = command.uniformMap;
-                if (!defined(uniforms) || !defined(uniforms.u_dayTextureAlpha)) {
-                    continue;
-                }
-
-                ++tileCommandCount;
-
-                expect(uniforms.u_dayTextureAlpha()).toEqual([0.123]);
-                expect(uniforms.u_dayTextureBrightness()).toEqual([0.456]);
-                expect(uniforms.u_dayTextureContrast()).toEqual([0.654]);
-                expect(uniforms.u_dayTextureOneOverGamma()).toEqual([1.0/0.321]);
-                expect(uniforms.u_dayTextureSaturation()).toEqual([0.123]);
-                expect(uniforms.u_dayTextureHue()).toEqual([0.456]);
-            }
-
-            expect(tileCommandCount).toBeGreaterThan(0);
-        });
-    });
-
     it('skips layer with uniform alpha value of zero', function() {
         var layerCollection = globe.imageryLayers;
         layerCollection.removeAll();


### PR DESCRIPTION
For example, gamma, alpha, hue, etc.  The main motivation is that these functions took a `FrameState`, which is now private.  But really the function feature isn't very worthwhile, so I removed it entirely.

As discussed briefly in #1988.
