### PR TITLE
Remove trailing references from ManagedArray and Heap

### DIFF
--- a/Source/Core/Heap.js
+++ b/Source/Core/Heap.js
@@ -24,6 +24,16 @@ function Heap(options) {
   this._maximumLength = undefined;
 }
 
+function removeTrailingReferences(heap, newLength) {
+  var originalLength = heap._length;
+  if (newLength < originalLength) {
+    var array = heap._array;
+    for (var i = newLength; i < originalLength; ++i) {
+      array[i] = undefined;
+    }
+  }
+}
+
 Object.defineProperties(Heap.prototype, {
   /**
    * Gets the length of the heap.
@@ -65,6 +75,7 @@ Object.defineProperties(Heap.prototype, {
       return this._maximumLength;
     },
     set: function (value) {
+      removeTrailingReferences(this, value);
       this._maximumLength = value;
       if (this._length > value && value > 0) {
         this._length = value;
@@ -211,6 +222,7 @@ Heap.prototype.pop = function (index) {
   var root = array[index];
   swap(array, index, --this._length);
   this.heapify(index);
+  array[this._length] = undefined; // Remove trailing reference
   return root;
 };
 

--- a/Source/Core/Heap.js
+++ b/Source/Core/Heap.js
@@ -65,6 +65,9 @@ Object.defineProperties(Heap.prototype, {
       return this._maximumLength;
     },
     set: function (value) {
+      //>>includeStart('debug', pragmas.debug);
+      Check.typeOf.number.greaterThanOrEquals("maximumLength", value, 0);
+      //>>includeEnd('debug');
       var originalLength = this._length;
       if (value < originalLength) {
         var array = this._array;

--- a/Source/Core/Heap.js
+++ b/Source/Core/Heap.js
@@ -24,16 +24,6 @@ function Heap(options) {
   this._maximumLength = undefined;
 }
 
-function removeTrailingReferences(heap, newLength) {
-  var originalLength = heap._length;
-  if (newLength < originalLength) {
-    var array = heap._array;
-    for (var i = newLength; i < originalLength; ++i) {
-      array[i] = undefined;
-    }
-  }
-}
-
 Object.defineProperties(Heap.prototype, {
   /**
    * Gets the length of the heap.
@@ -75,12 +65,17 @@ Object.defineProperties(Heap.prototype, {
       return this._maximumLength;
     },
     set: function (value) {
-      removeTrailingReferences(this, value);
-      this._maximumLength = value;
-      if (this._length > value && value > 0) {
+      var originalLength = this._length;
+      if (value < originalLength) {
+        var array = this._array;
+        // Remove trailing references
+        for (var i = value; i < originalLength; ++i) {
+          array[i] = undefined;
+        }
         this._length = value;
-        this._array.length = value;
+        array.length = value;
       }
+      this._maximumLength = value;
     },
   },
 

--- a/Source/Core/ManagedArray.js
+++ b/Source/Core/ManagedArray.js
@@ -16,16 +16,6 @@ function ManagedArray(length) {
   this._length = length;
 }
 
-function removeTrailingReferences(managedArray, newLength) {
-  var array = managedArray._array;
-  var originalLength = managedArray._length;
-  if (newLength < originalLength) {
-    for (var i = newLength; i < originalLength; ++i) {
-      array[i] = undefined;
-    }
-  }
-}
-
 Object.defineProperties(ManagedArray.prototype, {
   /**
    * Gets or sets the length of the array.
@@ -39,11 +29,17 @@ Object.defineProperties(ManagedArray.prototype, {
       return this._length;
     },
     set: function (length) {
-      removeTrailingReferences(this, length);
-      this._length = length;
-      if (length > this._array.length) {
-        this._array.length = length;
+      var array = this._array;
+      var originalLength = this._length;
+      if (length < originalLength) {
+        // Remove trailing references
+        for (var i = length; i < originalLength; ++i) {
+          array[i] = undefined;
+        }
+      } else if (length > array.length) {
+        array.length = length;
       }
+      this._length = length;
     },
   },
 

--- a/Source/Core/ManagedArray.js
+++ b/Source/Core/ManagedArray.js
@@ -29,6 +29,9 @@ Object.defineProperties(ManagedArray.prototype, {
       return this._length;
     },
     set: function (length) {
+      //>>includeStart('debug', pragmas.debug);
+      Check.typeOf.number.greaterThanOrEquals("length", length, 0);
+      //>>includeEnd('debug');
       var array = this._array;
       var originalLength = this._length;
       if (length < originalLength) {

--- a/Source/Core/ManagedArray.js
+++ b/Source/Core/ManagedArray.js
@@ -16,6 +16,16 @@ function ManagedArray(length) {
   this._length = length;
 }
 
+function removeTrailingReferences(managedArray, newLength) {
+  var array = managedArray._array;
+  var originalLength = managedArray._length;
+  if (newLength < originalLength) {
+    for (var i = newLength; i < originalLength; ++i) {
+      array[i] = undefined;
+    }
+  }
+}
+
 Object.defineProperties(ManagedArray.prototype, {
   /**
    * Gets or sets the length of the array.
@@ -29,6 +39,7 @@ Object.defineProperties(ManagedArray.prototype, {
       return this._length;
     },
     set: function (length) {
+      removeTrailingReferences(this, length);
       this._length = length;
       if (length > this._array.length) {
         this._array.length = length;
@@ -74,7 +85,7 @@ ManagedArray.prototype.set = function (index, element) {
   Check.typeOf.number("index", index);
   //>>includeEnd('debug');
 
-  if (index >= this.length) {
+  if (index >= this._length) {
     this.length = index + 1;
   }
   this._array[index] = element;
@@ -105,7 +116,12 @@ ManagedArray.prototype.push = function (element) {
  * @returns {*} The last element in the array.
  */
 ManagedArray.prototype.pop = function () {
-  return this._array[--this.length];
+  if (this._length === 0) {
+    return undefined;
+  }
+  var element = this._array[this._length - 1];
+  --this.length;
+  return element;
 };
 
 /**
@@ -142,7 +158,7 @@ ManagedArray.prototype.resize = function (length) {
  * @param {Number} [length] The length.
  */
 ManagedArray.prototype.trim = function (length) {
-  length = defaultValue(length, this.length);
+  length = defaultValue(length, this._length);
   this._array.length = length;
 };
 export default ManagedArray;

--- a/Specs/Core/HeapSpec.js
+++ b/Specs/Core/HeapSpec.js
@@ -207,4 +207,13 @@ describe("Core/Heap", function () {
       currentId = element.id;
     }
   });
+
+  it("maximumLength setter throws if length is less than 0", function () {
+    var heap = new Heap({
+      comparator: comparator,
+    });
+    expect(function () {
+      heap.maximumLength = -1;
+    }).toThrowDeveloperError();
+  });
 });

--- a/Specs/Core/HeapSpec.js
+++ b/Specs/Core/HeapSpec.js
@@ -3,6 +3,15 @@ import { Heap } from "../../Source/Cesium.js";
 describe("Core/Heap", function () {
   var length = 100;
 
+  function expectTrailingReferenceToBeRemoved(heap) {
+    var array = heap._array;
+    var length = heap._length;
+    var reservedLength = array.length;
+    for (var i = length; i < reservedLength; ++i) {
+      expect(array[i]).toBeUndefined();
+    }
+  }
+
   function checkHeap(heap, comparator) {
     var array = heap.internalArray;
     var pass = true;
@@ -88,6 +97,34 @@ describe("Core/Heap", function () {
       curr = next;
     }
     expect(pass).toBe(true);
+  });
+
+  it("pop removes trailing references", function () {
+    var heap = new Heap({
+      comparator: comparator,
+    });
+
+    for (var i = 0; i < 10; ++i) {
+      heap.insert(Math.random());
+    }
+
+    heap.pop();
+    heap.pop();
+
+    expectTrailingReferenceToBeRemoved(heap);
+  });
+
+  it("setting maximum length less than current length removes trailing references", function () {
+    var heap = new Heap({
+      comparator: comparator,
+    });
+
+    for (var i = 0; i < 10; ++i) {
+      heap.insert(Math.random());
+    }
+
+    heap.maximumLength = 5;
+    expectTrailingReferenceToBeRemoved(heap);
   });
 
   it("insert returns the removed element when maximumLength is set", function () {

--- a/Specs/Core/ManagedArraySpec.js
+++ b/Specs/Core/ManagedArraySpec.js
@@ -51,6 +51,13 @@ describe("Core/ManagedArray", function () {
     }).toThrowDeveloperError();
   });
 
+  it("length setter throws if length is less than 0", function () {
+    var array = new ManagedArray();
+    expect(function () {
+      array.length = -1;
+    }).toThrowDeveloperError();
+  });
+
   it("set resizes array", function () {
     var array = new ManagedArray();
     array.set(0, "a");

--- a/Specs/Core/ManagedArraySpec.js
+++ b/Specs/Core/ManagedArraySpec.js
@@ -1,6 +1,15 @@
 import { ManagedArray } from "../../Source/Cesium.js";
 
 describe("Core/ManagedArray", function () {
+  function expectTrailingReferenceToBeRemoved(managedArray) {
+    var array = managedArray._array;
+    var length = managedArray._length;
+    var reservedLength = array.length;
+    for (var i = length; i < reservedLength; ++i) {
+      expect(array[i]).toBeUndefined();
+    }
+  }
+
   it("constructor has expected default values", function () {
     var array = new ManagedArray();
     expect(array.length).toEqual(0);
@@ -90,6 +99,24 @@ describe("Core/ManagedArray", function () {
     }
   });
 
+  it("pop removes trailing references", function () {
+    var length = 10;
+    var array = new ManagedArray(length);
+    array.set(0, Math.random());
+    array.set(1, Math.random());
+    array.set(2, Math.random());
+    array.pop();
+    array.pop();
+    expectTrailingReferenceToBeRemoved(array);
+  });
+
+  it("pop returns undefined if array is empty", function () {
+    var array = new ManagedArray();
+    array.push(1);
+    expect(array.pop()).toBe(1);
+    expect(array.pop()).toBeUndefined();
+  });
+
   it("reserve throws if length is less than 0", function () {
     var array = new ManagedArray();
     expect(function () {
@@ -128,6 +155,16 @@ describe("Core/ManagedArray", function () {
     array.resize(5);
     expect(array.values.length).toEqual(20);
     expect(array.length).toEqual(5);
+  });
+
+  it("resize removes trailing references", function () {
+    var length = 10;
+    var array = new ManagedArray(length);
+    array.set(0, Math.random());
+    array.set(1, Math.random());
+    array.set(2, Math.random());
+    array.resize(1);
+    expectTrailingReferenceToBeRemoved(array);
   });
 
   it("trim", function () {


### PR DESCRIPTION
This is a companion PR to https://github.com/CesiumGS/cesium/pull/8883 that removes trailing references when elements are removed from `ManagedArray` and `Heap`.