### PR TITLE
Oct Encoding

### DIFF
--- a/Source/Core/Oct.js
+++ b/Source/Core/Oct.js
@@ -1,10 +1,12 @@
 /*global define*/
 define([
+        './Cartesian2',
         './Cartesian3',
         './defined',
         './DeveloperError',
         './Math'
     ], function(
+        Cartesian2,
         Cartesian3,
         defined,
         DeveloperError,
@@ -99,6 +101,39 @@ define([
         }
 
         return Cartesian3.normalize(result, result);
+    };
+
+    var scratchEncodeCart2 = new Cartesian2();
+
+    /**
+     * Encodes a normalized vector into 2 SNORM values in the range of [0-255] following the 'oct' encoding and
+     * stores those values in a single float-point number.
+     *
+     * @param {Cartesian3} vector The normalized vector to be compressed into 2 byte 'oct' encoding.
+     * @returns {Number} The 2 byte oct-encoded unit length vector.
+     *
+     * @exception {DeveloperError} vector must be defined.
+     * @exception {DeveloperError} vector must be normalized.
+     */
+    Oct.encodeFloat = function(vector) {
+        Oct.encode(vector, scratchEncodeCart2);
+        return 256.0 * scratchEncodeCart2.x + scratchEncodeCart2.y;
+    };
+
+    /**
+     * Decodes a unit-length vector in 'oct' encoding to a normalized 3-component vector.
+     *
+     * @param {Number} value The oct-encoded unit length vector stored as a single floating-point number.
+     * @param {Cartesian3} result The decoded and normalized vector
+     * @returns {Cartesian3} The decoded and normalized vector.
+     *
+     * @exception {DeveloperError} result must be defined.
+     */
+    Oct.decodeFloat = function(value, result) {
+        var temp = value / 256.0;
+        var x = Math.floor(temp);
+        var y = (temp - x) * 256.0;
+        return Oct.decode(x, y, result);
     };
 
     return Oct;

--- a/Source/Shaders/Builtin/Functions/octDecode.glsl
+++ b/Source/Shaders/Builtin/Functions/octDecode.glsl
@@ -17,3 +17,21 @@
     
     return normalize(v);
  }
+
+ /**
+ * Decodes a unit-length vector in 'oct' encoding to a normalized 3-component Cartesian vector.
+ * The 'oct' encoding is described in "A Survey of Efficient Representations of Independent Unit Vectors",
+ * Cigolle et al 2014: http://jcgt.org/published/0003/02/01/
+ * 
+ * @name czm_octDecode
+ * @param {float} encoded The oct-encoded, unit-length vector
+ * @returns {vec3} The decoded and normalized vector
+ */
+ vec3 czm_octDecode(float encoded)
+ {
+    float temp = encoded / 256.0;
+    float x = floor(temp);
+    float y = (temp - x) * 256.0;
+    return czm_octDecode(vec2(x, y));
+ }
+ 

--- a/Specs/Core/OctSpec.js
+++ b/Specs/Core/OctSpec.js
@@ -2,11 +2,13 @@
 defineSuite([
         'Core/Oct',
         'Core/Cartesian2',
-        'Core/Cartesian3'
+        'Core/Cartesian3',
+        'Core/Math'
     ], function(
         Oct,
         Cartesian2,
-        Cartesian3) {
+        Cartesian3,
+        CesiumMath) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
@@ -98,4 +100,226 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
+    it('oct encoding', function() {
+        var epsilon = CesiumMath.EPSILON1;
+
+        var encoded = new Cartesian2();
+        var result = new Cartesian3();
+        var normal = new Cartesian3(0.0, 0.0, 1.0);
+        Oct.encode(normal, encoded);
+        expect(Oct.decode(encoded.x, encoded.y, result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(0.0, 0.0, -1.0);
+        Oct.encode(normal, encoded);
+        expect(Oct.decode(encoded.x, encoded.y, result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(0.0, 1.0, 0.0);
+        Oct.encode(normal, encoded);
+        expect(Oct.decode(encoded.x, encoded.y, result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(0.0, -1.0, 0.0);
+        Oct.encode(normal, encoded);
+        expect(Oct.decode(encoded.x, encoded.y, result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(1.0, 0.0, 0.0);
+        Oct.encode(normal, encoded);
+        expect(Oct.decode(encoded.x, encoded.y, result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(-1.0, 0.0, 0.0);
+        Oct.encode(normal, encoded);
+        expect(Oct.decode(encoded.x, encoded.y, result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(1.0, 1.0, 1.0);
+        Cartesian3.normalize(normal, normal);
+        Oct.encode(normal, encoded);
+        expect(Oct.decode(encoded.x, encoded.y, result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(1.0, -1.0, 1.0);
+        Cartesian3.normalize(normal, normal);
+        Oct.encode(normal, encoded);
+        expect(Oct.decode(encoded.x, encoded.y, result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(-1.0, -1.0, 1.0);
+        Cartesian3.normalize(normal, normal);
+        Oct.encode(normal, encoded);
+        expect(Oct.decode(encoded.x, encoded.y, result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(-1.0, 1.0, 1.0);
+        Cartesian3.normalize(normal, normal);
+        Oct.encode(normal, encoded);
+        expect(Oct.decode(encoded.x, encoded.y, result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(1.0, 1.0, -1.0);
+        Cartesian3.normalize(normal, normal);
+        Oct.encode(normal, encoded);
+        expect(Oct.decode(encoded.x, encoded.y, result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(1.0, -1.0, -1.0);
+        Cartesian3.normalize(normal, normal);
+        Oct.encode(normal, encoded);
+        expect(Oct.decode(encoded.x, encoded.y, result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(-1.0, 1.0, -1.0);
+        Cartesian3.normalize(normal, normal);
+        Oct.encode(normal, encoded);
+        expect(Oct.decode(encoded.x, encoded.y, result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(-1.0, -1.0, -1.0);
+        Cartesian3.normalize(normal, normal);
+        Oct.encode(normal, encoded);
+        expect(Oct.decode(encoded.x, encoded.y, result)).toEqualEpsilon(normal, epsilon);
+    });
+
+    it('octFloat encoding', function() {
+        var epsilon = CesiumMath.EPSILON1;
+
+        var result = new Cartesian3();
+        var normal = new Cartesian3(0.0, 0.0, 1.0);
+        expect(Oct.decodeFloat(Oct.encodeFloat(normal), result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(0.0, 0.0, -1.0);
+        expect(Oct.decodeFloat(Oct.encodeFloat(normal), result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(0.0, 1.0, 0.0);
+        expect(Oct.decodeFloat(Oct.encodeFloat(normal), result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(0.0, -1.0, 0.0);
+        expect(Oct.decodeFloat(Oct.encodeFloat(normal), result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(1.0, 0.0, 0.0);
+        expect(Oct.decodeFloat(Oct.encodeFloat(normal), result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(-1.0, 0.0, 0.0);
+        expect(Oct.decodeFloat(Oct.encodeFloat(normal), result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(1.0, 1.0, 1.0);
+        Cartesian3.normalize(normal, normal);
+        expect(Oct.decodeFloat(Oct.encodeFloat(normal), result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(1.0, -1.0, 1.0);
+        Cartesian3.normalize(normal, normal);
+        expect(Oct.decodeFloat(Oct.encodeFloat(normal), result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(-1.0, -1.0, 1.0);
+        Cartesian3.normalize(normal, normal);
+        expect(Oct.decodeFloat(Oct.encodeFloat(normal), result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(-1.0, 1.0, 1.0);
+        Cartesian3.normalize(normal, normal);
+        expect(Oct.decodeFloat(Oct.encodeFloat(normal), result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(1.0, 1.0, -1.0);
+        Cartesian3.normalize(normal, normal);
+        expect(Oct.decodeFloat(Oct.encodeFloat(normal), result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(1.0, -1.0, -1.0);
+        Cartesian3.normalize(normal, normal);
+        expect(Oct.decodeFloat(Oct.encodeFloat(normal), result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(-1.0, 1.0, -1.0);
+        Cartesian3.normalize(normal, normal);
+        expect(Oct.decodeFloat(Oct.encodeFloat(normal), result)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(-1.0, -1.0, -1.0);
+        Cartesian3.normalize(normal, normal);
+        expect(Oct.decodeFloat(Oct.encodeFloat(normal), result)).toEqualEpsilon(normal, epsilon);
+    });
+
+    it('octFloat encoding is equivalent to oct encoding', function() {
+        var encoded = new Cartesian2();
+        var result1 = new Cartesian3();
+        var result2 = new Cartesian3();
+
+        var normal = new Cartesian3(0.0, 0.0, 1.0);
+        Oct.encode(normal, encoded);
+        Oct.decode(encoded.x, encoded.y, result1);
+        Oct.decodeFloat(Oct.encodeFloat(normal), result2);
+        expect(result1).toEqual(result2);
+
+        normal = new Cartesian3(0.0, 0.0, -1.0);
+        Oct.encode(normal, encoded);
+        Oct.decode(encoded.x, encoded.y, result1);
+        Oct.decodeFloat(Oct.encodeFloat(normal), result2);
+        expect(result1).toEqual(result2);
+
+        normal = new Cartesian3(0.0, 1.0, 0.0);
+        Oct.encode(normal, encoded);
+        Oct.decode(encoded.x, encoded.y, result1);
+        Oct.decodeFloat(Oct.encodeFloat(normal), result2);
+        expect(result1).toEqual(result2);
+
+        normal = new Cartesian3(0.0, -1.0, 0.0);
+        Oct.encode(normal, encoded);
+        Oct.decode(encoded.x, encoded.y, result1);
+        Oct.decodeFloat(Oct.encodeFloat(normal), result2);
+        expect(result1).toEqual(result2);
+
+        normal = new Cartesian3(1.0, 0.0, 0.0);
+        Oct.encode(normal, encoded);
+        Oct.decode(encoded.x, encoded.y, result1);
+        Oct.decodeFloat(Oct.encodeFloat(normal), result2);
+        expect(result1).toEqual(result2);
+
+        normal = new Cartesian3(-1.0, 0.0, 0.0);
+        Oct.encode(normal, encoded);
+        Oct.decode(encoded.x, encoded.y, result1);
+        Oct.decodeFloat(Oct.encodeFloat(normal), result2);
+        expect(result1).toEqual(result2);
+
+        normal = new Cartesian3(1.0, 1.0, 1.0);
+        Cartesian3.normalize(normal, normal);
+        Oct.encode(normal, encoded);
+        Oct.decode(encoded.x, encoded.y, result1);
+        Oct.decodeFloat(Oct.encodeFloat(normal), result2);
+        expect(result1).toEqual(result2);
+
+        normal = new Cartesian3(1.0, -1.0, 1.0);
+        Cartesian3.normalize(normal, normal);
+        Oct.encode(normal, encoded);
+        Oct.decode(encoded.x, encoded.y, result1);
+        Oct.decodeFloat(Oct.encodeFloat(normal), result2);
+        expect(result1).toEqual(result2);
+
+        normal = new Cartesian3(-1.0, -1.0, 1.0);
+        Cartesian3.normalize(normal, normal);
+        Oct.encode(normal, encoded);
+        Oct.decode(encoded.x, encoded.y, result1);
+        Oct.decodeFloat(Oct.encodeFloat(normal), result2);
+        expect(result1).toEqual(result2);
+
+        normal = new Cartesian3(-1.0, 1.0, 1.0);
+        Cartesian3.normalize(normal, normal);
+        Oct.encode(normal, encoded);
+        Oct.decode(encoded.x, encoded.y, result1);
+        Oct.decodeFloat(Oct.encodeFloat(normal), result2);
+        expect(result1).toEqual(result2);
+
+        normal = new Cartesian3(1.0, 1.0, -1.0);
+        Cartesian3.normalize(normal, normal);
+        Oct.encode(normal, encoded);
+        Oct.decode(encoded.x, encoded.y, result1);
+        Oct.decodeFloat(Oct.encodeFloat(normal), result2);
+        expect(result1).toEqual(result2);
+
+        normal = new Cartesian3(1.0, -1.0, -1.0);
+        Cartesian3.normalize(normal, normal);
+        Oct.encode(normal, encoded);
+        Oct.decode(encoded.x, encoded.y, result1);
+        Oct.decodeFloat(Oct.encodeFloat(normal), result2);
+        expect(result1).toEqual(result2);
+
+        normal = new Cartesian3(-1.0, 1.0, -1.0);
+        Cartesian3.normalize(normal, normal);
+        Oct.encode(normal, encoded);
+        Oct.decode(encoded.x, encoded.y, result1);
+        Oct.decodeFloat(Oct.encodeFloat(normal), result2);
+        expect(result1).toEqual(result2);
+
+        normal = new Cartesian3(-1.0, -1.0, -1.0);
+        Cartesian3.normalize(normal, normal);
+        Oct.encode(normal, encoded);
+        Oct.decode(encoded.x, encoded.y, result1);
+        Oct.decodeFloat(Oct.encodeFloat(normal), result2);
+        expect(result1).toEqual(result2);
+    });
 });

--- a/Specs/Renderer/BuiltinFunctionsSpec.js
+++ b/Specs/Renderer/BuiltinFunctionsSpec.js
@@ -224,10 +224,18 @@ defineSuite([
         verifyDraw(fs);
     });
 
-    it('has czm_octDecode', function() {
+    it('has czm_octDecode(vec2)', function() {
         var fs =
             'void main() { ' +
             '  gl_FragColor = vec4(czm_octDecode(vec2(0.0, 0.0)) == vec3(0.0, 0.0, 1.0)); ' +
+            '}';
+        verifyDraw(fs);
+    });
+
+    it('has czm_octDecode(float)', function() {
+        var fs =
+            'void main() { ' +
+            '  gl_FragColor = vec4(czm_octDecode(0.0) == vec3(0.0, 0.0, 1.0)); ' +
             '}';
         verifyDraw(fs);
     });


### PR DESCRIPTION
Add functions to store 2 byte oct encoded normals in a single float. This will be used for #1628, but opening as a separate PR.

CC @abwood
