### PR TITLE
glTF loaders

### DIFF
--- a/Source/Scene/DracoLoader.js
+++ b/Source/Scene/DracoLoader.js
@@ -287,6 +287,28 @@ DracoLoader.decodePointCloud = function (parameters) {
 };
 
 /**
+ * Decodes a buffer view. Returns undefined if the task cannot be scheduled.
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {Uint8Array} options.array The typed array containing the buffer view data.
+ * @param {Object} options.bufferView The glTF buffer view object.
+ * @param {Object.<String, Number>} options.compressedAttributes The compressed attributes.
+ * @param {Boolean} options.dequantizeInShader Whether POSITION and NORMAL attributes should be dequantized on the GPU.
+ *
+ * @returns {Promise} A promise that resolves to the decoded indices and attributes.
+ * @private
+ */
+DracoLoader.decodeBufferView = function (options) {
+  var decoderTaskProcessor = DracoLoader._getDecoderTaskProcessor();
+  if (!DracoLoader._taskProcessorReady) {
+    // The task processor is not ready to schedule tasks
+    return;
+  }
+
+  return decoderTaskProcessor.scheduleTask(options, [options.array.buffer]);
+};
+
+/**
  * Caches a models decoded data so it doesn't need to decode more than once.
  * @private
  */

--- a/Source/Scene/GltfBufferViewLoader.js
+++ b/Source/Scene/GltfBufferViewLoader.js
@@ -1,0 +1,175 @@
+import Check from "../Core/Check.js";
+import defaultValue from "../Core/defaultValue.js";
+import defined from "../Core/defined.js";
+import when from "../ThirdParty/when.js";
+import ResourceLoader from "./ResourceLoader.js";
+import ResourceLoaderState from "./ResourceLoaderState.js";
+
+/**
+ * Loads a glTF buffer view.
+ * <p>
+ * Implements the {@link ResourceLoader} interface.
+ * </p>
+ *
+ * @alias GltfBufferViewLoader
+ * @constructor
+ * @augments ResourceLoader
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {ResourceCache} options.resourceCache The {@link ResourceCache} (to avoid circular dependencies).
+ * @param {Object} options.gltf The glTF JSON.
+ * @param {Number} options.bufferViewId The buffer view ID.
+ * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {String} [options.cacheKey] The cache key of the resource.
+ *
+ * @private
+ */
+export default function GltfBufferViewLoader(options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var resourceCache = options.resourceCache;
+  var gltf = options.gltf;
+  var bufferViewId = options.bufferViewId;
+  var gltfResource = options.gltfResource;
+  var baseResource = options.baseResource;
+  var cacheKey = options.cacheKey;
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.func("options.resourceCache", resourceCache);
+  Check.typeOf.object("options.gltf", gltf);
+  Check.typeOf.number("options.bufferViewId", bufferViewId);
+  Check.typeOf.object("options.gltfResource", gltfResource);
+  Check.typeOf.object("options.baseResource", baseResource);
+  //>>includeEnd('debug');
+
+  var bufferView = gltf.bufferViews[bufferViewId];
+  var bufferId = bufferView.buffer;
+  var buffer = gltf.buffers[bufferId];
+
+  this._resourceCache = resourceCache;
+  this._gltfResource = gltfResource;
+  this._baseResource = baseResource;
+  this._buffer = buffer;
+  this._bufferId = bufferId;
+  this._byteOffset = bufferView.byteOffset;
+  this._byteLength = bufferView.byteLength;
+  this._cacheKey = cacheKey;
+  this._bufferLoader = undefined;
+  this._typedArray = undefined;
+  this._state = ResourceLoaderState.UNLOADED;
+  this._promise = when.defer();
+}
+
+if (defined(Object.create)) {
+  GltfBufferViewLoader.prototype = Object.create(ResourceLoader.prototype);
+  GltfBufferViewLoader.prototype.constructor = GltfBufferViewLoader;
+}
+
+Object.defineProperties(GltfBufferViewLoader.prototype, {
+  /**
+   * A promise that resolves to the resource when the resource is ready.
+   *
+   * @memberof GltfBufferViewLoader.prototype
+   *
+   * @type {Promise.<GltfBufferViewLoader>}
+   * @readonly
+   */
+  promise: {
+    get: function () {
+      return this._promise.promise;
+    },
+  },
+  /**
+   * The cache key of the resource.
+   *
+   * @memberof GltfBufferViewLoader.prototype
+   *
+   * @type {String}
+   * @readonly
+   */
+  cacheKey: {
+    get: function () {
+      return this._cacheKey;
+    },
+  },
+  /**
+   * The typed array containing buffer view data.
+   *
+   * @memberof GltfBufferViewLoader.prototype
+   *
+   * @type {Uint8Array}
+   * @readonly
+   */
+  typedArray: {
+    get: function () {
+      return this._typedArray;
+    },
+  },
+});
+
+/**
+ * Loads the resource.
+ */
+GltfBufferViewLoader.prototype.load = function () {
+  var bufferLoader = getBufferLoader(this);
+  this._bufferLoader = bufferLoader;
+  this._state = ResourceLoaderState.LOADING;
+
+  var that = this;
+
+  bufferLoader.promise
+    .then(function () {
+      if (that.isDestroyed()) {
+        return;
+      }
+      var bufferTypedArray = bufferLoader.typedArray;
+      var bufferViewTypedArray = new Uint8Array(
+        bufferTypedArray.buffer,
+        bufferTypedArray.byteOffset + that._byteOffset,
+        that._byteLength
+      );
+      // Keep bufferLoader loaded since we're still holding onto a view of the
+      // buffer and not ready to release it.
+      that._typedArray = bufferViewTypedArray;
+      that._state = ResourceLoaderState.READY;
+      that._promise.resolve(that);
+    })
+    .otherwise(function (error) {
+      that.unload();
+      that._state = ResourceLoaderState.FAILED;
+      var errorMessage = "Failed to load buffer view";
+      that._promise.reject(that.getError(errorMessage, error));
+    });
+};
+
+function getBufferLoader(bufferViewLoader) {
+  var resourceCache = bufferViewLoader._resourceCache;
+  var buffer = bufferViewLoader._buffer;
+  if (defined(buffer.uri)) {
+    var baseResource = bufferViewLoader._baseResource;
+    var resource = baseResource.getDerivedResource({
+      url: buffer.uri,
+    });
+    return resourceCache.loadExternalBuffer({
+      resource: resource,
+      keepResident: false,
+    });
+  }
+  return resourceCache.loadEmbeddedBuffer({
+    parentResource: bufferViewLoader._gltfResource,
+    bufferId: bufferViewLoader._bufferId,
+    keepResident: false,
+  });
+}
+
+/**
+ * Unloads the resource.
+ */
+GltfBufferViewLoader.prototype.unload = function () {
+  if (defined(this._bufferLoader)) {
+    this._resourceCache.unload(this._bufferLoader);
+  }
+
+  this._bufferLoader = undefined;
+  this._typedArray = undefined;
+};

--- a/Source/Scene/GltfDracoLoader.js
+++ b/Source/Scene/GltfDracoLoader.js
@@ -1,0 +1,219 @@
+import Check from "../Core/Check.js";
+import defaultValue from "../Core/defaultValue.js";
+import defined from "../Core/defined.js";
+import when from "../ThirdParty/when.js";
+import DracoLoader from "./DracoLoader.js";
+import ResourceLoader from "./ResourceLoader.js";
+import ResourceLoaderState from "./ResourceLoaderState.js";
+
+/**
+ * Load a draco buffer from a glTF.
+ * <p>
+ * Implements the {@link ResourceLoader} interface.
+ * </p>
+ *
+ * @alias GltfDracoLoader
+ * @constructor
+ * @augments ResourceLoader
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {ResourceCache} options.resourceCache The {@link ResourceCache} (to avoid circular dependencies).
+ * @param {Object} options.gltf The glTF JSON.
+ * @param {Object} options.draco The Draco extension object.
+ * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {String} [options.cacheKey] The cache key of the resource.
+ *
+ * @private
+ */
+export default function GltfDracoLoader(options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var resourceCache = options.resourceCache;
+  var gltf = options.gltf;
+  var draco = options.draco;
+  var gltfResource = options.gltfResource;
+  var baseResource = options.baseResource;
+  var cacheKey = options.cacheKey;
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.func("options.resourceCache", resourceCache);
+  Check.typeOf.object("options.gltf", gltf);
+  Check.typeOf.object("options.draco", draco);
+  Check.typeOf.object("options.gltfResource", gltfResource);
+  Check.typeOf.object("options.baseResource", baseResource);
+  //>>includeEnd('debug');
+
+  this._resourceCache = resourceCache;
+  this._gltfResource = gltfResource;
+  this._baseResource = baseResource;
+  this._gltf = gltf;
+  this._draco = draco;
+  this._cacheKey = cacheKey;
+  this._bufferViewLoader = undefined;
+  this._bufferViewTypedArray = undefined;
+  this._decodePromise = undefined;
+  this._decodedData = undefined;
+  this._state = ResourceLoaderState.UNLOADED;
+  this._promise = when.defer();
+}
+
+if (defined(Object.create)) {
+  GltfDracoLoader.prototype = Object.create(ResourceLoader.prototype);
+  GltfDracoLoader.prototype.constructor = GltfDracoLoader;
+}
+
+Object.defineProperties(GltfDracoLoader.prototype, {
+  /**
+   * A promise that resolves to the resource when the resource is ready.
+   *
+   * @memberof GltfDracoLoader.prototype
+   *
+   * @type {Promise.<GltfDracoLoader>}
+   * @readonly
+   */
+  promise: {
+    get: function () {
+      return this._promise.promise;
+    },
+  },
+  /**
+   * The cache key of the resource.
+   *
+   * @memberof GltfDracoLoader.prototype
+   *
+   * @type {String}
+   * @readonly
+   */
+  cacheKey: {
+    get: function () {
+      return this._cacheKey;
+    },
+  },
+  /**
+   * The decoded data.
+   *
+   * @memberof GltfDracoLoader.prototype
+   *
+   * @type {Object}
+   * @readonly
+   */
+  decodedData: {
+    get: function () {
+      return this._decodedData;
+    },
+  },
+});
+
+/**
+ * Loads the resource.
+ */
+GltfDracoLoader.prototype.load = function () {
+  var resourceCache = this._resourceCache;
+  var bufferViewLoader = resourceCache.loadBufferView({
+    gltf: this._gltf,
+    bufferViewId: this._draco.bufferView,
+    gltfResource: this._gltfResource,
+    baseResource: this._baseResource,
+    keepResident: false,
+  });
+
+  this._bufferViewLoader = bufferViewLoader;
+  this._state = ResourceLoaderState.LOADING;
+
+  var that = this;
+
+  bufferViewLoader.promise
+    .then(function () {
+      if (that.isDestroyed()) {
+        return;
+      }
+      // Now wait for the Draco resources to be created during processing.
+      that._bufferViewTypedArray = bufferViewLoader.typedArray;
+    })
+    .otherwise(function (error) {
+      handleError(that, error);
+    });
+};
+
+function handleError(dracoLoader, error) {
+  dracoLoader.unload();
+  dracoLoader._state = ResourceLoaderState.FAILED;
+  var errorMessage = "Failed to load Draco";
+  dracoLoader._promise.reject(dracoLoader.getError(errorMessage, error));
+}
+
+/**
+ * Processes the resource until it becomes ready.
+ *
+ * @param {FrameState} frameState The frame state.
+ */
+GltfDracoLoader.prototype.process = function (frameState) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("frameState", frameState);
+  //>>includeEnd('debug');
+
+  if (!defined(this._bufferViewTypedArray)) {
+    // Not ready to decode the Draco buffer
+    return;
+  }
+
+  if (defined(this._decodePromise)) {
+    // Currently decoding
+    return;
+  }
+
+  var draco = this._draco;
+  var gltf = this._gltf;
+  var bufferViews = gltf.bufferViews;
+  var bufferViewId = draco.bufferView;
+  var bufferView = bufferViews[bufferViewId];
+  var compressedAttributes = draco.attributes;
+
+  var decodeOptions = {
+    array: this._bufferViewTypedArray,
+    bufferView: bufferView,
+    compressedAttributes: compressedAttributes,
+    dequantizeInShader: true,
+  };
+
+  var decodePromise = DracoLoader.decodeBufferView(decodeOptions);
+
+  if (!defined(decodePromise)) {
+    // Cannot schedule task this frame
+    return;
+  }
+
+  var that = this;
+  this._decodePromise = decodePromise
+    .then(function (results) {
+      if (that.isDestroyed()) {
+        return;
+      }
+      // Unload everything except the decoded data
+      that.unload();
+
+      that._decodedData = {
+        indices: results.indexArray,
+        vertexAttributes: results.attributeData,
+      };
+      that._state = ResourceLoaderState.READY;
+      that._promise.resolve(that);
+    })
+    .otherwise(function (error) {
+      handleError(that, error);
+    });
+};
+
+/**
+ * Unloads the resource.
+ */
+GltfDracoLoader.prototype.unload = function () {
+  if (defined(this._bufferViewLoader)) {
+    this._resourceCache.unload(this._bufferViewLoader);
+  }
+
+  this._bufferViewLoader = undefined;
+  this._bufferViewTypedArray = undefined;
+  this._decodedData = undefined;
+  this._gltf = undefined;
+};

--- a/Source/Scene/GltfDracoLoader.js
+++ b/Source/Scene/GltfDracoLoader.js
@@ -127,7 +127,7 @@ GltfDracoLoader.prototype.load = function () {
       if (that.isDestroyed()) {
         return;
       }
-      // Now wait for the Draco resources to be created during processing.
+      // Now wait for process() to run to finish loading
       that._bufferViewTypedArray = bufferViewLoader.typedArray;
     })
     .otherwise(function (error) {

--- a/Source/Scene/GltfImageLoader.js
+++ b/Source/Scene/GltfImageLoader.js
@@ -1,0 +1,285 @@
+import Check from "../Core/Check.js";
+import defaultValue from "../Core/defaultValue.js";
+import defined from "../Core/defined.js";
+import loadCRN from "../Core/loadCRN.js";
+import loadImageFromTypedArray from "../Core/loadImageFromTypedArray.js";
+import loadKTX from "../Core/loadKTX.js";
+import RuntimeError from "../Core/RuntimeError.js";
+import when from "../ThirdParty/when.js";
+import GltfLoaderUtil from "./GltfLoaderUtil.js";
+import ResourceLoader from "./ResourceLoader.js";
+import ResourceLoaderState from "./ResourceLoaderState.js";
+
+/**
+ * Loads a glTF image.
+ * <p>
+ * Implements the {@link ResourceLoader} interface.
+ * </p>
+ *
+ * @alias GltfImageLoader
+ * @constructor
+ * @augments ResourceLoader
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {ResourceCache} options.resourceCache The {@link ResourceCache} (to avoid circular dependencies).
+ * @param {Object} options.gltf The glTF JSON.
+ * @param {Number} options.imageId The image ID.
+ * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
+ * @param {String} [options.cacheKey] The cache key of the resource.
+ *
+ * @private
+ */
+export default function GltfImageLoader(options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var resourceCache = options.resourceCache;
+  var gltf = options.gltf;
+  var imageId = options.imageId;
+  var gltfResource = options.gltfResource;
+  var baseResource = options.baseResource;
+  var supportedImageFormats = options.supportedImageFormats;
+  var cacheKey = options.cacheKey;
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.func("options.resourceCache", resourceCache);
+  Check.typeOf.object("options.gltf", gltf);
+  Check.typeOf.number("options.imageId", imageId);
+  Check.typeOf.object("options.gltfResource", gltfResource);
+  Check.typeOf.object("options.baseResource", baseResource);
+  Check.typeOf.object("options.supportedImageFormats", supportedImageFormats);
+  //>>includeEnd('debug');
+
+  var results = GltfLoaderUtil.getImageUriOrBufferView({
+    gltf: gltf,
+    imageId: imageId,
+    supportedImageFormats: supportedImageFormats,
+  });
+
+  var bufferViewId = results.bufferViewId;
+  var uri = results.uri;
+
+  this._resourceCache = resourceCache;
+  this._gltfResource = gltfResource;
+  this._baseResource = baseResource;
+  this._gltf = gltf;
+  this._bufferViewId = bufferViewId;
+  this._uri = uri;
+  this._cacheKey = cacheKey;
+  this._bufferViewLoader = undefined;
+  this._image = undefined;
+  this._state = ResourceLoaderState.UNLOADED;
+  this._promise = when.defer();
+}
+
+if (defined(Object.create)) {
+  GltfImageLoader.prototype = Object.create(ResourceLoader.prototype);
+  GltfImageLoader.prototype.constructor = GltfImageLoader;
+}
+
+Object.defineProperties(GltfImageLoader.prototype, {
+  /**
+   * A promise that resolves to the resource when the resource is ready.
+   *
+   * @memberof GltfImageLoader.prototype
+   *
+   * @type {Promise.<GltfImageLoader>}
+   * @readonly
+   */
+  promise: {
+    get: function () {
+      return this._promise.promise;
+    },
+  },
+  /**
+   * The cache key of the resource.
+   *
+   * @memberof GltfImageLoader.prototype
+   *
+   * @type {String}
+   * @readonly
+   */
+  cacheKey: {
+    get: function () {
+      return this._cacheKey;
+    },
+  },
+  /**
+   * The image.
+   *
+   * @memberof GltfImageLoader.prototype
+   *
+   * @type {Image|ImageBitmap|CompressedTextureBuffer}
+   * @readonly
+   */
+  image: {
+    get: function () {
+      return this._image;
+    },
+  },
+});
+
+/**
+ * Loads the resource.
+ */
+GltfImageLoader.prototype.load = function () {
+  if (defined(this._bufferViewId)) {
+    loadFromBufferView(this);
+  } else {
+    loadFromUri(this);
+  }
+};
+
+function loadFromBufferView(imageLoader) {
+  var resourceCache = imageLoader._resourceCache;
+  var bufferViewLoader = resourceCache.loadBufferView({
+    gltf: imageLoader._gltf,
+    bufferViewId: imageLoader._bufferViewId,
+    gltfResource: imageLoader._gltfResource,
+    baseResource: imageLoader._baseResource,
+    keepResident: false,
+  });
+
+  imageLoader._bufferViewLoader = bufferViewLoader;
+  imageLoader._state = ResourceLoaderState.LOADING;
+
+  bufferViewLoader.promise
+    .then(function () {
+      if (imageLoader.isDestroyed()) {
+        return;
+      }
+
+      var typedArray = bufferViewLoader.typedArray;
+      return loadImageFromBufferTypedArray(typedArray).then(function (image) {
+        if (imageLoader.isDestroyed()) {
+          return;
+        }
+
+        // Unload everything except the image
+        imageLoader.unload();
+
+        imageLoader._image = image;
+        imageLoader._state = ResourceLoaderState.READY;
+        imageLoader._promise.resolve(imageLoader);
+      });
+    })
+    .otherwise(function (error) {
+      handleError(imageLoader, error, "Failed to load embedded image");
+    });
+}
+
+function loadFromUri(imageLoader) {
+  var baseResource = imageLoader._baseResource;
+  var uri = imageLoader._uri;
+  var resource = baseResource.getDerivedResource({
+    url: uri,
+  });
+  imageLoader._state = ResourceLoaderState.LOADING;
+  loadImageFromUri(resource)
+    .then(function (image) {
+      if (imageLoader.isDestroyed()) {
+        return;
+      }
+
+      // Unload everything except the image
+      imageLoader.unload();
+
+      imageLoader._image = image;
+      imageLoader._state = ResourceLoaderState.READY;
+      imageLoader._promise.resolve(imageLoader);
+    })
+    .otherwise(function (error) {
+      handleError(imageLoader, error, "Failed to load image:" + uri);
+    });
+}
+
+function handleError(imageLoader, error, errorMessage) {
+  imageLoader.unload();
+  imageLoader._state = ResourceLoaderState.FAILED;
+  imageLoader._promise.reject(imageLoader.getError(errorMessage, error));
+}
+
+function getMimeTypeFromTypedArray(typedArray) {
+  var header = typedArray.subarray(0, 2);
+  var webpHeaderRIFFChars = typedArray.subarray(0, 4);
+  var webpHeaderWEBPChars = typedArray.subarray(8, 12);
+
+  if (header[0] === 0xff && header[1] === 0xd8) {
+    return "image/jpeg";
+  } else if (header[0] === 0x89 && header[1] === 0x50) {
+    return "image/png";
+  } else if (header[0] === 0xab && header[1] === 0x4b) {
+    return "image/ktx";
+  } else if (header[0] === 0x48 && header[1] === 0x78) {
+    return "image/crn";
+  } else if (header[0] === 0x73 && header[1] === 0x42) {
+    return "image/basis";
+  } else if (
+    webpHeaderRIFFChars[0] === 0x52 &&
+    webpHeaderRIFFChars[1] === 0x49 &&
+    webpHeaderRIFFChars[2] === 0x46 &&
+    webpHeaderRIFFChars[3] === 0x46 &&
+    webpHeaderWEBPChars[0] === 0x57 &&
+    webpHeaderWEBPChars[1] === 0x45 &&
+    webpHeaderWEBPChars[2] === 0x42 &&
+    webpHeaderWEBPChars[3] === 0x50
+  ) {
+    return "image/webp";
+  }
+
+  throw new RuntimeError("Image format is not recognized");
+}
+
+function loadImageFromBufferTypedArray(typedArray) {
+  var mimeType = getMimeTypeFromTypedArray(typedArray);
+  if (mimeType === "image/ktx") {
+    // Resolves to a CompressedTextureBuffer
+    return loadKTX(typedArray);
+  } else if (mimeType === "image/crn") {
+    // Resolves to a CompressedTextureBuffer
+    return loadCRN(typedArray);
+  }
+  // Resolves to an Image or ImageBitmap
+  return GltfImageLoader._loadImageFromTypedArray({
+    uint8Array: typedArray,
+    format: mimeType,
+    flipY: false,
+  });
+}
+
+var ktxRegex = /(^data:image\/ktx)|(\.ktx$)/i;
+var crnRegex = /(^data:image\/crn)|(\.crn$)/i;
+
+function loadImageFromUri(resource) {
+  var uri = resource.url;
+  if (ktxRegex.test(uri)) {
+    // Resolves to a CompressedTextureBuffer
+    return loadKTX(resource);
+  } else if (crnRegex.test(uri)) {
+    // Resolves to a CompressedTextureBuffer
+    return loadCRN(resource);
+  }
+  // Resolves to an ImageBitmap or Image
+  return resource.fetchImage();
+}
+
+/**
+ * Unloads the resource.
+ */
+GltfImageLoader.prototype.unload = function () {
+  if (defined(this._bufferViewLoader)) {
+    this._resourceCache.unload(this._bufferViewLoader);
+  }
+
+  this._bufferViewLoader = undefined;
+  this._uri = undefined; // Free in case the uri is a data uri
+  this._image = undefined;
+  this._gltf = undefined;
+};
+
+/**
+ * Exposed for testing
+ *
+ * @private
+ */
+GltfImageLoader._loadImageFromTypedArray = loadImageFromTypedArray;

--- a/Source/Scene/GltfImageLoader.js
+++ b/Source/Scene/GltfImageLoader.js
@@ -205,16 +205,22 @@ function getMimeTypeFromTypedArray(typedArray) {
   var webpHeaderWEBPChars = typedArray.subarray(8, 12);
 
   if (header[0] === 0xff && header[1] === 0xd8) {
+    // See https://en.wikipedia.org/wiki/JPEG_File_Interchange_Format
     return "image/jpeg";
   } else if (header[0] === 0x89 && header[1] === 0x50) {
+    // See http://www.libpng.org/pub/png/spec/1.2/PNG-Structure.html
     return "image/png";
   } else if (header[0] === 0xab && header[1] === 0x4b) {
+    // See http://github.khronos.org/KTX-Specification/#_identifier
     return "image/ktx";
   } else if (header[0] === 0x48 && header[1] === 0x78) {
+    // See https://github.com/BinomialLLC/crunch/blob/671a0648c8a440b4397f1d96ea5cf5700f830417/inc/crn_decomp.h#L268
     return "image/crn";
   } else if (header[0] === 0x73 && header[1] === 0x42) {
+    // See https://github.com/BinomialLLC/basis_universal/blob/ed135f03a05de315dd7ec7c1b8ef0589099b3e52/spec/basis_spec.txt#L125
     return "image/basis";
   } else if (
+    // See https://developers.google.com/speed/webp/docs/riff_container#webp_file_header
     webpHeaderRIFFChars[0] === 0x52 &&
     webpHeaderRIFFChars[1] === 0x49 &&
     webpHeaderRIFFChars[2] === 0x46 &&

--- a/Source/Scene/GltfIndexBufferLoader.js
+++ b/Source/Scene/GltfIndexBufferLoader.js
@@ -1,0 +1,337 @@
+import Check from "../Core/Check.js";
+import defaultValue from "../Core/defaultValue.js";
+import defined from "../Core/defined.js";
+import IndexDatatype from "../Core/IndexDatatype.js";
+import Buffer from "../Renderer/Buffer.js";
+import BufferUsage from "../Renderer/BufferUsage.js";
+import when from "../ThirdParty/when.js";
+import JobType from "./JobType.js";
+import ResourceLoader from "./ResourceLoader.js";
+import ResourceLoaderState from "./ResourceLoaderState.js";
+
+/**
+ * Loads an index buffer from a glTF accessor.
+ * <p>
+ * Implements the {@link ResourceLoader} interface.
+ * </p>
+ *
+ * @alias GltfIndexBufferLoader
+ * @constructor
+ * @augments ResourceLoader
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {ResourceCache} options.resourceCache The {@link ResourceCache} (to avoid circular dependencies).
+ * @param {Object} options.gltf The glTF JSON.
+ * @param {Number} options.accessorId The accessor ID corresponding to the index buffer.
+ * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {Object} [options.draco] The Draco extension object.
+ * @param {String} [options.cacheKey] The cache key of the resource.
+ * @param {Boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
+ *
+ * @private
+ */
+export default function GltfIndexBufferLoader(options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var resourceCache = options.resourceCache;
+  var gltf = options.gltf;
+  var accessorId = options.accessorId;
+  var gltfResource = options.gltfResource;
+  var baseResource = options.baseResource;
+  var draco = options.draco;
+  var cacheKey = options.cacheKey;
+  var asynchronous = defaultValue(options.asynchronous, true);
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.func("options.resourceCache", resourceCache);
+  Check.typeOf.object("options.gltf", gltf);
+  Check.typeOf.number("options.accessorId", accessorId);
+  Check.typeOf.object("options.gltfResource", gltfResource);
+  Check.typeOf.object("options.baseResource", baseResource);
+  //>>includeEnd('debug');
+
+  var indexDatatype = gltf.accessors[accessorId].componentType;
+
+  this._resourceCache = resourceCache;
+  this._gltfResource = gltfResource;
+  this._baseResource = baseResource;
+  this._gltf = gltf;
+  this._accessorId = accessorId;
+  this._indexDatatype = indexDatatype;
+  this._draco = draco;
+  this._cacheKey = cacheKey;
+  this._asynchronous = asynchronous;
+  this._bufferViewLoader = undefined;
+  this._dracoLoader = undefined;
+  this._typedArray = undefined;
+  this._indexBuffer = undefined;
+  this._state = ResourceLoaderState.UNLOADED;
+  this._promise = when.defer();
+}
+
+if (defined(Object.create)) {
+  GltfIndexBufferLoader.prototype = Object.create(ResourceLoader.prototype);
+  GltfIndexBufferLoader.prototype.constructor = GltfIndexBufferLoader;
+}
+
+Object.defineProperties(GltfIndexBufferLoader.prototype, {
+  /**
+   * A promise that resolves to the resource when the resource is ready.
+   *
+   * @memberof GltfIndexBufferLoader.prototype
+   *
+   * @type {Promise.<GltfIndexBufferLoader>}
+   * @readonly
+   */
+  promise: {
+    get: function () {
+      return this._promise.promise;
+    },
+  },
+  /**
+   * The cache key of the resource.
+   *
+   * @memberof GltfIndexBufferLoader.prototype
+   *
+   * @type {String}
+   * @readonly
+   */
+  cacheKey: {
+    get: function () {
+      return this._cacheKey;
+    },
+  },
+  /**
+   * The index buffer.
+   *
+   * @memberof GltfIndexBufferLoader.prototype
+   *
+   * @type {Buffer}
+   * @readonly
+   */
+  indexBuffer: {
+    get: function () {
+      return this._indexBuffer;
+    },
+  },
+});
+
+/**
+ * Loads the resource.
+ */
+GltfIndexBufferLoader.prototype.load = function () {
+  if (defined(this._draco)) {
+    loadFromDraco(this);
+  } else {
+    loadFromBufferView(this);
+  }
+};
+
+function loadFromDraco(indexBufferLoader) {
+  var resourceCache = indexBufferLoader._resourceCache;
+  var dracoLoader = resourceCache.loadDraco({
+    gltf: indexBufferLoader._gltf,
+    draco: indexBufferLoader._draco,
+    gltfResource: indexBufferLoader._gltfResource,
+    baseResource: indexBufferLoader._baseResource,
+    keepResident: false,
+  });
+
+  indexBufferLoader._dracoLoader = dracoLoader;
+  indexBufferLoader._state = ResourceLoaderState.LOADING;
+
+  dracoLoader.promise
+    .then(function () {
+      if (indexBufferLoader.isDestroyed()) {
+        return;
+      }
+      // Now wait for the GPU buffer to be created during processing.
+      indexBufferLoader._typedArray =
+        dracoLoader.decodedData.indices.typedArray;
+    })
+    .otherwise(function (error) {
+      handleError(indexBufferLoader, error);
+    });
+}
+
+function loadFromBufferView(indexBufferLoader) {
+  var gltf = indexBufferLoader._gltf;
+  var accessorId = indexBufferLoader._accessorId;
+  var accessor = gltf.accessors[accessorId];
+  var bufferViewId = accessor.bufferView;
+
+  var resourceCache = indexBufferLoader._resourceCache;
+  var bufferViewLoader = resourceCache.loadBufferView({
+    gltf: gltf,
+    bufferViewId: bufferViewId,
+    gltfResource: indexBufferLoader._gltfResource,
+    baseResource: indexBufferLoader._baseResource,
+    keepResident: false,
+  });
+  indexBufferLoader._state = ResourceLoaderState.LOADING;
+  indexBufferLoader._bufferViewLoader = bufferViewLoader;
+
+  bufferViewLoader.promise
+    .then(function () {
+      if (indexBufferLoader.isDestroyed()) {
+        return;
+      }
+      // Now wait for the GPU buffer to be created during processing.
+      var bufferViewTypedArray = bufferViewLoader.typedArray;
+      indexBufferLoader._typedArray = createIndicesTypedArray(
+        indexBufferLoader,
+        bufferViewTypedArray
+      );
+    })
+    .otherwise(function (error) {
+      handleError(indexBufferLoader, error);
+    });
+}
+
+function createIndicesTypedArray(indexBufferLoader, bufferViewTypedArray) {
+  var gltf = indexBufferLoader._gltf;
+  var accessorId = indexBufferLoader._accessorId;
+  var accessor = gltf.accessors[accessorId];
+  var count = accessor.count;
+  var indexDatatype = accessor.componentType;
+
+  var arrayBuffer = bufferViewTypedArray.buffer;
+  var byteOffset = bufferViewTypedArray.byteOffset + accessor.byteOffset;
+
+  var typedArray;
+  if (indexDatatype === IndexDatatype.UNSIGNED_BYTE) {
+    typedArray = new Uint8Array(arrayBuffer, byteOffset, count);
+  } else if (indexDatatype === IndexDatatype.UNSIGNED_SHORT) {
+    typedArray = new Uint16Array(arrayBuffer, byteOffset, count);
+  } else if (indexDatatype === IndexDatatype.UNSIGNED_INT) {
+    typedArray = new Uint32Array(arrayBuffer, byteOffset, count);
+  }
+
+  return typedArray;
+}
+
+function handleError(indexBufferLoader, error) {
+  indexBufferLoader.unload();
+  indexBufferLoader._state = ResourceLoaderState.FAILED;
+  var errorMessage = "Failed to load index buffer";
+  error = indexBufferLoader.getError(errorMessage, error);
+  indexBufferLoader._promise.reject(error);
+}
+
+function CreateIndexBufferJob() {
+  this.typedArray = undefined;
+  this.indexDatatype = undefined;
+  this.context = undefined;
+  this.indexBuffer = undefined;
+}
+
+CreateIndexBufferJob.prototype.set = function (
+  typedArray,
+  indexDatatype,
+  context
+) {
+  this.typedArray = typedArray;
+  this.indexDatatype = indexDatatype;
+  this.context = context;
+};
+
+CreateIndexBufferJob.prototype.execute = function () {
+  this.indexBuffer = createIndexBuffer(
+    this.typedArray,
+    this.indexDatatype,
+    this.context
+  );
+};
+
+function createIndexBuffer(typedArray, indexDatatype, context) {
+  var indexBuffer = Buffer.createIndexBuffer({
+    typedArray: typedArray,
+    context: context,
+    usage: BufferUsage.STATIC_DRAW,
+    indexDatatype: indexDatatype,
+  });
+  indexBuffer.vertexArrayDestroyable = false;
+  return indexBuffer;
+}
+
+var scratchIndexBufferJob = new CreateIndexBufferJob();
+
+/**
+ * Processes the resource until it becomes ready.
+ *
+ * @param {FrameState} frameState The frame state.
+ */
+GltfIndexBufferLoader.prototype.process = function (frameState) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("frameState", frameState);
+  //>>includeEnd('debug');
+
+  if (defined(this._dracoLoader)) {
+    this._dracoLoader.process(frameState);
+  }
+
+  if (defined(this._indexBuffer)) {
+    // Already created index buffer
+    return;
+  }
+
+  if (!defined(this._typedArray)) {
+    // Not ready to create index buffer
+    return;
+  }
+
+  var indexBuffer;
+
+  if (this._asynchronous) {
+    var indexBufferJob = scratchIndexBufferJob;
+    indexBufferJob.set(
+      this._typedArray,
+      this._indexDatatype,
+      frameState.context
+    );
+    var jobScheduler = frameState.jobScheduler;
+    if (!jobScheduler.execute(indexBufferJob, JobType.BUFFER)) {
+      // Job scheduler is full. Try again next frame.
+      return;
+    }
+    indexBuffer = indexBufferJob.indexBuffer;
+  } else {
+    indexBuffer = createIndexBuffer(
+      this._typedArray,
+      this._indexDatatype,
+      frameState.context
+    );
+  }
+
+  // Unload everything except the index buffer
+  this.unload();
+
+  this._indexBuffer = indexBuffer;
+  this._state = ResourceLoaderState.READY;
+  this._promise.resolve(this);
+};
+
+/**
+ * Unloads the resource.
+ */
+GltfIndexBufferLoader.prototype.unload = function () {
+  if (defined(this._indexBuffer)) {
+    this._indexBuffer.destroy();
+  }
+
+  var resourceCache = this._resourceCache;
+
+  if (defined(this._bufferViewLoader)) {
+    resourceCache.unload(this._bufferViewLoader);
+  }
+
+  if (defined(this._dracoLoader)) {
+    resourceCache.unload(this._dracoLoader);
+  }
+
+  this._bufferViewLoader = undefined;
+  this._dracoLoader = undefined;
+  this._typedArray = undefined;
+  this._indexBuffer = undefined;
+  this._gltf = undefined;
+};

--- a/Source/Scene/GltfIndexBufferLoader.js
+++ b/Source/Scene/GltfIndexBufferLoader.js
@@ -145,7 +145,7 @@ function loadFromDraco(indexBufferLoader) {
       if (indexBufferLoader.isDestroyed()) {
         return;
       }
-      // Now wait for the GPU buffer to be created during processing.
+      // Now wait for process() to run to finish loading
       indexBufferLoader._typedArray =
         dracoLoader.decodedData.indices.typedArray;
     })
@@ -176,7 +176,7 @@ function loadFromBufferView(indexBufferLoader) {
       if (indexBufferLoader.isDestroyed()) {
         return;
       }
-      // Now wait for the GPU buffer to be created during processing.
+      // Now wait for process() to run to finish loading
       var bufferViewTypedArray = bufferViewLoader.typedArray;
       indexBufferLoader._typedArray = createIndicesTypedArray(
         indexBufferLoader,

--- a/Source/Scene/GltfJsonLoader.js
+++ b/Source/Scene/GltfJsonLoader.js
@@ -1,0 +1,263 @@
+import Check from "../Core/Check.js";
+import defaultValue from "../Core/defaultValue.js";
+import defined from "../Core/defined.js";
+import getJsonFromTypedArray from "../Core/getJsonFromTypedArray.js";
+import getMagic from "../Core/getMagic.js";
+import isDataUri from "../Core/isDataUri.js";
+import Resource from "../Core/Resource.js";
+import addDefaults from "../ThirdParty/GltfPipeline/addDefaults.js";
+import addPipelineExtras from "../ThirdParty/GltfPipeline/addPipelineExtras.js";
+import ForEach from "../ThirdParty/GltfPipeline/ForEach.js";
+import parseGlb from "../ThirdParty/GltfPipeline/parseGlb.js";
+import removePipelineExtras from "../ThirdParty/GltfPipeline/removePipelineExtras.js";
+import updateVersion from "../ThirdParty/GltfPipeline/updateVersion.js";
+import when from "../ThirdParty/when.js";
+import ResourceLoader from "./ResourceLoader.js";
+import ResourceLoaderState from "./ResourceLoaderState.js";
+
+/**
+ * Loads a glTF JSON from a glTF or glb.
+ * <p>
+ * Implements the {@link ResourceLoader} interface.
+ * </p>
+ *
+ * @alias GltfJsonLoader
+ * @constructor
+ * @augments ResourceLoader
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {ResourceCache} options.resourceCache The {@link ResourceCache} (to avoid circular dependencies).
+ * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {String} [options.cacheKey] The cache key of the resource.
+ * @param {Boolean} [options.keepResident=false] Whether the glTF JSON and embedded buffers should stay in the cache indefinitely.
+ *
+ * @private
+ */
+export default function GltfJsonLoader(options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var resourceCache = options.resourceCache;
+  var gltfResource = options.gltfResource;
+  var baseResource = options.baseResource;
+  var cacheKey = options.cacheKey;
+  var keepResident = defaultValue(options.keepResident, false);
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.func("options.resourceCache", resourceCache);
+  Check.typeOf.object("options.gltfResource", gltfResource);
+  Check.typeOf.object("options.baseResource", baseResource);
+  //>>includeEnd('debug');
+
+  this._resourceCache = resourceCache;
+  this._gltfResource = gltfResource;
+  this._baseResource = baseResource;
+  this._cacheKey = cacheKey;
+  this._keepResident = keepResident;
+  this._gltf = undefined;
+  this._bufferLoaders = [];
+  this._state = ResourceLoaderState.UNLOADED;
+  this._promise = when.defer();
+}
+
+if (defined(Object.create)) {
+  GltfJsonLoader.prototype = Object.create(ResourceLoader.prototype);
+  GltfJsonLoader.prototype.constructor = GltfJsonLoader;
+}
+
+Object.defineProperties(GltfJsonLoader.prototype, {
+  /**
+   * A promise that resolves to the resource when the resource is ready.
+   *
+   * @memberof GltfJsonLoader.prototype
+   *
+   * @type {Promise.<GltfJsonLoader>}
+   * @readonly
+   */
+  promise: {
+    get: function () {
+      return this._promise.promise;
+    },
+  },
+  /**
+   * The cache key of the resource.
+   *
+   * @memberof GltfJsonLoader.prototype
+   *
+   * @type {String}
+   * @readonly
+   */
+  cacheKey: {
+    get: function () {
+      return this._cacheKey;
+    },
+  },
+  /**
+   * The glTF JSON.
+   *
+   * @memberof GltfJsonLoader.prototype
+   *
+   * @type {Object}
+   * @readonly
+   */
+  gltf: {
+    get: function () {
+      return this._gltf;
+    },
+  },
+});
+
+/**
+ * Loads the resource.
+ */
+GltfJsonLoader.prototype.load = function () {
+  var that = this;
+  this._state = ResourceLoaderState.LOADING;
+  this._fetchGltf()
+    .then(function (arrayBuffer) {
+      if (that.isDestroyed()) {
+        return;
+      }
+      var typedArray = new Uint8Array(arrayBuffer);
+      return processGltf(that, typedArray);
+    })
+    .then(function (gltf) {
+      if (that.isDestroyed()) {
+        return;
+      }
+      that._gltf = gltf;
+      that._state = ResourceLoaderState.READY;
+      that._promise.resolve(that);
+    })
+    .otherwise(function (error) {
+      that.unload();
+      that._state = ResourceLoaderState.FAILED;
+      var errorMessage = "Failed to load glTF: " + that._gltfResource.url;
+      that._promise.reject(that.getError(errorMessage, error));
+    });
+};
+
+function containsGltfMagic(typedArray) {
+  var magic = getMagic(typedArray);
+  return magic === "glTF";
+}
+
+function upgradeVersion(gltfJsonLoader, gltf) {
+  if (gltf.asset.version === "2.0") {
+    return when.resolve();
+  }
+
+  // Load all buffers into memory. updateVersion will read and in some cases modify
+  // the buffer data, which it accesses from buffer.extras._pipeline.source
+  var promises = [];
+  ForEach.buffer(gltf, function (buffer) {
+    if (
+      !defined(buffer.extras._pipeline.source) && // Ignore uri if this buffer uses the glTF 1.0 KHR_binary_glTF extension
+      defined(buffer.uri)
+    ) {
+      var resource = gltfJsonLoader._baseResource.getDerivedResource({
+        url: buffer.uri,
+      });
+      var resourceCache = gltfJsonLoader._resourceCache;
+      var bufferLoader = resourceCache.loadExternalBuffer({
+        resource: resource,
+        keepResident: false, // External buffers don't need to stay resident
+      });
+
+      gltfJsonLoader._bufferLoaders.push(bufferLoader);
+
+      promises.push(
+        bufferLoader.promise.then(function (bufferLoader) {
+          buffer.extras._pipeline.source = bufferLoader.typedArray;
+        })
+      );
+    }
+  });
+
+  return when.all(promises).then(function () {
+    updateVersion(gltf);
+  });
+}
+
+function decodeDataUris(gltf) {
+  var promises = [];
+  ForEach.buffer(gltf, function (buffer) {
+    var bufferUri = buffer.uri;
+    if (
+      !defined(buffer.extras._pipeline.source) && // Ignore uri if this buffer uses the glTF 1.0 KHR_binary_glTF extension
+      defined(bufferUri) &&
+      isDataUri(bufferUri)
+    ) {
+      delete buffer.uri; // Delete the data URI to keep the cached glTF JSON small
+      promises.push(
+        Resource.fetchArrayBuffer(bufferUri).then(function (arrayBuffer) {
+          buffer.extras._pipeline.source = new Uint8Array(arrayBuffer);
+        })
+      );
+    }
+  });
+  return when.all(promises);
+}
+
+function loadEmbeddedBuffers(gltfJsonLoader, gltf) {
+  var promises = [];
+  ForEach.buffer(gltf, function (buffer, bufferId) {
+    var source = buffer.extras._pipeline.source;
+    if (defined(source) && !defined(buffer.uri)) {
+      var resourceCache = gltfJsonLoader._resourceCache;
+      var bufferLoader = resourceCache.loadEmbeddedBuffer({
+        parentResource: gltfJsonLoader._gltfResource,
+        bufferId: bufferId,
+        typedArray: source,
+        keepResident: gltfJsonLoader._keepResident,
+      });
+
+      gltfJsonLoader._bufferLoaders.push(bufferLoader);
+      promises.push(bufferLoader.promise);
+    }
+  });
+  return when.all(promises);
+}
+
+function processGltf(gltfJsonLoader, typedArray) {
+  var gltf;
+  if (containsGltfMagic(typedArray)) {
+    gltf = parseGlb(typedArray);
+  } else {
+    gltf = getJsonFromTypedArray(typedArray);
+  }
+
+  addPipelineExtras(gltf);
+
+  return decodeDataUris(gltf).then(function () {
+    return upgradeVersion(gltfJsonLoader, gltf).then(function () {
+      addDefaults(gltf);
+      return loadEmbeddedBuffers(gltfJsonLoader, gltf).then(function () {
+        removePipelineExtras(gltf);
+        return gltf;
+      });
+    });
+  });
+}
+
+/**
+ * Unloads the resource.
+ */
+GltfJsonLoader.prototype.unload = function () {
+  var bufferLoaders = this._bufferLoaders;
+  var bufferLoadersLength = bufferLoaders.length;
+  for (var i = 0; i < bufferLoadersLength; ++i) {
+    this._resourceCache.unload(bufferLoaders[i]);
+  }
+  this._bufferLoaders = [];
+
+  this._gltf = undefined;
+};
+
+/**
+ * Exposed for testing
+ *
+ * @private
+ */
+GltfJsonLoader.prototype._fetchGltf = function () {
+  return this._gltfResource.fetchArrayBuffer();
+};

--- a/Source/Scene/GltfJsonLoader.js
+++ b/Source/Scene/GltfJsonLoader.js
@@ -136,11 +136,6 @@ GltfJsonLoader.prototype.load = function () {
     });
 };
 
-function containsGltfMagic(typedArray) {
-  var magic = getMagic(typedArray);
-  return magic === "glTF";
-}
-
 function upgradeVersion(gltfJsonLoader, gltf) {
   if (gltf.asset.version === "2.0") {
     return when.resolve();
@@ -220,7 +215,7 @@ function loadEmbeddedBuffers(gltfJsonLoader, gltf) {
 
 function processGltf(gltfJsonLoader, typedArray) {
   var gltf;
-  if (containsGltfMagic(typedArray)) {
+  if (getMagic(typedArray) === "glTF") {
     gltf = parseGlb(typedArray);
   } else {
     gltf = getJsonFromTypedArray(typedArray);

--- a/Source/Scene/GltfLoaderUtil.js
+++ b/Source/Scene/GltfLoaderUtil.js
@@ -1,0 +1,188 @@
+import Check from "../Core/Check.js";
+import defaultValue from "../Core/defaultValue.js";
+import defined from "../Core/defined.js";
+import Sampler from "../Renderer/Sampler.js";
+import TextureMagnificationFilter from "../Renderer/TextureMagnificationFilter.js";
+import TextureMinificationFilter from "../Renderer/TextureMinificationFilter.js";
+import TextureWrap from "../Renderer/TextureWrap.js";
+
+/**
+ * glTF loading utilities.
+ *
+ * @namespace GltfLoaderUtil
+ *
+ * @private
+ */
+var GltfLoaderUtil = {};
+
+/**
+ * Get the uri or buffer view for an image.
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {Object} options.gltf The glTF JSON.
+ * @param {Number} options.imageId The image ID.
+ * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
+ *
+ * @returns {Object} An object containing a <code>uri</code> and <code>bufferView</code> property.
+ */
+GltfLoaderUtil.getImageUriOrBufferView = function (options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var gltf = options.gltf;
+  var imageId = options.imageId;
+  var supportedImageFormats = options.supportedImageFormats;
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.gltf", gltf);
+  Check.typeOf.number("options.imageId", imageId);
+  Check.typeOf.object("options.supportedImageFormats", supportedImageFormats);
+  //>>includeEnd('debug');
+
+  var image = gltf.images[imageId];
+  var extras = image.extras;
+
+  var bufferViewId = image.bufferView;
+  var uri = image.uri;
+
+  // First check for a compressed texture
+  if (defined(extras) && defined(extras.compressedImage3DTiles)) {
+    var crunch = extras.compressedImage3DTiles.crunch;
+    var s3tc = extras.compressedImage3DTiles.s3tc;
+    var pvrtc = extras.compressedImage3DTiles.pvrtc1;
+    var etc1 = extras.compressedImage3DTiles.etc1;
+
+    if (supportedImageFormats.s3tc && defined(crunch)) {
+      if (defined(crunch.bufferView)) {
+        bufferViewId = crunch.bufferView;
+      } else {
+        uri = crunch.uri;
+      }
+    } else if (supportedImageFormats.s3tc && defined(s3tc)) {
+      if (defined(s3tc.bufferView)) {
+        bufferViewId = s3tc.bufferView;
+      } else {
+        uri = s3tc.uri;
+      }
+    } else if (supportedImageFormats.pvrtc && defined(pvrtc)) {
+      if (defined(pvrtc.bufferView)) {
+        bufferViewId = pvrtc.bufferView;
+      } else {
+        uri = pvrtc.uri;
+      }
+    } else if (supportedImageFormats.etc1 && defined(etc1)) {
+      if (defined(etc1.bufferView)) {
+        bufferViewId = etc1.bufferView;
+      } else {
+        uri = etc1.uri;
+      }
+    }
+  }
+
+  return {
+    bufferViewId: bufferViewId,
+    uri: uri,
+  };
+};
+
+/**
+ * Get the image ID referenced by a texture.
+ * <p>
+ * When the texture has the EXT_texture_webp extension and the browser supports
+ * WebP images the WebP image ID is returned.
+ * </p>
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {Object} options.gltf The glTF JSON.
+ * @param {Number} options.textureId The texture ID.
+ * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
+ *
+ * @returns {Number} The image ID.
+ */
+GltfLoaderUtil.getImageIdFromTexture = function (options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var gltf = options.gltf;
+  var textureId = options.textureId;
+  var supportedImageFormats = options.supportedImageFormats;
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.gltf", gltf);
+  Check.typeOf.number("options.textureId", textureId);
+  Check.typeOf.object("options.supportedImageFormats", supportedImageFormats);
+  //>>includeEnd('debug');
+
+  var texture = gltf.textures[textureId];
+  var extensions = texture.extensions;
+  if (defined(extensions)) {
+    if (supportedImageFormats.webp && defined(extensions.EXT_texture_webp)) {
+      return extensions.EXT_texture_webp.source;
+    }
+  }
+  return texture.source;
+};
+
+/**
+ * Create a sampler for a texture.
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {Object} options.gltf The glTF JSON.
+ * @param {Object} options.textureInfo The texture info object.
+ *
+ * @returns {Sampler} The sampler.
+ */
+GltfLoaderUtil.createSampler = function (options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var gltf = options.gltf;
+  var textureInfo = options.textureInfo;
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.gltf", gltf);
+  Check.typeOf.object("options.textureInfo", textureInfo);
+  //>>includeEnd('debug');
+
+  // Default sampler properties
+  var wrapS = TextureWrap.REPEAT;
+  var wrapT = TextureWrap.REPEAT;
+  var minFilter = TextureMinificationFilter.LINEAR;
+  var magFilter = TextureMagnificationFilter.LINEAR;
+
+  var textureId = textureInfo.index;
+  var texture = gltf.textures[textureId];
+  var samplerId = texture.sampler;
+
+  if (defined(samplerId)) {
+    var sampler = gltf.samplers[samplerId];
+    wrapS = defaultValue(sampler.wrapS, wrapS);
+    wrapT = defaultValue(sampler.wrapT, wrapT);
+    minFilter = defaultValue(sampler.minFilter, minFilter);
+    magFilter = defaultValue(sampler.magFilter, magFilter);
+  }
+
+  var usesTextureTransform = false;
+  var extensions = textureInfo.extensions;
+  if (defined(extensions) && defined(extensions.KHR_texture_transform)) {
+    usesTextureTransform = true;
+  }
+
+  if (
+    usesTextureTransform &&
+    minFilter !== TextureMinificationFilter.LINEAR &&
+    minFilter !== TextureMinificationFilter.NEAREST
+  ) {
+    if (
+      minFilter === TextureMinificationFilter.NEAREST_MIPMAP_NEAREST ||
+      minFilter === TextureMinificationFilter.NEAREST_MIPMAP_LINEAR
+    ) {
+      minFilter = TextureMinificationFilter.NEAREST;
+    } else {
+      minFilter = TextureMinificationFilter.LINEAR;
+    }
+  }
+
+  return new Sampler({
+    wrapS: wrapS,
+    wrapT: wrapT,
+    minificationFilter: minFilter,
+    magnificationFilter: magFilter,
+  });
+};
+
+export default GltfLoaderUtil;

--- a/Source/Scene/GltfTextureLoader.js
+++ b/Source/Scene/GltfTextureLoader.js
@@ -150,7 +150,7 @@ GltfTextureLoader.prototype.load = function () {
       if (that.isDestroyed()) {
         return;
       }
-      // Now wait for the GPU texture to be created during processing.
+      // Now wait for process() to run to finish loading
       that._image = imageLoader.image;
     })
     .otherwise(function (error) {

--- a/Source/Scene/GltfTextureLoader.js
+++ b/Source/Scene/GltfTextureLoader.js
@@ -1,0 +1,344 @@
+import Check from "../Core/Check.js";
+import CesiumMath from "../Core/Math.js";
+import defaultValue from "../Core/defaultValue.js";
+import defined from "../Core/defined.js";
+import Texture from "../Renderer/Texture.js";
+import TextureMinificationFilter from "../Renderer/TextureMinificationFilter.js";
+import TextureWrap from "../Renderer/TextureWrap.js";
+import when from "../ThirdParty/when.js";
+import GltfLoaderUtil from "./GltfLoaderUtil.js";
+import JobType from "./JobType.js";
+import ResourceLoader from "./ResourceLoader.js";
+import ResourceLoaderState from "./ResourceLoaderState.js";
+
+/**
+ * Loads a glTF texture.
+ * <p>
+ * Implements the {@link ResourceLoader} interface.
+ * </p>
+ *
+ * @alias GltfTextureLoader
+ * @constructor
+ * @augments ResourceLoader
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {ResourceCache} options.resourceCache The {@link ResourceCache} (to avoid circular dependencies).
+ * @param {Object} options.gltf The glTF JSON.
+ * @param {Object} options.textureInfo The texture info object.
+ * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
+ * @param {String} [options.cacheKey] The cache key of the resource.
+ * @param {Boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
+ *
+ * @private
+ */
+export default function GltfTextureLoader(options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var resourceCache = options.resourceCache;
+  var gltf = options.gltf;
+  var textureInfo = options.textureInfo;
+  var gltfResource = options.gltfResource;
+  var baseResource = options.baseResource;
+  var supportedImageFormats = options.supportedImageFormats;
+  var cacheKey = options.cacheKey;
+  var asynchronous = defaultValue(options.asynchronous, true);
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.func("options.resourceCache", resourceCache);
+  Check.typeOf.object("options.gltf", gltf);
+  Check.typeOf.object("options.textureInfo", textureInfo);
+  Check.typeOf.object("options.gltfResource", gltfResource);
+  Check.typeOf.object("options.baseResource", baseResource);
+  Check.typeOf.object("options.supportedImageFormats", supportedImageFormats);
+  //>>includeEnd('debug');
+
+  var textureId = textureInfo.index;
+
+  // imageId is guaranteed to be defined otherwise the GltfTextureLoader
+  // wouldn't have been created
+  var imageId = GltfLoaderUtil.getImageIdFromTexture({
+    gltf: gltf,
+    textureId: textureId,
+    supportedImageFormats: supportedImageFormats,
+  });
+
+  this._resourceCache = resourceCache;
+  this._gltf = gltf;
+  this._textureInfo = textureInfo;
+  this._imageId = imageId;
+  this._gltfResource = gltfResource;
+  this._baseResource = baseResource;
+  this._supportedImageFormats = supportedImageFormats;
+  this._cacheKey = cacheKey;
+  this._asynchronous = asynchronous;
+  this._imageLoader = undefined;
+  this._image = undefined;
+  this._texture = undefined;
+  this._state = ResourceLoaderState.UNLOADED;
+  this._promise = when.defer();
+}
+
+if (defined(Object.create)) {
+  GltfTextureLoader.prototype = Object.create(ResourceLoader.prototype);
+  GltfTextureLoader.prototype.constructor = GltfTextureLoader;
+}
+
+Object.defineProperties(GltfTextureLoader.prototype, {
+  /**
+   * A promise that resolves to the resource when the resource is ready.
+   *
+   * @memberof GltfTextureLoader.prototype
+   *
+   * @type {Promise.<GltfTextureLoader>}
+   * @readonly
+   */
+  promise: {
+    get: function () {
+      return this._promise.promise;
+    },
+  },
+  /**
+   * The cache key of the resource.
+   *
+   * @memberof GltfTextureLoader.prototype
+   *
+   * @type {String}
+   * @readonly
+   */
+  cacheKey: {
+    get: function () {
+      return this._cacheKey;
+    },
+  },
+  /**
+   * The texture.
+   *
+   * @memberof GltfTextureLoader.prototype
+   *
+   * @type {Texture}
+   * @readonly
+   */
+  texture: {
+    get: function () {
+      return this._texture;
+    },
+  },
+});
+
+/**
+ * Loads the resource.
+ */
+GltfTextureLoader.prototype.load = function () {
+  var resourceCache = this._resourceCache;
+  var imageLoader = resourceCache.loadImage({
+    gltf: this._gltf,
+    imageId: this._imageId,
+    gltfResource: this._gltfResource,
+    baseResource: this._baseResource,
+    supportedImageFormats: this._supportedImageFormats,
+    keepResident: false,
+  });
+
+  this._imageLoader = imageLoader;
+  this._state = ResourceLoaderState.LOADING;
+
+  var that = this;
+
+  imageLoader.promise
+    .then(function () {
+      if (that.isDestroyed()) {
+        return;
+      }
+      // Now wait for the GPU texture to be created during processing.
+      that._image = imageLoader.image;
+    })
+    .otherwise(function (error) {
+      that.unload();
+      that._state = ResourceLoaderState.FAILED;
+      var errorMessage = "Failed to load texture";
+      that._promise.reject(that.getError(errorMessage, error));
+    });
+};
+
+function CreateTextureJob() {
+  this.gltf = undefined;
+  this.textureInfo = undefined;
+  this.image = undefined;
+  this.context = undefined;
+  this.texture = undefined;
+}
+
+CreateTextureJob.prototype.set = function (gltf, textureInfo, image, context) {
+  this.gltf = gltf;
+  this.textureInfo = textureInfo;
+  this.image = image;
+  this.context = context;
+};
+
+CreateTextureJob.prototype.execute = function () {
+  this.texture = createTexture(
+    this.gltf,
+    this.textureInfo,
+    this.image,
+    this.context
+  );
+};
+
+function resizeImageToNextPowerOfTwo(image) {
+  var canvas = document.createElement("canvas");
+  canvas.width = CesiumMath.nextPowerOfTwo(image.width);
+  canvas.height = CesiumMath.nextPowerOfTwo(image.height);
+  var canvasContext = canvas.getContext("2d");
+  canvasContext.drawImage(
+    image,
+    0,
+    0,
+    image.width,
+    image.height,
+    0,
+    0,
+    canvas.width,
+    canvas.height
+  );
+  return canvas;
+}
+
+function createTexture(gltf, textureInfo, image, context) {
+  var sampler = GltfLoaderUtil.createSampler({
+    gltf: gltf,
+    textureInfo: textureInfo,
+  });
+
+  var minFilter = sampler.minificationFilter;
+  var wrapS = sampler.wrapS;
+  var wrapT = sampler.wrapT;
+
+  // internalFormat is only defined for CompressedTextureBuffer
+  var internalFormat = image.internalFormat;
+
+  var samplerRequiresMipmap =
+    minFilter === TextureMinificationFilter.NEAREST_MIPMAP_NEAREST ||
+    minFilter === TextureMinificationFilter.NEAREST_MIPMAP_LINEAR ||
+    minFilter === TextureMinificationFilter.LINEAR_MIPMAP_NEAREST ||
+    minFilter === TextureMinificationFilter.LINEAR_MIPMAP_LINEAR;
+
+  var generateMipmap = !defined(internalFormat) && samplerRequiresMipmap;
+
+  // WebGL 1 requires power-of-two texture dimensions for mipmapping and REPEAT/MIRRORED_REPEAT wrap modes.
+  var requiresPowerOfTwo =
+    generateMipmap ||
+    wrapS === TextureWrap.REPEAT ||
+    wrapS === TextureWrap.MIRRORED_REPEAT ||
+    wrapT === TextureWrap.REPEAT ||
+    wrapT === TextureWrap.MIRRORED_REPEAT;
+
+  var nonPowerOfTwo =
+    !CesiumMath.isPowerOfTwo(image.width) ||
+    !CesiumMath.isPowerOfTwo(image.height);
+
+  var requiresResize = requiresPowerOfTwo && nonPowerOfTwo;
+
+  var texture;
+  if (defined(internalFormat)) {
+    texture = new Texture({
+      context: context,
+      source: {
+        arrayBufferView: image.bufferView, // Only defined for CompressedTextureBuffer
+      },
+      width: image.width,
+      height: image.height,
+      pixelFormat: image.internalFormat, // Only defined for CompressedTextureBuffer
+      sampler: sampler,
+    });
+  } else {
+    if (requiresResize) {
+      image = resizeImageToNextPowerOfTwo(image);
+    }
+    texture = new Texture({
+      context: context,
+      source: image,
+      sampler: sampler,
+      flipY: false,
+    });
+  }
+
+  if (generateMipmap) {
+    texture.generateMipmap();
+  }
+
+  return texture;
+}
+
+var scratchTextureJob = new CreateTextureJob();
+
+/**
+ * Processes the resource until it becomes ready.
+ *
+ * @param {FrameState} frameState The frame state.
+ */
+GltfTextureLoader.prototype.process = function (frameState) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("frameState", frameState);
+  //>>includeEnd('debug');
+
+  if (defined(this._texture)) {
+    // Already created texture
+    return;
+  }
+
+  if (!defined(this._image)) {
+    // Not ready to create texture
+    return;
+  }
+
+  var texture;
+
+  if (this._asynchronous) {
+    var textureJob = scratchTextureJob;
+    textureJob.set(
+      this._gltf,
+      this._textureInfo,
+      this._image,
+      frameState.context
+    );
+    var jobScheduler = frameState.jobScheduler;
+    if (!jobScheduler.execute(textureJob, JobType.TEXTURE)) {
+      // Job scheduler is full. Try again next frame.
+      return;
+    }
+    texture = textureJob.texture;
+  } else {
+    texture = createTexture(
+      this._gltf,
+      this._textureInfo,
+      this._image,
+      frameState.context
+    );
+  }
+
+  // Unload everything except the texture
+  this.unload();
+
+  this._texture = texture;
+  this._state = ResourceLoaderState.READY;
+  this._promise.resolve(this);
+};
+
+/**
+ * Unloads the resource.
+ */
+GltfTextureLoader.prototype.unload = function () {
+  if (defined(this._texture)) {
+    this._texture.destroy();
+  }
+
+  if (defined(this._imageLoader)) {
+    this._resourceCache.unload(this._imageLoader);
+  }
+
+  this._imageLoader = undefined;
+  this._image = undefined;
+  this._texture = undefined;
+  this._gltf = undefined;
+};

--- a/Source/Scene/GltfVertexBufferLoader.js
+++ b/Source/Scene/GltfVertexBufferLoader.js
@@ -1,0 +1,314 @@
+import Check from "../Core/Check.js";
+import defaultValue from "../Core/defaultValue.js";
+import defined from "../Core/defined.js";
+import DeveloperError from "../Core/DeveloperError.js";
+import Buffer from "../Renderer/Buffer.js";
+import BufferUsage from "../Renderer/BufferUsage.js";
+import when from "../ThirdParty/when.js";
+import JobType from "./JobType.js";
+import ResourceLoader from "./ResourceLoader.js";
+import ResourceLoaderState from "./ResourceLoaderState.js";
+
+/**
+ * Loads a vertex buffer from a glTF buffer view.
+ * <p>
+ * Implements the {@link ResourceLoader} interface.
+ * </p>
+ *
+ * @alias GltfVertexBufferLoader
+ * @constructor
+ * @augments ResourceLoader
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {ResourceCache} options.resourceCache The {@link ResourceCache} (to avoid circular dependencies).
+ * @param {Object} options.gltf The glTF JSON.
+ * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {Number} [options.bufferViewId] The bufferView ID corresponding to the vertex buffer.
+ * @param {Object} [options.draco] The Draco extension object.
+ * @param {String} [options.dracoAttributeSemantic] The Draco attribute semantic, e.g. POSITION or NORMAL.
+ * @param {String} [options.cacheKey] The cache key of the resource.
+ * @param {Boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
+ *
+ * @exception {DeveloperError} One of options.bufferViewId and options.draco must be defined.
+ * @exception {DeveloperError} When options.draco is defined options.dracoAttributeSemantic must also be defined.
+ *
+ * @private
+ */
+export default function GltfVertexBufferLoader(options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var resourceCache = options.resourceCache;
+  var gltf = options.gltf;
+  var gltfResource = options.gltfResource;
+  var baseResource = options.baseResource;
+  var bufferViewId = options.bufferViewId;
+  var draco = options.draco;
+  var dracoAttributeSemantic = options.dracoAttributeSemantic;
+  var cacheKey = options.cacheKey;
+  var asynchronous = defaultValue(options.asynchronous, true);
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.func("options.resourceCache", resourceCache);
+  Check.typeOf.object("options.gltf", gltf);
+  Check.typeOf.object("options.gltfResource", gltfResource);
+  Check.typeOf.object("options.baseResource", baseResource);
+
+  var hasBufferViewId = defined(bufferViewId);
+  var hasDraco = defined(draco);
+  var hasDracoAttributeSemantic = defined(dracoAttributeSemantic);
+
+  if (hasBufferViewId === hasDraco) {
+    throw new DeveloperError(
+      "One of options.bufferViewId and options.draco must be defined."
+    );
+  }
+
+  if (hasDraco && !hasDracoAttributeSemantic) {
+    throw new DeveloperError(
+      "When options.draco is defined options.dracoAttributeSemantic must also be defined."
+    );
+  }
+
+  if (hasDraco) {
+    Check.typeOf.object("options.draco", draco);
+    Check.typeOf.string(
+      "options.dracoAttributeSemantic",
+      dracoAttributeSemantic
+    );
+  }
+  //>>includeEnd('debug');
+
+  this._resourceCache = resourceCache;
+  this._gltfResource = gltfResource;
+  this._baseResource = baseResource;
+  this._gltf = gltf;
+  this._bufferViewId = bufferViewId;
+  this._draco = draco;
+  this._dracoAttributeSemantic = dracoAttributeSemantic;
+  this._cacheKey = cacheKey;
+  this._asynchronous = asynchronous;
+  this._bufferViewLoader = undefined;
+  this._dracoLoader = undefined;
+  this._typedArray = undefined;
+  this._vertexBuffer = undefined;
+  this._state = ResourceLoaderState.UNLOADED;
+  this._promise = when.defer();
+}
+
+if (defined(Object.create)) {
+  GltfVertexBufferLoader.prototype = Object.create(ResourceLoader.prototype);
+  GltfVertexBufferLoader.prototype.constructor = GltfVertexBufferLoader;
+}
+
+Object.defineProperties(GltfVertexBufferLoader.prototype, {
+  /**
+   * A promise that resolves to the resource when the resource is ready.
+   *
+   * @memberof GltfVertexBufferLoader.prototype
+   *
+   * @type {Promise.<GltfVertexBufferLoader>}
+   * @readonly
+   */
+  promise: {
+    get: function () {
+      return this._promise.promise;
+    },
+  },
+  /**
+   * The cache key of the resource.
+   *
+   * @memberof GltfVertexBufferLoader.prototype
+   *
+   * @type {String}
+   * @readonly
+   */
+  cacheKey: {
+    get: function () {
+      return this._cacheKey;
+    },
+  },
+  /**
+   * The vertex buffer.
+   *
+   * @memberof GltfVertexBufferLoader.prototype
+   *
+   * @type {Buffer}
+   * @readonly
+   */
+  vertexBuffer: {
+    get: function () {
+      return this._vertexBuffer;
+    },
+  },
+});
+
+/**
+ * Loads the resource.
+ */
+GltfVertexBufferLoader.prototype.load = function () {
+  if (defined(this._draco)) {
+    loadFromDraco(this);
+  } else {
+    loadFromBufferView(this);
+  }
+};
+
+function loadFromDraco(vertexBufferLoader) {
+  var resourceCache = vertexBufferLoader._resourceCache;
+  var dracoLoader = resourceCache.loadDraco({
+    gltf: vertexBufferLoader._gltf,
+    draco: vertexBufferLoader._draco,
+    gltfResource: vertexBufferLoader._gltfResource,
+    baseResource: vertexBufferLoader._baseResource,
+    keepResident: false,
+  });
+
+  vertexBufferLoader._dracoLoader = dracoLoader;
+  vertexBufferLoader._state = ResourceLoaderState.LOADING;
+
+  dracoLoader.promise
+    .then(function () {
+      if (vertexBufferLoader.isDestroyed()) {
+        return;
+      }
+      // Now wait for the GPU buffer to be created during processing.
+      var decodedVertexAttributes = dracoLoader.decodedData.vertexAttributes;
+      var dracoSemantic = vertexBufferLoader._dracoAttributeSemantic;
+      var typedArray = decodedVertexAttributes[dracoSemantic].array;
+      vertexBufferLoader._typedArray = typedArray;
+    })
+    .otherwise(function (error) {
+      handleError(vertexBufferLoader, error);
+    });
+}
+
+function loadFromBufferView(vertexBufferLoader) {
+  var resourceCache = vertexBufferLoader._resourceCache;
+  var bufferViewLoader = resourceCache.loadBufferView({
+    gltf: vertexBufferLoader._gltf,
+    bufferViewId: vertexBufferLoader._bufferViewId,
+    gltfResource: vertexBufferLoader._gltfResource,
+    baseResource: vertexBufferLoader._baseResource,
+    keepResident: false,
+  });
+  vertexBufferLoader._state = ResourceLoaderState.LOADING;
+  vertexBufferLoader._bufferViewLoader = bufferViewLoader;
+
+  bufferViewLoader.promise
+    .then(function () {
+      if (vertexBufferLoader.isDestroyed()) {
+        return;
+      }
+      // Now wait for the GPU buffer to be created during processing.
+      vertexBufferLoader._typedArray = bufferViewLoader.typedArray;
+    })
+    .otherwise(function (error) {
+      handleError(vertexBufferLoader, error);
+    });
+}
+
+function handleError(vertexBufferLoader, error) {
+  vertexBufferLoader.unload();
+  vertexBufferLoader._state = ResourceLoaderState.FAILED;
+  var errorMessage = "Failed to load vertex buffer";
+  error = vertexBufferLoader.getError(errorMessage, error);
+  vertexBufferLoader._promise.reject(error);
+}
+
+function CreateVertexBufferJob() {
+  this.typedArray = undefined;
+  this.context = undefined;
+  this.vertexBuffer = undefined;
+}
+
+CreateVertexBufferJob.prototype.set = function (typedArray, context) {
+  this.typedArray = typedArray;
+  this.context = context;
+};
+
+CreateVertexBufferJob.prototype.execute = function () {
+  this.vertexBuffer = createVertexBuffer(this.typedArray, this.context);
+};
+
+function createVertexBuffer(typedArray, context) {
+  var vertexBuffer = Buffer.createVertexBuffer({
+    typedArray: typedArray,
+    context: context,
+    usage: BufferUsage.STATIC_DRAW,
+  });
+  vertexBuffer.vertexArrayDestroyable = false;
+  return vertexBuffer;
+}
+
+var scratchVertexBufferJob = new CreateVertexBufferJob();
+
+/**
+ * Processes the resource until it becomes ready.
+ *
+ * @param {FrameState} frameState The frame state.
+ */
+GltfVertexBufferLoader.prototype.process = function (frameState) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("frameState", frameState);
+  //>>includeEnd('debug');
+
+  if (defined(this._dracoLoader)) {
+    this._dracoLoader.process(frameState);
+  }
+
+  if (defined(this._vertexBuffer)) {
+    // Already created vertex buffer
+    return;
+  }
+
+  if (!defined(this._typedArray)) {
+    // Not ready to create vertex buffer
+    return;
+  }
+
+  var vertexBuffer;
+
+  if (this._asynchronous) {
+    var vertexBufferJob = scratchVertexBufferJob;
+    vertexBufferJob.set(this._typedArray, frameState.context);
+    var jobScheduler = frameState.jobScheduler;
+    if (!jobScheduler.execute(vertexBufferJob, JobType.BUFFER)) {
+      // Job scheduler is full. Try again next frame.
+      return;
+    }
+    vertexBuffer = vertexBufferJob.vertexBuffer;
+  } else {
+    vertexBuffer = createVertexBuffer(this._typedArray, frameState.context);
+  }
+
+  // Unload everything except the vertex buffer
+  this.unload();
+
+  this._vertexBuffer = vertexBuffer;
+  this._state = ResourceLoaderState.READY;
+  this._promise.resolve(this);
+};
+/**
+ * Unloads the resource.
+ */
+GltfVertexBufferLoader.prototype.unload = function () {
+  if (defined(this._vertexBuffer)) {
+    this._vertexBuffer.destroy();
+  }
+
+  var resourceCache = this._resourceCache;
+
+  if (defined(this._bufferViewLoader)) {
+    resourceCache.unload(this._bufferViewLoader);
+  }
+
+  if (defined(this._dracoLoader)) {
+    resourceCache.unload(this._dracoLoader);
+  }
+
+  this._bufferViewLoader = undefined;
+  this._dracoLoader = undefined;
+  this._typedArray = undefined;
+  this._vertexBuffer = undefined;
+  this._gltf = undefined;
+};

--- a/Source/Scene/GltfVertexBufferLoader.js
+++ b/Source/Scene/GltfVertexBufferLoader.js
@@ -171,7 +171,7 @@ function loadFromDraco(vertexBufferLoader) {
       if (vertexBufferLoader.isDestroyed()) {
         return;
       }
-      // Now wait for the GPU buffer to be created during processing.
+      // Now wait for process() to run to finish loading
       var decodedVertexAttributes = dracoLoader.decodedData.vertexAttributes;
       var dracoSemantic = vertexBufferLoader._dracoAttributeSemantic;
       var typedArray = decodedVertexAttributes[dracoSemantic].array;
@@ -199,7 +199,7 @@ function loadFromBufferView(vertexBufferLoader) {
       if (vertexBufferLoader.isDestroyed()) {
         return;
       }
-      // Now wait for the GPU buffer to be created during processing.
+      // Now wait for process() to run to finish loading
       vertexBufferLoader._typedArray = bufferViewLoader.typedArray;
     })
     .otherwise(function (error) {

--- a/Source/Scene/ResourceCache.js
+++ b/Source/Scene/ResourceCache.js
@@ -3,6 +3,13 @@ import defaultValue from "../Core/defaultValue.js";
 import defined from "../Core/defined.js";
 import DeveloperError from "../Core/DeveloperError.js";
 import BufferLoader from "./BufferLoader.js";
+import GltfBufferViewLoader from "./GltfBufferViewLoader.js";
+import GltfDracoLoader from "./GltfDracoLoader.js";
+import GltfImageLoader from "./GltfImageLoader.js";
+import GltfIndexBufferLoader from "./GltfIndexBufferLoader.js";
+import GltfJsonLoader from "./GltfJsonLoader.js";
+import GltfTextureLoader from "./GltfTextureLoader.js";
+import GltfVertexBufferLoader from "./GltfVertexBufferLoader.js";
 import MetadataSchemaLoader from "./MetadataSchemaLoader.js";
 import ResourceCacheKey from "./ResourceCacheKey.js";
 
@@ -183,7 +190,7 @@ ResourceCache.loadSchema = function (options) {
  * @param {Object} options Object with the following properties:
  * @param {Resource} options.parentResource The {@link Resource} containing the embedded buffer.
  * @param {Number} options.bufferId A unique identifier of the embedded buffer within the parent resource.
- * @param {Uint8Array} options.typedArray The typed array containing the embedded buffer contents.
+ * @param {Uint8Array} [options.typedArray] The typed array containing the embedded buffer contents.
  * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
  *
  * @returns {BufferLoader} The buffer loader.
@@ -198,7 +205,6 @@ ResourceCache.loadEmbeddedBuffer = function (options) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("options.parentResource", parentResource);
   Check.typeOf.number("options.bufferId", bufferId);
-  Check.typeOf.object("options.typedArray", typedArray);
   //>>includeEnd('debug');
 
   var cacheKey = ResourceCacheKey.getEmbeddedBufferCacheKey({
@@ -211,9 +217,13 @@ ResourceCache.loadEmbeddedBuffer = function (options) {
     return bufferLoader;
   }
 
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.typedArray", typedArray);
+  //>>includeEnd('debug');
+
   bufferLoader = new BufferLoader({
-    cacheKey: cacheKey,
     typedArray: typedArray,
+    cacheKey: cacheKey,
   });
 
   ResourceCache.load({
@@ -252,8 +262,8 @@ ResourceCache.loadExternalBuffer = function (options) {
   }
 
   bufferLoader = new BufferLoader({
-    cacheKey: cacheKey,
     resource: resource,
+    cacheKey: cacheKey,
   });
 
   ResourceCache.load({
@@ -262,6 +272,444 @@ ResourceCache.loadExternalBuffer = function (options) {
   });
 
   return bufferLoader;
+};
+
+/**
+ * Loads a glTF JSON from the cache.
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
+ *
+ * @returns {GltfJsonLoader} The glTF JSON.
+ */
+ResourceCache.loadGltf = function (options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var gltfResource = options.gltfResource;
+  var baseResource = options.baseResource;
+  var keepResident = defaultValue(options.keepResident, false);
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.gltfResource", gltfResource);
+  Check.typeOf.object("options.baseResource", baseResource);
+  //>>includeEnd('debug');
+
+  var cacheKey = ResourceCacheKey.getGltfCacheKey({
+    gltfResource: gltfResource,
+  });
+
+  var gltfJsonLoader = ResourceCache.get(cacheKey);
+  if (defined(gltfJsonLoader)) {
+    return gltfJsonLoader;
+  }
+
+  gltfJsonLoader = new GltfJsonLoader({
+    resourceCache: ResourceCache,
+    gltfResource: gltfResource,
+    baseResource: baseResource,
+    cacheKey: cacheKey,
+    keepResident: keepResident,
+  });
+
+  ResourceCache.load({
+    resourceLoader: gltfJsonLoader,
+    keepResident: keepResident,
+  });
+
+  return gltfJsonLoader;
+};
+
+/**
+ * Loads a glTF buffer view from the cache.
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {Object} options.gltf The glTF JSON.
+ * @param {Number} options.bufferViewId The bufferView ID.
+ * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
+ *
+ * @returns {GltfBufferViewLoader} The buffer view loader.
+ */
+ResourceCache.loadBufferView = function (options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var gltf = options.gltf;
+  var bufferViewId = options.bufferViewId;
+  var gltfResource = options.gltfResource;
+  var baseResource = options.baseResource;
+  var keepResident = defaultValue(options.keepResident, false);
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.gltf", gltf);
+  Check.typeOf.number("options.bufferViewId", bufferViewId);
+  Check.typeOf.object("options.gltfResource", gltfResource);
+  Check.typeOf.object("options.baseResource", baseResource);
+  //>>includeEnd('debug');
+
+  var cacheKey = ResourceCacheKey.getBufferViewCacheKey({
+    gltf: gltf,
+    bufferViewId: bufferViewId,
+    gltfResource: gltfResource,
+    baseResource: baseResource,
+  });
+
+  var bufferViewLoader = ResourceCache.get(cacheKey);
+  if (defined(bufferViewLoader)) {
+    return bufferViewLoader;
+  }
+
+  bufferViewLoader = new GltfBufferViewLoader({
+    resourceCache: ResourceCache,
+    gltf: gltf,
+    bufferViewId: bufferViewId,
+    gltfResource: gltfResource,
+    baseResource: baseResource,
+    cacheKey: cacheKey,
+  });
+
+  ResourceCache.load({
+    resourceLoader: bufferViewLoader,
+    keepResident: keepResident,
+  });
+
+  return bufferViewLoader;
+};
+
+/**
+ * Loads Draco data from the cache.
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {Object} options.gltf The glTF JSON.
+ * @param {Object} options.draco The Draco extension object.
+ * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
+ *
+ * @returns {GltfDracoLoader} The Draco loader.
+ */
+ResourceCache.loadDraco = function (options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var gltf = options.gltf;
+  var draco = options.draco;
+  var gltfResource = options.gltfResource;
+  var baseResource = options.baseResource;
+  var keepResident = defaultValue(options.keepResident, false);
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.gltf", gltf);
+  Check.typeOf.object("options.draco", draco);
+  Check.typeOf.object("options.gltfResource", gltfResource);
+  Check.typeOf.object("options.baseResource", baseResource);
+  //>>includeEnd('debug');
+
+  var cacheKey = ResourceCacheKey.getDracoCacheKey({
+    gltf: gltf,
+    draco: draco,
+    gltfResource: gltfResource,
+    baseResource: baseResource,
+  });
+
+  var dracoLoader = ResourceCache.get(cacheKey);
+  if (defined(dracoLoader)) {
+    return dracoLoader;
+  }
+
+  dracoLoader = new GltfDracoLoader({
+    resourceCache: ResourceCache,
+    gltf: gltf,
+    draco: draco,
+    gltfResource: gltfResource,
+    baseResource: baseResource,
+    cacheKey: cacheKey,
+  });
+
+  ResourceCache.load({
+    resourceLoader: dracoLoader,
+    keepResident: keepResident,
+  });
+
+  return dracoLoader;
+};
+
+/**
+ * Loads a glTF vertex buffer from the cache.
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {Object} options.gltf The glTF JSON.
+ * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {Number} [options.bufferViewId] The bufferView ID corresponding to the vertex buffer.
+ * @param {Object} [options.draco] The Draco extension object.
+ * @param {String} [options.dracoAttributeSemantic] The Draco attribute semantic, e.g. POSITION or NORMAL.
+ * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
+ * @param {Boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
+ *
+ * @exception {DeveloperError} One of options.bufferViewId and options.draco must be defined.
+ * @exception {DeveloperError} When options.draco is defined options.dracoAttributeSemantic must also be defined.
+ *
+ * @returns {GltfVertexBufferLoader} The vertex buffer loader.
+ */
+ResourceCache.loadVertexBuffer = function (options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var gltf = options.gltf;
+  var gltfResource = options.gltfResource;
+  var baseResource = options.baseResource;
+  var bufferViewId = options.bufferViewId;
+  var draco = options.draco;
+  var dracoAttributeSemantic = options.dracoAttributeSemantic;
+  var keepResident = defaultValue(options.keepResident, false);
+  var asynchronous = defaultValue(options.asynchronous, true);
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.gltf", gltf);
+  Check.typeOf.object("options.gltfResource", gltfResource);
+  Check.typeOf.object("options.baseResource", baseResource);
+
+  var hasBufferViewId = defined(bufferViewId);
+  var hasDraco = defined(draco);
+  var hasDracoAttributeSemantic = defined(dracoAttributeSemantic);
+
+  if (hasBufferViewId === hasDraco) {
+    throw new DeveloperError(
+      "One of options.bufferViewId and options.draco must be defined."
+    );
+  }
+
+  if (hasDraco && !hasDracoAttributeSemantic) {
+    throw new DeveloperError(
+      "When options.draco is defined options.dracoAttributeSemantic must also be defined."
+    );
+  }
+
+  if (hasDraco) {
+    Check.typeOf.object("options.draco", draco);
+    Check.typeOf.string(
+      "options.dracoAttributeSemantic",
+      dracoAttributeSemantic
+    );
+  }
+  //>>includeEnd('debug');
+
+  var cacheKey = ResourceCacheKey.getVertexBufferCacheKey({
+    gltf: gltf,
+    gltfResource: gltfResource,
+    baseResource: baseResource,
+    bufferViewId: bufferViewId,
+    draco: draco,
+    dracoAttributeSemantic: dracoAttributeSemantic,
+  });
+
+  var vertexBufferLoader = ResourceCache.get(cacheKey);
+  if (defined(vertexBufferLoader)) {
+    return vertexBufferLoader;
+  }
+
+  vertexBufferLoader = new GltfVertexBufferLoader({
+    resourceCache: ResourceCache,
+    gltf: gltf,
+    gltfResource: gltfResource,
+    baseResource: baseResource,
+    bufferViewId: bufferViewId,
+    draco: draco,
+    dracoAttributeSemantic: dracoAttributeSemantic,
+    cacheKey: cacheKey,
+    asynchronous: asynchronous,
+  });
+
+  ResourceCache.load({
+    resourceLoader: vertexBufferLoader,
+    keepResident: keepResident,
+  });
+
+  return vertexBufferLoader;
+};
+
+/**
+ * Loads a glTF index buffer from the cache.
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {Object} options.gltf The glTF JSON.
+ * @param {Number} options.accessorId The accessor ID corresponding to the index buffer.
+ * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {Object} [options.draco] The Draco extension object.
+ * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
+ * @param {Boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
+ *
+ * @returns {GltfIndexBufferLoader} The index buffer loader.
+ */
+ResourceCache.loadIndexBuffer = function (options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var gltf = options.gltf;
+  var accessorId = options.accessorId;
+  var gltfResource = options.gltfResource;
+  var baseResource = options.baseResource;
+  var draco = options.draco;
+  var keepResident = defaultValue(options.keepResident, false);
+  var asynchronous = defaultValue(options.asynchronous, true);
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.gltf", gltf);
+  Check.typeOf.number("options.accessorId", accessorId);
+  Check.typeOf.object("options.gltfResource", gltfResource);
+  Check.typeOf.object("options.baseResource", baseResource);
+  //>>includeEnd('debug');
+
+  var cacheKey = ResourceCacheKey.getIndexBufferCacheKey({
+    gltf: gltf,
+    accessorId: accessorId,
+    gltfResource: gltfResource,
+    baseResource: baseResource,
+    draco: draco,
+  });
+
+  var indexBufferLoader = ResourceCache.get(cacheKey);
+  if (defined(indexBufferLoader)) {
+    return indexBufferLoader;
+  }
+
+  indexBufferLoader = new GltfIndexBufferLoader({
+    resourceCache: ResourceCache,
+    gltf: gltf,
+    accessorId: accessorId,
+    gltfResource: gltfResource,
+    baseResource: baseResource,
+    draco: draco,
+    cacheKey: cacheKey,
+    asynchronous: asynchronous,
+  });
+
+  ResourceCache.load({
+    resourceLoader: indexBufferLoader,
+    keepResident: keepResident,
+  });
+
+  return indexBufferLoader;
+};
+
+/**
+ * Loads a glTF image from the cache.
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {Object} options.gltf The glTF JSON.
+ * @param {Number} options.imageId The image ID.
+ * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
+ * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
+ *
+ * @returns {GltfImageLoader} The image loader.
+ */
+ResourceCache.loadImage = function (options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var gltf = options.gltf;
+  var imageId = options.imageId;
+  var gltfResource = options.gltfResource;
+  var baseResource = options.baseResource;
+  var supportedImageFormats = options.supportedImageFormats;
+  var keepResident = defaultValue(options.keepResident, false);
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.gltf", gltf);
+  Check.typeOf.number("options.imageId", imageId);
+  Check.typeOf.object("options.gltfResource", gltfResource);
+  Check.typeOf.object("options.baseResource", baseResource);
+  Check.typeOf.object("options.supportedImageFormats", supportedImageFormats);
+  //>>includeEnd('debug');
+
+  var cacheKey = ResourceCacheKey.getImageCacheKey({
+    gltf: gltf,
+    imageId: imageId,
+    gltfResource: gltfResource,
+    baseResource: baseResource,
+    supportedImageFormats: supportedImageFormats,
+  });
+
+  var imageLoader = ResourceCache.get(cacheKey);
+  if (defined(imageLoader)) {
+    return imageLoader;
+  }
+
+  imageLoader = new GltfImageLoader({
+    resourceCache: ResourceCache,
+    gltf: gltf,
+    imageId: imageId,
+    gltfResource: gltfResource,
+    baseResource: baseResource,
+    supportedImageFormats: supportedImageFormats,
+    cacheKey: cacheKey,
+  });
+
+  ResourceCache.load({
+    resourceLoader: imageLoader,
+    keepResident: keepResident,
+  });
+
+  return imageLoader;
+};
+
+/**
+ * Loads a glTF texture from the cache.
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {Object} options.gltf The glTF JSON.
+ * @param {Object} options.textureInfo The texture info object.
+ * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
+ * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
+ * @param {Boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
+ *
+ * @returns {GltfTextureLoader} The texture loader.
+ */
+ResourceCache.loadTexture = function (options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var gltf = options.gltf;
+  var textureInfo = options.textureInfo;
+  var gltfResource = options.gltfResource;
+  var baseResource = options.baseResource;
+  var supportedImageFormats = options.supportedImageFormats;
+  var keepResident = defaultValue(options.keepResident, false);
+  var asynchronous = defaultValue(options.asynchronous, true);
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.gltf", gltf);
+  Check.typeOf.object("options.textureInfo", textureInfo);
+  Check.typeOf.object("options.gltfResource", gltfResource);
+  Check.typeOf.object("options.baseResource", baseResource);
+  //>>includeEnd('debug');
+
+  var cacheKey = ResourceCacheKey.getTextureCacheKey({
+    gltf: gltf,
+    textureInfo: textureInfo,
+    gltfResource: gltfResource,
+    baseResource: baseResource,
+    supportedImageFormats: supportedImageFormats,
+  });
+
+  var textureLoader = ResourceCache.get(cacheKey);
+  if (defined(textureLoader)) {
+    return textureLoader;
+  }
+
+  textureLoader = new GltfTextureLoader({
+    resourceCache: ResourceCache,
+    gltf: gltf,
+    textureInfo: textureInfo,
+    gltfResource: gltfResource,
+    baseResource: baseResource,
+    supportedImageFormats: supportedImageFormats,
+    cacheKey: cacheKey,
+    asynchronous: asynchronous,
+  });
+
+  ResourceCache.load({
+    resourceLoader: textureLoader,
+    keepResident: keepResident,
+  });
+
+  return textureLoader;
 };
 
 /**

--- a/Source/Scene/ResourceCacheKey.js
+++ b/Source/Scene/ResourceCacheKey.js
@@ -3,6 +3,7 @@ import defaultValue from "../Core/defaultValue.js";
 import defined from "../Core/defined.js";
 import DeveloperError from "../Core/DeveloperError.js";
 import getAbsoluteUri from "../Core/getAbsoluteUri.js";
+import GltfLoaderUtil from "./GltfLoaderUtil.js";
 
 /**
  * Compute cache keys for resources in {@link ResourceCache}.
@@ -15,6 +16,114 @@ var ResourceCacheKey = {};
 
 function getExternalResourceCacheKey(resource) {
   return getAbsoluteUri(resource.url);
+}
+
+function getBufferViewCacheKey(bufferView) {
+  var byteOffset = bufferView.byteOffset;
+  var byteLength = bufferView.byteLength;
+  return byteOffset + "-" + (byteOffset + byteLength);
+}
+
+function getAccessorCacheKey(accessor, bufferView) {
+  var byteOffset = bufferView.byteOffset + accessor.byteOffset;
+  var componentType = accessor.componentType;
+  var type = accessor.type;
+  var count = accessor.count;
+  return byteOffset + "-" + componentType + "-" + type + "-" + count;
+}
+
+function getExternalBufferCacheKey(resource) {
+  return getExternalResourceCacheKey(resource);
+}
+
+function getEmbeddedBufferCacheKey(parentResource, bufferId) {
+  var parentCacheKey = getExternalResourceCacheKey(parentResource);
+  return parentCacheKey + "-buffer-id-" + bufferId;
+}
+
+function getBufferCacheKey(buffer, bufferId, gltfResource, baseResource) {
+  if (defined(buffer.uri)) {
+    var resource = baseResource.getDerivedResource({
+      url: buffer.uri,
+    });
+    return getExternalBufferCacheKey(resource);
+  }
+
+  return getEmbeddedBufferCacheKey(gltfResource, bufferId);
+}
+
+function getDracoCacheKey(gltf, draco, gltfResource, baseResource) {
+  var bufferViewId = draco.bufferView;
+  var bufferView = gltf.bufferViews[bufferViewId];
+  var bufferId = bufferView.buffer;
+  var buffer = gltf.buffers[bufferId];
+
+  var bufferCacheKey = getBufferCacheKey(
+    buffer,
+    bufferId,
+    gltfResource,
+    baseResource
+  );
+
+  var bufferViewCacheKey = getBufferViewCacheKey(bufferView);
+
+  return bufferCacheKey + "-range-" + bufferViewCacheKey;
+}
+
+function getImageCacheKey(
+  gltf,
+  imageId,
+  gltfResource,
+  baseResource,
+  supportedImageFormats
+) {
+  var results = GltfLoaderUtil.getImageUriOrBufferView({
+    gltf: gltf,
+    imageId: imageId,
+    supportedImageFormats: supportedImageFormats,
+  });
+
+  var bufferViewId = results.bufferViewId;
+  var uri = results.uri;
+
+  if (defined(uri)) {
+    var resource = baseResource.getDerivedResource({
+      url: uri,
+    });
+    return getExternalResourceCacheKey(resource);
+  }
+
+  var bufferView = gltf.bufferViews[bufferViewId];
+  var bufferId = bufferView.buffer;
+  var buffer = gltf.buffers[bufferId];
+
+  var bufferCacheKey = getBufferCacheKey(
+    buffer,
+    bufferId,
+    gltfResource,
+    baseResource
+  );
+
+  var bufferViewCacheKey = getBufferViewCacheKey(bufferView);
+
+  return bufferCacheKey + "-range-" + bufferViewCacheKey;
+}
+
+function getSamplerCacheKey(gltf, textureInfo) {
+  var sampler = GltfLoaderUtil.createSampler({
+    gltf: gltf,
+    textureInfo: textureInfo,
+  });
+
+  return (
+    sampler.wrapS +
+    "-" +
+    sampler.wrapT +
+    "-" +
+    sampler.minificationFilter +
+    "-" +
+    sampler.magnificationFilter
+  );
 }
 
 /**
@@ -63,7 +172,7 @@ ResourceCacheKey.getExternalBufferCacheKey = function (options) {
   Check.typeOf.object("options.resource", resource);
   //>>includeEnd('debug');
 
-  return "external-buffer:" + getExternalResourceCacheKey(resource);
+  return "external-buffer:" + getExternalBufferCacheKey(resource);
 };
 
 /**
@@ -85,8 +194,326 @@ ResourceCacheKey.getEmbeddedBufferCacheKey = function (options) {
   Check.typeOf.number("options.bufferId", bufferId);
   //>>includeEnd('debug');
 
-  var parentCacheKey = getExternalResourceCacheKey(parentResource);
-  return "embedded-buffer:" + parentCacheKey + "-buffer-" + bufferId;
+  return (
+    "embedded-buffer:" + getEmbeddedBufferCacheKey(parentResource, bufferId)
+  );
+};
+
+/**
+ * Gets the glTF cache key.
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ *
+ * @returns {String} The glTF cache key.
+ */
+ResourceCacheKey.getGltfCacheKey = function (options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var gltfResource = options.gltfResource;
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.gltfResource", gltfResource);
+  //>>includeEnd('debug');
+
+  return "gltf:" + getExternalResourceCacheKey(gltfResource);
+};
+
+/**
+ * Gets the buffer view cache key.
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {Object} options.gltf The glTF JSON.
+ * @param {Number} options.bufferViewId The bufferView ID.
+ * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ *
+ * @returns {String} The buffer view cache key.
+ */
+ResourceCacheKey.getBufferViewCacheKey = function (options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var gltf = options.gltf;
+  var bufferViewId = options.bufferViewId;
+  var gltfResource = options.gltfResource;
+  var baseResource = options.baseResource;
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.gltf", gltf);
+  Check.typeOf.number("options.bufferViewId", bufferViewId);
+  Check.typeOf.object("options.gltfResource", gltfResource);
+  Check.typeOf.object("options.baseResource", baseResource);
+  //>>includeEnd('debug');
+
+  var bufferView = gltf.bufferViews[bufferViewId];
+  var bufferId = bufferView.buffer;
+  var buffer = gltf.buffers[bufferId];
+
+  var bufferCacheKey = getBufferCacheKey(
+    buffer,
+    bufferId,
+    gltfResource,
+    baseResource
+  );
+
+  var bufferViewCacheKey = getBufferViewCacheKey(bufferView);
+
+  return "buffer-view:" + bufferCacheKey + "-range-" + bufferViewCacheKey;
+};
+
+/**
+ * Gets the Draco cache key.
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {Object} options.gltf The glTF JSON.
+ * @param {Object} options.draco The Draco extension object.
+ * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ *
+ * @returns {String} The Draco cache key.
+ */
+ResourceCacheKey.getDracoCacheKey = function (options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var gltf = options.gltf;
+  var draco = options.draco;
+  var gltfResource = options.gltfResource;
+  var baseResource = options.baseResource;
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.gltf", gltf);
+  Check.typeOf.object("options.draco", draco);
+  Check.typeOf.object("options.gltfResource", gltfResource);
+  Check.typeOf.object("options.baseResource", baseResource);
+  //>>includeEnd('debug');
+
+  return "draco:" + getDracoCacheKey(gltf, draco, gltfResource, baseResource);
+};
+
+/**
+ * Gets the vertex buffer cache key.
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {Object} options.gltf The glTF JSON.
+ * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {Number} [options.bufferViewId] The bufferView ID corresponding to the vertex buffer.
+ * @param {Object} [options.draco] The Draco extension object.
+ * @param {String} [options.dracoAttributeSemantic] The Draco attribute semantic, e.g. POSITION or NORMAL.
+ *
+ * @exception {DeveloperError} One of options.bufferViewId and options.draco must be defined.
+ * @exception {DeveloperError} When options.draco is defined options.dracoAttributeSemantic must also be defined.
+ *
+ * @returns {String} The vertex buffer cache key.
+ */
+ResourceCacheKey.getVertexBufferCacheKey = function (options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var gltf = options.gltf;
+  var gltfResource = options.gltfResource;
+  var baseResource = options.baseResource;
+  var bufferViewId = options.bufferViewId;
+  var draco = options.draco;
+  var dracoAttributeSemantic = options.dracoAttributeSemantic;
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.gltf", gltf);
+  Check.typeOf.object("options.gltfResource", gltfResource);
+  Check.typeOf.object("options.baseResource", baseResource);
+
+  var hasBufferViewId = defined(bufferViewId);
+  var hasDraco = defined(draco);
+  var hasDracoAttributeSemantic = defined(dracoAttributeSemantic);
+
+  if (hasBufferViewId === hasDraco) {
+    throw new DeveloperError(
+      "One of options.bufferViewId and options.draco must be defined."
+    );
+  }
+
+  if (hasDraco && !hasDracoAttributeSemantic) {
+    throw new DeveloperError(
+      "When options.draco is defined options.dracoAttributeSemantic must also be defined."
+    );
+  }
+
+  if (hasDraco) {
+    Check.typeOf.object("options.draco", draco);
+    Check.typeOf.string(
+      "options.dracoAttributeSemantic",
+      dracoAttributeSemantic
+    );
+  }
+  //>>includeEnd('debug');
+
+  if (defined(draco)) {
+    var dracoCacheKey = getDracoCacheKey(
+      gltf,
+      draco,
+      gltfResource,
+      baseResource
+    );
+    return (
+      "vertex-buffer:" + dracoCacheKey + "-draco-" + dracoAttributeSemantic
+    );
+  }
+
+  var bufferView = gltf.bufferViews[bufferViewId];
+  var bufferId = bufferView.buffer;
+  var buffer = gltf.buffers[bufferId];
+
+  var bufferCacheKey = getBufferCacheKey(
+    buffer,
+    bufferId,
+    gltfResource,
+    baseResource
+  );
+
+  var bufferViewCacheKey = getBufferViewCacheKey(bufferView);
+
+  return "vertex-buffer:" + bufferCacheKey + "-range-" + bufferViewCacheKey;
+};
+
+/**
+ * Gets the index buffer cache key.
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {Object} options.gltf The glTF JSON.
+ * @param {Number} options.accessorId The accessor ID corresponding to the index buffer.
+ * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {Object} [options.draco] The Draco extension object.
+ *
+ * @returns {String} The index buffer cache key.
+ */
+ResourceCacheKey.getIndexBufferCacheKey = function (options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var gltf = options.gltf;
+  var accessorId = options.accessorId;
+  var gltfResource = options.gltfResource;
+  var baseResource = options.baseResource;
+  var draco = options.draco;
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.gltf", gltf);
+  Check.typeOf.number("options.accessorId", accessorId);
+  Check.typeOf.object("options.gltfResource", gltfResource);
+  Check.typeOf.object("options.baseResource", baseResource);
+  //>>includeEnd('debug');
+
+  if (defined(draco)) {
+    var dracoCacheKey = getDracoCacheKey(
+      gltf,
+      draco,
+      gltfResource,
+      baseResource
+    );
+    return "index-buffer:" + dracoCacheKey + "-draco";
+  }
+
+  var accessor = gltf.accessors[accessorId];
+  var bufferViewId = accessor.bufferView;
+  var bufferView = gltf.bufferViews[bufferViewId];
+  var bufferId = bufferView.buffer;
+  var buffer = gltf.buffers[bufferId];
+
+  var bufferCacheKey = getBufferCacheKey(
+    buffer,
+    bufferId,
+    gltfResource,
+    baseResource
+  );
+
+  var accessorCacheKey = getAccessorCacheKey(accessor, bufferView);
+
+  return "index-buffer:" + bufferCacheKey + "-accessor-" + accessorCacheKey;
+};
+
+/**
+ * Gets the image cache key.
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {Object} options.gltf The glTF JSON.
+ * @param {Number} options.imageId The image ID.
+ * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
+ *
+ * @returns {String} The image cache key.
+ */
+ResourceCacheKey.getImageCacheKey = function (options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var gltf = options.gltf;
+  var imageId = options.imageId;
+  var gltfResource = options.gltfResource;
+  var baseResource = options.baseResource;
+  var supportedImageFormats = options.supportedImageFormats;
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.gltf", gltf);
+  Check.typeOf.number("options.imageId", imageId);
+  Check.typeOf.object("options.gltfResource", gltfResource);
+  Check.typeOf.object("options.baseResource", baseResource);
+  Check.typeOf.object("options.supportedImageFormats", supportedImageFormats);
+  //>>includeEnd('debug');
+
+  var imageCacheKey = getImageCacheKey(
+    gltf,
+    imageId,
+    gltfResource,
+    baseResource,
+    supportedImageFormats
+  );
+
+  return "image:" + imageCacheKey;
+};
+
+/**
+ * Gets the texture cache key.
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {Object} options.gltf The glTF JSON.
+ * @param {Object} options.textureInfo The texture info object.
+ * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
+ *
+ * @returns {String} The texture cache key.
+ */
+ResourceCacheKey.getTextureCacheKey = function (options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var gltf = options.gltf;
+  var textureInfo = options.textureInfo;
+  var gltfResource = options.gltfResource;
+  var baseResource = options.baseResource;
+  var supportedImageFormats = options.supportedImageFormats;
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.gltf", gltf);
+  Check.typeOf.object("options.textureInfo", textureInfo);
+  Check.typeOf.object("options.gltfResource", gltfResource);
+  Check.typeOf.object("options.baseResource", baseResource);
+  Check.typeOf.object("options.supportedImageFormats", supportedImageFormats);
+  //>>includeEnd('debug');
+
+  var textureId = textureInfo.index;
+
+  var imageId = GltfLoaderUtil.getImageIdFromTexture({
+    gltf: gltf,
+    textureId: textureId,
+    supportedImageFormats: supportedImageFormats,
+  });
+
+  var imageCacheKey = getImageCacheKey(
+    gltf,
+    imageId,
+    gltfResource,
+    baseResource,
+    supportedImageFormats
+  );
+
+  // Include the sampler cache key in the texture cache key since textures and
+  // samplers are coupled in WebGL 1. When upgrading to WebGL 2 consider
+  // removing the sampleCacheKey here.
+  var samplerCacheKey = getSamplerCacheKey(gltf, textureInfo);
+
+  return "texture:" + imageCacheKey + "-sampler-" + samplerCacheKey;
 };
 
 export default ResourceCacheKey;

--- a/Source/Scene/ResourceLoader.js
+++ b/Source/Scene/ResourceLoader.js
@@ -63,11 +63,11 @@ ResourceLoader.prototype.load = function () {
 ResourceLoader.prototype.unload = function () {};
 
 /**
- * Updates the resource.
+ * Processes the resource until it becomes ready.
  *
  * @param {FrameState} frameState The frame state.
  */
-ResourceLoader.prototype.update = function (frameState) {};
+ResourceLoader.prototype.process = function (frameState) {};
 
 /**
  * Constructs a {@link RuntimeError} from an errorMessage and an error.

--- a/Source/Scene/SupportedImageFormats.js
+++ b/Source/Scene/SupportedImageFormats.js
@@ -1,0 +1,17 @@
+import defaultValue from "../Core/defaultValue.js";
+
+/**
+ * Image formats supported by the browser.
+ * @param {Object} [options] Object with the following properties:
+ * @param {Boolean} [options.webp=false] Whether the browser supports WebP images.
+ * @param {Boolean} [options.s3tc=false] Whether the browser supports s3tc compressed images.
+ * @param {Boolean} [options.pvrtc=false] Whether the browser supports pvrtc compressed images.
+ * @param {Boolean} [options.etc1=false] Whether the browser supports etc1 compressed images.
+ */
+export default function SupportedImageFormats(options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  this.webp = defaultValue(options.webp, false);
+  this.s3tc = defaultValue(options.s3tc, false);
+  this.pvrtc = defaultValue(options.pvrtc, false);
+  this.etc1 = defaultValue(options.etc1, false);
+}

--- a/Source/Scene/SupportedImageFormats.js
+++ b/Source/Scene/SupportedImageFormats.js
@@ -2,11 +2,14 @@ import defaultValue from "../Core/defaultValue.js";
 
 /**
  * Image formats supported by the browser.
+ *
  * @param {Object} [options] Object with the following properties:
  * @param {Boolean} [options.webp=false] Whether the browser supports WebP images.
  * @param {Boolean} [options.s3tc=false] Whether the browser supports s3tc compressed images.
  * @param {Boolean} [options.pvrtc=false] Whether the browser supports pvrtc compressed images.
  * @param {Boolean} [options.etc1=false] Whether the browser supports etc1 compressed images.
+ *
+ * @private
  */
 export default function SupportedImageFormats(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/Source/ThirdParty/GltfPipeline/parseGlb.js
+++ b/Source/ThirdParty/GltfPipeline/parseGlb.js
@@ -71,6 +71,7 @@ import RuntimeError from '../../Core/RuntimeError.js'
             var binaryGltfBuffer = defaultValue(buffers.binary_glTF, buffers.KHR_binary_glTF);
             if (defined(binaryGltfBuffer)) {
                 binaryGltfBuffer.extras._pipeline.source = binaryBuffer;
+                delete binaryGltfBuffer.uri;
             }
         }
         // Remove the KHR_binary_glTF extension

--- a/Source/WorkersES6/decodeDraco.js
+++ b/Source/WorkersES6/decodeDraco.js
@@ -332,7 +332,7 @@ function decodePrimitive(parameters) {
 }
 
 function decode(parameters) {
-  if (defined(parameters.primitive)) {
+  if (defined(parameters.bufferView)) {
     return decodePrimitive(parameters);
   }
   return decodePointCloud(parameters);

--- a/Specs/Cesium3DTilesTester.js
+++ b/Specs/Cesium3DTilesTester.js
@@ -491,14 +491,4 @@ Cesium3DTilesTester.generateGeometryTileBuffer = function (options) {
   return buffer;
 };
 
-Cesium3DTilesTester.generateJsonBuffer = function (jsonPayload) {
-  var jsonString = JSON.stringify(jsonPayload);
-  var buffer = new Uint8Array(jsonString.length);
-  for (var i = 0; i < jsonString.length; i++) {
-    buffer[i] = jsonString.charCodeAt(i);
-  }
-
-  return buffer.buffer;
-};
-
 export default Cesium3DTilesTester;

--- a/Specs/Core/ResourceSpec.js
+++ b/Specs/Core/ResourceSpec.js
@@ -8,6 +8,7 @@ import { Resource } from "../../Source/Cesium.js";
 import createCanvas from "../createCanvas.js";
 import { Uri } from "../../Source/Cesium.js";
 import { when } from "../../Source/Cesium.js";
+import dataUriToBuffer from "../dataUriToBuffer.js";
 
 describe("Core/Resource", function () {
   var dataUri =
@@ -1640,15 +1641,9 @@ describe("Core/Resource", function () {
         expect(headers).toEqual(expectedHeaders);
         expect(responseType).toEqual("blob");
 
-        var binary = atob(dataUri.split(",")[1]);
-        var array = [];
-        for (var i = 0; i < binary.length; i++) {
-          array.push(binary.charCodeAt(i));
-        }
+        var binary = dataUriToBuffer(dataUri);
 
-        deferred.resolve(
-          new Blob([new Uint8Array(array)], { type: "image/png" })
-        );
+        deferred.resolve(new Blob([binary], { type: "image/png" }));
       });
 
       var testResource = new Resource({

--- a/Specs/Scene/BufferLoaderSpec.js
+++ b/Specs/Scene/BufferLoaderSpec.js
@@ -1,14 +1,24 @@
-import { BufferLoader, Resource, when } from "../../Source/Cesium.js";
+import {
+  BufferLoader,
+  Resource,
+  ResourceCache,
+  when,
+} from "../../Source/Cesium.js";
 
 describe("Scene/BufferLoader", function () {
   var typedArray = new Uint8Array([1, 3, 7, 15, 31, 63, 127, 255]);
   var arrayBuffer = typedArray.buffer;
-  var resource = new Resource({ url: "https://example.com/buffer.bin" });
+  var resource = new Resource({ url: "https://example.com/external.bin" });
+
+  afterEach(function () {
+    ResourceCache.clearForSpecs();
+  });
 
   it("throws if neither options.typedArray nor options.resource are defined", function () {
     expect(function () {
       return new BufferLoader({
-        cacheKey: "cacheKey",
+        typedArray: undefined,
+        resource: undefined,
       });
     }).toThrowDeveloperError();
   });
@@ -40,7 +50,7 @@ describe("Scene/BufferLoader", function () {
       })
       .otherwise(function (runtimeError) {
         expect(runtimeError.message).toBe(
-          "Failed to load external buffer: https://example.com/buffer.bin\n404 Not Found"
+          "Failed to load external buffer: https://example.com/external.bin\n404 Not Found"
         );
       });
   });

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -35,6 +35,7 @@ import { ClippingPlaneCollection } from "../../Source/Cesium.js";
 import { CullFace } from "../../Source/Cesium.js";
 import Cesium3DTilesTester from "../Cesium3DTilesTester.js";
 import createScene from "../createScene.js";
+import generateJsonBuffer from "../generateJsonBuffer.js";
 import pollToPromise from "../pollToPromise.js";
 import { when } from "../../Source/Cesium.js";
 
@@ -190,6 +191,7 @@ describe(
 
     afterEach(function () {
       scene.primitives.removeAll();
+      ResourceCache.clearForSpecs();
     });
 
     function setZoom(distance) {
@@ -3863,7 +3865,7 @@ describe(
       var json = getJsonFromTypedArray(uint8Array);
       json.root.children.splice(0, 1);
 
-      return Cesium3DTilesTester.generateJsonBuffer(json);
+      return generateJsonBuffer(json).buffer;
     }
 
     it("tile with tileset content expires", function () {
@@ -5080,7 +5082,7 @@ describe(
             },
             geometricError: 100.0,
           };
-          var buffer = Cesium3DTilesTester.generateJsonBuffer(externalTileset);
+          var buffer = generateJsonBuffer(externalTileset).buffer;
           return when.resolve(buffer);
         });
 
@@ -5180,10 +5182,6 @@ describe(
         ],
         tileCount: 5,
       };
-
-      beforeEach(function () {
-        ResourceCache.clearForSpecs();
-      });
 
       it("loads tileset metadata", function () {
         return Cesium3DTilesTester.loadTileset(scene, tilesetMetadataUrl).then(

--- a/Specs/Scene/GltfBufferViewLoaderSpec.js
+++ b/Specs/Scene/GltfBufferViewLoaderSpec.js
@@ -1,0 +1,249 @@
+import {
+  BufferLoader,
+  GltfBufferViewLoader,
+  Resource,
+  ResourceCache,
+  when,
+} from "../../Source/Cesium.js";
+
+describe("Scene/GltfBufferViewLoader", function () {
+  var gltfEmbedded = {
+    buffers: [
+      {
+        byteLength: 8,
+      },
+    ],
+    bufferViews: [
+      {
+        buffer: 0,
+        byteOffset: 2,
+        byteLength: 3,
+      },
+    ],
+  };
+
+  var gltfExternal = {
+    buffers: [
+      {
+        uri: "external.bin",
+        byteLength: 8,
+      },
+    ],
+    bufferViews: [
+      {
+        buffer: 0,
+        byteOffset: 2,
+        byteLength: 3,
+      },
+    ],
+  };
+
+  var bufferTypedArray = new Uint8Array([1, 3, 7, 15, 31, 63, 127, 255]);
+  var bufferArrayBuffer = bufferTypedArray.buffer;
+
+  var gltfUri = "https://example.com/model.glb";
+  var gltfResource = new Resource({
+    url: gltfUri,
+  });
+  var bufferResource = new Resource({
+    url: "https://example.com/external.bin",
+  });
+
+  afterEach(function () {
+    ResourceCache.clearForSpecs();
+  });
+
+  it("throws if resourceCache is undefined", function () {
+    expect(function () {
+      return new GltfBufferViewLoader({
+        resourceCache: undefined,
+        gltf: gltfExternal,
+        bufferViewId: 0,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("throws if gltf is undefined", function () {
+    expect(function () {
+      return new GltfBufferViewLoader({
+        resourceCache: ResourceCache,
+        gltf: undefined,
+        bufferViewId: 0,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("throws if bufferViewId is undefined", function () {
+    expect(function () {
+      return new GltfBufferViewLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfExternal,
+        bufferViewId: undefined,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("throws if gltfResource is undefined", function () {
+    expect(function () {
+      return new GltfBufferViewLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfExternal,
+        bufferViewId: 0,
+        gltfResource: undefined,
+        baseResource: gltfResource,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("throws if baseResource is undefined", function () {
+    expect(function () {
+      return new GltfBufferViewLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfExternal,
+        bufferViewId: 0,
+        gltfResource: gltfResource,
+        baseResource: undefined,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("rejects promise if buffer fails to load", function () {
+    var error = new Error("404 Not Found");
+    spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+      when.reject(error)
+    );
+
+    var bufferViewLoader = new GltfBufferViewLoader({
+      resourceCache: ResourceCache,
+      gltf: gltfExternal,
+      bufferViewId: 0,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+
+    bufferViewLoader.load();
+
+    return bufferViewLoader.promise
+      .then(function (bufferViewLoader) {
+        fail();
+      })
+      .otherwise(function (runtimeError) {
+        expect(runtimeError.message).toBe(
+          "Failed to load buffer view\nFailed to load external buffer: https://example.com/external.bin\n404 Not Found"
+        );
+      });
+  });
+
+  it("loads buffer view for embedded buffer", function () {
+    ResourceCache.loadEmbeddedBuffer({
+      parentResource: gltfResource,
+      bufferId: 0,
+      typedArray: bufferTypedArray,
+    });
+
+    var bufferViewLoader = new GltfBufferViewLoader({
+      resourceCache: ResourceCache,
+      gltf: gltfEmbedded,
+      bufferViewId: 0,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+    bufferViewLoader.load();
+
+    return bufferViewLoader.promise.then(function (bufferViewLoader) {
+      expect(bufferViewLoader.typedArray).toEqual(new Uint8Array([7, 15, 31]));
+    });
+  });
+
+  it("loads buffer view for external buffer", function () {
+    spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+      when.resolve(bufferArrayBuffer)
+    );
+
+    var bufferViewLoader = new GltfBufferViewLoader({
+      resourceCache: ResourceCache,
+      gltf: gltfExternal,
+      bufferViewId: 0,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+    bufferViewLoader.load();
+
+    return bufferViewLoader.promise.then(function (bufferViewLoader) {
+      expect(bufferViewLoader.typedArray).toEqual(new Uint8Array([7, 15, 31]));
+    });
+  });
+
+  it("destroys buffer view", function () {
+    spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+      when.resolve(bufferArrayBuffer)
+    );
+
+    var unloadBuffer = spyOn(
+      BufferLoader.prototype,
+      "unload"
+    ).and.callThrough();
+
+    var bufferViewLoader = new GltfBufferViewLoader({
+      resourceCache: ResourceCache,
+      gltf: gltfExternal,
+      bufferViewId: 0,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+
+    expect(bufferViewLoader.typedArray).not.toBeDefined();
+
+    bufferViewLoader.load();
+
+    return bufferViewLoader.promise.then(function (bufferViewLoader) {
+      expect(bufferViewLoader.typedArray).toEqual(new Uint8Array([7, 15, 31]));
+      expect(bufferViewLoader.isDestroyed()).toBe(false);
+
+      bufferViewLoader.destroy();
+
+      expect(bufferViewLoader.typedArray).not.toBeDefined();
+      expect(bufferViewLoader.isDestroyed()).toBe(true);
+      expect(unloadBuffer).toHaveBeenCalled();
+    });
+  });
+
+  it("handles destroy before load finishes", function () {
+    var deferredPromise = when.defer();
+    spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+      deferredPromise.promise
+    );
+
+    // Load a copy of the buffer into the cache so that the buffer promise
+    // resolves even if the buffer view loader is destroyed
+    var bufferLoaderCopy = ResourceCache.loadExternalBuffer({
+      resource: bufferResource,
+    });
+
+    var bufferViewLoader = new GltfBufferViewLoader({
+      resourceCache: ResourceCache,
+      gltf: gltfExternal,
+      bufferViewId: 0,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+
+    expect(bufferViewLoader.typedArray).not.toBeDefined();
+
+    bufferViewLoader.load();
+    bufferViewLoader.destroy();
+
+    deferredPromise.resolve(bufferArrayBuffer);
+
+    expect(bufferViewLoader.typedArray).not.toBeDefined();
+    expect(bufferViewLoader.isDestroyed()).toBe(true);
+
+    ResourceCache.unload(bufferLoaderCopy);
+  });
+});

--- a/Specs/Scene/GltfDracoLoaderSpec.js
+++ b/Specs/Scene/GltfDracoLoaderSpec.js
@@ -1,0 +1,422 @@
+import {
+  ComponentDatatype,
+  DracoLoader,
+  GltfBufferViewLoader,
+  GltfDracoLoader,
+  Resource,
+  ResourceCache,
+  ResourceLoaderState,
+  when,
+} from "../../Source/Cesium.js";
+import createScene from "../createScene.js";
+import pollToPromise from "../pollToPromise.js";
+
+describe("Scene/GltfDracoLoader", function () {
+  var bufferTypedArray = new Uint8Array([1, 3, 7, 15, 31, 63, 127, 255]);
+  var bufferArrayBuffer = bufferTypedArray.buffer;
+
+  var decodedPositions = new Uint16Array([0, 0, 0, 65535, 65535, 65535, 0, 65535, 0]); // prettier-ignore
+  var decodedNormals = new Uint8Array([0, 255, 128, 128, 255, 0]);
+  var decodedIndices = new Uint16Array([0, 1, 2]);
+
+  var gltfUri = "https://example.com/model.glb";
+  var gltfResource = new Resource({
+    url: gltfUri,
+  });
+
+  var decodeDracoResults = {
+    indexArray: {
+      typedArray: decodedIndices,
+      numberOfIndices: decodedIndices.length,
+    },
+    attributeData: {
+      POSITION: {
+        array: decodedPositions,
+        data: {
+          byteOffset: 0,
+          byteStride: 6,
+          componentDatatype: ComponentDatatype.UNSIGNED_SHORT,
+          componentsPerAttribute: 3,
+          normalized: false,
+          quantization: {
+            octEncoded: false,
+            quantizationBits: 14,
+            minValues: [-1.0, -1.0, -1.0],
+            range: 2.0,
+          },
+        },
+      },
+      NORMAL: {
+        array: decodedNormals,
+        data: {
+          byteOffset: 0,
+          byteStride: 2,
+          componentDatatype: ComponentDatatype.UNSIGNED_BYTE,
+          componentsPerAttribute: 2,
+          normalized: false,
+          quantization: {
+            octEncoded: true,
+            quantizationBits: 10,
+          },
+        },
+      },
+    },
+  };
+
+  var gltfDraco = {
+    buffers: [
+      {
+        uri: "external.bin",
+        byteLength: 8,
+      },
+    ],
+    bufferViews: [
+      {
+        buffer: 0,
+        byteOffset: 4,
+        byteLength: 4,
+      },
+    ],
+    accessors: [
+      {
+        componentType: 5126,
+        count: 3,
+        max: [-1.0, -1.0, -1.0],
+        min: [1.0, 1.0, 1.0],
+        type: "VEC3",
+      },
+      {
+        componentType: 5126,
+        count: 3,
+        type: "VEC3",
+      },
+      {
+        componentType: 5123,
+        count: 3,
+        type: "SCALAR",
+      },
+    ],
+    meshes: [
+      {
+        primitives: [
+          {
+            attributes: {
+              POSITION: 0,
+              NORMAL: 1,
+            },
+            indices: 2,
+            extensions: {
+              KHR_draco_mesh_compression: {
+                bufferView: 0,
+                attributes: {
+                  POSITION: 0,
+                  NORMAL: 1,
+                },
+              },
+            },
+          },
+        ],
+      },
+    ],
+  };
+
+  var dracoExtension =
+    gltfDraco.meshes[0].primitives[0].extensions.KHR_draco_mesh_compression;
+
+  var scene;
+
+  beforeAll(function () {
+    scene = createScene();
+  });
+
+  afterAll(function () {
+    scene.destroyForSpecs();
+  });
+
+  afterEach(function () {
+    ResourceCache.clearForSpecs();
+  });
+
+  it("throws if resourceCache is undefined", function () {
+    expect(function () {
+      return new GltfDracoLoader({
+        resourceCache: undefined,
+        gltf: gltfDraco,
+        draco: dracoExtension,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("throws if gltf is undefined", function () {
+    expect(function () {
+      return new GltfDracoLoader({
+        resourceCache: ResourceCache,
+        gltf: undefined,
+        draco: dracoExtension,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("throws if draco is undefined", function () {
+    expect(function () {
+      return new GltfDracoLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfDraco,
+        draco: undefined,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("throws if gltfResource is undefined", function () {
+    expect(function () {
+      return new GltfDracoLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfDraco,
+        draco: dracoExtension,
+        gltfResource: undefined,
+        baseResource: gltfResource,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("throws if baseResource is undefined", function () {
+    expect(function () {
+      return new GltfDracoLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfDraco,
+        draco: dracoExtension,
+        gltfResource: gltfResource,
+        baseResource: undefined,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("rejects promise if buffer view fails to load", function () {
+    var error = new Error("404 Not Found");
+    spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+      when.reject(error)
+    );
+
+    var dracoLoader = new GltfDracoLoader({
+      resourceCache: ResourceCache,
+      gltf: gltfDraco,
+      draco: dracoExtension,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+
+    dracoLoader.load();
+
+    return dracoLoader.promise
+      .then(function (dracoLoader) {
+        fail();
+      })
+      .otherwise(function (runtimeError) {
+        expect(runtimeError.message).toBe(
+          "Failed to load Draco\nFailed to load buffer view\nFailed to load external buffer: https://example.com/external.bin\n404 Not Found"
+        );
+      });
+  });
+
+  it("rejects promise if draco decoding fails", function () {
+    spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+      when.resolve(bufferArrayBuffer)
+    );
+
+    var error = new Error("Draco decode failed");
+    spyOn(DracoLoader, "decodeBufferView").and.returnValue(when.reject(error));
+
+    var dracoLoader = new GltfDracoLoader({
+      resourceCache: ResourceCache,
+      gltf: gltfDraco,
+      draco: dracoExtension,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+
+    dracoLoader.load();
+
+    return pollToPromise(function () {
+      dracoLoader.process(scene.frameState);
+      return dracoLoader._state === ResourceLoaderState.FAILED;
+    }).then(function () {
+      return dracoLoader.promise
+        .then(function (dracoLoader) {
+          fail();
+        })
+        .otherwise(function (runtimeError) {
+          expect(runtimeError.message).toBe(
+            "Failed to load Draco\nDraco decode failed"
+          );
+        });
+    });
+  });
+
+  it("loads draco", function () {
+    spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+      when.resolve(bufferArrayBuffer)
+    );
+
+    // Simulate decodeBufferView not being ready for a few frames
+    // Then simulate the promise not resolving for another few frames
+    var deferredPromise = when.defer();
+    var decodeBufferViewCallsTotal = 3;
+    var decodeBufferViewCallsCount = 0;
+    var processCallsTotal = 6;
+    var processCallsCount = 0;
+    spyOn(DracoLoader, "decodeBufferView").and.callFake(function () {
+      if (decodeBufferViewCallsCount++ === decodeBufferViewCallsTotal) {
+        return deferredPromise.promise;
+      }
+      return undefined;
+    });
+
+    var dracoLoader = new GltfDracoLoader({
+      resourceCache: ResourceCache,
+      gltf: gltfDraco,
+      draco: dracoExtension,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+
+    dracoLoader.load();
+
+    return pollToPromise(function () {
+      dracoLoader.process(scene.frameState);
+      if (processCallsCount++ === processCallsTotal) {
+        deferredPromise.resolve(decodeDracoResults);
+      }
+      return dracoLoader._state === ResourceLoaderState.READY;
+    }).then(function () {
+      return dracoLoader.promise.then(function (dracoLoader) {
+        dracoLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
+        expect(dracoLoader.decodedData.indices).toBe(
+          decodeDracoResults.indexArray
+        );
+        expect(dracoLoader.decodedData.vertexAttributes).toBe(
+          decodeDracoResults.attributeData
+        );
+      });
+    });
+  });
+
+  it("destroys draco loader", function () {
+    spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+      when.resolve(bufferArrayBuffer)
+    );
+
+    spyOn(DracoLoader, "decodeBufferView").and.returnValue(
+      when.resolve(decodeDracoResults)
+    );
+
+    var unloadBufferView = spyOn(
+      GltfBufferViewLoader.prototype,
+      "unload"
+    ).and.callThrough();
+
+    var dracoLoader = new GltfDracoLoader({
+      resourceCache: ResourceCache,
+      gltf: gltfDraco,
+      draco: dracoExtension,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+
+    dracoLoader.load();
+
+    return pollToPromise(function () {
+      dracoLoader.process(scene.frameState);
+      return dracoLoader._state === ResourceLoaderState.READY;
+    }).then(function () {
+      return dracoLoader.promise.then(function (dracoLoader) {
+        expect(dracoLoader.decodedData).toBeDefined();
+        expect(dracoLoader.isDestroyed()).toBe(false);
+
+        dracoLoader.destroy();
+
+        expect(dracoLoader.decodedData).not.toBeDefined();
+        expect(dracoLoader.isDestroyed()).toBe(true);
+        expect(unloadBufferView).toHaveBeenCalled();
+      });
+    });
+  });
+
+  it("handles destroy before buffer view is finished loading", function () {
+    var deferredPromise = when.defer();
+    spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+      deferredPromise.promise
+    );
+
+    spyOn(DracoLoader, "decodeBufferView").and.returnValue(
+      when.resolve(decodeDracoResults)
+    );
+
+    // Load a copy of the buffer view into the cache so that the buffer view
+    // promise resolves even if the draco loader is destroyed
+    var bufferViewLoaderCopy = ResourceCache.loadBufferView({
+      gltf: gltfDraco,
+      bufferViewId: 0,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+
+    var dracoLoader = new GltfDracoLoader({
+      resourceCache: ResourceCache,
+      gltf: gltfDraco,
+      draco: dracoExtension,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+
+    expect(dracoLoader.decodedData).not.toBeDefined();
+
+    dracoLoader.load();
+    dracoLoader.destroy();
+
+    deferredPromise.resolve(bufferArrayBuffer);
+
+    expect(dracoLoader.decodedData).not.toBeDefined();
+    expect(dracoLoader.isDestroyed()).toBe(true);
+
+    ResourceCache.unload(bufferViewLoaderCopy);
+  });
+
+  it("handles destroy before draco data is finished decoding", function () {
+    spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+      when.resolve(bufferArrayBuffer)
+    );
+
+    var deferredPromise = when.defer();
+    var decodeBufferView = spyOn(DracoLoader, "decodeBufferView").and.callFake(
+      function () {
+        return deferredPromise.promise;
+      }
+    );
+
+    var dracoLoader = new GltfDracoLoader({
+      resourceCache: ResourceCache,
+      gltf: gltfDraco,
+      draco: dracoExtension,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+
+    expect(dracoLoader.decodedData).not.toBeDefined();
+
+    dracoLoader.load();
+    dracoLoader.process(scene.frameState);
+    expect(decodeBufferView).toHaveBeenCalled(); // Make sure the decode actually starts
+
+    dracoLoader.destroy();
+    deferredPromise.resolve(decodeDracoResults);
+
+    expect(dracoLoader.decodedData).not.toBeDefined();
+    expect(dracoLoader.isDestroyed()).toBe(true);
+  });
+});

--- a/Specs/Scene/GltfImageLoaderSpec.js
+++ b/Specs/Scene/GltfImageLoaderSpec.js
@@ -1,0 +1,435 @@
+import {
+  clone,
+  GltfBufferViewLoader,
+  GltfImageLoader,
+  FeatureDetection,
+  Resource,
+  ResourceCache,
+  SupportedImageFormats,
+  when,
+} from "../../Source/Cesium.js";
+import dataUriToBuffer from "../dataUriToBuffer.js";
+import pollToPromise from "../pollToPromise.js";
+
+describe("Scene/GltfImageLoader", function () {
+  var image = new Image();
+  image.src =
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII=";
+
+  var pngBuffer = dataUriToBuffer(
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII="
+  );
+  var jpgBuffer = dataUriToBuffer(
+    "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////wAALCAABAAEBAREA/8QAJgABAAAAAAAAAAAAAAAAAAAAAxABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQAAPwBH/9k"
+  );
+
+  var webpBuffer = dataUriToBuffer(
+    "data:image/webp;base64,UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA"
+  );
+
+  var gifBuffer = dataUriToBuffer(
+    "data:image/gif;base64,R0lGODdhBAAEAIAAAP///////ywAAAAABAAEAAACBISPCQUAOw=="
+  );
+
+  var gltfUri = "https://example.com/model.glb";
+  var gltfResource = new Resource({
+    url: gltfUri,
+  });
+
+  var gltf = {
+    buffers: [
+      {
+        uri: "external.bin",
+        byteLength: 0, // updated in getGltf
+      },
+    ],
+    bufferViews: [
+      {
+        buffer: 0,
+        byteOffset: 0,
+        byteLength: 0, // updated in getGltf
+      },
+    ],
+    images: [
+      {
+        mimeType: "image/png",
+        bufferView: 0,
+      },
+      {
+        uri: "image.png",
+      },
+    ],
+  };
+
+  function getGltf(imageBuffer) {
+    var clonedGltf = clone(gltf, true);
+    clonedGltf.buffers[0].byteLength = imageBuffer.byteLength;
+    clonedGltf.bufferViews[0].byteLength = imageBuffer.byteLength;
+    return clonedGltf;
+  }
+
+  afterEach(function () {
+    ResourceCache.clearForSpecs();
+  });
+
+  it("throws if resourceCache is undefined", function () {
+    expect(function () {
+      return new GltfImageLoader({
+        resourceCache: undefined,
+        gltf: gltf,
+        imageId: 0,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("throws if gltf is undefined", function () {
+    expect(function () {
+      return new GltfImageLoader({
+        resourceCache: ResourceCache,
+        gltf: undefined,
+        imageId: 0,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("throws if imageId is undefined", function () {
+    expect(function () {
+      return new GltfImageLoader({
+        resourceCache: ResourceCache,
+        gltf: gltf,
+        imageId: undefined,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("throws if gltfResource is undefined", function () {
+    expect(function () {
+      return new GltfImageLoader({
+        resourceCache: ResourceCache,
+        gltf: gltf,
+        imageId: 0,
+        gltfResource: undefined,
+        baseResource: gltfResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("throws if baseResource is undefined", function () {
+    expect(function () {
+      return new GltfImageLoader({
+        resourceCache: ResourceCache,
+        gltf: gltf,
+        imageId: 0,
+        gltfResource: gltfResource,
+        baseResource: undefined,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("throws if supportedImageFormats is undefined", function () {
+    expect(function () {
+      return new GltfImageLoader({
+        resourceCache: ResourceCache,
+        gltf: gltf,
+        imageId: 0,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        supportedImageFormats: undefined,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("rejects promise if buffer view fails to load", function () {
+    var error = new Error("404 Not Found");
+    spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+      when.reject(error)
+    );
+
+    var imageLoader = new GltfImageLoader({
+      resourceCache: ResourceCache,
+      gltf: getGltf(pngBuffer),
+      imageId: 0,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+      supportedImageFormats: new SupportedImageFormats(),
+    });
+
+    imageLoader.load();
+
+    return imageLoader.promise
+      .then(function (imageLoader) {
+        fail();
+      })
+      .otherwise(function (runtimeError) {
+        expect(runtimeError.message).toBe(
+          "Failed to load embedded image\nFailed to load buffer view\nFailed to load external buffer: https://example.com/external.bin\n404 Not Found"
+        );
+      });
+  });
+
+  it("rejects promise if image format is not recognized", function () {
+    spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+      when.resolve(gifBuffer)
+    );
+
+    var imageLoader = new GltfImageLoader({
+      resourceCache: ResourceCache,
+      gltf: getGltf(gifBuffer),
+      imageId: 0,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+      supportedImageFormats: new SupportedImageFormats(),
+    });
+
+    imageLoader.load();
+
+    return imageLoader.promise
+      .then(function (imageLoader) {
+        fail();
+      })
+      .otherwise(function (runtimeError) {
+        expect(runtimeError.message).toBe(
+          "Failed to load embedded image\nImage format is not recognized"
+        );
+      });
+  });
+
+  it("rejects promise if uri fails to load", function () {
+    var error = new Error("404 Not Found");
+    spyOn(Resource.prototype, "fetchImage").and.returnValue(when.reject(error));
+
+    var imageLoader = new GltfImageLoader({
+      resourceCache: ResourceCache,
+      gltf: getGltf(pngBuffer),
+      imageId: 1,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+      supportedImageFormats: new SupportedImageFormats(),
+    });
+
+    imageLoader.load();
+
+    return imageLoader.promise
+      .then(function (imageLoader) {
+        fail();
+      })
+      .otherwise(function (runtimeError) {
+        expect(runtimeError.message).toBe(
+          "Failed to load image:image.png\n404 Not Found"
+        );
+      });
+  });
+
+  function loadsFromBufferView(imageBuffer) {
+    spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+      when.resolve(imageBuffer)
+    );
+
+    var imageLoader = new GltfImageLoader({
+      resourceCache: ResourceCache,
+      gltf: getGltf(imageBuffer),
+      imageId: 0,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+      supportedImageFormats: new SupportedImageFormats(),
+    });
+
+    imageLoader.load();
+
+    return imageLoader.promise.then(function (imageLoader) {
+      expect(imageLoader.image.width).toBe(1);
+      expect(imageLoader.image.height).toBe(1);
+    });
+  }
+
+  it("loads PNG from buffer view", function () {
+    return loadsFromBufferView(pngBuffer);
+  });
+
+  it("loads JPEG from buffer view", function () {
+    return loadsFromBufferView(jpgBuffer);
+  });
+
+  it("loads WebP from buffer view", function () {
+    return pollToPromise(function () {
+      FeatureDetection.supportsWebP.initialize();
+      return FeatureDetection.supportsWebP.initialized;
+    }).then(function () {
+      if (!FeatureDetection.supportsWebP()) {
+        return;
+      }
+      return loadsFromBufferView(webpBuffer);
+    });
+  });
+
+  it("loads from uri", function () {
+    spyOn(Resource.prototype, "fetchImage").and.returnValue(
+      when.resolve(image)
+    );
+
+    var imageLoader = new GltfImageLoader({
+      resourceCache: ResourceCache,
+      gltf: getGltf(pngBuffer),
+      imageId: 1,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+      supportedImageFormats: new SupportedImageFormats(),
+    });
+
+    imageLoader.load();
+
+    return imageLoader.promise.then(function (imageLoader) {
+      expect(imageLoader.image.width).toBe(1);
+      expect(imageLoader.image.height).toBe(1);
+    });
+  });
+
+  it("destroys image loader", function () {
+    spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+      when.resolve(pngBuffer)
+    );
+
+    var unloadBufferView = spyOn(
+      GltfBufferViewLoader.prototype,
+      "unload"
+    ).and.callThrough();
+
+    var imageLoader = new GltfImageLoader({
+      resourceCache: ResourceCache,
+      gltf: getGltf(pngBuffer),
+      imageId: 0,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+      supportedImageFormats: new SupportedImageFormats(),
+    });
+    expect(imageLoader.image).not.toBeDefined();
+
+    imageLoader.load();
+
+    return imageLoader.promise.then(function (imageLoader) {
+      expect(imageLoader.image).toBeDefined();
+      expect(imageLoader.isDestroyed()).toBe(false);
+
+      imageLoader.destroy();
+
+      expect(imageLoader.image).not.toBeDefined();
+      expect(imageLoader.isDestroyed()).toBe(true);
+      expect(unloadBufferView).toHaveBeenCalled();
+    });
+  });
+
+  it("handles destroy before buffer view is finished loading", function () {
+    var deferredPromise = when.defer();
+    spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+      deferredPromise.promise
+    );
+
+    // Load a copy of the buffer view into the cache so that the buffer view
+    // promise resolves even if the image loader is destroyed
+    var bufferViewLoaderCopy = ResourceCache.loadBufferView({
+      gltf: getGltf(pngBuffer),
+      bufferViewId: 0,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+
+    var imageLoader = new GltfImageLoader({
+      resourceCache: ResourceCache,
+      gltf: getGltf(pngBuffer),
+      imageId: 0,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+      supportedImageFormats: new SupportedImageFormats(),
+    });
+
+    expect(imageLoader.image).not.toBeDefined();
+
+    imageLoader.load();
+    imageLoader.destroy();
+
+    deferredPromise.resolve(pngBuffer);
+
+    expect(imageLoader.image).not.toBeDefined();
+    expect(imageLoader.isDestroyed()).toBe(true);
+
+    ResourceCache.unload(bufferViewLoaderCopy);
+  });
+
+  it("handles destroy before image is finished loading from buffer", function () {
+    spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+      when.resolve(pngBuffer)
+    );
+
+    var deferredPromise = when.defer();
+    spyOn(GltfImageLoader, "_loadImageFromTypedArray").and.returnValue(
+      deferredPromise.promise
+    );
+
+    // Load a copy of the buffer view into the cache so that the buffer view
+    // promise resolves even if the image loader is destroyed
+    var bufferViewLoaderCopy = ResourceCache.loadBufferView({
+      gltf: getGltf(pngBuffer),
+      bufferViewId: 0,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+
+    var imageLoader = new GltfImageLoader({
+      resourceCache: ResourceCache,
+      gltf: getGltf(pngBuffer),
+      imageId: 0,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+      supportedImageFormats: new SupportedImageFormats(),
+    });
+
+    expect(imageLoader.image).not.toBeDefined();
+
+    imageLoader.load();
+    imageLoader.destroy();
+
+    deferredPromise.resolve(image);
+
+    expect(imageLoader.image).not.toBeDefined();
+    expect(imageLoader.isDestroyed()).toBe(true);
+
+    ResourceCache.unload(bufferViewLoaderCopy);
+  });
+
+  it("handles destroy before uri is finished loading", function () {
+    var deferredPromise = when.defer();
+    spyOn(Resource.prototype, "fetchImage").and.returnValue(
+      deferredPromise.promise
+    );
+
+    var imageLoader = new GltfImageLoader({
+      resourceCache: ResourceCache,
+      gltf: getGltf(pngBuffer),
+      imageId: 1,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+      supportedImageFormats: new SupportedImageFormats(),
+    });
+
+    expect(imageLoader.image).not.toBeDefined();
+
+    imageLoader.load();
+    imageLoader.destroy();
+
+    deferredPromise.resolve(image);
+
+    expect(imageLoader.image).not.toBeDefined();
+    expect(imageLoader.isDestroyed()).toBe(true);
+  });
+});

--- a/Specs/Scene/GltfIndexBufferLoaderSpec.js
+++ b/Specs/Scene/GltfIndexBufferLoaderSpec.js
@@ -1,0 +1,714 @@
+import {
+  Buffer,
+  ComponentDatatype,
+  DracoLoader,
+  GltfBufferViewLoader,
+  GltfDracoLoader,
+  GltfIndexBufferLoader,
+  JobScheduler,
+  Resource,
+  ResourceCache,
+  ResourceLoaderState,
+  when,
+} from "../../Source/Cesium.js";
+import concatTypedArrays from "../concatTypedArrays.js";
+import createScene from "../createScene.js";
+import pollToPromise from "../pollToPromise.js";
+
+describe(
+  "Scene/GltfIndexBufferLoader",
+  function () {
+    var dracoBufferTypedArray = new Uint8Array([1, 3, 7, 15, 31, 63, 127, 255]);
+    var dracoArrayBuffer = dracoBufferTypedArray.buffer;
+
+    var decodedPositions = new Uint16Array([0, 0, 0, 65535, 65535, 65535, 0, 65535, 0]); // prettier-ignore
+    var decodedNormals = new Uint8Array([0, 255, 128, 128, 255, 0]);
+    var decodedIndices = new Uint16Array([0, 1, 2]);
+
+    var positions = new Float32Array([-1.0, -1.0, -1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0]); // prettier-ignore
+    var normals = new Float32Array([-1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]); // prettier-ignore
+    var indicesUint32 = new Uint32Array([0, 1, 2]);
+    var indicesUint16 = new Uint16Array([0, 1, 2]);
+    var indicesUint8 = new Uint8Array([0, 1, 2]);
+
+    var bufferViewTypedArray = concatTypedArrays([
+      positions,
+      normals,
+      indicesUint32,
+      indicesUint16,
+      indicesUint8,
+    ]);
+    var arrayBuffer = bufferViewTypedArray.buffer;
+
+    var gltfUri = "https://example.com/model.glb";
+    var gltfResource = new Resource({
+      url: gltfUri,
+    });
+
+    var decodeDracoResults = {
+      indexArray: {
+        typedArray: decodedIndices,
+        numberOfIndices: decodedIndices.length,
+      },
+      attributeData: {
+        POSITION: {
+          array: decodedPositions,
+          data: {
+            byteOffset: 0,
+            byteStride: 6,
+            componentDatatype: ComponentDatatype.UNSIGNED_SHORT,
+            componentsPerAttribute: 3,
+            normalized: false,
+            quantization: {
+              octEncoded: false,
+              quantizationBits: 14,
+              minValues: [-1.0, -1.0, -1.0],
+              range: 2.0,
+            },
+          },
+        },
+        NORMAL: {
+          array: decodedNormals,
+          data: {
+            byteOffset: 0,
+            byteStride: 2,
+            componentDatatype: ComponentDatatype.UNSIGNED_BYTE,
+            componentsPerAttribute: 2,
+            normalized: false,
+            quantization: {
+              octEncoded: true,
+              quantizationBits: 10,
+            },
+          },
+        },
+      },
+    };
+
+    var gltfDraco = {
+      buffers: [
+        {
+          uri: "external.bin",
+          byteLength: 8,
+        },
+      ],
+      bufferViews: [
+        {
+          buffer: 0,
+          byteOffset: 4,
+          byteLength: 4,
+        },
+      ],
+      accessors: [
+        {
+          componentType: 5126,
+          count: 3,
+          max: [-1.0, -1.0, -1.0],
+          min: [1.0, 1.0, 1.0],
+          type: "VEC3",
+        },
+        {
+          componentType: 5126,
+          count: 3,
+          type: "VEC3",
+        },
+        {
+          componentType: 5123,
+          count: 3,
+          type: "SCALAR",
+        },
+      ],
+      meshes: [
+        {
+          primitives: [
+            {
+              attributes: {
+                POSITION: 0,
+                NORMAL: 1,
+              },
+              indices: 2,
+              extensions: {
+                KHR_draco_mesh_compression: {
+                  bufferView: 0,
+                  attributes: {
+                    POSITION: 0,
+                    NORMAL: 1,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    var dracoExtension =
+      gltfDraco.meshes[0].primitives[0].extensions.KHR_draco_mesh_compression;
+
+    var gltfUncompressed = {
+      buffers: [
+        {
+          uri: "external.bin",
+          byteLength: 78,
+        },
+      ],
+      bufferViews: [
+        {
+          buffer: 0,
+          byteOffset: 0,
+          byteLength: 36,
+        },
+        {
+          buffer: 0,
+          byteOffset: 36,
+          byteLength: 36,
+        },
+        {
+          buffer: 0,
+          byteOffset: 72,
+          byteLength: 12,
+        },
+        {
+          buffer: 0,
+          byteOffset: 84,
+          byteLength: 6,
+        },
+        {
+          buffer: 0,
+          byteOffset: 90,
+          byteLength: 3,
+        },
+      ],
+      accessors: [
+        {
+          componentType: 5126,
+          count: 3,
+          max: [-1.0, -1.0, -1.0],
+          min: [1.0, 1.0, 1.0],
+          type: "VEC3",
+          bufferView: 0,
+          byteOffset: 0,
+        },
+        {
+          componentType: 5126,
+          count: 3,
+          type: "VEC3",
+          bufferView: 1,
+          byteOffset: 0,
+        },
+        {
+          componentType: 5125, // UNSIGNED_INT
+          count: 3,
+          type: "SCALAR",
+          bufferView: 2,
+          byteOffset: 0,
+        },
+        {
+          componentType: 5123, // UNSIGNED_SHORT
+          count: 3,
+          type: "SCALAR",
+          bufferView: 3,
+          byteOffset: 0,
+        },
+        {
+          componentType: 5121, // UNSIGNED_BYTE
+          count: 3,
+          type: "SCALAR",
+          bufferView: 4,
+          byteOffset: 0,
+        },
+      ],
+      meshes: [
+        {
+          primitives: [
+            {
+              attributes: {
+                POSITION: 0,
+                NORMAL: 1,
+              },
+              indices: 2,
+            },
+            {
+              attributes: {
+                POSITION: 0,
+                NORMAL: 1,
+              },
+              indices: 3,
+            },
+            {
+              attributes: {
+                POSITION: 0,
+                NORMAL: 1,
+              },
+              indices: 4,
+            },
+          ],
+        },
+      ],
+    };
+
+    var scene;
+
+    beforeAll(function () {
+      scene = createScene();
+    });
+
+    afterAll(function () {
+      scene.destroyForSpecs();
+    });
+
+    afterEach(function () {
+      ResourceCache.clearForSpecs();
+    });
+
+    it("throws if resourceCache is undefined", function () {
+      expect(function () {
+        return new GltfIndexBufferLoader({
+          resourceCache: undefined,
+          gltf: gltfUncompressed,
+          accessorId: 3,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("throws if gltf is undefined", function () {
+      expect(function () {
+        return new GltfIndexBufferLoader({
+          resourceCache: ResourceCache,
+          gltf: undefined,
+          accessorId: 3,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("throws if accessorId is undefined", function () {
+      expect(function () {
+        return new GltfIndexBufferLoader({
+          resourceCache: ResourceCache,
+          gltf: gltfUncompressed,
+          accessorId: undefined,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("throws if gltfResource is undefined", function () {
+      expect(function () {
+        return new GltfIndexBufferLoader({
+          resourceCache: ResourceCache,
+          gltf: gltfUncompressed,
+          accessorId: 3,
+          gltfResource: undefined,
+          baseResource: gltfResource,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("throws if baseResource is undefined", function () {
+      expect(function () {
+        return new GltfIndexBufferLoader({
+          resourceCache: ResourceCache,
+          gltf: gltfUncompressed,
+          accessorId: 3,
+          gltfResource: gltfResource,
+          baseResource: undefined,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("rejects promise if buffer view fails to load", function () {
+      var error = new Error("404 Not Found");
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.reject(error)
+      );
+
+      var indexBufferLoader = new GltfIndexBufferLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfUncompressed,
+        accessorId: 3,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+      });
+
+      indexBufferLoader.load();
+
+      return indexBufferLoader.promise
+        .then(function (indexBufferLoader) {
+          fail();
+        })
+        .otherwise(function (runtimeError) {
+          expect(runtimeError.message).toBe(
+            "Failed to load index buffer\nFailed to load buffer view\nFailed to load external buffer: https://example.com/external.bin\n404 Not Found"
+          );
+        });
+    });
+
+    it("rejects promise if draco fails to load", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(dracoArrayBuffer)
+      );
+
+      var error = new Error("Draco decode failed");
+      spyOn(DracoLoader, "decodeBufferView").and.returnValue(
+        when.reject(error)
+      );
+
+      var indexBufferLoader = new GltfIndexBufferLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfDraco,
+        accessorId: 2,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        draco: dracoExtension,
+      });
+
+      indexBufferLoader.load();
+
+      return pollToPromise(function () {
+        indexBufferLoader.process(scene.frameState);
+        return indexBufferLoader._state === ResourceLoaderState.FAILED;
+      }).then(function () {
+        return indexBufferLoader.promise
+          .then(function (indexBufferLoader) {
+            fail();
+          })
+          .otherwise(function (runtimeError) {
+            expect(runtimeError.message).toBe(
+              "Failed to load index buffer\nFailed to load Draco\nDraco decode failed"
+            );
+          });
+      });
+    });
+
+    it("loads from accessor", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(arrayBuffer)
+      );
+
+      // Simulate JobScheduler not being ready for a few frames
+      var processCallsTotal = 3;
+      var processCallsCount = 0;
+      var jobScheduler = scene.frameState.jobScheduler;
+      var originalJobSchedulerExecute = jobScheduler.execute;
+      spyOn(JobScheduler.prototype, "execute").and.callFake(function (
+        job,
+        jobType
+      ) {
+        if (processCallsCount++ >= processCallsTotal) {
+          return originalJobSchedulerExecute.call(jobScheduler, job, jobType);
+        }
+        return false;
+      });
+
+      var indexBufferLoader = new GltfIndexBufferLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfUncompressed,
+        accessorId: 3,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+      });
+
+      indexBufferLoader.load();
+
+      return pollToPromise(function () {
+        indexBufferLoader.process(scene.frameState);
+        return indexBufferLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return indexBufferLoader.promise.then(function (indexBufferLoader) {
+          indexBufferLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
+          expect(indexBufferLoader.indexBuffer.sizeInBytes).toBe(
+            indicesUint16.byteLength
+          );
+        });
+      });
+    });
+
+    it("creates index buffer synchronously", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(arrayBuffer)
+      );
+
+      var indexBufferLoader = new GltfIndexBufferLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfUncompressed,
+        accessorId: 3,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        asynchronous: false,
+      });
+
+      indexBufferLoader.load();
+
+      return pollToPromise(function () {
+        indexBufferLoader.process(scene.frameState);
+        return indexBufferLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return indexBufferLoader.promise.then(function (indexBufferLoader) {
+          expect(indexBufferLoader.indexBuffer.sizeInBytes).toBe(
+            indicesUint16.byteLength
+          );
+        });
+      });
+    });
+
+    function loadIndices(accessorId, expectedByteLength) {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(arrayBuffer)
+      );
+
+      var indexBufferLoader = new GltfIndexBufferLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfUncompressed,
+        accessorId: accessorId,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+      });
+
+      indexBufferLoader.load();
+
+      return pollToPromise(function () {
+        indexBufferLoader.process(scene.frameState);
+        return indexBufferLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return indexBufferLoader.promise.then(function (indexBufferLoader) {
+          expect(indexBufferLoader.indexBuffer.sizeInBytes).toBe(
+            expectedByteLength
+          );
+        });
+      });
+    }
+
+    it("loads uint32 indices", function () {
+      if (!scene.frameState.context.elementIndexUint) {
+        return;
+      }
+
+      return loadIndices(2, indicesUint32.byteLength);
+    });
+
+    it("loads uint16 indices", function () {
+      return loadIndices(3, indicesUint16.byteLength);
+    });
+
+    it("loads uint8 indices", function () {
+      return loadIndices(4, indicesUint8.byteLength);
+    });
+
+    it("loads from draco", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(arrayBuffer)
+      );
+
+      // Simulate decodeBufferView not being ready for a few frames
+      var processCallsTotal = 3;
+      var processCallsCount = 0;
+      spyOn(DracoLoader, "decodeBufferView").and.callFake(function () {
+        if (processCallsCount++ === processCallsTotal) {
+          return when.resolve(decodeDracoResults);
+        }
+        return undefined;
+      });
+
+      var indexBufferLoader = new GltfIndexBufferLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfDraco,
+        accessorId: 2,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        draco: dracoExtension,
+      });
+
+      indexBufferLoader.load();
+
+      return pollToPromise(function () {
+        indexBufferLoader.process(scene.frameState);
+        return indexBufferLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return indexBufferLoader.promise.then(function (indexBufferLoader) {
+          indexBufferLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
+          expect(indexBufferLoader.indexBuffer.sizeInBytes).toBe(
+            decodedIndices.byteLength
+          );
+        });
+      });
+    });
+
+    it("destroys index buffer loaded from buffer view", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(arrayBuffer)
+      );
+
+      var unloadBufferView = spyOn(
+        GltfBufferViewLoader.prototype,
+        "unload"
+      ).and.callThrough();
+
+      var destroyIndexBuffer = spyOn(
+        Buffer.prototype,
+        "destroy"
+      ).and.callThrough();
+
+      var indexBufferLoader = new GltfIndexBufferLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfUncompressed,
+        accessorId: 3,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+      });
+
+      indexBufferLoader.load();
+
+      return pollToPromise(function () {
+        indexBufferLoader.process(scene.frameState);
+        return indexBufferLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return indexBufferLoader.promise.then(function (indexBufferLoader) {
+          expect(indexBufferLoader.indexBuffer).toBeDefined();
+          expect(indexBufferLoader.isDestroyed()).toBe(false);
+
+          indexBufferLoader.destroy();
+
+          expect(indexBufferLoader.indexBuffer).not.toBeDefined();
+          expect(indexBufferLoader.isDestroyed()).toBe(true);
+          expect(unloadBufferView).toHaveBeenCalled();
+          expect(destroyIndexBuffer).toHaveBeenCalled();
+        });
+      });
+    });
+
+    it("destroys index buffer loaded from draco", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(arrayBuffer)
+      );
+
+      spyOn(DracoLoader, "decodeBufferView").and.returnValue(
+        when.resolve(decodeDracoResults)
+      );
+
+      var unloadDraco = spyOn(
+        GltfDracoLoader.prototype,
+        "unload"
+      ).and.callThrough();
+
+      var destroyIndexBuffer = spyOn(
+        Buffer.prototype,
+        "destroy"
+      ).and.callThrough();
+
+      var indexBufferLoader = new GltfIndexBufferLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfDraco,
+        accessorId: 2,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        draco: dracoExtension,
+      });
+
+      indexBufferLoader.load();
+
+      return pollToPromise(function () {
+        indexBufferLoader.process(scene.frameState);
+        return indexBufferLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return indexBufferLoader.promise.then(function (indexBufferLoader) {
+          expect(indexBufferLoader.indexBuffer).toBeDefined();
+          expect(indexBufferLoader.isDestroyed()).toBe(false);
+
+          indexBufferLoader.destroy();
+
+          expect(indexBufferLoader.indexBuffer).not.toBeDefined();
+          expect(indexBufferLoader.isDestroyed()).toBe(true);
+          expect(unloadDraco).toHaveBeenCalled();
+          expect(destroyIndexBuffer).toHaveBeenCalled();
+        });
+      });
+    });
+
+    it("handles destroy before buffer view is finished loading", function () {
+      var deferredPromise = when.defer();
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        deferredPromise.promise
+      );
+
+      // Load a copy of the buffer view into the cache so that the buffer view
+      // promise resolves even if the index buffer loader is destroyed
+      var bufferViewLoaderCopy = ResourceCache.loadBufferView({
+        gltf: gltfUncompressed,
+        bufferViewId: 2,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+      });
+
+      var indexBufferLoader = new GltfIndexBufferLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfUncompressed,
+        accessorId: 3,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+      });
+
+      expect(indexBufferLoader.indexBuffer).not.toBeDefined();
+
+      indexBufferLoader.load();
+      indexBufferLoader.destroy();
+
+      deferredPromise.resolve(arrayBuffer);
+
+      expect(indexBufferLoader.indexBuffer).not.toBeDefined();
+      expect(indexBufferLoader.isDestroyed()).toBe(true);
+
+      ResourceCache.unload(bufferViewLoaderCopy);
+    });
+
+    it("handles destroy before draco data is finished loading", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(arrayBuffer)
+      );
+
+      var deferredPromise = when.defer();
+      var decodeBufferView = spyOn(
+        DracoLoader,
+        "decodeBufferView"
+      ).and.callFake(function () {
+        return deferredPromise.promise;
+      });
+
+      // Load a copy of the draco loader into the cache so that the draco loader
+      // promise resolves even if the index buffer loader is destroyed
+      var dracoLoaderCopy = ResourceCache.loadDraco({
+        gltf: gltfDraco,
+        draco: dracoExtension,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+      });
+
+      var indexBufferLoader = new GltfIndexBufferLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfDraco,
+        accessorId: 2,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        draco: dracoExtension,
+      });
+
+      expect(indexBufferLoader.indexBuffer).not.toBeDefined();
+
+      indexBufferLoader.load();
+      indexBufferLoader.process(scene.frameState);
+      expect(decodeBufferView).toHaveBeenCalled(); // Make sure the decode actually starts
+
+      indexBufferLoader.destroy();
+      deferredPromise.resolve(decodeDracoResults);
+
+      expect(indexBufferLoader.indexBuffer).not.toBeDefined();
+      expect(indexBufferLoader.isDestroyed()).toBe(true);
+
+      ResourceCache.unload(dracoLoaderCopy);
+    });
+  },
+  "WebGL"
+);

--- a/Specs/Scene/GltfJsonLoaderSpec.js
+++ b/Specs/Scene/GltfJsonLoaderSpec.js
@@ -1,0 +1,674 @@
+import {
+  BufferLoader,
+  clone,
+  GltfJsonLoader,
+  Resource,
+  ResourceCache,
+  when,
+} from "../../Source/Cesium.js";
+import generateJsonBuffer from "../generateJsonBuffer.js";
+
+describe("Scene/GltfJsonLoader", function () {
+  var gltfUri = "https://example.com/model.glb";
+  var gltfResource = new Resource({
+    url: gltfUri,
+  });
+
+  var gltf1 = {
+    asset: {
+      version: "1.0",
+    },
+    buffers: {
+      buffer: {
+        uri: "external.bin",
+      },
+    },
+    bufferViews: {
+      bufferView: {
+        buffer: "buffer",
+        byteOffset: 0,
+      },
+    },
+    accessors: {
+      accessor: {
+        bufferView: "bufferView",
+        byteOffset: 0,
+        componentType: 5126,
+        type: "VEC3",
+        count: 1,
+      },
+    },
+    meshes: {
+      mesh: {
+        primitives: [
+          {
+            attributes: {
+              POSITION: "accessor",
+            },
+          },
+        ],
+      },
+    },
+    nodes: {
+      node: {
+        meshes: ["mesh"],
+      },
+    },
+    scene: "scene",
+    scenes: {
+      scene: {
+        nodes: ["node"],
+      },
+    },
+  };
+
+  var gltf1Updated = {
+    asset: {
+      version: "2.0",
+    },
+    buffers: [
+      {
+        uri: "external.bin",
+        name: "buffer",
+        byteLength: 12,
+      },
+    ],
+    bufferViews: [
+      {
+        buffer: 0,
+        byteOffset: 0,
+        name: "bufferView",
+        byteLength: 12,
+        byteStride: 12,
+        target: 34962,
+      },
+    ],
+    accessors: [
+      {
+        bufferView: 0,
+        byteOffset: 0,
+        componentType: 5126,
+        type: "VEC3",
+        count: 1,
+        name: "accessor",
+        min: [0, 0, 0],
+        max: [0, 0, 0],
+        normalized: false,
+      },
+    ],
+    meshes: [
+      {
+        primitives: [
+          {
+            attributes: {
+              POSITION: 0,
+            },
+            mode: 4,
+            material: 0,
+          },
+        ],
+        name: "mesh",
+      },
+    ],
+    nodes: [
+      {
+        name: "node",
+        mesh: 0,
+        matrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+      },
+    ],
+    scene: 0,
+    scenes: [
+      {
+        nodes: [0],
+        name: "scene",
+      },
+    ],
+    materials: [
+      {
+        name: "default",
+        emissiveFactor: [0, 0, 0],
+        alphaMode: "OPAQUE",
+        doubleSided: false,
+      },
+    ],
+  };
+
+  var gltf2 = {
+    asset: {
+      version: "2.0",
+    },
+    buffers: [
+      {
+        uri: "external.bin",
+        byteLength: 12,
+      },
+    ],
+    bufferViews: [
+      {
+        buffer: 0,
+        byteOffset: 0,
+        byteLength: 12,
+      },
+    ],
+    accessors: [
+      {
+        bufferView: 0,
+        byteOffset: 0,
+        componentType: 5126,
+        type: "VEC3",
+        count: 1,
+        min: [0, 0, 0],
+        max: [0, 0, 0],
+      },
+    ],
+    meshes: [
+      {
+        primitives: [
+          {
+            attributes: {
+              POSITION: 0,
+            },
+          },
+        ],
+      },
+    ],
+    nodes: [
+      {
+        mesh: 0,
+        matrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+      },
+    ],
+    scene: 0,
+    scenes: [
+      {
+        nodes: [0],
+      },
+    ],
+  };
+
+  var gltf2Updated = {
+    asset: {
+      version: "2.0",
+    },
+    buffers: [
+      {
+        uri: "external.bin",
+        byteLength: 12,
+      },
+    ],
+    bufferViews: [
+      {
+        buffer: 0,
+        byteOffset: 0,
+        byteLength: 12,
+        byteStride: 12,
+        target: 34962,
+      },
+    ],
+    accessors: [
+      {
+        bufferView: 0,
+        byteOffset: 0,
+        componentType: 5126,
+        type: "VEC3",
+        count: 1,
+        min: [0, 0, 0],
+        max: [0, 0, 0],
+        normalized: false,
+      },
+    ],
+    meshes: [
+      {
+        primitives: [
+          {
+            attributes: {
+              POSITION: 0,
+            },
+            mode: 4,
+            material: 0,
+          },
+        ],
+      },
+    ],
+    nodes: [
+      {
+        mesh: 0,
+        matrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+      },
+    ],
+    scene: 0,
+    scenes: [
+      {
+        nodes: [0],
+      },
+    ],
+    materials: [
+      {
+        name: "default",
+        emissiveFactor: [0, 0, 0],
+        alphaMode: "OPAQUE",
+        doubleSided: false,
+      },
+    ],
+  };
+
+  function createGlb1(json) {
+    var jsonBuffer = generateJsonBuffer(json, 12, 4);
+    var positionBuffer = new Float32Array([0.0, 0.0, 0.0]);
+    var binaryBuffer = new Uint8Array(positionBuffer.buffer);
+    var glbLength = 20 + jsonBuffer.byteLength + binaryBuffer.byteLength;
+    var glb = new Uint8Array(glbLength);
+    var dataView = new DataView(glb.buffer, glb.byteOffset, glb.byteLength);
+
+    // Write binary glTF header (magic, version, length)
+    var byteOffset = 0;
+    dataView.setUint32(byteOffset, 0x46546c67, true);
+    byteOffset += 4;
+    dataView.setUint32(byteOffset, 1, true);
+    byteOffset += 4;
+    dataView.setUint32(byteOffset, glbLength, true);
+    byteOffset += 4;
+    dataView.setUint32(byteOffset, jsonBuffer.byteLength, true);
+    byteOffset += 4;
+    dataView.setUint32(byteOffset, 0, true);
+    byteOffset += 4;
+
+    // Write JSON Chunk
+    glb.set(jsonBuffer, byteOffset);
+    byteOffset += jsonBuffer.byteLength;
+
+    // Write Binary Chunk
+    glb.set(binaryBuffer, byteOffset);
+
+    return glb;
+  }
+
+  function createGlb2(json) {
+    var jsonBuffer = generateJsonBuffer(json, 12, 4);
+    var positionBuffer = new Float32Array([0.0, 0.0, 0.0]);
+    var binaryBuffer = new Uint8Array(positionBuffer.buffer);
+    var glbLength =
+      12 + 8 + jsonBuffer.byteLength + 8 + binaryBuffer.byteLength;
+    var glb = new Uint8Array(glbLength);
+    var dataView = new DataView(glb.buffer, glb.byteOffset, glb.byteLength);
+
+    // Write binary glTF header (magic, version, length)
+    var byteOffset = 0;
+    dataView.setUint32(byteOffset, 0x46546c67, true);
+    byteOffset += 4;
+    dataView.setUint32(byteOffset, 2, true);
+    byteOffset += 4;
+    dataView.setUint32(byteOffset, glbLength, true);
+    byteOffset += 4;
+
+    // Write JSON Chunk header (length, type)
+    dataView.setUint32(byteOffset, jsonBuffer.byteLength, true);
+    byteOffset += 4;
+    dataView.setUint32(byteOffset, 0x4e4f534a, true);
+    byteOffset += 4;
+
+    // Write JSON Chunk
+    glb.set(jsonBuffer, byteOffset);
+    byteOffset += jsonBuffer.byteLength;
+
+    // Write Binary Chunk header (length, type)
+    dataView.setUint32(byteOffset, binaryBuffer.byteLength);
+    byteOffset += 4;
+    dataView.setUint32(byteOffset, 0x004e4942, true);
+    byteOffset += 4;
+
+    // Write Binary Chunk
+    glb.set(binaryBuffer, byteOffset);
+
+    return glb;
+  }
+
+  afterEach(function () {
+    ResourceCache.clearForSpecs();
+  });
+
+  it("throws if resourceCache is undefined", function () {
+    expect(function () {
+      return new GltfJsonLoader({
+        resourceCache: undefined,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("throws if gltfResource is undefined", function () {
+    expect(function () {
+      return new GltfJsonLoader({
+        resourceCache: ResourceCache,
+        gltfResource: undefined,
+        baseResource: gltfResource,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("throws if baseResource is undefined", function () {
+    expect(function () {
+      return new GltfJsonLoader({
+        resourceCache: ResourceCache,
+        gltfResource: gltfResource,
+        baseResource: undefined,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("rejects promise if resource fails to load", function () {
+    var error = new Error("404 Not Found");
+    spyOn(GltfJsonLoader.prototype, "_fetchGltf").and.returnValue(
+      when.reject(error)
+    );
+
+    var gltfJsonLoader = new GltfJsonLoader({
+      resourceCache: ResourceCache,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+
+    gltfJsonLoader.load();
+
+    return gltfJsonLoader.promise
+      .then(function (gltfJsonLoader) {
+        fail();
+      })
+      .otherwise(function (runtimeError) {
+        expect(runtimeError.message).toBe(
+          "Failed to load glTF: https://example.com/model.glb\n404 Not Found"
+        );
+      });
+  });
+
+  it("rejects promise if glTF fails to process", function () {
+    var arrayBuffer = generateJsonBuffer(gltf1).buffer;
+
+    spyOn(GltfJsonLoader.prototype, "_fetchGltf").and.returnValue(
+      when.resolve(arrayBuffer)
+    );
+
+    var error = new Error("404 Not Found");
+    spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+      when.reject(error)
+    );
+
+    var gltfJsonLoader = new GltfJsonLoader({
+      resourceCache: ResourceCache,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+
+    gltfJsonLoader.load();
+
+    return gltfJsonLoader.promise
+      .then(function (gltfJsonLoader) {
+        fail();
+      })
+      .otherwise(function (runtimeError) {
+        expect(runtimeError.message).toBe(
+          "Failed to load glTF: https://example.com/model.glb\nFailed to load external buffer: https://example.com/external.bin\n404 Not Found"
+        );
+      });
+  });
+
+  it("loads glTF 1.0", function () {
+    var arrayBuffer = generateJsonBuffer(gltf1).buffer;
+
+    spyOn(GltfJsonLoader.prototype, "_fetchGltf").and.returnValue(
+      when.resolve(arrayBuffer)
+    );
+
+    spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+      when.resolve(new Float32Array([0.0, 0.0, 0.0]).buffer)
+    );
+
+    var gltfJsonLoader = new GltfJsonLoader({
+      resourceCache: ResourceCache,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+
+    gltfJsonLoader.load();
+
+    return gltfJsonLoader.promise.then(function (gltfJsonLoader) {
+      var gltf = gltfJsonLoader.gltf;
+      expect(gltf).toEqual(gltf1Updated);
+    });
+  });
+
+  it("loads glTF 1.0 binary", function () {
+    var gltf1Binary = clone(gltf1, true);
+    gltf1Binary.buffers = {
+      binary_glTF: {
+        type: "arraybuffer",
+        byteLength: 12,
+        uri: "data:,",
+      },
+    };
+    gltf1Binary.extensionsUsed = ["KHR_binary_glTF"];
+    gltf1Binary.bufferViews.bufferView.buffer = "binary_glTF";
+
+    var gltf1BinaryUpdated = clone(gltf1Updated, true);
+    gltf1BinaryUpdated.buffers[0].name = "binary_glTF";
+    delete gltf1BinaryUpdated.buffers[0].uri;
+
+    var arrayBuffer = createGlb1(gltf1Binary).buffer;
+
+    spyOn(GltfJsonLoader.prototype, "_fetchGltf").and.returnValue(
+      when.resolve(arrayBuffer)
+    );
+
+    var gltfJsonLoader = new GltfJsonLoader({
+      resourceCache: ResourceCache,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+
+    gltfJsonLoader.load();
+
+    return gltfJsonLoader.promise.then(function (gltfJsonLoader) {
+      var gltf = gltfJsonLoader.gltf;
+      expect(gltf).toEqual(gltf1BinaryUpdated);
+    });
+  });
+
+  it("loads glTF 1.0 with data uri", function () {
+    var gltf1DataUri = clone(gltf1, true);
+    gltf1DataUri.buffers.buffer = {
+      uri: "data:application/octet-stream;base64,AAAAAAAAAAAAAAAA",
+    };
+
+    var gltf1DataUriUpdated = clone(gltf1Updated, true);
+    delete gltf1DataUriUpdated.buffers[0].uri;
+
+    var arrayBuffer = generateJsonBuffer(gltf1DataUri).buffer;
+
+    spyOn(GltfJsonLoader.prototype, "_fetchGltf").and.returnValue(
+      when.resolve(arrayBuffer)
+    );
+
+    var gltfJsonLoader = new GltfJsonLoader({
+      resourceCache: ResourceCache,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+
+    gltfJsonLoader.load();
+
+    return gltfJsonLoader.promise.then(function (gltfJsonLoader) {
+      var gltf = gltfJsonLoader.gltf;
+      expect(gltf).toEqual(gltf1DataUriUpdated);
+    });
+  });
+
+  it("loads glTF 2.0", function () {
+    var arrayBuffer = generateJsonBuffer(gltf2).buffer;
+
+    spyOn(GltfJsonLoader.prototype, "_fetchGltf").and.returnValue(
+      when.resolve(arrayBuffer)
+    );
+
+    spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+      when.resolve(new Float32Array([0.0, 0.0, 0.0]).buffer)
+    );
+
+    var gltfJsonLoader = new GltfJsonLoader({
+      resourceCache: ResourceCache,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+
+    gltfJsonLoader.load();
+
+    return gltfJsonLoader.promise.then(function (gltfJsonLoader) {
+      var gltf = gltfJsonLoader.gltf;
+      expect(gltf).toEqual(gltf2Updated);
+    });
+  });
+
+  it("loads glTF 2.0 binary", function () {
+    var gltf2Binary = clone(gltf2, true);
+    delete gltf2Binary.buffers[0].uri;
+
+    var gltf2BinaryUpdated = clone(gltf2Updated, true);
+    delete gltf2BinaryUpdated.buffers[0].uri;
+
+    var arrayBuffer = createGlb2(gltf2Binary).buffer;
+
+    spyOn(GltfJsonLoader.prototype, "_fetchGltf").and.returnValue(
+      when.resolve(arrayBuffer)
+    );
+
+    var gltfJsonLoader = new GltfJsonLoader({
+      resourceCache: ResourceCache,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+
+    gltfJsonLoader.load();
+
+    return gltfJsonLoader.promise.then(function (gltfJsonLoader) {
+      var gltf = gltfJsonLoader.gltf;
+      expect(gltf).toEqual(gltf2BinaryUpdated);
+    });
+  });
+
+  it("loads glTF 2.0 with data uri", function () {
+    var gltf2DataUri = clone(gltf2, true);
+    gltf2DataUri.buffers[0].uri =
+      "data:application/octet-stream;base64,AAAAAAAAAAAAAAAA";
+
+    var gltf2DataUriUpdated = clone(gltf2Updated, true);
+    delete gltf2DataUriUpdated.buffers[0].uri;
+
+    var arrayBuffer = generateJsonBuffer(gltf2DataUri).buffer;
+
+    spyOn(GltfJsonLoader.prototype, "_fetchGltf").and.returnValue(
+      when.resolve(arrayBuffer)
+    );
+
+    var gltfJsonLoader = new GltfJsonLoader({
+      resourceCache: ResourceCache,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+
+    gltfJsonLoader.load();
+
+    return gltfJsonLoader.promise.then(function (gltfJsonLoader) {
+      var gltf = gltfJsonLoader.gltf;
+      expect(gltf).toEqual(gltf2DataUriUpdated);
+    });
+  });
+
+  it("destroys", function () {
+    var gltf2Binary = clone(gltf2, true);
+    delete gltf2Binary.buffers[0].uri;
+
+    var arrayBuffer = createGlb2(gltf2Binary).buffer;
+
+    spyOn(GltfJsonLoader.prototype, "_fetchGltf").and.returnValue(
+      when.resolve(arrayBuffer)
+    );
+
+    var unloadBuffer = spyOn(
+      BufferLoader.prototype,
+      "unload"
+    ).and.callThrough();
+
+    var gltfJsonLoader = new GltfJsonLoader({
+      resourceCache: ResourceCache,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+
+    gltfJsonLoader.load();
+
+    return gltfJsonLoader.promise.then(function (gltfJsonLoader) {
+      expect(gltfJsonLoader.gltf).toBeDefined();
+      expect(gltfJsonLoader.isDestroyed()).toBe(false);
+
+      gltfJsonLoader.destroy();
+
+      expect(gltfJsonLoader.gltf).not.toBeDefined();
+      expect(gltfJsonLoader.isDestroyed()).toBe(true);
+      expect(unloadBuffer).toHaveBeenCalled();
+    });
+  });
+
+  it("handles destroy before glTF is loaded", function () {
+    var deferredPromise = when.defer();
+    spyOn(GltfJsonLoader.prototype, "_fetchGltf").and.returnValue(
+      deferredPromise.promise
+    );
+
+    var arrayBuffer = generateJsonBuffer(gltf2).buffer;
+
+    var gltfJsonLoader = new GltfJsonLoader({
+      resourceCache: ResourceCache,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+
+    expect(gltfJsonLoader.gltf).not.toBeDefined();
+
+    gltfJsonLoader.load();
+    gltfJsonLoader.destroy();
+
+    deferredPromise.resolve(arrayBuffer);
+
+    expect(gltfJsonLoader.gltf).not.toBeDefined();
+    expect(gltfJsonLoader.isDestroyed()).toBe(true);
+  });
+
+  it("handles destroy before glTF is processed", function () {
+    spyOn(GltfJsonLoader.prototype, "_fetchGltf").and.returnValue(
+      when.resolve(generateJsonBuffer(gltf2).buffer)
+    );
+
+    var buffer = new Float32Array([0.0, 0.0, 0.0]).buffer;
+    var deferredPromise = when.defer();
+    spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+      deferredPromise.promise
+    );
+
+    var gltfJsonLoader = new GltfJsonLoader({
+      resourceCache: ResourceCache,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+    });
+
+    expect(gltfJsonLoader.gltf).not.toBeDefined();
+
+    gltfJsonLoader.load();
+    gltfJsonLoader.destroy();
+
+    deferredPromise.resolve(buffer);
+
+    expect(gltfJsonLoader.gltf).not.toBeDefined();
+    expect(gltfJsonLoader.isDestroyed()).toBe(true);
+  });
+});

--- a/Specs/Scene/GltfLoaderUtilSpec.js
+++ b/Specs/Scene/GltfLoaderUtilSpec.js
@@ -180,7 +180,7 @@ describe("Scene/GltfLoaderUtil", function () {
     expect(sampler.magnificationFilter).toBe(TextureMagnificationFilter.LINEAR);
   });
 
-  it("createSampler creates non mipmap sampler for KHR_texture_transform", function () {
+  it("createSampler creates non-mipmap sampler for KHR_texture_transform", function () {
     var sampler = createSampler({
       minFilter: TextureMinificationFilter.NEAREST_MIPMAP_NEAREST,
       useTextureTransform: true,

--- a/Specs/Scene/GltfLoaderUtilSpec.js
+++ b/Specs/Scene/GltfLoaderUtilSpec.js
@@ -1,0 +1,208 @@
+import {
+  GltfLoaderUtil,
+  SupportedImageFormats,
+  TextureWrap,
+  TextureMagnificationFilter,
+  TextureMinificationFilter,
+} from "../../Source/Cesium.js";
+
+describe("Scene/GltfLoaderUtil", function () {
+  var gltfWithTextures = {
+    images: [
+      {
+        uri: "image.png",
+      },
+      {
+        mimeType: "image/jpeg",
+        bufferView: 0,
+      },
+      {
+        uri: "image.webp",
+      },
+    ],
+    textures: [
+      {
+        source: 0,
+      },
+      {
+        source: 0,
+        extensions: {
+          EXT_texture_webp: {
+            source: 2,
+          },
+        },
+      },
+    ],
+  };
+
+  it("getImageIdFromTexture throws if gltf is undefined", function () {
+    expect(function () {
+      GltfLoaderUtil.getImageIdFromTexture({
+        gltf: undefined,
+        textureId: 0,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getImageIdFromTexture throws if textureId is undefined", function () {
+    expect(function () {
+      GltfLoaderUtil.getImageIdFromTexture({
+        gltf: gltfWithTextures,
+        textureId: undefined,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getImageIdFromTexture throws if supportedImageFormats is undefined", function () {
+    expect(function () {
+      GltfLoaderUtil.getImageIdFromTexture({
+        gltf: gltfWithTextures,
+        textureId: 0,
+        supportedImageFormats: undefined,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getImageIdFromTexture gets image id", function () {
+    var imageId = GltfLoaderUtil.getImageIdFromTexture({
+      gltf: gltfWithTextures,
+      textureId: 0,
+      supportedImageFormats: new SupportedImageFormats(),
+    });
+    expect(imageId).toBe(0);
+  });
+
+  it("getImageIdFromTexture gets WebP image when EXT_texture_webp extension is supported", function () {
+    var imageId = GltfLoaderUtil.getImageIdFromTexture({
+      gltf: gltfWithTextures,
+      textureId: 1,
+      supportedImageFormats: new SupportedImageFormats({
+        webp: true,
+      }),
+    });
+    expect(imageId).toBe(2);
+  });
+
+  it("getImageIdFromTexture gets default image when EXT_texture_webp extension is not supported", function () {
+    var imageId = GltfLoaderUtil.getImageIdFromTexture({
+      gltf: gltfWithTextures,
+      textureId: 1,
+      supportedImageFormats: new SupportedImageFormats({
+        webp: false,
+      }),
+    });
+    expect(imageId).toBe(0);
+  });
+
+  it("createSampler throws if gltf is undefined", function () {
+    expect(function () {
+      GltfLoaderUtil.getImageIdFromTexture({
+        gltf: undefined,
+        textureInfo: {
+          index: 0,
+        },
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("createSampler throws if gltf is undefined", function () {
+    expect(function () {
+      GltfLoaderUtil.getImageIdFromTexture({
+        gltf: gltfWithTextures,
+        textureInfo: undefined,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("createSampler gets default sampler when texture does not have a sampler", function () {
+    var sampler = GltfLoaderUtil.createSampler({
+      gltf: {
+        textures: [
+          {
+            source: 0,
+          },
+        ],
+      },
+      textureInfo: {
+        index: 0,
+      },
+    });
+    expect(sampler.wrapS).toBe(TextureWrap.REPEAT);
+    expect(sampler.wrapT).toBe(TextureWrap.REPEAT);
+    expect(sampler.minificationFilter).toBe(TextureMinificationFilter.LINEAR);
+    expect(sampler.magnificationFilter).toBe(TextureMagnificationFilter.LINEAR);
+  });
+
+  function createSampler(options) {
+    var gltf = {
+      textures: [
+        {
+          source: 0,
+          sampler: 0,
+        },
+      ],
+      samplers: [
+        {
+          minFilter: options.minFilter,
+          magFilter: options.magFilter,
+          wrapS: options.wrapS,
+          wrapT: options.wrapT,
+        },
+      ],
+    };
+
+    var textureInfo = {
+      index: 0,
+    };
+
+    if (options.useTextureTransform) {
+      textureInfo.extensions = {
+        KHR_texture_transform: {},
+      };
+    }
+
+    return GltfLoaderUtil.createSampler({
+      gltf: gltf,
+      textureInfo: textureInfo,
+    });
+  }
+
+  it("createSampler fills in undefined sampler properties", function () {
+    var sampler = createSampler({
+      wrapS: TextureWrap.CLAMP_TO_EDGE,
+    });
+
+    expect(sampler.wrapS).toBe(TextureWrap.CLAMP_TO_EDGE);
+    expect(sampler.wrapT).toBe(TextureWrap.REPEAT);
+    expect(sampler.minificationFilter).toBe(TextureMinificationFilter.LINEAR);
+    expect(sampler.magnificationFilter).toBe(TextureMagnificationFilter.LINEAR);
+  });
+
+  it("createSampler creates non mipmap sampler for KHR_texture_transform", function () {
+    var sampler = createSampler({
+      minFilter: TextureMinificationFilter.NEAREST_MIPMAP_NEAREST,
+      useTextureTransform: true,
+    });
+    expect(sampler.minificationFilter).toBe(TextureMinificationFilter.NEAREST);
+
+    sampler = createSampler({
+      minFilter: TextureMinificationFilter.NEAREST_MIPMAP_LINEAR,
+      useTextureTransform: true,
+    });
+    expect(sampler.minificationFilter).toBe(TextureMinificationFilter.NEAREST);
+
+    sampler = createSampler({
+      minFilter: TextureMinificationFilter.LINEAR_MIPMAP_NEAREST,
+      useTextureTransform: true,
+    });
+    expect(sampler.minificationFilter).toBe(TextureMinificationFilter.LINEAR);
+
+    sampler = createSampler({
+      minFilter: TextureMinificationFilter.LINEAR_MIPMAP_LINEAR,
+      useTextureTransform: true,
+    });
+    expect(sampler.minificationFilter).toBe(TextureMinificationFilter.LINEAR);
+  });
+});

--- a/Specs/Scene/GltfTextureLoaderSpec.js
+++ b/Specs/Scene/GltfTextureLoaderSpec.js
@@ -1,0 +1,445 @@
+import {
+  GltfImageLoader,
+  GltfTextureLoader,
+  JobScheduler,
+  Resource,
+  ResourceCache,
+  ResourceLoaderState,
+  SupportedImageFormats,
+  Texture,
+  when,
+} from "../../Source/Cesium.js";
+import createScene from "../createScene.js";
+import pollToPromise from "../pollToPromise.js";
+
+describe(
+  "Scene/GltfTextureLoader",
+  function () {
+    var image = new Image();
+    image.src =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII=";
+
+    var imageNpot = new Image();
+    imageNpot.src =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAACAQMAAACnuvRZAAAAA3NCSVQICAjb4U/gAAAABlBMVEUAAAD///+l2Z/dAAAAAnRSTlP/AOW3MEoAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAAcdEVYdFNvZnR3YXJlAEFkb2JlIEZpcmV3b3JrcyBDUzQGstOgAAAAFnRFWHRDcmVhdGlvbiBUaW1lADAxLzA0LzE0Kb6O2wAAAAxJREFUCJljeMDwAAADhAHBgGgjpQAAAABJRU5ErkJggg==";
+
+    var gltfUri = "https://example.com/model.glb";
+    var gltfResource = new Resource({
+      url: gltfUri,
+    });
+
+    var gltf = {
+      images: [
+        {
+          uri: "image.png",
+        },
+      ],
+      textures: [
+        {
+          source: 0,
+        },
+        {
+          source: 0,
+          sampler: 0,
+        },
+        {
+          source: 0,
+          sampler: 1,
+        },
+      ],
+      materials: [
+        {
+          emissiveTexture: {
+            index: 0,
+          },
+          occlusionTexture: {
+            index: 1,
+          },
+          normalTexture: {
+            index: 2,
+          },
+        },
+      ],
+      samplers: [
+        {
+          magFilter: 9728, // NEAREST
+          minFilter: 9984, // NEAREST_MIPMAP_NEAREST
+          wrapS: 10497, // REPEAT
+          wrapT: 10497, // REPEAT
+        },
+        {
+          magFilter: 9728, // NEAREST
+          minFilter: 9728, // NEAREST
+          wrapS: 33071, // CLAMP_TO_EDGE
+          wrapT: 33071, // CLAMP_TO_EDGE
+        },
+      ],
+    };
+
+    var scene;
+
+    beforeAll(function () {
+      scene = createScene();
+    });
+
+    afterAll(function () {
+      scene.destroyForSpecs();
+    });
+
+    afterEach(function () {
+      ResourceCache.clearForSpecs();
+    });
+
+    it("throws if resourceCache is undefined", function () {
+      expect(function () {
+        return new GltfTextureLoader({
+          resourceCache: undefined,
+          gltf: gltf,
+          imageId: 0,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          supportedImageFormats: new SupportedImageFormats(),
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("throws if gltf is undefined", function () {
+      expect(function () {
+        return new GltfTextureLoader({
+          resourceCache: ResourceCache,
+          gltf: undefined,
+          textureInfo: gltf.materials[0].emissiveTexture,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          supportedImageFormats: new SupportedImageFormats(),
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("throws if textureInfo is undefined", function () {
+      expect(function () {
+        return new GltfTextureLoader({
+          resourceCache: ResourceCache,
+          gltf: gltf,
+          textureInfo: undefined,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          supportedImageFormats: new SupportedImageFormats(),
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("throws if gltfResource is undefined", function () {
+      expect(function () {
+        return new GltfTextureLoader({
+          resourceCache: ResourceCache,
+          gltf: gltf,
+          textureInfo: gltf.materials[0].emissiveTexture,
+          gltfResource: undefined,
+          baseResource: gltfResource,
+          supportedImageFormats: new SupportedImageFormats(),
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("throws if baseResource is undefined", function () {
+      expect(function () {
+        return new GltfTextureLoader({
+          resourceCache: ResourceCache,
+          gltf: gltf,
+          textureInfo: gltf.materials[0].emissiveTexture,
+          gltfResource: gltfResource,
+          baseResource: undefined,
+          supportedImageFormats: new SupportedImageFormats(),
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("throws if supportedImageFormats is undefined", function () {
+      expect(function () {
+        return new GltfTextureLoader({
+          resourceCache: ResourceCache,
+          gltf: gltf,
+          textureInfo: gltf.materials[0].emissiveTexture,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          supportedImageFormats: undefined,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("rejects promise if image fails to load", function () {
+      var error = new Error("404 Not Found");
+      spyOn(Resource.prototype, "fetchImage").and.returnValue(
+        when.reject(error)
+      );
+
+      var textureLoader = new GltfTextureLoader({
+        resourceCache: ResourceCache,
+        gltf: gltf,
+        textureInfo: gltf.materials[0].emissiveTexture,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+
+      textureLoader.load();
+
+      return textureLoader.promise
+        .then(function (textureLoader) {
+          fail();
+        })
+        .otherwise(function (runtimeError) {
+          expect(runtimeError.message).toBe(
+            "Failed to load texture\nFailed to load image:image.png\n404 Not Found"
+          );
+        });
+    });
+
+    it("loads texture", function () {
+      spyOn(Resource.prototype, "fetchImage").and.returnValue(
+        when.resolve(image)
+      );
+
+      // Simulate JobScheduler not being ready for a few frames
+      var processCallsTotal = 3;
+      var processCallsCount = 0;
+      var jobScheduler = scene.frameState.jobScheduler;
+      var originalJobSchedulerExecute = jobScheduler.execute;
+      spyOn(JobScheduler.prototype, "execute").and.callFake(function (
+        job,
+        jobType
+      ) {
+        if (processCallsCount++ >= processCallsTotal) {
+          return originalJobSchedulerExecute.call(jobScheduler, job, jobType);
+        }
+        return false;
+      });
+
+      var textureLoader = new GltfTextureLoader({
+        resourceCache: ResourceCache,
+        gltf: gltf,
+        textureInfo: gltf.materials[0].emissiveTexture,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+
+      textureLoader.process(scene.frameState); // Check that calling process before load doesn't break anything
+
+      textureLoader.load();
+
+      return pollToPromise(function () {
+        textureLoader.process(scene.frameState);
+        return textureLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return textureLoader.promise.then(function (textureLoader) {
+          textureLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
+          expect(textureLoader.texture.width).toBe(1);
+          expect(textureLoader.texture.height).toBe(1);
+        });
+      });
+    });
+
+    it("creates texture synchronously", function () {
+      spyOn(Resource.prototype, "fetchImage").and.returnValue(
+        when.resolve(image)
+      );
+
+      var textureLoader = new GltfTextureLoader({
+        resourceCache: ResourceCache,
+        gltf: gltf,
+        textureInfo: gltf.materials[0].emissiveTexture,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        supportedImageFormats: new SupportedImageFormats(),
+        asynchronous: false,
+      });
+
+      textureLoader.load();
+
+      return pollToPromise(function () {
+        textureLoader.process(scene.frameState);
+        return textureLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return textureLoader.promise.then(function (textureLoader) {
+          textureLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
+          expect(textureLoader.texture.width).toBe(1);
+          expect(textureLoader.texture.height).toBe(1);
+        });
+      });
+    });
+
+    it("generates mipmap if sampler requires it", function () {
+      spyOn(Resource.prototype, "fetchImage").and.returnValue(
+        when.resolve(image)
+      );
+
+      var generateMipmap = spyOn(
+        Texture.prototype,
+        "generateMipmap"
+      ).and.callThrough();
+
+      var textureLoader = new GltfTextureLoader({
+        resourceCache: ResourceCache,
+        gltf: gltf,
+        textureInfo: gltf.materials[0].occlusionTexture, // This texture has a sampler that require a mipmap
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+
+      textureLoader.load();
+
+      return pollToPromise(function () {
+        textureLoader.process(scene.frameState);
+        return textureLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return textureLoader.promise.then(function (textureLoader) {
+          expect(textureLoader.texture.width).toBe(1);
+          expect(textureLoader.texture.height).toBe(1);
+          expect(generateMipmap).toHaveBeenCalled();
+        });
+      });
+    });
+
+    it("generates power-of-two texture if sampler requires it", function () {
+      spyOn(Resource.prototype, "fetchImage").and.returnValue(
+        when.resolve(imageNpot)
+      );
+
+      var textureLoader = new GltfTextureLoader({
+        resourceCache: ResourceCache,
+        gltf: gltf,
+        textureInfo: gltf.materials[0].occlusionTexture, // This texture has a sampler that require power-of-two texture
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+
+      textureLoader.load();
+
+      return pollToPromise(function () {
+        textureLoader.process(scene.frameState);
+        return textureLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return textureLoader.promise.then(function (textureLoader) {
+          expect(textureLoader.texture.width).toBe(4);
+          expect(textureLoader.texture.height).toBe(2);
+        });
+      });
+    });
+
+    it("does not generate power-of-two texture if sampler does not require it", function () {
+      spyOn(Resource.prototype, "fetchImage").and.returnValue(
+        when.resolve(imageNpot)
+      );
+
+      var textureLoader = new GltfTextureLoader({
+        resourceCache: ResourceCache,
+        gltf: gltf,
+        textureInfo: gltf.materials[0].normalTexture, // This texture has a sampler that does not require power-of-two texture
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+
+      textureLoader.load();
+
+      return pollToPromise(function () {
+        textureLoader.process(scene.frameState);
+        return textureLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return textureLoader.promise.then(function (textureLoader) {
+          expect(textureLoader.texture.width).toBe(3);
+          expect(textureLoader.texture.height).toBe(2);
+        });
+      });
+    });
+
+    it("destroys texture loader", function () {
+      spyOn(Resource.prototype, "fetchImage").and.returnValue(
+        when.resolve(image)
+      );
+
+      var unloadImage = spyOn(
+        GltfImageLoader.prototype,
+        "unload"
+      ).and.callThrough();
+
+      var destroyTexture = spyOn(
+        Texture.prototype,
+        "destroy"
+      ).and.callThrough();
+
+      var textureLoader = new GltfTextureLoader({
+        resourceCache: ResourceCache,
+        gltf: gltf,
+        textureInfo: gltf.materials[0].emissiveTexture,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+
+      expect(textureLoader.texture).not.toBeDefined();
+
+      textureLoader.load();
+
+      return pollToPromise(function () {
+        textureLoader.process(scene.frameState);
+        return textureLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return textureLoader.promise.then(function (textureLoader) {
+          expect(textureLoader.texture).toBeDefined();
+          expect(textureLoader.isDestroyed()).toBe(false);
+
+          textureLoader.destroy();
+
+          expect(textureLoader.texture).not.toBeDefined();
+          expect(textureLoader.isDestroyed()).toBe(true);
+          expect(unloadImage).toHaveBeenCalled();
+          expect(destroyTexture).toHaveBeenCalled();
+        });
+      });
+    });
+
+    it("handles destroy before image is finished loading", function () {
+      var deferredPromise = when.defer();
+      spyOn(Resource.prototype, "fetchImage").and.returnValue(
+        deferredPromise.promise
+      );
+
+      // Load a copy of the image into the cache so that the image
+      // promise resolves even if the texture loader is destroyed
+      var imageLoaderCopy = ResourceCache.loadImage({
+        gltf: gltf,
+        imageId: 0,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+
+      var textureLoader = new GltfTextureLoader({
+        resourceCache: ResourceCache,
+        gltf: gltf,
+        textureInfo: gltf.materials[0].emissiveTexture,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+
+      expect(textureLoader.texture).not.toBeDefined();
+
+      textureLoader.load();
+      textureLoader.destroy();
+
+      deferredPromise.resolve(image);
+
+      expect(textureLoader.texture).not.toBeDefined();
+      expect(textureLoader.isDestroyed()).toBe(true);
+
+      ResourceCache.unload(imageLoaderCopy);
+    });
+  },
+  "WebGL"
+);

--- a/Specs/Scene/GltfVertexBufferLoaderSpec.js
+++ b/Specs/Scene/GltfVertexBufferLoaderSpec.js
@@ -1,0 +1,650 @@
+import {
+  Buffer,
+  ComponentDatatype,
+  DracoLoader,
+  GltfBufferViewLoader,
+  GltfDracoLoader,
+  GltfVertexBufferLoader,
+  JobScheduler,
+  Resource,
+  ResourceCache,
+  ResourceLoaderState,
+  when,
+} from "../../Source/Cesium.js";
+import concatTypedArrays from "../concatTypedArrays.js";
+import createScene from "../createScene.js";
+import pollToPromise from "../pollToPromise.js";
+
+describe(
+  "Scene/GltfVertexBufferLoader",
+  function () {
+    var dracoBufferTypedArray = new Uint8Array([1, 3, 7, 15, 31, 63, 127, 255]);
+    var dracoArrayBuffer = dracoBufferTypedArray.buffer;
+
+    var decodedPositions = new Uint16Array([0, 0, 0, 65535, 65535, 65535, 0, 65535, 0]); // prettier-ignore
+    var decodedNormals = new Uint8Array([0, 255, 128, 128, 255, 0]);
+    var decodedIndices = new Uint16Array([0, 1, 2]);
+
+    var positions = new Float32Array([-1.0, -1.0, -1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0]); // prettier-ignore
+    var normals = new Float32Array([-1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]); // prettier-ignore
+    var indices = new Uint16Array([0, 1, 2]);
+
+    var bufferViewTypedArray = concatTypedArrays([positions, normals, indices]);
+    var arrayBuffer = bufferViewTypedArray.buffer;
+
+    var gltfUri = "https://example.com/model.glb";
+    var gltfResource = new Resource({
+      url: gltfUri,
+    });
+
+    var decodeDracoResults = {
+      indexArray: {
+        typedArray: decodedIndices,
+        numberOfIndices: decodedIndices.length,
+      },
+      attributeData: {
+        POSITION: {
+          array: decodedPositions,
+          data: {
+            byteOffset: 0,
+            byteStride: 6,
+            componentDatatype: ComponentDatatype.UNSIGNED_SHORT,
+            componentsPerAttribute: 3,
+            normalized: false,
+            quantization: {
+              octEncoded: false,
+              quantizationBits: 14,
+              minValues: [-1.0, -1.0, -1.0],
+              range: 2.0,
+            },
+          },
+        },
+        NORMAL: {
+          array: decodedNormals,
+          data: {
+            byteOffset: 0,
+            byteStride: 2,
+            componentDatatype: ComponentDatatype.UNSIGNED_BYTE,
+            componentsPerAttribute: 2,
+            normalized: false,
+            quantization: {
+              octEncoded: true,
+              quantizationBits: 10,
+            },
+          },
+        },
+      },
+    };
+
+    var gltfDraco = {
+      buffers: [
+        {
+          uri: "external.bin",
+          byteLength: 8,
+        },
+      ],
+      bufferViews: [
+        {
+          buffer: 0,
+          byteOffset: 4,
+          byteLength: 4,
+        },
+      ],
+      accessors: [
+        {
+          componentType: 5126,
+          count: 3,
+          max: [-1.0, -1.0, -1.0],
+          min: [1.0, 1.0, 1.0],
+          type: "VEC3",
+        },
+        {
+          componentType: 5126,
+          count: 3,
+          type: "VEC3",
+        },
+        {
+          componentType: 5123,
+          count: 3,
+          type: "SCALAR",
+        },
+      ],
+      meshes: [
+        {
+          primitives: [
+            {
+              attributes: {
+                POSITION: 0,
+                NORMAL: 1,
+              },
+              indices: 2,
+              extensions: {
+                KHR_draco_mesh_compression: {
+                  bufferView: 0,
+                  attributes: {
+                    POSITION: 0,
+                    NORMAL: 1,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    var dracoExtension =
+      gltfDraco.meshes[0].primitives[0].extensions.KHR_draco_mesh_compression;
+
+    var gltfUncompressed = {
+      buffers: [
+        {
+          uri: "external.bin",
+          byteLength: 78,
+        },
+      ],
+      bufferViews: [
+        {
+          buffer: 0,
+          byteOffset: 0,
+          byteLength: 36,
+        },
+        {
+          buffer: 0,
+          byteOffset: 36,
+          byteLength: 36,
+        },
+        {
+          buffer: 0,
+          byteOffset: 72,
+          byteLength: 6,
+        },
+      ],
+      accessors: [
+        {
+          componentType: 5126,
+          count: 3,
+          max: [-1.0, -1.0, -1.0],
+          min: [1.0, 1.0, 1.0],
+          type: "VEC3",
+          bufferView: 0,
+          byteOffset: 0,
+        },
+        {
+          componentType: 5126,
+          count: 3,
+          type: "VEC3",
+          bufferView: 1,
+          byteOffset: 0,
+        },
+        {
+          componentType: 5123,
+          count: 3,
+          type: "SCALAR",
+          bufferView: 2,
+          byteOffset: 0,
+        },
+      ],
+      meshes: [
+        {
+          primitives: [
+            {
+              attributes: {
+                POSITION: 0,
+                NORMAL: 1,
+              },
+              indices: 2,
+            },
+          ],
+        },
+      ],
+    };
+
+    var scene;
+
+    beforeAll(function () {
+      scene = createScene();
+    });
+
+    afterAll(function () {
+      scene.destroyForSpecs();
+    });
+
+    afterEach(function () {
+      ResourceCache.clearForSpecs();
+    });
+
+    it("throws if resourceCache is undefined", function () {
+      expect(function () {
+        return new GltfVertexBufferLoader({
+          resourceCache: undefined,
+          gltf: gltfUncompressed,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          bufferViewId: 0,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("throws if gltf is undefined", function () {
+      expect(function () {
+        return new GltfVertexBufferLoader({
+          resourceCache: ResourceCache,
+          gltf: undefined,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          bufferViewId: 0,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("throws if gltfResource is undefined", function () {
+      expect(function () {
+        return new GltfVertexBufferLoader({
+          resourceCache: ResourceCache,
+          gltf: gltfUncompressed,
+          gltfResource: undefined,
+          baseResource: gltfResource,
+          bufferViewId: 0,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("throws if baseResource is undefined", function () {
+      expect(function () {
+        return new GltfVertexBufferLoader({
+          resourceCache: ResourceCache,
+          gltf: gltfUncompressed,
+          gltfResource: gltfResource,
+          baseResource: undefined,
+          bufferViewId: 0,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("throws if bufferViewId and draco are both defined", function () {
+      expect(function () {
+        return new GltfVertexBufferLoader({
+          resourceCache: ResourceCache,
+          gltf: gltfDraco,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          bufferViewId: 0,
+          draco: dracoExtension,
+          dracoAttributeSemantic: "POSITION",
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("throws if bufferViewId and draco are both undefined", function () {
+      expect(function () {
+        return new GltfVertexBufferLoader({
+          resourceCache: ResourceCache,
+          gltf: gltfDraco,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("throws if draco is defined and dracoAttributeSemantic is not defined", function () {
+      expect(function () {
+        return new GltfVertexBufferLoader({
+          resourceCache: ResourceCache,
+          gltf: gltfDraco,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          draco: dracoExtension,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("rejects promise if buffer view fails to load", function () {
+      var error = new Error("404 Not Found");
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.reject(error)
+      );
+
+      var vertexBufferLoader = new GltfVertexBufferLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfUncompressed,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        bufferViewId: 0,
+      });
+
+      vertexBufferLoader.load();
+
+      return vertexBufferLoader.promise
+        .then(function (vertexBufferLoader) {
+          fail();
+        })
+        .otherwise(function (runtimeError) {
+          expect(runtimeError.message).toBe(
+            "Failed to load vertex buffer\nFailed to load buffer view\nFailed to load external buffer: https://example.com/external.bin\n404 Not Found"
+          );
+        });
+    });
+
+    it("rejects promise if draco fails to load", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(dracoArrayBuffer)
+      );
+
+      var error = new Error("Draco decode failed");
+      spyOn(DracoLoader, "decodeBufferView").and.returnValue(
+        when.reject(error)
+      );
+
+      var vertexBufferLoader = new GltfVertexBufferLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfDraco,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        draco: dracoExtension,
+        dracoAttributeSemantic: "POSITION",
+      });
+
+      vertexBufferLoader.load();
+
+      return pollToPromise(function () {
+        vertexBufferLoader.process(scene.frameState);
+        return vertexBufferLoader._state === ResourceLoaderState.FAILED;
+      }).then(function () {
+        return vertexBufferLoader.promise
+          .then(function (vertexBufferLoader) {
+            fail();
+          })
+          .otherwise(function (runtimeError) {
+            expect(runtimeError.message).toBe(
+              "Failed to load vertex buffer\nFailed to load Draco\nDraco decode failed"
+            );
+          });
+      });
+    });
+
+    it("loads from buffer view", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(arrayBuffer)
+      );
+
+      // Simulate JobScheduler not being ready for a few frames
+      var processCallsTotal = 3;
+      var processCallsCount = 0;
+      var jobScheduler = scene.frameState.jobScheduler;
+      var originalJobSchedulerExecute = jobScheduler.execute;
+      spyOn(JobScheduler.prototype, "execute").and.callFake(function (
+        job,
+        jobType
+      ) {
+        if (processCallsCount++ >= processCallsTotal) {
+          return originalJobSchedulerExecute.call(jobScheduler, job, jobType);
+        }
+        return false;
+      });
+
+      var vertexBufferLoader = new GltfVertexBufferLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfUncompressed,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        bufferViewId: 0,
+      });
+
+      vertexBufferLoader.load();
+
+      return pollToPromise(function () {
+        vertexBufferLoader.process(scene.frameState);
+        return vertexBufferLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return vertexBufferLoader.promise.then(function (vertexBufferLoader) {
+          vertexBufferLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
+          expect(vertexBufferLoader.vertexBuffer.sizeInBytes).toBe(
+            positions.byteLength
+          );
+        });
+      });
+    });
+
+    it("creates vertex buffer synchronously", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(arrayBuffer)
+      );
+
+      var vertexBufferLoader = new GltfVertexBufferLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfUncompressed,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        bufferViewId: 0,
+        asynchronous: false,
+      });
+
+      vertexBufferLoader.load();
+
+      return pollToPromise(function () {
+        vertexBufferLoader.process(scene.frameState);
+        return vertexBufferLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return vertexBufferLoader.promise.then(function (vertexBufferLoader) {
+          expect(vertexBufferLoader.vertexBuffer.sizeInBytes).toBe(
+            positions.byteLength
+          );
+        });
+      });
+    });
+
+    it("loads from draco", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(arrayBuffer)
+      );
+
+      // Simulate decodeBufferView not being ready for a few frames
+      var processCallsTotal = 3;
+      var processCallsCount = 0;
+      spyOn(DracoLoader, "decodeBufferView").and.callFake(function () {
+        if (processCallsCount++ === processCallsTotal) {
+          return when.resolve(decodeDracoResults);
+        }
+        return undefined;
+      });
+
+      var vertexBufferLoader = new GltfVertexBufferLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfDraco,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        draco: dracoExtension,
+        dracoAttributeSemantic: "POSITION",
+      });
+
+      vertexBufferLoader.load();
+
+      return pollToPromise(function () {
+        vertexBufferLoader.process(scene.frameState);
+        return vertexBufferLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return vertexBufferLoader.promise.then(function (vertexBufferLoader) {
+          vertexBufferLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
+          expect(vertexBufferLoader.vertexBuffer.sizeInBytes).toBe(
+            decodedPositions.byteLength
+          );
+        });
+      });
+    });
+
+    it("destroys vertex buffer loaded from buffer view", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(arrayBuffer)
+      );
+
+      var unloadBufferView = spyOn(
+        GltfBufferViewLoader.prototype,
+        "unload"
+      ).and.callThrough();
+
+      var destroyVertexBuffer = spyOn(
+        Buffer.prototype,
+        "destroy"
+      ).and.callThrough();
+
+      var vertexBufferLoader = new GltfVertexBufferLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfUncompressed,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        bufferViewId: 0,
+      });
+
+      vertexBufferLoader.load();
+
+      return pollToPromise(function () {
+        vertexBufferLoader.process(scene.frameState);
+        return vertexBufferLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return vertexBufferLoader.promise.then(function (vertexBufferLoader) {
+          expect(vertexBufferLoader.vertexBuffer).toBeDefined();
+          expect(vertexBufferLoader.isDestroyed()).toBe(false);
+
+          vertexBufferLoader.destroy();
+
+          expect(vertexBufferLoader.vertexBuffer).not.toBeDefined();
+          expect(vertexBufferLoader.isDestroyed()).toBe(true);
+          expect(unloadBufferView).toHaveBeenCalled();
+          expect(destroyVertexBuffer).toHaveBeenCalled();
+        });
+      });
+    });
+
+    it("destroys vertex buffer loaded from draco", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(arrayBuffer)
+      );
+
+      spyOn(DracoLoader, "decodeBufferView").and.returnValue(
+        when.resolve(decodeDracoResults)
+      );
+
+      var unloadDraco = spyOn(
+        GltfDracoLoader.prototype,
+        "unload"
+      ).and.callThrough();
+
+      var destroyVertexBuffer = spyOn(
+        Buffer.prototype,
+        "destroy"
+      ).and.callThrough();
+
+      var vertexBufferLoader = new GltfVertexBufferLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfDraco,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        draco: dracoExtension,
+        dracoAttributeSemantic: "POSITION",
+      });
+
+      vertexBufferLoader.load();
+
+      return pollToPromise(function () {
+        vertexBufferLoader.process(scene.frameState);
+        return vertexBufferLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return vertexBufferLoader.promise.then(function (vertexBufferLoader) {
+          expect(vertexBufferLoader.vertexBuffer).toBeDefined();
+          expect(vertexBufferLoader.isDestroyed()).toBe(false);
+
+          vertexBufferLoader.destroy();
+
+          expect(vertexBufferLoader.vertexBuffer).not.toBeDefined();
+          expect(vertexBufferLoader.isDestroyed()).toBe(true);
+          expect(unloadDraco).toHaveBeenCalled();
+          expect(destroyVertexBuffer).toHaveBeenCalled();
+        });
+      });
+    });
+
+    it("handles destroy before buffer view is finished loading", function () {
+      var deferredPromise = when.defer();
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        deferredPromise.promise
+      );
+
+      // Load a copy of the buffer view into the cache so that the buffer view
+      // promise resolves even if the vertex buffer loader is destroyed
+      var bufferViewLoaderCopy = ResourceCache.loadBufferView({
+        gltf: gltfUncompressed,
+        bufferViewId: 0,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+      });
+
+      var vertexBufferLoader = new GltfVertexBufferLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfUncompressed,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        bufferViewId: 0,
+      });
+
+      expect(vertexBufferLoader.vertexBuffer).not.toBeDefined();
+
+      vertexBufferLoader.load();
+      vertexBufferLoader.destroy();
+
+      deferredPromise.resolve(arrayBuffer);
+
+      expect(vertexBufferLoader.vertexBuffer).not.toBeDefined();
+      expect(vertexBufferLoader.isDestroyed()).toBe(true);
+
+      ResourceCache.unload(bufferViewLoaderCopy);
+    });
+
+    it("handles destroy before draco data is finished loading", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(arrayBuffer)
+      );
+
+      var deferredPromise = when.defer();
+      var decodeBufferView = spyOn(
+        DracoLoader,
+        "decodeBufferView"
+      ).and.callFake(function () {
+        return deferredPromise.promise;
+      });
+
+      // Load a copy of the draco loader into the cache so that the draco loader
+      // promise resolves even if the vertex buffer loader is destroyed
+      var dracoLoaderCopy = ResourceCache.loadDraco({
+        gltf: gltfDraco,
+        draco: dracoExtension,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+      });
+
+      var vertexBufferLoader = new GltfVertexBufferLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfDraco,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        draco: dracoExtension,
+        dracoAttributeSemantic: "POSITION",
+      });
+
+      expect(vertexBufferLoader.vertexBuffer).not.toBeDefined();
+
+      vertexBufferLoader.load();
+      vertexBufferLoader.process(scene.frameState);
+      expect(decodeBufferView).toHaveBeenCalled(); // Make sure the decode actually starts
+
+      vertexBufferLoader.destroy();
+      deferredPromise.resolve(decodeDracoResults);
+
+      expect(vertexBufferLoader.vertexBuffer).not.toBeDefined();
+      expect(vertexBufferLoader.isDestroyed()).toBe(true);
+
+      ResourceCache.unload(dracoLoaderCopy);
+    });
+  },
+  "WebGL"
+);

--- a/Specs/Scene/MetadataSchemaLoaderSpec.js
+++ b/Specs/Scene/MetadataSchemaLoaderSpec.js
@@ -1,5 +1,6 @@
 import {
   Resource,
+  ResourceCache,
   ResourceLoaderState,
   MetadataSchemaLoader,
   when,
@@ -38,10 +39,15 @@ describe("Scene/MetadataSchemaLoader", function () {
 
   var resource = new Resource({ url: "https://example.com/schema.json" });
 
+  afterEach(function () {
+    ResourceCache.clearForSpecs();
+  });
+
   it("throws if neither options.schema nor options.resource are defined", function () {
     expect(function () {
       return new MetadataSchemaLoader({
-        cacheKey: "cacheKey",
+        schema: undefined,
+        resource: undefined,
       });
     }).toThrowDeveloperError();
   });

--- a/Specs/Scene/Multiple3DTileContentSpec.js
+++ b/Specs/Scene/Multiple3DTileContentSpec.js
@@ -12,6 +12,7 @@ import {
 } from "../../Source/Cesium.js";
 import Cesium3DTilesTester from "../Cesium3DTilesTester.js";
 import createScene from "../createScene.js";
+import generateJsonBuffer from "../generateJsonBuffer.js";
 
 describe(
   "Scene/Multiple3DTileContent",
@@ -46,7 +47,7 @@ describe(
           version: "1.0",
         },
       };
-      return Cesium3DTilesTester.generateJsonBuffer(gltf);
+      return generateJsonBuffer(gltf).buffer;
     }
 
     var originalRequestsPerServer;

--- a/Specs/Scene/ResourceCacheKeySpec.js
+++ b/Specs/Scene/ResourceCacheKeySpec.js
@@ -1,17 +1,230 @@
-import { Resource, ResourceCacheKey } from "../../Source/Cesium.js";
+import {
+  Resource,
+  ResourceCacheKey,
+  SupportedImageFormats,
+} from "../../Source/Cesium.js";
 
 describe("ResourceCacheKey", function () {
   var schemaUri = "https://example.com/schema.json";
   var schemaResource = new Resource({ url: schemaUri });
 
-  var parentUri = "https://example.com/parent.gltf";
-  var parentResource = new Resource({ url: parentUri });
+  var gltfUri = "https://example.com/parent.gltf";
+  var gltfResource = new Resource({ url: gltfUri });
+
+  var baseUri = "https://example.com/resources/";
+  var baseResource = new Resource({ url: baseUri });
 
   var schemaJson = {};
 
   var bufferUri = "https://example.com/external.bin";
   var bufferResource = new Resource({ url: bufferUri });
   var bufferId = 0;
+
+  var gltfEmbeddedBuffer = {
+    buffers: [
+      {
+        byteLength: 100,
+      },
+    ],
+    bufferViews: [
+      {
+        buffer: 0,
+        byteOffset: 0,
+        byteLength: 100,
+      },
+    ],
+  };
+
+  var gltfExternalBuffer = {
+    buffers: [
+      {
+        uri: "external.bin",
+        byteLength: 100,
+      },
+    ],
+    bufferViews: [
+      {
+        buffer: 0,
+        byteOffset: 0,
+        byteLength: 100,
+      },
+    ],
+  };
+
+  var gltfUncompressed = {
+    buffers: [
+      {
+        uri: "external.bin",
+        byteLength: 100,
+      },
+    ],
+    bufferViews: [
+      {
+        buffer: 0,
+        byteOffset: 0,
+        byteLength: 40,
+      },
+      {
+        buffer: 0,
+        byteOffset: 40,
+        byteLength: 40,
+      },
+      {
+        buffer: 0,
+        byteOffset: 80,
+        byteLength: 20,
+      },
+    ],
+    accessors: [
+      {
+        componentType: 5126,
+        count: 24,
+        max: [0.5, 0.5, 0.5],
+        min: [-0.5, -0.5, -0.5],
+        type: "VEC3",
+        bufferView: 0,
+        byteOffset: 0,
+      },
+      {
+        componentType: 5126,
+        count: 24,
+        type: "VEC3",
+        bufferView: 1,
+        byteOffset: 0,
+      },
+      {
+        componentType: 5123,
+        count: 36,
+        type: "SCALAR",
+        bufferView: 2,
+        byteOffset: 0,
+      },
+    ],
+    meshes: [
+      {
+        primitives: [
+          {
+            attributes: {
+              POSITION: 0,
+              NORMAL: 1,
+            },
+            indices: 2,
+          },
+        ],
+      },
+    ],
+  };
+
+  var gltfDraco = {
+    buffers: [
+      {
+        uri: "external.bin",
+        byteLength: 100,
+      },
+    ],
+    bufferViews: [
+      {
+        buffer: 0,
+        byteOffset: 0,
+        byteLength: 100,
+      },
+    ],
+    accessors: [
+      {
+        componentType: 5126,
+        count: 24,
+        max: [0.5, 0.5, 0.5],
+        min: [-0.5, -0.5, -0.5],
+        type: "VEC3",
+      },
+      {
+        componentType: 5126,
+        count: 24,
+        type: "VEC3",
+      },
+      {
+        componentType: 5123,
+        count: 36,
+        type: "SCALAR",
+      },
+    ],
+    meshes: [
+      {
+        primitives: [
+          {
+            attributes: {
+              POSITION: 0,
+              NORMAL: 1,
+            },
+            indices: 2,
+            extensions: {
+              KHR_draco_mesh_compression: {
+                bufferView: 0,
+                attributes: {
+                  POSITION: 0,
+                  NORMAL: 1,
+                },
+              },
+            },
+          },
+        ],
+      },
+    ],
+  };
+
+  var gltfWithTextures = {
+    buffers: [
+      {
+        uri: "external.bin",
+        byteLength: 100,
+      },
+    ],
+    bufferViews: [
+      {
+        buffer: 0,
+        byteOffset: 0,
+        byteLength: 100,
+      },
+    ],
+    images: [
+      {
+        uri: "image.png",
+      },
+      {
+        mimeType: "image/jpeg",
+        bufferView: 0,
+      },
+      {
+        uri: "image.webp",
+      },
+    ],
+    textures: [
+      {
+        // Intentionally omitting sampler from this texture
+        source: 0,
+      },
+      {
+        sampler: 0,
+        source: 1,
+      },
+      {
+        source: 0,
+        extensions: {
+          EXT_texture_webp: {
+            source: 2,
+          },
+        },
+      },
+    ],
+    samplers: [
+      {
+        magFilter: 9728,
+        minFilter: 9984,
+        wrapS: 33071,
+        wrapT: 33648,
+      },
+    ],
+  };
 
   it("getSchemaCacheKey works for external schemas", function () {
     var cacheKey = ResourceCacheKey.getSchemaCacheKey({
@@ -26,7 +239,7 @@ describe("ResourceCacheKey", function () {
       schema: schemaJson,
     });
 
-    expect(cacheKey).toEqual("embedded-schema:" + JSON.stringify(schemaJson));
+    expect(cacheKey).toBe("embedded-schema:" + JSON.stringify(schemaJson));
   });
 
   it("getSchemaCacheKey throws if neither options.schema nor options.resource are defined", function () {
@@ -49,7 +262,7 @@ describe("ResourceCacheKey", function () {
       resource: bufferResource,
     });
 
-    expect(cacheKey).toEqual("external-buffer:" + bufferUri);
+    expect(cacheKey).toBe("external-buffer:" + bufferUri);
   });
 
   it("getExternalBufferCacheKey throws if resource is undefined", function () {
@@ -60,11 +273,11 @@ describe("ResourceCacheKey", function () {
 
   it("getEmbeddedBufferCacheKey works", function () {
     var cacheKey = ResourceCacheKey.getEmbeddedBufferCacheKey({
-      parentResource: parentResource,
+      parentResource: gltfResource,
       bufferId: bufferId,
     });
 
-    expect(cacheKey).toEqual("embedded-buffer:" + parentUri + "-buffer-0");
+    expect(cacheKey).toBe("embedded-buffer:" + gltfUri + "-buffer-id-0");
   });
 
   it("getEmbeddedBufferCacheKey throws if parentResource is undefined", function () {
@@ -78,7 +291,555 @@ describe("ResourceCacheKey", function () {
   it("getEmbeddedBufferCacheKey throws if bufferId is undefined", function () {
     expect(function () {
       ResourceCacheKey.getExternalBufferCacheKey({
-        parentResource: parentResource,
+        parentResource: gltfResource,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getGltfCacheKey works", function () {
+    var cacheKey = ResourceCacheKey.getGltfCacheKey({
+      gltfResource: gltfResource,
+    });
+
+    expect(cacheKey).toBe("gltf:" + gltfUri);
+  });
+
+  it("getGltfCacheKey throws if gltfResource is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getGltfCacheKey({});
+    }).toThrowDeveloperError();
+  });
+
+  it("getBufferViewCacheKey works with embedded buffer", function () {
+    var cacheKey = ResourceCacheKey.getBufferViewCacheKey({
+      gltf: gltfEmbeddedBuffer,
+      bufferViewId: 0,
+      gltfResource: gltfResource,
+      baseResource: baseResource,
+    });
+
+    expect(cacheKey).toBe(
+      "buffer-view:" + gltfUri + "-buffer-id-0-range-0-100"
+    );
+  });
+
+  it("getBufferViewCacheKey works with external buffer", function () {
+    var cacheKey = ResourceCacheKey.getBufferViewCacheKey({
+      gltf: gltfExternalBuffer,
+      bufferViewId: 0,
+      gltfResource: gltfResource,
+      baseResource: baseResource,
+    });
+
+    expect(cacheKey).toBe(
+      "buffer-view:https://example.com/resources/external.bin-range-0-100"
+    );
+  });
+
+  it("getBufferViewCacheKey throws if gltf is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getBufferViewCacheKey({
+        gltf: undefined,
+        bufferViewId: 0,
+        gltfResource: gltfResource,
+        baseResource: baseResource,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getBufferViewCacheKey throws if bufferViewId is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getBufferViewCacheKey({
+        gltf: gltfEmbeddedBuffer,
+        bufferViewId: undefined,
+        gltfResource: gltfResource,
+        baseResource: baseResource,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getBufferViewCacheKey throws if gltfResource is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getBufferViewCacheKey({
+        gltf: gltfEmbeddedBuffer,
+        bufferViewId: 0,
+        gltfResource: undefined,
+        baseResource: baseResource,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getBufferViewCacheKey throws if baseResource is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getBufferViewCacheKey({
+        gltf: gltfEmbeddedBuffer,
+        bufferViewId: 0,
+        gltfResource: gltfResource,
+        baseResource: undefined,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getDracoCacheKey works", function () {
+    var draco =
+      gltfDraco.meshes[0].primitives[0].extensions.KHR_draco_mesh_compression;
+
+    var cacheKey = ResourceCacheKey.getDracoCacheKey({
+      gltf: gltfDraco,
+      draco: draco,
+      gltfResource: gltfResource,
+      baseResource: baseResource,
+    });
+
+    expect(cacheKey).toBe(
+      "draco:https://example.com/resources/external.bin-range-0-100"
+    );
+  });
+
+  it("getDracoCacheKey throws if gltf is undefined", function () {
+    var draco =
+      gltfDraco.meshes[0].primitives[0].extensions.KHR_draco_mesh_compression;
+
+    expect(function () {
+      ResourceCacheKey.getBufferViewCacheKey({
+        gltf: undefined,
+        draco: draco,
+        gltfResource: gltfResource,
+        baseResource: baseResource,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getDracoCacheKey throws if draco is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getBufferViewCacheKey({
+        gltf: gltfDraco,
+        draco: undefined,
+        gltfResource: gltfResource,
+        baseResource: baseResource,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getDracoCacheKey throws if gltfResource is undefined", function () {
+    var draco =
+      gltfDraco.meshes[0].primitives[0].extensions.KHR_draco_mesh_compression;
+
+    expect(function () {
+      ResourceCacheKey.getBufferViewCacheKey({
+        gltf: gltfDraco,
+        draco: draco,
+        gltfResource: undefined,
+        baseResource: baseResource,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getDracoCacheKey throws if baseResource is undefined", function () {
+    var draco =
+      gltfDraco.meshes[0].primitives[0].extensions.KHR_draco_mesh_compression;
+
+    expect(function () {
+      ResourceCacheKey.getBufferViewCacheKey({
+        gltf: gltfDraco,
+        draco: draco,
+        gltfResource: gltfResource,
+        baseResource: undefined,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getVertexBufferCacheKey works from buffer view", function () {
+    var cacheKey = ResourceCacheKey.getVertexBufferCacheKey({
+      gltf: gltfUncompressed,
+      gltfResource: gltfResource,
+      baseResource: baseResource,
+      bufferViewId: 0,
+    });
+
+    expect(cacheKey).toBe(
+      "vertex-buffer:https://example.com/resources/external.bin-range-0-40"
+    );
+  });
+
+  it("getVertexBufferCacheKey works from draco", function () {
+    var draco =
+      gltfDraco.meshes[0].primitives[0].extensions.KHR_draco_mesh_compression;
+
+    var cacheKey = ResourceCacheKey.getVertexBufferCacheKey({
+      gltf: gltfDraco,
+      gltfResource: gltfResource,
+      baseResource: baseResource,
+      draco: draco,
+      dracoAttributeSemantic: "POSITION",
+    });
+
+    expect(cacheKey).toBe(
+      "vertex-buffer:https://example.com/resources/external.bin-range-0-100-draco-POSITION"
+    );
+  });
+
+  it("getVertexBufferCacheKey throws if gltf is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getVertexBufferCacheKey({
+        gltf: undefined,
+        gltfResource: gltfResource,
+        baseResource: baseResource,
+        bufferViewId: 0,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getVertexBufferCacheKey throws if gltfResource is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getVertexBufferCacheKey({
+        gltf: gltfUncompressed,
+        gltfResource: undefined,
+        baseResource: baseResource,
+        bufferViewId: 0,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getVertexBufferCacheKey throws if baseResource is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getVertexBufferCacheKey({
+        gltf: gltfUncompressed,
+        gltfResource: gltfResource,
+        baseResource: undefined,
+        bufferViewId: 0,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getVertexBufferCacheKey throws if both bufferViewId and draco are undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getVertexBufferCacheKey({
+        gltf: gltfUncompressed,
+        gltfResource: gltfResource,
+        baseResource: baseResource,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getVertexBufferCacheKey throws if both bufferViewId and draco are defined", function () {
+    var draco =
+      gltfDraco.meshes[0].primitives[0].extensions.KHR_draco_mesh_compression;
+
+    expect(function () {
+      ResourceCacheKey.getVertexBufferCacheKey({
+        gltf: gltfDraco,
+        gltfResource: gltfResource,
+        baseResource: baseResource,
+        bufferViewId: 0,
+        draco: draco,
+        dracoAttributeSemantic: "POSITION",
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getVertexBufferCacheKey throws if both draco is defined and dracoAttributeSemantic is undefined", function () {
+    var draco =
+      gltfDraco.meshes[0].primitives[0].extensions.KHR_draco_mesh_compression;
+
+    expect(function () {
+      ResourceCacheKey.getVertexBufferCacheKey({
+        gltf: gltfDraco,
+        gltfResource: gltfResource,
+        baseResource: baseResource,
+        draco: draco,
+        dracoAttributeSemantic: undefined,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getIndexBufferCacheKey works from buffer view", function () {
+    var cacheKey = ResourceCacheKey.getIndexBufferCacheKey({
+      gltf: gltfUncompressed,
+      accessorId: 2,
+      gltfResource: gltfResource,
+      baseResource: baseResource,
+    });
+
+    expect(cacheKey).toBe(
+      "index-buffer:https://example.com/resources/external.bin-accessor-80-5123-SCALAR-36"
+    );
+  });
+
+  it("getIndexBufferCacheKey works from draco", function () {
+    var draco =
+      gltfDraco.meshes[0].primitives[0].extensions.KHR_draco_mesh_compression;
+
+    var cacheKey = ResourceCacheKey.getIndexBufferCacheKey({
+      gltf: gltfDraco,
+      accessorId: 2,
+      gltfResource: gltfResource,
+      baseResource: baseResource,
+      draco: draco,
+    });
+
+    expect(cacheKey).toBe(
+      "index-buffer:https://example.com/resources/external.bin-range-0-100-draco"
+    );
+  });
+
+  it("getIndexBufferCacheKey throws if gltf is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getIndexBufferCacheKey({
+        gltf: undefined,
+        accessorId: 2,
+        gltfResource: gltfResource,
+        baseResource: baseResource,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getIndexBufferCacheKey throws if gltfResource is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getIndexBufferCacheKey({
+        gltf: gltfUncompressed,
+        accessorId: 2,
+        gltfResource: undefined,
+        baseResource: baseResource,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getIndexBufferCacheKey throws if baseResource is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getIndexBufferCacheKey({
+        gltf: gltfUncompressed,
+        accessorId: 2,
+        gltfResource: gltfResource,
+        baseResource: undefined,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getImageCacheKey works from uri", function () {
+    var cacheKey = ResourceCacheKey.getImageCacheKey({
+      gltf: gltfWithTextures,
+      imageId: 0,
+      gltfResource: gltfResource,
+      baseResource: baseResource,
+      supportedImageFormats: new SupportedImageFormats(),
+    });
+
+    expect(cacheKey).toBe("image:https://example.com/resources/image.png");
+  });
+
+  it("getImageCacheKey works from buffer view", function () {
+    var cacheKey = ResourceCacheKey.getImageCacheKey({
+      gltf: gltfWithTextures,
+      imageId: 1,
+      gltfResource: gltfResource,
+      baseResource: baseResource,
+      supportedImageFormats: new SupportedImageFormats(),
+    });
+
+    expect(cacheKey).toBe(
+      "image:https://example.com/resources/external.bin-range-0-100"
+    );
+  });
+
+  it("getImageCacheKey throws if gltf is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getImageCacheKey({
+        gltf: undefined,
+        imageId: 0,
+        gltfResource: gltfResource,
+        baseResource: baseResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getImageCacheKey throws if imageId is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getImageCacheKey({
+        gltf: gltfWithTextures,
+        imageId: undefined,
+        gltfResource: gltfResource,
+        baseResource: baseResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getImageCacheKey throws if gltfResource is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getImageCacheKey({
+        gltf: gltfWithTextures,
+        imageId: 0,
+        gltfResource: undefined,
+        baseResource: baseResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getImageCacheKey throws if baseResource is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getImageCacheKey({
+        gltf: gltfWithTextures,
+        imageId: 0,
+        gltfResource: gltfResource,
+        baseResource: undefined,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getImageCacheKey throws if supportedImageFormats is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getImageCacheKey({
+        gltf: gltfWithTextures,
+        imageId: 0,
+        gltfResource: gltfResource,
+        baseResource: baseResource,
+        supportedImageFormats: undefined,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getTextureCacheKey works with default sampler", function () {
+    var cacheKey = ResourceCacheKey.getTextureCacheKey({
+      gltf: gltfWithTextures,
+      textureInfo: {
+        index: 0,
+        texCoord: 0,
+      },
+      gltfResource: gltfResource,
+      baseResource: baseResource,
+      supportedImageFormats: new SupportedImageFormats(),
+    });
+
+    expect(cacheKey).toBe(
+      "texture:https://example.com/resources/image.png-sampler-10497-10497-9729-9729"
+    );
+  });
+
+  it("getTextureCacheKey works with explicit sampler", function () {
+    var cacheKey = ResourceCacheKey.getTextureCacheKey({
+      gltf: gltfWithTextures,
+      textureInfo: {
+        index: 1,
+        texCoord: 0,
+      },
+      gltfResource: gltfResource,
+      baseResource: baseResource,
+      supportedImageFormats: new SupportedImageFormats(),
+    });
+
+    expect(cacheKey).toBe(
+      "texture:https://example.com/resources/external.bin-range-0-100-sampler-33071-33648-9984-9728"
+    );
+  });
+
+  it("getTextureCacheKey works with EXT_texture_webp extension", function () {
+    var cacheKey = ResourceCacheKey.getTextureCacheKey({
+      gltf: gltfWithTextures,
+      textureInfo: {
+        index: 2,
+        texCoord: 0,
+      },
+      gltfResource: gltfResource,
+      baseResource: baseResource,
+      supportedImageFormats: new SupportedImageFormats({
+        webp: true,
+      }),
+    });
+
+    expect(cacheKey).toBe(
+      "texture:https://example.com/resources/image.webp-sampler-10497-10497-9729-9729"
+    );
+  });
+
+  it("getTextureCacheKey ignores EXT_texture_webp extension if WebP is not supported", function () {
+    var cacheKey = ResourceCacheKey.getTextureCacheKey({
+      gltf: gltfWithTextures,
+      textureInfo: {
+        index: 2,
+        texCoord: 0,
+      },
+      gltfResource: gltfResource,
+      baseResource: baseResource,
+      supportedImageFormats: new SupportedImageFormats(),
+    });
+
+    expect(cacheKey).toBe(
+      "texture:https://example.com/resources/image.png-sampler-10497-10497-9729-9729"
+    );
+  });
+
+  it("getTextureCacheKey throws if gltf is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getTextureCacheKey({
+        gltf: undefined,
+        textureInfo: {
+          index: 0,
+          texCoord: 0,
+        },
+        gltfResource: gltfResource,
+        baseResource: baseResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getTextureCacheKey throws if textureInfo is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getTextureCacheKey({
+        gltf: gltfWithTextures,
+        textureInfo: undefined,
+        gltfResource: gltfResource,
+        baseResource: baseResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getTextureCacheKey throws if gltfResource is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getTextureCacheKey({
+        gltf: gltfWithTextures,
+        textureInfo: {
+          index: 0,
+          texCoord: 0,
+        },
+        gltfResource: undefined,
+        baseResource: baseResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getTextureCacheKey throws if baseResource is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getTextureCacheKey({
+        gltf: gltfWithTextures,
+        textureInfo: {
+          index: 0,
+          texCoord: 0,
+        },
+        gltfResource: gltfResource,
+        baseResource: undefined,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getTextureCacheKey throws if supportedImageFormats is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getTextureCacheKey({
+        gltf: gltfWithTextures,
+        textureInfo: {
+          index: 0,
+          texCoord: 0,
+        },
+        gltfResource: gltfResource,
+        baseResource: baseResource,
+        supportedImageFormats: undefined,
       });
     }).toThrowDeveloperError();
   });

--- a/Specs/Scene/ResourceCacheSpec.js
+++ b/Specs/Scene/ResourceCacheSpec.js
@@ -1,417 +1,1398 @@
 import {
+  ComponentDatatype,
+  DracoLoader,
+  GltfJsonLoader,
   MetadataSchemaLoader,
   Resource,
   ResourceCache,
   ResourceCacheKey,
+  ResourceLoaderState,
+  SupportedImageFormats,
   when,
 } from "../../Source/Cesium.js";
+import concatTypedArrays from "../concatTypedArrays.js";
+import createScene from "../createScene.js";
+import generateJsonBuffer from "../generateJsonBuffer.js";
+import pollToPromise from "../pollToPromise.js";
 
-describe("ResourceCache", function () {
-  var schemaResource = new Resource({ url: "https://example.com/schema.json" });
-  var schemaJson = {};
-
-  var bufferTypedArray = new Uint8Array([1, 3, 7, 15, 31, 63, 127, 255]);
-  var bufferArrayBuffer = bufferTypedArray.buffer;
-  var bufferParentResource = new Resource({
-    url: "https://example.com/model.glb",
-  });
-  var bufferId = 0;
-  var bufferResource = new Resource({ url: "https://example.com/buffer.bin" });
-
-  beforeEach(function () {
-    ResourceCache.clearForSpecs();
-  });
-
-  it("loads resource", function () {
-    var fetchJson = spyOn(Resource.prototype, "fetchJson").and.returnValue(
-      when.resolve(schemaJson)
-    );
-
-    var cacheKey = ResourceCacheKey.getSchemaCacheKey({
-      resource: schemaResource,
+describe(
+  "ResourceCache",
+  function () {
+    var schemaResource = new Resource({
+      url: "https://example.com/schema.json",
     });
-    var resourceLoader = new MetadataSchemaLoader({
-      resource: schemaResource,
-      cacheKey: cacheKey,
+    var schemaJson = {};
+
+    var bufferParentResource = new Resource({
+      url: "https://example.com/model.glb",
+    });
+    var bufferResource = new Resource({
+      url: "https://example.com/external.bin",
     });
 
-    ResourceCache.load({
-      resourceLoader: resourceLoader,
+    var gltfUri = "https://example.com/model.glb";
+
+    var gltfResource = new Resource({
+      url: gltfUri,
     });
 
-    var cacheEntry = ResourceCache.cacheEntries[cacheKey];
-    expect(cacheEntry.referenceCount).toBe(1);
-    expect(cacheEntry.resourceLoader).toBe(resourceLoader);
-    expect(cacheEntry.keepResident).toBe(false);
+    var image = new Image();
+    image.src =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII=";
 
-    return resourceLoader.promise.then(function (resourceLoader) {
-      expect(fetchJson).toHaveBeenCalled();
+    var positions = new Float32Array([-1.0, -1.0, -1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0]); // prettier-ignore
+    var normals = new Float32Array([-1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]); // prettier-ignore
+    var indices = new Uint16Array([0, 1, 2]);
 
-      var schema = resourceLoader.schema;
-      expect(schema).toBeDefined();
+    var bufferTypedArray = concatTypedArrays([positions, normals, indices]);
+    var bufferArrayBuffer = bufferTypedArray.buffer;
+
+    var dracoBufferTypedArray = new Uint8Array([1, 3, 7, 15, 31, 63, 127, 255]);
+    var dracoArrayBuffer = dracoBufferTypedArray.buffer;
+
+    var decodedPositions = new Uint16Array([0, 0, 0, 65535, 65535, 65535, 0, 65535, 0]); // prettier-ignore
+    var decodedNormals = new Uint8Array([0, 255, 128, 128, 255, 0]);
+    var decodedIndices = new Uint16Array([0, 1, 2]);
+
+    var decodeDracoResults = {
+      indexArray: {
+        typedArray: decodedIndices,
+        numberOfIndices: decodedIndices.length,
+      },
+      attributeData: {
+        POSITION: {
+          array: decodedPositions,
+          data: {
+            byteOffset: 0,
+            byteStride: 6,
+            componentDatatype: ComponentDatatype.UNSIGNED_SHORT,
+            componentsPerAttribute: 3,
+            normalized: false,
+            quantization: {
+              octEncoded: false,
+              quantizationBits: 14,
+              minValues: [-1.0, -1.0, -1.0],
+              range: 2.0,
+            },
+          },
+        },
+        NORMAL: {
+          array: decodedNormals,
+          data: {
+            byteOffset: 0,
+            byteStride: 2,
+            componentDatatype: ComponentDatatype.UNSIGNED_BYTE,
+            componentsPerAttribute: 2,
+            normalized: false,
+            quantization: {
+              octEncoded: true,
+              quantizationBits: 10,
+            },
+          },
+        },
+      },
+    };
+
+    var gltfDraco = {
+      buffers: [
+        {
+          uri: "external.bin",
+          byteLength: 8,
+        },
+      ],
+      bufferViews: [
+        {
+          buffer: 0,
+          byteOffset: 4,
+          byteLength: 4,
+        },
+      ],
+      accessors: [
+        {
+          componentType: 5126,
+          count: 3,
+          max: [-1.0, -1.0, -1.0],
+          min: [1.0, 1.0, 1.0],
+          type: "VEC3",
+        },
+        {
+          componentType: 5126,
+          count: 3,
+          type: "VEC3",
+        },
+        {
+          componentType: 5123,
+          count: 3,
+          type: "SCALAR",
+        },
+      ],
+      meshes: [
+        {
+          primitives: [
+            {
+              attributes: {
+                POSITION: 0,
+                NORMAL: 1,
+              },
+              indices: 2,
+              extensions: {
+                KHR_draco_mesh_compression: {
+                  bufferView: 0,
+                  attributes: {
+                    POSITION: 0,
+                    NORMAL: 1,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    var dracoExtension =
+      gltfDraco.meshes[0].primitives[0].extensions.KHR_draco_mesh_compression;
+
+    var gltfUncompressed = {
+      buffers: [
+        {
+          uri: "external.bin",
+          byteLength: 78,
+        },
+      ],
+      bufferViews: [
+        {
+          buffer: 0,
+          byteOffset: 0,
+          byteLength: 36,
+        },
+        {
+          buffer: 0,
+          byteOffset: 36,
+          byteLength: 36,
+        },
+        {
+          buffer: 0,
+          byteOffset: 72,
+          byteLength: 6,
+        },
+      ],
+      accessors: [
+        {
+          componentType: 5126,
+          count: 3,
+          max: [-1.0, -1.0, -1.0],
+          min: [1.0, 1.0, 1.0],
+          type: "VEC3",
+          bufferView: 0,
+          byteOffset: 0,
+        },
+        {
+          componentType: 5126,
+          count: 3,
+          type: "VEC3",
+          bufferView: 1,
+          byteOffset: 0,
+        },
+        {
+          componentType: 5123,
+          count: 3,
+          type: "SCALAR",
+          bufferView: 2,
+          byteOffset: 0,
+        },
+      ],
+      meshes: [
+        {
+          primitives: [
+            {
+              attributes: {
+                POSITION: 0,
+                NORMAL: 1,
+              },
+              indices: 2,
+            },
+          ],
+        },
+      ],
+    };
+
+    var gltfWithTextures = {
+      images: [
+        {
+          uri: "image.png",
+        },
+      ],
+      textures: [
+        {
+          source: 0,
+        },
+      ],
+      materials: [
+        {
+          emissiveTexture: {
+            index: 0,
+          },
+          occlusionTexture: {
+            index: 1,
+          },
+        },
+      ],
+    };
+
+    var scene;
+
+    beforeAll(function () {
+      scene = createScene();
     });
-  });
 
-  it("load throws if resourceLoader is undefined", function () {
-    expect(function () {
-      ResourceCache.load({
-        keepResident: true,
+    afterAll(function () {
+      scene.destroyForSpecs();
+    });
+
+    afterEach(function () {
+      ResourceCache.clearForSpecs();
+    });
+
+    it("loads resource", function () {
+      var fetchJson = spyOn(Resource.prototype, "fetchJson").and.returnValue(
+        when.resolve(schemaJson)
+      );
+
+      var cacheKey = ResourceCacheKey.getSchemaCacheKey({
+        resource: schemaResource,
       });
-    }).toThrowDeveloperError();
-  });
+      var resourceLoader = new MetadataSchemaLoader({
+        resource: schemaResource,
+        cacheKey: cacheKey,
+      });
 
-  it("load throws if resourceLoader's cacheKey is undefined", function () {
-    var resourceLoader = new MetadataSchemaLoader({
-      resource: schemaResource,
-    });
-
-    expect(function () {
       ResourceCache.load({
         resourceLoader: resourceLoader,
       });
-    }).toThrowDeveloperError();
-  });
 
-  it("load throws if a resource with this cacheKey is already in the cache", function () {
-    var cacheKey = ResourceCacheKey.getSchemaCacheKey({
-      resource: schemaResource,
+      var cacheEntry = ResourceCache.cacheEntries[cacheKey];
+      expect(cacheEntry.referenceCount).toBe(1);
+      expect(cacheEntry.resourceLoader).toBe(resourceLoader);
+      expect(cacheEntry.keepResident).toBe(false);
+
+      return resourceLoader.promise.then(function (resourceLoader) {
+        expect(fetchJson).toHaveBeenCalled();
+
+        var schema = resourceLoader.schema;
+        expect(schema).toBeDefined();
+      });
     });
 
-    var resourceLoader = new MetadataSchemaLoader({
-      resource: schemaResource,
-      cacheKey: cacheKey,
+    it("load throws if resourceLoader is undefined", function () {
+      expect(function () {
+        ResourceCache.load({
+          keepResident: true,
+        });
+      }).toThrowDeveloperError();
     });
 
-    ResourceCache.load({
-      resourceLoader: resourceLoader,
+    it("load throws if resourceLoader's cacheKey is undefined", function () {
+      var resourceLoader = new MetadataSchemaLoader({
+        resource: schemaResource,
+      });
+
+      expect(function () {
+        ResourceCache.load({
+          resourceLoader: resourceLoader,
+        });
+      }).toThrowDeveloperError();
     });
 
-    expect(function () {
+    it("load throws if a resource with this cacheKey is already in the cache", function () {
+      var cacheKey = ResourceCacheKey.getSchemaCacheKey({
+        resource: schemaResource,
+      });
+
+      var resourceLoader = new MetadataSchemaLoader({
+        resource: schemaResource,
+        cacheKey: cacheKey,
+      });
+
       ResourceCache.load({
         resourceLoader: resourceLoader,
       });
-    }).toThrowDeveloperError();
-  });
 
-  it("destroys resource when reference count reaches 0", function () {
-    spyOn(Resource.prototype, "fetchJson").and.returnValue(
-      when.resolve(schemaJson)
-    );
-
-    var destroy = spyOn(
-      MetadataSchemaLoader.prototype,
-      "destroy"
-    ).and.callThrough();
-
-    var cacheKey = ResourceCacheKey.getSchemaCacheKey({
-      resource: schemaResource,
-    });
-    var resourceLoader = new MetadataSchemaLoader({
-      resource: schemaResource,
-      cacheKey: cacheKey,
+      expect(function () {
+        ResourceCache.load({
+          resourceLoader: resourceLoader,
+        });
+      }).toThrowDeveloperError();
     });
 
-    ResourceCache.load({
-      resourceLoader: resourceLoader,
-    });
+    it("destroys resource when reference count reaches 0", function () {
+      spyOn(Resource.prototype, "fetchJson").and.returnValue(
+        when.resolve(schemaJson)
+      );
 
-    ResourceCache.get(cacheKey);
+      var destroy = spyOn(
+        MetadataSchemaLoader.prototype,
+        "destroy"
+      ).and.callThrough();
 
-    var cacheEntry = ResourceCache.cacheEntries[cacheKey];
-    expect(cacheEntry.referenceCount).toBe(2);
+      var cacheKey = ResourceCacheKey.getSchemaCacheKey({
+        resource: schemaResource,
+      });
+      var resourceLoader = new MetadataSchemaLoader({
+        resource: schemaResource,
+        cacheKey: cacheKey,
+      });
 
-    ResourceCache.unload(resourceLoader);
-    expect(cacheEntry.referenceCount).toBe(1);
-    expect(destroy).not.toHaveBeenCalled();
-
-    ResourceCache.unload(resourceLoader);
-    expect(cacheEntry.referenceCount).toBe(0);
-    expect(destroy).toHaveBeenCalled();
-    expect(ResourceCache.cacheEntries[cacheKey]).toBeUndefined();
-  });
-
-  it("unload keeps resource in the cache if keepResident is true", function () {
-    spyOn(Resource.prototype, "fetchJson").and.returnValue(
-      when.resolve(schemaJson)
-    );
-
-    var destroy = spyOn(
-      MetadataSchemaLoader.prototype,
-      "destroy"
-    ).and.callThrough();
-
-    var cacheKey = ResourceCacheKey.getSchemaCacheKey({
-      resource: schemaResource,
-    });
-    var resourceLoader = new MetadataSchemaLoader({
-      resource: schemaResource,
-      cacheKey: cacheKey,
-    });
-
-    ResourceCache.load({
-      resourceLoader: resourceLoader,
-      keepResident: true,
-    });
-
-    var cacheEntry = ResourceCache.cacheEntries[cacheKey];
-    expect(cacheEntry.keepResident).toBe(true);
-    expect(cacheEntry.referenceCount).toBe(1);
-
-    ResourceCache.unload(resourceLoader);
-    expect(cacheEntry.referenceCount).toBe(0);
-    expect(destroy).not.toHaveBeenCalled();
-    expect(ResourceCache.cacheEntries[cacheKey]).toBe(cacheEntry);
-  });
-
-  it("unload throws if resourceLoader is undefined", function () {
-    expect(function () {
-      ResourceCache.unload();
-    }).toThrowDeveloperError();
-  });
-
-  it("unload throws if resourceLoader is not in the cache", function () {
-    var cacheKey = ResourceCacheKey.getSchemaCacheKey({
-      resource: schemaResource,
-    });
-    var resourceLoader = new MetadataSchemaLoader({
-      resource: schemaResource,
-      cacheKey: cacheKey,
-    });
-
-    expect(function () {
-      ResourceCache.unload({
+      ResourceCache.load({
         resourceLoader: resourceLoader,
       });
-    }).toThrowDeveloperError();
-  });
 
-  it("unload throws if resource has no references", function () {
-    spyOn(Resource.prototype, "fetchJson").and.returnValue(
-      when.resolve(schemaJson)
-    );
+      ResourceCache.get(cacheKey);
 
-    var cacheKey = ResourceCacheKey.getSchemaCacheKey({
-      resource: schemaResource,
-    });
-    var resourceLoader = new MetadataSchemaLoader({
-      resource: schemaResource,
-      cacheKey: cacheKey,
-    });
+      var cacheEntry = ResourceCache.cacheEntries[cacheKey];
+      expect(cacheEntry.referenceCount).toBe(2);
 
-    ResourceCache.load({
-      resourceLoader: resourceLoader,
-      keepResident: true,
-    });
-
-    ResourceCache.unload(resourceLoader);
-
-    expect(function () {
       ResourceCache.unload(resourceLoader);
-    }).toThrowDeveloperError();
-  });
+      expect(cacheEntry.referenceCount).toBe(1);
+      expect(destroy).not.toHaveBeenCalled();
 
-  it("gets resource", function () {
-    spyOn(Resource.prototype, "fetchJson").and.returnValue(
-      when.resolve(schemaJson)
-    );
-
-    var cacheKey = ResourceCacheKey.getSchemaCacheKey({
-      resource: schemaResource,
-    });
-    var resourceLoader = new MetadataSchemaLoader({
-      resource: schemaResource,
-      cacheKey: cacheKey,
+      ResourceCache.unload(resourceLoader);
+      expect(cacheEntry.referenceCount).toBe(0);
+      expect(destroy).toHaveBeenCalled();
+      expect(ResourceCache.cacheEntries[cacheKey]).toBeUndefined();
     });
 
-    ResourceCache.load({
-      resourceLoader: resourceLoader,
-    });
+    it("unload keeps resource in the cache if keepResident is true", function () {
+      spyOn(Resource.prototype, "fetchJson").and.returnValue(
+        when.resolve(schemaJson)
+      );
 
-    var cacheEntry = ResourceCache.cacheEntries[cacheKey];
+      var destroy = spyOn(
+        MetadataSchemaLoader.prototype,
+        "destroy"
+      ).and.callThrough();
 
-    ResourceCache.get(cacheKey);
-    expect(cacheEntry.referenceCount).toBe(2);
-
-    ResourceCache.get(cacheKey);
-    expect(cacheEntry.referenceCount).toBe(3);
-  });
-
-  it("get returns undefined if there is no resource with this cache key", function () {
-    var cacheKey = ResourceCacheKey.getSchemaCacheKey({
-      resource: schemaResource,
-    });
-
-    expect(ResourceCache.get(cacheKey)).toBeUndefined();
-  });
-
-  it("loads schema from JSON", function () {
-    var expectedCacheKey = ResourceCacheKey.getSchemaCacheKey({
-      schema: schemaJson,
-    });
-    var schemaLoader = ResourceCache.loadSchema({
-      schema: schemaJson,
-    });
-    var cacheEntry = ResourceCache.cacheEntries[expectedCacheKey];
-    expect(schemaLoader.cacheKey).toBe(expectedCacheKey);
-    expect(cacheEntry.referenceCount).toBe(1);
-    expect(cacheEntry.keepResident).toBe(false);
-
-    // The existing resource is returned if the computed cache key is the same
-    expect(
-      ResourceCache.loadSchema({
-        schema: schemaJson,
-      })
-    ).toBe(schemaLoader);
-
-    expect(cacheEntry.referenceCount).toBe(2);
-
-    return schemaLoader.promise.then(function (schemaLoader) {
-      var schema = schemaLoader.schema;
-      expect(schema).toBeDefined();
-    });
-  });
-
-  it("loads external schema", function () {
-    spyOn(Resource.prototype, "fetchJson").and.returnValue(
-      when.resolve(schemaJson)
-    );
-
-    var expectedCacheKey = ResourceCacheKey.getSchemaCacheKey({
-      resource: schemaResource,
-    });
-    var schemaLoader = ResourceCache.loadSchema({
-      resource: schemaResource,
-    });
-    var cacheEntry = ResourceCache.cacheEntries[expectedCacheKey];
-    expect(schemaLoader.cacheKey).toBe(expectedCacheKey);
-    expect(cacheEntry.referenceCount).toBe(1);
-    expect(cacheEntry.keepResident).toBe(false);
-
-    // The existing resource is returned if the computed cache key is the same
-    expect(
-      ResourceCache.loadSchema({
+      var cacheKey = ResourceCacheKey.getSchemaCacheKey({
         resource: schemaResource,
-      })
-    ).toBe(schemaLoader);
+      });
+      var resourceLoader = new MetadataSchemaLoader({
+        resource: schemaResource,
+        cacheKey: cacheKey,
+      });
 
-    expect(cacheEntry.referenceCount).toBe(2);
-
-    return schemaLoader.promise.then(function (schemaLoader) {
-      var schema = schemaLoader.schema;
-      expect(schema).toBeDefined();
-    });
-  });
-
-  it("loadSchema throws if neither options.schema nor options.resource are defined", function () {
-    expect(function () {
-      ResourceCache.loadSchema({
+      ResourceCache.load({
+        resourceLoader: resourceLoader,
         keepResident: true,
       });
-    }).toThrowDeveloperError();
-  });
 
-  it("loadSchema throws if both options.schema and options.resource are defined", function () {
-    expect(function () {
-      ResourceCache.loadSchema({
-        schema: schemaJson,
+      var cacheEntry = ResourceCache.cacheEntries[cacheKey];
+      expect(cacheEntry.keepResident).toBe(true);
+      expect(cacheEntry.referenceCount).toBe(1);
+
+      ResourceCache.unload(resourceLoader);
+      expect(cacheEntry.referenceCount).toBe(0);
+      expect(destroy).not.toHaveBeenCalled();
+      expect(ResourceCache.cacheEntries[cacheKey]).toBe(cacheEntry);
+    });
+
+    it("unload throws if resourceLoader is undefined", function () {
+      expect(function () {
+        ResourceCache.unload();
+      }).toThrowDeveloperError();
+    });
+
+    it("unload throws if resourceLoader is not in the cache", function () {
+      var cacheKey = ResourceCacheKey.getSchemaCacheKey({
         resource: schemaResource,
       });
-    }).toThrowDeveloperError();
-  });
+      var resourceLoader = new MetadataSchemaLoader({
+        resource: schemaResource,
+        cacheKey: cacheKey,
+      });
 
-  it("loads embedded buffer", function () {
-    var expectedCacheKey = ResourceCacheKey.getEmbeddedBufferCacheKey({
-      parentResource: bufferParentResource,
-      bufferId: bufferId,
+      expect(function () {
+        ResourceCache.unload({
+          resourceLoader: resourceLoader,
+        });
+      }).toThrowDeveloperError();
     });
-    var bufferLoader = ResourceCache.loadEmbeddedBuffer({
-      parentResource: bufferParentResource,
-      bufferId: bufferId,
-      typedArray: bufferTypedArray,
-    });
-    var cacheEntry = ResourceCache.cacheEntries[expectedCacheKey];
-    expect(bufferLoader.cacheKey).toBe(expectedCacheKey);
-    expect(cacheEntry.referenceCount).toBe(1);
-    expect(cacheEntry.keepResident).toBe(false);
 
-    // The existing resource is returned if the computed cache key is the same
-    expect(
-      ResourceCache.loadEmbeddedBuffer({
+    it("unload throws if resource has no references", function () {
+      spyOn(Resource.prototype, "fetchJson").and.returnValue(
+        when.resolve(schemaJson)
+      );
+
+      var cacheKey = ResourceCacheKey.getSchemaCacheKey({
+        resource: schemaResource,
+      });
+      var resourceLoader = new MetadataSchemaLoader({
+        resource: schemaResource,
+        cacheKey: cacheKey,
+      });
+
+      ResourceCache.load({
+        resourceLoader: resourceLoader,
+        keepResident: true,
+      });
+
+      ResourceCache.unload(resourceLoader);
+
+      expect(function () {
+        ResourceCache.unload(resourceLoader);
+      }).toThrowDeveloperError();
+    });
+
+    it("gets resource", function () {
+      spyOn(Resource.prototype, "fetchJson").and.returnValue(
+        when.resolve(schemaJson)
+      );
+
+      var cacheKey = ResourceCacheKey.getSchemaCacheKey({
+        resource: schemaResource,
+      });
+      var resourceLoader = new MetadataSchemaLoader({
+        resource: schemaResource,
+        cacheKey: cacheKey,
+      });
+
+      ResourceCache.load({
+        resourceLoader: resourceLoader,
+      });
+
+      var cacheEntry = ResourceCache.cacheEntries[cacheKey];
+
+      ResourceCache.get(cacheKey);
+      expect(cacheEntry.referenceCount).toBe(2);
+
+      ResourceCache.get(cacheKey);
+      expect(cacheEntry.referenceCount).toBe(3);
+    });
+
+    it("get returns undefined if there is no resource with this cache key", function () {
+      var cacheKey = ResourceCacheKey.getSchemaCacheKey({
+        resource: schemaResource,
+      });
+
+      expect(ResourceCache.get(cacheKey)).toBeUndefined();
+    });
+
+    it("loads schema from JSON", function () {
+      var expectedCacheKey = ResourceCacheKey.getSchemaCacheKey({
+        schema: schemaJson,
+      });
+      var schemaLoader = ResourceCache.loadSchema({
+        schema: schemaJson,
+      });
+      var cacheEntry = ResourceCache.cacheEntries[expectedCacheKey];
+      expect(schemaLoader.cacheKey).toBe(expectedCacheKey);
+      expect(cacheEntry.referenceCount).toBe(1);
+      expect(cacheEntry.keepResident).toBe(false);
+
+      // The existing resource is returned if the computed cache key is the same
+      expect(
+        ResourceCache.loadSchema({
+          schema: schemaJson,
+        })
+      ).toBe(schemaLoader);
+
+      expect(cacheEntry.referenceCount).toBe(2);
+
+      return schemaLoader.promise.then(function (schemaLoader) {
+        var schema = schemaLoader.schema;
+        expect(schema).toBeDefined();
+      });
+    });
+
+    it("loads external schema", function () {
+      spyOn(Resource.prototype, "fetchJson").and.returnValue(
+        when.resolve(schemaJson)
+      );
+
+      var expectedCacheKey = ResourceCacheKey.getSchemaCacheKey({
+        resource: schemaResource,
+      });
+      var schemaLoader = ResourceCache.loadSchema({
+        resource: schemaResource,
+      });
+      var cacheEntry = ResourceCache.cacheEntries[expectedCacheKey];
+      expect(schemaLoader.cacheKey).toBe(expectedCacheKey);
+      expect(cacheEntry.referenceCount).toBe(1);
+      expect(cacheEntry.keepResident).toBe(false);
+
+      // The existing resource is returned if the computed cache key is the same
+      expect(
+        ResourceCache.loadSchema({
+          resource: schemaResource,
+        })
+      ).toBe(schemaLoader);
+
+      expect(cacheEntry.referenceCount).toBe(2);
+
+      return schemaLoader.promise.then(function (schemaLoader) {
+        var schema = schemaLoader.schema;
+        expect(schema).toBeDefined();
+      });
+    });
+
+    it("loadSchema throws if neither options.schema nor options.resource are defined", function () {
+      expect(function () {
+        ResourceCache.loadSchema({
+          keepResident: true,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadSchema throws if both options.schema and options.resource are defined", function () {
+      expect(function () {
+        ResourceCache.loadSchema({
+          schema: schemaJson,
+          resource: schemaResource,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loads embedded buffer", function () {
+      var expectedCacheKey = ResourceCacheKey.getEmbeddedBufferCacheKey({
         parentResource: bufferParentResource,
-        bufferId: bufferId,
-        typedArray: bufferTypedArray,
-      })
-    ).toBe(bufferLoader);
-
-    expect(cacheEntry.referenceCount).toBe(2);
-
-    return bufferLoader.promise.then(function (bufferLoader) {
-      expect(bufferLoader.typedArray).toBe(bufferTypedArray);
-    });
-  });
-
-  it("loadEmbeddedBuffer throws if parentResource is undefined", function () {
-    expect(function () {
-      ResourceCache.loadEmbeddedBuffer({
-        bufferId: bufferId,
+        bufferId: 0,
+      });
+      var bufferLoader = ResourceCache.loadEmbeddedBuffer({
+        parentResource: bufferParentResource,
+        bufferId: 0,
         typedArray: bufferTypedArray,
       });
-    }).toThrowDeveloperError();
-  });
+      var cacheEntry = ResourceCache.cacheEntries[expectedCacheKey];
+      expect(bufferLoader.cacheKey).toBe(expectedCacheKey);
+      expect(cacheEntry.referenceCount).toBe(1);
+      expect(cacheEntry.keepResident).toBe(false);
 
-  it("loadEmbeddedBuffer throws if bufferId is undefined", function () {
-    expect(function () {
-      ResourceCache.loadEmbeddedBuffer({
-        parentResource: bufferParentResource,
-        typedArray: bufferTypedArray,
+      // The existing resource is returned if the computed cache key is the same
+      expect(
+        ResourceCache.loadEmbeddedBuffer({
+          parentResource: bufferParentResource,
+          bufferId: 0,
+          typedArray: bufferTypedArray,
+        })
+      ).toBe(bufferLoader);
+
+      expect(cacheEntry.referenceCount).toBe(2);
+
+      return bufferLoader.promise.then(function (bufferLoader) {
+        expect(bufferLoader.typedArray).toBe(bufferTypedArray);
       });
-    }).toThrowDeveloperError();
-  });
-
-  it("loadEmbeddedBuffer throws if typedArray is undefined", function () {
-    expect(function () {
-      ResourceCache.loadEmbeddedBuffer({
-        parentResource: bufferParentResource,
-        bufferId: bufferId,
-      });
-    }).toThrowDeveloperError();
-  });
-
-  it("loads external buffer", function () {
-    spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
-      when.resolve(bufferArrayBuffer)
-    );
-
-    var expectedCacheKey = ResourceCacheKey.getExternalBufferCacheKey({
-      resource: bufferResource,
     });
-    var bufferLoader = ResourceCache.loadExternalBuffer({
-      resource: bufferResource,
-    });
-    var cacheEntry = ResourceCache.cacheEntries[expectedCacheKey];
-    expect(bufferLoader.cacheKey).toBe(expectedCacheKey);
-    expect(cacheEntry.referenceCount).toBe(1);
-    expect(cacheEntry.keepResident).toBe(false);
 
-    // The existing resource is returned if the computed cache key is the same
-    expect(
-      ResourceCache.loadExternalBuffer({
+    it("loadEmbeddedBuffer throws if parentResource is undefined", function () {
+      expect(function () {
+        ResourceCache.loadEmbeddedBuffer({
+          bufferId: 0,
+          typedArray: bufferTypedArray,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadEmbeddedBuffer throws if bufferId is undefined", function () {
+      expect(function () {
+        ResourceCache.loadEmbeddedBuffer({
+          parentResource: bufferParentResource,
+          typedArray: bufferTypedArray,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadEmbeddedBuffer throws if typedArray is undefined", function () {
+      expect(function () {
+        ResourceCache.loadEmbeddedBuffer({
+          parentResource: bufferParentResource,
+          bufferId: 0,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loads external buffer", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(bufferArrayBuffer)
+      );
+
+      var expectedCacheKey = ResourceCacheKey.getExternalBufferCacheKey({
         resource: bufferResource,
-      })
-    ).toBe(bufferLoader);
-
-    expect(cacheEntry.referenceCount).toBe(2);
-
-    return bufferLoader.promise.then(function (bufferLoader) {
-      expect(bufferLoader.typedArray.buffer).toBe(bufferArrayBuffer);
-    });
-  });
-
-  it("loadExternalBuffer throws if resource is undefined", function () {
-    expect(function () {
-      ResourceCache.loadExternalBuffer({
-        keepResident: true,
       });
-    }).toThrowDeveloperError();
-  });
-});
+      var bufferLoader = ResourceCache.loadExternalBuffer({
+        resource: bufferResource,
+      });
+      var cacheEntry = ResourceCache.cacheEntries[expectedCacheKey];
+      expect(bufferLoader.cacheKey).toBe(expectedCacheKey);
+      expect(cacheEntry.referenceCount).toBe(1);
+      expect(cacheEntry.keepResident).toBe(false);
+
+      // The existing resource is returned if the computed cache key is the same
+      expect(
+        ResourceCache.loadExternalBuffer({
+          resource: bufferResource,
+        })
+      ).toBe(bufferLoader);
+
+      expect(cacheEntry.referenceCount).toBe(2);
+
+      return bufferLoader.promise.then(function (bufferLoader) {
+        expect(bufferLoader.typedArray.buffer).toBe(bufferArrayBuffer);
+      });
+    });
+
+    it("loadExternalBuffer throws if resource is undefined", function () {
+      expect(function () {
+        ResourceCache.loadExternalBuffer({
+          keepResident: true,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loads glTF", function () {
+      var gltf = {
+        asset: {
+          version: "2.0",
+        },
+      };
+      var arrayBuffer = generateJsonBuffer(gltf).buffer;
+
+      spyOn(GltfJsonLoader.prototype, "_fetchGltf").and.returnValue(
+        when.resolve(arrayBuffer)
+      );
+
+      var expectedCacheKey = ResourceCacheKey.getGltfCacheKey({
+        gltfResource: gltfResource,
+      });
+      var gltfLoader = ResourceCache.loadGltf({
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+      });
+      var cacheEntry = ResourceCache.cacheEntries[expectedCacheKey];
+      expect(gltfLoader.cacheKey).toBe(expectedCacheKey);
+      expect(cacheEntry.referenceCount).toBe(1);
+      expect(cacheEntry.keepResident).toBe(false);
+
+      // The existing resource is returned if the computed cache key is the same
+      expect(
+        ResourceCache.loadGltf({
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+        })
+      ).toBe(gltfLoader);
+
+      expect(cacheEntry.referenceCount).toBe(2);
+
+      return gltfLoader.promise.then(function (gltfLoader) {
+        expect(gltfLoader.gltf).toBeDefined();
+      });
+    });
+
+    it("loadGltf throws if gltfResource is undefined", function () {
+      expect(function () {
+        ResourceCache.loadGltf({
+          gltfResource: undefined,
+          baseResource: gltfResource,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadGltf throws if gltfResource is undefined", function () {
+      expect(function () {
+        ResourceCache.loadGltf({
+          gltfResource: gltfResource,
+          baseResource: undefined,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loads buffer view", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(bufferArrayBuffer)
+      );
+
+      var expectedCacheKey = ResourceCacheKey.getBufferViewCacheKey({
+        gltf: gltfUncompressed,
+        bufferViewId: 0,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+      });
+      var bufferViewLoader = ResourceCache.loadBufferView({
+        gltf: gltfUncompressed,
+        bufferViewId: 0,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+      });
+      var cacheEntry = ResourceCache.cacheEntries[expectedCacheKey];
+      expect(bufferViewLoader.cacheKey).toBe(expectedCacheKey);
+      expect(cacheEntry.referenceCount).toBe(1);
+      expect(cacheEntry.keepResident).toBe(false);
+
+      // The existing resource is returned if the computed cache key is the same
+      expect(
+        ResourceCache.loadBufferView({
+          gltf: gltfUncompressed,
+          bufferViewId: 0,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+        })
+      ).toBe(bufferViewLoader);
+
+      expect(cacheEntry.referenceCount).toBe(2);
+
+      return bufferViewLoader.promise.then(function (bufferViewLoader) {
+        expect(bufferViewLoader.typedArray).toBeDefined();
+      });
+    });
+
+    it("loadBufferView throws if gltf is undefined", function () {
+      expect(function () {
+        ResourceCache.loadBufferView({
+          gltf: undefined,
+          bufferViewId: 0,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadBufferView throws if bufferViewId is undefined", function () {
+      expect(function () {
+        ResourceCache.loadBufferView({
+          gltf: gltfUncompressed,
+          bufferViewId: undefined,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadBufferView throws if gltfResource is undefined", function () {
+      expect(function () {
+        ResourceCache.loadBufferView({
+          gltf: gltfUncompressed,
+          bufferViewId: 0,
+          gltfResource: undefined,
+          baseResource: gltfResource,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadBufferView throws if baseResource is undefined", function () {
+      expect(function () {
+        ResourceCache.loadBufferView({
+          gltf: gltfUncompressed,
+          bufferViewId: 0,
+          gltfResource: gltfResource,
+          baseResource: undefined,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loads draco", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(dracoArrayBuffer)
+      );
+
+      spyOn(DracoLoader, "decodeBufferView").and.returnValue(
+        when.resolve(decodeDracoResults)
+      );
+
+      var expectedCacheKey = ResourceCacheKey.getDracoCacheKey({
+        gltf: gltfDraco,
+        draco: dracoExtension,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+      });
+      var dracoLoader = ResourceCache.loadDraco({
+        gltf: gltfDraco,
+        draco: dracoExtension,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+      });
+
+      var cacheEntry = ResourceCache.cacheEntries[expectedCacheKey];
+      expect(dracoLoader.cacheKey).toBe(expectedCacheKey);
+      expect(cacheEntry.referenceCount).toBe(1);
+      expect(cacheEntry.keepResident).toBe(false);
+
+      // The existing resource is returned if the computed cache key is the same
+      expect(
+        ResourceCache.loadDraco({
+          gltf: gltfDraco,
+          draco: dracoExtension,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+        })
+      ).toBe(dracoLoader);
+
+      expect(cacheEntry.referenceCount).toBe(2);
+
+      return pollToPromise(function () {
+        dracoLoader.process(scene.frameState);
+        return dracoLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return dracoLoader.promise.then(function (dracoLoader) {
+          expect(dracoLoader.decodedData).toBeDefined();
+        });
+      });
+    });
+
+    it("loadDraco throws if gltf is undefined", function () {
+      expect(function () {
+        ResourceCache.loadBufferView({
+          gltf: undefined,
+          draco: dracoExtension,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadDraco throws if draco is undefined", function () {
+      expect(function () {
+        ResourceCache.loadBufferView({
+          gltf: gltfDraco,
+          draco: undefined,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadDraco throws if gltfResource is undefined", function () {
+      expect(function () {
+        ResourceCache.loadBufferView({
+          gltf: gltfDraco,
+          draco: dracoExtension,
+          gltfResource: undefined,
+          baseResource: gltfResource,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadDraco throws if baseResource is undefined", function () {
+      expect(function () {
+        ResourceCache.loadBufferView({
+          gltf: gltfDraco,
+          draco: dracoExtension,
+          gltfResource: gltfResource,
+          baseResource: undefined,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loads vertex buffer from buffer view", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(bufferArrayBuffer)
+      );
+
+      var expectedCacheKey = ResourceCacheKey.getVertexBufferCacheKey({
+        gltf: gltfUncompressed,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        bufferViewId: 0,
+      });
+      var vertexBufferLoader = ResourceCache.loadVertexBuffer({
+        gltf: gltfUncompressed,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        bufferViewId: 0,
+      });
+
+      var cacheEntry = ResourceCache.cacheEntries[expectedCacheKey];
+      expect(vertexBufferLoader.cacheKey).toBe(expectedCacheKey);
+      expect(cacheEntry.referenceCount).toBe(1);
+      expect(cacheEntry.keepResident).toBe(false);
+
+      // The existing resource is returned if the computed cache key is the same
+      expect(
+        ResourceCache.loadVertexBuffer({
+          gltf: gltfUncompressed,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          bufferViewId: 0,
+        })
+      ).toBe(vertexBufferLoader);
+
+      expect(cacheEntry.referenceCount).toBe(2);
+
+      return pollToPromise(function () {
+        vertexBufferLoader.process(scene.frameState);
+        return vertexBufferLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return vertexBufferLoader.promise.then(function (vertexBufferLoader) {
+          expect(vertexBufferLoader.vertexBuffer).toBeDefined();
+        });
+      });
+    });
+
+    it("loads vertex buffer from draco", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(dracoArrayBuffer)
+      );
+
+      spyOn(DracoLoader, "decodeBufferView").and.returnValue(
+        when.resolve(decodeDracoResults)
+      );
+
+      var expectedCacheKey = ResourceCacheKey.getVertexBufferCacheKey({
+        gltf: gltfDraco,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        draco: dracoExtension,
+        dracoAttributeSemantic: "POSITION",
+      });
+      var vertexBufferLoader = ResourceCache.loadVertexBuffer({
+        gltf: gltfDraco,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        draco: dracoExtension,
+        dracoAttributeSemantic: "POSITION",
+      });
+
+      var cacheEntry = ResourceCache.cacheEntries[expectedCacheKey];
+      expect(vertexBufferLoader.cacheKey).toBe(expectedCacheKey);
+      expect(cacheEntry.referenceCount).toBe(1);
+      expect(cacheEntry.keepResident).toBe(false);
+
+      // The existing resource is returned if the computed cache key is the same
+      expect(
+        ResourceCache.loadVertexBuffer({
+          gltf: gltfDraco,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          draco: dracoExtension,
+          dracoAttributeSemantic: "POSITION",
+        })
+      ).toBe(vertexBufferLoader);
+
+      expect(cacheEntry.referenceCount).toBe(2);
+
+      return pollToPromise(function () {
+        vertexBufferLoader.process(scene.frameState);
+        return vertexBufferLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return vertexBufferLoader.promise.then(function (vertexBufferLoader) {
+          expect(vertexBufferLoader.vertexBuffer).toBeDefined();
+        });
+      });
+    });
+
+    it("loadVertexBuffer throws if gltf is undefined", function () {
+      expect(function () {
+        ResourceCache.loadVertexBuffer({
+          gltf: undefined,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          bufferViewId: 0,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadVertexBuffer throws if gltfResource is undefined", function () {
+      expect(function () {
+        ResourceCache.loadVertexBuffer({
+          gltf: gltfUncompressed,
+          gltfResource: undefined,
+          baseResource: gltfResource,
+          bufferViewId: 0,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadVertexBuffer throws if baseResource is undefined", function () {
+      expect(function () {
+        ResourceCache.loadVertexBuffer({
+          gltf: gltfUncompressed,
+          gltfResource: gltfResource,
+          baseResource: undefined,
+          bufferViewId: 0,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadVertexBuffer throws if bufferViewId and draco are both defined", function () {
+      expect(function () {
+        ResourceCache.loadVertexBuffer({
+          gltf: gltfDraco,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          bufferViewId: 0,
+          draco: dracoExtension,
+          dracoAttributeSemantic: "POSITION",
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadVertexBuffer throws if bufferViewId and draco are both undefined", function () {
+      expect(function () {
+        ResourceCache.loadVertexBuffer({
+          gltf: gltfDraco,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadVertexBuffer throws if draco is defined and dracoAttributeSemantic is not defined", function () {
+      expect(function () {
+        ResourceCache.loadVertexBuffer({
+          gltf: gltfDraco,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          draco: dracoExtension,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loads index buffer from accessor", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(bufferArrayBuffer)
+      );
+
+      var expectedCacheKey = ResourceCacheKey.getIndexBufferCacheKey({
+        gltf: gltfUncompressed,
+        accessorId: 2,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+      });
+      var indexBufferLoader = ResourceCache.loadIndexBuffer({
+        gltf: gltfUncompressed,
+        accessorId: 2,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+      });
+
+      var cacheEntry = ResourceCache.cacheEntries[expectedCacheKey];
+      expect(indexBufferLoader.cacheKey).toBe(expectedCacheKey);
+      expect(cacheEntry.referenceCount).toBe(1);
+      expect(cacheEntry.keepResident).toBe(false);
+
+      // The existing resource is returned if the computed cache key is the same
+      expect(
+        ResourceCache.loadIndexBuffer({
+          gltf: gltfUncompressed,
+          accessorId: 2,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+        })
+      ).toBe(indexBufferLoader);
+
+      expect(cacheEntry.referenceCount).toBe(2);
+
+      return pollToPromise(function () {
+        indexBufferLoader.process(scene.frameState);
+        return indexBufferLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return indexBufferLoader.promise.then(function (indexBufferLoader) {
+          expect(indexBufferLoader.indexBuffer).toBeDefined();
+        });
+      });
+    });
+
+    it("loads index buffer from draco", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(dracoArrayBuffer)
+      );
+
+      spyOn(DracoLoader, "decodeBufferView").and.returnValue(
+        when.resolve(decodeDracoResults)
+      );
+
+      var expectedCacheKey = ResourceCacheKey.getIndexBufferCacheKey({
+        gltf: gltfDraco,
+        accessorId: 2,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        draco: dracoExtension,
+      });
+      var indexBufferLoader = ResourceCache.loadIndexBuffer({
+        gltf: gltfDraco,
+        accessorId: 2,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        draco: dracoExtension,
+      });
+
+      var cacheEntry = ResourceCache.cacheEntries[expectedCacheKey];
+      expect(indexBufferLoader.cacheKey).toBe(expectedCacheKey);
+      expect(cacheEntry.referenceCount).toBe(1);
+      expect(cacheEntry.keepResident).toBe(false);
+
+      // The existing resource is returned if the computed cache key is the same
+      expect(
+        ResourceCache.loadIndexBuffer({
+          gltf: gltfDraco,
+          accessorId: 2,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          draco: dracoExtension,
+        })
+      ).toBe(indexBufferLoader);
+
+      expect(cacheEntry.referenceCount).toBe(2);
+
+      return pollToPromise(function () {
+        indexBufferLoader.process(scene.frameState);
+        return indexBufferLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return indexBufferLoader.promise.then(function (indexBufferLoader) {
+          expect(indexBufferLoader.indexBuffer).toBeDefined();
+        });
+      });
+    });
+
+    it("loadIndexBuffer throws if gltf is undefined", function () {
+      expect(function () {
+        ResourceCache.loadIndexBuffer({
+          gltf: undefined,
+          accessorId: 2,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadIndexBuffer throws if accessorId is undefined", function () {
+      expect(function () {
+        ResourceCache.loadIndexBuffer({
+          gltf: gltfUncompressed,
+          accessorId: undefined,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadIndexBuffer throws if gltfResource is undefined", function () {
+      expect(function () {
+        ResourceCache.loadIndexBuffer({
+          gltf: gltfUncompressed,
+          accessorId: 2,
+          gltfResource: undefined,
+          baseResource: gltfResource,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadIndexBuffer throws if baseResource is undefined", function () {
+      expect(function () {
+        ResourceCache.loadIndexBuffer({
+          gltf: gltfUncompressed,
+          accessorId: 2,
+          gltfResource: gltfResource,
+          baseResource: undefined,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loads image", function () {
+      spyOn(Resource.prototype, "fetchImage").and.returnValue(
+        when.resolve(image)
+      );
+
+      var expectedCacheKey = ResourceCacheKey.getImageCacheKey({
+        gltf: gltfWithTextures,
+        imageId: 0,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+      var imageLoader = ResourceCache.loadImage({
+        gltf: gltfWithTextures,
+        imageId: 0,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+      var cacheEntry = ResourceCache.cacheEntries[expectedCacheKey];
+      expect(imageLoader.cacheKey).toBe(expectedCacheKey);
+      expect(cacheEntry.referenceCount).toBe(1);
+      expect(cacheEntry.keepResident).toBe(false);
+
+      // The existing resource is returned if the computed cache key is the same
+      expect(
+        ResourceCache.loadImage({
+          gltf: gltfWithTextures,
+          imageId: 0,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          supportedImageFormats: new SupportedImageFormats(),
+        })
+      ).toBe(imageLoader);
+
+      expect(cacheEntry.referenceCount).toBe(2);
+
+      return imageLoader.promise.then(function (imageLoader) {
+        expect(imageLoader.image).toBeDefined();
+      });
+    });
+
+    it("loadImage throws if gltf is undefined", function () {
+      expect(function () {
+        ResourceCache.loadIndexBuffer({
+          gltf: undefined,
+          imageId: 0,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          supportedImageFormats: new SupportedImageFormats(),
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadImage throws if imageId is undefined", function () {
+      expect(function () {
+        ResourceCache.loadIndexBuffer({
+          gltf: gltfWithTextures,
+          imageId: undefined,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          supportedImageFormats: new SupportedImageFormats(),
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadImage throws if gltfResource is undefined", function () {
+      expect(function () {
+        ResourceCache.loadIndexBuffer({
+          gltf: gltfWithTextures,
+          imageId: 0,
+          gltfResource: undefined,
+          baseResource: gltfResource,
+          supportedImageFormats: new SupportedImageFormats(),
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadImage throws if baseResource is undefined", function () {
+      expect(function () {
+        ResourceCache.loadIndexBuffer({
+          gltf: gltfWithTextures,
+          imageId: 0,
+          gltfResource: gltfResource,
+          baseResource: undefined,
+          supportedImageFormats: new SupportedImageFormats(),
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadImage throws if supportedImageFormats is undefined", function () {
+      expect(function () {
+        ResourceCache.loadIndexBuffer({
+          gltf: gltfWithTextures,
+          imageId: 0,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          supportedImageFormats: undefined,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loads texture", function () {
+      spyOn(Resource.prototype, "fetchImage").and.returnValue(
+        when.resolve(image)
+      );
+
+      var expectedCacheKey = ResourceCacheKey.getTextureCacheKey({
+        gltf: gltfWithTextures,
+        textureInfo: gltfWithTextures.materials[0].emissiveTexture,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+      var textureLoader = ResourceCache.loadTexture({
+        gltf: gltfWithTextures,
+        textureInfo: gltfWithTextures.materials[0].emissiveTexture,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+      var cacheEntry = ResourceCache.cacheEntries[expectedCacheKey];
+      expect(textureLoader.cacheKey).toBe(expectedCacheKey);
+      expect(cacheEntry.referenceCount).toBe(1);
+      expect(cacheEntry.keepResident).toBe(false);
+
+      // The existing resource is returned if the computed cache key is the same
+      expect(
+        ResourceCache.loadTexture({
+          gltf: gltfWithTextures,
+          textureInfo: gltfWithTextures.materials[0].emissiveTexture,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          supportedImageFormats: new SupportedImageFormats(),
+        })
+      ).toBe(textureLoader);
+
+      expect(cacheEntry.referenceCount).toBe(2);
+
+      return pollToPromise(function () {
+        textureLoader.process(scene.frameState);
+        return textureLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return textureLoader.promise.then(function (textureLoader) {
+          expect(textureLoader.texture).toBeDefined();
+        });
+      });
+    });
+
+    it("loadTexture throws if gltf is undefined", function () {
+      expect(function () {
+        ResourceCache.loadIndexBuffer({
+          gltf: undefined,
+          textureInfo: gltfWithTextures.materials[0].emissiveTexture,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          supportedImageFormats: new SupportedImageFormats(),
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadTexture throws if textureInfo is undefined", function () {
+      expect(function () {
+        ResourceCache.loadIndexBuffer({
+          gltf: gltfWithTextures,
+          textureInfo: undefined,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          supportedImageFormats: new SupportedImageFormats(),
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadTexture throws if gltfResource is undefined", function () {
+      expect(function () {
+        ResourceCache.loadIndexBuffer({
+          gltf: gltfWithTextures,
+          textureInfo: gltfWithTextures.materials[0].emissiveTexture,
+          gltfResource: undefined,
+          baseResource: gltfResource,
+          supportedImageFormats: new SupportedImageFormats(),
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadTexture throws if baseResource is undefined", function () {
+      expect(function () {
+        ResourceCache.loadIndexBuffer({
+          gltf: gltfWithTextures,
+          textureInfo: gltfWithTextures.materials[0].emissiveTexture,
+          gltfResource: gltfResource,
+          baseResource: undefined,
+          supportedImageFormats: new SupportedImageFormats(),
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadTexture throws if supportedImageFormats is undefined", function () {
+      expect(function () {
+        ResourceCache.loadIndexBuffer({
+          gltf: gltfWithTextures,
+          textureInfo: gltfWithTextures.materials[0].emissiveTexture,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          supportedImageFormats: undefined,
+        });
+      }).toThrowDeveloperError();
+    });
+  },
+  "WebGL"
+);

--- a/Specs/Scene/SupportedImageFormatsSpec.js
+++ b/Specs/Scene/SupportedImageFormatsSpec.js
@@ -1,0 +1,24 @@
+import { SupportedImageFormats } from "../../Source/Cesium.js";
+
+describe("Scene/SupportedImageFormats", function () {
+  it("constructs with options", function () {
+    var supportedImageFormats = new SupportedImageFormats({
+      webp: true,
+      s3tc: false,
+      pvrtc: true,
+      etc1: false,
+    });
+    expect(supportedImageFormats.webp).toBe(true);
+    expect(supportedImageFormats.s3tc).toBe(false);
+    expect(supportedImageFormats.pvrtc).toBe(true);
+    expect(supportedImageFormats.etc1).toBe(false);
+  });
+
+  it("constructs with default values", function () {
+    var supportedImageFormats = new SupportedImageFormats({});
+    expect(supportedImageFormats.webp).toBe(false);
+    expect(supportedImageFormats.s3tc).toBe(false);
+    expect(supportedImageFormats.pvrtc).toBe(false);
+    expect(supportedImageFormats.etc1).toBe(false);
+  });
+});

--- a/Specs/concatTypedArrays.js
+++ b/Specs/concatTypedArrays.js
@@ -12,10 +12,8 @@ export default function concatTypedArrays(arrays) {
   for (i = 0; i < length; ++i) {
     var array = arrays[i];
     var data = new Uint8Array(array.buffer, array.byteOffset, array.byteLength);
-    byteLength = data.length;
-    for (var j = 0; j < byteLength; ++j) {
-      buffer[byteOffset++] = data[j];
-    }
+    buffer.set(data, byteOffset);
+    byteOffset += data.length;
   }
   return buffer;
 }

--- a/Specs/dataUriToBuffer.js
+++ b/Specs/dataUriToBuffer.js
@@ -1,0 +1,9 @@
+export default function dataUriToBuffer(dataUri) {
+  var binaryString = atob(dataUri.split(",")[1]);
+  var length = binaryString.length;
+  var bytes = new Uint8Array(length);
+  for (var i = 0; i < length; ++i) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes;
+}

--- a/Specs/generateJsonBuffer.js
+++ b/Specs/generateJsonBuffer.js
@@ -1,0 +1,24 @@
+import { defaultValue } from "../Source/Cesium.js";
+
+export default function generateJsonBuffer(json, byteOffset, boundary) {
+  var i;
+  var jsonString = JSON.stringify(json);
+
+  byteOffset = defaultValue(byteOffset, 0);
+  boundary = defaultValue(boundary, 1);
+
+  var byteLength = jsonString.length;
+  var remainder = (byteOffset + byteLength) % boundary;
+  var padding = remainder === 0 ? 0 : boundary - remainder;
+
+  var buffer = new Uint8Array(byteLength + padding);
+
+  for (i = 0; i < byteLength; ++i) {
+    buffer[i] = jsonString.charCodeAt(i);
+  }
+  for (i = 0; i < padding; ++i) {
+    buffer[byteLength + i] = 32; // Whitespace
+  }
+
+  return buffer;
+}


### PR DESCRIPTION
This is a continuation of https://github.com/CesiumGS/cesium/pull/9452 that adds loaders for glTF resources. This includes:

* GltfBufferViewLoader - loads a buffer view from a buffer (Meshopt decode will go here)
* GltfDracoLoader - loads a Draco buffer view
* GltfVertexBufferLoader - loads a vertex buffer from a buffer view or from a draco buffer view
* GltfIndexBufferLoader - loads an index buffer from a buffer view or from a draco buffer view
* GltfJsonLoader - loads the JSON object for glTF or glb. Responsible for updating glTF 1.0 to 2.0 and setting defaults.
* GltfTextureLoader - loads a texture
* GltfImageLoader - loads an image (KTX2 decode will go here)

<img width="696" alt="112939950-5cea1300-90fa-11eb-9dd7-f5b819e082ea" src="https://user-images.githubusercontent.com/915398/114327478-34551680-9b07-11eb-9d65-c71e43f177b3.png">

A future PR will actually parse a glTF, load resources, and build a Model. A lot of that code is ready but it would be too much to add to an already big PR. The feature metadata loader will also be in a separate PR.

This is targeting the `3d-tiles-next` branch.

