### PR TITLE
Simplify Math functions.

### DIFF
--- a/Source/Core/Math.js
+++ b/Source/Core/Math.js
@@ -478,19 +478,7 @@ define([
             throw new DeveloperError('x is required.');
         }
         //>>includeEnd('debug');
-        var epsilon10 = CesiumMath.EPSILON10;
-        var pi = CesiumMath.PI;
-        var two_pi = CesiumMath.TWO_PI;
-        while (x < -(pi + epsilon10)) {
-            x += two_pi;
-        }
-        if (x < -pi) {
-            return -pi;
-        }
-        while (x > pi + epsilon10) {
-            x -= two_pi;
-        }
-        return x > pi ? pi : x;
+        return CesiumMath.zeroToTwoPi(x + CesiumMath.PI) - CesiumMath.PI;
     };
 
     /**
@@ -505,10 +493,7 @@ define([
             throw new DeveloperError('x is required.');
         }
         //>>includeEnd('debug');
-        var value = x % CesiumMath.TWO_PI;
-        // We do a second modules here if we add 2Pi to ensure that we don't have any numerical issues with very
-        // small negative values.
-        return (value < 0.0) ? (value + CesiumMath.TWO_PI) % CesiumMath.TWO_PI : value;
+        return CesiumMath.mod(x, CesiumMath.TWO_PI);
     };
 
     /**

--- a/Specs/Core/MathSpec.js
+++ b/Specs/Core/MathSpec.js
@@ -160,13 +160,13 @@ defineSuite([
     it('negativePiToPi positive', function() {
         expect(CesiumMath.negativePiToPi((Math.PI / 2) * Math.PI)).toEqualEpsilon((Math.PI / 2) * Math.PI - CesiumMath.TWO_PI, CesiumMath.EPSILON16);
         expect(CesiumMath.negativePiToPi(Math.PI / 0.5)).toEqualEpsilon(0.0, CesiumMath.EPSILON16);
-        expect(CesiumMath.negativePiToPi(Math.PI + CesiumMath.EPSILON10)).toEqualEpsilon(Math.PI, CesiumMath.EPSILON16);
+        expect(CesiumMath.negativePiToPi(Math.PI + CesiumMath.EPSILON10)).toEqualEpsilon(-Math.PI, CesiumMath.EPSILON9);
     });
 
     it('negativePiToPi negative', function() {
         expect(CesiumMath.negativePiToPi(-Math.PI / 0.5)).toEqualEpsilon(0.0, CesiumMath.EPSILON16);
         expect(CesiumMath.negativePiToPi(-(Math.PI / 2) * Math.PI)).toEqualEpsilon(-(Math.PI / 2) * Math.PI + CesiumMath.TWO_PI, CesiumMath.EPSILON16);
-        expect(CesiumMath.negativePiToPi(-(Math.PI + CesiumMath.EPSILON10))).toEqualEpsilon(-Math.PI, CesiumMath.EPSILON16);
+        expect(CesiumMath.negativePiToPi(-(Math.PI + CesiumMath.EPSILON10))).toEqualEpsilon(Math.PI, CesiumMath.EPSILON9);
     });
 
     it('negativePiToPi should not change', function() {

--- a/Specs/Core/RectangleSpec.js
+++ b/Specs/Core/RectangleSpec.js
@@ -334,7 +334,7 @@ defineSuite([
     it('center works across IDL', function() {
         var rectangle = Rectangle.fromDegrees(170, 0, -170, 0);
         var returnedResult = Rectangle.center(rectangle);
-        expect(returnedResult).toEqualEpsilon(Cartographic.fromDegrees(180, 0), CesiumMath.EPSILON11);
+        expect(returnedResult).toEqualEpsilon(Cartographic.fromDegrees(-180, 0), CesiumMath.EPSILON11);
 
         rectangle = Rectangle.fromDegrees(160, 0, -170, 0);
         returnedResult = Rectangle.center(rectangle);


### PR DESCRIPTION
Simplify functions to find equivalent angles in the [-pi, pi] and [0, 2 \* pi] ranges. We'll use one of these when allowing extents/rectangles cross +/- 180 degrees longitude.
