### PR TITLE
Fix JSDoc/TS of `writeTextToCanvas`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 1.75 - 2020-11-02
+
+- Fixed JSDoc and TypeScript type definitions for `writeTextToCanvas` which listed incorrect return type. [#9196](https://github.com/CesiumGS/cesium/pull/9196)
+
 ### 1.74 - 2020-10-01
 
 ##### Additions :tada:

--- a/Source/Core/writeTextToCanvas.js
+++ b/Source/Core/writeTextToCanvas.js
@@ -21,7 +21,7 @@ var imageSmoothingEnabledName;
  * @param {Number} [options.strokeWidth=1] The stroke width.
  * @param {Color} [options.backgroundColor=Color.TRANSPARENT] The background color of the canvas.
  * @param {Number} [options.padding=0] The pixel size of the padding to add around the text.
- * @returns {HTMLCanvasElement} A new canvas with the given text drawn into it.  The dimensions object
+ * @returns {HTMLCanvasElement|undefined} A new canvas with the given text drawn into it.  The dimensions object
  *                   from measureText will also be added to the returned canvas. If text is
  *                   blank, returns undefined.
  * @function writeTextToCanvas

--- a/Specs/TypeScript/index.ts
+++ b/Specs/TypeScript/index.ts
@@ -11,8 +11,8 @@ import {
   CheckerboardMaterialProperty,
   CircleGeometry,
   CircleOutlineGeometry,
-  ColorMaterialProperty,
   Color,
+  ColorMaterialProperty,
   CompositeMaterialProperty,
   CompositePositionProperty,
   CompositeProperty,
@@ -97,6 +97,7 @@ import {
   WallOutlineGeometry,
   WebMapServiceImageryProvider,
   WebMapTileServiceImageryProvider,
+  writeTextToCanvas,
 } from "cesium";
 
 // Verify ImageryProvider instances conform to the expected interface
@@ -384,3 +385,5 @@ geometryInstance = new GeometryInstance({
     positions: [],
   }),
 });
+
+const canvas: HTMLCanvasElement | undefined = writeTextToCanvas("test");


### PR DESCRIPTION
This moves the changes over from https://github.com/CesiumGS/cesium/pull/9196 since I didn't seem to have push access to that branch in the fork.

This fixes the return type of `writeTextToCanvas` which can return undefined, and updates CHANGES.md and adds a test in `index.ts`. 