### PR TITLE
Build output should also use const

### DIFF
--- a/gulpfile.cjs
+++ b/gulpfile.cjs
@@ -1532,7 +1532,7 @@ export default "' +
 }
 
 function createCesiumJs() {
-  let contents = `export var VERSION = '${version}';\n`;
+  let contents = `export const VERSION = '${version}';\n`;
   globby.sync(sourceFiles).forEach(function (file) {
     file = path.relative("Source", file);
 


### PR DESCRIPTION
Follow up from https://github.com/CesiumGS/cesium/pull/10026. The build output should generate code compliant with our new eslint rules.

Thanks for catching this @ptrgags! Could you please review? 

Since nothing else was merged since, I can update the tag so that this, once merged, is included as part of the other let/const changes as part of the merge instructions.