### PR TITLE
Incorrect texture coordinate for Wall when there are duplicate positions in input

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 - Fixed issue where a side of the wall was missing if the first position and the last position were equal [#9044](https://github.com/CesiumGS/cesium/pull/9044)
 - Fixed `translucencyByDistance` for label outline color [#9003](https://github.com/CesiumGS/cesium/pull/9003)
 - Fixed return value for `SampledPositionProperty.removeSample` [#9017](https://github.com/CesiumGS/cesium/pull/9017)
+- Fixed issue where wall doesn't have correct texture coordinates when there are duplicate positions input [#9042](https://github.com/CesiumGS/cesium/issues/9042)
 
 ### 1.71 - 2020-07-01
 

--- a/Source/Core/WallGeometry.js
+++ b/Source/Core/WallGeometry.js
@@ -402,7 +402,7 @@ WallGeometry.createGeometry = function (wallGeometry) {
   length /= 3;
   var i;
   var s = 0;
-  var ds = 1 / (length - wallPositions.length + 1);
+  var ds = 1 / (length - numCorners - 1);
   for (i = 0; i < length; ++i) {
     var i3 = i * 3;
     var topPosition = Cartesian3.fromArray(

--- a/Specs/Core/WallGeometrySpec.js
+++ b/Specs/Core/WallGeometrySpec.js
@@ -448,6 +448,48 @@ describe("Core/WallGeometry", function () {
     ]);
   });
 
+  it("creates correct texture coordinates when there are duplicate wall positions", function () {
+    var w = WallGeometry.createGeometry(
+      new WallGeometry({
+        vertexFormat: VertexFormat.ALL,
+        positions: Cartesian3.fromDegreesArrayHeights([
+          49.0,
+          18.0,
+          1000.0,
+          50.0,
+          18.0,
+          1000.0,
+          50.0,
+          18.0,
+          1000.0,
+          51.0,
+          18.0,
+          1000.0,
+        ]),
+      })
+    );
+
+    expect(w.attributes.st.values.length).toEqual(4 * 2 * 2);
+    expect(w.attributes.st.values).toEqual([
+      0.0,
+      0.0,
+      0.0,
+      1.0,
+      0.5,
+      0.0,
+      0.5,
+      1.0,
+      0.5,
+      0.0,
+      0.5,
+      1.0,
+      1.0,
+      0.0,
+      1.0,
+      1.0,
+    ]);
+  });
+
   it("fromConstantHeights throws without positions", function () {
     expect(function () {
       return WallGeometry.fromConstantHeights();


### PR DESCRIPTION
Fixes #9042 

The original wall positions input length is used as number of corners to calculate for the texture coordinate. However, after the input is cleaned for duplication, the length is outdated. I use numCorners returned by function `WallGeometryLibrary.computePositions()` to replace it. 

[Sandcastle example for the error](https://sandcastle.cesium.com/#c=lVJLT4NAEP4rE040qUvr24qNWg8eNJpovIiHLUzLxmWXzC7U2vS/u5Su1keMcoD5hu8x7FBzglrgDAlOQOEMRmhEVbCHVS9MgnSFR1pZLhRSEnRhAUJN9Ll+GcCES4Ow7BwnqnZOqKywAo3zak2Z7zhCojxgPMvCRaIAZlzKAaxKgFIb91orM/BTjDhZV3G1wyakiwucEqI5I+LzSxTT3JrwsdUCbB3usV7Xo92dDdDvNddGwz8/oygCpa1IEWyOkFWlFCm3+D4X5Ej4EXfA9j7i+r/F/Yf7rjnq/fFznjrronDDkuDuQDcWOcoxfUYaa07Z9ZpwS7pEsvNw4S0JS+T2s9Cf/Xa43YTBPuv5pGVbLN19tXu3/Xbdr1oX9zr8svzOcdANYmPnEoc+8VQUpSYLFcmQschiUUo3nonGlZvXstSYxrmhxtGmNM5EDSI7+eHXhFRyY9ybSSXlnXjFJBjGkeN/k0rNM6GmNzWS5POGlveHV22TMRZHDv6stFrLMacvzm8)

@hpinkos Can you please take a look at it? Please let me know if I should fix anything