### PR TITLE
Disable image bitmap in Safari and color space specs in Firefox

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,13 +6,12 @@
 
 - Fixed zip.js configurations causing CesiumJS to not work with Node 16. [#9861](https://github.com/CesiumGS/cesium/pull/9861)
 - Fixed a bug in `Rectangle.union` with rectangles that span the entire globe. [#9866](https://github.com/CesiumGS/cesium/pull/9866)
-- Fixed unit test failures with `Resource.supportsImageBitmapOptions` in Firefox and disabled image bitmap support in Safari. [#9874](https://github.com/CesiumGS/cesium/pull/9874/)
 
 ### 1.86 - 2021-10-01
 
 ##### Breaking Changes :mega:
 
-- Updated to Draco 1.4.1 and temporarily disabled attribute quantization. [#9847](https://github.com/CesiumGS/cesium/issues/9847)
+- Updated to Draco 1.4.1 and temporarily disabled attribute quantization. [9847](https://github.com/CesiumGS/cesium/issues/9847)
 
 ##### Fixes :wrench:
 


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/9859.

Context copied from my [comment](https://github.com/CesiumGS/cesium/issues/9859#issuecomment-941206378) on that issue: 

> In Resource we check whether the `colorSpaceConversion` option is available in `createImageBitmap` by checking whether the function throws when passed an `options` argument. After the new support for some of these options in FF 93 (but not `colorSpaceConversion`) the function no longer throws and the `.otherwise` block never gets reached in `Resource.supportsImageBitmapOptions()`.

Though color space conversion will continue to be broken in Firefox after this PR, it's not worth it to completely disable calls to `createImageBitmap` over just this option. The relevant specs now early out in Firefox. 

In Safari, `createImageBitmap` seemingly does not support any `options` flags at all (see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/createImageBitmap#browser_compatibility)) so it's safe for `Resource.supportsImageBitmapOptions` to return false.