### PR TITLE
Update prettier to version ^2.1.1

### DIFF
--- a/Apps/CesiumViewer/index.html
+++ b/Apps/CesiumViewer/index.html
@@ -14,7 +14,7 @@
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
     <link rel="stylesheet" href="CesiumViewer.css" media="screen" />
   </head>
-  <body style="background: #000;">
+  <body style="background: #000">
     <div id="cesiumContainer" class="fullWindow"></div>
     <div id="loadingIndicator" class="loadingIndicator"></div>
     <script src="CesiumViewer.js" type="module"></script>

--- a/Apps/Sandcastle/gallery/Globe Materials.html
+++ b/Apps/Sandcastle/gallery/Globe Materials.html
@@ -87,7 +87,7 @@
         <div>
           Spacing
           <input
-            style="width: 136px;"
+            style="width: 136px"
             type="range"
             min="1.0"
             max="500.0"
@@ -99,7 +99,7 @@
         <div>
           Line Width
           <input
-            style="width: 125px;"
+            style="width: 125px"
             type="range"
             min="1.0"
             max="10.0"

--- a/Apps/Sandcastle/gallery/HTML Overlays.html
+++ b/Apps/Sandcastle/gallery/HTML Overlays.html
@@ -33,7 +33,7 @@
     <div id="toolbar"></div>
     <img
       id="htmlOverlay"
-      style="position: absolute;"
+      style="position: absolute"
       src="../images/Cesium_Logo_overlay.png"
     />
     <script id="cesium_sandcastle_script">

--- a/Apps/Sandcastle/index.html
+++ b/Apps/Sandcastle/index.html
@@ -75,7 +75,7 @@
           <a href="http://cesium.com/" target="_blank"
             ><img
               src="./images/Cesium_Logo_Color_Overlay.png"
-              style="width: 118px;"
+              style="width: 118px"
           /></a>
         </div>
         <div
@@ -119,7 +119,7 @@
                 data-dojo-type="dijit.form.Textarea"
                 id="description"
                 data-dojo-props="trim:true"
-                style="width: 335px;"
+                style="width: 335px"
               ></textarea>
             </div>
             <br />
@@ -129,7 +129,7 @@
                 data-dojo-type="dijit.form.Textarea"
                 id="label"
                 data-dojo-props="trim:true"
-                style="width: 335px;"
+                style="width: 335px"
               ></textarea>
             </div>
           </div>
@@ -204,7 +204,7 @@
                 data-dojo-type="dijit.form.Textarea"
                 id="gistId"
                 data-dojo-props="trim:true"
-                style="width: 335px;"
+                style="width: 335px"
               ></textarea>
             </div>
             <div id="buttonImport" data-dojo-type="dijit.form.Button">

--- a/Apps/TimelineDemo/index.html
+++ b/Apps/TimelineDemo/index.html
@@ -194,7 +194,7 @@
       class="themeSelector"
     >
       <span>Theme: Lighter</span>
-      <div data-dojo-type="dijit.Menu" id="themeMenu" style="display: none;">
+      <div data-dojo-type="dijit.Menu" id="themeMenu" style="display: none">
         <div id="themeLighter" data-dojo-type="dijit.MenuItem">Lighter</div>
         <div id="themeDarker" data-dojo-type="dijit.MenuItem">Darker</div>
       </div>
@@ -239,9 +239,7 @@
       </div>
       <div class="info">
         <p>Visible Timespan: <span id="formatted">(none)</span></p>
-        <p id="endBeforeStart">
-          ERROR: Start time must come before end time.
-        </p>
+        <p id="endBeforeStart">ERROR: Start time must come before end time.</p>
       </div>
     </div>
 

--- a/Documentation/Contributors/CodingGuide/README.md
+++ b/Documentation/Contributors/CodingGuide/README.md
@@ -182,6 +182,7 @@ Cartesian3.fromDegrees = function (
 
 ```javascript
 "use strict";
+
 ```
 
 - :speedboat: To avoid type coercion (implicit type conversion), test for equality with `===` and `!==`, e.g.,

--- a/Source/Core/Color.js
+++ b/Source/Core/Color.js
@@ -541,10 +541,10 @@ Color.equals = function (left, right) {
   return (
     left === right || //
     (defined(left) && //
-    defined(right) && //
-    left.red === right.red && //
-    left.green === right.green && //
-    left.blue === right.blue && //
+      defined(right) && //
+      left.red === right.red && //
+      left.green === right.green && //
+      left.blue === right.blue && //
       left.alpha === right.alpha)
   );
 };
@@ -592,9 +592,9 @@ Color.prototype.equalsEpsilon = function (other, epsilon) {
   return (
     this === other || //
     (defined(other) && //
-    Math.abs(this.red - other.red) <= epsilon && //
-    Math.abs(this.green - other.green) <= epsilon && //
-    Math.abs(this.blue - other.blue) <= epsilon && //
+      Math.abs(this.red - other.red) <= epsilon && //
+      Math.abs(this.green - other.green) <= epsilon && //
+      Math.abs(this.blue - other.blue) <= epsilon && //
       Math.abs(this.alpha - other.alpha) <= epsilon)
   );
 };

--- a/Source/Core/Iau2006XysData.js
+++ b/Source/Core/Iau2006XysData.js
@@ -251,7 +251,7 @@ function requestXysChunk(xysData, chunkIndex) {
   if (defined(xysFileUrlTemplate)) {
     chunkUrl = xysFileUrlTemplate.getDerivedResource({
       templateValues: {
-        "0": chunkIndex,
+        0: chunkIndex,
       },
     });
   } else {

--- a/Source/DataSources/CheckerboardMaterialProperty.js
+++ b/Source/DataSources/CheckerboardMaterialProperty.js
@@ -143,8 +143,8 @@ CheckerboardMaterialProperty.prototype.equals = function (other) {
   return (
     this === other || //
     (other instanceof CheckerboardMaterialProperty && //
-    Property.equals(this._evenColor, other._evenColor) && //
-    Property.equals(this._oddColor, other._oddColor) && //
+      Property.equals(this._evenColor, other._evenColor) && //
+      Property.equals(this._oddColor, other._oddColor) && //
       Property.equals(this._repeat, other._repeat))
   );
 };

--- a/Source/DataSources/CompositePositionProperty.js
+++ b/Source/DataSources/CompositePositionProperty.js
@@ -135,7 +135,7 @@ CompositePositionProperty.prototype.equals = function (other) {
   return (
     this === other || //
     (other instanceof CompositePositionProperty && //
-    this._referenceFrame === other._referenceFrame && //
+      this._referenceFrame === other._referenceFrame && //
       this._composite.equals(other._composite, Property.equals))
   );
 };

--- a/Source/DataSources/GridMaterialProperty.js
+++ b/Source/DataSources/GridMaterialProperty.js
@@ -188,10 +188,10 @@ GridMaterialProperty.prototype.equals = function (other) {
   return (
     this === other || //
     (other instanceof GridMaterialProperty && //
-    Property.equals(this._color, other._color) && //
-    Property.equals(this._cellAlpha, other._cellAlpha) && //
-    Property.equals(this._lineCount, other._lineCount) && //
-    Property.equals(this._lineThickness, other._lineThickness) && //
+      Property.equals(this._color, other._color) && //
+      Property.equals(this._cellAlpha, other._cellAlpha) && //
+      Property.equals(this._lineCount, other._lineCount) && //
+      Property.equals(this._lineThickness, other._lineThickness) && //
       Property.equals(this._lineOffset, other._lineOffset))
   );
 };

--- a/Source/DataSources/PolylineOutlineMaterialProperty.js
+++ b/Source/DataSources/PolylineOutlineMaterialProperty.js
@@ -144,8 +144,8 @@ PolylineOutlineMaterialProperty.prototype.equals = function (other) {
   return (
     this === other || //
     (other instanceof PolylineOutlineMaterialProperty && //
-    Property.equals(this._color, other._color) && //
-    Property.equals(this._outlineColor, other._outlineColor) && //
+      Property.equals(this._color, other._color) && //
+      Property.equals(this._outlineColor, other._outlineColor) && //
       Property.equals(this._outlineWidth, other._outlineWidth))
   );
 };

--- a/Source/DataSources/PositionPropertyArray.js
+++ b/Source/DataSources/PositionPropertyArray.js
@@ -176,7 +176,7 @@ PositionPropertyArray.prototype.equals = function (other) {
   return (
     this === other || //
     (other instanceof PositionPropertyArray && //
-    this._referenceFrame === other._referenceFrame && //
+      this._referenceFrame === other._referenceFrame && //
       Property.arrayEquals(this._value, other._value))
   );
 };

--- a/Source/DataSources/SampledPositionProperty.js
+++ b/Source/DataSources/SampledPositionProperty.js
@@ -318,7 +318,7 @@ SampledPositionProperty.prototype.equals = function (other) {
   return (
     this === other || //
     (other instanceof SampledPositionProperty &&
-    Property.equals(this._property, other._property) && //
+      Property.equals(this._property, other._property) && //
       this._referenceFrame === other._referenceFrame)
   );
 };

--- a/Source/DataSources/StripeMaterialProperty.js
+++ b/Source/DataSources/StripeMaterialProperty.js
@@ -177,10 +177,10 @@ StripeMaterialProperty.prototype.equals = function (other) {
   return (
     this === other || //
     (other instanceof StripeMaterialProperty && //
-    Property.equals(this._orientation, other._orientation) && //
-    Property.equals(this._evenColor, other._evenColor) && //
-    Property.equals(this._oddColor, other._oddColor) && //
-    Property.equals(this._offset, other._offset) && //
+      Property.equals(this._orientation, other._orientation) && //
+      Property.equals(this._evenColor, other._evenColor) && //
+      Property.equals(this._oddColor, other._oddColor) && //
+      Property.equals(this._offset, other._offset) && //
       Property.equals(this._repeat, other._repeat))
   );
 };

--- a/Source/DataSources/TimeIntervalCollectionPositionProperty.js
+++ b/Source/DataSources/TimeIntervalCollectionPositionProperty.js
@@ -136,7 +136,7 @@ TimeIntervalCollectionPositionProperty.prototype.equals = function (other) {
   return (
     this === other || //
     (other instanceof TimeIntervalCollectionPositionProperty && //
-    this._intervals.equals(other._intervals, Property.equals) && //
+      this._intervals.equals(other._intervals, Property.equals) && //
       this._referenceFrame === other._referenceFrame)
   );
 };

--- a/Specs/Core/ResourceSpec.js
+++ b/Specs/Core/ResourceSpec.js
@@ -224,8 +224,8 @@ describe("Core/Resource", function () {
     var resource = new Resource({
       url: "http://test.com/tileset/{0}/{1}",
       templateValues: {
-        "0": "test1",
-        "1": "test2",
+        0: "test1",
+        1: "test2",
       },
     });
 

--- a/Specs/SpecRunner.html
+++ b/Specs/SpecRunner.html
@@ -25,7 +25,7 @@
   </head>
   <body>
     <span
-      style="font-family: 'Open Sans'; position: absolute; visibility: hidden;"
+      style="font-family: 'Open Sans'; position: absolute; visibility: hidden"
       >&nbsp;</span
     >
     <script>

--- a/index.release.html
+++ b/index.release.html
@@ -42,13 +42,13 @@
       }
     </style>
   </head>
-  <body style="background-color: #f5f7f9;">
+  <body style="background-color: #f5f7f9">
     <div>
       <div class="section">
         <a href="https://cesium.com/cesiumjs/"
           ><img
             src="https://cesium.com/images/logos/cesiumjs/cesiumjs_color_black.png"
-            style="width: 400px;"
+            style="width: 400px"
         /></a>
       </div>
       <div class="section">
@@ -152,7 +152,7 @@
           </tbody>
         </table>
         <div
-          style="padding-top: 300px; font-size: 10pt; vertical-align: bottom;"
+          style="padding-top: 300px; font-size: 10pt; vertical-align: bottom"
         >
           &copy; 2011-2020 CesiumJS Contributors
         </div>

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "mime": "^2.0.3",
     "mkdirp": "^1.0.0",
     "open": "^7.0.0",
-    "prettier": "^2.0.4",
+    "prettier": "^2.1.1",
     "pretty-quick": "^2.0.1",
     "request": "^2.79.0",
     "rimraf": "^3.0.0",


### PR DESCRIPTION
The `prettier` version in `package.json` is currently `^2.0.4` and a new `2.1.x` version was [released](https://www.npmjs.com/package/prettier/v/2.1.0) 2 days ago. We are now using this version (because of the `^`) but it's not compatible with `2.0.x`.

This pull request update the version and fixes the code.
