### PR TITLE
Updates to resource loaders (part 2)

### DIFF
--- a/Source/Scene/AttributeType.js
+++ b/Source/Scene/AttributeType.js
@@ -1,3 +1,11 @@
+import Cartesian2 from "../Core/Cartesian2.js";
+import Cartesian3 from "../Core/Cartesian3.js";
+import Cartesian4 from "../Core/Cartesian4.js";
+import DeveloperError from "../Core/DeveloperError.js";
+import Matrix2 from "../Core/Matrix2.js";
+import Matrix3 from "../Core/Matrix3.js";
+import Matrix4 from "../Core/Matrix4.js";
+
 /**
  * An enum describing the attribute type for glTF and 3D Tiles.
  *
@@ -62,4 +70,36 @@ var AttributeType = {
    */
   MAT4: "MAT4",
 };
+
+/**
+ * Gets the scalar, vector, or matrix type for the attribute type.
+ *
+ * @param {AttributeType} attributeType The attribute type.
+ * @returns {*} The math type.
+ *
+ * @private
+ */
+AttributeType.getMathType = function (attributeType) {
+  switch (attributeType) {
+    case AttributeType.SCALAR:
+      return Number;
+    case AttributeType.VEC2:
+      return Cartesian2;
+    case AttributeType.VEC3:
+      return Cartesian3;
+    case AttributeType.VEC4:
+      return Cartesian4;
+    case AttributeType.MAT2:
+      return Matrix2;
+    case AttributeType.MAT3:
+      return Matrix3;
+    case AttributeType.MAT4:
+      return Matrix4;
+    //>>includeStart('debug', pragmas.debug);
+    default:
+      throw new DeveloperError("attributeType is not a valid value.");
+    //>>includeEnd('debug');
+  }
+};
+
 export default Object.freeze(AttributeType);

--- a/Source/Scene/GltfBufferViewLoader.js
+++ b/Source/Scene/GltfBufferViewLoader.js
@@ -128,8 +128,10 @@ GltfBufferViewLoader.prototype.load = function () {
         bufferTypedArray.byteOffset + that._byteOffset,
         that._byteLength
       );
-      // Keep bufferLoader loaded since we're still holding onto a view of the
-      // buffer and not ready to release it.
+
+      // Unload the buffer
+      that.unload();
+
       that._typedArray = bufferViewTypedArray;
       that._state = ResourceLoaderState.READY;
       that._promise.resolve(that);
@@ -155,13 +157,11 @@ function getBufferLoader(bufferViewLoader) {
     });
     return resourceCache.loadExternalBuffer({
       resource: resource,
-      keepResident: false,
     });
   }
   return resourceCache.loadEmbeddedBuffer({
     parentResource: bufferViewLoader._gltfResource,
     bufferId: bufferViewLoader._bufferId,
-    keepResident: false,
   });
 }
 

--- a/Source/Scene/GltfDracoLoader.js
+++ b/Source/Scene/GltfDracoLoader.js
@@ -114,7 +114,6 @@ GltfDracoLoader.prototype.load = function () {
     bufferViewId: this._draco.bufferView,
     gltfResource: this._gltfResource,
     baseResource: this._baseResource,
-    keepResident: false,
   });
 
   this._bufferViewLoader = bufferViewLoader;

--- a/Source/Scene/GltfImageLoader.js
+++ b/Source/Scene/GltfImageLoader.js
@@ -137,7 +137,6 @@ function loadFromBufferView(imageLoader) {
     bufferViewId: imageLoader._bufferViewId,
     gltfResource: imageLoader._gltfResource,
     baseResource: imageLoader._baseResource,
-    keepResident: false,
   });
 
   imageLoader._bufferViewLoader = bufferViewLoader;
@@ -195,7 +194,7 @@ function loadFromUri(imageLoader) {
       if (imageLoader.isDestroyed()) {
         return;
       }
-      handleError(imageLoader, error, "Failed to load image:" + uri);
+      handleError(imageLoader, error, "Failed to load image: " + uri);
     });
 }
 

--- a/Source/Scene/GltfIndexBufferLoader.js
+++ b/Source/Scene/GltfIndexBufferLoader.js
@@ -134,7 +134,6 @@ function loadFromDraco(indexBufferLoader) {
     draco: indexBufferLoader._draco,
     gltfResource: indexBufferLoader._gltfResource,
     baseResource: indexBufferLoader._baseResource,
-    keepResident: false,
   });
 
   indexBufferLoader._dracoLoader = dracoLoader;
@@ -170,7 +169,6 @@ function loadFromBufferView(indexBufferLoader) {
     bufferViewId: bufferViewId,
     gltfResource: indexBufferLoader._gltfResource,
     baseResource: indexBufferLoader._baseResource,
-    keepResident: false,
   });
   indexBufferLoader._state = ResourceLoaderState.LOADING;
   indexBufferLoader._bufferViewLoader = bufferViewLoader;

--- a/Source/Scene/GltfJsonLoader.js
+++ b/Source/Scene/GltfJsonLoader.js
@@ -31,7 +31,6 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {Uint8Array} [options.typedArray] The typed array containing the glTF contents.
  * @param {String} [options.cacheKey] The cache key of the resource.
- * @param {Boolean} [options.keepResident=false] Whether the glTF JSON and embedded buffers should stay in the cache indefinitely.
  *
  * @private
  */
@@ -42,7 +41,6 @@ export default function GltfJsonLoader(options) {
   var baseResource = options.baseResource;
   var typedArray = options.typedArray;
   var cacheKey = options.cacheKey;
-  var keepResident = defaultValue(options.keepResident, false);
 
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.func("options.resourceCache", resourceCache);
@@ -55,7 +53,6 @@ export default function GltfJsonLoader(options) {
   this._baseResource = baseResource;
   this._typedArray = typedArray;
   this._cacheKey = cacheKey;
-  this._keepResident = keepResident;
   this._gltf = undefined;
   this._bufferLoaders = [];
   this._state = ResourceLoaderState.UNLOADED;
@@ -192,7 +189,6 @@ function upgradeVersion(gltfJsonLoader, gltf) {
       var resourceCache = gltfJsonLoader._resourceCache;
       var bufferLoader = resourceCache.loadExternalBuffer({
         resource: resource,
-        keepResident: false, // External buffers don't need to stay resident
       });
 
       gltfJsonLoader._bufferLoaders.push(bufferLoader);
@@ -240,7 +236,6 @@ function loadEmbeddedBuffers(gltfJsonLoader, gltf) {
         parentResource: gltfJsonLoader._gltfResource,
         bufferId: bufferId,
         typedArray: source,
-        keepResident: gltfJsonLoader._keepResident,
       });
 
       gltfJsonLoader._bufferLoaders.push(bufferLoader);

--- a/Source/Scene/GltfTextureLoader.js
+++ b/Source/Scene/GltfTextureLoader.js
@@ -137,7 +137,6 @@ GltfTextureLoader.prototype.load = function () {
     gltfResource: this._gltfResource,
     baseResource: this._baseResource,
     supportedImageFormats: this._supportedImageFormats,
-    keepResident: false,
   });
 
   this._imageLoader = imageLoader;
@@ -245,7 +244,7 @@ function createTexture(gltf, textureInfo, image, context) {
 
   var texture;
   if (defined(internalFormat)) {
-    texture = new Texture({
+    texture = Texture.create({
       context: context,
       source: {
         arrayBufferView: image.bufferView, // Only defined for CompressedTextureBuffer
@@ -259,7 +258,7 @@ function createTexture(gltf, textureInfo, image, context) {
     if (requiresResize) {
       image = resizeImageToNextPowerOfTwo(image);
     }
-    texture = new Texture({
+    texture = Texture.create({
       context: context,
       source: image,
       sampler: sampler,

--- a/Source/Scene/GltfVertexBufferLoader.js
+++ b/Source/Scene/GltfVertexBufferLoader.js
@@ -1,3 +1,4 @@
+import arrayFill from "../Core/arrayFill.js";
 import Check from "../Core/Check.js";
 import defaultValue from "../Core/defaultValue.js";
 import defined from "../Core/defined.js";
@@ -207,7 +208,7 @@ function getQuantizationInformation(
         dracoQuantization.minValues
       );
       quantization.quantizedVolumeDimensions = MathType.unpack(
-        new Array(componentCount).fill(dracoQuantization.range)
+        arrayFill(new Array(componentCount), dracoQuantization.range)
       );
     }
     quantization.type = type;

--- a/Source/Scene/ResourceCache.js
+++ b/Source/Scene/ResourceCache.js
@@ -114,9 +114,6 @@ ResourceCache.unload = function (resourceLoader) {
   if (!defined(cacheEntry)) {
     throw new DeveloperError("Resource is not in the cache: " + cacheKey);
   }
-  if (cacheEntry.referenceCount === 0) {
-    throw new DeveloperError("Cannot unload resource that has no references.");
-  }
   //>>includeEnd('debug');
 
   --cacheEntry.referenceCount;

--- a/Source/Scene/ResourceCache.js
+++ b/Source/Scene/ResourceCache.js
@@ -28,17 +28,15 @@ ResourceCache.cacheEntries = {};
  * A reference-counted cache entry.
  *
  * @param {ResourceLoader} resourceLoader The resource.
- * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
  *
  * @alias CacheEntry
  * @constructor
  *
  * @private
  */
-function CacheEntry(options) {
+function CacheEntry(resourceLoader) {
   this.referenceCount = 1;
-  this.resourceLoader = options.resourceLoader;
-  this.keepResident = defaultValue(options.keepResident, false);
+  this.resourceLoader = resourceLoader;
 }
 
 /**
@@ -67,14 +65,12 @@ ResourceCache.get = function (cacheKey) {
  *
  * @param {Object} options Object with the following properties:
  * @param {ResourceLoader} options.resourceLoader The resource.
- * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
  *
  * @exception {DeveloperError} Resource with this cacheKey is already in the cache.
  */
 ResourceCache.load = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   var resourceLoader = options.resourceLoader;
-  var keepResident = defaultValue(options.keepResident, false);
 
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("options.resourceLoader", resourceLoader);
@@ -92,10 +88,7 @@ ResourceCache.load = function (options) {
   }
   //>>includeEnd('debug');
 
-  ResourceCache.cacheEntries[cacheKey] = new CacheEntry({
-    resourceLoader: resourceLoader,
-    keepResident: keepResident,
-  });
+  ResourceCache.cacheEntries[cacheKey] = new CacheEntry(resourceLoader);
 
   resourceLoader.load();
 };
@@ -128,7 +121,7 @@ ResourceCache.unload = function (resourceLoader) {
 
   --cacheEntry.referenceCount;
 
-  if (cacheEntry.referenceCount === 0 && !cacheEntry.keepResident) {
+  if (cacheEntry.referenceCount === 0) {
     resourceLoader.destroy();
     delete ResourceCache.cacheEntries[cacheKey];
   }
@@ -140,7 +133,6 @@ ResourceCache.unload = function (resourceLoader) {
  * @param {Object} options Object with the following properties:
  * @param {Object} [options.schema] An object that explicitly defines a schema JSON. Mutually exclusive with options.resource.
  * @param {Resource} [options.resource] The {@link Resource} pointing to the schema JSON. Mutually exclusive with options.schema.
- * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
  *
  * @returns {MetadataSchemaLoader} The schema resource.
  *
@@ -150,7 +142,6 @@ ResourceCache.loadSchema = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   var schema = options.schema;
   var resource = options.resource;
-  var keepResident = defaultValue(options.keepResident, false);
 
   //>>includeStart('debug', pragmas.debug);
   if (defined(schema) === defined(resource)) {
@@ -178,7 +169,6 @@ ResourceCache.loadSchema = function (options) {
 
   ResourceCache.load({
     resourceLoader: schemaLoader,
-    keepResident: keepResident,
   });
 
   return schemaLoader;
@@ -191,7 +181,6 @@ ResourceCache.loadSchema = function (options) {
  * @param {Resource} options.parentResource The {@link Resource} containing the embedded buffer.
  * @param {Number} options.bufferId A unique identifier of the embedded buffer within the parent resource.
  * @param {Uint8Array} [options.typedArray] The typed array containing the embedded buffer contents.
- * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
  *
  * @returns {BufferLoader} The buffer loader.
  */
@@ -200,7 +189,6 @@ ResourceCache.loadEmbeddedBuffer = function (options) {
   var parentResource = options.parentResource;
   var bufferId = options.bufferId;
   var typedArray = options.typedArray;
-  var keepResident = defaultValue(options.keepResident, false);
 
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("options.parentResource", parentResource);
@@ -228,7 +216,6 @@ ResourceCache.loadEmbeddedBuffer = function (options) {
 
   ResourceCache.load({
     resourceLoader: bufferLoader,
-    keepResident: keepResident,
   });
 
   return bufferLoader;
@@ -239,14 +226,12 @@ ResourceCache.loadEmbeddedBuffer = function (options) {
  *
  * @param {Object} options Object with the following properties:
  * @param {Resource} options.resource The {@link Resource} pointing to the external buffer.
- * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
  *
  * @returns {BufferLoader} The buffer loader.
  */
 ResourceCache.loadExternalBuffer = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   var resource = options.resource;
-  var keepResident = defaultValue(options.keepResident, false);
 
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("options.resource", resource);
@@ -268,7 +253,6 @@ ResourceCache.loadExternalBuffer = function (options) {
 
   ResourceCache.load({
     resourceLoader: bufferLoader,
-    keepResident: keepResident,
   });
 
   return bufferLoader;
@@ -281,7 +265,6 @@ ResourceCache.loadExternalBuffer = function (options) {
  * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {Uint8Array} [options.typedArray] The typed array containing the glTF contents.
- * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
  *
  * @returns {GltfJsonLoader} The glTF JSON.
  */
@@ -290,7 +273,6 @@ ResourceCache.loadGltf = function (options) {
   var gltfResource = options.gltfResource;
   var baseResource = options.baseResource;
   var typedArray = options.typedArray;
-  var keepResident = defaultValue(options.keepResident, false);
 
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("options.gltfResource", gltfResource);
@@ -312,12 +294,10 @@ ResourceCache.loadGltf = function (options) {
     baseResource: baseResource,
     typedArray: typedArray,
     cacheKey: cacheKey,
-    keepResident: keepResident,
   });
 
   ResourceCache.load({
     resourceLoader: gltfJsonLoader,
-    keepResident: keepResident,
   });
 
   return gltfJsonLoader;
@@ -331,7 +311,6 @@ ResourceCache.loadGltf = function (options) {
  * @param {Number} options.bufferViewId The bufferView ID.
  * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
- * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
  *
  * @returns {GltfBufferViewLoader} The buffer view loader.
  */
@@ -341,7 +320,6 @@ ResourceCache.loadBufferView = function (options) {
   var bufferViewId = options.bufferViewId;
   var gltfResource = options.gltfResource;
   var baseResource = options.baseResource;
-  var keepResident = defaultValue(options.keepResident, false);
 
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("options.gltf", gltf);
@@ -373,7 +351,6 @@ ResourceCache.loadBufferView = function (options) {
 
   ResourceCache.load({
     resourceLoader: bufferViewLoader,
-    keepResident: keepResident,
   });
 
   return bufferViewLoader;
@@ -387,7 +364,6 @@ ResourceCache.loadBufferView = function (options) {
  * @param {Object} options.draco The Draco extension object.
  * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
- * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
  *
  * @returns {GltfDracoLoader} The Draco loader.
  */
@@ -397,7 +373,6 @@ ResourceCache.loadDraco = function (options) {
   var draco = options.draco;
   var gltfResource = options.gltfResource;
   var baseResource = options.baseResource;
-  var keepResident = defaultValue(options.keepResident, false);
 
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("options.gltf", gltf);
@@ -429,7 +404,6 @@ ResourceCache.loadDraco = function (options) {
 
   ResourceCache.load({
     resourceLoader: dracoLoader,
-    keepResident: keepResident,
   });
 
   return dracoLoader;
@@ -445,11 +419,12 @@ ResourceCache.loadDraco = function (options) {
  * @param {Number} [options.bufferViewId] The bufferView ID corresponding to the vertex buffer.
  * @param {Object} [options.draco] The Draco extension object.
  * @param {String} [options.dracoAttributeSemantic] The Draco attribute semantic, e.g. POSITION or NORMAL.
- * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
+ * @param {Number} [options.dracoAccessorId] The Draco accessor ID.
  * @param {Boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
  *
  * @exception {DeveloperError} One of options.bufferViewId and options.draco must be defined.
  * @exception {DeveloperError} When options.draco is defined options.dracoAttributeSemantic must also be defined.
+ * @exception {DeveloperError} When options.draco is defined options.dracoAccessorId must also be defined.
  *
  * @returns {GltfVertexBufferLoader} The vertex buffer loader.
  */
@@ -461,7 +436,7 @@ ResourceCache.loadVertexBuffer = function (options) {
   var bufferViewId = options.bufferViewId;
   var draco = options.draco;
   var dracoAttributeSemantic = options.dracoAttributeSemantic;
-  var keepResident = defaultValue(options.keepResident, false);
+  var dracoAccessorId = options.dracoAccessorId;
   var asynchronous = defaultValue(options.asynchronous, true);
 
   //>>includeStart('debug', pragmas.debug);
@@ -472,6 +447,7 @@ ResourceCache.loadVertexBuffer = function (options) {
   var hasBufferViewId = defined(bufferViewId);
   var hasDraco = defined(draco);
   var hasDracoAttributeSemantic = defined(dracoAttributeSemantic);
+  var hasDracoAccessorId = defined(dracoAccessorId);
 
   if (hasBufferViewId === hasDraco) {
     throw new DeveloperError(
@@ -485,12 +461,19 @@ ResourceCache.loadVertexBuffer = function (options) {
     );
   }
 
+  if (hasDraco && !hasDracoAccessorId) {
+    throw new DeveloperError(
+      "When options.draco is defined options.hasDracoAccessorId must also be defined."
+    );
+  }
+
   if (hasDraco) {
     Check.typeOf.object("options.draco", draco);
     Check.typeOf.string(
       "options.dracoAttributeSemantic",
       dracoAttributeSemantic
     );
+    Check.typeOf.number("options.dracoAccessorId", dracoAccessorId);
   }
   //>>includeEnd('debug');
 
@@ -516,13 +499,13 @@ ResourceCache.loadVertexBuffer = function (options) {
     bufferViewId: bufferViewId,
     draco: draco,
     dracoAttributeSemantic: dracoAttributeSemantic,
+    dracoAccessorId: dracoAccessorId,
     cacheKey: cacheKey,
     asynchronous: asynchronous,
   });
 
   ResourceCache.load({
     resourceLoader: vertexBufferLoader,
-    keepResident: keepResident,
   });
 
   return vertexBufferLoader;
@@ -537,7 +520,6 @@ ResourceCache.loadVertexBuffer = function (options) {
  * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {Object} [options.draco] The Draco extension object.
- * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
  * @param {Boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
  *
  * @returns {GltfIndexBufferLoader} The index buffer loader.
@@ -549,7 +531,6 @@ ResourceCache.loadIndexBuffer = function (options) {
   var gltfResource = options.gltfResource;
   var baseResource = options.baseResource;
   var draco = options.draco;
-  var keepResident = defaultValue(options.keepResident, false);
   var asynchronous = defaultValue(options.asynchronous, true);
 
   //>>includeStart('debug', pragmas.debug);
@@ -585,7 +566,6 @@ ResourceCache.loadIndexBuffer = function (options) {
 
   ResourceCache.load({
     resourceLoader: indexBufferLoader,
-    keepResident: keepResident,
   });
 
   return indexBufferLoader;
@@ -600,7 +580,6 @@ ResourceCache.loadIndexBuffer = function (options) {
  * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
- * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
  *
  * @returns {GltfImageLoader} The image loader.
  */
@@ -611,7 +590,6 @@ ResourceCache.loadImage = function (options) {
   var gltfResource = options.gltfResource;
   var baseResource = options.baseResource;
   var supportedImageFormats = options.supportedImageFormats;
-  var keepResident = defaultValue(options.keepResident, false);
 
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("options.gltf", gltf);
@@ -646,7 +624,6 @@ ResourceCache.loadImage = function (options) {
 
   ResourceCache.load({
     resourceLoader: imageLoader,
-    keepResident: keepResident,
   });
 
   return imageLoader;
@@ -661,7 +638,6 @@ ResourceCache.loadImage = function (options) {
  * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
- * @param {Boolean} [options.keepResident=false] Whether the resource should stay in the cache indefinitely.
  * @param {Boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
  *
  * @returns {GltfTextureLoader} The texture loader.
@@ -673,7 +649,6 @@ ResourceCache.loadTexture = function (options) {
   var gltfResource = options.gltfResource;
   var baseResource = options.baseResource;
   var supportedImageFormats = options.supportedImageFormats;
-  var keepResident = defaultValue(options.keepResident, false);
   var asynchronous = defaultValue(options.asynchronous, true);
 
   //>>includeStart('debug', pragmas.debug);
@@ -709,7 +684,6 @@ ResourceCache.loadTexture = function (options) {
 
   ResourceCache.load({
     resourceLoader: textureLoader,
-    keepResident: keepResident,
   });
 
   return textureLoader;

--- a/Source/Scene/parseFeatureMetadata.js
+++ b/Source/Scene/parseFeatureMetadata.js
@@ -7,7 +7,7 @@ import FeatureMetadata from "./FeatureMetadata.js";
 import MetadataTable from "./MetadataTable.js";
 
 /**
- * parse the <code>EXT_feature_metadata</code> glTF extension to create a
+ * Parse the <code>EXT_feature_metadata</code> glTF extension to create a
  * feature metadata object.
  *
  * @param {Object} options Object with the following properties:

--- a/Source/ThirdParty/GltfPipeline/addDefaults.js
+++ b/Source/ThirdParty/GltfPipeline/addDefaults.js
@@ -117,7 +117,7 @@ import WebGLConstants from '../../Core/WebGLConstants.js'
                 addTextureDefaults(pbrMetallicRoughness.metallicRoughnessTexture);
             }
 
-            var pbrSpecularGlossiness = extensions.pbrSpecularGlossiness;
+            var pbrSpecularGlossiness = extensions.KHR_materials_pbrSpecularGlossiness;
             if (defined(pbrSpecularGlossiness)) {
                 pbrSpecularGlossiness.diffuseFactor = defaultValue(pbrSpecularGlossiness.diffuseFactor, [1.0, 1.0, 1.0, 1.0]);
                 pbrSpecularGlossiness.specularFactor = defaultValue(pbrSpecularGlossiness.specularFactor, [1.0, 1.0, 1.0]);

--- a/Specs/Scene/AttributeTypeSpec.js
+++ b/Specs/Scene/AttributeTypeSpec.js
@@ -1,0 +1,27 @@
+import {
+  AttributeType,
+  Cartesian2,
+  Cartesian3,
+  Cartesian4,
+  Matrix2,
+  Matrix3,
+  Matrix4,
+} from "../../Source/Cesium.js";
+
+describe("Scene/AttributeType", function () {
+  it("getMathType works", function () {
+    expect(AttributeType.getMathType(AttributeType.SCALAR)).toBe(Number);
+    expect(AttributeType.getMathType(AttributeType.VEC2)).toBe(Cartesian2);
+    expect(AttributeType.getMathType(AttributeType.VEC3)).toBe(Cartesian3);
+    expect(AttributeType.getMathType(AttributeType.VEC4)).toBe(Cartesian4);
+    expect(AttributeType.getMathType(AttributeType.MAT2)).toBe(Matrix2);
+    expect(AttributeType.getMathType(AttributeType.MAT3)).toBe(Matrix3);
+    expect(AttributeType.getMathType(AttributeType.MAT4)).toBe(Matrix4);
+  });
+
+  it("getMathType throws with invalid type", function () {
+    expect(function () {
+      AttributeType.getMathType("Invalid");
+    }).toThrowDeveloperError();
+  });
+});

--- a/Specs/Scene/GltfDracoLoaderSpec.js
+++ b/Specs/Scene/GltfDracoLoaderSpec.js
@@ -292,7 +292,10 @@ describe("Scene/GltfDracoLoader", function () {
       if (processCallsCount++ === processCallsTotal) {
         deferredPromise.resolve(decodeDracoResults);
       }
-      return dracoLoader._state === ResourceLoaderState.READY;
+      return (
+        dracoLoader._state === ResourceLoaderState.READY ||
+        dracoLoader._state === ResourceLoaderState.FAILED
+      );
     }).then(function () {
       return dracoLoader.promise.then(function (dracoLoader) {
         dracoLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
@@ -332,7 +335,10 @@ describe("Scene/GltfDracoLoader", function () {
 
     return pollToPromise(function () {
       dracoLoader.process(scene.frameState);
-      return dracoLoader._state === ResourceLoaderState.READY;
+      return (
+        dracoLoader._state === ResourceLoaderState.READY ||
+        dracoLoader._state === ResourceLoaderState.FAILED
+      );
     }).then(function () {
       return dracoLoader.promise.then(function (dracoLoader) {
         expect(dracoLoader.decodedData).toBeDefined();

--- a/Specs/Scene/GltfDracoLoaderSpec.js
+++ b/Specs/Scene/GltfDracoLoaderSpec.js
@@ -10,6 +10,7 @@ import {
 } from "../../Source/Cesium.js";
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
+import waitForLoaderProcess from "../waitForLoaderProcess.js";
 
 describe("Scene/GltfDracoLoader", function () {
   var bufferTypedArray = new Uint8Array([1, 3, 7, 15, 31, 63, 127, 255]);
@@ -242,20 +243,15 @@ describe("Scene/GltfDracoLoader", function () {
 
     dracoLoader.load();
 
-    return pollToPromise(function () {
-      dracoLoader.process(scene.frameState);
-      return dracoLoader._state === ResourceLoaderState.FAILED;
-    }).then(function () {
-      return dracoLoader.promise
-        .then(function (dracoLoader) {
-          fail();
-        })
-        .otherwise(function (runtimeError) {
-          expect(runtimeError.message).toBe(
-            "Failed to load Draco\nDraco decode failed"
-          );
-        });
-    });
+    return waitForLoaderProcess(dracoLoader, scene)
+      .then(function (dracoLoader) {
+        fail();
+      })
+      .otherwise(function (runtimeError) {
+        expect(runtimeError.message).toBe(
+          "Failed to load Draco\nDraco decode failed"
+        );
+      });
   });
 
   it("loads draco", function () {
@@ -333,23 +329,17 @@ describe("Scene/GltfDracoLoader", function () {
 
     dracoLoader.load();
 
-    return pollToPromise(function () {
-      dracoLoader.process(scene.frameState);
-      return (
-        dracoLoader._state === ResourceLoaderState.READY ||
-        dracoLoader._state === ResourceLoaderState.FAILED
-      );
-    }).then(function () {
-      return dracoLoader.promise.then(function (dracoLoader) {
-        expect(dracoLoader.decodedData).toBeDefined();
-        expect(dracoLoader.isDestroyed()).toBe(false);
+    return waitForLoaderProcess(dracoLoader, scene).then(function (
+      dracoLoader
+    ) {
+      expect(dracoLoader.decodedData).toBeDefined();
+      expect(dracoLoader.isDestroyed()).toBe(false);
 
-        dracoLoader.destroy();
+      dracoLoader.destroy();
 
-        expect(dracoLoader.decodedData).not.toBeDefined();
-        expect(dracoLoader.isDestroyed()).toBe(true);
-        expect(unloadBufferView).toHaveBeenCalled();
-      });
+      expect(dracoLoader.decodedData).not.toBeDefined();
+      expect(dracoLoader.isDestroyed()).toBe(true);
+      expect(unloadBufferView).toHaveBeenCalled();
     });
   });
 

--- a/Specs/Scene/GltfFeatureMetadataLoaderSpec.js
+++ b/Specs/Scene/GltfFeatureMetadataLoaderSpec.js
@@ -277,7 +277,7 @@ describe(
         })
         .otherwise(function (runtimeError) {
           expect(runtimeError.message).toBe(
-            "Failed to load feature metadata\nFailed to load texture\nFailed to load image:map.png\n404 Not Found"
+            "Failed to load feature metadata\nFailed to load texture\nFailed to load image: map.png\n404 Not Found"
           );
         });
     });
@@ -338,7 +338,10 @@ describe(
 
       return pollToPromise(function () {
         featureMetadataLoader.process(scene.frameState);
-        return featureMetadataLoader._state === ResourceLoaderState.READY;
+        return (
+          featureMetadataLoader._state === ResourceLoaderState.READY ||
+          featureMetadataLoader._state === ResourceLoaderState.FAILED
+        );
       }).then(function () {
         return featureMetadataLoader.promise.then(function (
           featureMetadataLoader
@@ -405,7 +408,10 @@ describe(
 
       return pollToPromise(function () {
         featureMetadataLoader.process(scene.frameState);
-        return featureMetadataLoader._state === ResourceLoaderState.READY;
+        return (
+          featureMetadataLoader._state === ResourceLoaderState.READY ||
+          featureMetadataLoader._state === ResourceLoaderState.FAILED
+        );
       }).then(function () {
         return featureMetadataLoader.promise.then(function (
           featureMetadataLoader
@@ -461,7 +467,10 @@ describe(
 
       return pollToPromise(function () {
         featureMetadataLoader.process(scene.frameState);
-        return featureMetadataLoader._state === ResourceLoaderState.READY;
+        return (
+          featureMetadataLoader._state === ResourceLoaderState.READY ||
+          featureMetadataLoader._state === ResourceLoaderState.FAILED
+        );
       }).then(function () {
         return featureMetadataLoader.promise.then(function (
           featureMetadataLoader
@@ -527,11 +536,17 @@ describe(
 
       return pollToPromise(function () {
         featureMetadataLoaderCopy.process(scene.frameState);
-        return featureMetadataLoaderCopy._state === ResourceLoaderState.READY;
+        return (
+          featureMetadataLoaderCopy._state === ResourceLoaderState.READY ||
+          featureMetadataLoaderCopy._state === ResourceLoaderState.FAILED
+        );
       }).then(function () {
         return featureMetadataLoaderCopy.promise.then(function (
           featureMetadataLoaderCopy
         ) {
+          // Ignore featureMetadataLoaderCopy destroying its buffer views
+          destroyBufferView.calls.reset();
+
           var featureMetadataLoader = new GltfFeatureMetadataLoader({
             gltf: gltfSchemaUri,
             extension: extensionSchemaUri,

--- a/Specs/Scene/GltfFeatureMetadataLoaderSpec.js
+++ b/Specs/Scene/GltfFeatureMetadataLoaderSpec.js
@@ -6,13 +6,12 @@ import {
   MetadataSchemaLoader,
   Resource,
   ResourceCache,
-  ResourceLoaderState,
   SupportedImageFormats,
   when,
 } from "../../Source/Cesium.js";
 import createScene from "../createScene.js";
 import MetadataTester from "../MetadataTester.js";
-import pollToPromise from "../pollToPromise.js";
+import waitForLoaderProcess from "../waitForLoaderProcess.js";
 
 describe(
   "Scene/GltfFeatureMetadataLoader",
@@ -336,50 +335,42 @@ describe(
 
       featureMetadataLoader.load();
 
-      return pollToPromise(function () {
-        featureMetadataLoader.process(scene.frameState);
-        return (
-          featureMetadataLoader._state === ResourceLoaderState.READY ||
-          featureMetadataLoader._state === ResourceLoaderState.FAILED
-        );
-      }).then(function () {
-        return featureMetadataLoader.promise.then(function (
-          featureMetadataLoader
-        ) {
-          featureMetadataLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
-          var featureMetadata = featureMetadataLoader.featureMetadata;
-          var buildingsTable = featureMetadata.getFeatureTable("buildings");
-          var treesTable = featureMetadata.getFeatureTable("trees");
-          var mapTexture = featureMetadata.getFeatureTexture("mapTexture");
-          var orthoTexture = featureMetadata.getFeatureTexture("orthoTexture");
+      return waitForLoaderProcess(featureMetadataLoader, scene).then(function (
+        featureMetadataLoader
+      ) {
+        featureMetadataLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
+        var featureMetadata = featureMetadataLoader.featureMetadata;
+        var buildingsTable = featureMetadata.getFeatureTable("buildings");
+        var treesTable = featureMetadata.getFeatureTable("trees");
+        var mapTexture = featureMetadata.getFeatureTexture("mapTexture");
+        var orthoTexture = featureMetadata.getFeatureTexture("orthoTexture");
 
-          expect(buildingsTable.getProperty(0, "name")).toBe("House");
-          expect(buildingsTable.getProperty(1, "name")).toBe("Hospital");
-          expect(treesTable.getProperty(0, "species")).toEqual([
-            "Sparrow",
-            "Squirrel",
-          ]);
-          expect(treesTable.getProperty(1, "species")).toEqual(["Crow"]);
+        expect(buildingsTable.getProperty(0, "name")).toBe("House");
+        expect(buildingsTable.getProperty(1, "name")).toBe("Hospital");
+        expect(treesTable.getProperty(0, "species")).toEqual([
+          "Sparrow",
+          "Squirrel",
+        ]);
+        expect(treesTable.getProperty(1, "species")).toEqual(["Crow"]);
 
-          var colorProperty = mapTexture._properties.color;
-          var intensityProperty = mapTexture._properties.intensity;
+        var colorProperty = mapTexture._properties.color;
+        var intensityProperty = mapTexture._properties.intensity;
 
-          expect(colorProperty._texture.width).toBe(1);
-          expect(colorProperty._texture.height).toBe(1);
-          expect(colorProperty._texture).toBe(intensityProperty._texture);
+        expect(colorProperty._texture.width).toBe(1);
+        expect(colorProperty._texture.height).toBe(1);
+        expect(colorProperty._texture).toBe(intensityProperty._texture);
 
-          var vegetationProperty = orthoTexture._properties.vegetation;
-          expect(colorProperty._texture.width).toBe(1);
-          expect(colorProperty._texture.height).toBe(1);
-          expect(vegetationProperty._texture).not.toBe(colorProperty._texture);
+        var vegetationProperty = orthoTexture._properties.vegetation;
+        expect(colorProperty._texture.width).toBe(1);
+        expect(colorProperty._texture.height).toBe(1);
+        expect(vegetationProperty._texture).not.toBe(colorProperty._texture);
 
-          expect(Object.keys(featureMetadata.schema.classes).sort()).toEqual([
-            "building",
-            "map",
-            "ortho",
-            "tree",
-          ]);
-        });
+        expect(Object.keys(featureMetadata.schema.classes).sort()).toEqual([
+          "building",
+          "map",
+          "ortho",
+          "tree",
+        ]);
       });
     });
 
@@ -406,24 +397,16 @@ describe(
 
       featureMetadataLoader.load();
 
-      return pollToPromise(function () {
-        featureMetadataLoader.process(scene.frameState);
-        return (
-          featureMetadataLoader._state === ResourceLoaderState.READY ||
-          featureMetadataLoader._state === ResourceLoaderState.FAILED
-        );
-      }).then(function () {
-        return featureMetadataLoader.promise.then(function (
-          featureMetadataLoader
-        ) {
-          var featureMetadata = featureMetadataLoader.featureMetadata;
-          expect(Object.keys(featureMetadata.schema.classes).sort()).toEqual([
-            "building",
-            "map",
-            "ortho",
-            "tree",
-          ]);
-        });
+      return waitForLoaderProcess(featureMetadataLoader, scene).then(function (
+        featureMetadataLoader
+      ) {
+        var featureMetadata = featureMetadataLoader.featureMetadata;
+        expect(Object.keys(featureMetadata.schema.classes).sort()).toEqual([
+          "building",
+          "map",
+          "ortho",
+          "tree",
+        ]);
       });
     });
 
@@ -465,28 +448,20 @@ describe(
 
       featureMetadataLoader.load();
 
-      return pollToPromise(function () {
-        featureMetadataLoader.process(scene.frameState);
-        return (
-          featureMetadataLoader._state === ResourceLoaderState.READY ||
-          featureMetadataLoader._state === ResourceLoaderState.FAILED
-        );
-      }).then(function () {
-        return featureMetadataLoader.promise.then(function (
-          featureMetadataLoader
-        ) {
-          expect(featureMetadataLoader.featureMetadata).toBeDefined();
-          expect(featureMetadataLoader.isDestroyed()).toBe(false);
+      return waitForLoaderProcess(featureMetadataLoader, scene).then(function (
+        featureMetadataLoader
+      ) {
+        expect(featureMetadataLoader.featureMetadata).toBeDefined();
+        expect(featureMetadataLoader.isDestroyed()).toBe(false);
 
-          featureMetadataLoader.destroy();
+        featureMetadataLoader.destroy();
 
-          expect(featureMetadataLoader.featureMetadata).not.toBeDefined();
-          expect(featureMetadataLoader.isDestroyed()).toBe(true);
+        expect(featureMetadataLoader.featureMetadata).not.toBeDefined();
+        expect(featureMetadataLoader.isDestroyed()).toBe(true);
 
-          expect(destroyBufferView.calls.count()).toBe(6);
-          expect(destroyTexture.calls.count()).toBe(2);
-          expect(destroySchema.calls.count()).toBe(1);
-        });
+        expect(destroyBufferView.calls.count()).toBe(6);
+        expect(destroyTexture.calls.count()).toBe(2);
+        expect(destroySchema.calls.count()).toBe(1);
       });
     });
 
@@ -534,16 +509,8 @@ describe(
 
       featureMetadataLoaderCopy.load();
 
-      return pollToPromise(function () {
-        featureMetadataLoaderCopy.process(scene.frameState);
-        return (
-          featureMetadataLoaderCopy._state === ResourceLoaderState.READY ||
-          featureMetadataLoaderCopy._state === ResourceLoaderState.FAILED
-        );
-      }).then(function () {
-        return featureMetadataLoaderCopy.promise.then(function (
-          featureMetadataLoaderCopy
-        ) {
+      return waitForLoaderProcess(featureMetadataLoaderCopy, scene).then(
+        function (featureMetadataLoaderCopy) {
           // Ignore featureMetadataLoaderCopy destroying its buffer views
           destroyBufferView.calls.reset();
 
@@ -574,8 +541,8 @@ describe(
           expect(destroySchema.calls.count()).toBe(1);
 
           ResourceCache.unload(schemaCopy);
-        });
-      });
+        }
+      );
     }
 
     it("handles resolving resources after destroy", function () {

--- a/Specs/Scene/GltfImageLoaderSpec.js
+++ b/Specs/Scene/GltfImageLoaderSpec.js
@@ -226,7 +226,7 @@ describe("Scene/GltfImageLoader", function () {
       })
       .otherwise(function (runtimeError) {
         expect(runtimeError.message).toBe(
-          "Failed to load image:image.png\n404 Not Found"
+          "Failed to load image: image.png\n404 Not Found"
         );
       });
   });

--- a/Specs/Scene/GltfIndexBufferLoaderSpec.js
+++ b/Specs/Scene/GltfIndexBufferLoaderSpec.js
@@ -416,7 +416,10 @@ describe(
 
       return pollToPromise(function () {
         indexBufferLoader.process(scene.frameState);
-        return indexBufferLoader._state === ResourceLoaderState.READY;
+        return (
+          indexBufferLoader._state === ResourceLoaderState.READY ||
+          indexBufferLoader._state === ResourceLoaderState.FAILED
+        );
       }).then(function () {
         return indexBufferLoader.promise.then(function (indexBufferLoader) {
           indexBufferLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
@@ -445,7 +448,10 @@ describe(
 
       return pollToPromise(function () {
         indexBufferLoader.process(scene.frameState);
-        return indexBufferLoader._state === ResourceLoaderState.READY;
+        return (
+          indexBufferLoader._state === ResourceLoaderState.READY ||
+          indexBufferLoader._state === ResourceLoaderState.FAILED
+        );
       }).then(function () {
         return indexBufferLoader.promise.then(function (indexBufferLoader) {
           expect(indexBufferLoader.indexBuffer.sizeInBytes).toBe(
@@ -472,7 +478,10 @@ describe(
 
       return pollToPromise(function () {
         indexBufferLoader.process(scene.frameState);
-        return indexBufferLoader._state === ResourceLoaderState.READY;
+        return (
+          indexBufferLoader._state === ResourceLoaderState.READY ||
+          indexBufferLoader._state === ResourceLoaderState.FAILED
+        );
       }).then(function () {
         return indexBufferLoader.promise.then(function (indexBufferLoader) {
           expect(indexBufferLoader.indexBuffer.sizeInBytes).toBe(
@@ -526,7 +535,10 @@ describe(
 
       return pollToPromise(function () {
         indexBufferLoader.process(scene.frameState);
-        return indexBufferLoader._state === ResourceLoaderState.READY;
+        return (
+          indexBufferLoader._state === ResourceLoaderState.READY ||
+          indexBufferLoader._state === ResourceLoaderState.FAILED
+        );
       }).then(function () {
         return indexBufferLoader.promise.then(function (indexBufferLoader) {
           indexBufferLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
@@ -564,7 +576,10 @@ describe(
 
       return pollToPromise(function () {
         indexBufferLoader.process(scene.frameState);
-        return indexBufferLoader._state === ResourceLoaderState.READY;
+        return (
+          indexBufferLoader._state === ResourceLoaderState.READY ||
+          indexBufferLoader._state === ResourceLoaderState.FAILED
+        );
       }).then(function () {
         return indexBufferLoader.promise.then(function (indexBufferLoader) {
           expect(indexBufferLoader.indexBuffer).toBeDefined();
@@ -612,7 +627,10 @@ describe(
 
       return pollToPromise(function () {
         indexBufferLoader.process(scene.frameState);
-        return indexBufferLoader._state === ResourceLoaderState.READY;
+        return (
+          indexBufferLoader._state === ResourceLoaderState.READY ||
+          indexBufferLoader._state === ResourceLoaderState.FAILED
+        );
       }).then(function () {
         return indexBufferLoader.promise.then(function (indexBufferLoader) {
           expect(indexBufferLoader.indexBuffer).toBeDefined();

--- a/Specs/Scene/GltfIndexBufferLoaderSpec.js
+++ b/Specs/Scene/GltfIndexBufferLoaderSpec.js
@@ -8,12 +8,11 @@ import {
   JobScheduler,
   Resource,
   ResourceCache,
-  ResourceLoaderState,
   when,
 } from "../../Source/Cesium.js";
 import concatTypedArrays from "../concatTypedArrays.js";
 import createScene from "../createScene.js";
-import pollToPromise from "../pollToPromise.js";
+import waitForLoaderProcess from "../waitForLoaderProcess.js";
 
 describe(
   "Scene/GltfIndexBufferLoader",
@@ -368,20 +367,15 @@ describe(
 
       indexBufferLoader.load();
 
-      return pollToPromise(function () {
-        indexBufferLoader.process(scene.frameState);
-        return indexBufferLoader._state === ResourceLoaderState.FAILED;
-      }).then(function () {
-        return indexBufferLoader.promise
-          .then(function (indexBufferLoader) {
-            fail();
-          })
-          .otherwise(function (runtimeError) {
-            expect(runtimeError.message).toBe(
-              "Failed to load index buffer\nFailed to load Draco\nDraco decode failed"
-            );
-          });
-      });
+      return waitForLoaderProcess(indexBufferLoader, scene)
+        .then(function (indexBufferLoader) {
+          fail();
+        })
+        .otherwise(function (runtimeError) {
+          expect(runtimeError.message).toBe(
+            "Failed to load index buffer\nFailed to load Draco\nDraco decode failed"
+          );
+        });
     });
 
     it("loads from accessor", function () {
@@ -414,19 +408,13 @@ describe(
 
       indexBufferLoader.load();
 
-      return pollToPromise(function () {
-        indexBufferLoader.process(scene.frameState);
-        return (
-          indexBufferLoader._state === ResourceLoaderState.READY ||
-          indexBufferLoader._state === ResourceLoaderState.FAILED
+      return waitForLoaderProcess(indexBufferLoader, scene).then(function (
+        indexBufferLoader
+      ) {
+        indexBufferLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
+        expect(indexBufferLoader.indexBuffer.sizeInBytes).toBe(
+          indicesUint16.byteLength
         );
-      }).then(function () {
-        return indexBufferLoader.promise.then(function (indexBufferLoader) {
-          indexBufferLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
-          expect(indexBufferLoader.indexBuffer.sizeInBytes).toBe(
-            indicesUint16.byteLength
-          );
-        });
       });
     });
 
@@ -446,18 +434,12 @@ describe(
 
       indexBufferLoader.load();
 
-      return pollToPromise(function () {
-        indexBufferLoader.process(scene.frameState);
-        return (
-          indexBufferLoader._state === ResourceLoaderState.READY ||
-          indexBufferLoader._state === ResourceLoaderState.FAILED
+      return waitForLoaderProcess(indexBufferLoader, scene).then(function (
+        indexBufferLoader
+      ) {
+        expect(indexBufferLoader.indexBuffer.sizeInBytes).toBe(
+          indicesUint16.byteLength
         );
-      }).then(function () {
-        return indexBufferLoader.promise.then(function (indexBufferLoader) {
-          expect(indexBufferLoader.indexBuffer.sizeInBytes).toBe(
-            indicesUint16.byteLength
-          );
-        });
       });
     });
 
@@ -476,18 +458,12 @@ describe(
 
       indexBufferLoader.load();
 
-      return pollToPromise(function () {
-        indexBufferLoader.process(scene.frameState);
-        return (
-          indexBufferLoader._state === ResourceLoaderState.READY ||
-          indexBufferLoader._state === ResourceLoaderState.FAILED
+      return waitForLoaderProcess(indexBufferLoader, scene).then(function (
+        indexBufferLoader
+      ) {
+        expect(indexBufferLoader.indexBuffer.sizeInBytes).toBe(
+          expectedByteLength
         );
-      }).then(function () {
-        return indexBufferLoader.promise.then(function (indexBufferLoader) {
-          expect(indexBufferLoader.indexBuffer.sizeInBytes).toBe(
-            expectedByteLength
-          );
-        });
       });
     }
 
@@ -533,19 +509,13 @@ describe(
 
       indexBufferLoader.load();
 
-      return pollToPromise(function () {
-        indexBufferLoader.process(scene.frameState);
-        return (
-          indexBufferLoader._state === ResourceLoaderState.READY ||
-          indexBufferLoader._state === ResourceLoaderState.FAILED
+      return waitForLoaderProcess(indexBufferLoader, scene).then(function (
+        indexBufferLoader
+      ) {
+        indexBufferLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
+        expect(indexBufferLoader.indexBuffer.sizeInBytes).toBe(
+          decodedIndices.byteLength
         );
-      }).then(function () {
-        return indexBufferLoader.promise.then(function (indexBufferLoader) {
-          indexBufferLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
-          expect(indexBufferLoader.indexBuffer.sizeInBytes).toBe(
-            decodedIndices.byteLength
-          );
-        });
       });
     });
 
@@ -574,24 +544,18 @@ describe(
 
       indexBufferLoader.load();
 
-      return pollToPromise(function () {
-        indexBufferLoader.process(scene.frameState);
-        return (
-          indexBufferLoader._state === ResourceLoaderState.READY ||
-          indexBufferLoader._state === ResourceLoaderState.FAILED
-        );
-      }).then(function () {
-        return indexBufferLoader.promise.then(function (indexBufferLoader) {
-          expect(indexBufferLoader.indexBuffer).toBeDefined();
-          expect(indexBufferLoader.isDestroyed()).toBe(false);
+      return waitForLoaderProcess(indexBufferLoader, scene).then(function (
+        indexBufferLoader
+      ) {
+        expect(indexBufferLoader.indexBuffer).toBeDefined();
+        expect(indexBufferLoader.isDestroyed()).toBe(false);
 
-          indexBufferLoader.destroy();
+        indexBufferLoader.destroy();
 
-          expect(indexBufferLoader.indexBuffer).not.toBeDefined();
-          expect(indexBufferLoader.isDestroyed()).toBe(true);
-          expect(unloadBufferView).toHaveBeenCalled();
-          expect(destroyIndexBuffer).toHaveBeenCalled();
-        });
+        expect(indexBufferLoader.indexBuffer).not.toBeDefined();
+        expect(indexBufferLoader.isDestroyed()).toBe(true);
+        expect(unloadBufferView).toHaveBeenCalled();
+        expect(destroyIndexBuffer).toHaveBeenCalled();
       });
     });
 
@@ -625,24 +589,18 @@ describe(
 
       indexBufferLoader.load();
 
-      return pollToPromise(function () {
-        indexBufferLoader.process(scene.frameState);
-        return (
-          indexBufferLoader._state === ResourceLoaderState.READY ||
-          indexBufferLoader._state === ResourceLoaderState.FAILED
-        );
-      }).then(function () {
-        return indexBufferLoader.promise.then(function (indexBufferLoader) {
-          expect(indexBufferLoader.indexBuffer).toBeDefined();
-          expect(indexBufferLoader.isDestroyed()).toBe(false);
+      return waitForLoaderProcess(indexBufferLoader, scene).then(function (
+        indexBufferLoader
+      ) {
+        expect(indexBufferLoader.indexBuffer).toBeDefined();
+        expect(indexBufferLoader.isDestroyed()).toBe(false);
 
-          indexBufferLoader.destroy();
+        indexBufferLoader.destroy();
 
-          expect(indexBufferLoader.indexBuffer).not.toBeDefined();
-          expect(indexBufferLoader.isDestroyed()).toBe(true);
-          expect(unloadDraco).toHaveBeenCalled();
-          expect(destroyIndexBuffer).toHaveBeenCalled();
-        });
+        expect(indexBufferLoader.indexBuffer).not.toBeDefined();
+        expect(indexBufferLoader.isDestroyed()).toBe(true);
+        expect(unloadDraco).toHaveBeenCalled();
+        expect(destroyIndexBuffer).toHaveBeenCalled();
       });
     });
 

--- a/Specs/Scene/GltfTextureLoaderSpec.js
+++ b/Specs/Scene/GltfTextureLoaderSpec.js
@@ -4,13 +4,12 @@ import {
   JobScheduler,
   Resource,
   ResourceCache,
-  ResourceLoaderState,
   SupportedImageFormats,
   Texture,
   when,
 } from "../../Source/Cesium.js";
 import createScene from "../createScene.js";
-import pollToPromise from "../pollToPromise.js";
+import waitForLoaderProcess from "../waitForLoaderProcess.js";
 
 describe(
   "Scene/GltfTextureLoader",
@@ -229,18 +228,12 @@ describe(
 
       textureLoader.load();
 
-      return pollToPromise(function () {
-        textureLoader.process(scene.frameState);
-        return (
-          textureLoader._state === ResourceLoaderState.READY ||
-          textureLoader._state === ResourceLoaderState.FAILED
-        );
-      }).then(function () {
-        return textureLoader.promise.then(function (textureLoader) {
-          textureLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
-          expect(textureLoader.texture.width).toBe(1);
-          expect(textureLoader.texture.height).toBe(1);
-        });
+      return waitForLoaderProcess(textureLoader, scene).then(function (
+        textureLoader
+      ) {
+        textureLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
+        expect(textureLoader.texture.width).toBe(1);
+        expect(textureLoader.texture.height).toBe(1);
       });
     });
 
@@ -261,18 +254,12 @@ describe(
 
       textureLoader.load();
 
-      return pollToPromise(function () {
-        textureLoader.process(scene.frameState);
-        return (
-          textureLoader._state === ResourceLoaderState.READY ||
-          textureLoader._state === ResourceLoaderState.FAILED
-        );
-      }).then(function () {
-        return textureLoader.promise.then(function (textureLoader) {
-          textureLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
-          expect(textureLoader.texture.width).toBe(1);
-          expect(textureLoader.texture.height).toBe(1);
-        });
+      return waitForLoaderProcess(textureLoader, scene).then(function (
+        textureLoader
+      ) {
+        textureLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
+        expect(textureLoader.texture.width).toBe(1);
+        expect(textureLoader.texture.height).toBe(1);
       });
     });
 
@@ -297,18 +284,12 @@ describe(
 
       textureLoader.load();
 
-      return pollToPromise(function () {
-        textureLoader.process(scene.frameState);
-        return (
-          textureLoader._state === ResourceLoaderState.READY ||
-          textureLoader._state === ResourceLoaderState.FAILED
-        );
-      }).then(function () {
-        return textureLoader.promise.then(function (textureLoader) {
-          expect(textureLoader.texture.width).toBe(1);
-          expect(textureLoader.texture.height).toBe(1);
-          expect(generateMipmap).toHaveBeenCalled();
-        });
+      return waitForLoaderProcess(textureLoader, scene).then(function (
+        textureLoader
+      ) {
+        expect(textureLoader.texture.width).toBe(1);
+        expect(textureLoader.texture.height).toBe(1);
+        expect(generateMipmap).toHaveBeenCalled();
       });
     });
 
@@ -328,17 +309,11 @@ describe(
 
       textureLoader.load();
 
-      return pollToPromise(function () {
-        textureLoader.process(scene.frameState);
-        return (
-          textureLoader._state === ResourceLoaderState.READY ||
-          textureLoader._state === ResourceLoaderState.FAILED
-        );
-      }).then(function () {
-        return textureLoader.promise.then(function (textureLoader) {
-          expect(textureLoader.texture.width).toBe(4);
-          expect(textureLoader.texture.height).toBe(2);
-        });
+      return waitForLoaderProcess(textureLoader, scene).then(function (
+        textureLoader
+      ) {
+        expect(textureLoader.texture.width).toBe(4);
+        expect(textureLoader.texture.height).toBe(2);
       });
     });
 
@@ -358,17 +333,11 @@ describe(
 
       textureLoader.load();
 
-      return pollToPromise(function () {
-        textureLoader.process(scene.frameState);
-        return (
-          textureLoader._state === ResourceLoaderState.READY ||
-          textureLoader._state === ResourceLoaderState.FAILED
-        );
-      }).then(function () {
-        return textureLoader.promise.then(function (textureLoader) {
-          expect(textureLoader.texture.width).toBe(3);
-          expect(textureLoader.texture.height).toBe(2);
-        });
+      return waitForLoaderProcess(textureLoader, scene).then(function (
+        textureLoader
+      ) {
+        expect(textureLoader.texture.width).toBe(3);
+        expect(textureLoader.texture.height).toBe(2);
       });
     });
 
@@ -400,24 +369,18 @@ describe(
 
       textureLoader.load();
 
-      return pollToPromise(function () {
-        textureLoader.process(scene.frameState);
-        return (
-          textureLoader._state === ResourceLoaderState.READY ||
-          textureLoader._state === ResourceLoaderState.FAILED
-        );
-      }).then(function () {
-        return textureLoader.promise.then(function (textureLoader) {
-          expect(textureLoader.texture).toBeDefined();
-          expect(textureLoader.isDestroyed()).toBe(false);
+      return waitForLoaderProcess(textureLoader, scene).then(function (
+        textureLoader
+      ) {
+        expect(textureLoader.texture).toBeDefined();
+        expect(textureLoader.isDestroyed()).toBe(false);
 
-          textureLoader.destroy();
+        textureLoader.destroy();
 
-          expect(textureLoader.texture).not.toBeDefined();
-          expect(textureLoader.isDestroyed()).toBe(true);
-          expect(unloadImage).toHaveBeenCalled();
-          expect(destroyTexture).toHaveBeenCalled();
-        });
+        expect(textureLoader.texture).not.toBeDefined();
+        expect(textureLoader.isDestroyed()).toBe(true);
+        expect(unloadImage).toHaveBeenCalled();
+        expect(destroyTexture).toHaveBeenCalled();
       });
     });
 

--- a/Specs/Scene/GltfTextureLoaderSpec.js
+++ b/Specs/Scene/GltfTextureLoaderSpec.js
@@ -191,7 +191,7 @@ describe(
         })
         .otherwise(function (runtimeError) {
           expect(runtimeError.message).toBe(
-            "Failed to load texture\nFailed to load image:image.png\n404 Not Found"
+            "Failed to load texture\nFailed to load image: image.png\n404 Not Found"
           );
         });
     });
@@ -231,7 +231,10 @@ describe(
 
       return pollToPromise(function () {
         textureLoader.process(scene.frameState);
-        return textureLoader._state === ResourceLoaderState.READY;
+        return (
+          textureLoader._state === ResourceLoaderState.READY ||
+          textureLoader._state === ResourceLoaderState.FAILED
+        );
       }).then(function () {
         return textureLoader.promise.then(function (textureLoader) {
           textureLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
@@ -260,7 +263,10 @@ describe(
 
       return pollToPromise(function () {
         textureLoader.process(scene.frameState);
-        return textureLoader._state === ResourceLoaderState.READY;
+        return (
+          textureLoader._state === ResourceLoaderState.READY ||
+          textureLoader._state === ResourceLoaderState.FAILED
+        );
       }).then(function () {
         return textureLoader.promise.then(function (textureLoader) {
           textureLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
@@ -293,7 +299,10 @@ describe(
 
       return pollToPromise(function () {
         textureLoader.process(scene.frameState);
-        return textureLoader._state === ResourceLoaderState.READY;
+        return (
+          textureLoader._state === ResourceLoaderState.READY ||
+          textureLoader._state === ResourceLoaderState.FAILED
+        );
       }).then(function () {
         return textureLoader.promise.then(function (textureLoader) {
           expect(textureLoader.texture.width).toBe(1);
@@ -321,7 +330,10 @@ describe(
 
       return pollToPromise(function () {
         textureLoader.process(scene.frameState);
-        return textureLoader._state === ResourceLoaderState.READY;
+        return (
+          textureLoader._state === ResourceLoaderState.READY ||
+          textureLoader._state === ResourceLoaderState.FAILED
+        );
       }).then(function () {
         return textureLoader.promise.then(function (textureLoader) {
           expect(textureLoader.texture.width).toBe(4);
@@ -348,7 +360,10 @@ describe(
 
       return pollToPromise(function () {
         textureLoader.process(scene.frameState);
-        return textureLoader._state === ResourceLoaderState.READY;
+        return (
+          textureLoader._state === ResourceLoaderState.READY ||
+          textureLoader._state === ResourceLoaderState.FAILED
+        );
       }).then(function () {
         return textureLoader.promise.then(function (textureLoader) {
           expect(textureLoader.texture.width).toBe(3);
@@ -387,7 +402,10 @@ describe(
 
       return pollToPromise(function () {
         textureLoader.process(scene.frameState);
-        return textureLoader._state === ResourceLoaderState.READY;
+        return (
+          textureLoader._state === ResourceLoaderState.READY ||
+          textureLoader._state === ResourceLoaderState.FAILED
+        );
       }).then(function () {
         return textureLoader.promise.then(function (textureLoader) {
           expect(textureLoader.texture).toBeDefined();

--- a/Specs/Scene/GltfVertexBufferLoaderSpec.js
+++ b/Specs/Scene/GltfVertexBufferLoaderSpec.js
@@ -273,6 +273,7 @@ describe(
           bufferViewId: 0,
           draco: dracoExtension,
           dracoAttributeSemantic: "POSITION",
+          dracoAccessorId: 0,
         });
       }).toThrowDeveloperError();
     });
@@ -296,6 +297,22 @@ describe(
           gltfResource: gltfResource,
           baseResource: gltfResource,
           draco: dracoExtension,
+          dracoAttributeSemantic: undefined,
+          dracoAccessorId: 0,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("throws if draco is defined and dracoAccessorId is not defined", function () {
+      expect(function () {
+        return new GltfVertexBufferLoader({
+          resourceCache: ResourceCache,
+          gltf: gltfDraco,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          draco: dracoExtension,
+          dracoAttributeSemantic: "POSITION",
+          dracoAccessorId: undefined,
         });
       }).toThrowDeveloperError();
     });
@@ -344,6 +361,7 @@ describe(
         baseResource: gltfResource,
         draco: dracoExtension,
         dracoAttributeSemantic: "POSITION",
+        dracoAccessorId: 0,
       });
 
       vertexBufferLoader.load();
@@ -396,7 +414,10 @@ describe(
 
       return pollToPromise(function () {
         vertexBufferLoader.process(scene.frameState);
-        return vertexBufferLoader._state === ResourceLoaderState.READY;
+        return (
+          vertexBufferLoader._state === ResourceLoaderState.READY ||
+          vertexBufferLoader._state === ResourceLoaderState.FAILED
+        );
       }).then(function () {
         return vertexBufferLoader.promise.then(function (vertexBufferLoader) {
           vertexBufferLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
@@ -425,7 +446,10 @@ describe(
 
       return pollToPromise(function () {
         vertexBufferLoader.process(scene.frameState);
-        return vertexBufferLoader._state === ResourceLoaderState.READY;
+        return (
+          vertexBufferLoader._state === ResourceLoaderState.READY ||
+          vertexBufferLoader._state === ResourceLoaderState.FAILED
+        );
       }).then(function () {
         return vertexBufferLoader.promise.then(function (vertexBufferLoader) {
           expect(vertexBufferLoader.vertexBuffer.sizeInBytes).toBe(
@@ -457,13 +481,17 @@ describe(
         baseResource: gltfResource,
         draco: dracoExtension,
         dracoAttributeSemantic: "POSITION",
+        dracoAccessorId: 0,
       });
 
       vertexBufferLoader.load();
 
       return pollToPromise(function () {
         vertexBufferLoader.process(scene.frameState);
-        return vertexBufferLoader._state === ResourceLoaderState.READY;
+        return (
+          vertexBufferLoader._state === ResourceLoaderState.READY ||
+          vertexBufferLoader._state === ResourceLoaderState.FAILED
+        );
       }).then(function () {
         return vertexBufferLoader.promise.then(function (vertexBufferLoader) {
           vertexBufferLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
@@ -477,7 +505,7 @@ describe(
             new Cartesian3(-1.0, -1.0, -1.0)
           );
           expect(quantization.quantizedVolumeDimensions).toEqual(
-            new Cartesian3(2.0, 0.0, 0.0)
+            new Cartesian3(2.0, 2.0, 2.0)
           );
           expect(quantization.normalizationRange).toBe(16383);
           expect(quantization.componentDatatype).toBe(
@@ -503,13 +531,17 @@ describe(
         baseResource: gltfResource,
         draco: dracoExtension,
         dracoAttributeSemantic: "NORMAL",
+        dracoAccessorId: 1,
       });
 
       vertexBufferLoader.load();
 
       return pollToPromise(function () {
         vertexBufferLoader.process(scene.frameState);
-        return vertexBufferLoader._state === ResourceLoaderState.READY;
+        return (
+          vertexBufferLoader._state === ResourceLoaderState.READY ||
+          vertexBufferLoader._state === ResourceLoaderState.FAILED
+        );
       }).then(function () {
         return vertexBufferLoader.promise.then(function (vertexBufferLoader) {
           expect(vertexBufferLoader.vertexBuffer.sizeInBytes).toBe(
@@ -555,7 +587,10 @@ describe(
 
       return pollToPromise(function () {
         vertexBufferLoader.process(scene.frameState);
-        return vertexBufferLoader._state === ResourceLoaderState.READY;
+        return (
+          vertexBufferLoader._state === ResourceLoaderState.READY ||
+          vertexBufferLoader._state === ResourceLoaderState.FAILED
+        );
       }).then(function () {
         return vertexBufferLoader.promise.then(function (vertexBufferLoader) {
           expect(vertexBufferLoader.vertexBuffer).toBeDefined();
@@ -597,13 +632,17 @@ describe(
         baseResource: gltfResource,
         draco: dracoExtension,
         dracoAttributeSemantic: "POSITION",
+        dracoAccessorId: 0,
       });
 
       vertexBufferLoader.load();
 
       return pollToPromise(function () {
         vertexBufferLoader.process(scene.frameState);
-        return vertexBufferLoader._state === ResourceLoaderState.READY;
+        return (
+          vertexBufferLoader._state === ResourceLoaderState.READY ||
+          vertexBufferLoader._state === ResourceLoaderState.FAILED
+        );
       }).then(function () {
         return vertexBufferLoader.promise.then(function (vertexBufferLoader) {
           expect(vertexBufferLoader.vertexBuffer).toBeDefined();
@@ -696,6 +735,7 @@ describe(
         baseResource: gltfResource,
         draco: dracoExtension,
         dracoAttributeSemantic: "POSITION",
+        dracoAccessorId: 0,
       });
 
       expect(vertexBufferLoader.vertexBuffer).not.toBeDefined();

--- a/Specs/Scene/ResourceCacheSpec.js
+++ b/Specs/Scene/ResourceCacheSpec.js
@@ -6,14 +6,13 @@ import {
   Resource,
   ResourceCache,
   ResourceCacheKey,
-  ResourceLoaderState,
   SupportedImageFormats,
   when,
 } from "../../Source/Cesium.js";
 import concatTypedArrays from "../concatTypedArrays.js";
 import createScene from "../createScene.js";
 import generateJsonBuffer from "../generateJsonBuffer.js";
-import pollToPromise from "../pollToPromise.js";
+import waitForLoaderProcess from "../waitForLoaderProcess.js";
 
 describe(
   "ResourceCache",
@@ -381,7 +380,7 @@ describe(
       }).toThrowDeveloperError();
     });
 
-    it("unload throws if resource has no references", function () {
+    it("unload throws if resourceLoader has already been unloaded from the cache", function () {
       spyOn(Resource.prototype, "fetchJson").and.returnValue(
         when.resolve(schemaJson)
       );
@@ -783,16 +782,10 @@ describe(
 
       expect(cacheEntry.referenceCount).toBe(2);
 
-      return pollToPromise(function () {
-        dracoLoader.process(scene.frameState);
-        return (
-          dracoLoader._state === ResourceLoaderState.READY ||
-          dracoLoader._state === ResourceLoaderState.FAILED
-        );
-      }).then(function () {
-        return dracoLoader.promise.then(function (dracoLoader) {
-          expect(dracoLoader.decodedData).toBeDefined();
-        });
+      return waitForLoaderProcess(dracoLoader, scene).then(function (
+        dracoLoader
+      ) {
+        expect(dracoLoader.decodedData).toBeDefined();
       });
     });
 
@@ -874,16 +867,10 @@ describe(
 
       expect(cacheEntry.referenceCount).toBe(2);
 
-      return pollToPromise(function () {
-        vertexBufferLoader.process(scene.frameState);
-        return (
-          vertexBufferLoader._state === ResourceLoaderState.READY ||
-          vertexBufferLoader._state === ResourceLoaderState.FAILED
-        );
-      }).then(function () {
-        return vertexBufferLoader.promise.then(function (vertexBufferLoader) {
-          expect(vertexBufferLoader.vertexBuffer).toBeDefined();
-        });
+      return waitForLoaderProcess(vertexBufferLoader, scene).then(function (
+        vertexBufferLoader
+      ) {
+        expect(vertexBufferLoader.vertexBuffer).toBeDefined();
       });
     });
 
@@ -930,16 +917,10 @@ describe(
 
       expect(cacheEntry.referenceCount).toBe(2);
 
-      return pollToPromise(function () {
-        vertexBufferLoader.process(scene.frameState);
-        return (
-          vertexBufferLoader._state === ResourceLoaderState.READY ||
-          vertexBufferLoader._state === ResourceLoaderState.FAILED
-        );
-      }).then(function () {
-        return vertexBufferLoader.promise.then(function (vertexBufferLoader) {
-          expect(vertexBufferLoader.vertexBuffer).toBeDefined();
-        });
+      return waitForLoaderProcess(vertexBufferLoader, scene).then(function (
+        vertexBufferLoader
+      ) {
+        expect(vertexBufferLoader.vertexBuffer).toBeDefined();
       });
     });
 
@@ -1060,16 +1041,10 @@ describe(
 
       expect(cacheEntry.referenceCount).toBe(2);
 
-      return pollToPromise(function () {
-        indexBufferLoader.process(scene.frameState);
-        return (
-          indexBufferLoader._state === ResourceLoaderState.READY ||
-          indexBufferLoader._state === ResourceLoaderState.FAILED
-        );
-      }).then(function () {
-        return indexBufferLoader.promise.then(function (indexBufferLoader) {
-          expect(indexBufferLoader.indexBuffer).toBeDefined();
-        });
+      return waitForLoaderProcess(indexBufferLoader, scene).then(function (
+        indexBufferLoader
+      ) {
+        expect(indexBufferLoader.indexBuffer).toBeDefined();
       });
     });
 
@@ -1114,16 +1089,10 @@ describe(
 
       expect(cacheEntry.referenceCount).toBe(2);
 
-      return pollToPromise(function () {
-        indexBufferLoader.process(scene.frameState);
-        return (
-          indexBufferLoader._state === ResourceLoaderState.READY ||
-          indexBufferLoader._state === ResourceLoaderState.FAILED
-        );
-      }).then(function () {
-        return indexBufferLoader.promise.then(function (indexBufferLoader) {
-          expect(indexBufferLoader.indexBuffer).toBeDefined();
-        });
+      return waitForLoaderProcess(indexBufferLoader, scene).then(function (
+        indexBufferLoader
+      ) {
+        expect(indexBufferLoader.indexBuffer).toBeDefined();
       });
     });
 
@@ -1308,16 +1277,10 @@ describe(
 
       expect(cacheEntry.referenceCount).toBe(2);
 
-      return pollToPromise(function () {
-        textureLoader.process(scene.frameState);
-        return (
-          textureLoader._state === ResourceLoaderState.READY ||
-          textureLoader._state === ResourceLoaderState.FAILED
-        );
-      }).then(function () {
-        return textureLoader.promise.then(function (textureLoader) {
-          expect(textureLoader.texture).toBeDefined();
-        });
+      return waitForLoaderProcess(textureLoader, scene).then(function (
+        textureLoader
+      ) {
+        expect(textureLoader.texture).toBeDefined();
       });
     });
 

--- a/Specs/waitForLoaderProcess.js
+++ b/Specs/waitForLoaderProcess.js
@@ -1,4 +1,4 @@
-import { ResourceLoaderState } from "../../Source/Cesium.js";
+import { ResourceLoaderState } from "../Source/Cesium.js";
 
 import pollToPromise from "./pollToPromise.js";
 

--- a/Specs/waitForLoaderProcess.js
+++ b/Specs/waitForLoaderProcess.js
@@ -1,0 +1,15 @@
+import { ResourceLoaderState } from "../../Source/Cesium.js";
+
+import pollToPromise from "./pollToPromise.js";
+
+export default function waitForLoaderProcess(loader, scene) {
+  return pollToPromise(function () {
+    loader.process(scene.frameState);
+    return (
+      loader._state === ResourceLoaderState.READY ||
+      loader._state === ResourceLoaderState.FAILED
+    );
+  }).then(function () {
+    return loader.promise;
+  });
+}


### PR DESCRIPTION
Continuation of https://github.com/CesiumGS/cesium/pull/9494

* Removed `keepResident` option. Instead it will be implemented more like `Model`'s `releaseGltfJson`.
* Fixed issues with getting quantization information after Draco decode
* Make copies of feature metadata buffer views so that the underlying array buffer can be freed. The underlying array buffer will often by the whole glb file so this is important to reduce memory usage.
* Tweaks to unit tests to make them fail fast and not get stuck in timeouts (resolving `pollToPromise` when `READY` or `FAILED`)