### PR TITLE
LAB-1658 Improve ImageryLayer.cancelReprojections() handling

### DIFF
--- a/Source/Renderer/ComputeCommand.js
+++ b/Source/Renderer/ComputeCommand.js
@@ -70,6 +70,14 @@ function ComputeCommand(options) {
   this.postExecute = options.postExecute;
 
   /**
+   * Function that is called when the command is canceled
+   *
+   * @type {Function}
+   * @default undefined
+   */
+  this.canceled = options.canceled;
+
+  /**
    * Whether the renderer resources will persist beyond this call. If not, they
    * will be destroyed after completion.
    *

--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -1235,6 +1235,10 @@ ImageryLayer.prototype._reprojectTexture = function (
         imagery.state = ImageryState.READY;
         imagery.releaseReference();
       },
+      canceled: function () {
+        imagery.state = ImageryState.TEXTURE_LOADED;
+        imagery.releaseReference();
+      },
     });
     this._reprojectComputeCommands.push(computeCommand);
   } else {
@@ -1268,6 +1272,11 @@ ImageryLayer.prototype.queueReprojectionCommands = function (frameState) {
  * @private
  */
 ImageryLayer.prototype.cancelReprojections = function () {
+  this._reprojectComputeCommands.forEach(function (command) {
+    if (command.canceled) {
+      command.canceled();
+    }
+  });
   this._reprojectComputeCommands.length = 0;
 };
 


### PR DESCRIPTION
This was a bugfix that @kring helped us with a while back.  From memory it was causing problems in an `ImageryLayer` when a terrain provider was swapped out on a globe.