### PR TITLE
Add checks for empty content uris in `Cesium3DTile`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 ##### Additions :tada:
 
+- Added checks for empty content URIs in `Cesium3DTile`. [#9687](https://github.com/CesiumGS/cesium/pull/9687)
+
 ##### Fixes :wrench:
 
 - Fixed an issue in `TileBoundingRegion.distanceToCamera` that caused incorrect results when the camera was on the opposite site of the globe. [#9678](https://github.com/CesiumGS/cesium/pull/9678)
@@ -11,7 +13,7 @@
 - Fixed the ability to set a material's image to `undefined` and `Material.DefaultImageId`. [#9644](https://github.com/CesiumGS/cesium/pull/9644)
 - Fixed the calculation of `OrientedBoundingBox.distancedSquaredTo` such that they handle `halfAxes` with magnitudes near zero. [#9670](https://github.com/CesiumGS/cesium/pull/9670)
 - Fixed render crash when creating a `polylineVolume` with very close points. [#9669](https://github.com/CesiumGS/cesium/pull/9669)
-
+- 
 ### 1.83 - 2021-07-01
 
 ##### Breaking Changes :mega:

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -41,6 +41,7 @@ import TileBoundingSphere from "./TileBoundingSphere.js";
 import TileMetadata from "./TileMetadata.js";
 import TileOrientedBoundingBox from "./TileOrientedBoundingBox.js";
 import Pass from "../Renderer/Pass.js";
+import oneTimeWarning from "../Core/oneTimeWarning.js";
 
 /**
  * A tile in a {@link Cesium3DTileset}.  When a tile is first created, its content is not loaded;
@@ -220,13 +221,23 @@ function Cesium3DTile(tileset, baseResource, header, parent) {
       );
       contentHeaderUri = contentHeader.url;
     }
-    contentState = Cesium3DTileContentState.UNLOADED;
-    contentResource = baseResource.getDerivedResource({
-      url: contentHeaderUri,
-    });
-    serverKey = RequestScheduler.getServerKey(
-      contentResource.getUrlComponent()
-    );
+
+    if (contentHeaderUri === "") {
+      console.log(
+        "Warning: this tile has an empty content uri, which is disallowed by the 3D Tiles spec."
+      );
+      content = new Empty3DTileContent(tileset, this);
+      hasEmptyContent = true;
+      contentState = Cesium3DTileContentState.READY;
+    } else {
+      contentState = Cesium3DTileContentState.UNLOADED;
+      contentResource = baseResource.getDerivedResource({
+        url: contentHeaderUri,
+      });
+      serverKey = RequestScheduler.getServerKey(
+        contentResource.getUrlComponent()
+      );
+    }
   } else {
     content = new Empty3DTileContent(tileset, this);
     hasEmptyContent = true;


### PR DESCRIPTION
Fixes #7263. As discussed in the issue, if a tile contains an empty content uri, it will print a warning to the console and treat itself like a regular empty tile.

I'm not sure I handled all processes involved with the `"3DTILES_multiple_contents"` extension properly -- please let me know if I need to make changes.

cc @ebogo1 or @lilleyse