### PR TITLE
Fix widget error handling

### DIFF
--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -63,23 +63,32 @@ define([
             }
 
             if (widget._useDefaultRenderLoop) {
-                var targetFrameRate = widget._targetFrameRate;
-                if (!defined(targetFrameRate)) {
-                    widget.resize();
-                    widget.render();
-                    requestAnimationFrame(render);
-                } else {
-                    var lastFrameTime = widget._lastFrameTime;
-                    var interval = 1000.0 / targetFrameRate;
-                    var now = getTimestamp();
-                    var delta = now - lastFrameTime;
-
-                    if (delta > interval) {
+                try {
+                    var targetFrameRate = widget._targetFrameRate;
+                    if (!defined(targetFrameRate)) {
                         widget.resize();
                         widget.render();
-                        widget._lastFrameTime = now - (delta % interval);
+                        requestAnimationFrame(render);
+                    } else {
+                        var lastFrameTime = widget._lastFrameTime;
+                        var interval = 1000.0 / targetFrameRate;
+                        var now = getTimestamp();
+                        var delta = now - lastFrameTime;
+
+                        if (delta > interval) {
+                            widget.resize();
+                            widget.render();
+                            widget._lastFrameTime = now - (delta % interval);
+                        }
+                        requestAnimationFrame(render);
                     }
-                    requestAnimationFrame(render);
+                } catch (error) {
+                    widget._useDefaultRenderLoop = false;
+                    widget._renderLoopRunning = false;
+                    if (widget._showRenderLoopErrors) {
+                        var title = 'An error occurred while rendering.  Rendering has stopped.';
+                        widget.showErrorPanel(title, undefined, error);
+                    }
                 }
             } else {
                 widget._renderLoopRunning = false;
@@ -312,8 +321,7 @@ define([
                 that._renderLoopRunning = false;
                 if (that._showRenderLoopErrors) {
                     var title = 'An error occurred while rendering.  Rendering has stopped.';
-                    var message = 'This may indicate an incompatibility with your hardware or web browser, or it may indicate a bug in the application.  Visit <a href="http://get.webgl.org">http://get.webgl.org</a> to verify that your web browser and hardware support WebGL.  Consider trying a different web browser or updating your video drivers.  Detailed error information is below:';
-                    that.showErrorPanel(title, message, error);
+                    that.showErrorPanel(title, undefined, error);
                 }
             });
         } catch (error) {
@@ -507,10 +515,12 @@ define([
             window.addEventListener('resize', resizeCallback, false);
         }
 
-        var errorMessage = document.createElement('div');
-        errorMessage.className = 'cesium-widget-errorPanel-message';
-        errorMessage.innerHTML = '<p>' + message + '</p>';
-        errorPanelScroller.appendChild(errorMessage);
+        if (defined(message)) {
+            var errorMessage = document.createElement('div');
+            errorMessage.className = 'cesium-widget-errorPanel-message';
+            errorMessage.innerHTML = '<p>' + message + '</p>';
+            errorPanelScroller.appendChild(errorMessage);
+        }
 
         var errorDetails = '(no error details available)';
         if (defined(error)) {


### PR DESCRIPTION
Fix #2095 by making sure that exceptions generated by onTick callbacks are handled by the widget.
Remove superflous messaging from errors that are most likely not WebGL related.
