### PR TITLE
Revert "Update TileBoundingRegion.distanceToCamera to use OBB distance in 3D"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,6 @@
 - Fixed a regression where older tilesets without a top-level `geometricError` would fail to load. [#9618](https://github.com/CesiumGS/cesium/pull/9618)
 - Fixed an issue in `WebMapTileServiceImageryProvider` where using URL subdomains caused query parameters to be dropped from requests. [#9606](https://github.com/CesiumGS/cesium/pull/9606)
 - Fixed an issue in `ScreenSpaceCameraController.tilt3DOnTerrain` that caused unexpected camera behavior when tilting terrain diagonally along the screen. [#9562](https://github.com/CesiumGS/cesium/pull/9562)
-- Fixed an issue in `TileBoundingRegion.distanceToCamera` that caused incorrect results when the camera was on the opposite site of the globe. [#9652](https://github.com/CesiumGS/cesium/pull/9652)
 - Fixed error handling in `GlobeSurfaceTile` to print terrain tile request errors to console. [#9570](https://github.com/CesiumGS/cesium/pull/9570)
 - Fixed broken image URL in the KML Sandcastle. [#9579](https://github.com/CesiumGS/cesium/pull/9579)
 - Fixed an error where the `positionToEyeEC` and `tangentToEyeMatrix` properties for custom materials were not set in `GlobeFS`. [#9597](https://github.com/CesiumGS/cesium/pull/9597)

--- a/Source/Scene/TileBoundingRegion.js
+++ b/Source/Scene/TileBoundingRegion.js
@@ -4,7 +4,6 @@ import Cartographic from "../Core/Cartographic.js";
 import Check from "../Core/Check.js";
 import ColorGeometryInstanceAttribute from "../Core/ColorGeometryInstanceAttribute.js";
 import defaultValue from "../Core/defaultValue.js";
-import defined from "../Core/defined.js";
 import Ellipsoid from "../Core/Ellipsoid.js";
 import GeometryInstance from "../Core/GeometryInstance.js";
 import IntersectionTests from "../Core/IntersectionTests.js";
@@ -300,30 +299,39 @@ var negativeUnitY = new Cartesian3(0.0, -1.0, 0.0);
 var negativeUnitZ = new Cartesian3(0.0, 0.0, -1.0);
 var vectorScratch = new Cartesian3();
 
-function distanceToCameraRegion(tileBB, frameState) {
+/**
+ * Gets the distance from the camera to the closest point on the tile.  This is used for level of detail selection.
+ *
+ * @param {FrameState} frameState The state information of the current rendering frame.
+ * @returns {Number} The distance from the camera to the closest point on the tile, in meters.
+ */
+TileBoundingRegion.prototype.distanceToCamera = function (frameState) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.defined("frameState", frameState);
+  //>>includeEnd('debug');
   var camera = frameState.camera;
   var cameraCartesianPosition = camera.positionWC;
   var cameraCartographicPosition = camera.positionCartographic;
 
   var result = 0.0;
-  if (!Rectangle.contains(tileBB.rectangle, cameraCartographicPosition)) {
-    var southwestCornerCartesian = tileBB.southwestCornerCartesian;
-    var northeastCornerCartesian = tileBB.northeastCornerCartesian;
-    var westNormal = tileBB.westNormal;
-    var southNormal = tileBB.southNormal;
-    var eastNormal = tileBB.eastNormal;
-    var northNormal = tileBB.northNormal;
+  if (!Rectangle.contains(this.rectangle, cameraCartographicPosition)) {
+    var southwestCornerCartesian = this.southwestCornerCartesian;
+    var northeastCornerCartesian = this.northeastCornerCartesian;
+    var westNormal = this.westNormal;
+    var southNormal = this.southNormal;
+    var eastNormal = this.eastNormal;
+    var northNormal = this.northNormal;
 
     if (frameState.mode !== SceneMode.SCENE3D) {
       southwestCornerCartesian = frameState.mapProjection.project(
-        Rectangle.southwest(tileBB.rectangle),
+        Rectangle.southwest(this.rectangle),
         southwestCornerScratch
       );
       southwestCornerCartesian.z = southwestCornerCartesian.y;
       southwestCornerCartesian.y = southwestCornerCartesian.x;
       southwestCornerCartesian.x = 0.0;
       northeastCornerCartesian = frameState.mapProjection.project(
-        Rectangle.northeast(tileBB.rectangle),
+        Rectangle.northeast(this.rectangle),
         northeastCornerScratch
       );
       northeastCornerCartesian.z = northeastCornerCartesian.y;
@@ -381,8 +389,8 @@ function distanceToCameraRegion(tileBB, frameState) {
   var maximumHeight;
   if (frameState.mode === SceneMode.SCENE3D) {
     cameraHeight = cameraCartographicPosition.height;
-    minimumHeight = tileBB.minimumHeight;
-    maximumHeight = tileBB.maximumHeight;
+    minimumHeight = this.minimumHeight;
+    maximumHeight = this.maximumHeight;
   } else {
     cameraHeight = cameraCartesianPosition.x;
     minimumHeight = 0.0;
@@ -398,30 +406,6 @@ function distanceToCameraRegion(tileBB, frameState) {
   }
 
   return Math.sqrt(result);
-}
-
-/**
- * Gets the distance from the camera to the closest point on the tile.  This is used for level of detail selection.
- *
- * @param {FrameState} frameState The state information of the current rendering frame.
- * @returns {Number} The distance from the camera to the closest point on the tile, in meters.
- */
-TileBoundingRegion.prototype.distanceToCamera = function (frameState) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.defined("frameState", frameState);
-  //>>includeEnd('debug');
-
-  var regionResult = distanceToCameraRegion(this, frameState);
-  if (
-    frameState.mode === SceneMode.SCENE3D &&
-    defined(this._orientedBoundingBox)
-  ) {
-    var obbResult = Math.sqrt(
-      this._orientedBoundingBox.distanceSquaredTo(frameState.camera.positionWC)
-    );
-    return Math.max(regionResult, obbResult);
-  }
-  return regionResult;
 };
 
 /**


### PR DESCRIPTION
Reverts CesiumGS/cesium#9652. 

There are floating-point (probably) issues with this in some browsers on Windows due to the OBB distance failing with degenerate cases (i.e. half axis having a magnitude of near 0). 