### PR TITLE
Fixes crash on B3DMs without batch tables

### DIFF
--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -413,7 +413,7 @@ function initialize(content, arrayBuffer, byteOffset) {
   }
 
   var batchTable;
-  if (ExperimentalFeatures.enableModelExperimental) {
+  if (ExperimentalFeatures.enableModelExperimental && batchLength > 0) {
     var featureMetadata = parseBatchTable({
       count: batchLength,
       batchTable: batchTableJson,

--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -413,7 +413,11 @@ function initialize(content, arrayBuffer, byteOffset) {
   }
 
   var batchTable;
-  if (ExperimentalFeatures.enableModelExperimental && batchLength > 0) {
+  if (
+    ExperimentalFeatures.enableModelExperimental &&
+    batchLength > 0 &&
+    defined(batchTableJson)
+  ) {
     var featureMetadata = parseBatchTable({
       count: batchLength,
       batchTable: batchTableJson,

--- a/Specs/Scene/Batched3DModel3DTileContentSpec.js
+++ b/Specs/Scene/Batched3DModel3DTileContentSpec.js
@@ -470,12 +470,21 @@ describe(
         ExperimentalFeatures.enableModelExperimental = false;
       });
 
-      it("renders B3DM content", function () {
+      it("renders B3DM content with batch table", function () {
         return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl).then(
           function (tileset) {
             Cesium3DTilesTester.expectRender(scene, tileset);
           }
         );
+      });
+
+      it("renders B3DM content without batch table", function () {
+        return Cesium3DTilesTester.loadTileset(
+          scene,
+          withoutBatchTableUrl
+        ).then(function (tileset) {
+          Cesium3DTilesTester.expectRender(scene, tileset);
+        });
       });
 
       it("assigns feature table as batch table", function () {


### PR DESCRIPTION
This is a small fix that adds a condition to check whether a batch table is present in a B3DM before calling `parseBatchTable` for `ModelExperimental`

[Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=bVLbbptAEP2VkfuCK3dNeokq27Faua0aqVWixGpfeMEwtldddtBecJzK/56BBUrcwAPM7Jk558zsCq30hfj6UKKRBWqXqm+YOm/QCtTpRuFPylENz+EKnPE4T3SVGqgkHtBwTuMBVqHbryYXJaOsiVfEZVKjSUYT+JtoAIfGcObWUCVzNLOuMDPMjb/JqHwdINF4kujTmMnCW1M6qdCie84ZPu++rMNh1PAAeKP67tek79CSNxmKraHis2XgdR69jz9eXo5bmra5YCX5kQUW0mLdSrg96mjrdeYkaYha3BhaojAHYTPUKEqelXSy4iGmed5j58+gj0TFmqKQg87VpIsH3r6zFql3t9Jl+7tU77AvAohFPPkXvYnFh0HYmdmQ13WH+3KPBoXhdt7Ca3gr4g48Dj9B46mJBLFnc+ABDHzzWsj0rjPSlhQKRbv2pK1vFjaajBbWHRUuO5ZPsijJuHotkRBTh0WpeON2uvHZHxaaWdtNCeDVQeY7dP316UjrpyQra0EzSDeswDucD2xTOYOLuHwY5BRu3VnyFH4W06HGRS4rkPnVC5cXMpVayydbr9S9fMRktFxMGf9fqaJmYTcVGpUea9j+YvkjJIUQiymHL1eeWT5jeAI)