### PR TITLE
Update default value in jsdoc for maximumRenderTimeChange

### DIFF
--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -680,7 +680,7 @@ function Scene(options) {
    * @see Scene#requestRenderMode
    *
    * @type {Number}
-   * @default 0.5
+   * @default 0.0
    */
   this.maximumRenderTimeChange = defaultValue(
     options.maximumRenderTimeChange,


### PR DESCRIPTION
This was reported over email. The default value in the code is `0.0` but the doc still says `0.5`. 