### PR TITLE
Fix regression in GltfLoader for handling Draco _BATCHID

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
 - Fixed an error when loading GeoJSON with null `stroke` or `fill` properties but valid opacity values. [#9717](https://github.com/CesiumGS/cesium/pull/9717)
 - Fixed `scene.pickTranslucentDepth` for translucent point clouds with eye dome lighting. [#9991](https://github.com/CesiumGS/cesium/pull/9991)
 - Added a setter for `tileset.pointCloudShading` that throws if set to `undefined` to clarify that this is disallowed. [#9998](https://github.com/CesiumGS/cesium/pull/9998)
-- Fixes handling .b3dm `_BATCHID` accessors in `ModelExperimental` [#10008](https://github.com/CesiumGS/cesium/pull/10008)
+- Fixes handling .b3dm `_BATCHID` accessors in `ModelExperimental` [#10008](https://github.com/CesiumGS/cesium/pull/10008) and [10031](https://github.com/CesiumGS/cesium/pull/10031)
 - Fixed path entity being drawn when data is unavailable [#1704](https://github.com/CesiumGS/cesium/pull/1704)
 
 ### 1.89 - 2022-01-03

--- a/Source/Scene/GltfLoader.js
+++ b/Source/Scene/GltfLoader.js
@@ -522,8 +522,16 @@ function loadAttribute(
 
   var name = gltfSemantic;
   var modelSemantic = semanticType.fromGltfSemantic(renamedSemantic);
-  var setIndex = defined(modelSemantic) ? getSetIndex(renamedSemantic) : undefined;
-  var attribute = createAttribute(gltf, accessorId, name, modelSemantic, setIndex);
+  var setIndex = defined(modelSemantic)
+    ? getSetIndex(renamedSemantic)
+    : undefined;
+  var attribute = createAttribute(
+    gltf,
+    accessorId,
+    name,
+    modelSemantic,
+    setIndex
+  );
 
   if (!defined(draco) && !defined(bufferViewId)) {
     return attribute;

--- a/Source/Scene/GltfLoader.js
+++ b/Source/Scene/GltfLoader.js
@@ -511,19 +511,19 @@ function loadAttribute(
   var bufferViewId = accessor.bufferView;
 
   // For .b3dm, rename _BATCHID (or the legacy BATCHID) to FEATURE_ID_0
-  // for compatibility with EXT_feature_metadata
+  // in the generated model components for compatibility with EXT_mesh_features
+  var renamedSemantic = gltfSemantic;
   if (
     loader._renameBatchIdSemantic &&
     (gltfSemantic === "_BATCHID" || gltfSemantic === "BATCHID")
   ) {
-    gltfSemantic = "FEATURE_ID_0";
+    renamedSemantic = "FEATURE_ID_0";
   }
 
   var name = gltfSemantic;
-  var semantic = semanticType.fromGltfSemantic(gltfSemantic);
-  var setIndex = defined(semantic) ? getSetIndex(gltfSemantic) : undefined;
-
-  var attribute = createAttribute(gltf, accessorId, name, semantic, setIndex);
+  var modelSemantic = semanticType.fromGltfSemantic(renamedSemantic);
+  var setIndex = defined(modelSemantic) ? getSetIndex(renamedSemantic) : undefined;
+  var attribute = createAttribute(gltf, accessorId, name, modelSemantic, setIndex);
 
   if (!defined(draco) && !defined(bufferViewId)) {
     return attribute;


### PR DESCRIPTION
While working on #10018, I noticed that [this Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html?src=Custom%20Shaders%203D%20Tiles.html&label=3D%20Tiles%20Next) was failing to load draco tiles.

I tracked it down, it was a regression in #10008. Only the `ModelComponents.Attribute.semantic` should be renamed, not the semantic for the vertex buffer loader.

@lilleyse could you review?