### PR TITLE
Don't render model until the next frame

### DIFF
--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -614,12 +614,18 @@ ModelExperimental.prototype.update = function (frameState) {
     this._drawCommandsBuilt = true;
 
     var model = this;
-    // Set the model as ready after the first frame render since the user might set up events subscribed to
-    // the post render event, and the model may not be ready for those past the first frame.
-    frameState.afterRender.push(function () {
-      model._ready = true;
-      model._readyPromise.resolve(model);
-    });
+
+    if (!model._ready) {
+      // Set the model as ready after the first frame render since the user might set up events subscribed to
+      // the post render event, and the model may not be ready for those past the first frame.
+      frameState.afterRender.push(function () {
+        model._ready = true;
+        model._readyPromise.resolve(model);
+      });
+
+      // Don't render until the next frame after the ready promise is resolved
+      return;
+    }
   }
 
   if (this._debugShowBoundingVolumeDirty) {


### PR DESCRIPTION
Fixes awkward behavior in the "Model Experimental 3D Models" sandcastle demo in https://github.com/CesiumGS/cesium/pull/9922

Previously there was one frame where the model was visible before the camera snapped to its new location. That was because `ModelExperimental` was pushing its draw commands before its `readyPromise` resolved.

This fix also has the benefit of not resolving the ready promise multiple times if custom shaders or styles are changed.