### PR TITLE
Log Depth View Fix

### DIFF
--- a/Source/Scene/View.js
+++ b/Source/Scene/View.js
@@ -169,6 +169,9 @@ function updateFrustums(view, scene, near, far) {
     } else {
       curNear = Math.max(near, Math.pow(farToNearRatio, m) * near);
       curFar = Math.min(far, farToNearRatio * curNear);
+      if (scene.logarithmicDepthBuffer) {
+        curFar = Math.pow(10, Math.ceil(Math.log(curFar) / Math.log(10)));
+      }
     }
     var frustumCommands = frustumCommandsList[m];
     if (!defined(frustumCommands)) {


### PR DESCRIPTION
### Issue
After https://github.com/CesiumGS/cesium/pull/8850 we had some erratic picking failures (especially for billboards). I broke it down to [these lines](https://github.com/CesiumGS/cesium/pull/8850/files#diff-4f86819ea554476f615dea02f82a302c3303a6da3be2b2c7e3e90a0a08e8b90aL155-R164):

```diff
    } else {
      curNear = Math.max(near, Math.pow(farToNearRatio, m) * near);
-      curFar = farToNearRatio * curNear;
-      if (!logDepth) {
-        curFar = Math.min(far, curFar);
-      }
+      curFar = Math.min(far, farToNearRatio * curNear);
    }
```

### Solution
This MR trys to fix this by clamping the far plane to the next log10 range.

```diff
  } else {
      curNear = Math.max(near, Math.pow(farToNearRatio, m) * near);
      curFar = Math.min(far, farToNearRatio * curNear);
+      if (scene.logarithmicDepthBuffer) {
+       curFar = Math.pow(10, Math.ceil(Math.log(curFar) / Math.log(10)));
+      }
  }
``` 

 Since my grasp on the subject is slight at best, maybe @IanLilleyT you could pitch in here, thanks. 