### PR TITLE
Fix intermittent model and scene test failures

### DIFF
--- a/Source/Scene/Globe.js
+++ b/Source/Scene/Globe.js
@@ -666,7 +666,7 @@ import ShadowMode from './ShadowMode.js';
         // e.g. when we're getting a height in order to place a billboard
         // on terrain, and the camera is looking at that same billboard.
         // The culled tile must have a valid mesh, though.
-        if (!defined(tile)) {
+        if (!defined(tile) || !defined(tile.data) || !defined(tile.data.renderedMesh)) {
             // Tile was not rendered (culled).
             return undefined;
         }

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -212,10 +212,25 @@ describe('Scene/Model', function() {
 
     function verifyRender(model) {
         expect(model.ready).toBe(true);
+
+        expect({
+            scene : scene,
+            time : JulianDate.fromDate(new Date('January 1, 2014 12:00:00 UTC'))
+        }).toRenderAndCall(function(rgba) {
+            expect(rgba).toEqual([0, 0, 0, 255]);
+        });
+
         expect(scene).toRender([0, 0, 0, 255]);
         model.show = true;
         model.zoomTo();
-        expect(scene).notToRender([0, 0, 0, 255]);
+
+        expect({
+            scene : scene,
+            time : JulianDate.fromDate(new Date('January 1, 2014 12:00:00 UTC'))
+        }).toRenderAndCall(function(rgba) {
+            expect(rgba).not.toEqual([0, 0, 0, 255]);
+        });
+
         model.show = false;
     }
 


### PR DESCRIPTION
* Fixed a model render test that fails depending on time of day and light direction (see https://github.com/CesiumGS/cesium/pull/7173 for another example). If this keep becoming a problem we can hardcode a custom light source in the scene for tests. 
* `getHeight` needs to check that root tiles have rendered meshes before getting the height. This caused a race condition that has shown up repeatedly in CI lately, like https://travis-ci.org/github/CesiumGS/cesium/builds/669894295?utm_source=github_status&utm_medium=notification