### PR TITLE
Deprecate loadCRN and loadKTX

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,8 @@
 
 ##### Deprecated :hourglass_flowing_sand:
 
-- `loadCRN` has been deprecated and will be removed in CesiumJS 1.82. It will be replaced with support for KTX2. [9478](https://github.com/CesiumGS/cesium/pull/9478)
-- `loadKTX` has been deprecated and will be removed in CesiumJS 1.82. It will be replaced with support for KTX2. [9478](https://github.com/CesiumGS/cesium/pull/9478)
+- `loadCRN` has been deprecated and will be removed in CesiumJS 1.82. It will be replaced with support for KTX2. [#9478](https://github.com/CesiumGS/cesium/pull/9478)
+- `loadKTX` has been deprecated and will be removed in CesiumJS 1.82. It will be replaced with support for KTX2. [#9478](https://github.com/CesiumGS/cesium/pull/9478)
 
 ### 1.80 - 2021-04-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ##### Deprecated :hourglass_flowing_sand:
 
-- `loadCRN` has been deprecated and will be removed in CesiumJS 1.82. It will be replaced with support for KTX2.[9478](https://github.com/CesiumGS/cesium/pull/9478)
+- `loadCRN` has been deprecated and will be removed in CesiumJS 1.82. It will be replaced with support for KTX2. [9478](https://github.com/CesiumGS/cesium/pull/9478)
 - `loadKTX` has been deprecated and will be removed in CesiumJS 1.82. It will be replaced with support for KTX2. [9478](https://github.com/CesiumGS/cesium/pull/9478)
 
 ### 1.80 - 2021-04-01

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,8 @@
 
 ##### Deprecated :hourglass_flowing_sand:
 
-- `loadCRN` was deprecated and will be removed in Cesium 1.82. It will be replaced with support for KTX2.[9478](https://github.com/CesiumGS/cesium/pull/9478)
-- `loadKTX` was deprecated and will be removed in Cesium 1.82. It will be replaced with support for KTX2. [9478](https://github.com/CesiumGS/cesium/pull/9478)
+- `loadCRN` has been deprecated and will be removed in CesiumJS 1.82. It will be replaced with support for KTX2.[9478](https://github.com/CesiumGS/cesium/pull/9478)
+- `loadKTX` has been deprecated and will be removed in CesiumJS 1.82. It will be replaced with support for KTX2. [9478](https://github.com/CesiumGS/cesium/pull/9478)
 
 ### 1.80 - 2021-04-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change Log
 
+### 1.81 - 2021-05-01
+
+##### Deprecated :hourglass_flowing_sand:
+
+- `loadCRN` was deprecated and will be removed in Cesium 1.82. It will be replaced with support for KTX2.[9478](https://github.com/CesiumGS/cesium/pull/9478)
+- `loadKTX` was deprecated and will be removed in Cesium 1.82. It will be replaced with support for KTX2. [9478](https://github.com/CesiumGS/cesium/pull/9478)
+
 ### 1.80 - 2021-04-01
 
 ##### Additions :tada:

--- a/Source/Core/loadCRN.js
+++ b/Source/Core/loadCRN.js
@@ -37,12 +37,12 @@ var transcodeTaskProcessor = new TaskProcessor("transcodeCRNToDXT");
  * @see {@link https://github.com/BinomialLLC/crunch|crunch DXTc texture compression and transcoding library}
  * @see {@link http://www.w3.org/TR/cors/|Cross-Origin Resource Sharing}
  * @see {@link http://wiki.commonjs.org/wiki/Promises/A|CommonJS Promises/A}
- * @deprecated This function has been deprecated and will be removed in Cesium 1.82.
+ * @deprecated This function has been deprecated and will be removed in CesiumJS 1.82.
  */
 function loadCRN(resourceOrUrlOrBuffer) {
   deprecationWarning(
     "loadCRN",
-    "loadCRN is deprecated and will be removed in Cesium 1.82."
+    "loadCRN is deprecated and will be removed in CesiumJS 1.82."
   );
   //>>includeStart('debug', pragmas.debug);
   if (!defined(resourceOrUrlOrBuffer)) {

--- a/Source/Core/loadCRN.js
+++ b/Source/Core/loadCRN.js
@@ -4,6 +4,7 @@ import defined from "./defined.js";
 import DeveloperError from "./DeveloperError.js";
 import Resource from "./Resource.js";
 import TaskProcessor from "./TaskProcessor.js";
+import deprecationWarning from "./deprecationWarning.js";
 
 var transcodeTaskProcessor = new TaskProcessor("transcodeCRNToDXT");
 
@@ -36,8 +37,13 @@ var transcodeTaskProcessor = new TaskProcessor("transcodeCRNToDXT");
  * @see {@link https://github.com/BinomialLLC/crunch|crunch DXTc texture compression and transcoding library}
  * @see {@link http://www.w3.org/TR/cors/|Cross-Origin Resource Sharing}
  * @see {@link http://wiki.commonjs.org/wiki/Promises/A|CommonJS Promises/A}
+ * @deprecated This function has been deprecated and will be removed in Cesium 1.82.
  */
 function loadCRN(resourceOrUrlOrBuffer) {
+  deprecationWarning(
+    "loadCRN",
+    "loadCRN is deprecated and will be removed in Cesium 1.82."
+  );
   //>>includeStart('debug', pragmas.debug);
   if (!defined(resourceOrUrlOrBuffer)) {
     throw new DeveloperError("resourceOrUrlOrBuffer is required.");

--- a/Source/Core/loadKTX.js
+++ b/Source/Core/loadKTX.js
@@ -58,12 +58,12 @@ import deprecationWarning from "./deprecationWarning.js";
  * @see {@link https://www.khronos.org/opengles/sdk/tools/KTX/file_format_spec/|KTX file format}
  * @see {@link http://www.w3.org/TR/cors/|Cross-Origin Resource Sharing}
  * @see {@link http://wiki.commonjs.org/wiki/Promises/A|CommonJS Promises/A}
- * @deprecated This function has been deprecated and will be removed in Cesium 1.82.
+ * @deprecated This function has been deprecated and will be removed in CesiumJS 1.82.
  */
 function loadKTX(resourceOrUrlOrBuffer) {
   deprecationWarning(
     "loadKTX",
-    "loadKTX is deprecated and will be removed in Cesium 1.82."
+    "loadKTX is deprecated and will be removed in CesiumJS 1.82."
   );
   //>>includeStart('debug', pragmas.debug);
   Check.defined("resourceOrUrlOrBuffer", resourceOrUrlOrBuffer);

--- a/Source/Core/loadKTX.js
+++ b/Source/Core/loadKTX.js
@@ -6,6 +6,7 @@ import PixelFormat from "./PixelFormat.js";
 import Resource from "./Resource.js";
 import RuntimeError from "./RuntimeError.js";
 import WebGLConstants from "./WebGLConstants.js";
+import deprecationWarning from "./deprecationWarning.js";
 
 /**
  * Asynchronously loads and parses the given URL to a KTX file or parses the raw binary data of a KTX file.
@@ -57,8 +58,13 @@ import WebGLConstants from "./WebGLConstants.js";
  * @see {@link https://www.khronos.org/opengles/sdk/tools/KTX/file_format_spec/|KTX file format}
  * @see {@link http://www.w3.org/TR/cors/|Cross-Origin Resource Sharing}
  * @see {@link http://wiki.commonjs.org/wiki/Promises/A|CommonJS Promises/A}
+ * @deprecated This function has been deprecated and will be removed in Cesium 1.82.
  */
 function loadKTX(resourceOrUrlOrBuffer) {
+  deprecationWarning(
+    "loadKTX",
+    "loadKTX is deprecated and will be removed in Cesium 1.82."
+  );
   //>>includeStart('debug', pragmas.debug);
   Check.defined("resourceOrUrlOrBuffer", resourceOrUrlOrBuffer);
   //>>includeEnd('debug');


### PR DESCRIPTION
This deprecates `loadCRN` and `loadKTX` as we will move to support KTX2 in Cesium 1.82. 