### PR TITLE
fixed bug when mat has texture but model hasn't uv will cause crash

### DIFF
--- a/Source/Scene/processPbrMaterials.js
+++ b/Source/Scene/processPbrMaterials.js
@@ -775,7 +775,7 @@ function generateTechnique(
   }
 
   // Add base color to fragment shader
-  if (defined(generatedMaterialValues.u_baseColorTexture)) {
+  if (defined(generatedMaterialValues.u_baseColorTexture) && hasTexCoords) {
     fragmentShader +=
       "    vec4 baseColorWithAlpha = SRGBtoLINEAR4(texture2D(u_baseColorTexture, " +
       baseColorTexCoord +


### PR DESCRIPTION

 I've met some model who's materials (or some of them) have baseColorTexture but the mesh who use them has no uv coords,when load in cesium will cause crash.
this is a workaround to prevent cesium crash,who has idea to completely solve this problem