### PR TITLE
Fixes glTF loading bug, adds verifyRender specs for ModelExperimental

### DIFF
--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -416,7 +416,7 @@ ModelExperimental.prototype.destroy = function () {
  * @param {Axis} [options.forwardAxis=Axis.Z] The forward-axis of the glTF model.
  * @param {Boolean} [options.allowPicking=true] When <code>true</code>, each primitive is pickable with {@link Scene#pick}.
  * @param {CustomShader} [options.customShader] A custom shader. This will add user-defined GLSL code to the vertex and fragment shaders.
- * @param {Boolean} [options.show=false] Whether or not to render the model.
+ * @param {Boolean} [options.show=true] Whether or not to render the model.
  *
  * @returns {ModelExperimental} The newly created model.
  *

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -29,7 +29,7 @@ import Matrix4 from "../../Core/Matrix4.js";
  * @param {Boolean} [options.opaquePass=Pass.OPAQUE] The pass to use in the {@link DrawCommand} for the opaque portions of the model.
  * @param {Boolean} [options.allowPicking=true] When <code>true</code>, each primitive is pickable with {@link Scene#pick}.
  * @param {CustomShader} [options.customShader] A custom shader. This will add user-defined GLSL code to the vertex and fragment shaders.
- * @param {Boolean} [options.show=false] Whether or not to render the model.
+ * @param {Boolean} [options.show=true] Whether or not to render the model.
  *
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -283,7 +283,7 @@ Object.defineProperties(ModelExperimental.prototype, {
    *
    * @type {Boolean}
    *
-   * @default false
+   * @default true
    */
   show: {
     get: function () {

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -341,7 +341,7 @@ ModelExperimental.prototype.update = function (frameState) {
     this._debugShowBoundingVolumeDirty = false;
   }
 
-  // Check for show here because we still want the draw commands to be built so use can instantly see the model
+  // Check for show here because we still want the draw commands to be built so user can instantly see the model
   // when show is set to true.
   if (this._show) {
     frameState.commandList.push.apply(

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -28,7 +28,8 @@ import Matrix4 from "../../Core/Matrix4.js";
  * @param {Boolean} [options.cull=true]  Whether or not to cull the model using frustum/horizon culling. If the model is part of a 3D Tiles tileset, this property will always be false, since the 3D Tiles culling system is used.
  * @param {Boolean} [options.opaquePass=Pass.OPAQUE] The pass to use in the {@link DrawCommand} for the opaque portions of the model.
  * @param {Boolean} [options.allowPicking=true] When <code>true</code>, each primitive is pickable with {@link Scene#pick}.
- * @param {CustomShader} [options.customShader] A custom shader. This will add user-defined GLSL code to the vertex and fragment shaders
+ * @param {CustomShader} [options.customShader] A custom shader. This will add user-defined GLSL code to the vertex and fragment shaders.
+ * @param {Boolean} [options.show=false] Whether or not to render the model.
  *
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
@@ -64,6 +65,7 @@ export default function ModelExperimental(options) {
   this._cull = defaultValue(options.cull, true);
   this._opaquePass = defaultValue(options.opaquePass, Pass.OPAQUE);
   this._allowPicking = defaultValue(options.allowPicking, true);
+  this._show = defaultValue(options.show, true);
 
   // Keeps track of resources that need to be destroyed when the Model is destroyed.
   this._resources = [];
@@ -273,6 +275,24 @@ Object.defineProperties(ModelExperimental.prototype, {
       this._debugShowBoundingVolume = value;
     },
   },
+
+  /**
+   * Whether or not to render the model.
+   *
+   * @memberof ModelExperimental.prototype
+   *
+   * @type {Boolean}
+   *
+   * @default false
+   */
+  show: {
+    get: function () {
+      return this._show;
+    },
+    set: function (value) {
+      this._show = value;
+    },
+  },
 });
 
 /**
@@ -321,10 +341,14 @@ ModelExperimental.prototype.update = function (frameState) {
     this._debugShowBoundingVolumeDirty = false;
   }
 
-  frameState.commandList.push.apply(
-    frameState.commandList,
-    this._sceneGraph._drawCommands
-  );
+  // Check for show here because we still want the draw commands to be built so use can instantly see the model
+  // when show is set to true.
+  if (this._show) {
+    frameState.commandList.push.apply(
+      frameState.commandList,
+      this._sceneGraph._drawCommands
+    );
+  }
 };
 
 /**
@@ -391,7 +415,8 @@ ModelExperimental.prototype.destroy = function () {
  * @param {Axis} [options.upAxis=Axis.Y] The up-axis of the glTF model.
  * @param {Axis} [options.forwardAxis=Axis.Z] The forward-axis of the glTF model.
  * @param {Boolean} [options.allowPicking=true] When <code>true</code>, each primitive is pickable with {@link Scene#pick}.
- * @param {CustomShader} [options.customShader] A custom shader. This will add user-defined GLSL code to the vertex and fragment shaders
+ * @param {CustomShader} [options.customShader] A custom shader. This will add user-defined GLSL code to the vertex and fragment shaders.
+ * @param {Boolean} [options.show=false] Whether or not to render the model.
  *
  * @returns {ModelExperimental} The newly created model.
  *
@@ -403,11 +428,7 @@ ModelExperimental.fromGltf = function (options) {
   Check.defined("options.gltf", options.gltf);
   //>>includeEnd('debug');
 
-  var basePath = defaultValue(options.basePath, "");
-  var baseResource = Resource.createIfNeeded(basePath);
-
   var loaderOptions = {
-    baseResource: baseResource,
     releaseGltfJson: options.releaseGltfJson,
     incrementallyLoadTextures: options.incrementallyLoadTextures,
     upAxis: options.upAxis,
@@ -415,11 +436,17 @@ ModelExperimental.fromGltf = function (options) {
   };
 
   var gltf = options.gltf;
+
+  var basePath = defaultValue(options.basePath, "");
+  var baseResource = Resource.createIfNeeded(basePath);
+
   if (defined(gltf.asset)) {
     loaderOptions.gltfJson = gltf;
+    loaderOptions.baseResource = baseResource;
     loaderOptions.gltfResource = baseResource;
   } else if (gltf instanceof Uint8Array) {
     loaderOptions.typedArray = gltf;
+    loaderOptions.baseResource = baseResource;
     loaderOptions.gltfResource = baseResource;
   } else {
     loaderOptions.gltfResource = Resource.createIfNeeded(options.gltf);
@@ -436,6 +463,7 @@ ModelExperimental.fromGltf = function (options) {
     opaquePass: options.opaquePass,
     allowPicking: options.allowPicking,
     customShader: options.customShader,
+    show: options.show,
   };
   var model = new ModelExperimental(modelOptions);
 

--- a/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
+++ b/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
@@ -4,6 +4,7 @@ import pollToPromise from "../../pollToPromise.js";
 function loadAndZoomToModelExperimental(options, scene) {
   var model = ModelExperimental.fromGltf({
     gltf: options.gltf,
+    show: options.show,
     basePath: options.basePath,
     modelMatrix: options.modelMatrix,
     allowPicking: options.allowPicking,


### PR DESCRIPTION
This PR fixes a bug that was introduced in https://github.com/CesiumGS/cesium/pull/9763 that broke loading of glTF models with external buffers when loaded from a path.

Additionally, this PR adds a `show` property to `ModelExperimental` - this is required to add `verifyRender` specs.

Here is a [local Sandcastle](localhost:8080/Apps/Sandcastle/index.html#c=xVZtb9MwEP4rVj91Uud0rLyNboINNiZRMdGyfSB8cJNra+HYke10HWj/nbOdpOkIoAoKUrvkzr6757nz6mfJNFlyuAVNjomEW3IGhhcZvfa+btxJvH2mpGVcgo47ey9iGcsoIiOVgiBXyliuJJfzWC4xWa4Mdw5MV6Y6Y9riG5OHdKZV9hrmGsB0Y0nI/sGjQ9p/Ohg8OXjec47BgPYf9w+f9p94sx9LV87lXeQPEL4FlmLVK26TxQclRLffI+5TBcz4CtJzzTKYaCbNTOlsjal2GSpUwkTYp87rmAtAsswq7XHGHam0XcSdXrBuwdi4E8A1u2FC6cy/Y7VPbvs394cQCyt7hLGnavVRCm7LZIQoaUBAgouzQia+d929KoqQsOjTdyufwxCNc0hM9JpZFoXi0dXph6hKX7/QubAzBzYEOsjuee8e970WgBdaFTK9hgVPBPwZSsxGaYSfMctyAR5raE60UWXTQsTTbQCHmZ4yIZSSOwO8UWXT2hYwjuZSGstkAukOjsEFDvydYinoqFkpmovJeTRVq31eubY+G818/n9IMIf035FoFG3hs2/Xy3+L2w23ixGXI7b6LyzX5X/Ddz/j+GWrP+J9KS1oAWz5Lw9mo2gbR75e3prbiCdaJcpku2VTlwn4s8rcGu9E4z05F+Cmrgp7KVOOF/BuwbfXDEza17amdQPMLpx42CWPskgAfhuMXyKN5Wd/f9cYmnULLUpEQR5Rk6AkoLnmGeqbJTZBQ6aW8AqVR0hb3/x48f8shqVpyagUIr7Ym1UOuAdQYwmvkRyrbt0Ox+GIIKBe5fFlRsxqvjpqkTSLB9KoKWwaDa2kWm/tQpXVsMrMb4TguVE8pTcX42eDxoYWjVW3uuy0f4YGua9Hjq1j6d0VEuUGKM5JdtfnwO+oD0PZyARLaEZn4m6iTp1UQHrjHAcMYT+dbjh767OUFtr/PB6RPn1cYfJw/OM+CLgxk2nCjEXxgSOaKCWmTI9AFiG92XvR6XWGxt4JOKkyv+RZjqrQDaaLisECKgaGSjeaFskXsDQxpjpvw6gZOkz5kvD0uEVck0QwY3BlVggx5l9Rf50MI9z/Q6hQfsbvl/jbyO7ctsXBybvgpJQOIzTbI21g9yDzdw) to test. The Instancing models have external buffers.