### PR TITLE
Fix tile refinement when leaf is empty

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 - Fixed a bug where certain rhumb arc polylines would lead to a crash. [#8787](https://github.com/CesiumGS/cesium/pull/8787)
 - Fixed handling of Label's backgroundColor and backgroundPadding option [#8949](https://github.com/CesiumGS/cesium/8949)
 - Fixed several bugs when rendering CesiumJS in a WebG 2 context. [#797](https://github.com/CesiumGS/cesium/issues/797)
+- Fixed 3D Tileset replacement refinement when leaf is empty. [#8996](https://github.com/CesiumGS/cesium/8996)
 
 ### 1.70.1 - 2020-06-10
 

--- a/Source/Scene/Cesium3DTilesetTraversal.js
+++ b/Source/Scene/Cesium3DTilesetTraversal.js
@@ -652,11 +652,14 @@ function executeEmptyTraversal(tileset, root, frameState) {
     var childrenLength = children.length;
 
     // Only traverse if the tile is empty - traversal stop at descendants with content
-    var traverse = hasEmptyContent(tile) && canTraverse(tileset, tile);
+    var emptyContent = hasEmptyContent(tile);
+    var traverse = emptyContent && canTraverse(tileset, tile);
+    var emptyLeaf = emptyContent && tile.children.length === 0;
 
-    // Traversal stops but the tile does not have content yet.
-    // There will be holes if the parent tries to refine to its children, so don't refine.
-    if (!traverse && !tile.contentAvailable) {
+    // Traversal stops but the tile does not have content yet
+    // There will be holes if the parent tries to refine to its children, so don't refine
+    // One exception: a parent may refine even if one of its descendants is an empty leaf
+    if (!traverse && !tile.contentAvailable && !emptyLeaf) {
       allDescendantsLoaded = false;
     }
 

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -1411,7 +1411,7 @@ describe(
     });
 
     it("replacement refinement - refines if descendant is empty leaf tile", function () {
-      // Check that the root is refinable once its child is loaded
+      // Check that the root is refinable once its children with content are loaded
       //
       //          C
       //     C  C  C  E

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -1410,6 +1410,32 @@ describe(
       });
     });
 
+    it("replacement refinement - refines if descendant is empty leaf tile", function () {
+      // Check that the root is refinable once its child is loaded
+      //
+      //          C
+      //     C  C  C  E
+      //
+      viewAllTiles();
+      var originalLoadJson = Cesium3DTileset.loadJson;
+      spyOn(Cesium3DTileset, "loadJson").and.callFake(function (tilesetUrl) {
+        return originalLoadJson(tilesetUrl).then(function (tilesetJson) {
+          tilesetJson.root.refine = "REPLACE";
+          tilesetJson.root.children[3].content = undefined;
+          return tilesetJson;
+        });
+      });
+
+      return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function (
+        tileset
+      ) {
+        tileset.skipLevelOfDetail = false;
+        var statistics = tileset._statistics;
+        scene.renderForSpecs();
+        expect(statistics.numberOfCommands).toEqual(3);
+      });
+    });
+
     it("replacement and additive refinement", function () {
       //          A
       //      A       R (not rendered)


### PR DESCRIPTION
We got a support issue about a tileset that doesn't refine property when `skipLevelOfDetail` is false, which is the default since CesiumJS 1.67. The tileset has empty leaf tiles which exposed an edge case in `executeEmptyTraversal` in `Cesium3DTilesetTraversal` in which a tile with empty leaf descendants would not refine. The fix is to refine even if the tile would refine to empty leaf tiles. Note that this only applies to leaf tiles - if there's a tile chain that consists of a content tile, an empty tile, and a content tile, it will wait for the final content tile to load before refining the top-level content tile, which is the main purpose of `executeEmptyTraversal`- to prevent holes from appearing while tiles stream in.

Technically this fix could lead to situations where the parent will refine and there will be holes wherever there's empty leaf tiles, but I think that's acceptable and in the spirit of how the tileset is constructed.

[Local sandcastle with the fix](http://localhost:8080/Apps/Sandcastle/index.html#c=bZLbjtowEEB/xcoTK1ETblmxZVEpFGQEiRYCS1BeEscUgy9ZOxdItf/eBKi0bffJmplzPPKMs0CBjJKcKPAMBMnBiGiacri55mq+ga/xSIokoIIo33j46gtfZKWXUEY0Sf4Wb0d77N6KtV++ACBV7OkPgKRYEi1ThQncK8mHusRQVGs2Hx97nTq4CgAEuOysXXki4gn4BrnMDuEUU4fO0LpATZsijcSyi0fIQqd4uxnNerCE3qLpqYRQvuNLarfWZ2dlnnfHA5u7L0177CWeu+TexTSdqdd2XJwvXl86duHR+WgW78rLnFVOccvO8HRToGMcIj4pcNWMR0fETH2NWxsTX5D1Wvw42wXu2pMqzw5R6S/cdXdRLHJn7LXtrQkt8+07U9za9lIUBvtOYG3RdPllf7CGZncSknZJZkOvGDsL36ie/v5Q98X7fcrXLUCNiSAwVpTThGZEwyCKavfpV+AdK6TkrvxY8IVRN/o6uTAyuI0VgG+Ux1Il1U5qEDYSwmMWJEQ3whSfSAKx1pVaof3GR7Uf0QzQ6PmTPwEwC7QuK/uUsRUtiG8M+o2S/09lMoio+OlkRLHgUmGH5mB+S0II+40y/NxMpGRhoP65+Tc)
[Hosted sancastle](https://sandcastle.cesium.com/#c=bZLbjtowEEB/xcoTK1ETblmxZVEpFGQEiRYCS1BeEscUgy9ZOxdItf/eBKi0bffJmplzPPKMs0CBjJKcKPAMBMnBiGiacri55mq+ga/xSIokoIIo33j46gtfZKWXUEY0Sf4Wb0d77N6KtV++ACBV7OkPgKRYEi1ThQncK8mHusRQVGs2Hx97nTq4CgAEuOysXXki4gn4BrnMDuEUU4fO0LpATZsijcSyi0fIQqd4uxnNerCE3qLpqYRQvuNLarfWZ2dlnnfHA5u7L0177CWeu+TexTSdqdd2XJwvXl86duHR+WgW78rLnFVOccvO8HRToGMcIj4pcNWMR0fETH2NWxsTX5D1Wvw42wXu2pMqzw5R6S/cdXdRLHJn7LXtrQkt8+07U9za9lIUBvtOYG3RdPllf7CGZncSknZJZkOvGDsL36ie/v5Q98X7fcrXLUCNiSAwVpTThGZEwyCKavfpV+AdK6TkrvxY8IVRN/o6uTAyuI0VgG+Ux1Il1U5qEDYSwmMWJEQ3whSfSAKx1pVaof3GR7Uf0QzQ6PmTPwEwC7QuK/uUsRUtiG8M+o2S/09lMoio+OlkRLHgUmGH5mB+S0II+40y/NxMpGRhoP65+Tc)