### PR TITLE
Fix styling + flight destination bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Change Log
 ##### Fixes :wrench:
 
 * Fixed a bug where tiles would not load if the camera was tracking a moving tileset. [#8598](https://github.com/CesiumGS/cesium/pull/8598)
+* Fixed a bug where applying a new 3D Tiles style during a flight would not update all existing tiles. [#8622](https://github.com/CesiumGS/cesium/pull/8622)
 
 ### 1.66.0 - 2020-02-03
 

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -1321,7 +1321,6 @@ import TileOrientedBoundingBox from './TileOrientedBoundingBox.js';
      * @private
      */
     Cesium3DTile.prototype.update = function(tileset, frameState, passOptions) {
-        console.log(passOptions);
         var initCommandLength = frameState.commandList.length;
         updateClippingPlanes(this, tileset);
         applyDebugSettings(this, tileset, frameState, passOptions);

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -1211,8 +1211,8 @@ import TileOrientedBoundingBox from './TileOrientedBoundingBox.js';
         this.geometricError = this._geometricError * uniformScale;
     };
 
-    function applyDebugSettings(tile, tileset, frameState) {
-        if (!frameState.passes.render) {
+    function applyDebugSettings(tile, tileset, frameState, passOptions) {
+        if (!passOptions.isRender) {
             return;
         }
 
@@ -1320,10 +1320,11 @@ import TileOrientedBoundingBox from './TileOrientedBoundingBox.js';
      *
      * @private
      */
-    Cesium3DTile.prototype.update = function(tileset, frameState) {
+    Cesium3DTile.prototype.update = function(tileset, frameState, passOptions) {
+        console.log(passOptions);
         var initCommandLength = frameState.commandList.length;
         updateClippingPlanes(this, tileset);
-        applyDebugSettings(this, tileset, frameState);
+        applyDebugSettings(this, tileset, frameState, passOptions);
         updateContent(this, tileset, frameState);
         this._commandsLength = frameState.commandList.length - initCommandLength;
 

--- a/Source/Scene/Cesium3DTileStyleEngine.js
+++ b/Source/Scene/Cesium3DTileStyleEngine.js
@@ -26,7 +26,7 @@ import defineProperties from '../Core/defineProperties.js';
         this._styleDirty = true;
     };
 
-    Cesium3DTileStyleEngine.prototype.applyStyle = function(tileset, frameState) {
+    Cesium3DTileStyleEngine.prototype.applyStyle = function(tileset, passOptions) {
         if (!tileset.ready) {
             return;
         }
@@ -37,8 +37,8 @@ import defineProperties from '../Core/defineProperties.js';
 
         var styleDirty = this._styleDirty;
 
-        if (frameState.passes.render) {
-            // Don't reset until the color pass, e.g., for mouse-over picking
+        if (passOptions.isRender) {
+            // Don't reset until the render pass
             this._styleDirty = false;
         }
 

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1949,9 +1949,10 @@ import TileOrientedBoundingBox from './TileOrientedBoundingBox.js';
         tileset._tileDebugLabels.update(frameState);
     }
 
-    function updateTiles(tileset, frameState, isRender) {
-        tileset._styleEngine.applyStyle(tileset, frameState);
+    function updateTiles(tileset, frameState, passOptions) {
+        tileset._styleEngine.applyStyle(tileset, passOptions);
 
+        var isRender = passOptions.isRender;
         var statistics = tileset._statistics;
         var commandList = frameState.commandList;
         var numberOfInitialCommands = commandList.length;
@@ -1988,13 +1989,13 @@ import TileOrientedBoundingBox from './TileOrientedBoundingBox.js';
             if (isRender) {
                 tileVisible.raiseEvent(tile);
             }
-            tile.update(tileset, frameState);
+            tile.update(tileset, frameState, passOptions);
             statistics.incrementSelectionCounts(tile.content);
             ++statistics.selected;
         }
         for (i = 0; i < emptyLength; ++i) {
             tile = emptyTiles[i];
-            tile.update(tileset, frameState);
+            tile.update(tileset, frameState, passOptions);
         }
 
         var addedCommandsLength = commandList.length - lengthBeforeUpdate;
@@ -2202,7 +2203,7 @@ import TileOrientedBoundingBox from './TileOrientedBoundingBox.js';
             requestTiles(tileset);
         }
 
-        updateTiles(tileset, frameState, isRender);
+        updateTiles(tileset, frameState, passOptions);
 
         // Update pass statistics
         Cesium3DTilesetStatistics.clone(statistics, passStatistics);

--- a/Specs/Scene/Batched3DModel3DTileContentSpec.js
+++ b/Specs/Scene/Batched3DModel3DTileContentSpec.js
@@ -5,6 +5,7 @@ import { HeadingPitchRoll } from '../../Source/Cesium.js';
 import { Matrix4 } from '../../Source/Cesium.js';
 import { Transforms } from '../../Source/Cesium.js';
 import { Batched3DModel3DTileContent } from '../../Source/Cesium.js';
+import { Cesium3DTilePass } from '../../Source/Cesium.js';
 import { ClippingPlane } from '../../Source/Cesium.js';
 import { ClippingPlaneCollection } from '../../Source/Cesium.js';
 import { Model } from '../../Source/Cesium.js';
@@ -261,6 +262,7 @@ describe('Scene/Batched3DModel3DTileContent', function() {
             var tile = tileset.root;
             var content = tile.content;
             var model = content._model;
+            var passOptions = Cesium3DTilePass.getPassOptions(Cesium3DTilePass.RENDER);
 
             expect(model.clippingPlanes).toBeUndefined();
 
@@ -271,13 +273,13 @@ describe('Scene/Batched3DModel3DTileContent', function() {
             });
             tileset.clippingPlanes = clippingPlaneCollection;
             clippingPlaneCollection.update(scene.frameState);
-            tile.update(tileset, scene.frameState);
+            tile.update(tileset, scene.frameState, passOptions);
 
             expect(model.clippingPlanes).toBeDefined();
             expect(model.clippingPlanes).toBe(tileset.clippingPlanes);
 
             tile._isClipped = false;
-            tile.update(tileset, scene.frameState);
+            tile.update(tileset, scene.frameState, passOptions);
 
             expect(model.clippingPlanes).toBeUndefined();
         });
@@ -287,6 +289,7 @@ describe('Scene/Batched3DModel3DTileContent', function() {
         return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl).then(function(tileset) {
             var tile = tileset.root;
             var model = tile.content._model;
+            var passOptions = Cesium3DTilePass.getPassOptions(Cesium3DTilePass.RENDER);
 
             expect(model.clippingPlanes).toBeUndefined();
 
@@ -297,7 +300,7 @@ describe('Scene/Batched3DModel3DTileContent', function() {
             });
             tileset.clippingPlanes = clippingPlaneCollection;
             clippingPlaneCollection.update(scene.frameState);
-            tile.update(tileset, scene.frameState);
+            tile.update(tileset, scene.frameState, passOptions);
 
             expect(model.clippingPlanes).toBeDefined();
             expect(model.clippingPlanes).toBe(tileset.clippingPlanes);
@@ -311,7 +314,7 @@ describe('Scene/Batched3DModel3DTileContent', function() {
             newClippingPlaneCollection.update(scene.frameState);
             expect(model.clippingPlanes).not.toBe(tileset.clippingPlanes);
 
-            tile.update(tileset, scene.frameState);
+            tile.update(tileset, scene.frameState, passOptions);
             expect(model.clippingPlanes).toBe(tileset.clippingPlanes);
         });
     });
@@ -321,6 +324,7 @@ describe('Scene/Batched3DModel3DTileContent', function() {
 
         return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl).then(function(tileset) {
             var tile = tileset.root;
+            var passOptions = Cesium3DTilePass.getPassOptions(Cesium3DTilePass.RENDER);
 
             var clippingPlaneCollection = new ClippingPlaneCollection({
                 planes : [
@@ -329,7 +333,7 @@ describe('Scene/Batched3DModel3DTileContent', function() {
             });
             tileset.clippingPlanes = clippingPlaneCollection;
             clippingPlaneCollection.update(scene.frameState);
-            tile.update(tileset, scene.frameState);
+            tile.update(tileset, scene.frameState, passOptions);
 
             expect(Model._getClippingFunction.calls.count()).toEqual(1);
         });

--- a/Specs/Scene/Cesium3DTileSpec.js
+++ b/Specs/Scene/Cesium3DTileSpec.js
@@ -7,6 +7,7 @@ import { Matrix4 } from '../../Source/Cesium.js';
 import { Rectangle } from '../../Source/Cesium.js';
 import { Transforms } from '../../Source/Cesium.js';
 import { Cesium3DTile } from '../../Source/Cesium.js';
+import { Cesium3DTilePass } from '../../Source/Cesium.js';
 import { Cesium3DTileRefine } from '../../Source/Cesium.js';
 import { Cesium3DTilesetHeatmap } from '../../Source/Cesium.js';
 import { TileBoundingRegion } from '../../Source/Cesium.js';
@@ -347,25 +348,29 @@ describe('Scene/Cesium3DTile', function() {
 
         it('can be a bounding region', function() {
             var tile = new Cesium3DTile(mockTileset, '/some_url', tileWithBoundingRegion, undefined);
-            tile.update(mockTileset, scene.frameState);
+            var passOptions = Cesium3DTilePass.getPassOptions(Cesium3DTilePass.RENDER);
+            tile.update(mockTileset, scene.frameState, passOptions);
             expect(tile._debugBoundingVolume).toBeDefined();
         });
 
         it('can be an oriented bounding box', function() {
             var tile = new Cesium3DTile(mockTileset, '/some_url', tileWithBoundingBox, undefined);
-            tile.update(mockTileset, scene.frameState);
+            var passOptions = Cesium3DTilePass.getPassOptions(Cesium3DTilePass.RENDER);
+            tile.update(mockTileset, scene.frameState, passOptions);
             expect(tile._debugBoundingVolume).toBeDefined();
         });
 
         it('can be a bounding sphere', function() {
             var tile = new Cesium3DTile(mockTileset, '/some_url', tileWithBoundingSphere, undefined);
-            tile.update(mockTileset, scene.frameState);
+            var passOptions = Cesium3DTilePass.getPassOptions(Cesium3DTilePass.RENDER);
+            tile.update(mockTileset, scene.frameState, passOptions);
             expect(tile._debugBoundingVolume).toBeDefined();
         });
 
         it('creates debug bounding volume for viewer request volume', function() {
             var tile = new Cesium3DTile(mockTileset, '/some_url', tileWithViewerRequestVolume, undefined);
-            tile.update(mockTileset, scene.frameState);
+            var passOptions = Cesium3DTilePass.getPassOptions(Cesium3DTilePass.RENDER);
+            tile.update(mockTileset, scene.frameState, passOptions);
             expect(tile._debugViewerRequestVolume).toBeDefined();
         });
     });

--- a/Specs/Scene/Instanced3DModel3DTileContentSpec.js
+++ b/Specs/Scene/Instanced3DModel3DTileContentSpec.js
@@ -3,6 +3,7 @@ import { Color } from '../../Source/Cesium.js';
 import { HeadingPitchRange } from '../../Source/Cesium.js';
 import { HeadingPitchRoll } from '../../Source/Cesium.js';
 import { Transforms } from '../../Source/Cesium.js';
+import { Cesium3DTilePass } from '../../Source/Cesium.js';
 import { ClippingPlane } from '../../Source/Cesium.js';
 import { ClippingPlaneCollection } from '../../Source/Cesium.js';
 import { Model } from '../../Source/Cesium.js';
@@ -285,6 +286,7 @@ describe('Scene/Instanced3DModel3DTileContent', function() {
             var tile = tileset.root;
             var content = tile.content;
             var model = content._modelInstanceCollection._model;
+            var passOptions = Cesium3DTilePass.getPassOptions(Cesium3DTilePass.RENDER);
 
             expect(model.clippingPlanes).toBeUndefined();
 
@@ -295,13 +297,13 @@ describe('Scene/Instanced3DModel3DTileContent', function() {
             });
             tileset.clippingPlanes = clippingPlaneCollection;
             clippingPlaneCollection.update(scene.frameState);
-            tile.update(tileset, scene.frameState);
+            tile.update(tileset, scene.frameState, passOptions);
 
             expect(model.clippingPlanes).toBeDefined();
             expect(model.clippingPlanes).toBe(tileset.clippingPlanes);
 
             tile._isClipped = false;
-            tile.update(tileset, scene.frameState);
+            tile.update(tileset, scene.frameState, passOptions);
 
             expect(model.clippingPlanes).toBeUndefined();
         });
@@ -311,6 +313,7 @@ describe('Scene/Instanced3DModel3DTileContent', function() {
         return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl).then(function(tileset) {
             var tile = tileset.root;
             var model = tile.content._modelInstanceCollection._model;
+            var passOptions = Cesium3DTilePass.getPassOptions(Cesium3DTilePass.RENDER);
 
             expect(model.clippingPlanes).toBeUndefined();
 
@@ -321,7 +324,7 @@ describe('Scene/Instanced3DModel3DTileContent', function() {
             });
             tileset.clippingPlanes = clippingPlaneCollection;
             clippingPlaneCollection.update(scene.frameState);
-            tile.update(tileset, scene.frameState);
+            tile.update(tileset, scene.frameState, passOptions);
 
             expect(model.clippingPlanes).toBeDefined();
             expect(model.clippingPlanes).toBe(tileset.clippingPlanes);
@@ -335,7 +338,7 @@ describe('Scene/Instanced3DModel3DTileContent', function() {
             newClippingPlaneCollection.update(scene.frameState);
             expect(model.clippingPlanes).not.toBe(tileset.clippingPlanes);
 
-            tile.update(tileset, scene.frameState);
+            tile.update(tileset, scene.frameState, passOptions);
             expect(model.clippingPlanes).toBe(tileset.clippingPlanes);
         });
     });
@@ -351,10 +354,11 @@ describe('Scene/Instanced3DModel3DTileContent', function() {
                     new ClippingPlane(Cartesian3.UNIT_X, 0.0)
                 ]
             });
+            var passOptions = Cesium3DTilePass.getPassOptions(Cesium3DTilePass.RENDER);
             tileset.clippingPlanes = clippingPlaneCollection;
             clippingPlaneCollection.update(scene.frameState);
             content.clippingPlanesDirty = true;
-            tile.update(tileset, scene.frameState);
+            tile.update(tileset, scene.frameState, passOptions);
 
             expect(Model._getClippingFunction.calls.count()).toEqual(1);
         });

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -8,6 +8,7 @@ import { Math as CesiumMath } from '../../Source/Cesium.js';
 import { PerspectiveFrustum } from '../../Source/Cesium.js';
 import { Transforms } from '../../Source/Cesium.js';
 import { Pass } from '../../Source/Cesium.js';
+import { Cesium3DTilePass } from '../../Source/Cesium.js';
 import { Cesium3DTileRefine } from '../../Source/Cesium.js';
 import { Cesium3DTileStyle } from '../../Source/Cesium.js';
 import { ClippingPlane } from '../../Source/Cesium.js';
@@ -864,6 +865,7 @@ describe('Scene/PointCloud3DTileContent', function() {
             var tile = tileset.root;
             tile._isClipped = true;
             var content = tile.content;
+            var passOptions = Cesium3DTilePass.getPassOptions(Cesium3DTilePass.RENDER);
 
             var noClipFS = content._pointCloud._drawCommand.shaderProgram._fragmentShaderText;
             expect(noClipFS.indexOf('clip') !== -1).toBe(false);
@@ -877,7 +879,7 @@ describe('Scene/PointCloud3DTileContent', function() {
             tileset.clippingPlanes = clippingPlanes;
 
             clippingPlanes.update(scene.frameState);
-            tile.update(tileset, scene.frameState);
+            tile.update(tileset, scene.frameState, passOptions);
             var clipOneIntersectFS = content._pointCloud._drawCommand.shaderProgram._fragmentShaderText;
             expect(clipOneIntersectFS.indexOf('= clip(') !== -1).toBe(true);
             expect(clipOneIntersectFS.indexOf('float clip') !== -1).toBe(true);
@@ -885,7 +887,7 @@ describe('Scene/PointCloud3DTileContent', function() {
             clippingPlanes.unionClippingRegions = true;
 
             clippingPlanes.update(scene.frameState);
-            tile.update(tileset, scene.frameState);
+            tile.update(tileset, scene.frameState, passOptions);
             var clipOneUnionFS = content._pointCloud._drawCommand.shaderProgram._fragmentShaderText;
             expect(clipOneUnionFS.indexOf('= clip(') !== -1).toBe(true);
             expect(clipOneUnionFS.indexOf('float clip') !== -1).toBe(true);
@@ -894,7 +896,7 @@ describe('Scene/PointCloud3DTileContent', function() {
             clippingPlanes.add(new ClippingPlane(Cartesian3.UNIT_Y, 1.0));
 
             clippingPlanes.update(scene.frameState);
-            tile.update(tileset, scene.frameState);
+            tile.update(tileset, scene.frameState, passOptions);
             var clipTwoUnionFS = content._pointCloud._drawCommand.shaderProgram._fragmentShaderText;
             expect(clipTwoUnionFS.indexOf('= clip(') !== -1).toBe(true);
             expect(clipTwoUnionFS.indexOf('float clip') !== -1).toBe(true);


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/8618

Fixes two places where 3D Tiles code uses `frameState.passes.render` instead of the 3D Tiles-specific `passOptions.render`. Without this change the preload flight pass interferes with the style engine's dirty flag which is only supposed to be set to `false` in the render pass. The change in `applyDebugSettings` is not related to https://github.com/CesiumGS/cesium/issues/8618 but was a similar type of bug.