### PR TITLE
Morton order helper functions

### DIFF
--- a/Source/Core/MortonOrder.js
+++ b/Source/Core/MortonOrder.js
@@ -187,7 +187,7 @@ MortonOrder.decode3D = function (mortonIndex, result) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.number("mortonIndex", mortonIndex);
   if (mortonIndex < 0 || mortonIndex > 1073741823) {
-    throw new DeveloperError("input must be 30-bit unsigned integer");
+    throw new DeveloperError("input must be a 30-bit unsigned integer");
   }
   //>>includeEnd('debug');
 

--- a/Source/Core/MortonOrder.js
+++ b/Source/Core/MortonOrder.js
@@ -6,8 +6,6 @@ import DeveloperError from "./DeveloperError.js";
  * Morton Order (aka Z-Order Curve) helper functions.
  * @see {@link https://en.wikipedia.org/wiki/Z-order_curve}
  * @see {@link http://graphics.stanford.edu/~seander/bithacks.html#InterleaveBMN}
- *
- * @exports MortonOrder
  */
 var MortonOrder = {};
 

--- a/Source/Core/MortonOrder.js
+++ b/Source/Core/MortonOrder.js
@@ -1,0 +1,85 @@
+import Check from "./Check.js";
+import defined from "./defined.js";
+import DeveloperError from "./DeveloperError.js";
+
+/**
+ * Morton Order (aka Z-Order Curve) helper functions.
+ * @see {@link https://en.wikipedia.org/wiki/Z-order_curve}
+ * @see {@link http://graphics.stanford.edu/~seander/bithacks.html#InterleaveBMN}
+ *
+ * @exports MortonOrder
+ */
+var MortonOrder = {};
+
+/**
+ * @private
+ * @param {Number} v
+ */
+function insertSpacingBetweenBits(v) {
+  v = (v | (v << 8)) & 0x00ff00ff;
+  v = (v | (v << 4)) & 0x0f0f0f0f;
+  v = (v | (v << 2)) & 0x33333333;
+  v = (v | (v << 1)) & 0x55555555;
+  return v;
+}
+
+/**
+ * @private
+ * @param {Number} v
+ */
+function removeSpacingBetweenBits(v) {
+  v = v & 0x55555555;
+  v = (v | (v >> 1)) & 0x33333333;
+  v = (v | (v >> 2)) & 0x0f0f0f0f;
+  v = (v | (v >> 4)) & 0x00ff00ff;
+  v = (v | (v >> 8)) & 0x0000ffff;
+  return v;
+}
+
+/**
+ * Computes the Morton index from 2D coordinates. This is equivalent to interleaving their bits.
+ * The maximum allowed input is (2^16)-1 due to 32-bit bitwise operator limitation in Javascript.
+ *
+ * @param {Number} x The X coordinate in the range [0, (2^16)-1].
+ * @param {Number} y The Y coordinate in the range [0, (2^16)-1].
+ * @returns {Number} The 1D morton index.
+ */
+MortonOrder.encode2D = function (x, y) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.number("x", x);
+  Check.typeOf.number("y", y);
+  if (x < 0 || x > 65535 || y < 0 || y > 65535) {
+    throw new DeveloperError("inputs must be between 0 and (2^16)-1");
+  }
+  //>>includeEnd('debug');
+
+  return (
+    (insertSpacingBetweenBits(x) | (insertSpacingBetweenBits(y) << 1)) >>> 0
+  );
+};
+
+/**
+ * Computes the 2D coordinates from a Morton index. This is equivalent to deinterleaving their bits.
+ * The maximum allowed input is (2^32)-1 due to 32-bit bitwise operator limitation in Javascript.
+ *
+ * @param {Number} mortonIndex The Morton index in the range [0, (2^32)-1].
+ * @param {Number[]} [result] The array onto which to store the result.
+ * @returns {Number[]} An array containing the 2D coordinates correspoding to the Morton index.
+ */
+MortonOrder.decode2D = function (mortonIndex, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.number("mortonIndex", mortonIndex);
+  if (mortonIndex < 0 || mortonIndex > 4294967295) {
+    throw new DeveloperError("input must be between 0 and (2^32)-1");
+  }
+  //>>includeEnd('debug');
+
+  if (!defined(result)) {
+    result = new Array(2);
+  }
+
+  result[0] = removeSpacingBetweenBits(mortonIndex);
+  result[1] = removeSpacingBetweenBits(mortonIndex >> 1);
+  return result;
+};
+export default MortonOrder;

--- a/Source/Core/MortonOrder.js
+++ b/Source/Core/MortonOrder.js
@@ -5,15 +5,24 @@ import DeveloperError from "./DeveloperError.js";
 /**
  * Morton Order (aka Z-Order Curve) helper functions.
  * @see {@link https://en.wikipedia.org/wiki/Z-order_curve}
- * @see {@link http://graphics.stanford.edu/~seander/bithacks.html#InterleaveBMN}
  *
  * @namespace MortonOrder
  */
 var MortonOrder = {};
 
 /**
+ * Inserts 0 between the bits in a number. This is the opposite of removeSpacingBetweenBits.
+ * For example:
+ * input: 6
+ * input (binary): 110
+ * output (binary): 10100
+ *                   ^ ^  (added)
+ * output: 20
+ *
  * @private
- * @param {Number} v
+ * @param {Number} v A 16-bit unsigned integer
+ * @returns {Number} A 32-bit unsigned integer with 0 inserted between input bits
+ * @see {@link http://graphics.stanford.edu/~seander/bithacks.html#InterleaveBMN}
  */
 function insertSpacingBetweenBits(v) {
   v = (v | (v << 8)) & 0x00ff00ff;
@@ -24,8 +33,18 @@ function insertSpacingBetweenBits(v) {
 }
 
 /**
+ * Removes every other bit in a number. This is the opposite of insertSpacingBetweenBits.
+ * For example:
+ * input: 20
+ * input (binary): 10100
+ *                  ^ ^  (removed)
+ * output (binary): 110
+ * output: 6
+ *
  * @private
- * @param {Number} v
+ * @param {Number} v A 32-bit unsigned integer
+ * @returns {Number} A 16-bit unsigned integer with every other input bit removed
+ * @see {@link http://graphics.stanford.edu/~seander/bithacks.html#InterleaveBMN}
  */
 function removeSpacingBetweenBits(v) {
   v = v & 0x55555555;

--- a/Source/Core/MortonOrder.js
+++ b/Source/Core/MortonOrder.js
@@ -121,6 +121,10 @@ MortonOrder.encode2D = function (x, y) {
   }
   //>>includeEnd('debug');
 
+  // Note: JavaScript bitwise operations return signed 32-bit integers, so the
+  // final result needs to be reintepreted as an unsigned integer using >>> 0.
+  // This is not needed for encode3D because the result is guaranteed to be at most
+  // 30 bits and thus will always be interpreted as an unsigned value.
   return (insertOneSpacing(x) | (insertOneSpacing(y) << 1)) >>> 0;
 };
 

--- a/Source/Core/MortonOrder.js
+++ b/Source/Core/MortonOrder.js
@@ -6,6 +6,8 @@ import DeveloperError from "./DeveloperError.js";
  * Morton Order (aka Z-Order Curve) helper functions.
  * @see {@link https://en.wikipedia.org/wiki/Z-order_curve}
  * @see {@link http://graphics.stanford.edu/~seander/bithacks.html#InterleaveBMN}
+ *
+ * @namespace MortonOrder
  */
 var MortonOrder = {};
 

--- a/Source/Core/MortonOrder.js
+++ b/Source/Core/MortonOrder.js
@@ -11,75 +11,122 @@ import DeveloperError from "./DeveloperError.js";
 var MortonOrder = {};
 
 /**
- * Inserts 0 between the bits in a number. This is the opposite of removeSpacingBetweenBits.
- * For example:
- * input: 6
- * input (binary): 110
- * output (binary): 10100
- *                   ^ ^  (added)
- * output: 20
+ * Inserts one 0 bit of spacing between a number's bits. This is the opposite of removeOneSpacing.
+ *
+ * Example:
+ *  input: 6
+ *  input (binary):  110
+ *  output (binary): 10100
+ *                    ^ ^ (added)
+ *  output: 20
  *
  * @private
- * @param {Number} v A 16-bit unsigned integer
- * @returns {Number} A 32-bit unsigned integer with 0 inserted between input bits
- * @see {@link http://graphics.stanford.edu/~seander/bithacks.html#InterleaveBMN}
+ * @param {Number} v A 16-bit unsigned integer.
+ * @returns {Number} A 32-bit unsigned integer.
+ * @see {@link https://fgiesen.wordpress.com/2009/12/13/decoding-morton-codes/}
  */
-function insertSpacingBetweenBits(v) {
-  v = (v | (v << 8)) & 0x00ff00ff;
-  v = (v | (v << 4)) & 0x0f0f0f0f;
-  v = (v | (v << 2)) & 0x33333333;
-  v = (v | (v << 1)) & 0x55555555;
+function insertOneSpacing(v) {
+  v = (v ^ (v << 8)) & 0x00ff00ff;
+  v = (v ^ (v << 4)) & 0x0f0f0f0f;
+  v = (v ^ (v << 2)) & 0x33333333;
+  v = (v ^ (v << 1)) & 0x55555555;
   return v;
 }
 
 /**
- * Removes every other bit in a number. This is the opposite of insertSpacingBetweenBits.
- * For example:
- * input: 20
- * input (binary): 10100
- *                  ^ ^  (removed)
- * output (binary): 110
- * output: 6
+ * Inserts two 0 bits of spacing between a number's bits. This is the opposite of removeTwoSpacing.
+ *
+ * Example:
+ *  input: 6
+ *  input (binary):  110
+ *  output (binary): 1001000
+ *                    ^^ ^^ (added)
+ *  output: 72
  *
  * @private
- * @param {Number} v A 32-bit unsigned integer
- * @returns {Number} A 16-bit unsigned integer with every other input bit removed
- * @see {@link http://graphics.stanford.edu/~seander/bithacks.html#InterleaveBMN}
+ * @param {Number} v A 10-bit unsigned integer.
+ * @returns {Number} A 30-bit unsigned integer.
+ * @see {@link https://fgiesen.wordpress.com/2009/12/13/decoding-morton-codes/}
  */
-function removeSpacingBetweenBits(v) {
-  v = v & 0x55555555;
-  v = (v | (v >> 1)) & 0x33333333;
-  v = (v | (v >> 2)) & 0x0f0f0f0f;
-  v = (v | (v >> 4)) & 0x00ff00ff;
-  v = (v | (v >> 8)) & 0x0000ffff;
+function insertTwoSpacing(v) {
+  v = (v ^ (v << 16)) & 0x030000ff;
+  v = (v ^ (v << 8)) & 0x0300f00f;
+  v = (v ^ (v << 4)) & 0x030c30c3;
+  v = (v ^ (v << 2)) & 0x09249249;
+  return v;
+}
+
+/**
+ * Removes one bit of spacing between bits. This is the opposite of insertOneSpacing.
+ *
+ * Example:
+ *  input: 20
+ *  input (binary):  10100
+ *                    ^ ^ (removed)
+ *  output (binary): 110
+ *  output: 6
+ *
+ * @private
+ * @param {Number} v A 32-bit unsigned integer.
+ * @returns {Number} A 16-bit unsigned integer.
+ * @see {@link https://fgiesen.wordpress.com/2009/12/13/decoding-morton-codes/}
+ */
+function removeOneSpacing(v) {
+  v &= 0x55555555;
+  v = (v ^ (v >> 1)) & 0x33333333;
+  v = (v ^ (v >> 2)) & 0x0f0f0f0f;
+  v = (v ^ (v >> 4)) & 0x00ff00ff;
+  v = (v ^ (v >> 8)) & 0x0000ffff;
+  return v;
+}
+
+/**
+ * Removes two bits of spacing between bits. This is the opposite of insertTwoSpacing.
+ *
+ * Example:
+ *  input: 72
+ *  input (binary):  1001000
+ *                    ^^ ^^ (removed)
+ *  output (binary): 110
+ *  output: 6
+ *
+ * @private
+ * @param {Number} v A 30-bit unsigned integer.
+ * @returns {Number} A 10-bit unsigned integer.
+ * @see {@link https://fgiesen.wordpress.com/2009/12/13/decoding-morton-codes/}
+ */
+function removeTwoSpacing(v) {
+  v &= 0x09249249;
+  v = (v ^ (v >> 2)) & 0x030c30c3;
+  v = (v ^ (v >> 4)) & 0x0300f00f;
+  v = (v ^ (v >> 8)) & 0xff0000ff;
+  v = (v ^ (v >> 16)) & 0x000003ff;
   return v;
 }
 
 /**
  * Computes the Morton index from 2D coordinates. This is equivalent to interleaving their bits.
- * The maximum allowed input is (2^16)-1 due to 32-bit bitwise operator limitation in Javascript.
+ * The inputs must be 16-bit unsigned integers (resulting in 32-bit Morton index) due to 32-bit bitwise operator limitation in JavaScript.
  *
  * @param {Number} x The X coordinate in the range [0, (2^16)-1].
  * @param {Number} y The Y coordinate in the range [0, (2^16)-1].
- * @returns {Number} The 1D morton index.
+ * @returns {Number} The Morton index.
  */
 MortonOrder.encode2D = function (x, y) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.number("x", x);
   Check.typeOf.number("y", y);
   if (x < 0 || x > 65535 || y < 0 || y > 65535) {
-    throw new DeveloperError("inputs must be between 0 and (2^16)-1");
+    throw new DeveloperError("inputs must be 16-bit unsigned integers");
   }
   //>>includeEnd('debug');
 
-  return (
-    (insertSpacingBetweenBits(x) | (insertSpacingBetweenBits(y) << 1)) >>> 0
-  );
+  return (insertOneSpacing(x) | (insertOneSpacing(y) << 1)) >>> 0;
 };
 
 /**
  * Computes the 2D coordinates from a Morton index. This is equivalent to deinterleaving their bits.
- * The maximum allowed input is (2^32)-1 due to 32-bit bitwise operator limitation in Javascript.
+ * The input must be a 32-bit unsigned integer (resulting in 16 bits per coordinate) due to 32-bit bitwise operator limitation in JavaScript.
  *
  * @param {Number} mortonIndex The Morton index in the range [0, (2^32)-1].
  * @param {Number[]} [result] The array onto which to store the result.
@@ -89,7 +136,7 @@ MortonOrder.decode2D = function (mortonIndex, result) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.number("mortonIndex", mortonIndex);
   if (mortonIndex < 0 || mortonIndex > 4294967295) {
-    throw new DeveloperError("input must be between 0 and (2^32)-1");
+    throw new DeveloperError("input must be a 32-bit unsigned integer");
   }
   //>>includeEnd('debug');
 
@@ -97,8 +144,61 @@ MortonOrder.decode2D = function (mortonIndex, result) {
     result = new Array(2);
   }
 
-  result[0] = removeSpacingBetweenBits(mortonIndex);
-  result[1] = removeSpacingBetweenBits(mortonIndex >> 1);
+  result[0] = removeOneSpacing(mortonIndex);
+  result[1] = removeOneSpacing(mortonIndex >> 1);
   return result;
 };
+
+/**
+ * Computes the Morton index from 3D coordinates. This is equivalent to interleaving their bits.
+ * The inputs must be 10-bit unsigned integers (resulting in 30-bit Morton index) due to 32-bit bitwise operator limitation in JavaScript.
+ *
+ * @param {Number} x The X coordinate in the range [0, (2^10)-1].
+ * @param {Number} y The Y coordinate in the range [0, (2^10)-1].
+ * @param {Number} z The Z coordinate in the range [0, (2^10)-1].
+ * @returns {Number} The Morton index.
+ */
+MortonOrder.encode3D = function (x, y, z) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.number("x", x);
+  Check.typeOf.number("y", y);
+  Check.typeOf.number("z", z);
+  if (x < 0 || x > 1023 || y < 0 || y > 1023 || z < 0 || z > 1023) {
+    throw new DeveloperError("inputs must be 10-bit unsigned integers");
+  }
+  //>>includeEnd('debug');
+
+  return (
+    insertTwoSpacing(x) |
+    (insertTwoSpacing(y) << 1) |
+    (insertTwoSpacing(z) << 2)
+  );
+};
+
+/**
+ * Computes the 3D coordinates from a Morton index. This is equivalent to deinterleaving their bits.
+ * The input must be a 30-bit unsigned integer (resulting in 10 bits per coordinate) due to 32-bit bitwise operator limitation in JavaScript.
+ *
+ * @param {Number} mortonIndex The Morton index in the range [0, (2^30)-1].
+ * @param {Number[]} [result] The array onto which to store the result.
+ * @returns {Number[]} An array containing the 3D coordinates correspoding to the Morton index.
+ */
+MortonOrder.decode3D = function (mortonIndex, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.number("mortonIndex", mortonIndex);
+  if (mortonIndex < 0 || mortonIndex > 1073741823) {
+    throw new DeveloperError("input must be 30-bit unsigned integer");
+  }
+  //>>includeEnd('debug');
+
+  if (!defined(result)) {
+    result = new Array(3);
+  }
+
+  result[0] = removeTwoSpacing(mortonIndex);
+  result[1] = removeTwoSpacing(mortonIndex >> 1);
+  result[2] = removeTwoSpacing(mortonIndex >> 2);
+  return result;
+};
+
 export default MortonOrder;

--- a/Specs/Core/MortonOrderSpec.js
+++ b/Specs/Core/MortonOrderSpec.js
@@ -1,0 +1,75 @@
+import { MortonOrder } from "../../Source/Cesium.js";
+
+describe("Core/MortonOrder", function () {
+  it("encode2D throws for undefined x", function () {
+    expect(function () {
+      return MortonOrder.encode2D(undefined, 0);
+    }).toThrowDeveloperError();
+  });
+
+  it("encode2D throws for undefined y", function () {
+    expect(function () {
+      return MortonOrder.encode2D(0, undefined);
+    }).toThrowDeveloperError();
+  });
+
+  it("encode2D throws for out of range inputs", function () {
+    expect(function () {
+      return MortonOrder.encode2D(-1, -1);
+    }).toThrowDeveloperError();
+    expect(function () {
+      return MortonOrder.encode2D(65536, 65536); // 2^16
+    }).toThrowDeveloperError();
+  });
+
+  it("encode2D works", function () {
+    expect(MortonOrder.encode2D(0, 0)).toEqual(0); // binary: 000
+    expect(MortonOrder.encode2D(1, 0)).toEqual(1); // binary: 001
+    expect(MortonOrder.encode2D(0, 1)).toEqual(2); // binary: 010
+    expect(MortonOrder.encode2D(1, 1)).toEqual(3); // binary: 011
+    expect(MortonOrder.encode2D(2, 0)).toEqual(4); // binary: 100
+    expect(MortonOrder.encode2D(3, 0)).toEqual(5); // binary: 101
+    expect(MortonOrder.encode2D(2, 1)).toEqual(6); // binary: 110
+    expect(MortonOrder.encode2D(3, 1)).toEqual(7); // binary: 111
+    expect(MortonOrder.encode2D(7, 5)).toEqual(55); // binary: 110111
+
+    // largest input ((2^16)-1) results in largest 32-bit unsigned int ((2^32)-1)
+    expect(MortonOrder.encode2D(65535, 65535)).toEqual(4294967295);
+  });
+
+  it("decode2D throws for undefined mortonIndex", function () {
+    expect(function () {
+      return MortonOrder.decode2D(undefined);
+    }).toThrowDeveloperError();
+  });
+
+  it("encode2D throws for out of range inputs", function () {
+    expect(function () {
+      return MortonOrder.decode2D(-1);
+    }).toThrowDeveloperError();
+    expect(function () {
+      return MortonOrder.decode2D(4294967296); // 2^32
+    }).toThrowDeveloperError();
+  });
+
+  it("decode2D uses result parameter", function () {
+    var array = new Array(2);
+    var result = MortonOrder.decode2D(3, array);
+    expect(result).toBe(array);
+  });
+
+  it("decode2D works", function () {
+    expect(MortonOrder.decode2D(0)).toEqual([0, 0]); // binary: 000
+    expect(MortonOrder.decode2D(1)).toEqual([1, 0]); // binary: 001
+    expect(MortonOrder.decode2D(2)).toEqual([0, 1]); // binary: 010
+    expect(MortonOrder.decode2D(3)).toEqual([1, 1]); // binary: 011
+    expect(MortonOrder.decode2D(4)).toEqual([2, 0]); // binary: 100
+    expect(MortonOrder.decode2D(5)).toEqual([3, 0]); // binary: 101
+    expect(MortonOrder.decode2D(6)).toEqual([2, 1]); // binary: 110
+    expect(MortonOrder.decode2D(7)).toEqual([3, 1]); // binary: 111
+    expect(MortonOrder.decode2D(55)).toEqual([7, 5]); // binary: 110111
+
+    // largest input ((2^32)-1) results in largest 16-bit unsigned int ((2^16)-1)
+    expect(MortonOrder.decode2D(4294967295)).toEqual([65535, 65535]);
+  });
+});

--- a/Specs/Core/MortonOrderSpec.js
+++ b/Specs/Core/MortonOrderSpec.js
@@ -1,13 +1,10 @@
 import { MortonOrder } from "../../Source/Cesium.js";
 
 describe("Core/MortonOrder", function () {
-  it("encode2D throws for undefined x", function () {
+  it("encode2D throws for undefined inputs", function () {
     expect(function () {
       return MortonOrder.encode2D(undefined, 0);
     }).toThrowDeveloperError();
-  });
-
-  it("encode2D throws for undefined y", function () {
     expect(function () {
       return MortonOrder.encode2D(0, undefined);
     }).toThrowDeveloperError();
@@ -15,10 +12,16 @@ describe("Core/MortonOrder", function () {
 
   it("encode2D throws for out of range inputs", function () {
     expect(function () {
-      return MortonOrder.encode2D(-1, -1);
+      return MortonOrder.encode2D(-1, 0);
     }).toThrowDeveloperError();
     expect(function () {
-      return MortonOrder.encode2D(65536, 65536); // 2^16
+      return MortonOrder.encode2D(0, -1);
+    }).toThrowDeveloperError();
+    expect(function () {
+      return MortonOrder.encode2D(65536, 0); // 2^16
+    }).toThrowDeveloperError();
+    expect(function () {
+      return MortonOrder.encode2D(0, 65536); // 2^16
     }).toThrowDeveloperError();
   });
 
@@ -31,19 +34,22 @@ describe("Core/MortonOrder", function () {
     expect(MortonOrder.encode2D(3, 0)).toEqual(5); // binary: 101
     expect(MortonOrder.encode2D(2, 1)).toEqual(6); // binary: 110
     expect(MortonOrder.encode2D(3, 1)).toEqual(7); // binary: 111
+
     expect(MortonOrder.encode2D(7, 5)).toEqual(55); // binary: 110111
 
-    // largest input ((2^16)-1) results in largest 32-bit unsigned int ((2^32)-1)
-    expect(MortonOrder.encode2D(65535, 65535)).toEqual(4294967295);
+    // largest 16-bit unsigned integer inputs ((2^16)-1) result in largest 32-bit unsigned integer output ((2^32)-1)
+    expect(MortonOrder.encode2D(65535, 65535)).toEqual(4294967295); // binary: 11111111111111111111111111111111
+    expect(MortonOrder.encode2D(65535, 0)).toEqual(1431655765); ////// binary:  1010101010101010101010101010101
+    expect(MortonOrder.encode2D(0, 65535)).toEqual(2863311530); ////// binary: 10101010101010101010101010101010
   });
 
-  it("decode2D throws for undefined mortonIndex", function () {
+  it("decode2D throws for undefined input", function () {
     expect(function () {
       return MortonOrder.decode2D(undefined);
     }).toThrowDeveloperError();
   });
 
-  it("encode2D throws for out of range inputs", function () {
+  it("decode2D throws for out of range input", function () {
     expect(function () {
       return MortonOrder.decode2D(-1);
     }).toThrowDeveloperError();
@@ -54,7 +60,7 @@ describe("Core/MortonOrder", function () {
 
   it("decode2D uses result parameter", function () {
     var array = new Array(2);
-    var result = MortonOrder.decode2D(3, array);
+    var result = MortonOrder.decode2D(0, array);
     expect(result).toBe(array);
   });
 
@@ -67,9 +73,104 @@ describe("Core/MortonOrder", function () {
     expect(MortonOrder.decode2D(5)).toEqual([3, 0]); // binary: 101
     expect(MortonOrder.decode2D(6)).toEqual([2, 1]); // binary: 110
     expect(MortonOrder.decode2D(7)).toEqual([3, 1]); // binary: 111
+
     expect(MortonOrder.decode2D(55)).toEqual([7, 5]); // binary: 110111
 
-    // largest input ((2^32)-1) results in largest 16-bit unsigned int ((2^16)-1)
-    expect(MortonOrder.decode2D(4294967295)).toEqual([65535, 65535]);
+    // largest 32-bit unsigned integer input ((2^32)-1) results in largest 16-bit unsigned integer outputs ((2^16)-1)
+    expect(MortonOrder.decode2D(4294967295)).toEqual([65535, 65535]); // binary: 11111111111111111111111111111111
+    expect(MortonOrder.decode2D(1431655765)).toEqual([65535, 0]); ////// binary:  1010101010101010101010101010101
+    expect(MortonOrder.decode2D(2863311530)).toEqual([0, 65535]); ////// binary: 10101010101010101010101010101010
+  });
+
+  it("encode3D throws for undefined inputs", function () {
+    expect(function () {
+      return MortonOrder.encode3D(undefined, 0, 0);
+    }).toThrowDeveloperError();
+    expect(function () {
+      return MortonOrder.encode3D(0, undefined, 0);
+    }).toThrowDeveloperError();
+    expect(function () {
+      return MortonOrder.encode3D(0, 0, undefined);
+    }).toThrowDeveloperError();
+  });
+
+  it("encode3D throws for out of range inputs", function () {
+    expect(function () {
+      return MortonOrder.encode3D(-1, 0, 0);
+    }).toThrowDeveloperError();
+    expect(function () {
+      return MortonOrder.encode3D(0, -1, 0);
+    }).toThrowDeveloperError();
+    expect(function () {
+      return MortonOrder.encode3D(0, 0, -1);
+    }).toThrowDeveloperError();
+    expect(function () {
+      return MortonOrder.encode3D(1024, 0, 0); // 2^10
+    }).toThrowDeveloperError();
+    expect(function () {
+      return MortonOrder.encode3D(0, 1024, 0); // 2^10
+    }).toThrowDeveloperError();
+    expect(function () {
+      return MortonOrder.encode3D(0, 0, 1024); // 2^10
+    }).toThrowDeveloperError();
+  });
+
+  it("encode3D works", function () {
+    expect(MortonOrder.encode3D(0, 0, 0)).toEqual(0); // binary: 000
+    expect(MortonOrder.encode3D(1, 0, 0)).toEqual(1); // binary: 001
+    expect(MortonOrder.encode3D(0, 1, 0)).toEqual(2); // binary: 010
+    expect(MortonOrder.encode3D(1, 1, 0)).toEqual(3); // binary: 011
+    expect(MortonOrder.encode3D(0, 0, 1)).toEqual(4); // binary: 100
+    expect(MortonOrder.encode3D(1, 0, 1)).toEqual(5); // binary: 101
+    expect(MortonOrder.encode3D(0, 1, 1)).toEqual(6); // binary: 110
+    expect(MortonOrder.encode3D(1, 1, 1)).toEqual(7); // binary: 111
+
+    expect(MortonOrder.encode3D(1, 3, 3)).toEqual(55); // binary: 110111
+
+    // largest 10-bit unsigned integer inputs ((2^10)-1) result in largest 30-bit unsigned integer output ((2^30)-1)
+    expect(MortonOrder.encode3D(1023, 1023, 1023)).toEqual(1073741823); // binary: 111111111111111111111111111111
+    expect(MortonOrder.encode3D(1023, 0, 0)).toEqual(153391689); ///////// binary:   1001001001001001001001001001
+    expect(MortonOrder.encode3D(0, 1023, 0)).toEqual(306783378); ///////// binary:  10010010010010010010010010010
+    expect(MortonOrder.encode3D(0, 0, 1023)).toEqual(613566756); ///////// binary: 100100100100100100100100100100
+  });
+
+  it("decode3D throws for undefined input", function () {
+    expect(function () {
+      return MortonOrder.decode3D(undefined);
+    }).toThrowDeveloperError();
+  });
+
+  it("decode3D throws for out of range input", function () {
+    expect(function () {
+      return MortonOrder.decode3D(-1);
+    }).toThrowDeveloperError();
+    expect(function () {
+      return MortonOrder.decode3D(1073741824); // 2^30
+    }).toThrowDeveloperError();
+  });
+
+  it("decode3D uses result parameter", function () {
+    var array = new Array(3);
+    var result = MortonOrder.decode3D(0, array);
+    expect(result).toBe(array);
+  });
+
+  it("decode3D works", function () {
+    expect(MortonOrder.decode3D(0)).toEqual([0, 0, 0]); // binary: 000
+    expect(MortonOrder.decode3D(1)).toEqual([1, 0, 0]); // binary: 001
+    expect(MortonOrder.decode3D(2)).toEqual([0, 1, 0]); // binary: 010
+    expect(MortonOrder.decode3D(3)).toEqual([1, 1, 0]); // binary: 011
+    expect(MortonOrder.decode3D(4)).toEqual([0, 0, 1]); // binary: 100
+    expect(MortonOrder.decode3D(5)).toEqual([1, 0, 1]); // binary: 101
+    expect(MortonOrder.decode3D(6)).toEqual([0, 1, 1]); // binary: 110
+    expect(MortonOrder.decode3D(7)).toEqual([1, 1, 1]); // binary: 111
+
+    expect(MortonOrder.decode3D(55)).toEqual([1, 3, 3]); // binary: 110111
+
+    // largest 30-bit unsigned integer input ((2^30)-1) results in largest 10-bit unsigned integer outputs ((2^10)-1)
+    expect(MortonOrder.decode3D(1073741823)).toEqual([1023, 1023, 1023]); // binary: 111111111111111111111111111111
+    expect(MortonOrder.decode3D(153391689)).toEqual([1023, 0, 0]); ///////// binary:   1001001001001001001001001001
+    expect(MortonOrder.decode3D(306783378)).toEqual([0, 1023, 0]); ///////// binary:  10010010010010010010010010010
+    expect(MortonOrder.decode3D(613566756)).toEqual([0, 0, 1023]); ///////// binary: 100100100100100100100100100100
   });
 });


### PR DESCRIPTION
Here's the start of Morton order helper functions. It only does 2D encode and decode right now.

Update: Now include 3D encode and decode as well

cc @ptrgags @lilleyse 

For context, these are some preliminary helper routines that will eventually be used in an implementation of the [`3DTILES_implicit_tiling`](https://github.com/CesiumGS/3d-tiles/pull/444) specification (still a WIP)