### PR TITLE
Fix SceneTransforms tests

### DIFF
--- a/Specs/Scene/SceneTransformsSpec.js
+++ b/Specs/Scene/SceneTransformsSpec.js
@@ -23,13 +23,24 @@ defineSuite([
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     var scene;
+    var defaultCamera;
 
     beforeAll(function() {
         scene = createScene();
+        defaultCamera = scene.camera.clone();
     });
 
     afterAll(function() {
         destroyScene(scene);
+    });
+
+    beforeEach(function() {
+        scene.camera.position = defaultCamera.position.clone();
+        scene.camera.direction = defaultCamera.direction.clone();
+        scene.camera.up = defaultCamera.up.clone();
+        scene.camera.right = defaultCamera.right.clone();
+        scene.camera.transform = defaultCamera.transform.clone();
+        scene.camera.frustum = defaultCamera.frustum.clone();
     });
 
     it('throws an exception without scene', function() {


### PR DESCRIPTION
Since all SceneTransforms tests share state, we need to reset the camera before each test.  I really wish we wouldn't share state between tests; since this isn't a "real" fix because future tests could change other aspects of the Scene.

Also, I noticed all of these tests rely on current default values in order to pass; that's also bad practice.  All inputs should be local to the test.
