### PR TITLE
Add ability to specify Bing Maps geocoder culture

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # Change Log
 
-### 1.85 - 2021-08-10
+### 1.85 - 2021-09-01
+
+##### Additions :tada:
+
+- `BingMapsGeocoderService` now takes an optional [Culture Code](https://docs.microsoft.com/en-us/bingmaps/rest-services/common-parameters-and-types/supported-culture-codes) for localizing results.
 
 ##### Fixes :wrench:
 

--- a/Source/Core/BingMapsGeocoderService.js
+++ b/Source/Core/BingMapsGeocoderService.js
@@ -14,6 +14,7 @@ var url = "https://dev.virtualearth.net/REST/v1/Locations";
  *
  * @param {Object} options Object with the following properties:
  * @param {String} options.key A key to use with the Bing Maps geocoding service
+ * @param {String} [options.culture] A Bing Maps { @link https://docs.microsoft.com/en-us/bingmaps/rest-services/common-parameters-and-types/supported-culture-codes|Culture Code} to return results in a specific culture and language.
  */
 function BingMapsGeocoderService(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -26,11 +27,17 @@ function BingMapsGeocoderService(options) {
 
   this._key = key;
 
+  var queryParameters = {
+    key: key,
+  };
+
+  if (defined(options.culture)) {
+    queryParameters.culture = options.culture;
+  }
+
   this._resource = new Resource({
     url: url,
-    queryParameters: {
-      key: key,
-    },
+    queryParameters: queryParameters,
   });
 }
 

--- a/Source/Core/BingMapsGeocoderService.js
+++ b/Source/Core/BingMapsGeocoderService.js
@@ -14,7 +14,7 @@ var url = "https://dev.virtualearth.net/REST/v1/Locations";
  *
  * @param {Object} options Object with the following properties:
  * @param {String} options.key A key to use with the Bing Maps geocoding service
- * @param {String} [options.culture] A Bing Maps { @link https://docs.microsoft.com/en-us/bingmaps/rest-services/common-parameters-and-types/supported-culture-codes|Culture Code} to return results in a specific culture and language.
+ * @param {String} [options.culture] A Bing Maps {@link https://docs.microsoft.com/en-us/bingmaps/rest-services/common-parameters-and-types/supported-culture-codes|Culture Code} to return results in a specific culture and language.
  */
 function BingMapsGeocoderService(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/Source/Core/Resource.js
+++ b/Source/Core/Resource.js
@@ -14,6 +14,7 @@ import isBlobUri from "./isBlobUri.js";
 import isCrossOriginUrl from "./isCrossOriginUrl.js";
 import isDataUri from "./isDataUri.js";
 import loadAndExecuteScript from "./loadAndExecuteScript.js";
+import CesiumMath from "./Math.js";
 import objectToQuery from "./objectToQuery.js";
 import queryToObject from "./queryToObject.js";
 import Request from "./Request.js";
@@ -1258,7 +1259,8 @@ Resource.prototype.fetchJsonp = function (callbackParameterName) {
   //generate a unique function name
   var functionName;
   do {
-    functionName = "loadJsonp" + Math.random().toString().substring(2, 8);
+    functionName =
+      "loadJsonp" + CesiumMath.nextRandomNumber().toString().substring(2, 8);
   } while (defined(window[functionName]));
 
   return fetchJsonp(this, callbackParameterName, functionName);

--- a/Specs/Core/BingMapsGeocoderServiceSpec.js
+++ b/Specs/Core/BingMapsGeocoderServiceSpec.js
@@ -8,8 +8,9 @@ describe("Core/BingMapsGeocoderService", function () {
       Resource._DefaultImplementations.loadAndExecuteScript;
   });
 
-  it("returns geocoder results", function (done) {
+  it("returns geocoder results", function () {
     var query = "some query";
+    var key = "not_the_real_key;";
     var data = {
       resourceSets: [
         {
@@ -27,14 +28,51 @@ describe("Core/BingMapsGeocoderService", function () {
       functionName,
       deferred
     ) {
+      var parsedUrl = new URL(url);
+      expect(parsedUrl.searchParams.get("query")).toEqual(query);
+      expect(parsedUrl.searchParams.get("key")).toEqual(key);
+      expect(parsedUrl.searchParams.get("culture")).toBe(null);
       deferred.resolve(data);
     };
-    var service = new BingMapsGeocoderService({ key: "" });
-    service.geocode(query).then(function (results) {
+    var service = new BingMapsGeocoderService({ key: key });
+    return service.geocode(query).then(function (results) {
       expect(results.length).toEqual(1);
       expect(results[0].displayName).toEqual("a");
       expect(results[0].destination).toBeInstanceOf(Rectangle);
-      done();
+    });
+  });
+
+  it("uses supplied culture", function () {
+    var query = "some query";
+    var key = "not_the_real_key;";
+    var data = {
+      resourceSets: [
+        {
+          resources: [
+            {
+              name: "a",
+              bbox: [32.0, 3.0, 3.0, 4.0],
+            },
+          ],
+        },
+      ],
+    };
+    Resource._Implementations.loadAndExecuteScript = function (
+      url,
+      functionName,
+      deferred
+    ) {
+      var parsedUrl = new URL(url);
+      expect(parsedUrl.searchParams.get("query")).toEqual(query);
+      expect(parsedUrl.searchParams.get("key")).toEqual(key);
+      expect(parsedUrl.searchParams.get("culture")).toEqual("ja");
+      deferred.resolve(data);
+    };
+    var service = new BingMapsGeocoderService({ key: key, culture: "ja" });
+    return service.geocode(query).then(function (results) {
+      expect(results.length).toEqual(1);
+      expect(results[0].displayName).toEqual("a");
+      expect(results[0].destination).toBeInstanceOf(Rectangle);
     });
   });
 


### PR DESCRIPTION
1. Add optional `culture` property to BingMapsGeocoderService constructor and use it to set culture when making a request. This causes the results to be displayed in the specified culture and language.

2. Update Resource.js to use CesiumMath's RNG so we can have a random seed with consistent results

3. Slightly improve BingMapsGeocoderService tests to support the new functionality and double check some existing code.