### PR TITLE
Use an exact version of prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "mime": "^2.0.3",
     "mkdirp": "^1.0.0",
     "open": "^7.0.0",
-    "prettier": "^2.1.1",
+    "prettier": "2.1.1",
     "pretty-quick": "^2.0.1",
     "request": "^2.79.0",
     "rimraf": "^3.0.0",


### PR DESCRIPTION
As [recommended by the prettier project](https://prettier.io/docs/en/install.html#summary):

> Install an exact version of Prettier locally in your project. This makes sure that everyone in the project gets the exact same version of Prettier. Even a patch release of Prettier can result in slightly different formatting, so you wouldn’t want different team members using different versions and formatting each other’s changes back and forth.

Also avoids build failures when a new version of prettier comes out.