### PR TITLE
Remove broken debug depth options in Scene.js

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ### 1.89 - 2022-01-03
 
+##### Breaking Changes :mega:
+
+- Removed `Scene.debugShowGlobeDepth`. [#9965](https://github.com/CesiumGS/cesium/pull/9965)
+- Removed `CesiumInspectorViewModel.globeDepth` and `CesiumInspectorViewModel.pickDepth`. [#9965](https://github.com/CesiumGS/cesium/pull/9965)
+
 ##### Additions :tada:
 
 - Added a `pointSize` field to custom vertex shaders for more control over

--- a/Source/Scene/GlobeDepth.js
+++ b/Source/Scene/GlobeDepth.js
@@ -49,7 +49,6 @@ function GlobeDepth() {
   this._useScissorTest = false;
   this._scissorRectangle = undefined;
 
-  this._useLogDepth = undefined;
   this._useHdr = undefined;
   this._clearGlobeDepth = undefined;
 }

--- a/Source/Scene/GlobeDepth.js
+++ b/Source/Scene/GlobeDepth.js
@@ -8,7 +8,6 @@ import Framebuffer from "../Renderer/Framebuffer.js";
 import PixelDatatype from "../Renderer/PixelDatatype.js";
 import RenderState from "../Renderer/RenderState.js";
 import Sampler from "../Renderer/Sampler.js";
-import ShaderSource from "../Renderer/ShaderSource.js";
 import Texture from "../Renderer/Texture.js";
 import PassThrough from "../Shaders/PostProcessStages/PassThrough.js";
 import PassThroughDepth from "../Shaders/PostProcessStages/PassThroughDepth.js";

--- a/Source/Scene/GlobeDepth.js
+++ b/Source/Scene/GlobeDepth.js
@@ -53,8 +53,6 @@ function GlobeDepth() {
   this._useLogDepth = undefined;
   this._useHdr = undefined;
   this._clearGlobeDepth = undefined;
-
-  this._debugGlobeDepthViewportCommand = undefined;
 }
 
 Object.defineProperties(GlobeDepth.prototype, {
@@ -69,47 +67,6 @@ Object.defineProperties(GlobeDepth.prototype, {
     },
   },
 });
-
-function executeDebugGlobeDepth(globeDepth, context, passState, useLogDepth) {
-  if (
-    !defined(globeDepth._debugGlobeDepthViewportCommand) ||
-    useLogDepth !== globeDepth._useLogDepth
-  ) {
-    var fsSource =
-      "uniform highp sampler2D u_depthTexture;\n" +
-      "varying vec2 v_textureCoordinates;\n" +
-      "void main()\n" +
-      "{\n" +
-      "    float z_window = czm_unpackDepth(texture2D(u_depthTexture, v_textureCoordinates));\n" +
-      "    z_window = czm_reverseLogDepth(z_window); \n" +
-      "    float n_range = czm_depthRange.near;\n" +
-      "    float f_range = czm_depthRange.far;\n" +
-      "    float z_ndc = (2.0 * z_window - n_range - f_range) / (f_range - n_range);\n" +
-      "    float scale = pow(z_ndc * 0.5 + 0.5, 8.0);\n" +
-      "    gl_FragColor = vec4(mix(vec3(0.0), vec3(1.0), scale), 1.0);\n" +
-      "}\n";
-    var fs = new ShaderSource({
-      defines: [useLogDepth ? "LOG_DEPTH" : ""],
-      sources: [fsSource],
-    });
-
-    globeDepth._debugGlobeDepthViewportCommand = context.createViewportQuadCommand(
-      fs,
-      {
-        uniformMap: {
-          u_depthTexture: function () {
-            return globeDepth._globeDepthTexture;
-          },
-        },
-        owner: globeDepth,
-      }
-    );
-
-    globeDepth._useLogDepth = useLogDepth;
-  }
-
-  globeDepth._debugGlobeDepthViewportCommand.execute(context, passState);
-}
 
 function destroyTextures(globeDepth) {
   globeDepth._globeColorTexture =
@@ -464,14 +421,6 @@ function updateCopyCommands(globeDepth, context, width, height, passState) {
   globeDepth._mergeColorCommand.renderState = globeDepth._rsBlend;
 }
 
-GlobeDepth.prototype.executeDebugGlobeDepth = function (
-  context,
-  passState,
-  useLogDepth
-) {
-  executeDebugGlobeDepth(this, context, passState, useLogDepth);
-};
-
 GlobeDepth.prototype.update = function (
   context,
   passState,
@@ -587,10 +536,6 @@ GlobeDepth.prototype.destroy = function () {
 
   if (defined(this._mergeColorCommand)) {
     this._mergeColorCommand.shaderProgram = this._mergeColorCommand.shaderProgram.destroy();
-  }
-
-  if (defined(this._debugGlobeDepthViewportCommand)) {
-    this._debugGlobeDepthViewportCommand.shaderProgram = this._debugGlobeDepthViewportCommand.shaderProgram.destroy();
   }
 
   return destroyObject(this);

--- a/Source/Scene/PickDepth.js
+++ b/Source/Scene/PickDepth.js
@@ -16,8 +16,6 @@ function PickDepth() {
   this._depthTexture = undefined;
   this._textureToCopy = undefined;
   this._copyDepthCommand = undefined;
-
-  this._useLogDepth = undefined;
 }
 
 function destroyTextures(pickDepth) {

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -3483,7 +3483,6 @@ function updateAndClearFramebuffers(scene, passState, clearColor) {
  */
 Scene.prototype.resolveFramebuffers = function (passState) {
   var context = this._context;
-  var frameState = this._frameState;
   var environmentState = this._environmentState;
   var view = this._view;
   var globeDepth = view.globeDepth;
@@ -3537,13 +3536,6 @@ Scene.prototype.resolveFramebuffers = function (passState) {
   if (!useOIT && !usePostProcess && useGlobeDepthFramebuffer) {
     passState.framebuffer = defaultFramebuffer;
     globeDepth.executeCopyColor(context, passState);
-  }
-
-  var useLogDepth = frameState.useLogDepth;
-
-  if (this.debugShowPickDepth && useGlobeDepthFramebuffer) {
-    var pd = this._picking.getPickDepth(this, this.debugShowDepthFrustum - 1);
-    pd.executeDebugPickDepth(context, passState, useLogDepth);
   }
 };
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -47,7 +47,6 @@ import DerivedCommand from "./DerivedCommand.js";
 import DeviceOrientationCameraController from "./DeviceOrientationCameraController.js";
 import Fog from "./Fog.js";
 import FrameState from "./FrameState.js";
-import GlobeDepth from "./GlobeDepth.js";
 import GlobeTranslucencyState from "./GlobeTranslucencyState.js";
 import InvertClassification from "./InvertClassification.js";
 import JobScheduler from "./JobScheduler.js";
@@ -2386,8 +2385,6 @@ function executeCommands(scene, passState) {
       // Render to globe framebuffer in GLOBE pass
       passState.framebuffer = globeDepth.framebuffer;
     }
-
-    var fb;
 
     clearDepth.execute(context, passState);
 

--- a/Source/Scene/View.js
+++ b/Source/Scene/View.js
@@ -63,7 +63,6 @@ function View(scene, camera, viewport) {
     context
   );
   this.pickDepths = [];
-  this.debugGlobeDepths = [];
   this.frustumCommandsList = [];
   this.debugFrustumStatistics = undefined;
 
@@ -426,16 +425,10 @@ View.prototype.destroy = function () {
   var length;
 
   var pickDepths = this.pickDepths;
-  var debugGlobeDepths = this.debugGlobeDepths;
 
   length = pickDepths.length;
   for (i = 0; i < length; ++i) {
     pickDepths[i].destroy();
-  }
-
-  length = debugGlobeDepths.length;
-  for (i = 0; i < length; ++i) {
-    debugGlobeDepths[i].destroy();
   }
 };
 export default View;

--- a/Source/Widgets/CesiumInspector/CesiumInspector.js
+++ b/Source/Widgets/CesiumInspector/CesiumInspector.js
@@ -91,15 +91,6 @@ function CesiumInspector(container, scene) {
   shaderCacheDisplay.setAttribute("data-bind", "html: shaderCacheText");
   generalSection.appendChild(shaderCacheDisplay);
 
-  // https://github.com/CesiumGS/cesium/issues/6763
-  // var globeDepth = createCheckbox('Show globe depth', 'globeDepth');
-  // generalSection.appendChild(globeDepth);
-  //
-  // var globeDepthFrustum = document.createElement('div');
-  // globeDepth.appendChild(globeDepthFrustum);
-  //
-  // generalSection.appendChild(createCheckbox('Show pick depth', 'pickDepth'));
-
   var depthFrustum = document.createElement("div");
   generalSection.appendChild(depthFrustum);
 

--- a/Source/Widgets/CesiumInspector/CesiumInspectorViewModel.js
+++ b/Source/Widgets/CesiumInspector/CesiumInspectorViewModel.js
@@ -157,20 +157,6 @@ function CesiumInspectorViewModel(scene, performanceContainer) {
   this.wireframe = false;
 
   /**
-   * Gets or sets the show globe depth state.  This property is observable.
-   * @type {Boolean}
-   * @default false
-   */
-  this.globeDepth = false;
-
-  /**
-   * Gets or sets the show pick depth state.  This property is observable.
-   * @type {Boolean}
-   * @default false
-   */
-  this.pickDepth = false;
-
-  /**
    * Gets or sets the index of the depth frustum to display.  This property is observable.
    * @type {Number}
    * @default 1
@@ -280,8 +266,6 @@ function CesiumInspectorViewModel(scene, performanceContainer) {
     "tileBoundingSphere",
     "filterTile",
     "wireframe",
-    "globeDepth",
-    "pickDepth",
     "depthFrustum",
     "suspendUpdates",
     "tileCoordinates",
@@ -996,8 +980,6 @@ CesiumInspectorViewModel.prototype.destroy = function () {
   this._primitiveReferenceFrameSubscription.dispose();
   this._filterPrimitiveSubscription.dispose();
   this._wireframeSubscription.dispose();
-  this._globeDepthSubscription.dispose();
-  this._pickDepthSubscription.dispose();
   this._depthFrustumSubscription.dispose();
   this._suspendUpdatesSubscription.dispose();
   this._tileCoordinatesSubscription.dispose();

--- a/Source/Widgets/CesiumInspector/CesiumInspectorViewModel.js
+++ b/Source/Widgets/CesiumInspector/CesiumInspectorViewModel.js
@@ -410,20 +410,6 @@ function CesiumInspectorViewModel(scene, performanceContainer) {
       that._scene.requestRender();
     });
 
-  this._globeDepthSubscription = knockout
-    .getObservable(this, "globeDepth")
-    .subscribe(function (val) {
-      that._scene.debugShowGlobeDepth = val;
-      that._scene.requestRender();
-    });
-
-  this._pickDepthSubscription = knockout
-    .getObservable(this, "pickDepth")
-    .subscribe(function (val) {
-      that._scene.debugShowPickDepth = val;
-      that._scene.requestRender();
-    });
-
   this._depthFrustumSubscription = knockout
     .getObservable(this, "depthFrustum")
     .subscribe(function (val) {

--- a/Specs/Scene/SceneSpec.js
+++ b/Specs/Scene/SceneSpec.js
@@ -310,31 +310,6 @@ describe(
       scene.debugShowFramesPerSecond = false;
     });
 
-    it("debugShowGlobeDepth", function () {
-      if (!scene.context.depthTexture) {
-        return;
-      }
-
-      var rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
-      scene.camera.setView({ destination: rectangle });
-
-      var rectanglePrimitive = createRectangle(rectangle);
-      rectanglePrimitive.appearance.material.uniforms.color = new Color(
-        1.0,
-        0.0,
-        0.0,
-        1.0
-      );
-
-      scene.primitives.add(rectanglePrimitive);
-      expect(scene).toRender([255, 0, 0, 255]);
-
-      scene.debugShowGlobeDepth = true;
-      expect(scene).notToRender([255, 0, 0, 255]);
-
-      scene.debugShowGlobeDepth = false;
-    });
-
     it("opaque/translucent render order (1)", function () {
       var rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
 


### PR DESCRIPTION
This PR removes some code that's been broken for a while: https://github.com/CesiumGS/cesium/issues/6763. If we ever fix this code these commits can be reverted, but for now it's helpful to simplify Scene.js, GlobeDepth.js, and PickDepth.js so the Framebuffer code can be refactored.

- Removes `debugGlobeDepthViewportCommand` in `GlobeDepth`
- Removes `debugPickDepthViewportCommand` in `PickDepth`
- Removes `debugShowGlobeDepth` and `debugShowPickDepth` (which was only set through the inspector) options from `Scene`
- Removes `debugGlobeDepths` array in `View`
- Removes globe depth and pick depth toggles in the `CesiumInspector` widget and view model
- Removes a test testing debug globe depth in `SceneSpec`