### PR TITLE
check pixel tolerance for left button double click

### DIFF
--- a/Source/Core/ScreenSpaceEventHandler.js
+++ b/Source/Core/ScreenSpaceEventHandler.js
@@ -406,9 +406,21 @@ function handleDblClick(screenSpaceEventHandler, event) {
   );
 
   if (defined(action)) {
-    getPosition(screenSpaceEventHandler, event, mouseDblClickEvent.position);
-
-    action(mouseDblClickEvent);
+    var position = getPosition(
+      screenSpaceEventHandler,
+      event,
+      mouseDblClickEvent.position
+    );
+    var startPosition = screenSpaceEventHandler._primaryStartPosition;
+    if (
+      checkPixelTolerance(
+        startPosition,
+        position,
+        screenSpaceEventHandler._clickPixelTolerance
+      )
+    ) {
+      action(mouseDblClickEvent);
+    }
   }
 }
 


### PR DESCRIPTION
double click should check pixel tolerance like mouse click event, e.g., double click event shouldn't be triggered when mouse left button: down->up->down->move->up