### PR TITLE
Small fixes to match the latest 3D Tiles Next specs

### DIFF
--- a/Source/Scene/GroupMetadata.js
+++ b/Source/Scene/GroupMetadata.js
@@ -34,8 +34,6 @@ function GroupMetadata(options) {
   this._class = options.class;
   this._properties = properties;
   this._id = id;
-  this._name = group.name;
-  this._description = group.description;
   this._extras = group.extras;
   this._extensions = group.extensions;
 }
@@ -66,34 +64,6 @@ Object.defineProperties(GroupMetadata.prototype, {
   id: {
     get: function () {
       return this._id;
-    },
-  },
-
-  /**
-   * The name of the group.
-   *
-   * @memberof GroupMetadata.prototype
-   * @type {String}
-   * @readonly
-   * @private
-   */
-  name: {
-    get: function () {
-      return this._name;
-    },
-  },
-
-  /**
-   * The description of the group.
-   *
-   * @memberof GroupMetadata.prototype
-   * @type {String}
-   * @readonly
-   * @private
-   */
-  description: {
-    get: function () {
-      return this._description;
     },
   },
 

--- a/Source/Scene/MetadataSchema.js
+++ b/Source/Scene/MetadataSchema.js
@@ -48,6 +48,7 @@ function MetadataSchema(schema) {
 
   this._classes = classes;
   this._enums = enums;
+  this._id = schema.id;
   this._name = schema.name;
   this._description = schema.description;
   this._version = schema.version;
@@ -81,6 +82,20 @@ Object.defineProperties(MetadataSchema.prototype, {
   enums: {
     get: function () {
       return this._enums;
+    },
+  },
+
+  /**
+   * The ID of the schema.
+   *
+   * @memberof MetadataSchema.prototype
+   * @type {String}
+   * @readonly
+   * @private
+   */
+  id: {
+    get: function () {
+      return this._id;
     },
   },
 

--- a/Source/Scene/MetadataSemantic.js
+++ b/Source/Scene/MetadataSemantic.js
@@ -9,14 +9,6 @@
  */
 var MetadataSemantic = {
   /**
-   * A name, stored as a <code>STRING</code>. This does not have to be unique
-   *
-   * @type {String}
-   * @constant
-   * @private
-   */
-  NAME: "NAME",
-  /**
    * A unique identifier, stored as a <code>STRING</code>.
    *
    * @type {String}
@@ -24,6 +16,22 @@ var MetadataSemantic = {
    * @private
    */
   ID: "ID",
+  /**
+   * A name, stored as a <code>STRING</code>. This does not have to be unique.
+   *
+   * @type {String}
+   * @constant
+   * @private
+   */
+  NAME: "NAME",
+  /**
+   * A description, stored as a <code>STRING</code>.
+   *
+   * @type {String}
+   * @constant
+   * @private
+   */
+  DESCRIPTION: "DESCRIPTION",
   /**
    * A bounding box for a tile, stored as an array of 12 <code>FLOAT32</code> or <code>FLOAT64</code> components. The components are the same format as for <code>boundingVolume.box</code> in 3D Tiles 1.0. This semantic is used to provide a tighter bounding volume than the one implicitly calculated in <code>3DTILES_implicit_tiling</code>
    *
@@ -65,7 +73,7 @@ var MetadataSemantic = {
    */
   TILE_MAXIMUM_HEIGHT: "TILE_MAXIMUM_HEIGHT",
   /**
-   * The horizon occlusion point for a tile, stored as an <code>ARRAY</code> of 3 <code>FLOAT32</code> or <code>FLOAT64</code> components.
+   * The horizon occlusion point for a tile, stored as an <code>VEC3</code> of <code>FLOAT32</code> or <code>FLOAT64</code> components.
    *
    * @see {@link https://cesium.com/blog/2013/04/25/horizon-culling/|Horizon Culling}
    *
@@ -123,7 +131,7 @@ var MetadataSemantic = {
    */
   CONTENT_MAXIMUM_HEIGHT: "CONTENT_MAXIMUM_HEIGHT",
   /**
-   * The horizon occlusion point for the content of a tile, stored as an <code>ARRAY</code> of 3 <code>FLOAT32</code> or <code>FLOAT64</code> components.
+   * The horizon occlusion point for the content of a tile, stored as an <code>VEC3</code> of <code>FLOAT32</code> or <code>FLOAT64</code> components.
    *
    * @see {@link https://cesium.com/blog/2013/04/25/horizon-culling/|Horizon Culling}
    *

--- a/Source/Scene/TilesetMetadata.js
+++ b/Source/Scene/TilesetMetadata.js
@@ -30,8 +30,6 @@ function TilesetMetadata(options) {
 
   this._class = options.class;
   this._properties = properties;
-  this._name = tileset.name;
-  this._description = tileset.description;
   this._extras = tileset.extras;
   this._extensions = tileset.extensions;
 }
@@ -48,34 +46,6 @@ Object.defineProperties(TilesetMetadata.prototype, {
   class: {
     get: function () {
       return this._class;
-    },
-  },
-
-  /**
-   * The name of the tileset.
-   *
-   * @memberof TilesetMetadata.prototype
-   * @type {String}
-   * @readonly
-   * @private
-   */
-  name: {
-    get: function () {
-      return this._name;
-    },
-  },
-
-  /**
-   * The description of the tileset.
-   *
-   * @memberof TilesetMetadata.prototype
-   * @type {String}
-   * @readonly
-   * @private
-   */
-  description: {
-    get: function () {
-      return this._description;
     },
   },
 

--- a/Specs/Data/Cesium3DTiles/Metadata/AllMetadataTypes/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/AllMetadataTypes/tileset.json
@@ -86,7 +86,6 @@
         }
       },
       "tileset": {
-        "name": "Sample Tileset",
         "class": "tileset",
         "properties": {
           "author": "Cesium",

--- a/Specs/Data/Cesium3DTiles/Metadata/ExternalSchema/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/ExternalSchema/tileset.json
@@ -13,7 +13,6 @@
     "3DTILES_metadata": {
       "schemaUri": "schema.json",
       "tileset": {
-        "name": "Sample Tileset",
         "class": "tileset",
         "properties": {
           "author": "Cesium",

--- a/Specs/Data/Cesium3DTiles/Metadata/ImplicitHeightSemantics/s2-tileset.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/ImplicitHeightSemantics/s2-tileset.json
@@ -16,11 +16,11 @@
           "tile": {
             "properties": {
               "minimumHeight": {
-                "type": "FLOAT64",
+                "componentType": "FLOAT64",
                 "semantic": "TILE_MINIMUM_HEIGHT"
               },
               "maximumHeight": {
-                "type": "FLOAT64",
+                "componentType": "FLOAT64",
                 "semantic": "TILE_MAXIMUM_HEIGHT"
               }
             }

--- a/Specs/Data/Cesium3DTiles/Metadata/TilesetMetadata/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/TilesetMetadata/tileset.json
@@ -39,7 +39,6 @@
         }
       },
       "tileset": {
-        "name": "Sample Tileset",
         "class": "tileset",
         "properties": {
           "author": "Cesium",

--- a/Specs/Data/Models/GltfLoader/BoxInstancedInterleaved/glTF/box-instanced-interleaved.gltf
+++ b/Specs/Data/Models/GltfLoader/BoxInstancedInterleaved/glTF/box-instanced-interleaved.gltf
@@ -16,20 +16,20 @@
           "box": {
             "properties": {
               "name": {
-                "type": "STRING"
+                "componentType": "STRING"
               },
               "volume": {
-                "type": "FLOAT32"
+                "componentType": "FLOAT32"
               }
             }
           },
           "section": {
             "properties": {
               "name": {
-                "type": "STRING"
+                "componentType": "STRING"
               },
               "id": {
-                "type": "UINT16"
+                "componentType": "UINT16"
               }
             }
           }

--- a/Specs/Data/Models/GltfLoader/BuildingsMetadata/glTF/buildings-metadata.gltf
+++ b/Specs/Data/Models/GltfLoader/BuildingsMetadata/glTF/buildings-metadata.gltf
@@ -235,10 +235,10 @@
           "building": {
             "properties": {
               "height": {
-                "type": "FLOAT32"
+                "componentType": "FLOAT32"
               },
               "id": {
-                "type": "INT32"
+                "componentType": "INT32"
               }
             }
           }

--- a/Specs/Data/Models/GltfLoader/TriangleFaceBox/glTF/TriangleFaceBox.gltf
+++ b/Specs/Data/Models/GltfLoader/TriangleFaceBox/glTF/TriangleFaceBox.gltf
@@ -28,14 +28,14 @@
             "perTriangle": {
               "properties": {
                 "value": {
-                  "type": "UINT8"
+                  "componentType": "UINT8"
                 }
               }
             },
             "perFace": {
               "properties": {
                 "value": {
-                  "type": "INT8"
+                  "componentType": "INT8"
                 }
               }
             }

--- a/Specs/Scene/Cesium3DTilesetMetadataSpec.js
+++ b/Specs/Scene/Cesium3DTilesetMetadataSpec.js
@@ -9,21 +9,21 @@ describe("Scene/Cesium3DTilesetMetadata", function () {
       city: {
         properties: {
           name: {
-            type: "STRING",
+            componentType: "STRING",
           },
         },
       },
       neighborhood: {
         properties: {
           color: {
-            type: "STRING",
+            componentType: "STRING",
           },
         },
       },
       tree: {
         properties: {
           species: {
-            type: "STRING",
+            componentType: "STRING",
           },
         },
       },

--- a/Specs/Scene/FeatureMetadataSpec.js
+++ b/Specs/Scene/FeatureMetadataSpec.js
@@ -6,17 +6,17 @@ describe("Scene/FeatureMetadata", function () {
       building: {
         properties: {
           name: {
-            type: "STRING",
+            componentType: "STRING",
           },
           height: {
-            type: "FLOAT64",
+            componentType: "FLOAT64",
           },
         },
       },
       tree: {
         properties: {
           species: {
-            type: "STRING",
+            componentType: "STRING",
           },
         },
       },
@@ -33,14 +33,14 @@ describe("Scene/FeatureMetadata", function () {
             componentCount: 3,
           },
           intensity: {
-            type: "UINT8",
+            componentType: "UINT8",
           },
         },
       },
       ortho: {
         properties: {
           vegetation: {
-            type: "UINT8",
+            componentType: "UINT8",
             normalized: true,
           },
         },

--- a/Specs/Scene/GltfFeatureMetadataLoaderSpec.js
+++ b/Specs/Scene/GltfFeatureMetadataLoaderSpec.js
@@ -166,7 +166,7 @@ describe(
       }).toThrowDeveloperError();
     });
 
-    it("throws if neither extension nor extension is defined", function () {
+    it("throws if neither extension nor extensionLegacy is defined", function () {
       expect(function () {
         return new GltfFeatureMetadataLoader({
           gltf: gltf,

--- a/Specs/Scene/GltfFeatureMetadataLoaderSpec.js
+++ b/Specs/Scene/GltfFeatureMetadataLoaderSpec.js
@@ -65,7 +65,7 @@ describe(
         ortho: {
           properties: {
             vegetation: {
-              type: "UINT8",
+              componentType: "UINT8",
               normalized: true,
             },
           },

--- a/Specs/Scene/GroupMetadataSpec.js
+++ b/Specs/Scene/GroupMetadataSpec.js
@@ -13,8 +13,6 @@ describe("Scene/GroupMetadata", function () {
 
     expect(groupMetadata.id).toBe("building");
     expect(groupMetadata.class).toBeUndefined();
-    expect(groupMetadata.name).toBeUndefined();
-    expect(groupMetadata.description).toBeUndefined();
     expect(groupMetadata.extras).toBeUndefined();
     expect(groupMetadata.extensions).toBeUndefined();
   });
@@ -48,8 +46,6 @@ describe("Scene/GroupMetadata", function () {
       class: buildingClass,
       id: "building",
       group: {
-        name: "Building",
-        description: "Building Metadata",
         extras: extras,
         extensions: extensions,
         properties: properties,
@@ -58,8 +54,6 @@ describe("Scene/GroupMetadata", function () {
 
     expect(groupMetadata.id).toBe("building");
     expect(groupMetadata.class).toBe(buildingClass);
-    expect(groupMetadata.name).toBe("Building");
-    expect(groupMetadata.description).toBe("Building Metadata");
     expect(groupMetadata.extras).toBe(extras);
     expect(groupMetadata.extensions).toBe(extensions);
     expect(groupMetadata.getProperty("position")).toEqual(

--- a/Specs/Scene/ImplicitSubtreeSpec.js
+++ b/Specs/Scene/ImplicitSubtreeSpec.js
@@ -1716,7 +1716,7 @@ describe("Scene/ImplicitSubtree", function () {
           tile: {
             properties: {
               stringProperty: {
-                type: "STRING",
+                componentType: "STRING",
               },
               arrayProperty: {
                 type: "ARRAY",

--- a/Specs/Scene/ImplicitTilesetSpec.js
+++ b/Specs/Scene/ImplicitTilesetSpec.js
@@ -246,7 +246,7 @@ describe("Scene/ImplicitTileset", function () {
           tile: {
             properties: {
               buildingCount: {
-                type: "UINT16",
+                componentType: "UINT16",
               },
             },
           },

--- a/Specs/Scene/MetadataClassPropertySpec.js
+++ b/Specs/Scene/MetadataClassPropertySpec.js
@@ -103,7 +103,7 @@ describe("Scene/MetadataClassProperty", function () {
       property: {
         name: "Population",
         description: "Population (thousands)",
-        type: "INT32",
+        componentType: "INT32",
         normalized: true,
         max: max,
         min: min,
@@ -199,7 +199,7 @@ describe("Scene/MetadataClassProperty", function () {
     expect(function () {
       return new MetadataClassProperty({
         property: {
-          type: "FLOAT32",
+          componentType: "FLOAT32",
         },
       });
     }).toThrowDeveloperError();

--- a/Specs/Scene/MetadataClassPropertySpec.js
+++ b/Specs/Scene/MetadataClassPropertySpec.js
@@ -103,7 +103,7 @@ describe("Scene/MetadataClassProperty", function () {
       property: {
         name: "Population",
         description: "Population (thousands)",
-        componentType: "INT32",
+        type: "INT32",
         normalized: true,
         max: max,
         min: min,

--- a/Specs/Scene/MetadataSchemaSpec.js
+++ b/Specs/Scene/MetadataSchemaSpec.js
@@ -90,6 +90,7 @@ describe("Scene/MetadataSchema", function () {
           },
         },
       },
+      id: "mySchema",
       name: "My Schema",
       description: "My Schema Description",
       version: "3.1.0",
@@ -115,6 +116,7 @@ describe("Scene/MetadataSchema", function () {
     expect(treeProperties.species.enumType.id).toBe("species");
     expect(treeProperties.height.id).toBe("height");
 
+    expect(schema.id).toBe("mySchema");
     expect(schema.name).toBe("My Schema");
     expect(schema.description).toBe("My Schema Description");
     expect(schema.version).toBe("3.1.0");

--- a/Specs/Scene/MetadataTableSpec.js
+++ b/Specs/Scene/MetadataTableSpec.js
@@ -37,10 +37,10 @@ describe("Scene/MetadataTable", function () {
   it("creates metadata table", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
       },
       name: {
-        type: "STRING",
+        componentType: "STRING",
       },
     };
     var propertyValues = {
@@ -88,7 +88,7 @@ describe("Scene/MetadataTable", function () {
   it("hasProperty returns false when there's no property with the given property ID", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
       },
     };
     var propertyValues = {
@@ -105,7 +105,7 @@ describe("Scene/MetadataTable", function () {
   it("hasProperty returns true when there's a property with the given property ID", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
       },
     };
     var propertyValues = {
@@ -122,12 +122,12 @@ describe("Scene/MetadataTable", function () {
   it("hasProperty returns true when the class has a default value for a missing property", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
         default: 10.0,
         optional: true,
       },
       name: {
-        type: "STRING",
+        componentType: "STRING",
       },
     };
     var propertyValues = {
@@ -161,7 +161,7 @@ describe("Scene/MetadataTable", function () {
   it("hasPropertyBySemantic returns false when there's no property with the given semantic", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
       },
     };
     var propertyValues = {
@@ -178,7 +178,7 @@ describe("Scene/MetadataTable", function () {
   it("hasPropertyBySemantic returns true when there's a property with the given semantic", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
         semantic: "HEIGHT",
       },
     };
@@ -196,13 +196,13 @@ describe("Scene/MetadataTable", function () {
   it("hasPropertyBySemantic returns true when the class has a default value for a missing property", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
         semantic: "HEIGHT",
         default: 10.0,
         optional: true,
       },
       name: {
-        type: "STRING",
+        componentType: "STRING",
       },
     };
     var propertyValues = {
@@ -236,10 +236,10 @@ describe("Scene/MetadataTable", function () {
   it("getPropertyIds returns array of property IDs", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
       },
       name: {
-        type: "STRING",
+        componentType: "STRING",
       },
     };
     var propertyValues = {
@@ -258,12 +258,12 @@ describe("Scene/MetadataTable", function () {
   it("getPropertyIds includes properties with default values", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
         default: 10.0,
         optional: true,
       },
       name: {
-        type: "STRING",
+        componentType: "STRING",
       },
     };
     var propertyValues = {
@@ -281,10 +281,10 @@ describe("Scene/MetadataTable", function () {
   it("getPropertyIds uses results argument", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
       },
       name: {
-        type: "STRING",
+        componentType: "STRING",
       },
     };
     var propertyValues = {
@@ -307,7 +307,7 @@ describe("Scene/MetadataTable", function () {
   it("getProperty", function () {
     var properties = {
       propertyInt8: {
-        type: "INT8",
+        componentType: "INT8",
       },
     };
 
@@ -337,7 +337,7 @@ describe("Scene/MetadataTable", function () {
   it("getProperty returns undefined when there's no property with the given property ID", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
       },
     };
     var propertyValues = {
@@ -362,10 +362,10 @@ describe("Scene/MetadataTable", function () {
         default: position,
       },
       name: {
-        type: "STRING",
+        componentType: "STRING",
       },
       type: {
-        type: "ENUM",
+        componentType: "ENUM",
         enumType: "myEnum",
         optional: true,
         default: "Other",
@@ -390,7 +390,7 @@ describe("Scene/MetadataTable", function () {
   it("getProperty throws without index", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
       },
     };
     var propertyValues = {
@@ -409,7 +409,7 @@ describe("Scene/MetadataTable", function () {
   it("getProperty throws without propertyId", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
       },
     };
     var propertyValues = {
@@ -428,7 +428,7 @@ describe("Scene/MetadataTable", function () {
   it("getProperty throws if index is out of bounds", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
       },
     };
     var propertyValues = {
@@ -453,7 +453,7 @@ describe("Scene/MetadataTable", function () {
   it("setProperty sets values", function () {
     var properties = {
       propertyInt8: {
-        type: "INT8",
+        componentType: "INT8",
       },
     };
 
@@ -486,7 +486,7 @@ describe("Scene/MetadataTable", function () {
   it("setProperty returns false if the property ID doesn't exist", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
       },
     };
     var propertyValues = {
@@ -503,7 +503,7 @@ describe("Scene/MetadataTable", function () {
   it("setProperty throws without index", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
       },
     };
     var propertyValues = {
@@ -522,7 +522,7 @@ describe("Scene/MetadataTable", function () {
   it("setProperty throws without propertyId", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
       },
     };
     var propertyValues = {
@@ -541,7 +541,7 @@ describe("Scene/MetadataTable", function () {
   it("setProperty throws without value", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
       },
     };
     var propertyValues = {
@@ -560,7 +560,7 @@ describe("Scene/MetadataTable", function () {
   it("setProperty throws if index is out of bounds", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
       },
     };
     var propertyValues = {
@@ -593,7 +593,7 @@ describe("Scene/MetadataTable", function () {
   it("getPropertyBySemantic returns undefined when there's no property with the given semantic", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
       },
     };
     var propertyValues = {
@@ -610,7 +610,7 @@ describe("Scene/MetadataTable", function () {
   it("getPropertyBySemantic returns the property value", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
         semantic: "_HEIGHT",
       },
     };
@@ -628,7 +628,7 @@ describe("Scene/MetadataTable", function () {
   it("getPropertyBySemantic throws without index", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
         semantic: "_HEIGHT",
       },
     };
@@ -648,7 +648,7 @@ describe("Scene/MetadataTable", function () {
   it("getPropertyBySemantic throws without semantic", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
         semantic: "_HEIGHT",
       },
     };
@@ -668,7 +668,7 @@ describe("Scene/MetadataTable", function () {
   it("getPropertyBySemantic throws if index is out of bounds", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
         semantic: "_HEIGHT",
       },
     };
@@ -704,7 +704,7 @@ describe("Scene/MetadataTable", function () {
   it("setPropertyBySemantic returns false if the semantic doesn't exist", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
       },
     };
     var propertyValues = {
@@ -721,7 +721,7 @@ describe("Scene/MetadataTable", function () {
   it("setPropertyBySemantic sets property value", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
         semantic: "_HEIGHT",
       },
     };
@@ -740,7 +740,7 @@ describe("Scene/MetadataTable", function () {
   it("setPropertyBySemantic throws without index", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
         semantic: "_HEIGHT",
       },
     };
@@ -760,7 +760,7 @@ describe("Scene/MetadataTable", function () {
   it("setPropertyBySemantic throws without semantic", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
         semantic: "_HEIGHT",
       },
     };
@@ -780,7 +780,7 @@ describe("Scene/MetadataTable", function () {
   it("setPropertyBySemantic throws without value", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
         semantic: "_HEIGHT",
       },
     };
@@ -800,7 +800,7 @@ describe("Scene/MetadataTable", function () {
   it("setPropertyBySemantic throws if index is out of bounds", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
         semantic: "_HEIGHT",
       },
     };
@@ -827,7 +827,7 @@ describe("Scene/MetadataTable", function () {
   it("getPropertyTypedArray returns typed array", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
       },
     };
     var propertyValues = {
@@ -849,7 +849,7 @@ describe("Scene/MetadataTable", function () {
   it("getPropertyTypedArray returns undefined if property does not exist", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
       },
     };
     var propertyValues = {
@@ -877,7 +877,7 @@ describe("Scene/MetadataTable", function () {
   it("getPropertyTypedArrayBySemantic returns typed array", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
         semantic: "HEIGHT",
       },
     };
@@ -900,7 +900,7 @@ describe("Scene/MetadataTable", function () {
   it("getPropertyTypedArrayBySemantic returns undefined if semantic does not exist", function () {
     var properties = {
       height: {
-        type: "FLOAT32",
+        componentType: "FLOAT32",
       },
     };
     var propertyValues = {

--- a/Specs/Scene/ModelExperimental/ModelExperimental3DTileContentSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimental3DTileContentSpec.js
@@ -177,10 +177,10 @@ describe("Scene/ModelExperimental/ModelExperimental3DTileContent", function () {
       class: {
         properties: {
           name: {
-            type: "STRING",
+            componentType: "STRING",
           },
           height: {
-            type: "FLOAT32",
+            componentType: "FLOAT32",
           },
         },
       },

--- a/Specs/Scene/PropertyTextureSpec.js
+++ b/Specs/Scene/PropertyTextureSpec.js
@@ -27,10 +27,10 @@ describe("Scene/PropertyTexture", function () {
             componentCount: 3,
           },
           intensity: {
-            type: "UINT8",
+            componentType: "UINT8",
           },
           ortho: {
-            type: "UINT8",
+            componentType: "UINT8",
             normalized: true,
           },
         },

--- a/Specs/Scene/TilesetMetadataSpec.js
+++ b/Specs/Scene/TilesetMetadataSpec.js
@@ -11,8 +11,6 @@ describe("Scene/TilesetMetadata", function () {
     });
 
     expect(tilesetMetadata.class).toBeUndefined();
-    expect(tilesetMetadata.name).toBeUndefined();
-    expect(tilesetMetadata.description).toBeUndefined();
     expect(tilesetMetadata.extras).toBeUndefined();
   });
 
@@ -44,8 +42,6 @@ describe("Scene/TilesetMetadata", function () {
     var tilesetMetadata = new TilesetMetadata({
       class: cityClass,
       tileset: {
-        name: "City",
-        description: "City Metadata",
         extras: extras,
         extensions: extensions,
         properties: properties,
@@ -53,8 +49,6 @@ describe("Scene/TilesetMetadata", function () {
     });
 
     expect(tilesetMetadata.class).toBe(cityClass);
-    expect(tilesetMetadata.name).toBe("City");
-    expect(tilesetMetadata.description).toBe("City Metadata");
     expect(tilesetMetadata.extras).toBe(extras);
     expect(tilesetMetadata.extensions).toBe(extensions);
     expect(tilesetMetadata.getProperty("neighborhoods")).toEqual(

--- a/Specs/Scene/parseBoundingVolumeSemanticsSpec.js
+++ b/Specs/Scene/parseBoundingVolumeSemanticsSpec.js
@@ -46,19 +46,19 @@ describe("Scene/parseBoundingVolumeSemantics", function () {
       class: {
         properties: {
           tileMinimumHeight: {
-            type: "FLOAT32",
+            componentType: "FLOAT32",
             semantic: "TILE_MINIMUM_HEIGHT",
           },
           tileMaximumHeight: {
-            type: "FLOAT32",
+            componentType: "FLOAT32",
             semantic: "TILE_MAXIMUM_HEIGHT",
           },
           contentMinimumHeight: {
-            type: "FLOAT32",
+            componentType: "FLOAT32",
             semantic: "CONTENT_MINIMUM_HEIGHT",
           },
           contentMaximumHeight: {
-            type: "FLOAT32",
+            componentType: "FLOAT32",
             semantic: "CONTENT_MAXIMUM_HEIGHT",
           },
         },

--- a/Specs/Scene/parseFeatureMetadataLegacySpec.js
+++ b/Specs/Scene/parseFeatureMetadataLegacySpec.js
@@ -16,17 +16,17 @@ describe(
         building: {
           properties: {
             name: {
-              type: "STRING",
+              componentType: "STRING",
             },
             height: {
-              type: "FLOAT64",
+              componentType: "FLOAT64",
             },
           },
         },
         tree: {
           properties: {
             species: {
-              type: "STRING",
+              componentType: "STRING",
             },
           },
         },
@@ -43,14 +43,14 @@ describe(
               componentCount: 3,
             },
             intensity: {
-              type: "UINT8",
+              componentType: "UINT8",
             },
           },
         },
         ortho: {
           properties: {
             vegetation: {
-              type: "UINT8",
+              componentType: "UINT8",
               normalized: true,
             },
           },

--- a/Specs/Scene/parseFeatureMetadataLegacySpec.js
+++ b/Specs/Scene/parseFeatureMetadataLegacySpec.js
@@ -16,17 +16,17 @@ describe(
         building: {
           properties: {
             name: {
-              componentType: "STRING",
+              type: "STRING",
             },
             height: {
-              componentType: "FLOAT64",
+              type: "FLOAT64",
             },
           },
         },
         tree: {
           properties: {
             species: {
-              componentType: "STRING",
+              type: "STRING",
             },
           },
         },
@@ -43,14 +43,14 @@ describe(
               componentCount: 3,
             },
             intensity: {
-              componentType: "UINT8",
+              type: "UINT8",
             },
           },
         },
         ortho: {
           properties: {
             vegetation: {
-              componentType: "UINT8",
+              type: "UINT8",
               normalized: true,
             },
           },


### PR DESCRIPTION
Some of the code was out of date with the spec changes made over the last couple of months.

* Added `DESCRIPTION` semantic: https://github.com/CesiumGS/3d-tiles/pull/540
* Added `schema.id`: https://github.com/CesiumGS/3d-tiles/pull/539
* Removed `name` and `description` from group and tileset metadata: https://github.com/CesiumGS/3d-tiles/pull/524
* Horizon occlusion point semantic is now a `VEC3`
* Fixed types that should have been `componentType`