### PR TITLE
Fixed imageBasedLightingFactor setting for i3dm

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 - Added a setter for `tileset.pointCloudShading` that throws if set to `undefined` to clarify that this is disallowed. [#9998](https://github.com/CesiumGS/cesium/pull/9998)
 - Fixes handling .b3dm `_BATCHID` accessors in `ModelExperimental` [#10008](https://github.com/CesiumGS/cesium/pull/10008)
 - Fixed path entity being drawn when data is unavailable [#1704](https://github.com/CesiumGS/cesium/pull/1704)
+- Fixed setting `tileset.imageBasedLightingFactor` has no effect on i3dm tile content. [#10020](https://github.com/CesiumGS/cesium/pull/10020)
 
 ### 1.89 - 2022-01-03
 

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -526,6 +526,7 @@ Instanced3DModel3DTileContent.prototype.update = function (
   this._modelInstanceCollection.shadows = this._tileset.shadows;
   this._modelInstanceCollection.lightColor = this._tileset.lightColor;
   this._modelInstanceCollection.luminanceAtZenith = this._tileset.luminanceAtZenith;
+  this._modelInstanceCollection.imageBasedLightingFactor = this._tileset.imageBasedLightingFactor;
   this._modelInstanceCollection.sphericalHarmonicCoefficients = this._tileset.sphericalHarmonicCoefficients;
   this._modelInstanceCollection.specularEnvironmentMaps = this._tileset.specularEnvironmentMaps;
   this._modelInstanceCollection.backFaceCulling = this._tileset.backFaceCulling;

--- a/Specs/Cesium3DTilesTester.js
+++ b/Specs/Cesium3DTilesTester.js
@@ -168,6 +168,10 @@ Cesium3DTilesTester.rejectsReadyPromiseOnError = function (
     _statistics: {
       batchTableByteLength: 0,
     },
+    imageBasedLightingFactor: {
+      x: 1,
+      y: 1,
+    },
   };
   var url = Resource.createIfNeeded("");
   var content = Cesium3DTileContentFactory[type](


### PR DESCRIPTION
Setting `tileset.imageBasedLightingFactor` has no effect on i3dm content