### PR TITLE
add nullpointer check

### DIFF
--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -322,7 +322,7 @@ function BillboardCollection(options) {
         var billboards = this._billboards;
         var length = billboards.length;
         for (var i = 0; i < length; ++i) {
-          if (billboards[i]) {
+          if (defined(billboards[i])) {
             billboards[i]._updateClamping();
           }
         }

--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -322,7 +322,9 @@ function BillboardCollection(options) {
         var billboards = this._billboards;
         var length = billboards.length;
         for (var i = 0; i < length; ++i) {
-          billboards[i]._updateClamping();
+          if (billboards[i]) {
+            billboards[i]._updateClamping();
+          }
         }
       },
       this


### PR DESCRIPTION
add a nullpointer check for updateClamping function.

This fixes a bug where a removed billboard can prevent changing of the terrainProvider. 
This only occurs if the billboardcollection is a child of a primitiveCollection, which is set to show=false, so the billboard never gets cleaned up.

The following Sandcastle Code can produce the problem
```
var viewer = new Cesium.Viewer('cesiumContainer', {
    terrainProvider: Cesium.createWorldTerrain()
});

var scene = viewer.scene;

var primitiveCollection = new Cesium.PrimitiveCollection();
var billboards = primitiveCollection.add(new Cesium.BillboardCollection({scene: scene}));
scene.primitives.add(primitiveCollection);
var billboard = billboards.add({
    position : Cesium.Cartesian3.fromDegrees(-75.59777, 40.03883, 150000),
    image : '../images/Cesium_Logo_overlay.png',
    heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
});

Sandcastle.addToolbarButton( 'crash',function() {
    billboards.remove(billboard);
    primitiveCollection.show = false;                
    viewer.terrainProvider = new Cesium.EllipsoidTerrainProvider({});
});
```