### PR TITLE
Fix wms 1.3.0 get feature info

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -276,3 +276,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Yonatan Kra](https://github.com/yonatankra)
 - [Gusain Vipul](https://github.com/vipulgusain)
 - [Sam Bakkach](https://github.com/sambakk)
+- [Zoran Kokeza](https://github.com/zoran995)

--- a/Source/Scene/WebMapServiceImageryProvider.js
+++ b/Source/Scene/WebMapServiceImageryProvider.js
@@ -255,10 +255,16 @@ function WebMapServiceImageryProvider(options) {
 
   var pickFeatureParams = {
     query_layers: options.layers,
-    x: "{i}",
-    y: "{j}",
     info_format: "{format}",
   };
+  // use correct pixel coordinate identifier based on version
+  if (parseFloat(resource.queryParameters.version) >= 1.3) {
+    pickFeatureParams.i = "{i}";
+    pickFeatureParams.j = "{j}";
+  } else {
+    pickFeatureParams.x = "{i}";
+    pickFeatureParams.y = "{j}";
+  }
   pickFeatureResource.setQueryParameters(pickFeatureParams, true);
 
   this._resource = resource;

--- a/Source/Scene/WebMapServiceImageryProvider.js
+++ b/Source/Scene/WebMapServiceImageryProvider.js
@@ -258,7 +258,7 @@ function WebMapServiceImageryProvider(options) {
     info_format: "{format}",
   };
   // use correct pixel coordinate identifier based on version
-  if (parseFloat(resource.queryParameters.version) >= 1.3) {
+  if (parseFloat(pickFeatureResource.queryParameters.version) >= 1.3) {
     pickFeatureParams.i = "{i}";
     pickFeatureParams.j = "{j}";
   } else {

--- a/Specs/Scene/WebMapServiceImageryProviderSpec.js
+++ b/Specs/Scene/WebMapServiceImageryProviderSpec.js
@@ -1390,6 +1390,131 @@ describe("Scene/WebMapServiceImageryProvider", function () {
       });
     });
 
+    it("generates correct getFeatureInfo link, WMS 1.1.1, version in getFeatureInfoParameters", function () {
+      var provider = new WebMapServiceImageryProvider({
+        url: "made/up/wms/server",
+        layers: "someLayer",
+        getFeatureInfoParameters: {
+          version: "1.1.1",
+        },
+      });
+
+      Resource._Implementations.loadWithXhr = function (
+        url,
+        responseType,
+        method,
+        data,
+        headers,
+        deferred,
+        overrideMimeType
+      ) {
+        expect(url).toContain("GetFeatureInfo");
+        expect(url).toContain("1.1.1");
+        expect(url).not.toContain("1.3.0");
+        expect(url).toContain("&x=");
+        expect(url).toContain("&y=");
+        expect(url).not.toContain("&i=");
+        expect(url).not.toContain("&j=");
+        Resource._DefaultImplementations.loadWithXhr(
+          "Data/WMS/GetFeatureInfo-MapInfoMXP.xml",
+          responseType,
+          method,
+          data,
+          headers,
+          deferred,
+          overrideMimeType
+        );
+      };
+
+      return pollToPromise(function () {
+        return provider.ready;
+      }).then(function () {
+        return provider.pickFeatures(0, 0, 0, 0.5, 0.5);
+      });
+    });
+
+    it("generates correct getFeatureInfo link, WMS 1.3.0, version in getFeatureInfoParameters", function () {
+      var provider = new WebMapServiceImageryProvider({
+        url: "made/up/wms/server",
+        layers: "someLayer",
+        getFeatureInfoParameters: {
+          version: "1.3.0",
+        },
+      });
+
+      Resource._Implementations.loadWithXhr = function (
+        url,
+        responseType,
+        method,
+        data,
+        headers,
+        deferred,
+        overrideMimeType
+      ) {
+        expect(url).toContain("GetFeatureInfo");
+        expect(url).not.toContain("1.1.1");
+        expect(url).toContain("1.3.0");
+        expect(url).not.toContain("&x=");
+        expect(url).not.toContain("&y=");
+        expect(url).toContain("&i=");
+        expect(url).toContain("&j=");
+        Resource._DefaultImplementations.loadWithXhr(
+          "Data/WMS/GetFeatureInfo-MapInfoMXP.xml",
+          responseType,
+          method,
+          data,
+          headers,
+          deferred,
+          overrideMimeType
+        );
+      };
+
+      return pollToPromise(function () {
+        return provider.ready;
+      }).then(function () {
+        return provider.pickFeatures(0, 0, 0, 0.5, 0.5);
+      });
+    });
+
+    it("generates correct getFeatureInfo link, WMS 1.1.1, default version", function () {
+      var provider = new WebMapServiceImageryProvider({
+        url: "made/up/wms/server",
+        layers: "someLayer",
+      });
+
+      Resource._Implementations.loadWithXhr = function (
+        url,
+        responseType,
+        method,
+        data,
+        headers,
+        deferred,
+        overrideMimeType
+      ) {
+        expect(url).toContain("GetFeatureInfo");
+        expect(url).toContain("1.1.1");
+        expect(url).not.toContain("1.3.0");
+        expect(url).toContain("&x=");
+        expect(url).toContain("&y=");
+        expect(url).not.toContain("&i=");
+        expect(url).not.toContain("&j=");
+        Resource._DefaultImplementations.loadWithXhr(
+          "Data/WMS/GetFeatureInfo-MapInfoMXP.xml",
+          responseType,
+          method,
+          data,
+          headers,
+          deferred,
+          overrideMimeType
+        );
+      };
+      return pollToPromise(function () {
+        return provider.ready;
+      }).then(function () {
+        return provider.pickFeatures(0, 0, 0, 0.5, 0.5);
+      });
+    });
+
     it("uses custom GetFeatureInfo handling function if specified", function () {
       function fooProcessor(response) {
         var json = JSON.parse(response);


### PR DESCRIPTION
Fixes: #9021 
It will take a `version` parameter from `getFeatureInfoParameters` and determine which version to use. At first, I was going with an implementation where `version` is defined in `parameters` but that will break workflow for `getFeatureInfoParameters`, and override it. Is there an option to check if the version parameter is default one or is it set from `options.getFeatureInfoParameters`?