### PR TITLE
Set positionToEyeEC and tangentToEyeMatrix for globe material

### DIFF
--- a/Source/Shaders/GlobeFS.glsl
+++ b/Source/Shaders/GlobeFS.glsl
@@ -381,6 +381,8 @@ void main()
     czm_materialInput materialInput;
     materialInput.st = v_textureCoordinates.st;
     materialInput.normalEC = normalize(v_normalEC);
+    materialInput.positionToEyeEC = -v_positionEC;
+    materialInput.tangentToEyeMatrix = czm_eastNorthUpToEyeCoordinates(v_positionMC, normalize(v_normalEC));     
     materialInput.slope = v_slope;
     materialInput.height = v_height;
     materialInput.aspect = v_aspect;


### PR DESCRIPTION
As discussed here https://github.com/CesiumGS/cesium/issues/9557
positionToEyeEC and tangentToEyeMatrix were missing from Globe materialInput