### PR TITLE
Clear translucent classification buffer

### DIFF
--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -3461,13 +3461,6 @@ function updateAndClearFramebuffers(scene, passState, clearColor) {
     environmentState.useOIT = oit.isSupported();
   }
 
-  if (
-    useGlobeDepthFramebuffer &&
-    view.translucentTileClassification.isSupported()
-  ) {
-    view.translucentTileClassification.clear(context, passState);
-  }
-
   var postProcess = scene.postProcessStages;
   var usePostProcess = (environmentState.usePostProcess =
     !picking &&

--- a/Source/Scene/TranslucentTileClassification.js
+++ b/Source/Scene/TranslucentTileClassification.js
@@ -487,7 +487,7 @@ TranslucentTileClassification.prototype.executeClassificationCommands = function
   }
 
   passState.framebuffer = this._drawClassificationFBO;
-  if (this._frustumsDrawn > 1) {
+  if (this._frustumsDrawn >= 1) {
     this._clearColorCommand.execute(context, passState);
   }
 

--- a/Source/Scene/TranslucentTileClassification.js
+++ b/Source/Scene/TranslucentTileClassification.js
@@ -487,7 +487,7 @@ TranslucentTileClassification.prototype.executeClassificationCommands = function
   }
 
   passState.framebuffer = this._drawClassificationFBO;
-  if (this._frustumsDrawn >= 1) {
+  if (this._frustumsDrawn > 1) {
     this._clearColorCommand.execute(context, passState);
   }
 
@@ -527,18 +527,19 @@ TranslucentTileClassification.prototype.execute = function (scene, passState) {
     ? this._compositeCommand.derivedCommands.pick
     : this._compositeCommand;
   command.execute(scene.context, passState);
+
+  var framebuffer = passState.framebuffer;
+
+  passState.framebuffer = this._drawClassificationFBO;
+  this._clearColorCommand.execute(scene._context, passState);
+
+  passState.framebuffer = framebuffer;
 };
 
 TranslucentTileClassification.prototype.clear = function (context, passState) {
   if (!this._hasTranslucentDepth) {
     return;
   }
-  var framebuffer = passState.framebuffer;
-
-  passState.framebuffer = this._drawClassificationFBO;
-  this._clearColorCommand.execute(context, passState);
-
-  passState.framebuffer = framebuffer;
 
   if (this._frustumsDrawn > 1) {
     passState.framebuffer = this._accumulationFBO;

--- a/Source/Scene/TranslucentTileClassification.js
+++ b/Source/Scene/TranslucentTileClassification.js
@@ -528,27 +528,35 @@ TranslucentTileClassification.prototype.execute = function (scene, passState) {
     : this._compositeCommand;
   command.execute(scene.context, passState);
 
-  var framebuffer = passState.framebuffer;
-
-  passState.framebuffer = this._drawClassificationFBO;
-  this._clearColorCommand.execute(scene._context, passState);
-
-  passState.framebuffer = framebuffer;
+  clear(this, scene, passState);
 };
 
-TranslucentTileClassification.prototype.clear = function (context, passState) {
-  if (!this._hasTranslucentDepth) {
+function clear(translucentTileClassification, scene, passState) {
+  if (!translucentTileClassification._hasTranslucentDepth) {
     return;
   }
 
-  if (this._frustumsDrawn > 1) {
-    passState.framebuffer = this._accumulationFBO;
-    this._clearColorCommand.execute(context, passState);
+  var framebuffer = passState.framebuffer;
+
+  passState.framebuffer = translucentTileClassification._drawClassificationFBO;
+  translucentTileClassification._clearColorCommand.execute(
+    scene._context,
+    passState
+  );
+
+  passState.framebuffer = framebuffer;
+
+  if (translucentTileClassification._frustumsDrawn > 1) {
+    passState.framebuffer = translucentTileClassification._accumulationFBO;
+    translucentTileClassification._clearColorCommand.execute(
+      scene._context,
+      passState
+    );
   }
 
-  this._hasTranslucentDepth = false;
-  this._frustumsDrawn = 0;
-};
+  translucentTileClassification._hasTranslucentDepth = false;
+  translucentTileClassification._frustumsDrawn = 0;
+}
 
 TranslucentTileClassification.prototype.isSupported = function () {
   return this._supported;

--- a/Specs/Scene/TranslucentTileClassificationSpec.js
+++ b/Specs/Scene/TranslucentTileClassificationSpec.js
@@ -711,7 +711,7 @@ describe(
       var postClassifyPixels = readPixels(drawClassificationFBO);
       expect(postClassifyPixels).not.toEqual(preClassifyPixels);
 
-      translucentTileClassification.clear(context, passState);
+      translucentTileClassification.execute(scene, passState);
 
       var postClearPixels = readPixels(drawClassificationFBO);
       expect(postClearPixels).not.toEqual(postClassifyPixels);

--- a/Specs/Scene/TranslucentTileClassificationSpec.js
+++ b/Specs/Scene/TranslucentTileClassificationSpec.js
@@ -730,7 +730,7 @@ describe(
 
       spyOn(translucentTileClassification._clearColorCommand, "execute");
 
-      translucentTileClassification.clear(context, passState);
+      translucentTileClassification.execute(scene, passState);
 
       expect(
         translucentTileClassification._clearColorCommand.execute


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/9420. 

I believe this bug happens because it's possible for `Picking.pick` to cause `TranslucentTileClassification.executeClassificationCommands` to be called twice in a row without `clear` being called in between. I left more info in my comment (https://github.com/CesiumGS/cesium/issues/9420#issuecomment-804442902) on the issue, but maybe the conversation should continue here.

One alternative approach might be to fix this by having `pick` clear the buffer if needed rather than always clearing it each frame regardless.