### PR TITLE
Fix name of TextureReader property

### DIFF
--- a/Source/Scene/ModelComponents.js
+++ b/Source/Scene/ModelComponents.js
@@ -661,7 +661,7 @@ function TextureReader() {
    * @type {Texture}
    * @private
    */
-  this.textureReader = undefined;
+  this.texture = undefined;
 
   /**
    * The texture coordinate set.


### PR DESCRIPTION
A small mistake from https://github.com/CesiumGS/cesium/pull/9595/commits/b891542f28398e6c1d88c42ddc875bf659bd2c4e. The property inside `TextureReader` should be called `texture` not `textureReader`.