### PR TITLE
fixed formatting  a file:// URI

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -254,3 +254,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Daniel Leone](https://github.com/danielleone)
 - [Zhou Jiang](https://github.com/aboutqx)
 - [SungHo Lim](https://github.com/SambaLim)
+- [Michael Fink](https://github.com/vividos)

--- a/Source/ThirdParty/Uri.js
+++ b/Source/ThirdParty/Uri.js
@@ -262,6 +262,11 @@
 			result += this.scheme + ':';
 		if (this.authority)
 			result += '//' + this.authority;
+		else
+			// this else branch was added in cesium repository to fix URI handling in Android WebView context
+			// see: https://github.com/CesiumGS/cesium/pull/8669
+			if (this.scheme == "file")
+				result += '//';
 		result += this.path;
 		if (this.query)
 			result += '?' + this.query;


### PR DESCRIPTION
add the two forward slashes even when the authority part of the URI is empty
do this only for "file" scheme, to not break other schemes like mailto: or tel:
see RFC 3986 for details

part of a fix for #8665