### PR TITLE
Fix camera axis in 3D model exmaple

### DIFF
--- a/Apps/Sandcastle/gallery/3D Models.html
+++ b/Apps/Sandcastle/gallery/3D Models.html
@@ -51,14 +51,13 @@ function createModel(url, height) {
 
         // Zoom to model
         var center = Cesium.Matrix4.multiplyByPoint(model.modelMatrix, model.boundingSphere.center, new Cesium.Cartesian3());
-        var transform = Cesium.Transforms.northUpEastToFixedFrame(center);
+        var transform = Cesium.Transforms.eastNorthUpToFixedFrame(center);
         var camera = scene.camera;
         camera.transform = transform;
-        camera.constrainedAxis = Cesium.Cartesian3.UNIT_Y;
         var controller = scene.screenSpaceCameraController;
         var r = 2.0 * Math.max(model.boundingSphere.radius, camera.frustum.near);
         controller.minimumZoomDistance = r * 0.5;
-        camera.lookAt(new Cesium.Cartesian3(r, r, r), Cesium.Cartesian3.ZERO, Cesium.Cartesian3.UNIT_Y);
+        camera.lookAt(new Cesium.Cartesian3(r, r, r), Cesium.Cartesian3.ZERO, Cesium.Cartesian3.UNIT_Z);
     });
 }
 


### PR DESCRIPTION
In the 3D Models example, using the home button would cause issues in camera control because of differing Z axes.  Using Z as up in the zoom code fixes this issue.
