### PR TITLE
Updates to resource loaders

### DIFF
--- a/Source/Scene/BufferLoader.js
+++ b/Source/Scene/BufferLoader.js
@@ -118,6 +118,9 @@ function loadExternalBuffer(bufferLoader) {
       bufferLoader._promise.resolve(bufferLoader);
     })
     .otherwise(function (error) {
+      if (bufferLoader.isDestroyed()) {
+        return;
+      }
       bufferLoader._state = ResourceLoaderState.FAILED;
       var errorMessage = "Failed to load external buffer: " + resource.url;
       bufferLoader._promise.reject(bufferLoader.getError(errorMessage, error));

--- a/Source/Scene/GltfBufferViewLoader.js
+++ b/Source/Scene/GltfBufferViewLoader.js
@@ -135,6 +135,9 @@ GltfBufferViewLoader.prototype.load = function () {
       that._promise.resolve(that);
     })
     .otherwise(function (error) {
+      if (that.isDestroyed()) {
+        return;
+      }
       that.unload();
       that._state = ResourceLoaderState.FAILED;
       var errorMessage = "Failed to load buffer view";

--- a/Source/Scene/GltfDracoLoader.js
+++ b/Source/Scene/GltfDracoLoader.js
@@ -129,8 +129,12 @@ GltfDracoLoader.prototype.load = function () {
       }
       // Now wait for process() to run to finish loading
       that._bufferViewTypedArray = bufferViewLoader.typedArray;
+      that._state = ResourceLoaderState.PROCESSING;
     })
     .otherwise(function (error) {
+      if (that.isDestroyed()) {
+        return;
+      }
       handleError(that, error);
     });
 };
@@ -200,6 +204,9 @@ GltfDracoLoader.prototype.process = function (frameState) {
       that._promise.resolve(that);
     })
     .otherwise(function (error) {
+      if (that.isDestroyed()) {
+        return;
+      }
       handleError(that, error);
     });
 };

--- a/Source/Scene/GltfFeatureMetadataLoader.js
+++ b/Source/Scene/GltfFeatureMetadataLoader.js
@@ -141,6 +141,9 @@ GltfFeatureMetadataLoader.prototype.load = function () {
       that._promise.resolve(that);
     })
     .otherwise(function (error) {
+      if (that.isDestroyed()) {
+        return;
+      }
       that.unload();
       that._state = ResourceLoaderState.FAILED;
       var errorMessage = "Failed to load feature metadata";

--- a/Source/Scene/GltfImageLoader.js
+++ b/Source/Scene/GltfImageLoader.js
@@ -164,6 +164,9 @@ function loadFromBufferView(imageLoader) {
       });
     })
     .otherwise(function (error) {
+      if (imageLoader.isDestroyed()) {
+        return;
+      }
       handleError(imageLoader, error, "Failed to load embedded image");
     });
 }
@@ -189,6 +192,9 @@ function loadFromUri(imageLoader) {
       imageLoader._promise.resolve(imageLoader);
     })
     .otherwise(function (error) {
+      if (imageLoader.isDestroyed()) {
+        return;
+      }
       handleError(imageLoader, error, "Failed to load image:" + uri);
     });
 }

--- a/Source/Scene/GltfIndexBufferLoader.js
+++ b/Source/Scene/GltfIndexBufferLoader.js
@@ -148,8 +148,12 @@ function loadFromDraco(indexBufferLoader) {
       // Now wait for process() to run to finish loading
       indexBufferLoader._typedArray =
         dracoLoader.decodedData.indices.typedArray;
+      indexBufferLoader._state = ResourceLoaderState.PROCESSING;
     })
     .otherwise(function (error) {
+      if (indexBufferLoader.isDestroyed()) {
+        return;
+      }
       handleError(indexBufferLoader, error);
     });
 }
@@ -182,8 +186,12 @@ function loadFromBufferView(indexBufferLoader) {
         indexBufferLoader,
         bufferViewTypedArray
       );
+      indexBufferLoader._state = ResourceLoaderState.PROCESSING;
     })
     .otherwise(function (error) {
+      if (indexBufferLoader.isDestroyed()) {
+        return;
+      }
       handleError(indexBufferLoader, error);
     });
 }

--- a/Source/Scene/GltfJsonLoader.js
+++ b/Source/Scene/GltfJsonLoader.js
@@ -132,6 +132,9 @@ function loadFromTypedArray(gltfJsonLoader) {
       gltfJsonLoader._promise.resolve(gltfJsonLoader);
     })
     .otherwise(function (error) {
+      if (gltfJsonLoader.isDestroyed()) {
+        return;
+      }
       handleError(gltfJsonLoader, error);
     });
 }
@@ -156,6 +159,9 @@ function loadFromUri(gltfJsonLoader) {
       gltfJsonLoader._promise.resolve(gltfJsonLoader);
     })
     .otherwise(function (error) {
+      if (gltfJsonLoader.isDestroyed()) {
+        return;
+      }
       handleError(gltfJsonLoader, error);
     });
 }

--- a/Source/Scene/GltfTextureLoader.js
+++ b/Source/Scene/GltfTextureLoader.js
@@ -152,8 +152,12 @@ GltfTextureLoader.prototype.load = function () {
       }
       // Now wait for process() to run to finish loading
       that._image = imageLoader.image;
+      that._state = ResourceLoaderState.PROCESSING;
     })
     .otherwise(function (error) {
+      if (that.isDestroyed()) {
+        return;
+      }
       that.unload();
       that._state = ResourceLoaderState.FAILED;
       var errorMessage = "Failed to load texture";

--- a/Source/Scene/MetadataSchemaLoader.js
+++ b/Source/Scene/MetadataSchemaLoader.js
@@ -119,6 +119,9 @@ function loadExternalSchema(schemaLoader) {
       schemaLoader._promise.resolve(schemaLoader);
     })
     .otherwise(function (error) {
+      if (schemaLoader.isDestroyed()) {
+        return;
+      }
       schemaLoader._state = ResourceLoaderState.FAILED;
       var errorMessage = "Failed to load schema: " + resource.url;
       schemaLoader._promise.reject(schemaLoader.getError(errorMessage, error));

--- a/Source/Scene/ModelComponents.js
+++ b/Source/Scene/ModelComponents.js
@@ -1,0 +1,58 @@
+/**
+ * Components for building models.
+ *
+ * @namespace ModelComponents
+ *
+ * @private
+ */
+var ModelComponents = {};
+
+/**
+ * Information about the quantized attribute.
+ *
+ * @alias ModelComponents.Quantization
+ * @constructor
+ *
+ * @private
+ */
+function Quantization() {
+  /**
+   * Whether the quantized attribute is oct-encoded.
+   *
+   * @type {Boolean}
+   */
+  this.octEncoded = false;
+
+  /**
+   * The range used to convert buffer values to normalized values [0.0, 1.0]
+   * This is typically computed as (1 << quantizationBits) - 1
+   *
+   * @type {Number}
+   */
+  this.normalizationRange = undefined;
+
+  /**
+   * The bottom-left corner of the quantization volume. Not applicable for oct encoded attributes.
+   *
+   * @type {Number|Cartesian2|Cartesian3|Cartesian4|Matrix2|Matrix3|Matrix4}
+   */
+  this.quantizedVolumeOffset = undefined;
+
+  /**
+   * The dimensions of the quantization volume. Not applicable for oct encoded attributes.
+   *
+   * @type {Number|Cartesian2|Cartesian3|Cartesian4|Matrix2|Matrix3|Matrix4}
+   */
+  this.quantizedVolumeDimensions = undefined;
+
+  /**
+   * The component data type of the attribute, e.g. ComponentDatatype.UNSIGNED_SHORT.
+   *
+   * @type {ComponentDatatype}
+   */
+  this.componentDatatype = undefined;
+}
+
+ModelComponents.Quantization = Quantization;
+
+export default ModelComponents;

--- a/Source/Scene/ResourceLoaderState.js
+++ b/Source/Scene/ResourceLoaderState.js
@@ -6,7 +6,8 @@
 var ResourceLoaderState = {
   UNLOADED: 0,
   LOADING: 1,
-  READY: 2,
-  FAILED: 3,
+  PROCESSING: 2,
+  READY: 3,
+  FAILED: 4,
 };
 export default Object.freeze(ResourceLoaderState);

--- a/Specs/Scene/BufferLoaderSpec.js
+++ b/Specs/Scene/BufferLoaderSpec.js
@@ -107,7 +107,7 @@ describe("Scene/BufferLoader", function () {
     });
   });
 
-  it("handles destroy before load finishes", function () {
+  function resolveAfterDestroy(reject) {
     var deferredPromise = when.defer();
     spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
       deferredPromise.promise
@@ -122,9 +122,21 @@ describe("Scene/BufferLoader", function () {
     bufferLoader.load();
     bufferLoader.destroy();
 
-    deferredPromise.resolve(arrayBuffer);
+    if (reject) {
+      deferredPromise.reject(new Error());
+    } else {
+      deferredPromise.resolve(arrayBuffer);
+    }
 
     expect(bufferLoader.typedArray).not.toBeDefined();
     expect(bufferLoader.isDestroyed()).toBe(true);
+  }
+
+  it("handles resolving uri after destroy", function () {
+    resolveAfterDestroy(false);
+  });
+
+  it("handles rejecting uri after destroy", function () {
+    resolveAfterDestroy(true);
   });
 });

--- a/Specs/Scene/GltfBufferViewLoaderSpec.js
+++ b/Specs/Scene/GltfBufferViewLoaderSpec.js
@@ -214,7 +214,7 @@ describe("Scene/GltfBufferViewLoader", function () {
     });
   });
 
-  it("handles destroy before load finishes", function () {
+  function resolveAfterDestroy(reject) {
     var deferredPromise = when.defer();
     spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
       deferredPromise.promise
@@ -239,11 +239,23 @@ describe("Scene/GltfBufferViewLoader", function () {
     bufferViewLoader.load();
     bufferViewLoader.destroy();
 
-    deferredPromise.resolve(bufferArrayBuffer);
+    if (reject) {
+      deferredPromise.reject(new Error());
+    } else {
+      deferredPromise.resolve(bufferArrayBuffer);
+    }
 
     expect(bufferViewLoader.typedArray).not.toBeDefined();
     expect(bufferViewLoader.isDestroyed()).toBe(true);
 
     ResourceCache.unload(bufferLoaderCopy);
+  }
+
+  it("handles resolving buffer after destroy", function () {
+    resolveAfterDestroy(false);
+  });
+
+  it("handles rejecting buffer after destroy", function () {
+    resolveAfterDestroy(true);
   });
 });

--- a/Specs/Scene/GltfFeatureMetadataLoaderSpec.js
+++ b/Specs/Scene/GltfFeatureMetadataLoaderSpec.js
@@ -481,7 +481,7 @@ describe(
       });
     });
 
-    it("handles destroy before all resources are loaded", function () {
+    function resolveAfterDestroy(reject) {
       spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
         when.resolve(buffer)
       );
@@ -542,7 +542,13 @@ describe(
           expect(featureMetadataLoader.featureMetadata).not.toBeDefined();
           featureMetadataLoader.load();
           featureMetadataLoader.destroy();
-          deferredPromise.resolve(schemaJson);
+
+          if (reject) {
+            deferredPromise.reject(new Error());
+          } else {
+            deferredPromise.resolve(schemaJson);
+          }
+
           expect(featureMetadataLoader.featureMetadata).not.toBeDefined();
           expect(featureMetadataLoader.isDestroyed()).toBe(true);
 
@@ -555,6 +561,14 @@ describe(
           ResourceCache.unload(schemaCopy);
         });
       });
+    }
+
+    it("handles resolving resources after destroy", function () {
+      resolveAfterDestroy(false);
+    });
+
+    it("handles rejecting resources after destroy", function () {
+      resolveAfterDestroy(true);
     });
   },
   "WebGL"

--- a/Specs/Scene/GltfImageLoaderSpec.js
+++ b/Specs/Scene/GltfImageLoaderSpec.js
@@ -329,7 +329,7 @@ describe("Scene/GltfImageLoader", function () {
     });
   });
 
-  it("handles destroy before buffer view is finished loading", function () {
+  function resolveBufferViewAfterDestroy(reject) {
     var deferredPromise = when.defer();
     spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
       deferredPromise.promise
@@ -358,15 +358,27 @@ describe("Scene/GltfImageLoader", function () {
     imageLoader.load();
     imageLoader.destroy();
 
-    deferredPromise.resolve(pngBuffer);
+    if (reject) {
+      deferredPromise.reject(new Error());
+    } else {
+      deferredPromise.resolve(pngBuffer);
+    }
 
     expect(imageLoader.image).not.toBeDefined();
     expect(imageLoader.isDestroyed()).toBe(true);
 
     ResourceCache.unload(bufferViewLoaderCopy);
+  }
+
+  it("handles resolving buffer view after destroy", function () {
+    resolveBufferViewAfterDestroy(false);
   });
 
-  it("handles destroy before image is finished loading from buffer", function () {
+  it("handles rejecting buffer view after destroy", function () {
+    resolveBufferViewAfterDestroy(true);
+  });
+
+  function resolveImageFromTypedArrayAfterDestroy(reject) {
     spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
       when.resolve(pngBuffer)
     );
@@ -399,15 +411,27 @@ describe("Scene/GltfImageLoader", function () {
     imageLoader.load();
     imageLoader.destroy();
 
-    deferredPromise.resolve(image);
+    if (reject) {
+      deferredPromise.reject(new Error());
+    } else {
+      deferredPromise.resolve(image);
+    }
 
     expect(imageLoader.image).not.toBeDefined();
     expect(imageLoader.isDestroyed()).toBe(true);
 
     ResourceCache.unload(bufferViewLoaderCopy);
+  }
+
+  it("handles resolving image from typed array after destroy", function () {
+    resolveImageFromTypedArrayAfterDestroy(false);
   });
 
-  it("handles destroy before uri is finished loading", function () {
+  it("handles rejecting image from typed array after destroy", function () {
+    resolveImageFromTypedArrayAfterDestroy(true);
+  });
+
+  function resolveUriAfterDestroy(reject) {
     var deferredPromise = when.defer();
     spyOn(Resource.prototype, "fetchImage").and.returnValue(
       deferredPromise.promise
@@ -427,9 +451,21 @@ describe("Scene/GltfImageLoader", function () {
     imageLoader.load();
     imageLoader.destroy();
 
-    deferredPromise.resolve(image);
+    if (reject) {
+      deferredPromise.reject(new Error());
+    } else {
+      deferredPromise.resolve(image);
+    }
 
     expect(imageLoader.image).not.toBeDefined();
     expect(imageLoader.isDestroyed()).toBe(true);
+  }
+
+  it("handles resolving uri after destroy", function () {
+    resolveUriAfterDestroy(false);
+  });
+
+  it("handles rejecting uri after destroy", function () {
+    resolveUriAfterDestroy(true);
   });
 });

--- a/Specs/Scene/GltfTextureLoaderSpec.js
+++ b/Specs/Scene/GltfTextureLoaderSpec.js
@@ -403,7 +403,7 @@ describe(
       });
     });
 
-    it("handles destroy before image is finished loading", function () {
+    function resolveImageAfterDestroy(reject) {
       var deferredPromise = when.defer();
       spyOn(Resource.prototype, "fetchImage").and.returnValue(
         deferredPromise.promise
@@ -433,12 +433,24 @@ describe(
       textureLoader.load();
       textureLoader.destroy();
 
-      deferredPromise.resolve(image);
+      if (reject) {
+        deferredPromise.reject(new Error());
+      } else {
+        deferredPromise.resolve(image);
+      }
 
       expect(textureLoader.texture).not.toBeDefined();
       expect(textureLoader.isDestroyed()).toBe(true);
 
       ResourceCache.unload(imageLoaderCopy);
+    }
+
+    it("handles resolving image after destroy", function () {
+      resolveImageAfterDestroy(false);
+    });
+
+    it("handles rejecting image after destroy", function () {
+      resolveImageAfterDestroy(true);
     });
   },
   "WebGL"

--- a/Specs/Scene/MetadataSchemaLoaderSpec.js
+++ b/Specs/Scene/MetadataSchemaLoaderSpec.js
@@ -148,7 +148,7 @@ describe("Scene/MetadataSchemaLoader", function () {
     });
   });
 
-  it("handles destroy before load finishes", function () {
+  function resolveJsonAfterDestroy(reject) {
     var deferredPromise = when.defer();
     spyOn(Resource.prototype, "fetchJson").and.returnValue(
       deferredPromise.promise
@@ -164,9 +164,21 @@ describe("Scene/MetadataSchemaLoader", function () {
     expect(schemaLoader._state).toBe(ResourceLoaderState.LOADING);
     schemaLoader.destroy();
 
-    deferredPromise.resolve(schemaJson);
+    if (reject) {
+      deferredPromise.reject(new Error());
+    } else {
+      deferredPromise.resolve(schemaJson);
+    }
 
     expect(schemaLoader.schema).not.toBeDefined();
     expect(schemaLoader.isDestroyed()).toBe(true);
+  }
+
+  it("handles resolving json after destroy", function () {
+    resolveJsonAfterDestroy(false);
+  });
+
+  it("handles rejecting json after destroy", function () {
+    resolveJsonAfterDestroy(true);
   });
 });


### PR DESCRIPTION
Some loose ends from https://github.com/CesiumGS/cesium/pull/9481 before opening a PR for `GltfLoader`

* Added `isDestroyed()` checks to guard against unloading the loader after it's already been destroyed.
* Added `ResourceLoaderState.PROCESSING` to distinguish between loading and processing. It doesn't affect the behavior of the current loaders but was important to add for `GltfLoader` in a future PR.
* Save quantization information after Draco decode. This will be used by `GltfLoader`.