### PR TITLE
Fix polyline color issue involving duplicate positions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - Fixes an error with removing a CZML datasource when the clock interval has a duration of zero. [#9637](https://github.com/CesiumGS/cesium/pull/9637)
 - Fixed the ability to set a material's image to `undefined` and `Material.DefaultImageId`. [#9644](https://github.com/CesiumGS/cesium/pull/9644)
 - Fixed render crash when creating a `polylineVolume` with very close points. [#9669](https://github.com/CesiumGS/cesium/pull/9669)
+- Fixed a bug in `PolylineGeometry` that incorrectly shifted colors when duplicate positions were removed. [#9676](https://github.com/CesiumGS/cesium/pull/9676)
 
 ### 1.83 - 2021-07-01
 

--- a/Source/Core/PolylineGeometry.js
+++ b/Source/Core/PolylineGeometry.js
@@ -319,15 +319,17 @@ PolylineGeometry.createGeometry = function (polylineGeometry) {
 
   if (defined(colors) && removedIndices.length > 0) {
     var removedArrayIndex = 0;
-    var offset = colorsPerVertex ? 0 : 1;
     var nextRemovedIndex = removedIndices[0];
-    var perVertexAndEndpointCollapsed =
-      colorsPerVertex && nextRemovedIndex === 1;
     colors = colors.filter(function (color, index) {
-      if (
-        index + offset === nextRemovedIndex ||
-        (index === 0 && perVertexAndEndpointCollapsed)
-      ) {
+      var remove = false;
+      if (colorsPerVertex) {
+        remove =
+          index === nextRemovedIndex || (index === 0 && nextRemovedIndex === 1);
+      } else {
+        remove = index + 1 === nextRemovedIndex;
+      }
+
+      if (remove) {
         removedArrayIndex++;
         nextRemovedIndex = removedIndices[removedArrayIndex];
         return false;

--- a/Source/Core/PolylineGeometry.js
+++ b/Source/Core/PolylineGeometry.js
@@ -309,10 +309,45 @@ PolylineGeometry.createGeometry = function (polylineGeometry) {
   var j;
   var k;
 
+  var removedIndices = [];
   var positions = arrayRemoveDuplicates(
     polylineGeometry._positions,
-    Cartesian3.equalsEpsilon
+    Cartesian3.equalsEpsilon,
+    false,
+    removedIndices
   );
+
+  if (defined(colors) && removedIndices.length > 0) {
+    var removedArrayIndex = 0;
+    var length = colors.length;
+    var nextRemovedIndex = removedIndices[0];
+    var colorsScratch = [];
+    var ii;
+    if (colorsPerVertex) {
+      for (ii = 0; ii < length; ii++) {
+        if (ii === nextRemovedIndex) {
+          removedArrayIndex++;
+          nextRemovedIndex = removedIndices[removedArrayIndex];
+        } else {
+          colorsScratch.push(colors[ii]);
+        }
+      }
+    } else {
+      // If polyline is colored in segments, the color is counted
+      // if the endpoint hasn't been removed.
+      for (ii = 0; ii < length; ii++) {
+        if (ii + 1 === nextRemovedIndex) {
+          removedArrayIndex++;
+          nextRemovedIndex = removedIndices[removedArrayIndex];
+        } else {
+          colorsScratch.push(colors[ii]);
+        }
+      }
+    }
+
+    colors = colorsScratch;
+  }
+
   var positionsLength = positions.length;
 
   // A width of a pixel or less is not a valid geometry, but in order to support external data

--- a/Source/Core/PolylineGeometry.js
+++ b/Source/Core/PolylineGeometry.js
@@ -319,33 +319,21 @@ PolylineGeometry.createGeometry = function (polylineGeometry) {
 
   if (defined(colors) && removedIndices.length > 0) {
     var removedArrayIndex = 0;
-    var length = colors.length;
+    var offset = colorsPerVertex ? 0 : 1;
     var nextRemovedIndex = removedIndices[0];
-    var colorsScratch = [];
-    var ii;
-    if (colorsPerVertex) {
-      for (ii = 0; ii < length; ii++) {
-        if (ii === nextRemovedIndex) {
-          removedArrayIndex++;
-          nextRemovedIndex = removedIndices[removedArrayIndex];
-        } else {
-          colorsScratch.push(colors[ii]);
-        }
+    var perVertexAndEndpointCollapsed =
+      colorsPerVertex && nextRemovedIndex === 1;
+    colors = colors.filter(function (color, index) {
+      if (
+        index + offset === nextRemovedIndex ||
+        (index === 0 && perVertexAndEndpointCollapsed)
+      ) {
+        removedArrayIndex++;
+        nextRemovedIndex = removedIndices[removedArrayIndex];
+        return false;
       }
-    } else {
-      // If polyline is colored in segments, the color is counted
-      // if the endpoint hasn't been removed.
-      for (ii = 0; ii < length; ii++) {
-        if (ii + 1 === nextRemovedIndex) {
-          removedArrayIndex++;
-          nextRemovedIndex = removedIndices[removedArrayIndex];
-        } else {
-          colorsScratch.push(colors[ii]);
-        }
-      }
-    }
-
-    colors = colorsScratch;
+      return true;
+    });
   }
 
   var positionsLength = positions.length;

--- a/Source/Core/arrayRemoveDuplicates.js
+++ b/Source/Core/arrayRemoveDuplicates.js
@@ -10,7 +10,7 @@ var removeDuplicatesEpsilon = CesiumMath.EPSILON10;
  *
  * @param {Array.<*>} [values] The array of values.
  * @param {Function} equalsEpsilon Function to compare values with an epsilon. Boolean equalsEpsilon(left, right, epsilon).
- * @param {Boolean} [wrapAround=false] Compare the last value in the array against the first value.
+ * @param {Boolean} [wrapAround=false] Compare the last value in the array against the first value. If they are equal, the last value is removed.
  * @param {Array.<number>} [removedIndices=undefined] Store the indices that correspond to the duplicate items removed from the array, if there were any.
  * @returns {Array.<*>|undefined} A new array of values with no adjacent duplicate values or the input array if no duplicates were found.
  *
@@ -34,6 +34,17 @@ var removeDuplicatesEpsilon = CesiumMath.EPSILON10;
  *     new Cesium.Cartesian3(1.0, 1.0, 1.0)];
  * var nonDuplicatevalues = Cesium.PolylinePipeline.removeDuplicates(values, Cartesian3.equalsEpsilon, true);
  *
+ * @example
+ * // Returns [(1.0, 1.0, 1.0), (2.0, 2.0, 2.0), (3.0, 3.0, 3.0)]
+ * // removedIndices will be equal to [1, 3, 5]
+ * var values = [
+ *     new Cesium.Cartesian3(1.0, 1.0, 1.0),
+ *     new Cesium.Cartesian3(1.0, 1.0, 1.0),
+ *     new Cesium.Cartesian3(2.0, 2.0, 2.0),
+ *     new Cesium.Cartesian3(2.0, 2.0, 2.0),
+ *     new Cesium.Cartesian3(3.0, 3.0, 3.0),
+ *     new Cesium.Cartesian3(1.0, 1.0, 1.0)];
+ * var nonDuplicatevalues = Cesium.PolylinePipeline.removeDuplicates(values, Cartesian3.equalsEpsilon, true);
  * @private
  */
 function arrayRemoveDuplicates(
@@ -96,9 +107,10 @@ function arrayRemoveDuplicates(
       )
     ) {
       if (storeRemovedIndices) {
-        removedIndices.push(0);
+        removedIndices.push(values.length - 1);
       }
-      return values.slice(1);
+      values.length -= 1;
+      return values;
     }
     return values;
   }
@@ -113,9 +125,9 @@ function arrayRemoveDuplicates(
     )
   ) {
     if (storeRemovedIndices) {
-      removedIndices.unshift(0);
+      removedIndices.push(values.length - 1);
     }
-    cleanedValues.shift();
+    cleanedValues.length -= 1;
   }
 
   return cleanedValues;

--- a/Source/Core/arrayRemoveDuplicates.js
+++ b/Source/Core/arrayRemoveDuplicates.js
@@ -11,7 +11,7 @@ var removeDuplicatesEpsilon = CesiumMath.EPSILON10;
  * @param {Array.<*>} [values] The array of values.
  * @param {Function} equalsEpsilon Function to compare values with an epsilon. Boolean equalsEpsilon(left, right, epsilon).
  * @param {Boolean} [wrapAround=false] Compare the last value in the array against the first value. If they are equal, the last value is removed.
- * @param {Array.<number>} [removedIndices=undefined] Store the indices that correspond to the duplicate items removed from the array, if there were any.
+ * @param {Array.<Number>} [removedIndices=undefined] Store the indices that correspond to the duplicate items removed from the array, if there were any.
  * @returns {Array.<*>|undefined} A new array of values with no adjacent duplicate values or the input array if no duplicates were found.
  *
  * @example
@@ -97,10 +97,7 @@ function arrayRemoveDuplicates(
       if (defined(cleanedValues)) {
         cleanedValues.push(v1);
         lastCleanIndex = i;
-        if (
-          storeRemovedIndices &&
-          lastCleanIndex > removedIndices[removedIndices.length - 1]
-        ) {
+        if (storeRemovedIndices) {
           removedIndexLCI = removedIndices.length;
         }
       }
@@ -114,11 +111,7 @@ function arrayRemoveDuplicates(
   ) {
     if (storeRemovedIndices) {
       if (defined(cleanedValues)) {
-        removedIndices = removedIndices.splice(
-          removedIndexLCI,
-          0,
-          lastCleanIndex
-        );
+        removedIndices.splice(removedIndexLCI, 0, lastCleanIndex);
       } else {
         removedIndices.push(length - 1);
       }

--- a/Specs/Core/PolylineGeometrySpec.js
+++ b/Specs/Core/PolylineGeometrySpec.js
@@ -243,6 +243,41 @@ describe("Core/PolylineGeometry", function () {
     ).toBe(true);
   });
 
+  it("createGeometry removes duplicate positions", function () {
+    var positions = [
+      new Cartesian3(1.0, 2.0, 3.0),
+      new Cartesian3(2.0, 2.0, 3.0),
+      new Cartesian3(2.0, 2.0, 3.0),
+      new Cartesian3(3.0, 2.0, 3.0),
+      new Cartesian3(4.0, 2.0, 3.0),
+      new Cartesian3(4.0, 2.0, 3.0),
+      new Cartesian3(4.0, 2.0, 3.0),
+      new Cartesian3(5.0, 2.0, 3.0),
+    ];
+
+    var expectedPositions = [
+      new Cartesian3(1.0, 2.0, 3.0),
+      new Cartesian3(2.0, 2.0, 3.0),
+      new Cartesian3(3.0, 2.0, 3.0),
+      new Cartesian3(4.0, 2.0, 3.0),
+      new Cartesian3(5.0, 2.0, 3.0),
+    ];
+
+    var line = PolylineGeometry.createGeometry(
+      new PolylineGeometry({
+        positions: positions,
+        width: 10.0,
+        vertexFormat: VertexFormat.POSITION_ONLY,
+        arcType: ArcType.NONE,
+      })
+    );
+
+    var numVertices = expectedPositions.length * 4 - 4;
+    expect(line.attributes.position.values.length).toEqual(numVertices * 3);
+    expect(line.attributes.prevPosition.values.length).toEqual(numVertices * 3);
+    expect(line.attributes.nextPosition.values.length).toEqual(numVertices * 3);
+  });
+
   var positions = [
     new Cartesian3(1, 2, 3),
     new Cartesian3(4, 5, 6),

--- a/Specs/Core/PolylineGeometrySpec.js
+++ b/Specs/Core/PolylineGeometrySpec.js
@@ -1,4 +1,4 @@
-import { ArcType } from "../../Source/Cesium.js";
+import { ArcType, defaultValue } from "../../Source/Cesium.js";
 import { Cartesian3 } from "../../Source/Cesium.js";
 import { Color } from "../../Source/Cesium.js";
 import { Ellipsoid } from "../../Source/Cesium.js";
@@ -276,6 +276,217 @@ describe("Core/PolylineGeometry", function () {
     expect(line.attributes.position.values.length).toEqual(numVertices * 3);
     expect(line.attributes.prevPosition.values.length).toEqual(numVertices * 3);
     expect(line.attributes.nextPosition.values.length).toEqual(numVertices * 3);
+  });
+
+  function attributeArrayEqualsColorArray(
+    attributeArray,
+    colorArray,
+    colorsPerVertex
+  ) {
+    colorsPerVertex = defaultValue(colorsPerVertex, false);
+    var i;
+    var j;
+    var color;
+    var color2;
+    var reconstructedColor = new Color();
+    var attrArrayIndex;
+    var length = colorsPerVertex ? colorArray.length - 1 : colorArray.length;
+    for (i = 0; i < length; i++) {
+      color = colorArray[i];
+      color2 = colorArray[i + 1];
+
+      attrArrayIndex = 16 * i;
+      for (j = 0; j < 4; j++) {
+        reconstructedColor.red = attributeArray[attrArrayIndex + 4 * j] / 255;
+        reconstructedColor.green =
+          attributeArray[attrArrayIndex + 4 * j + 1] / 255;
+        reconstructedColor.blue =
+          attributeArray[attrArrayIndex + 4 * j + 2] / 255;
+        reconstructedColor.alpha =
+          attributeArray[attrArrayIndex + 4 * j + 3] / 255;
+        if (colorsPerVertex && j > 1) {
+          if (!reconstructedColor.equalsEpsilon(color2, CesiumMath.EPSILON2)) {
+            return false;
+          }
+        } else if (
+          !reconstructedColor.equalsEpsilon(color, CesiumMath.EPSILON2)
+        ) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  it("createGeometry removes segment colors corresponding to duplicate positions", function () {
+    var positions = [
+      new Cartesian3(1.0, 2.0, 3.0),
+      new Cartesian3(2.0, 2.0, 3.0),
+      new Cartesian3(2.0, 2.0, 3.0),
+      new Cartesian3(3.0, 2.0, 3.0),
+      new Cartesian3(4.0, 2.0, 3.0),
+      new Cartesian3(4.0, 2.0, 3.0),
+      new Cartesian3(4.0, 2.0, 3.0),
+      new Cartesian3(5.0, 2.0, 3.0),
+    ];
+
+    var colors = [
+      new Color(0.0, 1.0, 0.0, 1.0),
+      new Color(1.0, 0.0, 0.0, 1.0),
+      new Color(0.0, 0.0, 1.0, 1.0),
+      new Color(0.0, 1.0, 0.0, 1.0),
+      new Color(1.0, 0.0, 0.0, 1.0),
+      new Color(1.0, 0.0, 0.0, 1.0),
+      new Color(0.0, 0.0, 1.0, 1.0),
+    ];
+
+    var expectedPositions = [
+      new Cartesian3(1.0, 2.0, 3.0),
+      new Cartesian3(2.0, 2.0, 3.0),
+      new Cartesian3(3.0, 2.0, 3.0),
+      new Cartesian3(4.0, 2.0, 3.0),
+      new Cartesian3(5.0, 2.0, 3.0),
+    ];
+
+    var expectedColors = [
+      new Color(0.0, 1.0, 0.0, 1.0),
+      new Color(0.0, 0.0, 1.0, 1.0),
+      new Color(0.0, 1.0, 0.0, 1.0),
+      new Color(0.0, 0.0, 1.0, 1.0),
+    ];
+
+    var line = PolylineGeometry.createGeometry(
+      new PolylineGeometry({
+        positions: positions,
+        colors: colors,
+        width: 10.0,
+        vertexFormat: VertexFormat.POSITION_ONLY,
+        arcType: ArcType.NONE,
+      })
+    );
+
+    var numVertices = expectedPositions.length * 4 - 4;
+    expect(line.attributes.color.values.length).toEqual(numVertices * 4);
+    expect(
+      attributeArrayEqualsColorArray(
+        line.attributes.color.values,
+        expectedColors
+      )
+    ).toBe(true);
+  });
+
+  it("createGeometry removes per-vertex colors corresponding to duplicate positions", function () {
+    var positions = [
+      new Cartesian3(1.0, 2.0, 3.0),
+      new Cartesian3(2.0, 2.0, 3.0),
+      new Cartesian3(2.0, 2.0, 3.0),
+      new Cartesian3(3.0, 2.0, 3.0),
+      new Cartesian3(3.0, 2.0, 3.0),
+      new Cartesian3(4.0, 2.0, 3.0),
+      new Cartesian3(5.0, 2.0, 3.0),
+      new Cartesian3(5.0, 2.0, 3.0),
+      new Cartesian3(6.0, 2.0, 3.0),
+    ];
+
+    var colors = [
+      new Color(1.0, 0.0, 0.0, 1.0),
+      new Color(1.0, 0.5, 0.0, 1.0),
+      new Color(0.0, 0.0, 0.0, 1.0),
+      new Color(1.0, 1.0, 0.0, 1.0),
+      new Color(0.0, 0.0, 0.0, 1.0),
+      new Color(0.0, 1.0, 0.0, 1.0),
+      new Color(0.0, 1.0, 1.0, 1.0),
+      new Color(0.0, 0.0, 0.0, 1.0),
+      new Color(0.0, 0.0, 1.0, 1.0),
+    ];
+
+    var expectedPositions = [
+      new Cartesian3(1.0, 2.0, 3.0),
+      new Cartesian3(2.0, 2.0, 3.0),
+      new Cartesian3(3.0, 2.0, 3.0),
+      new Cartesian3(4.0, 2.0, 3.0),
+      new Cartesian3(5.0, 2.0, 3.0),
+      new Cartesian3(6.0, 2.0, 3.0),
+    ];
+
+    var expectedColors = [
+      new Color(1.0, 0.0, 0.0, 1.0),
+      new Color(1.0, 0.5, 0.0, 1.0),
+      new Color(1.0, 1.0, 0.0, 1.0),
+      new Color(0.0, 1.0, 0.0, 1.0),
+      new Color(0.0, 1.0, 1.0, 1.0),
+      new Color(0.0, 0.0, 1.0, 1.0),
+    ];
+
+    var line = PolylineGeometry.createGeometry(
+      new PolylineGeometry({
+        positions: positions,
+        colors: colors,
+        colorsPerVertex: true,
+        width: 10.0,
+        vertexFormat: VertexFormat.DEFAULT,
+        arcType: ArcType.NONE,
+      })
+    );
+
+    var numVertices = expectedPositions.length * 4 - 4;
+    expect(line.attributes.color.values.length).toEqual(numVertices * 4);
+    expect(
+      attributeArrayEqualsColorArray(
+        line.attributes.color.values,
+        expectedColors,
+        true
+      )
+    ).toBe(true);
+  });
+
+  it("createGeometry removes first color corresponding to endpoint with duplicate position", function () {
+    var positions = [
+      new Cartesian3(1.0, 2.0, 3.0),
+      new Cartesian3(1.0, 2.0, 3.0),
+      new Cartesian3(2.0, 2.0, 3.0),
+      new Cartesian3(3.0, 2.0, 3.0),
+    ];
+
+    var colors = [
+      new Color(0.0, 0.0, 0.0, 1.0),
+      new Color(1.0, 1.0, 1.0, 1.0),
+      new Color(0.0, 1.0, 0.0, 1.0),
+      new Color(0.0, 0.0, 1.0, 1.0),
+    ];
+
+    var expectedPositions = [
+      new Cartesian3(1.0, 2.0, 3.0),
+      new Cartesian3(2.0, 2.0, 3.0),
+      new Cartesian3(3.0, 2.0, 3.0),
+    ];
+
+    var expectedColors = [
+      new Color(1.0, 1.0, 1.0, 1.0),
+      new Color(0.0, 1.0, 0.0, 1.0),
+      new Color(0.0, 0.0, 1.0, 1.0),
+    ];
+
+    var line = PolylineGeometry.createGeometry(
+      new PolylineGeometry({
+        positions: positions,
+        colors: colors,
+        colorsPerVertex: true,
+        width: 10.0,
+        vertexFormat: VertexFormat.DEFAULT,
+        arcType: ArcType.NONE,
+      })
+    );
+
+    var numVertices = expectedPositions.length * 4 - 4;
+    expect(line.attributes.color.values.length).toEqual(numVertices * 4);
+    expect(
+      attributeArrayEqualsColorArray(
+        line.attributes.color.values,
+        expectedColors,
+        true
+      )
+    ).toBe(true);
   });
 
   var positions = [

--- a/Specs/Core/arrayRemoveDuplicatesSpec.js
+++ b/Specs/Core/arrayRemoveDuplicatesSpec.js
@@ -4,7 +4,7 @@ import { Math as CesiumMath } from "../../Source/Cesium.js";
 import { Spherical } from "../../Source/Cesium.js";
 
 describe("Core/arrayRemoveDuplicates", function () {
-  it("removeDuplicates returns positions if none removed", function () {
+  it("removeDuplicates returns positions if none removed - length === 1", function () {
     var positions = [Cartesian3.ZERO];
     var noDuplicates = arrayRemoveDuplicates(
       positions,
@@ -13,7 +13,7 @@ describe("Core/arrayRemoveDuplicates", function () {
     expect(noDuplicates).toBe(positions);
   });
 
-  it("removeDuplicates returns positions if none removed", function () {
+  it("removeDuplicates returns positions if none removed - length > 1", function () {
     var positions = [
       Cartesian3.ZERO,
       Cartesian3.UNIT_X,
@@ -179,6 +179,21 @@ describe("Core/arrayRemoveDuplicates", function () {
     expect(noDuplicates).toBe(undefined);
   });
 
+  it("removeDuplicates doesn't remove duplicate first and last points without wrapping", function () {
+    var positions = [
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(2.0, 2.0, 2.0),
+      new Cartesian3(3.0, 3.0, 3.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+    ];
+    var noDuplicates = arrayRemoveDuplicates(
+      positions,
+      Cartesian3.equalsEpsilon
+    );
+
+    expect(noDuplicates).toBe(positions);
+  });
+
   it("removeDuplicates wrapping removes duplicate first and last points", function () {
     var positions = [
       new Cartesian3(1.0, 1.0, 1.0),
@@ -205,6 +220,7 @@ describe("Core/arrayRemoveDuplicates", function () {
   it("removeDuplicates wrapping removes duplicate including first and last points", function () {
     var positions = [
       new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(1.0, 1.0, 1.0),
       new Cartesian3(2.0, 2.0, 2.0),
       new Cartesian3(2.0, 2.0, 2.0),
       new Cartesian3(3.0, 3.0, 3.0),
@@ -224,5 +240,153 @@ describe("Core/arrayRemoveDuplicates", function () {
     );
 
     expect(noDuplicates).toEqual(expectedPositions);
+  });
+
+  it("removeDuplicates doesn't modify removedIndices when there are no duplicates - length === 1", function () {
+    var positions = [Cartesian3.ZERO];
+
+    var removedIndices = [];
+
+    var noDuplicates = arrayRemoveDuplicates(
+      positions,
+      Cartesian3.equalsEpsilon,
+      false,
+      removedIndices
+    );
+
+    expect(noDuplicates).toBe(positions);
+    expect(removedIndices).toEqual([]);
+  });
+
+  it("removeDuplicates doesn't modify removedIndices when there are no duplicates - length > 1", function () {
+    var positions = [
+      Cartesian3.ZERO,
+      Cartesian3.UNIT_X,
+      Cartesian3.UNIT_Y,
+      Cartesian3.UNIT_Z,
+    ];
+
+    var removedIndices = [];
+
+    var noDuplicates = arrayRemoveDuplicates(
+      positions,
+      Cartesian3.equalsEpsilon,
+      false,
+      removedIndices
+    );
+
+    expect(noDuplicates).toBe(positions);
+    expect(removedIndices).toEqual([]);
+  });
+
+  it("removeDuplicates modifies removedIndices when there are duplicates", function () {
+    var positions = [
+      Cartesian3.ZERO,
+      Cartesian3.UNIT_X,
+      Cartesian3.UNIT_X,
+      Cartesian3.UNIT_Y,
+      Cartesian3.UNIT_Z,
+      Cartesian3.UNIT_Z,
+    ];
+
+    var expectedPositions = [
+      Cartesian3.ZERO,
+      Cartesian3.UNIT_X,
+      Cartesian3.UNIT_Y,
+      Cartesian3.UNIT_Z,
+    ];
+
+    var removedIndices = [];
+
+    var noDuplicates = arrayRemoveDuplicates(
+      positions,
+      Cartesian3.equalsEpsilon,
+      false,
+      removedIndices
+    );
+
+    expect(noDuplicates).toEqual(expectedPositions);
+    expect(removedIndices).toEqual([2, 5]);
+  });
+
+  it("removeDuplicates doesn't modify removedIndices when there are duplicates without wrapping", function () {
+    var positions = [
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(2.0, 2.0, 2.0),
+      new Cartesian3(3.0, 3.0, 3.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+    ];
+
+    var removedIndices = [];
+
+    var noDuplicates = arrayRemoveDuplicates(
+      positions,
+      Cartesian3.equalsEpsilon,
+      false,
+      removedIndices
+    );
+
+    expect(noDuplicates).toBe(positions);
+    expect(removedIndices).toEqual([]);
+  });
+
+  it("removeDuplicates modifies removedIndices when there are duplicates wrapped around", function () {
+    var positions = [
+      Cartesian3.ZERO,
+      Cartesian3.UNIT_X,
+      Cartesian3.UNIT_Y,
+      Cartesian3.UNIT_Z,
+      Cartesian3.ZERO,
+    ];
+
+    var expectedPositions = [
+      Cartesian3.UNIT_X,
+      Cartesian3.UNIT_Y,
+      Cartesian3.UNIT_Z,
+      Cartesian3.ZERO,
+    ];
+
+    var removedIndices = [];
+
+    var noDuplicates = arrayRemoveDuplicates(
+      positions,
+      Cartesian3.equalsEpsilon,
+      true,
+      removedIndices
+    );
+
+    expect(noDuplicates).toEqual(expectedPositions);
+    expect(removedIndices).toEqual([0]);
+  });
+
+  it("removeDuplicates modifies removedIndices when there are duplicates including wrapped around", function () {
+    var positions = [
+      Cartesian3.ZERO,
+      Cartesian3.ZERO,
+      Cartesian3.UNIT_X,
+      Cartesian3.UNIT_Y,
+      Cartesian3.UNIT_Y,
+      Cartesian3.UNIT_Z,
+      Cartesian3.UNIT_Z,
+      Cartesian3.ZERO,
+    ];
+
+    var expectedPositions = [
+      Cartesian3.UNIT_X,
+      Cartesian3.UNIT_Y,
+      Cartesian3.UNIT_Z,
+      Cartesian3.ZERO,
+    ];
+
+    var removedIndices = [];
+    var noDuplicates = arrayRemoveDuplicates(
+      positions,
+      Cartesian3.equalsEpsilon,
+      true,
+      removedIndices
+    );
+
+    expect(noDuplicates).toEqual(expectedPositions);
+    expect(removedIndices).toEqual([0, 1, 4, 6]);
   });
 });

--- a/Specs/Core/arrayRemoveDuplicatesSpec.js
+++ b/Specs/Core/arrayRemoveDuplicatesSpec.js
@@ -267,6 +267,34 @@ describe("Core/arrayRemoveDuplicates", function () {
     expect(noDuplicates).toEqual(expectedPositions);
   });
 
+  it("removeDuplicates wrapping removes string of duplicates at end", function () {
+    var positions = [
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(2.0, 2.0, 2.0),
+      new Cartesian3(3.0, 3.0, 3.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+    ];
+
+    var expectedPositions = [
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(2.0, 2.0, 2.0),
+      new Cartesian3(3.0, 3.0, 3.0),
+    ];
+
+    var noDuplicates = arrayRemoveDuplicates(
+      positions,
+      Cartesian3.equalsEpsilon,
+      true
+    );
+
+    expect(noDuplicates).toEqual(expectedPositions);
+  });
+
   it("removeDuplicates wrapping doesn't remove nonadjacent duplicates", function () {
     var positions = [
       new Cartesian3(1.0, 1.0, 1.0),
@@ -438,5 +466,72 @@ describe("Core/arrayRemoveDuplicates", function () {
 
     expect(noDuplicates).toEqual(expectedPositions);
     expect(removedIndices).toEqual([1, 4, 6, 7]);
+  });
+
+  it("removeDuplicates wrapping modifies indicesRemoved with string of duplicates", function () {
+    var positions = [
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(2.0, 2.0, 2.0),
+      new Cartesian3(3.0, 3.0, 3.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+    ];
+
+    var expectedPositions = [
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(2.0, 2.0, 2.0),
+      new Cartesian3(3.0, 3.0, 3.0),
+    ];
+
+    var removedIndices = [];
+    var noDuplicates = arrayRemoveDuplicates(
+      positions,
+      Cartesian3.equalsEpsilon,
+      true,
+      removedIndices
+    );
+
+    expect(noDuplicates).toEqual(expectedPositions);
+    expect(removedIndices).toEqual([1, 4, 5, 6, 7, 8]);
+  });
+
+  it("removeDuplicates wrapping modifies indicesRemoved with multiple strings of duplicates", function () {
+    var positions = [
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(2.0, 2.0, 2.0),
+      new Cartesian3(3.0, 3.0, 3.0),
+      new Cartesian3(3.0, 3.0, 3.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(3.0, 3.0, 3.0),
+      new Cartesian3(3.0, 3.0, 3.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+    ];
+
+    var expectedPositions = [
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(2.0, 2.0, 2.0),
+      new Cartesian3(3.0, 3.0, 3.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(3.0, 3.0, 3.0),
+    ];
+
+    var removedIndices = [];
+    var noDuplicates = arrayRemoveDuplicates(
+      positions,
+      Cartesian3.equalsEpsilon,
+      true,
+      removedIndices
+    );
+
+    expect(noDuplicates).toEqual(expectedPositions);
+    expect(removedIndices).toEqual([1, 4, 6, 7, 9, 10, 11]);
   });
 });

--- a/Specs/Core/arrayRemoveDuplicatesSpec.js
+++ b/Specs/Core/arrayRemoveDuplicatesSpec.js
@@ -64,6 +64,30 @@ describe("Core/arrayRemoveDuplicates", function () {
     expect(noDuplicates).toEqual(expectedPositions);
   });
 
+  it("removeDuplicates doesn't remove duplicates that are nonadjacent", function () {
+    var positions = [
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(2.0, 2.0, 2.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(3.0, 3.0, 3.0),
+      new Cartesian3(3.0, 3.0, 3.0),
+    ];
+    var expectedPositions = [
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(2.0, 2.0, 2.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(3.0, 3.0, 3.0),
+    ];
+    var noDuplicates = arrayRemoveDuplicates(
+      positions,
+      Cartesian3.equalsEpsilon
+    );
+    expect(noDuplicates).toEqual(expectedPositions);
+  });
+
   it("removeDuplicates to remove duplicates with anonymous types", function () {
     var positions = [
       { x: 1.0, y: 1.0, z: 1.0 },
@@ -203,9 +227,9 @@ describe("Core/arrayRemoveDuplicates", function () {
     ];
 
     var expectedPositions = [
+      new Cartesian3(1.0, 1.0, 1.0),
       new Cartesian3(2.0, 2.0, 2.0),
       new Cartesian3(3.0, 3.0, 3.0),
-      new Cartesian3(1.0, 1.0, 1.0),
     ];
 
     var noDuplicates = arrayRemoveDuplicates(
@@ -225,12 +249,38 @@ describe("Core/arrayRemoveDuplicates", function () {
       new Cartesian3(2.0, 2.0, 2.0),
       new Cartesian3(3.0, 3.0, 3.0),
       new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(1.0, 1.0, 1.0),
     ];
 
     var expectedPositions = [
+      new Cartesian3(1.0, 1.0, 1.0),
       new Cartesian3(2.0, 2.0, 2.0),
       new Cartesian3(3.0, 3.0, 3.0),
+    ];
+
+    var noDuplicates = arrayRemoveDuplicates(
+      positions,
+      Cartesian3.equalsEpsilon,
+      true
+    );
+
+    expect(noDuplicates).toEqual(expectedPositions);
+  });
+
+  it("removeDuplicates wrapping doesn't remove nonadjacent duplicates", function () {
+    var positions = [
       new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(2.0, 2.0, 2.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(3.0, 3.0, 3.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+    ];
+
+    var expectedPositions = [
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(2.0, 2.0, 2.0),
+      new Cartesian3(1.0, 1.0, 1.0),
+      new Cartesian3(3.0, 3.0, 3.0),
     ];
 
     var noDuplicates = arrayRemoveDuplicates(
@@ -340,10 +390,10 @@ describe("Core/arrayRemoveDuplicates", function () {
     ];
 
     var expectedPositions = [
+      Cartesian3.ZERO,
       Cartesian3.UNIT_X,
       Cartesian3.UNIT_Y,
       Cartesian3.UNIT_Z,
-      Cartesian3.ZERO,
     ];
 
     var removedIndices = [];
@@ -356,7 +406,7 @@ describe("Core/arrayRemoveDuplicates", function () {
     );
 
     expect(noDuplicates).toEqual(expectedPositions);
-    expect(removedIndices).toEqual([0]);
+    expect(removedIndices).toEqual([4]);
   });
 
   it("removeDuplicates modifies removedIndices when there are duplicates including wrapped around", function () {
@@ -372,10 +422,10 @@ describe("Core/arrayRemoveDuplicates", function () {
     ];
 
     var expectedPositions = [
+      Cartesian3.ZERO,
       Cartesian3.UNIT_X,
       Cartesian3.UNIT_Y,
       Cartesian3.UNIT_Z,
-      Cartesian3.ZERO,
     ];
 
     var removedIndices = [];
@@ -387,6 +437,6 @@ describe("Core/arrayRemoveDuplicates", function () {
     );
 
     expect(noDuplicates).toEqual(expectedPositions);
-    expect(removedIndices).toEqual([0, 1, 4, 6]);
+    expect(removedIndices).toEqual([1, 4, 6, 7]);
   });
 });


### PR DESCRIPTION
Fixes #9379. This PR changes how colors are handled in `PolylineGeometry.createGeometry`:
- `arrayRemoveDuplicates` now accepts an optional `removedIndices` parameter. If any entries are removed from the original array during this function, the indices of those entries will be stored in `removedIndices` in sorted order.
- `createGeometry` will use this array to remove the colors that correspond to those extraneous positions. This should work for both segment coloring and per-vertex coloring.

Additionally, I noticed that if `wrapAround` were set to `true` in the parameters, and if an array's first and last entries were equal, `arrayRemoveDuplicates` would remove the first entry. However, the examples in the documentation suggested that the last entry was supposed to be removed instead. I changed the function to match the example.

-------------------------------------
### Segment Coloring
 [This sandcastle](https://sandcastle.cesium.com/index.html#c=fVNhb9owEP0rFp9SiTllCE3LKBqiKavESsUQXdVUk0kOsObY0dkJY1X/++ykgZIhIlnyu3vvdHd+KRiSgsMWkFwRCVsyAs3zlC7KmBe14hKPlDSMS8CodfElkpEsrA5tZKm2x8J7JXbCMsegUjC4814iSUimNDdcSR3UvBFDY29MdukKVXoNawTQQ0S285yCkKcPn3pt8tEe3yfxhsk1ELPhmmwA7U2RMt/tuastZSpVHW3X8PMx7HQauNvAvRI/X5SRLU/MJiCdS3pZ4gJs139uFKbMBM2RR0ooHGYZMGQyBroIZ/Pw56+b6ez7cN521V2J2LH0PeCirBWQFRMa2odUQJ7qHTlMp7Ph3TisG6y+I8IsvD6TfQwnk+nDGcLocXh3Jv3w7XYePlf9CZZmczVGlcskIAZziOTrwRAZ8tQ+cwENS9ThygvrN2fcSm3cnuzA78jjRrbSHFRBbTsXfq1eie13HpyyYuNdvBfbOZNa5DFI87Z/W+owSul9qm0a6H4mTVmSeHvoqK12q6/NTsCgXt9XnmYKDclReJT6BtJMMGtOf5nHv8HQWGsndNS+/17aT3hBeHJ14odza9faZla5ED/4X4hag75v+f9JhWIJl+updalgO0fbdAaTKkgp7fsWnlYapcSSYaPyPw) was linked in the issue to demonstrate the bug. It sets up the following polyline:

![image](https://user-images.githubusercontent.com/32226860/125523329-00c1d222-395d-4a00-952f-c52a15490a3c.png)

In the current version of Cesium, if the orange segment is collapsed, the remaining segments will be colored incorrectly as shown.

![image](https://user-images.githubusercontent.com/32226860/125523487-ac4d1944-7b6f-444b-b084-e9a43768a0b4.png)

The changes in PR result in this polyline:

![image](https://user-images.githubusercontent.com/32226860/125524461-9a1312a9-c933-4bd6-80f1-98865b3f5dd9.png)

-------------------------------------

### Vertex Coloring
We can modify the sandcastle to have per-vertex coloring [like so](https://sandcastle.cesium.com/index.html#c=fVNhb9owEP0rFp9SiTllCE3LUrQsTVk1WiqK6KqmmkxygDXHjmwnjFX977OTBkqGiBTJ7+690935uSQSlRQ2INEF4rBBIShaZHhexZy4k1Q4FFwTykHGnbMvMY95aXTSRBZicyi8E2zLDHMEIgMtt85LzBHKhaKaCq68hhcSqc2J8D5eSpFdwkoCqEBKsnWsAqGnD58GXfTR/K6LkjXhK0B6TRVagzQngap8f2CPppSuVU2028DPh7DXa+F+Cw8q/HxWRTY01WsP9c7xeYVLMF3/uRIyI9prjxwKJmSQ50Ak4QngeTSdRT9/XU2mN8Gsa6vbEollqTuQ86qWh7QsoLvPeOipWZHFeDINbkdR01/9HRC+jYPwx4n8NLo8kX2MxuPJwwlC+Bjcnkg/fL+eRc91/4xk+UyMpCh4Ws8V89e9X3JJM+OCElqOacK1VVZvxrnmSts1moW8I49a2VqzV3mNK234tb5EsrsS75hTW9fmvJjOCVesSICbS14SpsCU2o9SPQ2sTBrwbiaFSZo6O2ipnW7HV3rLYNis7yvNciE1KiRzMHY1ZDkjxrvuokh+g8aJUlZoqb77XuqntEQ0vTjyHu3alTKZZcHYPf0LcWfou4b/n5QJklK+mhgTM7K1tHVvOK6DGGPfNfC4UgvBFkS2Kv8D).

![image](https://user-images.githubusercontent.com/32226860/125524827-90cd7e86-87db-40f8-9f33-be6f8e4827d7.png)

If we try to remove the black vertex by making it a duplicate, in the current version of Cesium, we'll find that it just shifts over to the other vertices:

![image](https://user-images.githubusercontent.com/32226860/125525088-d551e412-66d0-42d0-9a75-30638bc67e97.png)

However, we can remove it with these PR's changes:

![image](https://user-images.githubusercontent.com/32226860/125524980-9e62c93d-a8cd-49fe-b29e-9b7aa7527aa5.png)

cc @lilleyse for review

EDIT: now that I'm thinking about it, in the per-vertex example it probably makes more sense for the orange point to be removed rather than the middle black vertex, because that preserves the original coloring. I'll work a fix tomorrow