### PR TITLE
Support 3D Tiles feature picking in Viewer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Additions :tada:
 
 - Add support for the CSS `line-height` specifier in the `font` property of a `Label`. [#8954](https://github.com/CesiumGS/cesium/pull/8954)
+- `Viewer` now has default pick handling for `Cesium3DTileFeature` data and will display its properties in the default Viewer `InfoBox` as well as set `Viewer.selectedEntity` to a transient Entity instance representing the data.
 
 ##### Fixes :wrench:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,11 +5,11 @@
 ##### Additions :tada:
 
 - Add support for the CSS `line-height` specifier in the `font` property of a `Label`. [#8954](https://github.com/CesiumGS/cesium/pull/8954)
-- `Viewer` now has default pick handling for `Cesium3DTileFeature` data and will display its properties in the default Viewer `InfoBox` as well as set `Viewer.selectedEntity` to a transient Entity instance representing the data.
+- `Viewer` now has default pick handling for `Cesium3DTileFeature` data and will display its properties in the default Viewer `InfoBox` as well as set `Viewer.selectedEntity` to a transient Entity instance representing the data. [#9121](https://github.com/CesiumGS/cesium/pull/9121).
 
 ##### Fixes :wrench:
 
-- Fixed several artifcats on mobile devices caused by using insufficient precision. [#9064](https://github.com/CesiumGS/cesium/pull/9064)
+- Fixed several artifacts on mobile devices caused by using insufficient precision. [#9064](https://github.com/CesiumGS/cesium/pull/9064)
 - Fixed handling of `data:` scheme for the Cesium ion logo URL. [#9085](https://github.com/CesiumGS/cesium/pull/9085)
 - Fixed an issue where the boundary rectangles in `TileAvailability` are not sorted correctly, causing terrain to sometimes fail to achieve its maximum detail. [#9098](https://github.com/CesiumGS/cesium/pull/9098)
 - Fixed an issue where a request for an availability tile of the reference layer is delayed because the throttle option is on. [#9099](https://github.com/CesiumGS/cesium/pull/9099)

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -58,7 +58,7 @@ function getCesium3DTileFeatureDescription(feature) {
   var propertyNames = feature.getPropertyNames();
 
   var html = "";
-  propertyNames.forEach((propertyName) => {
+  propertyNames.forEach(function (propertyName) {
     var value = feature.getProperty(propertyName);
     if (defined(value)) {
       html += "<tr><th>" + propertyName + "</th><td>" + value + "</td></tr>";
@@ -76,9 +76,10 @@ function getCesium3DTileFeatureDescription(feature) {
 }
 
 function getCesium3DTileFeatureName(feature) {
+  var i;
   var possibleNames = [];
   var propertyNames = feature.getPropertyNames();
-  for (var i = 0; i < propertyNames.length; i++) {
+  for (i = 0; i < propertyNames.length; i++) {
     var propertyName = propertyNames[i];
     if (/^name$/i.test(propertyName)) {
       possibleNames[0] = feature.getProperty(propertyName);
@@ -95,9 +96,14 @@ function getCesium3DTileFeatureName(feature) {
     }
   }
 
-  var name = possibleNames.find((item) => defined(item));
-  if (!defined(name) || name === "") {
-    name = "Unnamed Feature";
+  var name = "Unnamed Feature";
+  var length = possibleNames.length;
+  for (i = 0; i < length; i++) {
+    var item = possibleNames[i];
+    if (!defined(item) || item === "") {
+      name = possibleNames[i];
+      break;
+    }
   }
   return name;
 }

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -96,16 +96,14 @@ function getCesium3DTileFeatureName(feature) {
     }
   }
 
-  var name = "Unnamed Feature";
   var length = possibleNames.length;
   for (i = 0; i < length; i++) {
     var item = possibleNames[i];
-    if (!defined(item) || item === "") {
-      name = possibleNames[i];
-      break;
+    if (defined(item) && item !== "") {
+      return item;
     }
   }
-  return name;
+  return "Unnamed Feature";
 }
 
 function pickEntity(viewer, e) {

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -76,6 +76,12 @@ function getCesium3DTileFeatureDescription(feature) {
 }
 
 function getCesium3DTileFeatureName(feature) {
+  // We need to iterate all property names to find potential
+  // candidates, but since we prefer some property names
+  // over others, we store them in an indexed array
+  // and then use the first defined element in the array
+  // as the preferred choice.
+
   var i;
   var possibleNames = [];
   var propertyNames = feature.getPropertyNames();
@@ -1437,6 +1443,10 @@ Object.defineProperties(Viewer.prototype, {
   },
   /**
    * Gets or sets the object instance for which to display a selection indicator.
+   *
+   * If a user interactively picks a Cesium3DTilesFeature instance, then this property
+   * will contain a transient Entity instance with a property named "feature" that is
+   * the instance that was picked.
    * @memberof Viewer.prototype
    * @type {Entity | undefined}
    */


### PR DESCRIPTION
Viewer` now has default pick handling for `Cesium3DTileFeature` data and will display its properties in the default `InfoBox` as well as set `Viewer.selectedEntity` to a transient Entity instance representing the data. While a little clunky, this is identical to how ImageryLayer picking has worked for ages.