### PR TITLE
Adds instructions for debugging CesiumJS within VSCode

### DIFF
--- a/Documentation/Contributors/VSCodeGuide/README.md
+++ b/Documentation/Contributors/VSCodeGuide/README.md
@@ -76,3 +76,9 @@ you save them.
 
 Keep in mind that `build-watch` will quietly terminate when
 you quit VSCode, so should be restarted manually on next launch.
+
+## Debugging CesiumJS
+
+To enable debugging from within VSCode, navigate to your [`settings.json` file](https://code.visualstudio.com/docs/getstarted/settings#_settings-file-locations)
+and set `"debug.javascript.debugByLinkOptions"` to `"always"`. Once you save your changes to this file, you can start a debugging session within VSCode by holding down
+`CTRL` and clicking on the link that is printed to the console when running `npm run start` or `npm start`.


### PR DESCRIPTION
This PR adds directions to the VS Code guide for debugging CesiumJS within VS Code. Now that the Chrome debugger extension has been deprecated, the correct way to debug within VSCode is by using the [Debug Link command introduced in July 2020](https://code.visualstudio.com/updates/v1_48#_debug-open-link-command).

Optionally, we could set this flag ourselves in this repository's `.vscode/settings.json`, but I am not sure if it's correct to have that on all the time since users may prefer using their preferred browsers' development tools.