### PR TITLE
Change branch name for vctr and geom documentation

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Classification.html
@@ -49,7 +49,7 @@
 
         // Geometry Tiles are experimental and the format is subject to change in the future.
         // For more details, see:
-        //    https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/TileFormats/Geometry
+        //    https://github.com/CesiumGS/3d-tiles/tree/vctr/TileFormats/Geometry
         var classificationTileset = new Cesium.Cesium3DTileset({
           url:
             "../../SampleData/Cesium3DTiles/Classification/PointCloud/tileset.json",

--- a/Apps/Sandcastle/gallery/3D Tiles Terrain Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Terrain Classification.html
@@ -47,7 +47,7 @@
 
         // Vector 3D Tiles are experimental and the format is subject to change in the future.
         // For more details, see:
-        //    https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/TileFormats/VectorData
+        //    https://github.com/CesiumGS/3d-tiles/tree/vctr/TileFormats/VectorData
         var tileset = new Cesium.Cesium3DTileset({
           url: Cesium.IonResource.fromAssetId(5737),
         });

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1109,7 +1109,7 @@ _This is an npm-only release to fix a publishing issue_.
 
 ##### Highlights :sparkler:
 
-- Added experimental support for [3D Tiles Vector and Geometry data](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/TileFormats/VectorData). ([#4665](https://github.com/CesiumGS/cesium/pull/4665))
+- Added experimental support for [3D Tiles Vector and Geometry data](https://github.com/CesiumGS/3d-tiles/tree/vctr/TileFormats/VectorData). ([#4665](https://github.com/CesiumGS/cesium/pull/4665))
 - Added optional mode to reduce CPU usage. See [Improving Performance with Explicit Rendering](https://cesium.com/blog/2018/01/24/cesium-scene-rendering-performance/). ([#6115](https://github.com/CesiumGS/cesium/pull/6115))
 - Added experimental `CesiumIon` utility class for working with the Cesium ion beta API. [#6136](https://github.com/CesiumGS/cesium/pull/6136)
 - Major refactor of URL handling. All classes that take a url parameter, can now take a Resource or a String. This includes all imagery providers, all terrain providers, `Cesium3DTileset`, `KMLDataSource`, `CZMLDataSource`, `GeoJsonDataSource`, `Model`, and `Billboard`.
@@ -1125,7 +1125,7 @@ _This is an npm-only release to fix a publishing issue_.
 
 ##### Additions :tada:
 
-- Added experimental support for [3D Tiles Vector and Geometry data](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/TileFormats/VectorData) ([#4665](https://github.com/CesiumGS/cesium/pull/4665)). The new and modified Cesium APIs are:
+- Added experimental support for [3D Tiles Vector and Geometry data](https://github.com/CesiumGS/3d-tiles/tree/vctr/TileFormats/VectorData) ([#4665](https://github.com/CesiumGS/cesium/pull/4665)). The new and modified Cesium APIs are:
   - `Cesium3DTileStyle` has expanded to include styling point features. See the [styling specification](https://github.com/CesiumGS/3d-tiles/tree/vector-tiles/Styling#vector-data) for details.
   - `Cesium3DTileFeature` can modify `color` and `show` properties for polygon, polyline, and geometry features.
   - `Cesium3DTilePointFeature` can modify the styling options for a point feature.

--- a/Source/Scene/Vector3DTileContent.js
+++ b/Source/Scene/Vector3DTileContent.js
@@ -19,7 +19,7 @@ import Vector3DTilePolylines from "./Vector3DTilePolylines.js";
 
 /**
  * Represents the contents of a
- * {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/TileFormats/VectorData|Vector}
+ * {@link https://github.com/CesiumGS/3d-tiles/tree/vctr/TileFormats/VectorData|Vector}
  * tile in a {@link https://github.com/CesiumGS/3d-tiles/tree/master/specification|3D Tiles} tileset.
  * <p>
  * Implements the {@link Cesium3DTileContent} interface.


### PR DESCRIPTION
The legacy [`vctr`](https://github.com/CesiumGS/3d-tiles/tree/vctr/TileFormats/VectorData) format is now being documented on a different branch in the 3D Tiles repo. We're going to start using the `3d-tiles-next` branch name for actual 3D Tiles Next features.