### PR TITLE
Adds dynamic model/node transformations to ModelExperimentalNode

### DIFF
--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -633,6 +633,8 @@ ModelExperimental.prototype.update = function (frameState) {
     this._debugShowBoundingVolumeDirty = false;
   }
 
+  this._sceneGraph.update(frameState);
+
   // Check for show here because we still want the draw commands to be built so user can instantly see the model
   // when show is set to true.
   if (this._show) {

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -636,10 +636,8 @@ ModelExperimental.prototype.update = function (frameState) {
   // Check for show here because we still want the draw commands to be built so user can instantly see the model
   // when show is set to true.
   if (this._show) {
-    frameState.commandList.push.apply(
-      frameState.commandList,
-      this._sceneGraph._drawCommands
-    );
+    var drawCommands = this._sceneGraph.getDrawCommands();
+    frameState.commandList.push.apply(frameState.commandList, drawCommands);
   }
 };
 

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -191,12 +191,6 @@ function initialize(model) {
 
   loader.promise
     .then(function (loader) {
-      Matrix4.multiply(
-        model._modelMatrix,
-        loader.components.transform,
-        model._modelMatrix
-      );
-
       var components = loader.components;
       var featureMetadata = components.featureMetadata;
 
@@ -309,6 +303,20 @@ Object.defineProperties(ModelExperimental.prototype, {
         this.resetDrawCommands();
       }
       this._customShader = value;
+    },
+  },
+
+  /**
+   * The scene graph of this model.
+   *
+   * @memberof ModelExperimental.prototype
+   *
+   * @type {ModelExperimentalSceneGraph}
+   * @private
+   */
+  sceneGraph: {
+    get: function () {
+      return this._sceneGraph;
     },
   },
 
@@ -467,7 +475,7 @@ Object.defineProperties(ModelExperimental.prototype, {
       }
       //>>includeEnd('debug');
 
-      return this._sceneGraph._boundingSphere;
+      return this._sceneGraph.boundingSphere;
     },
   },
 
@@ -582,7 +590,6 @@ ModelExperimental.prototype.resetDrawCommands = function () {
   }
   this.destroyResources();
   this._drawCommandsBuilt = false;
-  this._sceneGraph._drawCommands = [];
 };
 
 /**

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -62,6 +62,7 @@ export default function ModelExperimental(options) {
   this._loader = options.loader;
   this._resource = options.resource;
 
+  this._modelMatrixDirty = false;
   this._modelMatrix = Matrix4.clone(
     defaultValue(options.modelMatrix, Matrix4.IDENTITY)
   );
@@ -478,7 +479,11 @@ Object.defineProperties(ModelExperimental.prototype, {
       return this._modelMatrix;
     },
     set: function (value) {
+      if (Matrix4.equals(this._modelMatrix, value)) {
+        return;
+      }
       this._modelMatrix = value;
+      this._modelMatrixDirty = true;
     },
   },
 
@@ -631,6 +636,11 @@ ModelExperimental.prototype.update = function (frameState) {
   if (this._debugShowBoundingVolumeDirty) {
     updateShowBoundingVolume(this._sceneGraph, this._debugShowBoundingVolume);
     this._debugShowBoundingVolumeDirty = false;
+  }
+
+  if (this._modelMatrixDirty) {
+    this._sceneGraph.updateModelMatrix(this);
+    this._modelMatrixDirty = false;
   }
 
   this._sceneGraph.update(frameState);

--- a/Source/Scene/ModelExperimental/ModelExperimentalNode.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalNode.js
@@ -1,6 +1,8 @@
 import Check from "../../Core/Check.js";
 import defaultValue from "../../Core/defaultValue.js";
 import defined from "../../Core/defined.js";
+import DeveloperError from "../../Core/DeveloperError.js";
+import Matrix4 from "../../Core/Matrix4.js";
 import InstancingPipelineStage from "./InstancingPipelineStage.js";
 /**
  * An in-memory representation of a node as part of
@@ -9,6 +11,8 @@ import InstancingPipelineStage from "./InstancingPipelineStage.js";
  * @param {Object} options An object containing the following options:
  * @param {ModelComponents.Node} options.node The corresponding node components from the 3D model
  * @param {Matrix4} options.modelMatrix The model matrix associated with this node.
+ * @param {ModelExperimentalSceneGraph} The scene graph this node belongs to.
+ * @param {Number[]} options.children The indices of the children of this node in the runtime nodes array of the scene graph.
  *
  * @alias ModelExperimentalNode
  * @constructor
@@ -21,6 +25,26 @@ export default function ModelExperimentalNode(options) {
   Check.typeOf.object("options.node", options.node);
   Check.typeOf.object("options.modelMatrix", options.modelMatrix);
   //>>includeEnd('debug');
+
+  /**
+   * The scene graph this node belongs to.
+   *
+   * @type {ModelExperimentalSceneGraph}
+   * @readonly
+   *
+   * @private
+   */
+  this.sceneGraph = options.sceneGraph;
+
+  /**
+   * The indices of the children of this node in the runtime nodes array of the scene graph.
+   *
+   * @type {Number[]}
+   * @readonly
+   *
+   * @private
+   */
+  this.children = options.children;
 
   /**
    * The model components node associated with this scene graph node.
@@ -41,6 +65,14 @@ export default function ModelExperimentalNode(options) {
    * @private
    */
   this.modelMatrix = options.modelMatrix;
+
+  /**
+   * The runtime transform applied to this node.
+   *
+   * @type {Matrix4}
+   * @readonly
+   */
+  this.transform = Matrix4.clone(options.modelMatrix);
 
   /**
    * Pipeline stages to apply across all the mesh primitives of this node. This
@@ -66,6 +98,46 @@ export default function ModelExperimentalNode(options) {
 
   initialize(this);
 }
+
+Object.defineProperties(ModelExperimentalNode.prototype, {
+  transform: {
+    get: function () {
+      return this.transform;
+    },
+    set: function (value) {
+      // TODO: Set dirty flag.
+      this.transform = value;
+    },
+  },
+});
+
+/**
+ * Returns the child with the given index.
+ *
+ * @param {Number} index The index of the child.
+ *
+ * @returns {ModelExperimentalNode}
+ *
+ * @example
+ * // Iterate through all children of a runtime node.
+ * for (var i = 0; i < runtimeNode.children.length; i++)
+ * {
+ *   var childNode = runtimeNode.getChild(i);
+ * }
+ *
+ */
+ModelExperimentalNode.prototype.getChild = function (index) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.number("index", index);
+  if (index < 0 || index >= this.children.length) {
+    throw new DeveloperError(
+      "index must be greater than or equal to 0 and less than the number of children."
+    );
+  }
+  //>>includeEnd('debug');
+
+  return this.sceneGraph.runtimeNodes[this.children[index]];
+};
 
 function initialize(runtimeNode) {
   var node = runtimeNode.node;

--- a/Source/Scene/ModelExperimental/ModelExperimentalNode.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalNode.js
@@ -120,7 +120,6 @@ Object.defineProperties(ModelExperimentalNode.prototype, {
    *
    * @memberof ModelExperimentalNode.prototype
    * @type {Matrix4}
-   *
    */
   transform: {
     get: function () {
@@ -133,7 +132,7 @@ Object.defineProperties(ModelExperimentalNode.prototype, {
       this._transformDirty = true;
       this._transform = value;
       Matrix4.multiplyTransformation(
-        this._sceneGraph._computedModelMatrix,
+        this._sceneGraph.computedModelMatrix,
         value,
         this._computedTransform
       );
@@ -178,7 +177,6 @@ Object.defineProperties(ModelExperimentalNode.prototype, {
  * {
  *   var childNode = runtimeNode.getChild(i);
  * }
- *
  */
 ModelExperimentalNode.prototype.getChild = function (index) {
   //>>includeStart('debug', pragmas.debug);
@@ -213,7 +211,7 @@ function initialize(runtimeNode) {
 ModelExperimentalNode.prototype.updateModelMatrix = function () {
   this._transformDirty = true;
   Matrix4.multiplyTransformation(
-    this._sceneGraph._computedModelMatrix,
+    this._sceneGraph.computedModelMatrix,
     this._transform,
     this._computedTransform
   );

--- a/Source/Scene/ModelExperimental/ModelExperimentalNode.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalNode.js
@@ -74,7 +74,7 @@ export default function ModelExperimentalNode(options) {
    * @type {Matrix4}
    * @readonly
    */
-  this.transform = Matrix4.clone(options.modelMatrix);
+  this._transform = Matrix4.clone(options.modelMatrix);
 
   /**
    * Pipeline stages to apply across all the mesh primitives of this node. This
@@ -104,11 +104,14 @@ export default function ModelExperimentalNode(options) {
 Object.defineProperties(ModelExperimentalNode.prototype, {
   transform: {
     get: function () {
-      return this.transform;
+      return this._transform;
     },
     set: function (value) {
-      // TODO: Set dirty flag.
-      this.transform = value;
+      if (Matrix4.equals(this._transform, value)) {
+        return;
+      }
+      this.sceneGraph._transformDirty = true;
+      this._transform = value;
     },
   },
 });

--- a/Source/Scene/ModelExperimental/ModelExperimentalNode.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalNode.js
@@ -39,7 +39,7 @@ export default function ModelExperimentalNode(options) {
   this._originalTransform = Matrix4.clone(transform);
   this._transform = Matrix4.clone(transform);
   this._computedTransform = Matrix4.multiplyTransformation(
-    sceneGraph._computedModelMatrix,
+    sceneGraph.computedModelMatrix,
     transform,
     new Matrix4()
   );

--- a/Source/Scene/ModelExperimental/ModelExperimentalNode.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalNode.js
@@ -11,7 +11,7 @@ import InstancingPipelineStage from "./InstancingPipelineStage.js";
  * @param {Object} options An object containing the following options:
  * @param {ModelComponents.Node} options.node The corresponding node components from the 3D model
  * @param {Matrix4} options.modelMatrix The model matrix associated with this node.
- * @param {ModelExperimentalSceneGraph} The scene graph this node belongs to.
+ * @param {ModelExperimentalSceneGraph} options.sceneGraph The scene graph this node belongs to.
  * @param {Number[]} options.children The indices of the children of this node in the runtime nodes array of the scene graph.
  *
  * @alias ModelExperimentalNode
@@ -24,6 +24,8 @@ export default function ModelExperimentalNode(options) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("options.node", options.node);
   Check.typeOf.object("options.modelMatrix", options.modelMatrix);
+  Check.typeOf.object("options.sceneGraph", options.sceneGraph);
+  Check.typeOf.object("options.children", options.children);
   //>>includeEnd('debug');
 
   /**

--- a/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
@@ -83,6 +83,20 @@ export default function ModelExperimentalPrimitive(options) {
    */
   this.drawCommands = [];
 
+  /**
+   * The bounding sphere of this primitive (in object-space).
+   *
+   * @type {BoundingSphere}
+   *
+   * @private
+   */
+  this.boundingSphere = undefined;
+
+  /**
+   * Update stages to apply to this primitive.
+   */
+  this.updateStages = [];
+
   initialize(this);
 }
 

--- a/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
@@ -74,6 +74,15 @@ export default function ModelExperimentalPrimitive(options) {
    */
   this.pipelineStages = [];
 
+  /**
+   * The generated {@link DrawCommand}s associated with this primitive.
+   *
+   * @type {DrawCommand[]}
+   *
+   * @private
+   */
+  this.drawCommands = [];
+
   initialize(this);
 }
 

--- a/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
@@ -100,16 +100,6 @@ export default function ModelExperimentalSceneGraph(options) {
   this._drawCommands = [];
 
   /**
-   * The bounding sphere containing all the primitives in the scene graph.
-   *
-   * @type {BoundingSphere}
-   * @readonly
-   *
-   * @private
-   */
-  this._boundingSphere = undefined;
-
-  /**
    * The array of bounding spheres of all the primitives in the scene graph.
    *
    * @type {BoundingSphere[]}
@@ -119,22 +109,51 @@ export default function ModelExperimentalSceneGraph(options) {
    */
   this._boundingSpheres = [];
 
+  this._boundingSphere = undefined;
+  this._computedModelMatrix = Matrix4.clone(this._model.modelMatrix);
+
+  initialize(this);
+}
+
+Object.defineProperties(ModelExperimentalSceneGraph.prototype, {
   /**
-   * The corrected model matrix.
+   * The axis-corrected model matrix.
    *
    * @type {Matrix4}
    * @readonly
    *
    * @private
    */
-  this._computedModelMatrix = Matrix4.clone(this._model.modelMatrix);
-
-  initialize(this);
-}
+  computedModelMatrix: {
+    get: function () {
+      return this._computedModelMatrix;
+    },
+  },
+  /**
+   * The bounding sphere containing all the primitives in the scene graph.
+   *
+   * @type {BoundingSphere}
+   * @readonly
+   *
+   * @private
+   */
+  boundingSphere: {
+    get: function () {
+      return this._boundingSphere;
+    },
+  },
+});
 
 function initialize(sceneGraph) {
   var components = sceneGraph._modelComponents;
   var scene = components.scene;
+  var model = sceneGraph._model;
+
+  sceneGraph._computedModelMatrix = Matrix4.multiplyTransformation(
+    model.modelMatrix,
+    components.transform,
+    new Matrix4()
+  );
 
   ModelExperimentalUtility.correctModelMatrix(
     sceneGraph._computedModelMatrix,
@@ -334,6 +353,12 @@ ModelExperimentalSceneGraph.prototype.update = function (frameState) {
 };
 
 ModelExperimentalSceneGraph.prototype.updateModelMatrix = function () {
+  Matrix4.multiply(
+    this._computedModelMatrix,
+    this._modelComponents.transform,
+    this._computedModelMatrix
+  );
+
   this._computedModelMatrix = Matrix4.clone(this._model.modelMatrix);
   ModelExperimentalUtility.correctModelMatrix(
     this._computedModelMatrix,

--- a/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
@@ -138,13 +138,18 @@ function initialize(sceneGraph) {
  * @param {ModelComponents.Node} node The current node
  * @param {Matrix4} modelMatrix The current computed model matrix for this node.
  *
+ * @returns {Number} The index of this node in the runtimeNodes array.
+ *
  * @private
  */
 function traverseSceneGraph(sceneGraph, node, modelMatrix) {
   // No processing needs to happen if node has no children and no mesh primitives.
   if (!defined(node.children) && !defined(node.primitives)) {
-    return;
+    return -1;
   }
+
+  // The indices of the children of this node in the runtimeNodes array.
+  var childrenIndices = [];
 
   // Traverse through scene graph.
   var i;
@@ -157,7 +162,14 @@ function traverseSceneGraph(sceneGraph, node, modelMatrix) {
         new Matrix4()
       );
 
-      traverseSceneGraph(sceneGraph, childNode, childNodeModelMatrix);
+      var childIndex = traverseSceneGraph(
+        sceneGraph,
+        childNode,
+        childNodeModelMatrix
+      );
+      if (childIndex > -1) {
+        childrenIndices.push(childIndex);
+      }
     }
   }
 
@@ -165,6 +177,7 @@ function traverseSceneGraph(sceneGraph, node, modelMatrix) {
   var runtimeNode = new ModelExperimentalNode({
     node: node,
     modelMatrix: modelMatrix,
+    children: childrenIndices,
   });
 
   if (defined(node.primitives)) {
@@ -180,6 +193,9 @@ function traverseSceneGraph(sceneGraph, node, modelMatrix) {
   }
 
   sceneGraph._runtimeNodes.push(runtimeNode);
+
+  // The position of the runtime node in the array.
+  return sceneGraph._runtimeNodes.length - 1;
 }
 
 /**

--- a/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
@@ -133,12 +133,13 @@ export default function ModelExperimentalSceneGraph(options) {
 }
 
 function initialize(sceneGraph) {
-  var scene = sceneGraph._modelComponents.scene;
+  var components = sceneGraph._modelComponents;
+  var scene = components.scene;
 
   ModelExperimentalUtility.correctModelMatrix(
     sceneGraph._computedModelMatrix,
-    scene.upAxis,
-    scene.forwardAxis
+    components.upAxis,
+    components.forwardAxis
   );
 
   var rootNodes = scene.nodes;
@@ -336,8 +337,8 @@ ModelExperimentalSceneGraph.prototype.updateModelMatrix = function () {
   this._computedModelMatrix = Matrix4.clone(this._model.modelMatrix);
   ModelExperimentalUtility.correctModelMatrix(
     this._computedModelMatrix,
-    this._modelComponents.scene.upAxis,
-    this._modelComponents.scene.forwardAxis
+    this._modelComponents.upAxis,
+    this._modelComponents.forwardAxis
   );
 
   var rootNodes = this._rootNodes;

--- a/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
@@ -353,13 +353,13 @@ ModelExperimentalSceneGraph.prototype.update = function (frameState) {
 };
 
 ModelExperimentalSceneGraph.prototype.updateModelMatrix = function () {
+  this._computedModelMatrix = Matrix4.clone(this._model.modelMatrix);
   Matrix4.multiply(
     this._computedModelMatrix,
     this._modelComponents.transform,
     this._computedModelMatrix
   );
 
-  this._computedModelMatrix = Matrix4.clone(this._model.modelMatrix);
   ModelExperimentalUtility.correctModelMatrix(
     this._computedModelMatrix,
     this._modelComponents.upAxis,

--- a/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
@@ -113,24 +113,21 @@ export default function ModelExperimentalSceneGraph(options) {
 }
 
 function initialize(sceneGraph) {
-  var modelMatrix = Matrix4.clone(sceneGraph._model.modelMatrix);
-  var scene = sceneGraph._modelComponents.scene;
+  var model = sceneGraph._model;
+  var components = sceneGraph._modelComponents;
+
+  var scene = components.scene;
 
   ModelExperimentalUtility.correctModelMatrix(
-    modelMatrix,
+    model.modelMatrix,
     scene.upAxis,
     scene.forwardAxis
   );
 
-  var rootNodes = sceneGraph._modelComponents.scene.nodes;
+  var rootNodes = scene.nodes;
   for (var i = 0; i < rootNodes.length; i++) {
-    var rootNode = sceneGraph._modelComponents.scene.nodes[i];
+    var rootNode = scene.nodes[i];
     var rootNodeTransform = ModelExperimentalUtility.getNodeTransform(rootNode);
-    ModelExperimentalUtility.correctModelMatrix(
-      rootNodeTransform,
-      scene.upAxis,
-      scene.forwardAxis
-    );
     traverseSceneGraph(sceneGraph, rootNode, rootNodeTransform);
   }
 }

--- a/Source/Scene/ModelExperimental/ModelMatrixUpdateStage.js
+++ b/Source/Scene/ModelExperimental/ModelMatrixUpdateStage.js
@@ -1,0 +1,22 @@
+import BoundingSphere from "../../Core/BoundingSphere.js";
+import Matrix4 from "../../Core/Matrix4.js";
+
+var ModelMatrixUpdateStage = {};
+
+ModelMatrixUpdateStage.update = function (runtimePrimitive) {
+  for (var i = 0; i < runtimePrimitive.drawCommands; i++) {
+    var command = runtimePrimitive.drawCommands[i];
+    command.modelMatrix = Matrix4.clone(
+      runtimePrimitive.runtimeNode.transform,
+      command.modelMatrix
+    );
+
+    BoundingSphere.transform(
+      command.boundingSphere,
+      command.modelMatrix,
+      command.boundingVolume
+    );
+  }
+};
+
+export default ModelMatrixUpdateStage;

--- a/Source/Scene/ModelExperimental/ModelMatrixUpdateStage.js
+++ b/Source/Scene/ModelExperimental/ModelMatrixUpdateStage.js
@@ -1,8 +1,31 @@
 import BoundingSphere from "../../Core/BoundingSphere.js";
+import defined from "../../Core/defined.js";
 import Matrix4 from "../../Core/Matrix4.js";
 
+/**
+ * The model matrix update stage is responsible for updating the model matrices and bounding volumes of the draw commands.
+ *
+ * @namespace ModelMatrixUpdateStage
+ *
+ * @private
+ */
 var ModelMatrixUpdateStage = {};
+ModelMatrixUpdateStage.name = "ModelMatrixUpdateStage"; // Helps with debugging
 
+/**
+ * Processes a runtime node. This modifies the following parts of the scene graph and draw commands:
+ * <ul>
+ *  <li>updates the transforms the children of any nodes with a dirty transform</li>
+ *  <li>updates the model matrix of each draw command in each primitive of the the dirty nodes and their children</li>
+ *  <li>updates the bounding volume of each draw command in each primitive of the the dirty nodes and their children</li>
+ * </ul>
+ *
+ * @param {ModelExperimentalNode} runtimeNode
+ * @param {ModelExperimentalSceneGraph} sceneGraph
+ * @param {FrameState} frameState
+ *
+ * @private
+ */
 ModelMatrixUpdateStage.update = function (runtimeNode, sceneGraph, frameState) {
   if (runtimeNode._transformDirty) {
     updateRuntimeNode(runtimeNode, sceneGraph);
@@ -16,33 +39,37 @@ ModelMatrixUpdateStage.update = function (runtimeNode, sceneGraph, frameState) {
 function updateRuntimeNode(runtimeNode, sceneGraph) {
   var i, j;
 
-  // Update the DrawCommand's model matrix and bounding volume for each runtime primitive that belongs to this runtime node.
-  for (i = 0; i < runtimeNode.runtimePrimitives.length; i++) {
-    var runtimePrimitive = runtimeNode.runtimePrimitives[i];
-    for (j = 0; j < runtimePrimitive.drawCommands.length; j++) {
-      var drawCommand = runtimePrimitive.drawCommands[j];
+  if (defined(runtimeNode.runtimePrimitives)) {
+    // Update the DrawCommand's model matrix and bounding volume for each runtime primitive that belongs to this runtime node.
+    for (i = 0; i < runtimeNode.runtimePrimitives.length; i++) {
+      var runtimePrimitive = runtimeNode.runtimePrimitives[i];
+      for (j = 0; j < runtimePrimitive.drawCommands.length; j++) {
+        var drawCommand = runtimePrimitive.drawCommands[j];
 
-      Matrix4.clone(runtimeNode.computedTransform, drawCommand.modelMatrix);
+        Matrix4.clone(runtimeNode.computedTransform, drawCommand.modelMatrix);
 
-      BoundingSphere.transform(
-        runtimePrimitive.boundingSphere,
-        drawCommand.modelMatrix,
-        drawCommand.boundingVolume
-      );
+        BoundingSphere.transform(
+          runtimePrimitive.boundingSphere,
+          drawCommand.modelMatrix,
+          drawCommand.boundingVolume
+        );
+      }
     }
   }
 
-  // Update all children runtime nodes.
-  for (i = 0; i < runtimeNode.children.length; i++) {
-    var childRuntimeNode = sceneGraph.runtimeNodes[runtimeNode.children[i]];
+  if (defined(runtimeNode.children)) {
+    // Update all children runtime nodes.
+    for (i = 0; i < runtimeNode.children.length; i++) {
+      var childRuntimeNode = sceneGraph._runtimeNodes[runtimeNode.children[i]];
 
-    Matrix4.multiply(
-      runtimeNode.transform,
-      childRuntimeNode.transform,
-      childRuntimeNode.transform
-    );
+      Matrix4.multiplyTransformation(
+        runtimeNode.transform,
+        childRuntimeNode.transform,
+        childRuntimeNode.transform
+      );
 
-    updateRuntimeNode(childRuntimeNode, sceneGraph);
+      updateRuntimeNode(childRuntimeNode, sceneGraph);
+    }
   }
 }
 

--- a/Source/Scene/ModelExperimental/ModelMatrixUpdateStage.js
+++ b/Source/Scene/ModelExperimental/ModelMatrixUpdateStage.js
@@ -3,20 +3,47 @@ import Matrix4 from "../../Core/Matrix4.js";
 
 var ModelMatrixUpdateStage = {};
 
-ModelMatrixUpdateStage.update = function (runtimePrimitive) {
-  for (var i = 0; i < runtimePrimitive.drawCommands; i++) {
-    var command = runtimePrimitive.drawCommands[i];
-    command.modelMatrix = Matrix4.clone(
-      runtimePrimitive.runtimeNode.transform,
-      command.modelMatrix
-    );
-
-    BoundingSphere.transform(
-      command.boundingSphere,
-      command.modelMatrix,
-      command.boundingVolume
-    );
+ModelMatrixUpdateStage.update = function (runtimeNode, sceneGraph, frameState) {
+  if (runtimeNode._transformDirty) {
+    updateRuntimeNode(runtimeNode, sceneGraph);
+    runtimeNode._transformDirty = false;
   }
 };
+
+/**
+ * Recursively update runtime nodes.
+ */
+function updateRuntimeNode(runtimeNode, sceneGraph) {
+  var i, j;
+
+  // Update the DrawCommand's model matrix and bounding volume for each runtime primitive that belongs to this runtime node.
+  for (i = 0; i < runtimeNode.runtimePrimitives.length; i++) {
+    var runtimePrimitive = runtimeNode.runtimePrimitives[i];
+    for (j = 0; j < runtimePrimitive.drawCommands.length; j++) {
+      var drawCommand = runtimePrimitive.drawCommands[j];
+
+      Matrix4.clone(runtimeNode.computedTransform, drawCommand.modelMatrix);
+
+      BoundingSphere.transform(
+        runtimePrimitive.boundingSphere,
+        drawCommand.modelMatrix,
+        drawCommand.boundingVolume
+      );
+    }
+  }
+
+  // Update all children runtime nodes.
+  for (i = 0; i < runtimeNode.children.length; i++) {
+    var childRuntimeNode = sceneGraph.runtimeNodes[runtimeNode.children[i]];
+
+    Matrix4.multiply(
+      runtimeNode.transform,
+      childRuntimeNode.transform,
+      childRuntimeNode.transform
+    );
+
+    updateRuntimeNode(childRuntimeNode, sceneGraph);
+  }
+}
 
 export default ModelMatrixUpdateStage;

--- a/Source/Scene/ModelExperimental/ModelMatrixUpdateStage.js
+++ b/Source/Scene/ModelExperimental/ModelMatrixUpdateStage.js
@@ -49,7 +49,7 @@ function updateRuntimeNode(runtimeNode, sceneGraph, transform) {
       var drawCommand = runtimePrimitive.drawCommands[j];
 
       Matrix4.multiplyTransformation(
-        sceneGraph._model.modelMatrix,
+        sceneGraph._computedModelMatrix,
         transform,
         drawCommand.modelMatrix
       );

--- a/Source/Scene/ModelExperimental/NodeRenderResources.js
+++ b/Source/Scene/ModelExperimental/NodeRenderResources.js
@@ -81,7 +81,7 @@ export default function NodeRenderResources(modelRenderResources, runtimeNode) {
    *
    * @private
    */
-  this.modelMatrix = runtimeNode.modelMatrix;
+  this.modelMatrix = runtimeNode.transform;
   /**
    * An array of objects describing vertex attributes that will eventually
    * be used to create a {@link VertexArray} for the draw command. Attributes

--- a/Source/Scene/ModelExperimental/PrimitiveRenderResources.js
+++ b/Source/Scene/ModelExperimental/PrimitiveRenderResources.js
@@ -1,6 +1,7 @@
 import Check from "../../Core/Check.js";
 import clone from "../../Core/clone.js";
 import defined from "../../Core/defined.js";
+import Matrix4 from "../../Core/Matrix4.js";
 import BlendingState from "../BlendingState.js";
 import DepthFunction from "../DepthFunction.js";
 import ModelExperimentalUtility from "./ModelExperimentalUtility.js";
@@ -109,15 +110,15 @@ export default function PrimitiveRenderResources(
   this.alphaOptions = clone(nodeRenderResources.alphaOptions);
 
   /**
-   * The computed model matrix for this primitive. This is cloned from the
+   * The model space transform for this primitive. This is cloned from the
    * node render resources as the primitive may further modify it
    *
    * @type {Matrix4}
    *
    * @private
    */
+  this.transform = nodeRenderResources.runtimeNode.transform.clone();
 
-  this.modelMatrix = nodeRenderResources.modelMatrix.clone();
   /**
    * An object used to build a shader incrementally. This is cloned from the
    * node render resources because each primitive can compute a different shader.
@@ -198,7 +199,7 @@ export default function PrimitiveRenderResources(
    */
   this.boundingSphere = ModelExperimentalUtility.createBoundingSphere(
     primitive,
-    this.modelMatrix,
+    Matrix4.IDENTITY,
     nodeRenderResources.instancingTranslationMax,
     nodeRenderResources.instancingTranslationMin
   );

--- a/Source/Scene/ModelExperimental/buildDrawCommands.js
+++ b/Source/Scene/ModelExperimental/buildDrawCommands.js
@@ -9,6 +9,8 @@ import RenderState from "../../Renderer/RenderState.js";
 import RuntimeError from "../../Core/RuntimeError.js";
 import StyleCommandsNeeded from "./StyleCommandsNeeded.js";
 import VertexArray from "../../Renderer/VertexArray.js";
+import BoundingSphere from "../../Core/BoundingSphere.js";
+import Matrix4 from "../../Core/Matrix4.js";
 
 /**
  * Builds the DrawCommands for a {@link ModelExperimentalPrimitive} using its render resources.
@@ -50,9 +52,21 @@ export default function buildDrawCommands(
 
   var pass = primitiveRenderResources.alphaOptions.pass;
 
+  var modelMatrix = Matrix4.multiply(
+    primitiveRenderResources.model.modelMatrix,
+    primitiveRenderResources.transform,
+    new Matrix4()
+  );
+
+  BoundingSphere.transform(
+    primitiveRenderResources.boundingSphere,
+    modelMatrix,
+    primitiveRenderResources.boundingSphere
+  );
+
   var command = new DrawCommand({
     boundingVolume: primitiveRenderResources.boundingSphere,
-    modelMatrix: primitiveRenderResources.modelMatrix,
+    modelMatrix: modelMatrix,
     uniformMap: primitiveRenderResources.uniformMap,
     renderState: renderState,
     vertexArray: vertexArray,

--- a/Source/Scene/ModelExperimental/buildDrawCommands.js
+++ b/Source/Scene/ModelExperimental/buildDrawCommands.js
@@ -52,8 +52,9 @@ export default function buildDrawCommands(
 
   var pass = primitiveRenderResources.alphaOptions.pass;
 
+  var sceneGraph = model.sceneGraph;
   var modelMatrix = Matrix4.multiply(
-    model._sceneGraph._computedModelMatrix,
+    sceneGraph.computedModelMatrix,
     primitiveRenderResources.transform,
     new Matrix4()
   );
@@ -77,7 +78,7 @@ export default function buildDrawCommands(
     pickId: primitiveRenderResources.pickId,
     instanceCount: primitiveRenderResources.instanceCount,
     primitiveType: primitiveRenderResources.primitiveType,
-    debugShowBoundingVolume: true,
+    debugShowBoundingVolume: model.debugShowBoundingVolume,
   });
 
   var styleCommandsNeeded = primitiveRenderResources.styleCommandsNeeded;

--- a/Source/Scene/ModelExperimental/buildDrawCommands.js
+++ b/Source/Scene/ModelExperimental/buildDrawCommands.js
@@ -77,7 +77,7 @@ export default function buildDrawCommands(
     pickId: primitiveRenderResources.pickId,
     instanceCount: primitiveRenderResources.instanceCount,
     primitiveType: primitiveRenderResources.primitiveType,
-    debugShowBoundingVolume: model.debugShowBoundingVolume,
+    debugShowBoundingVolume: true,
   });
 
   var styleCommandsNeeded = primitiveRenderResources.styleCommandsNeeded;

--- a/Source/Scene/ModelExperimental/buildDrawCommands.js
+++ b/Source/Scene/ModelExperimental/buildDrawCommands.js
@@ -53,7 +53,7 @@ export default function buildDrawCommands(
   var pass = primitiveRenderResources.alphaOptions.pass;
 
   var modelMatrix = Matrix4.multiply(
-    primitiveRenderResources.model.modelMatrix,
+    model._sceneGraph._computedModelMatrix,
     primitiveRenderResources.transform,
     new Matrix4()
   );

--- a/Specs/Scene/ModelExperimental/ModelExperimentalNodeSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalNodeSpec.js
@@ -2,26 +2,54 @@ import {
   InstancingPipelineStage,
   Matrix4,
   ModelExperimentalNode,
+  ModelMatrixUpdateStage,
 } from "../../../Source/Cesium.js";
 
 describe("Scene/ModelExperimental/ModelExperimentalNode", function () {
   var mockNode = {};
-  var modelMatrix = Matrix4.IDENTITY;
+  var transform = Matrix4.IDENTITY;
+  var mockSceneGraph = {};
 
   it("throws for undefined node", function () {
     expect(function () {
       return new ModelExperimentalNode({
         node: undefined,
-        modelMatrix: modelMatrix,
+        transform: transform,
+        sceneGraph: mockSceneGraph,
+        children: [],
       });
     }).toThrowDeveloperError();
   });
 
-  it("throws for undefined modelMatrix", function () {
+  it("throws for undefined transform", function () {
     expect(function () {
       return new ModelExperimentalNode({
         node: mockNode,
-        modelMatrix: undefined,
+        transform: undefined,
+        sceneGraph: mockSceneGraph,
+        children: [],
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("throws for undefined scene graph", function () {
+    expect(function () {
+      return new ModelExperimentalNode({
+        node: mockNode,
+        transform: transform,
+        sceneGraph: undefined,
+        children: [],
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("throws for undefined children", function () {
+    expect(function () {
+      return new ModelExperimentalNode({
+        node: mockNode,
+        transform: transform,
+        sceneGraph: mockSceneGraph,
+        children: undefined,
       });
     }).toThrowDeveloperError();
   });
@@ -29,12 +57,17 @@ describe("Scene/ModelExperimental/ModelExperimentalNode", function () {
   it("constructs", function () {
     var node = new ModelExperimentalNode({
       node: mockNode,
-      modelMatrix: modelMatrix,
+      transform: transform,
+      sceneGraph: mockSceneGraph,
+      children: [],
     });
 
     expect(node.node).toBe(mockNode);
-    expect(node.modelMatrix).toBe(modelMatrix);
+    expect(node.transform).toBe(transform);
+    expect(node.sceneGraph).toBe(mockSceneGraph);
+    expect(node.children.length).toEqual(0);
     expect(node.pipelineStages).toEqual([]);
+    expect(node.updateStages).toEqual([ModelMatrixUpdateStage]);
     expect(node.runtimePrimitives).toEqual([]);
   });
 

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSceneGraphSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSceneGraphSpec.js
@@ -7,6 +7,7 @@ import {
   Matrix4,
   ModelColorPipelineStage,
   ModelExperimentalSceneGraph,
+  ModelExperimentalUtility,
   Pass,
   ResourceCache,
 } from "../../../Source/Cesium.js";
@@ -71,12 +72,14 @@ describe(
         var sceneGraph = model._sceneGraph;
         // Reset the draw commands so we can inspect the draw command generation.
         model._drawCommandsBuilt = false;
-        sceneGraph._drawCommands = [];
         frameState.commandList = [];
         scene.renderForSpecs();
-        expect(sceneGraph._drawCommands.length).toEqual(1);
+
+        var drawCommands = sceneGraph.getDrawCommands();
+
+        expect(drawCommands.length).toEqual(1);
+        expect(drawCommands[0].pass).toEqual(Pass.OPAQUE);
         expect(frameState.commandList.length).toEqual(1);
-        expect(sceneGraph._drawCommands[0].pass).toEqual(Pass.OPAQUE);
       });
     });
 
@@ -96,12 +99,14 @@ describe(
         var sceneGraph = model._sceneGraph;
         // Reset the draw commands so we can inspect the draw command generation.
         model._drawCommandsBuilt = false;
-        sceneGraph._drawCommands = [];
         frameState.commandList = [];
         scene.renderForSpecs();
-        expect(sceneGraph._drawCommands.length).toEqual(1);
+
+        var drawCommands = sceneGraph.getDrawCommands();
+
+        expect(drawCommands.length).toEqual(1);
+        expect(drawCommands[0].pass).toEqual(Pass.TRANSLUCENT);
         expect(frameState.commandList.length).toEqual(1);
-        expect(sceneGraph._drawCommands[0].pass).toEqual(Pass.TRANSLUCENT);
       });
     });
 
@@ -124,13 +129,14 @@ describe(
         var sceneGraph = model._sceneGraph;
         // Reset the draw commands so we can inspect the draw command generation.
         model._drawCommandsBuilt = false;
-        sceneGraph._drawCommands = [];
         frameState.commandList = [];
         scene.renderForSpecs();
-        expect(sceneGraph._drawCommands.length).toEqual(2);
+
+        var drawCommands = sceneGraph.getDrawCommands();
+        expect(drawCommands.length).toEqual(2);
+        expect(drawCommands[0].pass).toEqual(Pass.OPAQUE);
+        expect(drawCommands[1].pass).toEqual(Pass.TRANSLUCENT);
         expect(frameState.commandList.length).toEqual(2);
-        expect(sceneGraph._drawCommands[0].pass).toEqual(Pass.OPAQUE);
-        expect(sceneGraph._drawCommands[1].pass).toEqual(Pass.TRANSLUCENT);
       });
     });
 
@@ -138,6 +144,10 @@ describe(
       spyOn(
         ModelExperimentalSceneGraph.prototype,
         "buildDrawCommands"
+      ).and.callThrough();
+      spyOn(
+        ModelExperimentalSceneGraph.prototype,
+        "getDrawCommands"
       ).and.callThrough();
       return loadAndZoomToModelExperimental(
         { gltf: parentGltfUrl },
@@ -157,18 +167,22 @@ describe(
         expect(
           ModelExperimentalSceneGraph.prototype.buildDrawCommands
         ).toHaveBeenCalled();
+        expect(
+          ModelExperimentalSceneGraph.prototype.getDrawCommands
+        ).toHaveBeenCalled();
         expect(frameState.commandList.length).toEqual(primitivesCount);
 
         expect(model._drawCommandsBuilt).toEqual(true);
-        expect(sceneGraph._drawCommands.length).toEqual(primitivesCount);
 
         // Reset the draw command list to see if they're re-built.
         model._drawCommandsBuilt = false;
-        sceneGraph._drawCommands = [];
         frameState.commandList = [];
         scene.renderForSpecs();
         expect(
           ModelExperimentalSceneGraph.prototype.buildDrawCommands
+        ).toHaveBeenCalled();
+        expect(
+          ModelExperimentalSceneGraph.prototype.getDrawCommands
         ).toHaveBeenCalled();
         expect(frameState.commandList.length).toEqual(primitivesCount);
       });
@@ -204,13 +218,13 @@ describe(
         expect(modelComponents.upAxis).toEqual(Axis.Z);
         expect(modelComponents.forwardAxis).toEqual(Axis.X);
 
-        expect(runtimeNodes[1].modelMatrix).toEqual(
-          modelComponents.nodes[0].matrix
+        expect(runtimeNodes[1].transform).toEqual(
+          ModelExperimentalUtility.getNodeTransform(modelComponents.nodes[0])
         );
-        expect(runtimeNodes[0].modelMatrix).toEqual(
-          Matrix4.multiplyByTranslation(
-            runtimeNodes[1].modelMatrix,
-            modelComponents.nodes[1].translation,
+        expect(runtimeNodes[0].transform).toEqual(
+          Matrix4.multiplyTransformation(
+            runtimeNodes[1].transform,
+            ModelExperimentalUtility.getNodeTransform(modelComponents.nodes[1]),
             new Matrix4()
           )
         );

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -14,8 +14,10 @@ import {
   when,
   ShaderProgram,
   ModelFeature,
+  Axis,
   Color,
   StyleCommandsNeeded,
+  ModelExperimentalSceneGraph,
 } from "../../../Source/Cesium.js";
 import createScene from "../../createScene.js";
 import loadAndZoomToModelExperimental from "./loadAndZoomToModelExperimental.js";
@@ -450,6 +452,37 @@ describe(
         scene
       ).then(function (model) {
         expect(model.featureTableId).toEqual(0);
+      });
+    });
+
+    it("changing model matrix works", function () {
+      var updateModelMatrix = spyOn(
+        ModelExperimentalSceneGraph.prototype,
+        "updateModelMatrix"
+      ).and.callThrough();
+      return loadAndZoomToModelExperimental(
+        { gltf: boxTexturedGlbUrl, upAxis: Axis.Z, forwardAxis: Axis.X },
+        scene
+      ).then(function (model) {
+        var sceneGraph = model.sceneGraph;
+        expect(model._modelMatrixDirty).toBe(false);
+
+        var transform = Matrix4.fromTranslation(new Cartesian3(10, 0, 0));
+
+        model.modelMatrix = Matrix4.multiplyTransformation(
+          model.modelMatrix,
+          transform,
+          new Matrix4()
+        );
+
+        expect(model._modelMatrixDirty).toBe(true);
+        scene.renderForSpecs();
+        expect(model._modelMatrixDirty).toBe(false);
+
+        expect(updateModelMatrix).toHaveBeenCalled();
+        expect(Matrix4.equals(sceneGraph.computedModelMatrix, transform)).toBe(
+          true
+        );
       });
     });
 

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -208,7 +208,6 @@ describe(
           scene
         ).then(function (model) {
           expect(model.ready).toEqual(true);
-          expect(model._sceneGraph._drawCommands.length).toBeGreaterThan(0);
           expect(model.show).toEqual(false);
           verifyRender(model, false);
           model.show = true;

--- a/Specs/Scene/ModelExperimental/ModelMatrixUpdateStageSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelMatrixUpdateStageSpec.js
@@ -50,7 +50,7 @@ describe(
         );
         expect(node._transformDirty).toEqual(true);
         var expectedComputedTransform = Matrix4.multiplyTransformation(
-          sceneGraph._computedModelMatrix,
+          sceneGraph.computedModelMatrix,
           node.transform,
           new Matrix4()
         );
@@ -103,7 +103,7 @@ describe(
       expect(node._transformDirty).toEqual(true);
 
       var expectedComputedTransform = Matrix4.multiplyTransformation(
-        sceneGraph._computedModelMatrix,
+        sceneGraph.computedModelMatrix,
         node.transform,
         new Matrix4()
       );

--- a/Specs/Scene/ModelExperimental/ModelMatrixUpdateStageSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelMatrixUpdateStageSpec.js
@@ -8,45 +8,100 @@ import {
 import createScene from "../../createScene.js";
 import loadAndZoomToModelExperimental from "./loadAndZoomToModelExperimental.js";
 
-describe("Scene/ModelExperimental/ModelMatrixUpdateStage", function () {
-  var airplane = "./Data/Models/CesiumAir/Cesium_Air.gltf";
+describe(
+  "Scene/ModelExperimental/ModelMatrixUpdateStage",
+  function () {
+    var airplane = "./Data/Models/CesiumAir/Cesium_Air.gltf";
 
-  var scene;
+    var scene;
 
-  beforeAll(function () {
-    scene = createScene();
-  });
+    beforeAll(function () {
+      scene = createScene();
+    });
 
-  afterAll(function () {
-    scene.destroyForSpecs();
-  });
+    afterAll(function () {
+      scene.destroyForSpecs();
+    });
 
-  afterEach(function () {
-    scene.primitives.removeAll();
-    ResourceCache.clearForSpecs();
-  });
+    afterEach(function () {
+      scene.primitives.removeAll();
+      ResourceCache.clearForSpecs();
+    });
 
-  it("updates leaf nodes", function () {
-    return loadAndZoomToModelExperimental(
-      {
-        gltf: airplane,
-      },
-      scene
-    ).then(function (model) {
-      var sceneGraph = model._sceneGraph;
-      var node = sceneGraph._runtimeNodes[0];
-      var primitive = node.runtimePrimitives[0];
-      var drawCommand = primitive.drawCommands[0];
+    it("updates leaf nodes", function () {
+      return loadAndZoomToModelExperimental(
+        {
+          gltf: airplane,
+        },
+        scene
+      ).then(function (model) {
+        var sceneGraph = model._sceneGraph;
+        var node = sceneGraph._runtimeNodes[0];
+        var primitive = node.runtimePrimitives[0];
+        var drawCommand = primitive.drawCommands[0];
 
+        var expectedOriginalTransform = Matrix4.clone(node.originalTransform);
+        expect(node._transformDirty).toEqual(false);
+        var translation = new Cartesian3(0, 5, 0);
+        node.transform = Matrix4.multiplyByTranslation(
+          node.transform,
+          translation,
+          new Matrix4()
+        );
+        expect(node._transformDirty).toEqual(true);
+        var expectedComputedTransform = Matrix4.multiplyTransformation(
+          sceneGraph._computedModelMatrix,
+          node.transform,
+          new Matrix4()
+        );
+        expect(
+          Matrix4.equals(node.computedTransform, expectedComputedTransform)
+        ).toBe(true);
+        expect(
+          Matrix4.equals(node.originalTransform, expectedOriginalTransform)
+        ).toBe(true);
+
+        var expectedModelMatrix = Matrix4.multiplyByTranslation(
+          drawCommand.modelMatrix,
+          translation,
+          new Matrix4()
+        );
+
+        var expectedBoundingSphere = BoundingSphere.transform(
+          primitive.boundingSphere,
+          expectedComputedTransform,
+          new BoundingSphere()
+        );
+
+        scene.renderForSpecs();
+
+        expect(
+          Matrix4.equalsEpsilon(
+            drawCommand.modelMatrix,
+            expectedModelMatrix,
+            CesiumMath.EPSILON15
+          )
+        ).toBe(true);
+        expect(
+          BoundingSphere.equals(
+            drawCommand.boundingVolume,
+            expectedBoundingSphere
+          )
+        ).toBe(true);
+      });
+    });
+
+    function applyTransform(sceneGraph, node, transform) {
       var expectedOriginalTransform = Matrix4.clone(node.originalTransform);
       expect(node._transformDirty).toEqual(false);
-      var translation = new Cartesian3(0, 5, 0);
-      node.transform = Matrix4.multiplyByTranslation(
+
+      node.transform = Matrix4.multiplyTransformation(
         node.transform,
-        translation,
+        transform,
         new Matrix4()
       );
       expect(node._transformDirty).toEqual(true);
+
       var expectedComputedTransform = Matrix4.multiplyTransformation(
         sceneGraph._computedModelMatrix,
         node.transform,
@@ -58,129 +113,79 @@ describe("Scene/ModelExperimental/ModelMatrixUpdateStage", function () {
       expect(
         Matrix4.equals(node.originalTransform, expectedOriginalTransform)
       ).toBe(true);
+    }
 
-      var expectedModelMatrix = Matrix4.multiplyByTranslation(
-        drawCommand.modelMatrix,
-        translation,
-        new Matrix4()
-      );
+    it("updates nodes with children", function () {
+      return loadAndZoomToModelExperimental(
+        {
+          gltf: airplane,
+        },
+        scene
+      ).then(function (model) {
+        var sceneGraph = model._sceneGraph;
 
-      var expectedBoundingSphere = BoundingSphere.transform(
-        primitive.boundingSphere,
-        expectedComputedTransform,
-        new BoundingSphere()
-      );
+        // The root node is transformed.
+        var rootNode = sceneGraph._runtimeNodes[2];
+        // The static child node is not transformed relative to the parent.
+        var staticChildNode = sceneGraph._runtimeNodes[0];
+        // The transformed child node is transformed relative to the parent.
+        var transformedChildNode = sceneGraph._runtimeNodes[1];
 
-      scene.renderForSpecs();
+        var childTransformation = Matrix4.fromTranslation(
+          new Cartesian3(0, 5, 0)
+        );
+        applyTransform(sceneGraph, transformedChildNode, childTransformation);
 
-      expect(
-        Matrix4.equalsEpsilon(
-          drawCommand.modelMatrix,
-          expectedModelMatrix,
-          CesiumMath.EPSILON15
-        )
-      ).toBe(true);
-      expect(
-        BoundingSphere.equals(
-          drawCommand.boundingVolume,
-          expectedBoundingSphere
-        )
-      ).toBe(true);
+        var rootTransformation = Matrix4.fromTranslation(
+          new Cartesian3(12, 5, 0)
+        );
+        applyTransform(sceneGraph, rootNode, rootTransformation);
+
+        var rootPrimitive = rootNode.runtimePrimitives[0];
+        var staticChildPrimitive = staticChildNode.runtimePrimitives[0];
+        var transformedChildPrimitive =
+          transformedChildNode.runtimePrimitives[0];
+
+        var rootDrawCommand = rootPrimitive.drawCommands[0];
+        var staticChildDrawCommand = staticChildPrimitive.drawCommands[0];
+        var transformedChildDrawCommand =
+          transformedChildPrimitive.drawCommands[0];
+
+        var expectedRootModelMatrix = Matrix4.multiplyTransformation(
+          rootDrawCommand.modelMatrix,
+          rootTransformation,
+          new Matrix4()
+        );
+        var expectedStaticChildModelMatrix = Matrix4.multiplyTransformation(
+          expectedRootModelMatrix,
+          staticChildNode.transform,
+          new Matrix4()
+        );
+        var expectedTransformedChildModelMatrix = Matrix4.multiplyTransformation(
+          expectedRootModelMatrix,
+          transformedChildNode.transform,
+          new Matrix4()
+        );
+
+        scene.renderForSpecs();
+
+        expect(
+          Matrix4.equals(rootDrawCommand.modelMatrix, expectedRootModelMatrix)
+        ).toBe(true);
+        expect(
+          Matrix4.equals(
+            staticChildDrawCommand.modelMatrix,
+            expectedStaticChildModelMatrix
+          )
+        ).toBe(true);
+        expect(
+          Matrix4.equals(
+            transformedChildDrawCommand.modelMatrix,
+            expectedTransformedChildModelMatrix
+          )
+        ).toBe(true);
+      });
     });
-  });
-
-  function applyTransform(sceneGraph, node, transform) {
-    var expectedOriginalTransform = Matrix4.clone(node.originalTransform);
-    expect(node._transformDirty).toEqual(false);
-
-    node.transform = Matrix4.multiplyTransformation(
-      node.transform,
-      transform,
-      new Matrix4()
-    );
-    expect(node._transformDirty).toEqual(true);
-
-    var expectedComputedTransform = Matrix4.multiplyTransformation(
-      sceneGraph._computedModelMatrix,
-      node.transform,
-      new Matrix4()
-    );
-    expect(
-      Matrix4.equals(node.computedTransform, expectedComputedTransform)
-    ).toBe(true);
-    expect(
-      Matrix4.equals(node.originalTransform, expectedOriginalTransform)
-    ).toBe(true);
-  }
-
-  it("updates nodes with children", function () {
-    return loadAndZoomToModelExperimental(
-      {
-        gltf: airplane,
-      },
-      scene
-    ).then(function (model) {
-      var sceneGraph = model._sceneGraph;
-
-      // The root node is transformed.
-      var rootNode = sceneGraph._runtimeNodes[2];
-      // The static child node is not transformed relative to the parent.
-      var staticChildNode = sceneGraph._runtimeNodes[0];
-      // The transformed child node is transformed relative to the parent.
-      var transformedChildNode = sceneGraph._runtimeNodes[1];
-
-      var childTransformation = Matrix4.fromTranslation(
-        new Cartesian3(0, 5, 0)
-      );
-      applyTransform(sceneGraph, transformedChildNode, childTransformation);
-
-      var rootTransformation = Matrix4.fromTranslation(
-        new Cartesian3(12, 5, 0)
-      );
-      applyTransform(sceneGraph, rootNode, rootTransformation);
-
-      var rootPrimitive = rootNode.runtimePrimitives[0];
-      var staticChildPrimitive = staticChildNode.runtimePrimitives[0];
-      var transformedChildPrimitive = transformedChildNode.runtimePrimitives[0];
-
-      var rootDrawCommand = rootPrimitive.drawCommands[0];
-      var staticChildDrawCommand = staticChildPrimitive.drawCommands[0];
-      var transformedChildDrawCommand =
-        transformedChildPrimitive.drawCommands[0];
-
-      var expectedRootModelMatrix = Matrix4.multiplyTransformation(
-        rootDrawCommand.modelMatrix,
-        rootTransformation,
-        new Matrix4()
-      );
-      var expectedStaticChildModelMatrix = Matrix4.multiplyTransformation(
-        expectedRootModelMatrix,
-        staticChildNode.transform,
-        new Matrix4()
-      );
-      var expectedTransformedChildModelMatrix = Matrix4.multiplyTransformation(
-        expectedRootModelMatrix,
-        transformedChildNode.transform,
-        new Matrix4()
-      );
-
-      scene.renderForSpecs();
-
-      expect(
-        Matrix4.equals(rootDrawCommand.modelMatrix, expectedRootModelMatrix)
-      ).toBe(true);
-      expect(
-        Matrix4.equals(
-          staticChildDrawCommand.modelMatrix,
-          expectedStaticChildModelMatrix
-        )
-      ).toBe(true);
-      expect(
-        Matrix4.equals(
-          transformedChildDrawCommand.modelMatrix,
-          expectedTransformedChildModelMatrix
-        )
-      ).toBe(true);
-    });
-  });
-});
+  },
+  "WebGL"
+);

--- a/Specs/Scene/ModelExperimental/ModelMatrixUpdateStageSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelMatrixUpdateStageSpec.js
@@ -1,0 +1,219 @@
+import {
+  BoundingSphere,
+  Cartesian3,
+  Matrix4,
+  ResourceCache,
+} from "../../../Source/Cesium.js";
+import createScene from "../../createScene.js";
+import loadAndZoomToModelExperimental from "./loadAndZoomToModelExperimental.js";
+
+describe("Scene/ModelExperimental/ModelMatrixUpdateStage", function () {
+  var airplane = "./Data/Models/CesiumAir/Cesium_Air.gltf";
+
+  var scene;
+
+  beforeAll(function () {
+    scene = createScene();
+  });
+
+  afterAll(function () {
+    scene.destroyForSpecs();
+  });
+
+  afterEach(function () {
+    scene.primitives.removeAll();
+    ResourceCache.clearForSpecs();
+  });
+
+  it("updates leaf nodes", function () {
+    return loadAndZoomToModelExperimental(
+      {
+        gltf: airplane,
+      },
+      scene
+    ).then(function (model) {
+      var sceneGraph = model._sceneGraph;
+      var node = sceneGraph._runtimeNodes[0];
+      var primitive = node.runtimePrimitives[0];
+      var drawCommand = primitive.drawCommands[0];
+
+      var expectedOriginalTransform = Matrix4.clone(node.originalTransform);
+      expect(node._transformDirty).toEqual(false);
+      var translation = new Cartesian3(0, 5, 0);
+      node.transform = Matrix4.multiplyByTranslation(
+        node.transform,
+        translation,
+        new Matrix4()
+      );
+      expect(node._transformDirty).toEqual(true);
+      var expectedComputedTransform = Matrix4.multiplyTransformation(
+        sceneGraph._computedModelMatrix,
+        node.transform,
+        new Matrix4()
+      );
+      expect(
+        Matrix4.equals(node.computedTransform, expectedComputedTransform)
+      ).toBe(true);
+      expect(
+        Matrix4.equals(node.originalTransform, expectedOriginalTransform)
+      ).toBe(true);
+
+      var expectedModelMatrix = Matrix4.multiplyByTranslation(
+        drawCommand.modelMatrix,
+        translation,
+        new Matrix4()
+      );
+
+      var expectedBoundingSphere = BoundingSphere.transform(
+        primitive.boundingSphere,
+        expectedComputedTransform,
+        new BoundingSphere()
+      );
+
+      scene.renderForSpecs();
+
+      expect(Matrix4.equals(drawCommand.modelMatrix, expectedModelMatrix)).toBe(
+        true
+      );
+      expect(
+        BoundingSphere.equals(
+          drawCommand.boundingVolume,
+          expectedBoundingSphere
+        )
+      ).toBe(true);
+    });
+  });
+
+  function applyTransform(sceneGraph, node, transform) {
+    var expectedOriginalTransform = Matrix4.clone(node.originalTransform);
+    expect(node._transformDirty).toEqual(false);
+
+    node.transform = Matrix4.multiplyTransformation(
+      node.transform,
+      transform,
+      new Matrix4()
+    );
+    expect(node._transformDirty).toEqual(true);
+
+    var expectedComputedTransform = Matrix4.multiplyTransformation(
+      sceneGraph._computedModelMatrix,
+      node.transform,
+      new Matrix4()
+    );
+    expect(
+      Matrix4.equals(node.computedTransform, expectedComputedTransform)
+    ).toBe(true);
+    expect(
+      Matrix4.equals(node.originalTransform, expectedOriginalTransform)
+    ).toBe(true);
+  }
+
+  it("updates nodes with children", function () {
+    return loadAndZoomToModelExperimental(
+      {
+        gltf: airplane,
+      },
+      scene
+    ).then(function (model) {
+      var sceneGraph = model._sceneGraph;
+
+      // The root node is transformed.
+      var rootNode = sceneGraph._runtimeNodes[2];
+      // The static child node is not transformed relative to the parent.
+      var staticChildNode = sceneGraph._runtimeNodes[0];
+      // The transformed child node is transformed relative to the parent.
+      var transformedChildNode = sceneGraph._runtimeNodes[1];
+
+      var childTransformation = Matrix4.fromTranslation(
+        new Cartesian3(0, 5, 0)
+      );
+      applyTransform(sceneGraph, transformedChildNode, childTransformation);
+
+      var rootTransformation = Matrix4.fromTranslation(
+        new Cartesian3(12, 5, 0)
+      );
+      applyTransform(sceneGraph, rootNode, rootTransformation);
+
+      var rootPrimitive = rootNode.runtimePrimitives[0];
+      var staticChildPrimitive = staticChildNode.runtimePrimitives[0];
+      var transformedChildPrimitive = transformedChildNode.runtimePrimitives[0];
+
+      var rootDrawCommand = rootPrimitive.drawCommands[0];
+      var staticChildDrawCommand = staticChildPrimitive.drawCommands[0];
+      var transformedChildDrawCommand =
+        transformedChildPrimitive.drawCommands[0];
+
+      var expectedRootModelMatrix = Matrix4.multiplyTransformation(
+        rootDrawCommand.modelMatrix,
+        rootTransformation,
+        new Matrix4()
+      );
+      var expectedStaticChildModelMatrix = Matrix4.multiplyTransformation(
+        expectedRootModelMatrix,
+        staticChildNode.transform,
+        new Matrix4()
+      );
+      var expectedTransformedChildModelMatrix = Matrix4.multiplyTransformation(
+        expectedRootModelMatrix,
+        transformedChildNode.transform,
+        new Matrix4()
+      );
+
+      var expectedRootBoundingSphere = BoundingSphere.transform(
+        rootPrimitive.boundingSphere,
+        rootTransformation,
+        new BoundingSphere()
+      );
+      var expectedStaticChildBoundingSphere = BoundingSphere.transform(
+        staticChildDrawCommand.boundingVolume,
+        rootTransformation,
+        new BoundingSphere()
+      );
+      var expectedTransformedChildBoundingSphere = BoundingSphere.transform(
+        transformedChildDrawCommand.boundingVolume,
+        Matrix4.multiplyTransformation(
+          rootTransformation,
+          childTransformation,
+          new Matrix4()
+        ),
+        new BoundingSphere()
+      );
+
+      scene.renderForSpecs();
+
+      expect(
+        Matrix4.equals(rootDrawCommand.modelMatrix, expectedRootModelMatrix)
+      ).toBe(true);
+      expect(
+        BoundingSphere.equals(
+          rootDrawCommand.boundingVolume,
+          expectedRootBoundingSphere
+        )
+      ).toBe(true);
+      expect(
+        Matrix4.equals(
+          staticChildDrawCommand.modelMatrix,
+          expectedStaticChildModelMatrix
+        )
+      ).toBe(true);
+      expect(
+        BoundingSphere.equals(
+          staticChildDrawCommand.boundingVolume,
+          expectedStaticChildBoundingSphere
+        )
+      ).toBe(true);
+      expect(
+        Matrix4.equals(
+          transformedChildDrawCommand.modelMatrix,
+          expectedTransformedChildModelMatrix
+        )
+      ).toBe(true);
+      expect(
+        BoundingSphere.equals(
+          transformedChildDrawCommand.boundingVolume,
+          expectedTransformedChildBoundingSphere
+        )
+      ).toBe(true);
+    });
+  });
+});

--- a/Specs/Scene/ModelExperimental/ModelMatrixUpdateStageSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelMatrixUpdateStageSpec.js
@@ -2,6 +2,7 @@ import {
   BoundingSphere,
   Cartesian3,
   Matrix4,
+  Math as CesiumMath,
   ResourceCache,
 } from "../../../Source/Cesium.js";
 import createScene from "../../createScene.js";
@@ -72,9 +73,13 @@ describe("Scene/ModelExperimental/ModelMatrixUpdateStage", function () {
 
       scene.renderForSpecs();
 
-      expect(Matrix4.equals(drawCommand.modelMatrix, expectedModelMatrix)).toBe(
-        true
-      );
+      expect(
+        Matrix4.equalsEpsilon(
+          drawCommand.modelMatrix,
+          expectedModelMatrix,
+          CesiumMath.EPSILON15
+        )
+      ).toBe(true);
       expect(
         BoundingSphere.equals(
           drawCommand.boundingVolume,
@@ -159,36 +164,10 @@ describe("Scene/ModelExperimental/ModelMatrixUpdateStage", function () {
         new Matrix4()
       );
 
-      var expectedRootBoundingSphere = BoundingSphere.transform(
-        rootPrimitive.boundingSphere,
-        rootTransformation,
-        new BoundingSphere()
-      );
-      var expectedStaticChildBoundingSphere = BoundingSphere.transform(
-        staticChildDrawCommand.boundingVolume,
-        rootTransformation,
-        new BoundingSphere()
-      );
-      var expectedTransformedChildBoundingSphere = BoundingSphere.transform(
-        transformedChildDrawCommand.boundingVolume,
-        Matrix4.multiplyTransformation(
-          rootTransformation,
-          childTransformation,
-          new Matrix4()
-        ),
-        new BoundingSphere()
-      );
-
       scene.renderForSpecs();
 
       expect(
         Matrix4.equals(rootDrawCommand.modelMatrix, expectedRootModelMatrix)
-      ).toBe(true);
-      expect(
-        BoundingSphere.equals(
-          rootDrawCommand.boundingVolume,
-          expectedRootBoundingSphere
-        )
       ).toBe(true);
       expect(
         Matrix4.equals(
@@ -197,21 +176,9 @@ describe("Scene/ModelExperimental/ModelMatrixUpdateStage", function () {
         )
       ).toBe(true);
       expect(
-        BoundingSphere.equals(
-          staticChildDrawCommand.boundingVolume,
-          expectedStaticChildBoundingSphere
-        )
-      ).toBe(true);
-      expect(
         Matrix4.equals(
           transformedChildDrawCommand.modelMatrix,
           expectedTransformedChildModelMatrix
-        )
-      ).toBe(true);
-      expect(
-        BoundingSphere.equals(
-          transformedChildDrawCommand.boundingVolume,
-          expectedTransformedChildBoundingSphere
         )
       ).toBe(true);
     });

--- a/Specs/Scene/ModelExperimental/NodeRenderResourcesSpec.js
+++ b/Specs/Scene/ModelExperimental/NodeRenderResourcesSpec.js
@@ -9,7 +9,7 @@ describe("Scene/ModelExperimental/NodeRenderResources", function () {
   var mockModel = {};
   var mockNode = {};
   var mockSceneGraph = {
-    _computedModelMatrix: Matrix4.IDENTITY,
+    computedModelMatrix: Matrix4.IDENTITY,
   };
 
   var runtimeNode = new ModelExperimentalNode({

--- a/Specs/Scene/ModelExperimental/NodeRenderResourcesSpec.js
+++ b/Specs/Scene/ModelExperimental/NodeRenderResourcesSpec.js
@@ -8,9 +8,15 @@ import {
 describe("Scene/ModelExperimental/NodeRenderResources", function () {
   var mockModel = {};
   var mockNode = {};
+  var mockSceneGraph = {
+    _computedModelMatrix: Matrix4.IDENTITY,
+  };
+
   var runtimeNode = new ModelExperimentalNode({
     node: mockNode,
-    modelMatrix: Matrix4.IDENTITY,
+    transform: Matrix4.IDENTITY,
+    sceneGraph: mockSceneGraph,
+    children: [],
   });
 
   function checkShaderDefines(shaderBuilder, expectedDefines) {
@@ -36,7 +42,7 @@ describe("Scene/ModelExperimental/NodeRenderResources", function () {
     var nodeResources = new NodeRenderResources(modelResources, runtimeNode);
 
     expect(nodeResources.runtimeNode).toBe(runtimeNode);
-    expect(nodeResources.modelMatrix).toBe(runtimeNode.modelMatrix);
+    expect(nodeResources.modelMatrix).toBe(runtimeNode.transform);
     expect(nodeResources.attributes).toEqual([]);
   });
 

--- a/Specs/Scene/ModelExperimental/PrimitiveRenderResourcesSpec.js
+++ b/Specs/Scene/ModelExperimental/PrimitiveRenderResourcesSpec.js
@@ -19,9 +19,15 @@ import {
 describe("Scene/ModelExperimental/PrimitiveRenderResources", function () {
   var mockModel = {};
   var mockNode = {};
+  var mockSceneGraph = {
+    _computedModelMatrix: Matrix4.IDENTITY,
+  };
+
   var runtimeNode = new ModelExperimentalNode({
     node: mockNode,
-    modelMatrix: Matrix4.IDENTITY,
+    transform: Matrix4.IDENTITY,
+    sceneGraph: mockSceneGraph,
+    children: [],
   });
 
   function checkShaderDefines(shaderBuilder, expectedDefines) {

--- a/Specs/Scene/ModelExperimental/PrimitiveRenderResourcesSpec.js
+++ b/Specs/Scene/ModelExperimental/PrimitiveRenderResourcesSpec.js
@@ -20,7 +20,7 @@ describe("Scene/ModelExperimental/PrimitiveRenderResources", function () {
   var mockModel = {};
   var mockNode = {};
   var mockSceneGraph = {
-    _computedModelMatrix: Matrix4.IDENTITY,
+    computedModelMatrix: Matrix4.IDENTITY,
   };
 
   var runtimeNode = new ModelExperimentalNode({


### PR DESCRIPTION
This PR adds support for dynamically changing node transforms in `ModelExperimental`. It also adds the ability to traverse the scene graph of `ModelExperimentaNode` objects.

### Architecture

**`model.modelMatrix` update**

![Update Stage - Frame 1 (2)](https://user-images.githubusercontent.com/5172619/148442456-a43ce3e8-abcd-49aa-93c1-dc62d7c1d54a.jpg)

**`node.transform` update**

![Update Stage - Frame 2](https://user-images.githubusercontent.com/5172619/148442466-36cc3a55-ab32-4322-9fbf-bc1b965fc362.jpg)

### To-Do
- [x] Add a way to update the draw commands with the new `modelMatrix`
- [x] Fix child transform bug
- [x] Update documentation
- [x] Add tests

### Testing

| [Truck Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=xVbpbhs3EH4VVn+yQmVKTpymdRSjtWI7Qe0miNT0gICC2h1JRChyQXJlrQu/RX/26fokHR57SN4ARZGmhuAlh5zrm4sTMLzY0ItdDppvQFomLoHZQoOhINlCwI3KQLTPyQtidQHP53Iut0yTLYdb0EiVcEsmQd57T0vmvdTvJwoZuQQ97/VrPqEkMh0dP35CR89OTr46/uZ5PGAWD05O6Ojp6MmzUaQy4aijmj1XhlvuZUSlE6Ytrph8QpdabV7CSgOYZC6J0zXwX2b9F4XNZTAlSFvnBx68ApZxuXrLbbp+p4RIRgPifv1ozpLvILvUbAMzzaRZKr1pLKlJhgqVIqT+nrqsea4AwWBWaW/dvCeVtut5bxB2t2DsvFcZ6LRtXBBQfsCamhT5aY4RQQi2GCqWZV5S1P8gZh6QK2GXye/uGiErXJ+iKkqH+JuyTS7gJbNs6DWZ4ZVWhczew5qnAvZ3dCUW0VQSDLthVvPdaYf36wMU2xgkQQKpIzmoCBiMeh1lXgjBc6N4Rn+6mn59Uh93hCEc9d3nvh9ARFClt5RqNKh8i2BwA9SuQSbLQqY+jxJ/o088QhHoFAVrRpeinKlzhwE6M83XoCHcpos94oBEeLMCo4tCT8mIPg2WoBn3/b2iuYlB9TwI38h7VVaLO1wgj2eJKHyQKv2gCkutZumHpBZSJaVVSiyYy+RMpYULPV2BvRDglufla0ySXrwTKvFQLstzUZ5z75Jp5A8qyY4HMSaJ0yYRHMJl40vEji9Jw0rXzLy5lQg5ZqMtE8fU71c4HeivouqsfrMwoLeuA7Xt8Oz1NVMsTKr5ApIiz5htciAE/R7hqwA3ICC1kL0rpMWi+AHFeWTr8B9ISFrORCszWGIPy5IOUY1H4b8PhhMlWOxRrdbS9KkkZ9rApVDMthDb9Qek86D82MFdPzhMutyk9mGDChV7QjeFsBxDXrvtza0rs0ua0nzFJRM1y2GpVrJdy5k1GCQtPPo1TwuWyJfE8LZDGKbCwlfLxzM7WHvkL4b0rtslDgI5zVkKF1u8/4rJTDg62NcyL+x3PgOaTqDkNSztRHCsMWfERm29HmwmsTu4+YOnkD3oyY6nuk+rzhZ8can0xUEuBSlN+njjKZc4HmawcxNv3vOGoFEE+1WcBFbF2BBGJFLmvRh/DTi7ZQVdSMeOFA5qcYtjWTTaO+KNFuxdpjJUjs/yJmXjaN6nlp3Uuxa1y12vtbKE/PXnH9G5e4KDCT4NUBGb+0GVfNODFJmVOdDri8vZb5Pr15Pv+1294qaZfVW3cG+aL9E9OnJ/x17Xp3moxFFLWwO3873xP07c57HdzuUUCyxlxuJjAV8mszA7zgtrXW/pTdZMroCE8RdcwfcEaQZxBLMD5WaI9ga9sbGlgLPKsG/5JsdnFCm0SPBNYwHfNMhvhosC89fS1JiqS46HbdZxxreEZy86XqskFcwYPFkWQkz5HebP2XiI9x+wYkd2uL/ZghasdNfWx2fXgUgpHQ9x2+JsGOt5XDsytm7q1VtHWKisbBEcSe/tHSUjqRImZ/LF4yB6vyGe/YPyGA9ttq9neKCoU/HZzw8YA32fgjTu+i2xWF1on3Z5gCBvuMTd0bFbsh0u3cpYyHE5om6DicCOFvguQcqWiQJOyW5A/OpHnyWn5JEX/aiFY+3Bv3Lpl8/vUvkfu/Tr53fp7hO5hNu9GsB9q0jaJfk3) |
| - |
| ![transform](https://user-images.githubusercontent.com/5172619/148265329-0b27b28b-4496-44cd-b170-14394255f4e8.gif) |