### PR TITLE
Moves feature table selection inside feature metadata check

### DIFF
--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -193,22 +193,17 @@ function initialize(model) {
       var featureMetadata = components.featureMetadata;
 
       if (defined(featureMetadata) && featureMetadata.featureTableCount > 0) {
+        var featureTableId = selectFeatureTableId(components, model);
         var featureTables;
         if (defined(content)) {
           featureTables = createContentFeatureTables(content, featureMetadata);
           content.featureTables = featureTables;
+          content.featureTableId = featureTableId;
         } else {
           featureTables = createModelFeatureTables(model, featureMetadata);
           model._featureTables = featureTables;
+          model.featureTableId = featureTableId;
         }
-      }
-
-      var featureTableId = selectFeatureTableId(components, model);
-
-      if (defined(content)) {
-        content.featureTableId = featureTableId;
-      } else {
-        model.featureTableId = featureTableId;
       }
 
       model._sceneGraph = new ModelExperimentalSceneGraph({

--- a/Specs/Scene/Gltf3DTileContentSpec.js
+++ b/Specs/Scene/Gltf3DTileContentSpec.js
@@ -210,6 +210,23 @@ describe(
         ExperimentalFeatures.enableModelExperimental = false;
       });
 
+      it("renders glTF content with metadata", function () {
+        return Cesium3DTilesTester.loadTileset(
+          scene,
+          buildingsMetadataUrl
+        ).then(function (tileset) {
+          Cesium3DTilesTester.expectRender(scene, tileset);
+        });
+      });
+
+      it("renders glTF content without metadata", function () {
+        return Cesium3DTilesTester.loadTileset(scene, glbContentUrl).then(
+          function (tileset) {
+            Cesium3DTilesTester.expectRender(scene, tileset);
+          }
+        );
+      });
+
       it("assigns feature table as batch table", function () {
         return Cesium3DTilesTester.loadTileset(
           scene,


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/CesiumGS/cesium/pull/9773 where `ModelExperimental` was checking for feature tables when feature metadata is not present.