### PR TITLE
Fix custom property entity compositing

### DIFF
--- a/Source/DataSources/CompositeEntityCollection.js
+++ b/Source/DataSources/CompositeEntityCollection.js
@@ -506,6 +506,7 @@ define([
         var id = entity.id;
         var compositeEntity = composite.getById(id);
         var compositeProperty = compositeEntity[propertyName];
+        var newProperty = !defined(compositeProperty);
 
         var firstTime = true;
         for (var q = collectionsLength - 1; q >= 0; q--) {
@@ -529,6 +530,11 @@ define([
                 }
             }
         }
+
+        if (newProperty && compositeEntity.propertyNames.indexOf(propertyName) === -1) {
+            compositeEntity.addProperty(propertyName);
+        }
+
         compositeEntity[propertyName] = compositeProperty;
     };
 

--- a/Specs/DataSources/CompositeEntityCollectionSpec.js
+++ b/Specs/DataSources/CompositeEntityCollectionSpec.js
@@ -519,7 +519,7 @@ defineSuite([
         expect(composite.getById('id2')).toBeDefined();
     });
 
-    it('custom entity properties are properly registed on composited entity.', function() {
+    it('custom entity properties are properly registed on new composited entity.', function() {
         var oldValue = 'tubelcane';
         var newValue = 'fizzbuzz';
         var propertyName = 'customProperty';
@@ -530,6 +530,29 @@ defineSuite([
         e1[propertyName] = oldValue;
 
         var composite = new CompositeEntityCollection([collection]);
+        var e1Composite = composite.getById('id1');
+        expect(e1Composite[propertyName]).toEqual(e1[propertyName]);
+
+        var listener = jasmine.createSpy('listener');
+        e1Composite.definitionChanged.addEventListener(listener);
+
+        e1[propertyName] = newValue;
+        expect(listener).toHaveBeenCalledWith(e1Composite, propertyName, newValue, oldValue);
+    });
+
+    it('custom entity properties are properly registed on existing composited entity.', function() {
+        var oldValue = 'tubelcane';
+        var newValue = 'fizzbuzz';
+        var propertyName = 'customProperty';
+
+        var collection = new EntityCollection();
+        var e1 = collection.getOrCreateEntity('id1');
+
+        var composite = new CompositeEntityCollection([collection]);
+
+        e1.addProperty(propertyName);
+        e1[propertyName] = oldValue;
+
         var e1Composite = composite.getById('id1');
         expect(e1Composite[propertyName]).toEqual(e1[propertyName]);
 


### PR DESCRIPTION
Calling `Entity.addProperty` on an existing instance would not be reflected in existing composited instances of that entity.

I don't think this will be a performance regression when working with large numbers of composites, but if it is, we can switch to a `AssociativeArray` for propertyNames in order to improve lookup time.

Fixes #2209 
CC @shunter
