### PR TITLE
Added helper getJsonFromTypedArray

### DIFF
--- a/Source/Core/CesiumTerrainProvider.js
+++ b/Source/Core/CesiumTerrainProvider.js
@@ -9,7 +9,7 @@ import DeveloperError from "./DeveloperError.js";
 import Event from "./Event.js";
 import GeographicTilingScheme from "./GeographicTilingScheme.js";
 import WebMercatorTilingScheme from "./WebMercatorTilingScheme.js";
-import getStringFromTypedArray from "./getStringFromTypedArray.js";
+import getJsonFromTypedArray from "./getJsonFromTypedArray.js";
 import HeightmapTerrainData from "./HeightmapTerrainData.js";
 import IndexDatatype from "./IndexDatatype.js";
 import OrientedBoundingBox from "./OrientedBoundingBox.js";
@@ -710,12 +710,11 @@ function createQuantizedMeshTerrainData(provider, buffer, level, x, y, layer) {
     ) {
       var stringLength = view.getUint32(pos, true);
       if (stringLength > 0) {
-        var jsonString = getStringFromTypedArray(
+        var metadata = getJsonFromTypedArray(
           new Uint8Array(buffer),
           pos + Uint32Array.BYTES_PER_ELEMENT,
           stringLength
         );
-        var metadata = JSON.parse(jsonString);
         var availableTiles = metadata.available;
         if (defined(availableTiles)) {
           for (var offset = 0; offset < availableTiles.length; ++offset) {

--- a/Source/Core/getJsonFromTypedArray.js
+++ b/Source/Core/getJsonFromTypedArray.js
@@ -2,6 +2,10 @@ import getStringFromTypedArray from "./getStringFromTypedArray.js";
 
 /**
  * @private
+ * @function
+ * @param {Uint8Array} uint8Array
+ * @param {Number} byteOffset
+ * @param {Number} byteLength
  */
 function getJsonFromTypedArray(uint8Array, byteOffset, byteLength) {
   return JSON.parse(

--- a/Source/Core/getJsonFromTypedArray.js
+++ b/Source/Core/getJsonFromTypedArray.js
@@ -1,0 +1,12 @@
+import getStringFromTypedArray from "./getStringFromTypedArray.js";
+
+/**
+ * @private
+ */
+function getJsonFromTypedArray(uint8Array, byteOffset, byteLength) {
+  return JSON.parse(
+    getStringFromTypedArray(uint8Array, byteOffset, byteLength)
+  );
+}
+
+export default getJsonFromTypedArray;

--- a/Source/Core/getJsonFromTypedArray.js
+++ b/Source/Core/getJsonFromTypedArray.js
@@ -1,11 +1,16 @@
 import getStringFromTypedArray from "./getStringFromTypedArray.js";
 
 /**
- * @private
+ * Parses JSON from a Uint8Array.
+ *
  * @function
- * @param {Uint8Array} uint8Array
- * @param {Number} byteOffset
- * @param {Number} byteLength
+ *
+ * @param {Uint8Array} uint8Array The Uint8Array to read from.
+ * @param {Number} [byteOffset=0] The byte offset to start reading from.
+ * @param {Number} [byteLength] The byte length to read. If byteLength is omitted the remainder of the buffer is read.
+ * @returns {Object} An object containing the parsed JSON.
+ *
+ * @private
  */
 function getJsonFromTypedArray(uint8Array, byteOffset, byteLength) {
   return JSON.parse(

--- a/Source/Core/getStringFromTypedArray.js
+++ b/Source/Core/getStringFromTypedArray.js
@@ -4,6 +4,15 @@ import DeveloperError from "./DeveloperError.js";
 import RuntimeError from "./RuntimeError.js";
 
 /**
+ * Reads a string from a Uint8Array.
+ *
+ * @function
+ *
+ * @param {Uint8Array} uint8Array The Uint8Array to read from.
+ * @param {Number} [byteOffset=0] The byte offset to start reading from.
+ * @param {Number} [byteLength] The byte length to read. If byteLength is omitted the remainder of the buffer is read.
+ * @returns {String} The string.
+ *
  * @private
  */
 function getStringFromTypedArray(uint8Array, byteOffset, byteLength) {

--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -6,7 +6,7 @@ import defined from "../Core/defined.js";
 import deprecationWarning from "../Core/deprecationWarning.js";
 import destroyObject from "../Core/destroyObject.js";
 import DeveloperError from "../Core/DeveloperError.js";
-import getStringFromTypedArray from "../Core/getStringFromTypedArray.js";
+import getJsonFromTypedArray from "../Core/getJsonFromTypedArray.js";
 import Matrix4 from "../Core/Matrix4.js";
 import RequestType from "../Core/RequestType.js";
 import RuntimeError from "../Core/RuntimeError.js";
@@ -296,12 +296,11 @@ function initialize(content, arrayBuffer, byteOffset) {
       BATCH_LENGTH: defaultValue(batchLength, 0),
     };
   } else {
-    var featureTableString = getStringFromTypedArray(
+    featureTableJson = getJsonFromTypedArray(
       uint8Array,
       byteOffset,
       featureTableJsonByteLength
     );
-    featureTableJson = JSON.parse(featureTableString);
     byteOffset += featureTableJsonByteLength;
   }
 
@@ -328,12 +327,11 @@ function initialize(content, arrayBuffer, byteOffset) {
     //
     // We could also make another request for it, but that would make the property set/get
     // API async, and would double the number of numbers in some cases.
-    var batchTableString = getStringFromTypedArray(
+    batchTableJson = getJsonFromTypedArray(
       uint8Array,
       byteOffset,
       batchTableJsonByteLength
     );
-    batchTableJson = JSON.parse(batchTableString);
     byteOffset += batchTableJsonByteLength;
 
     if (batchTableBinaryByteLength > 0) {

--- a/Source/Scene/Geometry3DTileContent.js
+++ b/Source/Scene/Geometry3DTileContent.js
@@ -3,7 +3,7 @@ import defaultValue from "../Core/defaultValue.js";
 import defined from "../Core/defined.js";
 import destroyObject from "../Core/destroyObject.js";
 import DeveloperError from "../Core/DeveloperError.js";
-import getStringFromTypedArray from "../Core/getStringFromTypedArray.js";
+import getJsonFromTypedArray from "../Core/getJsonFromTypedArray.js";
 import Matrix4 from "../Core/Matrix4.js";
 import RuntimeError from "../Core/RuntimeError.js";
 import when from "../ThirdParty/when.js";
@@ -290,12 +290,11 @@ function initialize(content, arrayBuffer, byteOffset) {
   var batchTableBinaryByteLength = view.getUint32(byteOffset, true);
   byteOffset += sizeOfUint32;
 
-  var featureTableString = getStringFromTypedArray(
+  var featureTableJson = getJsonFromTypedArray(
     uint8Array,
     byteOffset,
     featureTableJSONByteLength
   );
-  var featureTableJson = JSON.parse(featureTableString);
   byteOffset += featureTableJSONByteLength;
 
   var featureTableBinary = new Uint8Array(
@@ -313,12 +312,11 @@ function initialize(content, arrayBuffer, byteOffset) {
     //
     // We could also make another request for it, but that would make the property set/get
     // API async, and would double the number of numbers in some cases.
-    var batchTableString = getStringFromTypedArray(
+    batchTableJson = getJsonFromTypedArray(
       uint8Array,
       byteOffset,
       batchTableJSONByteLength
     );
-    batchTableJson = JSON.parse(batchTableString);
     byteOffset += batchTableJSONByteLength;
 
     if (batchTableBinaryByteLength > 0) {

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -8,6 +8,7 @@ import deprecationWarning from "../Core/deprecationWarning.js";
 import destroyObject from "../Core/destroyObject.js";
 import DeveloperError from "../Core/DeveloperError.js";
 import Ellipsoid from "../Core/Ellipsoid.js";
+import getJsonFromTypedArray from "../Core/getJsonFromTypedArray.js";
 import getStringFromTypedArray from "../Core/getStringFromTypedArray.js";
 import Matrix3 from "../Core/Matrix3.js";
 import Matrix4 from "../Core/Matrix4.js";
@@ -203,12 +204,11 @@ function initialize(content, arrayBuffer, byteOffset) {
   }
   byteOffset += sizeOfUint32;
 
-  var featureTableString = getStringFromTypedArray(
+  var featureTableJson = getJsonFromTypedArray(
     uint8Array,
     byteOffset,
     featureTableJsonByteLength
   );
-  var featureTableJson = JSON.parse(featureTableString);
   byteOffset += featureTableJsonByteLength;
 
   var featureTableBinary = new Uint8Array(
@@ -234,12 +234,11 @@ function initialize(content, arrayBuffer, byteOffset) {
   var batchTableJson;
   var batchTableBinary;
   if (batchTableJsonByteLength > 0) {
-    var batchTableString = getStringFromTypedArray(
+    batchTableJson = getJsonFromTypedArray(
       uint8Array,
       byteOffset,
       batchTableJsonByteLength
     );
-    batchTableJson = JSON.parse(batchTableString);
     byteOffset += batchTableJsonByteLength;
 
     if (batchTableBinaryByteLength > 0) {

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -16,6 +16,7 @@ import DeveloperError from "../Core/DeveloperError.js";
 import DistanceDisplayCondition from "../Core/DistanceDisplayCondition.js";
 import FeatureDetection from "../Core/FeatureDetection.js";
 import getAbsoluteUri from "../Core/getAbsoluteUri.js";
+import getJsonFromTypedArray from "../Core/getJsonFromTypedArray.js";
 import getMagic from "../Core/getMagic.js";
 import getStringFromTypedArray from "../Core/getStringFromTypedArray.js";
 import IndexDatatype from "../Core/IndexDatatype.js";
@@ -1480,8 +1481,8 @@ Model.fromGltf = function (options) {
           cachedGltf.makeReady(parsedGltf);
         } else {
           // Load text (JSON) glTF
-          var json = getStringFromTypedArray(array);
-          cachedGltf.makeReady(JSON.parse(json));
+          var json = getJsonFromTypedArray(array);
+          cachedGltf.makeReady(json);
         }
 
         var resourceCredits = model._resourceCredits;

--- a/Source/Scene/PointCloud.js
+++ b/Source/Scene/PointCloud.js
@@ -10,7 +10,7 @@ import ComponentDatatype from "../Core/ComponentDatatype.js";
 import defaultValue from "../Core/defaultValue.js";
 import defined from "../Core/defined.js";
 import destroyObject from "../Core/destroyObject.js";
-import getStringFromTypedArray from "../Core/getStringFromTypedArray.js";
+import getJsonFromTypedArray from "../Core/getJsonFromTypedArray.js";
 import CesiumMath from "../Core/Math.js";
 import Matrix4 from "../Core/Matrix4.js";
 import oneTimeWarning from "../Core/oneTimeWarning.js";
@@ -235,12 +235,11 @@ function initialize(pointCloud, options) {
   var batchTableBinaryByteLength = view.getUint32(byteOffset, true);
   byteOffset += sizeOfUint32;
 
-  var featureTableString = getStringFromTypedArray(
+  var featureTableJson = getJsonFromTypedArray(
     uint8Array,
     byteOffset,
     featureTableJsonByteLength
   );
-  var featureTableJson = JSON.parse(featureTableString);
   byteOffset += featureTableJsonByteLength;
 
   var featureTableBinary = new Uint8Array(
@@ -255,12 +254,11 @@ function initialize(pointCloud, options) {
   var batchTableBinary;
   if (batchTableJsonByteLength > 0) {
     // Has a batch table JSON
-    var batchTableString = getStringFromTypedArray(
+    batchTableJson = getJsonFromTypedArray(
       uint8Array,
       byteOffset,
       batchTableJsonByteLength
     );
-    batchTableJson = JSON.parse(batchTableString);
     byteOffset += batchTableJsonByteLength;
 
     if (batchTableBinaryByteLength > 0) {

--- a/Source/Scene/Tileset3DTileContent.js
+++ b/Source/Scene/Tileset3DTileContent.js
@@ -1,6 +1,6 @@
 import defaultValue from "../Core/defaultValue.js";
 import destroyObject from "../Core/destroyObject.js";
-import getStringFromTypedArray from "../Core/getStringFromTypedArray.js";
+import getJsonFromTypedArray from "../Core/getJsonFromTypedArray.js";
 import RuntimeError from "../Core/RuntimeError.js";
 import when from "../ThirdParty/when.js";
 
@@ -111,11 +111,10 @@ Object.defineProperties(Tileset3DTileContent.prototype, {
 function initialize(content, arrayBuffer, byteOffset) {
   byteOffset = defaultValue(byteOffset, 0);
   var uint8Array = new Uint8Array(arrayBuffer);
-  var jsonString = getStringFromTypedArray(uint8Array, byteOffset);
   var tilesetJson;
 
   try {
-    tilesetJson = JSON.parse(jsonString);
+    tilesetJson = getJsonFromTypedArray(uint8Array, byteOffset);
   } catch (error) {
     content._readyPromise.reject(new RuntimeError("Invalid tile content."));
     return;

--- a/Source/Scene/Vector3DTileContent.js
+++ b/Source/Scene/Vector3DTileContent.js
@@ -4,7 +4,7 @@ import defined from "../Core/defined.js";
 import destroyObject from "../Core/destroyObject.js";
 import DeveloperError from "../Core/DeveloperError.js";
 import Ellipsoid from "../Core/Ellipsoid.js";
-import getStringFromTypedArray from "../Core/getStringFromTypedArray.js";
+import getJsonFromTypedArray from "../Core/getJsonFromTypedArray.js";
 import ComponentDatatype from "../Core/ComponentDatatype.js";
 import CesiumMath from "../Core/Math.js";
 import Matrix4 from "../Core/Matrix4.js";
@@ -297,12 +297,11 @@ function initialize(content, arrayBuffer, byteOffset) {
   var pointsPositionByteLength = view.getUint32(byteOffset, true);
   byteOffset += sizeOfUint32;
 
-  var featureTableString = getStringFromTypedArray(
+  var featureTableJson = getJsonFromTypedArray(
     uint8Array,
     byteOffset,
     featureTableJSONByteLength
   );
-  var featureTableJson = JSON.parse(featureTableString);
   byteOffset += featureTableJSONByteLength;
 
   var featureTableBinary = new Uint8Array(
@@ -320,12 +319,11 @@ function initialize(content, arrayBuffer, byteOffset) {
     //
     // We could also make another request for it, but that would make the property set/get
     // API async, and would double the number of numbers in some cases.
-    var batchTableString = getStringFromTypedArray(
+    batchTableJson = getJsonFromTypedArray(
       uint8Array,
       byteOffset,
       batchTableJSONByteLength
     );
-    batchTableJson = JSON.parse(batchTableString);
     byteOffset += batchTableJSONByteLength;
 
     if (batchTableBinaryByteLength > 0) {

--- a/Source/ThirdParty/GltfPipeline/parseGlb.js
+++ b/Source/ThirdParty/GltfPipeline/parseGlb.js
@@ -2,8 +2,8 @@ import addPipelineExtras from './addPipelineExtras.js'
 import removeExtensionsUsed from './removeExtensionsUsed.js'
 import defaultValue from '../../Core/defaultValue.js'
 import defined from '../../Core/defined.js'
+import getJsonFromTypedArray from '../../Core/getJsonFromTypedArray.js'
 import getMagic from '../../Core/getMagic.js'
-import getStringFromTypedArray from '../../Core/getStringFromTypedArray.js'
 import RuntimeError from '../../Core/RuntimeError.js'
 
     var sizeOfUint32 = 4;
@@ -60,8 +60,7 @@ import RuntimeError from '../../Core/RuntimeError.js'
         var jsonStart = 20;
         var binaryStart = jsonStart + contentLength;
 
-        var contentString = getStringFromTypedArray(glb, jsonStart, contentLength);
-        var gltf = JSON.parse(contentString);
+        var gltf = getJsonFromTypedArray(glb, jsonStart, contentLength);
         addPipelineExtras(gltf);
 
         var binaryBuffer = glb.subarray(binaryStart, length);
@@ -93,8 +92,7 @@ import RuntimeError from '../../Core/RuntimeError.js'
             byteOffset += chunkLength;
             // Load JSON chunk
             if (chunkType === 0x4E4F534A) {
-                var jsonString = getStringFromTypedArray(chunkBuffer);
-                gltf = JSON.parse(jsonString);
+                gltf = getJsonFromTypedArray(chunkBuffer);
                 addPipelineExtras(gltf);
             }
             // Load Binary chunk

--- a/Specs/Core/getJsonFromTypedArraySpec.js
+++ b/Specs/Core/getJsonFromTypedArraySpec.js
@@ -1,0 +1,45 @@
+import { getJsonFromTypedArray } from "../../Source/Cesium.js";
+
+describe("Core/getJsonFromTypedArray", function () {
+  it("converts a typed array to string", function () {
+    if (TextEncoder === undefined) {
+      return;
+    }
+
+    var json = {
+      a: [0, 1, 2],
+      b: "b",
+      c: {
+        d: true,
+      },
+    };
+
+    var string = JSON.stringify(json);
+    var encoder = new TextEncoder();
+    var typedArray = encoder.encode(string);
+    var result = getJsonFromTypedArray(typedArray);
+
+    expect(result).toEqual(json);
+  });
+
+  it("converts a sub-region of a typed array to json", function () {
+    if (TextEncoder === undefined) {
+      return;
+    }
+
+    var json = {
+      a: [0, 1, 2],
+      b: "b",
+      c: {
+        d: true,
+      },
+    };
+
+    var string = JSON.stringify(json);
+    var encoder = new TextEncoder();
+    var typedArray = encoder.encode(string);
+    var result = getJsonFromTypedArray(typedArray, 25, 10);
+
+    expect(result).toEqual(json.c);
+  });
+});

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -5,7 +5,7 @@ import { Color } from "../../Source/Cesium.js";
 import { CullingVolume } from "../../Source/Cesium.js";
 import { defined } from "../../Source/Cesium.js";
 import { getAbsoluteUri } from "../../Source/Cesium.js";
-import { getStringFromTypedArray } from "../../Source/Cesium.js";
+import { getJsonFromTypedArray } from "../../Source/Cesium.js";
 import { HeadingPitchRange } from "../../Source/Cesium.js";
 import { HeadingPitchRoll } from "../../Source/Cesium.js";
 import { Intersect } from "../../Source/Cesium.js";
@@ -3799,11 +3799,10 @@ describe(
 
     function modifySubtreeBuffer(arrayBuffer) {
       var uint8Array = new Uint8Array(arrayBuffer);
-      var jsonString = getStringFromTypedArray(uint8Array);
-      var json = JSON.parse(jsonString);
+      var json = getJsonFromTypedArray(uint8Array);
       json.root.children.splice(0, 1);
 
-      jsonString = JSON.stringify(json);
+      var jsonString = JSON.stringify(json);
       var length = jsonString.length;
       uint8Array = new Uint8Array(length);
       for (var i = 0; i < length; i++) {


### PR DESCRIPTION
Added a new helper `getJsonFromTypedArray` which calls `getStringFromTypedArray` internally. Previously we called `getStringFromTypedArray` followed by `JSON.parse` in many places, these have now been updated to call `getJsonFromTypedArray`.

Came up during PR review in https://github.com/CesiumGS/cesium/pull/9351/files#r567105254