### PR TITLE
Fix quantized vec3 colors in ModelExperimental

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 # Change Log
 
-### 1.88 - 2021-12-1
+### 1.89 - 2022-01-03
+
+##### Fixes :wrench:
+
+- Fixed handling of vec3 vertex colors in `ModelExperimental`. [#9955](https://github.com/CesiumGS/cesium/pull/9955)
+- Fixed handling of Draco quantized vec3 vertex colors in `ModelExperimental`. [#9957](https://github.com/CesiumGS/cesium/pull/9957)
+
+### 1.88 - 2021-12-01
 
 ##### Fixes :wrench:
 

--- a/Source/Scene/ModelExperimental/ModelExperimentalUtility.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalUtility.js
@@ -119,20 +119,24 @@ ModelExperimentalUtility.getAttributeInfo = function (attribute) {
     variableName = variableName.toLowerCase();
   }
 
+  var isVertexColor = /^color_\d+$/.test(variableName);
   var attributeType = attribute.type;
   var glslType = AttributeType.getGlslType(attributeType);
 
   // color_n can be either a vec3 or a vec4. But in GLSL we can always use
   // attribute vec4 since GLSL promotes vec3 attribute data to vec4 with
-  // the .a channel set to 1.0
-  if (/^color_\d+$/.test(variableName)) {
+  // the .a channel set to 1.0.
+  if (isVertexColor) {
     glslType = "vec4";
   }
 
   var isQuantized = defined(attribute.quantization);
   var quantizedGlslType;
   if (isQuantized) {
-    quantizedGlslType = AttributeType.getGlslType(attribute.quantization.type);
+    // The quantized color_n attribute also is promoted to a vec4 in the shader
+    quantizedGlslType = isVertexColor
+      ? "vec4"
+      : AttributeType.getGlslType(attribute.quantization.type);
   }
 
   return {

--- a/Specs/Scene/ModelExperimental/ModelExperimentalUtilitySpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalUtilitySpec.js
@@ -167,6 +167,26 @@ describe("Scene/ModelExperimental/ModelExperimentalUtility", function () {
     });
   });
 
+  it("getAttributeInfo handles quantized vertex colors correctly", function () {
+    var attribute = {
+      semantic: "COLOR",
+      setIndex: 0,
+      type: AttributeType.VEC3,
+      quantization: {
+        type: AttributeType.VEC3,
+      },
+    };
+
+    expect(ModelExperimentalUtility.getAttributeInfo(attribute)).toEqual({
+      attribute: attribute,
+      isQuantized: true,
+      variableName: "color_0",
+      hasSemantic: true,
+      glslType: "vec4",
+      quantizedGlslType: "vec4",
+    });
+  });
+
   it("createBoundingSphere works", function () {
     var mockPrimitive = {
       attributes: [


### PR DESCRIPTION
Fixes #9814

(Note: don't use the model from the original issue, it still won't load due to https://github.com/CesiumGS/cesium/issues/9956 which is a separate issue)

#9955 fixed vec3 colors in `ModelExperimental`, but a few more steps had to be done for this to work with quantized attributes (as even the offset/stepSize uniforms need to be promoted to `vec4`

@sanjeetsuhag could you review?