### PR TITLE
Added a `features` getter to `Cesium3DTileContent` that gets the features in the tile.

### DIFF
--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -71,6 +71,16 @@ function Batched3DModel3DTileContent(
 Batched3DModel3DTileContent._deprecationWarning = deprecationWarning;
 
 Object.defineProperties(Batched3DModel3DTileContent.prototype, {
+  features: {
+    get: function () {
+      if (defined(this._batchTable)) {
+        createFeatures(this);
+        return this._features;
+      }
+      return [];
+    },
+  },
+
   featuresLength: {
     get: function () {
       return this._batchTable.featuresLength;

--- a/Source/Scene/Cesium3DTileContent.js
+++ b/Source/Scene/Cesium3DTileContent.js
@@ -30,7 +30,7 @@ function Cesium3DTileContent() {
 }
 
 Object.defineProperties(Cesium3DTileContent.prototype, {
-    /**
+  /**
    * Gets the features in the tile.
    *
    * @memberof Cesium3DTileContent.prototype

--- a/Source/Scene/Cesium3DTileContent.js
+++ b/Source/Scene/Cesium3DTileContent.js
@@ -44,7 +44,7 @@ Object.defineProperties(Cesium3DTileContent.prototype, {
       DeveloperError.throwInstantiationError();
     },
   },
-  
+
   /**
    * Gets the number of features in the tile.
    *

--- a/Source/Scene/Cesium3DTileContent.js
+++ b/Source/Scene/Cesium3DTileContent.js
@@ -30,6 +30,21 @@ function Cesium3DTileContent() {
 }
 
 Object.defineProperties(Cesium3DTileContent.prototype, {
+    /**
+   * Gets the features in the tile.
+   *
+   * @memberof Cesium3DTileContent.prototype
+   *
+   * @type {Cesium3DTileFeature[]} The corresponding {@link Cesium3DTileFeature} object.
+   * @readonly
+   */
+  features: {
+    // eslint-disable-next-line getter-return
+    get: function () {
+      DeveloperError.throwInstantiationError();
+    },
+  },
+  
   /**
    * Gets the number of features in the tile.
    *

--- a/Source/Scene/Composite3DTileContent.js
+++ b/Source/Scene/Composite3DTileContent.js
@@ -63,7 +63,7 @@ Object.defineProperties(Composite3DTileContent.prototype, {
    * always returns <code>[]</code>.  Instead call <code>features</code> for the features in the composite.
    * @memberof Composite3DTileContent.prototype
    */
-   features: {
+  features: {
     get: function () {
       return [];
     },

--- a/Source/Scene/Composite3DTileContent.js
+++ b/Source/Scene/Composite3DTileContent.js
@@ -60,6 +60,17 @@ Object.defineProperties(Composite3DTileContent.prototype, {
 
   /**
    * Part of the {@link Cesium3DTileContent} interface.  <code>Composite3DTileContent</code>
+   * always returns <code>[]</code>.  Instead call <code>features</code> for the features in the composite.
+   * @memberof Composite3DTileContent.prototype
+   */
+   features: {
+    get: function () {
+      return [];
+    },
+  },
+
+  /**
+   * Part of the {@link Cesium3DTileContent} interface.  <code>Composite3DTileContent</code>
    * always returns <code>0</code>.  Instead call <code>featuresLength</code> for a tile in the composite.
    * @memberof Composite3DTileContent.prototype
    */

--- a/Source/Scene/Empty3DTileContent.js
+++ b/Source/Scene/Empty3DTileContent.js
@@ -22,6 +22,12 @@ function Empty3DTileContent(tileset, tile) {
 }
 
 Object.defineProperties(Empty3DTileContent.prototype, {
+  features: {
+    get: function () {
+      return [];
+    },
+  },
+
   featuresLength: {
     get: function () {
       return 0;

--- a/Source/Scene/Geometry3DTileContent.js
+++ b/Source/Scene/Geometry3DTileContent.js
@@ -48,6 +48,16 @@ function Geometry3DTileContent(
 }
 
 Object.defineProperties(Geometry3DTileContent.prototype, {
+  features: {
+    get: function () {
+      if (defined(this._batchTable)) {
+        createFeatures(this);
+        return this._features;
+      }
+      return [];
+    },
+  },
+
   featuresLength: {
     get: function () {
       return defined(this._batchTable) ? this._batchTable.featuresLength : 0;

--- a/Source/Scene/Gltf3DTileContent.js
+++ b/Source/Scene/Gltf3DTileContent.js
@@ -38,6 +38,12 @@ function Gltf3DTileContent(tileset, tile, resource, gltf) {
 }
 
 Object.defineProperties(Gltf3DTileContent.prototype, {
+  features: {
+    get: function () {
+      return [];
+    },
+  },
+
   featuresLength: {
     get: function () {
       return 0;

--- a/Source/Scene/Implicit3DTileContent.js
+++ b/Source/Scene/Implicit3DTileContent.js
@@ -73,6 +73,12 @@ export default function Implicit3DTileContent(
 }
 
 Object.defineProperties(Implicit3DTileContent.prototype, {
+  features: {
+    get: function () {
+      return [];
+    },
+  },
+
   featuresLength: {
     get: function () {
       return 0;

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -62,6 +62,16 @@ function Instanced3DModel3DTileContent(
 Instanced3DModel3DTileContent._deprecationWarning = deprecationWarning;
 
 Object.defineProperties(Instanced3DModel3DTileContent.prototype, {
+  features: {
+    get: function () {
+      if (defined(this._batchTable)) {
+        createFeatures(this);
+        return this._features;
+      }
+      return [];
+    },
+  },
+
   featuresLength: {
     get: function () {
       return this._batchTable.featuresLength;

--- a/Source/Scene/Multiple3DTileContent.js
+++ b/Source/Scene/Multiple3DTileContent.js
@@ -107,6 +107,18 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
 
   /**
    * Part of the {@link Cesium3DTileContent} interface.  <code>Multiple3DTileContent</code>
+   * always returns <code>[]</code>.  Instead call <code>features</code> for the features inner content.
+   * @memberof Multiple3DTileContent.prototype
+   * @private
+   */
+   features: {
+    get: function () {
+      return [];
+    },
+  },
+
+  /**
+   * Part of the {@link Cesium3DTileContent} interface.  <code>Multiple3DTileContent</code>
    * always returns <code>0</code>.  Instead call <code>featuresLength</code> for a specific inner content.
    * @memberof Multiple3DTileContent.prototype
    * @private

--- a/Source/Scene/Multiple3DTileContent.js
+++ b/Source/Scene/Multiple3DTileContent.js
@@ -111,7 +111,7 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
    * @memberof Multiple3DTileContent.prototype
    * @private
    */
-   features: {
+  features: {
     get: function () {
       return [];
     },

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -57,6 +57,16 @@ function PointCloud3DTileContent(
 }
 
 Object.defineProperties(PointCloud3DTileContent.prototype, {
+  features: {
+    get: function () {
+      if (defined(this._batchTable)) {
+        createFeatures(this);
+        return this._features;
+      }
+      return [];
+    },
+  },
+
   featuresLength: {
     get: function () {
       if (defined(this._batchTable)) {

--- a/Source/Scene/Tileset3DTileContent.js
+++ b/Source/Scene/Tileset3DTileContent.js
@@ -27,6 +27,12 @@ function Tileset3DTileContent(tileset, tile, resource, json) {
 }
 
 Object.defineProperties(Tileset3DTileContent.prototype, {
+  features: {
+    get: function () {
+      return [];
+    },
+  },
+
   featuresLength: {
     get: function () {
       return 0;

--- a/Source/Scene/Vector3DTileContent.js
+++ b/Source/Scene/Vector3DTileContent.js
@@ -57,6 +57,16 @@ function Vector3DTileContent(tileset, tile, resource, arrayBuffer, byteOffset) {
 }
 
 Object.defineProperties(Vector3DTileContent.prototype, {
+  features: {
+    get: function () {
+      if (defined(this._batchTable)) {
+        createFeatures(this);
+        return this._features;
+      }
+      return [];
+    },
+  },
+
   featuresLength: {
     get: function () {
       return defined(this._batchTable) ? this._batchTable.featuresLength : 0;


### PR DESCRIPTION
**Issues:** null

<br>

**It is convenient for us to traverse each feature.**

```diff
-  var featuresLength = content.featuresLength;
-  for (var i = 0; i < featuresLength; ++i) {
-      var feature = content.getFeature(i);
-      //...
-  }


+  content.features.forEach((feature) => {
+      //...
+  })
```



<br>

*Cesium.d.ts* after modification

```
export class Cesium3DTileContent {
    /**
     * Gets the features in the tile.
     */
    readonly features: Cesium3DTileFeature[];
}
```

