### PR TITLE
Fix for Node 14 Gulp Build issue

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -147,7 +147,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
   - [Joseph Stein](https://github.com/nahgrin)
 - [EOX IT Services GmbH](https://eox.at)
   - [Daniel Santillan](https://github.com/santilland)
-- [Navagis, Inc.](https://github.com/Navagis-LLC)
+- [Navagis, Inc.](https://navagis.com/)
   - [Jonathan Nogueira](https://github.com/LuminousPath)
 
 ## [Individual CLA](Documentation/Contributors/CLAs/individual-contributor-license-agreement-v1.0.pdf)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -147,6 +147,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
   - [Joseph Stein](https://github.com/nahgrin)
 - [EOX IT Services GmbH](https://eox.at)
   - [Daniel Santillan](https://github.com/santilland)
+- [Navagis, Inc.](https://github.com/Navagis-LLC)
+  - [Jonathan Nogueira](https://github.com/LuminousPath)
 
 ## [Individual CLA](Documentation/Contributors/CLAs/individual-contributor-license-agreement-v1.0.pdf)
 

--- a/gulpfile.cjs
+++ b/gulpfile.cjs
@@ -1327,7 +1327,7 @@ function combineJavaScript(options) {
 }
 
 function glslToJavaScript(minify, minifyStateFilePath) {
-  fs.writeFileSync(minifyStateFilePath, minify);
+  fs.writeFileSync(minifyStateFilePath, minify.toString());
   var minifyStateFileLastModified = fs.existsSync(minifyStateFilePath)
     ? fs.statSync(minifyStateFilePath).mtime.getTime()
     : 0;


### PR DESCRIPTION
Fixes #8864 by passing the `minify` argument as a string to `fs.writeFileSync`