### PR TITLE
Kml Tour Documentation 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Added `options.fadingEnabled` parameter to `ShadowMap` to control whether shadows fade out when the light source is close to the horizon. [#9565](https://github.com/CesiumGS/cesium/pull/9565)
 - Added checks for supported 3D Tiles extensions. [#9552](https://github.com/CesiumGS/cesium/issues/9552)
+- Added documentation for `KmlTour`, `KmlTourFlyTo`, and `KmlTourWait`. Added documentation and a `kmlTours` getter to `KmlDataSource`. Removed references to `KmlTourSoundCues`. [#8073](https://github.com/CesiumGS/cesium/issues/8073)
 
 ##### Fixes :wrench:
 

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -3349,6 +3349,7 @@ function load(dataSource, entityCollection, data, options) {
  * @property {Boolean} [clampToGround=false] true if we want the geometry features (Polygons, LineStrings and LinearRings) clamped to the ground.
  * @property {Ellipsoid} [ellipsoid=Ellipsoid.WGS84] The global ellipsoid used for geographical calculations.
  * @property {Credit|String} [credit] A credit for the data source, which is displayed on the canvas.
+ * @property {KmlTour} [KmlTours] The KmlTour that is used to guide the camera to specified destinations on given time intervals.
  */
 
 /**

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -2389,11 +2389,7 @@ function processTour(dataSource, node, processingData, deferredLoading) {
     }
   }
 
-  if (!defined(dataSource.kmlTours)) {
-    dataSource.kmlTours = [];
-  }
-
-  dataSource.kmlTours.push(tour);
+  dataSource._kmlTours.push(tour);
 }
 
 function processTourUnsupportedNode(tour, entryNode) {
@@ -3349,7 +3345,6 @@ function load(dataSource, entityCollection, data, options) {
  * @property {Boolean} [clampToGround=false] true if we want the geometry features (Polygons, LineStrings and LinearRings) clamped to the ground.
  * @property {Ellipsoid} [ellipsoid=Ellipsoid.WGS84] The global ellipsoid used for geographical calculations.
  * @property {Credit|String} [credit] A credit for the data source, which is displayed on the canvas.
- * @property {KmlTour} [KmlTours] The KmlTour that is used to guide the camera to specified destinations on given time intervals.
  */
 
 /**
@@ -3442,6 +3437,8 @@ function KmlDataSource(options) {
 
   // Create a list of Credit's from the resource that the user can't remove
   this._resourceCredits = [];
+
+  this._kmlTours = [];
 }
 
 /**
@@ -3599,6 +3596,16 @@ Object.defineProperties(KmlDataSource.prototype, {
   credit: {
     get: function () {
       return this._credit;
+    },
+  },
+  /**
+   * Gets the KML Tours that are used to guide the camera to specified destinations on given time intervals.
+   * @memberof KmlDataSource.prototype
+   * @type {KmlTour[]}
+   */
+  kmlTours: {
+    get: function () {
+      return this._kmlTours;
     },
   },
 });

--- a/Source/DataSources/KmlTour.js
+++ b/Source/DataSources/KmlTour.js
@@ -1,7 +1,7 @@
 import defined from "../Core/defined.js";
 import Event from "../Core/Event.js";
 /**
- * Describes a KmlTour, which uses KmlTourFlyTo, KmlTourWait, and KmlTourSoundCues to
+ * Describes a KmlTour, which uses KmlTourFlyTo, and KmlTourWait to
  * guide the camera to a specified destinations on given time intervals.
  *
  * @alias KmlTour
@@ -9,7 +9,7 @@ import Event from "../Core/Event.js";
  *
  * @param {String} name name parsed from KML
  * @param {String} id id parsed from KML
- * @param {Array} playlist array with KmlTourFlyTos, KmlTourWaits and KmlTourSoundCues
+ * @param {Array} playlist array with KmlTourFlyTos and KmlTourWaits
  *
  * @see KmlTourFlyTo
  * @see KmlTourWait

--- a/Source/DataSources/KmlTour.js
+++ b/Source/DataSources/KmlTour.js
@@ -14,7 +14,7 @@ import Event from "../Core/Event.js";
  * @see KmlTourFlyTo
  * @see KmlTourWait
  *
- * @demo {@link https://sandcastle.cesium.com/?src=KML%20Tours.html KML Tours}
+ * @demo {@link https://sandcastle.cesium.com/?src=KML%20Tours.html|KML Tours}
  */
 function KmlTour(name, id) {
   /**

--- a/Source/DataSources/KmlTour.js
+++ b/Source/DataSources/KmlTour.js
@@ -1,12 +1,20 @@
 import defined from "../Core/defined.js";
 import Event from "../Core/Event.js";
 /**
+ * Describes a KmlTour, which uses KmlTourFlyTo, KmlTourWait, and KmlTourSoundCues to
+ * guide the camera to a specified destinations on given time intervals.
+ *
  * @alias KmlTour
  * @constructor
  *
  * @param {String} name name parsed from KML
  * @param {String} id id parsed from KML
- * @param {Array} playlist array with KMLTourFlyTos, KMLTourWaits and KMLTourSoundCues
+ * @param {Array} playlist array with KmlTourFlyTos, KmlTourWaits and KmlTourSoundCues
+ *
+ * @see KmlTourFlyTo
+ * @see KmlTourWait
+ *
+ * @demo {@link https://sandcastle.cesium.com/?src=KML%20Tours.html KML Tours}
  */
 function KmlTour(name, id) {
   /**

--- a/Source/DataSources/KmlTourFlyTo.js
+++ b/Source/DataSources/KmlTourFlyTo.js
@@ -3,12 +3,18 @@ import combine from "../Core/combine.js";
 import defined from "../Core/defined.js";
 import EasingFunction from "../Core/EasingFunction.js";
 /**
+ * Transitions the KmlTour to the next destination. This transition is facilitated
+ * using a specified flyToMode over a given number of seconds.
+ *
  * @alias KmlTourFlyTo
  * @constructor
  *
  * @param {Number} duration entry duration
  * @param {String} flyToMode KML fly to mode: bounce, smooth, etc
  * @param {KmlCamera|KmlLookAt} view KmlCamera or KmlLookAt
+ *
+ * @see KmlTour
+ * @see KmlTourWait
  */
 function KmlTourFlyTo(duration, flyToMode, view) {
   this.type = "KmlTourFlyTo";

--- a/Source/DataSources/KmlTourWait.js
+++ b/Source/DataSources/KmlTourWait.js
@@ -1,5 +1,7 @@
 import defined from "../Core/defined.js";
 /**
+ * Pauses the KmlTour for a given number of seconds.
+ *
  * @alias KmlTourWait
  * @constructor
  *

--- a/Source/DataSources/KmlTourWait.js
+++ b/Source/DataSources/KmlTourWait.js
@@ -6,6 +6,8 @@ import defined from "../Core/defined.js";
  * @constructor
  *
  * @param {Number} duration entry duration
+ *
+ * @see KmlTour
  */
 function KmlTourWait(duration) {
   this.type = "KmlTourWait";

--- a/Source/DataSources/KmlTourWait.js
+++ b/Source/DataSources/KmlTourWait.js
@@ -8,6 +8,7 @@ import defined from "../Core/defined.js";
  * @param {Number} duration entry duration
  *
  * @see KmlTour
+ * @see KmlTourFlyTo
  */
 function KmlTourWait(duration) {
   this.type = "KmlTourWait";


### PR DESCRIPTION
In response to issue #8073

Updated documentation for `KmlTourWait`, `KmlTourFlyTo`, and `KmlTour`. Let me know if there are any suggested edits.

The current documentation references `KmlTourSoundCues` various times in `KmlTour`. This is seen here:
[https://cesium.com/docs/cesiumjs-ref-doc/KmlTour.html?classFilter=KmlTour](https://cesium.com/docs/cesiumjs-ref-doc/KmlTour.html?classFilter=KmlTour)

I was not able to find `KmlTourSoundCues` anywhere else in the documentation or in the code - how should we handle this?

@shehzan10
@OmarShehata