### PR TITLE
Fix bad picking tests

### DIFF
--- a/Specs/Scene/PickingSpec.js
+++ b/Specs/Scene/PickingSpec.js
@@ -208,7 +208,7 @@ describe(
         scene.morphTo2D(0.0);
         camera.setView({ destination: largeRectangle });
         var rectangle = createLargeRectangle(0.0);
-        scene.initializeFrame();
+        scene.renderForSpecs();
         expect(scene).toPickPrimitive(rectangle);
       });
 
@@ -223,7 +223,7 @@ describe(
 
         camera.setView({ destination: largeRectangle });
         var rectangle = createLargeRectangle(0.0);
-        scene.initializeFrame();
+        scene.renderForSpecs();
         expect(scene).toPickPrimitive(rectangle);
       });
     });


### PR DESCRIPTION
`toPickPrimitive` doesn't actually render the scene, just picks the scene at the time it is called.  Because these tests were never actually calling `render`, there was no guarantee that what was being picked was correct depending on the order the tests were run in.  Switch to calling `renderForSpecs` instead of `initializeFrame` to ensure that a render happens.

Fixes #9009 