### PR TITLE
Add more functions to FeatureTable

### DIFF
--- a/Source/Scene/BatchTableHierarchy.js
+++ b/Source/Scene/BatchTableHierarchy.js
@@ -358,6 +358,25 @@ BatchTableHierarchy.prototype.hasProperty = function (batchId, propertyId) {
 };
 
 /**
+ * Returns whether any feature has this property.
+ *
+ * @param {String} propertyId The case-sensitive ID of the property.
+ * @returns {Boolean} Whether any feature has this property.
+ * @private
+ */
+BatchTableHierarchy.prototype.propertyExists = function (propertyId) {
+  var classes = this._classes;
+  var classesLength = classes.length;
+  for (var i = 0; i < classesLength; ++i) {
+    var instances = classes[i].instances;
+    if (defined(instances[propertyId])) {
+      return true;
+    }
+  }
+  return false;
+};
+
+/**
  * Returns an array of property IDs.
  *
  * @param {Number} batchId the batch ID of the feature

--- a/Source/Scene/BatchTableHierarchy.js
+++ b/Source/Scene/BatchTableHierarchy.js
@@ -336,11 +336,11 @@ function traverseHierarchy(hierarchy, instanceIndex, endConditionCallback) {
 }
 
 /**
- * Returns whether this property exists.
+ * Returns whether the feature has this property.
  *
  * @param {Number} batchId the batch ID of the feature
  * @param {String} propertyId The case-sensitive ID of the property.
- * @returns {Boolean} Whether this property exists.
+ * @returns {Boolean} Whether the feature has this property.
  * @private
  */
 BatchTableHierarchy.prototype.hasProperty = function (batchId, propertyId) {
@@ -390,7 +390,7 @@ BatchTableHierarchy.prototype.getPropertyIds = function (batchId, results) {
  *
  * @param {Number} batchId the batch ID of the feature
  * @param {String} propertyId The case-sensitive ID of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @returns {*} The value of the property or <code>undefined</code> if the feature does not have this property.
  * @private
  */
 BatchTableHierarchy.prototype.getProperty = function (batchId, propertyId) {

--- a/Source/Scene/Cesium3DTileContent.js
+++ b/Source/Scene/Cesium3DTileContent.js
@@ -247,12 +247,11 @@ Object.defineProperties(Cesium3DTileContent.prototype, {
 });
 
 /**
- * Determines if the tile's batch table has a property.  If it does, each feature in
- * the tile will have the property.
+ * Determines if the feature has this property.
  *
  * @param {Number} batchId The batchId for the feature.
  * @param {String} name The case-sensitive name of the property.
- * @returns {Boolean} <code>true</code> if the property exists; otherwise, <code>false</code>.
+ * @returns {Boolean} <code>true</code> if the feature has this property; otherwise, <code>false</code>.
  */
 Cesium3DTileContent.prototype.hasProperty = function (batchId, name) {
   DeveloperError.throwInstantiationError();

--- a/Source/Scene/Cesium3DTileContent.js
+++ b/Source/Scene/Cesium3DTileContent.js
@@ -247,7 +247,7 @@ Object.defineProperties(Cesium3DTileContent.prototype, {
 });
 
 /**
- * Determines if the feature has this property.
+ * Returns whether the feature has this property.
  *
  * @param {Number} batchId The batchId for the feature.
  * @param {String} name The case-sensitive name of the property.

--- a/Source/Scene/Cesium3DTileFeature.js
+++ b/Source/Scene/Cesium3DTileFeature.js
@@ -175,7 +175,7 @@ Cesium3DTileFeature.prototype.getPropertyNames = function (results) {
  * @see {@link https://github.com/CesiumGS/3d-tiles/tree/master/extensions/3DTILES_batch_table_hierarchy}
  *
  * @param {String} name The case-sensitive name of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @returns {*} The value of the property or <code>undefined</code> if the feature does not have this property.
  *
  * @example
  * // Display all the properties for a feature in the console log.
@@ -202,7 +202,7 @@ Cesium3DTileFeature.prototype.getProperty = function (name) {
  * properties.
  * </p>
  * @param {String} name The case-sensitive name of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @returns {*} The value of the property or <code>undefined</code> if the feature does not have this property.
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */

--- a/Source/Scene/Cesium3DTilePointFeature.js
+++ b/Source/Scene/Cesium3DTilePointFeature.js
@@ -745,7 +745,7 @@ Cesium3DTilePointFeature.prototype.getPropertyNames = function (results) {
  * @see {@link https://github.com/CesiumGS/3d-tiles/tree/master/extensions/3DTILES_batch_table_hierarchy}
  *
  * @param {String} name The case-sensitive name of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @returns {*} The value of the property or <code>undefined</code> if the feature does not have this property.
  *
  * @example
  * // Display all the properties for a feature in the console log.

--- a/Source/Scene/FeatureTable.js
+++ b/Source/Scene/FeatureTable.js
@@ -146,6 +146,83 @@ FeatureTable.prototype.hasProperty = function (index, propertyId) {
   return false;
 };
 
+/**
+ * Returns whether the feature has a property with the given semantic.
+ *
+ * @param {String} semantic The case-sensitive semantic of the property.
+ * @returns {Boolean} Whether the feature has a property with the given semantic.
+ * @private
+ */
+FeatureTable.prototype.hasPropertyBySemantic = function (index, semantic) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.number("index", index);
+  Check.typeOf.string("semantic", semantic);
+  //>>includeEnd('debug');
+
+  if (defined(this._metadataTable)) {
+    return this._metadataTable.hasPropertyBySemantic(semantic);
+  }
+
+  return false;
+};
+
+/**
+ * Returns whether any feature has this property.
+ * This is mainly useful for checking whether a property exists in the class
+ * hierarchy when using the <code>3DTILES_batch_table_hierarchy</code> extension.
+ *
+ * @param {String} propertyId The case-sensitive ID of the property.
+ * @returns {Boolean} Whether any feature has this property.
+ * @private
+ */
+FeatureTable.prototype.propertyExists = function (propertyId) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.string("propertyId", propertyId);
+  //>>includeEnd('debug');
+
+  if (
+    defined(this._metadataTable) &&
+    this._metadataTable.hasProperty(propertyId)
+  ) {
+    return true;
+  }
+
+  if (
+    defined(this._jsonMetadataTable) &&
+    this._jsonMetadataTable.hasProperty(propertyId)
+  ) {
+    return true;
+  }
+
+  if (
+    defined(this._batchTableHierarchy) &&
+    this._batchTableHierarchy.propertyExists(propertyId)
+  ) {
+    return true;
+  }
+
+  return false;
+};
+
+/**
+ * Returns whether any feature has a property with the given semantic.
+ *
+ * @param {String} semantic The case-sensitive semantic of the property.
+ * @returns {Boolean} Whether any feature has a property with the given semantic.
+ * @private
+ */
+FeatureTable.prototype.propertyExistsBySemantic = function (semantic) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.string("semantic", semantic);
+  //>>includeEnd('debug');
+
+  if (defined(this._metadataTable)) {
+    return this._metadataTable.hasPropertyBySemantic(semantic);
+  }
+
+  return false;
+};
+
 var scratchResults = [];
 
 /**
@@ -307,6 +384,26 @@ FeatureTable.prototype.getPropertyTypedArray = function (propertyId) {
 
   if (defined(this._metadataTable)) {
     return this._metadataTable.getPropertyTypedArray(propertyId);
+  }
+
+  return undefined;
+};
+
+/**
+ * Returns a typed array containing the property values for the property with the given semantic.
+ *
+ * @param {String} semantic The case-sensitive semantic of the property.
+ * @returns {*} The typed array containing the property values or <code>undefined</code> if the property values are not stored in a typed array.
+ *
+ * @private
+ */
+FeatureTable.prototype.getPropertyTypedArrayBySemantic = function (semantic) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.string("semantic", semantic);
+  //>>includeEnd('debug');
+
+  if (defined(this._metadataTable)) {
+    return this._metadataTable.getPropertyTypedArrayBySemantic(semantic);
   }
 
   return undefined;

--- a/Source/Scene/FeatureTable.js
+++ b/Source/Scene/FeatureTable.js
@@ -337,7 +337,7 @@ FeatureTable.prototype.setProperty = function (index, propertyId, value) {
  *
  * @param {Number} index The index of the feature.
  * @param {String} semantic The case-sensitive semantic of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the feature does not have this property.
+ * @returns {*} The value of the property or <code>undefined</code> if the feature does not have this semantic.
  * @private
  */
 FeatureTable.prototype.getPropertyBySemantic = function (index, semantic) {

--- a/Source/Scene/FeatureTable.js
+++ b/Source/Scene/FeatureTable.js
@@ -153,14 +153,14 @@ FeatureTable.prototype.hasProperty = function (index, propertyId) {
  * @returns {Boolean} Whether the feature has a property with the given semantic.
  * @private
  */
-FeatureTable.prototype.hasPropertyBySemantic = function (index, semantic) {
+FeatureTable.prototype.hasSemantic = function (index, semantic) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.number("index", index);
   Check.typeOf.string("semantic", semantic);
   //>>includeEnd('debug');
 
   if (defined(this._metadataTable)) {
-    return this._metadataTable.hasPropertyBySemantic(semantic);
+    return this._metadataTable.hasSemantic(semantic);
   }
 
   return false;
@@ -211,13 +211,13 @@ FeatureTable.prototype.propertyExists = function (propertyId) {
  * @returns {Boolean} Whether any feature has a property with the given semantic.
  * @private
  */
-FeatureTable.prototype.propertyExistsBySemantic = function (semantic) {
+FeatureTable.prototype.semanticExists = function (semantic) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.string("semantic", semantic);
   //>>includeEnd('debug');
 
   if (defined(this._metadataTable)) {
-    return this._metadataTable.hasPropertyBySemantic(semantic);
+    return this._metadataTable.hasSemantic(semantic);
   }
 
   return false;

--- a/Source/Scene/FeatureTable.js
+++ b/Source/Scene/FeatureTable.js
@@ -109,11 +109,11 @@ Object.defineProperties(FeatureTable.prototype, {
 });
 
 /**
- * Returns whether this property exists. For compatibility with the <code>3DTILES_batch_table_hierarchy</code> extension, this is computed for a specific feature.
+ * Returns whether the feature has this property. For compatibility with the <code>3DTILES_batch_table_hierarchy</code> extension, this is computed for a specific feature.
  *
  * @param {Number} index The index of the feature.
  * @param {String} propertyId The case-sensitive ID of the property.
- * @returns {Boolean} Whether this property exists.
+ * @returns {Boolean} Whether the feature has this property.
  * @private
  */
 FeatureTable.prototype.hasProperty = function (index, propertyId) {
@@ -193,7 +193,7 @@ FeatureTable.prototype.getPropertyIds = function (index, results) {
  *
  * @param {Number} index The index of the feature.
  * @param {String} propertyId The case-sensitive ID of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @returns {*} The value of the property or <code>undefined</code> if the feature does not have this property.
  * @private
  */
 FeatureTable.prototype.getProperty = function (index, propertyId) {
@@ -260,7 +260,7 @@ FeatureTable.prototype.setProperty = function (index, propertyId, value) {
  *
  * @param {Number} index The index of the feature.
  * @param {String} semantic The case-sensitive semantic of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @returns {*} The value of the property or <code>undefined</code> if the feature does not have this property.
  * @private
  */
 FeatureTable.prototype.getPropertyBySemantic = function (index, semantic) {

--- a/Source/Scene/FeatureTable.js
+++ b/Source/Scene/FeatureTable.js
@@ -10,7 +10,7 @@ import defined from "../Core/defined.js";
  * For batch tables, properties are resolved in the following order:
  * </p>
  * <ol>
- *   <li>binary properties from options.featureTable</li>
+ *   <li>binary properties from options.metadataTable</li>
  *   <li>JSON properties from options.jsonMetadataTable</li>
  *   <li>batch table hierarchy properties from options.batchTableHierarchy</li>
  * </ol>
@@ -334,6 +334,11 @@ FeatureTable.prototype.setProperty = function (index, propertyId, value) {
 
 /**
  * Returns a copy of the value of the property with the given semantic.
+ * <p>
+ * This only operates on the underlying {@link MetadataTable} (if present) as
+ * {@link JsonMetadataTable} and {@link BatchTableHierarchy} do not have
+ * semantics.
+ * </p>
  *
  * @param {Number} index The index of the feature.
  * @param {String} semantic The case-sensitive semantic of the property.
@@ -350,6 +355,11 @@ FeatureTable.prototype.getPropertyBySemantic = function (index, semantic) {
 
 /**
  * Sets the value of the property with the given semantic.
+ * <p>
+ * This only operates on the underlying {@link MetadataTable} (if present) as
+ * {@link JsonMetadataTable} and {@link BatchTableHierarchy} do not have
+ * semantics.
+ * </p>
  *
  * @param {Number} index The index of the feature.
  * @param {String} semantic The case-sensitive semantic of the property.
@@ -371,6 +381,11 @@ FeatureTable.prototype.setPropertyBySemantic = function (
 
 /**
  * Returns a typed array containing the property values for a given propertyId.
+ * <p>
+ * This only operates on the underlying {@link MetadataTable} (if present) as
+ * {@link JsonMetadataTable} and {@link BatchTableHierarchy} do not store
+ * values in typed arrays.
+ * </p>
  *
  * @param {String} propertyId The case-sensitive ID of the property.
  * @returns {*} The typed array containing the property values or <code>undefined</code> if the property values are not stored in a typed array.
@@ -391,6 +406,11 @@ FeatureTable.prototype.getPropertyTypedArray = function (propertyId) {
 
 /**
  * Returns a typed array containing the property values for the property with the given semantic.
+ * <p>
+ * This only operates on the underlying {@link MetadataTable} (if present) as
+ * {@link JsonMetadataTable} and {@link BatchTableHierarchy} do not have
+ * semantics.
+ * </p>
  *
  * @param {String} semantic The case-sensitive semantic of the property.
  * @returns {*} The typed array containing the property values or <code>undefined</code> if the property values are not stored in a typed array.

--- a/Source/Scene/FeatureTable.js
+++ b/Source/Scene/FeatureTable.js
@@ -153,14 +153,14 @@ FeatureTable.prototype.hasProperty = function (index, propertyId) {
  * @returns {Boolean} Whether the feature has a property with the given semantic.
  * @private
  */
-FeatureTable.prototype.hasSemantic = function (index, semantic) {
+FeatureTable.prototype.hasPropertyBySemantic = function (index, semantic) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.number("index", index);
   Check.typeOf.string("semantic", semantic);
   //>>includeEnd('debug');
 
   if (defined(this._metadataTable)) {
-    return this._metadataTable.hasSemantic(semantic);
+    return this._metadataTable.hasPropertyBySemantic(semantic);
   }
 
   return false;
@@ -211,13 +211,13 @@ FeatureTable.prototype.propertyExists = function (propertyId) {
  * @returns {Boolean} Whether any feature has a property with the given semantic.
  * @private
  */
-FeatureTable.prototype.semanticExists = function (semantic) {
+FeatureTable.prototype.propertyExistsBySemantic = function (semantic) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.string("semantic", semantic);
   //>>includeEnd('debug');
 
   if (defined(this._metadataTable)) {
-    return this._metadataTable.hasSemantic(semantic);
+    return this._metadataTable.hasPropertyBySemantic(semantic);
   }
 
   return false;

--- a/Source/Scene/GroupMetadata.js
+++ b/Source/Scene/GroupMetadata.js
@@ -138,6 +138,21 @@ GroupMetadata.prototype.hasProperty = function (propertyId) {
 };
 
 /**
+ * Returns whether the group has a property with the given semantic.
+ *
+ * @param {String} semantic The case-sensitive semantic of the property.
+ * @returns {Boolean} Whether the group has a property with the given semantic.
+ * @private
+ */
+GroupMetadata.prototype.hasPropertyBySemantic = function (semantic) {
+  return MetadataEntity.hasPropertyBySemantic(
+    semantic,
+    this._properties,
+    this._class
+  );
+};
+
+/**
  * Returns an array of property IDs.
  *
  * @param {String[]} [results] An array into which to store the results.

--- a/Source/Scene/GroupMetadata.js
+++ b/Source/Scene/GroupMetadata.js
@@ -144,12 +144,8 @@ GroupMetadata.prototype.hasProperty = function (propertyId) {
  * @returns {Boolean} Whether the group has a property with the given semantic.
  * @private
  */
-GroupMetadata.prototype.hasPropertyBySemantic = function (semantic) {
-  return MetadataEntity.hasPropertyBySemantic(
-    semantic,
-    this._properties,
-    this._class
-  );
+GroupMetadata.prototype.hasSemantic = function (semantic) {
+  return MetadataEntity.hasSemantic(semantic, this._properties, this._class);
 };
 
 /**

--- a/Source/Scene/GroupMetadata.js
+++ b/Source/Scene/GroupMetadata.js
@@ -144,8 +144,12 @@ GroupMetadata.prototype.hasProperty = function (propertyId) {
  * @returns {Boolean} Whether the group has a property with the given semantic.
  * @private
  */
-GroupMetadata.prototype.hasSemantic = function (semantic) {
-  return MetadataEntity.hasSemantic(semantic, this._properties, this._class);
+GroupMetadata.prototype.hasPropertyBySemantic = function (semantic) {
+  return MetadataEntity.hasPropertyBySemantic(
+    semantic,
+    this._properties,
+    this._class
+  );
 };
 
 /**

--- a/Source/Scene/GroupMetadata.js
+++ b/Source/Scene/GroupMetadata.js
@@ -197,7 +197,7 @@ GroupMetadata.prototype.setProperty = function (propertyId, value) {
  * Returns a copy of the value of the property with the given semantic.
  *
  * @param {String} semantic The case-sensitive semantic of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the group does not have this property.
+ * @returns {*} The value of the property or <code>undefined</code> if the group does not have this semantic.
  * @private
  */
 GroupMetadata.prototype.getPropertyBySemantic = function (semantic) {

--- a/Source/Scene/GroupMetadata.js
+++ b/Source/Scene/GroupMetadata.js
@@ -127,10 +127,10 @@ Object.defineProperties(GroupMetadata.prototype, {
 });
 
 /**
- * Returns whether this property exists.
+ * Returns whether the group has this property.
  *
  * @param {String} propertyId The case-sensitive ID of the property.
- * @returns {Boolean} Whether this property exists.
+ * @returns {Boolean} Whether the group has this property.
  * @private
  */
 GroupMetadata.prototype.hasProperty = function (propertyId) {
@@ -155,7 +155,7 @@ GroupMetadata.prototype.getPropertyIds = function (results) {
  * </p>
  *
  * @param {String} propertyId The case-sensitive ID of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @returns {*} The value of the property or <code>undefined</code> if the group does not have this property.
  * @private
  */
 GroupMetadata.prototype.getProperty = function (propertyId) {
@@ -186,7 +186,7 @@ GroupMetadata.prototype.setProperty = function (propertyId, value) {
  * Returns a copy of the value of the property with the given semantic.
  *
  * @param {String} semantic The case-sensitive semantic of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @returns {*} The value of the property or <code>undefined</code> if the group does not have this property.
  * @private
  */
 GroupMetadata.prototype.getPropertyBySemantic = function (semantic) {

--- a/Source/Scene/ImplicitTileMetadata.js
+++ b/Source/Scene/ImplicitTileMetadata.js
@@ -103,8 +103,8 @@ ImplicitTileMetadata.prototype.hasProperty = function (propertyId) {
  * @returns {Boolean} Whether the tile has a property with the given semantic.
  * @private
  */
-ImplicitTileMetadata.prototype.hasSemantic = function (semantic) {
-  return this._metadataTable.hasSemantic(semantic);
+ImplicitTileMetadata.prototype.hasPropertyBySemantic = function (semantic) {
+  return this._metadataTable.hasPropertyBySemantic(semantic);
 };
 
 /**

--- a/Source/Scene/ImplicitTileMetadata.js
+++ b/Source/Scene/ImplicitTileMetadata.js
@@ -86,10 +86,10 @@ Object.defineProperties(ImplicitTileMetadata.prototype, {
 });
 
 /**
- * Returns whether this property exists.
+ * Returns whether the tile has this property.
  *
  * @param {String} propertyId The case-sensitive ID of the property.
- * @returns {Boolean} Whether this property exists.
+ * @returns {Boolean} Whether the tile has this property.
  * @private
  */
 ImplicitTileMetadata.prototype.hasProperty = function (propertyId) {
@@ -114,7 +114,7 @@ ImplicitTileMetadata.prototype.getPropertyIds = function (results) {
  * </p>
  *
  * @param {String} propertyId The case-sensitive ID of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @returns {*} The value of the property or <code>undefined</code> if the tile does not have this property.
  * @private
  */
 ImplicitTileMetadata.prototype.getProperty = function (propertyId) {
@@ -140,7 +140,7 @@ ImplicitTileMetadata.prototype.setProperty = function (propertyId, value) {
  * Returns a copy of the value of the property with the given semantic.
  *
  * @param {String} semantic The case-sensitive semantic of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @returns {*} The value of the property or <code>undefined</code> if the tile does not have this property.
  * @private
  */
 ImplicitTileMetadata.prototype.getPropertyBySemantic = function (semantic) {

--- a/Source/Scene/ImplicitTileMetadata.js
+++ b/Source/Scene/ImplicitTileMetadata.js
@@ -151,7 +151,7 @@ ImplicitTileMetadata.prototype.setProperty = function (propertyId, value) {
  * Returns a copy of the value of the property with the given semantic.
  *
  * @param {String} semantic The case-sensitive semantic of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the tile does not have this property.
+ * @returns {*} The value of the property or <code>undefined</code> if the tile does not have this semantic.
  * @private
  */
 ImplicitTileMetadata.prototype.getPropertyBySemantic = function (semantic) {

--- a/Source/Scene/ImplicitTileMetadata.js
+++ b/Source/Scene/ImplicitTileMetadata.js
@@ -103,8 +103,8 @@ ImplicitTileMetadata.prototype.hasProperty = function (propertyId) {
  * @returns {Boolean} Whether the tile has a property with the given semantic.
  * @private
  */
-ImplicitTileMetadata.prototype.hasPropertyBySemantic = function (semantic) {
-  return this._metadataTable.hasPropertyBySemantic(semantic);
+ImplicitTileMetadata.prototype.hasSemantic = function (semantic) {
+  return this._metadataTable.hasSemantic(semantic);
 };
 
 /**

--- a/Source/Scene/ImplicitTileMetadata.js
+++ b/Source/Scene/ImplicitTileMetadata.js
@@ -97,6 +97,17 @@ ImplicitTileMetadata.prototype.hasProperty = function (propertyId) {
 };
 
 /**
+ * Returns whether the tile has a property with the given semantic.
+ *
+ * @param {String} semantic The case-sensitive semantic of the property.
+ * @returns {Boolean} Whether the tile has a property with the given semantic.
+ * @private
+ */
+ImplicitTileMetadata.prototype.hasPropertyBySemantic = function (semantic) {
+  return this._metadataTable.hasPropertyBySemantic(semantic);
+};
+
+/**
  * Returns an array of property IDs.
  *
  * @param {String[]} [results] An array into which to store the results.

--- a/Source/Scene/JsonMetadataTable.js
+++ b/Source/Scene/JsonMetadataTable.js
@@ -26,10 +26,10 @@ export default function JsonMetadataTable(options) {
 }
 
 /**
- * Returns whether this property exists.
+ * Returns whether the table has this property.
  *
  * @param {String} propertyId The case-sensitive ID of the property.
- * @returns {Boolean} Whether this property exists.
+ * @returns {Boolean} Whether the table has this property.
  * @private
  */
 JsonMetadataTable.prototype.hasProperty = function (propertyId) {
@@ -52,7 +52,7 @@ JsonMetadataTable.prototype.getPropertyIds = function (results) {
  *
  * @param {Number} index The index of the entity.
  * @param {String} propertyId The case-sensitive ID of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @returns {*} The value of the property or <code>undefined</code> if the entity does not have this property.
  *
  * @exception {DeveloperError} index is out of bounds
  * @private

--- a/Source/Scene/MetadataEntity.js
+++ b/Source/Scene/MetadataEntity.js
@@ -48,6 +48,17 @@ MetadataEntity.prototype.hasProperty = function (propertyId) {
 };
 
 /**
+ * Returns whether the entity has a property with the given semantic.
+ *
+ * @param {String} semantic The case-sensitive semantic of the property.
+ * @returns {Boolean} Whether the entity has a property with the given semantic.
+ * @private
+ */
+MetadataEntity.prototype.hasPropertyBySemantic = function (semantic) {
+  DeveloperError.throwInstantiationError();
+};
+
+/**
  * Returns an array of property IDs.
  *
  * @param {String[]} [results] An array into which to store the results.
@@ -142,6 +153,34 @@ MetadataEntity.hasProperty = function (
   }
 
   return false;
+};
+
+/**
+ * Returns whether the entity has a property with the given semantic.
+ *
+ * @param {String} semantic The case-sensitive semantic of the property.
+ * @param {Object} properties The dictionary containing properties.
+ * @param {MetadataClass} [classDefinition] The class.
+ * @returns {Boolean} Whether the entity has a property with the given semantic.
+ *
+ * @private
+ */
+MetadataEntity.hasPropertyBySemantic = function (
+  semantic,
+  properties,
+  classDefinition
+) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.string("semantic", semantic);
+  Check.typeOf.object("properties", properties);
+  //>>includeEnd('debug');
+
+  if (!defined(classDefinition)) {
+    return false;
+  }
+
+  var property = classDefinition.propertiesBySemantic[semantic];
+  return defined(property);
 };
 
 /**

--- a/Source/Scene/MetadataEntity.js
+++ b/Source/Scene/MetadataEntity.js
@@ -37,10 +37,10 @@ Object.defineProperties(MetadataEntity.prototype, {
 });
 
 /**
- * Returns whether this property exists.
+ * Returns whether the entity has this property.
  *
  * @param {String} propertyId The case-sensitive ID of the property.
- * @returns {Boolean} Whether this property exists.
+ * @returns {Boolean} Whether the entity has this property.
  * @private
  */
 MetadataEntity.prototype.hasProperty = function (propertyId) {
@@ -65,7 +65,7 @@ MetadataEntity.prototype.getPropertyIds = function (results) {
  * </p>
  *
  * @param {String} propertyId The case-sensitive ID of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @returns {*} The value of the property or <code>undefined</code> if the entity does not have this property.
  * @private
  */
 MetadataEntity.prototype.getProperty = function (propertyId) {
@@ -91,7 +91,7 @@ MetadataEntity.prototype.setProperty = function (propertyId, value) {
  * Returns a copy of the value of the property with the given semantic.
  *
  * @param {String} semantic The case-sensitive semantic of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @returns {*} The value of the property or <code>undefined</code> if the entity does not have this property.
  * @private
  */
 MetadataEntity.prototype.getPropertyBySemantic = function (semantic) {
@@ -111,12 +111,12 @@ MetadataEntity.prototype.setPropertyBySemantic = function (semantic, value) {
 };
 
 /**
- * Returns whether this property exists.
+ * Returns whether the entity has this property.
  *
  * @param {String} propertyId The case-sensitive ID of the property.
  * @param {Object} properties The dictionary containing properties.
  * @param {MetadataClass} [classDefinition] The class.
- * @returns {Boolean} Whether this property exists.
+ * @returns {Boolean} Whether the entity has this property.
  *
  * @private
  */
@@ -202,7 +202,7 @@ MetadataEntity.getPropertyIds = function (
  * @param {String} propertyId The case-sensitive ID of the property.
  * @param {Object} properties The dictionary containing properties.
  * @param {MetadataClass} [classDefinition] The class.
- * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @returns {*} The value of the property or <code>undefined</code> if the entity does not have this property.
  *
  * @private
  */
@@ -295,7 +295,7 @@ MetadataEntity.setProperty = function (
  * @param {String} semantic The case-sensitive semantic of the property.
  * @param {Object} properties The dictionary containing properties.
  * @param {MetadataClass} classDefinition The class.
- * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @returns {*} The value of the property or <code>undefined</code> if the entity does not have this property.
  *
  * @private
  */

--- a/Source/Scene/MetadataEntity.js
+++ b/Source/Scene/MetadataEntity.js
@@ -54,7 +54,7 @@ MetadataEntity.prototype.hasProperty = function (propertyId) {
  * @returns {Boolean} Whether the entity has a property with the given semantic.
  * @private
  */
-MetadataEntity.prototype.hasPropertyBySemantic = function (semantic) {
+MetadataEntity.prototype.hasSemantic = function (semantic) {
   DeveloperError.throwInstantiationError();
 };
 
@@ -165,11 +165,7 @@ MetadataEntity.hasProperty = function (
  *
  * @private
  */
-MetadataEntity.hasPropertyBySemantic = function (
-  semantic,
-  properties,
-  classDefinition
-) {
+MetadataEntity.hasSemantic = function (semantic, properties, classDefinition) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.string("semantic", semantic);
   Check.typeOf.object("properties", properties);

--- a/Source/Scene/MetadataEntity.js
+++ b/Source/Scene/MetadataEntity.js
@@ -54,7 +54,7 @@ MetadataEntity.prototype.hasProperty = function (propertyId) {
  * @returns {Boolean} Whether the entity has a property with the given semantic.
  * @private
  */
-MetadataEntity.prototype.hasSemantic = function (semantic) {
+MetadataEntity.prototype.hasPropertyBySemantic = function (semantic) {
   DeveloperError.throwInstantiationError();
 };
 
@@ -165,7 +165,11 @@ MetadataEntity.hasProperty = function (
  *
  * @private
  */
-MetadataEntity.hasSemantic = function (semantic, properties, classDefinition) {
+MetadataEntity.hasPropertyBySemantic = function (
+  semantic,
+  properties,
+  classDefinition
+) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.string("semantic", semantic);
   Check.typeOf.object("properties", properties);

--- a/Source/Scene/MetadataTable.js
+++ b/Source/Scene/MetadataTable.js
@@ -206,7 +206,7 @@ MetadataTable.prototype.setProperty = function (index, propertyId, value) {
  *
  * @param {Number} index The index of the entity.
  * @param {String} semantic The case-sensitive semantic of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the entity does not have this property.
+ * @returns {*} The value of the property or <code>undefined</code> if the entity does not have this semantic.
  *
  * @exception {DeveloperError} index is required and between zero and count - 1
  * @private

--- a/Source/Scene/MetadataTable.js
+++ b/Source/Scene/MetadataTable.js
@@ -100,12 +100,8 @@ MetadataTable.prototype.hasProperty = function (propertyId) {
  * @returns {Boolean} Whether the table has a property with the given semantic.
  * @private
  */
-MetadataTable.prototype.hasPropertyBySemantic = function (semantic) {
-  return MetadataEntity.hasPropertyBySemantic(
-    semantic,
-    this._properties,
-    this._class
-  );
+MetadataTable.prototype.hasSemantic = function (semantic) {
+  return MetadataEntity.hasSemantic(semantic, this._properties, this._class);
 };
 
 /**

--- a/Source/Scene/MetadataTable.js
+++ b/Source/Scene/MetadataTable.js
@@ -83,10 +83,10 @@ Object.defineProperties(MetadataTable.prototype, {
 });
 
 /**
- * Returns whether this property exists.
+ * Returns whether the table has this property.
  *
  * @param {String} propertyId The case-sensitive ID of the property.
- * @returns {Boolean} Whether this property exists.
+ * @returns {Boolean} Whether the table has this property.
  * @private
  */
 MetadataTable.prototype.hasProperty = function (propertyId) {
@@ -124,7 +124,7 @@ MetadataTable.prototype.getPropertyIds = function (results) {
  *
  * @param {Number} index The index of the entity.
  * @param {String} propertyId The case-sensitive ID of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @returns {*} The value of the property or <code>undefined</code> if the entity does not have this property.
  *
  * @exception {DeveloperError} index is required and between zero and count - 1
  * @private
@@ -195,7 +195,7 @@ MetadataTable.prototype.setProperty = function (index, propertyId, value) {
  *
  * @param {Number} index The index of the entity.
  * @param {String} semantic The case-sensitive semantic of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @returns {*} The value of the property or <code>undefined</code> if the entity does not have this property.
  *
  * @exception {DeveloperError} index is required and between zero and count - 1
  * @private

--- a/Source/Scene/MetadataTable.js
+++ b/Source/Scene/MetadataTable.js
@@ -100,8 +100,12 @@ MetadataTable.prototype.hasProperty = function (propertyId) {
  * @returns {Boolean} Whether the table has a property with the given semantic.
  * @private
  */
-MetadataTable.prototype.hasSemantic = function (semantic) {
-  return MetadataEntity.hasSemantic(semantic, this._properties, this._class);
+MetadataTable.prototype.hasPropertyBySemantic = function (semantic) {
+  return MetadataEntity.hasPropertyBySemantic(
+    semantic,
+    this._properties,
+    this._class
+  );
 };
 
 /**

--- a/Source/Scene/MetadataTable.js
+++ b/Source/Scene/MetadataTable.js
@@ -94,6 +94,21 @@ MetadataTable.prototype.hasProperty = function (propertyId) {
 };
 
 /**
+ * Returns whether the table has a property with the given semantic.
+ *
+ * @param {String} semantic The case-sensitive semantic of the property.
+ * @returns {Boolean} Whether the table has a property with the given semantic.
+ * @private
+ */
+MetadataTable.prototype.hasPropertyBySemantic = function (semantic) {
+  return MetadataEntity.hasPropertyBySemantic(
+    semantic,
+    this._properties,
+    this._class
+  );
+};
+
+/**
  * Returns an array of property IDs.
  *
  * @param {String[]} [results] An array into which to store the results.
@@ -264,6 +279,29 @@ MetadataTable.prototype.getPropertyTypedArray = function (propertyId) {
 
   if (defined(property)) {
     return property.getTypedArray();
+  }
+
+  return undefined;
+};
+
+/**
+ * Returns a typed array containing the property values for the property with the given semantic.
+ *
+ * @param {String} semantic The case-sensitive semantic of the property.
+ * @returns {*} The typed array containing the property values or <code>undefined</code> if the property values are not stored in a typed array.
+ *
+ * @private
+ */
+MetadataTable.prototype.getPropertyTypedArrayBySemantic = function (semantic) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.string("semantic", semantic);
+  //>>includeEnd('debug');
+
+  if (defined(this._class)) {
+    var property = this._class.propertiesBySemantic[semantic];
+    if (defined(property)) {
+      return this.getPropertyTypedArray(property.id);
+    }
   }
 
   return undefined;

--- a/Source/Scene/TileMetadata.js
+++ b/Source/Scene/TileMetadata.js
@@ -148,7 +148,7 @@ TileMetadata.prototype.setProperty = function (propertyId, value) {
  * Returns a copy of the value of the property with the given semantic.
  *
  * @param {String} semantic The case-sensitive semantic of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the tile does not have this property.
+ * @returns {*} The value of the property or <code>undefined</code> if the tile does not have this semantic.
  * @private
  */
 TileMetadata.prototype.getPropertyBySemantic = function (semantic) {

--- a/Source/Scene/TileMetadata.js
+++ b/Source/Scene/TileMetadata.js
@@ -95,8 +95,12 @@ TileMetadata.prototype.hasProperty = function (propertyId) {
  * @returns {Boolean} Whether the tile has a property with the given semantic.
  * @private
  */
-TileMetadata.prototype.hasSemantic = function (semantic) {
-  return MetadataEntity.hasSemantic(semantic, this._properties, this._class);
+TileMetadata.prototype.hasPropertyBySemantic = function (semantic) {
+  return MetadataEntity.hasPropertyBySemantic(
+    semantic,
+    this._properties,
+    this._class
+  );
 };
 
 /**

--- a/Source/Scene/TileMetadata.js
+++ b/Source/Scene/TileMetadata.js
@@ -78,10 +78,10 @@ Object.defineProperties(TileMetadata.prototype, {
 });
 
 /**
- * Returns whether this property exists.
+ * Returns whether the tile has this property.
  *
  * @param {String} propertyId The case-sensitive ID of the property.
- * @returns {Boolean} Whether this property exists.
+ * @returns {Boolean} Whether the tile has this property.
  * @private
  */
 TileMetadata.prototype.hasProperty = function (propertyId) {
@@ -106,7 +106,7 @@ TileMetadata.prototype.getPropertyIds = function (results) {
  * </p>
  *
  * @param {String} propertyId The case-sensitive ID of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @returns {*} The value of the property or <code>undefined</code> if the tile does not have this property.
  * @private
  */
 TileMetadata.prototype.getProperty = function (propertyId) {
@@ -137,7 +137,7 @@ TileMetadata.prototype.setProperty = function (propertyId, value) {
  * Returns a copy of the value of the property with the given semantic.
  *
  * @param {String} semantic The case-sensitive semantic of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @returns {*} The value of the property or <code>undefined</code> if the tile does not have this property.
  * @private
  */
 TileMetadata.prototype.getPropertyBySemantic = function (semantic) {

--- a/Source/Scene/TileMetadata.js
+++ b/Source/Scene/TileMetadata.js
@@ -95,12 +95,8 @@ TileMetadata.prototype.hasProperty = function (propertyId) {
  * @returns {Boolean} Whether the tile has a property with the given semantic.
  * @private
  */
-TileMetadata.prototype.hasPropertyBySemantic = function (semantic) {
-  return MetadataEntity.hasPropertyBySemantic(
-    semantic,
-    this._properties,
-    this._class
-  );
+TileMetadata.prototype.hasSemantic = function (semantic) {
+  return MetadataEntity.hasSemantic(semantic, this._properties, this._class);
 };
 
 /**

--- a/Source/Scene/TileMetadata.js
+++ b/Source/Scene/TileMetadata.js
@@ -89,6 +89,21 @@ TileMetadata.prototype.hasProperty = function (propertyId) {
 };
 
 /**
+ * Returns whether the tile has a property with the given semantic.
+ *
+ * @param {String} semantic The case-sensitive semantic of the property.
+ * @returns {Boolean} Whether the tile has a property with the given semantic.
+ * @private
+ */
+TileMetadata.prototype.hasPropertyBySemantic = function (semantic) {
+  return MetadataEntity.hasPropertyBySemantic(
+    semantic,
+    this._properties,
+    this._class
+  );
+};
+
+/**
  * Returns an array of property IDs.
  *
  * @param {String[]} [results] An array into which to store the results.

--- a/Source/Scene/TilesetMetadata.js
+++ b/Source/Scene/TilesetMetadata.js
@@ -126,8 +126,12 @@ TilesetMetadata.prototype.hasProperty = function (propertyId) {
  * @returns {Boolean} Whether the tileset has a property with the given semantic.
  * @private
  */
-TilesetMetadata.prototype.hasSemantic = function (semantic) {
-  return MetadataEntity.hasSemantic(semantic, this._properties, this._class);
+TilesetMetadata.prototype.hasPropertyBySemantic = function (semantic) {
+  return MetadataEntity.hasPropertyBySemantic(
+    semantic,
+    this._properties,
+    this._class
+  );
 };
 
 /**

--- a/Source/Scene/TilesetMetadata.js
+++ b/Source/Scene/TilesetMetadata.js
@@ -109,10 +109,10 @@ Object.defineProperties(TilesetMetadata.prototype, {
 });
 
 /**
- * Returns whether this property exists.
+ * Returns whether the tileset has this property.
  *
  * @param {String} propertyId The case-sensitive ID of the property.
- * @returns {Boolean} Whether this property exists.
+ * @returns {Boolean} Whether the tileset has this property.
  * @private
  */
 TilesetMetadata.prototype.hasProperty = function (propertyId) {
@@ -137,7 +137,7 @@ TilesetMetadata.prototype.getPropertyIds = function (results) {
  * </p>
  *
  * @param {String} propertyId The case-sensitive ID of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @returns {*} The value of the property or <code>undefined</code> if the tileset does not have this property.
  * @private
  */
 TilesetMetadata.prototype.getProperty = function (propertyId) {
@@ -168,7 +168,7 @@ TilesetMetadata.prototype.setProperty = function (propertyId, value) {
  * Returns a copy of the value of the property with the given semantic.
  *
  * @param {String} semantic The case-sensitive semantic of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the property does not exist.
+ * @returns {*} The value of the property or <code>undefined</code> if the tileset does not have this property.
  * @private
  */
 TilesetMetadata.prototype.getPropertyBySemantic = function (semantic) {

--- a/Source/Scene/TilesetMetadata.js
+++ b/Source/Scene/TilesetMetadata.js
@@ -120,6 +120,21 @@ TilesetMetadata.prototype.hasProperty = function (propertyId) {
 };
 
 /**
+ * Returns whether the tileset has a property with the given semantic.
+ *
+ * @param {String} semantic The case-sensitive semantic of the property.
+ * @returns {Boolean} Whether the tileset has a property with the given semantic.
+ * @private
+ */
+TilesetMetadata.prototype.hasPropertyBySemantic = function (semantic) {
+  return MetadataEntity.hasPropertyBySemantic(
+    semantic,
+    this._properties,
+    this._class
+  );
+};
+
+/**
  * Returns an array of property IDs.
  *
  * @param {String[]} [results] An array into which to store the results.

--- a/Source/Scene/TilesetMetadata.js
+++ b/Source/Scene/TilesetMetadata.js
@@ -126,12 +126,8 @@ TilesetMetadata.prototype.hasProperty = function (propertyId) {
  * @returns {Boolean} Whether the tileset has a property with the given semantic.
  * @private
  */
-TilesetMetadata.prototype.hasPropertyBySemantic = function (semantic) {
-  return MetadataEntity.hasPropertyBySemantic(
-    semantic,
-    this._properties,
-    this._class
-  );
+TilesetMetadata.prototype.hasSemantic = function (semantic) {
+  return MetadataEntity.hasSemantic(semantic, this._properties, this._class);
 };
 
 /**

--- a/Source/Scene/TilesetMetadata.js
+++ b/Source/Scene/TilesetMetadata.js
@@ -179,7 +179,7 @@ TilesetMetadata.prototype.setProperty = function (propertyId, value) {
  * Returns a copy of the value of the property with the given semantic.
  *
  * @param {String} semantic The case-sensitive semantic of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the tileset does not have this property.
+ * @returns {*} The value of the property or <code>undefined</code> if the tileset does not have this semantic.
  * @private
  */
 TilesetMetadata.prototype.getPropertyBySemantic = function (semantic) {

--- a/Specs/Scene/BatchTableHierarchySpec.js
+++ b/Specs/Scene/BatchTableHierarchySpec.js
@@ -159,14 +159,14 @@ describe("Scene/BatchTableHierarchy", function () {
     }).toThrowRuntimeError();
   });
 
-  it("hasProperty returns true if property exists", function () {
+  it("hasProperty returns true if the feature has this property", function () {
     var hierarchy = new BatchTableHierarchy({
       extension: hierarchyExtension,
     });
     expect(hierarchy.hasProperty(0, "color")).toBe(true);
   });
 
-  it("hasProperty returns false if property does not exist", function () {
+  it("hasProperty returns false if property does not have this property", function () {
     var hierarchy = new BatchTableHierarchy({
       extension: hierarchyExtension,
     });

--- a/Specs/Scene/BatchTableHierarchySpec.js
+++ b/Specs/Scene/BatchTableHierarchySpec.js
@@ -166,18 +166,32 @@ describe("Scene/BatchTableHierarchy", function () {
     expect(hierarchy.hasProperty(0, "color")).toBe(true);
   });
 
-  it("hasProperty returns false if property does not have this property", function () {
+  it("hasProperty returns false if the feature does not have this property", function () {
     var hierarchy = new BatchTableHierarchy({
       extension: hierarchyExtension,
     });
     expect(hierarchy.hasProperty(0, "height")).toBe(false);
   });
 
-  it("hasProperty returns false if feature does not inherit property", function () {
+  it("hasProperty returns false if the feature does not inherit this property", function () {
     var hierarchy = new BatchTableHierarchy({
       extension: hierarchyExtension,
     });
     expect(hierarchy.hasProperty(6, "color")).toBe(false);
+  });
+
+  it("propertyExists returns true if any feature has this property", function () {
+    var hierarchy = new BatchTableHierarchy({
+      extension: hierarchyExtension,
+    });
+    expect(hierarchy.propertyExists("color")).toBe(true);
+  });
+
+  it("propertyExists returns false if no features have this property", function () {
+    var hierarchy = new BatchTableHierarchy({
+      extension: hierarchyExtension,
+    });
+    expect(hierarchy.propertyExists("other")).toBe(false);
   });
 
   it("getProperty returns property value", function () {

--- a/Specs/Scene/FeatureTableSpec.js
+++ b/Specs/Scene/FeatureTableSpec.js
@@ -88,12 +88,12 @@ describe("Scene/FeatureTable", function () {
     }).toThrowDeveloperError();
   });
 
-  it("hasProperty returns true if a property exists", function () {
+  it("hasProperty returns true if the feature has this property", function () {
     var featureTable = createFeatureTable();
     expect(featureTable.hasProperty(0, "name")).toBe(true);
   });
 
-  it("hasProperty returns false if a property does not exist", function () {
+  it("hasProperty returns false if the feature does not have this property", function () {
     var featureTable = createFeatureTable();
     expect(featureTable.hasProperty(0, "numberOfPoints")).toBe(false);
   });
@@ -105,7 +105,7 @@ describe("Scene/FeatureTable", function () {
     expect(propertyIds).toEqual(["height", "name"]);
   });
 
-  it("getProperty returns undefined if a property does not exist", function () {
+  it("getProperty returns undefined if the property does not exist", function () {
     var featureTable = createFeatureTable();
     expect(featureTable.getProperty(0, "numberOfPoints")).not.toBeDefined();
   });

--- a/Specs/Scene/FeatureTableSpec.js
+++ b/Specs/Scene/FeatureTableSpec.js
@@ -99,28 +99,28 @@ describe("Scene/FeatureTable", function () {
     expect(featureTable.hasProperty(0, "numberOfPoints")).toBe(false);
   });
 
-  it("hasPropertyBySemantic throws without index", function () {
+  it("hasSemantic throws without index", function () {
     var featureTable = createFeatureTable();
     expect(function () {
-      featureTable.hasPropertyBySemantic(undefined, "NAME");
+      featureTable.hasSemantic(undefined, "NAME");
     }).toThrowDeveloperError();
   });
 
-  it("hasPropertyBySemantic throws without semantic", function () {
+  it("hasSemantic throws without semantic", function () {
     var featureTable = createFeatureTable();
     expect(function () {
-      featureTable.hasPropertyBySemantic(0, undefined);
+      featureTable.hasSemantic(0, undefined);
     }).toThrowDeveloperError();
   });
 
-  it("hasPropertyBySemantic returns true if the feature has a property with the given semantic", function () {
+  it("hasSemantic returns true if the feature has a property with the given semantic", function () {
     var featureTable = createFeatureTable();
-    expect(featureTable.hasPropertyBySemantic(0, "NAME")).toBe(true);
+    expect(featureTable.hasSemantic(0, "NAME")).toBe(true);
   });
 
-  it("hasPropertyBySemantic returns false if the feature does not a property with the given semantic", function () {
+  it("hasSemantic returns false if the feature does not a property with the given semantic", function () {
     var featureTable = createFeatureTable();
-    expect(featureTable.hasPropertyBySemantic(0, "ID")).toBe(false);
+    expect(featureTable.hasSemantic(0, "ID")).toBe(false);
   });
 
   it("propertyExists throws without propertyId", function () {
@@ -140,21 +140,21 @@ describe("Scene/FeatureTable", function () {
     expect(featureTable.propertyExists("numberOfPoints")).toBe(false);
   });
 
-  it("propertyExistsBySemantic throws without semantic", function () {
+  it("semanticExists throws without semantic", function () {
     var featureTable = createFeatureTable();
     expect(function () {
-      featureTable.propertyExistsBySemantic(undefined);
+      featureTable.semanticExists(undefined);
     }).toThrowDeveloperError();
   });
 
-  it("propertyExistsBySemantic returns true if the property exists", function () {
+  it("semanticExists returns true if the property exists", function () {
     var featureTable = createFeatureTable();
-    expect(featureTable.propertyExistsBySemantic("NAME")).toBe(true);
+    expect(featureTable.semanticExists("NAME")).toBe(true);
   });
 
-  it("propertyExistsBySemantic returns false if the property does not exist", function () {
+  it("semanticExists returns false if the property does not exist", function () {
     var featureTable = createFeatureTable();
-    expect(featureTable.propertyExistsBySemantic("ID")).toBe(false);
+    expect(featureTable.semanticExists("ID")).toBe(false);
   });
 
   it("getPropertyIds returns array of property IDs", function () {
@@ -414,8 +414,8 @@ describe("Scene/FeatureTable", function () {
       expect(batchTable.hasProperty(0, "widgets")).toBe(false);
     });
 
-    it("hasPropertyBySemantic returns false when there is no metadata table", function () {
-      expect(batchTableJsonOnly.hasPropertyBySemantic(0, "NAME")).toBe(false);
+    it("hasSemantic returns false when there is no metadata table", function () {
+      expect(batchTableJsonOnly.hasSemantic(0, "NAME")).toBe(false);
     });
 
     it("propertyExists uses feature metadata", function () {
@@ -439,8 +439,8 @@ describe("Scene/FeatureTable", function () {
       expect(batchTable.propertyExists("widgets")).toBe(false);
     });
 
-    it("propertyExistsBySemantic returns false when there is no metadata table", function () {
-      expect(batchTableJsonOnly.propertyExistsBySemantic("NAME")).toBe(false);
+    it("semanticExists returns false when there is no metadata table", function () {
+      expect(batchTableJsonOnly.semanticExists("NAME")).toBe(false);
     });
 
     it("getProperty uses feature metadata", function () {

--- a/Specs/Scene/FeatureTableSpec.js
+++ b/Specs/Scene/FeatureTableSpec.js
@@ -19,6 +19,7 @@ describe("Scene/FeatureTable", function () {
     },
     height: {
       type: "FLOAT32",
+      semantic: "HEIGHT",
     },
   };
 
@@ -98,6 +99,64 @@ describe("Scene/FeatureTable", function () {
     expect(featureTable.hasProperty(0, "numberOfPoints")).toBe(false);
   });
 
+  it("hasPropertyBySemantic throws without index", function () {
+    var featureTable = createFeatureTable();
+    expect(function () {
+      featureTable.hasPropertyBySemantic(undefined, "NAME");
+    }).toThrowDeveloperError();
+  });
+
+  it("hasPropertyBySemantic throws without semantic", function () {
+    var featureTable = createFeatureTable();
+    expect(function () {
+      featureTable.hasPropertyBySemantic(0, undefined);
+    }).toThrowDeveloperError();
+  });
+
+  it("hasPropertyBySemantic returns true if the feature has a property with the given semantic", function () {
+    var featureTable = createFeatureTable();
+    expect(featureTable.hasPropertyBySemantic(0, "NAME")).toBe(true);
+  });
+
+  it("hasPropertyBySemantic returns false if the feature does not a property with the given semantic", function () {
+    var featureTable = createFeatureTable();
+    expect(featureTable.hasPropertyBySemantic(0, "ID")).toBe(false);
+  });
+
+  it("propertyExists throws without propertyId", function () {
+    var featureTable = createFeatureTable();
+    expect(function () {
+      featureTable.propertyExists(undefined);
+    }).toThrowDeveloperError();
+  });
+
+  it("propertyExists returns true if the property exists", function () {
+    var featureTable = createFeatureTable();
+    expect(featureTable.propertyExists("name")).toBe(true);
+  });
+
+  it("propertyExists returns false if the property does not exist", function () {
+    var featureTable = createFeatureTable();
+    expect(featureTable.propertyExists("numberOfPoints")).toBe(false);
+  });
+
+  it("propertyExistsBySemantic throws without semantic", function () {
+    var featureTable = createFeatureTable();
+    expect(function () {
+      featureTable.propertyExistsBySemantic(undefined);
+    }).toThrowDeveloperError();
+  });
+
+  it("propertyExistsBySemantic returns true if the property exists", function () {
+    var featureTable = createFeatureTable();
+    expect(featureTable.propertyExistsBySemantic("NAME")).toBe(true);
+  });
+
+  it("propertyExistsBySemantic returns false if the property does not exist", function () {
+    var featureTable = createFeatureTable();
+    expect(featureTable.propertyExistsBySemantic("ID")).toBe(false);
+  });
+
   it("getPropertyIds returns array of property IDs", function () {
     var featureTable = createFeatureTable();
     var propertyIds = featureTable.getPropertyIds([]);
@@ -105,7 +164,7 @@ describe("Scene/FeatureTable", function () {
     expect(propertyIds).toEqual(["height", "name"]);
   });
 
-  it("getProperty returns undefined if the property does not exist", function () {
+  it("getProperty returns undefined if a property does not exist", function () {
     var featureTable = createFeatureTable();
     expect(featureTable.getProperty(0, "numberOfPoints")).not.toBeDefined();
   });
@@ -188,6 +247,29 @@ describe("Scene/FeatureTable", function () {
     }).toThrowDeveloperError();
   });
 
+  it("getPropertyTypedArrayBySemantic returns typed array", function () {
+    var featureTable = createFeatureTable();
+    var expectedTypedArray = new Float32Array([10.0, 20.0, 30.0]);
+
+    expect(featureTable.getPropertyTypedArrayBySemantic("HEIGHT")).toEqual(
+      expectedTypedArray
+    );
+  });
+
+  it("getPropertyTypedArrayBySemantic returns undefined if semantic does not exist", function () {
+    var featureTable = createFeatureTable();
+
+    expect(featureTable.getPropertyTypedArrayBySemantic("ID")).toBeUndefined();
+  });
+
+  it("getPropertyTypedArrayBySemantic throws if semantic is undefined", function () {
+    var featureTable = createFeatureTable();
+
+    expect(function () {
+      featureTable.getPropertyTypedArrayBySemantic(undefined);
+    }).toThrowDeveloperError();
+  });
+
   describe("batch table compatibility", function () {
     var schemaJson = {
       classes: {
@@ -255,6 +337,8 @@ describe("Scene/FeatureTable", function () {
     };
 
     var batchTable;
+    var batchTableJsonOnly;
+
     beforeEach(function () {
       var jsonTable = new JsonMetadataTable({
         count: count,
@@ -277,6 +361,11 @@ describe("Scene/FeatureTable", function () {
         metadataTable: metadataTable,
         jsonMetadataTable: jsonTable,
         batchTableHierarchy: hierarchy,
+      });
+
+      batchTableJsonOnly = new FeatureTable({
+        count: count,
+        jsonMetadataTable: jsonTable,
       });
     });
 
@@ -323,6 +412,35 @@ describe("Scene/FeatureTable", function () {
 
     it("hasProperty returns false for unknown property", function () {
       expect(batchTable.hasProperty(0, "widgets")).toBe(false);
+    });
+
+    it("hasPropertyBySemantic returns false when there is no metadata table", function () {
+      expect(batchTableJsonOnly.hasPropertyBySemantic(0, "NAME")).toBe(false);
+    });
+
+    it("propertyExists uses feature metadata", function () {
+      expect(batchTable.propertyExists("itemId")).toBe(true);
+      expect(batchTable.propertyExists("itemCount")).toBe(true);
+    });
+
+    it("propertyExists uses JSON metadata", function () {
+      expect(batchTable.propertyExists("priority")).toBe(true);
+      expect(batchTable.propertyExists("uri")).toBe(true);
+    });
+
+    it("propertyExists uses batch table hierarchy", function () {
+      expect(batchTable.propertyExists("tireLocation")).toBe(true);
+      expect(batchTable.propertyExists("color")).toBe(true);
+      expect(batchTable.propertyExists("type")).toBe(true);
+      expect(batchTable.propertyExists("year")).toBe(true);
+    });
+
+    it("propertyExists returns false for unknown property", function () {
+      expect(batchTable.propertyExists("widgets")).toBe(false);
+    });
+
+    it("propertyExistsBySemantic returns false when there is no metadata table", function () {
+      expect(batchTableJsonOnly.propertyExistsBySemantic("NAME")).toBe(false);
     });
 
     it("getProperty uses feature metadata", function () {
@@ -405,6 +523,18 @@ describe("Scene/FeatureTable", function () {
       expect(batchTable.getPropertyTypedArray("priority")).not.toBeDefined();
       expect(
         batchTable.getPropertyTypedArray("tireLocation")
+      ).not.toBeDefined();
+    });
+
+    it("getPropertyTypedArray returns undefined when there is no metadata table", function () {
+      expect(
+        batchTableJsonOnly.getPropertyTypedArray("priority")
+      ).not.toBeDefined();
+    });
+
+    it("getPropertyTypedArrayBySemantic returns undefined when there is no metadata table", function () {
+      expect(
+        batchTableJsonOnly.getPropertyTypedArrayBySemantic("PRIORITY")
       ).not.toBeDefined();
     });
   });

--- a/Specs/Scene/FeatureTableSpec.js
+++ b/Specs/Scene/FeatureTableSpec.js
@@ -99,28 +99,28 @@ describe("Scene/FeatureTable", function () {
     expect(featureTable.hasProperty(0, "numberOfPoints")).toBe(false);
   });
 
-  it("hasSemantic throws without index", function () {
+  it("hasPropertyBySemantic throws without index", function () {
     var featureTable = createFeatureTable();
     expect(function () {
-      featureTable.hasSemantic(undefined, "NAME");
+      featureTable.hasPropertyBySemantic(undefined, "NAME");
     }).toThrowDeveloperError();
   });
 
-  it("hasSemantic throws without semantic", function () {
+  it("hasPropertyBySemantic throws without semantic", function () {
     var featureTable = createFeatureTable();
     expect(function () {
-      featureTable.hasSemantic(0, undefined);
+      featureTable.hasPropertyBySemantic(0, undefined);
     }).toThrowDeveloperError();
   });
 
-  it("hasSemantic returns true if the feature has a property with the given semantic", function () {
+  it("hasPropertyBySemantic returns true if the feature has a property with the given semantic", function () {
     var featureTable = createFeatureTable();
-    expect(featureTable.hasSemantic(0, "NAME")).toBe(true);
+    expect(featureTable.hasPropertyBySemantic(0, "NAME")).toBe(true);
   });
 
-  it("hasSemantic returns false if the feature does not a property with the given semantic", function () {
+  it("hasPropertyBySemantic returns false if the feature does not a property with the given semantic", function () {
     var featureTable = createFeatureTable();
-    expect(featureTable.hasSemantic(0, "ID")).toBe(false);
+    expect(featureTable.hasPropertyBySemantic(0, "ID")).toBe(false);
   });
 
   it("propertyExists throws without propertyId", function () {
@@ -140,21 +140,21 @@ describe("Scene/FeatureTable", function () {
     expect(featureTable.propertyExists("numberOfPoints")).toBe(false);
   });
 
-  it("semanticExists throws without semantic", function () {
+  it("propertyExistsBySemantic throws without semantic", function () {
     var featureTable = createFeatureTable();
     expect(function () {
-      featureTable.semanticExists(undefined);
+      featureTable.propertyExistsBySemantic(undefined);
     }).toThrowDeveloperError();
   });
 
-  it("semanticExists returns true if the property exists", function () {
+  it("propertyExistsBySemantic returns true if the property exists", function () {
     var featureTable = createFeatureTable();
-    expect(featureTable.semanticExists("NAME")).toBe(true);
+    expect(featureTable.propertyExistsBySemantic("NAME")).toBe(true);
   });
 
-  it("semanticExists returns false if the property does not exist", function () {
+  it("propertyExistsBySemantic returns false if the property does not exist", function () {
     var featureTable = createFeatureTable();
-    expect(featureTable.semanticExists("ID")).toBe(false);
+    expect(featureTable.propertyExistsBySemantic("ID")).toBe(false);
   });
 
   it("getPropertyIds returns array of property IDs", function () {
@@ -414,8 +414,8 @@ describe("Scene/FeatureTable", function () {
       expect(batchTable.hasProperty(0, "widgets")).toBe(false);
     });
 
-    it("hasSemantic returns false when there is no metadata table", function () {
-      expect(batchTableJsonOnly.hasSemantic(0, "NAME")).toBe(false);
+    it("hasPropertyBySemantic returns false when there is no metadata table", function () {
+      expect(batchTableJsonOnly.hasPropertyBySemantic(0, "NAME")).toBe(false);
     });
 
     it("propertyExists uses feature metadata", function () {
@@ -439,8 +439,8 @@ describe("Scene/FeatureTable", function () {
       expect(batchTable.propertyExists("widgets")).toBe(false);
     });
 
-    it("semanticExists returns false when there is no metadata table", function () {
-      expect(batchTableJsonOnly.semanticExists("NAME")).toBe(false);
+    it("propertyExistsBySemantic returns false when there is no metadata table", function () {
+      expect(batchTableJsonOnly.propertyExistsBySemantic("NAME")).toBe(false);
     });
 
     it("getProperty uses feature metadata", function () {

--- a/Specs/Scene/GroupMetadataSpec.js
+++ b/Specs/Scene/GroupMetadataSpec.js
@@ -173,6 +173,97 @@ describe("Scene/GroupMetadata", function () {
     }).toThrowDeveloperError();
   });
 
+  it("hasPropertyBySemantic returns false when there's no properties", function () {
+    var groupMetadata = new GroupMetadata({
+      id: "building",
+      group: {},
+    });
+    expect(groupMetadata.hasPropertyBySemantic("HEIGHT")).toBe(false);
+  });
+
+  it("hasPropertyBySemantic returns false when there's no property with the given semantic", function () {
+    var buildingClass = new MetadataClass({
+      id: "building",
+      class: {
+        properties: {
+          height: {
+            type: "FLOAT32",
+          },
+        },
+      },
+    });
+
+    var groupMetadata = new GroupMetadata({
+      class: buildingClass,
+      id: "building",
+      group: {
+        properties: {
+          height: 10.0,
+        },
+      },
+    });
+    expect(groupMetadata.hasPropertyBySemantic("HEIGHT")).toBe(false);
+  });
+
+  it("hasPropertyBySemantic returns true when there's a property with the given semantic", function () {
+    var buildingClass = new MetadataClass({
+      id: "building",
+      class: {
+        properties: {
+          height: {
+            type: "FLOAT32",
+            semantic: "HEIGHT",
+          },
+        },
+      },
+    });
+
+    var groupMetadata = new GroupMetadata({
+      class: buildingClass,
+      id: "building",
+      group: {
+        properties: {
+          height: 10.0,
+        },
+      },
+    });
+    expect(groupMetadata.hasPropertyBySemantic("HEIGHT")).toBe(true);
+  });
+
+  it("hasPropertyBySemantic returns true when the class has a default value for a missing property", function () {
+    var buildingClass = new MetadataClass({
+      id: "building",
+      class: {
+        properties: {
+          height: {
+            type: "FLOAT32",
+            semantic: "HEIGHT",
+            optional: true,
+            default: 10.0,
+          },
+        },
+      },
+    });
+    var groupMetadata = new GroupMetadata({
+      class: buildingClass,
+      id: "building",
+      group: {},
+    });
+
+    expect(groupMetadata.hasPropertyBySemantic("HEIGHT")).toBe(true);
+  });
+
+  it("hasPropertyBySemantic throws without semantic", function () {
+    var groupMetadata = new GroupMetadata({
+      id: "building",
+      group: {},
+    });
+
+    expect(function () {
+      groupMetadata.hasPropertyBySemantic(undefined);
+    }).toThrowDeveloperError();
+  });
+
   it("getPropertyIds returns empty array when there are no properties", function () {
     var groupMetadata = new GroupMetadata({
       id: "building",

--- a/Specs/Scene/GroupMetadataSpec.js
+++ b/Specs/Scene/GroupMetadataSpec.js
@@ -173,15 +173,15 @@ describe("Scene/GroupMetadata", function () {
     }).toThrowDeveloperError();
   });
 
-  it("hasSemantic returns false when there's no properties", function () {
+  it("hasPropertyBySemantic returns false when there's no properties", function () {
     var groupMetadata = new GroupMetadata({
       id: "building",
       group: {},
     });
-    expect(groupMetadata.hasSemantic("HEIGHT")).toBe(false);
+    expect(groupMetadata.hasPropertyBySemantic("HEIGHT")).toBe(false);
   });
 
-  it("hasSemantic returns false when there's no property with the given semantic", function () {
+  it("hasPropertyBySemantic returns false when there's no property with the given semantic", function () {
     var buildingClass = new MetadataClass({
       id: "building",
       class: {
@@ -202,10 +202,10 @@ describe("Scene/GroupMetadata", function () {
         },
       },
     });
-    expect(groupMetadata.hasSemantic("HEIGHT")).toBe(false);
+    expect(groupMetadata.hasPropertyBySemantic("HEIGHT")).toBe(false);
   });
 
-  it("hasSemantic returns true when there's a property with the given semantic", function () {
+  it("hasPropertyBySemantic returns true when there's a property with the given semantic", function () {
     var buildingClass = new MetadataClass({
       id: "building",
       class: {
@@ -227,10 +227,10 @@ describe("Scene/GroupMetadata", function () {
         },
       },
     });
-    expect(groupMetadata.hasSemantic("HEIGHT")).toBe(true);
+    expect(groupMetadata.hasPropertyBySemantic("HEIGHT")).toBe(true);
   });
 
-  it("hasSemantic returns true when the class has a default value for a missing property", function () {
+  it("hasPropertyBySemantic returns true when the class has a default value for a missing property", function () {
     var buildingClass = new MetadataClass({
       id: "building",
       class: {
@@ -250,17 +250,17 @@ describe("Scene/GroupMetadata", function () {
       group: {},
     });
 
-    expect(groupMetadata.hasSemantic("HEIGHT")).toBe(true);
+    expect(groupMetadata.hasPropertyBySemantic("HEIGHT")).toBe(true);
   });
 
-  it("hasSemantic throws without semantic", function () {
+  it("hasPropertyBySemantic throws without semantic", function () {
     var groupMetadata = new GroupMetadata({
       id: "building",
       group: {},
     });
 
     expect(function () {
-      groupMetadata.hasSemantic(undefined);
+      groupMetadata.hasPropertyBySemantic(undefined);
     }).toThrowDeveloperError();
   });
 

--- a/Specs/Scene/GroupMetadataSpec.js
+++ b/Specs/Scene/GroupMetadataSpec.js
@@ -173,15 +173,15 @@ describe("Scene/GroupMetadata", function () {
     }).toThrowDeveloperError();
   });
 
-  it("hasPropertyBySemantic returns false when there's no properties", function () {
+  it("hasSemantic returns false when there's no properties", function () {
     var groupMetadata = new GroupMetadata({
       id: "building",
       group: {},
     });
-    expect(groupMetadata.hasPropertyBySemantic("HEIGHT")).toBe(false);
+    expect(groupMetadata.hasSemantic("HEIGHT")).toBe(false);
   });
 
-  it("hasPropertyBySemantic returns false when there's no property with the given semantic", function () {
+  it("hasSemantic returns false when there's no property with the given semantic", function () {
     var buildingClass = new MetadataClass({
       id: "building",
       class: {
@@ -202,10 +202,10 @@ describe("Scene/GroupMetadata", function () {
         },
       },
     });
-    expect(groupMetadata.hasPropertyBySemantic("HEIGHT")).toBe(false);
+    expect(groupMetadata.hasSemantic("HEIGHT")).toBe(false);
   });
 
-  it("hasPropertyBySemantic returns true when there's a property with the given semantic", function () {
+  it("hasSemantic returns true when there's a property with the given semantic", function () {
     var buildingClass = new MetadataClass({
       id: "building",
       class: {
@@ -227,10 +227,10 @@ describe("Scene/GroupMetadata", function () {
         },
       },
     });
-    expect(groupMetadata.hasPropertyBySemantic("HEIGHT")).toBe(true);
+    expect(groupMetadata.hasSemantic("HEIGHT")).toBe(true);
   });
 
-  it("hasPropertyBySemantic returns true when the class has a default value for a missing property", function () {
+  it("hasSemantic returns true when the class has a default value for a missing property", function () {
     var buildingClass = new MetadataClass({
       id: "building",
       class: {
@@ -250,17 +250,17 @@ describe("Scene/GroupMetadata", function () {
       group: {},
     });
 
-    expect(groupMetadata.hasPropertyBySemantic("HEIGHT")).toBe(true);
+    expect(groupMetadata.hasSemantic("HEIGHT")).toBe(true);
   });
 
-  it("hasPropertyBySemantic throws without semantic", function () {
+  it("hasSemantic throws without semantic", function () {
     var groupMetadata = new GroupMetadata({
       id: "building",
       group: {},
     });
 
     expect(function () {
-      groupMetadata.hasPropertyBySemantic(undefined);
+      groupMetadata.hasSemantic(undefined);
     }).toThrowDeveloperError();
   });
 

--- a/Specs/Scene/ImplicitTileMetadataSpec.js
+++ b/Specs/Scene/ImplicitTileMetadataSpec.js
@@ -197,11 +197,11 @@ describe("Scene/ImplicitTileMetadata", function () {
     expect(tileMetadata.extensions).toBe(undefined);
   });
 
-  it("hasProperty returns true if a property exists", function () {
+  it("hasProperty returns true if the tile has this property", function () {
     expect(tileMetadata.hasProperty("highlightColor")).toBe(true);
   });
 
-  it("hasProperty returns false if a property does not exist", function () {
+  it("hasProperty returns false if the tile does not have this property", function () {
     expect(tileMetadata.hasProperty("numberOfPoints")).toBe(false);
   });
 
@@ -211,7 +211,7 @@ describe("Scene/ImplicitTileMetadata", function () {
     expect(propertyIds).toEqual(["buildingCount", "highlightColor"]);
   });
 
-  it("getProperty returns undefined if a property does not exist", function () {
+  it("getProperty returns undefined if the property does not exist", function () {
     expect(tileMetadata.getProperty("numberOfPoints")).not.toBeDefined();
   });
 

--- a/Specs/Scene/ImplicitTileMetadataSpec.js
+++ b/Specs/Scene/ImplicitTileMetadataSpec.js
@@ -205,12 +205,12 @@ describe("Scene/ImplicitTileMetadata", function () {
     expect(tileMetadata.hasProperty("numberOfPoints")).toBe(false);
   });
 
-  it("hasSemantic returns true if the tile has a property with the given semantic", function () {
-    expect(tileMetadata.hasSemantic("_HIGHLIGHT_COLOR")).toBe(true);
+  it("hasPropertyBySemantic returns true if the tile has a property with the given semantic", function () {
+    expect(tileMetadata.hasPropertyBySemantic("_HIGHLIGHT_COLOR")).toBe(true);
   });
 
-  it("hasSemantic returns false if the tile does not have a property with the given semantic", function () {
-    expect(tileMetadata.hasSemantic("_NUMBER_OF_POINTS")).toBe(false);
+  it("hasPropertyBySemantic returns false if the tile does not have a property with the given semantic", function () {
+    expect(tileMetadata.hasPropertyBySemantic("_NUMBER_OF_POINTS")).toBe(false);
   });
 
   it("getPropertyIds returns array of property IDs", function () {

--- a/Specs/Scene/ImplicitTileMetadataSpec.js
+++ b/Specs/Scene/ImplicitTileMetadataSpec.js
@@ -205,12 +205,12 @@ describe("Scene/ImplicitTileMetadata", function () {
     expect(tileMetadata.hasProperty("numberOfPoints")).toBe(false);
   });
 
-  it("hasPropertyBySemantic returns true if the tile has a property with the given semantic", function () {
-    expect(tileMetadata.hasPropertyBySemantic("_HIGHLIGHT_COLOR")).toBe(true);
+  it("hasSemantic returns true if the tile has a property with the given semantic", function () {
+    expect(tileMetadata.hasSemantic("_HIGHLIGHT_COLOR")).toBe(true);
   });
 
-  it("hasPropertyBySemantic returns false if the tile does not have a property with the given semantic", function () {
-    expect(tileMetadata.hasPropertyBySemantic("_NUMBER_OF_POINTS")).toBe(false);
+  it("hasSemantic returns false if the tile does not have a property with the given semantic", function () {
+    expect(tileMetadata.hasSemantic("_NUMBER_OF_POINTS")).toBe(false);
   });
 
   it("getPropertyIds returns array of property IDs", function () {

--- a/Specs/Scene/ImplicitTileMetadataSpec.js
+++ b/Specs/Scene/ImplicitTileMetadataSpec.js
@@ -205,13 +205,21 @@ describe("Scene/ImplicitTileMetadata", function () {
     expect(tileMetadata.hasProperty("numberOfPoints")).toBe(false);
   });
 
+  it("hasPropertyBySemantic returns true if the tile has a property with the given semantic", function () {
+    expect(tileMetadata.hasPropertyBySemantic("_HIGHLIGHT_COLOR")).toBe(true);
+  });
+
+  it("hasPropertyBySemantic returns false if the tile does not have a property with the given semantic", function () {
+    expect(tileMetadata.hasPropertyBySemantic("_NUMBER_OF_POINTS")).toBe(false);
+  });
+
   it("getPropertyIds returns array of property IDs", function () {
     var propertyIds = tileMetadata.getPropertyIds([]);
     propertyIds.sort();
     expect(propertyIds).toEqual(["buildingCount", "highlightColor"]);
   });
 
-  it("getProperty returns undefined if the property does not exist", function () {
+  it("getProperty returns undefined if a property does not exist", function () {
     expect(tileMetadata.getProperty("numberOfPoints")).not.toBeDefined();
   });
 

--- a/Specs/Scene/JsonMetadataTableSpec.js
+++ b/Specs/Scene/JsonMetadataTableSpec.js
@@ -58,11 +58,11 @@ describe("Scene/JsonMetadataTable", function () {
     expect(table.getProperty(0, "sizeInfo")).toEqual(sizeInfo);
   });
 
-  it("hasProperty returns true if the property exists", function () {
+  it("hasProperty returns true if the table has this property", function () {
     expect(table.hasProperty("priority")).toBe(true);
   });
 
-  it("hasProperty returns false if the property does not exist", function () {
+  it("hasProperty returns false if the table does not have this property", function () {
     expect(table.hasProperty("price")).toBe(false);
   });
 

--- a/Specs/Scene/MetadataEntitySpec.js
+++ b/Specs/Scene/MetadataEntitySpec.js
@@ -41,6 +41,9 @@ describe("Scene/MetadataEntity", function () {
       entity.hasProperty();
     }).toThrowDeveloperError();
     expect(function () {
+      entity.hasPropertyBySemantic();
+    }).toThrowDeveloperError();
+    expect(function () {
       entity.getPropertyIds();
     }).toThrowDeveloperError();
     expect(function () {
@@ -94,6 +97,57 @@ describe("Scene/MetadataEntity", function () {
   it("hasProperty works without classDefinition", function () {
     expect(MetadataEntity.hasProperty("name", properties)).toBe(true);
     expect(MetadataEntity.hasProperty("volume", properties)).toBe(false);
+  });
+
+  it("hasPropertyBySemantic returns false when there's no properties", function () {
+    expect(MetadataEntity.hasPropertyBySemantic("NAME", {})).toBe(false);
+  });
+
+  it("hasPropertyBySemantic returns false when there's no property with the given property ID", function () {
+    expect(
+      MetadataEntity.hasPropertyBySemantic(
+        "VOLUME",
+        properties,
+        classDefinition
+      )
+    ).toBe(false);
+  });
+
+  it("hasPropertyBySemantic returns false when there's no class definition", function () {
+    expect(MetadataEntity.hasPropertyBySemantic("NAME", properties)).toBe(
+      false
+    );
+    expect(MetadataEntity.hasPropertyBySemantic("VOLUME", properties)).toBe(
+      false
+    );
+  });
+
+  it("hasPropertyBySemantic returns true when there's a property with the given property ID", function () {
+    expect(
+      MetadataEntity.hasPropertyBySemantic("NAME", properties, classDefinition)
+    ).toBe(true);
+  });
+
+  it("hasPropertyBySemantic returns true when the class has a default value for a missing property", function () {
+    expect(
+      MetadataEntity.hasPropertyBySemantic("NAME", properties, classDefinition)
+    ).toBe(true);
+  });
+
+  it("hasPropertyBySemantic throws without semantic", function () {
+    expect(function () {
+      MetadataEntity.hasPropertyBySemantic(
+        undefined,
+        properties,
+        classDefinition
+      );
+    }).toThrowDeveloperError();
+  });
+
+  it("hasPropertyBySemantic throws without properties", function () {
+    expect(function () {
+      MetadataEntity.hasPropertyBySemantic("NAME", undefined, classDefinition);
+    }).toThrowDeveloperError();
   });
 
   it("getPropertyIds returns empty array when there are no properties", function () {
@@ -169,7 +223,7 @@ describe("Scene/MetadataEntity", function () {
 
   it("getProperty throws without properties", function () {
     expect(function () {
-      MetadataEntity.hasProperty("name", undefined, classDefinition);
+      MetadataEntity.getProperty("name", undefined, classDefinition);
     }).toThrowDeveloperError();
   });
 

--- a/Specs/Scene/MetadataEntitySpec.js
+++ b/Specs/Scene/MetadataEntitySpec.js
@@ -41,7 +41,7 @@ describe("Scene/MetadataEntity", function () {
       entity.hasProperty();
     }).toThrowDeveloperError();
     expect(function () {
-      entity.hasSemantic();
+      entity.hasPropertyBySemantic();
     }).toThrowDeveloperError();
     expect(function () {
       entity.getPropertyIds();
@@ -99,42 +99,54 @@ describe("Scene/MetadataEntity", function () {
     expect(MetadataEntity.hasProperty("volume", properties)).toBe(false);
   });
 
-  it("hasSemantic returns false when there's no properties", function () {
-    expect(MetadataEntity.hasSemantic("NAME", {})).toBe(false);
+  it("hasPropertyBySemantic returns false when there's no properties", function () {
+    expect(MetadataEntity.hasPropertyBySemantic("NAME", {})).toBe(false);
   });
 
-  it("hasSemantic returns false when there's no property with the given property ID", function () {
+  it("hasPropertyBySemantic returns false when there's no property with the given property ID", function () {
     expect(
-      MetadataEntity.hasSemantic("VOLUME", properties, classDefinition)
+      MetadataEntity.hasPropertyBySemantic(
+        "VOLUME",
+        properties,
+        classDefinition
+      )
     ).toBe(false);
   });
 
-  it("hasSemantic returns false when there's no class definition", function () {
-    expect(MetadataEntity.hasSemantic("NAME", properties)).toBe(false);
-    expect(MetadataEntity.hasSemantic("VOLUME", properties)).toBe(false);
+  it("hasPropertyBySemantic returns false when there's no class definition", function () {
+    expect(MetadataEntity.hasPropertyBySemantic("NAME", properties)).toBe(
+      false
+    );
+    expect(MetadataEntity.hasPropertyBySemantic("VOLUME", properties)).toBe(
+      false
+    );
   });
 
-  it("hasSemantic returns true when there's a property with the given property ID", function () {
+  it("hasPropertyBySemantic returns true when there's a property with the given property ID", function () {
     expect(
-      MetadataEntity.hasSemantic("NAME", properties, classDefinition)
+      MetadataEntity.hasPropertyBySemantic("NAME", properties, classDefinition)
     ).toBe(true);
   });
 
-  it("hasSemantic returns true when the class has a default value for a missing property", function () {
+  it("hasPropertyBySemantic returns true when the class has a default value for a missing property", function () {
     expect(
-      MetadataEntity.hasSemantic("NAME", properties, classDefinition)
+      MetadataEntity.hasPropertyBySemantic("NAME", properties, classDefinition)
     ).toBe(true);
   });
 
-  it("hasSemantic throws without semantic", function () {
+  it("hasPropertyBySemantic throws without semantic", function () {
     expect(function () {
-      MetadataEntity.hasSemantic(undefined, properties, classDefinition);
+      MetadataEntity.hasPropertyBySemantic(
+        undefined,
+        properties,
+        classDefinition
+      );
     }).toThrowDeveloperError();
   });
 
-  it("hasSemantic throws without properties", function () {
+  it("hasPropertyBySemantic throws without properties", function () {
     expect(function () {
-      MetadataEntity.hasSemantic("NAME", undefined, classDefinition);
+      MetadataEntity.hasPropertyBySemantic("NAME", undefined, classDefinition);
     }).toThrowDeveloperError();
   });
 

--- a/Specs/Scene/MetadataEntitySpec.js
+++ b/Specs/Scene/MetadataEntitySpec.js
@@ -41,7 +41,7 @@ describe("Scene/MetadataEntity", function () {
       entity.hasProperty();
     }).toThrowDeveloperError();
     expect(function () {
-      entity.hasPropertyBySemantic();
+      entity.hasSemantic();
     }).toThrowDeveloperError();
     expect(function () {
       entity.getPropertyIds();
@@ -99,54 +99,42 @@ describe("Scene/MetadataEntity", function () {
     expect(MetadataEntity.hasProperty("volume", properties)).toBe(false);
   });
 
-  it("hasPropertyBySemantic returns false when there's no properties", function () {
-    expect(MetadataEntity.hasPropertyBySemantic("NAME", {})).toBe(false);
+  it("hasSemantic returns false when there's no properties", function () {
+    expect(MetadataEntity.hasSemantic("NAME", {})).toBe(false);
   });
 
-  it("hasPropertyBySemantic returns false when there's no property with the given property ID", function () {
+  it("hasSemantic returns false when there's no property with the given property ID", function () {
     expect(
-      MetadataEntity.hasPropertyBySemantic(
-        "VOLUME",
-        properties,
-        classDefinition
-      )
+      MetadataEntity.hasSemantic("VOLUME", properties, classDefinition)
     ).toBe(false);
   });
 
-  it("hasPropertyBySemantic returns false when there's no class definition", function () {
-    expect(MetadataEntity.hasPropertyBySemantic("NAME", properties)).toBe(
-      false
-    );
-    expect(MetadataEntity.hasPropertyBySemantic("VOLUME", properties)).toBe(
-      false
-    );
+  it("hasSemantic returns false when there's no class definition", function () {
+    expect(MetadataEntity.hasSemantic("NAME", properties)).toBe(false);
+    expect(MetadataEntity.hasSemantic("VOLUME", properties)).toBe(false);
   });
 
-  it("hasPropertyBySemantic returns true when there's a property with the given property ID", function () {
+  it("hasSemantic returns true when there's a property with the given property ID", function () {
     expect(
-      MetadataEntity.hasPropertyBySemantic("NAME", properties, classDefinition)
+      MetadataEntity.hasSemantic("NAME", properties, classDefinition)
     ).toBe(true);
   });
 
-  it("hasPropertyBySemantic returns true when the class has a default value for a missing property", function () {
+  it("hasSemantic returns true when the class has a default value for a missing property", function () {
     expect(
-      MetadataEntity.hasPropertyBySemantic("NAME", properties, classDefinition)
+      MetadataEntity.hasSemantic("NAME", properties, classDefinition)
     ).toBe(true);
   });
 
-  it("hasPropertyBySemantic throws without semantic", function () {
+  it("hasSemantic throws without semantic", function () {
     expect(function () {
-      MetadataEntity.hasPropertyBySemantic(
-        undefined,
-        properties,
-        classDefinition
-      );
+      MetadataEntity.hasSemantic(undefined, properties, classDefinition);
     }).toThrowDeveloperError();
   });
 
-  it("hasPropertyBySemantic throws without properties", function () {
+  it("hasSemantic throws without properties", function () {
     expect(function () {
-      MetadataEntity.hasPropertyBySemantic("NAME", undefined, classDefinition);
+      MetadataEntity.hasSemantic("NAME", undefined, classDefinition);
     }).toThrowDeveloperError();
   });
 

--- a/Specs/Scene/MetadataTableSpec.js
+++ b/Specs/Scene/MetadataTableSpec.js
@@ -151,14 +151,14 @@ describe("Scene/MetadataTable", function () {
     }).toThrowDeveloperError();
   });
 
-  it("hasSemantic returns false when there's no properties", function () {
+  it("hasPropertyBySemantic returns false when there's no properties", function () {
     var metadataTable = new MetadataTable({
       count: 10,
     });
-    expect(metadataTable.hasSemantic("HEIGHT")).toBe(false);
+    expect(metadataTable.hasPropertyBySemantic("HEIGHT")).toBe(false);
   });
 
-  it("hasSemantic returns false when there's no property with the given semantic", function () {
+  it("hasPropertyBySemantic returns false when there's no property with the given semantic", function () {
     var properties = {
       height: {
         type: "FLOAT32",
@@ -172,10 +172,10 @@ describe("Scene/MetadataTable", function () {
       propertyValues: propertyValues,
     });
 
-    expect(metadataTable.hasSemantic("HEIGHT")).toBe(false);
+    expect(metadataTable.hasPropertyBySemantic("HEIGHT")).toBe(false);
   });
 
-  it("hasSemantic returns true when there's a property with the given semantic", function () {
+  it("hasPropertyBySemantic returns true when there's a property with the given semantic", function () {
     var properties = {
       height: {
         type: "FLOAT32",
@@ -190,10 +190,10 @@ describe("Scene/MetadataTable", function () {
       propertyValues: propertyValues,
     });
 
-    expect(metadataTable.hasSemantic("HEIGHT")).toBe(true);
+    expect(metadataTable.hasPropertyBySemantic("HEIGHT")).toBe(true);
   });
 
-  it("hasSemantic returns true when the class has a default value for a missing property", function () {
+  it("hasPropertyBySemantic returns true when the class has a default value for a missing property", function () {
     var properties = {
       height: {
         type: "FLOAT32",
@@ -214,15 +214,15 @@ describe("Scene/MetadataTable", function () {
       propertyValues: propertyValues,
     });
 
-    expect(metadataTable.hasSemantic("HEIGHT")).toBe(true);
+    expect(metadataTable.hasPropertyBySemantic("HEIGHT")).toBe(true);
   });
 
-  it("hasSemantic throws without semantic", function () {
+  it("hasPropertyBySemantic throws without semantic", function () {
     var metadataTable = new MetadataTable({
       count: 10,
     });
     expect(function () {
-      metadataTable.hasSemantic(undefined);
+      metadataTable.hasPropertyBySemantic(undefined);
     }).toThrowDeveloperError();
   });
 

--- a/Specs/Scene/MetadataTableSpec.js
+++ b/Specs/Scene/MetadataTableSpec.js
@@ -151,14 +151,14 @@ describe("Scene/MetadataTable", function () {
     }).toThrowDeveloperError();
   });
 
-  it("hasPropertyBySemantic returns false when there's no properties", function () {
+  it("hasSemantic returns false when there's no properties", function () {
     var metadataTable = new MetadataTable({
       count: 10,
     });
-    expect(metadataTable.hasPropertyBySemantic("HEIGHT")).toBe(false);
+    expect(metadataTable.hasSemantic("HEIGHT")).toBe(false);
   });
 
-  it("hasPropertyBySemantic returns false when there's no property with the given semantic", function () {
+  it("hasSemantic returns false when there's no property with the given semantic", function () {
     var properties = {
       height: {
         type: "FLOAT32",
@@ -172,10 +172,10 @@ describe("Scene/MetadataTable", function () {
       propertyValues: propertyValues,
     });
 
-    expect(metadataTable.hasPropertyBySemantic("HEIGHT")).toBe(false);
+    expect(metadataTable.hasSemantic("HEIGHT")).toBe(false);
   });
 
-  it("hasPropertyBySemantic returns true when there's a property with the given semantic", function () {
+  it("hasSemantic returns true when there's a property with the given semantic", function () {
     var properties = {
       height: {
         type: "FLOAT32",
@@ -190,10 +190,10 @@ describe("Scene/MetadataTable", function () {
       propertyValues: propertyValues,
     });
 
-    expect(metadataTable.hasPropertyBySemantic("HEIGHT")).toBe(true);
+    expect(metadataTable.hasSemantic("HEIGHT")).toBe(true);
   });
 
-  it("hasPropertyBySemantic returns true when the class has a default value for a missing property", function () {
+  it("hasSemantic returns true when the class has a default value for a missing property", function () {
     var properties = {
       height: {
         type: "FLOAT32",
@@ -214,15 +214,15 @@ describe("Scene/MetadataTable", function () {
       propertyValues: propertyValues,
     });
 
-    expect(metadataTable.hasPropertyBySemantic("HEIGHT")).toBe(true);
+    expect(metadataTable.hasSemantic("HEIGHT")).toBe(true);
   });
 
-  it("hasPropertyBySemantic throws without semantic", function () {
+  it("hasSemantic throws without semantic", function () {
     var metadataTable = new MetadataTable({
       count: 10,
     });
     expect(function () {
-      metadataTable.hasPropertyBySemantic(undefined);
+      metadataTable.hasSemantic(undefined);
     }).toThrowDeveloperError();
   });
 

--- a/Specs/Scene/MetadataTableSpec.js
+++ b/Specs/Scene/MetadataTableSpec.js
@@ -151,6 +151,81 @@ describe("Scene/MetadataTable", function () {
     }).toThrowDeveloperError();
   });
 
+  it("hasPropertyBySemantic returns false when there's no properties", function () {
+    var metadataTable = new MetadataTable({
+      count: 10,
+    });
+    expect(metadataTable.hasPropertyBySemantic("HEIGHT")).toBe(false);
+  });
+
+  it("hasPropertyBySemantic returns false when there's no property with the given semantic", function () {
+    var properties = {
+      height: {
+        type: "FLOAT32",
+      },
+    };
+    var propertyValues = {
+      height: [1.0, 2.0],
+    };
+    var metadataTable = MetadataTester.createMetadataTable({
+      properties: properties,
+      propertyValues: propertyValues,
+    });
+
+    expect(metadataTable.hasPropertyBySemantic("HEIGHT")).toBe(false);
+  });
+
+  it("hasPropertyBySemantic returns true when there's a property with the given semantic", function () {
+    var properties = {
+      height: {
+        type: "FLOAT32",
+        semantic: "HEIGHT",
+      },
+    };
+    var propertyValues = {
+      height: [1.0, 2.0],
+    };
+    var metadataTable = MetadataTester.createMetadataTable({
+      properties: properties,
+      propertyValues: propertyValues,
+    });
+
+    expect(metadataTable.hasPropertyBySemantic("HEIGHT")).toBe(true);
+  });
+
+  it("hasPropertyBySemantic returns true when the class has a default value for a missing property", function () {
+    var properties = {
+      height: {
+        type: "FLOAT32",
+        semantic: "HEIGHT",
+        default: 10.0,
+        optional: true,
+      },
+      name: {
+        type: "STRING",
+      },
+    };
+    var propertyValues = {
+      name: ["A", "B"],
+    };
+
+    var metadataTable = MetadataTester.createMetadataTable({
+      properties: properties,
+      propertyValues: propertyValues,
+    });
+
+    expect(metadataTable.hasPropertyBySemantic("HEIGHT")).toBe(true);
+  });
+
+  it("hasPropertyBySemantic throws without semantic", function () {
+    var metadataTable = new MetadataTable({
+      count: 10,
+    });
+    expect(function () {
+      metadataTable.hasPropertyBySemantic(undefined);
+    }).toThrowDeveloperError();
+  });
+
   it("getPropertyIds returns empty array when there are no properties", function () {
     var metadataTable = new MetadataTable({
       count: 10,
@@ -797,6 +872,59 @@ describe("Scene/MetadataTable", function () {
 
     expect(function () {
       metadataTable.getPropertyTypedArray(undefined);
+    }).toThrowDeveloperError();
+  });
+
+  it("getPropertyTypedArrayBySemantic returns typed array", function () {
+    var properties = {
+      height: {
+        type: "FLOAT32",
+        semantic: "HEIGHT",
+      },
+    };
+    var propertyValues = {
+      height: [1.0, 2.0],
+    };
+
+    var metadataTable = MetadataTester.createMetadataTable({
+      properties: properties,
+      propertyValues: propertyValues,
+    });
+
+    var expectedTypedArray = new Float32Array([1.0, 2.0]);
+
+    expect(metadataTable.getPropertyTypedArrayBySemantic("HEIGHT")).toEqual(
+      expectedTypedArray
+    );
+  });
+
+  it("getPropertyTypedArrayBySemantic returns undefined if semantic does not exist", function () {
+    var properties = {
+      height: {
+        type: "FLOAT32",
+      },
+    };
+    var propertyValues = {
+      height: [1.0, 2.0],
+    };
+
+    var metadataTable = MetadataTester.createMetadataTable({
+      properties: properties,
+      propertyValues: propertyValues,
+    });
+
+    expect(
+      metadataTable.getPropertyTypedArrayBySemantic("HEIGHT")
+    ).toBeUndefined();
+  });
+
+  it("getPropertyTypedArrayBySemantic throws if semantic is undefined", function () {
+    var metadataTable = new MetadataTable({
+      count: 10,
+    });
+
+    expect(function () {
+      metadataTable.getPropertyTypedArrayBySemantic(undefined);
     }).toThrowDeveloperError();
   });
 });

--- a/Specs/Scene/TileMetadataSpec.js
+++ b/Specs/Scene/TileMetadataSpec.js
@@ -92,11 +92,11 @@ describe("Scene/TileMetadata", function () {
     expect(tileMetadata.hasProperty("numberOfPoints")).toBe(false);
   });
 
-  it("hasPropertyBySemantic returns true if the tile has a property with the given semantic", function () {
-    expect(tileMetadata.hasPropertyBySemantic("COLOR")).toBe(true);
+  it("hasSemantic returns true if the tile has a property with the given semantic", function () {
+    expect(tileMetadata.hasSemantic("COLOR")).toBe(true);
   });
 
-  it("hasPropertyBySemantic returns false if the tile does not have a property with the given semantic", function () {
+  it("hasSemantic returns false if the tile does not have a property with the given semantic", function () {
     expect(tileMetadata.hasProperty("NUMBER_OF_POINTS")).toBe(false);
   });
 

--- a/Specs/Scene/TileMetadataSpec.js
+++ b/Specs/Scene/TileMetadataSpec.js
@@ -92,13 +92,21 @@ describe("Scene/TileMetadata", function () {
     expect(tileMetadata.hasProperty("numberOfPoints")).toBe(false);
   });
 
+  it("hasPropertyBySemantic returns true if the tile has a property with the given semantic", function () {
+    expect(tileMetadata.hasPropertyBySemantic("COLOR")).toBe(true);
+  });
+
+  it("hasPropertyBySemantic returns false if the tile does not have a property with the given semantic", function () {
+    expect(tileMetadata.hasProperty("NUMBER_OF_POINTS")).toBe(false);
+  });
+
   it("getPropertyIds returns array of property IDs", function () {
     var propertyIds = tileMetadata.getPropertyIds([]);
     propertyIds.sort();
     expect(propertyIds).toEqual(["color", "isSquare"]);
   });
 
-  it("getProperty returns undefined if the property does not exist", function () {
+  it("getProperty returns undefined if a property does not exist", function () {
     expect(tileMetadata.getProperty("numberOfPoints")).not.toBeDefined();
   });
 

--- a/Specs/Scene/TileMetadataSpec.js
+++ b/Specs/Scene/TileMetadataSpec.js
@@ -84,11 +84,11 @@ describe("Scene/TileMetadata", function () {
     expect(tileMetadata.extensions).toBe(extensions);
   });
 
-  it("hasProperty returns true if a property exists", function () {
+  it("hasProperty returns true if the tile has this property", function () {
     expect(tileMetadata.hasProperty("color")).toBe(true);
   });
 
-  it("hasProperty returns false if a property does not exist", function () {
+  it("hasProperty returns false if the tile does not have this property", function () {
     expect(tileMetadata.hasProperty("numberOfPoints")).toBe(false);
   });
 
@@ -98,7 +98,7 @@ describe("Scene/TileMetadata", function () {
     expect(propertyIds).toEqual(["color", "isSquare"]);
   });
 
-  it("getProperty returns undefined if a property does not exist", function () {
+  it("getProperty returns undefined if the property does not exist", function () {
     expect(tileMetadata.getProperty("numberOfPoints")).not.toBeDefined();
   });
 

--- a/Specs/Scene/TileMetadataSpec.js
+++ b/Specs/Scene/TileMetadataSpec.js
@@ -92,11 +92,11 @@ describe("Scene/TileMetadata", function () {
     expect(tileMetadata.hasProperty("numberOfPoints")).toBe(false);
   });
 
-  it("hasSemantic returns true if the tile has a property with the given semantic", function () {
-    expect(tileMetadata.hasSemantic("COLOR")).toBe(true);
+  it("hasPropertyBySemantic returns true if the tile has a property with the given semantic", function () {
+    expect(tileMetadata.hasPropertyBySemantic("COLOR")).toBe(true);
   });
 
-  it("hasSemantic returns false if the tile does not have a property with the given semantic", function () {
+  it("hasPropertyBySemantic returns false if the tile does not have a property with the given semantic", function () {
     expect(tileMetadata.hasProperty("NUMBER_OF_POINTS")).toBe(false);
   });
 

--- a/Specs/Scene/TilesetMetadataSpec.js
+++ b/Specs/Scene/TilesetMetadataSpec.js
@@ -152,6 +152,92 @@ describe("Scene/TilesetMetadata", function () {
     }).toThrowDeveloperError();
   });
 
+  it("hasPropertyBySemantic returns false when there's no properties", function () {
+    var tilesetMetadata = new TilesetMetadata({
+      tileset: {},
+    });
+    expect(tilesetMetadata.hasPropertyBySemantic("HEIGHT")).toBe(false);
+  });
+
+  it("hasPropertyBySemantic returns false when there's no property with the given semantic", function () {
+    var buildingClass = new MetadataClass({
+      id: "building",
+      class: {
+        properties: {
+          height: {
+            type: "FLOAT32",
+          },
+        },
+      },
+    });
+
+    var tilesetMetadata = new TilesetMetadata({
+      class: buildingClass,
+      tileset: {
+        properties: {
+          height: 10.0,
+        },
+      },
+    });
+    expect(tilesetMetadata.hasPropertyBySemantic("HEIGHT")).toBe(false);
+  });
+
+  it("hasPropertyBySemantic returns true when there's a property with the given semantic", function () {
+    var buildingClass = new MetadataClass({
+      id: "building",
+      class: {
+        properties: {
+          height: {
+            type: "FLOAT32",
+            semantic: "HEIGHT",
+          },
+        },
+      },
+    });
+
+    var tilesetMetadata = new TilesetMetadata({
+      class: buildingClass,
+      tileset: {
+        properties: {
+          height: 10.0,
+        },
+      },
+    });
+    expect(tilesetMetadata.hasPropertyBySemantic("HEIGHT")).toBe(true);
+  });
+
+  it("hasPropertyBySemantic returns true when the class has a default value for a missing property", function () {
+    var buildingClass = new MetadataClass({
+      id: "building",
+      class: {
+        properties: {
+          height: {
+            type: "FLOAT32",
+            semantic: "HEIGHT",
+            optional: true,
+            default: 10.0,
+          },
+        },
+      },
+    });
+    var tilesetMetadata = new TilesetMetadata({
+      class: buildingClass,
+      tileset: {},
+    });
+
+    expect(tilesetMetadata.hasPropertyBySemantic("HEIGHT")).toBe(true);
+  });
+
+  it("hasPropertyBySemantic throws without semantic", function () {
+    var tilesetMetadata = new TilesetMetadata({
+      tileset: {},
+    });
+
+    expect(function () {
+      tilesetMetadata.hasPropertyBySemantic(undefined);
+    }).toThrowDeveloperError();
+  });
+
   it("getPropertyIds returns empty array when there are no properties", function () {
     var tilesetMetadata = new TilesetMetadata({
       tileset: {},

--- a/Specs/Scene/TilesetMetadataSpec.js
+++ b/Specs/Scene/TilesetMetadataSpec.js
@@ -152,14 +152,14 @@ describe("Scene/TilesetMetadata", function () {
     }).toThrowDeveloperError();
   });
 
-  it("hasSemantic returns false when there's no properties", function () {
+  it("hasPropertyBySemantic returns false when there's no properties", function () {
     var tilesetMetadata = new TilesetMetadata({
       tileset: {},
     });
-    expect(tilesetMetadata.hasSemantic("HEIGHT")).toBe(false);
+    expect(tilesetMetadata.hasPropertyBySemantic("HEIGHT")).toBe(false);
   });
 
-  it("hasSemantic returns false when there's no property with the given semantic", function () {
+  it("hasPropertyBySemantic returns false when there's no property with the given semantic", function () {
     var buildingClass = new MetadataClass({
       id: "building",
       class: {
@@ -179,10 +179,10 @@ describe("Scene/TilesetMetadata", function () {
         },
       },
     });
-    expect(tilesetMetadata.hasSemantic("HEIGHT")).toBe(false);
+    expect(tilesetMetadata.hasPropertyBySemantic("HEIGHT")).toBe(false);
   });
 
-  it("hasSemantic returns true when there's a property with the given semantic", function () {
+  it("hasPropertyBySemantic returns true when there's a property with the given semantic", function () {
     var buildingClass = new MetadataClass({
       id: "building",
       class: {
@@ -203,10 +203,10 @@ describe("Scene/TilesetMetadata", function () {
         },
       },
     });
-    expect(tilesetMetadata.hasSemantic("HEIGHT")).toBe(true);
+    expect(tilesetMetadata.hasPropertyBySemantic("HEIGHT")).toBe(true);
   });
 
-  it("hasSemantic returns true when the class has a default value for a missing property", function () {
+  it("hasPropertyBySemantic returns true when the class has a default value for a missing property", function () {
     var buildingClass = new MetadataClass({
       id: "building",
       class: {
@@ -225,16 +225,16 @@ describe("Scene/TilesetMetadata", function () {
       tileset: {},
     });
 
-    expect(tilesetMetadata.hasSemantic("HEIGHT")).toBe(true);
+    expect(tilesetMetadata.hasPropertyBySemantic("HEIGHT")).toBe(true);
   });
 
-  it("hasSemantic throws without semantic", function () {
+  it("hasPropertyBySemantic throws without semantic", function () {
     var tilesetMetadata = new TilesetMetadata({
       tileset: {},
     });
 
     expect(function () {
-      tilesetMetadata.hasSemantic(undefined);
+      tilesetMetadata.hasPropertyBySemantic(undefined);
     }).toThrowDeveloperError();
   });
 

--- a/Specs/Scene/TilesetMetadataSpec.js
+++ b/Specs/Scene/TilesetMetadataSpec.js
@@ -152,14 +152,14 @@ describe("Scene/TilesetMetadata", function () {
     }).toThrowDeveloperError();
   });
 
-  it("hasPropertyBySemantic returns false when there's no properties", function () {
+  it("hasSemantic returns false when there's no properties", function () {
     var tilesetMetadata = new TilesetMetadata({
       tileset: {},
     });
-    expect(tilesetMetadata.hasPropertyBySemantic("HEIGHT")).toBe(false);
+    expect(tilesetMetadata.hasSemantic("HEIGHT")).toBe(false);
   });
 
-  it("hasPropertyBySemantic returns false when there's no property with the given semantic", function () {
+  it("hasSemantic returns false when there's no property with the given semantic", function () {
     var buildingClass = new MetadataClass({
       id: "building",
       class: {
@@ -179,10 +179,10 @@ describe("Scene/TilesetMetadata", function () {
         },
       },
     });
-    expect(tilesetMetadata.hasPropertyBySemantic("HEIGHT")).toBe(false);
+    expect(tilesetMetadata.hasSemantic("HEIGHT")).toBe(false);
   });
 
-  it("hasPropertyBySemantic returns true when there's a property with the given semantic", function () {
+  it("hasSemantic returns true when there's a property with the given semantic", function () {
     var buildingClass = new MetadataClass({
       id: "building",
       class: {
@@ -203,10 +203,10 @@ describe("Scene/TilesetMetadata", function () {
         },
       },
     });
-    expect(tilesetMetadata.hasPropertyBySemantic("HEIGHT")).toBe(true);
+    expect(tilesetMetadata.hasSemantic("HEIGHT")).toBe(true);
   });
 
-  it("hasPropertyBySemantic returns true when the class has a default value for a missing property", function () {
+  it("hasSemantic returns true when the class has a default value for a missing property", function () {
     var buildingClass = new MetadataClass({
       id: "building",
       class: {
@@ -225,16 +225,16 @@ describe("Scene/TilesetMetadata", function () {
       tileset: {},
     });
 
-    expect(tilesetMetadata.hasPropertyBySemantic("HEIGHT")).toBe(true);
+    expect(tilesetMetadata.hasSemantic("HEIGHT")).toBe(true);
   });
 
-  it("hasPropertyBySemantic throws without semantic", function () {
+  it("hasSemantic throws without semantic", function () {
     var tilesetMetadata = new TilesetMetadata({
       tileset: {},
     });
 
     expect(function () {
-      tilesetMetadata.hasPropertyBySemantic(undefined);
+      tilesetMetadata.hasSemantic(undefined);
     }).toThrowDeveloperError();
   });
 


### PR DESCRIPTION
This PR is extracting out some code from the [`model-loading`](https://github.com/CesiumGS/cesium/tree/model-loading) branch. Adds new functions to `FeatureTable`:

* `propertyExists` - whether *any* feature in the table has the property. This is mainly useful for checking whether a property exists in the class hierarchy when using the `3DTILES_batch_table_hierarchy` extension. This is used to see what variables in a shader are property IDs.
* `propertyExistsBySemantic` - like `propertyExists` but uses a semantic instead of a property ID
* `hasPropertyBySemantic` - like `hasProperty` but uses a semantic instead of a property ID
* `getPropertyTypedArrayBySemantic` - like `getPropertyTypedArray` but uses a semantic instead of a property ID