### PR TITLE
Two small JSDoc/TS fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,10 +8,12 @@
 
 ##### Fixes :wrench:
 
-- Improved `MaterialProperty` JSDoc and TypeScript type definitions, which were missing the ability to take primitive types in addition to Property instances in their constructor.
-- Fixed `EllipsoidGeodesic` JSDoc and TypeScript type definitions which incorrectly listed `result` as required.
+- Improved `MaterialProperty` JSDoc and TypeScript type definitions, which were missing the ability to take primitive types in addition to Property instances in their constructor. [#8904](https://github.com/CesiumGS/cesium/pull/8904)
+- Fixed `EllipsoidGeodesic` JSDoc and TypeScript type definitions which incorrectly listed `result` as required. [#8904](https://github.com/CesiumGS/cesium/pull/8904)
 - Fixed a bug with handling of PixelFormat's flipY. [#8893](https://github.com/CesiumGS/cesium/pull/8893)
-- Fixed JSDoc and TypeScript type definitions for all `ImageryProvider` types, which were missing `defaultNightAlpha` and `defaultDayAlpha` properties.
+- Fixed JSDoc and TypeScript type definitions for all `ImageryProvider` types, which were missing `defaultNightAlpha` and `defaultDayAlpha` properties. [#8908](https://github.com/CesiumGS/cesium/pull/8908)
+- Fixed JSDoc and TypeScript type definitions for `EllipsoidTangentPlane.fromPoints`, which takes an array of `Cartesian3`, not a single instance. [#8928](https://github.com/CesiumGS/cesium/pull/8928)
+- Fixed JSDoc and TypeScript type definitions for `EntityCollection.getById` and `CompositeEntityCollection.getById`, which can both return undefined. [#8928](https://github.com/CesiumGS/cesium/pull/8928)
 - Fixed JSDoc and TypeScript type definitions for `Viewer` options parameter, which was incorrectly listed as required.
 - Fixed a memory leak where some 3D Tiles requests were being unintentionally retained after the requests were cancelled. [#8843](https://github.com/CesiumGS/cesium/pull/8843)
 

--- a/Source/Core/EllipsoidTangentPlane.js
+++ b/Source/Core/EllipsoidTangentPlane.js
@@ -135,7 +135,7 @@ var tmp = new AxisAlignedBoundingBox();
  * Creates a new instance from the provided ellipsoid and the center
  * point of the provided Cartesians.
  *
- * @param {Cartesian3} cartesians The list of positions surrounding the center point.
+ * @param {Cartesian3[]} cartesians The list of positions surrounding the center point.
  * @param {Ellipsoid} [ellipsoid=Ellipsoid.WGS84] The ellipsoid to use.
  */
 EllipsoidTangentPlane.fromPoints = function (cartesians, ellipsoid) {

--- a/Source/DataSources/CompositeEntityCollection.js
+++ b/Source/DataSources/CompositeEntityCollection.js
@@ -463,7 +463,7 @@ CompositeEntityCollection.prototype.computeAvailability = function () {
  * Gets an entity with the specified id.
  *
  * @param {String} id The id of the entity to retrieve.
- * @returns {Entity} The entity with the provided id or undefined if the id did not exist in the collection.
+ * @returns {Entity|undefined} The entity with the provided id or undefined if the id did not exist in the collection.
  */
 CompositeEntityCollection.prototype.getById = function (id) {
   return this._composite.getById(id);

--- a/Source/DataSources/EntityCollection.js
+++ b/Source/DataSources/EntityCollection.js
@@ -397,7 +397,7 @@ EntityCollection.prototype.removeAll = function () {
  * Gets an entity with the specified id.
  *
  * @param {String} id The id of the entity to retrieve.
- * @returns {Entity} The entity with the provided id or undefined if the id did not exist in the collection.
+ * @returns {Entity|undefined} The entity with the provided id or undefined if the id did not exist in the collection.
  */
 EntityCollection.prototype.getById = function (id) {
   //>>includeStart('debug', pragmas.debug);


### PR DESCRIPTION
1. `EllipsoidTangentPlane.fromPoints` takes an array.
2. `EntityCollection.getById` and `CompositeEntityCollection.getById` can
both return undefined.

Fixes #8926
Handles bullet 1 from #8927