### PR TITLE
Update release schedule YAML format

### DIFF
--- a/.slackbot.yml
+++ b/.slackbot.yml
@@ -1,12 +1,12 @@
 # List of Slack usernames (not GitHub) for the Cesium Concierge Slackbot to send release reminders for.
 releaseSchedule:
-  mamato: 3/2/2020
-  oshehata: 4/1/2020
-  lilleyse: 5/1/2020
-  ian: 6/1/2020
-  sam.suhag: 7/1/2020
-  sam.vargas: 8/3/2020
-  kevin: 9/1/2020
-  mamato: 10/1/2020
-  oshehata: 11/2/2020
-  lilleyse: 12/1/2020
+  - mamato, 3/2/2020
+  - oshehata, 4/1/2020
+  - lilleyse, 5/1/2020
+  - ian, 6/1/2020
+  - sam.suhag, 7/1/2020
+  - sam.vargas, 8/3/2020
+  - kevin, 9/1/2020
+  - mamato, 10/1/2020
+  - oshehata, 11/2/2020
+  - lilleyse, 12/1/2020


### PR DESCRIPTION
Our slackbot was failing to send release reminders because the YAML was a dictionary, so having duplicate keys failed to parse. 

This updates the YAML to be an array instead of a dict. We should merge this after the concierge update here: https://github.com/CesiumGS/cesium-concierge/pull/149.