### PR TITLE
KmlDataSource: fix #9325 TypeError on tags lacking attribute

### DIFF
--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -434,8 +434,10 @@ function applyBasePath(div, elementType, attributeName, sourceResource) {
   for (var i = 0; i < elements.length; i++) {
     var element = elements[i];
     var value = element.getAttribute(attributeName);
-    var resource = resolveHref(value, sourceResource);
-    element.setAttribute(attributeName, resource.url);
+    if (defined(value)) {
+      var resource = resolveHref(value, sourceResource);
+      element.setAttribute(attributeName, resource.url);
+    }
   }
 }
 


### PR DESCRIPTION
KmlDataSource: fix #9325 TypeError on a tags without href attribute / img tags without src attribute in placemark popup balloon texts