### PR TITLE
Point Cloud Attenuation in `ModelExperimental`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,16 @@
 
 ### 1.90 - 2022-02-01
 
+##### Additions :tada:
+
+- Added `PntsLoader` to transcode .pnts to `ModelExperimental`. [#9978](https://github.com/CesiumGS/cesium/pull/9978)
+- Added point cloud attenuation support to `ModelExperimental`. [#9998](https://github.com/CesiumGS/cesium/pull/9998)
+
 ##### Fixes :wrench:
 
 - Fixed an error when loading GeoJSON with null `stroke` or `fill` properties but valid opacity values. [#9717](https://github.com/CesiumGS/cesium/pull/9717)
 - Fixed `scene.pickTranslucentDepth` for translucent point clouds with eye dome lighting. [#9991](https://github.com/CesiumGS/cesium/pull/9991)
+- Added a setter for `tileset.pointCloudShading` that throws if set to `undefined` to clarify that this is disallowed. [#9998](https://github.com/CesiumGS/cesium/pull/9998)
 
 ### 1.89 - 2022-01-03
 

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -453,12 +453,7 @@ function Cesium3DTileset(options) {
    */
   this.colorBlendAmount = 0.5;
 
-  /**
-   * Options for controlling point size based on geometric error and eye dome lighting.
-   * @type {PointCloudShading}
-   */
-  this.pointCloudShading = new PointCloudShading(options.pointCloudShading);
-
+  this._pointCloudShading = new PointCloudShading(options.pointCloudShading);
   this._pointCloudEyeDomeLighting = new PointCloudEyeDomeLighting();
 
   /**
@@ -1429,6 +1424,25 @@ Object.defineProperties(Cesium3DTileset.prototype, {
       //>>includeEnd('debug');
 
       this._maximumMemoryUsage = value;
+    },
+  },
+
+  /**
+   * Options for controlling point size based on geometric error and eye dome lighting.
+   *
+   * @memberof ModelExperimental.prototype
+   *
+   * @type {PointCloudShading}
+   */
+  pointCloudShading: {
+    get: function () {
+      return this._pointCloudShading;
+    },
+    set: function (value) {
+      //>>includeStart('debug', pragmas.debug);
+      Check.defined("pointCloudShading", value);
+      //>>includeEnd('debug');
+      this._pointCloudShading = value;
     },
   },
 

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1430,7 +1430,7 @@ Object.defineProperties(Cesium3DTileset.prototype, {
   /**
    * Options for controlling point size based on geometric error and eye dome lighting.
    *
-   * @memberof ModelExperimental.prototype
+   * @memberof Cesium3DTileset.prototype
    *
    * @type {PointCloudShading}
    */

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -298,6 +298,15 @@ Object.defineProperties(ModelExperimental.prototype, {
     },
   },
 
+  /**
+   * Point cloud shading settings for controlling point cloud attenuation
+   * and lighting. For 3D Tiles, this is inherited from the
+   * {@link Cesium3DTileset}.
+   *
+   * @memberof ModelExperimental.prototype
+   *
+   * @type {PointCloudShading}
+   */
   pointCloudShading: {
     get: function () {
       return this._pointCloudShading;
@@ -793,7 +802,7 @@ ModelExperimental.prototype.destroyResources = function () {
  * @param {Number} [options.colorBlendAmount=0.5] Value used to determine the color strength when the <code>colorBlendMode</code> is <code>MIX</code>. A value of 0.0 results in the model's rendered color while a value of 1.0 results in a solid color, with any value in-between resulting in a mix of the two.
  * @param {Number} [options.featureIdAttributeIndex=0] The index of the feature ID attribute to use for picking features per-instance or per-primitive.
  * @param {Number} [options.featureIdTextureIndex=0] The index of the feature ID texture to use for picking features per-primitive.
- * @param {Object} [options.pointCloudShading] Options for constructing a {@link PointCloudShading} object to control point attenuation based on geometric error and lighting.
+ * @param {Object} [options.pointCloudShading] Options for constructing a {@link PointCloudShading} object to control point attenuation and lighting.
  *
  * @returns {ModelExperimental} The newly created model.
  */

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -1,4 +1,5 @@
 import Check from "../../Core/Check.js";
+import Color from "../../Core/Color.js";
 import ColorBlendMode from "../ColorBlendMode.js";
 import defined from "../../Core/defined.js";
 import defaultValue from "../../Core/defaultValue.js";
@@ -13,9 +14,9 @@ import when from "../../ThirdParty/when.js";
 import destroyObject from "../../Core/destroyObject.js";
 import Matrix4 from "../../Core/Matrix4.js";
 import ModelFeatureTable from "./ModelFeatureTable.js";
+import PointCloudShading from "../PointCloudShading.js";
 import B3dmLoader from "./B3dmLoader.js";
 import PntsLoader from "./PntsLoader.js";
-import Color from "../../Core/Color.js";
 
 /**
  * A 3D model. This is a new architecture that is more decoupled than the older {@link Model}. This class is still experimental.
@@ -42,6 +43,7 @@ import Color from "../../Core/Color.js";
  * @param {Number} [options.colorBlendAmount=0.5] Value used to determine the color strength when the <code>colorBlendMode</code> is <code>MIX</code>. A value of 0.0 results in the model's rendered color while a value of 1.0 results in a solid color, with any value in-between resulting in a mix of the two.
  * @param {Number} [options.featureIdAttributeIndex=0] The index of the feature ID attribute to use for picking features per-instance or per-primitive.
  * @param {Number} [options.featureIdTextureIndex=0] The index of the feature ID texture to use for picking features per-primitive.
+ * @param {Object} [options.pointCloudShading] Options for constructing a {@link PointCloudShading} object to control point attenuation based on geometric error and lighting.
  *
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
@@ -114,6 +116,10 @@ export default function ModelExperimental(options) {
   this._resources = [];
 
   this._boundingSphere = undefined;
+
+  var pointCloudShading = new PointCloudShading(options.pointCloudShading);
+  this._attenuation = pointCloudShading.attenuation;
+  this._pointCloudShading = pointCloudShading;
 
   this._debugShowBoundingVolumeDirty = false;
   this._debugShowBoundingVolume = defaultValue(
@@ -289,6 +295,21 @@ Object.defineProperties(ModelExperimental.prototype, {
   opaquePass: {
     get: function () {
       return this._opaquePass;
+    },
+  },
+
+  pointCloudShading: {
+    get: function () {
+      return this._pointCloudShading;
+    },
+    set: function (value) {
+      //>>includeStart('debug', pragmas.debug);
+      Check.defined("pointCloudShading", value);
+      //>>includeEnd('debug');
+      if (value !== this._pointCloudShading) {
+        this.resetDrawCommands();
+      }
+      this._pointCloudShading = value;
     },
   },
 
@@ -619,6 +640,13 @@ ModelExperimental.prototype.update = function (frameState) {
   // A custom shader may have to load texture uniforms.
   if (defined(this._customShader)) {
     this._customShader.update(frameState);
+  }
+
+  // Check if the shader needs to be updated for point cloud attenuation
+  // settings.
+  if (this.pointCloudShading.attenuation !== this._attenuation) {
+    this.resetDrawCommands();
+    this._attenuation = this.pointCloudShading.attenuation;
   }
 
   // short-circuit if the model resources aren't ready.

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -793,6 +793,7 @@ ModelExperimental.prototype.destroyResources = function () {
  * @param {Number} [options.colorBlendAmount=0.5] Value used to determine the color strength when the <code>colorBlendMode</code> is <code>MIX</code>. A value of 0.0 results in the model's rendered color while a value of 1.0 results in a solid color, with any value in-between resulting in a mix of the two.
  * @param {Number} [options.featureIdAttributeIndex=0] The index of the feature ID attribute to use for picking features per-instance or per-primitive.
  * @param {Number} [options.featureIdTextureIndex=0] The index of the feature ID texture to use for picking features per-primitive.
+ * @param {Object} [options.pointCloudShading] Options for constructing a {@link PointCloudShading} object to control point attenuation based on geometric error and lighting.
  *
  * @returns {ModelExperimental} The newly created model.
  */
@@ -850,6 +851,7 @@ ModelExperimental.fromGltf = function (options) {
     colorBlendMode: options.colorBlendMode,
     featureIdAttributeIndex: options.featureIdAttributeIndex,
     featureIdTextureIndex: options.featureIdTextureIndex,
+    pointCloudShading: options.pointCloudShading,
   };
   var model = new ModelExperimental(modelOptions);
 

--- a/Source/Scene/ModelExperimental/ModelExperimental3DTileContent.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental3DTileContent.js
@@ -1,10 +1,7 @@
 import Axis from "../Axis.js";
 import defined from "../../Core/defined.js";
-import defaultValue from "../../Core/defaultValue.js";
 import destroyObject from "../../Core/destroyObject.js";
 import Pass from "../../Renderer/Pass.js";
-import Cesium3DTileRefine from "../Cesium3DTileRefine.js";
-import PointCloudShading from "../PointCloudShading.js";
 import ModelExperimental from "./ModelExperimental.js";
 
 /**
@@ -166,8 +163,6 @@ ModelExperimental3DTileContent.prototype.applyStyle = function (style) {
   this._model.applyStyle(style);
 };
 
-var defaultShading = new PointCloudShading();
-
 ModelExperimental3DTileContent.prototype.update = function (
   tileset,
   frameState
@@ -179,20 +174,7 @@ ModelExperimental3DTileContent.prototype.update = function (
   model.colorBlendMode = tileset.colorBlendMode;
   model.modelMatrix = tile.computedTransform;
   model.customShader = tileset.customShader;
-
-  var pointCloudShading = defaultValue(
-    tileset.pointCloudShading,
-    defaultShading
-  );
-
-  model.pointCloudShading = pointCloudShading;
-
-  if (!defined(pointCloudShading.maximumAttenuation)) {
-    pointCloudShading.maximumAttenuation =
-      tile.refine === Cesium3DTileRefine.ADD
-        ? 5.0
-        : tileset.maximumScreenSpaceError;
-  }
+  model.pointCloudShading = tileset.pointCloudShading;
 
   model.update(frameState);
 };

--- a/Source/Scene/ModelExperimental/ModelExperimental3DTileContent.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental3DTileContent.js
@@ -1,8 +1,11 @@
 import Axis from "../Axis.js";
 import defined from "../../Core/defined.js";
+import defaultValue from "../../Core/defaultValue.js";
 import destroyObject from "../../Core/destroyObject.js";
-import ModelExperimental from "./ModelExperimental.js";
 import Pass from "../../Renderer/Pass.js";
+import Cesium3DTileRefine from "../Cesium3DTileRefine.js";
+import PointCloudShading from "../PointCloudShading.js";
+import ModelExperimental from "./ModelExperimental.js";
 
 /**
  * Represents the contents of a glTF, glb or
@@ -163,6 +166,8 @@ ModelExperimental3DTileContent.prototype.applyStyle = function (style) {
   this._model.applyStyle(style);
 };
 
+var defaultShading = new PointCloudShading();
+
 ModelExperimental3DTileContent.prototype.update = function (
   tileset,
   frameState
@@ -174,7 +179,20 @@ ModelExperimental3DTileContent.prototype.update = function (
   model.colorBlendMode = tileset.colorBlendMode;
   model.modelMatrix = tile.computedTransform;
   model.customShader = tileset.customShader;
-  model.pointCloudShading = tileset.pointCloudShading;
+
+  var pointCloudShading = defaultValue(
+    tileset.pointCloudShading,
+    defaultShading
+  );
+
+  model.pointCloudShading = pointCloudShading;
+
+  if (!defined(pointCloudShading.maximumAttenuation)) {
+    pointCloudShading.maximumAttenuation =
+      tile.refine === Cesium3DTileRefine.ADD
+        ? 5.0
+        : tileset.maximumScreenSpaceError;
+  }
 
   model.update(frameState);
 };

--- a/Source/Scene/ModelExperimental/ModelExperimental3DTileContent.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental3DTileContent.js
@@ -174,6 +174,7 @@ ModelExperimental3DTileContent.prototype.update = function (
   model.colorBlendMode = tileset.colorBlendMode;
   model.modelMatrix = tile.computedTransform;
   model.customShader = tileset.customShader;
+  model.pointCloudShading = tileset.pointCloudShading;
 
   model.update(frameState);
 };

--- a/Source/Scene/ModelExperimental/ModelExperimentalNode.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalNode.js
@@ -72,7 +72,7 @@ export default function ModelExperimentalNode(options) {
    */
   this.updateStages = [];
 
-  initialize(this);
+  this.configurePipeline();
 }
 
 Object.defineProperties(ModelExperimentalNode.prototype, {
@@ -191,19 +191,26 @@ ModelExperimentalNode.prototype.getChild = function (index) {
   return this.sceneGraph.runtimeNodes[this.children[index]];
 };
 
-function initialize(runtimeNode) {
-  var node = runtimeNode.node;
-  var pipelineStages = runtimeNode.pipelineStages;
-  var updateStages = runtimeNode.updateStages;
+/**
+ * Configure the node pipeline stages. If the pipeline needs to be re-run, call
+ * this method again to ensure the correct sequence of pipeline stages are
+ * used.
+ *
+ * @private
+ */
+ModelExperimentalNode.prototype.configurePipeline = function () {
+  var node = this.node;
+  var pipelineStages = this.pipelineStages;
+  pipelineStages.length = 0;
+  var updateStages = this.updateStages;
+  updateStages.length = 0;
 
   if (defined(node.instances)) {
     pipelineStages.push(InstancingPipelineStage);
   }
 
   updateStages.push(ModelMatrixUpdateStage);
-
-  return;
-}
+};
 
 /**
  * @private

--- a/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
@@ -12,6 +12,7 @@ import LightingPipelineStage from "./LightingPipelineStage.js";
 import MaterialPipelineStage from "./MaterialPipelineStage.js";
 import ModelExperimentalUtility from "./ModelExperimentalUtility.js";
 import PickingPipelineStage from "./PickingPipelineStage.js";
+import PointCloudAttenuationPipelineStage from "./PointCloudAttenuationPipelineStage.js";
 import VertexAttributeSemantic from "../VertexAttributeSemantic.js";
 
 /**
@@ -94,8 +95,14 @@ function initialize(runtimePrimitive) {
   var hasQuantization = ModelExperimentalUtility.hasQuantizedAttributes(
     primitive.attributes
   );
+  var is3DTiles = defined(model.content);
+  var hasPointCloudShading = is3DTiles || defined(model.pointCloudShading);
 
   pipelineStages.push(GeometryPipelineStage);
+
+  if (hasPointCloudShading) {
+    pipelineStages.push(PointCloudAttenuationPipelineStage);
+  }
 
   if (hasQuantization) {
     pipelineStages.push(DequantizationPipelineStage);

--- a/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
@@ -4,12 +4,14 @@ import Check from "../../Core/Check.js";
 import CustomShaderMode from "./CustomShaderMode.js";
 import defaultValue from "../../Core/defaultValue.js";
 import defined from "../../Core/defined.js";
+import PrimitiveType from "../../Core/PrimitiveType.js";
 import FeatureIdPipelineStage from "./FeatureIdPipelineStage.js";
 import CPUStylingPipelineStage from "./CPUStylingPipelineStage.js";
 import DequantizationPipelineStage from "./DequantizationPipelineStage.js";
 import GeometryPipelineStage from "./GeometryPipelineStage.js";
 import LightingPipelineStage from "./LightingPipelineStage.js";
 import MaterialPipelineStage from "./MaterialPipelineStage.js";
+import ModelExperimentalType from "./ModelExperimentalType.js";
 import ModelExperimentalUtility from "./ModelExperimentalUtility.js";
 import PickingPipelineStage from "./PickingPipelineStage.js";
 import PointCloudAttenuationPipelineStage from "./PointCloudAttenuationPipelineStage.js";
@@ -118,12 +120,15 @@ function initialize(runtimePrimitive) {
   var hasQuantization = ModelExperimentalUtility.hasQuantizedAttributes(
     primitive.attributes
   );
-  var is3DTiles = defined(model.content);
+  var is3DTiles = ModelExperimentalType.is3DTiles(model.type);
   var hasPointCloudShading = is3DTiles || defined(model.pointCloudShading);
 
   pipelineStages.push(GeometryPipelineStage);
 
-  if (hasPointCloudShading) {
+  if (
+    hasPointCloudShading &&
+    primitive.primitiveType === PrimitiveType.POINTS
+  ) {
     pipelineStages.push(PointCloudAttenuationPipelineStage);
   }
 

--- a/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
@@ -129,15 +129,19 @@ ModelExperimentalPrimitive.prototype.configurePipeline = function () {
   var hasQuantization = ModelExperimentalUtility.hasQuantizedAttributes(
     primitive.attributes
   );
-  var is3DTiles = ModelExperimentalType.is3DTiles(model.type);
-  var hasPointCloudShading = is3DTiles || defined(model.pointCloudShading);
+
+  var pointCloudShading;
+  if (ModelExperimentalType.is3DTiles(model.type)) {
+    pointCloudShading = model.content.tileset.pointCloudShading;
+  } else {
+    pointCloudShading = model.pointCloudShading;
+  }
+  var hasAttenuation =
+    defined(pointCloudShading) && pointCloudShading.attenuation;
 
   pipelineStages.push(GeometryPipelineStage);
 
-  if (
-    hasPointCloudShading &&
-    primitive.primitiveType === PrimitiveType.POINTS
-  ) {
+  if (hasAttenuation && primitive.primitiveType === PrimitiveType.POINTS) {
     pipelineStages.push(PointCloudAttenuationPipelineStage);
   }
 

--- a/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
@@ -1,10 +1,11 @@
-import AlphaPipelineStage from "./AlphaPipelineStage.js";
-import BatchTexturePipelineStage from "./BatchTexturePipelineStage.js";
 import Check from "../../Core/Check.js";
-import CustomShaderMode from "./CustomShaderMode.js";
 import defaultValue from "../../Core/defaultValue.js";
 import defined from "../../Core/defined.js";
 import PrimitiveType from "../../Core/PrimitiveType.js";
+import AlphaPipelineStage from "./AlphaPipelineStage.js";
+import BatchTexturePipelineStage from "./BatchTexturePipelineStage.js";
+import CustomShaderMode from "./CustomShaderMode.js";
+import CustomShaderPipelineStage from "./CustomShaderPipelineStage.js";
 import FeatureIdPipelineStage from "./FeatureIdPipelineStage.js";
 import CPUStylingPipelineStage from "./CPUStylingPipelineStage.js";
 import DequantizationPipelineStage from "./DequantizationPipelineStage.js";
@@ -100,15 +101,23 @@ export default function ModelExperimentalPrimitive(options) {
    */
   this.updateStages = [];
 
-  initialize(this);
+  this.configurePipeline();
 }
 
-function initialize(runtimePrimitive) {
-  var pipelineStages = runtimePrimitive.pipelineStages;
+/**
+ * Configure the primitive pipeline stages. If the pipeline needs to be re-run, call
+ * this method again to ensure the correct sequence of pipeline stages are
+ * used.
+ *
+ * @private
+ */
+ModelExperimentalPrimitive.prototype.configurePipeline = function () {
+  var pipelineStages = this.pipelineStages;
+  pipelineStages.length = 0;
 
-  var primitive = runtimePrimitive.primitive;
-  var node = runtimePrimitive.node;
-  var model = runtimePrimitive.model;
+  var primitive = this.primitive;
+  var node = this.node;
+  var model = this.model;
   var customShader = model.customShader;
 
   var hasCustomShader = defined(customShader);
@@ -138,6 +147,10 @@ function initialize(runtimePrimitive) {
 
   if (materialsEnabled) {
     pipelineStages.push(MaterialPipelineStage);
+  }
+
+  if (defined(model.customShader)) {
+    pipelineStages.push(CustomShaderPipelineStage);
   }
 
   pipelineStages.push(LightingPipelineStage);
@@ -186,4 +199,4 @@ function initialize(runtimePrimitive) {
   pipelineStages.push(AlphaPipelineStage);
 
   return;
-}
+};

--- a/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
@@ -12,7 +12,6 @@ import DequantizationPipelineStage from "./DequantizationPipelineStage.js";
 import GeometryPipelineStage from "./GeometryPipelineStage.js";
 import LightingPipelineStage from "./LightingPipelineStage.js";
 import MaterialPipelineStage from "./MaterialPipelineStage.js";
-import ModelExperimentalType from "./ModelExperimentalType.js";
 import ModelExperimentalUtility from "./ModelExperimentalUtility.js";
 import PickingPipelineStage from "./PickingPipelineStage.js";
 import PointCloudAttenuationPipelineStage from "./PointCloudAttenuationPipelineStage.js";
@@ -130,12 +129,7 @@ ModelExperimentalPrimitive.prototype.configurePipeline = function () {
     primitive.attributes
   );
 
-  var pointCloudShading;
-  if (ModelExperimentalType.is3DTiles(model.type)) {
-    pointCloudShading = model.content.tileset.pointCloudShading;
-  } else {
-    pointCloudShading = model.pointCloudShading;
-  }
+  var pointCloudShading = model.pointCloudShading;
   var hasAttenuation =
     defined(pointCloudShading) && pointCloudShading.attenuation;
 

--- a/Source/Scene/ModelExperimental/PntsLoader.js
+++ b/Source/Scene/ModelExperimental/PntsLoader.js
@@ -442,6 +442,7 @@ function makeAttributes(loader, parsedContent, context) {
   if (defined(positions)) {
     computeApproximateExtrema(positions);
     attribute = makeAttribute(loader, positions, context);
+    attribute.count = parsedContent.pointsLength;
     attributes.push(attribute);
   }
 

--- a/Source/Scene/ModelExperimental/PointCloudAttenuationPipelineStage.js
+++ b/Source/Scene/ModelExperimental/PointCloudAttenuationPipelineStage.js
@@ -128,9 +128,8 @@ function getGeometricError(
 
   // Estimate the geometric error
   var nodeTransform = renderResources.runtimeNode.transform;
-  var dimensions = Cartesian3.clone(positionAttribute.max, scratchDimensions);
-  dimensions = Cartesian3.subtract(
-    dimensions,
+  var dimensions = Cartesian3.subtract(
+    positionAttribute.max,
     positionAttribute.min,
     scratchDimensions
   );

--- a/Source/Scene/ModelExperimental/PointCloudAttenuationPipelineStage.js
+++ b/Source/Scene/ModelExperimental/PointCloudAttenuationPipelineStage.js
@@ -79,3 +79,5 @@ PointCloudAttenuationPipelineStage.process = function (
     return scratch;
   };
 };
+
+export default PointCloudAttenuationPipelineStage;

--- a/Source/Scene/ModelExperimental/PointCloudAttenuationPipelineStage.js
+++ b/Source/Scene/ModelExperimental/PointCloudAttenuationPipelineStage.js
@@ -69,30 +69,27 @@ PointCloudAttenuationPipelineStage.process = function (
       : 1.0;
     scratch.x *= frameState.pixelRatio;
 
-    if (pointCloudShading.attenuation) {
-      var context = frameState.context;
-      var frustum = frameState.camera.frustum;
-      var depthMultiplier;
+    var context = frameState.context;
+    var frustum = frameState.camera.frustum;
+    var depthMultiplier;
 
-      // Attenuation is maximumAttenuation in 2D/ortho
-      if (
-        frameState.mode === SceneMode.SCENE2D ||
-        frustum instanceof OrthographicFrustum
-      ) {
-        depthMultiplier = Number.POSITIVE_INFINITY;
-      } else {
-        depthMultiplier =
-          context.drawingBufferHeight /
-          frameState.camera.frustum.sseDenominator;
-      }
-
-      // attenuation.y = geometricError
-      var geometricError = getGeometricError(pointCloudShading, content);
-      scratch.y = geometricError * pointCloudShading.geometricErrorScale;
-
-      // attenuation.z = depth multiplier
-      scratch.z = depthMultiplier;
+    // Attenuation is maximumAttenuation in 2D/ortho
+    if (
+      frameState.mode === SceneMode.SCENE2D ||
+      frustum instanceof OrthographicFrustum
+    ) {
+      depthMultiplier = Number.POSITIVE_INFINITY;
+    } else {
+      depthMultiplier =
+        context.drawingBufferHeight / frameState.camera.frustum.sseDenominator;
     }
+
+    // attenuation.y = geometricError
+    var geometricError = getGeometricError(pointCloudShading, content);
+    scratch.y = geometricError * pointCloudShading.geometricErrorScale;
+
+    // attenuation.z = depth multiplier
+    scratch.z = depthMultiplier;
 
     return scratch;
   };
@@ -107,7 +104,7 @@ function getGeometricError(pointCloudShading, content) {
     }
   }
 
-  if (defined(pointCloudShading) && defined(pointCloudShading.baseResolution)) {
+  if (defined(pointCloudShading.baseResolution)) {
     return pointCloudShading.baseResolution;
   }
 

--- a/Source/Scene/ModelExperimental/PointCloudAttenuationPipelineStage.js
+++ b/Source/Scene/ModelExperimental/PointCloudAttenuationPipelineStage.js
@@ -50,14 +50,12 @@ PointCloudAttenuationPipelineStage.process = function (
     ShaderDestination.VERTEX
   );
 
-  var pointCloudShading;
-  var content;
   var model = renderResources.model;
+  var pointCloudShading = model.pointCloudShading;
+
+  var content;
   if (ModelExperimentalType.is3DTiles(model.type)) {
     content = model.content;
-    pointCloudShading = content.tileset.pointCloudShading;
-  } else {
-    pointCloudShading = model.pointCloudShading;
   }
 
   shaderBuilder.addUniform(
@@ -136,7 +134,7 @@ function getGeometricError(
     positionAttribute.min,
     scratchDimensions
   );
-  // dimensions is a vector, as (point - point) = displacement vector
+  // dimensions is a vector, as it is a subtraction between two points
   dimensions = Matrix4.multiplyByPointAsVector(
     nodeTransform,
     dimensions,

--- a/Source/Scene/ModelExperimental/PointCloudAttenuationPipelineStage.js
+++ b/Source/Scene/ModelExperimental/PointCloudAttenuationPipelineStage.js
@@ -1,0 +1,66 @@
+import Cartesian3 from "../../Core/Cartesian3.js";
+import OrthographicFrustum from "../../Core/OrthographicFrustum.js";
+import ShaderDestination from "../../Renderer/ShaderDestination.js";
+import PointCloudAttenuationStageVS from "../../Shaders/ModelExperimental/PointCloudAttenuationStageVS.js";
+import SceneMode from "../SceneMode.js";
+
+var PointCloudAttenuationPipelineStage = {};
+PointCloudAttenuationPipelineStage.name = "PointCloudAttenuationPipelineStage"; // Helps with debugging
+
+var scratchAttenuationUniform = new Cartesian3();
+
+PointCloudAttenuationPipelineStage.process = function (
+  renderResources,
+  primitive,
+  frameState
+) {
+  var shaderBuilder = renderResources.shaderBuilder;
+  shaderBuilder.addVertexLines([PointCloudAttenuationStageVS]);
+  shaderBuilder.addDefine(
+    "USE_POINT_CLOUD_ATTENUATION",
+    undefined,
+    ShaderDestination.VERTEX
+  );
+
+  // TODO: what if it comes from the tileset?
+  var pointCloudShading = renderResources.model.pointCloudShading;
+
+  shaderBuilder.addUniform(
+    "vec3",
+    "model_pointCloudAttenuation",
+    ShaderDestination.VERTEX
+  );
+  renderResources.uniformMap.model_pointCloudAttenuation = function () {
+    var scratch = scratchAttenuationUniform;
+
+    scratch.x = pointCloudShading.attenuation
+      ? pointCloudShading.maximumAttenuation
+      : 1.0;
+    scratch.x *= frameState.pixelRatio;
+
+    if (pointCloudShading.attenuation) {
+      var context;
+      var frustum = frameState.camera.frustum;
+      var depthMultiplier;
+      // Attenuation is maximumAttenuation in 2D/ortho
+      if (
+        frameState.mode === SceneMode.SCENE2D ||
+        frustum instanceof OrthographicFrustum
+      ) {
+        depthMultiplier = Number.POSITIVE_INFINITY;
+      } else {
+        depthMultiplier =
+          context.drawingBufferHeight /
+          frameState.camera.frustum.sseDenominator;
+      }
+
+      // TODO: where to get the gE from? especially when not a part of a
+      // tileset?
+      var geometricError = 0;
+      scratch.y = geometricError * pointCloudShading.geometricErrorScale;
+      scratch.z = depthMultiplier;
+    }
+
+    return scratch;
+  };
+};

--- a/Source/Scene/ModelExperimental/PointCloudAttenuationPipelineStage.js
+++ b/Source/Scene/ModelExperimental/PointCloudAttenuationPipelineStage.js
@@ -9,7 +9,9 @@ import SceneMode from "../SceneMode.js";
 import ModelExperimentalType from "./ModelExperimentalType.js";
 
 /**
- * Stage to handle point cloud attenuation.
+ * Stage to handle point cloud attenuation. This stage assumes that either
+ * tileset.pointCloudShading.attenuation (3D Tiles) or
+ * model.pointCloudShading.attenuation (individual model) is true
  *
  * @namespace PointCloudAttenuationPipelineStage
  *
@@ -45,9 +47,9 @@ PointCloudAttenuationPipelineStage.process = function (
     ShaderDestination.VERTEX
   );
 
-  var model = renderResources.model;
   var pointCloudShading;
   var content;
+  var model = renderResources.model;
   if (ModelExperimentalType.is3DTiles(model.type)) {
     content = model.content;
     pointCloudShading = content.tileset.pointCloudShading;
@@ -64,9 +66,7 @@ PointCloudAttenuationPipelineStage.process = function (
     var scratch = scratchAttenuationUniform;
 
     // attenuation.x = pointSize
-    scratch.x = pointCloudShading.attenuation
-      ? defaultValue(pointCloudShading.maximumAttenuation, 1.0)
-      : 1.0;
+    scratch.x = defaultValue(pointCloudShading.maximumAttenuation, 1.0);
     scratch.x *= frameState.pixelRatio;
 
     var context = frameState.context;

--- a/Source/Scene/ModelExperimental/PointCloudAttenuationPipelineStage.js
+++ b/Source/Scene/ModelExperimental/PointCloudAttenuationPipelineStage.js
@@ -8,11 +8,30 @@ import PointCloudAttenuationStageVS from "../../Shaders/ModelExperimental/PointC
 import SceneMode from "../SceneMode.js";
 import ModelExperimentalType from "./ModelExperimentalType.js";
 
+/**
+ * Stage to handle point cloud attenuation.
+ *
+ * @namespace PointCloudAttenuationPipelineStage
+ *
+ * @private
+ */
 var PointCloudAttenuationPipelineStage = {};
 PointCloudAttenuationPipelineStage.name = "PointCloudAttenuationPipelineStage"; // Helps with debugging
 
 var scratchAttenuationUniform = new Cartesian3();
 
+/**
+ * This stage does the following:
+ * <ul>
+ *  <li>Add vertex shader code to compute attenuation and update gl_PointSize</li>
+ *  <li>Updates the uniform map to pass in the point cloud attenuation parameters</li>
+ * </ul>
+ * @param {PrimitiveRenderResources} renderResources The render resources for this primitive
+ * @param {ModelComponents.primitive} primitive The primitive
+ * @param {FrameState} frameState The frame state
+ *
+ * @private
+ */
 PointCloudAttenuationPipelineStage.process = function (
   renderResources,
   primitive,
@@ -81,7 +100,6 @@ PointCloudAttenuationPipelineStage.process = function (
 };
 
 function getGeometricError(pointCloudShading, content) {
-  // 1. get tile's geometric error (if content is defined)
   if (defined(content)) {
     var geometricError = content._tile.geometricError;
 

--- a/Source/Scene/ModelExperimental/PointCloudAttenuationPipelineStage.js
+++ b/Source/Scene/ModelExperimental/PointCloudAttenuationPipelineStage.js
@@ -2,7 +2,7 @@ import Cartesian3 from "../../Core/Cartesian3.js";
 import defaultValue from "../../Core/defaultValue.js";
 import defined from "../../Core/defined.js";
 import OrthographicFrustum from "../../Core/OrthographicFrustum.js";
-import PrimitiveType from "../../Core/PrimitiveType.js";
+
 import ShaderDestination from "../../Renderer/ShaderDestination.js";
 import PointCloudAttenuationStageVS from "../../Shaders/ModelExperimental/PointCloudAttenuationStageVS.js";
 import SceneMode from "../SceneMode.js";
@@ -37,11 +37,6 @@ PointCloudAttenuationPipelineStage.process = function (
   primitive,
   frameState
 ) {
-  // Attenuation only applies to point primitives
-  if (primitive.primitiveType !== PrimitiveType.POINTS) {
-    return;
-  }
-
   var shaderBuilder = renderResources.shaderBuilder;
   shaderBuilder.addVertexLines([PointCloudAttenuationStageVS]);
   shaderBuilder.addDefine(
@@ -53,8 +48,7 @@ PointCloudAttenuationPipelineStage.process = function (
   var model = renderResources.model;
   var pointCloudShading;
   var content;
-  var modelType = model.type;
-  if (ModelExperimentalType.is3DTiles(modelType)) {
+  if (ModelExperimentalType.is3DTiles(model.type)) {
     content = model.content;
     pointCloudShading = content.tileset.pointCloudShading;
   } else {
@@ -69,6 +63,7 @@ PointCloudAttenuationPipelineStage.process = function (
   renderResources.uniformMap.model_pointCloudAttenuation = function () {
     var scratch = scratchAttenuationUniform;
 
+    // attenuation.x = pointSize
     scratch.x = pointCloudShading.attenuation
       ? defaultValue(pointCloudShading.maximumAttenuation, 1.0)
       : 1.0;
@@ -78,6 +73,7 @@ PointCloudAttenuationPipelineStage.process = function (
       var context = frameState.context;
       var frustum = frameState.camera.frustum;
       var depthMultiplier;
+
       // Attenuation is maximumAttenuation in 2D/ortho
       if (
         frameState.mode === SceneMode.SCENE2D ||
@@ -90,8 +86,11 @@ PointCloudAttenuationPipelineStage.process = function (
           frameState.camera.frustum.sseDenominator;
       }
 
+      // attenuation.y = geometricError
       var geometricError = getGeometricError(pointCloudShading, content);
       scratch.y = geometricError * pointCloudShading.geometricErrorScale;
+
+      // attenuation.z = depth multiplier
       scratch.z = depthMultiplier;
     }
 

--- a/Source/Scene/ModelExperimental/PointCloudAttenuationPipelineStage.js
+++ b/Source/Scene/ModelExperimental/PointCloudAttenuationPipelineStage.js
@@ -69,6 +69,10 @@ PointCloudAttenuationPipelineStage.process = function (
     scratch.x = defaultValue(pointCloudShading.maximumAttenuation, 1.0);
     scratch.x *= frameState.pixelRatio;
 
+    // attenuation.y = geometricError
+    var geometricError = getGeometricError(pointCloudShading, content);
+    scratch.y = geometricError * pointCloudShading.geometricErrorScale;
+
     var context = frameState.context;
     var frustum = frameState.camera.frustum;
     var depthMultiplier;
@@ -84,10 +88,6 @@ PointCloudAttenuationPipelineStage.process = function (
         context.drawingBufferHeight / frameState.camera.frustum.sseDenominator;
     }
 
-    // attenuation.y = geometricError
-    var geometricError = getGeometricError(pointCloudShading, content);
-    scratch.y = geometricError * pointCloudShading.geometricErrorScale;
-
     // attenuation.z = depth multiplier
     scratch.z = depthMultiplier;
 
@@ -97,7 +97,7 @@ PointCloudAttenuationPipelineStage.process = function (
 
 function getGeometricError(pointCloudShading, content) {
   if (defined(content)) {
-    var geometricError = content._tile.geometricError;
+    var geometricError = content.tile.geometricError;
 
     if (geometricError > 0) {
       return geometricError;

--- a/Source/Scene/ModelExperimental/PointCloudAttenuationPipelineStage.js
+++ b/Source/Scene/ModelExperimental/PointCloudAttenuationPipelineStage.js
@@ -1,5 +1,7 @@
 import Cartesian3 from "../../Core/Cartesian3.js";
+import defined from "../../Core/defined.js";
 import OrthographicFrustum from "../../Core/OrthographicFrustum.js";
+import PrimitiveType from "../../Core/PrimitiveType.js";
 import ShaderDestination from "../../Renderer/ShaderDestination.js";
 import PointCloudAttenuationStageVS from "../../Shaders/ModelExperimental/PointCloudAttenuationStageVS.js";
 import SceneMode from "../SceneMode.js";
@@ -14,6 +16,11 @@ PointCloudAttenuationPipelineStage.process = function (
   primitive,
   frameState
 ) {
+  // Attenuation only applies to point primitives
+  if (primitive.primitiveType !== PrimitiveType.POINTS) {
+    return;
+  }
+
   var shaderBuilder = renderResources.shaderBuilder;
   shaderBuilder.addVertexLines([PointCloudAttenuationStageVS]);
   shaderBuilder.addDefine(
@@ -22,8 +29,16 @@ PointCloudAttenuationPipelineStage.process = function (
     ShaderDestination.VERTEX
   );
 
-  // TODO: what if it comes from the tileset?
-  var pointCloudShading = renderResources.model.pointCloudShading;
+  var model = renderResources.model;
+  var pointCloudShading;
+
+  // If this is 3D Tiles, use the point cloud shading object
+  if (defined(model.content)) {
+    var tileset = model.content.tileset;
+    pointCloudShading = tileset.pointCloudShading;
+  } else {
+    pointCloudShading = model.pointCloudShading;
+  }
 
   shaderBuilder.addUniform(
     "vec3",

--- a/Source/Shaders/ModelExperimental/ModelExperimentalVS.glsl
+++ b/Source/Shaders/ModelExperimental/ModelExperimentalVS.glsl
@@ -47,6 +47,8 @@ void main()
     #ifdef PRIMITIVE_TYPE_POINTS
         #ifdef HAS_CUSTOM_VERTEX_SHADER
         gl_PointSize = vsOutput.pointSize;
+        #elif defined(USE_POINT_CLOUD_ATTENUATION)
+        gl_PointSize = pointCloudAttenuationStage(v_positionEC);
         #else
         gl_PointSize = 1.0;
         #endif

--- a/Source/Shaders/ModelExperimental/PointCloudAttenuationStageVS.glsl
+++ b/Source/Shaders/ModelExperimental/PointCloudAttenuationStageVS.glsl
@@ -1,0 +1,8 @@
+float pointCloudAttenuationStage(vec3 positionEC) {
+  // Variables are packed into a single vector to minimize gl.uniformXXX() calls
+  float pointSize = model_pointCloudAttenuation.x;
+  float geometricError = model_pointCloudAttenuation.y;
+  float depthMultiplier = model_pointCloudAttenuation.z;
+  float depth = -positionEC.z;
+  return min((geometricError / depth) * depthMultiplier, pointSize);
+}

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -4351,6 +4351,16 @@ describe(
       );
     });
 
+    it("throws if pointCloudShading is set to undefined", function () {
+      return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function (
+        tileset
+      ) {
+        expect(function () {
+          tileset.pointCloudShading = undefined;
+        }).toThrowDeveloperError();
+      });
+    });
+
     describe("updateForPass", function () {
       it("updates for pass", function () {
         viewAllTiles();

--- a/Specs/Scene/ModelExperimental/MaterialPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/MaterialPipelineStageSpec.js
@@ -655,5 +655,5 @@ describe(
       });
     });
   },
-  "WEBGL"
+  "WebGL"
 );

--- a/Specs/Scene/ModelExperimental/ModelExperimentalPrimitiveSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalPrimitiveSpec.js
@@ -321,6 +321,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       model: {
         type: ModelExperimentalType.TILE_PNTS,
         featureIdAttributeIndex: 0,
+        pointCloudShading: pointCloudShading,
         content: {
           tileset: {
             pointCloudShading: pointCloudShading,

--- a/Specs/Scene/ModelExperimental/ModelExperimentalPrimitiveSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalPrimitiveSpec.js
@@ -8,7 +8,10 @@ import {
   GeometryPipelineStage,
   LightingPipelineStage,
   MaterialPipelineStage,
+  ModelExperimentalType,
   PickingPipelineStage,
+  PointCloudAttenuationPipelineStage,
+  PrimitiveType,
   VertexAttributeSemantic,
   BatchTexturePipelineStage,
   ModelExperimentalPrimitive,
@@ -22,6 +25,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
   };
   var mockNode = {};
   var mockModel = {
+    type: ModelExperimentalType.GLTF,
     allowPicking: true,
     featureIdAttributeIndex: 0,
   };
@@ -34,7 +38,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
   function verifyExpectedStages(stages, expectedStages) {
     expect(stages.length, expectedStages.stages);
     for (var i = 0; i < stages.length; i++) {
-      expect(expectedStages[i].name).toEqual(stages[i].name);
+      expect(stages[i].name).toEqual(expectedStages[i].name);
     }
   }
 
@@ -101,6 +105,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       primitive: mockPrimitive,
       node: mockNode,
       model: {
+        type: ModelExperimentalType.GLTF,
         allowPicking: false,
         content: {},
       },
@@ -154,6 +159,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       },
       node: {},
       model: {
+        type: ModelExperimentalType.GLTF,
         allowPicking: true,
         featureIdAttributeIndex: 1,
         content: {},
@@ -181,6 +187,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       },
       node: {},
       model: {
+        type: ModelExperimentalType.GLTF,
         allowPicking: true,
         featureIdTextureIndex: 1,
         content: {},
@@ -224,6 +231,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       primitive: mockPrimitive,
       node: mockNode,
       model: {
+        type: ModelExperimentalType.GLTF,
         content: {},
         customShader: new CustomShader({
           vertexShaderText: emptyVertexShader,
@@ -248,6 +256,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       primitive: mockPrimitive,
       node: mockNode,
       model: {
+        type: ModelExperimentalType.GLTF,
         content: {},
         customShader: new CustomShader({
           mode: CustomShaderMode.REPLACE_MATERIAL,
@@ -272,12 +281,92 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       primitive: mockPrimitive,
       node: mockNode,
       model: {
+        type: ModelExperimentalType.GLTF,
         content: {},
         customShader: new CustomShader({
           mode: CustomShaderMode.REPLACE_MATERIAL,
           vertexShaderText: emptyVertexShader,
         }),
         allowPicking: false,
+      },
+    });
+
+    var expectedStages = [
+      GeometryPipelineStage,
+      MaterialPipelineStage,
+      LightingPipelineStage,
+      AlphaPipelineStage,
+    ];
+
+    verifyExpectedStages(primitive.pipelineStages, expectedStages);
+  });
+
+  it("configures point cloud attenuation stage for 3D Tiles point clouds", function () {
+    var primitive = new ModelExperimentalPrimitive({
+      primitive: {
+        featureIdAttributes: [],
+        featureIdTextures: [],
+        attributes: [],
+        primitiveType: PrimitiveType.POINTS,
+      },
+      node: mockNode,
+      model: {
+        type: ModelExperimentalType.TILE_PNTS,
+        featureIdAttributeIndex: 0,
+      },
+    });
+
+    var expectedStages = [
+      GeometryPipelineStage,
+      PointCloudAttenuationPipelineStage,
+      MaterialPipelineStage,
+      LightingPipelineStage,
+      AlphaPipelineStage,
+    ];
+
+    verifyExpectedStages(primitive.pipelineStages, expectedStages);
+  });
+
+  it("configures point cloud attenuation stage for point clouds", function () {
+    var primitive = new ModelExperimentalPrimitive({
+      primitive: {
+        featureIdAttributes: [],
+        featureIdTextures: [],
+        attributes: [],
+        primitiveType: PrimitiveType.POINTS,
+      },
+      node: mockNode,
+      model: {
+        type: ModelExperimentalType.GLTF,
+        featureIdAttributeIndex: 0,
+        pointCloudShading: {},
+      },
+    });
+
+    var expectedStages = [
+      GeometryPipelineStage,
+      PointCloudAttenuationPipelineStage,
+      MaterialPipelineStage,
+      LightingPipelineStage,
+      AlphaPipelineStage,
+    ];
+
+    verifyExpectedStages(primitive.pipelineStages, expectedStages);
+  });
+
+  it("skips point cloud attenuation if point cloud shading is not set", function () {
+    var primitive = new ModelExperimentalPrimitive({
+      primitive: {
+        featureIdAttributes: [],
+        featureIdTextures: [],
+        attributes: [],
+        primitiveType: PrimitiveType.POINTS,
+      },
+      node: mockNode,
+      model: {
+        type: ModelExperimentalType.GLTF,
+        featureIdAttributeIndex: 0,
+        pointCloudShading: undefined,
       },
     });
 

--- a/Specs/Scene/ModelExperimental/ModelExperimentalPrimitiveSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalPrimitiveSpec.js
@@ -2,6 +2,7 @@ import {
   AlphaPipelineStage,
   CustomShader,
   CustomShaderMode,
+  CustomShaderPipelineStage,
   FeatureIdPipelineStage,
   CPUStylingPipelineStage,
   DequantizationPipelineStage,
@@ -244,6 +245,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
     var expectedStages = [
       GeometryPipelineStage,
       MaterialPipelineStage,
+      CustomShaderPipelineStage,
       LightingPipelineStage,
       AlphaPipelineStage,
     ];
@@ -269,6 +271,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
 
     var expectedStages = [
       GeometryPipelineStage,
+      CustomShaderPipelineStage,
       LightingPipelineStage,
       AlphaPipelineStage,
     ];
@@ -294,6 +297,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
     var expectedStages = [
       GeometryPipelineStage,
       MaterialPipelineStage,
+      CustomShaderPipelineStage,
       LightingPipelineStage,
       AlphaPipelineStage,
     ];

--- a/Specs/Scene/ModelExperimental/ModelExperimentalPrimitiveSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalPrimitiveSpec.js
@@ -12,6 +12,7 @@ import {
   ModelExperimentalType,
   PickingPipelineStage,
   PointCloudAttenuationPipelineStage,
+  PointCloudShading,
   PrimitiveType,
   VertexAttributeSemantic,
   BatchTexturePipelineStage,
@@ -306,6 +307,9 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
   });
 
   it("configures point cloud attenuation stage for 3D Tiles point clouds", function () {
+    var pointCloudShading = new PointCloudShading({
+      attenuation: true,
+    });
     var primitive = new ModelExperimentalPrimitive({
       primitive: {
         featureIdAttributes: [],
@@ -317,6 +321,11 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       model: {
         type: ModelExperimentalType.TILE_PNTS,
         featureIdAttributeIndex: 0,
+        content: {
+          tileset: {
+            pointCloudShading: pointCloudShading,
+          },
+        },
       },
     });
 
@@ -332,6 +341,9 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
   });
 
   it("configures point cloud attenuation stage for point clouds", function () {
+    var pointCloudShading = new PointCloudShading({
+      attenuation: true,
+    });
     var primitive = new ModelExperimentalPrimitive({
       primitive: {
         featureIdAttributes: [],
@@ -343,13 +355,42 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       model: {
         type: ModelExperimentalType.GLTF,
         featureIdAttributeIndex: 0,
-        pointCloudShading: {},
+        pointCloudShading: pointCloudShading,
       },
     });
 
     var expectedStages = [
       GeometryPipelineStage,
       PointCloudAttenuationPipelineStage,
+      MaterialPipelineStage,
+      LightingPipelineStage,
+      AlphaPipelineStage,
+    ];
+
+    verifyExpectedStages(primitive.pipelineStages, expectedStages);
+  });
+
+  it("skips point cloud attenuation if attenuation is false", function () {
+    var pointCloudShading = new PointCloudShading({
+      attenuation: false,
+    });
+    var primitive = new ModelExperimentalPrimitive({
+      primitive: {
+        featureIdAttributes: [],
+        featureIdTextures: [],
+        attributes: [],
+        primitiveType: PrimitiveType.POINTS,
+      },
+      node: mockNode,
+      model: {
+        type: ModelExperimentalType.GLTF,
+        featureIdAttributeIndex: 0,
+        pointCloudShading: pointCloudShading,
+      },
+    });
+
+    var expectedStages = [
+      GeometryPipelineStage,
       MaterialPipelineStage,
       LightingPipelineStage,
       AlphaPipelineStage,

--- a/Specs/Scene/ModelExperimental/PointCloudAttenuationPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/PointCloudAttenuationPipelineStageSpec.js
@@ -1,6 +1,7 @@
 import {
   Camera,
   Cartesian3,
+  Cesium3DTileRefine,
   Math as CesiumMath,
   Matrix4,
   ModelExperimentalType,
@@ -102,6 +103,76 @@ describe(
       expect(attenuation.x).toEqual(4 * frameState.pixelRatio);
     });
 
+    it("point size defaults to 5dp for 3D Tiles with additive refinement", function () {
+      var uniformMap = {};
+      var pointCloudShading = new PointCloudShading({
+        attenuation: true,
+        maximumAttenuation: undefined,
+      });
+      var renderResources = {
+        shaderBuilder: new ShaderBuilder(),
+        uniformMap: uniformMap,
+        runtimeNode: mockRuntimeNode,
+        model: {
+          type: ModelExperimentalType.TILE_GLTF,
+          pointCloudShading: pointCloudShading,
+          content: {
+            tile: {
+              refine: Cesium3DTileRefine.ADD,
+            },
+            tileset: {
+              maximumScreenSpaceError: 16,
+            },
+          },
+        },
+      };
+
+      var frameState = scene.frameState;
+      PointCloudAttenuationPipelineStage.process(
+        renderResources,
+        mockPrimitive,
+        frameState
+      );
+
+      var attenuation = uniformMap.model_pointCloudAttenuation();
+      expect(attenuation.x).toEqual(5 * frameState.pixelRatio);
+    });
+
+    it("point size defaults to tileset.maximumScreenSpaceError for 3D Tiles with replace refinement", function () {
+      var uniformMap = {};
+      var pointCloudShading = new PointCloudShading({
+        attenuation: true,
+        maximumAttenuation: undefined,
+      });
+      var renderResources = {
+        shaderBuilder: new ShaderBuilder(),
+        uniformMap: uniformMap,
+        runtimeNode: mockRuntimeNode,
+        model: {
+          type: ModelExperimentalType.TILE_GLTF,
+          pointCloudShading: pointCloudShading,
+          content: {
+            tile: {
+              refine: Cesium3DTileRefine.REPLACE,
+            },
+            tileset: {
+              maximumScreenSpaceError: 16,
+            },
+          },
+        },
+      };
+
+      var frameState = scene.frameState;
+      PointCloudAttenuationPipelineStage.process(
+        renderResources,
+        mockPrimitive,
+        frameState
+      );
+
+      var attenuation = uniformMap.model_pointCloudAttenuation();
+      expect(attenuation.x).toEqual(16 * frameState.pixelRatio);
+    });
+
     it("point size defaults to 1dp when maximumAttenuation is not defined", function () {
       var uniformMap = {};
       var pointCloudShading = new PointCloudShading({
@@ -144,6 +215,7 @@ describe(
           content: {
             tile: {
               geometricError: 3,
+              refine: Cesium3DTileRefine.ADD,
             },
           },
         },
@@ -176,6 +248,7 @@ describe(
           content: {
             tile: {
               geometricError: 3,
+              refine: Cesium3DTileRefine.ADD,
             },
           },
         },
@@ -209,6 +282,7 @@ describe(
           content: {
             tile: {
               geometricError: 0,
+              refine: Cesium3DTileRefine.ADD,
             },
           },
         },

--- a/Specs/Scene/ModelExperimental/PointCloudAttenuationPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/PointCloudAttenuationPipelineStageSpec.js
@@ -49,11 +49,12 @@ describe(
       expect(uniformMap.model_pointCloudAttenuation).toBeDefined();
     });
 
-    it("point size is set when attenuation is enabled", function () {
+    it("point size is determined by maximumAttenuation", function () {
       var uniformMap = {};
-      var pointCloudShading = new PointCloudShading();
-      pointCloudShading.attenuation = true;
-      pointCloudShading.maximumAttenuation = 4;
+      var pointCloudShading = new PointCloudShading({
+        attenuation: true,
+        maximumAttenuation: 4,
+      });
       var renderResources = {
         shaderBuilder: new ShaderBuilder(),
         uniformMap: uniformMap,
@@ -74,36 +75,12 @@ describe(
       expect(attenuation.x).toEqual(4 * frameState.pixelRatio);
     });
 
-    it("point size is set to 1dp when attenuation is disabled", function () {
-      var uniformMap = {};
-      var pointCloudShading = new PointCloudShading();
-      pointCloudShading.attenuation = false;
-      pointCloudShading.maximumAttenuation = 4;
-      var renderResources = {
-        shaderBuilder: new ShaderBuilder(),
-        uniformMap: uniformMap,
-        model: {
-          type: ModelExperimentalType.GLTF,
-          pointCloudShading: pointCloudShading,
-        },
-      };
-
-      var frameState = scene.frameState;
-      PointCloudAttenuationPipelineStage.process(
-        renderResources,
-        mockPrimitive,
-        frameState
-      );
-
-      var attenuation = uniformMap.model_pointCloudAttenuation();
-      expect(attenuation.x).toEqual(frameState.pixelRatio);
-    });
-
     it("point size defaults to 1dp when maximumAttenuation is not defined", function () {
       var uniformMap = {};
-      var pointCloudShading = new PointCloudShading();
-      pointCloudShading.attenuation = true;
-      pointCloudShading.maximumAttenuation = undefined;
+      var pointCloudShading = new PointCloudShading({
+        attenuation: true,
+        maximumAttenuation: undefined,
+      });
       var renderResources = {
         shaderBuilder: new ShaderBuilder(),
         uniformMap: uniformMap,

--- a/Specs/Scene/ModelExperimental/PointCloudAttenuationPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/PointCloudAttenuationPipelineStageSpec.js
@@ -1,0 +1,128 @@
+import {
+  ModelExperimentalType,
+  PointCloudAttenuationPipelineStage,
+  PointCloudShading,
+  ShaderBuilder,
+} from "../../../Source/Cesium.js";
+import createScene from "../../createScene.js";
+import ShaderBuilderTester from "../../ShaderBuilderTester.js";
+
+describe(
+  "Scene/ModelExperimental/PointCloudAttenuationPipelineStage",
+  function () {
+    var scene;
+    var mockPrimitive = {};
+
+    beforeAll(function () {
+      scene = createScene();
+    });
+
+    afterAll(function () {
+      scene.destroyForSpecs();
+    });
+
+    it("adds uniform and define to the shader", function () {
+      var shaderBuilder = new ShaderBuilder();
+      var uniformMap = {};
+      var renderResources = {
+        shaderBuilder: shaderBuilder,
+        uniformMap: uniformMap,
+        model: {
+          type: ModelExperimentalType.GLTF,
+        },
+      };
+
+      PointCloudAttenuationPipelineStage.process(
+        renderResources,
+        mockPrimitive,
+        scene.frameState
+      );
+
+      ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
+        "USE_POINT_CLOUD_ATTENUATION",
+      ]);
+      ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, []);
+      ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, [
+        "uniform vec3 model_pointCloudAttenuation;",
+      ]);
+      ShaderBuilderTester.expectHasFragmentUniforms(shaderBuilder, []);
+      expect(uniformMap.model_pointCloudAttenuation).toBeDefined();
+    });
+
+    it("point size is set when attenuation is enabled", function () {
+      var uniformMap = {};
+      var pointCloudShading = new PointCloudShading();
+      pointCloudShading.attenuation = true;
+      pointCloudShading.maximumAttenuation = 4;
+      var renderResources = {
+        shaderBuilder: new ShaderBuilder(),
+        uniformMap: uniformMap,
+        model: {
+          type: ModelExperimentalType.GLTF,
+          pointCloudShading: pointCloudShading,
+        },
+      };
+
+      var frameState = scene.frameState;
+      PointCloudAttenuationPipelineStage.process(
+        renderResources,
+        mockPrimitive,
+        frameState
+      );
+
+      var attenuation = uniformMap.model_pointCloudAttenuation();
+      expect(attenuation.x).toEqual(4 * frameState.pixelRatio);
+    });
+
+    it("point size is set to 1dp when attenuation is disabled", function () {
+      var uniformMap = {};
+      var pointCloudShading = new PointCloudShading();
+      pointCloudShading.attenuation = false;
+      pointCloudShading.maximumAttenuation = 4;
+      var renderResources = {
+        shaderBuilder: new ShaderBuilder(),
+        uniformMap: uniformMap,
+        model: {
+          type: ModelExperimentalType.GLTF,
+          pointCloudShading: pointCloudShading,
+        },
+      };
+
+      var frameState = scene.frameState;
+      PointCloudAttenuationPipelineStage.process(
+        renderResources,
+        mockPrimitive,
+        frameState
+      );
+
+      var attenuation = uniformMap.model_pointCloudAttenuation();
+      expect(attenuation.x).toEqual(frameState.pixelRatio);
+    });
+
+    it("point size defaults to 1dp when maximumAttenuation is not defined", function () {
+      var uniformMap = {};
+      var pointCloudShading = new PointCloudShading();
+      pointCloudShading.attenuation = true;
+      pointCloudShading.maximumAttenuation = undefined;
+      var renderResources = {
+        shaderBuilder: new ShaderBuilder(),
+        uniformMap: uniformMap,
+        model: {
+          type: ModelExperimentalType.GLTF,
+          pointCloudShading: pointCloudShading,
+        },
+      };
+
+      var frameState = scene.frameState;
+      PointCloudAttenuationPipelineStage.process(
+        renderResources,
+        mockPrimitive,
+        frameState
+      );
+
+      var attenuation = uniformMap.model_pointCloudAttenuation();
+      expect(attenuation.x).toEqual(frameState.pixelRatio);
+    });
+  },
+  "WebGL"
+);

--- a/Specs/Scene/ModelExperimental/PointCloudAttenuationPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/PointCloudAttenuationPipelineStageSpec.js
@@ -147,6 +147,160 @@ describe(
       expect(attenuation.x).toEqual(frameState.pixelRatio);
     });
 
+    it("scales geometricError", function () {
+      var uniformMap = {};
+      var pointCloudShading = new PointCloudShading({
+        attenuation: true,
+        geometricErrorScale: 2,
+      });
+      var renderResources = {
+        shaderBuilder: new ShaderBuilder(),
+        uniformMap: uniformMap,
+        model: {
+          type: ModelExperimentalType.TILE_GLTF,
+          content: {
+            tile: {
+              geometricError: 3,
+            },
+            tileset: {
+              pointCloudShading: pointCloudShading,
+            },
+          },
+        },
+      };
+
+      var frameState = scene.frameState;
+      PointCloudAttenuationPipelineStage.process(
+        renderResources,
+        mockPrimitive,
+        frameState
+      );
+
+      var attenuation = uniformMap.model_pointCloudAttenuation();
+      expect(attenuation.y).toEqual(6);
+    });
+
+    it("uses tile geometric error when available", function () {
+      var uniformMap = {};
+      var pointCloudShading = new PointCloudShading({
+        attenuation: true,
+        geometricErrorScale: 1,
+      });
+      var renderResources = {
+        shaderBuilder: new ShaderBuilder(),
+        uniformMap: uniformMap,
+        model: {
+          type: ModelExperimentalType.TILE_GLTF,
+          content: {
+            tile: {
+              geometricError: 3,
+            },
+            tileset: {
+              pointCloudShading: pointCloudShading,
+            },
+          },
+        },
+      };
+
+      var frameState = scene.frameState;
+      PointCloudAttenuationPipelineStage.process(
+        renderResources,
+        mockPrimitive,
+        frameState
+      );
+
+      var attenuation = uniformMap.model_pointCloudAttenuation();
+      expect(attenuation.y).toEqual(3);
+    });
+
+    it("uses baseResolution when tile geometric error is 0", function () {
+      var uniformMap = {};
+      var pointCloudShading = new PointCloudShading({
+        attenuation: true,
+        geometricErrorScale: 1,
+        baseResolution: 4,
+      });
+      var renderResources = {
+        shaderBuilder: new ShaderBuilder(),
+        uniformMap: uniformMap,
+        model: {
+          type: ModelExperimentalType.TILE_GLTF,
+          content: {
+            tile: {
+              geometricError: 0,
+            },
+            tileset: {
+              pointCloudShading: pointCloudShading,
+            },
+          },
+        },
+      };
+
+      var frameState = scene.frameState;
+      PointCloudAttenuationPipelineStage.process(
+        renderResources,
+        mockPrimitive,
+        frameState
+      );
+
+      var attenuation = uniformMap.model_pointCloudAttenuation();
+      expect(attenuation.y).toEqual(4);
+    });
+
+    it("uses baseResolution for glTF models", function () {
+      var uniformMap = {};
+      var pointCloudShading = new PointCloudShading({
+        attenuation: true,
+        geometricErrorScale: 1,
+        baseResolution: 4,
+      });
+      var renderResources = {
+        shaderBuilder: new ShaderBuilder(),
+        uniformMap: uniformMap,
+        model: {
+          type: ModelExperimentalType.GLTF,
+          pointCloudShading: pointCloudShading,
+        },
+      };
+
+      var frameState = scene.frameState;
+      PointCloudAttenuationPipelineStage.process(
+        renderResources,
+        mockPrimitive,
+        frameState
+      );
+
+      var attenuation = uniformMap.model_pointCloudAttenuation();
+      expect(attenuation.y).toEqual(4);
+    });
+
+    it("estimates geometric error when baseResolution is not available", function () {
+      var uniformMap = {};
+      var pointCloudShading = new PointCloudShading({
+        attenuation: true,
+        geometricErrorScale: 1,
+        baseResolution: undefined,
+      });
+      var renderResources = {
+        shaderBuilder: new ShaderBuilder(),
+        uniformMap: uniformMap,
+        model: {
+          type: ModelExperimentalType.GLTF,
+          pointCloudShading: pointCloudShading,
+        },
+      };
+
+      var frameState = scene.frameState;
+      PointCloudAttenuationPipelineStage.process(
+        renderResources,
+        mockPrimitive,
+        frameState
+      );
+
+      var attenuation = uniformMap.model_pointCloudAttenuation();
+      expect(attenuation.y).toEqual(100);
+    });
+
     it("computes depth multiplier from drawing buffer and frustum", function () {
       var uniformMap = {};
       var pointCloudShading = new PointCloudShading({

--- a/Specs/Scene/ModelExperimental/PointCloudAttenuationPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/PointCloudAttenuationPipelineStageSpec.js
@@ -75,45 +75,6 @@ describe(
       expect(uniformMap.model_pointCloudAttenuation).toBeDefined();
     });
 
-    it("uses tileset.pointCloudShading for 3D Tiles", function () {
-      var uniformMap = {};
-      var pointCloudShading1dp = new PointCloudShading({
-        attenuation: true,
-        maximumAttenuation: 1,
-      });
-      var pointCloudShading4dp = new PointCloudShading({
-        attenuation: true,
-        maximumAttenuation: 4,
-      });
-      var renderResources = {
-        shaderBuilder: new ShaderBuilder(),
-        uniformMap: uniformMap,
-        runtimeNode: mockRuntimeNode,
-        model: {
-          type: ModelExperimentalType.TILE_GLTF,
-          content: {
-            tile: {
-              geometricError: 3,
-            },
-            tileset: {
-              pointCloudShading: pointCloudShading1dp,
-            },
-          },
-          pointCloudShading: pointCloudShading4dp,
-        },
-      };
-
-      var frameState = scene.frameState;
-      PointCloudAttenuationPipelineStage.process(
-        renderResources,
-        mockPrimitive,
-        frameState
-      );
-
-      var attenuation = uniformMap.model_pointCloudAttenuation();
-      expect(attenuation.x).toEqual(1 * frameState.pixelRatio);
-    });
-
     it("point size is determined by maximumAttenuation", function () {
       var uniformMap = {};
       var pointCloudShading = new PointCloudShading({
@@ -179,12 +140,10 @@ describe(
         uniformMap: uniformMap,
         model: {
           type: ModelExperimentalType.TILE_GLTF,
+          pointCloudShading: pointCloudShading,
           content: {
             tile: {
               geometricError: 3,
-            },
-            tileset: {
-              pointCloudShading: pointCloudShading,
             },
           },
         },
@@ -213,12 +172,10 @@ describe(
         runtimeNode: mockRuntimeNode,
         model: {
           type: ModelExperimentalType.TILE_GLTF,
+          pointCloudShading: pointCloudShading,
           content: {
             tile: {
               geometricError: 3,
-            },
-            tileset: {
-              pointCloudShading: pointCloudShading,
             },
           },
         },
@@ -248,12 +205,10 @@ describe(
         runtimeNode: mockRuntimeNode,
         model: {
           type: ModelExperimentalType.TILE_GLTF,
+          pointCloudShading: pointCloudShading,
           content: {
             tile: {
               geometricError: 0,
-            },
-            tileset: {
-              pointCloudShading: pointCloudShading,
             },
           },
         },

--- a/Specs/Scene/ModelExperimental/PointCloudAttenuationPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/PointCloudAttenuationPipelineStageSpec.js
@@ -1,10 +1,14 @@
 import {
   Camera,
+  Cartesian3,
+  Math as CesiumMath,
+  Matrix4,
   ModelExperimentalType,
   OrthographicFrustum,
   PointCloudAttenuationPipelineStage,
   PointCloudShading,
   ShaderBuilder,
+  VertexAttributeSemantic,
 } from "../../../Source/Cesium.js";
 import createScene from "../../createScene.js";
 import ShaderBuilderTester from "../../ShaderBuilderTester.js";
@@ -13,7 +17,20 @@ describe(
   "Scene/ModelExperimental/PointCloudAttenuationPipelineStage",
   function () {
     var scene;
-    var mockPrimitive = {};
+    var mockPrimitive = {
+      attributes: [
+        {
+          semantic: VertexAttributeSemantic.POSITION,
+          min: new Cartesian3(0, 0, 0),
+          max: new Cartesian3(1, 1, 1),
+          count: 64,
+        },
+      ],
+    };
+
+    var mockRuntimeNode = {
+      transform: new Matrix4(2, 0, 0, 1, 0, 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1),
+    };
 
     beforeAll(function () {
       scene = createScene();
@@ -35,6 +52,7 @@ describe(
       var renderResources = {
         shaderBuilder: shaderBuilder,
         uniformMap: uniformMap,
+        runtimeNode: mockRuntimeNode,
         model: {
           type: ModelExperimentalType.GLTF,
         },
@@ -70,6 +88,7 @@ describe(
       var renderResources = {
         shaderBuilder: new ShaderBuilder(),
         uniformMap: uniformMap,
+        runtimeNode: mockRuntimeNode,
         model: {
           type: ModelExperimentalType.TILE_GLTF,
           content: {
@@ -104,6 +123,7 @@ describe(
       var renderResources = {
         shaderBuilder: new ShaderBuilder(),
         uniformMap: uniformMap,
+        runtimeNode: mockRuntimeNode,
         model: {
           type: ModelExperimentalType.GLTF,
           pointCloudShading: pointCloudShading,
@@ -130,6 +150,7 @@ describe(
       var renderResources = {
         shaderBuilder: new ShaderBuilder(),
         uniformMap: uniformMap,
+        runtimeNode: mockRuntimeNode,
         model: {
           type: ModelExperimentalType.GLTF,
           pointCloudShading: pointCloudShading,
@@ -189,6 +210,7 @@ describe(
       var renderResources = {
         shaderBuilder: new ShaderBuilder(),
         uniformMap: uniformMap,
+        runtimeNode: mockRuntimeNode,
         model: {
           type: ModelExperimentalType.TILE_GLTF,
           content: {
@@ -223,6 +245,7 @@ describe(
       var renderResources = {
         shaderBuilder: new ShaderBuilder(),
         uniformMap: uniformMap,
+        runtimeNode: mockRuntimeNode,
         model: {
           type: ModelExperimentalType.TILE_GLTF,
           content: {
@@ -257,6 +280,7 @@ describe(
       var renderResources = {
         shaderBuilder: new ShaderBuilder(),
         uniformMap: uniformMap,
+        runtimeNode: mockRuntimeNode,
         model: {
           type: ModelExperimentalType.GLTF,
           pointCloudShading: pointCloudShading,
@@ -284,6 +308,7 @@ describe(
       var renderResources = {
         shaderBuilder: new ShaderBuilder(),
         uniformMap: uniformMap,
+        runtimeNode: mockRuntimeNode,
         model: {
           type: ModelExperimentalType.GLTF,
           pointCloudShading: pointCloudShading,
@@ -298,7 +323,10 @@ describe(
       );
 
       var attenuation = uniformMap.model_pointCloudAttenuation();
-      expect(attenuation.y).toEqual(100);
+      var volume = 8;
+      var pointsLength = 64;
+      var expected = CesiumMath.cbrt(volume / pointsLength);
+      expect(attenuation.y).toEqual(expected);
     });
 
     it("computes depth multiplier from drawing buffer and frustum", function () {
@@ -309,6 +337,7 @@ describe(
       var renderResources = {
         shaderBuilder: new ShaderBuilder(),
         uniformMap: uniformMap,
+        runtimeNode: mockRuntimeNode,
         model: {
           type: ModelExperimentalType.GLTF,
           pointCloudShading: pointCloudShading,
@@ -338,6 +367,7 @@ describe(
       var renderResources = {
         shaderBuilder: new ShaderBuilder(),
         uniformMap: uniformMap,
+        runtimeNode: mockRuntimeNode,
         model: {
           type: ModelExperimentalType.GLTF,
           pointCloudShading: pointCloudShading,
@@ -369,6 +399,7 @@ describe(
       var renderResources = {
         shaderBuilder: new ShaderBuilder(),
         uniformMap: uniformMap,
+        runtimeNode: mockRuntimeNode,
         model: {
           type: ModelExperimentalType.GLTF,
           pointCloudShading: pointCloudShading,

--- a/Specs/Scene/ModelExperimental/PrimitiveRenderResourcesSpec.js
+++ b/Specs/Scene/ModelExperimental/PrimitiveRenderResourcesSpec.js
@@ -9,6 +9,7 @@ import {
   Matrix4,
   ModelExperimentalNode,
   ModelExperimentalPrimitive,
+  ModelExperimentalType,
   PrimitiveType,
   ModelRenderResources,
   NodeRenderResources,
@@ -17,7 +18,9 @@ import {
 } from "../../../Source/Cesium.js";
 
 describe("Scene/ModelExperimental/PrimitiveRenderResources", function () {
-  var mockModel = {};
+  var mockModel = {
+    type: ModelExperimentalType.GLTF,
+  };
   var mockNode = {};
   var mockSceneGraph = {
     computedModelMatrix: Matrix4.IDENTITY,


### PR DESCRIPTION
In #9978, I added a transcoder from `.pnts -> ModelExperimental`. However, there are more point-cloud specific features to add, point cloud attenuation being the main one that's missing.

[Point Cloud Shading Sandcastle + Model Experimental](http://localhost:8080/Apps/Sandcastle/index.html#c=zRnbcts29lfOeh8iz8gUKZK62fFuYrvbzCRNJlLS2a36AJGwhDVFsABoWc3433sAXkSKkmOntpOHTEzg3O8HOqOSpUvr4iahgi1prEj0EyUqFVRaNCaziL7jIY2q9/ASlEjp8TSextdEwDWjKyrwNKYrOMvofTZnrelBYL7POCKymIrpQRu+TGMARYXAkw+CX7OQilGBGAjkTn/lIgonGUjrsD2Nbw9LdjKgMUVuGVvLfB5vJDHiTlhEJVUGh11C6x859Q+cxeos4mk4XpCQxXOLyXGaJFwoGrYMqcPDTMAVi0O+skhEhUI9JgsmYSb4SqKqIacSYq5AZriQaLoQaMIgM8rTAy3yrZbgMo0DxXgMQgvVyhlU5bcSNC5T7BqtLuiSX9PWti6aGjQ0RDukcUgv0bZhwa7TgcmCbkDRWyS4kqDwUCq0LvBL4KmAJYsZkCSJWEC0fFZmxaQ0kkTyv00PxsqCn2lEY6ndNz04W6QiWEwPft82O4Ib1egNWSYRnawTKkdVem19G6RCYCBdbIBqML/ZvxuwJblhy3Q5xoig8TghAb0QgmOkOD3LNhBzypdUCRaYi3GAvsLb/DJHf6UUjVOj3gjsNqBxLv5I2TXCoscU35hPI82IpB+p5FF6TwS6pucoxFs2Xyh0+lihZnO12IixBfARYyOVxfXtcS08VObTCf9cGLSVH1VCZsv7qhLpCFBzXx7jGyircVcPKmuPzSsU9kBs0dnhGaTR4L4LbrdEFTfuJNQE02QA/vUAWHT3FvN6OOxkXAfZz3QXXJPhnnCClxlCk+wehLvJZkF4b6IZeKOYRZyEY5XVhaKmYbKMMSx1pcHaohg2i4AsqSBGGJ09EedXQBS8w5pSqSt57OZIH7hkucXzwn1GsEJLRmLXuhR8qUUiyDbT4KhrOa7nDfquM3D7A9sbeO3sxrYGdt9xB3a333f7dr9fXPh9z7XcoecN+8NB1+l19XFeYjdyvBdMd7xclEp7+5kaS31gKlh85FFkhDqnc0yKQijH6VrDoT/s9fpO17Fdf9AupHUs13OHtu/bg37X6zmlsChrb+g7Q2cwGA48x68IVW0WmUktTEddKFpfMvSQSvRWXum2DJlz4Bt9Rjt0zKFoHE4EWveSi2XZl98RTNMbz3pzfvHL5M3kvwY278rG73WHgnsORZGao8wC204I2krw9tUYkqzthzBbw0KpRI46ndVqZUVsFhFpcTHvSNMdZCcnb/pvXoQgldh/BU0iLD96JsG/dUU2f5I4hAWRm+YA1JQw7HOCY+KjINEa6B8pxqbiOXUdsOQapZzrwMXZJGvoIcN+GQf6DCgJFkYAqwgSVRbhSmRk/7nnufKFc1IRlaZ8w2NdCbCHUhM3ryQCvglbPkbq4cau+ycEEoZlY8gd8JXyjDLqrnlcBb1PYayNF9pQv7Ioghk1jTIEBNjHkMVSYZLczbBRX6uzzF2Iu/uL81UNSU21fIq9C2GrFFZHX7irX++sltncVKmVZhwFw1BnAg7DlxZ8oBh/8CrCNGrDGdpmOWMEPsXoeoHZvIaPfMYVCyS8JTPMuYDEsRYNCbyK6P8x/gWHieBBwCNm0gFzlzI4YzwgImJZAO9MKQwsE2L3yacyAnTuzDh6zgjBb0CyPylg8XiGlHF6Xtf58XLGQzRt4XMev0ALRhFfZW1WQkTEHN2rFiQGDxJ2QyNpPTBLsFH4hj6aIV1i5Yp1ZZ9j8dftNtHLm141CgSc9n1Aeyjc3zC0cI2haoWqog8wrGeIio7LxLO+Je1sK5dGbxIYRdjlMUAXzQqMkWSCBfWpyGc9Z8o+tI9Ww7QcQfIOD+B5ttP3PKvneY7nu04xXQB0u77tO5bn2P3B0HFsv1teef7Q97q25fa9/sDzXDe7ONzVo+8YOUohfGTf67s45Pi2O+z7/ZLTkW11+70eThW+O3CHg0GvvOpZ3YGDcg36vmfb9sCvCnF7+A0FLljQ4Op/VPAWCv2ZRCktlhbM++LoJyyDOvsTImT2sYE2bhUUozfehn9pYh7n6rI/wKgOU4hTH0qP83X4jMdYPLO5dLOsLulyptMBA4jDVcyDK54q4DPc8K/1w4fOhtz4xa1lVunNbl5yeM3y4K5s3dwcnL9/ByiOrqVSp6I++/RGFwCFyYrdVFdKpvLdW3EezYiuPSEPUo2ESacuMvzXayx504McJntg2BZQr/NrLQ3GitwI2i4oZxJvYWnLaz7vS92rmNOD5saOzA2STGcyEGxGW2UgbPsfimeP4+xLv8cUIMa19d2/xAJoOFMf3qI1sX7cScXZplJ03oJGJcofaIo9zeJB9tCy52zzcG6+9lQU2L67o2Htzau/pfOOsv+s+t63EVW0L2hBWSaKk8eLgeoDwvc1x84hZFOQn9QYWw8b39cQjVHpmYyw5xnmO1tj72vSs2XKzpekH8sqxWPYt9tkjINtQKTCPQe3jAmfzyP6OlWKx9isL8xvKFCrFW0zkbZho7Z5Ftehql+Vc3UepPk99CbN6pDv2bfl7yv3UeVijUMNGhAKC34vhZqD/m6lDtoHJ1KtI3paePHfbGl+tsEVs2VZHUVxrMEdWXZmKeIrK5CycDTAP4uZ7MsmLGY4Bc6FXnpHIOYz0vK6bSj+2dZggw0YV6EWdwReclM5xr0rpOJI5D8IVC9vG6xZnOBoWhFAj7MM294RidgcF4UlC8P87bzG9UjxZATdGufiCpc0xZf12yZra4GLB61pf8ljdbTSy6MaoR5RuI1+0qna+yRk18DClzt+DIQgIlLizWUaRWP2J84VpycdhG+g6ikOhX6PikdkrcEWzunb7NCyrJMOfu7GLMfl0v0nEkfKQEFIFDma4ayMUDzRgYuOqP521cblBZN/BLsGYGSX0dnQVTpBTjeGOlEzHq4rB/pI1L71SXj6LmvgkI10YGY6MLPNSQevmwj1EzzLIkShZKiMIPEcJdQ/8OEXrk76b3KDf/c88yEVTcyNgx9VM+T67pkwc3t8ShAFoV4Ypi8qlt0tjqI3SjNF/+KX/yCWDeINg+CB+LqJy0jLwhnJVkryN9I8/U/5wpEN4GYQfWSPde/lsB0D8VM6a+dG8DiOKnPhLv/8PZO6NZs65mN/RFbkeIb4rw0Kj2TR1/rBbTMWP7I1HbseofaeEK3P5k9pyu2V5KkqSGMS+lYHNQhBMas/sa/2uGrP4vCUPtu7QT1SDjRNnA3+P4SBM1Ge0bzFIvZA4+JnbaDB78rEUx2//gI) -- mostly working.

The nice thing is eye dome lighting seems to be working for free.

To Do:
- [x] Now that #9989 is merged, I can finish the one TODO in the code about the baseResolution estimate.
- [x] `PointCloud3DTileContent` has more handling code for `maximumAttenutation`, I need to find a place for this code.
- [x] Update unit tests as needed.