### PR TITLE
Prevent long terrain credits from being cut off

### DIFF
--- a/Source/Widgets/CesiumWidget/CesiumWidget.css
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.css
@@ -19,7 +19,6 @@
 }
 
 .cesium-credit-text {
-    white-space: nowrap;
 }
 
 .cesium-widget-errorPanel {


### PR DESCRIPTION
As discussed offline, terrain providers can currently only return a single credit, therefore long credits get get off if the window is to small or the credit to long.

The short term solution is to remove the `white-space: nowrap;` from `cesium-credit-text` CSS class.  The longer solution is to allow terrain providers to return multiple pre-broken up credits that can then be laid out using nowrap.
