### PR TITLE
Update npm major version changes (and pinned prettier)

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "karma-edge-launcher": "^0.4.2",
     "karma-firefox-launcher": "^1.0.0",
     "karma-ie-launcher": "^1.0.0",
-    "karma-jasmine": "^3.1.1",
+    "karma-jasmine": "^4.0.1",
     "karma-longest-reporter": "^1.1.0",
     "karma-safari-launcher": "^1.0.0",
     "karma-spec-reporter": "^0.0.32",
@@ -78,18 +78,18 @@
     "mime": "^2.0.3",
     "mkdirp": "^1.0.0",
     "open": "^7.0.0",
-    "prettier": "2.1.1",
-    "pretty-quick": "^2.0.1",
+    "prettier": "2.1.2",
+    "pretty-quick": "^3.0.2",
     "request": "^2.79.0",
     "rimraf": "^3.0.0",
     "rollup": "^2.22.1",
-    "rollup-plugin-external-globals": "^0.5.0",
+    "rollup-plugin-external-globals": "^0.6.0",
     "rollup-plugin-strip-pragma": "^1.0.0",
     "rollup-plugin-uglify": "^6.0.3",
     "stream-to-promise": "^3.0.0",
     "tsd-jsdoc": "^2.5.0",
     "typescript": "^3.9.2",
-    "yargs": "^15.0.1"
+    "yargs": "^16.0.3"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
1. No code change required on our end at all. These were mostly dropping support for Node 8, which is end-of-life.

2. I did not update to TypeScript 4.x, because I'm actually not sure what that would mean for the definition files and something we should probably look into separately.