### PR TITLE
Recommend the prettier vscode formatting plug-in.

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
     "recommendations": [
         "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
         "slevesque.shader",
         "cesium.gltf-vscode"
     ]


### PR DESCRIPTION
I thought I did this in the initial PR, but apparently I forgot.

This just suggests to new users that they install the prettier vscode plugin in addition to the other plugins we recommend when working on Cesium. This ensures that VS Code follows the same exact formatting as our prettier rules specify.

Completely optional to the user, just like the eslint/shader/gltf suggestions.