### PR TITLE
Fix vertical rhumb line when using PolylineGeometry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Fixes :wrench:
 
 - Fixed 3D Tileset replacement refinement when leaf is empty. [#8996](https://github.com/CesiumGS/cesium/8996)
+- Fixed vertical polylines with `arcType: ArcType.RHUMB`, including lines drawn via GeoJSON. [#9028](https://github.com/CesiumGS/cesium/pull/9028)
 
 ### 1.71 - 2020-07-01
 

--- a/Source/Core/PolylinePipeline.js
+++ b/Source/Core/PolylinePipeline.js
@@ -25,8 +25,10 @@ PolylinePipeline.numberOfPointsRhumbLine = function (p0, p1, granularity) {
   var radiansDistanceSquared =
     Math.pow(p0.longitude - p1.longitude, 2) +
     Math.pow(p0.latitude - p1.latitude, 2);
-  return Math.ceil(
-    Math.sqrt(radiansDistanceSquared / (granularity * granularity))
+
+  return Math.max(
+    1,
+    Math.ceil(Math.sqrt(radiansDistanceSquared / (granularity * granularity)))
   );
 };
 

--- a/Specs/Core/PolylineGeometrySpec.js
+++ b/Specs/Core/PolylineGeometrySpec.js
@@ -5,6 +5,7 @@ import { Ellipsoid } from "../../Source/Cesium.js";
 import { PolylineGeometry } from "../../Source/Cesium.js";
 import { VertexFormat } from "../../Source/Cesium.js";
 import createPackableSpecs from "../createPackableSpecs.js";
+import CesiumMath from "../../Source/Core/Math.js";
 
 describe("Core/PolylineGeometry", function () {
   it("constructor throws with no positions", function () {
@@ -182,6 +183,64 @@ describe("Core/PolylineGeometry", function () {
       })
     );
     expect(geometry).not.toBeDefined();
+  });
+
+  it("createGeometry returns positions if their endpoints'longtitude and latitude are the same for rhumb line", function () {
+    var positions = Cartesian3.fromRadiansArrayHeights([
+      30.0,
+      30.0,
+      10.0,
+      30.0,
+      30.0,
+      5.0,
+    ]);
+    var geometry = PolylineGeometry.createGeometry(
+      new PolylineGeometry({
+        positions: positions,
+        width: 10.0,
+        vertexFormat: VertexFormat.POSITION_ONLY,
+        arcType: ArcType.GEODESIC,
+      })
+    );
+
+    var attributePositions = geometry.attributes.position.values;
+    var geometryPosition = new Cartesian3();
+
+    Cartesian3.fromArray(attributePositions, 0, geometryPosition);
+    expect(
+      Cartesian3.equalsEpsilon(
+        geometryPosition,
+        positions[0],
+        CesiumMath.EPSILON7
+      )
+    ).toBe(true);
+
+    Cartesian3.fromArray(attributePositions, 3, geometryPosition);
+    expect(
+      Cartesian3.equalsEpsilon(
+        geometryPosition,
+        positions[0],
+        CesiumMath.EPSILON7
+      )
+    ).toBe(true);
+
+    Cartesian3.fromArray(attributePositions, 6, geometryPosition);
+    expect(
+      Cartesian3.equalsEpsilon(
+        geometryPosition,
+        positions[1],
+        CesiumMath.EPSILON7
+      )
+    ).toBe(true);
+
+    Cartesian3.fromArray(attributePositions, 9, geometryPosition);
+    expect(
+      Cartesian3.equalsEpsilon(
+        geometryPosition,
+        positions[1],
+        CesiumMath.EPSILON7
+      )
+    ).toBe(true);
   });
 
   var positions = [

--- a/Specs/Core/PolylineGeometrySpec.js
+++ b/Specs/Core/PolylineGeometrySpec.js
@@ -186,7 +186,7 @@ describe("Core/PolylineGeometry", function () {
   });
 
   it("createGeometry returns positions if their endpoints'longtitude and latitude are the same for rhumb line", function () {
-    var positions = Cartesian3.fromRadiansArrayHeights([
+    var positions = Cartesian3.fromDegreesArrayHeights([
       30.0,
       30.0,
       10.0,
@@ -199,7 +199,7 @@ describe("Core/PolylineGeometry", function () {
         positions: positions,
         width: 10.0,
         vertexFormat: VertexFormat.POSITION_ONLY,
-        arcType: ArcType.GEODESIC,
+        arcType: ArcType.RHUMB,
       })
     );
 


### PR DESCRIPTION
Fixes #8764 

The issue is that when two endpoints have the same longitude and latitude but different height, the math to calculate the number of points on rhumb line will return 0.

@lilleyse can you please take a look at it? Please let me know if I need to add anything