### PR TITLE
Remove need to explicitely set depthTest for geometry outlines.

### DIFF
--- a/Apps/Sandcastle/gallery/Box Outline.html
+++ b/Apps/Sandcastle/gallery/Box Outline.html
@@ -64,9 +64,6 @@ scene.primitives.add(new Cesium.Primitive({
     appearance : new Cesium.PerInstanceColorAppearance({
         flat : true,
         renderState : {
-            depthTest : {
-                enabled : true
-            },
             lineWidth : Math.min(2.0, scene.maximumAliasedLineWidth)
         }
     })

--- a/Apps/Sandcastle/gallery/Circle Outline.html
+++ b/Apps/Sandcastle/gallery/Circle Outline.html
@@ -51,9 +51,6 @@ scene.primitives.add(new Cesium.Primitive({
     appearance : new Cesium.PerInstanceColorAppearance({
         flat : true,
         renderState : {
-            depthTest : {
-                enabled : true
-            },
             lineWidth : Math.min(2.0, scene.maximumAliasedLineWidth)
         }
     })
@@ -84,9 +81,6 @@ scene.primitives.add(new Cesium.Primitive({
     appearance : new Cesium.PerInstanceColorAppearance({
         flat : true,
         renderState : {
-            depthTest : {
-                enabled : true
-            },
             lineWidth : Math.min(2.0, scene.maximumAliasedLineWidth)
         }
     })

--- a/Apps/Sandcastle/gallery/Corridor Outline.html
+++ b/Apps/Sandcastle/gallery/Corridor Outline.html
@@ -76,9 +76,6 @@ scene.primitives.add(new Cesium.Primitive({
     appearance : new Cesium.PerInstanceColorAppearance({
         flat : true,
         renderState : {
-            depthTest : {
-                enabled : true
-            },
             lineWidth : Math.min(2.0, scene.maximumAliasedLineWidth)
         }
     })

--- a/Apps/Sandcastle/gallery/Cylinder Outline.html
+++ b/Apps/Sandcastle/gallery/Cylinder Outline.html
@@ -64,9 +64,6 @@ scene.primitives.add(new Cesium.Primitive({
     appearance : new Cesium.PerInstanceColorAppearance({
         flat : true,
         renderState : {
-            depthTest : {
-                enabled : true
-            },
             lineWidth : Math.min(2.0, scene.maximumAliasedLineWidth)
         }
     })

--- a/Apps/Sandcastle/gallery/Ellipse Outline.html
+++ b/Apps/Sandcastle/gallery/Ellipse Outline.html
@@ -78,9 +78,6 @@ scene.primitives.add(new Cesium.Primitive({
     appearance : new Cesium.PerInstanceColorAppearance({
         flat : true,
         renderState : {
-            depthTest : {
-                enabled : true
-            },
             lineWidth : Math.min(2.0, scene.maximumAliasedLineWidth)
         }
     })

--- a/Apps/Sandcastle/gallery/Ellipsoid Outline.html
+++ b/Apps/Sandcastle/gallery/Ellipsoid Outline.html
@@ -61,9 +61,6 @@ scene.primitives.add(new Cesium.Primitive({
     appearance : new Cesium.PerInstanceColorAppearance({
         flat : true,
         renderState : {
-            depthTest : {
-                enabled : true
-            },
             lineWidth : Math.min(2.0, scene.maximumAliasedLineWidth)
         }
     })

--- a/Apps/Sandcastle/gallery/Geometry and Appearances.html
+++ b/Apps/Sandcastle/gallery/Geometry and Appearances.html
@@ -133,9 +133,6 @@ primitives.add(new Cesium.Primitive({
         flat : true,
         translucent : false,
         renderState : {
-            depthTest : {
-                enabled : true
-            },
             lineWidth : Math.min(4.0, scene.maximumAliasedLineWidth)
         }
     })
@@ -277,9 +274,6 @@ primitives.add(new Cesium.Primitive({
         flat : true,
         translucent : false,
         renderState : {
-            depthTest : {
-                enabled : true
-            },
             lineWidth : Math.min(4.0, scene.maximumAliasedLineWidth)
         }
     })
@@ -392,9 +386,6 @@ primitives.add(new Cesium.Primitive({
         flat : true,
         translucent : false,
         renderState : {
-            depthTest : {
-                enabled : true
-            },
             lineWidth : Math.min(4.0, scene.maximumAliasedLineWidth)
         }
     })
@@ -442,9 +433,6 @@ primitives.add(new Cesium.Primitive({
         flat : true,
         translucent : false,
         renderState : {
-            depthTest : {
-                enabled : true
-            },
             lineWidth : Math.min(4.0, scene.maximumAliasedLineWidth)
         }
     })
@@ -737,9 +725,6 @@ primitives.add(new Cesium.Primitive({
     appearance : new Cesium.PerInstanceColorAppearance({
         flat : true,
         renderState : {
-            depthTest : {
-                enabled : true
-            },
             // Override the appearance render state to change the
             // line width on system's that support it (Linx/Mac).
             lineWidth : Math.min(4.0, scene.maximumAliasedLineWidth)
@@ -899,9 +884,6 @@ primitives.add(new Cesium.Primitive({
         flat : true,
         translucent : false,
         renderState : {
-            depthTest : {
-                enabled : true
-            },
             lineWidth : Math.min(4.0, scene.maximumAliasedLineWidth)
         }
     })
@@ -997,9 +979,6 @@ primitives.add(new Cesium.Primitive({
         flat : true,
         translucent : false,
         renderState : {
-            depthTest : {
-                enabled : true
-            },
             lineWidth : 1.0
         }
     })

--- a/Apps/Sandcastle/gallery/Polygon Outline.html
+++ b/Apps/Sandcastle/gallery/Polygon Outline.html
@@ -105,9 +105,6 @@ scene.primitives.add(new Cesium.Primitive({
     appearance : new Cesium.PerInstanceColorAppearance({
         flat : true,
         renderState : {
-            depthTest : {
-                enabled : true
-            },
             lineWidth : Math.min(2.0, scene.maximumAliasedLineWidth)
         }
     })

--- a/Apps/Sandcastle/gallery/Polyline Volume Outline.html
+++ b/Apps/Sandcastle/gallery/Polyline Volume Outline.html
@@ -93,9 +93,6 @@ scene.primitives.add(new Cesium.Primitive({
     appearance : new Cesium.PerInstanceColorAppearance({
         flat : true,
         renderState : {
-            depthTest : {
-                enabled : true
-            },
             lineWidth : Math.min(2.0, scene.maximumAliasedLineWidth)
         }
     })

--- a/Apps/Sandcastle/gallery/Rectangle Outline.html
+++ b/Apps/Sandcastle/gallery/Rectangle Outline.html
@@ -49,9 +49,6 @@ scene.primitives.add(new Cesium.Primitive({
     appearance : new Cesium.PerInstanceColorAppearance({
         flat : true,
         renderState : {
-            depthTest : {
-                enabled : true
-            },
             lineWidth : Math.min(2.0, scene.maximumAliasedLineWidth)
         }
     })

--- a/Apps/Sandcastle/gallery/Simple Polyline.html
+++ b/Apps/Sandcastle/gallery/Simple Polyline.html
@@ -85,9 +85,6 @@ scene.primitives.add(new Cesium.Primitive({
     appearance : new Cesium.PerInstanceColorAppearance({
         flat : true,
         renderState : {
-            depthTest : {
-                enabled : true
-            },
             lineWidth : Math.min(2.0, scene.maximumAliasedLineWidth)
         }
     })
@@ -99,9 +96,6 @@ scene.primitives.add(new Cesium.Primitive({
     appearance : new Cesium.PerInstanceColorAppearance({
         flat : true,
         renderState : {
-            depthTest : {
-                enabled : true
-            },
             lineWidth : Math.min(2.0, scene.maximumAliasedLineWidth)
         }
     })

--- a/Apps/Sandcastle/gallery/Sphere Outline.html
+++ b/Apps/Sandcastle/gallery/Sphere Outline.html
@@ -60,9 +60,6 @@ scene.primitives.add(new Cesium.Primitive({
     appearance : new Cesium.PerInstanceColorAppearance({
         flat : true,
         renderState : {
-            depthTest : {
-                enabled : true
-            },
             lineWidth : Math.min(2.0, scene.maximumAliasedLineWidth)
         }
     })

--- a/Apps/Sandcastle/gallery/Wall Outline.html
+++ b/Apps/Sandcastle/gallery/Wall Outline.html
@@ -51,9 +51,6 @@ scene.primitives.add(new Cesium.Primitive({
     appearance : new Cesium.PerInstanceColorAppearance({
         flat : true,
         renderState : {
-            depthTest : {
-                enabled : true
-            },
             lineWidth : Math.min(2.0, scene.maximumAliasedLineWidth)
         }
     })

--- a/Source/DataSources/EllipseGeometryUpdater.js
+++ b/Source/DataSources/EllipseGeometryUpdater.js
@@ -609,9 +609,6 @@ define([
                     flat : true,
                     translucent : translucent,
                     renderState : {
-                        depthTest : {
-                            enabled : !translucent
-                        },
                         lineWidth : geometryUpdater._scene.clampLineWidth(outlineWidth)
                     }
                 }),

--- a/Source/DataSources/EllipsoidGeometryUpdater.js
+++ b/Source/DataSources/EllipsoidGeometryUpdater.js
@@ -645,9 +645,6 @@ define([
                     flat : true,
                     translucent : translucent,
                     renderState : {
-                        depthTest : {
-                            enabled : !translucent
-                        },
                         lineWidth : this._geometryUpdater._scene.clampLineWidth(outlineWidth)
                     }
                 }),

--- a/Source/DataSources/PolygonGeometryUpdater.js
+++ b/Source/DataSources/PolygonGeometryUpdater.js
@@ -594,9 +594,6 @@ define([
                     flat : true,
                     translucent : translucent,
                     renderState : {
-                        depthTest : {
-                            enabled : !translucent
-                        },
                         lineWidth : geometryUpdater._scene.clampLineWidth(outlineWidth)
                     }
                 }),

--- a/Source/DataSources/RectangleGeometryUpdater.js
+++ b/Source/DataSources/RectangleGeometryUpdater.js
@@ -604,9 +604,6 @@ define([
                     flat : true,
                     translucent : translucent,
                     renderState : {
-                        depthTest : {
-                            enabled : !translucent
-                        },
                         lineWidth : geometryUpdater._scene.clampLineWidth(outlineWidth)
                     }
                 }),

--- a/Source/DataSources/StaticOutlineGeometryBatch.js
+++ b/Source/DataSources/StaticOutlineGeometryBatch.js
@@ -74,9 +74,6 @@ define([
                         flat : true,
                         translucent : this.translucent,
                         renderState : {
-                            depthTest : {
-                                enabled : !this.translucent
-                            },
                             lineWidth : this.width
                         }
                     })

--- a/Source/DataSources/WallGeometryUpdater.js
+++ b/Source/DataSources/WallGeometryUpdater.js
@@ -577,9 +577,6 @@ define([
                     flat : true,
                     translucent : translucent,
                     renderState : {
-                        depthTest : {
-                            enabled : !translucent
-                        },
                         lineWidth : geometryUpdater._scene.clampLineWidth(outlineWidth)
                     }
                 }),

--- a/Source/Scene/Appearance.js
+++ b/Source/Scene/Appearance.js
@@ -1,6 +1,7 @@
 /*global define*/
 define([
         '../Core/clone',
+        '../Core/combine',
         '../Core/defaultValue',
         '../Core/defined',
         '../Core/defineProperties',
@@ -8,6 +9,7 @@ define([
         './CullFace'
     ], function(
         clone,
+        combine,
         defaultValue,
         defined,
         defineProperties,
@@ -183,7 +185,7 @@ define([
     /**
      * @private
      */
-    Appearance.getDefaultRenderState = function(translucent, closed) {
+    Appearance.getDefaultRenderState = function(translucent, closed, existing) {
         var rs = {
             depthTest : {
                 enabled : true
@@ -200,6 +202,10 @@ define([
                 enabled : true,
                 face : CullFace.BACK
             };
+        }
+
+        if (defined(existing)) {
+            rs = combine(existing, rs, true);
         }
 
         return rs;

--- a/Source/Scene/DebugAppearance.js
+++ b/Source/Scene/DebugAppearance.js
@@ -122,7 +122,7 @@ define([
 
         this._vertexShaderSource = defaultValue(options.vertexShaderSource, vs);
         this._fragmentShaderSource = defaultValue(options.fragmentShaderSource, fs);
-        this._renderState = defaultValue(options.renderState, Appearance.getDefaultRenderState(false, false));
+        this._renderState = Appearance.getDefaultRenderState(false, false, options.renderState);
         this._closed = defaultValue(options.closed, false);
 
         // Non-derived members

--- a/Source/Scene/EllipsoidSurfaceAppearance.js
+++ b/Source/Scene/EllipsoidSurfaceAppearance.js
@@ -85,7 +85,7 @@ define([
 
         this._vertexShaderSource = defaultValue(options.vertexShaderSource, EllipsoidSurfaceAppearanceVS);
         this._fragmentShaderSource = defaultValue(options.fragmentShaderSource, EllipsoidSurfaceAppearanceFS);
-        this._renderState = defaultValue(options.renderState, Appearance.getDefaultRenderState(translucent, !aboveGround));
+        this._renderState = Appearance.getDefaultRenderState(translucent, !aboveGround, options.renderState);
         this._closed = false;
 
         // Non-derived members

--- a/Source/Scene/MaterialAppearance.js
+++ b/Source/Scene/MaterialAppearance.js
@@ -95,7 +95,7 @@ define([
 
         this._vertexShaderSource = defaultValue(options.vertexShaderSource, materialSupport.vertexShaderSource);
         this._fragmentShaderSource = defaultValue(options.fragmentShaderSource, materialSupport.fragmentShaderSource);
-        this._renderState = defaultValue(options.renderState, Appearance.getDefaultRenderState(translucent, closed));
+        this._renderState = Appearance.getDefaultRenderState(translucent, closed, options.renderState);
         this._closed = closed;
 
         // Non-derived members

--- a/Source/Scene/PerInstanceColorAppearance.js
+++ b/Source/Scene/PerInstanceColorAppearance.js
@@ -110,7 +110,7 @@ define([
 
         this._vertexShaderSource = defaultValue(options.vertexShaderSource, vs);
         this._fragmentShaderSource = defaultValue(options.fragmentShaderSource, fs);
-        this._renderState = defaultValue(options.renderState, Appearance.getDefaultRenderState(translucent, closed));
+        this._renderState = Appearance.getDefaultRenderState(translucent, closed, options.renderState);
         this._closed = closed;
 
         // Non-derived members

--- a/Source/Scene/PolylineColorAppearance.js
+++ b/Source/Scene/PolylineColorAppearance.js
@@ -86,7 +86,7 @@ define([
 
         this._vertexShaderSource = defaultValue(options.vertexShaderSource, defaultVertexShaderSource);
         this._fragmentShaderSource = defaultValue(options.fragmentShaderSource, defaultFragmentShaderSource);
-        this._renderState = defaultValue(options.renderState, Appearance.getDefaultRenderState(translucent, closed));
+        this._renderState = Appearance.getDefaultRenderState(translucent, closed, options.renderState);
         this._closed = closed;
 
         // Non-derived members

--- a/Source/Scene/PolylineMaterialAppearance.js
+++ b/Source/Scene/PolylineMaterialAppearance.js
@@ -88,7 +88,7 @@ define([
 
         this._vertexShaderSource = defaultValue(options.vertexShaderSource, defaultVertexShaderSource);
         this._fragmentShaderSource = defaultValue(options.fragmentShaderSource, defaultFragmentShaderSource);
-        this._renderState = defaultValue(options.renderState, Appearance.getDefaultRenderState(translucent, closed));
+        this._renderState = Appearance.getDefaultRenderState(translucent, closed, options.renderState);
         this._closed = closed;
 
         // Non-derived members


### PR DESCRIPTION
We already compute the correct value automatically in `Appearance.getDefaultRenderState`. This change updates `Appearance.getDefaultRenderState` to apply unset defaults to the specified user options and remove the explicit settings throughout the code.

Also fixed a minor issue in DataSource outlines that I uncovered while testing.
