### PR TITLE
Check if Image is defined in IonResource retry callback

### DIFF
--- a/Source/Core/IonResource.js
+++ b/Source/Core/IonResource.js
@@ -235,10 +235,8 @@ function retryCallback(that, error) {
   // requests(since Image failures can not provide a status code)
   if (
     !defined(error) ||
-    (error.statusCode !== 401 && !(error.target instanceof Image))(
-      error.statusCode !== 401 &&
-        !(imageDefined && error.target instanceof Image)
-    )
+    (error.statusCode !== 401 &&
+      !(imageDefined && error.target instanceof Image))
   ) {
     return when.resolve(false);
   }

--- a/Source/Core/IonResource.js
+++ b/Source/Core/IonResource.js
@@ -227,11 +227,18 @@ function retryCallback(that, error) {
   var ionRoot = defaultValue(that._ionRoot, that);
   var endpointResource = ionRoot._ionEndpointResource;
 
+  // Image is not available in worker threads, so this avoids
+  // a ReferenceError
+  var imageDefined = typeof Image !== "undefined";
+
   // We only want to retry in the case of invalid credentials (401) or image
   // requests(since Image failures can not provide a status code)
   if (
     !defined(error) ||
-    (error.statusCode !== 401 && !(error.target instanceof Image))
+    (error.statusCode !== 401 && !(error.target instanceof Image))(
+      error.statusCode !== 401 &&
+        !(imageDefined && error.target instanceof Image)
+    )
   ) {
     return when.resolve(false);
   }


### PR DESCRIPTION
This fixes a very specific edge case where the Ion resource token has expired and we need to fetch a new one from inside a worker.  `Image` isn't defined inside a worker, so it would cause a crash.