### PR TITLE
Handle vec3 colors correctly in custom shaders

### DIFF
--- a/Apps/Sandcastle/gallery/Custom Shaders Models.html
+++ b/Apps/Sandcastle/gallery/Custom Shaders Models.html
@@ -313,7 +313,8 @@
             // of the wave, but at a different speed.
             // Coefficients were chosen arbitrarily
             "    vec2 uv = fsInput.attributes.positionMC.xy;",
-            "    material.diffuse = vec3(0.2, 0.3, 0.4) + vec3(0.2, 0.3, 0.4) * sin(2.0 * czm_pi * vec3(3.0, 2.0, 1.0) * uv.x - 3.0 * u_time);",
+            "    material.diffuse = 0.2 * fsInput.attributes.color_0.rgb;",
+            "    material.diffuse += vec3(0.2, 0.3, 0.4) + vec3(0.2, 0.3, 0.4) * sin(2.0 * czm_pi * vec3(3.0, 2.0, 1.0) * uv.x - 3.0 * u_time);",
             "}",
           ].join("\n"),
         });

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 
 - Fixed handling of vec3 vertex colors in `ModelExperimental`. [#9955](https://github.com/CesiumGS/cesium/pull/9955)
 - Fixed handling of Draco quantized vec3 vertex colors in `ModelExperimental`. [#9957](https://github.com/CesiumGS/cesium/pull/9957)
+- Fixed handling of vec3 vertex colors in `CustomShaderPipelineStage`. [#9964](https://github.com/CesiumGS/cesium/pull/9964)
 
 ### 1.88 - 2021-12-01
 


### PR DESCRIPTION
Don't merge this until https://github.com/CesiumGS/cesium/pull/9960 is merged first.

This continues the saga of #9955 and #9957, looks like I missed a spot in `CustomShaderPipelineStage` -- looks like I wasn't using `ModelExperimentalUtility.getAttributeInfo` which computes the correct GLSL type of `vec4` in this case.

@lilleyse could you review?

Use [this local Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html?src=Custom%20Shaders%20Models.html&label=3D%20Tiles%20Next) -- last item in the dropdown. I updated the shader to use `fsInput.attributes.color_0`, now it doesn't crash like in previous branches.