### PR TITLE
Sandcastle: Better default behavior for Toolbar Menu, Toolbar Button, and Toggle Button

### DIFF
--- a/Apps/Sandcastle/Sandcastle-header.js
+++ b/Apps/Sandcastle/Sandcastle-header.js
@@ -1,7 +1,7 @@
 (function () {
   "use strict";
 
-  var defaultAction;
+  var defaultActions = [];
   var bucket = window.location.href;
   var pos = bucket.lastIndexOf("/");
   if (pos > 0 && pos < bucket.length - 1) {
@@ -16,10 +16,14 @@
     finishedLoading: function () {
       window.Sandcastle.reset();
 
-      if (defaultAction) {
-        window.Sandcastle.highlight(defaultAction);
-        defaultAction();
-        defaultAction = undefined;
+      if (defaultActions.length > 0) {
+        if (defaultActions.length === 1) {
+          window.Sandcastle.highlight(defaultActions[0]);
+        }
+        for (var i = 0; i < defaultActions.length; i++) {
+          defaultActions[i]();
+        }
+        defaultActions.length = 0;
       }
 
       document.body.className = document.body.className.replace(
@@ -51,6 +55,12 @@
 
       document.getElementById(toolbarID || "toolbar").appendChild(button);
     },
+    addDefaultToggleButton: function (text, checked, onchange, toolbarID) {
+      window.Sandcastle.addToggleButton(text, checked, onchange, toolbarID);
+      defaultActions.push(function () {
+        onchange(checked);
+      });
+    },
     addToolbarButton: function (text, onclick, toolbarID) {
       window.Sandcastle.declare(onclick);
       var button = document.createElement("button");
@@ -66,11 +76,7 @@
     },
     addDefaultToolbarButton: function (text, onclick, toolbarID) {
       window.Sandcastle.addToolbarButton(text, onclick, toolbarID);
-      defaultAction = onclick;
-    },
-    addDefaultToolbarMenu: function (options, toolbarID) {
-      window.Sandcastle.addToolbarMenu(options, toolbarID);
-      defaultAction = options[0].onselect;
+      defaultActions.push(onclick);
     },
     addToolbarMenu: function (options, toolbarID) {
       var menu = document.createElement("select");
@@ -84,15 +90,17 @@
       };
       document.getElementById(toolbarID || "toolbar").appendChild(menu);
 
-      if (!defaultAction && typeof options[0].onselect === "function") {
-        defaultAction = options[0].onselect;
-      }
-
       for (var i = 0, len = options.length; i < len; ++i) {
         var option = document.createElement("option");
         option.textContent = options[i].text;
         option.value = options[i].value;
         menu.appendChild(option);
+      }
+    },
+    addDefaultToolbarMenu: function (options, toolbarID) {
+      window.Sandcastle.addToolbarMenu(options, toolbarID);
+      if (typeof options[0].onselect === "function") {
+        defaultActions.push(options[0].onselect);
       }
     },
     reset: function () {},

--- a/Apps/Sandcastle/gallery/3D Models Coloring.html
+++ b/Apps/Sandcastle/gallery/3D Models Coloring.html
@@ -313,7 +313,7 @@
           },
         ];
 
-        Sandcastle.addToolbarMenu(options);
+        Sandcastle.addDefaultToolbarMenu(options);
 
         Sandcastle.addToggleButton("Shadows", viewer.shadows, function (
           checked

--- a/Apps/Sandcastle/gallery/3D Models.html
+++ b/Apps/Sandcastle/gallery/3D Models.html
@@ -135,7 +135,7 @@
           },
         ];
 
-        Sandcastle.addToolbarMenu(options);
+        Sandcastle.addDefaultToolbarMenu(options);
         //Sandcastle_End
         Sandcastle.finishedLoading();
       }

--- a/Apps/Sandcastle/gallery/3D Tiles Batch Table Hierarchy.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Batch Table Hierarchy.html
@@ -182,7 +182,7 @@
           });
         }
 
-        Sandcastle.addToolbarMenu(styleOptions);
+        Sandcastle.addDefaultToolbarMenu(styleOptions);
 
         var handler = new Cesium.ScreenSpaceEventHandler(viewer.canvas);
 

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
@@ -233,7 +233,7 @@
           });
         }
 
-        Sandcastle.addToolbarMenu(styleOptions);
+        Sandcastle.addDefaultToolbarMenu(styleOptions);
         //Sandcastle_End
         Sandcastle.finishedLoading();
       }

--- a/Apps/Sandcastle/gallery/Billboards.html
+++ b/Apps/Sandcastle/gallery/Billboards.html
@@ -269,7 +269,7 @@
           viewer.zoomTo(viewer.entities);
         }
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "Add billboard",
             onselect: function () {

--- a/Apps/Sandcastle/gallery/CZML Custom Properties.html
+++ b/Apps/Sandcastle/gallery/CZML Custom Properties.html
@@ -149,7 +149,7 @@
         }
 
         // Custom properties can be used as the value of graphical properties:
-        Sandcastle.addToolbarMenu(
+        Sandcastle.addDefaultToolbarMenu(
           [
             {
               text: "Use interval data",

--- a/Apps/Sandcastle/gallery/Classification Types.html
+++ b/Apps/Sandcastle/gallery/Classification Types.html
@@ -166,8 +166,8 @@
           },
         ];
 
-        Sandcastle.addToolbarMenu(classificationOptions);
-        Sandcastle.addToolbarMenu(materialOptions);
+        Sandcastle.addDefaultToolbarMenu(classificationOptions);
+        Sandcastle.addDefaultToolbarMenu(materialOptions);
         //Sandcastle_End
         Sandcastle.finishedLoading();
       }

--- a/Apps/Sandcastle/gallery/Distance Display Conditions.html
+++ b/Apps/Sandcastle/gallery/Distance Display Conditions.html
@@ -99,7 +99,7 @@
           });
         }
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "Billboard and Primitive",
             onselect: function () {

--- a/Apps/Sandcastle/gallery/Drawing on Terrain.html
+++ b/Apps/Sandcastle/gallery/Drawing on Terrain.html
@@ -166,7 +166,7 @@
           },
         ];
 
-        Sandcastle.addToolbarMenu(options);
+        Sandcastle.addDefaultToolbarMenu(options);
         // Zoom in to an area with mountains
         viewer.camera.lookAt(
           Cesium.Cartesian3.fromDegrees(-122.2058, 46.1955, 1000.0),

--- a/Apps/Sandcastle/gallery/Export KML.html
+++ b/Apps/Sandcastle/gallery/Export KML.html
@@ -107,7 +107,7 @@
         var filenameToSave = "";
         var dataSourcePromise;
 
-        Sandcastle.addToolbarMenu(
+        Sandcastle.addDefaultToolbarMenu(
           [
             {
               text: "Satellites",

--- a/Apps/Sandcastle/gallery/Geometry Height Reference.html
+++ b/Apps/Sandcastle/gallery/Geometry Height Reference.html
@@ -47,7 +47,7 @@
         // instead of showing through it from underground
         viewer.scene.globe.depthTestAgainstTerrain = true;
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "Polygons",
             onselect: function () {
@@ -64,7 +64,7 @@
           },
         ]);
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "Terrain Enabled",
             onselect: function () {

--- a/Apps/Sandcastle/gallery/Globe Interior.html
+++ b/Apps/Sandcastle/gallery/Globe Interior.html
@@ -78,7 +78,7 @@
           );
         }
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "Translucency mask",
             onselect: function () {
@@ -138,10 +138,6 @@
           },
         });
 
-        innerCore.show = true;
-        outerCore.show = false;
-        mantle.show = false;
-
         var options = [
           {
             text: "Inner Core",
@@ -177,7 +173,7 @@
           },
         ];
 
-        Sandcastle.addToolbarMenu(options);
+        Sandcastle.addDefaultToolbarMenu(options);
         //Sandcastle_End
         Sandcastle.finishedLoading();
       }

--- a/Apps/Sandcastle/gallery/Globe Materials.html
+++ b/Apps/Sandcastle/gallery/Globe Materials.html
@@ -332,7 +332,7 @@
             updateMaterial();
           });
 
-        Sandcastle.addToolbarMenu(
+        Sandcastle.addDefaultToolbarMenu(
           [
             {
               text: "Himalayas",

--- a/Apps/Sandcastle/gallery/Ground Atmosphere.html
+++ b/Apps/Sandcastle/gallery/Ground Atmosphere.html
@@ -170,7 +170,7 @@
           globe.enableLighting = checked;
         });
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "Cesium World Terrain - no effects",
             onselect: function () {

--- a/Apps/Sandcastle/gallery/Interpolation.html
+++ b/Apps/Sandcastle/gallery/Interpolation.html
@@ -166,7 +166,7 @@
         });
 
         //Add a combo box for selecting each interpolation mode.
-        Sandcastle.addToolbarMenu(
+        Sandcastle.addDefaultToolbarMenu(
           [
             {
               text: "Interpolation: Linear Approximation",

--- a/Apps/Sandcastle/gallery/KML.html
+++ b/Apps/Sandcastle/gallery/KML.html
@@ -39,7 +39,7 @@
           canvas: viewer.scene.canvas,
         };
 
-        Sandcastle.addToolbarMenu(
+        Sandcastle.addDefaultToolbarMenu(
           [
             {
               text: "KML - Global Science Facilities",

--- a/Apps/Sandcastle/gallery/Labels.html
+++ b/Apps/Sandcastle/gallery/Labels.html
@@ -202,7 +202,7 @@
           );
         }
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "Add label",
             onselect: function () {

--- a/Apps/Sandcastle/gallery/Lighting.html
+++ b/Apps/Sandcastle/gallery/Lighting.html
@@ -225,7 +225,7 @@
           },
         ];
 
-        Sandcastle.addToolbarMenu(options);
+        Sandcastle.addDefaultToolbarMenu(options);
         //Sandcastle_End
         Sandcastle.finishedLoading();
       }

--- a/Apps/Sandcastle/gallery/Montreal Point Cloud.html
+++ b/Apps/Sandcastle/gallery/Montreal Point Cloud.html
@@ -101,31 +101,10 @@
           })
         );
 
-        // Fly to a nice overview of the city.
-        viewer.camera.flyTo({
-          destination: new Cesium.Cartesian3(
-            1223285.2286828577,
-            -4319476.080312792,
-            4562579.020145769
-          ),
-          orientation: {
-            direction: new Cesium.Cartesian3(
-              0.63053223097472,
-              0.47519958296727743,
-              -0.6136892226931869
-            ),
-            up: new Cesium.Cartesian3(
-              0.7699959023135587,
-              -0.4824455703743441,
-              0.41755548379407276
-            ),
-          },
-          easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
-        });
-
         // Add stored views around Montreal. You can add to this list by capturing camera.position, camera.direction and camera.up.
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
+            // Fly to a nice overview of the city.
             text: "Overview",
             onselect: function () {
               viewer.camera.flyTo({

--- a/Apps/Sandcastle/gallery/Particle System Tails.html
+++ b/Apps/Sandcastle/gallery/Particle System Tails.html
@@ -294,7 +294,7 @@
             },
           },
         ];
-        Sandcastle.addToolbarMenu(options);
+        Sandcastle.addDefaultToolbarMenu(options);
         //Sandcastle_End
         Sandcastle.finishedLoading();
       }

--- a/Apps/Sandcastle/gallery/Particle System Weather.html
+++ b/Apps/Sandcastle/gallery/Particle System Weather.html
@@ -210,7 +210,7 @@
             },
           },
         ];
-        Sandcastle.addToolbarMenu(options);
+        Sandcastle.addDefaultToolbarMenu(options);
         //Sandcastle_End
         Sandcastle.finishedLoading();
       }

--- a/Apps/Sandcastle/gallery/Particle System.html
+++ b/Apps/Sandcastle/gallery/Particle System.html
@@ -458,7 +458,7 @@
           },
         ];
 
-        Sandcastle.addToolbarMenu(options);
+        Sandcastle.addDefaultToolbarMenu(options);
         //Sandcastle_End
         Sandcastle.finishedLoading();
       }

--- a/Apps/Sandcastle/gallery/Per-Feature Post Processing.html
+++ b/Apps/Sandcastle/gallery/Per-Feature Post Processing.html
@@ -85,7 +85,7 @@
           stage.selected = [];
         }
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "Mouse-over Black and White",
             onselect: function () {

--- a/Apps/Sandcastle/gallery/Physically-Based Materials.html
+++ b/Apps/Sandcastle/gallery/Physically-Based Materials.html
@@ -150,7 +150,7 @@
           duration: 5.0,
           pitchAdjustHeight: 20,
         });
-        Sandcastle.addToolbarMenu(
+        Sandcastle.addDefaultToolbarMenu(
           [
             {
               text: "Front reflection",

--- a/Apps/Sandcastle/gallery/Points.html
+++ b/Apps/Sandcastle/gallery/Points.html
@@ -137,7 +137,7 @@
           });
         }
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "Add point",
             onselect: function () {

--- a/Apps/Sandcastle/gallery/Polylines on 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/Polylines on 3D Tiles.html
@@ -95,7 +95,7 @@
           },
         });
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "BIM",
             onselect: function () {

--- a/Apps/Sandcastle/gallery/Scene Rendering Performance.html
+++ b/Apps/Sandcastle/gallery/Scene Rendering Performance.html
@@ -352,7 +352,7 @@
           },
         ];
 
-        Sandcastle.addToolbarMenu(scenarios);
+        Sandcastle.addDefaultToolbarMenu(scenarios);
 
         //Sandcastle_End
         Sandcastle.finishedLoading();

--- a/Apps/Sandcastle/gallery/Shadows.html
+++ b/Apps/Sandcastle/gallery/Shadows.html
@@ -207,7 +207,7 @@
           }
         }
 
-        Sandcastle.addToolbarMenu(locationToolbarOptions);
+        Sandcastle.addDefaultToolbarMenu(locationToolbarOptions);
 
         function setEntity(entity) {
           for (i = 0; i < entitiesLength; ++i) {
@@ -232,7 +232,7 @@
           });
         }
 
-        Sandcastle.addToolbarMenu(entityToolbarOptions);
+        Sandcastle.addDefaultToolbarMenu(entityToolbarOptions);
 
         Sandcastle.addToggleButton("Shadows", viewer.shadows, function (
           checked
@@ -269,7 +269,7 @@
           }
         );
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "Size : 2048",
             onselect: function () {

--- a/Apps/Sandcastle/gallery/Terrain.html
+++ b/Apps/Sandcastle/gallery/Terrain.html
@@ -48,9 +48,6 @@
           terrainProvider: worldTerrain,
         });
 
-        // set lighting to true
-        viewer.scene.globe.enableLighting = true;
-
         // setup alternative terrain providers
         var ellipsoidProvider = new Cesium.EllipsoidTerrainProvider();
 
@@ -59,7 +56,7 @@
           credit: "Terrain data courtesy VT MÄK",
         });
 
-        Sandcastle.addToolbarMenu(
+        Sandcastle.addDefaultToolbarMenu(
           [
             {
               text: "CesiumTerrainProvider - Cesium World Terrain",

--- a/Apps/Sandcastle/gallery/development/3D Models Instancing.html
+++ b/Apps/Sandcastle/gallery/development/3D Models Instancing.html
@@ -190,7 +190,7 @@
           }
         }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "1024 instances",
             onselect: function () {
@@ -228,7 +228,7 @@
           },
         ]);
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "Aircraft",
             onselect: function () {
@@ -264,7 +264,7 @@
           },
         ]);
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "Instancing Enabled",
             onselect: function () {

--- a/Apps/Sandcastle/gallery/development/3D Models Node Explorer.html
+++ b/Apps/Sandcastle/gallery/development/3D Models Node Explorer.html
@@ -343,8 +343,7 @@
                 },
               };
             });
-            options[0].onselect();
-            Sandcastle.addToolbarMenu(options);
+            Sandcastle.addDefaultToolbarMenu(options);
 
             // respond to viewmodel changes by applying the computed matrix
             Cesium.knockout

--- a/Apps/Sandcastle/gallery/development/3D Models.html
+++ b/Apps/Sandcastle/gallery/development/3D Models.html
@@ -302,7 +302,7 @@
           },
         ];
 
-        Sandcastle.addToolbarMenu(options);
+        Sandcastle.addDefaultToolbarMenu(options);
 
         Sandcastle.addToggleButton("Shadows", viewer.shadows, function (
           checked

--- a/Apps/Sandcastle/gallery/development/BillboardClampToGround.html
+++ b/Apps/Sandcastle/gallery/development/BillboardClampToGround.html
@@ -108,7 +108,7 @@
           }
         });
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "Relative to ground",
             onselect: function () {

--- a/Apps/Sandcastle/gallery/development/Billboards Instancing.html
+++ b/Apps/Sandcastle/gallery/development/Billboards Instancing.html
@@ -116,7 +116,7 @@
           }
         }
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "Instancing Enabled",
             onselect: function () {
@@ -139,7 +139,7 @@
           },
         ]);
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "100489 billboards",
             onselect: function () {
@@ -184,7 +184,7 @@
           },
         ]);
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "Static billboards",
             onselect: function () {
@@ -201,7 +201,7 @@
           },
         ]);
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "Scale : 1.0",
             onselect: function () {

--- a/Apps/Sandcastle/gallery/development/Billboards.html
+++ b/Apps/Sandcastle/gallery/development/Billboards.html
@@ -341,7 +341,7 @@
           });
         }
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "Add billboard",
             onselect: function () {

--- a/Apps/Sandcastle/gallery/development/Display Conditions.html
+++ b/Apps/Sandcastle/gallery/development/Display Conditions.html
@@ -106,7 +106,7 @@
           );
         }
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "Billboard and Primitive",
             onselect: function () {

--- a/Apps/Sandcastle/gallery/development/Labels.html
+++ b/Apps/Sandcastle/gallery/development/Labels.html
@@ -171,7 +171,7 @@
           });
         }
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "Add label",
             onselect: function () {

--- a/Apps/Sandcastle/gallery/development/Picking.html
+++ b/Apps/Sandcastle/gallery/development/Picking.html
@@ -50,7 +50,7 @@
           originalColor: new Cesium.Color(),
         };
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "Billboard",
             onselect: function () {

--- a/Apps/Sandcastle/gallery/development/PointPrimitives.html
+++ b/Apps/Sandcastle/gallery/development/PointPrimitives.html
@@ -207,7 +207,7 @@
           }
         }
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "Add point",
             onselect: function () {

--- a/Apps/Sandcastle/gallery/development/Polylines On Terrain.html
+++ b/Apps/Sandcastle/gallery/development/Polylines On Terrain.html
@@ -318,7 +318,7 @@
 
         lookAt();
 
-        Sandcastle.addToolbarMenu([
+        Sandcastle.addDefaultToolbarMenu([
           {
             text: "Per Instance Color",
             onselect: function () {


### PR DESCRIPTION
Sandcastle has this concept of a `defaultAction` which is when the function passed to `addDefaultToolbarMenu` or `addDefaultToolbarButton` is called automatically at the start of the script. This makes it so the behavior doesn't have to be implemented twice: once as initial setup and once as part of the selection / button click.

But there are some inconsistencies:
* It only allows one `addDefaultToolbarMenu` or `addDefaultToolbarButton` per demo.
* It doesn't have `addDefaultToggleButton`, meaning the default `checked` action has to be triggered some other way.
* `addToolbarMenu` breaks the rules and does the same thing as `addDefaultToolbarMenu`.

This PR adds `addDefaultToggleButton` and makes it so there can be multiple `defaultActions` that get triggered at the start. When there is only one default action, it calls `window.Sandcastle.highlight`, though this doesn't seem to do anything, now or before ([try it here](https://sandcastle.cesium.com/#c=fZDNTsMwEIRfZeVTKkVOc4UQIcER1EO5YQ6uvSkWm3UU2xUF9d2Jmx7KTzmtdme+8chdYhOdZ1gNeSyLBXwqBjCegyeU5LeFErMISyUW1wCKD4oVd9/R+l+0zugJXGu2Roc4ebS199jpRPHJe9ro8RE5Fc855pgFEPE9XsF5hXIWpleQ0EziqXo+H8rLaH0RrY+o4pdcUZSiCXFP2M5mgFvXD36MkEYqpKwi9gPpiKHaJPOGUZoQMpitTXWONtbtwNkbJQwGl/o7z1E7xlEJMKRDmJQuEa3dByrRNtXk/4WS19bxdrXDkfQ+217r9mE+Simbalr/JuP8pT+SvwA))

[This sandcastle (localhost)](http://localhost:8080/Apps/Sandcastle/index.html#c=vVPBUsIwFPyVNz3hiA25amUc8ajDAW/GQ0gfJWNImCZhQId/N6FWbKXoOGoPSZu3b3ffdkIIjOYonqZmzfSE61xw6xSmPM9vcMa9cvemKBRee+eM7rGkRsOAJX2YcWUxbF4LJ0NdxCrmJ/DCNIAw2ppApkzR6DwHlsAp1OALprdxaRvoUqY/VqadyoRAJdSZglFTXr6bqV7eQqg9HBTfI48MepCcfpucNsjDLHeo/fFJIqL3EBl3tAAO1y7GM15Gud1kVSEIokIRim0v8Wn6iawwgDPYs0RPEbiN27bfrUh/RZG2FZl+PJL5H8ZA/z0G+lUMST/JrNsoHNYsV3KxNKUDX6pemhKHi6XiDi2Z+nBDXCqsrXky8rE1y+UKZH7JEoFW+sXIaMelxjJcMKG4taEy80pN5DOyZJiRgP/UqgzPpS7GKywV30TYnA5vq8M0TTMSPg93uur3tZhfAQ) demonstrates the new behavior for Toolbar Menu, Toolbar Button, and Toggle Button.

Since many of the Sandcastles call `addToolbarMenu` expecting the first entry to be called automatically, they now call `addDefaultToolbarMenu`.

An alternative is to call the Toolbar Menu and Toggle Button function automatically, and only make Toolbar Button have two options. This would reduce to `addToolbarMenu`, `addToggleButton`, `addToolbarButton`, `addDefaultToolbarButton`. I can see it going either way. It depends how flexible things need to be.