### PR TITLE
Use parent tilesets's tilesetVersion if it's set and none on the child.

### DIFF
--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1560,8 +1560,6 @@ define([
             // Append the tileset version to the resource
             this._basePath += '?v=' + tilesetVersion;
             resource.setQueryParameters({ v: tilesetVersion });
-        } else {
-            delete resource.queryParameters.v;
         }
 
         // A tileset JSON file referenced from a tile may exist in a different directory than the root tileset.


### PR DESCRIPTION
If a parent contains a `tilesetVersion` parameter, then child tilesets should use it if they do not have a `tilesetVersion` of their own.

This fixes [this demo](http://localhost:8080/Apps/Sandcastle/index.html#c=ZZJtb9owEMe/isUbgjQ5QNRpXSkaCxoNIzAghYHyxjgHGByb2k54mPbd5zR0Y5vfnH33/53Pd3Zd1FNEGOSDZlnanyJCKWiNjERnmSnEpEBEazA6FqUGB1LgBNYk46bzKo7kHgR6RFU497erHmUj1g+eL0FjyAIdiMkd9YP3wf7wfeb377EVvSS9fSHaLaPlbjEfHxfn+ml4WdQH0YSF82ezmA/5ctpIR1HYGEX9dNSbpOGFsoHfPyxtspAdGZl/qQc7eRp2qTeMqBdGYX09xqtGffZ51es+ed9Ic34KOsFm/PTVM3dR0nzxiU501NnvN7no6upDLGKRE4VyBkdQ9gkCjtdW4Nmrz6nS16MvhSFMgKrWflOGcbCdsVjJY01BAD4oljLDctCYJIkTC2TXTeLSeN2oxJ0fpaJYmeIf0Z82T0DbGVDAayXTTjGFIHGa917zQ61kflp7raes4CJlGknnWtlVhaXZgjoyDc46E9QUM3VAKalq6OZyKoWWHDCXm2v04e0Wu6m8q7S0OXNol85PLD1IZYqSHYxdA+mBEwPaXWV0DwZTrQus5b5BrYTliCWPceWfjsYVRLn9YzayzjifsgvElXbLtfq/MC5JwsRmlIPi5FxIto32oHRijFuuPf5PGSn5iqibjL8A) where you can see it was dropping the `v` parameter for some tiles when you zoomed in.

@lilleyse are there any spec implications here? I couldn't find anything in the spec regarding tilesetVersion and external/child tilesets but perhaps it's an implementation guidelines instead of not in the spec itself?