### PR TITLE
fix vector tile byteoffset alignment to 4 bytes

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -303,3 +303,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Robin Danielsson](https://github.com/robdan7)
 - [Oskar Havo](https://github.com/OskarHavo)
 - [Mark Williams](https://github.com/markw65)
+- [Rain Liang](https://github.com/rainliang000)

--- a/Source/Scene/Vector3DTileContent.js
+++ b/Source/Scene/Vector3DTileContent.js
@@ -408,7 +408,7 @@ function initialize(content, arrayBuffer, byteOffset) {
   }
 
   var batchIds = getBatchIds(featureTableJson, featureTableBinary);
-  byteOffset += byteOffset % 4;
+  byteOffset += (4 - (byteOffset % 4)) % 4;
 
   if (numberOfPolygons > 0) {
     featureTable.featuresLength = numberOfPolygons;


### PR DESCRIPTION
Fix byte offset alignment. 
>byteOffset += byteOffset % 4;

If the byte offset mod 4 is 1, we should add 3 to the alignment.

So i change it to
>byteOffset += (4 - (byteOffset % 4)) % 4;
