### PR TITLE
Fix post-processing crash when disabling and re-enabling stages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,7 @@
 - Fixed misleading documentation in `Matrix4.inverse` and `Matrix4.inverseTransformation` that used "affine transformation" instead of "rotation and translation" specifically. [#9608](https://github.com/CesiumGS/cesium/pull/9608)
 - Fixed a regression where external images in glTF models were not being loaded with `preferImageBitmap`, which caused them to decode on the main thread and cause frame rate stuttering. [#9627](https://github.com/CesiumGS/cesium/pull/9627)
 - Fixed misleading "else" case condition for `color` and `show` in `Cesium3DTileStyle`. A default `color` value is used if no `color` conditions are given. The default value for `show`, `true`, is used if no `show` conditions are given. [#9633](https://github.com/CesiumGS/cesium/pull/9633)
-- Fixed a crash that occurred after disabling and re-enabling a post-processing shader. [#9649](https://github.com/CesiumGS/cesium/pull/9649)
+- Fixed a crash that occurred after disabling and re-enabling a post-processing stage. [#9649](https://github.com/CesiumGS/cesium/pull/9649)
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,7 @@
 - Fixed misleading documentation in `Matrix4.inverse` and `Matrix4.inverseTransformation` that used "affine transformation" instead of "rotation and translation" specifically. [#9608](https://github.com/CesiumGS/cesium/pull/9608)
 - Fixed a regression where external images in glTF models were not being loaded with `preferImageBitmap`, which caused them to decode on the main thread and cause frame rate stuttering. [#9627](https://github.com/CesiumGS/cesium/pull/9627)
 - Fixed misleading "else" case condition for `color` and `show` in `Cesium3DTileStyle`. A default `color` value is used if no `color` conditions are given. The default value for `show`, `true`, is used if no `show` conditions are given. [#9633](https://github.com/CesiumGS/cesium/pull/9633)
-- Fixed a crash that occurred after disabling and re-enabling a post-processing shader.
+- Fixed a crash that occurred after disabling and re-enabling a post-processing shader. [#9649](https://github.com/CesiumGS/cesium/pull/9649)
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@
 - Fixed misleading documentation in `Matrix4.inverse` and `Matrix4.inverseTransformation` that used "affine transformation" instead of "rotation and translation" specifically. [#9608](https://github.com/CesiumGS/cesium/pull/9608)
 - Fixed a regression where external images in glTF models were not being loaded with `preferImageBitmap`, which caused them to decode on the main thread and cause frame rate stuttering. [#9627](https://github.com/CesiumGS/cesium/pull/9627)
 - Fixed misleading "else" case condition for `color` and `show` in `Cesium3DTileStyle`. A default `color` value is used if no `color` conditions are given. The default value for `show`, `true`, is used if no `show` conditions are given. [#9633](https://github.com/CesiumGS/cesium/pull/9633)
+- Fixed a crash that occurred after disabling and re-enabling a post-processing shader.
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,7 @@
 - Fixed misleading documentation in `Matrix4.inverse` and `Matrix4.inverseTransformation` that used "affine transformation" instead of "rotation and translation" specifically. [#9608](https://github.com/CesiumGS/cesium/pull/9608)
 - Fixed a regression where external images in glTF models were not being loaded with `preferImageBitmap`, which caused them to decode on the main thread and cause frame rate stuttering. [#9627](https://github.com/CesiumGS/cesium/pull/9627)
 - Fixed misleading "else" case condition for `color` and `show` in `Cesium3DTileStyle`. A default `color` value is used if no `color` conditions are given. The default value for `show`, `true`, is used if no `show` conditions are given. [#9633](https://github.com/CesiumGS/cesium/pull/9633)
-- Fixed a crash that occurred after disabling and re-enabling a post-processing stage. [#9649](https://github.com/CesiumGS/cesium/pull/9649)
+- Fixed a crash that occurred after disabling and re-enabling a post-processing stage. This also prevents the screen from randomly flashing when enabling stages for the first time. [#9649](https://github.com/CesiumGS/cesium/pull/9649)
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/Source/Scene/PostProcessStageCollection.js
+++ b/Source/Scene/PostProcessStageCollection.js
@@ -637,6 +637,7 @@ PostProcessStageCollection.prototype.update = function (
     this._textureCache.updateDependencies();
 
     this._lastEnabledLength = enabledCount;
+    this._lastActiveLength = activeCount;
     this._aoEnabled = aoEnabled;
     this._bloomEnabled = bloomEnabled;
     this._tonemappingEnabled = tonemappingEnabled;

--- a/Source/Scene/PostProcessStageTextureCache.js
+++ b/Source/Scene/PostProcessStageTextureCache.js
@@ -346,7 +346,9 @@ PostProcessStageTextureCache.prototype.update = function (context) {
     collection.fxaa.enabled &&
     collection.fxaa._isSupported(context);
   var needsCheckDimensionsUpdate =
+    !defined(collection._enabledStages) ||
     !defined(collection._activeStages) ||
+    collection._enabledStages.length > 0 ||
     collection._activeStages.length > 0 ||
     aoEnabled ||
     bloomEnabled ||

--- a/Source/Scene/PostProcessStageTextureCache.js
+++ b/Source/Scene/PostProcessStageTextureCache.js
@@ -346,9 +346,7 @@ PostProcessStageTextureCache.prototype.update = function (context) {
     collection.fxaa.enabled &&
     collection.fxaa._isSupported(context);
   var needsCheckDimensionsUpdate =
-    !defined(collection._enabledStages) ||
     !defined(collection._activeStages) ||
-    collection._enabledStages.length > 0 ||
     collection._activeStages.length > 0 ||
     aoEnabled ||
     bloomEnabled ||

--- a/Specs/Scene/PostProcessStageCollectionSpec.js
+++ b/Specs/Scene/PostProcessStageCollectionSpec.js
@@ -23,6 +23,7 @@ describe(
       scene.postProcessStages.fxaa.enabled = false;
       scene.postProcessStages.bloom.enabled = false;
       scene.postProcessStages.ambientOcclusion.enabled = false;
+      scene.postProcessStages.tonemapping = undefined;
     });
 
     it("constructs", function () {
@@ -293,6 +294,87 @@ describe(
       expect(
         scene.postProcessStages.getOutputTexture(stage1.name)
       ).not.toBeDefined();
+    });
+
+    it("shows correct output when single stage is enabled then disabled", function () {
+      var stage = scene.postProcessStages.add(
+        new PostProcessStage({
+          fragmentShader:
+            "void main() { gl_FragColor = vec4(1.0, 0.0, 1.0, 1.0); }",
+        })
+      );
+      scene.renderForSpecs();
+      expect(scene).toRender([255, 0, 255, 255]);
+
+      stage.enabled = false;
+
+      scene.renderForSpecs();
+      expect(scene).toRender([0, 0, 0, 255]);
+    });
+
+    it("shows correct output when single stage is disabled then enabled", function () {
+      var stage = scene.postProcessStages.add(
+        new PostProcessStage({
+          fragmentShader:
+            "void main() { gl_FragColor = vec4(1.0, 0.0, 1.0, 1.0); }",
+        })
+      );
+      stage.enabled = false;
+
+      scene.renderForSpecs();
+      expect(scene).toRender([0, 0, 0, 255]);
+
+      stage.enabled = true;
+
+      scene.renderForSpecs();
+      expect(scene).toRender([255, 0, 255, 255]);
+    });
+
+    it("shows correct output when additional stage is enabled then disabled", function () {
+      scene.postProcessStages.add(
+        new PostProcessStage({
+          fragmentShader:
+            "void main() { gl_FragColor = vec4(1.0, 0.0, 1.0, 1.0); }",
+        })
+      );
+      var stage = scene.postProcessStages.add(
+        new PostProcessStage({
+          fragmentShader:
+            "void main() { gl_FragColor = vec4(0.0, 1.0, 1.0, 1.0); }",
+        })
+      );
+
+      scene.renderForSpecs();
+      expect(scene).toRender([0, 255, 255, 255]);
+
+      stage.enabled = false;
+
+      scene.renderForSpecs();
+      expect(scene).toRender([255, 0, 255, 255]);
+    });
+
+    it("shows correct output when additional stage is disabled then enabled", function () {
+      scene.postProcessStages.add(
+        new PostProcessStage({
+          fragmentShader:
+            "void main() { gl_FragColor = vec4(1.0, 0.0, 1.0, 1.0); }",
+        })
+      );
+      var stage = scene.postProcessStages.add(
+        new PostProcessStage({
+          fragmentShader:
+            "void main() { gl_FragColor = vec4(0.0, 1.0, 1.0, 1.0); }",
+        })
+      );
+      stage.enabled = false;
+
+      scene.renderForSpecs();
+      expect(scene).toRender([255, 0, 255, 255]);
+
+      stage.enabled = true;
+
+      scene.renderForSpecs();
+      expect(scene).toRender([0, 255, 255, 255]);
     });
 
     it("uses Reinhard tonemapping", function () {

--- a/Specs/Scene/PostProcessStageCollectionSpec.js
+++ b/Specs/Scene/PostProcessStageCollectionSpec.js
@@ -23,7 +23,8 @@ describe(
       scene.postProcessStages.fxaa.enabled = false;
       scene.postProcessStages.bloom.enabled = false;
       scene.postProcessStages.ambientOcclusion.enabled = false;
-      scene.postProcessStages.tonemapping = undefined;
+      scene.highDynamicRange = false;
+      scene.primitives.removeAll();
     });
 
     it("constructs", function () {


### PR DESCRIPTION
Fixes #9204, also fixes #9528.

The crashes were happening because the texture cache wouldn't create framebuffers if no stages were marked as active, despite the fact that they are `enabled`. It will now create framebuffers if at least one stage is enabled.

I ran the unit tests and looked through all of the post-processing Sandcastles, and I don't believe this change introduced any other bugs.

cc: @lilleyse @ebogo1 