### PR TITLE
Improve consistency between prettier and pretty-quick.

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,11 +1,29 @@
-/node_modules
-/Build
-/ThirdParty
-/Apps/Sandcastle/ThirdParty
-/Source/Cesium.js
-/Source/Shaders/**/*.js
-/Source/ThirdParty/**
-/Source/Workers/**/*
-!/Source/Workers/cesiumWorkerBootstrapper.js
-!/Source/Workers/transferTypedArrayTest.js
-*.min.js
+
+# Ignore everything
+*
+
+# Unignore directories (to all depths) and unignore code and style files in these directories
+!.concierge/**/
+!.github/**/
+!.vscode/**/
+!Apps/**/
+!Documentation/**/
+!Source/**/
+!Specs/**/
+!Tools/**/
+
+!**/*.js
+!**/*.css
+!**/*.html
+!**/*.md
+
+# Re-ignore a few things caught above
+**/*.min.js
+Source/Cesium.js
+Source/Shaders/**/*.js
+Source/ThirdParty/**
+Source/Workers/**/*
+Apps/Sandcastle/ThirdParty
+
+!Source/Workers/cesiumWorkerBootstrapper.js
+!Source/Workers/transferTypedArrayTest.js

--- a/package.json
+++ b/package.json
@@ -121,8 +121,8 @@
     "deploy-s3": "gulp deploy-s3",
     "deploy-status": "gulp deploy-status",
     "deploy-set-version": "gulp deploy-set-version",
-    "prettier": "prettier --write \"**/*.(js|css|html|md)\"",
-    "prettier-check": "prettier --check \"**/*.(js|css|html|md)\"",
+    "prettier": "prettier --write \"**/*\"",
+    "prettier-check": "prettier --check \"**/*\"",
     "pretty-quick": "pretty-quick"
   }
 }


### PR DESCRIPTION
Use a fancier `.prettierignore` to completely control which files are formatted, rather than a mix of `.prettierignore` and a command-line glob. The previous approach was causing problems because some files would be formatted by the pre-commit hook if they were edited, but those same files would not be formatted by a regular `npm run prettier`.