### PR TITLE
Fixed a crash when loading OSM buildings with shadows enabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 - Fixed an issue where Plane doesn't rotate correctly around the main local axis. [#8268](https://github.com/CesiumGS/cesium/issues/8268)
 - Fixed clipping planes with non-uniform scale. [#9135](https://github.com/CesiumGS/cesium/pull/9135)
 - Fixed an issue where ground primitives would get clipped at certain camera angles. [#9114](https://github.com/CesiumGS/cesium/issues/9114)
+- Fixed a crash when loading Cesium OSM buildings with shadows enabled. [#9172](https://github.com/CesiumGS/cesium/pull/9172)
 
 ### 1.73 - 2020-09-01
 

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -1518,10 +1518,8 @@ function updateCameras(shadowMap, frameState) {
       frameState.shadowState.nearPlane,
       shadowMap.maximumDistance
     );
-    far = Math.min(
-      frameState.shadowState.farPlane,
-      shadowMap.maximumDistance + 1.0
-    );
+    far = Math.min(frameState.shadowState.farPlane, shadowMap.maximumDistance);
+    far = Math.max(far, near + 1.0);
   } else {
     near = camera.frustum.near;
     far = shadowMap.maximumDistance;


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/9137

This bug was exposed by the [sandcastle](https://sandcastle.cesium.com/#c=dVJhb9owEP0rt3xpkIIJKW0HpWgq/bJpVacRbdKUL8Y+wKpjo7MTxKb+9zkJoHaj3+zze+/evXPNCWqFOyS4A4M7mKNTVcl+tLW4iER7n1vjuTJIRZTAn8IAeCQKlW9kayWRJkeiIOQef1rSMu8gcS9pCG7Dpd25CXiqsDAvvdvCdJ2Z0FY8M1ERofG5KjF4Och9qbTi5iFIshXZ8rOzH6/TYfCVpVnaT8f9dJRn2WQ0mlxd/iqiRvQk6wQaZFtSpfKqRse4lPEbm0+uvK+UlsqsXdw7Qxa8ROJspfe5jdu5JTqvDPfKmtPMc04+nLi5bE0+4JoQXdy/GbF0OE5glLLr8TBL4OYq7cKwpMKoB5VWF2CDvDFyUn3kfsO8/R6q3Lg4O1ABtsqLzXuw/hH3krQhQzPTghspuPMamwxya/WS033lvTXxRW7Xa42w6PZzkcCqMqJxFvc6a8dEWsAj3zI0fKlRhi19eO/ttm0eJdHU+b3GWecc4JMqt5Y8VKRjxgYey60Oi3CDZSWe0TPhXLOGBjodvKZOpapBybszPxKE5s6Fl1Wl9UL9xiKaTQcB/x9V2zbipxpJ830D2wxnX7siY2w6CNfzTN9l9o/yXw) in https://github.com/CesiumGS/cesium/issues/9137 in which a single 3D Tiles command was behind the camera and caused `shadowNear` and `shadowFar` to both equal the camera's near distance, creating a zero-sized frustum and a divide-by-zero crash when computing cascade splits. The fix was to enforce shadow far always being greater than shadow near in `ShadowMap`.