### PR TITLE
Don't hardcode WGS84 in shaders

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@ Change Log
 
 * Interacting with the Cesium canvas will now blur the previously focused element. This prevents unintended modification of input elements when interacting with the globe.
 * `TileMapServiceImageryProvider` will now force `minimumLevel` to 0 if the `tilemapresource.xml` metadata request fails and the `rectangle` is too large for the given detail level [#8448](https://github.com/AnalyticalGraphicsInc/cesium/pull/8448)
+* Fixed ground atmosphere rendering when using a samller ellipsoid. [#8683](https://github.com/CesiumGS/cesium/issues/8683)
+* Fixed globe incorrectly occluding objects when using a smaller ellipsoid. [#7124](https://github.com/CesiumGS/cesium/issues/7124)
 
 ### 1.67.0 - 2020-03-02
 

--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -1864,6 +1864,34 @@ import WebGLConstants from '../Core/WebGLConstants.js';
             getValue : function(uniformState) {
                 return uniformState.gamma;
             }
+        }),
+
+        /**
+         * An automatic GLSL uniform that stores the ellipsoid radii.
+         *
+         * @alias czm_ellipsoidRadii
+         * @glslUniform
+         */
+        czm_ellipsoidRadii : new AutomaticUniform({
+            size : 1,
+            datatype : WebGLConstants.FLOAT_VEC3,
+            getValue : function(uniformState) {
+                return uniformState.ellipsoid.radii;
+            }
+        }),
+
+        /**
+         * An automatic GLSL uniform that stores the ellipsoid inverse radii.
+         *
+         * @alias czm_ellipsoidRadii
+         * @glslUniform
+         */
+        czm_ellipsoidInverseRadii : new AutomaticUniform({
+            size : 1,
+            datatype : WebGLConstants.FLOAT_VEC3,
+            getValue : function(uniformState) {
+                return uniformState.ellipsoid.oneOverRadii;
+            }
         })
     };
 export default AutomaticUniforms;

--- a/Source/Renderer/UniformState.js
+++ b/Source/Renderer/UniformState.js
@@ -6,6 +6,7 @@ import Cartographic from '../Core/Cartographic.js';
 import Color from '../Core/Color.js';
 import defaultValue from '../Core/defaultValue.js';
 import defined from '../Core/defined.js';
+import Ellipsoid from '../Core/Ellipsoid.js';
 import EncodedCartesian3 from '../Core/EncodedCartesian3.js';
 import CesiumMath from '../Core/Math.js';
 import Matrix3 from '../Core/Matrix3.js';
@@ -135,6 +136,7 @@ import SunLight from '../Scene/SunLight.js';
         this._pass = undefined;
         this._mode = undefined;
         this._mapProjection = undefined;
+        this._ellipsoid = undefined;
         this._cameraDirection = new Cartesian3();
         this._cameraRight = new Cartesian3();
         this._cameraUp = new Cartesian3();
@@ -998,6 +1000,18 @@ import SunLight from '../Scene/SunLight.js';
             get : function() {
                 return this._orthographicIn3D;
             }
+        },
+
+        /**
+         * The current ellipsoid.
+         *
+         * @memberOf UniformState.prototype
+         * @type {Ellipsoid}
+         */
+        ellipsoid : {
+            get : function() {
+                return defaultValue(this._ellipsoid, Ellipsoid.WGS84);
+            }
         }
     });
 
@@ -1143,6 +1157,7 @@ import SunLight from '../Scene/SunLight.js';
     UniformState.prototype.update = function(frameState) {
         this._mode = frameState.mode;
         this._mapProjection = frameState.mapProjection;
+        this._ellipsoid = frameState.mapProjection.ellipsoid;
         this._pixelRatio = frameState.pixelRatio;
 
         var camera = frameState.camera;

--- a/Source/Shaders/Builtin/Constants/ellipsoidInverseRadii.glsl
+++ b/Source/Shaders/Builtin/Constants/ellipsoidInverseRadii.glsl
@@ -1,7 +1,0 @@
-/**
- * The reciprocal of the radius of the WGS84 ellipsoid.
- *
- * @name czm_ellipsoidInverseRadii
- * @glslConstant
- */
-const vec3 czm_ellipsoidInverseRadii = vec3(1.0 / 6378137.0, 1.0 / 6378137.0, 1.0 / 6356752.314245);

--- a/Source/Shaders/Builtin/Constants/ellipsoidRadii.glsl
+++ b/Source/Shaders/Builtin/Constants/ellipsoidRadii.glsl
@@ -1,7 +1,0 @@
-/**
- * The radius of the WGS84 ellipsoid.
- *
- * @name czm_ellipsoidRadii
- * @glslConstant
- */
-const vec3 czm_ellipsoidRadii = vec3(6378137.0, 6378137.0, 6356752.314245);

--- a/Source/Shaders/GroundAtmosphere.glsl
+++ b/Source/Shaders/GroundAtmosphere.glsl
@@ -44,6 +44,8 @@ const float fKmESun = Km * ESun;
 const float fKr4PI = Kr * 4.0 * czm_pi;
 const float fKm4PI = Km * 4.0 * czm_pi;
 
+const vec3 v3InvWavelength = vec3(1.0 / pow(0.650, 4.0), 1.0 / pow(0.570, 4.0), 1.0 / pow(0.475, 4.0));
+
 const float fScaleDepth = 0.25;
 
 struct AtmosphereColor
@@ -69,8 +71,6 @@ AtmosphereColor computeGroundAtmosphereFromSpace(vec3 v3Pos, bool dynamicLightin
 
     float fScale = 1.0 / (fOuterRadius - fInnerRadius);
     float fScaleOverScaleDepth = fScale / fScaleDepth;
-
-    vec3 v3InvWavelength = vec3(1.0 / pow(0.650, 4.0), 1.0 / pow(0.570, 4.0), 1.0 / pow(0.475, 4.0));
 
     // Get the ray from the camera to the vertex and its length (which is the far point of the ray passing through the atmosphere)
     vec3 v3Ray = v3Pos - czm_viewerPositionWC;

--- a/Source/Shaders/GroundAtmosphere.glsl
+++ b/Source/Shaders/GroundAtmosphere.glsl
@@ -35,10 +35,6 @@
  //   Code:  http://sponeil.net/
  //   GPU Gems 2 Article:  https://developer.nvidia.com/gpugems/GPUGems2/gpugems2_chapter16.html
 
-const float fInnerRadius = 6378137.0;
-const float fOuterRadius = 6378137.0 * 1.025;
-const float fOuterRadius2 = fOuterRadius * fOuterRadius;
-
 const float Kr = 0.0025;
 const float Km = 0.0015;
 const float ESun = 15.0;
@@ -48,9 +44,7 @@ const float fKmESun = Km * ESun;
 const float fKr4PI = Kr * 4.0 * czm_pi;
 const float fKm4PI = Km * 4.0 * czm_pi;
 
-const float fScale = 1.0 / (fOuterRadius - fInnerRadius);
 const float fScaleDepth = 0.25;
-const float fScaleOverScaleDepth = fScale / fScaleDepth;
 
 struct AtmosphereColor
 {
@@ -69,7 +63,14 @@ float scale(float fCos)
 
 AtmosphereColor computeGroundAtmosphereFromSpace(vec3 v3Pos, bool dynamicLighting, vec3 lightDirectionWC)
 {
-	vec3 v3InvWavelength = vec3(1.0 / pow(0.650, 4.0), 1.0 / pow(0.570, 4.0), 1.0 / pow(0.475, 4.0));
+    float fInnerRadius = czm_ellipsoidRadii.x;
+    float fOuterRadius = czm_ellipsoidRadii.x * 1.025;
+    float fOuterRadius2 = fOuterRadius * fOuterRadius;
+
+    float fScale = 1.0 / (fOuterRadius - fInnerRadius);
+    float fScaleOverScaleDepth = fScale / fScaleDepth;
+
+    vec3 v3InvWavelength = vec3(1.0 / pow(0.650, 4.0), 1.0 / pow(0.570, 4.0), 1.0 / pow(0.475, 4.0));
 
     // Get the ray from the camera to the vertex and its length (which is the far point of the ray passing through the atmosphere)
     vec3 v3Ray = v3Pos - czm_viewerPositionWC;

--- a/Specs/Renderer/AutomaticUniformSpec.js
+++ b/Specs/Renderer/AutomaticUniformSpec.js
@@ -3,6 +3,8 @@ import { Cartesian3 } from '../../Source/Cesium.js';
 import { Color } from '../../Source/Cesium.js';
 import { defaultValue } from '../../Source/Cesium.js';
 import { DirectionalLight } from '../../Source/Cesium.js';
+import { Ellipsoid } from '../../Source/Cesium.js';
+import { GeographicProjection } from '../../Source/Cesium.js';
 import { Matrix4 } from '../../Source/Cesium.js';
 import { OrthographicFrustum } from '../../Source/Cesium.js';
 import { OrthographicOffCenterFrustum } from '../../Source/Cesium.js';
@@ -1370,6 +1372,45 @@ describe('Renderer/AutomaticUniforms', function() {
             '  bool b0 = czm_lightColorHdr.x == 0.5;' +
             '  bool b1 = czm_lightColorHdr.y == 1.0;' +
             '  bool b2 = czm_lightColorHdr.z == 2.0;' +
+            '  gl_FragColor = vec4(b0 && b1 && b2);' +
+            '}';
+        expect({
+            context : context,
+            fragmentShader : fs
+        }).contextToRender();
+    });
+
+    it('has czm_ellipsoidRadii', function() {
+        var us = context.uniformState;
+        var frameState = createFrameState(context, createMockCamera());
+        var ellipsoid = new Ellipsoid(1.0, 2.0, 3.0);
+        frameState.mapProjection = new GeographicProjection(ellipsoid);
+        us.update(frameState);
+        var fs =
+            'void main() {' +
+            '  bool b0 = czm_ellipsoidRadii.x == 1.0;' +
+            '  bool b1 = czm_ellipsoidRadii.y == 2.0;' +
+            '  bool b2 = czm_ellipsoidRadii.z == 3.0;' +
+            '  gl_FragColor = vec4(b0 && b1 && b2);' +
+            '}';
+        expect({
+            context : context,
+            fragmentShader : fs
+        }).contextToRender();
+    });
+
+    it('has czm_ellipsoidInverseRadii', function() {
+        var us = context.uniformState;
+        var frameState = createFrameState(context, createMockCamera());
+        var ellipsoid = new Ellipsoid(1.0, 1.0 / 2.0, 1.0 / 3.0);
+        frameState.mapProjection = new GeographicProjection(ellipsoid);
+        us.update(frameState);
+        var fs =
+            'float roundNumber(float number) { return floor(number + 0.5); }' +
+            'void main() {' +
+            '  bool b0 = roundNumber(czm_ellipsoidInverseRadii.x) == 1.0;' +
+            '  bool b1 = roundNumber(czm_ellipsoidInverseRadii.y) == 2.0;' +
+            '  bool b2 = roundNumber(czm_ellipsoidInverseRadii.z) == 3.0;' +
             '  gl_FragColor = vec4(b0 && b1 && b2);' +
             '}';
         expect({


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/8683
Fixes https://github.com/CesiumGS/cesium/issues/7124

The first bug is related to the depth plane being too large because `czm_ellipsoidInverseRadii` was hardcoded to WGS84. [Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=jVPfb5swEP5XLF4CUmTSdVrWhkaLsikvnbYpWp94ueALeDU2sg1ROu1/r4GQQMqmISTju+9+fHcfFWiigfHSkAfy7v3dfDabLWIZhmfjh9v5x5vbuTPGsnLoiuMBtXNIPJA1Gl7m9Kmx+ZOkua6VtMAl6smU/I4lcY/JVCnYSvIcLJJ7sgdhcHryPR9XNlemyFDj0JVD8V2rX5hYruR9v+IGVaqhyHhyAfg9/xcheGEUZ35LZDo4giCWf4KG0hYkS8BYgVSjQeuI7UvZ5gu69lvOlIGFrSq1o0mBMf9Ua/2Si89nFxUKmD+hNHTvFvJCYO0MDa8/aeLAk6Cu3SR2A8Wu1eFM3zAgw7Ntv0uSCrXDYYJNbfLP2S/4BktRwk7gI08zy2Va064Hv+hD3NYOG61KyS4L6gEv1V3VsYVc9TO2spH2TsM2CUqkHa/mXPwNQHdgcK2EqnXZbaW+0tWPn6vxzHuVnmbArsgPYLlSshnEv0Cm/A9MBkwdvkIxUtWpceFNvcjYo8BlG/zJ6UVpS0otfKcki04+7ucx4a5MntHSxDQSiMIuKGK8Ipw9xN7Vbxh7JBFgjPPsSyG2/AVjbxmFDj8Iq4XrpPCtQi3gWEOym+Vja6SURqG7vo2ySokd6F7GVw).

The second bug is related to ground atmosphere also hardcoding WGS84 but in a different way. For best results you should still tweaks the near and far fade distance to more closely match the ellipsoid. [Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=bVJha9swEP0rIl+cjCA33UbBSUNLt3WFjhYy1i+GcpYvtjZZEpLskJb898mW08Rp/cXo3bt3T7rXgCEoBNdW8ZxcEokbcoOW1xX9vofHs4vPF1/OzqYn/8k8lY3vr0A/GvUXmeNKDjVuURUGdMnZgTF+m7cXKITK8KSxhYbMjkVtqTa3RtUyv3aVsrpE07Y6U6PnBD2lnfXYayqJ/wb2kuFxGiiddBJ+PZSBxXvYonnk7B+ahKxBWEzlrvfccNygGZr+02HjiHXHGyUdcIkmmnaOJm/+eAUFmm0n3xoNWnQAe/LgTCHP7wLg7Tc894OORj9h9gv0Ck3DGZ7y+oeojSAJiUrntE3ieIOZfwsqjGIUbE0xr+Oov70I1jxb1BKeN8Ce28cBsSdoMFChC6Rev/2cAWl9EaXzhXYr00NxrUwFLR51V4u1LKJQ3fUsxwWXxYqVWPl9fBik30eU8eshvMlRjneTgx4+8dyVCfk6Oz8CfyIvStehfqeTsJuQMNFW/IgfkOND7b5x60CyNmR97ucfMe/keyL5RM7no+loYd1W4DJMv+KVVsa12xhTGjustACHNs5qHzRHme2Ssoj3TYucN4Tnl+noJFfpiDAB1vrKuhZixV8wHS0XsecP2oSC3Lt8aND4vbaUcra8DyCldBH74/sup5TIwBwp/gc).


