### PR TITLE
Fix Sandcastle error for non-existent labels

### DIFF
--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -1520,6 +1520,8 @@ require({
     searchContainer = registry.byId("searchContainer");
 
     hideSearchContainer();
-    registry.byId("innerPanel").selectChild(subtabs[currentTab]);
+    if (defined(subtabs[currentTab])) {
+      registry.byId("innerPanel").selectChild(subtabs[currentTab]);
+    }
   });
 });


### PR DESCRIPTION
If you copied the URL to a Sandcastle demo from a label like "New in 1.70" that link will produce an error when opened when that label doesn't exist (like when the next version comes out). Noticed on the release blog:

https://sandcastle.cesium.com/index.html?src=Globe%20Translucency.html&label=New%20in%201.69

This doesn't prevent the example from loading but prints a console error and no examples show up in the gallery.

This PR fixes it by ignoring the label if it doesn't exist. 