### PR TITLE
Fix walls when first and last positions are equal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Fixed 3D Tileset replacement refinement when leaf is empty. [#8996](https://github.com/CesiumGS/cesium/pull/8996)
 - Fixed a bug in the assessment of terrain tile visibility [#9033](https://github.com/CesiumGS/cesium/issues/9033)
 - Fixed vertical polylines with `arcType: ArcType.RHUMB`, including lines drawn via GeoJSON. [#9028](https://github.com/CesiumGS/cesium/pull/9028)
+- Fixed issue where a side of the wall was missing if the first position and the last position were equal [#9044](https://github.com/CesiumGS/cesium/pull/9044)
 
 ### 1.71 - 2020-07-01
 

--- a/Source/Core/WallGeometryLibrary.js
+++ b/Source/Core/WallGeometryLibrary.js
@@ -20,7 +20,7 @@ function latLonEquals(c0, c1) {
 var scratchCartographic1 = new Cartographic();
 var scratchCartographic2 = new Cartographic();
 function removeDuplicates(ellipsoid, positions, topHeights, bottomHeights) {
-  positions = arrayRemoveDuplicates(positions, Cartesian3.equalsEpsilon, true);
+  positions = arrayRemoveDuplicates(positions, Cartesian3.equalsEpsilon);
 
   var length = positions.length;
   if (length < 2) {

--- a/Specs/Core/WallGeometrySpec.js
+++ b/Specs/Core/WallGeometrySpec.js
@@ -128,6 +128,47 @@ describe("Core/WallGeometry", function () {
     expect(cartographic.height).toEqualEpsilon(1000.0, CesiumMath.EPSILON8);
   });
 
+  it("creates positions when first and last positions are equal", function () {
+    var w = WallGeometry.createGeometry(
+      new WallGeometry({
+        vertexFormat: VertexFormat.POSITION_ONLY,
+        positions: Cartesian3.fromDegreesArrayHeights([
+          -107.0,
+          43.0,
+          1000.0,
+          -106.0,
+          43.0,
+          1000.0,
+          -106.0,
+          42.0,
+          1000.0,
+          -107.0,
+          42.0,
+          1000.0,
+          -107.0,
+          43.0,
+          1000.0,
+        ]),
+      })
+    );
+
+    var positions = w.attributes.position.values;
+    var numPositions = 16;
+    var numTriangles = 8;
+    expect(positions.length).toEqual(numPositions * 3);
+    expect(w.indices.length).toEqual(numTriangles * 3);
+
+    var cartographic = ellipsoid.cartesianToCartographic(
+      Cartesian3.fromArray(positions, 0)
+    );
+    expect(cartographic.height).toEqualEpsilon(0.0, CesiumMath.EPSILON8);
+
+    cartographic = ellipsoid.cartesianToCartographic(
+      Cartesian3.fromArray(positions, 3)
+    );
+    expect(cartographic.height).toEqualEpsilon(1000.0, CesiumMath.EPSILON8);
+  });
+
   it("creates positions with minimum and maximum heights", function () {
     var w = WallGeometry.createGeometry(
       new WallGeometry({


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/9043

We were incorrectly using the `wrapAround` options for `arrayRemoveDuplicates`.