### PR TITLE
Fix error in ModelUtility

### DIFF
--- a/Source/Scene/ModelUtility.js
+++ b/Source/Scene/ModelUtility.js
@@ -227,9 +227,10 @@ ModelUtility.computeBoundingSphere = function (model) {
           var positionAccessor = primitives[m].attributes.POSITION;
           if (defined(positionAccessor)) {
             var minMax = ModelUtility.getAccessorMinMax(gltf, positionAccessor);
-            var aMin = Cartesian3.fromArray(minMax.min, 0, aMinScratch);
-            var aMax = Cartesian3.fromArray(minMax.max, 0, aMaxScratch);
-            if (defined(min) && defined(max)) {
+            if (defined(minMax.min) && defined(minMax.max)) {
+              var aMin = Cartesian3.fromArray(minMax.min, 0, aMinScratch);
+              var aMax = Cartesian3.fromArray(minMax.max, 0, aMaxScratch);
+
               Matrix4.multiplyByPoint(transformToRoot, aMin, aMin);
               Matrix4.multiplyByPoint(transformToRoot, aMax, aMax);
               Cartesian3.minimumByComponent(min, aMin, min);


### PR DESCRIPTION
Fixes #8458

Not sure if this is the correct fix but it was my best guess.  It was pointed out in #8458 min and max will always be defined so that didn't make sense.