### PR TITLE
Fix tileset style recompilation edge cases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ##### Fixes :wrench:
 
-- Fixed an issue where tileset styles would be reapplied every frame when a tileset has a style and `tileset.preloadWhenHidden` is true. Also fixed a related issue were styles would be reapplied if the style being set is the same as the active style.
+- Fixed an issue where tileset styles would be reapplied every frame when a tileset has a style and `tileset.preloadWhenHidden` is true and `tileset.show` is false. Also fixed a related issue where styles would be reapplied if the style being set is the same as the active style. [#9223](https://github.com/CesiumGS/cesium/pull/9223)
 
 ### 1.75 - 2020-11-02
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 1.76 - 2020-12-01
+
+##### Fixes :wrench:
+
+- Fixed an issue where tileset styles would be reapplied every frame when a tileset has a style and `tileset.preloadWhenHidden` is true. Also fixed a related issue were styles would be reapplied if the style being set is the same as the active style.
+
 ### 1.75 - 2020-11-02
 
 ##### Fixes :wrench:

--- a/Source/Scene/Cesium3DTileStyleEngine.js
+++ b/Source/Scene/Cesium3DTileStyleEngine.js
@@ -15,6 +15,9 @@ Object.defineProperties(Cesium3DTileStyleEngine.prototype, {
       return this._style;
     },
     set: function (value) {
+      if (value === this._style) {
+        return;
+      }
       this._style = value;
       this._styleDirty = true;
     },
@@ -25,7 +28,11 @@ Cesium3DTileStyleEngine.prototype.makeDirty = function () {
   this._styleDirty = true;
 };
 
-Cesium3DTileStyleEngine.prototype.applyStyle = function (tileset, passOptions) {
+Cesium3DTileStyleEngine.prototype.resetDirty = function () {
+  this._styleDirty = false;
+};
+
+Cesium3DTileStyleEngine.prototype.applyStyle = function (tileset) {
   if (!tileset.ready) {
     return;
   }
@@ -35,11 +42,6 @@ Cesium3DTileStyleEngine.prototype.applyStyle = function (tileset, passOptions) {
   }
 
   var styleDirty = this._styleDirty;
-
-  if (passOptions.isRender) {
-    // Don't reset until the render pass
-    this._styleDirty = false;
-  }
 
   if (styleDirty) {
     // Increase "time", so the style is applied to all visible tiles

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1892,6 +1892,7 @@ Cesium3DTileset.prototype.postPassesUpdate = function (frameState) {
   cancelOutOfViewRequests(this, frameState);
   raiseLoadProgressEvent(this, frameState);
   this._cache.unloadTiles(this, unloadTile);
+  this._styleEngine.resetDirty();
 };
 
 /**
@@ -2173,7 +2174,7 @@ function updateTileDebugLabels(tileset, frameState) {
 }
 
 function updateTiles(tileset, frameState, passOptions) {
-  tileset._styleEngine.applyStyle(tileset, passOptions);
+  tileset._styleEngine.applyStyle(tileset);
 
   var isRender = passOptions.isRender;
   var statistics = tileset._statistics;

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -2866,6 +2866,40 @@ describe(
       );
     });
 
+    it("doesn't re-evaluate style during the next update", function () {
+      return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl).then(
+        function (tileset) {
+          tileset.show = false;
+          tileset.preloadWhenHidden = true;
+          tileset.style = new Cesium3DTileStyle({ color: 'color("red")' });
+          scene.renderForSpecs();
+
+          var statistics = tileset._statisticsPerPass[Cesium3DTilePass.PRELOAD];
+          expect(statistics.numberOfTilesStyled).toBe(1);
+
+          scene.renderForSpecs();
+          expect(statistics.numberOfTilesStyled).toBe(0);
+        }
+      );
+    });
+
+    it("doesn't re-evaluate style if the style being set is the same as the active style", function () {
+      return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl).then(
+        function (tileset) {
+          var style = new Cesium3DTileStyle({ color: 'color("red")' });
+          tileset.style = style;
+          scene.renderForSpecs();
+
+          var statistics = tileset._statisticsPerPass[Cesium3DTilePass.RENDER];
+          expect(statistics.numberOfTilesStyled).toBe(1);
+
+          tileset.style = style;
+          scene.renderForSpecs();
+          expect(statistics.numberOfTilesStyled).toBe(0);
+        }
+      );
+    });
+
     function testColorBlendMode(url) {
       return Cesium3DTilesTester.loadTileset(scene, url).then(function (
         tileset


### PR DESCRIPTION
Fixed two cases where styles would be reapplied needlessly every frame
* When the tileset has a style and `tileset.preloadWhenHidden` is true and `tileset.show` is false
* When `tileset.style` is set to an identical style. This wasn't the original bug I was looking into but it was a slowdown waiting to be noticed.

There was some code in `Cesium3DTileStyleEngine` that only reset `styleDirty` during the render pass. This is bad because the render pass doesn't get called at all if `tileset.preloadWhenHidden` is true and `tileset.show` is false and so the style would forever be dirty, which causes shader recompilations to happen for each tile every frame.

The proper way to do pass-invariant updates is with `postPassesUpdate`. It ended up being a pretty simple fix.

For testing:

* [`preloadWhenHidden` Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=jVRdb9owFP0rFi8EKTP5Mgktrba1k4q0blVBqyblxcQXsObYzHZou2n/fTYBBC2V+hTnfp2Tc4+zphqtOTyCRhdIwiO6AsObGv/YxIKyU23er5S0lEvQZSdEf0uJkAWtXeROqzVnoM92jZUGauFBacGmbUnQC0v5r3deylK2UNhUIAFr+N2Asfcg3YBbxcBRsLqBttIRs1yAAXvMrH2k19M2GWzYNFrsGYyVvAejGl0BnmtVfzKubMyCeJAl8QGX7XRslurRQcypMB56F15pEIqyhyXIG84YyEN2+177LOBtfhOfbhlWSiinkhPUH4KuBtbtlZ3Tyqw0r7nlazCYMhZs0U4UVrQGTbFL+oW1SAgxpyqX1HIl0dkRN6qtO1GZBlkWxXmcYC9KkZFhHqIkIVGS4oRk8TCN0yxJQ+QyJEsJjgkpoowUqRfQYyjNwXniNcYNUMbl4o7banmvhAiIwxjkaVpEJEqHOXFIHyKc5INBlMckLdJhMYwd1AAnRRzHUZGTLIqiguygnD+mmkozV7pG+zXfUqv5U4bH11++TcfTn3slJ1SyihorwIs3VYuFgM+NtUoG3YnbdTdEh6sP0byRlf+OoFpC9QtYb+vwY39sk+c+9baNA8/hDSJKzKjeMblaUrkAtDFQ94DDS/B3G+y1xWaigdZjCG0ovYd4J+yMNqCX7VCEPvJ6pbT1dyzAuG+hXgl3xU1/1jhBLK6MaYcjNOofto4YXyPOLk78RFAlqDEuM2+EmPA/UHYuR31X/6rV30Fnp+9r0II++7JlfPm1DWKMR333errTtoK/mPwf) - observe that [`content.applyStyle(this._style);`](https://github.com/CesiumGS/cesium/blob/3d665a498b6902e70f653e3c4ec7bebf1e1cd580/Source/Scene/Cesium3DTileStyleEngine.js#L70) is no longer called every frame.
* [Identical style Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=dVLBTgIxEP2VZi8uCekGNR50IRr0QEKiEdRLL0s7aGO3Q6bdJWD8d9vdhSjCXroz7817r5PWBbFawxqIDZmFNRuD01XJX5teKhLZ1GO0vtAWSCR99iUsYx6IQueJsNYK6Ho3KAkKD29IRs1bStrrC/vduxFW2DrYeW3Agf/r1x4X9/MWTBuPisxed4L2GRxWJIEvCcs7F2gTlQ6uLs8HBw7Obwyc1p9FuHWQaDBkD9eMP+kZgTrriWSv1mXlO8XmDEi7Mu4kWOAr0qX2ugbHC6XSbqaL0xK3iOUcj0KdBjr/slJhdVHjoQbrp9r5AFG6rKz0GsMiu9WfCBUyJ/0kb8pRJMbvVpcrJB93mXKeeShXJri4bFHJzyAinYtxIjXPfo/mStdMq+GRJ8CkKZwLyLIyZqa3IJJRngX+v1GDhdL2/bEGMsUm0j4Go2nb5JznWSiPT3pEsyjoQPkH) - same

Both added unit tests will fail in `master` and pass in this branch.

I haven't yet tested this in the application code where this was first noticed, but maybe @IanLilleyT can take over that. Then we could also do a performance comparison.

CC @mramato @IanLilleyT 