### PR TITLE
Adds primitive picking to ModelExperimental.js

### DIFF
--- a/Source/Scene/ModelExperimental/GeometryPipelineStage.js
+++ b/Source/Scene/ModelExperimental/GeometryPipelineStage.js
@@ -32,14 +32,13 @@ var GeometryPipelineStage = {};
  */
 GeometryPipelineStage.process = function (renderResources, primitive) {
   // The attribute index is taken from the node render resources, which may have added some attributes of its own.
-  var attributeIndex = renderResources.attributeIndex;
   var index;
   var setIndexedAttributeInitializationLines = [];
   var customAttributeInitializationLines = [];
   for (var i = 0; i < primitive.attributes.length; i++) {
     var attribute = primitive.attributes[i];
     if (attribute.semantic !== VertexAttributeSemantic.POSITION) {
-      index = attributeIndex++;
+      index = renderResources.attributeIndex++;
     } else {
       index = 0;
     }

--- a/Source/Scene/ModelExperimental/InstancingPipelineStage.js
+++ b/Source/Scene/ModelExperimental/InstancingPipelineStage.js
@@ -14,7 +14,7 @@ import InstancingStageVS from "../../Shaders/ModelExperimental/InstancingStageVS
  * The instancing pipeline stage is responsible for handling GPU mesh instancing at the node
  * level.
  *
- * @namespace
+ * @namespace InstancingPipelineStage
  * @private
  */
 var InstancingPipelineStage = {};

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -27,6 +27,7 @@ import Matrix4 from "../../Core/Matrix4.js";
  * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for each draw command in the model.
  * @param {Boolean} [options.cull=true]  Whether or not to cull the model using frustum/horizon culling. If the model is part of a 3D Tiles tileset, this property will always be false, since the 3D Tiles culling system is used.
  * @param {Boolean} [options.opaquePass=Pass.OPAQUE] The pass to use in the {@link DrawCommand} for the opaque portions of the model.
+ * @param {Boolean} [options.allowPicking=true] When <code>true</code>, each primitive is pickable with {@link Scene#pick}.
  *
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
@@ -60,6 +61,7 @@ export default function ModelExperimental(options) {
 
   this._cull = defaultValue(options.cull, true);
   this._opaquePass = defaultValue(options.opaquePass, Pass.OPAQUE);
+  this._allowPicking = defaultValue(options.allowPicking, true);
 
   // Keeps track of resources that need to be destroyed when the Model is destroyed.
   this._resources = [];
@@ -167,6 +169,20 @@ Object.defineProperties(ModelExperimental.prototype, {
   opaquePass: {
     get: function () {
       return this._opaquePass;
+    },
+  },
+
+  /**
+   * When <code>true</code>, each mesh and primitive is pickable with {@link Scene#pick}.  When <code>false</code>, GPU memory is saved.
+   *
+   * @type {Boolean}
+   * @readonly
+   *
+   * @private
+   */
+  allowPicking: {
+    get: function () {
+      return this._allowPicking;
     },
   },
 
@@ -352,6 +368,7 @@ ModelExperimental.prototype.destroy = function () {
  * @param {Boolean} [options.opaquePass=Pass.OPAQUE] The pass to use in the {@link DrawCommand} for the opaque portions of the model.
  * @param {Axis} [options.upAxis=Axis.Y] The up-axis of the glTF model.
  * @param {Axis} [options.forwardAxis=Axis.Z] The forward-axis of the glTF model.
+ * @param {Boolean} [options.allowPicking=true] When <code>true</code>, each primitive is pickable with {@link Scene#pick}.
  *
  * @returns {ModelExperimental} The newly created model.
  *
@@ -390,6 +407,7 @@ ModelExperimental.fromGltf = function (options) {
     debugShowBoundingVolume: options.debugShowBoundingVolume,
     cull: options.cull,
     opaquePass: options.opaquePass,
+    allowPicking: options.allowPicking,
   };
   var model = new ModelExperimental(modelOptions);
 

--- a/Source/Scene/ModelExperimental/ModelExperimentalNode.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalNode.js
@@ -3,7 +3,7 @@ import defaultValue from "../../Core/defaultValue.js";
 import defined from "../../Core/defined.js";
 import InstancingPipelineStage from "./InstancingPipelineStage.js";
 /**
- * An in-memory representation of a scene node as part of
+ * An in-memory representation of a node as part of
  * the {@link ModelExperimentalSceneGraph}
  *
  * @param {Object} options An object containing the following options:

--- a/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
@@ -11,6 +11,7 @@ import PickingPipelineStage from "./PickingPipelineStage.js";
  *
  * @param {Object} options An object containing the following options:
  * @param {ModelComponents.Primitive} options.primitive The primitive component.
+ * @param {Boolean} options.allowPicking Whether or not the model this primitive belongs to allows picking of primitives. See {@link ModelExperimental#allowPicking}.
  *
  * @alias ModelExperimentalPrimitive
  * @constructor
@@ -33,6 +34,15 @@ export default function ModelExperimentalPrimitive(options) {
   this.primitive = options.primitive;
 
   /**
+   * Whether or not the model this primitive belongs to allows picking of primitives. See {@link ModelExperimental#allowPicking}.
+   *
+   * @type {Boolean}
+   *
+   * @private
+   */
+  this.allowPicking = options.allowPicking;
+
+  /**
    * Pipeline stages to apply to this primitive. This
    * is an array of classes, each with a static method called
    * <code>process()</code>
@@ -52,6 +62,10 @@ function initialize(runtimePrimitive) {
   pipelineStages.push(GeometryPipelineStage);
   pipelineStages.push(MaterialPipelineStage);
   pipelineStages.push(LightingPipelineStage);
-  pipelineStages.push(PickingPipelineStage);
+
+  if (runtimePrimitive.allowPicking) {
+    pipelineStages.push(PickingPipelineStage);
+  }
+
   return;
 }

--- a/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
@@ -3,6 +3,7 @@ import defaultValue from "../../Core/defaultValue.js";
 import GeometryPipelineStage from "./GeometryPipelineStage.js";
 import LightingPipelineStage from "./LightingPipelineStage.js";
 import MaterialPipelineStage from "./MaterialPipelineStage.js";
+import PickingPipelineStage from "./PickingPipelineStage.js";
 
 /**
  * In memory representation of a single primitive, that is, a primitive
@@ -51,5 +52,6 @@ function initialize(runtimePrimitive) {
   pipelineStages.push(GeometryPipelineStage);
   pipelineStages.push(MaterialPipelineStage);
   pipelineStages.push(LightingPipelineStage);
+  pipelineStages.push(PickingPipelineStage);
   return;
 }

--- a/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
@@ -61,7 +61,7 @@ export default function ModelExperimentalSceneGraph(options) {
   this._pipelineStages = [];
 
   /**
-   * The scene nodes that make up the scene graph
+   * The runtime nodes that make up the scene graph
    *
    * @type {ModelExperimentalNode[]}
    * @readonly
@@ -169,6 +169,7 @@ function traverseSceneGraph(sceneGraph, node, modelMatrix) {
       runtimeNode.runtimePrimitives.push(
         new ModelExperimentalPrimitive({
           primitive: node.primitives[i],
+          allowPicking: sceneGraph._model.allowPicking,
         })
       );
     }

--- a/Source/Scene/ModelExperimental/NodeRenderResources.js
+++ b/Source/Scene/ModelExperimental/NodeRenderResources.js
@@ -42,7 +42,7 @@ export default function NodeRenderResources(modelRenderResources, runtimeNode) {
 
   // other properties
   /**
-   * A reference to the scene node
+   * A reference to the runtime node
    *
    * @type {ModelExperimentalNode}
    * @readonly

--- a/Source/Scene/ModelExperimental/PickingPipelineStage.js
+++ b/Source/Scene/ModelExperimental/PickingPipelineStage.js
@@ -1,0 +1,99 @@
+import Color from "../../Core/Color.js";
+import ComponentDatatype from "../../Core/ComponentDatatype.js";
+import defined from "../../Core/defined.js";
+import Buffer from "../../Renderer/Buffer.js";
+import BufferUsage from "../../Renderer/BufferUsage.js";
+import ShaderDestination from "../../Renderer/ShaderDestination.js";
+
+var PickingPipelineStage = {};
+
+PickingPipelineStage.process = function (
+  renderResources,
+  primitive,
+  frameState
+) {
+  var context = frameState.context;
+  var runtimeNode = renderResources.runtimeNode;
+  var shaderBuilder = renderResources.shaderBuilder;
+
+  shaderBuilder.addDefine("ALLOWS_PICKING");
+
+  if (defined(runtimeNode.node.instances)) {
+    processInstancedPickIds(renderResources, context);
+  } else {
+    var pickObject = {
+      model: renderResources.model,
+      node: renderResources.runtimeNode,
+      primitive: renderResources.runtimePrimitive,
+    };
+
+    var pickId = context.createPickId(pickObject);
+    shaderBuilder.addUniform(
+      "vec4",
+      "czm_pickColor",
+      ShaderDestination.FRAGMENT
+    );
+
+    var uniformMap = renderResources.uniformMap;
+    uniformMap.czm_pickColor = function () {
+      return pickId.color;
+    };
+
+    renderResources.pickId = "czm_pickColor";
+  }
+};
+
+function processInstancedPickIds(renderResources, context) {
+  var instanceCount = renderResources.instanceCount;
+  var pickIds = new Array(instanceCount);
+  var pickIdsTypedArray = new Uint8Array(instanceCount * 4);
+
+  for (var i = 0; i < instanceCount; i++) {
+    var pickObject = {
+      model: renderResources.model,
+      node: renderResources.runtimeNode,
+      primitive: renderResources.runtimePrimitive,
+      instance: {
+        id: i,
+      },
+    };
+
+    var pickId = context.createPickId(pickObject);
+    var pickColor = pickId.color;
+
+    pickIds[i] = pickId;
+
+    pickIdsTypedArray[i * 4 + 0] = Color.floatToByte(pickColor.red);
+    pickIdsTypedArray[i * 4 + 1] = Color.floatToByte(pickColor.green);
+    pickIdsTypedArray[i * 4 + 2] = Color.floatToByte(pickColor.blue);
+    pickIdsTypedArray[i * 4 + 3] = Color.floatToByte(pickColor.alpha);
+  }
+
+  var pickIdsBuffer = Buffer.createVertexBuffer({
+    context: context,
+    typedArray: pickIdsTypedArray,
+    usage: BufferUsage.STATIC_DRAW,
+  });
+  pickIdsBuffer.vertexArrayDestroyable = false;
+  renderResources.model._resources.push(pickIdsBuffer);
+
+  var pickIdsVertexAttribute = {
+    index: renderResources.attributeIndex++,
+    vertexBuffer: pickIdsBuffer,
+    componentsPerAttribute: 4,
+    componentDatatype: ComponentDatatype.UNSIGNED_BYTE,
+    normalize: true,
+    offsetInBytes: 0,
+    strideInBytes: 0,
+    instanceDivisor: 1,
+  };
+
+  renderResources.attributes.push(pickIdsVertexAttribute);
+
+  var shaderBuilder = renderResources.shaderBuilder;
+  shaderBuilder.addAttribute("vec4", "a_pickColor");
+  shaderBuilder.addVarying("vec4", "v_pickColor");
+  renderResources.pickId = "v_pickColor";
+}
+
+export default PickingPipelineStage;

--- a/Source/Scene/ModelExperimental/PickingPipelineStage.js
+++ b/Source/Scene/ModelExperimental/PickingPipelineStage.js
@@ -5,8 +5,26 @@ import Buffer from "../../Renderer/Buffer.js";
 import BufferUsage from "../../Renderer/BufferUsage.js";
 import ShaderDestination from "../../Renderer/ShaderDestination.js";
 
+/**
+ * The picking pipeline stage is responsible for handling picking of primitives.
+ *
+ * @namespace PickingPipelineStage
+ * @private
+ */
 var PickingPipelineStage = {};
 
+/**
+ * Process a primitive. This modifies the following parts of the render resources:
+ * <ul>
+ *  <li>adds attribute and varying declaration for the pick color vertex attribute in the vertex shader for instanced meshes</li>
+ *  <li>adds declaration for the pick color uniform for non-instanced meshes</li>
+ *  <li>adds defines in the shader for when picking is enabled</li>
+ *  <li>creates the pick ID objects in the context</li>
+ * </ul>
+ * @param {PrimitiveRenderResources} renderResources The render resources for this primitive.
+ * @param {ModelComponents.Primitive} node The primitive.
+ * @param {FrameState} frameState The frame state.
+ */
 PickingPipelineStage.process = function (
   renderResources,
   primitive,
@@ -19,8 +37,10 @@ PickingPipelineStage.process = function (
   shaderBuilder.addDefine("ALLOWS_PICKING");
 
   if (defined(runtimeNode.node.instances)) {
+    // For instanced meshes, a pick color vertex attribute is used.
     processInstancedPickIds(renderResources, context);
   } else {
+    // For non-instanced meshes, a pick color uniform is used.
     var pickObject = {
       model: renderResources.model,
       node: renderResources.runtimeNode,

--- a/Source/Scene/ModelExperimental/PrimitiveRenderResources.js
+++ b/Source/Scene/ModelExperimental/PrimitiveRenderResources.js
@@ -94,6 +94,16 @@ export default function PrimitiveRenderResources(
   this.instanceCount = nodeRenderResources.instanceCount;
 
   /**
+   * A reference to the runtime node
+   *
+   * @type {ModelExperimentalPrimitive}
+   * @readonly
+   *
+   * @private
+   */
+  this.runtimePrimitive = runtimePrimitive;
+
+  /**
    * The primitive associated with the render resources.
    *
    * @type {ModelComponents.Primitive}
@@ -176,6 +186,16 @@ export default function PrimitiveRenderResources(
    * @private
    */
   this.pass = this.model.opaquePass;
+
+  /**
+   * The shader variable to use for picking.
+   *
+   * @type {String}
+   * @readonly
+   *
+   * @private
+   */
+  this.pickId = undefined;
 
   /**
    * An object storing options for creating a {@link RenderState}.

--- a/Source/Scene/ModelExperimental/PrimitiveRenderResources.js
+++ b/Source/Scene/ModelExperimental/PrimitiveRenderResources.js
@@ -33,7 +33,7 @@ export default function PrimitiveRenderResources(
    */
   this.model = nodeRenderResources.model;
   /**
-   * A reference to the scene node. Inherited from the node render resources.
+   * A reference to the runtime node. Inherited from the node render resources.
    *
    * @type {ModelExperimentalNode}
    * @readonly

--- a/Source/Scene/ModelExperimental/buildDrawCommand.js
+++ b/Source/Scene/ModelExperimental/buildDrawCommand.js
@@ -50,7 +50,7 @@ export default function buildDrawCommand(primitiveRenderResources, frameState) {
     cull: model.cull,
     pass: primitiveRenderResources.pass,
     count: primitiveRenderResources.count,
-    pickId: undefined,
+    pickId: primitiveRenderResources.pickId,
     instanceCount: primitiveRenderResources.instanceCount,
     primitiveType: primitiveRenderResources.primitiveType,
     debugShowBoundingVolume: model.debugShowBoundingVolume,

--- a/Source/Shaders/ModelExperimental/ModelExperimentalVS.glsl
+++ b/Source/Shaders/ModelExperimental/ModelExperimentalVS.glsl
@@ -8,6 +8,9 @@ void main()
 
     #ifdef HAS_INSTANCING
     position = instancingStage(position);
+        #ifdef ALLOWS_PICKING
+        v_pickColor = a_pickColor;
+        #endif
     #endif
 
     gl_Position = czm_modelViewProjection * vec4(position, 1.0);

--- a/Specs/Scene/ModelExperimental/ModelExperimentalPrimitiveSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalPrimitiveSpec.js
@@ -2,6 +2,7 @@ import {
   GeometryPipelineStage,
   LightingPipelineStage,
   MaterialPipelineStage,
+  PickingPipelineStage,
   ModelExperimentalPrimitive,
 } from "../../../Source/Cesium.js";
 
@@ -19,9 +20,11 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
   it("constructs", function () {
     var primitive = new ModelExperimentalPrimitive({
       primitive: mockPrimitive,
+      allowPicking: true,
     });
 
     expect(primitive.primitive).toBe(mockPrimitive);
+    expect(primitive.allowPicking).toBe(true);
   });
 
   it("configures the pipeline stages", function () {
@@ -33,6 +36,18 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       GeometryPipelineStage,
       MaterialPipelineStage,
       LightingPipelineStage,
+    ]);
+
+    primitive = new ModelExperimentalPrimitive({
+      primitive: mockPrimitive,
+      allowPicking: true,
+    });
+
+    expect(primitive.pipelineStages).toEqual([
+      GeometryPipelineStage,
+      MaterialPipelineStage,
+      LightingPipelineStage,
+      PickingPipelineStage,
     ]);
   });
 });

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSceneGraphSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSceneGraphSpec.js
@@ -29,7 +29,7 @@ describe(
       ResourceCache.clearForSpecs();
     });
 
-    it("creates scene nodes and scene primitives from a model", function () {
+    it("creates runtime nodes and runtime primitives from a model", function () {
       return loadAndZoomToModelExperimental(
         { gltf: vertexColorGltfUrl },
         scene

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -124,6 +124,26 @@ describe(
       });
     });
 
+    it("doesn't pick when allowPicking is false", function () {
+      if (FeatureDetection.isInternetExplorer()) {
+        // Workaround IE 11.0.9.  This test fails when all tests are ran without a breakpoint here.
+        return;
+      }
+
+      return loadAndZoomToModelExperimental(
+        {
+          gltf: boxTexturedGlbUrl,
+          modelMatrix: Matrix4.fromTranslation(new Cartesian3(6378237, 0, 0)),
+          allowPicking: false,
+        },
+        scene
+      ).then(function (model) {
+        expect(scene).toPickAndCall(function (result) {
+          expect(result).toBeUndefined();
+        });
+      });
+    });
+
     it("destroy works", function () {
       spyOn(ShaderProgram.prototype, "destroy").and.callThrough();
       return loadAndZoomToModelExperimental(

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -1,8 +1,10 @@
 import {
+  FeatureDetection,
   Math as CesiumMath,
   ResourceCache,
   Resource,
   ModelExperimental,
+  Matrix4,
   Cartesian3,
   when,
 } from "../../../Source/Cesium.js";
@@ -101,6 +103,25 @@ describe(
       expect(function () {
         ModelExperimental.fromGltf({});
       }).toThrowDeveloperError();
+    });
+
+    it("picks box textured", function () {
+      if (FeatureDetection.isInternetExplorer()) {
+        // Workaround IE 11.0.9.  This test fails when all tests are ran without a breakpoint here.
+        return;
+      }
+
+      return loadAndZoomToModelExperimental(
+        {
+          gltf: boxTexturedGlbUrl,
+          modelMatrix: Matrix4.fromTranslation(new Cartesian3(6378237, 0, 0)),
+        },
+        scene
+      ).then(function (model) {
+        expect(scene).toPickAndCall(function (result) {
+          expect(result.model).toEqual(model);
+        });
+      });
     });
 
     it("destroy works", function () {

--- a/Specs/Scene/ModelExperimental/PickingPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/PickingPipelineStageSpec.js
@@ -1,0 +1,183 @@
+import {
+  combine,
+  GltfLoader,
+  PickingPipelineStage,
+  ShaderBuilder,
+  Resource,
+  ResourceCache,
+} from "../../../Source/Cesium.js";
+import createScene from "../../createScene.js";
+import waitForLoaderProcess from "../../waitForLoaderProcess.js";
+
+describe("Scene/ModelExperimental/PickingPipelineStage", function () {
+  var boxVertexColors =
+    "./Data/Models/GltfLoader/BoxVertexColors/glTF/BoxVertexColors.gltf";
+  var boxInstanced =
+    "./Data/Models/GltfLoader/BoxInstanced/glTF/box-instanced.gltf";
+
+  var scene;
+  var gltfLoaders = [];
+
+  beforeAll(function () {
+    scene = createScene();
+  });
+
+  afterAll(function () {
+    scene.destroyForSpecs();
+  });
+
+  afterEach(function () {
+    var gltfLoadersLength = gltfLoaders.length;
+    for (var i = 0; i < gltfLoadersLength; ++i) {
+      var gltfLoader = gltfLoaders[i];
+      if (!gltfLoader.isDestroyed()) {
+        gltfLoader.destroy();
+      }
+    }
+    gltfLoaders.length = 0;
+    ResourceCache.clearForSpecs();
+  });
+
+  function getOptions(gltfPath, options) {
+    var resource = new Resource({
+      url: gltfPath,
+    });
+
+    return combine(options, {
+      gltfResource: resource,
+      incrementallyLoadTexture: false,
+    });
+  }
+
+  function loadGltf(gltfPath, options) {
+    var gltfLoader = new GltfLoader(getOptions(gltfPath, options));
+    gltfLoaders.push(gltfLoader);
+    gltfLoader.load();
+
+    return waitForLoaderProcess(gltfLoader, scene);
+  }
+
+  it("sets the picking variables in render resources", function () {
+    var renderResources = {
+      attributeIndex: 1,
+      pickId: undefined,
+      shaderBuilder: new ShaderBuilder(),
+      model: {},
+      runtimePrimitive: {
+        primitive: {},
+      },
+      runtimeNode: {
+        node: {},
+      },
+      uniformMap: {},
+    };
+
+    return loadGltf(boxVertexColors).then(function (gltfLoader) {
+      var components = gltfLoader.components;
+      var primitive = components.nodes[0].primitives[0];
+
+      var frameState = scene.frameState;
+      var context = frameState.context;
+      context._pickObjects = [];
+
+      PickingPipelineStage.process(renderResources, primitive, frameState);
+
+      var vertexDefineLines =
+        renderResources.shaderBuilder._vertexShaderParts.defineLines;
+      var fragmentDefineLines =
+        renderResources.shaderBuilder._fragmentShaderParts.defineLines;
+      var fragmentUniformLines =
+        renderResources.shaderBuilder._fragmentShaderParts.uniformLines;
+
+      expect(vertexDefineLines[0]).toEqual("ALLOWS_PICKING");
+      expect(fragmentDefineLines[0]).toEqual("ALLOWS_PICKING");
+      expect(fragmentUniformLines[0]).toEqual("uniform vec4 czm_pickColor;");
+
+      var pickObject = context._pickObjects["1"];
+      expect(pickObject).toBeDefined();
+      expect(pickObject.model).toBeDefined();
+      expect(pickObject.node).toBeDefined();
+      expect(pickObject.primitive).toBeDefined();
+
+      var uniformMap = renderResources.uniformMap;
+      expect(uniformMap.czm_pickColor).toBeDefined();
+      expect(uniformMap.czm_pickColor()).toBeDefined();
+
+      expect(renderResources.pickId).toEqual("czm_pickColor");
+    });
+  });
+
+  it("sets the picking variables in render resources with instancing", function () {
+    var renderResources = {
+      attributeIndex: 1,
+      instanceCount: 4,
+      pickId: undefined,
+      shaderBuilder: new ShaderBuilder(),
+      model: {
+        _resources: [],
+      },
+      runtimePrimitive: {
+        primitive: {},
+      },
+      runtimeNode: {
+        node: {
+          instances: {},
+        },
+      },
+      attributes: [],
+    };
+
+    return loadGltf(boxInstanced).then(function (gltfLoader) {
+      var components = gltfLoader.components;
+      var primitive = components.nodes[0].primitives[0];
+
+      var frameState = scene.frameState;
+      var context = frameState.context;
+      context._pickObjects = [];
+
+      PickingPipelineStage.process(renderResources, primitive, frameState);
+
+      var attributeLines = renderResources.shaderBuilder._attributeLines;
+      var vertexDefineLines =
+        renderResources.shaderBuilder._vertexShaderParts.defineLines;
+      var vertexVaryingLines =
+        renderResources.shaderBuilder._vertexShaderParts.varyingLines;
+      var fragmentDefineLines =
+        renderResources.shaderBuilder._fragmentShaderParts.defineLines;
+      var fragmentVaryingLines =
+        renderResources.shaderBuilder._fragmentShaderParts.varyingLines;
+
+      expect(attributeLines[0]).toEqual("attribute vec4 a_pickColor;");
+      expect(vertexDefineLines[0]).toEqual("ALLOWS_PICKING");
+      expect(fragmentDefineLines[0]).toEqual("ALLOWS_PICKING");
+      expect(vertexVaryingLines[0]).toEqual("varying vec4 v_pickColor;");
+      expect(fragmentVaryingLines[0]).toEqual("varying vec4 v_pickColor;");
+
+      var i = 0;
+      for (var key in context._pickObjects) {
+        if (context._pickObjects.hasOwnProperty(key)) {
+          var pickObject = context._pickObjects[key];
+          expect(pickObject).toBeDefined();
+          expect(pickObject.model).toBeDefined();
+          expect(pickObject.node).toBeDefined();
+          expect(pickObject.primitive).toBeDefined();
+          expect(pickObject.instance).toBeDefined();
+          expect(pickObject.instance.id).toEqual(i++);
+        }
+      }
+
+      var pickIdAttribute = renderResources.attributes[0];
+      expect(pickIdAttribute).toBeDefined();
+      expect(pickIdAttribute.index).toEqual(1);
+      // Each time an attribute is added, the attribute index should be incremented.
+      expect(renderResources.attributeIndex).toEqual(2);
+      expect(pickIdAttribute.vertexBuffer).toBeDefined();
+      expect(pickIdAttribute.vertexBuffer._sizeInBytes).toEqual(
+        renderResources.instanceCount * 4
+      );
+      expect(pickIdAttribute.instanceDivisor).toEqual(1);
+
+      expect(renderResources.pickId).toEqual("v_pickColor");
+    });
+  });
+});

--- a/Specs/Scene/ModelExperimental/PrimitiveRenderResourcesSpec.js
+++ b/Specs/Scene/ModelExperimental/PrimitiveRenderResourcesSpec.js
@@ -61,11 +61,11 @@ describe("Scene/ModelExperimental/PrimitiveRenderResources", function () {
     ],
   };
 
-  var scenePrimitive = new ModelExperimentalPrimitive({
+  var runtimePrimitive = new ModelExperimentalPrimitive({
     primitive: primitive,
   });
 
-  var scenePrimitiveWithoutIndices = new ModelExperimentalPrimitive({
+  var runtimePrimitiveWithoutIndices = new ModelExperimentalPrimitive({
     primitive: primitiveWithoutIndices,
   });
 
@@ -78,7 +78,7 @@ describe("Scene/ModelExperimental/PrimitiveRenderResources", function () {
 
   it("throws for undefined nodeRenderResources", function () {
     expect(function () {
-      return new PrimitiveRenderResources(undefined, scenePrimitive);
+      return new PrimitiveRenderResources(undefined, runtimePrimitive);
     }).toThrowDeveloperError();
   });
 
@@ -95,9 +95,11 @@ describe("Scene/ModelExperimental/PrimitiveRenderResources", function () {
     var nodeResources = new NodeRenderResources(modelResources, runtimeNode);
     var primitiveResources = new PrimitiveRenderResources(
       nodeResources,
-      scenePrimitive
+      runtimePrimitive
     );
 
+    expect(primitiveResources.runtimePrimitive).toBe(runtimePrimitive);
+    expect(primitiveResources.pickId).toBeUndefined();
     expect(primitiveResources.count).toBe(6);
     expect(primitiveResources.indices).toBe(primitive.indices);
     expect(primitiveResources.primitiveType).toBe(PrimitiveType.TRIANGLES);
@@ -123,7 +125,7 @@ describe("Scene/ModelExperimental/PrimitiveRenderResources", function () {
     var nodeResources = new NodeRenderResources(modelResources, runtimeNode);
     var primitiveResources = new PrimitiveRenderResources(
       nodeResources,
-      scenePrimitiveWithoutIndices
+      runtimePrimitiveWithoutIndices
     );
 
     expect(primitiveResources.count).toBe(8);
@@ -154,7 +156,7 @@ describe("Scene/ModelExperimental/PrimitiveRenderResources", function () {
     nodeResources.shaderBuilder.addDefine("NODE");
     var primitiveResources = new PrimitiveRenderResources(
       nodeResources,
-      scenePrimitive
+      runtimePrimitive
     );
     primitiveResources.shaderBuilder.addDefine("PRIMITIVE");
 
@@ -185,7 +187,7 @@ describe("Scene/ModelExperimental/PrimitiveRenderResources", function () {
     nodeResources.shaderBuilder.addDefine("NODE");
     var primitiveResources = new PrimitiveRenderResources(
       nodeResources,
-      scenePrimitive
+      runtimePrimitive
     );
     expect(primitiveResources.runtimeNode).toBe(runtimeNode);
     expect(primitiveResources.modelMatrix).toEqual(runtimeNode.modelMatrix);

--- a/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
+++ b/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
@@ -5,6 +5,7 @@ function loadAndZoomToModelExperimental(options, scene) {
   var model = ModelExperimental.fromGltf({
     gltf: options.gltf,
     modelMatrix: options.modelMatrix,
+    allowPicking: options.allowPicking,
     upAxis: options.upAxis,
     forwardAxis: options.forwardAxis,
     debugShowBoundingVolume: options.debugShowBoundingVolume,

--- a/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
+++ b/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
@@ -1,23 +1,16 @@
-import {
-  Cartesian3,
-  defaultValue,
-  HeadingPitchRange,
-  Matrix4,
-  ModelExperimental,
-  when,
-} from "../../../Source/Cesium.js";
+import { ModelExperimental, when } from "../../../Source/Cesium.js";
 import pollToPromise from "../../pollToPromise.js";
 
 function loadAndZoomToModelExperimental(options, scene) {
   var model = ModelExperimental.fromGltf({
     gltf: options.gltf,
+    modelMatrix: options.modelMatrix,
     upAxis: options.upAxis,
     forwardAxis: options.forwardAxis,
     debugShowBoundingVolume: options.debugShowBoundingVolume,
   });
 
   scene.primitives.add(model);
-  zoomTo(model, scene);
 
   return pollToPromise(
     function () {
@@ -27,26 +20,14 @@ function loadAndZoomToModelExperimental(options, scene) {
     { timeout: 10000 }
   )
     .then(function () {
+      scene.camera.flyToBoundingSphere(model.boundingSphere, {
+        duration: 0,
+      });
       return model;
     })
     .otherwise(function () {
       return when.reject(model);
     });
-}
-
-function zoomTo(model, scene) {
-  model.zoomTo = function (zoom) {
-    zoom = defaultValue(zoom, 4.0);
-
-    var camera = scene.camera;
-    var center = Matrix4.multiplyByPoint(
-      model.modelMatrix,
-      model.boundingSphere.center,
-      new Cartesian3()
-    );
-    var r = zoom * Math.max(model.boundingSphere.radius, camera.frustum.near);
-    camera.lookAt(center, new HeadingPitchRange(0.0, 0.0, r));
-  };
 }
 
 export default loadAndZoomToModelExperimental;


### PR DESCRIPTION
This PR adds support for picking primitives within a model. For non-instanced meshes, the `czm_pickColor` uniform is used to assign a pick ID to each primitive. For instanced meshes, a `a_pickColor` vertex attribute is created and added. This feature is enabled (by default) or disabled through the `allowPicking` parameter in `ModelExperimental.fromGltf`.

When a primitive is picked, the following object is returned:

```javascript
{
  model: ModelExperimental,
  node: ModelExperimentalNode,
  primitive: ModelExperimentalPrimitive,
  
  // This is only added for instanced meshes
  instance: {
    id: Number
  }
}
```

Here is a [local Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=xVdtb9s2EP4rmj8pgEM5S9puiRuscZM0mI0Ftdd8mIaBlk42MYoUSEqxN+S/70hKsux6G4zOHWBH4svdPc/dMXxcURVUDJ5BBW8DAc/BCDQrc/LJzYVxL3HjkRSGMgEq7p1cxSIWURRMZAo8eJTaMCmYWMSiQmeF1MxOoLva1Ygqg29UnJNMyfw9LBSADmMRBKdn356TwZuLi9dn3/ftxMUFGbwanL8ZvHbDQSxsOOt3Wewg/AA0xaiPzCTLj5LzcNAP7KcxyNgK0jtFc5gpKnQmVb7B1E5pwmVCud8n71qbe0Cy1EjlcMY9IZVZxr2+Hz2DNnHPg+tmQ/vQuXvHaL/Y7X/aP0FgYGUu0fZGrn4WnJnaWRBIoYFDgotZKRKXu/CksQoCv+jch82cxRBNC0h09J4aGvng0ePNx6hx376QBTeZBesNLWT7fLGPl/4egPdKliL9BEuWcPgylOiNkAg/U5oXHBxWn5xoK8r2CBHPDwHsa3pDOZdSHA3wVpTt0aGAsTQPQhsqEkiP0Ab3WPCxpCmoqBspWvDZXTSXq1PWTB3cG11/7gxxapF+PRKdoHv4nJrN8n/F7YmZ5YSJCV39Lyw34f+F72nO8EtXX8T7QRhQHGj1NRuzE3QfR7ZZPpjbhCVKJlLnx2XThvH482Z4MN6ZwntywcFWXZbmQaQML+Djgt8f0zPZv3YwrSegZmnFwzF51EE88Gc/+EeksfjV3d8thm7cUvEakZdHRCcoCUihWI76psIkKMhlBe9QeXi37c2PF//f2dA0rRnVQsQFu10VgHsANRZ3GsmyCtt0WA6XAQLqNzMuzIQaxVaXeyTNckcadYVNJ6GNVOtvplBldUa151vOWaElS8nT/fS7i86GPRqrTXWdaff0CbJfhxxTR9P1IxJlGgjWSYSbPnA72maoE5lgCEVJxtczeWOlAtKbFlhg8PvJfGuyv+mltFTu3+NlMCCvGkwOjnu8eAE3pSJNqDYoPrBEMyn5nKoJiNK7117o2Qr7HkHW2GClAj/fVBuFrZgWNIHbCov5AZ1yOw94cIrSvHMMN1SlGENmRpwlv4c+NxXYJkBdWXee1dO42kb7rLOsaWNGmnp6eiwLwm/qCqaQoXhPwy1nJ22SFeBYXNWHwhdqhydG3jJuC5rgWZaYNi4X4Y6Ny2+/6aLpTnZm6wLI+PZu9tto/DD68eSq1+8NtVlzuG5q9wPLC9TdtvVD1GQGUJNR/C0RzUuEYkiidXOih1HXdJiyKmDp2z0/X4KEU61xJSs5n7I/UOFeDyPc/5kpl+4U/VTh7UPXdtvy7HrsJwkhwwiH+y2N758dz38B) for testing.
