### PR TITLE
Updated the `outlineWidth` documentation for various classes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 - Added `options.fadingEnabled` parameter to `ShadowMap` to control whether shadows fade out when the light source is close to the horizon. [#9565](https://github.com/CesiumGS/cesium/pull/9565)
 - Added checks for supported 3D Tiles extensions. [#9552](https://github.com/CesiumGS/cesium/issues/9552)
+- Added documentation clarifying that the `outlineWidth` property will be ignored on all major
+  browsers on Windows platforms. [#9600](https://github.com/CesiumGS/cesium/pull/9600)
 
 ##### Fixes :wrench:
 

--- a/Source/DataSources/BoxGraphics.js
+++ b/Source/DataSources/BoxGraphics.js
@@ -128,7 +128,7 @@ Object.defineProperties(BoxGraphics.prototype, {
   outlineColor: createPropertyDescriptor("outlineColor"),
 
   /**
-   * Gets or sets the numeric Property specifying the width of the outline.
+   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms. For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
    * @memberof BoxGraphics.prototype
    * @type {Property|undefined}
    * @default 1.0

--- a/Source/DataSources/BoxGraphics.js
+++ b/Source/DataSources/BoxGraphics.js
@@ -128,7 +128,10 @@ Object.defineProperties(BoxGraphics.prototype, {
   outlineColor: createPropertyDescriptor("outlineColor"),
 
   /**
-   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms. For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
+   * Gets or sets the numeric Property specifying the width of the outline.
+   * <p>
+   * Note: This property will be ignored on all major browsers on Windows platforms. For details, see (@link https://github.com/CesiumGS/cesium/issues/40}.
+   * </p>
    * @memberof BoxGraphics.prototype
    * @type {Property|undefined}
    * @default 1.0

--- a/Source/DataSources/CorridorGraphics.js
+++ b/Source/DataSources/CorridorGraphics.js
@@ -114,7 +114,7 @@ Object.defineProperties(CorridorGraphics.prototype, {
   positions: createPropertyDescriptor("positions"),
 
   /**
-   * Gets or sets the numeric Property specifying the width of the corridor.
+   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms. For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
    * @memberof CorridorGraphics.prototype
    * @type {Property|undefined}
    */

--- a/Source/DataSources/CorridorGraphics.js
+++ b/Source/DataSources/CorridorGraphics.js
@@ -114,7 +114,7 @@ Object.defineProperties(CorridorGraphics.prototype, {
   positions: createPropertyDescriptor("positions"),
 
   /**
-   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms. For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
+   * Gets or sets the numeric Property specifying the width of the outline.
    * @memberof CorridorGraphics.prototype
    * @type {Property|undefined}
    */
@@ -202,7 +202,7 @@ Object.defineProperties(CorridorGraphics.prototype, {
   outlineColor: createPropertyDescriptor("outlineColor"),
 
   /**
-   * Gets or sets the numeric Property specifying the width of the outline.
+   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms. For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
    * @memberof CorridorGraphics.prototype
    * @type {Property|undefined}
    * @default 1.0

--- a/Source/DataSources/CorridorGraphics.js
+++ b/Source/DataSources/CorridorGraphics.js
@@ -202,7 +202,10 @@ Object.defineProperties(CorridorGraphics.prototype, {
   outlineColor: createPropertyDescriptor("outlineColor"),
 
   /**
-   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms. For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
+   * Gets or sets the numeric Property specifying the width of the outline.
+   * <p>
+   * Note: This property will be ignored on all major browsers on Windows platforms. For details, see (@link https://github.com/CesiumGS/cesium/issues/40}.
+   * </p>
    * @memberof CorridorGraphics.prototype
    * @type {Property|undefined}
    * @default 1.0

--- a/Source/DataSources/CylinderGraphics.js
+++ b/Source/DataSources/CylinderGraphics.js
@@ -153,7 +153,7 @@ Object.defineProperties(CylinderGraphics.prototype, {
   outlineColor: createPropertyDescriptor("outlineColor"),
 
   /**
-   * Gets or sets the numeric Property specifying the width of the outline.
+   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms. For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
    * @memberof CylinderGraphics.prototype
    * @type {Property|undefined}
    * @default 1.0

--- a/Source/DataSources/CylinderGraphics.js
+++ b/Source/DataSources/CylinderGraphics.js
@@ -153,7 +153,10 @@ Object.defineProperties(CylinderGraphics.prototype, {
   outlineColor: createPropertyDescriptor("outlineColor"),
 
   /**
-   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms. For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
+   * Gets or sets the numeric Property specifying the width of the outline.
+   * <p>
+   * Note: This property will be ignored on all major browsers on Windows platforms. For details, see (@link https://github.com/CesiumGS/cesium/issues/40}.
+   * </p>
    * @memberof CylinderGraphics.prototype
    * @type {Property|undefined}
    * @default 1.0

--- a/Source/DataSources/EllipseGraphics.js
+++ b/Source/DataSources/EllipseGraphics.js
@@ -216,7 +216,7 @@ Object.defineProperties(EllipseGraphics.prototype, {
   outlineColor: createPropertyDescriptor("outlineColor"),
 
   /**
-   * Gets or sets the numeric Property specifying the width of the outline.
+   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms. For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
    * @memberof EllipseGraphics.prototype
    * @type {Property|undefined}
    * @default 1.0

--- a/Source/DataSources/EllipseGraphics.js
+++ b/Source/DataSources/EllipseGraphics.js
@@ -216,7 +216,10 @@ Object.defineProperties(EllipseGraphics.prototype, {
   outlineColor: createPropertyDescriptor("outlineColor"),
 
   /**
-   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms. For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
+   * Gets or sets the numeric Property specifying the width of the outline.
+   * <p>
+   * Note: This property will be ignored on all major browsers on Windows platforms. For details, see (@link https://github.com/CesiumGS/cesium/issues/40}.
+   * </p>
    * @memberof EllipseGraphics.prototype
    * @type {Property|undefined}
    * @default 1.0

--- a/Source/DataSources/EllipsoidGraphics.js
+++ b/Source/DataSources/EllipsoidGraphics.js
@@ -192,7 +192,10 @@ Object.defineProperties(EllipsoidGraphics.prototype, {
   outlineColor: createPropertyDescriptor("outlineColor"),
 
   /**
-   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms. For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
+   * Gets or sets the numeric Property specifying the width of the outline.
+   * <p>
+   * Note: This property will be ignored on all major browsers on Windows platforms. For details, see (@link https://github.com/CesiumGS/cesium/issues/40}.
+   * </p>
    * @memberof EllipsoidGraphics.prototype
    * @type {Property|undefined}
    * @default 1.0

--- a/Source/DataSources/EllipsoidGraphics.js
+++ b/Source/DataSources/EllipsoidGraphics.js
@@ -192,7 +192,7 @@ Object.defineProperties(EllipsoidGraphics.prototype, {
   outlineColor: createPropertyDescriptor("outlineColor"),
 
   /**
-   * Gets or sets the numeric Property specifying the width of the outline.
+   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms. For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
    * @memberof EllipsoidGraphics.prototype
    * @type {Property|undefined}
    * @default 1.0

--- a/Source/DataSources/PlaneGraphics.js
+++ b/Source/DataSources/PlaneGraphics.js
@@ -128,7 +128,10 @@ Object.defineProperties(PlaneGraphics.prototype, {
   outlineColor: createPropertyDescriptor("outlineColor"),
 
   /**
-   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms. For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
+   * Gets or sets the numeric Property specifying the width of the outline.
+   * <p>
+   * Note: This property will be ignored on all major browsers on Windows platforms. For details, see (@link https://github.com/CesiumGS/cesium/issues/40}.
+   * </p>
    * @memberof PlaneGraphics.prototype
    * @type {Property|undefined}
    * @default 1.0

--- a/Source/DataSources/PlaneGraphics.js
+++ b/Source/DataSources/PlaneGraphics.js
@@ -128,7 +128,7 @@ Object.defineProperties(PlaneGraphics.prototype, {
   outlineColor: createPropertyDescriptor("outlineColor"),
 
   /**
-   * Gets or sets the numeric Property specifying the width of the outline.
+   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms. For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
    * @memberof PlaneGraphics.prototype
    * @type {Property|undefined}
    * @default 1.0

--- a/Source/DataSources/PolygonGraphics.js
+++ b/Source/DataSources/PolygonGraphics.js
@@ -219,7 +219,10 @@ Object.defineProperties(PolygonGraphics.prototype, {
   outlineColor: createPropertyDescriptor("outlineColor"),
 
   /**
-   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms. For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
+   * Gets or sets the numeric Property specifying the width of the outline.
+   * <p>
+   * Note: This property will be ignored on all major browsers on Windows platforms. For details, see (@link https://github.com/CesiumGS/cesium/issues/40}.
+   * </p>
    * @memberof PolygonGraphics.prototype
    * @type {Property|undefined}
    * @default 1.0

--- a/Source/DataSources/PolygonGraphics.js
+++ b/Source/DataSources/PolygonGraphics.js
@@ -219,7 +219,7 @@ Object.defineProperties(PolygonGraphics.prototype, {
   outlineColor: createPropertyDescriptor("outlineColor"),
 
   /**
-   * Gets or sets the numeric Property specifying the width of the outline.
+   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms. For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
    * @memberof PolygonGraphics.prototype
    * @type {Property|undefined}
    * @default 1.0

--- a/Source/DataSources/PolylineVolumeGraphics.js
+++ b/Source/DataSources/PolylineVolumeGraphics.js
@@ -151,7 +151,7 @@ Object.defineProperties(PolylineVolumeGraphics.prototype, {
   outlineColor: createPropertyDescriptor("outlineColor"),
 
   /**
-   * Gets or sets the numeric Property specifying the width of the outline.
+   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms. For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
    * @memberof PolylineVolumeGraphics.prototype
    * @type {Property|undefined}
    * @default 1.0

--- a/Source/DataSources/PolylineVolumeGraphics.js
+++ b/Source/DataSources/PolylineVolumeGraphics.js
@@ -151,7 +151,10 @@ Object.defineProperties(PolylineVolumeGraphics.prototype, {
   outlineColor: createPropertyDescriptor("outlineColor"),
 
   /**
-   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms.  For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
+   * Gets or sets the numeric Property specifying the width of the outline.
+   * <p>
+   * Note: This property will be ignored on all major browsers on Windows platforms. For details, see (@link https://github.com/CesiumGS/cesium/issues/40}.
+   * </p>
    * @memberof PolylineVolumeGraphics.prototype
    * @type {Property|undefined}
    * @default 1.0

--- a/Source/DataSources/PolylineVolumeGraphics.js
+++ b/Source/DataSources/PolylineVolumeGraphics.js
@@ -151,7 +151,7 @@ Object.defineProperties(PolylineVolumeGraphics.prototype, {
   outlineColor: createPropertyDescriptor("outlineColor"),
 
   /**
-   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms. For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
+   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms.  For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
    * @memberof PolylineVolumeGraphics.prototype
    * @type {Property|undefined}
    * @default 1.0

--- a/Source/DataSources/RectangleGraphics.js
+++ b/Source/DataSources/RectangleGraphics.js
@@ -203,7 +203,10 @@ Object.defineProperties(RectangleGraphics.prototype, {
   outlineColor: createPropertyDescriptor("outlineColor"),
 
   /**
-   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms. For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
+   * Gets or sets the numeric Property specifying the width of the outline.
+   * <p>
+   * Note: This property will be ignored on all major browsers on Windows platforms. For details, see (@link https://github.com/CesiumGS/cesium/issues/40}.
+   * </p>
    * @memberof RectangleGraphics.prototype
    * @type {Property|undefined}
    * @default 1.0

--- a/Source/DataSources/RectangleGraphics.js
+++ b/Source/DataSources/RectangleGraphics.js
@@ -203,7 +203,7 @@ Object.defineProperties(RectangleGraphics.prototype, {
   outlineColor: createPropertyDescriptor("outlineColor"),
 
   /**
-   * Gets or sets the numeric Property specifying the width of the outline.
+   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms. For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
    * @memberof RectangleGraphics.prototype
    * @type {Property|undefined}
    * @default 1.0

--- a/Source/DataSources/WallGraphics.js
+++ b/Source/DataSources/WallGraphics.js
@@ -152,7 +152,7 @@ Object.defineProperties(WallGraphics.prototype, {
   outlineColor: createPropertyDescriptor("outlineColor"),
 
   /**
-   * Gets or sets the numeric Property specifying the width of the outline.
+   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms. For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
    * @memberof WallGraphics.prototype
    * @type {Property|undefined}
    * @default 1.0

--- a/Source/DataSources/WallGraphics.js
+++ b/Source/DataSources/WallGraphics.js
@@ -152,7 +152,10 @@ Object.defineProperties(WallGraphics.prototype, {
   outlineColor: createPropertyDescriptor("outlineColor"),
 
   /**
-   * Gets or sets the numeric Property specifying the width of the outline. Please note that this property will be ignored on all major browsers that are running on Windows platforms. For technical details, see this {@link https://github.com/CesiumGS/cesium/issues/40|issue} or this {@link https://stackoverflow.com/questions/25394677/how-do-you-change-the-width-on-an-ellipseoutlinegeometry-in-cesium-map/25405483#25405483|Stack Overflow post}.
+   * Gets or sets the numeric Property specifying the width of the outline.
+   * <p>
+   * Note: This property will be ignored on all major browsers on Windows platforms. For details, see (@link https://github.com/CesiumGS/cesium/issues/40}.
+   * </p>
    * @memberof WallGraphics.prototype
    * @type {Property|undefined}
    * @default 1.0


### PR DESCRIPTION

Fixes #8577

Updated the `outlineWidth` member documentation for the following classes:
- `BoxGraphics`
- `CorridorGraphics`
- `CylinderGraphics`
- `EllipseGraphics`
- `EllipsoidGraphics`
- `PlaneGraphics`
- `PolygonGraphics`
- `RectangleGraphics`
- `WallGraphics`
- `PolylineVolumeGraphics`

The updated documentation clarifies how `outlineWidth` can be used. It also provides the community with technical resources that are related to `outlineWidth`.

@shehzan10 
@ebogo1 

