### PR TITLE
Static configuration options for EntityView.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -159,6 +159,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
   - [Jonathan Nogueira](https://github.com/LuminousPath)
 - [Palantir Technologies, Inc.](https://palantir.com)
   - [Joey Rafidi](https://github.com/jrafidi)
+  - [Dan Cervelli](https://github.com/dcervelli)
 - [Geoplex GIS GmbH](https://www.geoplex.de)
   - [Leonard Holst](https://github.com/LHolst)
 


### PR DESCRIPTION
Extract constants as editable static variables so users can tune `EntityView` behavior. In particular, this allows users to:

1. set a larger velocity approximate time delta when working with Entities that lack enough precision with 0.001s time steps,
2. change the multiplier for determining if an object is in "deep space" (this is likely what was being asked for in #8426).

I think a better long-term approach may be to allow entities to provide velocity information and/or specify the kind of camera reference frame they prefer. However, this seems like a reasonable, minimal (backwards compatible) change.

This provides a workaround for #9484.


