### PR TITLE
Exposing Transforms.rotationMatrixFromPositionVelocity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Additions :tada:
 
 - Add a `toString` method to the `Resource` class in case an instance gets logged as a string. [#8722](https://github.com/CesiumGS/cesium/issues/8722)
+- Exposed `Transforms.rotationMatrixFromPositionVelocity` method from Cesium's private API. [#8927](https://github.com/CesiumGS/cesium/issues/8927)
 
 ##### Fixes :wrench:
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -260,3 +260,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Edvinas Pranka](https://github.com/epranka)
 - [James Bromwell](https://github.com/thw0rted)
 - [Brandon Nguyen](https://github.com/bn-dignitas)
+- [John Remsberg](https://github.com/easternmotors)

--- a/Source/Core/Transforms.js
+++ b/Source/Core/Transforms.js
@@ -949,7 +949,13 @@ var rightScratch = new Cartesian3();
 var upScratch = new Cartesian3();
 
 /**
- * @private
+ * Transform a position and velocity to a rotation matrix.
+ *
+ * @param {Cartesian3} position The position to transform.
+ * @param {Cartesian3} velocity The velocity vector to transform.
+ * @param {Ellipsoid} [ellipsoid=Ellipsoid.WGS84] The ellipsoid whose fixed frame is used in the transformation.
+ * @param {Matrix3} [result] The object onto which to store the result.
+ * @returns {Matrix3} The modified result parameter or a new Matrix3 instance if none was provided.
  */
 Transforms.rotationMatrixFromPositionVelocity = function (
   position,

--- a/Specs/Core/TransformsSpec.js
+++ b/Specs/Core/TransformsSpec.js
@@ -1722,30 +1722,21 @@ describe("Core/Transforms", function () {
       Cartesian3.UNIT_Y
     );
     var expected = new Matrix3(0, 0, 1, 1, 0, 0, 0, 1, 0);
-    // using Matrix3.abs to fix the 0/-0 comparisons
-    expect(Matrix3.toArray(Matrix3.abs(matrix, new Matrix3()))).toEqual(
-      Matrix3.toArray(expected)
-    );
+    expect(matrix).toEqualEpsilon(expected, CesiumMath.EPSILON14);
 
     matrix = Transforms.rotationMatrixFromPositionVelocity(
       Cartesian3.UNIT_X,
       Cartesian3.UNIT_Z
     );
-    expected = new Matrix3(0, 0, 1, 0, 1, 0, 1, 0, 0);
-    // using Matrix3.abs to fix the 0/-0 comparisons
-    expect(Matrix3.toArray(Matrix3.abs(matrix, new Matrix3()))).toEqual(
-      Matrix3.toArray(expected)
-    );
+    expected = new Matrix3(0, 0, 1, 0, -1, 0, 1, 0, 0);
+    expect(matrix).toEqualEpsilon(expected, CesiumMath.EPSILON14);
 
     matrix = Transforms.rotationMatrixFromPositionVelocity(
       Cartesian3.UNIT_Y,
       Cartesian3.UNIT_Z
     );
     expected = new Matrix3(0, 1, 0, 0, 0, 1, 1, 0, 0);
-    // using Matrix3.abs to fix the 0/-0 comparisons
-    expect(Matrix3.toArray(Matrix3.abs(matrix, new Matrix3()))).toEqual(
-      Matrix3.toArray(expected)
-    );
+    expect(matrix).toEqualEpsilon(expected, CesiumMath.EPSILON14);
   });
 
   it("rotationMatrixFromPositionVelocity works with a result parameter", function () {
@@ -1757,10 +1748,7 @@ describe("Core/Transforms", function () {
       result
     );
     var expected = new Matrix3(0, 0, 1, 1, 0, 0, 0, 1, 0);
-    // using Matrix3.abs to fix the 0/-0 comparisons
-    expect(Matrix3.toArray(Matrix3.abs(result, new Matrix3()))).toEqual(
-      Matrix3.toArray(expected)
-    );
+    expect(result).toEqualEpsilon(expected, CesiumMath.EPSILON14);
 
     Transforms.rotationMatrixFromPositionVelocity(
       Cartesian3.UNIT_X,
@@ -1768,11 +1756,8 @@ describe("Core/Transforms", function () {
       Ellipsoid.WGS84,
       result
     );
-    expected = new Matrix3(0, 0, 1, 0, 1, 0, 1, 0, 0);
-    // using Matrix3.abs to fix the 0/-0 comparisons
-    expect(Matrix3.toArray(Matrix3.abs(result, new Matrix3()))).toEqual(
-      Matrix3.toArray(expected)
-    );
+    expected = new Matrix3(0, 0, 1, 0, -1, 0, 1, 0, 0);
+    expect(result).toEqualEpsilon(expected, CesiumMath.EPSILON14);
 
     Transforms.rotationMatrixFromPositionVelocity(
       Cartesian3.UNIT_Y,
@@ -1781,10 +1766,7 @@ describe("Core/Transforms", function () {
       result
     );
     expected = new Matrix3(0, 1, 0, 0, 0, 1, 1, 0, 0);
-    // using Matrix3.abs to fix the 0/-0 comparisons
-    expect(Matrix3.toArray(Matrix3.abs(result, new Matrix3()))).toEqual(
-      Matrix3.toArray(expected)
-    );
+    expect(result).toEqualEpsilon(expected, CesiumMath.EPSILON14);
   });
 
   it("basisTo2D projects translation", function () {

--- a/Specs/Core/TransformsSpec.js
+++ b/Specs/Core/TransformsSpec.js
@@ -1716,6 +1716,65 @@ describe("Core/Transforms", function () {
     expect(returnedResult).toEqualEpsilon(expected, CesiumMath.EPSILON12);
   });
 
+  it("rotationMatrixFromPositionVelocity works without a result parameter", function () {
+    var matrix = Transforms.rotationMatrixFromPositionVelocity(
+      Cartesian3.UNIT_X,
+      Cartesian3.UNIT_Y
+    );
+    var expected = new Matrix3(0, 0, 1, 1, 0, 0, 0, 1, 0);
+    // using Matrix3.abs to fix the 0/-0 comparisons
+    expect(Matrix3.toArray(Matrix3.abs(matrix, new Matrix3()))).toEqual(Matrix3.toArray(expected));
+
+    matrix = Transforms.rotationMatrixFromPositionVelocity(
+      Cartesian3.UNIT_X,
+      Cartesian3.UNIT_Z
+    );
+    expected = new Matrix3(0, 0, 1, 0, 1, 0, 1, 0, 0);
+    // using Matrix3.abs to fix the 0/-0 comparisons
+    expect(Matrix3.toArray(Matrix3.abs(matrix, new Matrix3()))).toEqual(Matrix3.toArray(expected));
+
+    matrix = Transforms.rotationMatrixFromPositionVelocity(
+      Cartesian3.UNIT_Y,
+      Cartesian3.UNIT_Z
+    );
+    expected = new Matrix3(0, 1, 0, 0, 0, 1, 1, 0, 0);
+    // using Matrix3.abs to fix the 0/-0 comparisons
+    expect(Matrix3.toArray(Matrix3.abs(matrix, new Matrix3()))).toEqual(Matrix3.toArray(expected));
+  });
+
+  it("rotationMatrixFromPositionVelocity works with a result parameter", function () {
+    var result = new Matrix3();
+    Transforms.rotationMatrixFromPositionVelocity(
+      Cartesian3.UNIT_X,
+      Cartesian3.UNIT_Y,
+      Ellipsoid.WGS84,
+      result
+    );
+    var expected = new Matrix3(0, 0, 1, 1, 0, 0, 0, 1, 0);
+    // using Matrix3.abs to fix the 0/-0 comparisons
+    expect(Matrix3.toArray(Matrix3.abs(result, new Matrix3()))).toEqual(Matrix3.toArray(expected));
+
+    Transforms.rotationMatrixFromPositionVelocity(
+      Cartesian3.UNIT_X,
+      Cartesian3.UNIT_Z,
+      Ellipsoid.WGS84,
+      result
+    );
+    expected = new Matrix3(0, 0, 1, 0, 1, 0, 1, 0, 0);
+    // using Matrix3.abs to fix the 0/-0 comparisons
+    expect(Matrix3.toArray(Matrix3.abs(result, new Matrix3()))).toEqual(Matrix3.toArray(expected));
+
+    Transforms.rotationMatrixFromPositionVelocity(
+      Cartesian3.UNIT_Y,
+      Cartesian3.UNIT_Z,
+      Ellipsoid.WGS84,
+      result
+    );
+    expected = new Matrix3(0, 1, 0, 0, 0, 1, 1, 0, 0);
+    // using Matrix3.abs to fix the 0/-0 comparisons
+    expect(Matrix3.toArray(Matrix3.abs(result, new Matrix3()))).toEqual(Matrix3.toArray(expected));
+  });
+
   it("basisTo2D projects translation", function () {
     var ellipsoid = Ellipsoid.WGS84;
     var projection = new GeographicProjection(ellipsoid);

--- a/Specs/Core/TransformsSpec.js
+++ b/Specs/Core/TransformsSpec.js
@@ -1723,7 +1723,9 @@ describe("Core/Transforms", function () {
     );
     var expected = new Matrix3(0, 0, 1, 1, 0, 0, 0, 1, 0);
     // using Matrix3.abs to fix the 0/-0 comparisons
-    expect(Matrix3.toArray(Matrix3.abs(matrix, new Matrix3()))).toEqual(Matrix3.toArray(expected));
+    expect(Matrix3.toArray(Matrix3.abs(matrix, new Matrix3()))).toEqual(
+      Matrix3.toArray(expected)
+    );
 
     matrix = Transforms.rotationMatrixFromPositionVelocity(
       Cartesian3.UNIT_X,
@@ -1731,7 +1733,9 @@ describe("Core/Transforms", function () {
     );
     expected = new Matrix3(0, 0, 1, 0, 1, 0, 1, 0, 0);
     // using Matrix3.abs to fix the 0/-0 comparisons
-    expect(Matrix3.toArray(Matrix3.abs(matrix, new Matrix3()))).toEqual(Matrix3.toArray(expected));
+    expect(Matrix3.toArray(Matrix3.abs(matrix, new Matrix3()))).toEqual(
+      Matrix3.toArray(expected)
+    );
 
     matrix = Transforms.rotationMatrixFromPositionVelocity(
       Cartesian3.UNIT_Y,
@@ -1739,7 +1743,9 @@ describe("Core/Transforms", function () {
     );
     expected = new Matrix3(0, 1, 0, 0, 0, 1, 1, 0, 0);
     // using Matrix3.abs to fix the 0/-0 comparisons
-    expect(Matrix3.toArray(Matrix3.abs(matrix, new Matrix3()))).toEqual(Matrix3.toArray(expected));
+    expect(Matrix3.toArray(Matrix3.abs(matrix, new Matrix3()))).toEqual(
+      Matrix3.toArray(expected)
+    );
   });
 
   it("rotationMatrixFromPositionVelocity works with a result parameter", function () {
@@ -1752,7 +1758,9 @@ describe("Core/Transforms", function () {
     );
     var expected = new Matrix3(0, 0, 1, 1, 0, 0, 0, 1, 0);
     // using Matrix3.abs to fix the 0/-0 comparisons
-    expect(Matrix3.toArray(Matrix3.abs(result, new Matrix3()))).toEqual(Matrix3.toArray(expected));
+    expect(Matrix3.toArray(Matrix3.abs(result, new Matrix3()))).toEqual(
+      Matrix3.toArray(expected)
+    );
 
     Transforms.rotationMatrixFromPositionVelocity(
       Cartesian3.UNIT_X,
@@ -1762,7 +1770,9 @@ describe("Core/Transforms", function () {
     );
     expected = new Matrix3(0, 0, 1, 0, 1, 0, 1, 0, 0);
     // using Matrix3.abs to fix the 0/-0 comparisons
-    expect(Matrix3.toArray(Matrix3.abs(result, new Matrix3()))).toEqual(Matrix3.toArray(expected));
+    expect(Matrix3.toArray(Matrix3.abs(result, new Matrix3()))).toEqual(
+      Matrix3.toArray(expected)
+    );
 
     Transforms.rotationMatrixFromPositionVelocity(
       Cartesian3.UNIT_Y,
@@ -1772,7 +1782,9 @@ describe("Core/Transforms", function () {
     );
     expected = new Matrix3(0, 1, 0, 0, 0, 1, 1, 0, 0);
     // using Matrix3.abs to fix the 0/-0 comparisons
-    expect(Matrix3.toArray(Matrix3.abs(result, new Matrix3()))).toEqual(Matrix3.toArray(expected));
+    expect(Matrix3.toArray(Matrix3.abs(result, new Matrix3()))).toEqual(
+      Matrix3.toArray(expected)
+    );
   });
 
   it("basisTo2D projects translation", function () {


### PR DESCRIPTION
Also added tests for Transforms.rotationMatrixFromPositionVelocity

NOTE: I wasn't able to figure out how to get the tests to pass since `Transforms.rotationMatrixFromPositionVelocity` sometimes return 0 or -0 for it's 0 values. I ended up just using the `Matrix3.abs` function for now but if there is a better way to handle this let me know.

Handles bullet 3 from #8927