### PR TITLE
Fix crash when material source uses Windows line endings.

### DIFF
--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -806,10 +806,12 @@ define([
                     createUniform(material, imageDimensionsUniformName);
                 }
             }
+
             // Add uniform declaration to source code.
-            var uniformPhrase = 'uniform ' + uniformType + ' ' + uniformId + ';\n';
-            if (material.shaderSource.indexOf(uniformPhrase) === -1) {
-                material.shaderSource = uniformPhrase + material.shaderSource;
+            var uniformDeclarationRegex = new RegExp('uniform\\s+' + uniformType + '\\s+' + uniformId + '\\s*;');
+            if (!uniformDeclarationRegex.test(material.shaderSource)) {
+                var uniformDeclaration = 'uniform ' + uniformType + ' ' + uniformId + ';';
+                material.shaderSource = uniformDeclaration + material.shaderSource;
             }
 
             var newUniformId = uniformId + '_' + material._count++;
@@ -921,9 +923,8 @@ define([
     function replaceToken(material, token, newToken, excludePeriod) {
         excludePeriod = defaultValue(excludePeriod, true);
         var count = 0;
-        var invalidCharacters = 'a-zA-Z0-9_';
-        var suffixChars = '([' + invalidCharacters + '])?';
-        var prefixChars = '([' + invalidCharacters + (excludePeriod ? '.' : '') + '])?';
+        var suffixChars = '([\\w])?';
+        var prefixChars = '([\\w' + (excludePeriod ? '.' : '') + '])?';
         var regExp = new RegExp(prefixChars + token + suffixChars, 'g');
         material.shaderSource = material.shaderSource.replace(regExp, function($0, $1, $2) {
             if ($1 || $2) {

--- a/Specs/Scene/MaterialSpec.js
+++ b/Specs/Scene/MaterialSpec.js
@@ -353,6 +353,33 @@ defineSuite([
         expect(pixel).not.toEqual([0, 0, 0, 0]);
     });
 
+    it('does not crash if source uniform is formatted differently', function() {
+        var material = new Material({
+            strict : true,
+            fabric : {
+                uniforms : {
+                    cubeMap : {
+                        positiveX : './Data/Images/Blue.png',
+                        negativeX : './Data/Images/Blue.png',
+                        positiveY : './Data/Images/Blue.png',
+                        negativeY : './Data/Images/Blue.png',
+                        positiveZ : './Data/Images/Blue.png',
+                        negativeZ : './Data/Images/Blue.png'
+                    }
+                },
+                source : 'uniform   samplerCube   cubeMap  ;\r\n' +
+                    'czm_material czm_getMaterial(czm_materialInput materialInput)\r\n' +
+                    '{\r\n' +
+                    '    czm_material material = czm_getDefaultMaterial(materialInput);\r\n' +
+                    '    material.diffuse = textureCube(cubeMap, vec3(1.0)).xyz;\r\n' +
+                    '    return material;\r\n' +
+                    '}'
+            }
+        });
+        var pixel = renderMaterial(material);
+        expect(pixel).not.toEqual([0, 0, 0, 0]);
+    });
+
     it('creates a material with a boolean uniform', function () {
         var material = new Material({
             strict : true,


### PR DESCRIPTION
- Also would crash if uniform declaration in source used extra spaces or tabs.

`indexOf` bad, regex good.
