### PR TITLE
Enable use of Cesium release package with Node.js

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ##### Fixes :wrench:
 
+- Fixed an issue that prevented use of the full CesiumJS zip release package in a Node.js application.
 - Fixed an issue where certain inputs to EllipsoidGeodesic would result in a surfaceDistance of NaN. [#9316](https://github.com/CesiumGS/cesium/pull/9316)
 
 ### 1.78 - 2021-02-01

--- a/gulpfile.cjs
+++ b/gulpfile.cjs
@@ -381,6 +381,7 @@ gulp.task(
         "Build/Cesium/**",
         "Build/CesiumUnminified/**",
         "Build/Documentation/**",
+        "Build/package.json",
       ],
       {
         base: ".",
@@ -397,6 +398,7 @@ gulp.task(
         "favicon.ico",
         "gulpfile.cjs",
         "server.cjs",
+        "index.cjs",
         "package.json",
         "LICENSE.md",
         "CHANGES.md",


### PR DESCRIPTION
If you unzipped the Cesium release package and pointed to it in a Node.js application, it would fail because of missing `index.cjs` and `Build/package.json`. This includes those files in the release zip so that everything works the same if you retrieved the package from the npm registry.

To test:

1. Run `makeZipFile` to generate a release zip in this branch.
2. Unzip it somewhere.
3. Stick the below in a new package.json. Change `Cesium-1.78` to whatever directory you unzipped it in

```json
{
  "name": "node-demo",
  "version": "1.0.0",
  "dependencies": {
    "cesium": "file:Cesium-1.78"
  }
}
```

4. Put the below `test.js` in the same directory as the package.json

```
const { defined } = require("cesium");
console.log(!!defined);
```

5. Run `npm install`

6. Run `node test.js` and it should print `true`.

If you run these same steps in master, the app will crash.