### PR TITLE
Tweak the glow by subtracting the amount of glow at the edge.

### DIFF
--- a/Apps/Sandcastle/gallery/Polylines.html
+++ b/Apps/Sandcastle/gallery/Polylines.html
@@ -65,7 +65,7 @@ function createPrimitives(scene) {
             -85.0, 40.0
         ]),
         material : Cesium.Material.fromType(Cesium.Material.PolylineGlowType, {
-            innerWidth : 3.0,
+            glowPower : 0.25,
             color : new Cesium.Color(1.0, 0.5, 0.0, 1.0)
         }),
         width : 10.0

--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -1357,7 +1357,7 @@ define([
             type : Material.PolylineGlowType,
             uniforms : {
                 color : new Color(0.0, 0.5, 1.0, 1.0),
-                glowPower : 0.1
+                glowPower : 0.25
             },
             source : PolylineGlowMaterial
         },

--- a/Source/Shaders/Materials/PolylineGlowMaterial.glsl
+++ b/Source/Shaders/Materials/PolylineGlowMaterial.glsl
@@ -8,7 +8,7 @@ czm_material czm_getMaterial(czm_materialInput materialInput)
     czm_material material = czm_getDefaultMaterial(materialInput);
 
     vec2 st = materialInput.st;
-    float glow = glowPower / abs(st.t - 0.5);
+    float glow = glowPower / abs(st.t - 0.5) - (glowPower / 0.5);
 
     material.emission = max(vec3(glow - 1.0 + color.rgb), color.rgb);
     material.alpha = clamp(0.0, 1.0, glow) * color.a;


### PR DESCRIPTION
The `PolylineGlowMaterial` had a sharp visible edge, where the glow abruptly came to an end.  This tweaks the glow by subtracting that bit at the egde, making the edge of the polyline always reach full transparency, so you don't see a hard line.

Also, our material default didn't match the CZML default for `glowPower`.  The CZML default was slightly better, so I made it the default for the material as well.  They were similar, so this isn't a very noticeable change.
