### PR TITLE
Use `GetAttribute` to enable Draco quantization when possible

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Added `ScreenOverlay` support to `KMLDataSource`. [#9864](https://github.com/CesiumGS/cesium/pull/9864)
 - Fixed crashes caused by the cloud noise texture exceeding WebGL's maximum supported texture size. [#9885](https://github.com/CesiumGS/cesium/pull/9885)
+- Added back some support for Draco attribute quantization as a workaround until a full fix in the next Draco version. [#9904](https://github.com/CesiumGS/cesium/pull/9904)
 - Updated third-party zip.js library to 2.3.12, fixing compatibility with Webpack 4. [#9897][https://github.com/cesiumgs/cesium/pull/9897]
 
 ##### Fixes :wrench:

--- a/Source/WorkersES6/decodeDraco.js
+++ b/Source/WorkersES6/decodeDraco.js
@@ -275,6 +275,24 @@ function decodePointCloud(parameters) {
 function decodePrimitive(parameters) {
   var dracoDecoder = new draco.Decoder();
 
+  // Skip all parameter types except generic
+  // Note: As a temporary work-around until GetAttributeByUniqueId() works after
+  // calling SkipAttributeTransform(), we will not skip attributes with multiple
+  // sets of data in the glTF.
+  var attributesToSkip = ["POSITION", "NORMAL"];
+  var compressedAttributes = parameters.compressedAttributes;
+  if (!defined(compressedAttributes["COLOR_1"])) {
+    attributesToSkip.push("COLOR");
+  }
+  if (!defined(compressedAttributes["TEXCOORD_1"])) {
+    attributesToSkip.push("TEX_COORD");
+  }
+  if (parameters.dequantizeInShader) {
+    for (var i = 0; i < attributesToSkip.length; ++i) {
+      dracoDecoder.SkipAttributeTransform(draco[attributesToSkip[i]]);
+    }
+  }
+
   var bufferView = parameters.bufferView;
   var buffer = new draco.DecoderBuffer();
   buffer.Init(parameters.array, bufferView.byteLength);
@@ -295,15 +313,37 @@ function decodePrimitive(parameters) {
   draco.destroy(buffer);
 
   var attributeData = {};
-
-  var compressedAttributes = parameters.compressedAttributes;
   for (var attributeName in compressedAttributes) {
     if (compressedAttributes.hasOwnProperty(attributeName)) {
-      var compressedAttribute = compressedAttributes[attributeName];
-      var dracoAttribute = dracoDecoder.GetAttributeByUniqueId(
-        dracoGeometry,
-        compressedAttribute
-      );
+      // Since GetAttributeByUniqueId() only works on attributes that we have not called
+      // SkipAttributeTransform() on, we must first store a `dracoAttributeName` in case
+      // we call GetAttributeId() instead.
+      var dracoAttributeName = attributeName;
+      if (attributeName === "TEXCOORD_0") {
+        dracoAttributeName = "TEX_COORD";
+      }
+      if (attributeName === "COLOR_0") {
+        dracoAttributeName = "COLOR";
+      }
+
+      var dracoAttribute;
+      if (attributesToSkip.includes(dracoAttributeName)) {
+        var dracoAttributeId = dracoDecoder.GetAttributeId(
+          dracoGeometry,
+          draco[dracoAttributeName]
+        );
+        dracoAttribute = dracoDecoder.GetAttribute(
+          dracoGeometry,
+          dracoAttributeId
+        );
+      } else {
+        var compressedAttribute = compressedAttributes[attributeName];
+        dracoAttribute = dracoDecoder.GetAttributeByUniqueId(
+          dracoGeometry,
+          compressedAttribute
+        );
+      }
+
       attributeData[attributeName] = decodeAttribute(
         dracoGeometry,
         dracoDecoder,

--- a/Specs/Scene/GltfLoaderSpec.js
+++ b/Specs/Scene/GltfLoaderSpec.js
@@ -2003,6 +2003,9 @@ describe(
           VertexAttributeSemantic.TEXCOORD,
           0
         );
+        var positionQuantization = positionAttribute.quantization;
+        var normalQuantization = normalAttribute.quantization;
+        var texcoordQuantization = texcoordAttribute.quantization;
 
         var indices = primitive.indices;
 
@@ -2036,6 +2039,28 @@ describe(
         expect(positionAttribute.buffer).toBeDefined();
         expect(positionAttribute.byteOffset).toBe(0);
         expect(positionAttribute.byteStride).toBeUndefined();
+        expect(positionQuantization.octEncoded).toBe(false);
+        expect(positionQuantization.normalizationRange).toEqual(
+          new Cartesian3(2047, 2047, 2047)
+        );
+        expect(positionQuantization.quantizedVolumeOffset).toEqual(
+          new Cartesian3(
+            -69.29850006103516,
+            9.929369926452637,
+            -61.32819747924805
+          )
+        );
+        expect(positionQuantization.quantizedVolumeDimensions).toEqual(
+          new Cartesian3(
+            165.4783935546875,
+            165.4783935546875,
+            165.4783935546875
+          )
+        );
+        expect(positionQuantization.componentDatatype).toBe(
+          ComponentDatatype.UNSIGNED_SHORT
+        );
+        expect(positionQuantization.type).toBe(AttributeType.VEC3);
 
         expect(normalAttribute.name).toBe("NORMAL");
         expect(normalAttribute.semantic).toBe(VertexAttributeSemantic.NORMAL);
@@ -2063,6 +2088,14 @@ describe(
         expect(normalAttribute.buffer).toBeDefined();
         expect(normalAttribute.byteOffset).toBe(0);
         expect(normalAttribute.byteStride).toBeUndefined();
+        expect(normalQuantization.octEncoded).toBe(true);
+        expect(normalQuantization.normalizationRange).toBe(255);
+        expect(normalQuantization.quantizedVolumeOffset).toBeUndefined();
+        expect(normalQuantization.quantizedVolumeDimensions).toBeUndefined();
+        expect(normalQuantization.componentDatatype).toBe(
+          ComponentDatatype.UNSIGNED_BYTE
+        );
+        expect(normalQuantization.type).toBe(AttributeType.VEC2);
 
         expect(texcoordAttribute.name).toBe("TEXCOORD_0");
         expect(texcoordAttribute.semantic).toBe(
@@ -2086,6 +2119,20 @@ describe(
         expect(texcoordAttribute.buffer).toBeDefined();
         expect(texcoordAttribute.byteOffset).toBe(0);
         expect(texcoordAttribute.byteStride).toBeUndefined();
+        expect(texcoordQuantization.octEncoded).toBe(false);
+        expect(texcoordQuantization.normalizationRange).toEqual(
+          new Cartesian2(1023, 1023)
+        );
+        expect(texcoordQuantization.quantizedVolumeOffset).toEqual(
+          new Cartesian2(0.026409000158309937, 0.01996302604675293)
+        );
+        expect(texcoordQuantization.quantizedVolumeDimensions).toEqual(
+          new Cartesian2(0.9600739479064941, 0.9600739479064941)
+        );
+        expect(texcoordQuantization.componentDatatype).toBe(
+          ComponentDatatype.UNSIGNED_SHORT
+        );
+        expect(texcoordQuantization.type).toBe(AttributeType.VEC2);
 
         expect(indices.indexDatatype).toBe(IndexDatatype.UNSIGNED_SHORT);
         expect(indices.count).toBe(12636);
@@ -2095,9 +2142,9 @@ describe(
         expect(positionAttribute.buffer).not.toBe(normalAttribute.buffer);
         expect(positionAttribute.buffer).not.toBe(texcoordAttribute.buffer);
 
-        expect(positionAttribute.buffer.sizeInBytes).toBe(28788);
-        expect(normalAttribute.buffer.sizeInBytes).toBe(28788);
-        expect(texcoordAttribute.buffer.sizeInBytes).toBe(19192);
+        expect(positionAttribute.buffer.sizeInBytes).toBe(14394);
+        expect(normalAttribute.buffer.sizeInBytes).toBe(4798);
+        expect(texcoordAttribute.buffer.sizeInBytes).toBe(9596);
       });
     });
 

--- a/Specs/Scene/ModelExperimental/DequantizationPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/DequantizationPipelineStageSpec.js
@@ -1,7 +1,10 @@
 import {
+  Cartesian2,
+  Cartesian3,
   combine,
   DequantizationPipelineStage,
   GltfLoader,
+  Math as CesiumMath,
   Resource,
   ResourceCache,
   ShaderBuilder,
@@ -13,6 +16,10 @@ import ShaderBuilderTester from "../../ShaderBuilderTester.js";
 describe("Scene/ModelExperimental/DequantizationPipelineStage", function () {
   var boxUncompressed =
     "./Data/Models/GltfLoader/BoxTextured/glTF-Binary/BoxTextured.glb";
+  var boxWithLines =
+    "./Data/Models/DracoCompression/BoxWithLines/BoxWithLines.gltf";
+  var milkTruck =
+    "./Data/Models/DracoCompression/CesiumMilkTruck/CesiumMilkTruck.gltf";
 
   var scene;
   var gltfLoaders = [];
@@ -55,6 +62,91 @@ describe("Scene/ModelExperimental/DequantizationPipelineStage", function () {
 
     return waitForLoaderProcess(gltfLoader, scene);
   }
+
+  it("adds a dequantization function", function () {
+    var uniformMap = {};
+    var shaderBuilder = new ShaderBuilder();
+    var renderResources = {
+      uniformMap: uniformMap,
+      shaderBuilder: shaderBuilder,
+    };
+    return loadGltf(boxWithLines).then(function (gltfLoader) {
+      var components = gltfLoader.components;
+      var primitive = components.nodes[1].primitives[0];
+      DequantizationPipelineStage.process(renderResources, primitive);
+
+      ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
+        "USE_DEQUANTIZATION",
+      ]);
+      ShaderBuilderTester.expectHasVertexFunction(
+        shaderBuilder,
+        DequantizationPipelineStage.FUNCTION_ID_DEQUANTIZATION_STAGE_VS,
+        DequantizationPipelineStage.FUNCTION_SIGNATURE_DEQUANTIZATION_STAGE_VS,
+        [
+          "    attributes.normalMC = czm_octDecode(a_quantized_normalMC, model_normalizationRange_normalMC).zxy;",
+          "    attributes.positionMC = model_quantizedVolumeOffset_positionMC + a_quantized_positionMC * model_quantizedVolumeStepSize_positionMC;",
+        ]
+      );
+      ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, []);
+      expect(shaderBuilder._fragmentShaderParts.functionIds).toEqual([]);
+    });
+  });
+
+  it("adds dequantization uniforms", function () {
+    var uniformMap = {};
+    var shaderBuilder = new ShaderBuilder();
+    var renderResources = {
+      uniformMap: uniformMap,
+      shaderBuilder: shaderBuilder,
+    };
+
+    return loadGltf(milkTruck).then(function (gltfLoader) {
+      var components = gltfLoader.components;
+      var primitive = components.nodes[0].primitives[0];
+      DequantizationPipelineStage.process(renderResources, primitive);
+
+      ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, [
+        "uniform float model_normalizationRange_normalMC;",
+        "uniform vec2 model_quantizedVolumeOffset_texCoord_0;",
+        "uniform vec2 model_quantizedVolumeStepSize_texCoord_0;",
+        "uniform vec3 model_quantizedVolumeOffset_positionMC;",
+        "uniform vec3 model_quantizedVolumeStepSize_positionMC;",
+      ]);
+      ShaderBuilderTester.expectHasFragmentUniforms(shaderBuilder, []);
+
+      var uniformValues = {
+        normalRange: uniformMap.model_normalizationRange_normalMC(),
+        positionOffset: uniformMap.model_quantizedVolumeOffset_positionMC(),
+        positionStepSize: uniformMap.model_quantizedVolumeStepSize_positionMC(),
+        texCoordOffset: uniformMap.model_quantizedVolumeOffset_texCoord_0(),
+        texCoordStepSize: uniformMap.model_quantizedVolumeStepSize_texCoord_0(),
+      };
+
+      var expected = {
+        normalRange: 1023,
+        positionOffset: new Cartesian3(
+          -2.430910110473633,
+          0.2667999863624573,
+          -1.3960000276565552
+        ),
+        positionStepSize: new Cartesian3(
+          0.0002971928118058615,
+          0.0002971928118058615,
+          0.0002971928118058615
+        ),
+        texCoordOffset: new Cartesian2(
+          0.0029563899151980877,
+          0.015672028064727783
+        ),
+        texCoordStepSize: new Cartesian2(
+          0.0002397004064622816,
+          0.0002397004064622816
+        ),
+      };
+
+      expect(uniformValues).toEqualEpsilon(expected, CesiumMath.EPSILON15);
+    });
+  });
 
   it("skips non-quantized attributes", function () {
     var uniformMap = {};

--- a/Specs/Scene/ModelExperimental/GeometryPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/GeometryPipelineStageSpec.js
@@ -60,6 +60,8 @@ describe(
     var weather = "./Data/Models/GltfLoader/Weather/glTF/weather.gltf";
     var buildingsMetadata =
       "./Data/Models/GltfLoader/BuildingsMetadata/glTF/buildings-metadata.gltf";
+    var dracoMilkTruck =
+      "./Data/Models/DracoCompression/CesiumMilkTruck/CesiumMilkTruck.gltf";
 
     var scene;
     var gltfLoaders = [];
@@ -939,6 +941,98 @@ describe(
         ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
           "HAS_FEATURE_ID_0",
           "PRIMITIVE_TYPE_POINTS",
+        ]);
+      });
+    });
+
+    it("prepares Draco model for dequantization stage", function () {
+      var renderResources = {
+        attributes: [],
+        shaderBuilder: new ShaderBuilder(),
+        attributeIndex: 1,
+      };
+
+      return loadGltf(dracoMilkTruck).then(function (gltfLoader) {
+        var components = gltfLoader.components;
+        var primitive = components.nodes[0].primitives[0];
+
+        GeometryPipelineStage.process(renderResources, primitive);
+
+        var shaderBuilder = renderResources.shaderBuilder;
+        var attributes = renderResources.attributes;
+
+        expect(attributes.length).toEqual(3);
+
+        var normalAttribute = attributes[0];
+        expect(normalAttribute.index).toEqual(1);
+        expect(normalAttribute.vertexBuffer).toBeDefined();
+        expect(normalAttribute.componentsPerAttribute).toEqual(2);
+        expect(normalAttribute.componentDatatype).toEqual(
+          ComponentDatatype.UNSIGNED_SHORT
+        );
+        expect(normalAttribute.offsetInBytes).toBe(0);
+        expect(normalAttribute.strideInBytes).not.toBeDefined();
+
+        var positionAttribute = attributes[1];
+        expect(positionAttribute.index).toEqual(0);
+        expect(positionAttribute.vertexBuffer).toBeDefined();
+        expect(positionAttribute.componentsPerAttribute).toEqual(3);
+        expect(positionAttribute.componentDatatype).toEqual(
+          ComponentDatatype.UNSIGNED_SHORT
+        );
+        expect(positionAttribute.offsetInBytes).toBe(0);
+        expect(positionAttribute.strideInBytes).not.toBeDefined();
+
+        var texCoord0Attribute = attributes[2];
+        expect(texCoord0Attribute.index).toEqual(2);
+        expect(texCoord0Attribute.vertexBuffer).toBeDefined();
+        expect(texCoord0Attribute.componentsPerAttribute).toEqual(2);
+        expect(texCoord0Attribute.componentDatatype).toEqual(
+          ComponentDatatype.UNSIGNED_SHORT
+        );
+        expect(texCoord0Attribute.offsetInBytes).toBe(0);
+        expect(texCoord0Attribute.strideInBytes).not.toBeDefined();
+
+        ShaderBuilderTester.expectHasVertexStruct(
+          shaderBuilder,
+          GeometryPipelineStage.STRUCT_ID_PROCESSED_ATTRIBUTES_VS,
+          GeometryPipelineStage.STRUCT_NAME_PROCESSED_ATTRIBUTES,
+          ["    vec3 positionMC;", "    vec3 normalMC;", "    vec2 texCoord_0;"]
+        );
+        ShaderBuilderTester.expectHasFragmentStruct(
+          shaderBuilder,
+          GeometryPipelineStage.STRUCT_ID_PROCESSED_ATTRIBUTES_FS,
+          GeometryPipelineStage.STRUCT_NAME_PROCESSED_ATTRIBUTES,
+          [
+            "    vec3 positionMC;",
+            "    vec3 positionWC;",
+            "    vec3 positionEC;",
+            "    vec3 normalEC;",
+            "    vec2 texCoord_0;",
+          ]
+        );
+        // Initialization is skipped for dequantized attributes
+        ShaderBuilderTester.expectHasVertexFunction(
+          shaderBuilder,
+          GeometryPipelineStage.FUNCTION_ID_INITIALIZE_ATTRIBUTES,
+          GeometryPipelineStage.FUNCTION_SIGNATURE_INITIALIZE_ATTRIBUTES,
+          []
+        );
+        ShaderBuilderTester.expectHasAttributes(
+          shaderBuilder,
+          "attribute vec3 a_quantized_positionMC;",
+          [
+            "attribute vec2 a_quantized_normalMC;",
+            "attribute vec2 a_quantized_texCoord_0;",
+          ]
+        );
+        ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
+          "HAS_NORMALS",
+          "HAS_TEXCOORD_0",
+        ]);
+        ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
+          "HAS_NORMALS",
+          "HAS_TEXCOORD_0",
         ]);
       });
     });

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -3240,6 +3240,39 @@ describe(
       });
     });
 
+    it("loads a draco compressed glTF and dequantizes in the shader", function () {
+      return loadModel(dracoCompressedModelUrl, {
+        dequantizeInShader: true,
+      }).then(function (m) {
+        verifyRender(m);
+
+        var atrributeData = m._decodedData["0.primitive.0"].attributes;
+        expect(atrributeData["POSITION"].quantization).toBeDefined();
+        expect(atrributeData["TEXCOORD_0"].quantization).toBeDefined();
+        expect(atrributeData["NORMAL"].quantization).toBeDefined();
+        expect(atrributeData["NORMAL"].quantization.octEncoded).toBe(true);
+
+        primitives.remove(m);
+      });
+    });
+
+    it("loads a draco compressed glTF and dequantizes in the shader, skipping generic attributes", function () {
+      return loadModel(dracoCompressedModelWithAnimationUrl, {
+        dequantizeInShader: true,
+        forwardAxis: Axis.X,
+      }).then(function (m) {
+        verifyRender(m);
+
+        var atrributeData = m._decodedData["0.primitive.0"].attributes;
+        expect(atrributeData["POSITION"].quantization).toBeDefined();
+        expect(atrributeData["TEXCOORD_0"].quantization).toBeDefined();
+        expect(atrributeData["NORMAL"].quantization).toBeDefined();
+        expect(atrributeData["JOINTS_0"].quantization).toBeUndefined();
+
+        primitives.remove(m);
+      });
+    });
+
     it("loads draco compressed glTF with RGBA per-vertex color", function () {
       return loadModel(dracoBoxVertexColorsRGBAUrl).then(function (m) {
         verifyRender(m);


### PR DESCRIPTION
This is a temporary workaround for https://github.com/CesiumGS/cesium/issues/9847. See https://github.com/google/draco/issues/742#issuecomment-954934088 for more info. Since `SkipAttributeTransform` breaks lookups with `GetAttributeByUniqueId`, this PR uses the alternative approach with `GetAttributeId` and `GetAttribute` to preserve quantization when possible. 

The downside is that this might not work when there are multiple sets of an attribute, i.e. `TEXCOORD_0` and `TEXCOORD_1`. Because of this, we only call `SkipAttributeTransform` with the new `GetAttribute` approach for "single" attributes. Otherwise, we continue without quantization and use the `GetAttributeByUniqueId` call as before.

I'm working on adding back some of the specs that were removed previously, but the core change is all in decodeDraco.js.