### PR TITLE
Fix embedded glb aligned to a 4-byte boundary

### DIFF
--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -378,7 +378,7 @@ function initialize(content, arrayBuffer, byteOffset) {
       "The embedded glb is not aligned to a 4-byte boundary."
     );
     gltfView = new Uint8Array(
-      uint8Array.subarray(byteOffset, byteOffset + gltfByteLength)
+      arrayBuffer.slice(byteOffset, byteOffset + gltfByteLength)
     );
   }
 


### PR DESCRIPTION
> The subarray() method returns a new TypedArray on the **same ArrayBuffe**r store and with the same element types as for this TypedArray object.

So if we want to align the embedded glb to a 4-byte boundary which is not aligned in original ArrayBuffer , we should use `ArrayBuffer.prototype.slice()`  to copy the embedded glb to a new ArrayBuffer.

I notice these code is added by you, so can you take a look at this please?@lilleyse