### PR TITLE
3D Tiles Next Metadata: Automatically unpack vector types

### DIFF
--- a/Source/Scene/MetadataClassProperty.js
+++ b/Source/Scene/MetadataClassProperty.js
@@ -1,3 +1,6 @@
+import Cartesian2 from "../Core/Cartesian2.js";
+import Cartesian3 from "../Core/Cartesian3.js";
+import Cartesian4 from "../Core/Cartesian4.js";
 import Check from "../Core/Check.js";
 import defaultValue from "../Core/defaultValue.js";
 import defined from "../Core/defined.js";
@@ -295,6 +298,78 @@ MetadataClassProperty.prototype.unnormalize = function (value) {
 };
 
 /**
+ * Unpack array values into {@link Cartesian2}, {@link Cartesian3}, or
+ * {@link Cartesian4} if this property is an <code>ARRAY</code> of length 2, 3,
+ * or 4, respectively. All other values (including arrays of other sizes) are
+ * passed through unaltered.
+ *
+ * @param {*} value the original, normalized values.
+ * @returns {*} The appropriate vector type if the value is a vector type. Otherwise, the value is returned unaltered.
+ */
+MetadataClassProperty.prototype.unpackVectorTypes = function (value) {
+  var type = this._type;
+  var componentCount = this._componentCount;
+
+  if (
+    type !== MetadataType.ARRAY ||
+    !defined(componentCount) ||
+    !MetadataType.isVectorCompatible(this._componentType)
+  ) {
+    return value;
+  }
+
+  if (componentCount === 2) {
+    return Cartesian2.unpack(value);
+  }
+
+  if (componentCount === 3) {
+    return Cartesian3.unpack(value);
+  }
+
+  if (componentCount === 4) {
+    return Cartesian4.unpack(value);
+  }
+
+  return value;
+};
+
+/**
+ * Unpack Pack a {@link Cartesian2}, {@link Cartesian3}, or
+ * {@link Cartesian4} into an array if this property is an <code>ARRAY</code> of length 2, 3,
+ * or 4, respectively. All other values (including arrays of other sizes) are
+ * passed through unaltered.
+ *
+ * @param {*} value The value of this property
+ * @returns {*} An array of the appropriate length if the property is a vector type. Otherwise, the value is returned unaltered.
+ */
+MetadataClassProperty.prototype.packVectorTypes = function (value) {
+  var type = this._type;
+  var componentCount = this._componentCount;
+
+  if (
+    type !== MetadataType.ARRAY ||
+    !defined(componentCount) ||
+    !MetadataType.isVectorCompatible(this._componentType)
+  ) {
+    return value;
+  }
+
+  if (componentCount === 2) {
+    return Cartesian2.pack(value, []);
+  }
+
+  if (componentCount === 3) {
+    return Cartesian3.pack(value, []);
+  }
+
+  if (componentCount === 4) {
+    return Cartesian4.pack(value, []);
+  }
+
+  return value;
+};
+
+/**
  * Validates whether the given value conforms to the property.
  *
  * @param {*} value The value.
@@ -304,11 +379,18 @@ MetadataClassProperty.prototype.validate = function (value) {
   var message;
   var type = this._type;
   if (type === MetadataType.ARRAY) {
+    var componentCount = this._componentCount;
+
+    // arrays of length 2, 3, and 4 are implicitly converted to CartesianN
+    if (defined(componentCount) && componentCount >= 2 && componentCount <= 4) {
+      return validateVector(value, componentCount);
+    }
+
     if (!Array.isArray(value)) {
       return getTypeErrorMessage(value, type);
     }
     var length = value.length;
-    if (defined(this._componentCount) && this._componentCount !== length) {
+    if (defined(componentCount) && componentCount !== length) {
       return "Array length does not match componentCount";
     }
     for (var i = 0; i < length; ++i) {
@@ -324,6 +406,20 @@ MetadataClassProperty.prototype.validate = function (value) {
     }
   }
 };
+
+function validateVector(value, componentCount) {
+  if (componentCount === 2 && !(value instanceof Cartesian2)) {
+    return "vector value " + value + " must be a Cartesian2";
+  }
+
+  if (componentCount === 3 && !(value instanceof Cartesian3)) {
+    return "vector value " + value + " must be a Cartesian3";
+  }
+
+  if (componentCount === 4 && !(value instanceof Cartesian4)) {
+    return "vector value " + value + " must be a Cartesian4";
+  }
+}
 
 function getTypeErrorMessage(value, type) {
   return "value " + value + " does not match type " + type;

--- a/Source/Scene/MetadataClassProperty.js
+++ b/Source/Scene/MetadataClassProperty.js
@@ -305,6 +305,7 @@ MetadataClassProperty.prototype.unnormalize = function (value) {
  *
  * @param {*} value the original, normalized values.
  * @returns {*} The appropriate vector type if the value is a vector type. Otherwise, the value is returned unaltered.
+ * @private
  */
 MetadataClassProperty.prototype.unpackVectorTypes = function (value) {
   var type = this._type;
@@ -341,6 +342,7 @@ MetadataClassProperty.prototype.unpackVectorTypes = function (value) {
  *
  * @param {*} value The value of this property
  * @returns {*} An array of the appropriate length if the property is a vector type. Otherwise, the value is returned unaltered.
+ * @private
  */
 MetadataClassProperty.prototype.packVectorTypes = function (value) {
   var type = this._type;

--- a/Source/Scene/MetadataClassProperty.js
+++ b/Source/Scene/MetadataClassProperty.js
@@ -335,10 +335,9 @@ MetadataClassProperty.prototype.unpackVectorTypes = function (value) {
 };
 
 /**
- * Unpack Pack a {@link Cartesian2}, {@link Cartesian3}, or
- * {@link Cartesian4} into an array if this property is an <code>ARRAY</code> of length 2, 3,
- * or 4, respectively. All other values (including arrays of other sizes) are
- * passed through unaltered.
+ * Pack a {@link Cartesian2}, {@link Cartesian3}, or {@link Cartesian4} into an
+ * array if this property is an <code>ARRAY</code> of length 2, 3, or 4, respectively.
+ * All other values (including arrays of other sizes) are passed through unaltered.
  *
  * @param {*} value The value of this property
  * @returns {*} An array of the appropriate length if the property is a vector type. Otherwise, the value is returned unaltered.

--- a/Source/Scene/MetadataClassProperty.js
+++ b/Source/Scene/MetadataClassProperty.js
@@ -382,7 +382,12 @@ MetadataClassProperty.prototype.validate = function (value) {
     var componentCount = this._componentCount;
 
     // arrays of length 2, 3, and 4 are implicitly converted to CartesianN
-    if (defined(componentCount) && componentCount >= 2 && componentCount <= 4) {
+    if (
+      defined(componentCount) &&
+      componentCount >= 2 &&
+      componentCount <= 4 &&
+      MetadataType.isVectorCompatible(this._componentType)
+    ) {
       return validateVector(value, componentCount);
     }
 

--- a/Source/Scene/MetadataEntity.js
+++ b/Source/Scene/MetadataEntity.js
@@ -227,6 +227,7 @@ MetadataEntity.getProperty = function (
 
   if (defined(classProperty)) {
     value = classProperty.normalize(value);
+    value = classProperty.unpackVectorTypes(value);
   }
 
   return value;
@@ -269,6 +270,7 @@ MetadataEntity.setProperty = function (
   if (defined(classDefinition)) {
     var classProperty = classDefinition.properties[propertyId];
     if (defined(classProperty)) {
+      value = classProperty.packVectorTypes(value);
       value = classProperty.unnormalize(value);
     }
   }

--- a/Source/Scene/MetadataTable.js
+++ b/Source/Scene/MetadataTable.js
@@ -244,7 +244,8 @@ function getDefault(classDefinition, propertyId) {
       if (classProperty.type === MetadataType.ARRAY) {
         value = value.slice(); // clone
       }
-      return classProperty.normalize(value);
+      value = classProperty.normalize(value);
+      return classProperty.unpackVectorTypes(value);
     }
   }
 }

--- a/Source/Scene/MetadataTableProperty.js
+++ b/Source/Scene/MetadataTableProperty.js
@@ -187,7 +187,8 @@ MetadataTableProperty.prototype.get = function (index) {
   //>>includeEnd('debug');
 
   var value = get(this, index);
-  return this._classProperty.normalize(value);
+  value = this._classProperty.normalize(value);
+  return this._classProperty.unpackVectorTypes(value);
 };
 
 /**
@@ -209,6 +210,7 @@ MetadataTableProperty.prototype.set = function (index, value) {
   }
   //>>includeEnd('debug');
 
+  value = classProperty.packVectorTypes(value);
   value = classProperty.unnormalize(value);
 
   set(this, index, value);

--- a/Source/Scene/MetadataType.js
+++ b/Source/Scene/MetadataType.js
@@ -213,6 +213,31 @@ MetadataType.isUnsignedIntegerType = function (type) {
 };
 
 /**
+ * Returns whether a type can be used in a vector, i.e. the {@link Cartesian2},
+ * {@link Cartesian3}, or {@link Cartesian4} classes. This includes all numeric
+ * types except for types requiring 64-bits
+ */
+MetadataType.isVectorCompatible = function (type) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.string("type", type);
+  //>>includeEnd('debug');
+
+  switch (type) {
+    case MetadataType.INT8:
+    case MetadataType.UINT8:
+    case MetadataType.INT16:
+    case MetadataType.UINT16:
+    case MetadataType.INT32:
+    case MetadataType.UINT32:
+    case MetadataType.FLOAT32:
+    case MetadataType.FLOAT64:
+      return true;
+    default:
+      return false;
+  }
+};
+
+/**
  * Normalizes signed integers to the range [-1.0, 1.0] and unsigned integers to
  * the range [0.0, 1.0].
  * <p>

--- a/Specs/Data/Cesium3DTiles/Metadata/AllMetadataTypes/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/AllMetadataTypes/tileset.json
@@ -26,7 +26,7 @@
                 "description": "Center of the tileset as [longitude, latitude, height] where longitude and latitude are in radians, and height is in meters].",
                 "type": "ARRAY",
                 "componentType": "FLOAT64",
-                "componentCount": "3"
+                "componentCount": 3
               },
               "tileCount": {
                 "description": "Total number of tiles in the tileset",

--- a/Specs/Data/Cesium3DTiles/Metadata/TilesetMetadata/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/TilesetMetadata/tileset.json
@@ -29,7 +29,7 @@
                 "description": "Center of the tileset as [longitude, latitude, height] where longitude and latitude are in radians, and height is in meters].",
                 "type": "ARRAY",
                 "componentType": "FLOAT64",
-                "componentCount": "3"
+                "componentCount": 3
               },
               "tileCount": {
                 "description": "Total number of tiles in the tileset",

--- a/Specs/Scene/Cesium3DTileFeatureSpec.js
+++ b/Specs/Scene/Cesium3DTileFeatureSpec.js
@@ -1,5 +1,6 @@
 import {
   Cartesian3,
+  Cartesian4,
   Cesium3DTileFeature,
   HeadingPitchRange,
 } from "../../Source/Cesium.js";
@@ -55,22 +56,16 @@ describe(
 
       it("getPropertyInherited returns tile property by semantic", function () {
         var feature = new Cesium3DTileFeature(childContents["ll.b3dm"], 0);
-        expect(feature.getPropertyInherited("COLOR")).toEqual([
-          255,
-          255,
-          0,
-          1.0,
-        ]);
+        expect(feature.getPropertyInherited("COLOR")).toEqual(
+          new Cartesian4(255, 255, 0, 1.0)
+        );
       });
 
       it("getPropertyInherited returns tile property", function () {
         var feature = new Cesium3DTileFeature(childContents["ll.b3dm"], 0);
-        expect(feature.getPropertyInherited("color")).toEqual([
-          255,
-          255,
-          0,
-          1.0,
-        ]);
+        expect(feature.getPropertyInherited("color")).toEqual(
+          new Cartesian4(255, 255, 0, 1.0)
+        );
         expect(feature.getPropertyInherited("population")).toBe(50);
       });
 
@@ -92,12 +87,9 @@ describe(
 
       it("getPropertyInherited returns tileset property by semantic", function () {
         var feature = new Cesium3DTileFeature(parentContent, 0);
-        expect(feature.getPropertyInherited("COLOR")).toEqual([
-          255,
-          0,
-          255,
-          1.0,
-        ]);
+        expect(feature.getPropertyInherited("COLOR")).toEqual(
+          new Cartesian4(255, 0, 255, 1.0)
+        );
         expect(feature.getPropertyInherited("DATE_ISO_8601")).toBe(
           "2021-04-07"
         );
@@ -106,17 +98,16 @@ describe(
 
       it("getPropertyInherited returns tileset property", function () {
         var feature = new Cesium3DTileFeature(parentContent, 0);
-        expect(feature.getPropertyInherited("color")).toEqual([
-          255,
-          0,
-          255,
-          1.0,
-        ]);
-        expect(feature.getPropertyInherited("centerCartographic")).toEqual([
-          -1.3196816996258511,
-          0.6988767486400521,
-          45.78600543644279,
-        ]);
+        expect(feature.getPropertyInherited("color")).toEqual(
+          new Cartesian4(255, 0, 255, 1.0)
+        );
+        expect(feature.getPropertyInherited("centerCartographic")).toEqual(
+          new Cartesian3(
+            -1.3196816996258511,
+            0.6988767486400521,
+            45.78600543644279
+          )
+        );
         expect(feature.getPropertyInherited("date")).toBe("2021-04-07");
         expect(feature.getPropertyInherited("author")).toBe("Cesium");
         expect(feature.getPropertyInherited("tileCount")).toBe(5);
@@ -126,12 +117,9 @@ describe(
         // tile metadata is more specific than tileset metadata so this returns
         // yellow not magenta
         var feature = new Cesium3DTileFeature(childContents["ll.b3dm"], 0);
-        expect(feature.getPropertyInherited("color")).toEqual([
-          255,
-          255,
-          0,
-          1.0,
-        ]);
+        expect(feature.getPropertyInherited("color")).toEqual(
+          new Cartesian4(255, 255, 0, 1.0)
+        );
 
         // group metadata is more specific than tileset metadata, so this returns
         // 2 not 5

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -5198,7 +5198,7 @@ describe(
               tilesetProperties.date
             );
             expect(tilesetMetadata.getProperty("centerCartographic")).toEqual(
-              tilesetProperties.centerCartographic
+              Cartesian3.unpack(tilesetProperties.centerCartographic)
             );
             expect(tilesetMetadata.getProperty("tileCount")).toBe(
               tilesetProperties.tileCount
@@ -5298,23 +5298,23 @@ describe(
         ).then(function (tileset) {
           var expected = {
             "parent.b3dm": {
-              color: [0.5, 0.0, 1.0],
+              color: new Cartesian3(0.5, 0.0, 1.0),
               population: 530,
             },
             "ll.b3dm": {
-              color: [1.0, 1.0, 0.0],
+              color: new Cartesian3(1.0, 1.0, 0.0),
               population: 50,
             },
             "lr.b3dm": {
-              color: [1.0, 0.0, 0.5],
+              color: new Cartesian3(1.0, 0.0, 0.5),
               population: 230,
             },
             "ur.b3dm": {
-              color: [1.0, 0.5, 0.0],
+              color: new Cartesian3(1.0, 0.5, 0.0),
               population: 150,
             },
             "ul.b3dm": {
-              color: [1.0, 0.0, 0.0],
+              color: new Cartesian3(1.0, 0.0, 0.0),
               population: 100,
             },
           };
@@ -5360,10 +5360,10 @@ describe(
             "Northeast",
           ];
           var expectedColors = [
-            [255, 255, 255],
-            [255, 0, 0],
-            [0, 255, 0],
-            [0, 0, 255],
+            new Cartesian3(255, 255, 255),
+            new Cartesian3(255, 0, 0),
+            new Cartesian3(0, 255, 0),
+            new Cartesian3(0, 0, 255),
           ];
 
           var tiles = [transcodedRoot].concat(transcodedRoot.children);

--- a/Specs/Scene/GroupMetadataSpec.js
+++ b/Specs/Scene/GroupMetadataSpec.js
@@ -1,4 +1,8 @@
-import { MetadataClass, GroupMetadata } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  MetadataClass,
+  GroupMetadata,
+} from "../../Source/Cesium.js";
 
 describe("Scene/GroupMetadata", function () {
   it("creates group metadata with default values", function () {
@@ -59,7 +63,9 @@ describe("Scene/GroupMetadata", function () {
     expect(groupMetadata.description).toBe("Building Metadata");
     expect(groupMetadata.extras).toBe(extras);
     expect(groupMetadata.extensions).toBe(extensions);
-    expect(groupMetadata.getProperty("position")).toEqual(properties.position);
+    expect(groupMetadata.getProperty("position")).toEqual(
+      Cartesian3.unpack(properties.position)
+    );
   });
 
   it("constructor throws without id", function () {
@@ -326,8 +332,7 @@ describe("Scene/GroupMetadata", function () {
     });
 
     var value = groupMetadata.getProperty("position");
-    expect(value).toEqual(position);
-    expect(value).not.toBe(position); // The value is cloned
+    expect(value).toEqual(Cartesian3.unpack(position));
   });
 
   it("getProperty returns the default value when the property is missing", function () {
@@ -354,8 +359,7 @@ describe("Scene/GroupMetadata", function () {
     });
 
     var value = groupMetadata.getProperty("position");
-    expect(value).toEqual(position);
-    expect(value).not.toBe(position); // The value is cloned
+    expect(value).toEqual(Cartesian3.unpack(position));
   });
 
   it("getProperty throws without propertyId", function () {
@@ -405,10 +409,10 @@ describe("Scene/GroupMetadata", function () {
       },
     });
 
-    var position = [1.0, 1.0, 1.0];
+    var position = new Cartesian3(1.0, 1.0, 1.0);
     groupMetadata.setProperty("position", position);
     expect(groupMetadata.getProperty("position")).toEqual(position);
-    expect(groupMetadata.getProperty("position")).not.toBe(position); // The value is cloned
+    expect(groupMetadata.getProperty("position")).not.toBe(position); // copies value
   });
 
   it("setProperty throws without propertyId", function () {

--- a/Specs/Scene/Implicit3DTileContentSpec.js
+++ b/Specs/Scene/Implicit3DTileContentSpec.js
@@ -844,11 +844,15 @@ describe(
 
           var groups = tileset.metadata.groups;
           var ground = groups.ground;
-          expect(ground.getProperty("color")).toEqual([120, 68, 32]);
+          expect(ground.getProperty("color")).toEqual(
+            new Cartesian3(120, 68, 32)
+          );
           expect(ground.getProperty("priority")).toBe(0);
 
           var sky = groups.sky;
-          expect(sky.getProperty("color")).toEqual([206, 237, 242]);
+          expect(sky.getProperty("color")).toEqual(
+            new Cartesian3(206, 237, 242)
+          );
           expect(sky.getProperty("priority")).toBe(1);
 
           tiles.forEach(function (tile) {

--- a/Specs/Scene/ImplicitSubtreeSpec.js
+++ b/Specs/Scene/ImplicitSubtreeSpec.js
@@ -1,4 +1,5 @@
 import {
+  Cartesian3,
   ImplicitSubdivisionScheme,
   ImplicitSubtree,
   ImplicitTileCoordinates,
@@ -1114,7 +1115,7 @@ describe("Scene/ImplicitSubtree", function () {
 
         for (var i = 0; i < buildingCounts.length; i++) {
           expect(metadataTable.getProperty(i, "highlightColor")).toEqual(
-            highlightColors[i]
+            Cartesian3.unpack(highlightColors[i])
           );
           expect(metadataTable.getProperty(i, "buildingCount")).toBe(
             buildingCounts[i]
@@ -1171,7 +1172,7 @@ describe("Scene/ImplicitSubtree", function () {
 
         for (var i = 0; i < buildingCounts.length; i++) {
           expect(metadataTable.getProperty(i, "highlightColor")).toEqual(
-            highlightColors[i]
+            Cartesian3.unpack(highlightColors[i])
           );
           expect(metadataTable.getProperty(i, "buildingCount")).toBe(
             buildingCounts[i]
@@ -1228,7 +1229,7 @@ describe("Scene/ImplicitSubtree", function () {
 
         for (var i = 0; i < buildingCounts.length; i++) {
           expect(metadataTable.getProperty(i, "highlightColor")).toEqual(
-            highlightColors[i]
+            Cartesian3.unpack(highlightColors[i])
           );
           expect(metadataTable.getProperty(i, "buildingCount")).toBe(
             buildingCounts[i]
@@ -1480,7 +1481,7 @@ describe("Scene/ImplicitSubtree", function () {
 
         for (var i = 0; i < buildingCounts.length; i++) {
           expect(metadataTable.getProperty(i, "highlightColor")).toEqual(
-            highlightColors[i]
+            Cartesian3.unpack(highlightColors[i])
           );
           expect(metadataTable.getProperty(i, "buildingCount")).toBe(
             buildingCounts[i]

--- a/Specs/Scene/ImplicitTileMetadataSpec.js
+++ b/Specs/Scene/ImplicitTileMetadataSpec.js
@@ -1,4 +1,5 @@
 import {
+  Cartesian3,
   ImplicitSubdivisionScheme,
   ImplicitSubtree,
   ImplicitTileCoordinates,
@@ -212,7 +213,9 @@ describe("Scene/ImplicitTileMetadata", function () {
   });
 
   it("getProperty returns the property value", function () {
-    expect(tileMetadata.getProperty("highlightColor")).toEqual([255, 255, 0]);
+    expect(tileMetadata.getProperty("highlightColor")).toEqual(
+      new Cartesian3(255, 255, 0)
+    );
     expect(tileMetadata.getProperty("buildingCount")).toBe(350);
   });
 
@@ -233,27 +236,24 @@ describe("Scene/ImplicitTileMetadata", function () {
   });
 
   it("getPropertyBySemantic returns the property value", function () {
-    expect(tileMetadata.getPropertyBySemantic("_HIGHLIGHT_COLOR")).toEqual([
-      255,
-      255,
-      0,
-    ]);
+    expect(tileMetadata.getPropertyBySemantic("_HIGHLIGHT_COLOR")).toEqual(
+      new Cartesian3(255, 255, 0)
+    );
   });
 
   it("setPropertyBySemantic sets property value", function () {
-    expect(tileMetadata.getPropertyBySemantic("_HIGHLIGHT_COLOR")).toEqual([
-      255,
-      255,
-      0,
-    ]);
+    expect(tileMetadata.getPropertyBySemantic("_HIGHLIGHT_COLOR")).toEqual(
+      new Cartesian3(255, 255, 0)
+    );
     expect(
-      tileMetadata.setPropertyBySemantic("_HIGHLIGHT_COLOR", [0, 0, 0])
+      tileMetadata.setPropertyBySemantic(
+        "_HIGHLIGHT_COLOR",
+        new Cartesian3(0, 0, 0)
+      )
     ).toBe(true);
-    expect(tileMetadata.getPropertyBySemantic("_HIGHLIGHT_COLOR")).toEqual([
-      0,
-      0,
-      0,
-    ]);
+    expect(tileMetadata.getPropertyBySemantic("_HIGHLIGHT_COLOR")).toEqual(
+      new Cartesian3(0, 0, 0)
+    );
   });
 
   it("setPropertyBySemantic returns false if the semantic does not exist", function () {

--- a/Specs/Scene/MetadataClassPropertySpec.js
+++ b/Specs/Scene/MetadataClassPropertySpec.js
@@ -1,4 +1,5 @@
 import {
+  Cartesian3,
   FeatureDetection,
   MetadataClassProperty,
   MetadataEnum,
@@ -339,10 +340,23 @@ describe("Scene/MetadataClassProperty", function () {
       },
     });
 
-    expect(property.validate([1.0, 2.0, 3.0])).toBeUndefined();
+    expect(property.validate(new Cartesian3(1.0, 2.0, 3.0))).toBeUndefined();
   });
 
   it("validate returns error message if type is ARRAY and value is not an array", function () {
+    var property = new MetadataClassProperty({
+      id: "position",
+      property: {
+        type: "ARRAY",
+        componentType: "FLOAT32",
+        componentCount: 8,
+      },
+    });
+
+    expect(property.validate(8.0)).toBe("value 8 does not match type ARRAY");
+  });
+
+  it("validate returns error message if type is a vector and value is not a Cartesian", function () {
     var property = new MetadataClassProperty({
       id: "position",
       property: {
@@ -352,7 +366,7 @@ describe("Scene/MetadataClassProperty", function () {
       },
     });
 
-    expect(property.validate(8.0)).toBe("value 8 does not match type ARRAY");
+    expect(property.validate(8.0)).toBe("vector value 8 must be a Cartesian3");
   });
 
   it("validate returns error message if type is ARRAY and the array length does not match componentCount", function () {

--- a/Specs/Scene/MetadataClassPropertySpec.js
+++ b/Specs/Scene/MetadataClassPropertySpec.js
@@ -375,7 +375,7 @@ describe("Scene/MetadataClassProperty", function () {
       property: {
         type: "ARRAY",
         componentType: "FLOAT32",
-        componentCount: 3,
+        componentCount: 6,
       },
     });
 

--- a/Specs/Scene/MetadataClassPropertySpec.js
+++ b/Specs/Scene/MetadataClassPropertySpec.js
@@ -1,5 +1,7 @@
 import {
+  Cartesian2,
   Cartesian3,
+  Cartesian4,
   FeatureDetection,
   MetadataClassProperty,
   MetadataEnum,
@@ -325,6 +327,258 @@ describe("Scene/MetadataClassProperty", function () {
           var value = propertyValues[propertyId][i];
           var normalizeValue = property.normalize(value);
           expect(normalizeValue).toEqual(value);
+        }
+      }
+    }
+  });
+
+  it("packVectorTypes packs vectors", function () {
+    var properties = {
+      propertyVec2: {
+        type: "ARRAY",
+        componentType: "FLOAT32",
+        componentCount: 2,
+      },
+      propertyIVec3: {
+        type: "ARRAY",
+        componentType: "INT32",
+        componentCount: 3,
+      },
+      propertyDVec4: {
+        type: "ARRAY",
+        componentType: "FLOAT64",
+        componentCount: 4,
+      },
+    };
+
+    var propertyValues = {
+      propertyVec2: [
+        new Cartesian2(0.1, 0.8),
+        new Cartesian2(0.3, 0.5),
+        new Cartesian2(0.7, 0.2),
+      ],
+      propertyIVec3: [
+        new Cartesian3(1, 2, 3),
+        new Cartesian3(4, 5, 6),
+        new Cartesian3(7, 8, 9),
+      ],
+      propertyDVec4: [
+        new Cartesian4(0.1, 0.2, 0.3, 0.4),
+        new Cartesian4(0.3, 0.2, 0.1, 0.0),
+        new Cartesian4(0.1, 0.2, 0.4, 0.5),
+      ],
+    };
+
+    var packedValues = {
+      propertyVec2: [
+        [0.1, 0.8],
+        [0.3, 0.5],
+        [0.7, 0.2],
+      ],
+      propertyIVec3: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ],
+      propertyDVec4: [
+        [0.1, 0.2, 0.3, 0.4],
+        [0.3, 0.2, 0.1, 0.0],
+        [0.1, 0.2, 0.4, 0.5],
+      ],
+    };
+
+    for (var propertyId in properties) {
+      if (properties.hasOwnProperty(propertyId)) {
+        var property = new MetadataClassProperty({
+          id: propertyId,
+          property: properties[propertyId],
+        });
+        var length = propertyValues[propertyId].length;
+        for (var i = 0; i < length; ++i) {
+          var value = propertyValues[propertyId][i];
+          var packed = property.packVectorTypes(value);
+          expect(packed).toEqual(packedValues[propertyId][i]);
+        }
+      }
+    }
+  });
+
+  it("packVectorTypes does not affect non-vectors", function () {
+    if (!FeatureDetection.supportsBigInt()) {
+      return;
+    }
+
+    var properties = {
+      propertyString: {
+        type: "STRING",
+      },
+      propertyBoolean: {
+        type: "BOOLEAN",
+      },
+      propertyArray: {
+        type: "ARRAY",
+        componentType: "UINT8",
+        componentCount: 5,
+      },
+      propertyBigIntArray: {
+        type: "ARRAY",
+        componentType: "UINT64",
+        componentCount: 2,
+      },
+    };
+
+    var propertyValues = {
+      propertyString: ["a", "bc", ""],
+      propertyBoolean: [true, false, false],
+      propertyArray: [
+        [1, 2, 3, 4, 5],
+        [0, 1, 2, 3, 4],
+        [1, 4, 9, 16, 25],
+      ],
+      propertyBigIntArray: [
+        [BigInt(0), BigInt(0)], // eslint-disable-line
+        [BigInt(1), BigInt(3)], // eslint-disable-line
+        [BigInt(45), BigInt(32)], // eslint-disable-line
+      ],
+    };
+
+    for (var propertyId in properties) {
+      if (properties.hasOwnProperty(propertyId)) {
+        var property = new MetadataClassProperty({
+          id: propertyId,
+          property: properties[propertyId],
+        });
+        var length = propertyValues[propertyId].length;
+        for (var i = 0; i < length; ++i) {
+          var value = propertyValues[propertyId][i];
+          var packed = property.packVectorTypes(value);
+          expect(packed).toEqual(value);
+        }
+      }
+    }
+  });
+
+  it("unpackVectorTypes unpacks vectors", function () {
+    var properties = {
+      propertyVec2: {
+        type: "ARRAY",
+        componentType: "FLOAT32",
+        componentCount: 2,
+      },
+      propertyIVec3: {
+        type: "ARRAY",
+        componentType: "INT32",
+        componentCount: 3,
+      },
+      propertyDVec4: {
+        type: "ARRAY",
+        componentType: "FLOAT64",
+        componentCount: 4,
+      },
+    };
+
+    var propertyValues = {
+      propertyVec2: [
+        new Cartesian2(0.1, 0.8),
+        new Cartesian2(0.3, 0.5),
+        new Cartesian2(0.7, 0.2),
+      ],
+      propertyIVec3: [
+        new Cartesian3(1, 2, 3),
+        new Cartesian3(4, 5, 6),
+        new Cartesian3(7, 8, 9),
+      ],
+      propertyDVec4: [
+        new Cartesian4(0.1, 0.2, 0.3, 0.4),
+        new Cartesian4(0.3, 0.2, 0.1, 0.0),
+        new Cartesian4(0.1, 0.2, 0.4, 0.5),
+      ],
+    };
+
+    var packedValues = {
+      propertyVec2: [
+        [0.1, 0.8],
+        [0.3, 0.5],
+        [0.7, 0.2],
+      ],
+      propertyIVec3: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ],
+      propertyDVec4: [
+        [0.1, 0.2, 0.3, 0.4],
+        [0.3, 0.2, 0.1, 0.0],
+        [0.1, 0.2, 0.4, 0.5],
+      ],
+    };
+
+    for (var propertyId in properties) {
+      if (properties.hasOwnProperty(propertyId)) {
+        var property = new MetadataClassProperty({
+          id: propertyId,
+          property: properties[propertyId],
+        });
+        var length = propertyValues[propertyId].length;
+        for (var i = 0; i < length; ++i) {
+          var value = packedValues[propertyId][i];
+          var unpacked = property.unpackVectorTypes(value);
+          expect(unpacked).toEqual(propertyValues[propertyId][i]);
+        }
+      }
+    }
+  });
+
+  it("unpackVectorTypes does not affect non-vectors", function () {
+    if (!FeatureDetection.supportsBigInt()) {
+      return;
+    }
+
+    var properties = {
+      propertyString: {
+        type: "STRING",
+      },
+      propertyBoolean: {
+        type: "BOOLEAN",
+      },
+      propertyArray: {
+        type: "ARRAY",
+        componentType: "UINT8",
+        componentCount: 5,
+      },
+      propertyBigIntArray: {
+        type: "ARRAY",
+        componentType: "UINT64",
+        componentCount: 2,
+      },
+    };
+
+    var propertyValues = {
+      propertyString: ["a", "bc", ""],
+      propertyBoolean: [true, false, false],
+      propertyArray: [
+        [1, 2, 3, 4, 5],
+        [0, 1, 2, 3, 4],
+        [1, 4, 9, 16, 25],
+      ],
+      propertyBigIntArray: [
+        [BigInt(0), BigInt(0)], // eslint-disable-line
+        [BigInt(1), BigInt(3)], // eslint-disable-line
+        [BigInt(45), BigInt(32)], // eslint-disable-line
+      ],
+    };
+
+    for (var propertyId in properties) {
+      if (properties.hasOwnProperty(propertyId)) {
+        var property = new MetadataClassProperty({
+          id: propertyId,
+          property: properties[propertyId],
+        });
+        var length = propertyValues[propertyId].length;
+        for (var i = 0; i < length; ++i) {
+          var value = propertyValues[propertyId][i];
+          var unpacked = property.unpackVectorTypes(value);
+          expect(unpacked).toEqual(value);
         }
       }
     }

--- a/Specs/Scene/MetadataEntitySpec.js
+++ b/Specs/Scene/MetadataEntitySpec.js
@@ -1,4 +1,8 @@
-import { MetadataClass, MetadataEntity } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  MetadataClass,
+  MetadataEntity,
+} from "../../Source/Cesium.js";
 
 describe("Scene/MetadataEntity", function () {
   var classDefinition = new MetadataClass({
@@ -148,8 +152,7 @@ describe("Scene/MetadataEntity", function () {
       properties,
       classDefinition
     );
-    expect(value).toEqual(properties.position);
-    expect(value).not.toBe(properties.position); // The value is cloned
+    expect(value).toEqual(Cartesian3.unpack(properties.position));
   });
 
   it("getProperty returns the default value when the property is missing", function () {

--- a/Specs/Scene/MetadataTablePropertySpec.js
+++ b/Specs/Scene/MetadataTablePropertySpec.js
@@ -1,5 +1,6 @@
 import {
   defaultValue,
+  Cartesian3,
   MetadataClassProperty,
   MetadataTableProperty,
 } from "../../Source/Cesium.js";
@@ -824,30 +825,12 @@ describe("Scene/MetadataTableProperty", function () {
     };
 
     var valuesToSet = {
-      propertyInt8: [
-        [-2, -1, 0],
-        [1, 2, 3],
-      ],
-      propertyUint8: [
-        [0, 1, 2],
-        [3, 4, 5],
-      ],
-      propertyInt16: [
-        [-2, -1, 0],
-        [1, 2, 3],
-      ],
-      propertyUint16: [
-        [0, 1, 2],
-        [3, 4, 5],
-      ],
-      propertyInt32: [
-        [-2, -1, 0],
-        [1, 2, 3],
-      ],
-      propertyUint32: [
-        [0, 1, 2],
-        [3, 4, 5],
-      ],
+      propertyInt8: [new Cartesian3(-2, -1, 0), new Cartesian3(1, 2, 3)],
+      propertyUint8: [new Cartesian3(0, 1, 2), new Cartesian3(3, 4, 5)],
+      propertyInt16: [new Cartesian3(-2, -1, 0), new Cartesian3(1, 2, 3)],
+      propertyUint16: [new Cartesian3(0, 1, 2), new Cartesian3(3, 4, 5)],
+      propertyInt32: [new Cartesian3(-2, -1, 0), new Cartesian3(1, 2, 3)],
+      propertyUint32: [new Cartesian3(0, 1, 2), new Cartesian3(3, 4, 5)],
       propertyInt64: [
         [BigInt(-2), BigInt(-1), BigInt(0)], // eslint-disable-line
         [BigInt(1), BigInt(2), BigInt(3)], // eslint-disable-line
@@ -857,12 +840,12 @@ describe("Scene/MetadataTableProperty", function () {
         [BigInt(3), BigInt(4), BigInt(5)], // eslint-disable-line
       ],
       propertyFloat32: [
-        [-2.0, -1.0, 0.0],
-        [1.0, 2.0, 3.0],
+        new Cartesian3(-2.0, -1.0, 0.0),
+        new Cartesian3(1.0, 2.0, 3.0),
       ],
       propertyFloat64: [
-        [-2.0, -1.0, 0.0],
-        [1.0, 2.0, 3.0],
+        new Cartesian3(-2.0, -1.0, 0.0),
+        new Cartesian3(1.0, 2.0, 3.0),
       ],
       propertyBoolean: [
         [false, true, false],

--- a/Specs/Scene/MetadataTablePropertySpec.js
+++ b/Specs/Scene/MetadataTablePropertySpec.js
@@ -288,7 +288,7 @@ describe("Scene/MetadataTableProperty", function () {
     }
   });
 
-  it("get returns fixed size arrays", function () {
+  it("get returns vectors", function () {
     var properties = {
       propertyInt8: {
         type: "ARRAY",
@@ -320,16 +320,6 @@ describe("Scene/MetadataTableProperty", function () {
         componentType: "UINT32",
         componentCount: 3,
       },
-      propertyInt64: {
-        type: "ARRAY",
-        componentType: "INT64",
-        componentCount: 3,
-      },
-      propertyUint64: {
-        type: "ARRAY",
-        componentType: "UINT64",
-        componentCount: 3,
-      },
       propertyFloat32: {
         type: "ARRAY",
         componentType: "FLOAT32",
@@ -338,22 +328,6 @@ describe("Scene/MetadataTableProperty", function () {
       propertyFloat64: {
         type: "ARRAY",
         componentType: "FLOAT64",
-        componentCount: 3,
-      },
-      propertyBoolean: {
-        type: "ARRAY",
-        componentType: "BOOLEAN",
-        componentCount: 3,
-      },
-      propertyString: {
-        type: "ARRAY",
-        componentType: "STRING",
-        componentCount: 3,
-      },
-      propertyEnum: {
-        type: "ARRAY",
-        componentType: "ENUM",
-        enumType: "myEnum",
         componentCount: 3,
       },
     };
@@ -383,14 +357,6 @@ describe("Scene/MetadataTableProperty", function () {
         [0, 1, 2],
         [3, 4, 5],
       ],
-      propertyInt64: [
-        [BigInt(-2), BigInt(-1), BigInt(0)], // eslint-disable-line
-        [BigInt(1), BigInt(2), BigInt(3)], // eslint-disable-line
-      ],
-      propertyUint64: [
-        [BigInt(0), BigInt(1), BigInt(2)], // eslint-disable-line
-        [BigInt(3), BigInt(4), BigInt(5)], // eslint-disable-line
-      ],
       propertyFloat32: [
         [-2.0, -1.0, 0.0],
         [1.0, 2.0, 3.0],
@@ -398,6 +364,65 @@ describe("Scene/MetadataTableProperty", function () {
       propertyFloat64: [
         [-2.0, -1.0, 0.0],
         [1.0, 2.0, 3.0],
+      ],
+    };
+
+    for (var propertyId in properties) {
+      if (properties.hasOwnProperty(propertyId)) {
+        var property = MetadataTester.createProperty({
+          property: properties[propertyId],
+          values: propertyValues[propertyId],
+          enums: enums,
+        });
+
+        var expectedValues = propertyValues[propertyId];
+        var length = expectedValues.length;
+        for (var i = 0; i < length; ++i) {
+          var value = property.get(i);
+          expect(value).toEqual(Cartesian3.unpack(expectedValues[i]));
+        }
+      }
+    }
+  });
+
+  it("get returns fixed size arrays", function () {
+    var properties = {
+      propertyInt64: {
+        type: "ARRAY",
+        componentType: "INT64",
+        componentCount: 3,
+      },
+      propertyUint64: {
+        type: "ARRAY",
+        componentType: "UINT64",
+        componentCount: 3,
+      },
+      propertyBoolean: {
+        type: "ARRAY",
+        componentType: "BOOLEAN",
+        componentCount: 3,
+      },
+      propertyString: {
+        type: "ARRAY",
+        componentType: "STRING",
+        componentCount: 3,
+      },
+      propertyEnum: {
+        type: "ARRAY",
+        componentType: "ENUM",
+        enumType: "myEnum",
+        componentCount: 3,
+      },
+    };
+
+    var propertyValues = {
+      propertyInt64: [
+        [BigInt(-2), BigInt(-1), BigInt(0)], // eslint-disable-line
+        [BigInt(1), BigInt(2), BigInt(3)], // eslint-disable-line
+      ],
+      propertyUint64: [
+        [BigInt(0), BigInt(1), BigInt(2)], // eslint-disable-line
+        [BigInt(3), BigInt(4), BigInt(5)], // eslint-disable-line
       ],
       propertyBoolean: [
         [false, true, false],
@@ -699,7 +724,7 @@ describe("Scene/MetadataTableProperty", function () {
     }
   });
 
-  it("set sets fixed size arrays", function () {
+  it("set sets vector values", function () {
     var properties = {
       propertyInt8: {
         type: "ARRAY",
@@ -731,16 +756,6 @@ describe("Scene/MetadataTableProperty", function () {
         componentType: "UINT32",
         componentCount: 3,
       },
-      propertyInt64: {
-        type: "ARRAY",
-        componentType: "INT64",
-        componentCount: 3,
-      },
-      propertyUint64: {
-        type: "ARRAY",
-        componentType: "UINT64",
-        componentCount: 3,
-      },
       propertyFloat32: {
         type: "ARRAY",
         componentType: "FLOAT32",
@@ -749,22 +764,6 @@ describe("Scene/MetadataTableProperty", function () {
       propertyFloat64: {
         type: "ARRAY",
         componentType: "FLOAT64",
-        componentCount: 3,
-      },
-      propertyBoolean: {
-        type: "ARRAY",
-        componentType: "BOOLEAN",
-        componentCount: 3,
-      },
-      propertyString: {
-        type: "ARRAY",
-        componentType: "STRING",
-        componentCount: 3,
-      },
-      propertyEnum: {
-        type: "ARRAY",
-        componentType: "ENUM",
-        enumType: "myEnum",
         componentCount: 3,
       },
     };
@@ -794,14 +793,6 @@ describe("Scene/MetadataTableProperty", function () {
         [0, 0, 0],
         [0, 0, 0],
       ],
-      propertyInt64: [
-        [BigInt(0), BigInt(0), BigInt(0)], // eslint-disable-line
-        [BigInt(0), BigInt(0), BigInt(0)], // eslint-disable-line
-      ],
-      propertyUint64: [
-        [BigInt(0), BigInt(0), BigInt(0)], // eslint-disable-line
-        [BigInt(0), BigInt(0), BigInt(0)], // eslint-disable-line
-      ],
       propertyFloat32: [
         [0.0, 0.0, 0.0],
         [0.0, 0.0, 0.0],
@@ -809,6 +800,86 @@ describe("Scene/MetadataTableProperty", function () {
       propertyFloat64: [
         [0.0, 0.0, 0.0],
         [0.0, 0.0, 0.0],
+      ],
+    };
+
+    var valuesToSet = {
+      propertyInt8: [new Cartesian3(-2, -1, 0), new Cartesian3(1, 2, 3)],
+      propertyUint8: [new Cartesian3(0, 1, 2), new Cartesian3(3, 4, 5)],
+      propertyInt16: [new Cartesian3(-2, -1, 0), new Cartesian3(1, 2, 3)],
+      propertyUint16: [new Cartesian3(0, 1, 2), new Cartesian3(3, 4, 5)],
+      propertyInt32: [new Cartesian3(-2, -1, 0), new Cartesian3(1, 2, 3)],
+      propertyUint32: [new Cartesian3(0, 1, 2), new Cartesian3(3, 4, 5)],
+      propertyFloat32: [
+        new Cartesian3(-2.0, -1.0, 0.0),
+        new Cartesian3(1.0, 2.0, 3.0),
+      ],
+      propertyFloat64: [
+        new Cartesian3(-2.0, -1.0, 0.0),
+        new Cartesian3(1.0, 2.0, 3.0),
+      ],
+    };
+
+    for (var propertyId in properties) {
+      if (properties.hasOwnProperty(propertyId)) {
+        var property = MetadataTester.createProperty({
+          property: properties[propertyId],
+          values: propertyValues[propertyId],
+          enums: enums,
+        });
+        var expectedValues = valuesToSet[propertyId];
+        var length = expectedValues.length;
+        for (var i = 0; i < length; ++i) {
+          property.set(i, expectedValues[i]);
+          var value = property.get(i);
+          expect(value).toEqual(expectedValues[i]);
+          // Test setting / getting again
+          property.set(i, expectedValues[i]);
+          value = property.get(i);
+          expect(value).toEqual(expectedValues[i]);
+        }
+      }
+    }
+  });
+
+  it("set sets fixed size arrays", function () {
+    var properties = {
+      propertyInt64: {
+        type: "ARRAY",
+        componentType: "INT64",
+        componentCount: 3,
+      },
+      propertyUint64: {
+        type: "ARRAY",
+        componentType: "UINT64",
+        componentCount: 3,
+      },
+      propertyBoolean: {
+        type: "ARRAY",
+        componentType: "BOOLEAN",
+        componentCount: 3,
+      },
+      propertyString: {
+        type: "ARRAY",
+        componentType: "STRING",
+        componentCount: 3,
+      },
+      propertyEnum: {
+        type: "ARRAY",
+        componentType: "ENUM",
+        enumType: "myEnum",
+        componentCount: 3,
+      },
+    };
+
+    var propertyValues = {
+      propertyInt64: [
+        [BigInt(0), BigInt(0), BigInt(0)], // eslint-disable-line
+        [BigInt(0), BigInt(0), BigInt(0)], // eslint-disable-line
+      ],
+      propertyUint64: [
+        [BigInt(0), BigInt(0), BigInt(0)], // eslint-disable-line
+        [BigInt(0), BigInt(0), BigInt(0)], // eslint-disable-line
       ],
       propertyBoolean: [
         [false, false, false],
@@ -825,12 +896,6 @@ describe("Scene/MetadataTableProperty", function () {
     };
 
     var valuesToSet = {
-      propertyInt8: [new Cartesian3(-2, -1, 0), new Cartesian3(1, 2, 3)],
-      propertyUint8: [new Cartesian3(0, 1, 2), new Cartesian3(3, 4, 5)],
-      propertyInt16: [new Cartesian3(-2, -1, 0), new Cartesian3(1, 2, 3)],
-      propertyUint16: [new Cartesian3(0, 1, 2), new Cartesian3(3, 4, 5)],
-      propertyInt32: [new Cartesian3(-2, -1, 0), new Cartesian3(1, 2, 3)],
-      propertyUint32: [new Cartesian3(0, 1, 2), new Cartesian3(3, 4, 5)],
       propertyInt64: [
         [BigInt(-2), BigInt(-1), BigInt(0)], // eslint-disable-line
         [BigInt(1), BigInt(2), BigInt(3)], // eslint-disable-line
@@ -838,14 +903,6 @@ describe("Scene/MetadataTableProperty", function () {
       propertyUint64: [
         [BigInt(0), BigInt(1), BigInt(2)], // eslint-disable-line
         [BigInt(3), BigInt(4), BigInt(5)], // eslint-disable-line
-      ],
-      propertyFloat32: [
-        new Cartesian3(-2.0, -1.0, 0.0),
-        new Cartesian3(1.0, 2.0, 3.0),
-      ],
-      propertyFloat64: [
-        new Cartesian3(-2.0, -1.0, 0.0),
-        new Cartesian3(1.0, 2.0, 3.0),
       ],
       propertyBoolean: [
         [false, true, false],

--- a/Specs/Scene/MetadataTableSpec.js
+++ b/Specs/Scene/MetadataTableSpec.js
@@ -1,4 +1,4 @@
-import { MetadataTable } from "../../Source/Cesium.js";
+import { Cartesian3, MetadataTable } from "../../Source/Cesium.js";
 import MetadataTester from "../MetadataTester.js";
 
 describe("Scene/MetadataTable", function () {
@@ -308,8 +308,7 @@ describe("Scene/MetadataTable", function () {
     });
 
     var value = metadataTable.getProperty(0, "position");
-    expect(value).toEqual(position);
-    expect(value).not.toBe(position); // The value is cloned
+    expect(value).toEqual(Cartesian3.unpack(position));
 
     expect(metadataTable.getProperty(0, "type")).toBe("Other");
   });

--- a/Specs/Scene/Multiple3DTileContentSpec.js
+++ b/Specs/Scene/Multiple3DTileContentSpec.js
@@ -349,14 +349,18 @@ describe(
           var buildingsContent = innerContents[0];
           var groupMetadata = buildingsContent.groupMetadata;
           expect(groupMetadata).toBeDefined();
-          expect(groupMetadata.getProperty("color")).toEqual([255, 127, 0]);
+          expect(groupMetadata.getProperty("color")).toEqual(
+            new Cartesian3(255, 127, 0)
+          );
           expect(groupMetadata.getProperty("priority")).toBe(10);
           expect(groupMetadata.getProperty("isInstanced")).toBe(false);
 
           var cubesContent = innerContents[1];
           groupMetadata = cubesContent.groupMetadata;
           expect(groupMetadata).toBeDefined();
-          expect(groupMetadata.getProperty("color")).toEqual([0, 255, 127]);
+          expect(groupMetadata.getProperty("color")).toEqual(
+            new Cartesian3(0, 255, 127)
+          );
           expect(groupMetadata.getProperty("priority")).toBe(5);
           expect(groupMetadata.getProperty("isInstanced")).toBe(true);
         });

--- a/Specs/Scene/TilesetMetadataSpec.js
+++ b/Specs/Scene/TilesetMetadataSpec.js
@@ -1,4 +1,8 @@
-import { MetadataClass, TilesetMetadata } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  MetadataClass,
+  TilesetMetadata,
+} from "../../Source/Cesium.js";
 
 describe("Scene/TilesetMetadata", function () {
   it("creates tileset metadata with default values", function () {
@@ -306,8 +310,7 @@ describe("Scene/TilesetMetadata", function () {
     });
 
     var value = tilesetMetadata.getProperty("position");
-    expect(value).toEqual(position);
-    expect(value).not.toBe(position); // The value is cloned
+    expect(value).toEqual(Cartesian3.unpack(position));
   });
 
   it("getProperty returns the default value when the property is missing", function () {
@@ -333,8 +336,7 @@ describe("Scene/TilesetMetadata", function () {
     });
 
     var value = tilesetMetadata.getProperty("position");
-    expect(value).toEqual(position);
-    expect(value).not.toBe(position); // The value is cloned
+    expect(value).toEqual(Cartesian3.unpack(position));
   });
 
   it("getProperty throws without propertyId", function () {
@@ -381,7 +383,7 @@ describe("Scene/TilesetMetadata", function () {
       },
     });
 
-    var position = [1.0, 1.0, 1.0];
+    var position = new Cartesian3(1.0, 1.0, 1.0);
     tilesetMetadata.setProperty("position", position);
     expect(tilesetMetadata.getProperty("position")).toEqual(position);
     expect(tilesetMetadata.getProperty("position")).not.toBe(position); // The value is cloned

--- a/Specs/Scene/parseBatchTableSpec.js
+++ b/Specs/Scene/parseBatchTableSpec.js
@@ -1,4 +1,10 @@
-import { parseBatchTable, MetadataType } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Cartesian4,
+  parseBatchTable,
+  MetadataType,
+} from "../../Source/Cesium.js";
 
 describe("Scene/parseBatchTable", function () {
   var batchTableJson = {};
@@ -170,14 +176,15 @@ describe("Scene/parseBatchTable", function () {
     expect(properties.dvec4Property.componentCount).toBe(4);
 
     var featureTable = metadata.getFeatureTable("_batchTable");
-    expect(featureTable.getProperty(0, "vec2Property")).toEqual([0.0, 0.0]);
-    expect(featureTable.getProperty(0, "uvec3Property")).toEqual([0, 0, 0]);
-    expect(featureTable.getProperty(0, "dvec4Property")).toEqual([
-      0.0,
-      0.0,
-      0.0,
-      0.0,
-    ]);
+    expect(featureTable.getProperty(0, "vec2Property")).toEqual(
+      new Cartesian2(0.0, 0.0)
+    );
+    expect(featureTable.getProperty(0, "uvec3Property")).toEqual(
+      new Cartesian3(0, 0, 0)
+    );
+    expect(featureTable.getProperty(0, "dvec4Property")).toEqual(
+      new Cartesian4(0.0, 0.0, 0.0, 0.0)
+    );
   });
 
   it("parses batch table with JSON properties", function () {


### PR DESCRIPTION
This is another PR that targets the `3d-tiles-next` branch. 

This PR is to maintain backwards compatibility with the old batch table, where vector types are automatically parsed as `Cartesian(2|3|4)` types.

The following types are automatically packed: `ARRAY`s with `componentCount` of 2, 3, or 4, and one of the following `componentType`s:

* UINT8
* UINT16
* UINT32
* INT8
* INT16
* INT32
* FLOAT32
* FLOAT64

64-bit integers are NOT supported as vectors, as they are not compatible with the Cartesian classes.

[Local Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=lVZRb9s2EP4rNyOopcGQ7KR5SexgTTr0pZmL2ttLFQw0dba5UaRAUnZVw/99J0py5CRLXMCQRd53H49395HiWlkHG4FbNDABhVu4QyuKLPrLzwVJj/vxnVaOCYUm6YXXiUpU7RNZjgqj3IhMOLFBG7E0DRoKbpA5nNrsthAyFWplg7B25n5ZJyRadMfr1n8XH+e1MdglCqAw8gqSXjzLkdv4I3MsPsLF9+hYWk1/kLJ9n5c5WZpFon+sVkkvUfu3w29cKmAD+6F1NtddQ7uHmSsl0g5eiN6bOlCupTa3ZWUiB7+vOIb5Gg+JsE4bTGugBWahEMrZAaxRcUIRMhUbYYVWUeNdzeWaUIQxCMJCqQtIteo7SipxOQ2FRWjgZrFiwdnOL/Bt+LAfQDsYdQfn3cHFwz4EpsqMYqto/OwV9Bv7HmLYIH8fnF9eDuDxMQr7lOzn2/+i80IyR3tok9AQ+vdqpFJRme0VfKungF56FHZ+cN3DL5MJFCrFJfVkGsK7d3BsH8NoOEx6A+oazx/0VwZR9cOk9zDo0DpT4BGMCuBBNcb/7Y83Ytd6e1tYWtjadg/VXNWhZ7tFY7nThXJ7mFCco/cXvvM8x5N0zDBjygn+JBmU3bvp5+nXn8vuJ6OL3P5cXs92n75O//zy9x8f7n+vw6UUWJEiRcVk/4QUvsDAdZah4c8I2uQe3KknlYaVj/u1qixkgW+UpSMvn/uOxrRC0EsvFrdtl4O6eaxXX+2xXQu+BqG4LFIynNfCbLWGGzSlW9M5BihJU0KR5oSzsDQ6q8kbHT9lXJOULztkTWWSnlktWF3as93BaQ+/wuVwAPQbRcPwsXWWheJeOCzPZemPl8BWz7DeqUFXGAVBCJObtuzt8Webc6o6abue1z6T9Nz7U5EZ0LnvEsL6Nml58LurIr6rQodFCVWeqUS1lfAokROiE1qnIKFfZfAa3+O5cBLrI/z/uWckSmiVSvWcKlm+Tt6V9gkxt+I9KeIW/BZvLeITKGvgCWEeOuvkenl02IjswTffjKmUM+skVnfkXGu5YOYeVRE0DRNe9wa9se+qm1bKv4ks18ZV93cQRbHDLKei0a28KPi/1JWc0nxdg8dx13VMFx2IdPLC5wdwyawly7KQciZ+UBfejGPCP3OVmlVfHVPSrWRlBVuPbj7Xk1EUjWMavuzp6u09Yf4P)

@lilleyse could you review?