### PR TITLE
Fix ArcGISTiledElevationTerrainProvider TypeScript definition

### DIFF
--- a/gulpfile.cjs
+++ b/gulpfile.cjs
@@ -1510,6 +1510,7 @@ function createTypeScriptDefinitions() {
     firstNode,
     node
   );
+  newSource += "\n\n";
   node.forEachChild((child) => {
     if (
       typescript.SyntaxKind[child.kind] !== "EnumDeclaration" ||


### PR DESCRIPTION
https://github.com/CesiumGS/cesium/issues/9465#issuecomment-830465969

There was no new line after the `WebGLConstants` enum definition in the TypeScript definition file:

```ts
...
    MAX_TEXTURE_MAX_ANISOTROPY_EXT = 34047
}/**
 * A {@link TerrainProvider} that produces terrain geometry by tessellating height maps
...
```

This caused `ArcGISTiledElevationTerrainProvider` to not be completely picked up by the TypeScript compiler. There's special handling from WebGLConstants to hoist it to the top of the file, so we just needed to insert two new lines in the special handling code to fix the problem:

```ts
...
    MAX_TEXTURE_MAX_ANISOTROPY_EXT = 34047
}

/**
 * A {@link TerrainProvider} that produces terrain geometry by tessellating height maps
...
```