### PR TITLE
 Fix buildModuleUrl.setBaseUrl and .getCesiumBaseUrl in JSDoc/TypeScript

### DIFF
--- a/Source/Core/buildModuleUrl.js
+++ b/Source/Core/buildModuleUrl.js
@@ -91,7 +91,7 @@ var implementation;
 
 /**
  * Given a relative URL under the Cesium base URL, returns an absolute URL.
- * @function
+ * @function buildModuleUrl
  *
  * @param {String} relativeUrl The relative path.
  * @returns {String} The absolutely URL representation of the provided path.
@@ -130,9 +130,14 @@ buildModuleUrl._clearBaseResource = function () {
   baseResource = undefined;
 };
 
+/** @namespace buildModuleUrl(1) */
+
 /**
  * Sets the base URL for resolving modules.
+ * @function setBaseUrl
+ * @memberof buildModuleUrl(1)
  * @param {String} value The new base URL.
+ * @return {Void} void
  */
 buildModuleUrl.setBaseUrl = function (value) {
   baseResource = Resource.DEFAULT.getDerivedResource({
@@ -142,6 +147,9 @@ buildModuleUrl.setBaseUrl = function (value) {
 
 /**
  * Gets the base URL for resolving modules.
+ * @function getCesiumBaseUrl
+ * @memberof buildModuleUrl(1)
+ * @return {Resource} The base URL for resolving modules.
  */
 buildModuleUrl.getCesiumBaseUrl = getCesiumBaseUrl;
 


### PR DESCRIPTION
**Issue** [8922](https://github.com/CesiumGS/cesium/issues/8922) [8924](https://github.com/CesiumGS/cesium/issues/8924)



**Description**

If we use TypeScript, we will encounter the following problems.

```
import { buildModuleUrl } from 'cesium'

buildModuleUrl.setBaseUrl('./static/Cesium/')
buildModuleUrl.getCesiumBaseUrl()
```

PROBLEMS:

```
Property 'setBaseUrl' does not exist on type '(relativeUrl: string) => string'.
Property 'getCesiumBaseUrl' does not exist on type '(relativeUrl: string) => string'.
```



<br>

**Why?**

*Source/Core/buildModuleUrl.js*

```
/**
 * Given a relative URL under the Cesium base URL, returns an absolute URL.
 * @function
 *
 * ...
 */
function buildModuleUrl(relativeUrl) {
  ...
}



/**
 * Sets the base URL for resolving modules.
 * @param {String} value The new base URL.
 */
buildModuleUrl.setBaseUrl = function (value) {
  ...
};

/**
 * Gets the base URL for resolving modules.
 */
buildModuleUrl.getCesiumBaseUrl = getCesiumBaseUrl;
```

We can see that:

1. `buildModuleUrl` is a function
2. `buildModuleUrl` also is a namespace

When we execute the command `build-ts`, this is very confusing for `JSDoc`.

*Cesium.d.ts*

```
/**
 * Given a relative URL under the Cesium base URL, returns an absolute URL.
 * @example
 * ...
 */
export function buildModuleUrl(relativeUrl: string): string;
```

We can see that `buildModuleUrl.setBaseUrl` and `buildModuleUrl.getCesiumBaseUrl` is not exported.



<br>

**Wrong solution**

I have tried but failed.

```diff
+ /** @namespace buildModuleUrl */

 /**
  * @function
  */
 function buildModuleUrl(relativeUrl) {
   ...
 }


 /**
+ * @memberof buildModuleUrl
  * ...
  */
 buildModuleUrl.setBaseUrl = function (value) {
   ...
 };

 /**
+ * @memberof buildModuleUrl
  * ...
  */
 buildModuleUrl.getCesiumBaseUrl = getCesiumBaseUrl;
```

`yarn run build-ts`

*Cesium.d.ts*

```
export namespace buildModuleUrl {
    /**
     * ...
     */
    function setBaseUrl(value: string): void;
    /**
     * ...
     */
    function getCesiumBaseUrl(): Resource;
}
```

This time `buildModuleUrl.setBaseUrl` and `buildModuleUrl.getCesiumBaseUrl` is exported.

But `export function buildModuleUrl` has disappeared.



<br>

Emm.... I'm tired, destroy it.



<br>

**The right solution**

After unremitting efforts, I finally found a solution.

https://groups.google.com/g/jsdoc-users/c/1Md5S8j2ZI4

1. We use `buildModuleUrl` to represent the function
2. We use `buildModuleUrl(1)` to represent the namespace

<br>

*Source/Core/buildModuleUrl.js*

```diff
  /**
   * Given a relative URL under the Cesium base URL, returns an absolute URL.
+  * @function buildModuleUrl
   *
   * ...
   */
  function buildModuleUrl(relativeUrl) {
    ...
  }

+ /** @namespace buildModuleUrl(1) */

  /**
+  * @function setBaseUrl
+  * @memberof buildModuleUrl(1)
   * ...
   */
  buildModuleUrl.setBaseUrl = function (value) {
    ...
  };

  /**
+  * @function getCesiumBaseUrl
+  * @memberof buildModuleUrl(1)
   * ...
   */
  buildModuleUrl.getCesiumBaseUrl = getCesiumBaseUrl;
```

`yarn run build-ts`

Wow...

```
/**
 * Given a relative URL under the Cesium base URL, returns an absolute URL.
 * @example
 * var viewer = new Cesium.Viewer("cesiumContainer", {
 *   imageryProvider: new Cesium.TileMapServiceImageryProvider({
 *   url: Cesium.buildModuleUrl("Assets/Textures/NaturalEarthII"),
 *   }),
 *   baseLayerPicker: false,
 * });
 * @param relativeUrl - The relative path.
 * @returns The absolutely URL representation of the provided path.
 */
export function buildModuleUrl(relativeUrl: string): string;

export namespace buildModuleUrl {
    /**
     * Sets the base URL for resolving modules.
     * @param value - The new base URL.
     * @returns void
     */
    function setBaseUrl(value: string): void;
    /**
     * Gets the base URL for resolving modules.
     * @returns The base URL for resolving modules.
     */
    function getCesiumBaseUrl(): Resource;
}
```

Perfect !!!

