### PR TITLE
Fix vector tiles precision

### DIFF
--- a/Source/WorkersES6/createVectorTilePolygons.js
+++ b/Source/WorkersES6/createVectorTilePolygons.js
@@ -136,7 +136,7 @@ import createTaskProcessorWorker from './createTaskProcessorWorker.js';
         var vBuffer = positions.subarray(positionsLength, 2 * positionsLength);
         AttributeCompression.zigZagDeltaDecode(uBuffer, vBuffer);
 
-        var decodedPositions = new Float32Array(positionsLength * 3);
+        var decodedPositions = new Float64Array(positionsLength * 3);
         for (i = 0; i < positionsLength; ++i) {
             var u = uBuffer[i];
             var v = vBuffer[i];

--- a/Source/WorkersES6/createVectorTilePolylines.js
+++ b/Source/WorkersES6/createVectorTilePolylines.js
@@ -19,7 +19,7 @@ import createTaskProcessorWorker from './createTaskProcessorWorker.js';
         var heightBuffer = positions.subarray(2 * positionsLength, 3 * positionsLength);
         AttributeCompression.zigZagDeltaDecode(uBuffer, vBuffer, heightBuffer);
 
-        var decoded = new Float32Array(positions.length);
+        var decoded = new Float64Array(positions.length);
         for (var i = 0; i < positionsLength; ++i) {
             var u = uBuffer[i];
             var v = vBuffer[i];


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/8656 by using Float64Array's to store the decoded cartesian positions.

[Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=dZTbbuM2EIZfhfCNHcCheBaZOkHRTe92sUB30V5EvmAkZs1GplSRcuAt9t07kuysD6gvdJghP/4z1j8726Gdd2+uQ/couDf0wUXfb/GfY2wxL8fXD01I1gfXzZfo3yIg+O263/qUmoDuUOp6t5yinfundzH94ULluk9N5Q7pIvy4+aUIRcgy9LGxFfIBpY1D/BElX7uIarsHCW8+bRDelakbw2ixta8O+QTc6qYIOxCbznVON/74daC4tBjV9V0N5843KbV3WVY3pa03TUx3mhCWxWSTL7NHF19T02Zp2oj/jk2Yj1VU7rn/9pfv3Etnt+5Mf8Ix7UHX/0r4MqQnEWVTN90gY3xYFDOooZjdzA+oqek4li443HZ+65PfuYhtVS3Se68+2dDbut6jsnM2OWRR29T7Gv4K1Ecfvo1NbBsfUkSL2tkdLIlQwYvt64Ru0dvGJwedK5sQ03HhPXoaBD6hW6GYyXmOlRSKMMnYEjGZU6kMJkIaw3IpxBLdcimYkBwLrnOuGBFovTxDcCy1IYSYAyAnwOTMcE1y+Q6gmAquckaJvCIQTJWiBk7gRwbDiuaQ1OwdIQzmgufSSKUuCCzHnGmuOIeTjgiBDVFaK5nrd0SOjRFDdZSyS4bEhAujda71EZFjCEhpOCfqhEGUkIqCGH3J4JgpCh1llB4YmmCeG6KBz3+WojC8MSk1F/KSQUGj4YwzedShocUCVjJBjDphcGOkZtqwawSTgsCR+ZGgACoJp1zRE4BSjDGuzPV+IqCpVOTiADAE51A0MIQRJ63g3ChuJNR8zRBUMcoHxRNCYE0V3A056YTG8PlBIxQchtZAWOOtbRctun84M5rtEjzZwBftE1kvUftExytb3wyOQdNXfmHP30PyaT95EgVw9ODJwUGT238a6u442iAUwY0Ag9jkmTHxA66jdw8TE7sB7Q+mdaeZ702z/doMsdlythqHxsME/9Vv26ZLw4xaYJwlt21rcHbMnvvyFeZQGeMAWmXHTavK75Cv7ovZxSwuZqisbYyQeenr+ov/7orZwyqD9Wfbapi3MCo+71wHU3ZYsqEPH6cgxniVwev1rtQ09bPtToj/AQ) (need to be on a branch that combines this and https://github.com/CesiumGS/cesium/pull/8639)  and [tileset.zip](https://github.com/CesiumGS/cesium/files/4281448/tileset.zip)


@likangning93 can you review?