### PR TITLE
switch to using terser plugin instead of uglify

### DIFF
--- a/gulpfile.cjs
+++ b/gulpfile.cjs
@@ -32,7 +32,7 @@ var mime = require("mime");
 var rollup = require("rollup");
 var rollupPluginStripPragma = require("rollup-plugin-strip-pragma");
 var rollupPluginExternalGlobals = require("rollup-plugin-external-globals");
-var rollupPluginUglify = require("rollup-plugin-uglify");
+var rollupPluginTerser = require("rollup-plugin-terser");
 var cleanCSS = require("gulp-clean-css");
 var typescript = require("typescript");
 
@@ -1158,7 +1158,7 @@ function combineCesium(debug, optimizer, combineOutput) {
     );
   }
   if (optimizer === "uglify2") {
-    plugins.push(rollupPluginUglify.uglify());
+    plugins.push(rollupPluginTerser.terser());
   }
 
   return rollup
@@ -1231,7 +1231,7 @@ function combineWorkers(debug, optimizer, combineOutput) {
         );
       }
       if (optimizer === "uglify2") {
-        plugins.push(rollupPluginUglify.uglify());
+        plugins.push(rollupPluginTerser.terser());
       }
 
       return rollup
@@ -1819,7 +1819,7 @@ function buildCesiumViewer() {
           rollupPluginStripPragma({
             pragmas: ["debug"],
           }),
-          rollupPluginUglify.uglify(),
+          rollupPluginTerser.terser(),
         ],
         onwarn: rollupWarning,
       })

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "rollup": "^2.22.1",
     "rollup-plugin-external-globals": "^0.6.0",
     "rollup-plugin-strip-pragma": "^1.0.0",
-    "rollup-plugin-uglify": "^6.0.3",
+    "rollup-plugin-terser": "*",
     "stream-to-promise": "^3.0.0",
     "tsd-jsdoc": "^2.5.0",
     "typescript": "^3.9.2",


### PR DESCRIPTION
Due to changes in how `npm@7.x` processes dependencies, `rollup-plugin-uglify` causes the install to fail since it is looking for a peer dependency of `rollup@ >=0.66.0 <2.0.0`.  [See here](https://github.com/npm/cli/issues/2000).

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: cesium@1.74.0
npm ERR! Found: rollup@2.32.1
npm ERR! node_modules/rollup
npm ERR!   dev rollup@"^2.22.1" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer rollup@">=0.66.0 <2" from rollup-plugin-uglify@6.0.4
npm ERR! node_modules/rollup-plugin-uglify
npm ERR!   dev rollup-plugin-uglify@"^6.0.3" from the root project
```

In addition, `rollup-plugin-terser` and `terser` as a whole are the [recommended follow-ons for `uglify`](https://www.npmjs.com/package/rollup-plugin-uglify) and can natively handle es6 modules.

Fixes https://github.com/CesiumGS/cesium/issues/9129
Fixes https://github.com/CesiumGS/cesium/issues/9630