### PR TITLE
Minor PrimitivePipeline cleanup.

### DIFF
--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -718,7 +718,6 @@ define([
                 this._attributeLocations = result.attributeLocations;
                 this._vaAttributes = result.vaAttributes;
                 this._perInstanceAttributeLocations = result.vaAttributeLocations;
-                this.modelMatrix = Matrix4.clone(result.modelMatrix, this.modelMatrix);
                 this._state = PrimitiveState.COMBINED;
             }
         }

--- a/Source/Scene/PrimitivePipeline.js
+++ b/Source/Scene/PrimitivePipeline.js
@@ -361,21 +361,10 @@ define([
      * @private
      */
     PrimitivePipeline.combineGeometry = function(parameters) {
-        var clonedParameters = {
-            instances : parameters.instances,
-            pickIds : parameters.pickIds,
-            ellipsoid : parameters.ellipsoid,
-            projection : parameters.projection,
-            elementIndexUintSupported : parameters.elementIndexUintSupported,
-            scene3DOnly : parameters.scene3DOnly,
-            allowPicking : parameters.allowPicking,
-            vertexCacheOptimize : parameters.vertexCacheOptimize,
-            modelMatrix : Matrix4.clone(parameters.modelMatrix)
-        };
-        var geometries = geometryPipeline(clonedParameters);
+        var geometries = geometryPipeline(parameters);
         var attributeLocations = GeometryPipeline.createAttributeLocations(geometries[0]);
 
-        var instances = clonedParameters.instances;
+        var instances = parameters.instances;
         var perInstanceAttributeNames = getCommonPerInstanceAttributeNames(instances);
 
         var perInstanceAttributes = [];
@@ -389,7 +378,7 @@ define([
 
         return {
             geometries : geometries,
-            modelMatrix : clonedParameters.modelMatrix,
+            modelMatrix : parameters.modelMatrix,
             attributeLocations : attributeLocations,
             vaAttributes : perInstanceAttributes,
             vaAttributeLocations : indices
@@ -871,7 +860,6 @@ define([
 
         var ellipsoid = Ellipsoid.clone(packedParameters.ellipsoid);
         var projection = packedParameters.isGeographic ? new GeographicProjection(ellipsoid) : new WebMercatorProjection(ellipsoid);
-        var modelMatrix = Matrix4.clone(packedParameters.modelMatrix);
 
         return {
             instances : instances,
@@ -882,7 +870,7 @@ define([
             scene3DOnly : packedParameters.scene3DOnly,
             allowPicking : packedParameters.allowPicking,
             vertexCacheOptimize : packedParameters.vertexCacheOptimize,
-            modelMatrix : packedParameters.modelMatrix
+            modelMatrix : Matrix4.clone(packedParameters.modelMatrix)
         };
     };
 


### PR DESCRIPTION
This change is basically a no-op but makes the code less confusing.  Eagle eye @shunter noticed an unused variable in PrimitivePipeline a while ago that he thought might be a bug.  Turns out it wasn't a bug but just sloppy coding on my part.

`PrimitivePipeline.unpackCombineGeometryParameters` was not including the cloned `modelMatrix` parameter as part of the result.  Because of that `PrimitivePipeline.combineGeometry` was unnecessarily creating a dummy object in order to clone it.  This is no longer needed.

There was also an uneeded clone of the resulting `modelMatrix` in Primtive.js, the result matrix is the same instance that is passed into `PrimitivePipeline.combineGeometry` so no clone is needed.
