### PR TITLE
Fix the transformation of plane's normal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 - Fixed an issue where the boundary rectangles in `TileAvailability` are not sorted correctly, causing terrain to sometimes fail to achieve its maximum detail. [#9098](https://github.com/CesiumGS/cesium/pull/9098)
 - Fixed an issue where a request for an availability tile of the reference layer is delayed because the throttle option is on. [#9099](https://github.com/CesiumGS/cesium/pull/9099)
 - Fixed an issue where Node.js tooling could not resolve package.json. [#9105](https://github.com/CesiumGS/cesium/pull/9105)
+- Fixed an issue where plane's normal is not transformed correctly with a non-uniform scale matrix. [#9109](https://github.com/CesiumGS/cesium/issues/9109)
 
 ### 1.72 - 2020-08-03
 

--- a/Source/Core/Plane.js
+++ b/Source/Core/Plane.js
@@ -193,6 +193,8 @@ Plane.projectPointOntoPlane = function (plane, point, result) {
 };
 
 var scratchPosition = new Cartesian3();
+var scratchInverseTransform = new Matrix4();
+var scratchTransposeTransform = new Matrix4();
 /**
  * Transforms the plane by the given transformation matrix.
  *
@@ -207,7 +209,11 @@ Plane.transform = function (plane, transform, result) {
   Check.typeOf.object("transform", transform);
   //>>includeEnd('debug');
 
-  Matrix4.multiplyByPointAsVector(transform, plane.normal, scratchNormal);
+  var normalTransform = Matrix4.transpose(
+    Matrix4.inverse(transform, scratchInverseTransform),
+    scratchTransposeTransform
+  );
+  Matrix4.multiplyByPointAsVector(normalTransform, plane.normal, scratchNormal);
   Cartesian3.normalize(scratchNormal, scratchNormal);
 
   Cartesian3.multiplyByScalar(plane.normal, -plane.distance, scratchPosition);

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -18,6 +18,7 @@ import GeometryPipeline from "../Core/GeometryPipeline.js";
 import IndexDatatype from "../Core/IndexDatatype.js";
 import Intersect from "../Core/Intersect.js";
 import CesiumMath from "../Core/Math.js";
+import Matrix3 from "../Core/Matrix3.js";
 import Matrix4 from "../Core/Matrix4.js";
 import NearFarScalar from "../Core/NearFarScalar.js";
 import OrientedBoundingBox from "../Core/OrientedBoundingBox.js";
@@ -1513,15 +1514,18 @@ function calcClippingPlanesMatrix(frameState, globeSurfaceTileProvider) {
     : Matrix4.IDENTITY;
 }
 
-var scratchInverseClippingPlaneMatrix = new Matrix4();
-var scratchTransposeClippingPlaneMatrix = new Matrix4();
+var scratchTransformMatrix3 = new Matrix3();
+var scratchInverseClippingPlaneMatrix = new Matrix3();
+var scratchTransposeClippingPlaneMatrix = new Matrix3();
 function calcNormalClippingPlanesMatrix(frameState, globeSurfaceTileProvider) {
   var transform = calcClippingPlanesMatrix(
     frameState,
     globeSurfaceTileProvider
   );
-  return Matrix4.transpose(
-    Matrix4.inverse(transform, scratchInverseClippingPlaneMatrix),
+  var transformMatrix3 = Matrix4.getMatrix3(transform, scratchTransformMatrix3);
+
+  return Matrix3.transpose(
+    Matrix3.inverse(transformMatrix3, scratchInverseClippingPlaneMatrix),
     scratchTransposeClippingPlaneMatrix
   );
 }

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -3685,13 +3685,18 @@ function createClippingPlanesMatrixFunction(model) {
   };
 }
 
-var scratchInverseClippingPlaneMatrix = new Matrix4();
-var scratchTransposeClippingPlaneMatrix = new Matrix4();
+var scratchTransformMatrix3 = new Matrix3();
+var scratchInverseClippingPlaneMatrix = new Matrix3();
+var scratchTransposeClippingPlaneMatrix = new Matrix3();
 function createNormalClippingPlanesMatrixFunction(model) {
   return function () {
     var transform = calcClippingPlanesMatrix(model);
-    return Matrix4.transpose(
-      Matrix4.inverse(transform, scratchInverseClippingPlaneMatrix),
+    var transformMatrix3 = Matrix4.getMatrix3(
+      transform,
+      scratchTransformMatrix3
+    );
+    return Matrix3.transpose(
+      Matrix3.inverse(transformMatrix3, scratchInverseClippingPlaneMatrix),
       scratchTransposeClippingPlaneMatrix
     );
   };
@@ -4818,7 +4823,7 @@ function modifyShaderForClippingPlanes(
   shader +=
     "uniform highp sampler2D gltf_clippingPlanes; \n" +
     "uniform mat4 gltf_clippingPlanesMatrix; \n" +
-    "uniform mat4 gltf_normalClippingPlanesMatrix; \n" +
+    "uniform mat3 gltf_normalClippingPlanesMatrix; \n" +
     "uniform vec4 gltf_clippingPlanesEdgeStyle; \n" +
     "void main() \n" +
     "{ \n" +

--- a/Source/Scene/PointCloud.js
+++ b/Source/Scene/PointCloud.js
@@ -12,6 +12,7 @@ import defined from "../Core/defined.js";
 import destroyObject from "../Core/destroyObject.js";
 import getStringFromTypedArray from "../Core/getStringFromTypedArray.js";
 import CesiumMath from "../Core/Math.js";
+import Matrix3 from "../Core/Matrix3.js";
 import Matrix4 from "../Core/Matrix4.js";
 import oneTimeWarning from "../Core/oneTimeWarning.js";
 import OrthographicFrustum from "../Core/OrthographicFrustum.js";
@@ -891,12 +892,14 @@ function calcClippingPlanesMatrix(pointCloud, frameState) {
   );
 }
 
-var scratchInverseClippingPlaneMatrix = new Matrix4();
-var scratchTransposeClippingPlaneMatrix = new Matrix4();
+var scratchTransformMatrix3 = new Matrix3();
+var scratchInverseClippingPlaneMatrix = new Matrix3();
+var scratchTransposeClippingPlaneMatrix = new Matrix3();
 function calcNormalClippingPlanesMatrix(pointCloud, frameState) {
   var transform = calcClippingPlanesMatrix(pointCloud, frameState);
-  return Matrix4.transpose(
-    Matrix4.inverse(transform, scratchInverseClippingPlaneMatrix),
+  var transformMatrix3 = Matrix4.getMatrix3(transform, scratchTransformMatrix3);
+  return Matrix3.transpose(
+    Matrix3.inverse(transformMatrix3, scratchInverseClippingPlaneMatrix),
     scratchTransposeClippingPlaneMatrix
   );
 }
@@ -1376,7 +1379,7 @@ function createShaders(pointCloud, frameState, style) {
     fs +=
       "uniform highp sampler2D u_clippingPlanes; \n" +
       "uniform mat4 u_clippingPlanesMatrix; \n" +
-      "uniform mat4 u_normalClippingPlanesMatrix; \n" +
+      "uniform mat3 u_normalClippingPlanesMatrix; \n" +
       "uniform vec4 u_clippingPlanesEdgeStyle; \n";
     fs += "\n";
     fs += getClippingFunction(clippingPlanes, context);

--- a/Source/Scene/getClipAndStyleCode.js
+++ b/Source/Scene/getClipAndStyleCode.js
@@ -12,11 +12,13 @@ import Check from "../Core/Check.js";
 function getClipAndStyleCode(
   samplerUniformName,
   matrixUniformName,
+  normalMatrixUniformName,
   styleUniformName
 ) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.string("samplerUniformName", samplerUniformName);
   Check.typeOf.string("matrixUniformName", matrixUniformName);
+  Check.typeOf.string("normalMatrixUniformName", normalMatrixUniformName);
   Check.typeOf.string("styleUniformName", styleUniformName);
   //>>includeEnd('debug');
 
@@ -25,6 +27,8 @@ function getClipAndStyleCode(
     samplerUniformName +
     ", " +
     matrixUniformName +
+    ", " +
+    normalMatrixUniformName +
     "); \n" +
     "    vec4 clippingPlanesEdgeColor = vec4(1.0); \n" +
     "    clippingPlanesEdgeColor.rgb = " +

--- a/Source/Scene/getClippingFunction.js
+++ b/Source/Scene/getClippingFunction.js
@@ -39,7 +39,7 @@ function getClippingFunction(clippingPlaneCollection, context) {
 
 function clippingFunctionUnion(clippingPlanesLength) {
   var functionString =
-    "float clip(vec4 fragCoord, sampler2D clippingPlanes, mat4 clippingPlanesMatrix, mat4 normalClippingPlanesMatrix)\n" +
+    "float clip(vec4 fragCoord, sampler2D clippingPlanes, mat4 clippingPlanesMatrix, mat3 normalClippingPlanesMatrix)\n" +
     "{\n" +
     "    vec4 position = czm_windowToEyeCoordinates(fragCoord);\n" +
     "    vec3 clipNormal = vec3(0.0);\n" +
@@ -72,7 +72,7 @@ function clippingFunctionUnion(clippingPlanesLength) {
 
 function clippingFunctionIntersect(clippingPlanesLength) {
   var functionString =
-    "float clip(vec4 fragCoord, sampler2D clippingPlanes, mat4 clippingPlanesMatrix, mat4 normalClippingPlanesMatrix)\n" +
+    "float clip(vec4 fragCoord, sampler2D clippingPlanes, mat4 clippingPlanesMatrix, mat3 normalClippingPlanesMatrix)\n" +
     "{\n" +
     "    bool clipped = true;\n" +
     "    vec4 position = czm_windowToEyeCoordinates(fragCoord);\n" +
@@ -114,7 +114,7 @@ function getClippingPlaneFloat(width, height) {
   }
 
   var functionString =
-    "vec4 getClippingPlane(highp sampler2D packedClippingPlanes, int clippingPlaneNumber, mat4 transform, mat4 normalTransform)\n" +
+    "vec4 getClippingPlane(highp sampler2D packedClippingPlanes, int clippingPlaneNumber, mat4 transform, mat3 normalTransform)\n" +
     "{\n" +
     "    int pixY = clippingPlaneNumber / " +
     width +
@@ -148,7 +148,7 @@ function getClippingPlaneUint8(width, height) {
   }
 
   var functionString =
-    "vec4 getClippingPlane(highp sampler2D packedClippingPlanes, int clippingPlaneNumber, mat4 transform, mat4 normalTransform)\n" +
+    "vec4 getClippingPlane(highp sampler2D packedClippingPlanes, int clippingPlaneNumber, mat4 transform, mat3 normalTransform)\n" +
     "{\n" +
     "    int clippingPlaneStartIndex = clippingPlaneNumber * 2;\n" + // clipping planes are two pixels each
     "    int pixY = clippingPlaneStartIndex / " +

--- a/Source/Scene/getClippingFunction.js
+++ b/Source/Scene/getClippingFunction.js
@@ -39,7 +39,7 @@ function getClippingFunction(clippingPlaneCollection, context) {
 
 function clippingFunctionUnion(clippingPlanesLength) {
   var functionString =
-    "float clip(vec4 fragCoord, sampler2D clippingPlanes, mat4 clippingPlanesMatrix)\n" +
+    "float clip(vec4 fragCoord, sampler2D clippingPlanes, mat4 clippingPlanesMatrix, mat4 normalClippingPlanesMatrix)\n" +
     "{\n" +
     "    vec4 position = czm_windowToEyeCoordinates(fragCoord);\n" +
     "    vec3 clipNormal = vec3(0.0);\n" +
@@ -51,7 +51,7 @@ function clippingFunctionUnion(clippingPlanesLength) {
     clippingPlanesLength +
     "; ++i)\n" +
     "    {\n" +
-    "        vec4 clippingPlane = getClippingPlane(clippingPlanes, i, clippingPlanesMatrix);\n" +
+    "        vec4 clippingPlane = getClippingPlane(clippingPlanes, i, clippingPlanesMatrix, normalClippingPlanesMatrix);\n" +
     "        clipNormal = clippingPlane.xyz;\n" +
     "        clipPosition = -clippingPlane.w * clipNormal;\n" +
     "        float amount = dot(clipNormal, (position.xyz - clipPosition)) / pixelWidth;\n" +
@@ -72,7 +72,7 @@ function clippingFunctionUnion(clippingPlanesLength) {
 
 function clippingFunctionIntersect(clippingPlanesLength) {
   var functionString =
-    "float clip(vec4 fragCoord, sampler2D clippingPlanes, mat4 clippingPlanesMatrix)\n" +
+    "float clip(vec4 fragCoord, sampler2D clippingPlanes, mat4 clippingPlanesMatrix, mat4 normalClippingPlanesMatrix)\n" +
     "{\n" +
     "    bool clipped = true;\n" +
     "    vec4 position = czm_windowToEyeCoordinates(fragCoord);\n" +
@@ -84,7 +84,7 @@ function clippingFunctionIntersect(clippingPlanesLength) {
     clippingPlanesLength +
     "; ++i)\n" +
     "    {\n" +
-    "        vec4 clippingPlane = getClippingPlane(clippingPlanes, i, clippingPlanesMatrix);\n" +
+    "        vec4 clippingPlane = getClippingPlane(clippingPlanes, i, clippingPlanesMatrix, normalClippingPlanesMatrix);\n" +
     "        clipNormal = clippingPlane.xyz;\n" +
     "        clipPosition = -clippingPlane.w * clipNormal;\n" +
     "        float amount = dot(clipNormal, (position.xyz - clipPosition)) / pixelWidth;\n" +
@@ -114,7 +114,7 @@ function getClippingPlaneFloat(width, height) {
   }
 
   var functionString =
-    "vec4 getClippingPlane(highp sampler2D packedClippingPlanes, int clippingPlaneNumber, mat4 transform)\n" +
+    "vec4 getClippingPlane(highp sampler2D packedClippingPlanes, int clippingPlaneNumber, mat4 transform, mat4 normalTransform)\n" +
     "{\n" +
     "    int pixY = clippingPlaneNumber / " +
     width +
@@ -129,7 +129,7 @@ function getClippingPlaneFloat(width, height) {
     pixelHeightString +
     ";\n" +
     "    vec4 plane = texture2D(packedClippingPlanes, vec2(u, v));\n" +
-    "    return czm_transformPlane(plane, transform);\n" +
+    "    return czm_transformPlane(plane, transform, normalTransform);\n" +
     "}\n";
   return functionString;
 }
@@ -148,7 +148,7 @@ function getClippingPlaneUint8(width, height) {
   }
 
   var functionString =
-    "vec4 getClippingPlane(highp sampler2D packedClippingPlanes, int clippingPlaneNumber, mat4 transform)\n" +
+    "vec4 getClippingPlane(highp sampler2D packedClippingPlanes, int clippingPlaneNumber, mat4 transform, mat4 normalTransform)\n" +
     "{\n" +
     "    int clippingPlaneStartIndex = clippingPlaneNumber * 2;\n" + // clipping planes are two pixels each
     "    int pixY = clippingPlaneStartIndex / " +
@@ -170,7 +170,7 @@ function getClippingPlaneUint8(width, height) {
     "    plane.w = czm_unpackFloat(texture2D(packedClippingPlanes, vec2(u + " +
     pixelWidthString +
     ", v)));\n" +
-    "    return czm_transformPlane(plane, transform);\n" +
+    "    return czm_transformPlane(plane, transform, normalTransform);\n" +
     "}\n";
   return functionString;
 }

--- a/Source/Shaders/Builtin/Functions/transformPlane.glsl
+++ b/Source/Shaders/Builtin/Functions/transformPlane.glsl
@@ -1,5 +1,5 @@
-vec4 czm_transformPlane(vec4 clippingPlane, mat4 transform) {
-    vec3 transformedDirection = normalize((transform * vec4(clippingPlane.xyz, 0.0)).xyz);
+vec4 czm_transformPlane(vec4 clippingPlane, mat4 transform, mat4 normalTransform) {
+    vec3 transformedDirection = normalize((normalTransform * vec4(clippingPlane.xyz, 0.0)).xyz);
     vec3 transformedPosition = (transform * vec4(clippingPlane.xyz * -clippingPlane.w, 1.0)).xyz;
     vec4 transformedPlane;
     transformedPlane.xyz = transformedDirection;

--- a/Source/Shaders/Builtin/Functions/transformPlane.glsl
+++ b/Source/Shaders/Builtin/Functions/transformPlane.glsl
@@ -1,5 +1,5 @@
-vec4 czm_transformPlane(vec4 clippingPlane, mat4 transform, mat4 normalTransform) {
-    vec3 transformedDirection = normalize((normalTransform * vec4(clippingPlane.xyz, 0.0)).xyz);
+vec4 czm_transformPlane(vec4 clippingPlane, mat4 transform, mat3 normalTransform) {
+    vec3 transformedDirection = normalize(normalTransform * clippingPlane.xyz);
     vec3 transformedPosition = (transform * vec4(clippingPlane.xyz * -clippingPlane.w, 1.0)).xyz;
     vec4 transformedPlane;
     transformedPlane.xyz = transformedDirection;

--- a/Source/Shaders/GlobeFS.glsl
+++ b/Source/Shaders/GlobeFS.glsl
@@ -74,6 +74,7 @@ uniform vec2 u_nightFadeDistance;
 #ifdef ENABLE_CLIPPING_PLANES
 uniform highp sampler2D u_clippingPlanes;
 uniform mat4 u_clippingPlanesMatrix;
+uniform mat4 u_normalClippingPlanesMatrix;
 uniform vec4 u_clippingPlanesEdgeStyle;
 #endif
 
@@ -301,7 +302,7 @@ void main()
 #endif
 
 #ifdef ENABLE_CLIPPING_PLANES
-    float clipDistance = clip(gl_FragCoord, u_clippingPlanes, u_clippingPlanesMatrix);
+    float clipDistance = clip(gl_FragCoord, u_clippingPlanes, u_clippingPlanesMatrix, u_normalClippingPlanesMatrix);
 #endif
 
 #if defined(SHOW_REFLECTIVE_OCEAN) || defined(ENABLE_DAYNIGHT_SHADING) || defined(HDR)

--- a/Source/Shaders/GlobeFS.glsl
+++ b/Source/Shaders/GlobeFS.glsl
@@ -74,7 +74,7 @@ uniform vec2 u_nightFadeDistance;
 #ifdef ENABLE_CLIPPING_PLANES
 uniform highp sampler2D u_clippingPlanes;
 uniform mat4 u_clippingPlanesMatrix;
-uniform mat4 u_normalClippingPlanesMatrix;
+uniform mat3 u_normalClippingPlanesMatrix;
 uniform vec4 u_clippingPlanesEdgeStyle;
 #endif
 

--- a/Specs/Core/PlaneSpec.js
+++ b/Specs/Core/PlaneSpec.js
@@ -241,6 +241,37 @@ describe("Core/Plane", function () {
     expect(transformedPlane.normal.z).toEqual(-plane.normal.z);
   });
 
+  it("transforms a plane according to a non-uniform scale transform", function () {
+    var normal = new Cartesian3(1.0, 0.0, 1.0);
+    normal = Cartesian3.normalize(normal, normal);
+    var plane = new Plane(normal, 0.0);
+    var planeOrigin = new Cartesian3(0.0, 0.0, 0.0);
+    var planePosition = new Cartesian3(1.0, 0.0, -1.0);
+    var planeDiff = Cartesian3.subtract(
+      planePosition,
+      planeOrigin,
+      new Cartesian3()
+    );
+    expect(Cartesian3.dot(planeDiff, plane.normal)).toEqualEpsilon(
+      0.0,
+      CesiumMath.EPSILON16
+    );
+
+    var transform = Matrix4.fromScale(
+      new Cartesian3(4.0, 1.0, 10.0),
+      new Matrix4()
+    );
+    var transformPlane = Plane.transform(plane, transform);
+    var transformPlaneDiff = Matrix4.multiplyByPointAsVector(
+      transform,
+      planeDiff,
+      new Cartesian3()
+    );
+    expect(
+      Cartesian3.dot(transformPlaneDiff, transformPlane.normal)
+    ).toEqualEpsilon(0.0, CesiumMath.EPSILON16);
+  });
+
   it("transform throws without a plane", function () {
     var transform = Matrix4.IDENTITY;
     expect(function () {

--- a/Specs/Renderer/BuiltinFunctionsSpec.js
+++ b/Specs/Renderer/BuiltinFunctionsSpec.js
@@ -440,7 +440,11 @@ describe(
         "                            0.0, 2.0, 0.0, 0.0," +
         "                            0.0, 0.0, 2.0, 0.0," +
         "                            0.0, 0.0, 0.0, 1.0);" +
-        "  gl_FragColor = vec4(all(equal(czm_transformPlane(vec4(1.0, 0.0, 0.0, 10.0), uniformScale2), vec4(1.0, 0.0, 0.0, 20.0))));" +
+        "  mat4 uniformNormalScale2 = mat4(0.5, 0.0, 0.0, 0.0," +
+        "                                  0.0, 0.5, 0.0, 0.0," +
+        "                                  0.0, 0.0, 0.5, 0.0," +
+        "                                  0.0, 0.0, 0.0, 1.0);" +
+        "  gl_FragColor = vec4(all(equal(czm_transformPlane(vec4(1.0, 0.0, 0.0, 10.0), uniformScale2, uniformNormalScale2), vec4(1.0, 0.0, 0.0, 20.0))));" +
         "}";
       expect({
         context: context,

--- a/Specs/Renderer/BuiltinFunctionsSpec.js
+++ b/Specs/Renderer/BuiltinFunctionsSpec.js
@@ -440,10 +440,9 @@ describe(
         "                            0.0, 2.0, 0.0, 0.0," +
         "                            0.0, 0.0, 2.0, 0.0," +
         "                            0.0, 0.0, 0.0, 1.0);" +
-        "  mat4 uniformNormalScale2 = mat4(0.5, 0.0, 0.0, 0.0," +
-        "                                  0.0, 0.5, 0.0, 0.0," +
-        "                                  0.0, 0.0, 0.5, 0.0," +
-        "                                  0.0, 0.0, 0.0, 1.0);" +
+        "  mat3 uniformNormalScale2 = mat3(0.5, 0.0, 0.0," +
+        "                                  0.0, 0.5, 0.0," +
+        "                                  0.0, 0.0, 0.5);" +
         "  gl_FragColor = vec4(all(equal(czm_transformPlane(vec4(1.0, 0.0, 0.0, 10.0), uniformScale2, uniformNormalScale2), vec4(1.0, 0.0, 0.0, 20.0))));" +
         "}";
       expect({


### PR DESCRIPTION
Fixes #9109 

This PR will convert the transformation matrix to a normal matrix before multiplying with the plane's normal. Most of the fix happens in glsl `czm_transformPlane()` function and `Cesium.Plane.transform()`

@lilleyse Can you please take a look at it?