### PR TITLE
Fix bugs in CompositeEntityCollection

### DIFF
--- a/Source/DataSources/CompositeEntityCollection.js
+++ b/Source/DataSources/CompositeEntityCollection.js
@@ -465,6 +465,7 @@ define([
             if (!defined(compositeEntity)) {
                 composite.removeById(removedId);
             }
+            compositeEntity = undefined;
         }
 
         var addedLength = added.length;
@@ -491,6 +492,7 @@ define([
                     compositeEntity.merge(entity);
                 }
             }
+            compositeEntity = undefined;
         }
 
         composite.resumeEvents();

--- a/Source/DataSources/Entity.js
+++ b/Source/DataSources/Entity.js
@@ -324,11 +324,19 @@ define([
         this.availability = defaultValue(source.availability, this.availability);
 
         var propertyNames = this._propertyNames;
-        var propertyNamesLength = propertyNames.length;
+        var sourcePropertyNames = source._propertyNames;
+        var propertyNamesLength = sourcePropertyNames.length;
         for (var i = 0; i < propertyNamesLength; i++) {
-            var name = propertyNames[i];
+            var name = sourcePropertyNames[i];
             var targetProperty = this[name];
             var sourceProperty = source[name];
+
+            //Custom properties that are registered on the source entity must also
+            //get registered on this entity.
+            if (!defined(targetProperty) && propertyNames.indexOf(name) === -1) {
+                this.addProperty(name);
+            }
+
             if (defined(sourceProperty)) {
                 if (defined(targetProperty)) {
                     if (defined(targetProperty.merge)) {

--- a/Specs/DataSources/CompositeEntityCollectionSpec.js
+++ b/Specs/DataSources/CompositeEntityCollectionSpec.js
@@ -502,6 +502,44 @@ defineSuite([
         expect(compositeObject.billboard.show).toBeUndefined();
     });
 
+    it('works when collection being composited suspends updates', function() {
+        var collection = new EntityCollection();
+        var composite = new CompositeEntityCollection([collection]);
+
+        collection.suspendEvents();
+        collection.getOrCreateEntity('id1');
+        collection.getOrCreateEntity('id2');
+
+        expect(composite.getById('id1')).toBeUndefined();
+        expect(composite.getById('id2')).toBeUndefined();
+
+        collection.resumeEvents();
+
+        expect(composite.getById('id1')).toBeDefined();
+        expect(composite.getById('id2')).toBeDefined();
+    });
+
+    it('custom entity properties are properly registed on composited entity.', function() {
+        var oldValue = 'tubelcane';
+        var newValue = 'fizzbuzz';
+        var propertyName = 'customProperty';
+
+        var collection = new EntityCollection();
+        var e1 = collection.getOrCreateEntity('id1');
+        e1.addProperty(propertyName);
+        e1[propertyName] = oldValue;
+
+        var composite = new CompositeEntityCollection([collection]);
+        var e1Composite = composite.getById('id1');
+        expect(e1Composite[propertyName]).toEqual(e1[propertyName]);
+
+        var listener = jasmine.createSpy('listener');
+        e1Composite.definitionChanged.addEventListener(listener);
+
+        e1[propertyName] = newValue;
+        expect(listener).toHaveBeenCalledWith(e1Composite, propertyName, newValue, oldValue);
+    });
+
     it('can use the same entity collection in multiple composites', function() {
         var id = 'test';
 

--- a/Specs/DataSources/EntitySpec.js
+++ b/Specs/DataSources/EntitySpec.js
@@ -93,6 +93,26 @@ defineSuite([
         expect(entity.availability).toBe(interval2);
     });
 
+    it('merge works with custom properties.', function() {
+        var propertyName = 'customProperty';
+        var value = 'fizzbuzz';
+
+        var source = new Entity('source');
+        source.addProperty(propertyName);
+        source[propertyName] = value;
+
+        var listener = jasmine.createSpy('listener');
+
+        var target = new Entity('target');
+
+        //Merging should actually call addProperty for the customProperty.
+        spyOn(target, 'addProperty').andCallThrough();
+        target.merge(source);
+
+        expect(target.addProperty).toHaveBeenCalledWith(propertyName);
+        expect(target[propertyName]).toEqual(source[propertyName]);
+    });
+
     it('merge throws with undefined source', function() {
         var entity = new Entity();
         expect(function() {


### PR DESCRIPTION
1. `onCollectionChanged` handling was not properly resetting a value to undefine for each iteration of a for loop, leading to the first entity incorrectly being the target for all merged properties.
2. Fix bug in `Entity.merge` which was causing custom properties registered on the source entity to not propagate to the target entity if they did not already exist.
3. Added specs to expose both issues.

Fixes #2180

@shunter I didn't modify`_propertyNames` as we discussed offline because (as it stands right now) that array should only contain optional properties, where as id/availability/parent/name/etc.. are all considered required to exist (even if left undefined).  We can revisit this separately in the future.
