### PR TITLE
Fix LabelVisualizer crash

### DIFF
--- a/Source/DataSources/LabelVisualizer.js
+++ b/Source/DataSources/LabelVisualizer.js
@@ -131,11 +131,11 @@ define([
                 var length = unusedIndexes.length;
                 if (length > 0) {
                     var index = unusedIndexes.pop();
-                    label.index = index;
+                    item.index = index;
                     label = labelCollection.get(index);
                 } else {
                     label = labelCollection.add();
-                    label.index = labelCollection.length - 1;
+                    item.index = labelCollection.length - 1;
                 }
                 label.id = entity;
                 item.label = label;

--- a/Specs/DataSources/BillboardVisualizerSpec.js
+++ b/Specs/DataSources/BillboardVisualizerSpec.js
@@ -180,6 +180,38 @@ defineSuite([
         });
     });
 
+    it('Reuses primitives when hiding one and showing another', function() {
+        var time = JulianDate.now();
+        var entityCollection = new EntityCollection();
+        visualizer = new BillboardVisualizer(scene, entityCollection);
+
+        var testObject = entityCollection.getOrCreateEntity('test');
+        testObject.position = new ConstantProperty(new Cartesian3(1234, 5678, 9101112));
+        testObject.billboard = new BillboardGraphics();
+        testObject.billboard.image = new ConstantProperty('Data/Images/Blue.png');
+        testObject.billboard.show = new ConstantProperty(true);
+
+        visualizer.update(time);
+
+        var billboardCollection = scene.primitives.get(0);
+        expect(billboardCollection.length).toEqual(1);
+
+        testObject.billboard.show = new ConstantProperty(false);
+
+        visualizer.update(time);
+
+        expect(billboardCollection.length).toEqual(1);
+
+        var testObject2 = entityCollection.getOrCreateEntity('test2');
+        testObject2.position = new ConstantProperty(new Cartesian3(1234, 5678, 9101112));
+        testObject2.billboard = new BillboardGraphics();
+        testObject2.billboard.image = new ConstantProperty('Data/Images/Blue.png');
+        testObject2.billboard.show = new ConstantProperty(true);
+
+        visualizer.update(time);
+        expect(billboardCollection.length).toEqual(1);
+    });
+
     it('clear hides billboards.', function() {
         var entityCollection = new EntityCollection();
         visualizer = new BillboardVisualizer(scene, entityCollection);

--- a/Specs/DataSources/LabelVisualizerSpec.js
+++ b/Specs/DataSources/LabelVisualizerSpec.js
@@ -203,6 +203,38 @@ defineSuite([
         visualizer.update(time);
     });
 
+    it('Reuses primitives when hiding one and showing another', function() {
+        var time = JulianDate.now();
+        var entityCollection = new EntityCollection();
+        visualizer = new LabelVisualizer(scene, entityCollection);
+
+        var testObject = entityCollection.getOrCreateEntity('test');
+        testObject.position = new ConstantProperty(new Cartesian3(1234, 5678, 9101112));
+        testObject.label = new LabelGraphics();
+        testObject.label.text = new ConstantProperty('a');
+        testObject.label.show = new ConstantProperty(true);
+
+        visualizer.update(time);
+
+        var labelCollection = scene.primitives.get(0);
+        expect(labelCollection.length).toEqual(1);
+
+        testObject.label.show = new ConstantProperty(false);
+
+        visualizer.update(time);
+
+        expect(labelCollection.length).toEqual(1);
+
+        var testObject2 = entityCollection.getOrCreateEntity('test2');
+        testObject2.position = new ConstantProperty(new Cartesian3(1234, 5678, 9101112));
+        testObject2.label = new LabelGraphics();
+        testObject2.label.text = new ConstantProperty('b');
+        testObject2.label.show = new ConstantProperty(true);
+
+        visualizer.update(time);
+        expect(labelCollection.length).toEqual(1);
+    });
+
     it('clear hides labels.', function() {
         var entityCollection = new EntityCollection();
         visualizer = new LabelVisualizer(scene, entityCollection);

--- a/Specs/DataSources/PointVisualizerSpec.js
+++ b/Specs/DataSources/PointVisualizerSpec.js
@@ -141,6 +141,36 @@ defineSuite([
         expect(bb.show).toEqual(testObject.point.show.getValue(time));
     });
 
+    it('Reuses primitives when hiding one and showing another', function() {
+        var time = JulianDate.now();
+        var entityCollection = new EntityCollection();
+        visualizer = new PointVisualizer(scene, entityCollection);
+
+        var testObject = entityCollection.getOrCreateEntity('test');
+        testObject.position = new ConstantProperty(new Cartesian3(1234, 5678, 9101112));
+        testObject.point = new PointGraphics();
+        testObject.point.show = new ConstantProperty(true);
+
+        visualizer.update(time);
+
+        var billboardCollection = scene.primitives.get(0);
+        expect(billboardCollection.length).toEqual(1);
+
+        testObject.point.show = new ConstantProperty(false);
+
+        visualizer.update(time);
+
+        expect(billboardCollection.length).toEqual(1);
+
+        var testObject2 = entityCollection.getOrCreateEntity('test2');
+        testObject2.position = new ConstantProperty(new Cartesian3(1234, 5678, 9101112));
+        testObject2.point = new PointGraphics();
+        testObject2.point.show = new ConstantProperty(true);
+
+        visualizer.update(time);
+        expect(billboardCollection.length).toEqual(1);
+    });
+
     it('clear hides billboards.', function() {
         var entityCollection = new EntityCollection();
         visualizer = new PointVisualizer(scene, entityCollection);


### PR DESCRIPTION
#2223 introduced a regression (due to a typo) that was not covered by any unit tests. (which @shunter promptly ran into).  This change adds unit tests and fixed the bug.
