### PR TITLE
Add console errors when a tileset contains unsupported extensions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Additions :tada:
 
 - Added `options.fadingEnabled` parameter to `ShadowMap` to control whether shadows fade out when the light source is close to the horizon. [#9565](https://github.com/CesiumGS/cesium/pull/9565)
+- Added checks for supported 3D tiles extensions.[#9552](https://github.com/CesiumGS/cesium/issues/9552)
 
 ##### Fixes :wrench:
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -152,6 +152,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
   - [Nithin Pranesh](https://github.com/nithinp7)
   - [Alexander Gallegos](https://github.com/argallegos)
   - [Janine Liu](https://github.com/j9liu)
+  - [Sam Rothstein](https://github.com/srothst1)
 - [Northrop Grumman](http://www.northropgrumman.com)
   - [Joseph Stein](https://github.com/nahgrin)
 - [EOX IT Services GmbH](https://eox.at)

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -2809,13 +2809,13 @@ Cesium3DTileset.prototype.destroy = function () {
 };
 
 Cesium3DTileset.supportedExtensions = {
-  3DTILES_metadata: true,
-  3DTILES_implicit_tiling: true,
-  3DTILES_content_gltf: true,
-  3DTILES_multiple_contents: true,
-  3DTILES_bounding_volume_S2: true,
-  3DTILES_batch_table_hierarchy: true,
-  3DTILES_draco_point_compression: true,
+  "3DTILES_metadata:" true,
+  "3DTILES_implicit_tiling:" true,
+  "3DTILES_content_gltf:" true,
+  "3DTILES_multiple_contents:" true,
+  "3DTILES_bounding_volume_S2:" true,
+  "3DTILES_batch_table_hierarchy:" true,
+  "3DTILES_draco_point_compression:" true,
 };
 
 /**

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -2809,13 +2809,13 @@ Cesium3DTileset.prototype.destroy = function () {
 };
 
 Cesium3DTileset.supportedExtensions = {
-  "3DTILES_metadata:" true,
-  "3DTILES_implicit_tiling:" true,
-  "3DTILES_content_gltf:" true,
-  "3DTILES_multiple_contents:" true,
-  "3DTILES_bounding_volume_S2:" true,
-  "3DTILES_batch_table_hierarchy:" true,
-  "3DTILES_draco_point_compression:" true,
+  "3DTILES_metadata": true,
+  "3DTILES_implicit_tiling": true,
+  "3DTILES_content_gltf": true,
+  "3DTILES_multiple_contents": true,
+  "3DTILES_bounding_volume_S2": true,
+  "3DTILES_batch_table_hierarchy": true,
+  "3DTILES_draco_point_compression": true,
 };
 
 /**

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -2822,7 +2822,7 @@ Cesium3DTileset.supportedExtensions = {
  * Checks to see if a given extension is supported by Cesium3DTileset. If 
  * the extension is not supported by Cesium3DTileset, it throws a RuntimeError.
  *
- * @param {3DTILES_metadata} extensionsRequired The extensions we wish to check
+ * @param {Object} extensionsRequired The extensions we wish to check
  *
  * @private
  */

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -2819,7 +2819,7 @@ Cesium3DTileset.supportedExtensions = {
 };
 
 /**
- * Checks to see if a given extension is supported by Cesium3DTileset. If 
+ * Checks to see if a given extension is supported by Cesium3DTileset. If
  * the extension is not supported by Cesium3DTileset, it throws a RuntimeError.
  *
  * @param {Object} extensionsRequired The extensions we wish to check
@@ -2827,11 +2827,9 @@ Cesium3DTileset.supportedExtensions = {
  * @private
  */
 Cesium3DTileset.checkSupportedExtensions = function (extensionsRequired) {
-  for (var extension in extensionsRequired) {
-    if (extensionsRequired.hasOwnProperty(extension)) {
-      if (!Cesium3DTileset.supportedExtensions[extension]) {
-        throw new RuntimeError("Unsupported 3D Tiles Extension: " + extension);
-      }
+  for (var i = 0; i < extensionsRequired.length; i++) {
+    if (!Cesium3DTileset.supportedExtensions[extensionsRequired[i]]) {
+      throw new RuntimeError("Unsupported 3D Tiles Extension: " + extension);
     }
   }
 };

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1751,7 +1751,9 @@ Cesium3DTileset.prototype.loadTileset = function (
     throw new RuntimeError("The tileset must be 3D Tiles version 0.0 or 1.0.");
   }
 
-  Cesium3DTileset.checkSupportedExtensions(this._extensions);
+  if (defined(tilesetJson.extensionsRequired)) {
+    Cesium3DTileset.checkSupportedExtensions(tilesetJson.extensionsRequired);
+  }
 
   var statistics = this._statistics;
 

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -2829,7 +2829,9 @@ Cesium3DTileset.supportedExtensions = {
 Cesium3DTileset.checkSupportedExtensions = function (extensionsRequired) {
   for (var i = 0; i < extensionsRequired.length; i++) {
     if (!Cesium3DTileset.supportedExtensions[extensionsRequired[i]]) {
-      throw new RuntimeError("Unsupported 3D Tiles Extension: " + extension);
+      throw new RuntimeError(
+        "Unsupported 3D Tiles Extension: " + extensionsRequired[i]
+      );
     }
   }
 };

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -2816,6 +2816,14 @@ Cesium3DTileset.supportedExtensions = {
   CESIUM_3DTILES_draco_point_compression: true,
 };
 
+/**
+ * Checks to see if a given extension is supported by Cesium3DTileset. If 
+ * the extension is not supported by Cesium3DTileset, it throws a RuntimeError.
+ *
+ * @param {3DTILES_metadata} extensionsRequired The extensions we wish to check
+ *
+ * @private
+ */
 Cesium3DTileset.checkSupportedExtensions = function (extensionsRequired) {
   for (var extension in extensionsRequired) {
     if (extensionsRequired.hasOwnProperty(extension)) {

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1751,6 +1751,8 @@ Cesium3DTileset.prototype.loadTileset = function (
     throw new RuntimeError("The tileset must be 3D Tiles version 0.0 or 1.0.");
   }
 
+  Cesium3DTileset.checkSupportedExtensions(this._extensions);
+
   var statistics = this._statistics;
 
   var tilesetVersion = asset.tilesetVersion;
@@ -2802,6 +2804,26 @@ Cesium3DTileset.prototype.destroy = function () {
 
   this._root = undefined;
   return destroyObject(this);
+};
+
+Cesium3DTileset.supportedExtensions = {
+  CESIUM_3DTILES_metadata: true,
+  CESIUM_3DTILES_implicit_tiling: true,
+  CESIUM_3DTILES_content_gltf: true,
+  CESIUM_3DTILES_multiple_contents: true,
+  CESIUM_3DTILES_bounding_volume_S2: true,
+  CESIUM_3DTILES_batch_table_hierarchy: true,
+  CESIUM_3DTILES_draco_point_compression: true,
+};
+
+Cesium3DTileset.checkSupportedExtensions = function (extensionsRequired) {
+  for (var extension in extensionsRequired) {
+    if (extensionsRequired.hasOwnProperty(extension)) {
+      if (!Cesium3DTileset.supportedExtensions[extension]) {
+        throw new RuntimeError("Unsupported 3D Tiles Extension: " + extension);
+      }
+    }
+  }
 };
 
 /**

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -372,6 +372,28 @@ describe(
         });
     });
 
+    it("rejects readyPromise with unsupported extension", function () {
+      var tilesetJson = {
+        asset: {
+          version: 1.0,
+        },
+        extensionsUsed: ["unsupported_extension"],
+        extensionsRequired: ["unsupported_extension"],
+      };
+
+      var uri = "data:text/plain;base64," + btoa(JSON.stringify(tilesetJson));
+
+      options.url = uri;
+      var tileset = scene.primitives.add(new Cesium3DTileset(options));
+      return tileset.readyPromise
+        .then(function () {
+          fail("should not resolve");
+        })
+        .otherwise(function (error) {
+          expect(tileset.ready).toEqual(false);
+        });
+    });
+
     it("url and tilesetUrl set up correctly given tileset JSON filepath", function () {
       var path = "Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tileset.json";
       var tileset = new Cesium3DTileset({


### PR DESCRIPTION
Fixes #9552

There is no `_extensionsRequired` property in Cesium3DTileset so this pull request uses the `_extensions` property - should we add `_extensionsRequired`? 

Updated `CONTRIBUTORS.md`. 

@ptrgags 