### PR TITLE
Modify error message in GlobalSurfaceTile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 ##### Fixes :wrench:
 
 - Fixed `processTerrain` in `decodeGoogleEarthEnterprisePacket` to handle a newer terrain packet format that includes water surface meshes after terrain meshes. [#9519](https://github.com/CesiumGS/cesium/pull/9519)
+- Fixed the handling of errors in `GlobeSurfaceTile`. The console should now print the error that caused the terrain tile request to fail. [#8313](https://github.com/CesiumGS/cesium/issues/8313)
 
 ### 1.81 - 2021-05-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 ##### Fixes :wrench:
 
 - Fixed an issue in `ScreenSpaceCameraController.tilt3DOnTerrain` that caused unexpected camera behavior when tilting terrain diagonally along the screen. [#9562](https://github.com/CesiumGS/cesium/pull/9562)
+- Fixed error handling in `GlobeSurfaceTile` to print terrain tile request errors to console. [#9570](https://github.com/CesiumGS/cesium/pull/9570)
 
 ### 1.82.1 - 2021-06-01
 
@@ -23,7 +24,6 @@
 ##### Fixes :wrench:
 
 - Fixed `processTerrain` in `decodeGoogleEarthEnterprisePacket` to handle a newer terrain packet format that includes water surface meshes after terrain meshes. [#9519](https://github.com/CesiumGS/cesium/pull/9519)
-- Fixed the handling of errors in `GlobeSurfaceTile`. The console should now print the error that caused the terrain tile request to fail. [#8313](https://github.com/CesiumGS/cesium/issues/8313)
 
 ### 1.81 - 2021-05-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -151,6 +151,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
   - [Dzung Nguyen](https://github.com/dzungpng)
   - [Nithin Pranesh](https://github.com/nithinp7)
   - [Alexander Gallegos](https://github.com/argallegos)
+  - [Janine Liu](https://github.com/j9liu)
 - [Northrop Grumman](http://www.northropgrumman.com)
   - [Joseph Stein](https://github.com/nahgrin)
 - [EOX IT Services GmbH](https://eox.at)

--- a/Source/Scene/GlobeSurfaceTile.js
+++ b/Source/Scene/GlobeSurfaceTile.js
@@ -563,7 +563,7 @@ function requestTileGeometry(surfaceTile, terrainProvider, x, y, level) {
     surfaceTile.request = undefined;
   }
 
-  function failure() {
+  function failure(error) {
     if (surfaceTile.request.state === RequestState.CANCELLED) {
       // Cancelled due to low priority - try again later.
       surfaceTile.terrainData = undefined;
@@ -584,7 +584,9 @@ function requestTileGeometry(surfaceTile, terrainProvider, x, y, level) {
       y +
       " Level: " +
       level +
-      ".";
+      '. Error message: "' +
+      error +
+      '"';
     terrainProvider._requestError = TileProviderError.handleError(
       terrainProvider._requestError,
       terrainProvider,
@@ -605,6 +607,7 @@ function requestTileGeometry(surfaceTile, terrainProvider, x, y, level) {
       type: RequestType.TERRAIN,
     });
     surfaceTile.request = request;
+
     var requestPromise = terrainProvider.requestTileGeometry(
       x,
       y,


### PR DESCRIPTION
In response to issue [#8313](https://github.com/CesiumGS/cesium/issues/8313).

Changed the error message for failed terrain tile requests. The console now prints the error that caused the failure. 