### PR TITLE
Fixed invalid texture pixel formats when using WebGL2 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,12 @@
 
 ##### Fixes :wrench:
 
+- Fixed undefined references in `PixelFormat.toInternalFormat(...)`. [#9237](https://github.com/CesiumGS/cesium/issues/9237)
+- Added `PixelFormat.toWebGLPixelFormat(...)` to convert any valid cesium pixel format into a corresponding pixel format that is compliant to the version of WebGL being used. [#9237](https://github.com/CesiumGS/cesium/issues/9237)
+- Refactored all texImage2D and texSubImage2D calls in `Textures.js` to use WebGL version-compliant pixel formats. [#9237](https://github.com/CesiumGS/cesium/issues/9237)
+
+##### Fixes :wrench:
+
 - Fixed an issue where tileset styles would be reapplied every frame when a tileset has a style and `tileset.preloadWhenHidden` is true and `tileset.show` is false. Also fixed a related issue where styles would be reapplied if the style being set is the same as the active style. [#9223](https://github.com/CesiumGS/cesium/pull/9223)
 - Fixed JSDoc and TypeScript type definitions for `EllipsoidTangentPlane.fromPoints` which didn't list a return type. [#9227](https://github.com/CesiumGS/cesium/pull/9227)
 - Updated DOMPurify from 1.0.8 to 2.2.2. [#9240](https://github.com/CesiumGS/cesium/issues/9240)

--- a/Source/Core/PixelFormat.js
+++ b/Source/Core/PixelFormat.js
@@ -397,9 +397,11 @@ PixelFormat.toInternalFormat = function (pixelFormat, pixelDatatype, context) {
         return WebGLConstants.RGBA32F;
       case PixelFormat.RGB:
         return WebGLConstants.RGB32F;
-      case PixelFormat.RG:
+      case PixelFormat.LUMINANCE_ALPHA:
         return WebGLConstants.RG32F;
-      case PixelFormat.R:
+      case PixelFormat.LUMINANCE:
+        return WebGLConstants.R32F;
+      case PixelFormat.ALPHA:
         return WebGLConstants.R32F;
     }
   }
@@ -410,10 +412,40 @@ PixelFormat.toInternalFormat = function (pixelFormat, pixelDatatype, context) {
         return WebGLConstants.RGBA16F;
       case PixelFormat.RGB:
         return WebGLConstants.RGB16F;
-      case PixelFormat.RG:
+      case PixelFormat.LUMINANCE_ALPHA:
         return WebGLConstants.RG16F;
-      case PixelFormat.R:
+      case PixelFormat.LUMINANCE:
         return WebGLConstants.R16F;
+      case PixelFormat.ALPHA:
+        return WebGLConstants.R16F;
+    }
+  }
+
+  return pixelFormat;
+};
+
+/**
+ * @private
+ */
+PixelFormat.toWebGLPixelFormat = function (
+  pixelFormat,
+  pixelDatatype,
+  context
+) {
+  // WebGL 2 does not allow floating point LUMINANCE_ALPHA, LUMINANCE, or ALPHA pixel formats
+  if (
+    (pixelDatatype === PixelDatatype.FLOAT ||
+      pixelDatatype === PixelDatatype.HALF_FLOAT) &&
+    context.webgl2
+  ) {
+    if (pixelFormat === PixelFormat.LUMINANCE_ALPHA) {
+      return WebGLConstants.RG;
+    }
+    if (pixelFormat === PixelFormat.LUMINANCE) {
+      return WebGLConstants.RED;
+    }
+    if (pixelFormat === PixelFormat.ALPHA) {
+      return WebGLConstants.RED;
     }
   }
 

--- a/Source/Renderer/Texture.js
+++ b/Source/Renderer/Texture.js
@@ -48,7 +48,11 @@ function Texture(options) {
     pixelDatatype,
     context
   );
-
+  var webGLPixelFormat = PixelFormat.toWebGLPixelFormat(
+    pixelFormat,
+    pixelDatatype,
+    context
+  );
   var isCompressed = PixelFormat.isCompressedFormat(internalFormat);
 
   //>>includeStart('debug', pragmas.debug);
@@ -224,6 +228,7 @@ function Texture(options) {
             height
           );
         }
+
         gl.texImage2D(
           textureTarget,
           0,
@@ -231,7 +236,7 @@ function Texture(options) {
           width,
           height,
           0,
-          pixelFormat,
+          webGLPixelFormat,
           PixelDatatype.toWebGLConstant(pixelDatatype, context),
           arrayBufferView
         );
@@ -255,7 +260,7 @@ function Texture(options) {
               mipWidth,
               mipHeight,
               0,
-              pixelFormat,
+              webGLPixelFormat,
               PixelDatatype.toWebGLConstant(pixelDatatype, context),
               source.mipLevels[i]
             );
@@ -295,7 +300,7 @@ function Texture(options) {
         textureTarget,
         0,
         internalFormat,
-        pixelFormat,
+        webGLPixelFormat,
         PixelDatatype.toWebGLConstant(pixelDatatype, context),
         source
       );
@@ -308,7 +313,7 @@ function Texture(options) {
       width,
       height,
       0,
-      pixelFormat,
+      webGLPixelFormat,
       PixelDatatype.toWebGLConstant(pixelDatatype, context),
       null
     );
@@ -339,6 +344,7 @@ function Texture(options) {
   this._texture = texture;
   this._internalFormat = internalFormat;
   this._pixelFormat = pixelFormat;
+  this._webGLPixelFormat = webGLPixelFormat;
   this._pixelDatatype = pixelDatatype;
   this._width = width;
   this._height = height;
@@ -669,6 +675,7 @@ Texture.prototype.copyFrom = function (source, xOffset, yOffset) {
   var textureHeight = this._height;
   var internalFormat = this._internalFormat;
   var pixelFormat = this._pixelFormat;
+  var webGLPixelFormat = this._webGLPixelFormat;
   var pixelDatatype = this._pixelDatatype;
 
   var preMultiplyAlpha = this._preMultiplyAlpha;
@@ -714,7 +721,7 @@ Texture.prototype.copyFrom = function (source, xOffset, yOffset) {
           textureWidth,
           textureHeight,
           0,
-          pixelFormat,
+          webGLPixelFormat,
           PixelDatatype.toWebGLConstant(pixelDatatype, context),
           arrayBufferView
         );
@@ -727,7 +734,7 @@ Texture.prototype.copyFrom = function (source, xOffset, yOffset) {
           target,
           0,
           internalFormat,
-          pixelFormat,
+          webGLPixelFormat,
           PixelDatatype.toWebGLConstant(pixelDatatype, context),
           source
         );
@@ -751,7 +758,7 @@ Texture.prototype.copyFrom = function (source, xOffset, yOffset) {
         textureWidth,
         textureHeight,
         0,
-        pixelFormat,
+        webGLPixelFormat,
         PixelDatatype.toWebGLConstant(pixelDatatype, context),
         bufferView
       );
@@ -780,7 +787,7 @@ Texture.prototype.copyFrom = function (source, xOffset, yOffset) {
         yOffset,
         width,
         height,
-        pixelFormat,
+        webGLPixelFormat,
         PixelDatatype.toWebGLConstant(pixelDatatype, context),
         arrayBufferView
       );
@@ -794,7 +801,7 @@ Texture.prototype.copyFrom = function (source, xOffset, yOffset) {
         0,
         xOffset,
         yOffset,
-        pixelFormat,
+        webGLPixelFormat,
         PixelDatatype.toWebGLConstant(pixelDatatype, context),
         source
       );


### PR DESCRIPTION
Partially addresses #9237 

Fixed undefined references in `PixelFormat.toInternalFormat` addressing the first part of the issue.

As mentioned in the rest of the issue and comments, floating point `LUMINANCE`, `ALPHA`, and `LUMINANCE_ALPHA` pixel formats are invalid in WebGL2 but were being used internally inside CesiumJS irrespective of the WebGL version being used. I added `PixelFormat.toWebGLPixelFormat` to convert any currently valid cesium pixel format into a corresponding pixel format that is compliant to the version of WebGL being used. `LUMINANCE`, `ALPHA`, and `LUMINANCE_ALPHA` floating point formats convert to `RED`, `RED`, and `RG` floating point formats respectively when using WebGL2.

I refactored all `texImage2D` and `texSubImage2D` calls in `Texture.js` to use the converted WebGL version-compliant pixel format. 

Note that `CubeMap.js` and `CubeMapFace.js` both need a similar refactor to what I did in `Texture.js`. If this PR is reviewed / merged and no one disagrees with my approach in refactoring `Texture.js`, I will probably just go ahead and do the same thing for `CubeMap.js` and `CubeMapFace.js` in a separate PR.

Edit: Needs unit tests in `TextureSpec.js` and possibly `PixelFormatSpec.js`.