### PR TITLE
Fix for ImageryProvider with rectangle bounds

### DIFF
--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -724,6 +724,9 @@ ImageryLayer.prototype._createTileImagerySkeletons = function (
     imageryBounds,
     clippedRectangleScratch
   );
+  if (!defined(clippedImageryRectangle)) {
+    return false;
+  }
 
   var imageryTileXYToRectangle;
   if (useWebMercatorT) {


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/9312

The intersection between the `imageryRectangle` and `imageryBounds` could be undefined if the terrain tile is outside the bounds of the provider rectangle.

See https://github.com/CesiumGS/cesium/issues/9312 for a reproducible sandcastle example