### PR TITLE
Fix ordering of arguments to Matrix3.getElementIndex in documentation.

### DIFF
--- a/Source/Core/Matrix3.js
+++ b/Source/Core/Matrix3.js
@@ -648,8 +648,8 @@ Matrix3.toArray = function (matrix, result) {
 /**
  * Computes the array index of the element at the provided row and column.
  *
- * @param {Number} row The zero-based index of the row.
  * @param {Number} column The zero-based index of the column.
+ * @param {Number} row The zero-based index of the row.
  * @returns {Number} The index of the element at the provided row and column.
  *
  * @exception {DeveloperError} row must be 0, 1, or 2.


### PR DESCRIPTION
As they are reversed compared to the code.