### PR TITLE
Fix documentation of Scene properties accessors

### DIFF
--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -632,7 +632,6 @@ define([
          * @memberof Scene.prototype
          *
          * @type {TerrainProvider}
-         * @readonly
          */
         terrainProvider : {
             get : function() {
@@ -690,6 +689,7 @@ define([
         /**
          * @memberof Scene.prototype
          * @private
+         * @readonly
          */
         context : {
             get : function() {
@@ -725,6 +725,7 @@ define([
          * Gets whether or not the scene is optimized for 3D only viewing.
          * @memberof Scene.prototype
          * @type {Boolean}
+         * @readonly
          */
         scene3DOnly : {
             get : function() {
@@ -738,6 +739,7 @@ define([
          * other factors that could prevent OIT from functioning on a given system configuration.
          * @memberof Scene.prototype
          * @type {Boolean}
+         * @readonly
          */
         orderIndependentTranslucency : {
             get : function() {
@@ -749,6 +751,7 @@ define([
          * Gets the unique identifier for this scene.
          * @memberof Scene.prototype
          * @type {String}
+         * @readonly
          */
         id : {
             get : function() {


### PR DESCRIPTION
Added or removed `@readonly` annotations to match actual implementation.
