### PR TITLE
fix: shadowMode cannot apply to i3dm tileset.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -268,3 +268,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Wang Bao](https://github.com/xiaobaogeit)
 - [John Remsberg](https://github.com/easternmotors)
 - [Bao Thien Tran](https://github.com/baothientran)
+- [JiaoJianing](https://github.com/JiaoJianing)

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -305,6 +305,7 @@ function initialize(content, arrayBuffer, byteOffset) {
     sphericalHarmonicCoefficients: tileset.sphericalHarmonicCoefficients,
     specularEnvironmentMaps: tileset.specularEnvironmentMaps,
     backFaceCulling: tileset.backFaceCulling,
+    shadows: tileset.shadows
   };
 
   if (gltfFormat === 0) {


### PR DESCRIPTION
I tried to create a Cesium.Cesium3DTileset with the shadowMode: Cesium.ShadowMode.CAST_ONLY. The tileset contains many trees with i3dm format. But It looks like that shadowMode cannot apply to the tree Model. They will always receive shadow.
I finally find the reason:  the shadowMode did not pass to the Model.