### PR TITLE
Remove dead code.

### DIFF
--- a/Source/DataSources/ColorMaterialProperty.js
+++ b/Source/DataSources/ColorMaterialProperty.js
@@ -123,12 +123,5 @@ define([
                 Property.equals(this._color, other._color));
     };
 
-    /**
-     * @private
-     */
-    ColorMaterialProperty.prototype._raiseDefinitionChanged = function() {
-        this._definitionChanged.raiseEvent(this);
-    };
-
     return ColorMaterialProperty;
 });

--- a/Source/DataSources/GridMaterialProperty.js
+++ b/Source/DataSources/GridMaterialProperty.js
@@ -158,12 +158,5 @@ define([
         Property.equals(this._lineOffset, other._lineOffset));
     };
 
-    /**
-     * @private
-     */
-    GridMaterialProperty.prototype._raiseDefinitionChanged = function() {
-        this._definitionChanged.raiseEvent(this);
-    };
-
     return GridMaterialProperty;
 });

--- a/Source/DataSources/ImageMaterialProperty.js
+++ b/Source/DataSources/ImageMaterialProperty.js
@@ -114,12 +114,5 @@ define([
                 Property.equals(this._repeat, other._repeat));
     };
 
-    /**
-     * @private
-     */
-    ImageMaterialProperty.prototype._raiseDefinitionChanged = function(){
-        this._definitionChanged.raiseEvent(this);
-    };
-
     return ImageMaterialProperty;
 });

--- a/Source/DataSources/PolylineGlowMaterialProperty.js
+++ b/Source/DataSources/PolylineGlowMaterialProperty.js
@@ -111,12 +111,5 @@ define([
                 Property.equals(this._glowPower, other._glowPower));
     };
 
-    /**
-     * @private
-     */
-    PolylineGlowProperty.prototype._raiseDefinitionChanged = function() {
-        this._definitionChanged.raiseEvent(this);
-    };
-
     return PolylineGlowProperty;
 });

--- a/Source/DataSources/PolylineOutlineMaterialProperty.js
+++ b/Source/DataSources/PolylineOutlineMaterialProperty.js
@@ -127,12 +127,5 @@ define([
                 Property.equals(this._outlineWidth, other._outlineWidth));
     };
 
-    /**
-     * @private
-     */
-    PolylineOutlineMaterialProperty.prototype._raiseDefinitionChanged = function(){
-        this._definitionChanged.raiseEvent(this);
-    };
-
     return PolylineOutlineMaterialProperty;
 });

--- a/Source/DataSources/StripeMaterialProperty.js
+++ b/Source/DataSources/StripeMaterialProperty.js
@@ -161,12 +161,5 @@ define([
                        Property.equals(this._repeat, other._repeat));
     };
 
-    /**
-     * @private
-     */
-    StripeMaterialProperty.prototype._raiseDefinitionChanged = function() {
-        this._definitionChanged.raiseEvent(this);
-    };
-
     return StripeMaterialProperty;
 });


### PR DESCRIPTION
These private functions are from an old implementation of the property system that is no longer used.
`createPropertyDescriptor` now handles the events automatically.
