### PR TITLE
#8006 Fix incorrect billboard clamping when terrain provider changes

### DIFF
--- a/Source/Scene/Billboard.js
+++ b/Source/Scene/Billboard.js
@@ -1109,11 +1109,17 @@ Billboard._updateClamping = function (collection, owner) {
         clampedPosition.x += position.height;
       }
     }
-    owner._clampedPosition = Cartesian3.clone(
-      clampedPosition,
-      owner._clampedPosition
-    );
+
+    // Billboards can be reused, i.e. by EntityCluster so check that the height
+    // reference did not change since the clamping callback was created
+    if (owner._heightReference !== HeightReference.NONE) {
+      owner._clampedPosition = Cartesian3.clone(
+        clampedPosition,
+        owner._clampedPosition
+      );
+    }
   }
+
   var ownerId = defined(owner) && defined(owner.id) ? owner.id.id : undefined;
   owner._removeCallbackFunc = surface.updateHeight(
     position,

--- a/Source/Scene/Billboard.js
+++ b/Source/Scene/Billboard.js
@@ -1120,11 +1120,10 @@ Billboard._updateClamping = function (collection, owner) {
     }
   }
 
-  var ownerId = defined(owner) && defined(owner.id) ? owner.id.id : undefined;
   owner._removeCallbackFunc = surface.updateHeight(
     position,
     updateFunction,
-    ownerId
+    owner
   );
 
   Cartographic.clone(position, scratchCartographic);

--- a/Source/Scene/Billboard.js
+++ b/Source/Scene/Billboard.js
@@ -1114,7 +1114,12 @@ Billboard._updateClamping = function (collection, owner) {
       owner._clampedPosition
     );
   }
-  owner._removeCallbackFunc = surface.updateHeight(position, updateFunction);
+  var ownerId = defined(owner) && defined(owner.id) ? owner.id.id : undefined;
+  owner._removeCallbackFunc = surface.updateHeight(
+    position,
+    updateFunction,
+    ownerId
+  );
 
   Cartographic.clone(position, scratchCartographic);
   var height = globe.getHeight(position);

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -208,11 +208,13 @@ QuadtreePrimitive.prototype.invalidateAllTiles = function () {
 
 function containsOwnerHeightCallbackData(heightCallbacks, ownerId) {
   var found = false;
-  for (var i = 0; i < heightCallbacks.length; ++i) {
-    var cbData = heightCallbacks[i];
-    if (cbData.ownerId === ownerId) {
-      found = true;
-      break;
+  if (defined(ownerId)) {
+    for (var i = 0; i < heightCallbacks.length; ++i) {
+      var cbData = heightCallbacks[i];
+      if (cbData.ownerId === ownerId) {
+        found = true;
+        break;
+      }
     }
   }
   return found;

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -297,7 +297,7 @@ QuadtreePrimitive.prototype.forEachRenderedTile = function (tileFunction) {
  *
  * @param {Cartographic} cartographic The cartographic position.
  * @param {Function} callback The function to be called when a new tile is loaded containing cartographic.
- * @param {string} [owner] Object requesting height update callback
+ * @param {Object} [owner] Object requesting height update callback
  * @returns {Function} The function to remove this callback from the quadtree.
  */
 QuadtreePrimitive.prototype.updateHeight = function (

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -206,12 +206,12 @@ QuadtreePrimitive.prototype.invalidateAllTiles = function () {
   this._tilesInvalidated = true;
 };
 
-function containsOwnerHeightCallbackData(heightCallbacks, ownerId) {
+function containsOwnerHeightCallbackData(heightCallbacks, owner) {
   var found = false;
-  if (defined(ownerId)) {
+  if (defined(owner)) {
     for (var i = 0; i < heightCallbacks.length; ++i) {
       var cbData = heightCallbacks[i];
-      if (cbData.ownerId === ownerId) {
+      if (cbData.owner === owner) {
         found = true;
         break;
       }
@@ -244,7 +244,7 @@ function invalidateAllTiles(primitive) {
         if (
           !containsOwnerHeightCallbackData(
             primitive._addHeightCallbacks,
-            data.ownerId
+            data.owner
           )
         ) {
           primitive._addHeightCallbacks.push(data);
@@ -297,13 +297,13 @@ QuadtreePrimitive.prototype.forEachRenderedTile = function (tileFunction) {
  *
  * @param {Cartographic} cartographic The cartographic position.
  * @param {Function} callback The function to be called when a new tile is loaded containing cartographic.
- * @param {string} [ownerId] ID of the object requesting height update callback
+ * @param {string} [owner] Object requesting height update callback
  * @returns {Function} The function to remove this callback from the quadtree.
  */
 QuadtreePrimitive.prototype.updateHeight = function (
   cartographic,
   callback,
-  ownerId
+  owner
 ) {
   var primitive = this;
   var object = {
@@ -311,7 +311,7 @@ QuadtreePrimitive.prototype.updateHeight = function (
     positionCartographic: cartographic,
     level: -1,
     callback: callback,
-    ownerId: ownerId,
+    owner: owner,
   };
 
   object.removeFunc = function () {


### PR DESCRIPTION
#8006 Pass id of billboard to callback function to prevent multiple callbacks being registered for the same billboard in invalidateAllTiles, resulting in leaked/stale callbacks and bad clamped locations.