### PR TITLE
Remove no longer needed IE 11 workarounds

### DIFF
--- a/Source/Renderer/RenderState.js
+++ b/Source/Renderer/RenderState.js
@@ -359,16 +359,9 @@ define([
         gl.stencilMask(renderState.stencilMask);
     }
 
-    var applyBlendingColor;
-    if (FeatureDetection.isInternetExplorer()) {
-        // blendColor is not supported in IE 11.0.8
-        applyBlendingColor = function() {
-        };
-    } else {
-        applyBlendingColor = function(gl, color) {
-            gl.blendColor(color.red, color.green, color.blue, color.alpha);
-        };
-    }
+    var applyBlendingColor = function(gl, color) {
+        gl.blendColor(color.red, color.green, color.blue, color.alpha);
+    };
 
     function applyBlending(gl, renderState, passState) {
         var blending = renderState.blending;
@@ -418,23 +411,16 @@ define([
         }
     }
 
-    var applySampleCoverage;
-    if (FeatureDetection.isInternetExplorer()) {
-        // sampleCoverage is not supported in IE 11.0.8
-        applySampleCoverage = function() {
-        };
-    } else {
-        applySampleCoverage = function(gl, renderState) {
-            var sampleCoverage = renderState.sampleCoverage;
-            var enabled = sampleCoverage.enabled;
+    var applySampleCoverage = function(gl, renderState) {
+        var sampleCoverage = renderState.sampleCoverage;
+        var enabled = sampleCoverage.enabled;
 
-            enableOrDisable(gl, gl.SAMPLE_COVERAGE, enabled);
+        enableOrDisable(gl, gl.SAMPLE_COVERAGE, enabled);
 
-            if (enabled) {
-                gl.sampleCoverage(sampleCoverage.value, sampleCoverage.invert);
-            }
-        };
-    }
+        if (enabled) {
+            gl.sampleCoverage(sampleCoverage.value, sampleCoverage.invert);
+        }
+    };
 
     var scratchViewport = new BoundingRectangle();
     function applyViewport(gl, renderState, passState) {

--- a/Source/Renderer/Texture.js
+++ b/Source/Renderer/Texture.js
@@ -313,28 +313,6 @@ define([
         }
         //>>includeEnd('debug');
 
-        // Internet Explorer 11.0.8 is apparently unable to upload a texture to a non-zero
-        // yOffset when the pipeline is configured to FLIP_Y.  So do the flip manually.
-        if (FeatureDetection.isInternetExplorer() && yOffset !== 0 && this._flipY) {
-            var texture = new Texture(this._context, {
-                source : source,
-                flipY : true,
-                pixelFormat : this._pixelFormat,
-                pixelDatatype : this._pixelDatatype,
-                preMultiplyAlpha : this._preMultiplyAlpha
-            });
-
-            var framebuffer = this._context.createFramebuffer({
-                colorTextures : [texture]
-            });
-            framebuffer._bind();
-            this.copyFromFramebuffer(xOffset, yOffset, 0, 0, texture.width, texture.height);
-            framebuffer._unBind();
-            framebuffer.destroy();
-
-            return;
-        }
-
         var gl = this._context._gl;
         var target = this._textureTarget;
 

--- a/Specs/Renderer/CubeMapSpec.js
+++ b/Specs/Renderer/CubeMapSpec.js
@@ -233,11 +233,6 @@ defineSuite([
     });
 
     it('draws with a cube map with premultiplied alpha', function() {
-        if (FeatureDetection.isInternetExplorer()) {
-            // Workaround IE 11.0.8, which does not support premultiplied alpha
-            return;
-        }
-
         cubeMap = context.createCubeMap({
             source : {
                 positiveX : blueAlphaImage,
@@ -1141,11 +1136,6 @@ defineSuite([
     });
 
     it('fails to generate mipmaps (width)', function() {
-        if (FeatureDetection.isInternetExplorer()) {
-            // Workaround IE 11.0.9, which does not support non-power-of-two cube map faces
-            return;
-        }
-
         cubeMap = context.createCubeMap({
             width : 3,
             height : 3

--- a/Specs/Renderer/DrawSpec.js
+++ b/Specs/Renderer/DrawSpec.js
@@ -360,11 +360,6 @@ defineSuite([
     });
 
     it('draws with blend color', function() {
-        if (FeatureDetection.isInternetExplorer()) {
-            // blendColor is not supported in IE 11.0.8
-            return;
-        }
-
         var vs = 'attribute vec4 position; void main() { gl_PointSize = 1.0; gl_Position = position; }';
         var fs = 'void main() { gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0); }';
         sp = context.createShaderProgram(vs, fs);
@@ -548,12 +543,6 @@ defineSuite([
     });
 
     it('draws with depth range', function() {
-        if (FeatureDetection.isInternetExplorer()) {
-            // gl_DepthRange is not supported in IE 11.0.8.
-            // When needed, Cesium will fully workaround this with czm_depthRange.
-            return;
-        }
-
         var vs = 'attribute vec4 position; void main() { gl_PointSize = 1.0; gl_Position = position; }';
         var fs = 'void main() { gl_FragColor = vec4(gl_DepthRange.near, gl_DepthRange.far, 0.0, 1.0); }';
         sp = context.createShaderProgram(vs, fs);
@@ -646,11 +635,6 @@ defineSuite([
     it('draws with sample coverage', function() {
         if (!context.antialias) {
             // Sample coverage requires antialiasing.
-            return;
-        }
-
-        if (FeatureDetection.isInternetExplorer()) {
-            // sampleCoverage is not supported in IE 11.0.8
             return;
         }
 

--- a/Specs/Renderer/TextureSpec.js
+++ b/Specs/Renderer/TextureSpec.js
@@ -194,11 +194,6 @@ defineSuite([
     });
 
     it('renders with premultiplied alpha', function() {
-        if (FeatureDetection.isInternetExplorer()) {
-            // Workaround IE 11.0.8, which does not support premultiplied alpha
-            return;
-        }
-
         texture = context.createTexture2D({
             source : blueAlphaImage,
             pixelFormat : PixelFormat.RGBA,


### PR DESCRIPTION
As of IE 11.0.12 (KB2977629), many of the workarounds we have in place for IE 11 are no longer needed.  I tested this by removing all of the `isInternetExplorer` checks sprinkled throughout the code and then putting back the ones that were still needed (i.e. failing tests).  Then I ran through the Sandcastle examples just to be sure.

@pjcozzi or @kring should probably review this, since they did a lot of the initial work to get things happy in IE.
