### PR TITLE
Expose buildModuleUrl as part of the Cesium API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,9 +11,7 @@
 - Improved `MaterialProperty` JSDoc and TypeScript type definitions, which were missing the ability to take primitive types in addition to Property instances in their constructor.
 - Fixed `EllipsoidGeodesic` JSDoc and TypeScript type definitions which incorrectly listed `result` as required.
 - Fixed a bug with handling of PixelFormat's flipY. [#8893](https://github.com/CesiumGS/cesium/pull/8893)
-
-* Fixed JSDoc and TypeScript for `buildModuleUrl`, which was accidentally excluded from the official CesiumJS API.
-
+- Fixed JSDoc and TypeScript for `buildModuleUrl`, which was accidentally excluded from the official CesiumJS API.
 - Fixed JSDoc and TypeScript type definitions for all `ImageryProvider` types, which were missing `defaultNightAlpha` and `defaultDayAlpha` properties.
 - Fixed JSDoc and TypeScript type definitions for `Viewer` options parameter, which was incorrectly listed as required.
 - Fixed a memory leak where some 3D Tiles requests were being unintentionally retained after the requests were cancelled. [#8843](https://github.com/CesiumGS/cesium/pull/8843)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 - Improved `MaterialProperty` JSDoc and TypeScript type definitions, which were missing the ability to take primitive types in addition to Property instances in their constructor.
 - Fixed `EllipsoidGeodesic` JSDoc and TypeScript type definitions which incorrectly listed `result` as required.
 - Fixed a bug with handling of PixelFormat's flipY. [#8893](https://github.com/CesiumGS/cesium/pull/8893)
+
+* Fixed JSDoc and TypeScript for `buildModuleUrl`, which was accidentally excluded from the official CesiumJS API.
+
 - Fixed JSDoc and TypeScript type definitions for all `ImageryProvider` types, which were missing `defaultNightAlpha` and `defaultDayAlpha` properties.
 - Fixed JSDoc and TypeScript type definitions for `Viewer` options parameter, which was incorrectly listed as required.
 - Fixed a memory leak where some 3D Tiles requests were being unintentionally retained after the requests were cancelled. [#8843](https://github.com/CesiumGS/cesium/pull/8843)

--- a/Source/Core/buildModuleUrl.js
+++ b/Source/Core/buildModuleUrl.js
@@ -90,13 +90,20 @@ function buildModuleUrlFromBaseUrl(moduleID) {
 var implementation;
 
 /**
- * Given a non-relative moduleID, returns an absolute URL to the file represented by that module ID,
- * using, in order of preference, require.toUrl, the value of a global CESIUM_BASE_URL, or
- * the base URL of the Cesium.js script.
+ * Given a relative URL under the Cesium base URL, returns an absolute URL.
+ * @function
  *
- * @private
+ * @param {String} relativeUrl The relative path.
+ *
+ * @example
+ * var viewer = new Cesium.Viewer("cesiumContainer", {
+ *   imageryProvider: new Cesium.TileMapServiceImageryProvider({
+ *   url: Cesium.buildModuleUrl("Assets/Textures/NaturalEarthII"),
+ *   }),
+ *   baseLayerPicker: false,
+ * });
  */
-function buildModuleUrl(moduleID) {
+function buildModuleUrl(relativeUrl) {
   if (!defined(implementation)) {
     //select implementation
     if (
@@ -111,7 +118,7 @@ function buildModuleUrl(moduleID) {
     }
   }
 
-  var url = implementation(moduleID);
+  var url = implementation(relativeUrl);
   return url;
 }
 


### PR DESCRIPTION
It's been used in Sandcastle examples forever, but has always been marked as private in jsdoc. In order to make it available in TypeScript, we need to expose it.

Also cleaned up the doc to be more inline with what the current version actually does.

Fixes #8922