### PR TITLE
Make entire sandcastle code searchable

### DIFF
--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -550,6 +550,7 @@ require({
     lineNumbers: true,
     matchBrackets: true,
     indentUnit: 2,
+    viewportMargin: Infinity,
     extraKeys: {
       "Ctrl-Space": "autocomplete",
       F8: "runCesium",
@@ -566,6 +567,7 @@ require({
     lineNumbers: true,
     matchBrackets: true,
     indentUnit: 2,
+    viewportMargin: Infinity,
     extraKeys: {
       F8: "runCesium",
       Tab: "indentMore",

--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -550,7 +550,7 @@ require({
     lineNumbers: true,
     matchBrackets: true,
     indentUnit: 2,
-    viewportMargin: Infinity,
+    viewportMargin: 1300,
     extraKeys: {
       "Ctrl-Space": "autocomplete",
       F8: "runCesium",
@@ -567,7 +567,7 @@ require({
     lineNumbers: true,
     matchBrackets: true,
     indentUnit: 2,
-    viewportMargin: Infinity,
+    viewportMargin: 1300,
     extraKeys: {
       F8: "runCesium",
       Tab: "indentMore",


### PR DESCRIPTION
This PR makes the entire sandcastle code searchable. Before it could only search the visible region.

From [CodeMirror Docs](https://codemirror.net/doc/manual.html#config):
> viewportMargin: integer
> Specifies the amount of lines that are rendered above and below the part of the document that's currently scrolled into view. This affects the amount of updates needed when scrolling, and the amount of work that such an update does. You should usually leave it at its default, 10. Can be set to Infinity to make sure the whole document is always rendered, and thus the browser's text search works on it. This will have bad effects on performance of big documents.
>

So far I've only noticed performance issues for very large sandcastles like: http://localhost:8080/Apps/Sandcastle/index.html?src=CZML%20Path.html (7267 lines)

The next largest sandcastle is fine: http://localhost:8080/Apps/Sandcastle/index.html?src=development%2FGeometry%20and%20Appearances.html (1289 lines)

So there's definitely a tradeoff here. And we can't predict how large user sandcastles will be. Thoughts?

