### PR TITLE
Update all forum links to community.cesium.com

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: Ask a question
-about: Please use the community forum (http://community.cesium.com/) for general questions about using Cesium. 
+about: Please use the community forum (https://community.cesium.com/) for general questions about using Cesium. 
 ---
 
-:exclamation: Please use the [community forum](http://community.cesium.com/) for asking questions about how to use Cesium and best practices. The core Cesium team actively monitors the forum and we love seeing what people are working on! :exclamation:
+:exclamation: Please use the [community forum](https://community.cesium.com/) for asking questions about how to use Cesium and best practices. The core Cesium team actively monitors the forum and we love seeing what people are working on! :exclamation:

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: Ask a question
-about: Please use the forum (https://groups.google.com/forum/#!forum/cesium-dev) for general questions about using Cesium. 
+about: Please use the community forum (http://community.cesium.com/) for general questions about using Cesium. 
 ---
 
-:exclamation: Please use the [forum](https://groups.google.com/forum/#!forum/cesium-dev) for asking questions about how to use Cesium and best practices. The core Cesium team actively monitors the forum and we love seeing what people are working on! :exclamation:
+:exclamation: Please use the [community forum](http://community.cesium.com/) for asking questions about how to use Cesium and best practices. The core Cesium team actively monitors the forum and we love seeing what people are working on! :exclamation:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2380,7 +2380,7 @@ Beta Releases
 
 ### b28 - 2014-05-01
 
-* Breaking changes ([why so many?](https://community.cesium.com/t/moving-towards-cesium-1-0/1209)):
+* Breaking changes ([why so many?](https://community.cesium.com/t/breaking-changes/1132)):
   * Renamed and moved `Scene.primitives.centralBody` moved to `Scene.globe`.
   * Removed `CesiumWidget.centralBody` and `Viewer.centralBody`.  Use `CesiumWidget.scene.globe` and `Viewer.scene.globe`.
   * Renamed `CentralBody` to `Globe`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1958,7 +1958,7 @@ _This is an npm-only release to fix an issue with using Cesium in Node.js.__
 * Added `DataSourceDisplay.defaultDataSource` which is an instance of `CustomDataSource` and allows you to easily add custom entities to the display.
 * Added `Camera.viewBoundingSphere` and `Camera.flyToBoundingSphere`, which as the names imply, sets or flies to a view that encloses the provided `BoundingSphere`
 * For constant `Property` values, there is no longer a need to create an instance of `ConstantProperty` or `ConstantPositionProperty`, you can now assign a value directly to the corresponding property. The same is true for material images and colors.
-* All Entity and related classes can now be assigned using anonymous objects as well as be passed template objects. The correct underlying instance is created for you automatically. For a more detailed overview of changes to the Entity API, see [this forum thread](https://groups.google.com/d/msg/cesium-dev/ol7edT6EtZw/a2-gvI4H0IwJ) for details.
+* All Entity and related classes can now be assigned using anonymous objects as well as be passed template objects. The correct underlying instance is created for you automatically. For a more detailed overview of changes to the Entity API, see [this forum thread](https://community.cesium.com/t/cesium-in-2015-entity-api/1863) for details.
 
 ### 1.5 - 2015-01-05
 
@@ -2069,7 +2069,7 @@ _This is an npm-only release to fix an issue with using Cesium in Node.js.__
 
 ### 1.0 - 2014-08-01
 
-* Breaking changes ([why so many?](https://groups.google.com/forum/#!topic/cesium-dev/Y_mG11IZD9k))
+* Breaking changes ([why so many?](https://community.cesium.com/t/moving-towards-cesium-1-0/1209))
   * All `Matrix2`, `Matrix3`, `Matrix4` and `Quaternion` functions that take a `result` parameter now require the parameter, except functions starting with `from`.
   * Removed `Billboard.imageIndex` and `BillboardCollection.textureAtlas`. Instead, use `Billboard.image`.
     * Code that looked like:
@@ -2093,7 +2093,7 @@ _This is an npm-only release to fix an issue with using Cesium in Node.js.__
                 position : //...
             });
 
-  * Updated the [Model Converter](http://cesiumjs.org/convertmodel.html) and `Model` to support [glTF 0.8](https://github.com/KhronosGroup/glTF/blob/schema-8/specification/README.md).  See the [forum post](https://groups.google.com/forum/#!topic/cesium-dev/KNl2K3Cazno) for full details.
+  * Updated the [Model Converter](http://cesiumjs.org/convertmodel.html) and `Model` to support [glTF 0.8](https://github.com/KhronosGroup/glTF/blob/schema-8/specification/README.md).  See the [forum post](https://community.cesium.com/t/cesium-and-gltf-version-compatibility/1343) for full details.
   * `Model` primitives are now rotated to be `Z`-up to match Cesium convention; glTF stores models with `Y` up.
   * `SimplePolylineGeometry` and `PolylineGeometry` now curve to follow the ellipsoid surface by default. To disable this behavior, set the option `followSurface` to `false`.
   * Renamed `DynamicScene` layer to `DataSources`.  The following types were also renamed:
@@ -2207,7 +2207,7 @@ Beta Releases
 
 ### b30 - 2014-07-01
 
-* Breaking changes ([why so many?](https://groups.google.com/forum/#!topic/cesium-dev/Y_mG11IZD9k))
+* Breaking changes ([why so many?](https://community.cesium.com/t/moving-towards-cesium-1-0/1209))
   * CZML property references now use a `#` symbol to separate identifier from property path. `objectId.position` should now be `objectId#position`.
   * All `Cartesian2`, `Cartesian3`, `Cartesian4`, `TimeInterval`, and `JulianDate` functions that take a `result` parameter now require the parameter (except for functions starting with `from`).
   * Modified `Transforms.pointToWindowCoordinates` and `SceneTransforms.wgs84ToWindowCoordinates` to return window coordinates with origin at the top left corner.
@@ -2336,7 +2336,7 @@ Beta Releases
 
 ### b29 - 2014-06-02
 
-* Breaking changes ([why so many?](https://groups.google.com/forum/#!topic/cesium-dev/Y_mG11IZD9k))
+* Breaking changes ([why so many?](https://community.cesium.com/t/moving-towards-cesium-1-0/1209))
   * Replaced `Scene.createTextureAtlas` with `new TextureAtlas`.
   * Removed `CameraFlightPath.createAnimationCartographic`. Code that looked like:
 
@@ -2380,7 +2380,7 @@ Beta Releases
 
 ### b28 - 2014-05-01
 
-* Breaking changes ([why so many?](https://groups.google.com/forum/#!topic/cesium-dev/CQ0wCHjJ9x4)):
+* Breaking changes ([why so many?](https://community.cesium.com/t/moving-towards-cesium-1-0/1209)):
   * Renamed and moved `Scene.primitives.centralBody` moved to `Scene.globe`.
   * Removed `CesiumWidget.centralBody` and `Viewer.centralBody`.  Use `CesiumWidget.scene.globe` and `Viewer.scene.globe`.
   * Renamed `CentralBody` to `Globe`.
@@ -2710,7 +2710,7 @@ Beta Releases
 * Added `Model` for drawing 3D models using glTF.  See the [tutorial](http://cesiumjs.org/2014/03/03/Cesium-3D-Models-Tutorial/) and [Sandcastle example](http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=3D%20Models.html&label=Showcases).
 * DynamicScene now makes use of [Geometry and Appearances](http://cesiumjs.org/2013/11/04/Geometry-and-Appearances/), which provides a tremendous improvements to DataSource visualization (CZML, GeoJSON, etc..).  Extruded geometries are now supported and in many use cases performance is an order of magnitude faster.
 * Added new `SelectionIndicator` and `InfoBox` widgets to `Viewer`, activated by `viewerDynamicObjectMixin`.
-* `CesiumTerrainProvider` now supports mesh-based terrain like the tiles created by [STK Terrain Server](https://groups.google.com/forum/#!topic/cesium-dev/cP01iP7YOCU).
+* `CesiumTerrainProvider` now supports mesh-based terrain like the tiles created by [STK Terrain Server](https://community.cesium.com/t/stk-terrain-server-beta/1017).
 * Fixed rendering artifact on translucent objects when zooming in or out.
 * Added `CesiumInspector` widget for graphics debugging.  In Cesium Viewer, it is enabled by using the query parameter `inspector=true`.  Also see the [Sandcastle example](http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Cesium%20Inspector.html&label=Showcases).
 * Improved compatibility with Internet Explorer 11.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ To ensure an inclusive community, contributors and users in the Cesium community
 
 # Submitting an Issue
 
-If you have a question, do not submit an issue; instead, search the [Cesium forum](https://groups.google.com/forum/?hl=en#!forum/cesium-dev).  The forum is very active and there are years of informative archives, often with answers from the core Cesium team.  If you do not find an answer to your question, start a new thread and you'll likely get a quick response.
+If you have a question, do not submit an issue; instead, search the [Cesium community forum](https://community.cesium.com/).  The forum is very active and there are years of informative archives, often with answers from the core Cesium team.  If you do not find an answer to your question, start a new thread and you'll likely get a quick response.
 
 If you think you've found a bug in CesiumJS, first search the [issues](https://github.com/CesiumGS/cesium/issues).  If an issue already exists, please add a comment expressing your interest and any additional information.  This helps us prioritize issues.
 
@@ -26,7 +26,7 @@ Everyone is welcome to contribute to CesiumJS!
 
 In addition to contributing core CesiumJS code, we appreciate many types of contributions:
 
-* Being active on the [Cesium forum](https://groups.google.com/forum/?hl=en#!forum/cesium-dev) by answering questions and providing input on Cesium's direction.
+* Being active on the [Cesium community forum](https://community.cesium.com/) by answering questions and providing input on Cesium's direction.
 * Showcasing your Cesium apps on [Cesium blog](https://cesium.com/blog/categories/userstories/).  Contact us at hello@cesium.com.
 * Writing tutorials, creating examples, and improving the reference documentation.  See the issues labeled [doc](https://github.com/CesiumGS/cesium/labels/doc).
 * Submitting issues as [described above](#submitting-an-issue).
@@ -40,13 +40,13 @@ For ideas for CesiumJS code contributions, see:
 
 See the [Build Guide](Documentation/Contributors/BuildGuide/README.md) for how to build and run Cesium on your system.
 
-Always feel free to introduce yourself on the [Cesium forum](https://groups.google.com/forum/?hl=en#!forum/cesium-dev) to brainstorm ideas and ask for guidance.
+Always feel free to introduce yourself on the [Cesium community forum](https://community.cesium.com/) to brainstorm ideas and ask for guidance.
 
 # Opening a Pull Request
 
 We love pull requests.  We strive to promptly review them, provide feedback, and merge.  Interest in Cesium is at an all-time high so the core team is busy.  Following the tips in this guide will help your pull request get merged quickly.
 
-> If you plan to make a major change, please start a new thread on the [Cesium forum](https://groups.google.com/forum/?hl=en#!forum/cesium-dev) first.  Pull requests for small features and bug fixes can generally just be opened without discussion on the forum.
+> If you plan to make a major change, please start a new thread on the [Cesium community forum](https://community.cesium.com/) first.  Pull requests for small features and bug fixes can generally just be opened without discussion on the forum.
 
 ## Contributor License Agreement (CLA)
 

--- a/Documentation/Contributors/CodingGuide/README.md
+++ b/Documentation/Contributors/CodingGuide/README.md
@@ -837,7 +837,7 @@ function Foo() {
 
 ## Third-Party Libraries
 
-:house: Cesium uses third-party libraries sparingly.  If you want to add a new one, please start a thread on the [Cesium forum](http://cesiumjs.org/forum.html) ([example discussion](https://groups.google.com/forum/#!topic/cesium-dev/Bh4BolxlT80)).  The library should
+:house: Cesium uses third-party libraries sparingly.  If you want to add a new one, please start a thread on the [Cesium community forum](http://community.cesium.com/) ([example discussion](https://community.cesium.com/t/do-we-like-using-third-party-libraries/745)).  The library should
 * Have a compatible license such as MIT, BSD, or Apache 2.0.
 * Provide capabilities that Cesium truly needs and that the team doesn't have the time and/or expertise to develop.
 * Be lightweight, tested, maintained, and reasonably widely used.

--- a/Documentation/Contributors/CodingGuide/README.md
+++ b/Documentation/Contributors/CodingGuide/README.md
@@ -837,7 +837,7 @@ function Foo() {
 
 ## Third-Party Libraries
 
-:house: Cesium uses third-party libraries sparingly.  If you want to add a new one, please start a thread on the [Cesium community forum](http://community.cesium.com/) ([example discussion](https://community.cesium.com/t/do-we-like-using-third-party-libraries/745)).  The library should
+:house: Cesium uses third-party libraries sparingly.  If you want to add a new one, please start a thread on the [Cesium community forum](https://community.cesium.com/) ([example discussion](https://community.cesium.com/t/do-we-like-using-third-party-libraries/745)).  The library should
 * Have a compatible license such as MIT, BSD, or Apache 2.0.
 * Provide capabilities that Cesium truly needs and that the team doesn't have the time and/or expertise to develop.
 * Be lightweight, tested, maintained, and reasonably widely used.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Visit the [Downloads page](https://cesium.com/downloads/) or use the npm module:
 npm install cesium
 ```
 
-Have questions?  Ask them on the [forum](https://groups.google.com/forum/?hl=en#!forum/cesium-dev).
+Have questions?  Ask them on the [community forum](https://community.cesium.com/).
 
 Interested in contributing?  See [CONTRIBUTING.md](CONTRIBUTING.md). :heart:
 

--- a/index.release.html
+++ b/index.release.html
@@ -105,7 +105,7 @@
                 <td>Step-by-step guides for learning to use CesiumJS</td>
             </tr>
             <tr>
-                <td><a href="https://groups.google.com/forum/?hl=en#!forum/cesium-dev">Forum</a></td>
+                <td><a href="https://community.cesium.com/">Community Forum</a></td>
                 <td>Questions and feedback welcome from all skill levels</td>
             </tr>
             <tr>


### PR DESCRIPTION
This updates all links in this repo from the old Google groups to the new [community.cesium.com](community.cesium.com) and changes names from `forum` -> `community forum` where appropriate. 

I also updated forum links in the change log to point to the right topic in the new community forum.

@shehzan10 