### PR TITLE
Fix the wrong order of the boundary rectangles in TileAvailability

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Fixed several artifcats on mobile devices caused by using insufficient precision. [#9064](https://github.com/CesiumGS/cesium/pull/9064)
 - Fixed handling of `data:` scheme for the Cesium ion logo URL. [#9085](https://github.com/CesiumGS/cesium/pull/9085)
+- Fixed an issue where the boundary rectangles in TileAvailability are not sorted correctly. [#9098](https://github.com/CesiumGS/cesium/pull/9098)
 
 ### 1.72 - 2020-08-03
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 - Fixed several artifcats on mobile devices caused by using insufficient precision. [#9064](https://github.com/CesiumGS/cesium/pull/9064)
 - Fixed handling of `data:` scheme for the Cesium ion logo URL. [#9085](https://github.com/CesiumGS/cesium/pull/9085)
-- Fixed an issue where the boundary rectangles in TileAvailability are not sorted correctly. [#9098](https://github.com/CesiumGS/cesium/pull/9098)
+- Fixed an issue where the boundary rectangles in `TileAvailability` are not sorted correctly, causing terrain to sometimes fail to achieve its maximum detail. [#9098](https://github.com/CesiumGS/cesium/pull/9098)
 
 ### 1.72 - 2020-08-03
 

--- a/Source/Core/TileAvailability.js
+++ b/Source/Core/TileAvailability.js
@@ -361,7 +361,7 @@ function putRectangleInQuadtree(maxDepth, node, rectangle) {
       rectangle.level,
       rectangleLevelComparator
     );
-    if (index <= 0) {
+    if (index < 0) {
       index = ~index;
     }
     node.rectangles.splice(index, 0, rectangle);

--- a/Specs/Core/TileAvailabilitySpec.js
+++ b/Specs/Core/TileAvailabilitySpec.js
@@ -232,7 +232,7 @@ describe("Core/TileAvailability", function () {
       ).toBe(1);
     });
 
-    it("ensure the boundary rectangle is sorted properly", function () {
+    it("ensure the boundary rectangles are sorted properly", function () {
       var availability = new TileAvailability(geographic, 6);
       availability.addAvailableTileRange(0, 0, 0, 1, 0);
       availability.addAvailableTileRange(1, 0, 0, 2, 0);

--- a/Specs/Core/TileAvailabilitySpec.js
+++ b/Specs/Core/TileAvailabilitySpec.js
@@ -3,6 +3,7 @@ import { GeographicTilingScheme } from "../../Source/Cesium.js";
 import { Rectangle } from "../../Source/Cesium.js";
 import { TileAvailability } from "../../Source/Cesium.js";
 import { WebMercatorTilingScheme } from "../../Source/Cesium.js";
+import { defined } from "../../Source/Cesium.js";
 
 describe("Core/TileAvailability", function () {
   var webMercator = new WebMercatorTilingScheme();
@@ -190,6 +191,26 @@ describe("Core/TileAvailability", function () {
   });
 
   describe("addAvailableTileRange", function () {
+    function checkNodeRectanglesSorted(node) {
+      if (!defined(node)) {
+        return;
+      }
+
+      var levelRectangles = node.rectangles;
+      for (var i = 0; i < levelRectangles.length; ++i) {
+        for (var j = i; j < levelRectangles.length; ++j) {
+          expect(levelRectangles[i].level <= levelRectangles[j].level).toBe(
+            true
+          );
+        }
+      }
+
+      checkNodeRectanglesSorted(node._ne);
+      checkNodeRectanglesSorted(node._se);
+      checkNodeRectanglesSorted(node._nw);
+      checkNodeRectanglesSorted(node._sw);
+    }
+
     it("keeps availability ranges sorted by rectangle", function () {
       var availability = createAvailability(geographic, 15);
       availability.addAvailableTileRange(0, 0, 0, 1, 0);
@@ -209,6 +230,20 @@ describe("Core/TileAvailability", function () {
           new Cartographic(-Math.PI / 2.0, 0.0)
         )
       ).toBe(1);
+    });
+
+    it("ensure the boundary rectangle is sorted properly", function () {
+      var availability = new TileAvailability(geographic, 6);
+      availability.addAvailableTileRange(0, 0, 0, 1, 0);
+      availability.addAvailableTileRange(1, 0, 0, 2, 0);
+      availability.addAvailableTileRange(2, 0, 0, 4, 0);
+      availability.addAvailableTileRange(3, 0, 0, 8, 0);
+      availability.addAvailableTileRange(0, 0, 0, 1, 0);
+
+      for (var i = 0; i < availability._rootNodes.length; ++i) {
+        var node = availability._rootNodes[i];
+        checkNodeRectanglesSorted(node);
+      }
     });
   });
 });


### PR DESCRIPTION
When rectangles are inserted into the `QuadtreeNode` in `TileAvailability`, they are ordered by level using the index returned by `binarySearch()`. However, it negates the index when it is 0, which results in the wrong order of the rectangle lists and wrongly identify a tile is not available. This is the [Sandcastle example](https://sandcastle.cesium.com/#c=bVFdS8MwFP0rlz51UNNNRIR1Q9ir4MPAF+tDmt2uwTQpN0lnFf3tpl9OdOEG7tc599yk5QStxBMSbEDjCXZopa/Z05CL80gM8c5ox6VGyqPFOtdpCjtC7hA4CFM3nLgzBKXXwkmjwRmwyElU4Coy/lgB18CJeAemBO3rAsmyXP8AziQxT6BYwEeuIRxC5ylA4QqKMPcz3DYonhiC5OdVAtcJ3Mx2m8Ddy9TV11eTL/UB30I8rVdIzanbDxrjiS2BYGch/Z6yhHhEZhtYTqpmqq/B6VXlel7JNkoKHDEJLANlTyOMtkYhU+Y4D1usoyTKrOsUbsdVAe5l3Rhy4EnFjKUO60aFN7Zp4cUrOibswNa3ZulvaHaQLcjD5sJvgVDc2lApvVJ7+Y55tM3S0P8Pqgw/SH18bJEU7/q2arV9GJOMsSwN4WWkM0YVnP4wfwM)

Below is the visual problem:

Before the fix. The tile is not really detail because it is falsely identified as unavailable and therefore, upsampled from the parent
![Screenshot_20200818_013710](https://user-images.githubusercontent.com/20376598/90474524-743c3900-e0f3-11ea-8579-f14fb97037cc.png)

After the fix. It is much more detail now
![Screenshot_20200818_013345](https://user-images.githubusercontent.com/20376598/90474519-71d9df00-e0f3-11ea-84bd-735791cbd54f.png)

@lilleyse Can you please take a look at it? Please let me know if I should add anything


