### PR TITLE
Remove greenkeeper badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 [![Build Status](https://travis-ci.org/CesiumGS/cesium.svg?branch=master)](https://travis-ci.org/CesiumGS/cesium)&nbsp;
-[![Docs](https://img.shields.io/badge/docs-online-orange.svg)](https://cesium.com/docs/) [![Greenkeeper badge](https://badges.greenkeeper.io/CesiumGS/cesium.svg)](https://greenkeeper.io/)
+[![Docs](https://img.shields.io/badge/docs-online-orange.svg)](https://cesium.com/docs/)
 
 CesiumJS is a JavaScript library for creating 3D globes and 2D maps in a web browser without a plugin. It uses WebGL for hardware-accelerated graphics, and is cross-platform, cross-browser, and tuned for dynamic-data visualization.
 


### PR DESCRIPTION
Removes the greenkeeper badge instead of showing a missing image icon. I'm not sure if we intend on adding greenkeeper back or not.

![Capture](https://user-images.githubusercontent.com/915398/77101739-2b6e4000-69ee-11ea-98e3-7659b507761e.JPG)