### PR TITLE
Fix classification crash when toggling translucency

### DIFF
--- a/Source/Scene/Cesium3DTileBatchTable.js
+++ b/Source/Scene/Cesium3DTileBatchTable.js
@@ -1621,6 +1621,8 @@ function getTranslucentRenderState(renderState) {
   rs.depthTest.enabled = true;
   rs.depthMask = false;
   rs.blending = BlendingState.ALPHA_BLEND;
+  rs.stencilTest = StencilConstants.setCesium3DTileBit();
+  rs.stencilMask = StencilConstants.CESIUM_3D_TILE_MASK;
 
   return RenderState.fromCache(rs);
 }

--- a/Source/Scene/PointCloud.js
+++ b/Source/Scene/PointCloud.js
@@ -832,20 +832,25 @@ function createResources(pointCloud, frameState) {
     },
   };
 
-  if (pointCloud._opaquePass === Pass.CESIUM_3D_TILE) {
-    opaqueRenderState.stencilTest = StencilConstants.setCesium3DTileBit();
-    opaqueRenderState.stencilMask = StencilConstants.CESIUM_3D_TILE_MASK;
-  }
-
-  pointCloud._opaqueRenderState = RenderState.fromCache(opaqueRenderState);
-
-  pointCloud._translucentRenderState = RenderState.fromCache({
+  var translucentRenderState = {
     depthTest: {
       enabled: true,
     },
     depthMask: false,
     blending: BlendingState.ALPHA_BLEND,
-  });
+  };
+
+  if (pointCloud._opaquePass === Pass.CESIUM_3D_TILE) {
+    opaqueRenderState.stencilTest = StencilConstants.setCesium3DTileBit();
+    opaqueRenderState.stencilMask = StencilConstants.CESIUM_3D_TILE_MASK;
+    translucentRenderState.stencilTest = StencilConstants.setCesium3DTileBit();
+    translucentRenderState.stencilMask = StencilConstants.CESIUM_3D_TILE_MASK;
+  }
+
+  pointCloud._opaqueRenderState = RenderState.fromCache(opaqueRenderState);
+  pointCloud._translucentRenderState = RenderState.fromCache(
+    translucentRenderState
+  );
 
   pointCloud._drawCommand = new DrawCommand({
     boundingVolume: new BoundingSphere(),

--- a/Source/Scene/TranslucentTileClassification.js
+++ b/Source/Scene/TranslucentTileClassification.js
@@ -15,7 +15,6 @@ import Texture from "../Renderer/Texture.js";
 import CompareAndPackTranslucentDepth from "../Shaders/CompareAndPackTranslucentDepth.js";
 import CompositeTranslucentClassification from "../Shaders/PostProcessStages/CompositeTranslucentClassification.js";
 import BlendingState from "./BlendingState.js";
-import DerivedCommand from "./DerivedCommand.js";
 import StencilConstants from "./StencilConstants.js";
 import StencilFunction from "./StencilFunction.js";
 
@@ -451,8 +450,9 @@ TranslucentTileClassification.prototype.executeTranslucentCommands = function (
       continue;
     }
 
-    var derivedCommand = getDerivedCommand(command, scene, context);
-    executeCommand(derivedCommand.depthOnlyCommand, scene, context, passState);
+    // Depth-only commands are created for all translucent 3D Tiles commands
+    var depthOnlyCommand = command.derivedCommands.depth.depthOnlyCommand;
+    executeCommand(depthOnlyCommand, scene, context, passState);
   }
 
   this._frustumsDrawn += this._hasTranslucentDepth ? 1 : 0;
@@ -584,23 +584,4 @@ TranslucentTileClassification.prototype.destroy = function () {
   return destroyObject(this);
 };
 
-function getDerivedCommand(command, scene, context) {
-  var derivedCommands = command.derivedCommands;
-  var depthForClassification = derivedCommands.depthForClassification;
-  if (!defined(depthForClassification) || command.dirty) {
-    depthForClassification = derivedCommands.depthForClassification = DerivedCommand.createDepthOnlyDerivedCommand(
-      scene,
-      command,
-      context,
-      derivedCommands.depthForClassification
-    );
-
-    var depthOnlyCommand = depthForClassification.depthOnlyCommand;
-    var rs = RenderState.getState(depthOnlyCommand.renderState);
-    rs.stencilTest = StencilConstants.setCesium3DTileBit();
-
-    depthOnlyCommand.renderState = RenderState.fromCache(rs);
-  }
-  return depthForClassification;
-}
 export default TranslucentTileClassification;

--- a/Source/Scene/TranslucentTileClassification.js
+++ b/Source/Scene/TranslucentTileClassification.js
@@ -587,7 +587,7 @@ TranslucentTileClassification.prototype.destroy = function () {
 function getDerivedCommand(command, scene, context) {
   var derivedCommands = command.derivedCommands;
   var depthForClassification = derivedCommands.depthForClassification;
-  if (!defined(depthForClassification)) {
+  if (!defined(depthForClassification) || command.dirty) {
     depthForClassification = derivedCommands.depthForClassification = DerivedCommand.createDepthOnlyDerivedCommand(
       scene,
       command,


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/9421. 

The idea behind this fix is that it is possible for the translucent command in `TranslucentTileClassification` to have a previously destroyed shader by the time `getDerivedCommand` is called from `executeTranslucentCommands`. One clue that supports this idea is that the crash only seems to happen when the translucency checkbox is turned on, and not off (see the [Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=xVRba9swFP4rIuzBGZl8j50uLdvcwgIdLU22vRiKbJ8kWhUpSLK7rPS/T76FpulghcFCQNa5fUffuVREoorCPUh0ijjcowQULTf4WyOz0kHe3BPBNaEcZDoYoYeUI6RBSiO5lqKiBciT3jGXQDR8F5IVi9bEGo5S/jh8n/KUVwZOUwYK9CFee/jni1ZpNRilZPu4M8FvQIlS5oCXUmw+KmM2Kyx3HHjuHqF9ClY5cMBbSTdU0woUJkVhdbhtIt0FK71j8OdU5rW6TSYXTJhnpgO5yoj15iG5ury6ecQSvUVeGI7QXrI6kmS9xMXOMB3s2Ui5baOE0fwO6TWgfA35XSZ+IoKykudrJJaGrA0oRHiBqEb3lDEEFXBdEsZ2KJdErZsgWamR4EZEl20oRpSiS5oTTQXfU05NqKKAAmnRmDU8tVU59Fi8qkb1iQwzGNvmPyebLYNzool94GEnBxD2taBcJ0yUhd1X44cS3HRYQ/dhPrst7FshOVLh5GI++/rl1j+/XcwuL/6mG158b1+WA8ecbEASbNT1ULSvLkBpyhvXkwOKiNTmi3DfakkJAseNggCPg8ANQt8NRq3c80IndHHgOlE8cV0n9DpFEE7CwHOwHwVRHAS+X4uHjVJIakp/DPoZSEH56prqfH0jGOugQwM6jnw/dkLHn0Rh1CG8c7AXjcdO5IZ+7E/ieNwpxtiLXZNLHIWB4zhx2EN37To3bZgTpRnUDC7EasXgU6m14GZPLCThipWGMY0yoqDvuXphLAlTYA7T1HXyVtPoUAzbTWJa9pkEodePZ/37FyPq4LAZ0Tpe825zIDD5///U+u3xNLWuOIPRYNokdNYDfqCbrZC6nk/LDKUGM5RmMSs7Kw3TGudKtSEQmtpPXacFrRAtTl9Y/e1QGs2yZGxOf0E6OJvaxv7IlYmmJa8qkIzsarO1e3bZCjHGU9tcX/bUQrCMyGeRfwM)). If the command is dirty by the time `getDerivedCommand` is called, the shader should be recreated instead of reusing the outdated one from when the tileset was opaque.

I'm still not 100% sure when the command state gets messed up, but I believe the bug happens because: 
- Toggling on translucency changes the translucency command's shaders.
- The translucency command now has `dirty = true`.
- `Scene` never checks whether the translucent commands are dirty (i.e. like it does with shadow maps in `updateDerivedCommands`), and the state is only visible from the loop over commands inside `executeTranslucentCommands`. For this reason, checking for `... || command.dirty` inside `TranslucentTileClassification#getDerivedCommand` makes sense to me (as opposed to somewhere higher up like `Scene`).
- If the derived command is never updated in a `dirty` command, the shader program can be pointing to an outdated shader that has already been destroyed.

