### PR TITLE
Fix 3d tiles vctr polylines feature table reading

### DIFF
--- a/Source/Scene/Vector3DTileContent.js
+++ b/Source/Scene/Vector3DTileContent.js
@@ -1,4 +1,4 @@
-// import Cartesian3 from '../Core/Cartesian3.js';
+import Cartesian3 from '../Core/Cartesian3.js';
 import defaultValue from '../Core/defaultValue.js';
 import defined from '../Core/defined.js';
 import defineProperties from '../Core/defineProperties.js';
@@ -317,8 +317,9 @@ import Vector3DTilePolylines from './Vector3DTilePolylines.js';
 
         var modelMatrix = content._tile.computedTransform;
 
-        var center = featureTable.getGlobalProperty('RTC_CENTER');
+        var center = featureTable.getGlobalProperty('RTC_CENTER', ComponentDatatype.FLOAT, 3);
         if (defined(center)) {
+            center = Cartesian3.unpack(center);
             Matrix4.multiplyByPoint(modelMatrix, center, center);
         } else {
             center = Rectangle.center(rectangle);

--- a/Source/Scene/Vector3DTileContent.js
+++ b/Source/Scene/Vector3DTileContent.js
@@ -372,9 +372,15 @@ import Vector3DTilePolylines from './Vector3DTilePolylines.js';
         }
 
         if (numberOfPolylines > 0) {
-            var polylineCounts = featureTable.getPropertyArray('POLYLINE_COUNTS', ComponentDatatype.UNSIGNED_INT, numberOfPolylines);
+            featureTable.featuresLength = numberOfPolylines;
+
+            var polylineCounts = defaultValue(
+                featureTable.getPropertyArray('POLYLINE_COUNTS', ComponentDatatype.UNSIGNED_INT, numberOfPolylines),
+                featureTable.getPropertyArray('POLYLINE_COUNT', ComponentDatatype.UNSIGNED_INT, numberOfPolylines) // Workaround for old vector tilesets using the non-plural name
+            );
+
             if (!defined(polylineCounts)) {
-              throw new RuntimeError('Feature table property: POLYLINE_COUNTS must be defined when POLYLINES_LENGTH is greater than 0');
+                throw new RuntimeError('Feature table property: POLYLINE_COUNTS must be defined when POLYLINES_LENGTH is greater than 0');
             }
 
             var widths = featureTable.getPropertyArray('POLYLINE_WIDTHS', ComponentDatatype.UNSIGNED_SHORT, numberOfPolylines);
@@ -388,7 +394,7 @@ import Vector3DTilePolylines from './Vector3DTilePolylines.js';
             // Use the counts array to determine how many position values we want. If we used the byte length then
             // zero padding values would be included and cause the delta zig-zag decoding to fail
             var numPolylinePositions = polylineCounts.reduce(function(total, count) {
-              return total + count * 3;
+                return total + count * 3;
             }, 0);
             var polylinePositions = new Uint16Array(arrayBuffer, byteOffset, numPolylinePositions);
             byteOffset += polylinePositionByteLength;

--- a/Source/Scene/Vector3DTileContent.js
+++ b/Source/Scene/Vector3DTileContent.js
@@ -220,7 +220,6 @@ import Vector3DTilePolylines from './Vector3DTilePolylines.js';
         };
     }
 
-    var sizeOfUint16 = Uint16Array.BYTES_PER_ELEMENT;
     var sizeOfUint32 = Uint32Array.BYTES_PER_ELEMENT;
 
     function initialize(content, arrayBuffer, byteOffset) {

--- a/Source/Scene/Vector3DTileContent.js
+++ b/Source/Scene/Vector3DTileContent.js
@@ -409,6 +409,7 @@ import Vector3DTilePolylines from './Vector3DTilePolylines.js';
 
         if (numberOfPoints > 0) {
             var pointPositions = new Uint16Array(arrayBuffer, byteOffset, numberOfPoints * 3);
+            byteOffset += pointsPositionByteLength;
             content._points = new Vector3DTilePoints({
                 positions : pointPositions,
                 batchIds : batchIds.points,

--- a/Source/Scene/Vector3DTileContent.js
+++ b/Source/Scene/Vector3DTileContent.js
@@ -1,4 +1,4 @@
-import Cartesian3 from '../Core/Cartesian3.js';
+// import Cartesian3 from '../Core/Cartesian3.js';
 import defaultValue from '../Core/defaultValue.js';
 import defined from '../Core/defined.js';
 import defineProperties from '../Core/defineProperties.js';
@@ -6,12 +6,14 @@ import destroyObject from '../Core/destroyObject.js';
 import DeveloperError from '../Core/DeveloperError.js';
 import Ellipsoid from '../Core/Ellipsoid.js';
 import getStringFromTypedArray from '../Core/getStringFromTypedArray.js';
+import ComponentDatatype from '../Core/ComponentDatatype.js';
 import CesiumMath from '../Core/Math.js';
 import Matrix4 from '../Core/Matrix4.js';
 import Rectangle from '../Core/Rectangle.js';
 import RuntimeError from '../Core/RuntimeError.js';
 import when from '../ThirdParty/when.js';
 import Cesium3DTileBatchTable from './Cesium3DTileBatchTable.js';
+import Cesium3DTileFeatureTable from './Cesium3DTileFeatureTable.js';
 import Vector3DTilePoints from './Vector3DTilePoints.js';
 import Vector3DTilePolygons from './Vector3DTilePolygons.js';
 import Vector3DTilePolylines from './Vector3DTilePolylines.js';
@@ -304,23 +306,19 @@ import Vector3DTilePolylines from './Vector3DTilePolylines.js';
             return;
         }
 
-        var rectangle;
-        var minHeight;
-        var maxHeight;
-        if (defined(featureTableJson.REGION)) {
-            var region = featureTableJson.REGION;
-            rectangle = Rectangle.unpack(region);
-            minHeight = region[4];
-            maxHeight = region[5];
-        } else {
-            throw new RuntimeError('REGION is required in the feature table.');
+        var featureTable = new Cesium3DTileFeatureTable(featureTableJson, featureTableBinary);
+        var region = featureTable.getGlobalProperty('REGION');
+        if (!defined(region)) {
+            throw new RuntimeError('Feature table global property: REGION must be defined');
         }
+        var rectangle = Rectangle.unpack(region);
+        var minHeight = region[4];
+        var maxHeight = region[5];
 
         var modelMatrix = content._tile.computedTransform;
 
-        var center;
-        if (defined(featureTableJson.RTC_CENTER)) {
-            center = Cartesian3.unpack(featureTableJson.RTC_CENTER);
+        var center = featureTable.getGlobalProperty('RTC_CENTER');
+        if (defined(center)) {
             Matrix4.multiplyByPoint(modelMatrix, center, center);
         } else {
             center = Rectangle.center(rectangle);
@@ -329,7 +327,6 @@ import Vector3DTilePolylines from './Vector3DTilePolylines.js';
         }
 
         var batchIds = getBatchIds(featureTableJson, featureTableBinary);
-
         byteOffset += byteOffset % 4;
 
         if (numberOfPolygons > 0) {
@@ -374,22 +371,26 @@ import Vector3DTilePolylines from './Vector3DTilePolylines.js';
         }
 
         if (numberOfPolylines > 0) {
-            var polylinePositions = new Uint16Array(arrayBuffer, byteOffset, polylinePositionByteLength / sizeOfUint16);
-            byteOffset += polylinePositionByteLength;
+            var polylineCounts = featureTable.getPropertyArray('POLYLINE_COUNTS', ComponentDatatype.UNSIGNED_INT, numberOfPolylines);
+            if (!defined(polylineCounts)) {
+              throw new RuntimeError('Feature table property: POLYLINE_COUNTS must be defined when POLYLINES_LENGTH is greater than 0');
+            }
 
-            var polylineCountByteOffset = featureTableBinary.byteOffset + featureTableJson.POLYLINE_COUNT.byteOffset;
-            var polylineCounts = new Uint32Array(featureTableBinary.buffer, polylineCountByteOffset, numberOfPolylines);
-
-            var widths;
-            if (!defined(featureTableJson.POLYLINE_WIDTHS)) {
+            var widths = featureTable.getPropertyArray('POLYLINE_WIDTHS', ComponentDatatype.UNSIGNED_SHORT, numberOfPolylines);
+            if (!defined(widths)) {
                 widths = new Uint16Array(numberOfPolylines);
                 for (var i = 0; i < numberOfPolylines; ++i) {
                     widths[i] = 2.0;
                 }
-            } else {
-                var polylineWidthsByteOffset = featureTableBinary.byteOffset + featureTableJson.POLYLINE_WIDTHS.byteOffset;
-                widths = new Uint16Array(featureTableBinary.buffer, polylineWidthsByteOffset, numberOfPolylines);
             }
+
+            // Use the counts array to determine how many position values we want. If we used the byte length then
+            // zero padding values would be included and cause the delta zig-zag decoding to fail
+            var numPolylinePositions = polylineCounts.reduce(function(total, count) {
+              return total + count * 3;
+            }, 0);
+            var polylinePositions = new Uint16Array(arrayBuffer, byteOffset, numPolylinePositions);
+            byteOffset += polylinePositionByteLength;
 
             content._polylines = new Vector3DTilePolylines({
                 positions : polylinePositions,

--- a/Source/Scene/Vector3DTileContent.js
+++ b/Source/Scene/Vector3DTileContent.js
@@ -408,7 +408,7 @@ import Vector3DTilePolylines from './Vector3DTilePolylines.js';
         }
 
         if (numberOfPoints > 0) {
-            var pointPositions = new Uint16Array(arrayBuffer, byteOffset, pointsPositionByteLength / sizeOfUint16);
+            var pointPositions = new Uint16Array(arrayBuffer, byteOffset, numberOfPoints * 3);
             content._points = new Vector3DTilePoints({
                 positions : pointPositions,
                 batchIds : batchIds.points,

--- a/Source/Scene/Vector3DTileContent.js
+++ b/Source/Scene/Vector3DTileContent.js
@@ -334,8 +334,8 @@ import Vector3DTilePolylines from './Vector3DTilePolylines.js';
             featureTable.featuresLength = numberOfPolygons;
 
             var polygonCounts = defaultValue(
-                featureTable.getPropertyArray('POLYGON_COUNTS', ComponentDatatype.UNSIGNED_INT, numberOfPolygons),
-                featureTable.getPropertyArray('POLYGON_COUNT', ComponentDatatype.UNSIGNED_INT, numberOfPolygons) // Workaround for old vector tilesets using the non-plural name
+                featureTable.getPropertyArray('POLYGON_COUNTS', ComponentDatatype.UNSIGNED_INT, 1),
+                featureTable.getPropertyArray('POLYGON_COUNT', ComponentDatatype.UNSIGNED_INT, 1) // Workaround for old vector tilesets using the non-plural name
             );
 
             if (!defined(polygonCounts)) {
@@ -343,8 +343,8 @@ import Vector3DTilePolylines from './Vector3DTilePolylines.js';
             }
 
             var polygonIndexCounts = defaultValue(
-                featureTable.getPropertyArray('POLYGON_INDEX_COUNTS', ComponentDatatype.UNSIGNED_INT, numberOfPolygons),
-                featureTable.getPropertyArray('POLYGON_INDEX_COUNT', ComponentDatatype.UNSIGNED_INT, numberOfPolygons) // Workaround for old vector tilesets using the non-plural name
+                featureTable.getPropertyArray('POLYGON_INDEX_COUNTS', ComponentDatatype.UNSIGNED_INT, 1),
+                featureTable.getPropertyArray('POLYGON_INDEX_COUNT', ComponentDatatype.UNSIGNED_INT, 1) // Workaround for old vector tilesets using the non-plural name
             );
 
             if (!defined(polygonIndexCounts)) {
@@ -370,8 +370,8 @@ import Vector3DTilePolylines from './Vector3DTilePolylines.js';
             var polygonMinimumHeights;
             var polygonMaximumHeights;
             if (defined(featureTableJson.POLYGON_MINIMUM_HEIGHTS) && defined(featureTableJson.POLYGON_MAXIMUM_HEIGHTS)) {
-                polygonMinimumHeights = featureTable.getPropertyArray('POLYGON_MINIMUM_HEIGHTS', ComponentDatatype.FLOAT, numberOfPolygons);
-                polygonMaximumHeights = featureTable.getPropertyArray('POLYGON_MAXIMUM_HEIGHTS', ComponentDatatype.FLOAT, numberOfPolygons);
+                polygonMinimumHeights = featureTable.getPropertyArray('POLYGON_MINIMUM_HEIGHTS', ComponentDatatype.FLOAT, 1);
+                polygonMaximumHeights = featureTable.getPropertyArray('POLYGON_MAXIMUM_HEIGHTS', ComponentDatatype.FLOAT, 1);
             }
 
             content._polygons = new Vector3DTilePolygons({
@@ -396,15 +396,15 @@ import Vector3DTilePolylines from './Vector3DTilePolylines.js';
             featureTable.featuresLength = numberOfPolylines;
 
             var polylineCounts = defaultValue(
-                featureTable.getPropertyArray('POLYLINE_COUNTS', ComponentDatatype.UNSIGNED_INT, numberOfPolylines),
-                featureTable.getPropertyArray('POLYLINE_COUNT', ComponentDatatype.UNSIGNED_INT, numberOfPolylines) // Workaround for old vector tilesets using the non-plural name
+                featureTable.getPropertyArray('POLYLINE_COUNTS', ComponentDatatype.UNSIGNED_INT, 1),
+                featureTable.getPropertyArray('POLYLINE_COUNT', ComponentDatatype.UNSIGNED_INT, 1) // Workaround for old vector tilesets using the non-plural name
             );
 
             if (!defined(polylineCounts)) {
                 throw new RuntimeError('Feature table property: POLYLINE_COUNTS must be defined when POLYLINES_LENGTH is greater than 0');
             }
 
-            var widths = featureTable.getPropertyArray('POLYLINE_WIDTHS', ComponentDatatype.UNSIGNED_SHORT, numberOfPolylines);
+            var widths = featureTable.getPropertyArray('POLYLINE_WIDTHS', ComponentDatatype.UNSIGNED_SHORT, 1);
             if (!defined(widths)) {
                 widths = new Uint16Array(numberOfPolylines);
                 for (var i = 0; i < numberOfPolylines; ++i) {


### PR DESCRIPTION
Fixes as few issues with the .vctr 3d tiles format reader.

 - Use `POLYLINE_COUNTS` instead of `POLYLINE_COUNT` (see [spec](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/TileFormats/VectorData))
- Read the positions array based on the number of polylines rather than buffer size to avoid reading zero padding at end of array used for byte offset alignment
- Allow widths and counts to be specified directly in JSON or in binary format as per feature table spec