### PR TITLE
Fixed a 32 bit vertex indices model render issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Fixed an issue where tileset styles would be reapplied every frame when a tileset has a style and `tileset.preloadWhenHidden` is true and `tileset.show` is false. Also fixed a related issue where styles would be reapplied if the style being set is the same as the active style. [#9223](https://github.com/CesiumGS/cesium/pull/9223)
 - Updated DOMPurify from 1.0.8 to 2.2.2. [#9240](https://github.com/CesiumGS/cesium/issues/9240)
 - Fixed JSDoc and TypeScript type definitions for `EllipsoidTangentPlane.fromPoints` which didn't listed a return type. [#9227](https://github.com/CesiumGS/cesium/pull/9227)
+- Fixed a model render issue where gltf mesh vertices over than 65535(16 bit).
 
 ### 1.75 - 2020-11-02
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -281,3 +281,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Benjamin Abb](https://github.com/benjaminabb)
 - [Victor Turansky](https://github.com/turansky)
 - [Will Jadkowski](https://github.com/willjad)
+- [Ren Jianqiang](https://github.com/renjianqiang)

--- a/Source/Renderer/Buffer.js
+++ b/Source/Renderer/Buffer.js
@@ -411,7 +411,7 @@ Buffer.prototype.cloneAndUpdateIndexDatatype = function (componentType) {
   //>>includeStart('debug', pragmas.debug);
   Check.defined("componentType", componentType);
   //>>includeEnd('debug');
-  
+
   var result = Object.assign({}, this);
   result.__proto__ = Buffer.prototype;
 
@@ -436,7 +436,7 @@ Buffer.prototype.cloneAndUpdateIndexDatatype = function (componentType) {
     },
   });
   return result;
-}
+};
 
 Buffer.prototype.isDestroyed = function () {
   return false;

--- a/Source/Renderer/Buffer.js
+++ b/Source/Renderer/Buffer.js
@@ -407,6 +407,37 @@ Buffer.prototype.getBufferData = function (
   gl.bindBuffer(target, null);
 };
 
+Buffer.prototype.cloneAndUpdateIndexDatatype = function (componentType) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.defined("componentType", componentType);
+  //>>includeEnd('debug');
+  
+  var result = Object.assign({}, this);
+  result.__proto__ = Buffer.prototype;
+
+  var indexDatatype = componentType;
+  var bytesPerIndex = IndexDatatype.getSizeInBytes(indexDatatype);
+  var numberOfIndices = this.sizeInBytes / bytesPerIndex;
+  Object.defineProperties(result, {
+    indexDatatype: {
+      get: function () {
+        return indexDatatype;
+      },
+    },
+    bytesPerIndex: {
+      get: function () {
+        return bytesPerIndex;
+      },
+    },
+    numberOfIndices: {
+      get: function () {
+        return numberOfIndices;
+      },
+    },
+  });
+  return result;
+}
+
 Buffer.prototype.isDestroyed = function () {
   return false;
 };

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -3271,6 +3271,9 @@ function createVertexArrays(model, context) {
         }
 
         indexBuffer = rendererBuffers[bufferView];
+        if(indexBuffer.indexDatatype !== accessor.componentType){
+          indexBuffer = indexBuffer.cloneAndUpdateIndexDatatype(accessor.componentType);
+        }
       }
       rendererVertexArrays[
         meshId + ".primitive." + primitiveId

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -3271,8 +3271,10 @@ function createVertexArrays(model, context) {
         }
 
         indexBuffer = rendererBuffers[bufferView];
-        if(indexBuffer.indexDatatype !== accessor.componentType){
-          indexBuffer = indexBuffer.cloneAndUpdateIndexDatatype(accessor.componentType);
+        if (indexBuffer.indexDatatype !== accessor.componentType) {
+          indexBuffer = indexBuffer.cloneAndUpdateIndexDatatype(
+            accessor.componentType
+          );
         }
       }
       rendererVertexArrays[


### PR DESCRIPTION
There are some render error when the gltf model both contains meshes which vertices over than 65535 and another less than 65535. There is the model:[model.zip](https://github.com/CesiumGS/cesium/files/5596216/model.zip)

![3](https://user-images.githubusercontent.com/16470294/100219236-b1b12d80-2f50-11eb-8c28-db3f4c507842.png)

This model can be render correctly in `babylon.js` and `three.js`, and check valid via [glTF-Validator](http://github.khronos.org/glTF-Validator/) , so i think maybe there are some problems in ceisum.
![1](https://user-images.githubusercontent.com/16470294/100219228-b0800080-2f50-11eb-84d8-e5520b667000.png)![2](https://user-images.githubusercontent.com/16470294/100219231-b0800080-2f50-11eb-8381-d955c1a8e8c1.png)

Function `parseBufferViews()` in `Model.js` assumed all  `accessors`  for each `bufferview` should have same `componentType`, but actually this model is not.  Then function `createVertexArrays` create the wrong `rendererVertexArrays` by the wrong `indexBuffer`, and then the function `createCommand` created the wrong draw command which called by `_gl.drawElements`. At last, the render error occurred.

I try to fix this issue gracefully, but maybe there are some other more efficient methods if someone can help.
Thanks!





 