### PR TITLE
Scene: change options to required

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -294,3 +294,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Ethan Wong](https://github.com/GetToSet)
 - [Calogero Mauceri](https://github.com/kalosma)
 - [Ren Jianqiang](https://github.com/renjianqiang)
+- [Yang Puxiao](https://github.com/puxiao)

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -124,7 +124,7 @@ var requestRenderAfterFrame = function (scene) {
  * @alias Scene
  * @constructor
  *
- * @param {Object} [options] Object with the following properties:
+ * @param {Object} options Object with the following properties:
  * @param {HTMLCanvasElement} options.canvas The HTML canvas element to create the scene for.
  * @param {Object} [options.contextOptions] Context and WebGL creation properties.  See details above.
  * @param {Element} [options.creditContainer] The HTML element in which the credits will be displayed.

--- a/Specs/TypeScript/index.ts
+++ b/Specs/TypeScript/index.ts
@@ -152,9 +152,10 @@ terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
 let dataSource: DataSource;
 dataSource = new CzmlDataSource();
 dataSource = new GeoJsonDataSource();
+let canvasElement = document.createElement("canvas");
 dataSource = new KmlDataSource({
-  canvas: document.createElement("canvas"),
-  camera: new Camera(new Scene()),
+  canvas: canvasElement,
+  camera: new Camera(new Scene({ canvas: canvasElement })),
 });
 dataSource = new CustomDataSource();
 


### PR DESCRIPTION
Even though i know :

1. Generally, a scene is not created directly.

2. in the Scene.js：

   ```
   function Scene(options) {
     options = defaultValue(options, defaultValue.EMPTY_OBJECT);
     ...
   }
   ```



<br>

*Cesium.d.ts*

```
export class Scene {
    constructor(options?: {
        canvas: HTMLCanvasElement;
        ...
    )
}
```



<br>

But if you really do

```
var scene = new Cesium.Scene();
```

Throws:
DeveloperError : options and options.canvas are required.



<br>

Emm...

I think that is not a good type description.

So:

```diff
- * @param {Object} [options] Object with the following properties:
+ * @param {Object} options Object with the following properties:
```





