### PR TITLE
Fix highp samplers issues

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 1.73 - 2020-09-01
+
+##### Fixes :wrench:
+
+- Fixed several artifcats on mobile devices caused by using insufficient precision. [#9064](https://github.com/CesiumGS/cesium/pull/9064)
+
 ### 1.72 - 2020-08-03
 
 ##### Breaking Changes :mega:

--- a/Source/Renderer/ShaderSource.js
+++ b/Source/Renderer/ShaderSource.js
@@ -241,6 +241,7 @@ function combineShader(shaderSource, isFragmentShader, context) {
     precision highp float;\n\
 #else\n\
     precision mediump float;\n\
+    #define highp mediump;\n\
 #endif\n\n";
   }
 

--- a/Source/Renderer/ShaderSource.js
+++ b/Source/Renderer/ShaderSource.js
@@ -235,13 +235,16 @@ function combineShader(shaderSource, isFragmentShader, context) {
   }
 
   if (isFragmentShader) {
+    // If high precision isn't support replace occurrences of highp with mediump
+    // The highp keyword is not always available on older mobile devices
+    // See https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#In_WebGL_1_highp_float_support_is_optional_in_fragment_shaders
     result +=
       "\
 #ifdef GL_FRAGMENT_PRECISION_HIGH\n\
     precision highp float;\n\
 #else\n\
     precision mediump float;\n\
-    #define highp mediump;\n\
+    #define highp mediump\n\
 #endif\n\n";
   }
 

--- a/Source/Scene/GlobeDepth.js
+++ b/Source/Scene/GlobeDepth.js
@@ -76,7 +76,7 @@ function executeDebugGlobeDepth(globeDepth, context, passState, useLogDepth) {
     useLogDepth !== globeDepth._useLogDepth
   ) {
     var fsSource =
-      "uniform sampler2D u_depthTexture;\n" +
+      "uniform highp sampler2D u_depthTexture;\n" +
       "varying vec2 v_textureCoordinates;\n" +
       "void main()\n" +
       "{\n" +

--- a/Source/Scene/PickDepth.js
+++ b/Source/Scene/PickDepth.js
@@ -29,7 +29,7 @@ function executeDebugPickDepth(pickDepth, context, passState, useLogDepth) {
     useLogDepth !== pickDepth._useLogDepth
   ) {
     var fsSource =
-      "uniform sampler2D u_texture;\n" +
+      "uniform highp sampler2D u_texture;\n" +
       "varying vec2 v_textureCoordinates;\n" +
       "void main()\n" +
       "{\n" +
@@ -116,7 +116,7 @@ function updateFramebuffers(pickDepth, context, depthTexture) {
 function updateCopyCommands(pickDepth, context, depthTexture) {
   if (!defined(pickDepth._copyDepthCommand)) {
     var fs =
-      "uniform sampler2D u_texture;\n" +
+      "uniform highp sampler2D u_texture;\n" +
       "varying vec2 v_textureCoordinates;\n" +
       "void main()\n" +
       "{\n" +

--- a/Source/Shaders/Builtin/Functions/shadowDepthCompare.glsl
+++ b/Source/Shaders/Builtin/Functions/shadowDepthCompare.glsl
@@ -1,10 +1,10 @@
 
-float czm_sampleShadowMap(samplerCube shadowMap, vec3 d)
+float czm_sampleShadowMap(highp samplerCube shadowMap, vec3 d)
 {
     return czm_unpackDepth(textureCube(shadowMap, d));
 }
 
-float czm_sampleShadowMap(sampler2D shadowMap, vec2 uv)
+float czm_sampleShadowMap(highp sampler2D shadowMap, vec2 uv)
 {
 #ifdef USE_SHADOW_DEPTH_TEXTURE
     return texture2D(shadowMap, uv).r;

--- a/Source/Shaders/PostProcessStages/PassThroughDepth.glsl
+++ b/Source/Shaders/PostProcessStages/PassThroughDepth.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D u_depthTexture;
+uniform highp sampler2D u_depthTexture;
 
 varying vec2 v_textureCoordinates;
 


### PR DESCRIPTION
Fixes #6735
Fixes #4752
Fixes #7273 
#7176 is partly fixed

@likangning93 observed in #8311 that "devices are free to select the precision of sampler2D when it isn't explicitly set". Following,
#8805 and #9060 explicitly set `highp` for samplers in batch tables and clipping planes, respectively, to solve some issues. 

As mentioned in my [comment](https://github.com/CesiumGS/cesium/issues/9023#issuecomment-663995898) in #9023, I tried adding more `highp`s across the code and had some success:

1. Adding `highp` in https://github.com/CesiumGS/cesium/blob/67a36c7cf55e2219c9053ed278b1bbb0c4d1feb3/Source/Shaders/Builtin/Functions/shadowDepthCompare.glsl#L7
solves #7176.
Edit: #7176 seems fixed on Android devices, but some iPads still have the issue. See comments below. 
- In the [shadows sandcastle](https://sandcastle.cesium.com/?src=Shadows.html), if you check the `soft shadow` option and decrease the shadow map size from 2048 to 256 you still get some artifacts. But I get them also on my linux so I suspect that's another issue.
- There are likely more places across the shadow map code needing a `highp`.
2. Adding `highp` in https://github.com/CesiumGS/cesium/blob/67a36c7cf55e2219c9053ed278b1bbb0c4d1feb3/Source/Shaders/PostProcessStages/PassThroughDepth.glsl#L1
fixes #6735, or at least some of the issues mentioned over there. `PassThroughDepth` is used for the globe depth texture.
3. Adding `highp` in https://github.com/CesiumGS/cesium/blob/67a36c7cf55e2219c9053ed278b1bbb0c4d1feb3/Source/Scene/PickDepth.js#L119
has some precision benefits. I haven't noticed any related open issue, but can elaborate if needed.
4. Added `highp` also in `executeDebugPickDepth` and `executeDebugGlobeDepth`.

TODO:
- [x] Check which other samplers can do with `highp`.
- [x] Check if other open issues are solved by this PR.  Strong candidates are #7273, #4752 and a number of other iOS issues.
- [ ] Profile
- [x] Check `highp` support as [noted](https://github.com/CesiumGS/cesium/issues/9023#issuecomment-664407709) by @lilleyse. Replace by `mediump` if not supported.
- [x] Update CHANGES.md

@likangning93, @lilleyse your feedback will be appreciated.