### PR TITLE
Add Color.toCssHexString and unit tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ##### Breaking Changes :mega:
 
+- Added `Color.toCssHexString` for getting the CSS hex string equivalent for a color.
 - Updated `WallGeometry` to respect the order of positions passed in, instead of making the positions respect a counter clockwise winding order. This will only effect the look of walls with an image material. If this changed the way your wall is drawing, reverse the order of the positions.
 
 ##### Additions :tada:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,11 +4,11 @@
 
 ##### Breaking Changes :mega:
 
-- Added `Color.toCssHexString` for getting the CSS hex string equivalent for a color.
 - Updated `WallGeometry` to respect the order of positions passed in, instead of making the positions respect a counter clockwise winding order. This will only effect the look of walls with an image material. If this changed the way your wall is drawing, reverse the order of the positions.
 
 ##### Additions :tada:
 
+- Added `Color.toCssHexString` for getting the CSS hex string equivalent for a color.
 - Added support for PolylineVolume in CZML [#8841](https://github.com/CesiumGS/cesium/pull/8841)
 
 ##### Fixes :wrench:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
 
 ##### Additions :tada:
 
-- Added `Color.toCssHexString` for getting the CSS hex string equivalent for a color.
+- Added `Color.toCssHexString` for getting the CSS hex string equivalent for a color. [#8987](https://github.com/CesiumGS/cesium/pull/8987)
 - Added support for PolylineVolume in CZML [#8841](https://github.com/CesiumGS/cesium/pull/8841)
 
 ##### Fixes :wrench:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -144,6 +144,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
   - [Sam Suhag](https://github.com/sanjeetsuhag)
   - [Youssef Victor](https://github.com/YoussefV)
   - [Eli Bogomolny](https://github.com/ebogo1)
+  - [Erixen Cruz](https://github.com/ErixenCruz)
 - [Northrop Grumman](http://www.northropgrumman.com)
   - [Joseph Stein](https://github.com/nahgrin)
 - [EOX IT Services GmbH](https://eox.at)

--- a/Source/Core/Color.js
+++ b/Source/Core/Color.js
@@ -633,6 +633,27 @@ Color.prototype.toCssColorString = function () {
 };
 
 /**
+ * Creates a string containing CSS hex string color value for this color.
+ *
+ * @returns {String} The CSS hex string equivalent of this color.
+ */
+Color.prototype.toCssHexString = function () {
+  var r = Color.floatToByte(this.red).toString(16);
+  if (r.length < 2) {
+    r = "0" + r;
+  }
+  var g = Color.floatToByte(this.green).toString(16);
+  if (g.length < 2) {
+    g = "0" + g;
+  }
+  var b = Color.floatToByte(this.blue).toString(16);
+  if (b.length < 2) {
+    b = "0" + b;
+  }
+  return "#" + r + g + b;
+};
+
+/**
  * Converts this color to an array of red, green, blue, and alpha values
  * that are in the range of 0 to 255.
  *

--- a/Source/Core/Color.js
+++ b/Source/Core/Color.js
@@ -650,6 +650,13 @@ Color.prototype.toCssHexString = function () {
   if (b.length < 2) {
     b = "0" + b;
   }
+  if (this.alpha < 1) {
+    var hexAlpha = Color.floatToByte(this.alpha).toString(16);
+    if (hexAlpha.length < 2) {
+      hexAlpha = "0" + hexAlpha;
+    }
+    return "#" + r + g + b + hexAlpha;
+  }
   return "#" + r + g + b;
 };
 

--- a/Specs/Core/ColorSpec.js
+++ b/Specs/Core/ColorSpec.js
@@ -166,7 +166,7 @@ describe("Core/Color", function () {
     expect(Color.BLUE.toCssHexString()).toEqual("#0000ff");
     expect(Color.LIME.toCssHexString()).toEqual("#00ff00");
     expect(new Color(0.0, 0.0, 0.0, 1.0).toCssHexString()).toEqual("#000000");
-    expect(new Color(0.1, 0.2, 0.3, 0.4).toCssHexString()).toEqual("#19334c");
+    expect(new Color(0.1, 0.2, 0.3, 0.4).toCssHexString()).toEqual("#19334c66");
   });
 
   it("fromCssColorString supports transparent", function () {

--- a/Specs/Core/ColorSpec.js
+++ b/Specs/Core/ColorSpec.js
@@ -160,6 +160,15 @@ describe("Core/Color", function () {
     );
   });
 
+  it("toCssHexString produces expected output", function () {
+    expect(Color.WHITE.toCssHexString()).toEqual("#ffffff");
+    expect(Color.RED.toCssHexString()).toEqual("#ff0000");
+    expect(Color.BLUE.toCssHexString()).toEqual("#0000ff");
+    expect(Color.LIME.toCssHexString()).toEqual("#00ff00");
+    expect(new Color(0.0, 0.0, 0.0, 1.0).toCssHexString()).toEqual("#000000");
+    expect(new Color(0.1, 0.2, 0.3, 0.4).toCssHexString()).toEqual("#19334c");
+  });
+
   it("fromCssColorString supports transparent", function () {
     expect(Color.fromCssColorString("transparent")).toEqual(
       new Color(0.0, 0.0, 0.0, 0.0)


### PR DESCRIPTION
Added `Color.toCssHexString` for getting the CSS hex string equivalent for a color.