### PR TITLE
Add additional smokescreen to build-ts

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -17,6 +17,7 @@
 !**/*.css
 !**/*.html
 !**/*.md
+!**/*.ts
 
 # Re-ignore a few things caught above
 **/*.min.js

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
 ##### Fixes :wrench:
 
 - Fixed a bug with handling of PixelFormat's flipY. [#8893](https://github.com/CesiumGS/cesium/pull/8893)
+- Fixed JSDoc and TypeScript type definitions for all `ImageryProvider` types, which were missing `defaultNightAlpha` and `defaultDayAlpha` properties.
+- Fixed JSDoc and TypeScript type definitions for `Viewer` options parameter, which was incorrectly listed as required.
 
 ### 1.70.0 - 2020-06-01
 

--- a/Source/Core/HeadingPitchRange.js
+++ b/Source/Core/HeadingPitchRange.js
@@ -17,6 +17,7 @@ function HeadingPitchRange(heading, pitch, range) {
   /**
    * Heading is the rotation from the local north direction where a positive angle is increasing eastward.
    * @type {Number}
+   * @default 0.0
    */
   this.heading = defaultValue(heading, 0.0);
 
@@ -24,12 +25,14 @@ function HeadingPitchRange(heading, pitch, range) {
    * Pitch is the rotation from the local xy-plane. Positive pitch angles
    * are above the plane. Negative pitch angles are below the plane.
    * @type {Number}
+   * @default 0.0
    */
   this.pitch = defaultValue(pitch, 0.0);
 
   /**
    * Range is the distance from the center of the local frame.
    * @type {Number}
+   * @default 0.0
    */
   this.range = defaultValue(range, 0.0);
 }

--- a/Source/Core/HeadingPitchRoll.js
+++ b/Source/Core/HeadingPitchRoll.js
@@ -15,8 +15,23 @@ import CesiumMath from "./Math.js";
  * @param {Number} [roll=0.0] The roll component in radians.
  */
 function HeadingPitchRoll(heading, pitch, roll) {
+  /**
+   * Gets or sets the heading.
+   * @type {Number}
+   * @default 0.0
+   */
   this.heading = defaultValue(heading, 0.0);
+  /**
+   * Gets or sets the pitch.
+   * @type {Number}
+   * @default 0.0
+   */
   this.pitch = defaultValue(pitch, 0.0);
+  /**
+   * Gets or sets the roll.
+   * @type {Number}
+   * @default 0.0
+   */
   this.roll = defaultValue(roll, 0.0);
 }
 

--- a/Source/DataSources/NodeTransformationProperty.js
+++ b/Source/DataSources/NodeTransformationProperty.js
@@ -13,9 +13,9 @@ var defaultNodeTransformation = new TranslationRotationScale();
  * @constructor
  *
  * @param {Object} [options] Object with the following properties:
- * @param {Property} [options.translation=Cartesian3.ZERO] A {@link Cartesian3} Property specifying the (x, y, z) translation to apply to the node.
- * @param {Property} [options.rotation=Quaternion.IDENTITY] A {@link Quaternion} Property specifying the (x, y, z, w) rotation to apply to the node.
- * @param {Property} [options.scale=new Cartesian3(1.0, 1.0, 1.0)] A {@link Cartesian3} Property specifying the (x, y, z) scaling to apply to the node.
+ * @param {Property|Cartesian3} [options.translation=Cartesian3.ZERO] A {@link Cartesian3} Property specifying the (x, y, z) translation to apply to the node.
+ * @param {Property|Quaternion} [options.rotation=Quaternion.IDENTITY] A {@link Quaternion} Property specifying the (x, y, z, w) rotation to apply to the node.
+ * @param {Property|Cartesian3} [options.scale=new Cartesian3(1.0, 1.0, 1.0)] A {@link Cartesian3} Property specifying the (x, y, z) scaling to apply to the node.
  */
 function NodeTransformationProperty(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/Source/DataSources/PositionPropertyArray.js
+++ b/Source/DataSources/PositionPropertyArray.js
@@ -7,7 +7,7 @@ import ReferenceFrame from "../Core/ReferenceFrame.js";
 import Property from "./Property.js";
 
 /**
- * A {@link PositionProperty} whose value is an array whose items are the computed value
+ * A {@link Property} whose value is an array whose items are the computed value
  * of other PositionProperty instances.
  *
  * @alias PositionPropertyArray

--- a/Source/DataSources/VelocityOrientationProperty.js
+++ b/Source/DataSources/VelocityOrientationProperty.js
@@ -16,7 +16,7 @@ import VelocityVectorProperty from "./VelocityVectorProperty.js";
  * @alias VelocityOrientationProperty
  * @constructor
  *
- * @param {Property} [position] The position property used to compute the orientation.
+ * @param {PositionProperty} [position] The position property used to compute the orientation.
  * @param {Ellipsoid} [ellipsoid=Ellipsoid.WGS84] The ellipsoid used to determine which way is up.
  *
  * @example

--- a/Source/DataSources/VelocityVectorProperty.js
+++ b/Source/DataSources/VelocityVectorProperty.js
@@ -13,7 +13,7 @@ import Property from "./Property.js";
  * @alias VelocityVectorProperty
  * @constructor
  *
- * @param {Property} [position] The position property used to compute the velocity.
+ * @param {PositionProperty} [position] The position property used to compute the velocity.
  * @param {Boolean} [normalize=true] Whether to normalize the computed velocity vector.
  *
  * @example

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -107,6 +107,24 @@ function ArcGisMapServerImageryProvider(options) {
   this.defaultAlpha = undefined;
 
   /**
+   * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultNightAlpha = undefined;
+
+  /**
+   * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultDayAlpha = undefined;
+
+  /**
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -101,7 +101,7 @@ function ArcGisMapServerImageryProvider(options) {
    * The default alpha blending value of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultAlpha = undefined;
@@ -110,7 +110,7 @@ function ArcGisMapServerImageryProvider(options) {
    * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultNightAlpha = undefined;
@@ -119,7 +119,7 @@ function ArcGisMapServerImageryProvider(options) {
    * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultDayAlpha = undefined;
@@ -128,7 +128,7 @@ function ArcGisMapServerImageryProvider(options) {
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultBrightness = undefined;
@@ -137,7 +137,7 @@ function ArcGisMapServerImageryProvider(options) {
    * The default contrast of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0 reduces
    * the contrast while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultContrast = undefined;
@@ -145,7 +145,7 @@ function ArcGisMapServerImageryProvider(options) {
   /**
    * The default hue of this provider in radians. 0.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultHue = undefined;
@@ -154,7 +154,7 @@ function ArcGisMapServerImageryProvider(options) {
    * The default saturation of this provider. 1.0 uses the unmodified imagery color. Less than 1.0 reduces the
    * saturation while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultSaturation = undefined;
@@ -162,7 +162,7 @@ function ArcGisMapServerImageryProvider(options) {
   /**
    * The default gamma correction to apply to this provider.  1.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultGamma = undefined;
@@ -542,7 +542,7 @@ Object.defineProperties(ArcGisMapServerImageryProvider.prototype, {
    * Gets the maximum level-of-detail that can be requested.  This function should
    * not be called before {@link ArcGisMapServerImageryProvider#ready} returns true.
    * @memberof ArcGisMapServerImageryProvider.prototype
-   * @type {Number}
+   * @type {Number|undefined}
    * @readonly
    */
   maximumLevel: {

--- a/Source/Scene/BingMapsImageryProvider.js
+++ b/Source/Scene/BingMapsImageryProvider.js
@@ -80,7 +80,7 @@ function BingMapsImageryProvider(options) {
    * The default alpha blending value of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultAlpha = undefined;
@@ -89,7 +89,7 @@ function BingMapsImageryProvider(options) {
    * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultNightAlpha = undefined;
@@ -98,7 +98,7 @@ function BingMapsImageryProvider(options) {
    * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultDayAlpha = undefined;
@@ -107,7 +107,7 @@ function BingMapsImageryProvider(options) {
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultBrightness = undefined;
@@ -116,7 +116,7 @@ function BingMapsImageryProvider(options) {
    * The default contrast of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0 reduces
    * the contrast while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultContrast = undefined;
@@ -124,7 +124,7 @@ function BingMapsImageryProvider(options) {
   /**
    * The default hue of this provider in radians. 0.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultHue = undefined;
@@ -133,7 +133,7 @@ function BingMapsImageryProvider(options) {
    * The default saturation of this provider. 1.0 uses the unmodified imagery color. Less than 1.0 reduces the
    * saturation while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultSaturation = undefined;
@@ -141,7 +141,7 @@ function BingMapsImageryProvider(options) {
   /**
    * The default gamma correction to apply to this provider.  1.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default 1.0
    */
   this.defaultGamma = 1.0;
@@ -422,7 +422,7 @@ Object.defineProperties(BingMapsImageryProvider.prototype, {
    * Gets the maximum level-of-detail that can be requested.  This function should
    * not be called before {@link BingMapsImageryProvider#ready} returns true.
    * @memberof BingMapsImageryProvider.prototype
-   * @type {Number}
+   * @type {Number|undefined}
    * @readonly
    */
   maximumLevel: {

--- a/Source/Scene/BingMapsImageryProvider.js
+++ b/Source/Scene/BingMapsImageryProvider.js
@@ -86,6 +86,24 @@ function BingMapsImageryProvider(options) {
   this.defaultAlpha = undefined;
 
   /**
+   * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultNightAlpha = undefined;
+
+  /**
+   * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultDayAlpha = undefined;
+
+  /**
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *

--- a/Source/Scene/GoogleEarthEnterpriseImageryProvider.js
+++ b/Source/Scene/GoogleEarthEnterpriseImageryProvider.js
@@ -106,6 +106,24 @@ function GoogleEarthEnterpriseImageryProvider(options) {
   this.defaultAlpha = undefined;
 
   /**
+   * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultNightAlpha = undefined;
+
+  /**
+   * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultDayAlpha = undefined;
+
+  /**
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *

--- a/Source/Scene/GoogleEarthEnterpriseImageryProvider.js
+++ b/Source/Scene/GoogleEarthEnterpriseImageryProvider.js
@@ -100,7 +100,7 @@ function GoogleEarthEnterpriseImageryProvider(options) {
    * The default alpha blending value of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultAlpha = undefined;
@@ -109,7 +109,7 @@ function GoogleEarthEnterpriseImageryProvider(options) {
    * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultNightAlpha = undefined;
@@ -118,7 +118,7 @@ function GoogleEarthEnterpriseImageryProvider(options) {
    * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultDayAlpha = undefined;
@@ -127,7 +127,7 @@ function GoogleEarthEnterpriseImageryProvider(options) {
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultBrightness = undefined;
@@ -136,7 +136,7 @@ function GoogleEarthEnterpriseImageryProvider(options) {
    * The default contrast of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0 reduces
    * the contrast while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultContrast = undefined;
@@ -144,7 +144,7 @@ function GoogleEarthEnterpriseImageryProvider(options) {
   /**
    * The default hue of this provider in radians. 0.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultHue = undefined;
@@ -153,7 +153,7 @@ function GoogleEarthEnterpriseImageryProvider(options) {
    * The default saturation of this provider. 1.0 uses the unmodified imagery color. Less than 1.0 reduces the
    * saturation while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultSaturation = undefined;
@@ -161,7 +161,7 @@ function GoogleEarthEnterpriseImageryProvider(options) {
   /**
    * The default gamma correction to apply to this provider.  1.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultGamma = undefined;
@@ -333,7 +333,7 @@ Object.defineProperties(GoogleEarthEnterpriseImageryProvider.prototype, {
    * Gets the maximum level-of-detail that can be requested.  This function should
    * not be called before {@link GoogleEarthEnterpriseImageryProvider#ready} returns true.
    * @memberof GoogleEarthEnterpriseImageryProvider.prototype
-   * @type {Number}
+   * @type {Number|undefined}
    * @readonly
    */
   maximumLevel: {

--- a/Source/Scene/GoogleEarthEnterpriseMapsProvider.js
+++ b/Source/Scene/GoogleEarthEnterpriseMapsProvider.js
@@ -105,7 +105,7 @@ function GoogleEarthEnterpriseMapsProvider(options) {
    * The default alpha blending value of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultAlpha = undefined;
@@ -132,7 +132,7 @@ function GoogleEarthEnterpriseMapsProvider(options) {
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultBrightness = undefined;
@@ -141,7 +141,7 @@ function GoogleEarthEnterpriseMapsProvider(options) {
    * The default contrast of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0 reduces
    * the contrast while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultContrast = undefined;
@@ -149,7 +149,7 @@ function GoogleEarthEnterpriseMapsProvider(options) {
   /**
    * The default hue of this provider in radians. 0.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultHue = undefined;
@@ -158,7 +158,7 @@ function GoogleEarthEnterpriseMapsProvider(options) {
    * The default saturation of this provider. 1.0 uses the unmodified imagery color. Less than 1.0 reduces the
    * saturation while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultSaturation = undefined;
@@ -166,7 +166,7 @@ function GoogleEarthEnterpriseMapsProvider(options) {
   /**
    * The default gamma correction to apply to this provider.  1.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default 1.9
    */
   this.defaultGamma = 1.9;
@@ -443,7 +443,7 @@ Object.defineProperties(GoogleEarthEnterpriseMapsProvider.prototype, {
    * Gets the maximum level-of-detail that can be requested.  This function should
    * not be called before {@link GoogleEarthEnterpriseMapsProvider#ready} returns true.
    * @memberof GoogleEarthEnterpriseMapsProvider.prototype
-   * @type {Number}
+   * @type {Number|undefined}
    * @readonly
    */
   maximumLevel: {

--- a/Source/Scene/GoogleEarthEnterpriseMapsProvider.js
+++ b/Source/Scene/GoogleEarthEnterpriseMapsProvider.js
@@ -111,6 +111,24 @@ function GoogleEarthEnterpriseMapsProvider(options) {
   this.defaultAlpha = undefined;
 
   /**
+   * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultNightAlpha = undefined;
+
+  /**
+   * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultDayAlpha = undefined;
+
+  /**
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *

--- a/Source/Scene/GoogleEarthEnterpriseMapsProvider.js
+++ b/Source/Scene/GoogleEarthEnterpriseMapsProvider.js
@@ -114,7 +114,7 @@ function GoogleEarthEnterpriseMapsProvider(options) {
    * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultNightAlpha = undefined;
@@ -123,7 +123,7 @@ function GoogleEarthEnterpriseMapsProvider(options) {
    * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultDayAlpha = undefined;

--- a/Source/Scene/GridImageryProvider.js
+++ b/Source/Scene/GridImageryProvider.js
@@ -44,7 +44,7 @@ function GridImageryProvider(options) {
    * The default alpha blending value of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultAlpha = undefined;
@@ -53,7 +53,7 @@ function GridImageryProvider(options) {
    * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultNightAlpha = undefined;
@@ -62,7 +62,7 @@ function GridImageryProvider(options) {
    * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultDayAlpha = undefined;
@@ -71,7 +71,7 @@ function GridImageryProvider(options) {
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultBrightness = undefined;
@@ -80,7 +80,7 @@ function GridImageryProvider(options) {
    * The default contrast of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0 reduces
    * the contrast while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultContrast = undefined;
@@ -88,7 +88,7 @@ function GridImageryProvider(options) {
   /**
    * The default hue of this provider in radians. 0.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultHue = undefined;
@@ -97,7 +97,7 @@ function GridImageryProvider(options) {
    * The default saturation of this provider. 1.0 uses the unmodified imagery color. Less than 1.0 reduces the
    * saturation while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultSaturation = undefined;
@@ -105,7 +105,7 @@ function GridImageryProvider(options) {
   /**
    * The default gamma correction to apply to this provider.  1.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultGamma = undefined;
@@ -195,7 +195,7 @@ Object.defineProperties(GridImageryProvider.prototype, {
    * Gets the maximum level-of-detail that can be requested.  This function should
    * not be called before {@link GridImageryProvider#ready} returns true.
    * @memberof GridImageryProvider.prototype
-   * @type {Number}
+   * @type {Number|undefined}
    * @readonly
    */
   maximumLevel: {

--- a/Source/Scene/GridImageryProvider.js
+++ b/Source/Scene/GridImageryProvider.js
@@ -50,6 +50,24 @@ function GridImageryProvider(options) {
   this.defaultAlpha = undefined;
 
   /**
+   * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultNightAlpha = undefined;
+
+  /**
+   * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultDayAlpha = undefined;
+
+  /**
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *

--- a/Source/Scene/ImageryProvider.js
+++ b/Source/Scene/ImageryProvider.js
@@ -36,7 +36,7 @@ function ImageryProvider() {
    * The default alpha blending value of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultAlpha = undefined;
@@ -45,7 +45,7 @@ function ImageryProvider() {
    * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultNightAlpha = undefined;
@@ -54,7 +54,7 @@ function ImageryProvider() {
    * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultDayAlpha = undefined;
@@ -63,7 +63,7 @@ function ImageryProvider() {
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultBrightness = undefined;
@@ -72,7 +72,7 @@ function ImageryProvider() {
    * The default contrast of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0 reduces
    * the contrast while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultContrast = undefined;
@@ -80,7 +80,7 @@ function ImageryProvider() {
   /**
    * The default hue of this provider in radians. 0.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultHue = undefined;
@@ -89,7 +89,7 @@ function ImageryProvider() {
    * The default saturation of this provider. 1.0 uses the unmodified imagery color. Less than 1.0 reduces the
    * saturation while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultSaturation = undefined;
@@ -97,7 +97,7 @@ function ImageryProvider() {
   /**
    * The default gamma correction to apply to this provider.  1.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultGamma = undefined;
@@ -179,7 +179,7 @@ Object.defineProperties(ImageryProvider.prototype, {
    * Gets the maximum level-of-detail that can be requested.  This function should
    * not be called before {@link ImageryProvider#ready} returns true.
    * @memberof ImageryProvider.prototype
-   * @type {Number}
+   * @type {Number|undefined}
    * @readonly
    */
   maximumLevel: {

--- a/Source/Scene/IonImageryProvider.js
+++ b/Source/Scene/IonImageryProvider.js
@@ -69,7 +69,7 @@ function IonImageryProvider(options) {
    * The default alpha blending value of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultAlpha = undefined;
@@ -78,7 +78,7 @@ function IonImageryProvider(options) {
    * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultNightAlpha = undefined;
@@ -87,7 +87,7 @@ function IonImageryProvider(options) {
    * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultDayAlpha = undefined;
@@ -96,7 +96,7 @@ function IonImageryProvider(options) {
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultBrightness = undefined;
@@ -105,7 +105,7 @@ function IonImageryProvider(options) {
    * The default contrast of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0 reduces
    * the contrast while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultContrast = undefined;
@@ -113,7 +113,7 @@ function IonImageryProvider(options) {
   /**
    * The default hue of this provider in radians. 0.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultHue = undefined;
@@ -122,7 +122,7 @@ function IonImageryProvider(options) {
    * The default saturation of this provider. 1.0 uses the unmodified imagery color. Less than 1.0 reduces the
    * saturation while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultSaturation = undefined;
@@ -130,7 +130,7 @@ function IonImageryProvider(options) {
   /**
    * The default gamma correction to apply to this provider.  1.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultGamma = undefined;
@@ -307,7 +307,7 @@ Object.defineProperties(IonImageryProvider.prototype, {
    * Gets the maximum level-of-detail that can be requested.  This function should
    * not be called before {@link IonImageryProvider#ready} returns true.
    * @memberof IonImageryProvider.prototype
-   * @type {Number}
+   * @type {Number|undefined}
    * @readonly
    */
   maximumLevel: {

--- a/Source/Scene/IonImageryProvider.js
+++ b/Source/Scene/IonImageryProvider.js
@@ -75,6 +75,24 @@ function IonImageryProvider(options) {
   this.defaultAlpha = undefined;
 
   /**
+   * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultNightAlpha = undefined;
+
+  /**
+   * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultDayAlpha = undefined;
+
+  /**
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *

--- a/Source/Scene/MapboxImageryProvider.js
+++ b/Source/Scene/MapboxImageryProvider.js
@@ -60,7 +60,7 @@ function MapboxImageryProvider(options) {
    * The default alpha blending value of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultAlpha = undefined;
@@ -69,7 +69,7 @@ function MapboxImageryProvider(options) {
    * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultNightAlpha = undefined;
@@ -78,7 +78,7 @@ function MapboxImageryProvider(options) {
    * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultDayAlpha = undefined;
@@ -87,7 +87,7 @@ function MapboxImageryProvider(options) {
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultBrightness = undefined;
@@ -96,7 +96,7 @@ function MapboxImageryProvider(options) {
    * The default contrast of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0 reduces
    * the contrast while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultContrast = undefined;
@@ -104,7 +104,7 @@ function MapboxImageryProvider(options) {
   /**
    * The default hue of this provider in radians. 0.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultHue = undefined;
@@ -113,7 +113,7 @@ function MapboxImageryProvider(options) {
    * The default saturation of this provider. 1.0 uses the unmodified imagery color. Less than 1.0 reduces the
    * saturation while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultSaturation = undefined;
@@ -121,7 +121,7 @@ function MapboxImageryProvider(options) {
   /**
    * The default gamma correction to apply to this provider.  1.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultGamma = undefined;
@@ -271,7 +271,7 @@ Object.defineProperties(MapboxImageryProvider.prototype, {
    * Gets the maximum level-of-detail that can be requested.  This function should
    * not be called before {@link MapboxImageryProvider#ready} returns true.
    * @memberof MapboxImageryProvider.prototype
-   * @type {Number}
+   * @type {Number|undefined}
    * @readonly
    */
   maximumLevel: {

--- a/Source/Scene/MapboxImageryProvider.js
+++ b/Source/Scene/MapboxImageryProvider.js
@@ -66,6 +66,24 @@ function MapboxImageryProvider(options) {
   this.defaultAlpha = undefined;
 
   /**
+   * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultNightAlpha = undefined;
+
+  /**
+   * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultDayAlpha = undefined;
+
+  /**
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *

--- a/Source/Scene/MapboxStyleImageryProvider.js
+++ b/Source/Scene/MapboxStyleImageryProvider.js
@@ -68,6 +68,24 @@ function MapboxStyleImageryProvider(options) {
   this.defaultAlpha = undefined;
 
   /**
+   * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultNightAlpha = undefined;
+
+  /**
+   * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultDayAlpha = undefined;
+
+  /**
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *

--- a/Source/Scene/MapboxStyleImageryProvider.js
+++ b/Source/Scene/MapboxStyleImageryProvider.js
@@ -62,7 +62,7 @@ function MapboxStyleImageryProvider(options) {
    * The default alpha blending value of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultAlpha = undefined;
@@ -71,7 +71,7 @@ function MapboxStyleImageryProvider(options) {
    * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultNightAlpha = undefined;
@@ -80,7 +80,7 @@ function MapboxStyleImageryProvider(options) {
    * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultDayAlpha = undefined;
@@ -89,7 +89,7 @@ function MapboxStyleImageryProvider(options) {
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultBrightness = undefined;
@@ -98,7 +98,7 @@ function MapboxStyleImageryProvider(options) {
    * The default contrast of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0 reduces
    * the contrast while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultContrast = undefined;
@@ -106,7 +106,7 @@ function MapboxStyleImageryProvider(options) {
   /**
    * The default hue of this provider in radians. 0.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultHue = undefined;
@@ -115,7 +115,7 @@ function MapboxStyleImageryProvider(options) {
    * The default saturation of this provider. 1.0 uses the unmodified imagery color. Less than 1.0 reduces the
    * saturation while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultSaturation = undefined;
@@ -123,7 +123,7 @@ function MapboxStyleImageryProvider(options) {
   /**
    * The default gamma correction to apply to this provider.  1.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultGamma = undefined;
@@ -283,7 +283,7 @@ Object.defineProperties(MapboxStyleImageryProvider.prototype, {
    * Gets the maximum level-of-detail that can be requested.  This function should
    * not be called before {@link MapboxStyleImageryProvider#ready} returns true.
    * @memberof MapboxStyleImageryProvider.prototype
-   * @type {Number}
+   * @type {Number|undefined}
    * @readonly
    */
   maximumLevel: {

--- a/Source/Scene/SingleTileImageryProvider.js
+++ b/Source/Scene/SingleTileImageryProvider.js
@@ -52,7 +52,7 @@ function SingleTileImageryProvider(options) {
    * The default alpha blending value of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultAlpha = undefined;
@@ -61,7 +61,7 @@ function SingleTileImageryProvider(options) {
    * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultNightAlpha = undefined;
@@ -70,7 +70,7 @@ function SingleTileImageryProvider(options) {
    * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultDayAlpha = undefined;
@@ -79,7 +79,7 @@ function SingleTileImageryProvider(options) {
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultBrightness = undefined;
@@ -88,7 +88,7 @@ function SingleTileImageryProvider(options) {
    * The default contrast of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0 reduces
    * the contrast while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultContrast = undefined;
@@ -96,7 +96,7 @@ function SingleTileImageryProvider(options) {
   /**
    * The default hue of this provider in radians. 0.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultHue = undefined;
@@ -105,7 +105,7 @@ function SingleTileImageryProvider(options) {
    * The default saturation of this provider. 1.0 uses the unmodified imagery color. Less than 1.0 reduces the
    * saturation while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultSaturation = undefined;
@@ -113,7 +113,7 @@ function SingleTileImageryProvider(options) {
   /**
    * The default gamma correction to apply to this provider.  1.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultGamma = undefined;
@@ -267,7 +267,7 @@ Object.defineProperties(SingleTileImageryProvider.prototype, {
    * Gets the maximum level-of-detail that can be requested.  This function should
    * not be called before {@link SingleTileImageryProvider#ready} returns true.
    * @memberof SingleTileImageryProvider.prototype
-   * @type {Number}
+   * @type {Number|undefined}
    * @readonly
    */
   maximumLevel: {

--- a/Source/Scene/SingleTileImageryProvider.js
+++ b/Source/Scene/SingleTileImageryProvider.js
@@ -58,6 +58,24 @@ function SingleTileImageryProvider(options) {
   this.defaultAlpha = undefined;
 
   /**
+   * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultNightAlpha = undefined;
+
+  /**
+   * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultDayAlpha = undefined;
+
+  /**
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *

--- a/Source/Scene/TileCoordinatesImageryProvider.js
+++ b/Source/Scene/TileCoordinatesImageryProvider.js
@@ -27,7 +27,7 @@ import when from "../ThirdParty/when.js";
  * @alias TileCoordinatesImageryProvider
  * @constructor
  *
- * @param {TileCoordinatesImageryProvider.ConstructorOptions} options Object describing initialization options
+ * @param {TileCoordinatesImageryProvider.ConstructorOptions} [options] Object describing initialization options
  */
 function TileCoordinatesImageryProvider(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -49,6 +49,24 @@ function TileCoordinatesImageryProvider(options) {
    * @default undefined
    */
   this.defaultAlpha = undefined;
+
+  /**
+   * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultNightAlpha = undefined;
+
+  /**
+   * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultDayAlpha = undefined;
 
   /**
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0

--- a/Source/Scene/TileCoordinatesImageryProvider.js
+++ b/Source/Scene/TileCoordinatesImageryProvider.js
@@ -45,7 +45,7 @@ function TileCoordinatesImageryProvider(options) {
    * The default alpha blending value of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultAlpha = undefined;
@@ -54,7 +54,7 @@ function TileCoordinatesImageryProvider(options) {
    * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultNightAlpha = undefined;
@@ -63,7 +63,7 @@ function TileCoordinatesImageryProvider(options) {
    * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultDayAlpha = undefined;
@@ -72,7 +72,7 @@ function TileCoordinatesImageryProvider(options) {
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultBrightness = undefined;
@@ -81,7 +81,7 @@ function TileCoordinatesImageryProvider(options) {
    * The default contrast of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0 reduces
    * the contrast while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultContrast = undefined;
@@ -89,7 +89,7 @@ function TileCoordinatesImageryProvider(options) {
   /**
    * The default hue of this provider in radians. 0.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultHue = undefined;
@@ -98,7 +98,7 @@ function TileCoordinatesImageryProvider(options) {
    * The default saturation of this provider. 1.0 uses the unmodified imagery color. Less than 1.0 reduces the
    * saturation while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultSaturation = undefined;
@@ -106,7 +106,7 @@ function TileCoordinatesImageryProvider(options) {
   /**
    * The default gamma correction to apply to this provider.  1.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultGamma = undefined;
@@ -171,7 +171,7 @@ Object.defineProperties(TileCoordinatesImageryProvider.prototype, {
    * Gets the maximum level-of-detail that can be requested.  This function should
    * not be called before {@link TileCoordinatesImageryProvider#ready} returns true.
    * @memberof TileCoordinatesImageryProvider.prototype
-   * @type {Number}
+   * @type {Number|undefined}
    * @readonly
    */
   maximumLevel: {

--- a/Source/Scene/UrlTemplateImageryProvider.js
+++ b/Source/Scene/UrlTemplateImageryProvider.js
@@ -220,7 +220,7 @@ function UrlTemplateImageryProvider(options) {
    * The default alpha blending value of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultAlpha = undefined;
@@ -229,7 +229,7 @@ function UrlTemplateImageryProvider(options) {
    * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultNightAlpha = undefined;
@@ -238,7 +238,7 @@ function UrlTemplateImageryProvider(options) {
    * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultDayAlpha = undefined;
@@ -247,7 +247,7 @@ function UrlTemplateImageryProvider(options) {
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultBrightness = undefined;
@@ -256,7 +256,7 @@ function UrlTemplateImageryProvider(options) {
    * The default contrast of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0 reduces
    * the contrast while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultContrast = undefined;
@@ -264,7 +264,7 @@ function UrlTemplateImageryProvider(options) {
   /**
    * The default hue of this provider in radians. 0.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultHue = undefined;
@@ -273,7 +273,7 @@ function UrlTemplateImageryProvider(options) {
    * The default saturation of this provider. 1.0 uses the unmodified imagery color. Less than 1.0 reduces the
    * saturation while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultSaturation = undefined;
@@ -281,7 +281,7 @@ function UrlTemplateImageryProvider(options) {
   /**
    * The default gamma correction to apply to this provider.  1.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultGamma = undefined;
@@ -457,7 +457,7 @@ Object.defineProperties(UrlTemplateImageryProvider.prototype, {
    * Gets the maximum level-of-detail that can be requested, or undefined if there is no limit.
    * This function should not be called before {@link UrlTemplateImageryProvider#ready} returns true.
    * @memberof UrlTemplateImageryProvider.prototype
-   * @type {Number}
+   * @type {Number|undefined}
    * @readonly
    * @default undefined
    */

--- a/Source/Scene/UrlTemplateImageryProvider.js
+++ b/Source/Scene/UrlTemplateImageryProvider.js
@@ -226,6 +226,24 @@ function UrlTemplateImageryProvider(options) {
   this.defaultAlpha = undefined;
 
   /**
+   * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultNightAlpha = undefined;
+
+  /**
+   * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultDayAlpha = undefined;
+
+  /**
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *

--- a/Source/Scene/WebMapServiceImageryProvider.js
+++ b/Source/Scene/WebMapServiceImageryProvider.js
@@ -98,7 +98,7 @@ function WebMapServiceImageryProvider(options) {
    * The default alpha blending value of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultAlpha = undefined;
@@ -107,7 +107,7 @@ function WebMapServiceImageryProvider(options) {
    * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultNightAlpha = undefined;
@@ -116,7 +116,7 @@ function WebMapServiceImageryProvider(options) {
    * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultDayAlpha = undefined;
@@ -125,7 +125,7 @@ function WebMapServiceImageryProvider(options) {
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultBrightness = undefined;
@@ -134,7 +134,7 @@ function WebMapServiceImageryProvider(options) {
    * The default contrast of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0 reduces
    * the contrast while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultContrast = undefined;
@@ -142,7 +142,7 @@ function WebMapServiceImageryProvider(options) {
   /**
    * The default hue of this provider in radians. 0.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultHue = undefined;
@@ -151,7 +151,7 @@ function WebMapServiceImageryProvider(options) {
    * The default saturation of this provider. 1.0 uses the unmodified imagery color. Less than 1.0 reduces the
    * saturation while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultSaturation = undefined;
@@ -159,7 +159,7 @@ function WebMapServiceImageryProvider(options) {
   /**
    * The default gamma correction to apply to this provider.  1.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultGamma = undefined;
@@ -386,7 +386,7 @@ Object.defineProperties(WebMapServiceImageryProvider.prototype, {
    * Gets the maximum level-of-detail that can be requested.  This function should
    * not be called before {@link WebMapServiceImageryProvider#ready} returns true.
    * @memberof WebMapServiceImageryProvider.prototype
-   * @type {Number}
+   * @type {Number|undefined}
    * @readonly
    */
   maximumLevel: {

--- a/Source/Scene/WebMapServiceImageryProvider.js
+++ b/Source/Scene/WebMapServiceImageryProvider.js
@@ -104,6 +104,24 @@ function WebMapServiceImageryProvider(options) {
   this.defaultAlpha = undefined;
 
   /**
+   * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultNightAlpha = undefined;
+
+  /**
+   * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultDayAlpha = undefined;
+
+  /**
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *

--- a/Source/Scene/WebMapTileServiceImageryProvider.js
+++ b/Source/Scene/WebMapTileServiceImageryProvider.js
@@ -141,7 +141,7 @@ function WebMapTileServiceImageryProvider(options) {
    * The default alpha blending value of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultAlpha = undefined;
@@ -150,7 +150,7 @@ function WebMapTileServiceImageryProvider(options) {
    * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultNightAlpha = undefined;
@@ -159,7 +159,7 @@ function WebMapTileServiceImageryProvider(options) {
    * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
    * 1.0 representing fully opaque.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultDayAlpha = undefined;
@@ -168,7 +168,7 @@ function WebMapTileServiceImageryProvider(options) {
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultBrightness = undefined;
@@ -177,7 +177,7 @@ function WebMapTileServiceImageryProvider(options) {
    * The default contrast of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0 reduces
    * the contrast while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultContrast = undefined;
@@ -185,7 +185,7 @@ function WebMapTileServiceImageryProvider(options) {
   /**
    * The default hue of this provider in radians. 0.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultHue = undefined;
@@ -194,7 +194,7 @@ function WebMapTileServiceImageryProvider(options) {
    * The default saturation of this provider. 1.0 uses the unmodified imagery color. Less than 1.0 reduces the
    * saturation while greater than 1.0 increases it.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultSaturation = undefined;
@@ -202,7 +202,7 @@ function WebMapTileServiceImageryProvider(options) {
   /**
    * The default gamma correction to apply to this provider.  1.0 uses the unmodified imagery color.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @default undefined
    */
   this.defaultGamma = undefined;
@@ -432,7 +432,7 @@ Object.defineProperties(WebMapTileServiceImageryProvider.prototype, {
    * Gets the maximum level-of-detail that can be requested.  This function should
    * not be called before {@link WebMapTileServiceImageryProvider#ready} returns true.
    * @memberof WebMapTileServiceImageryProvider.prototype
-   * @type {Number}
+   * @type {Number|undefined}
    * @readonly
    */
   maximumLevel: {

--- a/Source/Scene/WebMapTileServiceImageryProvider.js
+++ b/Source/Scene/WebMapTileServiceImageryProvider.js
@@ -147,6 +147,24 @@ function WebMapTileServiceImageryProvider(options) {
   this.defaultAlpha = undefined;
 
   /**
+   * The default alpha blending value on the night side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultNightAlpha = undefined;
+
+  /**
+   * The default alpha blending value on the day side of the globe of this provider, with 0.0 representing fully transparent and
+   * 1.0 representing fully opaque.
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  this.defaultDayAlpha = undefined;
+
+  /**
    * The default brightness of this provider.  1.0 uses the unmodified imagery color.  Less than 1.0
    * makes the imagery darker while greater than 1.0 makes it brighter.
    *

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -269,7 +269,7 @@ function enableVRUI(viewer, enabled) {
  * @constructor
  *
  * @param {Element|String} container The DOM element or ID that will contain the widget.
- * @param {Viewer.ConstructorOptions} options Object describing initialization options
+ * @param {Viewer.ConstructorOptions} [options] Object describing initialization options
  *
  * @exception {DeveloperError} Element with id "container" does not exist in the document.
  * @exception {DeveloperError} options.selectedImageryProviderViewModel is not available when not using the BaseLayerPicker widget, specify options.imageryProvider instead.

--- a/Specs/TypeScript/index.ts
+++ b/Specs/TypeScript/index.ts
@@ -1,0 +1,142 @@
+import {
+  ArcGisMapServerImageryProvider,
+  BingMapsImageryProvider,
+  ImageryProvider,
+  WebMapServiceImageryProvider,
+  OpenStreetMapImageryProvider,
+  TileMapServiceImageryProvider,
+  GoogleEarthEnterpriseImageryProvider,
+  GoogleEarthEnterpriseMapsProvider,
+  GridImageryProvider,
+  IonImageryProvider,
+  MapboxImageryProvider,
+  MapboxStyleImageryProvider,
+  SingleTileImageryProvider,
+  TileCoordinatesImageryProvider,
+  UrlTemplateImageryProvider,
+  WebMapTileServiceImageryProvider,
+  GoogleEarthEnterpriseMetadata,
+  TerrainProvider,
+  ArcGISTiledElevationTerrainProvider,
+  CesiumTerrainProvider,
+  EllipsoidTerrainProvider,
+  GoogleEarthEnterpriseTerrainProvider,
+  VRTheWorldTerrainProvider,
+  DataSource,
+  CzmlDataSource,
+  GeoJsonDataSource,
+  KmlDataSource,
+  CustomDataSource,
+  Camera,
+  Scene,
+  Property,
+  ConstantProperty,
+  SampledProperty,
+  PositionProperty,
+  SampledPositionProperty,
+  TimeIntervalCollectionProperty,
+  CompositeProperty,
+  CompositePositionProperty,
+  Cartesian3,
+  ReferenceProperty,
+  MaterialProperty,
+  EntityCollection,
+  CallbackProperty,
+  ConstantPositionProperty,
+  TimeIntervalCollectionPositionProperty,
+  ColorMaterialProperty,
+  CompositeMaterialProperty,
+  GridMaterialProperty,
+  ImageMaterialProperty,
+  PolylineGlowMaterialProperty,
+  PolylineOutlineMaterialProperty,
+  StripeMaterialProperty,
+} from "cesium";
+
+// Verify ImageryProvider instances conform to the expected interface
+let imageryProvider: ImageryProvider;
+imageryProvider = new WebMapServiceImageryProvider({ url: "", layers: "0" });
+imageryProvider = new BingMapsImageryProvider({ url: "" });
+imageryProvider = new ArcGisMapServerImageryProvider({ url: "" });
+imageryProvider = new BingMapsImageryProvider({ url: "" });
+imageryProvider = new OpenStreetMapImageryProvider({ url: "" });
+imageryProvider = new TileMapServiceImageryProvider({ url: "" });
+imageryProvider = new GridImageryProvider({ url: "" });
+imageryProvider = new IonImageryProvider({ assetId: 2 });
+imageryProvider = new MapboxImageryProvider({ mapId: "" });
+imageryProvider = new MapboxStyleImageryProvider({ styleId: "" });
+imageryProvider = new SingleTileImageryProvider({ url: "" });
+imageryProvider = new TileCoordinatesImageryProvider();
+imageryProvider = new UrlTemplateImageryProvider({ url: "" });
+imageryProvider = new WebMapServiceImageryProvider({ url: "", layers: "" });
+imageryProvider = new GoogleEarthEnterpriseImageryProvider({
+  url: "",
+  metadata: new GoogleEarthEnterpriseMetadata(""),
+});
+imageryProvider = new GoogleEarthEnterpriseMapsProvider({
+  url: "",
+  channel: 1,
+});
+imageryProvider = new WebMapTileServiceImageryProvider({
+  url: "",
+  layer: "",
+  style: "",
+  tileMatrixSetID: "",
+});
+
+// Verify TerrainProvider instances conform to the expected interface
+let terrainProvider: TerrainProvider;
+terrainProvider = new ArcGISTiledElevationTerrainProvider({ url: "" });
+terrainProvider = new CesiumTerrainProvider({ url: "" });
+terrainProvider = new EllipsoidTerrainProvider();
+terrainProvider = new VRTheWorldTerrainProvider({ url: "" });
+terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
+  url: "",
+  metadata: new GoogleEarthEnterpriseMetadata(""),
+});
+
+// Verify DataSource instances conform to the expected interface
+let dataSource: DataSource;
+dataSource = new CzmlDataSource();
+dataSource = new GeoJsonDataSource();
+dataSource = new KmlDataSource({
+  canvas: document.createElement("canvas"),
+  camera: new Camera(new Scene()),
+});
+dataSource = new CustomDataSource();
+
+// Verify Property instances conform to the expected interface
+let property: Property;
+property = new CallbackProperty(() => 0, false);
+property = new ConstantProperty(1);
+property = new TimeIntervalCollectionProperty();
+property = new CompositeProperty();
+property = new SampledProperty(Cartesian3);
+property = new PositionProperty();
+property = new MaterialProperty();
+property = new ReferenceProperty(new EntityCollection(), "object1", [
+  "billboard",
+  "scale",
+]);
+
+// Verify PositionProperty instances conform to the expected PositionProperty and Property interfaces
+let positionProperty: PositionProperty;
+property = positionProperty = new SampledPositionProperty();
+property = positionProperty = new CompositePositionProperty();
+property = positionProperty = new ConstantPositionProperty();
+property = positionProperty = new TimeIntervalCollectionPositionProperty();
+property = positionProperty = new ReferenceProperty(
+  new EntityCollection(),
+  "object1",
+  ["billboard", "scale"]
+);
+
+// Verify MaterialProperty instances conform to the expected MaterialProperty and Property interfaces
+let materialProperty: MaterialProperty;
+property = materialProperty = new ColorMaterialProperty();
+property = materialProperty = new CompositeMaterialProperty();
+property = materialProperty = new GridMaterialProperty();
+property = materialProperty = new ImageMaterialProperty();
+property = materialProperty = new PolylineGlowMaterialProperty();
+property = materialProperty = new PolylineOutlineMaterialProperty();
+property = materialProperty = new StripeMaterialProperty();

--- a/Specs/TypeScript/index.ts
+++ b/Specs/TypeScript/index.ts
@@ -30,6 +30,7 @@ import {
   Camera,
   Scene,
   Property,
+  PropertyBag,
   ConstantProperty,
   SampledProperty,
   PositionProperty,
@@ -51,6 +52,14 @@ import {
   PolylineGlowMaterialProperty,
   PolylineOutlineMaterialProperty,
   StripeMaterialProperty,
+  CheckerboardMaterialProperty,
+  PolylineDashMaterialProperty,
+  VelocityVectorProperty,
+  VelocityOrientationProperty,
+  PropertyArray,
+  PositionPropertyArray,
+  PolylineArrowMaterialProperty,
+  NodeTransformationProperty,
 } from "cesium";
 
 // Verify ImageryProvider instances conform to the expected interface
@@ -112,8 +121,14 @@ property = new ConstantProperty(1);
 property = new TimeIntervalCollectionProperty();
 property = new CompositeProperty();
 property = new SampledProperty(Cartesian3);
+property = new PropertyBag();
+property = new PropertyArray();
 property = new PositionProperty();
 property = new MaterialProperty();
+property = new VelocityVectorProperty();
+property = new VelocityOrientationProperty();
+property = new PositionPropertyArray();
+property = new NodeTransformationProperty();
 property = new ReferenceProperty(new EntityCollection(), "object1", [
   "billboard",
   "scale",
@@ -140,3 +155,6 @@ property = materialProperty = new ImageMaterialProperty();
 property = materialProperty = new PolylineGlowMaterialProperty();
 property = materialProperty = new PolylineOutlineMaterialProperty();
 property = materialProperty = new StripeMaterialProperty();
+property = materialProperty = new CheckerboardMaterialProperty();
+property = materialProperty = new PolylineDashMaterialProperty();
+property = materialProperty = new PolylineArrowMaterialProperty();

--- a/Specs/TypeScript/tsconfig.json
+++ b/Specs/TypeScript/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "types": [],
+    "strict": true
+  },
+  "include": [
+    "../.."
+  ],
+}

--- a/gulpfile.cjs
+++ b/gulpfile.cjs
@@ -1594,6 +1594,11 @@ ${source}
     stdio: "inherit",
   });
 
+  // Also compile our smokescreen to make sure interfaces work as expected.
+  child_process.execSync("npx tsc -p Specs/TypeScript/tsconfig.json", {
+    stdio: "inherit",
+  });
+
   // Below is a sanity check to make sure we didn't leave anything out that
   // we don't already know about
 


### PR DESCRIPTION
1. Add a Specs/TypeScript directory with a minimal TS configuration that uses the d.ts files generated by build-ts

2. Have `build-ts` compile index.ts from this directory which makes sure various types actually conform to their expected interfaces.

3. Fix ImageryProvider interfaces which had issues exposed by this new test.

In the future we can add any additional smokescreens that we think are important to validate our definitions going forward, but this will never be a fully exhaustive check.

We currently don't actually execute the output, it's just there for compile-time checking.  We can revisit this if we ever feel that it's needed.

Thanks for the assist here, @thw0rted!