### PR TITLE
Add Draco quantization workaround for point clouds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,13 +5,14 @@
 ##### Additions :tada:
 
 - Added `ScreenOverlay` support to `KMLDataSource`. [#9864](https://github.com/CesiumGS/cesium/pull/9864)
-- Fixed crashes caused by the cloud noise texture exceeding WebGL's maximum supported texture size. [#9885](https://github.com/CesiumGS/cesium/pull/9885)
 - Added back some support for Draco attribute quantization as a workaround until a full fix in the next Draco version. [#9904](https://github.com/CesiumGS/cesium/pull/9904)
 - Updated third-party zip.js library to 2.3.12, fixing compatibility with Webpack 4. [#9897](https://github.com/cesiumgs/cesium/pull/9897)
 
 ##### Fixes :wrench:
 
 - Point cloud styles that reference a missing property now treat the missing property as `undefined` rather than throwing an error. [#9882](https://github.com/CesiumGS/cesium/pull/9882)
+- Fixed Draco attribute quantization in point clouds [#9908](https://github.com/CesiumGS/cesium/pull/9908)
+- Fixed crashes caused by the cloud noise texture exceeding WebGL's maximum supported texture size. [#9885](https://github.com/CesiumGS/cesium/pull/9885)
 
 ### 1.86.1 - 2021-10-15
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
 ##### Fixes :wrench:
 
 - Point cloud styles that reference a missing property now treat the missing property as `undefined` rather than throwing an error. [#9882](https://github.com/CesiumGS/cesium/pull/9882)
-- Fixed Draco attribute quantization in point clouds [#9908](https://github.com/CesiumGS/cesium/pull/9908)
+- Fixed Draco attribute quantization in point clouds. [#9908](https://github.com/CesiumGS/cesium/pull/9908)
 - Fixed crashes caused by the cloud noise texture exceeding WebGL's maximum supported texture size. [#9885](https://github.com/CesiumGS/cesium/pull/9885)
 
 ### 1.86.1 - 2021-10-15

--- a/Source/WorkersES6/decodeDraco.js
+++ b/Source/WorkersES6/decodeDraco.js
@@ -253,11 +253,23 @@ function decodePointCloud(parameters) {
   var properties = parameters.properties;
   for (var propertyName in properties) {
     if (properties.hasOwnProperty(propertyName)) {
-      var attributeId = properties[propertyName];
-      var dracoAttribute = dracoDecoder.GetAttributeByUniqueId(
-        dracoPointCloud,
-        attributeId
-      );
+      var dracoAttribute;
+      if (propertyName === "POSITION" || propertyName === "NORMAL") {
+        var dracoAttributeId = dracoDecoder.GetAttributeId(
+          dracoPointCloud,
+          draco[propertyName]
+        );
+        dracoAttribute = dracoDecoder.GetAttribute(
+          dracoPointCloud,
+          dracoAttributeId
+        );
+      } else {
+        var attributeId = properties[propertyName];
+        dracoAttribute = dracoDecoder.GetAttributeByUniqueId(
+          dracoPointCloud,
+          attributeId
+        );
+      }
       result[propertyName] = decodeAttribute(
         dracoPointCloud,
         dracoDecoder,

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -54,6 +54,8 @@ describe(
       "./Data/Cesium3DTiles/PointCloud/PointCloudDraco/tileset.json";
     var pointCloudDracoPartialUrl =
       "./Data/Cesium3DTiles/PointCloud/PointCloudDracoPartial/tileset.json";
+    var pointCloudDracoBatchedUrl =
+      "./Data/Cesium3DTiles/PointCloud/PointCloudDracoBatched/tileset.json";
     var pointCloudWGS84Url =
       "./Data/Cesium3DTiles/PointCloud/PointCloudWGS84/tileset.json";
     var pointCloudBatchedUrl =
@@ -277,10 +279,36 @@ describe(
       });
     });
 
+    it("renders point cloud with draco encoded positions, normals, colors, and batch table properties", function () {
+      return Cesium3DTilesTester.loadTileset(scene, pointCloudDracoUrl).then(
+        function (tileset) {
+          Cesium3DTilesTester.expectRender(scene, tileset);
+          // Test that Draco-encoded batch table properties are functioning correctly
+          tileset.style = new Cesium3DTileStyle({
+            color: "vec4(Number(${secondaryColor}[0] < 1.0), 0.0, 0.0, 1.0)",
+          });
+          expect(scene).toRenderAndCall(function (rgba) {
+            // Produces a red color
+            expect(rgba[0]).toBeGreaterThan(rgba[1]);
+            expect(rgba[0]).toBeGreaterThan(rgba[2]);
+          });
+        }
+      );
+    });
+
     it("renders point cloud with draco encoded positions and uncompressed normals and colors", function () {
       return Cesium3DTilesTester.loadTileset(
         scene,
         pointCloudDracoPartialUrl
+      ).then(function (tileset) {
+        Cesium3DTilesTester.expectRender(scene, tileset);
+      });
+    });
+
+    it("renders point cloud with draco encoded positions, colors, and batch ids", function () {
+      return Cesium3DTilesTester.loadTileset(
+        scene,
+        pointCloudDracoBatchedUrl
       ).then(function (tileset) {
         Cesium3DTilesTester.expectRender(scene, tileset);
       });


### PR DESCRIPTION
This fixes a regression from 1.86 after updating Draco, where `SkipAttributeTransform` broke future attribute lookups with `GetAttributeByUniqueId`. To reproduce, see this [Sandcastle](https://sandcastle.cesium.com/?src=3D%20Tiles%20Formats.html&label=All) and select the "PointCloudDraco" tileset. 

This change is analogous to https://github.com/CesiumGS/cesium/pull/9904/, but since `decodePointCloud` always tries to call `SkipAttributeTransform` on `"POSITION"` and `"NORMAL"`, those are the two attributes that use `GetAttributeId` and `GetAttribute` instead of `GetAttributeByUniqueId`. 