### PR TITLE
Lock colors to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "bitmap-sdf": "^1.0.3",
     "bluebird": "^3.7.2",
     "cloc": "^2.8.0",
+    "colors": "1.4.0",
     "compression": "^1.7.4",
     "dompurify": "^2.2.2",
     "draco3d": "^1.4.1",


### PR DESCRIPTION
`karma` and `karma-spec-reporter` both depend on `colors`, which is broken after 1.4.1. Until the Karma libraries are fixed this is a workaround to lock the `colors` version.

edit - `karma-spec-reporter` looks like it got fixed as of 0.0.33 just now.