### PR TITLE
Update urls to from /docs to /learn

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -276,7 +276,7 @@
   - If you’re using your own custom definitions and you’re not yet ready to switch, you can delete `Source/Cesium.d.ts` after install.
   - See our [blog post](https://cesium.com/blog/2020/06/01/cesiumjs-tsd/) for more information and a technical overview of how it all works.
 - CesiumJS now supports underground rendering with globe translucency! [#8726](https://github.com/CesiumGS/cesium/pull/8726)
-  - Added options for controlling globe translucency through the new [`GlobeTranslucency`](https://cesium.com/docs/cesiumjs-ref-doc/GlobeTranslucency.html) object including front face alpha, back face alpha, and a translucency rectangle.
+  - Added options for controlling globe translucency through the new [`GlobeTranslucency`](https://cesium.com/learn/cesiumjs/ref-doc/GlobeTranslucency.html) object including front face alpha, back face alpha, and a translucency rectangle.
   - Added `Globe.undergroundColor` and `Globe.undergroundColorAlphaByDistance` for controlling how the back side of the globe is rendered when the camera is underground or the globe is translucent. [#8867](https://github.com/CesiumGS/cesium/pull/8867)
   - Improved camera controls when the camera is underground. [#8811](https://github.com/CesiumGS/cesium/pull/8811)
   - Sandcastle examples: [Globe Translucency](https://sandcastle.cesium.com/?src=Globe%20Translucency.html), [Globe Interior](https://sandcastle.cesium.com/?src=Globe%20Interior.html), and [Underground Color](https://sandcastle.cesium.com/?src=Underground%20Color.html&label=All)
@@ -471,7 +471,7 @@ var viewer = new Viewer("cesiumContainer", {
 - Cesium has migrated to ES6 modules. This may or may not be a breaking change for your application depending on how you use Cesium. See our [blog post](https://cesium.com/blog/2019/10/31/cesiumjs-es6/) for the full details.
 - We’ve consolidated all of our website content from cesiumjs.org and cesium.com into one home on cesium.com. Here’s where you can now find:
   - [Sandcastle](https://sandcastle.cesium.com) - `https://sandcastle.cesium.com`
-  - [API Docs](https://cesium.com/docs/cesiumjs-ref-doc/) - `https://cesium.com/docs/cesiumjs-ref-doc/`
+  - [API Docs](https://cesium.com/learn/cesiumjs/ref-doc/) - `https://cesium.com/learn/cesiumjs/ref-doc/`
   - [Downloads](https://cesium.com/downloads/) - `https://cesium.com/downloads/`
   - Hosted releases can be found at `https://cesium.com/downloads/cesiumjs/releases/<CesiumJS Version Number>/Build/Cesium/Cesium.js`
   - See our [blog post](https://cesium.com/blog/2019/10/15/cesiumjs-migration/) for more information.

--- a/Documentation/Contributors/BuildGuide/README.md
+++ b/Documentation/Contributors/BuildGuide/README.md
@@ -50,7 +50,7 @@ npm start
 
 Then browse to [http://localhost:8080/](http://localhost:8080/). The landing page includes apps and tools commonly used during development, including:
 
-- **Hello World** : an example for how to create a 3D globe. [Tutorial here](https://cesium.com/docs/tutorials/quick-start/)
+- **Hello World** : an example for how to create a 3D globe. [Tutorial here](https://cesium.com/learn/cesiumjs-learn/cesiumjs-quickstart/)
 - **Sandcastle** : an app for viewing and creating [code examples](https://sandcastle.cesium.com?src=Hello%20World.html&label=Showcases), complete with a live preview
 - **Test Suites** : tests using [Jasmine](https://jasmine.github.io/). [Testing guide here.](https://github.com/CesiumGS/cesium/blob/master/Documentation/Contributors/TestingGuide/README.md#testing-guide)
 - **Documentation** : reference documentation built from source. [Documentation guide here.](https://github.com/CesiumGS/cesium/blob/master/Documentation/Contributors/DocumentationGuide/README.md#documentation-guide)

--- a/Documentation/Contributors/PresentersGuide/README.md
+++ b/Documentation/Contributors/PresentersGuide/README.md
@@ -1,6 +1,6 @@
 # Presenter's Guide
 
-The Cesium team gives a lot of [talks](http://cesium.com/docs/presentations/). Here's some tips, based on our experience, for delivering a great talk.
+The Cesium team gives a lot of [talks](https://cesium.com/learn/presentations/). Here's some tips, based on our experience, for delivering a great talk.
 
 - [Invest Time Preparing](#invest-time-preparing)
 - [Know the Audience](#know-the-audience)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Build Status](https://travis-ci.com/CesiumGS/cesium.svg?branch=master)](https://travis-ci.com/CesiumGS/cesium)
 [![npm](https://img.shields.io/npm/v/cesium)](https://www.npmjs.com/package/cesium)
-[![Docs](https://img.shields.io/badge/docs-online-orange.svg)](https://cesium.com/docs/)
+[![Docs](https://img.shields.io/badge/docs-online-orange.svg)](https://cesium.com/learn/)
 
 CesiumJS is a JavaScript library for creating 3D globes and 2D maps in a web browser without a plugin. It uses WebGL for hardware-accelerated graphics, and is cross-platform, cross-browser, and tuned for dynamic-data visualization.
 

--- a/Source/DataSources/Entity.js
+++ b/Source/DataSources/Entity.js
@@ -103,7 +103,7 @@ function createPropertyTypeDescriptor(name, Type) {
  *
  * @param {Entity.ConstructorOptions} [options] Object describing initialization options
  *
- * @see {@link https://cesium.com/docs/tutorials/creating-entities/|Creating Entities}
+ * @see {@link https://cesium.com/learn/cesiumjs-learn/cesiumjs-creating-entities/|Creating Entities}
  */
 function Entity(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/Source/DataSources/ModelGraphics.js
+++ b/Source/DataSources/ModelGraphics.js
@@ -59,7 +59,6 @@ function createArticulationStagePropertyBag(value) {
  *
  * @param {ModelGraphics.ConstructorOptions} [options] Object describing initialization options
  *
- * @see {@link https://cesium.com/docs/tutorials/3d-models/|3D Models Tutorial}
  * @demo {@link https://sandcastle.cesium.com/index.html?src=3D%20Models.html|Cesium Sandcastle 3D Models Demo}
  */
 function ModelGraphics(options) {

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -47,7 +47,7 @@ import SceneMode from "./SceneMode.js";
  *
  * @demo {@link https://sandcastle.cesium.com/index.html?src=Camera.html|Cesium Sandcastle Camera Demo}
  * @demo {@link https://sandcastle.cesium.com/index.html?src=Camera%20Tutorial.html|Cesium Sandcastle Camera Tutorial Example}
- * @demo {@link https://cesium.com/docs/tutorials/camera/|Camera Tutorial}
+ * @demo {@link https://cesium.com/learn/cesiumjs-learn/cesiumjs-camera|Camera Tutorial}
  *
  * @example
  * // Create a camera looking down the negative z-axis, positioned at the origin,

--- a/Source/Scene/ParticleSystem.js
+++ b/Source/Scene/ParticleSystem.js
@@ -51,7 +51,7 @@ var defaultImageSize = new Cartesian2(1.0, 1.0);
  * @param {Number} [options.mass=1.0] Sets the minimum and maximum mass of particles in kilograms.
  * @param {Number} [options.minimumMass] Sets the minimum bound for the mass of a particle in kilograms. A particle's actual mass will be chosen as a random amount above this value.
  * @param {Number} [options.maximumMass] Sets the maximum mass of particles in kilograms. A particle's actual mass will be chosen as a random amount below this value.
- * @tutorial {@link https://cesium.com/docs/tutorials/particle-systems/|Particle Systems Tutorial}
+ * @demo {@link https://cesium.com/learn/cesiumjs-learn/cesiumjs-particle-systems/|Particle Systems Tutorial}
  * @demo {@link https://sandcastle.cesium.com/?src=Particle%20System.html&label=Showcases|Particle Systems Tutorial Demo}
  * @demo {@link https://sandcastle.cesium.com/?src=Particle%20System%20Fireworks.html&label=Showcases|Particle Systems Fireworks Demo}
  */

--- a/index.release.html
+++ b/index.release.html
@@ -121,7 +121,7 @@
               </td>
             </tr>
             <tr>
-              <td><a href="https://cesium.com/docs/">Tutorials</a></td>
+              <td><a href="https://cesium.com/learn/">Tutorials</a></td>
               <td>Step-by-step guides for learning to use CesiumJS</td>
             </tr>
             <tr>
@@ -163,9 +163,8 @@
         document.body.innerHTML = "";
         document.write("<p><b>This file must be hosted in a web server.</br>");
         document.write(
-          'See our <a href="https://cesium.com/docs/tutorials/cesium-workshop/#setup">Cesium Workshop</a> '
+          'Need help?  Ask on our <a href="https://community.cesium.com/">Community Forum</a>.</b></p>'
         );
-        document.write("tutorial for a step-by-step guide.</b></p>");
       }
     </script>
   </body>


### PR DESCRIPTION
We recently released a new version of our learning content on the cesium.com website and some of the URLs have changed.  This updates URLs throughout the repo.