### PR TITLE
Added more helper functions to `ImplicitTileCoordinates`

### DIFF
--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -395,7 +395,7 @@ function Cesium3DTile(tileset, baseResource, header, parent) {
    * placeholder tile with the <code>3DTILES_implicit_tiling</code> extension.
    * This way the {@link Implicit3DTileContent} can access the tile later once the content is fetched.
    *
-   * @type {ImplicitTileset}
+   * @type {ImplicitTileset|undefined}
    *
    * @private
    * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
@@ -406,7 +406,7 @@ function Cesium3DTile(tileset, baseResource, header, parent) {
    * For implicit tiling, the (level, x, y, [z]) coordinates within the
    * implicit tileset are stored in the tile.
    *
-   * @type {ImplicitTileCoordinates}
+   * @type {ImplicitTileCoordinates|undefined}
    *
    * @private
    * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
@@ -417,7 +417,7 @@ function Cesium3DTile(tileset, baseResource, header, parent) {
    * For implicit tiling, each transcoded tile will hold a weak reference to
    * the {@link ImplicitSubtree}.
    *
-   * @type {ImplicitSubtree}
+   * @type {ImplicitSubtree|undefined}
    *
    * @private
    * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -926,7 +926,7 @@ function Cesium3DTileset(options) {
    * If the 3DTILES_metadata extension is used, this stores
    * a {@link Cesium3DTilesetMetadata} object to access metadata.
    *
-   * @type {Cesium3DTilesetMetadata}
+   * @type {Cesium3DTilesetMetadata|undefined}
    * @private
    * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
@@ -1815,13 +1815,18 @@ Cesium3DTileset.prototype.loadTileset = function (
  */
 function makeTile(tileset, baseResource, tileHeader, parentTile) {
   if (has3DTilesExtension(tileHeader, "3DTILES_implicit_tiling")) {
+    var metadataSchema = defined(tileset.metadata)
+      ? tileset.metadata.schema
+      : undefined;
+
     var implicitTileset = new ImplicitTileset(
-      tileset,
       baseResource,
-      tileHeader
+      tileHeader,
+      metadataSchema
     );
     var rootCoordinates = new ImplicitTileCoordinates({
       subdivisionScheme: implicitTileset.subdivisionScheme,
+      subtreeLevels: implicitTileset.subtreeLevels,
       level: 0,
       x: 0,
       y: 0,

--- a/Source/Scene/Implicit3DTileContent.js
+++ b/Source/Scene/Implicit3DTileContent.js
@@ -372,14 +372,14 @@ function deriveChildTile(
   if (defaultValue(parentIsPlaceholderTile, false)) {
     implicitCoordinates = parentTile.implicitCoordinates;
   } else {
-    implicitCoordinates = parentTile.implicitCoordinates.deriveChildCoordinates(
+    implicitCoordinates = parentTile.implicitCoordinates.getChildCoordinates(
       childIndex
     );
   }
 
   var contentJsons = [];
   for (var i = 0; i < implicitTileset.contentCount; i++) {
-    if (!subtree.contentIsAvailable(childBitIndex, i)) {
+    if (!subtree.contentIsAvailableAtIndex(childBitIndex, i)) {
       continue;
     }
     var childContentTemplate = implicitTileset.contentUriTemplates[i];
@@ -634,7 +634,7 @@ function deriveBoundingRegion(rootRegion, level, x, y, z) {
  */
 function makePlaceholderChildSubtree(content, parentTile, childIndex) {
   var implicitTileset = content._implicitTileset;
-  var implicitCoordinates = parentTile.implicitCoordinates.deriveChildCoordinates(
+  var implicitCoordinates = parentTile.implicitCoordinates.getChildCoordinates(
     childIndex
   );
 

--- a/Source/Scene/Implicit3DTileContent.js
+++ b/Source/Scene/Implicit3DTileContent.js
@@ -250,7 +250,7 @@ function listChildSubtrees(content, subtree, bottomRow) {
 
     for (var j = 0; j < branchingFactor; j++) {
       var index = i * branchingFactor + j;
-      if (subtree.childSubtreeIsAvailable(index)) {
+      if (subtree.childSubtreeIsAvailableAtIndex(index)) {
         results.push({
           tile: leafTile,
           childIndex: j,
@@ -312,7 +312,7 @@ function transcodeSubtreeTiles(content, subtree, placeholderTile, childIndex) {
     ) {
       var childBitIndex = levelOffset + childMortonIndex;
 
-      if (!subtree.tileIsAvailable(childBitIndex)) {
+      if (!subtree.tileIsAvailableAtIndex(childBitIndex)) {
         currentRow.push(undefined);
         continue;
       }

--- a/Source/Scene/ImplicitSubtree.js
+++ b/Source/Scene/ImplicitSubtree.js
@@ -736,6 +736,11 @@ function makeJumpBuffer(subtree) {
  * @private
  */
 ImplicitSubtree.prototype.getTileIndex = function (implicitCoordinates) {
+  var localLevel = implicitCoordinates.level - this._implicitCoordinates.level;
+  if (localLevel < 0 || this._subtreeLevels <= localLevel) {
+    throw new RuntimeError("level is out of bounds for this subtree");
+  }
+
   var localCoordinates = implicitCoordinates.deriveLocalTileCoordinates();
   var levelOffset = this.getLevelOffset(localCoordinates.level);
   var mortonIndex = localCoordinates.mortonIndex;
@@ -752,6 +757,11 @@ ImplicitSubtree.prototype.getTileIndex = function (implicitCoordinates) {
 ImplicitSubtree.prototype.getChildSubtreeIndex = function (
   implicitCoordinates
 ) {
+  var localLevel = implicitCoordinates.level - this._implicitCoordinates.level;
+  if (localLevel !== this._implicitCoordinates.subtreeLevels) {
+    throw new RuntimeError("level is out of bounds for this subtree");
+  }
+
   var localCoordinates = implicitCoordinates.deriveLocalChildSubtreeCoordinates();
   var mortonIndex = localCoordinates.mortonIndex;
   return mortonIndex;

--- a/Source/Scene/ImplicitTileCoordinates.js
+++ b/Source/Scene/ImplicitTileCoordinates.js
@@ -25,7 +25,8 @@ import ImplicitSubdivisionScheme from "./ImplicitSubdivisionScheme.js";
  *
  * @param {Object} options An object with the following properties:
  * @param {ImplicitSubdivisionScheme} options.subdivisionScheme Whether the coordinates are for a quadtree or octree
- * @param {Number} options.level The level of a tile relative to the tile with the extension.
+ * @param {Number} options.subtreeLevels The number of distinct levels within the coordinate's subtree
+ * @param {Number} options.level The level of a tile relative to the tile with the extension
  * @param {Number} options.x The x coordinate of the tile
  * @param {Number} options.y The y coordinate of the tile
  * @param {Number} [options.z] The z coordinate of the tile. Only required when options.subdivisionScheme is ImplicitSubdivisionScheme.OCTREE
@@ -35,11 +36,41 @@ import ImplicitSubdivisionScheme from "./ImplicitSubdivisionScheme.js";
 export default function ImplicitTileCoordinates(options) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.string("options.subdivisionScheme", options.subdivisionScheme);
+  Check.typeOf.number("options.subtreeLevels", options.subtreeLevels);
   Check.typeOf.number("options.level", options.level);
   Check.typeOf.number("options.x", options.x);
   Check.typeOf.number("options.y", options.y);
   if (options.subdivisionScheme === ImplicitSubdivisionScheme.OCTREE) {
     Check.typeOf.number("options.z", options.z);
+  }
+  // Check for values that are negative
+  if (options.level < 0) {
+    throw new DeveloperError("level must be non-negative");
+  }
+  if (options.x < 0) {
+    throw new DeveloperError("x must be non-negative");
+  }
+  if (options.y < 0) {
+    throw new DeveloperError("y must be non-negative");
+  }
+  if (options.subdivisionScheme === ImplicitSubdivisionScheme.OCTREE) {
+    if (options.z < 0) {
+      throw new DeveloperError("z must be non-negative");
+    }
+  }
+
+  // Check for values that are too large
+  var dimensionAtLevel = 1 << options.level;
+  if (options.x >= dimensionAtLevel) {
+    throw new DeveloperError("x is out of range");
+  }
+  if (options.y >= dimensionAtLevel) {
+    throw new DeveloperError("y is out of range");
+  }
+  if (options.subdivisionScheme === ImplicitSubdivisionScheme.OCTREE) {
+    if (options.z >= dimensionAtLevel) {
+      throw new DeveloperError("z is out of range");
+    }
   }
   //>>includeEnd('debug');
 
@@ -51,6 +82,15 @@ export default function ImplicitTileCoordinates(options) {
    * @private
    */
   this.subdivisionScheme = options.subdivisionScheme;
+
+  /**
+   * The number of distinct levels within the coordinate's subtree
+   *
+   * @type {Number}
+   * @readonly
+   * @private
+   */
+  this.subtreeLevels = options.subtreeLevels;
 
   /**
    * Level of this tile, relative to the tile with the
@@ -83,7 +123,7 @@ export default function ImplicitTileCoordinates(options) {
   /**
    * Z coordinate of this tile. Only defined for octrees.
    *
-   * @type {Number}
+   * @type {Number|undefined}
    * @readonly
    * @private
    */
@@ -121,7 +161,7 @@ Object.defineProperties(ImplicitTileCoordinates.prototype, {
   },
 
   /**
-   * Get the Morton index for this tile within the current LOD by interleaving
+   * Get the Morton index for this tile within the current level by interleaving
    * the bits of the x, y and z coordinates.
    *
    * @type {Number}
@@ -168,6 +208,7 @@ ImplicitTileCoordinates.prototype.deriveChildCoordinates = function (
     var z = 2 * this.z + (Math.floor(childIndex / 4) % 2);
     return new ImplicitTileCoordinates({
       subdivisionScheme: this.subdivisionScheme,
+      subtreeLevels: this.subtreeLevels,
       level: level,
       x: x,
       y: y,
@@ -178,10 +219,320 @@ ImplicitTileCoordinates.prototype.deriveChildCoordinates = function (
   // Quadtree
   return new ImplicitTileCoordinates({
     subdivisionScheme: this.subdivisionScheme,
+    subtreeLevels: this.subtreeLevels,
     level: level,
     x: x,
     y: y,
   });
+};
+
+/**
+ * Given the (level, x, y, [z]) coordinates of the parent and
+ * a (level, x, y, [z]) relative offset, compute the coordinates of the descendant.
+ *
+ * @param {ImplicitTileCoordinates} localCoordinates The local coordinates of the descendant
+ * @returns {ImplicitTileCoordinates} The tile coordinates of the descendant
+ * @private
+ */
+ImplicitTileCoordinates.prototype.deriveDescendantCoordinates = function (
+  localCoordinates
+) {
+  var subdivisionScheme = this.subdivisionScheme;
+  var subtreeLevels = this.subtreeLevels;
+  var tileLevel = this.level;
+  var tileX = this.x;
+  var tileY = this.y;
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("localCoordinates", localCoordinates);
+  if (subdivisionScheme !== localCoordinates.subdivisionScheme) {
+    throw new DeveloperError("coordinates must have same subdivisionScheme");
+  }
+
+  if (subtreeLevels !== localCoordinates.subtreeLevels) {
+    throw new DeveloperError("coordinates must have same subtreeLevels");
+  }
+  //>>includeEnd('debug');
+
+  var globalLevel = tileLevel + localCoordinates.level;
+  var globalX = (tileX << localCoordinates.level) + localCoordinates.x;
+  var globalY = (tileY << localCoordinates.level) + localCoordinates.y;
+
+  if (subdivisionScheme === ImplicitSubdivisionScheme.OCTREE) {
+    var tileZ = this.z;
+    var globalZ = (tileZ << localCoordinates.level) + localCoordinates.z;
+
+    return new ImplicitTileCoordinates({
+      subdivisionScheme: subdivisionScheme,
+      subtreeLevels: subtreeLevels,
+      level: globalLevel,
+      x: globalX,
+      y: globalY,
+      z: globalZ,
+    });
+  }
+
+  // Quadtree
+  return new ImplicitTileCoordinates({
+    subdivisionScheme: subdivisionScheme,
+    subtreeLevels: subtreeLevels,
+    level: globalLevel,
+    x: globalX,
+    y: globalY,
+  });
+};
+
+/**
+ * Get the coordinates of the subtree that contains this tile
+ *
+ * @returns {ImplicitTileCoordinates} The subtree that contains this tile
+ * @private
+ */
+ImplicitTileCoordinates.prototype.deriveSubtreeCoordinates = function () {
+  var subdivisionScheme = this.subdivisionScheme;
+  var subtreeLevels = this.subtreeLevels;
+  var tileLevel = this.level;
+  var tileX = this.x;
+  var tileY = this.y;
+
+  var subtreeLevel = ((tileLevel / subtreeLevels) | 0) * subtreeLevels;
+  var divisor = 1 << (tileLevel - subtreeLevel);
+  var subtreeX = (tileX / divisor) | 0;
+  var subtreeY = (tileY / divisor) | 0;
+
+  if (subdivisionScheme === ImplicitSubdivisionScheme.OCTREE) {
+    var tileZ = this.z;
+    var subtreeZ = (tileZ / divisor) | 0;
+
+    return new ImplicitTileCoordinates({
+      subdivisionScheme: subdivisionScheme,
+      subtreeLevels: subtreeLevels,
+      level: subtreeLevel,
+      x: subtreeX,
+      y: subtreeY,
+      z: subtreeZ,
+    });
+  }
+
+  // Quadtree
+  return new ImplicitTileCoordinates({
+    subdivisionScheme: subdivisionScheme,
+    subtreeLevels: subtreeLevels,
+    level: subtreeLevel,
+    x: subtreeX,
+    y: subtreeY,
+  });
+};
+
+/**
+ * Get the coordinates of the parent subtree that contains this tile
+ *
+ * @returns {ImplicitTileCoordinates} The parent subtree that contains this tile
+ * @private
+ */
+ImplicitTileCoordinates.prototype.deriveParentSubtreeCoordinates = function () {
+  var subtreeCoordinates = this.deriveSubtreeCoordinates();
+  if (subtreeCoordinates.isRoot()) {
+    // This subtree is the root of the entire tileset, so it can't go up any higher.
+    return subtreeCoordinates;
+  }
+
+  var subdivisionScheme = subtreeCoordinates.subdivisionScheme;
+  var subtreeLevels = subtreeCoordinates.subtreeLevels;
+  var subtreeLevel = subtreeCoordinates.level;
+  var subtreeX = subtreeCoordinates.x;
+  var subtreeY = subtreeCoordinates.y;
+
+  var parentSubtreeLevel = subtreeLevel - subtreeLevels;
+  var parentSubtreeX = subtreeX >> subtreeLevels;
+  var parentSubtreeY = subtreeY >> subtreeLevels;
+
+  if (subdivisionScheme === ImplicitSubdivisionScheme.OCTREE) {
+    var subtreeZ = subtreeCoordinates.z;
+    var parentSubtreeZ = subtreeZ >> subtreeLevels;
+
+    return new ImplicitTileCoordinates({
+      subdivisionScheme: subdivisionScheme,
+      subtreeLevels: subtreeLevels,
+      level: parentSubtreeLevel,
+      x: parentSubtreeX,
+      y: parentSubtreeY,
+      z: parentSubtreeZ,
+    });
+  }
+
+  // Quadtree
+  return new ImplicitTileCoordinates({
+    subdivisionScheme: subdivisionScheme,
+    subtreeLevels: subtreeLevels,
+    level: parentSubtreeLevel,
+    x: parentSubtreeX,
+    y: parentSubtreeY,
+  });
+};
+
+/**
+ * Get the local coordinates of the tile relative to its subtree
+ *
+ * @returns {ImplicitTileCoordinates} The local coordinates of the tile
+ * @private
+ */
+ImplicitTileCoordinates.prototype.deriveLocalTileCoordinates = function () {
+  var subdivisionScheme = this.subdivisionScheme;
+  var subtreeLevels = this.subtreeLevels;
+  var tileX = this.x;
+  var tileY = this.y;
+  var tileLevel = this.level;
+
+  var subtreeCoordinates = this.deriveSubtreeCoordinates();
+  var localLevel = tileLevel - subtreeCoordinates.level;
+
+  var localX = tileX % (1 << localLevel);
+  var localY = tileY % (1 << localLevel);
+
+  if (subdivisionScheme === ImplicitSubdivisionScheme.OCTREE) {
+    var tileZ = this.z;
+    var localZ = tileZ % (1 << localLevel);
+
+    return new ImplicitTileCoordinates({
+      subdivisionScheme: subdivisionScheme,
+      subtreeLevels: subtreeLevels,
+      level: localLevel,
+      x: localX,
+      y: localY,
+      z: localZ,
+    });
+  }
+
+  // Quadtree
+  return new ImplicitTileCoordinates({
+    subdivisionScheme: subdivisionScheme,
+    subtreeLevels: subtreeLevels,
+    level: localLevel,
+    x: localX,
+    y: localY,
+  });
+};
+
+/**
+ * Get the local coordinates of the child subtree relative to its subtree
+ *
+ * @returns {ImplicitTileCoordinates} The local coordinates of the child subtree
+ * @private
+ */
+ImplicitTileCoordinates.prototype.deriveLocalChildSubtreeCoordinates = function () {
+  //>>includeStart('debug', pragmas.debug);
+  if (!this.isRootOfSubtree() || this.isRoot()) {
+    throw new DeveloperError(
+      "child subtree must be the root of a non-root subtree"
+    );
+  }
+  //>>includeEnd('debug');
+
+  var subdivisionScheme = this.subdivisionScheme;
+  var subtreeLevels = this.subtreeLevels;
+  var tileX = this.x;
+  var tileY = this.y;
+
+  var localX = tileX % (1 << subtreeLevels);
+  var localY = tileY % (1 << subtreeLevels);
+
+  if (subdivisionScheme === ImplicitSubdivisionScheme.OCTREE) {
+    var tileZ = this.z;
+    var localZ = tileZ % (1 << subtreeLevels);
+
+    return new ImplicitTileCoordinates({
+      subdivisionScheme: subdivisionScheme,
+      subtreeLevels: subtreeLevels,
+      level: subtreeLevels,
+      x: localX,
+      y: localY,
+      z: localZ,
+    });
+  }
+
+  // Quadtree
+  return new ImplicitTileCoordinates({
+    subdivisionScheme: subdivisionScheme,
+    subtreeLevels: subtreeLevels,
+    level: subtreeLevels,
+    x: localX,
+    y: localY,
+  });
+};
+
+/**
+ * Returns whether this tile is an ancestor of another tile
+ *
+ * @param {ImplicitTileCoordinates} otherCoordinates the other tile coordinates
+ * @returns {Boolean} <code>true</code> if this tile is an ancestor of the other tile
+ * @private
+ */
+ImplicitTileCoordinates.prototype.isAncestorOf = function (otherCoordinates) {
+  var subdivisionScheme = this.subdivisionScheme;
+  var subtreeLevels = this.subtreeLevels;
+  var tileLevel = this.level;
+  var tileX = this.x;
+  var tileY = this.y;
+
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("otherCoordinates", otherCoordinates);
+  if (subdivisionScheme !== otherCoordinates.subdivisionScheme) {
+    throw new DeveloperError("coordinates must have same subdivisionScheme");
+  }
+
+  if (subtreeLevels !== otherCoordinates.subtreeLevels) {
+    throw new DeveloperError("coordinates must have same subtreeLevels");
+  }
+  //>>includeEnd('debug');
+
+  var levelDifference = otherCoordinates.level - tileLevel;
+  if (levelDifference <= 0) {
+    return false;
+  }
+
+  var isAncestorX = tileX === otherCoordinates.x >> levelDifference;
+  var isAncestorY = tileY === otherCoordinates.y >> levelDifference;
+
+  if (subdivisionScheme === ImplicitSubdivisionScheme.OCTREE) {
+    var tileZ = this.z;
+    var isAncestorZ = tileZ === otherCoordinates.z >> levelDifference;
+
+    return isAncestorX && isAncestorY && isAncestorZ;
+  }
+
+  // Quadtree
+  return isAncestorX && isAncestorY;
+};
+
+/**
+ * Returns whether this tile is the root
+ *
+ * @returns {Boolean} <code>true</code> if this tile is the root
+ * @private
+ */
+ImplicitTileCoordinates.prototype.isRoot = function () {
+  return this.level === 0;
+};
+
+/**
+ * Returns whether this tile is the root of the subtree
+ *
+ * @returns {Boolean} <code>true</code> if this tile is the root of the subtree
+ * @private
+ */
+ImplicitTileCoordinates.prototype.isRootOfSubtree = function () {
+  return this.level % this.subtreeLevels === 0;
+};
+
+/**
+ * Returns whether this tile is at the bottom of the subtree
+ *
+ * @returns {Boolean} <code>true</code> if this tile is at the bottom of the subtree
+ * @private
+ */
+ImplicitTileCoordinates.prototype.isBottomOfSubtree = function () {
+  return this.level % this.subtreeLevels === this.subtreeLevels - 1;
 };
 
 /**
@@ -209,6 +560,7 @@ var scratchCoordinatesArray = [0, 0, 0];
  * octree/quadtree, compute the (level, x, y, [z]) coordinates
  *
  * @param {ImplicitSubdivisionScheme} subdivisionScheme
+ * @param {Number} subtreeLevels
  * @param {Number} level The level of the tree
  * @param {Number} mortonIndex The morton index of the tile.
  * @returns {ImplicitTileCoordinates} The coordinates of the tile with the given Morton index
@@ -216,6 +568,7 @@ var scratchCoordinatesArray = [0, 0, 0];
  */
 ImplicitTileCoordinates.fromMortonIndex = function (
   subdivisionScheme,
+  subtreeLevels,
   level,
   mortonIndex
 ) {
@@ -227,6 +580,7 @@ ImplicitTileCoordinates.fromMortonIndex = function (
     );
     return new ImplicitTileCoordinates({
       subdivisionScheme: subdivisionScheme,
+      subtreeLevels: subtreeLevels,
       level: level,
       x: coordinatesArray[0],
       y: coordinatesArray[1],
@@ -237,6 +591,7 @@ ImplicitTileCoordinates.fromMortonIndex = function (
   coordinatesArray = MortonOrder.decode2D(mortonIndex, scratchCoordinatesArray);
   return new ImplicitTileCoordinates({
     subdivisionScheme: subdivisionScheme,
+    subtreeLevels: subtreeLevels,
     level: level,
     x: coordinatesArray[0],
     y: coordinatesArray[1],

--- a/Source/Scene/ImplicitTileset.js
+++ b/Source/Scene/ImplicitTileset.js
@@ -16,13 +16,17 @@ import ImplicitSubdivisionScheme from "./ImplicitSubdivisionScheme.js";
  * @alias ImplicitTileset
  * @constructor
  *
- * @param {Cesium3DTileset} tileset The tileset this implicit tileset belongs to. Used for accessing metadata properties
  * @param {Resource} baseResource The base resource for the tileset
  * @param {Object} tileJson The JSON header of the tile with the 3DTILES_implicit_tiling extension.
+ * @param {MetadataSchema} [metadataSchema] The metadata schema containing the implicit tile metadata class.
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function ImplicitTileset(tileset, baseResource, tileJson) {
+export default function ImplicitTileset(
+  baseResource,
+  tileJson,
+  metadataSchema
+) {
   var extension = tileJson.extensions["3DTILES_implicit_tiling"];
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object(
@@ -30,15 +34,6 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
     extension
   );
   //>>includeEnd('debug');
-
-  /**
-   * A reference to the tileset to which this implicit tileset belongs.
-   *
-   * @type {Cesium3DTileset}
-   * @readonly
-   * @private
-   */
-  this.tileset = tileset;
 
   /**
    * The base resource for the tileset. This is stored here as it is needed
@@ -59,6 +54,15 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @private
    */
   this.geometricError = tileJson.geometricError;
+
+  /**
+   * The metadata schema containing the implicit tile metadata class.
+   *
+   * @type {MetadataSchema|undefined}
+   * @readonly
+   * @private
+   */
+  this.metadataSchema = metadataSchema;
 
   if (
     !defined(tileJson.boundingVolume.box) &&
@@ -96,6 +100,7 @@ export default function ImplicitTileset(tileset, baseResource, tileJson) {
    * @readonly
    * @private
    */
+
   this.subtreeUriTemplate = new Resource({ url: extension.subtrees.uri });
 
   /**

--- a/Specs/Scene/Implicit3DTileContentSpec.js
+++ b/Specs/Scene/Implicit3DTileContentSpec.js
@@ -29,6 +29,7 @@ describe(
     var mockTileset = {
       modelMatrix: Matrix4.IDENTITY,
     };
+    var metadataSchema; // intentionally left undefined
 
     var tileJson = {
       geometricError: 800,
@@ -58,9 +59,9 @@ describe(
     };
 
     var implicitTileset = new ImplicitTileset(
-      mockTileset,
       tilesetResource,
-      tileJson
+      tileJson,
+      metadataSchema
     );
 
     var quadtreeBuffer = ImplicitTilingTester.generateSubtreeBuffers({
@@ -85,6 +86,7 @@ describe(
 
     var rootCoordinates = new ImplicitTileCoordinates({
       subdivisionScheme: implicitTileset.subdivisionScheme,
+      subtreeLevels: implicitTileset.subtreeLevels,
       level: 0,
       x: 0,
       y: 0,
@@ -193,6 +195,7 @@ describe(
           var expected = expectedCoordinates[i];
           var coordinates = new ImplicitTileCoordinates({
             subdivisionScheme: implicitTileset.subdivisionScheme,
+            subtreeLevels: implicitTileset.subtreeLevels,
             level: expected[0],
             x: expected[1],
             y: expected[2],
@@ -205,6 +208,7 @@ describe(
     it("handles deeper subtrees correctly", function () {
       mockPlaceholderTile.implicitCoordinates = new ImplicitTileCoordinates({
         subdivisionScheme: implicitTileset.subdivisionScheme,
+        subtreeLevels: implicitTileset.subtreeLevels,
         level: 2,
         x: 2,
         y: 1,
@@ -404,6 +408,7 @@ describe(
           var expected = expectedCoordinates[i];
           var coordinates = new ImplicitTileCoordinates({
             subdivisionScheme: implicitTileset.subdivisionScheme,
+            subtreeLevels: implicitTileset.subtreeLevels,
             level: expected[0],
             x: expected[1],
             y: expected[2],
@@ -449,6 +454,7 @@ describe(
           var expected = expectedCoordinates[i];
           var coordinates = new ImplicitTileCoordinates({
             subdivisionScheme: implicitTileset.subdivisionScheme,
+            subtreeLevels: implicitTileset.subtreeLevels,
             level: expected[0],
             x: expected[1],
             y: expected[2],

--- a/Specs/Scene/Implicit3DTileContentSpec.js
+++ b/Specs/Scene/Implicit3DTileContentSpec.js
@@ -226,7 +226,7 @@ describe(
           : Cesium3DTileRefine.REPLACE;
 
       var parentCoordinates = mockPlaceholderTile.implicitCoordinates;
-      var childCoordinates = parentCoordinates.deriveChildCoordinates(0);
+      var childCoordinates = parentCoordinates.getChildCoordinates(0);
 
       var parentGeometricError = implicitTileset.geometricError / 4;
       var childGeometricError = implicitTileset.geometricError / 8;

--- a/Specs/Scene/ImplicitSubtreeSpec.js
+++ b/Specs/Scene/ImplicitSubtreeSpec.js
@@ -74,7 +74,6 @@ describe("Scene/ImplicitSubtree", function () {
   var subtreeResource = new Resource({
     url: "https://example.com/test.subtree",
   });
-  var mockTileset = {};
   var metadataSchema; // intentionally left undefined
 
   var implicitQuadtreeJson = {
@@ -1075,13 +1074,7 @@ describe("Scene/ImplicitSubtree", function () {
       },
     };
 
-    var mockTilesetWithMetadata = {
-      metadata: {
-        schema: new MetadataSchema(schema),
-      },
-    };
-
-    var metadataSchema = mockTilesetWithMetadata.metadata.schema;
+    var metadataSchema = new MetadataSchema(schema);
 
     var metadataQuadtree = new ImplicitTileset(
       tilesetResource,
@@ -1582,13 +1575,7 @@ describe("Scene/ImplicitSubtree", function () {
         },
       };
 
-      var mockTilesetWithArrayMetadata = {
-        metadata: {
-          schema: new MetadataSchema(arraySchema),
-        },
-      };
-
-      var metadataSchema = mockTilesetWithArrayMetadata.metadata.schema;
+      var metadataSchema = new MetadataSchema(arraySchema);
 
       var arrayQuadtree = new ImplicitTileset(
         tilesetResource,

--- a/Specs/Scene/ImplicitSubtreeSpec.js
+++ b/Specs/Scene/ImplicitSubtreeSpec.js
@@ -1588,6 +1588,8 @@ describe("Scene/ImplicitSubtree", function () {
         },
       };
 
+      var metadataSchema = mockTilesetWithArrayMetadata.metadata.schema;
+
       var arrayQuadtree = new ImplicitTileset(
         tilesetResource,
         implicitQuadtreeJson,

--- a/Specs/Scene/ImplicitTileCoordinatesSpec.js
+++ b/Specs/Scene/ImplicitTileCoordinatesSpec.js
@@ -1,22 +1,41 @@
 import {
+  defaultValue,
   ImplicitSubdivisionScheme,
   ImplicitTileCoordinates,
 } from "../../Source/Cesium.js";
 
 describe("Scene/ImplicitTileCoordinates", function () {
-  function internalQuadtree(level, x, y) {
+  /**
+   * Helper function for creating quadtree implicit tile coordinates
+   * @param {Number} level
+   * @param {Number} x
+   * @param {Number} y
+   * @param {Number} [subtreeLevels=2]
+   * @returns {ImplicitTileCoordinates}
+   */
+  function quadtreeCoordinates(level, x, y, subtreeLevels) {
     return new ImplicitTileCoordinates({
       subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-      subtreeLevels: 2,
+      subtreeLevels: defaultValue(subtreeLevels, 2),
       level: level,
       x: x,
       y: y,
     });
   }
-  function internalOctree(level, x, y, z) {
+
+  /**
+   * Helper function for creating octree implicit tile coordinates
+   * @param {Number} level
+   * @param {Number} x
+   * @param {Number} y
+   * @param {Number} z
+   * @param {Number} [subtreeLevels=2]
+   * @returns {ImplicitTileCoordinates}
+   */
+  function octreeCoordinates(level, x, y, z, subtreeLevels) {
     return new ImplicitTileCoordinates({
       subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
-      subtreeLevels: 2,
+      subtreeLevels: defaultValue(subtreeLevels, 2),
       level: level,
       x: x,
       y: y,
@@ -64,329 +83,280 @@ describe("Scene/ImplicitTileCoordinates", function () {
   it("constructor throws with invalid inputs for quadree", function () {
     // negative level
     expect(function () {
-      internalQuadtree(-1, 0, 0);
+      quadtreeCoordinates(-1, 0, 0);
     }).toThrowDeveloperError();
 
     // negative x
     expect(function () {
-      internalQuadtree(0, -1, 0);
+      quadtreeCoordinates(0, -1, 0);
     }).toThrowDeveloperError();
 
     // negative y
     expect(function () {
-      internalQuadtree(0, 0, -1);
+      quadtreeCoordinates(0, 0, -1);
     }).toThrowDeveloperError();
 
     // out of range x
     expect(function () {
-      internalQuadtree(0, 4, 0);
+      quadtreeCoordinates(0, 4, 0);
     }).toThrowDeveloperError();
 
     // out of range y
     expect(function () {
-      internalQuadtree(0, 0, 4);
+      quadtreeCoordinates(0, 0, 4);
     }).toThrowDeveloperError();
   });
 
   it("constructor throws with invalid inputs for octree", function () {
     // negative z
     expect(function () {
-      internalOctree(0, 0, 0, -1);
+      octreeCoordinates(0, 0, 0, -1);
     }).toThrowDeveloperError();
 
     // out of range z
     expect(function () {
-      internalOctree(0, 0, 0, 4);
+      octreeCoordinates(0, 0, 0, 4);
     }).toThrowDeveloperError();
   });
 
   it("getDescendantCoordinates throws with invalid inputs", function () {
     // undefined input
     expect(function () {
-      internalQuadtree(0, 0, 0).getDescendantCoordinates(undefined);
+      quadtreeCoordinates(0, 0, 0).getDescendantCoordinates(undefined);
     }).toThrowDeveloperError();
 
     // mismatched subdivisionScheme
     expect(function () {
-      return new ImplicitTileCoordinates({
-        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-        subtreeLevels: 2,
-        level: 0,
-        x: 0,
-        y: 0,
-      }).getDescendantCoordinates(
-        new ImplicitTileCoordinates({
-          subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
-          subtreeLevels: 2,
-          level: 0,
-          x: 0,
-          y: 0,
-          z: 0,
-        })
+      return quadtreeCoordinates(0, 0, 0).getDescendantCoordinates(
+        octreeCoordinates(0, 0, 0, 0)
       );
     }).toThrowDeveloperError();
 
     // mismatched subtreeLevels
     expect(function () {
-      return new ImplicitTileCoordinates({
-        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-        subtreeLevels: 2,
-        level: 0,
-        x: 0,
-        y: 0,
-      }).getDescendantCoordinates(
-        new ImplicitTileCoordinates({
-          subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-          subtreeLevels: 3,
-          level: 0,
-          x: 0,
-          y: 0,
-        })
-      );
+      var subtreeLevelsA = 2;
+      var subtreeLevelsB = 3;
+      return quadtreeCoordinates(
+        0,
+        0,
+        0,
+        subtreeLevelsA
+      ).getDescendantCoordinates(quadtreeCoordinates(0, 0, 0, subtreeLevelsB));
     }).toThrowDeveloperError();
   });
 
   it("getDescendantCoordinates works as expected for quadtree", function () {
     expect(
-      internalQuadtree(0, 0, 0)
-        .getDescendantCoordinates(internalQuadtree(0, 0, 0))
-        .isEqual(internalQuadtree(0, 0, 0))
+      quadtreeCoordinates(0, 0, 0)
+        .getDescendantCoordinates(quadtreeCoordinates(0, 0, 0))
+        .isEqual(quadtreeCoordinates(0, 0, 0))
     ).toEqual(true);
 
     expect(
-      internalQuadtree(0, 0, 0)
-        .getDescendantCoordinates(internalQuadtree(1, 1, 1))
-        .isEqual(internalQuadtree(1, 1, 1))
+      quadtreeCoordinates(0, 0, 0)
+        .getDescendantCoordinates(quadtreeCoordinates(1, 1, 1))
+        .isEqual(quadtreeCoordinates(1, 1, 1))
     ).toEqual(true);
 
     expect(
-      internalQuadtree(1, 1, 1)
-        .getDescendantCoordinates(internalQuadtree(2, 3, 3))
-        .isEqual(internalQuadtree(3, 7, 7))
+      quadtreeCoordinates(1, 1, 1)
+        .getDescendantCoordinates(quadtreeCoordinates(2, 3, 3))
+        .isEqual(quadtreeCoordinates(3, 7, 7))
     ).toEqual(true);
   });
 
   it("getDescendantCoordinates works as expected for octree", function () {
     expect(
-      internalOctree(0, 0, 0, 0)
-        .getDescendantCoordinates(internalOctree(0, 0, 0, 0))
-        .isEqual(internalOctree(0, 0, 0, 0))
+      octreeCoordinates(0, 0, 0, 0)
+        .getDescendantCoordinates(octreeCoordinates(0, 0, 0, 0))
+        .isEqual(octreeCoordinates(0, 0, 0, 0))
     ).toEqual(true);
 
     expect(
-      internalOctree(0, 0, 0, 0)
-        .getDescendantCoordinates(internalOctree(1, 1, 1, 1))
-        .isEqual(internalOctree(1, 1, 1, 1))
+      octreeCoordinates(0, 0, 0, 0)
+        .getDescendantCoordinates(octreeCoordinates(1, 1, 1, 1))
+        .isEqual(octreeCoordinates(1, 1, 1, 1))
     ).toEqual(true);
 
     expect(
-      internalOctree(1, 1, 1, 1)
-        .getDescendantCoordinates(internalOctree(2, 3, 3, 3))
-        .isEqual(internalOctree(3, 7, 7, 7))
+      octreeCoordinates(1, 1, 1, 1)
+        .getDescendantCoordinates(octreeCoordinates(2, 3, 3, 3))
+        .isEqual(octreeCoordinates(3, 7, 7, 7))
     ).toEqual(true);
   });
 
   it("getAncestorCoordinates throws with invalid inputs", function () {
     // undefined input
     expect(function () {
-      return internalQuadtree(0, 0, 0).getAncestorCoordinates(undefined);
+      return quadtreeCoordinates(0, 0, 0).getAncestorCoordinates(undefined);
     }).toThrowDeveloperError();
 
     // negative input
     expect(function () {
-      return internalQuadtree(0, 0, 0).getAncestorCoordinates(-1);
+      return quadtreeCoordinates(0, 0, 0).getAncestorCoordinates(-1);
     }).toThrowDeveloperError();
 
     // ancestor cannot be above tileset root
     expect(function () {
-      return internalQuadtree(0, 0, 0).getAncestorCoordinates(1);
+      return quadtreeCoordinates(0, 0, 0).getAncestorCoordinates(1);
     }).toThrowDeveloperError();
   });
 
   it("getAncestorCoordinates works as expected for quadtree", function () {
     expect(
-      internalQuadtree(0, 0, 0)
+      quadtreeCoordinates(0, 0, 0)
         .getAncestorCoordinates(0)
-        .isEqual(internalQuadtree(0, 0, 0))
+        .isEqual(quadtreeCoordinates(0, 0, 0))
     ).toEqual(true);
 
     expect(
-      internalQuadtree(1, 0, 0)
+      quadtreeCoordinates(1, 0, 0)
         .getAncestorCoordinates(1)
-        .isEqual(internalQuadtree(0, 0, 0))
+        .isEqual(quadtreeCoordinates(0, 0, 0))
     ).toEqual(true);
 
     expect(
-      internalQuadtree(1, 1, 1)
+      quadtreeCoordinates(1, 1, 1)
         .getAncestorCoordinates(1)
-        .isEqual(internalQuadtree(0, 0, 0))
+        .isEqual(quadtreeCoordinates(0, 0, 0))
     ).toEqual(true);
 
     expect(
-      internalQuadtree(2, 3, 3)
+      quadtreeCoordinates(2, 3, 3)
         .getAncestorCoordinates(1)
-        .isEqual(internalQuadtree(1, 1, 1))
+        .isEqual(quadtreeCoordinates(1, 1, 1))
     ).toEqual(true);
 
     expect(
-      internalQuadtree(2, 3, 3)
+      quadtreeCoordinates(2, 3, 3)
         .getAncestorCoordinates(2)
-        .isEqual(internalQuadtree(0, 0, 0))
+        .isEqual(quadtreeCoordinates(0, 0, 0))
     ).toEqual(true);
   });
 
   it("getAncestorCoordinates works as expected for octree", function () {
     expect(
-      internalOctree(0, 0, 0, 0)
+      octreeCoordinates(0, 0, 0, 0)
         .getAncestorCoordinates(0)
-        .isEqual(internalOctree(0, 0, 0, 0))
+        .isEqual(octreeCoordinates(0, 0, 0, 0))
     ).toEqual(true);
 
     expect(
-      internalOctree(1, 0, 0, 0)
+      octreeCoordinates(1, 0, 0, 0)
         .getAncestorCoordinates(1)
-        .isEqual(internalOctree(0, 0, 0, 0))
+        .isEqual(octreeCoordinates(0, 0, 0, 0))
     ).toEqual(true);
 
     expect(
-      internalOctree(1, 1, 1, 1)
+      octreeCoordinates(1, 1, 1, 1)
         .getAncestorCoordinates(1)
-        .isEqual(internalOctree(0, 0, 0, 0))
+        .isEqual(octreeCoordinates(0, 0, 0, 0))
     ).toEqual(true);
 
     expect(
-      internalOctree(2, 3, 3, 3)
+      octreeCoordinates(2, 3, 3, 3)
         .getAncestorCoordinates(1)
-        .isEqual(internalOctree(1, 1, 1, 1))
+        .isEqual(octreeCoordinates(1, 1, 1, 1))
     ).toEqual(true);
 
     expect(
-      internalOctree(2, 3, 3, 3)
+      octreeCoordinates(2, 3, 3, 3)
         .getAncestorCoordinates(2)
-        .isEqual(internalOctree(0, 0, 0, 0))
+        .isEqual(octreeCoordinates(0, 0, 0, 0))
     ).toEqual(true);
   });
 
   it("getOffsetCoordinates throws with invalid inputs", function () {
     // undefined input
     expect(function () {
-      return internalQuadtree(0, 0, 0).getOffsetCoordinates(undefined);
+      return quadtreeCoordinates(0, 0, 0).getOffsetCoordinates(undefined);
     }).toThrowDeveloperError();
 
     // descendant is above ancestor
     expect(function () {
-      return internalQuadtree(1, 0, 0).getOffsetCoordinates(
-        internalQuadtree(0, 0, 0)
+      return quadtreeCoordinates(1, 0, 0).getOffsetCoordinates(
+        quadtreeCoordinates(0, 0, 0)
       );
     }).toThrowDeveloperError();
 
     // descendant is not actually a descendant
     expect(function () {
-      return internalQuadtree(1, 0, 0).getOffsetCoordinates(
-        internalQuadtree(2, 3, 3)
+      return quadtreeCoordinates(1, 0, 0).getOffsetCoordinates(
+        quadtreeCoordinates(2, 3, 3)
       );
     }).toThrowDeveloperError();
 
     // mismatched subdivisionScheme
     expect(function () {
-      return new ImplicitTileCoordinates({
-        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-        subtreeLevels: 2,
-        level: 0,
-        x: 0,
-        y: 0,
-      }).getOffsetCoordinates(
-        new ImplicitTileCoordinates({
-          subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
-          subtreeLevels: 2,
-          level: 0,
-          x: 0,
-          y: 0,
-          z: 0,
-        })
+      return quadtreeCoordinates(0, 0, 0).getOffsetCoordinates(
+        octreeCoordinates(0, 0, 0, 0)
       );
     }).toThrowDeveloperError();
 
     // mismatched subtreeLevels
     expect(function () {
-      return new ImplicitTileCoordinates({
-        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-        subtreeLevels: 2,
-        level: 0,
-        x: 0,
-        y: 0,
-      }).getOffsetCoordinates(
-        new ImplicitTileCoordinates({
-          subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-          subtreeLevels: 3,
-          level: 0,
-          x: 0,
-          y: 0,
-        })
+      var subtreeLevelsA = 2;
+      var subtreeLevelsB = 3;
+      return quadtreeCoordinates(0, 0, 0, subtreeLevelsA).getOffsetCoordinates(
+        quadtreeCoordinates(0, 0, 0, subtreeLevelsB)
       );
     }).toThrowDeveloperError();
   });
 
   it("getOffsetCoordinates works as expected for quadtree", function () {
     expect(
-      internalQuadtree(0, 0, 0)
-        .getOffsetCoordinates(internalQuadtree(0, 0, 0))
-        .isEqual(internalQuadtree(0, 0, 0))
+      quadtreeCoordinates(0, 0, 0)
+        .getOffsetCoordinates(quadtreeCoordinates(0, 0, 0))
+        .isEqual(quadtreeCoordinates(0, 0, 0))
     ).toEqual(true);
 
     expect(
-      internalQuadtree(0, 0, 0)
-        .getOffsetCoordinates(internalQuadtree(1, 1, 1))
-        .isEqual(internalQuadtree(1, 1, 1))
+      quadtreeCoordinates(0, 0, 0)
+        .getOffsetCoordinates(quadtreeCoordinates(1, 1, 1))
+        .isEqual(quadtreeCoordinates(1, 1, 1))
     ).toEqual(true);
 
     expect(
-      internalQuadtree(0, 0, 0)
-        .getOffsetCoordinates(internalQuadtree(2, 3, 3))
-        .isEqual(internalQuadtree(2, 3, 3))
+      quadtreeCoordinates(0, 0, 0)
+        .getOffsetCoordinates(quadtreeCoordinates(2, 3, 3))
+        .isEqual(quadtreeCoordinates(2, 3, 3))
     ).toEqual(true);
 
     expect(
-      internalQuadtree(1, 1, 1)
-        .getOffsetCoordinates(internalQuadtree(2, 2, 2))
-        .isEqual(internalQuadtree(1, 0, 0))
+      quadtreeCoordinates(1, 1, 1)
+        .getOffsetCoordinates(quadtreeCoordinates(2, 2, 2))
+        .isEqual(quadtreeCoordinates(1, 0, 0))
     ).toEqual(true);
   });
 
   it("getOffsetCoordinates works as expected for octree", function () {
     expect(
-      internalOctree(0, 0, 0, 0)
-        .getOffsetCoordinates(internalOctree(0, 0, 0, 0))
-        .isEqual(internalOctree(0, 0, 0, 0))
+      octreeCoordinates(0, 0, 0, 0)
+        .getOffsetCoordinates(octreeCoordinates(0, 0, 0, 0))
+        .isEqual(octreeCoordinates(0, 0, 0, 0))
     ).toEqual(true);
 
     expect(
-      internalOctree(0, 0, 0, 0)
-        .getOffsetCoordinates(internalOctree(1, 1, 1, 1))
-        .isEqual(internalOctree(1, 1, 1, 1))
+      octreeCoordinates(0, 0, 0, 0)
+        .getOffsetCoordinates(octreeCoordinates(1, 1, 1, 1))
+        .isEqual(octreeCoordinates(1, 1, 1, 1))
     ).toEqual(true);
 
     expect(
-      internalOctree(0, 0, 0, 0)
-        .getOffsetCoordinates(internalOctree(2, 3, 3, 3))
-        .isEqual(internalOctree(2, 3, 3, 3))
+      octreeCoordinates(0, 0, 0, 0)
+        .getOffsetCoordinates(octreeCoordinates(2, 3, 3, 3))
+        .isEqual(octreeCoordinates(2, 3, 3, 3))
     ).toEqual(true);
 
     expect(
-      internalOctree(1, 1, 1, 1)
-        .getOffsetCoordinates(internalOctree(2, 2, 2, 2))
-        .isEqual(internalOctree(1, 0, 0, 0))
+      octreeCoordinates(1, 1, 1, 1)
+        .getOffsetCoordinates(octreeCoordinates(2, 2, 2, 2))
+        .isEqual(octreeCoordinates(1, 0, 0, 0))
     ).toEqual(true);
   });
 
   it("getChildCoordinates throws for invalid inputs", function () {
-    var coordinates = new ImplicitTileCoordinates({
-      subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-      subtreeLevels: 6,
-      level: 1,
-      x: 0,
-      y: 0,
-    });
+    var coordinates = quadtreeCoordinates(1, 0, 0);
     expect(function () {
       return coordinates.getChildCoordinates(undefined);
     }).toThrowDeveloperError();
@@ -399,308 +369,208 @@ describe("Scene/ImplicitTileCoordinates", function () {
   });
 
   it("getChildCoordinates works as expected for quadree", function () {
-    var coordinates = new ImplicitTileCoordinates({
-      subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-      subtreeLevels: 6,
-      level: 1,
-      x: 0,
-      y: 0,
-    });
+    var coordinates = quadtreeCoordinates(1, 0, 0);
 
-    var expectedChildren = [
-      {
-        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-        subtreeLevels: 6,
-        level: 2,
-        x: 0,
-        y: 0,
-      },
-      {
-        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-        subtreeLevels: 6,
-        level: 2,
-        x: 1,
-        y: 0,
-      },
-      {
-        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-        subtreeLevels: 6,
-        level: 2,
-        x: 0,
-        y: 1,
-      },
-      {
-        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-        subtreeLevels: 6,
-        level: 2,
-        x: 1,
-        y: 1,
-      },
-    ];
+    expect(
+      coordinates.getChildCoordinates(0).isEqual(quadtreeCoordinates(2, 0, 0))
+    ).toEqual(true);
 
-    for (var i = 0; i < expectedChildren.length; i++) {
-      var expected = new ImplicitTileCoordinates(expectedChildren[i]);
-      expect(coordinates.getChildCoordinates(i).isEqual(expected)).toEqual(
-        true
-      );
-    }
+    expect(
+      coordinates.getChildCoordinates(1).isEqual(quadtreeCoordinates(2, 1, 0))
+    ).toEqual(true);
+
+    expect(
+      coordinates.getChildCoordinates(2).isEqual(quadtreeCoordinates(2, 0, 1))
+    ).toEqual(true);
+
+    expect(
+      coordinates.getChildCoordinates(3).isEqual(quadtreeCoordinates(2, 1, 1))
+    ).toEqual(true);
   });
 
   it("getChildCoordinates works as expected for octree", function () {
-    var coordinates = new ImplicitTileCoordinates({
-      subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
-      subtreeLevels: 6,
-      level: 1,
-      x: 0,
-      y: 1,
-      z: 1,
-    });
+    var coordinates = octreeCoordinates(1, 0, 1, 1);
 
-    var expectedChildren = [
-      {
-        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
-        subtreeLevels: 6,
-        level: 2,
-        x: 0,
-        y: 2,
-        z: 2,
-      },
-      {
-        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
-        subtreeLevels: 6,
-        level: 2,
-        x: 1,
-        y: 2,
-        z: 2,
-      },
-      {
-        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
-        subtreeLevels: 6,
-        level: 2,
-        x: 0,
-        y: 3,
-        z: 2,
-      },
-      {
-        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
-        subtreeLevels: 6,
-        level: 2,
-        x: 1,
-        y: 3,
-        z: 2,
-      },
-      {
-        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
-        subtreeLevels: 6,
-        level: 2,
-        x: 0,
-        y: 2,
-        z: 3,
-      },
-      {
-        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
-        subtreeLevels: 6,
-        level: 2,
-        x: 1,
-        y: 2,
-        z: 3,
-      },
-      {
-        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
-        subtreeLevels: 6,
-        level: 2,
-        x: 0,
-        y: 3,
-        z: 3,
-      },
-      {
-        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
-        subtreeLevels: 6,
-        level: 2,
-        x: 1,
-        y: 3,
-        z: 3,
-      },
-    ];
+    expect(
+      coordinates.getChildCoordinates(0).isEqual(octreeCoordinates(2, 0, 2, 2))
+    ).toEqual(true);
 
-    for (var i = 0; i < expectedChildren.length; i++) {
-      var expected = new ImplicitTileCoordinates(expectedChildren[i]);
-      expect(coordinates.getChildCoordinates(i).isEqual(expected)).toEqual(
-        true
-      );
-    }
+    expect(
+      coordinates.getChildCoordinates(1).isEqual(octreeCoordinates(2, 1, 2, 2))
+    ).toEqual(true);
+
+    expect(
+      coordinates.getChildCoordinates(2).isEqual(octreeCoordinates(2, 0, 3, 2))
+    ).toEqual(true);
+
+    expect(
+      coordinates.getChildCoordinates(3).isEqual(octreeCoordinates(2, 1, 3, 2))
+    ).toEqual(true);
+
+    expect(
+      coordinates.getChildCoordinates(4).isEqual(octreeCoordinates(2, 0, 2, 3))
+    ).toEqual(true);
+
+    expect(
+      coordinates.getChildCoordinates(5).isEqual(octreeCoordinates(2, 1, 2, 3))
+    ).toEqual(true);
+
+    expect(
+      coordinates.getChildCoordinates(6).isEqual(octreeCoordinates(2, 0, 3, 3))
+    ).toEqual(true);
+
+    expect(
+      coordinates.getChildCoordinates(7).isEqual(octreeCoordinates(2, 1, 3, 3))
+    ).toEqual(true);
   });
 
   it("getSubtreeCoordinates works as expected for quadtree", function () {
     expect(
-      internalQuadtree(0, 0, 0)
+      quadtreeCoordinates(0, 0, 0)
         .getSubtreeCoordinates()
-        .isEqual(internalQuadtree(0, 0, 0))
+        .isEqual(quadtreeCoordinates(0, 0, 0))
     ).toEqual(true);
 
     expect(
-      internalQuadtree(1, 1, 1)
+      quadtreeCoordinates(1, 1, 1)
         .getSubtreeCoordinates()
-        .isEqual(internalQuadtree(0, 0, 0))
+        .isEqual(quadtreeCoordinates(0, 0, 0))
     ).toEqual(true);
 
     expect(
-      internalQuadtree(2, 3, 3)
+      quadtreeCoordinates(2, 3, 3)
         .getSubtreeCoordinates()
-        .isEqual(internalQuadtree(2, 3, 3))
+        .isEqual(quadtreeCoordinates(2, 3, 3))
     ).toEqual(true);
 
     expect(
-      internalQuadtree(3, 7, 7)
+      quadtreeCoordinates(3, 7, 7)
         .getSubtreeCoordinates()
-        .isEqual(internalQuadtree(2, 3, 3))
+        .isEqual(quadtreeCoordinates(2, 3, 3))
     ).toEqual(true);
   });
 
   it("getSubtreeCoordinates works as expected for octree", function () {
     expect(
-      internalOctree(0, 0, 0, 0)
+      octreeCoordinates(0, 0, 0, 0)
         .getSubtreeCoordinates()
-        .isEqual(internalOctree(0, 0, 0, 0))
+        .isEqual(octreeCoordinates(0, 0, 0, 0))
     ).toEqual(true);
 
     expect(
-      internalOctree(1, 1, 1, 1)
+      octreeCoordinates(1, 1, 1, 1)
         .getSubtreeCoordinates()
-        .isEqual(internalOctree(0, 0, 0, 0))
+        .isEqual(octreeCoordinates(0, 0, 0, 0))
     ).toEqual(true);
 
     expect(
-      internalOctree(2, 3, 3, 3)
+      octreeCoordinates(2, 3, 3, 3)
         .getSubtreeCoordinates()
-        .isEqual(internalOctree(2, 3, 3, 3))
+        .isEqual(octreeCoordinates(2, 3, 3, 3))
     ).toEqual(true);
 
     expect(
-      internalOctree(3, 7, 7, 7)
+      octreeCoordinates(3, 7, 7, 7)
         .getSubtreeCoordinates()
-        .isEqual(internalOctree(2, 3, 3, 3))
+        .isEqual(octreeCoordinates(2, 3, 3, 3))
     ).toEqual(true);
   });
 
   it("getParentSubtreeCoordinates throws for invalid inputs", function () {
     // tileset root
     expect(function () {
-      return internalQuadtree(0, 0, 0).getParentSubtreeCoordinates();
+      return quadtreeCoordinates(0, 0, 0).getParentSubtreeCoordinates();
     }).toThrowDeveloperError();
 
     // in root subtree
     expect(function () {
-      return internalQuadtree(1, 1, 1).getParentSubtreeCoordinates();
+      return quadtreeCoordinates(1, 1, 1).getParentSubtreeCoordinates();
     }).toThrowDeveloperError();
   });
 
   it("getParentSubtreeCoordinates works as expected for quadtree", function () {
     expect(
-      internalQuadtree(2, 0, 0)
+      quadtreeCoordinates(2, 0, 0)
         .getParentSubtreeCoordinates()
-        .isEqual(internalQuadtree(0, 0, 0))
+        .isEqual(quadtreeCoordinates(0, 0, 0))
     ).toEqual(true);
 
     expect(
-      internalQuadtree(2, 3, 3)
+      quadtreeCoordinates(2, 3, 3)
         .getParentSubtreeCoordinates()
-        .isEqual(internalQuadtree(0, 0, 0))
+        .isEqual(quadtreeCoordinates(0, 0, 0))
     ).toEqual(true);
 
     expect(
-      internalQuadtree(3, 7, 7)
+      quadtreeCoordinates(3, 7, 7)
         .getParentSubtreeCoordinates()
-        .isEqual(internalQuadtree(0, 0, 0))
+        .isEqual(quadtreeCoordinates(0, 0, 0))
     ).toEqual(true);
 
     expect(
-      internalQuadtree(4, 0, 0)
+      quadtreeCoordinates(4, 0, 0)
         .getParentSubtreeCoordinates()
-        .isEqual(internalQuadtree(2, 0, 0))
+        .isEqual(quadtreeCoordinates(2, 0, 0))
     ).toEqual(true);
 
     expect(
-      internalQuadtree(4, 15, 15)
+      quadtreeCoordinates(4, 15, 15)
         .getParentSubtreeCoordinates()
-        .isEqual(internalQuadtree(2, 3, 3))
+        .isEqual(quadtreeCoordinates(2, 3, 3))
     ).toEqual(true);
   });
 
   it("getParentSubtreeCoordinates works as expected for octree", function () {
     expect(
-      internalOctree(2, 0, 0, 0)
+      octreeCoordinates(2, 0, 0, 0)
         .getParentSubtreeCoordinates()
-        .isEqual(internalOctree(0, 0, 0, 0))
+        .isEqual(octreeCoordinates(0, 0, 0, 0))
     ).toEqual(true);
 
     expect(
-      internalOctree(2, 3, 3, 3)
+      octreeCoordinates(2, 3, 3, 3)
         .getParentSubtreeCoordinates()
-        .isEqual(internalOctree(0, 0, 0, 0))
+        .isEqual(octreeCoordinates(0, 0, 0, 0))
     ).toEqual(true);
 
     expect(
-      internalOctree(3, 7, 7, 7)
+      octreeCoordinates(3, 7, 7, 7)
         .getParentSubtreeCoordinates()
-        .isEqual(internalOctree(0, 0, 0, 0))
+        .isEqual(octreeCoordinates(0, 0, 0, 0))
     ).toEqual(true);
 
     expect(
-      internalOctree(4, 0, 0, 0)
+      octreeCoordinates(4, 0, 0, 0)
         .getParentSubtreeCoordinates()
-        .isEqual(internalOctree(2, 0, 0, 0))
+        .isEqual(octreeCoordinates(2, 0, 0, 0))
     ).toEqual(true);
 
     expect(
-      internalOctree(4, 15, 15, 15)
+      octreeCoordinates(4, 15, 15, 15)
         .getParentSubtreeCoordinates()
-        .isEqual(internalOctree(2, 3, 3, 3))
+        .isEqual(octreeCoordinates(2, 3, 3, 3))
     ).toEqual(true);
   });
 
   it("isAncestor throws with invalid inputs", function () {
     // undefined input
     expect(function () {
-      internalQuadtree(0, 0, 0).isAncestor(undefined);
+      quadtreeCoordinates(0, 0, 0).isAncestor(undefined);
     }).toThrowDeveloperError();
 
     // mismatched subdivisionScheme
     expect(function () {
-      return new ImplicitTileCoordinates({
-        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-        subtreeLevels: 2,
-        level: 0,
-        x: 0,
-        y: 0,
-      }).isAncestor(
-        new ImplicitTileCoordinates({
-          subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
-          subtreeLevels: 2,
-          level: 0,
-          x: 0,
-          y: 0,
-          z: 0,
-        })
+      return quadtreeCoordinates(0, 0, 0).isAncestor(
+        octreeCoordinates(0, 0, 0, 0)
       );
     }).toThrowDeveloperError();
 
     // mismatched subtreeLevels
     expect(function () {
-      return new ImplicitTileCoordinates({
-        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-        subtreeLevels: 2,
-        level: 0,
-        x: 0,
-        y: 0,
-      }).isAncestor(
-        new ImplicitTileCoordinates({
-          subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-          subtreeLevels: 3,
-          level: 0,
-          x: 0,
-          y: 0,
-        })
+      var subtreeLevelsA = 2;
+      var subtreeLevelsB = 3;
+      return quadtreeCoordinates(0, 0, 0, subtreeLevelsA).isAncestor(
+        quadtreeCoordinates(0, 0, 0, subtreeLevelsB)
       );
     }).toThrowDeveloperError();
   });
@@ -708,205 +578,153 @@ describe("Scene/ImplicitTileCoordinates", function () {
   it("isAncestor works as expected for quadtree", function () {
     // cannot be ancestor of itself
     expect(
-      internalQuadtree(0, 0, 0).isAncestor(internalQuadtree(0, 0, 0))
+      quadtreeCoordinates(0, 0, 0).isAncestor(quadtreeCoordinates(0, 0, 0))
     ).toEqual(false);
 
     // ancestor one level above
     expect(
-      internalQuadtree(0, 0, 0).isAncestor(internalQuadtree(1, 1, 1))
+      quadtreeCoordinates(0, 0, 0).isAncestor(quadtreeCoordinates(1, 1, 1))
     ).toEqual(true);
 
     // cannot be descendant
     expect(
-      internalQuadtree(1, 1, 1).isAncestor(internalQuadtree(0, 0, 0))
+      quadtreeCoordinates(1, 1, 1).isAncestor(quadtreeCoordinates(0, 0, 0))
     ).toEqual(false);
 
     // works with bigger divide
     expect(
-      internalQuadtree(0, 0, 0).isAncestor(internalQuadtree(3, 7, 7))
+      quadtreeCoordinates(0, 0, 0).isAncestor(quadtreeCoordinates(3, 7, 7))
     ).toEqual(true);
 
     // higher up in the tree but not an ancestor
     expect(
-      internalQuadtree(1, 0, 0).isAncestor(internalQuadtree(2, 3, 3))
+      quadtreeCoordinates(1, 0, 0).isAncestor(quadtreeCoordinates(2, 3, 3))
     ).toEqual(false);
   });
 
   it("isAncestor works as expected for octree", function () {
     // cannot be ancestor of itself
     expect(
-      internalOctree(0, 0, 0, 0).isAncestor(internalOctree(0, 0, 0, 0))
+      octreeCoordinates(0, 0, 0, 0).isAncestor(octreeCoordinates(0, 0, 0, 0))
     ).toEqual(false);
 
     // ancestor one level above
     expect(
-      internalOctree(0, 0, 0, 0).isAncestor(internalOctree(1, 1, 1, 1))
+      octreeCoordinates(0, 0, 0, 0).isAncestor(octreeCoordinates(1, 1, 1, 1))
     ).toEqual(true);
 
     // cannot be descendant
     expect(
-      internalOctree(1, 1, 1, 1).isAncestor(internalOctree(0, 0, 0, 0))
+      octreeCoordinates(1, 1, 1, 1).isAncestor(octreeCoordinates(0, 0, 0, 0))
     ).toEqual(false);
 
     // works with bigger divide
     expect(
-      internalOctree(0, 0, 0, 0).isAncestor(internalOctree(3, 7, 7, 7))
+      octreeCoordinates(0, 0, 0, 0).isAncestor(octreeCoordinates(3, 7, 7, 7))
     ).toEqual(true);
 
     // higher up in the tree but not an ancestor
     expect(
-      internalOctree(1, 0, 0, 0).isAncestor(internalOctree(2, 3, 3, 3))
+      octreeCoordinates(1, 0, 0, 0).isAncestor(octreeCoordinates(2, 3, 3, 3))
     ).toEqual(false);
   });
 
   it("isEqual throws with invalid inputs", function () {
     // undefined input
     expect(function () {
-      internalQuadtree(0, 0, 0).isEqual(undefined);
+      quadtreeCoordinates(0, 0, 0).isEqual(undefined);
     }).toThrowDeveloperError();
   });
 
   it("isEqual works as expected for quadtree", function () {
     // same
     expect(
-      internalOctree(0, 0, 0, 0).isEqual(internalOctree(0, 0, 0, 0))
+      octreeCoordinates(0, 0, 0, 0).isEqual(octreeCoordinates(0, 0, 0, 0))
     ).toEqual(true);
 
     // different level
     expect(
-      internalOctree(0, 0, 0, 0).isEqual(internalOctree(1, 0, 0, 0))
+      octreeCoordinates(0, 0, 0, 0).isEqual(octreeCoordinates(1, 0, 0, 0))
     ).toEqual(false);
 
     // different X
     expect(
-      internalOctree(1, 0, 0, 0).isEqual(internalOctree(1, 1, 0, 0))
+      octreeCoordinates(1, 0, 0, 0).isEqual(octreeCoordinates(1, 1, 0, 0))
     ).toEqual(false);
 
     // different Y
     expect(
-      internalOctree(1, 0, 0, 0).isEqual(internalOctree(1, 0, 1, 0))
+      octreeCoordinates(1, 0, 0, 0).isEqual(octreeCoordinates(1, 0, 1, 0))
     ).toEqual(false);
 
     // different Z
     expect(
-      internalOctree(1, 0, 0, 0).isEqual(internalOctree(1, 0, 0, 1))
+      octreeCoordinates(1, 0, 0, 0).isEqual(octreeCoordinates(1, 0, 0, 1))
     ).toEqual(false);
 
     // mismatched subdivisionScheme
     expect(
-      new ImplicitTileCoordinates({
-        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-        subtreeLevels: 2,
-        level: 0,
-        x: 0,
-        y: 0,
-      }).isEqual(
-        new ImplicitTileCoordinates({
-          subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
-          subtreeLevels: 2,
-          level: 0,
-          x: 0,
-          y: 0,
-          z: 0,
-        })
-      )
+      quadtreeCoordinates(0, 0, 0).isEqual(octreeCoordinates(0, 0, 0, 0))
     ).toEqual(false);
 
     // mismatched subtreeLevels
+    var subtreeLevelsA = 2;
+    var subtreeLevelsB = 3;
     expect(
-      new ImplicitTileCoordinates({
-        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-        subtreeLevels: 2,
-        level: 0,
-        x: 0,
-        y: 0,
-      }).isEqual(
-        new ImplicitTileCoordinates({
-          subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-          subtreeLevels: 3,
-          level: 0,
-          x: 0,
-          y: 0,
-        })
+      quadtreeCoordinates(0, 0, 0, subtreeLevelsA).isEqual(
+        quadtreeCoordinates(0, 0, 0, subtreeLevelsB)
       )
     ).toEqual(false);
   });
 
   it("isImplicitTilesetRoot works as expected", function () {
-    expect(internalQuadtree(0, 0, 0).isImplicitTilesetRoot()).toEqual(true);
-    expect(internalQuadtree(1, 0, 0).isImplicitTilesetRoot()).toEqual(false);
-    expect(internalQuadtree(2, 0, 0).isImplicitTilesetRoot()).toEqual(false);
+    expect(quadtreeCoordinates(0, 0, 0).isImplicitTilesetRoot()).toEqual(true);
+    expect(quadtreeCoordinates(1, 0, 0).isImplicitTilesetRoot()).toEqual(false);
+    expect(quadtreeCoordinates(2, 0, 0).isImplicitTilesetRoot()).toEqual(false);
   });
 
   it("isSubtreeRoot works as expected", function () {
-    expect(internalQuadtree(0, 0, 0).isSubtreeRoot()).toEqual(true);
-    expect(internalQuadtree(1, 0, 0).isSubtreeRoot()).toEqual(false);
-    expect(internalQuadtree(2, 0, 0).isSubtreeRoot()).toEqual(true);
-    expect(internalQuadtree(3, 0, 0).isSubtreeRoot()).toEqual(false);
+    expect(quadtreeCoordinates(0, 0, 0).isSubtreeRoot()).toEqual(true);
+    expect(quadtreeCoordinates(1, 0, 0).isSubtreeRoot()).toEqual(false);
+    expect(quadtreeCoordinates(2, 0, 0).isSubtreeRoot()).toEqual(true);
+    expect(quadtreeCoordinates(3, 0, 0).isSubtreeRoot()).toEqual(false);
   });
 
   it("isBottomOfSubtree works as expected", function () {
-    expect(internalQuadtree(0, 0, 0).isBottomOfSubtree()).toEqual(false);
-    expect(internalQuadtree(1, 0, 0).isBottomOfSubtree()).toEqual(true);
-    expect(internalQuadtree(2, 0, 0).isBottomOfSubtree()).toEqual(false);
-    expect(internalQuadtree(3, 0, 0).isBottomOfSubtree()).toEqual(true);
+    expect(quadtreeCoordinates(0, 0, 0).isBottomOfSubtree()).toEqual(false);
+    expect(quadtreeCoordinates(1, 0, 0).isBottomOfSubtree()).toEqual(true);
+    expect(quadtreeCoordinates(2, 0, 0).isBottomOfSubtree()).toEqual(false);
+    expect(quadtreeCoordinates(3, 0, 0).isBottomOfSubtree()).toEqual(true);
   });
 
   it("childIndex works as expected for quadtree", function () {
-    var coordinates = new ImplicitTileCoordinates({
-      subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-      subtreeLevels: 6,
-      level: 4,
-      x: 3,
-      y: 2,
-    });
-    // interleaving the last bit of x, y gives 0b01 = 1
-    expect(coordinates.childIndex).toEqual(1);
+    // x = 3 = 0b11
+    // y = 2 = 0b10
+    // interleaving the last bit of y, x gives 0b01 = 1
+    expect(quadtreeCoordinates(4, 3, 2).childIndex).toEqual(1);
   });
 
   it("childIndex works as expected for octree", function () {
-    var coordinates = new ImplicitTileCoordinates({
-      subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
-      subtreeLevels: 6,
-      level: 4,
-      x: 3,
-      y: 2,
-      z: 1,
-    });
-    // interleaving the last bit of z, x, y gives 0b101 = 5
-    expect(coordinates.childIndex).toEqual(5);
+    // x = 3 = 0b11
+    // y = 2 = 0b10
+    // z = 1 = 0b01
+    // interleaving the last bit of z, y, x gives 0b101 = 5
+    expect(octreeCoordinates(4, 3, 2, 1).childIndex).toEqual(5);
   });
 
   it("mortonIndex works as expected for quadtree", function () {
-    var coordinates = new ImplicitTileCoordinates({
-      subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-      subtreeLevels: 6,
-      level: 4,
-      x: 5,
-      y: 11,
-    });
-
     // x = 5 =  0b0101
     // y = 11 = 0b1011
     // interleave(y, x) = 0b10011011 = 155
-    expect(coordinates.mortonIndex).toEqual(155);
+    expect(quadtreeCoordinates(4, 5, 11).mortonIndex).toEqual(155);
   });
 
   it("mortonIndex works as expected for octree", function () {
-    var coordinates = new ImplicitTileCoordinates({
-      subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
-      subtreeLevels: 8,
-      level: 6,
-      x: 7,
-      y: 15,
-      z: 32,
-    });
-
     // x = 7 =  0b000111
     // y = 15 = 0b001111
     // z = 32 = 0b100000
     // interleave(z, y, x) = 0b100000010011011011 = 132315
-    expect(coordinates.mortonIndex).toEqual(132315);
+    expect(octreeCoordinates(6, 7, 15, 32).mortonIndex).toEqual(132315);
   });
 
   it("fromMortonIndex works as expected for quadtree", function () {
@@ -921,15 +739,9 @@ describe("Scene/ImplicitTileCoordinates", function () {
       42
     );
 
-    var expected = new ImplicitTileCoordinates({
-      subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-      subtreeLevels: subtreeLevels,
-      level: 3,
-      x: 0,
-      y: 7,
-    });
-
-    expect(coordinates.isEqual(expected)).toEqual(true);
+    expect(
+      coordinates.isEqual(quadtreeCoordinates(3, 0, 7, subtreeLevels))
+    ).toEqual(true);
   });
 
   it("fromMortonIndex works as expected for octree", function () {
@@ -944,46 +756,22 @@ describe("Scene/ImplicitTileCoordinates", function () {
       43
     );
 
-    var expected = new ImplicitTileCoordinates({
-      subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
-      subtreeLevels: subtreeLevels,
-      level: 2,
-      x: 3,
-      y: 1,
-      z: 2,
-    });
-
-    expect(coordinates.isEqual(expected)).toEqual(true);
+    expect(
+      coordinates.isEqual(octreeCoordinates(2, 3, 1, 2, subtreeLevels))
+    ).toEqual(true);
   });
 
   it("tileIndex works as expected for quadtree", function () {
-    var coordinates = new ImplicitTileCoordinates({
-      subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-      subtreeLevels: 6,
-      level: 4,
-      x: 5,
-      y: 11,
-    });
-
     // level = 4
     // x = 5 =  0b0101
     // y = 11 = 0b1011
     // interleave(y, x) = 0b10011011 = 155
     // levelOffset = (4^level-1)/(4-1) = 85
     // tileIndex = 85 + 155 = 240
-    expect(coordinates.tileIndex).toEqual(240);
+    expect(quadtreeCoordinates(4, 5, 11).tileIndex).toEqual(240);
   });
 
   it("tileIndex works as expected for octree", function () {
-    var coordinates = new ImplicitTileCoordinates({
-      subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
-      subtreeLevels: 8,
-      level: 6,
-      x: 7,
-      y: 15,
-      z: 32,
-    });
-
     // level = 6
     // x = 7 =  0b000111
     // y = 15 = 0b001111
@@ -991,7 +779,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
     // interleave(z, y, x) = 0b100000010011011011 = 132315
     // levelOffset = (8^level-1)/(8-1) = 37449
     // tileIndex = 37449 + 132315 = 169764
-    expect(coordinates.tileIndex).toEqual(169764);
+    expect(octreeCoordinates(6, 7, 15, 32).tileIndex).toEqual(169764);
   });
 
   it("fromTileIndex works as expected for quadtree", function () {
@@ -1008,15 +796,9 @@ describe("Scene/ImplicitTileCoordinates", function () {
       63
     );
 
-    var expected = new ImplicitTileCoordinates({
-      subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-      subtreeLevels: subtreeLevels,
-      level: 3,
-      x: 0,
-      y: 7,
-    });
-
-    expect(coordinates.isEqual(expected)).toEqual(true);
+    expect(
+      coordinates.isEqual(quadtreeCoordinates(3, 0, 7, subtreeLevels))
+    ).toEqual(true);
   });
 
   it("fromTileIndex works as expected for octree", function () {
@@ -1033,27 +815,16 @@ describe("Scene/ImplicitTileCoordinates", function () {
       52
     );
 
-    var expected = new ImplicitTileCoordinates({
-      subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
-      subtreeLevels: subtreeLevels,
-      level: 2,
-      x: 3,
-      y: 1,
-      z: 2,
-    });
-
-    expect(coordinates.isEqual(expected)).toEqual(true);
+    expect(
+      coordinates.isEqual(octreeCoordinates(2, 3, 1, 2, subtreeLevels))
+    ).toEqual(true);
   });
 
   it("getTemplateValues works as expected for quadtree", function () {
-    var coordinates = new ImplicitTileCoordinates({
-      subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
-      subtreeLevels: 6,
-      level: 4,
-      x: 3,
-      y: 2,
-    });
-    expect(coordinates.getTemplateValues()).toEqual({
+    var subtreeLevels = 6;
+    expect(
+      quadtreeCoordinates(4, 3, 2, subtreeLevels).getTemplateValues()
+    ).toEqual({
       level: 4,
       x: 3,
       y: 2,
@@ -1061,15 +832,11 @@ describe("Scene/ImplicitTileCoordinates", function () {
   });
 
   it("getTemplateValues works as expected for octree", function () {
-    var coordinates = new ImplicitTileCoordinates({
-      subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
-      subtreeLevels: 6,
-      level: 4,
-      x: 3,
-      y: 2,
-      z: 1,
-    });
-    expect(coordinates.getTemplateValues()).toEqual({
+    var subtreeLevels = 6;
+
+    expect(
+      octreeCoordinates(4, 3, 2, 1, subtreeLevels).getTemplateValues()
+    ).toEqual({
       level: 4,
       x: 3,
       y: 2,

--- a/Specs/Scene/ImplicitTileCoordinatesSpec.js
+++ b/Specs/Scene/ImplicitTileCoordinatesSpec.js
@@ -7,6 +7,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
   it("constructs quadtree", function () {
     var coordinates = new ImplicitTileCoordinates({
       subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+      subtreeLevels: 6,
       level: 4,
       x: 3,
       y: 2,
@@ -24,6 +25,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
   it("constructs octree", function () {
     var coordinates = new ImplicitTileCoordinates({
       subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+      subtreeLevels: 6,
       level: 4,
       x: 3,
       y: 2,
@@ -39,9 +41,91 @@ describe("Scene/ImplicitTileCoordinates", function () {
     expect(coordinates.z).toEqual(1);
   });
 
+  it("constructor throws with invalid inputs", function () {
+    // negative level
+    expect(function () {
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: -1,
+        x: 0,
+        y: 0,
+      });
+    }).toThrowDeveloperError();
+
+    // negative x
+    expect(function () {
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: -1,
+        y: 0,
+      });
+    }).toThrowDeveloperError();
+
+    // negative y
+    expect(function () {
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: -1,
+      });
+    }).toThrowDeveloperError();
+
+    // negative z
+    expect(function () {
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+        z: -1,
+      });
+    }).toThrowDeveloperError();
+
+    // out of range x
+    expect(function () {
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 4,
+        y: 0,
+      });
+    }).toThrowDeveloperError();
+
+    // out of range y
+    expect(function () {
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 4,
+      });
+    }).toThrowDeveloperError();
+
+    // out of range z
+    expect(function () {
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+        z: 4,
+      });
+    }).toThrowDeveloperError();
+  });
+
   it("deriveChildCoordinates throws for out of bounds index", function () {
     var coordinates = new ImplicitTileCoordinates({
       subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+      subtreeLevels: 6,
       level: 1,
       x: 0,
       y: 0,
@@ -57,6 +141,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
   it("derives child quadtree coordinates", function () {
     var coordinates = new ImplicitTileCoordinates({
       subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+      subtreeLevels: 6,
       level: 1,
       x: 0,
       y: 0,
@@ -65,24 +150,28 @@ describe("Scene/ImplicitTileCoordinates", function () {
     var expectedChildren = [
       {
         subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 6,
         level: 2,
         x: 0,
         y: 0,
       },
       {
         subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 6,
         level: 2,
         x: 1,
         y: 0,
       },
       {
         subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 6,
         level: 2,
         x: 0,
         y: 1,
       },
       {
         subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 6,
         level: 2,
         x: 1,
         y: 1,
@@ -98,6 +187,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
   it("derives child octree coordinates", function () {
     var coordinates = new ImplicitTileCoordinates({
       subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+      subtreeLevels: 6,
       level: 1,
       x: 0,
       y: 1,
@@ -107,6 +197,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
     var expectedChildren = [
       {
         subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 6,
         level: 2,
         x: 0,
         y: 2,
@@ -114,6 +205,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
       },
       {
         subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 6,
         level: 2,
         x: 1,
         y: 2,
@@ -121,6 +213,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
       },
       {
         subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 6,
         level: 2,
         x: 0,
         y: 3,
@@ -128,6 +221,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
       },
       {
         subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 6,
         level: 2,
         x: 1,
         y: 3,
@@ -135,6 +229,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
       },
       {
         subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 6,
         level: 2,
         x: 0,
         y: 2,
@@ -142,6 +237,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
       },
       {
         subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 6,
         level: 2,
         x: 1,
         y: 2,
@@ -149,6 +245,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
       },
       {
         subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 6,
         level: 2,
         x: 0,
         y: 3,
@@ -156,6 +253,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
       },
       {
         subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 6,
         level: 2,
         x: 1,
         y: 3,
@@ -169,9 +267,1201 @@ describe("Scene/ImplicitTileCoordinates", function () {
     }
   });
 
+  it("deriveDescendantCoordinates throws with mismatched values", function () {
+    // mismatched subdivisionScheme
+    expect(function () {
+      return new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 2,
+        x: 0,
+        y: 0,
+      }).deriveDescendantCoordinates(
+        new ImplicitTileCoordinates({
+          subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+          subtreeLevels: 2,
+          level: 0,
+          x: 0,
+          y: 0,
+          z: 0,
+        })
+      );
+    }).toThrowDeveloperError();
+
+    // mismatched subtreeLevels
+    expect(function () {
+      return new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 2,
+        x: 0,
+        y: 0,
+      }).deriveDescendantCoordinates(
+        new ImplicitTileCoordinates({
+          subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+          subtreeLevels: 3,
+          level: 0,
+          x: 0,
+          y: 0,
+        })
+      );
+    }).toThrowDeveloperError();
+  });
+
+  it("deriveDescendantCoordinates works as expected for quadtree", function () {
+    // no change expected
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+      }).deriveDescendantCoordinates(
+        new ImplicitTileCoordinates({
+          subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+          subtreeLevels: 2,
+          level: 0,
+          x: 0,
+          y: 0,
+        })
+      )
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+      })
+    );
+
+    // one level below with offset
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+      }).deriveDescendantCoordinates(
+        new ImplicitTileCoordinates({
+          subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+          subtreeLevels: 2,
+          level: 1,
+          x: 1,
+          y: 1,
+        })
+      )
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 1,
+        x: 1,
+        y: 1,
+      })
+    );
+
+    // two levels below with offset
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 1,
+        x: 1,
+        y: 1,
+      }).deriveDescendantCoordinates(
+        new ImplicitTileCoordinates({
+          subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+          subtreeLevels: 2,
+          level: 2,
+          x: 3,
+          y: 3,
+        })
+      )
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 3,
+        x: 7,
+        y: 7,
+      })
+    );
+  });
+
+  it("deriveDescendantCoordinates works as expected for octree", function () {
+    // no change expected
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+        z: 0,
+      }).deriveDescendantCoordinates(
+        new ImplicitTileCoordinates({
+          subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+          subtreeLevels: 2,
+          level: 0,
+          x: 0,
+          y: 0,
+          z: 0,
+        })
+      )
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+        z: 0,
+      })
+    );
+
+    // one level below with offset
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+        z: 0,
+      }).deriveDescendantCoordinates(
+        new ImplicitTileCoordinates({
+          subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+          subtreeLevels: 2,
+          level: 1,
+          x: 1,
+          y: 1,
+          z: 1,
+        })
+      )
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 1,
+        x: 1,
+        y: 1,
+        z: 1,
+      })
+    );
+
+    // two levels below with offset
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 1,
+        x: 1,
+        y: 1,
+        z: 1,
+      }).deriveDescendantCoordinates(
+        new ImplicitTileCoordinates({
+          subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+          subtreeLevels: 2,
+          level: 2,
+          x: 3,
+          y: 3,
+          z: 3,
+        })
+      )
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 3,
+        x: 7,
+        y: 7,
+        z: 7,
+      })
+    );
+  });
+
+  it("deriveSubtreeCoordinates works as expected for quadtree", function () {
+    // already root subtree
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+      }).deriveSubtreeCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+      })
+    );
+
+    // inside root subtree
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 2,
+        x: 1,
+        y: 1,
+      }).deriveSubtreeCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 2,
+        x: 1,
+        y: 1,
+      })
+    );
+
+    // already non-root subtree
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 2,
+        x: 3,
+        y: 3,
+      }).deriveSubtreeCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 2,
+        x: 3,
+        y: 3,
+      })
+    );
+
+    // inside non-root subtree
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 3,
+        x: 7,
+        y: 7,
+      }).deriveSubtreeCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 2,
+        x: 3,
+        y: 3,
+      })
+    );
+  });
+
+  it("deriveSubtreeCoordinates works as expected for octree", function () {
+    // already root subtree
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+        z: 0,
+      }).deriveSubtreeCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+        z: 0,
+      })
+    );
+
+    // inside root subtree
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 1,
+        x: 1,
+        y: 1,
+        z: 1,
+      }).deriveSubtreeCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+        z: 0,
+      })
+    );
+
+    // already non-root subtree
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 2,
+        x: 3,
+        y: 3,
+        z: 3,
+      }).deriveSubtreeCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 2,
+        x: 3,
+        y: 3,
+        z: 3,
+      })
+    );
+
+    // inside non-root subtree
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 3,
+        x: 7,
+        y: 7,
+        z: 7,
+      }).deriveSubtreeCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 2,
+        x: 3,
+        y: 3,
+        z: 3,
+      })
+    );
+  });
+
+  it("deriveParentSubtreeCoordinates works as expected for quadtree", function () {
+    // already root subtree
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+      }).deriveParentSubtreeCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+      })
+    );
+
+    // one level below
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 1,
+        x: 1,
+        y: 1,
+      }).deriveParentSubtreeCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+      })
+    );
+
+    // one subtree below
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 3,
+        x: 7,
+        y: 7,
+      }).deriveParentSubtreeCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+      })
+    );
+
+    // one subtree below, but deeper
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 4,
+        x: 0,
+        y: 0,
+      }).deriveParentSubtreeCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 2,
+        x: 0,
+        y: 0,
+      })
+    );
+  });
+
+  it("deriveParentSubtreeCoordinates works as expected for octree", function () {
+    // already root subtree
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+        z: 0,
+      }).deriveParentSubtreeCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+        z: 0,
+      })
+    );
+
+    // one level below
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 1,
+        x: 1,
+        y: 1,
+        z: 1,
+      }).deriveParentSubtreeCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+        z: 0,
+      })
+    );
+
+    // one subtree below
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 3,
+        x: 7,
+        y: 7,
+        z: 7,
+      }).deriveParentSubtreeCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+        z: 0,
+      })
+    );
+
+    // one subtree below, but deeper
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 4,
+        x: 0,
+        y: 0,
+        z: 0,
+      }).deriveParentSubtreeCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 2,
+        x: 0,
+        y: 0,
+        z: 0,
+      })
+    );
+  });
+
+  it("deriveLocalTileCoordinates works as expected for quadtree", function () {
+    // no change
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+      }).deriveLocalTileCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+      })
+    );
+
+    // no change, but deeper
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 1,
+        x: 1,
+        y: 1,
+      }).deriveLocalTileCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 1,
+        x: 1,
+        y: 1,
+      })
+    );
+
+    // local to deeper
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 2,
+        x: 3,
+        y: 3,
+      }).deriveLocalTileCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+      })
+    );
+
+    // local to deeper
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 3,
+        x: 7,
+        y: 7,
+      }).deriveLocalTileCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 1,
+        x: 1,
+        y: 1,
+      })
+    );
+  });
+
+  it("deriveLocalTileCoordinates works as expected for octree", function () {
+    // no change
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+        z: 0,
+      }).deriveLocalTileCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+        z: 0,
+      })
+    );
+
+    // no change, but deeper
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 1,
+        x: 1,
+        y: 1,
+        z: 1,
+      }).deriveLocalTileCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 1,
+        x: 1,
+        y: 1,
+        z: 1,
+      })
+    );
+
+    // local to deeper
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 2,
+        x: 3,
+        y: 3,
+        z: 3,
+      }).deriveLocalTileCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+        z: 0,
+      })
+    );
+
+    // local to deeper
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 3,
+        x: 7,
+        y: 7,
+        z: 7,
+      }).deriveLocalTileCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 1,
+        x: 1,
+        y: 1,
+        z: 1,
+      })
+    );
+  });
+
+  it("deriveLocalChildSubtreeCoordinates throws if not a child subtree", function () {
+    // quadtree
+    expect(function () {
+      return new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+      }).deriveLocalChildSubtreeCoordinates();
+    }).toThrowDeveloperError();
+
+    // quadtree
+    expect(function () {
+      return new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 1,
+        x: 1,
+        y: 1,
+      }).deriveLocalChildSubtreeCoordinates();
+    }).toThrowDeveloperError();
+
+    // octree
+    expect(function () {
+      return new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+        z: 0,
+      }).deriveLocalChildSubtreeCoordinates();
+    }).toThrowDeveloperError();
+
+    // octree
+    expect(function () {
+      return new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 1,
+        x: 1,
+        y: 1,
+        z: 1,
+      }).deriveLocalChildSubtreeCoordinates();
+    }).toThrowDeveloperError();
+  });
+
+  it("deriveLocalChildSubtreeCoordinates works as expected for quadtree", function () {
+    // no change
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 2,
+        x: 3,
+        y: 3,
+      }).deriveLocalChildSubtreeCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 2,
+        x: 3,
+        y: 3,
+      })
+    );
+
+    // deeper subtree
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 4,
+        x: 15,
+        y: 15,
+      }).deriveLocalChildSubtreeCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 2,
+        x: 3,
+        y: 3,
+      })
+    );
+  });
+
+  it("deriveLocalChildSubtreeCoordinates works as expected for octree", function () {
+    // no change
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 2,
+        x: 3,
+        y: 3,
+        z: 3,
+      }).deriveLocalChildSubtreeCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 2,
+        x: 3,
+        y: 3,
+        z: 3,
+      })
+    );
+
+    // deeper subtree
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 4,
+        x: 15,
+        y: 15,
+        z: 15,
+      }).deriveLocalChildSubtreeCoordinates()
+    ).toEqual(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 2,
+        x: 3,
+        y: 3,
+        z: 3,
+      })
+    );
+  });
+
+  it("isAncestorOf throws with mismatched values", function () {
+    // mismatched subdivisionScheme
+    expect(function () {
+      return new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+      }).isAncestorOf(
+        new ImplicitTileCoordinates({
+          subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+          subtreeLevels: 2,
+          level: 0,
+          x: 0,
+          y: 0,
+          z: 0,
+        })
+      );
+    }).toThrowDeveloperError();
+
+    // mismatched subtreeLevels
+    expect(function () {
+      return new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+      }).isAncestorOf(
+        new ImplicitTileCoordinates({
+          subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+          subtreeLevels: 3,
+          level: 0,
+          x: 0,
+          y: 0,
+        })
+      );
+    }).toThrowDeveloperError();
+  });
+
+  it("isAncestorOf works as expected for quadtree", function () {
+    // cannot be ancestor of itself
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+      }).isAncestorOf(
+        new ImplicitTileCoordinates({
+          subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+          subtreeLevels: 2,
+          level: 0,
+          x: 0,
+          y: 0,
+        })
+      )
+    ).toEqual(false);
+
+    // ancestor one level above
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+      }).isAncestorOf(
+        new ImplicitTileCoordinates({
+          subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+          subtreeLevels: 2,
+          level: 1,
+          x: 1,
+          y: 1,
+        })
+      )
+    ).toEqual(true);
+
+    // cannot be descendant
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 1,
+        x: 1,
+        y: 1,
+      }).isAncestorOf(
+        new ImplicitTileCoordinates({
+          subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+          subtreeLevels: 2,
+          level: 0,
+          x: 0,
+          y: 0,
+        })
+      )
+    ).toEqual(false);
+
+    // works across subtrees
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+      }).isAncestorOf(
+        new ImplicitTileCoordinates({
+          subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+          subtreeLevels: 2,
+          level: 3,
+          x: 7,
+          y: 7,
+        })
+      )
+    ).toEqual(true);
+
+    // higher up in the tree but not an ancestor
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 1,
+        x: 0,
+        y: 0,
+      }).isAncestorOf(
+        new ImplicitTileCoordinates({
+          subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+          subtreeLevels: 2,
+          level: 2,
+          x: 3,
+          y: 3,
+        })
+      )
+    ).toEqual(false);
+  });
+
+  it("isAncestorOf works as expected for octree", function () {
+    // cannot be ancestor of itself
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+        z: 0,
+      }).isAncestorOf(
+        new ImplicitTileCoordinates({
+          subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+          subtreeLevels: 2,
+          level: 0,
+          x: 0,
+          y: 0,
+          z: 0,
+        })
+      )
+    ).toEqual(false);
+
+    // ancestor one level above
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+        z: 0,
+      }).isAncestorOf(
+        new ImplicitTileCoordinates({
+          subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+          subtreeLevels: 2,
+          level: 1,
+          x: 1,
+          y: 1,
+          z: 1,
+        })
+      )
+    ).toEqual(true);
+
+    // cannot be descendant
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 1,
+        x: 1,
+        y: 1,
+        z: 1,
+      }).isAncestorOf(
+        new ImplicitTileCoordinates({
+          subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+          subtreeLevels: 2,
+          level: 0,
+          x: 0,
+          y: 0,
+          z: 0,
+        })
+      )
+    ).toEqual(false);
+
+    // works across subtrees
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+        z: 0,
+      }).isAncestorOf(
+        new ImplicitTileCoordinates({
+          subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+          subtreeLevels: 2,
+          level: 3,
+          x: 7,
+          y: 7,
+          z: 7,
+        })
+      )
+    ).toEqual(true);
+
+    // higher up in the tree but not an ancestor
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+        subtreeLevels: 2,
+        level: 1,
+        x: 0,
+        y: 0,
+        z: 0,
+      }).isAncestorOf(
+        new ImplicitTileCoordinates({
+          subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+          subtreeLevels: 2,
+          level: 2,
+          x: 3,
+          y: 3,
+          z: 3,
+        })
+      )
+    ).toEqual(false);
+  });
+
+  it("isRoot works as expected", function () {
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+      }).isRoot()
+    ).toEqual(true);
+
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 1,
+        x: 0,
+        y: 0,
+      }).isRoot()
+    ).toEqual(false);
+  });
+
+  it("isRootOfSubtree works as expected", function () {
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+      }).isRootOfSubtree()
+    ).toEqual(true);
+
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 1,
+        x: 0,
+        y: 0,
+      }).isRootOfSubtree()
+    ).toEqual(false);
+
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 2,
+        x: 0,
+        y: 0,
+      }).isRootOfSubtree()
+    ).toEqual(true);
+
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 3,
+        x: 0,
+        y: 0,
+      }).isRootOfSubtree()
+    ).toEqual(false);
+  });
+
+  it("isBottomOfSubtree works as expected", function () {
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 0,
+        x: 0,
+        y: 0,
+      }).isBottomOfSubtree()
+    ).toEqual(false);
+
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 1,
+        x: 0,
+        y: 0,
+      }).isBottomOfSubtree()
+    ).toEqual(true);
+
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 2,
+        x: 0,
+        y: 0,
+      }).isBottomOfSubtree()
+    ).toEqual(false);
+
+    expect(
+      new ImplicitTileCoordinates({
+        subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+        subtreeLevels: 2,
+        level: 3,
+        x: 0,
+        y: 0,
+      }).isBottomOfSubtree()
+    ).toEqual(true);
+  });
+
   it("gets the child index for quadtree coordinates", function () {
     var coordinates = new ImplicitTileCoordinates({
       subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+      subtreeLevels: 6,
       level: 4,
       x: 3,
       y: 2,
@@ -183,6 +1473,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
   it("gets the child index for octree coordinates", function () {
     var coordinates = new ImplicitTileCoordinates({
       subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+      subtreeLevels: 6,
       level: 4,
       x: 3,
       y: 2,
@@ -195,6 +1486,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
   it("computes the morton index for quadtree coordinates", function () {
     var coordinates = new ImplicitTileCoordinates({
       subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+      subtreeLevels: 6,
       level: 4,
       x: 5,
       y: 11,
@@ -209,7 +1501,8 @@ describe("Scene/ImplicitTileCoordinates", function () {
   it("computes the morton index for octree coordinates", function () {
     var coordinates = new ImplicitTileCoordinates({
       subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
-      level: 4,
+      subtreeLevels: 8,
+      level: 6,
       x: 7,
       y: 15,
       z: 32,
@@ -223,15 +1516,19 @@ describe("Scene/ImplicitTileCoordinates", function () {
   });
 
   it("constructs quadtree coordinates from morton index", function () {
+    var subtreeLevels = 6;
+
     // 42 = 0b101010
     // deinterleave2D(42) = [0b111, 0b000] = [7, 0] = [y, x]
     var coordinates = ImplicitTileCoordinates.fromMortonIndex(
       ImplicitSubdivisionScheme.QUADTREE,
+      subtreeLevels,
       3,
       42
     );
     var expected = new ImplicitTileCoordinates({
       subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+      subtreeLevels: subtreeLevels,
       level: 3,
       x: 0,
       y: 7,
@@ -241,15 +1538,19 @@ describe("Scene/ImplicitTileCoordinates", function () {
   });
 
   it("constructs octree coordinates from morton index", function () {
+    var subtreeLevels = 6;
+
     // 43 = 0b101011
     // deinterleave3D(43) = [0b10, 0b01, 0b11] = [2, 1, 3] = [z, y, x]
     var coordinates = ImplicitTileCoordinates.fromMortonIndex(
       ImplicitSubdivisionScheme.OCTREE,
+      subtreeLevels,
       2,
       43
     );
     var expected = new ImplicitTileCoordinates({
       subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+      subtreeLevels: subtreeLevels,
       level: 2,
       x: 3,
       y: 1,
@@ -262,6 +1563,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
   it("computes quadtree template values", function () {
     var coordinates = new ImplicitTileCoordinates({
       subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+      subtreeLevels: 6,
       level: 4,
       x: 3,
       y: 2,
@@ -276,6 +1578,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
   it("computes octree template values", function () {
     var coordinates = new ImplicitTileCoordinates({
       subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
+      subtreeLevels: 6,
       level: 4,
       x: 3,
       y: 2,

--- a/Specs/Scene/ImplicitTileCoordinatesSpec.js
+++ b/Specs/Scene/ImplicitTileCoordinatesSpec.js
@@ -44,7 +44,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
   it("constructor throws with invalid inputs", function () {
     // negative level
     expect(function () {
-      new ImplicitTileCoordinates({
+      return new ImplicitTileCoordinates({
         subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
         subtreeLevels: 2,
         level: -1,
@@ -55,7 +55,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
 
     // negative x
     expect(function () {
-      new ImplicitTileCoordinates({
+      return new ImplicitTileCoordinates({
         subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
         subtreeLevels: 2,
         level: 0,
@@ -66,7 +66,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
 
     // negative y
     expect(function () {
-      new ImplicitTileCoordinates({
+      return new ImplicitTileCoordinates({
         subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
         subtreeLevels: 2,
         level: 0,
@@ -77,7 +77,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
 
     // negative z
     expect(function () {
-      new ImplicitTileCoordinates({
+      return new ImplicitTileCoordinates({
         subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
         subtreeLevels: 2,
         level: 0,
@@ -89,7 +89,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
 
     // out of range x
     expect(function () {
-      new ImplicitTileCoordinates({
+      return new ImplicitTileCoordinates({
         subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
         subtreeLevels: 2,
         level: 0,
@@ -100,7 +100,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
 
     // out of range y
     expect(function () {
-      new ImplicitTileCoordinates({
+      return new ImplicitTileCoordinates({
         subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
         subtreeLevels: 2,
         level: 0,
@@ -111,7 +111,7 @@ describe("Scene/ImplicitTileCoordinates", function () {
 
     // out of range z
     expect(function () {
-      new ImplicitTileCoordinates({
+      return new ImplicitTileCoordinates({
         subdivisionScheme: ImplicitSubdivisionScheme.OCTREE,
         subtreeLevels: 2,
         level: 0,

--- a/Specs/Scene/ImplicitTileMetadataSpec.js
+++ b/Specs/Scene/ImplicitTileMetadataSpec.js
@@ -1,6 +1,5 @@
 import {
   Cartesian3,
-  ImplicitSubdivisionScheme,
   ImplicitSubtree,
   ImplicitTileCoordinates,
   ImplicitTileset,

--- a/Specs/Scene/ImplicitTileMetadataSpec.js
+++ b/Specs/Scene/ImplicitTileMetadataSpec.js
@@ -101,6 +101,8 @@ describe("Scene/ImplicitTileMetadata", function () {
     },
   };
 
+  var metadataSchema = mockTilesetWithMetadata.metadata.schema;
+
   var implicitQuadtreeJson = {
     geometricError: 500,
     refine: "ADD",
@@ -123,20 +125,22 @@ describe("Scene/ImplicitTileMetadata", function () {
   };
 
   var metadataQuadtree = new ImplicitTileset(
-    mockTilesetWithMetadata,
     tilesetResource,
-    implicitQuadtreeJson
+    implicitQuadtreeJson,
+    metadataSchema
   );
 
   var rootCoordinates = new ImplicitTileCoordinates({
-    subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+    subdivisionScheme: metadataQuadtree.subdivisionScheme,
+    subtreeLevels: metadataQuadtree.subtreeLevels,
     x: 0,
     y: 0,
     level: 0,
   });
 
   var implicitCoordinates = new ImplicitTileCoordinates({
-    subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
+    subdivisionScheme: metadataQuadtree.subdivisionScheme,
+    subtreeLevels: metadataQuadtree.subtreeLevels,
     x: 0,
     y: 1,
     level: 1,

--- a/Specs/Scene/ImplicitTilesetSpec.js
+++ b/Specs/Scene/ImplicitTilesetSpec.js
@@ -38,7 +38,6 @@ describe("Scene/ImplicitTileset", function () {
   var baseResource = new Resource("https://example.com/tileset.json");
   var contentUriTemplate = new Resource(contentUriPattern);
   var subtreeUriTemplate = new Resource(subtreeUriPattern);
-  var mockTileset = {};
   var metadataSchema; // intentionally left undefined
 
   it("gathers information from both tile JSON and extension", function () {

--- a/Specs/Scene/ImplicitTilesetSpec.js
+++ b/Specs/Scene/ImplicitTilesetSpec.js
@@ -3,6 +3,7 @@ import {
   combine,
   ImplicitSubdivisionScheme,
   ImplicitTileset,
+  MetadataSchema,
   Resource,
 } from "../../Source/Cesium.js";
 
@@ -38,14 +39,15 @@ describe("Scene/ImplicitTileset", function () {
   var baseResource = new Resource("https://example.com/tileset.json");
   var contentUriTemplate = new Resource(contentUriPattern);
   var subtreeUriTemplate = new Resource(subtreeUriPattern);
-  var metadataSchema; // intentionally left undefined
 
   it("gathers information from both tile JSON and extension", function () {
+    var metadataSchema; // intentionally left undefined
     var implicitTileset = new ImplicitTileset(
       baseResource,
       implicitTileJson,
       metadataSchema
     );
+    expect(implicitTileset.metadata).toBeUndefined();
     expect(implicitTileset.subtreeLevels).toEqual(3);
     expect(implicitTileset.maximumLevel).toEqual(4);
     expect(implicitTileset.subdivisionScheme).toEqual(
@@ -61,6 +63,7 @@ describe("Scene/ImplicitTileset", function () {
   });
 
   it("stores a template of the tile JSON structure", function () {
+    var metadataSchema; // intentionally left undefined
     var implicitTileset = new ImplicitTileset(
       baseResource,
       implicitTileJson,
@@ -78,6 +81,7 @@ describe("Scene/ImplicitTileset", function () {
     var withExtensions = clone(implicitTileJson, deep);
     withExtensions.extensions["3DTILES_extension"] = {};
 
+    var metadataSchema; // intentionally left undefined
     var implicitTileset = new ImplicitTileset(
       baseResource,
       withExtensions,
@@ -90,6 +94,7 @@ describe("Scene/ImplicitTileset", function () {
   });
 
   it("stores a template of the tile content structure", function () {
+    var metadataSchema; // intentionally left undefined
     var implicitTileset = new ImplicitTileset(
       baseResource,
       implicitTileJson,
@@ -101,6 +106,7 @@ describe("Scene/ImplicitTileset", function () {
   it("allows undefined content URI", function () {
     var noContentJson = clone(implicitTileJson);
     delete noContentJson.content;
+    var metadataSchema; // intentionally left undefined
     var implicitTileset = new ImplicitTileset(
       baseResource,
       noContentJson,
@@ -116,6 +122,7 @@ describe("Scene/ImplicitTileset", function () {
       },
     };
     var tileJson = combine(sphereJson, implicitTileJson);
+    var metadataSchema; // intentionally left undefined
     expect(function () {
       return new ImplicitTileset(baseResource, tileJson, metadataSchema);
     }).toThrowRuntimeError();
@@ -157,6 +164,7 @@ describe("Scene/ImplicitTileset", function () {
     };
 
     it("gathers content URIs from multiple contents extension", function () {
+      var metadataSchema; // intentionally left undefined
       var implicitTileset = new ImplicitTileset(
         baseResource,
         multipleContentTile,
@@ -182,6 +190,7 @@ describe("Scene/ImplicitTileset", function () {
         contents[i].extensions = extension;
       }
 
+      var metadataSchema; // intentionally left undefined
       var implicitTileset = new ImplicitTileset(
         baseResource,
         withProperties,
@@ -193,12 +202,39 @@ describe("Scene/ImplicitTileset", function () {
     });
 
     it("template tileHeader does not store multiple contents extension", function () {
+      var metadataSchema; // intentionally left undefined
       var implicitTileset = new ImplicitTileset(
         baseResource,
         multipleContentTile,
         metadataSchema
       );
       expect(implicitTileset.tileHeader.extensions).not.toBeDefined();
+    });
+  });
+
+  describe("3DTILES_metadata", function () {
+    it("stores metadataSchema", function () {
+      var schema = {
+        classes: {
+          tile: {
+            properties: {
+              buildingCount: {
+                type: "UINT16",
+              },
+            },
+          },
+        },
+      };
+
+      var metadataSchema = new MetadataSchema(schema);
+
+      var implicitTileset = new ImplicitTileset(
+        baseResource,
+        implicitTileJson,
+        metadataSchema
+      );
+
+      expect(implicitTileset.metadataSchema).toBeDefined();
     });
   });
 });

--- a/Specs/Scene/ImplicitTilesetSpec.js
+++ b/Specs/Scene/ImplicitTilesetSpec.js
@@ -235,6 +235,7 @@ describe("Scene/ImplicitTileset", function () {
       );
 
       expect(implicitTileset.metadataSchema).toBeDefined();
+      expect(implicitTileset.metadataSchema.classes.tile).toBeDefined();
     });
   });
 });

--- a/Specs/Scene/ImplicitTilesetSpec.js
+++ b/Specs/Scene/ImplicitTilesetSpec.js
@@ -39,12 +39,13 @@ describe("Scene/ImplicitTileset", function () {
   var contentUriTemplate = new Resource(contentUriPattern);
   var subtreeUriTemplate = new Resource(subtreeUriPattern);
   var mockTileset = {};
+  var metadataSchema; // intentionally left undefined
 
   it("gathers information from both tile JSON and extension", function () {
     var implicitTileset = new ImplicitTileset(
-      mockTileset,
       baseResource,
-      implicitTileJson
+      implicitTileJson,
+      metadataSchema
     );
     expect(implicitTileset.subtreeLevels).toEqual(3);
     expect(implicitTileset.maximumLevel).toEqual(4);
@@ -62,9 +63,9 @@ describe("Scene/ImplicitTileset", function () {
 
   it("stores a template of the tile JSON structure", function () {
     var implicitTileset = new ImplicitTileset(
-      mockTileset,
       baseResource,
-      implicitTileJson
+      implicitTileJson,
+      metadataSchema
     );
     var deep = true;
     var expected = clone(implicitTileJson, deep);
@@ -79,9 +80,9 @@ describe("Scene/ImplicitTileset", function () {
     withExtensions.extensions["3DTILES_extension"] = {};
 
     var implicitTileset = new ImplicitTileset(
-      mockTileset,
       baseResource,
-      withExtensions
+      withExtensions,
+      metadataSchema
     );
     var expected = clone(withExtensions, deep);
     delete expected.content;
@@ -91,9 +92,9 @@ describe("Scene/ImplicitTileset", function () {
 
   it("stores a template of the tile content structure", function () {
     var implicitTileset = new ImplicitTileset(
-      mockTileset,
       baseResource,
-      implicitTileJson
+      implicitTileJson,
+      metadataSchema
     );
     expect(implicitTileset.contentHeaders[0]).toEqual(implicitTileJson.content);
   });
@@ -102,9 +103,9 @@ describe("Scene/ImplicitTileset", function () {
     var noContentJson = clone(implicitTileJson);
     delete noContentJson.content;
     var implicitTileset = new ImplicitTileset(
-      mockTileset,
       baseResource,
-      noContentJson
+      noContentJson,
+      metadataSchema
     );
     expect(implicitTileset.contentUriTemplates).toEqual([]);
   });
@@ -117,7 +118,7 @@ describe("Scene/ImplicitTileset", function () {
     };
     var tileJson = combine(sphereJson, implicitTileJson);
     expect(function () {
-      return new ImplicitTileset(mockTileset, baseResource, tileJson);
+      return new ImplicitTileset(baseResource, tileJson, metadataSchema);
     }).toThrowRuntimeError();
   });
 
@@ -158,9 +159,9 @@ describe("Scene/ImplicitTileset", function () {
 
     it("gathers content URIs from multiple contents extension", function () {
       var implicitTileset = new ImplicitTileset(
-        mockTileset,
         baseResource,
-        multipleContentTile
+        multipleContentTile,
+        metadataSchema
       );
       expect(implicitTileset.contentUriTemplates).toEqual([
         new Resource({ url: b3dmPattern }),
@@ -183,9 +184,9 @@ describe("Scene/ImplicitTileset", function () {
       }
 
       var implicitTileset = new ImplicitTileset(
-        mockTileset,
         baseResource,
-        withProperties
+        withProperties,
+        metadataSchema
       );
       for (i = 0; i < implicitTileset.contentHeaders.length; i++) {
         expect(implicitTileset.contentHeaders[i]).toEqual(contents[i]);
@@ -194,9 +195,9 @@ describe("Scene/ImplicitTileset", function () {
 
     it("template tileHeader does not store multiple contents extension", function () {
       var implicitTileset = new ImplicitTileset(
-        mockTileset,
         baseResource,
-        multipleContentTile
+        multipleContentTile,
+        metadataSchema
       );
       expect(implicitTileset.tileHeader.extensions).not.toBeDefined();
     });

--- a/Specs/Scene/ImplicitTilesetSpec.js
+++ b/Specs/Scene/ImplicitTilesetSpec.js
@@ -47,7 +47,7 @@ describe("Scene/ImplicitTileset", function () {
       implicitTileJson,
       metadataSchema
     );
-    expect(implicitTileset.metadata).toBeUndefined();
+    expect(implicitTileset.metadataSchema).toBeUndefined();
     expect(implicitTileset.subtreeLevels).toEqual(3);
     expect(implicitTileset.maximumLevel).toEqual(4);
     expect(implicitTileset.subdivisionScheme).toEqual(


### PR DESCRIPTION
While reviewing https://github.com/CesiumGS/cesium/pull/9517 I started to integrate the implicit tiling code into another feature I'm working on. The transition went really smoothly except I wanted more capability out of `ImplicitTileCoordinates`. So this PR is mainly about that, as well as some little fixes I found along the way.