### PR TITLE
Update NYC 3D Tiles demo to use new Asset Depot tileset

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
@@ -40,7 +40,7 @@ viewer.scene.camera.setView({
 });
 
 // Load the NYC buildings tileset
-var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(5741) });
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(75343) });
 viewer.scene.primitives.add(tileset);
 
 // HTML overlay for showing feature name on mouseover
@@ -99,10 +99,7 @@ if (Cesium.PostProcessStageLibrary.isSilhouetteSupported(viewer.scene)) {
         nameOverlay.style.display = 'block';
         nameOverlay.style.bottom = viewer.canvas.clientHeight - movement.endPosition.y + 'px';
         nameOverlay.style.left = movement.endPosition.x + 'px';
-        var name = pickedFeature.getProperty('name');
-        if (!Cesium.defined(name)) {
-            name = pickedFeature.getProperty('id');
-        }
+        var name = pickedFeature.getProperty('BIN');
         nameOverlay.textContent = name;
 
         // Highlight the feature if it's not already selected.

--- a/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
@@ -41,7 +41,7 @@ viewer.scene.camera.setView({
 });
 
 // Load the NYC buildings tileset.
-var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(5741) });
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(75343) });
 viewer.scene.primitives.add(tileset);
 
 // Color buildings based on their height.
@@ -49,13 +49,13 @@ function colorByHeight() {
     tileset.style = new Cesium.Cesium3DTileStyle({
         color: {
             conditions: [
-                ['${height} >= 300', 'rgba(45, 0, 75, 0.5)'],
-                ['${height} >= 200', 'rgb(102, 71, 151)'],
-                ['${height} >= 100', 'rgb(170, 162, 204)'],
-                ['${height} >= 50', 'rgb(224, 226, 238)'],
-                ['${height} >= 25', 'rgb(252, 230, 200)'],
-                ['${height} >= 10', 'rgb(248, 176, 87)'],
-                ['${height} >= 5', 'rgb(198, 106, 11)'],
+                ['${Height} >= 300', 'rgba(45, 0, 75, 0.5)'],
+                ['${Height} >= 200', 'rgb(102, 71, 151)'],
+                ['${Height} >= 100', 'rgb(170, 162, 204)'],
+                ['${Height} >= 50', 'rgb(224, 226, 238)'],
+                ['${Height} >= 25', 'rgb(252, 230, 200)'],
+                ['${Height} >= 10', 'rgb(248, 176, 87)'],
+                ['${Height} >= 5', 'rgb(198, 106, 11)'],
                 ['true', 'rgb(127, 59, 8)']
             ]
         }
@@ -66,7 +66,7 @@ function colorByHeight() {
 function colorByLatitude() {
     tileset.style = new Cesium.Cesium3DTileStyle({
         defines: {
-            latitudeRadians: 'radians(${latitude})'
+            latitudeRadians: 'radians(${Latitude})'
         },
         color: {
             conditions: [
@@ -86,7 +86,7 @@ function colorByLatitude() {
 function colorByDistance() {
     tileset.style = new Cesium.Cesium3DTileStyle({
         defines : {
-            distance : 'distance(vec2(radians(${longitude}), radians(${latitude})), vec2(-1.291777521, 0.7105706624))'
+            distance : 'distance(vec2(radians(${Longitude}), radians(${Latitude})), vec2(-1.291777521, 0.7105706624))'
         },
         color : {
             conditions : [
@@ -100,17 +100,17 @@ function colorByDistance() {
     });
 }
 
-// Color buildings with a '3' in their name.
-function colorByNameRegex() {
+// Color buildings with a '3' in their BIN property.
+function colorByStringRegex() {
     tileset.style = new Cesium.Cesium3DTileStyle({
-        color : "(regExp('3').test(String(${name}))) ? color('cyan', 0.9) : color('purple', 0.1)"
+        color : "(regExp('3').test(String(${BIN}))) ? color('cyan', 0.9) : color('purple', 0.1)"
     });
 }
 
 // Show only buildings greater than 200 meters in height.
 function hideByHeight() {
     tileset.style = new Cesium.Cesium3DTileStyle({
-        show : '${height} > 200'
+        show : '${Height} > 200'
     });
 }
 
@@ -132,7 +132,7 @@ Sandcastle.addToolbarMenu([{
 }, {
     text : 'Color By Name Regex',
     onselect : function() {
-        colorByNameRegex();
+        colorByStringRegex();
     }
 }, {
     text : 'Hide By Height',

--- a/Apps/Sandcastle/gallery/3D Tiles Inspector.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Inspector.html
@@ -32,7 +32,7 @@ viewer.scene.globe.depthTestAgainstTerrain = true;
 viewer.extend(Cesium.viewerCesium3DTilesInspectorMixin);
 var inspectorViewModel = viewer.cesium3DTilesInspector.viewModel;
 
-var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(5741) });
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(75343) });
 viewer.scene.primitives.add(tileset);
 
 tileset.readyPromise.then(function(){

--- a/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
@@ -72,11 +72,11 @@ scene.camera.setView({
 });
 
 // Load the NYC buildings tileset.
-var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(5741) });
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(75343) });
 scene.primitives.add(tileset);
 tileset.style = new Cesium.Cesium3DTileStyle({
     meta: {
-        description: "'Building id ${id} has height ${height}.'"
+        description: "'Building ${BIN} has height ${Height}.'"
     }
 });
 
@@ -144,9 +144,9 @@ function printProperties(movement, feature) {
 }
 
 function zoom(movement, feature) {
-    var longitude = Cesium.Math.toRadians(feature.getProperty('longitude'));
-    var latitude = Cesium.Math.toRadians(feature.getProperty('latitude'));
-    var height = feature.getProperty('height');
+    var longitude = Cesium.Math.toRadians(feature.getProperty('Longitude'));
+    var latitude = Cesium.Math.toRadians(feature.getProperty('Latitude'));
+    var height = feature.getProperty('Height');
 
     var positionCartographic = new Cesium.Cartographic(longitude, latitude, height * 0.5);
     var position = scene.globe.ellipsoid.cartographicToCartesian(positionCartographic);

--- a/Apps/Sandcastle/gallery/FXAA.html
+++ b/Apps/Sandcastle/gallery/FXAA.html
@@ -33,7 +33,7 @@ viewer.scene.camera.setView({
 });
 
 viewer.scene.primitives.add(new Cesium.Cesium3DTileset({
-    url: Cesium.IonResource.fromAssetId(5741)
+    url: Cesium.IonResource.fromAssetId(75343)
 }));
 
 viewer.scene.postProcessStages.fxaa.enabled = true;

--- a/Apps/Sandcastle/gallery/development/3D Tiles Performance Testing.html
+++ b/Apps/Sandcastle/gallery/development/3D Tiles Performance Testing.html
@@ -52,7 +52,7 @@ var referenceMaximum = new Cesium.JulianDate();
 var heatmapTileProperty = '_foveatedFactor';
 
 var tileset = new Cesium.Cesium3DTileset({
-    url: Cesium.IonResource.fromAssetId(5741),
+    url: Cesium.IonResource.fromAssetId(75343),
     debugHeatmapTilePropertyName: heatmapTileProperty
 });
 


### PR DESCRIPTION
The old NYC tileset we used was not available to all ion users and was specific to CesiumJS. This new version is now available on the Asset Depot and can be used by anyone with an ion account.