### PR TITLE
Remove default Mapbox token, Default Mapbox layers in BaseLayerPicker

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,14 @@
 
 ### 1.72 - 2020-08-03
 
+##### Breaking Changes :mega:
+
+- CesiumJS no longer ships with a default Mapbox access token and Mapbox imagery layers have been removed from the `BaseLayerPicker` defaults. `accessToken` is now required when constructing `MapboxImageryProvider` or `MapboxStyleImageryProvider`. This only affects out-of-the-box behavior and applications using their own Mapbox access token are unaffected.
+
+##### Deprecated :hourglass_flowing_sand:
+
+- Deprecated `MapboxApi.defaultAccessToken`. Pass an `accessToken` parameter to individual Mapbox related constructors instead.
+
 ##### Fixes :wrench:
 
 - Fixed 3D Tileset replacement refinement when leaf is empty. [#8996](https://github.com/CesiumGS/cesium/8996)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ##### Breaking Changes :mega:
 
-- CesiumJS no longer ships with a default Mapbox access token and Mapbox imagery layers have been removed from the `BaseLayerPicker` defaults. `accessToken` is now required when constructing `MapboxImageryProvider` or `MapboxStyleImageryProvider`. This only affects out-of-the-box behavior and applications using their own Mapbox access token are unaffected.
+- CesiumJS no longer ships with a default Mapbox access token and Mapbox imagery layers have been removed from the `BaseLayerPicker` defaults. If you are using `MapboxImageryProvider` or `MapboxStyleImageryProvider`, use `options.accessToken` when initializing the imagery provider.
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
 
 ##### Deprecated :hourglass_flowing_sand:
 
-- Deprecated `MapboxApi.defaultAccessToken`. Pass an `accessToken` parameter to individual Mapbox related constructors instead.
+- `MapboxApi.defaultAccessToken` was deprecated and will be removed in CesiumJS 1.73. Pass your access token directly to the MapboxImageryProvider or MapboxStyleImageryProvider constructors.
 
 ##### Fixes :wrench:
 

--- a/Source/Core/MapboxApi.js
+++ b/Source/Core/MapboxApi.js
@@ -1,54 +1,47 @@
-import Credit from "./Credit.js";
 import defined from "./defined.js";
+import deprecationWarning from "./deprecationWarning.js";
+
+var defaultAccessToken;
 
 /**
  * @namespace MapboxApi
  */
 var MapboxApi = {};
 
-/**
- * The default Mapbox API access token to use if one is not provided to the
- * constructor of an object that uses the Mapbox API.  If this property is undefined,
- * Cesium's default access token is used, which is only suitable for use early in development.
- * Please supply your own access token as soon as possible and prior to deployment.
- * Visit {@link https://www.mapbox.com/help/create-api-access-token/} for details.
- * When Cesium's default access token is used, a message is printed to the console the first
- * time the Mapbox API is used.
- *
- * @type {String}
- */
-MapboxApi.defaultAccessToken = undefined;
-
-var printedMapboxWarning = false;
-var errorCredit;
-var errorString =
-  "<b>This application is using Cesium's default Mapbox access token.  Please create a new access token for the application as soon as possible and prior to deployment by visiting <a href=https://www.mapbox.com/account/apps/>https://www.mapbox.com/account/apps/</a>, and provide your token to Cesium by setting the Cesium.MapboxApi.defaultAccessToken property before constructing the CesiumWidget or any other object that uses the Mapbox API.</b>";
+Object.defineProperties(MapboxApi, {
+  /**
+   * The default Mapbox API access token to use if one is not provided to the
+   * constructor of an object that uses the Mapbox API.  If this property is undefined,
+   * Cesium's default access token is used, which is only suitable for use early in development.
+   * Please supply your own access token as soon as possible and prior to deployment.
+   * Visit {@link https://www.mapbox.com/help/create-api-access-token/} for details.
+   * When Cesium's default access token is used, a message is printed to the console the first
+   * time the Mapbox API is used.
+   *
+   * @type {String}
+   * @memberof MapboxApi
+   * @deprecated
+   */
+  defaultAccessToken: {
+    set: function (value) {
+      defaultAccessToken = value;
+      deprecationWarning(
+        "mapbox-token",
+        "MapboxApi.defaultToken is deprecated and will be removed in CesiumJS 1.73. Pass an accessToken directly to the MapboxImageryProvider or MapboxStyleImageryProvider constructors."
+      );
+    },
+    get: function () {
+      return defaultAccessToken;
+    },
+  },
+});
 
 MapboxApi.getAccessToken = function (providedToken) {
   if (defined(providedToken)) {
     return providedToken;
   }
 
-  if (!defined(MapboxApi.defaultAccessToken)) {
-    if (!printedMapboxWarning) {
-      console.log(errorString);
-      printedMapboxWarning = true;
-    }
-    return "pk.eyJ1IjoiYW5hbHl0aWNhbGdyYXBoaWNzIiwiYSI6ImNpd204Zm4wejAwNzYyeW5uNjYyZmFwdWEifQ.7i-VIZZWX8pd1bTfxIVj9g";
-  }
-
   return MapboxApi.defaultAccessToken;
 };
 
-MapboxApi.getErrorCredit = function (providedToken) {
-  if (defined(providedToken) || defined(MapboxApi.defaultAccessToken)) {
-    return undefined;
-  }
-
-  if (!defined(errorCredit)) {
-    errorCredit = new Credit(errorString, true);
-  }
-
-  return errorCredit;
-};
 export default MapboxApi;

--- a/Source/Core/MapboxApi.js
+++ b/Source/Core/MapboxApi.js
@@ -27,7 +27,7 @@ Object.defineProperties(MapboxApi, {
       defaultAccessToken = value;
       deprecationWarning(
         "mapbox-token",
-        "MapboxApi.defaultToken is deprecated and will be removed in CesiumJS 1.73. Pass an accessToken directly to the MapboxImageryProvider or MapboxStyleImageryProvider constructors."
+        "MapboxApi.defaultAccessToken is deprecated and will be removed in CesiumJS 1.73. Pass your access token directly to the MapboxImageryProvider or MapboxStyleImageryProvider constructors."
       );
     },
     get: function () {

--- a/Source/Scene/MapboxImageryProvider.js
+++ b/Source/Scene/MapboxImageryProvider.js
@@ -5,6 +5,7 @@ import DeveloperError from "../Core/DeveloperError.js";
 import MapboxApi from "../Core/MapboxApi.js";
 import Resource from "../Core/Resource.js";
 import UrlTemplateImageryProvider from "./UrlTemplateImageryProvider.js";
+import deprecationWarning from "../Core/deprecationWarning.js";
 
 var trailingSlashRegex = /\/$/;
 var defaultCredit = new Credit(
@@ -18,7 +19,7 @@ var defaultCredit = new Credit(
  *
  * @property {String} [url='https://api.mapbox.com/v4/'] The Mapbox server url.
  * @property {String} mapId The Mapbox Map ID.
- * @property {String} [accessToken] The public access token for the imagery.
+ * @property {String} accessToken The public access token for the imagery.
  * @property {String} [format='png'] The format of the image request.
  * @property {Ellipsoid} [ellipsoid] The ellipsoid.  If not specified, the WGS84 ellipsoid is used.
  * @property {Number} [minimumLevel=0] The minimum level-of-detail supported by the imagery provider.  Take care when specifying
@@ -53,6 +54,13 @@ function MapboxImageryProvider(options) {
   //>>includeStart('debug', pragmas.debug);
   if (!defined(mapId)) {
     throw new DeveloperError("options.mapId is required.");
+  }
+  //>>includeEnd('debug');
+
+  var accessToken = MapboxApi.getAccessToken(options.accessToken);
+  //>>includeStart('debug', pragmas.debug);
+  if (!defined(accessToken)) {
+    throw new DeveloperError("options.accessToken is required.");
   }
   //>>includeEnd('debug');
 
@@ -146,13 +154,9 @@ function MapboxImageryProvider(options) {
     defaultValue(options.url, "https://{s}.tiles.mapbox.com/v4/")
   );
 
-  var accessToken = MapboxApi.getAccessToken(options.accessToken);
   this._mapId = mapId;
   this._accessToken = accessToken;
 
-  this._accessTokenErrorCredit = Credit.clone(
-    MapboxApi.getErrorCredit(options.accessToken)
-  );
   var format = defaultValue(options.format, "png");
   if (!/\./.test(format)) {
     format = "." + format;
@@ -393,9 +397,7 @@ Object.defineProperties(MapboxImageryProvider.prototype, {
  * @exception {DeveloperError} <code>getTileCredits</code> must not be called before the imagery provider is ready.
  */
 MapboxImageryProvider.prototype.getTileCredits = function (x, y, level) {
-  if (defined(this._accessTokenErrorCredit)) {
-    return [this._accessTokenErrorCredit];
-  }
+  return undefined;
 };
 
 /**

--- a/Source/Scene/MapboxImageryProvider.js
+++ b/Source/Scene/MapboxImageryProvider.js
@@ -5,7 +5,6 @@ import DeveloperError from "../Core/DeveloperError.js";
 import MapboxApi from "../Core/MapboxApi.js";
 import Resource from "../Core/Resource.js";
 import UrlTemplateImageryProvider from "./UrlTemplateImageryProvider.js";
-import deprecationWarning from "../Core/deprecationWarning.js";
 
 var trailingSlashRegex = /\/$/;
 var defaultCredit = new Credit(

--- a/Source/Scene/MapboxStyleImageryProvider.js
+++ b/Source/Scene/MapboxStyleImageryProvider.js
@@ -5,6 +5,7 @@ import DeveloperError from "../Core/DeveloperError.js";
 import MapboxApi from "../Core/MapboxApi.js";
 import Resource from "../Core/Resource.js";
 import UrlTemplateImageryProvider from "./UrlTemplateImageryProvider.js";
+import deprecationWarning from "../Core/deprecationWarning.js";
 
 var trailingSlashRegex = /\/$/;
 var defaultCredit = new Credit(
@@ -19,7 +20,7 @@ var defaultCredit = new Credit(
  * @property {Resource|String} [url='https://api.mapbox.com/styles/v1/'] The Mapbox server url.
  * @property {String} [username='mapbox'] The username of the map account.
  * @property {String} styleId The Mapbox Style ID.
- * @property {String} [accessToken] The public access token for the imagery.
+ * @property {String} accessToken The public access token for the imagery.
  * @property {Number} [tilesize=512] The size of the image tiles.
  * @property {Boolean} [scaleFactor] Determines if tiles are rendered at a @2x scale factor.
  * @property {Ellipsoid} [ellipsoid] The ellipsoid.  If not specified, the WGS84 ellipsoid is used.
@@ -55,6 +56,13 @@ function MapboxStyleImageryProvider(options) {
   //>>includeStart('debug', pragmas.debug);
   if (!defined(styleId)) {
     throw new DeveloperError("options.styleId is required.");
+  }
+  //>>includeEnd('debug');
+
+  var accessToken = MapboxApi.getAccessToken(options.accessToken);
+  //>>includeStart('debug', pragmas.debug);
+  if (!defined(accessToken)) {
+    throw new DeveloperError("options.accessToken is required.");
   }
   //>>includeEnd('debug');
 
@@ -148,13 +156,8 @@ function MapboxStyleImageryProvider(options) {
     defaultValue(options.url, "https://api.mapbox.com/styles/v1/")
   );
 
-  var accessToken = MapboxApi.getAccessToken(options.accessToken);
   this._styleId = styleId;
   this._accessToken = accessToken;
-
-  this._accessTokenErrorCredit = Credit.clone(
-    MapboxApi.getErrorCredit(options.accessToken)
-  );
 
   var tilesize = defaultValue(options.tilesize, 512);
   this._tilesize = tilesize;
@@ -405,9 +408,7 @@ Object.defineProperties(MapboxStyleImageryProvider.prototype, {
  * @exception {DeveloperError} <code>getTileCredits</code> must not be called before the imagery provider is ready.
  */
 MapboxStyleImageryProvider.prototype.getTileCredits = function (x, y, level) {
-  if (defined(this._accessTokenErrorCredit)) {
-    return [this._accessTokenErrorCredit];
-  }
+  return undefined;
 };
 
 /**

--- a/Source/Scene/MapboxStyleImageryProvider.js
+++ b/Source/Scene/MapboxStyleImageryProvider.js
@@ -5,7 +5,6 @@ import DeveloperError from "../Core/DeveloperError.js";
 import MapboxApi from "../Core/MapboxApi.js";
 import Resource from "../Core/Resource.js";
 import UrlTemplateImageryProvider from "./UrlTemplateImageryProvider.js";
-import deprecationWarning from "../Core/deprecationWarning.js";
 
 var trailingSlashRegex = /\/$/;
 var defaultCredit = new Credit(

--- a/Source/Widgets/BaseLayerPicker/createDefaultImageryProviderViewModels.js
+++ b/Source/Widgets/BaseLayerPicker/createDefaultImageryProviderViewModels.js
@@ -3,7 +3,6 @@ import ArcGisMapServerImageryProvider from "../../Scene/ArcGisMapServerImageryPr
 import createWorldImagery from "../../Scene/createWorldImagery.js";
 import IonImageryProvider from "../../Scene/IonImageryProvider.js";
 import IonWorldImageryStyle from "../../Scene/IonWorldImageryStyle.js";
-import MapboxStyleImageryProvider from "../../Scene/MapboxStyleImageryProvider.js";
 import OpenStreetMapImageryProvider from "../../Scene/OpenStreetMapImageryProvider.js";
 import TileMapServiceImageryProvider from "../../Scene/TileMapServiceImageryProvider.js";
 import ProviderViewModel from "../BaseLayerPicker/ProviderViewModel.js";
@@ -52,54 +51,6 @@ function createDefaultImageryProviderViewModels() {
       creationFunction: function () {
         return createWorldImagery({
           style: IonWorldImageryStyle.ROAD,
-        });
-      },
-    })
-  );
-
-  providerViewModels.push(
-    new ProviderViewModel({
-      name: "Mapbox Satellite",
-      tooltip: "Mapbox satellite imagery https://www.mapbox.com/maps/",
-      iconUrl: buildModuleUrl(
-        "Widgets/Images/ImageryProviders/mapboxSatellite.png"
-      ),
-      category: "Other",
-      creationFunction: function () {
-        return new MapboxStyleImageryProvider({
-          styleId: "satellite-v9",
-        });
-      },
-    })
-  );
-
-  providerViewModels.push(
-    new ProviderViewModel({
-      name: "Mapbox Streets",
-      tooltip: "Mapbox streets imagery https://www.mapbox.com/maps/",
-      iconUrl: buildModuleUrl(
-        "Widgets/Images/ImageryProviders/mapboxTerrain.png"
-      ),
-      category: "Other",
-      creationFunction: function () {
-        return new MapboxStyleImageryProvider({
-          styleId: "satellite-streets-v11",
-        });
-      },
-    })
-  );
-
-  providerViewModels.push(
-    new ProviderViewModel({
-      name: "Mapbox Streets Classic",
-      tooltip: "Mapbox streets basic imagery https://www.mapbox.com/maps/",
-      iconUrl: buildModuleUrl(
-        "Widgets/Images/ImageryProviders/mapboxStreets.png"
-      ),
-      category: "Other",
-      creationFunction: function () {
-        return new MapboxStyleImageryProvider({
-          styleId: "streets-v11",
         });
       },
     })

--- a/Specs/Core/MapboxApiSpec.js
+++ b/Specs/Core/MapboxApiSpec.js
@@ -11,11 +11,4 @@ describe("Core/MapboxApi", function () {
     expect(MapboxApi.getAccessToken(undefined)).toEqual("someaccesstoken");
     MapboxApi.defaultAccessToken = oldAccessToken;
   });
-
-  it("getAccessToken returns a access token even if the provided access token and the default access token are undefined", function () {
-    var oldAccessToken = MapboxApi.defaultAccessToken;
-    MapboxApi.defaultAccessToken = undefined;
-    expect(MapboxApi.getAccessToken(undefined).length).toBeGreaterThan(0);
-    MapboxApi.defaultAccessToken = oldAccessToken;
-  });
 });

--- a/Specs/Scene/IonImageryProviderSpec.js
+++ b/Specs/Scene/IonImageryProviderSpec.js
@@ -354,7 +354,7 @@ describe("Scene/IonImageryProvider", function () {
   it("createImageryProvider works with MAPBOX", function () {
     return testExternalImagery(
       "MAPBOX",
-      { url: "http://test.invalid", mapId: 1 },
+      { accessToken: "test-token", url: "http://test.invalid", mapId: 1 },
       MapboxImageryProvider
     );
   });

--- a/Specs/Scene/MapboxImageryProviderSpec.js
+++ b/Specs/Scene/MapboxImageryProviderSpec.js
@@ -28,12 +28,13 @@ describe("Scene/MapboxImageryProvider", function () {
 
   it("requires the mapId to be specified", function () {
     expect(function () {
-      return new MapboxImageryProvider({});
+      return new MapboxImageryProvider({ accessToken: "test-token" });
     }).toThrowDeveloperError();
   });
 
   it("resolves readyPromise", function () {
     var provider = new MapboxImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server/",
       mapId: "test-id",
     });
@@ -50,6 +51,7 @@ describe("Scene/MapboxImageryProvider", function () {
     });
 
     var provider = new MapboxImageryProvider({
+      accessToken: "test-token",
       url: resource,
       mapId: "test-id",
     });
@@ -62,6 +64,7 @@ describe("Scene/MapboxImageryProvider", function () {
 
   it("returns valid value for hasAlphaChannel", function () {
     var provider = new MapboxImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server/",
       mapId: "test-id",
     });
@@ -75,6 +78,7 @@ describe("Scene/MapboxImageryProvider", function () {
 
   it("supports a slash at the end of the URL", function () {
     var provider = new MapboxImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server/",
       mapId: "test-id",
     });
@@ -106,6 +110,7 @@ describe("Scene/MapboxImageryProvider", function () {
 
   it("supports no slash at the endof the URL", function () {
     var provider = new MapboxImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server",
       mapId: "test-id",
     });
@@ -137,13 +142,13 @@ describe("Scene/MapboxImageryProvider", function () {
 
   it("requestImage returns a promise for an image and loads it for cross-origin use", function () {
     var provider = new MapboxImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server/",
       mapId: "test-id",
     });
 
     expect(provider.url).toEqual(
-      "made/up/mapbox/server/test-id/{z}/{x}/{y}.png?access_token=" +
-        MapboxApi.getAccessToken()
+      "made/up/mapbox/server/test-id/{z}/{x}/{y}.png?access_token=test-token"
     );
 
     return pollToPromise(function () {
@@ -180,6 +185,7 @@ describe("Scene/MapboxImageryProvider", function () {
   it("rectangle passed to constructor does not affect tile numbering", function () {
     var rectangle = new Rectangle(0.1, 0.2, 0.3, 0.4);
     var provider = new MapboxImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server/",
       mapId: "test-id",
       rectangle: rectangle,
@@ -222,6 +228,7 @@ describe("Scene/MapboxImageryProvider", function () {
 
   it("uses maximumLevel passed to constructor", function () {
     var provider = new MapboxImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server/",
       mapId: "test-id",
       maximumLevel: 5,
@@ -231,6 +238,7 @@ describe("Scene/MapboxImageryProvider", function () {
 
   it("uses minimumLevel passed to constructor", function () {
     var provider = new MapboxImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server/",
       mapId: "test-id",
       minimumLevel: 1,
@@ -240,6 +248,7 @@ describe("Scene/MapboxImageryProvider", function () {
 
   it("when no credit is supplied, the provider adds a default credit", function () {
     var provider = new MapboxImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server/",
       mapId: "test-id",
     });
@@ -249,6 +258,7 @@ describe("Scene/MapboxImageryProvider", function () {
   it("turns the supplied credit into a logo", function () {
     var creditText = "Thanks to our awesome made up source of this imagery!";
     var providerWithCredit = new MapboxImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server/",
       mapId: "test-id",
       credit: creditText,
@@ -258,6 +268,7 @@ describe("Scene/MapboxImageryProvider", function () {
 
   it("raises error event when image cannot be loaded", function () {
     var provider = new MapboxImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server/",
       mapId: "test-id",
     });
@@ -316,6 +327,7 @@ describe("Scene/MapboxImageryProvider", function () {
 
   it("appends specified format", function () {
     var provider = new MapboxImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server/",
       mapId: "test-id",
       format: "@2x.png",
@@ -351,6 +363,7 @@ describe("Scene/MapboxImageryProvider", function () {
 
   it("adds missing period for format", function () {
     var provider = new MapboxImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server/",
       mapId: "test-id",
       format: "png",

--- a/Specs/Scene/MapboxImageryProviderSpec.js
+++ b/Specs/Scene/MapboxImageryProviderSpec.js
@@ -1,4 +1,3 @@
-import { MapboxApi } from "../../Source/Cesium.js";
 import { Math as CesiumMath } from "../../Source/Cesium.js";
 import { Rectangle } from "../../Source/Cesium.js";
 import { Request } from "../../Source/Cesium.js";

--- a/Specs/Scene/MapboxStyleImageryProviderSpec.js
+++ b/Specs/Scene/MapboxStyleImageryProviderSpec.js
@@ -1,4 +1,3 @@
-import { MapboxApi } from "../../Source/Cesium.js";
 import { Math as CesiumMath } from "../../Source/Cesium.js";
 import { Rectangle } from "../../Source/Cesium.js";
 import { Request } from "../../Source/Cesium.js";
@@ -28,12 +27,13 @@ describe("Scene/MapboxStyleImageryProvider", function () {
 
   it("requires the styleId to be specified", function () {
     expect(function () {
-      return new MapboxStyleImageryProvider({});
+      return new MapboxStyleImageryProvider({ accessToken: "test-token" });
     }).toThrowDeveloperError("styleId is required");
   });
 
   it("resolves readyPromise", function () {
     var provider = new MapboxStyleImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server/",
       styleId: "test-id",
     });
@@ -50,6 +50,7 @@ describe("Scene/MapboxStyleImageryProvider", function () {
     });
 
     var provider = new MapboxStyleImageryProvider({
+      accessToken: "test-token",
       url: resource,
       styleId: "test-id",
     });
@@ -62,6 +63,7 @@ describe("Scene/MapboxStyleImageryProvider", function () {
 
   it("returns valid value for hasAlphaChannel", function () {
     var provider = new MapboxStyleImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server/",
       styleId: "test-id",
     });
@@ -75,6 +77,7 @@ describe("Scene/MapboxStyleImageryProvider", function () {
 
   it("supports a slash at the end of the URL", function () {
     var provider = new MapboxStyleImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server/",
       styleId: "test-id",
     });
@@ -106,6 +109,7 @@ describe("Scene/MapboxStyleImageryProvider", function () {
 
   it("supports no slash at the endof the URL", function () {
     var provider = new MapboxStyleImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server",
       styleId: "test-id",
     });
@@ -137,13 +141,13 @@ describe("Scene/MapboxStyleImageryProvider", function () {
 
   it("requestImage returns a promise for an image and loads it for cross-origin use", function () {
     var provider = new MapboxStyleImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server/",
       styleId: "test-id",
     });
 
     expect(provider.url).toEqual(
-      "made/up/mapbox/server/mapbox/test-id/tiles/512/{z}/{x}/{y}?access_token=" +
-        MapboxApi.getAccessToken()
+      "made/up/mapbox/server/mapbox/test-id/tiles/512/{z}/{x}/{y}?access_token=test-token"
     );
 
     return pollToPromise(function () {
@@ -180,6 +184,7 @@ describe("Scene/MapboxStyleImageryProvider", function () {
   it("rectangle passed to constructor does not affect tile numbering", function () {
     var rectangle = new Rectangle(0.1, 0.2, 0.3, 0.4);
     var provider = new MapboxStyleImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server/",
       styleId: "test-id",
       rectangle: rectangle,
@@ -222,6 +227,7 @@ describe("Scene/MapboxStyleImageryProvider", function () {
 
   it("uses maximumLevel passed to constructor", function () {
     var provider = new MapboxStyleImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server/",
       styleId: "test-id",
       maximumLevel: 5,
@@ -231,6 +237,7 @@ describe("Scene/MapboxStyleImageryProvider", function () {
 
   it("uses minimumLevel passed to constructor", function () {
     var provider = new MapboxStyleImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server/",
       styleId: "test-id",
       minimumLevel: 1,
@@ -240,6 +247,7 @@ describe("Scene/MapboxStyleImageryProvider", function () {
 
   it("when no credit is supplied, the provider adds a default credit", function () {
     var provider = new MapboxStyleImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server/",
       styleId: "test-id",
     });
@@ -249,6 +257,7 @@ describe("Scene/MapboxStyleImageryProvider", function () {
   it("turns the supplied credit into a logo", function () {
     var creditText = "Thanks to our awesome made up source of this imagery!";
     var providerWithCredit = new MapboxStyleImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server/",
       styleId: "test-id",
       credit: creditText,
@@ -258,6 +267,7 @@ describe("Scene/MapboxStyleImageryProvider", function () {
 
   it("raises error event when image cannot be loaded", function () {
     var provider = new MapboxStyleImageryProvider({
+      accessToken: "test-token",
       url: "made/up/mapbox/server/",
       styleId: "test-id",
     });
@@ -316,6 +326,7 @@ describe("Scene/MapboxStyleImageryProvider", function () {
 
   it("contains specified url", function () {
     var provider = new MapboxStyleImageryProvider({
+      accessToken: "test-token",
       url: "http://fake.map.com",
       styleId: "test-id",
     });
@@ -344,6 +355,7 @@ describe("Scene/MapboxStyleImageryProvider", function () {
 
   it("contains specified username", function () {
     var provider = new MapboxStyleImageryProvider({
+      accessToken: "test-token",
       styleId: "test-id",
       username: "fakeUsername",
     });
@@ -374,6 +386,7 @@ describe("Scene/MapboxStyleImageryProvider", function () {
 
   it("contains specified tilesize", function () {
     var provider = new MapboxStyleImageryProvider({
+      accessToken: "test-token",
       styleId: "test-id",
       tilesize: 256,
     });
@@ -404,6 +417,7 @@ describe("Scene/MapboxStyleImageryProvider", function () {
 
   it("enables @2x scale factor", function () {
     var provider = new MapboxStyleImageryProvider({
+      accessToken: "test-token",
       styleId: "test-id",
       scaleFactor: true,
     });

--- a/Specs/TypeScript/index.ts
+++ b/Specs/TypeScript/index.ts
@@ -108,8 +108,11 @@ imageryProvider = new OpenStreetMapImageryProvider({ url: "" });
 imageryProvider = new TileMapServiceImageryProvider({ url: "" });
 imageryProvider = new GridImageryProvider({ url: "" });
 imageryProvider = new IonImageryProvider({ assetId: 2 });
-imageryProvider = new MapboxImageryProvider({ mapId: "" });
-imageryProvider = new MapboxStyleImageryProvider({ styleId: "" });
+imageryProvider = new MapboxImageryProvider({ mapId: "", accessToken: "" });
+imageryProvider = new MapboxStyleImageryProvider({
+  styleId: "",
+  accessToken: "",
+});
 imageryProvider = new SingleTileImageryProvider({ url: "" });
 imageryProvider = new TileCoordinatesImageryProvider();
 imageryProvider = new UrlTemplateImageryProvider({ url: "" });


### PR DESCRIPTION
Mapbox no longer provides CesiumJS with a free access token for demonstration purposes. So this change removes the default token and also Mapbox related layers from the `BaseLayerPicker` defaults.

`accessToken` is now required when constructing `MapboxImageryProvider` or `MapboxStyleImageryProvider`.

This only affects out-of-the-box behavior and applications using their own Mapbox access token are unaffected.