### PR TITLE
Introducing a "maximumTilt" property for the Camera

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 ##### Additions :tada:
 
 - Added `Matrix3.inverseTranspose` and `Matrix4.inverseTranspose`. [#9135](https://github.com/CesiumGS/cesium/pull/9135)
-- Added `Camera.maxTilt` to prevent camera from being tilted past that angle.
+- Added `Camera.maximumTilt` to prevent camera from being tilted past that angle.
 
 ##### Fixes :wrench:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Additions :tada:
 
 - Added `Matrix3.inverseTranspose` and `Matrix4.inverseTranspose`. [#9135](https://github.com/CesiumGS/cesium/pull/9135)
+- Added `Camera.maxTilt` to prevent camera from being tilted past that angle.
 
 ##### Fixes :wrench:
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -158,6 +158,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
   - [Joey Rafidi](https://github.com/jrafidi)
 - [Geoplex GIS GmbH](https://www.geoplex.de)
   - [Leonard Holst](https://github.com/LHolst)
+- [Business Geografic](https://www.business-geografic.com/)
+  - [Fabien Nicollet](https://github.com/fnicollet)
 
 ## [Individual CLA](Documentation/Contributors/CLAs/individual-contributor-license-agreement-v1.0.pdf)
 

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -178,6 +178,12 @@ function Camera(scene) {
    */
   this.defaultZoomAmount = 100000.0;
   /**
+   * If set, the camera will not be able to tilt past this angle, expressed in radians.
+   * @type {Number}
+   * @default undefined
+   */
+  this.maxTilt = undefined;
+  /**
    * If set, the camera will not be able to rotate past this axis in either direction.
    * @type {Cartesian3}
    * @default undefined

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -182,7 +182,7 @@ function Camera(scene) {
    * @type {Number}
    * @default undefined
    */
-  this.maxTilt = undefined;
+  this.maximumTilt = undefined;
   /**
    * If set, the camera will not be able to rotate past this axis in either direction.
    * @type {Cartesian3}

--- a/Source/Scene/ScreenSpaceCameraController.js
+++ b/Source/Scene/ScreenSpaceCameraController.js
@@ -2014,13 +2014,13 @@ function rotate3D(
   var deltaPhi = rotateRate * phiWindowRatio * Math.PI * 2.0;
   var deltaTheta = rotateRate * thetaWindowRatio * Math.PI;
 
-  if (defined(constrainedAxis) && defined(camera.maxTilt)) {
-    var maxTilt = camera.maxTilt;
+  if (defined(constrainedAxis) && defined(camera.maximumTilt)) {
+    var maximumTilt = camera.maximumTilt;
     var tilt = Cartesian3.dot(camera.direction, constrainedAxis);
     tilt = Math.PI - Math.acos(tilt);
     tilt += deltaTheta;
-    if (tilt > maxTilt) {
-      deltaTheta -= tilt - maxTilt;
+    if (tilt > maximumTilt) {
+      deltaTheta -= tilt - maximumTilt;
     }
   }
 

--- a/Source/Scene/ScreenSpaceCameraController.js
+++ b/Source/Scene/ScreenSpaceCameraController.js
@@ -2014,6 +2014,16 @@ function rotate3D(
   var deltaPhi = rotateRate * phiWindowRatio * Math.PI * 2.0;
   var deltaTheta = rotateRate * thetaWindowRatio * Math.PI;
 
+  if (defined(constrainedAxis) && defined(camera.maxTilt)) {
+    var maxTilt = camera.maxTilt;
+    var tilt = Cartesian3.dot(camera.direction, constrainedAxis);
+    tilt = Math.PI - Math.acos(tilt);
+    tilt += deltaTheta;
+    if (tilt > maxTilt) {
+      deltaTheta -= tilt - maxTilt;
+    }
+  }
+
   if (!rotateOnlyVertical) {
     camera.rotateRight(deltaPhi);
   }


### PR DESCRIPTION
Introduced a maximumTilt property for the Camera, that, if present, limits the camera's tilt.

Here is a sandbox sample to showcase this behaviour:
```
var viewer = new Cesium.Viewer("cesiumContainer");
var camera = viewer.camera;
camera.maximumTilt = 1.2;

camera.setView({
  destination: new Cesium.Cartesian3(
    1216394.1392207467,
    -4736348.59346919,
    4081293.9160685353
  ),
  orientation: {
    heading: 0.018509338875732695,
    pitch: -0.09272999615872646,
  },
});
```
The camera's pitch is limited (wether you use mousewheel-click + up/down or Ctrl+mouse up/down), which is currently impossible to do with the Cesium public API unless you re-code all the mouse/keyboard/touch gestures.

The maximumTilt value is expressed in radians. Degrees might have been more dev-friendly but most things seem to be expressed in radians in Cesium.

Follows-up on this PR which was never completed:
https://github.com/CesiumGS/cesium/pull/7428

Added Business Geografic/fnicollet to the Contributors
The CLA for Business Geografic has been signed today.

Added a line in the CHANGES.md file. Should I wait for the PR to be created and update the file with the PR link or someone from Cesium will?