### PR TITLE
Fix bug when no buffers are present in implicit subtree

### DIFF
--- a/Source/Scene/ImplicitSubtree.js
+++ b/Source/Scene/ImplicitSubtree.js
@@ -238,7 +238,7 @@ function parseSubtreeChunks(subtreeView) {
  * @private
  */
 function preprocessBuffers(bufferHeaders) {
-  bufferHeaders = defaultValue(bufferHeaders, []);
+  bufferHeaders = defined(bufferHeaders) ? bufferHeaders : [];
   for (var i = 0; i < bufferHeaders.length; i++) {
     var bufferHeader = bufferHeaders[i];
     bufferHeader.isExternal = defined(bufferHeader.uri);
@@ -271,7 +271,7 @@ function preprocessBuffers(bufferHeaders) {
  * @private
  */
 function preprocessBufferViews(bufferViewHeaders, bufferHeaders) {
-  bufferViewHeaders = defaultValue(bufferViewHeaders, []);
+  bufferViewHeaders = defined(bufferViewHeaders) ? bufferViewHeaders : [];
   for (var i = 0; i < bufferViewHeaders.length; i++) {
     var bufferViewHeader = bufferViewHeaders[i];
     var bufferHeader = bufferHeaders[bufferViewHeader.buffer];

--- a/Source/Scene/ImplicitSubtree.js
+++ b/Source/Scene/ImplicitSubtree.js
@@ -233,11 +233,12 @@ function parseSubtreeChunks(subtreeView) {
  * isExternal and isActive fields for easier parsing later. This modifies
  * the objects in place.
  *
- * @param {Object[]} bufferHeaders The JSON from subtreeJson.buffers.
+ * @param {Object[]} [bufferHeaders=[]] The JSON from subtreeJson.buffers.
  * @returns {BufferHeader[]} The same array of headers with additional fields.
  * @private
  */
 function preprocessBuffers(bufferHeaders) {
+  bufferHeaders = defaultValue(bufferHeaders, []);
   for (var i = 0; i < bufferHeaders.length; i++) {
     var bufferHeader = bufferHeaders[i];
     bufferHeader.isExternal = defined(bufferHeader.uri);
@@ -264,12 +265,13 @@ function preprocessBuffers(bufferHeaders) {
  * Iterate the list of buffer views from the subtree JSON and add the
  * isActive flag. Also save a reference to the bufferHeader
  *
- * @param {Object[]} bufferViewHeaders The JSON from subtree.bufferViews
+ * @param {Object[]} [bufferViewHeaders=[]] The JSON from subtree.bufferViews
  * @param {BufferHeader[]} bufferHeaders The preprocessed buffer headers
  * @returns {BufferViewHeader[]} The same array of bufferView headers with additional fields
  * @private
  */
 function preprocessBufferViews(bufferViewHeaders, bufferHeaders) {
+  bufferViewHeaders = defaultValue(bufferViewHeaders, []);
   for (var i = 0; i < bufferViewHeaders.length; i++) {
     var bufferViewHeader = bufferViewHeaders[i];
     var bufferHeader = bufferHeaders[bufferViewHeader.buffer];

--- a/Specs/ImplicitTilingTester.js
+++ b/Specs/ImplicitTilingTester.js
@@ -1,16 +1,71 @@
 import { defined, defaultValue } from "../Source/Cesium.js";
 import concatTypedArrays from "./concatTypedArrays.js";
 
+/**
+ * Class to generate implicit subtrees for implicit tiling unit tests
+ * @private
+ */
 export default function ImplicitTilingTester() {}
 
 /**
- *
+ * Description of a single availability bitstream
+ * @typedef {Object} AvailabilityDescription
+ * @property {String|Number} descriptor Either a string of <code>0</code>s and <code>1</code>s representing the bitstream values, or an integer <code>0</code> or <code>1</code> to indicate a constant value.
+ * @property {Number} lengthBits How many bits are in the bitstream. This must be specified, even if descriptor is a string of <code>0</code>s and <code>1</code>s
+ * @property {Boolean} isInternal <code>true</code> if an internal bufferView should be created. <code>false</code> indicates the bufferview is stored in an external buffer instead.
+ * @property {Boolean} [shareBuffer=false] This is only used for content availability. If <code>true</code>, then the content availability will share the same buffer as the tile availaibility, as this is a common optimization
+ */
+
+/**
+ * A JSON description of a subtree file for easier generation
+ * @typedef {Object} SubtreeDescription
+ * @property {AvailabilityDescription} tileAvailability A description of the tile availability bitstream to generate
+ * @property {AvailabilityDescription} contentAvailability A description of the content availability bitstream to generate
+ * @property {AvailabilityDescription} childSubtreeAvailability A description of the child subtree availability bitstream to generate
+ * @private
+ */
+
+/**
+ * Results of procedurally generating a subtree.
+ * @typedef {Object} GeneratedSubtree
+ * @property {Uint8Array} subtreeBuffer A typed array storing the contents of the subtree file (including the internal buffer)
+ * @property {Uint8Array} externalBuffer A typed array representing an external .bin file. This is always returned, but it may be an empty typed array.
  */
 
 /**
  * Generate a subtree buffer
  * @param {SubtreeDescription} subtreeDescription A JSON description of the subtree's structure and values
- * @param {Boolean} constantOnly true if
+ * @param {Boolean} constantOnly true if all the bitstreams are constant, i.e. no buffers/bufferViews are needed.
+ * @return {GeneratedSubtree} The procedurally generated subtree and an external buffer.
+ *
+ * @example
+ *  var subtreeDescription = {
+ *    tileAvailability: {
+ *      descriptor: 1,
+ *      lengthBits: 5,
+ *      isInternal: true,
+ *    },
+ *    contentAvailability: {
+ *      descriptor: "11000",
+ *      lengthBits: 5,
+ *      isInternal: true,
+ *    },
+ *    childSubtreeAvailability: {
+ *      descriptor: "1111000010100000",
+ *      lengthBits: 16,
+ *      isInternal: true,
+ *    },
+ *    other: {
+ *      descriptor: "101010",
+ *      lengthBits: 6,
+ *      isInternal: false,
+ *    },
+ *  };
+ *  var results = ImplicitTilingTester.generateSubtreeBuffers(
+ *    subtreeDescription
+ *  );
+ *
+ * @private
  */
 ImplicitTilingTester.generateSubtreeBuffers = function (
   subtreeDescription,

--- a/Specs/ImplicitTilingTester.js
+++ b/Specs/ImplicitTilingTester.js
@@ -1,14 +1,31 @@
-import { defined } from "../Source/Cesium.js";
+import { defined, defaultValue } from "../Source/Cesium.js";
 import concatTypedArrays from "./concatTypedArrays.js";
 
 export default function ImplicitTilingTester() {}
 
-ImplicitTilingTester.generateSubtreeBuffers = function (subtreeDescription) {
+/**
+ *
+ */
+
+/**
+ * Generate a subtree buffer
+ * @param {SubtreeDescription} subtreeDescription A JSON description of the subtree's structure and values
+ * @param {Boolean} constantOnly true if
+ */
+ImplicitTilingTester.generateSubtreeBuffers = function (
+  subtreeDescription,
+  constantOnly
+) {
+  constantOnly = defaultValue(constantOnly, false);
+
   // This will be populated by makeBufferViews() and makeBuffers()
-  var subtreeJson = {
-    buffers: [],
-    bufferViews: [],
-  };
+  var subtreeJson = {};
+  if (!constantOnly) {
+    subtreeJson = {
+      buffers: [],
+      bufferViews: [],
+    };
+  }
 
   var bufferViewsU8 = makeBufferViews(subtreeDescription, subtreeJson);
   var buffersU8 = makeBuffers(bufferViewsU8, subtreeJson);

--- a/Specs/Scene/ImplicitSubtreeSpec.js
+++ b/Specs/Scene/ImplicitSubtreeSpec.js
@@ -467,4 +467,46 @@ describe("Scene/ImplicitSubtree", function () {
       );
     });
   });
+
+  it("handles subtree with constant-only data", function () {
+    var subtreeDescription = {
+      tileAvailability: {
+        descriptor: 1,
+        lengthBits: 9,
+        isInternal: true,
+      },
+      contentAvailability: {
+        descriptor: 0,
+        lengthBits: 9,
+        isInternal: true,
+      },
+      childSubtreeAvailability: {
+        descriptor: 0,
+        lengthBits: 64,
+        isInternal: true,
+      },
+    };
+
+    var constantOnly = true;
+    var results = ImplicitTilingTester.generateSubtreeBuffers(
+      subtreeDescription,
+      constantOnly
+    );
+    var subtree = new ImplicitSubtree(
+      subtreeResource,
+      results.subtreeBuffer,
+      implicitOctree
+    );
+    return subtree.readyPromise.then(function () {
+      expectTileAvailability(subtree, subtreeDescription.tileAvailability);
+      expectContentAvailability(
+        subtree,
+        subtreeDescription.contentAvailability
+      );
+      expectChildSubtreeAvailability(
+        subtree,
+        subtreeDescription.childSubtreeAvailability
+      );
+    });
+  });
 });


### PR DESCRIPTION
Today @ErixenCruz and I noticed a bug in implicit tiling where a subtree with no buffers/bufferViews results in an undefined that breaks `ImplicitSubtree.js`

This was easy to fix, I just needed to add a couple `defaultValue()` calls.

@lilleyse could you review? i'll work on getting you a subtree file to test with