### PR TITLE
Remove faulty logic from GlobeSurfaceTileProvider when layer removed.

### DIFF
--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -604,10 +604,6 @@ define([
             if (startIndex !== -1) {
                 tileImageryCollection.splice(startIndex, numDestroyed);
             }
-            // If the base layer has been removed, mark the tile as non-renderable.
-            if (layer.isBaseLayer()) {
-                tile.isRenderable = false;
-            }
         });
     };
 


### PR DESCRIPTION
The property is named `renderable`, not `isRenderable`, but it doesn't matter anyway because this code is wrong.  If the property name is corrected, then removing the base layer produces a missing globe instead of the blue globe that you get when you don't add a base layer at construction time.
