### PR TITLE
Add background color to doc nav bar, to help with horizontal scrolling.

### DIFF
--- a/Tools/jsdoc/cesium_template/static/styles/jsdoc-default.css
+++ b/Tools/jsdoc/cesium_template/static/styles/jsdoc-default.css
@@ -176,7 +176,7 @@ div.menu {
 div.nav {
   overflow-x: hidden;
   overflow-y: auto;
-  background: #f8f8f8;  /* Can be any color, but is needed for horizontal scrolling of main content. */
+  background: #f8f8f8; /* Can be any color, but is needed for horizontal scrolling of main content. */
 }
 
 @media (max-width: 839px) {

--- a/Tools/jsdoc/cesium_template/static/styles/jsdoc-default.css
+++ b/Tools/jsdoc/cesium_template/static/styles/jsdoc-default.css
@@ -176,6 +176,7 @@ div.menu {
 div.nav {
   overflow-x: hidden;
   overflow-y: auto;
+  background: #f8f8f8;  /* Can be any color, but is needed for horizontal scrolling of main content. */
 }
 
 @media (max-width: 839px) {


### PR DESCRIPTION
Fixes #9162.

My local doc build is busted, so I can't test this locally except by jamming it in DevTools.

Also I set the nav bar to be a slightly darker color, to draw more attention to the main panel.