### PR TITLE
GeoJson fixes and cleanup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 * Fixed model orientations to follow the same Z-up convention used throughout Cesium. There was also an orientation issue fixed in the [online model converter](http://cesiumjs.org/convertmodel.html). If you are having orientation issues after updating, try reconverting your models.
 * Fixed a bug in `Model` where the wrong animations could be used when the model was created from glTF JSON instead of 
 a url to a glTF file.  [#2078](https://github.com/AnalyticalGraphicsInc/cesium/issues/2078)
+* Fixed a bug in `GeoJsonDataSource` which was causing polygons with height values to be drawn onto the surface.
 * Eliminated imagery artifacts at some zoom levels due to Mercator reprojection.
 * Added a constructor option to `Scene`, `CesiumWidget`, and `Viewer` to disable order independent translucency.
 * Added support for WKID 102113 (equivalent to 102100) to `ArcGisMapServerImageryProvider`.

--- a/Specs/DataSources/GeoJsonDataSourceSpec.js
+++ b/Specs/DataSources/GeoJsonDataSourceSpec.js
@@ -19,7 +19,7 @@ defineSuite([
     var time = new JulianDate();
 
     function coordinatesToCartesian(coordinates) {
-        return Cartesian3.fromDegrees(coordinates[0], coordinates[1]);
+        return Cartesian3.fromDegrees(coordinates[0], coordinates[1], coordinates[2]);
     }
 
     function coordinatesArrayToCartesian(coordinates) {
@@ -103,6 +103,11 @@ defineSuite([
         type : 'Polygon',
         coordinates : [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]], [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2]]]
     };
+
+    var polygonWithHeights = {
+            type : 'Polygon',
+            coordinates : [[[100.0, 0.0, 1.0], [101.0, 0.0, 2.0], [101.0, 1.0, 1.0], [100.0, 1.0, 2.0], [100.0, 0.0, 3.0]]]
+        };
 
     var multiPoint = {
         type : 'MultiPoint',
@@ -356,6 +361,23 @@ defineSuite([
             var object = entityCollection.entities[0];
             expect(object.properties).toBe(polygon.properties);
             expect(object.polygon.positions.getValue(time)).toEqual(polygonCoordinatesToCartesian(polygon.coordinates));
+            expect(object.polygon.perPositionHeight).toBeUndefined();
+        });
+    });
+
+    it('Works with polygon geometry with Heights', function() {
+        var dataSource = new GeoJsonDataSource();
+        dataSource.load(polygonWithHeights);
+
+        var entityCollection = dataSource.entities;
+        waitsFor(function() {
+            return entityCollection.entities.length === 1;
+        });
+        runs(function() {
+            var object = entityCollection.entities[0];
+            expect(object.properties).toBe(polygonWithHeights.properties);
+            expect(object.polygon.positions.getValue(time)).toEqual(polygonCoordinatesToCartesian(polygonWithHeights.coordinates));
+            expect(object.polygon.perPositionHeight.getValue(time)).toBe(true);
         });
     });
 


### PR DESCRIPTION
1. Automatically set `perPositionHeight` to true if a polygon contains altitude values.
2. Remove `sourceUri` parameter from the geometry functions since they are no longer used (and haven't been for a while).
3. Move polygon creation code into a helper function to de-duplicate code that was in both `processPolygon` and `processMultiPolygon`
4. Added specs and updated CHANGES.
