### PR TITLE
Rewrite the documentation for Matrix4.inverse and Matrix4.inverseTransformation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 - Fixed error handling in `GlobeSurfaceTile` to print terrain tile request errors to console. [#9570](https://github.com/CesiumGS/cesium/pull/9570)
 - Fixed broken image URL in the KML Sandcastle. [#9579](https://github.com/CesiumGS/cesium/pull/9579)
 - Fixed an error where the `positionToEyeEC` and `tangentToEyeMatrix` properties for custom materials were not set in `GlobeFS`. [#9597](https://github.com/CesiumGS/cesium/pull/9597)
+- Fixed misleading documentation in `Matrix4.inverse` and `Matrix4.inverseTransformation` that used "affine transformation" instead of "rotation and translation" specifically
 
 ### 1.82.1 - 2021-06-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
 - Fixed error handling in `GlobeSurfaceTile` to print terrain tile request errors to console. [#9570](https://github.com/CesiumGS/cesium/pull/9570)
 - Fixed broken image URL in the KML Sandcastle. [#9579](https://github.com/CesiumGS/cesium/pull/9579)
 - Fixed an error where the `positionToEyeEC` and `tangentToEyeMatrix` properties for custom materials were not set in `GlobeFS`. [#9597](https://github.com/CesiumGS/cesium/pull/9597)
-- Fixed misleading documentation in `Matrix4.inverse` and `Matrix4.inverseTransformation` that used "affine transformation" instead of "rotation and translation" specifically
+- Fixed misleading documentation in `Matrix4.inverse` and `Matrix4.inverseTransformation` that used "affine transformation" instead of "rotation and translation" specifically. [#9608](https://github.com/CesiumGS/cesium/pull/9608)
 
 ### 1.82.1 - 2021-06-01
 

--- a/Source/Core/Matrix4.js
+++ b/Source/Core/Matrix4.js
@@ -1607,10 +1607,9 @@ Matrix4.subtract = function (left, right, result) {
 };
 
 /**
- * Computes the product of two matrices assuming the matrices are
- * proper rigid transformation matrices,
- * where the upper left 3x3 elements are a rotation matrix,
- * and the upper three elements in the fourth column are the translation.
+ * Computes the product of two matrices assuming the matrices are affine transformation matrices,
+ * where the upper left 3x3 elements are any affine matrix, and
+ * the upper three elements in the fourth column are the translation.
  * The bottom row is assumed to be [0, 0, 0, 1].
  * The matrix is not verified to be in the proper form.
  * This method is faster than computing the product for general 4x4
@@ -1820,13 +1819,13 @@ Matrix4.multiplyByTranslation = function (matrix, translation, result) {
 var uniformScaleScratch = new Cartesian3();
 
 /**
- * Multiplies a proper rigid transformation matrix (with a bottom row of <code>[0.0, 0.0, 0.0, 1.0]</code>)
+ * Multiplies an affine transformation matrix (with a bottom row of <code>[0.0, 0.0, 0.0, 1.0]</code>)
  * by an implicit uniform scale matrix.  This is an optimization
  * for <code>Matrix4.multiply(m, Matrix4.fromUniformScale(scale), m);</code>, where
- * <code>m</code> must be a proper rigid matrix.
+ * <code>m</code> must be an affine matrix.
  * This function performs fewer allocations and arithmetic operations.
  *
- * @param {Matrix4} matrix The rigid matrix on the left-hand side.
+ * @param {Matrix4} matrix The affine matrix on the left-hand side.
  * @param {Number} scale The uniform scale on the right-hand side.
  * @param {Matrix4} result The object onto which to store the result.
  * @returns {Matrix4} The modified result parameter.
@@ -1853,13 +1852,13 @@ Matrix4.multiplyByUniformScale = function (matrix, scale, result) {
 };
 
 /**
- * Multiplies a proper rigid transformation matrix (with a bottom row of <code>[0.0, 0.0, 0.0, 1.0]</code>)
- * by an implicit non-uniform scale matrix.  This is an optimization
+ * Multiplies an affine transformation matrix (with a bottom row of <code>[0.0, 0.0, 0.0, 1.0]</code>)
+ * by an implicit non-uniform scale matrix. This is an optimization
  * for <code>Matrix4.multiply(m, Matrix4.fromUniformScale(scale), m);</code>, where
- * <code>m</code> must be a proper rigid matrix.
+ * <code>m</code> must be an affine matrix.
  * This function performs fewer allocations and arithmetic operations.
  *
- * @param {Matrix4} matrix The proper rigid matrix on the left-hand side.
+ * @param {Matrix4} matrix The affine matrix on the left-hand side.
  * @param {Cartesian3} scale The non-uniform scale on the right-hand side.
  * @param {Matrix4} result The object onto which to store the result.
  * @returns {Matrix4} The modified result parameter.
@@ -2330,8 +2329,7 @@ Matrix4.getTranslation = function (matrix, result) {
 };
 
 /**
- * Gets the upper left 3x3 rotation matrix of the provided matrix,
- * assuming the matrix is a proper rigid transformation matrix.
+ * Gets the upper left 3x3 matrix of the provided matrix.
  *
  * @param {Matrix4} matrix The matrix to use.
  * @param {Matrix3} result The object onto which to store the result.

--- a/Source/Core/Matrix4.js
+++ b/Source/Core/Matrix4.js
@@ -1235,7 +1235,7 @@ Matrix4.setColumn = function (matrix, index, cartesian, result) {
 
 /**
  * Computes a new matrix that replaces the translation in the rightmost column of the provided
- * matrix with the provided translation.  This assumes the matrix is an affine transformation
+ * matrix with the provided translation. This assumes the matrix is a rigid transformation.
  *
  * @param {Matrix4} matrix The matrix to use.
  * @param {Cartesian3} translation The translation that replaces the translation of the provided matrix.
@@ -1274,7 +1274,8 @@ Matrix4.setTranslation = function (matrix, translation, result) {
 
 var scaleScratch = new Cartesian3();
 /**
- * Computes a new matrix that replaces the scale with the provided scale.  This assumes the matrix is an affine transformation
+ * Computes a new matrix that replaces the scale with the provided scale.
+ * This assumes the matrix is a rigid transformation.
  *
  * @param {Matrix4} matrix The matrix to use.
  * @param {Cartesian3} scale The scale that replaces the scale of the provided matrix.
@@ -1394,7 +1395,7 @@ Matrix4.setRow = function (matrix, index, cartesian, result) {
 var scratchColumn = new Cartesian3();
 
 /**
- * Extracts the non-uniform scale assuming the matrix is an affine transformation.
+ * Extracts the non-uniform scale assuming the matrix is a rigid transformation.
  *
  * @param {Matrix4} matrix The matrix.
  * @param {Cartesian3} result The object onto which to store the result.
@@ -1421,7 +1422,7 @@ Matrix4.getScale = function (matrix, result) {
 var scratchScale = new Cartesian3();
 
 /**
- * Computes the maximum scale assuming the matrix is an affine transformation.
+ * Computes the maximum scale assuming the matrix is a rigid transformation.
  * The maximum scale is the maximum length of the column vectors in the upper-left
  * 3x3 matrix.
  *
@@ -1607,9 +1608,10 @@ Matrix4.subtract = function (left, right, result) {
 
 /**
  * Computes the product of two matrices assuming the matrices are
- * affine transformation matrices, where the upper left 3x3 elements
- * are a rotation matrix, and the upper three elements in the fourth
- * column are the translation.  The bottom row is assumed to be [0, 0, 0, 1].
+ * rigid transformation matrices, where the upper left 3x3 elements
+ * are a rotation and/or reflection matrix, and the upper three elements
+ * in the fourth column are the translation.
+ * The bottom row is assumed to be [0, 0, 0, 1].
  * The matrix is not verified to be in the proper form.
  * This method is faster than computing the product for general 4x4
  * matrices using {@link Matrix4.multiply}.
@@ -1818,13 +1820,13 @@ Matrix4.multiplyByTranslation = function (matrix, translation, result) {
 var uniformScaleScratch = new Cartesian3();
 
 /**
- * Multiplies an affine transformation matrix (with a bottom row of <code>[0.0, 0.0, 0.0, 1.0]</code>)
+ * Multiplies a rigid transformation matrix (with a bottom row of <code>[0.0, 0.0, 0.0, 1.0]</code>)
  * by an implicit uniform scale matrix.  This is an optimization
  * for <code>Matrix4.multiply(m, Matrix4.fromUniformScale(scale), m);</code>, where
- * <code>m</code> must be an affine matrix.
+ * <code>m</code> must be a rigid matrix.
  * This function performs fewer allocations and arithmetic operations.
  *
- * @param {Matrix4} matrix The affine matrix on the left-hand side.
+ * @param {Matrix4} matrix The rigid matrix on the left-hand side.
  * @param {Number} scale The uniform scale on the right-hand side.
  * @param {Matrix4} result The object onto which to store the result.
  * @returns {Matrix4} The modified result parameter.
@@ -1851,13 +1853,13 @@ Matrix4.multiplyByUniformScale = function (matrix, scale, result) {
 };
 
 /**
- * Multiplies an affine transformation matrix (with a bottom row of <code>[0.0, 0.0, 0.0, 1.0]</code>)
+ * Multiplies a rigid transformation matrix (with a bottom row of <code>[0.0, 0.0, 0.0, 1.0]</code>)
  * by an implicit non-uniform scale matrix.  This is an optimization
  * for <code>Matrix4.multiply(m, Matrix4.fromUniformScale(scale), m);</code>, where
- * <code>m</code> must be an affine matrix.
+ * <code>m</code> must be a rigid matrix.
  * This function performs fewer allocations and arithmetic operations.
  *
- * @param {Matrix4} matrix The affine matrix on the left-hand side.
+ * @param {Matrix4} matrix The rigid matrix on the left-hand side.
  * @param {Cartesian3} scale The non-uniform scale on the right-hand side.
  * @param {Matrix4} result The object onto which to store the result.
  * @returns {Matrix4} The modified result parameter.
@@ -2309,7 +2311,7 @@ Matrix4.equalsEpsilon = function (left, right, epsilon) {
 };
 
 /**
- * Gets the translation portion of the provided matrix, assuming the matrix is a affine transformation matrix.
+ * Gets the translation portion of the provided matrix, assuming the matrix is a rigid transformation matrix.
  *
  * @param {Matrix4} matrix The matrix to use.
  * @param {Cartesian3} result The object onto which to store the result.
@@ -2328,7 +2330,8 @@ Matrix4.getTranslation = function (matrix, result) {
 };
 
 /**
- * Gets the upper left 3x3 rotation matrix of the provided matrix, assuming the matrix is an affine transformation matrix.
+ * Gets the upper left 3x3 rotation or reflection matrix of the provided matrix,
+ * assuming the matrix is a rigid transformation matrix.
  *
  * @param {Matrix4} matrix The matrix to use.
  * @param {Matrix3} result The object onto which to store the result.
@@ -2375,7 +2378,7 @@ var scratchExpectedBottomRow = new Cartesian4(0.0, 0.0, 0.0, 1.0);
 /**
  * Computes the inverse of the provided matrix using Cramers Rule.
  * If the determinant is zero, the matrix can not be inverted, and an exception is thrown.
- * If the matrix is a composition of a rotation and a translation, it is more efficient
+ * If the matrix is a rigid transformation, it is more efficient
  * to invert it with {@link Matrix4.inverseTransformation}.
  *
  * @param {Matrix4} matrix The matrix to invert.
@@ -2586,9 +2589,8 @@ Matrix4.inverse = function (matrix, result) {
 };
 
 /**
- * Computes the inverse of the provided matrix assuming it is
- * a composition of a rotation and a translation,
- * where the upper left 3x3 elements are a rotation matrix,
+ * Computes the inverse of the provided matrix assuming it is a rigid matrix,
+ * where the upper left 3x3 elements are a rotation or reflection matrix,
  * and the upper three elements in the fourth column are the translation.
  * The bottom row is assumed to be [0, 0, 0, 1].
  * The matrix is not verified to be in the proper form.

--- a/Source/Core/Matrix4.js
+++ b/Source/Core/Matrix4.js
@@ -1235,7 +1235,7 @@ Matrix4.setColumn = function (matrix, index, cartesian, result) {
 
 /**
  * Computes a new matrix that replaces the translation in the rightmost column of the provided
- * matrix with the provided translation. This assumes the matrix is a rigid transformation.
+ * matrix with the provided translation. This assumes the matrix is an affine transformation.
  *
  * @param {Matrix4} matrix The matrix to use.
  * @param {Cartesian3} translation The translation that replaces the translation of the provided matrix.
@@ -1275,7 +1275,7 @@ Matrix4.setTranslation = function (matrix, translation, result) {
 var scaleScratch = new Cartesian3();
 /**
  * Computes a new matrix that replaces the scale with the provided scale.
- * This assumes the matrix is a rigid transformation.
+ * This assumes the matrix is an affine transformation.
  *
  * @param {Matrix4} matrix The matrix to use.
  * @param {Cartesian3} scale The scale that replaces the scale of the provided matrix.
@@ -1395,7 +1395,7 @@ Matrix4.setRow = function (matrix, index, cartesian, result) {
 var scratchColumn = new Cartesian3();
 
 /**
- * Extracts the non-uniform scale assuming the matrix is a rigid transformation.
+ * Extracts the non-uniform scale assuming the matrix is an affine transformation.
  *
  * @param {Matrix4} matrix The matrix.
  * @param {Cartesian3} result The object onto which to store the result.
@@ -1422,7 +1422,7 @@ Matrix4.getScale = function (matrix, result) {
 var scratchScale = new Cartesian3();
 
 /**
- * Computes the maximum scale assuming the matrix is a rigid transformation.
+ * Computes the maximum scale assuming the matrix is an affine transformation.
  * The maximum scale is the maximum length of the column vectors in the upper-left
  * 3x3 matrix.
  *

--- a/Source/Core/Matrix4.js
+++ b/Source/Core/Matrix4.js
@@ -1608,7 +1608,7 @@ Matrix4.subtract = function (left, right, result) {
 
 /**
  * Computes the product of two matrices assuming the matrices are affine transformation matrices,
- * where the upper left 3x3 elements are any affine matrix, and
+ * where the upper left 3x3 elements are any matrix, and
  * the upper three elements in the fourth column are the translation.
  * The bottom row is assumed to be [0, 0, 0, 1].
  * The matrix is not verified to be in the proper form.

--- a/Source/Core/Matrix4.js
+++ b/Source/Core/Matrix4.js
@@ -2375,7 +2375,7 @@ var scratchExpectedBottomRow = new Cartesian4(0.0, 0.0, 0.0, 1.0);
 /**
  * Computes the inverse of the provided matrix using Cramers Rule.
  * If the determinant is zero, the matrix can not be inverted, and an exception is thrown.
- * If the matrix is an affine transformation matrix, it is more efficient
+ * If the matrix is a composition of a rotation and a translation, it is more efficient
  * to invert it with {@link Matrix4.inverseTransformation}.
  *
  * @param {Matrix4} matrix The matrix to invert.
@@ -2587,9 +2587,10 @@ Matrix4.inverse = function (matrix, result) {
 
 /**
  * Computes the inverse of the provided matrix assuming it is
- * an affine transformation matrix, where the upper left 3x3 elements
- * are a rotation matrix, and the upper three elements in the fourth
- * column are the translation.  The bottom row is assumed to be [0, 0, 0, 1].
+ * a composition of a rotation and a translation,
+ * where the upper left 3x3 elements are a rotation matrix,
+ * and the upper three elements in the fourth column are the translation.
+ * The bottom row is assumed to be [0, 0, 0, 1].
  * The matrix is not verified to be in the proper form.
  * This method is faster than computing the inverse for a general 4x4
  * matrix using {@link Matrix4.inverse}.

--- a/Source/Core/Matrix4.js
+++ b/Source/Core/Matrix4.js
@@ -1608,9 +1608,9 @@ Matrix4.subtract = function (left, right, result) {
 
 /**
  * Computes the product of two matrices assuming the matrices are
- * rigid transformation matrices, where the upper left 3x3 elements
- * are a rotation and/or reflection matrix, and the upper three elements
- * in the fourth column are the translation.
+ * proper rigid transformation matrices,
+ * where the upper left 3x3 elements are a rotation matrix,
+ * and the upper three elements in the fourth column are the translation.
  * The bottom row is assumed to be [0, 0, 0, 1].
  * The matrix is not verified to be in the proper form.
  * This method is faster than computing the product for general 4x4
@@ -1820,10 +1820,10 @@ Matrix4.multiplyByTranslation = function (matrix, translation, result) {
 var uniformScaleScratch = new Cartesian3();
 
 /**
- * Multiplies a rigid transformation matrix (with a bottom row of <code>[0.0, 0.0, 0.0, 1.0]</code>)
+ * Multiplies a proper rigid transformation matrix (with a bottom row of <code>[0.0, 0.0, 0.0, 1.0]</code>)
  * by an implicit uniform scale matrix.  This is an optimization
  * for <code>Matrix4.multiply(m, Matrix4.fromUniformScale(scale), m);</code>, where
- * <code>m</code> must be a rigid matrix.
+ * <code>m</code> must be a proper rigid matrix.
  * This function performs fewer allocations and arithmetic operations.
  *
  * @param {Matrix4} matrix The rigid matrix on the left-hand side.
@@ -1853,13 +1853,13 @@ Matrix4.multiplyByUniformScale = function (matrix, scale, result) {
 };
 
 /**
- * Multiplies a rigid transformation matrix (with a bottom row of <code>[0.0, 0.0, 0.0, 1.0]</code>)
+ * Multiplies a proper rigid transformation matrix (with a bottom row of <code>[0.0, 0.0, 0.0, 1.0]</code>)
  * by an implicit non-uniform scale matrix.  This is an optimization
  * for <code>Matrix4.multiply(m, Matrix4.fromUniformScale(scale), m);</code>, where
- * <code>m</code> must be a rigid matrix.
+ * <code>m</code> must be a proper rigid matrix.
  * This function performs fewer allocations and arithmetic operations.
  *
- * @param {Matrix4} matrix The rigid matrix on the left-hand side.
+ * @param {Matrix4} matrix The proper rigid matrix on the left-hand side.
  * @param {Cartesian3} scale The non-uniform scale on the right-hand side.
  * @param {Matrix4} result The object onto which to store the result.
  * @returns {Matrix4} The modified result parameter.
@@ -2311,7 +2311,7 @@ Matrix4.equalsEpsilon = function (left, right, epsilon) {
 };
 
 /**
- * Gets the translation portion of the provided matrix, assuming the matrix is a rigid transformation matrix.
+ * Gets the translation portion of the provided matrix, assuming the matrix is an affine transformation matrix.
  *
  * @param {Matrix4} matrix The matrix to use.
  * @param {Cartesian3} result The object onto which to store the result.
@@ -2330,8 +2330,8 @@ Matrix4.getTranslation = function (matrix, result) {
 };
 
 /**
- * Gets the upper left 3x3 rotation or reflection matrix of the provided matrix,
- * assuming the matrix is a rigid transformation matrix.
+ * Gets the upper left 3x3 rotation matrix of the provided matrix,
+ * assuming the matrix is a proper rigid transformation matrix.
  *
  * @param {Matrix4} matrix The matrix to use.
  * @param {Matrix3} result The object onto which to store the result.
@@ -2378,7 +2378,7 @@ var scratchExpectedBottomRow = new Cartesian4(0.0, 0.0, 0.0, 1.0);
 /**
  * Computes the inverse of the provided matrix using Cramers Rule.
  * If the determinant is zero, the matrix can not be inverted, and an exception is thrown.
- * If the matrix is a rigid transformation, it is more efficient
+ * If the matrix is a proper rigid transformation, it is more efficient
  * to invert it with {@link Matrix4.inverseTransformation}.
  *
  * @param {Matrix4} matrix The matrix to invert.
@@ -2589,8 +2589,8 @@ Matrix4.inverse = function (matrix, result) {
 };
 
 /**
- * Computes the inverse of the provided matrix assuming it is a rigid matrix,
- * where the upper left 3x3 elements are a rotation or reflection matrix,
+ * Computes the inverse of the provided matrix assuming it is a proper rigid matrix,
+ * where the upper left 3x3 elements are a rotation matrix,
  * and the upper three elements in the fourth column are the translation.
  * The bottom row is assumed to be [0, 0, 0, 1].
  * The matrix is not verified to be in the proper form.


### PR DESCRIPTION
Fixes #9594 , waiting on a consensus to change `inverseTransformation` to something more specific as well.