### PR TITLE
Minor tweaks to Geocoder

### DIFF
--- a/Source/Widgets/Geocoder/Geocoder.js
+++ b/Source/Widgets/Geocoder/Geocoder.js
@@ -66,6 +66,7 @@ define([
         textBox.setAttribute('data-bind', '\
 value: searchText,\
 valueUpdate: "afterkeydown",\
+disable: isSearchInProgress,\
 css: { "cesium-geocoder-input-wide" : searchText.length > 0 }');
         form.appendChild(textBox);
 


### PR DESCRIPTION
This prevents the Geocoder widget from both allowing editing of text while searching and also prevents submitting of the text "Searching..." while already geocoding.

Fixes #2087
