### PR TITLE
Add link to CLA folder for maintainers

### DIFF
--- a/.concierge/templates/pullRequestOpened.hbs
+++ b/.concierge/templates/pullRequestOpened.hbs
@@ -12,6 +12,7 @@ Thanks for the pull request @{{ userName }}!
 {{#if errorCla}}
 * :grey_exclamation: There was an error checking the CLA! If this is your first contribution, please send in a [Contributor License Agreement](https://github.com/CesiumGS/cesium/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla).
     * Maintainers, this was the error I ran into while attempting to process the CLA check. Please resolve it to continue CLA checking.
+    * You'll need to [manually check for a submitted CLA](https://github.com/CesiumGS/cesium/blob/master/Documentation/Contributors/CLAs/README.md)
     ```
     {{ errorCla }}
     ```
@@ -19,6 +20,7 @@ Thanks for the pull request @{{ userName }}!
 {{#if askForCla}}
 * :x: Missing CLA.
     * Please send in a [Contributor License Agreement](https://github.com/CesiumGS/cesium/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla) (CLA) and comment back here to let us know to check this!
+    * Maintainers, [here's how to check](https://github.com/CesiumGS/cesium/blob/master/Documentation/Contributors/CLAs/README.md) for a submitted CLA.
 {{else}}
 * :heavy_check_mark: Signed CLA found.
 {{/if}}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,8 +60,6 @@ This only needs to be completed once, and enables contributions to all of the pr
 
 If you have any questions, feel free to reach out to [hello@cesium.com](mailto:hello@cesium)!
 
-CesiumJS maintainers can access the submitted CLA's [in this Google Drive folder](https://drive.google.com/drive/u/0/folders/1bLc_vxV5KvXVhO1E4Aqyi4dLjrL1jZPp).
-
 ## Pull Request Guidelines
 
 Our code is our lifeblood so maintaining CesiumJS's high code quality is important to us.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,8 @@ This only needs to be completed once, and enables contributions to all of the pr
 
 If you have any questions, feel free to reach out to [hello@cesium.com](mailto:hello@cesium)!
 
+CesiumJS maintainers can access the submitted CLA's [in this Google Drive folder](https://drive.google.com/drive/u/0/folders/1bLc_vxV5KvXVhO1E4Aqyi4dLjrL1jZPp).
+
 ## Pull Request Guidelines
 
 Our code is our lifeblood so maintaining CesiumJS's high code quality is important to us.

--- a/Documentation/Contributors/CLAs/README.md
+++ b/Documentation/Contributors/CLAs/README.md
@@ -1,0 +1,7 @@
+# Contributor License Agreements (CLA)
+
+Before we can review a pull request, we require a signed Contributor License Agreement. See [Contributing Guide](CONTRIBUTING.md#contributor-license-agreement-cla).
+
+CLAs are submitted electronically using a Google form. This folder contains PDF versions of the Google form for both the individual CLA and the corporate CLA.
+
+Maintainers can access the submitted CLA's [in this Google Drive folder](https://drive.google.com/drive/u/0/folders/1bLc_vxV5KvXVhO1E4Aqyi4dLjrL1jZPp).

--- a/Documentation/Contributors/CLAs/README.md
+++ b/Documentation/Contributors/CLAs/README.md
@@ -1,6 +1,6 @@
 # Contributor License Agreements (CLA)
 
-Before we can review a pull request, we require a signed Contributor License Agreement. See [Contributing Guide](CONTRIBUTING.md#contributor-license-agreement-cla).
+Before we can review a pull request, we require a signed Contributor License Agreement. See [Contributing Guide](https://github.com/CesiumGS/cesium/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 CLAs are submitted electronically using a Google form. This folder contains PDF versions of the Google form for both the individual CLA and the corporate CLA.
 


### PR DESCRIPTION
The linked Google Drive folder is not a publicly accessible link, but is visible to members of the Cesium team. It's useful to have this link handy in cases when you need to manually check a CLA, like if the bot fails: https://github.com/CesiumGS/cesium/pull/9147#issuecomment-691075404. 

