### PR TITLE
Triangulation RNG

### DIFF
--- a/Source/Core/PolygonPipeline.js
+++ b/Source/Core/PolygonPipeline.js
@@ -329,24 +329,14 @@ define([
         return newPolygonVertices;
     }
 
-    /**
-     * Use seeded pseudo-random number to be testable.
-     *
-     * @param {Number} length
-     * @returns {Number} Random integer from 0 to <code>length - 1</code>
-     *
-     * @private
-     */
     function getRandomIndex(length) {
-        var random = '0.' + Math.sin(rseed).toString().substr(5);
-        rseed += 0.2;
+        var random = CesiumMath.nextRandomNumber();
         var i = Math.floor(random * length);
         if (i === length) {
             i--;
         }
         return i;
     }
-    var rseed = 0;
 
     function indexedEdgeCrossZ(p0Index, p1Index, vertexIndex, array) {
         var p0 = array[p0Index].position;
@@ -812,15 +802,6 @@ define([
 
         // Recursive chop
         return randomChop(nodeArray);
-    };
-
-    /**
-     * This function is used for predictable testing.
-     *
-     * @private
-     */
-    PolygonPipeline.resetSeed = function(seed) {
-        rseed = defaultValue(seed, 0);
     };
 
     /**

--- a/Specs/Core/PolygonPipelineSpec.js
+++ b/Specs/Core/PolygonPipelineSpec.js
@@ -4,18 +4,20 @@ defineSuite([
         'Core/Cartesian2',
         'Core/Cartesian3',
         'Core/Ellipsoid',
+        'Core/Math',
         'Core/WindingOrder'
     ], function(
         PolygonPipeline,
         Cartesian2,
         Cartesian3,
         Ellipsoid,
+        CesiumMath,
         WindingOrder) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     beforeEach(function() {
-        PolygonPipeline.resetSeed();
+        CesiumMath.setRandomNumberSeed(0.0);
     });
 
     it('removeDuplicates removes duplicate points', function() {
@@ -170,10 +172,7 @@ defineSuite([
                          new Cartesian2(2,6), new Cartesian2(6,6), new Cartesian2(6,9), new Cartesian2(0,9)];
 
         var indices = PolygonPipeline.triangulate(positions);
-        expect(indices).toEqual([ 0, 4, 7, 0, 3, 4, 0, 2, 3, 4, 6, 7, 4, 5, 6, 0, 1, 2 ]);
-
-        indices = PolygonPipeline.triangulate(positions);
-        expect(indices).toEqual([ 0, 3, 7, 0, 1, 3, 1, 2, 3, 3, 4, 7, 4, 5, 7, 5, 6, 7 ]);
+        expect(indices).toEqual([ 0, 3, 7, 0, 2, 3, 0, 1, 2, 3, 4, 7, 4, 6, 7, 4, 5, 6 ]);
 
         /* Do it a few times to make sure we never get stuck on it */
         for (var i = 0; i < 30; i++) {
@@ -195,14 +194,11 @@ defineSuite([
      * 0           1
      */
     it('triangulates a convex polygon with vertical and horizontal sides', function() {
-        var positions = [new Cartesian2(0,0), new Cartesian2(6,0), new Cartesian2(6,3), new Cartesian2(2,3),
-                         new Cartesian2(2,6), new Cartesian2(6,6), new Cartesian2(6,9), new Cartesian2(0,9)];
+        var positions = [new Cartesian2(0,0), new Cartesian2(6,0), new Cartesian2(6,3), new Cartesian2(8,3),
+                         new Cartesian2(8,6), new Cartesian2(6,6), new Cartesian2(6,9), new Cartesian2(0,9)];
 
         var indices = PolygonPipeline.triangulate(positions);
-        expect(indices).toEqual([ 0, 4, 7, 0, 3, 4, 0, 2, 3, 4, 6, 7, 4, 5, 6, 0, 1, 2 ]);
-
-        indices = PolygonPipeline.triangulate(positions);
-        expect(indices).toEqual([ 0, 3, 7, 0, 1, 3, 1, 2, 3, 3, 4, 7, 4, 5, 7, 5, 6, 7 ]);
+        expect(indices).toEqual([ 0, 2, 7, 0, 1, 2, 2, 3, 7, 3, 5, 7, 5, 6, 7, 3, 4, 5 ]);
 
         /* Do it a few times to make sure we never get stuck on it */
         for (var i = 0; i < 30; i++) {
@@ -216,7 +212,6 @@ defineSuite([
                 new Cartesian2(0.0, 1.0), new Cartesian2(1.9, 0.5)];
 
         var indices = PolygonPipeline.triangulate(positions);
-
         expect(indices).toEqual([ 0, 1, 7, 1, 2, 7, 2, 3, 7, 3, 6, 7, 3, 5, 6, 3, 4, 5 ]);
     });
 
@@ -225,9 +220,9 @@ defineSuite([
                     new Cartesian2(40, 2), new Cartesian2(10, 5), new Cartesian2(30, 10), new Cartesian2(25, 20),
                     new Cartesian2(20,20), new Cartesian2(10,15), new Cartesian2(15, 10), new Cartesian2(8, 10),
                     new Cartesian2(-1, 3)];
-        var indices = PolygonPipeline.triangulate(positions);
 
-        expect(indices).toEqual([ 0, 11, 12, 0, 10, 11, 0, 5, 10, 5, 6, 10, 6, 8, 10, 8, 9, 10, 6, 7, 8, 0, 4, 5, 0, 1, 4, 1, 3, 4, 1, 2, 3 ]);
+        var indices = PolygonPipeline.triangulate(positions);
+        expect(indices).toEqual([ 0, 1, 12, 1, 5, 12, 1, 4, 5, 1, 2, 4, 5, 11, 12, 2, 3, 4, 5, 10, 11, 5, 6, 10, 6, 9, 10, 6, 7, 9, 7, 8, 9 ]);
 
         /* Try it a bunch of times to make sure we can never get stuck on it */
         for (var i = 0; i < 50; i++) {
@@ -246,9 +241,9 @@ defineSuite([
      */
     it('triangulates a polygon with a side that intersects on of its other vertices', function() {
         var positions = [new Cartesian2(0,0), new Cartesian2(0, -5), new Cartesian2(2,0), new Cartesian2(4, -5), new Cartesian2(4, 0)];
-        var indices = PolygonPipeline.triangulate(positions);
 
-        expect(indices).toEqual([ 2, 3, 4, 0, 1, 2 ]);
+        var indices = PolygonPipeline.triangulate(positions);
+        expect(indices).toEqual([ 0, 1, 2, 2, 3, 4 ]);
     });
 
     /*
@@ -263,8 +258,8 @@ defineSuite([
     it('triangulates a polygon with a side that intersects on of its other vertices and superfluous vertices', function() {
         var positions = [ new Cartesian2(0,0), new Cartesian2(2, -5), new Cartesian2(4,0), new Cartesian2(6, -5), new Cartesian2(8, 0),
                           new Cartesian2(6,0), new Cartesian2(2,0) ];
-        var indices = PolygonPipeline.triangulate(positions);
 
+        var indices = PolygonPipeline.triangulate(positions);
         expect(indices).toEqual([ 0, 1, 2, 2, 3, 4 ]);
     });
 
@@ -281,9 +276,9 @@ defineSuite([
     it('triangulations a polygon with a "tucked" vertex', function() {
         var positions = [new Cartesian2(0,0), new Cartesian2(5,0), new Cartesian2(5,2), new Cartesian2(1, 2),
                          new Cartesian2(3, 2), new Cartesian2(3,4), new Cartesian2(0,4)];
-        var indices = PolygonPipeline.triangulate(positions);
 
-        expect(indices).toEqual([ 0, 4, 6, 0, 2, 4, 4, 5, 6, 0, 1, 2 ]);
+        var indices = PolygonPipeline.triangulate(positions);
+        expect(indices).toEqual([ 0, 1, 6, 1, 4, 6, 1, 2, 4, 4, 5, 6 ]);
     });
 
     it('throws without positions', function() {


### PR DESCRIPTION
Change the triangulation RNG to the Mersenne Twister. 

This is a PR into `triangulateCleanUp`. I made this separate because it changed all of the indices in the tests. I verified that the indices are correct and can post screen shots of the wireframes if needed.
