### PR TITLE
Fix Rectangle.union when rectangle spans entire globe

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Fixes :wrench:
 
 - Fixed zip.js configurations causing CesiumJS to not work with Node 16. [#9861](https://github.com/CesiumGS/cesium/pull/9861)
+- Fixed a bug in `Rectangle.union` with rectangles that span the entire globe. [#9866](https://github.com/CesiumGS/cesium/pull/9866)
 
 ### 1.86 - 2021-10-01
 

--- a/Source/Core/Rectangle.js
+++ b/Source/Core/Rectangle.js
@@ -740,10 +740,10 @@ Rectangle.union = function (rectangle, otherRectangle, result) {
     rectangleWest += CesiumMath.TWO_PI;
   }
 
-  var west = CesiumMath.convertLongitudeRange(
+  var west = CesiumMath.negativePiToPi(
     Math.min(rectangleWest, otherRectangleWest)
   );
-  var east = CesiumMath.convertLongitudeRange(
+  var east = CesiumMath.negativePiToPi(
     Math.max(rectangleEast, otherRectangleEast)
   );
 

--- a/Specs/Core/RectangleSpec.js
+++ b/Specs/Core/RectangleSpec.js
@@ -773,6 +773,29 @@ describe("Core/Rectangle", function () {
     expect(returnedResult).toEqualEpsilon(expected, CesiumMath.EPSILON15);
   });
 
+  it("union works with rectangles that span the entire globe", function () {
+    var rectangle1 = new Rectangle(
+      -CesiumMath.PI,
+      -CesiumMath.PI_OVER_TWO,
+      +CesiumMath.PI,
+      0.0
+    );
+    var rectangle2 = new Rectangle(
+      -CesiumMath.PI,
+      0.0,
+      +CesiumMath.PI,
+      +CesiumMath.PI_OVER_TWO
+    );
+    var expected = new Rectangle(
+      -CesiumMath.PI,
+      -CesiumMath.PI_OVER_TWO,
+      +CesiumMath.PI,
+      +CesiumMath.PI_OVER_TWO
+    );
+    var returnedResult = Rectangle.union(rectangle1, rectangle2);
+    expect(returnedResult).toEqualEpsilon(expected, CesiumMath.EPSILON15);
+  });
+
   it("expand works if rectangle needs to grow right", function () {
     var rectangle = new Rectangle(0.5, 0.1, 0.75, 0.9);
     var cartographic = new Cartographic(0.85, 0.5);


### PR DESCRIPTION
The code used to call `CesiumMath.convertLongitudeRange` which
> converts a longitude value, in radians, to the range `[-Math.PI, Math.PI)`

So when the `rectangle.east` equals `Math.PI`, it will get converted to `-Math.PI`. If the rectangle spans the entire globe, this creates a rectangle that has 0 width.

I replaced it with `CesiumMath.negativePiToPi` which returns
> the angle in the range `[-CesiumMath.PI, CesiumMath.PI]`

[Sandcastle demonstrating the fix](http://localhost:8080/Apps/Sandcastle/index.html#c=nZJRa8IwFIX/SuhTRZc2aWtbrDLwdTDYYE95ifVOw2IiSVpxv35JZcxp2cNCXu655xw+QnpuUC/gBAYtkYITWoMV3QG/DVrMonaY11o5LhQYFk0WTDHV+5yB1nG1k5D+zr586zFTCD1kmOSkqOm8yIqqLutsNsgEp3lJaF7RmuRZVuVk0MfdBBdlWtJs7jM5LbOUMjUCQv4Hct1d0LT6A+SCTcvUQ3j2cp7/IumU0MpD3ALgYRH/vNjsCjrEW62s9j6pd/HgxSewDk0Ri8KdXpqx1Z3b36nAR6xKG7efLKJZ1Fh3lrAK+OE8isPR71BnZIxx4uBwlNyBTTZd+wEOt9YGomBtkutosxU9EtvlyKdAreTW+s17J+Wr+AQWrZrE+++iUvOtULvnHozk52Dbk9XTRcQYN4kfx5NOa7nh5qb5Cw)