### PR TITLE
Fixes globe visibility bug in S2 Sandcastle

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Next S2 Globe.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Next S2 Globe.html
@@ -78,7 +78,7 @@
         // MAXAR OWT WFF 1.2 Base Globe
         var tileset = viewer.scene.primitives.add(
           new Cesium.Cesium3DTileset({
-            url: Cesium.IonResource.fromAssetId(666330),
+            url: Cesium.IonResource.fromAssetId(691510),
             maximumScreenSpaceError: 4,
           })
         );


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/9941

The problem was not caught earlier because it only manifests on smaller screens. I was initially testing on 2560x1440, where the globe did load correctly.

The fix involved increasing the geometric error of the root tiles in the tileset itself. I tested on a variety of screen sizes to ensure that the fix works. Here is an [ online Sandcastle](http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesium/s2-sandcastle-fix/Apps/Sandcastle/index.html?src=3D%20Tiles%20Next%20S2%20Globe.html&label=3D%20Tiles%20Next) for testing.

| Resolution | Screenshot |
| - | - | 
| `1920x1080` | ![1920x1080](https://user-images.githubusercontent.com/5172619/144085117-990b00d3-ad5d-41e7-9639-45202b5bf73d.png) | 
| `1280x720` |![1280x720](https://user-images.githubusercontent.com/5172619/144085136-6da6f6d0-317d-4584-bdd4-01283e5b6b52.png) |
| `1024x768` (iPad) | ![1024x768(iPad)](https://user-images.githubusercontent.com/5172619/144085418-45fdae45-47ab-4802-8787-8c44b929e3d7.png) |
|  `800x600` | ![800x600](https://user-images.githubusercontent.com/5172619/144085155-88439125-e448-46c7-be06-8127b7390355.png) |
| `312x812` (iPhone) | ![375x812 (iPhone)](https://user-images.githubusercontent.com/5172619/144085484-977bba31-249e-4333-a64a-98003d62a252.png) |
 