### PR TITLE
Minor render loop cleanup.

### DIFF
--- a/Source/Core/requestAnimationFrame.js
+++ b/Source/Core/requestAnimationFrame.js
@@ -1,8 +1,10 @@
 /*global define*/
 define([
-        './defined'
+        './defined',
+        './getTimestamp'
     ], function(
-        defined) {
+        defined,
+        getTimestamp) {
     "use strict";
 
     var implementation = window.requestAnimationFrame;
@@ -21,13 +23,14 @@ define([
 
         // build an implementation based on setTimeout
         if (!defined(implementation)) {
+            var msPerFrame = 1000.0 / 60.0;
             var lastFrameTime = 0;
             implementation = function(callback) {
-                var currentTime = Date.now();
+                var currentTime = getTimestamp();
 
                 // schedule the callback to target 60fps, 16.7ms per frame,
                 // accounting for the time taken by the callback
-                var delay = Math.max(16 - (currentTime - lastFrameTime), 0);
+                var delay = Math.max(msPerFrame - (currentTime - lastFrameTime), 0);
                 lastFrameTime = currentTime + delay;
 
                 return setTimeout(function() {

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -11,7 +11,6 @@ define([
         '../../Core/DeveloperError',
         '../../Core/Ellipsoid',
         '../../Core/formatError',
-        '../../Core/getTimestamp',
         '../../Core/requestAnimationFrame',
         '../../Core/ScreenSpaceEventHandler',
         '../../Scene/BingMapsImageryProvider',
@@ -35,7 +34,6 @@ define([
         DeveloperError,
         Ellipsoid,
         formatError,
-        getTimestamp,
         requestAnimationFrame,
         ScreenSpaceEventHandler,
         BingMapsImageryProvider,
@@ -55,9 +53,9 @@ define([
 
     function startRenderLoop(widget) {
         widget._renderLoopRunning = true;
-        widget._lastFrameTime = getTimestamp();
 
-        function render() {
+        var lastFrameTime = 0;
+        function render(frameTime) {
             if (widget.isDestroyed()) {
                 return;
             }
@@ -70,15 +68,13 @@ define([
                         widget.render();
                         requestAnimationFrame(render);
                     } else {
-                        var lastFrameTime = widget._lastFrameTime;
                         var interval = 1000.0 / targetFrameRate;
-                        var now = getTimestamp();
-                        var delta = now - lastFrameTime;
+                        var delta = frameTime - lastFrameTime;
 
                         if (delta > interval) {
                             widget.resize();
                             widget.render();
-                            widget._lastFrameTime = now - (delta % interval);
+                            lastFrameTime = frameTime - (delta % interval);
                         }
                         requestAnimationFrame(render);
                     }
@@ -233,7 +229,6 @@ define([
         this._resolutionScale = 1.0;
         this._forceResize = false;
         this._clock = defined(options.clock) ? options.clock : new Clock();
-        this._lastFrameTime = undefined;
 
         configureCanvasSize(this);
 


### PR DESCRIPTION
If targeting a specific fps; there's no need for us to call `getTimestamp` ourselves because the requestAnimationFrame callback passes us in the frame time (specifically a DOMHighResTimeStamp)

I also made a tweak to the requestAnimationFrame polyfill to use `getTimestamp` instead of `Date.now` so that we use higher resolution timers if they are available.
