### PR TITLE
JSdoc/TS fix of EllipsoidTangentPlane.fromPoints

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Fixes :wrench:
 
 - Fixed an issue where tileset styles would be reapplied every frame when a tileset has a style and `tileset.preloadWhenHidden` is true and `tileset.show` is false. Also fixed a related issue where styles would be reapplied if the style being set is the same as the active style. [#9223](https://github.com/CesiumGS/cesium/pull/9223)
+- Fixed JSDoc and TypeScript type definitions for `EllipsoidTangentPlane.fromPoints` which didn't listed a return type. [#9227](https://github.com/CesiumGS/cesium/pull/9227)
 
 ### 1.75 - 2020-11-02
 

--- a/Source/Core/EllipsoidTangentPlane.js
+++ b/Source/Core/EllipsoidTangentPlane.js
@@ -137,6 +137,7 @@ var tmp = new AxisAlignedBoundingBox();
  *
  * @param {Cartesian3[]} cartesians The list of positions surrounding the center point.
  * @param {Ellipsoid} [ellipsoid=Ellipsoid.WGS84] The ellipsoid to use.
+ * @returns {EllipsoidTangentPlane} The new instance of EllipsoidTangentPlane.
  */
 EllipsoidTangentPlane.fromPoints = function (cartesians, ellipsoid) {
   //>>includeStart('debug', pragmas.debug);


### PR DESCRIPTION
The `EllipsoidTangentPlane.fromPoints` misses a return type, it creates a new instance of EllipsoidTangentPlane. Missed to report this in #8926.