### PR TITLE
Remove deprecated Cesium3DTileset.url getter, quadratic easing function typos

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@
 - Removed `Cesium3DTileset.url`, which was deprecated in v1.78. Use `Cesium3DTileset.resource.url` to retrieve the url value.
 - Removed `EasingFunction.QUADRACTIC_IN`, which was deprecated in v1.77. Use `EasingFunction.QUADRATIC_IN`.
 - Removed `EasingFunction.QUADRACTIC_OUT`, which was deprecated in v1.77. Use `EasingFunction.QUADRATIC_OUT`.
-- Removed `EasingFunction.QUADRACTIC_IN_OUT`, which was deprecated in v1.77. Use `EasingFunction.QUADRATIC_IN_OUT`. 
+- Removed `EasingFunction.QUADRACTIC_IN_OUT`, which was deprecated in v1.77. Use `EasingFunction.QUADRATIC_IN_OUT`.
 
 ##### Fixes :wrench:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 
 ### 1.79 - 2021-03-01
 
+##### Breaking Changes :mega:
+
+- Removed `Cesium3DTileset.url`, which was deprecated in v1.78. Use `Cesium3DTileset.resource.url` to retrieve the url value.
+- Removed `EasingFunction.QUADRACTIC_IN`, which was deprecated in v1.77. Use `EasingFunction.QUADRATIC_IN`.
+- Removed `EasingFunction.QUADRACTIC_OUT`, which was deprecated in v1.77. Use `EasingFunction.QUADRATIC_OUT`.
+- Removed `EasingFunction.QUADRACTIC_IN_OUT`, which was deprecated in v1.77. Use `EasingFunction.QUADRATIC_IN_OUT`. 
+
 ##### Fixes :wrench:
 
 - Fixed an issue that prevented use of the full CesiumJS zip release package in a Node.js application.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,10 +4,10 @@
 
 ##### Breaking Changes :mega:
 
-- Removed `Cesium3DTileset.url`, which was deprecated in v1.78. Use `Cesium3DTileset.resource.url` to retrieve the url value.
-- Removed `EasingFunction.QUADRACTIC_IN`, which was deprecated in v1.77. Use `EasingFunction.QUADRATIC_IN`.
-- Removed `EasingFunction.QUADRACTIC_OUT`, which was deprecated in v1.77. Use `EasingFunction.QUADRATIC_OUT`.
-- Removed `EasingFunction.QUADRACTIC_IN_OUT`, which was deprecated in v1.77. Use `EasingFunction.QUADRATIC_IN_OUT`.
+- Removed `Cesium3DTileset.url`, which was deprecated in CesiumJS 1.78. Use `Cesium3DTileset.resource.url` to retrieve the url value.
+- Removed `EasingFunction.QUADRACTIC_IN`, which was deprecated in CesiumJS 1.77. Use `EasingFunction.QUADRATIC_IN`.
+- Removed `EasingFunction.QUADRACTIC_OUT`, which was deprecated in CesiumJS 1.77. Use `EasingFunction.QUADRATIC_OUT`.
+- Removed `EasingFunction.QUADRACTIC_IN_OUT`, which was deprecated in CesiumJS 1.77. Use `EasingFunction.QUADRATIC_IN_OUT`.
 
 ##### Fixes :wrench:
 
@@ -82,8 +82,8 @@
 
 ##### Breaking Changes :mega:
 
-- Removed `MapboxApi`, which was deprecated in v1.72. Pass your access token directly to the `MapboxImageryProvider` or `MapboxStyleImageryProvider` constructors.
-- Removed `BingMapsApi`, which was deprecated in v1.72. Pass your access key directly to the `BingMapsImageryProvider` or `BingMapsGeocoderService` constructors.
+- Removed `MapboxApi`, which was deprecated in CesiumJS 1.72. Pass your access token directly to the `MapboxImageryProvider` or `MapboxStyleImageryProvider` constructors.
+- Removed `BingMapsApi`, which was deprecated in CesiumJS 1.72. Pass your access key directly to the `BingMapsImageryProvider` or `BingMapsGeocoderService` constructors.
 
 ##### Additions :tada:
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -150,6 +150,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
   - [Erixen Cruz](https://github.com/ErixenCruz)
   - [Dzung Nguyen](https://github.com/dzungpng)
   - [Nithin Pranesh](https://github.com/nithinp7)
+  - [Alexander Gallegos](https://github.com/argallegos)
 - [Northrop Grumman](http://www.northropgrumman.com)
   - [Joseph Stein](https://github.com/nahgrin)
 - [EOX IT Services GmbH](https://eox.at)

--- a/Source/Core/EasingFunction.js
+++ b/Source/Core/EasingFunction.js
@@ -1,5 +1,4 @@
 import Tween from "../ThirdParty/Tween.js";
-import deprecationWarning from "./deprecationWarning.js";
 
 /**
  * Easing functions for use with TweenCollection.  These function are from

--- a/Source/Core/EasingFunction.js
+++ b/Source/Core/EasingFunction.js
@@ -238,57 +238,6 @@ var EasingFunction = {
   BOUNCE_IN_OUT: Tween.Easing.Bounce.InOut,
 };
 
-Object.defineProperties(EasingFunction, {
-  /**
-   * Quadratic in.
-   * @memberof EasingFunction
-   * @type {EasingFunction.Callback}
-   * @constant
-   * @deprecated This enum has been deprecated and will be removed in Cesium 1.79. Use {@link EasingFunction.QUADRATIC_IN} instead.
-   */
-  QUADRACTIC_IN: {
-    get: function () {
-      deprecationWarning(
-        "QUADRACTIC_IN",
-        "QUADRACTIC_IN is deprecated and will be removed in Cesium 1.79. Use QUADRATIC_IN instead."
-      );
-      return Tween.Easing.Quadratic.In;
-    },
-  },
-  /**
-   * Quadratic out.
-   * @memberof EasingFunction
-   * @type {EasingFunction.Callback}
-   * @constant
-   * @deprecated This enum has been deprecated and will be removed in Cesium 1.79. Use {@link EasingFunction.QUADRATIC_OUT} instead.
-   */
-  QUADRACTIC_OUT: {
-    get: function () {
-      deprecationWarning(
-        "QUADRACTIC_OUT",
-        "QUADRACTIC_OUT is deprecated and will be removed in Cesium 1.79. Use QUADRATIC_OUT instead."
-      );
-      return Tween.Easing.Quadratic.Out;
-    },
-  },
-  /**
-   * Quadratic in then out.
-   * @memberof EasingFunction
-   * @type {EasingFunction.Callback}
-   * @constant
-   * @deprecated This enum has been deprecated and will be removed in Cesium 1.79. Use {@link EasingFunction.QUADRATIC_IN_OUT} instead.
-   */
-  QUADRACTIC_IN_OUT: {
-    get: function () {
-      deprecationWarning(
-        "QUADRACTIC_IN_OUT",
-        "QUADRACTIC_IN_OUT is deprecated and will be removed in Cesium 1.79. Use QUADRATIC_IN_OUT instead."
-      );
-      return Tween.Easing.Quadratic.InOut;
-    },
-  },
-});
-
 /**
  * Function interface for implementing a custom easing function.
  * @callback EasingFunction.Callback

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1166,25 +1166,6 @@ Object.defineProperties(Cesium3DTileset.prototype, {
   },
 
   /**
-   * The url to a tileset JSON file.
-   *
-   * @memberof Cesium3DTileset.prototype
-   *
-   * @type {String}
-   * @readonly
-   * @deprecated
-   */
-  url: {
-    get: function () {
-      deprecationWarning(
-        "Cesium3DTileset.url",
-        "Cesium3DTileset.url has been deprecated and will be removed in CesiumJS 1.79.  Instead, use Cesium3DTileset.resource.url to retrieve the url value."
-      );
-      return this._url;
-    },
-  },
-
-  /**
    * The resource used to fetch the tileset JSON file
    *
    * @memberof Cesium3DTileset.prototype


### PR DESCRIPTION
Removed deprecated Cesium3DTileset.url getter - Fixes #9349.
Removed deprecated EasingFunction.js enums - Fixes #9268.