### PR TITLE
Fixed error when nodeCommands[0] is undefined in Model.updateColor()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### 1.77 - 2020-01-04
 
+##### Fixes :wrench:
+
+- Fixed an issue where Model.updateColor, Model.updateBackFaceCulling and Model.updateSilhouette threw errors when length of nodeCommands was 0 [#9271](https://github.com/CesiumGS/cesium/pull/9271)
+
 ##### Deprecated :hourglass_flowing_sand:
 
 - `EasingFunction.QUADRACTIC_IN` was deprecated and will be removed in Cesium 1.79. It has been replaced with `EasingFunction.QUADRATIC_IN`. [#9220](https://github.com/CesiumGS/cesium/issues/9220)

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -4546,7 +4546,10 @@ function updateBackFaceCulling(model, frameState, forceDerive) {
   if (!backFaceCulling) {
     var nodeCommands = model._nodeCommands;
     var length = nodeCommands.length;
-    if (!defined(nodeCommands[0].disableCullingCommand) || forceDerive) {
+    if (
+      length > 0 &&
+      (!defined(nodeCommands[0].disableCullingCommand) || forceDerive)
+    ) {
       for (var i = 0; i < length; ++i) {
         var nodeCommand = nodeCommands[i];
         var command = nodeCommand.command;
@@ -4816,12 +4819,13 @@ function updateSilhouette(model, frameState, force) {
 
   var nodeCommands = model._nodeCommands;
   var dirty =
-    alphaDirty(model.color.alpha, model._colorPreviousAlpha) ||
-    alphaDirty(
-      model.silhouetteColor.alpha,
-      model._silhouetteColorPreviousAlpha
-    ) ||
-    !defined(nodeCommands[0].silhouetteModelCommand);
+    nodeCommands.length > 0 &&
+    (alphaDirty(model.color.alpha, model._colorPreviousAlpha) ||
+      alphaDirty(
+        model.silhouetteColor.alpha,
+        model._silhouetteColorPreviousAlpha
+      ) ||
+      !defined(nodeCommands[0].silhouetteModelCommand));
 
   model._colorPreviousAlpha = model.color.alpha;
   model._silhouetteColorPreviousAlpha = model.silhouetteColor.alpha;

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -4507,7 +4507,10 @@ function updateColor(model, frameState, forceDerive) {
   if (alpha > 0.0 && alpha < 1.0) {
     var nodeCommands = model._nodeCommands;
     var length = nodeCommands.length;
-    if (!defined(nodeCommands[0].translucentCommand) || forceDerive) {
+    if (
+      length > 0 &&
+      (!defined(nodeCommands[0].translucentCommand) || forceDerive)
+    ) {
       for (var i = 0; i < length; ++i) {
         var nodeCommand = nodeCommands[i];
         var command = nodeCommand.command;


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/9273
Fixes https://github.com/CesiumGS/cesium/issues/8394
Fixes https://github.com/CesiumGS/cesium/issues/9278

Model.js was missing code to handle the case in updateColor where `nodeCommands.length == 0`.

---
## Background
For some reason that I ran out of time to diagnose, [this PR](https://github.com/TerriaJS/terriajs/pull/4974) to TerriaJS is hitting a case where `nodeCommands[0]` in Model.updateColor() is undefined. This seems like something that shouldn't happen, but this PR stops Cesium from throwing an error and doesn't seem to have any negative consequences.