### PR TITLE
Don't use enormous offset for second log depth frustum near plane.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 ##### Fixes :wrench:
 
 * Fixed several problems with polylines when the logarithmic depth buffer is enabled, which is the default on most systems. [#8706](https://github.com/CesiumGS/cesium/pull/8706)
+* Fixed a bug with very long view ranges requiring multiple frustums even with the logarithmic depth buffer enabled. Previously, such scenes could resolve depth incorrectly. [#8727](https://github.com/CesiumGS/cesium/pull/8727)
 
 ### 1.68.0 - 2020-04-01
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1608,7 +1608,7 @@ import View from './View.js';
          */
         opaqueFrustumNearOffset : {
             get : function() {
-                return this._frameState.useLogDepth ? 0.9 : 0.9999;
+                return 0.9999;
             }
         }
     });

--- a/Source/Shaders/Builtin/Functions/vertexLogDepth.glsl
+++ b/Source/Shaders/Builtin/Functions/vertexLogDepth.glsl
@@ -36,7 +36,7 @@ vec4 czm_updatePositionDepth(vec4 coords) {
 void czm_vertexLogDepth()
 {
 #ifdef LOG_DEPTH
-    v_depthFromNearPlusOne = 1.0 - czm_currentFrustum.x + gl_Position.w;
+    v_depthFromNearPlusOne = (gl_Position.w - czm_currentFrustum.x) + 1.0;
     gl_Position = czm_updatePositionDepth(gl_Position);
 #endif
 }
@@ -58,7 +58,7 @@ void czm_vertexLogDepth()
 void czm_vertexLogDepth(vec4 clipCoords)
 {
 #ifdef LOG_DEPTH
-    v_depthFromNearPlusOne = 1.0 - czm_currentFrustum.x + clipCoords.w;
+    v_depthFromNearPlusOne = (clipCoords.w - czm_currentFrustum.x) + 1.0;
     czm_updatePositionDepth(clipCoords);
 #endif
 }


### PR DESCRIPTION
When log depth is enabled, and multiple frustums are still needed, `Scene` previously made the next near plane overlap the previous one by 10% for opaque rendering (as compared to 0.01% overlap when log depth is disabled) . With the default setup, this is 10 million meters. When a scene has a mix of opaque and translucent objects, 10 million meters of eye-space difference is easily visible as incorrect depth testing. This PR changes log depth to use the same overlap as non-log-depth (0.01%).

Since I have no idea why this was set to 10% in the first place, there's a decent chance this will introduce a bug elsewhere. But multiple frustums are rare with log depth anyway, and any artifacts would be seams between frustums, which I expect to be much less offensive than rubbish depth testing.

This PR also includes a small tweak to how `v_depthFromNearPlusOne` is calculated that might make it more numerically stable, but I couldn't see a difference either way from it.

Fixes #8725 
