### PR TITLE
Load glTF/glb as typed array

### DIFF
--- a/Source/Scene/GltfBufferViewLoader.js
+++ b/Source/Scene/GltfBufferViewLoader.js
@@ -19,7 +19,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {ResourceCache} options.resourceCache The {@link ResourceCache} (to avoid circular dependencies).
  * @param {Object} options.gltf The glTF JSON.
  * @param {Number} options.bufferViewId The buffer view ID.
- * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {String} [options.cacheKey] The cache key of the resource.
  *

--- a/Source/Scene/GltfDracoLoader.js
+++ b/Source/Scene/GltfDracoLoader.js
@@ -20,7 +20,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {ResourceCache} options.resourceCache The {@link ResourceCache} (to avoid circular dependencies).
  * @param {Object} options.gltf The glTF JSON.
  * @param {Object} options.draco The Draco extension object.
- * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {String} [options.cacheKey] The cache key of the resource.
  *

--- a/Source/Scene/GltfFeatureMetadataLoader.js
+++ b/Source/Scene/GltfFeatureMetadataLoader.js
@@ -20,7 +20,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {Object} options Object with the following properties:
  * @param {Object} options.gltf The glTF JSON.
  * @param {String} options.extension The feature metadata extension object.
- * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
  * @param {String} [options.cacheKey] The cache key of the resource.

--- a/Source/Scene/GltfImageLoader.js
+++ b/Source/Scene/GltfImageLoader.js
@@ -24,7 +24,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {ResourceCache} options.resourceCache The {@link ResourceCache} (to avoid circular dependencies).
  * @param {Object} options.gltf The glTF JSON.
  * @param {Number} options.imageId The image ID.
- * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
  * @param {String} [options.cacheKey] The cache key of the resource.

--- a/Source/Scene/GltfIndexBufferLoader.js
+++ b/Source/Scene/GltfIndexBufferLoader.js
@@ -23,7 +23,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {ResourceCache} options.resourceCache The {@link ResourceCache} (to avoid circular dependencies).
  * @param {Object} options.gltf The glTF JSON.
  * @param {Number} options.accessorId The accessor ID corresponding to the index buffer.
- * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {Object} [options.draco] The Draco extension object.
  * @param {String} [options.cacheKey] The cache key of the resource.

--- a/Source/Scene/GltfTextureLoader.js
+++ b/Source/Scene/GltfTextureLoader.js
@@ -25,7 +25,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {ResourceCache} options.resourceCache The {@link ResourceCache} (to avoid circular dependencies).
  * @param {Object} options.gltf The glTF JSON.
  * @param {Object} options.textureInfo The texture info object.
- * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
  * @param {String} [options.cacheKey] The cache key of the resource.

--- a/Source/Scene/GltfVertexBufferLoader.js
+++ b/Source/Scene/GltfVertexBufferLoader.js
@@ -22,7 +22,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {Object} options Object with the following properties:
  * @param {ResourceCache} options.resourceCache The {@link ResourceCache} (to avoid circular dependencies).
  * @param {Object} options.gltf The glTF JSON.
- * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {Number} [options.bufferViewId] The bufferView ID corresponding to the vertex buffer.
  * @param {Object} [options.draco] The Draco extension object.

--- a/Source/Scene/ResourceCache.js
+++ b/Source/Scene/ResourceCache.js
@@ -278,8 +278,9 @@ ResourceCache.loadExternalBuffer = function (options) {
  * Loads a glTF JSON from the cache.
  *
  * @param {Object} options Object with the following properties:
- * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {Uint8Array} [options.typedArray] The typed array containing the glTF contents.
  * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
  *
  * @returns {GltfJsonLoader} The glTF JSON.
@@ -288,6 +289,7 @@ ResourceCache.loadGltf = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   var gltfResource = options.gltfResource;
   var baseResource = options.baseResource;
+  var typedArray = options.typedArray;
   var keepResident = defaultValue(options.keepResident, false);
 
   //>>includeStart('debug', pragmas.debug);
@@ -308,6 +310,7 @@ ResourceCache.loadGltf = function (options) {
     resourceCache: ResourceCache,
     gltfResource: gltfResource,
     baseResource: baseResource,
+    typedArray: typedArray,
     cacheKey: cacheKey,
     keepResident: keepResident,
   });
@@ -326,7 +329,7 @@ ResourceCache.loadGltf = function (options) {
  * @param {Object} options Object with the following properties:
  * @param {Object} options.gltf The glTF JSON.
  * @param {Number} options.bufferViewId The bufferView ID.
- * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
  *
@@ -382,7 +385,7 @@ ResourceCache.loadBufferView = function (options) {
  * @param {Object} options Object with the following properties:
  * @param {Object} options.gltf The glTF JSON.
  * @param {Object} options.draco The Draco extension object.
- * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
  *
@@ -437,7 +440,7 @@ ResourceCache.loadDraco = function (options) {
  *
  * @param {Object} options Object with the following properties:
  * @param {Object} options.gltf The glTF JSON.
- * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {Number} [options.bufferViewId] The bufferView ID corresponding to the vertex buffer.
  * @param {Object} [options.draco] The Draco extension object.
@@ -531,7 +534,7 @@ ResourceCache.loadVertexBuffer = function (options) {
  * @param {Object} options Object with the following properties:
  * @param {Object} options.gltf The glTF JSON.
  * @param {Number} options.accessorId The accessor ID corresponding to the index buffer.
- * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {Object} [options.draco] The Draco extension object.
  * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
@@ -594,7 +597,7 @@ ResourceCache.loadIndexBuffer = function (options) {
  * @param {Object} options Object with the following properties:
  * @param {Object} options.gltf The glTF JSON.
  * @param {Number} options.imageId The image ID.
- * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
  * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
@@ -655,7 +658,7 @@ ResourceCache.loadImage = function (options) {
  * @param {Object} options Object with the following properties:
  * @param {Object} options.gltf The glTF JSON.
  * @param {Object} options.textureInfo The texture info object.
- * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
  * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.

--- a/Source/Scene/ResourceCacheKey.js
+++ b/Source/Scene/ResourceCacheKey.js
@@ -203,7 +203,7 @@ ResourceCacheKey.getEmbeddedBufferCacheKey = function (options) {
  * Gets the glTF cache key.
  *
  * @param {Object} options Object with the following properties:
- * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  *
  * @returns {String} The glTF cache key.
  */
@@ -224,7 +224,7 @@ ResourceCacheKey.getGltfCacheKey = function (options) {
  * @param {Object} options Object with the following properties:
  * @param {Object} options.gltf The glTF JSON.
  * @param {Number} options.bufferViewId The bufferView ID.
- * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  *
  * @returns {String} The buffer view cache key.
@@ -265,7 +265,7 @@ ResourceCacheKey.getBufferViewCacheKey = function (options) {
  * @param {Object} options Object with the following properties:
  * @param {Object} options.gltf The glTF JSON.
  * @param {Object} options.draco The Draco extension object.
- * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  *
  * @returns {String} The Draco cache key.
@@ -292,7 +292,7 @@ ResourceCacheKey.getDracoCacheKey = function (options) {
  *
  * @param {Object} options Object with the following properties:
  * @param {Object} options.gltf The glTF JSON.
- * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {Number} [options.bufferViewId] The bufferView ID corresponding to the vertex buffer.
  * @param {Object} [options.draco] The Draco extension object.
@@ -376,7 +376,7 @@ ResourceCacheKey.getVertexBufferCacheKey = function (options) {
  * @param {Object} options Object with the following properties:
  * @param {Object} options.gltf The glTF JSON.
  * @param {Number} options.accessorId The accessor ID corresponding to the index buffer.
- * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {Object} [options.draco] The Draco extension object.
  *
@@ -431,7 +431,7 @@ ResourceCacheKey.getIndexBufferCacheKey = function (options) {
  * @param {Object} options Object with the following properties:
  * @param {Object} options.gltf The glTF JSON.
  * @param {Number} options.imageId The image ID.
- * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
  *
@@ -470,7 +470,7 @@ ResourceCacheKey.getImageCacheKey = function (options) {
  * @param {Object} options Object with the following properties:
  * @param {Object} options.gltf The glTF JSON.
  * @param {Object} options.textureInfo The texture info object.
- * @param {Resource} options.gltfResource The {@link Resource} pointing to the glTF file.
+ * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
  *

--- a/Specs/Scene/GltfJsonLoaderSpec.js
+++ b/Specs/Scene/GltfJsonLoaderSpec.js
@@ -584,6 +584,30 @@ describe("Scene/GltfJsonLoader", function () {
     });
   });
 
+  it("loads typed array", function () {
+    var gltf2Binary = clone(gltf2, true);
+    delete gltf2Binary.buffers[0].uri;
+
+    var gltf2BinaryUpdated = clone(gltf2Updated, true);
+    delete gltf2BinaryUpdated.buffers[0].uri;
+
+    var typedArray = createGlb2(gltf2Binary);
+
+    var gltfJsonLoader = new GltfJsonLoader({
+      resourceCache: ResourceCache,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+      typedArray: typedArray,
+    });
+
+    gltfJsonLoader.load();
+
+    return gltfJsonLoader.promise.then(function (gltfJsonLoader) {
+      var gltf = gltfJsonLoader.gltf;
+      expect(gltf).toEqual(gltf2BinaryUpdated);
+    });
+  });
+
   it("destroys", function () {
     var gltf2Binary = clone(gltf2, true);
     delete gltf2Binary.buffers[0].uri;
@@ -659,6 +683,33 @@ describe("Scene/GltfJsonLoader", function () {
       resourceCache: ResourceCache,
       gltfResource: gltfResource,
       baseResource: gltfResource,
+    });
+
+    expect(gltfJsonLoader.gltf).not.toBeDefined();
+
+    gltfJsonLoader.load();
+    gltfJsonLoader.destroy();
+
+    deferredPromise.resolve(buffer);
+
+    expect(gltfJsonLoader.gltf).not.toBeDefined();
+    expect(gltfJsonLoader.isDestroyed()).toBe(true);
+  });
+
+  it("handles destroy before typed array is processed", function () {
+    var typedArray = generateJsonBuffer(gltf2);
+
+    var buffer = new Float32Array([0.0, 0.0, 0.0]).buffer;
+    var deferredPromise = when.defer();
+    spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+      deferredPromise.promise
+    );
+
+    var gltfJsonLoader = new GltfJsonLoader({
+      resourceCache: ResourceCache,
+      gltfResource: gltfResource,
+      baseResource: gltfResource,
+      typedArray: typedArray,
     });
 
     expect(gltfJsonLoader.gltf).not.toBeDefined();


### PR DESCRIPTION
Adds the option of loading a glTF/glb from a typed array instead of from a uri.

This builds on top of the `GltfJsonLoader` in https://github.com/CesiumGS/cesium/pull/9481.

Note that `gltfResource` and `typedArray` can both be provided together. This is because `gltfResource` is still needed to determine the cache key of embedded resources. `gltfResource` now means the resource containing the glTF instead of just the resource pointing to the glTF file. This allows `gltfResource` to be the glTF, glb, b3dm, i3dm, or cmpt file for cache key purposes.

A future PR will add `GltfLoader` which can take either a typed array or uri. It explains `gltfResource` in more detail.

```
 * @param {Resource} options.gltfResource The {@link Resource} containing the glTF. This is often the path of the .gltf or .glb file, but may also be the path of the .b3dm, .i3dm, or .cmpt file containing the embedded glb. .cmpt resources should have a URI fragment indicating the index of the content to which the glb belongs, e.g. http://example.com/tile.cmpt#index=2
```