### PR TITLE
Add a feature ID getter for picking

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Next Photogrammetry Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Next Photogrammetry Classification.html
@@ -256,7 +256,7 @@
                 "Component: " +
                 pickedObject.getProperty("component") +
                 "\nFeature ID: " +
-                pickedObject._batchId;
+                pickedObject.featureId;
               nameOverlay.textContent = message;
             } else {
               nameOverlay.style.display = "none";
@@ -272,11 +272,11 @@
             var pickedObject = scene.pick(movement.position);
             if (
               Cesium.defined(pickedObject) &&
-              Cesium.defined(pickedObject._batchId)
+              Cesium.defined(pickedObject.featureId)
             ) {
               selectFeatureShader.setUniform(
                 "u_selectedFeature",
-                pickedObject._batchId
+                pickedObject.featureId
               );
             } else {
               selectFeatureShader.setUniform(

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ##### Additions :tada:
 
+- Added getters `Cesium3DTileFeature.featureId` and `ModelFeature.featureId` so the feature ID or batch ID can be accessed from a picked feature. [#10022](https://github.com/CesiumGS/cesium/pull/10022)
 - Added `I3dmLoader` to transcode .i3dm to `ModelExperimental`. [#9968](https://github.com/CesiumGS/cesium/pull/9968)
 - Added `PntsLoader` to transcode .pnts to `ModelExperimental`. [#9978](https://github.com/CesiumGS/cesium/pull/9978)
 - Added point cloud attenuation support to `ModelExperimental`. [#9998](https://github.com/CesiumGS/cesium/pull/9998)

--- a/Source/Scene/Cesium3DTileFeature.js
+++ b/Source/Scene/Cesium3DTileFeature.js
@@ -157,18 +157,18 @@ Object.defineProperties(Cesium3DTileFeature.prototype, {
    * Get the feature ID associated with this feature. For 3D Tiles 1.0, the
    * batch ID is returned. For EXT_mesh_features, this is the feature ID from
    * the selected feature ID set.
-   * 
+   *
    * @memberof Cesium3DTileFeature.prototype
-   * 
+   *
    * @type {Number}
-   * 
+   *
    * @readonly
    * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
   featureId: {
-    get: function() {
+    get: function () {
       return this._batchId;
-    }
+    },
   },
 
   /**

--- a/Source/Scene/Cesium3DTileFeature.js
+++ b/Source/Scene/Cesium3DTileFeature.js
@@ -154,6 +154,24 @@ Object.defineProperties(Cesium3DTileFeature.prototype, {
   },
 
   /**
+   * Get the feature ID associated with this feature. For 3D Tiles 1.0, the
+   * batch ID is returned. For EXT_mesh_features, this is the feature ID from
+   * the selected feature ID set.
+   * 
+   * @memberof Cesium3DTileFeature.prototype
+   * 
+   * @type {Number}
+   * 
+   * @readonly
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
+   */
+  featureId: {
+    get: function() {
+      return this._batchId;
+    }
+  },
+
+  /**
    * @private
    */
   pickId: {

--- a/Source/Scene/ModelExperimental/ModelFeature.js
+++ b/Source/Scene/ModelExperimental/ModelFeature.js
@@ -116,6 +116,24 @@ Object.defineProperties(ModelFeature.prototype, {
       return this._featureTable;
     },
   },
+
+  /**
+   * Get the feature ID associated with this feature. For 3D Tiles 1.0, the
+   * batch ID is returned. For EXT_mesh_features, this is the feature ID from
+   * the selected feature ID set.
+   * 
+   * @memberof ModelFeature.prototype
+   * 
+   * @type {Number}
+   * 
+   * @readonly
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
+   */
+   featureId: {
+    get: function() {
+      return this._featureId;
+    }
+  },
 });
 
 /**

--- a/Source/Scene/ModelExperimental/ModelFeature.js
+++ b/Source/Scene/ModelExperimental/ModelFeature.js
@@ -121,18 +121,18 @@ Object.defineProperties(ModelFeature.prototype, {
    * Get the feature ID associated with this feature. For 3D Tiles 1.0, the
    * batch ID is returned. For EXT_mesh_features, this is the feature ID from
    * the selected feature ID set.
-   * 
+   *
    * @memberof ModelFeature.prototype
-   * 
+   *
    * @type {Number}
-   * 
+   *
    * @readonly
    * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
-   featureId: {
-    get: function() {
+  featureId: {
+    get: function () {
       return this._featureId;
-    }
+    },
   },
 });
 

--- a/Specs/Scene/ModelExperimental/ModelExperimental3DTileContentSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimental3DTileContentSpec.js
@@ -130,6 +130,7 @@ describe("Scene/ModelExperimental/ModelExperimental3DTileContent", function () {
           expect(result).toBeDefined();
           expect(result.primitive).toBe(tileset);
           expect(result.content).toBe(content);
+          expect(result.featureId).toBeUndefined();
           expect(content.hasProperty(0, "id")).toBe(false);
           expect(content.getFeature(0)).toBeUndefined();
         });
@@ -149,8 +150,10 @@ describe("Scene/ModelExperimental/ModelExperimental3DTileContent", function () {
           expect(result).toBeDefined();
           expect(result.primitive).toBe(tileset);
           expect(result.content).toBe(content);
-          expect(content.hasProperty(0, "id")).toBe(false);
-          expect(content.getFeature(0)).toBeDefined();
+          var featureId = result.featureId;
+          expect(featureId).toBe(0);
+          expect(content.hasProperty(featureId, "id")).toBe(false);
+          expect(content.getFeature(featureId)).toBeDefined();
         });
       }
     );
@@ -167,9 +170,11 @@ describe("Scene/ModelExperimental/ModelExperimental3DTileContent", function () {
           expect(result).toBeDefined();
           expect(result.primitive).toBe(tileset);
           expect(result.content).toBe(content);
+          var featureId = result.featureId;
+          expect(featureId).toBe(0);
           expect(content.batchTable).toBeDefined();
-          expect(content.hasProperty(0, "id")).toBe(true);
-          expect(content.getFeature(0)).toBeDefined();
+          expect(content.hasProperty(featureId, "id")).toBe(true);
+          expect(content.getFeature(featureId)).toBeDefined();
         });
       }
     );
@@ -187,9 +192,11 @@ describe("Scene/ModelExperimental/ModelExperimental3DTileContent", function () {
           expect(result).toBeDefined();
           expect(result.primitive).toBe(tileset);
           expect(result.content).toBe(content);
+          var featureId = result.featureId;
+          expect(featureId).toBe(0);
           expect(content.batchTable).toBeDefined();
-          expect(content.hasProperty(0, "id")).toBe(true);
-          expect(content.getFeature(0)).toBeDefined();
+          expect(content.hasProperty(featureId, "id")).toBe(true);
+          expect(content.getFeature(featureId)).toBeDefined();
         });
       }
     );
@@ -213,8 +220,10 @@ describe("Scene/ModelExperimental/ModelExperimental3DTileContent", function () {
         expect(result).toBeDefined();
         expect(result.primitive).toBe(tileset);
         expect(result.content).toBe(content);
-        expect(content.hasProperty(0, "Height")).toBe(true);
-        expect(content.getFeature(0)).toBeDefined();
+        var featureId = result.featureId;
+        expect(featureId).toBe(12);
+        expect(content.hasProperty(featureId, "Height")).toBe(true);
+        expect(content.getFeature(featureId)).toBeDefined();
       });
     });
   });


### PR DESCRIPTION
This PR adds two getters:

* `Cesium3DTileFeature.featureId` (before this, it was only accessible through the private `pickedFeature._batchId`)
* `ModelFeature.featureId` (formally the private `pickedFeature._featureId`)

@lilleyse two questions on this one:

1. Right now I marked these as experimental in case we have better ideas of how to expose feature ID values to the public API. Do we want this experimental flag or is this a good addition to the public API?
1. I also realized it would be easy to expose `featuresLength` as well to get the total count of features in the `Cesium3DTileBatchTable`/`ModelFeatureTable`. Do we want this too?

[Updated photogrammetry classification sandcastle](http://localhost:8080/Apps/Sandcastle/index.html?src=3D%20Tiles%20Next%20Photogrammetry%20Classification.html&label=3D%20Tiles%20Next)