### PR TITLE
Fix articulated model CZML Sandcastle example

### DIFF
--- a/Apps/Sandcastle/gallery/CZML Model Articulations.html
+++ b/Apps/Sandcastle/gallery/CZML Model Articulations.html
@@ -53,7 +53,8 @@
               cartographicDegrees: [-77, 37, 10000],
             },
             model: {
-              gltf: "https://assets.agi.com/models/launchvehicle.glb",
+              gltf:
+                "https://cesium.com/public/SandcastleSampleData/launchvehicle.glb",
               scale: 2.0,
               minimumPixelSize: 128,
               runAnimations: false,


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/9855

It looks like there `assets.agi.com` no longer has CORS enabled so https://sandcastle.cesium.com/?src=CZML%20Model%20Articulations.html&label=CZML can't load the sample model.  I put a copy on cesium.com/public/SandcastleSampleData instead.