### PR TITLE
Simplify skinning to always expect VEC4 joint/weight accessors.

### DIFF
--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -4388,7 +4388,7 @@ function applySkins(model) {
         computedJointMatrices[m]
       );
       if (defined(bindShapeMatrix)) {
-        // Optimization for when bind shape matrix is the identity.
+        // NOTE: bindShapeMatrix is glTF 1.0 only, removed in glTF 2.0.
         computedJointMatrices[m] = Matrix4.multiplyTransformation(
           computedJointMatrices[m],
           bindShapeMatrix,

--- a/Source/Scene/ModelUtility.js
+++ b/Source/Scene/ModelUtility.js
@@ -70,13 +70,13 @@ ModelUtility.splitIncompatibleMaterials = function (gltf) {
 
       var jointAccessorId = primitive.attributes.JOINTS_0;
       var componentType;
-      var type;
+      var accessorType;
       if (defined(jointAccessorId)) {
         var jointAccessor = accessors[jointAccessorId];
         componentType = jointAccessor.componentType;
-        type = jointAccessor.type;
+        accessorType = jointAccessor.type;
       }
-      var isSkinned = defined(jointAccessorId);
+      var isSkinned = defined(jointAccessorId) && accessorType === "VEC4";
       var hasVertexColors = defined(primitive.attributes.COLOR_0);
       var hasMorphTargets = defined(primitive.targets);
       var hasNormals = defined(primitive.attributes.NORMAL);
@@ -92,7 +92,6 @@ ModelUtility.splitIncompatibleMaterials = function (gltf) {
           skinning: {
             skinned: isSkinned,
             componentType: componentType,
-            type: type,
           },
           hasVertexColors: hasVertexColors,
           hasMorphTargets: hasMorphTargets,
@@ -103,7 +102,6 @@ ModelUtility.splitIncompatibleMaterials = function (gltf) {
         };
       } else if (
         primitiveInfo.skinning.skinned !== isSkinned ||
-        primitiveInfo.skinning.type !== type ||
         primitiveInfo.hasVertexColors !== hasVertexColors ||
         primitiveInfo.hasMorphTargets !== hasMorphTargets ||
         primitiveInfo.hasNormals !== hasNormals ||
@@ -124,7 +122,6 @@ ModelUtility.splitIncompatibleMaterials = function (gltf) {
           skinning: {
             skinned: isSkinned,
             componentType: componentType,
-            type: type,
           },
           hasVertexColors: hasVertexColors,
           hasMorphTargets: hasMorphTargets,

--- a/Source/Scene/processModelMaterialsCommon.js
+++ b/Source/Scene/processModelMaterialsCommon.js
@@ -406,7 +406,7 @@ function generateTechnique(
   vertexShader += "varying vec3 v_positionEC;\n";
   if (hasSkinning) {
     vertexShaderMain +=
-      "  vec4 pos = u_modelViewMatrix * skinMat * vec4(a_position,1.0);\n";
+      "  vec4 pos = u_modelViewMatrix * skinMatrix * vec4(a_position,1.0);\n";
   } else {
     vertexShaderMain +=
       "  vec4 pos = u_modelViewMatrix * vec4(a_position,1.0);\n";
@@ -424,7 +424,7 @@ function generateTechnique(
     vertexShader += "varying vec3 v_normal;\n";
     if (hasSkinning) {
       vertexShaderMain +=
-        "  v_normal = u_normalMatrix * mat3(skinMat) * a_normal;\n";
+        "  v_normal = u_normalMatrix * mat3(skinMatrix) * a_normal;\n";
     } else {
       vertexShaderMain += "  v_normal = u_normalMatrix * a_normal;\n";
     }
@@ -449,10 +449,10 @@ function generateTechnique(
 
   if (hasSkinning) {
     techniqueAttributes.a_joint = {
-      semantic: "JOINT",
+      semantic: "JOINTS_0",
     };
     techniqueAttributes.a_weight = {
-      semantic: "WEIGHT",
+      semantic: "WEIGHTS_0",
     };
 
     vertexShader += "attribute vec4 a_joint;\n";

--- a/Source/Scene/processModelMaterialsCommon.js
+++ b/Source/Scene/processModelMaterialsCommon.js
@@ -389,44 +389,12 @@ function generateTechnique(
   // Add attributes with semantics
   var vertexShaderMain = "";
   if (hasSkinning) {
-    var i, j;
-    var numberOfComponents = numberOfComponentsForType(skinningInfo.type);
-    var matrix = false;
-    if (skinningInfo.type.indexOf("MAT") === 0) {
-      matrix = true;
-      numberOfComponents = Math.sqrt(numberOfComponents);
-    }
-    if (!matrix) {
-      for (i = 0; i < numberOfComponents; i++) {
-        if (i === 0) {
-          vertexShaderMain += "  mat4 skinMat = ";
-        } else {
-          vertexShaderMain += "  skinMat += ";
-        }
-        vertexShaderMain +=
-          "a_weight[" + i + "] * u_jointMatrix[int(a_joint[" + i + "])];\n";
-      }
-    } else {
-      for (i = 0; i < numberOfComponents; i++) {
-        for (j = 0; j < numberOfComponents; j++) {
-          if (i === 0 && j === 0) {
-            vertexShaderMain += "  mat4 skinMat = ";
-          } else {
-            vertexShaderMain += "  skinMat += ";
-          }
-          vertexShaderMain +=
-            "a_weight[" +
-            i +
-            "][" +
-            j +
-            "] * u_jointMatrix[int(a_joint[" +
-            i +
-            "][" +
-            j +
-            "])];\n";
-        }
-      }
-    }
+    vertexShaderMain +=
+      "    mat4 skinMatrix =\n" +
+      "        a_weight.x * u_jointMatrix[int(a_joint.x)] +\n" +
+      "        a_weight.y * u_jointMatrix[int(a_joint.y)] +\n" +
+      "        a_weight.z * u_jointMatrix[int(a_joint.z)] +\n" +
+      "        a_weight.w * u_jointMatrix[int(a_joint.w)];\n";
   }
 
   // Add position always
@@ -481,7 +449,6 @@ function generateTechnique(
   }
 
   if (hasSkinning) {
-    var attributeType = ModelUtility.getShaderVariable(skinningInfo.type);
     techniqueAttributes.a_joint = {
       semantic: "JOINT",
     };
@@ -489,8 +456,8 @@ function generateTechnique(
       semantic: "WEIGHT",
     };
 
-    vertexShader += "attribute " + attributeType + " a_joint;\n";
-    vertexShader += "attribute " + attributeType + " a_weight;\n";
+    vertexShader += "attribute vec4 a_joint;\n";
+    vertexShader += "attribute vec4 a_weight;\n";
   }
 
   if (hasVertexColors) {

--- a/Source/Scene/processModelMaterialsCommon.js
+++ b/Source/Scene/processModelMaterialsCommon.js
@@ -5,7 +5,6 @@ import webGLConstantToGlslType from "../Core/webGLConstantToGlslType.js";
 import addToArray from "../ThirdParty/GltfPipeline/addToArray.js";
 import ForEach from "../ThirdParty/GltfPipeline/ForEach.js";
 import hasExtension from "../ThirdParty/GltfPipeline/hasExtension.js";
-import numberOfComponentsForType from "../ThirdParty/GltfPipeline/numberOfComponentsForType.js";
 import ModelUtility from "./ModelUtility.js";
 
 /**

--- a/Source/Scene/processPbrMaterials.js
+++ b/Source/Scene/processPbrMaterials.js
@@ -5,7 +5,6 @@ import webGLConstantToGlslType from "../Core/webGLConstantToGlslType.js";
 import addToArray from "../ThirdParty/GltfPipeline/addToArray.js";
 import ForEach from "../ThirdParty/GltfPipeline/ForEach.js";
 import hasExtension from "../ThirdParty/GltfPipeline/hasExtension.js";
-import numberOfComponentsForType from "../ThirdParty/GltfPipeline/numberOfComponentsForType.js";
 import ModelUtility from "./ModelUtility.js";
 
 /**

--- a/Source/Scene/processPbrMaterials.js
+++ b/Source/Scene/processPbrMaterials.js
@@ -374,44 +374,12 @@ function generateTechnique(
   // Add attributes with semantics
   var vertexShaderMain = "";
   if (hasSkinning) {
-    var i, j;
-    var numberOfComponents = numberOfComponentsForType(skinningInfo.type);
-    var matrix = false;
-    if (skinningInfo.type.indexOf("MAT") === 0) {
-      matrix = true;
-      numberOfComponents = Math.sqrt(numberOfComponents);
-    }
-    if (!matrix) {
-      for (i = 0; i < numberOfComponents; i++) {
-        if (i === 0) {
-          vertexShaderMain += "    mat4 skinMatrix = ";
-        } else {
-          vertexShaderMain += "    skinMatrix += ";
-        }
-        vertexShaderMain +=
-          "a_weight[" + i + "] * u_jointMatrix[int(a_joint[" + i + "])];\n";
-      }
-    } else {
-      for (i = 0; i < numberOfComponents; i++) {
-        for (j = 0; j < numberOfComponents; j++) {
-          if (i === 0 && j === 0) {
-            vertexShaderMain += "    mat4 skinMatrix = ";
-          } else {
-            vertexShaderMain += "    skinMatrix += ";
-          }
-          vertexShaderMain +=
-            "a_weight[" +
-            i +
-            "][" +
-            j +
-            "] * u_jointMatrix[int(a_joint[" +
-            i +
-            "][" +
-            j +
-            "])];\n";
-        }
-      }
-    }
+    vertexShaderMain +=
+      "    mat4 skinMatrix =\n" +
+      "        a_weight.x * u_jointMatrix[int(a_joint.x)] +\n" +
+      "        a_weight.y * u_jointMatrix[int(a_joint.y)] +\n" +
+      "        a_weight.z * u_jointMatrix[int(a_joint.z)] +\n" +
+      "        a_weight.w * u_jointMatrix[int(a_joint.w)];\n";
   }
 
   // Add position always
@@ -619,7 +587,6 @@ function generateTechnique(
 
   // Add skinning information if available
   if (hasSkinning) {
-    var attributeType = ModelUtility.getShaderVariable(skinningInfo.type);
     techniqueAttributes.a_joint = {
       semantic: "JOINTS_0",
     };
@@ -627,8 +594,8 @@ function generateTechnique(
       semantic: "WEIGHTS_0",
     };
 
-    vertexShader += "attribute " + attributeType + " a_joint;\n";
-    vertexShader += "attribute " + attributeType + " a_weight;\n";
+    vertexShader += "attribute vec4 a_joint;\n";
+    vertexShader += "attribute vec4 a_weight;\n";
   }
 
   if (hasVertexColors) {


### PR DESCRIPTION
A few weeks ago I was implementing skinning in a desktop product, and looked to Cesium's implementation for some inspiration.  This is a story of what I unearthed.

In glTF 2.0, the `JOINTS_0` and `WEIGHTS_0` accessors are [specified](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#meshes) to be vertex attributes of type `VEC4` only.  But in glTF 1.0, this was left unspecified.  Normal software that writes this stuff always wrote VEC4 data, but our intrepid intern at the time took the loose specification to mean that any type of accessor could appear there.

As a result, a complex block of JavaScript writes skinning GLSL vertex shader code for any conceivable layout of joint+weight data, including the possibility of using a per-vertex matrix of references to joint matricies.  There is no known sample or test data that does this, and indeed this code was not covered by unit tests for any case other than the `VEC4` case alone.

In this PR, I've replaced all the crazy skinning-shader-writing code with a copy of the correct output for `VEC4` which should always have been the only allowed case.  As a precaution I put in a sanity check to disable skinning on a mesh in case an invalid format is ever found in this field.

I tested this with the four old sample glTF 1.0 files, to confirm they all use `VEC4`, and yes, they do and they work correctly.  I also briefly tested with a glTF 2.0 file, but I'm not as concerned there since the spec is a little tighter.

I expect no change in behavior, this is just a simplification (and removal of untested, presumed-dead code for dealing with matrices of matrices).