### PR TITLE
Suppress Chromium violation warning "Added non-passive event listener to a scroll-blocking 'wheel' event"

### DIFF
--- a/Source/Core/ScreenSpaceEventHandler.js
+++ b/Source/Core/ScreenSpaceEventHandler.js
@@ -53,7 +53,13 @@ import ScreenSpaceEventType from './ScreenSpaceEventType.js';
         function listener(e) {
             callback(screenSpaceEventHandler, e);
         }
-        element.addEventListener(domType, listener, { capture: false, passive: false });
+
+        if (FeatureDetection.isInternetExplorer()) {
+            element.addEventListener(domType, listener, false);
+        }
+        else {
+            element.addEventListener(domType, listener, { capture: false, passive: false });
+        }
 
         screenSpaceEventHandler._removalFunctions.push(function() {
             element.removeEventListener(domType, listener, false);

--- a/Source/Core/ScreenSpaceEventHandler.js
+++ b/Source/Core/ScreenSpaceEventHandler.js
@@ -53,7 +53,7 @@ import ScreenSpaceEventType from './ScreenSpaceEventType.js';
         function listener(e) {
             callback(screenSpaceEventHandler, e);
         }
-        element.addEventListener(domType, listener, false);
+        element.addEventListener(domType, listener, { capture: false, passive: false });
 
         screenSpaceEventHandler._removalFunctions.push(function() {
             element.removeEventListener(domType, listener, false);


### PR DESCRIPTION
Chromium 79.0 writes the following violation to JavaScript console:

> [Violation] Added non-passive event listener to a scroll-blocking 'wheel' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/57455437959

Callstack:

| method | | source |
| :--- | :--- | :--- |
| registerListener | @ | ScreenSpaceEventHandler.js:56 |
| registerListeners | @ | ScreenSpaceEventHandler.js:101 |
| ScreenSpaceEventHandler | @ | ScreenSpaceEventHandler.js:709 |
| CameraEventAggregator | @ | CameraEventAggregator.js:252 |
| ScreenSpaceCameraController | @ | ScreenSpaceCameraController.js:243 |
| Scene | @ | Scene.js:597 |
| CesiumWidget | @ | CesiumWidget.js:243 |

This pull request suppresses the warning message by setting `passive` to `false` explicitly. Here is [addEventListener](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) docs:

* **passive**: A `Boolean` which, if true, indicates that the function specified by listener will never call [preventDefault()](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault). If a passive listener does call preventDefault(), the user agent will do nothing other than generate a console warning. See [Improving scrolling performance with passive listeners](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Improving_scrolling_performance_with_passive_listeners) to learn more.
