### PR TITLE
Remove sortRequires from package.json and doc

### DIFF
--- a/Documentation/Contributors/BuildGuide/README.md
+++ b/Documentation/Contributors/BuildGuide/README.md
@@ -109,7 +109,6 @@ Here's the full set of scripts and what they do.
   - `eslint-watch` - A never-ending task that watches your file system for changes to Cesium and runs ESLint on any changed source files.
   - `clean` - Removes all generated build artifacts.
   - `cloc` - Runs [CLOC](https://github.com/AlDanial/cloc) to count the lines of code on the Source and Specs directories. This requires [Perl](http://www.perl.org/) to execute.
-  - `sortRequires` - Alphabetically sorts the list of required modules in every `js` file. It also makes sure that the top of every source file uses the same formatting.
 - **Testing scripts** -- build and run the unit tests
   - `test` - Runs all tests with [Karma](http://karma-runner.github.io/0.13/index.html) using the default browser specified in the Karma config file.
   - `test-all` - Runs all tests with Karma using all browsers installed on the current system.

--- a/Documentation/Contributors/CodingGuide/README.md
+++ b/Documentation/Contributors/CodingGuide/README.md
@@ -887,26 +887,6 @@ It is usually obvious what directory a file belongs in. When it isn't, the decis
 
 Modules (files) should only reference modules in the same level or a lower level of the stack. For example, a module in `Scene` can use modules in `Scene`, `Renderer`, and `Core`, but not in `DataSources` or `Widgets`.
 
-- Modules in `define` statements should be in alphabetical order. This can be done automatically with `npm run sortRequires`, see the [Build Guide](../BuildGuide/README.md). For example, the modules required by `Scene/ModelAnimation.js` are:
-
-```javascript
-define([
-  "../Core/defaultValue",
-  "../Core/Event",
-  "../Core/JulianDate",
-  "./ModelAnimationLoop",
-  "./ModelAnimationState",
-], function (
-  defaultValue,
-  Event,
-  JulianDate,
-  ModelAnimationLoop,
-  ModelAnimationState
-) {
-  /* ... */
-});
-```
-
 - WebGL resources need to be explicitly deleted so classes that contain them (and classes that contain these classes, and so on) have `destroy` and `isDestroyed` functions, e.g.,
 
 ```javascript

--- a/Documentation/Contributors/TestingGuide/README.md
+++ b/Documentation/Contributors/TestingGuide/README.md
@@ -236,16 +236,14 @@ Tests are written in JavaScript using Jasmine. It is important to realize that t
 Here is a stripped down version of the tests:
 
 ```javascript
-define(["Core/Cartesian3"], function (Cartesian3) {
-  "use strict";
+import { Cartesian3 } from "../../Source/Cesium.js";
 
-  describe("Cartesian3", function () {
-    it("construct with default values", function () {
-      var cartesian = new Cartesian3();
-      expect(cartesian.x).toEqual(0.0);
-      expect(cartesian.y).toEqual(0.0);
-      expect(cartesian.z).toEqual(0.0);
-    });
+describe("Cartesian3", function () {
+  it("construct with default values", function () {
+    var cartesian = new Cartesian3();
+    expect(cartesian.x).toEqual(0.0);
+    expect(cartesian.y).toEqual(0.0);
+    expect(cartesian.z).toEqual(0.0);
   });
 });
 ```
@@ -724,30 +722,26 @@ This test is more cohesive and easier to debug than if it were written using a _
 As mentioned above, some tests are in the `'WebGL'` category. To assign a category to a suite, pass the category to `describe`.
 
 ```javascript
-define(["Scene/DebugModelMatrixPrimitive", "Specs/createScene"], function (
-  DebugModelMatrixPrimitive,
-  createScene
-) {
-  "use strict";
+import { DebugModelMatrixPrimitive } from "../../Source/Cesium.js";
+import createScene from "../createScene.js";
 
-  describe(
-    "Scene/DebugModelMatrixPrimitive",
-    function () {
-      var scene;
+describe(
+  "Scene/DebugModelMatrixPrimitive",
+  function () {
+    var scene;
 
-      beforeAll(function () {
-        scene = createScene();
-      });
+    beforeAll(function () {
+      scene = createScene();
+    });
 
-      afterAll(function () {
-        scene.destroyForSpecs();
-      });
+    afterAll(function () {
+      scene.destroyForSpecs();
+    });
 
-      // ...
-    },
-    "WebGL"
-  );
-});
+    // ...
+  },
+  "WebGL"
+);
 ```
 
 CesiumJS uses a customized `describe` function that wraps Jasmine describe calls and provides the category capability.

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "test-webgl-validation": "gulp test --webglValidation",
     "test-webgl-stub": "gulp test --webglStub",
     "test-release": "gulp test --release",
-    "sortRequires": "gulp sortRequires",
     "deploy-s3": "gulp deploy-s3",
     "deploy-status": "gulp deploy-status",
     "deploy-set-version": "gulp deploy-set-version",


### PR DESCRIPTION
`sortRequires` was removed with the es6 module migration. Also change imports to es6 in the Testing Guide doc