### PR TITLE
Fix duplicate PerInstanceColorAppearance

### DIFF
--- a/Source/Scene/Appearance.js
+++ b/Source/Scene/Appearance.js
@@ -27,7 +27,6 @@ import CullFace from './CullFace.js';
      * @see DebugAppearance
      * @see PolylineColorAppearance
      * @see PolylineMaterialAppearance
-     * @see PerInstanceColorAppearance
      *
      * @demo {@link https://sandcastle.cesium.com/index.html?src=Geometry%20and%20Appearances.html|Geometry and Appearances Demo}
      */


### PR DESCRIPTION
For #8721 

In Appearance.js reference, There is a duplicate PerInstanceColorAppearance.
I delete last one.
