### PR TITLE
Camera flyto fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ##### Fixes :wrench:
 
-- `Camera.flyTo` flies to the correct location in 3D when no default ellipsoid is used [#9498](https://github.com/CesiumGS/cesium/pull/9498)
+- Fixed an issue where `Camera.flyTo` would not work properly with a non-WGS84 Ellipsoid. [#9498](https://github.com/CesiumGS/cesium/pull/9498)
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### 1.81 - 2021-05-01
 
+##### Fixes :wrench:
+
+- `Camera.flyTo` flies to the correct location in 3D when no default ellipsoid is used [#9498](https://github.com/CesiumGS/cesium/pull/9498)
+
 ##### Deprecated :hourglass_flowing_sand:
 
 - `loadCRN` has been deprecated and will be removed in CesiumJS 1.82. It will be replaced with support for KTX2. [#9478](https://github.com/CesiumGS/cesium/pull/9478)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -286,3 +286,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Mac Clayton](https://github.com/mclayton7)
 - [Ben Murphy](https://github.com/littlemurph)
 - [Ethan Wong](https://github.com/GetToSet)
+- [Calogero Mauceri](https://github.com/kalosma)

--- a/Source/Scene/CameraFlightPath.js
+++ b/Source/Scene/CameraFlightPath.js
@@ -303,7 +303,8 @@ function createUpdate3D(
       var position = Cartesian3.fromRadians(
         CesiumMath.lerp(startLongitude, destLongitude, time),
         CesiumMath.lerp(startLatitude, destLatitude, time),
-        heightFunction(time)
+        heightFunction(time),
+        ellipsoid
       );
 
       camera.setView({

--- a/Specs/Scene/CameraFlightPathSpec.js
+++ b/Specs/Scene/CameraFlightPathSpec.js
@@ -1,5 +1,8 @@
 import { Cartesian3 } from "../../Source/Cesium.js";
 import { Cartographic } from "../../Source/Cesium.js";
+import { Ellipsoid } from "../../Source/Cesium.js";
+import { GeographicProjection } from "../../../Source/Cesium.js";
+import { Globe } from "../../../Source/Cesium.js";
 import { Math as CesiumMath } from "../../Source/Cesium.js";
 import { OrthographicOffCenterFrustum } from "../../Source/Cesium.js";
 import { CameraFlightPath } from "../../Source/Cesium.js";
@@ -106,6 +109,27 @@ describe(
       expect(camera.heading).toEqualEpsilon(endHeading, CesiumMath.EPSILON12);
       expect(camera.pitch).toEqualEpsilon(endPitch, CesiumMath.EPSILON12);
       expect(camera.roll).toEqualEpsilon(endRoll, CesiumMath.EPSILON12);
+    });
+
+    it("creates an animation in 3d using custom ellipsoid", function () {
+      var ellipsoid = new Ellipsoid(1737400, 1737400, 1737400);
+      var mapProjection = new GeographicProjection(ellipsoid);
+      scene = createScene({
+        mapProjection: mapProjection,
+      });
+      scene.globe = new Globe(ellipsoid);
+
+      var camera = scene.camera;
+      var endPosition = Cartesian3.fromDegrees(0.0, 0.0, 100.0, ellipsoid);
+
+      var duration = 1.0;
+      var flight = CameraFlightPath.createTween(scene, {
+        destination: endPosition,
+        duration: duration,
+      });
+
+      flight.update({ time: duration });
+      expect(camera.position).toEqualEpsilon(endPosition, CesiumMath.EPSILON7);
     });
 
     it("creates an animation in Columbus view", function () {

--- a/Specs/Scene/CameraFlightPathSpec.js
+++ b/Specs/Scene/CameraFlightPathSpec.js
@@ -120,6 +120,8 @@ describe(
       scene.globe = new Globe(ellipsoid);
 
       var camera = scene.camera;
+
+      var startPosition = Cartesian3.clone(camera.position);
       var endPosition = Cartesian3.fromDegrees(0.0, 0.0, 100.0, ellipsoid);
 
       var duration = 1.0;
@@ -127,6 +129,12 @@ describe(
         destination: endPosition,
         duration: duration,
       });
+
+      flight.update({ time: 0.0 });
+      expect(camera.position).toEqualEpsilon(
+        startPosition,
+        CesiumMath.EPSILON12
+      );
 
       flight.update({ time: duration });
       expect(camera.position).toEqualEpsilon(endPosition, CesiumMath.EPSILON7);


### PR DESCRIPTION
Fix for bug [#9497](https://github.com/CesiumGS/cesium/issues/9497)

The camera flyTo is not properly working when using a generic ellipsoid, for example a lunar one (ellipsoid radius: 1737400).
The final cartographic camera position is the one in WGS84 ellipsoid.

The problem is visible in the following sandcastle example.
The flyTo destination position is set to
(1737500, 0, 0)
The final camera position when the flyTo finishes is
(6378237, 0, 0)

Sandcastle example:
[sandcastle](https://sandcastle.cesium.com/#c=jVVra9swFP0rIl/iQJCTdVvBTcsg7R7QsULD+iVQFPvG0SZLRpIdspL/vivLjh/NygTB1r1H5577sFIyTUAInhvFE3JNJOzJEgwvMnrXmIP55cXl+9lsOnhOrtYyDAkwbXdEs4QXpuWqXOX/sH+8uJzPkHXwdOzufMbyB61+QWy5kn2OL6BSzfIdj1tEcIrXEKRCbWBw0Jn6SI9VuTUIfVlLgqsXOupvpx5SkUf+UZs2zMA9O4B+4PFv0BHZMmFgLY+1npLDHnRf0M/KFozjartU0jIuQY+nlaJWH89YCvpQ0Tuhnov2zAju7SlLkm/egPJLnmCgTugn2Hxn+SPokscwxNWFKLQgERnvrM1NFIZ72GAtqNAqpswUFJIiHNfZCy8N0aKQ7HnP4mdXHCYaQM40y8B6UM3vltVMGnSCtOiwumjq6dZW6Yw5+7hKLcxlOvbeY42yXHCZPsY7yLAfZ4dk1YEEL+1gRp0ZPU5aPnjiid1F5MP8Xcf4FXi6s5UVezrxvammfSsOVpEEjOWSVdOaK8Pdi29ejHlr1nbNxCCBems9G6h7We0flGtvncISvzB8Y/KCbrXKbiHVACZoy+PWbPr2Hr+pgaU3/7GSRgmgQqXBenR7LonRENdV285oAsKyFar/4OCVn2JpVip46cbv1Cnq5T09QXrwQtdYz9/J5djGjrFSTbuXTbk7w7Ds+IPqgvCtqGVmqoQ7mbgv5q7EQbznxmKPdLAtpL9dJn5kT6WjcdObleqR14xN8aZnpE2ufIru1y//ZyyMaOaloSDBaQ4mvhf9Y4OIrwFv8jbS/kH9Wrsb/qvRdLQw9iDgpmnHJ57lSlt3ZQSUhhayXDBUHW4KvA0tjY3x/IQswu7RRcJLwpPr9WhwCa5HJBbMGPRsCyEe+R9Yj24WIeJfHRUK/4Zk+qMEjReRg+3mN/feSCldhLg9f9IqJTZMD5j/Ag)