### PR TITLE
Clean up 3D Tiles Next documentation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Change Log
 
-### 3d-tiles-next
+### 1.82 - 2021-06-01
 
 ##### Additions :tada:
 

--- a/Source/Core/MortonOrder.js
+++ b/Source/Core/MortonOrder.js
@@ -8,7 +8,6 @@ import DeveloperError from "./DeveloperError.js";
  *
  * @namespace MortonOrder
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 var MortonOrder = {};
 
@@ -115,7 +114,6 @@ function removeTwoSpacing(v) {
  * @param {Number} y The Y coordinate in the range [0, (2^16)-1].
  * @returns {Number} The Morton index.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MortonOrder.encode2D = function (x, y) {
   //>>includeStart('debug', pragmas.debug);
@@ -141,7 +139,6 @@ MortonOrder.encode2D = function (x, y) {
  * @param {Number[]} [result] The array onto which to store the result.
  * @returns {Number[]} An array containing the 2D coordinates correspoding to the Morton index.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MortonOrder.decode2D = function (mortonIndex, result) {
   //>>includeStart('debug', pragmas.debug);
@@ -169,7 +166,6 @@ MortonOrder.decode2D = function (mortonIndex, result) {
  * @param {Number} z The Z coordinate in the range [0, (2^10)-1].
  * @returns {Number} The Morton index.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MortonOrder.encode3D = function (x, y, z) {
   //>>includeStart('debug', pragmas.debug);
@@ -194,9 +190,8 @@ MortonOrder.encode3D = function (x, y, z) {
  *
  * @param {Number} mortonIndex The Morton index in the range [0, (2^30)-1].
  * @param {Number[]} [result] The array onto which to store the result.
- * @returns {Number[]} An array containing the 3D coordinates correspoding to the Morton index.
+ * @returns {Number[]} An array containing the 3D coordinates corresponding to the Morton index.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MortonOrder.decode3D = function (mortonIndex, result) {
   //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/MortonOrder.js
+++ b/Source/Core/MortonOrder.js
@@ -26,6 +26,7 @@ var MortonOrder = {};
  * @param {Number} v A 16-bit unsigned integer.
  * @returns {Number} A 32-bit unsigned integer.
  * @see {@link https://fgiesen.wordpress.com/2009/12/13/decoding-morton-codes/}
+ * @private
  */
 function insertOneSpacing(v) {
   v = (v ^ (v << 8)) & 0x00ff00ff;
@@ -113,6 +114,8 @@ function removeTwoSpacing(v) {
  * @param {Number} x The X coordinate in the range [0, (2^16)-1].
  * @param {Number} y The Y coordinate in the range [0, (2^16)-1].
  * @returns {Number} The Morton index.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MortonOrder.encode2D = function (x, y) {
   //>>includeStart('debug', pragmas.debug);
@@ -137,6 +140,8 @@ MortonOrder.encode2D = function (x, y) {
  * @param {Number} mortonIndex The Morton index in the range [0, (2^32)-1].
  * @param {Number[]} [result] The array onto which to store the result.
  * @returns {Number[]} An array containing the 2D coordinates correspoding to the Morton index.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MortonOrder.decode2D = function (mortonIndex, result) {
   //>>includeStart('debug', pragmas.debug);
@@ -163,6 +168,8 @@ MortonOrder.decode2D = function (mortonIndex, result) {
  * @param {Number} y The Y coordinate in the range [0, (2^10)-1].
  * @param {Number} z The Z coordinate in the range [0, (2^10)-1].
  * @returns {Number} The Morton index.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MortonOrder.encode3D = function (x, y, z) {
   //>>includeStart('debug', pragmas.debug);
@@ -188,6 +195,8 @@ MortonOrder.encode3D = function (x, y, z) {
  * @param {Number} mortonIndex The Morton index in the range [0, (2^30)-1].
  * @param {Number[]} [result] The array onto which to store the result.
  * @returns {Number[]} An array containing the 3D coordinates correspoding to the Morton index.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MortonOrder.decode3D = function (mortonIndex, result) {
   //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/MortonOrder.js
+++ b/Source/Core/MortonOrder.js
@@ -7,6 +7,8 @@ import DeveloperError from "./DeveloperError.js";
  * @see {@link https://en.wikipedia.org/wiki/Z-order_curve}
  *
  * @namespace MortonOrder
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 var MortonOrder = {};
 

--- a/Source/Core/RequestScheduler.js
+++ b/Source/Core/RequestScheduler.js
@@ -175,6 +175,16 @@ RequestScheduler.serverHasOpenSlots = function (serverKey, desiredRequests) {
   return hasOpenSlotsServer;
 };
 
+/**
+ * Check if the priority heap has open slots, regardless of which server they
+ * are from. This is used in {@link Multiple3DTileContent} for determining when
+ * all requests can be scheduled
+ * @param {Number} desiredRequests The number of requests the caller intends to make
+ * @return {Boolean} <code>true</code> if the heap has enough available slots to meet the desiredRequests. <code>false</code> otherwise.
+ *
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
+ */
 RequestScheduler.heapHasOpenSlots = function (desiredRequests) {
   var hasOpenSlotsHeap =
     requestHeap.length + desiredRequests <= priorityHeapLength;

--- a/Source/Core/RequestScheduler.js
+++ b/Source/Core/RequestScheduler.js
@@ -183,7 +183,6 @@ RequestScheduler.serverHasOpenSlots = function (serverKey, desiredRequests) {
  * @return {Boolean} <code>true</code> if the heap has enough available slots to meet the desiredRequests. <code>false</code> otherwise.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 RequestScheduler.heapHasOpenSlots = function (desiredRequests) {
   var hasOpenSlotsHeap =

--- a/Source/Scene/AlphaMode.js
+++ b/Source/Scene/AlphaMode.js
@@ -2,6 +2,8 @@
  * The alpha rendering mode of the material.
  *
  * @enum {String}
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 var AlphaMode = {
   /**

--- a/Source/Scene/AlphaMode.js
+++ b/Source/Scene/AlphaMode.js
@@ -3,7 +3,6 @@
  *
  * @enum {String}
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 var AlphaMode = {
   /**

--- a/Source/Scene/AttributeType.js
+++ b/Source/Scene/AttributeType.js
@@ -12,7 +12,6 @@ import Matrix4 from "../Core/Matrix4.js";
  * @enum {String}
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 var AttributeType = {
   /**
@@ -79,7 +78,6 @@ var AttributeType = {
  * @returns {*} The math type.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 AttributeType.getMathType = function (attributeType) {
   switch (attributeType) {

--- a/Source/Scene/AttributeType.js
+++ b/Source/Scene/AttributeType.js
@@ -12,6 +12,7 @@ import Matrix4 from "../Core/Matrix4.js";
  * @enum {String}
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 var AttributeType = {
   /**
@@ -78,6 +79,7 @@ var AttributeType = {
  * @returns {*} The math type.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 AttributeType.getMathType = function (attributeType) {
   switch (attributeType) {

--- a/Source/Scene/BatchTableHierarchy.js
+++ b/Source/Scene/BatchTableHierarchy.js
@@ -21,6 +21,7 @@ import RuntimeError from "../Core/RuntimeError.js";
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function BatchTableHierarchy(options) {
   this._classes = undefined;
@@ -342,6 +343,7 @@ function traverseHierarchy(hierarchy, instanceIndex, endConditionCallback) {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {Boolean} Whether this property exists.
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BatchTableHierarchy.prototype.hasProperty = function (batchId, propertyId) {
   var result = traverseHierarchy(this, batchId, function (

--- a/Source/Scene/BatchTableHierarchy.js
+++ b/Source/Scene/BatchTableHierarchy.js
@@ -21,7 +21,6 @@ import RuntimeError from "../Core/RuntimeError.js";
  * @constructor
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function BatchTableHierarchy(options) {
   this._classes = undefined;
@@ -343,7 +342,6 @@ function traverseHierarchy(hierarchy, instanceIndex, endConditionCallback) {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {Boolean} Whether this property exists.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BatchTableHierarchy.prototype.hasProperty = function (batchId, propertyId) {
   var result = traverseHierarchy(this, batchId, function (

--- a/Source/Scene/BatchTexture.js
+++ b/Source/Scene/BatchTexture.js
@@ -25,7 +25,6 @@ import Texture from "../Renderer/Texture.js";
  * @constructor
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function BatchTexture(options) {
   //>>includeStart('debug', pragmas.debug);
@@ -81,7 +80,6 @@ Object.defineProperties(BatchTexture.prototype, {
    * @type {Number}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   translucentFeaturesLength: {
     get: function () {
@@ -96,7 +94,6 @@ Object.defineProperties(BatchTexture.prototype, {
    * @type {Number}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   memorySizeInBytes: {
     get: function () {
@@ -118,7 +115,6 @@ Object.defineProperties(BatchTexture.prototype, {
    * @type {Cartesian2}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   textureDimensions: {
     get: function () {
@@ -134,7 +130,6 @@ Object.defineProperties(BatchTexture.prototype, {
    * @type {Cartesian4}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   textureStep: {
     get: function () {
@@ -151,7 +146,6 @@ Object.defineProperties(BatchTexture.prototype, {
    * @type {Texture}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   batchTexture: {
     get: function () {
@@ -166,7 +160,6 @@ Object.defineProperties(BatchTexture.prototype, {
    * @type {Texture}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   defaultTexture: {
     get: function () {
@@ -182,7 +175,6 @@ Object.defineProperties(BatchTexture.prototype, {
    * @type {Texture}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   pickTexture: {
     get: function () {
@@ -238,7 +230,6 @@ function checkBatchId(batchId, featuresLength) {
  * @param {Number} batchId the ID of the feature
  * @param {Boolean} show <code>true</code> if the feature should be shown, <code>false</code> otherwise
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BatchTexture.prototype.setShow = function (batchId, show) {
   //>>includeStart('debug', pragmas.debug);
@@ -273,7 +264,6 @@ BatchTexture.prototype.setShow = function (batchId, show) {
  *
  * @param {Boolean} show <code>true</code> if the feature should be shown, <code>false</code> otherwise
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BatchTexture.prototype.setAllShow = function (show) {
   //>>includeStart('debug', pragmas.debug);
@@ -292,7 +282,6 @@ BatchTexture.prototype.setAllShow = function (show) {
  * @param {Number} batchId the ID of the feature
  * @return {Boolean} <code>true</code> if the feature is shown, or <code>false</code> otherwise
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BatchTexture.prototype.getShow = function (batchId) {
   //>>includeStart('debug', pragmas.debug);
@@ -317,7 +306,6 @@ var scratchColorBytes = new Array(4);
  * @param {Color} color the color to assign to this feature.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BatchTexture.prototype.setColor = function (batchId, color) {
   //>>includeStart('debug', pragmas.debug);
@@ -382,7 +370,6 @@ BatchTexture.prototype.setColor = function (batchId, color) {
  * @param {Color} color the color to assign to all features.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BatchTexture.prototype.setAllColor = function (color) {
   //>>includeStart('debug', pragmas.debug);
@@ -403,7 +390,6 @@ BatchTexture.prototype.setAllColor = function (color) {
  * @return {Color} The color assigned to the selected feature
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BatchTexture.prototype.getColor = function (batchId, result) {
   //>>includeStart('debug', pragmas.debug);
@@ -438,7 +424,6 @@ BatchTexture.prototype.getColor = function (batchId, result) {
  * @return {PickId} The picking color assigned to this feature
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BatchTexture.prototype.getPickColor = function (batchId) {
   //>>includeStart('debug', pragmas.debug);
@@ -538,7 +523,6 @@ BatchTexture.prototype.update = function (tileset, frameState) {
  *
  * @see BatchTexture#destroy
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BatchTexture.prototype.isDestroyed = function () {
   return false;
@@ -560,7 +544,6 @@ BatchTexture.prototype.isDestroyed = function () {
  *
  * @see BatchTexture#isDestroyed
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BatchTexture.prototype.destroy = function () {
   this._batchTexture = this._batchTexture && this._batchTexture.destroy();

--- a/Source/Scene/BatchTexture.js
+++ b/Source/Scene/BatchTexture.js
@@ -25,6 +25,7 @@ import Texture from "../Renderer/Texture.js";
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function BatchTexture(options) {
   //>>includeStart('debug', pragmas.debug);
@@ -80,6 +81,7 @@ Object.defineProperties(BatchTexture.prototype, {
    * @type {Number}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   translucentFeaturesLength: {
     get: function () {
@@ -94,6 +96,7 @@ Object.defineProperties(BatchTexture.prototype, {
    * @type {Number}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   memorySizeInBytes: {
     get: function () {
@@ -115,6 +118,7 @@ Object.defineProperties(BatchTexture.prototype, {
    * @type {Cartesian2}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   textureDimensions: {
     get: function () {
@@ -130,6 +134,7 @@ Object.defineProperties(BatchTexture.prototype, {
    * @type {Cartesian4}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   textureStep: {
     get: function () {
@@ -146,6 +151,7 @@ Object.defineProperties(BatchTexture.prototype, {
    * @type {Texture}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   batchTexture: {
     get: function () {
@@ -160,6 +166,7 @@ Object.defineProperties(BatchTexture.prototype, {
    * @type {Texture}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   defaultTexture: {
     get: function () {
@@ -175,6 +182,7 @@ Object.defineProperties(BatchTexture.prototype, {
    * @type {Texture}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   pickTexture: {
     get: function () {
@@ -230,6 +238,7 @@ function checkBatchId(batchId, featuresLength) {
  * @param {Number} batchId the ID of the feature
  * @param {Boolean} show <code>true</code> if the feature should be shown, <code>false</code> otherwise
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BatchTexture.prototype.setShow = function (batchId, show) {
   //>>includeStart('debug', pragmas.debug);
@@ -264,6 +273,7 @@ BatchTexture.prototype.setShow = function (batchId, show) {
  *
  * @param {Boolean} show <code>true</code> if the feature should be shown, <code>false</code> otherwise
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BatchTexture.prototype.setAllShow = function (show) {
   //>>includeStart('debug', pragmas.debug);
@@ -282,6 +292,7 @@ BatchTexture.prototype.setAllShow = function (show) {
  * @param {Number} batchId the ID of the feature
  * @return {Boolean} <code>true</code> if the feature is shown, or <code>false</code> otherwise
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BatchTexture.prototype.getShow = function (batchId) {
   //>>includeStart('debug', pragmas.debug);
@@ -306,6 +317,7 @@ var scratchColorBytes = new Array(4);
  * @param {Color} color the color to assign to this feature.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BatchTexture.prototype.setColor = function (batchId, color) {
   //>>includeStart('debug', pragmas.debug);
@@ -370,6 +382,7 @@ BatchTexture.prototype.setColor = function (batchId, color) {
  * @param {Color} color the color to assign to all features.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BatchTexture.prototype.setAllColor = function (color) {
   //>>includeStart('debug', pragmas.debug);
@@ -390,6 +403,7 @@ BatchTexture.prototype.setAllColor = function (color) {
  * @return {Color} The color assigned to the selected feature
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BatchTexture.prototype.getColor = function (batchId, result) {
   //>>includeStart('debug', pragmas.debug);
@@ -424,6 +438,7 @@ BatchTexture.prototype.getColor = function (batchId, result) {
  * @return {PickId} The picking color assigned to this feature
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BatchTexture.prototype.getPickColor = function (batchId) {
   //>>includeStart('debug', pragmas.debug);
@@ -523,6 +538,7 @@ BatchTexture.prototype.update = function (tileset, frameState) {
  *
  * @see BatchTexture#destroy
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BatchTexture.prototype.isDestroyed = function () {
   return false;
@@ -543,6 +559,8 @@ BatchTexture.prototype.isDestroyed = function () {
  * e = e && e.destroy();
  *
  * @see BatchTexture#isDestroyed
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BatchTexture.prototype.destroy = function () {
   this._batchTexture = this._batchTexture && this._batchTexture.destroy();

--- a/Source/Scene/BufferLoader.js
+++ b/Source/Scene/BufferLoader.js
@@ -23,6 +23,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @exception {DeveloperError} One of options.typedArray and options.resource must be defined.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function BufferLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -58,6 +59,7 @@ Object.defineProperties(BufferLoader.prototype, {
    *
    * @type {Promise.<BufferLoader>}
    * @readonly
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     get: function () {
@@ -71,6 +73,7 @@ Object.defineProperties(BufferLoader.prototype, {
    *
    * @type {String}
    * @readonly
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     get: function () {
@@ -84,6 +87,7 @@ Object.defineProperties(BufferLoader.prototype, {
    *
    * @type {Uint8Array}
    * @readonly
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   typedArray: {
     get: function () {
@@ -94,6 +98,8 @@ Object.defineProperties(BufferLoader.prototype, {
 
 /**
  * Loads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BufferLoader.prototype.load = function () {
   if (defined(this._typedArray)) {
@@ -129,6 +135,8 @@ function loadExternalBuffer(bufferLoader) {
 
 /**
  * Unloads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BufferLoader.prototype.unload = function () {
   this._typedArray = undefined;

--- a/Source/Scene/BufferLoader.js
+++ b/Source/Scene/BufferLoader.js
@@ -23,7 +23,6 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @exception {DeveloperError} One of options.typedArray and options.resource must be defined.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function BufferLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -59,7 +58,6 @@ Object.defineProperties(BufferLoader.prototype, {
    *
    * @type {Promise.<BufferLoader>}
    * @readonly
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     get: function () {
@@ -73,7 +71,6 @@ Object.defineProperties(BufferLoader.prototype, {
    *
    * @type {String}
    * @readonly
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     get: function () {
@@ -87,7 +84,6 @@ Object.defineProperties(BufferLoader.prototype, {
    *
    * @type {Uint8Array}
    * @readonly
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   typedArray: {
     get: function () {
@@ -99,7 +95,6 @@ Object.defineProperties(BufferLoader.prototype, {
 /**
  * Loads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BufferLoader.prototype.load = function () {
   if (defined(this._typedArray)) {
@@ -136,7 +131,6 @@ function loadExternalBuffer(bufferLoader) {
 /**
  * Unloads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 BufferLoader.prototype.unload = function () {
   this._typedArray = undefined;

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -275,6 +275,7 @@ function Cesium3DTile(tileset, baseResource, header, parent) {
    * @readonly
    *
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.hasImplicitContent = false;
 
@@ -310,6 +311,8 @@ function Cesium3DTile(tileset, baseResource, header, parent) {
    *
    * @type {TileMetadata}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.metadata = metadata;
 
@@ -395,6 +398,7 @@ function Cesium3DTile(tileset, baseResource, header, parent) {
    * @type {ImplicitTileset}
    *
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.implicitTileset = undefined;
 
@@ -405,6 +409,7 @@ function Cesium3DTile(tileset, baseResource, header, parent) {
    * @type {ImplicitTileCoordinates}
    *
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.implicitCoordinates = undefined;
 
@@ -415,6 +420,7 @@ function Cesium3DTile(tileset, baseResource, header, parent) {
    * @type {ImplicitSubtree}
    *
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.implicitSubtree = undefined;
 

--- a/Source/Scene/Cesium3DTileContent.js
+++ b/Source/Scene/Cesium3DTileContent.js
@@ -127,11 +127,9 @@ Object.defineProperties(Cesium3DTileContent.prototype, {
   },
 
   /**
-   * Gets the array of {@link Cesium3DTileContent} objects for contents that contain other contents. This includes composite contents as well as the <code>3DTILES_multiple_contents extension</code>. The inner contents may in turn have inner
-   * contents, such as a composite tile that contains a composite tile.
+   * Gets the array of {@link Cesium3DTileContent} objects for contents that contain other contents, such as composite tiles. The inner contents may in turn have inner contents, such as a composite tile that contains a composite tile.
    *
    * @see {@link https://github.com/CesiumGS/3d-tiles/tree/master/specification/TileFormats/Composite|Composite specification}
-   * @see {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_multiple_contents/0.0.0|3DTILES_multiple_contents specification}
    *
    * @memberof Cesium3DTileContent.prototype
    *

--- a/Source/Scene/Cesium3DTileContent.js
+++ b/Source/Scene/Cesium3DTileContent.js
@@ -233,6 +233,7 @@ Object.defineProperties(Cesium3DTileContent.prototype, {
    * @type {GroupMetadata}
    *
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   groupMetadata: {
     // eslint-disable-next-line getter-return

--- a/Source/Scene/Cesium3DTileContentType.js
+++ b/Source/Scene/Cesium3DTileContentType.js
@@ -71,6 +71,7 @@ var Cesium3DTileContentType = {
    * @type {String}
    * @constant
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   GLTF: "gltf",
   /**
@@ -81,6 +82,7 @@ var Cesium3DTileContentType = {
    * @type {String}
    * @constant
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   GLTF_BINARY: "glb",
   /**
@@ -91,6 +93,7 @@ var Cesium3DTileContentType = {
    * @type {String}
    * @constant
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   IMPLICIT_SUBTREE: "subt",
   /**
@@ -110,6 +113,7 @@ var Cesium3DTileContentType = {
    * @type {String}
    * @constant
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   MULTIPLE_CONTENT: "multipleContent",
 };

--- a/Source/Scene/Cesium3DTileFeature.js
+++ b/Source/Scene/Cesium3DTileFeature.js
@@ -204,6 +204,7 @@ Cesium3DTileFeature.prototype.getProperty = function (name) {
  * @param {String} name The case-sensitive name of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 Cesium3DTileFeature.prototype.getPropertyInherited = function (name) {
   var value;

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -927,6 +927,8 @@ function Cesium3DTileset(options) {
    * a {@link Cesium3DTilesetMetadata} object to access metadata.
    *
    * @type {Cesium3DTilesetMetadata}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.metadata = undefined;
 

--- a/Source/Scene/Cesium3DTilesetMetadata.js
+++ b/Source/Scene/Cesium3DTilesetMetadata.js
@@ -73,6 +73,8 @@ Object.defineProperties(Cesium3DTilesetMetadata.prototype, {
    * @memberof Cesium3DTilesetMetadata.prototype
    * @type {MetadataSchema}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   schema: {
     get: function () {
@@ -86,6 +88,8 @@ Object.defineProperties(Cesium3DTilesetMetadata.prototype, {
    * @memberof Cesium3DTilesetMetadata.prototype
    * @type {Object.<String, GroupMetadata>}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   groups: {
     get: function () {
@@ -99,6 +103,8 @@ Object.defineProperties(Cesium3DTilesetMetadata.prototype, {
    * @memberof Cesium3DTilesetMetadata.prototype
    * @type {TilesetMetadata}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   tileset: {
     get: function () {
@@ -116,6 +122,8 @@ Object.defineProperties(Cesium3DTilesetMetadata.prototype, {
    * @memberof Cesium3DTilesetMetadata.prototype
    * @type {Object}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   statistics: {
     get: function () {
@@ -129,6 +137,8 @@ Object.defineProperties(Cesium3DTilesetMetadata.prototype, {
    * @memberof Cesium3DTilesetMetadata.prototype
    * @type {*}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -142,6 +152,8 @@ Object.defineProperties(Cesium3DTilesetMetadata.prototype, {
    * @memberof Cesium3DTilesetMetadata.prototype
    * @type {Object}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {

--- a/Source/Scene/Cesium3DTilesetMetadata.js
+++ b/Source/Scene/Cesium3DTilesetMetadata.js
@@ -20,6 +20,7 @@ import TilesetMetadata from "./TilesetMetadata.js";
  *
  * @alias Cesium3DTilesetMetadata
  * @constructor
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Cesium3DTilesetMetadata(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/Source/Scene/Cesium3DTilesetMetadata.js
+++ b/Source/Scene/Cesium3DTilesetMetadata.js
@@ -20,6 +20,7 @@ import TilesetMetadata from "./TilesetMetadata.js";
  *
  * @alias Cesium3DTilesetMetadata
  * @constructor
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Cesium3DTilesetMetadata(options) {

--- a/Source/Scene/Cesium3DTilesetMetadata.js
+++ b/Source/Scene/Cesium3DTilesetMetadata.js
@@ -74,7 +74,6 @@ Object.defineProperties(Cesium3DTilesetMetadata.prototype, {
    * @type {MetadataSchema}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   schema: {
     get: function () {
@@ -89,7 +88,6 @@ Object.defineProperties(Cesium3DTilesetMetadata.prototype, {
    * @type {Object.<String, GroupMetadata>}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   groups: {
     get: function () {
@@ -104,7 +102,6 @@ Object.defineProperties(Cesium3DTilesetMetadata.prototype, {
    * @type {TilesetMetadata}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   tileset: {
     get: function () {
@@ -123,7 +120,6 @@ Object.defineProperties(Cesium3DTilesetMetadata.prototype, {
    * @type {Object}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   statistics: {
     get: function () {
@@ -138,7 +134,6 @@ Object.defineProperties(Cesium3DTilesetMetadata.prototype, {
    * @type {*}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -153,7 +148,6 @@ Object.defineProperties(Cesium3DTilesetMetadata.prototype, {
    * @type {Object}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {

--- a/Source/Scene/Composite3DTileContent.js
+++ b/Source/Scene/Composite3DTileContent.js
@@ -169,6 +169,8 @@ Object.defineProperties(Composite3DTileContent.prototype, {
    * Part of the {@link Cesium3DTileContent} interface. <code>Composite3DTileContent</code>
    * both stores the group metadata and propagates the group metadata to all of its children.
    * @memberof Composite3DTileContent.prototype
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   groupMetadata: {
     get: function () {

--- a/Source/Scene/FeatureMetadata.js
+++ b/Source/Scene/FeatureMetadata.js
@@ -19,6 +19,7 @@ import defaultValue from "../Core/defaultValue.js";
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function FeatureMetadata(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -43,6 +44,7 @@ Object.defineProperties(FeatureMetadata.prototype, {
    * @type {MetadataSchema}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   schema: {
     get: function () {
@@ -60,6 +62,7 @@ Object.defineProperties(FeatureMetadata.prototype, {
    * @type {Object}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   statistics: {
     get: function () {
@@ -74,6 +77,7 @@ Object.defineProperties(FeatureMetadata.prototype, {
    * @type {*}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -88,6 +92,7 @@ Object.defineProperties(FeatureMetadata.prototype, {
    * @type {Object}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {
@@ -101,6 +106,8 @@ Object.defineProperties(FeatureMetadata.prototype, {
  *
  * @param {String} featureTableId The feature table ID.
  * @returns {FeatureTable} The feature table.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 FeatureMetadata.prototype.getFeatureTable = function (featureTableId) {
   //>>includeStart('debug', pragmas.debug);
@@ -115,6 +122,8 @@ FeatureMetadata.prototype.getFeatureTable = function (featureTableId) {
  *
  * @param {String} featureTextureId The feature texture ID.
  * @returns {FeatureTexture} The feature texture.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 FeatureMetadata.prototype.getFeatureTexture = function (featureTextureId) {
   //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/FeatureMetadata.js
+++ b/Source/Scene/FeatureMetadata.js
@@ -44,7 +44,6 @@ Object.defineProperties(FeatureMetadata.prototype, {
    * @type {MetadataSchema}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   schema: {
     get: function () {
@@ -62,7 +61,6 @@ Object.defineProperties(FeatureMetadata.prototype, {
    * @type {Object}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   statistics: {
     get: function () {
@@ -77,7 +75,6 @@ Object.defineProperties(FeatureMetadata.prototype, {
    * @type {*}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -92,7 +89,6 @@ Object.defineProperties(FeatureMetadata.prototype, {
    * @type {Object}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {
@@ -107,7 +103,6 @@ Object.defineProperties(FeatureMetadata.prototype, {
  * @param {String} featureTableId The feature table ID.
  * @returns {FeatureTable} The feature table.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 FeatureMetadata.prototype.getFeatureTable = function (featureTableId) {
   //>>includeStart('debug', pragmas.debug);
@@ -123,7 +118,6 @@ FeatureMetadata.prototype.getFeatureTable = function (featureTableId) {
  * @param {String} featureTextureId The feature texture ID.
  * @returns {FeatureTexture} The feature texture.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 FeatureMetadata.prototype.getFeatureTexture = function (featureTextureId) {
   //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/FeatureTable.js
+++ b/Source/Scene/FeatureTable.js
@@ -52,7 +52,6 @@ Object.defineProperties(FeatureTable.prototype, {
    * @type {Number}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   count: {
     get: function () {
@@ -66,7 +65,6 @@ Object.defineProperties(FeatureTable.prototype, {
    * @memberof FeatureTable.prototype
    * @type {MetadataClass}
    * @readonly
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   class: {
     get: function () {
@@ -85,7 +83,6 @@ Object.defineProperties(FeatureTable.prototype, {
    * @type {*}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -100,7 +97,6 @@ Object.defineProperties(FeatureTable.prototype, {
    * @type {Object}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {
@@ -116,7 +112,6 @@ Object.defineProperties(FeatureTable.prototype, {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {Boolean} Whether this property exists.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 FeatureTable.prototype.hasProperty = function (index, propertyId) {
   //>>includeStart('debug', pragmas.debug);
@@ -157,7 +152,6 @@ var scratchResults = [];
  * @param {String[]} [results] An array into which to store the results.
  * @returns {String[]} The property IDs.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 FeatureTable.prototype.getPropertyIds = function (index, results) {
   results = defined(results) ? results : [];
@@ -198,7 +192,6 @@ FeatureTable.prototype.getPropertyIds = function (index, results) {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 FeatureTable.prototype.getProperty = function (index, propertyId) {
   var result;
@@ -237,7 +230,6 @@ FeatureTable.prototype.getProperty = function (index, propertyId) {
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 FeatureTable.prototype.setProperty = function (index, propertyId, value) {
   if (
@@ -267,7 +259,6 @@ FeatureTable.prototype.setProperty = function (index, propertyId, value) {
  * @param {String} semantic The case-sensitive semantic of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 FeatureTable.prototype.getPropertyBySemantic = function (index, semantic) {
   if (defined(this._metadataTable)) {
@@ -285,7 +276,6 @@ FeatureTable.prototype.getPropertyBySemantic = function (index, semantic) {
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 FeatureTable.prototype.setPropertyBySemantic = function (
   index,

--- a/Source/Scene/FeatureTable.js
+++ b/Source/Scene/FeatureTable.js
@@ -27,6 +27,7 @@ import defined from "../Core/defined.js";
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function FeatureTable(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -51,6 +52,7 @@ Object.defineProperties(FeatureTable.prototype, {
    * @type {Number}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   count: {
     get: function () {
@@ -64,6 +66,7 @@ Object.defineProperties(FeatureTable.prototype, {
    * @memberof FeatureTable.prototype
    * @type {MetadataClass}
    * @readonly
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   class: {
     get: function () {
@@ -82,6 +85,7 @@ Object.defineProperties(FeatureTable.prototype, {
    * @type {*}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -96,6 +100,7 @@ Object.defineProperties(FeatureTable.prototype, {
    * @type {Object}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {
@@ -110,6 +115,8 @@ Object.defineProperties(FeatureTable.prototype, {
  * @param {Number} index The index of the feature.
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {Boolean} Whether this property exists.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 FeatureTable.prototype.hasProperty = function (index, propertyId) {
   //>>includeStart('debug', pragmas.debug);
@@ -149,6 +156,8 @@ var scratchResults = [];
  * @param {Number} index The index of the feature.
  * @param {String[]} [results] An array into which to store the results.
  * @returns {String[]} The property IDs.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 FeatureTable.prototype.getPropertyIds = function (index, results) {
   results = defined(results) ? results : [];
@@ -188,6 +197,8 @@ FeatureTable.prototype.getPropertyIds = function (index, results) {
  * @param {Number} index The index of the feature.
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 FeatureTable.prototype.getProperty = function (index, propertyId) {
   var result;
@@ -225,6 +236,8 @@ FeatureTable.prototype.getProperty = function (index, propertyId) {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 FeatureTable.prototype.setProperty = function (index, propertyId, value) {
   if (
@@ -253,6 +266,8 @@ FeatureTable.prototype.setProperty = function (index, propertyId, value) {
  * @param {Number} index The index of the feature.
  * @param {String} semantic The case-sensitive semantic of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 FeatureTable.prototype.getPropertyBySemantic = function (index, semantic) {
   if (defined(this._metadataTable)) {
@@ -269,6 +284,8 @@ FeatureTable.prototype.getPropertyBySemantic = function (index, semantic) {
  * @param {String} semantic The case-sensitive semantic of the property.
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 FeatureTable.prototype.setPropertyBySemantic = function (
   index,

--- a/Source/Scene/FeatureTexture.js
+++ b/Source/Scene/FeatureTexture.js
@@ -15,6 +15,7 @@ import FeatureTextureProperty from "./FeatureTextureProperty.js";
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function FeatureTexture(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -58,6 +59,7 @@ Object.defineProperties(FeatureTexture.prototype, {
    * @type {MetadataClass}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   class: {
     get: function () {
@@ -72,6 +74,7 @@ Object.defineProperties(FeatureTexture.prototype, {
    * @type {*}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -86,6 +89,7 @@ Object.defineProperties(FeatureTexture.prototype, {
    * @type {Object}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {

--- a/Source/Scene/FeatureTexture.js
+++ b/Source/Scene/FeatureTexture.js
@@ -59,7 +59,6 @@ Object.defineProperties(FeatureTexture.prototype, {
    * @type {MetadataClass}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   class: {
     get: function () {
@@ -74,7 +73,6 @@ Object.defineProperties(FeatureTexture.prototype, {
    * @type {*}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -89,7 +87,6 @@ Object.defineProperties(FeatureTexture.prototype, {
    * @type {Object}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {

--- a/Source/Scene/FeatureTextureProperty.js
+++ b/Source/Scene/FeatureTextureProperty.js
@@ -45,7 +45,6 @@ Object.defineProperties(FeatureTextureProperty.prototype, {
    * @type {*}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -60,7 +59,6 @@ Object.defineProperties(FeatureTextureProperty.prototype, {
    * @type {*}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {

--- a/Source/Scene/FeatureTextureProperty.js
+++ b/Source/Scene/FeatureTextureProperty.js
@@ -13,6 +13,7 @@ import defaultValue from "../Core/defaultValue.js";
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function FeatureTextureProperty(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -44,6 +45,7 @@ Object.defineProperties(FeatureTextureProperty.prototype, {
    * @type {*}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -58,6 +60,7 @@ Object.defineProperties(FeatureTextureProperty.prototype, {
    * @type {*}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {

--- a/Source/Scene/Gltf3DTileContent.js
+++ b/Source/Scene/Gltf3DTileContent.js
@@ -20,6 +20,7 @@ import ModelAnimationLoop from "./ModelAnimationLoop.js";
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Gltf3DTileContent(tileset, tile, resource, gltf) {
   this._tileset = tileset;

--- a/Source/Scene/GltfBufferViewLoader.js
+++ b/Source/Scene/GltfBufferViewLoader.js
@@ -24,7 +24,6 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {String} [options.cacheKey] The cache key of the resource.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function GltfBufferViewLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -75,7 +74,6 @@ Object.defineProperties(GltfBufferViewLoader.prototype, {
    * @type {Promise.<GltfBufferViewLoader>}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     get: function () {
@@ -90,7 +88,6 @@ Object.defineProperties(GltfBufferViewLoader.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     get: function () {
@@ -105,7 +102,6 @@ Object.defineProperties(GltfBufferViewLoader.prototype, {
    * @type {Uint8Array}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   typedArray: {
     get: function () {
@@ -117,7 +113,6 @@ Object.defineProperties(GltfBufferViewLoader.prototype, {
 /**
  * Loads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfBufferViewLoader.prototype.load = function () {
   var bufferLoader = getBufferLoader(this);
@@ -177,7 +172,6 @@ function getBufferLoader(bufferViewLoader) {
 /**
  * Unloads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfBufferViewLoader.prototype.unload = function () {
   if (defined(this._bufferLoader)) {

--- a/Source/Scene/GltfBufferViewLoader.js
+++ b/Source/Scene/GltfBufferViewLoader.js
@@ -24,6 +24,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {String} [options.cacheKey] The cache key of the resource.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function GltfBufferViewLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -73,6 +74,8 @@ Object.defineProperties(GltfBufferViewLoader.prototype, {
    *
    * @type {Promise.<GltfBufferViewLoader>}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     get: function () {
@@ -86,6 +89,8 @@ Object.defineProperties(GltfBufferViewLoader.prototype, {
    *
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     get: function () {
@@ -99,6 +104,8 @@ Object.defineProperties(GltfBufferViewLoader.prototype, {
    *
    * @type {Uint8Array}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   typedArray: {
     get: function () {
@@ -109,6 +116,8 @@ Object.defineProperties(GltfBufferViewLoader.prototype, {
 
 /**
  * Loads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfBufferViewLoader.prototype.load = function () {
   var bufferLoader = getBufferLoader(this);
@@ -167,6 +176,8 @@ function getBufferLoader(bufferViewLoader) {
 
 /**
  * Unloads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfBufferViewLoader.prototype.unload = function () {
   if (defined(this._bufferLoader)) {

--- a/Source/Scene/GltfDracoLoader.js
+++ b/Source/Scene/GltfDracoLoader.js
@@ -25,7 +25,6 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {String} [options.cacheKey] The cache key of the resource.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function GltfDracoLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -72,7 +71,6 @@ Object.defineProperties(GltfDracoLoader.prototype, {
    * @type {Promise.<GltfDracoLoader>}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     get: function () {
@@ -87,7 +85,6 @@ Object.defineProperties(GltfDracoLoader.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     get: function () {
@@ -102,7 +99,6 @@ Object.defineProperties(GltfDracoLoader.prototype, {
    * @type {Object}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   decodedData: {
     get: function () {
@@ -114,7 +110,6 @@ Object.defineProperties(GltfDracoLoader.prototype, {
 /**
  * Loads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfDracoLoader.prototype.load = function () {
   var resourceCache = this._resourceCache;
@@ -159,7 +154,6 @@ function handleError(dracoLoader, error) {
  *
  * @param {FrameState} frameState The frame state.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfDracoLoader.prototype.process = function (frameState) {
   //>>includeStart('debug', pragmas.debug);
@@ -224,7 +218,6 @@ GltfDracoLoader.prototype.process = function (frameState) {
 /**
  * Unloads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfDracoLoader.prototype.unload = function () {
   if (defined(this._bufferViewLoader)) {

--- a/Source/Scene/GltfDracoLoader.js
+++ b/Source/Scene/GltfDracoLoader.js
@@ -25,6 +25,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {String} [options.cacheKey] The cache key of the resource.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function GltfDracoLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -70,6 +71,8 @@ Object.defineProperties(GltfDracoLoader.prototype, {
    *
    * @type {Promise.<GltfDracoLoader>}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     get: function () {
@@ -83,6 +86,8 @@ Object.defineProperties(GltfDracoLoader.prototype, {
    *
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     get: function () {
@@ -96,6 +101,8 @@ Object.defineProperties(GltfDracoLoader.prototype, {
    *
    * @type {Object}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   decodedData: {
     get: function () {
@@ -106,6 +113,8 @@ Object.defineProperties(GltfDracoLoader.prototype, {
 
 /**
  * Loads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfDracoLoader.prototype.load = function () {
   var resourceCache = this._resourceCache;
@@ -149,6 +158,8 @@ function handleError(dracoLoader, error) {
  * Processes the resource until it becomes ready.
  *
  * @param {FrameState} frameState The frame state.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfDracoLoader.prototype.process = function (frameState) {
   //>>includeStart('debug', pragmas.debug);
@@ -212,6 +223,8 @@ GltfDracoLoader.prototype.process = function (frameState) {
 
 /**
  * Unloads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfDracoLoader.prototype.unload = function () {
   if (defined(this._bufferViewLoader)) {

--- a/Source/Scene/GltfFeatureMetadataLoader.js
+++ b/Source/Scene/GltfFeatureMetadataLoader.js
@@ -27,6 +27,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {Boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function GltfFeatureMetadataLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -74,6 +75,8 @@ Object.defineProperties(GltfFeatureMetadataLoader.prototype, {
    *
    * @type {Promise.<GltfFeatureMetadataLoader>}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     get: function () {
@@ -87,6 +90,8 @@ Object.defineProperties(GltfFeatureMetadataLoader.prototype, {
    *
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     get: function () {
@@ -100,6 +105,8 @@ Object.defineProperties(GltfFeatureMetadataLoader.prototype, {
    *
    * @type {FeatureMetadata}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   featureMetadata: {
     get: function () {
@@ -110,6 +117,8 @@ Object.defineProperties(GltfFeatureMetadataLoader.prototype, {
 
 /**
  * Loads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfFeatureMetadataLoader.prototype.load = function () {
   var bufferViewsPromise = loadBufferViews(this);
@@ -311,6 +320,8 @@ function loadSchema(featureMetadataLoader) {
  * Processes the resource until it becomes ready.
  *
  * @param {FrameState} frameState The frame state.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfFeatureMetadataLoader.prototype.process = function (frameState) {
   //>>includeStart('debug', pragmas.debug);
@@ -350,6 +361,8 @@ function unloadTextures(featureMetadataLoader) {
 
 /**
  * Unloads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfFeatureMetadataLoader.prototype.unload = function () {
   unloadBufferViews(this);

--- a/Source/Scene/GltfFeatureMetadataLoader.js
+++ b/Source/Scene/GltfFeatureMetadataLoader.js
@@ -76,7 +76,6 @@ Object.defineProperties(GltfFeatureMetadataLoader.prototype, {
    * @type {Promise.<GltfFeatureMetadataLoader>}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     get: function () {
@@ -91,7 +90,6 @@ Object.defineProperties(GltfFeatureMetadataLoader.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     get: function () {
@@ -106,7 +104,6 @@ Object.defineProperties(GltfFeatureMetadataLoader.prototype, {
    * @type {FeatureMetadata}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   featureMetadata: {
     get: function () {
@@ -118,7 +115,6 @@ Object.defineProperties(GltfFeatureMetadataLoader.prototype, {
 /**
  * Loads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfFeatureMetadataLoader.prototype.load = function () {
   var bufferViewsPromise = loadBufferViews(this);
@@ -321,7 +317,6 @@ function loadSchema(featureMetadataLoader) {
  *
  * @param {FrameState} frameState The frame state.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfFeatureMetadataLoader.prototype.process = function (frameState) {
   //>>includeStart('debug', pragmas.debug);
@@ -362,7 +357,6 @@ function unloadTextures(featureMetadataLoader) {
 /**
  * Unloads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfFeatureMetadataLoader.prototype.unload = function () {
   unloadBufferViews(this);

--- a/Source/Scene/GltfImageLoader.js
+++ b/Source/Scene/GltfImageLoader.js
@@ -30,6 +30,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {String} [options.cacheKey] The cache key of the resource.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function GltfImageLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -85,6 +86,8 @@ Object.defineProperties(GltfImageLoader.prototype, {
    *
    * @type {Promise.<GltfImageLoader>}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     get: function () {
@@ -98,6 +101,8 @@ Object.defineProperties(GltfImageLoader.prototype, {
    *
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     get: function () {
@@ -111,6 +116,8 @@ Object.defineProperties(GltfImageLoader.prototype, {
    *
    * @type {Image|ImageBitmap|CompressedTextureBuffer}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   image: {
     get: function () {
@@ -121,6 +128,8 @@ Object.defineProperties(GltfImageLoader.prototype, {
 
 /**
  * Loads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfImageLoader.prototype.load = function () {
   if (defined(this._bufferViewId)) {
@@ -276,6 +285,8 @@ function loadImageFromUri(resource) {
 
 /**
  * Unloads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfImageLoader.prototype.unload = function () {
   if (defined(this._bufferViewLoader)) {
@@ -288,9 +299,5 @@ GltfImageLoader.prototype.unload = function () {
   this._gltf = undefined;
 };
 
-/**
- * Exposed for testing
- *
- * @private
- */
+//Exposed for testing
 GltfImageLoader._loadImageFromTypedArray = loadImageFromTypedArray;

--- a/Source/Scene/GltfImageLoader.js
+++ b/Source/Scene/GltfImageLoader.js
@@ -30,7 +30,6 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {String} [options.cacheKey] The cache key of the resource.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function GltfImageLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -87,7 +86,6 @@ Object.defineProperties(GltfImageLoader.prototype, {
    * @type {Promise.<GltfImageLoader>}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     get: function () {
@@ -102,7 +100,6 @@ Object.defineProperties(GltfImageLoader.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     get: function () {
@@ -117,7 +114,6 @@ Object.defineProperties(GltfImageLoader.prototype, {
    * @type {Image|ImageBitmap|CompressedTextureBuffer}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   image: {
     get: function () {
@@ -129,7 +125,6 @@ Object.defineProperties(GltfImageLoader.prototype, {
 /**
  * Loads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfImageLoader.prototype.load = function () {
   if (defined(this._bufferViewId)) {
@@ -286,7 +281,6 @@ function loadImageFromUri(resource) {
 /**
  * Unloads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfImageLoader.prototype.unload = function () {
   if (defined(this._bufferViewLoader)) {

--- a/Source/Scene/GltfIndexBufferLoader.js
+++ b/Source/Scene/GltfIndexBufferLoader.js
@@ -30,7 +30,6 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {Boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function GltfIndexBufferLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -84,7 +83,6 @@ Object.defineProperties(GltfIndexBufferLoader.prototype, {
    * @type {Promise.<GltfIndexBufferLoader>}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     get: function () {
@@ -99,7 +97,6 @@ Object.defineProperties(GltfIndexBufferLoader.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     get: function () {
@@ -114,7 +111,6 @@ Object.defineProperties(GltfIndexBufferLoader.prototype, {
    * @type {Buffer}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   indexBuffer: {
     get: function () {
@@ -126,7 +122,6 @@ Object.defineProperties(GltfIndexBufferLoader.prototype, {
 /**
  * Loads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfIndexBufferLoader.prototype.load = function () {
   if (defined(this._draco)) {
@@ -276,7 +271,6 @@ var scratchIndexBufferJob = new CreateIndexBufferJob();
  *
  * @param {FrameState} frameState The frame state.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfIndexBufferLoader.prototype.process = function (frameState) {
   //>>includeStart('debug', pragmas.debug);
@@ -331,7 +325,6 @@ GltfIndexBufferLoader.prototype.process = function (frameState) {
 /**
  * Unloads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfIndexBufferLoader.prototype.unload = function () {
   if (defined(this._indexBuffer)) {

--- a/Source/Scene/GltfIndexBufferLoader.js
+++ b/Source/Scene/GltfIndexBufferLoader.js
@@ -30,6 +30,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {Boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function GltfIndexBufferLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -82,6 +83,8 @@ Object.defineProperties(GltfIndexBufferLoader.prototype, {
    *
    * @type {Promise.<GltfIndexBufferLoader>}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     get: function () {
@@ -95,6 +98,8 @@ Object.defineProperties(GltfIndexBufferLoader.prototype, {
    *
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     get: function () {
@@ -108,6 +113,8 @@ Object.defineProperties(GltfIndexBufferLoader.prototype, {
    *
    * @type {Buffer}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   indexBuffer: {
     get: function () {
@@ -118,6 +125,8 @@ Object.defineProperties(GltfIndexBufferLoader.prototype, {
 
 /**
  * Loads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfIndexBufferLoader.prototype.load = function () {
   if (defined(this._draco)) {
@@ -266,6 +275,8 @@ var scratchIndexBufferJob = new CreateIndexBufferJob();
  * Processes the resource until it becomes ready.
  *
  * @param {FrameState} frameState The frame state.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfIndexBufferLoader.prototype.process = function (frameState) {
   //>>includeStart('debug', pragmas.debug);
@@ -319,6 +330,8 @@ GltfIndexBufferLoader.prototype.process = function (frameState) {
 
 /**
  * Unloads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfIndexBufferLoader.prototype.unload = function () {
   if (defined(this._indexBuffer)) {

--- a/Source/Scene/GltfJsonLoader.js
+++ b/Source/Scene/GltfJsonLoader.js
@@ -33,7 +33,6 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {String} [options.cacheKey] The cache key of the resource.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function GltfJsonLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -74,7 +73,6 @@ Object.defineProperties(GltfJsonLoader.prototype, {
    * @type {Promise.<GltfJsonLoader>}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     get: function () {
@@ -89,7 +87,6 @@ Object.defineProperties(GltfJsonLoader.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     get: function () {
@@ -104,7 +101,6 @@ Object.defineProperties(GltfJsonLoader.prototype, {
    * @type {Object}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   gltf: {
     get: function () {
@@ -116,7 +112,6 @@ Object.defineProperties(GltfJsonLoader.prototype, {
 /**
  * Loads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfJsonLoader.prototype.load = function () {
   if (defined(this._typedArray)) {
@@ -278,7 +273,6 @@ function processGltf(gltfJsonLoader, typedArray) {
 /**
  * Unloads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfJsonLoader.prototype.unload = function () {
   var bufferLoaders = this._bufferLoaders;

--- a/Source/Scene/GltfJsonLoader.js
+++ b/Source/Scene/GltfJsonLoader.js
@@ -33,6 +33,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {String} [options.cacheKey] The cache key of the resource.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function GltfJsonLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -72,6 +73,8 @@ Object.defineProperties(GltfJsonLoader.prototype, {
    *
    * @type {Promise.<GltfJsonLoader>}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     get: function () {
@@ -85,6 +88,8 @@ Object.defineProperties(GltfJsonLoader.prototype, {
    *
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     get: function () {
@@ -98,6 +103,8 @@ Object.defineProperties(GltfJsonLoader.prototype, {
    *
    * @type {Object}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   gltf: {
     get: function () {
@@ -108,6 +115,8 @@ Object.defineProperties(GltfJsonLoader.prototype, {
 
 /**
  * Loads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfJsonLoader.prototype.load = function () {
   if (defined(this._typedArray)) {
@@ -268,6 +277,8 @@ function processGltf(gltfJsonLoader, typedArray) {
 
 /**
  * Unloads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfJsonLoader.prototype.unload = function () {
   var bufferLoaders = this._bufferLoaders;

--- a/Source/Scene/GltfLoader.js
+++ b/Source/Scene/GltfLoader.js
@@ -56,6 +56,7 @@ var Material = ModelComponents.Material;
  * @param {Boolean} [options.incrementallyLoadTextures=true] Determine if textures may continue to stream in after the glTF is loaded.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function GltfLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -110,6 +111,8 @@ Object.defineProperties(GltfLoader.prototype, {
    *
    * @type {Promise.<GltfLoader>}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     get: function () {
@@ -123,6 +126,8 @@ Object.defineProperties(GltfLoader.prototype, {
    *
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     get: function () {
@@ -136,6 +141,8 @@ Object.defineProperties(GltfLoader.prototype, {
    *
    * @type {ModelComponents.Components}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   components: {
     get: function () {
@@ -152,6 +159,8 @@ Object.defineProperties(GltfLoader.prototype, {
    *
    * @type {Promise}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   texturesLoadedPromise: {
     get: function () {
@@ -162,6 +171,8 @@ Object.defineProperties(GltfLoader.prototype, {
 
 /**
  * Loads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfLoader.prototype.load = function () {
   var gltfJsonLoader = ResourceCache.loadGltfJson({
@@ -201,6 +212,8 @@ function handleError(gltfLoader, error) {
  * Processes the resource until it becomes ready.
  *
  * @param {FrameState} frameState The frame state.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfLoader.prototype.process = function (frameState) {
   //>>includeStart('debug', pragmas.debug);
@@ -1112,6 +1125,8 @@ function unloadGeometry(loader) {
 
 /**
  * Unloads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfLoader.prototype.unload = function () {
   if (defined(this._gltfJsonLoader)) {

--- a/Source/Scene/GltfLoader.js
+++ b/Source/Scene/GltfLoader.js
@@ -56,7 +56,6 @@ var Material = ModelComponents.Material;
  * @param {Boolean} [options.incrementallyLoadTextures=true] Determine if textures may continue to stream in after the glTF is loaded.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function GltfLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -112,7 +111,6 @@ Object.defineProperties(GltfLoader.prototype, {
    * @type {Promise.<GltfLoader>}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     get: function () {
@@ -127,7 +125,6 @@ Object.defineProperties(GltfLoader.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     get: function () {
@@ -142,7 +139,6 @@ Object.defineProperties(GltfLoader.prototype, {
    * @type {ModelComponents.Components}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   components: {
     get: function () {
@@ -160,7 +156,6 @@ Object.defineProperties(GltfLoader.prototype, {
    * @type {Promise}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   texturesLoadedPromise: {
     get: function () {
@@ -172,7 +167,6 @@ Object.defineProperties(GltfLoader.prototype, {
 /**
  * Loads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfLoader.prototype.load = function () {
   var gltfJsonLoader = ResourceCache.loadGltfJson({
@@ -213,7 +207,6 @@ function handleError(gltfLoader, error) {
  *
  * @param {FrameState} frameState The frame state.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfLoader.prototype.process = function (frameState) {
   //>>includeStart('debug', pragmas.debug);
@@ -1126,7 +1119,6 @@ function unloadGeometry(loader) {
 /**
  * Unloads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfLoader.prototype.unload = function () {
   if (defined(this._gltfJsonLoader)) {

--- a/Source/Scene/GltfLoaderUtil.js
+++ b/Source/Scene/GltfLoaderUtil.js
@@ -12,7 +12,6 @@ import TextureWrap from "../Renderer/TextureWrap.js";
  * @namespace GltfLoaderUtil
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 var GltfLoaderUtil = {};
 
@@ -26,7 +25,6 @@ var GltfLoaderUtil = {};
  *
  * @returns {Object} An object containing a <code>uri</code> and <code>bufferView</code> property.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfLoaderUtil.getImageUriOrBufferView = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -100,7 +98,6 @@ GltfLoaderUtil.getImageUriOrBufferView = function (options) {
  *
  * @returns {Number} The image ID.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfLoaderUtil.getImageIdFromTexture = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -133,7 +130,6 @@ GltfLoaderUtil.getImageIdFromTexture = function (options) {
  *
  * @returns {Sampler} The sampler.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfLoaderUtil.createSampler = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/Source/Scene/GltfLoaderUtil.js
+++ b/Source/Scene/GltfLoaderUtil.js
@@ -12,6 +12,7 @@ import TextureWrap from "../Renderer/TextureWrap.js";
  * @namespace GltfLoaderUtil
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 var GltfLoaderUtil = {};
 
@@ -24,6 +25,8 @@ var GltfLoaderUtil = {};
  * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
  *
  * @returns {Object} An object containing a <code>uri</code> and <code>bufferView</code> property.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfLoaderUtil.getImageUriOrBufferView = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -96,6 +99,8 @@ GltfLoaderUtil.getImageUriOrBufferView = function (options) {
  * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
  *
  * @returns {Number} The image ID.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfLoaderUtil.getImageIdFromTexture = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -127,6 +132,8 @@ GltfLoaderUtil.getImageIdFromTexture = function (options) {
  * @param {Object} options.textureInfo The texture info object.
  *
  * @returns {Sampler} The sampler.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfLoaderUtil.createSampler = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/Source/Scene/GltfTextureLoader.js
+++ b/Source/Scene/GltfTextureLoader.js
@@ -32,7 +32,6 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {Boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function GltfTextureLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -94,7 +93,6 @@ Object.defineProperties(GltfTextureLoader.prototype, {
    * @type {Promise.<GltfTextureLoader>}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     get: function () {
@@ -109,7 +107,6 @@ Object.defineProperties(GltfTextureLoader.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     get: function () {
@@ -124,7 +121,6 @@ Object.defineProperties(GltfTextureLoader.prototype, {
    * @type {Texture}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   texture: {
     get: function () {
@@ -136,7 +132,6 @@ Object.defineProperties(GltfTextureLoader.prototype, {
 /**
  * Loads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfTextureLoader.prototype.load = function () {
   var resourceCache = this._resourceCache;
@@ -289,7 +284,6 @@ var scratchTextureJob = new CreateTextureJob();
  *
  * @param {FrameState} frameState The frame state.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfTextureLoader.prototype.process = function (frameState) {
   //>>includeStart('debug', pragmas.debug);
@@ -342,7 +336,6 @@ GltfTextureLoader.prototype.process = function (frameState) {
 /**
  * Unloads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfTextureLoader.prototype.unload = function () {
   if (defined(this._texture)) {

--- a/Source/Scene/GltfTextureLoader.js
+++ b/Source/Scene/GltfTextureLoader.js
@@ -32,6 +32,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {Boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function GltfTextureLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -92,6 +93,8 @@ Object.defineProperties(GltfTextureLoader.prototype, {
    *
    * @type {Promise.<GltfTextureLoader>}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     get: function () {
@@ -105,6 +108,8 @@ Object.defineProperties(GltfTextureLoader.prototype, {
    *
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     get: function () {
@@ -118,6 +123,8 @@ Object.defineProperties(GltfTextureLoader.prototype, {
    *
    * @type {Texture}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   texture: {
     get: function () {
@@ -128,6 +135,8 @@ Object.defineProperties(GltfTextureLoader.prototype, {
 
 /**
  * Loads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfTextureLoader.prototype.load = function () {
   var resourceCache = this._resourceCache;
@@ -279,6 +288,8 @@ var scratchTextureJob = new CreateTextureJob();
  * Processes the resource until it becomes ready.
  *
  * @param {FrameState} frameState The frame state.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfTextureLoader.prototype.process = function (frameState) {
   //>>includeStart('debug', pragmas.debug);
@@ -330,6 +341,8 @@ GltfTextureLoader.prototype.process = function (frameState) {
 
 /**
  * Unloads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfTextureLoader.prototype.unload = function () {
   if (defined(this._texture)) {

--- a/Source/Scene/GltfVertexBufferLoader.js
+++ b/Source/Scene/GltfVertexBufferLoader.js
@@ -39,7 +39,6 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @exception {DeveloperError} When options.draco is defined options.dracoAccessorId must also be defined.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function GltfVertexBufferLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -126,7 +125,6 @@ Object.defineProperties(GltfVertexBufferLoader.prototype, {
    * @type {Promise.<GltfVertexBufferLoader>}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     get: function () {
@@ -141,7 +139,6 @@ Object.defineProperties(GltfVertexBufferLoader.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     get: function () {
@@ -156,7 +153,6 @@ Object.defineProperties(GltfVertexBufferLoader.prototype, {
    * @type {Buffer}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   vertexBuffer: {
     get: function () {
@@ -171,7 +167,6 @@ Object.defineProperties(GltfVertexBufferLoader.prototype, {
    * @type {ModelComponents.Quantization}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   quantization: {
     get: function () {
@@ -183,7 +178,6 @@ Object.defineProperties(GltfVertexBufferLoader.prototype, {
 /**
  * Loads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfVertexBufferLoader.prototype.load = function () {
   if (defined(this._draco)) {
@@ -343,7 +337,6 @@ var scratchVertexBufferJob = new CreateVertexBufferJob();
  *
  * @param {FrameState} frameState The frame state.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfVertexBufferLoader.prototype.process = function (frameState) {
   //>>includeStart('debug', pragmas.debug);
@@ -390,7 +383,6 @@ GltfVertexBufferLoader.prototype.process = function (frameState) {
 /**
  * Unloads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfVertexBufferLoader.prototype.unload = function () {
   if (defined(this._vertexBuffer)) {

--- a/Source/Scene/GltfVertexBufferLoader.js
+++ b/Source/Scene/GltfVertexBufferLoader.js
@@ -39,6 +39,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @exception {DeveloperError} When options.draco is defined options.dracoAccessorId must also be defined.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function GltfVertexBufferLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -124,6 +125,8 @@ Object.defineProperties(GltfVertexBufferLoader.prototype, {
    *
    * @type {Promise.<GltfVertexBufferLoader>}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     get: function () {
@@ -137,6 +140,8 @@ Object.defineProperties(GltfVertexBufferLoader.prototype, {
    *
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     get: function () {
@@ -150,6 +155,8 @@ Object.defineProperties(GltfVertexBufferLoader.prototype, {
    *
    * @type {Buffer}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   vertexBuffer: {
     get: function () {
@@ -163,6 +170,8 @@ Object.defineProperties(GltfVertexBufferLoader.prototype, {
    *
    * @type {ModelComponents.Quantization}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   quantization: {
     get: function () {
@@ -173,6 +182,8 @@ Object.defineProperties(GltfVertexBufferLoader.prototype, {
 
 /**
  * Loads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfVertexBufferLoader.prototype.load = function () {
   if (defined(this._draco)) {
@@ -331,6 +342,8 @@ var scratchVertexBufferJob = new CreateVertexBufferJob();
  * Processes the resource until it becomes ready.
  *
  * @param {FrameState} frameState The frame state.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfVertexBufferLoader.prototype.process = function (frameState) {
   //>>includeStart('debug', pragmas.debug);
@@ -373,8 +386,11 @@ GltfVertexBufferLoader.prototype.process = function (frameState) {
   this._state = ResourceLoaderState.READY;
   this._promise.resolve(this);
 };
+
 /**
  * Unloads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GltfVertexBufferLoader.prototype.unload = function () {
   if (defined(this._vertexBuffer)) {

--- a/Source/Scene/GroupMetadata.js
+++ b/Source/Scene/GroupMetadata.js
@@ -13,6 +13,7 @@ import MetadataEntity from "./MetadataEntity.js";
  *
  * @alias GroupMetadata
  * @constructor
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function GroupMetadata(options) {

--- a/Source/Scene/GroupMetadata.js
+++ b/Source/Scene/GroupMetadata.js
@@ -44,6 +44,8 @@ Object.defineProperties(GroupMetadata.prototype, {
    * @memberof GroupMetadata.prototype
    * @type {MetadataClass}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   class: {
     get: function () {
@@ -57,6 +59,8 @@ Object.defineProperties(GroupMetadata.prototype, {
    * @memberof GroupMetadata.prototype
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   id: {
     get: function () {
@@ -70,6 +74,8 @@ Object.defineProperties(GroupMetadata.prototype, {
    * @memberof GroupMetadata.prototype
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   name: {
     get: function () {
@@ -83,6 +89,8 @@ Object.defineProperties(GroupMetadata.prototype, {
    * @memberof GroupMetadata.prototype
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   description: {
     get: function () {
@@ -96,6 +104,8 @@ Object.defineProperties(GroupMetadata.prototype, {
    * @memberof GroupMetadata.prototype
    * @type {*}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -109,6 +119,8 @@ Object.defineProperties(GroupMetadata.prototype, {
    * @memberof GroupMetadata.prototype
    * @type {Object}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {
@@ -122,6 +134,7 @@ Object.defineProperties(GroupMetadata.prototype, {
  *
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {Boolean} Whether this property exists.
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GroupMetadata.prototype.hasProperty = function (propertyId) {
@@ -133,6 +146,7 @@ GroupMetadata.prototype.hasProperty = function (propertyId) {
  *
  * @param {String[]} [results] An array into which to store the results.
  * @returns {String[]} The property IDs.
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GroupMetadata.prototype.getPropertyIds = function (results) {
@@ -147,6 +161,8 @@ GroupMetadata.prototype.getPropertyIds = function (results) {
  *
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GroupMetadata.prototype.getProperty = function (propertyId) {
   return MetadataEntity.getProperty(propertyId, this._properties, this._class);
@@ -161,6 +177,7 @@ GroupMetadata.prototype.getProperty = function (propertyId) {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GroupMetadata.prototype.setProperty = function (propertyId, value) {
@@ -177,6 +194,7 @@ GroupMetadata.prototype.setProperty = function (propertyId, value) {
  *
  * @param {String} semantic The case-sensitive semantic of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GroupMetadata.prototype.getPropertyBySemantic = function (semantic) {
@@ -193,6 +211,7 @@ GroupMetadata.prototype.getPropertyBySemantic = function (semantic) {
  * @param {String} semantic The case-sensitive semantic of the property.
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GroupMetadata.prototype.setPropertyBySemantic = function (semantic, value) {

--- a/Source/Scene/GroupMetadata.js
+++ b/Source/Scene/GroupMetadata.js
@@ -13,6 +13,7 @@ import MetadataEntity from "./MetadataEntity.js";
  *
  * @alias GroupMetadata
  * @constructor
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function GroupMetadata(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -120,6 +121,7 @@ Object.defineProperties(GroupMetadata.prototype, {
  *
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {Boolean} Whether this property exists.
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GroupMetadata.prototype.hasProperty = function (propertyId) {
   return MetadataEntity.hasProperty(propertyId, this._properties, this._class);
@@ -130,6 +132,7 @@ GroupMetadata.prototype.hasProperty = function (propertyId) {
  *
  * @param {String[]} [results] An array into which to store the results.
  * @returns {String[]} The property IDs.
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GroupMetadata.prototype.getPropertyIds = function (results) {
   return MetadataEntity.getPropertyIds(this._properties, this._class, results);
@@ -157,6 +160,7 @@ GroupMetadata.prototype.getProperty = function (propertyId) {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GroupMetadata.prototype.setProperty = function (propertyId, value) {
   return MetadataEntity.setProperty(
@@ -172,6 +176,7 @@ GroupMetadata.prototype.setProperty = function (propertyId, value) {
  *
  * @param {String} semantic The case-sensitive semantic of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GroupMetadata.prototype.getPropertyBySemantic = function (semantic) {
   return MetadataEntity.getPropertyBySemantic(
@@ -187,6 +192,7 @@ GroupMetadata.prototype.getPropertyBySemantic = function (semantic) {
  * @param {String} semantic The case-sensitive semantic of the property.
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GroupMetadata.prototype.setPropertyBySemantic = function (semantic, value) {
   return MetadataEntity.setPropertyBySemantic(

--- a/Source/Scene/GroupMetadata.js
+++ b/Source/Scene/GroupMetadata.js
@@ -45,7 +45,6 @@ Object.defineProperties(GroupMetadata.prototype, {
    * @type {MetadataClass}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   class: {
     get: function () {
@@ -60,7 +59,6 @@ Object.defineProperties(GroupMetadata.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   id: {
     get: function () {
@@ -75,7 +73,6 @@ Object.defineProperties(GroupMetadata.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   name: {
     get: function () {
@@ -90,7 +87,6 @@ Object.defineProperties(GroupMetadata.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   description: {
     get: function () {
@@ -105,7 +101,6 @@ Object.defineProperties(GroupMetadata.prototype, {
    * @type {*}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -120,7 +115,6 @@ Object.defineProperties(GroupMetadata.prototype, {
    * @type {Object}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {
@@ -135,7 +129,6 @@ Object.defineProperties(GroupMetadata.prototype, {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {Boolean} Whether this property exists.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GroupMetadata.prototype.hasProperty = function (propertyId) {
   return MetadataEntity.hasProperty(propertyId, this._properties, this._class);
@@ -147,7 +140,6 @@ GroupMetadata.prototype.hasProperty = function (propertyId) {
  * @param {String[]} [results] An array into which to store the results.
  * @returns {String[]} The property IDs.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GroupMetadata.prototype.getPropertyIds = function (results) {
   return MetadataEntity.getPropertyIds(this._properties, this._class, results);
@@ -162,7 +154,6 @@ GroupMetadata.prototype.getPropertyIds = function (results) {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GroupMetadata.prototype.getProperty = function (propertyId) {
   return MetadataEntity.getProperty(propertyId, this._properties, this._class);
@@ -178,7 +169,6 @@ GroupMetadata.prototype.getProperty = function (propertyId) {
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GroupMetadata.prototype.setProperty = function (propertyId, value) {
   return MetadataEntity.setProperty(
@@ -195,7 +185,6 @@ GroupMetadata.prototype.setProperty = function (propertyId, value) {
  * @param {String} semantic The case-sensitive semantic of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GroupMetadata.prototype.getPropertyBySemantic = function (semantic) {
   return MetadataEntity.getPropertyBySemantic(
@@ -212,7 +201,6 @@ GroupMetadata.prototype.getPropertyBySemantic = function (semantic) {
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 GroupMetadata.prototype.setPropertyBySemantic = function (semantic, value) {
   return MetadataEntity.setPropertyBySemantic(

--- a/Source/Scene/Implicit3DTileContent.js
+++ b/Source/Scene/Implicit3DTileContent.js
@@ -687,7 +687,6 @@ function makeTile(content, baseResource, tileJson, parentTile) {
  * Part of the {@link Cesium3DTileContent} interface.  <code>Implicit3DTileContent</code>
  * always returns <code>false</code> since a tile of this type does not have any features.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 Implicit3DTileContent.prototype.hasProperty = function (batchId, name) {
   return false;
@@ -697,7 +696,6 @@ Implicit3DTileContent.prototype.hasProperty = function (batchId, name) {
  * Part of the {@link Cesium3DTileContent} interface.  <code>Implicit3DTileContent</code>
  * always returns <code>undefined</code> since a tile of this type does not have any features.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 Implicit3DTileContent.prototype.getFeature = function (batchId) {
   return undefined;

--- a/Source/Scene/Implicit3DTileContent.js
+++ b/Source/Scene/Implicit3DTileContent.js
@@ -31,6 +31,7 @@ import ImplicitTileMetadata from "./ImplicitTileMetadata.js";
  * @param {ArrayBuffer} arrayBuffer The array buffer that stores the content payload
  * @param {Number} [byteOffset=0] The offset into the array buffer
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function Implicit3DTileContent(
   tileset,
@@ -686,6 +687,7 @@ function makeTile(content, baseResource, tileJson, parentTile) {
  * Part of the {@link Cesium3DTileContent} interface.  <code>Implicit3DTileContent</code>
  * always returns <code>false</code> since a tile of this type does not have any features.
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 Implicit3DTileContent.prototype.hasProperty = function (batchId, name) {
   return false;
@@ -695,6 +697,7 @@ Implicit3DTileContent.prototype.hasProperty = function (batchId, name) {
  * Part of the {@link Cesium3DTileContent} interface.  <code>Implicit3DTileContent</code>
  * always returns <code>undefined</code> since a tile of this type does not have any features.
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 Implicit3DTileContent.prototype.getFeature = function (batchId) {
   return undefined;

--- a/Source/Scene/ImplicitAvailabilityBitstream.js
+++ b/Source/Scene/ImplicitAvailabilityBitstream.js
@@ -92,7 +92,6 @@ Object.defineProperties(ImplicitAvailabilityBitstream.prototype, {
    * @type {Number}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   lengthBits: {
     get: function () {
@@ -107,7 +106,6 @@ Object.defineProperties(ImplicitAvailabilityBitstream.prototype, {
    * @type {Number}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   availableCount: {
     get: function () {
@@ -123,7 +121,6 @@ Object.defineProperties(ImplicitAvailabilityBitstream.prototype, {
  * @param {Number} index The integer index of the bit.
  * @returns {Boolean} The value of the bit
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitAvailabilityBitstream.prototype.getBit = function (index) {
   //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/ImplicitAvailabilityBitstream.js
+++ b/Source/Scene/ImplicitAvailabilityBitstream.js
@@ -18,6 +18,7 @@ import RuntimeError from "../Core/RuntimeError.js";
  * @param {Number} [options.availableCount] A number indicating how many 1 bits are found in the bitstream
  * @param {Boolean} [options.computeAvailableCountEnabled=false] If true, and options.availableCount is undefined, the availableCount will be computed from the bitstream.
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function ImplicitAvailabilityBitstream(options) {
   var lengthBits = options.lengthBits;
@@ -91,6 +92,7 @@ Object.defineProperties(ImplicitAvailabilityBitstream.prototype, {
    * @type {Number}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   lengthBits: {
     get: function () {
@@ -105,6 +107,7 @@ Object.defineProperties(ImplicitAvailabilityBitstream.prototype, {
    * @type {Number}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   availableCount: {
     get: function () {
@@ -120,6 +123,7 @@ Object.defineProperties(ImplicitAvailabilityBitstream.prototype, {
  * @param {Number} index The integer index of the bit.
  * @returns {Boolean} The value of the bit
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitAvailabilityBitstream.prototype.getBit = function (index) {
   //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/ImplicitSubdivisionScheme.js
+++ b/Source/Scene/ImplicitSubdivisionScheme.js
@@ -5,6 +5,7 @@ import DeveloperError from "../Core/DeveloperError.js";
  *
  * @enum {String}
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 var ImplicitSubdivisionScheme = {
   /**
@@ -30,6 +31,7 @@ var ImplicitSubdivisionScheme = {
  * @param {ImplicitSubdivisionScheme} subdivisionScheme The subdivision scheme
  * @returns {Number} The branching factor, either 4 for QUADTREE or 8 for OCTREE
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitSubdivisionScheme.getBranchingFactor = function (subdivisionScheme) {
   switch (subdivisionScheme) {

--- a/Source/Scene/ImplicitSubdivisionScheme.js
+++ b/Source/Scene/ImplicitSubdivisionScheme.js
@@ -31,7 +31,6 @@ var ImplicitSubdivisionScheme = {
  * @param {ImplicitSubdivisionScheme} subdivisionScheme The subdivision scheme
  * @returns {Number} The branching factor, either 4 for QUADTREE or 8 for OCTREE
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitSubdivisionScheme.getBranchingFactor = function (subdivisionScheme) {
   switch (subdivisionScheme) {

--- a/Source/Scene/ImplicitSubtree.js
+++ b/Source/Scene/ImplicitSubtree.js
@@ -29,6 +29,7 @@ import when from "../ThirdParty/when.js";
  * @param {ImplicitTileset} implicitTileset The implicit tileset. This includes information about the size of subtrees
  * @param {ImplicitTileCoordinates} implicitCoordinates The coordinates of the subtree's root tile.
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function ImplicitSubtree(
   resource,
@@ -72,6 +73,7 @@ Object.defineProperties(ImplicitSubtree.prototype, {
    * @type {Promise}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   readyPromise: {
     get: function () {
@@ -86,6 +88,7 @@ Object.defineProperties(ImplicitSubtree.prototype, {
    * @type {MetadataTable}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   metadataTable: {
     get: function () {
@@ -101,6 +104,7 @@ Object.defineProperties(ImplicitSubtree.prototype, {
    * @type {MetadataTable}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   metadataExtension: {
     get: function () {
@@ -115,6 +119,7 @@ Object.defineProperties(ImplicitSubtree.prototype, {
  * @param {Number} index the index of the desired tile
  * @returns {Boolean} the value of the i-th bit
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitSubtree.prototype.tileIsAvailable = function (index) {
   return this._tileAvailability.getBit(index);
@@ -127,6 +132,7 @@ ImplicitSubtree.prototype.tileIsAvailable = function (index) {
  * @param {Number} [contentIndex=0] the index of the desired content when the <code>3DTILES_multiple_contents</code> extension is used.
  * @returns {Boolean} the value of the i-th bit
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitSubtree.prototype.contentIsAvailable = function (index, contentIndex) {
   contentIndex = defaultValue(contentIndex, 0);
@@ -148,6 +154,7 @@ ImplicitSubtree.prototype.contentIsAvailable = function (index, contentIndex) {
  * @param {Number} index the index of the desired child subtree
  * @returns {Boolean} the value of the i-th bit
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitSubtree.prototype.childSubtreeIsAvailable = function (index) {
   return this._childSubtreeAvailability.getBit(index);
@@ -165,6 +172,7 @@ ImplicitSubtree.prototype.childSubtreeIsAvailable = function (index) {
  * @param {Number} level The 0-indexed level number relative to the root of the subtree
  * @returns {Number} The first index at the desired level
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitSubtree.prototype.getLevelOffset = function (level) {
   var branchingFactor = this._branchingFactor;
@@ -179,6 +187,7 @@ ImplicitSubtree.prototype.getLevelOffset = function (level) {
  * @param {Number} childIndex The morton index of the child tile relative to its parent
  * @returns {Number} The index of the child's parent node
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitSubtree.prototype.getParentMortonIndex = function (mortonIndex) {
   var bitsPerLevel = 2;
@@ -692,6 +701,7 @@ function makeJumpBuffer(subtree) {
  * @property {ImplicitTileCoordinates} implicitCoordinates The coordinates of a tile
  * @return {Number} The tile's index within the subtree.
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitSubtree.prototype.getTileIndex = function (implicitCoordinates) {
   var localLevel = implicitCoordinates.level - this._implicitCoordinates.level;
@@ -711,6 +721,7 @@ ImplicitSubtree.prototype.getTileIndex = function (implicitCoordinates) {
  * @return {Number} The entity ID for this tile for accessing tile metadata, or <code>undefined</code> if not applicable.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitSubtree.prototype.getEntityId = function (implicitCoordinates) {
   if (!defined(this._metadataTable)) {
@@ -727,6 +738,7 @@ ImplicitSubtree.prototype.getEntityId = function (implicitCoordinates) {
 
 /**
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitSubtree.prototype.isDestroyed = function () {
   return false;
@@ -734,6 +746,7 @@ ImplicitSubtree.prototype.isDestroyed = function () {
 
 /**
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitSubtree.prototype.destroy = function () {
   if (defined(this._bufferLoader)) {

--- a/Source/Scene/ImplicitSubtree.js
+++ b/Source/Scene/ImplicitSubtree.js
@@ -73,7 +73,6 @@ Object.defineProperties(ImplicitSubtree.prototype, {
    * @type {Promise}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   readyPromise: {
     get: function () {
@@ -88,7 +87,6 @@ Object.defineProperties(ImplicitSubtree.prototype, {
    * @type {MetadataTable}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   metadataTable: {
     get: function () {
@@ -104,7 +102,6 @@ Object.defineProperties(ImplicitSubtree.prototype, {
    * @type {MetadataTable}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   metadataExtension: {
     get: function () {
@@ -119,7 +116,6 @@ Object.defineProperties(ImplicitSubtree.prototype, {
  * @param {Number} index the index of the desired tile
  * @returns {Boolean} the value of the i-th bit
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitSubtree.prototype.tileIsAvailable = function (index) {
   return this._tileAvailability.getBit(index);
@@ -132,7 +128,6 @@ ImplicitSubtree.prototype.tileIsAvailable = function (index) {
  * @param {Number} [contentIndex=0] the index of the desired content when the <code>3DTILES_multiple_contents</code> extension is used.
  * @returns {Boolean} the value of the i-th bit
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitSubtree.prototype.contentIsAvailable = function (index, contentIndex) {
   contentIndex = defaultValue(contentIndex, 0);
@@ -154,7 +149,6 @@ ImplicitSubtree.prototype.contentIsAvailable = function (index, contentIndex) {
  * @param {Number} index the index of the desired child subtree
  * @returns {Boolean} the value of the i-th bit
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitSubtree.prototype.childSubtreeIsAvailable = function (index) {
   return this._childSubtreeAvailability.getBit(index);
@@ -172,7 +166,6 @@ ImplicitSubtree.prototype.childSubtreeIsAvailable = function (index) {
  * @param {Number} level The 0-indexed level number relative to the root of the subtree
  * @returns {Number} The first index at the desired level
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitSubtree.prototype.getLevelOffset = function (level) {
   var branchingFactor = this._branchingFactor;
@@ -187,7 +180,6 @@ ImplicitSubtree.prototype.getLevelOffset = function (level) {
  * @param {Number} childIndex The morton index of the child tile relative to its parent
  * @returns {Number} The index of the child's parent node
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitSubtree.prototype.getParentMortonIndex = function (mortonIndex) {
   var bitsPerLevel = 2;
@@ -701,7 +693,6 @@ function makeJumpBuffer(subtree) {
  * @property {ImplicitTileCoordinates} implicitCoordinates The coordinates of a tile
  * @return {Number} The tile's index within the subtree.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitSubtree.prototype.getTileIndex = function (implicitCoordinates) {
   var localLevel = implicitCoordinates.level - this._implicitCoordinates.level;
@@ -721,7 +712,6 @@ ImplicitSubtree.prototype.getTileIndex = function (implicitCoordinates) {
  * @return {Number} The entity ID for this tile for accessing tile metadata, or <code>undefined</code> if not applicable.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitSubtree.prototype.getEntityId = function (implicitCoordinates) {
   if (!defined(this._metadataTable)) {
@@ -738,7 +728,6 @@ ImplicitSubtree.prototype.getEntityId = function (implicitCoordinates) {
 
 /**
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitSubtree.prototype.isDestroyed = function () {
   return false;
@@ -746,7 +735,6 @@ ImplicitSubtree.prototype.isDestroyed = function () {
 
 /**
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitSubtree.prototype.destroy = function () {
   if (defined(this._bufferLoader)) {

--- a/Source/Scene/ImplicitTileCoordinates.js
+++ b/Source/Scene/ImplicitTileCoordinates.js
@@ -49,7 +49,6 @@ export default function ImplicitTileCoordinates(options) {
    * @type {ImplicitSubdivisionScheme}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.subdivisionScheme = options.subdivisionScheme;
 
@@ -60,7 +59,6 @@ export default function ImplicitTileCoordinates(options) {
    * @type {Number}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.level = options.level;
 
@@ -70,7 +68,6 @@ export default function ImplicitTileCoordinates(options) {
    * @type {Number}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.x = options.x;
 
@@ -80,7 +77,6 @@ export default function ImplicitTileCoordinates(options) {
    * @type {Number}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.y = options.y;
 
@@ -90,7 +86,6 @@ export default function ImplicitTileCoordinates(options) {
    * @type {Number}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.z = undefined;
   if (options.subdivisionScheme === ImplicitSubdivisionScheme.OCTREE) {
@@ -111,7 +106,6 @@ Object.defineProperties(ImplicitTileCoordinates.prototype, {
    * @type {Number}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   childIndex: {
     get: function () {
@@ -133,7 +127,6 @@ Object.defineProperties(ImplicitTileCoordinates.prototype, {
    * @type {Number}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   mortonIndex: {
     get: function () {
@@ -152,7 +145,6 @@ Object.defineProperties(ImplicitTileCoordinates.prototype, {
  * @param {Number} childIndex The morton index of the child tile relative to its parent
  * @returns {ImplicitTileCoordinates} The tile coordinates of the child
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitTileCoordinates.prototype.deriveChildCoordinates = function (
   childIndex
@@ -197,7 +189,6 @@ ImplicitTileCoordinates.prototype.deriveChildCoordinates = function (
  *
  * @returns {Object} An object suitable for use with {@link Resource#getDerivedResource}
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitTileCoordinates.prototype.getTemplateValues = function () {
   var values = {
@@ -222,7 +213,6 @@ var scratchCoordinatesArray = [0, 0, 0];
  * @param {Number} mortonIndex The morton index of the tile.
  * @returns {ImplicitTileCoordinates} The coordinates of the tile with the given Morton index
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitTileCoordinates.fromMortonIndex = function (
   subdivisionScheme,

--- a/Source/Scene/ImplicitTileCoordinates.js
+++ b/Source/Scene/ImplicitTileCoordinates.js
@@ -30,6 +30,7 @@ import ImplicitSubdivisionScheme from "./ImplicitSubdivisionScheme.js";
  * @param {Number} options.y The y coordinate of the tile
  * @param {Number} [options.z] The z coordinate of the tile. Only required when options.subdivisionScheme is ImplicitSubdivisionScheme.OCTREE
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function ImplicitTileCoordinates(options) {
   //>>includeStart('debug', pragmas.debug);
@@ -48,6 +49,7 @@ export default function ImplicitTileCoordinates(options) {
    * @type {ImplicitSubdivisionScheme}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.subdivisionScheme = options.subdivisionScheme;
 
@@ -58,6 +60,7 @@ export default function ImplicitTileCoordinates(options) {
    * @type {Number}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.level = options.level;
 
@@ -67,6 +70,7 @@ export default function ImplicitTileCoordinates(options) {
    * @type {Number}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.x = options.x;
 
@@ -76,6 +80,7 @@ export default function ImplicitTileCoordinates(options) {
    * @type {Number}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.y = options.y;
 
@@ -85,6 +90,7 @@ export default function ImplicitTileCoordinates(options) {
    * @type {Number}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.z = undefined;
   if (options.subdivisionScheme === ImplicitSubdivisionScheme.OCTREE) {
@@ -105,6 +111,7 @@ Object.defineProperties(ImplicitTileCoordinates.prototype, {
    * @type {Number}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   childIndex: {
     get: function () {
@@ -126,6 +133,7 @@ Object.defineProperties(ImplicitTileCoordinates.prototype, {
    * @type {Number}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   mortonIndex: {
     get: function () {
@@ -144,6 +152,7 @@ Object.defineProperties(ImplicitTileCoordinates.prototype, {
  * @param {Number} childIndex The morton index of the child tile relative to its parent
  * @returns {ImplicitTileCoordinates} The tile coordinates of the child
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitTileCoordinates.prototype.deriveChildCoordinates = function (
   childIndex
@@ -188,6 +197,7 @@ ImplicitTileCoordinates.prototype.deriveChildCoordinates = function (
  *
  * @returns {Object} An object suitable for use with {@link Resource#getDerivedResource}
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitTileCoordinates.prototype.getTemplateValues = function () {
   var values = {
@@ -212,6 +222,7 @@ var scratchCoordinatesArray = [0, 0, 0];
  * @param {Number} mortonIndex The morton index of the tile.
  * @returns {ImplicitTileCoordinates} The coordinates of the tile with the given Morton index
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitTileCoordinates.fromMortonIndex = function (
   subdivisionScheme,

--- a/Source/Scene/ImplicitTileMetadata.js
+++ b/Source/Scene/ImplicitTileMetadata.js
@@ -48,7 +48,6 @@ Object.defineProperties(ImplicitTileMetadata.prototype, {
    * @memberof ImplicitTileMetadata.prototype
    * @type {MetadataClass}
    * @readonly
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   class: {
     get: function () {
@@ -62,7 +61,6 @@ Object.defineProperties(ImplicitTileMetadata.prototype, {
    * @memberof ImplicitTileMetadata.prototype
    * @type {*}
    * @readonly
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -76,7 +74,6 @@ Object.defineProperties(ImplicitTileMetadata.prototype, {
    * @memberof ImplicitTileMetadata.prototype
    * @type {Object}
    * @readonly
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {
@@ -91,7 +88,6 @@ Object.defineProperties(ImplicitTileMetadata.prototype, {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {Boolean} Whether this property exists.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitTileMetadata.prototype.hasProperty = function (propertyId) {
   return this._metadataTable.hasProperty(propertyId);
@@ -103,7 +99,6 @@ ImplicitTileMetadata.prototype.hasProperty = function (propertyId) {
  * @param {String[]} [results] An array into which to store the results.
  * @returns {String[]} The property IDs.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitTileMetadata.prototype.getPropertyIds = function (results) {
   return this._metadataTable.getPropertyIds(results);
@@ -118,7 +113,6 @@ ImplicitTileMetadata.prototype.getPropertyIds = function (results) {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitTileMetadata.prototype.getProperty = function (propertyId) {
   return this._metadataTable.getProperty(this._entityId, propertyId);
@@ -134,7 +128,6 @@ ImplicitTileMetadata.prototype.getProperty = function (propertyId) {
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitTileMetadata.prototype.setProperty = function (propertyId, value) {
   return this._metadataTable.setProperty(this._entityId, propertyId, value);
@@ -146,7 +139,6 @@ ImplicitTileMetadata.prototype.setProperty = function (propertyId, value) {
  * @param {String} semantic The case-sensitive semantic of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitTileMetadata.prototype.getPropertyBySemantic = function (semantic) {
   return this._metadataTable.getPropertyBySemantic(this._entityId, semantic);
@@ -159,7 +151,6 @@ ImplicitTileMetadata.prototype.getPropertyBySemantic = function (semantic) {
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitTileMetadata.prototype.setPropertyBySemantic = function (
   semantic,

--- a/Source/Scene/ImplicitTileMetadata.js
+++ b/Source/Scene/ImplicitTileMetadata.js
@@ -17,6 +17,7 @@ import defaultValue from "../Core/defaultValue.js";
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function ImplicitTileMetadata(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -47,6 +48,7 @@ Object.defineProperties(ImplicitTileMetadata.prototype, {
    * @memberof ImplicitTileMetadata.prototype
    * @type {MetadataClass}
    * @readonly
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   class: {
     get: function () {
@@ -60,6 +62,7 @@ Object.defineProperties(ImplicitTileMetadata.prototype, {
    * @memberof ImplicitTileMetadata.prototype
    * @type {*}
    * @readonly
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -73,6 +76,7 @@ Object.defineProperties(ImplicitTileMetadata.prototype, {
    * @memberof ImplicitTileMetadata.prototype
    * @type {Object}
    * @readonly
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {
@@ -86,6 +90,8 @@ Object.defineProperties(ImplicitTileMetadata.prototype, {
  *
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {Boolean} Whether this property exists.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitTileMetadata.prototype.hasProperty = function (propertyId) {
   return this._metadataTable.hasProperty(propertyId);
@@ -96,6 +102,8 @@ ImplicitTileMetadata.prototype.hasProperty = function (propertyId) {
  *
  * @param {String[]} [results] An array into which to store the results.
  * @returns {String[]} The property IDs.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitTileMetadata.prototype.getPropertyIds = function (results) {
   return this._metadataTable.getPropertyIds(results);
@@ -109,6 +117,8 @@ ImplicitTileMetadata.prototype.getPropertyIds = function (results) {
  *
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitTileMetadata.prototype.getProperty = function (propertyId) {
   return this._metadataTable.getProperty(this._entityId, propertyId);
@@ -123,6 +133,8 @@ ImplicitTileMetadata.prototype.getProperty = function (propertyId) {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitTileMetadata.prototype.setProperty = function (propertyId, value) {
   return this._metadataTable.setProperty(this._entityId, propertyId, value);
@@ -133,6 +145,8 @@ ImplicitTileMetadata.prototype.setProperty = function (propertyId, value) {
  *
  * @param {String} semantic The case-sensitive semantic of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitTileMetadata.prototype.getPropertyBySemantic = function (semantic) {
   return this._metadataTable.getPropertyBySemantic(this._entityId, semantic);
@@ -144,6 +158,8 @@ ImplicitTileMetadata.prototype.getPropertyBySemantic = function (semantic) {
  * @param {String} semantic The case-sensitive semantic of the property.
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ImplicitTileMetadata.prototype.setPropertyBySemantic = function (
   semantic,

--- a/Source/Scene/ImplicitTileset.js
+++ b/Source/Scene/ImplicitTileset.js
@@ -20,6 +20,7 @@ import ImplicitSubdivisionScheme from "./ImplicitSubdivisionScheme.js";
  * @param {Resource} baseResource The base resource for the tileset
  * @param {Object} tileJson The JSON header of the tile with the 3DTILES_implicit_tiling extension.
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function ImplicitTileset(tileset, baseResource, tileJson) {
   var extension = tileJson.extensions["3DTILES_implicit_tiling"];
@@ -36,6 +37,7 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Cesium3DTileset}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.tileset = tileset;
 
@@ -47,6 +49,7 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Resource}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.baseResource = baseResource;
 
@@ -56,6 +59,7 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Number}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.geometricError = tileJson.geometricError;
 
@@ -75,6 +79,7 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Object}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.boundingVolume = tileJson.boundingVolume;
 
@@ -84,6 +89,7 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {String}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.refine = tileJson.refine;
 
@@ -94,6 +100,7 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Resource}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.subtreeUriTemplate = new Resource({ url: extension.subtrees.uri });
 
@@ -107,6 +114,7 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Resource[]}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.contentUriTemplates = [];
 
@@ -121,6 +129,7 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Object[]}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.contentHeaders = [];
 
@@ -139,6 +148,7 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Number}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.contentCount = this.contentHeaders.length;
 
@@ -157,6 +167,7 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Object}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.tileHeader = makeTileHeaderTemplate(tileJson);
 
@@ -166,6 +177,7 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {ImplicitSubdivisionScheme}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.subdivisionScheme =
     ImplicitSubdivisionScheme[extension.subdivisionScheme];
@@ -177,6 +189,7 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Number}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.branchingFactor = ImplicitSubdivisionScheme.getBranchingFactor(
     this.subdivisionScheme
@@ -189,6 +202,7 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Number}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.subtreeLevels = extension.subtreeLevels;
 
@@ -198,6 +212,7 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Number}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.maximumLevel = extension.maximumLevel;
 }

--- a/Source/Scene/ImplicitTileset.js
+++ b/Source/Scene/ImplicitTileset.js
@@ -37,7 +37,6 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Cesium3DTileset}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.tileset = tileset;
 
@@ -49,7 +48,6 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Resource}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.baseResource = baseResource;
 
@@ -59,7 +57,6 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Number}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.geometricError = tileJson.geometricError;
 
@@ -79,7 +76,6 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Object}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.boundingVolume = tileJson.boundingVolume;
 
@@ -89,7 +85,6 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.refine = tileJson.refine;
 
@@ -100,7 +95,6 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Resource}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.subtreeUriTemplate = new Resource({ url: extension.subtrees.uri });
 
@@ -114,7 +108,6 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Resource[]}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.contentUriTemplates = [];
 
@@ -129,7 +122,6 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Object[]}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.contentHeaders = [];
 
@@ -148,7 +140,6 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Number}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.contentCount = this.contentHeaders.length;
 
@@ -167,7 +158,6 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Object}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.tileHeader = makeTileHeaderTemplate(tileJson);
 
@@ -177,7 +167,6 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {ImplicitSubdivisionScheme}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.subdivisionScheme =
     ImplicitSubdivisionScheme[extension.subdivisionScheme];
@@ -189,7 +178,6 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Number}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.branchingFactor = ImplicitSubdivisionScheme.getBranchingFactor(
     this.subdivisionScheme
@@ -202,7 +190,6 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Number}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.subtreeLevels = extension.subtreeLevels;
 
@@ -212,7 +199,6 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @type {Number}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.maximumLevel = extension.maximumLevel;
 }

--- a/Source/Scene/JsonMetadataTable.js
+++ b/Source/Scene/JsonMetadataTable.js
@@ -14,6 +14,7 @@ import MetadataEntity from "./MetadataEntity.js";
  * @alias JsonMetadataTable
  * @constructor
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function JsonMetadataTable(options) {
   //>>includeStart('debug', pragmas.debug);
@@ -31,6 +32,7 @@ export default function JsonMetadataTable(options) {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {Boolean} Whether this property exists.
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 JsonMetadataTable.prototype.hasProperty = function (propertyId) {
   return MetadataEntity.hasProperty(propertyId, this._properties);
@@ -42,6 +44,7 @@ JsonMetadataTable.prototype.hasProperty = function (propertyId) {
  * @param {String[]} [results] An array into which to store the results.
  * @returns {String[]} The property IDs.
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 JsonMetadataTable.prototype.getPropertyIds = function (results) {
   return MetadataEntity.getPropertyIds(this._properties, undefined, results);
@@ -56,6 +59,7 @@ JsonMetadataTable.prototype.getPropertyIds = function (results) {
  *
  * @exception {DeveloperError} index is out of bounds
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 JsonMetadataTable.prototype.getProperty = function (index, propertyId) {
   //>>includeStart('debug', pragmas.debug);
@@ -85,6 +89,7 @@ JsonMetadataTable.prototype.getProperty = function (index, propertyId) {
  *
  * @exception {DeveloperError} index is out of bounds
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 JsonMetadataTable.prototype.setProperty = function (index, propertyId, value) {
   //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/JsonMetadataTable.js
+++ b/Source/Scene/JsonMetadataTable.js
@@ -14,7 +14,6 @@ import MetadataEntity from "./MetadataEntity.js";
  * @alias JsonMetadataTable
  * @constructor
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function JsonMetadataTable(options) {
   //>>includeStart('debug', pragmas.debug);
@@ -32,7 +31,6 @@ export default function JsonMetadataTable(options) {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {Boolean} Whether this property exists.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 JsonMetadataTable.prototype.hasProperty = function (propertyId) {
   return MetadataEntity.hasProperty(propertyId, this._properties);
@@ -44,7 +42,6 @@ JsonMetadataTable.prototype.hasProperty = function (propertyId) {
  * @param {String[]} [results] An array into which to store the results.
  * @returns {String[]} The property IDs.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 JsonMetadataTable.prototype.getPropertyIds = function (results) {
   return MetadataEntity.getPropertyIds(this._properties, undefined, results);
@@ -59,7 +56,6 @@ JsonMetadataTable.prototype.getPropertyIds = function (results) {
  *
  * @exception {DeveloperError} index is out of bounds
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 JsonMetadataTable.prototype.getProperty = function (index, propertyId) {
   //>>includeStart('debug', pragmas.debug);
@@ -89,7 +85,6 @@ JsonMetadataTable.prototype.getProperty = function (index, propertyId) {
  *
  * @exception {DeveloperError} index is out of bounds
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 JsonMetadataTable.prototype.setProperty = function (index, propertyId, value) {
   //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/MetadataClass.js
+++ b/Source/Scene/MetadataClass.js
@@ -13,6 +13,7 @@ import MetadataClassProperty from "./MetadataClassProperty.js";
  *
  * @alias MetadataClass
  * @constructor
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function MetadataClass(options) {

--- a/Source/Scene/MetadataClass.js
+++ b/Source/Scene/MetadataClass.js
@@ -58,6 +58,8 @@ Object.defineProperties(MetadataClass.prototype, {
    * @memberof MetadataClass.prototype
    * @type {Object.<String, MetadataClassProperty>}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   properties: {
     get: function () {
@@ -73,6 +75,7 @@ Object.defineProperties(MetadataClass.prototype, {
    * @readonly
    *
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   propertiesBySemantic: {
     get: function () {
@@ -86,6 +89,8 @@ Object.defineProperties(MetadataClass.prototype, {
    * @memberof MetadataClass.prototype
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   id: {
     get: function () {
@@ -99,6 +104,8 @@ Object.defineProperties(MetadataClass.prototype, {
    * @memberof MetadataClass.prototype
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   name: {
     get: function () {
@@ -112,6 +119,8 @@ Object.defineProperties(MetadataClass.prototype, {
    * @memberof MetadataClass.prototype
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   description: {
     get: function () {
@@ -125,6 +134,8 @@ Object.defineProperties(MetadataClass.prototype, {
    * @memberof MetadataClass.prototype
    * @type {*}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -138,6 +149,8 @@ Object.defineProperties(MetadataClass.prototype, {
    * @memberof MetadataClass.prototype
    * @type {Object}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {

--- a/Source/Scene/MetadataClass.js
+++ b/Source/Scene/MetadataClass.js
@@ -13,6 +13,7 @@ import MetadataClassProperty from "./MetadataClassProperty.js";
  *
  * @alias MetadataClass
  * @constructor
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function MetadataClass(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/Source/Scene/MetadataClass.js
+++ b/Source/Scene/MetadataClass.js
@@ -59,7 +59,6 @@ Object.defineProperties(MetadataClass.prototype, {
    * @type {Object.<String, MetadataClassProperty>}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   properties: {
     get: function () {
@@ -75,7 +74,6 @@ Object.defineProperties(MetadataClass.prototype, {
    * @readonly
    *
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   propertiesBySemantic: {
     get: function () {
@@ -90,7 +88,6 @@ Object.defineProperties(MetadataClass.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   id: {
     get: function () {
@@ -105,7 +102,6 @@ Object.defineProperties(MetadataClass.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   name: {
     get: function () {
@@ -120,7 +116,6 @@ Object.defineProperties(MetadataClass.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   description: {
     get: function () {
@@ -135,7 +130,6 @@ Object.defineProperties(MetadataClass.prototype, {
    * @type {*}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -150,7 +144,6 @@ Object.defineProperties(MetadataClass.prototype, {
    * @type {Object}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {

--- a/Source/Scene/MetadataClassProperty.js
+++ b/Source/Scene/MetadataClassProperty.js
@@ -69,7 +69,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   id: {
     get: function () {
@@ -84,7 +83,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   name: {
     get: function () {
@@ -99,7 +97,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   description: {
     get: function () {
@@ -114,7 +111,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @type {MetadataType}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   type: {
     get: function () {
@@ -129,7 +125,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @type {MetadataEnum}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   enumType: {
     get: function () {
@@ -144,7 +139,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @type {MetadataType}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   componentType: {
     get: function () {
@@ -160,7 +154,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @readonly
    *
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   valueType: {
     get: function () {
@@ -175,7 +168,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @type {Number}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   componentCount: {
     get: function () {
@@ -190,7 +182,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @type {Boolean}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   normalized: {
     get: function () {
@@ -205,7 +196,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @type {Number|Number[]}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   max: {
     get: function () {
@@ -220,7 +210,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @type {Number|Number[]}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   min: {
     get: function () {
@@ -235,7 +224,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @type {Boolean|Number|String|Array}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   default: {
     get: function () {
@@ -250,7 +238,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @type {Boolean}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   optional: {
     get: function () {
@@ -265,7 +252,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   semantic: {
     get: function () {
@@ -280,7 +266,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @type {*}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -295,7 +280,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @type {Object}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {
@@ -312,7 +296,6 @@ Object.defineProperties(MetadataClassProperty.prototype, {
  * @returns {*} The normalized value or array of normalized values.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataClassProperty.prototype.normalize = function (value) {
   return normalize(this, value, MetadataType.normalize);
@@ -326,7 +309,6 @@ MetadataClassProperty.prototype.normalize = function (value) {
  * @returns {*} The integer value or array of integer values.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataClassProperty.prototype.unnormalize = function (value) {
   return normalize(this, value, MetadataType.unnormalize);
@@ -341,7 +323,6 @@ MetadataClassProperty.prototype.unnormalize = function (value) {
  * @param {*} value the original, normalized values.
  * @returns {*} The appropriate vector type if the value is a vector type. Otherwise, the value is returned unaltered.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataClassProperty.prototype.unpackVectorTypes = function (value) {
   var type = this._type;
@@ -378,7 +359,6 @@ MetadataClassProperty.prototype.unpackVectorTypes = function (value) {
  * @param {*} value The value of this property
  * @returns {*} An array of the appropriate length if the property is a vector type. Otherwise, the value is returned unaltered.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataClassProperty.prototype.packVectorTypes = function (value) {
   var type = this._type;
@@ -413,7 +393,6 @@ MetadataClassProperty.prototype.packVectorTypes = function (value) {
  * @param {*} value The value.
  * @returns {String|undefined} An error message if the value does not conform to the property, otherwise undefined.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataClassProperty.prototype.validate = function (value) {
   var message;

--- a/Source/Scene/MetadataClassProperty.js
+++ b/Source/Scene/MetadataClassProperty.js
@@ -68,6 +68,8 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   id: {
     get: function () {
@@ -81,6 +83,8 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   name: {
     get: function () {
@@ -94,6 +98,8 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   description: {
     get: function () {
@@ -107,6 +113,8 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {MetadataType}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   type: {
     get: function () {
@@ -120,6 +128,8 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {MetadataEnum}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   enumType: {
     get: function () {
@@ -133,6 +143,8 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {MetadataType}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   componentType: {
     get: function () {
@@ -148,6 +160,7 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @readonly
    *
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   valueType: {
     get: function () {
@@ -161,6 +174,8 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {Number}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   componentCount: {
     get: function () {
@@ -174,6 +189,8 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {Boolean}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   normalized: {
     get: function () {
@@ -187,6 +204,8 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {Number|Number[]}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   max: {
     get: function () {
@@ -200,6 +219,8 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {Number|Number[]}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   min: {
     get: function () {
@@ -213,6 +234,8 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {Boolean|Number|String|Array}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   default: {
     get: function () {
@@ -226,6 +249,8 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {Boolean}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   optional: {
     get: function () {
@@ -239,6 +264,8 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   semantic: {
     get: function () {
@@ -252,6 +279,8 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {*}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -265,6 +294,8 @@ Object.defineProperties(MetadataClassProperty.prototype, {
    * @memberof MetadataClassProperty.prototype
    * @type {Object}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {
@@ -281,6 +312,7 @@ Object.defineProperties(MetadataClassProperty.prototype, {
  * @returns {*} The normalized value or array of normalized values.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataClassProperty.prototype.normalize = function (value) {
   return normalize(this, value, MetadataType.normalize);
@@ -294,6 +326,7 @@ MetadataClassProperty.prototype.normalize = function (value) {
  * @returns {*} The integer value or array of integer values.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataClassProperty.prototype.unnormalize = function (value) {
   return normalize(this, value, MetadataType.unnormalize);
@@ -308,6 +341,7 @@ MetadataClassProperty.prototype.unnormalize = function (value) {
  * @param {*} value the original, normalized values.
  * @returns {*} The appropriate vector type if the value is a vector type. Otherwise, the value is returned unaltered.
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataClassProperty.prototype.unpackVectorTypes = function (value) {
   var type = this._type;
@@ -344,6 +378,7 @@ MetadataClassProperty.prototype.unpackVectorTypes = function (value) {
  * @param {*} value The value of this property
  * @returns {*} An array of the appropriate length if the property is a vector type. Otherwise, the value is returned unaltered.
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataClassProperty.prototype.packVectorTypes = function (value) {
   var type = this._type;
@@ -377,6 +412,7 @@ MetadataClassProperty.prototype.packVectorTypes = function (value) {
  *
  * @param {*} value The value.
  * @returns {String|undefined} An error message if the value does not conform to the property, otherwise undefined.
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataClassProperty.prototype.validate = function (value) {

--- a/Source/Scene/MetadataClassProperty.js
+++ b/Source/Scene/MetadataClassProperty.js
@@ -16,6 +16,7 @@ import MetadataType from "./MetadataType.js";
  *
  * @alias MetadataClassProperty
  * @constructor
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function MetadataClassProperty(options) {

--- a/Source/Scene/MetadataClassProperty.js
+++ b/Source/Scene/MetadataClassProperty.js
@@ -16,6 +16,7 @@ import MetadataType from "./MetadataType.js";
  *
  * @alias MetadataClassProperty
  * @constructor
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function MetadataClassProperty(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -375,6 +376,7 @@ MetadataClassProperty.prototype.packVectorTypes = function (value) {
  *
  * @param {*} value The value.
  * @returns {String|undefined} An error message if the value does not conform to the property, otherwise undefined.
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataClassProperty.prototype.validate = function (value) {
   var message;

--- a/Source/Scene/MetadataEntity.js
+++ b/Source/Scene/MetadataEntity.js
@@ -12,6 +12,7 @@ import DeveloperError from "../Core/DeveloperError.js";
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function MetadataEntity() {}
 
@@ -23,6 +24,7 @@ Object.defineProperties(MetadataEntity.prototype, {
    * @type {MetadataClass}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   class: {
     // eslint-disable-next-line getter-return
@@ -37,6 +39,8 @@ Object.defineProperties(MetadataEntity.prototype, {
  *
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {Boolean} Whether this property exists.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.prototype.hasProperty = function (propertyId) {
   DeveloperError.throwInstantiationError();
@@ -47,6 +51,8 @@ MetadataEntity.prototype.hasProperty = function (propertyId) {
  *
  * @param {String[]} [results] An array into which to store the results.
  * @returns {String[]} The property IDs.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.prototype.getPropertyIds = function (results) {
   DeveloperError.throwInstantiationError();
@@ -60,6 +66,8 @@ MetadataEntity.prototype.getPropertyIds = function (results) {
  *
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.prototype.getProperty = function (propertyId) {
   DeveloperError.throwInstantiationError();
@@ -74,6 +82,8 @@ MetadataEntity.prototype.getProperty = function (propertyId) {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.prototype.setProperty = function (propertyId, value) {
   DeveloperError.throwInstantiationError();
@@ -84,6 +94,8 @@ MetadataEntity.prototype.setProperty = function (propertyId, value) {
  *
  * @param {String} semantic The case-sensitive semantic of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.prototype.getPropertyBySemantic = function (semantic) {
   DeveloperError.throwInstantiationError();
@@ -95,6 +107,8 @@ MetadataEntity.prototype.getPropertyBySemantic = function (semantic) {
  * @param {String} semantic The case-sensitive semantic of the property.
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.prototype.setPropertyBySemantic = function (semantic, value) {
   DeveloperError.throwInstantiationError();
@@ -109,6 +123,7 @@ MetadataEntity.prototype.setPropertyBySemantic = function (semantic, value) {
  * @returns {Boolean} Whether this property exists.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.hasProperty = function (
   propertyId,
@@ -143,6 +158,7 @@ MetadataEntity.hasProperty = function (
  * @returns {String[]} The property IDs.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.getPropertyIds = function (
   properties,
@@ -195,6 +211,7 @@ MetadataEntity.getPropertyIds = function (
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.getProperty = function (
   propertyId,
@@ -246,6 +263,7 @@ MetadataEntity.getProperty = function (
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.setProperty = function (
   propertyId,
@@ -288,6 +306,7 @@ MetadataEntity.setProperty = function (
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.getPropertyBySemantic = function (
   semantic,
@@ -318,6 +337,7 @@ MetadataEntity.getPropertyBySemantic = function (
  * @param {MetadataClass} classDefinition The class.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.setPropertyBySemantic = function (
   semantic,

--- a/Source/Scene/MetadataEntity.js
+++ b/Source/Scene/MetadataEntity.js
@@ -24,7 +24,6 @@ Object.defineProperties(MetadataEntity.prototype, {
    * @type {MetadataClass}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   class: {
     // eslint-disable-next-line getter-return
@@ -40,7 +39,6 @@ Object.defineProperties(MetadataEntity.prototype, {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {Boolean} Whether this property exists.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.prototype.hasProperty = function (propertyId) {
   DeveloperError.throwInstantiationError();
@@ -52,7 +50,6 @@ MetadataEntity.prototype.hasProperty = function (propertyId) {
  * @param {String[]} [results] An array into which to store the results.
  * @returns {String[]} The property IDs.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.prototype.getPropertyIds = function (results) {
   DeveloperError.throwInstantiationError();
@@ -67,7 +64,6 @@ MetadataEntity.prototype.getPropertyIds = function (results) {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.prototype.getProperty = function (propertyId) {
   DeveloperError.throwInstantiationError();
@@ -83,7 +79,6 @@ MetadataEntity.prototype.getProperty = function (propertyId) {
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.prototype.setProperty = function (propertyId, value) {
   DeveloperError.throwInstantiationError();
@@ -95,7 +90,6 @@ MetadataEntity.prototype.setProperty = function (propertyId, value) {
  * @param {String} semantic The case-sensitive semantic of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.prototype.getPropertyBySemantic = function (semantic) {
   DeveloperError.throwInstantiationError();
@@ -108,7 +102,6 @@ MetadataEntity.prototype.getPropertyBySemantic = function (semantic) {
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.prototype.setPropertyBySemantic = function (semantic, value) {
   DeveloperError.throwInstantiationError();
@@ -123,7 +116,6 @@ MetadataEntity.prototype.setPropertyBySemantic = function (semantic, value) {
  * @returns {Boolean} Whether this property exists.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.hasProperty = function (
   propertyId,
@@ -158,7 +150,6 @@ MetadataEntity.hasProperty = function (
  * @returns {String[]} The property IDs.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.getPropertyIds = function (
   properties,
@@ -211,7 +202,6 @@ MetadataEntity.getPropertyIds = function (
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.getProperty = function (
   propertyId,
@@ -263,7 +253,6 @@ MetadataEntity.getProperty = function (
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.setProperty = function (
   propertyId,
@@ -306,7 +295,6 @@ MetadataEntity.setProperty = function (
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.getPropertyBySemantic = function (
   semantic,
@@ -337,7 +325,6 @@ MetadataEntity.getPropertyBySemantic = function (
  * @param {MetadataClass} classDefinition The class.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataEntity.setPropertyBySemantic = function (
   semantic,

--- a/Source/Scene/MetadataEnum.js
+++ b/Source/Scene/MetadataEnum.js
@@ -56,6 +56,8 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @memberof MetadataEnum.prototype
    * @type {MetadataEnumValue[]}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   values: {
     get: function () {
@@ -71,6 +73,7 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @readonly
    *
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   namesByValue: {
     get: function () {
@@ -86,6 +89,7 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @readonly
    *
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   valuesByName: {
     get: function () {
@@ -101,6 +105,7 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @readonly
    *
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   valueType: {
     get: function () {
@@ -114,6 +119,8 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @memberof MetadataEnum.prototype
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   id: {
     get: function () {
@@ -127,6 +134,8 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @memberof MetadataEnum.prototype
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   name: {
     get: function () {
@@ -140,6 +149,8 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @memberof MetadataEnum.prototype
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   description: {
     get: function () {
@@ -153,6 +164,8 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @memberof MetadataEnum.prototype
    * @type {*}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -166,6 +179,8 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @memberof MetadataEnum.prototype
    * @type {Object}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {

--- a/Source/Scene/MetadataEnum.js
+++ b/Source/Scene/MetadataEnum.js
@@ -12,6 +12,7 @@ import MetadataType from "./MetadataType.js";
  *
  * @alias MetadataEnum
  * @constructor
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function MetadataEnum(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/Source/Scene/MetadataEnum.js
+++ b/Source/Scene/MetadataEnum.js
@@ -57,7 +57,6 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @type {MetadataEnumValue[]}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   values: {
     get: function () {
@@ -73,7 +72,6 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @readonly
    *
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   namesByValue: {
     get: function () {
@@ -89,7 +87,6 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @readonly
    *
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   valuesByName: {
     get: function () {
@@ -105,7 +102,6 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @readonly
    *
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   valueType: {
     get: function () {
@@ -120,7 +116,6 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   id: {
     get: function () {
@@ -135,7 +130,6 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   name: {
     get: function () {
@@ -150,7 +144,6 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   description: {
     get: function () {
@@ -165,7 +158,6 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @type {*}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -180,7 +172,6 @@ Object.defineProperties(MetadataEnum.prototype, {
    * @type {Object}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {

--- a/Source/Scene/MetadataEnum.js
+++ b/Source/Scene/MetadataEnum.js
@@ -12,6 +12,7 @@ import MetadataType from "./MetadataType.js";
  *
  * @alias MetadataEnum
  * @constructor
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function MetadataEnum(options) {

--- a/Source/Scene/MetadataEnumValue.js
+++ b/Source/Scene/MetadataEnumValue.js
@@ -7,6 +7,7 @@ import Check from "../Core/Check.js";
  *
  * @alias MetadataEnumValue
  * @constructor
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function MetadataEnumValue(value) {
   //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/MetadataEnumValue.js
+++ b/Source/Scene/MetadataEnumValue.js
@@ -29,6 +29,8 @@ Object.defineProperties(MetadataEnumValue.prototype, {
    * @memberof MetadataEnumValue.prototype
    * @type {Number}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   value: {
     get: function () {
@@ -42,6 +44,8 @@ Object.defineProperties(MetadataEnumValue.prototype, {
    * @memberof MetadataEnumValue.prototype
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   name: {
     get: function () {
@@ -55,6 +59,8 @@ Object.defineProperties(MetadataEnumValue.prototype, {
    * @memberof MetadataEnumValue.prototype
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   description: {
     get: function () {
@@ -68,6 +74,8 @@ Object.defineProperties(MetadataEnumValue.prototype, {
    * @memberof MetadataEnumValue.prototype
    * @type {*}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -81,6 +89,8 @@ Object.defineProperties(MetadataEnumValue.prototype, {
    * @memberof MetadataEnumValue.prototype
    * @type {Object}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {

--- a/Source/Scene/MetadataEnumValue.js
+++ b/Source/Scene/MetadataEnumValue.js
@@ -7,6 +7,7 @@ import Check from "../Core/Check.js";
  *
  * @alias MetadataEnumValue
  * @constructor
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function MetadataEnumValue(value) {

--- a/Source/Scene/MetadataEnumValue.js
+++ b/Source/Scene/MetadataEnumValue.js
@@ -30,7 +30,6 @@ Object.defineProperties(MetadataEnumValue.prototype, {
    * @type {Number}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   value: {
     get: function () {
@@ -45,7 +44,6 @@ Object.defineProperties(MetadataEnumValue.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   name: {
     get: function () {
@@ -60,7 +58,6 @@ Object.defineProperties(MetadataEnumValue.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   description: {
     get: function () {
@@ -75,7 +72,6 @@ Object.defineProperties(MetadataEnumValue.prototype, {
    * @type {*}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -90,7 +86,6 @@ Object.defineProperties(MetadataEnumValue.prototype, {
    * @type {Object}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {

--- a/Source/Scene/MetadataSchema.js
+++ b/Source/Scene/MetadataSchema.js
@@ -59,6 +59,8 @@ Object.defineProperties(MetadataSchema.prototype, {
    * @memberof MetadataSchema.prototype
    * @type {Object.<String, MetadataClass>}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   classes: {
     get: function () {
@@ -72,6 +74,8 @@ Object.defineProperties(MetadataSchema.prototype, {
    * @memberof MetadataSchema.prototype
    * @type {Object.<String, MetadataEnum>}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   enums: {
     get: function () {
@@ -85,6 +89,8 @@ Object.defineProperties(MetadataSchema.prototype, {
    * @memberof MetadataSchema.prototype
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   name: {
     get: function () {
@@ -98,6 +104,8 @@ Object.defineProperties(MetadataSchema.prototype, {
    * @memberof MetadataSchema.prototype
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   description: {
     get: function () {
@@ -111,6 +119,8 @@ Object.defineProperties(MetadataSchema.prototype, {
    * @memberof MetadataSchema.prototype
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   version: {
     get: function () {
@@ -124,6 +134,8 @@ Object.defineProperties(MetadataSchema.prototype, {
    * @memberof MetadataSchema.prototype
    * @type {*}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -137,6 +149,8 @@ Object.defineProperties(MetadataSchema.prototype, {
    * @memberof MetadataSchema.prototype
    * @type {Object}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {

--- a/Source/Scene/MetadataSchema.js
+++ b/Source/Scene/MetadataSchema.js
@@ -60,7 +60,6 @@ Object.defineProperties(MetadataSchema.prototype, {
    * @type {Object.<String, MetadataClass>}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   classes: {
     get: function () {
@@ -75,7 +74,6 @@ Object.defineProperties(MetadataSchema.prototype, {
    * @type {Object.<String, MetadataEnum>}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   enums: {
     get: function () {
@@ -90,7 +88,6 @@ Object.defineProperties(MetadataSchema.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   name: {
     get: function () {
@@ -105,7 +102,6 @@ Object.defineProperties(MetadataSchema.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   description: {
     get: function () {
@@ -120,7 +116,6 @@ Object.defineProperties(MetadataSchema.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   version: {
     get: function () {
@@ -135,7 +130,6 @@ Object.defineProperties(MetadataSchema.prototype, {
    * @type {*}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -150,7 +144,6 @@ Object.defineProperties(MetadataSchema.prototype, {
    * @type {Object}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {

--- a/Source/Scene/MetadataSchema.js
+++ b/Source/Scene/MetadataSchema.js
@@ -10,6 +10,7 @@ import MetadataEnum from "./MetadataEnum.js";
  *
  * @alias MetadataSchema
  * @constructor
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function MetadataSchema(schema) {
   //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/MetadataSchema.js
+++ b/Source/Scene/MetadataSchema.js
@@ -10,6 +10,7 @@ import MetadataEnum from "./MetadataEnum.js";
  *
  * @alias MetadataSchema
  * @constructor
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function MetadataSchema(schema) {

--- a/Source/Scene/MetadataSchemaLoader.js
+++ b/Source/Scene/MetadataSchemaLoader.js
@@ -24,6 +24,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @exception {DeveloperError} One of options.schema and options.resource must be defined.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function MetadataSchemaLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/Source/Scene/MetadataSchemaLoader.js
+++ b/Source/Scene/MetadataSchemaLoader.js
@@ -61,7 +61,6 @@ Object.defineProperties(MetadataSchemaLoader.prototype, {
    * @type {Promise.<MetadataSchemaLoader>}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     get: function () {
@@ -76,7 +75,6 @@ Object.defineProperties(MetadataSchemaLoader.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     get: function () {
@@ -91,7 +89,6 @@ Object.defineProperties(MetadataSchemaLoader.prototype, {
    * @type {MetadataSchema}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   schema: {
     get: function () {
@@ -103,7 +100,6 @@ Object.defineProperties(MetadataSchemaLoader.prototype, {
 /**
  * Loads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataSchemaLoader.prototype.load = function () {
   if (defined(this._schema)) {
@@ -140,7 +136,6 @@ function loadExternalSchema(schemaLoader) {
 /**
  * Unloads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataSchemaLoader.prototype.unload = function () {
   this._schema = undefined;

--- a/Source/Scene/MetadataSchemaLoader.js
+++ b/Source/Scene/MetadataSchemaLoader.js
@@ -60,6 +60,8 @@ Object.defineProperties(MetadataSchemaLoader.prototype, {
    *
    * @type {Promise.<MetadataSchemaLoader>}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     get: function () {
@@ -73,6 +75,8 @@ Object.defineProperties(MetadataSchemaLoader.prototype, {
    *
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     get: function () {
@@ -86,6 +90,8 @@ Object.defineProperties(MetadataSchemaLoader.prototype, {
    *
    * @type {MetadataSchema}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   schema: {
     get: function () {
@@ -96,6 +102,8 @@ Object.defineProperties(MetadataSchemaLoader.prototype, {
 
 /**
  * Loads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataSchemaLoader.prototype.load = function () {
   if (defined(this._schema)) {
@@ -131,6 +139,8 @@ function loadExternalSchema(schemaLoader) {
 
 /**
  * Unloads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataSchemaLoader.prototype.unload = function () {
   this._schema = undefined;

--- a/Source/Scene/MetadataSemantic.js
+++ b/Source/Scene/MetadataSemantic.js
@@ -7,11 +7,55 @@
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 var MetadataSemantic = {
+  /**
+   * The horizon occlusion point for horizon culling, stored as an <code>ARRAY</code> of 3 <code>FLOAT32</code> or <code>FLOAT64</code> components.
+   *
+   * @see {https://cesium.com/blog/2013/04/25/horizon-culling/|Horizon Culling}
+   *
+   * @type {String}
+   * @constant
+   * @private
+   */
   HORIZON_OCCLUSION_POINT: "HORIZON_OCCLUSION_POINT",
+  /**
+   * A bounding sphere, stored as an <code>ARRAY</code> of 4 <code>FLOAT32</code> or a <code>FLOAT64</code> components. The components represent <code>[x, y, z, radius]</code>, i.e. the center and radius of the bounding sphere.
+   *
+   * @type {String}
+   * @constant
+   * @private
+   */
   BOUNDING_SPHERE: "BOUNDING_SPHERE",
+  /**
+   * A minimum height relative to some ellipsoid, stored as a <code>FLOAT32</code> or a <code>FLOAT64</code>
+   *
+   * @type {String}
+   * @constant
+   * @private
+   */
   MINIMUM_HEIGHT: "MINIMUM_HEIGHT",
+  /**
+   * A maximum height relative to some ellipsoid, stored as a <code>FLOAT32</code> or a <code>FLOAT64</code>
+   *
+   * @type {String}
+   * @constant
+   * @private
+   */
   MAXIMUM_HEIGHT: "MAXIMUM_HEIGHT",
+  /**
+   * A name, stored as a <code>STRING</code>. This does not have to be unique
+   *
+   * @type {String}
+   * @constant
+   * @private
+   */
   NAME: "NAME",
+  /**
+   * A unique identifier, stored as a <code>STRING</code>.
+   *
+   * @type {String}
+   * @constant
+   * @private
+   */
   ID: "ID",
 };
 

--- a/Source/Scene/MetadataSemantic.js
+++ b/Source/Scene/MetadataSemantic.js
@@ -4,6 +4,7 @@
  * @enum MetadataSemantic
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 var MetadataSemantic = {
   HORIZON_OCCLUSION_POINT: "HORIZON_OCCLUSION_POINT",

--- a/Source/Scene/MetadataTable.js
+++ b/Source/Scene/MetadataTable.js
@@ -18,6 +18,7 @@ import MetadataType from "./MetadataType.js";
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function MetadataTable(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -54,6 +55,7 @@ Object.defineProperties(MetadataTable.prototype, {
    * @type {Number}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   count: {
     get: function () {
@@ -68,6 +70,7 @@ Object.defineProperties(MetadataTable.prototype, {
    * @type {MetadataClass}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   class: {
     get: function () {
@@ -81,6 +84,8 @@ Object.defineProperties(MetadataTable.prototype, {
  *
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {Boolean} Whether this property exists.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataTable.prototype.hasProperty = function (propertyId) {
   return MetadataEntity.hasProperty(propertyId, this._properties, this._class);
@@ -91,6 +96,8 @@ MetadataTable.prototype.hasProperty = function (propertyId) {
  *
  * @param {String[]} [results] An array into which to store the results.
  * @returns {String[]} The property IDs.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataTable.prototype.getPropertyIds = function (results) {
   return MetadataEntity.getPropertyIds(this._properties, this._class, results);
@@ -119,6 +126,8 @@ MetadataTable.prototype.getPropertyIds = function (results) {
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
  *
  * @exception {DeveloperError} index is required and between zero and count - 1
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataTable.prototype.getProperty = function (index, propertyId) {
   //>>includeStart('debug', pragmas.debug);
@@ -165,6 +174,8 @@ MetadataTable.prototype.getProperty = function (index, propertyId) {
  * @exception {DeveloperError} value does not match type
  * @exception {DeveloperError} value is out of range for type
  * @exception {DeveloperError} Array length does not match componentCount
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataTable.prototype.setProperty = function (index, propertyId, value) {
   //>>includeStart('debug', pragmas.debug);
@@ -188,6 +199,8 @@ MetadataTable.prototype.setProperty = function (index, propertyId, value) {
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
  *
  * @exception {DeveloperError} index is required and between zero and count - 1
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataTable.prototype.getPropertyBySemantic = function (index, semantic) {
   //>>includeStart('debug', pragmas.debug);
@@ -215,6 +228,8 @@ MetadataTable.prototype.getPropertyBySemantic = function (index, semantic) {
  * @exception {DeveloperError} value does not match type
  * @exception {DeveloperError} value is out of range for type
  * @exception {DeveloperError} Array length does not match componentCount
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataTable.prototype.setPropertyBySemantic = function (
   index,

--- a/Source/Scene/MetadataTable.js
+++ b/Source/Scene/MetadataTable.js
@@ -55,7 +55,6 @@ Object.defineProperties(MetadataTable.prototype, {
    * @type {Number}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   count: {
     get: function () {
@@ -70,7 +69,6 @@ Object.defineProperties(MetadataTable.prototype, {
    * @type {MetadataClass}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   class: {
     get: function () {
@@ -85,7 +83,6 @@ Object.defineProperties(MetadataTable.prototype, {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {Boolean} Whether this property exists.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataTable.prototype.hasProperty = function (propertyId) {
   return MetadataEntity.hasProperty(propertyId, this._properties, this._class);
@@ -97,7 +94,6 @@ MetadataTable.prototype.hasProperty = function (propertyId) {
  * @param {String[]} [results] An array into which to store the results.
  * @returns {String[]} The property IDs.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataTable.prototype.getPropertyIds = function (results) {
   return MetadataEntity.getPropertyIds(this._properties, this._class, results);
@@ -127,7 +123,6 @@ MetadataTable.prototype.getPropertyIds = function (results) {
  *
  * @exception {DeveloperError} index is required and between zero and count - 1
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataTable.prototype.getProperty = function (index, propertyId) {
   //>>includeStart('debug', pragmas.debug);
@@ -175,7 +170,6 @@ MetadataTable.prototype.getProperty = function (index, propertyId) {
  * @exception {DeveloperError} value is out of range for type
  * @exception {DeveloperError} Array length does not match componentCount
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataTable.prototype.setProperty = function (index, propertyId, value) {
   //>>includeStart('debug', pragmas.debug);
@@ -200,7 +194,6 @@ MetadataTable.prototype.setProperty = function (index, propertyId, value) {
  *
  * @exception {DeveloperError} index is required and between zero and count - 1
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataTable.prototype.getPropertyBySemantic = function (index, semantic) {
   //>>includeStart('debug', pragmas.debug);
@@ -229,7 +222,6 @@ MetadataTable.prototype.getPropertyBySemantic = function (index, semantic) {
  * @exception {DeveloperError} value is out of range for type
  * @exception {DeveloperError} Array length does not match componentCount
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataTable.prototype.setPropertyBySemantic = function (
   index,

--- a/Source/Scene/MetadataTableProperty.js
+++ b/Source/Scene/MetadataTableProperty.js
@@ -152,7 +152,6 @@ Object.defineProperties(MetadataTableProperty.prototype, {
    * @type {*}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -167,7 +166,6 @@ Object.defineProperties(MetadataTableProperty.prototype, {
    * @type {*}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {
@@ -183,7 +181,6 @@ Object.defineProperties(MetadataTableProperty.prototype, {
  * @returns {*} The value of the property.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataTableProperty.prototype.get = function (index) {
   //>>includeStart('debug', pragmas.debug);
@@ -202,7 +199,6 @@ MetadataTableProperty.prototype.get = function (index) {
  * @param {*} value The value of the property.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataTableProperty.prototype.set = function (index, value) {
   var classProperty = this._classProperty;

--- a/Source/Scene/MetadataTableProperty.js
+++ b/Source/Scene/MetadataTableProperty.js
@@ -21,6 +21,7 @@ import MetadataType from "./MetadataType.js";
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function MetadataTableProperty(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -151,6 +152,7 @@ Object.defineProperties(MetadataTableProperty.prototype, {
    * @type {*}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -165,6 +167,7 @@ Object.defineProperties(MetadataTableProperty.prototype, {
    * @type {*}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {
@@ -180,6 +183,7 @@ Object.defineProperties(MetadataTableProperty.prototype, {
  * @returns {*} The value of the property.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataTableProperty.prototype.get = function (index) {
   //>>includeStart('debug', pragmas.debug);
@@ -198,6 +202,7 @@ MetadataTableProperty.prototype.get = function (index) {
  * @param {*} value The value of the property.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataTableProperty.prototype.set = function (index, value) {
   var classProperty = this._classProperty;

--- a/Source/Scene/MetadataType.js
+++ b/Source/Scene/MetadataType.js
@@ -6,6 +6,7 @@ import FeatureDetection from "../Core/FeatureDetection.js";
  * An enum of metadata types.
  *
  * @enum MetadataType
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 var MetadataType = {
   INT8: "INT8",

--- a/Source/Scene/MetadataType.js
+++ b/Source/Scene/MetadataType.js
@@ -10,19 +10,124 @@ import FeatureDetection from "../Core/FeatureDetection.js";
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 var MetadataType = {
+  /**
+   * An 8-bit signed integer
+   *
+   * @type {String}
+   * @constant
+   * @private
+   */
   INT8: "INT8",
+  /**
+   * An 8-bit unsigned integer
+   *
+   * @type {String}
+   * @constant
+   * @private
+   */
   UINT8: "UINT8",
+  /**
+   * A 16-bit signed integer
+   *
+   * @type {String}
+   * @constant
+   * @private
+   */
   INT16: "INT16",
+  /**
+   * A 16-bit unsigned integer
+   *
+   * @type {String}
+   * @constant
+   * @private
+   */
   UINT16: "UINT16",
+  /**
+   * A 32-bit signed integer
+   *
+   * @type {String}
+   * @constant
+   * @private
+   */
   INT32: "INT32",
+  /**
+   * A 32-bit unsigned integer
+   *
+   * @type {String}
+   * @constant
+   * @private
+   */
   UINT32: "UINT32",
+  /**
+   * A 64-bit signed integer. This type requires BigInt support.
+   *
+   * @see FeatureDetection.supportsBigInt
+   *
+   * @type {String}
+   * @constant
+   * @private
+   */
   INT64: "INT64",
+  /**
+   * A 64-bit signed integer. This type requires BigInt support
+   *
+   * @see FeatureDetection.supportsBigInt
+   *
+   * @type {String}
+   * @constant
+   * @private
+   */
   UINT64: "UINT64",
+  /**
+   * A 32-bit (single precision) floating point number
+   *
+   * @type {String}
+   * @constant
+   * @private
+   */
   FLOAT32: "FLOAT32",
+  /**
+   * A 64-bit (double precision) floating point number
+   *
+   * @type {String}
+   * @constant
+   * @private
+   */
   FLOAT64: "FLOAT64",
+  /**
+   * A boolean (true/false) value
+   *
+   * @type {String}
+   * @constant
+   * @private
+   */
   BOOLEAN: "BOOLEAN",
+  /**
+   * A UTF-8 encoded string value
+   *
+   * @type {String}
+   * @constant
+   * @private
+   */
   STRING: "STRING",
+  /**
+   * An enumerated value. This type is used in conjunction with a {@link MetadataEnum} to describe the valid values.
+   *
+   * @see MetadataEnum
+   *
+   * @type {String}
+   * @constant
+   * @private
+   */
   ENUM: "ENUM",
+  /**
+   * An array of values. A <code>componentType</code> property is needed to
+   * define what type of values are stored in the array.
+   *
+   * @type {String}
+   * @constant
+   * @private
+   */
   ARRAY: "ARRAY",
 };
 

--- a/Source/Scene/MetadataType.js
+++ b/Source/Scene/MetadataType.js
@@ -144,7 +144,6 @@ var MetadataType = {
  * @exception {DeveloperError} type must be a numeric type
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataType.getMinimum = function (type) {
   //>>includeStart('debug', pragmas.debug);
@@ -197,7 +196,6 @@ MetadataType.getMinimum = function (type) {
  * @exception {DeveloperError} type must be a numeric type
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataType.getMaximum = function (type) {
   //>>includeStart('debug', pragmas.debug);
@@ -246,7 +244,6 @@ MetadataType.getMaximum = function (type) {
  * @returns {Boolean} Whether the type is a numeric type.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataType.isNumericType = function (type) {
   //>>includeStart('debug', pragmas.debug);
@@ -277,7 +274,6 @@ MetadataType.isNumericType = function (type) {
  * @returns {Boolean} Whether the type is an integer type.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataType.isIntegerType = function (type) {
   //>>includeStart('debug', pragmas.debug);
@@ -306,7 +302,6 @@ MetadataType.isIntegerType = function (type) {
  * @returns {Boolean} Whether the type is an unsigned integer type.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataType.isUnsignedIntegerType = function (type) {
   //>>includeStart('debug', pragmas.debug);
@@ -331,7 +326,6 @@ MetadataType.isUnsignedIntegerType = function (type) {
  * @param {MetadataType} type The type to check
  * @return {Boolean} <code>true</code> if the type can be encoded as a vector type, or <code>false</code> otherwise
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataType.isVectorCompatible = function (type) {
   //>>includeStart('debug', pragmas.debug);
@@ -370,7 +364,6 @@ MetadataType.isVectorCompatible = function (type) {
  * @exception {DeveloperError} type must be an integer type
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataType.normalize = function (value, type) {
   //>>includeStart('debug', pragmas.debug);
@@ -404,7 +397,6 @@ MetadataType.normalize = function (value, type) {
  * @exception {DeveloperError} type must be an integer type
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataType.unnormalize = function (value, type) {
   //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/MetadataType.js
+++ b/Source/Scene/MetadataType.js
@@ -6,6 +6,7 @@ import FeatureDetection from "../Core/FeatureDetection.js";
  * An enum of metadata types.
  *
  * @enum MetadataType
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 var MetadataType = {

--- a/Source/Scene/MetadataType.js
+++ b/Source/Scene/MetadataType.js
@@ -39,6 +39,7 @@ var MetadataType = {
  * @exception {DeveloperError} type must be a numeric type
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataType.getMinimum = function (type) {
   //>>includeStart('debug', pragmas.debug);
@@ -91,6 +92,7 @@ MetadataType.getMinimum = function (type) {
  * @exception {DeveloperError} type must be a numeric type
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataType.getMaximum = function (type) {
   //>>includeStart('debug', pragmas.debug);
@@ -139,6 +141,7 @@ MetadataType.getMaximum = function (type) {
  * @returns {Boolean} Whether the type is a numeric type.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataType.isNumericType = function (type) {
   //>>includeStart('debug', pragmas.debug);
@@ -169,6 +172,7 @@ MetadataType.isNumericType = function (type) {
  * @returns {Boolean} Whether the type is an integer type.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataType.isIntegerType = function (type) {
   //>>includeStart('debug', pragmas.debug);
@@ -197,6 +201,7 @@ MetadataType.isIntegerType = function (type) {
  * @returns {Boolean} Whether the type is an unsigned integer type.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataType.isUnsignedIntegerType = function (type) {
   //>>includeStart('debug', pragmas.debug);
@@ -218,6 +223,10 @@ MetadataType.isUnsignedIntegerType = function (type) {
  * Returns whether a type can be used in a vector, i.e. the {@link Cartesian2},
  * {@link Cartesian3}, or {@link Cartesian4} classes. This includes all numeric
  * types except for types requiring 64-bits
+ * @param {MetadataType} type The type to check
+ * @return {Boolean} <code>true</code> if the type can be encoded as a vector type, or <code>false</code> otherwise
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataType.isVectorCompatible = function (type) {
   //>>includeStart('debug', pragmas.debug);
@@ -256,6 +265,7 @@ MetadataType.isVectorCompatible = function (type) {
  * @exception {DeveloperError} type must be an integer type
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataType.normalize = function (value, type) {
   //>>includeStart('debug', pragmas.debug);
@@ -289,6 +299,7 @@ MetadataType.normalize = function (value, type) {
  * @exception {DeveloperError} type must be an integer type
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 MetadataType.unnormalize = function (value, type) {
   //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/ModelComponents.js
+++ b/Source/Scene/ModelComponents.js
@@ -8,6 +8,7 @@ import AlphaMode from "./AlphaMode.js";
  * @namespace ModelComponents
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 var ModelComponents = {};
 
@@ -18,12 +19,15 @@ var ModelComponents = {};
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Quantization() {
   /**
    * Whether the quantized attribute is oct-encoded.
    *
    * @type {Boolean}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.octEncoded = false;
 
@@ -32,6 +36,8 @@ function Quantization() {
    * This is typically computed as (1 << quantizationBits) - 1
    *
    * @type {Number}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.normalizationRange = undefined;
 
@@ -39,6 +45,8 @@ function Quantization() {
    * The bottom-left corner of the quantization volume. Not applicable for oct encoded attributes.
    *
    * @type {Number|Cartesian2|Cartesian3|Cartesian4|Matrix2|Matrix3|Matrix4}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.quantizedVolumeOffset = undefined;
 
@@ -46,6 +54,8 @@ function Quantization() {
    * The dimensions of the quantization volume. Not applicable for oct encoded attributes.
    *
    * @type {Number|Cartesian2|Cartesian3|Cartesian4|Matrix2|Matrix3|Matrix4}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.quantizedVolumeDimensions = undefined;
 
@@ -53,6 +63,8 @@ function Quantization() {
    * The component data type of the quantized attribute, e.g. ComponentDatatype.UNSIGNED_SHORT.
    *
    * @type {ComponentDatatype}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.componentDatatype = undefined;
 
@@ -60,6 +72,8 @@ function Quantization() {
    * The type of the quantized attribute, e.g. AttributeType.VEC2 for oct-encoded normals.
    *
    * @type {AttributeType}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.type = undefined;
 }
@@ -71,6 +85,7 @@ function Quantization() {
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Attribute() {
   /**
@@ -92,6 +107,8 @@ function Attribute() {
    * </ul>
    *
    * @type {String}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.semantic = undefined;
 
@@ -99,6 +116,8 @@ function Attribute() {
    * The component data type of the attribute, e.g. ComponentDatatype.FLOAT.
    *
    * @type {ComponentDatatype}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.componentDatatype = undefined;
 
@@ -106,6 +125,8 @@ function Attribute() {
    * The type of the attribute, e.g. AttributeType.VEC3.
    *
    * @type {AttributeType}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.type = undefined;
 
@@ -114,6 +135,8 @@ function Attribute() {
    *
    * @type {Boolean}
    * @default false
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.normalized = false;
 
@@ -121,6 +144,8 @@ function Attribute() {
    * The number of elements.
    *
    * @type {Number}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.count = undefined;
 
@@ -128,6 +153,8 @@ function Attribute() {
    * Minimum value of each component in the attribute.
    *
    * @type {Number|Cartesian2|Cartesian3|Cartesian4|Matrix2|Matrix3|Matrix4}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.min = undefined;
 
@@ -135,6 +162,8 @@ function Attribute() {
    * Maximum value of each component in the attribute.
    *
    * @type {Number|Cartesian2|Cartesian3|Cartesian4|Matrix2|Matrix3|Matrix4}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.max = undefined;
 
@@ -142,14 +171,17 @@ function Attribute() {
    * A constant value used for all elements when typed array and buffer are undefined.
    *
    * @type {Number|Cartesian2|Cartesian3|Cartesian4|Matrix2|Matrix3|Matrix4}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.constant = undefined;
 
   /**
    * Information about the quantized attribute.
    *
-   * @alias ModelComponents.Quantization
-   * @constructor
+   * @type {ModelComponents.Quantization}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.quantization = undefined;
 
@@ -157,6 +189,8 @@ function Attribute() {
    * A typed array containing tightly-packed attribute values.
    *
    * @type {Uint8Array|Int8Array|Uint16Array|Int16Array|Uint32Array|Int32Array|Float32Array}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.typedArray = undefined;
 
@@ -164,6 +198,8 @@ function Attribute() {
    * A vertex buffer containing attribute values. Attribute values are accessed using byteOffset and byteStride.
    *
    * @type {Buffer}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.buffer = undefined;
 
@@ -172,6 +208,8 @@ function Attribute() {
    *
    * @type {Number}
    * @default 0
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.byteOffset = 0;
 
@@ -179,6 +217,8 @@ function Attribute() {
    * The byte stride of elements in the buffer. When undefined the elements are tightly packed.
    *
    * @type {Number}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.byteStride = undefined;
 }
@@ -190,12 +230,15 @@ function Attribute() {
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Indices() {
   /**
    * The index data type of the attribute, e.g. IndexDatatype.UNSIGNED_SHORT.
    *
    * @type {IndexDatatype}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.indexDatatype = undefined;
 
@@ -203,6 +246,8 @@ function Indices() {
    * The number of indices.
    *
    * @type {Number}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.count = undefined;
 
@@ -210,6 +255,8 @@ function Indices() {
    * An index buffer containing indices.
    *
    * @type {Buffer}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.buffer = undefined;
 }
@@ -222,12 +269,15 @@ function Indices() {
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function FeatureIdAttribute() {
   /**
    * The ID of the feature table that feature IDs index into.
    *
    * @type {String}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.featureTableId = undefined;
 
@@ -235,6 +285,8 @@ function FeatureIdAttribute() {
    * The semantic of the attribute containing feature IDs, e.g. "_FEATURE_ID_0".
    *
    * @type {String}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.semantic = undefined;
 
@@ -243,6 +295,8 @@ function FeatureIdAttribute() {
    *
    * @type {Number}
    * @default 0
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.constant = 0;
 
@@ -251,6 +305,8 @@ function FeatureIdAttribute() {
    *
    * @type {Number}
    * @default 0
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.divisor = 0;
 }
@@ -262,12 +318,15 @@ function FeatureIdAttribute() {
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function FeatureIdTexture() {
   /**
    * The ID of the feature table that feature IDs index into.
    *
    * @type {String}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.featureTableId = undefined;
 
@@ -275,6 +334,8 @@ function FeatureIdTexture() {
    * The texture channel containing feature IDs, may be "r", "g", "b", or "a".
    *
    * @type {String}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.channel = undefined;
 
@@ -282,6 +343,8 @@ function FeatureIdTexture() {
    * The texture containing feature IDs.
    *
    * @type {ModelComponents.Texture}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.texture = undefined;
 }
@@ -293,12 +356,15 @@ function FeatureIdTexture() {
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function MorphTarget() {
   /**
    * Attributes that are part of the morph target, e.g. positions, normals, and tangents.
    *
    * @type {ModelComponents.Attribute[]}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.attributes = [];
 }
@@ -310,12 +376,15 @@ function MorphTarget() {
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Primitive() {
   /**
    * The vertex attributes, e.g. positions, normals, etc.
    *
    * @type {ModelComponents.Attribute[]}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.attributes = [];
 
@@ -323,6 +392,8 @@ function Primitive() {
    * The morph targets.
    *
    * @type {ModelComponents.MorphTarget[]}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.morphTargets = [];
 
@@ -330,6 +401,8 @@ function Primitive() {
    * An array of weights to be applied to morph targets.
    *
    * @type {Number[]}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.morphWeights = [];
 
@@ -337,6 +410,8 @@ function Primitive() {
    * The indices.
    *
    * @type {ModelComponents.Indices}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.indices = undefined;
 
@@ -344,6 +419,8 @@ function Primitive() {
    * The material.
    *
    * @type {ModelComponents.Material}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.material = undefined;
 
@@ -351,6 +428,8 @@ function Primitive() {
    * The primitive type, e.g. PrimitiveType.TRIANGLES.
    *
    * @type {PrimitiveType}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.primitiveType = undefined;
 
@@ -358,6 +437,8 @@ function Primitive() {
    * The feature ID attributes.
    *
    * @type {ModelComponents.FeatureIdAttribute[]}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.featureIdAttributes = [];
 
@@ -365,6 +446,8 @@ function Primitive() {
    * The feature ID textures.
    *
    * @type {ModelComponents.FeatureIdTexture[]}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.featureIdTextures = [];
 
@@ -372,6 +455,8 @@ function Primitive() {
    * The feature texture IDs.
    *
    * @type {String[]}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.featureTextureIds = [];
 }
@@ -383,12 +468,15 @@ function Primitive() {
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Instances() {
   /**
    * The instance attributes, e.g. translation, rotation, scale, feature id, etc.
    *
    * @type {ModelComponents.Attribute[]}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.attributes = [];
 
@@ -396,6 +484,8 @@ function Instances() {
    * The feature ID attributes.
    *
    * @type {ModelComponents.FeatureIdAttribute[]}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.featureIdAttributes = [];
 }
@@ -407,12 +497,15 @@ function Instances() {
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Skin() {
   /**
    * The joints.
    *
    * @type {ModelComponents.Node[]}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.joints = undefined;
 
@@ -420,6 +513,8 @@ function Skin() {
    * The inverse bind matrices of the joints.
    *
    * @type {Matrix4[]}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.inverseBindMatrices = undefined;
 }
@@ -431,12 +526,15 @@ function Skin() {
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Node() {
   /**
    * The children nodes.
    *
    * @type {ModelComponents.Node[]}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.children = [];
 
@@ -444,6 +542,8 @@ function Node() {
    * The mesh primitives.
    *
    * @type {ModelComponents.Primitive[]}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.primitives = [];
 
@@ -451,6 +551,8 @@ function Node() {
    * Instances of this node.
    *
    * @type {ModelComponents.Instances}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.instances = undefined;
 
@@ -458,6 +560,8 @@ function Node() {
    * The skin.
    *
    * @type {ModelComponents.Skin}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.skin = undefined;
 
@@ -467,6 +571,8 @@ function Node() {
    * translation, rotation, and scale must all be defined.
    *
    * @type {Matrix4}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.matrix = undefined;
 
@@ -474,6 +580,8 @@ function Node() {
    * The local translation.
    *
    * @type {Cartesian3}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.translation = undefined;
 
@@ -481,6 +589,8 @@ function Node() {
    * The local rotation.
    *
    * @type {Quaternion}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.rotation = undefined;
 
@@ -488,6 +598,8 @@ function Node() {
    * The local scale.
    *
    * @type {Cartesian3}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.scale = undefined;
 }
@@ -499,12 +611,15 @@ function Node() {
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Scene() {
   /**
    * The nodes belonging to the scene.
    *
    * @type {ModelComponents.Node[]}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.nodes = [];
 }
@@ -516,12 +631,15 @@ function Scene() {
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Components() {
   /**
    * The default scene.
    *
    * @type {ModelComponents.Scene}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.scene = undefined;
 
@@ -536,6 +654,8 @@ function Components() {
    * Feature metadata containing the schema, feature tables, and feature textures.
    *
    * @type {FeatureMetadata}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.featureMetadata = undefined;
 }
@@ -547,12 +667,15 @@ function Components() {
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Texture() {
   /**
    * The underlying GPU texture.
    *
    * @type {Texture}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.texture = undefined;
 
@@ -561,6 +684,8 @@ function Texture() {
    *
    * @type {Number}
    * @default 0
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.texCoord = 0;
 
@@ -568,6 +693,8 @@ function Texture() {
    * The sampler.
    *
    * @type {Sampler}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.sampler = undefined;
 }
@@ -579,12 +706,15 @@ function Texture() {
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function MetallicRoughness() {
   /**
    * The base color texture.
    *
    * @type {ModelComponents.Texture}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.baseColorTexture = undefined;
 
@@ -592,6 +722,8 @@ function MetallicRoughness() {
    * The metallic roughness texture.
    *
    * @type {ModelComponents.Texture}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.metallicRoughnessTexture = undefined;
 
@@ -600,6 +732,8 @@ function MetallicRoughness() {
    *
    * @type {Cartesian4}
    * @default new Cartesian4(1.0, 1.0, 1.0, 1.0)
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.baseColorFactor = new Cartesian4(1.0, 1.0, 1.0, 1.0);
 
@@ -608,6 +742,8 @@ function MetallicRoughness() {
    *
    * @type {Number}
    * @default 1.0
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.metallicFactor = 1.0;
 
@@ -616,6 +752,8 @@ function MetallicRoughness() {
    *
    * @type {Number}
    * @default 1.0
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.roughnessFactor = 1.0;
 }
@@ -627,12 +765,15 @@ function MetallicRoughness() {
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function SpecularGlossiness() {
   /**
    * The diffuse texture.
    *
    * @type {ModelComponents.Texture}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.diffuseTexture = undefined;
 
@@ -640,6 +781,8 @@ function SpecularGlossiness() {
    * The specular glossiness texture.
    *
    * @type {ModelComponents.Texture}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.specularGlossinessTexture = undefined;
 
@@ -648,6 +791,8 @@ function SpecularGlossiness() {
    *
    * @type {Cartesian4}
    * @default new Cartesian4(1.0, 1.0, 1.0, 1.0)
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.diffuseFactor = new Cartesian4(1.0, 1.0, 1.0, 1.0);
 
@@ -656,6 +801,8 @@ function SpecularGlossiness() {
    *
    * @type {Cartesian3}
    * @default new Cartesian3(1.0, 1.0, 1.0, 1.0)
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.specularFactor = new Cartesian3(1.0, 1.0, 1.0);
 
@@ -664,6 +811,8 @@ function SpecularGlossiness() {
    *
    * @type {Number}
    * @default 1.0
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.glossinessFactor = 1.0;
 }
@@ -675,12 +824,15 @@ function SpecularGlossiness() {
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Material() {
   /**
    * Material properties for the PBR metallic roughness shading model.
    *
    * @type {ModelComponents.MetallicRoughness}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.metallicRoughness = undefined;
 
@@ -688,6 +840,8 @@ function Material() {
    * Material properties for the PBR specular glossiness shading model.
    *
    * @type {ModelComponents.SpecularGlossiness}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.specularGlossiness = undefined;
 
@@ -695,6 +849,8 @@ function Material() {
    * The emissive texture.
    *
    * @type {ModelComponents.Texture}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.emissiveTexture = undefined;
 
@@ -702,6 +858,8 @@ function Material() {
    * The normal texture.
    *
    * @type {ModelComponents.Texture}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.normalTexture = undefined;
 
@@ -709,6 +867,8 @@ function Material() {
    * The occlusion texture.
    *
    * @type {ModelComponents.Texture}
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.occlusionTexture = undefined;
 
@@ -717,6 +877,8 @@ function Material() {
    *
    * @type {Cartesian3}
    * @default Cartesian3.ZERO
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.emissiveFactor = new Cartesian3(0.0, 0.0, 0.0);
 
@@ -725,6 +887,8 @@ function Material() {
    *
    * @type {AlphaMode}
    * @default AlphaMode.OPAQUE
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.alphaMode = AlphaMode.OPAQUE;
 
@@ -733,6 +897,8 @@ function Material() {
    *
    * @type {Number}
    * @default 0.5
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.alphaCutoff = 0.5;
 
@@ -741,6 +907,8 @@ function Material() {
    *
    * @type {Boolean}
    * @default false
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.doubleSided = false;
 
@@ -749,6 +917,8 @@ function Material() {
    *
    * @type {Boolean}
    * @default false
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.unlit = false;
 }

--- a/Source/Scene/ModelComponents.js
+++ b/Source/Scene/ModelComponents.js
@@ -8,7 +8,6 @@ import AlphaMode from "./AlphaMode.js";
  * @namespace ModelComponents
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 var ModelComponents = {};
 
@@ -19,7 +18,6 @@ var ModelComponents = {};
  * @constructor
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Quantization() {
   /**
@@ -27,7 +25,6 @@ function Quantization() {
    *
    * @type {Boolean}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.octEncoded = false;
 
@@ -37,7 +34,6 @@ function Quantization() {
    *
    * @type {Number}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.normalizationRange = undefined;
 
@@ -46,7 +42,6 @@ function Quantization() {
    *
    * @type {Number|Cartesian2|Cartesian3|Cartesian4|Matrix2|Matrix3|Matrix4}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.quantizedVolumeOffset = undefined;
 
@@ -55,7 +50,6 @@ function Quantization() {
    *
    * @type {Number|Cartesian2|Cartesian3|Cartesian4|Matrix2|Matrix3|Matrix4}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.quantizedVolumeDimensions = undefined;
 
@@ -64,7 +58,6 @@ function Quantization() {
    *
    * @type {ComponentDatatype}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.componentDatatype = undefined;
 
@@ -73,7 +66,6 @@ function Quantization() {
    *
    * @type {AttributeType}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.type = undefined;
 }
@@ -85,7 +77,6 @@ function Quantization() {
  * @constructor
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Attribute() {
   /**
@@ -108,7 +99,6 @@ function Attribute() {
    *
    * @type {String}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.semantic = undefined;
 
@@ -117,7 +107,6 @@ function Attribute() {
    *
    * @type {ComponentDatatype}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.componentDatatype = undefined;
 
@@ -126,7 +115,6 @@ function Attribute() {
    *
    * @type {AttributeType}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.type = undefined;
 
@@ -136,7 +124,6 @@ function Attribute() {
    * @type {Boolean}
    * @default false
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.normalized = false;
 
@@ -145,7 +132,6 @@ function Attribute() {
    *
    * @type {Number}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.count = undefined;
 
@@ -154,7 +140,6 @@ function Attribute() {
    *
    * @type {Number|Cartesian2|Cartesian3|Cartesian4|Matrix2|Matrix3|Matrix4}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.min = undefined;
 
@@ -163,7 +148,6 @@ function Attribute() {
    *
    * @type {Number|Cartesian2|Cartesian3|Cartesian4|Matrix2|Matrix3|Matrix4}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.max = undefined;
 
@@ -172,7 +156,6 @@ function Attribute() {
    *
    * @type {Number|Cartesian2|Cartesian3|Cartesian4|Matrix2|Matrix3|Matrix4}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.constant = undefined;
 
@@ -181,7 +164,6 @@ function Attribute() {
    *
    * @type {ModelComponents.Quantization}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.quantization = undefined;
 
@@ -190,7 +172,6 @@ function Attribute() {
    *
    * @type {Uint8Array|Int8Array|Uint16Array|Int16Array|Uint32Array|Int32Array|Float32Array}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.typedArray = undefined;
 
@@ -199,7 +180,6 @@ function Attribute() {
    *
    * @type {Buffer}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.buffer = undefined;
 
@@ -209,7 +189,6 @@ function Attribute() {
    * @type {Number}
    * @default 0
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.byteOffset = 0;
 
@@ -218,7 +197,6 @@ function Attribute() {
    *
    * @type {Number}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.byteStride = undefined;
 }
@@ -230,7 +208,6 @@ function Attribute() {
  * @constructor
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Indices() {
   /**
@@ -238,7 +215,6 @@ function Indices() {
    *
    * @type {IndexDatatype}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.indexDatatype = undefined;
 
@@ -247,7 +223,6 @@ function Indices() {
    *
    * @type {Number}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.count = undefined;
 
@@ -256,7 +231,6 @@ function Indices() {
    *
    * @type {Buffer}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.buffer = undefined;
 }
@@ -269,7 +243,6 @@ function Indices() {
  * @constructor
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function FeatureIdAttribute() {
   /**
@@ -277,7 +250,6 @@ function FeatureIdAttribute() {
    *
    * @type {String}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.featureTableId = undefined;
 
@@ -286,7 +258,6 @@ function FeatureIdAttribute() {
    *
    * @type {String}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.semantic = undefined;
 
@@ -296,7 +267,6 @@ function FeatureIdAttribute() {
    * @type {Number}
    * @default 0
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.constant = 0;
 
@@ -306,7 +276,6 @@ function FeatureIdAttribute() {
    * @type {Number}
    * @default 0
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.divisor = 0;
 }
@@ -318,7 +287,6 @@ function FeatureIdAttribute() {
  * @constructor
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function FeatureIdTexture() {
   /**
@@ -326,7 +294,6 @@ function FeatureIdTexture() {
    *
    * @type {String}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.featureTableId = undefined;
 
@@ -335,7 +302,6 @@ function FeatureIdTexture() {
    *
    * @type {String}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.channel = undefined;
 
@@ -344,7 +310,6 @@ function FeatureIdTexture() {
    *
    * @type {ModelComponents.Texture}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.texture = undefined;
 }
@@ -356,7 +321,6 @@ function FeatureIdTexture() {
  * @constructor
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function MorphTarget() {
   /**
@@ -364,7 +328,6 @@ function MorphTarget() {
    *
    * @type {ModelComponents.Attribute[]}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.attributes = [];
 }
@@ -376,7 +339,6 @@ function MorphTarget() {
  * @constructor
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Primitive() {
   /**
@@ -384,7 +346,6 @@ function Primitive() {
    *
    * @type {ModelComponents.Attribute[]}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.attributes = [];
 
@@ -393,7 +354,6 @@ function Primitive() {
    *
    * @type {ModelComponents.MorphTarget[]}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.morphTargets = [];
 
@@ -402,7 +362,6 @@ function Primitive() {
    *
    * @type {Number[]}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.morphWeights = [];
 
@@ -411,7 +370,6 @@ function Primitive() {
    *
    * @type {ModelComponents.Indices}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.indices = undefined;
 
@@ -420,7 +378,6 @@ function Primitive() {
    *
    * @type {ModelComponents.Material}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.material = undefined;
 
@@ -429,7 +386,6 @@ function Primitive() {
    *
    * @type {PrimitiveType}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.primitiveType = undefined;
 
@@ -438,7 +394,6 @@ function Primitive() {
    *
    * @type {ModelComponents.FeatureIdAttribute[]}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.featureIdAttributes = [];
 
@@ -447,7 +402,6 @@ function Primitive() {
    *
    * @type {ModelComponents.FeatureIdTexture[]}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.featureIdTextures = [];
 
@@ -456,7 +410,6 @@ function Primitive() {
    *
    * @type {String[]}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.featureTextureIds = [];
 }
@@ -468,7 +421,6 @@ function Primitive() {
  * @constructor
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Instances() {
   /**
@@ -476,7 +428,6 @@ function Instances() {
    *
    * @type {ModelComponents.Attribute[]}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.attributes = [];
 
@@ -485,7 +436,6 @@ function Instances() {
    *
    * @type {ModelComponents.FeatureIdAttribute[]}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.featureIdAttributes = [];
 }
@@ -497,7 +447,6 @@ function Instances() {
  * @constructor
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Skin() {
   /**
@@ -505,7 +454,6 @@ function Skin() {
    *
    * @type {ModelComponents.Node[]}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.joints = undefined;
 
@@ -514,7 +462,6 @@ function Skin() {
    *
    * @type {Matrix4[]}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.inverseBindMatrices = undefined;
 }
@@ -526,7 +473,6 @@ function Skin() {
  * @constructor
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Node() {
   /**
@@ -534,7 +480,6 @@ function Node() {
    *
    * @type {ModelComponents.Node[]}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.children = [];
 
@@ -543,7 +488,6 @@ function Node() {
    *
    * @type {ModelComponents.Primitive[]}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.primitives = [];
 
@@ -552,7 +496,6 @@ function Node() {
    *
    * @type {ModelComponents.Instances}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.instances = undefined;
 
@@ -561,7 +504,6 @@ function Node() {
    *
    * @type {ModelComponents.Skin}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.skin = undefined;
 
@@ -572,7 +514,6 @@ function Node() {
    *
    * @type {Matrix4}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.matrix = undefined;
 
@@ -581,7 +522,6 @@ function Node() {
    *
    * @type {Cartesian3}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.translation = undefined;
 
@@ -590,7 +530,6 @@ function Node() {
    *
    * @type {Quaternion}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.rotation = undefined;
 
@@ -599,7 +538,6 @@ function Node() {
    *
    * @type {Cartesian3}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.scale = undefined;
 }
@@ -611,7 +549,6 @@ function Node() {
  * @constructor
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Scene() {
   /**
@@ -619,7 +556,6 @@ function Scene() {
    *
    * @type {ModelComponents.Node[]}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.nodes = [];
 }
@@ -631,7 +567,6 @@ function Scene() {
  * @constructor
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Components() {
   /**
@@ -639,7 +574,6 @@ function Components() {
    *
    * @type {ModelComponents.Scene}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.scene = undefined;
 
@@ -655,7 +589,6 @@ function Components() {
    *
    * @type {FeatureMetadata}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.featureMetadata = undefined;
 }
@@ -667,7 +600,6 @@ function Components() {
  * @constructor
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Texture() {
   /**
@@ -675,7 +607,6 @@ function Texture() {
    *
    * @type {Texture}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.texture = undefined;
 
@@ -685,7 +616,6 @@ function Texture() {
    * @type {Number}
    * @default 0
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.texCoord = 0;
 
@@ -694,7 +624,6 @@ function Texture() {
    *
    * @type {Sampler}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.sampler = undefined;
 }
@@ -706,7 +635,6 @@ function Texture() {
  * @constructor
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function MetallicRoughness() {
   /**
@@ -714,7 +642,6 @@ function MetallicRoughness() {
    *
    * @type {ModelComponents.Texture}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.baseColorTexture = undefined;
 
@@ -723,7 +650,6 @@ function MetallicRoughness() {
    *
    * @type {ModelComponents.Texture}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.metallicRoughnessTexture = undefined;
 
@@ -733,7 +659,6 @@ function MetallicRoughness() {
    * @type {Cartesian4}
    * @default new Cartesian4(1.0, 1.0, 1.0, 1.0)
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.baseColorFactor = new Cartesian4(1.0, 1.0, 1.0, 1.0);
 
@@ -743,7 +668,6 @@ function MetallicRoughness() {
    * @type {Number}
    * @default 1.0
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.metallicFactor = 1.0;
 
@@ -753,7 +677,6 @@ function MetallicRoughness() {
    * @type {Number}
    * @default 1.0
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.roughnessFactor = 1.0;
 }
@@ -765,7 +688,6 @@ function MetallicRoughness() {
  * @constructor
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function SpecularGlossiness() {
   /**
@@ -773,7 +695,6 @@ function SpecularGlossiness() {
    *
    * @type {ModelComponents.Texture}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.diffuseTexture = undefined;
 
@@ -782,7 +703,6 @@ function SpecularGlossiness() {
    *
    * @type {ModelComponents.Texture}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.specularGlossinessTexture = undefined;
 
@@ -792,7 +712,6 @@ function SpecularGlossiness() {
    * @type {Cartesian4}
    * @default new Cartesian4(1.0, 1.0, 1.0, 1.0)
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.diffuseFactor = new Cartesian4(1.0, 1.0, 1.0, 1.0);
 
@@ -802,7 +721,6 @@ function SpecularGlossiness() {
    * @type {Cartesian3}
    * @default new Cartesian3(1.0, 1.0, 1.0, 1.0)
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.specularFactor = new Cartesian3(1.0, 1.0, 1.0);
 
@@ -812,7 +730,6 @@ function SpecularGlossiness() {
    * @type {Number}
    * @default 1.0
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.glossinessFactor = 1.0;
 }
@@ -824,7 +741,6 @@ function SpecularGlossiness() {
  * @constructor
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function Material() {
   /**
@@ -832,7 +748,6 @@ function Material() {
    *
    * @type {ModelComponents.MetallicRoughness}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.metallicRoughness = undefined;
 
@@ -841,7 +756,6 @@ function Material() {
    *
    * @type {ModelComponents.SpecularGlossiness}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.specularGlossiness = undefined;
 
@@ -850,7 +764,6 @@ function Material() {
    *
    * @type {ModelComponents.Texture}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.emissiveTexture = undefined;
 
@@ -859,7 +772,6 @@ function Material() {
    *
    * @type {ModelComponents.Texture}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.normalTexture = undefined;
 
@@ -868,7 +780,6 @@ function Material() {
    *
    * @type {ModelComponents.Texture}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.occlusionTexture = undefined;
 
@@ -878,7 +789,6 @@ function Material() {
    * @type {Cartesian3}
    * @default Cartesian3.ZERO
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.emissiveFactor = new Cartesian3(0.0, 0.0, 0.0);
 
@@ -888,7 +798,6 @@ function Material() {
    * @type {AlphaMode}
    * @default AlphaMode.OPAQUE
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.alphaMode = AlphaMode.OPAQUE;
 
@@ -898,7 +807,6 @@ function Material() {
    * @type {Number}
    * @default 0.5
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.alphaCutoff = 0.5;
 
@@ -908,7 +816,6 @@ function Material() {
    * @type {Boolean}
    * @default false
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.doubleSided = false;
 
@@ -918,7 +825,6 @@ function Material() {
    * @type {Boolean}
    * @default false
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   this.unlit = false;
 }

--- a/Source/Scene/Multiple3DTileContent.js
+++ b/Source/Scene/Multiple3DTileContent.js
@@ -84,7 +84,6 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    * @type {Boolean}
    *
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   featurePropertiesDirty: {
     get: function () {
@@ -112,7 +111,6 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    * always returns <code>0</code>.  Instead call <code>featuresLength</code> for a specific inner content.
    * @memberof Multiple3DTileContent.prototype
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   featuresLength: {
     get: function () {
@@ -125,7 +123,6 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    * always returns <code>0</code>.  Instead, call <code>pointsLength</code> for a specific inner content.
    * @memberof Multiple3DTileContent.prototype
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   pointsLength: {
     get: function () {
@@ -138,7 +135,6 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    * always returns <code>0</code>.  Instead call <code>trianglesLength</code> for a specific inner content.
    * @memberof Multiple3DTileContent.prototype
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   trianglesLength: {
     get: function () {
@@ -151,7 +147,6 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    * always returns <code>0</code>.  Instead call <code>geometryByteLength</code> for a specific inner content.
    * @memberof Multiple3DTileContent.prototype
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   geometryByteLength: {
     get: function () {
@@ -164,7 +159,6 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    * always returns <code>0</code>.  Instead call <code>texturesByteLength</code> for a specific inner content.
    * @memberof Multiple3DTileContent.prototype
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   texturesByteLength: {
     get: function () {
@@ -177,7 +171,6 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    * always returns <code>0</code>.  Instead call <code>batchTableByteLength</code> for a specific inner content.
    * @memberof Multiple3DTileContent.prototype
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   batchTableByteLength: {
     get: function () {
@@ -218,7 +211,6 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   url: {
     get: function () {
@@ -231,7 +223,6 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    * always returns <code>undefined</code>.  Instead call <code>batchTable</code> for a specific inner content.
    * @memberof Multiple3DTileContent.prototype
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   batchTable: {
     get: function () {
@@ -244,7 +235,6 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    * always returns <code>undefined</code>.  Instead call <code>groupMetadata</code> for a specific inner content.
    * @memberof Multiple3DTileContent.prototype
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   groupMetadata: {
     get: function () {
@@ -266,7 +256,6 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    * @type {String[]}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   innerContentUrls: {
     get: function () {
@@ -284,7 +273,6 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    *
    * @type {Promise}
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   contentsFetchedPromise: {
     get: function () {
@@ -328,7 +316,6 @@ function cancelPendingRequests(multipleContents, originalContentState) {
  *
  * @return {Number} The number of attempted requests that were unable to be scheduled.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 Multiple3DTileContent.prototype.requestInnerContents = function () {
   // It's possible for these promises to leak content array buffers if the
@@ -573,7 +560,6 @@ function handleInnerContentFailed(multipleContents, index, error) {
  * when a tile goes out of view.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 Multiple3DTileContent.prototype.cancelRequests = function () {
   for (var i = 0; i < this._requests.length; i++) {
@@ -588,7 +574,6 @@ Multiple3DTileContent.prototype.cancelRequests = function () {
  * Part of the {@link Cesium3DTileContent} interface.  <code>Multiple3DTileContent</code>
  * always returns <code>false</code>.  Instead call <code>hasProperty</code> for a specific inner content
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 Multiple3DTileContent.prototype.hasProperty = function (batchId, name) {
   return false;
@@ -598,7 +583,6 @@ Multiple3DTileContent.prototype.hasProperty = function (batchId, name) {
  * Part of the {@link Cesium3DTileContent} interface.  <code>Multiple3DTileContent</code>
  * always returns <code>undefined</code>.  Instead call <code>getFeature</code> for a specific inner content
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 Multiple3DTileContent.prototype.getFeature = function (batchId) {
   return undefined;

--- a/Source/Scene/Multiple3DTileContent.js
+++ b/Source/Scene/Multiple3DTileContent.js
@@ -29,6 +29,7 @@ import preprocess3DTileContent from "./preprocess3DTileContent.js";
  * @param {Object} extensionJson The <code>3DTILES_multiple_contents</code> extension JSON
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function Multiple3DTileContent(
   tileset,
@@ -83,6 +84,7 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    * @type {Boolean}
    *
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   featurePropertiesDirty: {
     get: function () {
@@ -109,6 +111,8 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    * Part of the {@link Cesium3DTileContent} interface.  <code>Multiple3DTileContent</code>
    * always returns <code>0</code>.  Instead call <code>featuresLength</code> for a specific inner content.
    * @memberof Multiple3DTileContent.prototype
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   featuresLength: {
     get: function () {
@@ -120,6 +124,8 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    * Part of the {@link Cesium3DTileContent} interface.  <code>Multiple3DTileContent</code>
    * always returns <code>0</code>.  Instead, call <code>pointsLength</code> for a specific inner content.
    * @memberof Multiple3DTileContent.prototype
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   pointsLength: {
     get: function () {
@@ -131,6 +137,8 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    * Part of the {@link Cesium3DTileContent} interface.  <code>Multiple3DTileContent</code>
    * always returns <code>0</code>.  Instead call <code>trianglesLength</code> for a specific inner content.
    * @memberof Multiple3DTileContent.prototype
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   trianglesLength: {
     get: function () {
@@ -142,6 +150,8 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    * Part of the {@link Cesium3DTileContent} interface.  <code>Multiple3DTileContent</code>
    * always returns <code>0</code>.  Instead call <code>geometryByteLength</code> for a specific inner content.
    * @memberof Multiple3DTileContent.prototype
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   geometryByteLength: {
     get: function () {
@@ -153,6 +163,8 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    * Part of the {@link Cesium3DTileContent} interface.   <code>Multiple3DTileContent</code>
    * always returns <code>0</code>.  Instead call <code>texturesByteLength</code> for a specific inner content.
    * @memberof Multiple3DTileContent.prototype
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   texturesByteLength: {
     get: function () {
@@ -164,6 +176,8 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    * Part of the {@link Cesium3DTileContent} interface.  <code>Multiple3DTileContent</code>
    * always returns <code>0</code>.  Instead call <code>batchTableByteLength</code> for a specific inner content.
    * @memberof Multiple3DTileContent.prototype
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   batchTableByteLength: {
     get: function () {
@@ -203,6 +217,8 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    *
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   url: {
     get: function () {
@@ -215,6 +231,7 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    * always returns <code>undefined</code>.  Instead call <code>batchTable</code> for a specific inner content.
    * @memberof Multiple3DTileContent.prototype
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   batchTable: {
     get: function () {
@@ -227,6 +244,7 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    * always returns <code>undefined</code>.  Instead call <code>groupMetadata</code> for a specific inner content.
    * @memberof Multiple3DTileContent.prototype
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   groupMetadata: {
     get: function () {
@@ -248,6 +266,7 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    * @type {String[]}
    * @readonly
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   innerContentUrls: {
     get: function () {
@@ -265,6 +284,7 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    *
    * @type {Promise}
    * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   contentsFetchedPromise: {
     get: function () {
@@ -308,6 +328,7 @@ function cancelPendingRequests(multipleContents, originalContentState) {
  *
  * @return {Number} The number of attempted requests that were unable to be scheduled.
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 Multiple3DTileContent.prototype.requestInnerContents = function () {
   // It's possible for these promises to leak content array buffers if the
@@ -552,6 +573,7 @@ function handleInnerContentFailed(multipleContents, index, error) {
  * when a tile goes out of view.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 Multiple3DTileContent.prototype.cancelRequests = function () {
   for (var i = 0; i < this._requests.length; i++) {
@@ -566,6 +588,7 @@ Multiple3DTileContent.prototype.cancelRequests = function () {
  * Part of the {@link Cesium3DTileContent} interface.  <code>Multiple3DTileContent</code>
  * always returns <code>false</code>.  Instead call <code>hasProperty</code> for a specific inner content
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 Multiple3DTileContent.prototype.hasProperty = function (batchId, name) {
   return false;
@@ -575,6 +598,7 @@ Multiple3DTileContent.prototype.hasProperty = function (batchId, name) {
  * Part of the {@link Cesium3DTileContent} interface.  <code>Multiple3DTileContent</code>
  * always returns <code>undefined</code>.  Instead call <code>getFeature</code> for a specific inner content
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 Multiple3DTileContent.prototype.getFeature = function (batchId) {
   return undefined;

--- a/Source/Scene/ResourceCache.js
+++ b/Source/Scene/ResourceCache.js
@@ -19,7 +19,6 @@ import ResourceCacheKey from "./ResourceCacheKey.js";
  * @namespace ResourceCache
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function ResourceCache() {}
 
@@ -34,7 +33,6 @@ ResourceCache.cacheEntries = {};
  * @constructor
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function CacheEntry(resourceLoader) {
   this.referenceCount = 1;
@@ -49,7 +47,6 @@ function CacheEntry(resourceLoader) {
  *
  * @returns {ResourceLoader|undefined} The resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.get = function (cacheKey) {
   //>>includeStart('debug', pragmas.debug);
@@ -72,7 +69,6 @@ ResourceCache.get = function (cacheKey) {
  *
  * @exception {DeveloperError} Resource with this cacheKey is already in the cach
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.load = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -108,7 +104,6 @@ ResourceCache.load = function (options) {
  * @exception {DeveloperError} Resource is not in the cache.
  * @exception {DeveloperError} Cannot unload resource that has no references.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.unload = function (resourceLoader) {
   //>>includeStart('debug', pragmas.debug);
@@ -143,7 +138,6 @@ ResourceCache.unload = function (resourceLoader) {
  *
  * @exception {DeveloperError} One of options.schema and options.resource must be defined.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.loadSchema = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -191,7 +185,6 @@ ResourceCache.loadSchema = function (options) {
  *
  * @returns {BufferLoader} The buffer loader.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.loadEmbeddedBuffer = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -238,7 +231,6 @@ ResourceCache.loadEmbeddedBuffer = function (options) {
  *
  * @returns {BufferLoader} The buffer loader.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.loadExternalBuffer = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -279,7 +271,6 @@ ResourceCache.loadExternalBuffer = function (options) {
  *
  * @returns {GltfJsonLoader} The glTF JSON.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.loadGltfJson = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -327,7 +318,6 @@ ResourceCache.loadGltfJson = function (options) {
  *
  * @returns {GltfBufferViewLoader} The buffer view loader.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.loadBufferView = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -382,7 +372,6 @@ ResourceCache.loadBufferView = function (options) {
  *
  * @returns {GltfDracoLoader} The Draco loader.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.loadDraco = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -445,7 +434,6 @@ ResourceCache.loadDraco = function (options) {
  *
  * @returns {GltfVertexBufferLoader} The vertex buffer loader.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.loadVertexBuffer = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -543,7 +531,6 @@ ResourceCache.loadVertexBuffer = function (options) {
  *
  * @returns {GltfIndexBufferLoader} The index buffer loader.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.loadIndexBuffer = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -604,7 +591,6 @@ ResourceCache.loadIndexBuffer = function (options) {
  *
  * @returns {GltfImageLoader} The image loader.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.loadImage = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -665,7 +651,6 @@ ResourceCache.loadImage = function (options) {
  *
  * @returns {GltfTextureLoader} The texture loader.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.loadTexture = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -718,7 +703,6 @@ ResourceCache.loadTexture = function (options) {
  * Unload everything from the cache. This is used for unit testing.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.clearForSpecs = function () {
   // Unload in the order below. This prevents an unload function from unloading

--- a/Source/Scene/ResourceCache.js
+++ b/Source/Scene/ResourceCache.js
@@ -19,6 +19,7 @@ import ResourceCacheKey from "./ResourceCacheKey.js";
  * @namespace ResourceCache
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function ResourceCache() {}
 
@@ -33,6 +34,7 @@ ResourceCache.cacheEntries = {};
  * @constructor
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function CacheEntry(resourceLoader) {
   this.referenceCount = 1;
@@ -46,6 +48,8 @@ function CacheEntry(resourceLoader) {
  * @param {String} cacheKey The cache key of the resource.
  *
  * @returns {ResourceLoader|undefined} The resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.get = function (cacheKey) {
   //>>includeStart('debug', pragmas.debug);
@@ -66,7 +70,9 @@ ResourceCache.get = function (cacheKey) {
  * @param {Object} options Object with the following properties:
  * @param {ResourceLoader} options.resourceLoader The resource.
  *
- * @exception {DeveloperError} Resource with this cacheKey is already in the cache.
+ * @exception {DeveloperError} Resource with this cacheKey is already in the cach
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.load = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -101,6 +107,8 @@ ResourceCache.load = function (options) {
  *
  * @exception {DeveloperError} Resource is not in the cache.
  * @exception {DeveloperError} Cannot unload resource that has no references.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.unload = function (resourceLoader) {
   //>>includeStart('debug', pragmas.debug);
@@ -134,6 +142,8 @@ ResourceCache.unload = function (resourceLoader) {
  * @returns {MetadataSchemaLoader} The schema resource.
  *
  * @exception {DeveloperError} One of options.schema and options.resource must be defined.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.loadSchema = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -180,6 +190,8 @@ ResourceCache.loadSchema = function (options) {
  * @param {Uint8Array} [options.typedArray] The typed array containing the embedded buffer contents.
  *
  * @returns {BufferLoader} The buffer loader.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.loadEmbeddedBuffer = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -225,6 +237,8 @@ ResourceCache.loadEmbeddedBuffer = function (options) {
  * @param {Resource} options.resource The {@link Resource} pointing to the external buffer.
  *
  * @returns {BufferLoader} The buffer loader.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.loadExternalBuffer = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -264,6 +278,8 @@ ResourceCache.loadExternalBuffer = function (options) {
  * @param {Uint8Array} [options.typedArray] The typed array containing the glTF contents.
  *
  * @returns {GltfJsonLoader} The glTF JSON.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.loadGltfJson = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -310,6 +326,8 @@ ResourceCache.loadGltfJson = function (options) {
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  *
  * @returns {GltfBufferViewLoader} The buffer view loader.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.loadBufferView = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -363,6 +381,8 @@ ResourceCache.loadBufferView = function (options) {
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  *
  * @returns {GltfDracoLoader} The Draco loader.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.loadDraco = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -424,6 +444,8 @@ ResourceCache.loadDraco = function (options) {
  * @exception {DeveloperError} When options.draco is defined options.dracoAccessorId must also be defined.
  *
  * @returns {GltfVertexBufferLoader} The vertex buffer loader.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.loadVertexBuffer = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -520,6 +542,8 @@ ResourceCache.loadVertexBuffer = function (options) {
  * @param {Boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
  *
  * @returns {GltfIndexBufferLoader} The index buffer loader.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.loadIndexBuffer = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -579,6 +603,8 @@ ResourceCache.loadIndexBuffer = function (options) {
  * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
  *
  * @returns {GltfImageLoader} The image loader.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.loadImage = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -638,6 +664,8 @@ ResourceCache.loadImage = function (options) {
  * @param {Boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
  *
  * @returns {GltfTextureLoader} The texture loader.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.loadTexture = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -690,6 +718,7 @@ ResourceCache.loadTexture = function (options) {
  * Unload everything from the cache. This is used for unit testing.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCache.clearForSpecs = function () {
   // Unload in the order below. This prevents an unload function from unloading

--- a/Source/Scene/ResourceCacheKey.js
+++ b/Source/Scene/ResourceCacheKey.js
@@ -11,7 +11,6 @@ import GltfLoaderUtil from "./GltfLoaderUtil.js";
  * @namespace ResourceCacheKey
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 var ResourceCacheKey = {};
 
@@ -138,7 +137,6 @@ function getSamplerCacheKey(gltf, textureInfo) {
  *
  * @exception {DeveloperError} One of options.schema and options.resource must be defined.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCacheKey.getSchemaCacheKey = function (options) {
   var schema = options.schema;
@@ -167,7 +165,6 @@ ResourceCacheKey.getSchemaCacheKey = function (options) {
  *
  * @returns {String} The external buffer cache key.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCacheKey.getExternalBufferCacheKey = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -189,7 +186,6 @@ ResourceCacheKey.getExternalBufferCacheKey = function (options) {
  *
  * @returns {String} The embedded buffer cache key.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCacheKey.getEmbeddedBufferCacheKey = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -214,7 +210,6 @@ ResourceCacheKey.getEmbeddedBufferCacheKey = function (options) {
  *
  * @returns {String} The glTF cache key.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCacheKey.getGltfCacheKey = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -238,7 +233,6 @@ ResourceCacheKey.getGltfCacheKey = function (options) {
  *
  * @returns {String} The buffer view cache key.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCacheKey.getBufferViewCacheKey = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -281,7 +275,6 @@ ResourceCacheKey.getBufferViewCacheKey = function (options) {
  *
  * @returns {String} The Draco cache key.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCacheKey.getDracoCacheKey = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -316,7 +309,6 @@ ResourceCacheKey.getDracoCacheKey = function (options) {
  *
  * @returns {String} The vertex buffer cache key.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCacheKey.getVertexBufferCacheKey = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -397,7 +389,6 @@ ResourceCacheKey.getVertexBufferCacheKey = function (options) {
  *
  * @returns {String} The index buffer cache key.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCacheKey.getIndexBufferCacheKey = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -454,7 +445,6 @@ ResourceCacheKey.getIndexBufferCacheKey = function (options) {
  *
  * @returns {String} The image cache key.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCacheKey.getImageCacheKey = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -495,7 +485,6 @@ ResourceCacheKey.getImageCacheKey = function (options) {
  *
  * @returns {String} The texture cache key.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCacheKey.getTextureCacheKey = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/Source/Scene/ResourceCacheKey.js
+++ b/Source/Scene/ResourceCacheKey.js
@@ -11,6 +11,7 @@ import GltfLoaderUtil from "./GltfLoaderUtil.js";
  * @namespace ResourceCacheKey
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 var ResourceCacheKey = {};
 
@@ -136,6 +137,8 @@ function getSamplerCacheKey(gltf, textureInfo) {
  * @returns {String} The schema cache key.
  *
  * @exception {DeveloperError} One of options.schema and options.resource must be defined.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCacheKey.getSchemaCacheKey = function (options) {
   var schema = options.schema;
@@ -163,6 +166,8 @@ ResourceCacheKey.getSchemaCacheKey = function (options) {
  * @param {Resource} options.resource The {@link Resource} pointing to the external buffer.
  *
  * @returns {String} The external buffer cache key.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCacheKey.getExternalBufferCacheKey = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -183,6 +188,8 @@ ResourceCacheKey.getExternalBufferCacheKey = function (options) {
  * @param {Number} options.bufferId A unique identifier of the embedded buffer within the parent resource.
  *
  * @returns {String} The embedded buffer cache key.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCacheKey.getEmbeddedBufferCacheKey = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -206,6 +213,8 @@ ResourceCacheKey.getEmbeddedBufferCacheKey = function (options) {
  * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  *
  * @returns {String} The glTF cache key.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCacheKey.getGltfCacheKey = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -228,6 +237,8 @@ ResourceCacheKey.getGltfCacheKey = function (options) {
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  *
  * @returns {String} The buffer view cache key.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCacheKey.getBufferViewCacheKey = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -269,6 +280,8 @@ ResourceCacheKey.getBufferViewCacheKey = function (options) {
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  *
  * @returns {String} The Draco cache key.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCacheKey.getDracoCacheKey = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -302,6 +315,8 @@ ResourceCacheKey.getDracoCacheKey = function (options) {
  * @exception {DeveloperError} When options.draco is defined options.dracoAttributeSemantic must also be defined.
  *
  * @returns {String} The vertex buffer cache key.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCacheKey.getVertexBufferCacheKey = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -381,6 +396,8 @@ ResourceCacheKey.getVertexBufferCacheKey = function (options) {
  * @param {Object} [options.draco] The Draco extension object.
  *
  * @returns {String} The index buffer cache key.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCacheKey.getIndexBufferCacheKey = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -436,6 +453,8 @@ ResourceCacheKey.getIndexBufferCacheKey = function (options) {
  * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
  *
  * @returns {String} The image cache key.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCacheKey.getImageCacheKey = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -475,6 +494,8 @@ ResourceCacheKey.getImageCacheKey = function (options) {
  * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
  *
  * @returns {String} The texture cache key.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceCacheKey.getTextureCacheKey = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/Source/Scene/ResourceLoader.js
+++ b/Source/Scene/ResourceLoader.js
@@ -16,6 +16,7 @@ import RuntimeError from "../Core/RuntimeError.js";
  * @see ResourceCache
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function ResourceLoader() {}
 
@@ -27,6 +28,8 @@ Object.defineProperties(ResourceLoader.prototype, {
    *
    * @type {Promise.<ResourceLoader>}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     // eslint-disable-next-line getter-return
@@ -41,6 +44,8 @@ Object.defineProperties(ResourceLoader.prototype, {
    *
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     // eslint-disable-next-line getter-return
@@ -52,6 +57,8 @@ Object.defineProperties(ResourceLoader.prototype, {
 
 /**
  * Loads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceLoader.prototype.load = function () {
   DeveloperError.throwInstantiationError();
@@ -59,6 +66,8 @@ ResourceLoader.prototype.load = function () {
 
 /**
  * Unloads the resource.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceLoader.prototype.unload = function () {};
 
@@ -66,6 +75,8 @@ ResourceLoader.prototype.unload = function () {};
  * Processes the resource until it becomes ready.
  *
  * @param {FrameState} frameState The frame state.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceLoader.prototype.process = function (frameState) {};
 
@@ -76,6 +87,8 @@ ResourceLoader.prototype.process = function (frameState) {};
  * @param {Error} [error] The error.
  *
  * @returns {RuntimeError} The runtime error.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceLoader.prototype.getError = function (errorMessage, error) {
   //>>includeStart('debug', pragmas.debug);
@@ -97,6 +110,8 @@ ResourceLoader.prototype.getError = function (errorMessage, error) {
  * @returns {Boolean} <code>true</code> if this object was destroyed; otherwise, <code>false</code>.
  *
  * @see ResourceLoader#destroy
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceLoader.prototype.isDestroyed = function () {
   return false;
@@ -115,6 +130,8 @@ ResourceLoader.prototype.isDestroyed = function () {
  * resourceLoader = resourceLoader && resourceLoader.destroy();
  *
  * @see ResourceLoader#isDestroyed
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceLoader.prototype.destroy = function () {
   this.unload();

--- a/Source/Scene/ResourceLoader.js
+++ b/Source/Scene/ResourceLoader.js
@@ -16,7 +16,6 @@ import RuntimeError from "../Core/RuntimeError.js";
  * @see ResourceCache
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function ResourceLoader() {}
 
@@ -29,7 +28,6 @@ Object.defineProperties(ResourceLoader.prototype, {
    * @type {Promise.<ResourceLoader>}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   promise: {
     // eslint-disable-next-line getter-return
@@ -45,7 +43,6 @@ Object.defineProperties(ResourceLoader.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   cacheKey: {
     // eslint-disable-next-line getter-return
@@ -58,7 +55,6 @@ Object.defineProperties(ResourceLoader.prototype, {
 /**
  * Loads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceLoader.prototype.load = function () {
   DeveloperError.throwInstantiationError();
@@ -67,7 +63,6 @@ ResourceLoader.prototype.load = function () {
 /**
  * Unloads the resource.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceLoader.prototype.unload = function () {};
 
@@ -76,7 +71,6 @@ ResourceLoader.prototype.unload = function () {};
  *
  * @param {FrameState} frameState The frame state.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceLoader.prototype.process = function (frameState) {};
 
@@ -88,7 +82,6 @@ ResourceLoader.prototype.process = function (frameState) {};
  *
  * @returns {RuntimeError} The runtime error.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceLoader.prototype.getError = function (errorMessage, error) {
   //>>includeStart('debug', pragmas.debug);
@@ -111,7 +104,6 @@ ResourceLoader.prototype.getError = function (errorMessage, error) {
  *
  * @see ResourceLoader#destroy
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceLoader.prototype.isDestroyed = function () {
   return false;
@@ -131,7 +123,6 @@ ResourceLoader.prototype.isDestroyed = function () {
  *
  * @see ResourceLoader#isDestroyed
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ResourceLoader.prototype.destroy = function () {
   this.unload();

--- a/Source/Scene/ResourceLoaderState.js
+++ b/Source/Scene/ResourceLoaderState.js
@@ -5,10 +5,45 @@
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 var ResourceLoaderState = {
+  /**
+   * The resource has not yet been loaded.
+   *
+   * @type {Number}
+   * @constant
+   * @private
+   */
   UNLOADED: 0,
+  /**
+   * The resource is loading. In this state, external resources are fetched as needed.
+   *
+   * @type {Number}
+   * @constant
+   * @private
+   */
   LOADING: 1,
+  /**
+   * The resource has finished loading, but requires further processing. GPU resources are allocated in this state as needed.
+   *
+   * @type {Number}
+   * @constant
+   * @private
+   */
   PROCESSING: 2,
+  /**
+   * The resource has finished loading and processing; the results are ready to be used.
+   *
+   * @type {Number}
+   * @constant
+   * @private
+   */
   READY: 3,
+  /**
+   * The resource loading or processing has failed due to an error.
+   *
+   * @type {Number}
+   * @constant
+   * @private
+   */
   FAILED: 4,
 };
 export default Object.freeze(ResourceLoaderState);

--- a/Source/Scene/ResourceLoaderState.js
+++ b/Source/Scene/ResourceLoaderState.js
@@ -2,6 +2,7 @@
  * The {@link ResourceLoader} state.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 var ResourceLoaderState = {
   UNLOADED: 0,

--- a/Source/Scene/ResourceLoaderState.js
+++ b/Source/Scene/ResourceLoaderState.js
@@ -2,7 +2,6 @@
  * The {@link ResourceLoader} state.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 var ResourceLoaderState = {
   /**

--- a/Source/Scene/SupportedImageFormats.js
+++ b/Source/Scene/SupportedImageFormats.js
@@ -10,6 +10,7 @@ import defaultValue from "../Core/defaultValue.js";
  * @param {Boolean} [options.etc1=false] Whether the browser supports etc1 compressed images.
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function SupportedImageFormats(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/Source/Scene/SupportedImageFormats.js
+++ b/Source/Scene/SupportedImageFormats.js
@@ -10,7 +10,6 @@ import defaultValue from "../Core/defaultValue.js";
  * @param {Boolean} [options.etc1=false] Whether the browser supports etc1 compressed images.
  *
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function SupportedImageFormats(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/Source/Scene/TileMetadata.js
+++ b/Source/Scene/TileMetadata.js
@@ -12,6 +12,7 @@ import MetadataEntity from "./MetadataEntity.js";
  *
  * @alias TileMetadata
  * @constructor
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function TileMetadata(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -74,6 +75,7 @@ Object.defineProperties(TileMetadata.prototype, {
  *
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {Boolean} Whether this property exists.
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TileMetadata.prototype.hasProperty = function (propertyId) {
   return MetadataEntity.hasProperty(propertyId, this._properties, this._class);
@@ -84,6 +86,7 @@ TileMetadata.prototype.hasProperty = function (propertyId) {
  *
  * @param {String[]} [results] An array into which to store the results.
  * @returns {String[]} The property IDs.
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TileMetadata.prototype.getPropertyIds = function (results) {
   return MetadataEntity.getPropertyIds(this._properties, this._class, results);
@@ -97,6 +100,7 @@ TileMetadata.prototype.getPropertyIds = function (results) {
  *
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TileMetadata.prototype.getProperty = function (propertyId) {
   return MetadataEntity.getProperty(propertyId, this._properties, this._class);
@@ -111,6 +115,7 @@ TileMetadata.prototype.getProperty = function (propertyId) {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TileMetadata.prototype.setProperty = function (propertyId, value) {
   return MetadataEntity.setProperty(
@@ -126,6 +131,7 @@ TileMetadata.prototype.setProperty = function (propertyId, value) {
  *
  * @param {String} semantic The case-sensitive semantic of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TileMetadata.prototype.getPropertyBySemantic = function (semantic) {
   return MetadataEntity.getPropertyBySemantic(
@@ -141,6 +147,7 @@ TileMetadata.prototype.getPropertyBySemantic = function (semantic) {
  * @param {String} semantic The case-sensitive semantic of the property.
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TileMetadata.prototype.setPropertyBySemantic = function (semantic, value) {
   return MetadataEntity.setPropertyBySemantic(

--- a/Source/Scene/TileMetadata.js
+++ b/Source/Scene/TileMetadata.js
@@ -38,7 +38,6 @@ Object.defineProperties(TileMetadata.prototype, {
    * @type {MetadataClass}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   class: {
     get: function () {
@@ -53,7 +52,6 @@ Object.defineProperties(TileMetadata.prototype, {
    * @type {*}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -68,7 +66,6 @@ Object.defineProperties(TileMetadata.prototype, {
    * @type {Object}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {
@@ -83,7 +80,6 @@ Object.defineProperties(TileMetadata.prototype, {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {Boolean} Whether this property exists.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TileMetadata.prototype.hasProperty = function (propertyId) {
   return MetadataEntity.hasProperty(propertyId, this._properties, this._class);
@@ -95,7 +91,6 @@ TileMetadata.prototype.hasProperty = function (propertyId) {
  * @param {String[]} [results] An array into which to store the results.
  * @returns {String[]} The property IDs.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TileMetadata.prototype.getPropertyIds = function (results) {
   return MetadataEntity.getPropertyIds(this._properties, this._class, results);
@@ -110,7 +105,6 @@ TileMetadata.prototype.getPropertyIds = function (results) {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TileMetadata.prototype.getProperty = function (propertyId) {
   return MetadataEntity.getProperty(propertyId, this._properties, this._class);
@@ -126,7 +120,6 @@ TileMetadata.prototype.getProperty = function (propertyId) {
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TileMetadata.prototype.setProperty = function (propertyId, value) {
   return MetadataEntity.setProperty(
@@ -143,7 +136,6 @@ TileMetadata.prototype.setProperty = function (propertyId, value) {
  * @param {String} semantic The case-sensitive semantic of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TileMetadata.prototype.getPropertyBySemantic = function (semantic) {
   return MetadataEntity.getPropertyBySemantic(
@@ -160,7 +152,6 @@ TileMetadata.prototype.getPropertyBySemantic = function (semantic) {
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TileMetadata.prototype.setPropertyBySemantic = function (semantic, value) {
   return MetadataEntity.setPropertyBySemantic(

--- a/Source/Scene/TileMetadata.js
+++ b/Source/Scene/TileMetadata.js
@@ -37,6 +37,8 @@ Object.defineProperties(TileMetadata.prototype, {
    * @memberof TileMetadata.prototype
    * @type {MetadataClass}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   class: {
     get: function () {
@@ -50,6 +52,8 @@ Object.defineProperties(TileMetadata.prototype, {
    * @memberof TileMetadata.prototype
    * @type {*}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -63,6 +67,8 @@ Object.defineProperties(TileMetadata.prototype, {
    * @memberof TileMetadata.prototype
    * @type {Object}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {
@@ -76,6 +82,7 @@ Object.defineProperties(TileMetadata.prototype, {
  *
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {Boolean} Whether this property exists.
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TileMetadata.prototype.hasProperty = function (propertyId) {
@@ -87,6 +94,7 @@ TileMetadata.prototype.hasProperty = function (propertyId) {
  *
  * @param {String[]} [results] An array into which to store the results.
  * @returns {String[]} The property IDs.
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TileMetadata.prototype.getPropertyIds = function (results) {
@@ -101,6 +109,7 @@ TileMetadata.prototype.getPropertyIds = function (results) {
  *
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TileMetadata.prototype.getProperty = function (propertyId) {
@@ -116,6 +125,7 @@ TileMetadata.prototype.getProperty = function (propertyId) {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TileMetadata.prototype.setProperty = function (propertyId, value) {
@@ -132,6 +142,7 @@ TileMetadata.prototype.setProperty = function (propertyId, value) {
  *
  * @param {String} semantic The case-sensitive semantic of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TileMetadata.prototype.getPropertyBySemantic = function (semantic) {
@@ -148,6 +159,7 @@ TileMetadata.prototype.getPropertyBySemantic = function (semantic) {
  * @param {String} semantic The case-sensitive semantic of the property.
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TileMetadata.prototype.setPropertyBySemantic = function (semantic, value) {

--- a/Source/Scene/TileMetadata.js
+++ b/Source/Scene/TileMetadata.js
@@ -12,6 +12,7 @@ import MetadataEntity from "./MetadataEntity.js";
  *
  * @alias TileMetadata
  * @constructor
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function TileMetadata(options) {

--- a/Source/Scene/TilesetMetadata.js
+++ b/Source/Scene/TilesetMetadata.js
@@ -41,7 +41,6 @@ Object.defineProperties(TilesetMetadata.prototype, {
    * @type {MetadataClass}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   class: {
     get: function () {
@@ -56,7 +55,6 @@ Object.defineProperties(TilesetMetadata.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   name: {
     get: function () {
@@ -71,7 +69,6 @@ Object.defineProperties(TilesetMetadata.prototype, {
    * @type {String}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   description: {
     get: function () {
@@ -86,7 +83,6 @@ Object.defineProperties(TilesetMetadata.prototype, {
    * @type {*}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -101,7 +97,6 @@ Object.defineProperties(TilesetMetadata.prototype, {
    * @type {Object}
    * @readonly
    * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {
@@ -116,7 +111,6 @@ Object.defineProperties(TilesetMetadata.prototype, {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {Boolean} Whether this property exists.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TilesetMetadata.prototype.hasProperty = function (propertyId) {
   return MetadataEntity.hasProperty(propertyId, this._properties, this._class);
@@ -128,7 +122,6 @@ TilesetMetadata.prototype.hasProperty = function (propertyId) {
  * @param {String[]} [results] An array into which to store the results.
  * @returns {String[]} The property IDs.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TilesetMetadata.prototype.getPropertyIds = function (results) {
   return MetadataEntity.getPropertyIds(this._properties, this._class, results);
@@ -143,7 +136,6 @@ TilesetMetadata.prototype.getPropertyIds = function (results) {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TilesetMetadata.prototype.getProperty = function (propertyId) {
   return MetadataEntity.getProperty(propertyId, this._properties, this._class);
@@ -159,7 +151,6 @@ TilesetMetadata.prototype.getProperty = function (propertyId) {
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TilesetMetadata.prototype.setProperty = function (propertyId, value) {
   return MetadataEntity.setProperty(
@@ -176,7 +167,6 @@ TilesetMetadata.prototype.setProperty = function (propertyId, value) {
  * @param {String} semantic The case-sensitive semantic of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TilesetMetadata.prototype.getPropertyBySemantic = function (semantic) {
   return MetadataEntity.getPropertyBySemantic(
@@ -193,7 +183,6 @@ TilesetMetadata.prototype.getPropertyBySemantic = function (semantic) {
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TilesetMetadata.prototype.setPropertyBySemantic = function (semantic, value) {
   return MetadataEntity.setPropertyBySemantic(

--- a/Source/Scene/TilesetMetadata.js
+++ b/Source/Scene/TilesetMetadata.js
@@ -12,6 +12,7 @@ import MetadataEntity from "./MetadataEntity.js";
  *
  * @alias TilesetMetadata
  * @constructor
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function TilesetMetadata(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -113,6 +114,7 @@ TilesetMetadata.prototype.hasProperty = function (propertyId) {
  *
  * @param {String[]} [results] An array into which to store the results.
  * @returns {String[]} The property IDs.
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TilesetMetadata.prototype.getPropertyIds = function (results) {
   return MetadataEntity.getPropertyIds(this._properties, this._class, results);
@@ -126,6 +128,7 @@ TilesetMetadata.prototype.getPropertyIds = function (results) {
  *
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TilesetMetadata.prototype.getProperty = function (propertyId) {
   return MetadataEntity.getProperty(propertyId, this._properties, this._class);
@@ -140,6 +143,7 @@ TilesetMetadata.prototype.getProperty = function (propertyId) {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TilesetMetadata.prototype.setProperty = function (propertyId, value) {
   return MetadataEntity.setProperty(
@@ -155,6 +159,7 @@ TilesetMetadata.prototype.setProperty = function (propertyId, value) {
  *
  * @param {String} semantic The case-sensitive semantic of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TilesetMetadata.prototype.getPropertyBySemantic = function (semantic) {
   return MetadataEntity.getPropertyBySemantic(
@@ -170,6 +175,7 @@ TilesetMetadata.prototype.getPropertyBySemantic = function (semantic) {
  * @param {String} semantic The case-sensitive semantic of the property.
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TilesetMetadata.prototype.setPropertyBySemantic = function (semantic, value) {
   return MetadataEntity.setPropertyBySemantic(

--- a/Source/Scene/TilesetMetadata.js
+++ b/Source/Scene/TilesetMetadata.js
@@ -12,6 +12,7 @@ import MetadataEntity from "./MetadataEntity.js";
  *
  * @alias TilesetMetadata
  * @constructor
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 function TilesetMetadata(options) {

--- a/Source/Scene/TilesetMetadata.js
+++ b/Source/Scene/TilesetMetadata.js
@@ -40,6 +40,8 @@ Object.defineProperties(TilesetMetadata.prototype, {
    * @memberof TilesetMetadata.prototype
    * @type {MetadataClass}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   class: {
     get: function () {
@@ -53,6 +55,8 @@ Object.defineProperties(TilesetMetadata.prototype, {
    * @memberof TilesetMetadata.prototype
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   name: {
     get: function () {
@@ -66,6 +70,8 @@ Object.defineProperties(TilesetMetadata.prototype, {
    * @memberof TilesetMetadata.prototype
    * @type {String}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   description: {
     get: function () {
@@ -79,6 +85,8 @@ Object.defineProperties(TilesetMetadata.prototype, {
    * @memberof TilesetMetadata.prototype
    * @type {*}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extras: {
     get: function () {
@@ -92,6 +100,8 @@ Object.defineProperties(TilesetMetadata.prototype, {
    * @memberof TilesetMetadata.prototype
    * @type {Object}
    * @readonly
+   * @private
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   extensions: {
     get: function () {
@@ -105,6 +115,8 @@ Object.defineProperties(TilesetMetadata.prototype, {
  *
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {Boolean} Whether this property exists.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TilesetMetadata.prototype.hasProperty = function (propertyId) {
   return MetadataEntity.hasProperty(propertyId, this._properties, this._class);
@@ -115,6 +127,7 @@ TilesetMetadata.prototype.hasProperty = function (propertyId) {
  *
  * @param {String[]} [results] An array into which to store the results.
  * @returns {String[]} The property IDs.
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TilesetMetadata.prototype.getPropertyIds = function (results) {
@@ -129,6 +142,7 @@ TilesetMetadata.prototype.getPropertyIds = function (results) {
  *
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TilesetMetadata.prototype.getProperty = function (propertyId) {
@@ -144,6 +158,7 @@ TilesetMetadata.prototype.getProperty = function (propertyId) {
  * @param {String} propertyId The case-sensitive ID of the property.
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TilesetMetadata.prototype.setProperty = function (propertyId, value) {
@@ -160,6 +175,7 @@ TilesetMetadata.prototype.setProperty = function (propertyId, value) {
  *
  * @param {String} semantic The case-sensitive semantic of the property.
  * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TilesetMetadata.prototype.getPropertyBySemantic = function (semantic) {
@@ -176,6 +192,7 @@ TilesetMetadata.prototype.getPropertyBySemantic = function (semantic) {
  * @param {String} semantic The case-sensitive semantic of the property.
  * @param {*} value The value of the property that will be copied.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
+ * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 TilesetMetadata.prototype.setPropertyBySemantic = function (semantic, value) {

--- a/Source/Scene/findGroupMetadata.js
+++ b/Source/Scene/findGroupMetadata.js
@@ -10,6 +10,7 @@ import has3DTilesExtension from "./has3DTilesExtension.js";
  * @param {Object} contentHeader the JSON header for a {@link Cesium3DTileContent}
  * @return {GroupMetadata} the group metadata, or <code>undefined</code> if not found
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function findGroupMetadata(tileset, contentHeader) {
   if (has3DTilesExtension(contentHeader, "3DTILES_metadata")) {

--- a/Source/Scene/has3DTilesExtension.js
+++ b/Source/Scene/has3DTilesExtension.js
@@ -8,7 +8,6 @@ import defined from "../Core/defined.js";
  * @param {String} extensionName The name of the extension, e.g. '3DTILES_implicit_tiling'
  * @returns {Boolean} True if the extension is present
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function has3DTilesExtension(json, extensionName) {
   return (

--- a/Source/Scene/has3DTilesExtension.js
+++ b/Source/Scene/has3DTilesExtension.js
@@ -8,6 +8,7 @@ import defined from "../Core/defined.js";
  * @param {String} extensionName The name of the extension, e.g. '3DTILES_implicit_tiling'
  * @returns {Boolean} True if the extension is present
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function has3DTilesExtension(json, extensionName) {
   return (

--- a/Source/Scene/parseBatchTable.js
+++ b/Source/Scene/parseBatchTable.js
@@ -24,6 +24,7 @@ import MetadataTable from "./MetadataTable.js";
  * @return {FeatureMetadata} A transcoded feature metadata object
  *
  * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function parseBatchTable(options) {
   //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/parseFeatureMetadata.js
+++ b/Source/Scene/parseFeatureMetadata.js
@@ -16,6 +16,8 @@ import MetadataTable from "./MetadataTable.js";
  * @param {Object.<String, Uint8Array>} [options.bufferViews] An object mapping bufferView IDs to Uint8Array objects.
  * @param {Object.<String, Texture>} [options.textures] An object mapping texture IDs to {@link Texture} objects.
  * @return {FeatureMetadata} A feature metadata object
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function parseFeatureMetadata(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);


### PR DESCRIPTION
This is another PR that targets the `3d-tiles-next` branch. It is to clean up the branch before we open a PR to merge `3d-tiles-next` into `master`

This PR does the following:
* Any 3D Tiles Next features are marked as `@private` (so it doesn't show up in the JSDoc) and `@experimental` (so even those looking at the code know these features are subject to change)
* A few enums were missing documentation of individual members. I added these.
* Updated the changelog to mark these features as part of a future release in June

The `@private/@experimental` changes are perhaps a bit overkill, but we want to be extra careful that we are not introducing public API changes at this time.

@lilleyse could you review? Note that there were many, many files to update, so here's a full list I used as I went: [changed-files.txt](https://github.com/CesiumGS/cesium/files/6393886/tile-files.txt)
