### PR TITLE
Fix error handling for ModelExperimental

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,11 +5,13 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Chrome",
-            "type": "chrome",
+            "type": "node",
             "request": "launch",
-            "url": "http://localhost:8080/",
-            "webRoot": "${workspaceFolder}"
+            "name": "Launch Program",
+            "cwd": "${workspaceFolder}",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": ["run-script", "start"],
+            "noDebug": true
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,13 +5,11 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "type": "node",
+            "name": "Chrome",
+            "type": "chrome",
             "request": "launch",
-            "name": "Launch Program",
-            "cwd": "${workspaceFolder}",
-            "runtimeExecutable": "npm",
-            "runtimeArgs": ["run-script", "start"],
-            "noDebug": true
+            "url": "http://localhost:8080/",
+            "webRoot": "${workspaceFolder}"
         }
     ]
 }

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -202,17 +202,17 @@ function initialize(model) {
       });
       model._resourcesLoaded = true;
     })
-    .otherwise(function () {
-      ModelExperimentalUtility.getFailedLoadFunction(this, "model", resource);
-    });
+    .otherwise(
+      ModelExperimentalUtility.getFailedLoadFunction(model, "model", resource)
+    );
 
   loader.texturesLoadedPromise
     .then(function () {
       model._texturesLoaded = true;
     })
-    .otherwise(function () {
-      ModelExperimentalUtility.getFailedLoadFunction(this, "model", resource);
-    });
+    .otherwise(
+      ModelExperimentalUtility.getFailedLoadFunction(model, "model", resource)
+    );
 }
 
 Object.defineProperties(ModelExperimental.prototype, {

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -158,6 +158,47 @@ describe(
       });
     });
 
+    it("rejects ready promise when texture fails to load", function () {
+      var resource = Resource.createIfNeeded(boxTexturedGltfUrl);
+      return resource.fetchJson().then(function (gltf) {
+        gltf.images[0].uri = "non-existent-path.png";
+        return loadAndZoomToModelExperimental(
+          {
+            gltf: gltf,
+            basePath: boxTexturedGltfUrl,
+            incrementallyLoadTextures: false,
+          },
+          scene
+        )
+          .then(function (model) {
+            fail();
+          })
+          .otherwise(function (error) {
+            expect(error).toBeDefined();
+          });
+      });
+    });
+
+    it("rejects ready promise when external buffer fails to load", function () {
+      var resource = Resource.createIfNeeded(boxTexturedGltfUrl);
+      return resource.fetchJson().then(function (gltf) {
+        gltf.buffers[0].uri = "non-existent-path.bin";
+        return loadAndZoomToModelExperimental(
+          {
+            gltf: gltf,
+            basePath: boxTexturedGltfUrl,
+          },
+          scene
+        )
+          .then(function (model) {
+            fail();
+          })
+          .otherwise(function (error) {
+            expect(error).toBeDefined();
+          });
+      });
+    });
+
     it("show works", function () {
       var resource = Resource.createIfNeeded(boxTexturedGlbUrl);
       var loadPromise = resource.fetchArrayBuffer();

--- a/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
+++ b/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
@@ -2,7 +2,6 @@ import { ModelExperimental, when } from "../../../Source/Cesium.js";
 import pollToPromise from "../../pollToPromise.js";
 
 function loadAndZoomToModelExperimental(options, scene) {
-
   var model;
 
   try {
@@ -20,7 +19,7 @@ function loadAndZoomToModelExperimental(options, scene) {
       debugShowBoundingVolume: options.debugShowBoundingVolume,
       featureIdAttributeIndex: options.featureIdAttributeIndex,
       featureIdTextureIndex: options.featureIdTextureIndex,
-      incrementallyLoadTextures: options.incrementallyLoadTextures
+      incrementallyLoadTextures: options.incrementallyLoadTextures,
     });
   } catch (error) {
     return when.reject(error);

--- a/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
+++ b/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
@@ -2,41 +2,55 @@ import { ModelExperimental, when } from "../../../Source/Cesium.js";
 import pollToPromise from "../../pollToPromise.js";
 
 function loadAndZoomToModelExperimental(options, scene) {
-  var model = ModelExperimental.fromGltf({
-    content: options.content,
-    color: options.color,
-    gltf: options.gltf,
-    show: options.show,
-    customShader: options.customShader,
-    basePath: options.basePath,
-    modelMatrix: options.modelMatrix,
-    allowPicking: options.allowPicking,
-    upAxis: options.upAxis,
-    forwardAxis: options.forwardAxis,
-    debugShowBoundingVolume: options.debugShowBoundingVolume,
-    featureIdAttributeIndex: options.featureIdAttributeIndex,
-    featureIdTextureIndex: options.featureIdTextureIndex,
-  });
+  try {
+    var model = ModelExperimental.fromGltf({
+      content: options.content,
+      color: options.color,
+      gltf: options.gltf,
+      show: options.show,
+      customShader: options.customShader,
+      basePath: options.basePath,
+      modelMatrix: options.modelMatrix,
+      allowPicking: options.allowPicking,
+      upAxis: options.upAxis,
+      forwardAxis: options.forwardAxis,
+      debugShowBoundingVolume: options.debugShowBoundingVolume,
+      featureIdAttributeIndex: options.featureIdAttributeIndex,
+      featureIdTextureIndex: options.featureIdTextureIndex,
+      incrementallyLoadTextures: options.incrementallyLoadTextures
+    });
+  } catch (error) {
+    return when.reject(error);
+  }
 
   scene.primitives.add(model);
+
+  var finished = false;
+  var rejected = false;
+  model.readyPromise
+    .otherwise(function () {
+      rejected = true;
+    })
+    .always(function () {
+      finished = true;
+    });
 
   return pollToPromise(
     function () {
       scene.renderForSpecs();
-      return model.ready;
+      return finished;
     },
     { timeout: 10000 }
-  )
-    .then(function () {
-      scene.camera.flyToBoundingSphere(model.boundingSphere, {
-        duration: 0,
-        offset: options.offset,
-      });
-      return model;
-    })
-    .otherwise(function () {
-      return when.reject(model);
+  ).then(function () {
+    if (rejected) {
+      return model.readyPromise;
+    }
+    scene.camera.flyToBoundingSphere(model.boundingSphere, {
+      duration: 0,
+      offset: options.offset,
     });
+    return model.readyPromise;
+  });
 }
 
 export default loadAndZoomToModelExperimental;

--- a/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
+++ b/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
@@ -2,8 +2,11 @@ import { ModelExperimental, when } from "../../../Source/Cesium.js";
 import pollToPromise from "../../pollToPromise.js";
 
 function loadAndZoomToModelExperimental(options, scene) {
+
+  var model;
+
   try {
-    var model = ModelExperimental.fromGltf({
+    model = ModelExperimental.fromGltf({
       content: options.content,
       color: options.color,
       gltf: options.gltf,


### PR DESCRIPTION
Model loading errors were not getting propagated correctly in `ModelExperimental`. I added two unit tests but this should have been unit tested when `ModelExperimental` was first added.

`loadAndZoomToModelExperimental.js` was also not handling rejected promises correctly. I modeled it after `waitForLoaderProcess.js`. It's a little verbose but it should work for catching any errors.