### PR TITLE
Fixes configuration name in launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "noDebug": true,
             "serverReadyAction":{
                 "action": "startDebugging",
-                "name": "Debug in Chrome",
+                "name": "Launch in Chrome",
                 "pattern": "Cesium development server running locally."
             }
         },


### PR DESCRIPTION
This PR fixes the name of the "Launch in Chrome" configuration that is triggered after the "Launch Server" configuration.