### PR TITLE
Adds ability to get vctr polyline positions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 ##### Additions :tada:
 
+- Added a `polylinePositions` getter to `Cesium3DTileFeature` that gets the decoded positions of a polyline vector feature. [#9684](https://github.com/CesiumGS/cesium/pull/9684)
+
 ##### Fixes :wrench:
 
 - Fixed an issue in `TileBoundingRegion.distanceToCamera` that caused incorrect results when the camera was on the opposite site of the globe. [#9678](https://github.com/CesiumGS/cesium/pull/9678)

--- a/Source/Scene/Cesium3DTileFeature.js
+++ b/Source/Scene/Cesium3DTileFeature.js
@@ -86,6 +86,30 @@ Object.defineProperties(Cesium3DTileFeature.prototype, {
   },
 
   /**
+   * Gets a typed array containing the ECEF positions of the polyline.
+   * The feature must be a polyline in a vector tile and {@link Cesium3DTileset#vectorKeepDecodedPositions} must be true.
+   *
+   * @memberof Cesium3DTileFeature.prototype
+   *
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
+   *
+   * @type {Float64Array}
+   */
+  polylinePositions: {
+    get: function () {
+      if (!this.tileset.vectorKeepDecodedPositions) {
+        return undefined;
+      }
+
+      if (!defined(this._content.getPolylinePositions)) {
+        return undefined;
+      }
+
+      return this._content.getPolylinePositions(this._batchId);
+    },
+  },
+
+  /**
    * Gets the content of the tile containing the feature.
    *
    * @memberof Cesium3DTileFeature.prototype

--- a/Source/Scene/Cesium3DTileFeature.js
+++ b/Source/Scene/Cesium3DTileFeature.js
@@ -87,7 +87,8 @@ Object.defineProperties(Cesium3DTileFeature.prototype, {
 
   /**
    * Gets a typed array containing the ECEF positions of the polyline.
-   * The feature must be a polyline in a vector tile and {@link Cesium3DTileset#vectorKeepDecodedPositions} must be true.
+   * Returns undefined if {@link Cesium3DTileset#vectorKeepDecodedPositions} is false
+   * or the feature is not a polyline in a vector tile.
    *
    * @memberof Cesium3DTileFeature.prototype
    *
@@ -97,10 +98,6 @@ Object.defineProperties(Cesium3DTileFeature.prototype, {
    */
   polylinePositions: {
     get: function () {
-      if (!this.tileset.vectorKeepDecodedPositions) {
-        return undefined;
-      }
-
       if (!defined(this._content.getPolylinePositions)) {
         return undefined;
       }

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -98,6 +98,7 @@ import TileOrientedBoundingBox from "./TileOrientedBoundingBox.js";
  * @param {Boolean} [options.backFaceCulling=true] Whether to cull back-facing geometry. When true, back face culling is determined by the glTF material's doubleSided property; when false, back face culling is disabled.
  * @param {Boolean} [options.showOutline=true] Whether to display the outline for models using the {@link https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Vendor/CESIUM_primitive_outline|CESIUM_primitive_outline} extension. When true, outlines are displayed. When false, outlines are not displayed.
  * @param {Boolean} [options.vectorClassificationOnly=false] Indicates that only the tileset's vector tiles should be used for classification.
+ * @param {Boolean} [options.vectorKeepDecodedPositions=false] Whether vector tiles should keep decoded positions in memory. This is used with {@link Cesium3DTileFeature.getPolylinePositions}.
  * @param {String} [options.debugHeatmapTilePropertyName] The tile variable to colorize as a heatmap. All rendered tiles will be colorized relative to each other's specified variable value.
  * @param {Boolean} [options.debugFreezeFrame=false] For debugging only. Determines if only the tiles from last frame should be used for rendering.
  * @param {Boolean} [options.debugColorizeTiles=false] For debugging only. When true, assigns a random color to each tile.
@@ -283,6 +284,11 @@ function Cesium3DTileset(options) {
 
   this._vectorClassificationOnly = defaultValue(
     options.vectorClassificationOnly,
+    false
+  );
+
+  this._vectorKeepDecodedPositions = defaultValue(
+    options.vectorKeepDecodedPositions,
     false
   );
 
@@ -1730,6 +1736,23 @@ Object.defineProperties(Cesium3DTileset.prototype, {
   vectorClassificationOnly: {
     get: function () {
       return this._vectorClassificationOnly;
+    },
+  },
+
+  /**
+   * Whether vector tiles should keep decoded positions in memory.
+   * This is used with {@link Cesium3DTileFeature.getPolylinePositions}.
+   *
+   * @memberof Cesium3DTileset.prototype
+   *
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
+   *
+   * @type {Boolean}
+   * @default false
+   */
+  vectorKeepDecodedPositions: {
+    get: function () {
+      return this._vectorKeepDecodedPositions;
     },
   },
 });

--- a/Source/Scene/Vector3DTileClampedPolylines.js
+++ b/Source/Scene/Vector3DTileClampedPolylines.js
@@ -51,7 +51,8 @@ import Vector3DTilePolylines from "./Vector3DTilePolylines.js";
  * @param {Cartesian3} [options.center=Cartesian3.ZERO] The RTC center.
  * @param {Cesium3DTileBatchTable} options.batchTable The batch table for the tile containing the batched polylines.
  * @param {Uint16Array} options.batchIds The batch ids for each polyline.
- * @param {Cesium3DTileset} options.tileset The tileset.
+ * @param {ClassificationType} options.classificationType The classification type.
+ * @param {Boolean} options.keepDecodedPositions Whether to keep decoded positions in memory.
  *
  * @private
  */
@@ -79,7 +80,6 @@ function Vector3DTileClampedPolylines(options) {
 
   this._transferrableBatchIds = undefined;
   this._packedBuffer = undefined;
-  this._tileset = options.tileset;
   this._minimumMaximumVectorHeights = new Cartesian2(
     ApproximateTerrainHeights._defaultMinTerrainHeight,
     ApproximateTerrainHeights._defaultMaxTerrainHeight
@@ -90,8 +90,9 @@ function Vector3DTileClampedPolylines(options) {
     ApproximateTerrainHeights._defaultMaxTerrainHeight,
     this._ellipsoid
   );
+  this._classificationType = options.classificationType;
 
-  this._keepDecodedPositions = options.tileset.vectorKeepDecodedPositions;
+  this._keepDecodedPositions = options.keepDecodedPositions;
   this._decodedPositions = undefined;
   this._decodedPositionOffsets = undefined;
 
@@ -606,7 +607,7 @@ function queueCommands(primitive, frameState) {
     command.derivedCommands.tileset = derivedTilesetCommand;
   }
 
-  var classificationType = primitive._tileset.classificationType;
+  var classificationType = primitive._classificationType;
   if (
     classificationType === ClassificationType.TERRAIN ||
     classificationType === ClassificationType.BOTH

--- a/Source/Scene/Vector3DTileClampedPolylines.js
+++ b/Source/Scene/Vector3DTileClampedPolylines.js
@@ -627,7 +627,7 @@ function queueCommands(primitive, frameState) {
  *
  * @param {Number} batchId The batch ID of the feature.
  */
- Vector3DTileClampedPolylines.prototype.getPositions = function (batchId) {
+Vector3DTileClampedPolylines.prototype.getPositions = function (batchId) {
   return Vector3DTilePolylines.getPolylinePositions(this, batchId);
 };
 

--- a/Source/Scene/Vector3DTileClampedPolylines.js
+++ b/Source/Scene/Vector3DTileClampedPolylines.js
@@ -33,6 +33,7 @@ import CullFace from "./CullFace.js";
 import StencilConstants from "./StencilConstants.js";
 import StencilFunction from "./StencilFunction.js";
 import StencilOperation from "./StencilOperation.js";
+import Vector3DTilePolylines from "./Vector3DTilePolylines.js";
 
 /**
  * Creates a batch of polylines as volumes with shader-adjustable width.
@@ -50,7 +51,7 @@ import StencilOperation from "./StencilOperation.js";
  * @param {Cartesian3} [options.center=Cartesian3.ZERO] The RTC center.
  * @param {Cesium3DTileBatchTable} options.batchTable The batch table for the tile containing the batched polylines.
  * @param {Uint16Array} options.batchIds The batch ids for each polyline.
- * @param {Cesium3DTileset} options.tileset Tileset carrying minimum and maximum clamping heights.
+ * @param {Cesium3DTileset} options.tileset The tileset.
  *
  * @private
  */
@@ -89,6 +90,10 @@ function Vector3DTileClampedPolylines(options) {
     ApproximateTerrainHeights._defaultMaxTerrainHeight,
     this._ellipsoid
   );
+
+  this._keepDecodedPositions = options.tileset.vectorKeepDecodedPositions;
+  this._decodedPositions = undefined;
+  this._decodedPositionOffsets = undefined;
 
   // Fat vertices - all information for each volume packed to a vec3 and 5 vec4s
   this._startEllipsoidNormals = undefined;
@@ -261,6 +266,7 @@ function createVertexArray(polylines, context) {
       counts: counts.buffer,
       batchIds: batchIds.buffer,
       packedBuffer: packedBuffer.buffer,
+      keepDecodedPositions: polylines._keepDecodedPositions,
     };
 
     var verticesPromise = (polylines._verticesPromise = createVerticesTaskProcessor.scheduleTask(
@@ -273,6 +279,13 @@ function createVertexArray(polylines, context) {
     }
 
     when(verticesPromise, function (result) {
+      if (polylines._keepDecodedPositions) {
+        polylines._decodedPositions = new Float64Array(result.decodedPositions);
+        polylines._decodedPositionOffsets = new Uint32Array(
+          result.decodedPositionOffsets
+        );
+      }
+
       polylines._startEllipsoidNormals = new Float32Array(
         result.startEllipsoidNormals
       );
@@ -607,6 +620,15 @@ function queueCommands(primitive, frameState) {
     frameState.commandList.push(command.derivedCommands.tileset);
   }
 }
+
+/**
+ * Get the polyline positions for the given feature.
+ *
+ * @param {Number} batchId The batch ID of the feature.
+ */
+ Vector3DTileClampedPolylines.prototype.getPositions = function (batchId) {
+  return Vector3DTilePolylines.getPolylinePositions(this, batchId);
+};
 
 /**
  * Creates features for each polyline and places it at the batch id index of features.

--- a/Source/Scene/Vector3DTileContent.js
+++ b/Source/Scene/Vector3DTileContent.js
@@ -717,6 +717,15 @@ Vector3DTileContent.prototype.update = function (tileset, frameState) {
   }
 };
 
+Vector3DTileContent.prototype.getPolylinePositions = function (batchId) {
+  var polylines = this._polylines;
+  if (!defined(polylines)) {
+    return undefined;
+  }
+
+  return polylines.getPositions(batchId);
+};
+
 Vector3DTileContent.prototype.isDestroyed = function () {
   return false;
 };

--- a/Source/Scene/Vector3DTileContent.js
+++ b/Source/Scene/Vector3DTileContent.js
@@ -589,7 +589,8 @@ function initialize(content, arrayBuffer, byteOffset) {
       rectangle: rectangle,
       boundingVolume: content.tile.boundingVolume.boundingVolume,
       batchTable: batchTable,
-      tileset: tileset,
+      classificationType: tileset.classificationType,
+      keepDecodedPositions: tileset.vectorKeepDecodedPositions,
     });
   }
 

--- a/Source/Scene/Vector3DTilePolylines.js
+++ b/Source/Scene/Vector3DTilePolylines.js
@@ -42,7 +42,7 @@ import Cesium3DTileFeature from "./Cesium3DTileFeature.js";
  * @param {Cesium3DTileBatchTable} options.batchTable The batch table for the tile containing the batched polylines.
  * @param {Uint16Array} options.batchIds The batch ids for each polyline.
  * @param {BoundingSphere} options.boundingVolume The bounding volume for the entire batch of polylines.
- * @param {Cesium3DTileset} options.tileset The tileset.
+ * @param {Boolean} options.keepDecodedPositions Whether to keep decoded positions in memory.
  *
  * @private
  */
@@ -71,7 +71,7 @@ function Vector3DTilePolylines(options) {
   this._transferrableBatchIds = undefined;
   this._packedBuffer = undefined;
 
-  this._keepDecodedPositions = options.tileset.vectorKeepDecodedPositions;
+  this._keepDecodedPositions = options.keepDecodedPositions;
   this._decodedPositions = undefined;
   this._decodedPositionOffsets = undefined;
 
@@ -493,7 +493,7 @@ function queueCommands(primitive, frameState) {
   frameState.commandList.push(primitive._command);
 }
 
-Vector3DTilePolylines.getPolylinePositions = function(polylines, batchId) {
+Vector3DTilePolylines.getPolylinePositions = function (polylines, batchId) {
   var batchIds = polylines._batchIds;
   var positions = polylines._decodedPositions;
   var offsets = polylines._decodedPositionOffsets;
@@ -512,6 +512,10 @@ Vector3DTilePolylines.getPolylinePositions = function(polylines, batchId) {
     if (batchIds[i] === batchId) {
       positionsLength += offsets[i + 1] - offsets[i];
     }
+  }
+
+  if (positionsLength === 0) {
+    return undefined;
   }
 
   var results = new Float64Array(positionsLength * 3);
@@ -537,7 +541,7 @@ Vector3DTilePolylines.getPolylinePositions = function(polylines, batchId) {
  *
  * @param {Number} batchId The batch ID of the feature.
  */
- Vector3DTilePolylines.prototype.getPositions = function (batchId) {
+Vector3DTilePolylines.prototype.getPositions = function (batchId) {
   return Vector3DTilePolylines.getPolylinePositions(this, batchId);
 };
 

--- a/Source/Scene/Vector3DTilePolylines.js
+++ b/Source/Scene/Vector3DTilePolylines.js
@@ -42,6 +42,7 @@ import Cesium3DTileFeature from "./Cesium3DTileFeature.js";
  * @param {Cesium3DTileBatchTable} options.batchTable The batch table for the tile containing the batched polylines.
  * @param {Uint16Array} options.batchIds The batch ids for each polyline.
  * @param {BoundingSphere} options.boundingVolume The bounding volume for the entire batch of polylines.
+ * @param {Cesium3DTileset} options.tileset The tileset.
  *
  * @private
  */
@@ -69,6 +70,10 @@ function Vector3DTilePolylines(options) {
 
   this._transferrableBatchIds = undefined;
   this._packedBuffer = undefined;
+
+  this._keepDecodedPositions = options.tileset.vectorKeepDecodedPositions;
+  this._decodedPositions = undefined;
+  this._decodedPositionOffsets = undefined;
 
   this._currentPositions = undefined;
   this._previousPositions = undefined;
@@ -211,6 +216,7 @@ function createVertexArray(polylines, context) {
       counts: counts.buffer,
       batchIds: batchIds.buffer,
       packedBuffer: packedBuffer.buffer,
+      keepDecodedPositions: polylines._keepDecodedPositions,
     };
 
     var verticesPromise = (polylines._verticesPromise = createVerticesTaskProcessor.scheduleTask(
@@ -224,6 +230,15 @@ function createVertexArray(polylines, context) {
 
     when(verticesPromise)
       .then(function (result) {
+        if (polylines._keepDecodedPositions) {
+          polylines._decodedPositions = new Float64Array(
+            result.decodedPositions
+          );
+          polylines._decodedPositionOffsets = new Uint32Array(
+            result.decodedPositionOffsets
+          );
+        }
+
         polylines._currentPositions = new Float32Array(result.currentPositions);
         polylines._previousPositions = new Float32Array(
           result.previousPositions
@@ -477,6 +492,54 @@ function queueCommands(primitive, frameState) {
 
   frameState.commandList.push(primitive._command);
 }
+
+Vector3DTilePolylines.getPolylinePositions = function(polylines, batchId) {
+  var batchIds = polylines._batchIds;
+  var positions = polylines._decodedPositions;
+  var offsets = polylines._decodedPositionOffsets;
+
+  if (!defined(batchIds) || !defined(positions)) {
+    return undefined;
+  }
+
+  var i;
+  var j;
+  var polylinesLength = batchIds.length;
+  var positionsLength = 0;
+  var resultCounter = 0;
+
+  for (i = 0; i < polylinesLength; ++i) {
+    if (batchIds[i] === batchId) {
+      positionsLength += offsets[i + 1] - offsets[i];
+    }
+  }
+
+  var results = new Float64Array(positionsLength * 3);
+
+  for (i = 0; i < polylinesLength; ++i) {
+    if (batchIds[i] === batchId) {
+      var offset = offsets[i];
+      var count = offsets[i + 1] - offset;
+      for (j = 0; j < count; ++j) {
+        var decodedOffset = (offset + j) * 3;
+        results[resultCounter++] = positions[decodedOffset];
+        results[resultCounter++] = positions[decodedOffset + 1];
+        results[resultCounter++] = positions[decodedOffset + 2];
+      }
+    }
+  }
+
+  return results;
+};
+
+/**
+ * Get the polyline positions for the given feature.
+ *
+ * @param {Number} batchId The batch ID of the feature.
+ */
+ Vector3DTilePolylines.prototype.getPositions = function (batchId) {
+  return Vector3DTilePolylines.getPolylinePositions(this, batchId);
+};
 
 /**
  * Creates features for each polyline and places it at the batch id index of features.

--- a/Specs/Scene/Cesium3DTileFeatureSpec.js
+++ b/Specs/Scene/Cesium3DTileFeatureSpec.js
@@ -2,7 +2,10 @@ import {
   Cartesian3,
   Cartesian4,
   Cesium3DTileFeature,
+  Ellipsoid,
   HeadingPitchRange,
+  Math as CesiumMath,
+  Rectangle,
 } from "../../Source/Cesium.js";
 import Cesium3DTilesTester from "../Cesium3DTilesTester.js";
 import createScene from "../createScene.js";
@@ -10,6 +13,73 @@ import createScene from "../createScene.js";
 describe(
   "Scene/Cesium3DTileFeatureSpec",
   function () {
+    describe("polylinePositions", function () {
+      var vectorPolylinesWithBatchIds =
+        "./Data/Cesium3DTiles/Vector/VectorTilePolylinesWithBatchIds/tileset.json";
+      var b3dmWithBatchIds =
+        "Data/Cesium3DTiles/Batched/BatchedWithBatchTable/tileset.json";
+
+      var scene;
+      beforeAll(function () {
+        scene = createScene();
+      });
+
+      afterAll(function () {
+        scene.destroyForSpecs();
+      });
+
+      beforeEach(function () {
+        scene.primitives.removeAll();
+      });
+
+      it("polylinePositions gets positions for polyline vector data", function () {
+        var tilesetRectangle = Rectangle.fromDegrees(-0.01, -0.01, 0.01, 0.01);
+        var ellipsoid = Ellipsoid.WGS84;
+        scene.camera.lookAt(
+          ellipsoid.cartographicToCartesian(Rectangle.center(tilesetRectangle)),
+          new Cartesian3(0.0, 0.0, 0.01)
+        );
+        return Cesium3DTilesTester.loadTileset(
+          scene,
+          vectorPolylinesWithBatchIds,
+          {
+            vectorKeepDecodedPositions: true,
+          }
+        ).then(function (tileset) {
+          var feature = tileset.root.content.getFeature(0);
+          var polylinePositions = feature.polylinePositions;
+          expect(polylinePositions.length).toBe(60);
+          expect(polylinePositions[0]).toEqualEpsilon(
+            6378136.806372941,
+            CesiumMath.EPSILON7
+          );
+          expect(polylinePositions[1]).toEqualEpsilon(
+            -1113.194885441724,
+            CesiumMath.EPSILON7
+          );
+          expect(polylinePositions[2]).toEqualEpsilon(
+            1105.675261474196,
+            CesiumMath.EPSILON7
+          );
+        });
+      });
+
+      it("polylinePositions returns undefined for non polyline features", function () {
+        var centerLongitude = -1.31968;
+        var centerLatitude = 0.698874;
+        var center = Cartesian3.fromRadians(centerLongitude, centerLatitude);
+        scene.camera.lookAt(center, new HeadingPitchRange(0.0, -1.57, 15.0));
+
+        return Cesium3DTilesTester.loadTileset(scene, b3dmWithBatchIds, {
+          vectorKeepDecodedPositions: true,
+        }).then(function (tileset) {
+          var feature = tileset.root.content.getFeature(0);
+          var polylinePositions = feature.polylinePositions;
+          expect(polylinePositions).toBeUndefined();
+        });
+      });
+    });
+
     describe("3DTILES_metadata", function () {
       var tilesetWithMetadataUrl =
         "Data/Cesium3DTiles/Metadata/AllMetadataTypes/tileset.json";

--- a/Specs/Scene/Vector3DTileContentSpec.js
+++ b/Specs/Scene/Vector3DTileContentSpec.js
@@ -9,6 +9,7 @@ import {
   Ellipsoid,
   GeometryInstance,
   MetadataClass,
+  Math as CesiumMath,
   GroupMetadata,
   Pass,
   PerInstanceColorAppearance,
@@ -898,6 +899,117 @@ xdescribe(
         expect(content.innerContents).toBeUndefined();
         expect(content.hasProperty(0, "name")).toBe(true);
         expect(content.getFeature(0)).toBeDefined();
+      });
+    });
+
+    it("gets polyline positions", function () {
+      return Cesium3DTilesTester.loadTileset(
+        scene,
+        vectorPolylinesWithBatchIds,
+        {
+          vectorKeepDecodedPositions: true,
+        }
+      ).then(function (tileset) {
+        var content = tileset.root.content;
+        var polylinePositions = content.getPolylinePositions(0);
+        expect(polylinePositions.length).toBe(60);
+        expect(polylinePositions[0]).toEqualEpsilon(
+          6378136.806372941,
+          CesiumMath.EPSILON7
+        );
+        expect(polylinePositions[1]).toEqualEpsilon(
+          -1113.194885441724,
+          CesiumMath.EPSILON7
+        );
+        expect(polylinePositions[2]).toEqualEpsilon(
+          1105.675261474196,
+          CesiumMath.EPSILON7
+        );
+      });
+    });
+
+    it("gets polyline positions for individual polylines in a batch", function () {
+      return Cesium3DTilesTester.loadTileset(
+        scene,
+        vectorPolylinesBatchedChildren,
+        {
+          vectorKeepDecodedPositions: true,
+        }
+      ).then(function (tileset) {
+        var content = tileset.root.children[0].content;
+        expect(content.getPolylinePositions(0).length).toBe(60);
+        expect(content.getPolylinePositions(1).length).toBe(60);
+        expect(content.getPolylinePositions(2).length).toBe(60);
+        expect(content.getPolylinePositions(3).length).toBe(60);
+      });
+    });
+
+    it("gets polyline positions for clamped polylines", function () {
+      return Cesium3DTilesTester.loadTileset(
+        scene,
+        vectorPolylinesWithBatchIds,
+        {
+          vectorKeepDecodedPositions: true,
+          classificationType: ClassificationType.TERRAIN,
+        }
+      ).then(function (tileset) {
+        var content = tileset.root.content;
+        var polylinePositions = content.getPolylinePositions(0);
+        expect(polylinePositions.length).toBe(54); // duplicate positions are removed
+        expect(polylinePositions[0]).toEqualEpsilon(
+          6378136.806372941,
+          CesiumMath.EPSILON7
+        );
+        expect(polylinePositions[1]).toEqualEpsilon(
+          -1113.194885441724,
+          CesiumMath.EPSILON7
+        );
+        expect(polylinePositions[2]).toEqualEpsilon(
+          1105.675261474196,
+          CesiumMath.EPSILON7
+        );
+      });
+    });
+
+    it("getPolylinePositions returns undefined if there are no positions associated with the given batchId", function () {
+      return Cesium3DTilesTester.loadTileset(
+        scene,
+        vectorPolylinesWithBatchIds,
+        {
+          vectorKeepDecodedPositions: true,
+        }
+      ).then(function (tileset) {
+        var content = tileset.root.content;
+        var polylinePositions = content.getPolylinePositions(1);
+        expect(polylinePositions).toBeUndefined();
+      });
+    });
+
+    it("getPolylinePositions returns undefined if there are no polylines", function () {
+      return Cesium3DTilesTester.loadTileset(
+        scene,
+        vectorPolygonsWithBatchIds,
+        {
+          vectorKeepDecodedPositions: true,
+        }
+      ).then(function (tileset) {
+        var content = tileset.root.content;
+        var polylinePositions = content.getPolylinePositions(0);
+        expect(polylinePositions).toBeUndefined();
+      });
+    });
+
+    it("getPolylinePositions returns undefined if tileset.vectorKeepDecodedPositions is false", function () {
+      return Cesium3DTilesTester.loadTileset(
+        scene,
+        vectorPolylinesWithBatchIds,
+        {
+          vectorKeepDecodedPositions: false,
+        }
+      ).then(function (tileset) {
+        var content = tileset.root.content;
+        var polylinePositions = content.getPolylinePositions(0);
+        expect(polylinePositions).toBeUndefined();
       });
     });
 

--- a/Specs/Scene/Vector3DTilePolylinesSpec.js
+++ b/Specs/Scene/Vector3DTilePolylinesSpec.js
@@ -143,6 +143,7 @@ describe(
           center: center,
           boundingVolume: new BoundingSphere(center, 1000000.0),
           batchTable: batchTable,
+          keepDecodedPositions: false,
         })
       );
       return loadPolylines(polylines).then(function () {
@@ -193,6 +194,7 @@ describe(
           center: center,
           boundingVolume: new BoundingSphere(center, 1000000.0),
           batchTable: batchTable,
+          keepDecodedPositions: false,
         })
       );
       return loadPolylines(polylines).then(function () {
@@ -242,6 +244,7 @@ describe(
           center: center,
           boundingVolume: new BoundingSphere(center, 1000000.0),
           batchTable: batchTable,
+          keepDecodedPositions: false,
         })
       );
       return loadPolylines(polylines).then(function () {


### PR DESCRIPTION
Adds a `polylinePositions` getter to `Cesium3DTileFeature` that returns a Float64Array of cartesian coordinates for a polyline in a vctr tile. It works for both clamped and unclamped polylines.

Also adds an option to `Cesium3DTileset` called `vectorKeepDecodedPositions`. This option allows positions and offsets to stay in memory even after the positions have been uploaded  to the GPU. This must be set to true in order to use this feature. It is false by default so that applications that don't use this feature don't pay the extra memory cost.

Both are marked as `@experimental`.

There are some limitations:

* If multiple polylines have the same batch id there isn't a way to distinguish positions in one polyline vs. another. I haven't run across this case in practice. I was considering returning an array of `Float64Array` but thought it might make the API too complicated.
* The positions don't update correctly if the tileset model matrix changes. I'm pretty sure this is broken for vector tiles in general because the model matrix is only used once to transform the center point in the beginning (the rotational component is not applied to the positions). I'm not too surprised because the vctr format, like quantized mesh, defines positions in cartographic coordinates so there isn't usually a need to transform the data.
* Doesn't returned the clamped positions, just the positions as they are in the data

@angrycat9000 @mramato this is good for testing though I still need to finish up the to-do items below:

* [x] Tests
* [x] `CHANGES.md`

![Untitled](https://user-images.githubusercontent.com/915398/126245634-9bee47ab-b9d3-43d8-a6a4-c67572556cf7.png)

[Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=zVdtTxs5EP4rbr6wOZZdWvopAXQoBIGaACopVdWtkLM7IT4ce2V7E9Jr/vuNvS/J5oVSqapOgiRrz2PPPPN4PDulikwZzECREyJgRjqgWTYJ7t2Ytxe7x44UhjIBaq/ZjsQUMToGAQjJsYF7xKlIhCG5lFNczn2MgJpMgSZGEg1AzBiYIqnUzDAptDPvcBY/1SwTRWeEEp2OQQGRggCNxxXKgT5L9aTJSCoy6H78eHZ17ZNO9+7qU//h6PxhcNXr+oSKhFzfXHdJzKnWbMRimsPzCAzjoMHUw86/js4H+aT3byQIyRRvkagRBGH+d5dCrMNzamhYsw/vITZSFV926FbyOUfedFjsFvyj0YOGb5etuzWYp9Cq3NiYCsowLTIMfw1rWXDAqfPsA0B6DrFMILktM9EiRmUQiUXTZbFI63cpJwPpFc673K/kO0gVmyB8CjqgSbJqFolRJmK7ss3RhJqSiWpDL10faRLHtssNPNvERI2o0S7HKtH0QDyaMU5vrBDwfCokRw5m5eFZLEPrwzZ+Ha8v0yb7+6zYmeT77m9Z+Ssjf5Gjb2QfffLxH3/ssMGZt6+0e5fbRUhXHubCfijAcyCcKzi4qHGJLPepegL1/6TP2sZUGRQiFYgpFVkOHQWZSGn8tOm8TxwpzfZyoSHPoMs5S7VkybLSgDAIKRRX7Esqt1rL/f1yDspFWqSyR5ppwlirdvYrN713h8GhT5afTX8JRDGDYpQvD5zkUgWdL2fXldWi+LVolnldlLVx0O+50sjp3BGsx3LGxGNZ/4igE1fyJjLTYA3zamWHbwrYCUlknE2QiSBWCEOawD55USNh06ixck7jsnAHNE1BJJ0x44m3spi1XXkMXGG5tj5Y/QwxWYmSqdPRqpk2cw5BwnSaOxQ1hBSww6xMjrOjQy15ZnbZDqUxcuIsD3eYcBiZlwy+Ro1UMoFZOoAp0qKjxrefuIiQ2ZgZONAoTyjtU7UzIhSfTZq1ep8+74oF2XtUMkParURyRjkOOvs8r2P2OOb4b8Bq3OmzUEKLIBBGmLzEqUkq9sgE5W6tunDtiGc1ulgt3hrFAeLORtS1PFzihcjtOJgrkWbmzNUUryouUvSt5vooOm+CH1ZSxdFG4V6N8EYuRTqjmiA7U4YAPl8NwrdeS3vPL0ftCmxEvMLdIihvBRUUCzerUrJlEsWcs7g6V2OlvROLqIrNZanFsG5t70Edm4VpVTBxBpKLCl+/+XCyIglrUnWR5gfeRvtmLdzaek3y4wd5Ux8jTGhDRQxytK0duVin6JXn0RU7d6csAy+CvyyJcvkqqULnmdnTREhDKMcCk8yxd+PYOiCfFrmd31osbqtafYw5OuTl7tRM87T6m6mrpdZO59xuAa9cNW6vL91e7+Zzu4w0v/7Wbpx1j4MNi92Z3Lh6f2NOzuqHzLnoEy3dRZEnprw+bHFH+Vngy/sOuSyKzjbLquSWdwbFyqQxYcwWDXD6OCDbxB7MXQNTFMBtaxe1eiv4eTfYNjCdPDoXwLJNdc0SAl/fVdomyi/1cbdWE1173L/5dNd96N/cd5u/oX6615n1AvqLBSX989Vkmxz/4MHZtv2L3e7P09rrXgweOr2rzoc8rQ2/cexUeVq2aX+zSSqVsS94Hr7XGZjgkcEeMBxmGCB2V1qXHelxuAo9xj6LsOQkaqy9H6M2XQeFM6OM8zv2HQ/86XGI9htQLqltIgrNW7Px29NePhgEwXGIj9uRRko+pGpt5f8A)