### PR TITLE
Use availability to determine when entity paths should be shown

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 - Fixed `scene.pickTranslucentDepth` for translucent point clouds with eye dome lighting. [#9991](https://github.com/CesiumGS/cesium/pull/9991)
 - Added a setter for `tileset.pointCloudShading` that throws if set to `undefined` to clarify that this is disallowed. [#9998](https://github.com/CesiumGS/cesium/pull/9998)
 - Fixes handling .b3dm `_BATCHID` accessors in `ModelExperimental` [#10008](https://github.com/CesiumGS/cesium/pull/10008)
+- Fixed path entity being drawn when data is unavailable [#1704](https://github.com/CesiumGS/cesium/pull/1704)
 
 ### 1.89 - 2022-01-03
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -308,3 +308,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [lyqh-ctx](https://github.com/lyqh-ctx)
 - [David Tryse](https://github.com/dtryse)
 - [Martin Chan](https://github.com/martin-bom)
+- [Jon Beniston](https://github.com/srcejon)

--- a/Source/DataSources/PathVisualizer.js
+++ b/Source/DataSources/PathVisualizer.js
@@ -452,7 +452,7 @@ PolylineUpdater.prototype.updateObject = function (time, item) {
   var showProperty = pathGraphics._show;
   var polyline = item.polyline;
   var show =
-    entity.isShowing && (!defined(showProperty) || showProperty.getValue(time));
+    entity.isShowing && entity.isAvailable(time) && (!defined(showProperty) || showProperty.getValue(time));
 
   //While we want to show the path, there may not actually be anything to show
   //depending on lead/trail settings.  Compute the interval of the path to

--- a/Source/DataSources/PathVisualizer.js
+++ b/Source/DataSources/PathVisualizer.js
@@ -452,7 +452,9 @@ PolylineUpdater.prototype.updateObject = function (time, item) {
   var showProperty = pathGraphics._show;
   var polyline = item.polyline;
   var show =
-    entity.isShowing && entity.isAvailable(time) && (!defined(showProperty) || showProperty.getValue(time));
+    entity.isShowing &&
+    entity.isAvailable(time) &&
+    (!defined(showProperty) || showProperty.getValue(time));
 
   //While we want to show the path, there may not actually be anything to show
   //depending on lead/trail settings.  Compute the interval of the path to


### PR DESCRIPTION
As per https://community.cesium.com/t/entity-path-not-disappearing-when-entity-is-not-available/8551 and #1740, it seems entity paths are always shown even when other parts of the entity are no longer displayed due to its availability value.

This patch makes it so that the path is only displayed when the entity is available.
