### PR TITLE
Fix glTF loader test timeouts

### DIFF
--- a/Specs/Scene/GltfDracoLoaderSpec.js
+++ b/Specs/Scene/GltfDracoLoaderSpec.js
@@ -9,6 +9,7 @@ import {
   when,
 } from "../../Source/Cesium.js";
 import createScene from "../createScene.js";
+import loaderProcess from "../loaderProcess.js";
 import pollToPromise from "../pollToPromise.js";
 import waitForLoaderProcess from "../waitForLoaderProcess.js";
 
@@ -284,7 +285,7 @@ describe("Scene/GltfDracoLoader", function () {
     dracoLoader.load();
 
     return pollToPromise(function () {
-      dracoLoader.process(scene.frameState);
+      loaderProcess(dracoLoader, scene);
       if (processCallsCount++ === processCallsTotal) {
         deferredPromise.resolve(decodeDracoResults);
       }
@@ -294,7 +295,7 @@ describe("Scene/GltfDracoLoader", function () {
       );
     }).then(function () {
       return dracoLoader.promise.then(function (dracoLoader) {
-        dracoLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
+        loaderProcess(dracoLoader, scene); // Check that calling process after load doesn't break anything
         expect(dracoLoader.decodedData.indices).toBe(
           decodeDracoResults.indexArray
         );
@@ -418,7 +419,7 @@ describe("Scene/GltfDracoLoader", function () {
     expect(dracoLoader.decodedData).not.toBeDefined();
 
     dracoLoader.load();
-    dracoLoader.process(scene.frameState);
+    loaderProcess(dracoLoader, scene);
     expect(decodeBufferView).toHaveBeenCalled(); // Make sure the decode actually starts
 
     dracoLoader.destroy();

--- a/Specs/Scene/GltfFeatureMetadataLoaderSpec.js
+++ b/Specs/Scene/GltfFeatureMetadataLoaderSpec.js
@@ -10,6 +10,7 @@ import {
   when,
 } from "../../Source/Cesium.js";
 import createScene from "../createScene.js";
+import loaderProcess from "../loaderProcess.js";
 import MetadataTester from "../MetadataTester.js";
 import waitForLoaderProcess from "../waitForLoaderProcess.js";
 
@@ -342,7 +343,7 @@ describe(
       return waitForLoaderProcess(featureMetadataLoader, scene).then(function (
         featureMetadataLoader
       ) {
-        featureMetadataLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
+        loaderProcess(featureMetadataLoader, scene); // Check that calling process after load doesn't break anything
         var featureMetadata = featureMetadataLoader.featureMetadata;
         var buildingsTable = featureMetadata.getFeatureTable("buildings");
         var treesTable = featureMetadata.getFeatureTable("trees");

--- a/Specs/Scene/GltfIndexBufferLoaderSpec.js
+++ b/Specs/Scene/GltfIndexBufferLoaderSpec.js
@@ -12,6 +12,7 @@ import {
 } from "../../Source/Cesium.js";
 import concatTypedArrays from "../concatTypedArrays.js";
 import createScene from "../createScene.js";
+import loaderProcess from "../loaderProcess.js";
 import waitForLoaderProcess from "../waitForLoaderProcess.js";
 
 describe(
@@ -411,7 +412,7 @@ describe(
       return waitForLoaderProcess(indexBufferLoader, scene).then(function (
         indexBufferLoader
       ) {
-        indexBufferLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
+        loaderProcess(indexBufferLoader, scene); // Check that calling process after load doesn't break anything
         expect(indexBufferLoader.indexBuffer.sizeInBytes).toBe(
           indicesUint16.byteLength
         );
@@ -512,7 +513,7 @@ describe(
       return waitForLoaderProcess(indexBufferLoader, scene).then(function (
         indexBufferLoader
       ) {
-        indexBufferLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
+        loaderProcess(indexBufferLoader, scene); // Check that calling process after load doesn't break anything
         expect(indexBufferLoader.indexBuffer.sizeInBytes).toBe(
           decodedIndices.byteLength
         );
@@ -686,7 +687,7 @@ describe(
       expect(indexBufferLoader.indexBuffer).not.toBeDefined();
 
       indexBufferLoader.load();
-      indexBufferLoader.process(scene.frameState);
+      loaderProcess(indexBufferLoader, scene);
       expect(decodeBufferView).toHaveBeenCalled(); // Make sure the decode actually starts
 
       indexBufferLoader.destroy();

--- a/Specs/Scene/GltfLoaderSpec.js
+++ b/Specs/Scene/GltfLoaderSpec.js
@@ -30,6 +30,7 @@ import {
 } from "../../Source/Cesium.js";
 import createScene from "../createScene.js";
 import generateJsonBuffer from "../generateJsonBuffer.js";
+import loaderProcess from "../loaderProcess.js";
 import pollToPromise from "../pollToPromise.js";
 import waitForLoaderProcess from "../waitForLoaderProcess.js";
 
@@ -1807,7 +1808,7 @@ describe(
 
         // Continue processing to load in textures
         return pollToPromise(function () {
-          gltfLoader.process(scene.frameState);
+          loaderProcess(gltfLoader, scene);
           return gltfLoader._textureLoaders.every(function (loader) {
             return (
               loader._state === ResourceLoaderState.READY ||

--- a/Specs/Scene/GltfTextureLoaderSpec.js
+++ b/Specs/Scene/GltfTextureLoaderSpec.js
@@ -12,6 +12,7 @@ import {
   when,
 } from "../../Source/Cesium.js";
 import createScene from "../createScene.js";
+import loaderProcess from "../loaderProcess.js";
 import waitForLoaderProcess from "../waitForLoaderProcess.js";
 
 describe(
@@ -289,14 +290,14 @@ describe(
         supportedImageFormats: new SupportedImageFormats(),
       });
 
-      textureLoader.process(scene.frameState); // Check that calling process before load doesn't break anything
+      loaderProcess(textureLoader, scene); // Check that calling process before load doesn't break anything
 
       textureLoader.load();
 
       return waitForLoaderProcess(textureLoader, scene).then(function (
         textureLoader
       ) {
-        textureLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
+        loaderProcess(textureLoader, scene); // Check that calling process after load doesn't break anything
         expect(textureLoader.texture.width).toBe(1);
         expect(textureLoader.texture.height).toBe(1);
       });
@@ -322,7 +323,7 @@ describe(
       return waitForLoaderProcess(textureLoader, scene).then(function (
         textureLoader
       ) {
-        textureLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
+        loaderProcess(textureLoader, scene); // Check that calling process after load doesn't break anything
         expect(textureLoader.texture.width).toBe(1);
         expect(textureLoader.texture.height).toBe(1);
       });

--- a/Specs/Scene/GltfVertexBufferLoaderSpec.js
+++ b/Specs/Scene/GltfVertexBufferLoaderSpec.js
@@ -13,6 +13,7 @@ import {
 } from "../../Source/Cesium.js";
 import concatTypedArrays from "../concatTypedArrays.js";
 import createScene from "../createScene.js";
+import loaderProcess from "../loaderProcess.js";
 import waitForLoaderProcess from "../waitForLoaderProcess.js";
 
 describe(
@@ -409,7 +410,7 @@ describe(
       return waitForLoaderProcess(vertexBufferLoader, scene).then(function (
         vertexBufferLoader
       ) {
-        vertexBufferLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
+        loaderProcess(vertexBufferLoader, scene); // Check that calling process after load doesn't break anything
         expect(vertexBufferLoader.vertexBuffer.sizeInBytes).toBe(
           positions.byteLength
         );
@@ -471,7 +472,7 @@ describe(
       return waitForLoaderProcess(vertexBufferLoader, scene).then(function (
         vertexBufferLoader
       ) {
-        vertexBufferLoader.process(scene.frameState); // Check that calling process after load doesn't break anything
+        loaderProcess(vertexBufferLoader, scene); // Check that calling process after load doesn't break anything
         expect(vertexBufferLoader.vertexBuffer.sizeInBytes).toBe(
           decodedPositions.byteLength
         );
@@ -702,7 +703,7 @@ describe(
       expect(vertexBufferLoader.vertexBuffer).not.toBeDefined();
 
       vertexBufferLoader.load();
-      vertexBufferLoader.process(scene.frameState);
+      loaderProcess(vertexBufferLoader, scene);
       expect(decodeBufferView).toHaveBeenCalled(); // Make sure the decode actually starts
 
       vertexBufferLoader.destroy();

--- a/Specs/loaderProcess.js
+++ b/Specs/loaderProcess.js
@@ -1,0 +1,9 @@
+export default function loaderProcess(loader, scene) {
+  // Normally scene is responsible for resetting the job scheduler every frame
+  // but since we're not calling scene.renderForSpecs we need to reset budgets
+  // explicitly. This is only required for loaders that use the job scheduler
+  // like GltfVertexBufferLoader, GltfIndexBufferLoader, and GltfTextureLoader
+  scene.jobScheduler.resetBudgets();
+  loader.process(scene.frameState);
+  scene.jobScheduler.resetBudgets();
+}

--- a/Specs/waitForLoaderProcess.js
+++ b/Specs/waitForLoaderProcess.js
@@ -1,3 +1,4 @@
+import loaderProcess from "./loaderProcess.js";
 import pollToPromise from "./pollToPromise.js";
 
 export default function waitForLoaderProcess(loader, scene) {
@@ -6,7 +7,7 @@ export default function waitForLoaderProcess(loader, scene) {
     loaderFinished = true;
   });
   return pollToPromise(function () {
-    loader.process(scene.frameState);
+    loaderProcess(loader, scene);
     return loaderFinished;
   }).then(function () {
     return loader.promise;


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/9710

Certain glTF loader tests were timing out because the `JobScheduler` was was getting clogged after repeatedly loading GPU resources and not getting reset. This was a bug in the testing code only.

Normally scene is responsible for resetting the job scheduler every frame but since we're not calling `scene.renderForSpecs` we need to reset budgets manually. This is only required for loaders that use the job scheduler like `GltfVertexBufferLoader`, `GltfIndexBufferLoader`, and `GltfTextureLoader`

I can pretty frequently reproduce the timeouts in Firefox on Linux with cache disabled (this seems to indirectly effect the speed at which the JobScheduler fills up), but it may vary by device.