### PR TITLE
Fix skipLevelOfDetail doc

### DIFF
--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -619,7 +619,7 @@ function Cesium3DTileset(options) {
    * </p>
    *
    * @type {Boolean}
-   * @default true
+   * @default false
    */
   this.skipLevelOfDetail = defaultValue(options.skipLevelOfDetail, false);
   this._skipLevelOfDetail = this.skipLevelOfDetail;


### PR DESCRIPTION
`Cesium3DTileset.skipLevelOfDetail` has been false by default since 1.67. We missed this doc that says it's true by default. 