### PR TITLE
Factor out a BatchTexture class

### DIFF
--- a/Source/Scene/BatchTexture.js
+++ b/Source/Scene/BatchTexture.js
@@ -215,7 +215,7 @@ function getShowAlphaProperties(batchTexture) {
 }
 
 function checkBatchId(batchId, featuresLength) {
-  if (!defined(batchId) || batchId < 0 || batchId > featuresLength) {
+  if (!defined(batchId) || batchId < 0 || batchId >= featuresLength) {
     throw new DeveloperError(
       "batchId is required and between zero and featuresLength - 1 (" +
         featuresLength -

--- a/Source/Scene/BatchTexture.js
+++ b/Source/Scene/BatchTexture.js
@@ -63,6 +63,7 @@ export default function BatchTexture(options) {
     textureStep = new Cartesian4(stepX, centerX, stepY, centerY);
   }
 
+  this._translucentFeaturesLength = 0;
   this._featuresLength = featuresLength;
   this._textureDimensions = textureDimensions;
   this._textureStep = textureStep;
@@ -71,6 +72,20 @@ export default function BatchTexture(options) {
 }
 
 Object.defineProperties(BatchTexture.prototype, {
+  /**
+   * Number of features that are translucent
+   *
+   * @memberof BatchTexture.prototype
+   * @type {Number}
+   * @readonly
+   * @private
+   */
+  translucentFeaturesLength: {
+    get: function () {
+      return this._translucentFeaturesLength;
+    },
+  },
+
   /**
    * Total size of all GPU resources used by this batch texture.
    *

--- a/Source/Scene/BatchTexture.js
+++ b/Source/Scene/BatchTexture.js
@@ -29,6 +29,7 @@ import Texture from "../Renderer/Texture.js";
 export default function BatchTexture(options) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.number("options.featuresLength", options.featuresLength);
+  Check.typeOf.object("options.content", options.content);
   //>>includeEnd('debug');
 
   var featuresLength = options.featuresLength;

--- a/Source/Scene/BatchTexture.js
+++ b/Source/Scene/BatchTexture.js
@@ -1,0 +1,369 @@
+import arrayFill from "../Core/arrayFill.js";
+import Cartesian2 from "../Core/Cartesian2.js";
+import Cartesian4 from "../Core/Cartesian4.js";
+import Check from "../Core/Check.js";
+import Color from "../Core/Color.js";
+import defined from "../Core/defined.js";
+import destroyObject from "../Core/destroyObject.js";
+import DeveloperError from "../Core/DeveloperError.js";
+import PixelFormat from "../Core/PixelFormat.js";
+import ContextLimits from "../Renderer/ContextLimits.js";
+import PixelDatatype from "../Renderer/PixelDatatype.js";
+import Sampler from "../Renderer/Sampler.js";
+import Texture from "../Renderer/Texture.js";
+
+export default function BatchTexture(options) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.number("options.featuresLength", options.featuresLength);
+  //>>includeEnd('debug');
+
+  var featuresLength = options.featuresLength;
+
+  // PERFORMANCE_IDEA: These parallel arrays probably generate cache misses in get/set color/show
+  // and use A LOT of memory.  How can we use less memory?
+  this._showAlphaProperties = undefined; // [Show (0 or 255), Alpha (0 to 255)] property for each feature
+  this._batchValues = undefined; // Per-feature RGBA (A is based on the color's alpha and feature's show property)
+
+  this._batchValuesDirty = false;
+  this._batchTexture = undefined;
+  this._defaultTexture = undefined;
+
+  this._pickTexture = undefined;
+  this._pickIds = [];
+
+  // Dimensions for batch and pick textures
+  var textureDimensions;
+  var textureStep;
+
+  if (featuresLength > 0) {
+    // PERFORMANCE_IDEA: this can waste memory in the last row in the uncommon case
+    // when more than one row is needed (e.g., > 16K features in one tile)
+    var width = Math.min(featuresLength, ContextLimits.maximumTextureSize);
+    var height = Math.ceil(featuresLength / ContextLimits.maximumTextureSize);
+    var stepX = 1.0 / width;
+    var centerX = stepX * 0.5;
+    var stepY = 1.0 / height;
+    var centerY = stepY * 0.5;
+
+    textureDimensions = new Cartesian2(width, height);
+    textureStep = new Cartesian4(stepX, centerX, stepY, centerY);
+  }
+
+  this._textureDimensions = textureDimensions;
+  this._textureStep = textureStep;
+
+  this._colorChangedCallback = options.colorChangedCallback;
+}
+
+Object.defineProperties(BatchTexture.prototype, {
+  memorySizeInBytes: {
+    get: function () {
+      var memory = 0;
+      if (defined(this._pickTexture)) {
+        memory += this._pickTexture.sizeInBytes;
+      }
+      if (defined(this._batchTexture)) {
+        memory += this._batchTexture.sizeInBytes;
+      }
+      return memory;
+    },
+  },
+
+  textureDimensions: {
+    get: function () {
+      return this._textureDimensions;
+    },
+  },
+});
+
+BatchTexture.DEFAULT_COLOR_VALUE = Color.WHITE;
+BatchTexture.DEFAULT_SHOW_VALUE = true;
+
+function getByteLength(batchTexture) {
+  var dimensions = batchTexture._textureDimensions;
+  return dimensions.x * dimensions.y * 4;
+}
+
+function getBatchValues(batchTexture) {
+  if (!defined(batchTexture._batchValues)) {
+    // Default batch texture to RGBA = 255: white highlight (RGB) and show/alpha = true/255 (A).
+    var byteLength = getByteLength(batchTexture);
+    var bytes = new Uint8Array(byteLength);
+    arrayFill(bytes, 255);
+    batchTexture._batchValues = bytes;
+  }
+
+  return batchTexture._batchValues;
+}
+
+function getShowAlphaProperties(batchTexture) {
+  if (!defined(batchTexture._showAlphaProperties)) {
+    var byteLength = 2 * batchTexture.featuresLength;
+    var bytes = new Uint8Array(byteLength);
+    // [Show = true, Alpha = 255]
+    arrayFill(bytes, 255);
+    batchTexture._showAlphaProperties = bytes;
+  }
+  return batchTexture._showAlphaProperties;
+}
+
+function checkBatchId(batchId, featuresLength) {
+  if (!defined(batchId) || batchId < 0 || batchId > featuresLength) {
+    throw new DeveloperError(
+      "batchId is required and between zero and featuresLength - 1 (" +
+        featuresLength -
+        +")."
+    );
+  }
+}
+
+BatchTexture.prototype.setShow = function (batchId, show) {
+  //>>includeStart('debug', pragmas.debug);
+  checkBatchId(batchId, this.featuresLength);
+  Check.typeOf.bool("show", show);
+  //>>includeEnd('debug');
+
+  if (show && !defined(this._showAlphaProperties)) {
+    // Avoid allocating since the default is show = true
+    return;
+  }
+
+  var showAlphaProperties = getShowAlphaProperties(this);
+  var propertyOffset = batchId * 2;
+
+  var newShow = show ? 255 : 0;
+  if (showAlphaProperties[propertyOffset] !== newShow) {
+    showAlphaProperties[propertyOffset] = newShow;
+
+    var batchValues = getBatchValues(this);
+
+    // Compute alpha used in the shader based on show and color.alpha properties
+    var offset = batchId * 4 + 3;
+    batchValues[offset] = show ? showAlphaProperties[propertyOffset + 1] : 0;
+
+    this._batchValuesDirty = true;
+  }
+};
+
+BatchTexture.prototype.setAllShow = function (show) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.bool("show", show);
+  //>>includeEnd('debug');
+
+  var featuresLength = this.featuresLength;
+  for (var i = 0; i < featuresLength; ++i) {
+    this.setShow(i, show);
+  }
+};
+
+BatchTexture.prototype.getShow = function (batchId) {
+  //>>includeStart('debug', pragmas.debug);
+  checkBatchId(batchId, this.featuresLength);
+  //>>includeEnd('debug');
+
+  if (!defined(this._showAlphaProperties)) {
+    // Avoid allocating since the default is show = true
+    return true;
+  }
+
+  var offset = batchId * 2;
+  return this._showAlphaProperties[offset] === 255;
+};
+
+var scratchColorBytes = new Array(4);
+BatchTexture.prototype.setColor = function (batchId, color) {
+  //>>includeStart('debug', pragmas.debug);
+  checkBatchId(batchId, this.featuresLength);
+  Check.typeOf.object("color", color);
+  //>>includeEnd('debug');
+
+  if (
+    Color.equals(color, BatchTexture.DEFAULT_COLOR_VALUE) &&
+    !defined(this._batchValues)
+  ) {
+    // Avoid allocating since the default is white
+    return;
+  }
+
+  var newColor = color.toBytes(scratchColorBytes);
+  var newAlpha = newColor[3];
+
+  var batchValues = getBatchValues(this);
+  var offset = batchId * 4;
+
+  var showAlphaProperties = getShowAlphaProperties(this);
+  var propertyOffset = batchId * 2;
+
+  if (
+    batchValues[offset] !== newColor[0] ||
+    batchValues[offset + 1] !== newColor[1] ||
+    batchValues[offset + 2] !== newColor[2] ||
+    showAlphaProperties[propertyOffset + 1] !== newAlpha
+  ) {
+    batchValues[offset] = newColor[0];
+    batchValues[offset + 1] = newColor[1];
+    batchValues[offset + 2] = newColor[2];
+
+    var wasTranslucent = showAlphaProperties[propertyOffset + 1] !== 255;
+
+    // Compute alpha used in the shader based on show and color.alpha properties
+    var show = showAlphaProperties[propertyOffset] !== 0;
+    batchValues[offset + 3] = show ? newAlpha : 0;
+    showAlphaProperties[propertyOffset + 1] = newAlpha;
+
+    // Track number of translucent features so we know if this tile needs
+    // opaque commands, translucent commands, or both for rendering.
+    var isTranslucent = newAlpha !== 255;
+    if (isTranslucent && !wasTranslucent) {
+      ++this._translucentFeaturesLength;
+    } else if (!isTranslucent && wasTranslucent) {
+      --this._translucentFeaturesLength;
+    }
+
+    this._batchValuesDirty = true;
+
+    if (defined(this._colorChangedCallback)) {
+      this._colorChangedCallback(batchId, color);
+    }
+  }
+};
+
+BatchTexture.prototype.setAllColor = function (color) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("color", color);
+  //>>includeEnd('debug');
+
+  var featuresLength = this.featuresLength;
+  for (var i = 0; i < featuresLength; ++i) {
+    this.setColor(i, color);
+  }
+};
+
+BatchTexture.prototype.getColor = function (batchId, result) {
+  //>>includeStart('debug', pragmas.debug);
+  checkBatchId(batchId, this.featuresLength);
+  Check.typeOf.object("result", result);
+  //>>includeEnd('debug');
+
+  if (!defined(this._batchValues)) {
+    return Color.clone(BatchTexture.DEFAULT_COLOR_VALUE, result);
+  }
+
+  var batchValues = this._batchValues;
+  var offset = batchId * 4;
+
+  var showAlphaProperties = this._showAlphaProperties;
+  var propertyOffset = batchId * 2;
+
+  return Color.fromBytes(
+    batchValues[offset],
+    batchValues[offset + 1],
+    batchValues[offset + 2],
+    showAlphaProperties[propertyOffset + 1],
+    result
+  );
+};
+
+BatchTexture.prototype.getPickColor = function (batchId) {
+  //>>includeStart('debug', pragmas.debug);
+  checkBatchId(batchId, this.featuresLength);
+  //>>includeEnd('debug');
+  return this._pickIds[batchId];
+};
+
+function createTexture(batchTexture, context, bytes) {
+  var dimensions = batchTexture._textureDimensions;
+  return new Texture({
+    context: context,
+    pixelFormat: PixelFormat.RGBA,
+    pixelDatatype: PixelDatatype.UNSIGNED_BYTE,
+    source: {
+      width: dimensions.x,
+      height: dimensions.y,
+      arrayBufferView: bytes,
+    },
+    flipY: false,
+    sampler: Sampler.NEAREST,
+  });
+}
+
+function createPickTexture(batchTexture, context) {
+  var featuresLength = batchTexture.featuresLength;
+  if (!defined(batchTexture._pickTexture) && featuresLength > 0) {
+    var pickIds = batchTexture._pickIds;
+    var byteLength = getByteLength(batchTexture);
+    var bytes = new Uint8Array(byteLength);
+    var content = batchTexture._content;
+
+    // PERFORMANCE_IDEA: we could skip the pick texture completely by allocating
+    // a continuous range of pickIds and then converting the base pickId + batchId
+    // to RGBA in the shader.  The only consider is precision issues, which might
+    // not be an issue in WebGL 2.
+    for (var i = 0; i < featuresLength; ++i) {
+      var pickId = context.createPickId(content.getFeature(i));
+      pickIds.push(pickId);
+
+      var pickColor = pickId.color;
+      var offset = i * 4;
+      bytes[offset] = Color.floatToByte(pickColor.red);
+      bytes[offset + 1] = Color.floatToByte(pickColor.green);
+      bytes[offset + 2] = Color.floatToByte(pickColor.blue);
+      bytes[offset + 3] = Color.floatToByte(pickColor.alpha);
+    }
+
+    batchTexture._pickTexture = createTexture(batchTexture, context, bytes);
+    content.tileset._statistics.batchTableByteLength +=
+      batchTexture._pickTexture.sizeInBytes;
+  }
+}
+
+function updateBatchTexture(batchTexture) {
+  var dimensions = batchTexture._textureDimensions;
+  // PERFORMANCE_IDEA: Instead of rewriting the entire texture, use fine-grained
+  // texture updates when less than, for example, 10%, of the values changed.  Or
+  // even just optimize the common case when one feature show/color changed.
+  batchTexture._batchTexture.copyFrom({
+    width: dimensions.x,
+    height: dimensions.y,
+    arrayBufferView: batchTexture._batchValues,
+  });
+}
+
+BatchTexture.prototype.update = function (tileset, frameState) {
+  var context = frameState.context;
+  this._defaultTexture = context.defaultTexture;
+
+  var passes = frameState.passes;
+  if (passes.pick || passes.postProcess) {
+    createPickTexture(this, context);
+  }
+
+  if (this._batchValuesDirty) {
+    this._batchValuesDirty = false;
+
+    // Create batch texture on-demand
+    if (!defined(this._batchTexture)) {
+      this._batchTexture = createTexture(this, context, this._batchValues);
+      tileset._statistics.batchTableByteLength += this._batchTexture.sizeInBytes;
+    }
+
+    updateBatchTexture(this); // Apply per-feature show/color updates
+  }
+};
+
+BatchTexture.prototype.isDestroyed = function () {
+  return false;
+};
+
+BatchTexture.prototype.destroy = function () {
+  this._batchTexture = this._batchTexture && this._batchTexture.destroy();
+  this._pickTexture = this._pickTexture && this._pickTexture.destroy();
+
+  var pickIds = this._pickIds;
+  var length = pickIds.length;
+  for (var i = 0; i < length; ++i) {
+    pickIds[i].destroy();
+  }
+
+  return destroyObject(this);
+};

--- a/Source/Scene/Cesium3DTileBatchTable.js
+++ b/Source/Scene/Cesium3DTileBatchTable.js
@@ -260,7 +260,7 @@ function setBinaryProperty(binaryProperty, index, value) {
 }
 
 function checkBatchId(batchId, featuresLength) {
-  if (!defined(batchId) || batchId < 0 || batchId > featuresLength) {
+  if (!defined(batchId) || batchId < 0 || batchId >= featuresLength) {
     throw new DeveloperError(
       "batchId is required and between zero and featuresLength - 1 (" +
         featuresLength -

--- a/Source/Scene/Cesium3DTileBatchTable.js
+++ b/Source/Scene/Cesium3DTileBatchTable.js
@@ -44,8 +44,6 @@ function Cesium3DTileBatchTable(
    */
   this.featuresLength = featuresLength;
 
-  this._translucentFeaturesLength = 0; // Number of features in the tile that are translucent
-
   var extensions;
   if (defined(batchTableJson)) {
     extensions = batchTableJson.extensions;
@@ -954,7 +952,8 @@ Cesium3DTileBatchTable.prototype.addDerivedCommands = function (
 };
 
 function getStyleCommandsNeeded(batchTable) {
-  var translucentFeaturesLength = batchTable._translucentFeaturesLength;
+  var translucentFeaturesLength =
+    batchTable._batchTexture.translucentFeaturesLength;
 
   if (translucentFeaturesLength === 0) {
     return StyleCommandsNeeded.ALL_OPAQUE;

--- a/Source/Scene/Cesium3DTileBatchTable.js
+++ b/Source/Scene/Cesium3DTileBatchTable.js
@@ -1,6 +1,4 @@
-import arrayFill from "../Core/arrayFill.js";
 import Cartesian2 from "../Core/Cartesian2.js";
-import Cartesian4 from "../Core/Cartesian4.js";
 import Check from "../Core/Check.js";
 import clone from "../Core/clone.js";
 import Color from "../Core/Color.js";
@@ -11,16 +9,13 @@ import deprecationWarning from "../Core/deprecationWarning.js";
 import destroyObject from "../Core/destroyObject.js";
 import DeveloperError from "../Core/DeveloperError.js";
 import CesiumMath from "../Core/Math.js";
-import PixelFormat from "../Core/PixelFormat.js";
 import RuntimeError from "../Core/RuntimeError.js";
 import ContextLimits from "../Renderer/ContextLimits.js";
 import DrawCommand from "../Renderer/DrawCommand.js";
 import Pass from "../Renderer/Pass.js";
-import PixelDatatype from "../Renderer/PixelDatatype.js";
 import RenderState from "../Renderer/RenderState.js";
-import Sampler from "../Renderer/Sampler.js";
 import ShaderSource from "../Renderer/ShaderSource.js";
-import Texture from "../Renderer/Texture.js";
+import BatchTexture from "./BatchTexture.js";
 import BatchTableHierarchy from "./BatchTableHierarchy.js";
 import BlendingState from "./BlendingState.js";
 import Cesium3DTileColorBlendMode from "./Cesium3DTileColorBlendMode.js";
@@ -30,8 +25,8 @@ import StencilConstants from "./StencilConstants.js";
 import StencilFunction from "./StencilFunction.js";
 import StencilOperation from "./StencilOperation.js";
 
-var DEFAULT_COLOR_VALUE = Color.WHITE;
-var DEFAULT_SHOW_VALUE = true;
+var DEFAULT_COLOR_VALUE = BatchTexture.DEFAULT_COLOR_VALUE;
+var DEFAULT_SHOW_VALUE = BatchTexture.DEFAULT_SHOW_VALUE;
 
 /**
  * @private
@@ -71,42 +66,12 @@ function Cesium3DTileBatchTable(
     batchTableBinary
   );
 
-  // PERFORMANCE_IDEA: These parallel arrays probably generate cache misses in get/set color/show
-  // and use A LOT of memory.  How can we use less memory?
-  this._showAlphaProperties = undefined; // [Show (0 or 255), Alpha (0 to 255)] property for each feature
-  this._batchValues = undefined; // Per-feature RGBA (A is based on the color's alpha and feature's show property)
-
-  this._batchValuesDirty = false;
-  this._batchTexture = undefined;
-  this._defaultTexture = undefined;
-
-  this._pickTexture = undefined;
-  this._pickIds = [];
-
   this._content = content;
 
-  this._colorChangedCallback = colorChangedCallback;
-
-  // Dimensions for batch and pick textures
-  var textureDimensions;
-  var textureStep;
-
-  if (featuresLength > 0) {
-    // PERFORMANCE_IDEA: this can waste memory in the last row in the uncommon case
-    // when more than one row is needed (e.g., > 16K features in one tile)
-    var width = Math.min(featuresLength, ContextLimits.maximumTextureSize);
-    var height = Math.ceil(featuresLength / ContextLimits.maximumTextureSize);
-    var stepX = 1.0 / width;
-    var centerX = stepX * 0.5;
-    var stepY = 1.0 / height;
-    var centerY = stepY * 0.5;
-
-    textureDimensions = new Cartesian2(width, height);
-    textureStep = new Cartesian4(stepX, centerX, stepY, centerY);
-  }
-
-  this._textureDimensions = textureDimensions;
-  this._textureStep = textureStep;
+  this._batchTexture = new BatchTexture({
+    featuresLength: featuresLength,
+    colorChangedCallback: colorChangedCallback,
+  });
 }
 
 // This can be overridden for testing purposes
@@ -115,14 +80,7 @@ Cesium3DTileBatchTable._deprecationWarning = deprecationWarning;
 Object.defineProperties(Cesium3DTileBatchTable.prototype, {
   memorySizeInBytes: {
     get: function () {
-      var memory = 0;
-      if (defined(this._pickTexture)) {
-        memory += this._pickTexture.sizeInBytes;
-      }
-      if (defined(this._batchTexture)) {
-        memory += this._batchTexture.sizeInBytes;
-      }
-      return memory;
+      return this._batchTexture.memorySizeInBytes;
     },
   },
 });
@@ -231,194 +189,32 @@ Cesium3DTileBatchTable.getBinaryProperties = function (
   return getBinaryProperties(featuresLength, batchTableJson, batchTableBinary);
 };
 
-function getByteLength(batchTable) {
-  var dimensions = batchTable._textureDimensions;
-  return dimensions.x * dimensions.y * 4;
-}
-
-function getBatchValues(batchTable) {
-  if (!defined(batchTable._batchValues)) {
-    // Default batch texture to RGBA = 255: white highlight (RGB) and show/alpha = true/255 (A).
-    var byteLength = getByteLength(batchTable);
-    var bytes = new Uint8Array(byteLength);
-    arrayFill(bytes, 255);
-    batchTable._batchValues = bytes;
-  }
-
-  return batchTable._batchValues;
-}
-
-function getShowAlphaProperties(batchTable) {
-  if (!defined(batchTable._showAlphaProperties)) {
-    var byteLength = 2 * batchTable.featuresLength;
-    var bytes = new Uint8Array(byteLength);
-    // [Show = true, Alpha = 255]
-    arrayFill(bytes, 255);
-    batchTable._showAlphaProperties = bytes;
-  }
-  return batchTable._showAlphaProperties;
-}
-
-function checkBatchId(batchId, featuresLength) {
-  if (!defined(batchId) || batchId < 0 || batchId > featuresLength) {
-    throw new DeveloperError(
-      "batchId is required and between zero and featuresLength - 1 (" +
-        featuresLength -
-        +")."
-    );
-  }
-}
-
 Cesium3DTileBatchTable.prototype.setShow = function (batchId, show) {
-  //>>includeStart('debug', pragmas.debug);
-  checkBatchId(batchId, this.featuresLength);
-  Check.typeOf.bool("show", show);
-  //>>includeEnd('debug');
-
-  if (show && !defined(this._showAlphaProperties)) {
-    // Avoid allocating since the default is show = true
-    return;
-  }
-
-  var showAlphaProperties = getShowAlphaProperties(this);
-  var propertyOffset = batchId * 2;
-
-  var newShow = show ? 255 : 0;
-  if (showAlphaProperties[propertyOffset] !== newShow) {
-    showAlphaProperties[propertyOffset] = newShow;
-
-    var batchValues = getBatchValues(this);
-
-    // Compute alpha used in the shader based on show and color.alpha properties
-    var offset = batchId * 4 + 3;
-    batchValues[offset] = show ? showAlphaProperties[propertyOffset + 1] : 0;
-
-    this._batchValuesDirty = true;
-  }
+  this._batchTexture.setShow(batchId, show);
 };
 
 Cesium3DTileBatchTable.prototype.setAllShow = function (show) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.bool("show", show);
-  //>>includeEnd('debug');
-
-  var featuresLength = this.featuresLength;
-  for (var i = 0; i < featuresLength; ++i) {
-    this.setShow(i, show);
-  }
+  this._batchTexture.setAllShow(show);
 };
 
 Cesium3DTileBatchTable.prototype.getShow = function (batchId) {
-  //>>includeStart('debug', pragmas.debug);
-  checkBatchId(batchId, this.featuresLength);
-  //>>includeEnd('debug');
-
-  if (!defined(this._showAlphaProperties)) {
-    // Avoid allocating since the default is show = true
-    return true;
-  }
-
-  var offset = batchId * 2;
-  return this._showAlphaProperties[offset] === 255;
+  return this._batchTexture.getShow(batchId);
 };
 
-var scratchColorBytes = new Array(4);
-
 Cesium3DTileBatchTable.prototype.setColor = function (batchId, color) {
-  //>>includeStart('debug', pragmas.debug);
-  checkBatchId(batchId, this.featuresLength);
-  Check.typeOf.object("color", color);
-  //>>includeEnd('debug');
-
-  if (Color.equals(color, DEFAULT_COLOR_VALUE) && !defined(this._batchValues)) {
-    // Avoid allocating since the default is white
-    return;
-  }
-
-  var newColor = color.toBytes(scratchColorBytes);
-  var newAlpha = newColor[3];
-
-  var batchValues = getBatchValues(this);
-  var offset = batchId * 4;
-
-  var showAlphaProperties = getShowAlphaProperties(this);
-  var propertyOffset = batchId * 2;
-
-  if (
-    batchValues[offset] !== newColor[0] ||
-    batchValues[offset + 1] !== newColor[1] ||
-    batchValues[offset + 2] !== newColor[2] ||
-    showAlphaProperties[propertyOffset + 1] !== newAlpha
-  ) {
-    batchValues[offset] = newColor[0];
-    batchValues[offset + 1] = newColor[1];
-    batchValues[offset + 2] = newColor[2];
-
-    var wasTranslucent = showAlphaProperties[propertyOffset + 1] !== 255;
-
-    // Compute alpha used in the shader based on show and color.alpha properties
-    var show = showAlphaProperties[propertyOffset] !== 0;
-    batchValues[offset + 3] = show ? newAlpha : 0;
-    showAlphaProperties[propertyOffset + 1] = newAlpha;
-
-    // Track number of translucent features so we know if this tile needs
-    // opaque commands, translucent commands, or both for rendering.
-    var isTranslucent = newAlpha !== 255;
-    if (isTranslucent && !wasTranslucent) {
-      ++this._translucentFeaturesLength;
-    } else if (!isTranslucent && wasTranslucent) {
-      --this._translucentFeaturesLength;
-    }
-
-    this._batchValuesDirty = true;
-
-    if (defined(this._colorChangedCallback)) {
-      this._colorChangedCallback(batchId, color);
-    }
-  }
+  this._batchTexture.setColor(batchId, color);
 };
 
 Cesium3DTileBatchTable.prototype.setAllColor = function (color) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("color", color);
-  //>>includeEnd('debug');
-
-  var featuresLength = this.featuresLength;
-  for (var i = 0; i < featuresLength; ++i) {
-    this.setColor(i, color);
-  }
+  this._batchTexture.setAllColor(color);
 };
 
 Cesium3DTileBatchTable.prototype.getColor = function (batchId, result) {
-  //>>includeStart('debug', pragmas.debug);
-  checkBatchId(batchId, this.featuresLength);
-  Check.typeOf.object("result", result);
-  //>>includeEnd('debug');
-
-  if (!defined(this._batchValues)) {
-    return Color.clone(DEFAULT_COLOR_VALUE, result);
-  }
-
-  var batchValues = this._batchValues;
-  var offset = batchId * 4;
-
-  var showAlphaProperties = this._showAlphaProperties;
-  var propertyOffset = batchId * 2;
-
-  return Color.fromBytes(
-    batchValues[offset],
-    batchValues[offset + 1],
-    batchValues[offset + 2],
-    showAlphaProperties[propertyOffset + 1],
-    result
-  );
+  return this._batchTexture.getColor(batchId, result);
 };
 
 Cesium3DTileBatchTable.prototype.getPickColor = function (batchId) {
-  //>>includeStart('debug', pragmas.debug);
-  checkBatchId(batchId, this.featuresLength);
-  //>>includeEnd('debug');
-  return this._pickIds[batchId];
+  return this._batchTexture.getPickColor(batchId);
 };
 
 var scratchColor = new Color();
@@ -461,6 +257,16 @@ function setBinaryProperty(binaryProperty, index, value) {
     typedArray[index] = value;
   } else {
     binaryProperty.type.pack(value, typedArray, index * componentCount);
+  }
+}
+
+function checkBatchId(batchId, featuresLength) {
+  if (!defined(batchId) || batchId < 0 || batchId > featuresLength) {
+    throw new DeveloperError(
+      "batchId is required and between zero and featuresLength - 1 (" +
+        featuresLength -
+        +")."
+    );
   }
 }
 
@@ -600,7 +406,7 @@ Cesium3DTileBatchTable.prototype.setProperty = function (batchId, name, value) {
 
 function getGlslComputeSt(batchTable) {
   // GLSL batchId is zero-based: [0, featuresLength - 1]
-  if (batchTable._textureDimensions.y === 1) {
+  if (batchTable._batchTexture.textureDimensions.y === 1) {
     return (
       "uniform vec4 tile_textureStep; \n" +
       "vec2 computeSt(float batchId) \n" +
@@ -1307,86 +1113,8 @@ function getOpaqueRenderState(renderState) {
   return RenderState.fromCache(rs);
 }
 
-///////////////////////////////////////////////////////////////////////////
-
-function createTexture(batchTable, context, bytes) {
-  var dimensions = batchTable._textureDimensions;
-  return new Texture({
-    context: context,
-    pixelFormat: PixelFormat.RGBA,
-    pixelDatatype: PixelDatatype.UNSIGNED_BYTE,
-    source: {
-      width: dimensions.x,
-      height: dimensions.y,
-      arrayBufferView: bytes,
-    },
-    flipY: false,
-    sampler: Sampler.NEAREST,
-  });
-}
-
-function createPickTexture(batchTable, context) {
-  var featuresLength = batchTable.featuresLength;
-  if (!defined(batchTable._pickTexture) && featuresLength > 0) {
-    var pickIds = batchTable._pickIds;
-    var byteLength = getByteLength(batchTable);
-    var bytes = new Uint8Array(byteLength);
-    var content = batchTable._content;
-
-    // PERFORMANCE_IDEA: we could skip the pick texture completely by allocating
-    // a continuous range of pickIds and then converting the base pickId + batchId
-    // to RGBA in the shader.  The only consider is precision issues, which might
-    // not be an issue in WebGL 2.
-    for (var i = 0; i < featuresLength; ++i) {
-      var pickId = context.createPickId(content.getFeature(i));
-      pickIds.push(pickId);
-
-      var pickColor = pickId.color;
-      var offset = i * 4;
-      bytes[offset] = Color.floatToByte(pickColor.red);
-      bytes[offset + 1] = Color.floatToByte(pickColor.green);
-      bytes[offset + 2] = Color.floatToByte(pickColor.blue);
-      bytes[offset + 3] = Color.floatToByte(pickColor.alpha);
-    }
-
-    batchTable._pickTexture = createTexture(batchTable, context, bytes);
-    content.tileset._statistics.batchTableByteLength +=
-      batchTable._pickTexture.sizeInBytes;
-  }
-}
-
-function updateBatchTexture(batchTable) {
-  var dimensions = batchTable._textureDimensions;
-  // PERFORMANCE_IDEA: Instead of rewriting the entire texture, use fine-grained
-  // texture updates when less than, for example, 10%, of the values changed.  Or
-  // even just optimize the common case when one feature show/color changed.
-  batchTable._batchTexture.copyFrom({
-    width: dimensions.x,
-    height: dimensions.y,
-    arrayBufferView: batchTable._batchValues,
-  });
-}
-
 Cesium3DTileBatchTable.prototype.update = function (tileset, frameState) {
-  var context = frameState.context;
-  this._defaultTexture = context.defaultTexture;
-
-  var passes = frameState.passes;
-  if (passes.pick || passes.postProcess) {
-    createPickTexture(this, context);
-  }
-
-  if (this._batchValuesDirty) {
-    this._batchValuesDirty = false;
-
-    // Create batch texture on-demand
-    if (!defined(this._batchTexture)) {
-      this._batchTexture = createTexture(this, context, this._batchValues);
-      tileset._statistics.batchTableByteLength += this._batchTexture.sizeInBytes;
-    }
-
-    updateBatchTexture(this); // Apply per-feature show/color updates
-  }
+  this._batchTexture.update(tileset, frameState);
 };
 
 Cesium3DTileBatchTable.prototype.isDestroyed = function () {
@@ -1395,14 +1123,6 @@ Cesium3DTileBatchTable.prototype.isDestroyed = function () {
 
 Cesium3DTileBatchTable.prototype.destroy = function () {
   this._batchTexture = this._batchTexture && this._batchTexture.destroy();
-  this._pickTexture = this._pickTexture && this._pickTexture.destroy();
-
-  var pickIds = this._pickIds;
-  var length = pickIds.length;
-  for (var i = 0; i < length; ++i) {
-    pickIds[i].destroy();
-  }
-
   return destroyObject(this);
 };
 export default Cesium3DTileBatchTable;

--- a/Source/Scene/Cesium3DTileBatchTable.js
+++ b/Source/Scene/Cesium3DTileBatchTable.js
@@ -71,6 +71,7 @@ function Cesium3DTileBatchTable(
   this._batchTexture = new BatchTexture({
     featuresLength: featuresLength,
     colorChangedCallback: colorChangedCallback,
+    content: content,
   });
 }
 
@@ -811,19 +812,22 @@ Cesium3DTileBatchTable.prototype.getUniformMapCallback = function () {
     var batchUniformMap = {
       tile_batchTexture: function () {
         // PERFORMANCE_IDEA: we could also use a custom shader that avoids the texture read.
-        return defaultValue(that._batchTexture, that._defaultTexture);
+        return defaultValue(
+          that._batchTexture.batchTexture,
+          that._batchTexture.defaultTexture
+        );
       },
       tile_textureDimensions: function () {
-        return that._textureDimensions;
+        return that._batchTexture.textureDimensions;
       },
       tile_textureStep: function () {
-        return that._textureStep;
+        return that._batchTexture.textureStep;
       },
       tile_colorBlend: function () {
         return getColorBlend(that);
       },
       tile_pickTexture: function () {
-        return that._pickTexture;
+        return that._batchTexture.pickTexture;
       },
     };
 

--- a/Specs/Scene/BatchTextureSpec.js
+++ b/Specs/Scene/BatchTextureSpec.js
@@ -49,7 +49,7 @@ describe(
         batchTexture.setShow(-1);
       }).toThrowDeveloperError();
       expect(function () {
-        batchTexture.setShow(2);
+        batchTexture.setShow(1);
       }).toThrowDeveloperError();
     });
 
@@ -107,7 +107,7 @@ describe(
         batchTexture.getShow(-1);
       }).toThrowDeveloperError();
       expect(function () {
-        batchTexture.getShow(2);
+        batchTexture.getShow(1);
       }).toThrowDeveloperError();
     });
 
@@ -134,7 +134,7 @@ describe(
         batchTexture.setColor(-1);
       }).toThrowDeveloperError();
       expect(function () {
-        batchTexture.setColor(2);
+        batchTexture.setColor(1);
       }).toThrowDeveloperError();
     });
 
@@ -213,7 +213,7 @@ describe(
     it("setAllShow", function () {
       var batchTexture = new BatchTexture({
         content: mockContent,
-        featuresLength: 1,
+        featuresLength: 2,
       });
       batchTexture.setAllShow(false);
       expect(batchTexture.getShow(0)).toBe(false);
@@ -232,7 +232,7 @@ describe(
         batchTexture.getColor(-1);
       }).toThrowDeveloperError();
       expect(function () {
-        batchTexture.getColor(2);
+        batchTexture.getColor(1);
       }).toThrowDeveloperError();
     });
 

--- a/Specs/Scene/BatchTextureSpec.js
+++ b/Specs/Scene/BatchTextureSpec.js
@@ -19,6 +19,50 @@ describe(
 
     var result = new Color();
 
+    it("throws without featuresLength", function () {
+      expect(function () {
+        return new BatchTexture({
+          featuresLength: undefined,
+          content: mockContent,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("throws without content", function () {
+      expect(function () {
+        return new BatchTexture({
+          featuresLength: 1,
+          content: undefined,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("setShow throws with invalid batchId", function () {
+      var batchTexture = new BatchTexture({
+        content: mockContent,
+        featuresLength: 1,
+      });
+      expect(function () {
+        batchTexture.setShow();
+      }).toThrowDeveloperError();
+      expect(function () {
+        batchTexture.setShow(-1);
+      }).toThrowDeveloperError();
+      expect(function () {
+        batchTexture.setShow(2);
+      }).toThrowDeveloperError();
+    });
+
+    it("setShow throws with undefined value", function () {
+      var batchTexture = new BatchTexture({
+        content: mockContent,
+        featuresLength: 1,
+      });
+      expect(function () {
+        batchTexture.setShow(0);
+      }).toThrowDeveloperError();
+    });
+
     it("setShow sets show", function () {
       var batchTexture = new BatchTexture({
         content: mockContent,
@@ -51,6 +95,59 @@ describe(
       expect(batchTexture.getShow(0)).toEqual(false);
     });
 
+    it("getShow throws with invalid batchId", function () {
+      var batchTexture = new BatchTexture({
+        content: mockContent,
+        featuresLength: 1,
+      });
+      expect(function () {
+        batchTexture.getShow();
+      }).toThrowDeveloperError();
+      expect(function () {
+        batchTexture.getShow(-1);
+      }).toThrowDeveloperError();
+      expect(function () {
+        batchTexture.getShow(2);
+      }).toThrowDeveloperError();
+    });
+
+    it("getShow", function () {
+      var batchTexture = new BatchTexture({
+        content: mockContent,
+        featuresLength: 1,
+      });
+      // Show is true by default
+      expect(batchTexture.getShow(0)).toEqual(true);
+      batchTexture.setShow(0, false);
+      expect(batchTexture.getShow(0)).toEqual(false);
+    });
+
+    it("setColor throws with invalid batchId", function () {
+      var batchTexture = new BatchTexture({
+        content: mockContent,
+        featuresLength: 1,
+      });
+      expect(function () {
+        batchTexture.setColor();
+      }).toThrowDeveloperError();
+      expect(function () {
+        batchTexture.setColor(-1);
+      }).toThrowDeveloperError();
+      expect(function () {
+        batchTexture.setColor(2);
+      }).toThrowDeveloperError();
+    });
+
+    it("setColor throws with undefined value", function () {
+      var batchTexture = new BatchTexture({
+        content: mockContent,
+        featuresLength: 1,
+      });
+      expect(function () {
+        batchTexture.setColor(0);
+      }).toThrowDeveloperError();
+    });
+
     it("setColor", function () {
       var batchTexture = new BatchTexture({
         content: mockContent,
@@ -80,6 +177,83 @@ describe(
       // Check that dirty stays false when value is the same
       batchTexture.setColor(0, Color.YELLOW);
       expect(batchTexture._batchValuesDirty).toEqual(false);
+      expect(batchTexture.getColor(0, result)).toEqual(Color.YELLOW);
+    });
+
+    it("setAllColor throws with undefined value", function () {
+      var batchTexture = new BatchTexture({
+        content: mockContent,
+        featuresLength: 1,
+      });
+      expect(function () {
+        batchTexture.setAllColor();
+      }).toThrowDeveloperError();
+    });
+
+    it("setAllColor", function () {
+      var batchTexture = new BatchTexture({
+        content: mockContent,
+        featuresLength: 2,
+      });
+      batchTexture.setAllColor(Color.YELLOW);
+      expect(batchTexture.getColor(0, result)).toEqual(Color.YELLOW);
+      expect(batchTexture.getColor(1, result)).toEqual(Color.YELLOW);
+    });
+
+    it("setAllShow throws with undefined value", function () {
+      var batchTexture = new BatchTexture({
+        content: mockContent,
+        featuresLength: 1,
+      });
+      expect(function () {
+        batchTexture.setAllShow();
+      }).toThrowDeveloperError();
+    });
+
+    it("setAllShow", function () {
+      var batchTexture = new BatchTexture({
+        content: mockContent,
+        featuresLength: 1,
+      });
+      batchTexture.setAllShow(false);
+      expect(batchTexture.getShow(0)).toBe(false);
+      expect(batchTexture.getShow(1)).toBe(false);
+    });
+
+    it("getColor throws with invalid batchId", function () {
+      var batchTexture = new BatchTexture({
+        content: mockContent,
+        featuresLength: 1,
+      });
+      expect(function () {
+        batchTexture.getColor();
+      }).toThrowDeveloperError();
+      expect(function () {
+        batchTexture.getColor(-1);
+      }).toThrowDeveloperError();
+      expect(function () {
+        batchTexture.getColor(2);
+      }).toThrowDeveloperError();
+    });
+
+    it("getColor throws with undefined result", function () {
+      var batchTexture = new BatchTexture({
+        content: mockContent,
+        featuresLength: 1,
+      });
+      expect(function () {
+        batchTexture.getColor(0);
+      }).toThrowDeveloperError();
+    });
+
+    it("getColor", function () {
+      var batchTexture = new BatchTexture({
+        content: mockContent,
+        featuresLength: 1,
+      });
+      // Color is true by default
+      expect(batchTexture.getColor(0, result)).toEqual(Color.WHITE);
+      batchTexture.setColor(0, Color.YELLOW);
       expect(batchTexture.getColor(0, result)).toEqual(Color.YELLOW);
     });
   },

--- a/Specs/Scene/BatchTextureSpec.js
+++ b/Specs/Scene/BatchTextureSpec.js
@@ -1,0 +1,87 @@
+import { BatchTexture, Color } from "../../Source/Cesium.js";
+
+import createScene from "../createScene.js";
+
+describe(
+  "Scene/BatchTexture",
+  function () {
+    var scene;
+    var mockContent = {};
+    var mockTileset = {
+      _statistics: {
+        batchTableByteLength: 0,
+      },
+    };
+
+    beforeAll(function () {
+      scene = createScene();
+    });
+
+    var result = new Color();
+
+    it("setShow sets show", function () {
+      var batchTexture = new BatchTexture({
+        content: mockContent,
+        featuresLength: 1,
+      });
+
+      // Batch table resources are undefined by default
+      expect(batchTexture._batchValues).toBeUndefined();
+      expect(batchTexture._batchTexture).toBeUndefined();
+
+      // Check that batch table resources are still undefined because value is true by default
+      batchTexture.setShow(0, true);
+      batchTexture.update(mockTileset, scene.frameState);
+      expect(batchTexture._batchValues).toBeUndefined();
+      expect(batchTexture._batchTexture).toBeUndefined();
+      expect(batchTexture.getShow(0)).toEqual(true);
+
+      // Check that batch values are dirty and resources are created when value changes
+      batchTexture.setShow(0, false);
+      expect(batchTexture._batchValuesDirty).toEqual(true);
+      batchTexture.update(mockTileset, scene.frameState);
+      expect(batchTexture._batchValues).toBeDefined();
+      expect(batchTexture._batchTexture).toBeDefined();
+      expect(batchTexture._batchValuesDirty).toEqual(false);
+      expect(batchTexture.getShow(0)).toEqual(false);
+
+      // Check that dirty stays false when value is the same
+      batchTexture.setShow(0, false);
+      expect(batchTexture._batchValuesDirty).toEqual(false);
+      expect(batchTexture.getShow(0)).toEqual(false);
+    });
+
+    it("setColor", function () {
+      var batchTexture = new BatchTexture({
+        content: mockContent,
+        featuresLength: 1,
+      });
+
+      // Batch table resources are undefined by default
+      expect(batchTexture._batchValues).toBeUndefined();
+      expect(batchTexture._batchTexture).toBeUndefined();
+
+      // Check that batch table resources are still undefined because value is true by default
+      batchTexture.setColor(0, Color.WHITE);
+      batchTexture.update(mockTileset, scene.frameState);
+      expect(batchTexture._batchValues).toBeUndefined();
+      expect(batchTexture._batchTexture).toBeUndefined();
+      expect(batchTexture.getColor(0, result)).toEqual(Color.WHITE);
+
+      // Check that batch values are dirty and resources are created when value changes
+      batchTexture.setColor(0, Color.YELLOW);
+      expect(batchTexture._batchValuesDirty).toEqual(true);
+      batchTexture.update(mockTileset, scene.frameState);
+      expect(batchTexture._batchValues).toBeDefined();
+      expect(batchTexture._batchTexture).toBeDefined();
+      expect(batchTexture._batchValuesDirty).toEqual(false);
+      expect(batchTexture.getColor(0, result)).toEqual(Color.YELLOW);
+
+      // Check that dirty stays false when value is the same
+      batchTexture.setColor(0, Color.YELLOW);
+      expect(batchTexture._batchValuesDirty).toEqual(false);
+      expect(batchTexture.getColor(0, result)).toEqual(Color.YELLOW);
+    });
+  },
+  "WebGL"
+);

--- a/Specs/Scene/Cesium3DTileBatchTableSpec.js
+++ b/Specs/Scene/Cesium3DTileBatchTableSpec.js
@@ -93,29 +93,12 @@ describe(
     it("setShow sets show", function () {
       var batchTable = new Cesium3DTileBatchTable(mockTileset, 1);
 
-      // Batch table resources are undefined by default
-      expect(batchTable._batchValues).toBeUndefined();
-      expect(batchTable._batchTexture).toBeUndefined();
-
-      // Check that batch table resources are still undefined because value is true by default
-      batchTable.setShow(0, true);
-      batchTable.update(mockTileset, scene.frameState);
-      expect(batchTable._batchValues).toBeUndefined();
-      expect(batchTable._batchTexture).toBeUndefined();
-      expect(batchTable.getShow(0)).toEqual(true);
+      // Show is true by default
+      expect(batchTable.getShow(0)).toBe(true);
 
       // Check that batch values are dirty and resources are created when value changes
       batchTable.setShow(0, false);
-      expect(batchTable._batchValuesDirty).toEqual(true);
       batchTable.update(mockTileset, scene.frameState);
-      expect(batchTable._batchValues).toBeDefined();
-      expect(batchTable._batchTexture).toBeDefined();
-      expect(batchTable._batchValuesDirty).toEqual(false);
-      expect(batchTable.getShow(0)).toEqual(false);
-
-      // Check that dirty stays false when value is the same
-      batchTable.setShow(0, false);
-      expect(batchTable._batchValuesDirty).toEqual(false);
       expect(batchTable.getShow(0)).toEqual(false);
     });
 
@@ -163,29 +146,8 @@ describe(
     it("setColor", function () {
       var batchTable = new Cesium3DTileBatchTable(mockTileset, 1);
 
-      // Batch table resources are undefined by default
-      expect(batchTable._batchValues).toBeUndefined();
-      expect(batchTable._batchTexture).toBeUndefined();
-
-      // Check that batch table resources are still undefined because value is true by default
-      batchTable.setColor(0, Color.WHITE);
-      batchTable.update(mockTileset, scene.frameState);
-      expect(batchTable._batchValues).toBeUndefined();
-      expect(batchTable._batchTexture).toBeUndefined();
-      expect(batchTable.getColor(0, result)).toEqual(Color.WHITE);
-
-      // Check that batch values are dirty and resources are created when value changes
       batchTable.setColor(0, Color.YELLOW);
-      expect(batchTable._batchValuesDirty).toEqual(true);
       batchTable.update(mockTileset, scene.frameState);
-      expect(batchTable._batchValues).toBeDefined();
-      expect(batchTable._batchTexture).toBeDefined();
-      expect(batchTable._batchValuesDirty).toEqual(false);
-      expect(batchTable.getColor(0, result)).toEqual(Color.YELLOW);
-
-      // Check that dirty stays false when value is the same
-      batchTable.setColor(0, Color.YELLOW);
-      expect(batchTable._batchValuesDirty).toEqual(false);
       expect(batchTable.getColor(0, result)).toEqual(Color.YELLOW);
     });
 

--- a/Specs/Scene/Cesium3DTileBatchTableSpec.js
+++ b/Specs/Scene/Cesium3DTileBatchTableSpec.js
@@ -79,7 +79,7 @@ describe(
         batchTable.setShow(-1);
       }).toThrowDeveloperError();
       expect(function () {
-        batchTable.setShow(2);
+        batchTable.setShow(1);
       }).toThrowDeveloperError();
     });
 
@@ -111,7 +111,7 @@ describe(
         batchTable.getShow(-1);
       }).toThrowDeveloperError();
       expect(function () {
-        batchTable.getShow(2);
+        batchTable.getShow(1);
       }).toThrowDeveloperError();
     });
 
@@ -132,7 +132,7 @@ describe(
         batchTable.setColor(-1);
       }).toThrowDeveloperError();
       expect(function () {
-        batchTable.setColor(2);
+        batchTable.setColor(1);
       }).toThrowDeveloperError();
     });
 
@@ -188,7 +188,7 @@ describe(
         batchTable.getColor(-1);
       }).toThrowDeveloperError();
       expect(function () {
-        batchTable.getColor(2);
+        batchTable.getColor(1);
       }).toThrowDeveloperError();
     });
 
@@ -216,7 +216,7 @@ describe(
         batchTable.hasProperty(-1);
       }).toThrowDeveloperError();
       expect(function () {
-        batchTable.hasProperty(2);
+        batchTable.hasProperty(1);
       }).toThrowDeveloperError();
     });
 
@@ -249,7 +249,7 @@ describe(
         batchTable.getPropertyNames(-1);
       }).toThrowDeveloperError();
       expect(function () {
-        batchTable.getPropertyNames(2);
+        batchTable.getPropertyNames(1);
       }).toThrowDeveloperError();
     });
 
@@ -290,7 +290,7 @@ describe(
         batchTable.getProperty(-1);
       }).toThrowDeveloperError();
       expect(function () {
-        batchTable.getProperty(2);
+        batchTable.getProperty(1);
       }).toThrowDeveloperError();
     });
 
@@ -322,7 +322,7 @@ describe(
         batchTable.setProperty(-1);
       }).toThrowDeveloperError();
       expect(function () {
-        batchTable.setProperty(2);
+        batchTable.setProperty(1);
       }).toThrowDeveloperError();
     });
 
@@ -831,7 +831,7 @@ describe(
         batchTable.isExactClass();
       }).toThrowDeveloperError();
       expect(function () {
-        batchTable.isExactClass(2, "door");
+        batchTable.isExactClass(1, "door");
       }).toThrowDeveloperError();
       expect(function () {
         batchTable.isExactClass(-1, "door");
@@ -851,7 +851,7 @@ describe(
         batchTable.isClass();
       }).toThrowDeveloperError();
       expect(function () {
-        batchTable.isClass(2, "door");
+        batchTable.isClass(1, "door");
       }).toThrowDeveloperError();
       expect(function () {
         batchTable.isClass(-1, "door");
@@ -871,7 +871,7 @@ describe(
         batchTable.getExactClassName();
       }).toThrowDeveloperError();
       expect(function () {
-        batchTable.getExactClassName(1000);
+        batchTable.getExactClassName(1);
       }).toThrowDeveloperError();
       expect(function () {
         batchTable.getExactClassName(-1);


### PR DESCRIPTION
Another branch that targets `3d-tiles-next`

In preparation for future 3D TIles Next changes, the batch texture and pick texture from `Cesium3DTileBatchTable` are now moved to their own class, `BatchTexture`.

@lilleyse could you review this?