### PR TITLE
Add configuration for prettier code formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,13 +3,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 4
+indent_size = 2
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-
-[*.md]
-trim_trailing_whitespace = false
-
-[package.json]
-indent_size = 2

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-    "extends": "./Tools/eslint-config-cesium/browser.js",
+    "extends": ["./Tools/eslint-config-cesium/browser.js", "prettier"],
     "plugins": [
         "html"
     ],

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,11 @@
+/node_modules
+/Build
+/ThirdParty
+/Apps/Sandcastle/ThirdParty
+/Source/Cesium.js
+/Source/Shaders/**/*.js
+/Source/ThirdParty/**
+/Source/Workers/**/*
+!/Source/Workers/cesiumWorkerBootstrapper.js
+!/Source/Workers/transferTypedArrayTest.js
+*.min.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ script:
   - npm --silent run deploy-status -- --status pending --message 'Waiting for build'
 
   - npm --silent run eslint
+  - npm --silent run prettier-check
 
   - npm --silent run build
   - npm --silent run coverage -- --browsers FirefoxHeadless --webgl-stub --failTaskOnError --suppressPassed

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
   - npm --silent run deploy-status -- --status pending --message 'Waiting for build'
 
   - npm --silent run eslint
-  - npm --silent run prettier-check
+#  - npm --silent run prettier-check
 
   - npm --silent run build
   - npm --silent run coverage -- --browsers FirefoxHeadless --webgl-stub --failTaskOnError --suppressPassed

--- a/Apps/CesiumViewer/CesiumViewer.js
+++ b/Apps/CesiumViewer/CesiumViewer.js
@@ -71,7 +71,8 @@ function main() {
         var message = formatError(exception);
         console.error(message);
         if (!document.querySelector('.cesium-widget-errorPanel')) {
-            window.alert(message); //eslint-disable-line no-alert
+            //eslint-disable-next-line no-alert
+            window.alert(message);
         }
         return;
     }

--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -758,6 +758,7 @@ require({
                 }
 
                 var scriptCode = scriptMatch[1];
+                scriptCode = scriptCode.replace(/^ {8}/gm, ""); //Account for Prettier spacing
 
                 var htmlText = '';
                 var childIndex = 0;

--- a/Apps/Sandcastle/gallery/CZML Custom Properties.html
+++ b/Apps/Sandcastle/gallery/CZML Custom Properties.html
@@ -20,7 +20,6 @@
 <div id="toolbar">
     <div id="propertiesMenu"></div>
 </div>
-</div>
 
 <script id="cesium_sandcastle_script">
 function startup(Cesium) {

--- a/Documentation/Contributors/CodingGuide/README.md
+++ b/Documentation/Contributors/CodingGuide/README.md
@@ -121,10 +121,11 @@ For syntax and style guidelines, we use the ESLint recommended settings (the lis
 - [no-new-require](http://eslint.org/docs/rules/no-new-require)
 
 **[Disabling Rules with Inline Comments](http://eslint.org/docs/user-guide/configuring#disabling-rules-with-inline-comments)**
- * When disabling linting for one line, use `//eslint-disable-line`:
+ * When disabling linting for one line, use `//eslint-disable-next-line`:
 ```js
 function exit(warningMessage) {
-    window.alert('Cannot exit: ' + warningMessage); //eslint-disable-line no-alert
+    //eslint-disable-next-line no-alert
+    window.alert('Cannot exit: ' + warningMessage);
 }
 ```
 

--- a/Documentation/Contributors/CodingGuide/README.md
+++ b/Documentation/Contributors/CodingGuide/README.md
@@ -90,53 +90,9 @@ A few more naming conventions are introduced below along with their design patte
 
 ## Formatting
 
-In general, format new code in the same way as the existing code.
-
-* Use four spaces for indentation.  Do not use tab characters.
-* Do not include trailing whitespace.
-* Put `{` on the same line as the previous statement:
-```javascript
-function defaultValue(a, b) {
-   // ...
-}
-
-if (!defined(result)) {
-   // ...
-}
-```
-* Use curly braces even for single line `if`, `for`, and `while` blocks, e.g.,
-```javascript
-if (!defined(result))
-    result = new Cartesian3();
-```
-is better written as
-```javascript
-if (!defined(result)) {
-    result = new Cartesian3();
-}
-```
-* Use parenthesis judiciously, e.g.,
-```javascript
-var foo = x > 0.0 && y !== 0.0;
-```
-is better written as
-```javascript
-var foo = (x > 0.0) && (y !== 0.0);
-```
-* Use vertical whitespace to separate functions and to group related statements within a function, e.g.,
-```javascript
-function Model(options) {
-    // ...
-    this._allowPicking = defaultValue(options.allowPicking, true);
-
-    this._ready = false;
-    this._readyPromise = when.defer();
-    // ...
-};
-```
-* In JavaScript code, use single quotes, `'`, instead of double quotes, `"`.  In HTML, use double quotes.
-
-* Text files, including JavaScript files, end with a newline to minimize the noise in diffs.
+* We use [prettier](https://prettier.io/) to automatically re-format all JS code at commit time, so all of the work is done for you. Code is automatically reformatted when you commit.
+* For HTML code, keep the existing style. Use double quotes.
+* Text files, end with a newline to minimize the noise in diffs.
 
 ## Linting
 

--- a/Source/Core/Resource.js
+++ b/Source/Core/Resource.js
@@ -1898,9 +1898,12 @@ import TrustedServers from './TrustedServers.js';
 
     function loadWithHttpRequest(url, responseType, method, data, headers, deferred, overrideMimeType) {
         // Note: only the 'json' and 'text' responseTypes transforms the loaded buffer
-        var URL = require('url').parse(url); // eslint-disable-line
-        var http = URL.protocol === 'https:' ? require('https') : require('http'); // eslint-disable-line
-        var zlib = require('zlib'); // eslint-disable-line
+        /* eslint-disable no-undef */
+        var URL = require('url').parse(url);
+        var http = URL.protocol === 'https:' ? require('https') : require('http');
+        var zlib = require('zlib');
+        /* eslint-enable no-undef */
+
         var options = {
             protocol : URL.protocol,
             hostname : URL.hostname,
@@ -1924,7 +1927,8 @@ import TrustedServers from './TrustedServers.js';
                 });
 
                 res.on('end', function() {
-                    var result = Buffer.concat(chunkArray); // eslint-disable-line
+                    // eslint-disable-next-line no-undef
+                    var result = Buffer.concat(chunkArray);
                     if (res.headers['content-encoding'] === 'gzip') {
                         zlib.gunzip(result, function(error, resultUnzipped) {
                             if (error) {

--- a/Source/Core/buildModuleUrl.js
+++ b/Source/Core/buildModuleUrl.js
@@ -31,7 +31,8 @@ import Resource from './Resource.js';
         a.href = url;
 
         // IE only absolutizes href on get, not set
-        a.href = a.href; // eslint-disable-line no-self-assign
+        // eslint-disable-next-line no-self-assign
+        a.href = a.href;
         return a.href;
     }
 

--- a/Source/Core/isCrossOriginUrl.js
+++ b/Source/Core/isCrossOriginUrl.js
@@ -22,7 +22,8 @@ import defined from './defined.js';
 
         a.href = url;
         // IE only absolutizes href on get, not set
-        a.href = a.href; // eslint-disable-line no-self-assign
+        // eslint-disable-next-line no-self-assign
+        a.href = a.href;
 
         return protocol !== a.protocol || host !== a.host;
     }

--- a/Source/Scene/Cesium3DTileContent.js
+++ b/Source/Scene/Cesium3DTileContent.js
@@ -39,7 +39,8 @@ import DeveloperError from '../Core/DeveloperError.js';
          * @readonly
          */
         featuresLength : {
-            get : function() {  // eslint-disable-line getter-return
+            // eslint-disable-next-line getter-return
+            get : function() {
                 DeveloperError.throwInstantiationError();
             }
         },
@@ -59,7 +60,8 @@ import DeveloperError from '../Core/DeveloperError.js';
          * @readonly
          */
         pointsLength : {
-            get : function() {  // eslint-disable-line getter-return
+            // eslint-disable-next-line getter-return
+            get : function() {
                 DeveloperError.throwInstantiationError();
             }
         },
@@ -73,7 +75,8 @@ import DeveloperError from '../Core/DeveloperError.js';
          * @readonly
          */
         trianglesLength : {
-            get : function() {  // eslint-disable-line getter-return
+            // eslint-disable-next-line getter-return
+            get : function() {
                 DeveloperError.throwInstantiationError();
             }
         },
@@ -87,7 +90,8 @@ import DeveloperError from '../Core/DeveloperError.js';
          * @readonly
          */
         geometryByteLength : {
-            get : function() {  // eslint-disable-line getter-return
+            // eslint-disable-next-line getter-return
+            get : function() {
                 DeveloperError.throwInstantiationError();
             }
         },
@@ -101,7 +105,8 @@ import DeveloperError from '../Core/DeveloperError.js';
          * @readonly
          */
         texturesByteLength : {
-            get : function() {  // eslint-disable-line getter-return
+            // eslint-disable-next-line getter-return
+            get : function() {
                 DeveloperError.throwInstantiationError();
             }
         },
@@ -115,7 +120,8 @@ import DeveloperError from '../Core/DeveloperError.js';
          * @readonly
          */
         batchTableByteLength : {
-            get : function() {  // eslint-disable-line getter-return
+            // eslint-disable-next-line getter-return
+            get : function() {
                 DeveloperError.throwInstantiationError();
             }
         },
@@ -132,7 +138,8 @@ import DeveloperError from '../Core/DeveloperError.js';
          * @readonly
          */
         innerContents : {
-            get : function() {  // eslint-disable-line getter-return
+            // eslint-disable-next-line getter-return
+            get : function() {
                 DeveloperError.throwInstantiationError();
             }
         },
@@ -146,7 +153,8 @@ import DeveloperError from '../Core/DeveloperError.js';
          * @readonly
          */
         readyPromise : {
-            get : function() {  // eslint-disable-line getter-return
+            // eslint-disable-next-line getter-return
+            get : function() {
                 DeveloperError.throwInstantiationError();
             }
         },
@@ -160,7 +168,8 @@ import DeveloperError from '../Core/DeveloperError.js';
          * @readonly
          */
         tileset : {
-            get : function() {  // eslint-disable-line getter-return
+            // eslint-disable-next-line getter-return
+            get : function() {
                 DeveloperError.throwInstantiationError();
             }
         },
@@ -174,7 +183,8 @@ import DeveloperError from '../Core/DeveloperError.js';
          * @readonly
          */
         tile : {
-            get : function() {  // eslint-disable-line getter-return
+            // eslint-disable-next-line getter-return
+            get : function() {
                 DeveloperError.throwInstantiationError();
             }
         },
@@ -187,7 +197,8 @@ import DeveloperError from '../Core/DeveloperError.js';
          * @readonly
          */
         url : {
-            get : function() {  // eslint-disable-line getter-return
+            // eslint-disable-next-line getter-return
+            get : function() {
                 DeveloperError.throwInstantiationError();
             }
         },
@@ -205,7 +216,8 @@ import DeveloperError from '../Core/DeveloperError.js';
          * @private
          */
         batchTable : {
-            get : function() {  // eslint-disable-line getter-return
+            // eslint-disable-next-line getter-return
+            get : function() {
                 DeveloperError.throwInstantiationError();
             }
         }

--- a/Source/Scene/Polyline.js
+++ b/Source/Scene/Polyline.js
@@ -73,7 +73,8 @@ import Material from './Material.js';
 
         this._actualLength = undefined;
 
-        this._propertiesChanged = new Uint32Array(NUMBER_OF_PROPERTIES); //eslint-disable-line no-use-before-define
+        // eslint-disable-next-line no-use-before-define
+        this._propertiesChanged = new Uint32Array(NUMBER_OF_PROPERTIES);
         this._polylineCollection = polylineCollection;
         this._dirty = false;
         this._pickId = undefined;

--- a/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
+++ b/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
@@ -34,7 +34,8 @@ import knockout from '../../ThirdParty/knockout.js';
             viewModel._eventHandler.removeInputAction(ScreenSpaceEventType.MOUSE_MOVE);
 
             // Restore hover-over selection to its current value
-            viewModel.picking = viewModel.picking; // eslint-disable-line no-self-assign
+            // eslint-disable-next-line no-self-assign
+            viewModel.picking = viewModel.picking;
         }
     }
 
@@ -321,6 +322,7 @@ import knockout from '../../ThirdParty/knockout.js';
          */
         this.colorBlendMode = Cesium3DTileColorBlendMode.HIGHLIGHT;
 
+        var showOnlyPickedTileDebugLabel = knockout.observable();
         var picking = knockout.observable();
         knockout.defineProperty(this, 'picking', {
             get : function() {
@@ -347,7 +349,7 @@ import knockout from '../../ThirdParty/knockout.js';
                         if (!defined(that._tileset)) {
                             return;
                         }
-                        if (showOnlyPickedTileDebugLabel && defined(picked) && defined(picked.content)) { //eslint-disable-line no-use-before-define
+                        if (showOnlyPickedTileDebugLabel && defined(picked) && defined(picked.content)) {
                             var position;
                             if (scene.pickPositionSupported) {
                                 position = scene.pickPosition(e.endPosition);
@@ -503,7 +505,6 @@ import knockout from '../../ThirdParty/knockout.js';
          */
         this.freezeFrame = false;
 
-        var showOnlyPickedTileDebugLabel = knockout.observable();
         knockout.defineProperty(this, 'showOnlyPickedTileDebugLabel', {
             get : function() {
                 return showOnlyPickedTileDebugLabel();
@@ -1126,7 +1127,8 @@ import knockout from '../../ThirdParty/knockout.js';
                     var length = settings.length;
                     for (var i = 0; i < length; ++i) {
                         var setting = settings[i];
-                        this[setting] = this[setting]; // eslint-disable-line no-self-assign
+                        //eslint-disable-next-line no-self-assign
+                        this[setting] = this[setting];
                     }
 
                     // update view model with existing tileset settings

--- a/Source/Workers/transferTypedArrayTest.js
+++ b/Source/Workers/transferTypedArrayTest.js
@@ -1,6 +1,7 @@
 // make sure self is defined so that the Dojo build can evaluate this file without crashing.
 if (typeof self === 'undefined') {
-    self = {}; //eslint-disable-line no-implicit-globals, no-global-assign
+    //eslint-disable-next-line no-implicit-globals, no-global-assign
+    self = {};
 }
 
 self.onmessage = function(event) {

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -2494,7 +2494,8 @@ describe('Scene/Model', function() {
             }
             Matrix4.multiplyByMatrix3(m.modelMatrix, rotate, m.modelMatrix);
 
-            expect(scene).toRenderAndCall(function(rgba) { //eslint-disable-line no-loop-func
+            //eslint-disable-next-line no-loop-func
+            expect(scene).toRenderAndCall(function(rgba) {
                 expect(rgba).not.toEqual([0, 0, 0, 255]);
                 expect(rgba).not.toEqual(oldPixelColor);
                 oldPixelColor = rgba;

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -448,7 +448,8 @@ describe('Scene/PointCloud3DTileContent', function() {
                 /* jshint loopfunc: true */
                 while (defined(picked)) {
                     picked.show = false;
-                    expect(scene).toPickAndCall(function(result) { //eslint-disable-line no-loop-func
+                    //eslint-disable-next-line no-loop-func
+                    expect(scene).toPickAndCall(function(result) {
                         picked = result;
                     });
                     ++pickedCountCulling;
@@ -471,7 +472,8 @@ describe('Scene/PointCloud3DTileContent', function() {
                 /* jshint loopfunc: true */
                 while (defined(picked)) {
                     picked.show = false;
-                    expect(scene).toPickAndCall(function(result) { //eslint-disable-line no-loop-func
+                    //eslint-disable-next-line no-loop-func
+                    expect(scene).toPickAndCall(function(result) {
                         picked = result;
                     });
                     ++pickedCount;

--- a/Specs/Scene/ShadowMapSpec.js
+++ b/Specs/Scene/ShadowMapSpec.js
@@ -735,14 +735,16 @@ describe('Scene/ShadowMap', function() {
             // Render without shadows
             scene.shadowMap.enabled = false;
             var unshadowedColor;
-            renderAndCall(function(rgba) { //eslint-disable-line no-loop-func
+            //eslint-disable-next-line no-loop-func
+            renderAndCall(function(rgba) {
                 unshadowedColor = rgba;
                 expect(rgba).not.toEqual(backgroundColor);
             });
 
             // Render with shadows
             scene.shadowMap.enabled = true;
-            renderAndCall(function(rgba) { //eslint-disable-line no-loop-func
+            //eslint-disable-next-line no-loop-func
+            renderAndCall(function(rgba) {
                 expect(rgba).not.toEqual(backgroundColor);
                 expect(rgba).not.toEqual(unshadowedColor);
             });

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "cloc": "^2.3.3",
     "compression": "^1.6.2",
     "eslint": "^6.4.0",
+    "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-html": "^6.0.0",
     "express": "^4.15.0",
     "globby": "^11.0.0",
@@ -54,6 +55,7 @@
     "gulp-tap": "^2.0.0",
     "gulp-uglify": "^3.0.0",
     "gulp-zip": "^5.0.0",
+    "husky": "^4.2.5",
     "jasmine-core": "^3.3.0",
     "jsdoc": "^3.4.3",
     "karma": "^4.0.0",
@@ -72,6 +74,8 @@
     "mime": "^2.0.3",
     "mkdirp": "^1.0.0",
     "open": "^7.0.0",
+    "prettier": "^2.0.4",
+    "pretty-quick": "^2.0.1",
     "request": "^2.79.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.21.4",
@@ -80,6 +84,11 @@
     "rollup-plugin-uglify": "^6.0.3",
     "stream-to-promise": "^2.2.0",
     "yargs": "^15.0.1"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged"
+    }
   },
   "scripts": {
     "convertToModules": "gulp convertToModules",
@@ -111,6 +120,9 @@
     "sortRequires": "gulp sortRequires",
     "deploy-s3": "gulp deploy-s3",
     "deploy-status": "gulp deploy-status",
-    "deploy-set-version": "gulp deploy-set-version"
+    "deploy-set-version": "gulp deploy-set-version",
+    "prettier": "prettier --write \"**/*.(js|css|html|md)\"",
+    "prettier-check": "prettier --check \"**/*.(js|css|html|md)\"",
+    "pretty-quick": "pretty-quick"
   }
 }


### PR DESCRIPTION
We have always worked incredibly hard to keep the CesiumJS code base clean and well-formatted. We've always believed that a good code base should look like it was written by a single person, even with the ~200 contributors we've had on CesiumJS, we've largely hit and maintained that goal.  But it's been tough.

[prettier](prettier.io) took the JS world by storm a while ago and the time has come for CesiumJS to embrace it and automatically format all (actually most) of our JavaScript code.

At a high level, this PR:

1. Adds prettier and configuration files, but does not format code yet.

2. Configures prettier for Source/Apps/Specs but not anything else. JS code only. If we want to do Markdown and HTML code, we can.  HTML may be a little tough because we have to trim whitespace so we can show it in Sandcastle so it may be better to do that in a separate PR, but I'm open to  opinions.

3. Fix a bad closing div in `CZML Custom Properties.html`  that prettier found while I was experimenting.

4. Adds a pre-commit hook via husky and pretty-quick which will automatically format changed files when they are committed on the client.  This means that you don't even need to THINK about code formatting, it just magically happens when you commit and it's fast.

5. Run `prettier-check` during CI and fail the build if code is not formatted properly.

6. Install eslint config for prettier. This does not enable prettier checking in eslint (it's unusably slow) but instead just makes sure that no eslint rules conflict with prettier formatting.

7. Update the coding guide to remove our manual rules and just mention prettier.

If you want to see the results yourself, just check out this branch, run `npm install` and then run `npm run prettier`.  It will take a minute since it is doing the entire code-base right now but that will allow you to see what the "new" code will look like when we do the initial mass-format.

prettier has a limited number of options specified in `.prettierrc`. I mostly kept he defaults, but when with the following because it's how Cesium has always worked. (Okay the arrowParens once doesn't apply yet, but it will really soon).

```json
{
  "singleQuote": true,
  "tabWidth": 4,
  "trailingComma": "none",
  "arrowParens": "avoid"
}
```

At prettier's suggestion, I kept the default line width to 80, but that's open for debate as well.

While there is no immediate rush to converge on this, I would like to get to an answer sooner rather than later and avoid too much bike shedding.  I honestly don't care about the formatting that much as long as it is consistent.  It will also be easier to run prettier everywhere and then put back any custom formatting people want via [prettier-ignore](https://prettier.io/docs/en/ignore.html)

Once we all agree, we'll do a single commit with the full format in order to make it easy to merge into other branches.  @kring can provide some guidance here since he's done it for other projects.

EDIT: We've since gone back to all of prettier's defaults, as per the discussion below.