### PR TITLE
Activate model animations when loaded via CZML

### DIFF
--- a/Source/DataSources/ModelVisualizer.js
+++ b/Source/DataSources/ModelVisualizer.js
@@ -10,6 +10,7 @@ define([
         '../Core/Quaternion',
         '../Core/Transforms',
         '../Scene/Model',
+        '../Scene/ModelAnimationLoop',
         './Property'
     ], function(
         AssociativeArray,
@@ -22,6 +23,7 @@ define([
         Quaternion,
         Transforms,
         Model,
+        ModelAnimationLoop,
         Property) {
     "use strict";
 
@@ -115,6 +117,8 @@ define([
                     url : uri
                 });
 
+                model.readyToRender.addEventListener(readyToRender, this);
+
                 model.id = entity;
                 primitives.add(model);
 
@@ -162,7 +166,7 @@ define([
         var modelHash = this._modelHash;
         var primitives = this._primitives;
         for (var i = entities.length - 1; i > -1; i--) {
-            removeModel(entities[i], modelHash, primitives);
+            removeModel(this, entities[i], modelHash, primitives);
         }
         return destroyObject(this);
     };
@@ -189,22 +193,23 @@ define([
             if (defined(entity._model) && defined(entity._position)) {
                 entities.set(entity.id, entity);
             } else {
-                removeModel(entity, modelHash, primitives);
+                removeModel(this, entity, modelHash, primitives);
                 entities.remove(entity.id);
             }
         }
 
         for (i = removed.length - 1; i > -1; i--) {
             entity = removed[i];
-            removeModel(entity, modelHash, primitives);
+            removeModel(this, entity, modelHash, primitives);
             entities.remove(entity.id);
         }
     };
 
-    function removeModel(entity, modelHash, primitives) {
+    function removeModel(visualizer, entity, modelHash, primitives) {
         var modelData = modelHash[entity.id];
         if (defined(modelData)) {
             var model = modelData.modelPrimitive;
+            model.readyToRender.removeEventListener(readyToRender, visualizer);
             primitives.remove(model);
             if (!model.isDestroyed()) {
                 model.destroy();
@@ -213,5 +218,10 @@ define([
         }
     }
 
+    function readyToRender(model) {
+        model.activeAnimations.addAll({
+            loop : ModelAnimationLoop.REPEAT
+        });
+    }
     return ModelVisualizer;
 });

--- a/Source/Scene/TileMapServiceImageryProvider.js
+++ b/Source/Scene/TileMapServiceImageryProvider.js
@@ -14,8 +14,8 @@ define([
         '../Core/RuntimeError',
         '../Core/TileProviderError',
         '../Core/WebMercatorTilingScheme',
-        './ImageryProvider',
-        '../ThirdParty/when'
+        '../ThirdParty/when',
+        './ImageryProvider'
     ], function(
         Cartesian2,
         Cartographic,
@@ -31,8 +31,8 @@ define([
         RuntimeError,
         TileProviderError,
         WebMercatorTilingScheme,
-        ImageryProvider,
-        when) {
+        when,
+        ImageryProvider) {
     "use strict";
 
     var trailingSlashRegex = /\/$/;


### PR DESCRIPTION
Eventually we will allow compelte animation control via CZML, but for now we can simply activate all animations so that wheels always spin and propellers twirl.

Also ran sortRequires.

I'm still in the process of making a new CZML demo to use models; for now you can add the below to vehicle.czml (after availability should be fine).  Not the orientation will be incorrect (because the file doesn't have any), but you can see the wheels spinning.

```
"model": {
    "gltf":"/Apps/SampleData/models/CesiumGround/Cesium_Ground.gltf"
},   
```
