### PR TITLE
Fix shader compilation failure in IE11.

### DIFF
--- a/Source/Scene/GlobeSurfaceShaderSet.js
+++ b/Source/Scene/GlobeSurfaceShaderSet.js
@@ -155,20 +155,18 @@ define([
 
             vs.sources.push(getPositionMode);
 
-            if (sceneMode !== SceneMode.SCENE3D) {
-                var get2DYPositionFractionGeographicProjection = 'float get2DYPositionFraction() { return get2DGeographicYPositionFraction(); }';
-                var get2DYPositionFractionMercatorProjection = 'float get2DYPositionFraction() { return get2DMercatorYPositionFraction(); }';
+            var get2DYPositionFractionGeographicProjection = 'float get2DYPositionFraction() { return get2DGeographicYPositionFraction(); }';
+            var get2DYPositionFractionMercatorProjection = 'float get2DYPositionFraction() { return get2DMercatorYPositionFraction(); }';
 
-                var get2DYPositionFraction;
+            var get2DYPositionFraction;
 
-                if (useWebMercatorProjection) {
-                    get2DYPositionFraction = get2DYPositionFractionMercatorProjection;
-                } else {
-                    get2DYPositionFraction = get2DYPositionFractionGeographicProjection;
-                }
-
-                vs.sources.push(get2DYPositionFraction);
+            if (useWebMercatorProjection) {
+                get2DYPositionFraction = get2DYPositionFractionMercatorProjection;
+            } else {
+                get2DYPositionFraction = get2DYPositionFractionGeographicProjection;
             }
+
+            vs.sources.push(get2DYPositionFraction);
 
             var shader = context.createShaderProgram(vs, fs, this._attributeLocations);
             surfaceShader = shadersByFlags[flags] = new GlobeSurfaceShader(numberOfDayTextures, flags, shader);


### PR DESCRIPTION
Fixes #2358

A function needed only in 2D mode was not being included in 3D.  Other
browsers were ok with this because the functions that called the missing
one were never called, but IE had a problem with it.

This change includes the function in 3D as well, which is consistent with Cesium's behavior before #2346.
