### PR TITLE
Fix coplanar polygon geometry example

### DIFF
--- a/Source/Core/CoplanarPolygonGeometry.js
+++ b/Source/Core/CoplanarPolygonGeometry.js
@@ -221,17 +221,16 @@ function createGeometryFromPolygon(
  * @param {Ellipsoid} [options.ellipsoid=Ellipsoid.WGS84] The ellipsoid to be used as a reference.
  *
  * @example
- * var polygon = new Cesium.CoplanarPolygonGeometry({
- *   positions : Cesium.Cartesian3.fromDegreesArrayHeights([
+ * var polygonGeometry = new Cesium.CoplanarPolygonGeometry({
+ *  polygonHierarchy: new Cesium.PolygonHierarchy(
+ *     Cesium.Cartesian3.fromDegreesArrayHeights([
  *      -90.0, 30.0, 0.0,
- *      -90.0, 30.0, 1000.0,
- *      -80.0, 30.0, 1000.0,
+ *      -90.0, 30.0, 300000.0,
+ *      -80.0, 30.0, 300000.0,
  *      -80.0, 30.0, 0.0
- *   ])
+ *   ]))
  * });
- * var geometry = Cesium.CoplanarPolygonGeometry.createGeometry(polygon);
  *
- * @see CoplanarPolygonGeometry.createGeometry
  */
 function CoplanarPolygonGeometry(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);


### PR DESCRIPTION
The example in the CoplanarGeometry doc has a few issues: https://cesium.com/docs/cesiumjs-ref-doc/CoplanarPolygonGeometry.html?classFilter=polygon. 

[Here's a Sandcastle using that code](https://sandcastle.cesium.com/index.html#c=jVLRSsMwFP2V0Bc70HTDF3XdUCaooCgovlgf7tprF0yTcpNVquzfTdq123SIeQjJPefc5JykAmKVwA8kNmEKP9gMjVgW/LmphUmQNvuZVhaEQkqCwThRiaqcrtSyzrXaFc50KUEBPbTgFeoCLdXhV6KYUxhhhVaGnfV8IOtWoI75G+niEnNCNBdEUF+jyBfWhC9e6sbR6ZAPD9lxM/tpX300HG5DJ/+D3OTLr4NErTYG8/XlncO/3fGUECz2ZtfJ+E5NUCQK57vC3ageunIbTnfajTIWlMvdhbTFvvoBt6KNzLG7pQdWg8YolCUCef5utzt3XRIgL3q861eskc0TddzmgZ7qEsODmZaaDtojVl1o7T/iJkWFvPdsOGRZ2G8H4+AwiI2tJU7XL8HORVFqsmxJMuQ8sli4lN2viObL9B0tT43x/T01jralcSYqJrLJnm/KUgnGOORtKeWj+MQkmMaR4/+SSg2ZUPl9hSSh9rTFaHrbFjnnceS2+5VWazkH+tH5Gw) to add a polygon to the scene. It's missing a `polygonHierarchy` argument, and it should be passing the polygon geometry directly to the geometry instance instead of calling `Cesium.CoplanarPolygonGeometry.createGeometry`.

I've updated the example to include the missing `polygonHierarchy` plus change the coordinates so it's more visible from a global view.

[Sandcastle with the new code](https://sandcastle.cesium.com/index.html#c=jVJNT4NAEP0rGy5CoktNL2qxsamJmmhsovEiHkaY0o3LLpndYtD0v7tAqQV7cA8TZt4H7GNKIFYK/ERil0zhJ5ujEeucvzQzP/aSpp9rZUEopNgLJrGKVel0hZZVptUN6hwtVX2DuS4kKKBFn+R/x6oT3gokoGRVXewLFwPQdwJ3Olsg655AjfmSdH6NGSGaGRFUtyiylTX+aytgJ+cjPjpm46bW5dB8PKrPHnj2X9CVevwWBLHa7IVCIhdWlNiPY9GNmwBYto3jThkLymXMehncDOBW9Ctz7EH4Nb4Jmg+FokCgWtY3fQCLJEDOdnhnm28Rxx9wm5CfqwL9o7mWmo7aV2y6O7erw02CCvnu6oZDmvq7Nph4x15kbCVxuk2SXYm80GTZmqTPeWgxd+vi/mz4vk4+0PLEmNq/pkbhvjRKRclEenlgM1kiwRiHLNdSPokvjL1pFDr+H6nUkAqVPZZIEqqatjqd3rdDznkUuvaw0mot34EGzj8).