### PR TITLE
Added version property to MetadataSchema

### DIFF
--- a/Source/Scene/MetadataSchema.js
+++ b/Source/Scene/MetadataSchema.js
@@ -42,6 +42,7 @@ function MetadataSchema(schema) {
   this._enums = enums;
   this._name = schema.name;
   this._description = schema.description;
+  this._version = schema.version;
   this._extras = schema.extras;
   this._extensions = schema.extensions;
 }
@@ -100,6 +101,20 @@ Object.defineProperties(MetadataSchema.prototype, {
   description: {
     get: function () {
       return this._description;
+    },
+  },
+
+  /**
+   * The application-specific version of the schema.
+   *
+   * @memberof MetadataSchema.prototype
+   * @type {String}
+   * @readonly
+   * @private
+   */
+  version: {
+    get: function () {
+      return this._version;
     },
   },
 

--- a/Specs/Scene/MetadataSchemaSpec.js
+++ b/Specs/Scene/MetadataSchemaSpec.js
@@ -8,6 +8,7 @@ describe("Scene/MetadataSchema", function () {
     expect(schema.enums).toEqual({});
     expect(schema.name).toBeUndefined();
     expect(schema.description).toBeUndefined();
+    expect(schema.version).toBeUndefined();
     expect(schema.extras).toBeUndefined();
   });
 
@@ -91,6 +92,7 @@ describe("Scene/MetadataSchema", function () {
       },
       name: "My Schema",
       description: "My Schema Description",
+      version: "3.1.0",
       extras: extras,
       extensions: extensions,
     });
@@ -115,6 +117,7 @@ describe("Scene/MetadataSchema", function () {
 
     expect(schema.name).toBe("My Schema");
     expect(schema.description).toBe("My Schema Description");
+    expect(schema.version).toBe("3.1.0");
 
     expect(schema.extras).toBe(extras);
     expect(schema.extensions).toBe(extensions);


### PR DESCRIPTION
Added a `version` property to `MetadataSchema` to accompany spec changes for `3DTILES_metadata`.