### PR TITLE
Optimizes S2 position calculations and distanceToCamera check

### DIFF
--- a/Source/Core/S2Cell.js
+++ b/Source/Core/S2Cell.js
@@ -379,7 +379,7 @@ S2Cell.prototype.getParentAtLevel = function (level) {
 S2Cell.prototype.getCenter = function (ellipsoid) {
   ellipsoid = defaultValue(ellipsoid, Ellipsoid.WGS84);
 
-  var center = getS2Center(this._cellId);
+  var center = getS2Center(this._cellId, this._level);
   // Normalize XYZ.
   center = Cartesian3.normalize(center, center);
   var cartographic = new Cartographic.fromCartesian(
@@ -408,7 +408,7 @@ S2Cell.prototype.getVertex = function (index, ellipsoid) {
 
   ellipsoid = defaultValue(ellipsoid, Ellipsoid.WGS84);
 
-  var vertex = getS2Vertex(this._cellId, index);
+  var vertex = getS2Vertex(this._cellId, this._level, index);
   // Normalize XYZ.
   vertex = Cartesian3.normalize(vertex, vertex);
   var cartographic = new Cartographic.fromCartesian(
@@ -422,19 +422,16 @@ S2Cell.prototype.getVertex = function (index, ellipsoid) {
 /**
  * @private
  */
-function getS2Center(cellId) {
-  var faceSiTi = convertCellIdToFaceSiTi(cellId);
+function getS2Center(cellId, level) {
+  var faceSiTi = convertCellIdToFaceSiTi(cellId, level);
   return convertFaceSiTitoXYZ(faceSiTi[0], faceSiTi[1], faceSiTi[2]);
 }
 /**
  * @private
  */
-function getS2Vertex(cellId, index) {
-  var faceIJ = convertCellIdToFaceIJ(cellId);
-  var uv = convertIJLeveltoBoundUV(
-    [faceIJ[1], faceIJ[2]],
-    S2Cell.getLevel(cellId)
-  );
+function getS2Vertex(cellId, level, index) {
+  var faceIJ = convertCellIdToFaceIJ(cellId, level);
+  var uv = convertIJLeveltoBoundUV([faceIJ[1], faceIJ[2]], level);
   // Handles CCW ordering of the vertices.
   var y = (index >> 1) & 1;
   return convertFaceUVtoXYZ(faceIJ[0], uv[0][y ^ (index & 1)], uv[1][y]);
@@ -445,7 +442,7 @@ function getS2Vertex(cellId, index) {
 /**
  * @private
  */
-function convertCellIdToFaceSiTi(cellId) {
+function convertCellIdToFaceSiTi(cellId, level) {
   var faceIJ = convertCellIdToFaceIJ(cellId);
   var face = faceIJ[0];
   var i = faceIJ[1];
@@ -455,7 +452,7 @@ function convertCellIdToFaceSiTi(cellId) {
   // (remember that this space has 31 levels - which allows us to pick center and edges of the leaf cells). For non leaf cells,
   // we get one of either two cells diagonal to the cell center. The correction is used to make sure we pick the leaf cell edges
   // that represent the parent cell center.
-  var isLeaf = S2Cell.getLevel(cellId) === 30;
+  var isLeaf = level === 30;
   var shouldCorrect =
     !isLeaf && (BigInt(i) ^ (cellId >> BigInt(2))) & BigInt(1); // eslint-disable-line
   var correction = isLeaf ? 1 : shouldCorrect ? 2 : 0;


### PR DESCRIPTION
This PR adds some optimizations for the S2 implementation in CesiumJS.

1. Avoid redundant re-computation of the `level` in `S2Cell.getCenter()` and `S2Cell.getVertex()`.
2. Pre-computes the vertices per-plane in the `TileBoundingS2Cell` so we don't have to re-allocate arrays in the `distanceToCamera` function.

Here are the results from a benchmark that calculates how much faster is the `distanceToCamera` check in  `OrientedBoundingBox` versus the kDOP in `TileBoundingS2Cell`:

| Run # 	| [`master`](http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesium/feature-id-texture-mvp/Build/Apps/Sandcastle/index.html#c=3VZtbxo5EP4rFl+y22xMQlupIjS6Qrjrh6SpoJeoykYns2sWq14b2V4CqfLfO7bXQDgSaKVKp0OI9csz45nnGc+SSaENmjF6TxV6jwS9Rz2qWVXia7cWpY3MzXtSGMIEVWkjPk1F5uwyUlJFPkvNDIMFcHB799xmjygjC0WmE5YFYCrGlcjsNioo+CaGDojIZbm0ikSCSjKHHwYjRXXFTQKuV750jL6nAqEZUYid2tFYKhQxOOP4FDHUQQIeh4c1zAPnQ1YIQFwSM8HKHRnF6AxM8NvTFWyxH+xhN8xHfsvunpJsSYEREa8jj0N1aK82nL1CEdCAjiwPMTp0dASLxU9bPPykRVxn8YR3n8xaImEHj5Usl5lFy9S9l8dUPFrlnxP85Nh9EtSCgGrvfc7ZVEuW45u/hu/eYAiTlVU5IDmrdLInaqMek5cKNHbFmQqrrm51r5+q9oVx2pWVyJkohq0e5TxytWXkNyraKG2cpA3HHDBoI/hIWTExbXTsF31YYdHnC6T4M/1VxDoDevBUsRKCm1GNSZ5HNhKcKQqsndNRVVxLXpU0ChJILhUe9M/j2hPELkejlUZXilFhaB5C78q5k+qzZMJo7/2fGVWGwZW3PmoP29Lf4stVMMBxZndUEqYTwscf5lSnYneG7rRdKXYv/u6v5ahoZlZJDmBGRMHp0yr8oBRZbKSINYdH9CZB7+KQrqIF1MJLgg8cwguuwmFtN9xb89bb/UUPEe1i5Wv/4uLqZo0Xls/dmFMDNawNUAFZTamC/lgSkVEs5H1k8b5h5vO6ZcKgs3k5MKeiMBO3u+yljs6cgWvw9kX2nEn0PfQKO2uHrovQtPZ102ujTfe34PYu2USu38j2S9fVmXvrx9pLKXNQpWZoaIm9hBU87PU/9V+fu0ZkU38M/FCRP8NOQFxSYpt85LFHgdMYNZ8jy78JJdQil0V0MGyh6LxmK4Y2kRr4HkCj9b6xkX+yOc2hA8ah/9iT4U4Mf4N4/qr9knr/MfEgk/4O9QAS5KvRR0te9xfwqtvdVNDKVztf1w9WDxLYRnY/8vo2a1y8BLYcbn6witNf9t8h97KN/B8U98nsEt2jgu4rm6N1mvdX3zf+bQWwOmhnDayg28qgkTQ62iw4PQvc/sHKqYRiqBSPMG4aWk45vAV0c1Rl36jBmdbhz1mnuW7aydkMCuD9lv/vKONEa9gZV5wP2QNNG2edJuD/Zcolsa+8K3hjcrKwsMnJ2YVfxBh3mjDdbmmk5COiNjz/AA)	| [`s2-optimize` ](http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesium/s2-optimize/Build/Apps/Sandcastle/index.html#c=3VZhbxo5EP0rFl/YbTYmoa1UERpdIejuQ3KpoE10ykYns2sWq14b2V4CqfLfb2yvgVAS6EmVTheh4LXfPM+8Z8+SSaENmjP6QBX6iAR9QH2qWVXiGzcXpY3MPfelMIQJqtJGfJaKzMVlpKSKfJaaGQYTQHB3/9JinygjC0VmU5YFYComlcjsMioocBNDh0TkslxFRSJBJVnAPwYjRXXFTQLUay4do++pQGhOFGJndjSRCkUM9jg5Qwx1kYCvo6Ma5oGLESsEIK6ImWLltoxidA4h+P3ZGrY8DPa4H+Yzv2P3z0W2osCIiLeRx6E6tTdbZG9QBDKgY6tDjI6cHCFi+dMRjz8ZEddVPNPdF7NRSFjBEyXLVWXRqnTP8pSKJ+v8S4afnri/BLUhoZp9wDmbaclyfPv76MM7DGmysiqHJGeVTg5EbZ3H5LUDGrvDmQrrrm73bp679oVx2pOVyJkoRu0+5TxyZ8vIb1R0UNo4TRtOOVDQZvAHZcXUdNCJn/RphUlfL4ji9/RXEesM5MEzxUpIbk41Jnke2UxwpiiodkHHVXEjeVXSKFgguVR4OLiIaybIXY7Ha4+uFaPC0Dyk3pMLZ9VnyYTRnv3vOVWGwZW3HDXDrvJ3cLkTDHCc2RWVhMcp4ZNPC6pTsb9Ct9u+EnuXXwcbNSqamXWRQ3giouD0+Sn8pBRZbpWINYev6F2CPsShXEULOAuvGT50CG+4Cpt13PBgz9vvDzc9ZLRPlb8Gl5fXtxu6sHzhxpwaOMPagBRQ1Ywq6I8lERnFQj5EFu8bZr6oWyYMutuXA3MqCjN1q6te6uTMGVAD2xfZdyHR99Ar7FMndF2EZjXXbb+DtunvgPY+2UZu3sjOa9fVhfvop5qllDm4Uis0ssJewQwe9Qd/Dt5euEZkS38K+lCRv6BOQFxRYpt85LHHQdMYtV4Sy78JJZxFLouoOWqj6KJWK4Y2kRr4NKHReu7Qc+xucA9Gv8Awf73+lWP/McOgksEexwASLKvRxytdDzftutfbds1aFsiPUDOBKWTnIu9jq16zr9DmorlOyN/kX+Hrqkf8H6z1xexz16OCweuY402ZD7fZd/VdTm9stMvs9fLK70bS6Gqz5PQ8iPgbK2cSXK8UjzBuGVrOOPRy3RpX2TdqcKZ1+InVbW2GdnM2B6c/7vgVjjJOtIaVScX5iD3StHHebQH+h1AuiX1xXcN7j5OlhU1Pzy/9JMa424LH3ZFGSj4maov5Hw)	|
|-------	|----------	|---------------	|
| 1     	| 3.52x    	| 2.24x         	|
| 2     	| 3.24x    	| 2.49x         	|
| 3     	| 3.62x    	| 2.09x         	|
| 4     	| 3.39x    	| 2.37x         	|
| 5     	| 3.56x    	| 2.46x         	|