### PR TITLE
Add other methods to checkout a pull request in Code Review Guide 

### DIFF
--- a/Documentation/Contributors/CodeReviewGuide/README.md
+++ b/Documentation/Contributors/CodeReviewGuide/README.md
@@ -124,6 +124,8 @@ git push -f origin mybranch # Requires force push as it is changing existing his
 
 ### You want to checkout a pull-request for review
 
+#### Using hub
+
 GitHub's [hub](https://hub.github.com) makes checking-out PR's simple. For example, run:
 
 `hub checkout https://github.com/CesiumGS/cesium/pull/3941`
@@ -135,6 +137,26 @@ forks with:
 
 which will automatically add these repos as remotes and fetch them. See the hub [open-source maintainer section](https://hub.github.com/#maintainer)
 for more info.
+
+#### Using Github CLI
+
+[GitHub CLI](https://cli.github.com/) allows you to checkout a PR using either its ID number, its URL, or its branch name. For instance,
+
+`gh pr checkout 3941`
+
+will checkout pull request [#3941](https://github.com/CesiumGS/cesium/pull/3941).
+
+More details can be found [here](https://cli.github.com/manual/gh_pr_checkout).
+
+#### Using git
+
+You can also use regular git commands to checkout a PR. First, fetch the pull request using its ID number and create a new branch for it.
+
+`git fetch origin pull/ID/head:BRANCHNAME`
+
+Then, you can switch to the newly created branch.
+
+`git checkout BRANCHNAME`
 
 ## Resources
 


### PR DESCRIPTION
Based on @shehzan10 's suggestion. While we were going over the Code Review Guide, we found that the current [Code Review Guide](https://github.com/CesiumGS/cesium/blob/ab07bcb130d99baaae08ce5e4346ae79899136e0/Documentation/Contributors/CodeReviewGuide/README.md) only explains how to checkout a PR using [hub](https://hub.github.com/). Since I don't use hub, I wanted to know alternate methods to checkout a PR. I added explanations of how to use Github CLI and regular git, which I think will be helpful for future reference.