### PR TITLE
ts defintions, export Cesium as  namesapce

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -260,3 +260,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Edvinas Pranka](https://github.com/epranka)
 - [James Bromwell](https://github.com/thw0rted)
 - [Brandon Nguyen](https://github.com/bn-dignitas)
+- [Yang Yang](https://github.com/xxbld)

--- a/gulpfile.cjs
+++ b/gulpfile.cjs
@@ -1557,7 +1557,7 @@ function createTypeScriptDefinitions() {
 
   // Wrap the source to actually be inside of a declared cesium module
   // and add any workaround and private utility types.
-  source = `declare module "cesium" {
+  source = `declare namespace Cesium {
 
 /**
  * Private interfaces to support PropertyBag being a dictionary-like object.
@@ -1568,7 +1568,9 @@ interface DictionaryLike {
 
 ${source}
 }
-
+declare module "cesium" {
+  export = Cesium
+}
 `;
 
   // Map individual modules back to their source file so that TS still works


### PR DESCRIPTION
ts defintions 
support `new Cesium.Entity({point:...})`
and keep `cesium` module