### PR TITLE
Move upAxis, forwardAxis, and transform into ModelComponents

### DIFF
--- a/Source/Scene/GltfLoader.js
+++ b/Source/Scene/GltfLoader.js
@@ -116,7 +116,6 @@ export default function GltfLoader(options) {
   this._textureState = GltfLoaderState.UNLOADED;
   this._promise = when.defer();
   this._texturesLoadedPromise = when.defer();
-  this._transform = Matrix4.IDENTITY;
 
   // Loaders that need to be processed before the glTF becomes ready
   this._textureLoaders = [];
@@ -191,22 +190,6 @@ Object.defineProperties(GltfLoader.prototype, {
   texturesLoadedPromise: {
     get: function () {
       return this._texturesLoadedPromise.promise;
-    },
-  },
-
-  /**
-   * A world-space transform to apply to the primitives.
-   *
-   * @memberof GltfLoader.prototype
-   *
-   * @type {Matrix4}
-   * @default {@link Matrix4.IDENTITY}
-   * @readonly
-   * @private
-   */
-  transform: {
-    get: function () {
-      return this._transform;
     },
   },
 });
@@ -1344,10 +1327,8 @@ function getSceneNodeIds(gltf) {
   return nodesIds;
 }
 
-function loadScene(gltf, nodes, upAxis, forwardAxis) {
+function loadScene(gltf, nodes) {
   var scene = new Scene();
-  scene.upAxis = upAxis;
-  scene.forwardAxis = forwardAxis;
   var sceneNodeIds = getSceneNodeIds(gltf);
   scene.nodes = sceneNodeIds.map(function (sceneNodeId) {
     return nodes[sceneNodeId];
@@ -1376,13 +1357,13 @@ function parse(loader, gltf, supportedImageFormats, frameState) {
   }
 
   var nodes = loadNodes(loader, gltf, supportedImageFormats, frameState);
-  var upAxis = loader._upAxis;
-  var forwardAxis = loader._forwardAxis;
-  var scene = loadScene(gltf, nodes, upAxis, forwardAxis);
+  var scene = loadScene(gltf, nodes);
 
   var components = new Components();
   components.scene = scene;
   components.nodes = nodes;
+  components.upAxis = loader._upAxis;
+  components.forwardAxis = loader._forwardAxis;
 
   loader._components = components;
 

--- a/Source/Scene/ModelComponents.js
+++ b/Source/Scene/ModelComponents.js
@@ -694,6 +694,9 @@ function Components() {
 
   /**
    * A world-space transform to apply to the primitives.
+   *
+   * @type {Matrix4}
+   * @private
    */
   this.transform = Matrix4.clone(Matrix4.IDENTITY);
 }

--- a/Source/Scene/ModelComponents.js
+++ b/Source/Scene/ModelComponents.js
@@ -1,6 +1,7 @@
 import Cartesian3 from "../Core/Cartesian3.js";
 import Cartesian4 from "../Core/Cartesian4.js";
 import Matrix3 from "../Core/Matrix3.js";
+import Matrix4 from "../Core/Matrix4.js";
 import AlphaMode from "./AlphaMode.js";
 
 /**
@@ -641,22 +642,6 @@ function Scene() {
    * @private
    */
   this.nodes = [];
-
-  /**
-   * The scene's up axis.
-   *
-   * @type {Axis}
-   * @private
-   */
-  this.upAxis = undefined;
-
-  /**
-   * The scene's forward axis.
-   *
-   * @type {Axis}
-   * @private
-   */
-  this.forwardAxis = undefined;
 }
 
 /**
@@ -690,6 +675,27 @@ function Components() {
    * @private
    */
   this.featureMetadata = undefined;
+
+  /**
+   * The model's up axis.
+   *
+   * @type {Axis}
+   * @private
+   */
+  this.upAxis = undefined;
+
+  /**
+   * The model's forward axis.
+   *
+   * @type {Axis}
+   * @private
+   */
+  this.forwardAxis = undefined;
+
+  /**
+   * A world-space transform to apply to the primitives.
+   */
+  this.transform = Matrix4.clone(Matrix4.IDENTITY);
 }
 
 /**

--- a/Source/Scene/ModelExperimental/B3dmLoader.js
+++ b/Source/Scene/ModelExperimental/B3dmLoader.js
@@ -169,22 +169,6 @@ Object.defineProperties(B3dmLoader.prototype, {
       return this._components;
     },
   },
-
-  /**
-   * A world-space transform to apply to the primitives.
-   * See {@link https://github.com/CesiumGS/3d-tiles/tree/main/specification/TileFormats/Batched3DModel#global-semantics}
-   *
-   * @memberof B3dmLoader.prototype
-   *
-   * @type {Matrix4}
-   * @readonly
-   * @private
-   */
-  transform: {
-    get: function () {
-      return this._transform;
-    },
-  },
 });
 
 /**
@@ -223,8 +207,8 @@ B3dmLoader.prototype.load = function () {
   };
 
   var gltfLoader = new GltfLoader({
-    upAxis: this._upAxis,
     typedArray: b3dm.gltf,
+    upAxis: this._upAxis,
     forwardAxis: this._forwardAxis,
     gltfResource: this._b3dmResource,
     baseResource: this._baseResource,
@@ -245,6 +229,7 @@ B3dmLoader.prototype.load = function () {
       }
 
       var components = gltfLoader.components;
+      components.transform = that._transform;
       createFeatureMetadata(that, components);
       that._components = components;
 

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -181,7 +181,7 @@ function initialize(model) {
     .then(function (loader) {
       Matrix4.multiply(
         model._modelMatrix,
-        loader.transform,
+        loader.components.transform,
         model._modelMatrix
       );
 

--- a/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
@@ -108,18 +108,18 @@ export default function ModelExperimentalSceneGraph(options) {
 }
 
 function initialize(sceneGraph) {
-  var modelMatrix = Matrix4.clone(sceneGraph._model.modelMatrix);
-  var scene = sceneGraph._modelComponents.scene;
+  var model = sceneGraph._model;
+  var modelComponents = sceneGraph._modelComponents;
+  var modelMatrix = Matrix4.clone(model.modelMatrix);
+  var scene = modelComponents.scene;
+  var upAxis = modelComponents.upAxis;
+  var forwardAxis = modelComponents.forwardAxis;
 
-  ModelExperimentalUtility.correctModelMatrix(
-    modelMatrix,
-    scene.upAxis,
-    scene.forwardAxis
-  );
+  ModelExperimentalUtility.correctModelMatrix(modelMatrix, upAxis, forwardAxis);
 
-  var rootNodes = sceneGraph._modelComponents.scene.nodes;
+  var rootNodes = scene.nodes;
   for (var i = 0; i < rootNodes.length; i++) {
-    var rootNode = sceneGraph._modelComponents.scene.nodes[i];
+    var rootNode = scene.nodes[i];
     var rootNodeModelMatrix = Matrix4.multiply(
       modelMatrix,
       ModelExperimentalUtility.getNodeTransform(rootNode),

--- a/Specs/Scene/GltfLoaderSpec.js
+++ b/Specs/Scene/GltfLoaderSpec.js
@@ -2159,8 +2159,8 @@ describe(
         var material = primitive.material;
         var specularGlossiness = material.specularGlossiness;
 
-        expect(scene.upAxis).toBe(Axis.Y);
-        expect(scene.forwardAxis).toBe(Axis.Z);
+        expect(components.upAxis).toBe(Axis.Y);
+        expect(components.forwardAxis).toBe(Axis.Z);
         expect(material.occlusionTexture.texture.width).toBe(128);
         expect(material.normalTexture.texture.width).toBe(128);
         expect(material.emissiveTexture.texture.width).toBe(128);
@@ -2326,7 +2326,7 @@ describe(
 
     it("sets default transform", function () {
       return loadGltf(microcosm).then(function (gltfLoader) {
-        expect(gltfLoader.transform).toEqual(Matrix4.IDENTITY);
+        expect(gltfLoader.components.transform).toEqual(Matrix4.IDENTITY);
       });
     });
 

--- a/Specs/Scene/ModelExperimental/B3dmLoaderSpec.js
+++ b/Specs/Scene/ModelExperimental/B3dmLoaderSpec.js
@@ -116,7 +116,7 @@ describe("Scene/ModelExperimental/B3dmLoader", function () {
       expect(propertyTable).toBeDefined();
       expect(propertyTable.count).toEqual(10);
 
-      expect(loader.transform).toEqual(
+      expect(loader.components.transform).toEqual(
         Matrix4.fromTranslation(new Cartesian3(0.1, 0.2, 0.3))
       );
     });

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSceneGraphSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSceneGraphSpec.js
@@ -199,11 +199,10 @@ describe(
       ).then(function (model) {
         var sceneGraph = model._sceneGraph;
         var modelComponents = sceneGraph._modelComponents;
-        var scene = modelComponents.scene;
         var runtimeNodes = sceneGraph._runtimeNodes;
 
-        expect(scene.upAxis).toEqual(Axis.Z);
-        expect(scene.forwardAxis).toEqual(Axis.X);
+        expect(modelComponents.upAxis).toEqual(Axis.Z);
+        expect(modelComponents.forwardAxis).toEqual(Axis.X);
 
         expect(runtimeNodes[1].modelMatrix).toEqual(
           modelComponents.nodes[0].matrix


### PR DESCRIPTION
Previous upAxis and forwardAxis were attached to the Scene object and transform was attached to the loader. Neither of these seemed like the right place. They are now part of the Components object.