### PR TITLE
Make FullscreenViewModel accept element id

### DIFF
--- a/Source/Widgets/FullscreenButton/FullscreenButton.js
+++ b/Source/Widgets/FullscreenButton/FullscreenButton.js
@@ -27,7 +27,7 @@ define([
      * @constructor
      *
      * @param {Element|String} container The DOM element or ID that will contain the widget.
-     * @param {Element} [fullscreenElement=document.body] The element to be placed into fullscreen mode.
+     * @param {Element|String} [fullscreenElement=document.body] The element or id to be placed into fullscreen mode.
      *
      * @exception {DeveloperError} Element with id "container" does not exist in the document.
      *

--- a/Source/Widgets/FullscreenButton/FullscreenButtonViewModel.js
+++ b/Source/Widgets/FullscreenButton/FullscreenButtonViewModel.js
@@ -6,7 +6,8 @@ define([
         '../../Core/DeveloperError',
         '../../Core/Fullscreen',
         '../../ThirdParty/knockout',
-        '../createCommand'
+        '../createCommand',
+        '../getElement'
     ], function(
         defaultValue,
         defineProperties,
@@ -14,7 +15,8 @@ define([
         DeveloperError,
         Fullscreen,
         knockout,
-        createCommand) {
+        createCommand,
+        getElement) {
     "use strict";
 
     /**
@@ -22,7 +24,7 @@ define([
      * @alias FullscreenButtonViewModel
      * @constructor
      *
-     * @param {Element} [fullscreenElement=document.body] The element to be placed into fullscreen mode.
+     * @param {Element|String} [fullscreenElement=document.body] The element or id to be placed into fullscreen mode.
      */
     var FullscreenButtonViewModel = function(fullscreenElement) {
         var that = this;
@@ -79,7 +81,7 @@ define([
             }
         }, knockout.getObservable(this, 'isFullscreenEnabled'));
 
-        this._fullscreenElement = defaultValue(fullscreenElement, document.body);
+        this._fullscreenElement = defaultValue(getElement(fullscreenElement), document.body);
 
         this._callback = function() {
             tmpIsFullscreen(Fullscreen.fullscreen);

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -90,7 +90,7 @@ define([
      * @param {ImageryProvider} [options.imageryProvider=new BingMapsImageryProvider()] The imagery provider to use.  This value is only valid if options.baseLayerPicker is set to false.
      * @param {TerrainProvider} [options.terrainProvider=new EllipsoidTerrainProvider()] The terrain provider to use
      * @param {SkyBox} [options.skyBox] The skybox used to render the stars.  When <code>undefined</code>, the default stars are used.
-     * @param {Element} [options.fullscreenElement=document.body] The element to make full screen when the full screen button is pressed.
+     * @param {Element|String} [options.fullscreenElement=document.body] The element or id to be placed into fullscreen mode when the full screen button is pressed.
      * @param {Boolean} [options.useDefaultRenderLoop=true] True if this widget should control the render loop, false otherwise.
      * @param {Number} [options.targetFrameRate] The target frame rate when using the default render loop.
      * @param {Boolean} [options.showRenderLoopErrors=true] If true, this widget will automatically display an HTML panel to the user containing the error, if a render loop error occurs.

--- a/Specs/Widgets/FullscreenButton/FullscreenButtonViewModelSpec.js
+++ b/Specs/Widgets/FullscreenButton/FullscreenButtonViewModelSpec.js
@@ -23,6 +23,16 @@ defineSuite([
         viewModel.destroy();
     });
 
+    it('constructor can take an element id', function() {
+        var testElement = document.createElement('span');
+        testElement.id = 'testElement';
+        document.body.appendChild(testElement);
+        var viewModel = new FullscreenButtonViewModel('testElement');
+        expect(viewModel.fullscreenElement).toBe(testElement);
+        viewModel.destroy();
+        document.body.removeChild(testElement);
+    });
+
     it('isFullscreenEnabled work as expected', function() {
         var viewModel = new FullscreenButtonViewModel();
         expect(viewModel.isFullscreenEnabled).toEqual(Fullscreen.enabled);


### PR DESCRIPTION
Everywhere in Cesium we take an element, we also allow the string id to be used instead. This just updates `FullscreenViewModel` to be in line with everything else,
