### PR TITLE
Clamp position to rectangle in interpolateHeight.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Change Log
 * Added `Primitive.compressVertices`. When true, the geometry vertices are compressed, which will save memory.
 * Upgraded topojson from 1.6.8 to 1.6.18.
 * Fixed a bug in `Globe.pick` that caused it to return incorrect results when using terrain data with vertex normals.  The bug manifested itself as strange behavior when navigating around the surface with the mouse as well as incorrect results when using `Camera.viewRectangle`.
+* Fixed a bug in `sampleTerrain` that could cause it to produce undefined heights when sampling for a position very near the edge of a tile.
 
 ### 1.2 - 2014-10-01
 

--- a/Source/Core/QuantizedMeshTerrainData.js
+++ b/Source/Core/QuantizedMeshTerrainData.js
@@ -410,14 +410,13 @@ define([
      * @param {Rectangle} rectangle The rectangle covered by this terrain data.
      * @param {Number} longitude The longitude in radians.
      * @param {Number} latitude The latitude in radians.
-     * @returns {Number} The terrain height at the specified position.  If the position
-     *          is outside the rectangle, this method will extrapolate the height, which is likely to be wildly
-     *          incorrect for positions far outside the rectangle.
+     * @returns {Number} The terrain height at the specified position.  The position is clamped to
+     *          the rectangle, so expect incorrect results for positions far outside the rectangle.
      */
     QuantizedMeshTerrainData.prototype.interpolateHeight = function(rectangle, longitude, latitude) {
-        var u = (longitude - rectangle.west) / (rectangle.east - rectangle.west);
+        var u = CesiumMath.clamp((longitude - rectangle.west) / (rectangle.east - rectangle.west), 0.0, 1.0);
         u *= maxShort;
-        var v = (latitude - rectangle.south) / (rectangle.north - rectangle.south);
+        var v = CesiumMath.clamp((latitude - rectangle.south) / (rectangle.north - rectangle.south), 0.0, 1.0);
         v *= maxShort;
 
         var uBuffer = this._uValues;

--- a/Specs/Core/sampleTerrainSpec.js
+++ b/Specs/Core/sampleTerrainSpec.js
@@ -3,11 +3,13 @@ defineSuite([
         'Core/sampleTerrain',
         'Core/Cartographic',
         'Core/CesiumTerrainProvider',
+        'Specs/waitsForPromise',
         'ThirdParty/when'
     ], function(
         sampleTerrain,
         Cartographic,
         CesiumTerrainProvider,
+        waitsForPromise,
         when) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
@@ -134,5 +136,18 @@ defineSuite([
         expect(function() {
             sampleTerrain(terrainProvider, 11, undefined);
         }).toThrowDeveloperError();
+    });
+
+    it('works for a dodgy point right near the edge of a tile', function() {
+        var stkWorldTerrain = new CesiumTerrainProvider({
+            url : 'http://cesiumjs.org/stk-terrain/tilesets/world/tiles'
+        });
+
+        var positions = [new Cartographic(0.33179290856829535, 0.7363107781851078)];
+        var promise = sampleTerrain(stkWorldTerrain, 12, positions);
+
+        waitsForPromise(promise, function() {
+            expect(positions[0].height).toBeDefined();
+        });
     });
 });


### PR DESCRIPTION
sampleTerrain works by computing the tile that contains each of the positions it is sampling using `tilingScheme.positionToTileXY`.  For a position very near the edge of a tile, it is possible for this method to return a tile that does not actually contain the position (e.g. latitude is one ulp greater than the north bound).  I considered trying to avoid this, but doing so is tricky and a bit expensive.  So instead, this change clamps the coordinates coming in to `QuantizedMeshTerrainData.interpolateHeight` to be within the tile.

Fixes #2206
