### PR TITLE
Specify highp sampler2D for clipping plane textures to improve reliability on some devices

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 - Fixed `translucencyByDistance` for label outline color [#9003](https://github.com/CesiumGS/cesium/pull/9003)
 - Fixed return value for `SampledPositionProperty.removeSample` [#9017](https://github.com/CesiumGS/cesium/pull/9017)
 - Fixed issue where wall doesn't have correct texture coordinates when there are duplicate positions input [#9042](https://github.com/CesiumGS/cesium/issues/9042)
+- Fixed an issue where clipping planes would not clip at the correct distances on some Android devices, most commonly reproducible on devices with `Mali` GPUs that do not support float textures via WebGL [#9023](https://github.com/CesiumGS/cesium/issues/9023)
 
 ### 1.71 - 2020-07-01
 

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -4797,7 +4797,7 @@ function modifyShaderForClippingPlanes(
   shader = ShaderSource.replaceMain(shader, "gltf_clip_main");
   shader += Model._getClippingFunction(clippingPlaneCollection, context) + "\n";
   shader +=
-    "uniform sampler2D gltf_clippingPlanes; \n" +
+    "uniform highp sampler2D gltf_clippingPlanes; \n" +
     "uniform mat4 gltf_clippingPlanesMatrix; \n" +
     "uniform vec4 gltf_clippingPlanesEdgeStyle; \n" +
     "void main() \n" +

--- a/Source/Scene/PointCloud.js
+++ b/Source/Scene/PointCloud.js
@@ -1356,7 +1356,7 @@ function createShaders(pointCloud, frameState, style) {
 
   if (hasClippedContent) {
     fs +=
-      "uniform sampler2D u_clippingPlanes; \n" +
+      "uniform highp sampler2D u_clippingPlanes; \n" +
       "uniform mat4 u_clippingPlanesMatrix; \n" +
       "uniform vec4 u_clippingPlanesEdgeStyle; \n";
     fs += "\n";

--- a/Source/Scene/getClippingFunction.js
+++ b/Source/Scene/getClippingFunction.js
@@ -114,7 +114,7 @@ function getClippingPlaneFloat(width, height) {
   }
 
   var functionString =
-    "vec4 getClippingPlane(sampler2D packedClippingPlanes, int clippingPlaneNumber, mat4 transform)\n" +
+    "vec4 getClippingPlane(highp sampler2D packedClippingPlanes, int clippingPlaneNumber, mat4 transform)\n" +
     "{\n" +
     "    int pixY = clippingPlaneNumber / " +
     width +
@@ -148,7 +148,7 @@ function getClippingPlaneUint8(width, height) {
   }
 
   var functionString =
-    "vec4 getClippingPlane(sampler2D packedClippingPlanes, int clippingPlaneNumber, mat4 transform)\n" +
+    "vec4 getClippingPlane(highp sampler2D packedClippingPlanes, int clippingPlaneNumber, mat4 transform)\n" +
     "{\n" +
     "    int clippingPlaneStartIndex = clippingPlaneNumber * 2;\n" + // clipping planes are two pixels each
     "    int pixY = clippingPlaneStartIndex / " +

--- a/Source/Shaders/GlobeFS.glsl
+++ b/Source/Shaders/GlobeFS.glsl
@@ -72,7 +72,7 @@ uniform vec2 u_nightFadeDistance;
 #endif
 
 #ifdef ENABLE_CLIPPING_PLANES
-uniform sampler2D u_clippingPlanes;
+uniform highp sampler2D u_clippingPlanes;
 uniform mat4 u_clippingPlanesMatrix;
 uniform vec4 u_clippingPlanesEdgeStyle;
 #endif


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/9023.

Some devices with Mali GPUs (mostly Android, but also seen on some Chromebooks) were having trouble with clipping plane reliability, apparently due to precision problems. As observed in https://github.com/CesiumGS/cesium/issues/8311, WebGL implementations are free to use lower precision sampling if the precision isn't specified, so this PR explicitly specifies `highp` on texture sampling for clipping planes. This seems to help on the devices in the issue above.

I also tested `Model`, `pnts`, `b3dm`, `i3dm`, and `Globe` clipping planes with these changes on Chrome and Firefox in Linux and on Internet Explorer and Chrome in Windows, both using float textures where supported and using `Cesium.ClippingPlaneCollection.useFloatTexture = function() { return false; };` to force the `uint8 RGBA` codepath, and it looks like this doesn't cause problems there.

@lilleyse can you test in Safari on macos?