### PR TITLE
Fix Entity.orientation type in JSDoc/TypeScript

### DIFF
--- a/Source/DataSources/Entity.js
+++ b/Source/DataSources/Entity.js
@@ -71,7 +71,7 @@ function createPropertyTypeDescriptor(name, Type) {
  * @property {Boolean} [show] A boolean value indicating if the entity and its children are displayed.
  * @property {Property | string} [description] A string Property specifying an HTML description for this entity.
  * @property {PositionProperty | Cartesian3} [position] A Property specifying the entity position.
- * @property {Property} [orientation] A Property specifying the entity orientation.
+ * @property {Property | Quaternion} [orientation] A Property specifying the entity orientation.
  * @property {Property} [viewFrom] A suggested initial offset for viewing this object.
  * @property {Entity} [parent] A parent entity to associate with this entity.
  * @property {BillboardGraphics | BillboardGraphics.ConstructorOptions} [billboard] A billboard to associate with this entity.
@@ -415,7 +415,7 @@ Object.defineProperties(Entity.prototype, {
   /**
    * Gets or sets the orientation.
    * @memberof Entity.prototype
-   * @type {Property|undefined}
+   * @type {Property|Quaternion|undefined}
    */
   orientation: createPropertyDescriptor("orientation"),
   /**


### PR DESCRIPTION
*Entity.js*

```
  if (!defined(orientation)) {
    result = Transforms.eastNorthUpToFixedFrame(position, undefined, result);
  } else {
    result = Matrix4.fromRotationTranslation(
      Matrix3.fromQuaternion(orientation, matrix3Scratch),
      position,
      result
    );
  }
```

<br>

If use TypeScript: 

```
const position = Cartesian3.fromDegrees(-123.0744619, 44.0503706, 100)
const hpr = new HeadingPitchRoll(135 * Math.PI / 180.0, 0, 0)
const orientation = Transforms.headingPitchRollQuaternion(position, hpr)

const entity = viewer.entities.add({
    position,
    orientation
})
```

<br>

:exclamation: ​PROBLEMS: 

```
Type 'Quaternion' is missing the following properties from type 'Property': isConstant, definitionChanged, getValue
```

<br>

```diff
 const entity = viewer.entities.add({
     position,
+    //@ts-ignore
     orientation
 })
```

