### PR TITLE
Fixed displaying Cesium Ion icon in WebView

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@
 - Fixed a bug where the elevation contour material's alpha was not being applied. [#8749](https://github.com/CesiumGS/cesium/pull/8749)
 - Fix potential memory leak when destroying `CesiumWidget` instances.
 - Geometry instance floats now work for high precision floats on newer iOS devices. [#8805](https://github.com/CesiumGS/cesium/pull/8805)
-- Fixed displaying Cesium Ion icon when Cesium is hosted in an Android, iOS or UWP WebView. [#8758](https://github.com/CesiumGS/cesium/pull/8758)
+- Fixed displaying the Cesium ion icon when running in an Android, iOS or UWP WebView. [#8758](https://github.com/CesiumGS/cesium/pull/8758)
 
 ### 1.68.0 - 2020-04-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 - Fixed a bug where the elevation contour material's alpha was not being applied. [#8749](https://github.com/CesiumGS/cesium/pull/8749)
 - Fix potential memory leak when destroying `CesiumWidget` instances.
 - Geometry instance floats now work for high precision floats on newer iOS devices. [#8805](https://github.com/CesiumGS/cesium/pull/8805)
+- Fixed displaying Cesium Ion icon when Cesium is hosted in an Android, iOS or UWP WebView. [#8758](https://github.com/CesiumGS/cesium/pull/8758)
 
 ### 1.68.0 - 2020-04-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -254,3 +254,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Daniel Leone](https://github.com/danielleone)
 - [Zhou Jiang](https://github.com/aboutqx)
 - [SungHo Lim](https://github.com/SambaLim)
+- [Michael Fink](https://github.com/vividos)

--- a/Source/Scene/CreditDisplay.js
+++ b/Source/Scene/CreditDisplay.js
@@ -5,6 +5,7 @@ import Credit from "../Core/Credit.js";
 import defaultValue from "../Core/defaultValue.js";
 import defined from "../Core/defined.js";
 import destroyObject from "../Core/destroyObject.js";
+import Uri from "../ThirdParty/Uri.js";
 
 var mobileWidth = 576;
 var lightboxHeight = 100;
@@ -512,6 +513,14 @@ var defaultCredit;
 function getDefaultCredit() {
   if (!defined(defaultCredit)) {
     var logo = buildModuleUrl("Assets/Images/ion-credit.png");
+
+    // When hosting in a WebView, the base URL scheme is file:// or ms-appx-web://
+    // which is stripped out from the Credit's <img> tag; use the full path instead
+    if (!logo.startsWith("http://") && !logo.startsWith("https://")) {
+      var logoUrl = new Uri(logo);
+      logo = logoUrl.getPath();
+    }
+
     defaultCredit = new Credit(
       '<a href="https://cesium.com/" target="_blank"><img src="' +
         logo +


### PR DESCRIPTION
When running in a WebView on Android, iOS or UWP `WebView`, the base URL either starts with `file:///` or `ms-appx-web:///`. When the Credits object for Cesium Ion is created, the `<img>` tag contains a `src` attribute with this base URL. The integrated `DOMpurify` strips all src tags which doesn't contain `http` or `https` URLs. This fix changes the `src` attribute to contain an absolute Url in that case.

This PR doesn't need my other try at fixing the Ion icon issue, PR #8669, as it would also work without it.

Fixes #8665.