### PR TITLE
Show/hide collections

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 1.78 - 2021-02-01
+
+##### Additions :tada:
+
+- Added `BillboardCollection.show`, `LabelCollection.show`, `PointPrimitiveCollection.show`, and `PolylineCollection.show` for a convenient way to control show of the entire collection
+
 ### 1.77 - 2021-01-04
 
 ##### Additions :tada:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ##### Additions :tada:
 
-- Added `BillboardCollection.show`, `LabelCollection.show`, `PointPrimitiveCollection.show`, and `PolylineCollection.show` for a convenient way to control show of the entire collection
+- Added `BillboardCollection.show`, `EntityCluster.show`, `LabelCollection.show`, `PointPrimitiveCollection.show`, and `PolylineCollection.show` for a convenient way to control show of the entire collection [#9307](https://github.com/CesiumGS/cesium/pull/9307)
 
 ### 1.77 - 2021-01-04
 

--- a/Source/DataSources/EntityCluster.js
+++ b/Source/DataSources/EntityCluster.js
@@ -25,6 +25,7 @@ import kdbush from "../ThirdParty/kdbush.js";
  * @param {Boolean} [options.clusterBillboards=true] Whether or not to cluster the billboards of an entity.
  * @param {Boolean} [options.clusterLabels=true] Whether or not to cluster the labels of an entity.
  * @param {Boolean} [options.clusterPoints=true] Whether or not to cluster the points of an entity.
+ * @param {Boolean} [options.show=true] Determines if the entities in the cluster will be shown.
  *
  * @alias EntityCluster
  * @constructor
@@ -65,6 +66,14 @@ function EntityCluster(options) {
   this._removeEventListener = undefined;
 
   this._clusterEvent = new Event();
+
+  /**
+   * Determines if billboards in this collection will be shown.
+   *
+   * @type {Boolean}
+   * @default true
+   */
+  this.show = defaultValue(options.show, true);
 }
 
 function getX(point) {
@@ -844,6 +853,10 @@ function updateEnable(entityCluster) {
  * @private
  */
 EntityCluster.prototype.update = function (frameState) {
+  if (!this.show) {
+    return;
+  }
+
   // If clustering is enabled before the label collection is updated,
   // the glyphs haven't been created so the screen space bounding boxes
   // are incorrect.

--- a/Source/DataSources/EntityCluster.js
+++ b/Source/DataSources/EntityCluster.js
@@ -68,7 +68,7 @@ function EntityCluster(options) {
   this._clusterEvent = new Event();
 
   /**
-   * Determines if billboards in this collection will be shown.
+   * Determines if entities in this collection will be shown.
    *
    * @type {Boolean}
    * @default true

--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -111,6 +111,7 @@ var attributeLocationsInstanced = {
  * @param {BlendOption} [options.blendOption=BlendOption.OPAQUE_AND_TRANSLUCENT] The billboard blending option. The default
  * is used for rendering both opaque and translucent billboards. However, if either all of the billboards are completely opaque or all are completely translucent,
  * setting the technique to BlendOption.OPAQUE or BlendOption.TRANSLUCENT can improve performance by up to 2x.
+ * @param {Boolean} [options.show=true] Determines if the billboards in the collection will be shown.
  *
  * @performance For best performance, prefer a few collections, each with many billboards, to
  * many collections with only a few billboards each.  Organize collections so that billboards
@@ -199,6 +200,14 @@ function BillboardCollection(options) {
   this._boundingVolumeDirty = false;
 
   this._colorCommands = [];
+
+  /**
+   * Determines if billboards in this collection will be shown.
+   *
+   * @type {Boolean}
+   * @default true
+   */
+  this.show = defaultValue(options.show, true);
 
   /**
    * The 4x4 transformation matrix that transforms each billboard in this collection from model to world coordinates.
@@ -1809,6 +1818,11 @@ var scratchWriterArray = [];
  */
 BillboardCollection.prototype.update = function (frameState) {
   removeBillboards(this);
+
+  if (!this.show) {
+    return;
+  }
+
   var billboards = this._billboards;
   var billboardsLength = billboards.length;
 

--- a/Source/Scene/LabelCollection.js
+++ b/Source/Scene/LabelCollection.js
@@ -576,6 +576,7 @@ function destroyLabel(labelCollection, label) {
  * @param {BlendOption} [options.blendOption=BlendOption.OPAQUE_AND_TRANSLUCENT] The label blending option. The default
  * is used for rendering both opaque and translucent labels. However, if either all of the labels are completely opaque or all are completely translucent,
  * setting the technique to BlendOption.OPAQUE or BlendOption.TRANSLUCENT can improve performance by up to 2x.
+ * @param {Boolean} [options.show=true] Determines if the labels in the collection will be shown.
  *
  * @performance For best performance, prefer a few collections, each with many labels, to
  * many collections with only a few labels each.  Avoid having collections where some
@@ -630,6 +631,14 @@ function LabelCollection(options) {
   this._totalGlyphCount = 0;
 
   this._highlightColor = Color.clone(Color.WHITE); // Only used by Vector3DTilePoints
+
+  /**
+   * Determines if labels in this collection will be shown.
+   *
+   * @type {Boolean}
+   * @default true
+   */
+  this.show = defaultValue(options.show, true);
 
   /**
    * The 4x4 transformation matrix that transforms each label in this collection from model to world coordinates.
@@ -887,6 +896,10 @@ LabelCollection.prototype.get = function (index) {
  *
  */
 LabelCollection.prototype.update = function (frameState) {
+  if (!this.show) {
+    return;
+  }
+
   var billboardCollection = this._billboardCollection;
   var backgroundBillboardCollection = this._backgroundBillboardCollection;
 

--- a/Source/Scene/PointPrimitiveCollection.js
+++ b/Source/Scene/PointPrimitiveCollection.js
@@ -63,6 +63,7 @@ var attributeLocations = {
  * @param {BlendOption} [options.blendOption=BlendOption.OPAQUE_AND_TRANSLUCENT] The point blending option. The default
  * is used for rendering both opaque and translucent points. However, if either all of the points are completely opaque or all are completely translucent,
  * setting the technique to BlendOption.OPAQUE or BlendOption.TRANSLUCENT can improve performance by up to 2x.
+ * @param {Boolean} [options.show=true] Determines if the primitives in the collection will be shown.
  *
  * @performance For best performance, prefer a few collections, each with many points, to
  * many collections with only a few points each.  Organize collections so that points
@@ -125,6 +126,14 @@ function PointPrimitiveCollection(options) {
   this._boundingVolumeDirty = false;
 
   this._colorCommands = [];
+
+  /**
+   * Determines if primitives in this collection will be shown.
+   *
+   * @type {Boolean}
+   * @default true
+   */
+  this.show = defaultValue(options.show, true);
 
   /**
    * The 4x4 transformation matrix that transforms each point in this collection from model to world coordinates.
@@ -838,6 +847,10 @@ var scratchWriterArray = [];
  */
 PointPrimitiveCollection.prototype.update = function (frameState) {
   removePointPrimitives(this);
+
+  if (!this.show) {
+    return;
+  }
 
   this._maxTotalPointSize = ContextLimits.maximumAliasedPointSize;
 

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -80,6 +80,7 @@ var attributeLocations = {
  * @param {Object} [options] Object with the following properties:
  * @param {Matrix4} [options.modelMatrix=Matrix4.IDENTITY] The 4x4 transformation matrix that transforms each polyline from model to world coordinates.
  * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Determines if this primitive's commands' bounding spheres are shown.
+ * @param {Boolean} [options.show=true] Determines if the polylines in the collection will be shown.
  *
  * @performance For best performance, prefer a few collections, each with many polylines, to
  * many collections with only a few polylines each.  Organize collections so that polylines
@@ -115,6 +116,14 @@ var attributeLocations = {
  */
 function PolylineCollection(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+
+  /**
+   * Determines if polylines in this collection will be shown.
+   *
+   * @type {Boolean}
+   * @default true
+   */
+  this.show = defaultValue(options.show, true);
 
   /**
    * The 4x4 transformation matrix that transforms each polyline in this collection from model to world coordinates.
@@ -414,7 +423,7 @@ var scratchNearFarCartesian2 = new Cartesian2();
 PolylineCollection.prototype.update = function (frameState) {
   removePolylines(this);
 
-  if (this._polylines.length === 0) {
+  if (this._polylines.length === 0 || !this.show) {
     return;
   }
 

--- a/Specs/DataSources/EntityClusterSpec.js
+++ b/Specs/DataSources/EntityClusterSpec.js
@@ -88,6 +88,7 @@ describe(
     it("constructor sets default properties", function () {
       cluster = new EntityCluster();
       expect(cluster.enabled).toEqual(false);
+      expect(cluster.show).toEqual(true);
       expect(cluster.pixelRange).toEqual(80);
       expect(cluster.minimumClusterSize).toEqual(2);
       expect(cluster.clusterBillboards).toEqual(true);
@@ -107,6 +108,7 @@ describe(
     it("constructor sets expected properties", function () {
       var options = {
         enabled: true,
+        show: false,
         pixelRange: 30,
         minimumClusterSize: 5,
         clusterBillboards: false,
@@ -115,6 +117,7 @@ describe(
       };
       cluster = new EntityCluster(options);
       expect(cluster.enabled).toEqual(options.enabled);
+      expect(cluster.show).toEqual(false);
       expect(cluster.pixelRange).toEqual(options.pixelRange);
       expect(cluster.minimumClusterSize).toEqual(options.minimumClusterSize);
       expect(cluster.clusterBillboards).toEqual(options.clusterBillboards);

--- a/Specs/Scene/BillboardCollectionSpec.js
+++ b/Specs/Scene/BillboardCollectionSpec.js
@@ -352,6 +352,22 @@ describe(
       expect(scene).toRender([0, 0, 0, 255]);
     });
 
+    it("does not render billboard if show is false", function () {
+      billboards.add({
+        position: Cartesian3.ZERO,
+        image: greenImage,
+        width: 2.0,
+        height: 2.0,
+        sizeInMeters: true,
+      });
+
+      camera.position = new Cartesian3(2.0, 0.0, 0.0);
+      expect(scene).toRender([0, 255, 0, 255]);
+
+      billboards.show = false;
+      expect(scene).toRender([0, 0, 0, 255]);
+    });
+
     it("throws scaleByDistance with nearDistance === farDistance", function () {
       var b = billboards.add();
       var scale = new NearFarScalar(2.0e5, 1.0, 2.0e5, 0.0);

--- a/Specs/Scene/LabelCollectionSpec.js
+++ b/Specs/Scene/LabelCollectionSpec.js
@@ -650,6 +650,23 @@ describe(
       expect(scene).toRender([0, 0, 0, 255]);
     });
 
+    it("does not renders label if show is false", function () {
+      labels.add({
+        position: Cartesian3.ZERO,
+        text: solidBox,
+        horizontalOrigin: HorizontalOrigin.CENTER,
+        verticalOrigin: VerticalOrigin.CENTER,
+        scaleByDistance: new NearFarScalar(2.0, 1.0, 4.0, 0.0),
+      });
+
+      camera.position = new Cartesian3(2.0, 0.0, 0.0);
+      expect(scene).toRender([255, 255, 255, 255]);
+
+      labels.show = false;
+
+      expect(scene).toRender([0, 0, 0, 255]);
+    });
+
     it("throws new label with invalid distanceDisplayCondition (near >= far)", function () {
       var dc = new DistanceDisplayCondition(100.0, 10.0);
       expect(function () {

--- a/Specs/Scene/LabelCollectionSpec.js
+++ b/Specs/Scene/LabelCollectionSpec.js
@@ -650,7 +650,7 @@ describe(
       expect(scene).toRender([0, 0, 0, 255]);
     });
 
-    it("does not renders label if show is false", function () {
+    it("does not render label if show is false", function () {
       labels.add({
         position: Cartesian3.ZERO,
         text: solidBox,
@@ -663,7 +663,6 @@ describe(
       expect(scene).toRender([255, 255, 255, 255]);
 
       labels.show = false;
-
       expect(scene).toRender([0, 0, 0, 255]);
     });
 

--- a/Specs/Scene/PointPrimitiveCollectionSpec.js
+++ b/Specs/Scene/PointPrimitiveCollectionSpec.js
@@ -228,7 +228,7 @@ describe(
       expect(scene).toRender([0, 0, 0, 255]);
     });
 
-    it("does not renders pointPrimitive if show is false", function () {
+    it("does not render pointPrimitive if show is false", function () {
       pointPrimitives.add({
         position: Cartesian3.ZERO,
         translucencyByDistance: new NearFarScalar(2.0, 1.0, 4.0, 0.0),

--- a/Specs/Scene/PointPrimitiveCollectionSpec.js
+++ b/Specs/Scene/PointPrimitiveCollectionSpec.js
@@ -228,6 +228,20 @@ describe(
       expect(scene).toRender([0, 0, 0, 255]);
     });
 
+    it("does not renders pointPrimitive if show is false", function () {
+      pointPrimitives.add({
+        position: Cartesian3.ZERO,
+        translucencyByDistance: new NearFarScalar(2.0, 1.0, 4.0, 0.0),
+        color: Color.LIME,
+      });
+
+      camera.position = new Cartesian3(2.0, 0.0, 0.0);
+      expect(scene).toRender([0, 255, 0, 255]);
+
+      pointPrimitives.show = false;
+      expect(scene).toRender([0, 0, 0, 255]);
+    });
+
     it("throws scaleByDistance with nearDistance === farDistance", function () {
       var p = pointPrimitives.add();
       var scale = new NearFarScalar(2.0e5, 1.0, 2.0e5, 0.0);

--- a/Specs/Scene/PolylineCollectionSpec.js
+++ b/Specs/Scene/PolylineCollectionSpec.js
@@ -511,6 +511,21 @@ describe(
       expect(scene).notToRender([0, 0, 0, 255]);
     });
 
+    it("does not render polyline if show is false", function () {
+      var p = polylines.add();
+      p.positions = [
+        new Cartesian3(0.0, -1000000.0, 0.0),
+        new Cartesian3(0.0, 1000000.0, 0.0),
+        new Cartesian3(0.0, 2000000.0, 0.0),
+      ];
+
+      scene.primitives.add(polylines);
+      expect(scene).notToRender([0, 0, 0, 255]);
+
+      polylines.show = false;
+      expect(scene).toRender([0, 0, 0, 255]);
+    });
+
     it("A polyline that used to cross the IDL but now does not, triggers vertex creation (This code used to crash)", function () {
       //Need to be in 2D or CV
       scene.mode = SceneMode.SCENE2D;


### PR DESCRIPTION
Adds `show` property to `BillboardCollection`, `EntityCluster`, `LabelCollection`, `PointPrimitiveCollection`, and `PolylineCollection` for a convenient way to control show of the entire collection