### PR TITLE
Particle System Sandcastle ES6 Update

### DIFF
--- a/Apps/Sandcastle/gallery/Particle System Weather.html
+++ b/Apps/Sandcastle/gallery/Particle System Weather.html
@@ -34,7 +34,6 @@
     <script id="cesium_sandcastle_script">
       function startup(Cesium) {
         "use strict";
-        /* eslint-disable prefer-const */
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
           shouldAnimate: true,

--- a/Apps/Sandcastle/gallery/Particle System Weather.html
+++ b/Apps/Sandcastle/gallery/Particle System Weather.html
@@ -68,10 +68,8 @@
           snowParticleSize * 2.0,
           snowParticleSize * 2.0
         );
-        let snowSystem;
-
-        let snowGravityScratch = new Cesium.Cartesian3();
         const snowUpdate = function (particle, dt) {
+          let snowGravityScratch = new Cesium.Cartesian3();
           snowGravityScratch = Cesium.Cartesian3.normalize(
             particle.position,
             snowGravityScratch
@@ -86,7 +84,6 @@
             snowGravityScratch,
             particle.velocity
           );
-
           const distance = Cesium.Cartesian3.distance(
             scene.camera.position,
             particle.position
@@ -99,7 +96,7 @@
           }
         };
 
-        snowSystem = new Cesium.ParticleSystem({
+        const snowSystem = new Cesium.ParticleSystem({
           modelMatrix: new Cesium.Matrix4.fromTranslation(
             scene.camera.position
           ),

--- a/Apps/Sandcastle/gallery/Particle System Weather.html
+++ b/Apps/Sandcastle/gallery/Particle System Weather.html
@@ -91,7 +91,7 @@
             particle.endColor.alpha = 0.0;
           } else {
             particle.endColor.alpha =
-              Cesium.Color.WHITE.withAlpha(1.0).alpha /
+              1.0 /
               (distance / snowRadius + 0.1);
           }
         };

--- a/Apps/Sandcastle/gallery/Particle System Weather.html
+++ b/Apps/Sandcastle/gallery/Particle System Weather.html
@@ -124,10 +124,8 @@
           rainParticleSize * 2.0
         );
 
-        let rainSystem;
-
-        let rainGravityScratch = new Cesium.Cartesian3();
         const rainUpdate = function (particle, dt) {
+          let rainGravityScratch = new Cesium.Cartesian3();
           rainGravityScratch = Cesium.Cartesian3.normalize(
             particle.position,
             rainGravityScratch
@@ -156,7 +154,7 @@
           }
         };
 
-        rainSystem = new Cesium.ParticleSystem({
+        const rainSystem = new Cesium.ParticleSystem({
           modelMatrix: new Cesium.Matrix4.fromTranslation(
             scene.camera.position
           ),

--- a/Apps/Sandcastle/gallery/Particle System Weather.html
+++ b/Apps/Sandcastle/gallery/Particle System Weather.html
@@ -91,29 +91,10 @@
             particle.endColor.alpha = 0.0;
           } else {
             particle.endColor.alpha =
-              snowSystem.endColor.alpha / (distance / snowRadius + 0.1);
+              Cesium.Color.WHITE.withAlpha(1.0).alpha /
+              (distance / snowRadius + 0.1);
           }
         };
-
-        const snowSystem = new Cesium.ParticleSystem({
-          modelMatrix: new Cesium.Matrix4.fromTranslation(
-            scene.camera.position
-          ),
-          minimumSpeed: -1.0,
-          maximumSpeed: 0.0,
-          lifetime: 15.0,
-          emitter: new Cesium.SphereEmitter(snowRadius),
-          startScale: 0.5,
-          endScale: 1.0,
-          image: "../../SampleData/snowflake_particle.png",
-          emissionRate: 7000.0,
-          startColor: Cesium.Color.WHITE.withAlpha(0.0),
-          endColor: Cesium.Color.WHITE.withAlpha(1.0),
-          minimumImageSize: minimumSnowImageSize,
-          maximumImageSize: maximumSnowImageSize,
-          updateCallback: snowUpdate,
-        });
-        scene.primitives.add(snowSystem);
 
         // rain
         const rainParticleSize = 15.0;
@@ -122,7 +103,6 @@
           rainParticleSize,
           rainParticleSize * 2.0
         );
-
         const rainUpdate = function (particle, dt) {
           let rainGravityScratch = new Cesium.Cartesian3();
           rainGravityScratch = Cesium.Cartesian3.normalize(
@@ -149,27 +129,9 @@
             particle.endColor.alpha = 0.0;
           } else {
             particle.endColor.alpha =
-              rainSystem.endColor.alpha / (distance / rainRadius + 0.1);
+              Cesium.Color.BLUE.alpha / (distance / rainRadius + 0.1);
           }
         };
-
-        const rainSystem = new Cesium.ParticleSystem({
-          modelMatrix: new Cesium.Matrix4.fromTranslation(
-            scene.camera.position
-          ),
-          speed: -1.0,
-          lifetime: 15.0,
-          emitter: new Cesium.SphereEmitter(rainRadius),
-          startScale: 1.0,
-          endScale: 0.0,
-          image: "../../SampleData/circular_particle.png",
-          emissionRate: 9000.0,
-          startColor: new Cesium.Color(0.27, 0.5, 0.7, 0.0),
-          endColor: new Cesium.Color(0.27, 0.5, 0.7, 0.98),
-          imageSize: rainImageSize,
-          updateCallback: rainUpdate,
-        });
-        scene.primitives.add(rainSystem);
 
         // button
         Sandcastle.addToolbarButton("Reset Camera", resetCameraFunction);
@@ -179,13 +141,31 @@
           {
             text: "Snow",
             onselect: function () {
-              rainSystem.show = false;
-              snowSystem.show = true;
+              scene.primitives.removeAll();
+              scene.primitives.add(
+                new Cesium.ParticleSystem({
+                  modelMatrix: new Cesium.Matrix4.fromTranslation(
+                    scene.camera.position
+                  ),
+                  minimumSpeed: -1.0,
+                  maximumSpeed: 0.0,
+                  lifetime: 15.0,
+                  emitter: new Cesium.SphereEmitter(snowRadius),
+                  startScale: 0.5,
+                  endScale: 1.0,
+                  image: "../../SampleData/snowflake_particle.png",
+                  emissionRate: 7000.0,
+                  startColor: Cesium.Color.WHITE.withAlpha(0.0),
+                  endColor: Cesium.Color.WHITE.withAlpha(1.0),
+                  minimumImageSize: minimumSnowImageSize,
+                  maximumImageSize: maximumSnowImageSize,
+                  updateCallback: snowUpdate,
+                })
+              );
 
               scene.skyAtmosphere.hueShift = -0.8;
               scene.skyAtmosphere.saturationShift = -0.7;
               scene.skyAtmosphere.brightnessShift = -0.33;
-
               scene.fog.density = 0.001;
               scene.fog.minimumBrightness = 0.8;
             },
@@ -193,13 +173,29 @@
           {
             text: "Rain",
             onselect: function () {
-              rainSystem.show = true;
-              snowSystem.show = false;
+              scene.primitives.removeAll();
+              scene.primitives.add(
+                new Cesium.ParticleSystem({
+                  modelMatrix: new Cesium.Matrix4.fromTranslation(
+                    scene.camera.position
+                  ),
+                  speed: -1.0,
+                  lifetime: 15.0,
+                  emitter: new Cesium.SphereEmitter(rainRadius),
+                  startScale: 1.0,
+                  endScale: 0.0,
+                  image: "../../SampleData/circular_particle.png",
+                  emissionRate: 9000.0,
+                  startColor: new Cesium.Color(0.27, 0.5, 0.7, 0.0),
+                  endColor: new Cesium.Color(0.27, 0.5, 0.7, 0.98),
+                  imageSize: rainImageSize,
+                  updateCallback: rainUpdate,
+                })
+              );
 
               scene.skyAtmosphere.hueShift = -0.97;
               scene.skyAtmosphere.saturationShift = 0.25;
               scene.skyAtmosphere.brightnessShift = -0.4;
-
               scene.fog.density = 0.00025;
               scene.fog.minimumBrightness = 0.01;
             },

--- a/Apps/Sandcastle/gallery/Particle System Weather.html
+++ b/Apps/Sandcastle/gallery/Particle System Weather.html
@@ -101,8 +101,8 @@
           rainParticleSize,
           rainParticleSize * 2.0
         );
+        let rainGravityScratch = new Cesium.Cartesian3();
         const rainUpdate = function (particle, dt) {
-          let rainGravityScratch = new Cesium.Cartesian3();
           rainGravityScratch = Cesium.Cartesian3.normalize(
             particle.position,
             rainGravityScratch

--- a/Apps/Sandcastle/gallery/Particle System Weather.html
+++ b/Apps/Sandcastle/gallery/Particle System Weather.html
@@ -67,8 +67,8 @@
           snowParticleSize * 2.0,
           snowParticleSize * 2.0
         );
+        let snowGravityScratch = new Cesium.Cartesian3();
         const snowUpdate = function (particle, dt) {
-          let snowGravityScratch = new Cesium.Cartesian3();
           snowGravityScratch = Cesium.Cartesian3.normalize(
             particle.position,
             snowGravityScratch
@@ -90,9 +90,7 @@
           if (distance > snowRadius) {
             particle.endColor.alpha = 0.0;
           } else {
-            particle.endColor.alpha =
-              1.0 /
-              (distance / snowRadius + 0.1);
+            particle.endColor.alpha = 1.0 / (distance / snowRadius + 0.1);
           }
         };
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
 - Fixed path entity being drawn when data is unavailable [#1704](https://github.com/CesiumGS/cesium/pull/1704)
 - Fixed setting `tileset.imageBasedLightingFactor` has no effect on i3dm tile content. [#10020](https://github.com/CesiumGS/cesium/pull/10020)
 - Zooming out is no longer sluggish when close to `screenSpaceCameraController.minimumDistance`. [#9932](https://github.com/CesiumGS/cesium/pull/9932)
+- Fixed Particle System Weather sandcastle demo to work with new ES6 rules. [#10045](https://github.com/CesiumGS/cesium/pull/10045)
 
 ### 1.89 - 2022-01-03
 


### PR DESCRIPTION
Fixes #10038

The goal of this pull request is to re-work the Particle System Weather sandcastle demo such that it is functional when the `prefer-const` ES6 rule is enabled.

My initial commits have made the following changes:
- Removed the line disabling one of our global ES6 rules: `/* eslint-disable prefer-const */`
- Updated where `snowGravityScratch` and `rainGravityScratch` are declared.
- Removed the `snowSystem` and `rainSystem` variables.
- In the original implementation, both the `snowSystem` and the `rainSystem` objects were added to the scene as primitives. Their visibility was toggled using the `show`. I suspect that this may have caused performance issues. I added a commit that ensures that only the necessary primitives are kept in the scene.

I am now able to run the Particle System Weather demo locally without the line:
`/* eslint-disable prefer-const */`

It has been mentioned various times that the [current code](https://sandcastle.cesium.com/?src=Particle%20System%20Weather.html) is not well structured. As seen above, I made various edits. The biggest thing that stood out to me was how primitives were handled. However, if there is anything specific that still needs to be reworked, I would be happy to take a look at it.