### PR TITLE
Improve polygon outline performance

### DIFF
--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -342,12 +342,11 @@ define([
         if (!perPositionHeight) {
             var radius = ellipsoid.maximumRadius;
             var minDistance = 2.0 * radius * Math.sin(granularity * 0.5);
-            var minDistanceSqrd = minDistance * minDistance;
 
             for (i = 0; i < length; i++) {
                 p1 = positions[i];
                 p2 = positions[(i + 1) % length];
-                subdividedEdge = PolygonGeometryLibrary.subdivideLine(p1, p2, minDistanceSqrd);
+                subdividedEdge = PolygonGeometryLibrary.subdivideLine(p1, p2, minDistance);
                 subdividedEdge.push(p2.x, p2.y, p2.z);
                 edgePositions = edgePositions.concat(subdividedEdge);
             }

--- a/Source/Core/PolygonGeometryLibrary.js
+++ b/Source/Core/PolygonGeometryLibrary.js
@@ -27,9 +27,9 @@ define([
     /**
      * @private
      */
-    PolygonGeometryLibrary.subdivideLineCount = function(p0, p1, minDistanceSqrd) {
-        var distanceSqrd = Cartesian3.magnitudeSquared(Cartesian3.subtract(p1, p0, distanceScratch));
-        var n = distanceSqrd / minDistanceSqrd;
+    PolygonGeometryLibrary.subdivideLineCount = function(p0, p1, minDistance) {
+        var distance = Cartesian3.distance(p0, p1);
+        var n = distance / minDistance;
         var countDivide = Math.ceil(Math.log(n) / Math.log(2));
         if (countDivide < 1) {
             countDivide = 0;
@@ -40,8 +40,8 @@ define([
     /**
      * @private
      */
-    PolygonGeometryLibrary.subdivideLine = function(p0, p1, minDistanceSqrd, result) {
-        var numVertices = PolygonGeometryLibrary.subdivideLineCount(p0, p1, minDistanceSqrd);
+    PolygonGeometryLibrary.subdivideLine = function(p0, p1, minDistance, result) {
+        var numVertices = PolygonGeometryLibrary.subdivideLineCount(p0, p1, minDistance);
         var length = Cartesian3.distance(p0, p1);
         var distanceBetweenVertices = length / numVertices;
 

--- a/Source/Core/PolygonOutlineGeometry.js
+++ b/Source/Core/PolygonOutlineGeometry.js
@@ -43,7 +43,7 @@ define([
     var createGeometryFromPositionsPositions = [];
     var createGeometryFromPositionsSubdivided = [];
 
-    function createGeometryFromPositions(ellipsoid, positions, minDistanceSqrd, perPositionHeight) {
+    function createGeometryFromPositions(ellipsoid, positions, minDistance, perPositionHeight) {
         var cleanedPositions = PolygonPipeline.removeDuplicates(positions);
 
         //>>includeStart('debug', pragmas.debug);
@@ -70,11 +70,11 @@ define([
         if (!perPositionHeight) {
             var numVertices = 0;
             for (i = 0; i < length; i++) {
-                numVertices += PolygonGeometryLibrary.subdivideLineCount(cleanedPositions[i], cleanedPositions[(i + 1) % length], minDistanceSqrd);
+                numVertices += PolygonGeometryLibrary.subdivideLineCount(cleanedPositions[i], cleanedPositions[(i + 1) % length], minDistance);
             }
             subdividedPositions = new Float64Array(numVertices * 3);
             for (i = 0; i < length; i++) {
-                var tempPositions = PolygonGeometryLibrary.subdivideLine(cleanedPositions[i], cleanedPositions[(i + 1) % length], minDistanceSqrd, createGeometryFromPositionsSubdivided);
+                var tempPositions = PolygonGeometryLibrary.subdivideLine(cleanedPositions[i], cleanedPositions[(i + 1) % length], minDistance, createGeometryFromPositionsSubdivided);
                 var tempPositionsLength = tempPositions.length;
                 for (var j = 0; j < tempPositionsLength; ++j) {
                     subdividedPositions[index++] = tempPositions[j];
@@ -120,7 +120,7 @@ define([
         });
     }
 
-    function createGeometryFromPositionsExtruded(ellipsoid, positions, minDistanceSqrd, perPositionHeight) {
+    function createGeometryFromPositionsExtruded(ellipsoid, positions, minDistance, perPositionHeight) {
         var cleanedPositions = PolygonPipeline.removeDuplicates(positions);
 
         //>>includeStart('debug', pragmas.debug);
@@ -148,13 +148,13 @@ define([
         if (!perPositionHeight) {
             var numVertices = 0;
             for (i = 0; i < length; i++) {
-                numVertices += PolygonGeometryLibrary.subdivideLineCount(cleanedPositions[i], cleanedPositions[(i + 1) % length], minDistanceSqrd);
+                numVertices += PolygonGeometryLibrary.subdivideLineCount(cleanedPositions[i], cleanedPositions[(i + 1) % length], minDistance);
             }
 
             subdividedPositions = new Float64Array(numVertices * 3 * 2);
             for (i = 0; i < length; ++i) {
                 corners[i] = index / 3;
-                var tempPositions = PolygonGeometryLibrary.subdivideLine(cleanedPositions[i], cleanedPositions[(i + 1) % length], minDistanceSqrd, createGeometryFromPositionsSubdivided);
+                var tempPositions = PolygonGeometryLibrary.subdivideLine(cleanedPositions[i], cleanedPositions[(i + 1) % length], minDistance, createGeometryFromPositionsSubdivided);
                 var tempPositionsLength = tempPositions.length;
                 for (var j = 0; j < tempPositionsLength; ++j) {
                     subdividedPositions[index++] = tempPositions[j];
@@ -434,17 +434,16 @@ define([
 
         var radius = ellipsoid.maximumRadius;
         var minDistance = 2.0 * radius * Math.sin(granularity * 0.5);
-        var minDistanceSqrd = minDistance * minDistance;
 
         if (extrude) {
             for (i = 0; i < polygons.length; i++) {
-                geometry = createGeometryFromPositionsExtruded(ellipsoid, polygons[i], minDistanceSqrd, perPositionHeight);
+                geometry = createGeometryFromPositionsExtruded(ellipsoid, polygons[i], minDistance, perPositionHeight);
                 geometry.geometry = PolygonGeometryLibrary.scaleToGeodeticHeightExtruded(geometry.geometry, height, extrudedHeight, ellipsoid, perPositionHeight);
                 geometries.push(geometry);
             }
         } else {
             for (i = 0; i < polygons.length; i++) {
-                geometry = createGeometryFromPositions(ellipsoid, polygons[i], minDistanceSqrd, perPositionHeight);
+                geometry = createGeometryFromPositions(ellipsoid, polygons[i], minDistance, perPositionHeight);
                 geometry.geometry = PolygonPipeline.scaleToGeodeticHeight(geometry.geometry, height, ellipsoid, !perPositionHeight);
                 geometries.push(geometry);
             }


### PR DESCRIPTION
- Instead of `concat`ing multiply arrays then copying the result to a `Float64Array`, compute the array length up front and index into it.
- Use a scratch array when subdividing the polygon edges.
- Avoid looping over inverse trig functions.
