### PR TITLE
Implement basic `Cloud` and `CloudCollection` functionality

### DIFF
--- a/Source/Scene/Cloud.js
+++ b/Source/Scene/Cloud.js
@@ -1,0 +1,147 @@
+import Cartesian2 from "../Core/Cartesian2.js";
+import Cartesian3 from "../Core/Cartesian3.js";
+import CloudType from "./CloudType.js";
+import defaultValue from "../Core/defaultValue.js";
+import defined from "../Core/defined.js";
+import DeveloperError from "../Core/DeveloperError.js";
+
+/**
+ * A cloud billboard that is created and rendered using a {@link CloudCollection}.
+ * A cloud is created and its initial properties are set by calling {@link CloudCollection#add}.
+ * and {@link CloudCollection#remove}.
+ *
+ * @alias CloudCollection
+ *
+ * @see CloudCollection
+ * @see CloudCollection#add
+ *
+ * @internalConstructor
+ * @class
+ */
+function Cloud(options, cloudCollection) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+
+  this._show = defaultValue(options.show, true);
+  this._position = Cartesian3.clone(
+    defaultValue(options.position, Cartesian3.ZERO)
+  );
+  this._scale = Cartesian2.clone(
+    defaultValue(options.scale, new Cartesian2(1.0, 1.0))
+  );
+
+  this._type = defaultValue(options.type, CloudType.CUMULUS);
+
+  this._cloudCollection = cloudCollection;
+  this._index = -1; // Used by CloudCollection
+}
+
+Object.defineProperties(Cloud.prototype, {
+  /**
+   * Determines if this cloud will be shown.  Use this to hide or show a cloud, instead
+   * of removing it and re-adding it to the collection.
+   * @memberof Cloud.prototype
+   * @type {Boolean}
+   * @default true
+   */
+  show: {
+    get: function () {
+      return this._show;
+    },
+    set: function (value) {
+      //>>includeStart('debug', pragmas.debug);
+      if (!defined(value)) {
+        throw new DeveloperError("value is required.");
+      }
+      //>>includeEnd('debug');
+
+      if (this._show !== value) {
+        this._show = value;
+        //makeDirty(this, SHOW_INDEX);
+      }
+    },
+  },
+
+  /**
+   * Gets or sets the Cartesian position of this cloud.
+   * @memberof Cloud.prototype
+   * @type {Cartesian3}
+   */
+  position: {
+    get: function () {
+      return this._position;
+    },
+    set: function (value) {
+      //>>includeStart('debug', pragmas.debug)
+      if (!defined(value)) {
+        throw new DeveloperError("value is required.");
+      }
+      //>>includeEnd('debug');
+
+      var position = this._position;
+      if (!Cartesian3.equals(position, value)) {
+        Cartesian3.clone(value, position);
+      }
+    },
+  },
+
+  /**
+   * Gets or sets the scale of the cloud.
+   * @memberof Cloud.prototype
+   * @type {Cartesian2}
+   */
+  scale: {
+    get: function () {
+      return this._scale;
+    },
+    set: function (value) {
+      //>>includeStart('debug', pragmas.debug)
+      if (!defined(value)) {
+        throw new DeveloperError("value is required.");
+      }
+      //>>includeEnd('debug');
+
+      var scale = this._scale;
+      if (!Cartesian2.equals(scale, value)) {
+        Cartesian2.clone(value, scale);
+      }
+    },
+  },
+
+  /**
+   * Gets or sets the type of the cloud.
+   * @memberof Cloud.prototype
+   * @type {CloudType}
+   */
+  type: {
+    get: function () {
+      return this._type;
+    },
+    set: function (value) {
+      //>>includeStart('debug', pragmas.debug)
+      if (!defined(value)) {
+        throw new DeveloperError("value is not a valid CloudType.");
+      }
+      //>>includeEnd('debug');
+
+      this._type = value;
+    },
+  },
+});
+
+/**
+ * Destroys the WebGL resources held by this object.  Destroying an object allows for deterministic
+ * release of WebGL resources, instead of relying on the garbage collector to destroy this object.
+ * <br /><br />
+ * Once an object is destroyed, it should not be used; calling any function other than
+ * <code>isDestroyed</code> will result in a {@link DeveloperError} exception.  Therefore,
+ * assign the return value (<code>undefined</code>) to the object as done in the example.
+ *
+ * @exception {DeveloperError} This object was destroyed, i.e., destroy() was called.
+ *
+ * @see Clouds#isDestroyed
+ */
+Cloud.prototype._destroy = function () {
+  this._cloudCollection = undefined;
+};
+
+export default Cloud;

--- a/Source/Scene/Cloud.js
+++ b/Source/Scene/Cloud.js
@@ -1,6 +1,5 @@
 import Cartesian2 from "../Core/Cartesian2.js";
 import Cartesian3 from "../Core/Cartesian3.js";
-import CloudType from "./CloudType.js";
 import defaultValue from "../Core/defaultValue.js";
 import defined from "../Core/defined.js";
 import DeveloperError from "../Core/DeveloperError.js";
@@ -29,7 +28,7 @@ function Cloud(options, cloudCollection) {
     defaultValue(options.scale, new Cartesian2(1.0, 1.0))
   );
 
-  this._type = defaultValue(options.type, CloudType.CUMULUS);
+  this._flat = defaultValue(options.flat, false);
 
   this._cloudCollection = cloudCollection;
   this._index = -1; // Used by CloudCollection
@@ -108,22 +107,22 @@ Object.defineProperties(Cloud.prototype, {
   },
 
   /**
-   * Gets or sets the type of the cloud.
+   * Gets or sets whether the cloud is flat or cumulus.
    * @memberof Cloud.prototype
    * @type {CloudType}
    */
-  type: {
+  flat: {
     get: function () {
-      return this._type;
+      return this._flat;
     },
     set: function (value) {
       //>>includeStart('debug', pragmas.debug)
       if (!defined(value)) {
-        throw new DeveloperError("value is not a valid CloudType.");
+        throw new DeveloperError("value is required.");
       }
       //>>includeEnd('debug');
 
-      this._type = value;
+      this._flat = value;
     },
   },
 });

--- a/Source/Scene/Cloud.js
+++ b/Source/Scene/Cloud.js
@@ -126,7 +126,7 @@ Object.defineProperties(Cloud.prototype, {
   /**
    * Gets or sets whether the cloud is flat or cumulus.
    * @memberof Cloud.prototype
-   * @type {CloudType}
+   * @type {Boolean}
    */
   flat: {
     get: function () {

--- a/Source/Scene/Cloud.js
+++ b/Source/Scene/Cloud.js
@@ -31,7 +31,22 @@ function Cloud(options, cloudCollection) {
   this._flat = defaultValue(options.flat, false);
 
   this._cloudCollection = cloudCollection;
+  this._dirty = false;
   this._index = -1; // Used by CloudCollection
+}
+
+var SHOW_INDEX = (Cloud.SHOW_INDEX = 0);
+var POSITION_INDEX = (Cloud.POSITION_INDEX = 1);
+var SCALE_INDEX = (Cloud.SCALE_INDEX = 2);
+var TYPE_INDEX = (Cloud.TYPE_INDEX = 3);
+Cloud.NUMBER_OF_PROPERTIES = 4;
+
+function makeDirty(cloud, propertyChanged) {
+  var cloudCollection = cloud._cloudCollection;
+  if (defined(cloudCollection)) {
+    cloudCollection._updateCloud(cloud, propertyChanged);
+    cloud._dirty = true;
+  }
 }
 
 Object.defineProperties(Cloud.prototype, {
@@ -55,7 +70,7 @@ Object.defineProperties(Cloud.prototype, {
 
       if (this._show !== value) {
         this._show = value;
-        //makeDirty(this, SHOW_INDEX);
+        makeDirty(this, SHOW_INDEX);
       }
     },
   },
@@ -79,6 +94,7 @@ Object.defineProperties(Cloud.prototype, {
       var position = this._position;
       if (!Cartesian3.equals(position, value)) {
         Cartesian3.clone(value, position);
+        makeDirty(this, POSITION_INDEX);
       }
     },
   },
@@ -102,6 +118,7 @@ Object.defineProperties(Cloud.prototype, {
       var scale = this._scale;
       if (!Cartesian2.equals(scale, value)) {
         Cartesian2.clone(value, scale);
+        makeDirty(this, SCALE_INDEX);
       }
     },
   },
@@ -122,7 +139,10 @@ Object.defineProperties(Cloud.prototype, {
       }
       //>>includeEnd('debug');
 
-      this._flat = value;
+      if (this._flat !== value) {
+        this._flat = value;
+        makeDirty(this, TYPE_INDEX);
+      }
     },
   },
 });

--- a/Source/Scene/CloudCollection.js
+++ b/Source/Scene/CloudCollection.js
@@ -1,8 +1,39 @@
+import BoundingSphere from "../Core/BoundingSphere.js";
+import Buffer from "../Renderer/Buffer.js";
+import BufferUsage from "../Renderer/BufferUsage.js";
 import Cloud from "./Cloud.js";
+import CloudCollectionFS from "../Shaders/CloudCollectionFS.js";
+import CloudCollectionVS from "../Shaders/CloudCollectionVS.js";
+import ComponentDatatype from "../Core/ComponentDatatype.js";
 import defaultValue from "../Core/defaultValue.js";
 import defined from "../Core/defined.js";
 import destroyObject from "../Core/destroyObject.js";
 import DeveloperError from "../Core/DeveloperError.js";
+import DrawCommand from "../Renderer/DrawCommand.js";
+import EncodedCartesian3 from "../Core/EncodedCartesian3.js";
+import IndexDatatype from "../Core/IndexDatatype.js";
+import Matrix4 from "../Core/Matrix4.js";
+import Pass from "../Renderer/Pass.js";
+import RenderState from "../Renderer/RenderState.js";
+import ShaderSource from "../Renderer/ShaderSource.js";
+import ShaderProgram from "../Renderer/ShaderProgram.js";
+import VertexArrayFacade from "../Renderer/VertexArrayFacade.js";
+import WebGLConstants from "../Core/WebGLConstants.js";
+
+var attributeLocations;
+
+var attributeLocationsBatched = {
+  positionHighAndScaleX: 0,
+  positionLowAndScaleY: 1,
+  compressedAttribute: 2, // show, cloud type, texture coordinates
+};
+
+var attributeLocationsInstanced = {
+  direction: 0,
+  positionHighAndScaleX: 1,
+  positionLowAndScaleY: 2,
+  compressedAttribute: 3,
+};
 
 /**
  * A collection of clouds in the sky.
@@ -24,6 +55,26 @@ function CloudCollection(options) {
   this._show = defaultValue(options.show, true);
 
   this._sp = undefined;
+  this._rs = undefined;
+  this._boundingVolume = new BoundingSphere();
+
+  /**
+   * This property is for debugging only; it is not for production use nor is it optimized.
+   * <p>
+   * Draws the bounding sphere for each draw command in the primitive.
+   * </p>
+   *
+   * @type {Boolean}
+   *
+   * @default false
+   */
+  this.debugShowBoundingVolume = defaultValue(
+    options.debugShowBoundingVolume,
+    false
+  );
+
+  this._modelMatrix = defaultValue(options.modelMatrix, Matrix4.IDENTITY);
+  this._colorCommands = [];
 }
 
 Object.defineProperties(CloudCollection.prototype, {
@@ -109,6 +160,7 @@ CloudCollection.prototype.add = function (options) {
   c._index = this._clouds.length;
 
   this._clouds.push(c);
+  this._createVertexArray = true;
 
   return c;
 };
@@ -134,6 +186,7 @@ CloudCollection.prototype.remove = function (cloud) {
   if (this.contains(cloud)) {
     this._clouds[cloud._index] = null; // Removed later
     this._cloudsRemoved = true;
+    this._createVertexArray = true;
     cloud._destroy();
     return true;
   }
@@ -162,6 +215,8 @@ CloudCollection.prototype.removeAll = function () {
   destroyClouds(this._clouds);
   this._clouds = [];
   this._cloudsRemoved = false;
+
+  this._createVertexArray = true;
 };
 
 function removeClouds(cloudCollection) {
@@ -232,6 +287,171 @@ CloudCollection.prototype.get = function (index) {
   return this._clouds[index];
 };
 
+var getIndexBuffer;
+
+function getIndexBufferBatched(context) {
+  var sixteenK = 16 * 1024;
+
+  var indexBuffer = context.cache.cloudCollection_indexBufferBatched;
+  if (defined(indexBuffer)) {
+    return indexBuffer;
+  }
+
+  // Subtract 6 because the last index is reserved for primitive restart.
+  // https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.18
+  var length = sixteenK * 6 - 6;
+  var indices = new Uint16Array(length);
+  for (var i = 0, j = 0; i < length; i += 6, j += 4) {
+    indices[i] = j;
+    indices[i + 1] = j + 1;
+    indices[i + 2] = j + 2;
+
+    indices[i + 3] = j;
+    indices[i + 4] = j + 2;
+    indices[i + 5] = j + 3;
+  }
+
+  indexBuffer = Buffer.createIndexBuffer({
+    context: context,
+    typedArray: indices,
+    usage: BufferUsage.STATIC_DRAW,
+    indexDatatype: IndexDatatype.UNSIGNED_SHORT,
+  });
+  indexBuffer.vertexArrayDestroyable = false;
+  context.cache.cloudCollection_indexBufferBatched = indexBuffer;
+  return indexBuffer;
+}
+
+function getIndexBufferInstanced(context) {
+  var indexBuffer = context.cache.cloudCollection_indexBufferInstanced;
+  if (defined(indexBuffer)) {
+    return indexBuffer;
+  }
+
+  indexBuffer = Buffer.createIndexBuffer({
+    context: context,
+    typedArray: new Uint16Array([0, 1, 2, 0, 2, 3]),
+    usage: BufferUsage.STATIC_DRAW,
+    indexDatatype: IndexDatatype.UNSIGNED_SHORT,
+  });
+
+  indexBuffer.vertexArrayDestroyable = false;
+  context.cache.cloudCollection_indexBufferInstanced = indexBuffer;
+  return indexBuffer;
+}
+
+function getVertexBufferInstanced(context) {
+  var vertexBuffer = context.cache.cloudCollection_vertexBufferInstanced;
+  if (defined(vertexBuffer)) {
+    return vertexBuffer;
+  }
+
+  vertexBuffer = Buffer.createVertexBuffer({
+    context: context,
+    typedArray: new Float32Array([0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0]),
+    usage: BufferUsage.STATIC_DRAW,
+  });
+
+  vertexBuffer.vertexArrayDestroyable = false;
+  context.cache.cloudCollection_vertexBufferInstanced = vertexBuffer;
+  return vertexBuffer;
+}
+
+function createVAF(context, numberOfClouds, instanced) {
+  var attributes = [
+    {
+      index: attributeLocations.positionHighAndScaleX,
+      componentsPerAttribute: 4,
+      componentDatatype: ComponentDatatype.FLOAT,
+      usage: BufferUsage.STATIC_DRAW, // this.autogenerate ? BufferUsage.DYNAMIC_DRAW : BufferUsage.STATIC_DRAW
+    },
+    {
+      index: attributeLocations.positionLowAndScaleY,
+      componentsPerAttribute: 4,
+      componentDatatype: ComponentDatatype.FLOAT,
+      usage: BufferUsage.STATIC_DRAW, // this.autogenerate ? BufferUsage.DYNAMIC_DRAW : BufferUsage.STATIC_DRAW
+    },
+    {
+      index: attributeLocations.compressedAttribute,
+      componentsPerAttribute: 4,
+      componentDatatype: ComponentDatatype.FLOAT,
+      usage: BufferUsage.STATIC_DRAW,
+    },
+  ];
+
+  if (instanced) {
+    attributes.push({
+      index: attributeLocations.direction,
+      componentsPerAttribute: 2,
+      componentDatatype: ComponentDatatype.FLOAT,
+      vertexBuffer: getVertexBufferInstanced(context),
+    });
+  }
+
+  var sizeInVertices = instanced ? numberOfClouds : 4 * numberOfClouds;
+  return new VertexArrayFacade(context, attributes, sizeInVertices, instanced);
+}
+
+var writePositionScratch = new EncodedCartesian3();
+
+function writePositionAndScale(cloudCollection, frameState, vafWriters, cloud) {
+  var i;
+  var positionHighWriter = vafWriters[attributeLocations.positionHighAndScaleX];
+  var positionLowWriter = vafWriters[attributeLocations.positionLowAndScaleY];
+  var position = cloud.position;
+
+  EncodedCartesian3.fromCartesian(position, writePositionScratch);
+  var scale = cloud.scale;
+
+  var high = writePositionScratch.high;
+  var low = writePositionScratch.low;
+
+  if (cloudCollection._instanced) {
+    i = cloud._index;
+    positionHighWriter(i, high.x, high.y, high.z, scale.x);
+    positionLowWriter(i, low.x, low.y, low.z, scale.y);
+  } else {
+    i = cloud._index * 4;
+    positionHighWriter(i + 0, high.x, high.y, high.z, scale.x);
+    positionHighWriter(i + 1, high.x, high.y, high.z, scale.x);
+    positionHighWriter(i + 2, high.x, high.y, high.z, scale.x);
+    positionHighWriter(i + 3, high.x, high.y, high.z, scale.x);
+
+    positionLowWriter(i + 0, low.x, low.y, low.z, scale.y);
+    positionLowWriter(i + 1, low.x, low.y, low.z, scale.y);
+    positionLowWriter(i + 2, low.x, low.y, low.z, scale.y);
+    positionLowWriter(i + 3, low.x, low.y, low.z, scale.y);
+  }
+}
+
+function writeCompressedAttribute(
+  cloudCollection,
+  frameState,
+  vafWriters,
+  cloud
+) {
+  var i;
+  var writer = vafWriters[attributeLocations.compressedAttribute];
+  var show = cloud.show;
+  var cloudType = cloud.flat;
+
+  if (cloudCollection._instanced) {
+    i = cloud._index;
+    writer(i, show, cloudType, 0.0, 0.0);
+  } else {
+    i = cloud._index * 4;
+    writer(i + 0, show, cloudType, 0.0, 0.0);
+    writer(i + 1, show, cloudType, 1.0, 0.0);
+    writer(i + 2, show, cloudType, 1.0, 1.0);
+    writer(i + 3, show, cloudType, 0.0, 1.0);
+  }
+}
+
+function writeCloud(cloudCollection, frameState, vafWriters, cloud) {
+  writePositionAndScale(cloudCollection, frameState, vafWriters, cloud);
+  writeCompressedAttribute(cloudCollection, frameState, vafWriters, cloud);
+}
+
 /**
  * @private
  */
@@ -241,11 +461,101 @@ CloudCollection.prototype.update = function (frameState) {
     return;
   }
 
-  if (this.autogenerate) {
-    // TODO:
-    // 1. Add code to add billboards to the sky
-    // 2. Add code to add texture to the billboards
-    // 3. Add code to add flat cloud gltfs to the sky
+  var context = frameState.context;
+  this._instanced = context.instancedArrays;
+  attributeLocations = this._instanced
+    ? attributeLocationsInstanced
+    : attributeLocationsBatched;
+  getIndexBuffer = this._instanced
+    ? getIndexBufferInstanced
+    : getIndexBufferBatched;
+
+  var clouds = this._clouds;
+  var cloudsLength = clouds.length;
+
+  var vafWriters;
+  var pass = frameState.passes;
+
+  if (this._createVertexArray) {
+    this._createVertexArray = false;
+    console.log("Creating");
+    this._vaf = this._vaf && this._vaf.destroy();
+    if (cloudsLength > 0) {
+      this._vaf = createVAF(context, cloudsLength, this._instanced);
+      vafWriters = this._vaf.writers;
+
+      // Rewrite entire buffer if clouds were added or removed.
+      for (var i = 0; i < cloudsLength; ++i) {
+        var cloud = this._clouds[i];
+        writeCloud(this, frameState, vafWriters, cloud);
+      }
+
+      // Different cloud collections share the same index buffer.
+      this._vaf.commit(getIndexBuffer(context));
+    }
+  }
+
+  if (!defined(this._vaf) || !defined(this._vaf.va)) {
+    return;
+  }
+
+  var vsSource = CloudCollectionVS;
+  var fsSource = CloudCollectionFS;
+
+  var vs = new ShaderSource({
+    defines: [],
+    sources: [vsSource],
+  });
+
+  if (this._instanced) {
+    vs.defines.push("INSTANCED");
+  }
+
+  var fs = new ShaderSource({
+    defines: [],
+    sources: [fsSource],
+  });
+
+  this._sp = ShaderProgram.replaceCache({
+    context: context,
+    shaderProgram: this._sp,
+    vertexShaderSource: vs,
+    fragmentShaderSource: fs,
+    attributeLocations: attributeLocations,
+  });
+
+  this._rs = RenderState.fromCache({
+    depthTest: {
+      enabled: true,
+      func: WebGLConstants.LESS,
+    },
+    depthMask: true,
+  });
+
+  var commandList = frameState.commandList;
+  if (pass.render) {
+    var colorList = this._colorCommands;
+
+    var va = this._vaf.va;
+    var vaLength = va.length;
+    colorList.length = vaLength;
+    var command;
+    for (var j = 0; j < vaLength; j++) {
+      command = colorList[j] = new DrawCommand();
+      command.pass = Pass.OPAQUE;
+      command.owner = this;
+
+      command.count = va[j].indicesCount;
+      command.shaderProgram = this._sp;
+      command.vertexArray = va[j].va;
+      command.renderState = this._rs;
+      if (this._instanced) {
+        command.count = 6;
+        command.instanceCount = cloudsLength;
+      }
+
+      commandList.push(command);
+    }
   }
 };
 

--- a/Source/Scene/CloudCollection.js
+++ b/Source/Scene/CloudCollection.js
@@ -1,0 +1,288 @@
+import Cloud from "./Cloud.js";
+import defaultValue from "../Core/defaultValue.js";
+import defined from "../Core/defined.js";
+import destroyObject from "../Core/destroyObject.js";
+import DeveloperError from "../Core/DeveloperError.js";
+
+/**
+ * A collection of clouds in the sky.
+ *
+ * @alias CloudCollection
+ * @constructor
+ *
+ * @param {Object} [options] Object with the following properties:
+ * @param {Matrix4} [options.modelMatrix=Matrix4.IDENTITY] The 4x4 transformation matrix that transforms each cloud from model to world coordinates.
+ * @param {Boolean} [options.show=true] Whether to display the clouds.
+ *
+ */
+function CloudCollection(options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+
+  this._clouds = [];
+  this._cloudsRemoved = false;
+
+  this._show = defaultValue(options.show, true);
+
+  this._sp = undefined;
+}
+
+Object.defineProperties(CloudCollection.prototype, {
+  /**
+   * Returns the number of clouds in this collection.
+   * @memberof CloudCollection.prototype
+   * @type {Number}
+   */
+  length: {
+    get: function () {
+      removeClouds(this);
+      return this._clouds.length;
+    },
+  },
+
+  /**
+   * Determines if this collection of clouds will be shown.
+   * @memberof CloudCollection.prototype
+   * @type {Boolean}
+   * @default true
+   */
+  show: {
+    get: function () {
+      return this._show;
+    },
+    set: function (value) {
+      //>>includeStart('debug', pragmas.debug);
+      if (!defined(value)) {
+        throw new DeveloperError("value is required.");
+      }
+      //>>includeEnd('debug');
+
+      if (this._show !== value) {
+        this._show = value;
+      }
+    },
+  },
+});
+
+function destroyClouds(clouds) {
+  var length = clouds.length;
+  for (var i = 0; i < length; ++i) {
+    if (clouds[i]) {
+      clouds[i]._destroy();
+    }
+  }
+}
+
+/**
+ * Creates and adds a cloud with the specified initial properties to the collection.
+ * The added cloud is returned so it can be modified or removed from the collection later.
+ *
+ * @param {Object}[options] A template describing the cloud's properties as shown in Example 1.
+ * @returns {Cloud} The cloud that was added to the collection.
+ *
+ * @performance Calling <code>add</code> is expected constant time.  However, the collection's vertex buffer
+ * is rewritten - an <code>O(n)</code> operation that also incurs CPU to GPU overhead.  For
+ * best performance, add as many clouds as possible before calling <code>update</code>.
+ *
+ * @exception {DeveloperError} This object was destroyed, i.e., destroy() was called.
+ *
+ *
+ * @example
+ * // Example 1:  Add a cloud, specifying all the default values.
+ * var c = clouds.add({
+ *   show : true,
+ *   position : Cesium.Cartesian3.ZERO,
+ *   scale : new Cesium.Cartesian2(1.0, 1.0),
+ *   type : CloudType.CUMULUS
+ * });
+ *
+ * @example
+ * // Example 2:  Specify only the cloud's cartographic position.
+ * var c = clouds.add({
+ *   position : Cesium.Cartesian3.fromDegrees(longitude, latitude, height)
+ * });
+ *
+ * @see CloudCollection#remove
+ * @see CloudCollection#removeAll
+ */
+CloudCollection.prototype.add = function (options) {
+  var c = new Cloud(options, this);
+  c._index = this._clouds.length;
+
+  this._clouds.push(c);
+
+  return c;
+};
+
+/**
+ * Removes a cloud from the collection.
+ *
+ * @param {Cloud} cloud The cloud to remove.
+ * @returns {Boolean} <code>true</code> if the cloud was removed; <code>false</code> if the cloud was not found in the collection.
+ *
+ * @exception {DeveloperError} This object was destroyed, i.e., destroy() was called.
+ *
+ *
+ * @example
+ * var c = clouds.add(...);
+ * clouds.remove(c);  // Returns true
+ *
+ * @see CloudCollection#add
+ * @see CloudCollection#removeAll
+ * @see Cloud#show
+ */
+CloudCollection.prototype.remove = function (cloud) {
+  if (this.contains(cloud)) {
+    this._clouds[cloud._index] = null; // Removed later
+    this._cloudsRemoved = true;
+    cloud._destroy();
+    return true;
+  }
+
+  return false;
+};
+
+/**
+ * Removes all clouds from the collection.
+ *
+ * @performance <code>O(n)</code>.  It is more efficient to remove all the clouds
+ * from a collection and then add new ones than to create a new collection entirely.
+ *
+ * @exception {DeveloperError} This object was destroyed, i.e., destroy() was called.
+ *
+ *
+ * @example
+ * clouds.add(...);
+ * clouds.add(...);
+ * clouds.removeAll();
+ *
+ * @see CloudCollection#add
+ * @see CloudCollection#remove
+ */
+CloudCollection.prototype.removeAll = function () {
+  destroyClouds(this._clouds);
+  this._clouds = [];
+  this._cloudsRemoved = false;
+};
+
+function removeClouds(cloudCollection) {
+  if (cloudCollection._cloudsRemoved) {
+    cloudCollection._cloudsRemoved = false;
+
+    var newClouds = [];
+    var clouds = cloudCollection._clouds;
+    var length = clouds.length;
+    for (var i = 0, j = 0; i < length; ++i) {
+      var cloud = clouds[i];
+      if (cloud) {
+        clouds._index = j++;
+        newClouds.push(cloud);
+      }
+    }
+
+    cloudCollection._clouds = newClouds;
+  }
+}
+
+/**
+ * Check whether this collection contains a given cloud.
+ *
+ * @param {Billboard} [cloud] The cloud to check for.
+ * @returns {Boolean} true if this collection contains the cloud, false otherwise.
+ *
+ * @see BillboardCollection#get
+ */
+CloudCollection.prototype.contains = function (cloud) {
+  return defined(cloud) && cloud._cloudCollection === this;
+};
+
+/**
+ * Returns the cloud in the collection at the specified index. Indices are zero-based
+ * and increase as clouds are added. Removing a billboard shifts all clouds after
+ * it to the left, changing their indices. This function is commonly used with
+ * {@link CloudCollection#length} to iterate over all the clouds in the collection.
+ *
+ * @param {Number} index The zero-based index of the cloud.
+ * @returns {Cloud} The cloud at the specified index.
+ *
+ * @performance Expected constant time. If clouds were removed from the collection and
+ * {@link CloudCollection#update} was not called, an implicit <code>O(n)</code>
+ * operation is performed.
+ *
+ * @exception {DeveloperError} This object was destroyed, i.e., destroy() was called.
+ *
+ *
+ * @example
+ * // Toggle the show property of every cloud in the collection
+ * var len = clouds.length;
+ * for (var i = 0; i < len; ++i) {
+ *   var c = clouds.get(i);
+ *   c.show = !c.show;
+ * }
+ *
+ * @see CloudCollection#length
+ */
+CloudCollection.prototype.get = function (index) {
+  //>>includeStart('debug', pragmas.debug);
+  if (!defined(index)) {
+    throw new DeveloperError("index is required.");
+  }
+  //>>includeEnd('debug');
+
+  removeClouds(this);
+  return this._clouds[index];
+};
+
+/**
+ * @private
+ */
+CloudCollection.prototype.update = function (frameState) {
+  removeClouds(this);
+  if (!this.show) {
+    return;
+  }
+
+  if (this.autogenerate) {
+    // TODO:
+    // 1. Add code to add billboards to the sky
+    // 2. Add code to add texture to the billboards
+    // 3. Add code to add flat cloud gltfs to the sky
+  }
+};
+
+/**
+ * Returns true if this object was destroyed; otherwise, false.
+ * <br /><br />
+ * If this object was destroyed, it should not be used; calling any function other than
+ * <code>isDestroyed</code> will result in a {@link DeveloperError} exception.
+ *
+ * @returns {Boolean} <code>true</code> if this object was destroyed; otherwise, <code>false</code>.
+ *
+ * @see CloudCollection#destroy
+ */
+CloudCollection.prototype.isDestroyed = function () {
+  return false;
+};
+
+/**
+ * Destroys the WebGL resources held by this object.  Destroying an object allows for deterministic
+ * release of WebGL resources, instead of relying on the garbage collector to destroy this object.
+ * <br /><br />
+ * Once an object is destroyed, it should not be used; calling any function other than
+ * <code>isDestroyed</code> will result in a {@link DeveloperError} exception.  Therefore,
+ * assign the return value (<code>undefined</code>) to the object as done in the example.
+ *
+ * @exception {DeveloperError} This object was destroyed, i.e., destroy() was called.
+ *
+ *
+ * @example
+ * clouds = clouds && clouds.destroy();
+ *
+ * @see CloudCollection#isDestroyed
+ */
+CloudCollection.prototype.destroy = function () {
+  destroyClouds(this._clouds);
+
+  return destroyObject(this);
+};
+
+export default CloudCollection;

--- a/Source/Scene/CloudType.js
+++ b/Source/Scene/CloudType.js
@@ -1,0 +1,4 @@
+export default Object.freeze({
+  CUMULUS: 0,
+  CIRRUS: 1,
+});

--- a/Source/Scene/CloudType.js
+++ b/Source/Scene/CloudType.js
@@ -1,4 +1,0 @@
-export default Object.freeze({
-  CUMULUS: 0,
-  CIRRUS: 1,
-});

--- a/Source/Shaders/CloudCollectionFS.glsl
+++ b/Source/Shaders/CloudCollectionFS.glsl
@@ -1,0 +1,6 @@
+varying vec2 v_textureCoordinates;
+
+void main() {
+    vec4 color = vec4(0.0, 1.0, 1.0, 1.0);
+    gl_FragColor = color;
+}

--- a/Source/Shaders/CloudCollectionVS.glsl
+++ b/Source/Shaders/CloudCollectionVS.glsl
@@ -1,0 +1,31 @@
+#ifdef INSTANCED
+attribute vec2 direction;
+#endif
+attribute vec4 positionHighAndScaleX;
+attribute vec4 positionLowAndScaleY;
+attribute vec4 compressedAttribute;
+
+varying vec2 v_textureCoordinates;
+void main() {
+    // Unpack attributes.
+    vec3 positionHigh = positionHighAndScaleX.xyz;
+    vec3 positionLow = positionLowAndScaleY.xyz;
+    vec2 scale = vec2(positionHighAndScaleX.w, positionLowAndScaleY.w);
+    float show = compressedAttribute.x;
+    float flatCloud = compressedAttribute.y;
+    vec2 textureCoordinates = compressedAttribute.wz;
+    
+#ifdef INSTANCED
+    vec2 dir = direction;
+#else
+    vec2 dir = textureCoordinates;
+#endif
+    vec2 offset = dir - vec2(0.5, 0.5);
+    vec2 scaledOffset = scale * offset;
+    vec4 p = czm_translateRelativeToEye(positionHigh, positionLow);
+    vec4 positionEC = czm_modelViewRelativeToEye * p;
+    positionEC.xy += scaledOffset;
+    positionEC.xyz *= show;
+    gl_Position = czm_projection * positionEC;
+    v_textureCoordinates = dir;
+}

--- a/Specs/Scene/CloudCollectionSpec.js
+++ b/Specs/Scene/CloudCollectionSpec.js
@@ -2,8 +2,6 @@ import { Cartesian2 } from "../../Source/Cesium.js";
 import { Cartesian3 } from "../../Source/Cesium.js";
 import { Math as CesiumMath } from "../../Source/Cesium.js";
 import { PerspectiveFrustum } from "../../Source/Cesium.js";
-import { CloudType } from "../../Source/Cesium.js";
-import { Cloud } from "../../Source/Cesium.js";
 import { CloudCollection } from "../../Source/Cesium.js";
 import createScene from "../createScene.js";
 
@@ -11,13 +9,11 @@ describe(
   "Scene/CloudCollection",
   function () {
     var scene;
-    var context;
     var camera;
     var clouds;
 
     beforeAll(function () {
       scene = createScene();
-      context = scene.context;
       camera = scene.camera;
     });
 
@@ -51,7 +47,7 @@ describe(
       expect(c.show).toEqual(true);
       expect(c.position).toEqual(Cartesian3.ZERO);
       expect(c.scale).toEqual(new Cartesian2(1.0, 1.0));
-      expect(c.type).toEqual(CloudType.CUMULUS);
+      expect(c.flat).toEqual(false);
     });
 
     it("explicitly constructs a cloud", function () {
@@ -59,12 +55,12 @@ describe(
         show: false,
         position: new Cartesian3(1.0, 2.0, 3.0),
         scale: new Cartesian2(2.0, 3.0),
-        type: CloudType.CIRRUS,
+        flat: true,
       });
       expect(c.show).toEqual(false);
       expect(c.position).toEqual(new Cartesian3(1.0, 2.0, 3.0));
       expect(c.scale).toEqual(new Cartesian2(2.0, 3.0));
-      expect(c.type).toEqual(CloudType.CIRRUS);
+      expect(c.flat).toEqual(true);
     });
 
     it("sets cloud properties", function () {
@@ -72,12 +68,12 @@ describe(
       c.show = false;
       c.position = new Cartesian3(1.0, 2.0, 3.0);
       c.scale = new Cartesian2(2.0, 3.0);
-      c.type = CloudType.CIRRUS;
+      c.flat = true;
 
       expect(c.show).toEqual(false);
       expect(c.position).toEqual(new Cartesian3(1.0, 2.0, 3.0));
       expect(c.scale).toEqual(new Cartesian2(2.0, 3.0));
-      expect(c.type).toEqual(CloudType.CIRRUS);
+      expect(c.flat).toEqual(true);
     });
 
     it("is not destroyed", function () {

--- a/Specs/Scene/CloudCollectionSpec.js
+++ b/Specs/Scene/CloudCollectionSpec.js
@@ -1,0 +1,230 @@
+import { Cartesian2 } from "../../Source/Cesium.js";
+import { Cartesian3 } from "../../Source/Cesium.js";
+import { Math as CesiumMath } from "../../Source/Cesium.js";
+import { PerspectiveFrustum } from "../../Source/Cesium.js";
+import { CloudType } from "../../Source/Cesium.js";
+import { Cloud } from "../../Source/Cesium.js";
+import { CloudCollection } from "../../Source/Cesium.js";
+import createScene from "../createScene.js";
+
+describe(
+  "Scene/CloudCollection",
+  function () {
+    var scene;
+    var context;
+    var camera;
+    var clouds;
+
+    beforeAll(function () {
+      scene = createScene();
+      context = scene.context;
+      camera = scene.camera;
+    });
+
+    afterAll(function () {
+      scene.destroyForSpecs();
+    });
+
+    beforeEach(function () {
+      scene.morphTo3D(0);
+
+      camera.position = new Cartesian3(10.0, 0.0, 0.0);
+      camera.direction = Cartesian3.negate(Cartesian3.UNIT_X, new Cartesian3());
+      camera.up = Cartesian3.clone(Cartesian3.UNIT_Z);
+
+      camera.frustum = new PerspectiveFrustum();
+      camera.frustum.aspectRatio =
+        scene.drawingBufferWidth / scene.drawingBufferHeight;
+      camera.frustum.fov = CesiumMath.toRadians(60.0);
+
+      clouds = new CloudCollection();
+      scene.primitives.add(clouds);
+    });
+
+    afterEach(function () {
+      // clouds are destroyed by removeAll().
+      scene.primitives.removeAll();
+    });
+
+    it("constructs a default cloud", function () {
+      var c = clouds.add();
+      expect(c.show).toEqual(true);
+      expect(c.position).toEqual(Cartesian3.ZERO);
+      expect(c.scale).toEqual(new Cartesian2(1.0, 1.0));
+      expect(c.type).toEqual(CloudType.CUMULUS);
+    });
+
+    it("explicitly constructs a cloud", function () {
+      var c = clouds.add({
+        show: false,
+        position: new Cartesian3(1.0, 2.0, 3.0),
+        scale: new Cartesian2(2.0, 3.0),
+        type: CloudType.CIRRUS,
+      });
+      expect(c.show).toEqual(false);
+      expect(c.position).toEqual(new Cartesian3(1.0, 2.0, 3.0));
+      expect(c.scale).toEqual(new Cartesian2(2.0, 3.0));
+      expect(c.type).toEqual(CloudType.CIRRUS);
+    });
+
+    it("sets cloud properties", function () {
+      var c = clouds.add();
+      c.show = false;
+      c.position = new Cartesian3(1.0, 2.0, 3.0);
+      c.scale = new Cartesian2(2.0, 3.0);
+      c.type = CloudType.CIRRUS;
+
+      expect(c.show).toEqual(false);
+      expect(c.position).toEqual(new Cartesian3(1.0, 2.0, 3.0));
+      expect(c.scale).toEqual(new Cartesian2(2.0, 3.0));
+      expect(c.type).toEqual(CloudType.CIRRUS);
+    });
+
+    it("is not destroyed", function () {
+      expect(clouds.isDestroyed()).toEqual(false);
+    });
+
+    it("sets a removed cloud property", function () {
+      var c = clouds.add();
+      clouds.remove(c);
+      c.show = false;
+      expect(c.show).toEqual(false);
+    });
+
+    it("has zero clouds when constructed", function () {
+      expect(clouds.length).toEqual(0);
+    });
+
+    it("adds a cloud", function () {
+      var c = clouds.add({
+        position: new Cartesian3(1.0, 2.0, 3.0),
+      });
+
+      expect(clouds.length).toEqual(1);
+      expect(clouds.get(0)).toBe(c);
+    });
+
+    it("removes the first cloud", function () {
+      var one = clouds.add({
+        position: new Cartesian3(1.0, 2.0, 3.0),
+      });
+      var two = clouds.add({
+        position: new Cartesian3(4.0, 5.0, 6.0),
+      });
+
+      expect(clouds.length).toEqual(2);
+
+      expect(clouds.remove(one)).toEqual(true);
+
+      expect(clouds.length).toEqual(1);
+      expect(clouds.get(0)).toBe(two);
+    });
+
+    it("removes the last cloud", function () {
+      var one = clouds.add({
+        position: new Cartesian3(1.0, 2.0, 3.0),
+      });
+      var two = clouds.add({
+        position: new Cartesian3(4.0, 5.0, 6.0),
+      });
+
+      expect(clouds.length).toEqual(2);
+
+      expect(clouds.remove(two)).toEqual(true);
+
+      expect(clouds.length).toEqual(1);
+      expect(clouds.get(0)).toBe(one);
+    });
+
+    it("removes the same cloud twice", function () {
+      var b = clouds.add({
+        position: new Cartesian3(1.0, 2.0, 3.0),
+      });
+      expect(clouds.length).toEqual(1);
+
+      expect(clouds.remove(b)).toEqual(true);
+      expect(clouds.length).toEqual(0);
+
+      expect(clouds.remove(b)).toEqual(false);
+      expect(clouds.length).toEqual(0);
+    });
+
+    it("returns false when removing undefined", function () {
+      clouds.add({
+        position: new Cartesian3(1.0, 2.0, 3.0),
+      });
+      expect(clouds.length).toEqual(1);
+
+      expect(clouds.remove(undefined)).toEqual(false);
+      expect(clouds.length).toEqual(1);
+    });
+
+    it("adds and removes clouds", function () {
+      var one = clouds.add({
+        position: new Cartesian3(1.0, 2.0, 3.0),
+      });
+      var two = clouds.add({
+        position: new Cartesian3(4.0, 5.0, 6.0),
+      });
+      expect(clouds.length).toEqual(2);
+      expect(clouds.get(0)).toBe(one);
+      expect(clouds.get(1)).toBe(two);
+
+      expect(clouds.remove(two)).toEqual(true);
+      expect(clouds.length).toEqual(1);
+
+      var three = clouds.add({
+        position: new Cartesian3(7.0, 8.0, 9.0),
+      });
+      expect(clouds.length).toEqual(2);
+      expect(clouds.get(0)).toBe(one);
+      expect(clouds.get(1)).toBe(three);
+    });
+
+    it("removes all clouds", function () {
+      clouds.add({
+        position: new Cartesian3(1.0, 2.0, 3.0),
+      });
+      clouds.add({
+        position: new Cartesian3(4.0, 5.0, 6.0),
+      });
+      expect(clouds.length).toEqual(2);
+
+      clouds.removeAll();
+      expect(clouds.length).toEqual(0);
+    });
+
+    it("can check if it contains a cloud", function () {
+      var cloud = clouds.add();
+
+      expect(clouds.contains(cloud)).toEqual(true);
+    });
+
+    it("returns false when checking if it contains a cloud it does not contain", function () {
+      var cloud = clouds.add();
+      clouds.remove(cloud);
+
+      expect(clouds.contains(cloud)).toEqual(false);
+    });
+
+    it("does not contain undefined", function () {
+      expect(clouds.contains(undefined)).toEqual(false);
+    });
+
+    it("does not contain random other objects", function () {
+      expect(clouds.contains({})).toEqual(false);
+      expect(clouds.contains(new Cartesian2())).toEqual(false);
+    });
+
+    it("does not render when constructed", function () {
+      expect(scene).toRender([0, 0, 0, 255]);
+    });
+
+    it("throws when accessing without an index", function () {
+      expect(function () {
+        clouds.get();
+      }).toThrowDeveloperError();
+    });
+  },
+  "WebGL"
+);

--- a/Specs/Scene/CloudCollectionSpec.js
+++ b/Specs/Scene/CloudCollectionSpec.js
@@ -1,9 +1,9 @@
 import { Cartesian2 } from "../../Source/Cesium.js";
 import { Cartesian3 } from "../../Source/Cesium.js";
+import createScene from "../createScene.js";
 import { Math as CesiumMath } from "../../Source/Cesium.js";
 import { PerspectiveFrustum } from "../../Source/Cesium.js";
 import { CloudCollection } from "../../Source/Cesium.js";
-import createScene from "../createScene.js";
 
 describe(
   "Scene/CloudCollection",
@@ -213,6 +213,164 @@ describe(
     });
 
     it("does not render when constructed", function () {
+      expect(scene).toRender([0, 0, 0, 255]);
+    });
+
+    it("renders a cloud", function () {
+      clouds.add({
+        position: Cartesian3.ZERO,
+        scale: new Cartesian2(1.0, 1.0),
+      });
+
+      expect(scene).not.toRender([0, 0, 0, 255]);
+    });
+
+    it("adds and renders a cloud", function () {
+      clouds.add({
+        position: Cartesian3.ZERO,
+        scale: new Cartesian2(1.0, 1.0),
+      });
+
+      expect(scene).not.toRender([0, 0, 0, 255]);
+
+      clouds.add({
+        position: new Cartesian3(1.0, 0.0, 0.0),
+        scale: new Cartesian2(1.0, 1.0),
+      });
+
+      expect(scene).not.toRender([0, 0, 0, 255]);
+    });
+
+    it("modifies and removes a cloud, then renders", function () {
+      var c = clouds.add({
+        position: Cartesian3.ZERO,
+        scale: new Cartesian2(1.0, 1.0),
+      });
+      expect(scene).not.toRender([0, 0, 0, 255]);
+
+      c.scale = 2.0;
+      clouds.remove(c);
+      expect(scene).toRender([0, 0, 0, 255]);
+    });
+
+    it("removes and renders a cloud", function () {
+      clouds.add({
+        position: Cartesian3.ZERO,
+        scale: new Cartesian2(1.0, 1.0),
+      });
+      var cloud = clouds.add({
+        position: new Cartesian3(1.0, 0.0, 0.0), // Closer to camera
+        scale: new Cartesian2(1.0, 1.0),
+      });
+
+      expect(scene).not.toRender([0, 0, 0, 255]);
+
+      clouds.remove(cloud);
+      expect(scene).not.toRender([0, 0, 0, 255]);
+    });
+
+    it("removes all clouds and renders", function () {
+      clouds.add({
+        position: Cartesian3.ZERO,
+        scale: new Cartesian2(1.0, 1.0),
+      });
+      clouds.add({
+        position: new Cartesian3(1.0, 0.0, 0.0),
+        scale: new Cartesian2(1.0, 1.0),
+      });
+      expect(scene).not.toRender([0, 0, 0, 255]);
+
+      clouds.removeAll();
+      expect(scene).toRender([0, 0, 0, 255]);
+    });
+
+    it("removes all clouds, adds a cloud, and renders", function () {
+      clouds.add({
+        position: Cartesian3.ZERO,
+        scale: new Cartesian2(1.0, 1.0),
+      });
+
+      clouds.add({
+        position: new Cartesian3(1.0, 0.0, 0.0),
+        scale: new Cartesian2(1.0, 1.0),
+      });
+      expect(scene).not.toRender([0, 0, 0, 255]);
+
+      clouds.removeAll();
+      clouds.add({
+        position: Cartesian3.ZERO,
+        scale: new Cartesian2(1.0, 1.0),
+      });
+
+      expect(scene).not.toRender([0, 0, 0, 255]);
+    });
+
+    it("renders using cloud show property", function () {
+      var c = clouds.add({
+        position: Cartesian3.ZERO,
+        scale: new Cartesian3(1.0, 1.0),
+      });
+
+      expect(scene).not.toRender([0, 0, 0, 255]);
+      c.show = false;
+      expect(scene).toRender([0, 0, 0, 255]);
+    });
+
+    it("renders using cloud position property", function () {
+      var c = clouds.add({
+        position: Cartesian3.ZERO,
+        scale: new Cartesian3(1.0, 1.0),
+      });
+
+      expect(scene).not.toRender([0, 0, 0, 255]);
+
+      c.position = new Cartesian3(20.0, 0.0, 0.0); // Behind camera
+      expect(scene).toRender([0, 0, 0, 255]);
+
+      c.position = new Cartesian3(1.0, 0.0, 0.0); // Back in front of camera
+      expect(scene).not.toRender([0, 0, 0, 255]);
+    });
+
+    it("renders using cloud scale property", function () {
+      var c = clouds.add({
+        position: Cartesian3.ZERO,
+        scale: new Cartesian3(1.0, 1.0),
+      });
+
+      expect(scene).not.toRender([0, 0, 0, 255]);
+
+      c.scale = Cartesian2.ZERO;
+      expect(scene).toRender([0, 0, 0, 255]);
+
+      c.scale = new Cartesian2(2.0, 2.0);
+      expect(scene).not.toRender([0, 0, 0, 255]);
+    });
+
+    it("updates 10% of clouds", function () {
+      for (var i = 0; i < 10; ++i) {
+        clouds.add({
+          position: Cartesian3.ZERO,
+          scale: new Cartesian2(1.0, 1.0),
+          show: i === 3,
+        });
+      }
+
+      expect(scene).not.toRender([0, 0, 0, 255]);
+
+      clouds.get(3).scale = Cartesian2.ZERO;
+      expect(scene).toRender([0, 0, 0, 255]);
+
+      clouds.get(3).scale = new Cartesian3(2.0, 2.0);
+      expect(scene).not.toRender([0, 0, 0, 255]);
+    });
+
+    it("does not render if show is false", function () {
+      clouds.add({
+        position: Cartesian3.ZERO,
+        scale: new Cartesian2(1.0, 1.0),
+      });
+      expect(scene).not.toRender([0, 0, 0, 255]);
+      clouds.show = false;
       expect(scene).toRender([0, 0, 0, 255]);
     });
 


### PR DESCRIPTION
This PR involves the creation of the `Cloud` and `CloudCollection` classes well as their respective specs. The basic functionality includes
- Adding and removing `Cloud` instances to `CloudCollection`
- Visualizing `Cloud` instances as cyan billboard quads, with both instanced and non-instanced functionality
- Modifying a `Cloud` dynamically.

Here is a localhost [Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=nZRRb5swEMe/iscTqMRASNNuIdE2+jhp0lLtiRcXLqlVY0e2oUumfffZkBLSpSsJT7bv7n+/uzOuiUQ1hWeQaI44PKMUFK1K/LM5czMnb/ap4JpQDjJzvFnGaxOlcuBggtpo3GyNqTVuhKKaCm7se8GUSG1WhMd4JUV5B2sJoNxRNI5xeDOZTKOPPppMcHgdxjfh1OukciaqQhmhJgPeSFoa6RoUJkXh9pBT65gKxiC3qV3vhbRRiIxCK9XE/c446ig/9Ss/gLovdvzL73zxtrfeoSt06/lWS+WEwWmhsRuFPrq2fn/aui4HMQmt2IEGjY4PLNI4HMA09lHUIV0ONDLZjniujg92DfEAnthHca9FS8KLnCjNwFLdwYpUTN8LwR6I/FppbQacOfdivWaAlo/CKNoSMsdHq4rvLwBqamnHj5V1mqMPve3szGyScMWIhndz9a7/gIEeN/B17269MzGXtsvvt6Pxmr91OQySuUVnZv4BCvTQQWhZ2ffikp7992+cDS6y/SsPNe5fspyUIAlmQjx90V1W/w0qozG1OmHz3Di+kyi9ZbCwFPb7TMuNkBpVkrkYBxrKjb1CKnio8ifQOFeqRUYoCfqhSUFrRIv5iSfYlEeUMpZVxdiS7iBzFklg/P8JZYIUlK+/1yAZ2Vq3x2jxrT3EGCeB2Z6O1O1sXyn/BQ) that demonstrates the cloud API.

@lilleyse 