### PR TITLE
Ignore empty tile 's SSE when refining tile

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,13 +4,6 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
-    {
-        "name": "Launch Chrome",
-        "request": "launch",
-        "type": "pwa-chrome",
-        "url": "http://localhost:8080",
-        "webRoot": "${workspaceFolder}"
-    },
         {
             "type": "node",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,13 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
+    {
+        "name": "Launch Chrome",
+        "request": "launch",
+        "type": "pwa-chrome",
+        "url": "http://localhost:8080",
+        "webRoot": "${workspaceFolder}"
+    },
         {
             "type": "node",
             "request": "launch",

--- a/Source/Scene/Cesium3DTilesetTraversal.js
+++ b/Source/Scene/Cesium3DTilesetTraversal.js
@@ -653,29 +653,22 @@ function executeEmptyTraversal(tileset, root, frameState) {
 
     // Only traverse if the tile is empty - traversal stop at descendants with content
     var emptyContent = hasEmptyContent(tile);
+    var traverse = emptyContent;
     var emptyLeaf = emptyContent && tile.children.length === 0;
-    var traverse = true;
-    if (tile.children.length === 0) {
-      traverse = false;
-    } else if (tile.hasTilesetContent) {
-      traverse = !tile.contentExpired;
-    }
-    traverse = emptyContent && traverse;
 
     // Traversal stops but the tile does not have content yet
     // There will be holes if the parent tries to refine to its children, so don't refine
     // One exception: a parent may refine even if one of its descendants is an empty leaf
     if (!traverse && !tile.contentAvailable && !emptyLeaf) {
-      root._criminal = tile;
       allDescendantsLoaded = false;
     }
 
     updateTile(tileset, tile, frameState);
-    if (!isVisible(tile) || !tile.contentAvailable) {
+    if (!isVisible(tile)) {
       // Load tiles that aren't visible since they are still needed for the parent to refine
       loadTile(tileset, tile, frameState);
-      touchTile(tileset, tile, frameState);
     }
+    touchTile(tileset, tile, frameState);
 
     if (traverse) {
       for (var i = 0; i < childrenLength; ++i) {

--- a/Source/Scene/Cesium3DTilesetTraversal.js
+++ b/Source/Scene/Cesium3DTilesetTraversal.js
@@ -653,18 +653,25 @@ function executeEmptyTraversal(tileset, root, frameState) {
 
     // Only traverse if the tile is empty - traversal stop at descendants with content
     var emptyContent = hasEmptyContent(tile);
-    var traverse = emptyContent && canTraverse(tileset, tile);
     var emptyLeaf = emptyContent && tile.children.length === 0;
+    var traverse = true;
+    if (tile.children.length === 0) {
+      traverse = false;
+    } else if (tile.hasTilesetContent) {
+      traverse = !tile.contentExpired;
+    }
+    traverse = emptyContent && traverse;
 
     // Traversal stops but the tile does not have content yet
     // There will be holes if the parent tries to refine to its children, so don't refine
     // One exception: a parent may refine even if one of its descendants is an empty leaf
     if (!traverse && !tile.contentAvailable && !emptyLeaf) {
+      root._criminal = tile;
       allDescendantsLoaded = false;
     }
 
     updateTile(tileset, tile, frameState);
-    if (!isVisible(tile)) {
+    if (!isVisible(tile) || !tile.contentAvailable) {
       // Load tiles that aren't visible since they are still needed for the parent to refine
       loadTile(tileset, tile, frameState);
       touchTile(tileset, tile, frameState);

--- a/Source/Scene/Cesium3DTilesetTraversal.js
+++ b/Source/Scene/Cesium3DTilesetTraversal.js
@@ -653,13 +653,12 @@ function executeEmptyTraversal(tileset, root, frameState) {
 
     // Only traverse if the tile is empty - traversal stop at descendants with content
     var emptyContent = hasEmptyContent(tile);
-    var traverse = emptyContent;
     var emptyLeaf = emptyContent && tile.children.length === 0;
 
     // Traversal stops but the tile does not have content yet
     // There will be holes if the parent tries to refine to its children, so don't refine
     // One exception: a parent may refine even if one of its descendants is an empty leaf
-    if (!traverse && !tile.contentAvailable && !emptyLeaf) {
+    if (!emptyContent && !tile.contentAvailable && !emptyLeaf) {
       allDescendantsLoaded = false;
     }
 
@@ -670,7 +669,8 @@ function executeEmptyTraversal(tileset, root, frameState) {
     }
     touchTile(tileset, tile, frameState);
 
-    if (traverse) {
+    // Only traverse down for empty tile
+    if (emptyContent) {
       for (var i = 0; i < childrenLength; ++i) {
         var child = children[i];
         stack.push(child);

--- a/Source/Scene/Cesium3DTilesetTraversal.js
+++ b/Source/Scene/Cesium3DTilesetTraversal.js
@@ -323,7 +323,7 @@ function meetsScreenSpaceErrorEarly(tileset, tile, frameState) {
   var parent = tile.parent;
   if (
     !defined(parent) ||
-    parent.hasTilesetContent ||
+    hasEmptyContent(parent) ||
     parent.refine !== Cesium3DTileRefine.ADD
   ) {
     return false;
@@ -660,40 +660,15 @@ function executeEmptyTraversal(tileset, root, frameState) {
     // Only traverse if the tile is empty - traversal stop at descendants with content
     var emptyContent = hasEmptyContent(tile);
     var emptyLeaf = emptyContent && tile.children.length === 0;
-    var traverse = emptyContent;
-    var childUpdated = false;
-    var child;
-    var i;
 
     // Traversal stops but the tile does not have content yet
     // There will be holes if the parent tries to refine to its children, so don't refine
     // One exception: a parent may refine even if one of its descendants is an empty leaf
     if (!emptyContent && !tile.contentAvailable && !emptyLeaf) {
       allDescendantsLoaded = false;
-    } else if (emptyContent && tile.refine === Cesium3DTileRefine.ADD) {
-      // set flag to prevent another update tile when traversing down
-      childUpdated = true;
-
-      // check if any child is visible and content is available to render in this frame
-      var anyVisibleChild = false;
-      var addRefineHasAllEmpty = true;
-      for (i = 0; i < childrenLength; ++i) {
-        child = children[i];
-        updateTile(tileset, child, frameState);
-        addRefineHasAllEmpty &= hasEmptyContent(child);
-        anyVisibleChild |= isVisible(child) && child.contentAvailable;
-      }
-
-      // if at least one children has content, but none of them are visible or
-      // content are not ready, then we don't want to refine to prevent hole
-      if (!anyVisibleChild && !addRefineHasAllEmpty) {
-        allDescendantsLoaded = false;
-      }
-
-      // only traverse down if all children are empty
-      traverse = emptyContent && addRefineHasAllEmpty;
     }
 
+    updateTile(tileset, tile, frameState);
     if (!isVisible(tile)) {
       // Load tiles that aren't visible since they are still needed for the parent to refine
       loadTile(tileset, tile, frameState);
@@ -701,12 +676,9 @@ function executeEmptyTraversal(tileset, root, frameState) {
     }
 
     // Only traverse down for empty tile
-    if (traverse) {
-      for (i = 0; i < childrenLength; ++i) {
-        child = children[i];
-        if (!childUpdated) {
-          updateTile(tileset, child, frameState);
-        }
+    if (emptyContent) {
+      for (var i = 0; i < childrenLength; ++i) {
+        var child = children[i];
         stack.push(child);
       }
     }

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -1308,7 +1308,7 @@ describe(
       });
     });
 
-    it("replacement refinement - refines when tile with ADD refinement has children to render", function () {
+    it("replacement refinement - refines when tile with add refinement has children to render", function () {
       // No children have content, but all grandchildren have content
       //
       //          C

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -1286,7 +1286,7 @@ describe(
       });
     });
 
-    it("replacement refinement - selects upwards when tile with add refinement doesn't have available children to render", function () {
+    it("replacement refinement - refines when ignoring empty tiles", function () {
       // No children have content, but all grandchildren have content
       //
       //          C
@@ -1301,24 +1301,6 @@ describe(
         setZoom(80);
         scene.renderForSpecs();
 
-        var statistics = tileset._statistics;
-        expect(statistics.selected).toEqual(1);
-        expect(statistics.visited).toEqual(3);
-        expect(isSelected(tileset, tileset.root)).toBe(true);
-      });
-    });
-
-    it("replacement refinement - refines when tile with add refinement has children to render", function () {
-      // No children have content, but all grandchildren have content
-      //
-      //          C
-      //      E       E
-      //    C   C   C   C
-      //
-      return Cesium3DTilesTester.loadTileset(
-        scene,
-        tilesetReplacement1Url
-      ).then(function (tileset) {
         var statistics = tileset._statistics;
         expect(statistics.selected).toEqual(4);
         expect(statistics.visited).toEqual(7);

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -1286,7 +1286,7 @@ describe(
       });
     });
 
-    it("replacement refinement - selects upwards when traversal stops at empty tile", function () {
+    it("replacement refinement - selects upwards when tile with add refinement doesn't have available children to render", function () {
       // No children have content, but all grandchildren have content
       //
       //          C
@@ -1305,6 +1305,23 @@ describe(
         expect(statistics.selected).toEqual(1);
         expect(statistics.visited).toEqual(3);
         expect(isSelected(tileset, tileset.root)).toBe(true);
+      });
+    });
+
+    it("replacement refinement - refines when tile with ADD refinement has children to render", function () {
+      // No children have content, but all grandchildren have content
+      //
+      //          C
+      //      E       E
+      //    C   C   C   C
+      //
+      return Cesium3DTilesTester.loadTileset(
+        scene,
+        tilesetReplacement1Url
+      ).then(function (tileset) {
+        var statistics = tileset._statistics;
+        expect(statistics.selected).toEqual(4);
+        expect(statistics.visited).toEqual(7);
       });
     });
 


### PR DESCRIPTION
We got a support issue where the tileset has some of the empty tiles that are near the leaf of the tree. These tiles usually have low SSE, which prevents the current tile from refining further. It is unfortunate that we have to ignore empty tile's SSE and traverse down the tree until we meet a tile that has content available to render.

@lilleyse Can you please take a look at it? Please let me know if I should add anything