### PR TITLE
Handle the alpha component of specular-glossiness textures

### DIFF
--- a/Source/Scene/processPbrMaterials.js
+++ b/Source/Scene/processPbrMaterials.js
@@ -856,6 +856,10 @@ function generateTechnique(
       } else {
         fragmentShader += "    vec4 diffuse = vec4(1.0);\n";
       }
+
+      // the specular glossiness extension's alpha takes precedence over
+      // the base color alpha.
+      fragmentShader += "    baseColorWithAlpha.a = diffuse.a;\n";
     } else if (defined(generatedMaterialValues.u_metallicRoughnessTexture)) {
       fragmentShader +=
         "    vec3 metallicRoughness = texture2D(u_metallicRoughnessTexture, " +

--- a/Source/Shaders/ModelExperimental/MaterialStageFS.glsl
+++ b/Source/Shaders/ModelExperimental/MaterialStageFS.glsl
@@ -178,6 +178,9 @@ void materialStage(inout czm_modelMaterial material, ProcessedAttributes attribu
       glossiness
     );
     material.diffuse = parameters.diffuseColor;
+    // the specular glossiness extension's alpha overrides anything set
+    // by the base material.
+    material.alpha = diffuse.a;
     material.specular = parameters.f0;
     material.roughness = parameters.roughness;
     #elif defined(LIGHTING_PBR)


### PR DESCRIPTION
Fixes #9928

`KHR_materials_pbrSpecularGlossiness` has a diffuse texture with an alpha component. This alpha value should be used when rendering the model. See [`diffuseTexture` in the spec](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Archived/KHR_materials_pbrSpecularGlossiness#diffusetexture)

since specular glossiness takes higher priority over metallic roughness (see the table in [this section of the spec](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Archived/KHR_materials_pbrSpecularGlossiness#best-practices)), this alpha value should override anything that came before it in the shader.

the CesiumJS implementation in `processPbrMaterials` was not doing this. `diffuse.rgb` was used for PBR lighting, but `diffuse.a` was unused. `ModelExperimental` was based on that file, so it also had the same problem. Fortunately, each case required only 1 line of GLSL to fix!

@ebogo1 could you review?