### PR TITLE
Fix the issue where resource silently fails to load

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 - Fixed an issue where the boundary rectangles in `TileAvailability` are not sorted correctly, causing terrain to sometimes fail to achieve its maximum detail. [#9098](https://github.com/CesiumGS/cesium/pull/9098)
 - Fixed an issue where a request for an availability tile of the reference layer is delayed because the throttle option is on. [#9099](https://github.com/CesiumGS/cesium/pull/9099)
 - Fixed an issue where Node.js tooling could not resolve package.json. [#9105](https://github.com/CesiumGS/cesium/pull/9105)
+- Fixed an issue where Resource silently fails to load if being used multiple times. [#9093](https://github.com/CesiumGS/cesium/issues/9093)
 
 ### 1.72 - 2020-08-03
 


### PR DESCRIPTION
Fixes #9093 

When `request.deferred.resolve(result)` get called in the function `RequestScheduler.getRequestReceivedFunction()`, the callback can potentially create a new `deferred` object and assign it to the existing `request`. But after the `resolve()` above is executed, the `request.deferred` is assigned to `undefined`, which accidentally removes the newly created `deferred` object. So the second call of `RequestScheduler.getRequestReceivedFunction()` for the same request will lead to error of `request.undefined.resolve(result)`. 

For the fix, I save the old deferred object first, then modify the state of request, and call the `resolve()` at the end. The fix is similar to the cancel function just in case it can have the same potential problem

@lilleyse Can you please take a look at it? Please let me know if I should add anything