### PR TITLE
Fixed clockwise to counter clock-wise in ElllipseGraphics.js

### DIFF
--- a/Source/DataSources/EllipseGraphics.js
+++ b/Source/DataSources/EllipseGraphics.js
@@ -160,7 +160,7 @@ Object.defineProperties(EllipseGraphics.prototype, {
   extrudedHeightReference: createPropertyDescriptor("extrudedHeightReference"),
 
   /**
-   * Gets or sets the numeric property specifying the rotation of the ellipse clockwise from north.
+   * Gets or sets the numeric property specifying the rotation of the ellipse counter-clockwise from north.
    * @memberof EllipseGraphics.prototype
    * @type {Property|undefined}
    * @default 0


### PR DESCRIPTION
This fixes an error in the ellipse graphics documentation. In the [rotation ](https://cesium.com/docs/cesiumjs-ref-doc/EllipseGraphics.html?classFilter=ellip#rotation)member variable, it says that it's a **clockwise** rotation from north. But in the [constructor options](https://cesium.com/docs/cesiumjs-ref-doc/EllipseGraphics.html?classFilter=ellip#.ConstructorOptions) table, it says it's a **counter-clockwise** rotation from north. 