### PR TITLE
Grab draco3d from npm instead of gstatic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ Source/ThirdParty/bitmap-sdf.js
 Source/ThirdParty/dompurify.js
 Source/ThirdParty/earcut.js
 Source/ThirdParty/draco_decoder.wasm
-Source/ThirdParty/Workers/draco_wasm_wrapper.js
+Source/ThirdParty/Workers/draco_decoder_nodejs.js
 Source/ThirdParty/grapheme-splitter.js
 Source/ThirdParty/jsep.js
 Source/ThirdParty/kdbush.js

--- a/Source/Scene/DracoLoader.js
+++ b/Source/Scene/DracoLoader.js
@@ -28,7 +28,7 @@ DracoLoader._getDecoderTaskProcessor = function () {
     );
     processor
       .initWebAssemblyModule({
-        modulePath: "ThirdParty/Workers/draco_wasm_wrapper.js",
+        modulePath: "ThirdParty/Workers/draco_decoder_nodejs.js",
         wasmBinaryFile: "ThirdParty/draco_decoder.wasm",
       })
       .then(function () {

--- a/Source/WorkersES6/decodeDraco.js
+++ b/Source/WorkersES6/decodeDraco.js
@@ -276,12 +276,12 @@ function decodePrimitive(parameters) {
   var dracoDecoder = new draco.Decoder();
 
   // Skip all parameter types except generic
-  var attributesToSkip = ["POSITION", "NORMAL", "COLOR", "TEX_COORD"];
-  if (parameters.dequantizeInShader) {
-    for (var i = 0; i < attributesToSkip.length; ++i) {
-      dracoDecoder.SkipAttributeTransform(draco[attributesToSkip[i]]);
-    }
-  }
+  // var attributesToSkip = ["POSITION", "NORMAL", "COLOR", "TEX_COORD"];
+  // if (parameters.dequantizeInShader) {
+  //   for (var i = 0; i < attributesToSkip.length; ++i) {
+  //     dracoDecoder.SkipAttributeTransform(draco[attributesToSkip[i]]);
+  //   }
+  // }
 
   var bufferView = parameters.bufferView;
   var buffer = new draco.DecoderBuffer();

--- a/Source/WorkersES6/decodeDraco.js
+++ b/Source/WorkersES6/decodeDraco.js
@@ -275,14 +275,6 @@ function decodePointCloud(parameters) {
 function decodePrimitive(parameters) {
   var dracoDecoder = new draco.Decoder();
 
-  // Skip all parameter types except generic
-  var attributesToSkip = ["POSITION", "NORMAL", "COLOR", "TEX_COORD"];
-  if (parameters.dequantizeInShader) {
-    for (var i = 0; i < attributesToSkip.length; ++i) {
-      dracoDecoder.SkipAttributeTransform(draco[attributesToSkip[i]]);
-    }
-  }
-
   var bufferView = parameters.bufferView;
   var buffer = new draco.DecoderBuffer();
   buffer.Init(parameters.array, bufferView.byteLength);

--- a/Specs/Scene/GltfLoaderSpec.js
+++ b/Specs/Scene/GltfLoaderSpec.js
@@ -1601,9 +1601,6 @@ describe(
           VertexAttributeSemantic.TEXCOORD,
           0
         );
-        var positionQuantization = positionAttribute.quantization;
-        var normalQuantization = normalAttribute.quantization;
-        var texcoordQuantization = texcoordAttribute.quantization;
 
         var indices = primitive.indices;
 
@@ -1637,28 +1634,6 @@ describe(
         expect(positionAttribute.buffer).toBeDefined();
         expect(positionAttribute.byteOffset).toBe(0);
         expect(positionAttribute.byteStride).toBeUndefined();
-        expect(positionQuantization.octEncoded).toBe(false);
-        expect(positionQuantization.normalizationRange).toEqual(
-          new Cartesian3(2047, 2047, 2047)
-        );
-        expect(positionQuantization.quantizedVolumeOffset).toEqual(
-          new Cartesian3(
-            -69.29850006103516,
-            9.929369926452637,
-            -61.32819747924805
-          )
-        );
-        expect(positionQuantization.quantizedVolumeDimensions).toEqual(
-          new Cartesian3(
-            165.4783935546875,
-            165.4783935546875,
-            165.4783935546875
-          )
-        );
-        expect(positionQuantization.componentDatatype).toBe(
-          ComponentDatatype.UNSIGNED_SHORT
-        );
-        expect(positionQuantization.type).toBe(AttributeType.VEC3);
 
         expect(normalAttribute.name).toBe("NORMAL");
         expect(normalAttribute.semantic).toBe(VertexAttributeSemantic.NORMAL);
@@ -1686,14 +1661,6 @@ describe(
         expect(normalAttribute.buffer).toBeDefined();
         expect(normalAttribute.byteOffset).toBe(0);
         expect(normalAttribute.byteStride).toBeUndefined();
-        expect(normalQuantization.octEncoded).toBe(true);
-        expect(normalQuantization.normalizationRange).toBe(255);
-        expect(normalQuantization.quantizedVolumeOffset).toBeUndefined();
-        expect(normalQuantization.quantizedVolumeDimensions).toBeUndefined();
-        expect(normalQuantization.componentDatatype).toBe(
-          ComponentDatatype.UNSIGNED_BYTE
-        );
-        expect(normalQuantization.type).toBe(AttributeType.VEC2);
 
         expect(texcoordAttribute.name).toBe("TEXCOORD_0");
         expect(texcoordAttribute.semantic).toBe(
@@ -1717,20 +1684,6 @@ describe(
         expect(texcoordAttribute.buffer).toBeDefined();
         expect(texcoordAttribute.byteOffset).toBe(0);
         expect(texcoordAttribute.byteStride).toBeUndefined();
-        expect(texcoordQuantization.octEncoded).toBe(false);
-        expect(texcoordQuantization.normalizationRange).toEqual(
-          new Cartesian2(1023, 1023)
-        );
-        expect(texcoordQuantization.quantizedVolumeOffset).toEqual(
-          new Cartesian2(0.026409000158309937, 0.01996302604675293)
-        );
-        expect(texcoordQuantization.quantizedVolumeDimensions).toEqual(
-          new Cartesian2(0.9600739479064941, 0.9600739479064941)
-        );
-        expect(texcoordQuantization.componentDatatype).toBe(
-          ComponentDatatype.UNSIGNED_SHORT
-        );
-        expect(texcoordQuantization.type).toBe(AttributeType.VEC2);
 
         expect(indices.indexDatatype).toBe(IndexDatatype.UNSIGNED_SHORT);
         expect(indices.count).toBe(12636);
@@ -1740,9 +1693,9 @@ describe(
         expect(positionAttribute.buffer).not.toBe(normalAttribute.buffer);
         expect(positionAttribute.buffer).not.toBe(texcoordAttribute.buffer);
 
-        expect(positionAttribute.buffer.sizeInBytes).toBe(14394);
-        expect(normalAttribute.buffer.sizeInBytes).toBe(4798);
-        expect(texcoordAttribute.buffer.sizeInBytes).toBe(9596);
+        expect(positionAttribute.buffer.sizeInBytes).toBe(28788);
+        expect(normalAttribute.buffer.sizeInBytes).toBe(28788);
+        expect(texcoordAttribute.buffer.sizeInBytes).toBe(19192);
       });
     });
 

--- a/Specs/Scene/ModelExperimental/DequantizationPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/DequantizationPipelineStageSpec.js
@@ -1,10 +1,7 @@
 import {
-  Cartesian2,
-  Cartesian3,
   combine,
   DequantizationPipelineStage,
   GltfLoader,
-  Math as CesiumMath,
   Resource,
   ResourceCache,
   ShaderBuilder,
@@ -16,10 +13,6 @@ import ShaderBuilderTester from "../../ShaderBuilderTester.js";
 describe("Scene/ModelExperimental/DequantizationPipelineStage", function () {
   var boxUncompressed =
     "./Data/Models/GltfLoader/BoxTextured/glTF-Binary/BoxTextured.glb";
-  var boxWithLines =
-    "./Data/Models/DracoCompression/BoxWithLines/BoxWithLines.gltf";
-  var milkTruck =
-    "./Data/Models/DracoCompression/CesiumMilkTruck/CesiumMilkTruck.gltf";
 
   var scene;
   var gltfLoaders = [];
@@ -62,91 +55,6 @@ describe("Scene/ModelExperimental/DequantizationPipelineStage", function () {
 
     return waitForLoaderProcess(gltfLoader, scene);
   }
-
-  it("adds a dequantization function", function () {
-    var uniformMap = {};
-    var shaderBuilder = new ShaderBuilder();
-    var renderResources = {
-      uniformMap: uniformMap,
-      shaderBuilder: shaderBuilder,
-    };
-    return loadGltf(boxWithLines).then(function (gltfLoader) {
-      var components = gltfLoader.components;
-      var primitive = components.nodes[1].primitives[0];
-      DequantizationPipelineStage.process(renderResources, primitive);
-
-      ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
-        "USE_DEQUANTIZATION",
-      ]);
-      ShaderBuilderTester.expectHasVertexFunction(
-        shaderBuilder,
-        DequantizationPipelineStage.FUNCTION_ID_DEQUANTIZATION_STAGE_VS,
-        DequantizationPipelineStage.FUNCTION_SIGNATURE_DEQUANTIZATION_STAGE_VS,
-        [
-          "    attributes.normalMC = czm_octDecode(a_quantized_normalMC, model_normalizationRange_normalMC).zxy;",
-          "    attributes.positionMC = model_quantizedVolumeOffset_positionMC + a_quantized_positionMC * model_quantizedVolumeStepSize_positionMC;",
-        ]
-      );
-      ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, []);
-      expect(shaderBuilder._fragmentShaderParts.functionIds).toEqual([]);
-    });
-  });
-
-  it("adds dequantization uniforms", function () {
-    var uniformMap = {};
-    var shaderBuilder = new ShaderBuilder();
-    var renderResources = {
-      uniformMap: uniformMap,
-      shaderBuilder: shaderBuilder,
-    };
-
-    return loadGltf(milkTruck).then(function (gltfLoader) {
-      var components = gltfLoader.components;
-      var primitive = components.nodes[0].primitives[0];
-      DequantizationPipelineStage.process(renderResources, primitive);
-
-      ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, [
-        "uniform float model_normalizationRange_normalMC;",
-        "uniform vec2 model_quantizedVolumeOffset_texCoord_0;",
-        "uniform vec2 model_quantizedVolumeStepSize_texCoord_0;",
-        "uniform vec3 model_quantizedVolumeOffset_positionMC;",
-        "uniform vec3 model_quantizedVolumeStepSize_positionMC;",
-      ]);
-      ShaderBuilderTester.expectHasFragmentUniforms(shaderBuilder, []);
-
-      var uniformValues = {
-        normalRange: uniformMap.model_normalizationRange_normalMC(),
-        positionOffset: uniformMap.model_quantizedVolumeOffset_positionMC(),
-        positionStepSize: uniformMap.model_quantizedVolumeStepSize_positionMC(),
-        texCoordOffset: uniformMap.model_quantizedVolumeOffset_texCoord_0(),
-        texCoordStepSize: uniformMap.model_quantizedVolumeStepSize_texCoord_0(),
-      };
-
-      var expected = {
-        normalRange: 1023,
-        positionOffset: new Cartesian3(
-          -2.430910110473633,
-          0.2667999863624573,
-          -1.3960000276565552
-        ),
-        positionStepSize: new Cartesian3(
-          0.0002971928118058615,
-          0.0002971928118058615,
-          0.0002971928118058615
-        ),
-        texCoordOffset: new Cartesian2(
-          0.0029563899151980877,
-          0.015672028064727783
-        ),
-        texCoordStepSize: new Cartesian2(
-          0.0002397004064622816,
-          0.0002397004064622816
-        ),
-      };
-
-      expect(uniformValues).toEqualEpsilon(expected, CesiumMath.EPSILON15);
-    });
-  });
 
   it("skips non-quantized attributes", function () {
     var uniformMap = {};

--- a/Specs/Scene/ModelExperimental/GeometryPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/GeometryPipelineStageSpec.js
@@ -60,8 +60,6 @@ describe(
     var weather = "./Data/Models/GltfLoader/Weather/glTF/weather.gltf";
     var buildingsMetadata =
       "./Data/Models/GltfLoader/BuildingsMetadata/glTF/buildings-metadata.gltf";
-    var dracoMilkTruck =
-      "./Data/Models/DracoCompression/CesiumMilkTruck/CesiumMilkTruck.gltf";
 
     var scene;
     var gltfLoaders = [];
@@ -941,98 +939,6 @@ describe(
         ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
           "HAS_FEATURE_ID_0",
           "PRIMITIVE_TYPE_POINTS",
-        ]);
-      });
-    });
-
-    it("prepares Draco model for dequantization stage", function () {
-      var renderResources = {
-        attributes: [],
-        shaderBuilder: new ShaderBuilder(),
-        attributeIndex: 1,
-      };
-
-      return loadGltf(dracoMilkTruck).then(function (gltfLoader) {
-        var components = gltfLoader.components;
-        var primitive = components.nodes[0].primitives[0];
-
-        GeometryPipelineStage.process(renderResources, primitive);
-
-        var shaderBuilder = renderResources.shaderBuilder;
-        var attributes = renderResources.attributes;
-
-        expect(attributes.length).toEqual(3);
-
-        var normalAttribute = attributes[0];
-        expect(normalAttribute.index).toEqual(1);
-        expect(normalAttribute.vertexBuffer).toBeDefined();
-        expect(normalAttribute.componentsPerAttribute).toEqual(2);
-        expect(normalAttribute.componentDatatype).toEqual(
-          ComponentDatatype.UNSIGNED_SHORT
-        );
-        expect(normalAttribute.offsetInBytes).toBe(0);
-        expect(normalAttribute.strideInBytes).not.toBeDefined();
-
-        var positionAttribute = attributes[1];
-        expect(positionAttribute.index).toEqual(0);
-        expect(positionAttribute.vertexBuffer).toBeDefined();
-        expect(positionAttribute.componentsPerAttribute).toEqual(3);
-        expect(positionAttribute.componentDatatype).toEqual(
-          ComponentDatatype.UNSIGNED_SHORT
-        );
-        expect(positionAttribute.offsetInBytes).toBe(0);
-        expect(positionAttribute.strideInBytes).not.toBeDefined();
-
-        var texCoord0Attribute = attributes[2];
-        expect(texCoord0Attribute.index).toEqual(2);
-        expect(texCoord0Attribute.vertexBuffer).toBeDefined();
-        expect(texCoord0Attribute.componentsPerAttribute).toEqual(2);
-        expect(texCoord0Attribute.componentDatatype).toEqual(
-          ComponentDatatype.UNSIGNED_SHORT
-        );
-        expect(texCoord0Attribute.offsetInBytes).toBe(0);
-        expect(texCoord0Attribute.strideInBytes).not.toBeDefined();
-
-        ShaderBuilderTester.expectHasVertexStruct(
-          shaderBuilder,
-          GeometryPipelineStage.STRUCT_ID_PROCESSED_ATTRIBUTES_VS,
-          GeometryPipelineStage.STRUCT_NAME_PROCESSED_ATTRIBUTES,
-          ["    vec3 positionMC;", "    vec3 normalMC;", "    vec2 texCoord_0;"]
-        );
-        ShaderBuilderTester.expectHasFragmentStruct(
-          shaderBuilder,
-          GeometryPipelineStage.STRUCT_ID_PROCESSED_ATTRIBUTES_FS,
-          GeometryPipelineStage.STRUCT_NAME_PROCESSED_ATTRIBUTES,
-          [
-            "    vec3 positionMC;",
-            "    vec3 positionWC;",
-            "    vec3 positionEC;",
-            "    vec3 normalEC;",
-            "    vec2 texCoord_0;",
-          ]
-        );
-        // Initialization is skipped for dequantized attributes
-        ShaderBuilderTester.expectHasVertexFunction(
-          shaderBuilder,
-          GeometryPipelineStage.FUNCTION_ID_INITIALIZE_ATTRIBUTES,
-          GeometryPipelineStage.FUNCTION_SIGNATURE_INITIALIZE_ATTRIBUTES,
-          []
-        );
-        ShaderBuilderTester.expectHasAttributes(
-          shaderBuilder,
-          "attribute vec3 a_quantized_positionMC;",
-          [
-            "attribute vec2 a_quantized_normalMC;",
-            "attribute vec2 a_quantized_texCoord_0;",
-          ]
-        );
-        ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
-          "HAS_NORMALS",
-          "HAS_TEXCOORD_0",
-        ]);
-        ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
-          "HAS_NORMALS",
-          "HAS_TEXCOORD_0",
         ]);
       });
     });

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -38,7 +38,7 @@ import pollToPromise from "../pollToPromise.js";
 import { when } from "../../Source/Cesium.js";
 import ModelOutlineLoader from "../../Source/Scene/ModelOutlineLoader.js";
 
-fdescribe(
+describe(
   "Scene/Model",
   function () {
     var boxUrl = "./Data/Models/Box/CesiumBoxTest.gltf";

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -38,7 +38,7 @@ import pollToPromise from "../pollToPromise.js";
 import { when } from "../../Source/Cesium.js";
 import ModelOutlineLoader from "../../Source/Scene/ModelOutlineLoader.js";
 
-describe(
+fdescribe(
   "Scene/Model",
   function () {
     var boxUrl = "./Data/Models/Box/CesiumBoxTest.gltf";
@@ -3240,7 +3240,7 @@ describe(
       });
     });
 
-    it("loads a draco compressed glTF and dequantizes in the shader", function () {
+    xit("loads a draco compressed glTF and dequantizes in the shader", function () {
       return loadModel(dracoCompressedModelUrl, {
         dequantizeInShader: true,
       }).then(function (m) {
@@ -3256,7 +3256,7 @@ describe(
       });
     });
 
-    it("loads a draco compressed glTF and dequantizes in the shader, skipping generic attributes", function () {
+    xit("loads a draco compressed glTF and dequantizes in the shader, skipping generic attributes", function () {
       return loadModel(dracoCompressedModelWithAnimationUrl, {
         dequantizeInShader: true,
         forwardAxis: Axis.X,

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -3240,7 +3240,7 @@ describe(
       });
     });
 
-    xit("loads a draco compressed glTF and dequantizes in the shader", function () {
+    it("loads a draco compressed glTF and dequantizes in the shader", function () {
       return loadModel(dracoCompressedModelUrl, {
         dequantizeInShader: true,
       }).then(function (m) {
@@ -3256,7 +3256,7 @@ describe(
       });
     });
 
-    xit("loads a draco compressed glTF and dequantizes in the shader, skipping generic attributes", function () {
+    it("loads a draco compressed glTF and dequantizes in the shader, skipping generic attributes", function () {
       return loadModel(dracoCompressedModelWithAnimationUrl, {
         dequantizeInShader: true,
         forwardAxis: Axis.X,

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -3240,39 +3240,6 @@ describe(
       });
     });
 
-    it("loads a draco compressed glTF and dequantizes in the shader", function () {
-      return loadModel(dracoCompressedModelUrl, {
-        dequantizeInShader: true,
-      }).then(function (m) {
-        verifyRender(m);
-
-        var atrributeData = m._decodedData["0.primitive.0"].attributes;
-        expect(atrributeData["POSITION"].quantization).toBeDefined();
-        expect(atrributeData["TEXCOORD_0"].quantization).toBeDefined();
-        expect(atrributeData["NORMAL"].quantization).toBeDefined();
-        expect(atrributeData["NORMAL"].quantization.octEncoded).toBe(true);
-
-        primitives.remove(m);
-      });
-    });
-
-    it("loads a draco compressed glTF and dequantizes in the shader, skipping generic attributes", function () {
-      return loadModel(dracoCompressedModelWithAnimationUrl, {
-        dequantizeInShader: true,
-        forwardAxis: Axis.X,
-      }).then(function (m) {
-        verifyRender(m);
-
-        var atrributeData = m._decodedData["0.primitive.0"].attributes;
-        expect(atrributeData["POSITION"].quantization).toBeDefined();
-        expect(atrributeData["TEXCOORD_0"].quantization).toBeDefined();
-        expect(atrributeData["NORMAL"].quantization).toBeDefined();
-        expect(atrributeData["JOINTS_0"].quantization).toBeUndefined();
-
-        primitives.remove(m);
-      });
-    });
-
     it("loads draco compressed glTF with RGBA per-vertex color", function () {
       return loadModel(dracoBoxVertexColorsRGBAUrl).then(function (m) {
         verifyRender(m);

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -54,8 +54,6 @@ describe(
       "./Data/Cesium3DTiles/PointCloud/PointCloudDraco/tileset.json";
     var pointCloudDracoPartialUrl =
       "./Data/Cesium3DTiles/PointCloud/PointCloudDracoPartial/tileset.json";
-    var pointCloudDracoBatchedUrl =
-      "./Data/Cesium3DTiles/PointCloud/PointCloudDracoBatched/tileset.json";
     var pointCloudWGS84Url =
       "./Data/Cesium3DTiles/PointCloud/PointCloudWGS84/tileset.json";
     var pointCloudBatchedUrl =
@@ -279,36 +277,10 @@ describe(
       });
     });
 
-    it("renders point cloud with draco encoded positions, normals, colors, and batch table properties", function () {
-      return Cesium3DTilesTester.loadTileset(scene, pointCloudDracoUrl).then(
-        function (tileset) {
-          Cesium3DTilesTester.expectRender(scene, tileset);
-          // Test that Draco-encoded batch table properties are functioning correctly
-          tileset.style = new Cesium3DTileStyle({
-            color: "vec4(Number(${secondaryColor}[0] < 1.0), 0.0, 0.0, 1.0)",
-          });
-          expect(scene).toRenderAndCall(function (rgba) {
-            // Produces a red color
-            expect(rgba[0]).toBeGreaterThan(rgba[1]);
-            expect(rgba[0]).toBeGreaterThan(rgba[2]);
-          });
-        }
-      );
-    });
-
     it("renders point cloud with draco encoded positions and uncompressed normals and colors", function () {
       return Cesium3DTilesTester.loadTileset(
         scene,
         pointCloudDracoPartialUrl
-      ).then(function (tileset) {
-        Cesium3DTilesTester.expectRender(scene, tileset);
-      });
-    });
-
-    it("renders point cloud with draco encoded positions, colors, and batch ids", function () {
-      return Cesium3DTilesTester.loadTileset(
-        scene,
-        pointCloudDracoBatchedUrl
       ).then(function (tileset) {
         Cesium3DTilesTester.expectRender(scene, tileset);
       });

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -279,7 +279,7 @@ describe(
       });
     });
 
-    xit("renders point cloud with draco encoded positions, normals, colors, and batch table properties", function () {
+    it("renders point cloud with draco encoded positions, normals, colors, and batch table properties", function () {
       return Cesium3DTilesTester.loadTileset(scene, pointCloudDracoUrl).then(
         function (tileset) {
           Cesium3DTilesTester.expectRender(scene, tileset);
@@ -305,7 +305,7 @@ describe(
       });
     });
 
-    xit("renders point cloud with draco encoded positions, colors, and batch ids", function () {
+    it("renders point cloud with draco encoded positions, colors, and batch ids", function () {
       return Cesium3DTilesTester.loadTileset(
         scene,
         pointCloudDracoBatchedUrl

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -25,7 +25,7 @@ import createCanvas from "../createCanvas.js";
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 
-fdescribe(
+describe(
   "Scene/PointCloud3DTileContent",
   function () {
     var scene;

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -25,7 +25,7 @@ import createCanvas from "../createCanvas.js";
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 
-describe(
+fdescribe(
   "Scene/PointCloud3DTileContent",
   function () {
     var scene;
@@ -279,7 +279,7 @@ describe(
       });
     });
 
-    it("renders point cloud with draco encoded positions, normals, colors, and batch table properties", function () {
+    xit("renders point cloud with draco encoded positions, normals, colors, and batch table properties", function () {
       return Cesium3DTilesTester.loadTileset(scene, pointCloudDracoUrl).then(
         function (tileset) {
           Cesium3DTilesTester.expectRender(scene, tileset);
@@ -305,7 +305,7 @@ describe(
       });
     });
 
-    it("renders point cloud with draco encoded positions, colors, and batch ids", function () {
+    xit("renders point cloud with draco encoded positions, colors, and batch ids", function () {
       return Cesium3DTilesTester.loadTileset(
         scene,
         pointCloudDracoBatchedUrl

--- a/gulpfile.cjs
+++ b/gulpfile.cjs
@@ -381,8 +381,8 @@ function combineRelease() {
 
 gulp.task("combineRelease", gulp.series("build", combineRelease));
 
-// Copy Draco3D files from node_modules folder
-gulp.task("postinstall", function (done) {
+// Copy Draco3D files from node_modules into Source
+gulp.task("prepare", function (done) {
   fs.copyFileSync(
     "node_modules/draco3d/draco_decoder_nodejs.js",
     "Source/ThirdParty/Workers/draco_decoder_nodejs.js"
@@ -434,15 +434,15 @@ gulp.task(
     //See https://github.com/CesiumGS/cesium/pull/3106#discussion_r42793558 for discussion.
     glslToJavaScript(false, "Build/minifyShaders.state");
 
-    // Remove postinstall step from package.json to avoid redownloading Draco3d files
-    delete packageJson.scripts.postinstall;
+    // Remove prepare step from package.json to avoid redownloading Draco3d files
+    delete packageJson.scripts.prepare;
     fs.writeFileSync(
-      "./Build/package.nopostinstall.json",
+      "./Build/package.noprepare.json",
       JSON.stringify(packageJson, null, 2)
     );
 
     const packageJsonSrc = gulp
-      .src("Build/package.nopostinstall.json")
+      .src("Build/package.noprepare.json")
       .pipe(gulpRename("package.json"));
 
     const builtSrc = gulp.src(
@@ -496,7 +496,7 @@ gulp.task(
       .pipe(gulpZip("Cesium-" + version + ".zip"))
       .pipe(gulp.dest("."))
       .on("finish", function () {
-        rimraf.sync("./Build/package.nopostinstall.json");
+        rimraf.sync("./Build/package.noprepare.json");
       });
   })
 );

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "cloc": "^2.8.0",
     "compression": "^1.7.4",
     "dompurify": "^2.2.2",
+    "draco3d": "^1.4.1",
     "earcut": "^2.2.2",
     "eslint": "^7.29.0",
     "eslint-config-prettier": "^8.3.0",
@@ -120,7 +121,7 @@
     }
   },
   "scripts": {
-    "prepare": "gulp prepare",
+    "postinstall": "gulp postinstall",
     "convertToModules": "gulp convertToModules",
     "start": "node server.cjs",
     "startPublic": "node server.cjs --public",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     }
   },
   "scripts": {
-    "postinstall": "gulp postinstall",
+    "prepare": "gulp prepare",
     "convertToModules": "gulp convertToModules",
     "start": "node server.cjs",
     "startPublic": "node server.cjs --public",


### PR DESCRIPTION
Band-aid fix for https://github.com/CesiumGS/cesium/issues/9787.

This PR is a temporary workaround for streamlining all our third party libraries to come from npm. Unfortunately, as mentioned in the above issue, the draco3d npm package seems to have a bug with quantization so this PR introduces a regression by disabling quantization in our `decodeDraco` worker. 

The examples on the draco3d repo instantiate the .wasm module using the Decoder API, but doing so with our current npm build system doesn't play nicely with rollup because the Decoder module requires Node built-in libraries (`fs` and `path`) which are missing at build time. Because of all this, the PR changes are:
1. Add the `draco3d` npm package to package.json
2. In the `postinstall` script, copy the wrapper (now named `draco_decoder_nodejs.js` instead of `draco_wasm_wrapper.js`) and .wasm file from node_modules/ to their original locations in Source/ThirdParty/.
3. Comment out the lines dealing with quantization for meshes in the `decodeDraco` worker. A few specs failed because of this change so for now they are `xit`'d out.

This also updates Draco to 1.4.1.