### PR TITLE
Webgl2 remove OES_standard_derivative extension

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,9 @@
 - Fixed a bug where silhouette postprocess doesn't work in WebGL 2. [#7952](https://github.com/CesiumGS/cesium/issues/7952)
 - Fixed an error of applying clip planes to globe when enabling WebGL 2.0 [#7712](https://github.com/CesiumGS/cesium/issues/7712)
 - Fixed a bug where half-float texture doesn't have correct WebGL 2.0 parameter [#8975](https://github.com/CesiumGS/cesium/pull/8975)
+- Fixed a bug where the label's text is not anti-alias when enabling WebGL 2.0 [#797](https://github.com/CesiumGS/cesium/issues/797#issuecomment-646884821)
+- Fixed a bug where polyline get squashed when zooming when enabling WebGL 2.0 [#797](https://github.com/CesiumGS/cesium/issues/797#issuecomment-646918076)
+- Fixed a bug where contour lines are thinner when enabling WebGL 2.0 [#797](https://github.com/CesiumGS/cesium/issues/797#issuecomment-646920630)
 
 ### 1.70.1 - 2020-06-10
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,8 +21,8 @@
 - Fixed a bug where silhouette postprocess doesn't work in WebGL 2. [#7952](https://github.com/CesiumGS/cesium/issues/7952)
 - Fixed an error of applying clip planes to globe when enabling WebGL 2.0 [#7712](https://github.com/CesiumGS/cesium/issues/7712)
 - Fixed a bug where half-float texture doesn't have correct WebGL 2.0 parameter [#8975](https://github.com/CesiumGS/cesium/pull/8975)
-- Fixed a bug where the label's text is not anti-alias when enabling WebGL 2.0 [#797](https://github.com/CesiumGS/cesium/issues/797#issuecomment-646884821)
-- Fixed a bug where polyline get squashed when zooming when enabling WebGL 2.0 [#797](https://github.com/CesiumGS/cesium/issues/797#issuecomment-646918076)
+- Fixed a bug where the label's text is not anti-aliased when enabling WebGL 2.0 [#797](https://github.com/CesiumGS/cesium/issues/797#issuecomment-646884821)
+- Fixed a bug where polylines get squashed when zooming when enabling WebGL 2.0 [#797](https://github.com/CesiumGS/cesium/issues/797#issuecomment-646918076)
 - Fixed a bug where contour lines are thinner when enabling WebGL 2.0 [#797](https://github.com/CesiumGS/cesium/issues/797#issuecomment-646920630)
 
 ### 1.70.1 - 2020-06-10

--- a/Source/Renderer/modernizeShader.js
+++ b/Source/Renderer/modernizeShader.js
@@ -119,6 +119,7 @@ function modernizeShader(source, isFragmentShader) {
 
   removeExtension("EXT_draw_buffers", webgl2UniqueID, splitSource);
   removeExtension("EXT_frag_depth", webgl2UniqueID, splitSource);
+  removeExtension("OES_standard_derivatives", webgl2UniqueID, splitSource);
 
   replaceInSourceString("texture2D", "texture", splitSource);
   replaceInSourceString("texture3D", "texture", splitSource);


### PR DESCRIPTION
Fixes a bug [where label's text is not anti-aliased in WebGL 2](https://github.com/CesiumGS/cesium/issues/797#issuecomment-646884821)
Fixes a bug [where polylines get squashed when zooming in WebGL 2](https://github.com/CesiumGS/cesium/issues/797#issuecomment-646918076)
Fixes a bug [where contour lines are thinner in WebGL 2](https://github.com/CesiumGS/cesium/issues/797#issuecomment-646920630)