### PR TITLE
Enable ImageBitmap again for external images in Model

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 - Fixed broken image URL in the KML Sandcastle. [#9579](https://github.com/CesiumGS/cesium/pull/9579)
 - Fixed an error where the `positionToEyeEC` and `tangentToEyeMatrix` properties for custom materials were not set in `GlobeFS`. [#9597](https://github.com/CesiumGS/cesium/pull/9597)
 - Fixed misleading documentation in `Matrix4.inverse` and `Matrix4.inverseTransformation` that used "affine transformation" instead of "rotation and translation" specifically. [#9608](https://github.com/CesiumGS/cesium/pull/9608)
+- Fixed a regression where external images in glTF models were not being loaded with `preferImageBitmap`, which caused them to decode on the main thread and cause frame rate stuttering. [#9627](https://github.com/CesiumGS/cesium/pull/9627)
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/Source/Scene/GltfImageLoader.js
+++ b/Source/Scene/GltfImageLoader.js
@@ -275,7 +275,9 @@ function loadImageFromUri(resource) {
     return loadCRN(resource);
   }
   // Resolves to an ImageBitmap or Image
-  return resource.fetchImage();
+  return resource.fetchImage({
+    preferImageBitmap: true,
+  });
 }
 
 /**

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -2032,7 +2032,9 @@ function parseTextures(model, context, supportsWebP) {
       } else if (crnRegex.test(uri)) {
         promise = loadCRN(imageResource);
       } else {
-        promise = imageResource.fetchImage();
+        promise = imageResource.fetchImage({
+          preferImageBitmap: true,
+        });
       }
       promise
         .then(imageLoad(model, id, imageId))


### PR DESCRIPTION
`ImageBitmap` was added in https://github.com/CesiumGS/cesium/pull/7579 to reduce frame rate hitches when loading models and a follow up PR was added to fix a regression for images that were being flipped incorrectly https://github.com/CesiumGS/cesium/pull/7701. The PR added a flag called `preferImageBitmap` and each system now had to opt-in to using `ImageBitmap`. While reviewing https://github.com/CesiumGS/cesium/pull/9624 I noticed a pretty big omission where calls to `fetchImage` in `Model.js` were not setting this flag to true and were not taking advantage of `ImageBitmap`. Note that this was only happening for **external** images; embedded images were fine because they go through a different code path, `loadImageFromTypedArray`, which defaults to using `ImageBitmap` if available. Thankfully embedded images are much more common in 3D Tiles so the regression wasn't super serious.

This wasn't mentioned in the PR at all so I think it was a mistake rather than intentional. I looked at all the sample models and everything still looks correct after the change. I also tested the bike model in https://github.com/CesiumGS/cesium/pull/7579 and saw the expected improvement.

I fixed this in `GltfImageLoader` too which will be used as part of the model rewrite.