### PR TITLE
Data fix for glTF 0.8

### DIFF
--- a/Apps/SampleData/models/CesiumAir/Cesium_Air.gltf
+++ b/Apps/SampleData/models/CesiumAir/Cesium_Air.gltf
@@ -192,7 +192,7 @@
         }
     },
     "asset": {
-        "generator": "collada2gltf@b4ea90169e759529c34baaabbfb15b475053c177",
+        "generator": "collada2gltf@df4892809111a8c6dbff4fab6c386a24745d344e",
         "premultipliedAlpha": true,
         "profile": "WebGL 1.0.2",
         "version": 0.8
@@ -621,7 +621,6 @@
                         }
                     },
                     "states": {
-                        "depthMask": true,
                         "enable": [
                             2884,
                             2929
@@ -706,22 +705,23 @@
                         }
                     },
                     "states": {
-                        "blendEquationSeparate": [
-                            32774,
-                            32774
-                        ],
-                        "blendFuncSeparate": [
-                            1,
-                            771,
-                            1,
-                            771
-                        ],
-                        "depthMask": true,
                         "enable": [
                             2884,
                             2929,
                             3042
-                        ]
+                        ],
+                        "functions": {
+                            "blendEquationSeparate": [
+                                32774,
+                                32774
+                            ],
+                            "blendFuncSeparate": [
+                                1,
+                                771,
+                                1,
+                                771
+                            ]
+                        }
                     }
                 }
             }

--- a/Apps/SampleData/models/CesiumGround/Cesium_Ground.gltf
+++ b/Apps/SampleData/models/CesiumGround/Cesium_Ground.gltf
@@ -215,7 +215,7 @@
         }
     },
     "asset": {
-        "generator": "collada2gltf@b4ea90169e759529c34baaabbfb15b475053c177",
+        "generator": "collada2gltf@df4892809111a8c6dbff4fab6c386a24745d344e",
         "premultipliedAlpha": true,
         "profile": "WebGL 1.0.2",
         "version": 0.8
@@ -651,7 +651,6 @@
                         }
                     },
                     "states": {
-                        "depthMask": true,
                         "enable": [
                             2884,
                             2929

--- a/Apps/SampleData/models/CesiumMan/Cesium_Man.gltf
+++ b/Apps/SampleData/models/CesiumMan/Cesium_Man.gltf
@@ -2080,7 +2080,7 @@
         }
     },
     "asset": {
-        "generator": "collada2gltf@432d6a159fc880112aa23774881eda665709f222",
+        "generator": "collada2gltf@df4892809111a8c6dbff4fab6c386a24745d344e",
         "premultipliedAlpha": true,
         "profile": "WebGL 1.0.2",
         "version": 0.8
@@ -2965,7 +2965,6 @@
                         }
                     },
                     "states": {
-                        "depthMask": true,
                         "enable": [
                             2884,
                             2929

--- a/Specs/Data/Models/CesiumAir/Cesium_Air.gltf
+++ b/Specs/Data/Models/CesiumAir/Cesium_Air.gltf
@@ -192,7 +192,7 @@
         }
     },
     "asset": {
-        "generator": "collada2gltf@b4ea90169e759529c34baaabbfb15b475053c177",
+        "generator": "collada2gltf@df4892809111a8c6dbff4fab6c386a24745d344e",
         "premultipliedAlpha": true,
         "profile": "WebGL 1.0.2",
         "version": 0.8
@@ -621,7 +621,6 @@
                         }
                     },
                     "states": {
-                        "depthMask": true,
                         "enable": [
                             2884,
                             2929
@@ -706,22 +705,23 @@
                         }
                     },
                     "states": {
-                        "blendEquationSeparate": [
-                            32774,
-                            32774
-                        ],
-                        "blendFuncSeparate": [
-                            1,
-                            771,
-                            1,
-                            771
-                        ],
-                        "depthMask": true,
                         "enable": [
                             2884,
                             2929,
                             3042
-                        ]
+                        ],
+                        "functions": {
+                            "blendEquationSeparate": [
+                                32774,
+                                32774
+                            ],
+                            "blendFuncSeparate": [
+                                1,
+                                771,
+                                1,
+                                771
+                            ]
+                        }
                     }
                 }
             }

--- a/Specs/Data/Models/anim-test-1-boxes/anim-test-1-boxes.gltf
+++ b/Specs/Data/Models/anim-test-1-boxes/anim-test-1-boxes.gltf
@@ -198,7 +198,7 @@
         }
     },
     "asset": {
-        "generator": "collada2gltf@b4ea90169e759529c34baaabbfb15b475053c177",
+        "generator": "collada2gltf@df4892809111a8c6dbff4fab6c386a24745d344e",
         "premultipliedAlpha": true,
         "profile": "WebGL 1.0.2",
         "version": 0.8
@@ -575,7 +575,6 @@
                         }
                     },
                     "states": {
-                        "depthMask": true,
                         "enable": [
                             2884,
                             2929

--- a/Specs/Data/Models/customDuck/duck.gltf
+++ b/Specs/Data/Models/customDuck/duck.gltf
@@ -63,7 +63,7 @@
     },
     "animations": {},
     "asset": {
-        "generator": "collada2gltf@refs/heads/unify-up-format-changes",
+        "generator": "collada2gltf@df4892809111a8c6dbff4fab6c386a24745d344e",
         "premultipliedAlpha": true,
         "profile": "WebGL 1.0.2",
         "version": 0.7
@@ -451,7 +451,6 @@
                         }
                     },
                     "states": {
-                        "depthMask": true,
                         "enable": [
                             2884,
                             2929

--- a/Specs/Data/Models/duck/duck.gltf
+++ b/Specs/Data/Models/duck/duck.gltf
@@ -63,7 +63,7 @@
     },
     "animations": {},
     "asset": {
-        "generator": "collada2gltf@b4ea90169e759529c34baaabbfb15b475053c177",
+        "generator": "collada2gltf@df4892809111a8c6dbff4fab6c386a24745d344e",
         "premultipliedAlpha": true,
         "profile": "WebGL 1.0.2",
         "version": 0.8
@@ -381,7 +381,6 @@
                         }
                     },
                     "states": {
-                        "depthMask": true,
                         "enable": [
                             2884,
                             2929

--- a/Specs/Data/Models/rigged-figure-test/rigged-figure-test.gltf
+++ b/Specs/Data/Models/rigged-figure-test/rigged-figure-test.gltf
@@ -1360,7 +1360,7 @@
         }
     },
     "asset": {
-        "generator": "collada2gltf@432d6a159fc880112aa23774881eda665709f222",
+        "generator": "collada2gltf@df4892809111a8c6dbff4fab6c386a24745d344e",
         "premultipliedAlpha": true,
         "profile": "WebGL 1.0.2",
         "version": 0.8
@@ -2276,7 +2276,6 @@
                         }
                     },
                     "states": {
-                        "depthMask": true,
                         "enable": [
                             2884,
                             2929

--- a/Specs/Data/Models/separateDuck/duck.gltf
+++ b/Specs/Data/Models/separateDuck/duck.gltf
@@ -63,7 +63,7 @@
     },
     "animations": {},
     "asset": {
-        "generator": "collada2gltf@b4ea90169e759529c34baaabbfb15b475053c177",
+        "generator": "collada2gltf@df4892809111a8c6dbff4fab6c386a24745d344e",
         "premultipliedAlpha": true,
         "profile": "WebGL 1.0.2",
         "version": 0.8
@@ -381,7 +381,6 @@
                         }
                     },
                     "states": {
-                        "depthMask": true,
                         "enable": [
                             2884,
                             2929


### PR DESCRIPTION
Updates the glTF models in the repo to use the latest COLLADA2GLTF, which contained a fix for the render states.

May fix #2013 but was not tested on IE 11.
