### PR TITLE
Add isFirefox and firefoxVersion to FeatureDetection

### DIFF
--- a/Source/Core/FeatureDetection.js
+++ b/Source/Core/FeatureDetection.js
@@ -21,10 +21,10 @@ define([
     var chromeVersionResult;
     function isChrome() {
         if (!defined(isChromeResult)) {
+            isChromeResult = false;
+
             var fields = (/ Chrome\/([\.0-9]+)/).exec(navigator.userAgent);
-            if (fields === null) {
-                isChromeResult = false;
-            } else {
+            if (fields !== null) {
                 isChromeResult = true;
                 chromeVersionResult = extractVersion(fields[1]);
             }
@@ -41,14 +41,12 @@ define([
     var safariVersionResult;
     function isSafari() {
         if (!defined(isSafariResult)) {
+            isSafariResult = false;
+
             // Chrome contains Safari in the user agent too
-            if (isChrome() || !(/ Safari\/[\.0-9]+/).test(navigator.userAgent)) {
-                isSafariResult = false;
-            } else {
+            if (!isChrome() && (/ Safari\/[\.0-9]+/).test(navigator.userAgent)) {
                 var fields = (/ Version\/([\.0-9]+)/).exec(navigator.userAgent);
-                if (fields === null) {
-                    isSafariResult = false;
-                } else {
+                if (fields !== null) {
                     isSafariResult = true;
                     safariVersionResult = extractVersion(fields[1]);
                 }
@@ -66,10 +64,10 @@ define([
     var webkitVersionResult;
     function isWebkit() {
         if (!defined(isWebkitResult)) {
+            isWebkitResult = false;
+
             var fields = (/ AppleWebKit\/([\.0-9]+)(\+?)/).exec(navigator.userAgent);
-            if (fields === null) {
-                isWebkitResult = false;
-            } else {
+            if (fields !== null) {
                 isWebkitResult = true;
                 webkitVersionResult = extractVersion(fields[1]);
                 webkitVersionResult.isNightly = !!fields[2];
@@ -87,6 +85,8 @@ define([
     var internetExplorerVersionResult;
     function isInternetExplorer() {
         if (!defined(isInternetExplorerResult)) {
+            isInternetExplorerResult = false;
+
             var fields;
             if (navigator.appName === 'Microsoft Internet Explorer') {
                 fields = /MSIE ([0-9]{1,}[\.0-9]{0,})/.exec(navigator.userAgent);
@@ -100,8 +100,6 @@ define([
                     isInternetExplorerResult = true;
                     internetExplorerVersionResult = extractVersion(fields[1]);
                 }
-            } else {
-                isInternetExplorerResult = false;
             }
         }
         return isInternetExplorerResult;
@@ -115,10 +113,10 @@ define([
     var firefoxVersionResult;
     function isFirefox() {
         if (!defined(isFirefoxResult)) {
+            isFirefoxResult = false;
+
             var fields = /Firefox\/([\.0-9]+)/.exec(navigator.userAgent);
-            if (fields === null) {
-                isFirefoxResult = false
-            } else {
+            if (fields !== null) {
                 isFirefoxResult = true;
                 firefoxVersionResult = extractVersion(fields[1]);
             }

--- a/Specs/Core/FeatureDetectionSpec.js
+++ b/Specs/Core/FeatureDetectionSpec.js
@@ -6,13 +6,93 @@ defineSuite([
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
+    //generally, these tests just make sure the function runs, the test can't expect a value of true or false
     it('detects fullscreen support', function() {
-        //just make sure the function runs, the test can't expect a value of true or false
-        expect(FeatureDetection.supportsFullscreen()).toBeDefined();
+        var supportsFullscreen = FeatureDetection.supportsFullscreen();
+        expect(typeof supportsFullscreen).toEqual('boolean');
     });
 
     it('detects web worker support', function() {
-        //just make sure the function runs, the test can't expect a value of true or false
-        expect(FeatureDetection.supportsWebWorkers()).toBeDefined();
+        var supportsWebWorkers = FeatureDetection.supportsWebWorkers();
+        expect(typeof supportsWebWorkers).toEqual('boolean');
+    });
+
+    it('detects typed array support', function() {
+        var supportsTypedArrays = FeatureDetection.supportsTypedArrays();
+        expect(typeof supportsTypedArrays).toEqual('boolean');
+    });
+
+    function checkVersionArray(array) {
+        expect(Array.isArray(array)).toEqual(true);
+        array.forEach(function(d) {
+            expect(typeof d).toEqual('number');
+        });
+    }
+
+    it('detects Chrome', function() {
+        var isChrome = FeatureDetection.isChrome();
+        expect(typeof isChrome).toEqual('boolean');
+
+        if (isChrome) {
+            var chromeVersion = FeatureDetection.chromeVersion();
+            checkVersionArray(chromeVersion);
+
+            /*global console*/
+            console.log('detected Chrome ' + chromeVersion.join('.'));
+        }
+    });
+
+    it('detects Safari', function() {
+        var isSafari = FeatureDetection.isSafari();
+        expect(typeof isSafari).toEqual('boolean');
+
+        if (isSafari) {
+            var safariVersion = FeatureDetection.safariVersion();
+            checkVersionArray(safariVersion);
+
+            /*global console*/
+            console.log('detected Safari ' + safariVersion.join('.'));
+        }
+    });
+
+    it('detects Webkit', function() {
+        var isWebkit = FeatureDetection.isWebkit();
+        expect(typeof isWebkit).toEqual('boolean');
+
+        if (isWebkit) {
+            var webkitVersion = FeatureDetection.webkitVersion();
+            checkVersionArray(webkitVersion);
+            expect(typeof webkitVersion.isNightly).toEqual('boolean');
+
+            /*global console*/
+            console.log('detected Webkit ' + webkitVersion.join('.') + (webkitVersion.isNightly ? ' (Nightly)' : ''));
+        }
+    });
+
+    it('detects Internet Explorer', function() {
+        var isInternetExplorer = FeatureDetection.isInternetExplorer();
+        expect(typeof isInternetExplorer).toEqual('boolean');
+
+        if (isInternetExplorer) {
+            var internetExplorerVersion = FeatureDetection.internetExplorerVersion();
+            checkVersionArray(internetExplorerVersion);
+
+            /*global console*/
+            console.log('detected Internet Explorer ' + internetExplorerVersion.join('.'));
+        }
+    });
+
+    it('detects Firefox', function() {
+        var isFirefox = FeatureDetection.isFirefox();
+        expect(typeof isFirefox).toEqual('boolean');
+
+        if (isFirefox) {
+            var firefoxVersion = FeatureDetection.firefoxVersion();
+
+            checkVersionArray(firefoxVersion);
+
+            /*global console*/
+            console.log('detected Firefox ' + firefoxVersion.join('.'));
+        }
     });
 });


### PR DESCRIPTION
I don't think this needs to be mentioned in `CHANGES.md`, and a test couldn't do any more than verify that it returns true or false (and we don't have tests for the existing browser detection functions).

We needed this in National Map to enable `preserveDrawingBuffer` in Firefox due to this bug:
https://bugzilla.mozilla.org/show_bug.cgi?id=976173

We could add it elsewhere, of course, but I think it makes sense to go here.
