### PR TITLE
Reorganize CesiumViewer module configuration.

### DIFF
--- a/Apps/CesiumViewer/CesiumViewer.js
+++ b/Apps/CesiumViewer/CesiumViewer.js
@@ -1,16 +1,16 @@
 /*global define*/
 define([
-        'Core/defined',
-        'Core/formatError',
-        'Core/getFilenameFromUri',
-        'Core/queryToObject',
-        'DataSources/CzmlDataSource',
-        'DataSources/GeoJsonDataSource',
-        'Scene/TileMapServiceImageryProvider',
-        'Widgets/Viewer/Viewer',
-        'Widgets/Viewer/viewerCesiumInspectorMixin',
-        'Widgets/Viewer/viewerDragDropMixin',
-        'Widgets/Viewer/viewerEntityMixin',
+        'Cesium/Core/defined',
+        'Cesium/Core/formatError',
+        'Cesium/Core/getFilenameFromUri',
+        'Cesium/Core/queryToObject',
+        'Cesium/DataSources/CzmlDataSource',
+        'Cesium/DataSources/GeoJsonDataSource',
+        'Cesium/Scene/TileMapServiceImageryProvider',
+        'Cesium/Widgets/Viewer/Viewer',
+        'Cesium/Widgets/Viewer/viewerCesiumInspectorMixin',
+        'Cesium/Widgets/Viewer/viewerDragDropMixin',
+        'Cesium/Widgets/Viewer/viewerEntityMixin',
         'domReady!'
     ], function(
         defined,

--- a/Apps/CesiumViewer/CesiumViewerStartup.js
+++ b/Apps/CesiumViewer/CesiumViewerStartup.js
@@ -1,11 +1,9 @@
 /*global require*/
 require({
-    baseUrl : '../../Source',
+    baseUrl : '.',
     paths : {
-        CesiumViewer : '../Apps/CesiumViewer',
-        domReady : '../ThirdParty/requirejs-2.1.9/domReady'
+        domReady : '../../ThirdParty/requirejs-2.1.9/domReady',
+        Cesium : '../../Source'
     }
-}, [
-        'CesiumViewer/CesiumViewer'
-    ], function() {
+}, ['CesiumViewer'], function() {
 });

--- a/build.xml
+++ b/build.xml
@@ -541,9 +541,17 @@
 			<arg value="optimize=uglify2" />
 			<arg value="pragmas.debug=false" />
 			<arg value="mainConfigFile=../Apps/CesiumViewer/CesiumViewerStartup.js" />
-			<arg value="name=CesiumViewer/CesiumViewerStartup" />
+			<arg value="name=CesiumViewerStartup" />
 			<arg value="out=${relativeCesiumViewerOutputDirectory}/CesiumViewerStartup.js" />
 		</exec>
+
+		<!-- add copyright header -->
+		<copy file="${cesiumViewerOutputDirectory}/CesiumViewerStartup.js" tofile="${cesiumViewerOutputDirectory}/CesiumViewerStartup.js.tmp">
+			<filterchain>
+				<concatfilter prepend="${sourceDirectory}/copyrightHeader.js" />
+			</filterchain>
+		</copy>
+		<move file="${cesiumViewerOutputDirectory}/CesiumViewerStartup.js.tmp" tofile="${cesiumViewerOutputDirectory}/CesiumViewerStartup.js" />
 
 		<exec executable="${nodePath}" dir="${cesiumViewerDirectory}">
 			<arg value="${rjsPath}" />
@@ -565,8 +573,13 @@
 		<copy file="${requirejsPath}/require.min.js" tofile="${cesiumViewerOutputDirectory}/require.js" />
 
 		<!-- Copy the built Cesium assets and workers -->
-		<copy todir="${cesiumViewerOutputDirectory}">
-			<fileset dir="${buildOutputDirectory}" excludes="Cesium.js" />
+		<copy todir="${cesiumViewerOutputDirectory}" includeemptydirs="false">
+			<fileset dir="${buildOutputDirectory}">
+				<include name="Assets/**" />
+				<include name="Workers/**" />
+				<include name="Widgets/**" />
+				<exclude name="Widgets/**/*.css" />
+			</fileset>
 		</copy>
 
 		<!-- Copy web.config -->
@@ -575,8 +588,7 @@
 		<!-- rewrite the paths in the configuration -->
 		<replace dir="${cesiumViewerOutputDirectory}" summary="true">
 			<replacefilter token="../../Source" value="." />
-			<replacefilter token="../Apps/CesiumViewer" value="." />
-			<replacefilter token="../ThirdParty/requirejs-2.1.9" value="." />
+			<replacefilter token="../../ThirdParty/requirejs-2.1.9" value="." />
 			<include name="CesiumViewerStartup.js" />
 		</replace>
 


### PR DESCRIPTION
Flip the baseUrl around so that CesiumViewer is more like a self-contained application which pulls in Cesium modules using path configuration with a Cesium prefix.

Also fix build script to include the Cesium copyright header at the top of the built file.
