### PR TITLE
Fix Extruded Polygon bug

### DIFF
--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -408,7 +408,7 @@ define([
 
             p1 = Cartesian3.fromArray(edgePositions, UL * 3, p1Scratch);
             p2 = Cartesian3.fromArray(edgePositions, UR * 3, p2Scratch);
-            if (Cartesian3.equalsEpsilon(p1, p2, CesiumMath.EPSILON6)) {
+            if (Cartesian3.equalsEpsilon(p1, p2, CesiumMath.EPSILON14)) {
                 continue;
             }
 

--- a/Source/Core/PolygonGeometryLibrary.js
+++ b/Source/Core/PolygonGeometryLibrary.js
@@ -30,10 +30,7 @@ define([
     PolygonGeometryLibrary.subdivideLineCount = function(p0, p1, minDistance) {
         var distance = Cartesian3.distance(p0, p1);
         var n = distance / minDistance;
-        var countDivide = Math.ceil(Math.log(n) / Math.log(2));
-        if (countDivide < 1) {
-            countDivide = 0;
-        }
+        var countDivide = Math.max(0, Math.ceil(Math.log(n) / Math.log(2)));
         return Math.pow(2, countDivide);
     };
 
@@ -53,10 +50,7 @@ define([
         positions.length = numVertices * 3;
 
         var index = 0;
-        positions[index++] = p0.x;
-        positions[index++] = p0.y;
-        positions[index++] = p0.z;
-        for ( var i = 1; i < numVertices; i++) {
+        for ( var i = 0; i < numVertices; i++) {
             var p = getPointAtDistance(p0, p1, i * distanceBetweenVertices, length);
             positions[index++] = p[0];
             positions[index++] = p[1];


### PR DESCRIPTION
Fixes #2368. Decreases the epsilon value used to compare extruded polygon wall vertices. We really need to go through and check all of our epsilon values at some point.
