### PR TITLE
Fix ReferenceProperty circular event

### DIFF
--- a/Source/DataSources/ReferenceProperty.js
+++ b/Source/DataSources/ReferenceProperty.js
@@ -114,7 +114,6 @@ define([
         this._targetProperty = undefined;
         this._targetEntity = undefined;
         this._definitionChanged = new Event();
-        this._inOwnEvent = false;
 
         targetCollection.collectionChanged.addEventListener(ReferenceProperty.prototype._onCollectionChanged, this);
     };
@@ -328,20 +327,15 @@ define([
     };
 
     ReferenceProperty.prototype._onCollectionChanged = function(collection, added, removed) {
-        if (this._inOwnEvent) {
-            return;
-        }
-        this._inOwnEvent = true;
         var targetEntity = this._targetEntity;
         if (defined(targetEntity)) {
-            if (removed.indexOf(targetEntity) === -1) {
+            if (removed.indexOf(targetEntity) !== -1) {
                 targetEntity.definitionChanged.removeEventListener(ReferenceProperty.prototype._onTargetEntityDefinitionChanged, this);
                 this._targetProperty = undefined;
                 this._targetEntity = undefined;
                 this._definitionChanged.raiseEvent(this);
             }
         }
-        this._inOwnEvent = false;
     };
 
     return ReferenceProperty;

--- a/Specs/DataSources/ReferencePropertySpec.js
+++ b/Specs/DataSources/ReferencePropertySpec.js
@@ -169,6 +169,29 @@ defineSuite([
         expect(left.equals(right)).toEqual(false);
     });
 
+    it('does not raise definition changed when target entity has not changed.', function() {
+        var testObject = new Entity('testId');
+        testObject.billboard = new BillboardGraphics();
+        testObject.billboard.scale = new ConstantProperty(5);
+
+        var otherObject = new Entity('other');
+
+        var collection = new EntityCollection();
+        collection.add(testObject);
+        collection.add(otherObject);
+
+        var property = ReferenceProperty.fromString(collection, 'testId#billboard.scale');
+        expect(property.resolvedProperty).toBe(testObject.billboard.scale);
+
+        var listener = jasmine.createSpy('listener');
+        property.definitionChanged.addEventListener(listener);
+
+        collection.remove(otherObject);
+        expect(listener).not.toHaveBeenCalled();
+        collection.remove(testObject);
+        expect(listener).toHaveBeenCalledWith(property);
+    });
+
     it('constructor throws with undefined targetCollection', function() {
         expect(function() {
             return new ReferenceProperty(undefined, 'objectid', ['property']);


### PR DESCRIPTION
Since `ReferenceProperty` registered for the changed event of the collection it is inside of, it can generate a circular raiseEvent call that ultimately leads to a stack overflow. We add a boolean to keep track of whether we raised the event we are in and ignore subsequent calls until we exit.

I'm open to other fixes for this issue; but this is the simplest/best thing I could come up with for now.
