### PR TITLE
Fixes picking in ModelExperimental

### DIFF
--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -435,6 +435,7 @@ function initialize(content, arrayBuffer, byteOffset) {
     };
 
     if (ExperimentalFeatures.enableModelExperimental) {
+      modelOptions.content = content;
       modelOptions.customShader = tileset.customShader;
       content._model = ModelExperimental.fromGltf(modelOptions);
     } else {

--- a/Source/Scene/ModelExperimental/PickingPipelineStage.js
+++ b/Source/Scene/ModelExperimental/PickingPipelineStage.js
@@ -45,11 +45,7 @@ PickingPipelineStage.process = function (
     processInstancedPickIds(renderResources, instances, context);
   } else {
     // For non-instanced meshes, a pick color uniform is used.
-    var pickObject = {
-      model: model,
-      node: renderResources.runtimeNode,
-      primitive: renderResources.runtimePrimitive,
-    };
+    var pickObject = buildPickObject(renderResources);
 
     var pickId = context.createPickId(pickObject);
     model._resources.push(pickId);
@@ -67,6 +63,45 @@ PickingPipelineStage.process = function (
     renderResources.pickId = "czm_pickColor";
   }
 };
+
+/**
+ * @private
+ */
+function buildPickObject(renderResources, instanceId) {
+  var model = renderResources.model;
+
+  var detailPickObject = {
+    model: model,
+    node: renderResources.runtimeNode,
+    primitive: renderResources.runtimePrimitive,
+  };
+
+  var content = model.content;
+  var pickObject;
+
+  if (defined(content)) {
+    // For 3D Tiles, the pick object's content and primitive are set to the Cesium3DTileContent that owns the model
+    //and the parent tileset it belongs to, respectively. The detail pick object is returned under the detail key.
+    pickObject = {
+      content: content,
+      primitive: content.tileset,
+      detail: detailPickObject,
+    };
+  } else {
+    // For models, the model itself is returned as the primitive, with the detail pick object under the detail key.
+    pickObject = {
+      primitive: model,
+      detail: detailPickObject,
+    };
+  }
+
+  if (defined(instanceId)) {
+    // For instanced models, an instanceId property is attached.
+    pickObject.instanceId = instanceId;
+  }
+
+  return pickObject;
+}
 
 function processPickTexture(renderResources, primitive, instances) {
   var model = renderResources.model;
@@ -130,12 +165,7 @@ function processInstancedPickIds(renderResources, instances, context) {
 
   var modelResources = model._resources;
   for (var i = 0; i < instanceCount; i++) {
-    var pickObject = {
-      model: renderResources.model,
-      node: renderResources.runtimeNode,
-      primitive: renderResources.runtimePrimitive,
-      instanceId: i,
-    };
+    var pickObject = buildPickObject(renderResources, i);
 
     var pickId = context.createPickId(pickObject);
     modelResources.push(pickId);

--- a/Source/Scene/ModelExperimental/PickingPipelineStage.js
+++ b/Source/Scene/ModelExperimental/PickingPipelineStage.js
@@ -81,7 +81,7 @@ function buildPickObject(renderResources, instanceId) {
 
   if (defined(content)) {
     // For 3D Tiles, the pick object's content and primitive are set to the Cesium3DTileContent that owns the model
-    //and the parent tileset it belongs to, respectively. The detail pick object is returned under the detail key.
+    // and the tileset it belongs to, respectively. The detail pick object is returned under the detail key.
     pickObject = {
       content: content,
       primitive: content.tileset,
@@ -96,7 +96,7 @@ function buildPickObject(renderResources, instanceId) {
   }
 
   if (defined(instanceId)) {
-    // For instanced models, an instanceId property is attached.
+    // For instanced models, an instanceId property is added to the pick object.
     pickObject.instanceId = instanceId;
   }
 

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -248,7 +248,8 @@ describe(
         scene
       ).then(function (model) {
         expect(scene).toPickAndCall(function (result) {
-          expect(result.model).toEqual(model);
+          expect(result.primitive).toBeInstanceOf(ModelExperimental);
+          expect(result.primitive).toEqual(model);
         });
       });
     });

--- a/Specs/Scene/ModelExperimental/PickingPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/PickingPipelineStageSpec.js
@@ -105,6 +105,8 @@ describe("Scene/ModelExperimental/PickingPipelineStage", function () {
       shaderBuilder: new ShaderBuilder(),
       model: {
         _resources: [],
+        // Setting the content property here makes PickingPipelineStage handle this
+        // as part of a tileset.
         content: {
           tileset: {},
         },

--- a/Specs/Scene/ModelExperimental/PickingPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/PickingPipelineStageSpec.js
@@ -5,6 +5,7 @@ import {
   ShaderBuilder,
   Resource,
   ResourceCache,
+  defined,
 } from "../../../Source/Cesium.js";
 import createScene from "../../createScene.js";
 import ShaderBuilderTester from "../../ShaderBuilderTester.js";
@@ -70,7 +71,82 @@ describe("Scene/ModelExperimental/PickingPipelineStage", function () {
     }
   }
 
-  it("sets the picking variables in render resources", function () {
+  function verifyPickObject(pickObject, renderResources, instanceId) {
+    var model = renderResources.model;
+    var content = model.content;
+
+    expect(pickObject).toBeDefined();
+    if (defined(content)) {
+      // 3D Tiles case
+      expect(pickObject.primitive).toEqual(content.tileset);
+      expect(pickObject.content).toEqual(content);
+    } else {
+      // ModelExperimental case
+      expect(pickObject.primitive).toEqual(model);
+    }
+
+    if (defined(instanceId)) {
+      expect(pickObject.instanceId).toEqual(instanceId);
+    }
+
+    var detailPickObject = pickObject.detail;
+    expect(detailPickObject).toBeDefined();
+    expect(detailPickObject.model).toEqual(model);
+    expect(detailPickObject.node).toEqual(renderResources.runtimeNode);
+    expect(detailPickObject.primitive).toEqual(
+      renderResources.runtimePrimitive
+    );
+  }
+
+  it("sets the picking variables in render resources for 3D Tiles", function () {
+    var renderResources = {
+      attributeIndex: 1,
+      pickId: undefined,
+      shaderBuilder: new ShaderBuilder(),
+      model: {
+        _resources: [],
+        content: {
+          tileset: {},
+        },
+      },
+      runtimePrimitive: {},
+      runtimeNode: {
+        node: {},
+      },
+      uniformMap: {},
+    };
+
+    return loadGltf(boxVertexColors).then(function (gltfLoader) {
+      var components = gltfLoader.components;
+      var primitive = components.nodes[0].primitives[0];
+
+      var frameState = scene.frameState;
+      var context = frameState.context;
+      // Reset pick objects.
+      context._pickObjects = [];
+
+      PickingPipelineStage.process(renderResources, primitive, frameState);
+
+      var shaderBuilder = renderResources.shaderBuilder;
+      ShaderBuilderTester.expectHasFragmentUniforms(shaderBuilder, [
+        "uniform vec4 czm_pickColor;",
+      ]);
+
+      var pickObject =
+        context._pickObjects[Object.keys(context._pickObjects)[0]];
+      verifyPickObject(pickObject, renderResources);
+
+      var uniformMap = renderResources.uniformMap;
+      expect(uniformMap.czm_pickColor).toBeDefined();
+      expect(uniformMap.czm_pickColor()).toBeDefined();
+
+      expect(renderResources.model._resources.length).toEqual(1);
+
+      expect(renderResources.pickId).toEqual("czm_pickColor");
+    });
+  });
+
+  it("sets the picking variables in render resources for models", function () {
     var renderResources = {
       attributeIndex: 1,
       pickId: undefined,
@@ -103,11 +179,9 @@ describe("Scene/ModelExperimental/PickingPipelineStage", function () {
         "uniform vec4 czm_pickColor;",
       ]);
 
-      var pickObject = context._pickObjects["1"];
-      expect(pickObject).toBeDefined();
-      expect(pickObject.model).toBe(renderResources.model);
-      expect(pickObject.node).toBe(renderResources.runtimeNode);
-      expect(pickObject.primitive).toBe(renderResources.runtimePrimitive);
+      var pickObject =
+        context._pickObjects[Object.keys(context._pickObjects)[0]];
+      verifyPickObject(pickObject, renderResources);
 
       var uniformMap = renderResources.uniformMap;
       expect(uniformMap.czm_pickColor).toBeDefined();
@@ -142,6 +216,7 @@ describe("Scene/ModelExperimental/PickingPipelineStage", function () {
     return loadGltf(boxInstanced).then(function (gltfLoader) {
       var components = gltfLoader.components;
       var primitive = components.nodes[0].primitives[0];
+      renderResources.runtimeNode.node = components.nodes[0];
 
       var frameState = scene.frameState;
       var context = frameState.context;
@@ -162,11 +237,7 @@ describe("Scene/ModelExperimental/PickingPipelineStage", function () {
       for (var key in context._pickObjects) {
         if (context._pickObjects.hasOwnProperty(key)) {
           var pickObject = context._pickObjects[key];
-          expect(pickObject).toBeDefined();
-          expect(pickObject.model).toBe(renderResources.model);
-          expect(pickObject.node).toBe(renderResources.runtimeNode);
-          expect(pickObject.primitive).toBe(renderResources.runtimePrimitive);
-          expect(pickObject.instanceId).toEqual(i++);
+          verifyPickObject(pickObject, renderResources, i++);
         }
       }
 


### PR DESCRIPTION
This PR fixes https://github.com/CesiumGS/cesium/issues/9832 by changing the construction of the object(s) returned by `Scene.pick()` and `Scene.drillPick()`. It also adds a `detail` property to the pick object, allowing a user to discern which `model`, `node` and `primitive` are picked.

When loading a `Cesium3DTileset` without a feature table, the pick object is constructed as follows:
```jsonc
{
  "content": Cesium3DTileContent,
  "primitive": Cesium3DTileset,
  "detail": {
    "model": ModelExperimental,
    "node": ModelExperimentalNode,
    "primitive": ModelExperimentalPrimitive
  }
}
```

When loading a `ModelExperimental` without a feature table, the pick object is constructed as follows:
```jsonc
{
  "primitive": ModelExperimental,
  "detail": {
    "model": ModelExperimental,
    "node": ModelExperimentalNode,
    "primitive": ModelExperimentalPrimitive
  }
}
```

*The duplicated return of the model  in this object is a deliberate choice to preserve the structure of the `detail` object for all cases.*

When an instanced model is loaded, an `instanceId` property is also added to the top level object returned.

Use the following Sandcastles for testing:

1. [`ModelExperimental` without instancing](http://localhost:8080/Apps/Sandcastle/index.html#c=dVRdb9owFP0rVp6CxJzQ0rVjtNpKP7VWRYVtL5Em41yIV8eObCeFTf3vu3EgtJRJebCvzzk+98OpmCGVgGcw5JQoeCYjsKLM6Q8fC5OA+/1IK8eEApMEnc+JSlSFvEJb4YRWyFyzRsw4XDF1SOdG5xewMAA2TBQhH3oHhzQ+7vc/9j5160C/T+Oj+PA4/ui3vThOVK1dK2fFjp0bYKlQi7FwPHvUUoZxl9Tf1sxcLCG9MiyHqWHKzrXJt77akKVScyYbnL5qOdeAuTGnjfeaBEoblyVBt9k9g3VJ0Nhrbst1ChL1m9JRy5FPCyNyLEgFlrI09Urr++9r+OWyAEQAVlL68lxLNw//1jBCFrge4FXRpABuowvmWORZNhqfP0bnevldSeHaBa0Ja4OksXPPnBHLwZ6cs53qvc48bBRI283uJoBNaNdrzUspRWG1SOnP68lJvz3eU/zmqLMxKJTIy3yMODkRf2BAegcn/uyls6mrT4Ia9LoaY3WEBeoyUOG8VNyPWegRHeJLtq48xzsNo3O5mupzXao6z0mRgYEGTWdvgl2yrndaYrtRdEBietT4QBMv2w5nTKVy91VMOM6zmhSMw2WFjbxpQOGbMeAMBWyttNagFtytKkr31efRJoQOK6jnobNx5V+V4E8Ps9/A3bv5wpOWQzf9qi+quVwrqyXggC/CrYbPqvs//9NVAfTu8mr6a3R3O/pWg4NuMLRuJeFs09wvIi/wOZDSyJDSyEFeSIbPPJqV/Akc5dZuPAyj19RhKioi0tM9PxHCJbMWT+al9AORBGfDCPHvqFL72X2owEi2qmFZ7+yuCVJKhxFu9zOd1nLGzI7yPw)
2. [`ModelExperimental` with instancing](http://localhost:8080/Apps/Sandcastle/index.html#c=dVRdb9owFP0rVp6CRJ3Q0o8xWm2l0FajajXQ9hJpMs6FeHXsyHZS2NT/PttJoKVM4iG+95zjcz9MRRSqGLyAQpdIwAsagWZljn/4WJgE1J9HUhjCBKgk6HxORCIqyyukZoZJYZkNa0SUsV9EnOClkvkNrBSADhOB0FHv+ATH5/3+We9T1wX6fRyfxifn8Zk/9uI4EU7bKWfFnp07ICkTqydmaPZdch7GXeR+OzNLtoZ0okgOc0WEXkqV73xtQxpzSQmvcXKy5dyCrY0YqbzXJBBSmSwJuvXpBbRJgtpefVsuU+BWv24d1tTycaFYbhtSgcYkTb1Sc/+Dg4/XBVgE2E5y355bbpbhXwdDaGW/B/aqaFYA1dENMSTyLB052FSSFFR0Ldf3QhsiKKS+Jk7cAKIVn0+ihVwfsTZ7ZHZp7MSbYlBt/YEYxdaDA/3J9jr9tkthrYC2k++2ATuw7XejOeacFVqyFP+8nV30t+kDg6pTndYgEywv8yeL4zP2Bwaod3zhc6+ddga+CKys182T7STTgE0GIlyWgvqVDD2ig3x7mylRe6cieMk3c3ktS+HqnBUZKKjRePEu2EXNbNJS+T4OUIxPax/WxOtuGzIiUr7/gmbU7r6YFYTCuLJDv6tB4buVocQKaKfUaGAN5l4Upfnq69gWZB1W4Han07ryL5DR58fFb6Dmwy7azJaD23m5ixyXSqElB/sYVuFOw1fV/Z//+aYAPB1P5r9G0/vRNwcOusFQmw2Hq3a4X1he2KeDSsVDjCMDeWF3EHS0KOkzGEy1bj0Mo7fUYcoqxNLLA384iHKitc0sS+4XIgmuhpHFf6By6Xf3sQLFycbBst7VtA5ijIeRPR5mGin5gqg95X8)
3. [`Gltf3DTileContent` without features](http://localhost:8080/Apps/Sandcastle/index.html#c=bVJNb9QwEP0rQ05ZqbKFuNF0BUq3ULGoh11xslQ5zmRx64wj20nZov3v2EkK2dJLHM+89+bjuUSv+5ZtfnXodIsUpLlBGXqHniHJyuB3W6NZ5uEKguvxUpCy5AMMGp/QxSjhE5ST3o8xlotMjffSRqImdCJb/eUFbdBjOCdOx4fr/ZTMfwsC6J35CCLjuw6V59cySH6G419MaFKN2B8/mIrP0uzBWxKZoFOqKmjqlHmFhKyL8+ighziorOt8piTgDHu2tt3bZWKh4BBp10mFmyEW/SqpNimO4Za6PnxWQVvKm57GH7C0xSaURqvHPA3U2gHTMgWtYJxwkA66mL2rHlCllZy3mngvHNZZr5Nq6ghAN5C/m5dXYxOXXOf/lFazPoDDaCqNlFP6JA+sQWbsYYmPgNPFixm7V2Pujx2y7eZmf19ub8tvq8vsIit8OBpcT0UAPum2sy4ky3LGeMC2MzJEi6pePUZHlPdT3wAFX1KLWg+g66s3ngwoI72PmaY3ZqefUWTrgkf8f1RjZa3pcDegM/KYYD/fr7dTkDFW8Hh9mxmsNZV0r5T/AA)
4. [`Gltf3DTileContent` with features](http://localhost:8080/Apps/Sandcastle/index.html#c=bVLBbtswDP0VzicHKGQMva1usMFNsWIpekiwk4BBkehWrUwJkuwuHfLvk2K3c7pebJN875F8dINB9x1b/XbodYcUhblGEXuPgSGJncFbq9DM63AJ0fd4wUlaChEGjc/oU5bwGZpR7+cxV/JCHuPGJqIm9LxYvPGiNhgwnhLH1/nVdiyWfzgB9N58AV5UG4cyVFciiuoEV91iFCqnp9nf4qkHewyWeMHpkNtzGkdmQSIhc2kxHfWQNhZKlRMlAyfYi7Xd1s4LMwWPSBsnJK6G5M53QcrkPMYbcn38JqO2VLY9HT/A0hrb2Bgtn8q8WWcHzK5yWsBx1UF4cKl6t3tEmb05HTXzXjnM2aCzap4IQLdQfppcVNgmt1X5T2kx6QN4TA7RkXLIj3wMa5AZez/HJ8Dh7PUqm3drbvcO2Xp1vf3VrG+aH4uL4qyoQ9wbXI5NAL7qzlkf8+1KxqqInTMiplvtevmULiJDGOcGqKs5tVZ6AK0uP/h3QBoRQqq0vTEb/YK8WNZVwv9HNVYoTfd3A3oj9hn28Hm5HpOMsbpK4cfMaK3ZCf9O+S8)
5. [`Batched3DTileContent`](http://localhost:8080/Apps/Sandcastle/index.html#c=dVJta9swEP4rwp8cCPJKRxmbE1a8hIVlFJbQT4aiyJdWi3wn9OIuHf3vleIkS9ruk6x7Xu65sypwKrR88seAVS2gF3oKwgcLjgOKlYaf1IA+xdmIeRvgS401dsKyTsEj2FhFeGRV73e7q+V1Jnf3iqJQIdg6Gxx1Xmlw4M+F/XH5bdmD+d8aGQtWfz4QZoS/wFGwEvjaUnvtIm3W5B8/fLq6GgxrfN532CXgTgICNzG78qqLQ4mmyfedE3FPeyJql3QK9BkfBDb69XALaQFwYYSESRdX8r0n5WctpYgGLjntPXjKiSb4a+kVYb4O2H+01EHa7IDthmUsNTZKbm5Wv0Gm/ZzPEpGjhhtyKrmkRkkrCR1p4Jru838eCX0e/i//cmuAzyfT5V01n1U/EjkbZqXzWw3j3paxr6o1ZH36FznnhYfWaOHBFasgN+C5dO6QoSxOpWWjOqaa0TtvgUktnIvIOmi9UE9QZ+OyiPw3Uk2iUXh/04HVYptoDxfjeV/knJdFvL6v9ER6Jewr5xc)