### PR TITLE
Detect external tilesets with json.root instead of json.geometricError

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 
 ##### Fixes :wrench:
 
+- Fixed a regression where older tilesets without a top-level `geometricError` would fail to load. [#9618](https://github.com/CesiumGS/cesium/pull/9618)
 - Fixed an issue in `WebMapTileServiceImageryProvider` where using URL subdomains caused query parameters to be dropped from requests. [#9606](https://github.com/CesiumGS/cesium/pull/9606)
 - Fixed an issue in `ScreenSpaceCameraController.tilt3DOnTerrain` that caused unexpected camera behavior when tilting terrain diagonally along the screen. [#9562](https://github.com/CesiumGS/cesium/pull/9562)
 - Fixed error handling in `GlobeSurfaceTile` to print terrain tile request errors to console. [#9570](https://github.com/CesiumGS/cesium/pull/9570)

--- a/Source/Scene/preprocess3DTileContent.js
+++ b/Source/Scene/preprocess3DTileContent.js
@@ -43,7 +43,7 @@ export default function preprocess3DTileContent(arrayBuffer) {
   }
 
   var json = getJsonContent(uint8Array);
-  if (defined(json.geometricError)) {
+  if (defined(json.root)) {
     // Most likely a tileset JSON
     return {
       contentType: Cesium3DTileContentType.EXTERNAL_TILESET,

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -5102,7 +5102,7 @@ describe(
             asset: {
               version: "1.0",
             },
-            geometricError: 100.0,
+            root: {},
           };
           var buffer = generateJsonBuffer(externalTileset).buffer;
           return when.resolve(buffer);


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/9590

Due to the absence of content identifiers in tileset.json `preprocess3DTileContent.js` needs to look at either the header of the binary content or the properties of the JSON content in order to determine the type of content (e.g. b3dm, i3dm, external tileset JSON, glTF, glb).

For JSON the way to distinguish external tilesets from glTF was to see if the json had a `geometricError` property, since tilesets have this property but glTF does not.

```
if (defined(json.geometricError)) {
  // Most likely a tileset JSON
  ...
}
```

However some older tilesets don't have this property. A safer thing to do is to check for `root` which is another required property. If this problem shows up again we'll have to come up with a better approach.

Thanks to @baothientran for finding an asset that had this problem and providing clues for fixing this.