### PR TITLE
Correct removing duplicate positions from WallGeometry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 1.71 - 2020-07-01
+
+##### Fixes :wrench:
+
+- Fixed error with `WallGeoemtry` when there were adjacent positions with very close values [#8952](https://github.com/CesiumGS/cesium/pull/8952)
+
 ### 1.70.1 - 2020-06-10
 
 ##### Additions :tada:

--- a/Source/Core/WallGeometryLibrary.js
+++ b/Source/Core/WallGeometryLibrary.js
@@ -1,3 +1,5 @@
+import arrayRemoveDuplicates from "./arrayRemoveDuplicates.js";
+import Cartesian3 from "./Cartesian3.js";
 import Cartographic from "./Cartographic.js";
 import defined from "./defined.js";
 import EllipsoidTangentPlane from "./EllipsoidTangentPlane.js";
@@ -13,14 +15,16 @@ var WallGeometryLibrary = {};
 
 function latLonEquals(c0, c1) {
   return (
-    CesiumMath.equalsEpsilon(c0.latitude, c1.latitude, CesiumMath.EPSILON14) &&
-    CesiumMath.equalsEpsilon(c0.longitude, c1.longitude, CesiumMath.EPSILON14)
+    CesiumMath.equalsEpsilon(c0.latitude, c1.latitude, CesiumMath.EPSILON10) &&
+    CesiumMath.equalsEpsilon(c0.longitude, c1.longitude, CesiumMath.EPSILON10)
   );
 }
 
 var scratchCartographic1 = new Cartographic();
 var scratchCartographic2 = new Cartographic();
 function removeDuplicates(ellipsoid, positions, topHeights, bottomHeights) {
+  positions = arrayRemoveDuplicates(positions, Cartesian3.equalsEpsilon, true);
+
   var length = positions.length;
   if (length < 2) {
     return;

--- a/Specs/Core/WallGeometrySpec.js
+++ b/Specs/Core/WallGeometrySpec.js
@@ -219,8 +219,53 @@ describe("Core/WallGeometry", function () {
     expect(cartographic.height).toEqualEpsilon(2000.0, CesiumMath.EPSILON8);
   });
 
-  it("does not clean positions that add up past EPSILON14", function () {
-    var eightyPercentOfEpsilon14 = 0.8 * CesiumMath.EPSILON14;
+  it("removes duplicates with very small difference", function () {
+    var w = WallGeometry.createGeometry(
+      new WallGeometry({
+        vertexFormat: VertexFormat.POSITION_ONLY,
+        positions: [
+          new Cartesian3(
+            4347090.215457887,
+            1061403.4237998386,
+            4538066.036525028
+          ),
+          new Cartesian3(
+            4348147.589624987,
+            1043897.8776143644,
+            4541092.234751661
+          ),
+          new Cartesian3(
+            4348147.589882754,
+            1043897.8776762491,
+            4541092.234492364
+          ),
+          new Cartesian3(
+            4335659.882947743,
+            1047571.602084736,
+            4552098.654605664
+          ),
+        ],
+      })
+    );
+
+    var numPositions = 8;
+    var numTriangles = 4;
+    var positions = w.attributes.position.values;
+    expect(positions.length).toEqual(numPositions * 3);
+    expect(w.indices.length).toEqual(numTriangles * 3);
+
+    var cartographic = ellipsoid.cartesianToCartographic(
+      Cartesian3.fromArray(positions, 0)
+    );
+    expect(cartographic.height).toEqualEpsilon(0.0, CesiumMath.EPSILON8);
+
+    cartographic = ellipsoid.cartesianToCartographic(
+      Cartesian3.fromArray(positions, 3)
+    );
+  });
+
+  it("does not clean positions that add up past EPSILON10", function () {
+    var eightyPercentOfEpsilon14 = 0.8 * CesiumMath.EPSILON10;
     var inputPositions = Cartesian3.fromRadiansArrayHeights([
       1.0,
       1.0,

--- a/Specs/Core/WallGeometrySpec.js
+++ b/Specs/Core/WallGeometrySpec.js
@@ -253,15 +253,6 @@ describe("Core/WallGeometry", function () {
     var positions = w.attributes.position.values;
     expect(positions.length).toEqual(numPositions * 3);
     expect(w.indices.length).toEqual(numTriangles * 3);
-
-    var cartographic = ellipsoid.cartesianToCartographic(
-      Cartesian3.fromArray(positions, 0)
-    );
-    expect(cartographic.height).toEqualEpsilon(0.0, CesiumMath.EPSILON8);
-
-    cartographic = ellipsoid.cartesianToCartographic(
-      Cartesian3.fromArray(positions, 3)
-    );
   });
 
   it("does not clean positions that add up past EPSILON10", function () {


### PR DESCRIPTION
Fixes #8842

`WallGeometry` was missing a call to `arrayRemoveDuplicates` that we created to standardize the epsilon distance at which to remove duplicate positions.

Also updated the lat/lon epsilon check to use `EPSILON10`.  We initially undershot with `EPSILON6`, then https://github.com/CesiumGS/cesium/pull/1483 overshot and changed it to `EPSILON14`, but `EPSILON10` is what we've standardized on in `arrayRemoveDuplicates` and our other geometry duplicate check functions.