### PR TITLE
Fix return type of sampleHeightMostDetailed function

### DIFF
--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -4371,7 +4371,7 @@ Scene.prototype.clampToHeight = function (
  * @param {Cartographic[]} positions The cartographic positions to update with sampled heights.
  * @param {Object[]} [objectsToExclude] A list of primitives, entities, or 3D Tiles features to not sample height from.
  * @param {Number} [width=0.1] Width of the intersection volume in meters.
- * @returns {Promise.<Number[]>} A promise that resolves to the provided list of positions when the query has completed.
+ * @returns {Promise.<Cartographic[]>} A promise that resolves to the provided list of positions when the query has completed.
  *
  * @example
  * var positions = [


### PR DESCRIPTION
Change the return type to be array of `Cartographic` objects. Fixes #9013 