### PR TITLE
Remove Firefox workaround

### DIFF
--- a/Source/Scene/Globe.js
+++ b/Source/Scene/Globe.js
@@ -925,15 +925,6 @@ define([
                 }
             }
 
-            // Firefox 33-34 has a regression that prevents the CORDIC implementation from compiling
-            // https://github.com/AnalyticalGraphicsInc/cesium/issues/2197
-            if (FeatureDetection.isFirefox()) {
-                var firefoxVersion = FeatureDetection.firefoxVersion();
-                if (firefoxVersion[0] >= 33 && firefoxVersion[0] <= 34) {
-                    shaderDefines.push('DISABLE_CORDIC');
-                }
-            }
-
             surfaceShaderSet.baseVertexShaderSource = new ShaderSource({
                 defines : shaderDefines,
                 sources : [GlobeVS, getPositionMode, get2DYPositionFraction]


### PR DESCRIPTION
Firefox 33.0.2 and Firefox 34.0 both work at head of master with this workaround removed (because of backported changes from the Firefox team).  Removing this means 33.0 and 33.01 probably won't work, but historically we're not that fine grained in support and telling users to be on 33.0.2 seems like the right decision; especially since all 33 versions of Firefox will auto-upgrade.

Also, since I don't trust just myself, can other people try this branch in Firefox stable and confirm my findings?

@shunter Since you did the work to add this, any problem with removing it?

CC #2197
