### PR TITLE
Fix loading of Draco compressed model

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
 - Fixed handling of Draco quantized vec3 vertex colors in `ModelExperimental`. [#9957](https://github.com/CesiumGS/cesium/pull/9957)
 - Fixed handling of vec3 vertex colors in `CustomShaderPipelineStage`. [#9964](https://github.com/CesiumGS/cesium/pull/9964)
 - Fixed handling of subtree root transforms in `Implicit3DTileContent`. [#9971](https://github.com/CesiumGS/cesium/pull/9971)
+- Fixed issue in `ModelExperimental` where indices were not the correct data type after draco decode.
 
 ### 1.88 - 2021-12-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@
 - Fixed handling of Draco quantized vec3 vertex colors in `ModelExperimental`. [#9957](https://github.com/CesiumGS/cesium/pull/9957)
 - Fixed handling of vec3 vertex colors in `CustomShaderPipelineStage`. [#9964](https://github.com/CesiumGS/cesium/pull/9964)
 - Fixed handling of subtree root transforms in `Implicit3DTileContent`. [#9971](https://github.com/CesiumGS/cesium/pull/9971)
-- Fixed issue in `ModelExperimental` where indices were not the correct data type after draco decode.
+- Fixed issue in `ModelExperimental` where indices were not the correct data type after draco decode. [#9974](https://github.com/CesiumGS/cesium/pull/9974)
 
 ### 1.88 - 2021-12-01
 

--- a/Source/Scene/GltfIndexBufferLoader.js
+++ b/Source/Scene/GltfIndexBufferLoader.js
@@ -1,4 +1,5 @@
 import Check from "../Core/Check.js";
+import ComponentDatatype from "../Core/ComponentDatatype.js";
 import defaultValue from "../Core/defaultValue.js";
 import defined from "../Core/defined.js";
 import IndexDatatype from "../Core/IndexDatatype.js";
@@ -134,6 +135,21 @@ Object.defineProperties(GltfIndexBufferLoader.prototype, {
       return this._typedArray;
     },
   },
+
+  /**
+   * The index datatype after decode.
+   *
+   * @memberof GltfIndexBufferLoader.prototype
+   *
+   * @type {IndexDatatype}
+   * @readonly
+   * @private
+   */
+  indexDatatype: {
+    get: function () {
+      return this._indexDatatype;
+    },
+  },
 });
 
 /**
@@ -166,8 +182,12 @@ function loadFromDraco(indexBufferLoader) {
         return;
       }
       // Now wait for process() to run to finish loading
-      indexBufferLoader._typedArray =
-        dracoLoader.decodedData.indices.typedArray;
+      var typedArray = dracoLoader.decodedData.indices.typedArray;
+      indexBufferLoader._typedArray = typedArray;
+      // The index datatype may be a smaller datatype after draco decode
+      indexBufferLoader._indexDatatype = ComponentDatatype.fromTypedArray(
+        typedArray
+      );
       indexBufferLoader._state = ResourceLoaderState.PROCESSING;
     })
     .otherwise(function (error) {

--- a/Source/Scene/GltfLoader.js
+++ b/Source/Scene/GltfLoader.js
@@ -622,7 +622,6 @@ function loadIndices(loader, gltf, accessorId, draco) {
   }
 
   var indices = new Indices();
-  indices.indexDatatype = accessor.componentType;
   indices.count = accessor.count;
 
   var loadAsTypedArray = loader._loadAsTypedArray;
@@ -639,6 +638,8 @@ function loadIndices(loader, gltf, accessorId, draco) {
     if (loader.isDestroyed()) {
       return;
     }
+
+    indices.indexDatatype = indexBufferLoader.indexDatatype;
 
     if (loadAsTypedArray) {
       indices.typedArray = indexBufferLoader.typedArray;

--- a/Specs/Scene/GltfIndexBufferLoaderSpec.js
+++ b/Specs/Scene/GltfIndexBufferLoaderSpec.js
@@ -1,5 +1,6 @@
 import {
   Buffer,
+  clone,
   ComponentDatatype,
   DracoLoader,
   GltfBufferViewLoader,
@@ -545,6 +546,37 @@ describe(
         expect(indexBufferLoader.buffer.sizeInBytes).toBe(
           decodedIndices.byteLength
         );
+      });
+    });
+
+    it("uses the decoded data's type instead of the accessor component type", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        when.resolve(arrayBuffer)
+      );
+
+      spyOn(DracoLoader, "decodeBufferView").and.returnValue(
+        when.resolve(decodeDracoResults)
+      );
+
+      var clonedGltf = clone(gltfDraco, true);
+      clonedGltf.accessors[2].componentType = 5125;
+
+      var indexBufferLoader = new GltfIndexBufferLoader({
+        resourceCache: ResourceCache,
+        gltf: clonedGltf,
+        accessorId: 2,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        draco: dracoExtension,
+      });
+
+      indexBufferLoader.load();
+
+      return waitForLoaderProcess(indexBufferLoader, scene).then(function (
+        indexBufferLoader
+      ) {
+        expect(indexBufferLoader.indexDatatype).toBe(5123);
+        expect(indexBufferLoader.buffer.indexDatatype).toBe(5123);
       });
     });
 


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/9972

The componentType of the indices accessor was 5125 (UNSIGNED_INT) but the typed array returned by `decodeDraco` was `Uint16Array`, causing a mismatch between the buffer's index datatype and the buffer's contents that resulted in a WebGL error. The fix was to use the index datatype of the decoded data instead of the accessor's component type.

Why does this model use 5125 for it's componentType? I'm not sure. The model only has 600 or so vertices. But technically it's valid so we should support this case.