### PR TITLE
Only include Source folder in TypeScript smokescreen tests.

### DIFF
--- a/Specs/TypeScript/tsconfig.json
+++ b/Specs/TypeScript/tsconfig.json
@@ -5,6 +5,6 @@
     "strict": true
   },
   "include": [
-    "../.."
+    "../../Source"
   ],
 }


### PR DESCRIPTION
We were including all Cesium directories in the TypeScript smokescreen configuration. This meant that multiple Cesium.d.ts files were included if you did a full build and then ran `build-ts` afterwards. This updates the config used by the smokescreen to only include Source.

CC @OmarShehata 