### PR TITLE
Fixes S2 bounding volumes

### DIFF
--- a/Source/Core/HilbertOrder.js
+++ b/Source/Core/HilbertOrder.js
@@ -38,12 +38,14 @@ HilbertOrder.encode2D = function (level, x, y) {
   var rx,
     ry,
     s,
-    index = 0;
+    // eslint-disable-next-line no-undef
+    index = BigInt(0);
 
   for (s = n / 2; s > 0; s /= 2) {
     rx = (p.x & s) > 0 ? 1 : 0;
     ry = (p.y & s) > 0 ? 1 : 0;
-    index += ((3 * rx) ^ ry) * s * s;
+    // eslint-disable-next-line no-undef
+    index += BigInt(((3 * rx) ^ ry) * s * s);
     rotate(n, p, rx, ry);
   }
 
@@ -54,18 +56,19 @@ HilbertOrder.encode2D = function (level, x, y) {
  * Computes the 2D coordinates from the Hilbert index at the given level.
  *
  * @param {Number} level The level of the curve
- * @param {Number} index The Hilbert index
+ * @param {BigInt} index The Hilbert index
  * @returns {Number[]} An array containing the 2D coordinates ([x, y]) corresponding to the Morton index.
  * @private
  */
 HilbertOrder.decode2D = function (level, index) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.number("level", level);
-  Check.typeOf.number("index", index);
+  Check.typeOf.bigint("index", index);
   if (level < 1) {
     throw new DeveloperError("Hilbert level cannot be less than 1.");
   }
-  if (index < 0 || index >= Math.pow(4, level)) {
+  // eslint-disable-next-line no-undef
+  if (index < BigInt(0) || index >= BigInt(Math.pow(4, level))) {
     throw new DeveloperError(
       "Hilbert index exceeds valid maximum for given level."
     );
@@ -80,12 +83,15 @@ HilbertOrder.decode2D = function (level, index) {
   var rx, ry, s, t;
 
   for (s = 1, t = index; s < n; s *= 2) {
-    rx = 1 & (t / 2);
-    ry = 1 & (t ^ rx);
+    // eslint-disable-next-line no-undef
+    rx = 1 & Number(t / BigInt(2));
+    // eslint-disable-next-line no-undef
+    ry = 1 & Number(t ^ BigInt(rx));
     rotate(s, p, rx, ry);
     p.x += s * rx;
     p.y += s * ry;
-    t /= 4;
+    // eslint-disable-next-line no-undef
+    t /= BigInt(4);
   }
 
   return [p.x, p.y];

--- a/Source/Core/S2Cell.js
+++ b/Source/Core/S2Cell.js
@@ -420,6 +420,50 @@ S2Cell.prototype.getVertex = function (index, ellipsoid) {
 };
 
 /**
+ * Creates an S2Cell from its face, position along the Hilbert curve for a given level.
+ *
+ * @param {Number} face The root face of S2 this cell is on. Must be in the range [0-5].
+ * @param {BigInt} position The position along the Hilbert curve. Must be in the range [0-4**level).
+ * @param {Number} face The level of the S2 curve. Must be in the range [0-30].
+ * @returns {S2Cell} A new S2Cell from the given parameters.
+ * @private
+ */
+S2Cell.fromFacePosLevel = function (face, position, level) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.bigint("pos", position);
+  if (face < 0 || face > 5) {
+    throw new DeveloperError("Invalid S2 Face (must be within 0-5)");
+  }
+
+  if (level < 0 || level > S2_MAX_LEVEL) {
+    throw new DeveloperError("Invalid level (must be within 0-30)");
+  }
+  if (position < 0 || position >= Math.pow(4, level)) {
+    throw new DeveloperError("Invalid Hilbert position for level");
+  }
+  //>>includeEnd('debug');
+
+  var faceBitString =
+    (face < 4 ? "0" : "") + (face < 2 ? "0" : "") + face.toString(2);
+  var positionBitString = position.toString(2);
+  var positionPrefixPadding = Array(
+    2 * level - positionBitString.length + 1
+  ).join("0");
+  var positionSuffixPadding = Array(S2_POSITION_BITS - 2 * level).join("0");
+
+  // eslint-disable-next-line
+  var cellId = BigInt(
+    "0b" +
+      faceBitString +
+      positionPrefixPadding +
+      positionBitString +
+      "1" +
+      positionSuffixPadding
+  );
+  return new S2Cell(cellId);
+};
+
+/**
  * @private
  */
 function getS2Center(cellId, level) {

--- a/Source/Core/S2Cell.js
+++ b/Source/Core/S2Cell.js
@@ -457,7 +457,7 @@ S2Cell.fromFacePositionLevel = function (face, position, level) {
       faceBitString +
       positionPrefixPadding +
       positionBitString +
-      "1" +
+      "1" + // Adding the sentinel bit that always follows the position bits.
       positionSuffixPadding
   );
   return new S2Cell(cellId);

--- a/Source/Core/S2Cell.js
+++ b/Source/Core/S2Cell.js
@@ -424,13 +424,13 @@ S2Cell.prototype.getVertex = function (index, ellipsoid) {
  *
  * @param {Number} face The root face of S2 this cell is on. Must be in the range [0-5].
  * @param {BigInt} position The position along the Hilbert curve. Must be in the range [0-4**level).
- * @param {Number} face The level of the S2 curve. Must be in the range [0-30].
+ * @param {Number} level The level of the S2 curve. Must be in the range [0-30].
  * @returns {S2Cell} A new S2Cell from the given parameters.
  * @private
  */
-S2Cell.fromFacePosLevel = function (face, position, level) {
+S2Cell.fromFacePositionLevel = function (face, position, level) {
   //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.bigint("pos", position);
+  Check.typeOf.bigint("position", position);
   if (face < 0 || face > 5) {
     throw new DeveloperError("Invalid S2 Face (must be within 0-5)");
   }

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -2252,7 +2252,7 @@ function computeTileLabelPosition(tile) {
   return position;
 }
 
-function addTileDebugLabel(tile, tileset, position, frameState) {
+function addTileDebugLabel(tile, tileset, position) {
   var labelString = "";
   var attributes = 0;
 
@@ -2307,14 +2307,7 @@ function addTileDebugLabel(tile, tileset, position, frameState) {
   }
 
   var newLabel = {
-    text:
-      labelString +
-      "\nDistance: " +
-      tile.boundingVolume.distanceToCamera(frameState) +
-      "\nClosest Point is on: " +
-      tile.boundingVolume._debugText +
-      "\nToken: " +
-      tile.boundingVolume._token,
+    text: labelString.substring(1),
     position: position,
     font: 19 - attributes + "px sans-serif",
     showBackground: true,
@@ -2338,33 +2331,18 @@ function updateTileDebugLabels(tileset, frameState) {
       var position = defined(tileset.debugPickPosition)
         ? tileset.debugPickPosition
         : computeTileLabelPosition(tileset.debugPickedTile);
-      var label = addTileDebugLabel(
-        tileset.debugPickedTile,
-        tileset,
-        position,
-        frameState
-      );
+      var label = addTileDebugLabel(tileset.debugPickedTile, tileset, position);
       label.pixelOffset = new Cartesian2(15, -15); // Offset to avoid picking the label.
     }
   } else {
     for (i = 0; i < selectedLength; ++i) {
       tile = selectedTiles[i];
-      addTileDebugLabel(
-        tile,
-        tileset,
-        computeTileLabelPosition(tile),
-        frameState
-      );
+      addTileDebugLabel(tile, tileset, computeTileLabelPosition(tile));
     }
     for (i = 0; i < emptyLength; ++i) {
       tile = emptyTiles[i];
       if (tile.hasTilesetContent || tile.hasImplicitContent) {
-        addTileDebugLabel(
-          tile,
-          tileset,
-          computeTileLabelPosition(tile),
-          frameState
-        );
+        addTileDebugLabel(tile, tileset, computeTileLabelPosition(tile));
       }
     }
   }

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -2312,7 +2312,9 @@ function addTileDebugLabel(tile, tileset, position, frameState) {
       "\nDistance: " +
       tile.boundingVolume.distanceToCamera(frameState) +
       "\nClosest Point is on: " +
-      tile.boundingVolume._debugText,
+      tile.boundingVolume._debugText +
+      "\nToken: " +
+      tile.boundingVolume._token,
     position: position,
     font: 19 - attributes + "px sans-serif",
     showBackground: true,

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -2252,7 +2252,7 @@ function computeTileLabelPosition(tile) {
   return position;
 }
 
-function addTileDebugLabel(tile, tileset, position) {
+function addTileDebugLabel(tile, tileset, position, frameState) {
   var labelString = "";
   var attributes = 0;
 
@@ -2307,7 +2307,12 @@ function addTileDebugLabel(tile, tileset, position) {
   }
 
   var newLabel = {
-    text: labelString.substring(1),
+    text:
+      labelString +
+      "\nDistance: " +
+      tile.boundingVolume.distanceToCamera(frameState) +
+      "\nClosest Point is on: " +
+      tile.boundingVolume._debugText,
     position: position,
     font: 19 - attributes + "px sans-serif",
     showBackground: true,
@@ -2331,18 +2336,33 @@ function updateTileDebugLabels(tileset, frameState) {
       var position = defined(tileset.debugPickPosition)
         ? tileset.debugPickPosition
         : computeTileLabelPosition(tileset.debugPickedTile);
-      var label = addTileDebugLabel(tileset.debugPickedTile, tileset, position);
+      var label = addTileDebugLabel(
+        tileset.debugPickedTile,
+        tileset,
+        position,
+        frameState
+      );
       label.pixelOffset = new Cartesian2(15, -15); // Offset to avoid picking the label.
     }
   } else {
     for (i = 0; i < selectedLength; ++i) {
       tile = selectedTiles[i];
-      addTileDebugLabel(tile, tileset, computeTileLabelPosition(tile));
+      addTileDebugLabel(
+        tile,
+        tileset,
+        computeTileLabelPosition(tile),
+        frameState
+      );
     }
     for (i = 0; i < emptyLength; ++i) {
       tile = emptyTiles[i];
       if (tile.hasTilesetContent || tile.hasImplicitContent) {
-        addTileDebugLabel(tile, tileset, computeTileLabelPosition(tile));
+        addTileDebugLabel(
+          tile,
+          tileset,
+          computeTileLabelPosition(tile),
+          frameState
+        );
       }
     }
   }

--- a/Source/Scene/Implicit3DTileContent.js
+++ b/Source/Scene/Implicit3DTileContent.js
@@ -642,7 +642,11 @@ function deriveBoundingVolumeS2(
   // Decode Morton index. The modulus 4 ensures that it works for both quadtrees and octrees.
   var childCoords = MortonOrder.decode2D(childIndex % 4);
   // Encode Hilbert index.
-  var hilbertIndex = HilbertOrder.encode2D(1, childCoords[0], childCoords[1]);
+  var hilbertIndex = HilbertOrder.encode2D(
+    1 + (boundingVolumeS2.s2Cell._level % 2),
+    childCoords[0],
+    childCoords[1]
+  );
   var childCell = boundingVolumeS2.s2Cell.getChild(hilbertIndex);
 
   var minHeight, maxHeight;

--- a/Source/Scene/Implicit3DTileContent.js
+++ b/Source/Scene/Implicit3DTileContent.js
@@ -654,7 +654,7 @@ function deriveBoundingVolumeS2(
   // Extract the first 3 face bits from the 64-bit S2 cell ID.
   // eslint-disable-next-line
   var face = Number(parentTile._boundingVolume.s2Cell._cellId >> BigInt(61));
-  // The Hilbert curve is rotate for the "odd" faces on the S2 Earthcube.
+  // The Hilbert curve is rotated for the "odd" faces on the S2 Earthcube.
   // See http://s2geometry.io/devguide/img/s2cell_global.jpg
   var position =
     face % 2 === 0

--- a/Source/Scene/Implicit3DTileContent.js
+++ b/Source/Scene/Implicit3DTileContent.js
@@ -661,7 +661,7 @@ function deriveBoundingVolumeS2(
       ? HilbertOrder.encode2D(level, x, y)
       : HilbertOrder.encode2D(level, y, x);
   // eslint-disable-next-line
-  var cell = S2Cell.fromFacePosLevel(face, BigInt(position), level);
+  var cell = S2Cell.fromFacePositionLevel(face, BigInt(position), level);
 
   var minHeight, maxHeight;
   if (defined(z)) {

--- a/Source/Scene/Implicit3DTileContent.js
+++ b/Source/Scene/Implicit3DTileContent.js
@@ -7,11 +7,9 @@ import destroyObject from "../Core/destroyObject.js";
 import CesiumMath from "../Core/Math.js";
 import HilbertOrder from "../Core/HilbertOrder.js";
 import Matrix3 from "../Core/Matrix3.js";
-import MortonOrder from "../Core/MortonOrder.js";
 import Rectangle from "../Core/Rectangle.js";
 import S2Cell from "../Core/S2Cell.js";
 import when from "../ThirdParty/when.js";
-import ImplicitSubdivisionScheme from "./ImplicitSubdivisionScheme.js";
 import ImplicitSubtree from "./ImplicitSubtree.js";
 import ImplicitTileMetadata from "./ImplicitTileMetadata.js";
 import has3DTilesExtension from "./has3DTilesExtension.js";
@@ -559,10 +557,13 @@ function deriveBoundingVolume(
 
   if (has3DTilesExtension(rootBoundingVolume, "3DTILES_bounding_volume_S2")) {
     return deriveBoundingVolumeS2(
-      implicitTileset,
-      parentTile,
       parentIsPlaceholderTile,
-      childIndex
+      parentTile,
+      childIndex,
+      implicitCoordinates.level,
+      implicitCoordinates.x,
+      implicitCoordinates.y,
+      implicitCoordinates.z
     );
   }
 
@@ -594,39 +595,51 @@ function deriveBoundingVolume(
 }
 
 /**
- * Derive a bounding volume for a child tile from a parent tile,
- * assuming a quadtree or octree implicit tiling scheme.
+ * Derive a bounding volume for a descendant tile (child, grandchild, etc.),
+ * assuming a quadtree or octree implicit tiling scheme. The (level, x, y, [z])
+ * coordinates are given to select the descendant tile and compute its position
+ * and dimensions.
  * <p>
- * If implicitSubdivisionScheme is OCTREE, octree subdivision is used.
- * Otherwise, quadtree subdivision is used. Quadtrees are always divided
- * using the S2 cell hierarchy. Octrees have an additional split at the midpoint
- * of the the vertical (z) dimension.
+ * If z is present, octree subdivision is used. Otherwise, quadtree subdivision
+ * is used. Quadtrees are always divided at the midpoint of the the horizontal
+ * dimensions, i.e. (x, y), leaving the z axis unchanged.
  * </p>
  *
- * @param {ImplicitTileset} implicitTileset The implicit tileset struct which holds the root bounding volume
- * @param {Cesium3DTile} parentTile The parent of the new child tile
  * @param {Boolean} parentIsPlaceholderTile True if parentTile is a placeholder tile. This is true for the root of each subtree.
+ * @param {Cesium3DTile} parentTile The parent of the new child tile
  * @param {Number} childIndex The morton index of the child tile relative to its parent
+ * @param {Number} level The level of the descendant tile relative to the root implicit tile
+ * @param {Number} x The x coordinate of the descendant tile
+ * @param {Number} y The y coordinate of the descendant tile
+ * @param {Number} [z] The z coordinate of the descendant tile (octree only)
+ * @returns {Object} An object with the 3DTILES_bounding_volume_S2 extension.
  * @private
  */
 function deriveBoundingVolumeS2(
-  implicitTileset,
-  parentTile,
   parentIsPlaceholderTile,
-  childIndex
+  parentTile,
+  childIndex,
+  level,
+  x,
+  y,
+  z
 ) {
   //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("implicitTileset", implicitTileset);
-  Check.typeOf.object("parentTile", parentTile);
   Check.typeOf.bool("parentIsPlaceholderTile", parentIsPlaceholderTile);
+  Check.typeOf.object("parentTile", parentTile);
   Check.typeOf.number("childIndex", childIndex);
+  Check.typeOf.number("level", level);
+  Check.typeOf.number("x", x);
+  Check.typeOf.number("y", y);
+  if (defined(z)) {
+    Check.typeOf.number("z", z);
+  }
   //>>includeEnd('debug');
 
-  var boundingVolumeS2;
+  var boundingVolumeS2 = parentTile._boundingVolume;
 
-  // Handle the placeholder tile case.
+  // Handle the placeholder tile case, where we just duplicate the placeholder's bounding volume.
   if (parentIsPlaceholderTile) {
-    boundingVolumeS2 = parentTile._boundingVolume;
     return {
       extensions: {
         "3DTILES_bounding_volume_S2": {
@@ -637,20 +650,21 @@ function deriveBoundingVolumeS2(
       },
     };
   }
-  boundingVolumeS2 = parentTile._boundingVolume;
 
-  // Decode Morton index. The modulus 4 ensures that it works for both quadtrees and octrees.
-  var childCoords = MortonOrder.decode2D(childIndex % 4);
-  // Encode Hilbert index.
-  var hilbertIndex = HilbertOrder.encode2D(
-    1 + (boundingVolumeS2.s2Cell._level % 2),
-    childCoords[0],
-    childCoords[1]
-  );
-  var childCell = boundingVolumeS2.s2Cell.getChild(hilbertIndex);
+  // Extract the first 3 face bits from the 64-bit S2 cell ID.
+  // eslint-disable-next-line
+  var face = Number(parentTile._boundingVolume.s2Cell._cellId >> BigInt(61));
+  // The Hilbert curve is rotate for the "odd" faces on the S2 Earthcube.
+  // See http://s2geometry.io/devguide/img/s2cell_global.jpg
+  var position =
+    face % 2 === 0
+      ? HilbertOrder.encode2D(level, x, y)
+      : HilbertOrder.encode2D(level, y, x);
+  // eslint-disable-next-line
+  var cell = S2Cell.fromFacePosLevel(face, BigInt(position), level);
 
   var minHeight, maxHeight;
-  if (implicitTileset.subdivisionScheme === ImplicitSubdivisionScheme.OCTREE) {
+  if (defined(z)) {
     var midpointHeight =
       (boundingVolumeS2.maximumHeight + boundingVolumeS2.minimumHeight) / 2;
     minHeight =
@@ -665,7 +679,7 @@ function deriveBoundingVolumeS2(
   return {
     extensions: {
       "3DTILES_bounding_volume_S2": {
-        token: S2Cell.getTokenFromId(childCell._cellId),
+        token: S2Cell.getTokenFromId(cell._cellId),
         minimumHeight: minHeight,
         maximumHeight: maxHeight,
       },

--- a/Source/Scene/TileBoundingS2Cell.js
+++ b/Source/Scene/TileBoundingS2Cell.js
@@ -120,8 +120,6 @@ function TileBoundingS2Cell(options) {
   );
 
   this._boundingSphere = BoundingSphere.fromPoints(vertices);
-
-  this._debugText = "";
 }
 
 var centerGeodeticNormalScratch = new Cartesian3();
@@ -446,14 +444,6 @@ TileBoundingS2Cell.prototype.distanceToCamera = function (frameState) {
       edgeNormals
     );
 
-    if (selectedPlaneIndices[0] === 0) {
-      this._debugText = "Case I: Top Plane";
-    } else if (selectedPlaneIndices[0] === 1) {
-      this._debugText = "Case I: Bottom Plane";
-    } else {
-      this._debugText = "Case I: Side Plane";
-    }
-
     return Cartesian3.distance(facePoint, point);
   } else if (selectedPlaneIndices.length === 2) {
     // Handles Case II
@@ -469,7 +459,6 @@ TileBoundingS2Cell.prototype.distanceToCamera = function (frameState) {
         ],
       ];
       facePoint = closestPointLineSegment(point, edge[0], edge[1]);
-      this._debugText = "Case II: Edge of Top Plane";
       return Cartesian3.distance(facePoint, point);
     }
     var minimumDistance = Number.MAX_VALUE;
@@ -488,7 +477,6 @@ TileBoundingS2Cell.prototype.distanceToCamera = function (frameState) {
         minimumDistance = distance;
       }
     }
-    this._debugText = "Case II: Side or Bottom Plane";
     return Math.sqrt(minimumDistance);
   } else if (selectedPlaneIndices.length > 3) {
     // Handles Case IV
@@ -502,25 +490,20 @@ TileBoundingS2Cell.prototype.distanceToCamera = function (frameState) {
       this._boundingPlanes[1],
       this._edgeNormals[1]
     );
-    this._color = Color.RED;
-    this._debugText = "Case IV: Bottom Plane (Degenerate)";
     return Cartesian3.distance(facePoint, point);
   }
 
   // Handles Case III
   skip = selectedPlaneIndices[1] === 2 && selectedPlaneIndices[2] === 5 ? 0 : 1;
-  this._color = Color.YELLOW;
 
   // Vertex is on top plane.
   if (selectedPlaneIndices[0] === 0) {
-    this._debugText = "Case III: Vertex on Top Plane";
     return Cartesian3.distance(
       point,
       this._vertices[(selectedPlaneIndices[1] - 2 + skip) % 4]
     );
   }
 
-  this._debugText = "Case III: Vertex on Bottom Plane";
   // Vertex is on bottom plane.
   return Cartesian3.distance(
     point,

--- a/Source/Scene/TileBoundingS2Cell.js
+++ b/Source/Scene/TileBoundingS2Cell.js
@@ -14,7 +14,6 @@ import GeometryInstance from "../Core/GeometryInstance.js";
 import Matrix4 from "../Core/Matrix4.js";
 import PerInstanceColorAppearance from "./PerInstanceColorAppearance.js";
 import Primitive from "./Primitive.js";
-import Color from "../Core/Color.js";
 import S2Cell from "../Core/S2Cell.js";
 var centerCartographicScratch = new Cartographic();
 /**

--- a/Source/Scene/TileBoundingS2Cell.js
+++ b/Source/Scene/TileBoundingS2Cell.js
@@ -56,7 +56,6 @@ function TileBoundingS2Cell(options) {
     ellipsoid
   );
   this._boundingPlanes = boundingPlanes;
-  this._token = options.token;
 
   // Pre-compute vertices to speed up the plane intersection test.
   var vertices = computeVertices(boundingPlanes);

--- a/Specs/Core/HilbertOrderSpec.js
+++ b/Specs/Core/HilbertOrderSpec.js
@@ -47,27 +47,47 @@ describe("Core/HilbertOrder", function () {
   });
 
   it("encode2D works", function () {
-    expect(HilbertOrder.encode2D(1, 0, 0)).toEqual(0);
-    expect(HilbertOrder.encode2D(1, 0, 1)).toEqual(1);
-    expect(HilbertOrder.encode2D(1, 1, 1)).toEqual(2);
-    expect(HilbertOrder.encode2D(1, 1, 0)).toEqual(3);
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.encode2D(1, 0, 0)).toEqual(BigInt(0));
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.encode2D(1, 0, 1)).toEqual(BigInt(1));
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.encode2D(1, 1, 1)).toEqual(BigInt(2));
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.encode2D(1, 1, 0)).toEqual(BigInt(3));
 
-    expect(HilbertOrder.encode2D(2, 0, 0)).toEqual(0);
-    expect(HilbertOrder.encode2D(2, 1, 0)).toEqual(1);
-    expect(HilbertOrder.encode2D(2, 1, 1)).toEqual(2);
-    expect(HilbertOrder.encode2D(2, 0, 1)).toEqual(3);
-    expect(HilbertOrder.encode2D(2, 0, 2)).toEqual(4);
-    expect(HilbertOrder.encode2D(2, 0, 3)).toEqual(5);
-    expect(HilbertOrder.encode2D(2, 1, 3)).toEqual(6);
-    expect(HilbertOrder.encode2D(2, 1, 2)).toEqual(7);
-    expect(HilbertOrder.encode2D(2, 2, 2)).toEqual(8);
-    expect(HilbertOrder.encode2D(2, 2, 3)).toEqual(9);
-    expect(HilbertOrder.encode2D(2, 3, 3)).toEqual(10);
-    expect(HilbertOrder.encode2D(2, 3, 2)).toEqual(11);
-    expect(HilbertOrder.encode2D(2, 3, 1)).toEqual(12);
-    expect(HilbertOrder.encode2D(2, 2, 1)).toEqual(13);
-    expect(HilbertOrder.encode2D(2, 2, 0)).toEqual(14);
-    expect(HilbertOrder.encode2D(2, 3, 0)).toEqual(15);
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.encode2D(2, 0, 0)).toEqual(BigInt(0));
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.encode2D(2, 1, 0)).toEqual(BigInt(1));
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.encode2D(2, 1, 1)).toEqual(BigInt(2));
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.encode2D(2, 0, 1)).toEqual(BigInt(3));
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.encode2D(2, 0, 2)).toEqual(BigInt(4));
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.encode2D(2, 0, 3)).toEqual(BigInt(5));
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.encode2D(2, 1, 3)).toEqual(BigInt(6));
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.encode2D(2, 1, 2)).toEqual(BigInt(7));
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.encode2D(2, 2, 2)).toEqual(BigInt(8));
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.encode2D(2, 2, 3)).toEqual(BigInt(9));
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.encode2D(2, 3, 3)).toEqual(BigInt(10));
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.encode2D(2, 3, 2)).toEqual(BigInt(11));
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.encode2D(2, 3, 1)).toEqual(BigInt(12));
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.encode2D(2, 2, 1)).toEqual(BigInt(13));
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.encode2D(2, 2, 0)).toEqual(BigInt(14));
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.encode2D(2, 3, 0)).toEqual(BigInt(15));
   });
 
   it("decode2D throws for invalid level", function () {
@@ -86,26 +106,45 @@ describe("Core/HilbertOrder", function () {
   });
 
   it("decode2D works", function () {
-    expect(HilbertOrder.decode2D(1, 0)).toEqual([0, 0]);
-    expect(HilbertOrder.decode2D(1, 1)).toEqual([0, 1]);
-    expect(HilbertOrder.decode2D(1, 2)).toEqual([1, 1]);
-    expect(HilbertOrder.decode2D(1, 3)).toEqual([1, 0]);
-
-    expect(HilbertOrder.decode2D(2, 0)).toEqual([0, 0]);
-    expect(HilbertOrder.decode2D(2, 1)).toEqual([1, 0]);
-    expect(HilbertOrder.decode2D(2, 2)).toEqual([1, 1]);
-    expect(HilbertOrder.decode2D(2, 3)).toEqual([0, 1]);
-    expect(HilbertOrder.decode2D(2, 4)).toEqual([0, 2]);
-    expect(HilbertOrder.decode2D(2, 5)).toEqual([0, 3]);
-    expect(HilbertOrder.decode2D(2, 6)).toEqual([1, 3]);
-    expect(HilbertOrder.decode2D(2, 7)).toEqual([1, 2]);
-    expect(HilbertOrder.decode2D(2, 8)).toEqual([2, 2]);
-    expect(HilbertOrder.decode2D(2, 9)).toEqual([2, 3]);
-    expect(HilbertOrder.decode2D(2, 10)).toEqual([3, 3]);
-    expect(HilbertOrder.decode2D(2, 11)).toEqual([3, 2]);
-    expect(HilbertOrder.decode2D(2, 12)).toEqual([3, 1]);
-    expect(HilbertOrder.decode2D(2, 13)).toEqual([2, 1]);
-    expect(HilbertOrder.decode2D(2, 14)).toEqual([2, 0]);
-    expect(HilbertOrder.decode2D(2, 15)).toEqual([3, 0]);
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.decode2D(1, BigInt(0))).toEqual([0, 0]);
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.decode2D(1, BigInt(1))).toEqual([0, 1]);
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.decode2D(1, BigInt(2))).toEqual([1, 1]);
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.decode2D(1, BigInt(3))).toEqual([1, 0]);
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.decode2D(2, BigInt(0))).toEqual([0, 0]);
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.decode2D(2, BigInt(1))).toEqual([1, 0]);
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.decode2D(2, BigInt(2))).toEqual([1, 1]);
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.decode2D(2, BigInt(3))).toEqual([0, 1]);
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.decode2D(2, BigInt(4))).toEqual([0, 2]);
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.decode2D(2, BigInt(5))).toEqual([0, 3]);
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.decode2D(2, BigInt(6))).toEqual([1, 3]);
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.decode2D(2, BigInt(7))).toEqual([1, 2]);
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.decode2D(2, BigInt(8))).toEqual([2, 2]);
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.decode2D(2, BigInt(9))).toEqual([2, 3]);
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.decode2D(2, BigInt(10))).toEqual([3, 3]);
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.decode2D(2, BigInt(11))).toEqual([3, 2]);
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.decode2D(2, BigInt(12))).toEqual([3, 1]);
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.decode2D(2, BigInt(13))).toEqual([2, 1]);
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.decode2D(2, BigInt(14))).toEqual([2, 0]);
+    // eslint-disable-next-line no-undef
+    expect(HilbertOrder.decode2D(2, BigInt(15))).toEqual([3, 0]);
   });
 });

--- a/Specs/Core/HilbertOrderSpec.js
+++ b/Specs/Core/HilbertOrderSpec.js
@@ -2,6 +2,7 @@ import { FeatureDetection } from "../../Source/Cesium.js";
 import { HilbertOrder } from "../../Source/Cesium.js";
 
 describe("Core/HilbertOrder", function () {
+  /* eslint-disable no-undef */
   if (!FeatureDetection.supportsBigInt()) {
     return;
   }
@@ -52,104 +53,64 @@ describe("Core/HilbertOrder", function () {
   });
 
   it("encode2D works", function () {
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.encode2D(1, 0, 0)).toEqual(BigInt(0));
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.encode2D(1, 0, 1)).toEqual(BigInt(1));
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.encode2D(1, 1, 1)).toEqual(BigInt(2));
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.encode2D(1, 1, 0)).toEqual(BigInt(3));
 
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.encode2D(2, 0, 0)).toEqual(BigInt(0));
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.encode2D(2, 1, 0)).toEqual(BigInt(1));
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.encode2D(2, 1, 1)).toEqual(BigInt(2));
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.encode2D(2, 0, 1)).toEqual(BigInt(3));
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.encode2D(2, 0, 2)).toEqual(BigInt(4));
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.encode2D(2, 0, 3)).toEqual(BigInt(5));
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.encode2D(2, 1, 3)).toEqual(BigInt(6));
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.encode2D(2, 1, 2)).toEqual(BigInt(7));
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.encode2D(2, 2, 2)).toEqual(BigInt(8));
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.encode2D(2, 2, 3)).toEqual(BigInt(9));
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.encode2D(2, 3, 3)).toEqual(BigInt(10));
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.encode2D(2, 3, 2)).toEqual(BigInt(11));
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.encode2D(2, 3, 1)).toEqual(BigInt(12));
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.encode2D(2, 2, 1)).toEqual(BigInt(13));
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.encode2D(2, 2, 0)).toEqual(BigInt(14));
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.encode2D(2, 3, 0)).toEqual(BigInt(15));
   });
 
   it("decode2D throws for invalid level", function () {
     expect(function () {
-      return HilbertOrder.decode2D(-1, 0, 0);
+      return HilbertOrder.decode2D(-1, BigInt(0));
     }).toThrowDeveloperError();
     expect(function () {
-      return HilbertOrder.decode2D(0, 0, 0);
+      return HilbertOrder.decode2D(0, BigInt(0));
     }).toThrowDeveloperError();
   });
 
   it("decode2D throws for invalid index", function () {
     expect(function () {
-      return HilbertOrder.decode2D(1, 4);
+      return HilbertOrder.decode2D(1, BigInt(4));
     }).toThrowDeveloperError();
   });
 
   it("decode2D works", function () {
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.decode2D(1, BigInt(0))).toEqual([0, 0]);
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.decode2D(1, BigInt(1))).toEqual([0, 1]);
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.decode2D(1, BigInt(2))).toEqual([1, 1]);
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.decode2D(1, BigInt(3))).toEqual([1, 0]);
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.decode2D(2, BigInt(0))).toEqual([0, 0]);
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.decode2D(2, BigInt(1))).toEqual([1, 0]);
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.decode2D(2, BigInt(2))).toEqual([1, 1]);
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.decode2D(2, BigInt(3))).toEqual([0, 1]);
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.decode2D(2, BigInt(4))).toEqual([0, 2]);
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.decode2D(2, BigInt(5))).toEqual([0, 3]);
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.decode2D(2, BigInt(6))).toEqual([1, 3]);
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.decode2D(2, BigInt(7))).toEqual([1, 2]);
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.decode2D(2, BigInt(8))).toEqual([2, 2]);
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.decode2D(2, BigInt(9))).toEqual([2, 3]);
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.decode2D(2, BigInt(10))).toEqual([3, 3]);
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.decode2D(2, BigInt(11))).toEqual([3, 2]);
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.decode2D(2, BigInt(12))).toEqual([3, 1]);
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.decode2D(2, BigInt(13))).toEqual([2, 1]);
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.decode2D(2, BigInt(14))).toEqual([2, 0]);
-    // eslint-disable-next-line no-undef
     expect(HilbertOrder.decode2D(2, BigInt(15))).toEqual([3, 0]);
   });
 });

--- a/Specs/Core/HilbertOrderSpec.js
+++ b/Specs/Core/HilbertOrderSpec.js
@@ -1,6 +1,11 @@
+import { FeatureDetection } from "../../Source/Cesium.js";
 import { HilbertOrder } from "../../Source/Cesium.js";
 
 describe("Core/HilbertOrder", function () {
+  if (!FeatureDetection.supportsBigInt()) {
+    return;
+  }
+
   it("encode2D throws for undefined inputs", function () {
     expect(function () {
       return HilbertOrder.encode2D(undefined, 0, 0);

--- a/Specs/Core/S2CellSpec.js
+++ b/Specs/Core/S2CellSpec.js
@@ -40,6 +40,46 @@ describe("Core/S2Cell", function () {
     }).toThrowDeveloperError();
   });
 
+  it("creates cell from face, position, level", function () {
+    var cell = S2Cell.fromFacePosLevel(0, BigInt(0), 1);
+    expect(S2Cell.getTokenFromId(cell._cellId)).toEqual("04");
+    cell = S2Cell.fromFacePosLevel(BigInt(0), BigInt(1), 1);
+    expect(S2Cell.getTokenFromId(cell._cellId)).toEqual("0c");
+    cell = S2Cell.fromFacePosLevel(BigInt(0), BigInt(2), 1);
+    expect(S2Cell.getTokenFromId(cell._cellId)).toEqual("14");
+    cell = S2Cell.fromFacePosLevel(BigInt(0), BigInt(3), 1);
+    expect(S2Cell.getTokenFromId(cell._cellId)).toEqual("1c");
+
+    cell = S2Cell.fromFacePosLevel(1, BigInt("538969508876688737"), 30);
+    expect(S2Cell.getTokenFromId(cell._cellId)).toEqual("2ef59bd352b93ac3");
+  });
+
+  it("throws for creating cell from invalid face, position, level", function () {
+    expect(function () {
+      S2Cell.fromFacePosLevel(-1, BigInt(0), 1);
+    }).toThrowDeveloperError();
+
+    expect(function () {
+      S2Cell.fromFacePosLevel(6, BigInt(0), 1);
+    }).toThrowDeveloperError();
+
+    expect(function () {
+      S2Cell.fromFacePosLevel(0, BigInt(-1), 1);
+    }).toThrowDeveloperError();
+
+    expect(function () {
+      S2Cell.fromFacePosLevel(0, BigInt(4), 1);
+    }).toThrowDeveloperError();
+
+    expect(function () {
+      S2Cell.fromFacePosLevel(0, BigInt(0), -1);
+    }).toThrowDeveloperError();
+
+    expect(function () {
+      S2Cell.fromFacePosLevel(0, BigInt(0), 31);
+    }).toThrowDeveloperError();
+  });
+
   it("accepts valid token", function () {
     var tokenValidity = S2Cell.isValidToken("1");
     expect(tokenValidity).toBe(true);

--- a/Specs/Core/S2CellSpec.js
+++ b/Specs/Core/S2CellSpec.js
@@ -41,42 +41,42 @@ describe("Core/S2Cell", function () {
   });
 
   it("creates cell from face, position, level", function () {
-    var cell = S2Cell.fromFacePosLevel(0, BigInt(0), 1);
+    var cell = S2Cell.fromFacePositionLevel(0, BigInt(0), 1);
     expect(S2Cell.getTokenFromId(cell._cellId)).toEqual("04");
-    cell = S2Cell.fromFacePosLevel(BigInt(0), BigInt(1), 1);
+    cell = S2Cell.fromFacePositionLevel(BigInt(0), BigInt(1), 1);
     expect(S2Cell.getTokenFromId(cell._cellId)).toEqual("0c");
-    cell = S2Cell.fromFacePosLevel(BigInt(0), BigInt(2), 1);
+    cell = S2Cell.fromFacePositionLevel(BigInt(0), BigInt(2), 1);
     expect(S2Cell.getTokenFromId(cell._cellId)).toEqual("14");
-    cell = S2Cell.fromFacePosLevel(BigInt(0), BigInt(3), 1);
+    cell = S2Cell.fromFacePositionLevel(BigInt(0), BigInt(3), 1);
     expect(S2Cell.getTokenFromId(cell._cellId)).toEqual("1c");
 
-    cell = S2Cell.fromFacePosLevel(1, BigInt("538969508876688737"), 30);
+    cell = S2Cell.fromFacePositionLevel(1, BigInt("538969508876688737"), 30);
     expect(S2Cell.getTokenFromId(cell._cellId)).toEqual("2ef59bd352b93ac3");
   });
 
   it("throws for creating cell from invalid face, position, level", function () {
     expect(function () {
-      S2Cell.fromFacePosLevel(-1, BigInt(0), 1);
+      S2Cell.fromFacePositionLevel(-1, BigInt(0), 1);
     }).toThrowDeveloperError();
 
     expect(function () {
-      S2Cell.fromFacePosLevel(6, BigInt(0), 1);
+      S2Cell.fromFacePositionLevel(6, BigInt(0), 1);
     }).toThrowDeveloperError();
 
     expect(function () {
-      S2Cell.fromFacePosLevel(0, BigInt(-1), 1);
+      S2Cell.fromFacePositionLevel(0, BigInt(-1), 1);
     }).toThrowDeveloperError();
 
     expect(function () {
-      S2Cell.fromFacePosLevel(0, BigInt(4), 1);
+      S2Cell.fromFacePositionLevel(0, BigInt(4), 1);
     }).toThrowDeveloperError();
 
     expect(function () {
-      S2Cell.fromFacePosLevel(0, BigInt(0), -1);
+      S2Cell.fromFacePositionLevel(0, BigInt(0), -1);
     }).toThrowDeveloperError();
 
     expect(function () {
-      S2Cell.fromFacePosLevel(0, BigInt(0), 31);
+      S2Cell.fromFacePositionLevel(0, BigInt(0), 31);
     }).toThrowDeveloperError();
   });
 

--- a/Specs/Core/S2CellSpec.js
+++ b/Specs/Core/S2CellSpec.js
@@ -40,7 +40,7 @@ describe("Core/S2Cell", function () {
     }).toThrowDeveloperError();
   });
 
-  it("creates cell from face, position, level", function () {
+  it("creates cell from valid face, position, level", function () {
     var cell = S2Cell.fromFacePositionLevel(0, BigInt(0), 1);
     expect(S2Cell.getTokenFromId(cell._cellId)).toEqual("04");
     cell = S2Cell.fromFacePositionLevel(BigInt(0), BigInt(1), 1);
@@ -49,7 +49,10 @@ describe("Core/S2Cell", function () {
     expect(S2Cell.getTokenFromId(cell._cellId)).toEqual("14");
     cell = S2Cell.fromFacePositionLevel(BigInt(0), BigInt(3), 1);
     expect(S2Cell.getTokenFromId(cell._cellId)).toEqual("1c");
-
+    cell = S2Cell.fromFacePositionLevel(2, BigInt("0"), 1);
+    expect(S2Cell.getTokenFromId(cell._cellId)).toEqual("44");
+    cell = S2Cell.fromFacePositionLevel(4, BigInt("0"), 1);
+    expect(S2Cell.getTokenFromId(cell._cellId)).toEqual("84");
     cell = S2Cell.fromFacePositionLevel(1, BigInt("538969508876688737"), 30);
     expect(S2Cell.getTokenFromId(cell._cellId)).toEqual("2ef59bd352b93ac3");
   });

--- a/Specs/Scene/Implicit3DTileContentSpec.js
+++ b/Specs/Scene/Implicit3DTileContentSpec.js
@@ -589,27 +589,45 @@ describe(
         subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
       };
 
-      it("throws if implicitTileset is undefined", function () {
+      it("throws if parentIsPlaceholderTile is undefined", function () {
         expect(function () {
-          deriveBoundingVolumeS2(undefined, {}, false, 0);
+          deriveBoundingVolumeS2(undefined, {}, 0, 0, 0, 0, 0);
         }).toThrowDeveloperError();
       });
 
       it("throws if parentTile is undefined", function () {
         expect(function () {
-          deriveBoundingVolumeS2({}, undefined, false, 0);
-        }).toThrowDeveloperError();
-      });
-
-      it("throws if parentIsPlaceholderTile is undefined", function () {
-        expect(function () {
-          deriveBoundingVolumeS2({}, {}, undefined, 0);
+          deriveBoundingVolumeS2(false, undefined, 0, 0, 0, 0, 0);
         }).toThrowDeveloperError();
       });
 
       it("throws if childIndex is undefined", function () {
         expect(function () {
-          deriveBoundingVolumeS2({}, {}, false, undefined);
+          deriveBoundingVolumeS2(false, {}, undefined, 0, 0, 0, 0);
+        }).toThrowDeveloperError();
+      });
+
+      it("throws if level is undefined", function () {
+        expect(function () {
+          deriveBoundingVolumeS2(false, {}, 0, undefined, 0, 0, 0);
+        }).toThrowDeveloperError();
+      });
+
+      it("throws if x is undefined", function () {
+        expect(function () {
+          deriveBoundingVolumeS2(false, {}, 0, 0, undefined, 0, 0);
+        }).toThrowDeveloperError();
+      });
+
+      it("throws if y is undefined", function () {
+        expect(function () {
+          deriveBoundingVolumeS2(false, {}, 0, 0, 0, undefined, 0);
+        }).toThrowDeveloperError();
+      });
+
+      it("throws if z is defined but not a number", function () {
+        expect(function () {
+          deriveBoundingVolumeS2(false, {}, 0, 0, 0, 0, "");
         }).toThrowDeveloperError();
       });
 
@@ -618,9 +636,12 @@ describe(
           _boundingVolume: simpleBoundingVolumeS2Cell,
         };
         var result = deriveBoundingVolumeS2(
-          implicitTilesetS2,
-          placeholderTile,
           true,
+          placeholderTile,
+          0,
+          0,
+          0,
+          0,
           0
         );
         expect(result).toEqual(implicitTilesetS2.boundingVolume);
@@ -636,12 +657,24 @@ describe(
           minimumHeight: 0,
           maximumHeight: 10,
         };
-        var result = deriveBoundingVolumeS2(
-          implicitTilesetS2,
-          parentTile,
-          false,
-          0
-        );
+        var result = deriveBoundingVolumeS2(false, parentTile, 0, 1, 0, 0);
+        expect(result).toEqual({
+          extensions: {
+            "3DTILES_bounding_volume_S2": expected,
+          },
+        });
+
+        parentTile._boundingVolume = new TileBoundingS2Cell({
+          token: "3",
+          minimumHeight: 0,
+          maximumHeight: 10,
+        });
+        expected = {
+          token: "24",
+          minimumHeight: 0,
+          maximumHeight: 10,
+        };
+        result = deriveBoundingVolumeS2(false, parentTile, 0, 1, 0, 0);
         expect(result).toEqual({
           extensions: {
             "3DTILES_bounding_volume_S2": expected,
@@ -664,23 +697,13 @@ describe(
           minimumHeight: 5,
           maximumHeight: 10,
         };
-        var result0 = deriveBoundingVolumeS2(
-          implicitTilesetS2,
-          parentTile,
-          false,
-          0
-        );
+        var result0 = deriveBoundingVolumeS2(false, parentTile, 0, 1, 0, 0, 0);
         expect(result0).toEqual({
           extensions: {
             "3DTILES_bounding_volume_S2": expected0,
           },
         });
-        var result1 = deriveBoundingVolumeS2(
-          implicitTilesetS2,
-          parentTile,
-          false,
-          4
-        );
+        var result1 = deriveBoundingVolumeS2(false, parentTile, 4, 1, 0, 0, 0);
         expect(result1).toEqual({
           extensions: {
             "3DTILES_bounding_volume_S2": expected1,


### PR DESCRIPTION
This PR fixes some two main issues in the current S2 implementation:
1. Incorrect conversion from `{level}/{x}/{y}/{z}` to Hilbert/S2 index.
2. The parent bounding volume being updated when a child bounding volume is created.