### PR TITLE
Fixed condition in Custom DataSource Sandcastle example

### DIFF
--- a/Apps/Sandcastle/gallery/Custom DataSource.html
+++ b/Apps/Sandcastle/gallery/Custom DataSource.html
@@ -174,7 +174,7 @@ Object.defineProperties(WebGLGlobeDataSource.prototype, {
             return this._heightScale;
         },
         set : function(value) {
-            if (value > 0) {
+            if (value <= 0) {
                 throw new Cesium.DeveloperError('value must be greater than 0');
             }
             this._heightScale = value;


### PR DESCRIPTION
The condition was reversed. (The function wasn't called anyhow, and it's not possible to update the height after the entities have been created, but someone might call it before loading the data, so this might be relevant...)
