### PR TITLE
Adds boundingSphere and debugShowBoundingVolume to ModelExperimental

### DIFF
--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -155,7 +155,7 @@ Object.defineProperties(ModelExperimental.prototype, {
   boundingSphere: {
     get: function () {
       //>>includeStart('debug', pragmas.debug);
-      if (!this._drawCommandsBuilt) {
+      if (!this._ready) {
         throw new DeveloperError(
           "The model is not loaded. Use ModelExperimental.readyPromise or wait for ModelExperimental.ready to be true."
         );

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -57,7 +57,7 @@ export default function ModelExperimental(options) {
   this._resources = [];
 
   this._boundingSphere = undefined;
-  this._boundingSphereTransform = options._boundingSphereTransform;
+  this._boundingSphereTransform = options.boundingSphereTransform;
 
   this._debugShowBoundingVolumeDirty = false;
   this._debugShowBoundingVolume = defaultValue(

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -25,6 +25,8 @@ import BoundingSphere from "../../Core/BoundingSphere.js";
  * @param {Matrix4} [options.modelMatrix=Matrix4.IDENTITY]  The 4x4 transformation matrix that transforms the model from model to world coordinates.
  * @param {Boolean} [options.incrementallyLoadTextures=true] Determine if textures may continue to stream in after the model is loaded.
  * @param {Boolean} [options.releaseGltfJson=false] When true, the glTF JSON is released once the glTF is loaded. This is is especially useful for cases like 3D Tiles, where each .gltf model is unique and caching the glTF JSON is not effective.
+ * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for each draw command in the model.
+ * @param {Matrix4} [options.boundingSphereTransform=Matrix4.IDENTITY] The 4x4 transformation matrix that transforms the bounding sphere for the model.
  *
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
@@ -349,6 +351,8 @@ function initialize(model, options) {
  * @param {Matrix4} [options.modelMatrix=Matrix4.IDENTITY] The 4x4 transformation matrix that transforms the model from model to world coordinates.
  * @param {Boolean} [options.incrementallyLoadTextures=true] Determine if textures may continue to stream in after the model is loaded.
  * @param {Boolean} [options.releaseGltfJson=false] When true, the glTF JSON is released once the glTF is loaded. This is is especially useful for cases like 3D Tiles, where each .gltf model is unique and caching the glTF JSON is not effective.
+ * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for each draw command in the model.
+ * @param {Matrix4} [options.boundingSphereTransform=Matrix4.IDENTITY] The 4x4 transformation matrix that transforms the bounding sphere for the model.
  */
 ModelExperimental.fromGltf = function (options) {
   //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -230,8 +230,14 @@ ModelExperimental.prototype.update = function (frameState) {
   if (!this._drawCommandsBuilt) {
     this._sceneGraph.buildDrawCommands(frameState);
     this._drawCommandsBuilt = true;
-    this._ready = true;
-    this._readyPromise.resolve(this);
+
+    var model = this;
+    // Set the model as ready after the first frame render since the user might set up events subscribed to
+    // the post render event, and the model may not be ready for those past the first frame.
+    frameState.afterRender.push(function () {
+      model._ready = true;
+      model._readyPromise.resolve(model);
+    });
   }
 
   if (this._debugShowBoundingVolumeDirty) {

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -8,7 +8,6 @@ import ModelExperimentalSceneGraph from "./ModelExperimentalSceneGraph.js";
 import Resource from "../../Core/Resource.js";
 import when from "../../ThirdParty/when.js";
 import destroyObject from "../../Core/destroyObject.js";
-import BoundingSphere from "../../Core/BoundingSphere.js";
 
 /**
  * A 3D model based on glTF, the runtime asset format for WebGL. This is
@@ -26,7 +25,6 @@ import BoundingSphere from "../../Core/BoundingSphere.js";
  * @param {Boolean} [options.incrementallyLoadTextures=true] Determine if textures may continue to stream in after the model is loaded.
  * @param {Boolean} [options.releaseGltfJson=false] When true, the glTF JSON is released once the glTF is loaded. This is is especially useful for cases like 3D Tiles, where each .gltf model is unique and caching the glTF JSON is not effective.
  * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for each draw command in the model.
- * @param {Matrix4} [options.boundingSphereTransform=undefined] A 4x4 transformation matrix that transforms the bounding sphere for the model.
  *
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
@@ -57,7 +55,6 @@ export default function ModelExperimental(options) {
   this._resources = [];
 
   this._boundingSphere = undefined;
-  this._boundingSphereTransform = options.boundingSphereTransform;
 
   this._debugShowBoundingVolumeDirty = false;
   this._debugShowBoundingVolume = defaultValue(
@@ -162,15 +159,7 @@ Object.defineProperties(ModelExperimental.prototype, {
       }
       //>>includeEnd('debug');
 
-      var boundingSphere = this._sceneGraph._boundingSphere;
-      if (defined(this._boundingSphereTransform)) {
-        boundingSphere = BoundingSphere.transform(
-          boundingSphere,
-          this._boundingSphereTransform
-        );
-      }
-
-      return boundingSphere;
+      return this._sceneGraph._boundingSphere;
     },
   },
 
@@ -358,7 +347,6 @@ function initialize(model, options) {
  * @param {Boolean} [options.incrementallyLoadTextures=true] Determine if textures may continue to stream in after the model is loaded.
  * @param {Boolean} [options.releaseGltfJson=false] When true, the glTF JSON is released once the glTF is loaded. This is is especially useful for cases like 3D Tiles, where each .gltf model is unique and caching the glTF JSON is not effective.
  * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for each draw command in the model.
- * @param {Matrix4} [options.boundingSphereTransform=undefined] A 4x4 transformation matrix that transforms the bounding sphere for the model.
  */
 ModelExperimental.fromGltf = function (options) {
   //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -26,7 +26,7 @@ import BoundingSphere from "../../Core/BoundingSphere.js";
  * @param {Boolean} [options.incrementallyLoadTextures=true] Determine if textures may continue to stream in after the model is loaded.
  * @param {Boolean} [options.releaseGltfJson=false] When true, the glTF JSON is released once the glTF is loaded. This is is especially useful for cases like 3D Tiles, where each .gltf model is unique and caching the glTF JSON is not effective.
  * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for each draw command in the model.
- * @param {Matrix4} [options.boundingSphereTransform=Matrix4.IDENTITY] The 4x4 transformation matrix that transforms the bounding sphere for the model.
+ * @param {Matrix4} [options.boundingSphereTransform=undefined] A 4x4 transformation matrix that transforms the bounding sphere for the model.
  *
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
@@ -358,7 +358,7 @@ function initialize(model, options) {
  * @param {Boolean} [options.incrementallyLoadTextures=true] Determine if textures may continue to stream in after the model is loaded.
  * @param {Boolean} [options.releaseGltfJson=false] When true, the glTF JSON is released once the glTF is loaded. This is is especially useful for cases like 3D Tiles, where each .gltf model is unique and caching the glTF JSON is not effective.
  * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for each draw command in the model.
- * @param {Matrix4} [options.boundingSphereTransform=Matrix4.IDENTITY] The 4x4 transformation matrix that transforms the bounding sphere for the model.
+ * @param {Matrix4} [options.boundingSphereTransform=undefined] A 4x4 transformation matrix that transforms the bounding sphere for the model.
  */
 ModelExperimental.fromGltf = function (options) {
   //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
@@ -8,6 +8,7 @@ import ModelExperimentalSceneMeshPrimitive from "./ModelExperimentalSceneMeshPri
 import ModelExperimentalSceneNode from "./ModelExperimentalSceneNode.js";
 import ModelExperimentalUtility from "./ModelExperimentalUtility.js";
 import RenderResources from "./RenderResources.js";
+import BoundingSphere from "../../Core/BoundingSphere.js";
 
 /**
  * An in memory representation of the scene graph for a {@link ModelExperimental}
@@ -98,6 +99,26 @@ export default function ModelExperimentalSceneGraph(options) {
    * @private
    */
   this._forwardAxis = defaultValue(options.forwardAxis, Axis.Z);
+
+  /**
+   * The bounding sphere containing all the primitives in the scene graph.
+   *
+   * @type {BoundingSphere}
+   * @readonly
+   *
+   * @private
+   */
+  this._boundingSphere = undefined;
+
+  /**
+   * The array of bounding spheres of all the primitives in the scene graph.
+   *
+   * @type {BoundingSphere[]}
+   * @readonly
+   *
+   * @private
+   */
+  this._boundingSpheres = [];
 
   /**
    * The 4x4 transformation matrix that transforms the model from model to world coordinates.
@@ -244,6 +265,8 @@ ModelExperimentalSceneGraph.prototype.buildDrawCommands = function (
         );
       }
 
+      this._boundingSpheres.push(meshPrimitiveRenderResources.boundingSphere);
+
       var drawCommand = buildDrawCommand(
         meshPrimitiveRenderResources,
         frameState
@@ -251,4 +274,7 @@ ModelExperimentalSceneGraph.prototype.buildDrawCommands = function (
       this._drawCommands.push(drawCommand);
     }
   }
+  this._boundingSphere = BoundingSphere.fromBoundingSpheres(
+    this._boundingSpheres
+  );
 };

--- a/Source/Scene/ModelExperimental/buildDrawCommand.js
+++ b/Source/Scene/ModelExperimental/buildDrawCommand.js
@@ -51,5 +51,7 @@ export default function buildDrawCommand(
     pickId: undefined,
     instanceCount: meshPrimitiveRenderResources.instanceCount,
     primitiveType: meshPrimitiveRenderResources.primitiveType,
+    debugShowBoundingVolume:
+      meshPrimitiveRenderResources.model._debugShowBoundingVolume,
   });
 }

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -90,31 +90,6 @@ describe(
       });
     });
 
-    it("boundingSphereTransform is applied", function () {
-      var resource = Resource.createIfNeeded(boxTexturedGlbUrl);
-      var loadPromise = resource.fetchArrayBuffer();
-      var translation = new Cartesian3(1, 1, 1);
-      var transform = Matrix4.fromTranslation(new Cartesian3(1, 1, 1));
-      return loadPromise.then(function (buffer) {
-        return loadAndZoomToModelExperimental(
-          {
-            gltf: new Uint8Array(buffer),
-            debugShowBoundingVolume: true,
-            boundingSphereTransform: transform,
-          },
-          scene
-        ).then(function (model) {
-          var boundingSphere = model.boundingSphere;
-          expect(boundingSphere).toBeDefined();
-          expect(boundingSphere.center).toEqual(translation);
-          expect(boundingSphere.radius).toEqualEpsilon(
-            0.8660254037844386,
-            CesiumMath.EPSILON8
-          );
-        });
-      });
-    });
-
     it("fromGltf throws with undefined options", function () {
       expect(function () {
         ModelExperimental.fromGltf();

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -6,7 +6,6 @@ import {
   Resource,
   ModelExperimental,
   Cartesian3,
-  Matrix4,
 } from "../../../Source/Cesium.js";
 import createScene from "../../createScene.js";
 import loadAndZoomToModelExperimental from "./loadModelExperimentalForSpec.js";

--- a/Specs/Scene/ModelExperimental/loadModelExperimentalForSpec.js
+++ b/Specs/Scene/ModelExperimental/loadModelExperimentalForSpec.js
@@ -14,7 +14,6 @@ function loadAndZoomToModelExperimental(options, scene) {
       upAxis: options.upAxis,
       forwardAxis: options.forwardAxis,
       debugShowBoundingVolume: options.debugShowBoundingVolume,
-      boundingSphereTransform: options.boundingSphereTransform,
     });
   } else {
     model = new ModelExperimental({
@@ -22,7 +21,6 @@ function loadAndZoomToModelExperimental(options, scene) {
       upAxis: options.upAxis,
       forwardAxis: options.forwardAxis,
       debugShowBoundingVolume: options.debugShowBoundingVolume,
-      boundingSphereTransform: options.boundingSphereTransform,
     });
   }
 

--- a/Specs/Scene/ModelExperimental/loadModelExperimentalForSpec.js
+++ b/Specs/Scene/ModelExperimental/loadModelExperimentalForSpec.js
@@ -13,12 +13,16 @@ function loadAndZoomToModelExperimental(options, scene) {
       url: options.url,
       upAxis: options.upAxis,
       forwardAxis: options.forwardAxis,
+      debugShowBoundingVolume: options.debugShowBoundingVolume,
+      boundingSphereTransform: options.boundingSphereTransform,
     });
   } else {
     model = new ModelExperimental({
       gltf: options.gltf,
       upAxis: options.upAxis,
       forwardAxis: options.forwardAxis,
+      debugShowBoundingVolume: options.debugShowBoundingVolume,
+      boundingSphereTransform: options.boundingSphereTransform,
     });
   }
 


### PR DESCRIPTION
This is a pretty simple PR in terms of features being added, but it'll pave the path for how we want to handle dynamic updates (cases where we need to modify or reset draw commands).

Additionally, implementing this revealed a flaw in the way we were handling the `readyPromise`. The model is not considered ready in `Model.js` until the first `update()`, so I fixed that here.

Here is a [local Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=xVdbj+I2FP4rFk8ZKZMwHXa3peyoZW4daVHRQmcemj6Y5ABWHRvZDoRW89977FwIbGjLbtlKgGP7XL5zMf6ypoqsGWxAkfdEwIbcgmZZGjy7NS/qxG5+K4WhTICKOhffRyISYUhGMgFOxlIbJgUTi0is0dhKamYX0Fxp6pYqg09UXAdzJdM7WCgA7UWCkMurb66D7rte7+3Vd75d6PWC7pvu9bvuWzd9042E9WcNL1cHEH8CmqDbMTPx8qPk3Ov6xH4qhTnLIXlQNIWpokLPpUp3oOolHXAZU17IyYda5xEwWmqkckCjjpDKLKOOX8w2oE3UKcA106EL16l7Rm+/WvE/7Q8hBnLTR92hlOlQ5qUtQqTQwCHGvXkmYpc776JSIqTYdNa9as1CCCcriHV4Rw0NC9/hePgxLK1XY7DgZm6RFmoWrx1f7fDqt6LL71OmNVvD2RDWHprPn4P0F8GZOR9MZ75++ByAT0IbKmJIzgDyEeF8kDQBFTY9hQs+fQhnMr9k1dIXIXcnhVOL9OsF0XDaEs+l2W3/V7G9MLMcMTGi+f8S5c79P8R7mTL80vyL4n4SBhQHuv6ajdlw2hYj222fHNuIxUrGUqfnjaZ2U+BPq+nJeKcKr8MFB1t1mZknkTC8Z88Lvt1nEUn73ulhbeSEJZCMORXnuj32fOzPTsb7DMhM8lvJpZq6C/0siA+8HM5PRv0C1CwtEztnt5ROivbYFJO/RRqJ3xwXsvQngVm2mCzlZigzYTnas+RZCsiH5pRrKPlZAQwS59zp1vibmDPFy2gKnhroGKlZsFIsRaK5xjZVkMo1/IgMsIC0ZxidHtOjSVJmpCSFTuE+XwHKABJe7girzYpXpxPh9O2PXy0wESMAJ863NntTrFOmQPeLaGtBRwpH1CiW91to6PKAzjbJaKNwFb/2d0vIjBuz0vI952ylJUuCl8fJt72GQAsvrktaix0pYf/YRtkKF3YsqvBJJbBONNmOMaNMQ4ANJbyWhi2LFSM8RYM5305l5WmywiYEb9/obG/T3/V9kil3YfZJtwLncLnhtaDtEyqSmGrDwTbDVEo+o2oEIvMKBm9FD2UW+D85zIyRAt+ObCLInU0JqVCSMiEd/1iu/MZBtYjiJcS/400syiSwOfHKKiYwx7euZD/mizpZxw9aabM8ovsp+3damCJMVcfvDLTZcrip8voDS1f4LmTPgBcEoYF0hcwEb5JZhromiLWu/hkGYVN1kLA1Ycn7lndKEnOqNe7MM84n7A/M3s0gRPlPVLl0p+TnNXIFurViy6ubD8ViEASDEKftmqao7oHlvwA) for testing.

@ptrgags Let me know your thoughts on how the update pattern is implemented here and what your suggestions are for improving it. I think we may want to move some update functions to `ModelExperimentalSceneGraph` but we may risk making that file a monolith.