### PR TITLE
Draw walls with positions in order given

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 1.71 - 2020-07-01
+
+##### Breaking Changes :mega:
+
+- Updated `WallGeometry` to respect the order of positions passed in, instead of making the positions respect a counter clockwise winding order. This will only effect the look of walls with an image material. If this changed the way your wall is drawing, reverse the order of the positions.
+
 ### 1.70.1 - 2020-06-10
 
 ##### Additions :tada:

--- a/Source/Core/WallGeometryLibrary.js
+++ b/Source/Core/WallGeometryLibrary.js
@@ -1,10 +1,7 @@
 import Cartographic from "./Cartographic.js";
 import defined from "./defined.js";
-import EllipsoidTangentPlane from "./EllipsoidTangentPlane.js";
 import CesiumMath from "./Math.js";
-import PolygonPipeline from "./PolygonPipeline.js";
 import PolylinePipeline from "./PolylinePipeline.js";
-import WindingOrder from "./WindingOrder.js";
 
 /**
  * @private

--- a/Source/Core/WallGeometryLibrary.js
+++ b/Source/Core/WallGeometryLibrary.js
@@ -128,24 +128,6 @@ WallGeometryLibrary.computePositions = function (
   maximumHeights = o.topHeights;
   minimumHeights = o.bottomHeights;
 
-  if (wallPositions.length >= 3) {
-    // Order positions counter-clockwise
-    var tangentPlane = EllipsoidTangentPlane.fromPoints(
-      wallPositions,
-      ellipsoid
-    );
-    var positions2D = tangentPlane.projectPointsOntoPlane(wallPositions);
-
-    if (
-      PolygonPipeline.computeWindingOrder2D(positions2D) ===
-      WindingOrder.CLOCKWISE
-    ) {
-      wallPositions.reverse();
-      maximumHeights.reverse();
-      minimumHeights.reverse();
-    }
-  }
-
   var length = wallPositions.length;
   var numCorners = length - 2;
   var topPositions;


### PR DESCRIPTION
Fixes #8708

We had logic to reverse the order of the wall positions to give them a counter-clockwise winding order.  However, I can't see a reason for doing this and I think it was a mistake that got copy/pasted in based on how we handle positions for polygons.  This removes that check and uses the positions passed in by the end user in the order they were given to draw the wall.

[localhost example](http://localhost:8080/Apps/Sandcastle/index.html#c=3VZNb5wwEP0rFheItDX7RSptyartNlIPUXpI1T2EaOXAhHXrD2SbXW2q/PcaTJTVllwiUFHNwfYw8zy8N4O8IwrtKOxBoQskYI9WoGnJ8Y/aFvhpvV1JYQgVoPyzD4monp2NW1+uCWM2zgFgEIYaChqTLAt+JwLZIQgHtED+vvIkBm2B5lvjj9zb2rpAjW81CqkthhTamptUVkQZuyJihh+U5F8gVwD6k1Lk8LVG08HtZD7G4xF6N5tW03RcDbt6wX3jmERtuHdnR8icCspL3qRi076duMORm++OfYkBRUn1zf7WmEIvwlATkaVEGwbYkY1TyUPKSQ46dBRsrmQuNyvJpNp824Fi5IALkfsO+CkRT06WSpTL9XBEeSEv6lSUeRtuF6IkHsavUo9/Fnnivc75ZxCZvhkW87OumY+ecd/3I+nszZL2I637xzlpp4PQtjuu5z0Vx7zr4ojaEh5AcRz1/fWw+j7qSdoIT/vp+2i4fX/9v/X9eU/Fcd51cURtCf/j4miuv64cHqXk32VwUhyVozfyYm0ODJbPB3+kvJDKoFKxwJ5qgBfMZqLD+zL9BQanug6sXOPwODTO6A7R7CLxTi7jiYdSRrS2bx5Kxm7oIyTeMg6t/1+hTJKMiry5PVZu28nyyhkxxnFot+2RRkp2T9QJ8h8)