### PR TITLE
Feature metadata loader

### DIFF
--- a/Source/Scene/GltfFeatureMetadataLoader.js
+++ b/Source/Scene/GltfFeatureMetadataLoader.js
@@ -1,0 +1,353 @@
+import Check from "../Core/Check.js";
+import defaultValue from "../Core/defaultValue.js";
+import defined from "../Core/defined.js";
+import when from "../ThirdParty/when.js";
+import FeatureMetadata from "./FeatureMetadata.js";
+import ResourceCache from "./ResourceCache.js";
+import ResourceLoader from "./ResourceLoader.js";
+import ResourceLoaderState from "./ResourceLoaderState.js";
+
+/**
+ * Loads glTF feature metadata.
+ * <p>
+ * Implements the {@link ResourceLoader} interface.
+ * </p>
+ *
+ * @alias GltfFeatureMetadataLoader
+ * @constructor
+ * @augments ResourceLoader
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {Object} options.gltf The glTF JSON.
+ * @param {String} options.extension The feature metadata extension object.
+ * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
+ * @param {String} [options.cacheKey] The cache key of the resource.
+ * @param {Boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
+ *
+ * @private
+ */
+export default function GltfFeatureMetadataLoader(options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  var gltf = options.gltf;
+  var extension = options.extension;
+  var gltfResource = options.gltfResource;
+  var baseResource = options.baseResource;
+  var supportedImageFormats = options.supportedImageFormats;
+  var cacheKey = options.cacheKey;
+  var asynchronous = defaultValue(options.asynchronous, true);
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.gltf", gltf);
+  Check.typeOf.object("options.extension", extension);
+  Check.typeOf.object("options.gltfResource", gltfResource);
+  Check.typeOf.object("options.baseResource", baseResource);
+  Check.typeOf.object("options.supportedImageFormats", supportedImageFormats);
+  //>>includeEnd('debug');
+
+  this._gltfResource = gltfResource;
+  this._baseResource = baseResource;
+  this._gltf = gltf;
+  this._extension = extension;
+  this._supportedImageFormats = supportedImageFormats;
+  this._cacheKey = cacheKey;
+  this._asynchronous = asynchronous;
+  this._bufferViewLoaders = [];
+  this._textureLoaders = [];
+  this._schemaLoader = undefined;
+  this._featureMetadata = undefined;
+  this._state = ResourceLoaderState.UNLOADED;
+  this._promise = when.defer();
+}
+
+if (defined(Object.create)) {
+  GltfFeatureMetadataLoader.prototype = Object.create(ResourceLoader.prototype);
+  GltfFeatureMetadataLoader.prototype.constructor = GltfFeatureMetadataLoader;
+}
+
+Object.defineProperties(GltfFeatureMetadataLoader.prototype, {
+  /**
+   * A promise that resolves to the resource when the resource is ready.
+   *
+   * @memberof GltfFeatureMetadataLoader.prototype
+   *
+   * @type {Promise.<GltfFeatureMetadataLoader>}
+   * @readonly
+   */
+  promise: {
+    get: function () {
+      return this._promise.promise;
+    },
+  },
+  /**
+   * The cache key of the resource.
+   *
+   * @memberof GltfFeatureMetadataLoader.prototype
+   *
+   * @type {String}
+   * @readonly
+   */
+  cacheKey: {
+    get: function () {
+      return this._cacheKey;
+    },
+  },
+  /**
+   * Feature metadata.
+   *
+   * @memberof GltfFeatureMetadataLoader.prototype
+   *
+   * @type {FeatureMetadata}
+   * @readonly
+   */
+  featureMetadata: {
+    get: function () {
+      return this._featureMetadata;
+    },
+  },
+});
+
+/**
+ * Loads the resource.
+ */
+GltfFeatureMetadataLoader.prototype.load = function () {
+  var bufferViewsPromise = loadBufferViews(this);
+  var texturesPromise = loadTextures(this);
+  var schemaPromise = loadSchema(this);
+
+  this._gltf = undefined; // No longer need to hold onto the glTF
+  this._state = ResourceLoaderState.LOADING;
+
+  var that = this;
+
+  when
+    .all([bufferViewsPromise, texturesPromise, schemaPromise])
+    .then(function (results) {
+      if (that.isDestroyed()) {
+        return;
+      }
+      var bufferViews = results[0];
+      var textures = results[1];
+      var schema = results[2];
+
+      that._featureMetadata = new FeatureMetadata({
+        extension: that._extension,
+        schema: schema,
+        bufferViews: bufferViews,
+        textures: textures,
+      });
+      that._state = ResourceLoaderState.READY;
+      that._promise.resolve(that);
+    })
+    .otherwise(function (error) {
+      that.unload();
+      that._state = ResourceLoaderState.FAILED;
+      var errorMessage = "Failed to load feature metadata";
+      that._promise.reject(that.getError(errorMessage, error));
+    });
+};
+
+function loadBufferViews(featureMetadataLoader) {
+  var extension = featureMetadataLoader._extension;
+  var featureTables = extension.featureTables;
+
+  // Gather the used buffer views
+  var bufferViewIds = {};
+  if (defined(featureTables)) {
+    for (var featureTableId in featureTables) {
+      if (featureTables.hasOwnProperty(featureTableId)) {
+        var featureTable = featureTables[featureTableId];
+        var properties = featureTable.properties;
+        if (defined(properties)) {
+          for (var propertyId in properties) {
+            if (properties.hasOwnProperty(propertyId)) {
+              var property = properties[propertyId];
+              var bufferView = property.bufferView;
+              var arrayOffsetBufferView = property.arrayOffsetBufferView;
+              var stringOffsetBufferView = property.stringOffsetBufferView;
+              if (defined(bufferView)) {
+                bufferViewIds[bufferView] = true;
+              }
+              if (defined(arrayOffsetBufferView)) {
+                bufferViewIds[arrayOffsetBufferView] = true;
+              }
+              if (defined(stringOffsetBufferView)) {
+                bufferViewIds[stringOffsetBufferView] = true;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Load the buffer views
+  var bufferViewPromises = [];
+  var bufferViewLoaders = {};
+  for (var bufferViewId in bufferViewIds) {
+    if (bufferViewIds.hasOwnProperty(bufferViewId)) {
+      var bufferViewLoader = ResourceCache.loadBufferView({
+        gltf: featureMetadataLoader._gltf,
+        bufferViewId: parseInt(bufferViewId),
+        gltfResource: featureMetadataLoader._gltfResource,
+        baseResource: featureMetadataLoader._baseResource,
+        keepResident: false,
+      });
+      bufferViewPromises.push(bufferViewLoader.promise);
+      featureMetadataLoader._bufferViewLoaders.push(bufferViewLoader);
+      bufferViewLoaders[bufferViewId] = bufferViewLoader;
+    }
+  }
+
+  // Return a promise to a map of buffer view IDs to typed arrays
+  return when.all(bufferViewPromises).then(function () {
+    var bufferViews = {};
+    for (var bufferViewId in bufferViewLoaders) {
+      if (bufferViewLoaders.hasOwnProperty(bufferViewId)) {
+        var bufferViewLoader = bufferViewLoaders[bufferViewId];
+        bufferViews[bufferViewId] = bufferViewLoader.typedArray;
+      }
+    }
+    return bufferViews;
+  });
+}
+
+function loadTextures(featureMetadataLoader) {
+  var extension = featureMetadataLoader._extension;
+  var featureTextures = extension.featureTextures;
+
+  var gltf = featureMetadataLoader._gltf;
+  var gltfResource = featureMetadataLoader._gltfResource;
+  var baseResource = featureMetadataLoader._baseResource;
+  var supportedImageFormats = featureMetadataLoader._supportedImageFormats;
+  var asynchronous = featureMetadataLoader._asynchronous;
+
+  // Gather the used textures
+  var textureIds = {};
+  if (defined(featureTextures)) {
+    for (var featureTextureId in featureTextures) {
+      if (featureTextures.hasOwnProperty(featureTextureId)) {
+        var featureTexture = featureTextures[featureTextureId];
+        var properties = featureTexture.properties;
+        if (defined(properties)) {
+          for (var propertyId in properties) {
+            if (properties.hasOwnProperty(propertyId)) {
+              var property = properties[propertyId];
+              var textureInfo = property.texture;
+              textureIds[textureInfo.index] = textureInfo;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Load the textures
+  var texturePromises = [];
+  var textureLoaders = {};
+  for (var textureId in textureIds) {
+    if (textureIds.hasOwnProperty(textureId)) {
+      var textureLoader = ResourceCache.loadTexture({
+        gltf: gltf,
+        textureInfo: textureIds[textureId],
+        gltfResource: gltfResource,
+        baseResource: baseResource,
+        supportedImageFormats: supportedImageFormats,
+        keepResident: false,
+        asynchronous: asynchronous,
+      });
+      texturePromises.push(textureLoader.promise);
+      featureMetadataLoader._textureLoaders.push(textureLoader);
+      textureLoaders[textureId] = textureLoader;
+    }
+  }
+
+  // Return a promise to a map of texture IDs to Texture objects
+  return when.all(texturePromises).then(function () {
+    var textures = {};
+    for (var textureId in textureLoaders) {
+      if (textureLoaders.hasOwnProperty(textureId)) {
+        var textureLoader = textureLoaders[textureId];
+        textures[textureId] = textureLoader.texture;
+      }
+    }
+    return textures;
+  });
+}
+
+function loadSchema(featureMetadataLoader) {
+  var extension = featureMetadataLoader._extension;
+
+  var schemaLoader;
+  if (defined(extension.schemaUri)) {
+    var resource = featureMetadataLoader._baseResource.getDerivedResource({
+      url: extension.schemaUri,
+    });
+    schemaLoader = ResourceCache.loadSchema({
+      resource: resource,
+      keepResident: false,
+    });
+  } else {
+    schemaLoader = ResourceCache.loadSchema({
+      schema: extension.schema,
+      keepResident: false,
+    });
+  }
+
+  featureMetadataLoader._schemaLoader = schemaLoader;
+
+  return schemaLoader.promise.then(function (schemaLoader) {
+    return schemaLoader.schema;
+  });
+}
+
+/**
+ * Processes the resource until it becomes ready.
+ *
+ * @param {FrameState} frameState The frame state.
+ */
+GltfFeatureMetadataLoader.prototype.process = function (frameState) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("frameState", frameState);
+  //>>includeEnd('debug');
+
+  if (this._state !== ResourceLoaderState.LOADING) {
+    return;
+  }
+
+  var textureLoaders = this._textureLoaders;
+  var textureLoadersLength = textureLoaders.length;
+
+  for (var i = 0; i < textureLoadersLength; ++i) {
+    var textureLoader = textureLoaders[i];
+    textureLoader.process(frameState);
+  }
+};
+
+/**
+ * Unloads the resource.
+ */
+GltfFeatureMetadataLoader.prototype.unload = function () {
+  var i;
+  var bufferViewLoaders = this._bufferViewLoaders;
+  var bufferViewLoadersLength = bufferViewLoaders.length;
+  for (i = 0; i < bufferViewLoadersLength; ++i) {
+    ResourceCache.unload(bufferViewLoaders[i]);
+  }
+  this._bufferViewLoaders = [];
+
+  var textureLoaders = this._textureLoaders;
+  var textureLoadersLength = textureLoaders.length;
+  for (i = 0; i < textureLoadersLength; ++i) {
+    ResourceCache.unload(textureLoaders[i]);
+  }
+  this._textureLoaders = [];
+
+  if (defined(this._schemaLoader)) {
+    ResourceCache.unload(this._schemaLoader);
+  }
+  this._schemaLoader = undefined;
+
+  this._featureMetadata = undefined;
+};

--- a/Specs/Scene/GltfFeatureMetadataLoaderSpec.js
+++ b/Specs/Scene/GltfFeatureMetadataLoaderSpec.js
@@ -1,0 +1,485 @@
+import {
+  clone,
+  GltfBufferViewLoader,
+  GltfFeatureMetadataLoader,
+  GltfTextureLoader,
+  MetadataSchemaLoader,
+  Resource,
+  ResourceCache,
+  ResourceLoaderState,
+  SupportedImageFormats,
+  when,
+} from "../../Source/Cesium.js";
+import createScene from "../createScene.js";
+import MetadataTester from "../MetadataTester.js";
+import pollToPromise from "../pollToPromise.js";
+
+describe(
+  "Scene/GltfFeatureMetadataLoader",
+  function () {
+    var image = new Image();
+    image.src =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII=";
+
+    var gltfUri = "https://example.com/model.glb";
+    var gltfResource = new Resource({
+      url: gltfUri,
+    });
+
+    var schemaJson = {
+      classes: {
+        building: {
+          properties: {
+            name: {
+              type: "STRING",
+            },
+            height: {
+              type: "FLOAT64",
+            },
+          },
+        },
+        tree: {
+          properties: {
+            species: {
+              type: "ARRAY",
+              componentType: "STRING",
+            },
+          },
+        },
+        map: {
+          properties: {
+            color: {
+              type: "ARRAY",
+              componentType: "UINT8",
+              componentCount: 3,
+            },
+            intensity: {
+              type: "UINT8",
+            },
+          },
+        },
+        ortho: {
+          properties: {
+            vegetation: {
+              type: "UINT8",
+              normalized: true,
+            },
+          },
+        },
+      },
+    };
+
+    var results = MetadataTester.createGltf({
+      schema: schemaJson,
+      featureTables: {
+        buildings: {
+          class: "building",
+          properties: {
+            name: ["House", "Hospital"],
+            height: [10.0, 20.0],
+          },
+        },
+        trees: {
+          class: "tree",
+          properties: {
+            species: [["Sparrow", "Squirrel"], ["Crow"]],
+          },
+        },
+      },
+      images: [
+        {
+          uri: "map.png",
+        },
+        {
+          uri: "ortho.png",
+        },
+      ],
+      textures: [
+        {
+          source: 0,
+        },
+        {
+          source: 1,
+        },
+      ],
+      featureTextures: {
+        mapTexture: {
+          class: "map",
+          properties: {
+            color: {
+              channels: "rgb",
+              texture: {
+                index: 0,
+                texCoord: 0,
+              },
+            },
+            intensity: {
+              channels: "a",
+              texture: {
+                index: 0,
+                texCoord: 0,
+              },
+            },
+          },
+        },
+        orthoTexture: {
+          class: "ortho",
+          properties: {
+            vegetation: {
+              channels: "r",
+              texture: {
+                index: 1,
+                texCoord: 1,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    var gltf = results.gltf;
+    var extension = gltf.extensions.EXT_feature_metadata;
+    var buffer = results.buffer.buffer;
+
+    var gltfSchemaUri = clone(gltf, true);
+    var extensionSchemaUri = gltfSchemaUri.extensions.EXT_feature_metadata;
+    extensionSchemaUri.schemaUri = "schema.json";
+    delete extensionSchemaUri.schema;
+
+    var scene;
+
+    beforeAll(function () {
+      scene = createScene();
+    });
+
+    afterAll(function () {
+      scene.destroyForSpecs();
+    });
+
+    afterEach(function () {
+      ResourceCache.clearForSpecs();
+    });
+
+    it("throws if gltf is undefined", function () {
+      expect(function () {
+        return new GltfFeatureMetadataLoader({
+          gltf: undefined,
+          extension: extension,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          supportedImageFormats: new SupportedImageFormats(),
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("throws if extension is undefined", function () {
+      expect(function () {
+        return new GltfFeatureMetadataLoader({
+          gltf: gltf,
+          extension: undefined,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          supportedImageFormats: new SupportedImageFormats(),
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("throws if gltfResource is undefined", function () {
+      expect(function () {
+        return new GltfFeatureMetadataLoader({
+          gltf: gltf,
+          extension: extension,
+          gltfResource: undefined,
+          baseResource: gltfResource,
+          supportedImageFormats: new SupportedImageFormats(),
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("throws if baseResource is undefined", function () {
+      expect(function () {
+        return new GltfFeatureMetadataLoader({
+          gltf: gltf,
+          extension: extension,
+          gltfResource: gltfResource,
+          baseResource: undefined,
+          supportedImageFormats: new SupportedImageFormats(),
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("throws if gltf is undefined", function () {
+      expect(function () {
+        return new GltfFeatureMetadataLoader({
+          gltf: gltf,
+          extension: extension,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          supportedImageFormats: undefined,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("rejects promise if buffer view fails to load", function () {
+      var error = new Error("404 Not Found");
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.reject(error)
+      );
+
+      spyOn(Resource.prototype, "fetchImage").and.returnValue(
+        when.resolve(image)
+      );
+
+      var featureMetadataLoader = new GltfFeatureMetadataLoader({
+        gltf: gltf,
+        extension: extension,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+
+      featureMetadataLoader.load();
+
+      return featureMetadataLoader.promise
+        .then(function (featureMetadataLoader) {
+          fail();
+        })
+        .otherwise(function (runtimeError) {
+          expect(runtimeError.message).toBe(
+            "Failed to load feature metadata\nFailed to load buffer view\nFailed to load external buffer: https://example.com/external.bin\n404 Not Found"
+          );
+        });
+    });
+
+    it("rejects promise if texture fails to load", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(buffer)
+      );
+
+      var error = new Error("404 Not Found");
+      spyOn(Resource.prototype, "fetchImage").and.returnValue(
+        when.reject(error)
+      );
+
+      var featureMetadataLoader = new GltfFeatureMetadataLoader({
+        gltf: gltf,
+        extension: extension,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+
+      featureMetadataLoader.load();
+
+      return featureMetadataLoader.promise
+        .then(function (featureMetadataLoader) {
+          fail();
+        })
+        .otherwise(function (runtimeError) {
+          expect(runtimeError.message).toBe(
+            "Failed to load feature metadata\nFailed to load texture\nFailed to load image:map.png\n404 Not Found"
+          );
+        });
+    });
+
+    it("rejects promise if external schema fails to load", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(buffer)
+      );
+
+      spyOn(Resource.prototype, "fetchImage").and.returnValue(
+        when.resolve(image)
+      );
+
+      var error = new Error("404 Not Found");
+      spyOn(Resource.prototype, "fetchJson").and.returnValue(
+        when.reject(error)
+      );
+
+      var featureMetadataLoader = new GltfFeatureMetadataLoader({
+        gltf: gltfSchemaUri,
+        extension: extensionSchemaUri,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+
+      featureMetadataLoader.load();
+
+      return featureMetadataLoader.promise
+        .then(function (featureMetadataLoader) {
+          fail();
+        })
+        .otherwise(function (runtimeError) {
+          expect(runtimeError.message).toBe(
+            "Failed to load feature metadata\nFailed to load schema: https://example.com/schema.json\n404 Not Found"
+          );
+        });
+    });
+
+    it("loads feature metadata", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(buffer)
+      );
+
+      spyOn(Resource.prototype, "fetchImage").and.returnValue(
+        when.resolve(image)
+      );
+
+      var featureMetadataLoader = new GltfFeatureMetadataLoader({
+        gltf: gltf,
+        extension: extension,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+
+      featureMetadataLoader.load();
+
+      return pollToPromise(function () {
+        featureMetadataLoader.process(scene.frameState);
+        return featureMetadataLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return featureMetadataLoader.promise.then(function (
+          featureMetadataLoader
+        ) {
+          featureMetadataLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
+          var featureMetadata = featureMetadataLoader.featureMetadata;
+          var buildingsTable = featureMetadata.getFeatureTable("buildings");
+          var treesTable = featureMetadata.getFeatureTable("trees");
+          var mapTexture = featureMetadata.getFeatureTexture("mapTexture");
+          var orthoTexture = featureMetadata.getFeatureTexture("orthoTexture");
+
+          expect(buildingsTable.getProperty(0, "name")).toBe("House");
+          expect(buildingsTable.getProperty(1, "name")).toBe("Hospital");
+          expect(treesTable.getProperty(0, "species")).toEqual([
+            "Sparrow",
+            "Squirrel",
+          ]);
+          expect(treesTable.getProperty(1, "species")).toEqual(["Crow"]);
+
+          var colorProperty = mapTexture._properties.color;
+          var intensityProperty = mapTexture._properties.intensity;
+
+          expect(colorProperty._texture.width).toBe(1);
+          expect(colorProperty._texture.height).toBe(1);
+          expect(colorProperty._texture).toBe(intensityProperty._texture);
+
+          var vegetationProperty = orthoTexture._properties.vegetation;
+          expect(colorProperty._texture.width).toBe(1);
+          expect(colorProperty._texture.height).toBe(1);
+          expect(vegetationProperty._texture).not.toBe(colorProperty._texture);
+
+          expect(Object.keys(featureMetadata.schema.classes).sort()).toEqual([
+            "building",
+            "map",
+            "ortho",
+            "tree",
+          ]);
+        });
+      });
+    });
+
+    it("loads feature metadata with external schema", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(buffer)
+      );
+
+      spyOn(Resource.prototype, "fetchImage").and.returnValue(
+        when.resolve(image)
+      );
+
+      spyOn(Resource.prototype, "fetchJson").and.returnValue(
+        when.resolve(schemaJson)
+      );
+
+      var featureMetadataLoader = new GltfFeatureMetadataLoader({
+        gltf: gltfSchemaUri,
+        extension: extensionSchemaUri,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+
+      featureMetadataLoader.load();
+
+      return pollToPromise(function () {
+        featureMetadataLoader.process(scene.frameState);
+        return featureMetadataLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return featureMetadataLoader.promise.then(function (
+          featureMetadataLoader
+        ) {
+          var featureMetadata = featureMetadataLoader.featureMetadata;
+          expect(Object.keys(featureMetadata.schema.classes).sort()).toEqual([
+            "building",
+            "map",
+            "ortho",
+            "tree",
+          ]);
+        });
+      });
+    });
+
+    it("destroys feature metadata", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(buffer)
+      );
+
+      spyOn(Resource.prototype, "fetchImage").and.returnValue(
+        when.resolve(image)
+      );
+
+      spyOn(Resource.prototype, "fetchJson").and.returnValue(
+        when.resolve(schemaJson)
+      );
+
+      var destroyBufferView = spyOn(
+        GltfBufferViewLoader.prototype,
+        "destroy"
+      ).and.callThrough();
+
+      var destroyTexture = spyOn(
+        GltfTextureLoader.prototype,
+        "destroy"
+      ).and.callThrough();
+
+      var destroySchema = spyOn(
+        MetadataSchemaLoader.prototype,
+        "destroy"
+      ).and.callThrough();
+
+      var featureMetadataLoader = new GltfFeatureMetadataLoader({
+        gltf: gltf,
+        extension: extension,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+
+      featureMetadataLoader.load();
+
+      return pollToPromise(function () {
+        featureMetadataLoader.process(scene.frameState);
+        return featureMetadataLoader._state === ResourceLoaderState.READY;
+      }).then(function () {
+        return featureMetadataLoader.promise.then(function (
+          featureMetadataLoader
+        ) {
+          expect(featureMetadataLoader.featureMetadata).toBeDefined();
+          expect(featureMetadataLoader.isDestroyed()).toBe(false);
+
+          featureMetadataLoader.destroy();
+
+          expect(featureMetadataLoader.featureMetadata).not.toBeDefined();
+          expect(featureMetadataLoader.isDestroyed()).toBe(true);
+
+          expect(destroyBufferView.calls.count()).toBe(6);
+          expect(destroyTexture.calls.count()).toBe(2);
+          expect(destroySchema.calls.count()).toBe(1);
+        });
+      });
+    });
+  },
+  "WebGL"
+);


### PR DESCRIPTION
Follow up to https://github.com/CesiumGS/cesium/pull/9481

Adds a loader for the `EXT_feature_metadata` extension. `GltfFeatureMetadataLoader` loads textures, buffer views, and schemas from the cache but does not itself need to go in the cache, so there are no changes to `ResourceCache` and `ResourceCacheKey`.

<img width="696" alt="114327478-34551680-9b07-11eb-9d65-c71e43f177b3" src="https://user-images.githubusercontent.com/915398/114467175-848bb180-9bb7-11eb-8f9d-04834e4f944a.png">
