### PR TITLE
startsWith is not supported on IE11

### DIFF
--- a/Source/Scene/CreditDisplay.js
+++ b/Source/Scene/CreditDisplay.js
@@ -516,7 +516,7 @@ function getDefaultCredit() {
 
     // When hosting in a WebView, the base URL scheme is file:// or ms-appx-web://
     // which is stripped out from the Credit's <img> tag; use the full path instead
-    if (!logo.startsWith("http://") && !logo.startsWith("https://")) {
+    if (logo.indexOf("http://") !== 0 && logo.indexOf("https://") !== 0) {
       var logoUrl = new Uri(logo);
       logo = logoUrl.getPath();
     }


### PR DESCRIPTION
The PR https://github.com/CesiumGS/cesium/pull/8758 added a `startsWith` call, which is not supported on IE11.

This PR replaces it with an `indexOf()` check. Tested with a built Cesium Viewer.

@mramato 