### PR TITLE
Changed type for some properties to Color from Property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ##### Changes PR https://github.com/CesiumGS/cesium/pull/9673
+
 - Changes type annotations for several color properties from Property|undifined to Color|undefined
 
 ### 1.84 - 2021-08-02
@@ -14,6 +15,7 @@
 - Fixed render crash when creating a `polylineVolume` with very close points. [#9669](https://github.com/CesiumGS/cesium/pull/9669)
 
 =======
+
 ### 1.83 - 2021-07-01
 
 ##### Breaking Changes :mega:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,6 @@
 - Fixed the ability to set a material's image to `undefined` and `Material.DefaultImageId`. [#9644](https://github.com/CesiumGS/cesium/pull/9644)
 - Fixed render crash when creating a `polylineVolume` with very close points. [#9669](https://github.com/CesiumGS/cesium/pull/9669)
 
-=======
 
 ### 1.83 - 2021-07-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Change Log
 
+##### Changes PR https://github.com/CesiumGS/cesium/pull/9673
+- Changes type annotations for several color properties from Property|undifined to Color|undefined
+
 ### 1.84 - 2021-08-02
 
 ##### Additions :tada:
@@ -10,6 +13,7 @@
 - Fixed the ability to set a material's image to `undefined` and `Material.DefaultImageId`. [#9644](https://github.com/CesiumGS/cesium/pull/9644)
 - Fixed render crash when creating a `polylineVolume` with very close points. [#9669](https://github.com/CesiumGS/cesium/pull/9669)
 
+=======
 ### 1.83 - 2021-07-01
 
 ##### Breaking Changes :mega:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ##### Changes PR https://github.com/CesiumGS/cesium/pull/9673
 
-- Changes type annotations for several color properties from Property|undifined to Color|undefined
+- Changes type annotations for several color properties from `Property|undefined` to `Color|undefined`
 
 ### 1.84 - 2021-08-02
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -294,3 +294,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Ethan Wong](https://github.com/GetToSet)
 - [Calogero Mauceri](https://github.com/kalosma)
 - [Ren Jianqiang](https://github.com/renjianqiang)
+- [Mark Hagers](https://github.com/markchagers)

--- a/Source/DataSources/BillboardGraphics.js
+++ b/Source/DataSources/BillboardGraphics.js
@@ -221,7 +221,7 @@ Object.defineProperties(BillboardGraphics.prototype, {
    * </div>
    * </p>
    * @memberof BillboardGraphics.prototype
-   * @type {Property|undefined}
+   * @type {Color|undefined}
    * @default Color.WHITE
    */
   color: createPropertyDescriptor("color"),

--- a/Source/DataSources/BoxGraphics.js
+++ b/Source/DataSources/BoxGraphics.js
@@ -122,7 +122,7 @@ Object.defineProperties(BoxGraphics.prototype, {
   /**
    * Gets or sets the Property specifying the {@link Color} of the outline.
    * @memberof BoxGraphics.prototype
-   * @type {Property|undefined}
+   * @type {Color|undefined}
    * @default Color.BLACK
    */
   outlineColor: createPropertyDescriptor("outlineColor"),

--- a/Source/DataSources/CorridorGraphics.js
+++ b/Source/DataSources/CorridorGraphics.js
@@ -196,7 +196,7 @@ Object.defineProperties(CorridorGraphics.prototype, {
   /**
    * Gets or sets the Property specifying the {@link Color} of the outline.
    * @memberof CorridorGraphics.prototype
-   * @type {Property|undefined}
+   * @type {Color|undefined}
    * @default Color.BLACK
    */
   outlineColor: createPropertyDescriptor("outlineColor"),

--- a/Source/DataSources/CylinderGraphics.js
+++ b/Source/DataSources/CylinderGraphics.js
@@ -147,7 +147,7 @@ Object.defineProperties(CylinderGraphics.prototype, {
   /**
    * Gets or sets the Property specifying the {@link Color} of the outline.
    * @memberof CylinderGraphics.prototype
-   * @type {Property|undefined}
+   * @type {Color|undefined}
    * @default Color.BLACK
    */
   outlineColor: createPropertyDescriptor("outlineColor"),

--- a/Source/DataSources/EllipseGraphics.js
+++ b/Source/DataSources/EllipseGraphics.js
@@ -210,7 +210,7 @@ Object.defineProperties(EllipseGraphics.prototype, {
   /**
    * Gets or sets the Property specifying the {@link Color} of the outline.
    * @memberof EllipseGraphics.prototype
-   * @type {Property|undefined}
+   * @type {Color|undefined}
    * @default Color.BLACK
    */
   outlineColor: createPropertyDescriptor("outlineColor"),

--- a/Source/DataSources/EllipsoidGraphics.js
+++ b/Source/DataSources/EllipsoidGraphics.js
@@ -186,7 +186,7 @@ Object.defineProperties(EllipsoidGraphics.prototype, {
   /**
    * Gets or sets the Property specifying the {@link Color} of the outline.
    * @memberof EllipsoidGraphics.prototype
-   * @type {Property|undefined}
+   * @type {Color|undefined}
    * @default Color.BLACK
    */
   outlineColor: createPropertyDescriptor("outlineColor"),

--- a/Source/DataSources/LabelGraphics.js
+++ b/Source/DataSources/LabelGraphics.js
@@ -167,7 +167,7 @@ Object.defineProperties(LabelGraphics.prototype, {
   /**
    * Gets or sets the Property specifying the background {@link Color}.
    * @memberof LabelGraphics.prototype
-   * @type {Property|undefined}
+   * @type {Color|undefined}
    * @default new Color(0.165, 0.165, 0.165, 0.8)
    */
   backgroundColor: createPropertyDescriptor("backgroundColor"),
@@ -251,14 +251,14 @@ Object.defineProperties(LabelGraphics.prototype, {
   /**
    * Gets or sets the Property specifying the fill {@link Color}.
    * @memberof LabelGraphics.prototype
-   * @type {Property|undefined}
+   * @type {Color|undefined}
    */
   fillColor: createPropertyDescriptor("fillColor"),
 
   /**
    * Gets or sets the Property specifying the outline {@link Color}.
    * @memberof LabelGraphics.prototype
-   * @type {Property|undefined}
+   * @type {Color|undefined}
    */
   outlineColor: createPropertyDescriptor("outlineColor"),
 

--- a/Source/DataSources/ModelGraphics.js
+++ b/Source/DataSources/ModelGraphics.js
@@ -229,7 +229,7 @@ Object.defineProperties(ModelGraphics.prototype, {
   /**
    * Gets or sets the Property specifying the {@link Color} that blends with the model's rendered color.
    * @memberof ModelGraphics.prototype
-   * @type {Property|undefined}
+   * @type {Color|undefined}
    * @default Color.WHITE
    */
   color: createPropertyDescriptor("color"),

--- a/Source/DataSources/PlaneGraphics.js
+++ b/Source/DataSources/PlaneGraphics.js
@@ -122,7 +122,7 @@ Object.defineProperties(PlaneGraphics.prototype, {
   /**
    * Gets or sets the Property specifying the {@link Color} of the outline.
    * @memberof PlaneGraphics.prototype
-   * @type {Property|undefined}
+   * @type {Color|undefined}
    * @default Color.BLACK
    */
   outlineColor: createPropertyDescriptor("outlineColor"),

--- a/Source/DataSources/PointGraphics.js
+++ b/Source/DataSources/PointGraphics.js
@@ -96,7 +96,7 @@ Object.defineProperties(PointGraphics.prototype, {
   /**
    * Gets or sets the Property specifying the {@link Color} of the point.
    * @memberof PointGraphics.prototype
-   * @type {Property|undefined}
+   * @type {Color|undefined}
    * @default Color.WHITE
    */
   color: createPropertyDescriptor("color"),
@@ -104,7 +104,7 @@ Object.defineProperties(PointGraphics.prototype, {
   /**
    * Gets or sets the Property specifying the {@link Color} of the outline.
    * @memberof PointGraphics.prototype
-   * @type {Property|undefined}
+   * @type {Color|undefined}
    * @default Color.BLACK
    */
   outlineColor: createPropertyDescriptor("outlineColor"),

--- a/Source/DataSources/PolygonGraphics.js
+++ b/Source/DataSources/PolygonGraphics.js
@@ -213,7 +213,7 @@ Object.defineProperties(PolygonGraphics.prototype, {
   /**
    * Gets or sets the Property specifying the {@link Color} of the outline.
    * @memberof PolygonGraphics.prototype
-   * @type {Property|undefined}
+   * @type {Color|undefined}
    * @default Color.BLACK
    */
   outlineColor: createPropertyDescriptor("outlineColor"),

--- a/Source/DataSources/PolylineVolumeGraphics.js
+++ b/Source/DataSources/PolylineVolumeGraphics.js
@@ -145,7 +145,7 @@ Object.defineProperties(PolylineVolumeGraphics.prototype, {
   /**
    * Gets or sets the Property specifying the {@link Color} of the outline.
    * @memberof PolylineVolumeGraphics.prototype
-   * @type {Property|undefined}
+   * @type {Color|undefined}
    * @default Color.BLACK
    */
   outlineColor: createPropertyDescriptor("outlineColor"),

--- a/Source/DataSources/RectangleGraphics.js
+++ b/Source/DataSources/RectangleGraphics.js
@@ -197,7 +197,7 @@ Object.defineProperties(RectangleGraphics.prototype, {
   /**
    * Gets or sets the Property specifying the {@link Color} of the outline.
    * @memberof RectangleGraphics.prototype
-   * @type {Property|undefined}
+   * @type {Color|undefined}
    * @default Color.BLACK
    */
   outlineColor: createPropertyDescriptor("outlineColor"),

--- a/Source/DataSources/WallGraphics.js
+++ b/Source/DataSources/WallGraphics.js
@@ -146,7 +146,7 @@ Object.defineProperties(WallGraphics.prototype, {
   /**
    * Gets or sets the Property specifying the {@link Color} of the outline.
    * @memberof WallGraphics.prototype
-   * @type {Property|undefined}
+   * @type {Color|undefined}
    * @default Color.BLACK
    */
   outlineColor: createPropertyDescriptor("outlineColor"),


### PR DESCRIPTION
Fixes #9667. Some color properties of several Graphics classes (i.e. LabelGraphics.outlineColor) accept only a Cesium.Color, trying to set a ColorMaterialProperty has no effect at runtime. However the typescript definitions specify using a Property. This pull request attempts to address this by changing the type annotations for these properties. Going the other route: changing the implementation to work properly with a ColorMaterialProperty may be a better solution eventually, but is currently beyond my expertise. 