### PR TITLE
Change version to 1.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,21 +1,21 @@
 Change Log
 ==========
 
-### 1.01 - 2014-09-01
+### 1.1 - 2014-09-02
 
 * Added a new imagery provider, `WebMapTileServiceImageryProvider`, for accessing tiles on a WMTS 1.0.0 server.
-* Greatly improved the performance of time-varying polylines when using DataSources.
 * Added an optional `pickFeatures` function to the `ImageryProvider` interface.  With supporting imagery providers, such as `WebMapServiceImageryProvider`, it can be used to determine the rasterized features under a particular location.
 * Added `ImageryLayerCollection.pickImageryLayerFeatures`.  It determines the rasterized imagery layer features intersected by a given pick ray by querying supporting layers using `ImageryProvider.pickFeatures`.
+* Added `tileWidth`, `tileHeight`, `minimumLevel`, and `tilingScheme` parameters to the `WebMapServiceImageryProvider` constructor.
+* Added `id` property to `Scene` which is a readonly unique identifier associated with each instance.
+* Added `FeatureDetection.supportsWebWorkers`.
+* Greatly improved the performance of time-varying polylines when using DataSources.
 * `viewerEntityMixin` now automatically queries for imagery layer features on click and shows their properties in the `InfoBox` panel.
-* `WebMapServiceImageryProvider` now accepts `tileWidth`, `tileHeight`, `minimumLevel`, and `tilingScheme` parameters to its constructor.
-* Fixed a bug in terrain and imagery loading that could cause a choppy, inconsistent frame rate when moving around the globe, especially on a faster internet connection.
+* Fixed a bug in terrain and imagery loading that could cause an inconsistent frame rate when moving around the globe, especially on a faster internet connection.
 * Fixed a bug that caused `SceneTransforms.wgs84ToWindowCoordinates` to incorrectly return `undefined` when in 2D.
 * Fixed a bug in `ImageryLayer` that caused layer images to be rendered twice for each terrain tile that existed prior to adding the imagery layer.
 * Fixed a bug in `Camera.pickEllipsoid` that caused it to return the back side of the ellipsoid when near the surface.
-* Added `FeatureDetection.supportsWebWorkers`.
-* Added `id` property to `Scene` which is a readonly unique identifier associated with each instance.
-* `loadWithXhr` now works with older browsers, such as Internet Explorer 9.
+* Fixed a bug which prevented `loadWithXhr` from working with older browsers, such as Internet Explorer 9.
 
 ### 1.0 - 2014-08-01
 

--- a/build.xml
+++ b/build.xml
@@ -106,7 +106,7 @@
 
 	<!-- Inputs -->
 	<!-- this version should be set to the upcoming version, so it can be tagged without requiring a bump first -->
-	<property name="version" value="1.0" />
+	<property name="version" value="1.1" />
 	<property name="sourceDirectory" location="Source" />
 	<property name="shadersDirectory" location="${sourceDirectory}/Shaders" />
 	<property name="examplesDirectory" location="Examples" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cesium",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Cesium is a JavaScript library for creating 3D globes and 2D maps in a web browser without a plugin.",
     "homepage": "http://cesiumjs.org",
     "license": "Apache-2.0",


### PR DESCRIPTION
Also clean up CHANGES.MD.

I'm opening this up as a PR because it's a switch to our new permanent versioning scheme and just wanted to make sure everyone is on the same page (and in agreement).
1. Cesium will primarily use a `major.minor` versioning scheme, where the minor version will be bumped with each monthly release; i.e. 12 months from now will be `Cesium 1.12`.
2. When releasing a out-of-band patch, (or when required by systems that follow semver) we will use a a third digit, i.e. `Cesium 1.12.1` would be an out of band patch to `1.12`.
3. Major version bumps will only be done when we feel it's necessary and not to indicate a breaking change.
