### PR TITLE
Tweak VSCode config files.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.glsl]
+indent_size = 4

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,11 +19,6 @@
     "files.associations": {
         "*.czml": "json"
     },
-    "files.trimTrailingWhitespace": true,
-    "files.insertFinalNewline": true,
-    "editor.insertSpaces": true,
-    "editor.tabSize": 2,
-    "editor.detectIndentation": false,
     "eslint.enable": true,
     "javascript.format.insertSpaceAfterCommaDelimiter": true,
     "javascript.format.insertSpaceAfterSemicolonInForStatements": true,
@@ -33,5 +28,6 @@
     "javascript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
     "javascript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets": false,
     "javascript.format.placeOpenBraceOnNewLineForFunctions": false,
-    "javascript.format.placeOpenBraceOnNewLineForControlBlocks": false
+    "javascript.format.placeOpenBraceOnNewLineForControlBlocks": false,
+    "glTF.defaultV2Engine": "Cesium"
 }


### PR DESCRIPTION
Fixes #8791.

Remember, you may hand-edit any GitHub URL to include `?w=1` on the end, to show diffs that ignore whitespace changes.