### PR TITLE
Always use https for Caja.

### DIFF
--- a/Source/Workers/sanitizeHtml.js
+++ b/Source/Workers/sanitizeHtml.js
@@ -9,7 +9,7 @@ define([
         createTaskProcessorWorker) {
     "use strict";
 
-    var cajaScript = '//caja.appspot.com/html-css-sanitizer-minified.js';
+    var cajaScript = 'https://caja.appspot.com/html-css-sanitizer-minified.js';
     var html_sanitize;
 
     /**


### PR DESCRIPTION
The built `Cesium.js` file calls Caja from a `blob` which is neither `http` nor `https`, so the URL `//caja.appspot.com/` does not work.  This changes it to always use `https` which appears to work even on `http` pages.
