### PR TITLE
primitive can be used to per-feature postprocess

### DIFF
--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -491,7 +491,7 @@ Object.defineProperties(Primitive.prototype, {
   /**
    * get pickIds. insure primitive can be used to per-feature postprocess .
    * @memberof Primitive.prototype
-   * @type {PickId[]}
+   * @type {Array}
    * @readonly
    */
   pickIds: {

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -498,7 +498,7 @@ Object.defineProperties(Primitive.prototype, {
     get: function () {
       return this._pickIds;
     }
- },
+  },
 });
 
 function getCommonPerInstanceAttributeNames(instances) {

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -487,6 +487,18 @@ Object.defineProperties(Primitive.prototype, {
       return this._readyPromise.promise;
     },
   },
+  
+  /**
+   * get pickIds. insure primitive can be used to per-feature postprocess .
+   * @memberof Primitive.prototype
+   * @type {PickId[]}
+   * @readonly
+   */
+  pickIds: {
+    get: function () {
+      return this._pickIds;
+    }
+ },
 });
 
 function getCommonPerInstanceAttributeNames(instances) {


### PR DESCRIPTION
before this, set primitive selected in the per-feature postprocess had no effect, because they can't get the primitive's  pickIds.
add a readonly property to insure primitive can be used to per-feature postprocess