### PR TITLE
Add tileset.extensions getter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ##### Additions :tada:
 
-- Added `Cesium3DTileset.extensions` to get the extensions property from the tileset JSON.
+- Added `Cesium3DTileset.extensions` to get the extensions property from the tileset JSON. [#8829](https://github.com/CesiumGS/cesium/pull/8829)
 
 ##### Fixes :wrench:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### 1.70.0 - 2020-06-01
 
+##### Additions :tada:
+
+- Added `Cesium3DTileset.extensions` to get the extensions property from the tileset JSON.
+
 ##### Fixes :wrench:
 
 - This fixes a bug where a removed billboard can prevent changing of the terrainProvider [#8766](https://github.com/CesiumGS/cesium/pull/8766)

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -147,6 +147,7 @@ function Cesium3DTileset(options) {
   this._properties = undefined; // Metadata for per-model/point/etc properties
   this._geometricError = undefined; // Geometric error when the tree is not rendered at all
   this._extensionsUsed = undefined;
+  this._extensions = undefined;
   this._gltfUpAxis = undefined;
   this._cache = new Cesium3DTilesetCache();
   this._processingQueue = [];
@@ -916,6 +917,7 @@ function Cesium3DTileset(options) {
       that._properties = tilesetJson.properties;
       that._geometricError = tilesetJson.geometricError;
       that._extensionsUsed = tilesetJson.extensionsUsed;
+      that._extensions = tilesetJson.extensions;
       that._gltfUpAxis = gltfUpAxis;
       that._extras = tilesetJson.extras;
 
@@ -1010,6 +1012,31 @@ Object.defineProperties(Cesium3DTileset.prototype, {
       return this._asset;
     },
   },
+
+  /**
+   * Gets the tileset's extensions object property.
+   *
+   * @memberof Cesium3DTileset.prototype
+   *
+   * @type {Object}
+   * @readonly
+   *
+   * @exception {DeveloperError} The tileset is not loaded.  Use Cesium3DTileset.readyPromise or wait for Cesium3DTileset.ready to be true.
+   */
+  extensions: {
+    get: function () {
+      //>>includeStart('debug', pragmas.debug);
+      if (!this.ready) {
+        throw new DeveloperError(
+          "The tileset is not loaded.  Use Cesium3DTileset.readyPromise or wait for Cesium3DTileset.ready to be true."
+        );
+      }
+      //>>includeEnd('debug');
+
+      return this._extensions;
+    },
+  },
+
   /**
    * The {@link ClippingPlaneCollection} used to selectively disable rendering the tileset.
    *

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -496,6 +496,15 @@ describe(
       }).toThrowDeveloperError();
     });
 
+    it("throws when getting extensions and tileset is not ready", function () {
+      var tileset = new Cesium3DTileset({
+        url: tilesetUrl,
+      });
+      expect(function () {
+        return tileset.extensions;
+      }).toThrowDeveloperError();
+    });
+
     it("throws when getting properties and tileset is not ready", function () {
       var tileset = new Cesium3DTileset({
         url: tilesetUrl,


### PR DESCRIPTION
Adds a getter for the extensions object in the tileset JSON

@Samulus can you review? This is relevant to grabbing the extent shape from [3DTILES_extent](https://github.com/CesiumGS/3d-tiles/tree/3DTILES_extent/extensions/3DTILES_extent).