### PR TITLE
Save tileset resource for deriving resources after construction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### 1.78 - 2021-02-01
 
+##### Deprecated :hourglass_flowing_sand:
+
+- `Cesium3DTileset.url` has been deprecated and will be removed in Cesium 1.79. Instead, use `Cesium3DTileset.resource.url` to retrieve the url value.
+
 ##### Additions :tada:
 
 - `TaskProcessor` now accepts an absolute URL in addition to a worker name as it's first parameter. This makes it possible to use custom web workers with Cesium's task processing system without copying them to Cesium's Workers directory.

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1172,10 +1172,29 @@ Object.defineProperties(Cesium3DTileset.prototype, {
    *
    * @type {String}
    * @readonly
+   * @deprecated
    */
   url: {
     get: function () {
+      deprecationWarning(
+        "Cesium3DTileset.url",
+        "Cesium3DTileset.url has been deprecated and will be removed in CesiumJS 1.79.  Instead, use Cesium3DTileset.resource.url to retrieve the url value."
+      );
       return this._url;
+    },
+  },
+
+  /**
+   * The resource used to fetch the tileset JSON file
+   *
+   * @memberof Cesium3DTileset.prototype
+   *
+   * @type {Resource}
+   * @readonly
+   */
+  resource: {
+    get: function () {
+      return this._resource;
     },
   },
 

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -144,6 +144,7 @@ function Cesium3DTileset(options) {
   this._url = undefined;
   this._basePath = undefined;
   this._root = undefined;
+  this._resource = undefined;
   this._asset = undefined; // Metadata for the entire tileset
   this._properties = undefined; // Metadata for per-model/point/etc properties
   this._geometricError = undefined; // Geometric error when the tree is not rendered at all
@@ -903,6 +904,7 @@ function Cesium3DTileset(options) {
     .then(function (url) {
       var basePath;
       resource = Resource.createIfNeeded(url);
+      that._resource = resource;
 
       // ion resources have a credits property we can use for additional attribution.
       that._credits = resource.credits;

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1718,6 +1718,7 @@ Cesium3DTileset.prototype.loadTileset = function (
   if (defined(tilesetVersion)) {
     // Append the tileset version to the resource
     this._basePath += "?v=" + tilesetVersion;
+    resource = resource.clone();
     resource.setQueryParameters({ v: tilesetVersion });
   }
 

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -363,7 +363,7 @@ describe(
       var tileset = new Cesium3DTileset({
         url: path,
       });
-      expect(tileset.url).toEqual(path);
+      expect(tileset.resource.url).toEqual(path);
     });
 
     it("url and tilesetUrl set up correctly given path with query string", function () {
@@ -372,7 +372,7 @@ describe(
       var tileset = new Cesium3DTileset({
         url: path + param,
       });
-      expect(tileset.url).toEqual(path + param);
+      expect(tileset.resource.url).toEqual(path + param);
     });
 
     it("resolves readyPromise", function () {
@@ -402,7 +402,7 @@ describe(
 
         expect(tileset._geometricError).toEqual(240.0);
         expect(tileset.root).toBeDefined();
-        expect(tileset.url).toEqual(tilesetUrl);
+        expect(tileset.resource.url).toEqual(tilesetUrl);
       });
     });
 


### PR DESCRIPTION
I have a use case where I need to call `tileset._resource.getDerivedResource` after the tileset has been initialized.  This provides me with a way to access it.