### PR TITLE
Fixes B3dmLoader's handling of B3DMs with no features

### DIFF
--- a/Source/Scene/ModelExperimental/B3dmLoader.js
+++ b/Source/Scene/ModelExperimental/B3dmLoader.js
@@ -281,6 +281,10 @@ function createFeatureMetadata(loader, components) {
   var batchTable = loader._batchTable;
   var batchLength = loader._batchLength;
 
+  if (batchLength === 0) {
+    return;
+  }
+
   var featureMetadata;
   if (defined(batchTable.json)) {
     // Add the feature metadata from the batch table to the model components.

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -124,8 +124,6 @@ function createModelFeatureTables(model, featureMetadata) {
     if (modelFeatureTable.featuresLength > 0) {
       modelFeatureTables.push(modelFeatureTable);
     }
-
-    modelFeatureTable.applyStyle(model.style);
   }
 
   return modelFeatureTables;

--- a/Specs/Scene/ModelExperimental/B3dmLoaderSpec.js
+++ b/Specs/Scene/ModelExperimental/B3dmLoaderSpec.js
@@ -22,6 +22,9 @@ describe("Scene/ModelExperimental/B3dmLoader", function () {
     "./Data/Cesium3DTiles/Batched/BatchedWithRtcCenter/batchedWithRtcCenter.b3dm";
   var withBatchTableHierarchy =
     "./Data/Cesium3DTiles/Hierarchy/BatchTableHierarchy/tile.b3dm";
+  var noBatchIdsUrl =
+    "Data/Cesium3DTiles/Batched/BatchedNoBatchIds/batchedNoBatchIds.b3dm";
+
   var scene;
   var b3dmLoaders = [];
 
@@ -62,6 +65,15 @@ describe("Scene/ModelExperimental/B3dmLoader", function () {
       return waitForLoaderProcess(loader, scene);
     });
   }
+
+  it("loads BatchedNoBatchIds", function () {
+    return loadB3dm(noBatchIdsUrl).then(function (loader) {
+      var components = loader.components;
+      expect(components).toBeDefined();
+      var featureMetadata = components.featureMetadata;
+      expect(featureMetadata).toBeUndefined();
+    });
+  });
 
   it("loads BatchedWithBatchTable", function () {
     return loadB3dm(withBatchTableUrl).then(function (loader) {

--- a/Specs/Scene/ModelExperimental/ModelExperimental3DTileContentSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimental3DTileContentSpec.js
@@ -18,6 +18,8 @@ describe("Scene/ModelExperimental/ModelExperimental3DTileContent", function () {
     "./Data/Cesium3DTiles/Batched/BatchedWithBatchTable/tileset.json";
   var withoutBatchTableUrl =
     "./Data/Cesium3DTiles/Batched/BatchedWithoutBatchTable/tileset.json";
+  var noBatchIdsUrl =
+    "Data/Cesium3DTiles/Batched/BatchedNoBatchIds/tileset.json";
 
   var scene;
   var centerLongitude = -1.31968;
@@ -78,6 +80,15 @@ describe("Scene/ModelExperimental/ModelExperimental3DTileContent", function () {
         Cesium3DTilesTester.expectRender(scene, tileset);
       }
     );
+  });
+
+  it("renders B3DM content without features", function () {
+    setCamera(centerLongitude, centerLatitude, 15.0);
+    return Cesium3DTilesTester.loadTileset(scene, noBatchIdsUrl).then(function (
+      tileset
+    ) {
+      Cesium3DTilesTester.expectRender(scene, tileset);
+    });
   });
 
   it("picks from glTF", function () {


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/9918

#### Dicussion

- Regarding the tileset that specifically triggered this bug, the core problem lay in `B3dmLoader`, which was always creating an empty `PropertyTable` without checking if the `batchLength` was greater than 0.

- This was not caught in a test because there was no test for a B3DM with 0 features. `BatchedWithoutBatchTable` is not the same as `BatchedNoBatchIds` - which is what needed testing against.

- The actual crash happened inside `ModelExperimental`'s `createModelFeatureTables` function that always called `applyStyle` on each `ModelFeatureTable` created. Since the number of features in the table was actually 0, this caused a crash when trying to set a style/color on all features. At initialization, the `model.style` is always `false`, so I believe this line can be removed.

#### Sandcastles

1. Tilesets without features

| [Before](http://localhost:8080/Apps/Sandcastle/index.html#c=bVHBbtswDP0VwpcqWCCv2FAMnRusSFOgQIcNW7BdfFEkJhUqiwElu2uH/ftoOym8tRcR4nvkeySXmHzb6NWvPbJvMGYTrtHkljFpjGYT8DM5DFMcLiBzix/rWMfOMHQeH5AlG/EBlmO/H0NO1YUd/kuSQh+R62IOv+sIkJFZMl+ZOu+Qz4+FlkUdfxIHtx4pajav45/Zs1z2ARPmf/XG8O5qPYJq0Gg5PPe9ofgNE7VsUW+ZmssktBun3r/9cHY2UTh01328NvI4bZxbdTL5rU8ZZQa1baPNnqISg8SzcSAASzFRQB1op04uIwwokLUtMzoIZJyPu8H/OZzAm5GgxWUv/aLDqkenxAZTMjvsycd1DFvWyYotvZf7+Ow7OZw4VodBeuKB9kTUrGkK1LGYF1XKjwEXowOAT77ZE+d+eUrrMmOzD3KRVG5aey+LsSkd7VbltLRyvgPvLl65OdhgUhJk24bw3T9hXSyqUvgvSg9L+tIhB/PY0+5OF7djUmtdlfJ9vTIThY3h/zr/BQ) | [After](http://localhost:8080/Apps/Sandcastle/index.html#c=bVHBbtswDP0VwpcqWCCv2FAMnRusSFOgQIcNW7BdfFEkJhUqiwElu2uH/ftoOym8tRcR4nvkeySXmHzb6NWvPbJvMGYTrtHkljFpjGYT8DM5DFMcLiBzix/rWMfOMHQeH5AlG/EBlmO/H0NO1YUd/kuSQh+R62IOv+sIkJFZMl+ZOu+Qz4+FlkUdfxIHtx4pajav45/Zs1z2ARPmf/XG8O5qPYJq0Gg5PPe9ofgNE7VsUW+ZmssktBun3r/9cHY2UTh01328NvI4bZxbdTL5rU8ZZQa1baPNnqISg8SzcSAASzFRQB1op04uIwwokLUtMzoIZJyPu8H/OZzAm5GgxWUv/aLDqkenxAZTMjvsycd1DFvWyYotvZf7+Ow7OZw4VodBeuKB9kTUrGkK1LGYF1XKjwEXowOAT77ZE+d+eUrrMmOzD3KRVG5aey+LsSkd7VbltLRyvgPvLl65OdhgUhJk24bw3T9hXSyqUvgvSg9L+tIhB/PY0+5OF7djUmtdlfJ9vTIThY3h/zr/BQ) | [With Style](http://localhost:8080/Apps/Sandcastle/index.html#c=dVLfb9MwEP5XrLw0FZUDAk2oZBVT6aRJQyBWwQPhwbWvxcLxVWcnY0P73znH7Ra28ZKL77777rsfSwi2a+Xq9x7ItuCjcuegYkcQJHi1cfARDbhxXJyKSB28a3zje0Wit3ANxF4P12KZ+b4OvrIp9PBeIidaD9QUM/Gn8UJEIGLPZ8LeGqD5MVETV4dvSM6sM6Sczhp/N70vF62DAPHfetm8/rDOwXKo0ZG7571A/wUCdqRBbgnbs8CwC1O+efn25GRU4cAukz1X/DFSGbPqufNLGyJwD+W28zpa9CULRJrmhoTQ6AM6kA535eTMiyEqUOuOCIxwqIz1u0H/XEzEiwyQrDKVfsKwStExsIUQ1A4S+JHYEG8c/H8gVymcR6LRJdIHxcamTsJcfM8uwT9FWm/aFK8v4cvJxnUwmTbFjwwazN3DVoZly6B5OnLPZ8KcPd8PD648SEzAA+wWsV3jOND4YlbUQxOLo4r3tt0jxbTDUsoqQrt3fBih2nT6F7esQzhOra7GqbWxvbDm9JnTE9qpEDiy7Zy7srfc46KuGP8k9bCrTz2QUzcJ9vPV4jI7pZR1xc/nMyOi2yh6xPwX) |
| - | - | - |
| ![image](https://user-images.githubusercontent.com/5172619/140741871-5714ed81-7488-498b-bc80-120b16c25601.png) | ![image](https://user-images.githubusercontent.com/5172619/140741984-2e319ccf-5230-4221-80ba-5faf615b7781.png) | ![image](https://user-images.githubusercontent.com/5172619/140742182-27f2b66c-e81c-4362-a9f5-4a8baa778947.png) |
| ❌ | ✔ | ✔ |

2. Tilesets with features, without batch table

| [Before](http://localhost:8080/Apps/Sandcastle/index.html#c=bVFNTyMxDP0r1lwYBEqEuLFDxW4pJxAHqt1LLmli2uxm4lHiDAuI/05mpq3KxyWW/d5znu05JpdbsfjfYXQtBtb+BjXniElg0CuPd2TRH+JwCRwz/lBBhV5H6B0+YSzVgE8wn/r9Hmu1qsyYz6kIXcCoqlN4VeHteK9m5zEhf5RP4fx6OYF1kQDk6C9AVfKhQ5PktWYtP/DkL81mg3YX/zjeUOYxWw6TyO1f4m+ioKq9jV15iDe6PFZoaxd9mfbWJcbiu37MwbCjUGOMFI9hdARgKCTyKDyt66OfAUYUyJgcI1rwpK0L63HICziCk4kgyijD1186LAb0kNhiSnqNA3m3s3GzIpliS3TlJo5dX45VHNfbQQbilvZC1C7pEFChOq2axM8eZ5MDgCvXdhR52HAthGRsO6+5bHSVzb+yGJPSzm4jD6WNdT04e/nNncF4nVJBHrP3D+4FVTVrZOF/kW6XdN9j9Pp5oG3OZrdTUQjRyJJ+r2Qiv9LxU+d3) | [After](http://localhost:8080/Apps/Sandcastle/index.html#c=bVFNTyMxDP0r1lwYBEqEuLFDxW4pJxAHqt1LLmli2uxm4lHiDAuI/05mpq3KxyWW/d5znu05JpdbsfjfYXQtBtb+BjXniElg0CuPd2TRH+JwCRwz/lBBhV5H6B0+YSzVgE8wn/r9Hmu1qsyYz6kIXcCoqlN4VeHteK9m5zEhf5RP4fx6OYF1kQDk6C9AVfKhQ5PktWYtP/DkL81mg3YX/zjeUOYxWw6TyO1f4m+ioKq9jV15iDe6PFZoaxd9mfbWJcbiu37MwbCjUGOMFI9hdARgKCTyKDyt66OfAUYUyJgcI1rwpK0L63HICziCk4kgyijD1186LAb0kNhiSnqNA3m3s3GzIpliS3TlJo5dX45VHNfbQQbilvZC1C7pEFChOq2axM8eZ5MDgCvXdhR52HAthGRsO6+5bHSVzb+yGJPSzm4jD6WNdT04e/nNncF4nVJBHrP3D+4FVTVrZOF/kW6XdN9j9Pp5oG3OZrdTUQjRyJJ+r2Qiv9LxU+d3) | [With Style](http://localhost:8080/Apps/Sandcastle/index.html#c=dVJNb9swDP0rhC9xsELCsFvmBt3S9NSihwTbYepBkdhEmywZ+nDXDv3vo+ykTb8upkW+R/HxaYHR5JYt/3YYTIsuSXuBMuWAkaGTG4tXXqM9rsMppJDxq3DC9TJAb/AOA2Ud3sFi7PdjyNWiUsN54YloHAZRncA/4R6nT+xkLEZML+lj+HK+Hos1UQBysDMQFV91qCI/l0nyFzj+XSa1Q32IP03a+ZyG07oo4fu72O/onaiexjikS7yQ9NFMar3sSe2liQlp7vo2O5WMdzWG4MMUhokAlHfRW2TWb+vJNwdDFbxSOQTUYL3Uxm0HkTOYwKcRwEhKufpNh2WpHgNbjFFusYBfDRvTvcWPt7Yq5XFvytvS9HlibYqSOINfYwropyqWFnfIsoKvJxubcTIV1c0IGsLjs3WDwSwq2g7r6GlQz57eDC2u3o9YgHvYg/ft2h8XhKtOqmYQMT9McWbazodUjK4Z4wnbzspExm6y+kOSVYyHrTX8mNpo04PRp+88N1BWxkiV22ztyjyQxnnDCf+Guvfqusdg5X2B7T7PL8ckY6zhdHyfmby3Gxledf4P) |
| - | - | - |
| ![image](https://user-images.githubusercontent.com/5172619/140745310-5e40d9b0-f44a-4148-a9df-fe139169775a.png) | ![image](https://user-images.githubusercontent.com/5172619/140745364-63a8223f-e9c0-465a-9667-a4437705188f.png) | ![image](https://user-images.githubusercontent.com/5172619/140745408-845eefce-991a-4b3d-8102-40d589c1de9f.png) |
| ✔ | ✔ | ✔ |

3. Tilesets with features, with batch table

| [Before](http://localhost:8080/Apps/Sandcastle/index.html#c=bVHBbtswDP0VwpcqWCCv2FAMnRusSFOgQIcNW7BdfFEkJhUqiwElu2uH/ftoOym8tRcR4nvkeySXmHzb6NWvPbJvMGYTrtHkljFpjGYT8DM5DFMcLiBzix/rWMfOMHQeH5AlG/EBlmO/H0NO1YUd/kuSQh+R62IOv+sIkJFZMl+ZOu+Qz4+FlkUdfxIHtx4pajav45/Zs1z2ARPmf/XG8O5qPYJq0Gg5PPe9ofgNE7VsUW+ZmssktBun3r/9cHY2UTh01328NvI4bZxbdTL5rU8ZZQa1baPNnqISg8SzcSAASzFRQB1op04uIwwokLUtMzoIZJyPu8H/OZzAm5GgxWUv/aLDqkenxAZTMjvsycd1DFvWyYotvZf7+Ow7OZw4VodBeuKB9kTUrGkK1LGYF1XKjwEXowOAT77ZE+d+eUrrMmOzD3KRVG5aey+LsSkd7VbltLRyvgPvLl65OdhgUhJk24bw3T9hXSyqUvgvSg9L+tIhB/PY0+5OF7djUmtdlfJ9vTIThY3h/zr/BQ) | [After](http://localhost:8080/Apps/Sandcastle/index.html#c=bVFNTwIxEP0rk72wRNLGeNOFqAgnjQeJXnop7QjVbrvpxyoY/7vdDwgIl53tvPemb16n6FUsyey7QqdKNIHrOfIQHXqChi81PlmJ+hCHMQQX8YYZZmruoFb4hS51DX7BtJv32vZylon2PLVJqAw6lo3gh5nf4V4dlEaP4VjelauHRQfmSQIQnb4GltGXCoWnDzxwesSj9zyINcpdfVNh3f4umjVofxH58NawbO9h127qnKePJFzKWZ1WfVQ+YDKdv0cjgrImR+esG0JrB0BY461Gou0qH9wZaFGwQkTnUIK2XCqzaje8hgFcdASS9miuPpkwa9BDYone8xU25N5sG1obLfEiWSNVehQVVJ1eK7nO+2Uack/bWlsu7CHATDbKCh82GiedC4BbVVbWhSbinBAasKw0DynSZRSfKRzh/c5yQQ+lhVQ1KDk+89AgNPc+Ie9R6xe1RZZNCpr4J9I+qOcaneabhra+nDx2TUJIQdPxvDJYq5fc/Zv8Bw) | [With Style](http://localhost:8080/Apps/Sandcastle/index.html#c=dVJNb9swDP0rhC9xsELCsFvmBt3S9NSihwTbYepBkdhEmywZ+nDXDv3vo+ykTb8upkW+R/HxaYHR5JYt/3YYTIsuSXuBMuWAkaGTG4tXXqM9rsMppJDxq3DC9TJAb/AOA2Ud3sFi7PdjyNWiUsN54YloHAZRncA/4R6nT+xkLEZML+lj+HK+Hos1UQBysDMQFV91qCI/l0nyFzj+XSa1Q32IP03aDb/rIoPvL2K/o3eieprhkC7xQtJHM6n1sieplyYmpKHr2+xUMt7VGIIPUxjGAVDeRW+RWb+tJ98cDFXwSuUQUIP1Uhu3HRTOYAKfRgAjHeXqNx2WpXoMbDFGucUCfjVsTPcWP17ZqpTHpSlvS9PnibUpSuIMfo0poJ+q+FmsIb8Kvp5sbMbJVFQ3I2gIj8++De6yqGg7rKN3QT17ejC0uHo/YgHuYQ/et2t/XBCuOqmaQcT8MMWZaTsfUnG5ZownbDsrE7m6yeoPSVYxHrbW8GNqo00PRp++89ZAWRkjVW6ztSvzQBrnDSf8G+req+seg5X3Bbb7PL8ck4yxhtPxfWby3m5keNX5Pw) |
| - | - | - |
| ![image](https://user-images.githubusercontent.com/5172619/140745013-25a9a099-3c7b-4b26-a644-3ab58a8f1cbe.png) | ![image](https://user-images.githubusercontent.com/5172619/140745075-837ddd05-bb05-488c-88e0-3da7422a5759.png) | ![image](https://user-images.githubusercontent.com/5172619/140745140-755bf1c5-f21d-4496-b8f2-76c20a45c466.png) |
| ✔ | ✔ | ✔ |