### PR TITLE
Add isNaN, isFinite, null, and undefined support to GLSL styling backend

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
 * Added `tileset.uri`, `tileset.show`, and `tileset.maximumScreenSpaceError` properties to CZML processing for loading 3D Tiles.
 * Added `Color.lerp` for linearly interpolating between two RGB colors. [#8607](https://github.com/CesiumGS/cesium/pull/8607)
 * `CesiumTerrainProvider` now supports terrain tiles using a `WebMercatorTilingScheme` by specifying `"projection": "EPSG:3857"` in `layer.json`. It also now supports numbering tiles from the North instead of the South by specifying `"scheme": "slippyMap"` in `layer.json`. [#8563](https://github.com/CesiumGS/cesium/pull/8563)
+* Added basic support for `isNaN`, `isFinite`, `null`, and `undefined` in the 3D Tiles styling GLSL backend for point clouds. [#8621](https://github.com/CesiumGS/cesium/pull/8621)
 
 ##### Fixes :wrench:
 

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -1559,6 +1559,8 @@ import ExpressionNodeType from './ExpressionNodeType.js';
         return expressions;
     }
 
+    var nullSentinel = 'czm_infinity'; // null just needs to be some sentinel value that will cause "[expression] === null" to be false in nearly all cases. GLSL doesn't have a NaN constant so use czm_infinity.
+
     Node.prototype.getShaderExpression = function(attributePrefix, shaderState, parent) {
         var color;
         var left;
@@ -1603,7 +1605,13 @@ import ExpressionNodeType from './ExpressionNodeType.js';
                     return 'floor(' + left + ' + 0.5)';
                 } else if (defined(unaryFunctions[value])) {
                     return value + '(' + left + ')';
-                } else if ((value === 'isNaN') || (value === 'isFinite') || (value === 'String') || (value === 'isExactClass') || (value === 'isClass') || (value === 'getExactClassName')) {
+                } else if (value === 'isNaN') {
+                    // In GLSL 2.0 use isnan instead
+                    return '(' + left + ' != ' + left + ')';
+                } else if (value === 'isFinite') {
+                    // In GLSL 2.0 use isinf instead. GLSL doesn't have an infinity constant so use czm_infinity which is an arbitrarily big enough number.
+                    return '(abs(' + left + ') < czm_infinity)';
+                } else if ((value === 'String') || (value === 'isExactClass') || (value === 'isClass') || (value === 'getExactClassName')) {
                     throw new RuntimeError('Error generating style shader: "' + value + '" is not supported.');
                 } else if (defined(unaryFunctions[value])) {
                     return value + '(' + left + ')';
@@ -1659,7 +1667,7 @@ import ExpressionNodeType from './ExpressionNodeType.js';
             case ExpressionNodeType.VARIABLE_IN_STRING:
                 throw new RuntimeError('Error generating style shader: Converting a variable to a string is not supported.');
             case ExpressionNodeType.LITERAL_NULL:
-                throw new RuntimeError('Error generating style shader: null is not supported.');
+                return nullSentinel;
             case ExpressionNodeType.LITERAL_BOOLEAN:
                 return value ? 'true' : 'false';
             case ExpressionNodeType.LITERAL_NUMBER:
@@ -1745,7 +1753,7 @@ import ExpressionNodeType from './ExpressionNodeType.js';
             case ExpressionNodeType.LITERAL_REGEX:
                 throw new RuntimeError('Error generating style shader: Regular expressions are not supported.');
             case ExpressionNodeType.LITERAL_UNDEFINED:
-                throw new RuntimeError('Error generating style shader: undefined is not supported.');
+                return nullSentinel;
             case ExpressionNodeType.BUILTIN_VARIABLE:
                 if (value === 'tiles3d_tileset_time') {
                     return 'u_time';

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -3546,6 +3546,34 @@ describe('Scene/Expression', function() {
         expect(shaderExpression).toEqual(expected);
     });
 
+    it('gets shader expression for isNaN', function() {
+        var expression = new Expression('isNaN(1.0)');
+        var shaderExpression = expression.getShaderExpression('', {});
+        var expected = '(1.0 != 1.0)';
+        expect(shaderExpression).toEqual(expected);
+    });
+
+    it('gets shader expression for isFinite', function() {
+        var expression = new Expression('isFinite(1.0)');
+        var shaderExpression = expression.getShaderExpression('', {});
+        var expected = '(abs(1.0) < czm_infinity)';
+        expect(shaderExpression).toEqual(expected);
+    });
+
+    it('gets shader expression for null', function() {
+        var expression = new Expression('null');
+        var shaderExpression = expression.getShaderExpression('', {});
+        var expected = 'czm_infinity';
+        expect(shaderExpression).toEqual(expected);
+    });
+
+    it('gets shader expression for undefined', function() {
+        var expression = new Expression('undefined');
+        var shaderExpression = expression.getShaderExpression('', {});
+        var expected = 'czm_infinity';
+        expect(shaderExpression).toEqual(expected);
+    });
+
     it('throws when getting shader expression for regex', function() {
         var expression = new Expression('regExp("a").test("abc")');
         expect(function() {
@@ -3605,34 +3633,6 @@ describe('Scene/Expression', function() {
 
     it('throws when getting shader expression for variable in string', function() {
         var expression = new Expression('"${property}"');
-        expect(function() {
-            return expression.getShaderExpression('', {});
-        }).toThrowRuntimeError();
-    });
-
-    it('throws when getting shader expression for literal undefined', function() {
-        var expression = new Expression('undefined');
-        expect(function() {
-            return expression.getShaderExpression('', {});
-        }).toThrowRuntimeError();
-    });
-
-    it('throws when getting shader expression for literal null', function() {
-        var expression = new Expression('null');
-        expect(function() {
-            return expression.getShaderExpression('', {});
-        }).toThrowRuntimeError();
-    });
-
-    it('throws when getting shader expression for isNaN', function() {
-        var expression = new Expression('isNaN(1.0)');
-        expect(function() {
-            return expression.getShaderExpression('', {});
-        }).toThrowRuntimeError();
-    });
-
-    it('throws when getting shader expression for isFinite', function() {
-        var expression = new Expression('isFinite(1.0)');
         expect(function() {
             return expression.getShaderExpression('', {});
         }).toThrowRuntimeError();


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/8615

[Local sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=dVLbTttAEP2VIVTYUZO1CQJUSKJKQRUPFY0aRF/8srEHMmW9m+6uHUGUf+/YjiWHi2XZuzPnzOXMlNJCSbhBCxPQuIEZOipy8VDbwiCtrzOjvSSNNuhfJzrRJbM8KXToD2nN7+zmvnGG20QDP4VVVxAIEfG7kPla4Y30MjpAR3ND2s+UKbLO8Q/51RxtbZhbs0bribH75OKvMzpI9K4qq2lDuBQ1irWlnDyV6ITMsnCP78BejcnvTesYdJu4RZmRfpqTT1e/pX7CMBbxAIan1fecz/1GhbYI518Ufq7DonK3SriV2QBrcUTuTt6FX7Yec25K+sLirg8nJ0DuB2ny+JHv0ARHE05aKPWJq9AZPvLUsqDJHUWd7B8mga9w/i2+OLu8GF2O4rhq9R23Kdz9sz4cjhgBwze5+/12IonuDXrjWp5pE+Y75WtjfbUQIe9CRVPS80CXRfrMUqbOVcQKeuyNUUtetGXhvdGwhYwco1+uYKlM+nwNu0SPozb6OKMSKJskvTcrm/QgVdI59jyyVgt6xaQ3HUeMP6ApU0/9V4mWk1SQ1en0Z2MUQowjvr5n7YvsRPwP)

The goal of this PR is to make `isNaN`, `isFinite`, `null`, and `undefined` usable in point clouds styles so that a style written for 3D buildings with `null` properties won't throw an error if also applied to point clouds.

* `isNaN` - `isnan` is not available in GLSL 1.0 so the approximation is `value != value`. The Sandcastle confirms that this check works.
* `isFinite` - `isinf` is not available in GLSL 1.0 so the approximation is `value < czm_infinity`. GLSL doesn't have an infinity constant and floating point precision is not predictable enough across the board to use the actual max float. `czm_infinity` is `5906376272000.0`, the distance from the Sun to Pluto in meters, and is "big enough".
* `null` - uses sentinel `czm_infinity`. Would have preferred to use NaN but GLSL doesn't have a NaN constant. You can sometimes fake a NaN by doing an operation like `sqrt(-20.0)` but I read that it's not reliable across all drivers/GPUs.
* `undefined` - uses sentinel `czm_infinity`. Same as above.

This PR does not attempt to make GLSL follow the same casting and comparison rules as JavaScript. E.g. `Boolean(null)` is false in JS while `bool(5906376272000.0)` is true in transcoded GLSL. Not to mention all the math operations and edge cases like `isNaN(null)`. I think it's possible to fix nearly all of these with some ternaries like for `Boolean(value)` getting transcoded to `'(' + left + ' === ' + nullSentinel + ' ? false : bool(' + left + ')'`, and I started doing that, but it's not super important and  was holding up this PR.

But in the end I'm not too worried about this because per-point properties are stored in binary and can never be null or undefined. The user would need to write a meaningless style like `${temperature} < 10.0 === Boolean(undefined)` to trigger one of the edge cases.
