### PR TITLE
Add MetadataType.convertToPixelDatatype

### DIFF
--- a/Source/Scene/MetadataType.js
+++ b/Source/Scene/MetadataType.js
@@ -1,6 +1,7 @@
 import Check from "../Core/Check.js";
 import DeveloperError from "../Core/DeveloperError.js";
 import FeatureDetection from "../Core/FeatureDetection.js";
+import PixelDatatype from "../Renderer/PixelDatatype.js";
 
 /**
  * An enum of metadata types.
@@ -466,6 +467,30 @@ MetadataType.getSizeInBytes = function (type) {
       return 4;
     case MetadataType.FLOAT64:
       return 8;
+  }
+};
+
+/**
+ * Returns the corresponding {@link PixelDatatype}
+ *
+ * @param {MetadataType} type The type.
+ * @returns {PixelDatatype} The corresponding {@link PixelDatatype}
+ *
+ * @exception {DeveloperError} type has no PixelDatatype equivalent
+ *
+ * @private
+ *
+ */
+MetadataType.convertToPixelDatatype = function (type) {
+  switch (type) {
+    case MetadataType.UINT8:
+      return PixelDatatype.UNSIGNED_BYTE;
+    case MetadataType.UINT16:
+      return PixelDatatype.UNSIGNED_SHORT;
+    case MetadataType.FLOAT32:
+      return PixelDatatype.FLOAT;
+    default:
+      throw new DeveloperError("type has no PixelDatatype equivalent");
   }
 };
 

--- a/Specs/Scene/MetadataTypeSpec.js
+++ b/Specs/Scene/MetadataTypeSpec.js
@@ -1,4 +1,8 @@
-import { FeatureDetection, MetadataType } from "../../Source/Cesium.js";
+import {
+  FeatureDetection,
+  MetadataType,
+  PixelDatatype,
+} from "../../Source/Cesium.js";
 
 describe("Scene/MetadataType", function () {
   it("getMinimum", function () {
@@ -374,6 +378,30 @@ describe("Scene/MetadataType", function () {
   it("getSizeInBytes throws if type is not a numeric type", function () {
     expect(function () {
       MetadataType.getSizeInBytes(MetadataType.STRING);
+    }).toThrowDeveloperError();
+  });
+
+  it("convertToPixelDatatype", function () {
+    expect(MetadataType.convertToPixelDatatype(MetadataType.UINT8)).toBe(
+      PixelDatatype.UNSIGNED_BYTE
+    );
+    expect(MetadataType.convertToPixelDatatype(MetadataType.UINT16)).toBe(
+      PixelDatatype.UNSIGNED_SHORT
+    );
+    expect(MetadataType.convertToPixelDatatype(MetadataType.FLOAT32)).toBe(
+      PixelDatatype.FLOAT
+    );
+  });
+
+  it("convertToPixelDatatype throws without type", function () {
+    expect(function () {
+      MetadataType.convertToPixelDatatype();
+    }).toThrowDeveloperError();
+  });
+
+  it("convertToPixelDatatype throws if type has no PixelDatatype equivalent", function () {
+    expect(function () {
+      MetadataType.convertToPixelDatatype(MetadataType.FLOAT64);
     }).toThrowDeveloperError();
   });
 });


### PR DESCRIPTION
Adds function to MetadataType that converts a MetadataType to the PixelDatatype equivalent.