### PR TITLE
Fix camera's unexpected transition when flying at negative height

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 - Fixed 3D Tileset replacement refinement when leaf is empty. [#8996](https://github.com/CesiumGS/cesium/8996)
 
+##### Additions :tada:
+
+- Added maximumStraightFlyRadius option to Camera.flyTo() function. The option specifies the radius of an imaginary sphere with the destination as a center. Within the sphere, the camera will fly straight to the destination. [#9025](https://github.com/CesiumGS/cesium/pull/9025)
+
 ### 1.71 - 2020-07-01
 
 ##### Breaking Changes :mega:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,13 +2,13 @@
 
 ### 1.72 - 2020-08-03
 
-##### Fixes :wrench:
-
-- Fixed 3D Tileset replacement refinement when leaf is empty. [#8996](https://github.com/CesiumGS/cesium/8996)
-
 ##### Additions :tada:
 
 - Added maximumStraightFlyRadius option to Camera.flyTo() function. The option specifies the radius of an imaginary sphere with the destination as a center. Within the sphere, the camera will fly straight to the destination. [#9025](https://github.com/CesiumGS/cesium/pull/9025)
+
+##### Fixes :wrench:
+
+- Fixed 3D Tileset replacement refinement when leaf is empty. [#8996](https://github.com/CesiumGS/cesium/8996)
 
 ### 1.71 - 2020-07-01
 

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -3219,6 +3219,7 @@ Camera.prototype.completeFlight = function () {
  * @param {Camera.FlightCancelledCallback} [options.cancel] The function to execute if the flight is cancelled.
  * @param {Matrix4} [options.endTransform] Transform matrix representing the reference frame the camera will be in when the flight is completed.
  * @param {Number} [options.maximumHeight] The maximum height at the peak of the flight.
+ * @param {Number} [options.maxGroundDistance] The maximum ground distance to let the camera fly straight to the destination.
  * @param {Number} [options.pitchAdjustHeight] If camera flyes higher than that value, adjust pitch duiring the flight to look down, and keep Earth in viewport.
  * @param {Number} [options.flyOverLongitude] There are always two ways between 2 points on globe. This option force camera to choose fight direction to fly over that longitude.
  * @param {Number} [options.flyOverLongitudeWeight] Fly over the lon specifyed via flyOverLongitude only if that way is not longer than short way times flyOverLongitudeWeight.
@@ -3329,6 +3330,7 @@ Camera.prototype.flyTo = function (options) {
   newOptions.endTransform = options.endTransform;
   newOptions.convert = isRectangle ? false : options.convert;
   newOptions.maximumHeight = options.maximumHeight;
+  newOptions.maxGroundDistance = options.maxGroundDistance;
   newOptions.pitchAdjustHeight = options.pitchAdjustHeight;
   newOptions.flyOverLongitude = options.flyOverLongitude;
   newOptions.flyOverLongitudeWeight = options.flyOverLongitudeWeight;

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -3219,7 +3219,7 @@ Camera.prototype.completeFlight = function () {
  * @param {Camera.FlightCancelledCallback} [options.cancel] The function to execute if the flight is cancelled.
  * @param {Matrix4} [options.endTransform] Transform matrix representing the reference frame the camera will be in when the flight is completed.
  * @param {Number} [options.maximumHeight] The maximum height at the peak of the flight.
- * @param {Number} [options.maxGroundDistance] The maximum ground distance to let the camera fly straight to the destination.
+ * @param {Number} [options.maximumStraightFlyRadius] The maximum radius within which the camera flies straight to the destination.
  * @param {Number} [options.pitchAdjustHeight] If camera flyes higher than that value, adjust pitch duiring the flight to look down, and keep Earth in viewport.
  * @param {Number} [options.flyOverLongitude] There are always two ways between 2 points on globe. This option force camera to choose fight direction to fly over that longitude.
  * @param {Number} [options.flyOverLongitudeWeight] Fly over the lon specifyed via flyOverLongitude only if that way is not longer than short way times flyOverLongitudeWeight.
@@ -3330,7 +3330,7 @@ Camera.prototype.flyTo = function (options) {
   newOptions.endTransform = options.endTransform;
   newOptions.convert = isRectangle ? false : options.convert;
   newOptions.maximumHeight = options.maximumHeight;
-  newOptions.maxGroundDistance = options.maxGroundDistance;
+  newOptions.maximumStraightFlyRadius = options.maximumStraightFlyRadius;
   newOptions.pitchAdjustHeight = options.pitchAdjustHeight;
   newOptions.flyOverLongitude = options.flyOverLongitude;
   newOptions.flyOverLongitudeWeight = options.flyOverLongitudeWeight;

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -3219,7 +3219,7 @@ Camera.prototype.completeFlight = function () {
  * @param {Camera.FlightCancelledCallback} [options.cancel] The function to execute if the flight is cancelled.
  * @param {Matrix4} [options.endTransform] Transform matrix representing the reference frame the camera will be in when the flight is completed.
  * @param {Number} [options.maximumHeight] The maximum height at the peak of the flight.
- * @param {Number} [options.maximumStraightFlyRadius] The maximum radius within which the camera flies straight to the destination.
+ * @param {Number} [options.maximumStraightFlightDistance=3000.0] The maximum distance within which the camera flies straight to the destination instead of following a parabolic arc.
  * @param {Number} [options.pitchAdjustHeight] If camera flyes higher than that value, adjust pitch duiring the flight to look down, and keep Earth in viewport.
  * @param {Number} [options.flyOverLongitude] There are always two ways between 2 points on globe. This option force camera to choose fight direction to fly over that longitude.
  * @param {Number} [options.flyOverLongitudeWeight] Fly over the lon specifyed via flyOverLongitude only if that way is not longer than short way times flyOverLongitudeWeight.
@@ -3330,7 +3330,8 @@ Camera.prototype.flyTo = function (options) {
   newOptions.endTransform = options.endTransform;
   newOptions.convert = isRectangle ? false : options.convert;
   newOptions.maximumHeight = options.maximumHeight;
-  newOptions.maximumStraightFlyRadius = options.maximumStraightFlyRadius;
+  newOptions.maximumStraightFlightDistance =
+    options.maximumStraightFlightDistance;
   newOptions.pitchAdjustHeight = options.pitchAdjustHeight;
   newOptions.flyOverLongitude = options.flyOverLongitude;
   newOptions.flyOverLongitudeWeight = options.flyOverLongitudeWeight;
@@ -3489,6 +3490,7 @@ var scratchFlyToBoundingSphereMatrix3 = new Matrix3();
  * @param {Camera.FlightCancelledCallback} [options.cancel] The function to execute if the flight is cancelled.
  * @param {Matrix4} [options.endTransform] Transform matrix representing the reference frame the camera will be in when the flight is completed.
  * @param {Number} [options.maximumHeight] The maximum height at the peak of the flight.
+ * @param {Number} [options.maximumStraightFlightDistance=3000.0] The maximum distance within which the camera flies straight to the destination instead of following a parabolic arc.
  * @param {Number} [options.pitchAdjustHeight] If camera flyes higher than that value, adjust pitch duiring the flight to look down, and keep Earth in viewport.
  * @param {Number} [options.flyOverLongitude] There are always two ways between 2 points on globe. This option force camera to choose fight direction to fly over that longitude.
  * @param {Number} [options.flyOverLongitudeWeight] Fly over the lon specifyed via flyOverLongitude only if that way is not longer than short way times flyOverLongitudeWeight.
@@ -3583,6 +3585,7 @@ Camera.prototype.flyToBoundingSphere = function (boundingSphere, options) {
     cancel: options.cancel,
     endTransform: options.endTransform,
     maximumHeight: options.maximumHeight,
+    maximumStraightFlightDistance: options.maximumStraightFlightDistance,
     easingFunction: options.easingFunction,
     flyOverLongitude: options.flyOverLongitude,
     flyOverLongitudeWeight: options.flyOverLongitudeWeight,

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -2434,7 +2434,7 @@ function rectangleCameraPosition3D(camera, rectangle, result, updateCamera) {
   // even look for this case in optimized builds, so we have to test for it here instead.
   //
   // Fortunately, this case can only happen (here) when north is very close to the north pole and south is very close to the south pole,
-  // so handle it just by using 0 latitude as the center.  It's certainliy possible to use a smaller tolerance
+  // so handle it just by using 0 latitude as the center.  It's certainly possible to use a smaller tolerance
   // than one degree here, but one degree is safe and putting the center at 0 latitude should be good enough for any
   // rectangle that spans 178+ of the 180 degrees of latitude.
   var longitude = (west + east) * 0.5;
@@ -3220,9 +3220,9 @@ Camera.prototype.completeFlight = function () {
  * @param {Matrix4} [options.endTransform] Transform matrix representing the reference frame the camera will be in when the flight is completed.
  * @param {Number} [options.maximumHeight] The maximum height at the peak of the flight.
  * @param {Number} [options.maximumStraightFlightDistance=3000.0] The maximum distance within which the camera flies straight to the destination instead of following a parabolic arc.
- * @param {Number} [options.pitchAdjustHeight] If camera flyes higher than that value, adjust pitch duiring the flight to look down, and keep Earth in viewport.
+ * @param {Number} [options.pitchAdjustHeight] If camera flies higher than that value, adjust pitch during the flight to look down, and keep Earth in viewport.
  * @param {Number} [options.flyOverLongitude] There are always two ways between 2 points on globe. This option force camera to choose fight direction to fly over that longitude.
- * @param {Number} [options.flyOverLongitudeWeight] Fly over the lon specifyed via flyOverLongitude only if that way is not longer than short way times flyOverLongitudeWeight.
+ * @param {Number} [options.flyOverLongitudeWeight] Fly over the lon specified via flyOverLongitude only if that way is not longer than short way times flyOverLongitudeWeight.
  * @param {Boolean} [options.convert] Whether to convert the destination from world coordinates to scene coordinates (only relevant when not using 3D). Defaults to <code>true</code>.
  * @param {EasingFunction.Callback} [options.easingFunction] Controls how the time is interpolated over the duration of the flight.
  *
@@ -3491,9 +3491,9 @@ var scratchFlyToBoundingSphereMatrix3 = new Matrix3();
  * @param {Matrix4} [options.endTransform] Transform matrix representing the reference frame the camera will be in when the flight is completed.
  * @param {Number} [options.maximumHeight] The maximum height at the peak of the flight.
  * @param {Number} [options.maximumStraightFlightDistance=3000.0] The maximum distance within which the camera flies straight to the destination instead of following a parabolic arc.
- * @param {Number} [options.pitchAdjustHeight] If camera flyes higher than that value, adjust pitch duiring the flight to look down, and keep Earth in viewport.
+ * @param {Number} [options.pitchAdjustHeight] If camera flies higher than that value, adjust pitch during the flight to look down, and keep Earth in viewport.
  * @param {Number} [options.flyOverLongitude] There are always two ways between 2 points on globe. This option force camera to choose fight direction to fly over that longitude.
- * @param {Number} [options.flyOverLongitudeWeight] Fly over the lon specifyed via flyOverLongitude only if that way is not longer than short way times flyOverLongitudeWeight.
+ * @param {Number} [options.flyOverLongitudeWeight] Fly over the lon specified via flyOverLongitude only if that way is not longer than short way times flyOverLongitudeWeight.
  * @param {EasingFunction.Callback} [options.easingFunction] Controls how the time is interpolated over the duration of the flight.
  */
 Camera.prototype.flyToBoundingSphere = function (boundingSphere, options) {

--- a/Source/Scene/CameraFlightPath.js
+++ b/Source/Scene/CameraFlightPath.js
@@ -174,9 +174,12 @@ function createUpdateCV(
   heading,
   pitch,
   roll,
-  optionAltitude
+  optionAltitude,
+  optionMaxGroundDistance
 ) {
   var camera = scene.camera;
+  var projection = scene.mapProjection;
+  var ellipsoid = projection.ellipsoid;
 
   var start = Cartesian3.clone(camera.position, scratchStart);
   var startPitch = camera.pitch;
@@ -184,11 +187,13 @@ function createUpdateCV(
   var startRoll = adjustAngleForLERP(camera.roll, roll);
 
   var heightFunction = createHeightFunction(
+    ellipsoid,
     camera,
     destination,
     start.z,
     destination.z,
-    optionAltitude
+    optionAltitude,
+    optionMaxGroundDistance
   );
 
   function update(value) {
@@ -236,6 +241,7 @@ function createUpdate3D(
   pitch,
   roll,
   optionAltitude,
+  optionMaxGroundDistance,
   optionFlyOverLongitude,
   optionFlyOverLongitudeWeight,
   optionPitchAdjustHeight
@@ -298,7 +304,8 @@ function createUpdate3D(
     destination,
     startCart.height,
     destCart.height,
-    optionAltitude
+    optionAltitude,
+    optionMaxGroundDistance
   );
   var pitchFunction = createPitchFunction(
     startPitch,
@@ -347,20 +354,25 @@ function createUpdate2D(
   heading,
   pitch,
   roll,
-  optionAltitude
+  optionAltitude,
+  optionMaxGroundDistance
 ) {
   var camera = scene.camera;
+  var projection = scene.mapProjection;
+  var ellipsoid = projection.ellipsoid;
 
   var start = Cartesian3.clone(camera.position, scratchStart);
   var startHeading = adjustAngleForLERP(camera.heading, heading);
 
   var startHeight = camera.frustum.right - camera.frustum.left;
   var heightFunction = createHeightFunction(
+    ellipsoid,
     camera,
     destination,
     startHeight,
     destination.z,
-    optionAltitude
+    optionAltitude,
+    optionMaxGroundDistance
   );
 
   function update(value) {
@@ -434,6 +446,7 @@ CameraFlightPath.createTween = function (scene, options) {
   var projection = scene.mapProjection;
   var ellipsoid = projection.ellipsoid;
   var maximumHeight = options.maximumHeight;
+  var maxGroundDistance = options.maxGroundDistance;
   var flyOverLongitude = options.flyOverLongitude;
   var flyOverLongitudeWeight = options.flyOverLongitudeWeight;
   var pitchAdjustHeight = options.pitchAdjustHeight;
@@ -528,6 +541,7 @@ CameraFlightPath.createTween = function (scene, options) {
         pitch,
         roll,
         maximumHeight,
+        maxGroundDistance,
         flyOverLongitude,
         flyOverLongitudeWeight,
         pitchAdjustHeight
@@ -549,6 +563,7 @@ CameraFlightPath.createTween = function (scene, options) {
     pitch,
     roll,
     maximumHeight,
+    maxGroundDistance,
     flyOverLongitude,
     flyOverLongitudeWeight,
     pitchAdjustHeight

--- a/Source/Scene/CameraFlightPath.js
+++ b/Source/Scene/CameraFlightPath.js
@@ -19,6 +19,10 @@ import SceneMode from "./SceneMode.js";
  */
 var CameraFlightPath = {};
 
+/**
+ * More details about the math behind this function is in
+ * https://github.com/CesiumGS/cesium/issues/8610#issuecomment-656137112
+ */
 function getAltitude(frustum, dx, dy) {
   var near;
   var top;

--- a/Source/Scene/CameraFlightPath.js
+++ b/Source/Scene/CameraFlightPath.js
@@ -19,11 +19,9 @@ import SceneMode from "./SceneMode.js";
  */
 var CameraFlightPath = {};
 
-/**
- * More details about the math behind this function is in
- * https://github.com/CesiumGS/cesium/issues/8610#issuecomment-656137112
- */
 function getAltitude(frustum, dx, dy) {
+  // More details about the math behind this function is in
+  // https://github.com/CesiumGS/cesium/issues/8610#issuecomment-656137112
   var near;
   var top;
   var right;

--- a/Source/Scene/CameraFlightPath.js
+++ b/Source/Scene/CameraFlightPath.js
@@ -80,9 +80,12 @@ function createHeightFunction(
   startHeight,
   endHeight,
   optionAltitude,
-  optionMaxStraightFlyRadius
+  optionMaxStraightFlightDistance
 ) {
-  var maxStraightFlyRadius = defaultValue(optionMaxStraightFlyRadius, 3000.0);
+  var maxStraightFlightDistance = defaultValue(
+    optionMaxStraightFlightDistance,
+    3000.0
+  );
   var altitude = optionAltitude;
   var maxHeight = Math.max(startHeight, endHeight);
   var start = camera.position;
@@ -112,7 +115,7 @@ function createHeightFunction(
     );
   }
 
-  if (distance > maxStraightFlyRadius && maxHeight < altitude) {
+  if (distance > maxStraightFlightDistance && maxHeight < altitude) {
     var power = 8.0;
     var factor = 1000000.0;
 
@@ -160,7 +163,7 @@ function createUpdateCV(
   pitch,
   roll,
   optionAltitude,
-  optionMaxStraightFlyRadius
+  optionMaxStraightFlightDistance
 ) {
   var camera = scene.camera;
 
@@ -175,7 +178,7 @@ function createUpdateCV(
     start.z,
     destination.z,
     optionAltitude,
-    optionMaxStraightFlyRadius
+    optionMaxStraightFlightDistance
   );
 
   function update(value) {
@@ -223,7 +226,7 @@ function createUpdate3D(
   pitch,
   roll,
   optionAltitude,
-  optionMaxStraightFlyRadius,
+  optionMaxStraightFlightDistance,
   optionFlyOverLongitude,
   optionFlyOverLongitudeWeight,
   optionPitchAdjustHeight
@@ -286,7 +289,7 @@ function createUpdate3D(
     startCart.height,
     destCart.height,
     optionAltitude,
-    optionMaxStraightFlyRadius
+    optionMaxStraightFlightDistance
   );
   var pitchFunction = createPitchFunction(
     startPitch,
@@ -336,7 +339,7 @@ function createUpdate2D(
   pitch,
   roll,
   optionAltitude,
-  optionMaxStraightFlyRadius
+  optionMaxStraightFlightDistance
 ) {
   var camera = scene.camera;
 
@@ -350,7 +353,7 @@ function createUpdate2D(
     startHeight,
     destination.z,
     optionAltitude,
-    optionMaxStraightFlyRadius
+    optionMaxStraightFlightDistance
   );
 
   function update(value) {
@@ -424,7 +427,7 @@ CameraFlightPath.createTween = function (scene, options) {
   var projection = scene.mapProjection;
   var ellipsoid = projection.ellipsoid;
   var maximumHeight = options.maximumHeight;
-  var maxStraightFlyRadius = options.maximumStraightFlyRadius;
+  var maximumStraightFlightDistance = options.maximumStraightFlightDistance;
   var flyOverLongitude = options.flyOverLongitude;
   var flyOverLongitudeWeight = options.flyOverLongitudeWeight;
   var pitchAdjustHeight = options.pitchAdjustHeight;
@@ -519,7 +522,7 @@ CameraFlightPath.createTween = function (scene, options) {
         pitch,
         roll,
         maximumHeight,
-        maxStraightFlyRadius,
+        maximumStraightFlightDistance,
         flyOverLongitude,
         flyOverLongitudeWeight,
         pitchAdjustHeight
@@ -541,7 +544,7 @@ CameraFlightPath.createTween = function (scene, options) {
     pitch,
     roll,
     maximumHeight,
-    maxStraightFlyRadius,
+    maximumStraightFlightDistance,
     flyOverLongitude,
     flyOverLongitudeWeight,
     pitchAdjustHeight

--- a/Source/Scene/CameraFlightPath.js
+++ b/Source/Scene/CameraFlightPath.js
@@ -20,8 +20,10 @@ import SceneMode from "./SceneMode.js";
 var CameraFlightPath = {};
 
 function getAltitude(frustum, dx, dy) {
-  // More details about the math behind this function is in
-  // https://github.com/CesiumGS/cesium/issues/8610#issuecomment-656137112
+  // Calculate the necessary altitude for the camera from the start position,
+  // so that the destination will appear on the screen. The function assumes
+  // top-down view and the camera's height is positive. It is an approximation
+  // and minor inaccuracies are neglected
   var near;
   var top;
   var right;


### PR DESCRIPTION
Fixes #8610

I added `maximumStraightFlyRadius` option to function `Camera.flyTo()`. The option specify the radius of an imaginary sphere with the destination point as a center. If camera is inside this sphere, it will fly straight to the destination, without doing any upside down parabolic curve. I think this option should satisfy the requirement we have for the camera: 
- fly straight to the nearest point (maximumStraightFlyRadius option is where user defines how far is near)
- fly straight if the `maxHeight > max(height(start), height(destination))` (this already exists)
- fly along the upside down parabolic curve if the two points are very far away from each other (even if they have negative height)

This is the [sandcastle's example](http://localhost:8080/Apps/Sandcastle/index.html#c=tZVNj9s2EIb/CuGL7dSlSQ5JkRvvougW6aVAg+yiveiiSFxHqEwZFOXECfa/dyR/ya7TTYBWPph8OZx5xXlAbbJANqX76AK5Jd59JPeuKdsV/aPXJuO8n97XPmald2E8I19ST/CJLgSU3oZ6UxYu3Bw25sFl0f1Zh6p43IVMpql/nr5Offd7yHyRZ02sHM2K4hf3lLVVfKzr6n0Wfm5jrP1k/KbakliTdd2Usaw94Vj1qfV5N5lMDwZ2rmmerVzI6FO1fawn+6XuKVwTS5/1CW6Gb3afhYijzMNESpBMcApcK8YEJDMCXHFhOLWSS2EN7yTgRnFFrRGKG5zp6exUpw6lw8PZ1xkY6E2UweX/auFHRrWGrpi0DIRkdkY6zSgrlAShBVfMzAij6MYmiTUYqSxINTTRPe36q0UYBcWUskyBtonEOrrLyLRhhiVWAhjAkepETM20MIJbYFqaszLPg3HRhsNLw0BeZZ/KVbt6iNj55YeIrXyXFWXb3BDJGNsH9jR8BYkXWBD/IwtgjKAgpVQACd+xADKhXCWagQK7Z8ECNcJyK7j5b0lgzAqBDCBlAhjjWvYwWJtYKwUorfAvMb2ITdLCSmOZYAmAst/Fg+EaAJjUSgCCBbuUErTR3CRgkUTRocioSpBEbXVXSnCtv4WHa11O/fxV6g+tI0sX7/tuvembdeok3ke7NuJ9dNbW16eAIw23+1h6UAZBpxM/Rh2lQRge03G9Xfdmz30gyqVfYtD4S4qr6fdhNSY/HO3STzhBfs+07RXtc6fhQZ+Xu+TrfPXbIOvKHKOGfk7i9pp43dELmHUp2vWwCs62Z7PreZ8vhTO4TkvP430jg4tt8GcN69h74W751UWyg5DglRHrq1dLXvumxu1VvZxcQnsE/NV8NBstmrit3N3B9U/lal2HSNpQTSidR7daV/hlbObv2/wvF2neNNO9/cV8uHVRlBtSFrfp6OLjm45IXmVNgytPbVU9lJ9dOrpbzDH+H1urGq9dv/x940KVbbuwD/zut51IKV3McXp9Z9wd0kXmvwE) for the option

This should make the camera's flight path more predictable. For example, if we want the camera to flight straight from one point to the other, we can put them within the radius of each other.

I also add @dennisadams 's [comment link](https://github.com/CesiumGS/cesium/issues/8610#issuecomment-656137112) to the getAltitude() function as it is a very reasonable explanation for the math behind the function.

@lilleyse @OmarShehata Can you please take a look at it? Please let me know if this is what we expect the camera to behave
