### PR TITLE
Deprecate BingMapsApi

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 ##### Deprecated :hourglass_flowing_sand:
 
 - `MapboxApi.defaultAccessToken` was deprecated and will be removed in CesiumJS 1.73. Pass your access token directly to the MapboxImageryProvider or MapboxStyleImageryProvider constructors.
+- `BingMapxApi` was deprecated and will be removed in CesiumJS 1.73. Pass your access key directly to the BingMapsImageryProvider or BingMapsGeocoderService constructors.
 
 ##### Fixes :wrench:
 

--- a/Source/Core/BingMapsApi.js
+++ b/Source/Core/BingMapsApi.js
@@ -1,4 +1,7 @@
 import defined from "./defined.js";
+import deprecationWarning from "./deprecationWarning.js";
+
+var defaultKey;
 
 /**
  * Object for setting and retrieving the default Bing Maps API key.
@@ -8,24 +11,50 @@ import defined from "./defined.js";
  * {@link https://www.bingmapsportal.com/}.
  *
  * @namespace BingMapsApi
+ * @deprecated
  */
 var BingMapsApi = {};
 
-/**
- * The default Bing Maps API key to use if one is not provided to the
- * constructor of an object that uses the Bing Maps API.
- *
- * @type {String}
- */
-BingMapsApi.defaultKey = undefined;
+Object.defineProperties(BingMapsApi, {
+  /**
+   * The default Bing Maps API key to use if one is not provided to the
+   * constructor of an object that uses the Bing Maps API.
+   *
+   * @type {String}
+   * @memberof BingMapsApi
+   * @deprecated
+   */
+
+  defaultKey: {
+    set: function (value) {
+      defaultKey = value;
+      deprecationWarning(
+        "bing-maps-api-default-key",
+        "BingMapsApi.defaultKey is deprecated and will be removed in CesiumJS 1.73. Pass your access token directly to the BingMapsGeocoderService or BingMapsImageryProvider constructors."
+      );
+    },
+    get: function () {
+      return defaultKey;
+    },
+  },
+});
 
 /**
  * Gets the key to use to access the Bing Maps API. If the provided
  * key is defined, it is returned. Otherwise, returns {@link BingMapsApi.defaultKey}.
  * @param {string|null|undefined} providedKey The provided key to use if defined.
  * @returns {string|undefined} The Bing Maps API key to use.
+ * @deprecated
  */
 BingMapsApi.getKey = function (providedKey) {
+  deprecationWarning(
+    "bing-maps-api-get-key",
+    "BingMapsApi.getKey is deprecated and will be removed in CesiumJS 1.73. Pass your access token directly to the BingMapsGeocoderService or BingMapsImageryProvider constructors."
+  );
+  return BingMapsApi._getKeyNoDeprecate(providedKey);
+};
+
+BingMapsApi._getKeyNoDeprecate = function (providedKey) {
   if (defined(providedKey)) {
     return providedKey;
   }

--- a/Source/Core/BingMapsGeocoderService.js
+++ b/Source/Core/BingMapsGeocoderService.js
@@ -3,6 +3,8 @@ import Check from "./Check.js";
 import defaultValue from "./defaultValue.js";
 import Rectangle from "./Rectangle.js";
 import Resource from "./Resource.js";
+import defined from "./defined.js";
+import DeveloperError from "./DeveloperError.js";
 
 var url = "https://dev.virtualearth.net/REST/v1/Locations";
 
@@ -12,18 +14,23 @@ var url = "https://dev.virtualearth.net/REST/v1/Locations";
  * @constructor
  *
  * @param {Object} options Object with the following properties:
- * @param {String} [options.key] A key to use with the Bing Maps geocoding service
+ * @param {String} options.key A key to use with the Bing Maps geocoding service
  */
 function BingMapsGeocoderService(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var key = BingMapsApi._getKeyNoDeprecate(options.key);
+  //>>includeStart('debug', pragmas.debug);
+  if (!defined(key)) {
+    throw new DeveloperError("options.key is required.");
+  }
+  //>>includeEnd('debug');
 
-  var key = options.key;
-  this._key = BingMapsApi.getKey(key);
+  this._key = key;
 
   this._resource = new Resource({
     url: url,
     queryParameters: {
-      key: this._key,
+      key: key,
     },
   });
 }

--- a/Source/Scene/BingMapsImageryProvider.js
+++ b/Source/Scene/BingMapsImageryProvider.js
@@ -23,7 +23,7 @@ import ImageryProvider from "./ImageryProvider.js";
  * Initialization options for the BingMapsImageryProvider constructor
  *
  * @property {Resource|String} url The url of the Bing Maps server hosting the imagery.
- * @property {String} [key] The Bing Maps key for your application, which can be
+ * @property {String} key The Bing Maps key for your application, which can be
  *        created at {@link https://www.bingmapsportal.com/}.
  *        If this parameter is not provided, {@link BingMapsApi.defaultKey} is used, which is undefined by default.
  * @property {String} [tileProtocol] The protocol to use when loading tiles, e.g. 'http' or 'https'.
@@ -69,10 +69,14 @@ import ImageryProvider from "./ImageryProvider.js";
  */
 function BingMapsImageryProvider(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var accessKey = BingMapsApi._getKeyNoDeprecate(options.key);
 
   //>>includeStart('debug', pragmas.debug);
   if (!defined(options.url)) {
     throw new DeveloperError("options.url is required.");
+  }
+  if (!defined(accessKey)) {
+    throw new DeveloperError("options.key is required.");
   }
   //>>includeEnd('debug');
 
@@ -162,7 +166,7 @@ function BingMapsImageryProvider(options) {
    */
   this.defaultMagnificationFilter = undefined;
 
-  this._key = BingMapsApi.getKey(options.key);
+  this._key = accessKey;
   this._resource = Resource.createIfNeeded(options.url);
   this._resource.appendForwardSlash();
   this._tileProtocol = options.tileProtocol;

--- a/Specs/Core/BingMapsGeocoderServiceSpec.js
+++ b/Specs/Core/BingMapsGeocoderServiceSpec.js
@@ -29,7 +29,7 @@ describe("Core/BingMapsGeocoderService", function () {
     ) {
       deferred.resolve(data);
     };
-    var service = new BingMapsGeocoderService();
+    var service = new BingMapsGeocoderService({ key: "" });
     service.geocode(query).then(function (results) {
       expect(results.length).toEqual(1);
       expect(results[0].displayName).toEqual("a");
@@ -50,7 +50,7 @@ describe("Core/BingMapsGeocoderService", function () {
     ) {
       deferred.resolve(data);
     };
-    var service = new BingMapsGeocoderService();
+    var service = new BingMapsGeocoderService({ key: "" });
     service.geocode(query).then(function (results) {
       expect(results.length).toEqual(0);
       done();
@@ -73,7 +73,7 @@ describe("Core/BingMapsGeocoderService", function () {
     ) {
       deferred.resolve(data);
     };
-    var service = new BingMapsGeocoderService();
+    var service = new BingMapsGeocoderService({ key: "" });
     service.geocode(query).then(function (results) {
       expect(results.length).toEqual(0);
       done();

--- a/Specs/Scene/BingMapsImageryProviderSpec.js
+++ b/Specs/Scene/BingMapsImageryProviderSpec.js
@@ -82,6 +82,17 @@ describe("Scene/BingMapsImageryProvider", function () {
     function constructWithoutServer() {
       return new BingMapsImageryProvider({
         mapStyle: BingMapsStyle.AERIAL,
+        key: "",
+      });
+    }
+    expect(constructWithoutServer).toThrowDeveloperError();
+  });
+
+  it("constructor throws when key is not specified", function () {
+    function constructWithoutServer() {
+      return new BingMapsImageryProvider({
+        url: "http://fake.fake.invalid",
+        mapStyle: BingMapsStyle.AERIAL,
       });
     }
     expect(constructWithoutServer).toThrowDeveloperError();
@@ -278,6 +289,7 @@ describe("Scene/BingMapsImageryProvider", function () {
 
     var provider = new BingMapsImageryProvider({
       url: url,
+      key: "",
       mapStyle: mapStyle,
     });
 
@@ -296,6 +308,7 @@ describe("Scene/BingMapsImageryProvider", function () {
     var provider = new BingMapsImageryProvider({
       url: url,
       mapStyle: mapStyle,
+      key: "",
     });
     var provider2;
     var provider3;
@@ -310,6 +323,7 @@ describe("Scene/BingMapsImageryProvider", function () {
         provider2 = new BingMapsImageryProvider({
           url: url,
           mapStyle: mapStyle,
+          key: "",
         });
         return provider2.readyPromise;
       })
@@ -325,6 +339,7 @@ describe("Scene/BingMapsImageryProvider", function () {
         provider3 = new BingMapsImageryProvider({
           url: url,
           mapStyle: BingMapsStyle.AERIAL,
+          key: "",
         });
         return provider3.readyPromise;
       })
@@ -347,6 +362,7 @@ describe("Scene/BingMapsImageryProvider", function () {
     var provider = new BingMapsImageryProvider({
       url: url,
       mapStyle: mapStyle,
+      key: "",
     });
 
     return provider.readyPromise.then(function (result) {
@@ -365,6 +381,7 @@ describe("Scene/BingMapsImageryProvider", function () {
     var provider = new BingMapsImageryProvider({
       url: url,
       mapStyle: mapStyle,
+      key: "",
     });
 
     return provider.readyPromise.then(function (result) {
@@ -387,6 +404,7 @@ describe("Scene/BingMapsImageryProvider", function () {
     var provider = new BingMapsImageryProvider({
       url: resource,
       mapStyle: mapStyle,
+      key: "",
     });
 
     return provider.readyPromise.then(function (result) {
@@ -399,6 +417,7 @@ describe("Scene/BingMapsImageryProvider", function () {
     var url = "http://host.invalid";
     var provider = new BingMapsImageryProvider({
       url: url,
+      key: "",
     });
 
     return provider.readyPromise
@@ -421,6 +440,7 @@ describe("Scene/BingMapsImageryProvider", function () {
     var provider = new BingMapsImageryProvider({
       url: url,
       mapStyle: mapStyle,
+      key: "",
     });
 
     return pollToPromise(function () {
@@ -489,6 +509,7 @@ describe("Scene/BingMapsImageryProvider", function () {
       url: url,
       mapStyle: mapStyle,
       culture: culture,
+      key: "",
     });
 
     expect(provider.culture).toEqual(culture);
@@ -514,6 +535,7 @@ describe("Scene/BingMapsImageryProvider", function () {
     var url = "http://host.invalid";
     var provider = new BingMapsImageryProvider({
       url: url,
+      key: "",
     });
 
     var errorEventRaised = false;
@@ -540,6 +562,7 @@ describe("Scene/BingMapsImageryProvider", function () {
     var provider = new BingMapsImageryProvider({
       url: url,
       mapStyle: mapStyle,
+      key: "",
     });
 
     var layer = new ImageryLayer(provider);
@@ -638,6 +661,7 @@ describe("Scene/BingMapsImageryProvider", function () {
     var provider = new BingMapsImageryProvider({
       url: url,
       mapStyle: mapStyle,
+      key: "",
     });
 
     var layer = new ImageryLayer(provider);

--- a/Specs/Scene/ImageryLayerSpec.js
+++ b/Specs/Scene/ImageryLayerSpec.js
@@ -194,6 +194,7 @@ describe(
 
       return new BingMapsImageryProvider({
         url: "http://host.invalid",
+        key: "",
         tileDiscardPolicy: new NeverTileDiscardPolicy(),
       });
     }

--- a/Specs/Scene/IonImageryProviderSpec.js
+++ b/Specs/Scene/IonImageryProviderSpec.js
@@ -326,7 +326,7 @@ describe("Scene/IonImageryProvider", function () {
     );
     return testExternalImagery(
       "BING",
-      { url: "http://test.invalid" },
+      { url: "http://test.invalid", key: "" },
       BingMapsImageryProvider
     );
   });

--- a/Specs/TypeScript/index.ts
+++ b/Specs/TypeScript/index.ts
@@ -101,9 +101,8 @@ import {
 // Verify ImageryProvider instances conform to the expected interface
 let imageryProvider: ImageryProvider;
 imageryProvider = new WebMapServiceImageryProvider({ url: "", layers: "0" });
-imageryProvider = new BingMapsImageryProvider({ url: "" });
 imageryProvider = new ArcGisMapServerImageryProvider({ url: "" });
-imageryProvider = new BingMapsImageryProvider({ url: "" });
+imageryProvider = new BingMapsImageryProvider({ url: "", key: "" });
 imageryProvider = new OpenStreetMapImageryProvider({ url: "" });
 imageryProvider = new TileMapServiceImageryProvider({ url: "" });
 imageryProvider = new GridImageryProvider({ url: "" });


### PR DESCRIPTION
A long time ago, Cesium created instances of `BingMapsGeocoderService` and `BigMapsImageryProvider` behind the scenes by default using a demo key. We provided the `BingMapsApi` singleton to make it easy to set a different key in one place.

We haven't shipped with a demo key in a long time and there's really no good reason to maintain the `BingMapsApi` singleton at the library level.