### PR TITLE
Runtime Errors when a tileset contains unsupported extensions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 1.83 - 2021-07-01
+
+##### Additions :tada:
+
+- Added checks for supported 3D tiles extensions.[#9552](https://github.com/CesiumGS/cesium/issues/9552)
+
 ### 1.82 - 2021-06-01
 
 ##### Additions :tada:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -151,6 +151,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
   - [Dzung Nguyen](https://github.com/dzungpng)
   - [Nithin Pranesh](https://github.com/nithinp7)
   - [Alexander Gallegos](https://github.com/argallegos)
+  - [Sam Rothstein](https://github.com/srothst1)
 - [Northrop Grumman](http://www.northropgrumman.com)
   - [Joseph Stein](https://github.com/nahgrin)
 - [EOX IT Services GmbH](https://eox.at)

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1751,6 +1751,8 @@ Cesium3DTileset.prototype.loadTileset = function (
     throw new RuntimeError("The tileset must be 3D Tiles version 0.0 or 1.0.");
   }
 
+  Cesium3DTileset.checkSupportedExtensions(this._extensions);
+
   var statistics = this._statistics;
 
   var tilesetVersion = asset.tilesetVersion;
@@ -2802,6 +2804,26 @@ Cesium3DTileset.prototype.destroy = function () {
 
   this._root = undefined;
   return destroyObject(this);
+};
+
+Cesium3DTileset.supportedExtensions = {
+  CESIUM_3DTILES_metadata: true,
+  CESIUM_3DTILES_implicit_tiling: true,
+  CESIUM_3DTILES_content_gltf: true,
+  CESIUM_3DTILES_multiple_contents: true,
+  CESIUM_3DTILES_bounding_volume_S2: true,
+  CESIUM_3DTILES_batch_table_hierarchy: true,
+  CESIUM_3DTILES_draco_point_compression: true,
+};
+
+Cesium3DTileset.checkSupportedExtensions = function (extensionsRequired) {
+  for (var extension in extensionsRequired) {
+    if (extensionsRequired.hasOwnProperty(extension)) {
+      if (!Cesium3DTileset.supportedExtensions[extension]) {
+        throw new RuntimeError("Unsupported 3D Tiles Extension: " + extension);
+      }
+    }
+  }
 };
 
 /**

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -372,6 +372,28 @@ describe(
         });
     });
 
+    it("rejects readyPromise with unsupported extension", function () {
+      var tilesetJson = {
+        asset: {
+          version: 1.0,
+        },
+        extensionsUsed: ["unsupported_extension"],
+        extensionsRequired: ["unsupported_extension"],
+      };
+
+      var uri = "data:text/plain;base64," + btoa(JSON.stringify(tilesetJson));
+
+      options.url = uri;
+      var tileset = scene.primitives.add(new Cesium3DTileset(options));
+      return tileset.readyPromise
+        .then(function () {
+          fail("should not resolve");
+        })
+        .otherwise(function (error) {
+          expect(tileset.ready).toEqual(false);
+        });
+    });
+
     it("url and tilesetUrl set up correctly given tileset JSON filepath", function () {
       var path = "Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tileset.json";
       var tileset = new Cesium3DTileset({


### PR DESCRIPTION
Fixes Issue #9552
There is currently no `_extensionsRequired` property in Cesium3DTileset. This pull request uses the `_extensions` property. 

Should we add `_extensionsRequired`?

cc @ptrgags @lilleyse  