### PR TITLE
Make polygons with an image material render as translucent

### DIFF
--- a/Source/DataSources/StaticGeometryPerMaterialBatch.js
+++ b/Source/DataSources/StaticGeometryPerMaterialBatch.js
@@ -130,7 +130,7 @@ import Property from './Property.js';
                     geometryInstances : geometries,
                     appearance : new this.appearanceType({
                         material : this.material,
-                        translucent : this.material.isTranslucent(),
+                        // omitting translucent property to override it
                         closed : this.closed
                     }),
                     depthFailAppearance : depthFailAppearance,


### PR DESCRIPTION
This [came up on the forum](https://groups.google.com/forum/#!topic/cesium-dev/-765VoQtBOU).

Here's a PNG with a transparent background:

![Cesium](https://sandcastle.cesium.com/images/Cesium_Logo_overlay.png)

If you add this as a material to a polygon, you get a black background:

![image](https://user-images.githubusercontent.com/1711126/68072926-73ebd080-fd61-11e9-905c-2a6cbcebe136.png)

Code:

```
var viewer = new Cesium.Viewer('cesiumContainer');

viewer.entities.add({
    polygon : {
        hierarchy : Cesium.Cartesian3.fromDegreesArray([-93.42146226782502, 40.966453300249995, -93.41909064452037, 40.966453300249995, -93.41909064452037, 40.96882492355465, -93.42146226782502, 40.96882492355465]),
        material : "../images/Cesium_Logo_overlay.png",
        height: 100
    }
});


viewer.zoomTo(viewer.entities);
```

But if you comment out the height so it's clamped, it works fine:

![image](https://user-images.githubusercontent.com/1711126/68072934-92ea6280-fd61-11e9-9da8-3b7a96927e00.png)

This inconsistency is because the ground primitives batch will override the translucency property of a material:

https://github.com/AnalyticalGraphicsInc/cesium/blob/dceac54c0e96bcbd3f07e9632746c5e0e05a1025/Source/DataSources/StaticGroundGeometryPerMaterialBatch.js#L123-L126

Whereas the regular primitive batch will not:

https://github.com/AnalyticalGraphicsInc/cesium/blob/dceac54c0e96bcbd3f07e9632746c5e0e05a1025/Source/DataSources/StaticGeometryPerMaterialBatch.js#L131-L134

This PR updates the regular primitive batch to behave the same as the ground primitive one. In retrospect, I'm not sure if this is the right solution. The real problem is that the material declares it is not translucent, because the color's alpha channel is 1:

https://github.com/AnalyticalGraphicsInc/cesium/blob/dceac54c0e96bcbd3f07e9632746c5e0e05a1025/Source/Scene/Material.js#L1102-L1119

But I think for an image material, the behavior should be translucent by default, since you would expect an image with transparency to render as transparent. If we make the change in Material.js then the batches won't need to override this.