### PR TITLE
Add JsonMetadataTable in preparation for batch table refactor

### DIFF
--- a/Source/Scene/JsonMetadataTable.js
+++ b/Source/Scene/JsonMetadataTable.js
@@ -9,10 +9,11 @@ import MetadataEntity from "./MetadataEntity.js";
  *
  * @param {Object} options Object with the following properties:
  * @param {Number} options.count The number of entities in the table.
- * @param {Object.<String, Array>} options.properties The JSON representation of the metadata table. All the arrays must have exactly options.count elements. The value of array
+ * @param {Object.<String, Array>} options.properties The JSON representation of the metadata table. All the arrays must have exactly options.count elements.
  * @param {MetadataClass} [options.class] The class that group metadata conforms to.
  * @alias JsonMetadataTable
  * @constructor
+ * @private
  */
 export default function JsonMetadataTable(options) {
   //>>includeStart('debug', pragmas.debug);
@@ -29,6 +30,7 @@ export default function JsonMetadataTable(options) {
  *
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {Boolean} Whether this property exists.
+ * @private
  */
 JsonMetadataTable.prototype.hasProperty = function (propertyId) {
   return MetadataEntity.hasProperty(propertyId, this._properties);
@@ -39,6 +41,7 @@ JsonMetadataTable.prototype.hasProperty = function (propertyId) {
  *
  * @param {String[]} [results] An array into which to store the results.
  * @returns {String[]} The property IDs.
+ * @private
  */
 JsonMetadataTable.prototype.getPropertyIds = function (results) {
   return MetadataEntity.getPropertyIds(this._properties, undefined, results);
@@ -46,13 +49,12 @@ JsonMetadataTable.prototype.getPropertyIds = function (results) {
 
 /**
  * Returns a copy of the value of the property with the given ID.
- * <p>
- * If the property is normalized the normalized value is returned.
- * </p>
  *
  * @param {Number} index The index of the entity.
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @exception {DeveloperError} index is out of bounds
+ * @private
  */
 JsonMetadataTable.prototype.getProperty = function (index, propertyId) {
   //>>includeStart('debug', pragmas.debug);
@@ -79,6 +81,8 @@ JsonMetadataTable.prototype.getProperty = function (index, propertyId) {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @param {*} value The value of the property that will be copied.
  * @exception {DeveloperError} A property with the given ID doesn't exist.
+ * @exception {DeveloperError} index is out of bounds
+ * @private
  */
 JsonMetadataTable.prototype.setProperty = function (index, propertyId, value) {
   //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/JsonMetadataTable.js
+++ b/Source/Scene/JsonMetadataTable.js
@@ -10,7 +10,7 @@ import MetadataEntity from "./MetadataEntity.js";
  * @param {Object} options Object with the following properties:
  * @param {Number} options.count The number of entities in the table.
  * @param {Object.<String, Array>} options.properties The JSON representation of the metadata table. All the arrays must have exactly options.count elements.
- * @param {MetadataClass} [options.class] The class that group metadata conforms to.
+ *
  * @alias JsonMetadataTable
  * @constructor
  * @private
@@ -61,7 +61,7 @@ JsonMetadataTable.prototype.getProperty = function (index, propertyId) {
   Check.typeOf.number("index", index);
   Check.typeOf.string("propertyId", propertyId);
 
-  if (index < 0 || this._count < index) {
+  if (index < 0 || index >= this._count) {
     throw new DeveloperError("index must be in [0, " + this._count + ")");
   }
   //>>includeEnd('debug');
@@ -98,8 +98,5 @@ JsonMetadataTable.prototype.setProperty = function (index, propertyId, value) {
   }
   //>>includeEnd('debug');
 
-  var property = this._properties[propertyId];
-  if (defined(property)) {
-    property[index] = clone(value, true);
-  }
+  this._properties[propertyId][index] = clone(value, true);
 };

--- a/Source/Scene/JsonMetadataTable.js
+++ b/Source/Scene/JsonMetadataTable.js
@@ -93,7 +93,7 @@ JsonMetadataTable.prototype.setProperty = function (index, propertyId, value) {
     throw new DeveloperError("propertyId " + propertyId + " does not exist");
   }
 
-  if (index < 0 || this._count < index) {
+  if (index < 0 || index >= this._count) {
     throw new DeveloperError("index must be in [0, " + this._count + ")");
   }
   //>>includeEnd('debug');

--- a/Source/Scene/JsonMetadataTable.js
+++ b/Source/Scene/JsonMetadataTable.js
@@ -1,0 +1,101 @@
+import Check from "../Core/Check.js";
+import clone from "../Core/clone.js";
+import defined from "../Core/defined.js";
+import DeveloperError from "../Core/DeveloperError.js";
+import MetadataEntity from "./MetadataEntity.js";
+
+/**
+ * A table for storing free-form JSON metadata, as in the 3D Tiles batch table.
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {Number} options.count The number of entities in the table.
+ * @param {Object.<String, Array>} options.properties The JSON representation of the metadata table. All the arrays must have exactly options.count elements. The value of array
+ * @param {MetadataClass} [options.class] The class that group metadata conforms to.
+ * @alias JsonMetadataTable
+ * @constructor
+ */
+export default function JsonMetadataTable(options) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.number.greaterThan("options.count", options.count, 0);
+  Check.typeOf.object("options.properties", options.properties);
+  //>>includeEnd('debug');
+
+  this._count = options.count;
+  this._properties = clone(options.properties, true);
+}
+
+/**
+ * Returns whether this property exists.
+ *
+ * @param {String} propertyId The case-sensitive ID of the property.
+ * @returns {Boolean} Whether this property exists.
+ */
+JsonMetadataTable.prototype.hasProperty = function (propertyId) {
+  return MetadataEntity.hasProperty(propertyId, this._properties);
+};
+
+/**
+ * Returns an array of property IDs.
+ *
+ * @param {String[]} [results] An array into which to store the results.
+ * @returns {String[]} The property IDs.
+ */
+JsonMetadataTable.prototype.getPropertyIds = function (results) {
+  return MetadataEntity.getPropertyIds(this._properties, undefined, results);
+};
+
+/**
+ * Returns a copy of the value of the property with the given ID.
+ * <p>
+ * If the property is normalized the normalized value is returned.
+ * </p>
+ *
+ * @param {Number} index The index of the entity.
+ * @param {String} propertyId The case-sensitive ID of the property.
+ * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ */
+JsonMetadataTable.prototype.getProperty = function (index, propertyId) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.number("index", index);
+  Check.typeOf.string("propertyId", propertyId);
+
+  if (index < 0 || this._count < index) {
+    throw new DeveloperError("index must be in [0, " + this._count + ")");
+  }
+  //>>includeEnd('debug');
+
+  var property = this._properties[propertyId];
+  if (defined(property)) {
+    return clone(property[index], true);
+  }
+
+  return undefined;
+};
+
+/**
+ * Sets the value of the property with the given ID.
+ *
+ * @param {Number} index The index of the entity.
+ * @param {String} propertyId The case-sensitive ID of the property.
+ * @param {*} value The value of the property that will be copied.
+ * @exception {DeveloperError} A property with the given ID doesn't exist.
+ */
+JsonMetadataTable.prototype.setProperty = function (index, propertyId, value) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.number("index", index);
+  Check.typeOf.string("propertyId", propertyId);
+
+  if (!defined(this._properties[propertyId])) {
+    throw new DeveloperError("propertyId " + propertyId + " does not exist");
+  }
+
+  if (index < 0 || this._count < index) {
+    throw new DeveloperError("index must be in [0, " + this._count + ")");
+  }
+  //>>includeEnd('debug');
+
+  var property = this._properties[propertyId];
+  if (defined(property)) {
+    property[index] = clone(value, true);
+  }
+};

--- a/Source/Scene/MetadataEntity.js
+++ b/Source/Scene/MetadataEntity.js
@@ -281,7 +281,7 @@ MetadataEntity.setProperty = function (
  *
  * @param {String} semantic The case-sensitive semantic of the property.
  * @param {Object} properties The dictionary containing properties.
- * @param {MetadataClass} [classDefinition] The class.
+ * @param {MetadataClass} classDefinition The class.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
  *
  * @private
@@ -295,16 +295,13 @@ MetadataEntity.getPropertyBySemantic = function (
   Check.typeOf.string("semantic", semantic);
   Check.typeOf.object("properties", properties);
   //>>includeEnd('debug');
+  if (!defined(classDefinition)) {
+    return undefined;
+  }
 
-  if (defined(classDefinition)) {
-    var property = classDefinition.propertiesBySemantic[semantic];
-    if (defined(property)) {
-      return MetadataEntity.getProperty(
-        property.id,
-        properties,
-        classDefinition
-      );
-    }
+  var property = classDefinition.propertiesBySemantic[semantic];
+  if (defined(property)) {
+    return MetadataEntity.getProperty(property.id, properties, classDefinition);
   }
   return undefined;
 };
@@ -315,7 +312,7 @@ MetadataEntity.getPropertyBySemantic = function (
  * @param {String} semantic The case-sensitive semantic of the property.
  * @param {*} value The value of the property that will be copied.
  * @param {Object} properties The dictionary containing properties.
- * @param {MetadataClass} [classDefinition] The class.
+ * @param {MetadataClass} classDefinition The class.
  * @exception {DeveloperError} A property with the given semantic doesn't exist.
  * @private
  */
@@ -329,24 +326,18 @@ MetadataEntity.setPropertyBySemantic = function (
   Check.typeOf.string("semantic", semantic);
   Check.defined("value", value);
   Check.typeOf.object("properties", properties);
+  Check.typeOf.object("classDefinition", classDefinition);
   //>>includeEnd('debug');
 
-  if (defined(classDefinition)) {
-    var property = classDefinition.propertiesBySemantic[semantic];
-    if (defined(property)) {
-      MetadataEntity.setProperty(
-        property.id,
-        value,
-        properties,
-        classDefinition
-      );
-    }
-    //>>includeStart('debug', pragmas.debug);
-    else {
-      throw new DeveloperError("semantic " + semantic + " does not exist");
-    }
-    //>>includeEnd('debug');
+  var property = classDefinition.propertiesBySemantic[semantic];
+  if (defined(property)) {
+    MetadataEntity.setProperty(property.id, value, properties, classDefinition);
   }
+  //>>includeStart('debug', pragmas.debug);
+  else {
+    throw new DeveloperError("semantic " + semantic + " does not exist");
+  }
+  //>>includeEnd('debug');
 };
 
 export default MetadataEntity;

--- a/Specs/Scene/JsonMetadataTableSpec.js
+++ b/Specs/Scene/JsonMetadataTableSpec.js
@@ -1,0 +1,161 @@
+import { JsonMetadataTable } from "../../Source/Cesium.js";
+
+describe("Scene/JsonMetadataTable", function () {
+  var properties = {
+    priority: [2, 1, 0],
+    labels: ["Point Cloud", "Mesh", "Raster"],
+    uri: ["tree.las", "building.gltf", "map.tif"],
+    sizeInfo: [
+      {
+        pointCount: 100,
+      },
+      {
+        vertices: 3000,
+        faces: 1000,
+      },
+      {
+        width: 1024,
+        height: 1024,
+      },
+    ],
+    mixedValues: ["red", 3, false],
+  };
+  var count = 3;
+
+  var table;
+  beforeEach(function () {
+    table = new JsonMetadataTable({
+      count: count,
+      properties: properties,
+    });
+  });
+
+  it("constructor throws without count", function () {
+    expect(function () {
+      return new JsonMetadataTable({
+        count: undefined,
+        properties: properties,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("constructor throws without properties", function () {
+    expect(function () {
+      return new JsonMetadataTable({
+        count: count,
+        properties: undefined,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("constructor clones properties", function () {
+    var oldValue = properties.sizeInfo[0];
+    var sizeInfo = {
+      lengthBytes: 1024,
+    };
+    table.setProperty(0, "sizeInfo", sizeInfo);
+    expect(properties.sizeInfo[0]).toBe(oldValue);
+    expect(table.getProperty(0, "sizeInfo")).toEqual(sizeInfo);
+  });
+
+  it("hasProperty returns true if the property exists", function () {
+    expect(table.hasProperty("priority")).toBe(true);
+  });
+
+  it("hasProperty returns false if the property does not exist", function () {
+    expect(table.hasProperty("price")).toBe(false);
+  });
+
+  it("getPropertyIds returns a list of property Ids", function () {
+    expect(table.getPropertyIds().sort()).toEqual([
+      "labels",
+      "mixedValues",
+      "priority",
+      "sizeInfo",
+      "uri",
+    ]);
+  });
+
+  it("getProperty returns undefined for unknown property Id", function () {
+    expect(table.getProperty(0, "color")).not.toBeDefined();
+  });
+
+  it("getProperty throws without index", function () {
+    expect(function () {
+      return table.getProperty(undefined, "priority");
+    }).toThrowDeveloperError();
+  });
+
+  it("getProperty throws for out-of-bounds index", function () {
+    expect(function () {
+      return table.getProperty(5, "priority");
+    }).toThrowDeveloperError();
+  });
+
+  it("getProperty throws without propertyId", function () {
+    expect(function () {
+      return table.getProperty(5, undefined);
+    }).toThrowDeveloperError();
+  });
+
+  it("getProperty returns the property value", function () {
+    expect(table.getProperty(0, "priority")).toBe(2);
+    expect(table.getProperty(1, "priority")).toBe(1);
+    expect(table.getProperty(2, "priority")).toBe(0);
+  });
+
+  it("getProperty returns copy of value", function () {
+    var value1 = table.getProperty(1, "sizeInfo");
+    var value2 = table.getProperty(1, "sizeInfo");
+    expect(value1).toEqual(properties.sizeInfo[1]);
+    expect(value1).toEqual(value2);
+    expect(value2).not.toBe(value1);
+  });
+
+  it("getProperty works with heterogeneous values", function () {
+    expect(table.getProperty(0, "mixedValues")).toBe("red");
+    expect(table.getProperty(1, "mixedValues")).toBe(3);
+    expect(table.getProperty(2, "mixedValues")).toBe(false);
+  });
+
+  it("setProperty throws without index", function () {
+    expect(function () {
+      return table.setProperty(undefined, undefined);
+    }).toThrowDeveloperError();
+  });
+
+  it("setProperty throws for out-of-bounds index", function () {
+    expect(function () {
+      return table.setProperty(5, "priority", 3);
+    }).toThrowDeveloperError();
+  });
+
+  it("setProperty throws without propertyId", function () {
+    expect(function () {
+      return table.setProperty(5, undefined);
+    }).toThrowDeveloperError();
+  });
+
+  it("setProperty throws if property doesn't exist", function () {
+    expect(function () {
+      return table.setProperty(0, "color", [255, 255, 255, 1.0]);
+    }).toThrowDeveloperError();
+  });
+
+  it("setProperty sets property value", function () {
+    var sizeInfo = {
+      lengthBytes: 1024,
+    };
+    table.setProperty(0, "sizeInfo", sizeInfo);
+    expect(table.getProperty(0, "sizeInfo")).toEqual(sizeInfo);
+  });
+
+  it("setProperty copies value", function () {
+    var sizeInfo = {
+      lengthBytes: 1024,
+    };
+    table.setProperty(1, "sizeInfo", sizeInfo);
+    sizeInfo.offset = 8;
+    expect(table.getProperty(1, "sizeInfo")).not.toEqual(sizeInfo);
+  });
+});

--- a/Specs/Scene/MetadataEntitySpec.js
+++ b/Specs/Scene/MetadataEntitySpec.js
@@ -87,6 +87,11 @@ describe("Scene/MetadataEntity", function () {
     }).toThrowDeveloperError();
   });
 
+  it("hasProperty works without classDefinition", function () {
+    expect(MetadataEntity.hasProperty("name", properties)).toBe(true);
+    expect(MetadataEntity.hasProperty("volume", properties)).toBe(false);
+  });
+
   it("getPropertyIds returns empty array when there are no properties", function () {
     expect(MetadataEntity.getPropertyIds({}).length).toBe(0);
   });
@@ -114,6 +119,17 @@ describe("Scene/MetadataEntity", function () {
     expect(function () {
       MetadataEntity.getPropertyIds(undefined, classDefinition);
     }).toThrowDeveloperError();
+  });
+
+  it("getPropertyIds works without classDefinition", function () {
+    var results = [];
+    var returnedResults = MetadataEntity.getPropertyIds(
+      properties,
+      undefined,
+      results
+    );
+    expect(results).toBe(returnedResults);
+    expect(results.sort()).toEqual(["name", "position"]);
   });
 
   it("getProperty returns undefined when there's no properties", function () {
@@ -152,6 +168,12 @@ describe("Scene/MetadataEntity", function () {
     expect(function () {
       MetadataEntity.hasProperty("name", undefined, classDefinition);
     }).toThrowDeveloperError();
+  });
+
+  it("getProperty works without classDefinition", function () {
+    var value = MetadataEntity.getProperty("position", properties, undefined);
+    expect(value).toEqual(properties.position);
+    expect(value).not.toBe(properties.position); // The value is cloned
   });
 
   it("setProperty throws if property doesn't exist", function () {
@@ -210,6 +232,14 @@ describe("Scene/MetadataEntity", function () {
     }).toThrowDeveloperError();
   });
 
+  it("setProperty works without classDefinition", function () {
+    var position = [1.0, 1.0, 1.0];
+    MetadataEntity.setProperty("position", position, properties);
+    var retrievedPosition = MetadataEntity.getProperty("position", properties);
+    expect(retrievedPosition).toEqual(position);
+    expect(retrievedPosition).not.toBe(position); // The value is cloned
+  });
+
   it("getPropertyBySemantic returns undefined when there's no class", function () {
     expect(
       MetadataEntity.getPropertyBySemantic("NAME", properties)
@@ -246,6 +276,12 @@ describe("Scene/MetadataEntity", function () {
     expect(function () {
       MetadataEntity.getPropertyBySemantic("NAME", undefined, classDefinition);
     }).toThrowDeveloperError();
+  });
+
+  it("getPropertyBySemantic returns undefined without classDefinition", function () {
+    expect(
+      MetadataEntity.getPropertyBySemantic("NAME", properties, undefined)
+    ).toBeUndefined();
   });
 
   it("setPropertyBySemantic sets property value", function () {
@@ -300,6 +336,17 @@ describe("Scene/MetadataEntity", function () {
         "Building B",
         undefined,
         classDefinition
+      );
+    }).toThrowDeveloperError();
+  });
+
+  it("setPropertyBySemantic throws without classDefinition", function () {
+    expect(function () {
+      MetadataEntity.setPropertyBySemantic(
+        "NAME",
+        "Building B",
+        properties,
+        undefined
       );
     }).toThrowDeveloperError();
   });


### PR DESCRIPTION
This branch targets `3d-tiles-next`.

This adds a `JsonMetadataTable`, a class that serves a similar purpose as `MetadataTable` does, though instead of binary properties, it stores free-form JSON arrays. This is for compatibility with [Batch Tables](https://github.com/CesiumGS/3d-tiles/tree/master/specification/TileFormats/BatchTable).

This PR does not handle batch table hierarchy or parsing batch tables, that will be in future PRs

@lilleyse 