### PR TITLE
3D Tiles: Don't double-apply transform from placeholder implicit tile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 - Fixed handling of vec3 vertex colors in `ModelExperimental`. [#9955](https://github.com/CesiumGS/cesium/pull/9955)
 - Fixed handling of Draco quantized vec3 vertex colors in `ModelExperimental`. [#9957](https://github.com/CesiumGS/cesium/pull/9957)
 - Fixed handling of vec3 vertex colors in `CustomShaderPipelineStage`. [#9964](https://github.com/CesiumGS/cesium/pull/9964)
+- Fixed handling of subtree root transforms in `Implicit3DTileContent`. [#9971](https://github.com/CesiumGS/cesium/pull/9971)
 
 ### 1.88 - 2021-12-01
 

--- a/Source/Scene/Implicit3DTileContent.js
+++ b/Source/Scene/Implicit3DTileContent.js
@@ -476,6 +476,7 @@ function deriveChildTile(
   var deep = true;
   var rootHeader = clone(implicitTileset.tileHeader, deep);
   delete rootHeader.boundingVolume;
+  delete rootHeader.transform;
   var combinedTileJson = combine(tileJson, rootHeader, deep);
 
   var childTile = makeTile(

--- a/Specs/Scene/Implicit3DTileContentSpec.js
+++ b/Specs/Scene/Implicit3DTileContentSpec.js
@@ -41,6 +41,7 @@ describe(
       boundingVolume: {
         box: [0, 0, 0, 256, 0, 0, 0, 256, 0, 0, 0, 256],
       },
+      transform: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 10, 0, 0, 1],
       content: {
         uri: "https://example.com/{level}/{x}/{y}.b3dm",
         extras: {
@@ -138,6 +139,7 @@ describe(
         boundingVolume: {
           box: [0, 0, 0, 256, 0, 0, 0, 256, 0, 0, 0, 256],
         },
+        transform: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 10, 0, 0, 1],
       });
       mockPlaceholderTile.implicitCoordinates = rootCoordinates;
       mockPlaceholderTile.implicitTileset = implicitTileset;
@@ -236,7 +238,7 @@ describe(
       var parentGeometricError = implicitTileset.geometricError / 4;
       var childGeometricError = implicitTileset.geometricError / 8;
 
-      var rootBoundingVolume = [0, 0, 0, 256, 0, 0, 0, 256, 0, 0, 0, 256];
+      var rootBoundingVolume = [10, 0, 0, 256, 0, 0, 0, 256, 0, 0, 0, 256];
       var parentBox = Implicit3DTileContent._deriveBoundingBox(
         rootBoundingVolume,
         parentCoordinates.level,
@@ -543,7 +545,7 @@ describe(
           [2, 0, 3],
           [2, 1, 3],
         ];
-        var rootBoundingVolume = [0, 0, 0, 256, 0, 0, 0, 256, 0, 0, 0, 256];
+        var rootBoundingVolume = [10, 0, 0, 256, 0, 0, 0, 256, 0, 0, 0, 256];
 
         var subtreeRootTile = mockPlaceholderTile.children[0];
         var tiles = [];
@@ -566,6 +568,22 @@ describe(
           );
           expect(childBox).toEqual(expectedBounds);
         }
+      });
+    });
+
+    it("propagates transform", function () {
+      var content = new Implicit3DTileContent(
+        mockTileset,
+        mockPlaceholderTile,
+        tilesetResource,
+        quadtreeBuffer,
+        0
+      );
+      return content.readyPromise.then(function () {
+        var subtreeRootTile = mockPlaceholderTile.children[0];
+        expect(subtreeRootTile.computedTransform).toEqual(
+          mockPlaceholderTile.transform
+        );
       });
     });
 


### PR DESCRIPTION
The placeholder implicit tile transform was being double-applied to its child tile, causing it to go to the wrong spot and not render. This was happening because the `combine` function was copying the parent transform to the child transform and then multiplying with the parent transform again in `Cesium3DTile`. The fix is similar to https://github.com/CesiumGS/cesium/pull/9940.

[Sample Data](https://github.com/CesiumGS/cesium/files/7681284/tileset.zip) - [Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=bZHJbtswEIZfhdBJBgLSTS6FqxgFkkuABCnQoCdeGGocT0PNCORIXoq8e6mlTtqal8Es3z8LexdVj7CDqK4VwU7dQMKu0T/GWGkLP/o3TOKQINpi8cWSpT5zbcQGBXvI6KShkwcCfUok7eq6/CA7mavbJwyQQMpflpTqYlgpW2xF2pUxgb0LW06y+rxcXpokTtAbmYA/Vv9MTLaw9LaY5jm11BFcffgWucEEWrZA5aYjL8hULtTYb571yNw8cXkiB6G3hebMxF2G3zmIcUY9U+IAOvDLGB2R6SCTKOwFqC7ndafgX0vfUWrBC8cH3CMN7Ez6s1WjxAPXEPS8ej72aeRMFxdFleQQYD3MN7yv2LQcZThrqbURaNrgBJJ57vxrPp1PaWg7lFbmI1rV2Cusr898uvLBpZQzmy6E73gEW6wrk+v/QwO7GunlsYcY3GEo235a309BrXVlsnueFObw7OI/yr8B)

Before                     |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/1328450/145312527-63e251fb-5855-4c40-a160-ac4f0c5767f5.png)  |  ![](https://user-images.githubusercontent.com/1328450/145312538-2a1404d1-fe47-4b61-b315-3539b0bf06d3.png)
