### PR TITLE
Fix incorrect `distanceSquaredTo` calculation in `BoundingSphere`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 - Fixed the calculation of `OrientedBoundingBox.distancedSquaredTo` such that they handle `halfAxes` with magnitudes near zero. [#9670](https://github.com/CesiumGS/cesium/pull/9670)
 - Fixed render crash when creating a `polylineVolume` with very close points. [#9669](https://github.com/CesiumGS/cesium/pull/9669)
 - Fixed a bug in `PolylineGeometry` that incorrectly shifted colors when duplicate positions were removed. [#9676](https://github.com/CesiumGS/cesium/pull/9676)
+- Fixed the incorrect calculation of `distanceSquaredTo` in `BoundingSphere`. [#9686](https://github.com/CesiumGS/cesium/pull/9686)
 
 ### 1.83 - 2021-07-01
 

--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -1113,7 +1113,7 @@ var distanceSquaredToScratch = new Cartesian3();
  *
  * @param {BoundingSphere} sphere The sphere.
  * @param {Cartesian3} cartesian The point
- * @returns {Number} The estimated distance squared from the bounding sphere to the point.
+ * @returns {Number} The distance squared from the bounding sphere to the point. Returns 0 if the point is inside the sphere.
  *
  * @example
  * // Sort bounding spheres from back to front
@@ -1134,6 +1134,9 @@ BoundingSphere.distanceSquaredTo = function (sphere, cartesian) {
   );
 
   var distance = Cartesian3.magnitude(diff) - sphere.radius;
+  if (distance <= 0.0) {
+    return 0.0;
+  }
 
   return distance * distance;
 };

--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -1132,7 +1132,10 @@ BoundingSphere.distanceSquaredTo = function (sphere, cartesian) {
     cartesian,
     distanceSquaredToScratch
   );
-  return Cartesian3.magnitudeSquared(diff) - sphere.radius * sphere.radius;
+
+  var distance = Cartesian3.magnitude(diff) - sphere.radius;
+
+  return distance * distance;
 };
 
 /**

--- a/Source/Core/OrientedBoundingBox.js
+++ b/Source/Core/OrientedBoundingBox.js
@@ -693,7 +693,7 @@ var scratchPPrime = new Cartesian3();
  *
  * @param {OrientedBoundingBox} box The box.
  * @param {Cartesian3} cartesian The point
- * @returns {Number} The estimated distance squared from the bounding sphere to the point.
+ * @returns {Number} The distance squared from the oriented bounding box to the point. Returns 0 if the point is inside the box.
  *
  * @example
  * // Sort bounding boxes from back to front

--- a/Specs/Core/BoundingSphereSpec.js
+++ b/Specs/Core/BoundingSphereSpec.js
@@ -703,7 +703,7 @@ describe("Core/BoundingSphere", function () {
     ).toEqual(expected);
   });
 
-  it("distance squared to point", function () {
+  it("distance squared to point outside of sphere", function () {
     var bs = new BoundingSphere(Cartesian3.ZERO, 1.0);
     var position = new Cartesian3(-2.0, 1.0, 0.0);
     var expected = 1.52786405;
@@ -711,6 +711,12 @@ describe("Core/BoundingSphere", function () {
       expected,
       CesiumMath.EPSILON6
     );
+  });
+
+  it("distance squared to point inside sphere", function () {
+    var bs = new BoundingSphere(Cartesian3.ZERO, 1.0);
+    var position = new Cartesian3(-0.5, 0.5, 0.0);
+    expect(BoundingSphere.distanceSquaredTo(bs, position)).toEqual(0.0);
   });
 
   it("projectTo2D", function () {

--- a/Specs/Core/BoundingSphereSpec.js
+++ b/Specs/Core/BoundingSphereSpec.js
@@ -703,10 +703,11 @@ describe("Core/BoundingSphere", function () {
     ).toEqual(expected);
   });
 
-  it("estimated distance squared to point", function () {
+  it("distance squared to point", function () {
     var bs = new BoundingSphere(Cartesian3.ZERO, 1.0);
     var position = new Cartesian3(-2.0, 1.0, 0.0);
-    var expected = Cartesian3.magnitudeSquared(position) - 1.0;
+    var distance = Cartesian3.magnitude(position) - 1.0;
+    var expected = distance * distance;
     expect(BoundingSphere.distanceSquaredTo(bs, position)).toEqual(expected);
   });
 

--- a/Specs/Core/BoundingSphereSpec.js
+++ b/Specs/Core/BoundingSphereSpec.js
@@ -706,9 +706,11 @@ describe("Core/BoundingSphere", function () {
   it("distance squared to point", function () {
     var bs = new BoundingSphere(Cartesian3.ZERO, 1.0);
     var position = new Cartesian3(-2.0, 1.0, 0.0);
-    var distance = Cartesian3.magnitude(position) - 1.0;
-    var expected = distance * distance;
-    expect(BoundingSphere.distanceSquaredTo(bs, position)).toEqual(expected);
+    var expected = 1.52786405;
+    expect(BoundingSphere.distanceSquaredTo(bs, position)).toEqualEpsilon(
+      expected,
+      CesiumMath.EPSILON6
+    );
   });
 
   it("projectTo2D", function () {


### PR DESCRIPTION
As noted in [the forum](https://community.cesium.com/t/distance-to-bounding-sphere-function-looks-wrong/13567), the `distanceSquaredTo` calculation of `BoundingSphere` was incorrect. It was calculated as `(position - center)**2 - radius**2`, instead of `((position - center) - radius)**2`. This PR fixes the algorithm and the unit test that corresponds to it.

cc @lilleyse @ebogo1 