### PR TITLE
Fix _BATCHID handling for `ModelExperimental`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 - Fixed an error when loading GeoJSON with null `stroke` or `fill` properties but valid opacity values. [#9717](https://github.com/CesiumGS/cesium/pull/9717)
 - Fixed `scene.pickTranslucentDepth` for translucent point clouds with eye dome lighting. [#9991](https://github.com/CesiumGS/cesium/pull/9991)
 - Added a setter for `tileset.pointCloudShading` that throws if set to `undefined` to clarify that this is disallowed. [#9998](https://github.com/CesiumGS/cesium/pull/9998)
+- Fixes handling .b3dm `_BATCHID` accessors in `ModelExperimental` [#10008](https://github.com/CesiumGS/cesium/pull/10008)
 
 ### 1.89 - 2022-01-03
 

--- a/Source/Scene/GltfLoader.js
+++ b/Source/Scene/GltfLoader.js
@@ -70,6 +70,7 @@ var GltfLoaderState = {
  * @param {Axis} [options.upAxis=Axis.Y] The up-axis of the glTF model.
  * @param {Axis} [options.forwardAxis=Axis.Z] The forward-axis of the glTF model.
  * @param {Boolean} [options.loadAsTypedArray=false] Load all attributes and indices as typed arrays instead of GPU buffers.
+ * @param {Boolean} [options.renameBatchIdSemantic=false] If true, rename _BATCHID or BATCHID to FEATURE_ID_0. This is used for .b3dm models
  *
  * @private
  */
@@ -87,6 +88,10 @@ export default function GltfLoader(options) {
   var upAxis = defaultValue(options.upAxis, Axis.Y);
   var forwardAxis = defaultValue(options.forwardAxis, Axis.Z);
   var loadAsTypedArray = defaultValue(options.loadAsTypedArray, false);
+  var renameBatchIdSemantic = defaultValue(
+    options.renameBatchIdSemantic,
+    false
+  );
 
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("options.gltfResource", gltfResource);
@@ -104,6 +109,7 @@ export default function GltfLoader(options) {
   this._upAxis = upAxis;
   this._forwardAxis = forwardAxis;
   this._loadAsTypedArray = loadAsTypedArray;
+  this._renameBatchIdSemantic = renameBatchIdSemantic;
 
   // When loading EXT_feature_metadata, the feature tables and textures
   // are now stored as arrays like the newer EXT_mesh_features extension.
@@ -503,6 +509,15 @@ function loadAttribute(
 ) {
   var accessor = gltf.accessors[accessorId];
   var bufferViewId = accessor.bufferView;
+
+  // For .b3dm, rename _BATCHID (or the legacy BATCHID) to FEATURE_ID_0
+  // for compatibility with EXT_feature_metadata
+  if (
+    loader._renameBatchIdSemantic &&
+    (gltfSemantic === "_BATCHID" || gltfSemantic === "BATCHID")
+  ) {
+    gltfSemantic = "FEATURE_ID_0";
+  }
 
   var name = gltfSemantic;
   var semantic = semanticType.fromGltfSemantic(gltfSemantic);

--- a/Source/Scene/GltfVertexBufferLoader.js
+++ b/Source/Scene/GltfVertexBufferLoader.js
@@ -32,11 +32,11 @@ import ComponentDatatype from "../Core/ComponentDatatype.js";
  * @param {Number} [options.bufferViewId] The bufferView ID corresponding to the vertex buffer.
  * @param {Object} [options.draco] The Draco extension object.
  * @param {String} [options.attributeSemantic] The attribute semantic, e.g. POSITION or NORMAL.
- * @param {String} [options.accessorId] The accessor id.
+ * @param {Number} [options.accessorId] The accessor id.
  * @param {String} [options.cacheKey] The cache key of the resource.
  * @param {Boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
- * @param {Boolean} [dequantize=false] Determines whether or not the vertex buffer will be dequantized on the CPU.
- * @param {Boolean} [loadAsTypedArray=false] Load vertex buffer as a typed array instead of a GPU vertex buffer.
+ * @param {Boolean} [options.dequantize=false] Determines whether or not the vertex buffer will be dequantized on the CPU.
+ * @param {Boolean} [options.loadAsTypedArray=false] Load vertex buffer as a typed array instead of a GPU vertex buffer.
  *
  * @exception {DeveloperError} One of options.bufferViewId and options.draco must be defined.
  * @exception {DeveloperError} When options.draco is defined options.attributeSemantic must also be defined.

--- a/Source/Scene/ModelExperimental/B3dmLoader.js
+++ b/Source/Scene/ModelExperimental/B3dmLoader.js
@@ -214,6 +214,7 @@ B3dmLoader.prototype.load = function () {
     releaseGltfJson: this._releaseGltfJson,
     incrementallyLoadTextures: this._incrementallyLoadTextures,
     loadAsTypedArray: this._loadAsTypedArray,
+    renameBatchIdSemantic: true,
   });
 
   this._gltfLoader = gltfLoader;

--- a/Source/Scene/VertexAttributeSemantic.js
+++ b/Source/Scene/VertexAttributeSemantic.js
@@ -172,8 +172,6 @@ VertexAttributeSemantic.fromGltfSemantic = function (gltfSemantic) {
       return VertexAttributeSemantic.WEIGHTS;
     case "_FEATURE_ID": // for EXT_feature_metadata
     case "FEATURE_ID": // for EXT_mesh_features
-    case "_BATCHID": // for b3dm compatibility
-    case "BATCHID": // for legacy b3dm compatibility
       return VertexAttributeSemantic.FEATURE_ID;
   }
 

--- a/Specs/Scene/VertexAttributeSemanticSpec.js
+++ b/Specs/Scene/VertexAttributeSemanticSpec.js
@@ -50,8 +50,6 @@ describe("Scene/VertexAttributeSemantic", function () {
       "WEIGHTS_1",
       "_FEATURE_ID_0",
       "_FEATURE_ID_1",
-      "_BATCHID",
-      "BATCHID",
       "_OTHER",
     ];
 
@@ -67,8 +65,6 @@ describe("Scene/VertexAttributeSemantic", function () {
       VertexAttributeSemantic.JOINTS,
       VertexAttributeSemantic.WEIGHTS,
       VertexAttributeSemantic.WEIGHTS,
-      VertexAttributeSemantic.FEATURE_ID,
-      VertexAttributeSemantic.FEATURE_ID,
       VertexAttributeSemantic.FEATURE_ID,
       VertexAttributeSemantic.FEATURE_ID,
       undefined,


### PR DESCRIPTION
Fixes #9956 

This PR:

1. removes `_BATCHID`/`BATCHID` from `VertexAttributeSemantic` since this should be handling by the parsing/loading code.
2. For B3DMs, renames the `_BATCHID` accessor to `FEATURE_ID_0`

@lilleyse could you review?

See https://github.com/CesiumGS/cesium/issues/6561#issuecomment-1012411954 for a Sandcastle and data to test with.