### PR TITLE
Fix classification on 3D Tiles using ModelExperimental

### DIFF
--- a/Source/Scene/ModelExperimental/buildDrawCommands.js
+++ b/Source/Scene/ModelExperimental/buildDrawCommands.js
@@ -7,6 +7,7 @@ import ModelExperimentalVS from "../../Shaders/ModelExperimental/ModelExperiment
 import Pass from "../../Renderer/Pass.js";
 import RenderState from "../../Renderer/RenderState.js";
 import RuntimeError from "../../Core/RuntimeError.js";
+import StencilConstants from "../StencilConstants.js";
 import StyleCommandsNeeded from "./StyleCommandsNeeded.js";
 import VertexArray from "../../Renderer/VertexArray.js";
 
@@ -41,9 +42,16 @@ export default function buildDrawCommands(
   var model = primitiveRenderResources.model;
   model._resources.push(vertexArray);
 
-  var renderState = RenderState.fromCache(
-    primitiveRenderResources.renderStateOptions
-  );
+  var renderState = primitiveRenderResources.renderStateOptions;
+
+  if (model.opaquePass === Pass.CESIUM_3D_TILE) {
+    // Set stencil values for classification on 3D Tiles
+    renderState = clone(renderState, true);
+    renderState.stencilTest = StencilConstants.setCesium3DTileBit();
+    renderState.stencilMask = StencilConstants.CESIUM_3D_TILE_MASK;
+  }
+
+  renderState = RenderState.fromCache(renderState);
 
   var shaderProgram = shaderBuilder.buildShaderProgram(frameState.context);
   model._resources.push(shaderProgram);


### PR DESCRIPTION
While reviewing https://github.com/CesiumGS/cesium/pull/9978 I noticed that classification wasn't working on point clouds when using ModelExperimental, then realized it wasn't working for any 3D Tiles. This sets the correct stencil state so that classification works for any tiles that use ModelExperimental.

Similar code is in [`PointCloud.js`](https://github.com/CesiumGS/cesium/blob/db2669aae149e965a3578fd0343384a33f83543c/Source/Scene/PointCloud.js#L843-L848), [`Cesium3DTileBatchTable`](https://github.com/CesiumGS/cesium/blob/db2669aae149e965a3578fd0343384a33f83543c/Source/Scene/Cesium3DTileBatchTable.js#L1127-L1128) and other places.

Before|After
--|--
![before](https://user-images.githubusercontent.com/915398/148454952-5c48d9c4-8200-42e1-b150-66724bd97314.jpg)|![after](https://user-images.githubusercontent.com/915398/148454954-581376e2-e783-47d7-8e28-e13cffb56c91.jpg)

[Local sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=vVdbb9s2FP4rnJ9kzGUoUTe6SbFcjNVY0hSOt6KYi0CRGJurLBkU5dQr/N93qJttyWmLYu2LZZHnO9fvHFLrQKK14E9cojOU8Cd0yTORL/FfxZox64XF+2WaqEAkXM56A/R5liCkuJSw8lamaxFxOayBoeSB4u9SGUfTUsToD2bJtv9ylsySNZhTIuYZV4f2yge9mpabRmEjl3Gjd5wmE56luQw5fpTp8jwDsXFk2MR33cZCGQrOQp5wvJJiKZRY8wwHUWRUdktHqhcM3kYbCGIpMo7VgifGY56ESqQJMvplpNrnhzRPIpHM71YLLjm4XuMPN14W8qUPYbDkMsD67eJAyNBCqKVyUC7uZeQ1eAbbb4UKF5Mgmdc4hAgmg/r/C4Kd5uVQJZagIM/Qr8ghACmF+vrRP+JnnKYfz9VUBkn2mMqlUXlxEygpPtl4fDV6Mx1P32voXi1XabyZQ67Oam0cMqtElfEifZXIsEwmQgsB5mS42Az3o31bSr2uN5tga34EUsG/IKFF9ScQGnh6DgTbGH/XspAOE1OT2dRlludR0yaWNdjtEuwy3yeu5VDCiH4O2lDKHIf5xCK2ZXpdKDMdz/c803LsI1BqWhZhDqNuB+qBT9SyGbC1a9Smjm9ZNrEdYHMX6ZnMdRzHZWy3+aFf1bNaWULTSRHs+uUyjVOJJ6Mr/CTU4jxeLQIDuFLLh3GQZeJRhIHm+nSz4jtkZwtf3E5fF8DtoFP+GMbC1+qvZRoCrNJMaM3Z8JniXvG55Lxd3Beeg10CVaGU2IS6xGySYQO9bZNYvm95hNl7ZdUghzHXtxzLNmGnBSJQKxNSS3zPbIE0CUyH+pbfgnhQLw/4QR2vBXE9m1EQsKGgLZBvuuC55Wvn2yhKQJvHTM+kByjKfBdoCsZ822qBHBf45Po2Y57fAgG3gS/A7k5INrMoyDNGWAvke4CzfNt1/A7I8RgDYrte25JPocuICR3j+W4bZdk+Ba5bttMKyvOA5ZA7y2LtOoEbJqSCEUrdQxAYh1Y24dEpLnVgvBHoLLqXpALk+L7nQstSpynHh5r/TyJSiyHyO+3Tmkmaube50o+bSgZOixWXamN8rq2Futdanfd+dH19+65xKC11vCvNWu31yyMaLq7PL/+oBLd7fbtcTdPfpR71Q6Rkzo815mF7366KfoMuLbqp8lvxT2qIZr2q3zfoIlULON/LXZDnMQ9BonMglk1czGtcP7vzBJ3tBtmXJ8vLfaU6G7j58z+o3Tb5eT7y6qbys4OfjiaT8/GbHxD/oeZvSQG9QsXd62fn4HJ0N/7z5p5e3U/H16MfkIqjBnYZ+dD0TD0DvtwtEx6hehJ8b65qS2DiK6f11ws4hWcuv8Mp8YiMXf5+qRwZ6fN7g7N8tUqlymql+k44qo7226S+2O/gzW2yuHnv1vv13z3DevgmUfqEgxjG6IESHU6hGpV+NDXJUADX7iRVqPIMAoZ41EJkaBUHSl9ZZ709uw2Rtt9QhFkP4xOxDOY8OynzcH+dztP7sir/rOaz3jO8uQuSKAwyFXN94ZmmafwQyBue5MbRCazdeh7SImD/qIX5POYXuVIppL9XXNfjHHKu9hsYPULG+GCv7uGChx95VFVBl/5wBTUfNJnaxPz5b7M7vd05+WY9OX8IDMtxBmj3owlcF2VbVmSLOHj2A22amHRsFidjb9A7Ley8qvX8JpaaSfor04D6K77UTAIKPOSQGYXDLKtpdHqyDz2NxBqJ6OzIx3F58MLOYx7Hd+JfPuu9Oj0B+Q40TovPu9s1l3Gw0WIL89V1uYgxPj2B1+NIVVKmpfk/) that tests a bunch of different configurations. Also see [3D Tiles Point Cloud Classification](http://localhost:8080/Apps/Sandcastle/index.html?src=3D%20Tiles%20Point%20Cloud%20Classification.html&label=3D%20Tiles).