### PR TITLE
Fixed quadratic easing function typos

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,12 +1,14 @@
 # Change Log
 
-### 1.76 - 2020-12-01
+### 1.77 - 2020-01-04
 
 ##### Deprecated :hourglass_flowing_sand:
 
 - `EasingFunction.QUADRACTIC_IN` was deprecated and will be removed in Cesium 1.79. It has been replaced with `EasingFunction.QUADRATIC_IN`. [#9220](https://github.com/CesiumGS/cesium/issues/9220)
 - `EasingFunction.QUADRACTIC_OUT` was deprecated and will be removed in Cesium 1.79. It has been replaced with `EasingFunction.QUADRATIC_OUT`. [#9220](https://github.com/CesiumGS/cesium/issues/9220)
 - `EasingFunction.QUADRACTIC_IN_OUT` was deprecated and will be removed in Cesium 1.79. It has been replaced with `EasingFunction.QUADRATIC_IN_OUT`. [#9220](https://github.com/CesiumGS/cesium/issues/9220)
+
+### 1.76 - 2020-12-01
 
 ##### Fixes :wrench:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,9 @@
 
 ##### Deprecated :hourglass_flowing_sand:
 
-- `EasingFunction.QUADRACTIC_IN` was deprecated and will be removed in Cesium ???. It has been replaced with `EasingFunction.QUADRATIC_IN`. [#9220](https://github.com/CesiumGS/cesium/issues/9220)
-- `EasingFunction.QUADRACTIC_OUT` was deprecated and will be removed in Cesium ???. It has been replaced with `EasingFunction.QUADRATIC_OUT`. [#9220](https://github.com/CesiumGS/cesium/issues/9220)
-- `EasingFunction.QUADRACTIC_IN_OUT` was deprecated and will be removed in Cesium ???. It has been replaced with `EasingFunction.QUADRATIC_IN_OUT`. [#9220](https://github.com/CesiumGS/cesium/issues/9220)
+- `EasingFunction.QUADRACTIC_IN` was deprecated and will be removed in Cesium 1.79. It has been replaced with `EasingFunction.QUADRATIC_IN`. [#9220](https://github.com/CesiumGS/cesium/issues/9220)
+- `EasingFunction.QUADRACTIC_OUT` was deprecated and will be removed in Cesium 1.79. It has been replaced with `EasingFunction.QUADRATIC_OUT`. [#9220](https://github.com/CesiumGS/cesium/issues/9220)
+- `EasingFunction.QUADRACTIC_IN_OUT` was deprecated and will be removed in Cesium 1.79. It has been replaced with `EasingFunction.QUADRATIC_IN_OUT`. [#9220](https://github.com/CesiumGS/cesium/issues/9220)
 
 ##### Fixes :wrench:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ### 1.76 - 2020-12-01
 
+##### Deprecated :hourglass_flowing_sand:
+
+- `EasingFunction.QUADRACTIC_IN` was deprecated and will be removed in Cesium ???. It has been replaced with `EasingFunction.QUADRATIC_IN`. [#9220](https://github.com/CesiumGS/cesium/issues/9220)
+- `EasingFunction.QUADRACTIC_OUT` was deprecated and will be removed in Cesium ???. It has been replaced with `EasingFunction.QUADRATIC_OUT`. [#9220](https://github.com/CesiumGS/cesium/issues/9220)
+- `EasingFunction.QUADRACTIC_IN_OUT` was deprecated and will be removed in Cesium ???. It has been replaced with `EasingFunction.QUADRATIC_IN_OUT`. [#9220](https://github.com/CesiumGS/cesium/issues/9220)
+
 ##### Fixes :wrench:
 
 - Fixed an issue where tileset styles would be reapplied every frame when a tileset has a style and `tileset.preloadWhenHidden` is true and `tileset.show` is false. Also fixed a related issue where styles would be reapplied if the style being set is the same as the active style. [#9223](https://github.com/CesiumGS/cesium/pull/9223)

--- a/Source/Core/EasingFunction.js
+++ b/Source/Core/EasingFunction.js
@@ -1,4 +1,5 @@
 import Tween from "../ThirdParty/Tween.js";
+import deprecationWarning from "./deprecationWarning.js";
 
 /**
  * Easing functions for use with TweenCollection.  These function are from
@@ -22,21 +23,64 @@ var EasingFunction = {
    * @type {EasingFunction.Callback}
    * @constant
    */
-  QUADRACTIC_IN: Tween.Easing.Quadratic.In,
+  QUADRATIC_IN: Tween.Easing.Quadratic.In,
   /**
    * Quadratic out.
    *
    * @type {EasingFunction.Callback}
    * @constant
    */
-  QUADRACTIC_OUT: Tween.Easing.Quadratic.Out,
+  QUADRATIC_OUT: Tween.Easing.Quadratic.Out,
   /**
    * Quadratic in then out.
    *
    * @type {EasingFunction.Callback}
    * @constant
    */
-  QUADRACTIC_IN_OUT: Tween.Easing.Quadratic.InOut,
+  QUADRATIC_IN_OUT: Tween.Easing.Quadratic.InOut,
+
+  /**
+   * Quadratic in.
+   *
+   * @type {EasingFunction.Callback}
+   * @constant
+   * @deprecated This enum has been deprecated and will be removed in Cesium ????. Use {@link EasingFunction.QUADRATIC_IN} instead.
+   */
+  get QUADRACTIC_IN() {
+    deprecationWarning(
+      "QUADRACTIC_IN",
+      "QUADRACTIC_IN is deprecated and will be removed in Cesium ????. Use QUADRATIC_IN instead."
+    );
+    return Tween.Easing.Quadratic.In;
+  },
+  /**
+   * Quadratic out.
+   *
+   * @type {EasingFunction.Callback}
+   * @constant
+   * @deprecated This enum has been deprecated and will be removed in Cesium ????. Use {@link EasingFunction.QUADRATIC_OUT} instead.
+   */
+  get QUADRACTIC_OUT() {
+    deprecationWarning(
+      "QUADRACTIC_OUT",
+      "QUADRACTIC_OUT is deprecated and will be removed in Cesium ????. Use QUADRATIC_OUT instead."
+    );
+    return Tween.Easing.Quadratic.Out;
+  },
+  /**
+   * Quadratic in then out.
+   *
+   * @type {EasingFunction.Callback}
+   * @constant
+   * @deprecated This enum has been deprecated and will be removed in Cesium ????. Use {@link EasingFunction.QUADRATIC_IN_OUT} instead.
+   */
+  get QUADRACTIC_IN_OUT() {
+    deprecationWarning(
+      "QUADRACTIC_IN_OUT",
+      "QUADRACTIC_IN_OUT is deprecated and will be removed in Cesium ????. Use QUADRATIC_IN_OUT instead."
+    );
+    return Tween.Easing.Quadratic.InOut;
+  },
 
   /**
    * Cubic in.

--- a/Source/Core/EasingFunction.js
+++ b/Source/Core/EasingFunction.js
@@ -40,49 +40,6 @@ var EasingFunction = {
   QUADRATIC_IN_OUT: Tween.Easing.Quadratic.InOut,
 
   /**
-   * Quadratic in.
-   *
-   * @type {EasingFunction.Callback}
-   * @constant
-   * @deprecated This enum has been deprecated and will be removed in Cesium ????. Use {@link EasingFunction.QUADRATIC_IN} instead.
-   */
-  get QUADRACTIC_IN() {
-    deprecationWarning(
-      "QUADRACTIC_IN",
-      "QUADRACTIC_IN is deprecated and will be removed in Cesium ????. Use QUADRATIC_IN instead."
-    );
-    return Tween.Easing.Quadratic.In;
-  },
-  /**
-   * Quadratic out.
-   *
-   * @type {EasingFunction.Callback}
-   * @constant
-   * @deprecated This enum has been deprecated and will be removed in Cesium ????. Use {@link EasingFunction.QUADRATIC_OUT} instead.
-   */
-  get QUADRACTIC_OUT() {
-    deprecationWarning(
-      "QUADRACTIC_OUT",
-      "QUADRACTIC_OUT is deprecated and will be removed in Cesium ????. Use QUADRATIC_OUT instead."
-    );
-    return Tween.Easing.Quadratic.Out;
-  },
-  /**
-   * Quadratic in then out.
-   *
-   * @type {EasingFunction.Callback}
-   * @constant
-   * @deprecated This enum has been deprecated and will be removed in Cesium ????. Use {@link EasingFunction.QUADRATIC_IN_OUT} instead.
-   */
-  get QUADRACTIC_IN_OUT() {
-    deprecationWarning(
-      "QUADRACTIC_IN_OUT",
-      "QUADRACTIC_IN_OUT is deprecated and will be removed in Cesium ????. Use QUADRATIC_IN_OUT instead."
-    );
-    return Tween.Easing.Quadratic.InOut;
-  },
-
-  /**
    * Cubic in.
    *
    * @type {EasingFunction.Callback}
@@ -281,6 +238,57 @@ var EasingFunction = {
   BOUNCE_IN_OUT: Tween.Easing.Bounce.InOut,
 };
 
+Object.defineProperties(EasingFunction, {
+  /**
+   * Quadratic in.
+   * @memberof EasingFunction
+   * @type {EasingFunction.Callback}
+   * @constant
+   * @deprecated This enum has been deprecated and will be removed in Cesium 1.79. Use {@link EasingFunction.QUADRATIC_IN} instead.
+   */
+  QUADRACTIC_IN: {
+    get: function () {
+      deprecationWarning(
+        "QUADRACTIC_IN",
+        "QUADRACTIC_IN is deprecated and will be removed in Cesium 1.79. Use QUADRATIC_IN instead."
+      );
+      return Tween.Easing.Quadratic.In;
+    },
+  },
+  /**
+   * Quadratic out.
+   * @memberof EasingFunction
+   * @type {EasingFunction.Callback}
+   * @constant
+   * @deprecated This enum has been deprecated and will be removed in Cesium 1.79. Use {@link EasingFunction.QUADRATIC_OUT} instead.
+   */
+  QUADRACTIC_OUT: {
+    get: function () {
+      deprecationWarning(
+        "QUADRACTIC_OUT",
+        "QUADRACTIC_OUT is deprecated and will be removed in Cesium 1.79. Use QUADRATIC_OUT instead."
+      );
+      return Tween.Easing.Quadratic.Out;
+    },
+  },
+  /**
+   * Quadratic in then out.
+   * @memberof EasingFunction
+   * @type {EasingFunction.Callback}
+   * @constant
+   * @deprecated This enum has been deprecated and will be removed in Cesium 1.79. Use {@link EasingFunction.QUADRATIC_IN_OUT} instead.
+   */
+  QUADRACTIC_IN_OUT: {
+    get: function () {
+      deprecationWarning(
+        "QUADRACTIC_IN_OUT",
+        "QUADRACTIC_IN_OUT is deprecated and will be removed in Cesium 1.79. Use QUADRATIC_IN_OUT instead."
+      );
+      return Tween.Easing.Quadratic.InOut;
+    },
+  },
+});
+
 /**
  * Function interface for implementing a custom easing function.
  * @callback EasingFunction.Callback
@@ -297,4 +305,5 @@ var EasingFunction = {
  *     return time * (2.0 - time);
  * }
  */
+
 export default Object.freeze(EasingFunction);

--- a/Specs/Scene/TweenCollectionSpec.js
+++ b/Specs/Scene/TweenCollectionSpec.js
@@ -22,7 +22,7 @@ describe(
         stopObject: stopObject,
         duration: 1.0,
         delay: 0.5,
-        easingFunction: EasingFunction.QUADRACTIC_IN,
+        easingFunction: EasingFunction.QUADRATIC_IN,
         update: update,
         complete: complete,
         cancel: cancel,
@@ -32,7 +32,7 @@ describe(
       expect(tween.stopObject).toEqual(stopObject);
       expect(tween.duration).toEqual(1.0);
       expect(tween.delay).toEqual(0.5);
-      expect(tween.easingFunction).toEqual(EasingFunction.QUADRACTIC_IN);
+      expect(tween.easingFunction).toEqual(EasingFunction.QUADRATIC_IN);
       expect(tween.update).toBe(update);
       expect(tween.complete).toBe(complete);
       expect(tween.cancel).toBe(cancel);


### PR DESCRIPTION
Deprecated and added `deprecationWarning` for the incorrectly spelled `QUADRACTIC_IN`, `QUADRACTIC_OUT`, and `QUADRACTIC_IN_OUT` in `EasingFunction.js` and added the correct spellings. Changed the only two internal references to the incorrect spellings (in `TweenCollectionSpec.js`). 

This addresses the open issue:  #9220. It will be resolved after the deprecation period. 

Note that there were two sandcastles [here](https://sandcastle.cesium.com/?src=Montreal%20Point%20Cloud.html) and [here](https://sandcastle.cesium.com/?src=3D%20Tiles%20Interactivity.html) that already use the correct spellings of the quadratic easing functions and were so far silently failing (reverting to a default easing function). After this fix, they will be using the correct intended easing functions. 
