### PR TITLE
WIP: support background outline color and width for labels

### DIFF
--- a/Source/DataSources/CzmlDataSource.js
+++ b/Source/DataSources/CzmlDataSource.js
@@ -3067,6 +3067,15 @@ function processLabel(entity, packet, entityCollection, sourceUri) {
     entityCollection
   );
   processPacketData(
+    Color,
+    label,
+    "backgroundOutlineColor",
+    labelData.backgroundOutlineColor,
+    interval,
+    sourceUri,
+    entityCollection
+  );
+  processPacketData(
     Cartesian2,
     label,
     "backgroundPadding",

--- a/Source/DataSources/LabelGraphics.js
+++ b/Source/DataSources/LabelGraphics.js
@@ -16,6 +16,7 @@ import createPropertyDescriptor from "./createPropertyDescriptor.js";
  * @property {Property | number} [scale=1.0] A numeric Property specifying the scale to apply to the text.
  * @property {Property | boolean} [showBackground=false] A boolean Property specifying the visibility of the background behind the label.
  * @property {Property | Color} [backgroundColor=new Color(0.165, 0.165, 0.165, 0.8)] A Property specifying the background {@link Color}.
+ * @property {Property | Color} [backgroundOutlineColor=new Color(0.165, 0.165, 0.165, 0.8)] A Property specifying the background outline {@link Color}.
  * @property {Property | Cartesian2} [backgroundPadding=new Cartesian2(7, 5)] A {@link Cartesian2} Property specifying the horizontal and vertical background padding in pixels.
  * @property {Property | Cartesian2} [pixelOffset=Cartesian2.ZERO] A {@link Cartesian2} Property specifying the pixel offset.
  * @property {Property | Cartesian3} [eyeOffset=Cartesian3.ZERO] A {@link Cartesian3} Property specifying the eye offset.
@@ -64,6 +65,8 @@ function LabelGraphics(options) {
   this._showBackgroundSubscription = undefined;
   this._backgroundColor = undefined;
   this._backgroundColorSubscription = undefined;
+  this._backgroundOutlineColor = undefined;
+  this._backgroundOutlineColorSubscription = undefined;
   this._backgroundPadding = undefined;
   this._backgroundPaddingSubscription = undefined;
   this._pixelOffset = undefined;
@@ -171,6 +174,14 @@ Object.defineProperties(LabelGraphics.prototype, {
    * @default new Color(0.165, 0.165, 0.165, 0.8)
    */
   backgroundColor: createPropertyDescriptor("backgroundColor"),
+
+  /**
+   * Gets or sets the Property specifying the background {@link Color}.
+   * @memberof LabelGraphics.prototype
+   * @type {Property|undefined}
+   * @default new Color(0.165, 0.165, 0.165, 0.8)
+   */
+  backgroundOutlineColor: createPropertyDescriptor("backgroundOutlineColor"),
 
   /**
    * Gets or sets the {@link Cartesian2} Property specifying the label's horizontal and vertical
@@ -342,6 +353,7 @@ LabelGraphics.prototype.clone = function (result) {
   result.scale = this.scale;
   result.showBackground = this.showBackground;
   result.backgroundColor = this.backgroundColor;
+  result.backgroundOutlineColor = this.backgroundOutlineColor;
   result.backgroundPadding = this.backgroundPadding;
   result.pixelOffset = this.pixelOffset;
   result.eyeOffset = this.eyeOffset;
@@ -384,6 +396,10 @@ LabelGraphics.prototype.merge = function (source) {
   this.backgroundColor = defaultValue(
     this.backgroundColor,
     source.backgroundColor
+  );
+  this.backgroundOutlineColor = defaultValue(
+    this.backgroundOutlineColor,
+    source.backgroundOutlineColor
   );
   this.backgroundPadding = defaultValue(
     this.backgroundPadding,

--- a/Source/DataSources/LabelVisualizer.js
+++ b/Source/DataSources/LabelVisualizer.js
@@ -24,6 +24,7 @@ var defaultOutlineWidth = 1.0;
 var defaultShowBackground = false;
 var defaultBackgroundColor = new Color(0.165, 0.165, 0.165, 0.8);
 var defaultBackgroundPadding = new Cartesian2(7, 5);
+var defaultOutlineBackgroundColor = new Color(0.165, 0.165, 0.165, 0.8);
 var defaultPixelOffset = Cartesian2.ZERO;
 var defaultEyeOffset = Cartesian3.ZERO;
 var defaultHeightReference = HeightReference.NONE;
@@ -34,6 +35,7 @@ var positionScratch = new Cartesian3();
 var fillColorScratch = new Color();
 var outlineColorScratch = new Color();
 var backgroundColorScratch = new Color();
+var backgroundOutlineColorScratch = new Color();
 var backgroundPaddingScratch = new Cartesian2();
 var eyeOffsetScratch = new Cartesian3();
 var pixelOffsetScratch = new Cartesian2();
@@ -193,6 +195,12 @@ LabelVisualizer.prototype.update = function (time) {
       time,
       defaultBackgroundColor,
       backgroundColorScratch
+    );
+    label.backgroundOutlineColor = Property.getValueOrDefault(
+      labelGraphics._backgroundOutlineColor,
+      time,
+      defaultOutlineBackgroundColor,
+      backgroundOutlineColorScratch
     );
     label.backgroundPadding = Property.getValueOrDefault(
       labelGraphics._backgroundPadding,

--- a/Source/Scene/Label.js
+++ b/Source/Scene/Label.js
@@ -169,6 +169,10 @@ function Label(options, labelCollection) {
     options.backgroundColor,
     new Color(0.165, 0.165, 0.165, 0.8)
   );
+  this._backgroundOutlineColor = defaultValue(
+    options.backgroundOutlineColor,
+    new Color(0.165, 0.165, 0.165, 0.8)
+  );
   this._backgroundPadding = defaultValue(
     options.backgroundPadding,
     new Cartesian2(7, 5)
@@ -516,6 +520,35 @@ Object.defineProperties(Label.prototype, {
         var backgroundBillboard = this._backgroundBillboard;
         if (defined(backgroundBillboard)) {
           backgroundBillboard.color = backgroundColor;
+        }
+      }
+    },
+  },
+
+  /**
+   * Gets or sets the background outline color of this label.
+   * @memberof Label.prototype
+   * @type {Color}
+   * @default new Color(0.165, 0.165, 0.165, 0.8)
+   */
+  backgroundOutlineColor: {
+    get: function () {
+      return this._backgroundOutlineColor;
+    },
+    set: function (value) {
+      //>>includeStart('debug', pragmas.debug);
+      if (!defined(value)) {
+        throw new DeveloperError("value is required.");
+      }
+      //>>includeEnd('debug');
+
+      var backgroundOutlineColor = this._backgroundOutlineColor;
+      if (!Color.equals(backgroundOutlineColor, value)) {
+        Color.clone(value, backgroundOutlineColor);
+
+        var backgroundBillboard = this._backgroundBillboard;
+        if (defined(backgroundBillboard)) {
+          backgroundBillboard.color = backgroundOutlineColor;
         }
       }
     },
@@ -1326,6 +1359,10 @@ Label.prototype.equals = function (other) {
       Color.equals(this._fillColor, other._fillColor) &&
       Color.equals(this._outlineColor, other._outlineColor) &&
       Color.equals(this._backgroundColor, other._backgroundColor) &&
+      Color.equals(
+        this._backgroundOutlineColor,
+        other._backgroundOutlineColor
+      ) &&
       Cartesian2.equals(this._backgroundPadding, other._backgroundPadding) &&
       Cartesian2.equals(this._pixelOffset, other._pixelOffset) &&
       Cartesian3.equals(this._eyeOffset, other._eyeOffset) &&

--- a/Source/Scene/LabelCollection.js
+++ b/Source/Scene/LabelCollection.js
@@ -166,6 +166,8 @@ function rebindAllGlyphs(labelCollection, label) {
     }
 
     backgroundBillboard.color = label._backgroundColor;
+    backgroundBillboard.outlineColor = label._backgroundOutlineColor;
+    backgroundBillboard.outlineWidth = 1.0; // TODO: support backgroundOutlineWidth
     backgroundBillboard.show = label._show;
     backgroundBillboard.position = label._position;
     backgroundBillboard.eyeOffset = label._eyeOffset;


### PR DESCRIPTION
relates to issue #8907 

This is what I've tried. yet, could not see any border. tried `backgroundOutlineColor: Color.BLACK` with no results. I do see that the value is passed correctly to `LabelCollection`

What am I missing here?

This is still work in progress and I will add also `backgroundOutlineWidth` support once the color works.

@hpinkos 