### PR TITLE
Add `ModelExperimentalType`

### DIFF
--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -732,7 +732,6 @@ ModelExperimental.prototype.destroyResources = function () {
  * @param {Object} options Object with the following properties:
  * @param {String|Resource|Uint8Array|Object} options.gltf A Resource/URL to a glTF/glb file, a binary glTF buffer, or a JSON object containing the glTF contents
  * @param {String|Resource} [options.basePath=''] The base path that paths in the glTF JSON are relative to.
- * @param {Boolean} [options.is3DTiles=false] Flag to distinguish 3D Tiles from individual glTF files.
  * @param {Matrix4} [options.modelMatrix=Matrix4.IDENTITY] The 4x4 transformation matrix that transforms the model from model to world coordinates.
  * @param {Boolean} [options.incrementallyLoadTextures=true] Determine if textures may continue to stream in after the model is loaded.
  * @param {Boolean} [options.releaseGltfJson=false] When true, the glTF JSON is released once the glTF is loaded. This is is especially useful for cases like 3D Tiles, where each .gltf model is unique and caching the glTF JSON is not effective.
@@ -786,7 +785,7 @@ ModelExperimental.fromGltf = function (options) {
   var loader = new GltfLoader(loaderOptions);
 
   // undocumented option for
-  var is3DTiles = defaultValue(options.is3DTiles, false);
+  var is3DTiles = defined(options.content);
   var type = is3DTiles
     ? ModelExperimentalType.TILE_GLTF
     : ModelExperimentalType.GLTF;

--- a/Source/Scene/ModelExperimental/ModelExperimentalType.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalType.js
@@ -1,0 +1,78 @@
+import Check from "../../Core/Check.js";
+import DeveloperError from "../../Core/DeveloperError.js";
+
+/**
+ * An enum to distinguishing the different uses for {@link ModelExperimental},
+ * which includes individual glTF models, and various 3D Tiles formats
+ * (including glTF via <code>3DTILES_content_gltf</code>).
+ *
+ * @enum {String}
+ */
+var ModelExperimentalType = {
+  /**
+   * An individual glTF model.
+   * <p>
+   * Not to be confused with {@link ModelExperimentalType.TILE_GLTF}
+   * which is for 3D Tiles
+   * </p>
+   *
+   * @type {String}
+   * @constant
+   */
+  GLTF: "GLTF",
+  /**
+   * A glTF model used as a tile in a 3D Tileset via
+   * <code>3DTILES_content_gltf</code>.
+   * <p>
+   * Not to be confused with {@link ModelExperimentalType.GLTF}
+   * which is for individual models
+   * </p>
+   *
+   * @type {String}
+   * @constant
+   */
+  TILE_GLTF: "TILE_GLTF",
+  /**
+   * A 3D Tiles 1.0 Batched 3D Model
+   *
+   * @type {String}
+   * @constant
+   */
+  TILE_B3DM: "B3DM",
+  /**
+   * A 3D Tiles 1.0 Instanced 3D Model
+   *
+   * @type {String}
+   * @constant
+   */
+  TILE_I3DM: "I3DM",
+  /**
+   * A 3D Tiles 1.0 Point Cloud
+   *
+   * @type {String}
+   * @constant
+   */
+  TILE_PNTS: "PNTS",
+};
+
+ModelExperimentalType.is3DTiles = function (modelType) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.string("modelType", modelType);
+  //>>includeEnd('debug');
+
+  switch (modelType) {
+    case ModelExperimentalType.TILE_GLTF:
+    case ModelExperimentalType.TILE_B3DM:
+    case ModelExperimentalType.TILE_I3DM:
+    case ModelExperimentalType.TILE_PNTS:
+      return true;
+    case ModelExperimentalType.GLTF:
+      return false;
+    //>>includeStart('debug', pragmas.debug);
+    default:
+      throw new DeveloperError("attributeType is not a valid value.");
+    //>>includeEnd('debug');
+  }
+};
+
+export default Object.freeze(ModelExperimentalType);

--- a/Source/Scene/ModelExperimental/ModelFeatureTable.js
+++ b/Source/Scene/ModelExperimental/ModelFeatureTable.js
@@ -7,6 +7,7 @@ import destroyObject from "../../Core/destroyObject.js";
 import ModelFeature from "./ModelFeature.js";
 import defaultValue from "../../Core/defaultValue.js";
 import StyleCommandsNeeded from "./StyleCommandsNeeded.js";
+import ModelExperimentalType from "./ModelExperimentalType.js";
 
 /**
  * Manages the {@link ModelFeature}s in a {@link ModelExperimental}.
@@ -96,21 +97,25 @@ Object.defineProperties(ModelFeatureTable.prototype, {
 });
 
 function initialize(modelFeatureTable) {
-  var content = modelFeatureTable._model.content;
-  var hasContent = defined(content);
+  var model = modelFeatureTable._model;
+  var is3DTiles = ModelExperimentalType.is3DTiles(model.type);
 
   var featuresLength = modelFeatureTable._propertyTable.count;
   if (featuresLength === 0) {
     return;
   }
 
+  var i;
   var features = new Array(featuresLength);
-  for (var i = 0; i < featuresLength; i++) {
-    if (hasContent) {
+  if (is3DTiles) {
+    var content = model.content;
+    for (i = 0; i < featuresLength; i++) {
       features[i] = new Cesium3DTileFeature(content, i);
-    } else {
+    }
+  } else {
+    for (i = 0; i < featuresLength; i++) {
       features[i] = new ModelFeature({
-        model: modelFeatureTable._model,
+        model: model,
         featureId: i,
         featureTable: modelFeatureTable,
       });
@@ -123,8 +128,8 @@ function initialize(modelFeatureTable) {
   modelFeatureTable._batchTexture = new BatchTexture({
     featuresLength: featuresLength,
     owner: modelFeatureTable,
-    statistics: hasContent
-      ? content.tileset.statistics
+    statistics: is3DTiles
+      ? model.content.tileset.statistics
       : modelFeatureTable._statistics,
   });
 }

--- a/Source/Scene/ModelExperimental/PickingPipelineStage.js
+++ b/Source/Scene/ModelExperimental/PickingPipelineStage.js
@@ -6,6 +6,7 @@ import ComponentDatatype from "../../Core/ComponentDatatype.js";
 import defaultValue from "../../Core/defaultValue.js";
 import defined from "../../Core/defined.js";
 import ShaderDestination from "../../Renderer/ShaderDestination.js";
+import ModelExperimentalType from "./ModelExperimentalType.js";
 
 /**
  * The picking pipeline stage is responsible for handling picking of primitives.
@@ -77,12 +78,12 @@ function buildPickObject(renderResources, instanceId) {
     primitive: renderResources.runtimePrimitive,
   };
 
-  var content = model.content;
   var pickObject;
 
-  if (defined(content)) {
+  if (ModelExperimentalType.is3DTiles(model.content)) {
     // For 3D Tiles, the pick object's content and primitive are set to the Cesium3DTileContent that owns the model
     // and the tileset it belongs to, respectively. The detail pick object is returned under the detail key.
+    var content = model.content;
     pickObject = {
       content: content,
       primitive: content.tileset,

--- a/Source/Scene/ModelExperimental/PickingPipelineStage.js
+++ b/Source/Scene/ModelExperimental/PickingPipelineStage.js
@@ -80,7 +80,7 @@ function buildPickObject(renderResources, instanceId) {
 
   var pickObject;
 
-  if (ModelExperimentalType.is3DTiles(model.content)) {
+  if (ModelExperimentalType.is3DTiles(model.type)) {
     // For 3D Tiles, the pick object's content and primitive are set to the Cesium3DTileContent that owns the model
     // and the tileset it belongs to, respectively. The detail pick object is returned under the detail key.
     var content = model.content;

--- a/Specs/Scene/ModelExperimental/ModelExperimentalTypeSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalTypeSpec.js
@@ -1,0 +1,39 @@
+import { ModelExperimentalType } from "../../../Source/Cesium.js";
+
+describe("Scene/ModelExperimental/ModelExperimentalType", function () {
+  it("is3DTiles works", function () {
+    expect(ModelExperimentalType.is3DTiles(ModelExperimentalType.GLTF)).toBe(
+      false
+    );
+    expect(
+      ModelExperimentalType.is3DTiles(ModelExperimentalType.TILE_GLTF)
+    ).toBe(true);
+    expect(
+      ModelExperimentalType.is3DTiles(ModelExperimentalType.TILE_B3DM)
+    ).toBe(true);
+    expect(
+      ModelExperimentalType.is3DTiles(ModelExperimentalType.TILE_I3DM)
+    ).toBe(true);
+    expect(
+      ModelExperimentalType.is3DTiles(ModelExperimentalType.TILE_PNTS)
+    ).toBe(true);
+  });
+
+  it("is3DTiles throws for invalid value", function () {
+    expect(function () {
+      return ModelExperimentalType.is3DTiles("4DTiles");
+    }).toThrowDeveloperError();
+  });
+
+  it("is3DTiles throws without modelType", function () {
+    expect(function () {
+      return ModelExperimentalType.is3DTiles();
+    }).toThrowDeveloperError();
+  });
+
+  it("is3DTiles throws with invalid modelType", function () {
+    expect(function () {
+      return ModelExperimentalType.is3DTiles(10);
+    }).toThrowDeveloperError();
+  });
+});

--- a/Specs/Scene/ModelExperimental/ModelFeatureTableSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelFeatureTableSpec.js
@@ -1,5 +1,6 @@
 import {
   Cesium3DTileFeature,
+  ModelExperimentalType,
   ModelFeatureTable,
   ModelFeature,
 } from "../../../Source/Cesium.js";
@@ -32,7 +33,9 @@ describe("Scene/ModelExperimental/ModelFeatureTable", function () {
   it("creates ModelFeatures when model does not have content", function () {
     var table = new ModelFeatureTable({
       propertyTable: mockPropertyTable,
-      model: {},
+      model: {
+        type: ModelExperimentalType.GLTF,
+      },
     });
     expect(table._featuresLength).toEqual(mockPropertyTable.count);
     var modelFeatures = table._features;
@@ -49,6 +52,7 @@ describe("Scene/ModelExperimental/ModelFeatureTable", function () {
         content: {
           tileset: {},
         },
+        type: ModelExperimentalType.TILE_GLTF,
       },
     });
     expect(table._featuresLength).toEqual(mockPropertyTable.count);
@@ -61,7 +65,9 @@ describe("Scene/ModelExperimental/ModelFeatureTable", function () {
 
   it("hasProperty works", function () {
     var table = new ModelFeatureTable({
-      model: {},
+      model: {
+        type: ModelExperimentalType.GLTF,
+      },
       propertyTable: mockPropertyTable,
     });
     var modelFeatures = table._features;
@@ -74,7 +80,9 @@ describe("Scene/ModelExperimental/ModelFeatureTable", function () {
 
   it("getFeature works", function () {
     var table = new ModelFeatureTable({
-      model: {},
+      model: {
+        type: ModelExperimentalType.GLTF,
+      },
       propertyTable: mockPropertyTable,
     });
     expect(table._featuresLength).toEqual(mockPropertyTable.count);
@@ -88,7 +96,9 @@ describe("Scene/ModelExperimental/ModelFeatureTable", function () {
 
   it("getProperty works", function () {
     var table = new ModelFeatureTable({
-      model: {},
+      model: {
+        type: ModelExperimentalType.GLTF,
+      },
       propertyTable: mockPropertyTable,
     });
     expect(table._featuresLength).toEqual(mockPropertyTable.count);
@@ -108,7 +118,9 @@ describe("Scene/ModelExperimental/ModelFeatureTable", function () {
 
   it("getPropertyInherited works", function () {
     var table = new ModelFeatureTable({
-      model: {},
+      model: {
+        type: ModelExperimentalType.GLTF,
+      },
       propertyTable: mockPropertyTable,
     });
     expect(table._featuresLength).toEqual(mockPropertyTable.count);
@@ -137,7 +149,9 @@ describe("Scene/ModelExperimental/ModelFeatureTable", function () {
 
   it("getPropertyNames works", function () {
     var table = new ModelFeatureTable({
-      model: {},
+      model: {
+        type: ModelExperimentalType.GLTF,
+      },
       propertyTable: mockPropertyTable,
     });
     var modelFeatures = table._features;
@@ -155,7 +169,9 @@ describe("Scene/ModelExperimental/ModelFeatureTable", function () {
 
   it("setProperty works", function () {
     var table = new ModelFeatureTable({
-      model: {},
+      model: {
+        type: ModelExperimentalType.GLTF,
+      },
       propertyTable: mockPropertyTable,
     });
     var feature = table._features[0];
@@ -166,7 +182,9 @@ describe("Scene/ModelExperimental/ModelFeatureTable", function () {
 
   it("destroy works", function () {
     var table = new ModelFeatureTable({
-      model: {},
+      model: {
+        type: ModelExperimentalType.GLTF,
+      },
       propertyTable: mockPropertyTable,
     });
     var batchTexture = table._batchTexture;

--- a/Specs/Scene/ModelExperimental/PickingPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/PickingPipelineStageSpec.js
@@ -1,6 +1,7 @@
 import {
   combine,
   GltfLoader,
+  ModelExperimentalType,
   PickingPipelineStage,
   ShaderBuilder,
   Resource,
@@ -73,15 +74,13 @@ describe("Scene/ModelExperimental/PickingPipelineStage", function () {
 
   function verifyPickObject(pickObject, renderResources, instanceId) {
     var model = renderResources.model;
-    var content = model.content;
 
     expect(pickObject).toBeDefined();
-    if (defined(content)) {
-      // 3D Tiles case
+    if (ModelExperimentalType.is3DTiles(model.type)) {
+      var content = model.content;
       expect(pickObject.primitive).toEqual(content.tileset);
       expect(pickObject.content).toEqual(content);
     } else {
-      // ModelExperimental case
       expect(pickObject.primitive).toEqual(model);
     }
 

--- a/Specs/Scene/ModelExperimental/PickingPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/PickingPipelineStageSpec.js
@@ -109,6 +109,7 @@ describe("Scene/ModelExperimental/PickingPipelineStage", function () {
         content: {
           tileset: {},
         },
+        type: ModelExperimentalType.TILE_GLTF,
       },
       runtimePrimitive: {},
       runtimeNode: {
@@ -154,6 +155,7 @@ describe("Scene/ModelExperimental/PickingPipelineStage", function () {
       shaderBuilder: new ShaderBuilder(),
       model: {
         _resources: [],
+        type: ModelExperimentalType.GLTF,
       },
       runtimePrimitive: {
         primitive: {},
@@ -202,6 +204,7 @@ describe("Scene/ModelExperimental/PickingPipelineStage", function () {
       shaderBuilder: new ShaderBuilder(),
       model: {
         _resources: [],
+        type: ModelExperimentalType.GLTF,
       },
       runtimePrimitive: {
         primitive: {},
@@ -276,6 +279,7 @@ describe("Scene/ModelExperimental/PickingPipelineStage", function () {
       uniformMap: {},
       model: {
         featureIdTextureIndex: 0,
+        type: ModelExperimentalType.GLTF,
         _resources: [],
         featureTables: [mockModelFeatureTable],
       },


### PR DESCRIPTION
Added an enum to label models so we know if it's a single glTF or if it's part of a 3D Tileset (and furthermore if it's a .b3dm, .pnts, .gltf, etc.). This will be useful both in #9978 and #9968 

@sanjeetsuhag could you review?