### PR TITLE
Strip soft hyphens from rendered text in labels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 - Fixed the ability to set a material's image to `undefined` and `Material.DefaultImageId`. [#9644](https://github.com/CesiumGS/cesium/pull/9644)
 - Fixed the calculation of `OrientedBoundingBox.distancedSquaredTo` such that they handle `halfAxes` with magnitudes near zero. [#9670](https://github.com/CesiumGS/cesium/pull/9670)
 - Fixed render crash when creating a `polylineVolume` with very close points. [#9669](https://github.com/CesiumGS/cesium/pull/9669)
+- Fixed a crash that would hang the browser if a `Label` was created with a soft hyphen in its text.
 
 ### 1.83 - 2021-07-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
 - Fixed the ability to set a material's image to `undefined` and `Material.DefaultImageId`. [#9644](https://github.com/CesiumGS/cesium/pull/9644)
 - Fixed the calculation of `OrientedBoundingBox.distancedSquaredTo` such that they handle `halfAxes` with magnitudes near zero. [#9670](https://github.com/CesiumGS/cesium/pull/9670)
 - Fixed render crash when creating a `polylineVolume` with very close points. [#9669](https://github.com/CesiumGS/cesium/pull/9669)
-- Fixed a crash that would hang the browser if a `Label` was created with a soft hyphen in its text.
+- Fixed a crash that would hang the browser if a `Label` was created with a soft hyphen in its text. [#9682](https://github.com/CesiumGS/cesium/pull/9682)
 
 ### 1.83 - 2021-07-01
 

--- a/Source/Scene/Label.js
+++ b/Source/Scene/Label.js
@@ -365,9 +365,12 @@ Object.defineProperties(Label.prototype, {
 
       if (this._text !== value) {
         this._text = value;
+
+        // Strip soft-hyphen (auto-wrap) characters from input string
+        var renderedValue = value.replace(/\u00ad/g, "");
         this._renderedText = Label.enableRightToLeftDetection
-          ? reverseRtl(value)
-          : value;
+          ? reverseRtl(renderedValue)
+          : renderedValue;
         rebindAllGlyphs(this);
       }
     },

--- a/Specs/Scene/LabelCollectionSpec.js
+++ b/Specs/Scene/LabelCollectionSpec.js
@@ -2004,6 +2004,18 @@ describe(
 
           expect(label.text).toEqual(text);
         });
+
+        it("filters out soft hyphens from input strings", function () {
+          var softHyphen = String.fromCharCode(0xad);
+          var text = "test string" + softHyphen;
+          var label = labels.add({
+            text: text,
+          });
+          scene.renderForSpecs();
+
+          expect(label.text).toEqual(text);
+          expect(label._renderedText).toEqual("test string");
+        });
       },
       "WebGL"
     );


### PR DESCRIPTION
Fixes #9334. [This sandcastle (localhost)](http://localhost:8080/Apps/Sandcastle/index.html#c=bVHBTgIxEP2VyZ6WBLtBBAIuxGQ9kmhC4qmXoTtgQ7clbXcRDZ/ET+iP2S4QjdJLO2/ee3kzbdBCI2lHFqagaQcFOVlX7KXFUp6Iti6M9ig1WZ507rlugkrhktRcOk8BLlCpJYpN6HG9qrXw0mjAspxHVtqBD64BFqhLgc4rYiUJhZbSCyW6wjkJI+2ll+RY6KatEmBrnIymk0vCAq0PL9R9trKmeqS1JXLpzWjAesO73nA46kJ/zMaD23g63ZNNm3oCZ1MAT29+Ajx5llh/HT+PPDkTD+19iLkOcaifWQKSdJPc+b2i2cXnQVZbYz3UVqWMZZ6qrcKQL1vWYkOeCedOIwLk2W9pXsoGZDm9smkIK3IudFa1Ugv5TjyZ5Vng/5Mqg6XU66eGrMJ9pL32ZvMTyBjLs1BeV3pjwsfZP87f) will hang the browser on the current version of Cesium because the label contains a [soft hyphen](https://en.wikipedia.org/wiki/Soft_hyphen) character (`0xAD` in hex). When the label attempts to create its texture atlas for its text, it doesn't properly handle the soft hyphen and gets stuck.

The fix I went with strips the soft hyphen from the `_renderedText` variable so it never makes it to the texture atlas function. Let me know if there is another way I should approach this.

cc @lilleyse 