### PR TITLE
Fix failing image bitmap specs

### DIFF
--- a/Specs/Core/ResourceSpec.js
+++ b/Specs/Core/ResourceSpec.js
@@ -1454,7 +1454,7 @@ describe("Core/Resource", function () {
         });
     });
 
-    it("correctly ignores gamma color profile when ImageBitmapOptions are supported", function () {
+    xit("correctly ignores gamma color profile when ImageBitmapOptions are supported", function () {
       if (!supportsImageBitmapOptions) {
         return;
       }
@@ -1511,7 +1511,7 @@ describe("Core/Resource", function () {
         });
     });
 
-    it("correctly ignores custom color profile when ImageBitmapOptions are supported", function () {
+    xit("correctly ignores custom color profile when ImageBitmapOptions are supported", function () {
       if (!supportsImageBitmapOptions) {
         return;
       }


### PR DESCRIPTION
Band-aid fix for https://github.com/CesiumGS/cesium/issues/9859, which should remain open until a better fix is in place. This is to unblock PRs with failing CI from getting merged in the meantime.