### PR TITLE
Return first position when interpolating rhumblines at surface distance 0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 ##### Fixes :wrench:
 
 - Fixed a regression in 1.79 that broke terrain exaggeration. [#9397](https://github.com/CesiumGS/cesium/pull/9397)
+- Fixed an issue where interpolating certain small rhumblines with surface distance 0.0 would not return the expected result. [#9430](https://github.com/CesiumGS/cesium/pull/9430)
 
 ### 1.79 - 2021-03-01
 

--- a/Source/Core/EllipsoidRhumbLine.js
+++ b/Source/Core/EllipsoidRhumbLine.js
@@ -300,6 +300,10 @@ function interpolateUsingSurfaceDistance(
   ellipticity,
   result
 ) {
+  if (distance === 0.0) {
+    return Cartographic.clone(start, result);
+  }
+
   var ellipticitySquared = ellipticity * ellipticity;
 
   var longitude;

--- a/Specs/Core/EllipsoidRhumbLineSpec.js
+++ b/Specs/Core/EllipsoidRhumbLineSpec.js
@@ -1,3 +1,4 @@
+import { Cartesian3 } from "../../Source/Cesium.js";
 import { Cartographic } from "../../Source/Cesium.js";
 import { Ellipsoid } from "../../Source/Cesium.js";
 import { EllipsoidGeodesic } from "../../Source/Cesium.js";
@@ -1022,5 +1023,28 @@ describe("Core/EllipsoidRhumbLine", function () {
         CesiumMath.EPSILON12
       )
     ).toBe(true);
+  });
+
+  it("returns the start point when interpolating at surface distance 0.0", function () {
+    var p0 = new Cartesian3(
+      899411.2767873341,
+      -5079219.747324299,
+      3738850.924729517
+    );
+    var p1 = new Cartesian3(
+      899411.0994891181,
+      -5079219.778719673,
+      3738850.9247295167
+    );
+
+    var ellipsoid = Ellipsoid.WGS84;
+    var c0 = ellipsoid.cartesianToCartographic(p0, new Cartographic());
+    var c1 = ellipsoid.cartesianToCartographic(p1, new Cartographic());
+    var rhumb = new EllipsoidRhumbLine(c0, c1, ellipsoid);
+
+    var c = rhumb.interpolateUsingSurfaceDistance(0.0, new Cartographic());
+    var p = ellipsoid.cartographicToCartesian(c, new Cartesian3());
+
+    expect(p).toEqualEpsilon(p0, CesiumMath.EPSILON7);
   });
 });


### PR DESCRIPTION
In some cases, very small rhumblines can return an unexpected value when requesting a position at the beginning of the rhumbline (surface distance 0.0) using `interpolateUsingSurfaceDistance`.
This PR ensures that rhumbline interpolation always returns the start position when using surface distance 0.0.