### PR TITLE
Fix reversed camera tilt.

### DIFF
--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -1538,8 +1538,7 @@ define([
         Cartesian3.subtract(northEast, center, northEast);
         Cartesian3.subtract(southWest, center, southWest);
 
-        var direction = ellipsoid.geodeticSurfaceNormal(center, cameraRF.direction);
-        Cartesian3.negate(direction, direction);
+        var direction = Cartesian3.negate(center, cameraRF.direction);
         Cartesian3.normalize(direction, direction);
         var right = Cartesian3.cross(direction, Cartesian3.UNIT_Z, cameraRF.right);
         Cartesian3.normalize(right, right);


### PR DESCRIPTION
Fix reversed camera tilt on start-up. There is still an issue in certain situations with tilting after using a shift-left drag to look. That will have to be fixed post-1.0.

For #1970.
