### PR TITLE
Add package.json to exports so it can be resolved

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,11 @@
   "module": "./Source/Cesium.js",
   "types": "./Source/Cesium.d.ts",
   "exports": {
-    "require": "./index.cjs",
-    "import": "./Source/Cesium.js"
+    "./package.json": "./package.json",
+    ".": {
+      "require": "./index.cjs",
+      "import": "./Source/Cesium.js"
+    }
   },
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
Many tools attempt to `require.resolve` `package.json`, and in the latest versions of node that is not possible if the package specifies `exports`. The solution is to simply add `package.json` to exports.

Resolves #8992