### PR TITLE
Extend far plane slightly to prevent clipping

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Fixed an issue where the camera zooming is stuck when looking up. [#9126](https://github.com/CesiumGS/cesium/pull/9126)
 - Fixed an issue where Plane doesn't rotate correctly around the main local axis. [#8268](https://github.com/CesiumGS/cesium/issues/8268)
+- Fixed an issue where ground primitives would get clipped at certain camera angles. [#9114](https://github.com/CesiumGS/cesium/issues/9114)
 
 ### 1.73 - 2020-09-01
 

--- a/Source/Scene/View.js
+++ b/Source/Scene/View.js
@@ -126,6 +126,9 @@ function updateFrustums(view, scene, near, far) {
   var is2D = scene.mode === SceneMode.SCENE2D;
   var nearToFarDistance2D = scene.nearToFarDistance2D;
 
+  // Extend the far plane slightly further to prevent geometry clipping against the far plane.
+  far *= 1.0 + CesiumMath.EPSILON2;
+
   // The computed near plane must be between the user defined near and far planes.
   // The computed far plane must between the user defined far and computed near.
   // This will handle the case where the computed near plane is further than the user defined far plane.


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/9114

https://github.com/CesiumGS/cesium/pull/8850 made it so that the far plane only goes as far as the farthest object visible to the camera. The problem was geometry right on the far plane might get clipped at certain camera angles. This was somewhat hardware dependent since the problem didn't happen on my 2015 Macbook but happened on mostly everything else.

The fix was to extend the far plane a bit further than the farthest object:

```
// Extend the far plane slightly further to prevent geometry clipping against the far plane.
far *= 1.0 + CesiumMath.EPSILON2;
```

Here's a debug view showing the problem. The ground primitive's bounding volume lines up almost perfectly with the frustum which causes clipping.

![alignment2](https://user-images.githubusercontent.com/915398/92308725-e921c680-ef6d-11ea-98b0-3006b2c59a6b.png)

![alignment](https://user-images.githubusercontent.com/915398/92308724-e8893000-ef6d-11ea-9c83-7e31af431847.jpg)

[Sandcastle for testing](https://sandcastle.cesium.com/#c=pVRrb9owFP0rFl8apNR5kgel1VqoVKSxVStaNQmpMskNeHPsyHYo7dT/PiehlLVoX/YJ+/rcc+7jkA2RaEPhESQ6Rxwe0RgUrUv8vY1Zi17W3seCa0I5yEXPRr8XHCENUprIrRQbmoMcviZmEoiGeyFZPu8gVn/BX/pnC77gG6MGXFP9ZNQ6WdzeKShM8txqqSuhTETwPeeYSG1OhAe4kKKcwEoCKOvUc0OcptEg9gc2ClIch37kmaPbtxseYIxWCoZdwQgpKOmMciEvt1QNkR+79sED+fnxwXFK04ykhL3VIpiQ+P5mOr/Gj1SvL1m1JpaLB/0m5eWt1a47lQEHvGJiCfhB1bIgGWBNGbwODj/ksKxXhktCIUkJZjIFYQoMyx3heUaUZtAMZy5WKwZXtdaCWyd7/Ind4c1PzbNmbla2huwX5P2u8f+pZMd0drwtZZYN/K4yTGODl6SxiRSMtWslSwZmWowqU9MENLTFHbTnOH+xMbEi0ky0pNkEKr2+qouiteUr/p161kpiBboxq7Vbcg5KU05aqeGho99MZIzjx57vxtj1/ST24zAIbXQaxuEgCkLsJqmbDIIwslHoDuIojHGShG7kh14c9HfOEJIa4x6RuQGSU766pTpbfzPdWxH2k8AzhG7sxekgMbSnHh7EbpxGgR/FaZikUbQ3rbEtz+eScFUIWaK972ZES7oN8XRy/WU+nf94vxHYapNo7dBdsLtMuarM7IWc0S3lTVLP7o2UfmJw0Ski9ImWlZAa1ZJZGDsayooZ5ytnWZv9a5wp1SQ20JFzmDrK6QbR/PzIhwJljChlXoqasTv6DIvexcgx+A+pTLQz+7oBychTA1t7F5+7IMZ45Jjr8UwtBFsSI7bv5OCt+/zMgNfvlA9Rz0KU3X9K/QOliBkIHMcdnv8A)