### PR TITLE
Fix assessment of terrain tile visibility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
 
 ##### Fixes :wrench:
 
-- Fixed 3D Tileset replacement refinement when leaf is empty. [#8996](https://github.com/CesiumGS/cesium/8996)
+- Fixed 3D Tileset replacement refinement when leaf is empty. [#8996](https://github.com/CesiumGS/cesium/pull/8996)
+- Fixed a bug in the assessment of terrain tile visibility [#9033](https://github.com/CesiumGS/cesium/issues/9033)
 
 ### 1.71 - 2020-07-01
 

--- a/Source/Core/Occluder.js
+++ b/Source/Core/Occluder.js
@@ -290,7 +290,7 @@ var tempScratch = new Cartesian3();
  * Determine to what extent an occludee is visible (not visible, partially visible,  or fully visible).
  *
  * @param {BoundingSphere} occludeeBS The bounding sphere of the occludee.
- * @returns {Number} Visibility.NONE if the occludee is not visible,
+ * @returns {Visibility} Visibility.NONE if the occludee is not visible,
  *                       Visibility.PARTIAL if the occludee is partially visible, or
  *                       Visibility.FULL if the occludee is fully visible.
  *

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -580,7 +580,8 @@ GlobeSurfaceTileProvider.prototype.loadTile = function (frameState, tile) {
     // b) The bounding volume is accurate (updated as a side effect of computing visibility)
     // Then we'll load imagery, too.
     if (
-      this.computeTileVisibility(tile, frameState, this.quadtree.occluders) &&
+      this.computeTileVisibility(tile, frameState, this.quadtree.occluders) !==
+        Visibility.NONE &&
       surfaceTile.boundingVolumeSourceTile === tile
     ) {
       terrainOnly = false;


### PR DESCRIPTION
Fixes #9033.
Compare the return value of `computeTileVisibility` to `Visibility.NONE` instead of treating it as a boolean. 
Hope this doesn't trigger any side-effects.

For clarity, I also made `computeTileVisibility` return only `Visibility` values and not (the equivalent) `Intersect` values. I went for simplicity over elegance, but feel free to make changes. 