### PR TITLE
Use content classificationType rather than tileset classificationType

### DIFF
--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -460,7 +460,7 @@ function initialize(content, arrayBuffer, byteOffset) {
       ),
       uniformMapLoaded: batchTable.getUniformMapCallback(),
       pickIdLoaded: getPickIdCallback(content),
-      classificationType: tileset._classificationType,
+      classificationType: content._classificationType,
       batchTable: batchTable,
     });
   }


### PR DESCRIPTION
`Batched3DModel3DTileContent` should be using its own internal `classificationType` rather than `tileset.classificationType`. This was missed in one spot in https://github.com/CesiumGS/cesium/pull/9398.

In this code path `content._classificationType` will be the same as `tileset.classificationType` so this is just a cosmetic fix.

I confirmed that [Photogrammetry Classification](http://localhost:8080/Apps/Sandcastle/index.html?src=3D%20Tiles%20Photogrammetry%20Classification.html) still works.