### PR TITLE
NetworkLinkControl Updates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### NEXT RELEASE
+
+##### Additions :tada:
+
+- Added support for NetworkLinkControl Updates (Change, Create, and Delete elements). [#9647](https://github.com/CesiumGS/cesium/pull/9647)
+
 ### 1.85 - 2021-09-01
 
 ##### Breaking Changes :mega:

--- a/Source/DataSources/NetworkLinkUpdateMgr.js
+++ b/Source/DataSources/NetworkLinkUpdateMgr.js
@@ -1,0 +1,123 @@
+import defined from "../Core/defined.js";
+
+/**
+ * NetworkLinkUpdateMgr keeps track kmls that are loaded from network links so that
+ * they can be updated later.
+ *
+ * When an 'Update' link is loaded, the manager will use the link's targetHref to
+ * find the stored kml and updated it.
+ */
+export default function NetworkLinkUpdateMgr() {
+  this._links = {};
+  this._sourceToUrl = {};
+}
+
+NetworkLinkUpdateMgr.prototype.addLink = function (href, kml, dataSource) {
+  this._links[href.request.url] = {
+    kml: kml,
+    dataSource: dataSource,
+  };
+  this._sourceToUrl[dataSource] = href.request.url;
+};
+
+NetworkLinkUpdateMgr.prototype.processUpdate = function (updateNode) {
+  processUpdate(this._links, updateNode);
+};
+
+NetworkLinkUpdateMgr.prototype.removeLink = function (dataSource) {
+  var url = this._sourceToUrl[dataSource];
+  delete this._links[url];
+  delete this._sourceToUrl[dataSource];
+};
+
+function processUpdate(links, updateNode) {
+  var link = links[getUpdateTargetHref(updateNode)];
+  if (!defined(link)) return;
+
+  processUpdateNode(link.kml, updateNode);
+  link.dataSource.load(link.kml).then(function () {
+    link.dataSource._changed.raiseEvent(link);
+  });
+}
+
+function getUpdateTargetHref(updateNode) {
+  var elements = updateNode.getElementsByTagName("targetHref");
+  if (elements.length > 0) return elements[0].innerHTML;
+
+  return undefined;
+}
+
+function processUpdateNode(kmlRoot, updateNode) {
+  forEachChild(updateNode, function (child) {
+    switch (child.tagName) {
+      case "Change":
+        processChangeNodes(kmlRoot, child);
+        break;
+      case "Create":
+        processCreateNodes(kmlRoot, child);
+        break;
+      case "Delete":
+        processDeleteNode(kmlRoot, child);
+        break;
+    }
+  });
+}
+
+function processChangeNodes(root, changeNode) {
+  forEachChild(changeNode, function (child) {
+    processChangeNode(root, child);
+  });
+}
+
+function processChangeNode(root, newNode) {
+  var oldNode = root.getElementById(newNode.getAttribute("targetId"));
+  if (!defined(oldNode)) return;
+
+  forEachChild(newNode, function (newProp) {
+    var oldProp = oldNode.getElementsByTagName(newProp.tagName)[0];
+    if (!defined(oldProp)) return;
+
+    oldNode.replaceChild(newProp, oldProp);
+  });
+}
+
+function processCreateNodes(root, createNode) {
+  forEachChild(createNode, function (child) {
+    processCreateNode(root, child);
+  });
+}
+
+function processCreateNode(root, newParent) {
+  var oldParent = root.getElementById(newParent.getAttribute("targetId"));
+  if (!defined(oldParent)) return;
+
+  forEachChild(newParent, function (child) {
+    oldParent.appendChild(child);
+  });
+}
+
+function processDeleteNode(root, deleteNode) {
+  forEachChild(deleteNode, function (child) {
+    var nodeToDelete = root.getElementById(child.getAttribute("targetId"));
+    if (!defined(nodeToDelete)) return;
+
+    nodeToDelete.parentNode.removeChild(nodeToDelete);
+  });
+}
+
+function forEachChild(parent, callback) {
+  if (!defined(parent.children)) return;
+
+  var children = copyNodes(parent.children);
+
+  for (var i = 0; i < children.length; i++) {
+    callback(children[i]);
+  }
+}
+
+function copyNodes(nodes) {
+  var copy = new Array(nodes.length);
+  for (var i = 0; i < copy.length; i++) {
+    copy[i] = nodes[i];
+  }
+}

--- a/Specs/Data/KML/multiPoint.kml
+++ b/Specs/Data/KML/multiPoint.kml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+<Document id="test-doc">
+	<Placemark id="pm1">
+		<name>PM1</name>
+		<Point>
+			<coordinates>1,2,3</coordinates>
+		</Point>
+	</Placemark>
+    <Placemark id="pm2">
+		<name>PM2</name>
+		<Point>
+			<coordinates>4,5,6</coordinates>
+		</Point>
+	</Placemark>
+    <Placemark id="pm3">
+		<name>PM3</name>
+		<Point>
+			<coordinates>7,8,9</coordinates>
+		</Point>
+	</Placemark>
+</Document>
+</kml>

--- a/Specs/Data/KML/multiPointNetworkLink.kml
+++ b/Specs/Data/KML/multiPointNetworkLink.kml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <NetworkLink id="link">
 	<Link>
-		<href>simple.kml</href>
+		<href>multiPoint.kml</href>
 	</Link>
 </NetworkLink>

--- a/Specs/Data/KML/simple.kml
+++ b/Specs/Data/KML/simple.kml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <kml xmlns="http://www.opengis.net/kml/2.2">
-<Document>
-	<Placemark>
+<Document id="test-doc">
+	<Placemark id='pm1'>
 		<Style>
 			<IconStyle>
 			  <Icon>


### PR DESCRIPTION
Copy of this PR https://github.com/CesiumGS/cesium/pull/9596
Had to change branches (from master) because I'm opening another PR soon for an unrelated fix

Adds support for NewtworkLinkControl Updates

- Every time a KML is loaded from a network link it is saved in a map (href -> {kml, datasource})
- After update, the KML/Z is updated and loaded back into the data source