### PR TITLE
Add bounding volume to eye dome lighting full screen command

### DIFF
--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -2051,7 +2051,7 @@ import TileOrientedBoundingBox from './TileOrientedBoundingBox.js';
             tileset.pointCloudShading.attenuation &&
             tileset.pointCloudShading.eyeDomeLighting &&
             (addedCommandsLength > 0)) {
-            tileset._pointCloudEyeDomeLighting.update(frameState, numberOfInitialCommands, tileset.pointCloudShading);
+            tileset._pointCloudEyeDomeLighting.update(frameState, numberOfInitialCommands, tileset.pointCloudShading, tileset.boundingSphere);
         }
 
         if (isRender) {

--- a/Source/Scene/PointCloudEyeDomeLighting.js
+++ b/Source/Scene/PointCloudEyeDomeLighting.js
@@ -205,7 +205,7 @@ import PointCloudEyeDomeLightingShader from '../Shaders/PostProcessStages/PointC
         return shader;
     }
 
-    PointCloudEyeDomeLighting.prototype.update = function(frameState, commandStart, pointCloudShading) {
+    PointCloudEyeDomeLighting.prototype.update = function(frameState, commandStart, pointCloudShading, boundingVolume) {
         if (!isSupported(frameState.context)) {
             return;
         }
@@ -242,6 +242,8 @@ import PointCloudEyeDomeLightingShader from '../Shaders/PostProcessStages/PointC
 
         var clearCommand = this._clearCommand;
         var blendCommand = this._drawCommand;
+
+        blendCommand.boundingVolume = boundingVolume;
 
         // Blend EDL into the main FBO
         commandList.push(blendCommand);

--- a/Source/Scene/TimeDynamicPointCloud.js
+++ b/Source/Scene/TimeDynamicPointCloud.js
@@ -723,7 +723,7 @@ import ShadowMode from './ShadowMode.js';
         var addedCommandsLength = lengthAfterUpdate - lengthBeforeUpdate;
 
         if (defined(shading) && shading.attenuation && shading.eyeDomeLighting && (addedCommandsLength > 0)) {
-            eyeDomeLighting.update(frameState, lengthBeforeUpdate, shading);
+            eyeDomeLighting.update(frameState, lengthBeforeUpdate, shading, this.boundingSphere);
         }
     };
 

--- a/Source/Scene/View.js
+++ b/Source/Scene/View.js
@@ -273,7 +273,7 @@ import ShadowMap from './ShadowMap.js';
                     // worst-case near and far planes to avoid clipping something important.
                     distances.start = camera.frustum.near;
                     distances.stop = camera.frustum.far;
-                    undefBV = !(command instanceof ClearCommand);
+                    undefBV = undefBV || !(command instanceof ClearCommand);
                 }
 
                 insertIntoBin(scene, this, command, distances);


### PR DESCRIPTION
If a command without a bounding volume is added to the command list the near/far will be set to the maximum possible range (1.0 to 500000000.0) and all four frustums will be rendered when log depth is disabled. This behavior makes sense because if you don't know where a draw command is you don't have enough information to contrain the near/far range. It's not good for performance though, which is why every draw command that CesiumJS pushes to a command list has a bounding volume.

There's one exception though: `EyeDomeLighting` pushes a viewport quad command which doesn't have a bounding volume. We would expect the scene to render with 4 frustums but this actually doesn't happen because EDL also pushes a clear command and this causes `undefBV` in `createPotentiallyVisibleSet` to be reset back to false. Basically the two bugs cancel each other out.

So the two fixes are:
* In createPotentiallyVisibleSet: `undefBV = !(command instanceof ClearCommand);` should instead be `undefBV = undefBV || !(command instanceof ClearCommand);`
* EDL sets the bounding volume of the draw command using the tileset's bounding sphere.

This fix doesn't have to be mentioned in CHANGES.md because the bugs were cancelling each other out before and there wasn't a noticeable problem.

@likangning93 can you review? There's way more text here than actual lines of code changed.