### PR TITLE
Don't stomp on existing CZML DataSource name

### DIFF
--- a/Source/DataSources/CzmlDataSource.js
+++ b/Source/DataSources/CzmlDataSource.js
@@ -1417,7 +1417,7 @@ define([
         if (defined(documentPacket.name) && dataSource._name !== documentPacket.name) {
             dataSource._name = documentPacket.name;
             raiseChangedEvent = true;
-        } else if (defined(sourceUri)) {
+        } else if (!defined(dataSource._name) && defined(sourceUri)) {
             dataSource._name = getFilenameFromUri(sourceUri);
             raiseChangedEvent = true;
         }

--- a/Specs/DataSources/CzmlDataSourceSpec.js
+++ b/Specs/DataSources/CzmlDataSourceSpec.js
@@ -167,6 +167,12 @@ defineSuite([
         expect(dataSource.name).toEqual('simple.czml');
     });
 
+    it('does not overwrite existing name if CZML name is undefined', function() {
+        var dataSource = new CzmlDataSource('myName');
+        dataSource.load(clockCzml, 'Gallery/simple.czml');
+        expect(dataSource.name).toEqual('myName');
+    });
+
     it('clock returns undefined for static CZML', function() {
         var dataSource = new CzmlDataSource();
         dataSource.load(makePacket(staticCzml));


### PR DESCRIPTION
If a CZML document does not define a name, it generates one from the provided source URI.  However, it shouldn't generate a name if one has already been provided via the constructor.
