### PR TITLE
Fixed shadow volume regression for mobile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,11 +8,12 @@
 
 ##### Fixes :wrench:
 
-- Fixed several artifcats on mobile devices caused by using insufficient precision. [#9064](https://github.com/CesiumGS/cesium/pull/9064)
+- Fixed several artifacts on mobile devices caused by using insufficient precision. [#9064](https://github.com/CesiumGS/cesium/pull/9064)
 - Fixed handling of `data:` scheme for the Cesium ion logo URL. [#9085](https://github.com/CesiumGS/cesium/pull/9085)
 - Fixed an issue where the boundary rectangles in `TileAvailability` are not sorted correctly, causing terrain to sometimes fail to achieve its maximum detail. [#9098](https://github.com/CesiumGS/cesium/pull/9098)
 - Fixed an issue where a request for an availability tile of the reference layer is delayed because the throttle option is on. [#9099](https://github.com/CesiumGS/cesium/pull/9099)
 - Fixed an issue where Node.js tooling could not resolve package.json. [#9105](https://github.com/CesiumGS/cesium/pull/9105)
+- Fixed classification artifacts on some mobile devices. [#9108](https://github.com/CesiumGS/cesium/pull/9108)
 
 ### 1.72 - 2020-08-03
 

--- a/Source/Shaders/Builtin/Functions/depthClamp.glsl
+++ b/Source/Shaders/Builtin/Functions/depthClamp.glsl
@@ -1,16 +1,32 @@
 // emulated noperspective
-#ifndef LOG_DEPTH
+#if defined(GL_EXT_frag_depth) && !defined(LOG_DEPTH)
 varying float v_WindowZ;
 #endif
 
 /**
- * Clamps a vertex to the near and far planes.
+ * Emulates GL_DEPTH_CLAMP, which is not available in WebGL 1 or 2.
+ * GL_DEPTH_CLAMP clamps geometry that is outside the near and far planes, 
+ * capping the shadow volume. More information here: 
+ * https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_depth_clamp.txt.
+ *
+ * When GL_EXT_frag_depth is available we emulate GL_DEPTH_CLAMP by ensuring 
+ * no geometry gets clipped by setting the clip space z value to 0.0 and then
+ * sending the unaltered screen space z value (using emulated noperspective
+ * interpolation) to the frag shader where it is clamped to [0,1] and then
+ * written with gl_FragDepth (see czm_writeDepthClamp). This technique is based on:
+ * https://stackoverflow.com/questions/5960757/how-to-emulate-gl-depth-clamp-nv.
+ *
+ * When GL_EXT_frag_depth is not available, which is the case on some mobile 
+ * devices, we must attempt to fix this only in the vertex shader. 
+ * The approach is to clamp the z value to the far plane, which closes the 
+ * shadow volume but also distorts the geometry, so there can still be artifacts
+ * on frustum seams.
  *
  * @name czm_depthClamp
  * @glslFunction
  *
  * @param {vec4} coords The vertex in clip coordinates.
- * @returns {vec4} The vertex clipped to the near and far planes.
+ * @returns {vec4} The modified vertex.
  *
  * @example
  * gl_Position = czm_depthClamp(czm_modelViewProjection * vec4(position, 1.0));
@@ -20,8 +36,12 @@ varying float v_WindowZ;
 vec4 czm_depthClamp(vec4 coords)
 {
 #ifndef LOG_DEPTH
+#ifdef GL_EXT_frag_depth
     v_WindowZ = (0.5 * (coords.z / coords.w) + 0.5) * coords.w;
-    coords.z = clamp(coords.z, -coords.w, +coords.w);
+    coords.z = 0.0;
+#else
+    coords.z = min(coords.z, coords.w);
+#endif
 #endif
     return coords;
 }

--- a/Source/Shaders/Builtin/Functions/writeDepthClamp.glsl
+++ b/Source/Shaders/Builtin/Functions/writeDepthClamp.glsl
@@ -1,9 +1,11 @@
 // emulated noperspective
-#ifndef LOG_DEPTH
+#if defined(GL_EXT_frag_depth) && !defined(LOG_DEPTH)
 varying float v_WindowZ;
 #endif
+
 /**
- * Clamps a vertex to the far plane by writing the fragments depth.
+ * Emulates GL_DEPTH_CLAMP. Clamps a fragment to the near and far plane
+ * by writing the fragment's depth. See czm_depthClamp for more details.
  * <p>
  * The shader must enable the GL_EXT_frag_depth extension.
  * </p>


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/8953

https://github.com/CesiumGS/cesium/pull/8854 clamped vertices to the near plane in order to create a watertight shadow volume. While this happened to work well for orthographic mode, and worked sometimes on desktop (curiously, only when ANGLE was enabled), it broke down for mobile, and was flawed to begin with. This is because the way we do shadow volumes doesn't actually require the front of the volume to be closed, just the back.

Ultimately we want a solution that emulates `GL_DEPTH_CLAMP`, which is not available in WebGL 1 or 2. `GL_DEPTH_CLAMP` clamps geometry that is outside the near and far planes, capping the shadow volume. More information [here](https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_depth_clamp.txt).

We emulate `GL_DEPTH_CLAMP` by ensuring no geometry gets clipped by setting the clip space `z` value to `0.0` and then sending the unaltered screen space `z` value (using emulated `noperspective` interpolation) to the frag shader where it is clamped to `[0,1]` and then written with `gl_FragDepth`. This is the solution when `GL_EXT_frag_depth` is available and works for both perspective and orthographic. It is based off of https://stackoverflow.com/questions/5960757/how-to-emulate-gl-depth-clamp-nv.

When `GL_EXT_frag_depth` is not available, which is the case on some mobile devices, we must attempt to fix this only in the vertex shader. Our approach is to clamp the `z` value to the far plane, which closes the shadow volume but also distorts the geometry, so there can still be artifacts on frustum seams but it won't be as severe as the code in https://github.com/CesiumGS/cesium/pull/8854 which also clamps the near plane unnecessarily.

Before:
![Screenshot 2020-08-22 at 10 29 48 PM](https://user-images.githubusercontent.com/1328450/90969499-4b3af000-e4c7-11ea-8f71-8016c4540b98.png)

After:
![Screenshot 2020-08-22 at 10 30 46 PM](https://user-images.githubusercontent.com/1328450/90969496-47a76900-e4c7-11ea-917e-6751c6bfe510.png)

[Sandcastle](http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesium/shadowVolumeMobile/Apps/Sandcastle/index.html#c=vVZtb6NGEP4rW38JVukCxgY7b+qdk1OspmoU+3pfkKINrM32YBcti3O+Kv+9AwuOITiXfmglS7aZ2WeefWaYGctCHzii30iaJRSJNSpyxjeIoEc3SpFiSU4VUgKFCclztt4hwoWKqdzbKTjggG+JRFtGn8BygTh9QnOasyLFf1bPjGAQVv/ngivCOJXBwER/BxwhRaWEJ3dSbFlE5WlzMJSUKPpFyCRaaRdjaAb8eXgWcAhXweI8pJziRGyIZCpOWXhFMxV/LNbriseaAP3X/iFJqSQYiJfsjIoGQhHNFeNEMcHR6eEV5kQq+EW4azgjx3OnDva96dgf+aPZxES/jH3Xc8cuHtnjievaMxON7anjOlM8Gvv22B/PnJJ5GUNIRkGA1zFuKIlA9zumwvheJIlhY8ebAM5o5oxmM0DzIZKN3cnY9X3Pd2azycibeSaysW3bk6njeGN34tv+dDLx3GEtlAXZRVzIlCSthJWJzmKhxEaSNKVK7nQGG3MrhfrLvVppo9arkMk+VQvB72kuChlSvJYi/ZCD2yIygL7n7ZPWSkEmWcoU29Ickygy6rh1boFIXW5hJVUd+LNM0EUZOxhgbMFnWRXtFVHEanG05vo008etu9ZNraZo/8oFDwaNSi15ipxGraqHku8I1vi2+LIW4ffKeOSyVc10gHcZ3cs+f2XC8+vl4vPvD+7Vw2pxe90o30sO52oHb/xRisvSrEmGIhHwYgYDuXkkxmgCRW/rD54M4UV+R4J7Keh0g/orUDeHl7InCWvRFddEj4VCknLoFuCgqzvZaU+RZtAKILF1S+KCz/+r1OSxeDrVPaaR4Fi4/1fsYyy03kvCo5DkKqGl80psNgn9WCglOHTpJdypo3fZqZUsqInWBQ+r1mVURGMafqVRwIe6kR+pshLwonE+Kx2Pi6R9f3pxfn7pCDHQTrrTZQlTgvJlRkJ6vYXOeqOdjE67B4C8RKoxys6/4FmhPlTXMZp7GanY0hRg6hshVAauQCDsIebZi1kPE7AfzpYDe8bCr3ci3w+RvWdtYK3IOKufDPshyv6TxSy8JxEAHQyoxlA14H0woxt92GZ+Q9kmVu9Cqofmnh+Oq7M1Xih4LpJqFBsnZVBAr08emaUn6Gd0jF0/WkPsFWBj6EAeaNULXGcObvQGxe613wCKmPwxEDjRqti+zN/Curm7/zFWrJcGeHCCDrmWS0T3oYSl4q2AOpunzRFdGL0H3l6l3r9L9aiLv5W0TdRn2h03fS9NsGf82x2rX0qzV0uzK2YVM6ha1Emp07N5rClVk/n2+tPqYX67mP9WOg/MwXk1Ei41Z4R+ZWkmpCqnjgGrjaKw2sD+m1uPBfRChcM8b7Jxbh0ePY/YFrHoomfD1i0ZLOsiSZbsOw0Gl+cW+L86mojq+n9sqUzIrnSLnctb/RBjfG7B3/6TSojkkcgO8j8)

Here are some examples of frustum seam artifacts that could not be fixed in this PR when `GL_EXT_frag_depth` is not available. These artifacts have existed since shadow volumes were first implemented:

![Screenshot 2020-08-22 at 8 51 44 PM](https://user-images.githubusercontent.com/1328450/90968683-335e6e80-e4bd-11ea-8aaf-e0838e7fe16e.png)

![Screenshot 2020-08-22 at 9 15 44 PM](https://user-images.githubusercontent.com/1328450/90968685-35283200-e4bd-11ea-86ec-e19eedd8089d.png)

[Sandcastle for testing more options](http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesium/shadowVolumeMobile/Apps/Sandcastle/index.html#c=zVh7b9pIEP8qe/kn5o4ufmJM0t4RQprokgYR+pBKFTn2Ans1Xt/aJqVVvvvN+o1xEnpqpaJIsXdmfvPY2dkZr22O1pTcE45eIp/coyEJabzC75I16dBJXofMj2zqE37YRt9mPkIBZ/8QJ6LMH1PnM+F9FPGYtAUpIpwD75izNXUBtp9DOpzYEXnPuOdOUx6pNfMfWkczv/P7zF//P0sQcmCJfImuA2FO2M+XxY+Tf2MSRu/J3cJTUxtT4kOm+PfOzAfViQoMIMR3pUxvupi+XPhhAO4yfkW/UF8IFkKhQ3yCFx67I9glQbScgsLBAmwMo8xN8EdoPqrJeGxhcxotV9Q5FYIn8XyeOD+3vXCHO3NlAhYSfsVcUqLO/Bvbdx07jDyCbdedssXCIydxFDFfmh1cskWCPztooz0MaKN57CdbiyRnSWB33VYa0/2sz2SO0kA/7oMkwviQxRL2PqIeCUm0vfnpP+10mhKlbyjmXpFRF8yfkJDF3CF4ztlqEALPhSt1ZVNvoQR7S3/A6YpGdE1CESYp01iaEDBvs2D+OSXc5s5ys23LuEbNE2Vo8wiebF9LjJjYLjyHA9j6jfTxhYI1xdK1rqWapqbosqq2kYy7Vq8nd1VDky1Z/G+jlFGzDMPqyaqsq4pZMFqKYfZMU1ENvWTUFFWVLcPSujmjCWo0VbfkXrcA1DWjp6q6rBu63Cv4TMXqGobRtazep1YSJvCeE3fIPCb2MPdMvOLJ6BQ4KtT8Ed/D/g+8YGlLMjZymCLIwPlU9EV+VKL7mrPYd8c5j5Sd4gVhKxLxDZzAyPahBvS3hGpUqTj7uVy/YQdzKalSKepb399ZaefMD63i0Y4iTu/iiGyXHUdEp78Vxbqlg1wyyZmERcrjWuI/FE/U7aPZQWYTUuAsZ4UsZ3Y8OwzpnDq2OLrTTUBKA3ZIeDi6uXh7daud3k4vLkcZRKfjkrt4cbNk9zdL22X375gXrwiqFHeECpYTsV/UX2wxCZ4HqOrlmVpwQvzGvHo9GY3eAN8WR/nSnF0cyrDtQ3kr0Sb5Er4afLh9N7h8O6owj3/ddCwMb0rIwtF++dguyWsCRefLGeMrOyo2euR5NAgZdW9iPrchyYKA2FxYgt+NJtPRh9uz68nVYPrzU7ncxl86mStMe6YzS7sMSKaPWZRE7wHsh5lhG6SdouS6OsyUADvxYAuBKb9ZpVY1xkUm4l2/K4fmOcePtpNn/MNRn7nL876q/VhgTli0/PlBObmenv+oUNSw9g0AeiwCWUP484MwHU0mg4s3PyoOu3B7huLT0W5zyrw7m18RP5ayw5SerqLrBEsJdPRcamo7HXsF9zGGtk3MBXnBdEE79RN70VaJLXszSVGVLrRh2NChPTIUaJWgR9JNraurGlZ1A7ops9tG0CYpqqlhQ7MsDbq1bl6TGKdgVoOOc2KLwjGmkbOcMM+TuljtaUoPmjtTMS2jB6gv4AqTZdGxmT3VkqEvU9poh6+V1pskfj/Yc0PRsWkolqoZstbLPNc0AwPNNI2eaA6F67CIobfsQoOoy+b3+65j3TQhvl3VVGRDy31XFIhyT1MNBZpP3Ux8Ny3dgj/DAjZLK31/ENlQJkHjgJPkUDHhXLE1EdNNeYiS6GxhVCYNHy7FKTuz+TWni3pbMBe0N8AxEe5mjQQMO2+eEqoPQ2d1kGdGtGEcRmyFhAQC2cQXMQTuOYtt21zOYOhPpMjFD8vJ3lXcOHp2qjt7GjmBrAdnF/XRuW+7KIVwDVfG36BO2G/cfQ2juO3VWog9ItpoS3WY3bHntyp1/0F3CdZ79a8cN47omG4C6NpGa8ja85RJqpUAAEjKZYYhqsGFH8TRIM374gCs4ESsAKa4TYTiBKSWukclOS0wQK/Wmwo9oM7nMQuLwlJwZgS6pRkH2UqrGYItuB0sqQPjcuXqqRDSbjJXJtW1t7YtPyd0sYz2QsoKaWEfXiayR8XXpJB5yUmQDoVSQM8kH6mvh+gP9Jh1zWi5YTuAOaEGWYlVI3C2c+DREybW3X4CyKX8eSBgSr8Avh8+hXU+njyPtUyvEVg4RFVbxbVSX+RwzTylMN3Nfi6SJkajwNPX6/73a0N08Rdhdhs1kTaPk74KEly633vrNoey3RjLdj2Yic5ZUqIOk1LVfqwoJb3g5ehseju8vBj+LZgP2gfHYbTxyKu8N/yLrgLGI/GhTsK4E5FV4NkQqs5dDMUywk4Y5rtx3KmKHrt0DaPhy9lB7VPv7CCt5kCZx553Q7/Cbf/quAP8O6IeS9y/hvnYszeCbam8ukwXMcbHHXhtlozSpqKG/B8)

@lilleyse and I worked on this fix together so someone else should review. @kring?

CC @OmarShehata 