### PR TITLE
Updated label links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ In addition to contributing core CesiumJS code, we appreciate many types of cont
 
 - Being active on the [Cesium community forum](https://community.cesium.com/) by answering questions and providing input on Cesium's direction.
 - Showcasing your Cesium apps on [Cesium blog](https://cesium.com/blog/categories/userstories/). Contact us at hello@cesium.com.
-- Writing tutorials, creating examples, and improving the reference documentation. See the issues labeled [doc](https://github.com/CesiumGS/cesium/labels/doc).
+- Writing tutorials, creating examples, and improving the reference documentation. See the issues labeled [category - doc](https://github.com/CesiumGS/cesium/labels/category%20-%20doc).
 - Submitting issues as [described above](#submitting-an-issue).
 - Triaging issues. Browse the [issues](https://github.com/CesiumGS/cesium/issues) and comment on issues that are no longer reproducible or on issues which you have additional information.
 - Creating ecosystem projects for [glTF](https://github.com/KhronosGroup/glTF/issues/456), [CZML](https://github.com/CesiumGS/cesium/wiki/CZML-Guide), and [3D Tiles](https://github.com/CesiumGS/3d-tiles).
@@ -37,7 +37,7 @@ In addition to contributing core CesiumJS code, we appreciate many types of cont
 For ideas for CesiumJS code contributions, see:
 
 - issues labeled [`good first issue`](https://github.com/CesiumGS/cesium/labels/good%20first%20issue) and
-- issues labeled [`roadmap`](https://github.com/CesiumGS/cesium/labels/roadmap).
+- issues labeled [`type - roadmap`](https://github.com/CesiumGS/cesium/labels/type%20-%20roadmap).
 
 See the [Build Guide](Documentation/Contributors/BuildGuide/README.md) for how to build and run Cesium on your system.
 


### PR DESCRIPTION
The tags `doc` and `roadmap` apparently have been renamed to `category - doc` and `type - roadmap` at some point. This only updates the links in the CONTRIBUTING.md

(Ironically, I don't think that it's appropriate to add me to the CONTRIBUTORS.md for this...)
