### PR TITLE
More accurate packFloat and unpackFloat

### DIFF
--- a/Source/Core/Cartesian4.js
+++ b/Source/Core/Cartesian4.js
@@ -896,11 +896,6 @@ Cartesian4.packFloat = function (value, result) {
   // scratchU8Array and scratchF32Array are views into the same buffer
   scratchF32Array[0] = value;
 
-  // Values outside the 32-bit float range get converted to the max 32-bit float.
-  if (!isFinite(scratchF32Array[0]) && scratchF32Array[0] !== value) {
-    scratchF32Array[0] = Math.sign(value) * 3.4028234663852886e38; // max 32-bit float
-  }
-
   if (littleEndian) {
     result.x = scratchU8Array[0];
     result.y = scratchU8Array[1];

--- a/Source/Core/Cartesian4.js
+++ b/Source/Core/Cartesian4.js
@@ -897,11 +897,8 @@ Cartesian4.packFloat = function (value, result) {
   scratchF32Array[0] = value;
 
   // Values outside the 32-bit float range get converted to the max 32-bit float.
-  if (scratchF32Array[0] === +Infinity && scratchF32Array[0] !== value) {
-    scratchF32Array[0] = +3.4028234663852886e38; // max positive 32-bit float
-  }
-  if (scratchF32Array[0] === -Infinity && scratchF32Array[0] !== value) {
-    scratchF32Array[0] = -3.4028234663852886e38; // max negative 32-bit float
+  if (!isFinite(scratchF32Array[0]) && scratchF32Array[0] !== value) {
+    scratchF32Array[0] = Math.sign(value) * 3.4028234663852886e38; // max 32-bit float
   }
 
   if (littleEndian) {

--- a/Source/Core/Cartesian4.js
+++ b/Source/Core/Cartesian4.js
@@ -869,16 +869,13 @@ Cartesian4.prototype.toString = function () {
   return "(" + this.x + ", " + this.y + ", " + this.z + ", " + this.w + ")";
 };
 
-var scratchFloatArray = new Float32Array(1);
-var SHIFT_LEFT_8 = 256.0;
-var SHIFT_LEFT_16 = 65536.0;
-var SHIFT_LEFT_24 = 16777216.0;
+// scratchU8Array and scratchF32Array are views into the same buffer
+var scratchF32Array = new Float32Array(1);
+var scratchU8Array = new Uint8Array(scratchF32Array.buffer);
 
-var SHIFT_RIGHT_8 = 1.0 / SHIFT_LEFT_8;
-var SHIFT_RIGHT_16 = 1.0 / SHIFT_LEFT_16;
-var SHIFT_RIGHT_24 = 1.0 / SHIFT_LEFT_24;
-
-var BIAS = 38.0;
+var testU32 = new Uint32Array([0x11223344]);
+var testU8 = new Uint8Array(testU32.buffer);
+var littleEndian = testU8[0] === 0x44;
 
 /**
  * Packs an arbitrary floating point value to 4 values representable using uint8.
@@ -896,34 +893,20 @@ Cartesian4.packFloat = function (value, result) {
     result = new Cartesian4();
   }
 
-  // Force the value to 32 bit precision
-  scratchFloatArray[0] = value;
-  value = scratchFloatArray[0];
-
-  if (value === 0.0) {
-    return Cartesian4.clone(Cartesian4.ZERO, result);
-  }
-
-  var sign = value < 0.0 ? 1.0 : 0.0;
-  var exponent;
-
-  if (!isFinite(value)) {
-    value = 0.1;
-    exponent = BIAS;
+  // scratchU8Array and scratchF32Array are views into the same buffer
+  scratchF32Array[0] = value;
+  if (littleEndian) {
+    result.x = scratchU8Array[0];
+    result.y = scratchU8Array[1];
+    result.z = scratchU8Array[2];
+    result.w = scratchU8Array[3];
   } else {
-    value = Math.abs(value);
-    exponent = Math.floor(CesiumMath.logBase(value, 10)) + 1.0;
-    value = value / Math.pow(10.0, exponent);
+    // store the result as little endian
+    result.x = scratchU8Array[3];
+    result.y = scratchU8Array[2];
+    result.z = scratchU8Array[1];
+    result.w = scratchU8Array[0];
   }
-
-  var temp = value * SHIFT_LEFT_8;
-  result.x = Math.floor(temp);
-  temp = (temp - result.x) * SHIFT_LEFT_8;
-  result.y = Math.floor(temp);
-  temp = (temp - result.y) * SHIFT_LEFT_8;
-  result.z = Math.floor(temp);
-  result.w = (exponent + BIAS) * 2.0 + sign;
-
   return result;
 };
 
@@ -939,22 +922,19 @@ Cartesian4.unpackFloat = function (packedFloat) {
   Check.typeOf.object("packedFloat", packedFloat);
   //>>includeEnd('debug');
 
-  var temp = packedFloat.w / 2.0;
-  var exponent = Math.floor(temp);
-  var sign = (temp - exponent) * 2.0;
-  exponent = exponent - BIAS;
-
-  sign = sign * 2.0 - 1.0;
-  sign = -sign;
-
-  if (exponent >= BIAS) {
-    return sign < 0.0 ? Number.NEGATIVE_INFINITY : Number.POSITIVE_INFINITY;
+  // scratchU8Array and scratchF32Array are views into the same buffer
+  if (littleEndian) {
+    scratchU8Array[0] = packedFloat.x;
+    scratchU8Array[1] = packedFloat.y;
+    scratchU8Array[2] = packedFloat.z;
+    scratchU8Array[3] = packedFloat.w;
+  } else {
+    // load the result from little endian
+    scratchU8Array[0] = packedFloat.w;
+    scratchU8Array[1] = packedFloat.z;
+    scratchU8Array[2] = packedFloat.y;
+    scratchU8Array[3] = packedFloat.x;
   }
-
-  var unpacked = sign * packedFloat.x * SHIFT_RIGHT_8;
-  unpacked += sign * packedFloat.y * SHIFT_RIGHT_16;
-  unpacked += sign * packedFloat.z * SHIFT_RIGHT_24;
-
-  return unpacked * Math.pow(10.0, exponent);
+  return scratchF32Array[0];
 };
 export default Cartesian4;

--- a/Source/Core/Cartesian4.js
+++ b/Source/Core/Cartesian4.js
@@ -3,6 +3,7 @@ import defaultValue from "./defaultValue.js";
 import defined from "./defined.js";
 import DeveloperError from "./DeveloperError.js";
 import CesiumMath from "./Math.js";
+import RuntimeError from "./RuntimeError.js";
 
 /**
  * A 4D Cartesian point.
@@ -895,6 +896,16 @@ Cartesian4.packFloat = function (value, result) {
 
   // scratchU8Array and scratchF32Array are views into the same buffer
   scratchF32Array[0] = value;
+
+  // Only allow values that fit into the 32-bit float range.
+  // Values outside the 32-bit float range become Infinity.
+  if (
+    (scratchF32Array[0] === +Infinity || scratchF32Array[0] === -Infinity) &&
+    scratchF32Array[0] !== value
+  ) {
+    throw new RuntimeError("Input exceeds the range of a 32-bit float");
+  }
+
   if (littleEndian) {
     result.x = scratchU8Array[0];
     result.y = scratchU8Array[1];

--- a/Source/Core/Cartesian4.js
+++ b/Source/Core/Cartesian4.js
@@ -881,7 +881,8 @@ var littleEndian = testU8[0] === 0x44;
 /**
  * Packs an arbitrary floating point value to 4 values representable using uint8.
  *
- * @param {Number} value A floating point number
+ * @param {Number} value A floating point number. If this number exceeds the
+ * 32-bit floating point range, a {@link RuntimeError} will be thrown.
  * @param {Cartesian4} [result] The Cartesian4 that will contain the packed float.
  * @returns {Cartesian4} A Cartesian4 representing the float packed to values in x, y, z, and w.
  */
@@ -898,7 +899,8 @@ Cartesian4.packFloat = function (value, result) {
   scratchF32Array[0] = value;
 
   // Only allow values that fit into the 32-bit float range.
-  // Values outside the 32-bit float range become Infinity.
+  // Values outside the 32-bit float range can be detected by checking if
+  // the resulting 32-bit value is Infinity.
   if (
     (scratchF32Array[0] === +Infinity || scratchF32Array[0] === -Infinity) &&
     scratchF32Array[0] !== value

--- a/Source/Shaders/Builtin/Functions/unpackFloat.glsl
+++ b/Source/Shaders/Builtin/Functions/unpackFloat.glsl
@@ -12,13 +12,13 @@ float czm_unpackFloat(vec4 packedFloat)
 {
     // Convert to [0.0, 255.0] and round to integer
     packedFloat = floor(packedFloat * 255.0 + 0.5);
-    float Sign = 1.0 - step(128.0, packedFloat[3]) * 2.0;
-    float Exponent = 2.0 * mod(packedFloat[3], 128.0) + step(128.0, packedFloat[2]) - 127.0;    
-    if (Exponent == -127.0)
+    float sign = 1.0 - step(128.0, packedFloat[3]) * 2.0;
+    float exponent = 2.0 * mod(packedFloat[3], 128.0) + step(128.0, packedFloat[2]) - 127.0;    
+    if (exponent == -127.0)
     {
         return 0.0;
     }
-    float Mantissa = mod(packedFloat[2], 128.0) * 65536.0 + packedFloat[1] * 256.0 + packedFloat[0] + float(0x800000);
-    float Result = Sign * exp2(Exponent - 23.0) * Mantissa;
-    return Result;
+    float mantissa = mod(packedFloat[2], 128.0) * 65536.0 + packedFloat[1] * 256.0 + packedFloat[0] + float(0x800000);
+    float result = sign * exp2(exponent - 23.0) * mantissa;
+    return result;
 }

--- a/Source/Shaders/Builtin/Functions/unpackFloat.glsl
+++ b/Source/Shaders/Builtin/Functions/unpackFloat.glsl
@@ -1,11 +1,5 @@
-#define SHIFT_RIGHT_8 0.00390625 //1.0 / 256.0
-#define SHIFT_RIGHT_16 0.00001525878 //1.0 / 65536.0
-#define SHIFT_RIGHT_24 5.960464477539063e-8//1.0 / 16777216.0
-
-#define BIAS 38.0
-
 /**
- * Unpacks a vec4 value containing values expressable as uint8 to an arbitrary float.
+ * Unpack an IEEE 754 single-precision float that is packed as a little-endian unsigned normalized vec4.
  *
  * @name czm_unpackFloat
  * @glslFunction
@@ -14,17 +8,17 @@
  *
  * @returns {float} The floating-point depth in arbitrary range.
  */
- float czm_unpackFloat(vec4 packedFloat)
+float czm_unpackFloat(vec4 packedFloat)
 {
-    packedFloat *= 255.0;
-    float temp = packedFloat.w / 2.0;
-    float exponent = floor(temp);
-    float sign = (temp - exponent) * 2.0;
-    exponent = exponent - float(BIAS);
-    sign = sign * 2.0 - 1.0;
-    sign = -sign;
-    float unpacked = sign * packedFloat.x * float(SHIFT_RIGHT_8);
-    unpacked += sign * packedFloat.y * float(SHIFT_RIGHT_16);
-    unpacked += sign * packedFloat.z * float(SHIFT_RIGHT_24);
-    return unpacked * pow(10.0, exponent);
+    // Convert to [0.0, 255.0] and round to integer
+    packedFloat = floor(packedFloat * 255.0 + 0.5);
+    float Sign = 1.0 - step(128.0, packedFloat[3]) * 2.0;
+    float Exponent = 2.0 * mod(packedFloat[3], 128.0) + step(128.0, packedFloat[2]) - 127.0;    
+    if (Exponent == -127.0)
+    {
+        return 0.0;
+    }
+    float Mantissa = mod(packedFloat[2], 128.0) * 65536.0 + packedFloat[1] * 256.0 + packedFloat[0] + float(0x800000);
+    float Result = Sign * exp2(Exponent - 23.0) * Mantissa;
+    return Result;
 }

--- a/Specs/Core/ApproximateTerrainHeightsSpec.js
+++ b/Specs/Core/ApproximateTerrainHeightsSpec.js
@@ -25,11 +25,11 @@ describe("Core/ApproximateTerrainHeights", function () {
     );
     expect(result.minimumTerrainHeight).toEqualEpsilon(
       -476.12571188755,
-      CesiumMath.EPSILON10
+      CesiumMath.EPSILON8
     );
     expect(result.maximumTerrainHeight).toEqualEpsilon(
       -28.53,
-      CesiumMath.EPSILON10
+      CesiumMath.EPSILON8
     );
   });
 
@@ -60,11 +60,11 @@ describe("Core/ApproximateTerrainHeights", function () {
         -5403772.559109628,
         1154581.5821590829
       ),
-      CesiumMath.EPSILON10
+      CesiumMath.EPSILON8
     );
     expect(result.radius).toEqualEpsilon(
       77884.16321007285,
-      CesiumMath.EPSILON10
+      CesiumMath.EPSILON8
     );
   });
 

--- a/Specs/Core/Cartesian4Spec.js
+++ b/Specs/Core/Cartesian4Spec.js
@@ -1102,7 +1102,7 @@ describe("Core/Cartesian4", function () {
       expect(unpackedFloat).toBeNaN();
     }
 
-    function testOutOfRange(float) {
+    function testFloatOutOfRange(float) {
       expect(function () {
         Cartesian4.packFloat(float);
       }).toThrowRuntimeError();
@@ -1122,8 +1122,8 @@ describe("Core/Cartesian4", function () {
     testFloat(Float32Array.of(-Infinity)[0]); // 32-bit infinity
     testFloatNaN(Float32Array.of(NaN)[0]); // 32-bit NaN
 
-    testOutOfRange(+Number.MAX_VALUE);
-    testOutOfRange(-Number.MAX_VALUE);
+    testFloatOutOfRange(+Number.MAX_VALUE);
+    testFloatOutOfRange(-Number.MAX_VALUE);
   });
 
   createPackableSpecs(Cartesian4, new Cartesian4(1, 2, 3, 4), [1, 2, 3, 4]);

--- a/Specs/Core/Cartesian4Spec.js
+++ b/Specs/Core/Cartesian4Spec.js
@@ -1094,11 +1094,36 @@ describe("Core/Cartesian4", function () {
       var unpackedFloat = Cartesian4.unpackFloat(packedFloat);
       expect(unpackedFloat).toEqual(float);
     }
+
+    function testFloatNaN(float) {
+      expect(float).toBeNaN();
+      var packedFloat = Cartesian4.packFloat(float);
+      var unpackedFloat = Cartesian4.unpackFloat(packedFloat);
+      expect(unpackedFloat).toBeNaN();
+    }
+
+    function testOutOfRange(float) {
+      expect(function () {
+        Cartesian4.packFloat(float);
+      }).toThrowRuntimeError();
+    }
+
     testFloat(0.0);
     testFloat(-1.0);
     testFloat(+1.0);
     testFloat(123.5);
     testFloat(16777216);
+
+    testFloat(+Infinity); // 64-bit infinity -> 32-bit infinity
+    testFloat(-Infinity); // 64-bit infinity -> 32-bit infinity
+    testFloatNaN(NaN); // 64-bit NaN -> 32bit NaN
+
+    testFloat(Float32Array.of(+Infinity)[0]); // 32-bit infinity
+    testFloat(Float32Array.of(-Infinity)[0]); // 32-bit infinity
+    testFloatNaN(Float32Array.of(NaN)[0]); // 32-bit NaN
+
+    testOutOfRange(+Number.MAX_VALUE);
+    testOutOfRange(-Number.MAX_VALUE);
   });
 
   createPackableSpecs(Cartesian4, new Cartesian4(1, 2, 3, 4), [1, 2, 3, 4]);

--- a/Specs/Core/Cartesian4Spec.js
+++ b/Specs/Core/Cartesian4Spec.js
@@ -1105,8 +1105,7 @@ describe("Core/Cartesian4", function () {
     function testFloatOutOfRange(float) {
       var packedFloat = Cartesian4.packFloat(float);
       var unpackedFloat = Cartesian4.unpackFloat(packedFloat);
-      var maxFloat32 = 3.4028234663852886e38;
-      expect(unpackedFloat).toEqual(Math.sign(float) * maxFloat32);
+      expect(unpackedFloat).toEqual(Math.sign(float) * Infinity);
     }
 
     testFloat(0.0);

--- a/Specs/Core/Cartesian4Spec.js
+++ b/Specs/Core/Cartesian4Spec.js
@@ -1084,20 +1084,21 @@ describe("Core/Cartesian4", function () {
   });
 
   it("packs and unpacks floating point values for representation as uint8 4-vectors", function () {
-    var float = 123.456;
-    var packedFloat = Cartesian4.packFloat(float);
-    expect(0 <= packedFloat.x && packedFloat.x <= 255).toBe(true);
-    expect(0 <= packedFloat.y && packedFloat.y <= 255).toBe(true);
-    expect(0 <= packedFloat.z && packedFloat.z <= 255).toBe(true);
-    expect(0 <= packedFloat.w && packedFloat.w <= 255).toBe(true);
+    function testFloat(float) {
+      var packedFloat = Cartesian4.packFloat(float);
+      expect(0 <= packedFloat.x && packedFloat.x <= 255).toBe(true);
+      expect(0 <= packedFloat.y && packedFloat.y <= 255).toBe(true);
+      expect(0 <= packedFloat.z && packedFloat.z <= 255).toBe(true);
+      expect(0 <= packedFloat.w && packedFloat.w <= 255).toBe(true);
 
-    var unpackedFloat = Cartesian4.unpackFloat(packedFloat);
-    expect(
-      CesiumMath.equalsEpsilon(float, unpackedFloat, CesiumMath.EPSILON7)
-    ).toBe(true);
-
-    var packedZero = Cartesian4.packFloat(0);
-    expect(packedZero).toEqual(Cartesian4.ZERO);
+      var unpackedFloat = Cartesian4.unpackFloat(packedFloat);
+      expect(unpackedFloat).toEqual(float);
+    }
+    testFloat(0.0);
+    testFloat(-1.0);
+    testFloat(+1.0);
+    testFloat(123.5);
+    testFloat(16777216);
   });
 
   createPackableSpecs(Cartesian4, new Cartesian4(1, 2, 3, 4), [1, 2, 3, 4]);

--- a/Specs/Core/Cartesian4Spec.js
+++ b/Specs/Core/Cartesian4Spec.js
@@ -1118,12 +1118,19 @@ describe("Core/Cartesian4", function () {
     testFloat(-Infinity); // 64-bit infinity -> 32-bit infinity
     testFloatNaN(NaN); // 64-bit NaN -> 32bit NaN
 
-    testFloat(Float32Array.of(+Infinity)[0]); // 32-bit infinity
-    testFloat(Float32Array.of(-Infinity)[0]); // 32-bit infinity
-    testFloatNaN(Float32Array.of(NaN)[0]); // 32-bit NaN
-
     testFloatOutOfRange(+Number.MAX_VALUE);
     testFloatOutOfRange(-Number.MAX_VALUE);
+
+    var f32 = new Float32Array(1);
+
+    f32[0] = +Infinity;
+    testFloat(f32[0]); // 32-bit infinity
+
+    f32[0] = -Infinity;
+    testFloat(f32[0]); // 32-bit infinity
+
+    f32[0] = NaN;
+    testFloatNaN(f32[0]); // 32-bit NaN
   });
 
   createPackableSpecs(Cartesian4, new Cartesian4(1, 2, 3, 4), [1, 2, 3, 4]);

--- a/Specs/Core/Cartesian4Spec.js
+++ b/Specs/Core/Cartesian4Spec.js
@@ -1103,9 +1103,10 @@ describe("Core/Cartesian4", function () {
     }
 
     function testFloatOutOfRange(float) {
-      expect(function () {
-        Cartesian4.packFloat(float);
-      }).toThrowRuntimeError();
+      var packedFloat = Cartesian4.packFloat(float);
+      var unpackedFloat = Cartesian4.unpackFloat(packedFloat);
+      var maxFloat32 = 3.4028234663852886e38;
+      expect(unpackedFloat).toEqual(Math.sign(float) * maxFloat32);
     }
 
     testFloat(0.0);

--- a/Specs/Renderer/BuiltinFunctionsSpec.js
+++ b/Specs/Renderer/BuiltinFunctionsSpec.js
@@ -450,6 +450,7 @@ describe(
 
     it("has czm_unpackFloat", function () {
       var packed = Cartesian4.packFloat(1);
+      packed = Cartesian4.divideByScalar(packed, 255, packed);
       var vec4 =
         "vec4(" +
         packed.x +


### PR DESCRIPTION
The old `packFloat` / `unpackFloat` has some accuracy issues for large numbers. For example, `16777216` comes out to `16777211.427688599`, even though `16777216` is perfectly representable by a float32.

The initial float packing implementation was added here: https://github.com/CesiumGS/cesium/commit/dacc45254559237ed68945c69a3b66a423dadc28. I'm not sure how the original encoding scheme was devised, but it can be improved by storing the exact bit representation of the float32 (IEEE 754) into four uint8s (forced to be little endian so that the shader function `czm_unpackFloat` knows what to expect). Assuming the packed floats are used completely internally in CesiumJS and not moved to another computer, there should be no endianness problems.

The new `czm_unpackFloat` was adapted from https://stackoverflow.com/questions/7059962/how-do-i-convert-a-vec4-rgba-value-to-a-float

There appears to only be two systems that use `packFloat` / `unpackFloat`: clipping planes and batch tables when `context.floatingPointTexture` is `false`. Both work with the new code.

I tested by manually turning off floating point textures in `BatchTable.js` with
```
var textureFloatSupported = false; //context.floatingPointTexture;
```
and in `ClippingPlaneCollection.js` with
```
return false; //context.floatingPointTexture
```
Then I opened http://localhost:8080/Apps/Sandcastle/index.html?src=Custom%20DataSource.html and http://localhost:8080/Apps/Sandcastle/index.html?src=development%2FMany%20Clipping%20Planes.html and put breakpoints in `Cartesian4.packFloat` to make sure they were being hit. I also broke the code intentionally with code below and the demos stop working:
```
result.x = 10;//scratchU8Array[0];
result.y = 10;//scratchU8Array[1];
result.z = 10;//scratchU8Array[2];
result.w = 10;//scratchU8Array[3];
```

I also wrote a C program with the `czm_unpackFloat` function to make sure everything was ok:

```
#include <math.h>
#include <stdint.h>
#include <stdio.h>

float m_floor(float f) { return floorf(f); }
float m_step(float edge, float val) { return val < edge ? 0.0 : 1.0; }
float m_mod(float f, float m) { return fmodf(f, m); }
float m_exp2(float f) { return exp2f(f); }

float recode(float f) {
  uint8_t* packedU8 = (uint8_t*)&f;
  float packedFloat[] = {
      (float)(packedU8[0]) / 255.0f, (float)(packedU8[1]) / 255.0f,
      (float)(packedU8[2]) / 255.0f, (float)(packedU8[3]) / 255.0f};

  // Convert to [0.0, 255.0] and round to integer
  packedFloat[0] = m_floor(packedFloat[0] * 255.0f + 0.5f);
  packedFloat[1] = m_floor(packedFloat[1] * 255.0f + 0.5f);
  packedFloat[2] = m_floor(packedFloat[2] * 255.0f + 0.5f);
  packedFloat[3] = m_floor(packedFloat[3] * 255.0f + 0.5f);
  float Sign = 1.0f - m_step(128.0f, packedFloat[3]) * 2.0f;
  float Exponent = 2.0f * m_mod(packedFloat[3], 128.0f) +
                   m_step(128.0f, packedFloat[2]) - 127.0f;
  if (Exponent == -127.0f) {
    return 0.0f;
  }
  float Mantissa = m_mod(packedFloat[2], 128.0f) * 65536.0f +
                   packedFloat[1] * 256.0f + packedFloat[0] + 8388608.0f;
  float Result = Sign * m_exp2(Exponent - 23.0f) * Mantissa;
  return Result;
}

int main(int agrc, char* argv[]) {
  float test[] = {0.0,          -1.0,    +1.0,     1.1,
                  2.0,          4.0,     16777216, UINT32_MAX,
                  4494949.4235, 334.111, 44.784,   100093494.3431};
  uint32_t testCount = sizeof(test) / sizeof(test[0]);
  for (uint32_t i = 0; i < testCount; i++) {
    float f = test[i];
    float result = recode(f);
    printf("result: %f, %f, %s\n", f, result, f == result ? "GOOD" : "BAD");
  }
}
```

This PR is needed for https://github.com/CesiumGS/cesium/pull/9132 to store heights accurately when there are no floating point textures available, which is also why the unit tests aren't passing.