### PR TITLE
Use LEQUAL instead of LESS for depth testing models.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 ##### Breaking Changes :mega:
 * `Cesium3DTileset.skipLevelOfDetail` is now `false` by default. [#8631](https://github.com/CesiumGS/cesium/pull/8631)
+* glTF models are now rendered using the `LEQUALS` depth test function insead of `LESS`. This means that when geometry overlaps, the _later_ geometry will be visible above the earlier, where previously the opposite was true. We believe this is a more sensible default, and makes it easier to render e.g. outlined buildings with glTF.
 
 ##### Additions :tada:
 

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -57,6 +57,7 @@ import Axis from './Axis.js';
 import BlendingState from './BlendingState.js';
 import ClippingPlaneCollection from './ClippingPlaneCollection.js';
 import ColorBlendMode from './ColorBlendMode.js';
+import DepthFunction from './DepthFunction.js';
 import DracoLoader from './DracoLoader.js';
 import getClipAndStyleCode from './getClipAndStyleCode.js';
 import getClippingFunction from './getClippingFunction.js';
@@ -3011,7 +3012,7 @@ import ShadowMode from './ShadowMode.js';
             },
             depthTest : {
                 enabled : true,
-                func: WebGLConstants.LEQUAL
+                func: DepthFunction.LESS_OR_EQUAL
             },
             depthMask : !blendingEnabled,
             blending : {

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -3010,7 +3010,8 @@ import ShadowMode from './ShadowMode.js';
                 enabled : enableCulling
             },
             depthTest : {
-                enabled : true
+                enabled : true,
+                func: WebGLConstants.LEQUAL
             },
             depthMask : !blendingEnabled,
             blending : {

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -32,6 +32,7 @@ import { DracoLoader } from '../../Source/Cesium.js';
 import { HeightReference } from '../../Source/Cesium.js';
 import { Model } from '../../Source/Cesium.js';
 import { ModelAnimationLoop } from '../../Source/Cesium.js';
+import { DepthFunction } from '../../Source/Cesium.js';
 import createScene from '../createScene.js';
 import pollToPromise from '../pollToPromise.js';
 import { when } from '../../Source/Cesium.js';
@@ -522,7 +523,8 @@ describe('Scene/Model', function() {
                     enabled : true
                 },
                 depthTest : {
-                    enabled : true
+                    enabled : true,
+                    func : DepthFunction.LESS_OR_EQUAL
                 },
                 depthMask : true,
                 blending : {


### PR DESCRIPTION
This means that a glTF that has a primitive with filled faces followed by a primitive with edge lines will look like this:
![image](https://user-images.githubusercontent.com/924374/75649961-b9d18a80-5ca8-11ea-9a82-4b37699f80f5.png)

Where previously it looked like this:
![image](https://user-images.githubusercontent.com/924374/75649975-c229c580-5ca8-11ea-8f84-2f6f6c833c83.png)

If this looks ok to everyone it would be really great to get it into the March CesiumJS release!