### PR TITLE
Fixes crash when styling vctr points

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 ##### Fixes :wrench:
 
+- Fixed an issue where styling vector points based on their batch table properties would crash. [#9692](https://github.com/CesiumGS/cesium/pull/9692)
 - Fixed an issue in `TileBoundingRegion.distanceToCamera` that caused incorrect results when the camera was on the opposite site of the globe. [#9678](https://github.com/CesiumGS/cesium/pull/9678)
 - Fixes an error with removing a CZML datasource when the clock interval has a duration of zero. [#9637](https://github.com/CesiumGS/cesium/pull/9637)
 - Fixed the ability to set a material's image to `undefined` and `Material.DefaultImageId`. [#9644](https://github.com/CesiumGS/cesium/pull/9644)

--- a/Source/Scene/Cesium3DTileFeature.js
+++ b/Source/Scene/Cesium3DTileFeature.js
@@ -283,7 +283,11 @@ Cesium3DTileFeature.getPropertyInherited = function (content, batchId, name) {
  * @private
  */
 Cesium3DTileFeature.prototype.getPropertyInherited = function (name) {
-  return Cesium3DTileFeature.getPropertyInherited(this._content, this._batchId, name);
+  return Cesium3DTileFeature.getPropertyInherited(
+    this._content,
+    this._batchId,
+    name
+  );
 };
 
 /**

--- a/Source/Scene/Cesium3DTileFeature.js
+++ b/Source/Scene/Cesium3DTileFeature.js
@@ -212,27 +212,13 @@ Cesium3DTileFeature.prototype.getProperty = function (name) {
 };
 
 /**
- * Returns a copy of the value of the feature's property with the given name.
- * If the feature is contained within a tileset that uses the
- * <code>3DTILES_metadata</code> extension, tileset, group and tile metadata is
- * inherited.
- * <p>
- * To resolve name conflicts, this method resolves names from most specific to
- * least specific by metadata granularity in the order: feature, tile, group,
- * tileset. Within each granularity, semantics are resolved first, then other
- * properties.
- * </p>
- * @param {String} name The case-sensitive name of the property.
- * @returns {*} The value of the property or <code>undefined</code> if the feature does not have this property.
  * @private
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-Cesium3DTileFeature.prototype.getPropertyInherited = function (name) {
+Cesium3DTileFeature.getPropertyInherited = function (content, batchId, name) {
   var value;
-  var content = this._content;
-  var batchTable = this._content.batchTable;
+  var batchTable = content.batchTable;
   if (defined(batchTable)) {
-    value = batchTable.getProperty(this._batchId, name);
+    value = batchTable.getProperty(batchId, name);
     if (defined(value)) {
       return value;
     }
@@ -279,6 +265,25 @@ Cesium3DTileFeature.prototype.getPropertyInherited = function (name) {
   }
 
   return undefined;
+};
+
+/**
+ * Returns a copy of the value of the feature's property with the given name.
+ * If the feature is contained within a tileset that uses the
+ * <code>3DTILES_metadata</code> extension, tileset, group and tile metadata is
+ * inherited.
+ * <p>
+ * To resolve name conflicts, this method resolves names from most specific to
+ * least specific by metadata granularity in the order: feature, tile, group,
+ * tileset. Within each granularity, semantics are resolved first, then other
+ * properties.
+ * </p>
+ * @param {String} name The case-sensitive name of the property.
+ * @returns {*} The value of the property or <code>undefined</code> if the feature does not have this property.
+ * @private
+ */
+Cesium3DTileFeature.prototype.getPropertyInherited = function (name) {
+  return Cesium3DTileFeature.getPropertyInherited(this._content, this._batchId, name);
 };
 
 /**

--- a/Source/Scene/Cesium3DTilePointFeature.js
+++ b/Source/Scene/Cesium3DTilePointFeature.js
@@ -2,6 +2,7 @@ import Cartographic from "../Core/Cartographic.js";
 import Color from "../Core/Color.js";
 import defaultValue from "../Core/defaultValue.js";
 import defined from "../Core/defined.js";
+import Cesium3DTileFeature from "./Cesium3DTileFeature.js";
 import createBillboardPointCallback from "./createBillboardPointCallback.js";
 
 /**
@@ -761,6 +762,30 @@ Cesium3DTilePointFeature.prototype.getProperty = function (name) {
 };
 
 /**
+ * Returns a copy of the value of the feature's property with the given name.
+ * If the feature is contained within a tileset that uses the
+ * <code>3DTILES_metadata</code> extension, tileset, group and tile metadata is
+ * inherited.
+ * <p>
+ * To resolve name conflicts, this method resolves names from most specific to
+ * least specific by metadata granularity in the order: feature, tile, group,
+ * tileset. Within each granularity, semantics are resolved first, then other
+ * properties.
+ * </p>
+ * @param {String} name The case-sensitive name of the property.
+ * @returns {*} The value of the property or <code>undefined</code> if the feature does not have this property.
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
+ */
+Cesium3DTilePointFeature.prototype.getPropertyInherited = function (name) {
+  return Cesium3DTileFeature.getPropertyInherited(
+    this._content,
+    this._batchId,
+    name
+  );
+};
+
+/**
  * Sets the value of the feature's property with the given name.
  * <p>
  * If a property with the given name doesn't exist, it is created.
@@ -793,7 +818,7 @@ Cesium3DTilePointFeature.prototype.setProperty = function (name, value) {
 };
 
 /**
- * Returns whether the feature's class name equals <code>className</code>. Unlike {@link Cesium3DTileFeature#isClass}
+ * Returns whether the feature's class name equals <code>className</code>. Unlike {@link Cesium3DTilePointFeature#isClass}
  * this function only checks the feature's exact class and not inherited classes.
  * <p>
  * This function returns <code>false</code> if no batch table hierarchy is present.

--- a/Specs/Scene/Vector3DTilePointsSpec.js
+++ b/Specs/Scene/Vector3DTilePointsSpec.js
@@ -1,6 +1,7 @@
 import { Cartesian2 } from "../../Source/Cesium.js";
 import { Cartesian3 } from "../../Source/Cesium.js";
 import { Cartographic } from "../../Source/Cesium.js";
+import { clone } from "../../Source/Cesium.js";
 import { Color } from "../../Source/Cesium.js";
 import { DistanceDisplayCondition } from "../../Source/Cesium.js";
 import { Ellipsoid } from "../../Source/Cesium.js";
@@ -45,6 +46,7 @@ describe(
         colorBlendMode: ColorBlendMode.HIGHLIGHT,
         ellipsoid: Ellipsoid.WGS84,
       },
+      tile: {},
       getFeature: function (id) {
         return { batchId: id };
       },
@@ -272,8 +274,14 @@ describe(
         cartoPositions
       );
 
-      var batchTable = new Cesium3DTileBatchTable(mockTileset, 5);
-      batchTable.update(mockTileset, scene.frameState);
+      var mockTilesetClone = clone(mockTileset);
+      var batchTable = new Cesium3DTileBatchTable(mockTilesetClone, 5);
+      mockTilesetClone.batchTable = batchTable;
+
+      for (var i = 0; i < 5; ++i) {
+        batchTable.setProperty(i, "temperature", i);
+      }
+      batchTable.update(mockTilesetClone, scene.frameState);
 
       points = scene.primitives.add(
         new Vector3DTilePoints({
@@ -291,7 +299,7 @@ describe(
         pointSize: "10.0",
         color: "rgba(255, 255, 0, 0.5)",
         pointOutlineColor: "rgba(255, 255, 0, 1.0)",
-        pointOutlineWidth: "11.0",
+        pointOutlineWidth: "11.0 * ${temperature}",
         labelColor: "rgba(255, 255, 0, 1.0)",
         labelOutlineColor: "rgba(255, 255, 0, 0.5)",
         labelOutlineWidth: "1.0",
@@ -316,7 +324,7 @@ describe(
 
       return loadPoints(points).then(function () {
         var features = [];
-        points.createFeatures(mockTileset, features);
+        points.createFeatures(mockTilesetClone, features);
         points.applyStyle(style, features);
 
         var i;
@@ -328,7 +336,7 @@ describe(
           expect(feature.pointOutlineColor).toEqual(
             new Color(1.0, 1.0, 0.0, 1.0)
           );
-          expect(feature.pointOutlineWidth).toEqual(11.0);
+          expect(feature.pointOutlineWidth).toEqual(11.0 * i);
           expect(feature.labelColor).toEqual(new Color(1.0, 1.0, 0.0, 1.0));
           expect(feature.labelOutlineColor).toEqual(
             new Color(1.0, 1.0, 0.0, 0.5)


### PR DESCRIPTION
This was a regression introduced in https://github.com/CesiumGS/cesium/pull/9471. `getPropertyInherited` was added to `Cesium3DTileFeature` but not to `Cesium3DTilePointFeature`, so a style applied to a vctr tileset containing points that accessed metadata properties would crash. All the existing unit tests had simpler styles that didn't catch this. I edited one of the existing tests.

Before|After
--|--
![before](https://user-images.githubusercontent.com/915398/126727715-641a391b-8903-46da-8d13-638c2daa149b.png)|![after](https://user-images.githubusercontent.com/915398/126727716-05e08634-a1a6-4c4e-988a-154ca07243ee.png)

[Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=jVZhj9o4EP0rblSJoGNDT9dPLKyuR6m20nK7EtxW1aU6mWQAX40d2Q4sbfnvN2MnNKGwV2m1wZ559syb57G33LCtgB0YNmIKdmwMVpSb5NHPxZ3MD8daOS4UmE73OlVbxNgMFCAkYBM/RFMwOiHBgmuvGD6/vZ0HY/w1VYyVRg5YGiVJP/zNCshs/y13vN/y7z9C5rSpPjT1oIVy9oNw6z+4y9ZzvpDQrzZO/rVapVGqDl0fUz1t3V7C5ahmZA5xFbT6THyBAXv9qkczmZbaDJi30kjlwgmt7ID9HaYY/oheflV8Awc2Go1YpywKpFXC0nXSqIdp+jXijoG8002jT71LQKl3Z4HZnqvnkWFLI1brE+jKAKif2fUMdiFLaEI/0edwZLeSwBetN3MdV1x7nTS0kRRGbJCxLdiE53nTLVX9PrudT++Y3oKRfM+WGgW21juhVmwJ3JUGGAXKtGIbXVogxyA1mr6vYCOW66zcgHJJZhAGEwk0itMoF9s0asSU1YJOODKm8vFayDxuLEa+jWGSSW7tnxTDCIlZ8OxzbnSRRiduXmFJLmwRAkojpRVccCu09RryfnxhtSzdJd+Fdk5vvOerCy6kl+ccsN5e1mCuYIu0WKzo/4SIkN1aOLiyBc+g9i/MxYywtFQ08npdPF3KBdlbGV0i7SSwwKjESe8f6rpGGUqSIuRo96euUsKAIRCWWLzc61GjYoXichwOaPNse/l20evQFKrN6CzMKKMJ8XDLVS5pHtx7VZTuTUZFiZel8j9QdFPS3BRFF2/wH0mqG0JC4b5fMn4U6Y5bhuxsBQLkvplEj6LWzK3h+yytIJYsrsKtkoobqKRauNutG88ZY5JVLDZtLVauL2IRdWTzujrWPq0HkX3GxIjNypUMVJkCLZC/O+LbpxyNR5ISPFgPlca713W2L07Sba3XZd++sRftOSaUdVxloJfnura/CN6d8vSTh5JcDSBUfc++YuC2ZssXreYLMxCuY5nSjnGJXSbfMwsSryUklZDnSW4l5LdqahS7CwYUh3BarqG2vR/r16ovmQPBZ8C4e2uvj5O7u/sPVe5Vrm/aCvaL9JjVvguHhOveTJ0Ta0vA5zleSF2d6HOex35WN2SOx94iEYJOJHjer9g5JSV79gs1oaeLa1eN8Cz46TLYwZMbh+xOK5aswD1gvwfj9nibECpcJ4deTe7spKvM9wUk0/u/ZpN/pvePk3DRRb1o6GO8qS/h38Wm0MbRQyjG94+DDRLo8MGzKHF/vMis7Va1Gvab0CFeaUzkI7yl20+0NGL+skLLspSSHjFpdDPso/8PUKk59euKAXJb/3pzFyaTJBn2cXge6bSWC25OVv4P)
