### PR TITLE
Fix swapped sinAngles in Matrix3 fromRotation functions

### DIFF
--- a/Source/Core/Matrix3.js
+++ b/Source/Core/Matrix3.js
@@ -491,9 +491,9 @@ Matrix3.fromRotationX = function (angle, result) {
       0.0,
       0.0,
       cosAngle,
-      -sinAngle,
-      0.0,
       sinAngle,
+      0.0,
+      -sinAngle,
       cosAngle
     );
   }
@@ -536,11 +536,11 @@ Matrix3.fromRotationY = function (angle, result) {
     return new Matrix3(
       cosAngle,
       0.0,
-      sinAngle,
+      -sinAngle,
       0.0,
       1.0,
       0.0,
-      -sinAngle,
+      sinAngle,
       0.0,
       cosAngle
     );
@@ -583,9 +583,9 @@ Matrix3.fromRotationZ = function (angle, result) {
   if (!defined(result)) {
     return new Matrix3(
       cosAngle,
-      -sinAngle,
-      0.0,
       sinAngle,
+      0.0,
+      -sinAngle,
       cosAngle,
       0.0,
       0.0,

--- a/Specs/Core/Matrix3Spec.js
+++ b/Specs/Core/Matrix3Spec.js
@@ -392,8 +392,9 @@ describe("Core/Matrix3", function () {
   });
 
   it("fromRotationX works without a result parameter", function () {
-    var matrix = Matrix3.fromRotationX(0.0);
-    expect(matrix).toEqual(Matrix3.IDENTITY);
+    var expected = new Matrix3(1.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1.0, 0.0);
+    var matrix = Matrix3.fromRotationX(CesiumMath.toRadians(90.0));
+    expect(matrix).toEqualEpsilon(expected, CesiumMath.EPSILON15);
   });
 
   it("fromRotationX works with a result parameter", function () {
@@ -411,8 +412,9 @@ describe("Core/Matrix3", function () {
   });
 
   it("fromRotationY works without a result parameter", function () {
-    var matrix = Matrix3.fromRotationY(0.0);
-    expect(matrix).toEqual(Matrix3.IDENTITY);
+    var expected = new Matrix3(0.0, 0.0, 1.0, 0.0, 1.0, 0.0, -1.0, 0.0, 0.0);
+    var matrix = Matrix3.fromRotationY(CesiumMath.toRadians(90.0));
+    expect(matrix).toEqualEpsilon(expected, CesiumMath.EPSILON15);
   });
 
   it("fromRotationY works with a result parameter", function () {
@@ -430,8 +432,9 @@ describe("Core/Matrix3", function () {
   });
 
   it("fromRotationZ works without a result parameter", function () {
-    var matrix = Matrix3.fromRotationZ(0.0);
-    expect(matrix).toEqual(Matrix3.IDENTITY);
+    var expected = new Matrix3(0.0, -1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0);
+    var matrix = Matrix3.fromRotationZ(CesiumMath.toRadians(90.0));
+    expect(matrix).toEqualEpsilon(expected, CesiumMath.EPSILON15);
   });
 
   it("fromRotationZ works with a result parameter", function () {


### PR DESCRIPTION
Hi, I came across this randomly. It seems the signs of the sinAngle's in the result less branch of the Matrix3 fromRotation functions are swapped. 