### PR TITLE
make the error message more detailed when the request fails 

### DIFF
--- a/Source/Core/TileProviderError.js
+++ b/Source/Core/TileProviderError.js
@@ -151,6 +151,7 @@ TileProviderError.handleError = function (
         '": ' +
         formatError(message)
     );
+    console.error(error);
   }
 
   if (error.retry && defined(retryFunction)) {


### PR DESCRIPTION
Fix for the issue #8313 .

I agree that there is not enough information on what happens when a tile fails to load.
This is also mentioned in #8921.

> Basically, when the provider fails during the initial load, it emits an error but contains no useful information to tell me what the error was or what I can do about it.

I'd like to tackle this problem, so I've create the draft of a pull request