### PR TITLE
Update cesiumWorkerBootstrapper.js

### DIFF
--- a/Source/Workers/cesiumWorkerBootstrapper.js
+++ b/Source/Workers/cesiumWorkerBootstrapper.js
@@ -30,7 +30,7 @@ function setTimeout(fn) {
 /*jslint regexp: true, nomen: true, sloppy: true */
 /*global window, navigator, document, importScripts, setTimeout, opera */
 
-var requirejs, require, define;
+let requirejs, require, define;
 (function (global) {
   var req,
     s,


### PR DESCRIPTION
Proposed change enables Cesium to work with Electron.  Alters scope of variables: requirejs, require, define

This takes care of an issue as noted by Stuart Attenborrow in 2018.  

See at: https://community.cesium.com/t/fixing-cesiumworkerbootstrapper-when-using-electron-react-webpack/6532