### PR TITLE
Zoom out the camera to fix a log depth bug in ModelExperimental tests

### DIFF
--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -6,6 +6,7 @@ import {
   ModelExperimental,
   Cartesian3,
   defined,
+  HeadingPitchRange,
   when,
   ShaderProgram,
 } from "../../../Source/Cesium.js";
@@ -111,9 +112,14 @@ describe(
         return;
       }
 
+      // This model gets clipped in cesium-analytics due to disabled
+      // log depth, so zoom out just a little bit
+      var offset = new HeadingPitchRange(0, -CesiumMath.PI_OVER_FOUR, 2);
+
       return loadAndZoomToModelExperimental(
         {
           gltf: boxTexturedGlbUrl,
+          offset: offset,
         },
         scene
       ).then(function (model) {

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -112,8 +112,8 @@ describe(
         return;
       }
 
-      // This model gets clipped in cesium-analytics due to disabled
-      // log depth, so zoom out just a little bit
+      // This model gets clipped if log depth is disabled, so zoom out
+      // the camera just a little
       var offset = new HeadingPitchRange(0, -CesiumMath.PI_OVER_FOUR, 2);
 
       return loadAndZoomToModelExperimental(

--- a/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
+++ b/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
@@ -23,6 +23,7 @@ function loadAndZoomToModelExperimental(options, scene) {
     .then(function () {
       scene.camera.flyToBoundingSphere(model.boundingSphere, {
         duration: 0,
+        offset: options.offset,
       });
       return model;
     })


### PR DESCRIPTION
This branch makes a small tweak to one test to ensure it runs even in environments where log depth is disabled. We have internal code where this becomes a problem. 

To test this, you need to change `Scene.js` line 214 so that `this._logDepthBuffer = false`, not `context.fragmentDepth`. This will cause the test to fail because the camera zooms in so far it begins to clip:

@sanjeetsuhag could you review?