### PR TITLE
Adjust JSDoc visibility of MetadataSchema

### DIFF
--- a/Source/Scene/MetadataClass.js
+++ b/Source/Scene/MetadataClass.js
@@ -13,8 +13,6 @@ import MetadataClassProperty from "./MetadataClassProperty.js";
  *
  * @alias MetadataClass
  * @constructor
- *
- * @private
  */
 function MetadataClass(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -58,7 +56,6 @@ Object.defineProperties(MetadataClass.prototype, {
    * @memberof MetadataClass.prototype
    * @type {Object.<String, MetadataClassProperty>}
    * @readonly
-   * @private
    */
   properties: {
     get: function () {
@@ -72,7 +69,6 @@ Object.defineProperties(MetadataClass.prototype, {
    * @memberof MetadataClass.prototype
    * @type {Object.<String, MetadataClassProperty>}
    * @readonly
-   * @private
    */
   propertiesBySemantic: {
     get: function () {
@@ -86,7 +82,6 @@ Object.defineProperties(MetadataClass.prototype, {
    * @memberof MetadataClass.prototype
    * @type {String}
    * @readonly
-   * @private
    */
   id: {
     get: function () {
@@ -100,7 +95,6 @@ Object.defineProperties(MetadataClass.prototype, {
    * @memberof MetadataClass.prototype
    * @type {String}
    * @readonly
-   * @private
    */
   name: {
     get: function () {
@@ -114,7 +108,6 @@ Object.defineProperties(MetadataClass.prototype, {
    * @memberof MetadataClass.prototype
    * @type {String}
    * @readonly
-   * @private
    */
   description: {
     get: function () {
@@ -128,7 +121,6 @@ Object.defineProperties(MetadataClass.prototype, {
    * @memberof MetadataClass.prototype
    * @type {*}
    * @readonly
-   * @private
    */
   extras: {
     get: function () {
@@ -142,7 +134,6 @@ Object.defineProperties(MetadataClass.prototype, {
    * @memberof MetadataClass.prototype
    * @type {Object}
    * @readonly
-   * @private
    */
   extensions: {
     get: function () {

--- a/Source/Scene/MetadataClass.js
+++ b/Source/Scene/MetadataClass.js
@@ -69,6 +69,8 @@ Object.defineProperties(MetadataClass.prototype, {
    * @memberof MetadataClass.prototype
    * @type {Object.<String, MetadataClassProperty>}
    * @readonly
+   *
+   * @private
    */
   propertiesBySemantic: {
     get: function () {

--- a/Source/Scene/MetadataClassProperty.js
+++ b/Source/Scene/MetadataClassProperty.js
@@ -13,8 +13,6 @@ import MetadataType from "./MetadataType.js";
  *
  * @alias MetadataClassProperty
  * @constructor
- *
- * @private
  */
 function MetadataClassProperty(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -65,7 +63,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {String}
    * @readonly
-   * @private
    */
   id: {
     get: function () {
@@ -79,7 +76,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {String}
    * @readonly
-   * @private
    */
   name: {
     get: function () {
@@ -93,7 +89,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {String}
    * @readonly
-   * @private
    */
   description: {
     get: function () {
@@ -107,7 +102,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {MetadataType}
    * @readonly
-   * @private
    */
   type: {
     get: function () {
@@ -121,7 +115,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {MetadataEnum}
    * @readonly
-   * @private
    */
   enumType: {
     get: function () {
@@ -135,7 +128,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {MetadataType}
    * @readonly
-   * @private
    */
   componentType: {
     get: function () {
@@ -149,7 +141,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {MetadataType}
    * @readonly
-   * @private
    */
   valueType: {
     get: function () {
@@ -163,7 +154,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {Number}
    * @readonly
-   * @private
    */
   componentCount: {
     get: function () {
@@ -177,7 +167,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {Boolean}
    * @readonly
-   * @private
    */
   normalized: {
     get: function () {
@@ -191,7 +180,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {Number|Number[]}
    * @readonly
-   * @private
    */
   max: {
     get: function () {
@@ -205,7 +193,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {Number|Number[]}
    * @readonly
-   * @private
    */
   min: {
     get: function () {
@@ -219,7 +206,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {Boolean|Number|String|Array}
    * @readonly
-   * @private
    */
   default: {
     get: function () {
@@ -233,7 +219,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {Boolean}
    * @readonly
-   * @private
    */
   optional: {
     get: function () {
@@ -247,7 +232,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {String}
    * @readonly
-   * @private
    */
   semantic: {
     get: function () {
@@ -261,7 +245,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {*}
    * @readonly
-   * @private
    */
   extras: {
     get: function () {
@@ -275,7 +258,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {Object}
    * @readonly
-   * @private
    */
   extensions: {
     get: function () {
@@ -290,8 +272,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
  *
  * @param {*} value The integer value or array of integer values.
  * @returns {*} The normalized value or array of normalized values.
- *
- * @private
  */
 MetadataClassProperty.prototype.normalize = function (value) {
   return normalize(this, value, MetadataType.normalize);
@@ -303,8 +283,6 @@ MetadataClassProperty.prototype.normalize = function (value) {
  *
  * @param {*} value The normalized value or array of normalized values.
  * @returns {*} The integer value or array of integer values.
- *
- * @private
  */
 MetadataClassProperty.prototype.unnormalize = function (value) {
   return normalize(this, value, MetadataType.unnormalize);

--- a/Source/Scene/MetadataClassProperty.js
+++ b/Source/Scene/MetadataClassProperty.js
@@ -141,6 +141,8 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {MetadataType}
    * @readonly
+   *
+   * @private
    */
   valueType: {
     get: function () {
@@ -272,6 +274,8 @@ Object.defineProperties(MetadataClassProperty.prototype, {
  *
  * @param {*} value The integer value or array of integer values.
  * @returns {*} The normalized value or array of normalized values.
+ *
+ * @private
  */
 MetadataClassProperty.prototype.normalize = function (value) {
   return normalize(this, value, MetadataType.normalize);
@@ -283,6 +287,8 @@ MetadataClassProperty.prototype.normalize = function (value) {
  *
  * @param {*} value The normalized value or array of normalized values.
  * @returns {*} The integer value or array of integer values.
+ *
+ * @private
  */
 MetadataClassProperty.prototype.unnormalize = function (value) {
   return normalize(this, value, MetadataType.unnormalize);

--- a/Source/Scene/MetadataEnum.js
+++ b/Source/Scene/MetadataEnum.js
@@ -67,6 +67,8 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @memberof MetadataEnum.prototype
    * @type {Object.<Number, String>}
    * @readonly
+   *
+   * @private
    */
   namesByValue: {
     get: function () {
@@ -80,6 +82,8 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @memberof MetadataEnum.prototype
    * @type {Object.<String, Number>}
    * @readonly
+   *
+   * @private
    */
   valuesByName: {
     get: function () {
@@ -93,6 +97,8 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @memberof MetadataEnum.prototype
    * @type {MetadataType}
    * @readonly
+   *
+   * @private
    */
   valueType: {
     get: function () {

--- a/Source/Scene/MetadataEnum.js
+++ b/Source/Scene/MetadataEnum.js
@@ -12,8 +12,6 @@ import MetadataType from "./MetadataType.js";
  *
  * @alias MetadataEnum
  * @constructor
- *
- * @private
  */
 function MetadataEnum(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -56,7 +54,6 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @memberof MetadataEnum.prototype
    * @type {MetadataEnumValue[]}
    * @readonly
-   * @private
    */
   values: {
     get: function () {
@@ -70,7 +67,6 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @memberof MetadataEnum.prototype
    * @type {Object.<Number, String>}
    * @readonly
-   * @private
    */
   namesByValue: {
     get: function () {
@@ -84,7 +80,6 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @memberof MetadataEnum.prototype
    * @type {Object.<String, Number>}
    * @readonly
-   * @private
    */
   valuesByName: {
     get: function () {
@@ -98,7 +93,6 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @memberof MetadataEnum.prototype
    * @type {MetadataType}
    * @readonly
-   * @private
    */
   valueType: {
     get: function () {
@@ -112,7 +106,6 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @memberof MetadataEnum.prototype
    * @type {String}
    * @readonly
-   * @private
    */
   id: {
     get: function () {
@@ -126,7 +119,6 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @memberof MetadataEnum.prototype
    * @type {String}
    * @readonly
-   * @private
    */
   name: {
     get: function () {
@@ -140,7 +132,6 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @memberof MetadataEnum.prototype
    * @type {String}
    * @readonly
-   * @private
    */
   description: {
     get: function () {
@@ -154,7 +145,6 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @memberof MetadataEnum.prototype
    * @type {*}
    * @readonly
-   * @private
    */
   extras: {
     get: function () {
@@ -168,7 +158,6 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @memberof MetadataEnum.prototype
    * @type {Object}
    * @readonly
-   * @private
    */
   extensions: {
     get: function () {

--- a/Source/Scene/MetadataEnumValue.js
+++ b/Source/Scene/MetadataEnumValue.js
@@ -7,8 +7,6 @@ import Check from "../Core/Check.js";
  *
  * @alias MetadataEnumValue
  * @constructor
- *
- * @private
  */
 function MetadataEnumValue(value) {
   //>>includeStart('debug', pragmas.debug);
@@ -29,7 +27,6 @@ Object.defineProperties(MetadataEnumValue.prototype, {
    * @memberof MetadataEnumValue.prototype
    * @type {Number}
    * @readonly
-   * @private
    */
   value: {
     get: function () {
@@ -43,7 +40,6 @@ Object.defineProperties(MetadataEnumValue.prototype, {
    * @memberof MetadataEnumValue.prototype
    * @type {String}
    * @readonly
-   * @private
    */
   name: {
     get: function () {
@@ -57,7 +53,6 @@ Object.defineProperties(MetadataEnumValue.prototype, {
    * @memberof MetadataEnumValue.prototype
    * @type {String}
    * @readonly
-   * @private
    */
   description: {
     get: function () {
@@ -71,7 +66,6 @@ Object.defineProperties(MetadataEnumValue.prototype, {
    * @memberof MetadataEnumValue.prototype
    * @type {*}
    * @readonly
-   * @private
    */
   extras: {
     get: function () {
@@ -85,7 +79,6 @@ Object.defineProperties(MetadataEnumValue.prototype, {
    * @memberof MetadataEnumValue.prototype
    * @type {Object}
    * @readonly
-   * @private
    */
   extensions: {
     get: function () {

--- a/Source/Scene/MetadataSchema.js
+++ b/Source/Scene/MetadataSchema.js
@@ -9,8 +9,6 @@ import MetadataEnum from "./MetadataEnum.js";
  *
  * @alias MetadataSchema
  * @constructor
- *
- * @private
  */
 function MetadataSchema(schema) {
   //>>includeStart('debug', pragmas.debug);
@@ -54,7 +52,6 @@ Object.defineProperties(MetadataSchema.prototype, {
    * @memberof MetadataSchema.prototype
    * @type {Object.<String, MetadataClass>}
    * @readonly
-   * @private
    */
   classes: {
     get: function () {
@@ -68,7 +65,6 @@ Object.defineProperties(MetadataSchema.prototype, {
    * @memberof MetadataSchema.prototype
    * @type {Object.<String, MetadataEnum>}
    * @readonly
-   * @private
    */
   enums: {
     get: function () {
@@ -82,7 +78,6 @@ Object.defineProperties(MetadataSchema.prototype, {
    * @memberof MetadataSchema.prototype
    * @type {String}
    * @readonly
-   * @private
    */
   name: {
     get: function () {
@@ -96,7 +91,6 @@ Object.defineProperties(MetadataSchema.prototype, {
    * @memberof MetadataSchema.prototype
    * @type {String}
    * @readonly
-   * @private
    */
   description: {
     get: function () {
@@ -110,7 +104,6 @@ Object.defineProperties(MetadataSchema.prototype, {
    * @memberof MetadataSchema.prototype
    * @type {String}
    * @readonly
-   * @private
    */
   version: {
     get: function () {
@@ -124,7 +117,6 @@ Object.defineProperties(MetadataSchema.prototype, {
    * @memberof MetadataSchema.prototype
    * @type {*}
    * @readonly
-   * @private
    */
   extras: {
     get: function () {
@@ -138,7 +130,6 @@ Object.defineProperties(MetadataSchema.prototype, {
    * @memberof MetadataSchema.prototype
    * @type {Object}
    * @readonly
-   * @private
    */
   extensions: {
     get: function () {

--- a/Source/Scene/MetadataType.js
+++ b/Source/Scene/MetadataType.js
@@ -5,9 +5,7 @@ import FeatureDetection from "../Core/FeatureDetection.js";
 /**
  * An enum of metadata types.
  *
- * @exports MetadataType
- *
- * @private
+ * @enum MetadataType
  */
 var MetadataType = {
   INT8: "INT8",

--- a/Source/Scene/MetadataType.js
+++ b/Source/Scene/MetadataType.js
@@ -35,6 +35,8 @@ var MetadataType = {
  * @returns {Number|BigInt} The minimum value.
  *
  * @exception {DeveloperError} type must be a numeric type
+ *
+ * @private
  */
 MetadataType.getMinimum = function (type) {
   //>>includeStart('debug', pragmas.debug);
@@ -85,6 +87,8 @@ MetadataType.getMinimum = function (type) {
  * @returns {Number|BigInt} The maximum value.
  *
  * @exception {DeveloperError} type must be a numeric type
+ *
+ * @private
  */
 MetadataType.getMaximum = function (type) {
   //>>includeStart('debug', pragmas.debug);
@@ -131,6 +135,8 @@ MetadataType.getMaximum = function (type) {
  *
  * @param {MetadataType} type The type.
  * @returns {Boolean} Whether the type is a numeric type.
+ *
+ * @private
  */
 MetadataType.isNumericType = function (type) {
   //>>includeStart('debug', pragmas.debug);
@@ -159,6 +165,8 @@ MetadataType.isNumericType = function (type) {
  *
  * @param {MetadataType} type The type.
  * @returns {Boolean} Whether the type is an integer type.
+ *
+ * @private
  */
 MetadataType.isIntegerType = function (type) {
   //>>includeStart('debug', pragmas.debug);
@@ -185,6 +193,8 @@ MetadataType.isIntegerType = function (type) {
  *
  * @param {MetadataType} type The type.
  * @returns {Boolean} Whether the type is an unsigned integer type.
+ *
+ * @private
  */
 MetadataType.isUnsignedIntegerType = function (type) {
   //>>includeStart('debug', pragmas.debug);
@@ -217,6 +227,8 @@ MetadataType.isUnsignedIntegerType = function (type) {
  *
  * @exception {DeveloperError} value must be a number or a BigInt
  * @exception {DeveloperError} type must be an integer type
+ *
+ * @private
  */
 MetadataType.normalize = function (value, type) {
   //>>includeStart('debug', pragmas.debug);
@@ -248,6 +260,8 @@ MetadataType.normalize = function (value, type) {
  * @returns {Number|BigInt} The integer value.
  *
  * @exception {DeveloperError} type must be an integer type
+ *
+ * @private
  */
 MetadataType.unnormalize = function (value, type) {
   //>>includeStart('debug', pragmas.debug);


### PR DESCRIPTION
In a couple future 3D Tiles Next branches, the `MetadataSchema` object will be accessible through 3D Tiles objects such as `tileset.getSchema()`. Since this will be part of the public API, `MetadataSchema` and related classes also need to be marked as public in the JSDoc. Otherwise, the TypeScript build will fail. 

This only exposes `MetadataSchema` to the Cesium API, not other classes like `MetadataTable`.

@lilleyse could you review this?