### PR TITLE
Update Cesium3DTileBatchTable.js

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -285,3 +285,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Will Jadkowski](https://github.com/willjad)
 - [Mac Clayton](https://github.com/mclayton7)
 - [Ben Murphy](https://github.com/littlemurph)
+- [Zhang Han](https://github.com/Anigod)

--- a/Source/Scene/Cesium3DTileBatchTable.js
+++ b/Source/Scene/Cesium3DTileBatchTable.js
@@ -478,6 +478,10 @@ Cesium3DTileBatchTable.prototype.getShow = function (batchId) {
 var scratchColorBytes = new Array(4);
 
 Cesium3DTileBatchTable.prototype.setColor = function (batchId, color) {
+  if (!defined(color)) {
+    //Use default color
+    return;
+  }
   //>>includeStart('debug', pragmas.debug);
   checkBatchId(batchId, this.featuresLength);
   Check.typeOf.object("color", color);

--- a/Source/Scene/Cesium3DTileBatchTable.js
+++ b/Source/Scene/Cesium3DTileBatchTable.js
@@ -478,12 +478,12 @@ Cesium3DTileBatchTable.prototype.getShow = function (batchId) {
 var scratchColorBytes = new Array(4);
 
 Cesium3DTileBatchTable.prototype.setColor = function (batchId, color) {
+  //>>includeStart('debug', pragmas.debug);
+  checkBatchId(batchId, this.featuresLength);
   if (!defined(color)) {
     //Use default color
     return;
   }
-  //>>includeStart('debug', pragmas.debug);
-  checkBatchId(batchId, this.featuresLength);
   Check.typeOf.object("color", color);
   //>>includeEnd('debug');
 

--- a/Specs/Scene/Cesium3DTileBatchTableSpec.js
+++ b/Specs/Scene/Cesium3DTileBatchTableSpec.js
@@ -152,13 +152,6 @@ describe(
       }).toThrowDeveloperError();
     });
 
-    it("setColor throws with undefined value", function () {
-      var batchTable = new Cesium3DTileBatchTable(mockTileset, 1);
-      expect(function () {
-        batchTable.setColor(0);
-      }).toThrowDeveloperError();
-    });
-
     it("setColor", function () {
       var batchTable = new Cesium3DTileBatchTable(mockTileset, 1);
 
@@ -168,6 +161,13 @@ describe(
 
       // Check that batch table resources are still undefined because value is true by default
       batchTable.setColor(0, Color.WHITE);
+      batchTable.update(mockTileset, scene.frameState);
+      expect(batchTable._batchValues).toBeUndefined();
+      expect(batchTable._batchTexture).toBeUndefined();
+      expect(batchTable.getColor(0, result)).toEqual(Color.WHITE);
+
+      // Check that batch table resources are still undefined because value is true by default
+      batchTable.setColor(0);
       batchTable.update(mockTileset, scene.frameState);
       expect(batchTable._batchValues).toBeUndefined();
       expect(batchTable._batchTexture).toBeUndefined();


### PR DESCRIPTION
Cesium will crash when use Cesium3DTileStyle but not write all the cases, from issues #9418.
[https://github.com/CesiumGS/cesium/issues/9418](url)
