### PR TITLE
Fix for walls with negative heights

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Fixed 3D Tileset replacement refinement when leaf is empty. [#8996](https://github.com/CesiumGS/cesium/pull/8996)
 - Fixed a bug in the assessment of terrain tile visibility [#9033](https://github.com/CesiumGS/cesium/issues/9033)
 - Fixed vertical polylines with `arcType: ArcType.RHUMB`, including lines drawn via GeoJSON. [#9028](https://github.com/CesiumGS/cesium/pull/9028)
+- Fixed wall rendering when underground [#9041](https://github.com/CesiumGS/cesium/pull/9041)
 
 ### 1.71 - 2020-07-01
 

--- a/Source/Core/WallGeometry.js
+++ b/Source/Core/WallGeometry.js
@@ -16,7 +16,6 @@ import WallGeometryLibrary from "./WallGeometryLibrary.js";
 
 var scratchCartesian3Position1 = new Cartesian3();
 var scratchCartesian3Position2 = new Cartesian3();
-var scratchCartesian3Position3 = new Cartesian3();
 var scratchCartesian3Position4 = new Cartesian3();
 var scratchCartesian3Position5 = new Cartesian3();
 var scratchBitangent = new Cartesian3();
@@ -437,24 +436,19 @@ WallGeometry.createGeometry = function (wallGeometry) {
     }
 
     if (vertexFormat.normal || vertexFormat.tangent || vertexFormat.bitangent) {
-      var nextPosition;
       var nextTop = Cartesian3.clone(
         Cartesian3.ZERO,
         scratchCartesian3Position5
       );
-      var groundPosition = ellipsoid.scaleToGeodeticSurface(
-        Cartesian3.fromArray(topPositions, i3, scratchCartesian3Position2),
+      var groundPosition = Cartesian3.subtract(
+        topPosition,
+        ellipsoid.geodeticSurfaceNormal(
+          topPosition,
+          scratchCartesian3Position2
+        ),
         scratchCartesian3Position2
       );
       if (i + 1 < length) {
-        nextPosition = ellipsoid.scaleToGeodeticSurface(
-          Cartesian3.fromArray(
-            topPositions,
-            i3 + 3,
-            scratchCartesian3Position3
-          ),
-          scratchCartesian3Position3
-        );
         nextTop = Cartesian3.fromArray(
           topPositions,
           i3 + 3,
@@ -481,18 +475,14 @@ WallGeometry.createGeometry = function (wallGeometry) {
       }
 
       if (
-        Cartesian3.equalsEpsilon(
-          nextPosition,
-          groundPosition,
-          CesiumMath.EPSILON10
-        )
+        Cartesian3.equalsEpsilon(topPosition, nextTop, CesiumMath.EPSILON10)
       ) {
         recomputeNormal = true;
       } else {
         s += ds;
         if (vertexFormat.tangent) {
           tangent = Cartesian3.normalize(
-            Cartesian3.subtract(nextPosition, groundPosition, tangent),
+            Cartesian3.subtract(nextTop, topPosition, tangent),
             tangent
           );
         }

--- a/Source/Core/WallGeometryLibrary.js
+++ b/Source/Core/WallGeometryLibrary.js
@@ -29,7 +29,6 @@ function removeDuplicates(ellipsoid, positions, topHeights, bottomHeights) {
 
   var hasBottomHeights = defined(bottomHeights);
   var hasTopHeights = defined(topHeights);
-  var hasAllZeroHeights = true;
 
   var cleanedPositions = new Array(length);
   var cleanedTopHeights = new Array(length);
@@ -43,8 +42,6 @@ function removeDuplicates(ellipsoid, positions, topHeights, bottomHeights) {
     c0.height = topHeights[0];
   }
 
-  hasAllZeroHeights = hasAllZeroHeights && c0.height <= 0;
-
   cleanedTopHeights[0] = c0.height;
 
   if (hasBottomHeights) {
@@ -53,6 +50,10 @@ function removeDuplicates(ellipsoid, positions, topHeights, bottomHeights) {
     cleanedBottomHeights[0] = 0.0;
   }
 
+  var startTopHeight = cleanedTopHeights[0];
+  var startBottomHeight = cleanedBottomHeights[0];
+  var hasAllSameHeights = startTopHeight === startBottomHeight;
+
   var index = 1;
   for (var i = 1; i < length; ++i) {
     var v1 = positions[i];
@@ -60,7 +61,7 @@ function removeDuplicates(ellipsoid, positions, topHeights, bottomHeights) {
     if (hasTopHeights) {
       c1.height = topHeights[i];
     }
-    hasAllZeroHeights = hasAllZeroHeights && c1.height <= 0;
+    hasAllSameHeights = hasAllSameHeights && c1.height === 0;
 
     if (!latLonEquals(c0, c1)) {
       cleanedPositions[index] = v1; // Shallow copy!
@@ -71,15 +72,19 @@ function removeDuplicates(ellipsoid, positions, topHeights, bottomHeights) {
       } else {
         cleanedBottomHeights[index] = 0.0;
       }
+      hasAllSameHeights =
+        hasAllSameHeights &&
+        cleanedTopHeights[index] === cleanedBottomHeights[index];
 
       Cartographic.clone(c1, c0);
       ++index;
     } else if (c0.height < c1.height) {
+      // two adjacent positions are the same, so use whichever has the greater height
       cleanedTopHeights[index - 1] = c1.height;
     }
   }
 
-  if (hasAllZeroHeights || index < 2) {
+  if (hasAllSameHeights || index < 2) {
     return;
   }
 


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/4274
Replaces https://github.com/CesiumGS/cesium/pull/9022

[sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=lVPvT9swEP1XrHxKpcpptaFtJVRDhW1ITJugG0gEoSM5gjf/iGwnECb+9zltk7hpv5BPl3fvvTvf2RVoUjF8Qk2OiMQnskDDSkF/r7AwCdLV/0JJC0yiToLRYSITudZQk6JEWmgmmGUVGgpZFiaS+FY/22z4r8kQkqMSaHV9Jo0F6QrMfPrXQbZV9bot+hVw3kp6KiGFMq6oks58w1yAti4C+Y4+aCVOMNeI5lhrqMObXkjI+090MvaB6ccBcDB5O+PDAOjj25GXEPDMRCm+IcsfrWv+ZjppPid2nuugQ259HZPbupY9GR/soVfohvH8RWkBdua3tRnWd7CoGfDjokDQzR466LIsCqUtXZ5eL39dnJ74akKo79wVfG2P2AXQGW+tc7duv1Sxyc2G5NU+l3WB7r6eCcgxCcbEuwuswWYkCSiNVrGJ1g535ypXdwvFlaZ/ijwJdvrtq26O7Q3r7aPaHsLrKJGjw2AcxMbWHOet82cmGhUpNQ9dxxZFwZ2hie7L9C9amhrTPMKGGke+NM5YRVh2tOfVkpSDMS7zUHJ+yV7ciOZx5Pg7Uq4gYzL/4fbIoW5oj9P5+RqklMaR+92vtErxe9AD5/8)

The `removeDuplicates` function in `WallGeometryLibrary` was making the incorrect assumption that the minimum height of the bottom of the wall would be `0`, and if all positions at the top of the wall were `<=0` then the height of the wall was `0` and we didn't need to render anything.  This updates the `removeDuplicates` function to check if `topHeight === bottomHeight` instead of `topHeight <= 0` to determine if the wall positions resulted in a wall with 0 height.

Also fixed the logic for computing wall normals so it works when the top of the wall was at `height === 0` by using a position that is 1m below the top wall position instead of a position with `height === 0` for the cross product computation.