### PR TITLE
Fix IE crash

### DIFF
--- a/Source/Shaders/GroundAtmosphere.glsl
+++ b/Source/Shaders/GroundAtmosphere.glsl
@@ -44,6 +44,9 @@ const float fKmESun = Km * ESun;
 const float fKr4PI = Kr * 4.0 * czm_pi;
 const float fKm4PI = Km * 4.0 * czm_pi;
 
+// Original: vec3(1.0 / pow(0.650, 4.0), 1.0 / pow(0.570, 4.0), 1.0 / pow(0.475, 4.0));
+const vec3 v3InvWavelength = vec3(5.60204474633241, 9.473284437923038, 19.64380261047721);
+
 const float fScaleDepth = 0.25;
 
 struct AtmosphereColor
@@ -63,9 +66,6 @@ float scale(float fCos)
 
 AtmosphereColor computeGroundAtmosphereFromSpace(vec3 v3Pos, bool dynamicLighting, vec3 lightDirectionWC)
 {
-    // Shader compilation fails in IE if this variable is declared outside with the other const variables
-    vec3 v3InvWavelength = vec3(1.0 / pow(0.650, 4.0), 1.0 / pow(0.570, 4.0), 1.0 / pow(0.475, 4.0));
-
     float fInnerRadius = czm_ellipsoidRadii.x;
     float fOuterRadius = czm_ellipsoidRadii.x * 1.025;
     float fOuterRadius2 = fOuterRadius * fOuterRadius;

--- a/Source/Shaders/GroundAtmosphere.glsl
+++ b/Source/Shaders/GroundAtmosphere.glsl
@@ -44,8 +44,6 @@ const float fKmESun = Km * ESun;
 const float fKr4PI = Kr * 4.0 * czm_pi;
 const float fKm4PI = Km * 4.0 * czm_pi;
 
-const vec3 v3InvWavelength = vec3(1.0 / pow(0.650, 4.0), 1.0 / pow(0.570, 4.0), 1.0 / pow(0.475, 4.0));
-
 const float fScaleDepth = 0.25;
 
 struct AtmosphereColor
@@ -65,6 +63,9 @@ float scale(float fCos)
 
 AtmosphereColor computeGroundAtmosphereFromSpace(vec3 v3Pos, bool dynamicLighting, vec3 lightDirectionWC)
 {
+    // Shader compilation fails in IE if this variable is declared outside with the other const variables
+    vec3 v3InvWavelength = vec3(1.0 / pow(0.650, 4.0), 1.0 / pow(0.570, 4.0), 1.0 / pow(0.475, 4.0));
+
     float fInnerRadius = czm_ellipsoidRadii.x;
     float fOuterRadius = czm_ellipsoidRadii.x * 1.025;
     float fOuterRadius2 = fOuterRadius * fOuterRadius;


### PR DESCRIPTION
https://github.com/CesiumGS/cesium/pull/8684 broke ground atmosphere rendering in IE. After some investigation it looks like the cause is a faulty GLSL implementation.

This old commit helped me out: https://github.com/CesiumGS/cesium/pull/3154/commits/28d15df679652d11ac28478e6e8c9f4b00eed802.

Needs to be merged before April 1.