### PR TITLE
Add a function to set the default EntityView vector.

### DIFF
--- a/Source/DataSources/EntityView.js
+++ b/Source/DataSources/EntityView.js
@@ -202,12 +202,12 @@ define([
     // STATIC properties defined here, not per-instance.
     defineProperties(EntityView, {
         /**
-         * Gets or sets a camera offset vector that will be used to
+         * Gets or sets a camera offset that will be used to
          * initialize subsequent EntityViews.
          * @memberof EntityView
          * @type {Cartesian3}
          */
-        defaultViewVector : {
+        defaultOffset3D : {
             get : function() {
                 return this._defaultOffset3D;
             },
@@ -224,7 +224,7 @@ define([
     });
 
     // Initialize the static property.
-    EntityView.defaultViewVector = new Cartesian3(-14000, 3500, 3500);
+    EntityView.defaultOffset3D = new Cartesian3(-14000, 3500, 3500);
 
     /**
     * Should be called each animation frame to update the camera

--- a/Specs/DataSources/EntityViewSpec.js
+++ b/Specs/DataSources/EntityViewSpec.js
@@ -46,15 +46,15 @@ defineSuite([
         expect(view.ellipsoid).toBe(Ellipsoid.UNIT_SPHERE);
     });
 
-    it('can set and get defaultViewVector', function() {
-        var sampleVector = new Cartesian3(1, 2, 3);
-        EntityView.defaultViewVector = sampleVector;
+    it('can set and get defaultOffset3D', function() {
+        var sampleOffset = new Cartesian3(1, 2, 3);
+        EntityView.defaultOffset3D = sampleOffset;
         var entity = new Entity();
         entity.position = new ConstantPositionProperty(Cartesian3.ZERO);
         var view = new EntityView(entity, scene);
         view.update(JulianDate.now());
-        expect(Cartesian3.equalsEpsilon(EntityView.defaultViewVector, sampleVector, 1e-10)).toBe(true);
-        expect(Cartesian3.equalsEpsilon(view.scene.camera.position, sampleVector, 1e-10)).toBe(true);
+        expect(Cartesian3.equalsEpsilon(EntityView.defaultOffset3D, sampleOffset, 1e-10)).toBe(true);
+        expect(Cartesian3.equalsEpsilon(view.scene.camera.position, sampleOffset, 1e-10)).toBe(true);
     });
 
     it('update throws without time parameter', function() {


### PR DESCRIPTION
This allows the host app to control how objects are viewed by default.
