### PR TITLE
Allow TaskProcessor to take absolute urls for worker paths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 1.78 - 2021-02-01
+
+##### Additions :tada:
+
+- `TaskProcessor` now accepts an absolute URL in addition to a worker name as it's first parameter. This makes it possible to use custom web workers with Cesium's task processing system without copying them to Cesium's Workers directory.
+
 ### 1.77 - 2021-01-04
 
 ##### Additions :tada:

--- a/Source/Core/TaskProcessor.js
+++ b/Source/Core/TaskProcessor.js
@@ -1,3 +1,4 @@
+import Uri from "../ThirdParty/Uri.js";
 import when from "../ThirdParty/when.js";
 import buildModuleUrl from "./buildModuleUrl.js";
 import defaultValue from "./defaultValue.js";
@@ -142,7 +143,7 @@ function createWorker(processor) {
       },
       baseUrl: buildModuleUrl.getCesiumBaseUrl().url,
     },
-    workerModule: TaskProcessor._workerModulePrefix + processor._workerName,
+    workerModule: processor._workerPath,
   };
 
   worker.postMessage(bootstrapMessage);
@@ -165,7 +166,7 @@ function getWebAssemblyLoaderConfig(processor, wasmOptions) {
     if (!defined(wasmOptions.fallbackModulePath)) {
       throw new RuntimeError(
         "This browser does not support Web Assembly, and no backup module was provided for " +
-          processor._workerName
+          processor._workerPath
       );
     }
 
@@ -193,14 +194,15 @@ function getWebAssemblyLoaderConfig(processor, wasmOptions) {
  * @alias TaskProcessor
  * @constructor
  *
- * @param {String} workerName The name of the worker.  This is expected to be a script
- *                            in the Workers folder.
+ * @param {String} workerPath The Url to the worker. This can either be an absolute path or relative to the Cesium Workers folder.
  * @param {Number} [maximumActiveTasks=5] The maximum number of active tasks.  Once exceeded,
  *                                        scheduleTask will not queue any more tasks, allowing
  *                                        work to be rescheduled in future frames.
  */
-function TaskProcessor(workerName, maximumActiveTasks) {
-  this._workerName = workerName;
+function TaskProcessor(workerPath, maximumActiveTasks) {
+  this._workerPath = new Uri(workerPath).isAbsolute()
+    ? workerPath
+    : TaskProcessor._workerModulePrefix + workerPath;
   this._maximumActiveTasks = defaultValue(maximumActiveTasks, 5);
   this._activeTasks = 0;
   this._deferreds = {};
@@ -222,7 +224,7 @@ var emptyTransferableObjectArray = [];
  *                    if there are too many active tasks,
  *
  * @example
- * var taskProcessor = new Cesium.TaskProcessor('myWorkerName');
+ * var taskProcessor = new Cesium.TaskProcessor('myWorkerPath');
  * var promise = taskProcessor.scheduleTask({
  *     someParameter : true,
  *     another : 'hello'

--- a/Specs/Core/TaskProcessorSpec.js
+++ b/Specs/Core/TaskProcessorSpec.js
@@ -6,20 +6,14 @@ import { when } from "../../Source/Cesium.js";
 describe("Core/TaskProcessor", function () {
   var taskProcessor;
 
-  beforeEach(function () {
-    TaskProcessor._workerModulePrefix = absolutize("../Specs/TestWorkers/");
-  });
-
   afterEach(function () {
-    TaskProcessor._workerModulePrefix =
-      TaskProcessor._defaultWorkerModulePrefix;
-
     if (taskProcessor && !taskProcessor.isDestroyed()) {
       taskProcessor = taskProcessor.destroy();
     }
   });
 
-  it("works with a simple worker", function () {
+  it("works with a simple worker defined as relative to TaskProcessor._workerModulePrefix", function () {
+    TaskProcessor._workerModulePrefix = absolutize("../Specs/TestWorkers/");
     taskProcessor = new TaskProcessor("returnParameters.js");
 
     var parameters = {
@@ -29,13 +23,21 @@ describe("Core/TaskProcessor", function () {
       },
     };
 
-    return taskProcessor.scheduleTask(parameters).then(function (result) {
-      expect(result).toEqual(parameters);
-    });
+    return taskProcessor
+      .scheduleTask(parameters)
+      .then(function (result) {
+        expect(result).toEqual(parameters);
+      })
+      .always(function () {
+        TaskProcessor._workerModulePrefix =
+          TaskProcessor._defaultWorkerModulePrefix;
+      });
   });
 
   it("can be destroyed", function () {
-    taskProcessor = new TaskProcessor("returnParameters.js");
+    taskProcessor = new TaskProcessor(
+      absolutize("../Specs/TestWorkers/returnParameters.js")
+    );
 
     expect(taskProcessor.isDestroyed()).toEqual(false);
 
@@ -45,7 +47,9 @@ describe("Core/TaskProcessor", function () {
   });
 
   it("can transfer array buffer", function () {
-    taskProcessor = new TaskProcessor("returnByteLength.js");
+    taskProcessor = new TaskProcessor(
+      absolutize("../Specs/TestWorkers/returnByteLength.js")
+    );
 
     var byteLength = 100;
     var parameters = new ArrayBuffer(byteLength);
@@ -69,7 +73,9 @@ describe("Core/TaskProcessor", function () {
   });
 
   it("can transfer array buffer back from worker", function () {
-    taskProcessor = new TaskProcessor("transferArrayBuffer.js");
+    taskProcessor = new TaskProcessor(
+      absolutize("../Specs/TestWorkers/transferArrayBuffer.js")
+    );
 
     var byteLength = 100;
     var parameters = {
@@ -83,7 +89,9 @@ describe("Core/TaskProcessor", function () {
   });
 
   it("rejects promise if worker throws", function () {
-    taskProcessor = new TaskProcessor("throwError.js");
+    taskProcessor = new TaskProcessor(
+      absolutize("../Specs/TestWorkers/throwError.js")
+    );
 
     var message = "foo";
     var parameters = {
@@ -101,7 +109,9 @@ describe("Core/TaskProcessor", function () {
   });
 
   it("rejects promise if worker returns a non-clonable result", function () {
-    taskProcessor = new TaskProcessor("returnNonCloneable.js");
+    taskProcessor = new TaskProcessor(
+      absolutize("../Specs/TestWorkers/returnNonCloneable.js")
+    );
 
     var message = "foo";
     var parameters = {
@@ -119,7 +129,9 @@ describe("Core/TaskProcessor", function () {
   });
 
   it("successful task raises the taskCompletedEvent", function () {
-    taskProcessor = new TaskProcessor("returnParameters.js");
+    taskProcessor = new TaskProcessor(
+      absolutize("../Specs/TestWorkers/returnParameters.js")
+    );
 
     var parameters = {
       prop: "blah",
@@ -145,7 +157,9 @@ describe("Core/TaskProcessor", function () {
   });
 
   it("unsuccessful task raises the taskCompletedEvent with error", function () {
-    taskProcessor = new TaskProcessor("returnNonCloneable.js");
+    taskProcessor = new TaskProcessor(
+      absolutize("../Specs/TestWorkers/returnNonCloneable.js")
+    );
 
     var message = "foo";
     var parameters = {
@@ -175,7 +189,9 @@ describe("Core/TaskProcessor", function () {
 
   it("can load and compile web assembly module", function () {
     var binaryUrl = absolutize("../Specs/TestWorkers/TestWasm/testWasm.wasm");
-    taskProcessor = new TaskProcessor("returnWasmConfig.js", 5);
+    taskProcessor = new TaskProcessor(
+      absolutize("../Specs/TestWorkers/returnWasmConfig.js", 5)
+    );
     var promise = taskProcessor.initWebAssemblyModule({
       modulePath: "TestWasm/testWasmWrapper",
       wasmBinaryFile: binaryUrl,
@@ -193,7 +209,9 @@ describe("Core/TaskProcessor", function () {
 
   it("uses a backup module if web assembly is not supported", function () {
     var binaryUrl = absolutize("../Specs/TestWorkers/TestWasm/testWasm.wasm");
-    taskProcessor = new TaskProcessor("returnWasmConfig.js", 5);
+    taskProcessor = new TaskProcessor(
+      absolutize("../Specs/TestWorkers/returnWasmConfig.js", 5)
+    );
 
     spyOn(FeatureDetection, "supportsWebAssembly").and.returnValue(false);
 
@@ -212,7 +230,9 @@ describe("Core/TaskProcessor", function () {
 
   it("throws runtime error if web assembly is not supported and no backup is provided", function () {
     var binaryUrl = absolutize("../Specs/TestWorkers/TestWasm/testWasm.wasm");
-    taskProcessor = new TaskProcessor("returnWasmConfig.js", 5);
+    taskProcessor = new TaskProcessor(
+      absolutize("../Specs/TestWorkers/returnWasmConfig.js", 5)
+    );
 
     spyOn(FeatureDetection, "supportsWebAssembly").and.returnValue(false);
 


### PR DESCRIPTION
`TaskProcessor` now accepts an absolute URL in addition to a worker name as it's first parameter. This makes it possible to use custom web workers with Cesium's task processing system without copying them to Cesium's Workers directory.

@kring or @shunter I'm not sure if there are any gotchas that I might have missed here or if we just never really bothered to support this use case.