### PR TITLE
Fix ability to "unset" material image

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 1.84 - 2021-08-01
+
+##### Fixes :wrench:
+
+- Fixed the ability to set a material's image to `undefined` and `Material.DefaultImageId`. [#9644](https://github.com/CesiumGS/cesium/pull/9644)
+
 ### 1.83 - 2021-07-01
 
 ##### Breaking Changes :mega:
@@ -34,7 +40,6 @@
 - Fixed a regression where external images in glTF models were not being loaded with `preferImageBitmap`, which caused them to decode on the main thread and cause frame rate stuttering. [#9627](https://github.com/CesiumGS/cesium/pull/9627)
 - Fixed misleading "else" case condition for `color` and `show` in `Cesium3DTileStyle`. A default `color` value is used if no `color` conditions are given. The default value for `show`, `true`, is used if no `show` conditions are given. [#9633](https://github.com/CesiumGS/cesium/pull/9633)
 - Fixed a crash that occurred after disabling and re-enabling a post-processing stage. This also prevents the screen from randomly flashing when enabling stages for the first time. [#9649](https://github.com/CesiumGS/cesium/pull/9649)
-- Fixed the ability to set a material's image to `undefined` and `Material.DefaultImageId`. [#9644](https://github.com/CesiumGS/cesium/pull/9644)
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@
 - Fixed a regression where external images in glTF models were not being loaded with `preferImageBitmap`, which caused them to decode on the main thread and cause frame rate stuttering. [#9627](https://github.com/CesiumGS/cesium/pull/9627)
 - Fixed misleading "else" case condition for `color` and `show` in `Cesium3DTileStyle`. A default `color` value is used if no `color` conditions are given. The default value for `show`, `true`, is used if no `show` conditions are given. [#9633](https://github.com/CesiumGS/cesium/pull/9633)
 - Fixed a crash that occurred after disabling and re-enabling a post-processing stage. This also prevents the screen from randomly flashing when enabling stages for the first time. [#9649](https://github.com/CesiumGS/cesium/pull/9649)
+- Fixed the ability to set a material's image to `undefined` and `Material.DefaultImageId`. [#9644](https://github.com/CesiumGS/cesium/pull/9644)
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/Source/Core/Resource.js
+++ b/Source/Core/Resource.js
@@ -1026,7 +1026,6 @@ function fetchImage(options) {
     if (request.state !== RequestState.FAILED) {
       return when.reject(e);
     }
-
     return resource.retryOnError(e).then(function (retry) {
       if (retry) {
         // Reset request so it can try again
@@ -1040,7 +1039,6 @@ function fetchImage(options) {
           preferImageBitmap: preferImageBitmap,
         });
       }
-
       return when.reject(e);
     });
   });

--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -795,6 +795,12 @@ function createTexture2DUpdateFunction(uniformId) {
     var uniforms = material.uniforms;
     var uniformValue = uniforms[uniformId];
     var uniformChanged = oldUniformValue !== uniformValue;
+
+    var uniformValueIsDefaultImage = uniformValue === Material.DefaultImageId;
+    var oldUniformValueDefined = defined(oldUniformValue);
+    var oldUniformValueIsDefaultImage =
+      oldUniformValue === Material.DefaultImageId;
+
     oldUniformValue = uniformValue;
     var texture = material._textures[uniformId];
 
@@ -853,16 +859,18 @@ function createTexture2DUpdateFunction(uniformId) {
       return;
     }
 
-    if (uniformChanged) {
-      if (!defined(uniformValue) && defined(texture)) {
-        texture.destroy();
+    if (uniformChanged && defined(texture)) {
+      if (!defined(uniformValue) || uniformValueIsDefaultImage) {
+        if (oldUniformValueDefined && !oldUniformValueIsDefaultImage) {
+          texture.destroy();
+        }
         texture = undefined;
       }
     }
 
     if (!defined(texture)) {
       material._texturePaths[uniformId] = undefined;
-      if (!defined(material._defaultTexture)) {
+      if (uniformValueIsDefaultImage || !defined(material._defaultTexture)) {
         material._defaultTexture = context.defaultTexture;
       }
       texture = material._textures[uniformId] = material._defaultTexture;
@@ -875,7 +883,7 @@ function createTexture2DUpdateFunction(uniformId) {
       }
     }
 
-    if (uniformValue === Material.DefaultImageId) {
+    if (!defined(uniformValue) || uniformValueIsDefaultImage) {
       return;
     }
 

--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -427,7 +427,6 @@ Material.prototype.update = function (context) {
 
   var loadedImages = this._loadedImages;
   var length = loadedImages.length;
-
   for (i = 0; i < length; ++i) {
     var loadedImage = loadedImages[i];
     uniformId = loadedImage.id;
@@ -878,7 +877,6 @@ function createTexture2DUpdateFunction(uniformId) {
       } else {
         texture = material._textures[uniformId] = material._defaultTexture;
       }
-
       uniformDimensionsName = uniformId + "Dimensions";
       if (uniforms.hasOwnProperty(uniformDimensionsName)) {
         uniformDimensions = uniforms[uniformDimensionsName];

--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -870,10 +870,14 @@ function createTexture2DUpdateFunction(uniformId) {
 
     if (!defined(texture)) {
       material._texturePaths[uniformId] = undefined;
-      if (uniformValueIsDefaultImage || !defined(material._defaultTexture)) {
+      if (!defined(material._defaultTexture)) {
         material._defaultTexture = context.defaultTexture;
       }
-      texture = material._textures[uniformId] = material._defaultTexture;
+      if (uniformValueIsDefaultImage) {
+        texture = material._textures[uniformId] = context.defaultTexture;
+      } else {
+        texture = material._textures[uniformId] = material._defaultTexture;
+      }
 
       uniformDimensionsName = uniformId + "Dimensions";
       if (uniforms.hasOwnProperty(uniformDimensionsName)) {

--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -843,7 +843,7 @@ function createTexture2DUpdateFunction(uniformId) {
     if (uniformValue instanceof Texture && uniformValue !== texture) {
       material._texturePaths[uniformId] = undefined;
       var tmp = material._textures[uniformId];
-      if (tmp !== material._defaultTexture) {
+      if (defined(tmp) && tmp !== material._defaultTexture) {
         tmp.destroy();
       }
       material._textures[uniformId] = uniformValue;

--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -853,6 +853,13 @@ function createTexture2DUpdateFunction(uniformId) {
       return;
     }
 
+    if (uniformChanged && defined(texture)) {
+      if (!defined(uniforms.image)) {
+        texture.destroy();
+        uniformValue = texture = undefined;
+      }
+    }
+
     if (!defined(texture)) {
       material._texturePaths[uniformId] = undefined;
       if (!defined(material._defaultTexture)) {

--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -473,6 +473,14 @@ Material.prototype.update = function (context) {
       });
     }
 
+    // The material destroys its old texture only after the new one has been loaded.
+    // This will ensure a smooth swap of textures and prevent the default texture
+    // from appearing for a few frames.
+    var oldTexture = this._textures[uniformId];
+    if (defined(oldTexture) && oldTexture !== this._defaultTexture) {
+      oldTexture.destroy();
+    }
+
     this._textures[uniformId] = texture;
 
     var uniformDimensionsName = uniformId + "Dimensions";
@@ -858,14 +866,14 @@ function createTexture2DUpdateFunction(uniformId) {
       return;
     }
 
-    if (uniformChanged && defined(texture)) {
+    if (uniformChanged && defined(texture) && uniformValueIsDefaultImage) {
+      // If the newly-assigned texture is the default texture,
+      // we don't need to wait for a new image to load before destroying
+      // the old texture.
       if (texture !== material._defaultTexture) {
         texture.destroy();
       }
-
-      if (uniformValueIsDefaultImage) {
-        texture = undefined;
-      }
+      texture = undefined;
     }
 
     if (!defined(texture)) {

--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -853,10 +853,10 @@ function createTexture2DUpdateFunction(uniformId) {
       return;
     }
 
-    if (uniformChanged && defined(texture)) {
-      if (!defined(uniforms.image)) {
+    if (uniformChanged) {
+      if (!defined(uniformValue) && defined(texture)) {
         texture.destroy();
-        uniformValue = texture = undefined;
+        texture = undefined;
       }
     }
 

--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -422,9 +422,7 @@ Material.prototype.isTranslucent = function () {
  * @private
  */
 Material.prototype.update = function (context) {
-  if (!defined(this._defaultTexture)) {
-    this._defaultTexture = context.defaultTexture;
-  }
+  this._defaultTexture = context.defaultTexture;
 
   var i;
   var uniformId;
@@ -923,6 +921,9 @@ function createTexture2DUpdateFunction(uniformId) {
             });
           })
           .otherwise(function () {
+            if (defined(texture) && texture !== material._defaultTexture) {
+              texture.destroy();
+            }
             material._textures[uniformId] = material._defaultTexture;
           });
       } else if (

--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -469,15 +469,6 @@ Material.prototype.update = function (context) {
       });
     }
 
-    var oldTexture = this._textures[uniformId];
-    if (
-      defined(oldTexture) &&
-      oldTexture !== this.defaultTexture &&
-      oldTexture !== context.defaultTexture
-    ) {
-      oldTexture.destroy();
-    }
-
     this._textures[uniformId] = texture;
 
     var uniformDimensionsName = uniformId + "Dimensions";
@@ -803,10 +794,11 @@ function createTexture2DUpdateFunction(uniformId) {
     var uniforms = material.uniforms;
     var uniformValue = uniforms[uniformId];
     var uniformChanged = oldUniformValue !== uniformValue;
-    var uniformValueIsDefaultImage = uniformValue === Material.DefaultImageId;
+    var uniformValueIsDefaultImage =
+      !defined(uniformValue) || uniformValue === Material.DefaultImageId;
+    oldUniformValue = uniformValue;
 
     var texture = material._textures[uniformId];
-    oldUniformValue = uniformValue;
     var uniformDimensionsName;
     var uniformDimensions;
 
@@ -863,7 +855,14 @@ function createTexture2DUpdateFunction(uniformId) {
     }
 
     if (uniformChanged && defined(texture)) {
-      if (!defined(uniformValue) || uniformValueIsDefaultImage) {
+      if (
+        texture !== this.defaultTexture &&
+        texture !== context.defaultTexture
+      ) {
+        texture.destroy();
+      }
+
+      if (uniformValueIsDefaultImage) {
         texture = undefined;
       }
     }
@@ -886,7 +885,7 @@ function createTexture2DUpdateFunction(uniformId) {
       }
     }
 
-    if (!defined(uniformValue) || uniformValueIsDefaultImage) {
+    if (uniformValueIsDefaultImage) {
       return;
     }
 

--- a/Specs/Scene/MaterialSpec.js
+++ b/Specs/Scene/MaterialSpec.js
@@ -686,13 +686,10 @@ describe(
       });
 
       material.uniforms.image = "./Data/Images/Green.png";
-      return pollToPromise(
-        function () {
-          renderMaterial(material, true);
-          return material._textures["image"] !== material._defaultTexture;
-        },
-        { timeout: 10000 }
-      ).then(function () {
+      return pollToPromise(function () {
+        renderMaterial(material, true);
+        return material._textures["image"] !== material._defaultTexture;
+      }).then(function () {
         renderMaterial(material, true, function (rgba) {
           expect(rgba).toEqual([0, 255, 0, 255]);
         });
@@ -710,13 +707,10 @@ describe(
       });
 
       material.uniforms.image = "./Data/Images/Green.png";
-      return pollToPromise(
-        function () {
-          renderMaterial(material, true);
-          return material._textures["image"] !== material._defaultTexture;
-        },
-        { timeout: 10000 }
-      ).then(function () {
+      return pollToPromise(function () {
+        renderMaterial(material, true);
+        return material._textures["image"] !== material._defaultTexture;
+      }).then(function () {
         renderMaterial(material, true, function (rgba) {
           expect(rgba).toEqual([0, 255, 0, 255]);
         });
@@ -729,26 +723,18 @@ describe(
         color: Color.WHITE,
       });
 
-      return pollToPromise(
-        function () {
-          renderMaterial(material, true);
-          return material._textures["image"] !== material._defaultTexture;
-        },
-        { timeout: 10000 }
-      )
-        .then(function () {
-          renderMaterial(material, true, function (rgba) {
-            expect(rgba).toEqual([0, 255, 0, 255]);
-          });
-        })
-        .then(function () {
-          material.uniforms.image = undefined;
-        })
-        .then(function () {
-          renderMaterial(material, true, function (rgba) {
-            expect(rgba).toEqual([255, 255, 255, 255]);
-          });
+      return pollToPromise(function () {
+        renderMaterial(material, true);
+        return material._textures["image"] !== material._defaultTexture;
+      }).then(function () {
+        renderMaterial(material, true, function (rgba) {
+          expect(rgba).toEqual([0, 255, 0, 255]);
         });
+        material.uniforms.image = undefined;
+        renderMaterial(material, true, function (rgba) {
+          expect(rgba).toEqual([255, 255, 255, 255]);
+        });
+      });
     });
 
     it("handles when material image is changed from some image to default", function () {
@@ -757,26 +743,18 @@ describe(
         color: Color.WHITE,
       });
 
-      return pollToPromise(
-        function () {
-          renderMaterial(material, true);
-          return material._textures["image"] !== material._defaultTexture;
-        },
-        { timeout: 10000 }
-      )
-        .then(function () {
-          renderMaterial(material, true, function (rgba) {
-            expect(rgba).toEqual([0, 255, 0, 255]);
-          });
-        })
-        .then(function () {
-          material.uniforms.image = Material.DefaultImageId;
-        })
-        .then(function () {
-          renderMaterial(material, true, function (rgba) {
-            expect(rgba).toEqual([255, 255, 255, 255]);
-          });
+      return pollToPromise(function () {
+        renderMaterial(material, true);
+        return material._textures["image"] !== material._defaultTexture;
+      }).then(function () {
+        renderMaterial(material, true, function (rgba) {
+          expect(rgba).toEqual([0, 255, 0, 255]);
         });
+        material.uniforms.image = Material.DefaultImageId;
+        renderMaterial(material, true, function (rgba) {
+          expect(rgba).toEqual([255, 255, 255, 255]);
+        });
+      });
     });
 
     it("handles when material image is changed from some image to another", function () {
@@ -786,35 +764,24 @@ describe(
       });
       var greenTextureId;
 
-      return pollToPromise(
-        function () {
+      return pollToPromise(function () {
+        renderMaterial(material, true);
+        return material._textures["image"] !== material._defaultTexture;
+      }).then(function () {
+        greenTextureId = material._textures["image"].id;
+        renderMaterial(material, true, function (rgba) {
+          expect(rgba).toEqual([0, 255, 0, 255]);
+        });
+        material.uniforms.image = "./Data/Images/Blue.png";
+        return pollToPromise(function () {
           renderMaterial(material, true);
-          return material._textures["image"] !== material._defaultTexture;
-        },
-        { timeout: 10000 }
-      )
-        .then(function () {
-          greenTextureId = material._textures["image"].id;
+          return material._textures["image"].id !== greenTextureId;
+        }).then(function () {
           renderMaterial(material, true, function (rgba) {
-            expect(rgba).toEqual([0, 255, 0, 255]);
-          });
-        })
-        .then(function () {
-          material.uniforms.image = "./Data/Images/Blue.png";
-        })
-        .then(function () {
-          return pollToPromise(
-            function () {
-              renderMaterial(material, true);
-              return material._textures["image"].id !== greenTextureId;
-            },
-            { timeout: 10000 }
-          ).then(function () {
-            renderMaterial(material, true, function (rgba) {
-              expect(rgba).toEqual([0, 0, 255, 255]);
-            });
+            expect(rgba).toEqual([0, 0, 255, 255]);
           });
         });
+      });
     });
 
     it("handles when material image is changed from some image to invalid image", function () {
@@ -824,35 +791,24 @@ describe(
       });
       var greenTextureId;
 
-      return pollToPromise(
-        function () {
+      return pollToPromise(function () {
+        renderMaterial(material, true);
+        return material._textures["image"] !== material._defaultTexture;
+      }).then(function () {
+        greenTextureId = material._textures["image"].id;
+        renderMaterial(material, true, function (rgba) {
+          expect(rgba).toEqual([0, 255, 0, 255]);
+        });
+        material.uniforms.image = "i_dont_exist.png";
+        return pollToPromise(function () {
           renderMaterial(material, true);
-          return material._textures["image"] !== material._defaultTexture;
-        },
-        { timeout: 10000 }
-      )
-        .then(function () {
-          greenTextureId = material._textures["image"].id;
+          return material._textures["image"].id !== greenTextureId;
+        }).then(function () {
           renderMaterial(material, true, function (rgba) {
-            expect(rgba).toEqual([0, 255, 0, 255]);
-          });
-        })
-        .then(function () {
-          material.uniforms.image = "i_dont_exist.png";
-        })
-        .then(function () {
-          return pollToPromise(
-            function () {
-              renderMaterial(material, true);
-              return material._textures["image"].id !== greenTextureId;
-            },
-            { timeout: 10000 }
-          ).then(function () {
-            renderMaterial(material, true, function (rgba) {
-              expect(rgba).toEqual([255, 255, 255, 255]);
-            });
+            expect(rgba).toEqual([255, 255, 255, 255]);
           });
         });
+      });
     });
 
     it("throws with source and components in same template", function () {

--- a/Specs/Scene/MaterialSpec.js
+++ b/Specs/Scene/MaterialSpec.js
@@ -817,6 +817,44 @@ describe(
         });
     });
 
+    it("handles when material image is changed from some image to invalid image", function () {
+      var material = Material.fromType(Material.ImageType, {
+        image: "./Data/Images/Green.png",
+        color: Color.WHITE,
+      });
+      var greenTextureId;
+
+      return pollToPromise(
+        function () {
+          renderMaterial(material, true);
+          return material._textures["image"] !== material._defaultTexture;
+        },
+        { timeout: 10000 }
+      )
+        .then(function () {
+          greenTextureId = material._textures["image"].id;
+          renderMaterial(material, true, function (rgba) {
+            expect(rgba).toEqual([0, 255, 0, 255]);
+          });
+        })
+        .then(function () {
+          material.uniforms.image = "i_dont_exist.png";
+        })
+        .then(function () {
+          return pollToPromise(
+            function () {
+              renderMaterial(material, true);
+              return material._textures["image"].id !== greenTextureId;
+            },
+            { timeout: 10000 }
+          ).then(function () {
+            renderMaterial(material, true, function (rgba) {
+              expect(rgba).toEqual([255, 255, 255, 255]);
+            });
+          });
+        });
+    });
+
     it("throws with source and components in same template", function () {
       expect(function () {
         return new Material({

--- a/Specs/Scene/MaterialSpec.js
+++ b/Specs/Scene/MaterialSpec.js
@@ -655,6 +655,168 @@ describe(
         });
     });
 
+    it("handles when material image is undefined", function () {
+      var material = Material.fromType(Material.ImageType, {
+        image: undefined,
+        color: Color.RED,
+      });
+      renderMaterial(material, false, function (rgba) {
+        expect(rgba).toEqual([255, 0, 0, 255]);
+      });
+    });
+
+    it("handles when material image is set to default image", function () {
+      var material = Material.fromType(Material.ImageType, {
+        image: Material.DefaultImageId,
+        color: Color.RED,
+      });
+      renderMaterial(material, false, function (rgba) {
+        expect(rgba).toEqual([255, 0, 0, 255]);
+      });
+    });
+
+    it("handles when material image is changed from undefined to some image", function () {
+      var material = Material.fromType(Material.ImageType, {
+        image: undefined,
+        color: Color.WHITE,
+      });
+
+      renderMaterial(material, false, function (rgba) {
+        expect(rgba).toEqual([255, 255, 255, 255]);
+      });
+
+      material.uniforms.image = "./Data/Images/Green.png";
+      return pollToPromise(
+        function () {
+          renderMaterial(material, true);
+          return material._textures["image"] !== material._defaultTexture;
+        },
+        { timeout: 10000 }
+      ).then(function () {
+        renderMaterial(material, true, function (rgba) {
+          expect(rgba).toEqual([0, 255, 0, 255]);
+        });
+      });
+    });
+
+    it("handles when material image is changed from default to some image", function () {
+      var material = Material.fromType(Material.ImageType, {
+        image: Material.DefaultImageId,
+        color: Color.WHITE,
+      });
+
+      renderMaterial(material, false, function (rgba) {
+        expect(rgba).toEqual([255, 255, 255, 255]);
+      });
+
+      material.uniforms.image = "./Data/Images/Green.png";
+      return pollToPromise(
+        function () {
+          renderMaterial(material, true);
+          return material._textures["image"] !== material._defaultTexture;
+        },
+        { timeout: 10000 }
+      ).then(function () {
+        renderMaterial(material, true, function (rgba) {
+          expect(rgba).toEqual([0, 255, 0, 255]);
+        });
+      });
+    });
+
+    it("handles when material image is changed from some image to undefined", function () {
+      var material = Material.fromType(Material.ImageType, {
+        image: "./Data/Images/Green.png",
+        color: Color.WHITE,
+      });
+
+      return pollToPromise(
+        function () {
+          renderMaterial(material, true);
+          return material._textures["image"] !== material._defaultTexture;
+        },
+        { timeout: 10000 }
+      )
+        .then(function () {
+          renderMaterial(material, true, function (rgba) {
+            expect(rgba).toEqual([0, 255, 0, 255]);
+          });
+        })
+        .then(function () {
+          material.uniforms.image = undefined;
+        })
+        .then(function () {
+          renderMaterial(material, true, function (rgba) {
+            expect(rgba).toEqual([255, 255, 255, 255]);
+          });
+        });
+    });
+
+    it("handles when material image is changed from some image to default", function () {
+      var material = Material.fromType(Material.ImageType, {
+        image: "./Data/Images/Green.png",
+        color: Color.WHITE,
+      });
+
+      return pollToPromise(
+        function () {
+          renderMaterial(material, true);
+          return material._textures["image"] !== material._defaultTexture;
+        },
+        { timeout: 10000 }
+      )
+        .then(function () {
+          renderMaterial(material, true, function (rgba) {
+            expect(rgba).toEqual([0, 255, 0, 255]);
+          });
+        })
+        .then(function () {
+          material.uniforms.image = Material.DefaultImageId;
+        })
+        .then(function () {
+          renderMaterial(material, true, function (rgba) {
+            expect(rgba).toEqual([255, 255, 255, 255]);
+          });
+        });
+    });
+
+    it("handles when material image is changed from some image to another", function () {
+      var material = Material.fromType(Material.ImageType, {
+        image: "./Data/Images/Green.png",
+        color: Color.WHITE,
+      });
+      var greenTextureId;
+
+      return pollToPromise(
+        function () {
+          renderMaterial(material, true);
+          return material._textures["image"] !== material._defaultTexture;
+        },
+        { timeout: 10000 }
+      )
+        .then(function () {
+          greenTextureId = material._textures["image"].id;
+          renderMaterial(material, true, function (rgba) {
+            expect(rgba).toEqual([0, 255, 0, 255]);
+          });
+        })
+        .then(function () {
+          material.uniforms.image = "./Data/Images/Blue.png";
+        })
+        .then(function () {
+          return pollToPromise(
+            function () {
+              renderMaterial(material, true);
+              return material._textures["image"].id !== greenTextureId;
+            },
+            { timeout: 10000 }
+          ).then(function () {
+            renderMaterial(material, true, function (rgba) {
+              expect(rgba).toEqual([0, 0, 255, 255]);
+            });
+          });
+        });
+    });
+
     it("throws with source and components in same template", function () {
       expect(function () {
         return new Material({


### PR DESCRIPTION
Will fix #9385. Not complete, but I had some questions about [this block of code.](https://github.com/CesiumGS/cesium/blob/master/Source/Scene/Material.js#L856-L873)

1. I added something to the material update function (which comes from `createTexture2DUpdateFunction`) that can handle when the value of an image is undefined. However, I'm unclear about the intended behavior of this function when it has no texture. It seems that if a texture is not defined, it wants to define some default texture anyway -- is that what we want?
2. Regarding `"czm_defaultImage"`: is this default image being created anywhere? The function just returns early if `uniformValue === Material.DefaultImageId`, so I'm not sure if the `texture` property is actually being set.

I'm still addressing a bug where if you alternate between `czm_defaultImage` and `undefined`, some random image appears -- not sure what it is.

cc: @lilleyse @ebogo1