### PR TITLE
Fixes positions type in CorridorGraphics

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -295,3 +295,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Calogero Mauceri](https://github.com/kalosma)
 - [Ren Jianqiang](https://github.com/renjianqiang)
 - [Yang Puxiao](https://github.com/puxiao)
+- [Ivan Ludvig](https://github.com/IvanLudvig)

--- a/Source/DataSources/CorridorGraphics.js
+++ b/Source/DataSources/CorridorGraphics.js
@@ -11,7 +11,7 @@ import createPropertyDescriptor from "./createPropertyDescriptor.js";
  * Initialization options for the CorridorGraphics constructor
  *
  * @property {Property | boolean} [show=true] A boolean Property specifying the visibility of the corridor.
- * @property {Property | Cartesian3} [positions] A Property specifying the array of {@link Cartesian3} positions that define the centerline of the corridor.
+ * @property {Property | Cartesian3[]} [positions] A Property specifying the array of {@link Cartesian3} positions that define the centerline of the corridor.
  * @property {Property | number} [width] A numeric Property specifying the distance between the edges of the corridor.
  * @property {Property | number} [height=0] A numeric Property specifying the altitude of the corridor relative to the ellipsoid surface.
  * @property {Property | HeightReference} [heightReference=HeightReference.NONE] A Property specifying what the height is relative to.


### PR DESCRIPTION
There's an error in the type of the `positions` field of `CorridorGraphics`. It should accept an array of positions `Cartesian3[]`, instead of one position `Cartesian3`