### PR TITLE
Add Transforms.eastNorthUp

### DIFF
--- a/Apps/Sandcastle/gallery/development/EastNorthUp.html
+++ b/Apps/Sandcastle/gallery/development/EastNorthUp.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
+    />
+    <meta name="description" content="EastNorthUp" />
+    <meta name="cesium-sandcastle-labels" content="Beginner, Showcases" />
+    <title>Cesium Demo</title>
+    <script type="text/javascript" src="../Sandcastle-header.js"></script>
+    <script
+      type="text/javascript"
+      src="../../../Build/CesiumUnminified/Cesium.js"
+      nomodule
+    ></script>
+    <script type="module" src="../load-cesium-es6.js"></script>
+  </head>
+  <body
+    class="sandcastle-loading"
+    data-sandcastle-bucket="bucket-requirejs.html"
+  >
+    <style>
+      @import url(../templates/bucket.css);
+    </style>
+    <div id="cesiumContainer" class="fullSize"></div>
+    <div id="loadingOverlay"><h1>Loading...</h1></div>
+    <div id="toolbar"></div>
+    <script id="cesium_sandcastle_script">
+      function startup(Cesium) {
+        "use strict";
+        //Sandcastle_Begin
+        var viewer = new Cesium.Viewer("cesiumContainer", {
+          requestRenderMode: true,
+          terrainProvider: Cesium.createWorldTerrain(),
+        });
+        var position = Cesium.Cartesian3.fromDegrees(13.771, 50.4065, 500);
+        var entity = viewer.entities.add({
+          position: new Cesium.SampledPositionProperty(),
+          model: {
+            uri: "../../SampleData/models/CesiumAir/Cesium_Air.glb",
+            minimumPixelSize: 30,
+          },
+        });
+        entity.position.addSample(viewer.clock.currentTime, position);
+        entity.position.addSample(
+          Cesium.JulianDate.addMinutes(viewer.clock.currentTime, 30, new Cesium.JulianDate()),
+          Cesium.Cartesian3.fromDegrees(13.871, 50.4065, 500)
+        );
+        entity.position.forwardExtrapolationType = Cesium.ExtrapolationType.EXTRAPOLATE;
+        viewer.camera.lookAt(
+          position,
+          new Cesium.HeadingPitchRange(
+            Cesium.Math.toRadians(90),
+            Cesium.Math.toRadians(-30),
+            300
+          )
+        );
+        viewer.trackedEntity = entity; // Unlocks the camera from lookAt.
+        viewer.trackedEntity = undefined;
+
+        Sandcastle.addToolbarButton("Go/Stop", function () {
+          viewer.clock.shouldAnimate = !viewer.clock.shouldAnimate;
+          if (viewer.clock.shouldAnimate) {
+            entity.viewFrom = Cesium.Transforms.eastNorthUp(
+              entity.position.getValue(viewer.clock.currentTime),
+              viewer.camera.position
+            );
+            viewer.trackedEntity = entity;
+          } else {
+            viewer.trackedEntity = undefined;
+          }
+        });
+        //Sandcastle_End
+        Sandcastle.finishedLoading();
+      }
+      if (typeof Cesium !== "undefined") {
+        window.startupCalled = true;
+        startup(Cesium);
+      }
+    </script>
+  </body>
+</html>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Additions :tada:
 
 - Added `Cesium3DTileset.extensions` to get the extensions property from the tileset JSON. [#8829](https://github.com/CesiumGS/cesium/pull/8829)
+- Added `Transforms.eastNorthUp` to compute the east-north-up difference. [#8838](https://github.com/CesiumGS/cesium/pull/8838)
 
 ##### Fixes :wrench:
 

--- a/Specs/Core/TransformsSpec.js
+++ b/Specs/Core/TransformsSpec.js
@@ -1639,6 +1639,38 @@ describe("Core/Transforms", function () {
     expect(returnedResult).toEqualEpsilon(expected, CesiumMath.EPSILON12);
   });
 
+  it("eastNorthUp east", function () {
+    var left = Cartesian3.fromDegrees(11, 10);
+    var right = Cartesian3.fromDegrees(10, 10);
+    var expected = new Cartesian3(-109637, 0, 0);
+    var eastNorthUp = Transforms.eastNorthUp(left, right);
+    expect(eastNorthUp.equalsEpsilon(expected, CesiumMath.EPSILON1)).toEqual(true);
+  });
+
+  it("eastNorthUp north", function () {
+    var left = Cartesian3.fromDegrees(10, 11);
+    var right = Cartesian3.fromDegrees(10, 10);
+    var expected = new Cartesian3(0, -110609.8, 0);
+    var eastNorthUp = Transforms.eastNorthUp(left, right);
+    expect(eastNorthUp.equalsEpsilon(expected, CesiumMath.EPSILON1)).toEqual(true);
+  });
+
+  it("eastNorthUp up", function () {
+    var left = Cartesian3.fromDegrees(10, 10, 11);
+    var right = Cartesian3.fromDegrees(10, 10, 10);
+    var expected = new Cartesian3(0, 0, -1);
+    var eastNorthUp = Transforms.eastNorthUp(left, right);
+    expect(eastNorthUp.equalsEpsilon(expected, CesiumMath.EPSILON1)).toEqual(true);
+  });
+
+  it("eastNorthUp", function () {
+    var left = Cartesian3.fromDegrees(11, 11, 11);
+    var right = Cartesian3.fromDegrees(10, 10, 10);
+    var expected = new Cartesian3(-109286.4, -110610, -1);
+    var eastNorthUp = Transforms.eastNorthUp(left, right);
+    expect(eastNorthUp.equalsEpsilon(expected, CesiumMath.EPSILON1)).toEqual(true);
+  });
+
   it("pointToWindowCoordinates works at the center", function () {
     var view = Matrix4.fromCamera({
       position: Cartesian3.multiplyByScalar(


### PR DESCRIPTION
I need to keep the camera where it is and just point it to an entity I'm about to track. `Entity.viewFrom` accepts east-north-up and I don't see an obvious way how to compute it from the entity and camera positions.

This function does that in a dumb way - just create two points (one south from the entity and one down below camera) and compute the distance to them. Maybe it could be done easier with some matrix operations but I don't understand them.