### PR TITLE
Fix problem switching from Uint16 to Uint32 indices for outlining.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 1.70.0 - 2020-06-01
+
+##### Fixes :wrench:
+
+- Fixed a bug that could cause rendering of a glTF model to become corrupt when switching from a Uint16 to a Uint32 index buffer to accomodate new vertices added for edge outlining.
+
 ### 1.69.0 - 2020-05-01
 
 ##### Breaking Changes :mega:

--- a/Source/Scene/ModelOutlineLoader.js
+++ b/Source/Scene/ModelOutlineLoader.js
@@ -8,6 +8,10 @@ import TextureMinificationFilter from "../Renderer/TextureMinificationFilter.js"
 import TextureWrap from "../Renderer/TextureWrap.js";
 import ForEach from "../ThirdParty/GltfPipeline/ForEach.js";
 
+// glTF does not allow an index value of 65535 because this is the primitive
+// restart value in some APIs.
+const MAX_GLTF_UINT16_INDEX = 65534;
+
 /**
  * Creates face outlines for glTF primitives with the `CESIUM_primitive_outline` extension.
  * @private
@@ -273,7 +277,10 @@ function addOutline(
         vertexCopies[unmatchableVertexIndex] = copy;
       }
 
-      if (copy >= 65536 && triangleIndices instanceof Uint16Array) {
+      if (
+        copy > MAX_GLTF_UINT16_INDEX &&
+        triangleIndices instanceof Uint16Array
+      ) {
         // We outgrew a 16-bit index buffer, switch to 32-bit.
         triangleIndices = new Uint32Array(triangleIndices);
         triangleIndexAccessorGltf.componentType = 5125; // UNSIGNED_INT

--- a/Source/Scene/ModelOutlineLoader.js
+++ b/Source/Scene/ModelOutlineLoader.js
@@ -10,7 +10,7 @@ import ForEach from "../ThirdParty/GltfPipeline/ForEach.js";
 
 // glTF does not allow an index value of 65535 because this is the primitive
 // restart value in some APIs.
-const MAX_GLTF_UINT16_INDEX = 65534;
+var MAX_GLTF_UINT16_INDEX = 65534;
 
 /**
  * Creates face outlines for glTF primitives with the `CESIUM_primitive_outline` extension.

--- a/Source/Scene/ModelOutlineLoader.js
+++ b/Source/Scene/ModelOutlineLoader.js
@@ -295,6 +295,15 @@ function addOutline(
           0,
           triangleIndices.byteLength
         );
+
+        // The index componentType is also squirreled away in ModelLoadResources.
+        // Hackily update it, or else we'll end up creating the wrong type
+        // of index buffer later.
+        loadResources.indexBuffersToCreate._array.forEach(function (toCreate) {
+          if (toCreate.id === triangleIndexAccessorGltf.bufferView) {
+            toCreate.componentType = triangleIndexAccessorGltf.componentType;
+          }
+        });
       }
 
       if (unmatchableVertexIndex === i0) {

--- a/Specs/Scene/ModelOutlineLoaderSpec.js
+++ b/Specs/Scene/ModelOutlineLoaderSpec.js
@@ -575,6 +575,10 @@ describe(
           }
         }
 
+        var rendererIndexBuffer =
+          model._rendererResources.buffers[triangleIndexAccessor.bufferView];
+        expect(rendererIndexBuffer.bytesPerIndex).toBe(4);
+
         builder.destroy();
       });
     });

--- a/Specs/Scene/ModelOutlineLoaderSpec.js
+++ b/Specs/Scene/ModelOutlineLoaderSpec.js
@@ -500,6 +500,14 @@ describe(
     });
 
     it("switches to 32-bit indices if more than 65536 vertices are required", function () {
+      if (!scene.context.elementIndexUint) {
+        // This extension is supported everywhere these days, except possibly
+        // in our mocked WebGL context used in the tests on Travis. Consistent
+        // with the approach in ModelSpec.js, `loads a gltf with uint32 indices`,
+        // we'll just give this test a pass if uint indices aren't supported.
+        return;
+      }
+
       var vertices = [];
       var indices = [];
       var edges = [];

--- a/Specs/Scene/ModelOutlineLoaderSpec.js
+++ b/Specs/Scene/ModelOutlineLoaderSpec.js
@@ -499,7 +499,7 @@ describe(
       });
     });
 
-    it("switches to 32-bit indices if more than 65536 vertices are required", function () {
+    it("switches to 32-bit indices if more than 65535 vertices are required", function () {
       if (!scene.context.elementIndexUint) {
         // This extension is supported everywhere these days, except possibly
         // in our mocked WebGL context used in the tests on Travis. Consistent
@@ -513,7 +513,7 @@ describe(
       var edges = [];
 
       // Tricky model is 9 vertices. Add copies of it until we're just under 65636 vertices.
-      for (var i = 0; vertices.length / 7 + 9 <= 65536; ++i) {
+      for (var i = 0; vertices.length / 7 + 9 <= 65535; ++i) {
         createTrickyModel(vertices, indices, edges, 2, true, true, true);
       }
 


### PR DESCRIPTION
Adding edge outlines usually requires adding new vertices, and when we're using a UNSIGNED_SHORT index buffer and the new vertices push us over 65536 vertices, we need to upgrade to an UNSIGNED_INT index buffer. I had previously added this capability, and wrote tests for it, but didn't have any real-world data to test it with at the time. Unfortunately, that code doesn't actually work, and will corrupt rendering of the model when it's triggered. It was all part of my plan to serve as a good illustration for everyone of the dangers of only writing tests for some code and not actually trying it with real data. 😆 

The problem is that `Model` also squirrels away the bufferView's `componentType` in `ModelLoadResources.indexBuffersToCreate` and then uses _that_ to create the buffer instead of the accessor's `componentType` in the glTF. So I'm also helping to illustrate the dangers of denormalization. 👍