### PR TITLE
Add getPropertyTypedArray to FeatureTable

### DIFF
--- a/Source/Scene/FeatureTable.js
+++ b/Source/Scene/FeatureTable.js
@@ -290,7 +290,7 @@ FeatureTable.prototype.setPropertyBySemantic = function (
 };
 
 /**
- * Returns the typed array containing the property values.
+ * Returns a typed array containing the property values for a given propertyId.
  *
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {*} The typed array containing the property values or <code>undefined</code> if the property values are not stored in a typed array.
@@ -305,6 +305,8 @@ FeatureTable.prototype.getPropertyTypedArray = function (propertyId) {
   if (defined(this._metadataTable)) {
     return this._metadataTable.getPropertyTypedArray(propertyId);
   }
+
+  return undefined;
 };
 
 export default FeatureTable;

--- a/Source/Scene/FeatureTable.js
+++ b/Source/Scene/FeatureTable.js
@@ -289,4 +289,22 @@ FeatureTable.prototype.setPropertyBySemantic = function (
   return false;
 };
 
+/**
+ * Returns the typed array containing the property values.
+ *
+ * @param {String} propertyId The case-sensitive ID of the property.
+ * @returns {*} The typed array containing the property values or <code>undefined</code> if the property values are not stored in a typed array.
+ *
+ * @private
+ */
+FeatureTable.prototype.getPropertyTypedArray = function (propertyId) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.string("propertyId", propertyId);
+  //>>includeEnd('debug');
+
+  if (defined(this._metadataTable)) {
+    return this._metadataTable.getPropertyTypedArray(propertyId);
+  }
+};
+
 export default FeatureTable;

--- a/Source/Scene/MetadataTable.js
+++ b/Source/Scene/MetadataTable.js
@@ -243,7 +243,7 @@ MetadataTable.prototype.setPropertyBySemantic = function (
 };
 
 /**
- * Returns the typed array containing the property values.
+ * Returns a typed array containing the property values for a given propertyId.
  *
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {*} The typed array containing the property values or <code>undefined</code> if the property values are not stored in a typed array.
@@ -260,6 +260,8 @@ MetadataTable.prototype.getPropertyTypedArray = function (propertyId) {
   if (defined(property)) {
     return property.getTypedArray();
   }
+
+  return undefined;
 };
 
 function getDefault(classDefinition, propertyId) {

--- a/Source/Scene/MetadataTable.js
+++ b/Source/Scene/MetadataTable.js
@@ -242,6 +242,26 @@ MetadataTable.prototype.setPropertyBySemantic = function (
   return false;
 };
 
+/**
+ * Returns the typed array containing the property values.
+ *
+ * @param {String} propertyId The case-sensitive ID of the property.
+ * @returns {*} The typed array containing the property values or <code>undefined</code> if the property values are not stored in a typed array.
+ *
+ * @private
+ */
+MetadataTable.prototype.getPropertyTypedArray = function (propertyId) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.string("propertyId", propertyId);
+  //>>includeEnd('debug');
+
+  var property = this._properties[propertyId];
+
+  if (defined(property)) {
+    return property.getTypedArray();
+  }
+};
+
 function getDefault(classDefinition, propertyId) {
   if (defined(classDefinition)) {
     var classProperty = classDefinition.properties[propertyId];

--- a/Source/Scene/MetadataTableProperty.js
+++ b/Source/Scene/MetadataTableProperty.js
@@ -217,6 +217,22 @@ MetadataTableProperty.prototype.set = function (index, value) {
   set(this, index, value);
 };
 
+/**
+ * Returns the typed array containing the property values.
+ *
+ * @returns {*} The typed array containing the property values or <code>undefined</code> if the property values are not stored in a typed array.
+ *
+ * @private
+ */
+MetadataTableProperty.prototype.getTypedArray = function () {
+  // Note: depending on the class definition some properties are unpacked to
+  // JS arrays when first accessed and values will be undefined. Generally not
+  // a concern for fixed-length arrays of numbers.
+  if (defined(this._values)) {
+    return this._values.typedArray;
+  }
+};
+
 function checkIndex(table, index) {
   var count = table._count;
   if (!defined(index) || index < 0 || index >= count) {

--- a/Source/Scene/MetadataTableProperty.js
+++ b/Source/Scene/MetadataTableProperty.js
@@ -218,7 +218,7 @@ MetadataTableProperty.prototype.set = function (index, value) {
 };
 
 /**
- * Returns the typed array containing the property values.
+ * Returns a typed array containing the property values.
  *
  * @returns {*} The typed array containing the property values or <code>undefined</code> if the property values are not stored in a typed array.
  *
@@ -231,6 +231,8 @@ MetadataTableProperty.prototype.getTypedArray = function () {
   if (defined(this._values)) {
     return this._values.typedArray;
   }
+
+  return undefined;
 };
 
 function checkIndex(table, index) {

--- a/Specs/Scene/FeatureTableSpec.js
+++ b/Specs/Scene/FeatureTableSpec.js
@@ -161,6 +161,23 @@ describe("Scene/FeatureTable", function () {
     expect(featureTable.setPropertyBySemantic(0, "NAME")).toBe(false);
   });
 
+  it("getPropertyTypedArray returns typed array", function () {
+    var featureTable = createFeatureTable();
+    var expectedTypedArray = new Float32Array([10.0, 20.0, 30.0]);
+
+    expect(featureTable.getPropertyTypedArray("height")).toEqual(
+      expectedTypedArray
+    );
+  });
+
+  it("getPropertyTypedArray throws if propertyId is undefined", function () {
+    var featureTable = createFeatureTable();
+
+    expect(function () {
+      featureTable.getPropertyTypedArray(undefined);
+    }).toThrowDeveloperError();
+  });
+
   describe("batch table compatibility", function () {
     var schemaJson = {
       classes: {
@@ -371,6 +388,14 @@ describe("Scene/FeatureTable", function () {
 
     it("setProperty returns false for unknown propertyId", function () {
       expect(batchTable.setProperty(0, "widgets", 5)).toBe(false);
+    });
+
+    it("getPropertyTypedArray returns undefined for JSON and hierarchy properties", function () {
+      expect(batchTable.getPropertyTypedArray("itemId")).toBeDefined();
+      expect(batchTable.getPropertyTypedArray("priority")).not.toBeDefined();
+      expect(
+        batchTable.getPropertyTypedArray("tireLocation")
+      ).not.toBeDefined();
     });
   });
 });

--- a/Specs/Scene/FeatureTableSpec.js
+++ b/Specs/Scene/FeatureTableSpec.js
@@ -170,6 +170,12 @@ describe("Scene/FeatureTable", function () {
     );
   });
 
+  it("getPropertyTypedArray returns undefined if property does not exist", function () {
+    var featureTable = createFeatureTable();
+
+    expect(featureTable.getPropertyTypedArray("volume")).toBeUndefined();
+  });
+
   it("getPropertyTypedArray throws if propertyId is undefined", function () {
     var featureTable = createFeatureTable();
 

--- a/Specs/Scene/MetadataTablePropertySpec.js
+++ b/Specs/Scene/MetadataTablePropertySpec.js
@@ -1341,4 +1341,52 @@ describe("Scene/MetadataTableProperty", function () {
       property.set(0, 8.0);
     }).toThrowDeveloperError();
   });
+
+  it("getTypedArray returns typed array", function () {
+    var propertyInt32 = {
+      type: "ARRAY",
+      componentType: "INT32",
+      componentCount: 3,
+    };
+
+    var propertyValues = [
+      [-2, -1, 0],
+      [1, 2, 3],
+    ];
+
+    var expectedTypedArray = new Int32Array([-2, -1, 0, 1, 2, 3]);
+
+    var property = MetadataTester.createProperty({
+      property: propertyInt32,
+      values: propertyValues,
+    });
+
+    expect(property.getTypedArray()).toEqual(expectedTypedArray);
+  });
+
+  it("getTypedArray returns undefined if values are unpacked", function () {
+    var propertyInt32 = {
+      type: "ARRAY",
+      componentType: "INT32",
+    };
+
+    var propertyValues = [
+      [-2, -1, 0],
+      [1, 2, 3],
+    ];
+
+    var expectedTypedArray = new Int32Array([-2, -1, 0, 1, 2, 3]);
+
+    var property = MetadataTester.createProperty({
+      property: propertyInt32,
+      values: propertyValues,
+    });
+
+    expect(property.getTypedArray()).toEqual(expectedTypedArray);
+
+    // Variable-size arrays are unpacked on set
+    property.set(0, [-2, -1]);
+
+    expect(property.getTypedArray()).toBeUndefined();
+  });
 });

--- a/Specs/Scene/MetadataTableSpec.js
+++ b/Specs/Scene/MetadataTableSpec.js
@@ -749,4 +749,54 @@ describe("Scene/MetadataTable", function () {
       metadataTable.setPropertyBySemantic(2, "_HEIGHT", 0.0);
     }).toThrowDeveloperError();
   });
+
+  it("getPropertyTypedArray returns typed array", function () {
+    var properties = {
+      height: {
+        type: "FLOAT32",
+      },
+    };
+    var propertyValues = {
+      height: [1.0, 2.0],
+    };
+
+    var metadataTable = MetadataTester.createMetadataTable({
+      properties: properties,
+      propertyValues: propertyValues,
+    });
+
+    var expectedTypedArray = new Float32Array([1.0, 2.0]);
+
+    expect(metadataTable.getPropertyTypedArray("height")).toEqual(
+      expectedTypedArray
+    );
+  });
+
+  it("getPropertyTypedArray returns undefined if property does not exist", function () {
+    var properties = {
+      height: {
+        type: "FLOAT32",
+      },
+    };
+    var propertyValues = {
+      height: [1.0, 2.0],
+    };
+
+    var metadataTable = MetadataTester.createMetadataTable({
+      properties: properties,
+      propertyValues: propertyValues,
+    });
+
+    expect(metadataTable.getPropertyTypedArray("volume")).toBeUndefined();
+  });
+
+  it("getPropertyTypedArray throws if propertyId is undefined", function () {
+    var metadataTable = new MetadataTable({
+      count: 10,
+    });
+
+    expect(function () {
+      metadataTable.getPropertyTypedArray(undefined);
+    }).toThrowDeveloperError();
+  });
 });


### PR DESCRIPTION
Targeting the `3d-tiles-next` branch. Fine to merge after https://github.com/CesiumGS/cesium/pull/9517.

Adds private functions for getting the typed array contents of a feature table property. This is a fast path for uploading per-point metadata to the GPU rather than calling `getProperty` for each feature individually.

```
featureTable.getProperty(0, "height")
featureTable.getProperty(1, "height")
featureTable.getProperty(2, "height")
...
```

Now just:
```
featureTable.getPropertyTypedArray("height")
```

Note: depending on the class definition some properties are unpacked to JS arrays when first accessed and `getPropertyTypedArray` will return undefined. This mainly applies to strings and variable-length arrays which aren't the target use case for this capability anyways.