### PR TITLE
Add ModelAnimation.startOffset

### DIFF
--- a/Source/Scene/ModelAnimation.js
+++ b/Source/Scene/ModelAnimation.js
@@ -38,6 +38,7 @@ function ModelAnimation(options, model, runtimeAnimation) {
   this._multiplier = defaultValue(options.multiplier, 1.0);
   this._reverse = defaultValue(options.reverse, false);
   this._loop = defaultValue(options.loop, ModelAnimationLoop.NONE);
+  this._startOffset = defaultValue(options.startOffset, 0.0);
 
   /**
    * The event fired when this animation is started.  This can be used, for
@@ -227,6 +228,32 @@ Object.defineProperties(ModelAnimation.prototype, {
   loop: {
     get: function () {
       return this._loop;
+    },
+  },
+
+  /**
+   * Fractional offset [0..1] in to animations timeline, to start playing
+   * animation at.
+   * When used with {@link ModelAnimation#startTime} and
+   * {@link ModelAnimation#stopTime}, this allows an animation to effectively be
+   * paused and then resumed.
+   * When {@link ModelAnimation#reverse} is <code>false</code>, a value of 0
+   * will start the animaton at the beginning, whereas a value of 0.25 will
+   * start the animation 25% of the way through.
+   * When {@link ModelAnimation#reverse} is <code>true</code>, 0 corresponds to
+   * the end of the animation. So if you wish to play the first 25% of the
+   * animation in reverse, this should be set to 0.75.
+   *
+   * @memberof ModelAnimation.prototype
+   *
+   * @type {Number}
+   * @readonly
+   *
+   * @default 0
+   */
+  startOffset: {
+    get: function () {
+      return this._startOffset;
     },
   },
 });

--- a/Source/Scene/ModelAnimationCollection.js
+++ b/Source/Scene/ModelAnimationCollection.js
@@ -92,6 +92,7 @@ function add(collection, index, options) {
  * @param {Boolean} [options.removeOnStop=false] When <code>true</code>, the animation is removed after it stops playing.
  * @param {Number} [options.multiplier=1.0] Values greater than <code>1.0</code> increase the speed that the animation is played relative to the scene clock speed; values less than <code>1.0</code> decrease the speed.
  * @param {Boolean} [options.reverse=false] When <code>true</code>, the animation is played in reverse.
+ * @param {Number} [options.startOffset=0.0] Fractional offset in to animations timeline, to start playing animation at.
  * @param {ModelAnimationLoop} [options.loop=ModelAnimationLoop.NONE] Determines if and how the animation is looped.
  * @returns {ModelAnimation} The animation that was added to the collection.
  *
@@ -450,11 +451,14 @@ ModelAnimationCollection.prototype.update = function (frameState) {
         delta = floor % 2 === 1.0 ? 1.0 - fract : fract;
       }
 
+      let startDelta = scheduledAnimation.startOffset;
       if (scheduledAnimation.reverse) {
         delta = 1.0 - delta;
+        startDelta = -startDelta;
       }
 
-      let localAnimationTime = delta * duration * scheduledAnimation.multiplier;
+      let localAnimationTime =
+        delta * duration * scheduledAnimation.multiplier + startDelta;
       // Clamp in case floating-point roundoff goes outside the animation's first or last keyframe
       localAnimationTime = CesiumMath.clamp(
         localAnimationTime,


### PR DESCRIPTION
As per #10042, this PR adds ModelAnimation.startOffset, which allows specifying at what point an animation starts playing from.
