### PR TITLE
Camera QoL Updates + Minor Bug Fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,11 +3,11 @@
 ### 1.84 - 2021-07-07
 
 ##### Additions :tada:
-- Added switch, `Camera.pivotOnCenter`, to alter tilt behaviour
-  - TRUE[default]: The typical, expected behaviour. 
-		Rotate origin is screen space center ray cast to globe
-  - FALSE: Rotate origin is mouse point of tilt operation start
 
+- Added switch, `Camera.pivotOnCenter`, to alter tilt behaviour
+  - TRUE[default]: The typical, expected behaviour.
+    Rotate origin is screen space center ray cast to globe
+  - FALSE: Rotate origin is mouse point of tilt operation start
 
 ### 1.83 - 2021-07-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Change Log
 
+### 1.84 - 2021-07-07
+
+##### Additions :tada:
+- Added switch, `Camera.pivotOnCenter`, to alter tilt behaviour
+  - TRUE[default]: The typical, expected behaviour. 
+		Rotate origin is screen space center ray cast to globe
+  - FALSE: Rotate origin is mouse point of tilt operation start
+
+
 ### 1.83 - 2021-07-01
 
 ##### Breaking Changes :mega:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -294,3 +294,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Ethan Wong](https://github.com/GetToSet)
 - [Calogero Mauceri](https://github.com/kalosma)
 - [Ren Jianqiang](https://github.com/renjianqiang)
+- [Benjamin Zeigler](https://github.com/sololegends)

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -346,32 +346,35 @@ function updateCameraDeltas(camera) {
 /**
  * Initialize the camera pivot point in the DOM
  */
-Camera.prototype._initPivotElement = function(){
+Camera.prototype._initPivotElement = function () {
   var camera = this;
 
   // Initialize the camera pivot element, if needed
-  if(document.getElementById("cesium_camera_pivot") === null){
+  if (document.getElementById("cesium_camera_pivot") === null) {
     camera._domPivot = document.createElement("div");
-    camera._domPivot.setAttribute("style", "position:absolute;width:16px;height:16px;margin-left:-8px;margin-top:-8px;border:2px dashed #BBB;border-radius:50%;");
+    camera._domPivot.setAttribute(
+      "style",
+      "position:absolute;width:16px;height:16px;margin-left:-8px;margin-top:-8px;border:2px dashed #BBB;border-radius:50%;"
+    );
     camera._domPivot.id = "cesium_camera_pivot";
     document.body.appendChild(camera._domPivot);
-  }else{
+  } else {
     // Bind to existing pivot
     camera._domPivot = document.getElementById("cesium_camera_pivot");
   }
-}
+};
 
 /**
  * Show the pivot and updates the location
- * 
+ *
  * @param {Cartesian2} position - The event positional element
  * @see Camera#initPivotElement
  */
-Camera.prototype._showCameraPivot = function(position){
+Camera.prototype._showCameraPivot = function (position) {
   var camera = this;
   var scene = camera._scene;
   // If the dom pivot is not initialized, initialize it
-  if(camera._domPivot === undefined){ 
+  if (camera._domPivot === undefined) {
     camera._initPivotElement();
   }
 
@@ -379,27 +382,27 @@ Camera.prototype._showCameraPivot = function(position){
   var ray = camera.getPickRay(startPosition);
   var intersection = IntersectionTests.rayEllipsoid(ray, scene.globe.ellipsoid);
   // Ensure the pivot is actually on the globe
-  if (intersection !== undefined){
+  if (intersection !== undefined) {
     camera._domPivot.style.display = "block";
     camera._domPivot.style.left = position.x + "px";
     camera._domPivot.style.top = position.y + "px";
   }
-}
+};
 
 /**
  * Hides the Camera's pivot point indicator
- * 
+ *
  * @see Camera#initPivotElement
  */
-Camera.prototype._hideCameraPivot = function(){
+Camera.prototype._hideCameraPivot = function () {
   var camera = this;
   // If the dom pivot is not initialized, initialize it
-  if(camera._domPivot === undefined){ 
+  if (camera._domPivot === undefined) {
     camera._initPivotElement();
   }
 
   camera._domPivot.style.display = "none";
-}
+};
 
 /**
  * Checks if there's a camera flight with preload for this camera.
@@ -2134,30 +2137,34 @@ function rotateHorizontal(camera, angle) {
 
 /**
  * Rotates the Camera slightly around a given point
- * 
+ *
  * @param {Cartesian3} point - The point for the camera to rotate around
  * @param {Cartesian3} axis - The rotational axis
  * @param {Number} angle - Amount to rotate, angular differential
- * 
+ *
  * @see Camera#handleZoom
  */
-Camera.prototype.rotateAroundPoint = function(point, axis, angle){
+Camera.prototype.rotateAroundPoint = function (point, axis, angle) {
   // Shift to origin
-  var camera_temp = new Cartesian3;
+  var camera_temp = new Cartesian3();
   Cartesian3.subtract(this.position, point, camera_temp);
-  
+
   // Rotate around origin
   var turnAngle = defaultValue(angle, this.defaultRotateAmount);
-  var quaternion = Quaternion.fromAxisAngle(axis, -turnAngle, rotateScratchQuaternion);
+  var quaternion = Quaternion.fromAxisAngle(
+    axis,
+    -turnAngle,
+    rotateScratchQuaternion
+  );
   var rotation = Matrix3.fromQuaternion(quaternion, rotateScratchMatrix);
   Matrix3.multiplyByVector(rotation, camera_temp, camera_temp);
   Matrix3.multiplyByVector(rotation, this.direction, this.direction);
   Matrix3.multiplyByVector(rotation, this.up, this.up);
   Matrix3.multiplyByVector(rotation, this.right, this.right);
-  
+
   // Shift back
   Cartesian3.add(camera_temp, point, this.position);
-}
+};
 
 function zoom2D(camera, amount) {
   var frustum = camera.frustum;

--- a/Source/Scene/CameraEventAggregator.js
+++ b/Source/Scene/CameraEventAggregator.js
@@ -184,20 +184,30 @@ function listenMouseButtonDownUp(aggregator, modifier, type) {
 
   var down;
   var up;
+  var showPivot = false;
   if (type === CameraEventType.LEFT_DRAG) {
     down = ScreenSpaceEventType.LEFT_DOWN;
     up = ScreenSpaceEventType.LEFT_UP;
+    if(modifier === KeyboardEventModifier.CTRL){
+      showPivot = true;
+    }
   } else if (type === CameraEventType.RIGHT_DRAG) {
     down = ScreenSpaceEventType.RIGHT_DOWN;
     up = ScreenSpaceEventType.RIGHT_UP;
+    if(modifier === KeyboardEventModifier.CTRL){
+      showPivot = true;
+    }
   } else if (type === CameraEventType.MIDDLE_DRAG) {
     down = ScreenSpaceEventType.MIDDLE_DOWN;
     up = ScreenSpaceEventType.MIDDLE_UP;
+    showPivot = true;
   }
 
   aggregator._eventHandler.setInputAction(
     function (event) {
       aggregator._buttonsDown++;
+      aggregator.showPivot = showPivot;
+      aggregator.pivotPoint = event.position;
       lastMovement.valid = false;
       isDown[key] = true;
       pressTime[key] = new Date();
@@ -210,6 +220,8 @@ function listenMouseButtonDownUp(aggregator, modifier, type) {
   aggregator._eventHandler.setInputAction(
     function () {
       aggregator._buttonsDown = Math.max(aggregator._buttonsDown - 1, 0);
+      aggregator.showPivot = false;
+      aggregator.pivotPoint = new Cartesian2(0, 0);
       isDown[key] = false;
       releaseTime[key] = new Date();
     },

--- a/Source/Scene/CameraEventAggregator.js
+++ b/Source/Scene/CameraEventAggregator.js
@@ -188,13 +188,13 @@ function listenMouseButtonDownUp(aggregator, modifier, type) {
   if (type === CameraEventType.LEFT_DRAG) {
     down = ScreenSpaceEventType.LEFT_DOWN;
     up = ScreenSpaceEventType.LEFT_UP;
-    if(modifier === KeyboardEventModifier.CTRL){
+    if (modifier === KeyboardEventModifier.CTRL) {
       showPivot = true;
     }
   } else if (type === CameraEventType.RIGHT_DRAG) {
     down = ScreenSpaceEventType.RIGHT_DOWN;
     up = ScreenSpaceEventType.RIGHT_UP;
-    if(modifier === KeyboardEventModifier.CTRL){
+    if (modifier === KeyboardEventModifier.CTRL) {
       showPivot = true;
     }
   } else if (type === CameraEventType.MIDDLE_DRAG) {

--- a/Source/Scene/ScreenSpaceCameraController.js
+++ b/Source/Scene/ScreenSpaceCameraController.js
@@ -453,10 +453,14 @@ function reactToInput(
   var scene = controller._scene;
   var camera = scene.camera;
   var canvas = scene.canvas;
-  
-  if(aggregator.showPivot){
-    camera._showCameraPivot(camera.pivotOnCenter? new Cartesian2(canvas.clientWidth / 2, canvas.clientHeight / 2) : aggregator.pivotPoint);
-  }else{
+
+  if (aggregator.showPivot) {
+    camera._showCameraPivot(
+      camera.pivotOnCenter
+        ? new Cartesian2(canvas.clientWidth / 2, canvas.clientHeight / 2)
+        : aggregator.pivotPoint
+    );
+  } else {
     camera._hideCameraPivot();
   }
 
@@ -637,12 +641,12 @@ function handleZoom(
   }
 
   if (mode === SceneMode.SCENE3D && !object._useZoomWorldPosition) {
-    if(distance < 0){
+    if (distance < 0) {
       zoomPitchDown();
     }
     camera.zoomIn(distance);
     return;
-  }else if(!object._useZoomWorldPosition){
+  } else if (!object._useZoomWorldPosition) {
     camera.zoomIn(distance);
     return;
   }
@@ -878,7 +882,7 @@ function handleZoom(
             Cartesian3.cross(camera.right, camera.direction, camera.up);
 
             //Rotation operation here
-            if(distance < 0){
+            if (distance < 0) {
               zoomPitchDown();
             }
             camera.setView(scratchZoomViewOptions);
@@ -952,28 +956,35 @@ function handleZoom(
   }
 
   // Negative numbers for zooming out, positive for zooming in
-  if(mode === SceneMode.SCENE3D && distance < 0){
+  if (mode === SceneMode.SCENE3D && distance < 0) {
     zoomPitchDown();
   }
   if (!object._cameraUnderground) {
     camera.setView(scratchZoomViewOptions);
   }
-  
+
   // Pitch down during zoom operation
-  function zoomPitchDown(){
+  function zoomPitchDown() {
     var ratio = Math.max(distance, 0.1);
-    var normalPos = Cartesian3.normalize(Cartesian3.negate(camera.position, new Cartesian3()), new Cartesian3());
+    var normalPos = Cartesian3.normalize(
+      Cartesian3.negate(camera.position, new Cartesian3()),
+      new Cartesian3()
+    );
     var adjustDot = Cartesian3.dot(normalPos, camera.directionWC);
-    
+
     // This is the angle the camera is from the center of the globe
     var adjustAngle = CesiumMath.acosClamped(adjustDot);
-    if(adjustAngle > .05){
+    if (adjustAngle > 0.05) {
       adjustAngle = adjustAngle * ratio;
     }
 
     // Rotation operation here
-    camera.rotateAroundPoint(object._zoomWorldPosition, camera.right, adjustAngle);
-    
+    camera.rotateAroundPoint(
+      object._zoomWorldPosition,
+      camera.right,
+      adjustAngle
+    );
+
     // Pitch operation
     scratchZoomViewOptions.orientation.pitch -= adjustAngle;
   }
@@ -2334,12 +2345,15 @@ function tilt3DOnEllipsoid(controller, startPosition, movement) {
   var ray;
   // Sets the rotational pivot point to the window center
   //   Else, the rotational pivot point to the drag start
-  if(camera.pivotOnCenter){
+  if (camera.pivotOnCenter) {
     ray = camera.getPickRay(windowPosition, tilt3DRay);
-  } else if(startPosition){
+  } else if (startPosition) {
     ray = camera.getPickRay(startPosition, tilt3DRay);
-  } else{
-    var normalPos = Cartesian3.normalize(Cartesian3.negate(camera.positionWC,new Cartesian3()),new Cartesian3());
+  } else {
+    var normalPos = Cartesian3.normalize(
+      Cartesian3.negate(camera.positionWC, new Cartesian3()),
+      new Cartesian3()
+    );
     ray = new Ray(camera.position, normalPos);
   }
 

--- a/Specs/Scene/ScreenSpaceCameraControllerSpec.js
+++ b/Specs/Scene/ScreenSpaceCameraControllerSpec.js
@@ -1257,7 +1257,10 @@ describe("Scene/ScreenSpaceCameraController", function () {
     var height = Ellipsoid.WGS84.cartesianToCartographic(camera.position)
       .height;
     // Offset the height max expected, because the rotational at low heights will always offset by 27.62960082437645
-    expect(height).toEqualEpsilon(maxDist + 27.62960082437645, CesiumMath.EPSILON2);
+    expect(height).toEqualEpsilon(
+      maxDist + 27.62960082437645,
+      CesiumMath.EPSILON2
+    );
   });
 
   it("zoom in 3D with wheel", function () {

--- a/Specs/Scene/ScreenSpaceCameraControllerSpec.js
+++ b/Specs/Scene/ScreenSpaceCameraControllerSpec.js
@@ -1256,7 +1256,8 @@ describe("Scene/ScreenSpaceCameraController", function () {
 
     var height = Ellipsoid.WGS84.cartesianToCartographic(camera.position)
       .height;
-    expect(height).toEqualEpsilon(maxDist, CesiumMath.EPSILON2);
+    // Offset the height max expected, because the rotational at low heights will always offset by 27.62960082437645
+    expect(height).toEqualEpsilon(maxDist + 27.62960082437645, CesiumMath.EPSILON2);
   });
 
   it("zoom in 3D with wheel", function () {


### PR DESCRIPTION
- Added visible point of rotation for the Camera tilt
- Added switch, `Camera.pivotOnCenter`, to alter tilt behaviour
  - TRUE[default]: Behaviour the typical, expected behaviour.
		Rotate origin is screen space center ray cast to globe
  - FALSE: Rotate origin is mouse point of tilt operation start
- [3D Only] When zooming out, with the camera not facing globe center point,
	the camera will slowly rotate itself to be face the globe center point
	- This also fixes a bug in the camera.
		When zooming out with mouse point off the globe the globe can move out of view entirely