### PR TITLE
Expose `ScreenSpaceCameraController.maximumRotateRate`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 1.75 - 2020-11-09
+
+##### Additions :tada:
+
+- Added `ScreenSpaceCameraController.maximumRotateRate` to allow constraining the maximum speed that the camera can be rotated.
+
 ### 1.74 - 2020-10-01
 
 ##### Additions :tada:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -158,6 +158,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
   - [Joey Rafidi](https://github.com/jrafidi)
 - [Geoplex GIS GmbH](https://www.geoplex.de)
   - [Leonard Holst](https://github.com/LHolst)
+- [onXmaps, Inc.](https://onxmaps.com)
+  - [Brian Maher](https://github.com/brianpmaher)
 
 ## [Individual CLA](Documentation/Contributors/CLAs/individual-contributor-license-agreement-v1.0.pdf)
 

--- a/Source/Scene/ScreenSpaceCameraController.js
+++ b/Source/Scene/ScreenSpaceCameraController.js
@@ -137,6 +137,15 @@ function ScreenSpaceCameraController(scene) {
    */
   this.maximumZoomDistance = Number.POSITIVE_INFINITY;
   /**
+   * The maximum rate at which the camera can rotate.  Can be used to constrain
+   * how many rotations the camera can make when dragging the cursor from one
+   * end of the screen to the other.
+   * @type {Number}
+   * @default 1.77
+   */
+  this.maximumRotateRate = 1.77;
+  this._maximumRotateRate = this.maximumRotateRate;
+  /**
    * The input that allows the user to pan around the map. This only applies in 2D and Columbus view modes.
    * <p>
    * The type came be a {@link CameraEventType}, <code>undefined</code>, an object with <code>eventType</code>
@@ -303,7 +312,6 @@ function ScreenSpaceCameraController(scene) {
   this._zoomFactor = 5.0;
   this._rotateFactor = undefined;
   this._rotateRateRangeAdjustment = undefined;
-  this._maximumRotateRate = 1.77;
   this._minimumRotateRate = 1.0 / 5000.0;
   this._minimumZoomRate = 20.0;
   this._maximumZoomRate = 5906376272000.0; // distance from the Sun to Pluto in meters.

--- a/Specs/Scene/ScreenSpaceCameraControllerSpec.js
+++ b/Specs/Scene/ScreenSpaceCameraControllerSpec.js
@@ -1170,6 +1170,44 @@ describe("Scene/ScreenSpaceCameraController", function () {
     );
   });
 
+  it("rotates in 3D with maximum rate", function () {
+    setUp3D();
+    var initialPosition = Cartesian3.clone(camera.position);
+    var initialDirection = Cartesian3.clone(camera.direction);
+
+    function moveTheMouse() {
+      var startPosition = new Cartesian2(0, 0);
+      var endPosition = new Cartesian2(canvas.clientWidth / 2, 0);
+      moveMouse(MouseButtons.MIDDLE, startPosition, endPosition);
+    }
+
+    // Small rotation.
+    controller.maximumRotateRate = 1;
+    moveTheMouse();
+    updateController();
+    var smallRotationPosition = Cartesian3.clone(camera.position);
+    var smallDistanceFromOrigin = Cartesian3.distance(
+      initialPosition,
+      smallRotationPosition
+    );
+
+    // Reset the camera.
+    camera.position = Cartesian3.clone(initialPosition);
+    camera.direction = Cartesian3.clone(initialDirection);
+
+    // Large rotation.
+    controller.maximumRotateRate = 2;
+    moveTheMouse();
+    updateController();
+    var largeRotationPosition = Cartesian3.clone(camera.position);
+    var largeDistanceFromOrigin = Cartesian3.distance(
+      initialPosition,
+      largeRotationPosition
+    );
+
+    expect(largeDistanceFromOrigin).toBeGreaterThan(smallDistanceFromOrigin);
+  });
+
   it("zoom in 3D", function () {
     setUp3D();
     var position = Cartesian3.clone(camera.position);


### PR DESCRIPTION
Implements https://github.com/CesiumGS/cesium/issues/9149

I wrote that issue up, so definitely open to alternative suggestions here as well.  The gist is that I needed a way to set a maximum rotation rate since the camera controls felt a little too fast for my needs.

This PR is to expose `ScreenSpaceCameraController.maximumRotateRate` as public so users can be confident there isn't a risk of the field going away when using the private member to accomplish the same thing.