### PR TITLE
Add space to JSDoc attributes

### DIFF
--- a/Tools/jsdoc/cesium_template/publish.js
+++ b/Tools/jsdoc/cesium_template/publish.js
@@ -120,7 +120,7 @@ function addAttribs(f) {
           attrib +
           '">' +
           htmlsafe(attrib) +
-          "</span>"
+          "</span> "
         );
       })
       .join("");

--- a/Tools/jsdoc/cesium_template/static/styles/jsdoc-default.css
+++ b/Tools/jsdoc/cesium_template/static/styles/jsdoc-default.css
@@ -603,7 +603,6 @@ span.attribute-constant {
   color: #fff;
   font-size: 0.7em;
   padding: 2px 4px;
-  margin-right: 8px;
   margin-bottom: 1px;
   position: relative;
   top: -1px;


### PR DESCRIPTION
I select text using double click a lot - it selects whole words so that I don't need to be that precise in selecting the beginning of a word and the end of it. The words are delimited by a space, not by visual look. If I try to select e.g. `Cesium.Cartographic.ZERO` in the Cesium docs using this method then it results in `staticconstantCesium.Cartographic.ZERO` being selected because there are no spaces after `static` and `constant`. This commit adds the spaces there.

Tested: jsdoc -c Tools/jsdoc/conf.json