### PR TITLE
fixes crash issue when create Viewer too many times

### DIFF
--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -9,6 +9,7 @@ import Ellipsoid from "../../Core/Ellipsoid.js";
 import FeatureDetection from "../../Core/FeatureDetection.js";
 import formatError from "../../Core/formatError.js";
 import requestAnimationFrame from "../../Core/requestAnimationFrame.js";
+import RuntimeError from "../../Core/RuntimeError.js";
 import ScreenSpaceEventHandler from "../../Core/ScreenSpaceEventHandler.js";
 import createWorldImagery from "../../Scene/createWorldImagery.js";
 import Globe from "../../Scene/Globe.js";
@@ -373,7 +374,16 @@ function CesiumWidget(container, options) {
         that.showErrorPanel(title, undefined, error);
       }
     };
+
     scene.renderError.addEventListener(this._onRenderError);
+    canvas.addEventListener("webglcontextlost", function () {
+      that._onRenderError(
+        scene,
+        new RuntimeError(
+          "The browser lost webgl context, please refresh the page to restore functionality!"
+        )
+      );
+    });
   } catch (error) {
     if (showRenderLoopErrors) {
       var title = "Error constructing CesiumWidget.";


### PR DESCRIPTION
I find that viewer will crash when i created too many viewers (the number is 16 in chrome) even i had destroy the previous viewers. Look at these code:
``` js
var viewerOldest = new Cesium.Viewer("cesiumContainer");

// then i create some other viewers, and i destroyed them when i didn't need it.
// the code can be simplified to:
for ( var  i =0; i<16; ++i){
   var viewer = new Viewer("cesiumContainer");

   // do something here...

   viewer.destroy();
}
```
 Then, the earliest created viewer will crash. I find the chrome console output the warning:

> WARNING: Too many active WebGL contexts. Oldest context will be lost.

After search some keyword, i think this crash is caused by that webgl context is not released when viewer destroyed. I make this  PR to fix this problem, please let me know if i have mistakes.
