### PR TITLE
Basic support for EXT_feature_metadata

### DIFF
--- a/Source/Core/ComponentDatatype.js
+++ b/Source/Core/ComponentDatatype.js
@@ -332,37 +332,4 @@ ComponentDatatype.fromName = function (name) {
   }
 };
 
-/**
- * Get the name from a ComponentDatatype.
- *
- * @param {ComponentDatatype} componentDatatype The component data type.
- * @returns {String} Name of the ComponentDatatype.
- *
- * @exception {DeveloperError} componentDatatype is not a valid value.
- */
-ComponentDatatype.getName = function (componentDatatype) {
-  switch (componentDatatype) {
-    case ComponentDatatype.BYTE:
-      return "BYTE";
-    case ComponentDatatype.UNSIGNED_BYTE:
-      return "UNSIGNED_BYTE";
-    case ComponentDatatype.SHORT:
-      return "SHORT";
-    case ComponentDatatype.UNSIGNED_SHORT:
-      return "UNSIGNED_SHORT";
-    case ComponentDatatype.INT:
-      return "INT";
-    case ComponentDatatype.UNSIGNED_INT:
-      return "UNSIGNED_INT";
-    case ComponentDatatype.FLOAT:
-      return "FLOAT";
-    case ComponentDatatype.DOUBLE:
-      return "DOUBLE";
-    //>>includeStart('debug', pragmas.debug);
-    default:
-      throw new DeveloperError("componentDatatype is not a valid value.");
-    //>>includeEnd('debug');
-  }
-};
-
 export default Object.freeze(ComponentDatatype);

--- a/Source/Core/ComponentDatatype.js
+++ b/Source/Core/ComponentDatatype.js
@@ -331,4 +331,38 @@ ComponentDatatype.fromName = function (name) {
     //>>includeEnd('debug');
   }
 };
+
+/**
+ * Get the name from a ComponentDatatype.
+ *
+ * @param {ComponentDatatype} componentDatatype The component data type.
+ * @returns {String} Name of the ComponentDatatype.
+ *
+ * @exception {DeveloperError} componentDatatype is not a valid value.
+ */
+ComponentDatatype.getName = function (componentDatatype) {
+  switch (componentDatatype) {
+    case ComponentDatatype.BYTE:
+      return "BYTE";
+    case ComponentDatatype.UNSIGNED_BYTE:
+      return "UNSIGNED_BYTE";
+    case ComponentDatatype.SHORT:
+      return "SHORT";
+    case ComponentDatatype.UNSIGNED_SHORT:
+      return "UNSIGNED_SHORT";
+    case ComponentDatatype.INT:
+      return "INT";
+    case ComponentDatatype.UNSIGNED_INT:
+      return "UNSIGNED_INT";
+    case ComponentDatatype.FLOAT:
+      return "FLOAT";
+    case ComponentDatatype.DOUBLE:
+      return "DOUBLE";
+    //>>includeStart('debug', pragmas.debug);
+    default:
+      throw new DeveloperError("componentDatatype is not a valid value.");
+    //>>includeEnd('debug');
+  }
+};
+
 export default Object.freeze(ComponentDatatype);

--- a/Source/Core/ComponentDatatype.js
+++ b/Source/Core/ComponentDatatype.js
@@ -331,5 +331,4 @@ ComponentDatatype.fromName = function (name) {
     //>>includeEnd('debug');
   }
 };
-
 export default Object.freeze(ComponentDatatype);

--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -71,7 +71,7 @@ Object.defineProperties(Batched3DModel3DTileContent.prototype, {
 
   pointsLength: {
     get: function () {
-      return 0;
+      return this._model.pointsLength;
     },
   },
 

--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -455,7 +455,7 @@ function initialize(content, arrayBuffer, byteOffset) {
       ),
       uniformMapLoaded: batchTable.getUniformMapCallback(),
       pickIdLoaded: getPickIdCallback(content),
-      classificationType: tileset._classificationType,
+      classificationType: tileset.classificationType,
       batchTable: batchTable,
     });
   }
@@ -520,36 +520,40 @@ Batched3DModel3DTileContent.prototype.applyStyle = function (style) {
 Batched3DModel3DTileContent.prototype.update = function (tileset, frameState) {
   var commandStart = frameState.commandList.length;
 
+  var model = this._model;
+  var tile = this._tile;
+  var batchTable = this._batchTable;
+
   // In the PROCESSING state we may be calling update() to move forward
   // the content's resource loading.  In the READY state, it will
   // actually generate commands.
-  this._batchTable.update(tileset, frameState);
+  batchTable.update(tileset, frameState);
 
   this._contentModelMatrix = Matrix4.multiply(
-    this._tile.computedTransform,
+    tile.computedTransform,
     this._rtcCenterTransform,
     this._contentModelMatrix
   );
-  this._model.modelMatrix = this._contentModelMatrix;
+  model.modelMatrix = this._contentModelMatrix;
 
-  this._model.shadows = this._tileset.shadows;
-  this._model.imageBasedLightingFactor = this._tileset.imageBasedLightingFactor;
-  this._model.lightColor = this._tileset.lightColor;
-  this._model.luminanceAtZenith = this._tileset.luminanceAtZenith;
-  this._model.sphericalHarmonicCoefficients = this._tileset.sphericalHarmonicCoefficients;
-  this._model.specularEnvironmentMaps = this._tileset.specularEnvironmentMaps;
-  this._model.backFaceCulling = this._tileset.backFaceCulling;
-  this._model.debugWireframe = this._tileset.debugWireframe;
+  model.shadows = tileset.shadows;
+  model.imageBasedLightingFactor = tileset.imageBasedLightingFactor;
+  model.lightColor = tileset.lightColor;
+  model.luminanceAtZenith = tileset.luminanceAtZenith;
+  model.sphericalHarmonicCoefficients = tileset.sphericalHarmonicCoefficients;
+  model.specularEnvironmentMaps = tileset.specularEnvironmentMaps;
+  model.backFaceCulling = tileset.backFaceCulling;
+  model.debugWireframe = tileset.debugWireframe;
 
   // Update clipping planes
-  var tilesetClippingPlanes = this._tileset.clippingPlanes;
-  this._model.referenceMatrix = this._tileset.clippingPlanesOriginMatrix;
-  if (defined(tilesetClippingPlanes) && this._tile.clippingPlanesDirty) {
+  var tilesetClippingPlanes = tileset.clippingPlanes;
+  model.referenceMatrix = tileset.clippingPlanesOriginMatrix;
+  if (defined(tilesetClippingPlanes) && tile.clippingPlanesDirty) {
     // Dereference the clipping planes from the model if they are irrelevant.
     // Link/Dereference directly to avoid ownership checks.
     // This will also trigger synchronous shader regeneration to remove or add the clipping plane and color blending code.
-    this._model._clippingPlanes =
-      tilesetClippingPlanes.enabled && this._tile._isClipped
+    model._clippingPlanes =
+      tilesetClippingPlanes.enabled && tile._isClipped
         ? tilesetClippingPlanes
         : undefined;
   }
@@ -558,13 +562,13 @@ Batched3DModel3DTileContent.prototype.update = function (tileset, frameState) {
   // ClippingPlaneCollection that gives this tile the same clipping status, update the model to use the new ClippingPlaneCollection.
   if (
     defined(tilesetClippingPlanes) &&
-    defined(this._model._clippingPlanes) &&
-    this._model._clippingPlanes !== tilesetClippingPlanes
+    defined(model._clippingPlanes) &&
+    model._clippingPlanes !== tilesetClippingPlanes
   ) {
-    this._model._clippingPlanes = tilesetClippingPlanes;
+    model._clippingPlanes = tilesetClippingPlanes;
   }
 
-  this._model.update(frameState);
+  model.update(frameState);
 
   // If any commands were pushed, add derived commands
   var commandEnd = frameState.commandList.length;
@@ -573,7 +577,7 @@ Batched3DModel3DTileContent.prototype.update = function (tileset, frameState) {
     (frameState.passes.render || frameState.passes.pick) &&
     !defined(tileset.classificationType)
   ) {
-    this._batchTable.addDerivedCommands(frameState, commandStart);
+    batchTable.addDerivedCommands(frameState, commandStart);
   }
 };
 

--- a/Source/Scene/Gltf3DTileContent.js
+++ b/Source/Scene/Gltf3DTileContent.js
@@ -440,7 +440,7 @@ function initialize(content, gltf) {
       ),
       uniformMapLoaded: batchTable.getUniformMapCallback(),
       pickIdLoaded: getPickIdCallback(content),
-      classificationType: tileset._classificationType,
+      classificationType: tileset.classificationType,
       batchTable: batchTable,
     });
   }
@@ -502,30 +502,34 @@ Gltf3DTileContent.prototype.applyStyle = function (style) {
 Gltf3DTileContent.prototype.update = function (tileset, frameState) {
   var commandStart = frameState.commandList.length;
 
+  var model = this._model;
+  var tile = this._tile;
+  var batchTable = this._batchTable;
+
   // In the PROCESSING state we may be calling update() to move forward
   // the content's resource loading.  In the READY state, it will
   // actually generate commands.
-  this._batchTable.update(tileset, frameState);
+  batchTable.update(tileset, frameState);
 
-  this._model.modelMatrix = this._tile.computedTransform;
-  this._model.shadows = this._tileset.shadows;
-  this._model.imageBasedLightingFactor = this._tileset.imageBasedLightingFactor;
-  this._model.lightColor = this._tileset.lightColor;
-  this._model.luminanceAtZenith = this._tileset.luminanceAtZenith;
-  this._model.sphericalHarmonicCoefficients = this._tileset.sphericalHarmonicCoefficients;
-  this._model.specularEnvironmentMaps = this._tileset.specularEnvironmentMaps;
-  this._model.backFaceCulling = this._tileset.backFaceCulling;
-  this._model.debugWireframe = this._tileset.debugWireframe;
+  model.modelMatrix = tile.computedTransform;
+  model.shadows = tileset.shadows;
+  model.imageBasedLightingFactor = tileset.imageBasedLightingFactor;
+  model.lightColor = tileset.lightColor;
+  model.luminanceAtZenith = tileset.luminanceAtZenith;
+  model.sphericalHarmonicCoefficients = tileset.sphericalHarmonicCoefficients;
+  model.specularEnvironmentMaps = tileset.specularEnvironmentMaps;
+  model.backFaceCulling = tileset.backFaceCulling;
+  model.debugWireframe = tileset.debugWireframe;
 
   // Update clipping planes
-  var tilesetClippingPlanes = this._tileset.clippingPlanes;
-  this._model.referenceMatrix = this._tileset.clippingPlanesOriginMatrix;
-  if (defined(tilesetClippingPlanes) && this._tile.clippingPlanesDirty) {
+  var tilesetClippingPlanes = tileset.clippingPlanes;
+  model.referenceMatrix = tileset.clippingPlanesOriginMatrix;
+  if (defined(tilesetClippingPlanes) && tile.clippingPlanesDirty) {
     // Dereference the clipping planes from the model if they are irrelevant.
     // Link/Dereference directly to avoid ownership checks.
     // This will also trigger synchronous shader regeneration to remove or add the clipping plane and color blending code.
-    this._model._clippingPlanes =
-      tilesetClippingPlanes.enabled && this._tile._isClipped
+    model._clippingPlanes =
+      tilesetClippingPlanes.enabled && tile._isClipped
         ? tilesetClippingPlanes
         : undefined;
   }
@@ -534,13 +538,13 @@ Gltf3DTileContent.prototype.update = function (tileset, frameState) {
   // ClippingPlaneCollection that gives this tile the same clipping status, update the model to use the new ClippingPlaneCollection.
   if (
     defined(tilesetClippingPlanes) &&
-    defined(this._model._clippingPlanes) &&
-    this._model._clippingPlanes !== tilesetClippingPlanes
+    defined(model._clippingPlanes) &&
+    model._clippingPlanes !== tilesetClippingPlanes
   ) {
-    this._model._clippingPlanes = tilesetClippingPlanes;
+    model._clippingPlanes = tilesetClippingPlanes;
   }
 
-  this._model.update(frameState);
+  model.update(frameState);
 
   // If any commands were pushed, add derived commands
   var commandEnd = frameState.commandList.length;
@@ -549,7 +553,7 @@ Gltf3DTileContent.prototype.update = function (tileset, frameState) {
     (frameState.passes.render || frameState.passes.pick) &&
     !defined(tileset.classificationType)
   ) {
-    this._batchTable.addDerivedCommands(frameState, commandStart);
+    batchTable.addDerivedCommands(frameState, commandStart);
   }
 };
 

--- a/Source/Scene/Gltf3DTileContent.js
+++ b/Source/Scene/Gltf3DTileContent.js
@@ -212,10 +212,31 @@ function createBatchTable(content, gltf, colorChangedCallback) {
     gltf.buffers.length > 0 &&
     defined(gltf.bufferViews)
   ) {
+    var i;
+    var j;
+    var hasFeatureIds = false;
+    var meshes = gltf.meshes;
+    if (defined(meshes)) {
+      var meshesLength = meshes.length;
+      for (i = 0; i < meshesLength; ++i) {
+        var mesh = gltf.meshes[i];
+        var primitives = mesh.primitives;
+        var primitivesLength = primitives.length;
+        for (j = 0; j < primitivesLength; ++j) {
+          if (defined(primitives[j].attributes._FEATURE_ID_0)) {
+            hasFeatureIds = true;
+          }
+        }
+      }
+    }
+
+    if (!hasFeatureIds) {
+      return;
+    }
+
     var buffer = gltf.buffers[0].extras._pipeline.source;
     var bufferViewsLength = gltf.bufferViews.length;
     var bufferViews = {};
-    var i;
 
     for (i = 0; i < bufferViewsLength; ++i) {
       var bufferView = gltf.bufferViews[i];

--- a/Source/Scene/Gltf3DTileContent.js
+++ b/Source/Scene/Gltf3DTileContent.js
@@ -1,14 +1,25 @@
 import Color from "../Core/Color.js";
+import ComponentDatatype from "../Core/ComponentDatatype.js";
+import defaultValue from "../Core/defaultValue.js";
 import defined from "../Core/defined.js";
 import destroyObject from "../Core/destroyObject.js";
+import DeveloperError from "../Core/DeveloperError.js";
 import RequestType from "../Core/RequestType.js";
 import Pass from "../Renderer/Pass.js";
+import hasExtension from "../ThirdParty/GltfPipeline/hasExtension.js";
+import parseGlb from "../ThirdParty/GltfPipeline/parseGlb.js";
 import Axis from "./Axis.js";
+import Cesium3DTileBatchTable from "./Cesium3DTileBatchTable.js";
+import Cesium3DTileFeature from "./Cesium3DTileFeature.js";
+import ClassificationModel from "./ClassificationModel.js";
+import MetadataGltfExtension from "./MetadataGltfExtension.js";
+import MetadataType from "./MetadataType.js";
 import Model from "./Model.js";
 import ModelAnimationLoop from "./ModelAnimationLoop.js";
+import ModelUtility from "./ModelUtility.js";
 
 /**
- * Represents the contents of a glTF or glb tile in a {@link https://github.com/CesiumGS/3d-tiles/tree/master/specification|3D Tiles} tileset using the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_content_gltf|3DTILES_content_gltf} extension.
+ * Represents the contents of a glTF or glb tile in a {@link https://github.com/CesiumGS/3d-tiles/tree/master/specification|3D Tiles} tileset using the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_content_gltf/0.0.0|3DTILES_content_gltf} extension.
  * <p>
  * Implements the {@link Cesium3DTileContent} interface.
  * </p>
@@ -23,6 +34,12 @@ function Gltf3DTileContent(tileset, tile, resource, gltf) {
   this._tile = tile;
   this._resource = resource;
   this._model = undefined;
+  this._batchTable = undefined;
+  this._features = undefined;
+
+  // Populate from gltf when available
+  this._batchIdAttributeName = undefined;
+  this._diffuseAttributeOrUniformName = {};
 
   this.featurePropertiesDirty = false;
 
@@ -32,7 +49,7 @@ function Gltf3DTileContent(tileset, tile, resource, gltf) {
 Object.defineProperties(Gltf3DTileContent.prototype, {
   featuresLength: {
     get: function () {
-      return 0;
+      return this._batchTable.featuresLength;
     },
   },
 
@@ -62,7 +79,7 @@ Object.defineProperties(Gltf3DTileContent.prototype, {
 
   batchTableByteLength: {
     get: function () {
-      return 0;
+      return this._batchTable.memorySizeInBytes;
     },
   },
 
@@ -98,97 +115,370 @@ Object.defineProperties(Gltf3DTileContent.prototype, {
 
   batchTable: {
     get: function () {
-      return undefined;
+      return this._batchTable;
     },
   },
 });
+
+function getVertexShaderCallback(content) {
+  return function (vs, programId) {
+    var batchTable = content._batchTable;
+    var handleTranslucent = !defined(content._tileset.classificationType);
+
+    var gltf = content._model.gltf;
+    if (defined(gltf)) {
+      content._batchIdAttributeName = ModelUtility.getAttributeOrUniformBySemantic(
+        gltf,
+        "_FEATURE_ID_0"
+      );
+      content._diffuseAttributeOrUniformName[
+        programId
+      ] = ModelUtility.getDiffuseAttributeOrUniform(gltf, programId);
+    }
+
+    var callback = batchTable.getVertexShaderCallback(
+      handleTranslucent,
+      content._batchIdAttributeName,
+      content._diffuseAttributeOrUniformName[programId]
+    );
+    return defined(callback) ? callback(vs) : vs;
+  };
+}
+
+function getFragmentShaderCallback(content) {
+  return function (fs, programId) {
+    var batchTable = content._batchTable;
+    var handleTranslucent = !defined(content._tileset.classificationType);
+
+    var gltf = content._model.gltf;
+    if (defined(gltf)) {
+      content._diffuseAttributeOrUniformName[
+        programId
+      ] = ModelUtility.getDiffuseAttributeOrUniform(gltf, programId);
+    }
+    var callback = batchTable.getFragmentShaderCallback(
+      handleTranslucent,
+      content._diffuseAttributeOrUniformName[programId]
+    );
+    return defined(callback) ? callback(fs) : fs;
+  };
+}
+
+function getPickIdCallback(content) {
+  return function () {
+    return content._batchTable.getPickId();
+  };
+}
+
+function getClassificationFragmentShaderCallback(content) {
+  return function (fs) {
+    var batchTable = content._batchTable;
+    var callback = batchTable.getClassificationFragmentShaderCallback();
+    return defined(callback) ? callback(fs) : fs;
+  };
+}
+
+function createColorChangedCallback(content) {
+  return function (batchId, color) {
+    content._model.updateCommands(batchId, color);
+  };
+}
+
+function getComponentDatatype(type) {
+  switch (type) {
+    case MetadataType.INT8:
+      return ComponentDatatype.BYTE;
+    case MetadataType.UINT8:
+      return ComponentDatatype.UNSIGNED_BYTE;
+    case MetadataType.INT16:
+      return ComponentDatatype.SHORT;
+    case MetadataType.UINT16:
+      return ComponentDatatype.UNSIGNED_SHORT;
+    case MetadataType.INT32:
+      return ComponentDatatype.INT;
+    case MetadataType.UINT32:
+      return ComponentDatatype.UNSIGNED_INT;
+    case MetadataType.FLOAT32:
+      return ComponentDatatype.FLOAT;
+    case MetadataType.FLOAT64:
+      return ComponentDatatype.DOUBLE;
+  }
+}
+
+function createBatchTable(content, gltf, colorChangedCallback) {
+  if (
+    hasExtension(gltf, "EXT_feature_metadata") &&
+    defined(gltf.buffers) &&
+    gltf.buffers.length > 0 &&
+    defined(gltf.bufferViews)
+  ) {
+    var buffer = gltf.buffers[0].extras._pipeline.source;
+    var bufferViewsLength = gltf.bufferViews.length;
+    var bufferViews = {};
+    var i;
+
+    for (i = 0; i < bufferViewsLength; ++i) {
+      var bufferView = gltf.bufferViews[i];
+      var byteOffset = defaultValue(bufferView.byteOffset, 0);
+      var byteLength = bufferView.byteLength;
+      var bufferViewData = new Uint8Array(
+        buffer.buffer,
+        buffer.byteOffset + byteOffset,
+        byteLength
+      );
+      bufferViews[i] = bufferViewData;
+    }
+
+    var extension = gltf.extensions.EXT_feature_metadata;
+    var metadata = new MetadataGltfExtension({
+      extension: extension,
+      bufferViews: bufferViews,
+    });
+
+    var featureTables = metadata.featureTables;
+    var featureTableIds = Object.keys(featureTables);
+    if (featureTableIds.length === 0) {
+      return;
+    }
+
+    var featureTable = featureTables[featureTableIds[0]];
+    if (defined(featureTable.class)) {
+      var count = featureTable.count;
+      var batchTableJson = {};
+      var batchTableBinary;
+      var classProperties = featureTable.class.properties;
+      for (var propertyId in classProperties) {
+        if (classProperties.hasOwnProperty(propertyId)) {
+          var property = featureTable.properties[propertyId];
+          var classProperty = classProperties[propertyId];
+          var type = classProperty.type;
+          var valueType = classProperty.valueType;
+          var batchTableBinaryType;
+          if (type === MetadataType.ARRAY) {
+            var componentCount = classProperty.componentCount;
+            if (componentCount === 2) {
+              batchTableBinaryType = "VEC2";
+            } else if (componentCount === 3) {
+              batchTableBinaryType = "VEC3";
+            } else if (componentCount === 4) {
+              batchTableBinaryType = "VEC4";
+            }
+          } else {
+            batchTableBinaryType = "SCALAR";
+          }
+
+          var componentDatatype = getComponentDatatype(valueType);
+
+          if (
+            defined(componentDatatype) &&
+            defined(batchTableBinaryType) &&
+            defined(property) // May be undefined if the property is optional
+          ) {
+            var typedArray = property._values.typedArray; // TODO: avoid private member access
+            batchTableJson[propertyId] = {
+              byteOffset: typedArray.byteOffset,
+              componentType: ComponentDatatype.getName(componentDatatype),
+              type: batchTableBinaryType,
+            };
+            batchTableBinary = new Uint8Array(buffer.buffer);
+          } else {
+            var values = new Array(count);
+            for (i = 0; i < count; ++i) {
+              values[i] = featureTable.getProperty(i, propertyId);
+            }
+            batchTableJson[propertyId] = values;
+          }
+        }
+      }
+      return new Cesium3DTileBatchTable(
+        content,
+        count,
+        batchTableJson,
+        batchTableBinary,
+        colorChangedCallback
+      );
+    }
+  }
+}
 
 function initialize(content, gltf) {
   var tileset = content._tileset;
   var tile = content._tile;
   var resource = content._resource;
 
+  if (gltf instanceof Uint8Array) {
+    gltf = parseGlb(gltf);
+  }
+
+  var colorChangedCallback;
+  if (defined(tileset.classificationType)) {
+    colorChangedCallback = createColorChangedCallback(content);
+  }
+
+  // TODO: many caveats right now
+  // * Only works with glb models with a single buffer
+  // * Does not work with schemaUri
+  // * Does not work with multiple feature tables
+  // * Only works with _FEATURE_ID_0
+  // * Does not support feature ID textures
+  // * Does not support feature textures
+  var batchTable = createBatchTable(content, gltf, colorChangedCallback);
+
+  if (!defined(batchTable)) {
+    batchTable = new Cesium3DTileBatchTable(
+      content,
+      0,
+      {},
+      undefined,
+      colorChangedCallback
+    );
+  }
+
+  content._batchTable = batchTable;
+
   var pickObject = {
     content: content,
     primitive: tileset,
   };
 
-  content._model = new Model({
-    gltf: gltf,
-    cull: false, // The model is already culled by 3D Tiles
-    releaseGltfJson: true, // Models are unique and will not benefit from caching so save memory
-    opaquePass: Pass.CESIUM_3D_TILE, // Draw opaque portions of the model during the 3D Tiles pass
-    basePath: resource,
-    requestType: RequestType.TILES3D,
-    modelMatrix: tile.computedTransform,
-    upAxis: Axis.Y,
-    forwardAxis: Axis.X,
-    shadows: tileset.shadows,
-    debugWireframe: tileset.debugWireframe,
-    incrementallyLoadTextures: false,
-    pickObject: pickObject,
-    imageBasedLightingFactor: tileset.imageBasedLightingFactor,
-    lightColor: tileset.lightColor,
-    luminanceAtZenith: tileset.luminanceAtZenith,
-    sphericalHarmonicCoefficients: tileset.sphericalHarmonicCoefficients,
-    specularEnvironmentMaps: tileset.specularEnvironmentMaps,
-    backFaceCulling: tileset.backFaceCulling,
-  });
-
-  content._model.readyPromise.then(function (model) {
-    model.activeAnimations.addAll({
-      loop: ModelAnimationLoop.REPEAT,
+  if (!defined(tileset.classificationType)) {
+    // PERFORMANCE_IDEA: patch the shader on demand, e.g., the first time show/color changes.
+    // The pick shader still needs to be patched.
+    content._model = new Model({
+      gltf: gltf,
+      cull: false, // The model is already culled by 3D Tiles
+      releaseGltfJson: true, // Models are unique and will not benefit from caching so save memory
+      opaquePass: Pass.CESIUM_3D_TILE, // Draw opaque portions of the model during the 3D Tiles pass
+      basePath: resource,
+      requestType: RequestType.TILES3D,
+      modelMatrix: tile.computedTransform,
+      upAxis: tileset._gltfUpAxis,
+      forwardAxis: Axis.X,
+      shadows: tileset.shadows,
+      debugWireframe: tileset.debugWireframe,
+      incrementallyLoadTextures: false,
+      vertexShaderLoaded: getVertexShaderCallback(content),
+      fragmentShaderLoaded: getFragmentShaderCallback(content),
+      uniformMapLoaded: batchTable.getUniformMapCallback(),
+      pickIdLoaded: getPickIdCallback(content),
+      addBatchIdToGeneratedShaders: batchTable.featuresLength > 0, // If the batch table has values in it, generated shaders will need a batchId attribute
+      pickObject: pickObject,
+      imageBasedLightingFactor: tileset.imageBasedLightingFactor,
+      lightColor: tileset.lightColor,
+      luminanceAtZenith: tileset.luminanceAtZenith,
+      sphericalHarmonicCoefficients: tileset.sphericalHarmonicCoefficients,
+      specularEnvironmentMaps: tileset.specularEnvironmentMaps,
+      backFaceCulling: tileset.backFaceCulling,
     });
-  });
+    content._model.readyPromise.then(function (model) {
+      model.activeAnimations.addAll({
+        loop: ModelAnimationLoop.REPEAT,
+      });
+    });
+  } else {
+    // This transcodes glTF to an internal representation for geometry so we can take advantage of the re-batching of vector data.
+    // For a list of limitations on the input glTF, see the documentation for classificationType of Cesium3DTileset.
+    content._model = new ClassificationModel({
+      gltf: gltf,
+      cull: false, // The model is already culled by 3D Tiles
+      basePath: resource,
+      requestType: RequestType.TILES3D,
+      modelMatrix: tile.computedTransform,
+      upAxis: tileset._gltfUpAxis,
+      forwardAxis: Axis.X,
+      debugWireframe: tileset.debugWireframe,
+      vertexShaderLoaded: getVertexShaderCallback(content),
+      classificationShaderLoaded: getClassificationFragmentShaderCallback(
+        content
+      ),
+      uniformMapLoaded: batchTable.getUniformMapCallback(),
+      pickIdLoaded: getPickIdCallback(content),
+      classificationType: tileset._classificationType,
+      batchTable: batchTable,
+    });
+  }
+}
+
+function createFeatures(content) {
+  var featuresLength = content.featuresLength;
+  if (!defined(content._features) && featuresLength > 0) {
+    var features = new Array(featuresLength);
+    for (var i = 0; i < featuresLength; ++i) {
+      features[i] = new Cesium3DTileFeature(content, i);
+    }
+    content._features = features;
+  }
 }
 
 Gltf3DTileContent.prototype.hasProperty = function (batchId, name) {
-  return false;
+  return this._batchTable.hasProperty(batchId, name);
 };
 
 Gltf3DTileContent.prototype.getFeature = function (batchId) {
-  return undefined;
+  //>>includeStart('debug', pragmas.debug);
+  var featuresLength = this.featuresLength;
+  if (!defined(batchId) || batchId < 0 || batchId >= featuresLength) {
+    throw new DeveloperError(
+      "batchId is required and between zero and featuresLength - 1 (" +
+        (featuresLength - 1) +
+        ")."
+    );
+  }
+  //>>includeEnd('debug');
+
+  createFeatures(this);
+  return this._features[batchId];
 };
 
 Gltf3DTileContent.prototype.applyDebugSettings = function (enabled, color) {
-  this._model.color = color;
+  color = enabled ? color : Color.WHITE;
+  if (this.featuresLength === 0) {
+    this._model.color = color;
+  } else {
+    this._batchTable.setAllColor(color);
+  }
 };
 
 Gltf3DTileContent.prototype.applyStyle = function (style) {
-  var hasColorStyle = defined(style) && defined(style.color);
-  var hasShowStyle = defined(style) && defined(style.show);
-  this._model.color = hasColorStyle
-    ? style.color.evaluateColor(undefined, this._model.color)
-    : Color.clone(Color.WHITE, this._model.color);
-  this._model.show = hasShowStyle ? style.show.evaluate(undefined) : true;
+  if (this.featuresLength === 0) {
+    var hasColorStyle = defined(style) && defined(style.color);
+    var hasShowStyle = defined(style) && defined(style.show);
+    this._model.color = hasColorStyle
+      ? style.color.evaluateColor(undefined, this._model.color)
+      : Color.clone(Color.WHITE, this._model.color);
+    this._model.show = hasShowStyle ? style.show.evaluate(undefined) : true;
+  } else {
+    this._batchTable.applyStyle(style);
+  }
 };
 
 Gltf3DTileContent.prototype.update = function (tileset, frameState) {
+  var commandStart = frameState.commandList.length;
+
   // In the PROCESSING state we may be calling update() to move forward
   // the content's resource loading.  In the READY state, it will
   // actually generate commands.
-  var model = this._model;
-  var tile = this._tile;
+  this._batchTable.update(tileset, frameState);
 
-  model.modelMatrix = tile.computedTransform;
-  model.shadows = tileset.shadows;
-  model.imageBasedLightingFactor = tileset.imageBasedLightingFactor;
-  model.lightColor = tileset.lightColor;
-  model.luminanceAtZenith = tileset.luminanceAtZenith;
-  model.sphericalHarmonicCoefficients = tileset.sphericalHarmonicCoefficients;
-  model.specularEnvironmentMaps = tileset.specularEnvironmentMaps;
-  model.backFaceCulling = tileset.backFaceCulling;
-  model.debugWireframe = tileset.debugWireframe;
+  this._model.modelMatrix = this._tile.computedTransform;
+  this._model.shadows = this._tileset.shadows;
+  this._model.imageBasedLightingFactor = this._tileset.imageBasedLightingFactor;
+  this._model.lightColor = this._tileset.lightColor;
+  this._model.luminanceAtZenith = this._tileset.luminanceAtZenith;
+  this._model.sphericalHarmonicCoefficients = this._tileset.sphericalHarmonicCoefficients;
+  this._model.specularEnvironmentMaps = this._tileset.specularEnvironmentMaps;
+  this._model.backFaceCulling = this._tileset.backFaceCulling;
+  this._model.debugWireframe = this._tileset.debugWireframe;
 
   // Update clipping planes
-  var tilesetClippingPlanes = tileset.clippingPlanes;
-  model.clippingPlanesOriginMatrix = tileset.clippingPlanesOriginMatrix;
-  if (defined(tilesetClippingPlanes) && tile.clippingPlanesDirty) {
+  var tilesetClippingPlanes = this._tileset.clippingPlanes;
+  this._model.referenceMatrix = this._tileset.clippingPlanesOriginMatrix;
+  if (defined(tilesetClippingPlanes) && this._tile.clippingPlanesDirty) {
     // Dereference the clipping planes from the model if they are irrelevant.
     // Link/Dereference directly to avoid ownership checks.
     // This will also trigger synchronous shader regeneration to remove or add the clipping plane and color blending code.
-    model._clippingPlanes =
-      tilesetClippingPlanes.enabled && tile._isClipped
+    this._model._clippingPlanes =
+      tilesetClippingPlanes.enabled && this._tile._isClipped
         ? tilesetClippingPlanes
         : undefined;
   }
@@ -197,13 +487,23 @@ Gltf3DTileContent.prototype.update = function (tileset, frameState) {
   // ClippingPlaneCollection that gives this tile the same clipping status, update the model to use the new ClippingPlaneCollection.
   if (
     defined(tilesetClippingPlanes) &&
-    defined(model._clippingPlanes) &&
-    model._clippingPlanes !== tilesetClippingPlanes
+    defined(this._model._clippingPlanes) &&
+    this._model._clippingPlanes !== tilesetClippingPlanes
   ) {
-    model._clippingPlanes = tilesetClippingPlanes;
+    this._model._clippingPlanes = tilesetClippingPlanes;
   }
 
-  model.update(frameState);
+  this._model.update(frameState);
+
+  // If any commands were pushed, add derived commands
+  var commandEnd = frameState.commandList.length;
+  if (
+    commandStart < commandEnd &&
+    (frameState.passes.render || frameState.passes.pick) &&
+    !defined(tileset.classificationType)
+  ) {
+    this._batchTable.addDerivedCommands(frameState, commandStart);
+  }
 };
 
 Gltf3DTileContent.prototype.isDestroyed = function () {
@@ -212,6 +512,7 @@ Gltf3DTileContent.prototype.isDestroyed = function () {
 
 Gltf3DTileContent.prototype.destroy = function () {
   this._model = this._model && this._model.destroy();
+  this._batchTable = this._batchTable && this._batchTable.destroy();
   return destroyObject(this);
 };
 

--- a/Source/Scene/MetadataClassProperty.js
+++ b/Source/Scene/MetadataClassProperty.js
@@ -186,10 +186,10 @@ Object.defineProperties(MetadataClassProperty.prototype, {
   },
 
   /**
-   * An array storing the maximum value of each component. Only defined when type or componentType is a numeric type.
+   * A number or an array of numbers storing the maximum allowable value of this property. Only defined when type or componentType is a numeric type.
    *
    * @memberof MetadataClassProperty.prototype
-   * @type {Number[]}
+   * @type {Number|Number[]}
    * @readonly
    * @private
    */
@@ -200,10 +200,10 @@ Object.defineProperties(MetadataClassProperty.prototype, {
   },
 
   /**
-   * An array storing the minimum value of each component. Only defined when type or componentType is a numeric type.
+   * A number or an array of numbers storing the minimum allowable value of this property. Only defined when type or componentType is a numeric type.
    *
    * @memberof MetadataClassProperty.prototype
-   * @type {Number[]}
+   * @type {Number|Number[]}
    * @readonly
    * @private
    */

--- a/Source/Scene/MetadataGltfExtension.js
+++ b/Source/Scene/MetadataGltfExtension.js
@@ -1,0 +1,149 @@
+import Check from "../Core/Check.js";
+import defaultValue from "../Core/defaultValue.js";
+import defined from "../Core/defined.js";
+import MetadataSchema from "./MetadataSchema.js";
+import MetadataTable from "./MetadataTable.js";
+
+/**
+ * An object containing metadata about a glTF model.
+ * <p>
+ * See the {@link https://github.com/CesiumGS/glTF/tree/master/extensions/2.0/Vendor/EXT_feature_metadata/1.0.0|EXT_feature_metadata Extension} for glTF.
+ * </p>
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {String} options.extension The extension JSON object.
+ * @param {MetadataSchema} [options.externalSchema] The schema pointed to from schemaUri.
+ * @param {Object} [options.bufferViews] An object mapping bufferView IDs to Uint8Array objects.
+ *
+ * @alias MetadataGltfExtension
+ * @constructor
+ *
+ * @private
+ */
+function MetadataGltfExtension(options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var extension = options.extension;
+  var externalSchema = options.externalSchema;
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.extension", extension);
+  //>>includeEnd('debug');
+
+  // The calling code is responsible for fetching the external schema JSON
+  // pointed at by the schemaUri property. This keeps metadata parsing
+  // synchronous and allows the calling code to maintain a schema cache.
+  var schema = externalSchema;
+
+  if (defined(extension.schema)) {
+    schema = new MetadataSchema(extension.schema);
+  }
+
+  var featureTables = {};
+  for (var featureTableId in extension.featureTables) {
+    if (extension.featureTables.hasOwnProperty(featureTableId)) {
+      var featureTable = extension.featureTables[featureTableId];
+      featureTables[featureTableId] = new MetadataTable({
+        count: featureTable.count,
+        properties: featureTable.properties,
+        class: schema.classes[featureTable.class],
+        bufferViews: options.bufferViews,
+      });
+    }
+  }
+
+  // TODO
+  // var featureTextures = {};
+  // for (var featureTextureId in extension.featureTextures) {
+  //   if (extension.featureTextures.hasOwnProperty(featureTextureId)) {
+  //     var featureTexture = extension.featureTextures[featureTextureId];
+  //     featureTextures[featureTextureId] = new MetadataTexture({
+  //       properties: featureTexture.properties,
+  //       class: schema.classes[featureTexture.class],
+  //     });
+  //   }
+  // }
+
+  this._schema = schema;
+  this._featureTables = featureTables;
+  this._statistics = extension.statistics;
+  this._extras = extension.extras;
+  this._extensions = extension.extensions;
+}
+
+Object.defineProperties(MetadataGltfExtension.prototype, {
+  /**
+   * Schema containing classes and enums.
+   *
+   * @memberof MetadataGltfExtension.prototype
+   * @type {MetadataSchema}
+   * @readonly
+   * @private
+   */
+  schema: {
+    get: function () {
+      return this._schema;
+    },
+  },
+
+  /**
+   * Feature tables.
+   *
+   * @memberof MetadataGltfExtension.prototype
+   * @type {Object.<String, MetadataTable>}
+   * @readonly
+   * @private
+   */
+  featureTables: {
+    get: function () {
+      return this._featureTables;
+    },
+  },
+
+  /**
+   * Statistics about the metadata.
+   * <p>
+   * See the {@link https://github.com/CesiumGS/glTF/blob/master/extensions/2.0/Vendor/EXT_feature_metadata/1.0.0/schema/statistics.schema.json|statistics schema reference}
+   * in the 3D Tiles spec for the full set of properties.
+   * </p>
+   *
+   * @memberof MetadataGltfExtension.prototype
+   * @type {Object}
+   * @readonly
+   * @private
+   */
+  statistics: {
+    get: function () {
+      return this._statistics;
+    },
+  },
+
+  /**
+   * Extras in the JSON object.
+   *
+   * @memberof MetadataGltfExtension.prototype
+   * @type {*}
+   * @readonly
+   * @private
+   */
+  extras: {
+    get: function () {
+      return this._extras;
+    },
+  },
+
+  /**
+   * Extensions in the JSON object.
+   *
+   * @memberof MetadataGltfExtension.prototype
+   * @type {Object}
+   * @readonly
+   * @private
+   */
+  extensions: {
+    get: function () {
+      return this._extensions;
+    },
+  },
+});
+
+export default MetadataGltfExtension;

--- a/Source/Scene/MetadataGltfExtension.js
+++ b/Source/Scene/MetadataGltfExtension.js
@@ -51,18 +51,6 @@ function MetadataGltfExtension(options) {
     }
   }
 
-  // TODO
-  // var featureTextures = {};
-  // for (var featureTextureId in extension.featureTextures) {
-  //   if (extension.featureTextures.hasOwnProperty(featureTextureId)) {
-  //     var featureTexture = extension.featureTextures[featureTextureId];
-  //     featureTextures[featureTextureId] = new MetadataTexture({
-  //       properties: featureTexture.properties,
-  //       class: schema.classes[featureTexture.class],
-  //     });
-  //   }
-  // }
-
   this._schema = schema;
   this._featureTables = featureTables;
   this._statistics = extension.statistics;

--- a/Specs/Scene/Gltf3DTileContentSpec.js
+++ b/Specs/Scene/Gltf3DTileContentSpec.js
@@ -1,9 +1,11 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { HeadingPitchRange } from "../../Source/Cesium.js";
-import { Cesium3DTilePass } from "../../Source/Cesium.js";
-import { ClippingPlane } from "../../Source/Cesium.js";
-import { ClippingPlaneCollection } from "../../Source/Cesium.js";
-import { Model } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Cesium3DTilePass,
+  ClippingPlane,
+  ClippingPlaneCollection,
+  HeadingPitchRange,
+  Model,
+} from "../../Source/Cesium.js";
 import Cesium3DTilesTester from "../Cesium3DTilesTester.js";
 import createScene from "../createScene.js";
 

--- a/Specs/Scene/Gltf3DTileContentSpec.js
+++ b/Specs/Scene/Gltf3DTileContentSpec.js
@@ -90,19 +90,6 @@ describe(
       );
     });
 
-    it("does not have batch table or features", function () {
-      return Cesium3DTilesTester.loadTileset(scene, gltfContentUrl).then(
-        function (tileset) {
-          var content = tileset.root.content;
-          expect(content.batchTableByteLength).toBe(0);
-          expect(content.batchTable).toBeUndefined();
-          expect(content.featuresLength).toBe(0);
-          expect(content.hasProperty(0, "property")).toBe(false);
-          expect(content.getFeature(0)).toBeUndefined();
-        }
-      );
-    });
-
     it("links model to tileset clipping planes based on bounding volume clipping", function () {
       return Cesium3DTilesTester.loadTileset(scene, gltfContentUrl).then(
         function (tileset) {

--- a/Specs/Scene/Metadata3DTilesExtensionSpec.js
+++ b/Specs/Scene/Metadata3DTilesExtensionSpec.js
@@ -1,5 +1,7 @@
-import { Metadata3DTilesExtension } from "../../Source/Cesium.js";
-import { MetadataSchema } from "../../Source/Cesium.js";
+import {
+  Metadata3DTilesExtension,
+  MetadataSchema,
+} from "../../Source/Cesium.js";
 
 describe("Scene/Metadata3DTilesExtension", function () {
   it("creates 3D Tiles metadata with default values", function () {

--- a/Specs/Scene/Metadata3DTilesExtensionSpec.js
+++ b/Specs/Scene/Metadata3DTilesExtensionSpec.js
@@ -48,8 +48,8 @@ describe("Scene/Metadata3DTilesExtension", function () {
           count: 100,
           properties: {
             height: {
-              min: [10.0],
-              max: [20.0],
+              min: 10.0,
+              max: 20.0,
             },
           },
         },

--- a/Specs/Scene/Metadata3DTilesExtensionSpec.js
+++ b/Specs/Scene/Metadata3DTilesExtensionSpec.js
@@ -1,5 +1,5 @@
 import { Metadata3DTilesExtension } from "../../Source/Cesium.js";
-import MetadataSchema from "../../Source/Scene/MetadataSchema.js";
+import { MetadataSchema } from "../../Source/Cesium.js";
 
 describe("Scene/Metadata3DTilesExtension", function () {
   it("creates 3D Tiles metadata with default values", function () {

--- a/Specs/Scene/MetadataClassPropertySpec.js
+++ b/Specs/Scene/MetadataClassPropertySpec.js
@@ -1,7 +1,9 @@
-import { FeatureDetection } from "../../Source/Cesium.js";
-import { MetadataClassProperty } from "../../Source/Cesium.js";
-import { MetadataEnum } from "../../Source/Cesium.js";
-import { MetadataType } from "../../Source/Cesium.js";
+import {
+  FeatureDetection,
+  MetadataClassProperty,
+  MetadataEnum,
+  MetadataType,
+} from "../../Source/Cesium.js";
 
 describe("Scene/MetadataClassProperty", function () {
   it("creates property with default values", function () {

--- a/Specs/Scene/MetadataClassSpec.js
+++ b/Specs/Scene/MetadataClassSpec.js
@@ -1,6 +1,8 @@
-import { MetadataClass } from "../../Source/Cesium.js";
-import { MetadataEnum } from "../../Source/Cesium.js";
-import { MetadataType } from "../../Source/Cesium.js";
+import {
+  MetadataClass,
+  MetadataEnum,
+  MetadataType,
+} from "../../Source/Cesium.js";
 
 describe("Scene/MetadataClass", function () {
   it("creates class with default values", function () {

--- a/Specs/Scene/MetadataEnumSpec.js
+++ b/Specs/Scene/MetadataEnumSpec.js
@@ -1,5 +1,4 @@
-import { MetadataEnum } from "../../Source/Cesium.js";
-import { MetadataType } from "../../Source/Cesium.js";
+import { MetadataEnum, MetadataType } from "../../Source/Cesium.js";
 
 describe("Scene/MetadataEnum", function () {
   it("creates enum with default values", function () {

--- a/Specs/Scene/MetadataGltfExtensionSpec.js
+++ b/Specs/Scene/MetadataGltfExtensionSpec.js
@@ -1,0 +1,124 @@
+import { MetadataGltfExtension } from "../../Source/Cesium.js";
+import MetadataTester from "../MetadataTester.js";
+
+describe("Scene/MetadataGltfExtension", function () {
+  it("creates glTF metadata with default values", function () {
+    var metadata = new MetadataGltfExtension({
+      extension: {},
+    });
+
+    expect(metadata.schema).toBeUndefined();
+    expect(metadata.featureTables).toEqual({});
+    expect(metadata.statistics).toBeUndefined();
+    expect(metadata.extras).toBeUndefined();
+    expect(metadata.extensions).toBeUndefined();
+  });
+
+  var schema = {
+    classes: {
+      building: {
+        properties: {
+          name: {
+            type: "STRING",
+          },
+          height: {
+            type: "FLOAT64",
+          },
+        },
+      },
+      tree: {
+        properties: {
+          species: {
+            type: "STRING",
+          },
+        },
+      },
+    },
+  };
+
+  it("creates glTF metadata", function () {
+    var statistics = {
+      classes: {
+        tree: {
+          count: 100,
+          properties: {
+            height: {
+              min: 10.0,
+              max: 20.0,
+            },
+          },
+        },
+      },
+    };
+
+    var extras = {
+      description: "Extra",
+    };
+
+    var extensions = {
+      EXT_other_extension: {},
+    };
+
+    var featureTableResults = MetadataTester.createFeatureTables({
+      schema: schema,
+      featureTables: {
+        buildings: {
+          class: "building",
+          properties: {
+            name: ["Building A", "Building B", "Building C"],
+            height: [10.0, 20.0, 30.0],
+          },
+        },
+        trees: {
+          class: "tree",
+          properties: {
+            species: ["Oak", "Pine"],
+          },
+        },
+      },
+    });
+
+    var extension = {
+      schema: schema,
+      featureTables: featureTableResults.featureTables,
+      statistics: statistics,
+      extras: extras,
+      extensions: extensions,
+    };
+
+    var metadata = new MetadataGltfExtension({
+      extension: extension,
+      bufferViews: featureTableResults.bufferViews,
+    });
+
+    var buildingClass = metadata.schema.classes.building;
+    var treeClass = metadata.schema.classes.tree;
+
+    expect(buildingClass.id).toBe("building");
+    expect(treeClass.id).toBe("tree");
+
+    var featureTables = metadata.featureTables;
+    var buildingsTable = featureTables.buildings;
+    var treesTable = featureTables.trees;
+
+    expect(buildingsTable.count).toBe(3);
+    expect(buildingsTable.class).toBe(buildingClass);
+    expect(Object.keys(buildingsTable.properties).length).toBe(2);
+    expect(buildingsTable.getProperty(0, "name")).toBe("Building A");
+    expect(buildingsTable.getProperty(1, "name")).toBe("Building B");
+    expect(buildingsTable.getProperty(2, "name")).toBe("Building C");
+    expect(buildingsTable.getProperty(0, "height")).toBe(10.0);
+    expect(buildingsTable.getProperty(1, "height")).toBe(20.0);
+    expect(buildingsTable.getProperty(2, "height")).toBe(30.0);
+
+    expect(treesTable.count).toBe(2);
+    expect(treesTable.class).toBe(treeClass);
+    expect(Object.keys(treesTable.properties).length).toBe(1);
+    expect(treesTable.getProperty(0, "species")).toBe("Oak");
+    expect(treesTable.getProperty(1, "species")).toBe("Pine");
+
+    expect(metadata.statistics).toBe(statistics);
+    expect(metadata.extras).toBe(extras);
+    expect(metadata.extensions).toBe(extensions);
+  });
+});

--- a/Specs/Scene/MetadataGroupSpec.js
+++ b/Specs/Scene/MetadataGroupSpec.js
@@ -1,5 +1,4 @@
-import { MetadataClass } from "../../Source/Cesium.js";
-import { MetadataGroup } from "../../Source/Cesium.js";
+import { MetadataClass, MetadataGroup } from "../../Source/Cesium.js";
 
 describe("Scene/MetadataGroup", function () {
   it("creates group metadata with default values", function () {

--- a/Specs/Scene/MetadataTablePropertySpec.js
+++ b/Specs/Scene/MetadataTablePropertySpec.js
@@ -1,6 +1,8 @@
-import { defaultValue } from "../../Source/Cesium.js";
-import { MetadataClassProperty } from "../../Source/Cesium.js";
-import { MetadataTableProperty } from "../../Source/Cesium.js";
+import {
+  defaultValue,
+  MetadataClassProperty,
+  MetadataTableProperty,
+} from "../../Source/Cesium.js";
 import MetadataTester from "../MetadataTester.js";
 
 describe("Scene/MetadataTableProperty", function () {

--- a/Specs/Scene/MetadataTablePropertySpec.js
+++ b/Specs/Scene/MetadataTablePropertySpec.js
@@ -1,6 +1,6 @@
 import { defaultValue } from "../../Source/Cesium.js";
+import { MetadataClassProperty } from "../../Source/Cesium.js";
 import { MetadataTableProperty } from "../../Source/Cesium.js";
-import MetadataClassProperty from "../../Source/Scene/MetadataClassProperty.js";
 import MetadataTester from "../MetadataTester.js";
 
 describe("Scene/MetadataTableProperty", function () {

--- a/Specs/Scene/MetadataTilesetSpec.js
+++ b/Specs/Scene/MetadataTilesetSpec.js
@@ -1,5 +1,4 @@
-import { MetadataClass } from "../../Source/Cesium.js";
-import { MetadataTileset } from "../../Source/Cesium.js";
+import { MetadataClass, MetadataTileset } from "../../Source/Cesium.js";
 
 describe("Scene/MetadataTileset", function () {
   it("creates tileset metadata with default values", function () {

--- a/Specs/Scene/MetadataTypeSpec.js
+++ b/Specs/Scene/MetadataTypeSpec.js
@@ -1,5 +1,4 @@
-import { FeatureDetection } from "../../Source/Cesium.js";
-import { MetadataType } from "../../Source/Cesium.js";
+import { FeatureDetection, MetadataType } from "../../Source/Cesium.js";
 
 describe("Scene/MetadataType", function () {
   it("getMinimum", function () {


### PR DESCRIPTION
This PR adds very basic support for [`EXT_feature_metadata`](https://github.com/CesiumGS/glTF/tree/feature-metadata/extensions/2.0/Vendor/EXT_feature_metadata/1.0.0), with a bunch of caveats:

 *  Only works with glb models with a single buffer
 *  Does not work with `schemaUri`
 *  Does not work with multiple feature tables
 *  Only works with `_FEATURE_ID_0`
 *  Does not support feature ID textures
 *  Does not support feature textures

First it reads feature metadata with the new `MetadataGltfExtension` class (mirrors `Metadata3DTilesExtension`), which creates a `MetadataTable` for each feature table. Then `Gltf3DTileContent` transcodes the first `MetadataTable` into a `Cesium3DTileBatchTable`. `Gltf3DTileContent` is now very similar to `Batched3DModel3DTileContent`.

This is enough to start testing output from [CDB to 3D Tiles](https://github.com/CesiumGS/cdb-to-3dtiles) and is not the complete solution. The complete solution would be to enhance `Cesium3DTileBatchTable` so that it supports all of the things that are not supported above and to unify b3dm and glb. I didn't add any new tests for `Gltf3DTileContent` because the entire approach will be changing soon, but I added tests for `MetadataGltfExtension`.

@ptrgags I'll pass along some sample data offline.