### PR TITLE
Preserve draw order in PolylineCollection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 - Added `lambertDiffuseMultiplier` property to Globe object to enhance terrain lighting. [#9878](https://github.com/CesiumGS/cesium/pull/9878)
 - Added `getFeatureInfoUrl` option to `WebMapServiceImageryProvider` which reads the getFeatureInfo request URL for WMS service if it differs with the getCapabilities URL. [#9563](https://github.com/CesiumGS/cesium/pull/9563)
 - Added `tileset.enableModelExperimental` so tilesets with `Model` and `ModelExperimental` can be mixed in the same scene. [#9982](https://github.com/CesiumGS/cesium/pull/9982)
+- Added a `preserveDrawOrder` option to `PolylineCollection` which allows polylines to be drawn on top of each other in the order they were added to the collection regardless of rendered depth. [#9985](https://github.com/CesiumGS/cesium/pull/9985)
 
 ##### Fixes :wrench:
 

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -123,7 +123,7 @@ function PolylineCollection(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
   /**
-   * Determines if polylines in this collection will be shown.
+   * Determines if polylines will be drawn on top of each other in the order they were added to the collection regardless of rendered depth.
    *
    * @type {Boolean}
    * @default true

--- a/Source/Scene/StencilConstants.js
+++ b/Source/Scene/StencilConstants.js
@@ -13,6 +13,7 @@ var StencilConstants = {
   SKIP_LOD_MASK: 0x70,
   SKIP_LOD_BIT_SHIFT: 4,
   CLASSIFICATION_MASK: 0x0f,
+  POLYLINE: 0x40, // 0b01000000
 };
 
 StencilConstants.setCesium3DTileBit = function () {

--- a/Source/Scene/StencilConstants.js
+++ b/Source/Scene/StencilConstants.js
@@ -13,7 +13,7 @@ var StencilConstants = {
   SKIP_LOD_MASK: 0x70,
   SKIP_LOD_BIT_SHIFT: 4,
   CLASSIFICATION_MASK: 0x0f,
-  POLYLINE: 0x40, // 0b01000000
+  POLYLINE: 0x40,
 };
 
 StencilConstants.setCesium3DTileBit = function () {


### PR DESCRIPTION
This PR adds a `preserveDrawOrder` option to `PolylineCollection` which allows polylines to be drawn on top of each other in the order they were added, regardless of depth. This avoids Z-fighting artifacts when polylines overlap and generally gives more control over the order polylines are rendered.

[Local Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=zVltc9s2Ev4rGN8HUy1Ni5YsW7KdXuK2c5m5NJ7a1/twug8QCUk4QwQHAG0rHf/3LgC+AKIk001808mYEZaLfXl2ubsgH7BAD5Q8EoGuUEYe0TWRtFhFvxlaMD1IzPqaZwrTjIjpQYh+n2YIKSIEUG4Ef6ApEZNqYyIIVuTfXLD0zrIEvVBv4ALYPmYpyQlcMnUncCZZkZAsWU/QHDNJQnR8jD5/vENUopRKPGMkRTOS4EISRBVKOZHZof4fYZQLnoPVwJOl0+y5dzHNppl1JZIglUQpmRWL2yV//FngFZE3RNyShGcpeKpEQS422BNgEjiSRGnnA+MlQimRimZYUZ6hiYvQNRYKfuFsEByNzofx2Sg6H4768fmgPxiE6OhsGA8HQBz1T4aj8WA8CtHJGRDG59FpPIoHw/j03CKjsaGAyBYl/yA4pdnihqpk+StnLBhF8eBscDLoj4encTw4H4KmOBqcx4N4fDbsD077w7FWP4pOwJCTk/FoMI7h32mvxkhjnGtVEgCA8Evw+5ozrjPAhOHC0nNBJBEP5EeBHz/r4Dm4wW1Vx09tbJQAuU4YwZlzxyi+AzRRztmaQTKVasoVmMBIou0yTF423rR4bHhaJk7apNJvYzIIvlUQN5DuRJEvBM6XNInmgq9+JAtBiAyO4n4/6kPMzBUWfbveyIBqb9BzlfxkkuxFFePXazAoVuC+BGQThA5Y6qhN3Ng5wCWW0hm70rHYutcVuVJLR/DK+MRjcz3tiN5DWe8+8ZRoYGwtEzi5/0SzCdIiGgp+mkBcXFLDUaFttsU+Se8DgzziNS8ypcVZsiSLFTw5drdPslp9Pm+3pi+ILqDaoHmR2Sj2UFmyBFGFyNAvxWoGJVwtqYyM8RoBhJ7Dcv+Nb1knOZ43G/JuPVM7iXO9K6VB1plAlTG8z3hyzwtlPQjq0NVPG+dshnVpSnlSaGERmPITI/rnh/XHFFpYyTM90Js25eI8Z+sPNNNlVjbyw0rytj2g4fNMVxndodw9oEubCZoiWcxkIuiMBC4SRZ5Cd6yQv+GSmkIcbC+CvYvnV6r34rPbDJrROvzfTrkbzW+ie5rd4ixNsFSMRDhN7/hiwciHQikQNT24hcYFRQM6l55K6jYWNrmXLElyT9IyBd1GV94xOecH5X2eEwy9LSE7jatb6V7zbspOhHQrQrYXgZ2tBrXT3m0NeLfdN5vcX2l+M58pbbbT7nca7I8E/weI9XBXdUOTA0332p0F3nTiGrmzgUZ6DzA7Wy+2j5y5oCt4pB+I1Nbu8e51u0qlVmG3B+hlPk9oBRZa4XvyK2DOV6a/BFL3/BDBkB3Cs6brtIXRThxl/SonjPcw768Dy3WBNFfFaaRc754eFK/H6UqjhxBhjOaS0zTcMYL3bPvQusDUjpqMU39aT0rnc1+J5dF1T7cBFdReh5VRHcRul5lxscKMfiGBVttBjCKr3B/8HD4zKdnxKeo3e8RW1YngUgagU4vco7mJdrFHji53HcwXfOMI8AkrQZ8GgYieQlToy1xfRLTWy7VervXyi15+0csvVlolEaZLSOyUFjpbh+W07QTTnDlAyzISJv2hV33nbKo5cQYVqGK9+YiO0QnIgZPr5t6K4TvD4JrxG0l2hsYYUm5OuAyMul6IXLqEQ3VF71cBbAT7iEWrgimqh5w13FZcBIBtWLHvDYVrczX71zntedSa2cuY63JWp34XlTZec+jRgZZNQSqAS9GlLT7w8/vv64nS5DlwUAiCLTvoCMVWTF2httrFiMiD2q2w8gFy/AXrrNj/UaXI9qelQfs2wQyLoAhbWaW8zIJFP4pf1LvLFdsxZFga1UWOLdr/of8FgbCsBu96RK9ZdJfzusNLPaWaXFo3IkFW/IG8ZyxoHnJvWgVb6mky2jyeOJvcKXNzj3sECSqHq41Uli8W2tahq6urHS8iLrwWppPNivnBeZsw8Q7IbiPa5NfPycQ56O7NeA+edua73Xdf124fsnz0tyJi0qpU5uTMpPkZVjcfaaqWE13kapJ9l6BfFpWk516TZK+YBXutBOx+gPLmlLfPs794lv0lcwyQDGhTl+z9yNXpViL7cmBPNuxPpa9IB/1H5yh4VUhrHA3sjKiOsCOkeV8BnLWvQhyzfInNm9rmLPYDNJhzyIi4nEPcPdqv+mDsGGGlPS6pItC+iKCYeaOFoZg3cnfrnASHZv9hYxPy90ZFRgGIlYyS8gTutilNCuJyHi0vxhFXXp0gq8YeT0fN+4wIk2TTFzgBrKthwU8BZ2jYpeg1jrf2d3BeGxci91r670fr2V2aaur7+va59nXg/Blo4vqw0pxY2jC80Cg6vBzZPbtsexHTotlWdRAeXEq1ZuRd5fLf6SrnUL4LwYIoOtaHKAaWyeNZkdwTFSVSNvj8rXqf6eTuDIrtQkDw0gkSixkOhichqv7gwfZSD9o2zRYTNMyfHPLMfHw7Embe9G8+t1TTLC+U9/AQoSgMs0dwAF1kE7SiacpIW+uR4jnMAZ7m6taMK8VX/t226mhJsIbXUT6HLnb0SOhiqSbgB0s3t18eu3hfpvQB0fRqy4dLlDAsJdyZF4zdwlF6evDu8hj4W1sZN1/dPoPjDK812zJ+909LjKLo8hiW23fWr5rr8F8q/aL0XePQpZrxdO0QNEl4a01J35kue3kMv9r3fArQbNAUPHRgBZT+BXgHwwTJYQmPTT+GJTwQ+GhGM20oVkpM0O8r/f2h+vwRQot/mtTfPp5DKJusICWlXP3LPFcTdGg0HjqebrdFkSelTQG8YXW6YYaroCWq5TsQRAfg6gPKtwBvH3DON6ASO+cTUAOfV4DfEsaNt//fCM5y2H1zNJtPYiWYzQexBkt30HxLKP1vGa9EEpbeMw5rpwi4leMP)
### Opaque
`preserveDrawOrder = false`

![Screenshot from 2021-12-23 17-25-46](https://user-images.githubusercontent.com/1328450/147296308-c297e97b-6729-4953-a5b5-f00f46d2578d.png)

`preserveDrawOrder = true`

![Screenshot from 2021-12-23 17-25-56](https://user-images.githubusercontent.com/1328450/147296306-32d8a222-327c-4053-83a8-ba9d26b8d842.png)

### Translucent
`preserveDrawOrder = false`

![Screenshot from 2021-12-23 17-26-28](https://user-images.githubusercontent.com/1328450/147296304-6a7fb6a9-2c6f-4b13-94f8-1da5c65e8a4e.png)

`preserveDrawOrder = true`

![Screenshot from 2021-12-23 17-26-12](https://user-images.githubusercontent.com/1328450/147296305-221ef975-1b2a-4113-8af4-8615383964da.png)

This option only affects the polylines within a single collection. If there are two polyline collection in the scene, they will depth test against each other like normal:

![Screenshot from 2021-12-23 17-31-02](https://user-images.githubusercontent.com/1328450/147296623-4e80b3b1-06f7-49d5-8054-e7268f99b281.png)

Thanks to @lilleyse for some ideas