### PR TITLE
Fix 1.67 ground polygon regression

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Change Log
 * `TileMapServiceImageryProvider` will now force `minimumLevel` to 0 if the `tilemapresource.xml` metadata request fails and the `rectangle` is too large for the given detail level [#8448](https://github.com/AnalyticalGraphicsInc/cesium/pull/8448)
 * Fixed ground atmosphere rendering when using a samller ellipsoid. [#8683](https://github.com/CesiumGS/cesium/issues/8683)
 * Fixed globe incorrectly occluding objects when using a smaller ellipsoid. [#7124](https://github.com/CesiumGS/cesium/issues/7124)
+* Fixed a regression introduced in 1.67 which caused overlapping colored ground geometry to have visual artifacts. [#8694](https://github.com/CesiumGS/cesium/pull/8694)
 
 ### 1.67.0 - 2020-03-02
 

--- a/Specs/DataSources/StaticGroundGeometryColorBatchSpec.js
+++ b/Specs/DataSources/StaticGroundGeometryColorBatchSpec.js
@@ -1,7 +1,6 @@
 import { ApproximateTerrainHeights } from '../../Source/Cesium.js';
 import { Cartesian3 } from '../../Source/Cesium.js';
 import { Color } from '../../Source/Cesium.js';
-import { defaultValue } from '../../Source/Cesium.js';
 import { DistanceDisplayCondition } from '../../Source/Cesium.js';
 import { JulianDate } from '../../Source/Cesium.js';
 import { Math as CesiumMath } from '../../Source/Cesium.js';
@@ -37,10 +36,6 @@ describe('DataSources/StaticGroundGeometryColorBatch', function() {
         ApproximateTerrainHeights._terrainHeights = undefined;
     });
 
-    function computeKey(zIndex) {
-        return defaultValue(zIndex, 0);
-    }
-
     it('updates color attribute after rebuilding primitive', function() {
         if (!GroundPrimitive.isSupported(scene)) {
             return;
@@ -72,13 +67,10 @@ describe('DataSources/StaticGroundGeometryColorBatch', function() {
             var primitive = scene.groundPrimitives.get(0);
             var attributes = primitive.getGeometryInstanceAttributes(entity);
             var red = [255, 0, 0, 255];
-            var redKey = computeKey();
             expect(attributes.color).toEqual(red);
 
-            // Verify we have 1 batch with the key for red
+            // Verify we have 1 batch
             expect(batch._batches.length).toEqual(1);
-            expect(batch._batches.contains(redKey)).toBe(true);
-            expect(batch._batches.get(redKey).key).toEqual(redKey);
 
             entity.ellipse.material = Color.GREEN;
             updater._onEntityPropertyChanged(entity, 'ellipse');
@@ -94,17 +86,53 @@ describe('DataSources/StaticGroundGeometryColorBatch', function() {
                 var primitive = scene.groundPrimitives.get(0);
                 var attributes = primitive.getGeometryInstanceAttributes(entity);
                 var green = [0, 128, 0, 255];
-                var greenKey = computeKey();
                 expect(attributes.color).toEqual(green);
 
                 // Verify we have 1 batch with the key for green
                 expect(batch._batches.length).toEqual(1);
-                expect(batch._batches.contains(greenKey)).toBe(true);
-                expect(batch._batches.get(greenKey).key).toEqual(greenKey);
 
                 batch.removeAllPrimitives();
             });
         });
+    });
+
+    it('batches overlapping geometry separately', function() {
+        if (!GroundPrimitive.isSupported(scene)) {
+            return;
+        }
+
+        var batch = new StaticGroundGeometryColorBatch(scene.groundPrimitives, ClassificationType.BOTH);
+        var entity = new Entity({
+            position : new Cartesian3(1234, 5678, 9101112),
+            ellipse : {
+                semiMajorAxis : 2,
+                semiMinorAxis : 1,
+                show : new CallbackProperty(function() {
+                    return true;
+                }, false),
+                material : Color.RED
+            }
+        });
+
+        var entity2 = new Entity({
+            position : new Cartesian3(1234, 5678, 9101112),
+            ellipse : {
+                semiMajorAxis : 2,
+                semiMinorAxis : 1,
+                show : new CallbackProperty(function() {
+                    return true;
+                }, false),
+                material : Color.RED
+            }
+        });
+
+        var updater = new EllipseGeometryUpdater(entity, scene);
+        batch.add(time, updater);
+
+        var updater2 = new EllipseGeometryUpdater(entity2, scene);
+        batch.add(time, updater2);
+
+        expect(batch._batches.length).toEqual(2);
     });
 
     it('updates with sampled distance display condition out of range', function() {
@@ -205,18 +233,6 @@ describe('DataSources/StaticGroundGeometryColorBatch', function() {
         }
 
         var batch = new StaticGroundGeometryColorBatch(scene.groundPrimitives, ClassificationType.BOTH);
-        function buildEntity() {
-            return new Entity({
-                position : new Cartesian3(1234, 5678, 9101112),
-                ellipse : {
-                    semiMajorAxis : 2,
-                    semiMinorAxis : 1,
-                    height : 0,
-                    outline : true,
-                    outlineColor : Color.RED.withAlpha(0.5)
-                }
-            });
-        }
 
         function renderScene() {
             scene.initializeFrame();
@@ -225,8 +241,25 @@ describe('DataSources/StaticGroundGeometryColorBatch', function() {
             return isUpdated;
         }
 
-        var entity1 = buildEntity();
-        var entity2 = buildEntity();
+        var entity1 = new Entity({
+            position : new Cartesian3(1234, 5678, 9101112),
+            ellipse : {
+                semiMajorAxis : 0.2,
+                semiMinorAxis : 0.1,
+                outline : true,
+                outlineColor : Color.RED.withAlpha(0.5)
+            }
+        });
+
+        var entity2 = new Entity({
+            position : new Cartesian3(1234, 4678, 9101112),
+            ellipse : {
+                semiMajorAxis : 0.2,
+                semiMinorAxis : 0.1,
+                outline : true,
+                outlineColor : Color.RED.withAlpha(0.5)
+            }
+        });
 
         var updater1 = new EllipseGeometryUpdater(entity1, scene);
         var updater2 = new EllipseGeometryUpdater(entity2, scene);
@@ -272,18 +305,6 @@ describe('DataSources/StaticGroundGeometryColorBatch', function() {
         }
 
         var batch = new StaticGroundGeometryColorBatch(scene.groundPrimitives, ClassificationType.BOTH);
-        function buildEntity() {
-            return new Entity({
-                position : new Cartesian3(1234, 5678, 9101112),
-                ellipse : {
-                    semiMajorAxis : 2,
-                    semiMinorAxis : 1,
-                    height : 0,
-                    outline : true,
-                    outlineColor : Color.RED.withAlpha(0.5)
-                }
-            });
-        }
 
         function renderScene() {
             scene.initializeFrame();
@@ -292,11 +313,27 @@ describe('DataSources/StaticGroundGeometryColorBatch', function() {
             return isUpdated;
         }
 
-        var entity1 = buildEntity();
+        var entity1 = new Entity({
+            position : new Cartesian3(1234, 5678, 9101112),
+            ellipse : {
+                semiMajorAxis : 0.2,
+                semiMinorAxis : 0.1,
+                outline : true,
+                outlineColor : Color.RED.withAlpha(0.5)
+            }
+        });
         var updater1 = new EllipseGeometryUpdater(entity1, scene);
         batch.add(time, updater1);
 
-        var entity2 = buildEntity();
+        var entity2 = new Entity({
+            position : new Cartesian3(1234, 4678, 9101112),
+            ellipse : {
+                semiMajorAxis : 0.2,
+                semiMinorAxis : 0.1,
+                outline : true,
+                outlineColor : Color.RED.withAlpha(0.5)
+            }
+        });
         var updater2 = new EllipseGeometryUpdater(entity2, scene);
 
         return pollToPromise(renderScene)


### PR DESCRIPTION
The performance improvements #8630 did not take into account the limitation that ground primitives that overlap cannot be batched together.

This change uses the `RectangleCollisionChecker` already implemented for `StaticGroundGeometryMaterialBatch` and performs the same check in `StaticGroundGeometryColorBatch`.

A big thanks to @likangning93 who figured out the root cause of the problem and pointed me to the existing collision checker.

Fixes #8664