### PR TITLE
Remove Cesium's use of glTF's optional skeleton property.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Change Log
 ##### Fixes :wrench:
 
 * Fixed several problems with polylines when the logarithmic depth buffer is enabled, which is the default on most systems. [#8706](https://github.com/CesiumGS/cesium/pull/8706)
+* Fixed an issue with glTF skinning support where an optional property `skeleton` was considered required by Cesium. [#8175](https://github.com/CesiumGS/cesium/issues/8175)
 * Fixed a bug with very long view ranges requiring multiple frustums even with the logarithmic depth buffer enabled. Previously, such scenes could resolve depth incorrectly. [#8727](https://github.com/CesiumGS/cesium/pull/8727)
 * Fixed a bug where the elevation contour material's alpha was not being applied. [#8749](https://github.com/CesiumGS/cesium/pull/8749)
 

--- a/Source/Scene/ModelAnimationCache.js
+++ b/Source/Scene/ModelAnimationCache.js
@@ -132,7 +132,6 @@ import AttributeType from './AttributeType.js';
                         weights : controlPoints
                     });
                 }
-                // GLTF_SPEC: Support more parameter types when glTF supports targeting materials. https://github.com/KhronosGroup/glTF/issues/142
             }
 
             if (defined(model.cacheKey)) {


### PR DESCRIPTION
Cesium was using the optional glTF property `skeleton` as a required property, and it looks like it was only using it to discover a list of joint nodes, which are required to be in the glTF.  This may be the result of historical changes along the way from early versions of glTF, I'm not sure.

In any case, this PR removes a pile of skeleton/forest searching logic and just uses the glTF joint list directly.

I tested CesiumMan of course, and a model of my own exported from Blender.  Would be good to test this against a few more complex skinning examples to make sure nothing broke.

Fixes #8175.