### PR TITLE
Turn off throttle option when requesting for an availability tile from the parent terrain layer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 - Fixed several artifcats on mobile devices caused by using insufficient precision. [#9064](https://github.com/CesiumGS/cesium/pull/9064)
 - Fixed handling of `data:` scheme for the Cesium ion logo URL. [#9085](https://github.com/CesiumGS/cesium/pull/9085)
+- Fixed an issue where a request for availability tile of the reference layer is delayed when throttle option is on. [##9099](https://github.com/CesiumGS/cesium/pull/9099)
 
 ### 1.72 - 2020-08-03
 

--- a/Source/Core/ArcGISTiledElevationTerrainProvider.js
+++ b/Source/Core/ArcGISTiledElevationTerrainProvider.js
@@ -624,7 +624,7 @@ function requestAvailability(that, level, x, y) {
   }
 
   var request = new Request({
-    throttle: true,
+    throttle: false,
     throttleByServer: true,
     type: RequestType.TERRAIN,
   });

--- a/Source/Core/CesiumTerrainProvider.js
+++ b/Source/Core/CesiumTerrainProvider.js
@@ -1278,7 +1278,7 @@ function checkLayer(provider, x, y, level, layer, topLayer) {
           // For cutout terrain, if this isn't the top layer the availability tiles
           //  may never get loaded, so request it here.
           var request = new Request({
-            throttle: true,
+            throttle: false,
             throttleByServer: true,
             type: RequestType.TERRAIN,
           });

--- a/Source/Core/GoogleEarthEnterpriseTerrainProvider.js
+++ b/Source/Core/GoogleEarthEnterpriseTerrainProvider.js
@@ -604,7 +604,7 @@ GoogleEarthEnterpriseTerrainProvider.prototype.getTileDataAvailable = function (
   if (metadata.isValid(quadKey)) {
     // We will need this tile, so request metadata and return false for now
     var request = new Request({
-      throttle: true,
+      throttle: false,
       throttleByServer: true,
       type: RequestType.TERRAIN,
     });

--- a/Source/Scene/TimeDynamicImagery.js
+++ b/Source/Scene/TimeDynamicImagery.js
@@ -282,7 +282,7 @@ function addToCache(that, tile, interval) {
 
   var keyElements = getKeyElements(key);
   var request = new Request({
-    throttle: true,
+    throttle: false,
     throttleByServer: true,
     type: RequestType.IMAGERY,
     priorityFunction: tile.priorityFunction,

--- a/Specs/Core/ArcGISTiledElevationTerrainProviderSpec.js
+++ b/Specs/Core/ArcGISTiledElevationTerrainProviderSpec.js
@@ -474,12 +474,11 @@ describe("Core/ArcGISTiledElevationTerrainProvider", function () {
         var promise;
         var i;
         for (i = 0; i < RequestScheduler.maximumRequestsPerServer; ++i) {
-          promise = terrainProvider.requestTileGeometry(
-            0,
-            0,
-            0,
-            createRequest()
-          );
+          var request = new Request({
+            throttle: true,
+            throttleByServer: true,
+          });
+          promise = terrainProvider.requestTileGeometry(0, 0, 0, request);
         }
         RequestScheduler.update();
         expect(promise).toBeDefined();

--- a/Specs/Scene/TimeDynamicImagerySpec.js
+++ b/Specs/Scene/TimeDynamicImagerySpec.js
@@ -142,7 +142,7 @@ describe("Scene/TimeDynamicImagery", function () {
     options.reloadFunction.calls.reset(); // Constructor calls reload
 
     var request = new Request({
-      throttle: true,
+      throttle: false,
       throttleByServer: true,
       type: RequestType.IMAGERY,
     });
@@ -173,7 +173,7 @@ describe("Scene/TimeDynamicImagery", function () {
     options.reloadFunction.calls.reset(); // Constructor calls reload
 
     var request = new Request({
-      throttle: true,
+      throttle: false,
       throttleByServer: true,
       type: RequestType.IMAGERY,
     });


### PR DESCRIPTION
The function `checkLayer()` in the `CesiumTerrainProvider.js` file [is responsible for requesting an availability tile for the parent layer](https://github.com/CesiumGS/cesium/blob/13b40ad846d70f58b0385d0b69a9316e4b599706/Source/Core/CesiumTerrainProvider.js#L1280). However, the promise is delayed for a long time or never get resolved especially where the tile is overlapped with the child layer, which makes `QuadtreePrimitive` upsamples the tile from the parent tile. Turning off the throttle option in the Request object does solves the issue though. This is consistent with other requests coming from the other terrain code

This is the parent layer when all the tiles are available. Notice the three lines on the head of the two tiles at level 10
![Screenshot_20200818_170231](https://user-images.githubusercontent.com/20376598/90565336-c4a7ab00-e174-11ea-8020-ee08463a991f.png)

This is the missing tiles from the parent layer when delay happens. Notice there are no three lines on the head of the tiles at level 10. Keeping zooming in doesn't solve the problem
![Screenshot_20200818_170108](https://user-images.githubusercontent.com/20376598/90565431-e7d25a80-e174-11ea-95b5-77691d7984a8.png)

@lilleyse Can you please take a look at it? Please let me know if I need to add anything 