### PR TITLE
Make sure clipping plane origin matches the bounding sphere center

### DIFF
--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -870,7 +870,11 @@ import TileOrientedBoundingBox from './TileOrientedBoundingBox.js';
                 var originCartographic = that._ellipsoid.cartesianToCartographic(clippingPlanesOrigin);
                 if (defined(originCartographic) && (originCartographic.height > ApproximateTerrainHeights._defaultMinTerrainHeight)) {
                     that._initialClippingPlanesOriginMatrix = Transforms.eastNorthUpToFixedFrame(clippingPlanesOrigin);
+                } else {
+                    // Make sure the origin of the clipping plane matches the bounding sphere center.
+                    that._initialClippingPlanesOriginMatrix = Matrix4.fromTranslation(clippingPlanesOrigin);
                 }
+
                 that._clippingPlanesOriginMatrix = Matrix4.clone(that._initialClippingPlanesOriginMatrix);
                 that._readyPromise.resolve(that);
             }).otherwise(function(error) {


### PR DESCRIPTION
This addresses the offset reported in:

* https://github.com/AnalyticalGraphicsInc/cesium/issues/8377
* https://github.com/AnalyticalGraphicsInc/cesium/issues/8181, https://github.com/AnalyticalGraphicsInc/cesium/issues/8391 (duplicates)
* https://github.com/AnalyticalGraphicsInc/cesium/issues/8053

This is easy to reproduce [in this Sandcastle](https://sandcastle.cesium.com/index.html#c=5VdbTxs5FP4rFvuQiRSchJJeAkXbDZQNagKFtBQKqjwzJ4mJx561PblQ8d/3eG6ZAN2L1KfdCDJjn/t3Pl/SbJJjzaQlPTA8iU4uCAsCMIZYRVYq0YQrSZgxYM2NzHRoX0kawpglwr5LlUdqBpK8JTVYnUz944Cf8pP+p/t+e8j7pi/PO0Gv/7I/i7987p28oaj0R3g8Q6X+8uryqHN6OJ1eX7TF4P7j7ofROR/cBfbqbhhdXbTaV9FwNrgcdIaj89n1XZ9/6J3E1+hsMLpaDVYLzi7ft/p3ajkc9TuD+8HO4O7javyR+l/a/c/82yn8Ll7pyze81W7JpQ6OXg9e9k6YfzpPji/9s9Prxc5ube9G3sg508RXyxeHPRbbRAMWsy72HAwiEQAdaxW9c1j0Q6+z++pVq75XMR2oEMQ/M2zXy6hzDgvQaCZhUZh+Tue8WpAOe0paxiXo2trKcgHoDs0ye2oCkEBjzSNu+RwMZWHo3UiCn4rj7PHicJSZe98zDfdJtOhW6misJc3maMpNGTJUYGTNkimbA2FEqIBZJEmDGEUWUEPsEsPlBEWRczRgVvOlo1MsWACEW8IsaTVIi3BpLLCQqDEJNVukRpbYKRAsxiIoKHAjYNpO1/lU3HaLwkbIYTNWOjIUmLFDhRaf4pF6z5cQvtcsAq+AAJ3hG5Mv0q4cwkQDGM8lVK9nQR7wmUGd10w1prk6Q3VugGJK0hsnMnBle3WSg9hskkOsIs3YV4kMXT0mnoIu6+GSaAhppu/amM+XnKkkFwglwSsTUMrSwutF6pRmxi7R1F3GA5xDAuT9r7Q3Voa7fLt5zEZVxKXtkopyOovIiQt+D13SbjU2ZYESSpfY99yInh8drpUeCiDz5J4i5AoitugaUZpPEB38W0y5hQpEaXbmb4heofiZ0z8rxJibgKxR33/AoA2IAxXFiYWw5FOjqKTE2eWE6WR5/Qhm0t1YdmVbvXoV+AJi4jCuQPaQL/Ss4nulopEqqJBzlCpEUS+QjyUViQdaK12vdjJQ0igBVKhJLt2rxKnuQcXulRuH3FgmA+w+JvaQ6ubFzKQKZiqxFLsXzLzStrI5KSV85mgdqiCJkG90AvZIgHv9bYV7YC1XSXe0x35ZHIvVbzyluln7bxR+N5dmIHgco+aZYBLM5j7aq8qeUiHOTLrk6xqwH1l7z7ezTd3GkX/Vs+/M2W2j7OPjAhGMU9+AnjNfQLXAWoF6rU5N4ptAc3/dX6+Q1h83CaseJpGPR0apkreZj4nHzZAN15INfmjA004WnCgWa/Z8HmH6LYPta+uWVuIXr2v2ZlxQsUvd9eVrHtbC0iLmNQcv+VLL1wPqgGsPSp5urcX+lsJUjdraWyv8BEKUC/MZYvx0ghSf28qOUG6Y2IqHBnkOsav/OmIpWO2fiNj1/wKxArZ/h9htulQvmAwDvDbhQYHn2SjbZgcgEy9fvvW9rcbWvrErAQeZ8a88ivGS5a6NHqVNCxEWhAk1/SSYOYSMKeL8UpwHFQR8PDom2t1nukRPfObt7jRI8d+ir+sV0GPMCRHokt14WZn2lQ5Bb2sW8sRUhQ+PwnKJR/pGm0FbHjCxzQSf4I0o4mEo4GnEbaviLtnZiFqIfGWtiqpSDLvfLCDaD/mc8PDtzdajO/zNFgkE/p5CyTgR6el/s3Ww30T9DTOhmItzirkKtnIq0/bBh2ySUrrfxOFTq7xkVM9ycpKDw5zLhXoqyECxqxjQDC87E0wDgZA42m7RjhuwJQ6yd7ynx+mg1cZRyCzb9vGAxqk5EwleEor10iDpxKcYdXC6loaprfPZCOtWqXOOGOCo89eeUx9FCX8C). Notice that the X/Y directions work fine, where 0 cuts through the middle of the tileset, and it correctly goes from -1 to 1 across in that axis. For Z, the 0 is at the bottom of the model.

This offset is because the difference between where the `tileset.root.computedTransform` places the origin, and where the `tileset.root.boundingSphere.center` is. In the image below, the red sphere marks the bounding sphere center. The white marks the root tile's computed transform's origin:

![image](https://user-images.githubusercontent.com/1711126/68824417-c92eb880-0664-11ea-9190-b4b3d24164af.png)

You can draw these two points on the power plant model to show that they are very close, but not the same, and that's where the small discrepancy there comes from. This PR fixes this issue by making sure to use the bounding sphere center as the origin for the clipping plane in the case where the bounding sphere center is not above the surface (where the tileset transform is what places the tile in its location on the globe). 

I marked as a draft because I still need to go through the discussion in https://github.com/AnalyticalGraphicsInc/cesium/pull/7182 to see why this wasn't done initially/make sure it's not breaking anything else.