### PR TITLE
Add toString method for Resource class

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### 1.71.0 - 2020-07-01
 
+##### Additions :tada:
+
+- Add a `toString` method to the `Resource` class in case an instance gets logged as a string. [#8722](https://github.com/CesiumGS/cesium/issues/8722)
+
 ##### Fixes :wrench:
 
 - Fixed a bug with handling of PixelFormat's flipY. [#8893](https://github.com/CesiumGS/cesium/pull/8893)

--- a/Source/Core/Resource.js
+++ b/Source/Core/Resource.js
@@ -522,10 +522,20 @@ Object.defineProperties(Resource.prototype, {
 });
 
 /**
+ * Override Object#toString so that implicit string conversion gives the
+ * complete URL represented by this Resource.
+ *
+ * @returns {String} The URL represented by this Resource
+ */
+Resource.prototype.toString = function () {
+  return this.getUrlComponent(true, true);
+};
+
+/**
  * Returns the url, optional with the query string and processed by a proxy.
  *
  * @param {Boolean} [query=false] If true, the query string is included.
- * @param {Boolean} [proxy=false] If true, the url is processed the proxy object if defined.
+ * @param {Boolean} [proxy=false] If true, the url is processed by the proxy object, if defined.
  *
  * @returns {String} The url with all the requested components.
  */

--- a/Specs/Core/ResourceSpec.js
+++ b/Specs/Core/ResourceSpec.js
@@ -59,7 +59,7 @@ describe("Core/Resource", function () {
     expect(resource.url).toEqual(
       proxy.getURL("http://test.com/tileset?key1=value1&key2=value2")
     );
-    expect(resource + "").toEqual(
+    expect(String(resource)).toEqual(
       proxy.getURL("http://test.com/tileset?key1=value1&key2=value2")
     );
     expect(resource.queryParameters).toEqual({
@@ -84,7 +84,7 @@ describe("Core/Resource", function () {
     var url = "http://invalid.domain.com/tileset";
     var resource = new Resource(url);
     expect(resource.url).toEqual(url);
-    expect(resource + "").toEqual(url);
+    expect(String(resource)).toEqual(url);
     expect(resource.queryParameters).toEqual({});
     expect(resource.templateValues).toEqual({});
     expect(resource.headers).toEqual({});

--- a/Specs/Core/ResourceSpec.js
+++ b/Specs/Core/ResourceSpec.js
@@ -59,6 +59,9 @@ describe("Core/Resource", function () {
     expect(resource.url).toEqual(
       proxy.getURL("http://test.com/tileset?key1=value1&key2=value2")
     );
+    expect(resource + "").toEqual(
+      proxy.getURL("http://test.com/tileset?key1=value1&key2=value2")
+    );
     expect(resource.queryParameters).toEqual({
       key1: "value1",
       key2: "value2",
@@ -81,6 +84,7 @@ describe("Core/Resource", function () {
     var url = "http://invalid.domain.com/tileset";
     var resource = new Resource(url);
     expect(resource.url).toEqual(url);
+    expect(resource + "").toEqual(url);
     expect(resource.queryParameters).toEqual({});
     expect(resource.templateValues).toEqual({});
     expect(resource.headers).toEqual({});


### PR DESCRIPTION
Does what it says on the tin.

I almost went through and changed all the docs to consistently use "URL" instead of "url" but I wanted to keep scope small until the maintainers say otherwise.  (I did use upper-case myself.)