### PR TITLE
Fix `Viewer.bottomContainer` type in JSDoc/TypeScript

### DIFF
--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -947,7 +947,7 @@ Object.defineProperties(Viewer.prototype, {
    * Gets the DOM element for the area at the bottom of the window containing the
    * {@link CreditDisplay} and potentially other things.
    * @memberof Viewer.prototype
-   * @type {Element}
+   * @type {HTMLDivElement}
    * @readonly
    */
   bottomContainer: {


### PR DESCRIPTION
*Viewer.js*

```
  // Bottom container
  var bottomContainer = document.createElement("div");
  bottomContainer.className = "cesium-viewer-bottom";

...

  /**
   * Gets the DOM element for the area at the bottom of the window containing the
   * {@link CreditDisplay} and potentially other things.
   * @memberof Viewer.prototype
   * @type {Element}
   * @readonly
   */
  bottomContainer: {
    get: function () {
      return this._bottomContainer;
    },
  },
```

<br>

If use TypeScript: 

```
viewer.bottomContainer.style.backgroundColor = 'blue';
```

<br>

:exclamation: ​PROBLEMS: 

```
Property 'style' does not exist on type 'Element'.
```

<br>

```diff
- viewer.bottomContainer.style.backgroundColor = 'blue';
+ (viewer.bottomContainer as HTMLElement).style.backgroundColor = 'blue';
```



<br>

<br>

**In fact, I think all `Element` should be changed to `HTMLElement` in Cesium.js.**

<br>

