### PR TITLE
Validate easily-confused custom shader variables

### DIFF
--- a/Source/Scene/ModelExperimental/CustomShader.js
+++ b/Source/Scene/ModelExperimental/CustomShader.js
@@ -223,6 +223,7 @@ export default function CustomShader(options) {
   };
 
   findUsedVariables(this);
+  validateBuiltinVariables(this);
 }
 
 function buildUniformMap(customShader) {
@@ -303,6 +304,77 @@ function findUsedVariables(customShader) {
     var materialSet = customShader.usedVariablesFragment.materialSet;
     getVariables(fragmentShaderText, materialRegex, materialSet);
   }
+}
+
+function expandCoordinateAbbreviations(variableName) {
+  var modelCoordinatesRegex = /^.*MC$/;
+  var worldCoordinatesRegex = /^.*WC$/;
+  var eyeCoordinatesRegex = /^.*EC$/;
+
+  if (modelCoordinatesRegex.test(variableName)) {
+    return variableName + " (model coordinates)";
+  }
+
+  if (worldCoordinatesRegex.test(variableName)) {
+    return variableName + " (Cartesian world coordinates)";
+  }
+
+  if (eyeCoordinatesRegex.test(variableName)) {
+    return variableName + " (eye coordinates)";
+  }
+
+  return variableName;
+}
+
+function validateVariableUsage(
+  variableSet,
+  incorrectVariable,
+  correctVariable,
+  vertexOrFragment
+) {
+  if (variableSet.hasOwnProperty(incorrectVariable)) {
+    var message =
+      expandCoordinateAbbreviations(incorrectVariable) +
+      " is not available in the " +
+      vertexOrFragment +
+      " shader. Did you mean " +
+      expandCoordinateAbbreviations(correctVariable) +
+      " instead?";
+    throw new DeveloperError(message);
+  }
+}
+
+function validateBuiltinVariables(customShader) {
+  var attributesVS = customShader.usedVariablesVertex.attributeSet;
+
+  // names without MC/WC/EC are ambiguous
+  validateVariableUsage(attributesVS, "position", "positionMC", "vertex");
+  validateVariableUsage(attributesVS, "normal", "normalMC", "vertex");
+  validateVariableUsage(attributesVS, "tangent", "tangentMC", "vertex");
+  validateVariableUsage(attributesVS, "bitangent", "bitangentMC", "vertex");
+
+  // world and eye coordinate positions are only available in the fragment shader.
+  validateVariableUsage(attributesVS, "positionWC", "positionMC", "vertex");
+  validateVariableUsage(attributesVS, "positionEC", "positionMC", "vertex");
+
+  // normal, tangent and bitangent are in model coordinates in the vertex shader
+  validateVariableUsage(attributesVS, "normalEC", "normalMC", "vertex");
+  validateVariableUsage(attributesVS, "tangentEC", "tangentMC", "vertex");
+  validateVariableUsage(attributesVS, "bitangentEC", "bitangentMC", "vertex");
+
+  var attributesFS = customShader.usedVariablesFragment.attributeSet;
+
+  // names without MC/WC/EC are ambiguous
+  validateVariableUsage(attributesFS, "position", "positionEC", "fragment");
+  validateVariableUsage(attributesFS, "normal", "normalEC", "fragment");
+  validateVariableUsage(attributesFS, "tangent", "tangentEC", "fragment");
+  validateVariableUsage(attributesFS, "bitangent", "bitangentEC", "fragment");
+
+  // normal, tangent, and bitangent are in eye coordinates in the fragment
+  // shader.
+  validateVariableUsage(attributesFS, "normalMC", "normalEC", "fragment");
+  validateVariableUsage(attributesFS, "tangentMC", "tangentEC", "fragment");
+  validateVariableUsage(attributesFS, "bitangentMC", "bitangentEC", "fragment");
 }
 
 /**

--- a/Specs/Scene/ModelExperimental/CustomShaderSpec.js
+++ b/Specs/Scene/ModelExperimental/CustomShaderSpec.js
@@ -204,6 +204,124 @@ describe("Scene/ModelExperimental/CustomShader", function () {
     );
   });
 
+  describe("variable validation", function () {
+    function makeSingleVariableVS(variableName) {
+      return new CustomShader({
+        vertexShaderText: [
+          "void vertexMain(VertexInput vsInput, inout vec3 positionMC)",
+          "{",
+          "    positionMC = vsInput.attributes." + variableName + ";",
+          "}",
+        ].join("\n"),
+      });
+    }
+
+    function makeSingleVariableFS(variableName) {
+      return new CustomShader({
+        fragmentShaderText: [
+          "void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)",
+          "{",
+          "    material.diffuse = fsInput.attributes." + variableName + ";",
+          "}",
+        ].join("\n"),
+      });
+    }
+
+    it("validates position", function () {
+      expect(function () {
+        return makeSingleVariableVS("position");
+      }).toThrowDeveloperError();
+      expect(function () {
+        return makeSingleVariableVS("positionMC");
+      }).not.toThrowDeveloperError();
+      expect(function () {
+        return makeSingleVariableVS("positionWC");
+      }).toThrowDeveloperError();
+      expect(function () {
+        return makeSingleVariableVS("positionEC");
+      }).toThrowDeveloperError();
+
+      expect(function () {
+        return makeSingleVariableFS("position");
+      }).toThrowDeveloperError();
+      expect(function () {
+        return makeSingleVariableFS("positionMC");
+      }).not.toThrowDeveloperError();
+      expect(function () {
+        return makeSingleVariableFS("positionWC");
+      }).not.toThrowDeveloperError();
+      expect(function () {
+        return makeSingleVariableFS("positionEC");
+      }).not.toThrowDeveloperError();
+    });
+
+    it("validates normal", function () {
+      expect(function () {
+        return makeSingleVariableVS("normal");
+      }).toThrowDeveloperError();
+      expect(function () {
+        return makeSingleVariableVS("normalMC");
+      }).not.toThrowDeveloperError();
+      expect(function () {
+        return makeSingleVariableVS("normalEC");
+      }).toThrowDeveloperError();
+
+      expect(function () {
+        return makeSingleVariableFS("normal");
+      }).toThrowDeveloperError();
+      expect(function () {
+        return makeSingleVariableFS("normalMC");
+      }).toThrowDeveloperError();
+      expect(function () {
+        return makeSingleVariableFS("normalEC");
+      }).not.toThrowDeveloperError();
+    });
+
+    it("validates tangent", function () {
+      expect(function () {
+        return makeSingleVariableVS("tangent");
+      }).toThrowDeveloperError();
+      expect(function () {
+        return makeSingleVariableVS("tangentMC");
+      }).not.toThrowDeveloperError();
+      expect(function () {
+        return makeSingleVariableVS("tangentEC");
+      }).toThrowDeveloperError();
+
+      expect(function () {
+        return makeSingleVariableFS("tangent");
+      }).toThrowDeveloperError();
+      expect(function () {
+        return makeSingleVariableFS("tangentMC");
+      }).toThrowDeveloperError();
+      expect(function () {
+        return makeSingleVariableFS("tangentEC");
+      }).not.toThrowDeveloperError();
+    });
+
+    it("validates bitangent", function () {
+      expect(function () {
+        return makeSingleVariableVS("bitangent");
+      }).toThrowDeveloperError();
+      expect(function () {
+        return makeSingleVariableVS("bitangentMC");
+      }).not.toThrowDeveloperError();
+      expect(function () {
+        return makeSingleVariableVS("bitangentEC");
+      }).toThrowDeveloperError();
+
+      expect(function () {
+        return makeSingleVariableFS("bitangent");
+      }).toThrowDeveloperError();
+      expect(function () {
+        return makeSingleVariableFS("bitangentMC");
+      }).toThrowDeveloperError();
+      expect(function () {
+        return makeSingleVariableFS("bitangentEC");
+      }).not.toThrowDeveloperError();
+    });
+  });
+
   // asynchronous code is only needed if texture uniforms are used.
   describe(
     "texture uniforms",


### PR DESCRIPTION
This is a small PR to improve the UX of using Custom Shaders after some recent changes.

in #9806, I made position/normal/tangent/bitangents require a `MC` (model coordinates) or `EC` (eye coordinates) suffix. This could potentially cause confusion since they are 1 character different, and furthermore, the usage is different between the vertex shader and the fragment shader. So now the custom shader will check for easily-confused combinations and throw an error with a message to explain what's wrong.

@ebogo1 could you review this one? Might be good so you learn a little about custom shaders.

Here's a [Local Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=bVNrT9swFP0rd9mXIBWHMaaxUNCmAFKllkmjmzQt0+TYt62HY0d+FArqf5/zKungQ+vexzn3+Po0Qyt8Sa4eKjSiROWovEbqvEFLUNFC4kxzlMM6nIMzHs9ylas1NbAWeI8mZBXeQ9by/WhycR6xJs50AAqFJo8OdjgnJFp0+8D2eH85b4vxU64AkgRufmZQeCG5UEu7g94Lt9LewaWhTAPTZRV0W6FVjfJGpj3tRKtvaLU3DMnC6PKLDfAJjz98/HR6dHowqvuZt06XtyvK0aR7mgaFVhCAFMuVC1qa7ezGTIdZ8v1mOpmP2v6Foct6fS3LHB9cCr/aUnO/TEvdrQSKDXBhHVUMwWlwKwRGSzS078+jtRZ8xzkLq42vu2CiqrCQhW3OEQhV74c9ln/KWtOMuvCO4Q3L7sdBHo2eaZ8GURDlzKZZMShtSipnWaCzDil/8wypv3sywsVi4S2GJ+0EEOqcEYV3wU4tyVV2tjdyu4t+k786XCSP8uCQqH2TbX1sa8+0LiOWoUJSBS8KJ9aBlXIed3YYtD1qXc71sJCraBSNrdtIvOinfxZlpY2rnRITkjgsKxmuYpPCszt0hFlbQ9vmt05rWQTfPvUZgIKyu6XRXvEUzLKg8cnxCPrPETl9RgNUQWmwRgon1cMgXWgTDHFoKBfe7he3L0aL5nEHAtZonGBUHtJgSJVCKTiX+HLqodNVCsd7k/tSoV2w9361Gz1Ohgsbc7EGwc9f+VcDk9TaUFl4KW/FI+bRxTgJ/S+gUtN66tegXNJN3bZ6dzFtk4SQcRLC15HdEv5j/gc) -- swap out `normalEC` in the shader for `normal` or `normalMC` to see the error message.