### PR TITLE
Fix wall negative height

### DIFF
--- a/Source/Core/WallGeometry.js
+++ b/Source/Core/WallGeometry.js
@@ -437,22 +437,19 @@ WallGeometry.createGeometry = function (wallGeometry) {
     }
 
     if (vertexFormat.normal || vertexFormat.tangent || vertexFormat.bitangent) {
-      var nextPosition;
+      var nextBottomPosition = Cartesian3.clone(
+        Cartesian3.ZERO,
+        scratchCartesian3Position3
+      );
       var nextTop = Cartesian3.clone(
         Cartesian3.ZERO,
         scratchCartesian3Position5
       );
-      var groundPosition = ellipsoid.scaleToGeodeticSurface(
-        Cartesian3.fromArray(topPositions, i3, scratchCartesian3Position2),
-        scratchCartesian3Position2
-      );
+
       if (i + 1 < length) {
-        nextPosition = ellipsoid.scaleToGeodeticSurface(
-          Cartesian3.fromArray(
-            topPositions,
-            i3 + 3,
-            scratchCartesian3Position3
-          ),
+        nextBottomPosition = Cartesian3.fromArray(
+          bottomPositions,
+          i3 + 3,
           scratchCartesian3Position3
         );
         nextTop = Cartesian3.fromArray(
@@ -468,13 +465,13 @@ WallGeometry.createGeometry = function (wallGeometry) {
           topPosition,
           scratchCartesian3Position4
         );
-        var scaledGroundPosition = Cartesian3.subtract(
-          groundPosition,
+        var scaledBottomPosition = Cartesian3.subtract(
+          bottomPosition,
           topPosition,
           scratchCartesian3Position1
         );
         normal = Cartesian3.normalize(
-          Cartesian3.cross(scaledGroundPosition, scalednextPosition, normal),
+          Cartesian3.cross(scaledBottomPosition, scalednextPosition, normal),
           normal
         );
         recomputeNormal = false;
@@ -482,8 +479,8 @@ WallGeometry.createGeometry = function (wallGeometry) {
 
       if (
         Cartesian3.equalsEpsilon(
-          nextPosition,
-          groundPosition,
+          bottomPosition,
+          nextBottomPosition,
           CesiumMath.EPSILON10
         )
       ) {
@@ -492,7 +489,7 @@ WallGeometry.createGeometry = function (wallGeometry) {
         s += ds;
         if (vertexFormat.tangent) {
           tangent = Cartesian3.normalize(
-            Cartesian3.subtract(nextPosition, groundPosition, tangent),
+            Cartesian3.subtract(nextBottomPosition, bottomPosition, tangent),
             tangent
           );
         }

--- a/Source/Core/WallGeometry.js
+++ b/Source/Core/WallGeometry.js
@@ -348,12 +348,6 @@ WallGeometry.fromConstantHeights = function (options) {
   return new WallGeometry(newOptions);
 };
 
-function initNormalTangentBitangent(normal, tangent, bitangent) {
-  Cartesian3.clone(Cartesian3.UNIT_X, tangent);
-  Cartesian3.clone(Cartesian3.UNIT_Y, normal);
-  Cartesian3.clone(Cartesian3.UNIT_Z, bitangent);
-}
-
 function calculateDirection(p0, p1, result) {
   if (Cartesian3.equalsEpsilon(p0, p1, CesiumMath.EPSILON10)) {
     return false;
@@ -537,10 +531,9 @@ WallGeometry.createGeometry = function (wallGeometry) {
   var topToBottom = scratchCartesian3Position4;
   var topToNextTop = scratchCartesian3Position5;
 
-  var normal = scratchNormal;
-  var tangent = scratchTangent;
-  var bitangent = scratchBitangent;
-  initNormalTangentBitangent(normal, tangent, bitangent);
+  var normal = Cartesian3.clone(Cartesian3.UNIT_Y, scratchNormal);
+  var tangent = Cartesian3.clone(Cartesian3.UNIT_X, scratchTangent);
+  var bitangent = Cartesian3.clone(Cartesian3.UNIT_Z, scratchBitangent);
 
   var isWallCorner = false;
   var validNormal = false;

--- a/Source/Core/WallGeometry.js
+++ b/Source/Core/WallGeometry.js
@@ -557,7 +557,7 @@ WallGeometry.createGeometry = function (wallGeometry) {
         CesiumMath.EPSILON10
       );
 
-      if (!validNormal || isWallCorner) {
+      if (!validNormal) {
         validNormal = calculateNormal(
           topPosition,
           bottomPosition,
@@ -568,13 +568,15 @@ WallGeometry.createGeometry = function (wallGeometry) {
         );
       }
 
-      if (validNormal && !isWallCorner) {
-        if (vertexFormat.tangent || vertexFormat.bitangent) {
-          tangent = Cartesian3.normalize(
-            Cartesian3.subtract(nextBottomPosition, bottomPosition, tangent),
-            tangent
-          );
-        }
+      if (isWallCorner) {
+        validNormal = false;
+      }
+
+      if (validNormal && (vertexFormat.tangent || vertexFormat.bitangent)) {
+        tangent = Cartesian3.normalize(
+          Cartesian3.subtract(nextBottomPosition, bottomPosition, tangent),
+          tangent
+        );
 
         if (vertexFormat.bitangent) {
           bitangent = Cartesian3.normalize(

--- a/Source/Core/WallGeometryLibrary.js
+++ b/Source/Core/WallGeometryLibrary.js
@@ -29,7 +29,6 @@ function removeDuplicates(ellipsoid, positions, topHeights, bottomHeights) {
 
   var hasBottomHeights = defined(bottomHeights);
   var hasTopHeights = defined(topHeights);
-  var hasAllZeroHeights = true;
 
   var cleanedPositions = new Array(length);
   var cleanedTopHeights = new Array(length);
@@ -42,8 +41,6 @@ function removeDuplicates(ellipsoid, positions, topHeights, bottomHeights) {
   if (hasTopHeights) {
     c0.height = topHeights[0];
   }
-
-  hasAllZeroHeights = hasAllZeroHeights && c0.height <= 0;
 
   cleanedTopHeights[0] = c0.height;
 
@@ -60,7 +57,6 @@ function removeDuplicates(ellipsoid, positions, topHeights, bottomHeights) {
     if (hasTopHeights) {
       c1.height = topHeights[i];
     }
-    hasAllZeroHeights = hasAllZeroHeights && c1.height <= 0;
 
     if (!latLonEquals(c0, c1)) {
       cleanedPositions[index] = v1; // Shallow copy!
@@ -79,7 +75,7 @@ function removeDuplicates(ellipsoid, positions, topHeights, bottomHeights) {
     }
   }
 
-  if (hasAllZeroHeights || index < 2) {
+  if (index < 2) {
     return;
   }
 

--- a/Source/Core/WallGeometryLibrary.js
+++ b/Source/Core/WallGeometryLibrary.js
@@ -50,6 +50,8 @@ function removeDuplicates(ellipsoid, positions, topHeights, bottomHeights) {
     cleanedBottomHeights[0] = 0.0;
   }
 
+  var wallHeight = Math.abs(cleanedTopHeights[0] - cleanedBottomHeights[0]);
+  var hasAllZeroHeights = wallHeight < CesiumMath.EPSILON10;
   var index = 1;
   for (var i = 1; i < length; ++i) {
     var v1 = positions[i];
@@ -68,14 +70,25 @@ function removeDuplicates(ellipsoid, positions, topHeights, bottomHeights) {
         cleanedBottomHeights[index] = 0.0;
       }
 
+      wallHeight = Math.abs(
+        cleanedTopHeights[index] - cleanedBottomHeights[index]
+      );
+      hasAllZeroHeights =
+        hasAllZeroHeights && wallHeight < CesiumMath.EPSILON10;
+
       Cartographic.clone(c1, c0);
       ++index;
     } else if (c0.height < c1.height) {
       cleanedTopHeights[index - 1] = c1.height;
+      wallHeight = Math.abs(
+        cleanedTopHeights[index - 1] - cleanedBottomHeights[index - 1]
+      );
+      hasAllZeroHeights =
+        hasAllZeroHeights && wallHeight < CesiumMath.EPSILON10;
     }
   }
 
-  if (index < 2) {
+  if (hasAllZeroHeights || index < 2) {
     return;
   }
 

--- a/Source/Core/WallGeometryLibrary.js
+++ b/Source/Core/WallGeometryLibrary.js
@@ -26,7 +26,6 @@ function removeDuplicates(ellipsoid, positions, topHeights, bottomHeights) {
   if (length < 2) {
     return;
   }
-
   var hasBottomHeights = defined(bottomHeights);
   var hasTopHeights = defined(topHeights);
 
@@ -35,13 +34,12 @@ function removeDuplicates(ellipsoid, positions, topHeights, bottomHeights) {
   var cleanedBottomHeights = new Array(length);
 
   var v0 = positions[0];
-  cleanedPositions[0] = v0;
-
   var c0 = ellipsoid.cartesianToCartographic(v0, scratchCartographic1);
   if (hasTopHeights) {
     c0.height = topHeights[0];
   }
 
+  cleanedPositions[0] = v0;
   cleanedTopHeights[0] = c0.height;
 
   if (hasBottomHeights) {
@@ -50,10 +48,9 @@ function removeDuplicates(ellipsoid, positions, topHeights, bottomHeights) {
     cleanedBottomHeights[0] = 0.0;
   }
 
-  var wallHeight = Math.abs(cleanedTopHeights[0] - cleanedBottomHeights[0]);
-  var hasAllZeroHeights = wallHeight < CesiumMath.EPSILON10;
   var index = 1;
-  for (var i = 1; i < length; ++i) {
+  var i;
+  for (i = 1; i < length; ++i) {
     var v1 = positions[i];
     var c1 = ellipsoid.cartesianToCartographic(v1, scratchCartographic2);
     if (hasTopHeights) {
@@ -70,25 +67,25 @@ function removeDuplicates(ellipsoid, positions, topHeights, bottomHeights) {
         cleanedBottomHeights[index] = 0.0;
       }
 
-      wallHeight = Math.abs(
-        cleanedTopHeights[index] - cleanedBottomHeights[index]
-      );
-      hasAllZeroHeights =
-        hasAllZeroHeights && wallHeight < CesiumMath.EPSILON10;
-
       Cartographic.clone(c1, c0);
       ++index;
     } else if (c0.height < c1.height) {
       cleanedTopHeights[index - 1] = c1.height;
-      wallHeight = Math.abs(
-        cleanedTopHeights[index - 1] - cleanedBottomHeights[index - 1]
-      );
-      hasAllZeroHeights =
-        hasAllZeroHeights && wallHeight < CesiumMath.EPSILON10;
     }
   }
 
-  if (hasAllZeroHeights || index < 2) {
+  var zeroHeightCount = 0;
+  for (i = 0; i < index; ++i) {
+    var topHeight = cleanedTopHeights[i];
+    var bottomHeight = cleanedBottomHeights[i];
+    zeroHeightCount += CesiumMath.equalsEpsilon(
+      topHeight,
+      bottomHeight,
+      CesiumMath.EPSILON10
+    );
+  }
+
+  if (zeroHeightCount === index || index < 2) {
     return;
   }
 

--- a/Specs/Core/WallGeometrySpec.js
+++ b/Specs/Core/WallGeometrySpec.js
@@ -82,6 +82,53 @@ describe("Core/WallGeometry", function () {
     expect(geometry).toBeUndefined();
   });
 
+  it("does not create when minimumHeights and maximumHeights are the same", function () {
+    var geometry = WallGeometry.createGeometry(
+      new WallGeometry({
+        positions: Cartesian3.fromDegreesArrayHeights([
+          -115.0,
+          44.0,
+          100000.0,
+          -90.0,
+          44.0,
+          200000.0,
+          -30.0,
+          44.0,
+          200000.0,
+        ]),
+        maximumHeights: [60000.0, 60000.0, 50000.0],
+        minimumHeights: [60000.0, 60000.0, 50000.0],
+      })
+    );
+
+    expect(geometry).toBeUndefined();
+  });
+
+  it("does not create when removing duplicated position results in minimumHeights and maximumHeights are the same", function () {
+    var geometry = WallGeometry.createGeometry(
+      new WallGeometry({
+        positions: Cartesian3.fromDegreesArrayHeights([
+          -115.0,
+          44.0,
+          200000.0,
+          -115.0,
+          44.0,
+          100000.0,
+          -90.0,
+          44.0,
+          200000.0,
+          -30.0,
+          44.0,
+          200000.0,
+        ]),
+        maximumHeights: [40000.0, 60000.0, 60000.0, 50000.0],
+        minimumHeights: [60000.0, 60000.0, 60000.0, 50000.0],
+      })
+    );
+
+    expect(geometry).toBeUndefined();
+  });
+
   it("does not throw when positions are unique but close", function () {
     WallGeometry.createGeometry(
       new WallGeometry({
@@ -238,7 +285,6 @@ describe("Core/WallGeometry", function () {
     Cartesian3.normalize(expectedNormal, expectedNormal);
 
     for (var i = 0; i < normals.length; i += 3) {
-      console.log(normals);
       expect(normals[i]).toEqualEpsilon(expectedNormal.x, CesiumMath.EPSILON7);
       expect(normals[i + 1]).toEqualEpsilon(
         expectedNormal.y,


### PR DESCRIPTION
Fixes #4274 

Currently there is a check to prevent maxHeights from being negative in the function `removeDuplicates()` in WallGeometryLibrary.js file. I remove it, and walls with negative height are rendered correctly. But with the old method when the first member of maximumHeights array is equal to 0.0, normal vector can't be calculated. It's because vertices of the geometry are clamped to the earth's surface first before being used to calculate normal. So when the vertices themselves are on the surface, they and the clamped values have the same coordinates, which leads to undefined normal vectors. for example, there is an exception thrown when running this [Sandcastle example](http://localhost:8080/Apps/Sandcastle/index.html#c=jZLPT8IwFID/lZedRgIdEzyIg2jAxIOJCRo9MA5le0Bjf5C2G4Lhf7fdIC7IgR26vtfve2v7VlINJcMtahiCxC2M0bBCkI8qF6ZBVsVjJS1lEnUatO5TmcrSeRrzT8q5E+sKBKVllqEhNM/Dn1QCSCpwAGkwxRy2nqUW1shWa5sGbQ/45AAqFmCjjPOVNIPTNsZUWzejskeWWokJrjSiedSa7p6rMiac1S5AJ45vSbd9Cvv9RnDT9U8j0bnrXs/2rmXnreNE0G8mCnHc4wBmnqlo/46P1vxEM3mBjmu4yVGLmlH+dz2KK02mT5MKOLjxcGxP3ZC9UuJdhWft8UjQDhJjdxxHp6M8MLFR2kKheUhIZFFsuPueiRZF9oWWZKYSPZpETTXJWQksH174VyDj1Bi3siw4f2N7TINREjn+n8oVzZlcvZaoOd15bB2PXuokISSJXHjZtErxBdVnlX8B). I'm not sure if we should let maximumHeight == minimumHeight. But since it works with value other than 0.0 in the master branch, I think I should fix it as well.

For the undefined normal vector problem above, instead of clamping the top vertex to the earth surface, I use the bottom vertex to calculate normal. If the top and bottom positions have the same coordinates at the beginning (aka maximumHeight[0] == minimumHeights[0]), I just assign Y_Axis to normal, X_Axis to tangent, and Z_Axis to bitangent. If the top and bottom positions in the middle of the wall are overlapped, I just assigned the last valid normal to it. Same with tangent and bitangent. So that should prevent all of those vectors from having zero length, which leads to the error above. I had to cleanup the WallGeometry.createGeometry() method more than I expected to accommodate the changes better. Please let me know if you have a better way.

There is also a bug where texture coordinate seems to be larger than 1.0 for [this sandcastle's example](http://localhost:8080/Apps/Sandcastle/index.html?src=development%2FGeometry%20and%20Appearances.html). This is the wall with checkerboard texture rendered in the master branch:

<img width="1280" alt="Screen Shot 2020-07-07 at 10 43 32 PM" src="https://user-images.githubusercontent.com/20376598/86868893-92019180-c0a3-11ea-9780-1cfaa8612c4f.png">

This is the fix in the PR:

<img width="1276" alt="Screen Shot 2020-07-07 at 10 45 03 PM" src="https://user-images.githubusercontent.com/20376598/86868906-96c64580-c0a3-11ea-83df-db3ebd18e40b.png">

@hpinkos @lilleyse Can you please take a look at it? Please let me know if there are anything I need to test