### PR TITLE
Webgl2 reimplement HBAO postprocess

### DIFF
--- a/Apps/Sandcastle/gallery/Ambient Occlusion.html
+++ b/Apps/Sandcastle/gallery/Ambient Occlusion.html
@@ -52,7 +52,7 @@
               <input
                 type="range"
                 min="1"
-                max="10"
+                max="30"
                 step="1"
                 data-bind="value: intensity, valueUpdate: 'input'"
               />
@@ -64,21 +64,9 @@
               <input
                 type="range"
                 min="0"
-                max="1"
+                max="2"
                 step="0.01"
                 data-bind="value: lengthCap, valueUpdate: 'input'"
-              />
-            </td>
-          </tr>
-          <tr>
-            <td>Step Size</td>
-            <td>
-              <input
-                type="range"
-                min="1"
-                max="10"
-                step="0.01"
-                data-bind="value: stepSize, valueUpdate: 'input'"
               />
             </td>
           </tr>
@@ -140,10 +128,9 @@
         var viewModel = {
           show: true,
           ambientOcclusionOnly: false,
-          intensity: 3.0,
+          intensity: 10.0,
           bias: 0.1,
-          lengthCap: 0.03,
-          stepSize: 1.0,
+          lengthCap: 0.5,
           blurStepSize: 0.86,
         };
 
@@ -169,7 +156,6 @@
           ambientOcclusion.uniforms.intensity = Number(viewModel.intensity);
           ambientOcclusion.uniforms.bias = Number(viewModel.bias);
           ambientOcclusion.uniforms.lengthCap = Number(viewModel.lengthCap);
-          ambientOcclusion.uniforms.stepSize = Number(viewModel.stepSize);
           ambientOcclusion.uniforms.blurStepSize = Number(
             viewModel.blurStepSize
           );

--- a/Apps/Sandcastle/gallery/Ambient Occlusion.html
+++ b/Apps/Sandcastle/gallery/Ambient Occlusion.html
@@ -140,7 +140,7 @@
         var viewModel = {
           show: true,
           ambientOcclusionOnly: false,
-          camFovy: viewer.scene.camera.frustum.fovy,
+          camFovy: Math.PI / 3.0,
           intensity: 10.0,
           bias: 0.1,
           lengthCap: 0.5,

--- a/Apps/Sandcastle/gallery/Ambient Occlusion.html
+++ b/Apps/Sandcastle/gallery/Ambient Occlusion.html
@@ -59,6 +59,18 @@
             </td>
           </tr>
           <tr>
+            <td>Camera Fovy</td>
+            <td>
+              <input
+                type="range"
+                min="1"
+                max="2.0"
+                step="0.01"
+                data-bind="value: camFovy, valueUpdate: 'input'"
+              />
+            </td>
+          </tr>
+          <tr>
             <td>Length Cap</td>
             <td>
               <input
@@ -128,6 +140,7 @@
         var viewModel = {
           show: true,
           ambientOcclusionOnly: false,
+          camFovy: viewer.scene.camera.frustum.fovy,
           intensity: 10.0,
           bias: 0.1,
           lengthCap: 0.5,
@@ -153,6 +166,7 @@
           ambientOcclusion.uniforms.ambientOcclusionOnly = Boolean(
             viewModel.ambientOcclusionOnly
           );
+          ambientOcclusion.uniforms.camFovy = Number(viewModel.camFovy);
           ambientOcclusion.uniforms.intensity = Number(viewModel.intensity);
           ambientOcclusion.uniforms.bias = Number(viewModel.bias);
           ambientOcclusion.uniforms.lengthCap = Number(viewModel.lengthCap);

--- a/Source/Scene/PostProcessStageCollection.js
+++ b/Source/Scene/PostProcessStageCollection.js
@@ -630,6 +630,7 @@ PostProcessStageCollection.prototype.update = function (
     var random = new Uint8Array(length);
     for (i = 0; i < length; i += 3) {
       random[i] = Math.floor(Math.random() * 255.0);
+      random[i + 1] = Math.floor(Math.random() * 255.0);
     }
 
     this._randomTexture = new Texture({

--- a/Source/Scene/PostProcessStageLibrary.js
+++ b/Source/Scene/PostProcessStageLibrary.js
@@ -520,6 +520,7 @@ PostProcessStageLibrary.createAmbientOcclusionStage = function () {
     uniforms: {
       intensity: 3.0,
       bias: 0.1,
+      camFovy: Math.PI / 3.0,
       lengthCap: 0.26,
       frustumLength: 1000.0,
       randomTexture: undefined,
@@ -565,6 +566,14 @@ PostProcessStageLibrary.createAmbientOcclusionStage = function () {
       },
       set: function (value) {
         generate.uniforms.lengthCap = value;
+      },
+    },
+    camFovy: {
+      get: function () {
+        return generate.uniforms.camFovy;
+      },
+      set: function (value) {
+        generate.uniforms.camFovy = value;
       },
     },
     frustumLength: {

--- a/Source/Scene/PostProcessStageLibrary.js
+++ b/Source/Scene/PostProcessStageLibrary.js
@@ -521,7 +521,6 @@ PostProcessStageLibrary.createAmbientOcclusionStage = function () {
       intensity: 3.0,
       bias: 0.1,
       lengthCap: 0.26,
-      stepSize: 1.95,
       frustumLength: 1000.0,
       randomTexture: undefined,
     },
@@ -566,14 +565,6 @@ PostProcessStageLibrary.createAmbientOcclusionStage = function () {
       },
       set: function (value) {
         generate.uniforms.lengthCap = value;
-      },
-    },
-    stepSize: {
-      get: function () {
-        return generate.uniforms.stepSize;
-      },
-      set: function (value) {
-        generate.uniforms.stepSize = value;
       },
     },
     frustumLength: {

--- a/Source/Shaders/PostProcessStages/AmbientOcclusionGenerate.glsl
+++ b/Source/Shaders/PostProcessStages/AmbientOcclusionGenerate.glsl
@@ -1,3 +1,6 @@
+#define NUM_DIRECTIONS 16
+#define NUM_STEPS 16
+
 uniform sampler2D randomTexture;
 uniform sampler2D depthTexture;
 uniform float intensity;
@@ -8,37 +11,73 @@ uniform float frustumLength;
 
 varying vec2 v_textureCoordinates;
 
-vec4 clipToEye(vec2 uv, float depth)
+vec3 clipToEye(vec2 uv, float depth)
 {
     vec2 xy = vec2((uv.x * 2.0 - 1.0), ((1.0 - uv.y) * 2.0 - 1.0));
     vec4 posEC = czm_inverseProjection * vec4(xy, depth, 1.0);
     posEC = posEC / posEC.w;
-    return posEC;
+    return posEC.xyz;
 }
 
-//Reconstruct Normal Without Edge Removation
-vec3 getNormalXEdge(vec3 posInCamera, float depthU, float depthD, float depthL, float depthR, vec2 pixelSize)
-{
-    vec4 posInCameraUp = clipToEye(v_textureCoordinates - vec2(0.0, pixelSize.y), depthU);
-    vec4 posInCameraDown = clipToEye(v_textureCoordinates + vec2(0.0, pixelSize.y), depthD);
-    vec4 posInCameraLeft = clipToEye(v_textureCoordinates - vec2(pixelSize.x, 0.0), depthL);
-    vec4 posInCameraRight = clipToEye(v_textureCoordinates + vec2(pixelSize.x, 0.0), depthR);
+vec3 getMinDepthDiff(vec3 posInCamera, vec2 uvLower, vec2 uvUpper) {
+    float depthLower = czm_readDepth(depthTexture, uvLower);
+    float depthUpper = czm_readDepth(depthTexture, uvUpper);
+    vec3 posLower = clipToEye(uvLower, depthLower);
+    vec3 posUpper = clipToEye(uvUpper, depthUpper);
 
-    vec3 up = posInCamera.xyz - posInCameraUp.xyz;
-    vec3 down = posInCameraDown.xyz - posInCamera.xyz;
-    vec3 left = posInCamera.xyz - posInCameraLeft.xyz;
-    vec3 right = posInCameraRight.xyz - posInCamera.xyz;
+    vec3 vecLower = posInCamera - posLower;
+    vec3 vecUpper = posUpper - posInCamera;
+    return length(vecLower) < length(vecUpper) ? normalize(vecLower) : normalize(vecUpper);
+}
 
-    vec3 DX = length(left) < length(right) ? left : right;
-    vec3 DY = length(up) < length(down) ? up : down;
+float computeDirectionalAO(vec3 posInCamera, vec3 dPdu, vec3 dPdv, vec2 sampleDirection, vec2 pixelSize) {
+    float ao = 0.0;
+    
+    // find tangent angle
+    vec3 T = dPdu * sampleDirection.x + dPdv * sampleDirection.y;
+    float tanT = T.z / length(T.xy) + tan(bias);
+    float sinT = tanT / sqrt(1.0 + tanT * tanT);
 
-    return normalize(cross(DY, DX));
+    // sample AO
+    float prevSinH = sinT;
+    vec2 sampleCoord = v_textureCoordinates;
+    for (int i = 0; i < NUM_STEPS; ++i) {
+        sampleCoord += sampleDirection * stepSize * pixelSize;
+
+        //Exception Handling
+        if(sampleCoord.x > 1.0 || sampleCoord.y > 1.0 || sampleCoord.x < 0.0 || sampleCoord.y < 0.0) 
+        {
+            break;
+        } 
+
+        // find horizon angle
+        float sampleDepth = czm_readDepth(depthTexture, sampleCoord);
+        vec3 samplePos = clipToEye(sampleCoord, sampleDepth);
+        vec3 view = samplePos - posInCamera;
+        float len = length(view);
+        if (len > lengthCap)
+        {
+            break;
+        }
+
+        float tanH = view.z / length(view.xy);
+        float sinH = tanH / sqrt(1.0 + tanH * tanH);
+        if (sinH > prevSinH) {
+            float weight = len / lengthCap;
+            weight = 1.0 - weight * weight;
+
+            ao += (sinH - prevSinH) * weight;
+            prevSinH = sinH;
+        }
+    }
+
+    return ao;
 }
 
 void main(void)
 {
     float depth = czm_readDepth(depthTexture, v_textureCoordinates);
-    vec4 posInCamera = clipToEye(v_textureCoordinates, depth);
+    vec3 posInCamera = clipToEye(v_textureCoordinates, depth);
 
     if (posInCamera.z > frustumLength)
     {
@@ -46,22 +85,26 @@ void main(void)
         return;
     }
 
+    // calculate dPdu, dPdv basis
     vec2 pixelSize = czm_pixelRatio / czm_viewport.zw;
-    float depthU = czm_readDepth(depthTexture, v_textureCoordinates - vec2(0.0, pixelSize.y));
-    float depthD = czm_readDepth(depthTexture, v_textureCoordinates + vec2(0.0, pixelSize.y));
-    float depthL = czm_readDepth(depthTexture, v_textureCoordinates - vec2(pixelSize.x, 0.0));
-    float depthR = czm_readDepth(depthTexture, v_textureCoordinates + vec2(pixelSize.x, 0.0));
-    vec3 normalInCamera = getNormalXEdge(posInCamera.xyz, depthU, depthD, depthL, depthR, pixelSize);
+    vec2 uvTop = v_textureCoordinates + vec2(0.0, pixelSize.y);
+    vec2 uvBot = v_textureCoordinates - vec2(0.0, pixelSize.y);
+    vec2 uvLeft = v_textureCoordinates - vec2(pixelSize.x, 0.0);
+    vec2 uvRight = v_textureCoordinates + vec2(pixelSize.x, 0.0);
 
+    vec3 dPdu = getMinDepthDiff(posInCamera, uvLeft, uvRight);
+    vec3 dPdv = getMinDepthDiff(posInCamera, uvBot, uvTop);
+
+    // calculate AO for current texCoord
     float ao = 0.0;
     vec2 sampleDirection = vec2(1.0, 0.0);
-    float gapAngle = 90.0 * czm_radiansPerDegree;
+    float gapAngle = 2.0 * czm_pi /float(NUM_DIRECTIONS);
 
     // RandomNoise
     float randomVal = texture2D(randomTexture, v_textureCoordinates).x;
 
     //Loop for each direction
-    for (int i = 0; i < 4; i++)
+    for (int i = 0; i < NUM_DIRECTIONS; i++)
     {
         float newGapAngle = gapAngle * (float(i) + randomVal);
         float cosVal = cos(newGapAngle);
@@ -69,46 +112,10 @@ void main(void)
 
         //Rotate Sampling Direction
         vec2 rotatedSampleDirection = vec2(cosVal * sampleDirection.x - sinVal * sampleDirection.y, sinVal * sampleDirection.x + cosVal * sampleDirection.y);
-        float localAO = 0.0;
-        float localStepSize = stepSize;
-
-        //Loop for each step
-        for (int j = 0; j < 6; j++)
-        {
-            vec2 newCoords = v_textureCoordinates + rotatedSampleDirection * localStepSize * pixelSize;
-
-            //Exception Handling
-            if(newCoords.x > 1.0 || newCoords.y > 1.0 || newCoords.x < 0.0 || newCoords.y < 0.0)
-            {
-                break;
-            }
-
-            float stepDepthInfo = czm_readDepth(depthTexture, newCoords);
-            vec4 stepPosInCamera = clipToEye(newCoords, stepDepthInfo);
-            vec3 diffVec = stepPosInCamera.xyz - posInCamera.xyz;
-            float len = length(diffVec);
-
-            if (len > lengthCap)
-            {
-                break;
-            }
-
-            float dotVal = clamp(dot(normalInCamera, normalize(diffVec)), 0.0, 1.0 );
-            float weight = len / lengthCap;
-            weight = 1.0 - weight * weight;
-
-            if (dotVal < bias)
-            {
-                dotVal = 0.0;
-            }
-
-            localAO = max(localAO, dotVal * weight);
-            localStepSize += stepSize;
-        }
-        ao += localAO;
+        ao += computeDirectionalAO(posInCamera, dPdu, dPdv, rotatedSampleDirection, pixelSize);
     }
 
-    ao /= 4.0;
+    ao /= float(NUM_DIRECTIONS * NUM_STEPS);
     ao = 1.0 - clamp(ao, 0.0, 1.0);
     ao = pow(ao, intensity);
     gl_FragColor = vec4(vec3(ao), 1.0);

--- a/Specs/Scene/PostProcessStageLibrarySpec.js
+++ b/Specs/Scene/PostProcessStageLibrarySpec.js
@@ -427,7 +427,6 @@ describe(
       expect(ao.uniforms.intensity).toEqual(3.0);
       expect(ao.uniforms.bias).toEqual(0.1);
       expect(ao.uniforms.lengthCap).toEqual(0.26);
-      expect(ao.uniforms.stepSize).toEqual(1.95);
       expect(ao.uniforms.frustumLength).toEqual(1000.0);
       expect(ao.uniforms.randomTexture).not.toBeDefined();
       expect(ao.uniforms.delta).toEqual(1.0);
@@ -438,7 +437,6 @@ describe(
       ao.uniforms.intensity = 4.0;
       ao.uniforms.bias = 0.2;
       ao.uniforms.lengthCap = 0.3;
-      ao.uniforms.stepSize = 2.0;
       ao.uniforms.frustumLength = 1001.0;
       ao.uniforms.delta = 2.0;
       ao.uniforms.sigma = 3.0;
@@ -448,7 +446,6 @@ describe(
       expect(ao.uniforms.intensity).toEqual(4.0);
       expect(ao.uniforms.bias).toEqual(0.2);
       expect(ao.uniforms.lengthCap).toEqual(0.3);
-      expect(ao.uniforms.stepSize).toEqual(2.0);
       expect(ao.uniforms.frustumLength).toEqual(1001.0);
       expect(ao.uniforms.delta).toEqual(2.0);
       expect(ao.uniforms.sigma).toEqual(3.0);


### PR DESCRIPTION
Re-implement HBAO post-process based on [NVIDIA paper](https://dl.acm.org/doi/pdf/10.1145/1401032.1401061) and [presentation](https://developer.download.nvidia.com/presentations/2008/SIGGRAPH/HBAO_SIG08b.pdf). Below are the results of the new implementation:

<img width="1278" alt="Screen Shot 2020-06-26 at 10 55 21 AM" src="https://user-images.githubusercontent.com/20376598/85871664-bce31000-b79c-11ea-8534-2591f8e61bdb.png">

<img width="902" alt="Screen Shot 2020-06-26 at 10 56 53 AM" src="https://user-images.githubusercontent.com/20376598/85871688-c2d8f100-b79c-11ea-994b-b4e573e7a7fa.png">

@lilleyse can you please take a look at it?