### PR TITLE
#7462 - set 3D tiles as default sandcastle bucket

### DIFF
--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -184,7 +184,7 @@ require({
   var searchTerm = "";
   var searchRegExp;
   var hintTimer;
-  var defaultDemo = "Hello World";
+  var defaultDemo = "3D Tiles Interactivity";
   var defaultLabel = "Showcases";
   var currentTab = defaultLabel;
   var newDemo;


### PR DESCRIPTION
Addresses this: https://github.com/CesiumGS/cesium/issues/7462

I left the default gallery tab as "Showcases" because I think it makes sense to keep showcasing them as default.