### PR TITLE
Get variables names used in a style

### DIFF
--- a/Source/Scene/Cesium3DTileStyle.js
+++ b/Source/Scene/Cesium3DTileStyle.js
@@ -1637,8 +1637,8 @@ Object.defineProperties(Cesium3DTileStyle.prototype, {
 /**
  * Gets the color shader function for this style.
  *
- * @param {String} functionName Name to give to the generated function.
- * @param {String} propertyNameMap Maps property variable names to shader attribute names.
+ * @param {String} functionHeader Header of the generated function.
+ * @param {Object} variableSubstitutionMap Maps variable names to shader names.
  * @param {Object} shaderState Stores information about the generated shader function, including whether it is translucent.
  *
  * @returns {String} The shader function.
@@ -1646,8 +1646,8 @@ Object.defineProperties(Cesium3DTileStyle.prototype, {
  * @private
  */
 Cesium3DTileStyle.prototype.getColorShaderFunction = function (
-  functionName,
-  propertyNameMap,
+  functionHeader,
+  variableSubstitutionMap,
   shaderState
 ) {
   if (this._colorShaderFunctionReady) {
@@ -1657,14 +1657,15 @@ Cesium3DTileStyle.prototype.getColorShaderFunction = function (
   }
 
   this._colorShaderFunctionReady = true;
-  this._colorShaderFunction = defined(this.color)
-    ? this.color.getShaderFunction(
-        functionName,
-        propertyNameMap,
-        shaderState,
-        "vec4"
-      )
-    : undefined;
+  this._colorShaderFunction =
+    defined(this.color) && defined(this.color.getShaderFunction)
+      ? this.color.getShaderFunction(
+          functionHeader,
+          variableSubstitutionMap,
+          shaderState,
+          "vec4"
+        )
+      : undefined;
   this._colorShaderTranslucent = shaderState.translucent;
   return this._colorShaderFunction;
 };
@@ -1672,8 +1673,8 @@ Cesium3DTileStyle.prototype.getColorShaderFunction = function (
 /**
  * Gets the show shader function for this style.
  *
- * @param {String} functionName Name to give to the generated function.
- * @param {String} propertyNameMap Maps property variable names to shader attribute names.
+ * @param {String} functionHeader Header of the generated function.
+ * @param {Object} variableSubstitutionMap Maps variable names to shader names.
  * @param {Object} shaderState Stores information about the generated shader function, including whether it is translucent.
  *
  * @returns {String} The shader function.
@@ -1681,8 +1682,8 @@ Cesium3DTileStyle.prototype.getColorShaderFunction = function (
  * @private
  */
 Cesium3DTileStyle.prototype.getShowShaderFunction = function (
-  functionName,
-  propertyNameMap,
+  functionHeader,
+  variableSubstitutionMap,
   shaderState
 ) {
   if (this._showShaderFunctionReady) {
@@ -1691,22 +1692,23 @@ Cesium3DTileStyle.prototype.getShowShaderFunction = function (
   }
 
   this._showShaderFunctionReady = true;
-  this._showShaderFunction = defined(this.show)
-    ? this.show.getShaderFunction(
-        functionName,
-        propertyNameMap,
-        shaderState,
-        "bool"
-      )
-    : undefined;
+  this._showShaderFunction =
+    defined(this.show) && defined(this.show.getShaderFunction)
+      ? this.show.getShaderFunction(
+          functionHeader,
+          variableSubstitutionMap,
+          shaderState,
+          "bool"
+        )
+      : undefined;
   return this._showShaderFunction;
 };
 
 /**
  * Gets the pointSize shader function for this style.
  *
- * @param {String} functionName Name to give to the generated function.
- * @param {String} propertyNameMap Maps property variable names to shader attribute names.
+ * @param {String} functionHeader Header of the generated function.
+ * @param {Object} variableSubstitutionMap Maps variable names to shader names.
  * @param {Object} shaderState Stores information about the generated shader function, including whether it is translucent.
  *
  * @returns {String} The shader function.
@@ -1714,8 +1716,8 @@ Cesium3DTileStyle.prototype.getShowShaderFunction = function (
  * @private
  */
 Cesium3DTileStyle.prototype.getPointSizeShaderFunction = function (
-  functionName,
-  propertyNameMap,
+  functionHeader,
+  variableSubstitutionMap,
   shaderState
 ) {
   if (this._pointSizeShaderFunctionReady) {
@@ -1724,14 +1726,46 @@ Cesium3DTileStyle.prototype.getPointSizeShaderFunction = function (
   }
 
   this._pointSizeShaderFunctionReady = true;
-  this._pointSizeShaderFunction = defined(this.pointSize)
-    ? this.pointSize.getShaderFunction(
-        functionName,
-        propertyNameMap,
-        shaderState,
-        "float"
-      )
-    : undefined;
+  this._pointSizeShaderFunction =
+    defined(this.pointSize) && defined(this.pointSize.getShaderFunction)
+      ? this.pointSize.getShaderFunction(
+          functionHeader,
+          variableSubstitutionMap,
+          shaderState,
+          "float"
+        )
+      : undefined;
   return this._pointSizeShaderFunction;
 };
+
+/**
+ * Gets the variables used by the style.
+ *
+ * @returns {String[]} The variables used by the style.
+ *
+ * @private
+ */
+Cesium3DTileStyle.prototype.getVariables = function () {
+  var variables = [];
+
+  if (defined(this.color) && defined(this.color.getVariables)) {
+    variables.push.apply(variables, this.color.getVariables());
+  }
+
+  if (defined(this.show) && defined(this.show.getVariables)) {
+    variables.push.apply(variables, this.show.getVariables());
+  }
+
+  if (defined(this.pointSize) && defined(this.pointSize.getVariables)) {
+    variables.push.apply(variables, this.pointSize.getVariables());
+  }
+
+  // Remove duplicates
+  variables = variables.filter(function (variable, index, variables) {
+    return variables.indexOf(variable) === index;
+  });
+
+  return variables;
+};
+
 export default Cesium3DTileStyle;

--- a/Source/Scene/Cesium3DTileStyle.js
+++ b/Source/Scene/Cesium3DTileStyle.js
@@ -1637,8 +1637,8 @@ Object.defineProperties(Cesium3DTileStyle.prototype, {
 /**
  * Gets the color shader function for this style.
  *
- * @param {String} functionHeader Header of the generated function.
- * @param {Object} variableSubstitutionMap Maps variable names to shader names.
+ * @param {String} functionSignature Signature of the generated function.
+ * @param {Object} variableSubstitutionMap Maps variable names to shader variable names.
  * @param {Object} shaderState Stores information about the generated shader function, including whether it is translucent.
  *
  * @returns {String} The shader function.
@@ -1646,7 +1646,7 @@ Object.defineProperties(Cesium3DTileStyle.prototype, {
  * @private
  */
 Cesium3DTileStyle.prototype.getColorShaderFunction = function (
-  functionHeader,
+  functionSignature,
   variableSubstitutionMap,
   shaderState
 ) {
@@ -1657,15 +1657,15 @@ Cesium3DTileStyle.prototype.getColorShaderFunction = function (
   }
 
   this._colorShaderFunctionReady = true;
-  this._colorShaderFunction =
-    defined(this.color) && defined(this.color.getShaderFunction)
-      ? this.color.getShaderFunction(
-          functionHeader,
-          variableSubstitutionMap,
-          shaderState,
-          "vec4"
-        )
-      : undefined;
+  if (defined(this.color) && defined(this.color.getShaderFunction)) {
+    this._colorShaderFunction = this.color.getShaderFunction(
+      functionSignature,
+      variableSubstitutionMap,
+      shaderState,
+      "vec4"
+    );
+  }
+
   this._colorShaderTranslucent = shaderState.translucent;
   return this._colorShaderFunction;
 };
@@ -1673,8 +1673,8 @@ Cesium3DTileStyle.prototype.getColorShaderFunction = function (
 /**
  * Gets the show shader function for this style.
  *
- * @param {String} functionHeader Header of the generated function.
- * @param {Object} variableSubstitutionMap Maps variable names to shader names.
+ * @param {String} functionSignature Signature of the generated function.
+ * @param {Object} variableSubstitutionMap Maps variable names to shader variable names.
  * @param {Object} shaderState Stores information about the generated shader function, including whether it is translucent.
  *
  * @returns {String} The shader function.
@@ -1682,7 +1682,7 @@ Cesium3DTileStyle.prototype.getColorShaderFunction = function (
  * @private
  */
 Cesium3DTileStyle.prototype.getShowShaderFunction = function (
-  functionHeader,
+  functionSignature,
   variableSubstitutionMap,
   shaderState
 ) {
@@ -1692,23 +1692,23 @@ Cesium3DTileStyle.prototype.getShowShaderFunction = function (
   }
 
   this._showShaderFunctionReady = true;
-  this._showShaderFunction =
-    defined(this.show) && defined(this.show.getShaderFunction)
-      ? this.show.getShaderFunction(
-          functionHeader,
-          variableSubstitutionMap,
-          shaderState,
-          "bool"
-        )
-      : undefined;
+
+  if (defined(this.show) && defined(this.show.getShaderFunction)) {
+    this._showShaderFunction = this.show.getShaderFunction(
+      functionSignature,
+      variableSubstitutionMap,
+      shaderState,
+      "bool"
+    );
+  }
   return this._showShaderFunction;
 };
 
 /**
  * Gets the pointSize shader function for this style.
  *
- * @param {String} functionHeader Header of the generated function.
- * @param {Object} variableSubstitutionMap Maps variable names to shader names.
+ * @param {String} functionSignature Signature of the generated function.
+ * @param {Object} variableSubstitutionMap Maps variable names to shader variable names.
  * @param {Object} shaderState Stores information about the generated shader function, including whether it is translucent.
  *
  * @returns {String} The shader function.
@@ -1716,7 +1716,7 @@ Cesium3DTileStyle.prototype.getShowShaderFunction = function (
  * @private
  */
 Cesium3DTileStyle.prototype.getPointSizeShaderFunction = function (
-  functionHeader,
+  functionSignature,
   variableSubstitutionMap,
   shaderState
 ) {
@@ -1726,15 +1726,15 @@ Cesium3DTileStyle.prototype.getPointSizeShaderFunction = function (
   }
 
   this._pointSizeShaderFunctionReady = true;
-  this._pointSizeShaderFunction =
-    defined(this.pointSize) && defined(this.pointSize.getShaderFunction)
-      ? this.pointSize.getShaderFunction(
-          functionHeader,
-          variableSubstitutionMap,
-          shaderState,
-          "float"
-        )
-      : undefined;
+  if (defined(this.pointSize) && defined(this.pointSize.getShaderFunction)) {
+    this._pointSizeShaderFunction = this.pointSize.getShaderFunction(
+      functionSignature,
+      variableSubstitutionMap,
+      shaderState,
+      "float"
+    );
+  }
+
   return this._pointSizeShaderFunction;
 };
 

--- a/Source/Scene/ConditionsExpression.js
+++ b/Source/Scene/ConditionsExpression.js
@@ -135,8 +135,8 @@ ConditionsExpression.prototype.evaluateColor = function (feature, result) {
  * Gets the shader function for this expression.
  * Returns undefined if the shader function can't be generated from this expression.
  *
- * @param {String} functionName Name to give to the generated function.
- * @param {String} propertyNameMap Maps property variable names to shader attribute names.
+ * @param {String} functionHeader Header of the generated function.
+ * @param {Object} variableSubstitutionMap Maps variable names to shader names.
  * @param {Object} shaderState Stores information about the generated shader function, including whether it is translucent.
  * @param {String} returnType The return type of the generated function.
  *
@@ -145,8 +145,8 @@ ConditionsExpression.prototype.evaluateColor = function (feature, result) {
  * @private
  */
 ConditionsExpression.prototype.getShaderFunction = function (
-  functionName,
-  propertyNameMap,
+  functionHeader,
+  variableSubstitutionMap,
   shaderState,
   returnType
 ) {
@@ -161,11 +161,11 @@ ConditionsExpression.prototype.getShaderFunction = function (
     var statement = conditions[i];
 
     var condition = statement.condition.getShaderExpression(
-      propertyNameMap,
+      variableSubstitutionMap,
       shaderState
     );
     var expression = statement.expression.getShaderExpression(
-      propertyNameMap,
+      variableSubstitutionMap,
       shaderState
     );
 
@@ -175,26 +175,57 @@ ConditionsExpression.prototype.getShaderFunction = function (
       (i === 0 ? "if" : "else if") +
       " (" +
       condition +
-      ") \n" +
-      "    { \n" +
+      ")\n" +
+      "    {\n" +
       "        return " +
       expression +
-      "; \n" +
-      "    } \n";
+      ";\n" +
+      "    }\n";
   }
 
   shaderFunction =
     returnType +
     " " +
-    functionName +
-    "() \n" +
-    "{ \n" +
+    functionHeader +
+    "\n" +
+    "{\n" +
     shaderFunction +
     "    return " +
     returnType +
-    "(1.0); \n" + // Return a default value if no conditions are met
-    "} \n";
+    "(1.0);\n" + // Return a default value if no conditions are met
+    "}\n";
 
   return shaderFunction;
 };
+
+/**
+ * Gets the variables used by the expression.
+ *
+ * @returns {String[]} The variables used by the expression.
+ *
+ * @private
+ */
+ConditionsExpression.prototype.getVariables = function () {
+  var variables = [];
+
+  var conditions = this._runtimeConditions;
+  if (!defined(conditions) || conditions.length === 0) {
+    return variables;
+  }
+
+  var length = conditions.length;
+  for (var i = 0; i < length; ++i) {
+    var statement = conditions[i];
+    variables.push.apply(variables, statement.condition.getVariables());
+    variables.push.apply(variables, statement.expression.getVariables());
+  }
+
+  // Remove duplicates
+  variables = variables.filter(function (variable, index, variables) {
+    return variables.indexOf(variable) === index;
+  });
+
+  return variables;
+};
+
 export default ConditionsExpression;

--- a/Source/Scene/ConditionsExpression.js
+++ b/Source/Scene/ConditionsExpression.js
@@ -135,8 +135,8 @@ ConditionsExpression.prototype.evaluateColor = function (feature, result) {
  * Gets the shader function for this expression.
  * Returns undefined if the shader function can't be generated from this expression.
  *
- * @param {String} functionHeader Header of the generated function.
- * @param {Object} variableSubstitutionMap Maps variable names to shader names.
+ * @param {String} functionSignature Signature of the generated function.
+ * @param {Object} variableSubstitutionMap Maps variable names to shader variable names.
  * @param {Object} shaderState Stores information about the generated shader function, including whether it is translucent.
  * @param {String} returnType The return type of the generated function.
  *
@@ -145,7 +145,7 @@ ConditionsExpression.prototype.evaluateColor = function (feature, result) {
  * @private
  */
 ConditionsExpression.prototype.getShaderFunction = function (
-  functionHeader,
+  functionSignature,
   variableSubstitutionMap,
   shaderState,
   returnType
@@ -186,7 +186,7 @@ ConditionsExpression.prototype.getShaderFunction = function (
   shaderFunction =
     returnType +
     " " +
-    functionHeader +
+    functionSignature +
     "\n" +
     "{\n" +
     shaderFunction +

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -170,8 +170,8 @@ Expression.prototype.evaluateColor = function (feature, result) {
  * Gets the shader function for this expression.
  * Returns undefined if the shader function can't be generated from this expression.
  *
- * @param {String} functionName Name to give to the generated function.
- * @param {String} propertyNameMap Maps property variable names to shader attribute names.
+ * @param {String} functionHeader Header of the generated function.
+ * @param {Object} variableSubstitutionMap Maps variable names to shader names.
  * @param {Object} shaderState Stores information about the generated shader function, including whether it is translucent.
  * @param {String} returnType The return type of the generated function.
  *
@@ -180,23 +180,26 @@ Expression.prototype.evaluateColor = function (feature, result) {
  * @private
  */
 Expression.prototype.getShaderFunction = function (
-  functionName,
-  propertyNameMap,
+  functionHeader,
+  variableSubstitutionMap,
   shaderState,
   returnType
 ) {
-  var shaderExpression = this.getShaderExpression(propertyNameMap, shaderState);
+  var shaderExpression = this.getShaderExpression(
+    variableSubstitutionMap,
+    shaderState
+  );
 
   shaderExpression =
     returnType +
     " " +
-    functionName +
-    "() \n" +
-    "{ \n" +
+    functionHeader +
+    "\n" +
+    "{\n" +
     "    return " +
     shaderExpression +
-    "; \n" +
-    "} \n";
+    ";\n" +
+    "}\n";
 
   return shaderExpression;
 };
@@ -205,7 +208,7 @@ Expression.prototype.getShaderFunction = function (
  * Gets the shader expression for this expression.
  * Returns undefined if the shader expression can't be generated from this expression.
  *
- * @param {String} propertyNameMap Maps property variable names to shader attribute names.
+ * @param {Object} variableSubstitutionMap Maps variable names to shader names.
  * @param {Object} shaderState Stores information about the generated shader function, including whether it is translucent.
  *
  * @returns {String} The shader expression.
@@ -213,10 +216,33 @@ Expression.prototype.getShaderFunction = function (
  * @private
  */
 Expression.prototype.getShaderExpression = function (
-  propertyNameMap,
+  variableSubstitutionMap,
   shaderState
 ) {
-  return this._runtimeAst.getShaderExpression(propertyNameMap, shaderState);
+  return this._runtimeAst.getShaderExpression(
+    variableSubstitutionMap,
+    shaderState
+  );
+};
+
+/**
+ * Gets the variables used by the expression.
+ *
+ * @returns {String[]} The variables used by the expression.
+ *
+ * @private
+ */
+Expression.prototype.getVariables = function () {
+  var variables = [];
+
+  this._runtimeAst.getVariables(variables);
+
+  // Remove duplicates
+  variables = variables.filter(function (variable, index, variables) {
+    return variables.indexOf(variable) === index;
+  });
+
+  return variables;
 };
 
 var unaryOperators = ["!", "-", "+"];
@@ -1967,12 +1993,17 @@ function colorToVec4(color) {
   return "vec4(" + r + ", " + g + ", " + b + ", " + a + ")";
 }
 
-function getExpressionArray(array, propertyNameMap, shaderState, parent) {
+function getExpressionArray(
+  array,
+  variableSubstitutionMap,
+  shaderState,
+  parent
+) {
   var length = array.length;
   var expressions = new Array(length);
   for (var i = 0; i < length; ++i) {
     expressions[i] = array[i].getShaderExpression(
-      propertyNameMap,
+      variableSubstitutionMap,
       shaderState,
       parent
     );
@@ -1980,8 +2011,8 @@ function getExpressionArray(array, propertyNameMap, shaderState, parent) {
   return expressions;
 }
 
-function getVariableName(variableName, propertyNameMap) {
-  if (!defined(propertyNameMap[variableName])) {
+function getVariableName(variableName, variableSubstitutionMap) {
+  if (!defined(variableSubstitutionMap[variableName])) {
     throw new RuntimeError(
       'Style references a property "' +
         variableName +
@@ -1989,13 +2020,16 @@ function getVariableName(variableName, propertyNameMap) {
     );
   }
 
-  return propertyNameMap[variableName];
+  return variableSubstitutionMap[variableName];
 }
 
-var nullSentinel = "czm_infinity"; // null just needs to be some sentinel value that will cause "[expression] === null" to be false in nearly all cases. GLSL doesn't have a NaN constant so use czm_infinity.
+/**
+ * @private
+ */
+Expression.NULL_SENTINEL = "czm_infinity"; // null just needs to be some sentinel value that will cause "[expression] === null" to be false in nearly all cases. GLSL doesn't have a NaN constant so use czm_infinity.
 
 Node.prototype.getShaderExpression = function (
-  propertyNameMap,
+  variableSubstitutionMap,
   shaderState,
   parent
 ) {
@@ -2010,23 +2044,45 @@ Node.prototype.getShaderExpression = function (
   if (defined(this._left)) {
     if (Array.isArray(this._left)) {
       // Left can be an array if the type is LITERAL_COLOR or LITERAL_VECTOR
-      left = getExpressionArray(this._left, propertyNameMap, shaderState, this);
+      left = getExpressionArray(
+        this._left,
+        variableSubstitutionMap,
+        shaderState,
+        this
+      );
     } else {
-      left = this._left.getShaderExpression(propertyNameMap, shaderState, this);
+      left = this._left.getShaderExpression(
+        variableSubstitutionMap,
+        shaderState,
+        this
+      );
     }
   }
 
   if (defined(this._right)) {
-    right = this._right.getShaderExpression(propertyNameMap, shaderState, this);
+    right = this._right.getShaderExpression(
+      variableSubstitutionMap,
+      shaderState,
+      this
+    );
   }
 
   if (defined(this._test)) {
-    test = this._test.getShaderExpression(propertyNameMap, shaderState, this);
+    test = this._test.getShaderExpression(
+      variableSubstitutionMap,
+      shaderState,
+      this
+    );
   }
 
   if (Array.isArray(this._value)) {
     // For ARRAY type
-    value = getExpressionArray(this._value, propertyNameMap, shaderState, this);
+    value = getExpressionArray(
+      this._value,
+      variableSubstitutionMap,
+      shaderState,
+      this
+    );
   }
 
   switch (type) {
@@ -2034,7 +2090,7 @@ Node.prototype.getShaderExpression = function (
       if (checkFeature(this)) {
         return undefined;
       }
-      return getVariableName(value, propertyNameMap);
+      return getVariableName(value, variableSubstitutionMap);
     case ExpressionNodeType.UNARY:
       // Supported types: +, -, !, Boolean, Number
       if (value === "Boolean") {
@@ -2085,7 +2141,7 @@ Node.prototype.getShaderExpression = function (
       return "(" + test + " ? " + left + " : " + right + ")";
     case ExpressionNodeType.MEMBER:
       if (checkFeature(this._left)) {
-        return getVariableName(right, propertyNameMap);
+        return getVariableName(right, variableSubstitutionMap);
       }
       // This is intended for accessing the components of vector properties. String members aren't supported.
       // Check for 0.0 rather than 0 because all numbers are previously converted to decimals.
@@ -2133,7 +2189,7 @@ Node.prototype.getShaderExpression = function (
         "Error generating style shader: Converting a variable to a string is not supported."
       );
     case ExpressionNodeType.LITERAL_NULL:
-      return nullSentinel;
+      return Expression.NULL_SENTINEL;
     case ExpressionNodeType.LITERAL_BOOLEAN:
       return value ? "true" : "false";
     case ExpressionNodeType.LITERAL_NUMBER:
@@ -2270,11 +2326,75 @@ Node.prototype.getShaderExpression = function (
         "Error generating style shader: Regular expressions are not supported."
       );
     case ExpressionNodeType.LITERAL_UNDEFINED:
-      return nullSentinel;
+      return Expression.NULL_SENTINEL;
     case ExpressionNodeType.BUILTIN_VARIABLE:
       if (value === "tiles3d_tileset_time") {
         return "u_time";
       }
   }
 };
+
+Node.prototype.getVariables = function (variables, parent) {
+  var array;
+  var length;
+  var i;
+
+  var type = this._type;
+  var value = this._value;
+
+  if (defined(this._left)) {
+    if (Array.isArray(this._left)) {
+      // Left can be an array if the type is LITERAL_COLOR or LITERAL_VECTOR
+      array = this._left;
+      length = array.length;
+      for (i = 0; i < length; ++i) {
+        array[i].getVariables(variables, this);
+      }
+    } else {
+      this._left.getVariables(variables, this);
+    }
+  }
+
+  if (defined(this._right)) {
+    this._right.getVariables(variables, this);
+  }
+
+  if (defined(this._test)) {
+    this._test.getVariables(variables, this);
+  }
+
+  if (Array.isArray(this._value)) {
+    // For ARRAY type
+    array = this._value;
+    length = array.length;
+    for (i = 0; i < length; ++i) {
+      array[i].getVariables(variables, this);
+    }
+  }
+
+  switch (type) {
+    case ExpressionNodeType.VARIABLE:
+      if (!checkFeature(this)) {
+        variables.push(value);
+      }
+      break;
+    case ExpressionNodeType.VARIABLE_IN_STRING:
+      var match = variableRegex.exec(value);
+      while (match !== null) {
+        variables.push(match[1]);
+        match = variableRegex.exec(value);
+      }
+      break;
+    case ExpressionNodeType.LITERAL_STRING:
+      if (
+        defined(parent) &&
+        parent._type === ExpressionNodeType.MEMBER &&
+        checkFeature(parent._left)
+      ) {
+        variables.push(value);
+      }
+      break;
+  }
+};
+
 export default Expression;

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -170,8 +170,8 @@ Expression.prototype.evaluateColor = function (feature, result) {
  * Gets the shader function for this expression.
  * Returns undefined if the shader function can't be generated from this expression.
  *
- * @param {String} functionHeader Header of the generated function.
- * @param {Object} variableSubstitutionMap Maps variable names to shader names.
+ * @param {String} functionSignature Signature of the generated function.
+ * @param {Object} variableSubstitutionMap Maps variable names to shader variable names.
  * @param {Object} shaderState Stores information about the generated shader function, including whether it is translucent.
  * @param {String} returnType The return type of the generated function.
  *
@@ -180,7 +180,7 @@ Expression.prototype.evaluateColor = function (feature, result) {
  * @private
  */
 Expression.prototype.getShaderFunction = function (
-  functionHeader,
+  functionSignature,
   variableSubstitutionMap,
   shaderState,
   returnType
@@ -193,7 +193,7 @@ Expression.prototype.getShaderFunction = function (
   shaderExpression =
     returnType +
     " " +
-    functionHeader +
+    functionSignature +
     "\n" +
     "{\n" +
     "    return " +
@@ -208,7 +208,7 @@ Expression.prototype.getShaderFunction = function (
  * Gets the shader expression for this expression.
  * Returns undefined if the shader expression can't be generated from this expression.
  *
- * @param {Object} variableSubstitutionMap Maps variable names to shader names.
+ * @param {Object} variableSubstitutionMap Maps variable names to shader variable names.
  * @param {Object} shaderState Stores information about the generated shader function, including whether it is translucent.
  *
  * @returns {String} The shader expression.

--- a/Source/Scene/PointCloud.js
+++ b/Source/Scene/PointCloud.js
@@ -996,7 +996,7 @@ function getStyleablePropertyIds(source, propertyIds) {
 }
 
 function getBuiltinPropertyNames(source, propertyNames) {
-  // Get all the builtin property names used by this style, ignoring the function header
+  // Get all the builtin property names used by this style, ignoring the function signature
   source = source.slice(source.indexOf("\n"));
   var regex = /czm_3dtiles_builtin_property_(\w+)/g;
   var matches = regex.exec(source);
@@ -1069,7 +1069,7 @@ function createShaders(pointCloud, frameState, style) {
     var shaderState = {
       translucent: false,
     };
-    var functionHeader =
+    var parameterList =
       "(" +
       "vec3 czm_3dtiles_builtin_property_POSITION, " +
       "vec3 czm_3dtiles_builtin_property_POSITION_ABSOLUTE, " +
@@ -1077,17 +1077,17 @@ function createShaders(pointCloud, frameState, style) {
       "vec3 czm_3dtiles_builtin_property_NORMAL" +
       ")";
     colorStyleFunction = style.getColorShaderFunction(
-      "getColorFromStyle" + functionHeader,
+      "getColorFromStyle" + parameterList,
       variableSubstitutionMap,
       shaderState
     );
     showStyleFunction = style.getShowShaderFunction(
-      "getShowFromStyle" + functionHeader,
+      "getShowFromStyle" + parameterList,
       variableSubstitutionMap,
       shaderState
     );
     pointSizeStyleFunction = style.getPointSizeShaderFunction(
-      "getPointSizeFromStyle" + functionHeader,
+      "getPointSizeFromStyle" + parameterList,
       variableSubstitutionMap,
       shaderState
     );

--- a/Source/Scene/PointCloud.js
+++ b/Source/Scene/PointCloud.js
@@ -996,7 +996,8 @@ function getStyleablePropertyIds(source, propertyIds) {
 }
 
 function getBuiltinPropertyNames(source, propertyNames) {
-  // Get all the builtin property names used by this style
+  // Get all the builtin property names used by this style, ignoring the function header
+  source = source.slice(source.indexOf("\n"));
   var regex = /czm_3dtiles_builtin_property_(\w+)/g;
   var matches = regex.exec(source);
   while (matches !== null) {
@@ -1018,25 +1019,12 @@ function getVertexAttribute(vertexArray, index) {
   }
 }
 
-var builtinPropertyNameMap = {
+var builtinVariableSubstitutionMap = {
   POSITION: "czm_3dtiles_builtin_property_POSITION",
   POSITION_ABSOLUTE: "czm_3dtiles_builtin_property_POSITION_ABSOLUTE",
   COLOR: "czm_3dtiles_builtin_property_COLOR",
   NORMAL: "czm_3dtiles_builtin_property_NORMAL",
 };
-
-function modifyStyleFunction(source) {
-  // Edit the function header to accept the point position, color, and normal
-  var functionHeader =
-    "(" +
-    "vec3 czm_3dtiles_builtin_property_POSITION, " +
-    "vec3 czm_3dtiles_builtin_property_POSITION_ABSOLUTE, " +
-    "vec4 czm_3dtiles_builtin_property_COLOR, " +
-    "vec3 czm_3dtiles_builtin_property_NORMAL" +
-    ")";
-
-  return source.replace("()", functionHeader);
-}
 
 function createShaders(pointCloud, frameState, style) {
   var i;
@@ -1065,13 +1053,14 @@ function createShaders(pointCloud, frameState, style) {
   var pointSizeStyleFunction;
   var styleTranslucent = isTranslucent;
 
-  var propertyNameMap = clone(builtinPropertyNameMap);
+  var variableSubstitutionMap = clone(builtinVariableSubstitutionMap);
   var propertyIdToAttributeMap = {};
   var styleableShaderAttributes = pointCloud._styleableShaderAttributes;
   for (name in styleableShaderAttributes) {
     if (styleableShaderAttributes.hasOwnProperty(name)) {
       attribute = styleableShaderAttributes[name];
-      propertyNameMap[name] = "czm_3dtiles_property_" + attribute.location;
+      variableSubstitutionMap[name] =
+        "czm_3dtiles_property_" + attribute.location;
       propertyIdToAttributeMap[attribute.location] = attribute;
     }
   }
@@ -1080,19 +1069,26 @@ function createShaders(pointCloud, frameState, style) {
     var shaderState = {
       translucent: false,
     };
+    var functionHeader =
+      "(" +
+      "vec3 czm_3dtiles_builtin_property_POSITION, " +
+      "vec3 czm_3dtiles_builtin_property_POSITION_ABSOLUTE, " +
+      "vec4 czm_3dtiles_builtin_property_COLOR, " +
+      "vec3 czm_3dtiles_builtin_property_NORMAL" +
+      ")";
     colorStyleFunction = style.getColorShaderFunction(
-      "getColorFromStyle",
-      propertyNameMap,
+      "getColorFromStyle" + functionHeader,
+      variableSubstitutionMap,
       shaderState
     );
     showStyleFunction = style.getShowShaderFunction(
-      "getShowFromStyle",
-      propertyNameMap,
+      "getShowFromStyle" + functionHeader,
+      variableSubstitutionMap,
       shaderState
     );
     pointSizeStyleFunction = style.getPointSizeShaderFunction(
-      "getPointSizeFromStyle",
-      propertyNameMap,
+      "getPointSizeFromStyle" + functionHeader,
+      variableSubstitutionMap,
       shaderState
     );
     if (defined(colorStyleFunction) && shaderState.translucent) {
@@ -1114,17 +1110,14 @@ function createShaders(pointCloud, frameState, style) {
   if (hasColorStyle) {
     getStyleablePropertyIds(colorStyleFunction, styleablePropertyIds);
     getBuiltinPropertyNames(colorStyleFunction, builtinPropertyNames);
-    colorStyleFunction = modifyStyleFunction(colorStyleFunction);
   }
   if (hasShowStyle) {
     getStyleablePropertyIds(showStyleFunction, styleablePropertyIds);
     getBuiltinPropertyNames(showStyleFunction, builtinPropertyNames);
-    showStyleFunction = modifyStyleFunction(showStyleFunction);
   }
   if (hasPointSizeStyle) {
     getStyleablePropertyIds(pointSizeStyleFunction, styleablePropertyIds);
     getBuiltinPropertyNames(pointSizeStyleFunction, builtinPropertyNames);
-    pointSizeStyleFunction = modifyStyleFunction(pointSizeStyleFunction);
   }
 
   var usesColorSemantic = builtinPropertyNames.indexOf("COLOR") >= 0;

--- a/Source/Scene/StyleExpression.js
+++ b/Source/Scene/StyleExpression.js
@@ -54,8 +54,8 @@ StyleExpression.prototype.evaluateColor = function (feature, result) {
  * Gets the shader function for this expression.
  * Returns undefined if the shader function can't be generated from this expression.
  *
- * @param {String} functionHeader Header of the generated function.
- * @param {Object} variableSubstitutionMap Maps variable names to shader names.
+ * @param {String} functionSignature Signature of the generated function.
+ * @param {Object} variableSubstitutionMap Maps variable names to shader variable names.
  * @param {Object} shaderState Stores information about the generated shader function, including whether it is translucent.
  * @param {String} returnType The return type of the generated function.
  *
@@ -64,7 +64,7 @@ StyleExpression.prototype.evaluateColor = function (feature, result) {
  * @private
  */
 StyleExpression.prototype.getShaderFunction = function (
-  functionHeader,
+  functionSignature,
   variableSubstitutionMap,
   shaderState,
   returnType

--- a/Source/Scene/StyleExpression.js
+++ b/Source/Scene/StyleExpression.js
@@ -54,8 +54,8 @@ StyleExpression.prototype.evaluateColor = function (feature, result) {
  * Gets the shader function for this expression.
  * Returns undefined if the shader function can't be generated from this expression.
  *
- * @param {String} functionName Name to give to the generated function.
- * @param {String} propertyNameMap Maps property variable names to shader attribute names.
+ * @param {String} functionHeader Header of the generated function.
+ * @param {Object} variableSubstitutionMap Maps variable names to shader names.
  * @param {Object} shaderState Stores information about the generated shader function, including whether it is translucent.
  * @param {String} returnType The return type of the generated function.
  *
@@ -64,11 +64,23 @@ StyleExpression.prototype.evaluateColor = function (feature, result) {
  * @private
  */
 StyleExpression.prototype.getShaderFunction = function (
-  functionName,
-  propertyNameMap,
+  functionHeader,
+  variableSubstitutionMap,
   shaderState,
   returnType
 ) {
   DeveloperError.throwInstantiationError();
 };
+
+/**
+ * Gets the variables used by the expression.
+ *
+ * @returns {String[]} The variables used by the expression.
+ *
+ * @private
+ */
+StyleExpression.prototype.getVariables = function () {
+  DeveloperError.throwInstantiationError();
+};
+
 export default StyleExpression;

--- a/Specs/Scene/Cesium3DTileStyleSpec.js
+++ b/Specs/Scene/Cesium3DTileStyleSpec.js
@@ -4132,4 +4132,20 @@ describe("Scene/Cesium3DTileStyle", function () {
     expect(showFunction).toBeUndefined();
     expect(pointSizeFunction).toBeUndefined();
   });
+
+  it("gets variables", function () {
+    var style = new Cesium3DTileStyle({
+      pointSize: {
+        conditions: [
+          ["(${Height} >= 100.0)", "6"],
+          ["true", "${PointSize}"],
+        ],
+      },
+      color: "${Height} * color('red')",
+      show: "${Floors} > 10",
+    });
+
+    var variables = style.getVariables();
+    expect(variables.sort()).toEqual(["Floors", "Height", "PointSize"]);
+  });
 });

--- a/Specs/Scene/ConditionsExpressionSpec.js
+++ b/Specs/Scene/ConditionsExpressionSpec.js
@@ -32,6 +32,14 @@ describe("Scene/ConditionsExpression", function () {
     ],
   };
 
+  var jsonExpMultipleVariables = {
+    conditions: [
+      ["${Height} > 100", "${FloorColor}"],
+      ["${Height} > 50", "${FloorColor} * 0.5"],
+      ["true", 'color("lime")'],
+    ],
+  };
+
   it("constructs", function () {
     var expression = new ConditionsExpression(jsonExp);
     expect(expression.conditionsExpression).toEqual(jsonExp);
@@ -95,32 +103,32 @@ describe("Scene/ConditionsExpression", function () {
 
   it("gets shader function", function () {
     var expression = new ConditionsExpression(jsonExp);
-    var properyNameMap = {
+    var variableSubstitutionMap = {
       Height: "a_height",
     };
     var shaderFunction = expression.getShaderFunction(
-      "getColor",
-      properyNameMap,
+      "getColor()",
+      variableSubstitutionMap,
       {},
       "vec4"
     );
     var expected =
-      "vec4 getColor() \n" +
-      "{ \n" +
-      "    if ((a_height > 100.0)) \n" +
-      "    { \n" +
-      "        return vec4(vec3(0.0, 0.0, 1.0), 1.0); \n" +
-      "    } \n" +
-      "    else if ((a_height > 50.0)) \n" +
-      "    { \n" +
-      "        return vec4(vec3(1.0, 0.0, 0.0), 1.0); \n" +
-      "    } \n" +
-      "    else if (true) \n" +
-      "    { \n" +
-      "        return vec4(vec3(0.0, 1.0, 0.0), 1.0); \n" +
-      "    } \n" +
-      "    return vec4(1.0); \n" +
-      "} \n";
+      "vec4 getColor()\n" +
+      "{\n" +
+      "    if ((a_height > 100.0))\n" +
+      "    {\n" +
+      "        return vec4(vec3(0.0, 0.0, 1.0), 1.0);\n" +
+      "    }\n" +
+      "    else if ((a_height > 50.0))\n" +
+      "    {\n" +
+      "        return vec4(vec3(1.0, 0.0, 0.0), 1.0);\n" +
+      "    }\n" +
+      "    else if (true)\n" +
+      "    {\n" +
+      "        return vec4(vec3(0.0, 1.0, 0.0), 1.0);\n" +
+      "    }\n" +
+      "    return vec4(1.0);\n" +
+      "}\n";
     expect(shaderFunction).toEqual(expected);
   });
 
@@ -133,5 +141,17 @@ describe("Scene/ConditionsExpression", function () {
       "vec4"
     );
     expect(shaderFunction).toBeUndefined();
+  });
+
+  it("gets variables", function () {
+    var expression = new ConditionsExpression(jsonExpMultipleVariables);
+    var variables = expression.getVariables();
+    expect(variables.sort()).toEqual(["FloorColor", "Height"]);
+  });
+
+  it("getVariables returns empty array when there are no conditions", function () {
+    var expression = new ConditionsExpression([]);
+    var variables = expression.getVariables();
+    expect(variables).toEqual([]);
   });
 });

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -3416,42 +3416,50 @@ describe("Scene/Expression", function () {
   it("gets shader function", function () {
     var expression = new Expression("true");
     var shaderFunction = expression.getShaderFunction(
-      "getShow",
+      "getShow()",
       {},
       {},
       "bool"
     );
-    var expected =
-      "bool getShow() \n" + "{ \n" + "    return true; \n" + "} \n";
+    var expected = "bool getShow()\n" + "{\n" + "    return true;\n" + "}\n";
     expect(shaderFunction).toEqual(expected);
   });
 
   it("gets shader expression for variable", function () {
     var expression = new Expression("${property}");
-    var propertyNameMap = {
+    var variableSubstitutionMap = {
       property: "a_property",
     };
-    var shaderExpression = expression.getShaderExpression(propertyNameMap, {});
+    var shaderExpression = expression.getShaderExpression(
+      variableSubstitutionMap,
+      {}
+    );
     var expected = "a_property";
     expect(shaderExpression).toEqual(expected);
   });
 
   it("gets shader expression for feature variable with bracket notation", function () {
     var expression = new Expression("${feature['property']}");
-    var propertyNameMap = {
+    var variableSubstitutionMap = {
       property: "a_property",
     };
-    var shaderExpression = expression.getShaderExpression(propertyNameMap, {});
+    var shaderExpression = expression.getShaderExpression(
+      variableSubstitutionMap,
+      {}
+    );
     var expected = "a_property";
     expect(shaderExpression).toEqual(expected);
   });
 
   it("gets shader expression for feature variable with dot notation", function () {
     var expression = new Expression("${feature.property}");
-    var propertyNameMap = {
+    var variableSubstitutionMap = {
       property: "a_property",
     };
-    var shaderExpression = expression.getShaderExpression(propertyNameMap, {});
+    var shaderExpression = expression.getShaderExpression(
+      variableSubstitutionMap,
+      {}
+    );
     var expected = "a_property";
     expect(shaderExpression).toEqual(expected);
   });
@@ -3590,15 +3598,21 @@ describe("Scene/Expression", function () {
   });
 
   it("gets shader expression for array indexing", function () {
-    var propertyNameMap = { property: "property" };
+    var variableSubstitutionMap = { property: "property" };
 
     var expression = new Expression("${property[0]}");
-    var shaderExpression = expression.getShaderExpression(propertyNameMap, {});
+    var shaderExpression = expression.getShaderExpression(
+      variableSubstitutionMap,
+      {}
+    );
     var expected = "property[0]";
     expect(shaderExpression).toEqual(expected);
 
     expression = new Expression("${property[4 / 2]}");
-    shaderExpression = expression.getShaderExpression(propertyNameMap, {});
+    shaderExpression = expression.getShaderExpression(
+      variableSubstitutionMap,
+      {}
+    );
     expected = "property[int((4.0 / 2.0))]";
     expect(shaderExpression).toEqual(expected);
   });
@@ -3659,11 +3673,11 @@ describe("Scene/Expression", function () {
   });
 
   it("gets shader expression for color", function () {
-    var propertyNameMap = { property: "property" };
+    var variableSubstitutionMap = { property: "property" };
     var shaderState = { translucent: false };
     var expression = new Expression("color()");
     var shaderExpression = expression.getShaderExpression(
-      propertyNameMap,
+      variableSubstitutionMap,
       shaderState
     );
     var expected = "vec4(1.0)";
@@ -3673,7 +3687,7 @@ describe("Scene/Expression", function () {
     shaderState = { translucent: false };
     expression = new Expression('color("red")');
     shaderExpression = expression.getShaderExpression(
-      propertyNameMap,
+      variableSubstitutionMap,
       shaderState
     );
     expected = "vec4(vec3(1.0, 0.0, 0.0), 1.0)";
@@ -3683,7 +3697,7 @@ describe("Scene/Expression", function () {
     shaderState = { translucent: false };
     expression = new Expression('color("#FFF")');
     shaderExpression = expression.getShaderExpression(
-      propertyNameMap,
+      variableSubstitutionMap,
       shaderState
     );
     expected = "vec4(vec3(1.0, 1.0, 1.0), 1.0)";
@@ -3693,7 +3707,7 @@ describe("Scene/Expression", function () {
     shaderState = { translucent: false };
     expression = new Expression('color("#FF0000")');
     shaderExpression = expression.getShaderExpression(
-      propertyNameMap,
+      variableSubstitutionMap,
       shaderState
     );
     expected = "vec4(vec3(1.0, 0.0, 0.0), 1.0)";
@@ -3703,7 +3717,7 @@ describe("Scene/Expression", function () {
     shaderState = { translucent: false };
     expression = new Expression('color("rgb(255, 0, 0)")');
     shaderExpression = expression.getShaderExpression(
-      propertyNameMap,
+      variableSubstitutionMap,
       shaderState
     );
     expected = "vec4(vec3(1.0, 0.0, 0.0), 1.0)";
@@ -3713,7 +3727,7 @@ describe("Scene/Expression", function () {
     shaderState = { translucent: false };
     expression = new Expression('color("red", 0.5)');
     shaderExpression = expression.getShaderExpression(
-      propertyNameMap,
+      variableSubstitutionMap,
       shaderState
     );
     expected = "vec4(vec3(1.0, 0.0, 0.0), 0.5)";
@@ -3723,7 +3737,7 @@ describe("Scene/Expression", function () {
     shaderState = { translucent: false };
     expression = new Expression("rgb(255, 0, 0)");
     shaderExpression = expression.getShaderExpression(
-      propertyNameMap,
+      variableSubstitutionMap,
       shaderState
     );
     expected = "vec4(1.0, 0.0, 0.0, 1.0)";
@@ -3733,7 +3747,7 @@ describe("Scene/Expression", function () {
     shaderState = { translucent: false };
     expression = new Expression("rgb(255, ${property}, 0)");
     shaderExpression = expression.getShaderExpression(
-      propertyNameMap,
+      variableSubstitutionMap,
       shaderState
     );
     expected = "vec4(255.0 / 255.0, property / 255.0, 0.0 / 255.0, 1.0)";
@@ -3743,7 +3757,7 @@ describe("Scene/Expression", function () {
     shaderState = { translucent: false };
     expression = new Expression("rgba(255, 0, 0, 0.5)");
     shaderExpression = expression.getShaderExpression(
-      propertyNameMap,
+      variableSubstitutionMap,
       shaderState
     );
     expected = "vec4(1.0, 0.0, 0.0, 0.5)";
@@ -3753,7 +3767,7 @@ describe("Scene/Expression", function () {
     shaderState = { translucent: false };
     expression = new Expression("rgba(255, ${property}, 0, 0.5)");
     shaderExpression = expression.getShaderExpression(
-      propertyNameMap,
+      variableSubstitutionMap,
       shaderState
     );
     expected = "vec4(255.0 / 255.0, property / 255.0, 0.0 / 255.0, 0.5)";
@@ -3763,7 +3777,7 @@ describe("Scene/Expression", function () {
     shaderState = { translucent: false };
     expression = new Expression("hsl(1.0, 0.5, 0.5)");
     shaderExpression = expression.getShaderExpression(
-      propertyNameMap,
+      variableSubstitutionMap,
       shaderState
     );
     expected = "vec4(0.75, 0.25, 0.25, 1.0)";
@@ -3773,7 +3787,7 @@ describe("Scene/Expression", function () {
     shaderState = { translucent: false };
     expression = new Expression("hsla(1.0, 0.5, 0.5, 0.5)");
     shaderExpression = expression.getShaderExpression(
-      propertyNameMap,
+      variableSubstitutionMap,
       shaderState
     );
     expected = "vec4(0.75, 0.25, 0.25, 0.5)";
@@ -3783,7 +3797,7 @@ describe("Scene/Expression", function () {
     shaderState = { translucent: false };
     expression = new Expression("hsl(1.0, ${property}, 0.5)");
     shaderExpression = expression.getShaderExpression(
-      propertyNameMap,
+      variableSubstitutionMap,
       shaderState
     );
     expected = "vec4(czm_HSLToRGB(vec3(1.0, property, 0.5)), 1.0)";
@@ -3793,7 +3807,7 @@ describe("Scene/Expression", function () {
     shaderState = { translucent: false };
     expression = new Expression("hsla(1.0, ${property}, 0.5, 0.5)");
     shaderExpression = expression.getShaderExpression(
-      propertyNameMap,
+      variableSubstitutionMap,
       shaderState
     );
     expected = "vec4(czm_HSLToRGB(vec3(1.0, property, 0.5)), 0.5)";
@@ -3827,26 +3841,38 @@ describe("Scene/Expression", function () {
   });
 
   it("gets shader expression for vector", function () {
-    var propertyNameMap = {
+    var variableSubstitutionMap = {
       property: "property",
     };
 
     var expression = new Expression("vec4(1, 2, 3, 4)");
-    var shaderExpression = expression.getShaderExpression(propertyNameMap, {});
+    var shaderExpression = expression.getShaderExpression(
+      variableSubstitutionMap,
+      {}
+    );
     expect(shaderExpression).toEqual("vec4(1.0, 2.0, 3.0, 4.0)");
 
     expression = new Expression("vec4(1) + vec4(2)");
-    shaderExpression = expression.getShaderExpression(propertyNameMap, {});
+    shaderExpression = expression.getShaderExpression(
+      variableSubstitutionMap,
+      {}
+    );
     expect(shaderExpression).toEqual("(vec4(1.0) + vec4(2.0))");
 
     expression = new Expression("vec4(1, ${property}, vec2(1, 2).x, 0)");
-    shaderExpression = expression.getShaderExpression(propertyNameMap, {});
+    shaderExpression = expression.getShaderExpression(
+      variableSubstitutionMap,
+      {}
+    );
     expect(shaderExpression).toEqual(
       "vec4(1.0, property, vec2(1.0, 2.0)[0], 0.0)"
     );
 
     expression = new Expression("vec4(vec3(2), 1.0)");
-    shaderExpression = expression.getShaderExpression(propertyNameMap, {});
+    shaderExpression = expression.getShaderExpression(
+      variableSubstitutionMap,
+      {}
+    );
     expect(shaderExpression).toEqual("vec4(vec3(2.0), 1.0)");
   });
 
@@ -4099,6 +4125,14 @@ describe("Scene/Expression", function () {
     var shaderExpression = expression.getShaderExpression({}, {});
     var expected = "czm_infinity";
     expect(shaderExpression).toEqual(expected);
+  });
+
+  it("gets variables", function () {
+    var expression = new Expression(
+      '${feature["w"]} + ${feature.x} + ${y} + ${y} + "${z}"'
+    );
+    var variables = expression.getVariables();
+    expect(variables.sort()).toEqual(["w", "x", "y", "z"]);
   });
 
   it("throws when getting shader expression for regex", function () {

--- a/Specs/Scene/StyleExpressionSpec.js
+++ b/Specs/Scene/StyleExpressionSpec.js
@@ -18,5 +18,13 @@ describe("Scene/StyleExpression", function () {
     expect(function () {
       return expression.evaluateColor(feature);
     }).toThrowDeveloperError();
+
+    expect(function () {
+      return expression.getShaderFunction("getColor()", {}, {}, "vec4");
+    }).toThrowDeveloperError();
+
+    expect(function () {
+      return expression.getVariables("");
+    }).toThrowDeveloperError();
   });
 });


### PR DESCRIPTION
This PR is extracting out some code from the [`model-loading`](https://github.com/CesiumGS/cesium/tree/model-loading) branch. When a style is converted into a custom shader it needs to know the variables used in the style whether that be feature properties like `${Height}` or built-ins like `${POSITION}` (for point clouds).

This adds a new private function `Cesium3DTileStyle.prototype.getVariables` as well as similar functions for `StyleExpression`, `Expression`, and `ConditionsExpression`.