### PR TITLE
fix bug of outline data process.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -285,3 +285,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Will Jadkowski](https://github.com/willjad)
 - [Mac Clayton](https://github.com/mclayton7)
 - [Ben Murphy](https://github.com/littlemurph)
+- [Kent Liu](https://github.com/bimangle)

--- a/Source/Scene/ModelOutlineLoader.js
+++ b/Source/Scene/ModelOutlineLoader.js
@@ -307,6 +307,7 @@ function addOutline(
         // Hackily update it, or else we'll end up creating the wrong type
         // of index buffer later.
         loadResources.indexBuffersToCreate._array.forEach(function (toCreate) {
+          if (toCreate === undefined) return;
           if (toCreate.id === triangleIndexAccessorGltf.bufferView) {
             toCreate.componentType = triangleIndexAccessorGltf.componentType;
           }


### PR DESCRIPTION
When working with outline data,  sometimes the 'loadResources.indexBuffersToCreate._array' values is all undefined,  cause an exception.