### PR TITLE
Use `metrics.width` for spaces in `writeTextToCanvas`

### DIFF
--- a/Source/Core/writeTextToCanvas.js
+++ b/Source/Core/writeTextToCanvas.js
@@ -87,7 +87,7 @@ function measureText(context2D, textString, font, stroke, fill) {
   }
 
   return {
-    width: 0,
+    width: metrics.width,
     height: 0,
     ascent: 0,
     descent: 0,


### PR DESCRIPTION
Fixes a mistake from https://github.com/CesiumGS/cesium/pull/9765/ where I hardcoded space characters to return a width of `0` in the new `measureText` function. This fix matches the implementation of the third party measureText that used to be in main and fixes the spacing bug seen in the [CMZL reference properties sandcastle](http://localhost:8080/Apps/Sandcastle/index.html?src=CZML%20Reference%20Properties.html) - 

PR branch:
![image](https://user-images.githubusercontent.com/31491650/131736519-5a7e3db3-b96b-449c-b17d-4a017f96a1e0.png)

1.84:
![image](https://user-images.githubusercontent.com/31491650/131736615-34519b62-ea95-4318-8702-b9539e0978ed.png)

main:
![image](https://user-images.githubusercontent.com/31491650/131736686-122a1ac2-d723-4336-9be0-5d002ff85849.png)
