### PR TITLE
Added Math.previousPowerOfTwo

### DIFF
--- a/Source/Core/Math.js
+++ b/Source/Core/Math.js
@@ -785,7 +785,7 @@ CesiumMath.incrementWrap = function (n, maximumValue, minimumValue) {
 };
 
 /**
- * Determines if a positive integer is a power of two.
+ * Determines if a non-negative integer is a power of two.
  * The maximum allowed input is (2^32)-1 due to 32-bit bitwise operator limitation in Javascript.
  *
  * @param {Number} n The integer to test in the range [0, (2^32)-1].
@@ -808,7 +808,7 @@ CesiumMath.isPowerOfTwo = function (n) {
 };
 
 /**
- * Computes the next power-of-two integer greater than or equal to the provided positive integer.
+ * Computes the next power-of-two integer greater than or equal to the provided non-negative integer.
  * The maximum allowed input is 2^31 due to 32-bit bitwise operator limitation in Javascript.
  *
  * @param {Number} n The integer to test in the range [0, 2^31].
@@ -840,7 +840,7 @@ CesiumMath.nextPowerOfTwo = function (n) {
 };
 
 /**
- * Computes the previous power-of-two integer less than or equal to the provided positive integer.
+ * Computes the previous power-of-two integer less than or equal to the provided non-negative integer.
  * The maximum allowed input is (2^32)-1 due to 32-bit bitwise operator limitation in Javascript.
  *
  * @param {Number} n The integer to test in the range [0, (2^32)-1].

--- a/Source/Core/Math.js
+++ b/Source/Core/Math.js
@@ -786,11 +786,12 @@ CesiumMath.incrementWrap = function (n, maximumValue, minimumValue) {
 
 /**
  * Determines if a positive integer is a power of two.
+ * The maximum allowed input is (2^32)-1 due to 32-bit bitwise operator limitation in Javascript.
  *
- * @param {Number} n The positive integer to test.
+ * @param {Number} n The integer to test in the range [0, (2^32)-1].
  * @returns {Boolean} <code>true</code> if the number if a power of two; otherwise, <code>false</code>.
  *
- * @exception {DeveloperError} A number greater than or equal to 0 is required.
+ * @exception {DeveloperError} A number between 0 and (2^32)-1 is required.
  *
  * @example
  * var t = Cesium.Math.isPowerOfTwo(16); // true
@@ -798,10 +799,8 @@ CesiumMath.incrementWrap = function (n, maximumValue, minimumValue) {
  */
 CesiumMath.isPowerOfTwo = function (n) {
   //>>includeStart('debug', pragmas.debug);
-  if (typeof n !== "number" || n < 0) {
-    throw new DeveloperError(
-      "A number greater than or equal to 0 is required."
-    );
+  if (typeof n !== "number" || n < 0 || n > 4294967295) {
+    throw new DeveloperError("A number between 0 and (2^32)-1 is required.");
   }
   //>>includeEnd('debug');
 
@@ -810,11 +809,12 @@ CesiumMath.isPowerOfTwo = function (n) {
 
 /**
  * Computes the next power-of-two integer greater than or equal to the provided positive integer.
+ * The maximum allowed input is 2^31 due to 32-bit bitwise operator limitation in Javascript.
  *
- * @param {Number} n The positive integer to test.
+ * @param {Number} n The integer to test in the range [0, 2^31].
  * @returns {Number} The next power-of-two integer.
  *
- * @exception {DeveloperError} A number greater than or equal to 0 is required.
+ * @exception {DeveloperError} A number between 0 and 2^31 is required.
  *
  * @example
  * var n = Cesium.Math.nextPowerOfTwo(29); // 32
@@ -822,10 +822,8 @@ CesiumMath.isPowerOfTwo = function (n) {
  */
 CesiumMath.nextPowerOfTwo = function (n) {
   //>>includeStart('debug', pragmas.debug);
-  if (typeof n !== "number" || n < 0) {
-    throw new DeveloperError(
-      "A number greater than or equal to 0 is required."
-    );
+  if (typeof n !== "number" || n < 0 || n > 2147483648) {
+    throw new DeveloperError("A number between 0 and 2^31 is required.");
   }
   //>>includeEnd('debug');
 
@@ -837,6 +835,39 @@ CesiumMath.nextPowerOfTwo = function (n) {
   n |= n >> 8;
   n |= n >> 16;
   ++n;
+
+  return n;
+};
+
+/**
+ * Computes the previous power-of-two integer less than or equal to the provided positive integer.
+ * The maximum allowed input is (2^32)-1 due to 32-bit bitwise operator limitation in Javascript.
+ *
+ * @param {Number} n The integer to test in the range [0, (2^32)-1].
+ * @returns {Number} The previous power-of-two integer.
+ *
+ * @exception {DeveloperError} A number between 0 and (2^32)-1 is required.
+ *
+ * @example
+ * var n = Cesium.Math.previousPowerOfTwo(29); // 16
+ * var m = Cesium.Math.previousPowerOfTwo(32); // 32
+ */
+CesiumMath.previousPowerOfTwo = function (n) {
+  //>>includeStart('debug', pragmas.debug);
+  if (typeof n !== "number" || n < 0 || n > 4294967295) {
+    throw new DeveloperError("A number between 0 and (2^32)-1 is required.");
+  }
+  //>>includeEnd('debug');
+
+  n |= n >> 1;
+  n |= n >> 2;
+  n |= n >> 4;
+  n |= n >> 8;
+  n |= n >> 16;
+  n |= n >> 32;
+
+  // The previous bitwise operations implicitly convert to signed 32-bit. Use `>>>` to convert to unsigned
+  n = (n >>> 0) - (n >>> 1);
 
   return n;
 };

--- a/Specs/Core/MathSpec.js
+++ b/Specs/Core/MathSpec.js
@@ -514,14 +514,11 @@ describe("Core/Math", function () {
   });
 
   it("isPowerOfTwo finds powers of two", function () {
-    expect(CesiumMath.isPowerOfTwo(1)).toEqual(true);
-    expect(CesiumMath.isPowerOfTwo(2)).toEqual(true);
-    expect(CesiumMath.isPowerOfTwo(4)).toEqual(true);
-    expect(CesiumMath.isPowerOfTwo(8)).toEqual(true);
-    expect(CesiumMath.isPowerOfTwo(16)).toEqual(true);
-    expect(CesiumMath.isPowerOfTwo(256)).toEqual(true);
-    expect(CesiumMath.isPowerOfTwo(1024)).toEqual(true);
-    expect(CesiumMath.isPowerOfTwo(16 * 1024)).toEqual(true);
+    // Test all power of twos from 1 to 2^31
+    for (var i = 0; i < 32; i++) {
+      var powerOfTwo = (1 << i) >>> 0; // `>>>` converts to unsigned
+      expect(CesiumMath.isPowerOfTwo(powerOfTwo)).toEqual(true);
+    }
   });
 
   it("isPowerOfTwo does not find powers of two", function () {
@@ -529,13 +526,33 @@ describe("Core/Math", function () {
     expect(CesiumMath.isPowerOfTwo(3)).toEqual(false);
     expect(CesiumMath.isPowerOfTwo(5)).toEqual(false);
     expect(CesiumMath.isPowerOfTwo(12)).toEqual(false);
+    expect(CesiumMath.isPowerOfTwo(4294967295)).toEqual(false); // (2^32)-1
   });
 
   it("nextPowerOfTwo finds next power of two", function () {
     expect(CesiumMath.nextPowerOfTwo(0)).toEqual(0);
+    expect(CesiumMath.nextPowerOfTwo(1)).toEqual(1);
+    expect(CesiumMath.nextPowerOfTwo(2)).toEqual(2);
+    expect(CesiumMath.nextPowerOfTwo(3)).toEqual(4);
     expect(CesiumMath.nextPowerOfTwo(257)).toEqual(512);
     expect(CesiumMath.nextPowerOfTwo(512)).toEqual(512);
     expect(CesiumMath.nextPowerOfTwo(1023)).toEqual(1024);
+    expect(CesiumMath.nextPowerOfTwo(1073741825)).toEqual(2147483648); // (2^30)+1 -> 2^31
+    expect(CesiumMath.nextPowerOfTwo(2147483647)).toEqual(2147483648); // (2^31)-1 -> 2^31
+    expect(CesiumMath.nextPowerOfTwo(2147483648)).toEqual(2147483648); // 2^31 -> 2^31
+  });
+
+  it("previousPowerOfTwo finds previous power of two", function () {
+    expect(CesiumMath.previousPowerOfTwo(0)).toEqual(0);
+    expect(CesiumMath.previousPowerOfTwo(1)).toEqual(1);
+    expect(CesiumMath.previousPowerOfTwo(2)).toEqual(2);
+    expect(CesiumMath.previousPowerOfTwo(3)).toEqual(2);
+    expect(CesiumMath.previousPowerOfTwo(257)).toEqual(256);
+    expect(CesiumMath.previousPowerOfTwo(512)).toEqual(512);
+    expect(CesiumMath.previousPowerOfTwo(1023)).toEqual(512);
+    expect(CesiumMath.previousPowerOfTwo(2147483648)).toEqual(2147483648); // 2^31 -> 2^31
+    expect(CesiumMath.previousPowerOfTwo(2147483649)).toEqual(2147483648); // (2^31)+1 -> 2^31
+    expect(CesiumMath.previousPowerOfTwo(4294967295)).toEqual(2147483648); // (2^32)-1 -> 2^31
   });
 
   it("factorial throws for non-numbers", function () {
@@ -577,6 +594,12 @@ describe("Core/Math", function () {
     }).toThrowDeveloperError();
   });
 
+  it("isPowerOfTwo throws for numbers that exceed maximum 32-bit unsigned int", function () {
+    expect(function () {
+      return CesiumMath.isPowerOfTwo(4294967296); // 2^32
+    }).toThrowDeveloperError();
+  });
+
   it("isPowerOfTwo throws for undefined", function () {
     expect(function () {
       CesiumMath.isPowerOfTwo();
@@ -595,9 +618,39 @@ describe("Core/Math", function () {
     }).toThrowDeveloperError();
   });
 
+  it("nextPowerOfTwo throws for results that would exceed maximum 32-bit unsigned int", function () {
+    expect(function () {
+      return CesiumMath.nextPowerOfTwo(2147483649); // (2^31)+1
+    }).toThrowDeveloperError();
+  });
+
   it("nextPowerOfTwo throws for undefined", function () {
     expect(function () {
       CesiumMath.nextPowerOfTwo();
+    }).toThrowDeveloperError();
+  });
+
+  it("previousPowerOfTwo throws for non-numbers", function () {
+    expect(function () {
+      CesiumMath.previousPowerOfTwo({});
+    }).toThrowDeveloperError();
+  });
+
+  it("previousPowerOfTwo throws for negative numbers", function () {
+    expect(function () {
+      CesiumMath.previousPowerOfTwo(-1);
+    }).toThrowDeveloperError();
+  });
+
+  it("previousPowerOfTwo throws for results that would exceed maximum 32-bit unsigned int", function () {
+    expect(function () {
+      return CesiumMath.previousPowerOfTwo(4294967296); // 2^32
+    }).toThrowDeveloperError();
+  });
+
+  it("previousPowerOfTwo throws for undefined", function () {
+    expect(function () {
+      CesiumMath.previousPowerOfTwo();
     }).toThrowDeveloperError();
   });
 


### PR DESCRIPTION
This PR adds `Math.previousPowerOfTwo` (`Math.nextPowerOfTwo` already exists)

Also improved the docs and specs to handle out of range inputs since Javascript bitwise operations convert operands to signed 32-bit int