### PR TITLE
Fixes Color.fromCssColorString when color string contains spaces

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ##### Fixes :wrench:
 
+- Fixed `Color.fromCssColorString` when color string contains spaces. [#9015](https://github.com/CesiumGS/cesium/issues/9015)
 - Fixed 3D Tileset replacement refinement when leaf is empty. [#8996](https://github.com/CesiumGS/cesium/pull/8996)
 - Fixed a bug in the assessment of terrain tile visibility [#9033](https://github.com/CesiumGS/cesium/issues/9033)
 - Fixed vertical polylines with `arcType: ArcType.RHUMB`, including lines drawn via GeoJSON. [#9028](https://github.com/CesiumGS/cesium/pull/9028)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -270,3 +270,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [John Remsberg](https://github.com/easternmotors)
 - [Bao Thien Tran](https://github.com/baothientran)
 - [Yonatan Kra](https://github.com/yonatankra)
+- [Sam Bakkach](https://github.com/sambakk)

--- a/Source/Core/Color.js
+++ b/Source/Core/Color.js
@@ -379,6 +379,9 @@ Color.fromCssColorString = function (color, result) {
     result = new Color();
   }
 
+  // Remove all whitespaces from the color string
+  color = color.replace(/\s/g, "");
+
   var namedColor = Color[color.toUpperCase()];
   if (defined(namedColor)) {
     Color.clone(namedColor, result);

--- a/Specs/Core/ColorSpec.js
+++ b/Specs/Core/ColorSpec.js
@@ -359,16 +359,16 @@ describe("Core/Color", function () {
   });
 
   it("fromCssColorString understands the color string even with any number of unnecessary leading, trailing or middle spaces", function () {
-    expect(Color.fromCssColorString(" rgb( 108, 136, 255)")).toBeDefined();
-    expect(Color.fromCssColorString("rgb( 108, 136, 255) ")).toBeDefined();
-    expect(Color.fromCssColorString("  #FF0000")).toBeDefined();
-    expect(Color.fromCssColorString("#FF0  ")).toBeDefined();
+    expect(Color.fromCssColorString(" rgb( 0, 0, 255)")).toEqual(Color.BLUE);
+    expect(Color.fromCssColorString("rgb( 255, 255, 255) ")).toEqual(
+      Color.WHITE
+    );
+    expect(Color.fromCssColorString("  #FF0000")).toEqual(Color.RED);
+    expect(Color.fromCssColorString("#FF0  ")).toEqual(Color.YELLOW);
     expect(Color.fromCssColorString(" hsla(720,   100%, 50%, 1.0)  ")).toEqual(
-      new Color(1, 0, 0, 1)
+      Color.RED
     );
-    expect(Color.fromCssColorString("hsl (720, 100%, 50%)")).toEqual(
-      new Color(1, 0, 0, 1)
-    );
+    expect(Color.fromCssColorString("hsl (720, 100%, 50%)")).toEqual(Color.RED);
   });
 
   it("fromHsl produces expected output", function () {

--- a/Specs/Core/ColorSpec.js
+++ b/Specs/Core/ColorSpec.js
@@ -363,10 +363,12 @@ describe("Core/Color", function () {
     expect(Color.fromCssColorString("rgb( 108, 136, 255) ")).toBeDefined();
     expect(Color.fromCssColorString("  #FF0000")).toBeDefined();
     expect(Color.fromCssColorString("#FF0  ")).toBeDefined();
-    expect(
-      Color.fromCssColorString(" hsla(720,   100%, 50%, 1.0)  ")
-    ).toBeDefined();
-    expect(Color.fromCssColorString("hsl (720, 100%, 50%)")).toBeDefined();
+    expect(Color.fromCssColorString(" hsla(720,   100%, 50%, 1.0)  ")).toEqual(
+      new Color(1, 0, 0, 1)
+    );
+    expect(Color.fromCssColorString("hsl (720, 100%, 50%)")).toEqual(
+      new Color(1, 0, 0, 1)
+    );
   });
 
   it("fromHsl produces expected output", function () {

--- a/Specs/Core/ColorSpec.js
+++ b/Specs/Core/ColorSpec.js
@@ -358,6 +358,17 @@ describe("Core/Color", function () {
     expect(c).toEqual(Color.LIME);
   });
 
+  it("fromCssColorString understands the color string even with any number of unnecessary leading, trailing or middle spaces", function () {
+    expect(Color.fromCssColorString(" rgb( 108, 136, 255)")).toBeDefined();
+    expect(Color.fromCssColorString("rgb( 108, 136, 255) ")).toBeDefined();
+    expect(Color.fromCssColorString("  #FF0000")).toBeDefined();
+    expect(Color.fromCssColorString("#FF0  ")).toBeDefined();
+    expect(
+      Color.fromCssColorString(" hsla(720,   100%, 50%, 1.0)  ")
+    ).toBeDefined();
+    expect(Color.fromCssColorString("hsl (720, 100%, 50%)")).toBeDefined();
+  });
+
   it("fromHsl produces expected output", function () {
     expect(Color.fromHsl(0.0, 1.0, 0.5, 1.0)).toEqual(Color.RED);
     expect(Color.fromHsl(120.0 / 360.0, 1.0, 0.5, 1.0)).toEqual(Color.LIME);


### PR DESCRIPTION

Fixes #9015 