### PR TITLE
Fix broken 3D Tiles Next links

### DIFF
--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -283,7 +283,7 @@ function Cesium3DTile(tileset, baseResource, header, parent) {
    * When <code>true</code>, the tile has multiple contents via the
    * <code>3DTILES_multiple_contents</code> extension.
    *
-   * @see {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_multiple_contents/0.0.0|3DTILES_multiple_contents extension}
+   * @see {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_multiple_contents|3DTILES_multiple_contents extension}
    *
    * @type {Boolean}
    * @readonly

--- a/Source/Scene/Cesium3DTilesetMetadata.js
+++ b/Source/Scene/Cesium3DTilesetMetadata.js
@@ -7,7 +7,7 @@ import TilesetMetadata from "./TilesetMetadata.js";
 /**
  * An object containing metadata about a 3D Tileset.
  * <p>
- * See the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata/1.0.0|3DTILES_metadata Extension} for 3D Tiles.
+ * See the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata|3DTILES_metadata Extension} for 3D Tiles.
  * </p>
  * <p>
  * This object represents the <code>3DTILES_metadata</code> object which
@@ -112,7 +112,7 @@ Object.defineProperties(Cesium3DTilesetMetadata.prototype, {
   /**
    * Statistics about the metadata.
    * <p>
-   * See the {@link https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_metadata/1.0.0/schema/statistics.schema.json|statistics schema reference}
+   * See the {@link https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_metadata/schema/statistics.schema.json|statistics schema reference}
    * in the 3D Tiles spec for the full set of properties.
    * </p>
    *

--- a/Source/Scene/FeatureMetadata.js
+++ b/Source/Scene/FeatureMetadata.js
@@ -4,7 +4,7 @@ import defaultValue from "../Core/defaultValue.js";
 /**
  * An object containing feature metadata.
  * <p>
- * See the {@link https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata/1.0.0|EXT_feature_metadata Extension} for glTF.
+ * See the {@link https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata|EXT_feature_metadata Extension} for glTF.
  * </p>
  *
  * @param {Object} options Object with the following properties:
@@ -54,7 +54,7 @@ Object.defineProperties(FeatureMetadata.prototype, {
   /**
    * Statistics about the metadata.
    * <p>
-   * See the {@link https://github.com/CesiumGS/glTF/blob/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata/1.0.0/schema/statistics.schema.json|statistics schema reference} for the full set of properties.
+   * See the {@link https://github.com/CesiumGS/glTF/blob/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata/schema/statistics.schema.json|statistics schema reference} for the full set of properties.
    * </p>
    *
    * @memberof FeatureMetadata.prototype

--- a/Source/Scene/FeatureTable.js
+++ b/Source/Scene/FeatureTable.js
@@ -15,7 +15,7 @@ import defined from "../Core/defined.js";
  *   <li>batch table hierarchy properties from options.batchTableHierarchy</li>
  * </ol>
  * <p>
- * See the {@link https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata/1.0.0|EXT_feature_metadata Extension} for glTF.
+ * See the {@link https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata|EXT_feature_metadata Extension} for glTF.
  * </p>
  *
  * @param {Object} options Object with the following properties:

--- a/Source/Scene/FeatureTexture.js
+++ b/Source/Scene/FeatureTexture.js
@@ -6,7 +6,7 @@ import FeatureTextureProperty from "./FeatureTextureProperty.js";
 /**
  * A feature texture.
  * <p>
- * See the {@link https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata/1.0.0|EXT_feature_metadata Extension} for glTF.
+ * See the {@link https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata|EXT_feature_metadata Extension} for glTF.
  * </p>
  *
  * @param {Object} options Object with the following properties:

--- a/Source/Scene/FeatureTextureProperty.js
+++ b/Source/Scene/FeatureTextureProperty.js
@@ -5,7 +5,7 @@ import GltfLoaderUtil from "./GltfLoaderUtil.js";
 /**
  * A property in a feature texture.
  * <p>
- * See the {@link https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata/1.0.0|EXT_feature_metadata Extension} for glTF.
+ * See the {@link https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata|EXT_feature_metadata Extension} for glTF.
  * </p>
  *
  * @param {Object} options Object with the following properties:

--- a/Source/Scene/Gltf3DTileContent.js
+++ b/Source/Scene/Gltf3DTileContent.js
@@ -11,9 +11,9 @@ import ModelExperimental from "./ModelExperimental/ModelExperimental.js";
 import combine from "../Core/combine.js";
 
 /**
- * Represents the contents of a glTF or glb tile in a {@link https://github.com/CesiumGS/3d-tiles/tree/main/specification|3D Tiles} tileset using the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_content_gltf/0.0.0|3DTILES_content_gltf} extension.
+ * Represents the contents of a glTF or glb tile in a {@link https://github.com/CesiumGS/3d-tiles/tree/main/specification|3D Tiles} tileset using the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_content_gltf|3DTILES_content_gltf} extension.
  * <p>
- * This class does not yet support the {@link https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata/1.0.0|EXT_feature_metadata Extension}.
+ * This class does not yet support the {@link https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata|EXT_feature_metadata Extension}.
  * </p>
  * <p>
  * Implements the {@link Cesium3DTileContent} interface.

--- a/Source/Scene/GroupMetadata.js
+++ b/Source/Scene/GroupMetadata.js
@@ -6,7 +6,7 @@ import MetadataEntity from "./MetadataEntity.js";
 /**
  * Metadata about a group of {@link Cesium3DTileContent}
  * <p>
- * See the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata/1.0.0|3DTILES_metadata Extension} for 3D Tiles
+ * See the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata|3DTILES_metadata Extension} for 3D Tiles
  * </p>
  *
  * @param {Object} options Object with the following properties:

--- a/Source/Scene/ImplicitSubtree.js
+++ b/Source/Scene/ImplicitSubtree.js
@@ -19,7 +19,7 @@ import when from "../ThirdParty/when.js";
  * Subtrees handle tile metadata from the <code>3DTILES_metadata</code> extension
  * </p>
  *
- * @see {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata/1.0.0#implicit-tile-metadata|Implicit Tile Metadata in the 3DTILES_metadata specification}
+ * @see {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata#implicit-tile-metadata|Implicit Tile Metadata in the 3DTILES_metadata specification}
  *
  * @alias ImplicitSubtree
  * @constructor

--- a/Source/Scene/ImplicitTileMetadata.js
+++ b/Source/Scene/ImplicitTileMetadata.js
@@ -9,7 +9,7 @@ import defaultValue from "../Core/defaultValue.js";
  * tile metadata is stored in a {@link MetadataTable} rather than a JSON object.
  * </p>
  * <p>
- * See the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata/1.0.0|3DTILES_metadata Extension} for 3D Tiles
+ * See the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata|3DTILES_metadata Extension} for 3D Tiles
  * </p>
  *
  * @param {ImplicitSubtree} options.implicitSubtree The implicit subtree the tile belongs to. It is assumed that the subtree's readyPromise has already resolved.

--- a/Source/Scene/MetadataClass.js
+++ b/Source/Scene/MetadataClass.js
@@ -7,7 +7,7 @@ import MetadataClassProperty from "./MetadataClassProperty.js";
  * A metadata class.
  *
  * <p>
- * See the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata/1.0.0|3DTILES_metadata Extension} for 3D Tiles
+ * See the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata|3DTILES_metadata Extension} for 3D Tiles
  * </p>
  *
  * @param {Object} options Object with the following properties:

--- a/Source/Scene/MetadataEntity.js
+++ b/Source/Scene/MetadataEntity.js
@@ -8,7 +8,7 @@ import DeveloperError from "../Core/DeveloperError.js";
  * This type describes an interface and is not intended to be instantiated directly.
  * </p>
  * <p>
- * See the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata/1.0.0|3DTILES_metadata Extension} for 3D Tiles
+ * See the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata|3DTILES_metadata Extension} for 3D Tiles
  * </p>
  *
  * @alias MetadataEntity

--- a/Source/Scene/MetadataEnum.js
+++ b/Source/Scene/MetadataEnum.js
@@ -6,7 +6,7 @@ import MetadataType from "./MetadataType.js";
 /**
  * A metadata enum.
  * <p>
- * See the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata/1.0.0|3DTILES_metadata Extension} for 3D Tiles
+ * See the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata|3DTILES_metadata Extension} for 3D Tiles
  * </p>
  *
  * @param {Object} options Object with the following properties:

--- a/Source/Scene/MetadataSchema.js
+++ b/Source/Scene/MetadataSchema.js
@@ -6,7 +6,7 @@ import MetadataEnum from "./MetadataEnum.js";
 /**
  * A schema containing classes and enums.
  * <p>
- * See the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata/1.0.0|3DTILES_metadata Extension} for 3D Tiles
+ * See the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata|3DTILES_metadata Extension} for 3D Tiles
  * </p>
  *
  * @param {Object} schema The schema JSON object.

--- a/Source/Scene/MetadataTable.js
+++ b/Source/Scene/MetadataTable.js
@@ -10,7 +10,7 @@ import MetadataType from "./MetadataType.js";
  * used for representing binary properties of a batch table, as well as binary
  * metadata in 3D Tiles next extensions.
  * <p>
- * For 3D Tiles Next details, see the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata/1.0.0|3DTILES_metadata Extension} for 3D Tiles, as well as the {@link https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata/1.0.0|EXT_feature_metadata Extension} for glTF.
+ * For 3D Tiles Next details, see the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata|3DTILES_metadata Extension} for 3D Tiles, as well as the {@link https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata|EXT_feature_metadata Extension} for glTF.
  * </p>
  *
  * @param {Object} options Object with the following properties:

--- a/Source/Scene/MetadataTableProperty.js
+++ b/Source/Scene/MetadataTableProperty.js
@@ -11,7 +11,7 @@ import MetadataType from "./MetadataType.js";
 /**
  * A binary property in a {@MetadataTable}
  * <p>
- * For 3D Tiles Next details, see the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata/1.0.0|3DTILES_metadata Extension} for 3D Tiles, as well as the {@link https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata/1.0.0|EXT_feature_metadata Extension} for glTF.
+ * For 3D Tiles Next details, see the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata|3DTILES_metadata Extension} for 3D Tiles, as well as the {@link https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata|EXT_feature_metadata Extension} for glTF.
  * </p>
  *
  * @param {Object} options Object with the following properties:

--- a/Source/Scene/Multiple3DTileContent.js
+++ b/Source/Scene/Multiple3DTileContent.js
@@ -18,7 +18,7 @@ import preprocess3DTileContent from "./preprocess3DTileContent.js";
  * Implements the {@link Cesium3DTileContent} interface.
  * </p>
  *
- * @see {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_multiple_contents/0.0.0|3DTILES_multiple_contents extension}
+ * @see {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_multiple_contents|3DTILES_multiple_contents extension}
  *
  * @alias Multiple3DTileContent
  * @constructor

--- a/Source/Scene/TileMetadata.js
+++ b/Source/Scene/TileMetadata.js
@@ -6,7 +6,7 @@ import MetadataEntity from "./MetadataEntity.js";
  * Metadata about a 3D Tile. This represents the <code>3DTILES_metadata</code>
  * extension on a single {@link Cesium3DTile}
  * <p>
- * See the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata/1.0.0|3DTILES_metadata Extension} for 3D Tiles
+ * See the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata|3DTILES_metadata Extension} for 3D Tiles
  * </p>
  *
  * @param {Object} options Object with the following properties:

--- a/Source/Scene/TilesetMetadata.js
+++ b/Source/Scene/TilesetMetadata.js
@@ -6,7 +6,7 @@ import MetadataEntity from "./MetadataEntity.js";
 /**
  * Metadata about the tileset.
  * <p>
- * See the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata/1.0.0|3DTILES_metadata Extension} for 3D Tiles
+ * See the {@link https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_metadata|3DTILES_metadata Extension} for 3D Tiles
  * </p>
  *
  * @param {Object} options Object with the following properties:

--- a/Source/Scene/parseBatchTable.js
+++ b/Source/Scene/parseBatchTable.js
@@ -14,7 +14,7 @@ import MetadataTable from "./MetadataTable.js";
  * An object that parses the the 3D Tiles 1.0 batch table and transcodes it to
  * be compatible with feature metadata from the `EXT_feature_metadata` glTF extension
  * <p>
- * See the {@link https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata/1.0.0|EXT_feature_metadata Extension} for glTF.
+ * See the {@link https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata|EXT_feature_metadata Extension} for glTF.
  * </p>
  *
  * @param {Object} options Object with the following properties:


### PR DESCRIPTION
The 3D Tiles Next specs were restructured a bit and this PR fixes the broken links in documentation.

See https://github.com/CesiumGS/3d-tiles/pull/478.