### PR TITLE
Make enableModelExperimental a per-tileset setting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 - Added a `pointSize` field to custom vertex shaders for more control over shading point clouds. [#9960](https://github.com/CesiumGS/cesium/pull/9960)
 - Added `lambertDiffuseMultiplier` property to Globe object to enhance terrain lighting. [#9878](https://github.com/CesiumGS/cesium/pull/9878)
 - Added `getFeatureInfoUrl` option to `WebMapServiceImageryProvider` which reads the getFeatureInfo request URL for WMS service if it differs with the getCapabilities URL. [#9563](https://github.com/CesiumGS/cesium/pull/9563)
+- Added `tileset.enableModelExperimental` so tilesets with `Model` and `ModelExperimental` can be mixed in the same scene. [#9982](https://github.com/CesiumGS/cesium/pull/9982)
 
 ##### Fixes :wrench:
 

--- a/Source/Scene/Cesium3DTileContentFactory.js
+++ b/Source/Scene/Cesium3DTileContentFactory.js
@@ -8,7 +8,6 @@ import PointCloud3DTileContent from "./PointCloud3DTileContent.js";
 import Tileset3DTileContent from "./Tileset3DTileContent.js";
 import Vector3DTileContent from "./Vector3DTileContent.js";
 import RuntimeError from "../Core/RuntimeError.js";
-import ExperimentalFeatures from "../Core/ExperimentalFeatures.js";
 import ModelExperimental3DTileContent from "./ModelExperimental/ModelExperimental3DTileContent.js";
 
 /**
@@ -18,7 +17,7 @@ import ModelExperimental3DTileContent from "./ModelExperimental/ModelExperimenta
  */
 var Cesium3DTileContentFactory = {
   b3dm: function (tileset, tile, resource, arrayBuffer, byteOffset) {
-    if (ExperimentalFeatures.enableModelExperimental) {
+    if (tileset.enableModelExperimental) {
       return ModelExperimental3DTileContent.fromB3dm(
         tileset,
         tile,
@@ -102,7 +101,7 @@ var Cesium3DTileContentFactory = {
     var dataView = new DataView(arrayBuffer, byteOffset);
     var byteLength = dataView.getUint32(8, true);
     var glb = new Uint8Array(arrayBuffer, byteOffset, byteLength);
-    if (ExperimentalFeatures.enableModelExperimental) {
+    if (tileset.enableModelExperimental) {
       return ModelExperimental3DTileContent.fromGltf(
         tileset,
         tile,
@@ -113,7 +112,7 @@ var Cesium3DTileContentFactory = {
     return new Gltf3DTileContent(tileset, tile, resource, glb);
   },
   gltf: function (tileset, tile, resource, json) {
-    if (ExperimentalFeatures.enableModelExperimental) {
+    if (tileset.enableModelExperimental) {
       return ModelExperimental3DTileContent.fromGltf(
         tileset,
         tile,

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -954,6 +954,15 @@ function Cesium3DTileset(options) {
 
   this._customShader = options.customShader;
 
+  /**
+   * If true, {@link ModelExperimental} will be used instead of {@link Model}
+   * for each tile with a glTF or 3D Tiles 1.0 content (where applicable).
+   * <p>
+   * The value defaults to {@link ExperimentalFeatures.enableModelExperimental}.
+   * </p>
+   * @type {Boolean}
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
+   */
   this.enableModelExperimental = defaultValue(
     options.enableModelExperimental,
     ExperimentalFeatures.enableModelExperimental

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -12,6 +12,7 @@ import destroyObject from "../Core/destroyObject.js";
 import DeveloperError from "../Core/DeveloperError.js";
 import Ellipsoid from "../Core/Ellipsoid.js";
 import Event from "../Core/Event.js";
+import ExperimentalFeatures from "../Core/ExperimentalFeatures.js";
 import JulianDate from "../Core/JulianDate.js";
 import ManagedArray from "../Core/ManagedArray.js";
 import CesiumMath from "../Core/Math.js";
@@ -953,6 +954,11 @@ function Cesium3DTileset(options) {
 
   this._customShader = options.customShader;
 
+  this.enableModelExperimental = defaultValue(
+    options.enableModelExperimental,
+    ExperimentalFeatures.enableModelExperimental
+  );
+
   this._schemaLoader = undefined;
 
   var that = this;
@@ -1320,7 +1326,7 @@ Object.defineProperties(Cesium3DTileset.prototype, {
    * contents that use {@link ModelExperimental}. Using custom shaders with a
    * {@link Cesium3DTileStyle} may lead to undefined behavior.
    * <p>
-   * To enable {@link ModelExperimental}, set {@link ExperimentalFeatures.enableModelExperimental} to <code>true</code>.
+   * To enable {@link ModelExperimental}, set {@link ExperimentalFeatures.enableModelExperimental} or tileset.enableModelExperimental to <code>true</code>.
    * </p>
    *
    * @memberof Cesium3DTileset.prototype

--- a/Source/Scene/ModelExperimental/CustomShader.js
+++ b/Source/Scene/ModelExperimental/CustomShader.js
@@ -66,7 +66,7 @@ import TextureManager from "./TextureManager.js";
  *   </li>
  * </ul>
  * <p>
- * To enable the use of {@link ModelExperimental} in {@link Cesium3DTileset}, set {@link ExperimentalFeatures.enableModelExperimental} to <code>true</code>.
+ * To enable the use of {@link ModelExperimental} in {@link Cesium3DTileset}, set {@link ExperimentalFeatures.enableModelExperimental} to <code>true</code> or tileset.enableModelExperimental to <code>true</code>.
  * </p>
  *
  * @param {Object} options An object with the following options


### PR DESCRIPTION
This PR adds a flag to `Cesium3DTileset` to enable ModelExperimental (defaulting to the global `ExperimentalFeatures.enableModelExperimental`).

This will help with debugging, as now you can mix tilesets between Model/ModelExperimental in the same scene.

Examples:

![image](https://user-images.githubusercontent.com/8422414/146592559-6a5e9867-a1dd-4a61-9c5c-780b56db2ac7.png)


[Local Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=rVJdS8MwFP0rlz51UNKNTYTZDWX6MHAIOnzKS9bcaTBNSpJ2H+J/t1k6V3UPPgiBcM89596TQ2pmoBa4QQMTULiBGVpRFeT5gMU0yg/1TCvHhEJDo94VVVTVjc4JiRbdd2G4hrfL0IzfqQKojBwfCXOtHtHqyuRI1kYXN7ahzXl8eTEcDXsJVR9+Q/BEbI4KSWlEIZyo0RLGedzuPRnBbYkNBRuP8r/dABSao1wwZ8R23J0doFHsOQCDBPqHM+j3kwD5okW/gCPWBTzm67AOFVtJXPild513jcGZCv+QTjeMNqLA3mtdLPUpvSiJMut2EqfBDMC1KEptnA8oJiR1WJSSObTpqsrf0JHcWj/RU7O0K824qEHwyZnvArlk1jaddSXlk9gjjaZZ2vB/SaVmXKiXhxqNZDtPex1M7wNICMnSpjyvdFrLFTM/Jn8C) -- use ModelExperimental for only one tileset

[Local Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=rZJtS8MwEMe/SuirDkq6sYkwu6FMhYFDUPFV32TNTYNpUvLQPYjf3aTpZqcTfCEUwv3vd/e/O1oThWoGa1BoggSs0Qw0syV+brQ4j4omnklhCBOg8qh3kYtctNjNpgLFSnBZfgvEWAUagyBLDgtJgXfzzsAoC0157WwN46DBHPuGZ3j9FJLxey4QsoqP98BcigfQ0qoC8ErJ8ko7bE7j87PhaNhLPP6L/xitCNeQiw+/Qlga6wIE4MoxzLDaDU8ojdvJeodR4XiNf5639JMuiFFsM+72DtIo9gxCgwT1m2/Q7ydB8kGrHoS91hW85uNg94cDdPdtrxDonZTlk/w6UJREmTZbDtPgh9AlKyupjL9BjHFqoKw4MaDTpS3ewOBCa9/Ro1naLc0oqxGjkxO/HCo40dplVpbzR7aDPJpmqeN/lHJJKBMv9zUoTrYeex1M74KIMc5SF56uNFLyJVHfOn8C) -- this one should look the same, but this time the global flag is set and the Model one overrides the setting.

NOTE: In the above Sandcastles, the two versions of the tileset will look visually different. This is because #9838 has not been implemented yet.

@lilleyse could you review?