### PR TITLE
Polyline Volume Close Point Error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Fixes :wrench:
 
 - Fixed the ability to set a material's image to `undefined` and `Material.DefaultImageId`. [#9644](https://github.com/CesiumGS/cesium/pull/9644)
+- Fixed render crash when creating a `polylineVolume` with very close points. [#9669](https://github.com/CesiumGS/cesium/pull/9669)
 
 ### 1.83 - 2021-07-01
 

--- a/Source/Core/PolylineVolumeGeometryLibrary.js
+++ b/Source/Core/PolylineVolumeGeometryLibrary.js
@@ -427,16 +427,6 @@ PolylineVolumeGeometryLibrary.computePositions = function (
     var repeat = duplicatePoints ? 2 : 1;
     nextPosition = positions[i + 1];
     forward = Cartesian3.subtract(nextPosition, position, forward);
-    console.log("position: " + position);
-    console.log("nextPosition: " + nextPosition);
-    console.log(
-      "Magnitude in PolylineVolumeGeometryLibrary.js " +
-        Cartesian3.magnitude(forward) +
-        " " +
-        "Value of forward: " +
-        forward
-    );
-    //If positions are too close, throw a warning specifying the rounding issue
     if (position.equals(nextPosition)) {
       oneTimeWarning(
         "Positions are too close and are considered equivalent with rounding error."

--- a/Source/Core/PolylineVolumeGeometryLibrary.js
+++ b/Source/Core/PolylineVolumeGeometryLibrary.js
@@ -426,13 +426,13 @@ PolylineVolumeGeometryLibrary.computePositions = function (
   for (var i = 1; i < length - 1; i++) {
     var repeat = duplicatePoints ? 2 : 1;
     nextPosition = positions[i + 1];
-    forward = Cartesian3.subtract(nextPosition, position, forward);
     if (position.equals(nextPosition)) {
       oneTimeWarning(
         "Positions are too close and are considered equivalent with rounding error."
       );
       continue;
     }
+    forward = Cartesian3.subtract(nextPosition, position, forward);
     forward = Cartesian3.normalize(forward, forward);
     cornerDirection = Cartesian3.add(forward, backward, cornerDirection);
     cornerDirection = Cartesian3.normalize(cornerDirection, cornerDirection);

--- a/Source/Core/PolylineVolumeGeometryLibrary.js
+++ b/Source/Core/PolylineVolumeGeometryLibrary.js
@@ -10,6 +10,7 @@ import Matrix4 from "./Matrix4.js";
 import PolylinePipeline from "./PolylinePipeline.js";
 import Quaternion from "./Quaternion.js";
 import Transforms from "./Transforms.js";
+import oneTimeWarning from "../Core/oneTimeWarning.js";
 
 var scratch2Array = [new Cartesian3(), new Cartesian3()];
 var scratchCartesian1 = new Cartesian3();
@@ -426,6 +427,22 @@ PolylineVolumeGeometryLibrary.computePositions = function (
     var repeat = duplicatePoints ? 2 : 1;
     nextPosition = positions[i + 1];
     forward = Cartesian3.subtract(nextPosition, position, forward);
+    console.log("position: " + position);
+    console.log("nextPosition: " + nextPosition);
+    console.log(
+      "Magnitude in PolylineVolumeGeometryLibrary.js " +
+        Cartesian3.magnitude(forward) +
+        " " +
+        "Value of forward: " +
+        forward
+    );
+    //If positions are too close, throw a warning specifying the rounding issue
+    if (position.equals(nextPosition)) {
+      oneTimeWarning(
+        "Positions are too close and are considered equivalent with rounding error."
+      );
+      continue;
+    }
     forward = Cartesian3.normalize(forward, forward);
     cornerDirection = Cartesian3.add(forward, backward, cornerDirection);
     cornerDirection = Cartesian3.normalize(cornerDirection, cornerDirection);


### PR DESCRIPTION
Fixes #9249

When creating a `polylineVolume` with very close points, `Cartesian3` throws `DeveloperError: normalized result is not a number`. While the points entered are not identical, they are rounded to the same value. We see this behavior in [this sandcastle demo](https://sandcastle.cesium.com/#c=hZNbb9MwFMe/ylGfUlbc9JKkXrMK1CHxAEIaaC+EBy89bS0cO7KdTh3qd8fOrd0FkQfHOf79z9U5MA0Hjo+o4QYkPsIaDa8Kcl/bgmyQ199rJS3jEnU2GC4zmcmD05XM7p3qZyYB3k8mUxJNQxrORxDNyYIm8dxt53FEwkUYTpLRJbZIzlhEWyyilMa0eaLneBz3eDxr8Tmli+T/2IzSJJO/6qy3lcwtVxJyVZSVxTXXucBAsw2vzBD+eGd1ZcpwzxlfnpcCbJWGwJ9xZwuX7pXCLPabq6tW2Wi9M1Yr21Z+dW0iVt019oAPlw3cByFlZfZBY4TLIayZtm7H5LQ/BWiShXdQ+82VCdqIw9G/IMNlD3VMu2mSOflFo620PKflTk71qOurQFBaZ0dD2GYT1PWWShyFuxT3SlQFXndN6B1cv6pjRrZaFbe404jmo9bs+Bn5bm9N4O9SV4DZs9K5ez6jSUjCDiiYRc2ZOAdQQmly9+m2Bk5uPTXXtM/+Sanihwpe1OKhwWiQGnsUuOpa84EXpdIWKi0CQsYWi1K4iGb8UOW/0ZLcmG6G6fhSmm74Afjm5o2/BnLBjHEn20qI7/wJs8EqHTv+lVQoNym5+3ZALdjRY/vJ6ktjJISkY/f5ttIqJR6YfuH5Lw) provided by @ulrichson.

While a potential solution would be to implement a more accurate number system, this ultimately would not fix the bug. Rather, it would cause the same error to occur when more precise values are used. In my solution, when consecutive positions are considered equivalent, I throw a `oneTimeWarning` and omit the "identical" value. [Here is a sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=hZNbb9MwFMe/ylGfUlbc9JKkXrMK1CHxAEIaaC+EBy89bS0cO7KdTh3qd8fOrd0FkQfHOf79z9U5MA0Hjo+o4QYkPsIaDa8Kcl/bgmyQ199rJS3jEnU2GC4zmcmD05XM7p3qZyYB3k8mUxJNQxrORxDNyYIm8dxt53FEwkUYTpLRJbZIzlhEWyyilMa0eaLneBz3eDxr8Tmli+T/2IzSJJO/6qy3lcwtVxJyVZSVxTXXucBAsw2vzBD+eGd1ZcpwzxlfnpcCbJWGwJ9xZwuX7pXCLPabq6tW2Wi9M1Yr21Z+dW0iVt019oAPlw3cByFlZfZBY4TLIayZtm7H5LQ/BWiShXdQ+82VCdqIw9G/IMNlD3VMu2mSOflFo620PKflTk71qOurQFBaZ0dD2GYT1PWWShyFuxT3SlQFXndN6B1cv6pjRrZaFbe404jmo9bs+Bn5bm9N4O9SV4DZs9K5ez6jSUjCDiiYRc2ZOAdQQmly9+m2Bk5uPTXXtM/+Sanihwpe1OKhwWiQGnsUuOpa84EXpdIWKi0CQsYWi1K4iGb8UOW/0ZLcmG6G6fhSmm74Afjm5o2/BnLBjHEn20qI7/wJs8EqHTv+lVQoNym5+3ZALdjRY/vJ6ktjJISkY/f5ttIqJR6YfuH5Lw) that demonstrates this functionality.

This is just one approach. I am curious to hear other ideas - maybe there is a more elegant solution.

@lilleyse 
@ebogo1 