### PR TITLE
Update TileBoundingRegion.distanceToCamera to use OBB distance in 3D

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@
 - Fixed a regression where older tilesets without a top-level `geometricError` would fail to load. [#9618](https://github.com/CesiumGS/cesium/pull/9618)
 - Fixed an issue in `WebMapTileServiceImageryProvider` where using URL subdomains caused query parameters to be dropped from requests. [#9606](https://github.com/CesiumGS/cesium/pull/9606)
 - Fixed an issue in `ScreenSpaceCameraController.tilt3DOnTerrain` that caused unexpected camera behavior when tilting terrain diagonally along the screen. [#9562](https://github.com/CesiumGS/cesium/pull/9562)
+- Fixed an issue in `TileBoundingRegion.distanceToCamera` that caused incorrect results when the camera was on the opposite site of the globe. [#9652](https://github.com/CesiumGS/cesium/pull/9652)
 - Fixed error handling in `GlobeSurfaceTile` to print terrain tile request errors to console. [#9570](https://github.com/CesiumGS/cesium/pull/9570)
 - Fixed broken image URL in the KML Sandcastle. [#9579](https://github.com/CesiumGS/cesium/pull/9579)
 - Fixed an error where the `positionToEyeEC` and `tangentToEyeMatrix` properties for custom materials were not set in `GlobeFS`. [#9597](https://github.com/CesiumGS/cesium/pull/9597)

--- a/Source/Scene/TileBoundingRegion.js
+++ b/Source/Scene/TileBoundingRegion.js
@@ -409,19 +409,19 @@ function distanceToCameraRegion(tileBB, frameState) {
 TileBoundingRegion.prototype.distanceToCamera = function (frameState) {
   //>>includeStart('debug', pragmas.debug);
   Check.defined("frameState", frameState);
-  //>>includeEnd('debug');(
+  //>>includeEnd('debug');
+
   var regionResult = distanceToCameraRegion(this, frameState);
   if (
-    frameState.mode == SceneMode.SCENE3D &&
+    frameState.mode === SceneMode.SCENE3D &&
     defined(this._orientedBoundingBox)
   ) {
     var obbResult = Math.sqrt(
       this._orientedBoundingBox.distanceSquaredTo(frameState.camera.positionWC)
     );
     return Math.max(regionResult, obbResult);
-  } else {
-    return regionResult;
   }
+  return regionResult;
 };
 
 /**

--- a/Source/Scene/TileBoundingRegion.js
+++ b/Source/Scene/TileBoundingRegion.js
@@ -4,6 +4,7 @@ import Cartographic from "../Core/Cartographic.js";
 import Check from "../Core/Check.js";
 import ColorGeometryInstanceAttribute from "../Core/ColorGeometryInstanceAttribute.js";
 import defaultValue from "../Core/defaultValue.js";
+import defined from "../Core/defined.js";
 import Ellipsoid from "../Core/Ellipsoid.js";
 import GeometryInstance from "../Core/GeometryInstance.js";
 import IntersectionTests from "../Core/IntersectionTests.js";
@@ -299,39 +300,30 @@ var negativeUnitY = new Cartesian3(0.0, -1.0, 0.0);
 var negativeUnitZ = new Cartesian3(0.0, 0.0, -1.0);
 var vectorScratch = new Cartesian3();
 
-/**
- * Gets the distance from the camera to the closest point on the tile.  This is used for level of detail selection.
- *
- * @param {FrameState} frameState The state information of the current rendering frame.
- * @returns {Number} The distance from the camera to the closest point on the tile, in meters.
- */
-TileBoundingRegion.prototype.distanceToCamera = function (frameState) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.defined("frameState", frameState);
-  //>>includeEnd('debug');
+function distanceToCameraRegion(tileBB, frameState) {
   var camera = frameState.camera;
   var cameraCartesianPosition = camera.positionWC;
   var cameraCartographicPosition = camera.positionCartographic;
 
   var result = 0.0;
-  if (!Rectangle.contains(this.rectangle, cameraCartographicPosition)) {
-    var southwestCornerCartesian = this.southwestCornerCartesian;
-    var northeastCornerCartesian = this.northeastCornerCartesian;
-    var westNormal = this.westNormal;
-    var southNormal = this.southNormal;
-    var eastNormal = this.eastNormal;
-    var northNormal = this.northNormal;
+  if (!Rectangle.contains(tileBB.rectangle, cameraCartographicPosition)) {
+    var southwestCornerCartesian = tileBB.southwestCornerCartesian;
+    var northeastCornerCartesian = tileBB.northeastCornerCartesian;
+    var westNormal = tileBB.westNormal;
+    var southNormal = tileBB.southNormal;
+    var eastNormal = tileBB.eastNormal;
+    var northNormal = tileBB.northNormal;
 
     if (frameState.mode !== SceneMode.SCENE3D) {
       southwestCornerCartesian = frameState.mapProjection.project(
-        Rectangle.southwest(this.rectangle),
+        Rectangle.southwest(tileBB.rectangle),
         southwestCornerScratch
       );
       southwestCornerCartesian.z = southwestCornerCartesian.y;
       southwestCornerCartesian.y = southwestCornerCartesian.x;
       southwestCornerCartesian.x = 0.0;
       northeastCornerCartesian = frameState.mapProjection.project(
-        Rectangle.northeast(this.rectangle),
+        Rectangle.northeast(tileBB.rectangle),
         northeastCornerScratch
       );
       northeastCornerCartesian.z = northeastCornerCartesian.y;
@@ -389,8 +381,8 @@ TileBoundingRegion.prototype.distanceToCamera = function (frameState) {
   var maximumHeight;
   if (frameState.mode === SceneMode.SCENE3D) {
     cameraHeight = cameraCartographicPosition.height;
-    minimumHeight = this.minimumHeight;
-    maximumHeight = this.maximumHeight;
+    minimumHeight = tileBB.minimumHeight;
+    maximumHeight = tileBB.maximumHeight;
   } else {
     cameraHeight = cameraCartesianPosition.x;
     minimumHeight = 0.0;
@@ -406,6 +398,30 @@ TileBoundingRegion.prototype.distanceToCamera = function (frameState) {
   }
 
   return Math.sqrt(result);
+}
+
+/**
+ * Gets the distance from the camera to the closest point on the tile.  This is used for level of detail selection.
+ *
+ * @param {FrameState} frameState The state information of the current rendering frame.
+ * @returns {Number} The distance from the camera to the closest point on the tile, in meters.
+ */
+TileBoundingRegion.prototype.distanceToCamera = function (frameState) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.defined("frameState", frameState);
+  //>>includeEnd('debug');(
+  var regionResult = distanceToCameraRegion(this, frameState);
+  if (
+    frameState.mode == SceneMode.SCENE3D &&
+    defined(this._orientedBoundingBox)
+  ) {
+    var obbResult = Math.sqrt(
+      this._orientedBoundingBox.distanceSquaredTo(frameState.camera.positionWC)
+    );
+    return Math.max(regionResult, obbResult);
+  } else {
+    return regionResult;
+  }
 };
 
 /**


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/9534. 

Discussed offline; I'm still not 100% convinced about why this works all the time but this uses the suggestions in the comments of #9534. I tested with the implicit tileset in this comment https://github.com/CesiumGS/cesium/issues/9534#issuecomment-837483086 and the OSM buildings tileset. The implicit tileset goes down from 1437 to 193 visited tiles after the fix (slightly less than the number after exclusively using the oriented bounding box distance). OSM buildings results are consistent with those in master.

All tests still pass and the above info seems okay to me, but I don't know how much more I can come up with before the release tomorrow. Opening for review and other thoughts.