### PR TITLE
Make polyline Sandcastle examples follow surface

### DIFF
--- a/Apps/Sandcastle/gallery/Materials.html
+++ b/Apps/Sandcastle/gallery/Materials.html
@@ -459,12 +459,12 @@ function createPrimitives(scene) {
 
     var polylines = scene.primitives.add(new Cesium.PolylineCollection());
     polyline = polylines.add({
-        positions : Cesium.Cartesian3.fromDegreesArray([
-            -110.0, 42.0,
-            -85.0, 36.0,
-            -100.0, 25.0,
-             -77.0, 12.0
-        ]),
+        positions : Cesium.PolylinePipeline.generateCartesianArc({
+            positions : Cesium.Cartesian3.fromDegreesArray([-110.0, 42.0,
+                                                            -85.0, 36.0,
+                                                            -100.0, 25.0,
+                                                            -77.0, 12.0])
+        }),
         width : 10.0,
         show : false
     });

--- a/Apps/Sandcastle/gallery/Polylines.html
+++ b/Apps/Sandcastle/gallery/Polylines.html
@@ -32,64 +32,64 @@ function createPrimitives(scene) {
 
     // A simple polyline with two points.
     var polyline = polylines.add({
-        positions : Cesium.Cartesian3.fromDegreesArray([
-            -120.0, 40.0,
-            -110.0, 30.0
-        ]),
+        positions : Cesium.PolylinePipeline.generateCartesianArc({
+            positions : Cesium.Cartesian3.fromDegreesArray([-120.0, 40.0,
+                                                            -110.0, 30.0])
+        }),
         material : Cesium.Material.fromType('Color', {
             color : new Cesium.Color(1.0, 1.0, 1.0, 1.0)
         })
     });
-    Sandcastle.declare(polyline);   // For highlighting on mouseover in Sandcastle.
+    Sandcastle.declare(polyline); // For highlighting on mouseover in Sandcastle.
 
     // Apply a polyline outline material
     var widePolyline = polylines.add({
-        positions : Cesium.Cartesian3.fromDegreesArray([
-            -105.0, 40.0,
-            -100.0, 38.0,
-            -105.0, 35.0,
-            -100.0, 32.0
-        ]),
+        positions : Cesium.PolylinePipeline.generateCartesianArc({
+            positions : Cesium.Cartesian3.fromDegreesArray([-105.0, 40.0,
+                                                            -100.0, 38.0,
+                                                            -105.0, 35.0,
+                                                            -100.0, 32.0])
+        }),
         material : Cesium.Material.fromType(Cesium.Material.PolylineOutlineType, {
             outlineWidth : 5.0
         }),
         width : 10.0
     });
-    Sandcastle.declare(widePolyline);   // For highlighting on mouseover in Sandcastle.
+    Sandcastle.declare(widePolyline); // For highlighting on mouseover in Sandcastle.
 
     // Apply a polyline glow material
     var coloredPolyline = polylines.add({
-        positions : Cesium.Cartesian3.fromDegreesArray([
-            -95.0, 30.0,
-            -85.0, 40.0
-        ]),
+        positions : Cesium.PolylinePipeline.generateCartesianArc({
+            positions : Cesium.Cartesian3.fromDegreesArray([-95.0, 30.0,
+                                                            -85.0, 40.0])
+        }),
         material : Cesium.Material.fromType(Cesium.Material.PolylineGlowType, {
             glowPower : 0.25,
             color : new Cesium.Color(1.0, 0.5, 0.0, 1.0)
         }),
         width : 10.0
     });
-    Sandcastle.declare(coloredPolyline);    // For highlighting on mouseover in Sandcastle.
-    
+    Sandcastle.declare(coloredPolyline); // For highlighting on mouseover in Sandcastle.
+
     // A polyline loop
     var loopPolyline = polylines.add({
-        positions : Cesium.Cartesian3.fromDegreesArray([
-            -105.0, 30.0,
-            -105.0, 25.0,
-            -100.0, 22.0,
-            -100.0, 28.0
-        ]),
+        positions : Cesium.PolylinePipeline.generateCartesianArc({
+            positions : Cesium.Cartesian3.fromDegreesArray([-105.0, 30.0,
+                                                            -105.0, 25.0,
+                                                            -100.0, 22.0,
+                                                            -100.0, 28.0])
+        }),
         width : 3.0,
         loop : true
     });
-    Sandcastle.declare(loopPolyline);   // For highlighting on mouseover in Sandcastle.
+    Sandcastle.declare(loopPolyline); // For highlighting on mouseover in Sandcastle.
 
     // Draw a line in a local reference frame
     // The arrow points to the east, i.e. along the local x-axis.
     var localPolylines = scene.primitives.add(new Cesium.PolylineCollection());
     var center = Cesium.Cartesian3.fromDegrees(-80.0, 35.0);
     localPolylines.modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(center);
-    
+
     var localPolyline = localPolylines.add({
         positions : [
             new Cesium.Cartesian3(0.0, 0.0, 0.0),
@@ -98,7 +98,7 @@ function createPrimitives(scene) {
         width : 10.0,
         material : Cesium.Material.fromType(Cesium.Material.PolylineArrowType)
     });
-    Sandcastle.declare(localPolyline);  // For highlighting on mouseover in Sandcastle.
+    Sandcastle.declare(localPolyline); // For highlighting on mouseover in Sandcastle.
 }
 
 var viewer = new Cesium.Viewer('cesiumContainer');


### PR DESCRIPTION
Two eamples that use Polylines were making them go well under the surface of the earth.  I took the easy route and used generateCartesianArc, but I guess in the long wrong we should consider adding a `followSurface` option to `Polyline` as well.  Fixes #2109
