### PR TITLE
Fix geometry creation in TypeScript

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 - Fixed JSDoc and TypeScript type definitions for `EllipsoidTangentPlane.fromPoints`, which takes an array of `Cartesian3`, not a single instance. [#8928](https://github.com/CesiumGS/cesium/pull/8928)
 - Fixed JSDoc and TypeScript type definitions for `EntityCollection.getById` and `CompositeEntityCollection.getById`, which can both return undefined. [#8928](https://github.com/CesiumGS/cesium/pull/8928)
 - Fixed JSDoc and TypeScript type definitions for `Viewer` options parameter, which was incorrectly listed as required.
+- Fixed TypeScript type definitions to allow the creation of `GeometryInstance` instances using `XXXGeometry` classes. [#8941](https://github.com/CesiumGS/cesium/pull/8941).
 - Fixed a memory leak where some 3D Tiles requests were being unintentionally retained after the requests were cancelled. [#8843](https://github.com/CesiumGS/cesium/pull/8843)
 
 ### 1.70.0 - 2020-06-01

--- a/Source/Core/GeometryFactory.js
+++ b/Source/Core/GeometryFactory.js
@@ -1,6 +1,9 @@
 import DeveloperError from "../Core/DeveloperError.js";
 
 /**
+ * Base class for all geometry creation utility classes that can be passed to {@link GeometryInstance}
+ * for asynchronous geometry creation.
+ *
  * @constructor
  * @class
  * @abstract

--- a/Source/Core/GeometryFactory.js
+++ b/Source/Core/GeometryFactory.js
@@ -1,0 +1,22 @@
+import DeveloperError from "../Core/DeveloperError.js";
+
+/**
+ * @constructor
+ * @class
+ * @abstract
+ */
+function GeometryFactory() {
+  DeveloperError.throwInstantiationError();
+}
+
+/**
+ * Returns a geometry.
+ *
+ * @param {GeometryFactory} geometryFactory A description of the circle.
+ * @returns {Geometry|undefined} The computed vertices and indices.
+ */
+GeometryFactory.createGeometry = function (geometryFactory) {
+  DeveloperError.throwInstantiationError();
+};
+
+export default GeometryFactory;

--- a/Source/Core/GeometryInstance.js
+++ b/Source/Core/GeometryInstance.js
@@ -13,7 +13,7 @@ import Matrix4 from "./Matrix4.js";
  * @constructor
  *
  * @param {Object} options Object with the following properties:
- * @param {Geometry} options.geometry The geometry to instance.
+ * @param {Geometry|GeometryFactory} options.geometry The geometry to instance.
  * @param {Matrix4} [options.modelMatrix=Matrix4.IDENTITY] The model matrix that transforms to transform the geometry from model to world coordinates.
  * @param {Object} [options.id] A user-defined object to return when the instance is picked with {@link Scene#pick} or get/set per-instance attributes with {@link Primitive#getGeometryInstanceAttributes}.
  * @param {Object} [options.attributes] Per-instance attributes like a show or color attribute shown in the example below.

--- a/Source/Core/PlaneGeometry.js
+++ b/Source/Core/PlaneGeometry.js
@@ -16,7 +16,7 @@ import VertexFormat from "./VertexFormat.js";
  * @alias PlaneGeometry
  * @constructor
  *
- * @param {Object} options Object with the following properties:
+ * @param {Object} [options] Object with the following properties:
  * @param {VertexFormat} [options.vertexFormat=VertexFormat.DEFAULT] The vertex attributes to be computed.
  *
  * @example

--- a/Source/Core/SimplePolylineGeometry.js
+++ b/Source/Core/SimplePolylineGeometry.js
@@ -251,7 +251,7 @@ var generateArcOptionsScratch = {
  * Computes the geometric representation of a simple polyline, including its vertices, indices, and a bounding sphere.
  *
  * @param {SimplePolylineGeometry} simplePolylineGeometry A description of the polyline.
- * @returns {Geometry} The computed vertices and indices.
+ * @returns {Geometry|undefined} The computed vertices and indices.
  */
 SimplePolylineGeometry.createGeometry = function (simplePolylineGeometry) {
   var positions = simplePolylineGeometry._positions;

--- a/Source/Core/SphereGeometry.js
+++ b/Source/Core/SphereGeometry.js
@@ -110,7 +110,7 @@ SphereGeometry.unpack = function (array, startingIndex, result) {
  * Computes the geometric representation of a sphere, including its vertices, indices, and a bounding sphere.
  *
  * @param {SphereGeometry} sphereGeometry A description of the sphere.
- * @returns {Geometry} The computed vertices and indices.
+ * @returns {Geometry|undefined} The computed vertices and indices.
  */
 SphereGeometry.createGeometry = function (sphereGeometry) {
   return EllipsoidGeometry.createGeometry(sphereGeometry._ellipsoidGeometry);

--- a/Source/Core/SphereOutlineGeometry.js
+++ b/Source/Core/SphereOutlineGeometry.js
@@ -110,7 +110,7 @@ SphereOutlineGeometry.unpack = function (array, startingIndex, result) {
  * Computes the geometric representation of an outline of a sphere, including its vertices, indices, and a bounding sphere.
  *
  * @param {SphereOutlineGeometry} sphereGeometry A description of the sphere outline.
- * @returns {Geometry} The computed vertices and indices.
+ * @returns {Geometry|undefined} The computed vertices and indices.
  */
 SphereOutlineGeometry.createGeometry = function (sphereGeometry) {
   return EllipsoidOutlineGeometry.createGeometry(

--- a/Specs/TypeScript/index.ts
+++ b/Specs/TypeScript/index.ts
@@ -1,65 +1,101 @@
 import {
   ArcGisMapServerImageryProvider,
-  BingMapsImageryProvider,
-  ImageryProvider,
-  WebMapServiceImageryProvider,
-  OpenStreetMapImageryProvider,
-  TileMapServiceImageryProvider,
-  GoogleEarthEnterpriseImageryProvider,
-  GoogleEarthEnterpriseMapsProvider,
-  GridImageryProvider,
-  IonImageryProvider,
-  MapboxImageryProvider,
-  MapboxStyleImageryProvider,
-  SingleTileImageryProvider,
-  TileCoordinatesImageryProvider,
-  UrlTemplateImageryProvider,
-  WebMapTileServiceImageryProvider,
-  GoogleEarthEnterpriseMetadata,
-  TerrainProvider,
   ArcGISTiledElevationTerrainProvider,
-  CesiumTerrainProvider,
-  EllipsoidTerrainProvider,
-  GoogleEarthEnterpriseTerrainProvider,
-  VRTheWorldTerrainProvider,
-  DataSource,
-  CzmlDataSource,
-  GeoJsonDataSource,
-  KmlDataSource,
-  CustomDataSource,
-  Camera,
-  Scene,
-  Property,
-  PropertyBag,
-  ConstantProperty,
-  SampledProperty,
-  PositionProperty,
-  SampledPositionProperty,
-  TimeIntervalCollectionProperty,
-  CompositeProperty,
-  CompositePositionProperty,
-  Cartesian3,
-  ReferenceProperty,
-  MaterialProperty,
-  EntityCollection,
+  BingMapsImageryProvider,
+  BoxGeometry,
+  BoxOutlineGeometry,
   CallbackProperty,
-  ConstantPositionProperty,
-  TimeIntervalCollectionPositionProperty,
+  Camera,
+  Cartesian3,
+  CesiumTerrainProvider,
+  CheckerboardMaterialProperty,
+  CircleGeometry,
+  CircleOutlineGeometry,
   ColorMaterialProperty,
   CompositeMaterialProperty,
+  CompositePositionProperty,
+  CompositeProperty,
+  ConstantPositionProperty,
+  ConstantProperty,
+  CoplanarPolygonGeometry,
+  CoplanarPolygonOutlineGeometry,
+  CorridorGeometry,
+  CorridorOutlineGeometry,
+  CustomDataSource,
+  CylinderGeometry,
+  CylinderOutlineGeometry,
+  CzmlDataSource,
+  DataSource,
+  EllipseGeometry,
+  EllipseOutlineGeometry,
+  EllipsoidGeometry,
+  EllipsoidOutlineGeometry,
+  EllipsoidTerrainProvider,
+  EntityCollection,
+  FrustumGeometry,
+  FrustumOutlineGeometry,
+  GeoJsonDataSource,
+  GeometryInstance,
+  GoogleEarthEnterpriseImageryProvider,
+  GoogleEarthEnterpriseMapsProvider,
+  GoogleEarthEnterpriseMetadata,
+  GoogleEarthEnterpriseTerrainProvider,
+  GridImageryProvider,
   GridMaterialProperty,
+  GroundPolylineGeometry,
   ImageMaterialProperty,
+  ImageryProvider,
+  IonImageryProvider,
+  KmlDataSource,
+  MapboxImageryProvider,
+  MapboxStyleImageryProvider,
+  MaterialProperty,
+  NodeTransformationProperty,
+  OpenStreetMapImageryProvider,
+  OrthographicFrustum,
+  PlaneGeometry,
+  PlaneOutlineGeometry,
+  PolygonGeometry,
+  PolygonHierarchy,
+  PolygonOutlineGeometry,
+  PolylineArrowMaterialProperty,
+  PolylineDashMaterialProperty,
+  PolylineGeometry,
   PolylineGlowMaterialProperty,
   PolylineOutlineMaterialProperty,
-  StripeMaterialProperty,
-  CheckerboardMaterialProperty,
-  PolylineDashMaterialProperty,
-  VelocityVectorProperty,
-  VelocityOrientationProperty,
-  PropertyArray,
+  PolylineVolumeGeometry,
+  PolylineVolumeOutlineGeometry,
+  PositionProperty,
   PositionPropertyArray,
-  PolylineArrowMaterialProperty,
-  NodeTransformationProperty,
+  Property,
+  PropertyArray,
+  PropertyBag,
+  Quaternion,
+  Rectangle,
+  RectangleGeometry,
+  RectangleOutlineGeometry,
+  ReferenceProperty,
+  SampledPositionProperty,
+  SampledProperty,
+  Scene,
+  SimplePolylineGeometry,
+  SingleTileImageryProvider,
+  SphereGeometry,
+  SphereOutlineGeometry,
+  StripeMaterialProperty,
+  TerrainProvider,
+  TileCoordinatesImageryProvider,
+  TileMapServiceImageryProvider,
+  TimeIntervalCollectionPositionProperty,
+  TimeIntervalCollectionProperty,
+  UrlTemplateImageryProvider,
+  VelocityOrientationProperty,
+  VelocityVectorProperty,
+  VRTheWorldTerrainProvider,
+  WallGeometry,
+  WallOutlineGeometry,
+  WebMapServiceImageryProvider,
+  WebMapTileServiceImageryProvider,
 } from "cesium";
 
 // Verify ImageryProvider instances conform to the expected interface
@@ -158,3 +194,186 @@ property = materialProperty = new StripeMaterialProperty();
 property = materialProperty = new CheckerboardMaterialProperty();
 property = materialProperty = new PolylineDashMaterialProperty();
 property = materialProperty = new PolylineArrowMaterialProperty();
+
+// Verify GeometryInstance can be take XXXGeometry objects.
+let geometryInstance: GeometryInstance;
+
+geometryInstance = new GeometryInstance({
+  geometry: new BoxGeometry({
+    minimum: new Cartesian3(0, 0, 0),
+    maximum: new Cartesian3(1, 1, 1),
+  }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new BoxOutlineGeometry({
+    minimum: new Cartesian3(0, 0, 0),
+    maximum: new Cartesian3(1, 1, 1),
+  }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new CircleGeometry({
+    center: new Cartesian3(0, 0, 0),
+    radius: 10,
+  }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new CircleOutlineGeometry({
+    center: new Cartesian3(0, 0, 0),
+    radius: 10,
+  }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new CoplanarPolygonGeometry({
+    polygonHierarchy: new PolygonHierarchy(),
+  }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new CoplanarPolygonOutlineGeometry({
+    polygonHierarchy: new PolygonHierarchy(),
+  }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new CorridorGeometry({ positions: [], width: 1 }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new CorridorOutlineGeometry({ positions: [], width: 1 }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new CylinderGeometry({
+    bottomRadius: 10,
+    length: 10,
+    topRadius: 10,
+  }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new CylinderOutlineGeometry({
+    bottomRadius: 10,
+    length: 10,
+    topRadius: 10,
+  }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new EllipseGeometry({
+    center: Cartesian3.ZERO,
+    semiMajorAxis: 1,
+    semiMinorAxis: 10,
+  }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new EllipseOutlineGeometry({
+    center: Cartesian3.ZERO,
+    semiMajorAxis: 1,
+    semiMinorAxis: 10,
+  }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new EllipsoidGeometry(),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new EllipsoidOutlineGeometry(),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new FrustumGeometry({
+    frustum: new OrthographicFrustum(),
+    orientation: new Quaternion(),
+    origin: Cartesian3.ZERO,
+  }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new FrustumOutlineGeometry({
+    frustum: new OrthographicFrustum(),
+    orientation: new Quaternion(),
+    origin: Cartesian3.ZERO,
+  }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new GroundPolylineGeometry({ positions: [] }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new PlaneGeometry(),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new PlaneOutlineGeometry(),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new PolygonGeometry({ polygonHierarchy: new PolygonHierarchy() }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new PolygonOutlineGeometry({
+    polygonHierarchy: new PolygonHierarchy(),
+  }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new PolylineGeometry({
+    positions: [],
+  }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new PolylineVolumeGeometry({
+    polylinePositions: [],
+    shapePositions: [],
+  }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new PolylineVolumeOutlineGeometry({
+    polylinePositions: [],
+    shapePositions: [],
+  }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new RectangleGeometry({ rectangle: Rectangle.MAX_VALUE }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new RectangleOutlineGeometry({ rectangle: Rectangle.MAX_VALUE }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new SimplePolylineGeometry({
+    positions: [],
+  }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new SphereGeometry(),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new SphereOutlineGeometry(),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new WallGeometry({
+    positions: [],
+  }),
+});
+
+geometryInstance = new GeometryInstance({
+  geometry: new WallOutlineGeometry({
+    positions: [],
+  }),
+});

--- a/Specs/TypeScript/tsconfig.json
+++ b/Specs/TypeScript/tsconfig.json
@@ -5,6 +5,7 @@
     "strict": true
   },
   "include": [
-    "../../Source"
-  ],
+    "index.ts",
+    "../../Source/Cesium.d.ts"
+  ]
 }


### PR DESCRIPTION
None of the `XXXGeometry` classes are actually `Geometry` instances. They are instead utility classes that create geometries via their `createGeometry` implementation. `GeometryInstance` can take either "type" but since JS doesn't have types we never really defined what the "utility" type is, so the TypeScript definition for `GeometryInstance` specifies that currently only specifies `Geometry`. This means that this valid JS code is a compiler error in TypeScript

```
const geometryInstance = new GeometryInstance({
  geometry: new PolylineGeometry({
    positions: [],
  }),
});
```

To fix this, I introduced a `GeometryFactory` base class like we have elsewhere in the code and changed `GeometryInstance` to take either type. This is the only place where we actually base "non-geometry Geometry" in the API.

Happy to consider other names, like `GeometryCreator` if we don't like factory for some reason, but I want to get this in sooner rather than later for 1.70.1 fixes.

Also fixed an issue with tsconfig.json I introduced in my last change which was failing to actually catch TS compile errors because it wasn't including the Cesium.d.ts.