### PR TITLE
Remove hardcoded node_modules in gulpfile.

### DIFF
--- a/gulpfile.cjs
+++ b/gulpfile.cjs
@@ -272,13 +272,11 @@ gulp.task("clean", function (done) {
 
 function cloc() {
   var cmdLine;
-  var clocPath = path.join("node_modules", "cloc", "lib", "cloc");
 
   //Run cloc on primary Source files only
   var source = new Promise(function (resolve, reject) {
     cmdLine =
-      "perl " +
-      clocPath +
+      "npx cloc" +
       " --quiet --progress-rate=0" +
       " Source/ --exclude-dir=Assets,ThirdParty,Workers --not-match-f=copyrightHeader.js";
 
@@ -297,8 +295,7 @@ function cloc() {
   return source.then(function () {
     return new Promise(function (resolve, reject) {
       cmdLine =
-        "perl " +
-        clocPath +
+        "npx cloc" +
         " --quiet --progress-rate=0" +
         " Specs/ --exclude-dir=Data";
       child_process.exec(cmdLine, function (error, stdout, stderr) {
@@ -341,30 +338,16 @@ gulp.task("combineRelease", gulp.series("build", combineRelease));
 
 //Builds the documentation
 function generateDocumentation() {
-  var envPathSeperator = os.platform() === "win32" ? ";" : ":";
-
-  return new Promise(function (resolve, reject) {
-    child_process.exec(
-      "jsdoc --configure Tools/jsdoc/conf.json",
-      {
-        env: {
-          PATH: process.env.PATH + envPathSeperator + "node_modules/.bin",
-          CESIUM_VERSION: version,
-        },
-      },
-      function (error, stdout, stderr) {
-        if (error) {
-          console.log(stderr);
-          return reject(error);
-        }
-        console.log(stdout);
-        var stream = gulp
-          .src("Documentation/Images/**")
-          .pipe(gulp.dest("Build/Documentation/Images"));
-        return streamToPromise(stream).then(resolve);
-      }
-    );
+  child_process.execSync("npx jsdoc --configure Tools/jsdoc/conf.json", {
+    stdio: "inherit",
+    env: Object.assign({}, process.env, { CESIUM_VERSION: version }),
   });
+
+  var stream = gulp
+    .src("Documentation/Images/**")
+    .pipe(gulp.dest("Build/Documentation/Images"));
+
+  return streamToPromise(stream);
 }
 gulp.task("generateDocumentation", generateDocumentation);
 
@@ -1481,10 +1464,9 @@ function createCesiumJs() {
 
 function createTypeScriptDefinitions() {
   // Run jsdoc with tsd-jsdoc to generate an initial Cesium.d.ts file.
-  child_process.execSync(
-    "node_modules/.bin/jsdoc --configure Tools/jsdoc/ts-conf.json",
-    { stdio: "inherit" }
-  );
+  child_process.execSync("npx jsdoc --configure Tools/jsdoc/ts-conf.json", {
+    stdio: "inherit",
+  });
 
   var source = fs.readFileSync("Source/Cesium.d.ts").toString();
 
@@ -1608,7 +1590,7 @@ ${source}
   fs.writeFileSync("Source/Cesium.d.ts", source);
 
   // Use tsc to compile it and make sure it is valid
-  child_process.execSync("node_modules/.bin/tsc -p Tools/jsdoc/tsconfig.json", {
+  child_process.execSync("npx tsc -p Tools/jsdoc/tsconfig.json", {
     stdio: "inherit",
   });
 


### PR DESCRIPTION
1. Use `npx` to execute binaries rather than hardcoded `node_modules/.bin`, which may not always be the right location.

2. Streamline generateDocumentation by calling it sync.

@thw0rted when you get a chance can you verify this fixes the issues you were having? Should be same or close to the same as the changes you originally proposed.