### PR TITLE
Don't extend the viewer credit container all the way to the right of the screen

### DIFF
--- a/Source/Widgets/Viewer/Viewer.css
+++ b/Source/Widgets/Viewer/Viewer.css
@@ -20,7 +20,6 @@
   position: absolute;
   bottom: 0;
   left: 0;
-  right: 0;
   padding-right: 5px;
 }
 


### PR DESCRIPTION
I noticed that I could click and drag the globe if moused down right above the timeline because this div was wider than it needed to be.  I think this was just leftover from when we use to display all the credits on screen instead of using the data attribution link.

Before:
![image](https://user-images.githubusercontent.com/3451886/106324188-bba02700-6246-11eb-8ed4-8dac33713d35.png)

After:
![image](https://user-images.githubusercontent.com/3451886/106324141-a925ed80-6246-11eb-8a9d-cf76bc0a1a2f.png)

