### PR TITLE
Disable skipLevelOfDetail by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Change Log
 ### 1.67.0 - 2020-03-02
 
 ##### Breaking Changes :mega:
-* `Cesium3DTileset.skipLevelOfDetail` is now `false` by default.
+* `Cesium3DTileset.skipLevelOfDetail` is now `false` by default. [#8631](https://github.com/CesiumGS/cesium/pull/8631)
 
 ##### Additions :tada:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@ Change Log
 
 ### 1.67.0 - 2020-03-02
 
+##### Breaking Changes :mega:
+* `Cesium3DTileset.skipLevelOfDetail` is now `false` by default.
+
 ##### Additions :tada:
 
 * Added `Entity.tileset` for loading a 3D Tiles tileset via the Entity API using the new `Cesium3DTilesetGraphics` class.

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -75,7 +75,7 @@ import TileOrientedBoundingBox from './TileOrientedBoundingBox.js';
      * @param {Number} [options.foveatedMinimumScreenSpaceErrorRelaxation=0.0] Optimization option. Used when {@link Cesium3DTileset#foveatedScreenSpaceError} is true to control the starting screen space error relaxation for tiles outside the foveated cone. The screen space error will be raised starting with tileset value up to {@link Cesium3DTileset#maximumScreenSpaceError} based on the provided {@link Cesium3DTileset#foveatedInterpolationCallback}.
      * @param {Cesium3DTileset~foveatedInterpolationCallback} [options.foveatedInterpolationCallback=Math.lerp] Optimization option. Used when {@link Cesium3DTileset#foveatedScreenSpaceError} is true to control how much to raise the screen space error for tiles outside the foveated cone, interpolating between {@link Cesium3DTileset#foveatedMinimumScreenSpaceErrorRelaxation} and {@link Cesium3DTileset#maximumScreenSpaceError}
      * @param {Number} [options.foveatedTimeDelay=0.2] Optimization option. Used when {@link Cesium3DTileset#foveatedScreenSpaceError} is true to control how long in seconds to wait after the camera stops moving before deferred tiles start loading in. This time delay prevents requesting tiles around the edges of the screen when the camera is moving. Setting this to 0.0 will immediately request all tiles in any given view.
-     * @param {Boolean} [options.skipLevelOfDetail=true] Optimization option. Determines if level of detail skipping should be applied during the traversal.
+     * @param {Boolean} [options.skipLevelOfDetail=false] Optimization option. Determines if level of detail skipping should be applied during the traversal.
      * @param {Number} [options.baseScreenSpaceError=1024] When <code>skipLevelOfDetail</code> is <code>true</code>, the screen space error that must be reached before skipping levels of detail.
      * @param {Number} [options.skipScreenSpaceErrorFactor=16] When <code>skipLevelOfDetail</code> is <code>true</code>, a multiplier defining the minimum screen space error to skip. Used in conjunction with <code>skipLevels</code> to determine which tiles to load.
      * @param {Number} [options.skipLevels=1] When <code>skipLevelOfDetail</code> is <code>true</code>, a constant defining the minimum number of levels to skip when loading tiles. When it is 0, no levels are skipped. Used in conjunction with <code>skipScreenSpaceErrorFactor</code> to determine which tiles to load.
@@ -575,7 +575,7 @@ import TileOrientedBoundingBox from './TileOrientedBoundingBox.js';
          * @type {Boolean}
          * @default true
          */
-        this.skipLevelOfDetail = defaultValue(options.skipLevelOfDetail, true);
+        this.skipLevelOfDetail = defaultValue(options.skipLevelOfDetail, false);
         this._skipLevelOfDetail = this.skipLevelOfDetail;
         this._disableSkipLevelOfDetail = false;
 

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -2672,9 +2672,13 @@ describe('Scene/Cesium3DTileset', function() {
         });
     });
 
+    var skipLevelOfDetailOptions = {
+        skipLevelOfDetail : true
+    };
+
     it('does not mark tileset as refining when tiles have selection depth 0', function() {
         viewRootOnly();
-        return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
+        return Cesium3DTilesTester.loadTileset(scene, tilesetUrl, skipLevelOfDetailOptions).then(function(tileset) {
             viewAllTiles();
             scene.renderForSpecs();
             var statistics = tileset._statistics;
@@ -2690,7 +2694,7 @@ describe('Scene/Cesium3DTileset', function() {
     });
 
     it('marks tileset as mixed when tiles have nonzero selection depth', function() {
-        return Cesium3DTilesTester.loadTileset(scene, tilesetReplacement3Url).then(function(tileset) {
+        return Cesium3DTilesTester.loadTileset(scene, tilesetReplacement3Url, skipLevelOfDetailOptions).then(function(tileset) {
             var statistics = tileset._statistics;
 
             tileset.root.children[0].children[0].children[0].unloadContent();
@@ -2713,7 +2717,7 @@ describe('Scene/Cesium3DTileset', function() {
     });
 
     it('adds stencil clear command first when unresolved', function() {
-        return Cesium3DTilesTester.loadTileset(scene, tilesetReplacement3Url).then(function(tileset) {
+        return Cesium3DTilesTester.loadTileset(scene, tilesetReplacement3Url, skipLevelOfDetailOptions).then(function(tileset) {
             tileset.root.children[0].children[0].children[0].unloadContent();
             tileset.root.children[0].children[0].children[1].unloadContent();
             tileset.root.children[0].children[0].children[2].unloadContent();
@@ -2726,7 +2730,7 @@ describe('Scene/Cesium3DTileset', function() {
     });
 
     it('creates duplicate backface commands', function() {
-        return Cesium3DTilesTester.loadTileset(scene, tilesetReplacement3Url).then(function(tileset) {
+        return Cesium3DTilesTester.loadTileset(scene, tilesetReplacement3Url, skipLevelOfDetailOptions).then(function(tileset) {
             var statistics = tileset._statistics;
             var root = tileset.root;
 
@@ -2754,7 +2758,7 @@ describe('Scene/Cesium3DTileset', function() {
     });
 
     it('does not create duplicate backface commands if no selected descendants', function() {
-        return Cesium3DTilesTester.loadTileset(scene, tilesetReplacement3Url).then(function(tileset) {
+        return Cesium3DTilesTester.loadTileset(scene, tilesetReplacement3Url, skipLevelOfDetailOptions).then(function(tileset) {
             var statistics = tileset._statistics;
             var root = tileset.root;
 
@@ -2779,6 +2783,7 @@ describe('Scene/Cesium3DTileset', function() {
 
     it('does not add commands or stencil clear command with no selected tiles', function() {
         options.url = tilesetUrl;
+        options.skipLevelOfDetail = true;
         var tileset = scene.primitives.add(new Cesium3DTileset(options));
         scene.renderForSpecs();
         var statistics = tileset._statistics;
@@ -2788,7 +2793,7 @@ describe('Scene/Cesium3DTileset', function() {
 
     it('does not add stencil clear command or backface commands when fully resolved', function() {
         viewAllTiles();
-        return Cesium3DTilesTester.loadTileset(scene, tilesetReplacement3Url).then(function(tileset) {
+        return Cesium3DTilesTester.loadTileset(scene, tilesetReplacement3Url, skipLevelOfDetailOptions).then(function(tileset) {
             var statistics = tileset._statistics;
             expect(statistics.numberOfCommands).toEqual(tileset._selectedTiles.length);
 
@@ -2805,6 +2810,7 @@ describe('Scene/Cesium3DTileset', function() {
     it('loadSiblings', function() {
         viewBottomLeft();
         return Cesium3DTilesTester.loadTileset(scene, tilesetReplacement3Url, {
+            skipLevelOfDetail : true,
             loadSiblings : false,
             foveatedTimeDelay : 0
         }).then(function(tileset) {
@@ -2821,6 +2827,7 @@ describe('Scene/Cesium3DTileset', function() {
     it('immediatelyLoadDesiredLevelOfDetail', function() {
         viewNothing();
         return Cesium3DTilesTester.loadTileset(scene, tilesetUrl, {
+            skipLevelOfDetail : true,
             immediatelyLoadDesiredLevelOfDetail : true
         }).then(function(tileset) {
             var root = tileset.root;
@@ -2846,7 +2853,7 @@ describe('Scene/Cesium3DTileset', function() {
     });
 
     it('selects children if no ancestors available', function() {
-        return Cesium3DTilesTester.loadTileset(scene, tilesetOfTilesetsUrl).then(function(tileset) {
+        return Cesium3DTilesTester.loadTileset(scene, tilesetOfTilesetsUrl, skipLevelOfDetailOptions).then(function(tileset) {
             var statistics = tileset._statistics;
             var parent = tileset.root.children[0];
             var child = parent.children[3].children[0];


### PR DESCRIPTION
3D Tiles skip lods has some pretty serious artifacts fundamental to the algorithm and we should disable it until we have the chance to fix it. I'm aware that this will cause more tiles to be downloaded and more memory usage but I think its more important that tilesets are artifact free. Thoughts?

![bivariate-arifacts](https://user-images.githubusercontent.com/915398/75300648-928d4000-5806-11ea-9bab-e3af48c20f10.gif)

![artifacts](https://user-images.githubusercontent.com/915398/75300774-f1eb5000-5806-11ea-890b-4c2e70b6f40b.gif)

![artifacts2](https://user-images.githubusercontent.com/915398/75300768-ee57c900-5806-11ea-9733-01ce408e286f.gif)
