### PR TITLE
Use ES6 template literals instead of string concatenation

### DIFF
--- a/Apps/CesiumViewer/CesiumViewer.js
+++ b/Apps/CesiumViewer/CesiumViewer.js
@@ -83,7 +83,7 @@ function main() {
   }
 
   const showLoadError = function (name, error) {
-    const title = "An error occurred while loading the file: " + name;
+    const title = `An error occurred while loading the file: ${name}`;
     const message =
       "An error occurred while loading the file, which may indicate that it is invalid.  A detailed error report is below:";
     viewer.cesiumWidget.showErrorPanel(title, message, error);
@@ -146,10 +146,7 @@ function main() {
             if (defined(entity)) {
               viewer.trackedEntity = entity;
             } else {
-              const error =
-                'No entity with id "' +
-                lookAt +
-                '" exists in the provided data source.';
+              const error = `No entity with id "${lookAt}" exists in the provided data source.`;
               showLoadError(source, error);
             }
           } else if (!defined(view) && endUserOptions.flyTo !== "false") {
@@ -172,7 +169,7 @@ function main() {
       document.body.classList.add("cesium-lighter");
       viewer.animation.applyThemeChanges();
     } else {
-      const error = "Unknown theme: " + theme;
+      const error = `Unknown theme: ${theme}`;
       viewer.cesiumWidget.showErrorPanel(error, "");
     }
   }
@@ -215,22 +212,14 @@ function main() {
     const position = camera.positionCartographic;
     let hpr = "";
     if (defined(camera.heading)) {
-      hpr =
-        "," +
-        CesiumMath.toDegrees(camera.heading) +
-        "," +
-        CesiumMath.toDegrees(camera.pitch) +
-        "," +
-        CesiumMath.toDegrees(camera.roll);
+      hpr = `,${CesiumMath.toDegrees(camera.heading)},${CesiumMath.toDegrees(
+        camera.pitch
+      )},${CesiumMath.toDegrees(camera.roll)}`;
     }
-    endUserOptions.view =
-      CesiumMath.toDegrees(position.longitude) +
-      "," +
-      CesiumMath.toDegrees(position.latitude) +
-      "," +
-      position.height +
-      hpr;
-    history.replaceState(undefined, "", "?" + objectToQuery(endUserOptions));
+    endUserOptions.view = `${CesiumMath.toDegrees(
+      position.longitude
+    )},${CesiumMath.toDegrees(position.latitude)},${position.height}${hpr}`;
+    history.replaceState(undefined, "", `?${objectToQuery(endUserOptions)}`);
   }
 
   let timeout;

--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -121,7 +121,7 @@ require({
   function appendConsole(className, message, showConsole) {
     const ele = document.createElement("span");
     ele.className = className;
-    ele.textContent = message + "\n";
+    ele.textContent = `${message}\n`;
     logOutput.appendChild(ele);
     logOutput.parentNode.scrollTop =
       logOutput.clientHeight + 8 - logOutput.parentNode.clientHeight;
@@ -131,7 +131,7 @@ require({
       ++numberOfNewConsoleMessages;
       registry
         .byId("logContainer")
-        .set("title", "Console (" + numberOfNewConsoleMessages + ")");
+        .set("title", `Console (${numberOfNewConsoleMessages})`);
     }
   }
 
@@ -245,7 +245,7 @@ require({
       docTabs[title] = new ContentPane({
         title: title,
         focused: true,
-        content: '<iframe class="fullFrame" src="' + link + '"></iframe>',
+        content: `<iframe class="fullFrame" src="${link}"></iframe>`,
         closable: true,
         onClose: function () {
           docTabs[this.title] = undefined;
@@ -294,12 +294,12 @@ require({
           .replace("module-", "")
           .replace("#.", ".")
           .replace("#", ".");
-        ele.href = "../../Build/Documentation/" + member;
+        ele.href = `../../Build/Documentation/${member}`;
         ele.onclick = onDocClick;
         docMessage.appendChild(ele);
       }
       jsEditor.addWidget(jsEditor.getCursor(true), docNode);
-      docNode.style.top = parseInt(docNode.style.top, 10) - 5 + "px";
+      docNode.style.top = `${parseInt(docNode.style.top, 10) - 5}px`;
     }
   }
 
@@ -340,7 +340,7 @@ require({
 
     const selectedTabName = registry.byId("innerPanel").selectedChildWidget
       .title;
-    let suffix = selectedTabName + "Demos";
+    let suffix = `${selectedTabName}Demos`;
     if (selectedTabName === "All") {
       suffix = "all";
     } else if (selectedTabName === "Search Results") {
@@ -397,7 +397,7 @@ require({
           line = jsEditor.setGutterMarker(
             i,
             "searchGutter",
-            makeLineLabel("Search: " + searchTerm, "searchMarker")
+            makeLineLabel(`Search: ${searchTerm}`, "searchMarker")
           );
           jsEditor.addLineClass(line, "text", "searchLine");
           errorLines.push(line);
@@ -624,7 +624,7 @@ require({
 
     const onScriptTagError = function () {
       if (bucketFrame.contentDocument === bucketDoc) {
-        appendConsole("consoleError", "Error loading " + this.src, true);
+        appendConsole("consoleError", `Error loading ${this.src}`, true);
         appendConsole(
           "consoleError",
           "Make sure Cesium is built, see the Contributor's Guide for details.",
@@ -698,9 +698,7 @@ require({
       ) {
         appendConsole(
           "consoleError",
-          "Error, first part of " +
-            local.bucketName +
-            " must match first part of bucket.html exactly.",
+          `Error, first part of ${local.bucketName} must match first part of bucket.html exactly.`,
           true
         );
       } else {
@@ -760,7 +758,7 @@ require({
           '<html><head></head><body data-sandcastle-bucket-loaded="no">';
         xhr
           .get({
-            url: "templates/" + bucketName,
+            url: `templates/${bucketName}`,
             handleAs: "text",
           })
           .then(function (value) {
@@ -781,7 +779,7 @@ require({
     queryObject = ioQuery.queryToObject(window.location.search.substring(1));
   }
   if (!defined(queryObject.src)) {
-    queryObject.src = defaultDemo + ".html";
+    queryObject.src = `${defaultDemo}.html`;
   }
   if (!defined(queryObject.label)) {
     queryObject.label = defaultLabel;
@@ -789,7 +787,7 @@ require({
 
   function loadFromGallery(demo) {
     deferredLoadError = false;
-    document.getElementById("saveAsFile").download = demo.name + ".html";
+    document.getElementById("saveAsFile").download = `${demo.name}.html`;
     registry
       .byId("description")
       .set("value", decodeHTML(demo.description).replace(/\\n/g, "\n"));
@@ -818,7 +816,7 @@ require({
       let json, code, html;
       if (defined(queryObject.gist)) {
         dojoscript
-          .get("https://api.github.com/gists/" + queryObject.gist, {
+          .get(`https://api.github.com/gists/${queryObject.gist}`, {
             jsonp: "callback",
           })
           .then(function (data) {
@@ -831,8 +829,7 @@ require({
           .otherwise(function (error) {
             appendConsole(
               "consoleError",
-              "Unable to GET gist from GitHub API. This could be due to too many requests from your IP. Try again in an hour or copy and paste the code from the gist: https://gist.github.com/" +
-                queryObject.gist,
+              `Unable to GET gist from GitHub API. This could be due to too many requests from your IP. Try again in an hour or copy and paste the code from the gist: https://gist.github.com/${queryObject.gist}`,
               true
             );
             console.log(error);
@@ -861,7 +858,7 @@ require({
         if (!script) {
           appendConsole(
             "consoleError",
-            "Error reading source file: " + demo.name,
+            `Error reading source file: ${demo.name}`,
             true
           );
           return;
@@ -871,7 +868,7 @@ require({
         if (!scriptMatch) {
           appendConsole(
             "consoleError",
-            "Error reading source file: " + demo.name,
+            `Error reading source file: ${demo.name}`,
             true
           );
           return;
@@ -905,7 +902,7 @@ require({
     function (e) {
       if (e.state && e.state.name && e.state.code) {
         loadFromGallery(e.state);
-        document.title = e.state.name + " - Cesium Sandcastle";
+        document.title = `${e.state.name} - Cesium Sandcastle`;
       }
     },
     false
@@ -949,9 +946,10 @@ require({
           if (deferredLoadError) {
             appendConsole(
               "consoleLog",
-              "Unable to load demo named " +
-                queryObject.src.replace(".html", "") +
-                ". Redirecting to HelloWorld.\n",
+              `Unable to load demo named ${queryObject.src.replace(
+                ".html",
+                ""
+              )}. Redirecting to HelloWorld.\n`,
               true
             );
           }
@@ -967,10 +965,10 @@ require({
           errorMsg += " (on line ";
 
           if (e.data.url) {
-            errorMsg += lineNumber + " of " + e.data.url + ")";
+            errorMsg += `${lineNumber} of ${e.data.url})`;
           } else {
             lineNumber = scriptLineToEditorLine(lineNumber);
-            errorMsg += lineNumber + 1 + ")";
+            errorMsg += `${lineNumber + 1})`;
             line = jsEditor.setGutterMarker(
               lineNumber,
               "errorGutter",
@@ -1015,11 +1013,11 @@ require({
         const demo = gallery_demos[i];
         const demoName = demo.name;
         if (searchRegExp.test(demoName) || searchRegExp.test(demo.code)) {
-          document.getElementById(demoName + "searchDemo").style.display =
+          document.getElementById(`${demoName}searchDemo`).style.display =
             "inline-block";
           ++numDemosShown;
         } else {
-          document.getElementById(demoName + "searchDemo").style.display =
+          document.getElementById(`${demoName}searchDemo`).style.display =
             "none";
         }
       }
@@ -1055,7 +1053,7 @@ require({
 
   function getBaseUrl() {
     // omits query string and hash
-    return location.protocol + "//" + location.host + location.pathname;
+    return `${location.protocol}//${location.host}${location.pathname}`;
   }
 
   function makeCompressedBase64String(data) {
@@ -1079,7 +1077,7 @@ require({
     const base64String = makeCompressedBase64String([code, html]);
 
     const shareUrlBox = document.getElementById("shareUrl");
-    shareUrlBox.value = getBaseUrl() + "#c=" + base64String;
+    shareUrlBox.value = `${getBaseUrl()}#c=${base64String}`;
     shareUrlBox.select();
   });
 
@@ -1090,19 +1088,19 @@ require({
     if (gistIndex !== -1) {
       gistId = gistId.substring(gistIndex + gistParameter.length);
     }
-    window.location.href = getBaseUrl() + "?gist=" + gistId;
+    window.location.href = `${getBaseUrl()}?gist=${gistId}`;
   });
 
   function getPushStateUrl(demo) {
     const obj = {};
     if (demo.name !== defaultDemo) {
-      obj.src = demo.name + ".html";
+      obj.src = `${demo.name}.html`;
     }
     if (currentTab !== defaultLabel) {
       obj.label = currentTab;
     }
     const query = ioQuery.objectToQuery(obj);
-    return query === "" ? query : "?" + query;
+    return query === "" ? query : `?${query}`;
   }
 
   registry.byId("buttonNew").on("click", function () {
@@ -1117,7 +1115,7 @@ require({
     if (confirmChange) {
       window.history.pushState(newDemo, newDemo.name, getPushStateUrl(newDemo));
       loadFromGallery(newDemo).then(function () {
-        document.title = newDemo.name + " - Cesium Sandcastle";
+        document.title = `${newDemo.name} - Cesium Sandcastle`;
       });
     }
   });
@@ -1132,14 +1130,14 @@ require({
 
   function getDemoHtml() {
     return (
-      local.headers +
-      "\n" +
-      htmlEditor.getValue() +
-      '<script id="cesium_sandcastle_script">\n' +
-      embedInSandcastleTemplate(jsEditor.getValue(), false) +
-      "</script>\n" +
-      "</body>\n" +
-      "</html>\n"
+      `${
+        local.headers
+      }\n${htmlEditor.getValue()}<script id="cesium_sandcastle_script">\n${embedInSandcastleTemplate(
+        jsEditor.getValue(),
+        false
+      )}</script>\n` +
+      `</body>\n` +
+      `</html>\n`
     );
   }
 
@@ -1156,13 +1154,11 @@ require({
     let html = getDemoHtml();
     html = html.replace(
       "<title>",
-      '<meta name="description" content="' + description + '">\n    <title>'
+      `<meta name="description" content="${description}">\n    <title>`
     );
     html = html.replace(
       "<title>",
-      '<meta name="cesium-sandcastle-labels" content="' +
-        label +
-        '">\n    <title>'
+      `<meta name="cesium-sandcastle-labels" content="${label}">\n    <title>`
     );
 
     const octetBlob = new Blob([html], {
@@ -1178,14 +1174,14 @@ require({
     //the demo's HTML to add a base href.
     let baseHref = getBaseUrl();
     const pos = baseHref.lastIndexOf("/");
-    baseHref = baseHref.substring(0, pos) + "/gallery/";
+    baseHref = `${baseHref.substring(0, pos)}/gallery/`;
 
     const code = jsEditor.getValue();
     const html = htmlEditor.getValue();
     const data = makeCompressedBase64String([code, html, baseHref]);
 
     let url = getBaseUrl();
-    url = url.replace("index.html", "") + "standalone.html" + "#c=" + data;
+    url = `${url.replace("index.html", "")}standalone.html` + `#c=${data}`;
 
     window.open(url, "_blank");
     window.focus();
@@ -1213,14 +1209,14 @@ require({
       demoTileHeightRule.style.display = "none";
     } else {
       demoTileHeightRule.style.display = "inline";
-      demoTileHeightRule.style.height = Math.min(newSize, 150) + "px";
+      demoTileHeightRule.style.height = `${Math.min(newSize, 150)}px`;
     }
     this.originalResize(changeSize, resultSize);
   };
 
   function requestDemo(name) {
     return xhr.get({
-      url: "gallery/" + name + ".html",
+      url: `gallery/${name}.html`,
       handleAs: "text",
       error: function (error) {
         loadFromGallery(gallery_demos[hello_world_index]).then(function () {
@@ -1230,7 +1226,7 @@ require({
     });
   }
 
-  const newInLabel = "New in " + VERSION;
+  const newInLabel = `New in ${VERSION}`;
   function loadDemoFromFile(demo) {
     return requestDemo(demo.name).then(function (value) {
       // Store the file contents for later searching.
@@ -1252,7 +1248,7 @@ require({
       );
       const labels = labelsMeta && labelsMeta.getAttribute("content");
       if (demo.isNew) {
-        demo.label = labels ? labels + "," + newInLabel : newInLabel;
+        demo.label = labels ? `${labels},${newInLabel}` : newInLabel;
       } else {
         demo.label = labels ? labels : "";
       }
@@ -1265,7 +1261,7 @@ require({
             if (defined(queryObject.gist)) {
               document.title = "Gist Import - Cesium Sandcastle";
             } else {
-              document.title = demo.name + " - Cesium Sandcastle";
+              document.title = `${demo.name} - Cesium Sandcastle`;
             }
           });
         }
@@ -1273,7 +1269,7 @@ require({
 
       // Create a tooltip containing the demo's description.
       demoTooltips[demo.name] = new TooltipDialog({
-        id: demo.name + "TooltipDialog",
+        id: `${demo.name}TooltipDialog`,
         style: "width: 200px; font-size: 12px;",
         content: demo.description.replace(/\\n/g, "<br/>"),
       });
@@ -1323,21 +1319,16 @@ require({
       for (let j = 0; j < labels.length; j++) {
         let label = labels[j];
         label = label.trim();
-        if (!dom.byId(label + "Demos")) {
+        if (!dom.byId(`${label}Demos`)) {
           const cp = new ContentPane({
-            content:
-              '<div id="' +
-              label +
-              'Container" class="demosContainer"><div class="demos" id="' +
-              label +
-              'Demos"></div></div>',
+            content: `<div id="${label}Container" class="demosContainer"><div class="demos" id="${label}Demos"></div></div>`,
             title: label,
             onShow: onShowCallback(),
           }).placeAt("innerPanel");
           subtabs[label] = cp;
-          registerScroll(dom.byId(label + "Container"));
+          registerScroll(dom.byId(`${label}Container`));
         }
-        const tabName = label + "Demos";
+        const tabName = `${label}Demos`;
         const tab = dom.byId(tabName);
         insertSortedById(tab, createGalleryButton(demo, tabName));
       }
@@ -1347,20 +1338,20 @@ require({
   function createGalleryButton(demo, tabName) {
     let imgSrc = "templates/Gallery_tile.jpg";
     if (defined(demo.img)) {
-      imgSrc = "gallery/" + demo.img;
+      imgSrc = `gallery/${demo.img}`;
     }
 
     const demoLink = document.createElement("a");
     demoLink.id = demo.name + tabName;
     demoLink.className = "linkButton";
-    demoLink.href = "gallery/" + encodeURIComponent(demo.name) + ".html";
+    demoLink.href = `gallery/${encodeURIComponent(demo.name)}.html`;
 
     if (demo.name === "Hello World") {
       newDemo = demo;
     }
     demoLink.onclick = function (e) {
       if (mouse.isMiddle(e)) {
-        window.open("gallery/" + demo.name + ".html");
+        window.open(`gallery/${demo.name}.html`);
       } else {
         const htmlText = htmlEditor.getValue().replace(/\s/g, "");
         const jsText = jsEditor.getValue().replace(/\s/g, "");
@@ -1376,7 +1367,7 @@ require({
 
           window.history.pushState(demo, demo.name, getPushStateUrl(demo));
           loadFromGallery(demo).then(function () {
-            document.title = demo.name + " - Cesium Sandcastle";
+            document.title = `${demo.name} - Cesium Sandcastle`;
           });
         }
       }
@@ -1385,12 +1376,8 @@ require({
 
     new LinkButton({
       label:
-        '<div class="demoTileTitle">' +
-        demo.name +
-        "</div>" +
-        '<img src="' +
-        imgSrc +
-        '" class="demoTileThumbnail" alt="" onDragStart="return false;" />',
+        `<div class="demoTileTitle">${demo.name}</div>` +
+        `<img src="${imgSrc}" class="demoTileThumbnail" alt="" onDragStart="return false;" />`,
     }).placeAt(demoLink);
 
     on(demoLink, "mouseover", function () {
@@ -1423,20 +1410,15 @@ require({
     registerScroll(dom.byId("showcasesContainer"));
 
     if (has_new_gallery_demos) {
-      const name = "New in " + VERSION;
+      const name = `New in ${VERSION}`;
       subtabs[name] = new ContentPane({
-        content:
-          '<div id="' +
-          name +
-          'Container" class="demosContainer"><div class="demos" id="' +
-          name +
-          'Demos"></div></div>',
+        content: `<div id="${name}Container" class="demosContainer"><div class="demos" id="${name}Demos"></div></div>`,
         title: name,
         onShow: function () {
           setSubtab(this.title);
         },
       }).placeAt("innerPanel");
-      registerScroll(dom.byId(name + "Container"));
+      registerScroll(dom.byId(`${name}Container`));
     }
 
     let i;

--- a/Apps/Sandcastle/Sandcastle-client.js
+++ b/Apps/Sandcastle/Sandcastle-client.js
@@ -112,7 +112,7 @@
         // Change lineNumber to the local one for highlighting.
         /*eslint-disable no-empty*/
         try {
-          let pos = errorMsg.indexOf(Sandcastle.bucket + ":");
+          let pos = errorMsg.indexOf(`${Sandcastle.bucket}:`);
           if (pos < 0) {
             pos = errorMsg.indexOf("<anonymous>");
           }
@@ -154,7 +154,7 @@
       } catch (ex) {
         stack = ex.stack.toString();
       }
-      let needle = Sandcastle.bucket + ":"; // Firefox
+      let needle = `${Sandcastle.bucket}:`; // Firefox
       let pos = stack.indexOf(needle);
       if (pos < 0) {
         needle = " (<anonymous>:"; // Chrome

--- a/Apps/Sandcastle/Sandcastle-helpers.js
+++ b/Apps/Sandcastle/Sandcastle-helpers.js
@@ -3,18 +3,17 @@
 
   window.embedInSandcastleTemplate = function (code, addExtraLine) {
     return (
-      "function startup(Cesium) {\n" +
-      "    'use strict';\n" +
-      "//Sandcastle_Begin\n" +
-      (addExtraLine ? "\n" : "") +
-      code +
-      "//Sandcastle_End\n" +
-      "    Sandcastle.finishedLoading();\n" +
-      "}\n" +
-      "if (typeof Cesium !== 'undefined') {\n" +
-      "    window.startupCalled = true;\n" +
-      "    startup(Cesium);\n" +
-      "}\n"
+      `${
+        "function startup(Cesium) {\n" +
+        "    'use strict';\n" +
+        "//Sandcastle_Begin\n"
+      }${addExtraLine ? "\n" : ""}${code}//Sandcastle_End\n` +
+      `    Sandcastle.finishedLoading();\n` +
+      `}\n` +
+      `if (typeof Cesium !== 'undefined') {\n` +
+      `    window.startupCalled = true;\n` +
+      `    startup(Cesium);\n` +
+      `}\n`
     );
   };
   window.decodeBase64Data = function (base64String, pako) {
@@ -29,7 +28,7 @@
       to: "string",
     });
     // we save a few bytes by omitting the leading [" and trailing "] since they are always the same
-    jsonString = '["' + jsonString + '"]';
+    jsonString = `["${jsonString}"]`;
     const json = JSON.parse(jsonString);
     // index 0 is code, index 1 is html
     const code = json[0];

--- a/Apps/Sandcastle/gallery/3D Tiles Batch Table Hierarchy.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Batch Table Hierarchy.html
@@ -192,14 +192,14 @@
           if (!Cesium.defined(feature)) {
             return;
           }
-          console.log("Class: " + feature.getExactClassName());
+          console.log(`Class: ${feature.getExactClassName()}`);
           console.log("Properties:");
           const propertyNames = feature.getPropertyNames();
           const length = propertyNames.length;
           for (let i = 0; i < length; ++i) {
             const name = propertyNames[i];
             const value = feature.getProperty(name);
-            console.log("  " + name + ": " + value);
+            console.log(`  ${name}: ${value}`);
           }
         }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
 

--- a/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
@@ -129,9 +129,10 @@
 
             // A feature was picked, so show it's overlay content
             nameOverlay.style.display = "block";
-            nameOverlay.style.bottom =
-              viewer.canvas.clientHeight - movement.endPosition.y + "px";
-            nameOverlay.style.left = movement.endPosition.x + "px";
+            nameOverlay.style.bottom = `${
+              viewer.canvas.clientHeight - movement.endPosition.y
+            }px`;
+            nameOverlay.style.left = `${movement.endPosition.x}px`;
             const name = pickedFeature.getProperty("BIN");
             nameOverlay.textContent = name;
 
@@ -177,17 +178,17 @@
               'Loading <div class="cesium-infoBox-loading"></div>';
             viewer.selectedEntity = selectedEntity;
             selectedEntity.description =
-              '<table class="cesium-infoBox-defaultTable"><tbody>' +
-              "<tr><th>BIN</th><td>" +
-              pickedFeature.getProperty("BIN") +
-              "</td></tr>" +
-              "<tr><th>DOITT ID</th><td>" +
-              pickedFeature.getProperty("DOITT_ID") +
-              "</td></tr>" +
-              "<tr><th>SOURCE ID</th><td>" +
-              pickedFeature.getProperty("SOURCE_ID") +
-              "</td></tr>" +
-              "</tbody></table>";
+              `${
+                '<table class="cesium-infoBox-defaultTable"><tbody>' +
+                "<tr><th>BIN</th><td>"
+              }${pickedFeature.getProperty("BIN")}</td></tr>` +
+              `<tr><th>DOITT ID</th><td>${pickedFeature.getProperty(
+                "DOITT_ID"
+              )}</td></tr>` +
+              `<tr><th>SOURCE ID</th><td>${pickedFeature.getProperty(
+                "SOURCE_ID"
+              )}</td></tr>` +
+              `</tbody></table>`;
           },
           Cesium.ScreenSpaceEventType.LEFT_CLICK);
         } else {
@@ -216,9 +217,10 @@
             }
             // A feature was picked, so show it's overlay content
             nameOverlay.style.display = "block";
-            nameOverlay.style.bottom =
-              viewer.canvas.clientHeight - movement.endPosition.y + "px";
-            nameOverlay.style.left = movement.endPosition.x + "px";
+            nameOverlay.style.bottom = `${
+              viewer.canvas.clientHeight - movement.endPosition.y
+            }px`;
+            nameOverlay.style.left = `${movement.endPosition.x}px`;
             let name = pickedFeature.getProperty("name");
             if (!Cesium.defined(name)) {
               name = pickedFeature.getProperty("id");
@@ -275,29 +277,29 @@
               'Loading <div class="cesium-infoBox-loading"></div>';
             viewer.selectedEntity = selectedEntity;
             selectedEntity.description =
-              '<table class="cesium-infoBox-defaultTable"><tbody>' +
-              "<tr><th>BIN</th><td>" +
-              pickedFeature.getProperty("BIN") +
-              "</td></tr>" +
-              "<tr><th>DOITT ID</th><td>" +
-              pickedFeature.getProperty("DOITT_ID") +
-              "</td></tr>" +
-              "<tr><th>SOURCE ID</th><td>" +
-              pickedFeature.getProperty("SOURCE_ID") +
-              "</td></tr>" +
-              "<tr><th>Longitude</th><td>" +
-              pickedFeature.getProperty("longitude") +
-              "</td></tr>" +
-              "<tr><th>Latitude</th><td>" +
-              pickedFeature.getProperty("latitude") +
-              "</td></tr>" +
-              "<tr><th>Height</th><td>" +
-              pickedFeature.getProperty("height") +
-              "</td></tr>" +
-              "<tr><th>Terrain Height (Ellipsoid)</th><td>" +
-              pickedFeature.getProperty("TerrainHeight") +
-              "</td></tr>" +
-              "</tbody></table>";
+              `${
+                '<table class="cesium-infoBox-defaultTable"><tbody>' +
+                "<tr><th>BIN</th><td>"
+              }${pickedFeature.getProperty("BIN")}</td></tr>` +
+              `<tr><th>DOITT ID</th><td>${pickedFeature.getProperty(
+                "DOITT_ID"
+              )}</td></tr>` +
+              `<tr><th>SOURCE ID</th><td>${pickedFeature.getProperty(
+                "SOURCE_ID"
+              )}</td></tr>` +
+              `<tr><th>Longitude</th><td>${pickedFeature.getProperty(
+                "longitude"
+              )}</td></tr>` +
+              `<tr><th>Latitude</th><td>${pickedFeature.getProperty(
+                "latitude"
+              )}</td></tr>` +
+              `<tr><th>Height</th><td>${pickedFeature.getProperty(
+                "height"
+              )}</td></tr>` +
+              `<tr><th>Terrain Height (Ellipsoid)</th><td>${pickedFeature.getProperty(
+                "TerrainHeight"
+              )}</td></tr>` +
+              `</tbody></table>`;
           },
           Cesium.ScreenSpaceEventType.LEFT_CLICK);
         }

--- a/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
@@ -133,12 +133,7 @@
         function colorByDistanceToCoordinate(pickedLatitude, pickedLongitude) {
           osmBuildingsTileset.style = new Cesium.Cesium3DTileStyle({
             defines: {
-              distance:
-                "distance(vec2(${feature['cesium#longitude']}, ${feature['cesium#latitude']}), vec2(" +
-                pickedLongitude +
-                "," +
-                pickedLatitude +
-                "))",
+              distance: `distance(vec2(\${feature['cesium#longitude']}, \${feature['cesium#latitude']}), vec2(${pickedLongitude},${pickedLatitude}))`,
             },
             color: {
               conditions: [

--- a/Apps/Sandcastle/gallery/3D Tiles Formats.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Formats.html
@@ -206,7 +206,7 @@
             for (let i = 0; i < length; ++i) {
               const propertyName = propertyNames[i];
               console.log(
-                propertyName + ": " + feature.getProperty(propertyName)
+                `${propertyName}: ${feature.getProperty(propertyName)}`
               );
             }
           }

--- a/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
@@ -160,7 +160,7 @@
             const cartesian = scene.pickPosition(movement.position);
             if (Cesium.defined(cartesian)) {
               const cartographic = Cesium.Cartographic.fromCartesian(cartesian);
-              const height = cartographic.height.toFixed(2) + " m";
+              const height = `${cartographic.height.toFixed(2)} m`;
 
               annotations.add({
                 position: cartesian,
@@ -182,13 +182,13 @@
           for (let i = 0; i < length; ++i) {
             const propertyName = propertyNames[i];
             console.log(
-              "  " + propertyName + ": " + feature.getProperty(propertyName)
+              `  ${propertyName}: ${feature.getProperty(propertyName)}`
             );
           }
 
           // Evaluate feature description
           console.log(
-            "Description : " + tileset.style.meta.description.evaluate(feature)
+            `Description : ${tileset.style.meta.description.evaluate(feature)}`
           );
         }
 

--- a/Apps/Sandcastle/gallery/3D Tiles Next CDB Yemen.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Next CDB Yemen.html
@@ -259,14 +259,14 @@
 
             if (isTerrainFeature) {
               metadataOverlay.style.display = "block";
-              metadataOverlay.style.bottom =
-                viewer.canvas.clientHeight - movement.endPosition.y + "px";
-              metadataOverlay.style.left = movement.endPosition.x + "px";
+              metadataOverlay.style.bottom = `${
+                viewer.canvas.clientHeight - movement.endPosition.y
+              }px`;
+              metadataOverlay.style.left = `${movement.endPosition.x}px`;
 
-              tableHtmlScratch =
-                "<table><thead><tr><td>Material:</td><th><tt>" +
-                feature.getProperty("name") +
-                "</tt></tr></thead><tbody>";
+              tableHtmlScratch = `<table><thead><tr><td>Material:</td><th><tt>${feature.getProperty(
+                "name"
+              )}</tt></tr></thead><tbody>`;
 
               materialsScratch = feature.getProperty("substrates");
               weightsScratch = feature.getProperty("weights");
@@ -274,12 +274,11 @@
                 "<tr><td colspan='2' style='text-align: center;'><b>Substrates</b></td></tr>";
 
               for (i = 0; i < materialsScratch.length; i++) {
-                tableHtmlScratch +=
-                  "<tr><td><tt>" +
-                  materialsScratch[i].slice(3) +
-                  "</tt></td><td style='text-align: right;'><tt>" +
-                  weightsScratch[i] +
-                  "%</tt></td></tr>";
+                tableHtmlScratch += `<tr><td><tt>${materialsScratch[i].slice(
+                  3
+                )}</tt></td><td style='text-align: right;'><tt>${
+                  weightsScratch[i]
+                }%</tt></td></tr>`;
               }
               tableHtmlScratch += "</tbody></table>";
               metadataOverlay.innerHTML = tableHtmlScratch;
@@ -350,18 +349,7 @@
               const propertyValue = feature.getProperty(propertyName);
               const property = metadataClass.properties[propertyName];
 
-              tableHtmlScratch +=
-                "<tr style='font-family: monospace;' title='" +
-                property.description +
-                "'><th>" +
-                property.name +
-                "</th><th><b>" +
-                property.id +
-                "</b></th><td>" +
-                property.componentType +
-                "</td><td>" +
-                propertyValue +
-                "</td></tr>";
+              tableHtmlScratch += `<tr style='font-family: monospace;' title='${property.description}'><th>${property.name}</th><th><b>${property.id}</b></th><td>${property.componentType}</td><td>${propertyValue}</td></tr>`;
             }
             tableHtmlScratch +=
               "<tr><th colspan='4'><i style='font-size:10px'>Hover on a row for description</i></th></tr></tbody></table>";

--- a/Apps/Sandcastle/gallery/3D Tiles Next Photogrammetry Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Next Photogrammetry Classification.html
@@ -292,14 +292,13 @@
             const pickedObject = viewer.scene.pick(movement.endPosition);
             if (pickedObject instanceof Cesium.Cesium3DTileFeature) {
               nameOverlay.style.display = "block";
-              nameOverlay.style.bottom =
-                viewer.canvas.clientHeight - movement.endPosition.y + "px";
-              nameOverlay.style.left = movement.endPosition.x + "px";
-              const message =
-                "Component: " +
-                pickedObject.getProperty("component") +
-                "\nFeature ID: " +
-                pickedObject.featureId;
+              nameOverlay.style.bottom = `${
+                viewer.canvas.clientHeight - movement.endPosition.y
+              }px`;
+              nameOverlay.style.left = `${movement.endPosition.x}px`;
+              const message = `Component: ${pickedObject.getProperty(
+                "component"
+              )}\nFeature ID: ${pickedObject.featureId}`;
               nameOverlay.textContent = message;
             } else {
               nameOverlay.style.display = "none";

--- a/Apps/Sandcastle/gallery/3D Tiles Next S2 Globe.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Next S2 Globe.html
@@ -157,9 +157,10 @@
             const feature = scene.pick(movement.endPosition);
             if (feature instanceof Cesium.Cesium3DTileFeature) {
               metadataOverlay.style.display = "block";
-              metadataOverlay.style.bottom =
-                viewer.canvas.clientHeight - movement.endPosition.y + "px";
-              metadataOverlay.style.left = movement.endPosition.x + "px";
+              metadataOverlay.style.bottom = `${
+                viewer.canvas.clientHeight - movement.endPosition.y
+              }px`;
+              metadataOverlay.style.left = `${movement.endPosition.x}px`;
 
               tableHtmlScratch =
                 "<table><thead><tr><th><tt>Property</tt></th><th><tt>Value</tt></th></tr></thead><tbody>";
@@ -169,12 +170,7 @@
               for (let i = 0; i < length; ++i) {
                 const propertyName = propertyNames[i];
                 const propertyValue = feature.getProperty(propertyName);
-                tableHtmlScratch +=
-                  "<tr><td><tt>" +
-                  propertyName +
-                  "</tt></td><td><tt>" +
-                  propertyValue +
-                  "</tt></td></tr>";
+                tableHtmlScratch += `<tr><td><tt>${propertyName}</tt></td><td><tt>${propertyValue}</tt></td></tr>`;
               }
               tableHtmlScratch += "</tbody></table>";
               metadataOverlay.innerHTML = tableHtmlScratch;

--- a/Apps/Sandcastle/gallery/CZML Model Data URL.html
+++ b/Apps/Sandcastle/gallery/CZML Model Data URL.html
@@ -133,7 +133,7 @@
 
         const encoded = btoa(JSON.stringify(gltf));
 
-        const dataUrl = "data:application/json;charset=utf-8;base64," + encoded;
+        const dataUrl = `data:application/json;charset=utf-8;base64,${encoded}`;
 
         const czml = [
           {

--- a/Apps/Sandcastle/gallery/Callback Property.html
+++ b/Apps/Sandcastle/gallery/Callback Property.html
@@ -85,7 +85,7 @@
 
           geodesic.setEndPoints(startCartographic, endCartographic);
           const lengthInMeters = Math.round(geodesic.surfaceDistance);
-          return (lengthInMeters / 1000).toFixed(1) + " km";
+          return `${(lengthInMeters / 1000).toFixed(1)} km`;
         }
 
         function getMidpoint(time, result) {

--- a/Apps/Sandcastle/gallery/Camera.html
+++ b/Apps/Sandcastle/gallery/Camera.html
@@ -241,8 +241,9 @@
             percentage
           ) {
             ++i;
-            cameraChanged.innerText =
-              "Camera Changed: " + i + ", " + percentage.toFixed(6);
+            cameraChanged.innerText = `Camera Changed: ${i}, ${percentage.toFixed(
+              6
+            )}`;
             cameraChanged.style.display = "block";
           });
         }

--- a/Apps/Sandcastle/gallery/Clamp to 3D Model.html
+++ b/Apps/Sandcastle/gallery/Clamp to 3D Model.html
@@ -93,7 +93,7 @@
 
           if (Cesium.defined(height)) {
             cartographic.height = height;
-            point.label.text = Math.abs(height).toFixed(2).toString() + " m";
+            point.label.text = `${Math.abs(height).toFixed(2).toString()} m`;
             point.label.show = true;
           } else {
             cartographic.height = 0.0;

--- a/Apps/Sandcastle/gallery/Clustering.html
+++ b/Apps/Sandcastle/gallery/Clustering.html
@@ -120,7 +120,7 @@
           const singleDigitPins = new Array(8);
           for (let i = 0; i < singleDigitPins.length; ++i) {
             singleDigitPins[i] = pinBuilder
-              .fromText("" + (i + 2), Cesium.Color.VIOLET, 48)
+              .fromText(`${i + 2}`, Cesium.Color.VIOLET, 48)
               .toDataURL();
           }
 

--- a/Apps/Sandcastle/gallery/Custom DataSource.html
+++ b/Apps/Sandcastle/gallery/Custom DataSource.html
@@ -347,7 +347,7 @@
 
               //The polyline instance itself needs to be on an entity.
               const entity = new Cesium.Entity({
-                id: seriesName + " index " + i.toString(),
+                id: `${seriesName} index ${i.toString()}`,
                 show: show,
                 polyline: polyline,
                 seriesName: seriesName, //Custom property to indicate series name

--- a/Apps/Sandcastle/gallery/HTML Overlays.html
+++ b/Apps/Sandcastle/gallery/HTML Overlays.html
@@ -55,8 +55,8 @@
             scratch
           );
           if (Cesium.defined(canvasPosition)) {
-            htmlOverlay.style.top = canvasPosition.y + "px";
-            htmlOverlay.style.left = canvasPosition.x + "px";
+            htmlOverlay.style.top = `${canvasPosition.y}px`;
+            htmlOverlay.style.left = `${canvasPosition.x}px`;
           }
         });
         //Sandcastle_End

--- a/Apps/Sandcastle/gallery/Imagery Layers Split.html
+++ b/Apps/Sandcastle/gallery/Imagery Layers Split.html
@@ -89,7 +89,7 @@
           const splitPosition =
             (slider.offsetLeft + relativeOffset) /
             slider.parentElement.offsetWidth;
-          slider.style.left = 100.0 * splitPosition + "%";
+          slider.style.left = `${100.0 * splitPosition}%`;
           viewer.scene.imagerySplitPosition = splitPosition;
         }
 

--- a/Apps/Sandcastle/gallery/Imagery Layers Texture Filters.html
+++ b/Apps/Sandcastle/gallery/Imagery Layers Texture Filters.html
@@ -111,7 +111,7 @@
           const slider = document.getElementById("slider");
           const splitPosition =
             (e.clientX - dragStartX) / slider.parentElement.offsetWidth;
-          slider.style.left = 100.0 * splitPosition + "%";
+          slider.style.left = `${100.0 * splitPosition}%`;
           viewer.scene.imagerySplitPosition = splitPosition;
         }
         //Sandcastle_End

--- a/Apps/Sandcastle/gallery/KML Tours.html
+++ b/Apps/Sandcastle/gallery/KML Tours.html
@@ -53,15 +53,13 @@
               console.log("Start tour");
             });
             tour.tourEnd.addEventListener(function (terminated) {
-              console.log((terminated ? "Terminate" : "End") + " tour");
+              console.log(`${terminated ? "Terminate" : "End"} tour`);
             });
             tour.entryStart.addEventListener(function (entry) {
-              console.log("Play " + entry.type + " (" + entry.duration + ")");
+              console.log(`Play ${entry.type} (${entry.duration})`);
             });
             tour.entryEnd.addEventListener(function (entry, terminated) {
-              console.log(
-                (terminated ? "Terminate" : "End") + " " + entry.type
-              );
+              console.log(`${terminated ? "Terminate" : "End"} ${entry.type}`);
             });
           });
 

--- a/Apps/Sandcastle/gallery/Labels.html
+++ b/Apps/Sandcastle/gallery/Labels.html
@@ -197,7 +197,7 @@
               if (fontSize >= maxFontSize || fontSize <= minFontSize) {
                 fontDelta *= -1.0;
               }
-              entity.label.font = fontSize + "px Calibri";
+              entity.label.font = `${fontSize}px Calibri`;
             }
           );
         }

--- a/Apps/Sandcastle/gallery/Montreal Point Cloud.html
+++ b/Apps/Sandcastle/gallery/Montreal Point Cloud.html
@@ -333,11 +333,11 @@
             const id = classificationDictionary[key];
 
             const colorCondition = [
-              "${Classification} === " + id,
+              `\${Classification} === ${id}`,
               styles[key].color,
             ];
             const showCondition = [
-              "${Classification} === " + id,
+              `\${Classification} === ${id}`,
               styles[key].show,
             ];
 

--- a/Apps/Sandcastle/gallery/Multi-part CZML.html
+++ b/Apps/Sandcastle/gallery/Multi-part CZML.html
@@ -77,7 +77,7 @@
         function updateStatusDisplay() {
           let msg = "";
           partsToLoad.forEach(function (part) {
-            msg += part.url + " - ";
+            msg += `${part.url} - `;
             if (part.loaded) {
               msg += "Loaded.<br/>";
             } else if (part.requested) {
@@ -139,7 +139,7 @@
               clock.currentTime
             );
             if (Cesium.defined(fuel)) {
-              fuelDisplay.textContent = "Fuel: " + fuel.toFixed(2) + " gal";
+              fuelDisplay.textContent = `Fuel: ${fuel.toFixed(2)} gal`;
             }
           }
         });

--- a/Apps/Sandcastle/gallery/Parallels and Meridians.html
+++ b/Apps/Sandcastle/gallery/Parallels and Meridians.html
@@ -39,7 +39,7 @@
         const toDegrees = Cesium.Math.toDegrees;
 
         function parallel(latitude, color, granularity) {
-          const name = "Parallel " + latitude;
+          const name = `Parallel ${latitude}`;
           return viewer.entities.add({
             name: name,
             polyline: {
@@ -64,7 +64,7 @@
         }
 
         function meridian(longitude, color, granularity) {
-          const name = "Meridian " + longitude;
+          const name = `Meridian ${longitude}`;
           return viewer.entities.add({
             name: name,
             polyline: {
@@ -88,7 +88,7 @@
           const position = Cesium.Cartographic.toCartesian(cartographic);
           const latitude = toDegrees(cartographic.latitude).toFixed(4);
           const longitude = toDegrees(cartographic.longitude).toFixed(4);
-          const label = "lat: " + latitude + "°\nlon: " + longitude + "°";
+          const label = `lat: ${latitude}°\nlon: ${longitude}°`;
 
           return viewer.entities.add({
             position: position,

--- a/Apps/Sandcastle/gallery/Picking.html
+++ b/Apps/Sandcastle/gallery/Picking.html
@@ -82,12 +82,8 @@
                 entity.position = cartesian;
                 entity.label.show = true;
                 entity.label.text =
-                  "Lon: " +
-                  ("   " + longitudeString).slice(-7) +
-                  "\u00B0" +
-                  "\nLat: " +
-                  ("   " + latitudeString).slice(-7) +
-                  "\u00B0";
+                  `Lon: ${`   ${longitudeString}`.slice(-7)}\u00B0` +
+                  `\nLat: ${`   ${latitudeString}`.slice(-7)}\u00B0`;
               } else {
                 entity.label.show = false;
               }
@@ -258,15 +254,9 @@
                   labelEntity.position = cartesian;
                   labelEntity.label.show = true;
                   labelEntity.label.text =
-                    "Lon: " +
-                    ("   " + longitudeString).slice(-7) +
-                    "\u00B0" +
-                    "\nLat: " +
-                    ("   " + latitudeString).slice(-7) +
-                    "\u00B0" +
-                    "\nAlt: " +
-                    ("   " + heightString).slice(-7) +
-                    "m";
+                    `Lon: ${`   ${longitudeString}`.slice(-7)}\u00B0` +
+                    `\nLat: ${`   ${latitudeString}`.slice(-7)}\u00B0` +
+                    `\nAlt: ${`   ${heightString}`.slice(-7)}m`;
 
                   labelEntity.label.eyeOffset = new Cesium.Cartesian3(
                     0.0,

--- a/Apps/Sandcastle/gallery/Scene Rendering Performance.html
+++ b/Apps/Sandcastle/gallery/Scene Rendering Performance.html
@@ -314,14 +314,9 @@
 
         scene.postRender.addEventListener(function () {
           const time = Cesium.JulianDate.toGregorianDate(scene.lastRenderTime);
-          const value =
-            time.hour +
-            ":" +
-            time.minute +
-            ":" +
-            time.second +
-            ":" +
-            time.millisecond.toFixed(0);
+          const value = `${time.hour}:${time.minute}:${
+            time.second
+          }:${time.millisecond.toFixed(0)}`;
           Cesium.knockout.getObservable(viewModel, "lastRenderTime")(value);
         });
 

--- a/Apps/Sandcastle/gallery/Star Burst.html
+++ b/Apps/Sandcastle/gallery/Star Burst.html
@@ -49,7 +49,7 @@
               scale: 2.5,
             },
             label: {
-              text: "Label" + i,
+              text: `Label${i}`,
               show: false,
             },
           });

--- a/Apps/Sandcastle/gallery/Time Dynamic Wheels.html
+++ b/Apps/Sandcastle/gallery/Time Dynamic Wheels.html
@@ -111,7 +111,7 @@
           const metersPerSecond = Cesium.Cartesian3.magnitude(velocityVector);
           const kmPerHour = Math.round(metersPerSecond * 3.6);
 
-          return kmPerHour + " km/hr";
+          return `${kmPerHour} km/hr`;
         }
 
         const rotationProperty = new Cesium.CallbackProperty(function (

--- a/Apps/Sandcastle/gallery/development/3D Models Articulations.html
+++ b/Apps/Sandcastle/gallery/development/3D Models Articulations.html
@@ -165,7 +165,7 @@
                     .getObservable(stageModel, "current")
                     .subscribe(function (newValue) {
                       model.setArticulationStage(
-                        articulationName + " " + stage.name,
+                        `${articulationName} ${stage.name}`,
                         +stageModel.current
                       );
                       model.applyArticulations();

--- a/Apps/Sandcastle/gallery/development/3D Models.html
+++ b/Apps/Sandcastle/gallery/development/3D Models.html
@@ -237,9 +237,7 @@
             Cesium.defined(pick.mesh)
           ) {
             // Output glTF node and mesh under the mouse.
-            console.log(
-              "node: " + pick.node.name + ". mesh: " + pick.mesh.name
-            );
+            console.log(`node: ${pick.node.name}. mesh: ${pick.mesh.name}`);
           }
         }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
 

--- a/Apps/Sandcastle/gallery/development/3D Tiles Performance Testing.html
+++ b/Apps/Sandcastle/gallery/development/3D Tiles Performance Testing.html
@@ -177,10 +177,7 @@ The heatmapTileProperty will colorize the tile property in a heatmap. Booleans s
 
         destinationFunctions[3] = function () {
           console.log(
-            "Total Loads and Time (ignoring first view and flight time): " +
-              tourLoads +
-              ", " +
-              tourTime
+            `Total Loads and Time (ignoring first view and flight time): ${tourLoads}, ${tourTime}`
           );
         };
 
@@ -223,12 +220,7 @@ The heatmapTileProperty will colorize the tile property in a heatmap. Booleans s
             duration -= currentDestination === 0 ? 0 : flightDuration;
             const flightLoads = totalLoaded - lastTotalLoaded;
             console.log(
-              "view " +
-                currentDestination +
-                " flight loads, final view time: " +
-                flightLoads +
-                ", " +
-                duration
+              `view ${currentDestination} flight loads, final view time: ${flightLoads}, ${duration}`
             );
             lastTotalLoaded = totalLoaded;
             tourTime += currentDestination === 0 ? 0 : duration;
@@ -255,37 +247,19 @@ The heatmapTileProperty will colorize the tile property in a heatmap. Booleans s
           const up = camera.up;
 
           console.log(
-            "\n\
+            `\n\
 Sandcastle.addToolbarButton(VIEW, function() {\n\
     camera.flyTo({\n\
-        destination : new Cartesian3(" +
-              position.x +
-              ", " +
-              position.y +
-              ", " +
-              position.z +
-              "),\n\
-        orientation : {\n\
-            direction : new Cartesian3(" +
-              direction.x +
-              ", " +
-              direction.y +
-              ", " +
-              direction.z +
-              "),\n\
-            up : new Cartesian3(" +
-              up.x +
-              ", " +
-              up.y +
-              ", " +
-              up.z +
-              "),\n\
-        },\n\
-        duration : flightDuration,\n\
-        easingFunction: Cesium.EasingFunction.LINEAR_NONE,\n\
+  destination : new Cartesian3(${position.x}, ${position.y}, ${position.z}),\n\
+  orientation : {\n\
+      direction : new Cartesian3(${direction.x}, ${direction.y}, ${direction.z}),\n\
+      up : new Cartesian3(${up.x}, ${up.y}, ${up.z}),\n\
+  },\n\
+  duration : flightDuration,\n\
+  easingFunction: Cesium.EasingFunction.LINEAR_NONE,\n\
     });\n\
     timeAll();\n\
-});"
+});`
           );
         }); //Sandcastle_End
         Sandcastle.finishedLoading();

--- a/Apps/Sandcastle/gallery/development/Ground Primitive.html
+++ b/Apps/Sandcastle/gallery/development/Ground Primitive.html
@@ -257,7 +257,7 @@
                   color: color,
                   show: show,
                 },
-                id: "rectangle" + i,
+                id: `rectangle${i}`,
               })
             );
           }

--- a/Apps/Sandcastle/gallery/development/Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Shadows.html
@@ -641,7 +641,7 @@
           // Update biases
           for (let i = 0; i < viewModel.biasModes.length; ++i) {
             const biasMode = viewModel.biasModes[i];
-            const bias = shadowMap["_" + biasMode.type + "Bias"];
+            const bias = shadowMap[`_${biasMode.type}Bias`];
             bias.polygonOffset =
               !shadowMap._isPointLight &&
               shadowMap._polygonOffsetSupported &&
@@ -734,9 +734,9 @@
             if (
               uiOptions.disable[viewModel.lightSource].indexOf(setting) > -1
             ) {
-              viewModel[setting + "Enabled"] = false;
+              viewModel[`${setting}Enabled`] = false;
             } else {
-              viewModel[setting + "Enabled"] = true;
+              viewModel[`${setting}Enabled`] = true;
             }
           });
         }

--- a/Apps/Sandcastle/gallery/development/Terrain Entity Batching.html
+++ b/Apps/Sandcastle/gallery/development/Terrain Entity Batching.html
@@ -128,7 +128,7 @@
             const cornerLat = latitude + 0.01 * x;
             const cornerLon = longitude + 0.01 * y;
             viewer.entities.add({
-              id: x + " " + y,
+              id: `${x} ${y}`,
               rectangle: {
                 coordinates: Cesium.Rectangle.fromDegrees(
                   cornerLon,

--- a/Apps/Sandcastle/gallery/development/Terrain Performance.html
+++ b/Apps/Sandcastle/gallery/development/Terrain Performance.html
@@ -92,15 +92,11 @@
             const endTime = window.performance.now();
             const duration = endTime - startTime;
             alert(
-              (duration / 1000).toFixed(2) +
-                " seconds " +
-                statistics.numberOfActiveRequestsEver +
-                " requests, min/max/avg frame FPS " +
-                minFrameRate +
-                "/" +
-                maxFrameRate +
-                "/" +
+              `${(duration / 1000).toFixed(2)} seconds ${
+                statistics.numberOfActiveRequestsEver
+              } requests, min/max/avg frame FPS ${minFrameRate}/${maxFrameRate}/${
                 sumFrameRate / frameRateSamples
+              }`
             );
             scene.postRender.removeEventListener(viewReady);
           }
@@ -270,34 +266,10 @@
 
         Sandcastle.addToolbarButton("Save camera", function () {
           const cameraString =
-            "camera.position = new Cesium.Cartesian3(" +
-            camera.positionWC.x +
-            ", " +
-            camera.positionWC.y +
-            ", " +
-            camera.positionWC.z +
-            ");\n" +
-            "camera.direction = new Cesium.Cartesian3(" +
-            camera.directionWC.x +
-            ", " +
-            camera.directionWC.y +
-            ", " +
-            camera.directionWC.z +
-            ");\n" +
-            "camera.right = new Cesium.Cartesian3(" +
-            camera.rightWC.x +
-            ", " +
-            camera.rightWC.y +
-            ", " +
-            camera.rightWC.z +
-            ");\n" +
-            "camera.up = new Cesium.Cartesian3(" +
-            camera.upWC.x +
-            ", " +
-            camera.upWC.y +
-            ", " +
-            camera.upWC.z +
-            ");\n";
+            `camera.position = new Cesium.Cartesian3(${camera.positionWC.x}, ${camera.positionWC.y}, ${camera.positionWC.z});\n` +
+            `camera.direction = new Cesium.Cartesian3(${camera.directionWC.x}, ${camera.directionWC.y}, ${camera.directionWC.z});\n` +
+            `camera.right = new Cesium.Cartesian3(${camera.rightWC.x}, ${camera.rightWC.y}, ${camera.rightWC.z});\n` +
+            `camera.up = new Cesium.Cartesian3(${camera.upWC.x}, ${camera.upWC.y}, ${camera.upWC.z});\n`;
           console.log(cameraString);
         }); //Sandcastle_End
         Sandcastle.finishedLoading();

--- a/Apps/Sandcastle/standalone.html
+++ b/Apps/Sandcastle/standalone.html
@@ -50,8 +50,7 @@
         data = window.decodeBase64Data(base64String, pako);
         //Handle case where demo is in a sub-directory by modifying
         //the HTML to add a base href.
-        document.head.innerHTML =
-          document.head.innerHTML + '<base href="' + data.baseHref + '" />';
+        document.head.innerHTML = `${document.head.innerHTML}<base href="${data.baseHref}" />`;
         window.sandcastleData = data;
       }
 

--- a/Apps/TimelineDemo/TimelineDemo.js
+++ b/Apps/TimelineDemo/TimelineDemo.js
@@ -21,8 +21,9 @@ define(["dijit/dijit", "dojo"], function (dijit, dojo) {
     animation;
 
   function updateScrubTime(julianDate) {
-    document.getElementById("mousePos").innerHTML =
-      timeline.makeLabel(julianDate) + " UTC";
+    document.getElementById("mousePos").innerHTML = `${timeline.makeLabel(
+      julianDate
+    )} UTC`;
   }
 
   function handleSetTime(e) {
@@ -55,22 +56,17 @@ define(["dijit/dijit", "dojo"], function (dijit, dojo) {
       span /= 60;
       spanUnits = "minutes";
     }
-    return span.toString() + " " + spanUnits;
+    return `${span.toString()} ${spanUnits}`;
   }
 
   function handleSetZoom(e) {
     dojo.byId("formatted").innerHTML =
       //'<br/>Epoch: ' + timeline.makeLabel(e.epochJulian) + ' UTC' +
-      "<br/>Start: " +
-      timeline.makeLabel(e.startJulian) +
-      " UTC" +
-      "<br/>&nbsp;Stop: " +
-      timeline.makeLabel(e.endJulian) +
-      " UTC" +
-      "<br/>&nbsp;Span: " +
-      spanToString(e.totalSpan) +
-      "<br/>&nbsp;&nbsp;Tic: " +
-      spanToString(e.mainTicSpan);
+      `<br/>Start: ${timeline.makeLabel(e.startJulian)} UTC` +
+      `<br/>&nbsp;Stop: ${timeline.makeLabel(e.endJulian)} UTC` +
+      `<br/>&nbsp;Span: ${spanToString(
+        e.totalSpan
+      )}<br/>&nbsp;&nbsp;Tic: ${spanToString(e.mainTicSpan)}`;
     updateScrubTime(clock.currentTime);
   }
 
@@ -136,10 +132,10 @@ define(["dijit/dijit", "dojo"], function (dijit, dojo) {
     let startJulian, endJulian;
 
     if (startDatePart && startTimePart) {
-      startJulian = JulianDate.fromIso8601(startDatePart + startTimePart + "Z"); // + 'Z' for UTC
+      startJulian = JulianDate.fromIso8601(`${startDatePart + startTimePart}Z`); // + 'Z' for UTC
     }
     if (endDatePart && endTimePart) {
-      endJulian = JulianDate.fromIso8601(endDatePart + endTimePart + "Z");
+      endJulian = JulianDate.fromIso8601(`${endDatePart + endTimePart}Z`);
     }
 
     if (startJulian && endJulian) {
@@ -178,12 +174,12 @@ define(["dijit/dijit", "dojo"], function (dijit, dojo) {
   //
   function getTimePart(newTime) {
     let h = newTime.getHours().toString();
-    h = h.length < 2 ? "0" + h : h;
+    h = h.length < 2 ? `0${h}` : h;
     let m = newTime.getMinutes().toString();
-    m = m.length < 2 ? "0" + m : m;
+    m = m.length < 2 ? `0${m}` : m;
     let s = newTime.getSeconds().toString();
-    s = s.length < 2 ? "0" + s : s;
-    return "T" + h + ":" + m + ":" + s;
+    s = s.length < 2 ? `0${s}` : s;
+    return `T${h}:${m}:${s}`;
   }
   function newStartTimeSelected(newTime) {
     startTimePart = getTimePart(newTime);

--- a/Documentation/Contributors/CodingGuide/README.md
+++ b/Documentation/Contributors/CodingGuide/README.md
@@ -14,35 +14,37 @@ This guide applies to CesiumJS and all parts of the Cesium ecosystem written in 
 
 To some extent, this guide can be summarized as _make new code similar to existing code_.
 
-- [Naming](#naming)
-- [Formatting](#formatting)
-- [Linting](#linting)
-- [Units](#units)
-- [Basic Code Construction](#basic-code-construction)
-- [Functions](#functions)
-  - [`options` Parameters](#options-parameters)
-  - [Default Parameter Values](#default-parameter-values)
-  - [Throwing Exceptions](#throwing-exceptions)
-  - [`result` Parameters and Scratch Variables](#result-parameters-and-scratch-variables)
-- [Classes](#classes)
-  - [Constructor Functions](#constructor-functions)
-  - [`from` Constructors](#from-constructors)
-  - [`to` Functions](#to-functions)
-  - [Use Prototype Functions for Fundamental Classes Sparingly](#use-prototype-functions-for-fundamental-classes-sparingly)
-  - [Static Constants](#static-constants)
-  - [Private Functions](#private-functions)
-  - [Property Getter/Setters](#property-gettersetters)
-  - [Shadowed Property](#shadowed-property)
-  - [Put the Constructor Function at the Top of the File](#put-the-constructor-function-at-the-top-of-the-file)
-- [Design](#design)
-  - [Deprecation and Breaking Changes](#deprecation-and-breaking-changes)
-- [Third-Party Libraries](#third-party-libraries)
-- [Widgets](#widgets)
-- [GLSL](#glsl)
-  - [Naming](#naming-1)
-  - [Formatting](#formatting-1)
-  - [Performance](#performance)
-- [Resources](#resources)
+- [Coding Guide](#coding-guide)
+  - [Naming](#naming)
+  - [Formatting](#formatting)
+  - [Linting](#linting)
+  - [Units](#units)
+  - [Basic Code Construction](#basic-code-construction)
+  - [Functions](#functions)
+    - [`options` Parameters](#options-parameters)
+    - [Default Parameter Values](#default-parameter-values)
+    - [Throwing Exceptions](#throwing-exceptions)
+    - [`result` Parameters and Scratch Variables](#result-parameters-and-scratch-variables)
+  - [Classes](#classes)
+    - [Constructor Functions](#constructor-functions)
+    - [`from` Constructors](#from-constructors)
+    - [`to` Functions](#to-functions)
+    - [Use Prototype Functions for Fundamental Classes Sparingly](#use-prototype-functions-for-fundamental-classes-sparingly)
+    - [Static Constants](#static-constants)
+    - [Private Functions](#private-functions)
+    - [Property Getter/Setters](#property-gettersetters)
+    - [Shadowed Property](#shadowed-property)
+    - [Put the Constructor Function at the Top of the File](#put-the-constructor-function-at-the-top-of-the-file)
+  - [Design](#design)
+    - [Deprecation and Breaking Changes](#deprecation-and-breaking-changes)
+  - [Third-Party Libraries](#third-party-libraries)
+  - [Widgets](#widgets)
+    - [Knockout subscriptions](#knockout-subscriptions)
+  - [GLSL](#glsl)
+    - [Naming](#naming-1)
+    - [Formatting](#formatting-1)
+    - [Performance](#performance)
+  - [Resources](#resources)
 
 ## Naming
 
@@ -670,7 +672,7 @@ Functions that start with `to` return a new type of object, e.g.,
 
 ```javascript
 Cartesian3.prototype.toString = function () {
-  return "(" + this.x + ", " + this.y + ", " + this.z + ")";
+  return "(${this.x}, ${this.y}, ${this.z})";
 };
 ```
 

--- a/Source/.eslintrc.json
+++ b/Source/.eslintrc.json
@@ -13,6 +13,7 @@
         "no-unused-vars": ["error", {"vars": "all", "args": "none"}],
         "es/no-modules": "off",
         "es/no-typed-arrays": "off",
-        "es/no-block-scoped-variables": "off"
+        "es/no-block-scoped-variables": "off",
+        "es/no-template-literals": "off"
     }
 }

--- a/Source/Core/ApproximateTerrainHeights.js
+++ b/Source/Core/ApproximateTerrainHeights.js
@@ -80,7 +80,7 @@ ApproximateTerrainHeights.getMinimumMaximumHeights = function (
   let minTerrainHeight = ApproximateTerrainHeights._defaultMinTerrainHeight;
   let maxTerrainHeight = ApproximateTerrainHeights._defaultMaxTerrainHeight;
   if (defined(xyLevel)) {
-    const key = xyLevel.level + "-" + xyLevel.x + "-" + xyLevel.y;
+    const key = `${xyLevel.level}-${xyLevel.x}-${xyLevel.y}`;
     const heights = ApproximateTerrainHeights._terrainHeights[key];
     if (defined(heights)) {
       minTerrainHeight = heights[0];
@@ -150,7 +150,7 @@ ApproximateTerrainHeights.getBoundingSphere = function (rectangle, ellipsoid) {
   // Get the terrain max for that tile
   let maxTerrainHeight = ApproximateTerrainHeights._defaultMaxTerrainHeight;
   if (defined(xyLevel)) {
-    const key = xyLevel.level + "-" + xyLevel.x + "-" + xyLevel.y;
+    const key = `${xyLevel.level}-${xyLevel.x}-${xyLevel.y}`;
     const heights = ApproximateTerrainHeights._terrainHeights[key];
     if (defined(heights)) {
       maxTerrainHeight = heights[1];

--- a/Source/Core/ArcGISTiledElevationTerrainProvider.js
+++ b/Source/Core/ArcGISTiledElevationTerrainProvider.js
@@ -185,8 +185,7 @@ function ArcGISTiledElevationTerrainProvider(options) {
       return true;
     })
     .otherwise(function (error) {
-      const message =
-        "An error occurred while accessing " + that._resource.url + ".";
+      const message = `An error occurred while accessing ${that._resource.url}.`;
       TileProviderError.handleError(undefined, that, that._errorEvent, message);
       return when.reject(error);
     });
@@ -351,7 +350,7 @@ ArcGISTiledElevationTerrainProvider.prototype.requestTileGeometry = function (
   //>>includeEnd('debug');
 
   const tileResource = this._resource.getDerivedResource({
-    url: "tile/" + level + "/" + y + "/" + x,
+    url: `tile/${level}/${y}/${x}`,
     request: request,
   });
 
@@ -634,8 +633,7 @@ function requestAvailability(that, level, x, y) {
   const yOffset = Math.floor(y / 128) * 128;
 
   const dim = Math.min(1 << level, 128);
-  const url =
-    "tilemap/" + level + "/" + yOffset + "/" + xOffset + "/" + dim + "/" + dim;
+  const url = `tilemap/${level}/${yOffset}/${xOffset}/${dim}/${dim}`;
 
   const availableCache = that._availableCache;
   if (defined(availableCache[url])) {

--- a/Source/Core/AttributeCompression.js
+++ b/Source/Core/AttributeCompression.js
@@ -121,7 +121,7 @@ AttributeCompression.octDecodeInRange = function (x, y, rangeMax, result) {
   Check.defined("result", result);
   if (x < 0 || x > rangeMax || y < 0 || y > rangeMax) {
     throw new DeveloperError(
-      "x and y must be unsigned normalized integers between 0 and " + rangeMax
+      `x and y must be unsigned normalized integers between 0 and ${rangeMax}`
     );
   }
   //>>includeEnd('debug');
@@ -456,7 +456,7 @@ AttributeCompression.dequantize = function (
     //>>includeStart('debug', pragmas.debug);
     default:
       throw new DeveloperError(
-        "Cannot dequantize component datatype: " + componentDatatype
+        `Cannot dequantize component datatype: ${componentDatatype}`
       );
     //>>includeEnd('debug');
   }

--- a/Source/Core/Cartesian2.js
+++ b/Source/Core/Cartesian2.js
@@ -792,6 +792,6 @@ Cartesian2.prototype.equalsEpsilon = function (
  * @returns {String} A string representing the provided Cartesian in the format '(x, y)'.
  */
 Cartesian2.prototype.toString = function () {
-  return "(" + this.x + ", " + this.y + ")";
+  return `(${this.x}, ${this.y})`;
 };
 export default Cartesian2;

--- a/Source/Core/Cartesian3.js
+++ b/Source/Core/Cartesian3.js
@@ -1183,6 +1183,6 @@ Cartesian3.prototype.equalsEpsilon = function (
  * @returns {String} A string representing this Cartesian in the format '(x, y, z)'.
  */
 Cartesian3.prototype.toString = function () {
-  return "(" + this.x + ", " + this.y + ", " + this.z + ")";
+  return `(${this.x}, ${this.y}, ${this.z})`;
 };
 export default Cartesian3;

--- a/Source/Core/Cartesian4.js
+++ b/Source/Core/Cartesian4.js
@@ -874,7 +874,7 @@ Cartesian4.prototype.equalsEpsilon = function (
  * @returns {String} A string representing the provided Cartesian in the format '(x, y, z, w)'.
  */
 Cartesian4.prototype.toString = function () {
-  return "(" + this.x + ", " + this.y + ", " + this.z + ", " + this.w + ")";
+  return `(${this.x}, ${this.y}, ${this.z}, ${this.w})`;
 };
 
 // scratchU8Array and scratchF32Array are views into the same buffer

--- a/Source/Core/Cartographic.js
+++ b/Source/Core/Cartographic.js
@@ -297,6 +297,6 @@ Cartographic.prototype.equalsEpsilon = function (right, epsilon) {
  * @returns {String} A string representing the provided cartographic in the format '(longitude, latitude, height)'.
  */
 Cartographic.prototype.toString = function () {
-  return "(" + this.longitude + ", " + this.latitude + ", " + this.height + ")";
+  return `(${this.longitude}, ${this.latitude}, ${this.height})`;
 };
 export default Cartographic;

--- a/Source/Core/CesiumTerrainProvider.js
+++ b/Source/Core/CesiumTerrainProvider.js
@@ -201,8 +201,7 @@ function CesiumTerrainProvider(options) {
       hasWaterMask = true;
       that._requestWaterMask = true;
     } else if (data.format.indexOf("quantized-mesh-1.") !== 0) {
-      message =
-        'The tile format "' + data.format + '" is invalid or not supported.';
+      message = `The tile format "${data.format}" is invalid or not supported.`;
       metadataError = TileProviderError.handleError(
         metadataError,
         that,
@@ -235,8 +234,7 @@ function CesiumTerrainProvider(options) {
         ellipsoid: that._ellipsoid,
       });
     } else {
-      message =
-        'The projection "' + data.projection + '" is invalid or not supported.';
+      message = `The projection "${data.projection}" is invalid or not supported.`;
       metadataError = TileProviderError.handleError(
         metadataError,
         that,
@@ -258,7 +256,7 @@ function CesiumTerrainProvider(options) {
     if (!data.scheme || data.scheme === "tms" || data.scheme === "slippyMap") {
       that._scheme = data.scheme;
     } else {
-      message = 'The scheme "' + data.scheme + '" is invalid or not supported.';
+      message = `The scheme "${data.scheme}" is invalid or not supported.`;
       metadataError = TileProviderError.handleError(
         metadataError,
         that,
@@ -402,8 +400,7 @@ function CesiumTerrainProvider(options) {
   }
 
   function parseMetadataFailure(data) {
-    const message =
-      "An error occurred while accessing " + layerJsonResource.url + ".";
+    const message = `An error occurred while accessing ${layerJsonResource.url}.`;
     metadataError = TileProviderError.handleError(
       metadataError,
       that,
@@ -524,10 +521,7 @@ function getRequestHeader(extensionsList) {
   }
   const extensions = extensionsList.join("-");
   return {
-    Accept:
-      "application/vnd.quantized-mesh;extensions=" +
-      extensions +
-      ",application/octet-stream;q=0.9,*/*;q=0.01",
+    Accept: `application/vnd.quantized-mesh;extensions=${extensions},application/octet-stream;q=0.9,*/*;q=0.01`,
   };
 }
 
@@ -1281,7 +1275,7 @@ function checkLayer(provider, x, y, level, layer, topLayer) {
     ) {
       let requestPromise;
       if (!topLayer) {
-        cacheKey = tile.level + "-" + tile.x + "-" + tile.y;
+        cacheKey = `${tile.level}-${tile.x}-${tile.y}`;
         requestPromise = layer.availabilityPromiseCache[cacheKey];
         if (!defined(requestPromise)) {
           // For cutout terrain, if this isn't the top layer the availability tiles

--- a/Source/Core/Check.js
+++ b/Source/Core/Check.js
@@ -14,18 +14,11 @@ const Check = {};
 Check.typeOf = {};
 
 function getUndefinedErrorMessage(name) {
-  return name + " is required, actual value was undefined";
+  return `${name} is required, actual value was undefined`;
 }
 
 function getFailedTypeErrorMessage(actual, expected, name) {
-  return (
-    "Expected " +
-    name +
-    " to be typeof " +
-    expected +
-    ", actual typeof was " +
-    actual
-  );
+  return `Expected ${name} to be typeof ${expected}, actual typeof was ${actual}`;
 }
 
 /**
@@ -98,12 +91,7 @@ Check.typeOf.number.lessThan = function (name, test, limit) {
   Check.typeOf.number(name, test);
   if (test >= limit) {
     throw new DeveloperError(
-      "Expected " +
-        name +
-        " to be less than " +
-        limit +
-        ", actual value was " +
-        test
+      `Expected ${name} to be less than ${limit}, actual value was ${test}`
     );
   }
 };
@@ -120,12 +108,7 @@ Check.typeOf.number.lessThanOrEquals = function (name, test, limit) {
   Check.typeOf.number(name, test);
   if (test > limit) {
     throw new DeveloperError(
-      "Expected " +
-        name +
-        " to be less than or equal to " +
-        limit +
-        ", actual value was " +
-        test
+      `Expected ${name} to be less than or equal to ${limit}, actual value was ${test}`
     );
   }
 };
@@ -142,12 +125,7 @@ Check.typeOf.number.greaterThan = function (name, test, limit) {
   Check.typeOf.number(name, test);
   if (test <= limit) {
     throw new DeveloperError(
-      "Expected " +
-        name +
-        " to be greater than " +
-        limit +
-        ", actual value was " +
-        test
+      `Expected ${name} to be greater than ${limit}, actual value was ${test}`
     );
   }
 };
@@ -164,12 +142,7 @@ Check.typeOf.number.greaterThanOrEquals = function (name, test, limit) {
   Check.typeOf.number(name, test);
   if (test < limit) {
     throw new DeveloperError(
-      "Expected " +
-        name +
-        " to be greater than or equal to " +
-        limit +
-        ", actual value was " +
-        test
+      `Expected ${name} to be greater than or equal to ${limit}, actual value was ${test}`
     );
   }
 };
@@ -233,13 +206,7 @@ Check.typeOf.number.equals = function (name1, name2, test1, test2) {
   Check.typeOf.number(name2, test2);
   if (test1 !== test2) {
     throw new DeveloperError(
-      name1 +
-        " must be equal to " +
-        name2 +
-        ", the actual values are " +
-        test1 +
-        " and " +
-        test2
+      `${name1} must be equal to ${name2}, the actual values are ${test1} and ${test2}`
     );
   }
 };

--- a/Source/Core/Color.js
+++ b/Source/Core/Color.js
@@ -605,17 +605,7 @@ Color.prototype.equalsEpsilon = function (other, epsilon) {
  * @returns {String} A string representing this Color in the format '(red, green, blue, alpha)'.
  */
 Color.prototype.toString = function () {
-  return (
-    "(" +
-    this.red +
-    ", " +
-    this.green +
-    ", " +
-    this.blue +
-    ", " +
-    this.alpha +
-    ")"
-  );
+  return `(${this.red}, ${this.green}, ${this.blue}, ${this.alpha})`;
 };
 
 /**
@@ -630,9 +620,9 @@ Color.prototype.toCssColorString = function () {
   const green = Color.floatToByte(this.green);
   const blue = Color.floatToByte(this.blue);
   if (this.alpha === 1) {
-    return "rgb(" + red + "," + green + "," + blue + ")";
+    return `rgb(${red},${green},${blue})`;
   }
-  return "rgba(" + red + "," + green + "," + blue + "," + this.alpha + ")";
+  return `rgba(${red},${green},${blue},${this.alpha})`;
 };
 
 /**
@@ -643,24 +633,24 @@ Color.prototype.toCssColorString = function () {
 Color.prototype.toCssHexString = function () {
   let r = Color.floatToByte(this.red).toString(16);
   if (r.length < 2) {
-    r = "0" + r;
+    r = `0${r}`;
   }
   let g = Color.floatToByte(this.green).toString(16);
   if (g.length < 2) {
-    g = "0" + g;
+    g = `0${g}`;
   }
   let b = Color.floatToByte(this.blue).toString(16);
   if (b.length < 2) {
-    b = "0" + b;
+    b = `0${b}`;
   }
   if (this.alpha < 1) {
     let hexAlpha = Color.floatToByte(this.alpha).toString(16);
     if (hexAlpha.length < 2) {
-      hexAlpha = "0" + hexAlpha;
+      hexAlpha = `0${hexAlpha}`;
     }
-    return "#" + r + g + b + hexAlpha;
+    return `#${r}${g}${b}${hexAlpha}`;
   }
-  return "#" + r + g + b;
+  return `#${r}${g}${b}`;
 };
 
 /**

--- a/Source/Core/DeveloperError.js
+++ b/Source/Core/DeveloperError.js
@@ -55,10 +55,10 @@ if (defined(Object.create)) {
 }
 
 DeveloperError.prototype.toString = function () {
-  let str = this.name + ": " + this.message;
+  let str = `${this.name}: ${this.message}`;
 
   if (defined(this.stack)) {
-    str += "\n" + this.stack.toString();
+    str += `\n${this.stack.toString()}`;
   }
 
   return str;

--- a/Source/Core/EarthOrientationParameters.js
+++ b/Source/Core/EarthOrientationParameters.js
@@ -87,10 +87,7 @@ function EarthOrientationParameters(options) {
         onDataReady(that, eopData);
       })
       .otherwise(function () {
-        that._dataError =
-          "An error occurred while retrieving the EOP data from the URL " +
-          resource.url +
-          ".";
+        that._dataError = `An error occurred while retrieving the EOP data from the URL ${resource.url}.`;
       });
   } else {
     // Use all zeros for EOP data.

--- a/Source/Core/Fullscreen.js
+++ b/Source/Core/Fullscreen.js
@@ -141,12 +141,12 @@ Fullscreen.supportsFullscreen = function () {
     const prefix = prefixes[i];
 
     // casing of Fullscreen differs across browsers
-    name = prefix + "RequestFullscreen";
+    name = `${prefix}RequestFullscreen`;
     if (typeof body[name] === "function") {
       _names.requestFullscreen = name;
       _supportsFullscreen = true;
     } else {
-      name = prefix + "RequestFullScreen";
+      name = `${prefix}RequestFullScreen`;
       if (typeof body[name] === "function") {
         _names.requestFullscreen = name;
         _supportsFullscreen = true;
@@ -154,42 +154,42 @@ Fullscreen.supportsFullscreen = function () {
     }
 
     // disagreement about whether it's "exit" as per spec, or "cancel"
-    name = prefix + "ExitFullscreen";
+    name = `${prefix}ExitFullscreen`;
     if (typeof document[name] === "function") {
       _names.exitFullscreen = name;
     } else {
-      name = prefix + "CancelFullScreen";
+      name = `${prefix}CancelFullScreen`;
       if (typeof document[name] === "function") {
         _names.exitFullscreen = name;
       }
     }
 
     // casing of Fullscreen differs across browsers
-    name = prefix + "FullscreenEnabled";
+    name = `${prefix}FullscreenEnabled`;
     if (document[name] !== undefined) {
       _names.fullscreenEnabled = name;
     } else {
-      name = prefix + "FullScreenEnabled";
+      name = `${prefix}FullScreenEnabled`;
       if (document[name] !== undefined) {
         _names.fullscreenEnabled = name;
       }
     }
 
     // casing of Fullscreen differs across browsers
-    name = prefix + "FullscreenElement";
+    name = `${prefix}FullscreenElement`;
     if (document[name] !== undefined) {
       _names.fullscreenElement = name;
     } else {
-      name = prefix + "FullScreenElement";
+      name = `${prefix}FullScreenElement`;
       if (document[name] !== undefined) {
         _names.fullscreenElement = name;
       }
     }
 
     // thankfully, event names are all lowercase per spec
-    name = prefix + "fullscreenchange";
+    name = `${prefix}fullscreenchange`;
     // event names do not have 'on' in the front, but the property on the document does
-    if (document["on" + name] !== undefined) {
+    if (document[`on${name}`] !== undefined) {
       //except on IE
       if (prefix === "ms") {
         name = "MSFullscreenChange";
@@ -197,8 +197,8 @@ Fullscreen.supportsFullscreen = function () {
       _names.fullscreenchange = name;
     }
 
-    name = prefix + "fullscreenerror";
-    if (document["on" + name] !== undefined) {
+    name = `${prefix}fullscreenerror`;
+    if (document[`on${name}`] !== undefined) {
       //except on IE
       if (prefix === "ms") {
         name = "MSFullscreenError";

--- a/Source/Core/GeometryPipeline.js
+++ b/Source/Core/GeometryPipeline.js
@@ -180,9 +180,7 @@ GeometryPipeline.createLineSegmentsForVectors = function (
   }
   if (!defined(geometry.attributes[attributeName])) {
     throw new DeveloperError(
-      "geometry.attributes must have an attribute with the same name as the attributeName parameter, " +
-        attributeName +
-        "."
+      `geometry.attributes must have an attribute with the same name as the attributeName parameter, ${attributeName}.`
     );
   }
   //>>includeEnd('debug');
@@ -638,9 +636,7 @@ GeometryPipeline.projectTo2D = function (
   }
   if (!defined(geometry.attributes[attributeName])) {
     throw new DeveloperError(
-      "geometry must have attribute matching the attributeName argument: " +
-        attributeName +
-        "."
+      `geometry must have attribute matching the attributeName argument: ${attributeName}.`
     );
   }
   if (
@@ -676,13 +672,7 @@ GeometryPipeline.projectTo2D = function (
     //>>includeStart('debug', pragmas.debug);
     if (!defined(lonLat)) {
       throw new DeveloperError(
-        "Could not project point (" +
-          value.x +
-          ", " +
-          value.y +
-          ", " +
-          value.z +
-          ") to 2D."
+        `Could not project point (${value.x}, ${value.y}, ${value.z}) to 2D.`
       );
     }
     //>>includeEnd('debug');
@@ -756,9 +746,7 @@ GeometryPipeline.encodeAttribute = function (
   }
   if (!defined(geometry.attributes[attributeName])) {
     throw new DeveloperError(
-      "geometry must have attribute matching the attributeName argument: " +
-        attributeName +
-        "."
+      `geometry must have attribute matching the attributeName argument: ${attributeName}.`
     );
   }
   if (

--- a/Source/Core/GoogleEarthEnterpriseMetadata.js
+++ b/Source/Core/GoogleEarthEnterpriseMetadata.js
@@ -124,10 +124,9 @@ function GoogleEarthEnterpriseMetadata(resourceOrUrl) {
       return true;
     })
     .otherwise(function (e) {
-      const message =
-        "An error occurred while accessing " +
-        getMetadataResource(that, "", 1).url +
-        ".";
+      const message = `An error occurred while accessing ${
+        getMetadataResource(that, "", 1).url
+      }.`;
       return when.reject(new RuntimeError(message));
     });
 }
@@ -430,7 +429,7 @@ function populateSubtree(that, quadKey, request) {
   //   undefined so no parent exists - this shouldn't ever happen once the provider is ready
   if (!defined(t) || !t.hasSubtree()) {
     return when.reject(
-      new RuntimeError("Couldn't load metadata for tile " + quadKey)
+      new RuntimeError(`Couldn't load metadata for tile ${quadKey}`)
     );
   }
 
@@ -494,7 +493,7 @@ GoogleEarthEnterpriseMetadata.prototype.getTileInformationFromQuadKey = function
 
 function getMetadataResource(that, quadKey, version, request) {
   return that._resource.getDerivedResource({
-    url: "flatfile?q2-0" + quadKey + "-q." + version.toString(),
+    url: `flatfile?q2-0${quadKey}-q.${version.toString()}`,
     request: request,
   });
 }
@@ -592,7 +591,7 @@ function requestDbRoot(that) {
     })
     .otherwise(function () {
       // Just eat the error and use the default values.
-      console.log("Failed to retrieve " + resource.url + ". Using defaults.");
+      console.log(`Failed to retrieve ${resource.url}. Using defaults.`);
       that.key = defaultKey;
     });
 }

--- a/Source/Core/GoogleEarthEnterpriseTerrainProvider.js
+++ b/Source/Core/GoogleEarthEnterpriseTerrainProvider.js
@@ -142,7 +142,7 @@ function GoogleEarthEnterpriseTerrainProvider(options) {
     .then(function (result) {
       if (!metadata.terrainPresent) {
         const e = new RuntimeError(
-          "The server " + metadata.url + " doesn't have terrain"
+          `The server ${metadata.url} doesn't have terrain`
         );
         metadataError = TileProviderError.handleError(
           metadataError,
@@ -635,7 +635,7 @@ GoogleEarthEnterpriseTerrainProvider.prototype.loadTileDataAvailability = functi
 function buildTerrainResource(terrainProvider, quadKey, version, request) {
   version = defined(version) && version > 0 ? version : 1;
   return terrainProvider._metadata.resource.getDerivedResource({
-    url: "flatfile?f1c-0" + quadKey + "-t." + version.toString(),
+    url: `flatfile?f1c-0${quadKey}-t.${version.toString()}`,
     request: request,
   });
 }

--- a/Source/Core/HeadingPitchRoll.js
+++ b/Source/Core/HeadingPitchRoll.js
@@ -231,6 +231,6 @@ HeadingPitchRoll.prototype.equalsEpsilon = function (
  * @returns {String} A string representing the provided HeadingPitchRoll in the format '(heading, pitch, roll)'.
  */
 HeadingPitchRoll.prototype.toString = function () {
-  return "(" + this.heading + ", " + this.pitch + ", " + this.roll + ")";
+  return `(${this.heading}, ${this.pitch}, ${this.roll})`;
 };
 export default HeadingPitchRoll;

--- a/Source/Core/Iau2006XysData.js
+++ b/Source/Core/Iau2006XysData.js
@@ -260,9 +260,7 @@ function requestXysChunk(xysData, chunkIndex) {
     });
   } else {
     chunkUrl = new Resource({
-      url: buildModuleUrl(
-        "Assets/IAU2006_XYS/IAU2006_XYS_" + chunkIndex + ".json"
-      ),
+      url: buildModuleUrl(`Assets/IAU2006_XYS/IAU2006_XYS_${chunkIndex}.json`),
     });
   }
 

--- a/Source/Core/IonResource.js
+++ b/Source/Core/IonResource.js
@@ -197,7 +197,7 @@ IonResource.prototype._makeRequest = function (options) {
   if (!defined(options.headers)) {
     options.headers = {};
   }
-  options.headers.Authorization = "Bearer " + this._ionEndpoint.accessToken;
+  options.headers.Authorization = `Bearer ${this._ionEndpoint.accessToken}`;
 
   return Resource.prototype._makeRequest.call(this, options);
 };
@@ -216,7 +216,7 @@ IonResource._createEndpointResource = function (assetId, options) {
   server = Resource.createIfNeeded(server);
 
   const resourceOptions = {
-    url: "v1/assets/" + assetId + "/endpoint",
+    url: `v1/assets/${assetId}/endpoint`,
   };
 
   if (defined(accessToken)) {

--- a/Source/Core/JulianDate.js
+++ b/Source/Core/JulianDate.js
@@ -786,40 +786,30 @@ JulianDate.toIso8601 = function (julianDate, precision) {
   if (!defined(precision) && millisecond !== 0) {
     //Forces milliseconds into a number with at least 3 digits to whatever the default toString() precision is.
     millisecondStr = (millisecond * 0.01).toString().replace(".", "");
-    return (
-      year.toString().padStart(4, "0") +
-      "-" +
-      month.toString().padStart(2, "0") +
-      "-" +
-      day.toString().padStart(2, "0") +
-      "T" +
-      hour.toString().padStart(2, "0") +
-      ":" +
-      minute.toString().padStart(2, "0") +
-      ":" +
-      second.toString().padStart(2, "0") +
-      "." +
-      millisecondStr +
-      "Z"
-    );
+    return `${year.toString().padStart(4, "0")}-${month
+      .toString()
+      .padStart(2, "0")}-${day
+      .toString()
+      .padStart(2, "0")}T${hour
+      .toString()
+      .padStart(2, "0")}:${minute
+      .toString()
+      .padStart(2, "0")}:${second
+      .toString()
+      .padStart(2, "0")}.${millisecondStr}Z`;
   }
 
   //Precision is either 0 or milliseconds is 0 with undefined precision, in either case, leave off milliseconds entirely
   if (!defined(precision) || precision === 0) {
-    return (
-      year.toString().padStart(4, "0") +
-      "-" +
-      month.toString().padStart(2, "0") +
-      "-" +
-      day.toString().padStart(2, "0") +
-      "T" +
-      hour.toString().padStart(2, "0") +
-      ":" +
-      minute.toString().padStart(2, "0") +
-      ":" +
-      second.toString().padStart(2, "0") +
-      "Z"
-    );
+    return `${year.toString().padStart(4, "0")}-${month
+      .toString()
+      .padStart(2, "0")}-${day
+      .toString()
+      .padStart(2, "0")}T${hour
+      .toString()
+      .padStart(2, "0")}:${minute
+      .toString()
+      .padStart(2, "0")}:${second.toString().padStart(2, "0")}Z`;
   }
 
   //Forces milliseconds into a number with at least 3 digits to whatever the specified precision is.
@@ -827,22 +817,17 @@ JulianDate.toIso8601 = function (julianDate, precision) {
     .toFixed(precision)
     .replace(".", "")
     .slice(0, precision);
-  return (
-    year.toString().padStart(4, "0") +
-    "-" +
-    month.toString().padStart(2, "0") +
-    "-" +
-    day.toString().padStart(2, "0") +
-    "T" +
-    hour.toString().padStart(2, "0") +
-    ":" +
-    minute.toString().padStart(2, "0") +
-    ":" +
-    second.toString().padStart(2, "0") +
-    "." +
-    millisecondStr +
-    "Z"
-  );
+  return `${year.toString().padStart(4, "0")}-${month
+    .toString()
+    .padStart(2, "0")}-${day
+    .toString()
+    .padStart(2, "0")}T${hour
+    .toString()
+    .padStart(2, "0")}:${minute
+    .toString()
+    .padStart(2, "0")}:${second
+    .toString()
+    .padStart(2, "0")}.${millisecondStr}Z`;
 };
 
 /**

--- a/Source/Core/Matrix2.js
+++ b/Source/Core/Matrix2.js
@@ -861,17 +861,6 @@ Matrix2.prototype.equalsEpsilon = function (right, epsilon) {
  * @returns {String} A string representing the provided Matrix with each row being on a separate line and in the format '(column0, column1)'.
  */
 Matrix2.prototype.toString = function () {
-  return (
-    "(" +
-    this[0] +
-    ", " +
-    this[2] +
-    ")\n" +
-    "(" +
-    this[1] +
-    ", " +
-    this[3] +
-    ")"
-  );
+  return `(${this[0]}, ${this[2]})\n` + `(${this[1]}, ${this[3]})`;
 };
 export default Matrix2;

--- a/Source/Core/Matrix3.js
+++ b/Source/Core/Matrix3.js
@@ -1605,27 +1605,9 @@ Matrix3.prototype.equalsEpsilon = function (right, epsilon) {
  */
 Matrix3.prototype.toString = function () {
   return (
-    "(" +
-    this[0] +
-    ", " +
-    this[3] +
-    ", " +
-    this[6] +
-    ")\n" +
-    "(" +
-    this[1] +
-    ", " +
-    this[4] +
-    ", " +
-    this[7] +
-    ")\n" +
-    "(" +
-    this[2] +
-    ", " +
-    this[5] +
-    ", " +
-    this[8] +
-    ")"
+    `(${this[0]}, ${this[3]}, ${this[6]})\n` +
+    `(${this[1]}, ${this[4]}, ${this[7]})\n` +
+    `(${this[2]}, ${this[5]}, ${this[8]})`
   );
 };
 export default Matrix3;

--- a/Source/Core/Matrix4.js
+++ b/Source/Core/Matrix4.js
@@ -2931,42 +2931,10 @@ Matrix4.prototype.equalsEpsilon = function (right, epsilon) {
  */
 Matrix4.prototype.toString = function () {
   return (
-    "(" +
-    this[0] +
-    ", " +
-    this[4] +
-    ", " +
-    this[8] +
-    ", " +
-    this[12] +
-    ")\n" +
-    "(" +
-    this[1] +
-    ", " +
-    this[5] +
-    ", " +
-    this[9] +
-    ", " +
-    this[13] +
-    ")\n" +
-    "(" +
-    this[2] +
-    ", " +
-    this[6] +
-    ", " +
-    this[10] +
-    ", " +
-    this[14] +
-    ")\n" +
-    "(" +
-    this[3] +
-    ", " +
-    this[7] +
-    ", " +
-    this[11] +
-    ", " +
-    this[15] +
-    ")"
+    `(${this[0]}, ${this[4]}, ${this[8]}, ${this[12]})\n` +
+    `(${this[1]}, ${this[5]}, ${this[9]}, ${this[13]})\n` +
+    `(${this[2]}, ${this[6]}, ${this[10]}, ${this[14]})\n` +
+    `(${this[3]}, ${this[7]}, ${this[11]}, ${this[15]})`
   );
 };
 export default Matrix4;

--- a/Source/Core/PinBuilder.js
+++ b/Source/Core/PinBuilder.js
@@ -85,7 +85,7 @@ PinBuilder.prototype.fromMakiIconId = function (id, color, size) {
   }
   //>>includeEnd('debug');
   return createPin(
-    buildModuleUrl("Assets/Textures/maki/" + encodeURIComponent(id) + ".png"),
+    buildModuleUrl(`Assets/Textures/maki/${encodeURIComponent(id)}.png`),
     undefined,
     color,
     size,
@@ -223,7 +223,7 @@ function createPin(url, label, color, size, cache) {
   } else if (defined(label)) {
     //If we have a label, write it to a canvas and then stamp the pin.
     const image = writeTextToCanvas(label, {
-      font: "bold " + size + "px sans-serif",
+      font: `bold ${size}px sans-serif`,
     });
     drawIcon(context2D, image, size);
   }

--- a/Source/Core/PolygonPipeline.js
+++ b/Source/Core/PolygonPipeline.js
@@ -190,7 +190,7 @@ PolygonPipeline.computeSubdivision = function (
     // of the granularity, subdivide the triangle
     if (max > minDistanceSqrd) {
       if (g0 === max) {
-        edge = Math.min(i0, i1) + " " + Math.max(i0, i1);
+        edge = `${Math.min(i0, i1)} ${Math.max(i0, i1)}`;
 
         i = edges[edge];
         if (!defined(i)) {
@@ -204,7 +204,7 @@ PolygonPipeline.computeSubdivision = function (
         triangles.push(i0, i, i2);
         triangles.push(i, i1, i2);
       } else if (g1 === max) {
-        edge = Math.min(i1, i2) + " " + Math.max(i1, i2);
+        edge = `${Math.min(i1, i2)} ${Math.max(i1, i2)}`;
 
         i = edges[edge];
         if (!defined(i)) {
@@ -218,7 +218,7 @@ PolygonPipeline.computeSubdivision = function (
         triangles.push(i1, i, i0);
         triangles.push(i, i2, i0);
       } else if (g2 === max) {
-        edge = Math.min(i2, i0) + " " + Math.max(i2, i0);
+        edge = `${Math.min(i2, i0)} ${Math.max(i2, i0)}`;
 
         i = edges[edge];
         if (!defined(i)) {
@@ -354,7 +354,7 @@ PolygonPipeline.computeRhumbLineSubdivision = function (
     // if the max length squared of a triangle edge is greater than granularity, subdivide the triangle
     if (max > minDistance) {
       if (g0 === max) {
-        edge = Math.min(i0, i1) + " " + Math.max(i0, i1);
+        edge = `${Math.min(i0, i1)} ${Math.max(i0, i1)}`;
 
         i = edges[edge];
         if (!defined(i)) {
@@ -382,7 +382,7 @@ PolygonPipeline.computeRhumbLineSubdivision = function (
         triangles.push(i0, i, i2);
         triangles.push(i, i1, i2);
       } else if (g1 === max) {
-        edge = Math.min(i1, i2) + " " + Math.max(i1, i2);
+        edge = `${Math.min(i1, i2)} ${Math.max(i1, i2)}`;
 
         i = edges[edge];
         if (!defined(i)) {
@@ -410,7 +410,7 @@ PolygonPipeline.computeRhumbLineSubdivision = function (
         triangles.push(i1, i, i0);
         triangles.push(i, i2, i0);
       } else if (g2 === max) {
-        edge = Math.min(i2, i0) + " " + Math.max(i2, i0);
+        edge = `${Math.min(i2, i0)} ${Math.max(i2, i0)}`;
 
         i = edges[edge];
         if (!defined(i)) {

--- a/Source/Core/Quaternion.js
+++ b/Source/Core/Quaternion.js
@@ -1136,6 +1136,6 @@ Quaternion.prototype.equalsEpsilon = function (right, epsilon) {
  * @returns {String} A string representing this Quaternion.
  */
 Quaternion.prototype.toString = function () {
-  return "(" + this.x + ", " + this.y + ", " + this.z + ", " + this.w + ")";
+  return `(${this.x}, ${this.y}, ${this.z}, ${this.w})`;
 };
 export default Quaternion;

--- a/Source/Core/RequestErrorEvent.js
+++ b/Source/Core/RequestErrorEvent.js
@@ -51,7 +51,7 @@ function RequestErrorEvent(statusCode, response, responseHeaders) {
 RequestErrorEvent.prototype.toString = function () {
   let str = "Request has failed.";
   if (defined(this.statusCode)) {
-    str += " Status Code: " + this.statusCode;
+    str += ` Status Code: ${this.statusCode}`;
   }
   return str;
 };

--- a/Source/Core/RequestScheduler.js
+++ b/Source/Core/RequestScheduler.js
@@ -359,7 +359,7 @@ RequestScheduler.getServerKey = function (url) {
   let serverKey = uri.authority();
   if (!/:/.test(serverKey)) {
     // If the authority does not contain a port number, add port 443 for https or port 80 for http
-    serverKey = serverKey + ":" + (uri.scheme() === "https" ? "443" : "80");
+    serverKey = `${serverKey}:${uri.scheme() === "https" ? "443" : "80"}`;
   }
 
   const length = numberOfActiveRequestsByServer[serverKey];
@@ -445,29 +445,28 @@ function updateStatistics() {
   ) {
     if (statistics.numberOfAttemptedRequests > 0) {
       console.log(
-        "Number of attempted requests: " + statistics.numberOfAttemptedRequests
+        `Number of attempted requests: ${statistics.numberOfAttemptedRequests}`
       );
       statistics.numberOfAttemptedRequests = 0;
     }
 
     if (statistics.numberOfCancelledRequests > 0) {
       console.log(
-        "Number of cancelled requests: " + statistics.numberOfCancelledRequests
+        `Number of cancelled requests: ${statistics.numberOfCancelledRequests}`
       );
       statistics.numberOfCancelledRequests = 0;
     }
 
     if (statistics.numberOfCancelledActiveRequests > 0) {
       console.log(
-        "Number of cancelled active requests: " +
-          statistics.numberOfCancelledActiveRequests
+        `Number of cancelled active requests: ${statistics.numberOfCancelledActiveRequests}`
       );
       statistics.numberOfCancelledActiveRequests = 0;
     }
 
     if (statistics.numberOfFailedRequests > 0) {
       console.log(
-        "Number of failed requests: " + statistics.numberOfFailedRequests
+        `Number of failed requests: ${statistics.numberOfFailedRequests}`
       );
       statistics.numberOfFailedRequests = 0;
     }

--- a/Source/Core/Resource.js
+++ b/Source/Core/Resource.js
@@ -1265,8 +1265,9 @@ Resource.prototype.fetchJsonp = function (callbackParameterName) {
   //generate a unique function name
   let functionName;
   do {
-    functionName =
-      "loadJsonp" + CesiumMath.nextRandomNumber().toString().substring(2, 8);
+    functionName = `loadJsonp${CesiumMath.nextRandomNumber()
+      .toString()
+      .substring(2, 8)}`;
   } while (defined(window[functionName]));
 
   return fetchJsonp(this, callbackParameterName, functionName);
@@ -1459,7 +1460,7 @@ function decodeDataUri(dataUriRegexResult, responseType) {
       return JSON.parse(decodeDataUriText(isBase64, data));
     default:
       //>>includeStart('debug', pragmas.debug);
-      throw new DeveloperError("Unhandled responseType: " + responseType);
+      throw new DeveloperError(`Unhandled responseType: ${responseType}`);
     //>>includeEnd('debug');
   }
 }
@@ -1951,9 +1952,7 @@ Resource._Implementations.createImage = function (
           if (!defined(blob)) {
             deferred.reject(
               new RuntimeError(
-                "Successfully retrieved " +
-                  url +
-                  " but it contained no content."
+                `Successfully retrieved ${url} but it contained no content.`
               )
             );
             return;

--- a/Source/Core/RuntimeError.js
+++ b/Source/Core/RuntimeError.js
@@ -54,10 +54,10 @@ if (defined(Object.create)) {
 }
 
 RuntimeError.prototype.toString = function () {
-  let str = this.name + ": " + this.message;
+  let str = `${this.name}: ${this.message}`;
 
   if (defined(this.stack)) {
-    str += "\n" + this.stack.toString();
+    str += `\n${this.stack.toString()}`;
   }
 
   return str;

--- a/Source/Core/S2Cell.js
+++ b/Source/Core/S2Cell.js
@@ -453,12 +453,10 @@ S2Cell.fromFacePositionLevel = function (face, position, level) {
 
   // eslint-disable-next-line
   var cellId = BigInt(
-    "0b" +
-      faceBitString +
-      positionPrefixPadding +
-      positionBitString +
-      "1" + // Adding the sentinel bit that always follows the position bits.
+    `0b${faceBitString}${positionPrefixPadding}${positionBitString}1${
+      // Adding the sentinel bit that always follows the position bits.
       positionSuffixPadding
+    }`
   );
   return new S2Cell(cellId);
 };

--- a/Source/Core/ScreenSpaceEventHandler.js
+++ b/Source/Core/ScreenSpaceEventHandler.js
@@ -26,7 +26,7 @@ function getPosition(screenSpaceEventHandler, event, result) {
 function getInputEventKey(type, modifier) {
   let key = type;
   if (defined(modifier)) {
-    key += "+" + modifier;
+    key += `+${modifier}`;
   }
   return key;
 }

--- a/Source/Core/Spherical.js
+++ b/Source/Core/Spherical.js
@@ -179,6 +179,6 @@ Spherical.prototype.equalsEpsilon = function (other, epsilon) {
  * @returns {String} A string representing this instance.
  */
 Spherical.prototype.toString = function () {
-  return "(" + this.clock + ", " + this.cone + ", " + this.magnitude + ")";
+  return `(${this.clock}, ${this.cone}, ${this.magnitude})`;
 };
 export default Spherical;

--- a/Source/Core/TaskProcessor.js
+++ b/Source/Core/TaskProcessor.js
@@ -98,7 +98,7 @@ function getWorkerUrl(moduleID) {
 
   if (isCrossOriginUrl(url)) {
     //to load cross-origin, create a shim worker from a blob URL
-    const script = 'importScripts("' + url + '");';
+    const script = `importScripts("${url}");`;
 
     let blob;
     try {
@@ -167,8 +167,7 @@ function getWebAssemblyLoaderConfig(processor, wasmOptions) {
   if (!FeatureDetection.supportsWebAssembly()) {
     if (!defined(wasmOptions.fallbackModulePath)) {
       throw new RuntimeError(
-        "This browser does not support Web Assembly, and no backup module was provided for " +
-          processor._workerPath
+        `This browser does not support Web Assembly, and no backup module was provided for ${processor._workerPath}`
       );
     }
 

--- a/Source/Core/TileProviderError.js
+++ b/Source/Core/TileProviderError.js
@@ -146,10 +146,9 @@ TileProviderError.handleError = function (
     event.raiseEvent(error);
   } else {
     console.log(
-      'An error occurred in "' +
-        provider.constructor.name +
-        '": ' +
-        formatError(message)
+      `An error occurred in "${provider.constructor.name}": ${formatError(
+        message
+      )}`
     );
   }
 

--- a/Source/Core/TimeInterval.js
+++ b/Source/Core/TimeInterval.js
@@ -183,11 +183,10 @@ TimeInterval.toIso8601 = function (timeInterval, precision) {
   Check.typeOf.object("timeInterval", timeInterval);
   //>>includeEnd('debug');
 
-  return (
-    JulianDate.toIso8601(timeInterval.start, precision) +
-    "/" +
-    JulianDate.toIso8601(timeInterval.stop, precision)
-  );
+  return `${JulianDate.toIso8601(
+    timeInterval.start,
+    precision
+  )}/${JulianDate.toIso8601(timeInterval.stop, precision)}`;
 };
 
 /**

--- a/Source/Core/TrustedServers.js
+++ b/Source/Core/TrustedServers.js
@@ -33,7 +33,7 @@ TrustedServers.add = function (host, port) {
   }
   //>>includeEnd('debug');
 
-  const authority = host.toLowerCase() + ":" + port;
+  const authority = `${host.toLowerCase()}:${port}`;
   if (!defined(_servers[authority])) {
     _servers[authority] = true;
   }
@@ -59,7 +59,7 @@ TrustedServers.remove = function (host, port) {
   }
   //>>includeEnd('debug');
 
-  const authority = host.toLowerCase() + ":" + port;
+  const authority = `${host.toLowerCase()}:${port}`;
   if (defined(_servers[authority])) {
     delete _servers[authority];
   }

--- a/Source/Core/VRTheWorldTerrainProvider.js
+++ b/Source/Core/VRTheWorldTerrainProvider.js
@@ -86,7 +86,7 @@ function VRTheWorldTerrainProvider(options) {
     if (srs === "EPSG:4326") {
       that._tilingScheme = new GeographicTilingScheme({ ellipsoid: ellipsoid });
     } else {
-      metadataFailure("SRS " + srs + " is not supported.");
+      metadataFailure(`SRS ${srs} is not supported.`);
       return;
     }
 
@@ -130,7 +130,7 @@ function VRTheWorldTerrainProvider(options) {
   function metadataFailure(e) {
     const message = defaultValue(
       e,
-      "An error occurred while accessing " + that._resource.url + "."
+      `An error occurred while accessing ${that._resource.url}.`
     );
     metadataError = TileProviderError.handleError(
       metadataError,
@@ -296,7 +296,7 @@ VRTheWorldTerrainProvider.prototype.requestTileGeometry = function (
 
   const yTiles = this._tilingScheme.getNumberOfYTilesAtLevel(level);
   const resource = this._resource.getDerivedResource({
-    url: level + "/" + x + "/" + (yTiles - y - 1) + ".tif",
+    url: `${level}/${x}/${yTiles - y - 1}.tif`,
     queryParameters: {
       cesium: true,
     },

--- a/Source/Core/appendForwardSlash.js
+++ b/Source/Core/appendForwardSlash.js
@@ -3,7 +3,7 @@
  */
 function appendForwardSlash(url) {
   if (url.length === 0 || url[url.length - 1] !== "/") {
-    url = url + "/";
+    url = `${url}/`;
   }
   return url;
 }

--- a/Source/Core/cancelAnimationFrame.js
+++ b/Source/Core/cancelAnimationFrame.js
@@ -12,9 +12,9 @@ if (typeof cancelAnimationFrame !== "undefined") {
     let i = 0;
     const len = vendors.length;
     while (i < len && !defined(implementation)) {
-      implementation = window[vendors[i] + "CancelAnimationFrame"];
+      implementation = window[`${vendors[i]}CancelAnimationFrame`];
       if (!defined(implementation)) {
-        implementation = window[vendors[i] + "CancelRequestAnimationFrame"];
+        implementation = window[`${vendors[i]}CancelRequestAnimationFrame`];
       }
       ++i;
     }

--- a/Source/Core/formatError.js
+++ b/Source/Core/formatError.js
@@ -15,14 +15,14 @@ function formatError(object) {
   const name = object.name;
   const message = object.message;
   if (defined(name) && defined(message)) {
-    result = name + ": " + message;
+    result = `${name}: ${message}`;
   } else {
     result = object.toString();
   }
 
   const stack = object.stack;
   if (defined(stack)) {
-    result += "\n" + stack;
+    result += `\n${stack}`;
   }
 
   return result;

--- a/Source/Core/getBaseUri.js
+++ b/Source/Core/getBaseUri.js
@@ -36,10 +36,10 @@ function getBaseUri(uri, includeQuery) {
 
   uri = new Uri(uri);
   if (uri.query().length !== 0) {
-    basePath += "?" + uri.query();
+    basePath += `?${uri.query()}`;
   }
   if (uri.fragment().length !== 0) {
-    basePath += "#" + uri.fragment();
+    basePath += `#${uri.fragment()}`;
   }
 
   return basePath;

--- a/Source/Core/objectToQuery.js
+++ b/Source/Core/objectToQuery.js
@@ -34,13 +34,13 @@ function objectToQuery(obj) {
     if (obj.hasOwnProperty(propName)) {
       const value = obj[propName];
 
-      const part = encodeURIComponent(propName) + "=";
+      const part = `${encodeURIComponent(propName)}=`;
       if (Array.isArray(value)) {
         for (let i = 0, len = value.length; i < len; ++i) {
-          result += part + encodeURIComponent(value[i]) + "&";
+          result += `${part + encodeURIComponent(value[i])}&`;
         }
       } else {
-        result += part + encodeURIComponent(value) + "&";
+        result += `${part + encodeURIComponent(value)}&`;
       }
     }
   }

--- a/Source/Core/requestAnimationFrame.js
+++ b/Source/Core/requestAnimationFrame.js
@@ -13,7 +13,7 @@ if (typeof requestAnimationFrame !== "undefined") {
     let i = 0;
     const len = vendors.length;
     while (i < len && !defined(implementation)) {
-      implementation = window[vendors[i] + "RequestAnimationFrame"];
+      implementation = window[`${vendors[i]}RequestAnimationFrame`];
       ++i;
     }
   }

--- a/Source/DataSources/CzmlDataSource.js
+++ b/Source/DataSources/CzmlDataSource.js
@@ -132,7 +132,7 @@ function createSpecializedProperty(type, entityCollection, packetData) {
     }
   }
 
-  throw new RuntimeError(JSON.stringify(packetData) + " is not valid CZML.");
+  throw new RuntimeError(`${JSON.stringify(packetData)} is not valid CZML.`);
 }
 
 function createAdapterProperty(property, adapterFunction) {
@@ -380,7 +380,7 @@ function unwrapCartesianInterval(czmlInterval) {
   }
 
   throw new RuntimeError(
-    JSON.stringify(czmlInterval) + " is not a valid CZML interval."
+    `${JSON.stringify(czmlInterval)} is not a valid CZML interval.`
   );
 }
 

--- a/Source/DataSources/Entity.js
+++ b/Source/DataSources/Entity.js
@@ -527,11 +527,11 @@ Entity.prototype.addProperty = function (propertyName) {
   }
   if (propertyNames.indexOf(propertyName) !== -1) {
     throw new DeveloperError(
-      propertyName + " is already a registered property."
+      `${propertyName} is already a registered property.`
     );
   }
   if (propertyName in this) {
-    throw new DeveloperError(propertyName + " is a reserved property name.");
+    throw new DeveloperError(`${propertyName} is a reserved property name.`);
   }
   //>>includeEnd('debug');
 
@@ -560,7 +560,7 @@ Entity.prototype.removeProperty = function (propertyName) {
     throw new DeveloperError("propertyName is required.");
   }
   if (index === -1) {
-    throw new DeveloperError(propertyName + " is not a registered property.");
+    throw new DeveloperError(`${propertyName} is not a registered property.`);
   }
   //>>includeEnd('debug');
 

--- a/Source/DataSources/EntityCollection.js
+++ b/Source/DataSources/EntityCollection.js
@@ -283,7 +283,7 @@ EntityCollection.prototype.add = function (entity) {
   const entities = this._entities;
   if (entities.contains(id)) {
     throw new RuntimeError(
-      "An entity with id " + id + " already exists in this collection."
+      `An entity with id ${id} already exists in this collection.`
     );
   }
 

--- a/Source/DataSources/GeoJsonDataSource.js
+++ b/Source/DataSources/GeoJsonDataSource.js
@@ -76,24 +76,16 @@ function defaultDescribe(properties, nameProperty) {
       const value = properties[key];
       if (defined(value)) {
         if (typeof value === "object") {
-          html +=
-            "<tr><th>" +
-            key +
-            "</th><td>" +
-            defaultDescribe(value) +
-            "</td></tr>";
+          html += `<tr><th>${key}</th><td>${defaultDescribe(value)}</td></tr>`;
         } else {
-          html += "<tr><th>" + key + "</th><td>" + value + "</td></tr>";
+          html += `<tr><th>${key}</th><td>${value}</td></tr>`;
         }
       }
     }
   }
 
   if (html.length > 0) {
-    html =
-      '<table class="cesium-infoBox-defaultTable"><tbody>' +
-      html +
-      "</tbody></table>";
+    html = `<table class="cesium-infoBox-defaultTable"><tbody>${html}</tbody></table>`;
   }
 
   return html;
@@ -127,7 +119,7 @@ function createObject(geoJson, entityCollection, describe) {
     let i = 2;
     let finalId = id;
     while (defined(entityCollection.getById(finalId))) {
-      finalId = id + "_" + i;
+      finalId = `${id}_${i}`;
       i++;
     }
     id = finalId;
@@ -235,7 +227,7 @@ function processFeature(dataSource, feature, notUsed, crsFunction, options) {
   const geometryType = feature.geometry.type;
   const geometryHandler = geometryTypes[geometryType];
   if (!defined(geometryHandler)) {
-    throw new RuntimeError("Unknown geometry type: " + geometryType);
+    throw new RuntimeError(`Unknown geometry type: ${geometryType}`);
   }
   geometryHandler(dataSource, feature, feature.geometry, crsFunction, options);
 }
@@ -266,7 +258,7 @@ function processGeometryCollection(
     const geometryType = geometry.type;
     const geometryHandler = geometryTypes[geometryType];
     if (!defined(geometryHandler)) {
-      throw new RuntimeError("Unknown geometry type: " + geometryType);
+      throw new RuntimeError(`Unknown geometry type: ${geometryType}`);
     }
     geometryHandler(dataSource, geoJson, geometry, crsFunction, options);
   }
@@ -998,7 +990,7 @@ function load(that, geoJson, options, sourceUri) {
 
   const typeHandler = geoJsonObjectTypes[geoJson.type];
   if (!defined(typeHandler)) {
-    throw new RuntimeError("Unsupported GeoJSON object type: " + geoJson.type);
+    throw new RuntimeError(`Unsupported GeoJSON object type: ${geoJson.type}`);
   }
 
   //Check for a Coordinate Reference System.
@@ -1014,7 +1006,7 @@ function load(that, geoJson, options, sourceUri) {
     if (crs.type === "name") {
       crsFunction = crsNames[properties.name];
       if (!defined(crsFunction)) {
-        throw new RuntimeError("Unknown crs name: " + properties.name);
+        throw new RuntimeError(`Unknown crs name: ${properties.name}`);
       }
     } else if (crs.type === "link") {
       let handler = crsLinkHrefs[properties.href];
@@ -1024,18 +1016,18 @@ function load(that, geoJson, options, sourceUri) {
 
       if (!defined(handler)) {
         throw new RuntimeError(
-          "Unable to resolve crs link: " + JSON.stringify(properties)
+          `Unable to resolve crs link: ${JSON.stringify(properties)}`
         );
       }
 
       crsFunction = handler(properties);
     } else if (crs.type === "EPSG") {
-      crsFunction = crsNames["EPSG:" + properties.code];
+      crsFunction = crsNames[`EPSG:${properties.code}`];
       if (!defined(crsFunction)) {
-        throw new RuntimeError("Unknown crs EPSG code: " + properties.code);
+        throw new RuntimeError(`Unknown crs EPSG code: ${properties.code}`);
       }
     } else {
-      throw new RuntimeError("Unknown crs type: " + crs.type);
+      throw new RuntimeError(`Unknown crs type: ${crs.type}`);
     }
   }
 

--- a/Source/DataSources/GeometryUpdater.js
+++ b/Source/DataSources/GeometryUpdater.js
@@ -68,7 +68,7 @@ function GeometryUpdater(options) {
   this._classificationTypeProperty = undefined;
   this._options = options.geometryOptions;
   this._geometryPropertyName = geometryPropertyName;
-  this._id = geometryPropertyName + "-" + entity.id;
+  this._id = `${geometryPropertyName}-${entity.id}`;
   this._observedPropertyNames = options.observedPropertyNames;
   this._supportsMaterialsforEntitiesOnTerrain = Entity.supportsMaterialsforEntitiesOnTerrain(
     options.scene

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -352,14 +352,14 @@ function insertNamespaces(text) {
 
   for (const key in namespaceMap) {
     if (namespaceMap.hasOwnProperty(key)) {
-      reg = RegExp("[< ]" + key + ":");
-      declaration = "xmlns:" + key + "=";
+      reg = RegExp(`[< ]${key}:`);
+      declaration = `xmlns:${key}=`;
       if (reg.test(text) && text.indexOf(declaration) === -1) {
         if (!defined(firstPart)) {
           firstPart = text.substr(0, text.indexOf("<kml") + 4);
           lastPart = text.substr(firstPart.length);
         }
-        firstPart += " " + declaration + '"' + namespaceMap[key] + '"';
+        firstPart += ` ${declaration}"${namespaceMap[key]}"`;
       }
     }
   }
@@ -853,12 +853,7 @@ function getIconHref(
     y = 7 - Math.min(y / 32, 7);
     const iconNum = 8 * y + x;
 
-    href =
-      "https://maps.google.com/mapfiles/kml/pal" +
-      palette +
-      "/icon" +
-      iconNum +
-      ".png";
+    href = `https://maps.google.com/mapfiles/kml/pal${palette}/icon${iconNum}.png`;
   }
 
   const hrefResource = resolveHref(href, sourceResource, uriResolver);
@@ -876,13 +871,13 @@ function getIconHref(
     );
     if (refreshMode === "onInterval" || refreshMode === "onExpire") {
       oneTimeWarning(
-        "kml-refreshMode-" + refreshMode,
-        "KML - Unsupported Icon refreshMode: " + refreshMode
+        `kml-refreshMode-${refreshMode}`,
+        `KML - Unsupported Icon refreshMode: ${refreshMode}`
       );
     } else if (viewRefreshMode === "onStop" || viewRefreshMode === "onRegion") {
       oneTimeWarning(
-        "kml-refreshMode-" + viewRefreshMode,
-        "KML - Unsupported Icon viewRefreshMode: " + viewRefreshMode
+        `kml-refreshMode-${viewRefreshMode}`,
+        `KML - Unsupported Icon viewRefreshMode: ${viewRefreshMode}`
       );
     }
 
@@ -1124,8 +1119,8 @@ function applyStyle(
       );
       if (listItemType === "radioFolder" || listItemType === "checkOffOnly") {
         oneTimeWarning(
-          "kml-listStyle-" + listItemType,
-          "KML - Unsupported ListStyle with listItemType: " + listItemType
+          `kml-listStyle-${listItemType}`,
+          `KML - Unsupported ListStyle with listItemType: ${listItemType}`
         );
       }
     }
@@ -1175,7 +1170,7 @@ function computeFinalStyle(
           if (defined(styleUrl)) {
             styleEntity = styleCollection.getById(styleUrl);
             if (!defined(styleEntity)) {
-              styleEntity = styleCollection.getById("#" + styleUrl);
+              styleEntity = styleCollection.getById(`#${styleUrl}`);
             }
             if (defined(styleEntity)) {
               result.merge(styleEntity);
@@ -1186,8 +1181,8 @@ function computeFinalStyle(
           }
         } else {
           oneTimeWarning(
-            "kml-styleMap-" + key,
-            "KML - Unsupported StyleMap key: " + key
+            `kml-styleMap-${key}`,
+            `KML - Unsupported StyleMap key: ${key}`
           );
         }
       }
@@ -1205,12 +1200,12 @@ function computeFinalStyle(
         url: uri,
       });
 
-      id = resource.getUrlComponent() + "#" + tokens[1];
+      id = `${resource.getUrlComponent()}#${tokens[1]}`;
     }
 
     styleEntity = styleCollection.getById(id);
     if (!defined(styleEntity)) {
-      styleEntity = styleCollection.getById("#" + id);
+      styleEntity = styleCollection.getById(`#${id}`);
     }
     if (defined(styleEntity)) {
       result.merge(styleEntity);
@@ -1251,7 +1246,7 @@ function processStyles(
       node = styleNodes[i];
       id = queryStringAttribute(node, "id");
       if (defined(id)) {
-        id = "#" + id;
+        id = `#${id}`;
         if (isExternal && defined(sourceResource)) {
           id = sourceResource.getUrlComponent() + id;
         }
@@ -1284,7 +1279,7 @@ function processStyles(
           const pair = pairs[p];
           const key = queryStringValue(pair, "key", namespaces.kml);
           if (key === "normal") {
-            id = "#" + id;
+            id = `#${id}`;
             if (isExternal && defined(sourceResource)) {
               id = sourceResource.getUrlComponent() + id;
             }
@@ -1294,7 +1289,7 @@ function processStyles(
               let styleUrl = queryStringValue(pair, "styleUrl", namespaces.kml);
               if (defined(styleUrl)) {
                 if (styleUrl[0] !== "#") {
-                  styleUrl = "#" + styleUrl;
+                  styleUrl = `#${styleUrl}`;
                 }
 
                 if (isExternal && defined(sourceResource)) {
@@ -1318,8 +1313,8 @@ function processStyles(
             }
           } else {
             oneTimeWarning(
-              "kml-styleMap-" + key,
-              "KML - Unsupported StyleMap key: " + key
+              `kml-styleMap-${key}`,
+              `KML - Unsupported StyleMap key: ${key}`
             );
           }
         }
@@ -1403,16 +1398,12 @@ function heightReferenceFromAltitudeMode(altitudeMode, gxAltitudeMode) {
   if (defined(altitudeMode)) {
     oneTimeWarning(
       "kml-altitudeMode-unknown",
-      "KML - Unknown <kml:altitudeMode>:" +
-        altitudeMode +
-        ", using <kml:altitudeMode>:CLAMP_TO_GROUND."
+      `KML - Unknown <kml:altitudeMode>:${altitudeMode}, using <kml:altitudeMode>:CLAMP_TO_GROUND.`
     );
   } else {
     oneTimeWarning(
       "kml-gx:altitudeMode-unknown",
-      "KML - Unknown <gx:altitudeMode>:" +
-        gxAltitudeMode +
-        ", using <kml:altitudeMode>:CLAMP_TO_GROUND."
+      `KML - Unknown <gx:altitudeMode>:${gxAltitudeMode}, using <kml:altitudeMode>:CLAMP_TO_GROUND.`
     );
   }
 
@@ -1440,8 +1431,10 @@ function createPositionPropertyFromAltitudeMode(
   ) {
     oneTimeWarning(
       "kml-altitudeMode-unknown",
-      "KML - Unknown altitudeMode: " +
-        defaultValue(altitudeMode, gxAltitudeMode)
+      `KML - Unknown altitudeMode: ${defaultValue(
+        altitudeMode,
+        gxAltitudeMode
+      )}`
     );
   }
 
@@ -1474,8 +1467,10 @@ function createPositionPropertyArrayFromAltitudeMode(
   ) {
     oneTimeWarning(
       "kml-altitudeMode-unknown",
-      "KML - Unknown altitudeMode: " +
-        defaultValue(altitudeMode, gxAltitudeMode)
+      `KML - Unknown altitudeMode: ${defaultValue(
+        altitudeMode,
+        gxAltitudeMode
+      )}`
     );
   }
 
@@ -2060,7 +2055,7 @@ function processUnsupportedGeometry(
 ) {
   oneTimeWarning(
     "kml-unsupportedGeometry",
-    "KML - Unsupported geometry: " + geometryNode.localName
+    `KML - Unsupported geometry: ${geometryNode.localName}`
   );
   return false;
 }
@@ -2180,12 +2175,10 @@ function processDescription(
       for (i = 0; i < keys.length; i++) {
         key = keys[i];
         value = extendedData[key];
-        text +=
-          "<tr><th>" +
-          defaultValue(value.displayName, key) +
-          "</th><td>" +
-          defaultValue(value.value, "") +
-          "</td></tr>";
+        text += `<tr><th>${defaultValue(
+          value.displayName,
+          key
+        )}</th><td>${defaultValue(value.value, "")}</td></tr>`;
       }
       text += "</tbody></table>";
     }
@@ -2242,10 +2235,10 @@ function processDescription(
   let tmp = '<div class="cesium-infoBox-description-lighter" style="';
   tmp += "overflow:auto;";
   tmp += "word-wrap:break-word;";
-  tmp += "background-color:" + background.toCssColorString() + ";";
-  tmp += "color:" + foreground.toCssColorString() + ";";
+  tmp += `background-color:${background.toCssColorString()};`;
+  tmp += `color:${foreground.toCssColorString()};`;
   tmp += '">';
-  tmp += scratchDiv.innerHTML + "</div>";
+  tmp += `${scratchDiv.innerHTML}</div>`;
   scratchDiv.innerHTML = "";
 
   //Set the final HTML as the description.
@@ -2420,7 +2413,7 @@ function processTour(dataSource, node, processingData, deferredLoading) {
           playlistNodeProcessor(tour, entryNode, ellipsoid);
         } else {
           console.log(
-            "Unknown KML Tour playlist entry type " + entryNode.localName
+            `Unknown KML Tour playlist entry type ${entryNode.localName}`
           );
         }
       }
@@ -2431,7 +2424,7 @@ function processTour(dataSource, node, processingData, deferredLoading) {
 }
 
 function processTourUnsupportedNode(tour, entryNode) {
-  oneTimeWarning("KML Tour unsupported node " + entryNode.localName);
+  oneTimeWarning(`KML Tour unsupported node ${entryNode.localName}`);
 }
 
 function processTourWait(tour, entryNode) {
@@ -2584,9 +2577,9 @@ function processScreenOverlay(
 
       if (defined(x) && x !== -1 && x !== 0) {
         if (xUnit === "fraction") {
-          xStyle = "width: " + Math.floor(x * 100) + "%";
+          xStyle = `width: ${Math.floor(x * 100)}%`;
         } else if (xUnit === "pixels") {
-          xStyle = "width: " + x + "px";
+          xStyle = `width: ${x}px`;
         }
 
         styles.push(xStyle);
@@ -2594,9 +2587,9 @@ function processScreenOverlay(
 
       if (defined(y) && y !== -1 && y !== 0) {
         if (yUnit === "fraction") {
-          yStyle = "height: " + Math.floor(y * 100) + "%";
+          yStyle = `height: ${Math.floor(y * 100)}%`;
         } else if (yUnit === "pixels") {
-          yStyle = "height: " + y + "px";
+          yStyle = `height: ${y}px`;
         }
 
         styles.push(yStyle);
@@ -2644,12 +2637,13 @@ function processScreenOverlay(
 
       if (defined(x)) {
         if (xUnit === "fraction") {
-          xStyle =
-            "left: " + "calc(" + Math.floor(x * 100) + "% - " + xOrigin + "px)";
+          xStyle = `${"left: " + "calc("}${Math.floor(
+            x * 100
+          )}% - ${xOrigin}px)`;
         } else if (xUnit === "pixels") {
-          xStyle = "left: " + (x - xOrigin) + "px";
+          xStyle = `left: ${x - xOrigin}px`;
         } else if (xUnit === "insetPixels") {
-          xStyle = "right: " + (x - xOrigin) + "px";
+          xStyle = `right: ${x - xOrigin}px`;
         }
 
         styles.push(xStyle);
@@ -2657,17 +2651,13 @@ function processScreenOverlay(
 
       if (defined(y)) {
         if (yUnit === "fraction") {
-          yStyle =
-            "bottom: " +
-            "calc(" +
-            Math.floor(y * 100) +
-            "% - " +
-            yOrigin +
-            "px)";
+          yStyle = `${"bottom: " + "calc("}${Math.floor(
+            y * 100
+          )}% - ${yOrigin}px)`;
         } else if (yUnit === "pixels") {
-          yStyle = "bottom: " + (y - yOrigin) + "px";
+          yStyle = `bottom: ${y - yOrigin}px`;
         } else if (yUnit === "insetPixels") {
-          yStyle = "top: " + (y - yOrigin) + "px";
+          yStyle = `top: ${y - yOrigin}px`;
         }
 
         styles.push(yStyle);
@@ -2799,7 +2789,7 @@ function processGroundOverlay(
     } else if (altitudeMode !== "clampToGround") {
       oneTimeWarning(
         "kml-altitudeMode-unknown",
-        "KML - Unknown altitudeMode: " + altitudeMode
+        `KML - Unknown altitudeMode: ${altitudeMode}`
       );
     }
     // else just use the default of 0 until we support 'clampToGround'
@@ -2828,7 +2818,7 @@ function processGroundOverlay(
     } else if (defined(altitudeMode)) {
       oneTimeWarning(
         "kml-altitudeMode-unknown",
-        "KML - Unknown altitudeMode: " + altitudeMode
+        `KML - Unknown altitudeMode: ${altitudeMode}`
       );
     }
   }
@@ -2850,8 +2840,8 @@ function processUnsupportedFeature(
     processingData.uriResolver
   );
   oneTimeWarning(
-    "kml-unsupportedFeature-" + node.nodeName,
-    "KML - Unsupported feature: " + node.nodeName
+    `kml-unsupportedFeature-${node.nodeName}`,
+    `KML - Unsupported feature: ${node.nodeName}`
   );
 }
 
@@ -3267,7 +3257,7 @@ function processNetworkLink(dataSource, node, processingData, deferredLoading) {
           }
         })
         .otherwise(function (error) {
-          oneTimeWarning("An error occured during loading " + href.url);
+          oneTimeWarning(`An error occured during loading ${href.url}`);
           dataSource._error.raiseEvent(dataSource, error);
         });
 
@@ -4217,8 +4207,7 @@ KmlDataSource.prototype.update = function (time) {
             )
           )
           .otherwise(function (error) {
-            const msg =
-              "NetworkLink " + networkLink.href + " refresh failed: " + error;
+            const msg = `NetworkLink ${networkLink.href} refresh failed: ${error}`;
             console.log(msg);
             that._error.raiseEvent(that, msg);
           });

--- a/Source/DataSources/PolylineGeometryUpdater.js
+++ b/Source/DataSources/PolylineGeometryUpdater.js
@@ -95,7 +95,7 @@ function PolylineGeometryUpdater(entity, scene) {
   this._depthFailMaterialProperty = undefined;
   this._geometryOptions = new GeometryOptions();
   this._groundGeometryOptions = new GroundGeometryOptions();
-  this._id = "polyline-" + entity.id;
+  this._id = `polyline-${entity.id}`;
   this._clampToGround = false;
   this._supportsPolylinesOnTerrain = Entity.supportsPolylinesOnTerrain(scene);
 

--- a/Source/DataSources/PropertyBag.js
+++ b/Source/DataSources/PropertyBag.js
@@ -108,7 +108,7 @@ PropertyBag.prototype.addProperty = function (
   }
   if (propertyNames.indexOf(propertyName) !== -1) {
     throw new DeveloperError(
-      propertyName + " is already a registered property."
+      `${propertyName} is already a registered property.`
     );
   }
   //>>includeEnd('debug');
@@ -147,7 +147,7 @@ PropertyBag.prototype.removeProperty = function (propertyName) {
     throw new DeveloperError("propertyName is required.");
   }
   if (index === -1) {
-    throw new DeveloperError(propertyName + " is not a registered property.");
+    throw new DeveloperError(`${propertyName} is not a registered property.`);
   }
   //>>includeEnd('debug');
 

--- a/Source/DataSources/createMaterialPropertyDescriptor.js
+++ b/Source/DataSources/createMaterialPropertyDescriptor.js
@@ -22,7 +22,7 @@ function createMaterialProperty(value) {
   }
 
   //>>includeStart('debug', pragmas.debug);
-  throw new DeveloperError("Unable to infer material type: " + value);
+  throw new DeveloperError(`Unable to infer material type: ${value}`);
   //>>includeEnd('debug');
 }
 

--- a/Source/DataSources/createPropertyDescriptor.js
+++ b/Source/DataSources/createPropertyDescriptor.js
@@ -63,8 +63,8 @@ function createPropertyDescriptor(name, configurable, createPropertyCallback) {
   //The two extra toString calls work around the issue.
   return createProperty(
     name,
-    "_" + name.toString(),
-    "_" + name.toString() + "Subscription",
+    `_${name.toString()}`,
+    `_${name.toString()}Subscription`,
     defaultValue(configurable, false),
     defaultValue(createPropertyCallback, createConstantProperty)
   );

--- a/Source/DataSources/exportKml.js
+++ b/Source/DataSources/exportKml.js
@@ -58,9 +58,9 @@ ExternalFileHandler.prototype.texture = function (texture) {
 
     // If its a data URI try and get the correct extension and then fetch the blob
     const regexResult = texture.url.match(imageTypeRegex);
-    filename = "texture_" + ++this._count;
+    filename = `texture_${++this._count}`;
     if (defined(regexResult)) {
-      filename += "." + regexResult[1];
+      filename += `.${regexResult[1]}`;
     }
 
     const promise = texture.fetchBlob().then(function (blob) {
@@ -76,7 +76,7 @@ ExternalFileHandler.prototype.texture = function (texture) {
     const deferred = when.defer();
     this._promises.push(deferred.promise);
 
-    filename = "texture_" + ++this._count + ".png";
+    filename = `texture_${++this._count}.png`;
     texture.toBlob(function (blob) {
       that._files[filename] = blob;
       deferred.resolve();
@@ -180,11 +180,11 @@ StyleCache.prototype.get = function (element) {
     return ids[key];
   }
 
-  let styleId = "style-" + ++this._count;
+  let styleId = `style-${++this._count}`;
   element.setAttribute("id", styleId);
 
   // Store with #
-  styleId = "#" + styleId;
+  styleId = `#${styleId}`;
   ids[key] = styleId;
   this._styles[key] = element;
 
@@ -220,7 +220,7 @@ IdManager.prototype.get = function (id) {
     return id;
   }
 
-  return id.toString() + "-" + ++ids[id];
+  return `${id.toString()}-${++ids[id]}`;
 };
 
 /**
@@ -1030,11 +1030,9 @@ function getRectangleBoundaries(state, rectangleGraphics, extrudedHeight) {
   for (let i = 0; i < 4; ++i) {
     cornerFunction[i](rectangle, scratchCartographic);
     coordinateStrings.push(
-      CesiumMath.toDegrees(scratchCartographic.longitude) +
-        "," +
-        CesiumMath.toDegrees(scratchCartographic.latitude) +
-        "," +
-        height
+      `${CesiumMath.toDegrees(
+        scratchCartographic.longitude
+      )},${CesiumMath.toDegrees(scratchCartographic.latitude)},${height}`
     );
   }
 
@@ -1061,11 +1059,11 @@ function getLinearRing(state, positions, height, perPositionHeight) {
   for (let i = 0; i < positionCount; ++i) {
     Cartographic.fromCartesian(positions[i], ellipsoid, scratchCartographic);
     coordinateStrings.push(
-      CesiumMath.toDegrees(scratchCartographic.longitude) +
-        "," +
-        CesiumMath.toDegrees(scratchCartographic.latitude) +
-        "," +
-        (perPositionHeight ? scratchCartographic.height : height)
+      `${CesiumMath.toDegrees(
+        scratchCartographic.longitude
+      )},${CesiumMath.toDegrees(scratchCartographic.latitude)},${
+        perPositionHeight ? scratchCartographic.height : height
+      }`
     );
   }
 
@@ -1455,11 +1453,11 @@ function getCoordinates(coordinates, ellipsoid) {
   for (let i = 0; i < count; ++i) {
     Cartographic.fromCartesian(coordinates[i], ellipsoid, scratchCartographic);
     coordinateStrings.push(
-      CesiumMath.toDegrees(scratchCartographic.longitude) +
-        "," +
-        CesiumMath.toDegrees(scratchCartographic.latitude) +
-        "," +
+      `${CesiumMath.toDegrees(
+        scratchCartographic.longitude
+      )},${CesiumMath.toDegrees(scratchCartographic.latitude)},${
         scratchCartographic.height
+      }`
     );
   }
 
@@ -1499,7 +1497,7 @@ function colorToString(color) {
   const bytes = color.toBytes();
   for (let i = 3; i >= 0; --i) {
     result +=
-      bytes[i] < 16 ? "0" + bytes[i].toString(16) : bytes[i].toString(16);
+      bytes[i] < 16 ? `0${bytes[i].toString(16)}` : bytes[i].toString(16);
   }
 
   return result;

--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -30,13 +30,13 @@ datatypeToGlsl[WebGLConstants.SAMPLER_2D] = "sampler2D";
 datatypeToGlsl[WebGLConstants.SAMPLER_CUBE] = "samplerCube";
 
 AutomaticUniform.prototype.getDeclaration = function (name) {
-  let declaration = "uniform " + datatypeToGlsl[this._datatype] + " " + name;
+  let declaration = `uniform ${datatypeToGlsl[this._datatype]} ${name}`;
 
   const size = this._size;
   if (size === 1) {
     declaration += ";";
   } else {
-    declaration += "[" + size.toString() + "];";
+    declaration += `[${size.toString()}];`;
   }
 
   return declaration;

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -50,14 +50,14 @@ function errorToString(gl, error) {
       message += "CONTEXT_LOST_WEBGL lost";
       break;
     default:
-      message += "Unknown (" + error + ")";
+      message += `Unknown (${error})`;
   }
 
   return message;
 }
 
 function createErrorMessage(gl, glFunc, glFuncArguments, error) {
-  let message = errorToString(gl, error) + ": " + glFunc.name + "(";
+  let message = `${errorToString(gl, error)}: ${glFunc.name}(`;
 
   for (let i = 0; i < glFuncArguments.length; ++i) {
     if (i !== 0) {
@@ -83,12 +83,12 @@ function makeGetterSetter(gl, propertyName, logFunction) {
   return {
     get: function () {
       const value = gl[propertyName];
-      logFunction(gl, "get: " + propertyName, value);
+      logFunction(gl, `get: ${propertyName}`, value);
       return gl[propertyName];
     },
     set: function (value) {
       gl[propertyName] = value;
-      logFunction(gl, "set: " + propertyName, value);
+      logFunction(gl, `set: ${propertyName}`, value);
     },
   };
 }

--- a/Source/Renderer/CubeMap.js
+++ b/Source/Renderer/CubeMap.js
@@ -102,9 +102,7 @@ function CubeMap(options) {
 
   if (size > ContextLimits.maximumCubeMapSize) {
     throw new DeveloperError(
-      "Width and height must be less than or equal to the maximum cube map size (" +
-        ContextLimits.maximumCubeMapSize +
-        ").  Check maximumCubeMapSize."
+      `Width and height must be less than or equal to the maximum cube map size (${ContextLimits.maximumCubeMapSize}).  Check maximumCubeMapSize.`
     );
   }
 

--- a/Source/Renderer/RenderState.js
+++ b/Source/Renderer/RenderState.js
@@ -349,16 +349,12 @@ function RenderState(renderState) {
 
     if (this.viewport.width > ContextLimits.maximumViewportWidth) {
       throw new DeveloperError(
-        "renderState.viewport.width must be less than or equal to the maximum viewport width (" +
-          ContextLimits.maximumViewportWidth.toString() +
-          ").  Check maximumViewportWidth."
+        `renderState.viewport.width must be less than or equal to the maximum viewport width (${ContextLimits.maximumViewportWidth.toString()}).  Check maximumViewportWidth.`
       );
     }
     if (this.viewport.height > ContextLimits.maximumViewportHeight) {
       throw new DeveloperError(
-        "renderState.viewport.height must be less than or equal to the maximum viewport height (" +
-          ContextLimits.maximumViewportHeight.toString() +
-          ").  Check maximumViewportHeight."
+        `renderState.viewport.height must be less than or equal to the maximum viewport height (${ContextLimits.maximumViewportHeight.toString()}).  Check maximumViewportHeight.`
       );
     }
   }

--- a/Source/Renderer/Renderbuffer.js
+++ b/Source/Renderer/Renderbuffer.js
@@ -35,9 +35,7 @@ function Renderbuffer(options) {
 
   if (width > maximumRenderbufferSize) {
     throw new DeveloperError(
-      "Width must be less than or equal to the maximum renderbuffer size (" +
-        maximumRenderbufferSize +
-        ").  Check maximumRenderbufferSize."
+      `Width must be less than or equal to the maximum renderbuffer size (${maximumRenderbufferSize}).  Check maximumRenderbufferSize.`
     );
   }
 
@@ -45,9 +43,7 @@ function Renderbuffer(options) {
 
   if (height > maximumRenderbufferSize) {
     throw new DeveloperError(
-      "Height must be less than or equal to the maximum renderbuffer size (" +
-        maximumRenderbufferSize +
-        ").  Check maximumRenderbufferSize."
+      `Height must be less than or equal to the maximum renderbuffer size (${maximumRenderbufferSize}).  Check maximumRenderbufferSize.`
     );
   }
   //>>includeEnd('debug');

--- a/Source/Renderer/ShaderBuilder.js
+++ b/Source/Renderer/ShaderBuilder.js
@@ -127,7 +127,7 @@ ShaderBuilder.prototype.addDefine = function (identifier, value, destination) {
   // The ShaderSource created in build() will add the #define part
   let line = identifier;
   if (defined(value)) {
-    line += " " + value.toString();
+    line += ` ${value.toString()}`;
   }
 
   if (ShaderDestination.includesVertexShader(destination)) {
@@ -278,7 +278,7 @@ ShaderBuilder.prototype.addUniform = function (type, identifier, destination) {
   //>>includeEnd('debug');
 
   destination = defaultValue(destination, ShaderDestination.BOTH);
-  const line = "uniform " + type + " " + identifier + ";";
+  const line = `uniform ${type} ${identifier};`;
 
   if (ShaderDestination.includesVertexShader(destination)) {
     this._vertexShaderParts.uniformLines.push(line);
@@ -318,7 +318,7 @@ ShaderBuilder.prototype.setPositionAttribute = function (type, identifier) {
   }
   //>>includeEnd('debug');
 
-  this._positionAttributeLine = "attribute " + type + " " + identifier + ";";
+  this._positionAttributeLine = `attribute ${type} ${identifier};`;
 
   // Some WebGL implementations require attribute 0 to always be active, so
   // this builder assumes the position will always go in location 0
@@ -348,7 +348,7 @@ ShaderBuilder.prototype.addAttribute = function (type, identifier) {
   Check.typeOf.string("identifier", identifier);
   //>>includeEnd('debug');
 
-  const line = "attribute " + type + " " + identifier + ";";
+  const line = `attribute ${type} ${identifier};`;
   this._attributeLines.push(line);
 
   const location = this._nextAttributeLocation;
@@ -373,7 +373,7 @@ ShaderBuilder.prototype.addVarying = function (type, identifier) {
   Check.typeOf.string("identifier", identifier);
   //>>includeEnd('debug');
 
-  const line = "varying " + type + " " + identifier + ";";
+  const line = `varying ${type} ${identifier};`;
   this._vertexShaderParts.varyingLines.push(line);
   this._fragmentShaderParts.varyingLines.push(line);
 };

--- a/Source/Renderer/ShaderFunction.js
+++ b/Source/Renderer/ShaderFunction.js
@@ -33,7 +33,7 @@ export default function ShaderFunction(signature) {
  */
 ShaderFunction.prototype.addLines = function (lines) {
   const paddedLines = lines.map(function (line) {
-    return "    " + line;
+    return `    ${line}`;
   });
   Array.prototype.push.apply(this.body, paddedLines);
 };

--- a/Source/Renderer/ShaderProgram.js
+++ b/Source/Renderer/ShaderProgram.js
@@ -163,9 +163,9 @@ function handleUniformPrecisionMismatches(
       for (j = 0; j < fragmentUniformsCount; j++) {
         if (vertexShaderUniforms[i] === fragmentShaderUniforms[j]) {
           uniformName = vertexShaderUniforms[i];
-          duplicateName = "czm_mediump_" + uniformName;
+          duplicateName = `czm_mediump_${uniformName}`;
           // Update fragmentShaderText with renamed uniforms
-          const re = new RegExp(uniformName + "\\b", "g");
+          const re = new RegExp(`${uniformName}\\b`, "g");
           fragmentShaderText = fragmentShaderText.replace(re, duplicateName);
           duplicateUniformNames[duplicateName] = uniformName;
         }
@@ -222,69 +222,65 @@ function createAndLinkProgram(gl, shader) {
     // For performance, only check compile errors if there is a linker error.
     if (!gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS)) {
       log = gl.getShaderInfoLog(fragmentShader);
-      console.error(consolePrefix + "Fragment shader compile log: " + log);
+      console.error(`${consolePrefix}Fragment shader compile log: ${log}`);
       if (defined(debugShaders)) {
         const fragmentSourceTranslation = debugShaders.getTranslatedShaderSource(
           fragmentShader
         );
         if (fragmentSourceTranslation !== "") {
           console.error(
-            consolePrefix +
-              "Translated fragment shader source:\n" +
-              fragmentSourceTranslation
+            `${consolePrefix}Translated fragment shader source:\n${fragmentSourceTranslation}`
           );
         } else {
-          console.error(consolePrefix + "Fragment shader translation failed.");
+          console.error(`${consolePrefix}Fragment shader translation failed.`);
         }
       }
 
       gl.deleteProgram(program);
       throw new RuntimeError(
-        "Fragment shader failed to compile.  Compile log: " + log
+        `Fragment shader failed to compile.  Compile log: ${log}`
       );
     }
 
     if (!gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS)) {
       log = gl.getShaderInfoLog(vertexShader);
-      console.error(consolePrefix + "Vertex shader compile log: " + log);
+      console.error(`${consolePrefix}Vertex shader compile log: ${log}`);
       if (defined(debugShaders)) {
         const vertexSourceTranslation = debugShaders.getTranslatedShaderSource(
           vertexShader
         );
         if (vertexSourceTranslation !== "") {
           console.error(
-            consolePrefix +
-              "Translated vertex shader source:\n" +
-              vertexSourceTranslation
+            `${consolePrefix}Translated vertex shader source:\n${vertexSourceTranslation}`
           );
         } else {
-          console.error(consolePrefix + "Vertex shader translation failed.");
+          console.error(`${consolePrefix}Vertex shader translation failed.`);
         }
       }
 
       gl.deleteProgram(program);
       throw new RuntimeError(
-        "Vertex shader failed to compile.  Compile log: " + log
+        `Vertex shader failed to compile.  Compile log: ${log}`
       );
     }
 
     log = gl.getProgramInfoLog(program);
-    console.error(consolePrefix + "Shader program link log: " + log);
+    console.error(`${consolePrefix}Shader program link log: ${log}`);
     if (defined(debugShaders)) {
       console.error(
-        consolePrefix +
-          "Translated vertex shader source:\n" +
-          debugShaders.getTranslatedShaderSource(vertexShader)
+        `${consolePrefix}Translated vertex shader source:\n${debugShaders.getTranslatedShaderSource(
+          vertexShader
+        )}`
       );
       console.error(
-        consolePrefix +
-          "Translated fragment shader source:\n" +
-          debugShaders.getTranslatedShaderSource(fragmentShader)
+        `${consolePrefix}Translated fragment shader source:\n${debugShaders.getTranslatedShaderSource(
+          fragmentShader
+        )}`
       );
     }
 
     gl.deleteProgram(program);
-    throw new RuntimeError("Program failed to link.  Link log: " + log);
+    throw new RuntimeError(`Program failed to link.  Link log: ${log}`);
   }
 
   const logShaderCompilation = shader._logShaderCompilation;
@@ -292,21 +288,21 @@ function createAndLinkProgram(gl, shader) {
   if (logShaderCompilation) {
     log = gl.getShaderInfoLog(vertexShader);
     if (defined(log) && log.length > 0) {
-      console.log(consolePrefix + "Vertex shader compile log: " + log);
+      console.log(`${consolePrefix}Vertex shader compile log: ${log}`);
     }
   }
 
   if (logShaderCompilation) {
     log = gl.getShaderInfoLog(fragmentShader);
     if (defined(log) && log.length > 0) {
-      console.log(consolePrefix + "Fragment shader compile log: " + log);
+      console.log(`${consolePrefix}Fragment shader compile log: ${log}`);
     }
   }
 
   if (logShaderCompilation) {
     log = gl.getProgramInfoLog(program);
     if (defined(log) && log.length > 0) {
-      console.log(consolePrefix + "Shader program link log: " + log);
+      console.log(`${consolePrefix}Shader program link log: ${log}`);
     }
   }
 
@@ -410,7 +406,7 @@ function findUniforms(gl, program) {
         } else {
           locations = [];
           for (let j = 0; j < activeUniform.size; ++j) {
-            loc = gl.getUniformLocation(program, uniformName + "[" + j + "]");
+            loc = gl.getUniformLocation(program, `${uniformName}[${j}]`);
 
             // Workaround for IE 11.0.9.  See above.
             if (loc !== null) {
@@ -620,8 +616,9 @@ ShaderProgram.prototype._setUniforms = function (
     //>>includeStart('debug', pragmas.debug);
     if (!gl.getProgramParameter(program, gl.VALIDATE_STATUS)) {
       throw new DeveloperError(
-        "Program validation failed.  Program info log: " +
-          gl.getProgramInfoLog(program)
+        `Program validation failed.  Program info log: ${gl.getProgramInfoLog(
+          program
+        )}`
       );
     }
     //>>includeEnd('debug');

--- a/Source/Renderer/ShaderSource.js
+++ b/Source/Renderer/ShaderSource.js
@@ -128,7 +128,7 @@ function sortDependencies(dependencyNodes) {
     let message =
       "A circular dependency was found in the following built-in functions/structs/constants: \n";
     for (let k = 0; k < badNodes.length; ++k) {
-      message = message + badNodes[k].name + "\n";
+      message = `${message + badNodes[k].name}\n`;
     }
     throw new DeveloperError(message);
   }
@@ -146,7 +146,7 @@ function getBuiltinsAndAutomaticUniforms(shaderSource) {
   // Iterate in reverse so that dependent items are declared before they are used.
   let builtinsSource = "";
   for (let i = dependencyNodes.length - 1; i >= 0; --i) {
-    builtinsSource = builtinsSource + dependencyNodes[i].glslSource + "\n";
+    builtinsSource = `${builtinsSource + dependencyNodes[i].glslSource}\n`;
   }
 
   return builtinsSource.replace(root.glslSource, "");
@@ -162,7 +162,7 @@ function combineShader(shaderSource, isFragmentShader, context) {
   if (defined(sources)) {
     for (i = 0, length = sources.length; i < length; ++i) {
       // #line needs to be on its own line.
-      combinedSources += "\n#line 0\n" + sources[i];
+      combinedSources += `\n#line 0\n${sources[i]}`;
     }
   }
 
@@ -177,7 +177,7 @@ function combineShader(shaderSource, isFragmentShader, context) {
     //>>includeStart('debug', pragmas.debug);
     if (defined(version) && version !== group1) {
       throw new DeveloperError(
-        "inconsistent versions found: " + version + " and " + group1
+        `inconsistent versions found: ${version} and ${group1}`
       );
     }
     //>>includeEnd('debug');
@@ -226,7 +226,7 @@ function combineShader(shaderSource, isFragmentShader, context) {
   // #version must be first
   // defaults to #version 100 if not specified
   if (defined(version)) {
-    result = "#version " + version + "\n";
+    result = `#version ${version}\n`;
   }
 
   const extensionsLength = extensions.length;
@@ -254,7 +254,7 @@ function combineShader(shaderSource, isFragmentShader, context) {
     for (i = 0, length = defines.length; i < length; ++i) {
       const define = defines[i];
       if (define.length !== 0) {
-        result += "#define " + define + "\n";
+        result += `#define ${define}\n`;
       }
     }
   }
@@ -352,7 +352,7 @@ ShaderSource.prototype.clone = function () {
 };
 
 ShaderSource.replaceMain = function (source, renamedMain) {
-  renamedMain = "void " + renamedMain + "()";
+  renamedMain = `void ${renamedMain}()`;
   return source.replace(/void\s+main\s*\(\s*(?:void)?\s*\)/g, renamedMain);
 };
 
@@ -416,7 +416,7 @@ ShaderSource.createPickVertexShaderSource = function (vertexShaderSource) {
     "    czm_pickColor = pickColor; \n" +
     "}";
 
-  return renamedVS + "\n" + pickMain;
+  return `${renamedVS}\n${pickMain}`;
 };
 
 ShaderSource.createPickFragmentShaderSource = function (
@@ -428,18 +428,17 @@ ShaderSource.createPickFragmentShaderSource = function (
     "czm_old_main"
   );
   const pickMain =
-    pickColorQualifier +
-    " vec4 czm_pickColor; \n" +
-    "void main() \n" +
-    "{ \n" +
-    "    czm_old_main(); \n" +
-    "    if (gl_FragColor.a == 0.0) { \n" +
-    "       discard; \n" +
-    "    } \n" +
-    "    gl_FragColor = czm_pickColor; \n" +
-    "}";
+    `${pickColorQualifier} vec4 czm_pickColor; \n` +
+    `void main() \n` +
+    `{ \n` +
+    `    czm_old_main(); \n` +
+    `    if (gl_FragColor.a == 0.0) { \n` +
+    `       discard; \n` +
+    `    } \n` +
+    `    gl_FragColor = czm_pickColor; \n` +
+    `}`;
 
-  return renamedFS + "\n" + pickMain;
+  return `${renamedFS}\n${pickMain}`;
 };
 
 ShaderSource.findVarying = function (shaderSource, names) {

--- a/Source/Renderer/ShaderStruct.js
+++ b/Source/Renderer/ShaderStruct.js
@@ -34,7 +34,7 @@ export default function ShaderStruct(name) {
  * @param {String} identifier The identifier of the struct field
  */
 ShaderStruct.prototype.addField = function (type, identifier) {
-  const field = "    " + type + " " + identifier + ";";
+  const field = `    ${type} ${identifier};`;
   this.fields.push(field);
 };
 
@@ -49,5 +49,5 @@ ShaderStruct.prototype.generateGlslLines = function () {
     fields = ["    float _empty;"];
   }
 
-  return [].concat("struct " + this.name, "{", fields, "};");
+  return [].concat(`struct ${this.name}`, "{", fields, "};");
 };

--- a/Source/Renderer/Texture.js
+++ b/Source/Renderer/Texture.js
@@ -62,9 +62,7 @@ function Texture(options) {
 
   if (width > ContextLimits.maximumTextureSize) {
     throw new DeveloperError(
-      "Width must be less than or equal to the maximum texture size (" +
-        ContextLimits.maximumTextureSize +
-        ").  Check maximumTextureSize."
+      `Width must be less than or equal to the maximum texture size (${ContextLimits.maximumTextureSize}).  Check maximumTextureSize.`
     );
   }
 
@@ -72,9 +70,7 @@ function Texture(options) {
 
   if (height > ContextLimits.maximumTextureSize) {
     throw new DeveloperError(
-      "Height must be less than or equal to the maximum texture size (" +
-        ContextLimits.maximumTextureSize +
-        ").  Check maximumTextureSize."
+      `Height must be less than or equal to the maximum texture size (${ContextLimits.maximumTextureSize}).  Check maximumTextureSize.`
     );
   }
 

--- a/Source/Renderer/VertexArray.js
+++ b/Source/Renderer/VertexArray.js
@@ -341,7 +341,7 @@ function VertexArray(options) {
     const index = vaAttributes[i].index;
     if (uniqueIndices[index]) {
       throw new DeveloperError(
-        "Index " + index + " is used by more than one attribute."
+        `Index ${index} is used by more than one attribute.`
       );
     }
     uniqueIndices[index] = true;
@@ -419,18 +419,12 @@ function interleaveAttributes(attributes) {
 
       if (currentNumberOfVertices !== numberOfVertices) {
         throw new RuntimeError(
-          "Each attribute list must have the same number of vertices.  " +
-            "Attribute " +
-            names[j] +
-            " has a different number of vertices " +
-            "(" +
-            currentNumberOfVertices.toString() +
-            ")" +
-            " than attribute " +
-            names[0] +
-            " (" +
-            numberOfVertices.toString() +
-            ")."
+          `${
+            "Each attribute list must have the same number of vertices.  " +
+            "Attribute "
+          }${names[j]} has a different number of vertices ` +
+            `(${currentNumberOfVertices.toString()})` +
+            ` than attribute ${names[0]} (${numberOfVertices.toString()}).`
         );
       }
     }

--- a/Source/Renderer/VertexArrayFacade.js
+++ b/Source/Renderer/VertexArrayFacade.js
@@ -154,7 +154,7 @@ VertexArrayFacade._verifyAttributes = function (attributes) {
     //>>includeStart('debug', pragmas.debug);
     if (uniqueIndices[index]) {
       throw new DeveloperError(
-        "Index " + index + " is used by more than one attribute."
+        `Index ${index} is used by more than one attribute.`
       );
     }
     //>>includeEnd('debug');

--- a/Source/Renderer/createUniform.js
+++ b/Source/Renderer/createUniform.js
@@ -46,11 +46,7 @@ function createUniform(gl, activeUniform, uniformName, location) {
       return new UniformMat4(gl, activeUniform, uniformName, location);
     default:
       throw new RuntimeError(
-        "Unrecognized uniform type: " +
-          activeUniform.type +
-          ' for uniform "' +
-          uniformName +
-          '".'
+        `Unrecognized uniform type: ${activeUniform.type} for uniform "${uniformName}".`
       );
   }
 }
@@ -143,9 +139,7 @@ UniformFloatVec3.prototype.set = function () {
     }
   } else {
     //>>includeStart('debug', pragmas.debug);
-    throw new DeveloperError(
-      'Invalid vec3 value for uniform "' + this.name + '".'
-    );
+    throw new DeveloperError(`Invalid vec3 value for uniform "${this.name}".`);
     //>>includeEnd('debug');
   }
 };
@@ -185,9 +179,7 @@ UniformFloatVec4.prototype.set = function () {
     }
   } else {
     //>>includeStart('debug', pragmas.debug);
-    throw new DeveloperError(
-      'Invalid vec4 value for uniform "' + this.name + '".'
-    );
+    throw new DeveloperError(`Invalid vec4 value for uniform "${this.name}".`);
     //>>includeEnd('debug');
   }
 };

--- a/Source/Renderer/createUniformArray.js
+++ b/Source/Renderer/createUniformArray.js
@@ -61,11 +61,7 @@ function createUniformArray(gl, activeUniform, uniformName, locations) {
       return new UniformArrayMat4(gl, activeUniform, uniformName, locations);
     default:
       throw new RuntimeError(
-        "Unrecognized uniform type: " +
-          activeUniform.type +
-          ' for uniform "' +
-          uniformName +
-          '".'
+        `Unrecognized uniform type: ${activeUniform.type} for uniform "${uniformName}".`
       );
   }
 }

--- a/Source/Renderer/modernizeShader.js
+++ b/Source/Renderer/modernizeShader.js
@@ -38,8 +38,8 @@ function modernizeShader(source, isFragmentShader) {
   const outputVariables = [];
 
   for (i = 0; i < 10; i++) {
-    const fragDataString = "gl_FragData\\[" + i + "\\]";
-    const newOutput = "czm_out" + i;
+    const fragDataString = `gl_FragData\\[${i}\\]`;
+    const newOutput = `czm_out${i}`;
     const regex = new RegExp(fragDataString, "g");
     if (regex.test(source)) {
       setAdd(newOutput, outputVariables);
@@ -47,7 +47,7 @@ function modernizeShader(source, isFragmentShader) {
       splitSource.splice(
         outputDeclarationLine,
         0,
-        "layout(location = " + i + ") out vec4 " + newOutput + ";"
+        `layout(location = ${i}) out vec4 ${newOutput};`
       );
       outputDeclarationLine += 1;
     }
@@ -75,7 +75,7 @@ function modernizeShader(source, isFragmentShader) {
     for (const variable in variableMap) {
       if (variableMap.hasOwnProperty(variable)) {
         const matchVar = new RegExp(
-          "(layout)[^]+(out)[^]+(" + variable + ")[^]+",
+          `(layout)[^]+(out)[^]+(${variable})[^]+`,
           "g"
         );
         if (matchVar.test(line)) {
@@ -96,13 +96,13 @@ function modernizeShader(source, isFragmentShader) {
       }
       lineNumber += depth + 1;
       for (let d = depth - 1; d >= 0; d--) {
-        splitSource.splice(lineNumber, 0, "#endif //" + entry[d]);
+        splitSource.splice(lineNumber, 0, `#endif //${entry[d]}`);
       }
     }
   }
 
   const webgl2UniqueID = "WEBGL_2";
-  const webgl2DefineMacro = "#define " + webgl2UniqueID;
+  const webgl2DefineMacro = `#define ${webgl2UniqueID}`;
   const versionThree = "#version 300 es";
   let foundVersion = false;
   for (i = 0; i < splitSource.length; i++) {
@@ -141,13 +141,13 @@ function modernizeShader(source, isFragmentShader) {
 // Note that this fails if your string looks like
 // searchString[singleCharacter]searchString
 function replaceInSourceString(str, replacement, splitSource) {
-  const regexStr = "(^|[^\\w])(" + str + ")($|[^\\w])";
+  const regexStr = `(^|[^\\w])(${str})($|[^\\w])`;
   const regex = new RegExp(regexStr, "g");
 
   const splitSourceLength = splitSource.length;
   for (let i = 0; i < splitSourceLength; ++i) {
     const line = splitSource[i];
-    splitSource[i] = line.replace(regex, "$1" + replacement + "$3");
+    splitSource[i] = line.replace(regex, `$1${replacement}$3`);
   }
 }
 
@@ -160,7 +160,7 @@ function replaceInSourceRegex(regex, replacement, splitSource) {
 }
 
 function findInSource(str, splitSource) {
-  const regexStr = "(^|[^\\w])(" + str + ")($|[^\\w])";
+  const regexStr = `(^|[^\\w])(${str})($|[^\\w])`;
   const regex = new RegExp(regexStr, "g");
 
   const splitSourceLength = splitSource.length;
@@ -178,7 +178,7 @@ function compileSource(splitSource) {
 
   const splitSourceLength = splitSource.length;
   for (let i = 0; i < splitSourceLength; ++i) {
-    wholeSource += splitSource[i] + "\n";
+    wholeSource += `${splitSource[i]}\n`;
   }
   return wholeSource;
 }
@@ -233,10 +233,10 @@ function getVariablePreprocessorBranch(layoutVariables, splitSource) {
 }
 
 function removeExtension(name, webgl2UniqueID, splitSource) {
-  const regex = "#extension\\s+GL_" + name + "\\s+:\\s+[a-zA-Z0-9]+\\s*$";
+  const regex = `#extension\\s+GL_${name}\\s+:\\s+[a-zA-Z0-9]+\\s*$`;
   replaceInSourceRegex(new RegExp(regex, "g"), "", splitSource);
 
   // replace any possible directive #ifdef (GL_EXT_extension) with WEBGL_2 unique directive
-  replaceInSourceString("GL_" + name, webgl2UniqueID, splitSource);
+  replaceInSourceString(`GL_${name}`, webgl2UniqueID, splitSource);
 }
 export default modernizeShader;

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -254,10 +254,7 @@ function ArcGisMapServerImageryProvider(options) {
           ellipsoid: options.ellipsoid,
         });
       } else {
-        const message =
-          "Tile spatial reference WKID " +
-          data.tileInfo.spatialReference.wkid +
-          " is not supported.";
+        const message = `Tile spatial reference WKID ${data.tileInfo.spatialReference.wkid} is not supported.`;
         metadataError = TileProviderError.handleError(
           metadataError,
           that,
@@ -323,10 +320,7 @@ function ArcGisMapServerImageryProvider(options) {
               data.fullExtent.ymax
             );
           } else {
-            const extentMessage =
-              "fullExtent.spatialReference WKID " +
-              data.fullExtent.spatialReference.wkid +
-              " is not supported.";
+            const extentMessage = `fullExtent.spatialReference WKID ${data.fullExtent.spatialReference.wkid} is not supported.`;
             metadataError = TileProviderError.handleError(
               metadataError,
               that,
@@ -373,8 +367,7 @@ function ArcGisMapServerImageryProvider(options) {
   }
 
   function metadataFailure(e) {
-    const message =
-      "An error occurred while accessing " + that._resource.url + ".";
+    const message = `An error occurred while accessing ${that._resource.url}.`;
     metadataError = TileProviderError.handleError(
       metadataError,
       that,
@@ -410,7 +403,7 @@ function buildImageResource(imageryProvider, x, y, level, request) {
   let resource;
   if (imageryProvider._useTiles) {
     resource = imageryProvider._resource.getDerivedResource({
-      url: "tile/" + level + "/" + y + "/" + x,
+      url: `tile/${level}/${y}/${x}`,
       request: request,
     });
   } else {
@@ -419,18 +412,11 @@ function buildImageResource(imageryProvider, x, y, level, request) {
       y,
       level
     );
-    const bbox =
-      nativeRectangle.west +
-      "," +
-      nativeRectangle.south +
-      "," +
-      nativeRectangle.east +
-      "," +
-      nativeRectangle.north;
+    const bbox = `${nativeRectangle.west},${nativeRectangle.south},${nativeRectangle.east},${nativeRectangle.north}`;
 
     const query = {
       bbox: bbox,
-      size: imageryProvider._tileWidth + "," + imageryProvider._tileHeight,
+      size: `${imageryProvider._tileWidth},${imageryProvider._tileHeight}`,
       format: "png32",
       transparent: true,
       f: "image",
@@ -446,7 +432,7 @@ function buildImageResource(imageryProvider, x, y, level, request) {
       query.imageSR = 3857;
     }
     if (imageryProvider.layers) {
-      query.layers = "show:" + imageryProvider.layers;
+      query.layers = `show:${imageryProvider.layers}`;
     }
 
     resource = imageryProvider._resource.getDerivedResource({
@@ -852,23 +838,16 @@ ArcGisMapServerImageryProvider.prototype.pickFeatures = function (
 
   let layers = "visible";
   if (defined(this._layers)) {
-    layers += ":" + this._layers;
+    layers += `:${this._layers}`;
   }
 
   const query = {
     f: "json",
     tolerance: 2,
     geometryType: "esriGeometryPoint",
-    geometry: horizontal + "," + vertical,
-    mapExtent:
-      rectangle.west +
-      "," +
-      rectangle.south +
-      "," +
-      rectangle.east +
-      "," +
-      rectangle.north,
-    imageDisplay: this._tileWidth + "," + this._tileHeight + ",96",
+    geometry: `${horizontal},${vertical}`,
+    mapExtent: `${rectangle.west},${rectangle.south},${rectangle.east},${rectangle.north}`,
+    imageDisplay: `${this._tileWidth},${this._tileHeight},96`,
     sr: sr,
     layers: layers,
   };

--- a/Source/Scene/B3dmParser.js
+++ b/Source/Scene/B3dmParser.js
@@ -39,9 +39,7 @@ B3dmParser.parse = function (arrayBuffer, byteOffset) {
   const version = view.getUint32(byteOffset, true);
   if (version !== 1) {
     throw new RuntimeError(
-      "Only Batched 3D Model version 1 is supported.  Version " +
-        version +
-        " is not."
+      `Only Batched 3D Model version 1 is supported.  Version ${version} is not.`
     );
   }
   byteOffset += sizeOfUint32;

--- a/Source/Scene/BatchTable.js
+++ b/Source/Scene/BatchTable.js
@@ -458,35 +458,35 @@ function getGlslComputeSt(batchTable) {
   // GLSL batchId is zero-based: [0, numberOfInstances - 1]
   if (batchTable._textureDimensions.y === 1) {
     return (
-      "uniform vec4 batchTextureStep; \n" +
-      "vec2 computeSt(float batchId) \n" +
-      "{ \n" +
-      "    float stepX = batchTextureStep.x; \n" +
-      "    float centerX = batchTextureStep.y; \n" +
-      "    float numberOfAttributes = float(" +
-      stride +
-      "); \n" +
-      "    return vec2(centerX + (batchId * numberOfAttributes * stepX), 0.5); \n" +
-      "} \n"
+      `${
+        "uniform vec4 batchTextureStep; \n" +
+        "vec2 computeSt(float batchId) \n" +
+        "{ \n" +
+        "    float stepX = batchTextureStep.x; \n" +
+        "    float centerX = batchTextureStep.y; \n" +
+        "    float numberOfAttributes = float("
+      }${stride}); \n` +
+      `    return vec2(centerX + (batchId * numberOfAttributes * stepX), 0.5); \n` +
+      `} \n`
     );
   }
 
   return (
-    "uniform vec4 batchTextureStep; \n" +
-    "uniform vec2 batchTextureDimensions; \n" +
-    "vec2 computeSt(float batchId) \n" +
-    "{ \n" +
-    "    float stepX = batchTextureStep.x; \n" +
-    "    float centerX = batchTextureStep.y; \n" +
-    "    float stepY = batchTextureStep.z; \n" +
-    "    float centerY = batchTextureStep.w; \n" +
-    "    float numberOfAttributes = float(" +
-    stride +
-    "); \n" +
-    "    float xId = mod(batchId * numberOfAttributes, batchTextureDimensions.x); \n" +
-    "    float yId = floor(batchId * numberOfAttributes / batchTextureDimensions.x); \n" +
-    "    return vec2(centerX + (xId * stepX), centerY + (yId * stepY)); \n" +
-    "} \n"
+    `${
+      "uniform vec4 batchTextureStep; \n" +
+      "uniform vec2 batchTextureDimensions; \n" +
+      "vec2 computeSt(float batchId) \n" +
+      "{ \n" +
+      "    float stepX = batchTextureStep.x; \n" +
+      "    float centerX = batchTextureStep.y; \n" +
+      "    float stepY = batchTextureStep.z; \n" +
+      "    float centerY = batchTextureStep.w; \n" +
+      "    float numberOfAttributes = float("
+    }${stride}); \n` +
+    `    float xId = mod(batchId * numberOfAttributes, batchTextureDimensions.x); \n` +
+    `    float yId = floor(batchId * numberOfAttributes / batchTextureDimensions.x); \n` +
+    `    return vec2(centerX + (xId * stepX), centerY + (yId * stepY)); \n` +
+    `} \n`
   );
 }
 
@@ -494,7 +494,7 @@ function getComponentType(componentsPerAttribute) {
   if (componentsPerAttribute === 1) {
     return "float";
   }
-  return "vec" + componentsPerAttribute;
+  return `vec${componentsPerAttribute}`;
 }
 
 function getComponentSwizzle(componentsPerAttribute) {
@@ -519,15 +519,10 @@ function getGlslAttributeFunction(batchTable, attributeIndex) {
   const offset = batchTable._offsets[attributeIndex];
 
   let glslFunction =
-    functionReturnType +
-    " " +
-    functionName +
-    "(float batchId) \n" +
-    "{ \n" +
-    "    vec2 st = computeSt(batchId); \n" +
-    "    st.x += batchTextureStep.x * float(" +
-    offset +
-    "); \n";
+    `${functionReturnType} ${functionName}(float batchId) \n` +
+    `{ \n` +
+    `    vec2 st = computeSt(batchId); \n` +
+    `    st.x += batchTextureStep.x * float(${offset}); \n`;
 
   if (
     batchTable._packFloats &&
@@ -543,12 +538,7 @@ function getGlslAttributeFunction(batchTable, attributeIndex) {
     glslFunction += "    vec4 textureValue = texture2D(batchTexture, st); \n";
   }
 
-  glslFunction +=
-    "    " +
-    functionReturnType +
-    " value = textureValue" +
-    functionReturnValue +
-    "; \n";
+  glslFunction += `    ${functionReturnType} value = textureValue${functionReturnValue}; \n`;
 
   if (
     batchTable._pixelDatatype === PixelDatatype.UNSIGNED_BYTE &&
@@ -582,7 +572,7 @@ BatchTable.prototype.getVertexShaderCallback = function () {
   }
 
   let batchTableShader = "uniform highp sampler2D batchTexture; \n";
-  batchTableShader += getGlslComputeSt(this) + "\n";
+  batchTableShader += `${getGlslComputeSt(this)}\n`;
 
   const length = attributes.length;
   for (let i = 0; i < length; ++i) {
@@ -593,7 +583,7 @@ BatchTable.prototype.getVertexShaderCallback = function () {
     const mainIndex = source.indexOf("void main");
     const beforeMain = source.substring(0, mainIndex);
     const afterMain = source.substring(mainIndex);
-    return beforeMain + "\n" + batchTableShader + "\n" + afterMain;
+    return `${beforeMain}\n${batchTableShader}\n${afterMain}`;
   };
 };
 

--- a/Source/Scene/BatchTableHierarchy.js
+++ b/Source/Scene/BatchTableHierarchy.js
@@ -159,7 +159,7 @@ function getBinaryProperties(featuresLength, properties, binaryBody) {
         }
         if (!defined(binaryBody)) {
           throw new RuntimeError(
-            "Property " + name + " requires a batch table binary."
+            `Property ${name} requires a batch table binary.`
           );
         }
 
@@ -217,10 +217,7 @@ function validateInstance(hierarchy, instanceIndex, stack) {
 
   if (instanceIndex >= instancesLength) {
     throw new DeveloperError(
-      "Parent index " +
-        instanceIndex +
-        " exceeds the total number of instances: " +
-        instancesLength
+      `Parent index ${instanceIndex} exceeds the total number of instances: ${instancesLength}`
     );
   }
   if (stack.indexOf(instanceIndex) > -1) {
@@ -465,7 +462,7 @@ BatchTableHierarchy.prototype.setProperty = function (
       //>>includeStart('debug', pragmas.debug);
       if (instanceIndex !== batchId) {
         throw new DeveloperError(
-          'Inherited property "' + propertyId + '" is read-only.'
+          `Inherited property "${propertyId}" is read-only.`
         );
       }
       //>>includeEnd('debug');

--- a/Source/Scene/BatchTexture.js
+++ b/Source/Scene/BatchTexture.js
@@ -219,8 +219,7 @@ function getShowAlphaProperties(batchTexture) {
 function checkBatchId(batchId, featuresLength) {
   if (!defined(batchId) || batchId < 0 || batchId >= featuresLength) {
     throw new DeveloperError(
-      "batchId is required and between zero and featuresLength - 1 (" +
-        featuresLength -
+      `batchId is required and between zero and featuresLength - 1 (${featuresLength}` -
         +")."
     );
   }

--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -370,9 +370,9 @@ Batched3DModel3DTileContent.prototype.getFeature = function (batchId) {
   const featuresLength = this.featuresLength;
   if (!defined(batchId) || batchId < 0 || batchId >= featuresLength) {
     throw new DeveloperError(
-      "batchId is required and between zero and featuresLength - 1 (" +
-        (featuresLength - 1) +
-        ")."
+      `batchId is required and between zero and featuresLength - 1 (${
+        featuresLength - 1
+      }).`
     );
   }
   //>>includeEnd('debug');

--- a/Source/Scene/Billboard.js
+++ b/Source/Scene/Billboard.js
@@ -1179,7 +1179,7 @@ Billboard.prototype._loadImage = function () {
       makeDirty(that, IMAGE_INDEX_INDEX);
     })
     .otherwise(function (error) {
-      console.error("Error loading image for billboard: " + error);
+      console.error(`Error loading image for billboard: ${error}`);
       that._imageIndexPromise = undefined;
     });
 };

--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -954,7 +954,7 @@ function writeCompressedAttrib0(
 
     //>>includeStart('debug', pragmas.debug);
     if (!defined(imageRectangle)) {
-      throw new DeveloperError("Invalid billboard image index: " + index);
+      throw new DeveloperError(`Invalid billboard image index: ${index}`);
     }
     //>>includeEnd('debug');
 
@@ -1088,7 +1088,7 @@ function writeCompressedAttrib1(
 
     //>>includeStart('debug', pragmas.debug);
     if (!defined(imageRectangle)) {
-      throw new DeveloperError("Invalid billboard image index: " + index);
+      throw new DeveloperError(`Invalid billboard image index: ${index}`);
     }
     //>>includeEnd('debug');
 
@@ -1164,7 +1164,7 @@ function writeCompressedAttrib2(
 
     //>>includeStart('debug', pragmas.debug);
     if (!defined(imageRectangle)) {
-      throw new DeveloperError("Invalid billboard image index: " + index);
+      throw new DeveloperError(`Invalid billboard image index: ${index}`);
     }
     //>>includeEnd('debug');
 
@@ -1245,7 +1245,7 @@ function writeEyeOffset(
 
       //>>includeStart('debug', pragmas.debug);
       if (!defined(imageRectangle)) {
-        throw new DeveloperError("Invalid billboard image index: " + index);
+        throw new DeveloperError(`Invalid billboard image index: ${index}`);
       }
       //>>includeEnd('debug');
 
@@ -1401,7 +1401,7 @@ function writeCompressedAttribute3(
 
       //>>includeStart('debug', pragmas.debug);
       if (!defined(imageRectangle)) {
-        throw new DeveloperError("Invalid billboard image index: " + index);
+        throw new DeveloperError(`Invalid billboard image index: ${index}`);
       }
       //>>includeEnd('debug');
 
@@ -1495,7 +1495,7 @@ function writeTextureCoordinateBoundsOrLabelTranslate(
 
     //>>includeStart('debug', pragmas.debug);
     if (!defined(imageRectangle)) {
-      throw new DeveloperError("Invalid billboard image index: " + index);
+      throw new DeveloperError(`Invalid billboard image index: ${index}`);
     }
     //>>includeEnd('debug');
 
@@ -2205,7 +2205,7 @@ BillboardCollection.prototype.update = function (frameState) {
 
       if (this._sdf) {
         fs.defines.push("SDF");
-        fs.defines.push("SDF_EDGE " + sdfEdge);
+        fs.defines.push(`SDF_EDGE ${sdfEdge}`);
       }
 
       this._sp = ShaderProgram.replaceCache({
@@ -2229,7 +2229,7 @@ BillboardCollection.prototype.update = function (frameState) {
       }
       if (this._sdf) {
         fs.defines.push("SDF");
-        fs.defines.push("SDF_EDGE " + sdfEdge);
+        fs.defines.push(`SDF_EDGE ${sdfEdge}`);
       }
       this._spTranslucent = ShaderProgram.replaceCache({
         context: context,
@@ -2254,7 +2254,7 @@ BillboardCollection.prototype.update = function (frameState) {
       }
       if (this._sdf) {
         fs.defines.push("SDF");
-        fs.defines.push("SDF_EDGE " + sdfEdge);
+        fs.defines.push(`SDF_EDGE ${sdfEdge}`);
       }
       this._sp = ShaderProgram.replaceCache({
         context: context,
@@ -2279,7 +2279,7 @@ BillboardCollection.prototype.update = function (frameState) {
       }
       if (this._sdf) {
         fs.defines.push("SDF");
-        fs.defines.push("SDF_EDGE " + sdfEdge);
+        fs.defines.push(`SDF_EDGE ${sdfEdge}`);
       }
       this._spTranslucent = ShaderProgram.replaceCache({
         context: context,

--- a/Source/Scene/BingMapsImageryProvider.js
+++ b/Source/Scene/BingMapsImageryProvider.js
@@ -178,9 +178,7 @@ function BingMapsImageryProvider(options) {
 
   this._proxy = options.proxy;
   this._credit = new Credit(
-    '<a href="http://www.bing.com"><img src="' +
-      BingMapsImageryProvider.logoUrl +
-      '" title="Bing Imagery"/></a>'
+    `<a href="http://www.bing.com"><img src="${BingMapsImageryProvider.logoUrl}" title="Bing Imagery"/></a>`
   );
 
   this._tilingScheme = new WebMercatorTilingScheme({
@@ -218,7 +216,7 @@ function BingMapsImageryProvider(options) {
   }
 
   const metadataResource = this._resource.getDerivedResource({
-    url: "REST/v1/Imagery/Metadata/" + this._mapStyle,
+    url: `REST/v1/Imagery/Metadata/${this._mapStyle}`,
     queryParameters: {
       incl: "ImageryProviders",
       key: this._key,
@@ -285,8 +283,7 @@ function BingMapsImageryProvider(options) {
   }
 
   function metadataFailure(e) {
-    const message =
-      "An error occurred while accessing " + metadataResource.url + ".";
+    const message = `An error occurred while accessing ${metadataResource.url}.`;
     metadataError = TileProviderError.handleError(
       metadataError,
       that,

--- a/Source/Scene/BufferLoader.js
+++ b/Source/Scene/BufferLoader.js
@@ -122,7 +122,7 @@ function loadExternalBuffer(bufferLoader) {
         return;
       }
       bufferLoader._state = ResourceLoaderState.FAILED;
-      const errorMessage = "Failed to load external buffer: " + resource.url;
+      const errorMessage = `Failed to load external buffer: ${resource.url}`;
       bufferLoader._promise.reject(bufferLoader.getError(errorMessage, error));
     });
 }

--- a/Source/Scene/CameraEventAggregator.js
+++ b/Source/Scene/CameraEventAggregator.js
@@ -11,7 +11,7 @@ import CameraEventType from "./CameraEventType.js";
 function getKey(type, modifier) {
   let key = type;
   if (defined(modifier)) {
-    key += "+" + modifier;
+    key += `+${modifier}`;
   }
   return key;
 }

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -148,11 +148,9 @@ function Cesium3DTile(tileset, baseResource, header, parent) {
     if (header.refine === "replace" || header.refine === "add") {
       Cesium3DTile._deprecationWarning(
         "lowercase-refine",
-        'This tile uses a lowercase refine "' +
-          header.refine +
-          '". Instead use "' +
-          header.refine.toUpperCase() +
-          '".'
+        `This tile uses a lowercase refine "${
+          header.refine
+        }". Instead use "${header.refine.toUpperCase()}".`
       );
     }
     refine =

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1882,7 +1882,7 @@ Cesium3DTileset.prototype.loadTileset = function (
   const tilesetVersion = asset.tilesetVersion;
   if (defined(tilesetVersion)) {
     // Append the tileset version to the resource
-    this._basePath += "?v=" + tilesetVersion;
+    this._basePath += `?v=${tilesetVersion}`;
     resource = resource.clone();
     resource.setQueryParameters({ v: tilesetVersion });
   }
@@ -2283,8 +2283,8 @@ function handleTileFailure(tileset, tile) {
         message: message,
       });
     } else {
-      console.log("A 3D tile failed to load: " + url);
-      console.log("Error: " + message);
+      console.log(`A 3D tile failed to load: ${url}`);
+      console.log(`Error: ${message}`);
     }
   };
 }
@@ -2379,38 +2379,38 @@ function addTileDebugLabel(tile, tileset, position) {
   let attributes = 0;
 
   if (tileset.debugShowGeometricError) {
-    labelString += "\nGeometric error: " + tile.geometricError;
+    labelString += `\nGeometric error: ${tile.geometricError}`;
     attributes++;
   }
 
   if (tileset.debugShowRenderingStatistics) {
-    labelString += "\nCommands: " + tile.commandsLength;
+    labelString += `\nCommands: ${tile.commandsLength}`;
     attributes++;
 
     // Don't display number of points or triangles if 0.
     const numberOfPoints = tile.content.pointsLength;
     if (numberOfPoints > 0) {
-      labelString += "\nPoints: " + tile.content.pointsLength;
+      labelString += `\nPoints: ${tile.content.pointsLength}`;
       attributes++;
     }
 
     const numberOfTriangles = tile.content.trianglesLength;
     if (numberOfTriangles > 0) {
-      labelString += "\nTriangles: " + tile.content.trianglesLength;
+      labelString += `\nTriangles: ${tile.content.trianglesLength}`;
       attributes++;
     }
 
-    labelString += "\nFeatures: " + tile.content.featuresLength;
+    labelString += `\nFeatures: ${tile.content.featuresLength}`;
     attributes++;
   }
 
   if (tileset.debugShowMemoryUsage) {
-    labelString +=
-      "\nTexture Memory: " +
-      formatMemoryString(tile.content.texturesByteLength);
-    labelString +=
-      "\nGeometry Memory: " +
-      formatMemoryString(tile.content.geometryByteLength);
+    labelString += `\nTexture Memory: ${formatMemoryString(
+      tile.content.texturesByteLength
+    )}`;
+    labelString += `\nGeometry Memory: ${formatMemoryString(
+      tile.content.geometryByteLength
+    )}`;
     attributes += 2;
   }
 
@@ -2419,11 +2419,11 @@ function addTileDebugLabel(tile, tileset, position) {
       labelString += "\nUrls:";
       const urls = tile.content.innerContentUrls;
       for (let i = 0; i < urls.length; i++) {
-        labelString += "\n- " + urls[i];
+        labelString += `\n- ${urls[i]}`;
       }
       attributes += urls.length;
     } else {
-      labelString += "\nUrl: " + tile._header.content.uri;
+      labelString += `\nUrl: ${tile._header.content.uri}`;
       attributes++;
     }
   }
@@ -2431,7 +2431,7 @@ function addTileDebugLabel(tile, tileset, position) {
   const newLabel = {
     text: labelString.substring(1),
     position: position,
-    font: 19 - attributes + "px sans-serif",
+    font: `${19 - attributes}px sans-serif`,
     showBackground: true,
     disableDepthTestDistance: Number.POSITIVE_INFINITY,
   };
@@ -2956,7 +2956,7 @@ Cesium3DTileset.checkSupportedExtensions = function (extensionsRequired) {
   for (let i = 0; i < extensionsRequired.length; i++) {
     if (!Cesium3DTileset.supportedExtensions[extensionsRequired[i]]) {
       throw new RuntimeError(
-        "Unsupported 3D Tiles Extension: " + extensionsRequired[i]
+        `Unsupported 3D Tiles Extension: ${extensionsRequired[i]}`
       );
     }
   }

--- a/Source/Scene/ClassificationModel.js
+++ b/Source/Scene/ClassificationModel.js
@@ -598,38 +598,19 @@ function createProgram(model) {
     }
 
     uniformDecl =
-      "uniform mat4 " +
-      modelViewName +
-      ";\n" +
-      "uniform mat4 " +
-      projectionName +
-      ";\n";
-    toClip =
-      projectionName +
-      " * " +
-      modelViewName +
-      " * vec4(" +
-      positionName +
-      ", 1.0)";
+      `uniform mat4 ${modelViewName};\n` + `uniform mat4 ${projectionName};\n`;
+    toClip = `${projectionName} * ${modelViewName} * vec4(${positionName}, 1.0)`;
   } else {
-    uniformDecl = "uniform mat4 " + modelViewProjectionName + ";\n";
-    toClip = modelViewProjectionName + " * vec4(" + positionName + ", 1.0)";
+    uniformDecl = `uniform mat4 ${modelViewProjectionName};\n`;
+    toClip = `${modelViewProjectionName} * vec4(${positionName}, 1.0)`;
   }
 
-  const computePosition = "    vec4 positionInClipCoords = " + toClip + ";\n";
+  const computePosition = `    vec4 positionInClipCoords = ${toClip};\n`;
 
   let vs =
-    "attribute vec3 " +
-    positionName +
-    ";\n" +
-    "attribute float " +
-    batchIdName +
-    ";\n" +
-    uniformDecl +
-    "void main() {\n" +
-    computePosition +
-    "    gl_Position = czm_depthClamp(positionInClipCoords);\n" +
-    "}\n";
+    `attribute vec3 ${positionName};\n` +
+    `attribute float ${batchIdName};\n${uniformDecl}void main() {\n${computePosition}    gl_Position = czm_depthClamp(positionInClipCoords);\n` +
+    `}\n`;
   const fs =
     "#ifdef GL_EXT_frag_depth\n" +
     "#extension GL_EXT_frag_depth : enable\n" +

--- a/Source/Scene/ClassificationPrimitive.js
+++ b/Source/Scene/ClassificationPrimitive.js
@@ -479,11 +479,10 @@ function modifyForEncodedNormals(primitive, vertexShaderSource) {
     const attributeName = "compressedAttributes";
 
     //only shadow volumes use extrudeDirection, and shadow volumes use vertexFormat: POSITION_ONLY so we don't need to check other attributes
-    const attributeDecl = "attribute vec2 " + attributeName + ";";
+    const attributeDecl = `attribute vec2 ${attributeName};`;
 
     const globalDecl = "vec3 extrudeDirection;\n";
-    const decode =
-      "    extrudeDirection = czm_octDecode(" + attributeName + ", 65535.0);\n";
+    const decode = `    extrudeDirection = czm_octDecode(${attributeName}, 65535.0);\n`;
 
     let modifiedVS = vertexShaderSource;
     modifiedVS = modifiedVS.replace(
@@ -495,11 +494,8 @@ function modifyForEncodedNormals(primitive, vertexShaderSource) {
       "czm_non_compressed_main"
     );
     const compressedMain =
-      "void main() \n" +
-      "{ \n" +
-      decode +
-      "    czm_non_compressed_main(); \n" +
-      "}";
+      `${"void main() \n" + "{ \n"}${decode}    czm_non_compressed_main(); \n` +
+      `}`;
 
     return [attributeDecl, globalDecl, modifiedVS, compressedMain].join("\n");
   }

--- a/Source/Scene/Composite3DTileContent.js
+++ b/Source/Scene/Composite3DTileContent.js
@@ -199,9 +199,7 @@ function initialize(content, arrayBuffer, byteOffset, factory) {
   const version = view.getUint32(byteOffset, true);
   if (version !== 1) {
     throw new RuntimeError(
-      "Only Composite Tile version 1 is supported. Version " +
-        version +
-        " is not."
+      `Only Composite Tile version 1 is supported. Version ${version} is not.`
     );
   }
   byteOffset += sizeOfUint32;
@@ -234,7 +232,7 @@ function initialize(content, arrayBuffer, byteOffset, factory) {
       contentPromises.push(innerContent.readyPromise);
     } else {
       throw new RuntimeError(
-        "Unknown tile content type, " + tileType + ", inside Composite tile"
+        `Unknown tile content type, ${tileType}, inside Composite tile`
       );
     }
 

--- a/Source/Scene/ConditionsExpression.js
+++ b/Source/Scene/ConditionsExpression.js
@@ -171,29 +171,16 @@ ConditionsExpression.prototype.getShaderFunction = function (
 
     // Build the if/else chain from the list of conditions
     shaderFunction +=
-      "    " +
-      (i === 0 ? "if" : "else if") +
-      " (" +
-      condition +
-      ")\n" +
-      "    {\n" +
-      "        return " +
-      expression +
-      ";\n" +
-      "    }\n";
+      `    ${i === 0 ? "if" : "else if"} (${condition})\n` +
+      `    {\n` +
+      `        return ${expression};\n` +
+      `    }\n`;
   }
 
   shaderFunction =
-    returnType +
-    " " +
-    functionSignature +
-    "\n" +
-    "{\n" +
-    shaderFunction +
-    "    return " +
-    returnType +
-    "(1.0);\n" + // Return a default value if no conditions are met
-    "}\n";
+    `${returnType} ${functionSignature}\n` +
+    `{\n${shaderFunction}    return ${returnType}(1.0);\n` + // Return a default value if no conditions are met
+    `}\n`;
 
   return shaderFunction;
 };

--- a/Source/Scene/CreditDisplay.js
+++ b/Source/Scene/CreditDisplay.js
@@ -128,24 +128,26 @@ function styleLightboxContainer(that) {
     } else {
       lightboxCredits.className =
         "cesium-credit-lightbox cesium-credit-lightbox-expanded";
-      lightboxCredits.style.marginTop =
-        Math.floor((height - lightboxCredits.clientHeight) * 0.5) + "px";
+      lightboxCredits.style.marginTop = `${Math.floor(
+        (height - lightboxCredits.clientHeight) * 0.5
+      )}px`;
     }
     that._lastViewportWidth = width;
   }
 
   if (width >= mobileWidth && height !== that._lastViewportHeight) {
-    lightboxCredits.style.marginTop =
-      Math.floor((height - lightboxCredits.clientHeight) * 0.5) + "px";
+    lightboxCredits.style.marginTop = `${Math.floor(
+      (height - lightboxCredits.clientHeight) * 0.5
+    )}px`;
     that._lastViewportHeight = height;
   }
 }
 
 function addStyle(selector, styles) {
-  let style = selector + " {";
+  let style = `${selector} {`;
   for (const attribute in styles) {
     if (styles.hasOwnProperty(attribute)) {
-      style += attribute + ": " + styles[attribute] + "; ";
+      style += `${attribute}: ${styles[attribute]}; `;
     }
   }
   style += " }\n";
@@ -169,7 +171,7 @@ function appendCss() {
     "background-color": "#303336",
     color: textColor,
     position: "relative",
-    "min-height": lightboxHeight + "px",
+    "min-height": `${lightboxHeight}px`,
     margin: "auto",
   });
 
@@ -526,9 +528,7 @@ function getDefaultCredit() {
     }
 
     defaultCredit = new Credit(
-      '<a href="https://cesium.com/" target="_blank"><img src="' +
-        logo +
-        '" title="Cesium ion"/></a>',
+      `<a href="https://cesium.com/" target="_blank"><img src="${logo}" title="Cesium ion"/></a>`,
       true
     );
   }

--- a/Source/Scene/DebugAppearance.js
+++ b/Source/Scene/DebugAppearance.js
@@ -48,7 +48,7 @@ function DebugAppearance(options) {
   }
 
   let glslDatatype = defaultValue(options.glslDatatype, "vec3");
-  const varyingName = "v_" + attributeName;
+  const varyingName = `v_${attributeName}`;
   let getColor;
 
   // Well-known normalized vector attributes in VertexFormat
@@ -57,10 +57,7 @@ function DebugAppearance(options) {
     attributeName === "tangent" ||
     attributeName === "bitangent"
   ) {
-    getColor =
-      "vec4 getColor() { return vec4((" +
-      varyingName +
-      " + vec3(1.0)) * 0.5, 1.0); }\n";
+    getColor = `vec4 getColor() { return vec4((${varyingName} + vec3(1.0)) * 0.5, 1.0); }\n`;
   } else {
     // All other attributes, both well-known and custom
     if (attributeName === "st") {
@@ -69,19 +66,16 @@ function DebugAppearance(options) {
 
     switch (glslDatatype) {
       case "float":
-        getColor =
-          "vec4 getColor() { return vec4(vec3(" + varyingName + "), 1.0); }\n";
+        getColor = `vec4 getColor() { return vec4(vec3(${varyingName}), 1.0); }\n`;
         break;
       case "vec2":
-        getColor =
-          "vec4 getColor() { return vec4(" + varyingName + ", 0.0, 1.0); }\n";
+        getColor = `vec4 getColor() { return vec4(${varyingName}, 0.0, 1.0); }\n`;
         break;
       case "vec3":
-        getColor =
-          "vec4 getColor() { return vec4(" + varyingName + ", 1.0); }\n";
+        getColor = `vec4 getColor() { return vec4(${varyingName}, 1.0); }\n`;
         break;
       case "vec4":
-        getColor = "vec4 getColor() { return " + varyingName + "; }\n";
+        getColor = `vec4 getColor() { return ${varyingName}; }\n`;
         break;
       //>>includeStart('debug', pragmas.debug);
       default:
@@ -93,37 +87,29 @@ function DebugAppearance(options) {
   }
 
   const vs =
-    "attribute vec3 position3DHigh;\n" +
-    "attribute vec3 position3DLow;\n" +
-    "attribute float batchId;\n" +
-    (perInstanceAttribute
-      ? ""
-      : "attribute " + glslDatatype + " " + attributeName + ";\n") +
-    "varying " +
-    glslDatatype +
-    " " +
-    varyingName +
-    ";\n" +
-    "void main()\n" +
-    "{\n" +
-    "vec4 p = czm_translateRelativeToEye(position3DHigh, position3DLow);\n" +
-    (perInstanceAttribute
-      ? varyingName + " = czm_batchTable_" + attributeName + "(batchId);\n"
-      : varyingName + " = " + attributeName + ";\n") +
-    "gl_Position = czm_modelViewProjectionRelativeToEye * p;\n" +
-    "}";
+    `${
+      "attribute vec3 position3DHigh;\n" +
+      "attribute vec3 position3DLow;\n" +
+      "attribute float batchId;\n"
+    }${
+      perInstanceAttribute
+        ? ""
+        : `attribute ${glslDatatype} ${attributeName};\n`
+    }varying ${glslDatatype} ${varyingName};\n` +
+    `void main()\n` +
+    `{\n` +
+    `vec4 p = czm_translateRelativeToEye(position3DHigh, position3DLow);\n${
+      perInstanceAttribute
+        ? `${varyingName} = czm_batchTable_${attributeName}(batchId);\n`
+        : `${varyingName} = ${attributeName};\n`
+    }gl_Position = czm_modelViewProjectionRelativeToEye * p;\n` +
+    `}`;
   const fs =
-    "varying " +
-    glslDatatype +
-    " " +
-    varyingName +
-    ";\n" +
-    getColor +
-    "\n" +
-    "void main()\n" +
-    "{\n" +
-    "gl_FragColor = getColor();\n" +
-    "}";
+    `varying ${glslDatatype} ${varyingName};\n${getColor}\n` +
+    `void main()\n` +
+    `{\n` +
+    `gl_FragColor = getColor();\n` +
+    `}`;
 
   /**
    * This property is part of the {@link Appearance} interface, but is not

--- a/Source/Scene/DebugInspector.js
+++ b/Source/Scene/DebugInspector.js
@@ -52,10 +52,8 @@ function createDebugShowFrustumsShaderProgram(scene, shaderProgram) {
   let i;
   if (length > 0) {
     for (i = 0; i < length; ++i) {
-      newMain +=
-        "    gl_FragData[" + targets[i] + "].rgb *= debugShowCommandsColor;\n";
-      newMain +=
-        "    gl_FragData[" + targets[i] + "].rgb *= debugShowFrustumsColor;\n";
+      newMain += `    gl_FragData[${targets[i]}].rgb *= debugShowCommandsColor;\n`;
+      newMain += `    gl_FragData[${targets[i]}].rgb *= debugShowFrustumsColor;\n`;
     }
   } else {
     newMain += "    gl_FragColor.rgb *= debugShowCommandsColor;\n";

--- a/Source/Scene/DerivedCommand.js
+++ b/Source/Scene/DerivedCommand.js
@@ -286,16 +286,15 @@ function getPickShaderProgram(context, shaderProgram, pickId) {
     const length = sources.length;
 
     const newMain =
-      "void main() \n" +
-      "{ \n" +
-      "    czm_non_pick_main(); \n" +
-      "    if (gl_FragColor.a == 0.0) { \n" +
-      "        discard; \n" +
-      "    } \n" +
-      "    gl_FragColor = " +
-      pickId +
-      "; \n" +
-      "} \n";
+      `${
+        "void main() \n" +
+        "{ \n" +
+        "    czm_non_pick_main(); \n" +
+        "    if (gl_FragColor.a == 0.0) { \n" +
+        "        discard; \n" +
+        "    } \n" +
+        "    gl_FragColor = "
+      }${pickId}; \n` + `} \n`;
     const newSources = new Array(length + 1);
     for (let i = 0; i < length; ++i) {
       newSources[i] = ShaderSource.replaceMain(sources[i], "czm_non_pick_main");

--- a/Source/Scene/DracoLoader.js
+++ b/Source/Scene/DracoLoader.js
@@ -54,8 +54,9 @@ DracoLoader.hasExtension = function (model) {
 
 function addBufferToLoadResources(loadResources, typedArray) {
   // Create a new id to differentiate from original glTF bufferViews
-  const bufferViewId =
-    "runtime." + Object.keys(loadResources.createdBufferViews).length;
+  const bufferViewId = `runtime.${
+    Object.keys(loadResources.createdBufferViews).length
+  }`;
 
   const loadResourceBuffers = loadResources.buffers;
   const id = Object.keys(loadResourceBuffers).length;
@@ -146,7 +147,7 @@ function scheduleDecodingTask(
       }
     }
 
-    model._decodedData[taskData.mesh + ".primitive." + taskData.primitive] = {
+    model._decodedData[`${taskData.mesh}.primitive.${taskData.primitive}`] = {
       bufferView: decodedIndexBuffer.bufferViewId,
       numberOfIndices: decodedIndexBuffer.numberOfIndices,
       attributes: attributes,

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -191,15 +191,10 @@ Expression.prototype.getShaderFunction = function (
   );
 
   shaderExpression =
-    returnType +
-    " " +
-    functionSignature +
-    "\n" +
-    "{\n" +
-    "    return " +
-    shaderExpression +
-    ";\n" +
-    "}\n";
+    `${returnType} ${functionSignature}\n` +
+    `{\n` +
+    `    return ${shaderExpression};\n` +
+    `}\n`;
 
   return shaderExpression;
 };
@@ -349,11 +344,7 @@ function getEvaluateUnaryComponentwise(operation) {
       );
     }
     throw new RuntimeError(
-      'Function "' +
-        call +
-        '" requires a vector or number argument. Argument is ' +
-        left +
-        "."
+      `Function "${call}" requires a vector or number argument. Argument is ${left}.`
     );
   };
 }
@@ -413,13 +404,7 @@ function getEvaluateBinaryComponentwise(operation, allowScalar) {
     }
 
     throw new RuntimeError(
-      'Function "' +
-        call +
-        '" requires vector or number arguments of matching types. Arguments are ' +
-        left +
-        " and " +
-        right +
-        "."
+      `Function "${call}" requires vector or number arguments of matching types. Arguments are ${left} and ${right}.`
     );
   };
 }
@@ -495,15 +480,7 @@ function getEvaluateTernaryComponentwise(operation, allowScalar) {
     }
 
     throw new RuntimeError(
-      'Function "' +
-        call +
-        '" requires vector or number arguments of matching types. Arguments are ' +
-        left +
-        ", " +
-        right +
-        ", and " +
-        test +
-        "."
+      `Function "${call}" requires vector or number arguments of matching types. Arguments are ${left}, ${right}, and ${test}.`
     );
   };
 }
@@ -520,11 +497,7 @@ function length(call, left) {
   }
 
   throw new RuntimeError(
-    'Function "' +
-      call +
-      '" requires a vector or number argument. Argument is ' +
-      left +
-      "."
+    `Function "${call}" requires a vector or number argument. Argument is ${left}.`
   );
 }
 
@@ -540,11 +513,7 @@ function normalize(call, left) {
   }
 
   throw new RuntimeError(
-    'Function "' +
-      call +
-      '" requires a vector or number argument. Argument is ' +
-      left +
-      "."
+    `Function "${call}" requires a vector or number argument. Argument is ${left}.`
   );
 }
 
@@ -560,13 +529,7 @@ function distance(call, left, right) {
   }
 
   throw new RuntimeError(
-    'Function "' +
-      call +
-      '" requires vector or number arguments of matching types. Arguments are ' +
-      left +
-      " and " +
-      right +
-      "."
+    `Function "${call}" requires vector or number arguments of matching types. Arguments are ${left} and ${right}.`
   );
 }
 
@@ -582,13 +545,7 @@ function dot(call, left, right) {
   }
 
   throw new RuntimeError(
-    'Function "' +
-      call +
-      '" requires vector or number arguments of matching types. Arguments are ' +
-      left +
-      " and " +
-      right +
-      "."
+    `Function "${call}" requires vector or number arguments of matching types. Arguments are ${left} and ${right}.`
   );
 }
 
@@ -598,13 +555,7 @@ function cross(call, left, right) {
   }
 
   throw new RuntimeError(
-    'Function "' +
-      call +
-      '" requires vec3 arguments. Arguments are ' +
-      left +
-      " and " +
-      right +
-      "."
+    `Function "${call}" requires vec3 arguments. Arguments are ${left} and ${right}.`
   );
 }
 
@@ -625,8 +576,8 @@ function replaceDefines(expression, defines) {
   }
   for (const key in defines) {
     if (defines.hasOwnProperty(key)) {
-      const definePlaceholder = new RegExp("\\$\\{" + key + "\\}", "g");
-      const defineReplace = "(" + defines[key] + ")";
+      const definePlaceholder = new RegExp(`\\$\\{${key}\\}`, "g");
+      const defineReplace = `(${defines[key]})`;
       if (defined(defineReplace)) {
         expression = expression.replace(definePlaceholder, defineReplace);
       }
@@ -668,7 +619,7 @@ function replaceVariables(expression) {
       if (j < 0) {
         throw new RuntimeError("Unmatched {.");
       }
-      result += "czm_" + exp.substr(i + 2, j - (i + 2));
+      result += `czm_${exp.substr(i + 2, j - (i + 2))}`;
       exp = exp.substr(j + 1);
       i = exp.indexOf("${");
     }
@@ -709,7 +660,7 @@ function parseCall(expression, ast) {
     if (call === "test" || call === "exec") {
       // Make sure this is called on a valid type
       if (object.callee.name !== "regExp") {
-        throw new RuntimeError(call + " is not a function.");
+        throw new RuntimeError(`${call} is not a function.`);
       }
       if (argsLength === 0) {
         if (call === "test") {
@@ -725,7 +676,7 @@ function parseCall(expression, ast) {
       return new Node(ExpressionNodeType.FUNCTION_CALL, call, val);
     }
 
-    throw new RuntimeError('Unexpected function call "' + call + '".');
+    throw new RuntimeError(`Unexpected function call "${call}".`);
   }
 
   // Non-member function calls
@@ -742,7 +693,7 @@ function parseCall(expression, ast) {
     return new Node(ExpressionNodeType.LITERAL_COLOR, call, [val]);
   } else if (call === "rgb" || call === "hsl") {
     if (argsLength < 3) {
-      throw new RuntimeError(call + " requires three arguments.");
+      throw new RuntimeError(`${call} requires three arguments.`);
     }
     val = [
       createRuntimeAst(expression, args[0]),
@@ -752,7 +703,7 @@ function parseCall(expression, ast) {
     return new Node(ExpressionNodeType.LITERAL_COLOR, call, val);
   } else if (call === "rgba" || call === "hsla") {
     if (argsLength < 4) {
-      throw new RuntimeError(call + " requires four arguments.");
+      throw new RuntimeError(`${call} requires four arguments.`);
     }
     val = [
       createRuntimeAst(expression, args[0]),
@@ -779,31 +730,31 @@ function parseCall(expression, ast) {
     return new Node(ExpressionNodeType.UNARY, call, val);
   } else if (call === "isExactClass" || call === "isClass") {
     if (argsLength < 1 || argsLength > 1) {
-      throw new RuntimeError(call + " requires exactly one argument.");
+      throw new RuntimeError(`${call} requires exactly one argument.`);
     }
     val = createRuntimeAst(expression, args[0]);
     return new Node(ExpressionNodeType.UNARY, call, val);
   } else if (call === "getExactClassName") {
     if (argsLength > 0) {
-      throw new RuntimeError(call + " does not take any argument.");
+      throw new RuntimeError(`${call} does not take any argument.`);
     }
     return new Node(ExpressionNodeType.UNARY, call);
   } else if (defined(unaryFunctions[call])) {
     if (argsLength !== 1) {
-      throw new RuntimeError(call + " requires exactly one argument.");
+      throw new RuntimeError(`${call} requires exactly one argument.`);
     }
     val = createRuntimeAst(expression, args[0]);
     return new Node(ExpressionNodeType.UNARY, call, val);
   } else if (defined(binaryFunctions[call])) {
     if (argsLength !== 2) {
-      throw new RuntimeError(call + " requires exactly two arguments.");
+      throw new RuntimeError(`${call} requires exactly two arguments.`);
     }
     left = createRuntimeAst(expression, args[0]);
     right = createRuntimeAst(expression, args[1]);
     return new Node(ExpressionNodeType.BINARY, call, left, right);
   } else if (defined(ternaryFunctions[call])) {
     if (argsLength !== 3) {
-      throw new RuntimeError(call + " requires exactly three arguments.");
+      throw new RuntimeError(`${call} requires exactly three arguments.`);
     }
     left = createRuntimeAst(expression, args[0]);
     right = createRuntimeAst(expression, args[1]);
@@ -831,7 +782,7 @@ function parseCall(expression, ast) {
     return parseRegex(expression, ast);
   }
 
-  throw new RuntimeError('Unexpected function call "' + call + '".');
+  throw new RuntimeError(`Unexpected function call "${call}".`);
 }
 
 function parseRegex(expression, ast) {
@@ -888,7 +839,7 @@ function parseKeywordsAndVariables(ast) {
     return new Node(ExpressionNodeType.LITERAL_UNDEFINED, undefined);
   }
 
-  throw new RuntimeError(ast.name + " is not defined.");
+  throw new RuntimeError(`${ast.name} is not defined.`);
 }
 
 function parseMathConstant(ast) {
@@ -958,7 +909,7 @@ function createRuntimeAst(expression, ast) {
     if (unaryOperators.indexOf(op) > -1) {
       node = new Node(ExpressionNodeType.UNARY, op, child);
     } else {
-      throw new RuntimeError('Unexpected operator "' + op + '".');
+      throw new RuntimeError(`Unexpected operator "${op}".`);
     }
   } else if (ast.type === "BinaryExpression") {
     op = ast.operator;
@@ -967,7 +918,7 @@ function createRuntimeAst(expression, ast) {
     if (binaryOperators.indexOf(op) > -1) {
       node = new Node(ExpressionNodeType.BINARY, op, left, right);
     } else {
-      throw new RuntimeError('Unexpected operator "' + op + '".');
+      throw new RuntimeError(`Unexpected operator "${op}".`);
     }
   } else if (ast.type === "LogicalExpression") {
     op = ast.operator;
@@ -1226,10 +1177,7 @@ Node.prototype._evaluateLiteralVector = function (feature) {
       components.push(value.x, value.y, value.z, value.w);
     } else {
       throw new RuntimeError(
-        call +
-          " argument must be a vector or number. Argument is " +
-          value +
-          "."
+        `${call} argument must be a vector or number. Argument is ${value}.`
       );
     }
   }
@@ -1238,17 +1186,13 @@ Node.prototype._evaluateLiteralVector = function (feature) {
   const vectorLength = parseInt(call.charAt(3));
 
   if (componentsLength === 0) {
-    throw new RuntimeError(
-      "Invalid " + call + " constructor. No valid arguments."
-    );
+    throw new RuntimeError(`Invalid ${call} constructor. No valid arguments.`);
   } else if (componentsLength < vectorLength && componentsLength > 1) {
     throw new RuntimeError(
-      "Invalid " + call + " constructor. Not enough arguments."
+      `Invalid ${call} constructor. Not enough arguments.`
     );
   } else if (componentsLength > vectorLength && argsLength > 1) {
-    throw new RuntimeError(
-      "Invalid " + call + " constructor. Too many arguments."
-    );
+    throw new RuntimeError(`Invalid ${call} constructor. Too many arguments.`);
   }
 
   if (componentsLength === 1) {
@@ -1370,7 +1314,7 @@ Node.prototype._evaluateNot = function (feature) {
   const left = this._left.evaluate(feature);
   if (typeof left !== "boolean") {
     throw new RuntimeError(
-      'Operator "!" requires a boolean argument. Argument is ' + left + "."
+      `Operator "!" requires a boolean argument. Argument is ${left}.`
     );
   }
   return !left;
@@ -1389,9 +1333,7 @@ Node.prototype._evaluateNegative = function (feature) {
   }
 
   throw new RuntimeError(
-    'Operator "-" requires a vector or number argument. Argument is ' +
-      left +
-      "."
+    `Operator "-" requires a vector or number argument. Argument is ${left}.`
   );
 };
 
@@ -1407,9 +1349,7 @@ Node.prototype._evaluatePositive = function (feature) {
     )
   ) {
     throw new RuntimeError(
-      'Operator "+" requires a vector or number argument. Argument is ' +
-        left +
-        "."
+      `Operator "+" requires a vector or number argument. Argument is ${left}.`
     );
   }
 
@@ -1422,11 +1362,7 @@ Node.prototype._evaluateLessThan = function (feature) {
 
   if (typeof left !== "number" || typeof right !== "number") {
     throw new RuntimeError(
-      'Operator "<" requires number arguments. Arguments are ' +
-        left +
-        " and " +
-        right +
-        "."
+      `Operator "<" requires number arguments. Arguments are ${left} and ${right}.`
     );
   }
 
@@ -1439,11 +1375,7 @@ Node.prototype._evaluateLessThanOrEquals = function (feature) {
 
   if (typeof left !== "number" || typeof right !== "number") {
     throw new RuntimeError(
-      'Operator "<=" requires number arguments. Arguments are ' +
-        left +
-        " and " +
-        right +
-        "."
+      `Operator "<=" requires number arguments. Arguments are ${left} and ${right}.`
     );
   }
 
@@ -1456,11 +1388,7 @@ Node.prototype._evaluateGreaterThan = function (feature) {
 
   if (typeof left !== "number" || typeof right !== "number") {
     throw new RuntimeError(
-      'Operator ">" requires number arguments. Arguments are ' +
-        left +
-        " and " +
-        right +
-        "."
+      `Operator ">" requires number arguments. Arguments are ${left} and ${right}.`
     );
   }
 
@@ -1473,11 +1401,7 @@ Node.prototype._evaluateGreaterThanOrEquals = function (feature) {
 
   if (typeof left !== "number" || typeof right !== "number") {
     throw new RuntimeError(
-      'Operator ">=" requires number arguments. Arguments are ' +
-        left +
-        " and " +
-        right +
-        "."
+      `Operator ">=" requires number arguments. Arguments are ${left} and ${right}.`
     );
   }
 
@@ -1488,9 +1412,7 @@ Node.prototype._evaluateOr = function (feature) {
   const left = this._left.evaluate(feature);
   if (typeof left !== "boolean") {
     throw new RuntimeError(
-      'Operator "||" requires boolean arguments. First argument is ' +
-        left +
-        "."
+      `Operator "||" requires boolean arguments. First argument is ${left}.`
     );
   }
 
@@ -1502,9 +1424,7 @@ Node.prototype._evaluateOr = function (feature) {
   const right = this._right.evaluate(feature);
   if (typeof right !== "boolean") {
     throw new RuntimeError(
-      'Operator "||" requires boolean arguments. Second argument is ' +
-        right +
-        "."
+      `Operator "||" requires boolean arguments. Second argument is ${right}.`
     );
   }
 
@@ -1515,9 +1435,7 @@ Node.prototype._evaluateAnd = function (feature) {
   const left = this._left.evaluate(feature);
   if (typeof left !== "boolean") {
     throw new RuntimeError(
-      'Operator "&&" requires boolean arguments. First argument is ' +
-        left +
-        "."
+      `Operator "&&" requires boolean arguments. First argument is ${left}.`
     );
   }
 
@@ -1529,9 +1447,7 @@ Node.prototype._evaluateAnd = function (feature) {
   const right = this._right.evaluate(feature);
   if (typeof right !== "boolean") {
     throw new RuntimeError(
-      'Operator "&&" requires boolean arguments. Second argument is ' +
-        right +
-        "."
+      `Operator "&&" requires boolean arguments. Second argument is ${right}.`
     );
   }
 
@@ -1555,11 +1471,7 @@ Node.prototype._evaluatePlus = function (feature) {
   }
 
   throw new RuntimeError(
-    'Operator "+" requires vector or number arguments of matching types, or at least one string argument. Arguments are ' +
-      left +
-      " and " +
-      right +
-      "."
+    `Operator "+" requires vector or number arguments of matching types, or at least one string argument. Arguments are ${left} and ${right}.`
   );
 };
 
@@ -1577,11 +1489,7 @@ Node.prototype._evaluateMinus = function (feature) {
   }
 
   throw new RuntimeError(
-    'Operator "-" requires vector or number arguments of matching types. Arguments are ' +
-      left +
-      " and " +
-      right +
-      "."
+    `Operator "-" requires vector or number arguments of matching types. Arguments are ${left} and ${right}.`
   );
 };
 
@@ -1647,11 +1555,7 @@ Node.prototype._evaluateTimes = function (feature) {
   }
 
   throw new RuntimeError(
-    'Operator "*" requires vector or number arguments. If both arguments are vectors they must be matching types. Arguments are ' +
-      left +
-      " and " +
-      right +
-      "."
+    `Operator "*" requires vector or number arguments. If both arguments are vectors they must be matching types. Arguments are ${left} and ${right}.`
   );
 };
 
@@ -1699,11 +1603,7 @@ Node.prototype._evaluateDivide = function (feature) {
   }
 
   throw new RuntimeError(
-    'Operator "/" requires vector or number arguments of matching types, or a number as the second argument. Arguments are ' +
-      left +
-      " and " +
-      right +
-      "."
+    `Operator "/" requires vector or number arguments of matching types, or a number as the second argument. Arguments are ${left} and ${right}.`
   );
 };
 
@@ -1736,11 +1636,7 @@ Node.prototype._evaluateMod = function (feature) {
   }
 
   throw new RuntimeError(
-    'Operator "%" requires vector or number arguments of matching types. Arguments are ' +
-      left +
-      " and " +
-      right +
-      "."
+    `Operator "%" requires vector or number arguments of matching types. Arguments are ${left} and ${right}.`
   );
 };
 
@@ -1775,9 +1671,7 @@ Node.prototype._evaluateConditional = function (feature) {
 
   if (typeof test !== "boolean") {
     throw new RuntimeError(
-      "Conditional argument of conditional expression must be a boolean. Argument is " +
-        test +
-        "."
+      `Conditional argument of conditional expression must be a boolean. Argument is ${test}.`
     );
   }
 
@@ -1850,11 +1744,7 @@ Node.prototype._evaluateRegExpTest = function (feature) {
 
   if (!(left instanceof RegExp && typeof right === "string")) {
     throw new RuntimeError(
-      "RegExp.test requires the first argument to be a RegExp and the second argument to be a string. Arguments are " +
-        left +
-        " and " +
-        right +
-        "."
+      `RegExp.test requires the first argument to be a RegExp and the second argument to be a string. Arguments are ${left} and ${right}.`
     );
   }
 
@@ -1872,11 +1762,7 @@ Node.prototype._evaluateRegExpMatch = function (feature) {
   }
 
   throw new RuntimeError(
-    'Operator "=~" requires one RegExp argument and one string argument. Arguments are ' +
-      left +
-      " and " +
-      right +
-      "."
+    `Operator "=~" requires one RegExp argument and one string argument. Arguments are ${left} and ${right}.`
   );
 };
 
@@ -1891,11 +1777,7 @@ Node.prototype._evaluateRegExpNotMatch = function (feature) {
   }
 
   throw new RuntimeError(
-    'Operator "!~" requires one RegExp argument and one string argument. Arguments are ' +
-      left +
-      " and " +
-      right +
-      "."
+    `Operator "!~" requires one RegExp argument and one string argument. Arguments are ${left} and ${right}.`
   );
 };
 
@@ -1905,11 +1787,7 @@ Node.prototype._evaluateRegExpExec = function (feature) {
 
   if (!(left instanceof RegExp && typeof right === "string")) {
     throw new RuntimeError(
-      "RegExp.exec requires the first argument to be a RegExp and the second argument to be a string. Arguments are " +
-        left +
-        " and " +
-        right +
-        "."
+      `RegExp.exec requires the first argument to be a RegExp and the second argument to be a string. Arguments are ${left} and ${right}.`
     );
   }
 
@@ -1931,7 +1809,7 @@ Node.prototype._evaluateToString = function (feature) {
     return String(left);
   }
 
-  throw new RuntimeError('Unexpected function call "' + this._value + '".');
+  throw new RuntimeError(`Unexpected function call "${this._value}".`);
 };
 
 function convertHSLToRGB(ast) {
@@ -1982,7 +1860,7 @@ function colorToVec3(color) {
   const r = numberToString(color.red);
   const g = numberToString(color.green);
   const b = numberToString(color.blue);
-  return "vec3(" + r + ", " + g + ", " + b + ")";
+  return `vec3(${r}, ${g}, ${b})`;
 }
 
 function colorToVec4(color) {
@@ -1990,7 +1868,7 @@ function colorToVec4(color) {
   const g = numberToString(color.green);
   const b = numberToString(color.blue);
   const a = numberToString(color.alpha);
-  return "vec4(" + r + ", " + g + ", " + b + ", " + a + ")";
+  return `vec4(${r}, ${g}, ${b}, ${a})`;
 }
 
 function getExpressionArray(
@@ -2093,19 +1971,19 @@ Node.prototype.getShaderExpression = function (
     case ExpressionNodeType.UNARY:
       // Supported types: +, -, !, Boolean, Number
       if (value === "Boolean") {
-        return "bool(" + left + ")";
+        return `bool(${left})`;
       } else if (value === "Number") {
-        return "float(" + left + ")";
+        return `float(${left})`;
       } else if (value === "round") {
-        return "floor(" + left + " + 0.5)";
+        return `floor(${left} + 0.5)`;
       } else if (defined(unaryFunctions[value])) {
-        return value + "(" + left + ")";
+        return `${value}(${left})`;
       } else if (value === "isNaN") {
         // In GLSL 2.0 use isnan instead
-        return "(" + left + " != " + left + ")";
+        return `(${left} != ${left})`;
       } else if (value === "isFinite") {
         // In GLSL 2.0 use isinf instead. GLSL doesn't have an infinity constant so use czm_infinity which is an arbitrarily big enough number.
-        return "(abs(" + left + ") < czm_infinity)";
+        return `(abs(${left}) < czm_infinity)`;
       } else if (
         value === "String" ||
         value === "isExactClass" ||
@@ -2113,31 +1991,31 @@ Node.prototype.getShaderExpression = function (
         value === "getExactClassName"
       ) {
         throw new RuntimeError(
-          'Error generating style shader: "' + value + '" is not supported.'
+          `Error generating style shader: "${value}" is not supported.`
         );
       }
       return value + left;
     case ExpressionNodeType.BINARY:
       // Supported types: ||, &&, ===, !==, <, >, <=, >=, +, -, *, /, %
       if (value === "%") {
-        return "mod(" + left + ", " + right + ")";
+        return `mod(${left}, ${right})`;
       } else if (value === "===") {
-        return "(" + left + " == " + right + ")";
+        return `(${left} == ${right})`;
       } else if (value === "!==") {
-        return "(" + left + " != " + right + ")";
+        return `(${left} != ${right})`;
       } else if (value === "atan2") {
-        return "atan(" + left + ", " + right + ")";
+        return `atan(${left}, ${right})`;
       } else if (defined(binaryFunctions[value])) {
-        return value + "(" + left + ", " + right + ")";
+        return `${value}(${left}, ${right})`;
       }
-      return "(" + left + " " + value + " " + right + ")";
+      return `(${left} ${value} ${right})`;
     case ExpressionNodeType.TERNARY:
       if (defined(ternaryFunctions[value])) {
-        return value + "(" + left + ", " + right + ", " + test + ")";
+        return `${value}(${left}, ${right}, ${test})`;
       }
       break;
     case ExpressionNodeType.CONDITIONAL:
-      return "(" + test + " ? " + left + " : " + right + ")";
+      return `(${test} ? ${left} : ${right})`;
     case ExpressionNodeType.MEMBER:
       if (checkFeature(this._left)) {
         return getVariableName(right, variableSubstitutionMap);
@@ -2145,36 +2023,26 @@ Node.prototype.getShaderExpression = function (
       // This is intended for accessing the components of vector properties. String members aren't supported.
       // Check for 0.0 rather than 0 because all numbers are previously converted to decimals.
       if (right === "r" || right === "x" || right === "0.0") {
-        return left + "[0]";
+        return `${left}[0]`;
       } else if (right === "g" || right === "y" || right === "1.0") {
-        return left + "[1]";
+        return `${left}[1]`;
       } else if (right === "b" || right === "z" || right === "2.0") {
-        return left + "[2]";
+        return `${left}[2]`;
       } else if (right === "a" || right === "w" || right === "3.0") {
-        return left + "[3]";
+        return `${left}[3]`;
       }
-      return left + "[int(" + right + ")]";
+      return `${left}[int(${right})]`;
     case ExpressionNodeType.FUNCTION_CALL:
       throw new RuntimeError(
-        'Error generating style shader: "' + value + '" is not supported.'
+        `Error generating style shader: "${value}" is not supported.`
       );
     case ExpressionNodeType.ARRAY:
       if (value.length === 4) {
-        return (
-          "vec4(" +
-          value[0] +
-          ", " +
-          value[1] +
-          ", " +
-          value[2] +
-          ", " +
-          value[3] +
-          ")"
-        );
+        return `vec4(${value[0]}, ${value[1]}, ${value[2]}, ${value[3]})`;
       } else if (value.length === 3) {
-        return "vec3(" + value[0] + ", " + value[1] + ", " + value[2] + ")";
+        return `vec3(${value[0]}, ${value[1]}, ${value[2]})`;
       } else if (value.length === 2) {
-        return "vec2(" + value[0] + ", " + value[1] + ")";
+        return `vec2(${value[0]}, ${value[1]})`;
       }
       throw new RuntimeError(
         "Error generating style shader: Invalid array length. Array length should be 2, 3, or 4."
@@ -2228,23 +2096,15 @@ Node.prototype.getShaderExpression = function (
           if (alpha !== "1.0") {
             shaderState.translucent = true;
           }
-          return "vec4(" + rgb + ", " + alpha + ")";
+          return `vec4(${rgb}, ${alpha})`;
         }
-        return "vec4(" + args[0] + ", 1.0)";
+        return `vec4(${args[0]}, 1.0)`;
       } else if (value === "rgb") {
         color = convertRGBToColor(this);
         if (defined(color)) {
           return colorToVec4(color);
         }
-        return (
-          "vec4(" +
-          args[0] +
-          " / 255.0, " +
-          args[1] +
-          " / 255.0, " +
-          args[2] +
-          " / 255.0, 1.0)"
-        );
+        return `vec4(${args[0]} / 255.0, ${args[1]} / 255.0, ${args[2]} / 255.0, 1.0)`;
       } else if (value === "rgba") {
         if (args[3] !== "1.0") {
           shaderState.translucent = true;
@@ -2253,31 +2113,13 @@ Node.prototype.getShaderExpression = function (
         if (defined(color)) {
           return colorToVec4(color);
         }
-        return (
-          "vec4(" +
-          args[0] +
-          " / 255.0, " +
-          args[1] +
-          " / 255.0, " +
-          args[2] +
-          " / 255.0, " +
-          args[3] +
-          ")"
-        );
+        return `vec4(${args[0]} / 255.0, ${args[1]} / 255.0, ${args[2]} / 255.0, ${args[3]})`;
       } else if (value === "hsl") {
         color = convertHSLToRGB(this);
         if (defined(color)) {
           return colorToVec4(color);
         }
-        return (
-          "vec4(czm_HSLToRGB(vec3(" +
-          args[0] +
-          ", " +
-          args[1] +
-          ", " +
-          args[2] +
-          ")), 1.0)"
-        );
+        return `vec4(czm_HSLToRGB(vec3(${args[0]}, ${args[1]}, ${args[2]})), 1.0)`;
       } else if (value === "hsla") {
         color = convertHSLToRGB(this);
         if (defined(color)) {
@@ -2289,17 +2131,7 @@ Node.prototype.getShaderExpression = function (
         if (args[3] !== "1.0") {
           shaderState.translucent = true;
         }
-        return (
-          "vec4(czm_HSLToRGB(vec3(" +
-          args[0] +
-          ", " +
-          args[1] +
-          ", " +
-          args[2] +
-          ")), " +
-          args[3] +
-          ")"
-        );
+        return `vec4(czm_HSLToRGB(vec3(${args[0]}, ${args[1]}, ${args[2]})), ${args[3]})`;
       }
       break;
     case ExpressionNodeType.LITERAL_VECTOR:
@@ -2311,7 +2143,7 @@ Node.prototype.getShaderExpression = function (
       }
       //>>includeEnd('debug');
       length = left.length;
-      vectorExpression = value + "(";
+      vectorExpression = `${value}(`;
       for (let i = 0; i < length; ++i) {
         vectorExpression += left[i];
         if (i < length - 1) {

--- a/Source/Scene/Geometry3DTileContent.js
+++ b/Source/Scene/Geometry3DTileContent.js
@@ -272,9 +272,7 @@ function initialize(content, arrayBuffer, byteOffset) {
   const version = view.getUint32(byteOffset, true);
   if (version !== 1) {
     throw new RuntimeError(
-      "Only Geometry tile version 1 is supported.  Version " +
-        version +
-        " is not."
+      `Only Geometry tile version 1 is supported.  Version ${version} is not.`
     );
   }
   byteOffset += sizeOfUint32;
@@ -466,9 +464,9 @@ Geometry3DTileContent.prototype.getFeature = function (batchId) {
   const featuresLength = this.featuresLength;
   if (!defined(batchId) || batchId < 0 || batchId >= featuresLength) {
     throw new DeveloperError(
-      "batchId is required and between zero and featuresLength - 1 (" +
-        (featuresLength - 1) +
-        ")."
+      `batchId is required and between zero and featuresLength - 1 (${
+        featuresLength - 1
+      }).`
     );
   }
   //>>includeEnd('debug');

--- a/Source/Scene/GlobeSurfaceShaderSet.js
+++ b/Source/Scene/GlobeSurfaceShaderSet.js
@@ -204,7 +204,7 @@ GlobeSurfaceShaderSet.prototype.getShaderProgram = function (options) {
 
     vs.defines.push(quantizationDefine);
     fs.defines.push(
-      "TEXTURE_UNITS " + numberOfDayTextures,
+      `TEXTURE_UNITS ${numberOfDayTextures}`,
       cartographicLimitRectangleDefine,
       imageryCutoutDefine
     );
@@ -320,62 +320,32 @@ GlobeSurfaceShaderSet.prototype.getShaderProgram = function (options) {
 
     for (let i = 0; i < numberOfDayTextures; ++i) {
       if (hasImageryLayerCutout) {
-        computeDayColor +=
-          "\
-        cutoutAndColorResult = u_dayTextureCutoutRectangles[" +
-          i +
-          "];\n\
+        computeDayColor += `\
+        cutoutAndColorResult = u_dayTextureCutoutRectangles[${i}];\n\
         texelUnclipped = v_textureCoordinates.x < cutoutAndColorResult.x || cutoutAndColorResult.z < v_textureCoordinates.x || v_textureCoordinates.y < cutoutAndColorResult.y || cutoutAndColorResult.w < v_textureCoordinates.y;\n\
-        cutoutAndColorResult = sampleAndBlend(\n";
+        cutoutAndColorResult = sampleAndBlend(\n`;
       } else {
         computeDayColor += "\
         color = sampleAndBlend(\n";
       }
-      computeDayColor +=
-        "\
+      computeDayColor += `\
             color,\n\
-            u_dayTextures[" +
-        i +
-        "],\n\
-            u_dayTextureUseWebMercatorT[" +
-        i +
-        "] ? textureCoordinates.xz : textureCoordinates.xy,\n\
-            u_dayTextureTexCoordsRectangle[" +
-        i +
-        "],\n\
-            u_dayTextureTranslationAndScale[" +
-        i +
-        "],\n\
-            " +
-        (applyAlpha ? "u_dayTextureAlpha[" + i + "]" : "1.0") +
-        ",\n\
-            " +
-        (applyDayNightAlpha ? "u_dayTextureNightAlpha[" + i + "]" : "1.0") +
-        ",\n" +
-        (applyDayNightAlpha ? "u_dayTextureDayAlpha[" + i + "]" : "1.0") +
-        ",\n" +
-        (applyBrightness ? "u_dayTextureBrightness[" + i + "]" : "0.0") +
-        ",\n\
-            " +
-        (applyContrast ? "u_dayTextureContrast[" + i + "]" : "0.0") +
-        ",\n\
-            " +
-        (applyHue ? "u_dayTextureHue[" + i + "]" : "0.0") +
-        ",\n\
-            " +
-        (applySaturation ? "u_dayTextureSaturation[" + i + "]" : "0.0") +
-        ",\n\
-            " +
-        (applyGamma ? "u_dayTextureOneOverGamma[" + i + "]" : "0.0") +
-        ",\n\
-            " +
-        (applySplit ? "u_dayTextureSplit[" + i + "]" : "0.0") +
-        ",\n\
-            " +
-        (colorToAlpha ? "u_colorsToAlpha[" + i + "]" : "vec4(0.0)") +
-        ",\n\
+            u_dayTextures[${i}],\n\
+            u_dayTextureUseWebMercatorT[${i}] ? textureCoordinates.xz : textureCoordinates.xy,\n\
+            u_dayTextureTexCoordsRectangle[${i}],\n\
+            u_dayTextureTranslationAndScale[${i}],\n\
+            ${applyAlpha ? `u_dayTextureAlpha[${i}]` : "1.0"},\n\
+            ${applyDayNightAlpha ? `u_dayTextureNightAlpha[${i}]` : "1.0"},\n${
+        applyDayNightAlpha ? `u_dayTextureDayAlpha[${i}]` : "1.0"
+      },\n${applyBrightness ? `u_dayTextureBrightness[${i}]` : "0.0"},\n\
+            ${applyContrast ? `u_dayTextureContrast[${i}]` : "0.0"},\n\
+            ${applyHue ? `u_dayTextureHue[${i}]` : "0.0"},\n\
+            ${applySaturation ? `u_dayTextureSaturation[${i}]` : "0.0"},\n\
+            ${applyGamma ? `u_dayTextureOneOverGamma[${i}]` : "0.0"},\n\
+            ${applySplit ? `u_dayTextureSplit[${i}]` : "0.0"},\n\
+            ${colorToAlpha ? `u_colorsToAlpha[${i}]` : "vec4(0.0)"},\n\
         nightBlend\
-        );\n";
+        );\n`;
       if (hasImageryLayerCutout) {
         computeDayColor +=
           "\

--- a/Source/Scene/GlobeSurfaceTile.js
+++ b/Source/Scene/GlobeSurfaceTile.js
@@ -711,16 +711,7 @@ function requestTileGeometry(surfaceTile, terrainProvider, x, y, level) {
     surfaceTile.terrainState = TerrainState.FAILED;
     surfaceTile.request = undefined;
 
-    const message =
-      "Failed to obtain terrain tile X: " +
-      x +
-      " Y: " +
-      y +
-      " Level: " +
-      level +
-      '. Error message: "' +
-      error +
-      '"';
+    const message = `Failed to obtain terrain tile X: ${x} Y: ${y} Level: ${level}. Error message: "${error}"`;
     terrainProvider._requestError = TileProviderError.handleError(
       terrainProvider._requestError,
       terrainProvider,

--- a/Source/Scene/GltfImageLoader.js
+++ b/Source/Scene/GltfImageLoader.js
@@ -226,7 +226,7 @@ function loadFromUri(imageLoader) {
       if (imageLoader.isDestroyed()) {
         return;
       }
-      handleError(imageLoader, error, "Failed to load image: " + uri);
+      handleError(imageLoader, error, `Failed to load image: ${uri}`);
     });
 }
 

--- a/Source/Scene/GltfJsonLoader.js
+++ b/Source/Scene/GltfJsonLoader.js
@@ -160,8 +160,7 @@ function loadFromUri(gltfJsonLoader) {
 function handleError(gltfJsonLoader, error) {
   gltfJsonLoader.unload();
   gltfJsonLoader._state = ResourceLoaderState.FAILED;
-  const errorMessage =
-    "Failed to load glTF: " + gltfJsonLoader._gltfResource.url;
+  const errorMessage = `Failed to load glTF: ${gltfJsonLoader._gltfResource.url}`;
   gltfJsonLoader._promise.reject(gltfJsonLoader.getError(errorMessage, error));
 }
 

--- a/Source/Scene/GoogleEarthEnterpriseImageryProvider.js
+++ b/Source/Scene/GoogleEarthEnterpriseImageryProvider.js
@@ -228,7 +228,7 @@ function GoogleEarthEnterpriseImageryProvider(options) {
     .then(function (result) {
       if (!metadata.imageryPresent) {
         const e = new RuntimeError(
-          "The server " + metadata.url + " doesn't have imagery"
+          `The server ${metadata.url} doesn't have imagery`
         );
         metadataError = TileProviderError.handleError(
           metadataError,
@@ -663,7 +663,7 @@ function buildImageResource(imageryProvider, info, x, y, level, request) {
   version = defined(version) && version > 0 ? version : 1;
 
   return imageryProvider._metadata.resource.getDerivedResource({
-    url: "flatfile?f1-0" + quadKey + "-i." + version.toString(),
+    url: `flatfile?f1-0${quadKey}-i.${version.toString()}`,
     request: request,
   });
 }

--- a/Source/Scene/GoogleEarthEnterpriseMapsProvider.js
+++ b/Source/Scene/GoogleEarthEnterpriseMapsProvider.js
@@ -204,9 +204,7 @@ function GoogleEarthEnterpriseMapsProvider(options) {
   this._channel = options.channel;
   this._requestType = "ImageryMaps";
   this._credit = new Credit(
-    '<a href="http://www.google.com/enterprise/mapsearth/products/earthenterprise.html"><img src="' +
-      GoogleEarthEnterpriseMapsProvider.logoUrl +
-      '" title="Google Imagery"/></a>'
+    `<a href="http://www.google.com/enterprise/mapsearth/products/earthenterprise.html"><img src="${GoogleEarthEnterpriseMapsProvider.logoUrl}" title="Google Imagery"/></a>`
   );
 
   this._tilingScheme = undefined;
@@ -258,8 +256,7 @@ function GoogleEarthEnterpriseMapsProvider(options) {
     let message;
 
     if (!defined(layer)) {
-      message =
-        "Could not find layer with channel (id) of " + that._channel + ".";
+      message = `Could not find layer with channel (id) of ${that._channel}.`;
       metadataError = TileProviderError.handleError(
         metadataError,
         that,
@@ -274,8 +271,7 @@ function GoogleEarthEnterpriseMapsProvider(options) {
     }
 
     if (!defined(layer.version)) {
-      message =
-        "Could not find a version in channel (id) " + that._channel + ".";
+      message = `Could not find a version in channel (id) ${that._channel}.`;
       metadataError = TileProviderError.handleError(
         metadataError,
         that,
@@ -305,7 +301,7 @@ function GoogleEarthEnterpriseMapsProvider(options) {
         ellipsoid: options.ellipsoid,
       });
     } else {
-      message = "Unsupported projection " + data.projection + ".";
+      message = `Unsupported projection ${data.projection}.`;
       metadataError = TileProviderError.handleError(
         metadataError,
         that,
@@ -325,8 +321,7 @@ function GoogleEarthEnterpriseMapsProvider(options) {
   }
 
   function metadataFailure(e) {
-    const message =
-      "An error occurred while accessing " + metadataResource.url + ".";
+    const message = `An error occurred while accessing ${metadataResource.url}.`;
     metadataError = TileProviderError.handleError(
       metadataError,
       that,

--- a/Source/Scene/GroundPolylinePrimitive.js
+++ b/Source/Scene/GroundPolylinePrimitive.js
@@ -377,8 +377,9 @@ function createShaderProgram(groundPolylinePrimitive, frameState, appearance) {
   );
 
   const vsDefines = [
-    "GLOBE_MINIMUM_ALTITUDE " +
-      frameState.mapProjection.ellipsoid.minimumRadius.toFixed(1),
+    `GLOBE_MINIMUM_ALTITUDE ${frameState.mapProjection.ellipsoid.minimumRadius.toFixed(
+      1
+    )}`,
   ];
   let colorDefine = "";
   let materialShaderSource = "";
@@ -454,8 +455,9 @@ function createShaderProgram(groundPolylinePrimitive, frameState, appearance) {
   if (!defined(colorProgramMorph)) {
     const vsColorMorph = new ShaderSource({
       defines: vsDefines.concat([
-        "MAX_TERRAIN_HEIGHT " +
-          ApproximateTerrainHeights._defaultMaxTerrainHeight.toFixed(1),
+        `MAX_TERRAIN_HEIGHT ${ApproximateTerrainHeights._defaultMaxTerrainHeight.toFixed(
+          1
+        )}`,
       ]),
       sources: [vsMorph],
     });

--- a/Source/Scene/I3dmParser.js
+++ b/Source/Scene/I3dmParser.js
@@ -39,9 +39,7 @@ I3dmParser.parse = function (arrayBuffer, byteOffset) {
   const version = view.getUint32(byteOffset, true);
   if (version !== 1) {
     throw new RuntimeError(
-      "Only Instanced 3D Model version 1 is supported. Version " +
-        version +
-        " is not."
+      `Only Instanced 3D Model version 1 is supported. Version ${version} is not.`
     );
   }
   byteOffset += sizeOfUint32;
@@ -69,9 +67,7 @@ I3dmParser.parse = function (arrayBuffer, byteOffset) {
   const gltfFormat = view.getUint32(byteOffset, true);
   if (gltfFormat !== 1 && gltfFormat !== 0) {
     throw new RuntimeError(
-      "Only glTF format 0 (uri) or 1 (embedded) are supported. Format " +
-        gltfFormat +
-        " is not."
+      `Only glTF format 0 (uri) or 1 (embedded) are supported. Format ${gltfFormat} is not.`
     );
   }
   byteOffset += sizeOfUint32;

--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -965,14 +965,7 @@ ImageryLayer.prototype._requestImagery = function (imagery) {
     imagery.state = ImageryState.FAILED;
     imagery.request = undefined;
 
-    const message =
-      "Failed to obtain image tile X: " +
-      imagery.x +
-      " Y: " +
-      imagery.y +
-      " Level: " +
-      imagery.level +
-      ".";
+    const message = `Failed to obtain image tile X: ${imagery.x} Y: ${imagery.y} Level: ${imagery.level}.`;
     that._requestImageError = TileProviderError.handleError(
       that._requestImageError,
       imageryProvider,
@@ -1114,9 +1107,7 @@ function getSamplerKey(
   magnificationFilter,
   maximumAnisotropy
 ) {
-  return (
-    minificationFilter + ":" + magnificationFilter + ":" + maximumAnisotropy
-  );
+  return `${minificationFilter}:${magnificationFilter}:${maximumAnisotropy}`;
 }
 
 ImageryLayer.prototype._finalizeReprojectTexture = function (context, texture) {

--- a/Source/Scene/ImageryLayerFeatureInfo.js
+++ b/Source/Scene/ImageryLayerFeatureInfo.js
@@ -95,10 +95,9 @@ ImageryLayerFeatureInfo.prototype.configureDescriptionFromProperties = function 
         const value = properties[key];
         if (defined(value)) {
           if (typeof value === "object") {
-            html +=
-              "<tr><td>" + key + "</td><td>" + describe(value) + "</td></tr>";
+            html += `<tr><td>${key}</td><td>${describe(value)}</td></tr>`;
           } else {
-            html += "<tr><td>" + key + "</td><td>" + value + "</td></tr>";
+            html += `<tr><td>${key}</td><td>${value}</td></tr>`;
           }
         }
       }

--- a/Source/Scene/ImplicitAvailabilityBitstream.js
+++ b/Source/Scene/ImplicitAvailabilityBitstream.js
@@ -38,13 +38,7 @@ export default function ImplicitAvailabilityBitstream(options) {
     const expectedLength = Math.ceil(lengthBits / 8);
     if (bitstream.length !== expectedLength) {
       throw new RuntimeError(
-        "Availability bitstream must be exactly " +
-          expectedLength +
-          " bytes long to store " +
-          lengthBits +
-          " bits. Actual bitstream was " +
-          bitstream.length +
-          " bytes long."
+        `Availability bitstream must be exactly ${expectedLength} bytes long to store ${lengthBits} bits. Actual bitstream was ${bitstream.length} bytes long.`
       );
     }
 

--- a/Source/Scene/ImplicitTileCoordinates.js
+++ b/Source/Scene/ImplicitTileCoordinates.js
@@ -384,7 +384,7 @@ ImplicitTileCoordinates.prototype.getChildCoordinates = function (childIndex) {
   );
   if (childIndex < 0 || branchingFactor <= childIndex) {
     throw new DeveloperError(
-      "childIndex must be at least 0 and less than " + branchingFactor
+      `childIndex must be at least 0 and less than ${branchingFactor}`
     );
   }
   //>>includeEnd('debug');

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -489,9 +489,9 @@ Instanced3DModel3DTileContent.prototype.getFeature = function (batchId) {
   //>>includeStart('debug', pragmas.debug);
   if (!defined(batchId) || batchId < 0 || batchId >= featuresLength) {
     throw new DeveloperError(
-      "batchId is required and between zero and featuresLength - 1 (" +
-        (featuresLength - 1) +
-        ")."
+      `batchId is required and between zero and featuresLength - 1 (${
+        featuresLength - 1
+      }).`
     );
   }
   //>>includeEnd('debug');

--- a/Source/Scene/IonImageryProvider.js
+++ b/Source/Scene/IonImageryProvider.js
@@ -176,9 +176,7 @@ function IonImageryProvider(options) {
   this._readyPromise = promise.then(function (endpoint) {
     if (endpoint.type !== "IMAGERY") {
       return when.reject(
-        new RuntimeError(
-          "Cesium ion asset " + assetId + " is not an imagery asset."
-        )
+        new RuntimeError(`Cesium ion asset ${assetId} is not an imagery asset.`)
       );
     }
 
@@ -194,7 +192,7 @@ function IonImageryProvider(options) {
       if (!defined(factory)) {
         return when.reject(
           new RuntimeError(
-            "Unrecognized Cesium ion imagery type: " + externalType
+            `Unrecognized Cesium ion imagery type: ${externalType}`
           )
         );
       }

--- a/Source/Scene/JsonMetadataTable.js
+++ b/Source/Scene/JsonMetadataTable.js
@@ -63,9 +63,7 @@ JsonMetadataTable.prototype.getProperty = function (index, propertyId) {
   Check.typeOf.string("propertyId", propertyId);
 
   if (index < 0 || index >= this._count) {
-    throw new DeveloperError(
-      "index must be in the range [0, " + this._count + ")"
-    );
+    throw new DeveloperError(`index must be in the range [0, ${this._count})`);
   }
   //>>includeEnd('debug');
 
@@ -94,9 +92,7 @@ JsonMetadataTable.prototype.setProperty = function (index, propertyId, value) {
   Check.typeOf.string("propertyId", propertyId);
 
   if (index < 0 || index >= this._count) {
-    throw new DeveloperError(
-      "index must be in the range [0, " + this._count + ")"
-    );
+    throw new DeveloperError(`index must be in the range [0, ${this._count})`);
   }
   //>>includeEnd('debug');
 

--- a/Source/Scene/Label.js
+++ b/Source/Scene/Label.js
@@ -1471,7 +1471,7 @@ function reverseBrackets(bracket) {
 //To add another language, simply add its Unicode block range(s) to the below regex.
 const hebrew = "\u05D0-\u05EA";
 const arabic = "\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF";
-const rtlChars = new RegExp("[" + hebrew + arabic + "]");
+const rtlChars = new RegExp(`[${hebrew}${arabic}]`);
 
 /**
  *

--- a/Source/Scene/LabelCollection.js
+++ b/Source/Scene/LabelCollection.js
@@ -204,14 +204,7 @@ function rebindAllGlyphs(labelCollection, label) {
 
     let glyphTextureInfo = glyphTextureCache[id];
     if (!defined(glyphTextureInfo)) {
-      const glyphFont =
-        label._fontStyle +
-        " " +
-        label._fontWeight +
-        " " +
-        SDFSettings.FONT_SIZE +
-        "px " +
-        label._fontFamily;
+      const glyphFont = `${label._fontStyle} ${label._fontWeight} ${SDFSettings.FONT_SIZE}px ${label._fontFamily}`;
 
       const canvas = createGlyphCanvas(
         character,

--- a/Source/Scene/MapboxImageryProvider.js
+++ b/Source/Scene/MapboxImageryProvider.js
@@ -157,7 +157,7 @@ function MapboxImageryProvider(options) {
 
   let format = defaultValue(options.format, "png");
   if (!/\./.test(format)) {
-    format = "." + format;
+    format = `.${format}`;
   }
   this._format = format;
 
@@ -165,7 +165,7 @@ function MapboxImageryProvider(options) {
   if (!trailingSlashRegex.test(templateUrl)) {
     templateUrl += "/";
   }
-  templateUrl += mapId + "/{z}/{x}/{y}" + this._format;
+  templateUrl += `${mapId}/{z}/{x}/{y}${this._format}`;
   resource.url = templateUrl;
 
   resource.setQueryParameters({

--- a/Source/Scene/MapboxStyleImageryProvider.js
+++ b/Source/Scene/MapboxStyleImageryProvider.js
@@ -169,14 +169,7 @@ function MapboxStyleImageryProvider(options) {
   if (!trailingSlashRegex.test(templateUrl)) {
     templateUrl += "/";
   }
-  templateUrl +=
-    this._username +
-    "/" +
-    styleId +
-    "/tiles/" +
-    this._tilesize +
-    "/{z}/{x}/{y}" +
-    scaleFactor;
+  templateUrl += `${this._username}/${styleId}/tiles/${this._tilesize}/{z}/{x}/{y}${scaleFactor}`;
   resource.url = templateUrl;
 
   resource.setQueryParameters({

--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -364,9 +364,7 @@ Material._uniformList = {};
 Material.fromType = function (type, uniforms) {
   //>>includeStart('debug', pragmas.debug);
   if (!defined(Material._materialCache.getMaterial(type))) {
-    throw new DeveloperError(
-      "material with type '" + type + "' does not exist."
-    );
+    throw new DeveloperError(`material with type '${type}' does not exist.`);
   }
   //>>includeEnd('debug');
 
@@ -481,7 +479,7 @@ Material.prototype.update = function (context) {
 
     this._textures[uniformId] = texture;
 
-    const uniformDimensionsName = uniformId + "Dimensions";
+    const uniformDimensionsName = `${uniformId}Dimensions`;
     if (this.uniforms.hasOwnProperty(uniformDimensionsName)) {
       const uniformDimensions = this.uniforms[uniformDimensionsName];
       uniformDimensions.x = texture._width;
@@ -665,14 +663,11 @@ function checkForValidProperties(object, properties, result, throwNotFound) {
 
 function invalidNameError(property, properties) {
   //>>includeStart('debug', pragmas.debug);
-  let errorString =
-    "fabric: property name '" + property + "' is not valid. It should be ";
+  let errorString = `fabric: property name '${property}' is not valid. It should be `;
   for (let i = 0; i < properties.length; i++) {
-    const propertyName = "'" + properties[i] + "'";
+    const propertyName = `'${properties[i]}'`;
     errorString +=
-      i === properties.length - 1
-        ? "or " + propertyName + "."
-        : propertyName + ", ";
+      i === properties.length - 1 ? `or ${propertyName}.` : `${propertyName}, `;
   }
   throw new DeveloperError(errorString);
   //>>includeEnd('debug');
@@ -680,10 +675,7 @@ function invalidNameError(property, properties) {
 
 function duplicateNameError(property, properties) {
   //>>includeStart('debug', pragmas.debug);
-  const errorString =
-    "fabric: uniforms and materials cannot share the same property '" +
-    property +
-    "'";
+  const errorString = `fabric: uniforms and materials cannot share the same property '${property}'`;
   throw new DeveloperError(errorString);
   //>>includeEnd('debug');
 }
@@ -756,7 +748,7 @@ function createMethodDefinition(material) {
   const components = material._template.components;
   const source = material._template.source;
   if (defined(source)) {
-    material.shaderSource += source + "\n";
+    material.shaderSource += `${source}\n`;
   } else {
     material.shaderSource +=
       "czm_material czm_getMaterial(czm_materialInput materialInput)\n{\n";
@@ -773,15 +765,12 @@ function createMethodDefinition(material) {
               isMaterialFused(components[component], material);
             const componentSource = isFusion
               ? components[component]
-              : "czm_gammaCorrect(" + components[component] + ")";
-            material.shaderSource +=
-              "material." + component + " = " + componentSource + "; \n";
+              : `czm_gammaCorrect(${components[component]})`;
+            material.shaderSource += `material.${component} = ${componentSource}; \n`;
           } else if (component === "alpha") {
-            material.shaderSource +=
-              "material.alpha = " + components.alpha + "; \n";
+            material.shaderSource += `material.alpha = ${components.alpha}; \n`;
           } else {
-            material.shaderSource +=
-              "material." + component + " = " + components[component] + ";\n";
+            material.shaderSource += `material.${component} = ${components[component]};\n`;
           }
         }
       }
@@ -854,7 +843,7 @@ function createTexture2DUpdateFunction(uniformId) {
       }
       material._textures[uniformId] = uniformValue;
 
-      uniformDimensionsName = uniformId + "Dimensions";
+      uniformDimensionsName = `${uniformId}Dimensions`;
       if (uniforms.hasOwnProperty(uniformDimensionsName)) {
         uniformDimensions = uniforms[uniformDimensionsName];
         uniformDimensions.x = uniformValue._width;
@@ -878,7 +867,7 @@ function createTexture2DUpdateFunction(uniformId) {
       material._texturePaths[uniformId] = undefined;
       texture = material._textures[uniformId] = material._defaultTexture;
 
-      uniformDimensionsName = uniformId + "Dimensions";
+      uniformDimensionsName = `${uniformId}Dimensions`;
       if (uniforms.hasOwnProperty(uniformDimensionsName)) {
         uniformDimensions = uniforms[uniformDimensionsName];
         uniformDimensions.x = texture._width;
@@ -1014,7 +1003,7 @@ function createUniform(material, uniformId) {
   //>>includeStart('debug', pragmas.debug);
   if (!defined(uniformType)) {
     throw new DeveloperError(
-      "fabric: uniform '" + uniformId + "' has invalid type."
+      `fabric: uniform '${uniformId}' has invalid type.`
     );
   }
   //>>includeEnd('debug');
@@ -1025,7 +1014,7 @@ function createUniform(material, uniformId) {
     //>>includeStart('debug', pragmas.debug);
     if (replacedTokenCount === 0 && strict) {
       throw new DeveloperError(
-        "strict: shader source does not use channels '" + uniformId + "'."
+        `strict: shader source does not use channels '${uniformId}'.`
       );
     }
     //>>includeEnd('debug');
@@ -1033,7 +1022,7 @@ function createUniform(material, uniformId) {
     // Since webgl doesn't allow texture dimension queries in glsl, create a uniform to do it.
     // Check if the shader source actually uses texture dimensions before creating the uniform.
     if (uniformType === "sampler2D") {
-      const imageDimensionsUniformName = uniformId + "Dimensions";
+      const imageDimensionsUniformName = `${uniformId}Dimensions`;
       if (getNumberOfTokens(material, imageDimensionsUniformName) > 0) {
         materialUniforms[imageDimensionsUniformName] = {
           type: "ivec3",
@@ -1046,20 +1035,19 @@ function createUniform(material, uniformId) {
 
     // Add uniform declaration to source code.
     const uniformDeclarationRegex = new RegExp(
-      "uniform\\s+" + uniformType + "\\s+" + uniformId + "\\s*;"
+      `uniform\\s+${uniformType}\\s+${uniformId}\\s*;`
     );
     if (!uniformDeclarationRegex.test(material.shaderSource)) {
-      const uniformDeclaration =
-        "uniform " + uniformType + " " + uniformId + ";";
+      const uniformDeclaration = `uniform ${uniformType} ${uniformId};`;
       material.shaderSource = uniformDeclaration + material.shaderSource;
     }
 
-    const newUniformId = uniformId + "_" + material._count++;
+    const newUniformId = `${uniformId}_${material._count++}`;
     replacedTokenCount = replaceToken(material, uniformId, newUniformId);
     //>>includeStart('debug', pragmas.debug);
     if (replacedTokenCount === 1 && strict) {
       throw new DeveloperError(
-        "strict: shader source does not use uniform '" + uniformId + "'."
+        `strict: shader source does not use uniform '${uniformId}'.`
       );
     }
     //>>includeEnd('debug');
@@ -1122,7 +1110,7 @@ function getUniformType(uniformValue) {
           uniformValue.length === 9 ||
           uniformValue.length === 16
         ) {
-          uniformType = "mat" + Math.sqrt(uniformValue.length);
+          uniformType = `mat${Math.sqrt(uniformValue.length)}`;
         }
       } else {
         let numAttributes = 0;
@@ -1132,7 +1120,7 @@ function getUniformType(uniformValue) {
           }
         }
         if (numAttributes >= 2 && numAttributes <= 4) {
-          uniformType = "vec" + numAttributes;
+          uniformType = `vec${numAttributes}`;
         } else if (numAttributes === 6) {
           uniformType = "samplerCube";
         }
@@ -1168,12 +1156,12 @@ function createSubMaterials(material) {
 
       // Make the material's czm_getMaterial unique by appending the sub-material type.
       const originalMethodName = "czm_getMaterial";
-      const newMethodName = originalMethodName + "_" + material._count++;
+      const newMethodName = `${originalMethodName}_${material._count++}`;
       replaceToken(subMaterial, originalMethodName, newMethodName);
       material.shaderSource = subMaterial.shaderSource + material.shaderSource;
 
       // Replace each material id with an czm_getMaterial method call.
-      const materialMethodCall = newMethodName + "(materialInput)";
+      const materialMethodCall = `${newMethodName}(materialInput)`;
       const tokensReplacedCount = replaceToken(
         material,
         subMaterialId,
@@ -1182,7 +1170,7 @@ function createSubMaterials(material) {
       //>>includeStart('debug', pragmas.debug);
       if (tokensReplacedCount === 0 && strict) {
         throw new DeveloperError(
-          "strict: shader source does not use material '" + subMaterialId + "'."
+          `strict: shader source does not use material '${subMaterialId}'.`
         );
       }
       //>>includeEnd('debug');
@@ -1197,7 +1185,7 @@ function replaceToken(material, token, newToken, excludePeriod) {
   excludePeriod = defaultValue(excludePeriod, true);
   let count = 0;
   const suffixChars = "([\\w])?";
-  const prefixChars = "([\\w" + (excludePeriod ? "." : "") + "])?";
+  const prefixChars = `([\\w${excludePeriod ? "." : ""}])?`;
   const regExp = new RegExp(prefixChars + token + suffixChars, "g");
   material.shaderSource = material.shaderSource.replace(regExp, function (
     $0,

--- a/Source/Scene/MetadataClassProperty.js
+++ b/Source/Scene/MetadataClassProperty.js
@@ -433,45 +433,45 @@ function validateArray(classProperty, value, componentCount) {
 
 function validateVectorOrMatrix(value, type, componentType) {
   if (!MetadataComponentType.isVectorCompatible(componentType)) {
-    const message = "componentType " + componentType + " is incompatible with ";
+    const message = `componentType ${componentType} is incompatible with `;
     if (MetadataType.isVectorType(type)) {
-      return message + "vector type " + type;
+      return `${message}vector type ${type}`;
     }
 
-    return message + "matrix type " + type;
+    return `${message}matrix type ${type}`;
   }
 
   if (type === MetadataType.VEC2 && !(value instanceof Cartesian2)) {
-    return "vector value " + value + " must be a Cartesian2";
+    return `vector value ${value} must be a Cartesian2`;
   }
 
   if (type === MetadataType.VEC3 && !(value instanceof Cartesian3)) {
-    return "vector value " + value + " must be a Cartesian3";
+    return `vector value ${value} must be a Cartesian3`;
   }
 
   if (type === MetadataType.VEC4 && !(value instanceof Cartesian4)) {
-    return "vector value " + value + " must be a Cartesian4";
+    return `vector value ${value} must be a Cartesian4`;
   }
 
   if (type === MetadataType.MAT2 && !(value instanceof Matrix2)) {
-    return "matrix value " + value + " must be a Matrix2";
+    return `matrix value ${value} must be a Matrix2`;
   }
 
   if (type === MetadataType.MAT3 && !(value instanceof Matrix3)) {
-    return "matrix value " + value + " must be a Matrix3";
+    return `matrix value ${value} must be a Matrix3`;
   }
 
   if (type === MetadataType.MAT4 && !(value instanceof Matrix4)) {
-    return "matrix value " + value + " must be a Matrix4";
+    return `matrix value ${value} must be a Matrix4`;
   }
 }
 
 function getTypeErrorMessage(value, type) {
-  return "value " + value + " does not match type " + type;
+  return `value ${value} does not match type ${type}`;
 }
 
 function getOutOfRangeErrorMessage(value, type, normalized) {
-  let errorMessage = "value " + value + " is out of range for type " + type;
+  let errorMessage = `value ${value} is out of range for type ${type}`;
   if (normalized) {
     errorMessage += " (normalized)";
   }
@@ -499,7 +499,7 @@ function checkInRange(value, componentType, normalized) {
 }
 
 function getNonFiniteErrorMessage(value, type) {
-  return "value " + value + " of type " + type + " must be finite";
+  return `value ${value} of type ${type} must be finite`;
 }
 
 function checkValue(classProperty, value) {
@@ -508,7 +508,7 @@ function checkValue(classProperty, value) {
   const enumType = classProperty._enumType;
   if (defined(enumType)) {
     if (javascriptType !== "string" || !defined(enumType.valuesByName[value])) {
-      return "value " + value + " is not a valid enum name for " + enumType.id;
+      return `value ${value} is not a valid enum name for ${enumType.id}`;
     }
     return;
   }

--- a/Source/Scene/MetadataSchemaLoader.js
+++ b/Source/Scene/MetadataSchemaLoader.js
@@ -128,7 +128,7 @@ function loadExternalSchema(schemaLoader) {
         return;
       }
       schemaLoader._state = ResourceLoaderState.FAILED;
-      const errorMessage = "Failed to load schema: " + resource.url;
+      const errorMessage = `Failed to load schema: ${resource.url}`;
       schemaLoader._promise.reject(schemaLoader.getError(errorMessage, error));
     });
 }

--- a/Source/Scene/MetadataTableProperty.js
+++ b/Source/Scene/MetadataTableProperty.js
@@ -262,8 +262,7 @@ function checkIndex(table, index) {
   if (!defined(index) || index < 0 || index >= count) {
     const maximumIndex = count - 1;
     throw new DeveloperError(
-      "index is required and between zero and count - 1. Actual value: " +
-        maximumIndex
+      `index is required and between zero and count - 1. Actual value: ${maximumIndex}`
     );
   }
 }

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -1947,7 +1947,7 @@ function parseArticulations(model) {
       const stage = articulation.stages[s];
       stage.currentValue = stage.initialValue;
 
-      const stageKey = articulation.name + " " + stage.name;
+      const stageKey = `${articulation.name} ${stage.name}`;
       articulationsByStageKey[stageKey] = articulation;
       runtimeStagesByKey[stageKey] = stage;
     }
@@ -2202,7 +2202,7 @@ function parseMeshes(model) {
           programPrimitives = {};
           model._programPrimitives[programId] = programPrimitives;
         }
-        programPrimitives[meshId + ".primitive." + primitiveId] = primitive;
+        programPrimitives[`${meshId}.primitive.${primitiveId}`] = primitive;
       });
     }
   });
@@ -2473,29 +2473,28 @@ function createProgram(programToCreate, model, context) {
   let drawFS = modifyShader(fs, programId, model._fragmentShaderLoaded);
 
   if (!defined(model._uniformMapLoaded)) {
-    drawFS = "uniform vec4 czm_pickColor;\n" + drawFS;
+    drawFS = `uniform vec4 czm_pickColor;\n${drawFS}`;
   }
 
   const useIBL =
     model._imageBasedLightingFactor.x > 0.0 ||
     model._imageBasedLightingFactor.y > 0.0;
   if (useIBL) {
-    drawFS = "#define USE_IBL_LIGHTING \n\n" + drawFS;
+    drawFS = `#define USE_IBL_LIGHTING \n\n${drawFS}`;
   }
 
   if (defined(model._lightColor)) {
-    drawFS = "#define USE_CUSTOM_LIGHT_COLOR \n\n" + drawFS;
+    drawFS = `#define USE_CUSTOM_LIGHT_COLOR \n\n${drawFS}`;
   }
 
   if (model._sourceVersion !== "2.0" || model._sourceKHRTechniquesWebGL) {
     drawFS = ShaderSource.replaceMain(drawFS, "non_gamma_corrected_main");
     drawFS =
-      drawFS +
-      "\n" +
-      "void main() { \n" +
-      "    non_gamma_corrected_main(); \n" +
-      "    gl_FragColor = czm_gammaCorrect(gl_FragColor); \n" +
-      "} \n";
+      `${drawFS}\n` +
+      `void main() { \n` +
+      `    non_gamma_corrected_main(); \n` +
+      `    gl_FragColor = czm_gammaCorrect(gl_FragColor); \n` +
+      `} \n`;
   }
 
   if (OctahedralProjectedCubeMap.isSupported(context)) {
@@ -2508,40 +2507,39 @@ function createProgram(programToCreate, model, context) {
       model._useDefaultSpecularMaps;
     const addMatrix = usesSH || usesSM || useIBL;
     if (addMatrix) {
-      drawFS = "uniform mat3 gltf_iblReferenceFrameMatrix; \n" + drawFS;
+      drawFS = `uniform mat3 gltf_iblReferenceFrameMatrix; \n${drawFS}`;
     }
 
     if (defined(model._sphericalHarmonicCoefficients)) {
-      drawFS =
+      drawFS = `${
         "#define DIFFUSE_IBL \n" +
         "#define CUSTOM_SPHERICAL_HARMONICS \n" +
-        "uniform vec3 gltf_sphericalHarmonicCoefficients[9]; \n" +
-        drawFS;
+        "uniform vec3 gltf_sphericalHarmonicCoefficients[9]; \n"
+      }${drawFS}`;
     } else if (model._useDefaultSphericalHarmonics) {
-      drawFS = "#define DIFFUSE_IBL \n" + drawFS;
+      drawFS = `#define DIFFUSE_IBL \n${drawFS}`;
     }
 
     if (
       defined(model._specularEnvironmentMapAtlas) &&
       model._specularEnvironmentMapAtlas.ready
     ) {
-      drawFS =
+      drawFS = `${
         "#define SPECULAR_IBL \n" +
         "#define CUSTOM_SPECULAR_IBL \n" +
         "uniform sampler2D gltf_specularMap; \n" +
         "uniform vec2 gltf_specularMapSize; \n" +
-        "uniform float gltf_maxSpecularLOD; \n" +
-        drawFS;
+        "uniform float gltf_maxSpecularLOD; \n"
+      }${drawFS}`;
     } else if (model._useDefaultSpecularMaps) {
-      drawFS = "#define SPECULAR_IBL \n" + drawFS;
+      drawFS = `#define SPECULAR_IBL \n${drawFS}`;
     }
   }
 
   if (defined(model._luminanceAtZenith)) {
-    drawFS =
-      "#define USE_SUN_LUMINANCE \n" +
-      "uniform float gltf_luminanceAtZenith;\n" +
-      drawFS;
+    drawFS = `${
+      "#define USE_SUN_LUMINANCE \n" + "uniform float gltf_luminanceAtZenith;\n"
+    }${drawFS}`;
   }
 
   createAttributesAndProgram(
@@ -2591,29 +2589,28 @@ function recreateProgram(programToCreate, model, context) {
   let drawFS = modifyShader(finalFS, programId, model._fragmentShaderLoaded);
 
   if (!defined(model._uniformMapLoaded)) {
-    drawFS = "uniform vec4 czm_pickColor;\n" + drawFS;
+    drawFS = `uniform vec4 czm_pickColor;\n${drawFS}`;
   }
 
   const useIBL =
     model._imageBasedLightingFactor.x > 0.0 ||
     model._imageBasedLightingFactor.y > 0.0;
   if (useIBL) {
-    drawFS = "#define USE_IBL_LIGHTING \n\n" + drawFS;
+    drawFS = `#define USE_IBL_LIGHTING \n\n${drawFS}`;
   }
 
   if (defined(model._lightColor)) {
-    drawFS = "#define USE_CUSTOM_LIGHT_COLOR \n\n" + drawFS;
+    drawFS = `#define USE_CUSTOM_LIGHT_COLOR \n\n${drawFS}`;
   }
 
   if (model._sourceVersion !== "2.0" || model._sourceKHRTechniquesWebGL) {
     drawFS = ShaderSource.replaceMain(drawFS, "non_gamma_corrected_main");
     drawFS =
-      drawFS +
-      "\n" +
-      "void main() { \n" +
-      "    non_gamma_corrected_main(); \n" +
-      "    gl_FragColor = czm_gammaCorrect(gl_FragColor); \n" +
-      "} \n";
+      `${drawFS}\n` +
+      `void main() { \n` +
+      `    non_gamma_corrected_main(); \n` +
+      `    gl_FragColor = czm_gammaCorrect(gl_FragColor); \n` +
+      `} \n`;
   }
 
   if (OctahedralProjectedCubeMap.isSupported(context)) {
@@ -2626,40 +2623,39 @@ function recreateProgram(programToCreate, model, context) {
       model._useDefaultSpecularMaps;
     const addMatrix = usesSH || usesSM || useIBL;
     if (addMatrix) {
-      drawFS = "uniform mat3 gltf_iblReferenceFrameMatrix; \n" + drawFS;
+      drawFS = `uniform mat3 gltf_iblReferenceFrameMatrix; \n${drawFS}`;
     }
 
     if (defined(model._sphericalHarmonicCoefficients)) {
-      drawFS =
+      drawFS = `${
         "#define DIFFUSE_IBL \n" +
         "#define CUSTOM_SPHERICAL_HARMONICS \n" +
-        "uniform vec3 gltf_sphericalHarmonicCoefficients[9]; \n" +
-        drawFS;
+        "uniform vec3 gltf_sphericalHarmonicCoefficients[9]; \n"
+      }${drawFS}`;
     } else if (model._useDefaultSphericalHarmonics) {
-      drawFS = "#define DIFFUSE_IBL \n" + drawFS;
+      drawFS = `#define DIFFUSE_IBL \n${drawFS}`;
     }
 
     if (
       defined(model._specularEnvironmentMapAtlas) &&
       model._specularEnvironmentMapAtlas.ready
     ) {
-      drawFS =
+      drawFS = `${
         "#define SPECULAR_IBL \n" +
         "#define CUSTOM_SPECULAR_IBL \n" +
         "uniform sampler2D gltf_specularMap; \n" +
         "uniform vec2 gltf_specularMapSize; \n" +
-        "uniform float gltf_maxSpecularLOD; \n" +
-        drawFS;
+        "uniform float gltf_maxSpecularLOD; \n"
+      }${drawFS}`;
     } else if (model._useDefaultSpecularMaps) {
-      drawFS = "#define SPECULAR_IBL \n" + drawFS;
+      drawFS = `#define SPECULAR_IBL \n${drawFS}`;
     }
   }
 
   if (defined(model._luminanceAtZenith)) {
-    drawFS =
-      "#define USE_SUN_LUMINANCE \n" +
-      "uniform float gltf_luminanceAtZenith;\n" +
-      drawFS;
+    drawFS = `${
+      "#define USE_SUN_LUMINANCE \n" + "uniform float gltf_luminanceAtZenith;\n"
+    }${drawFS}`;
   }
 
   createAttributesAndProgram(
@@ -2762,7 +2758,7 @@ function loadTexturesFromBufferViews(model) {
     const onerror = ModelUtility.getFailedLoadFunction(
       model,
       "image",
-      "id: " + gltfTexture.id + ", bufferView: " + gltfTexture.bufferView
+      `id: ${gltfTexture.id}, bufferView: ${gltfTexture.bufferView}`
     );
 
     if (gltfTexture.mimeType === "image/ktx2") {
@@ -3259,7 +3255,7 @@ function createVertexArrays(model, context) {
       let attributeLocation;
       const attributeLocations = getAttributeLocations(model, primitive);
       const decodedData =
-        model._decodedData[meshId + ".primitive." + primitiveId];
+        model._decodedData[`${meshId}.primitive.${primitiveId}`];
       ForEach.meshPrimitiveAttribute(primitive, function (
         accessorId,
         attributeName
@@ -3331,7 +3327,7 @@ function createVertexArrays(model, context) {
         indexBuffer = rendererBuffers[bufferView];
       }
       rendererVertexArrays[
-        meshId + ".primitive." + primitiveId
+        `${meshId}.primitive.${primitiveId}`
       ] = new VertexArray({
         context: context,
         attributes: attributes,
@@ -3842,7 +3838,7 @@ function createCommand(model, gltfNode, runtimeNode, context, scene3DOnly) {
     const ix = accessors[primitive.indices];
     const material = model._runtime.materialsById[primitive.material];
     const programId = material._program;
-    const decodedData = model._decodedData[id + ".primitive." + i];
+    const decodedData = model._decodedData[`${id}.primitive.${i}`];
 
     let boundingSphere;
     const positionAccessor = primitive.attributes.POSITION;
@@ -3854,7 +3850,7 @@ function createCommand(model, gltfNode, runtimeNode, context, scene3DOnly) {
       );
     }
 
-    const vertexArray = rendererVertexArrays[id + ".primitive." + i];
+    const vertexArray = rendererVertexArrays[`${id}.primitive.${i}`];
     let offset;
     let count;
 
@@ -4658,19 +4654,19 @@ function createSilhouetteProgram(model, program, frameState) {
   // Modified from http://forum.unity3d.com/threads/toon-outline-but-with-diffuse-surface.24668/
   vs = ShaderSource.replaceMain(vs, "gltf_silhouette_main");
   vs +=
-    "uniform float gltf_silhouetteSize; \n" +
-    "void main() \n" +
-    "{ \n" +
-    "    gltf_silhouette_main(); \n" +
-    "    vec3 n = normalize(czm_normal3D * " +
-    normalAttributeName +
-    "); \n" +
-    "    n.x *= czm_projection[0][0]; \n" +
-    "    n.y *= czm_projection[1][1]; \n" +
-    "    vec4 clip = gl_Position; \n" +
-    "    clip.xy += n.xy * clip.w * gltf_silhouetteSize * czm_pixelRatio / czm_viewport.z; \n" +
-    "    gl_Position = clip; \n" +
-    "}";
+    `${
+      "uniform float gltf_silhouetteSize; \n" +
+      "void main() \n" +
+      "{ \n" +
+      "    gltf_silhouette_main(); \n" +
+      "    vec3 n = normalize(czm_normal3D * "
+    }${normalAttributeName}); \n` +
+    `    n.x *= czm_projection[0][0]; \n` +
+    `    n.y *= czm_projection[1][1]; \n` +
+    `    vec4 clip = gl_Position; \n` +
+    `    clip.xy += n.xy * clip.w * gltf_silhouetteSize * czm_pixelRatio / czm_viewport.z; \n` +
+    `    gl_Position = clip; \n` +
+    `}`;
 
   const fs =
     "uniform vec4 gltf_silhouetteColor; \n" +
@@ -4863,20 +4859,19 @@ function modifyShaderForClippingPlanes(
   context
 ) {
   shader = ShaderSource.replaceMain(shader, "gltf_clip_main");
-  shader += Model._getClippingFunction(clippingPlaneCollection, context) + "\n";
-  shader +=
+  shader += `${Model._getClippingFunction(clippingPlaneCollection, context)}\n`;
+  shader += `${
     "uniform highp sampler2D gltf_clippingPlanes; \n" +
     "uniform mat4 gltf_clippingPlanesMatrix; \n" +
     "uniform vec4 gltf_clippingPlanesEdgeStyle; \n" +
     "void main() \n" +
     "{ \n" +
-    "    gltf_clip_main(); \n" +
-    getClipAndStyleCode(
-      "gltf_clippingPlanes",
-      "gltf_clippingPlanesMatrix",
-      "gltf_clippingPlanesEdgeStyle"
-    ) +
-    "} \n";
+    "    gltf_clip_main(); \n"
+  }${getClipAndStyleCode(
+    "gltf_clippingPlanes",
+    "gltf_clippingPlanesMatrix",
+    "gltf_clippingPlanesEdgeStyle"
+  )}} \n`;
   return shader;
 }
 
@@ -5433,7 +5428,7 @@ Model.prototype.update = function (frameState) {
           that._shouldRegenerateShaders = true;
         })
         .otherwise(function (error) {
-          console.error("Error loading specularEnvironmentMaps: " + error);
+          console.error(`Error loading specularEnvironmentMaps: ${error}`);
         });
     }
 

--- a/Source/Scene/ModelAnimationCache.js
+++ b/Source/Scene/ModelAnimationCache.js
@@ -32,7 +32,7 @@ function getAccessorKey(model, accessor) {
   const byteLength = accessor.count * numberOfComponentsForType(accessor.type);
 
   const uriKey = dataUriRegex.test(buffer.uri) ? "" : buffer.uri;
-  return model.cacheKey + "//" + uriKey + "/" + byteOffset + "/" + byteLength;
+  return `${model.cacheKey}//${uriKey}/${byteOffset}/${byteLength}`;
 }
 
 const cachedAnimationParameters = {};
@@ -92,7 +92,7 @@ ModelAnimationCache.getAnimationParameterValues = function (model, accessor) {
 const cachedAnimationSplines = {};
 
 function getAnimationSplineKey(model, animationName, samplerName) {
-  return model.cacheKey + "//" + animationName + "/" + samplerName;
+  return `${model.cacheKey}//${animationName}/${samplerName}`;
 }
 
 function ConstantSpline(value) {

--- a/Source/Scene/ModelExperimental/CustomShader.js
+++ b/Source/Scene/ModelExperimental/CustomShader.js
@@ -319,15 +319,15 @@ function expandCoordinateAbbreviations(variableName) {
   const eyeCoordinatesRegex = /^.*EC$/;
 
   if (modelCoordinatesRegex.test(variableName)) {
-    return variableName + " (model coordinates)";
+    return `${variableName} (model coordinates)`;
   }
 
   if (worldCoordinatesRegex.test(variableName)) {
-    return variableName + " (Cartesian world coordinates)";
+    return `${variableName} (Cartesian world coordinates)`;
   }
 
   if (eyeCoordinatesRegex.test(variableName)) {
-    return variableName + " (eye coordinates)";
+    return `${variableName} (eye coordinates)`;
   }
 
   return variableName;
@@ -340,13 +340,11 @@ function validateVariableUsage(
   vertexOrFragment
 ) {
   if (variableSet.hasOwnProperty(incorrectVariable)) {
-    const message =
-      expandCoordinateAbbreviations(incorrectVariable) +
-      " is not available in the " +
-      vertexOrFragment +
-      " shader. Did you mean " +
-      expandCoordinateAbbreviations(correctVariable) +
-      " instead?";
+    const message = `${expandCoordinateAbbreviations(
+      incorrectVariable
+    )} is not available in the ${vertexOrFragment} shader. Did you mean ${expandCoordinateAbbreviations(
+      correctVariable
+    )} instead?`;
     throw new DeveloperError(message);
   }
 }
@@ -395,9 +393,7 @@ CustomShader.prototype.setUniform = function (uniformName, value) {
   Check.defined("value", value);
   if (!defined(this.uniforms[uniformName])) {
     throw new DeveloperError(
-      "Uniform " +
-        uniformName +
-        " must be declared in the CustomShader constructor."
+      `Uniform ${uniformName} must be declared in the CustomShader constructor.`
     );
   }
   //>>includeEnd('debug');

--- a/Source/Scene/ModelExperimental/CustomShaderMode.js
+++ b/Source/Scene/ModelExperimental/CustomShaderMode.js
@@ -34,7 +34,7 @@ const CustomShaderMode = {
  * @private
  */
 CustomShaderMode.getDefineName = function (customShaderMode) {
-  return "CUSTOM_SHADER_" + customShaderMode;
+  return `CUSTOM_SHADER_${customShaderMode}`;
 };
 
 export default Object.freeze(CustomShaderMode);

--- a/Source/Scene/ModelExperimental/CustomShaderPipelineStage.js
+++ b/Source/Scene/ModelExperimental/CustomShaderPipelineStage.js
@@ -235,12 +235,7 @@ function generateVertexShaderLines(
       // Initializing attribute structs are just a matter of copying the
       // attribute or varying: E.g.:
       // "    vsInput.attributes.position = a_position;"
-      vertexInitialization =
-        "vsInput.attributes." +
-        variableName +
-        " = attributes." +
-        variableName +
-        ";";
+      vertexInitialization = `vsInput.attributes.${variableName} = attributes.${variableName};`;
       initializationLines.push(vertexInitialization);
     }
   }
@@ -251,9 +246,7 @@ function generateVertexShaderLines(
     if (!defined(attributeDefaults)) {
       CustomShaderPipelineStage._oneTimeWarning(
         "CustomShaderPipelineStage.incompatiblePrimitiveVS",
-        "Primitive is missing attribute " +
-          variableName +
-          ", disabling custom vertex shader"
+        `Primitive is missing attribute ${variableName}, disabling custom vertex shader`
       );
       // This primitive isn't compatible with the shader. Return early
       // to skip the vertex shader
@@ -261,12 +254,7 @@ function generateVertexShaderLines(
     }
 
     attributeFields.push(attributeDefaults.attributeField);
-    vertexInitialization =
-      "vsInput.attributes." +
-      variableName +
-      " = " +
-      attributeDefaults.value +
-      ";";
+    vertexInitialization = `vsInput.attributes.${variableName} = ${attributeDefaults.value};`;
     initializationLines.push(vertexInitialization);
   }
 
@@ -333,12 +321,7 @@ function generateFragmentShaderLines(
       // Initializing attribute structs are just a matter of copying the
       // value from the processed attributes
       // "    fsInput.attributes.positionMC = attributes.positionMC;"
-      fragmentInitialization =
-        "fsInput.attributes." +
-        variableName +
-        " = attributes." +
-        variableName +
-        ";";
+      fragmentInitialization = `fsInput.attributes.${variableName} = attributes.${variableName};`;
       initializationLines.push(fragmentInitialization);
     }
   }
@@ -349,9 +332,7 @@ function generateFragmentShaderLines(
     if (!defined(attributeDefaults)) {
       CustomShaderPipelineStage._oneTimeWarning(
         "CustomShaderPipelineStage.incompatiblePrimitiveFS",
-        "Primitive is missing attribute " +
-          variableName +
-          ", disabling custom fragment shader."
+        `Primitive is missing attribute ${variableName}, disabling custom fragment shader.`
       );
 
       // This primitive isn't compatible with the shader. Return early
@@ -360,12 +341,7 @@ function generateFragmentShaderLines(
     }
 
     attributeFields.push(attributeDefaults.attributeField);
-    fragmentInitialization =
-      "fsInput.attributes." +
-      variableName +
-      " = " +
-      attributeDefaults.value +
-      ";";
+    fragmentInitialization = `fsInput.attributes.${variableName} = ${attributeDefaults.value};`;
     initializationLines.push(fragmentInitialization);
   }
 

--- a/Source/Scene/ModelExperimental/DequantizationPipelineStage.js
+++ b/Source/Scene/ModelExperimental/DequantizationPipelineStage.js
@@ -67,7 +67,7 @@ function addDequantizationUniforms(renderResources, attributeInfo) {
   const quantization = attributeInfo.attribute.quantization;
 
   if (quantization.octEncoded) {
-    const normalizationRange = "model_normalizationRange_" + variableName;
+    const normalizationRange = `model_normalizationRange_${variableName}`;
     shaderBuilder.addUniform(
       "float",
       normalizationRange,
@@ -77,8 +77,8 @@ function addDequantizationUniforms(renderResources, attributeInfo) {
       return quantization.normalizationRange;
     };
   } else {
-    const offset = "model_quantizedVolumeOffset_" + variableName;
-    const stepSize = "model_quantizedVolumeStepSize_" + variableName;
+    const offset = `model_quantizedVolumeOffset_${variableName}`;
+    const stepSize = `model_quantizedVolumeStepSize_${variableName}`;
     const glslType = attributeInfo.glslType;
     shaderBuilder.addUniform(glslType, offset, ShaderDestination.VERTEX);
     shaderBuilder.addUniform(glslType, stepSize, ShaderDestination.VERTEX);
@@ -131,10 +131,10 @@ function updateDequantizationFunction(shaderBuilder, attributeInfo) {
 }
 
 function generateOctDecodeLine(variableName, quantization) {
-  const structField = "attributes." + variableName;
+  const structField = `attributes.${variableName}`;
 
-  const quantizedAttribute = "a_quantized_" + variableName;
-  const normalizationRange = "model_normalizationRange_" + variableName;
+  const quantizedAttribute = `a_quantized_${variableName}`;
+  const normalizationRange = `model_normalizationRange_${variableName}`;
 
   // Draco stores things as .zxy instead of xyz, so be explicit about the
   // swizzle to avoid confusion
@@ -142,36 +142,18 @@ function generateOctDecodeLine(variableName, quantization) {
 
   // This generates lines such as:
   // attributes.normal = czm_octDecode(a_quantized_normal, model_normalizationRange_normal).zxy;
-  return (
-    structField +
-    " = czm_octDecode(" +
-    quantizedAttribute +
-    ", " +
-    normalizationRange +
-    ")" +
-    swizzle +
-    ";"
-  );
+  return `${structField} = czm_octDecode(${quantizedAttribute}, ${normalizationRange})${swizzle};`;
 }
 
 function generateDequantizeLine(variableName) {
-  const structField = "attributes." + variableName;
-  const quantizedAttribute = "a_quantized_" + variableName;
-  const offset = "model_quantizedVolumeOffset_" + variableName;
-  const stepSize = "model_quantizedVolumeStepSize_" + variableName;
+  const structField = `attributes.${variableName}`;
+  const quantizedAttribute = `a_quantized_${variableName}`;
+  const offset = `model_quantizedVolumeOffset_${variableName}`;
+  const stepSize = `model_quantizedVolumeStepSize_${variableName}`;
 
   // This generates lines such as:
   // attributes.texCoord_0 = model_quantizedVolumeOffset_texCoord_0 + a_quantized_texCoord_0 * model_quantizedVolumeStepSize;
-  return (
-    structField +
-    " = " +
-    offset +
-    " + " +
-    quantizedAttribute +
-    " * " +
-    stepSize +
-    ";"
-  );
+  return `${structField} = ${offset} + ${quantizedAttribute} * ${stepSize};`;
 }
 
 export default DequantizationPipelineStage;

--- a/Source/Scene/ModelExperimental/FeatureIdPipelineStage.js
+++ b/Source/Scene/ModelExperimental/FeatureIdPipelineStage.js
@@ -108,7 +108,7 @@ function processInstanceFeatureIds(renderResources, instances, frameState) {
 
   for (let i = 0; i < featureIdsArray.length; i++) {
     const featureIds = featureIdsArray[i];
-    const variableName = "instanceFeatureId_" + i;
+    const variableName = `instanceFeatureId_${i}`;
 
     if (featureIds instanceof ModelComponents.FeatureIdAttribute) {
       processInstanceAttribute(renderResources, featureIds, variableName);
@@ -136,7 +136,7 @@ function processPrimitiveFeatureIds(renderResources, primitive, frameState) {
 
   for (let i = 0; i < featureIdsArray.length; i++) {
     const featureIds = featureIdsArray[i];
-    const variableName = "featureId_" + i;
+    const variableName = `featureId_${i}`;
     if (featureIds instanceof ModelComponents.FeatureIdAttribute) {
       processAttribute(renderResources, featureIds, variableName);
     } else if (featureIds instanceof ModelComponents.FeatureIdImplicitRange) {
@@ -183,10 +183,10 @@ function processInstanceAttribute(
   const setIndex = featureIdAttribute.setIndex;
   const prefix = variableName.replace(/_\d+$/, "_");
 
-  const attributeName = "a_" + prefix + setIndex;
-  const varyingName = "v_" + prefix + setIndex;
-  const vertexLine = "featureIds." + variableName + " = " + attributeName + ";";
-  const fragmentLine = "featureIds." + variableName + " = " + varyingName + ";";
+  const attributeName = `a_${prefix}${setIndex}`;
+  const varyingName = `v_${prefix}${setIndex}`;
+  const vertexLine = `featureIds.${variableName} = ${attributeName};`;
+  const fragmentLine = `featureIds.${variableName} = ${varyingName};`;
 
   shaderBuilder.addFunctionLines(
     FeatureIdPipelineStage.FUNCTION_ID_INITIALIZE_FEATURE_IDS_VS,
@@ -205,7 +205,7 @@ function processInstanceAttribute(
   // v_instanceFeatureId_n = a_instanceFeatureId_n;
   shaderBuilder.addFunctionLines(
     FeatureIdPipelineStage.FUNCTION_ID_SET_FEATURE_ID_VARYINGS,
-    [varyingName + " = " + attributeName + ";"]
+    [`${varyingName} = ${attributeName};`]
   );
 }
 
@@ -237,7 +237,7 @@ function processAttribute(renderResources, featureIdAttribute, variableName) {
   const prefix = variableName.replace(/_\d+$/, "_");
 
   const initializationLines = [
-    "featureIds." + variableName + " = attributes." + prefix + setIndex + ";",
+    `featureIds.${variableName} = attributes.${prefix}${setIndex};`,
   ];
   shaderBuilder.addFunctionLines(
     FeatureIdPipelineStage.FUNCTION_ID_INITIALIZE_FEATURE_IDS_VS,
@@ -270,12 +270,12 @@ function processImplicitRange(
   // Declare the vertex attribute in the shader
   // Example: attribute float a_implicit_feature_id_n;
   const shaderBuilder = renderResources.shaderBuilder;
-  const implicitAttributeName = "a_implicit_" + variableName;
+  const implicitAttributeName = `a_implicit_${variableName}`;
   shaderBuilder.addAttribute("float", implicitAttributeName);
 
   // Also declare the corresponding varyings
   // Example: varying float v_implicit_feature_id_n;
-  const implicitVaryingName = "v_implicit_" + variableName;
+  const implicitVaryingName = `v_implicit_${variableName}`;
   shaderBuilder.addVarying("float", implicitVaryingName);
 
   // Add a field to the FeatureIds struct.
@@ -301,7 +301,7 @@ function processImplicitRange(
   // v_implicit_featureId_n = a_implicit_featureId_n;
   shaderBuilder.addFunctionLines(
     FeatureIdPipelineStage.FUNCTION_ID_SET_FEATURE_ID_VARYINGS,
-    [implicitVaryingName + " = " + implicitAttributeName + ";"]
+    [`${implicitVaryingName} = ${implicitAttributeName};`]
   );
 
   // Initialize the field from the generated attribute/varying.
@@ -310,11 +310,11 @@ function processImplicitRange(
   // featureIds.featureId_n = v_implicit_featureId_n; (FS)
   shaderBuilder.addFunctionLines(
     FeatureIdPipelineStage.FUNCTION_ID_INITIALIZE_FEATURE_IDS_VS,
-    ["featureIds." + variableName + " = " + implicitAttributeName + ";"]
+    [`featureIds.${variableName} = ${implicitAttributeName};`]
   );
   shaderBuilder.addFunctionLines(
     FeatureIdPipelineStage.FUNCTION_ID_INITIALIZE_FEATURE_IDS_FS,
-    ["featureIds." + variableName + " = " + implicitVaryingName + ";"]
+    [`featureIds.${variableName} = ${implicitVaryingName};`]
   );
 }
 
@@ -327,7 +327,7 @@ function processTexture(
 ) {
   // Create the feature ID texture uniform. The index matches the index from
   // the featureIds array, even if this is not consecutive.
-  const uniformName = "u_featureIdTexture_" + index;
+  const uniformName = `u_featureIdTexture_${index}`;
   const uniformMap = renderResources.uniformMap;
   const textureReader = featureIdTexture.textureReader;
   uniformMap[uniformName] = function () {
@@ -362,16 +362,15 @@ function processTexture(
   // Example:
   // featureIds.featureId_n = floor(texture2D(u_featureIdTexture_m, attributes.texCoord_p).r * 255.0 + 0.5);
 
-  const texCoord = "v_texCoord_" + textureReader.texCoord;
+  const texCoord = `v_texCoord_${textureReader.texCoord}`;
 
   // The current EXT_mesh_features spec requires a single channel.
   const channel = textureReader.channels;
-  const textureRead =
-    "texture2D(" + uniformName + ", " + texCoord + ")." + channel;
-  const rounded = "floor(" + textureRead + " * 255.0 + 0.5)";
+  const textureRead = `texture2D(${uniformName}, ${texCoord}).${channel}`;
+  const rounded = `floor(${textureRead} * 255.0 + 0.5)`;
   shaderBuilder.addFunctionLines(
     FeatureIdPipelineStage.FUNCTION_ID_INITIALIZE_FEATURE_IDS_FS,
-    ["featureIds." + variableName + " = " + rounded + ";"]
+    [`featureIds.${variableName} = ${rounded};`]
   );
 }
 

--- a/Source/Scene/ModelExperimental/GeometryPipelineStage.js
+++ b/Source/Scene/ModelExperimental/GeometryPipelineStage.js
@@ -175,7 +175,7 @@ function addSemanticDefine(shaderBuilder, attribute) {
     case VertexAttributeSemantic.FEATURE_ID:
     case VertexAttributeSemantic.TEXCOORD:
     case VertexAttributeSemantic.COLOR:
-      shaderBuilder.addDefine("HAS_" + semantic + "_" + setIndex);
+      shaderBuilder.addDefine(`HAS_${semantic}_${setIndex}`);
   }
 }
 
@@ -220,7 +220,7 @@ function addAttributeToRenderResources(
 
 function addVaryingDeclaration(shaderBuilder, attributeInfo) {
   const variableName = attributeInfo.variableName;
-  let varyingName = "v_" + variableName;
+  let varyingName = `v_${variableName}`;
 
   let glslType;
   if (variableName === "normalMC") {
@@ -248,10 +248,10 @@ function addAttributeDeclaration(shaderBuilder, attributeInfo) {
   let attributeName;
   let glslType;
   if (attributeInfo.isQuantized) {
-    attributeName = "a_quantized_" + variableName;
+    attributeName = `a_quantized_${variableName}`;
     glslType = attributeInfo.quantizedGlslType;
   } else {
-    attributeName = "a_" + variableName;
+    attributeName = `a_${variableName}`;
     glslType = attributeInfo.glslType;
   }
 
@@ -304,7 +304,7 @@ function updateInitialzeAttributesFunction(shaderBuilder, attributeInfo) {
   if (variableName === "tangentMC") {
     line = "attributes.tangentMC = a_tangentMC.xyz;";
   } else {
-    line = "attributes." + variableName + " = a_" + variableName + ";";
+    line = `attributes.${variableName} = a_${variableName};`;
   }
   shaderBuilder.addFunctionLines(functionId, [line]);
 }
@@ -322,13 +322,13 @@ function updateSetDynamicVaryingsFunction(shaderBuilder, attributeInfo) {
   // v_texCoord_1 = attributes.texCoord_1;
   let functionId = GeometryPipelineStage.FUNCTION_ID_SET_DYNAMIC_VARYINGS_VS;
   const variableName = attributeInfo.variableName;
-  let line = "v_" + variableName + " = attributes." + variableName + ";";
+  let line = `v_${variableName} = attributes.${variableName};`;
   shaderBuilder.addFunctionLines(functionId, [line]);
 
   // In the fragment shader, we do the opposite:
   // attributes.texCoord_1 = v_texCoord_1;
   functionId = GeometryPipelineStage.FUNCTION_ID_SET_DYNAMIC_VARYINGS_FS;
-  line = "attributes." + variableName + " = v_" + variableName + ";";
+  line = `attributes.${variableName} = v_${variableName};`;
   shaderBuilder.addFunctionLines(functionId, [line]);
 }
 

--- a/Source/Scene/ModelExperimental/InstancingPipelineStage.js
+++ b/Source/Scene/ModelExperimental/InstancingPipelineStage.js
@@ -328,7 +328,7 @@ function processFeatureIdAttributes(
 
     shaderBuilder.addAttribute(
       "float",
-      "a_instanceFeatureId_" + attribute.setIndex
+      `a_instanceFeatureId_${attribute.setIndex}`
     );
   }
 }

--- a/Source/Scene/ModelExperimental/MaterialPipelineStage.js
+++ b/Source/Scene/ModelExperimental/MaterialPipelineStage.js
@@ -129,7 +129,7 @@ function processTextureTransform(
   defineName
 ) {
   // Add a define to enable the texture transformation code in the shader.
-  const transformDefine = "HAS_" + defineName + "_TEXTURE_TRANSFORM";
+  const transformDefine = `HAS_${defineName}_TEXTURE_TRANSFORM`;
   shaderBuilder.addDefine(
     transformDefine,
     undefined,
@@ -137,7 +137,7 @@ function processTextureTransform(
   );
 
   // Add a uniform for the transformation matrix
-  const transformUniformName = uniformName + "Transform";
+  const transformUniformName = `${uniformName}Transform`;
   shaderBuilder.addUniform(
     "mat3",
     transformUniformName,
@@ -178,13 +178,13 @@ function processTexture(
   };
 
   // Add a #define directive to enable using the texture in the shader
-  const textureDefine = "HAS_" + defineName + "_TEXTURE";
+  const textureDefine = `HAS_${defineName}_TEXTURE`;
   shaderBuilder.addDefine(textureDefine, undefined, ShaderDestination.FRAGMENT);
 
   // Add a #define to tell the shader which texture coordinates varying to use.
   const texCoordIndex = textureReader.texCoord;
-  const texCoordVarying = "v_texCoord_" + texCoordIndex;
-  const texCoordDefine = "TEXCOORD_" + defineName;
+  const texCoordVarying = `v_texCoord_${texCoordIndex}`;
+  const texCoordDefine = `TEXCOORD_${defineName}`;
   shaderBuilder.addDefine(
     texCoordDefine,
     texCoordVarying,

--- a/Source/Scene/ModelExperimental/ModelExperimentalUtility.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalUtility.js
@@ -27,9 +27,9 @@ export default function ModelExperimentalUtility() {}
  */
 ModelExperimentalUtility.getFailedLoadFunction = function (model, type, path) {
   return function (error) {
-    let message = "Failed to load " + type + ": " + path;
+    let message = `Failed to load ${type}: ${path}`;
     if (defined(error)) {
-      message += "\n" + error.message;
+      message += `\n${error.message}`;
     }
     model._readyPromise.reject(new RuntimeError(message));
   };

--- a/Source/Scene/ModelExperimental/SelectedFeatureIdPipelineStage.js
+++ b/Source/Scene/ModelExperimental/SelectedFeatureIdPipelineStage.js
@@ -104,7 +104,7 @@ function getSelectedFeatureIds(model, node, primitive) {
     featureIds = node.instances.featureIds[model.instanceFeatureIdIndex];
 
     if (defined(featureIds)) {
-      variableName = "instanceFeatureId_" + model.instanceFeatureIdIndex;
+      variableName = `instanceFeatureId_${model.instanceFeatureIdIndex}`;
       return {
         featureIds: featureIds,
         variableName: variableName,
@@ -115,7 +115,7 @@ function getSelectedFeatureIds(model, node, primitive) {
   }
 
   featureIds = primitive.featureIds[model.featureIdIndex];
-  variableName = "featureId_" + model.featureIdIndex;
+  variableName = `featureId_${model.featureIdIndex}`;
   return {
     featureIds: featureIds,
     variableName: variableName,

--- a/Source/Scene/ModelInstanceCollection.js
+++ b/Source/Scene/ModelInstanceCollection.js
@@ -281,14 +281,9 @@ function getCheckUniformSemanticFunction(
         uniformMap[uniformName] = semantic;
       } else {
         throw new RuntimeError(
-          "Shader program cannot be optimized for instancing. " +
-            'Uniform "' +
-            uniformName +
-            '" in program "' +
-            programId +
-            '" uses unsupported semantic "' +
-            semantic +
-            '"'
+          `${
+            "Shader program cannot be optimized for instancing. " + 'Uniform "'
+          }${uniformName}" in program "${programId}" uses unsupported semantic "${semantic}"`
         );
       }
     }
@@ -377,11 +372,11 @@ function getVertexShaderCallback(collection) {
         }
 
         // Remove the uniform declaration
-        let regex = new RegExp("uniform.*" + uniform + ".*");
+        let regex = new RegExp(`uniform.*${uniform}.*`);
         renamedSource = renamedSource.replace(regex, "");
 
         // Replace all occurrences of the uniform with the global variable
-        regex = new RegExp(uniform + "\\b", "g");
+        regex = new RegExp(`${uniform}\\b`, "g");
         renamedSource = renamedSource.replace(regex, varName);
       }
     }
@@ -409,23 +404,13 @@ function getVertexShaderCallback(collection) {
     }
 
     let instancedSource =
-      uniforms +
-      globalVarsHeader +
-      "mat4 czm_instanced_modelView;\n" +
-      "attribute vec4 czm_modelMatrixRow0;\n" +
-      "attribute vec4 czm_modelMatrixRow1;\n" +
-      "attribute vec4 czm_modelMatrixRow2;\n" +
-      batchIdAttribute +
-      pickAttribute +
-      renamedSource +
-      "void main()\n" +
-      "{\n" +
-      "    mat4 czm_instanced_model = mat4(czm_modelMatrixRow0.x, czm_modelMatrixRow1.x, czm_modelMatrixRow2.x, 0.0, czm_modelMatrixRow0.y, czm_modelMatrixRow1.y, czm_modelMatrixRow2.y, 0.0, czm_modelMatrixRow0.z, czm_modelMatrixRow1.z, czm_modelMatrixRow2.z, 0.0, czm_modelMatrixRow0.w, czm_modelMatrixRow1.w, czm_modelMatrixRow2.w, 1.0);\n" +
-      "    czm_instanced_modelView = czm_instanced_modifiedModelView * czm_instanced_model * czm_instanced_nodeTransform;\n" +
-      globalVarsMain +
-      "    czm_instancing_main();\n" +
-      pickVarying +
-      "}\n";
+      `${uniforms + globalVarsHeader}mat4 czm_instanced_modelView;\n` +
+      `attribute vec4 czm_modelMatrixRow0;\n` +
+      `attribute vec4 czm_modelMatrixRow1;\n` +
+      `attribute vec4 czm_modelMatrixRow2;\n${batchIdAttribute}${pickAttribute}${renamedSource}void main()\n` +
+      `{\n` +
+      `    mat4 czm_instanced_model = mat4(czm_modelMatrixRow0.x, czm_modelMatrixRow1.x, czm_modelMatrixRow2.x, 0.0, czm_modelMatrixRow0.y, czm_modelMatrixRow1.y, czm_modelMatrixRow2.y, 0.0, czm_modelMatrixRow0.z, czm_modelMatrixRow1.z, czm_modelMatrixRow2.z, 0.0, czm_modelMatrixRow0.w, czm_modelMatrixRow1.w, czm_modelMatrixRow2.w, 1.0);\n` +
+      `    czm_instanced_modelView = czm_instanced_modifiedModelView * czm_instanced_model * czm_instanced_nodeTransform;\n${globalVarsMain}    czm_instancing_main();\n${pickVarying}}\n`;
 
     if (usesBatchTable) {
       const gltf = collection._model.gltf;
@@ -459,7 +444,7 @@ function getFragmentShaderCallback(collection) {
         false
       )(fs);
     } else {
-      fs = "varying vec4 v_pickColor;\n" + fs;
+      fs = `varying vec4 v_pickColor;\n${fs}`;
     }
     return fs;
   };
@@ -520,7 +505,7 @@ function getVertexShaderNonInstancedCallback(collection) {
         diffuseAttributeOrUniformName
       )(vs);
       // Treat a_batchId as a uniform rather than a vertex attribute
-      vs = "uniform float a_batchId\n;" + vs;
+      vs = `uniform float a_batchId\n;${vs}`;
     }
     return vs;
   };
@@ -541,7 +526,7 @@ function getFragmentShaderNonInstancedCallback(collection) {
         false
       )(fs);
     } else {
-      fs = "uniform vec4 czm_pickColor;\n" + fs;
+      fs = `uniform vec4 czm_pickColor;\n${fs}`;
     }
     return fs;
   };
@@ -775,7 +760,7 @@ function createModel(collection, context) {
     modelOptions.uniformMapLoaded = getUniformMapCallback(collection, context);
 
     if (defined(collection._url)) {
-      modelOptions.cacheKey = collection._url.getUrlComponent() + "#instanced";
+      modelOptions.cacheKey = `${collection._url.getUrlComponent()}#instanced`;
     }
   } else {
     modelOptions.vertexShaderLoaded = getVertexShaderNonInstancedCallback(

--- a/Source/Scene/ModelMaterial.js
+++ b/Source/Scene/ModelMaterial.js
@@ -77,7 +77,7 @@ ModelMaterial.prototype.setValue = function (name, value) {
   }
   //>>includeEnd('debug');
 
-  const uniformName = "u_" + name;
+  const uniformName = `u_${name}`;
   const v = this._uniformMap.values[uniformName];
 
   //>>includeStart('debug', pragmas.debug);
@@ -106,7 +106,7 @@ ModelMaterial.prototype.getValue = function (name) {
   }
   //>>includeEnd('debug');
 
-  const uniformName = "u_" + name;
+  const uniformName = `u_${name}`;
   const v = this._uniformMap.values[uniformName];
 
   if (!defined(v)) {

--- a/Source/Scene/ModelUtility.js
+++ b/Source/Scene/ModelUtility.js
@@ -159,9 +159,9 @@ ModelUtility.ModelState = {
 ModelUtility.getFailedLoadFunction = function (model, type, path) {
   return function (error) {
     model._state = ModelUtility.ModelState.FAILED;
-    let message = "Failed to load " + type + ": " + path;
+    let message = `Failed to load ${type}: ${path}`;
     if (defined(error)) {
-      message += "\n" + error.message;
+      message += `\n${error.message}`;
     }
     model._readyPromise.reject(new RuntimeError(message));
   };
@@ -318,7 +318,7 @@ function ensureSemanticExistenceForPrimitive(gltf, primitive) {
       const targetAttributes = targets[target];
       for (const attribute in targetAttributes) {
         if (attribute !== "extras") {
-          attributes[attribute + "_" + target] = targetAttributes[attribute];
+          attributes[`${attribute}_${target}`] = targetAttributes[attribute];
         }
       }
     }
@@ -339,20 +339,16 @@ function ensureSemanticExistenceForPrimitive(gltf, primitive) {
         if (lowerCase.charAt(0) === "_") {
           lowerCase = lowerCase.slice(1);
         }
-        const attributeName = "a_" + lowerCase;
+        const attributeName = `a_${lowerCase}`;
         technique.attributes[attributeName] = {
           semantic: semantic,
           type: accessor.componentType,
         };
         const pipelineExtras = vertexShader.extras._pipeline;
         let shaderText = pipelineExtras.source;
-        shaderText =
-          "attribute " +
-          ModelUtility.getShaderVariable(accessor.type) +
-          " " +
-          attributeName +
-          ";\n" +
-          shaderText;
+        shaderText = `attribute ${ModelUtility.getShaderVariable(
+          accessor.type
+        )} ${attributeName};\n${shaderText}`;
         pipelineExtras.source = shaderText;
       }
     }
@@ -584,7 +580,7 @@ ModelUtility.checkSupportedExtensions = function (
   for (const extension in extensionsRequired) {
     if (extensionsRequired.hasOwnProperty(extension)) {
       if (!ModelUtility.supportedExtensions[extension]) {
-        throw new RuntimeError("Unsupported glTF Extension: " + extension);
+        throw new RuntimeError(`Unsupported glTF Extension: ${extension}`);
       }
 
       if (extension === "EXT_texture_webp" && browserSupportsWebp === false) {
@@ -602,7 +598,7 @@ ModelUtility.checkSupportedGlExtensions = function (extensionsUsed, context) {
     for (let i = 0; i < glExtensionsUsedLength; i++) {
       const extension = extensionsUsed[i];
       if (extension !== "OES_element_index_uint") {
-        throw new RuntimeError("Unsupported WebGL Extension: " + extension);
+        throw new RuntimeError(`Unsupported WebGL Extension: ${extension}`);
       } else if (!context.elementIndexUint) {
         throw new RuntimeError(
           "OES_element_index_uint WebGL extension is not enabled."
@@ -682,11 +678,10 @@ ModelUtility.modifyShaderForDracoQuantizedAttributes = function (
       if (attributeSemantic.charAt(0) === "_") {
         attributeSemantic = attributeSemantic.substring(1);
       }
-      const decodeUniformVarName =
-        "gltf_u_dec_" + attributeSemantic.toLowerCase();
+      const decodeUniformVarName = `gltf_u_dec_${attributeSemantic.toLowerCase()}`;
 
       if (!defined(quantizedUniforms[decodeUniformVarName])) {
-        const newMain = "gltf_decoded_" + attributeSemantic;
+        const newMain = `gltf_decoded_${attributeSemantic}`;
         const decodedAttributeVarName = attributeVarName.replace(
           "a_",
           "gltf_a_dec_"
@@ -705,11 +700,11 @@ ModelUtility.modifyShaderForDracoQuantizedAttributes = function (
         if (quantization.octEncoded) {
           variableType = "vec3";
         } else if (size > 1) {
-          variableType = "vec" + size;
+          variableType = `vec${size}`;
         } else {
           variableType = "float";
         }
-        shader = variableType + " " + decodedAttributeVarName + ";\n" + shader;
+        shader = `${variableType} ${decodedAttributeVarName};\n${shader}`;
 
         // The gltf 2.0 COLOR_0 vertex attribute can be VEC4 or VEC3
         const vec3Color = size === 3 && attributeSemantic === "COLOR_0";
@@ -717,67 +712,37 @@ ModelUtility.modifyShaderForDracoQuantizedAttributes = function (
           shader = replaceAllButFirstInString(
             shader,
             decodedAttributeVarName,
-            "vec4(" + decodedAttributeVarName + ", 1.0)"
+            `vec4(${decodedAttributeVarName}, 1.0)`
           );
         }
 
         // splice decode function into the shader
         let decode = "";
         if (quantization.octEncoded) {
-          const decodeUniformVarNameRangeConstant =
-            decodeUniformVarName + "_rangeConstant";
-          shader =
-            "uniform float " +
-            decodeUniformVarNameRangeConstant +
-            ";\n" +
-            shader;
+          const decodeUniformVarNameRangeConstant = `${decodeUniformVarName}_rangeConstant`;
+          shader = `uniform float ${decodeUniformVarNameRangeConstant};\n${shader}`;
           decode =
-            "\n" +
-            "void main() {\n" +
-            // Draco oct-encoding decodes to zxy order
-            "    " +
-            decodedAttributeVarName +
-            " = czm_octDecode(" +
-            attributeVarName +
-            ".xy, " +
-            decodeUniformVarNameRangeConstant +
-            ").zxy;\n" +
-            "    " +
-            newMain +
-            "();\n" +
-            "}\n";
+            `${
+              "\n" +
+              "void main() {\n" +
+              // Draco oct-encoding decodes to zxy order
+              "    "
+            }${decodedAttributeVarName} = czm_octDecode(${attributeVarName}.xy, ${decodeUniformVarNameRangeConstant}).zxy;\n` +
+            `    ${newMain}();\n` +
+            `}\n`;
         } else {
-          const decodeUniformVarNameNormConstant =
-            decodeUniformVarName + "_normConstant";
-          const decodeUniformVarNameMin = decodeUniformVarName + "_min";
+          const decodeUniformVarNameNormConstant = `${decodeUniformVarName}_normConstant`;
+          const decodeUniformVarNameMin = `${decodeUniformVarName}_min`;
           shader =
-            "uniform float " +
-            decodeUniformVarNameNormConstant +
-            ";\n" +
-            "uniform " +
-            variableType +
-            " " +
-            decodeUniformVarNameMin +
-            ";\n" +
-            shader;
+            `uniform float ${decodeUniformVarNameNormConstant};\n` +
+            `uniform ${variableType} ${decodeUniformVarNameMin};\n${shader}`;
           const attributeVarAccess = vec3Color ? ".xyz" : "";
           decode =
-            "\n" +
-            "void main() {\n" +
-            "    " +
-            decodedAttributeVarName +
-            " = " +
-            decodeUniformVarNameMin +
-            " + " +
-            attributeVarName +
-            attributeVarAccess +
-            " * " +
-            decodeUniformVarNameNormConstant +
-            ";\n" +
-            "    " +
-            newMain +
-            "();\n" +
-            "}\n";
+            `${
+              "\n" + "void main() {\n" + "    "
+            }${decodedAttributeVarName} = ${decodeUniformVarNameMin} + ${attributeVarName}${attributeVarAccess} * ${decodeUniformVarNameNormConstant};\n` +
+            `    ${newMain}();\n` +
+            `}\n`;
         }
 
         shader = ShaderSource.replaceMain(shader, newMain);
@@ -809,11 +774,10 @@ ModelUtility.modifyShaderForQuantizedAttributes = function (
       if (attributeSemantic.charAt(0) === "_") {
         attributeSemantic = attributeSemantic.substring(1);
       }
-      const decodeUniformVarName =
-        "gltf_u_dec_" + attributeSemantic.toLowerCase();
+      const decodeUniformVarName = `gltf_u_dec_${attributeSemantic.toLowerCase()}`;
 
-      const decodeUniformVarNameScale = decodeUniformVarName + "_scale";
-      const decodeUniformVarNameTranslate = decodeUniformVarName + "_translate";
+      const decodeUniformVarNameScale = `${decodeUniformVarName}_scale`;
+      const decodeUniformVarNameTranslate = `${decodeUniformVarName}_translate`;
       if (
         !defined(quantizedUniforms[decodeUniformVarName]) &&
         !defined(quantizedUniforms[decodeUniformVarNameScale])
@@ -821,7 +785,7 @@ ModelUtility.modifyShaderForQuantizedAttributes = function (
         const quantizedAttributes = getQuantizedAttributes(gltf, accessorId);
         if (defined(quantizedAttributes)) {
           const decodeMatrix = quantizedAttributes.decodeMatrix;
-          const newMain = "gltf_decoded_" + attributeSemantic;
+          const newMain = `gltf_decoded_${attributeSemantic}`;
           const decodedAttributeVarName = attributeVarName.replace(
             "a_",
             "gltf_a_dec_"
@@ -837,66 +801,35 @@ ModelUtility.modifyShaderForQuantizedAttributes = function (
           // declare decoded attribute
           let variableType;
           if (size > 2) {
-            variableType = "vec" + (size - 1);
+            variableType = `vec${size - 1}`;
           } else {
             variableType = "float";
           }
-          shader =
-            variableType + " " + decodedAttributeVarName + ";\n" + shader;
+          shader = `${variableType} ${decodedAttributeVarName};\n${shader}`;
           // splice decode function into the shader - attributes are pre-multiplied with the decode matrix
           // uniform in the shader (32-bit floating point)
           let decode = "";
           if (size === 5) {
             // separate scale and translate since glsl doesn't have mat5
-            shader =
-              "uniform mat4 " + decodeUniformVarNameScale + ";\n" + shader;
-            shader =
-              "uniform vec4 " + decodeUniformVarNameTranslate + ";\n" + shader;
+            shader = `uniform mat4 ${decodeUniformVarNameScale};\n${shader}`;
+            shader = `uniform vec4 ${decodeUniformVarNameTranslate};\n${shader}`;
             decode =
-              "\n" +
-              "void main() {\n" +
-              "    " +
-              decodedAttributeVarName +
-              " = " +
-              decodeUniformVarNameScale +
-              " * " +
-              attributeVarName +
-              " + " +
-              decodeUniformVarNameTranslate +
-              ";\n" +
-              "    " +
-              newMain +
-              "();\n" +
-              "}\n";
+              `${
+                "\n" + "void main() {\n" + "    "
+              }${decodedAttributeVarName} = ${decodeUniformVarNameScale} * ${attributeVarName} + ${decodeUniformVarNameTranslate};\n` +
+              `    ${newMain}();\n` +
+              `}\n`;
 
             quantizedUniforms[decodeUniformVarNameScale] = { mat: 4 };
             quantizedUniforms[decodeUniformVarNameTranslate] = { vec: 4 };
           } else {
-            shader =
-              "uniform mat" +
-              size +
-              " " +
-              decodeUniformVarName +
-              ";\n" +
-              shader;
+            shader = `uniform mat${size} ${decodeUniformVarName};\n${shader}`;
             decode =
-              "\n" +
-              "void main() {\n" +
-              "    " +
-              decodedAttributeVarName +
-              " = " +
-              variableType +
-              "(" +
-              decodeUniformVarName +
-              " * vec" +
-              size +
-              "(" +
-              attributeVarName +
-              ",1.0));\n" +
-              "    " +
-              newMain +
-              "();\n" +
-              "}\n";
+              `${
+                "\n" + "void main() {\n" + "    "
+              }${decodedAttributeVarName} = ${variableType}(${decodeUniformVarName} * vec${size}(${attributeVarName},1.0));\n` +
+              `    ${newMain}();\n` +
+              `}\n`;
 
             quantizedUniforms[decodeUniformVarName] = { mat: size };
           }
@@ -1113,10 +1046,10 @@ ModelUtility.createUniformsForDracoQuantizedAttributes = function (
         attribute = attribute.substring(1);
       }
 
-      const uniformVarName = "gltf_u_dec_" + attribute.toLowerCase();
+      const uniformVarName = `gltf_u_dec_${attribute.toLowerCase()}`;
 
       if (quantization.octEncoded) {
-        const uniformVarNameRangeConstant = uniformVarName + "_rangeConstant";
+        const uniformVarNameRangeConstant = `${uniformVarName}_rangeConstant`;
         const rangeConstant = (1 << quantization.quantizationBits) - 1.0;
         uniformMap[uniformVarNameRangeConstant] = getScalarUniformFunction(
           rangeConstant
@@ -1124,14 +1057,14 @@ ModelUtility.createUniformsForDracoQuantizedAttributes = function (
         continue;
       }
 
-      const uniformVarNameNormConstant = uniformVarName + "_normConstant";
+      const uniformVarNameNormConstant = `${uniformVarName}_normConstant`;
       const normConstant =
         quantization.range / (1 << quantization.quantizationBits);
       uniformMap[uniformVarNameNormConstant] = getScalarUniformFunction(
         normConstant
       ).func;
 
-      const uniformVarNameMin = uniformVarName + "_min";
+      const uniformVarNameMin = `${uniformVarName}_min`;
       switch (decodedData.componentsPerAttribute) {
         case 1:
           uniformMap[uniformVarNameMin] = getScalarUniformFunction(
@@ -1184,7 +1117,7 @@ ModelUtility.createUniformsForQuantizedAttributes = function (
         const quantizedAttributes = extensions.WEB3D_quantized_attributes;
         if (defined(quantizedAttributes)) {
           const decodeMatrix = quantizedAttributes.decodeMatrix;
-          const uniformVariable = "gltf_u_dec_" + attribute.toLowerCase();
+          const uniformVariable = `gltf_u_dec_${attribute.toLowerCase()}`;
           let uniformVariableScale;
           let uniformVariableTranslate;
           switch (a.type) {
@@ -1208,8 +1141,8 @@ ModelUtility.createUniformsForQuantizedAttributes = function (
               break;
             case AttributeType.VEC4:
               // VEC4 attributes are split into scale and translate because there is no mat5 in GLSL
-              uniformVariableScale = uniformVariable + "_scale";
-              uniformVariableTranslate = uniformVariable + "_translate";
+              uniformVariableScale = `${uniformVariable}_scale`;
+              uniformVariableTranslate = `${uniformVariable}_translate`;
               uniformMap[uniformVariableScale] = getMat4UniformFunction(
                 scaleFromMatrix5Array(decodeMatrix)
               ).func;

--- a/Source/Scene/Multiple3DTileContent.js
+++ b/Source/Scene/Multiple3DTileContent.js
@@ -551,8 +551,8 @@ function handleInnerContentFailed(multipleContents, index, error) {
       message: message,
     });
   } else {
-    console.log("A content failed to load: " + url);
-    console.log("Error: " + message);
+    console.log(`A content failed to load: ${url}`);
+    console.log(`Error: ${message}`);
   }
 }
 

--- a/Source/Scene/OIT.js
+++ b/Source/Scene/OIT.js
@@ -480,23 +480,23 @@ function getTranslucentShaderProgram(context, shaderProgram, keyword, source) {
     fs.sources.splice(
       0,
       0,
-      (source.indexOf("gl_FragData") !== -1
-        ? "#extension GL_EXT_draw_buffers : enable \n"
-        : "") +
-        "vec4 czm_gl_FragColor;\n" +
-        "bool czm_discard = false;\n"
+      `${
+        source.indexOf("gl_FragData") !== -1
+          ? "#extension GL_EXT_draw_buffers : enable \n"
+          : ""
+      }vec4 czm_gl_FragColor;\n` + `bool czm_discard = false;\n`
     );
 
     fs.sources.push(
-      "void main()\n" +
+      `${
+        "void main()\n" +
         "{\n" +
         "    czm_translucent_main();\n" +
         "    if (czm_discard)\n" +
         "    {\n" +
         "        discard;\n" +
-        "    }\n" +
-        source +
-        "}\n"
+        "    }\n"
+      }${source}}\n`
     );
 
     shader = context.shaderCache.createDerivedShaderProgram(

--- a/Source/Scene/OctahedralProjectedCubeMap.js
+++ b/Source/Scene/OctahedralProjectedCubeMap.js
@@ -377,7 +377,7 @@ OctahedralProjectedCubeMap.prototype.update = function (frameState) {
     });
     frameState.commandList.push(command);
 
-    uniformMap["texture" + i] = createUniformTexture(mipTexture);
+    uniformMap[`texture${i}`] = createUniformTexture(mipTexture);
   }
 
   this._texture = new Texture({

--- a/Source/Scene/OpenStreetMapImageryProvider.js
+++ b/Source/Scene/OpenStreetMapImageryProvider.js
@@ -62,7 +62,7 @@ function OpenStreetMapImageryProvider(options) {
     defaultValue(options.url, "https://a.tile.openstreetmap.org/")
   );
   resource.appendForwardSlash();
-  resource.url += "{z}/{x}/{y}." + defaultValue(options.fileExtension, "png");
+  resource.url += `{z}/{x}/{y}.${defaultValue(options.fileExtension, "png")}`;
 
   const tilingScheme = new WebMercatorTilingScheme({
     ellipsoid: options.ellipsoid,
@@ -92,9 +92,7 @@ function OpenStreetMapImageryProvider(options) {
   //>>includeStart('debug', pragmas.debug);
   if (tileCount > 4) {
     throw new DeveloperError(
-      "The rectangle and minimumLevel indicate that there are " +
-        tileCount +
-        " tiles at the minimum level. Imagery providers with more than four tiles at the minimum level are not supported."
+      `The rectangle and minimumLevel indicate that there are ${tileCount} tiles at the minimum level. Imagery providers with more than four tiles at the minimum level are not supported.`
     );
   }
   //>>includeEnd('debug');

--- a/Source/Scene/PerformanceDisplay.js
+++ b/Source/Scene/PerformanceDisplay.js
@@ -92,7 +92,7 @@ PerformanceDisplay.prototype.update = function (renderedThisFrame) {
       fps = ((this._fpsFrameCount * 1000) / fpsElapsedTime) | 0;
     }
 
-    this._fpsText.nodeValue = fps + " FPS";
+    this._fpsText.nodeValue = `${fps} FPS`;
     this._lastFpsSampleTime = time;
     this._fpsFrameCount = 0;
   }
@@ -105,7 +105,7 @@ PerformanceDisplay.prototype.update = function (renderedThisFrame) {
       ms = (msElapsedTime / this._msFrameCount).toFixed(2);
     }
 
-    this._msText.nodeValue = ms + " MS";
+    this._msText.nodeValue = `${ms} MS`;
     this._lastMsSampleTime = time;
     this._msFrameCount = 0;
   }

--- a/Source/Scene/PntsParser.js
+++ b/Source/Scene/PntsParser.js
@@ -44,9 +44,7 @@ PntsParser.parse = function (arrayBuffer, byteOffset) {
   const version = view.getUint32(byteOffset, true);
   if (version !== 1) {
     throw new RuntimeError(
-      "Only Point Cloud tile version 1 is supported.  Version " +
-        version +
-        " is not."
+      `Only Point Cloud tile version 1 is supported.  Version ${version} is not.`
     );
   }
   byteOffset += sizeOfUint32;

--- a/Source/Scene/PointCloud.js
+++ b/Source/Scene/PointCloud.js
@@ -326,9 +326,7 @@ function prepareVertexAttribute(typedArray, name) {
   ) {
     oneTimeWarning(
       "Cast pnts property to floats",
-      'Point cloud property "' +
-        name +
-        '" will be casted to a float array because INT, UNSIGNED_INT, and DOUBLE are not valid WebGL vertex attribute types. Some precision may be lost.'
+      `Point cloud property "${name}" will be casted to a float array because INT, UNSIGNED_INT, and DOUBLE are not valid WebGL vertex attribute types. Some precision may be lost.`
     );
     return new Float32Array(typedArray);
   }
@@ -793,8 +791,9 @@ function createShaders(pointCloud, frameState, style) {
   for (name in styleableShaderAttributes) {
     if (styleableShaderAttributes.hasOwnProperty(name)) {
       attribute = styleableShaderAttributes[name];
-      variableSubstitutionMap[name] =
-        "czm_3dtiles_property_" + attribute.location;
+      variableSubstitutionMap[
+        name
+      ] = `czm_3dtiles_property_${attribute.location}`;
       propertyIdToAttributeMap[attribute.location] = attribute;
     }
   }
@@ -811,17 +810,17 @@ function createShaders(pointCloud, frameState, style) {
       "vec3 czm_3dtiles_builtin_property_NORMAL" +
       ")";
     colorStyleFunction = style.getColorShaderFunction(
-      "getColorFromStyle" + parameterList,
+      `getColorFromStyle${parameterList}`,
       variableSubstitutionMap,
       shaderState
     );
     showStyleFunction = style.getShowShaderFunction(
-      "getShowFromStyle" + parameterList,
+      `getShowFromStyle${parameterList}`,
       variableSubstitutionMap,
       shaderState
     );
     pointSizeStyleFunction = style.getPointSizeShaderFunction(
-      "getPointSizeFromStyle" + parameterList,
+      `getPointSizeFromStyle${parameterList}`,
       variableSubstitutionMap,
       shaderState
     );
@@ -914,16 +913,15 @@ function createShaders(pointCloud, frameState, style) {
     const propertyId = styleablePropertyIds[i];
     attribute = propertyIdToAttributeMap[propertyId];
     const componentCount = attribute.componentCount;
-    const attributeName = "czm_3dtiles_property_" + propertyId;
+    const attributeName = `czm_3dtiles_property_${propertyId}`;
     let attributeType;
     if (componentCount === 1) {
       attributeType = "float";
     } else {
-      attributeType = "vec" + componentCount;
+      attributeType = `vec${componentCount}`;
     }
 
-    attributeDeclarations +=
-      "attribute " + attributeType + " " + attributeName + "; \n";
+    attributeDeclarations += `attribute ${attributeType} ${attributeName}; \n`;
     attributeLocations[attributeName] = attribute.location;
   }
 

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -167,7 +167,7 @@ function getFragmentShaderLoaded(content) {
         false
       )(fs);
     }
-    return "uniform vec4 czm_pickColor;\n" + fs;
+    return `uniform vec4 czm_pickColor;\n${fs}`;
   };
 }
 
@@ -262,9 +262,9 @@ PointCloud3DTileContent.prototype.getFeature = function (batchId) {
   //>>includeStart('debug', pragmas.debug);
   if (!defined(batchId) || batchId < 0 || batchId >= featuresLength) {
     throw new DeveloperError(
-      "batchId is required and between zero and featuresLength - 1 (" +
-        (featuresLength - 1) +
-        ")."
+      `batchId is required and between zero and featuresLength - 1 (${
+        featuresLength - 1
+      }).`
     );
   }
   //>>includeEnd('debug');

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -1148,7 +1148,7 @@ function createMaterialId(material) {
     index += 2;
   }
 
-  return material.type + ":" + JSON.stringify(scratchUniformArray, replacer);
+  return `${material.type}:${JSON.stringify(scratchUniformArray, replacer)}`;
 }
 
 function sortPolylinesIntoBuckets(collection) {

--- a/Source/Scene/PolylineColorAppearance.js
+++ b/Source/Scene/PolylineColorAppearance.js
@@ -6,13 +6,11 @@ import PolylineColorAppearanceVS from "../Shaders/Appearances/PolylineColorAppea
 import PolylineCommon from "../Shaders/PolylineCommon.js";
 import Appearance from "./Appearance.js";
 
-let defaultVertexShaderSource =
-  PolylineCommon + "\n" + PolylineColorAppearanceVS;
+let defaultVertexShaderSource = `${PolylineCommon}\n${PolylineColorAppearanceVS}`;
 const defaultFragmentShaderSource = PerInstanceFlatColorAppearanceFS;
 
 if (!FeatureDetection.isInternetExplorer()) {
-  defaultVertexShaderSource =
-    "#define CLIP_POLYLINE \n" + defaultVertexShaderSource;
+  defaultVertexShaderSource = `#define CLIP_POLYLINE \n${defaultVertexShaderSource}`;
 }
 
 /**

--- a/Source/Scene/PolylineMaterialAppearance.js
+++ b/Source/Scene/PolylineMaterialAppearance.js
@@ -8,13 +8,11 @@ import PolylineFS from "../Shaders/PolylineFS.js";
 import Appearance from "./Appearance.js";
 import Material from "./Material.js";
 
-let defaultVertexShaderSource =
-  PolylineCommon + "\n" + PolylineMaterialAppearanceVS;
+let defaultVertexShaderSource = `${PolylineCommon}\n${PolylineMaterialAppearanceVS}`;
 const defaultFragmentShaderSource = PolylineFS;
 
 if (!FeatureDetection.isInternetExplorer()) {
-  defaultVertexShaderSource =
-    "#define CLIP_POLYLINE \n" + defaultVertexShaderSource;
+  defaultVertexShaderSource = `#define CLIP_POLYLINE \n${defaultVertexShaderSource}`;
 }
 
 /**
@@ -117,7 +115,7 @@ Object.defineProperties(PolylineMaterialAppearance.prototype, {
           /varying\s+float\s+v_polylineAngle;/g
         ) !== -1
       ) {
-        vs = "#define POLYLINE_DASH\n" + vs;
+        vs = `#define POLYLINE_DASH\n${vs}`;
       }
       return vs;
     },

--- a/Source/Scene/PostProcessStage.js
+++ b/Source/Scene/PostProcessStage.js
@@ -433,7 +433,7 @@ function getUniformValueGetterAndSetter(stage, uniforms, name) {
       ) {
         stage._texturesToRelease.push(actualValue);
         delete actualUniforms[name];
-        delete actualUniforms[name + "Dimensions"];
+        delete actualUniforms[`${name}Dimensions`];
       }
 
       if (currentValue instanceof Texture) {
@@ -508,7 +508,7 @@ function createUniformMap(stage) {
         value instanceof HTMLCanvasElement ||
         value instanceof HTMLVideoElement
       ) {
-        uniformMap[name + "Dimensions"] = getUniformMapDimensionsFunction(
+        uniformMap[`${name}Dimensions`] = getUniformMapDimensionsFunction(
           uniformMap,
           name
         );
@@ -559,32 +559,31 @@ function createDrawCommand(stage, context) {
 
     fs = fs.replace(/varying\s+vec2\s+v_textureCoordinates;/g, "");
     fs =
-      "#define CZM_SELECTED_FEATURE \n" +
-      "uniform sampler2D czm_idTexture; \n" +
-      "uniform sampler2D czm_selectedIdTexture; \n" +
-      "uniform float czm_selectedIdTextureStep; \n" +
-      "varying vec2 v_textureCoordinates; \n" +
-      "bool czm_selected(vec2 offset) \n" +
-      "{ \n" +
-      "    bool selected = false;\n" +
-      "    vec4 id = texture2D(czm_idTexture, v_textureCoordinates + offset); \n" +
-      "    for (int i = 0; i < " +
-      width +
-      "; ++i) \n" +
-      "    { \n" +
-      "        vec4 selectedId = texture2D(czm_selectedIdTexture, vec2((float(i) + 0.5) * czm_selectedIdTextureStep, 0.5)); \n" +
-      "        if (all(equal(id, selectedId))) \n" +
-      "        { \n" +
-      "            return true; \n" +
-      "        } \n" +
-      "    } \n" +
-      "    return false; \n" +
-      "} \n\n" +
-      "bool czm_selected() \n" +
-      "{ \n" +
-      "    return czm_selected(vec2(0.0)); \n" +
-      "} \n\n" +
-      fs;
+      `${
+        "#define CZM_SELECTED_FEATURE \n" +
+        "uniform sampler2D czm_idTexture; \n" +
+        "uniform sampler2D czm_selectedIdTexture; \n" +
+        "uniform float czm_selectedIdTextureStep; \n" +
+        "varying vec2 v_textureCoordinates; \n" +
+        "bool czm_selected(vec2 offset) \n" +
+        "{ \n" +
+        "    bool selected = false;\n" +
+        "    vec4 id = texture2D(czm_idTexture, v_textureCoordinates + offset); \n" +
+        "    for (int i = 0; i < "
+      }${width}; ++i) \n` +
+      `    { \n` +
+      `        vec4 selectedId = texture2D(czm_selectedIdTexture, vec2((float(i) + 0.5) * czm_selectedIdTextureStep, 0.5)); \n` +
+      `        if (all(equal(id, selectedId))) \n` +
+      `        { \n` +
+      `            return true; \n` +
+      `        } \n` +
+      `    } \n` +
+      `    return false; \n` +
+      `} \n\n` +
+      `bool czm_selected() \n` +
+      `{ \n` +
+      `    return czm_selected(vec2(0.0)); \n` +
+      `} \n\n${fs}`;
   }
 
   const fragmentShader = new ShaderSource({

--- a/Source/Scene/PostProcessStageCollection.js
+++ b/Source/Scene/PostProcessStageCollection.js
@@ -428,8 +428,7 @@ PostProcessStageCollection.prototype.add = function (stage) {
     //>>includeStart('debug', pragmas.debug);
     if (defined(stageNames[currentStage.name])) {
       throw new DeveloperError(
-        currentStage.name +
-          " has already been added to the collection or does not have a unique name."
+        `${currentStage.name} has already been added to the collection or does not have a unique name.`
       );
     }
     //>>includeEnd('debug');

--- a/Source/Scene/PostProcessStageLibrary.js
+++ b/Source/Scene/PostProcessStageLibrary.js
@@ -39,9 +39,9 @@ function createBlur(name) {
   const sigma = 2.0;
   const stepSize = 1.0;
 
-  const blurShader = "#define USE_STEP_SIZE\n" + GaussianBlur1D;
+  const blurShader = `#define USE_STEP_SIZE\n${GaussianBlur1D}`;
   const blurX = new PostProcessStage({
-    name: name + "_x_direction",
+    name: `${name}_x_direction`,
     fragmentShader: blurShader,
     uniforms: {
       delta: delta,
@@ -52,7 +52,7 @@ function createBlur(name) {
     sampleMode: PostProcessStageSampleMode.LINEAR,
   });
   const blurY = new PostProcessStage({
-    name: name + "_y_direction",
+    name: `${name}_y_direction`,
     fragmentShader: blurShader,
     uniforms: {
       delta: delta,
@@ -241,7 +241,7 @@ PostProcessStageLibrary.createEdgeDetectionStage = function () {
   // unique name generated on call so more than one effect can be added
   const name = createGuid();
   return new PostProcessStage({
-    name: "czm_edge_detection_" + name,
+    name: `czm_edge_detection_${name}`,
     fragmentShader: EdgeDetection,
     uniforms: {
       length: 0.25,
@@ -281,38 +281,25 @@ function getSilhouetteEdgeDetection(edgeDetectionStages) {
   let fsDecl = "";
   let fsLoop = "";
   for (let i = 0; i < edgeDetectionStages.length; ++i) {
-    fsDecl += "uniform sampler2D edgeTexture" + i + "; \n";
+    fsDecl += `uniform sampler2D edgeTexture${i}; \n`;
     fsLoop +=
-      "        vec4 edge" +
-      i +
-      " = texture2D(edgeTexture" +
-      i +
-      ", v_textureCoordinates); \n" +
-      "        if (edge" +
-      i +
-      ".a > 0.0) \n" +
-      "        { \n" +
-      "            color = edge" +
-      i +
-      "; \n" +
-      "            break; \n" +
-      "        } \n";
-    compositeUniforms["edgeTexture" + i] = edgeDetectionStages[i].name;
+      `        vec4 edge${i} = texture2D(edgeTexture${i}, v_textureCoordinates); \n` +
+      `        if (edge${i}.a > 0.0) \n` +
+      `        { \n` +
+      `            color = edge${i}; \n` +
+      `            break; \n` +
+      `        } \n`;
+    compositeUniforms[`edgeTexture${i}`] = edgeDetectionStages[i].name;
   }
 
   const fs =
-    fsDecl +
-    "varying vec2 v_textureCoordinates; \n" +
-    "void main() { \n" +
-    "    vec4 color = vec4(0.0); \n" +
-    "    for (int i = 0; i < " +
-    edgeDetectionStages.length +
-    "; i++) \n" +
-    "    { \n" +
-    fsLoop +
-    "    } \n" +
-    "    gl_FragColor = color; \n" +
-    "} \n";
+    `${fsDecl}varying vec2 v_textureCoordinates; \n` +
+    `void main() { \n` +
+    `    vec4 color = vec4(0.0); \n` +
+    `    for (int i = 0; i < ${edgeDetectionStages.length}; i++) \n` +
+    `    { \n${fsLoop}    } \n` +
+    `    gl_FragColor = color; \n` +
+    `} \n`;
 
   const edgeComposite = new PostProcessStage({
     name: "czm_edge_detection_combine",
@@ -650,7 +637,7 @@ PostProcessStageLibrary.isAmbientOcclusionSupported = function (scene) {
   return scene.context.depthTexture;
 };
 
-const fxaaFS = "#define FXAA_QUALITY_PRESET 39 \n" + FXAA3_11 + "\n" + FXAA;
+const fxaaFS = `#define FXAA_QUALITY_PRESET 39 \n${FXAA3_11}\n${FXAA}`;
 
 /**
  * Creates a post-process stage that applies Fast Approximate Anti-aliasing (FXAA) to the input texture.

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -575,7 +575,7 @@ function createBatchTable(primitive, context) {
 
     attributeIndices[name] = i;
     attributes.push({
-      functionName: "czm_batchTable_" + name,
+      functionName: `czm_batchTable_${name}`,
       componentDatatype: attribute.componentDatatype,
       componentsPerAttribute: attribute.componentsPerAttribute,
       normalize: attribute.normalize,
@@ -743,74 +743,48 @@ Primitive._modifyShaderPosition = function (
   while ((match = positionRegex.exec(vertexShaderSource)) !== null) {
     const name = match[1];
 
-    const functionName =
-      "vec4 czm_compute" + name[0].toUpperCase() + name.substr(1) + "()";
+    const functionName = `vec4 czm_compute${name[0].toUpperCase()}${name.substr(
+      1
+    )}()`;
 
     // Don't forward-declare czm_computePosition because computePosition.glsl already does.
     if (functionName !== "vec4 czm_computePosition()") {
-      forwardDecl += functionName + ";\n";
+      forwardDecl += `${functionName};\n`;
     }
 
     if (!defined(primitive.rtcCenter)) {
       // Use GPU RTE
       if (!scene3DOnly) {
         attributes +=
-          "attribute vec3 " +
-          name +
-          "2DHigh;\n" +
-          "attribute vec3 " +
-          name +
-          "2DLow;\n";
+          `attribute vec3 ${name}2DHigh;\n` + `attribute vec3 ${name}2DLow;\n`;
 
         computeFunctions +=
-          functionName +
-          "\n" +
-          "{\n" +
-          "    vec4 p;\n" +
-          "    if (czm_morphTime == 1.0)\n" +
-          "    {\n" +
-          "        p = czm_translateRelativeToEye(" +
-          name +
-          "3DHigh, " +
-          name +
-          "3DLow);\n" +
-          "    }\n" +
-          "    else if (czm_morphTime == 0.0)\n" +
-          "    {\n" +
-          "        p = czm_translateRelativeToEye(" +
-          name +
-          "2DHigh.zxy, " +
-          name +
-          "2DLow.zxy);\n" +
-          "    }\n" +
-          "    else\n" +
-          "    {\n" +
-          "        p = czm_columbusViewMorph(\n" +
-          "                czm_translateRelativeToEye(" +
-          name +
-          "2DHigh.zxy, " +
-          name +
-          "2DLow.zxy),\n" +
-          "                czm_translateRelativeToEye(" +
-          name +
-          "3DHigh, " +
-          name +
-          "3DLow),\n" +
-          "                czm_morphTime);\n" +
-          "    }\n" +
-          "    return p;\n" +
-          "}\n\n";
+          `${functionName}\n` +
+          `{\n` +
+          `    vec4 p;\n` +
+          `    if (czm_morphTime == 1.0)\n` +
+          `    {\n` +
+          `        p = czm_translateRelativeToEye(${name}3DHigh, ${name}3DLow);\n` +
+          `    }\n` +
+          `    else if (czm_morphTime == 0.0)\n` +
+          `    {\n` +
+          `        p = czm_translateRelativeToEye(${name}2DHigh.zxy, ${name}2DLow.zxy);\n` +
+          `    }\n` +
+          `    else\n` +
+          `    {\n` +
+          `        p = czm_columbusViewMorph(\n` +
+          `                czm_translateRelativeToEye(${name}2DHigh.zxy, ${name}2DLow.zxy),\n` +
+          `                czm_translateRelativeToEye(${name}3DHigh, ${name}3DLow),\n` +
+          `                czm_morphTime);\n` +
+          `    }\n` +
+          `    return p;\n` +
+          `}\n\n`;
       } else {
         computeFunctions +=
-          functionName +
-          "\n" +
-          "{\n" +
-          "    return czm_translateRelativeToEye(" +
-          name +
-          "3DHigh, " +
-          name +
-          "3DLow);\n" +
-          "}\n\n";
+          `${functionName}\n` +
+          `{\n` +
+          `    return czm_translateRelativeToEye(${name}3DHigh, ${name}3DLow);\n` +
+          `}\n\n`;
       }
     } else {
       // Use RTC
@@ -827,11 +801,10 @@ Primitive._modifyShaderPosition = function (
       attributes += "attribute vec4 position;\n";
 
       computeFunctions +=
-        functionName +
-        "\n" +
-        "{\n" +
-        "    return u_modifiedModelView * position;\n" +
-        "}\n\n";
+        `${functionName}\n` +
+        `{\n` +
+        `    return u_modifiedModelView * position;\n` +
+        `}\n\n`;
 
       vertexShaderSource = vertexShaderSource.replace(
         /czm_modelViewRelativeToEye\s+\*\s+/g,
@@ -865,7 +838,7 @@ Primitive._appendShowToShader = function (primitive, vertexShaderSource) {
     "    gl_Position *= czm_batchTable_show(batchId); \n" +
     "}";
 
-  return renamedVS + "\n" + showMain;
+  return `${renamedVS}\n${showMain}`;
 };
 
 Primitive._updateColorAttribute = function (
@@ -923,11 +896,11 @@ function appendPickToVertexShader(source) {
     "    v_pickColor = czm_batchTable_pickColor(batchId); \n" +
     "}";
 
-  return renamedVS + "\n" + pickMain;
+  return `${renamedVS}\n${pickMain}`;
 }
 
 function appendPickToFragmentShader(source) {
-  return "varying vec4 v_pickColor;\n" + source;
+  return `varying vec4 v_pickColor;\n${source}`;
 }
 
 Primitive._updatePickColorAttribute = function (source) {
@@ -1035,7 +1008,7 @@ Primitive._appendDistanceDisplayConditionToShader = function (
     "    float show = (distanceSq >= nearSq && distanceSq <= farSq) ? 1.0 : 0.0; \n" +
     "    gl_Position *= show; \n" +
     "}";
-  return renamedVS + "\n" + distanceDisplayConditionMain;
+  return `${renamedVS}\n${distanceDisplayConditionMain}`;
 };
 
 function modifyForEncodedNormals(primitive, vertexShaderSource) {
@@ -1059,10 +1032,10 @@ function modifyForEncodedNormals(primitive, vertexShaderSource) {
   let numComponents = containsSt && containsNormal ? 2.0 : 1.0;
   numComponents += containsTangent || containsBitangent ? 1 : 0;
 
-  const type = numComponents > 1 ? "vec" + numComponents : "float";
+  const type = numComponents > 1 ? `vec${numComponents}` : "float";
 
   const attributeName = "compressedAttributes";
-  const attributeDecl = "attribute " + type + " " + attributeName + ";";
+  const attributeDecl = `attribute ${type} ${attributeName};`;
 
   let globalDecl = "";
   let decode = "";
@@ -1070,47 +1043,35 @@ function modifyForEncodedNormals(primitive, vertexShaderSource) {
   if (containsSt) {
     globalDecl += "vec2 st;\n";
     const stComponent =
-      numComponents > 1 ? attributeName + ".x" : attributeName;
-    decode +=
-      "    st = czm_decompressTextureCoordinates(" + stComponent + ");\n";
+      numComponents > 1 ? `${attributeName}.x` : attributeName;
+    decode += `    st = czm_decompressTextureCoordinates(${stComponent});\n`;
   }
 
   if (containsNormal && containsTangent && containsBitangent) {
     globalDecl += "vec3 normal;\n" + "vec3 tangent;\n" + "vec3 bitangent;\n";
-    decode +=
-      "    czm_octDecode(" +
-      attributeName +
-      "." +
-      (containsSt ? "yz" : "xy") +
-      ", normal, tangent, bitangent);\n";
+    decode += `    czm_octDecode(${attributeName}.${
+      containsSt ? "yz" : "xy"
+    }, normal, tangent, bitangent);\n`;
   } else {
     if (containsNormal) {
       globalDecl += "vec3 normal;\n";
-      decode +=
-        "    normal = czm_octDecode(" +
-        attributeName +
-        (numComponents > 1 ? "." + (containsSt ? "y" : "x") : "") +
-        ");\n";
+      decode += `    normal = czm_octDecode(${attributeName}${
+        numComponents > 1 ? `.${containsSt ? "y" : "x"}` : ""
+      });\n`;
     }
 
     if (containsTangent) {
       globalDecl += "vec3 tangent;\n";
-      decode +=
-        "    tangent = czm_octDecode(" +
-        attributeName +
-        "." +
-        (containsSt && containsNormal ? "z" : "y") +
-        ");\n";
+      decode += `    tangent = czm_octDecode(${attributeName}.${
+        containsSt && containsNormal ? "z" : "y"
+      });\n`;
     }
 
     if (containsBitangent) {
       globalDecl += "vec3 bitangent;\n";
-      decode +=
-        "    bitangent = czm_octDecode(" +
-        attributeName +
-        "." +
-        (containsSt && containsNormal ? "z" : "y") +
-        ");\n";
+      decode += `    bitangent = czm_octDecode(${attributeName}.${
+        containsSt && containsNormal ? "z" : "y"
+      });\n`;
     }
   }
 
@@ -1121,11 +1082,8 @@ function modifyForEncodedNormals(primitive, vertexShaderSource) {
   modifiedVS = modifiedVS.replace(/attribute\s+vec3\s+bitangent;/g, "");
   modifiedVS = ShaderSource.replaceMain(modifiedVS, "czm_non_compressed_main");
   const compressedMain =
-    "void main() \n" +
-    "{ \n" +
-    decode +
-    "    czm_non_compressed_main(); \n" +
-    "}";
+    `${"void main() \n" + "{ \n"}${decode}    czm_non_compressed_main(); \n` +
+    `}`;
 
   return [attributeDecl, globalDecl, modifiedVS, compressedMain].join("\n");
 }
@@ -1159,11 +1117,11 @@ function depthClampFS(fragmentShaderSource) {
     "    #endif\n" +
     "#endif\n" +
     "}\n";
-  modifiedFS =
+  modifiedFS = `${
     "#ifdef GL_EXT_frag_depth\n" +
     "#extension GL_EXT_frag_depth : enable\n" +
-    "#endif\n" +
-    modifiedFS;
+    "#endif\n"
+  }${modifiedFS}`;
   return modifiedFS;
 }
 
@@ -1184,9 +1142,7 @@ function validateShaderMatching(shaderProgram, attributeLocations) {
     if (shaderAttributes.hasOwnProperty(name)) {
       if (!defined(attributeLocations[name])) {
         throw new DeveloperError(
-          "Appearance/Geometry mismatch.  The appearance requires vertex shader attribute input '" +
-            name +
-            "', which was not computed as part of the Geometry.  Use the appearance's vertexFormat property when constructing the geometry."
+          `Appearance/Geometry mismatch.  The appearance requires vertex shader attribute input '${name}', which was not computed as part of the Geometry.  Use the appearance's vertexFormat property when constructing the geometry.`
         );
       }
     }
@@ -1854,7 +1810,7 @@ function getUniforms(primitive, appearance, material, frameState) {
         if (defined(materialUniformMap) && defined(materialUniformMap[name])) {
           // Later, we could rename uniforms behind-the-scenes if needed.
           throw new DeveloperError(
-            "Appearance and material have a uniform with the same name: " + name
+            `Appearance and material have a uniform with the same name: ${name}`
           );
         }
         //>>includeEnd('debug');

--- a/Source/Scene/PrimitivePipeline.js
+++ b/Source/Scene/PrimitivePipeline.js
@@ -176,8 +176,8 @@ function geometryPipeline(parameters) {
           attributes.hasOwnProperty(name) &&
           attributes[name].componentDatatype === ComponentDatatype.DOUBLE
         ) {
-          const name3D = name + "3D";
-          const name2D = name + "2D";
+          const name3D = `${name}3D`;
+          const name2D = `${name}2D`;
 
           // Compute 2D positions
           GeometryPipeline.projectTo2D(
@@ -196,14 +196,14 @@ function geometryPipeline(parameters) {
           GeometryPipeline.encodeAttribute(
             geometry,
             name3D,
-            name3D + "High",
-            name3D + "Low"
+            `${name3D}High`,
+            `${name3D}Low`
           );
           GeometryPipeline.encodeAttribute(
             geometry,
             name2D,
-            name2D + "High",
-            name2D + "Low"
+            `${name2D}High`,
+            `${name2D}Low`
           );
         }
       }
@@ -216,8 +216,8 @@ function geometryPipeline(parameters) {
           GeometryPipeline.encodeAttribute(
             geometry,
             name,
-            name + "3DHigh",
-            name + "3DLow"
+            `${name}3DHigh`,
+            `${name}3DLow`
           );
         }
       }

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -415,18 +415,7 @@ function updateTileLoadProgress(primitive, frameState) {
       debug.maxDepthVisited !== debug.lastMaxDepthVisited
     ) {
       console.log(
-        "Visited " +
-          debug.tilesVisited +
-          ", Rendered: " +
-          debug.tilesRendered +
-          ", Culled: " +
-          debug.tilesCulled +
-          ", Max Depth Rendered: " +
-          debug.maxDepth +
-          ", Max Depth Visited: " +
-          debug.maxDepthVisited +
-          ", Waiting for children: " +
-          debug.tilesWaitingForChildren
+        `Visited ${debug.tilesVisited}, Rendered: ${debug.tilesRendered}, Culled: ${debug.tilesCulled}, Max Depth Rendered: ${debug.maxDepth}, Max Depth Visited: ${debug.maxDepthVisited}, Waiting for children: ${debug.tilesWaitingForChildren}`
       );
 
       debug.lastTilesVisited = debug.tilesVisited;

--- a/Source/Scene/ResourceCache.js
+++ b/Source/Scene/ResourceCache.js
@@ -85,7 +85,7 @@ ResourceCache.load = function (options) {
 
   if (defined(ResourceCache.cacheEntries[cacheKey])) {
     throw new DeveloperError(
-      "Resource with this cacheKey is already in the cache: " + cacheKey
+      `Resource with this cacheKey is already in the cache: ${cacheKey}`
     );
   }
   //>>includeEnd('debug');
@@ -115,7 +115,7 @@ ResourceCache.unload = function (resourceLoader) {
 
   //>>includeStart('debug', pragmas.debug);
   if (!defined(cacheEntry)) {
-    throw new DeveloperError("Resource is not in the cache: " + cacheKey);
+    throw new DeveloperError(`Resource is not in the cache: ${cacheKey}`);
   }
   //>>includeEnd('debug');
 

--- a/Source/Scene/ResourceCacheKey.js
+++ b/Source/Scene/ResourceCacheKey.js
@@ -29,7 +29,7 @@ function getBufferViewCacheKey(bufferView) {
     byteLength = meshopt.byteLength;
   }
 
-  return byteOffset + "-" + (byteOffset + byteLength);
+  return `${byteOffset}-${byteOffset + byteLength}`;
 }
 
 function getAccessorCacheKey(accessor, bufferView) {
@@ -37,7 +37,7 @@ function getAccessorCacheKey(accessor, bufferView) {
   const componentType = accessor.componentType;
   const type = accessor.type;
   const count = accessor.count;
-  return byteOffset + "-" + componentType + "-" + type + "-" + count;
+  return `${byteOffset}-${componentType}-${type}-${count}`;
 }
 
 function getExternalBufferCacheKey(resource) {
@@ -46,7 +46,7 @@ function getExternalBufferCacheKey(resource) {
 
 function getEmbeddedBufferCacheKey(parentResource, bufferId) {
   const parentCacheKey = getExternalResourceCacheKey(parentResource);
-  return parentCacheKey + "-buffer-id-" + bufferId;
+  return `${parentCacheKey}-buffer-id-${bufferId}`;
 }
 
 function getBufferCacheKey(buffer, bufferId, gltfResource, baseResource) {
@@ -75,7 +75,7 @@ function getDracoCacheKey(gltf, draco, gltfResource, baseResource) {
 
   const bufferViewCacheKey = getBufferViewCacheKey(bufferView);
 
-  return bufferCacheKey + "-range-" + bufferViewCacheKey;
+  return `${bufferCacheKey}-range-${bufferViewCacheKey}`;
 }
 
 function getImageCacheKey(gltf, imageId, gltfResource, baseResource) {
@@ -103,7 +103,7 @@ function getImageCacheKey(gltf, imageId, gltfResource, baseResource) {
 
   const bufferViewCacheKey = getBufferViewCacheKey(bufferView);
 
-  return bufferCacheKey + "-range-" + bufferViewCacheKey;
+  return `${bufferCacheKey}-range-${bufferViewCacheKey}`;
 }
 
 function getSamplerCacheKey(gltf, textureInfo) {
@@ -112,15 +112,7 @@ function getSamplerCacheKey(gltf, textureInfo) {
     textureInfo: textureInfo,
   });
 
-  return (
-    sampler.wrapS +
-    "-" +
-    sampler.wrapT +
-    "-" +
-    sampler.minificationFilter +
-    "-" +
-    sampler.magnificationFilter
-  );
+  return `${sampler.wrapS}-${sampler.wrapT}-${sampler.minificationFilter}-${sampler.magnificationFilter}`;
 }
 
 /**
@@ -148,10 +140,10 @@ ResourceCacheKey.getSchemaCacheKey = function (options) {
   //>>includeEnd('debug');
 
   if (defined(schema)) {
-    return "embedded-schema:" + JSON.stringify(schema);
+    return `embedded-schema:${JSON.stringify(schema)}`;
   }
 
-  return "external-schema:" + getExternalResourceCacheKey(resource);
+  return `external-schema:${getExternalResourceCacheKey(resource)}`;
 };
 
 /**
@@ -171,7 +163,7 @@ ResourceCacheKey.getExternalBufferCacheKey = function (options) {
   Check.typeOf.object("options.resource", resource);
   //>>includeEnd('debug');
 
-  return "external-buffer:" + getExternalBufferCacheKey(resource);
+  return `external-buffer:${getExternalBufferCacheKey(resource)}`;
 };
 
 /**
@@ -194,9 +186,10 @@ ResourceCacheKey.getEmbeddedBufferCacheKey = function (options) {
   Check.typeOf.number("options.bufferId", bufferId);
   //>>includeEnd('debug');
 
-  return (
-    "embedded-buffer:" + getEmbeddedBufferCacheKey(parentResource, bufferId)
-  );
+  return `embedded-buffer:${getEmbeddedBufferCacheKey(
+    parentResource,
+    bufferId
+  )}`;
 };
 
 /**
@@ -216,7 +209,7 @@ ResourceCacheKey.getGltfCacheKey = function (options) {
   Check.typeOf.object("options.gltfResource", gltfResource);
   //>>includeEnd('debug');
 
-  return "gltf:" + getExternalResourceCacheKey(gltfResource);
+  return `gltf:${getExternalResourceCacheKey(gltfResource)}`;
 };
 
 /**
@@ -262,7 +255,7 @@ ResourceCacheKey.getBufferViewCacheKey = function (options) {
 
   const bufferViewCacheKey = getBufferViewCacheKey(bufferView);
 
-  return "buffer-view:" + bufferCacheKey + "-range-" + bufferViewCacheKey;
+  return `buffer-view:${bufferCacheKey}-range-${bufferViewCacheKey}`;
 };
 
 /**
@@ -291,7 +284,7 @@ ResourceCacheKey.getDracoCacheKey = function (options) {
   Check.typeOf.object("options.baseResource", baseResource);
   //>>includeEnd('debug');
 
-  return "draco:" + getDracoCacheKey(gltf, draco, gltfResource, baseResource);
+  return `draco:${getDracoCacheKey(gltf, draco, gltfResource, baseResource)}`;
 };
 
 /**
@@ -366,13 +359,7 @@ ResourceCacheKey.getVertexBufferCacheKey = function (options) {
       gltfResource,
       baseResource
     );
-    return (
-      "vertex-buffer:" +
-      dracoCacheKey +
-      "-draco-" +
-      attributeSemantic +
-      cacheKeySuffix
-    );
+    return `vertex-buffer:${dracoCacheKey}-draco-${attributeSemantic}${cacheKeySuffix}`;
   }
 
   const bufferView = gltf.bufferViews[bufferViewId];
@@ -388,13 +375,7 @@ ResourceCacheKey.getVertexBufferCacheKey = function (options) {
 
   const bufferViewCacheKey = getBufferViewCacheKey(bufferView);
 
-  return (
-    "vertex-buffer:" +
-    bufferCacheKey +
-    "-range-" +
-    bufferViewCacheKey +
-    cacheKeySuffix
-  );
+  return `vertex-buffer:${bufferCacheKey}-range-${bufferViewCacheKey}${cacheKeySuffix}`;
 };
 
 /**
@@ -439,7 +420,7 @@ ResourceCacheKey.getIndexBufferCacheKey = function (options) {
       gltfResource,
       baseResource
     );
-    return "index-buffer:" + dracoCacheKey + "-draco" + cacheKeySuffix;
+    return `index-buffer:${dracoCacheKey}-draco${cacheKeySuffix}`;
   }
 
   const accessor = gltf.accessors[accessorId];
@@ -457,13 +438,7 @@ ResourceCacheKey.getIndexBufferCacheKey = function (options) {
 
   const accessorCacheKey = getAccessorCacheKey(accessor, bufferView);
 
-  return (
-    "index-buffer:" +
-    bufferCacheKey +
-    "-accessor-" +
-    accessorCacheKey +
-    cacheKeySuffix
-  );
+  return `index-buffer:${bufferCacheKey}-accessor-${accessorCacheKey}${cacheKeySuffix}`;
 };
 
 /**
@@ -499,7 +474,7 @@ ResourceCacheKey.getImageCacheKey = function (options) {
     baseResource
   );
 
-  return "image:" + imageCacheKey;
+  return `image:${imageCacheKey}`;
 };
 
 /**
@@ -551,7 +526,7 @@ ResourceCacheKey.getTextureCacheKey = function (options) {
   // removing the sampleCacheKey here.
   const samplerCacheKey = getSamplerCacheKey(gltf, textureInfo);
 
-  return "texture:" + imageCacheKey + "-sampler-" + samplerCacheKey;
+  return `texture:${imageCacheKey}-sampler-${samplerCacheKey}`;
 };
 
 export default ResourceCacheKey;

--- a/Source/Scene/ResourceLoader.js
+++ b/Source/Scene/ResourceLoader.js
@@ -89,7 +89,7 @@ ResourceLoader.prototype.getError = function (errorMessage, error) {
   //>>includeEnd('debug');
 
   if (defined(error)) {
-    errorMessage += "\n" + error.message;
+    errorMessage += `\n${error.message}`;
   }
   return new RuntimeError(errorMessage);
 };

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -815,15 +815,16 @@ function createDebugShadowViewCommand(shadowMap, context) {
       "} \n";
   } else {
     fs =
-      "uniform sampler2D shadowMap_texture; \n" +
-      "varying vec2 v_textureCoordinates; \n" +
-      "void main() \n" +
-      "{ \n" +
-      (shadowMap._usesDepthTexture
-        ? "    float shadow = texture2D(shadowMap_texture, v_textureCoordinates).r; \n"
-        : "    float shadow = czm_unpackDepth(texture2D(shadowMap_texture, v_textureCoordinates)); \n") +
-      "    gl_FragColor = vec4(vec3(shadow), 1.0); \n" +
-      "} \n";
+      `${
+        "uniform sampler2D shadowMap_texture; \n" +
+        "varying vec2 v_textureCoordinates; \n" +
+        "void main() \n" +
+        "{ \n"
+      }${
+        shadowMap._usesDepthTexture
+          ? "    float shadow = texture2D(shadowMap_texture, v_textureCoordinates).r; \n"
+          : "    float shadow = czm_unpackDepth(texture2D(shadowMap_texture, v_textureCoordinates)); \n"
+      }    gl_FragColor = vec4(vec3(shadow), 1.0); \n` + `} \n`;
   }
 
   const drawCommand = context.createViewportQuadCommand(fs, {

--- a/Source/Scene/ShadowMapShader.js
+++ b/Source/Scene/ShadowMapShader.js
@@ -12,16 +12,7 @@ ShadowMapShader.getShadowCastShaderKeyword = function (
   usesDepthTexture,
   isOpaque
 ) {
-  return (
-    "castShadow " +
-    isPointLight +
-    " " +
-    isTerrain +
-    " " +
-    usesDepthTexture +
-    " " +
-    isOpaque
-  );
+  return `castShadow ${isPointLight} ${isTerrain} ${usesDepthTexture} ${isOpaque}`;
 };
 
 ShadowMapShader.createShadowCastVertexShader = function (
@@ -107,15 +98,13 @@ ShadowMapShader.createShadowCastFragmentShader = function (
 
   if (isPointLight) {
     fsSource +=
-      "    float distance = length(" +
-      positionVaryingName +
-      "); \n" +
-      "    if (distance >= shadowMap_lightPositionEC.w) \n" +
-      "    { \n" +
-      "        discard; \n" +
-      "    } \n" +
-      "    distance /= shadowMap_lightPositionEC.w; // radius \n" +
-      "    gl_FragColor = czm_packDepth(distance); \n";
+      `    float distance = length(${positionVaryingName}); \n` +
+      `    if (distance >= shadowMap_lightPositionEC.w) \n` +
+      `    { \n` +
+      `        discard; \n` +
+      `    } \n` +
+      `    distance /= shadowMap_lightPositionEC.w; // radius \n` +
+      `    gl_FragColor = czm_packDepth(distance); \n`;
   } else if (usesDepthTexture) {
     fsSource += "    gl_FragColor = vec4(1.0); \n";
   } else {
@@ -146,19 +135,7 @@ ShadowMapShader.getShadowReceiveShaderKeyword = function (
   const debugCascadeColors = shadowMap.debugCascadeColors;
   const softShadows = shadowMap.softShadows;
 
-  return (
-    "receiveShadow " +
-    usesDepthTexture +
-    polygonOffsetSupported +
-    isPointLight +
-    isSpotLight +
-    hasCascades +
-    debugCascadeColors +
-    softShadows +
-    castShadows +
-    isTerrain +
-    hasTerrainNormal
-  );
+  return `receiveShadow ${usesDepthTexture}${polygonOffsetSupported}${isPointLight}${isSpotLight}${hasCascades}${debugCascadeColors}${softShadows}${castShadows}${isTerrain}${hasTerrainNormal}`;
 };
 
 ShadowMapShader.createShadowReceiveVertexShader = function (
@@ -260,7 +237,7 @@ ShadowMapShader.createShadowReceiveFragmentShader = function (
 
   let returnPositionEC;
   if (hasPositionVarying) {
-    returnPositionEC = "    return vec4(" + positionVaryingName + ", 1.0); \n";
+    returnPositionEC = `    return vec4(${positionVaryingName}, 1.0); \n`;
   } else {
     returnPositionEC =
       "#ifndef LOG_DEPTH \n" +
@@ -271,34 +248,34 @@ ShadowMapShader.createShadowReceiveFragmentShader = function (
   }
 
   fsSource +=
-    "uniform mat4 shadowMap_matrix; \n" +
-    "uniform vec3 shadowMap_lightDirectionEC; \n" +
-    "uniform vec4 shadowMap_lightPositionEC; \n" +
-    "uniform vec4 shadowMap_normalOffsetScaleDistanceMaxDistanceAndDarkness; \n" +
-    "uniform vec4 shadowMap_texelSizeDepthBiasAndNormalShadingSmooth; \n" +
-    "#ifdef LOG_DEPTH \n" +
-    "varying vec3 v_logPositionEC; \n" +
-    "#endif \n" +
-    "vec4 getPositionEC() \n" +
-    "{ \n" +
-    returnPositionEC +
-    "} \n" +
-    "vec3 getNormalEC() \n" +
-    "{ \n" +
-    (hasNormalVarying
-      ? "    return normalize(" + normalVaryingName + "); \n"
-      : "    return vec3(1.0); \n") +
-    "} \n" +
+    `${
+      "uniform mat4 shadowMap_matrix; \n" +
+      "uniform vec3 shadowMap_lightDirectionEC; \n" +
+      "uniform vec4 shadowMap_lightPositionEC; \n" +
+      "uniform vec4 shadowMap_normalOffsetScaleDistanceMaxDistanceAndDarkness; \n" +
+      "uniform vec4 shadowMap_texelSizeDepthBiasAndNormalShadingSmooth; \n" +
+      "#ifdef LOG_DEPTH \n" +
+      "varying vec3 v_logPositionEC; \n" +
+      "#endif \n" +
+      "vec4 getPositionEC() \n" +
+      "{ \n"
+    }${returnPositionEC}} \n` +
+    `vec3 getNormalEC() \n` +
+    `{ \n${
+      hasNormalVarying
+        ? `    return normalize(${normalVaryingName}); \n`
+        : "    return vec3(1.0); \n"
+    }} \n` +
     // Offset the shadow position in the direction of the normal for perpendicular and back faces
-    "void applyNormalOffset(inout vec4 positionEC, vec3 normalEC, float nDotL) \n" +
-    "{ \n" +
-    (bias.normalOffset && hasNormalVarying
-      ? "    float normalOffset = shadowMap_normalOffsetScaleDistanceMaxDistanceAndDarkness.x; \n" +
-        "    float normalOffsetScale = 1.0 - nDotL; \n" +
-        "    vec3 offset = normalOffset * normalOffsetScale * normalEC; \n" +
-        "    positionEC.xyz += offset; \n"
-      : "") +
-    "} \n";
+    `void applyNormalOffset(inout vec4 positionEC, vec3 normalEC, float nDotL) \n` +
+    `{ \n${
+      bias.normalOffset && hasNormalVarying
+        ? "    float normalOffset = shadowMap_normalOffsetScaleDistanceMaxDistanceAndDarkness.x; \n" +
+          "    float normalOffsetScale = 1.0 - nDotL; \n" +
+          "    vec3 offset = normalOffset * normalOffsetScale * normalEC; \n" +
+          "    positionEC.xyz += offset; \n"
+        : ""
+    }} \n`;
 
   fsSource +=
     "void main() \n" +
@@ -359,7 +336,7 @@ ShadowMapShader.createShadowReceiveFragmentShader = function (
       "    shadowParameters.nDotL = nDotL; \n" +
       "    float visibility = czm_shadowVisibility(shadowMap_texture, shadowParameters); \n";
   } else if (hasCascades) {
-    fsSource +=
+    fsSource += `${
       "    float maxDepth = shadowMap_cascadeSplits[1].w; \n" +
       "    // Stop early if the eye depth exceeds the last cascade \n" +
       "    if (depth > maxDepth) \n" +
@@ -381,11 +358,13 @@ ShadowMapShader.createShadowReceiveFragmentShader = function (
       "    // Fade out shadows that are far away \n" +
       "    float shadowMapMaximumDistance = shadowMap_normalOffsetScaleDistanceMaxDistanceAndDarkness.z; \n" +
       "    float fade = max((depth - shadowMapMaximumDistance * 0.8) / (shadowMapMaximumDistance * 0.2), 0.0); \n" +
-      "    visibility = mix(visibility, 1.0, fade); \n" +
-      (debugCascadeColors
+      "    visibility = mix(visibility, 1.0, fade); \n"
+    }${
+      debugCascadeColors
         ? "    // Draw cascade colors for debugging \n" +
           "    gl_FragColor *= czm_cascadeColor(weights); \n"
-        : "");
+        : ""
+    }`;
   } else {
     fsSource +=
       "    float nDotL = clamp(dot(normalEC, shadowMap_lightDirectionEC), 0.0, 1.0); \n" +

--- a/Source/Scene/ShadowVolumeAppearance.js
+++ b/Source/Scene/ShadowVolumeAppearance.js
@@ -50,8 +50,7 @@ function ShadowVolumeAppearance(extentsCulling, planarExtents, appearance) {
     colorShaderDependencies.requiresNormalEC = !appearance.flat;
   } else {
     // Scan material source for what hookups are needed. Assume czm_materialInput materialInput.
-    const materialShaderSource =
-      appearance.material.shaderSource + "\n" + appearance.fragmentShaderSource;
+    const materialShaderSource = `${appearance.material.shaderSource}\n${appearance.fragmentShaderSource}`;
 
     colorShaderDependencies.normalEC =
       materialShaderSource.indexOf("materialInput.normalEC") !== -1 ||
@@ -270,11 +269,12 @@ function createShadowVolumeAppearanceVS(
       eastMostCartesian.x,
       longitudeExtentsEncodeScratch
     );
-    projectionExtentDefines.eastMostYhighDefine =
-      "EAST_MOST_X_HIGH " +
-      encoded.high.toFixed((encoded.high + "").length + 1);
-    projectionExtentDefines.eastMostYlowDefine =
-      "EAST_MOST_X_LOW " + encoded.low.toFixed((encoded.low + "").length + 1);
+    projectionExtentDefines.eastMostYhighDefine = `EAST_MOST_X_HIGH ${encoded.high.toFixed(
+      `${encoded.high}`.length + 1
+    )}`;
+    projectionExtentDefines.eastMostYlowDefine = `EAST_MOST_X_LOW ${encoded.low.toFixed(
+      `${encoded.low}`.length + 1
+    )}`;
 
     const westMostCartographic = longitudeExtentsCartographicScratch;
     westMostCartographic.longitude = -CesiumMath.PI;
@@ -288,11 +288,12 @@ function createShadowVolumeAppearanceVS(
       westMostCartesian.x,
       longitudeExtentsEncodeScratch
     );
-    projectionExtentDefines.westMostYhighDefine =
-      "WEST_MOST_X_HIGH " +
-      encoded.high.toFixed((encoded.high + "").length + 1);
-    projectionExtentDefines.westMostYlowDefine =
-      "WEST_MOST_X_LOW " + encoded.low.toFixed((encoded.low + "").length + 1);
+    projectionExtentDefines.westMostYhighDefine = `WEST_MOST_X_HIGH ${encoded.high.toFixed(
+      `${encoded.high}`.length + 1
+    )}`;
+    projectionExtentDefines.westMostYlowDefine = `WEST_MOST_X_LOW ${encoded.low.toFixed(
+      `${encoded.low}`.length + 1
+    )}`;
   }
 
   if (columbusView2D) {

--- a/Source/Scene/SingleTileImageryProvider.js
+++ b/Source/Scene/SingleTileImageryProvider.js
@@ -174,7 +174,7 @@ function SingleTileImageryProvider(options) {
   }
 
   function failure(e) {
-    const message = "Failed to load image " + resource.url + ".";
+    const message = `Failed to load image ${resource.url}.`;
     error = TileProviderError.handleError(
       error,
       that,

--- a/Source/Scene/TextureAtlas.js
+++ b/Source/Scene/TextureAtlas.js
@@ -434,9 +434,7 @@ TextureAtlas.prototype.addSubRegion = function (id, subRegion) {
 
   const indexPromise = this._idHash[id];
   if (!defined(indexPromise)) {
-    throw new RuntimeError(
-      'image with id "' + id + '" not found in the atlas.'
-    );
+    throw new RuntimeError(`image with id "${id}" not found in the atlas.`);
   }
 
   const that = this;

--- a/Source/Scene/TileCoordinatesImageryProvider.js
+++ b/Source/Scene/TileCoordinatesImageryProvider.js
@@ -353,9 +353,9 @@ TileCoordinatesImageryProvider.prototype.requestImage = function (
   context.font = "bold 25px Arial";
   context.textAlign = "center";
   context.fillStyle = cssColor;
-  context.fillText("L: " + level, 124, 86);
-  context.fillText("X: " + x, 124, 136);
-  context.fillText("Y: " + y, 124, 186);
+  context.fillText(`L: ${level}`, 124, 86);
+  context.fillText(`X: ${x}`, 124, 136);
+  context.fillText(`Y: ${y}`, 124, 186);
 
   return canvas;
 };

--- a/Source/Scene/TileMapServiceImageryProvider.js
+++ b/Source/Scene/TileMapServiceImageryProvider.js
@@ -205,10 +205,7 @@ TileMapServiceImageryProvider.prototype._metadataSuccess = function (xml) {
 
   let message;
   if (!defined(tilesets) || !defined(bbox)) {
-    message =
-      "Unable to find expected tilesets or bbox attributes in " +
-      xmlResource.url +
-      ".";
+    message = `Unable to find expected tilesets or bbox attributes in ${xmlResource.url}.`;
     metadataError = TileProviderError.handleError(
       metadataError,
       this,
@@ -266,11 +263,7 @@ TileMapServiceImageryProvider.prototype._metadataSuccess = function (xml) {
         ellipsoid: options.ellipsoid,
       });
     } else {
-      message =
-        xmlResource.url +
-        "specifies an unsupported profile attribute, " +
-        tilingSchemeName +
-        ".";
+      message = `${xmlResource.url}specifies an unsupported profile attribute, ${tilingSchemeName}.`;
       metadataError = TileProviderError.handleError(
         metadataError,
         this,
@@ -357,7 +350,7 @@ TileMapServiceImageryProvider.prototype._metadataSuccess = function (xml) {
   );
 
   const templateResource = this._tmsResource.getDerivedResource({
-    url: "{z}/{x}/{reverseY}." + fileExtension,
+    url: `{z}/{x}/{reverseY}.${fileExtension}`,
   });
 
   deferred.resolve({
@@ -396,7 +389,7 @@ TileMapServiceImageryProvider.prototype._metadataFailure = function (error) {
   );
 
   const templateResource = this._tmsResource.getDerivedResource({
-    url: "{z}/{x}/{reverseY}." + fileExtension,
+    url: `{z}/{x}/{reverseY}.${fileExtension}`,
   });
 
   this._deferred.resolve({

--- a/Source/Scene/TimeDynamicImagery.js
+++ b/Source/Scene/TimeDynamicImagery.js
@@ -215,7 +215,7 @@ TimeDynamicImagery.prototype._clockOnTick = function (clock) {
 };
 
 function getKey(x, y, level) {
-  return x + "-" + y + "-" + level;
+  return `${x}-${y}-${level}`;
 }
 
 function getKeyElements(key) {

--- a/Source/Scene/TimeDynamicPointCloud.js
+++ b/Source/Scene/TimeDynamicPointCloud.js
@@ -259,7 +259,7 @@ Object.defineProperties(TimeDynamicPointCloud.prototype, {
 });
 
 function getFragmentShaderLoaded(fs) {
-  return "uniform vec4 czm_pickColor;\n" + fs;
+  return `uniform vec4 czm_pickColor;\n${fs}`;
 }
 
 function getUniformMapLoaded(stream) {
@@ -370,8 +370,8 @@ function handleFrameFailure(that, uri) {
         message: message,
       });
     } else {
-      console.log("A frame failed to load: " + uri);
-      console.log("Error: " + message);
+      console.log(`A frame failed to load: ${uri}`);
+      console.log(`Error: ${message}`);
     }
   };
 }

--- a/Source/Scene/Vector3DTileContent.js
+++ b/Source/Scene/Vector3DTileContent.js
@@ -278,9 +278,7 @@ function initialize(content, arrayBuffer, byteOffset) {
   const version = view.getUint32(byteOffset, true);
   if (version !== 1) {
     throw new RuntimeError(
-      "Only Vector tile version 1 is supported.  Version " +
-        version +
-        " is not."
+      `Only Vector tile version 1 is supported.  Version ${version} is not.`
     );
   }
   byteOffset += sizeOfUint32;
@@ -643,9 +641,9 @@ Vector3DTileContent.prototype.getFeature = function (batchId) {
   const featuresLength = this.featuresLength;
   if (!defined(batchId) || batchId < 0 || batchId >= featuresLength) {
     throw new DeveloperError(
-      "batchId is required and between zero and featuresLength - 1 (" +
-        (featuresLength - 1) +
-        ")."
+      `batchId is required and between zero and featuresLength - 1 (${
+        featuresLength - 1
+      }).`
     );
   }
   //>>includeEnd('debug');

--- a/Source/Scene/Vector3DTilePrimitive.js
+++ b/Source/Scene/Vector3DTilePrimitive.js
@@ -280,14 +280,11 @@ function createShaders(primitive, context) {
       "czm_non_pick_main"
     );
     fragmentShaderSource =
-      fragmentShaderSource +
-      "void main() \n" +
-      "{ \n" +
-      "    czm_non_pick_main(); \n" +
-      "    gl_FragColor = " +
-      pickId +
-      "; \n" +
-      "} \n";
+      `${fragmentShaderSource}void main() \n` +
+      `{ \n` +
+      `    czm_non_pick_main(); \n` +
+      `    gl_FragColor = ${pickId}; \n` +
+      `} \n`;
     primitive._spPick = ShaderProgram.fromCache({
       context: context,
       vertexShaderSource: vertexShaderSource,
@@ -342,15 +339,12 @@ function createShaders(primitive, context) {
 
   fsSource = ShaderSource.replaceMain(fsSource, "czm_non_pick_main");
   fsSource =
-    fsSource +
-    "\n" +
-    "void main() \n" +
-    "{ \n" +
-    "    czm_non_pick_main(); \n" +
-    "    gl_FragColor = " +
-    pickId +
-    "; \n" +
-    "} \n";
+    `${fsSource}\n` +
+    `void main() \n` +
+    `{ \n` +
+    `    czm_non_pick_main(); \n` +
+    `    gl_FragColor = ${pickId}; \n` +
+    `} \n`;
 
   const pickVS = new ShaderSource({
     sources: [vsSource],

--- a/Source/Scene/VertexAttributeSemantic.js
+++ b/Source/Scene/VertexAttributeSemantic.js
@@ -266,7 +266,7 @@ VertexAttributeSemantic.getVariableName = function (semantic, setIndex) {
 
   let variableName = semanticToVariableName(semantic);
   if (defined(setIndex)) {
-    variableName += "_" + setIndex;
+    variableName += `_${setIndex}`;
   }
   return variableName;
 };

--- a/Source/Scene/WebMapTileServiceImageryProvider.js
+++ b/Source/Scene/WebMapTileServiceImageryProvider.js
@@ -305,9 +305,7 @@ function WebMapTileServiceImageryProvider(options) {
   //>>includeStart('debug', pragmas.debug);
   if (tileCount > 4) {
     throw new DeveloperError(
-      "The imagery provider's rectangle and minimumLevel indicate that there are " +
-        tileCount +
-        " tiles at the minimum level. Imagery providers with more than four tiles at the minimum level are not supported."
+      `The imagery provider's rectangle and minimumLevel indicate that there are ${tileCount} tiles at the minimum level. Imagery providers with more than four tiles at the minimum level are not supported.`
     );
   }
   //>>includeEnd('debug');

--- a/Source/Scene/createOsmBuildings.js
+++ b/Source/Scene/createOsmBuildings.js
@@ -62,9 +62,7 @@ function createOsmBuildings(options) {
       Color.WHITE
     ).toCssColorString();
     style = new Cesium3DTileStyle({
-      color:
-        "Boolean(${feature['cesium#color']}) ? color(${feature['cesium#color']}) : " +
-        color,
+      color: `Boolean(\${feature['cesium#color']}) ? color(\${feature['cesium#color']}) : ${color}`,
     });
   }
 

--- a/Source/Scene/getClipAndStyleCode.js
+++ b/Source/Scene/getClipAndStyleCode.js
@@ -21,22 +21,14 @@ function getClipAndStyleCode(
   //>>includeEnd('debug');
 
   const shaderCode =
-    "    float clipDistance = clip(gl_FragCoord, " +
-    samplerUniformName +
-    ", " +
-    matrixUniformName +
-    "); \n" +
-    "    vec4 clippingPlanesEdgeColor = vec4(1.0); \n" +
-    "    clippingPlanesEdgeColor.rgb = " +
-    styleUniformName +
-    ".rgb; \n" +
-    "    float clippingPlanesEdgeWidth = " +
-    styleUniformName +
-    ".a; \n" +
-    "    if (clipDistance > 0.0 && clipDistance < clippingPlanesEdgeWidth) \n" +
-    "    { \n" +
-    "        gl_FragColor = clippingPlanesEdgeColor;\n" +
-    "    } \n";
+    `    float clipDistance = clip(gl_FragCoord, ${samplerUniformName}, ${matrixUniformName}); \n` +
+    `    vec4 clippingPlanesEdgeColor = vec4(1.0); \n` +
+    `    clippingPlanesEdgeColor.rgb = ${styleUniformName}.rgb; \n` +
+    `    float clippingPlanesEdgeWidth = ${styleUniformName}.a; \n` +
+    `    if (clipDistance > 0.0 && clipDistance < clippingPlanesEdgeWidth) \n` +
+    `    { \n` +
+    `        gl_FragColor = clippingPlanesEdgeColor;\n` +
+    `    } \n`;
   return shaderCode;
 }
 export default getClipAndStyleCode;

--- a/Source/Scene/getClippingFunction.js
+++ b/Source/Scene/getClippingFunction.js
@@ -39,64 +39,64 @@ function getClippingFunction(clippingPlaneCollection, context) {
 
 function clippingFunctionUnion(clippingPlanesLength) {
   const functionString =
-    "float clip(vec4 fragCoord, sampler2D clippingPlanes, mat4 clippingPlanesMatrix)\n" +
-    "{\n" +
-    "    vec4 position = czm_windowToEyeCoordinates(fragCoord);\n" +
-    "    vec3 clipNormal = vec3(0.0);\n" +
-    "    vec3 clipPosition = vec3(0.0);\n" +
-    "    float clipAmount;\n" + // For union planes, we want to get the min distance. So we set the initial value to the first plane distance in the loop below.
-    "    float pixelWidth = czm_metersPerPixel(position);\n" +
-    "    bool breakAndDiscard = false;\n" +
-    "    for (int i = 0; i < " +
-    clippingPlanesLength +
-    "; ++i)\n" +
-    "    {\n" +
-    "        vec4 clippingPlane = getClippingPlane(clippingPlanes, i, clippingPlanesMatrix);\n" +
-    "        clipNormal = clippingPlane.xyz;\n" +
-    "        clipPosition = -clippingPlane.w * clipNormal;\n" +
-    "        float amount = dot(clipNormal, (position.xyz - clipPosition)) / pixelWidth;\n" +
-    "        clipAmount = czm_branchFreeTernary(i == 0, amount, min(amount, clipAmount));\n" +
-    "        if (amount <= 0.0)\n" +
-    "        {\n" +
-    "           breakAndDiscard = true;\n" +
-    "           break;\n" + // HLSL compiler bug if we discard here: https://bugs.chromium.org/p/angleproject/issues/detail?id=1945#c6
-    "        }\n" +
-    "    }\n" +
-    "    if (breakAndDiscard) {\n" +
-    "        discard;\n" +
-    "    }\n" +
-    "    return clipAmount;\n" +
-    "}\n";
+    `${
+      "float clip(vec4 fragCoord, sampler2D clippingPlanes, mat4 clippingPlanesMatrix)\n" +
+      "{\n" +
+      "    vec4 position = czm_windowToEyeCoordinates(fragCoord);\n" +
+      "    vec3 clipNormal = vec3(0.0);\n" +
+      "    vec3 clipPosition = vec3(0.0);\n" +
+      "    float clipAmount;\n" + // For union planes, we want to get the min distance. So we set the initial value to the first plane distance in the loop below.
+      "    float pixelWidth = czm_metersPerPixel(position);\n" +
+      "    bool breakAndDiscard = false;\n" +
+      "    for (int i = 0; i < "
+    }${clippingPlanesLength}; ++i)\n` +
+    `    {\n` +
+    `        vec4 clippingPlane = getClippingPlane(clippingPlanes, i, clippingPlanesMatrix);\n` +
+    `        clipNormal = clippingPlane.xyz;\n` +
+    `        clipPosition = -clippingPlane.w * clipNormal;\n` +
+    `        float amount = dot(clipNormal, (position.xyz - clipPosition)) / pixelWidth;\n` +
+    `        clipAmount = czm_branchFreeTernary(i == 0, amount, min(amount, clipAmount));\n` +
+    `        if (amount <= 0.0)\n` +
+    `        {\n` +
+    `           breakAndDiscard = true;\n` +
+    `           break;\n` + // HLSL compiler bug if we discard here: https://bugs.chromium.org/p/angleproject/issues/detail?id=1945#c6
+    `        }\n` +
+    `    }\n` +
+    `    if (breakAndDiscard) {\n` +
+    `        discard;\n` +
+    `    }\n` +
+    `    return clipAmount;\n` +
+    `}\n`;
   return functionString;
 }
 
 function clippingFunctionIntersect(clippingPlanesLength) {
   const functionString =
-    "float clip(vec4 fragCoord, sampler2D clippingPlanes, mat4 clippingPlanesMatrix)\n" +
-    "{\n" +
-    "    bool clipped = true;\n" +
-    "    vec4 position = czm_windowToEyeCoordinates(fragCoord);\n" +
-    "    vec3 clipNormal = vec3(0.0);\n" +
-    "    vec3 clipPosition = vec3(0.0);\n" +
-    "    float clipAmount = 0.0;\n" +
-    "    float pixelWidth = czm_metersPerPixel(position);\n" +
-    "    for (int i = 0; i < " +
-    clippingPlanesLength +
-    "; ++i)\n" +
-    "    {\n" +
-    "        vec4 clippingPlane = getClippingPlane(clippingPlanes, i, clippingPlanesMatrix);\n" +
-    "        clipNormal = clippingPlane.xyz;\n" +
-    "        clipPosition = -clippingPlane.w * clipNormal;\n" +
-    "        float amount = dot(clipNormal, (position.xyz - clipPosition)) / pixelWidth;\n" +
-    "        clipAmount = max(amount, clipAmount);\n" +
-    "        clipped = clipped && (amount <= 0.0);\n" +
-    "    }\n" +
-    "    if (clipped)\n" +
-    "    {\n" +
-    "        discard;\n" +
-    "    }\n" +
-    "    return clipAmount;\n" +
-    "}\n";
+    `${
+      "float clip(vec4 fragCoord, sampler2D clippingPlanes, mat4 clippingPlanesMatrix)\n" +
+      "{\n" +
+      "    bool clipped = true;\n" +
+      "    vec4 position = czm_windowToEyeCoordinates(fragCoord);\n" +
+      "    vec3 clipNormal = vec3(0.0);\n" +
+      "    vec3 clipPosition = vec3(0.0);\n" +
+      "    float clipAmount = 0.0;\n" +
+      "    float pixelWidth = czm_metersPerPixel(position);\n" +
+      "    for (int i = 0; i < "
+    }${clippingPlanesLength}; ++i)\n` +
+    `    {\n` +
+    `        vec4 clippingPlane = getClippingPlane(clippingPlanes, i, clippingPlanesMatrix);\n` +
+    `        clipNormal = clippingPlane.xyz;\n` +
+    `        clipPosition = -clippingPlane.w * clipNormal;\n` +
+    `        float amount = dot(clipNormal, (position.xyz - clipPosition)) / pixelWidth;\n` +
+    `        clipAmount = max(amount, clipAmount);\n` +
+    `        clipped = clipped && (amount <= 0.0);\n` +
+    `    }\n` +
+    `    if (clipped)\n` +
+    `    {\n` +
+    `        discard;\n` +
+    `    }\n` +
+    `    return clipAmount;\n` +
+    `}\n`;
   return functionString;
 }
 
@@ -104,33 +104,27 @@ function getClippingPlaneFloat(width, height) {
   const pixelWidth = 1.0 / width;
   const pixelHeight = 1.0 / height;
 
-  let pixelWidthString = pixelWidth + "";
+  let pixelWidthString = `${pixelWidth}`;
   if (pixelWidthString.indexOf(".") === -1) {
     pixelWidthString += ".0";
   }
-  let pixelHeightString = pixelHeight + "";
+  let pixelHeightString = `${pixelHeight}`;
   if (pixelHeightString.indexOf(".") === -1) {
     pixelHeightString += ".0";
   }
 
   const functionString =
-    "vec4 getClippingPlane(highp sampler2D packedClippingPlanes, int clippingPlaneNumber, mat4 transform)\n" +
-    "{\n" +
-    "    int pixY = clippingPlaneNumber / " +
-    width +
-    ";\n" +
-    "    int pixX = clippingPlaneNumber - (pixY * " +
-    width +
-    ");\n" +
-    "    float u = (float(pixX) + 0.5) * " +
-    pixelWidthString +
-    ";\n" + // sample from center of pixel
-    "    float v = (float(pixY) + 0.5) * " +
-    pixelHeightString +
-    ";\n" +
-    "    vec4 plane = texture2D(packedClippingPlanes, vec2(u, v));\n" +
-    "    return czm_transformPlane(plane, transform);\n" +
-    "}\n";
+    `${
+      "vec4 getClippingPlane(highp sampler2D packedClippingPlanes, int clippingPlaneNumber, mat4 transform)\n" +
+      "{\n" +
+      "    int pixY = clippingPlaneNumber / "
+    }${width};\n` +
+    `    int pixX = clippingPlaneNumber - (pixY * ${width});\n` +
+    `    float u = (float(pixX) + 0.5) * ${pixelWidthString};\n` + // sample from center of pixel
+    `    float v = (float(pixY) + 0.5) * ${pixelHeightString};\n` +
+    `    vec4 plane = texture2D(packedClippingPlanes, vec2(u, v));\n` +
+    `    return czm_transformPlane(plane, transform);\n` +
+    `}\n`;
   return functionString;
 }
 
@@ -138,40 +132,32 @@ function getClippingPlaneUint8(width, height) {
   const pixelWidth = 1.0 / width;
   const pixelHeight = 1.0 / height;
 
-  let pixelWidthString = pixelWidth + "";
+  let pixelWidthString = `${pixelWidth}`;
   if (pixelWidthString.indexOf(".") === -1) {
     pixelWidthString += ".0";
   }
-  let pixelHeightString = pixelHeight + "";
+  let pixelHeightString = `${pixelHeight}`;
   if (pixelHeightString.indexOf(".") === -1) {
     pixelHeightString += ".0";
   }
 
   const functionString =
-    "vec4 getClippingPlane(highp sampler2D packedClippingPlanes, int clippingPlaneNumber, mat4 transform)\n" +
-    "{\n" +
-    "    int clippingPlaneStartIndex = clippingPlaneNumber * 2;\n" + // clipping planes are two pixels each
-    "    int pixY = clippingPlaneStartIndex / " +
-    width +
-    ";\n" +
-    "    int pixX = clippingPlaneStartIndex - (pixY * " +
-    width +
-    ");\n" +
-    "    float u = (float(pixX) + 0.5) * " +
-    pixelWidthString +
-    ";\n" + // sample from center of pixel
-    "    float v = (float(pixY) + 0.5) * " +
-    pixelHeightString +
-    ";\n" +
-    "    vec4 oct32 = texture2D(packedClippingPlanes, vec2(u, v)) * 255.0;\n" +
-    "    vec2 oct = vec2(oct32.x * 256.0 + oct32.y, oct32.z * 256.0 + oct32.w);\n" +
-    "    vec4 plane;\n" +
-    "    plane.xyz = czm_octDecode(oct, 65535.0);\n" +
-    "    plane.w = czm_unpackFloat(texture2D(packedClippingPlanes, vec2(u + " +
-    pixelWidthString +
-    ", v)));\n" +
-    "    return czm_transformPlane(plane, transform);\n" +
-    "}\n";
+    `${
+      "vec4 getClippingPlane(highp sampler2D packedClippingPlanes, int clippingPlaneNumber, mat4 transform)\n" +
+      "{\n" +
+      "    int clippingPlaneStartIndex = clippingPlaneNumber * 2;\n" + // clipping planes are two pixels each
+      "    int pixY = clippingPlaneStartIndex / "
+    }${width};\n` +
+    `    int pixX = clippingPlaneStartIndex - (pixY * ${width});\n` +
+    `    float u = (float(pixX) + 0.5) * ${pixelWidthString};\n` + // sample from center of pixel
+    `    float v = (float(pixY) + 0.5) * ${pixelHeightString};\n` +
+    `    vec4 oct32 = texture2D(packedClippingPlanes, vec2(u, v)) * 255.0;\n` +
+    `    vec2 oct = vec2(oct32.x * 256.0 + oct32.y, oct32.z * 256.0 + oct32.w);\n` +
+    `    vec4 plane;\n` +
+    `    plane.xyz = czm_octDecode(oct, 65535.0);\n` +
+    `    plane.w = czm_unpackFloat(texture2D(packedClippingPlanes, vec2(u + ${pixelWidthString}, v)));\n` +
+    `    return czm_transformPlane(plane, transform);\n` +
+    `}\n`;
   return functionString;
 }
 export default getClippingFunction;

--- a/Source/Scene/parseBatchTable.js
+++ b/Source/Scene/parseBatchTable.js
@@ -166,7 +166,7 @@ function transcodeBinaryProperties(
 
     if (!defined(binaryBody)) {
       throw new RuntimeError(
-        "Property " + propertyId + " requires a batch table binary."
+        `Property ${propertyId} requires a batch table binary.`
       );
     }
 

--- a/Source/Scene/parseBoundingVolumeSemantics.js
+++ b/Source/Scene/parseBoundingVolumeSemantics.js
@@ -53,7 +53,7 @@ export default function parseBoundingVolumeSemantics(tileMetadata) {
  * @private
  */
 function parseBoundingVolume(prefix, tileMetadata) {
-  const boundingBoxSemantic = prefix + "_BOUNDING_BOX";
+  const boundingBoxSemantic = `${prefix}_BOUNDING_BOX`;
   const boundingBox = tileMetadata.getPropertyBySemantic(boundingBoxSemantic);
 
   if (defined(boundingBox)) {
@@ -62,7 +62,7 @@ function parseBoundingVolume(prefix, tileMetadata) {
     };
   }
 
-  const boundingRegionSemantic = prefix + "_BOUNDING_REGION";
+  const boundingRegionSemantic = `${prefix}_BOUNDING_REGION`;
   const boundingRegion = tileMetadata.getPropertyBySemantic(
     boundingRegionSemantic
   );
@@ -73,7 +73,7 @@ function parseBoundingVolume(prefix, tileMetadata) {
     };
   }
 
-  const boundingSphereSemantic = prefix + "_BOUNDING_SPHERE";
+  const boundingSphereSemantic = `${prefix}_BOUNDING_SPHERE`;
   const boundingSphere = tileMetadata.getPropertyBySemantic(
     boundingSphereSemantic
   );
@@ -99,7 +99,7 @@ function parseBoundingVolume(prefix, tileMetadata) {
  * @private
  */
 function parseMinimumHeight(prefix, tileMetadata) {
-  const minimumHeightSemantic = prefix + "_MINIMUM_HEIGHT";
+  const minimumHeightSemantic = `${prefix}_MINIMUM_HEIGHT`;
   return tileMetadata.getPropertyBySemantic(minimumHeightSemantic);
 }
 
@@ -114,6 +114,6 @@ function parseMinimumHeight(prefix, tileMetadata) {
  * @private
  */
 function parseMaximumHeight(prefix, tileMetadata) {
-  const maximumHeightSemantic = prefix + "_MAXIMUM_HEIGHT";
+  const maximumHeightSemantic = `${prefix}_MAXIMUM_HEIGHT`;
   return tileMetadata.getPropertyBySemantic(maximumHeightSemantic);
 }

--- a/Source/Scene/processModelMaterialsCommon.js
+++ b/Source/Scene/processModelMaterialsCommon.js
@@ -78,7 +78,7 @@ function processModelMaterialsCommon(gltf, options) {
           valueName !== "transparent" &&
           valueName !== "doubleSided"
         ) {
-          uniformName = "u_" + valueName.toLowerCase();
+          uniformName = `u_${valueName.toLowerCase()}`;
           materialValues[uniformName] = values[valueName];
         }
       }
@@ -150,7 +150,7 @@ function generateLightParameters(gltf) {
           delete lights[lightName];
           continue;
         }
-        const lightBaseName = "light" + lightCount.toString();
+        const lightBaseName = `light${lightCount.toString()}`;
         light.baseName = lightBaseName;
         let ambient;
         let directional;
@@ -159,19 +159,19 @@ function generateLightParameters(gltf) {
         switch (lightType) {
           case "ambient":
             ambient = light.ambient;
-            result[lightBaseName + "Color"] = {
+            result[`${lightBaseName}Color`] = {
               type: WebGLConstants.FLOAT_VEC3,
               value: ambient.color,
             };
             break;
           case "directional":
             directional = light.directional;
-            result[lightBaseName + "Color"] = {
+            result[`${lightBaseName}Color`] = {
               type: WebGLConstants.FLOAT_VEC3,
               value: directional.color,
             };
             if (defined(light.node)) {
-              result[lightBaseName + "Transform"] = {
+              result[`${lightBaseName}Transform`] = {
                 node: light.node,
                 semantic: "MODELVIEW",
                 type: WebGLConstants.FLOAT_MAT4,
@@ -180,18 +180,18 @@ function generateLightParameters(gltf) {
             break;
           case "point":
             point = light.point;
-            result[lightBaseName + "Color"] = {
+            result[`${lightBaseName}Color`] = {
               type: WebGLConstants.FLOAT_VEC3,
               value: point.color,
             };
             if (defined(light.node)) {
-              result[lightBaseName + "Transform"] = {
+              result[`${lightBaseName}Transform`] = {
                 node: light.node,
                 semantic: "MODELVIEW",
                 type: WebGLConstants.FLOAT_MAT4,
               };
             }
-            result[lightBaseName + "Attenuation"] = {
+            result[`${lightBaseName}Attenuation`] = {
               type: WebGLConstants.FLOAT_VEC3,
               value: [
                 point.constantAttenuation,
@@ -202,24 +202,24 @@ function generateLightParameters(gltf) {
             break;
           case "spot":
             spot = light.spot;
-            result[lightBaseName + "Color"] = {
+            result[`${lightBaseName}Color`] = {
               type: WebGLConstants.FLOAT_VEC3,
               value: spot.color,
             };
             if (defined(light.node)) {
-              result[lightBaseName + "Transform"] = {
+              result[`${lightBaseName}Transform`] = {
                 node: light.node,
                 semantic: "MODELVIEW",
                 type: WebGLConstants.FLOAT_MAT4,
               };
-              result[lightBaseName + "InverseTransform"] = {
+              result[`${lightBaseName}InverseTransform`] = {
                 node: light.node,
                 semantic: "MODELVIEWINVERSE",
                 type: WebGLConstants.FLOAT_MAT4,
                 useInFragment: true,
               };
             }
-            result[lightBaseName + "Attenuation"] = {
+            result[`${lightBaseName}Attenuation`] = {
               type: WebGLConstants.FLOAT_VEC3,
               value: [
                 spot.constantAttenuation,
@@ -228,7 +228,7 @@ function generateLightParameters(gltf) {
               ],
             };
 
-            result[lightBaseName + "FallOff"] = {
+            result[`${lightBaseName}FallOff`] = {
               type: WebGLConstants.FLOAT_VEC2,
               value: [spot.fallOffAngle, spot.fallOffExponent],
             };
@@ -333,7 +333,7 @@ function generateTechnique(
         name,
         parameterValues[name]
       );
-      uniformName = "u_" + name.toLowerCase();
+      uniformName = `u_${name.toLowerCase()}`;
       if (!hasTexCoords && uniformType === WebGLConstants.SAMPLER_2D) {
         hasTexCoords = true;
       }
@@ -353,7 +353,7 @@ function generateTechnique(
   if (defined(lightParameters)) {
     for (const lightParamName in lightParameters) {
       if (lightParameters.hasOwnProperty(lightParamName)) {
-        uniformName = "u_" + lightParamName;
+        uniformName = `u_${lightParamName}`;
         techniqueUniforms[uniformName] = lightParameters[lightParamName];
       }
     }
@@ -363,28 +363,20 @@ function generateTechnique(
   for (uniformName in techniqueUniforms) {
     if (techniqueUniforms.hasOwnProperty(uniformName)) {
       const uniform = techniqueUniforms[uniformName];
-      const arraySize = defined(uniform.count) ? "[" + uniform.count + "]" : "";
+      const arraySize = defined(uniform.count) ? `[${uniform.count}]` : "";
       if (
         (uniform.type !== WebGLConstants.FLOAT_MAT3 &&
           uniform.type !== WebGLConstants.FLOAT_MAT4) ||
         uniform.useInFragment
       ) {
-        fragmentShader +=
-          "uniform " +
-          webGLConstantToGlslType(uniform.type) +
-          " " +
-          uniformName +
-          arraySize +
-          ";\n";
+        fragmentShader += `uniform ${webGLConstantToGlslType(
+          uniform.type
+        )} ${uniformName}${arraySize};\n`;
         delete uniform.useInFragment;
       } else {
-        vertexShader +=
-          "uniform " +
-          webGLConstantToGlslType(uniform.type) +
-          " " +
-          uniformName +
-          arraySize +
-          ";\n";
+        vertexShader += `uniform ${webGLConstantToGlslType(
+          uniform.type
+        )} ${uniformName}${arraySize};\n`;
       }
     }
   }
@@ -445,10 +437,10 @@ function generateTechnique(
 
     v_texcoord = "v_texcoord_0";
     vertexShader += "attribute vec2 a_texcoord_0;\n";
-    vertexShader += "varying vec2 " + v_texcoord + ";\n";
-    vertexShaderMain += "  " + v_texcoord + " = a_texcoord_0;\n";
+    vertexShader += `varying vec2 ${v_texcoord};\n`;
+    vertexShaderMain += `  ${v_texcoord} = a_texcoord_0;\n`;
 
-    fragmentShader += "varying vec2 " + v_texcoord + ";\n";
+    fragmentShader += `varying vec2 ${v_texcoord};\n`;
   }
 
   if (hasSkinning) {
@@ -497,81 +489,53 @@ function generateTechnique(
       const lightType = light.type.toLowerCase();
       const lightBaseName = light.baseName;
       fragmentLightingBlock += "  {\n";
-      const lightColorName = "u_" + lightBaseName + "Color";
+      const lightColorName = `u_${lightBaseName}Color`;
       if (lightType === "ambient") {
         hasAmbientLights = true;
-        fragmentLightingBlock +=
-          "    ambientLight += " + lightColorName + ";\n";
+        fragmentLightingBlock += `    ambientLight += ${lightColorName};\n`;
       } else if (hasNormals) {
         hasNonAmbientLights = true;
-        const varyingDirectionName = "v_" + lightBaseName + "Direction";
-        const varyingPositionName = "v_" + lightBaseName + "Position";
+        const varyingDirectionName = `v_${lightBaseName}Direction`;
+        const varyingPositionName = `v_${lightBaseName}Position`;
 
         if (lightType !== "point") {
-          vertexShader += "varying vec3 " + varyingDirectionName + ";\n";
-          fragmentShader += "varying vec3 " + varyingDirectionName + ";\n";
+          vertexShader += `varying vec3 ${varyingDirectionName};\n`;
+          fragmentShader += `varying vec3 ${varyingDirectionName};\n`;
 
-          vertexShaderMain +=
-            "  " +
-            varyingDirectionName +
-            " = mat3(u_" +
-            lightBaseName +
-            "Transform) * vec3(0.,0.,1.);\n";
+          vertexShaderMain += `  ${varyingDirectionName} = mat3(u_${lightBaseName}Transform) * vec3(0.,0.,1.);\n`;
           if (lightType === "directional") {
-            fragmentLightingBlock +=
-              "    vec3 l = normalize(" + varyingDirectionName + ");\n";
+            fragmentLightingBlock += `    vec3 l = normalize(${varyingDirectionName});\n`;
           }
         }
 
         if (lightType !== "directional") {
-          vertexShader += "varying vec3 " + varyingPositionName + ";\n";
-          fragmentShader += "varying vec3 " + varyingPositionName + ";\n";
+          vertexShader += `varying vec3 ${varyingPositionName};\n`;
+          fragmentShader += `varying vec3 ${varyingPositionName};\n`;
 
-          vertexShaderMain +=
-            "  " +
-            varyingPositionName +
-            " = u_" +
-            lightBaseName +
-            "Transform[3].xyz;\n";
-          fragmentLightingBlock +=
-            "    vec3 VP = " + varyingPositionName + " - v_positionEC;\n";
+          vertexShaderMain += `  ${varyingPositionName} = u_${lightBaseName}Transform[3].xyz;\n`;
+          fragmentLightingBlock += `    vec3 VP = ${varyingPositionName} - v_positionEC;\n`;
           fragmentLightingBlock += "    vec3 l = normalize(VP);\n";
           fragmentLightingBlock += "    float range = length(VP);\n";
-          fragmentLightingBlock +=
-            "    float attenuation = 1.0 / (u_" +
-            lightBaseName +
-            "Attenuation.x + ";
-          fragmentLightingBlock +=
-            "(u_" + lightBaseName + "Attenuation.y * range) + ";
-          fragmentLightingBlock +=
-            "(u_" + lightBaseName + "Attenuation.z * range * range));\n";
+          fragmentLightingBlock += `    float attenuation = 1.0 / (u_${lightBaseName}Attenuation.x + `;
+          fragmentLightingBlock += `(u_${lightBaseName}Attenuation.y * range) + `;
+          fragmentLightingBlock += `(u_${lightBaseName}Attenuation.z * range * range));\n`;
         } else {
           fragmentLightingBlock += "    float attenuation = 1.0;\n";
         }
 
         if (lightType === "spot") {
-          fragmentLightingBlock +=
-            "    float spotDot = dot(l, normalize(" +
-            varyingDirectionName +
-            "));\n";
-          fragmentLightingBlock +=
-            "    if (spotDot < cos(u_" + lightBaseName + "FallOff.x * 0.5))\n";
+          fragmentLightingBlock += `    float spotDot = dot(l, normalize(${varyingDirectionName}));\n`;
+          fragmentLightingBlock += `    if (spotDot < cos(u_${lightBaseName}FallOff.x * 0.5))\n`;
           fragmentLightingBlock += "    {\n";
           fragmentLightingBlock += "      attenuation = 0.0;\n";
           fragmentLightingBlock += "    }\n";
           fragmentLightingBlock += "    else\n";
           fragmentLightingBlock += "    {\n";
-          fragmentLightingBlock +=
-            "        attenuation *= max(0.0, pow(spotDot, u_" +
-            lightBaseName +
-            "FallOff.y));\n";
+          fragmentLightingBlock += `        attenuation *= max(0.0, pow(spotDot, u_${lightBaseName}FallOff.y));\n`;
           fragmentLightingBlock += "    }\n";
         }
 
-        fragmentLightingBlock +=
-          "    diffuseLight += " +
-          lightColorName +
-          "* max(dot(normal,l), 0.) * attenuation;\n";
+        fragmentLightingBlock += `    diffuseLight += ${lightColorName}* max(dot(normal,l), 0.) * attenuation;\n`;
 
         if (hasSpecular) {
           if (lightingModel === "BLINN") {
@@ -585,10 +549,7 @@ function generateTechnique(
             fragmentLightingBlock +=
               "    float specularIntensity = max(0., pow(max(dot(reflectDir, viewDir), 0.), u_shininess)) * attenuation;\n";
           }
-          fragmentLightingBlock +=
-            "    specularLight += " +
-            lightColorName +
-            " * specularIntensity;\n";
+          fragmentLightingBlock += `    specularLight += ${lightColorName} * specularIntensity;\n`;
         }
       }
       fragmentLightingBlock += "  }\n";
@@ -613,10 +574,7 @@ function generateTechnique(
 
     fragmentLightingBlock += "  vec3 l = normalize(czm_lightDirectionEC);\n";
     const minimumLighting = "0.2"; // Use strings instead of values as 0.0 -> 0 when stringified
-    fragmentLightingBlock +=
-      "  diffuseLight += lightColor * max(dot(normal,l), " +
-      minimumLighting +
-      ");\n";
+    fragmentLightingBlock += `  diffuseLight += lightColor * max(dot(normal,l), ${minimumLighting});\n`;
 
     if (hasSpecular) {
       if (lightingModel === "BLINN") {
@@ -655,8 +613,7 @@ function generateTechnique(
   if (lightingModel !== "CONSTANT") {
     if (defined(techniqueUniforms.u_diffuse)) {
       if (techniqueUniforms.u_diffuse.type === WebGLConstants.SAMPLER_2D) {
-        fragmentShader +=
-          "  vec4 diffuse = texture2D(u_diffuse, " + v_texcoord + ");\n";
+        fragmentShader += `  vec4 diffuse = texture2D(u_diffuse, ${v_texcoord});\n`;
       } else {
         fragmentShader += "  vec4 diffuse = u_diffuse;\n";
       }
@@ -666,8 +623,7 @@ function generateTechnique(
 
     if (hasSpecular) {
       if (techniqueUniforms.u_specular.type === WebGLConstants.SAMPLER_2D) {
-        fragmentShader +=
-          "  vec3 specular = texture2D(u_specular, " + v_texcoord + ").rgb;\n";
+        fragmentShader += `  vec3 specular = texture2D(u_specular, ${v_texcoord}).rgb;\n`;
       } else {
         fragmentShader += "  vec3 specular = u_specular.rgb;\n";
       }
@@ -695,8 +651,7 @@ function generateTechnique(
 
   if (defined(techniqueUniforms.u_emission)) {
     if (techniqueUniforms.u_emission.type === WebGLConstants.SAMPLER_2D) {
-      fragmentShader +=
-        "  vec3 emission = texture2D(u_emission, " + v_texcoord + ").rgb;\n";
+      fragmentShader += `  vec3 emission = texture2D(u_emission, ${v_texcoord}).rgb;\n`;
     } else {
       fragmentShader += "  vec3 emission = u_emission.rgb;\n";
     }
@@ -706,8 +661,7 @@ function generateTechnique(
   if (defined(techniqueUniforms.u_ambient) || lightingModel !== "CONSTANT") {
     if (defined(techniqueUniforms.u_ambient)) {
       if (techniqueUniforms.u_ambient.type === WebGLConstants.SAMPLER_2D) {
-        fragmentShader +=
-          "  vec3 ambient = texture2D(u_ambient, " + v_texcoord + ").rgb;\n";
+        fragmentShader += `  vec3 ambient = texture2D(u_ambient, ${v_texcoord}).rgb;\n`;
       } else {
         fragmentShader += "  vec3 ambient = u_ambient.rgb;\n";
       }
@@ -808,7 +762,7 @@ function getKHRMaterialsCommonValueType(paramName, paramValue) {
 
 function getTechniqueKey(khrMaterialsCommon, primitiveInfo) {
   let techniqueKey = "";
-  techniqueKey += "technique:" + khrMaterialsCommon.technique + ";";
+  techniqueKey += `technique:${khrMaterialsCommon.technique};`;
 
   const values = khrMaterialsCommon.values;
   const keys = Object.keys(values).sort();
@@ -816,18 +770,20 @@ function getTechniqueKey(khrMaterialsCommon, primitiveInfo) {
   for (let i = 0; i < keysCount; ++i) {
     const name = keys[i];
     if (values.hasOwnProperty(name)) {
-      techniqueKey +=
-        name + ":" + getKHRMaterialsCommonValueType(name, values[name]);
+      techniqueKey += `${name}:${getKHRMaterialsCommonValueType(
+        name,
+        values[name]
+      )}`;
       techniqueKey += ";";
     }
   }
 
   const jointCount = defaultValue(khrMaterialsCommon.jointCount, 0);
-  techniqueKey += jointCount.toString() + ";";
+  techniqueKey += `${jointCount.toString()};`;
   if (defined(primitiveInfo)) {
     const skinningInfo = primitiveInfo.skinning;
     if (jointCount > 0) {
-      techniqueKey += skinningInfo.type + ";";
+      techniqueKey += `${skinningInfo.type};`;
     }
     techniqueKey += primitiveInfo.hasVertexColors;
   }

--- a/Source/Scene/processPbrMaterials.js
+++ b/Source/Scene/processPbrMaterials.js
@@ -95,20 +95,9 @@ function addTextureCoordinates(
   if (defined(texInfo) && defined(texInfo.texCoord) && texInfo.texCoord === 1) {
     defaultTexCoord = defaultTexCoord.replace("0", "1");
   }
-  if (defined(generatedMaterialValues[textureName + "Offset"])) {
-    texCoord = textureName + "Coord";
-    result.fragmentShaderMain +=
-      "    vec2 " +
-      texCoord +
-      " = computeTexCoord(" +
-      defaultTexCoord +
-      ", " +
-      textureName +
-      "Offset, " +
-      textureName +
-      "Rotation, " +
-      textureName +
-      "Scale);\n";
+  if (defined(generatedMaterialValues[`${textureName}Offset`])) {
+    texCoord = `${textureName}Coord`;
+    result.fragmentShaderMain += `    vec2 ${texCoord} = computeTexCoord(${defaultTexCoord}, ${textureName}Offset, ${textureName}Rotation, ${textureName}Scale);\n`;
   } else {
     texCoord = defaultTexCoord;
   }
@@ -132,17 +121,17 @@ function handleKHRTextureTransform(
     return;
   }
 
-  const uniformName = "u_" + parameterName;
+  const uniformName = `u_${parameterName}`;
   const extension = value.extensions.KHR_texture_transform;
-  generatedMaterialValues[uniformName + "Offset"] = defaultValue(
+  generatedMaterialValues[`${uniformName}Offset`] = defaultValue(
     extension.offset,
     DEFAULT_TEXTURE_OFFSET
   );
-  generatedMaterialValues[uniformName + "Rotation"] = defaultValue(
+  generatedMaterialValues[`${uniformName}Rotation`] = defaultValue(
     extension.rotation,
     DEFAULT_TEXTURE_ROTATION
   );
-  generatedMaterialValues[uniformName + "Scale"] = defaultValue(
+  generatedMaterialValues[`${uniformName}Scale`] = defaultValue(
     extension.scale,
     DEFAULT_TEXTURE_SCALE
   );
@@ -180,7 +169,7 @@ function generateTechnique(
     for (parameterName in pbrMetallicRoughness) {
       if (pbrMetallicRoughness.hasOwnProperty(parameterName)) {
         value = pbrMetallicRoughness[parameterName];
-        uniformName = "u_" + parameterName;
+        uniformName = `u_${parameterName}`;
         generatedMaterialValues[uniformName] = value;
         handleKHRTextureTransform(
           parameterName,
@@ -197,7 +186,7 @@ function generateTechnique(
     for (parameterName in pbrSpecularGlossiness) {
       if (pbrSpecularGlossiness.hasOwnProperty(parameterName)) {
         value = pbrSpecularGlossiness[parameterName];
-        uniformName = "u_" + parameterName;
+        uniformName = `u_${parameterName}`;
         generatedMaterialValues[uniformName] = value;
         handleKHRTextureTransform(
           parameterName,
@@ -214,7 +203,7 @@ function generateTechnique(
       (additional.indexOf("Texture") >= 0 || additional.indexOf("Factor") >= 0)
     ) {
       value = material[additional];
-      uniformName = "u_" + additional;
+      uniformName = `u_${additional}`;
       generatedMaterialValues[uniformName] = value;
       handleKHRTextureTransform(additional, value, generatedMaterialValues);
     }
@@ -343,29 +332,21 @@ function generateTechnique(
   for (uniformName in techniqueUniforms) {
     if (techniqueUniforms.hasOwnProperty(uniformName)) {
       const uniform = techniqueUniforms[uniformName];
-      const arraySize = defined(uniform.count) ? "[" + uniform.count + "]" : "";
+      const arraySize = defined(uniform.count) ? `[${uniform.count}]` : "";
       if (
         (uniform.type !== WebGLConstants.FLOAT_MAT3 &&
           uniform.type !== WebGLConstants.FLOAT_MAT4 &&
           uniformName !== "u_morphWeights") ||
         uniform.useInFragment
       ) {
-        fragmentShader +=
-          "uniform " +
-          webGLConstantToGlslType(uniform.type) +
-          " " +
-          uniformName +
-          arraySize +
-          ";\n";
+        fragmentShader += `uniform ${webGLConstantToGlslType(
+          uniform.type
+        )} ${uniformName}${arraySize};\n`;
         delete uniform.useInFragment;
       } else {
-        vertexShader +=
-          "uniform " +
-          webGLConstantToGlslType(uniform.type) +
-          " " +
-          uniformName +
-          arraySize +
-          ";\n";
+        vertexShader += `uniform ${webGLConstantToGlslType(
+          uniform.type
+        )} ${uniformName}${arraySize};\n`;
       }
     }
   }
@@ -423,32 +404,17 @@ function generateTechnique(
           targetAttributes.hasOwnProperty(targetAttribute) &&
           targetAttribute !== "extras"
         ) {
-          const attributeName = "a_" + targetAttribute + "_" + k;
+          const attributeName = `a_${targetAttribute}_${k}`;
           techniqueAttributes[attributeName] = {
-            semantic: targetAttribute + "_" + k,
+            semantic: `${targetAttribute}_${k}`,
           };
-          vertexShader += "attribute vec3 " + attributeName + ";\n";
+          vertexShader += `attribute vec3 ${attributeName};\n`;
           if (targetAttribute === "POSITION") {
-            vertexShaderMain +=
-              "    weightedPosition += u_morphWeights[" +
-              k +
-              "] * " +
-              attributeName +
-              ";\n";
+            vertexShaderMain += `    weightedPosition += u_morphWeights[${k}] * ${attributeName};\n`;
           } else if (targetAttribute === "NORMAL") {
-            vertexShaderMain +=
-              "    weightedNormal += u_morphWeights[" +
-              k +
-              "] * " +
-              attributeName +
-              ";\n";
+            vertexShaderMain += `    weightedNormal += u_morphWeights[${k}] * ${attributeName};\n`;
           } else if (hasTangents && targetAttribute === "TANGENT") {
-            vertexShaderMain +=
-              "    weightedTangent.xyz += u_morphWeights[" +
-              k +
-              "] * " +
-              attributeName +
-              ";\n";
+            vertexShaderMain += `    weightedTangent.xyz += u_morphWeights[${k}] * ${attributeName};\n`;
           }
         }
       }
@@ -528,10 +494,10 @@ function generateTechnique(
 
     v_texCoord = "v_texcoord_0";
     vertexShader += "attribute vec2 a_texcoord_0;\n";
-    vertexShader += "varying vec2 " + v_texCoord + ";\n";
-    vertexShaderMain += "    " + v_texCoord + " = a_texcoord_0;\n";
+    vertexShader += `varying vec2 ${v_texCoord};\n`;
+    vertexShaderMain += `    ${v_texCoord} = a_texcoord_0;\n`;
 
-    fragmentShader += "varying vec2 " + v_texCoord + ";\n";
+    fragmentShader += `varying vec2 ${v_texCoord};\n`;
 
     if (hasTexCoord1) {
       techniqueAttributes.a_texcoord_1 = {
@@ -540,10 +506,10 @@ function generateTechnique(
 
       const v_texCoord1 = v_texCoord.replace("0", "1");
       vertexShader += "attribute vec2 a_texcoord_1;\n";
-      vertexShader += "varying vec2 " + v_texCoord1 + ";\n";
-      vertexShaderMain += "    " + v_texCoord1 + " = a_texcoord_1;\n";
+      vertexShader += `varying vec2 ${v_texCoord1};\n`;
+      vertexShaderMain += `    ${v_texCoord1} = a_texcoord_1;\n`;
 
-      fragmentShader += "varying vec2 " + v_texCoord1 + ";\n";
+      fragmentShader += `varying vec2 ${v_texCoord1};\n`;
     }
 
     const result = {
@@ -747,35 +713,27 @@ function generateTechnique(
         fragmentShader +=
           "    vec3 b = normalize(cross(ng, t) * v_tangent.w);\n";
         fragmentShader += "    mat3 tbn = mat3(t, b, ng);\n";
-        fragmentShader +=
-          "    vec3 n = texture2D(u_normalTexture, " +
-          normalTexCoord +
-          ").rgb;\n";
+        fragmentShader += `    vec3 n = texture2D(u_normalTexture, ${normalTexCoord}).rgb;\n`;
         fragmentShader += "    n = normalize(tbn * (2.0 * n - 1.0));\n";
       } else {
         // Add standard derivatives extension
-        fragmentShader =
+        fragmentShader = `${
           "#ifdef GL_OES_standard_derivatives\n" +
           "#extension GL_OES_standard_derivatives : enable\n" +
-          "#endif\n" +
-          fragmentShader;
+          "#endif\n"
+        }${fragmentShader}`;
         // Compute tangents
         fragmentShader += "#ifdef GL_OES_standard_derivatives\n";
         fragmentShader += "    vec3 pos_dx = dFdx(v_positionEC);\n";
         fragmentShader += "    vec3 pos_dy = dFdy(v_positionEC);\n";
-        fragmentShader +=
-          "    vec3 tex_dx = dFdx(vec3(" + normalTexCoord + ",0.0));\n";
-        fragmentShader +=
-          "    vec3 tex_dy = dFdy(vec3(" + normalTexCoord + ",0.0));\n";
+        fragmentShader += `    vec3 tex_dx = dFdx(vec3(${normalTexCoord},0.0));\n`;
+        fragmentShader += `    vec3 tex_dy = dFdy(vec3(${normalTexCoord},0.0));\n`;
         fragmentShader +=
           "    vec3 t = (tex_dy.t * pos_dx - tex_dx.t * pos_dy) / (tex_dx.s * tex_dy.t - tex_dy.s * tex_dx.t);\n";
         fragmentShader += "    t = normalize(t - ng * dot(ng, t));\n";
         fragmentShader += "    vec3 b = normalize(cross(ng, t));\n";
         fragmentShader += "    mat3 tbn = mat3(t, b, ng);\n";
-        fragmentShader +=
-          "    vec3 n = texture2D(u_normalTexture, " +
-          normalTexCoord +
-          ").rgb;\n";
+        fragmentShader += `    vec3 n = texture2D(u_normalTexture, ${normalTexCoord}).rgb;\n`;
         fragmentShader += "    n = normalize(tbn * (2.0 * n - 1.0));\n";
         fragmentShader += "#else\n";
         fragmentShader += "    vec3 n = ng;\n";
@@ -794,10 +752,7 @@ function generateTechnique(
 
   // Add base color to fragment shader
   if (defined(generatedMaterialValues.u_baseColorTexture)) {
-    fragmentShader +=
-      "    vec4 baseColorWithAlpha = SRGBtoLINEAR4(texture2D(u_baseColorTexture, " +
-      baseColorTexCoord +
-      "));\n";
+    fragmentShader += `    vec4 baseColorWithAlpha = SRGBtoLINEAR4(texture2D(u_baseColorTexture, ${baseColorTexCoord}));\n`;
     if (defined(generatedMaterialValues.u_baseColorFactor)) {
       fragmentShader += "    baseColorWithAlpha *= u_baseColorFactor;\n";
     }
@@ -816,10 +771,7 @@ function generateTechnique(
   if (hasNormals && !isUnlit) {
     if (useSpecGloss) {
       if (defined(generatedMaterialValues.u_specularGlossinessTexture)) {
-        fragmentShader +=
-          "    vec4 specularGlossiness = SRGBtoLINEAR4(texture2D(u_specularGlossinessTexture, " +
-          specularGlossinessTexCoord +
-          "));\n";
+        fragmentShader += `    vec4 specularGlossiness = SRGBtoLINEAR4(texture2D(u_specularGlossinessTexture, ${specularGlossinessTexCoord}));\n`;
         fragmentShader += "    vec3 specular = specularGlossiness.rgb;\n";
         fragmentShader += "    float glossiness = specularGlossiness.a;\n";
         if (defined(generatedMaterialValues.u_specularFactor)) {
@@ -843,10 +795,7 @@ function generateTechnique(
         }
       }
       if (defined(generatedMaterialValues.u_diffuseTexture)) {
-        fragmentShader +=
-          "    vec4 diffuse = SRGBtoLINEAR4(texture2D(u_diffuseTexture, " +
-          diffuseTexCoord +
-          "));\n";
+        fragmentShader += `    vec4 diffuse = SRGBtoLINEAR4(texture2D(u_diffuseTexture, ${diffuseTexCoord}));\n`;
         if (defined(generatedMaterialValues.u_diffuseFactor)) {
           fragmentShader += "    diffuse *= u_diffuseFactor;\n";
         }
@@ -861,10 +810,7 @@ function generateTechnique(
       // the base color alpha.
       fragmentShader += "    baseColorWithAlpha.a = diffuse.a;\n";
     } else if (defined(generatedMaterialValues.u_metallicRoughnessTexture)) {
-      fragmentShader +=
-        "    vec3 metallicRoughness = texture2D(u_metallicRoughnessTexture, " +
-        metallicRoughnessTexCoord +
-        ").rgb;\n";
+      fragmentShader += `    vec3 metallicRoughness = texture2D(u_metallicRoughnessTexture, ${metallicRoughnessTexCoord}).rgb;\n`;
       fragmentShader +=
         "    float metalness = clamp(metallicRoughness.b, 0.0, 1.0);\n";
       fragmentShader +=
@@ -1082,16 +1028,10 @@ function generateTechnique(
   // Ignore occlusion and emissive when unlit
   if (!isUnlit) {
     if (defined(generatedMaterialValues.u_occlusionTexture)) {
-      fragmentShader +=
-        "    color *= texture2D(u_occlusionTexture, " +
-        occlusionTexCoord +
-        ").r;\n";
+      fragmentShader += `    color *= texture2D(u_occlusionTexture, ${occlusionTexCoord}).r;\n`;
     }
     if (defined(generatedMaterialValues.u_emissiveTexture)) {
-      fragmentShader +=
-        "    vec3 emissive = SRGBtoLINEAR3(texture2D(u_emissiveTexture, " +
-        emissiveTexCoord +
-        ").rgb);\n";
+      fragmentShader += `    vec3 emissive = SRGBtoLINEAR3(texture2D(u_emissiveTexture, ${emissiveTexCoord}).rgb);\n`;
       if (defined(generatedMaterialValues.u_emissiveFactor)) {
         fragmentShader += "    emissive *= u_emissiveFactor;\n";
       }

--- a/Source/Widgets/Animation/Animation.js
+++ b/Source/Widgets/Animation/Animation.js
@@ -124,9 +124,9 @@ function svgText(x, y, msg) {
 function setShuttleRingPointer(shuttleRingPointer, knobOuter, angle) {
   shuttleRingPointer.setAttribute(
     "transform",
-    "translate(100,100) rotate(" + angle + ")"
+    `translate(100,100) rotate(${angle})`
   );
-  knobOuter.setAttribute("transform", "rotate(" + angle + ")");
+  knobOuter.setAttribute("transform", `rotate(${angle})`);
 }
 
 const makeColorStringScratch = new Color();
@@ -148,7 +148,7 @@ function rectButton(x, y, path) {
   const button = {
     tagName: "g",
     class: "cesium-animation-rectButton",
-    transform: "translate(" + x + "," + y + ")",
+    transform: `translate(${x},${y})`,
     children: [
       {
         tagName: "rect",
@@ -189,7 +189,7 @@ function wingButton(x, y, path) {
   const button = {
     tagName: "g",
     class: "cesium-animation-rectButton",
-    transform: "translate(" + x + "," + y + ")",
+    transform: `translate(${x},${y})`,
     children: [
       {
         class: "cesium-animation-buttonGlow",
@@ -840,17 +840,12 @@ Animation.prototype.resize = function () {
   const scaleX = width / baseWidth;
   const scaleY = height / baseHeight;
 
-  svg.style.cssText =
-    "width: " +
-    width +
-    "px; height: " +
-    height +
-    "px; position: absolute; bottom: 0; left: 0; overflow: hidden;";
+  svg.style.cssText = `width: ${width}px; height: ${height}px; position: absolute; bottom: 0; left: 0; overflow: hidden;`;
   svg.setAttribute("width", width);
   svg.setAttribute("height", height);
-  svg.setAttribute("viewBox", "0 0 " + width + " " + height);
+  svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
 
-  this._topG.setAttribute("transform", "scale(" + scaleX + "," + scaleY + ")");
+  this._topG.setAttribute("transform", `scale(${scaleX},${scaleY})`);
 
   this._centerX = Math.max(1, 100.0 * scaleX);
   this._centerY = Math.max(1, 100.0 * scaleY);

--- a/Source/Widgets/Animation/AnimationViewModel.js
+++ b/Source/Widgets/Animation/AnimationViewModel.js
@@ -172,11 +172,11 @@ function AnimationViewModel(clockViewModel) {
 
     //If it's a whole number, just return it.
     if (multiplier % 1 === 0) {
-      return multiplier.toFixed(0) + "x";
+      return `${multiplier.toFixed(0)}x`;
     }
 
     //Convert to decimal string and remove any trailing zeroes
-    return multiplier.toFixed(3).replace(/0{0,3}$/, "") + "x";
+    return `${multiplier.toFixed(3).replace(/0{0,3}$/, "")}x`;
   });
 
   /**
@@ -383,13 +383,9 @@ function AnimationViewModel(clockViewModel) {
  */
 AnimationViewModel.defaultDateFormatter = function (date, viewModel) {
   const gregorianDate = JulianDate.toGregorianDate(date);
-  return (
-    monthNames[gregorianDate.month - 1] +
-    " " +
-    gregorianDate.day +
-    " " +
+  return `${monthNames[gregorianDate.month - 1]} ${gregorianDate.day} ${
     gregorianDate.year
-  );
+  }`;
 };
 
 /**
@@ -440,24 +436,19 @@ AnimationViewModel.defaultTimeFormatter = function (date, viewModel) {
   const gregorianDate = JulianDate.toGregorianDate(date);
   const millisecond = Math.round(gregorianDate.millisecond);
   if (Math.abs(viewModel._clockViewModel.multiplier) < 1) {
-    return (
-      gregorianDate.hour.toString().padStart(2, "0") +
-      ":" +
-      gregorianDate.minute.toString().padStart(2, "0") +
-      ":" +
-      gregorianDate.second.toString().padStart(2, "0") +
-      "." +
-      millisecond.toString().padStart(3, "0")
-    );
+    return `${gregorianDate.hour
+      .toString()
+      .padStart(2, "0")}:${gregorianDate.minute
+      .toString()
+      .padStart(2, "0")}:${gregorianDate.second
+      .toString()
+      .padStart(2, "0")}.${millisecond.toString().padStart(3, "0")}`;
   }
-  return (
-    gregorianDate.hour.toString().padStart(2, "0") +
-    ":" +
-    gregorianDate.minute.toString().padStart(2, "0") +
-    ":" +
-    gregorianDate.second.toString().padStart(2, "0") +
-    " UTC"
-  );
+  return `${gregorianDate.hour
+    .toString()
+    .padStart(2, "0")}:${gregorianDate.minute
+    .toString()
+    .padStart(2, "0")}:${gregorianDate.second.toString().padStart(2, "0")} UTC`;
 };
 
 /**

--- a/Source/Widgets/BaseLayerPicker/BaseLayerPickerViewModel.js
+++ b/Source/Widgets/BaseLayerPicker/BaseLayerPickerViewModel.js
@@ -147,7 +147,7 @@ function BaseLayerPickerViewModel(options) {
       : undefined;
 
     if (defined(imageryTip) && defined(terrainTip)) {
-      return imageryTip + "\n" + terrainTip;
+      return `${imageryTip}\n${terrainTip}`;
     } else if (defined(imageryTip)) {
       return imageryTip;
     }

--- a/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspector.js
+++ b/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspector.js
@@ -353,7 +353,7 @@ Cesium3DTilesInspector.prototype.destroy = function () {
 function makeRangeInput(property, min, max, step, text, displayProperty) {
   displayProperty = defaultValue(displayProperty, property);
   const input = document.createElement("input");
-  input.setAttribute("data-bind", "value: " + displayProperty);
+  input.setAttribute("data-bind", `value: ${displayProperty}`);
   input.type = "number";
 
   const slider = document.createElement("input");
@@ -361,7 +361,7 @@ function makeRangeInput(property, min, max, step, text, displayProperty) {
   slider.min = min;
   slider.max = max;
   slider.step = step;
-  slider.setAttribute("data-bind", 'valueUpdate: "input", value: ' + property);
+  slider.setAttribute("data-bind", `valueUpdate: "input", value: ${property}`);
 
   const wrapper = document.createElement("div");
   wrapper.appendChild(slider);
@@ -380,10 +380,9 @@ function makeButton(action, text, active) {
   button.type = "button";
   button.textContent = text;
   button.className = "cesium-cesiumInspector-pickButton";
-  let binding = "click: " + action;
+  let binding = `click: ${action}`;
   if (defined(active)) {
-    binding +=
-      ', css: {"cesium-cesiumInspector-pickButtonHighlight" : ' + active + "}";
+    binding += `, css: {"cesium-cesiumInspector-pickButtonHighlight" : ${active}}`;
   }
   button.setAttribute("data-bind", binding);
 

--- a/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
+++ b/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
@@ -65,90 +65,58 @@ function getStatistics(tileset, isPick) {
   let s = '<ul class="cesium-cesiumInspector-statistics">';
   s +=
     // --- Rendering statistics
-    "<li><strong>Visited: </strong>" +
-    statistics.visited.toLocaleString() +
-    "</li>" +
+    `<li><strong>Visited: </strong>${statistics.visited.toLocaleString()}</li>` +
     // Number of commands returned is likely to be higher than the number of tiles selected
     // because of tiles that create multiple commands.
-    "<li><strong>Selected: </strong>" +
-    statistics.selected.toLocaleString() +
-    "</li>" +
+    `<li><strong>Selected: </strong>${statistics.selected.toLocaleString()}</li>` +
     // Number of commands executed is likely to be higher because of commands overlapping
     // multiple frustums.
-    "<li><strong>Commands: </strong>" +
-    statistics.numberOfCommands.toLocaleString() +
-    "</li>";
+    `<li><strong>Commands: </strong>${statistics.numberOfCommands.toLocaleString()}</li>`;
   s += "</ul>";
   if (!isPick) {
     s += '<ul class="cesium-cesiumInspector-statistics">';
     s +=
       // --- Cache/loading statistics
-      "<li><strong>Requests: </strong>" +
-      statistics.numberOfPendingRequests.toLocaleString() +
-      "</li>" +
-      "<li><strong>Attempted: </strong>" +
-      statistics.numberOfAttemptedRequests.toLocaleString() +
-      "</li>" +
-      "<li><strong>Processing: </strong>" +
-      statistics.numberOfTilesProcessing.toLocaleString() +
-      "</li>" +
-      "<li><strong>Content Ready: </strong>" +
-      statistics.numberOfTilesWithContentReady.toLocaleString() +
-      "</li>" +
+      `<li><strong>Requests: </strong>${statistics.numberOfPendingRequests.toLocaleString()}</li>` +
+      `<li><strong>Attempted: </strong>${statistics.numberOfAttemptedRequests.toLocaleString()}</li>` +
+      `<li><strong>Processing: </strong>${statistics.numberOfTilesProcessing.toLocaleString()}</li>` +
+      `<li><strong>Content Ready: </strong>${statistics.numberOfTilesWithContentReady.toLocaleString()}</li>` +
       // Total number of tiles includes tiles without content, so "Ready" may never reach
       // "Total."  Total also will increase when a tile with a tileset JSON content is loaded.
-      "<li><strong>Total: </strong>" +
-      statistics.numberOfTilesTotal.toLocaleString() +
-      "</li>";
+      `<li><strong>Total: </strong>${statistics.numberOfTilesTotal.toLocaleString()}</li>`;
     s += "</ul>";
     s += '<ul class="cesium-cesiumInspector-statistics">';
     s +=
       // --- Features statistics
-      "<li><strong>Features Selected: </strong>" +
-      statistics.numberOfFeaturesSelected.toLocaleString() +
-      "</li>" +
-      "<li><strong>Features Loaded: </strong>" +
-      statistics.numberOfFeaturesLoaded.toLocaleString() +
-      "</li>" +
-      "<li><strong>Points Selected: </strong>" +
-      statistics.numberOfPointsSelected.toLocaleString() +
-      "</li>" +
-      "<li><strong>Points Loaded: </strong>" +
-      statistics.numberOfPointsLoaded.toLocaleString() +
-      "</li>" +
-      "<li><strong>Triangles Selected: </strong>" +
-      statistics.numberOfTrianglesSelected.toLocaleString() +
-      "</li>";
+      `<li><strong>Features Selected: </strong>${statistics.numberOfFeaturesSelected.toLocaleString()}</li>` +
+      `<li><strong>Features Loaded: </strong>${statistics.numberOfFeaturesLoaded.toLocaleString()}</li>` +
+      `<li><strong>Points Selected: </strong>${statistics.numberOfPointsSelected.toLocaleString()}</li>` +
+      `<li><strong>Points Loaded: </strong>${statistics.numberOfPointsLoaded.toLocaleString()}</li>` +
+      `<li><strong>Triangles Selected: </strong>${statistics.numberOfTrianglesSelected.toLocaleString()}</li>`;
     s += "</ul>";
     s += '<ul class="cesium-cesiumInspector-statistics">';
     s +=
       // --- Styling statistics
-      "<li><strong>Tiles styled: </strong>" +
-      statistics.numberOfTilesStyled.toLocaleString() +
-      "</li>" +
-      "<li><strong>Features styled: </strong>" +
-      statistics.numberOfFeaturesStyled.toLocaleString() +
-      "</li>";
+      `<li><strong>Tiles styled: </strong>${statistics.numberOfTilesStyled.toLocaleString()}</li>` +
+      `<li><strong>Features styled: </strong>${statistics.numberOfFeaturesStyled.toLocaleString()}</li>`;
     s += "</ul>";
     s += '<ul class="cesium-cesiumInspector-statistics">';
     s +=
       // --- Optimization statistics
-      "<li><strong>Children Union Culled: </strong>" +
-      statistics.numberOfTilesCulledWithChildrenUnion.toLocaleString() +
-      "</li>";
+      `<li><strong>Children Union Culled: </strong>${statistics.numberOfTilesCulledWithChildrenUnion.toLocaleString()}</li>`;
     s += "</ul>";
     s += '<ul class="cesium-cesiumInspector-statistics">';
     s +=
       // --- Memory statistics
-      "<li><strong>Geometry Memory (MB): </strong>" +
-      formatMemoryString(statistics.geometryByteLength) +
-      "</li>" +
-      "<li><strong>Texture Memory (MB): </strong>" +
-      formatMemoryString(statistics.texturesByteLength) +
-      "</li>" +
-      "<li><strong>Batch Table Memory (MB): </strong>" +
-      formatMemoryString(statistics.batchTableByteLength) +
-      "</li>";
+      `<li><strong>Geometry Memory (MB): </strong>${formatMemoryString(
+        statistics.geometryByteLength
+      )}</li>` +
+      `<li><strong>Texture Memory (MB): </strong>${formatMemoryString(
+        statistics.texturesByteLength
+      )}</li>` +
+      `<li><strong>Batch Table Memory (MB): </strong>${formatMemoryString(
+        statistics.batchTableByteLength
+      )}</li>`;
     s += "</ul>";
   }
   return s;
@@ -1477,7 +1445,7 @@ Cesium3DTilesInspectorViewModel.prototype.styleEditorKeyPress = function (
     let i;
     if (!event.shiftKey) {
       for (i = 0; i < length; ++i) {
-        lines[i] = "  " + lines[i];
+        lines[i] = `  ${lines[i]}`;
         newEnd += 2;
       }
     } else {

--- a/Source/Widgets/CesiumInspector/CesiumInspectorViewModel.js
+++ b/Source/Widgets/CesiumInspector/CesiumInspectorViewModel.js
@@ -34,10 +34,10 @@ function frustumStatisticsToString(statistics) {
           }
           s = f.reverse().join(" and ");
         }
-        str += "<br>&nbsp;&nbsp;&nbsp;&nbsp;" + com[n] + " in frustum " + s;
+        str += `<br>&nbsp;&nbsp;&nbsp;&nbsp;${com[n]} in frustum ${s}`;
       }
     }
-    str += "<br>Total: " + statistics.totalCommands;
+    str += `<br>Total: ${statistics.totalCommands}`;
   }
 
   return str;
@@ -895,25 +895,12 @@ Object.defineProperties(CesiumInspectorViewModel.prototype, {
         this.hasPickedTile = true;
         const oldTile = this._tile;
         if (newTile !== oldTile) {
-          this.tileText =
-            "L: " + newTile.level + " X: " + newTile.x + " Y: " + newTile.y;
-          this.tileText +=
-            "<br>SW corner: " +
-            newTile.rectangle.west +
-            ", " +
-            newTile.rectangle.south;
-          this.tileText +=
-            "<br>NE corner: " +
-            newTile.rectangle.east +
-            ", " +
-            newTile.rectangle.north;
+          this.tileText = `L: ${newTile.level} X: ${newTile.x} Y: ${newTile.y}`;
+          this.tileText += `<br>SW corner: ${newTile.rectangle.west}, ${newTile.rectangle.south}`;
+          this.tileText += `<br>NE corner: ${newTile.rectangle.east}, ${newTile.rectangle.north}`;
           const data = newTile.data;
           if (defined(data) && defined(data.tileBoundingRegion)) {
-            this.tileText +=
-              "<br>Min: " +
-              data.tileBoundingRegion.minimumHeight +
-              " Max: " +
-              data.tileBoundingRegion.maximumHeight;
+            this.tileText += `<br>Min: ${data.tileBoundingRegion.minimumHeight} Max: ${data.tileBoundingRegion.maximumHeight}`;
           } else {
             this.tileText += "<br>(Tile is not loaded)";
           }
@@ -946,7 +933,7 @@ CesiumInspectorViewModel.prototype._update = function () {
   // Bound the frustum to be displayed.
   this.depthFrustum = boundDepthFrustum(1, numberOfFrustums, this.depthFrustum);
   // Update the displayed text.
-  this.depthFrustumText = this.depthFrustum + " of " + numberOfFrustums;
+  this.depthFrustumText = `${this.depthFrustum} of ${numberOfFrustums}`;
 
   if (this.performance) {
     this._performanceDisplay.update();
@@ -955,8 +942,7 @@ CesiumInspectorViewModel.prototype._update = function () {
     this._modelMatrixPrimitive.modelMatrix = this._primitive.modelMatrix;
   }
 
-  this.shaderCacheText =
-    "Cached shaders: " + this._scene.context.shaderCache.numberOfShaders;
+  this.shaderCacheText = `Cached shaders: ${this._scene.context.shaderCache.numberOfShaders}`;
 };
 
 /**

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -22,9 +22,7 @@ import Sun from "../../Scene/Sun.js";
 import getElement from "../getElement.js";
 
 function getDefaultSkyBoxUrl(suffix) {
-  return buildModuleUrl(
-    "Assets/Textures/SkyBox/tycho2t3_80_" + suffix + ".jpg"
-  );
+  return buildModuleUrl(`Assets/Textures/SkyBox/tycho2t3_80_${suffix}.jpg`);
 }
 
 function startRenderLoop(widget) {
@@ -653,8 +651,10 @@ CesiumWidget.prototype.showErrorPanel = function (title, message, error) {
   errorPanelScroller.className = "cesium-widget-errorPanel-scroll";
   content.appendChild(errorPanelScroller);
   function resizeCallback() {
-    errorPanelScroller.style.maxHeight =
-      Math.max(Math.round(element.clientHeight * 0.9 - 100), 30) + "px";
+    errorPanelScroller.style.maxHeight = `${Math.max(
+      Math.round(element.clientHeight * 0.9 - 100),
+      30
+    )}px`;
   }
   resizeCallback();
   if (defined(window.addEventListener)) {
@@ -685,7 +685,7 @@ CesiumWidget.prototype.showErrorPanel = function (title, message, error) {
 
       //IE8 does not have a console object unless the dev tools are open.
       if (typeof console !== "undefined") {
-        console.error(title + "\n" + message + "\n" + errorDetails);
+        console.error(`${title}\n${message}\n${errorDetails}`);
       }
 
       const errorMessageDetails = document.createElement("div");
@@ -709,7 +709,7 @@ CesiumWidget.prototype.showErrorPanel = function (title, message, error) {
       errorPanelScroller.appendChild(errorMessageDetails);
     }
 
-    errorMessage.innerHTML = "<p>" + message + "</p>";
+    errorMessage.innerHTML = `<p>${message}</p>`;
   }
 
   const buttonPanel = document.createElement("div");

--- a/Source/Widgets/Geocoder/GeocoderViewModel.js
+++ b/Source/Widgets/Geocoder/GeocoderViewModel.js
@@ -471,7 +471,7 @@ function geocode(viewModel, geocoderServices, geocodeType) {
       viewModel.destinationFound(viewModel, geocoderResults[0].destination);
       return;
     }
-    viewModel._searchText = query + " (not found)";
+    viewModel._searchText = `${query} (not found)`;
   });
 }
 

--- a/Source/Widgets/InfoBox/InfoBox.js
+++ b/Source/Widgets/InfoBox/InfoBox.js
@@ -135,7 +135,7 @@ click: function () { closeClicked.raiseEvent(this); }"
 
         // Measure and set the new custom height, based on text wrapped above.
         const height = frameContent.getBoundingClientRect().height;
-        frame.style.height = height + "px";
+        frame.style.height = `${height}px`;
       }
     );
   });

--- a/Source/Widgets/InfoBox/InfoBoxViewModel.js
+++ b/Source/Widgets/InfoBox/InfoBoxViewModel.js
@@ -90,7 +90,7 @@ function InfoBoxViewModel() {
  * @returns {String}
  */
 InfoBoxViewModel.prototype.maxHeightOffset = function (offset) {
-  return this.maxHeight - offset + "px";
+  return `${this.maxHeight - offset}px`;
 };
 
 Object.defineProperties(InfoBoxViewModel.prototype, {

--- a/Source/Widgets/InspectorShared.js
+++ b/Source/Widgets/InspectorShared.js
@@ -28,9 +28,9 @@ InspectorShared.createCheckbox = function (
   const checkboxInput = document.createElement("input");
   checkboxInput.type = "checkbox";
 
-  let binding = "checked: " + checkedBinding;
+  let binding = `checked: ${checkedBinding}`;
   if (defined(enableBinding)) {
-    binding += ", enable: " + enableBinding;
+    binding += `, enable: ${enableBinding}`;
   }
   checkboxInput.setAttribute("data-bind", binding);
   checkboxLabel.appendChild(checkboxInput);
@@ -66,9 +66,7 @@ InspectorShared.createSection = function (
   section.className = "cesium-cesiumInspector-section";
   section.setAttribute(
     "data-bind",
-    'css: { "cesium-cesiumInspector-section-collapsed": !' +
-      sectionVisibleBinding +
-      " }"
+    `css: { "cesium-cesiumInspector-section-collapsed": !${sectionVisibleBinding} }`
   );
   panel.appendChild(section);
 
@@ -77,7 +75,7 @@ InspectorShared.createSection = function (
   sectionHeader.appendChild(document.createTextNode(headerText));
   sectionHeader.setAttribute(
     "data-bind",
-    "click: " + toggleSectionVisibilityBinding
+    `click: ${toggleSectionVisibilityBinding}`
   );
   section.appendChild(sectionHeader);
 

--- a/Source/Widgets/NavigationHelpButton/NavigationHelpButton.js
+++ b/Source/Widgets/NavigationHelpButton/NavigationHelpButton.js
@@ -116,22 +116,21 @@ cesiumSvgPath: { path: _svgPath, width: 32, height: 32 }"
     "data-bind",
     'css: { "cesium-click-navigation-help-visible" : !_touch}'
   );
-  clickInstructions.innerHTML =
-    '\
+  clickInstructions.innerHTML = `\
             <table>\
                 <tr>\
-                    <td><img src="' +
-    buildModuleUrl("Widgets/Images/NavigationHelp/MouseLeft.svg") +
-    '" width="48" height="48" /></td>\
+                    <td><img src="${buildModuleUrl(
+                      "Widgets/Images/NavigationHelp/MouseLeft.svg"
+                    )}" width="48" height="48" /></td>\
                     <td>\
                         <div class="cesium-navigation-help-pan">Pan view</div>\
                         <div class="cesium-navigation-help-details">Left click + drag</div>\
                     </td>\
                 </tr>\
                 <tr>\
-                    <td><img src="' +
-    buildModuleUrl("Widgets/Images/NavigationHelp/MouseRight.svg") +
-    '" width="48" height="48" /></td>\
+                    <td><img src="${buildModuleUrl(
+                      "Widgets/Images/NavigationHelp/MouseRight.svg"
+                    )}" width="48" height="48" /></td>\
                     <td>\
                         <div class="cesium-navigation-help-zoom">Zoom view</div>\
                         <div class="cesium-navigation-help-details">Right click + drag, or</div>\
@@ -139,16 +138,16 @@ cesiumSvgPath: { path: _svgPath, width: 32, height: 32 }"
                     </td>\
                 </tr>\
                 <tr>\
-                    <td><img src="' +
-    buildModuleUrl("Widgets/Images/NavigationHelp/MouseMiddle.svg") +
-    '" width="48" height="48" /></td>\
+                    <td><img src="${buildModuleUrl(
+                      "Widgets/Images/NavigationHelp/MouseMiddle.svg"
+                    )}" width="48" height="48" /></td>\
                     <td>\
                         <div class="cesium-navigation-help-rotate">Rotate view</div>\
                         <div class="cesium-navigation-help-details">Middle click + drag, or</div>\
                         <div class="cesium-navigation-help-details">CTRL + Left/Right click + drag</div>\
                     </td>\
                 </tr>\
-            </table>';
+            </table>`;
 
   instructionContainer.appendChild(clickInstructions);
 
@@ -159,46 +158,45 @@ cesiumSvgPath: { path: _svgPath, width: 32, height: 32 }"
     "data-bind",
     'css: { "cesium-touch-navigation-help-visible" : _touch}'
   );
-  touchInstructions.innerHTML =
-    '\
+  touchInstructions.innerHTML = `\
             <table>\
                 <tr>\
-                    <td><img src="' +
-    buildModuleUrl("Widgets/Images/NavigationHelp/TouchDrag.svg") +
-    '" width="70" height="48" /></td>\
+                    <td><img src="${buildModuleUrl(
+                      "Widgets/Images/NavigationHelp/TouchDrag.svg"
+                    )}" width="70" height="48" /></td>\
                     <td>\
                         <div class="cesium-navigation-help-pan">Pan view</div>\
                         <div class="cesium-navigation-help-details">One finger drag</div>\
                     </td>\
                 </tr>\
                 <tr>\
-                    <td><img src="' +
-    buildModuleUrl("Widgets/Images/NavigationHelp/TouchZoom.svg") +
-    '" width="70" height="48" /></td>\
+                    <td><img src="${buildModuleUrl(
+                      "Widgets/Images/NavigationHelp/TouchZoom.svg"
+                    )}" width="70" height="48" /></td>\
                     <td>\
                         <div class="cesium-navigation-help-zoom">Zoom view</div>\
                         <div class="cesium-navigation-help-details">Two finger pinch</div>\
                     </td>\
                 </tr>\
                 <tr>\
-                    <td><img src="' +
-    buildModuleUrl("Widgets/Images/NavigationHelp/TouchTilt.svg") +
-    '" width="70" height="48" /></td>\
+                    <td><img src="${buildModuleUrl(
+                      "Widgets/Images/NavigationHelp/TouchTilt.svg"
+                    )}" width="70" height="48" /></td>\
                     <td>\
                         <div class="cesium-navigation-help-rotate">Tilt view</div>\
                         <div class="cesium-navigation-help-details">Two finger drag, same direction</div>\
                     </td>\
                 </tr>\
                 <tr>\
-                    <td><img src="' +
-    buildModuleUrl("Widgets/Images/NavigationHelp/TouchRotate.svg") +
-    '" width="70" height="48" /></td>\
+                    <td><img src="${buildModuleUrl(
+                      "Widgets/Images/NavigationHelp/TouchRotate.svg"
+                    )}" width="70" height="48" /></td>\
                     <td>\
                         <div class="cesium-navigation-help-tilt">Rotate view</div>\
                         <div class="cesium-navigation-help-details">Two finger drag, opposite direction</div>\
                     </td>\
                 </tr>\
-            </table>';
+            </table>`;
 
   instructionContainer.appendChild(touchInstructions);
 

--- a/Source/Widgets/SelectionIndicator/SelectionIndicatorViewModel.js
+++ b/Source/Widgets/SelectionIndicator/SelectionIndicatorViewModel.js
@@ -79,7 +79,7 @@ function SelectionIndicatorViewModel(
 
   knockout.defineProperty(this, "_transform", {
     get: function () {
-      return "scale(" + this._scale + ")";
+      return `scale(${this._scale})`;
     },
   });
 
@@ -131,8 +131,8 @@ SelectionIndicatorViewModel.prototype.update = function () {
           containerHeight + indicatorSize
         ) - halfSize;
 
-      this._screenPositionX = Math.floor(screenPosition.x + 0.25) + "px";
-      this._screenPositionY = Math.floor(screenPosition.y + 0.25) + "px";
+      this._screenPositionX = `${Math.floor(screenPosition.x + 0.25)}px`;
+      this._screenPositionY = `${Math.floor(screenPosition.y + 0.25)}px`;
     }
   }
 };

--- a/Source/Widgets/SvgPathBindingHandler.js
+++ b/Source/Widgets/SvgPathBindingHandler.js
@@ -54,12 +54,12 @@ const SvgPathBindingHandler = {
 
             svg.setAttribute("width", pathWidth);
             svg.setAttribute("height", pathHeight);
-            svg.setAttribute("viewBox", "0 0 " + pathWidth + " " + pathHeight);
+            svg.setAttribute("viewBox", `0 0 ${pathWidth} ${pathHeight}`);
 
             if (value.css) {
               svg.setAttribute(
                 "class",
-                svgClassName + " " + knockout.unwrap(value.css)
+                `${svgClassName} ${knockout.unwrap(value.css)}`
               );
             }
           },

--- a/Source/Widgets/Timeline/Timeline.js
+++ b/Source/Widgets/Timeline/Timeline.js
@@ -369,7 +369,7 @@ Timeline.prototype.zoomFrom = function (amount) {
 };
 
 function twoDigits(num) {
-  return num < 10 ? "0" + num.toString() : num.toString();
+  return num < 10 ? `0${num.toString()}` : num.toString();
 }
 
 /**
@@ -382,25 +382,16 @@ Timeline.prototype.makeLabel = function (time) {
   if (millisecond > 0 && this._timeBarSecondsSpan < 3600) {
     millisecondString = Math.floor(millisecond).toString();
     while (millisecondString.length < 3) {
-      millisecondString = "0" + millisecondString;
+      millisecondString = `0${millisecondString}`;
     }
-    millisecondString = "." + millisecondString;
+    millisecondString = `.${millisecondString}`;
   }
 
-  return (
-    timelineMonthNames[gregorian.month - 1] +
-    " " +
-    gregorian.day +
-    " " +
-    gregorian.year +
-    " " +
-    twoDigits(gregorian.hour) +
-    ":" +
-    twoDigits(gregorian.minute) +
-    ":" +
-    twoDigits(gregorian.second) +
-    millisecondString
-  );
+  return `${timelineMonthNames[gregorian.month - 1]} ${gregorian.day} ${
+    gregorian.year
+  } ${twoDigits(gregorian.hour)}:${twoDigits(gregorian.minute)}:${twoDigits(
+    gregorian.second
+  )}${millisecondString}`;
 };
 
 /**
@@ -425,7 +416,7 @@ Timeline.prototype._makeTics = function () {
   let tic;
   const widget = this;
 
-  this._needleEle.style.left = xPos.toString() + "px";
+  this._needleEle.style.left = `${xPos.toString()}px`;
 
   let tics = "";
 
@@ -622,10 +613,9 @@ Timeline.prototype._makeTics = function () {
       tic <= endTime;
       tic = getNextTic(tic, tinyTic)
     ) {
-      tics +=
-        '<span class="cesium-timeline-ticTiny" style="left: ' +
-        Math.round(timeBarWidth * getAlpha(tic)).toString() +
-        'px;"></span>';
+      tics += `<span class="cesium-timeline-ticTiny" style="left: ${Math.round(
+        timeBarWidth * getAlpha(tic)
+      ).toString()}px;"></span>`;
     }
   }
   if (timeBarWidth * (subTic / this._timeBarSecondsSpan) >= 3.0) {
@@ -634,10 +624,9 @@ Timeline.prototype._makeTics = function () {
       tic <= endTime;
       tic = getNextTic(tic, subTic)
     ) {
-      tics +=
-        '<span class="cesium-timeline-ticSub" style="left: ' +
-        Math.round(timeBarWidth * getAlpha(tic)).toString() +
-        'px;"></span>';
+      tics += `<span class="cesium-timeline-ticSub" style="left: ${Math.round(
+        timeBarWidth * getAlpha(tic)
+      ).toString()}px;"></span>`;
     }
   }
   if (timeBarWidth * (mainTic / this._timeBarSecondsSpan) >= 2.0) {
@@ -674,19 +663,10 @@ Timeline.prototype._makeTics = function () {
       if (labelLeft > lastTextLeft) {
         lastTextLeft = labelLeft + textWidth + 5;
         tics +=
-          '<span class="cesium-timeline-ticMain" style="left: ' +
-          ticLeft.toString() +
-          'px;"></span>' +
-          '<span class="cesium-timeline-ticLabel" style="left: ' +
-          labelLeft.toString() +
-          'px;">' +
-          ticLabel +
-          "</span>";
+          `<span class="cesium-timeline-ticMain" style="left: ${ticLeft.toString()}px;"></span>` +
+          `<span class="cesium-timeline-ticLabel" style="left: ${labelLeft.toString()}px;">${ticLabel}</span>`;
       } else {
-        tics +=
-          '<span class="cesium-timeline-ticSub" style="left: ' +
-          ticLeft.toString() +
-          'px;"></span>';
+        tics += `<span class="cesium-timeline-ticSub" style="left: ${ticLeft.toString()}px;"></span>`;
       }
       tic = getNextTic(tic, mainTic);
     }
@@ -694,10 +674,7 @@ Timeline.prototype._makeTics = function () {
     this._mainTicSpan = -1;
   }
 
-  tics +=
-    '<span class="cesium-timeline-icon16" style="left:' +
-    scrubX +
-    'px;bottom:0;background-position: 0 0;"></span>';
+  tics += `<span class="cesium-timeline-icon16" style="left:${scrubX}px;bottom:0;background-position: 0 0;"></span>`;
   timeBar.innerHTML = tics;
   this._scrubElement = timeBar.lastChild;
 
@@ -734,8 +711,8 @@ Timeline.prototype.updateFromClock = function () {
     if (this._lastXPos !== xPos) {
       this._lastXPos = xPos;
 
-      scrubElement.style.left = xPos - 8 + "px";
-      this._needleEle.style.left = xPos + "px";
+      scrubElement.style.left = `${xPos - 8}px`;
+      this._needleEle.style.left = `${xPos}px`;
     }
   }
   if (defined(this._timelineDragLocation)) {
@@ -771,8 +748,8 @@ Timeline.prototype._setTimeBarTime = function (xPos, seconds) {
   );
   if (this._scrubElement) {
     const scrubX = xPos - 8;
-    this._scrubElement.style.left = scrubX.toString() + "px";
-    this._needleEle.style.left = xPos.toString() + "px";
+    this._scrubElement.style.left = `${scrubX.toString()}px`;
+    this._needleEle.style.left = `${xPos.toString()}px`;
   }
 
   const evt = document.createEvent("Event");
@@ -1015,13 +992,13 @@ Timeline.prototype.resize = function () {
     return;
   }
 
-  this._trackContainer.style.height = height + "px";
+  this._trackContainer.style.height = `${height}px`;
 
   let trackListHeight = 1;
   this._trackList.forEach(function (track) {
     trackListHeight += track.height;
   });
-  this._trackListEle.style.height = trackListHeight.toString() + "px";
+  this._trackListEle.style.height = `${trackListHeight.toString()}px`;
   this._trackListEle.width = this._trackListEle.clientWidth;
   this._trackListEle.height = trackListHeight;
   this._makeTics();

--- a/Source/Widgets/Timeline/TimelineHighlightRange.js
+++ b/Source/Widgets/Timeline/TimelineHighlightRange.js
@@ -57,18 +57,9 @@ TimelineHighlightRange.prototype.render = function (renderState) {
       highlightWidth = renderState.timeBarWidth - highlightLeft;
     }
     if (highlightWidth > 0) {
-      range =
-        '<span class="cesium-timeline-highlight" style="left: ' +
-        highlightLeft.toString() +
-        "px; width: " +
-        highlightWidth.toString() +
-        "px; bottom: " +
-        this._base.toString() +
-        "px; height: " +
-        this._height +
-        "px; background-color: " +
-        this._color +
-        ';"></span>';
+      range = `<span class="cesium-timeline-highlight" style="left: ${highlightLeft.toString()}px; width: ${highlightWidth.toString()}px; bottom: ${this._base.toString()}px; height: ${
+        this._height
+      }px; background-color: ${this._color};"></span>`;
     }
   }
   return range;

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -63,15 +63,12 @@ function getCesium3DTileFeatureDescription(feature) {
   propertyNames.forEach(function (propertyName) {
     const value = feature.getProperty(propertyName);
     if (defined(value)) {
-      html += "<tr><th>" + propertyName + "</th><td>" + value + "</td></tr>";
+      html += `<tr><th>${propertyName}</th><td>${value}</td></tr>`;
     }
   });
 
   if (html.length > 0) {
-    html =
-      '<table class="cesium-infoBox-defaultTable"><tbody>' +
-      html +
-      "</tbody></table>";
+    html = `<table class="cesium-infoBox-defaultTable"><tbody>${html}</tbody></table>`;
   }
 
   return html;
@@ -285,7 +282,7 @@ function enableVRUI(viewer, enabled) {
       enabled || !defined(fullscreenButton)
         ? 0
         : fullscreenButton.container.clientWidth;
-    viewer._vrButton.container.style.right = right + "px";
+    viewer._vrButton.container.style.right = `${right}px`;
 
     viewer.forceResize();
   }
@@ -763,8 +760,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
           ? "block"
           : "none";
         if (defined(timeline)) {
-          timeline.container.style.right =
-            fullscreenContainer.clientWidth + "px";
+          timeline.container.style.right = `${fullscreenContainer.clientWidth}px`;
           timeline.resize();
         }
       }
@@ -787,10 +783,10 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
       function (isVREnabled) {
         vrContainer.style.display = isVREnabled ? "block" : "none";
         if (defined(fullscreenButton)) {
-          vrContainer.style.right = fullscreenContainer.clientWidth + "px";
+          vrContainer.style.right = `${fullscreenContainer.clientWidth}px`;
         }
         if (defined(timeline)) {
-          timeline.container.style.right = vrContainer.clientWidth + "px";
+          timeline.container.style.right = `${vrContainer.clientWidth}px`;
           timeline.resize();
         }
       }
@@ -1568,12 +1564,12 @@ Viewer.prototype.resize = function () {
   const baseLayerPickerDropDown = this._baseLayerPickerDropDown;
 
   if (defined(baseLayerPickerDropDown)) {
-    baseLayerPickerDropDown.style.maxHeight = panelMaxHeight + "px";
+    baseLayerPickerDropDown.style.maxHeight = `${panelMaxHeight}px`;
   }
 
   if (defined(this._geocoder)) {
     const geocoderSuggestions = this._geocoder.searchSuggestionsContainer;
-    geocoderSuggestions.style.maxHeight = panelMaxHeight + "px";
+    geocoderSuggestions.style.maxHeight = `${panelMaxHeight}px`;
   }
 
   if (defined(this._infoBox)) {
@@ -1627,7 +1623,7 @@ Viewer.prototype.resize = function () {
     const timelineStyle = timelineContainer.style;
 
     creditBottom = timelineContainer.clientHeight + 3;
-    timelineStyle.left = animationWidth + "px";
+    timelineStyle.left = `${animationWidth}px`;
 
     let pixels = 0;
     if (defined(fullscreenButton)) {
@@ -1637,12 +1633,12 @@ Viewer.prototype.resize = function () {
       pixels += vrButton.container.clientWidth;
     }
 
-    timelineStyle.right = pixels + "px";
+    timelineStyle.right = `${pixels}px`;
     timeline.resize();
   }
 
-  this._bottomContainer.style.left = creditLeft + "px";
-  this._bottomContainer.style.bottom = creditBottom + "px";
+  this._bottomContainer.style.left = `${creditLeft}px`;
+  this._bottomContainer.style.bottom = `${creditBottom}px`;
 
   this._lastWidth = width;
   this._lastHeight = height;

--- a/Source/Widgets/Viewer/viewerDragDropMixin.js
+++ b/Source/Widgets/Viewer/viewerDragDropMixin.js
@@ -276,7 +276,7 @@ function createOnLoadCallback(viewer, file, proxy, clampToGround) {
         viewer.dropError.raiseEvent(
           viewer,
           fileName,
-          "Unrecognized file: " + fileName
+          `Unrecognized file: ${fileName}`
         );
         return;
       }

--- a/Source/Widgets/getElement.js
+++ b/Source/Widgets/getElement.js
@@ -14,7 +14,7 @@ function getElement(element) {
     //>>includeStart('debug', pragmas.debug);
     if (foundElement === null) {
       throw new DeveloperError(
-        'Element with id "' + element + '" does not exist in the document.'
+        `Element with id "${element}" does not exist in the document.`
       );
     }
     //>>includeEnd('debug');

--- a/Source/WorkersES6/createGeometry.js
+++ b/Source/WorkersES6/createGeometry.js
@@ -11,11 +11,11 @@ function getModule(moduleName) {
   if (!defined(module)) {
     if (typeof exports === "object") {
       // Use CommonJS-style require.
-      moduleCache[module] = module = require("Workers/" + moduleName);
+      moduleCache[module] = module = require(`Workers/${moduleName}`);
     } else {
       // Use AMD-style require.
       // in web workers, require is synchronous
-      require(["Workers/" + moduleName], function (f) {
+      require([`Workers/${moduleName}`], function (f) {
         module = f;
         moduleCache[module] = f;
       });

--- a/Source/WorkersES6/createTaskProcessorWorker.js
+++ b/Source/WorkersES6/createTaskProcessorWorker.js
@@ -88,11 +88,9 @@ function createTaskProcessorWorker(workerFunction) {
           // something went wrong trying to post the message, post a simpler
           // error that we can be sure will be cloneable
           responseMessage.result = undefined;
-          responseMessage.error =
-            "postMessage failed with error: " +
-            formatError(e) +
-            "\n  with responseMessage: " +
-            JSON.stringify(responseMessage);
+          responseMessage.error = `postMessage failed with error: ${formatError(
+            e
+          )}\n  with responseMessage: ${JSON.stringify(responseMessage)}`;
           postMessage(responseMessage);
         }
       });

--- a/Source/WorkersES6/decodeDraco.js
+++ b/Source/WorkersES6/decodeDraco.js
@@ -242,7 +242,7 @@ function decodePointCloud(parameters) {
   );
   if (!decodingStatus.ok() || dracoPointCloud.ptr === 0) {
     throw new RuntimeError(
-      "Error decoding draco point cloud: " + decodingStatus.error_msg()
+      `Error decoding draco point cloud: ${decodingStatus.error_msg()}`
     );
   }
 
@@ -318,7 +318,7 @@ function decodePrimitive(parameters) {
   const decodingStatus = dracoDecoder.DecodeBufferToMesh(buffer, dracoGeometry);
   if (!decodingStatus.ok() || dracoGeometry.ptr === 0) {
     throw new RuntimeError(
-      "Error decoding draco mesh geometry: " + decodingStatus.error_msg()
+      `Error decoding draco mesh geometry: ${decodingStatus.error_msg()}`
     );
   }
 

--- a/Specs/.eslintrc.json
+++ b/Specs/.eslintrc.json
@@ -5,7 +5,8 @@
     },
     "rules": {
         "no-self-assign": "off",
-        "es/no-block-scoped-variables": "off"
+        "es/no-block-scoped-variables": "off",
+        "es/no-template-literals": "off"
     },
     "overrides": [
         {

--- a/Specs/BadGeometry.js
+++ b/Specs/BadGeometry.js
@@ -12,7 +12,7 @@ function BadGeometry() {
   ) {
     const parameters = queryToObject(window.location.search.substring(1));
     if (parameters.built) {
-      this._workerName = "../" + this._workerName;
+      this._workerName = `../${this._workerName}`;
     }
   }
 }

--- a/Specs/Core/DeveloperErrorSpec.js
+++ b/Specs/Core/DeveloperErrorSpec.js
@@ -28,7 +28,7 @@ describe("Core/DeveloperError", function () {
   it("has a working toString", function () {
     const str = new DeveloperError(testMessage).toString();
 
-    expect(str).toContain(name + ": " + testMessage);
+    expect(str).toContain(`${name}: ${testMessage}`);
 
     if (window.specsUsingRelease) {
       expect(str).toContain("Specs.js");

--- a/Specs/Core/FeatureDetectionSpec.js
+++ b/Specs/Core/FeatureDetectionSpec.js
@@ -52,7 +52,7 @@ describe("Core/FeatureDetection", function () {
       const chromeVersion = FeatureDetection.chromeVersion();
       checkVersionArray(chromeVersion);
 
-      console.log("detected Chrome " + chromeVersion.join("."));
+      console.log(`detected Chrome ${chromeVersion.join(".")}`);
     }
   });
 
@@ -64,7 +64,7 @@ describe("Core/FeatureDetection", function () {
       const safariVersion = FeatureDetection.safariVersion();
       checkVersionArray(safariVersion);
 
-      console.log("detected Safari " + safariVersion.join("."));
+      console.log(`detected Safari ${safariVersion.join(".")}`);
     }
   });
 
@@ -78,9 +78,9 @@ describe("Core/FeatureDetection", function () {
       expect(typeof webkitVersion.isNightly).toEqual("boolean");
 
       console.log(
-        "detected Webkit " +
-          webkitVersion.join(".") +
-          (webkitVersion.isNightly ? " (Nightly)" : "")
+        `detected Webkit ${webkitVersion.join(".")}${
+          webkitVersion.isNightly ? " (Nightly)" : ""
+        }`
       );
     }
   });
@@ -94,7 +94,7 @@ describe("Core/FeatureDetection", function () {
       checkVersionArray(internetExplorerVersion);
 
       console.log(
-        "detected Internet Explorer " + internetExplorerVersion.join(".")
+        `detected Internet Explorer ${internetExplorerVersion.join(".")}`
       );
     }
   });
@@ -107,7 +107,7 @@ describe("Core/FeatureDetection", function () {
       const edgeVersion = FeatureDetection.edgeVersion();
       checkVersionArray(edgeVersion);
 
-      console.log("detected Edge " + edgeVersion.join("."));
+      console.log(`detected Edge ${edgeVersion.join(".")}`);
     }
   });
 
@@ -120,7 +120,7 @@ describe("Core/FeatureDetection", function () {
 
       checkVersionArray(firefoxVersion);
 
-      console.log("detected Firefox " + firefoxVersion.join("."));
+      console.log(`detected Firefox ${firefoxVersion.join(".")}`);
     }
   });
 

--- a/Specs/Core/FullscreenSpec.js
+++ b/Specs/Core/FullscreenSpec.js
@@ -55,7 +55,7 @@ describe("Core/Fullscreen", function () {
     it("can get the fullscreen change event name", function () {
       if (Fullscreen.supportsFullscreen()) {
         // the property on the document is the event name, prefixed with 'on'.
-        expect(document["on" + Fullscreen.changeEventName]).toBeDefined();
+        expect(document[`on${Fullscreen.changeEventName}`]).toBeDefined();
       } else {
         expect(Fullscreen.changeEventName).toBeUndefined();
       }
@@ -64,7 +64,7 @@ describe("Core/Fullscreen", function () {
     it("can get the fullscreen error event name", function () {
       if (Fullscreen.supportsFullscreen()) {
         // the property on the document is the event name, prefixed with 'on'.
-        expect(document["on" + Fullscreen.errorEventName]).toBeDefined();
+        expect(document[`on${Fullscreen.errorEventName}`]).toBeDefined();
       } else {
         expect(Fullscreen.errorEventName).toBeUndefined();
       }

--- a/Specs/Core/GoogleEarthEnterpriseMetadataSpec.js
+++ b/Specs/Core/GoogleEarthEnterpriseMetadataSpec.js
@@ -181,10 +181,10 @@ describe("Core/GoogleEarthEnterpriseMetadata", function () {
     ) {
       expect(responseType).toEqual("arraybuffer");
       if (req === 0) {
-        expect(url).toEqual(baseurl + "dbRoot.v5?output=proto");
+        expect(url).toEqual(`${baseurl}dbRoot.v5?output=proto`);
         deferred.reject(); // Reject dbRoot request and use defaults
       } else {
-        expect(url).toEqual(baseurl + "flatfile?q2-0-q.1");
+        expect(url).toEqual(`${baseurl}flatfile?q2-0-q.1`);
         Resource._DefaultImplementations.loadWithXhr(
           "Data/GoogleEarthEnterprise/gee.metadata",
           responseType,
@@ -240,10 +240,10 @@ describe("Core/GoogleEarthEnterpriseMetadata", function () {
     ) {
       expect(responseType).toEqual("arraybuffer");
       if (req === 0) {
-        expect(url).toEqual(baseurl + "dbRoot.v5?output=proto");
+        expect(url).toEqual(`${baseurl}dbRoot.v5?output=proto`);
         deferred.reject(); // Reject dbRoot request and use defaults
       } else {
-        expect(url).toEqual(baseurl + "flatfile?q2-0-q.1");
+        expect(url).toEqual(`${baseurl}flatfile?q2-0-q.1`);
         Resource._DefaultImplementations.loadWithXhr(
           "Data/GoogleEarthEnterprise/gee.metadata",
           responseType,

--- a/Specs/Core/GoogleEarthEnterpriseTerrainProviderSpec.js
+++ b/Specs/Core/GoogleEarthEnterpriseTerrainProviderSpec.js
@@ -22,19 +22,19 @@ describe("Core/GoogleEarthEnterpriseTerrainProvider", function () {
       quadKey = defaultValue(quadKey, "");
       let t = new GoogleEarthEnterpriseTileInformation(0xff, 1, 1, 1);
       t.ancestorHasTerrain = true;
-      this._tileInfo[quadKey + "0"] = t;
+      this._tileInfo[`${quadKey}0`] = t;
 
       t = new GoogleEarthEnterpriseTileInformation(0xff, 1, 1, 1);
       t.ancestorHasTerrain = true;
-      this._tileInfo[quadKey + "1"] = t;
+      this._tileInfo[`${quadKey}1`] = t;
 
       t = new GoogleEarthEnterpriseTileInformation(0xff, 1, 1, 1);
       t.ancestorHasTerrain = true;
-      this._tileInfo[quadKey + "2"] = t;
+      this._tileInfo[`${quadKey}2`] = t;
 
       t = new GoogleEarthEnterpriseTileInformation(0xff, 1, 1, 1);
       t.ancestorHasTerrain = true;
-      this._tileInfo[quadKey + "3"] = t;
+      this._tileInfo[`${quadKey}3`] = t;
 
       return when();
     });

--- a/Specs/Core/IonResourceSpec.js
+++ b/Specs/Core/IonResourceSpec.js
@@ -9,7 +9,7 @@ describe("Core/IonResource", function () {
   const assetId = 123890213;
   const endpoint = {
     type: "3DTILES",
-    url: "https://assets.cesium.com/" + assetId + "/tileset.json",
+    url: `https://assets.cesium.com/${assetId}/tileset.json`,
     accessToken: "not_really_a_refresh_token",
     attributions: [],
   };
@@ -54,7 +54,7 @@ describe("Core/IonResource", function () {
     const tilesAssetId = 123890213;
     const tilesEndpoint = {
       type: "3DTILES",
-      url: "https://assets.cesium.com/" + tilesAssetId + "/tileset.json",
+      url: `https://assets.cesium.com/${tilesAssetId}/tileset.json`,
       accessToken: "not_really_a_refresh_token",
       attributions: [],
     };
@@ -135,11 +135,7 @@ describe("Core/IonResource", function () {
     const assetId = 2348234;
     const resource = IonResource._createEndpointResource(assetId);
     expect(resource.url).toBe(
-      Ion.defaultServer.url +
-        "v1/assets/" +
-        assetId +
-        "/endpoint?access_token=" +
-        Ion.defaultAccessToken
+      `${Ion.defaultServer.url}v1/assets/${assetId}/endpoint?access_token=${Ion.defaultAccessToken}`
     );
   });
 
@@ -153,11 +149,7 @@ describe("Core/IonResource", function () {
       accessToken: accessToken,
     });
     expect(resource.url).toBe(
-      serverUrl +
-        "v1/assets/" +
-        assetId +
-        "/endpoint?access_token=" +
-        accessToken
+      `${serverUrl}v1/assets/${assetId}/endpoint?access_token=${accessToken}`
     );
   });
 
@@ -171,11 +163,7 @@ describe("Core/IonResource", function () {
     const assetId = 2348234;
     const resource = IonResource._createEndpointResource(assetId);
     expect(resource.url).toBe(
-      Ion.defaultServer.url +
-        "v1/assets/" +
-        assetId +
-        "/endpoint?access_token=" +
-        Ion.defaultAccessToken
+      `${Ion.defaultServer.url}v1/assets/${assetId}/endpoint?access_token=${Ion.defaultAccessToken}`
     );
 
     Ion.defaultServer = defaultServer;
@@ -186,7 +174,7 @@ describe("Core/IonResource", function () {
     const originalOptions = {};
     const expectedOptions = {
       headers: {
-        Authorization: "Bearer " + endpoint.accessToken,
+        Authorization: `Bearer ${endpoint.accessToken}`,
       },
     };
 
@@ -201,7 +189,7 @@ describe("Core/IonResource", function () {
     const originalOptions = {};
     const expectedOptions = {
       headers: {
-        Authorization: "Bearer " + endpoint.accessToken,
+        Authorization: `Bearer ${endpoint.accessToken}`,
       },
     };
 
@@ -310,7 +298,7 @@ describe("Core/IonResource", function () {
 
       const newEndpoint = {
         type: "3DTILES",
-        url: "https://assets.cesium.com/" + assetId,
+        url: `https://assets.cesium.com/${assetId}`,
         accessToken: "not_not_really_a_refresh_token",
       };
 

--- a/Specs/Core/ResourceSpec.js
+++ b/Specs/Core/ResourceSpec.js
@@ -1171,7 +1171,7 @@ describe("Core/Resource", function () {
     let headerString = "";
     for (const key in expectedResult) {
       if (expectedResult.hasOwnProperty(key)) {
-        headerString += key + ": " + expectedResult[key] + "\r\n";
+        headerString += `${key}: ${expectedResult[key]}\r\n`;
       }
     }
     const fakeXHR = {
@@ -1255,7 +1255,7 @@ describe("Core/Resource", function () {
     let headerString = "";
     for (const key in expectedResult) {
       if (expectedResult.hasOwnProperty(key)) {
-        headerString += key + ": " + expectedResult[key] + "\r\n";
+        headerString += `${key}: ${expectedResult[key]}\r\n`;
       }
     }
     const fakeXHR = {

--- a/Specs/Core/RuntimeErrorSpec.js
+++ b/Specs/Core/RuntimeErrorSpec.js
@@ -28,7 +28,7 @@ describe("Core/RuntimeError", function () {
   it("has a working toString", function () {
     const str = new RuntimeError(testMessage).toString();
 
-    expect(str).toContain(name + ": " + testMessage);
+    expect(str).toContain(`${name}: ${testMessage}`);
 
     if (window.specsUsingRelease) {
       expect(str).toContain("Specs.js");

--- a/Specs/Core/ScreenSpaceEventHandlerSpec.js
+++ b/Specs/Core/ScreenSpaceEventHandlerSpec.js
@@ -133,10 +133,12 @@ describe("Core/ScreenSpaceEventHandler", function () {
   }
 
   function createMouseSpec(specFunction, eventType, button, modifier) {
-    let specName = keyForValue(ScreenSpaceEventType, eventType) + " action";
+    let specName = `${keyForValue(ScreenSpaceEventType, eventType)} action`;
     if (defined(modifier)) {
-      specName +=
-        " with " + keyForValue(KeyboardEventModifier, modifier) + " modifier";
+      specName += ` with ${keyForValue(
+        KeyboardEventModifier,
+        modifier
+      )} modifier`;
     }
     it(specName, function () {
       const eventOptions = {

--- a/Specs/Core/TimeIntervalCollectionSpec.js
+++ b/Specs/Core/TimeIntervalCollectionSpec.js
@@ -957,39 +957,24 @@ describe("Core/TimeIntervalCollection", function () {
           // expect the interval at this time not to exist
           if (interval !== undefined) {
             throw new Error(
-              "expected undefined at " +
-                item.sec +
-                " seconds but it was " +
-                interval.data
+              `expected undefined at ${item.sec} seconds but it was ${interval.data}`
             );
           }
           expect(interval).toBeUndefined();
         } else if (interval === undefined) {
           throw new Error(
-            "expected " +
-              item.data +
-              " at " +
-              item.sec +
-              " seconds, but it was undefined"
+            `expected ${item.data} at ${item.sec} seconds, but it was undefined`
           );
         } else if (interval.data !== item.data) {
           throw new Error(
-            "expected " +
-              item.data +
-              " at " +
-              item.sec +
-              " seconds, but it was " +
-              interval.data
+            `expected ${item.data} at ${item.sec} seconds, but it was ${interval.data}`
           );
         }
       });
 
       if (collection.length !== count) {
         throw new Error(
-          "Expected interval to have " +
-            count +
-            " elements but it had " +
-            collection.length
+          `Expected interval to have ${count} elements but it had ${collection.length}`
         );
       }
     }
@@ -1592,7 +1577,7 @@ describe("Core/TimeIntervalCollection", function () {
     const julianDates = iso8601ToJulianDateArray([start, stop]);
 
     const intervals = TimeIntervalCollection.fromIso8601({
-      iso8601: start + "/" + stop,
+      iso8601: `${start}/${stop}`,
       isStartIncluded: false,
       isStopIncluded: false,
     });
@@ -1610,8 +1595,9 @@ describe("Core/TimeIntervalCollection", function () {
     const julianDates = iso8601ToJulianDateArray(iso8601Dates);
 
     const intervals = TimeIntervalCollection.fromIso8601({
-      iso8601:
-        iso8601Dates[0] + "/" + iso8601Dates[iso8601Dates.length - 1] + "/P1Y",
+      iso8601: `${iso8601Dates[0]}/${
+        iso8601Dates[iso8601Dates.length - 1]
+      }/P1Y`,
     });
 
     checkIntervals(intervals, julianDates, true, true);
@@ -1628,8 +1614,9 @@ describe("Core/TimeIntervalCollection", function () {
     const julianDates = iso8601ToJulianDateArray(iso8601Dates);
 
     const intervals = TimeIntervalCollection.fromIso8601({
-      iso8601:
-        iso8601Dates[0] + "/" + iso8601Dates[iso8601Dates.length - 1] + "/P1M",
+      iso8601: `${iso8601Dates[0]}/${
+        iso8601Dates[iso8601Dates.length - 1]
+      }/P1M`,
     });
 
     checkIntervals(intervals, julianDates, true, true);
@@ -1647,8 +1634,9 @@ describe("Core/TimeIntervalCollection", function () {
     const julianDates = iso8601ToJulianDateArray(iso8601Dates);
 
     const intervals = TimeIntervalCollection.fromIso8601({
-      iso8601:
-        iso8601Dates[0] + "/" + iso8601Dates[iso8601Dates.length - 1] + "/P1D",
+      iso8601: `${iso8601Dates[0]}/${
+        iso8601Dates[iso8601Dates.length - 1]
+      }/P1D`,
       isStartIncluded: false,
     });
 
@@ -1665,11 +1653,9 @@ describe("Core/TimeIntervalCollection", function () {
     const julianDates = iso8601ToJulianDateArray(iso8601Dates);
 
     const intervals = TimeIntervalCollection.fromIso8601({
-      iso8601:
-        iso8601Dates[0] +
-        "/" +
-        iso8601Dates[iso8601Dates.length - 1] +
-        "/P1Y2M3D",
+      iso8601: `${iso8601Dates[0]}/${
+        iso8601Dates[iso8601Dates.length - 1]
+      }/P1Y2M3D`,
       isStopIncluded: false,
     });
 
@@ -1686,8 +1672,9 @@ describe("Core/TimeIntervalCollection", function () {
     const julianDates = iso8601ToJulianDateArray(iso8601Dates);
 
     const intervals = TimeIntervalCollection.fromIso8601({
-      iso8601:
-        iso8601Dates[0] + "/" + iso8601Dates[iso8601Dates.length - 1] + "/PT1H",
+      iso8601: `${iso8601Dates[0]}/${
+        iso8601Dates[iso8601Dates.length - 1]
+      }/PT1H`,
       isStartIncluded: false,
     });
 
@@ -1704,8 +1691,9 @@ describe("Core/TimeIntervalCollection", function () {
     const julianDates = iso8601ToJulianDateArray(iso8601Dates);
 
     const intervals = TimeIntervalCollection.fromIso8601({
-      iso8601:
-        iso8601Dates[0] + "/" + iso8601Dates[iso8601Dates.length - 1] + "/PT1M",
+      iso8601: `${iso8601Dates[0]}/${
+        iso8601Dates[iso8601Dates.length - 1]
+      }/PT1M`,
       isStopIncluded: false,
     });
 
@@ -1722,8 +1710,9 @@ describe("Core/TimeIntervalCollection", function () {
     const julianDates = iso8601ToJulianDateArray(iso8601Dates);
 
     const intervals = TimeIntervalCollection.fromIso8601({
-      iso8601:
-        iso8601Dates[0] + "/" + iso8601Dates[iso8601Dates.length - 1] + "/PT1S",
+      iso8601: `${iso8601Dates[0]}/${
+        iso8601Dates[iso8601Dates.length - 1]
+      }/PT1S`,
       isStartIncluded: false,
       isStopIncluded: false,
     });
@@ -1742,11 +1731,9 @@ describe("Core/TimeIntervalCollection", function () {
     const julianDates = iso8601ToJulianDateArray(iso8601Dates);
 
     const intervals = TimeIntervalCollection.fromIso8601({
-      iso8601:
-        iso8601Dates[0] +
-        "/" +
-        iso8601Dates[iso8601Dates.length - 1] +
-        "/PT0.5S",
+      iso8601: `${iso8601Dates[0]}/${
+        iso8601Dates[iso8601Dates.length - 1]
+      }/PT0.5S`,
     });
 
     checkIntervals(intervals, julianDates, true, true);
@@ -1762,11 +1749,9 @@ describe("Core/TimeIntervalCollection", function () {
     const julianDates = iso8601ToJulianDateArray(iso8601Dates);
 
     const intervals = TimeIntervalCollection.fromIso8601({
-      iso8601:
-        iso8601Dates[0] +
-        "/" +
-        iso8601Dates[iso8601Dates.length - 1] +
-        "/PT1H2M3.5S",
+      iso8601: `${iso8601Dates[0]}/${
+        iso8601Dates[iso8601Dates.length - 1]
+      }/PT1H2M3.5S`,
     });
 
     checkIntervals(intervals, julianDates, true, true);
@@ -1782,11 +1767,9 @@ describe("Core/TimeIntervalCollection", function () {
     const julianDates = iso8601ToJulianDateArray(iso8601Dates);
 
     const intervals = TimeIntervalCollection.fromIso8601({
-      iso8601:
-        iso8601Dates[0] +
-        "/" +
-        iso8601Dates[iso8601Dates.length - 1] +
-        "/P1Y2M3DT1H2M3.5S",
+      iso8601: `${iso8601Dates[0]}/${
+        iso8601Dates[iso8601Dates.length - 1]
+      }/P1Y2M3DT1H2M3.5S`,
     });
 
     checkIntervals(intervals, julianDates, true, true);
@@ -1802,11 +1785,9 @@ describe("Core/TimeIntervalCollection", function () {
     const julianDates = iso8601ToJulianDateArray(iso8601Dates);
 
     const intervals = TimeIntervalCollection.fromIso8601({
-      iso8601:
-        iso8601Dates[0] +
-        "/" +
-        iso8601Dates[iso8601Dates.length - 1] +
-        "/0001-02-03T01:02:03.5",
+      iso8601: `${iso8601Dates[0]}/${
+        iso8601Dates[iso8601Dates.length - 1]
+      }/0001-02-03T01:02:03.5`,
     });
 
     checkIntervals(intervals, julianDates, true, true);
@@ -1830,11 +1811,9 @@ describe("Core/TimeIntervalCollection", function () {
     const julianDates = iso8601ToJulianDateArray(iso8601Dates);
 
     const intervals = TimeIntervalCollection.fromIso8601({
-      iso8601:
-        iso8601Dates[0] +
-        "/" +
-        iso8601Dates[iso8601Dates.length - 1] +
-        "/P1Y2M3DT1H2M3.5S",
+      iso8601: `${iso8601Dates[0]}/${
+        iso8601Dates[iso8601Dates.length - 1]
+      }/P1Y2M3DT1H2M3.5S`,
       dataCallback: dataSpy,
     });
 
@@ -1857,8 +1836,9 @@ describe("Core/TimeIntervalCollection", function () {
     const julianDates = iso8601ToJulianDateArray(iso8601Dates);
 
     const intervals = TimeIntervalCollection.fromIso8601({
-      iso8601:
-        iso8601Dates[0] + "/" + iso8601Dates[iso8601Dates.length - 1] + "/PT1M",
+      iso8601: `${iso8601Dates[0]}/${
+        iso8601Dates[iso8601Dates.length - 1]
+      }/PT1M`,
       isStartIncluded: true,
       isStopIncluded: false,
       leadingInterval: true,
@@ -1892,8 +1872,9 @@ describe("Core/TimeIntervalCollection", function () {
     const julianDates = iso8601ToJulianDateArray(iso8601Dates);
 
     const intervals = TimeIntervalCollection.fromIso8601({
-      iso8601:
-        iso8601Dates[0] + "/" + iso8601Dates[iso8601Dates.length - 1] + "/PT1M",
+      iso8601: `${iso8601Dates[0]}/${
+        iso8601Dates[iso8601Dates.length - 1]
+      }/PT1M`,
       isStartIncluded: false,
       isStopIncluded: true,
       trailingInterval: true,
@@ -1929,8 +1910,9 @@ describe("Core/TimeIntervalCollection", function () {
     const julianDates = iso8601ToJulianDateArray(iso8601Dates);
 
     const intervals = TimeIntervalCollection.fromIso8601({
-      iso8601:
-        iso8601Dates[0] + "/" + iso8601Dates[iso8601Dates.length - 1] + "/PT1M",
+      iso8601: `${iso8601Dates[0]}/${
+        iso8601Dates[iso8601Dates.length - 1]
+      }/PT1M`,
       isStartIncluded: false,
       isStopIncluded: false,
       leadingInterval: true,

--- a/Specs/Core/getAbsoluteUriSpec.js
+++ b/Specs/Core/getAbsoluteUriSpec.js
@@ -12,7 +12,7 @@ describe("Core/getAbsoluteUri", function () {
     expect(result).toEqual("http://test.com/awesome.png");
 
     result = getAbsoluteUri("awesome.png");
-    expect(result).toEqual(getBaseUri(document.location.href) + "awesome.png");
+    expect(result).toEqual(`${getBaseUri(document.location.href)}awesome.png`);
   });
 
   it("document.baseURI is respected", function () {

--- a/Specs/Core/isCrossOriginUrlSpec.js
+++ b/Specs/Core/isCrossOriginUrlSpec.js
@@ -30,7 +30,7 @@ describe("Core/isCrossOriginUrl", function () {
 
     // so does a different port
     pageUri = new Uri(location.href);
-    pageUri.authority(location.hostname + ":" + (+location.port + 1));
+    pageUri.authority(`${location.hostname}:${+location.port + 1}`);
 
     absoluteUrl = pageUri.toString();
     expect(isCrossOriginUrl(absoluteUrl)).toEqual(true);

--- a/Specs/Core/isDataUriSpec.js
+++ b/Specs/Core/isDataUriSpec.js
@@ -12,7 +12,7 @@ describe("Core/isDataUri", function () {
   });
 
   it("Determines that a uri is a data uri", function () {
-    const uri = "data:text/plain;base64," + btoa("a data uri");
+    const uri = `data:text/plain;base64,${btoa("a data uri")}`;
     expect(isDataUri(uri)).toEqual(true);
   });
 });

--- a/Specs/Core/sampleTerrainSpec.js
+++ b/Specs/Core/sampleTerrainSpec.js
@@ -189,10 +189,9 @@ describe("Core/sampleTerrain", function () {
         // it's a whitelist - meaning you have to proxy every request explicitly
         if (!defined(proxiedUrl)) {
           throw new Error(
-            "Unexpected XHR load to url: " +
-              url +
-              "; spec includes: " +
-              availablePaths.join(", ")
+            `Unexpected XHR load to url: ${url}; spec includes: ${availablePaths.join(
+              ", "
+            )}`
           );
         }
 

--- a/Specs/DataSources/CompositeEntityCollectionSpec.js
+++ b/Specs/DataSources/CompositeEntityCollectionSpec.js
@@ -831,7 +831,7 @@ describe("DataSources/CompositeEntityCollection", function () {
 
     // Add a new object
     const newObject = new Entity({
-      id: id + "billboard",
+      id: `${id}billboard`,
     });
     collection1.add(newObject);
 

--- a/Specs/DataSources/ConstantPropertySpec.js
+++ b/Specs/DataSources/ConstantPropertySpec.js
@@ -13,7 +13,7 @@ describe("DataSources/ConstantProperty", function () {
     expect(property.valueOf()).toBe(expected);
     expect(property.toString()).toBe(expected.toString());
     expect(0 + property).toBe(expected);
-    expect("0" + property).toBe("0" + expected);
+    expect(`0${property}`).toBe(`0${expected}`);
   });
 
   it("works with objects", function () {
@@ -72,7 +72,7 @@ describe("DataSources/ConstantProperty", function () {
 
     expect(property.valueOf()).toBeUndefined();
     expect(0 + property).toBeNaN();
-    expect("0" + property).toBe("0" + "undefined");
+    expect(`0${property}`).toBe("0" + "undefined");
   });
 
   it('equals works for object types with "equals" function', function () {

--- a/Specs/DataSources/CzmlDataSourceSpec.js
+++ b/Specs/DataSources/CzmlDataSourceSpec.js
@@ -725,11 +725,11 @@ describe("DataSources/CzmlDataSource", function () {
       expect(
         imageProperty.getValue(JulianDate.fromIso8601("2013-01-01T00:00:00Z"))
           .url
-      ).toEqual(source + "image.png");
+      ).toEqual(`${source}image.png`);
       expect(
         imageProperty.getValue(JulianDate.fromIso8601("2013-01-01T01:00:00Z"))
           .url
-      ).toEqual(source + "image2.png");
+      ).toEqual(`${source}image2.png`);
     });
   });
 

--- a/Specs/DataSources/GeoJsonDataSourceSpec.js
+++ b/Specs/DataSources/GeoJsonDataSourceSpec.js
@@ -460,7 +460,7 @@ describe("DataSources/GeoJsonDataSource", function () {
       for (const key in properties) {
         if (properties.hasOwnProperty(key)) {
           const value = properties[key];
-          desc += key + " = " + value + ". ";
+          desc += `${key} = ${value}. `;
         }
       }
       return desc;
@@ -495,7 +495,7 @@ describe("DataSources/GeoJsonDataSource", function () {
       for (const key in properties) {
         if (properties.hasOwnProperty(key)) {
           const value = properties[key];
-          desc += key + " = " + value + "; ";
+          desc += `${key} = ${value}; `;
         }
       }
       return desc;
@@ -596,7 +596,7 @@ describe("DataSources/GeoJsonDataSource", function () {
       let entity = entityCollection.values[0];
       expect(entity.id).toEqual(featureWithId.id);
       entity = entityCollection.values[1];
-      expect(entity.id).toEqual(featureWithId.id + "_2");
+      expect(entity.id).toEqual(`${featureWithId.id}_2`);
     });
   });
 

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -1625,20 +1625,17 @@ describe("DataSources/KmlDataSource", function () {
   });
 
   it("Styles: Applies expected styles to Point geometry", function () {
-    const kml =
-      '<?xml version="1.0" encoding="UTF-8"?>\
+    const kml = `<?xml version="1.0" encoding="UTF-8"?>\
         <Document xmlns="http://www.opengis.net/kml/2.2"\
                   xmlns:gx="http://www.google.com/kml/ext/2.2">\
-          <Placemark>' +
-      uberStyle +
-      "\
+          <Placemark>${uberStyle}\
             <name>TheName</name>\
             <Point>\
               <altitudeMode>absolute</altitudeMode>\
               <coordinates>1,2,3</coordinates>\
             </Point>\
           </Placemark>\
-        </Document>";
+        </Document>`;
 
     return KmlDataSource.load(
       parser.parseFromString(kml, "text/xml"),
@@ -1662,13 +1659,10 @@ describe("DataSources/KmlDataSource", function () {
   });
 
   it("Styles: Applies expected styles to extruded Point geometry", function () {
-    const kml =
-      '<?xml version="1.0" encoding="UTF-8"?>\
+    const kml = `<?xml version="1.0" encoding="UTF-8"?>\
         <Document xmlns="http://www.opengis.net/kml/2.2"\
                   xmlns:gx="http://www.google.com/kml/ext/2.2">\
-          <Placemark>' +
-      uberStyle +
-      "\
+          <Placemark>${uberStyle}\
             <name>TheName</name>\
             <Point>\
               <extrude>1</extrude>\
@@ -1676,7 +1670,7 @@ describe("DataSources/KmlDataSource", function () {
               <coordinates>1,2,3</coordinates>\
             </Point>\
           </Placemark>\
-        </Document>";
+        </Document>`;
 
     return KmlDataSource.load(
       parser.parseFromString(kml, "text/xml"),
@@ -1701,13 +1695,10 @@ describe("DataSources/KmlDataSource", function () {
   });
 
   it("Styles: Applies expected styles to LineString geometry", function () {
-    const kml =
-      '<?xml version="1.0" encoding="UTF-8"?>\
+    const kml = `<?xml version="1.0" encoding="UTF-8"?>\
         <Document xmlns="http://www.opengis.net/kml/2.2"\
                   xmlns:gx="http://www.google.com/kml/ext/2.2">\
-          <Placemark>' +
-      uberStyle +
-      "\
+          <Placemark>${uberStyle}\
             <name>TheName</name>\
             <LineString>\
             <coordinates>1,2,3 \
@@ -1715,7 +1706,7 @@ describe("DataSources/KmlDataSource", function () {
             </coordinates>\
             </LineString>\
           </Placemark>\
-        </Document>";
+        </Document>`;
 
     return KmlDataSource.load(
       parser.parseFromString(kml, "text/xml"),
@@ -1732,13 +1723,10 @@ describe("DataSources/KmlDataSource", function () {
   });
 
   it("Styles: Applies expected styles to extruded LineString geometry", function () {
-    const kml =
-      '<?xml version="1.0" encoding="UTF-8"?>\
+    const kml = `<?xml version="1.0" encoding="UTF-8"?>\
         <Document xmlns="http://www.opengis.net/kml/2.2"\
                   xmlns:gx="http://www.google.com/kml/ext/2.2">\
-          <Placemark>' +
-      uberStyle +
-      "\
+          <Placemark>${uberStyle}\
             <name>TheName</name>\
             <LineString>\
             <extrude>1</extrude>\
@@ -1748,7 +1736,7 @@ describe("DataSources/KmlDataSource", function () {
             </coordinates>\
             </LineString>\
           </Placemark>\
-        </Document>";
+        </Document>`;
 
     return KmlDataSource.load(
       parser.parseFromString(kml, "text/xml"),
@@ -1769,13 +1757,10 @@ describe("DataSources/KmlDataSource", function () {
   });
 
   it("Styles: Applies expected styles to Polygon geometry", function () {
-    const kml =
-      '<?xml version="1.0" encoding="UTF-8"?>\
+    const kml = `<?xml version="1.0" encoding="UTF-8"?>\
         <Document xmlns="http://www.opengis.net/kml/2.2"\
                   xmlns:gx="http://www.google.com/kml/ext/2.2">\
-          <Placemark>' +
-      uberStyle +
-      "\
+          <Placemark>${uberStyle}\
           <Polygon>\
             <extrude>1</extrude>\
             <altitudeMode>absolute</altitudeMode>\
@@ -1790,7 +1775,7 @@ describe("DataSources/KmlDataSource", function () {
               </outerBoundaryIs>\
             </Polygon>\
             </Placemark>\
-        </Document>";
+        </Document>`;
 
     return KmlDataSource.load(
       parser.parseFromString(kml, "text/xml"),
@@ -1810,13 +1795,10 @@ describe("DataSources/KmlDataSource", function () {
   });
 
   it("Styles: Applies expected styles to gx:Track geometry", function () {
-    const kml =
-      '<?xml version="1.0" encoding="UTF-8"?>\
+    const kml = `<?xml version="1.0" encoding="UTF-8"?>\
         <Document xmlns="http://www.opengis.net/kml/2.2"\
                   xmlns:gx="http://www.google.com/kml/ext/2.2">\
-          <Placemark>' +
-      uberStyle +
-      "\
+          <Placemark>${uberStyle}\
             <name>TheName</name>\
             <gx:Track>\
               <altitudeMode>absolute</altitudeMode>\
@@ -1824,7 +1806,7 @@ describe("DataSources/KmlDataSource", function () {
             <gx:coord>7 8 9</gx:coord>\
           </gx:Track>\
           </Placemark>\
-        </Document>";
+        </Document>`;
 
     return KmlDataSource.load(
       parser.parseFromString(kml, "text/xml"),
@@ -1855,13 +1837,10 @@ describe("DataSources/KmlDataSource", function () {
   });
 
   it("Styles: Applies expected styles to extruded gx:Track geometry", function () {
-    const kml =
-      '<?xml version="1.0" encoding="UTF-8"?>\
+    const kml = `<?xml version="1.0" encoding="UTF-8"?>\
         <Document xmlns="http://www.opengis.net/kml/2.2"\
                   xmlns:gx="http://www.google.com/kml/ext/2.2">\
-          <Placemark>' +
-      uberStyle +
-      "\
+          <Placemark>${uberStyle}\
             <name>TheName</name>\
             <gx:Track>\
               <extrude>1</extrude>\
@@ -1870,7 +1849,7 @@ describe("DataSources/KmlDataSource", function () {
               <gx:coord>7 8 9</gx:coord>\
             </gx:Track>\
           </Placemark>\
-        </Document>";
+        </Document>`;
 
     return KmlDataSource.load(
       parser.parseFromString(kml, "text/xml"),
@@ -1902,13 +1881,10 @@ describe("DataSources/KmlDataSource", function () {
   });
 
   it("Styles: Applies expected styles to gx:MultiTrack geometry", function () {
-    const kml =
-      '<?xml version="1.0" encoding="UTF-8"?>\
+    const kml = `<?xml version="1.0" encoding="UTF-8"?>\
         <Document xmlns="http://www.opengis.net/kml/2.2"\
                   xmlns:gx="http://www.google.com/kml/ext/2.2">\
-          <Placemark>' +
-      uberStyle +
-      "\
+          <Placemark>${uberStyle}\
             <name>TheName</name>\
             <gx:MultiTrack>\
               <gx:Track>\
@@ -1918,7 +1894,7 @@ describe("DataSources/KmlDataSource", function () {
               </gx:Track>\
             </gx:MultiTrack>\
           </Placemark>\
-        </Document>";
+        </Document>`;
 
     return KmlDataSource.load(
       parser.parseFromString(kml, "text/xml"),
@@ -1949,13 +1925,10 @@ describe("DataSources/KmlDataSource", function () {
   });
 
   it("Styles: Applies expected styles to extruded gx:MultiTrack geometry", function () {
-    const kml =
-      '<?xml version="1.0" encoding="UTF-8"?>\
+    const kml = `<?xml version="1.0" encoding="UTF-8"?>\
         <Document xmlns="http://www.opengis.net/kml/2.2"\
                   xmlns:gx="http://www.google.com/kml/ext/2.2">\
-          <Placemark>' +
-      uberStyle +
-      "\
+          <Placemark>${uberStyle}\
             <name>TheName</name>\
             <gx:MultiTrack>\
               <gx:Track>\
@@ -1966,7 +1939,7 @@ describe("DataSources/KmlDataSource", function () {
               </gx:Track>\
             </gx:MultiTrack>\
           </Placemark>\
-        </Document>";
+        </Document>`;
 
     return KmlDataSource.load(
       parser.parseFromString(kml, "text/xml"),
@@ -4586,7 +4559,7 @@ describe("DataSources/KmlDataSource", function () {
       }).then(function () {
         expect(spy).toHaveBeenCalledWith(
           dataSource,
-          expectedRefreshLinkHref + "?BBOX=-180%2C-90%2C180%2C90"
+          `${expectedRefreshLinkHref}?BBOX=-180%2C-90%2C180%2C90`
         );
 
         expect(entities.length).toEqual(3);
@@ -4691,7 +4664,7 @@ describe("DataSources/KmlDataSource", function () {
 
     return requestNetworkLink.promise.then(function (url) {
       expect(url).toEqual(
-        expectedRefreshLinkHref + "?BBOX=-180%2C-90%2C180%2C90"
+        `${expectedRefreshLinkHref}?BBOX=-180%2C-90%2C180%2C90`
       );
     });
   });
@@ -4725,7 +4698,7 @@ describe("DataSources/KmlDataSource", function () {
 
     return requestNetworkLink.promise.then(function (url) {
       expect(url).toEqual(
-        expectedRefreshLinkHref + "?client=Cesium-v1&v=2.2&lang=English"
+        `${expectedRefreshLinkHref}?client=Cesium-v1&v=2.2&lang=English`
       );
     });
   });
@@ -4759,7 +4732,7 @@ describe("DataSources/KmlDataSource", function () {
 
     return requestNetworkLink.promise.then(function (url) {
       expect(url).toEqual(
-        expectedRefreshLinkHref + "?client=Cesium-v1&v=2.2&lang=English"
+        `${expectedRefreshLinkHref}?client=Cesium-v1&v=2.2&lang=English`
       );
     });
   });
@@ -4795,8 +4768,7 @@ describe("DataSources/KmlDataSource", function () {
 
     return requestNetworkLink.promise.then(function (url) {
       expect(url).toEqual(
-        expectedRefreshLinkHref +
-          "?BBOX=-180%2C-90%2C180%2C90&CAMERA=0%2C0%2C6378137%2C0%2C0&VIEW=45%2C45%2C512%2C512%2C1"
+        `${expectedRefreshLinkHref}?BBOX=-180%2C-90%2C180%2C90&CAMERA=0%2C0%2C6378137%2C0%2C0&VIEW=45%2C45%2C512%2C512%2C1`
       );
     });
   });
@@ -4832,8 +4804,7 @@ describe("DataSources/KmlDataSource", function () {
 
     return requestNetworkLink.promise.then(function (url) {
       expect(url).toEqual(
-        expectedRefreshLinkHref +
-          "?BBOX=-180%2C-90%2C180%2C90&CAMERA=0%2C0%2C6378137%2C0%2C0&VIEW=45%2C45%2C512%2C512%2C1"
+        `${expectedRefreshLinkHref}?BBOX=-180%2C-90%2C180%2C90&CAMERA=0%2C0%2C6378137%2C0%2C0&VIEW=45%2C45%2C512%2C512%2C1`
       );
     });
   });
@@ -4867,7 +4838,7 @@ describe("DataSources/KmlDataSource", function () {
     KmlDataSource.load(parser.parseFromString(kml, "text/xml"), options);
 
     return requestNetworkLink.promise.then(function (url) {
-      expect(url).toEqual(expectedRefreshLinkHref + "?hq=1&vf=1");
+      expect(url).toEqual(`${expectedRefreshLinkHref}?hq=1&vf=1`);
     });
   });
 
@@ -4927,7 +4898,7 @@ describe("DataSources/KmlDataSource", function () {
       }).then(function () {
         expect(spy).toHaveBeenCalledWith(
           dataSource,
-          expectedRefreshLinkHref + "?BBOX=0%2C0%2C0%2C0"
+          `${expectedRefreshLinkHref}?BBOX=0%2C0%2C0%2C0`
         );
 
         expect(entities.length).toEqual(3);

--- a/Specs/DataSources/exportKmlSpec.js
+++ b/Specs/DataSources/exportKmlSpec.js
@@ -111,10 +111,10 @@ describe("DataSources/exportKml", function () {
   function createEntity(properties) {
     ++counter;
     const options = {
-      id: "e" + counter,
-      name: "entity" + counter,
+      id: `e${counter}`,
+      name: `entity${counter}`,
       show: true,
-      description: "This is entity number " + counter,
+      description: `This is entity number ${counter}`,
       position: pointPosition,
     };
 

--- a/Specs/Renderer/BufferSpec.js
+++ b/Specs/Renderer/BufferSpec.js
@@ -37,88 +37,66 @@ describe(
         }
       });
 
-      it(
-        "throws when creating a vertex buffer with no context" + webglMessage,
-        function () {
-          expect(function () {
-            buffer = Buffer.createVertexBuffer({
-              sizeInBytes: 4,
-              usage: BufferUsage.STATIC_DRAW,
-            });
-          }).toThrowDeveloperError();
-        }
-      );
+      it(`throws when creating a vertex buffer with no context${webglMessage}`, function () {
+        expect(function () {
+          buffer = Buffer.createVertexBuffer({
+            sizeInBytes: 4,
+            usage: BufferUsage.STATIC_DRAW,
+          });
+        }).toThrowDeveloperError();
+      });
 
-      it(
-        "throws when creating a vertex buffer with an invalid typed array" +
-          webglMessage,
-        function () {
-          expect(function () {
-            buffer = Buffer.createVertexBuffer({
-              context: context,
-              typedArray: {},
-              usage: BufferUsage.STATIC_DRAW,
-            });
-          }).toThrowDeveloperError();
-        }
-      );
+      it(`throws when creating a vertex buffer with an invalid typed array${webglMessage}`, function () {
+        expect(function () {
+          buffer = Buffer.createVertexBuffer({
+            context: context,
+            typedArray: {},
+            usage: BufferUsage.STATIC_DRAW,
+          });
+        }).toThrowDeveloperError();
+      });
 
-      it(
-        "throws when creating a vertex buffer with both a typed array and size in bytes" +
-          webglMessage,
-        function () {
-          expect(function () {
-            buffer = Buffer.createVertexBuffer({
-              context: context,
-              typedArray: new Float32Array([0, 0, 0, 1]),
-              sizeInBytes: 16,
-              usage: BufferUsage.STATIC_DRAW,
-            });
-          }).toThrowDeveloperError();
-        }
-      );
+      it(`throws when creating a vertex buffer with both a typed array and size in bytes${webglMessage}`, function () {
+        expect(function () {
+          buffer = Buffer.createVertexBuffer({
+            context: context,
+            typedArray: new Float32Array([0, 0, 0, 1]),
+            sizeInBytes: 16,
+            usage: BufferUsage.STATIC_DRAW,
+          });
+        }).toThrowDeveloperError();
+      });
 
-      it(
-        "throws when creating a vertex buffer without a typed array or size in bytes" +
-          webglMessage,
-        function () {
-          expect(function () {
-            buffer = Buffer.createVertexBuffer({
-              context: context,
-              usage: BufferUsage.STATIC_DRAW,
-            });
-          }).toThrowDeveloperError();
-        }
-      );
+      it(`throws when creating a vertex buffer without a typed array or size in bytes${webglMessage}`, function () {
+        expect(function () {
+          buffer = Buffer.createVertexBuffer({
+            context: context,
+            usage: BufferUsage.STATIC_DRAW,
+          });
+        }).toThrowDeveloperError();
+      });
 
-      it(
-        "throws when creating a vertex buffer with invalid usage" +
-          webglMessage,
-        function () {
-          expect(function () {
-            buffer = Buffer.createVertexBuffer({
-              context: context,
-              sizeInBytes: 16,
-              usage: 0,
-            });
-          }).toThrowDeveloperError();
-        }
-      );
+      it(`throws when creating a vertex buffer with invalid usage${webglMessage}`, function () {
+        expect(function () {
+          buffer = Buffer.createVertexBuffer({
+            context: context,
+            sizeInBytes: 16,
+            usage: 0,
+          });
+        }).toThrowDeveloperError();
+      });
 
-      it(
-        "throws when creating a vertex buffer with size of zero" + webglMessage,
-        function () {
-          expect(function () {
-            buffer = Buffer.createVertexBuffer({
-              context: context,
-              sizeInBytes: 0,
-              usage: BufferUsage.STATIC_DRAW,
-            });
-          }).toThrowDeveloperError();
-        }
-      );
+      it(`throws when creating a vertex buffer with size of zero${webglMessage}`, function () {
+        expect(function () {
+          buffer = Buffer.createVertexBuffer({
+            context: context,
+            sizeInBytes: 0,
+            usage: BufferUsage.STATIC_DRAW,
+          });
+        }).toThrowDeveloperError();
+      });
 
-      it("creates vertex buffer" + webglMessage, function () {
+      it(`creates vertex buffer${webglMessage}`, function () {
         buffer = Buffer.createVertexBuffer({
           context: context,
           sizeInBytes: 16,
@@ -129,7 +107,7 @@ describe(
         expect(buffer.usage).toEqual(BufferUsage.STATIC_DRAW);
       });
 
-      it("copies array to a vertex buffer" + webglMessage, function () {
+      it(`copies array to a vertex buffer${webglMessage}`, function () {
         const sizeInBytes = 3 * Float32Array.BYTES_PER_ELEMENT;
         const vertices = new ArrayBuffer(sizeInBytes);
         const positions = new Float32Array(vertices);
@@ -145,140 +123,108 @@ describe(
         buffer.copyFromArrayView(vertices);
       });
 
-      it(
-        "can create a vertex buffer from a typed array" + webglMessage,
-        function () {
-          const typedArray = new Float32Array(3);
-          typedArray[0] = 1.0;
-          typedArray[1] = 2.0;
-          typedArray[2] = 3.0;
+      it(`can create a vertex buffer from a typed array${webglMessage}`, function () {
+        const typedArray = new Float32Array(3);
+        typedArray[0] = 1.0;
+        typedArray[1] = 2.0;
+        typedArray[2] = 3.0;
 
-          buffer = Buffer.createVertexBuffer({
-            context: context,
-            typedArray: typedArray,
-            usage: BufferUsage.STATIC_DRAW,
-          });
-          expect(buffer.sizeInBytes).toEqual(typedArray.byteLength);
-          expect(buffer.usage).toEqual(BufferUsage.STATIC_DRAW);
-        }
-      );
+        buffer = Buffer.createVertexBuffer({
+          context: context,
+          typedArray: typedArray,
+          usage: BufferUsage.STATIC_DRAW,
+        });
+        expect(buffer.sizeInBytes).toEqual(typedArray.byteLength);
+        expect(buffer.usage).toEqual(BufferUsage.STATIC_DRAW);
+      });
 
-      it(
-        "can create a vertex buffer from a size in bytes" + webglMessage,
-        function () {
-          buffer = Buffer.createVertexBuffer({
-            context: context,
+      it(`can create a vertex buffer from a size in bytes${webglMessage}`, function () {
+        buffer = Buffer.createVertexBuffer({
+          context: context,
+          sizeInBytes: 4,
+          usage: BufferUsage.STATIC_DRAW,
+        });
+        expect(buffer.sizeInBytes).toEqual(4);
+        expect(buffer.usage).toEqual(BufferUsage.STATIC_DRAW);
+      });
+
+      it(`throws when creating an index buffer with no context${webglMessage}`, function () {
+        expect(function () {
+          buffer = Buffer.createIndexBuffer({
             sizeInBytes: 4,
             usage: BufferUsage.STATIC_DRAW,
+            indexDatatype: IndexDatatype.UNSIGNED_SHORT,
           });
-          expect(buffer.sizeInBytes).toEqual(4);
-          expect(buffer.usage).toEqual(BufferUsage.STATIC_DRAW);
-        }
-      );
+        }).toThrowDeveloperError();
+      });
 
-      it(
-        "throws when creating an index buffer with no context" + webglMessage,
-        function () {
-          expect(function () {
-            buffer = Buffer.createIndexBuffer({
-              sizeInBytes: 4,
-              usage: BufferUsage.STATIC_DRAW,
-              indexDatatype: IndexDatatype.UNSIGNED_SHORT,
-            });
-          }).toThrowDeveloperError();
-        }
-      );
+      it(`throws when creating an index buffer with an invalid typed array${webglMessage}`, function () {
+        expect(function () {
+          buffer = Buffer.createIndexBuffer({
+            context: context,
+            typedArray: {},
+            usage: BufferUsage.STATIC_DRAW,
+            indexDatatype: IndexDatatype.UNSIGNED_SHORT,
+          });
+        }).toThrowDeveloperError();
+      });
 
-      it(
-        "throws when creating an index buffer with an invalid typed array" +
-          webglMessage,
-        function () {
-          expect(function () {
-            buffer = Buffer.createIndexBuffer({
-              context: context,
-              typedArray: {},
-              usage: BufferUsage.STATIC_DRAW,
-              indexDatatype: IndexDatatype.UNSIGNED_SHORT,
-            });
-          }).toThrowDeveloperError();
-        }
-      );
+      it(`throws when creating an index buffer with both a typed array and size in bytes${webglMessage}`, function () {
+        expect(function () {
+          buffer = Buffer.createIndexBuffer({
+            context: context,
+            typedArray: new Uint16Array([0, 1, 2, 0, 2, 3]),
+            sizeInBytes: 12,
+            usage: BufferUsage.STATIC_DRAW,
+            indexDatatype: IndexDatatype.UNSIGNED_SHORT,
+          });
+        }).toThrowDeveloperError();
+      });
 
-      it(
-        "throws when creating an index buffer with both a typed array and size in bytes" +
-          webglMessage,
-        function () {
-          expect(function () {
-            buffer = Buffer.createIndexBuffer({
-              context: context,
-              typedArray: new Uint16Array([0, 1, 2, 0, 2, 3]),
-              sizeInBytes: 12,
-              usage: BufferUsage.STATIC_DRAW,
-              indexDatatype: IndexDatatype.UNSIGNED_SHORT,
-            });
-          }).toThrowDeveloperError();
-        }
-      );
+      it(`throws when creating an index buffer without a typed array or size in bytes${webglMessage}`, function () {
+        expect(function () {
+          buffer = Buffer.createIndexBuffer({
+            context: context,
+            usage: BufferUsage.STATIC_DRAW,
+            indexDatatype: IndexDatatype.UNSIGNED_SHORT,
+          });
+        }).toThrowDeveloperError();
+      });
 
-      it(
-        "throws when creating an index buffer without a typed array or size in bytes" +
-          webglMessage,
-        function () {
-          expect(function () {
-            buffer = Buffer.createIndexBuffer({
-              context: context,
-              usage: BufferUsage.STATIC_DRAW,
-              indexDatatype: IndexDatatype.UNSIGNED_SHORT,
-            });
-          }).toThrowDeveloperError();
-        }
-      );
+      it(`throws when creating an index buffer with invalid usage${webglMessage}`, function () {
+        expect(function () {
+          buffer = Buffer.createIndexBuffer({
+            context: context,
+            sizeInBytes: 16,
+            usage: "invalid",
+            indexDatatype: IndexDatatype.UNSIGNED_SHORT,
+          });
+        }).toThrowDeveloperError();
+      });
 
-      it(
-        "throws when creating an index buffer with invalid usage" +
-          webglMessage,
-        function () {
-          expect(function () {
-            buffer = Buffer.createIndexBuffer({
-              context: context,
-              sizeInBytes: 16,
-              usage: "invalid",
-              indexDatatype: IndexDatatype.UNSIGNED_SHORT,
-            });
-          }).toThrowDeveloperError();
-        }
-      );
+      it(`throws when creating an index buffer with invalid index data type${webglMessage}`, function () {
+        expect(function () {
+          buffer = Buffer.createIndexBuffer({
+            context: context,
+            sizeInBytes: 16,
+            usage: BufferUsage.STATIC_DRAW,
+            indexDatatype: "invalid",
+          });
+        }).toThrowDeveloperError();
+      });
 
-      it(
-        "throws when creating an index buffer with invalid index data type" +
-          webglMessage,
-        function () {
-          expect(function () {
-            buffer = Buffer.createIndexBuffer({
-              context: context,
-              sizeInBytes: 16,
-              usage: BufferUsage.STATIC_DRAW,
-              indexDatatype: "invalid",
-            });
-          }).toThrowDeveloperError();
-        }
-      );
+      it(`throws when creating an index buffer with size of zero${webglMessage}`, function () {
+        expect(function () {
+          buffer = Buffer.createIndexBuffer({
+            context: context,
+            sizeInBytes: 0,
+            usage: BufferUsage.STATIC_DRAW,
+            indexDatatype: IndexDatatype.UNSIGNED_SHORT,
+          });
+        }).toThrowDeveloperError();
+      });
 
-      it(
-        "throws when creating an index buffer with size of zero" + webglMessage,
-        function () {
-          expect(function () {
-            buffer = Buffer.createIndexBuffer({
-              context: context,
-              sizeInBytes: 0,
-              usage: BufferUsage.STATIC_DRAW,
-              indexDatatype: IndexDatatype.UNSIGNED_SHORT,
-            });
-          }).toThrowDeveloperError();
-        }
-      );
-
-      it("creates index buffer" + webglMessage, function () {
+      it(`creates index buffer${webglMessage}`, function () {
         buffer = Buffer.createIndexBuffer({
           context: context,
           sizeInBytes: 6,
@@ -294,7 +240,7 @@ describe(
         expect(buffer.numberOfIndices).toEqual(3);
       });
 
-      it("copies array to an index buffer" + webglMessage, function () {
+      it(`copies array to an index buffer${webglMessage}`, function () {
         const sizeInBytes = 3 * Uint16Array.BYTES_PER_ELEMENT;
         const elements = new ArrayBuffer(sizeInBytes);
         const indices = new Uint16Array(elements);
@@ -311,42 +257,36 @@ describe(
         buffer.copyFromArrayView(elements);
       });
 
-      it(
-        "can create an index buffer from a typed array" + webglMessage,
-        function () {
-          const typedArray = new Uint16Array(3);
-          typedArray[0] = 1;
-          typedArray[1] = 2;
-          typedArray[2] = 3;
+      it(`can create an index buffer from a typed array${webglMessage}`, function () {
+        const typedArray = new Uint16Array(3);
+        typedArray[0] = 1;
+        typedArray[1] = 2;
+        typedArray[2] = 3;
 
-          buffer = Buffer.createIndexBuffer({
-            context: context,
-            typedArray: typedArray,
-            usage: BufferUsage.STATIC_DRAW,
-            indexDatatype: IndexDatatype.UNSIGNED_SHORT,
-          });
-          expect(buffer.sizeInBytes).toEqual(typedArray.byteLength);
-          expect(buffer.usage).toEqual(BufferUsage.STATIC_DRAW);
-          expect(buffer.indexDatatype).toEqual(IndexDatatype.UNSIGNED_SHORT);
-        }
-      );
+        buffer = Buffer.createIndexBuffer({
+          context: context,
+          typedArray: typedArray,
+          usage: BufferUsage.STATIC_DRAW,
+          indexDatatype: IndexDatatype.UNSIGNED_SHORT,
+        });
+        expect(buffer.sizeInBytes).toEqual(typedArray.byteLength);
+        expect(buffer.usage).toEqual(BufferUsage.STATIC_DRAW);
+        expect(buffer.indexDatatype).toEqual(IndexDatatype.UNSIGNED_SHORT);
+      });
 
-      it(
-        "can create an index buffer from a size in bytes" + webglMessage,
-        function () {
-          buffer = Buffer.createIndexBuffer({
-            context: context,
-            sizeInBytes: 6,
-            usage: BufferUsage.STATIC_DRAW,
-            indexDatatype: IndexDatatype.UNSIGNED_SHORT,
-          });
-          expect(buffer.sizeInBytes).toEqual(6);
-          expect(buffer.usage).toEqual(BufferUsage.STATIC_DRAW);
-          expect(buffer.indexDatatype).toEqual(IndexDatatype.UNSIGNED_SHORT);
-        }
-      );
+      it(`can create an index buffer from a size in bytes${webglMessage}`, function () {
+        buffer = Buffer.createIndexBuffer({
+          context: context,
+          sizeInBytes: 6,
+          usage: BufferUsage.STATIC_DRAW,
+          indexDatatype: IndexDatatype.UNSIGNED_SHORT,
+        });
+        expect(buffer.sizeInBytes).toEqual(6);
+        expect(buffer.usage).toEqual(BufferUsage.STATIC_DRAW);
+        expect(buffer.indexDatatype).toEqual(IndexDatatype.UNSIGNED_SHORT);
+      });
 
-      it("getBufferData throws without WebGL 2" + webglMessage, function () {
+      it(`getBufferData throws without WebGL 2${webglMessage}`, function () {
         if (context.webgl2) {
           return;
         }
@@ -363,7 +303,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it("getBufferData throws without arrayView" + webglMessage, function () {
+      it(`getBufferData throws without arrayView${webglMessage}`, function () {
         if (!context.webgl2) {
           return;
         }
@@ -379,76 +319,67 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(
-        "getBufferData throws with invalid sourceOffset" + webglMessage,
-        function () {
-          if (!context.webgl2) {
-            return;
-          }
-
-          buffer = Buffer.createVertexBuffer({
-            context: context,
-            sizeInBytes: 4,
-            usage: BufferUsage.STATIC_DRAW,
-          });
-          const array = new Uint8Array(4);
-
-          expect(function () {
-            buffer.getBufferData(array, -1);
-          }).toThrowDeveloperError();
-          expect(function () {
-            buffer.getBufferData(array, 5);
-          }).toThrowDeveloperError();
+      it(`getBufferData throws with invalid sourceOffset${webglMessage}`, function () {
+        if (!context.webgl2) {
+          return;
         }
-      );
 
-      it(
-        "getBufferData throws with invalid destinationOffset" + webglMessage,
-        function () {
-          if (!context.webgl2) {
-            return;
-          }
+        buffer = Buffer.createVertexBuffer({
+          context: context,
+          sizeInBytes: 4,
+          usage: BufferUsage.STATIC_DRAW,
+        });
+        const array = new Uint8Array(4);
 
-          buffer = Buffer.createVertexBuffer({
-            context: context,
-            sizeInBytes: 4,
-            usage: BufferUsage.STATIC_DRAW,
-          });
-          const array = new Uint8Array(4);
+        expect(function () {
+          buffer.getBufferData(array, -1);
+        }).toThrowDeveloperError();
+        expect(function () {
+          buffer.getBufferData(array, 5);
+        }).toThrowDeveloperError();
+      });
 
-          expect(function () {
-            buffer.getBufferData(array, 0, -1);
-          }).toThrowDeveloperError();
-          expect(function () {
-            buffer.getBufferData(array, 0, 5);
-          }).toThrowDeveloperError();
+      it(`getBufferData throws with invalid destinationOffset${webglMessage}`, function () {
+        if (!context.webgl2) {
+          return;
         }
-      );
 
-      it(
-        "getBufferData throws with invalid length" + webglMessage,
-        function () {
-          if (!context.webgl2) {
-            return;
-          }
+        buffer = Buffer.createVertexBuffer({
+          context: context,
+          sizeInBytes: 4,
+          usage: BufferUsage.STATIC_DRAW,
+        });
+        const array = new Uint8Array(4);
 
-          buffer = Buffer.createVertexBuffer({
-            context: context,
-            sizeInBytes: 4,
-            usage: BufferUsage.STATIC_DRAW,
-          });
-          const array = new Uint8Array(4);
+        expect(function () {
+          buffer.getBufferData(array, 0, -1);
+        }).toThrowDeveloperError();
+        expect(function () {
+          buffer.getBufferData(array, 0, 5);
+        }).toThrowDeveloperError();
+      });
 
-          expect(function () {
-            buffer.getBufferData(array, 2, 0, 4);
-          }).toThrowDeveloperError();
-          expect(function () {
-            buffer.getBufferData(array, 0, 2, 4);
-          }).toThrowDeveloperError();
+      it(`getBufferData throws with invalid length${webglMessage}`, function () {
+        if (!context.webgl2) {
+          return;
         }
-      );
 
-      it("getBufferData reads from vertex buffer" + webglMessage, function () {
+        buffer = Buffer.createVertexBuffer({
+          context: context,
+          sizeInBytes: 4,
+          usage: BufferUsage.STATIC_DRAW,
+        });
+        const array = new Uint8Array(4);
+
+        expect(function () {
+          buffer.getBufferData(array, 2, 0, 4);
+        }).toThrowDeveloperError();
+        expect(function () {
+          buffer.getBufferData(array, 0, 2, 4);
+        }).toThrowDeveloperError();
+      });
+
+      it(`getBufferData reads from vertex buffer${webglMessage}`, function () {
         if (!context.webgl2) {
           return;
         }
@@ -471,7 +402,7 @@ describe(
         expect(destArray).toEqual(typedArray);
       });
 
-      it("getBufferData reads from index buffer" + webglMessage, function () {
+      it(`getBufferData reads from index buffer${webglMessage}`, function () {
         if (!context.webgl2) {
           return;
         }
@@ -493,7 +424,7 @@ describe(
         expect(destArray).toEqual(typedArray);
       });
 
-      it("copyFromBuffer throws without WebGL 2" + webglMessage, function () {
+      it(`copyFromBuffer throws without WebGL 2${webglMessage}`, function () {
         if (context.webgl2) {
           return;
         }
@@ -514,170 +445,150 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it(
-        "copyFromBuffer throws without readBuffer" + webglMessage,
-        function () {
-          if (!context.webgl2) {
-            return;
-          }
-
-          buffer = Buffer.createVertexBuffer({
-            context: context,
-            sizeInBytes: 4,
-            usage: BufferUsage.STATIC_DRAW,
-          });
-
-          expect(function () {
-            buffer.copyFromBuffer(undefined, 0, 0, 4);
-          }).toThrowDeveloperError();
+      it(`copyFromBuffer throws without readBuffer${webglMessage}`, function () {
+        if (!context.webgl2) {
+          return;
         }
-      );
 
-      it(
-        "copyFromBuffer throws with invalid readOffset" + webglMessage,
-        function () {
-          if (!context.webgl2) {
-            return;
-          }
+        buffer = Buffer.createVertexBuffer({
+          context: context,
+          sizeInBytes: 4,
+          usage: BufferUsage.STATIC_DRAW,
+        });
 
-          buffer = Buffer.createVertexBuffer({
-            context: context,
-            sizeInBytes: 4,
-            usage: BufferUsage.STATIC_DRAW,
-          });
-          buffer2 = Buffer.createVertexBuffer({
-            context: context,
-            sizeInBytes: 4,
-            usage: BufferUsage.STATIC_DRAW,
-          });
+        expect(function () {
+          buffer.copyFromBuffer(undefined, 0, 0, 4);
+        }).toThrowDeveloperError();
+      });
 
-          expect(function () {
-            buffer.copyFromBuffer(buffer2, undefined, 0, 4);
-          }).toThrowDeveloperError();
-          expect(function () {
-            buffer.copyFromBuffer(buffer2, -1, 0, 4);
-          }).toThrowDeveloperError();
-          expect(function () {
-            buffer.copyFromBuffer(buffer2, 5, 0, 4);
-          }).toThrowDeveloperError();
+      it(`copyFromBuffer throws with invalid readOffset${webglMessage}`, function () {
+        if (!context.webgl2) {
+          return;
         }
-      );
 
-      it(
-        "copyFromBuffer throws with invalid writeOffset" + webglMessage,
-        function () {
-          if (!context.webgl2) {
-            return;
-          }
+        buffer = Buffer.createVertexBuffer({
+          context: context,
+          sizeInBytes: 4,
+          usage: BufferUsage.STATIC_DRAW,
+        });
+        buffer2 = Buffer.createVertexBuffer({
+          context: context,
+          sizeInBytes: 4,
+          usage: BufferUsage.STATIC_DRAW,
+        });
 
-          buffer = Buffer.createVertexBuffer({
-            context: context,
-            sizeInBytes: 4,
-            usage: BufferUsage.STATIC_DRAW,
-          });
-          buffer2 = Buffer.createVertexBuffer({
-            context: context,
-            sizeInBytes: 4,
-            usage: BufferUsage.STATIC_DRAW,
-          });
+        expect(function () {
+          buffer.copyFromBuffer(buffer2, undefined, 0, 4);
+        }).toThrowDeveloperError();
+        expect(function () {
+          buffer.copyFromBuffer(buffer2, -1, 0, 4);
+        }).toThrowDeveloperError();
+        expect(function () {
+          buffer.copyFromBuffer(buffer2, 5, 0, 4);
+        }).toThrowDeveloperError();
+      });
 
-          expect(function () {
-            buffer.copyFromBuffer(buffer2, 0, undefined, 4);
-          }).toThrowDeveloperError();
-          expect(function () {
-            buffer.copyFromBuffer(buffer2, 0, -1, 4);
-          }).toThrowDeveloperError();
-          expect(function () {
-            buffer.copyFromBuffer(buffer2, 0, 5, 4);
-          }).toThrowDeveloperError();
+      it(`copyFromBuffer throws with invalid writeOffset${webglMessage}`, function () {
+        if (!context.webgl2) {
+          return;
         }
-      );
 
-      it(
-        "copyFromBuffer throws with invalid sizeInBytes" + webglMessage,
-        function () {
-          if (!context.webgl2) {
-            return;
-          }
+        buffer = Buffer.createVertexBuffer({
+          context: context,
+          sizeInBytes: 4,
+          usage: BufferUsage.STATIC_DRAW,
+        });
+        buffer2 = Buffer.createVertexBuffer({
+          context: context,
+          sizeInBytes: 4,
+          usage: BufferUsage.STATIC_DRAW,
+        });
 
-          buffer = Buffer.createVertexBuffer({
-            context: context,
-            sizeInBytes: 4,
-            usage: BufferUsage.STATIC_DRAW,
-          });
-          buffer2 = Buffer.createVertexBuffer({
-            context: context,
-            sizeInBytes: 4,
-            usage: BufferUsage.STATIC_DRAW,
-          });
+        expect(function () {
+          buffer.copyFromBuffer(buffer2, 0, undefined, 4);
+        }).toThrowDeveloperError();
+        expect(function () {
+          buffer.copyFromBuffer(buffer2, 0, -1, 4);
+        }).toThrowDeveloperError();
+        expect(function () {
+          buffer.copyFromBuffer(buffer2, 0, 5, 4);
+        }).toThrowDeveloperError();
+      });
 
-          expect(function () {
-            buffer.copyFromBuffer(buffer2, 0, 0, undefined);
-          }).toThrowDeveloperError();
-          expect(function () {
-            buffer.copyFromBuffer(buffer2, 0, 0, -1);
-          }).toThrowDeveloperError();
-          expect(function () {
-            buffer.copyFromBuffer(buffer2, 0, 0, 0);
-          }).toThrowDeveloperError();
-          expect(function () {
-            buffer.copyFromBuffer(buffer2, 0, 0, 5);
-          }).toThrowDeveloperError();
+      it(`copyFromBuffer throws with invalid sizeInBytes${webglMessage}`, function () {
+        if (!context.webgl2) {
+          return;
         }
-      );
 
-      it(
-        "copyFromBuffer throws with one index buffer and the other is not an index buffer" +
-          webglMessage,
-        function () {
-          if (!context.webgl2) {
-            return;
-          }
+        buffer = Buffer.createVertexBuffer({
+          context: context,
+          sizeInBytes: 4,
+          usage: BufferUsage.STATIC_DRAW,
+        });
+        buffer2 = Buffer.createVertexBuffer({
+          context: context,
+          sizeInBytes: 4,
+          usage: BufferUsage.STATIC_DRAW,
+        });
 
-          const typedArray = new Uint16Array([0, 1, 2, 3, 4]);
-          buffer = Buffer.createIndexBuffer({
-            context: context,
-            typedArray: typedArray,
-            usage: BufferUsage.STATIC_DRAW,
-            indexDatatype: IndexDatatype.UNSIGNED_SHORT,
-          });
-          const typedArray2 = new Float32Array([5.0, 6.0, 7.0, 8.0, 9.0]);
-          buffer2 = Buffer.createVertexBuffer({
-            context: context,
-            typedArray: typedArray2,
-            usage: BufferUsage.STATIC_DRAW,
-          });
+        expect(function () {
+          buffer.copyFromBuffer(buffer2, 0, 0, undefined);
+        }).toThrowDeveloperError();
+        expect(function () {
+          buffer.copyFromBuffer(buffer2, 0, 0, -1);
+        }).toThrowDeveloperError();
+        expect(function () {
+          buffer.copyFromBuffer(buffer2, 0, 0, 0);
+        }).toThrowDeveloperError();
+        expect(function () {
+          buffer.copyFromBuffer(buffer2, 0, 0, 5);
+        }).toThrowDeveloperError();
+      });
 
-          expect(function () {
-            buffer2.copyFromBuffer(buffer, 0, 0, typedArray.byteLength);
-          }).toThrowDeveloperError();
+      it(`copyFromBuffer throws with one index buffer and the other is not an index buffer${webglMessage}`, function () {
+        if (!context.webgl2) {
+          return;
         }
-      );
 
-      it(
-        "copyFromBuffer throws when readBuffer is the same buffer and copy range overlaps" +
-          webglMessage,
-        function () {
-          if (!context.webgl2) {
-            return;
-          }
+        const typedArray = new Uint16Array([0, 1, 2, 3, 4]);
+        buffer = Buffer.createIndexBuffer({
+          context: context,
+          typedArray: typedArray,
+          usage: BufferUsage.STATIC_DRAW,
+          indexDatatype: IndexDatatype.UNSIGNED_SHORT,
+        });
+        const typedArray2 = new Float32Array([5.0, 6.0, 7.0, 8.0, 9.0]);
+        buffer2 = Buffer.createVertexBuffer({
+          context: context,
+          typedArray: typedArray2,
+          usage: BufferUsage.STATIC_DRAW,
+        });
 
-          buffer = Buffer.createVertexBuffer({
-            context: context,
-            sizeInBytes: 4,
-            usage: BufferUsage.STATIC_DRAW,
-          });
+        expect(function () {
+          buffer2.copyFromBuffer(buffer, 0, 0, typedArray.byteLength);
+        }).toThrowDeveloperError();
+      });
 
-          expect(function () {
-            buffer.copyFromBuffer(buffer, 0, 1, 2);
-          }).toThrowDeveloperError();
-          expect(function () {
-            buffer.copyFromBuffer(buffer, 1, 0, 2);
-          }).toThrowDeveloperError();
+      it(`copyFromBuffer throws when readBuffer is the same buffer and copy range overlaps${webglMessage}`, function () {
+        if (!context.webgl2) {
+          return;
         }
-      );
 
-      it("copyFromBuffer with vertex buffers" + webglMessage, function () {
+        buffer = Buffer.createVertexBuffer({
+          context: context,
+          sizeInBytes: 4,
+          usage: BufferUsage.STATIC_DRAW,
+        });
+
+        expect(function () {
+          buffer.copyFromBuffer(buffer, 0, 1, 2);
+        }).toThrowDeveloperError();
+        expect(function () {
+          buffer.copyFromBuffer(buffer, 1, 0, 2);
+        }).toThrowDeveloperError();
+      });
+
+      it(`copyFromBuffer with vertex buffers${webglMessage}`, function () {
         if (!context.webgl2) {
           return;
         }
@@ -706,7 +617,7 @@ describe(
         expect(destArray).toEqual(typedArray);
       });
 
-      it("copyFromBuffer with index buffers" + webglMessage, function () {
+      it(`copyFromBuffer with index buffers${webglMessage}`, function () {
         if (!context.webgl2) {
           return;
         }
@@ -737,7 +648,7 @@ describe(
         expect(destArray).toEqual(typedArray);
       });
 
-      it("destroys" + webglMessage, function () {
+      it(`destroys${webglMessage}`, function () {
         const b = Buffer.createIndexBuffer({
           context: context,
           sizeInBytes: 3,
@@ -749,7 +660,7 @@ describe(
         expect(b.isDestroyed()).toEqual(true);
       });
 
-      it("fails to provide an array view" + webglMessage, function () {
+      it(`fails to provide an array view${webglMessage}`, function () {
         buffer = Buffer.createVertexBuffer({
           context: context,
           sizeInBytes: 3,
@@ -760,7 +671,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it("fails to copy a large array view" + webglMessage, function () {
+      it(`fails to copy a large array view${webglMessage}`, function () {
         buffer = Buffer.createVertexBuffer({
           context: context,
           sizeInBytes: 3,
@@ -773,7 +684,7 @@ describe(
         }).toThrowDeveloperError();
       });
 
-      it("fails to destroy" + webglMessage, function () {
+      it(`fails to destroy${webglMessage}`, function () {
         const b = Buffer.createIndexBuffer({
           context: context,
           sizeInBytes: 3,

--- a/Specs/Renderer/BuiltinFunctionsSpec.js
+++ b/Specs/Renderer/BuiltinFunctionsSpec.js
@@ -453,22 +453,11 @@ describe(
     it("has czm_unpackFloat", function () {
       let packed = Cartesian4.packFloat(1);
       packed = Cartesian4.divideByScalar(packed, 255, packed);
-      const vec4 =
-        "vec4(" +
-        packed.x +
-        ", " +
-        packed.y +
-        ", " +
-        packed.z +
-        ", " +
-        packed.w +
-        ")";
+      const vec4 = `vec4(${packed.x}, ${packed.y}, ${packed.z}, ${packed.w})`;
       const fs =
-        "void main() { " +
-        "  gl_FragColor = vec4(czm_unpackFloat(" +
-        vec4 +
-        "));" +
-        "}";
+        `${
+          "void main() { " + "  gl_FragColor = vec4(czm_unpackFloat("
+        }${vec4}));` + `}`;
       expect({
         context: context,
         fragmentShader: fs,

--- a/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
+++ b/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
@@ -227,7 +227,7 @@ describe("Scene/ArcGisMapServerImageryProvider", function () {
             deferred
           );
         } else {
-          expect(url).toEqual(getAbsoluteUri(baseUrl + "tile/0/0/0"));
+          expect(url).toEqual(getAbsoluteUri(`${baseUrl}tile/0/0/0`));
 
           // Just return any old image.
           Resource._DefaultImplementations.createImage(
@@ -247,7 +247,7 @@ describe("Scene/ArcGisMapServerImageryProvider", function () {
         deferred,
         overrideMimeType
       ) {
-        expect(url).toEqual(getAbsoluteUri(baseUrl + "tile/0/0/0"));
+        expect(url).toEqual(getAbsoluteUri(`${baseUrl}tile/0/0/0`));
 
         // Just return any old image.
         Resource._DefaultImplementations.loadWithXhr(
@@ -343,7 +343,7 @@ describe("Scene/ArcGisMapServerImageryProvider", function () {
             true
           );
         } else {
-          expect(url).toEqual(getAbsoluteUri(baseUrl + "tile/0/0/0"));
+          expect(url).toEqual(getAbsoluteUri(`${baseUrl}tile/0/0/0`));
 
           // Just return any old image.
           Resource._DefaultImplementations.createImage(
@@ -363,7 +363,7 @@ describe("Scene/ArcGisMapServerImageryProvider", function () {
         deferred,
         overrideMimeType
       ) {
-        expect(url).toEqual(getAbsoluteUri(baseUrl + "tile/0/0/0"));
+        expect(url).toEqual(getAbsoluteUri(`${baseUrl}tile/0/0/0`));
 
         // Just return any old image.
         Resource._DefaultImplementations.loadWithXhr(
@@ -423,7 +423,7 @@ describe("Scene/ArcGisMapServerImageryProvider", function () {
         uriWithoutQuery.query("");
 
         expect(uriWithoutQuery.toString()).toEqual(
-          getAbsoluteUri(baseUrl + "export")
+          getAbsoluteUri(`${baseUrl}export`)
         );
 
         expect(params.f).toEqual("image");
@@ -502,7 +502,7 @@ describe("Scene/ArcGisMapServerImageryProvider", function () {
         uriWithoutQuery.query("");
 
         expect(uriWithoutQuery.toString()).toEqual(
-          getAbsoluteUri(baseUrl + "export")
+          getAbsoluteUri(`${baseUrl}export`)
         );
 
         expect(params.f).toEqual("image");
@@ -540,11 +540,9 @@ describe("Scene/ArcGisMapServerImageryProvider", function () {
     });
 
     const expectedTileUrl = getAbsoluteUri(
-      baseUrl +
-        "tile/0/0/0?" +
-        objectToQuery({
-          token: token,
-        })
+      `${baseUrl}tile/0/0/0?${objectToQuery({
+        token: token,
+      })}`
     );
 
     expect(provider.url).toEqual(baseUrl);

--- a/Specs/Scene/BingMapsImageryProviderSpec.js
+++ b/Specs/Scene/BingMapsImageryProviderSpec.js
@@ -122,10 +122,7 @@ describe("Scene/BingMapsImageryProvider", function () {
               __type:
                 "ImageryMetadata:http://schemas.microsoft.com/search/local/ws/rest/v1",
               imageHeight: 256,
-              imageUrl:
-                "http://ecn.{subdomain}.tiles.virtualearth.net.fake.invalid/tiles/" +
-                stylePrefix +
-                "{quadkey}.jpeg?g=3031&mkt={culture}",
+              imageUrl: `http://ecn.{subdomain}.tiles.virtualearth.net.fake.invalid/tiles/${stylePrefix}{quadkey}.jpeg?g=3031&mkt={culture}`,
               imageUrlSubdomains: ["t0", "t1", "t2", "t3"],
               imageWidth: 256,
               imageryProviders: [
@@ -177,7 +174,7 @@ describe("Scene/BingMapsImageryProvider", function () {
   function installFakeMetadataRequest(url, mapStyle, proxy) {
     const baseUri = new Uri(appendForwardSlash(url));
     const expectedUri = new Uri(
-      "REST/v1/Imagery/Metadata/" + mapStyle
+      `REST/v1/Imagery/Metadata/${mapStyle}`
     ).absoluteTo(baseUri);
 
     Resource._Implementations.loadAndExecuteScript = function (

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -281,7 +281,7 @@ describe(
         },
       };
 
-      const uri = "data:text/plain;base64," + btoa(JSON.stringify(tilesetJson));
+      const uri = `data:text/plain;base64,${btoa(JSON.stringify(tilesetJson))}`;
 
       Cesium3DTileset.loadJson(uri)
         .then(function (result) {
@@ -364,7 +364,7 @@ describe(
         },
       };
 
-      const uri = "data:text/plain;base64," + btoa(JSON.stringify(tilesetJson));
+      const uri = `data:text/plain;base64,${btoa(JSON.stringify(tilesetJson))}`;
 
       options.url = uri;
       const tileset = scene.primitives.add(new Cesium3DTileset(options));
@@ -386,7 +386,7 @@ describe(
         extensionsRequired: ["unsupported_extension"],
       };
 
-      const uri = "data:text/plain;base64," + btoa(JSON.stringify(tilesetJson));
+      const uri = `data:text/plain;base64,${btoa(JSON.stringify(tilesetJson))}`;
 
       options.url = uri;
       const tileset = scene.primitives.add(new Cesium3DTileset(options));
@@ -1819,12 +1819,10 @@ describe(
       spyOn(Resource._Implementations, "loadWithXhr").and.callThrough();
 
       const queryParams = "a=1&b=boy";
-      let expectedUrl =
-        "Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tileset.json?" +
-        queryParams;
+      let expectedUrl = `Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tileset.json?${queryParams}`;
       return Cesium3DTilesTester.loadTileset(
         scene,
-        tilesetOfTilesetsUrl + "?" + queryParams
+        `${tilesetOfTilesetsUrl}?${queryParams}`
       )
         .then(function (tileset) {
           //Make sure tileset JSON file was requested with query parameters
@@ -1843,8 +1841,7 @@ describe(
         .then(function () {
           //Make sure tileset2.json was requested with query parameters and does not use parent tilesetVersion
           expectedUrl = getAbsoluteUri(
-            "Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tileset2.json?v=1.2.3&" +
-              queryParams
+            `Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tileset2.json?v=1.2.3&${queryParams}`
           );
           expect(
             Resource._Implementations.loadWithXhr.calls.argsFor(0)[0]
@@ -2052,19 +2049,19 @@ describe(
 
         const root = tileset.root;
         expect(tileset._tileDebugLabels._labels[0].text).toEqual(
-          "Geometric error: " + root.geometricError
+          `Geometric error: ${root.geometricError}`
         );
         expect(tileset._tileDebugLabels._labels[1].text).toEqual(
-          "Geometric error: " + root.children[0].geometricError
+          `Geometric error: ${root.children[0].geometricError}`
         );
         expect(tileset._tileDebugLabels._labels[2].text).toEqual(
-          "Geometric error: " + root.children[1].geometricError
+          `Geometric error: ${root.children[1].geometricError}`
         );
         expect(tileset._tileDebugLabels._labels[3].text).toEqual(
-          "Geometric error: " + root.children[2].geometricError
+          `Geometric error: ${root.children[2].geometricError}`
         );
         expect(tileset._tileDebugLabels._labels[4].text).toEqual(
-          "Geometric error: " + root.children[3].geometricError
+          `Geometric error: ${root.children[3].geometricError}`
         );
 
         tileset.debugShowGeometricError = false;
@@ -2086,10 +2083,10 @@ describe(
 
         const root = tileset.root;
         expect(tileset._tileDebugLabels._labels[0].text).toEqual(
-          "Geometric error: " + root.geometricError
+          `Geometric error: ${root.geometricError}`
         );
         expect(tileset._tileDebugLabels._labels[1].text).toEqual(
-          "Geometric error: " + root.children[0].geometricError
+          `Geometric error: ${root.children[0].geometricError}`
         );
 
         tileset.debugShowGeometricError = false;
@@ -2113,7 +2110,7 @@ describe(
 
         for (let i = 0; i < length; ++i) {
           expect(tileset._tileDebugLabels._labels[i].text).toEqual(
-            "Geometric error: " + tileset._selectedTiles[i].geometricError
+            `Geometric error: ${tileset._selectedTiles[i].geometricError}`
           );
         }
 
@@ -2136,14 +2133,9 @@ describe(
 
         const content = tileset.root.content;
         const expected =
-          "Commands: " +
-          tileset.root.commandsLength +
-          "\n" +
-          "Triangles: " +
-          content.trianglesLength +
-          "\n" +
-          "Features: " +
-          content.featuresLength;
+          `Commands: ${tileset.root.commandsLength}\n` +
+          `Triangles: ${content.trianglesLength}\n` +
+          `Features: ${content.featuresLength}`;
 
         expect(tileset._tileDebugLabels._labels[0].text).toEqual(expected);
 

--- a/Specs/Scene/CreditDisplaySpec.js
+++ b/Specs/Scene/CreditDisplaySpec.js
@@ -257,7 +257,7 @@ describe("Scene/CreditDisplay", function () {
 
   it("displays credits in a lightbox", function () {
     const credit1 = new Credit("credit1");
-    const credit2 = new Credit('<img src="' + imageUrl + '"/>');
+    const credit2 = new Credit(`<img src="${imageUrl}"/>`);
 
     creditDisplay = new CreditDisplay(container);
     const creditList = creditDisplay._creditList;
@@ -305,7 +305,7 @@ describe("Scene/CreditDisplay", function () {
 
   it("renders lightbox credits", function () {
     const credit1 = new Credit("credit1");
-    const credit2 = new Credit('<img src="' + imageUrl + '"/>');
+    const credit2 = new Credit(`<img src="${imageUrl}"/>`);
 
     creditDisplay = new CreditDisplay(container);
     const creditList = creditDisplay._creditList;
@@ -333,7 +333,7 @@ describe("Scene/CreditDisplay", function () {
 
   it("updates lightbox when a new frames are not rendered", function () {
     const credit1 = new Credit("credit1");
-    const credit2 = new Credit('<img src="' + imageUrl + '"/>');
+    const credit2 = new Credit(`<img src="${imageUrl}"/>`);
 
     creditDisplay = new CreditDisplay(container);
     const creditList = creditDisplay._creditList;

--- a/Specs/Scene/GlobeSurfaceTileProviderSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileProviderSpec.js
@@ -820,7 +820,7 @@ describe(
 
           if (command.owner instanceof QuadtreeTile) {
             const tile = command.owner;
-            const key = "L" + tile.level + "X" + tile.x + "Y" + tile.y;
+            const key = `L${tile.level}X${tile.x}Y${tile.y}`;
             if (!defined(drawCommandsPerTile[key])) {
               drawCommandsPerTile[key] = 0;
 

--- a/Specs/Scene/GlobeTranslucencyStateSpec.js
+++ b/Specs/Scene/GlobeTranslucencyStateSpec.js
@@ -41,7 +41,7 @@ function reset() {
 
 function createShaderProgram(colorString) {
   const vs = "void main() { gl_Position = vec4(0.0, 0.0, 0.0, 1.0); }";
-  const fs = "void main() { gl_FragColor = vec4(" + colorString + "); }";
+  const fs = `void main() { gl_FragColor = vec4(${colorString}); }`;
 
   const vertexShaderSource = new ShaderSource({
     sources: [vs],

--- a/Specs/Scene/GltfBuilder.js
+++ b/Specs/Scene/GltfBuilder.js
@@ -234,7 +234,7 @@ GltfPrimitiveBuilder.prototype.attribute = function (semantic, accessorName) {
   const gltf = this.gltfMeshBuilder.gltfBuilder.gltf;
   const accessorId = findAccessorByName(gltf, accessorName);
   if (accessorId < 0) {
-    throw new RuntimeError("Accessor named " + accessorName + " not found.");
+    throw new RuntimeError(`Accessor named ${accessorName} not found.`);
   }
 
   this.primitive.attributes[semantic] = accessorId;
@@ -250,7 +250,7 @@ GltfPrimitiveBuilder.prototype.indices = function (accessorName) {
   const gltf = this.gltfMeshBuilder.gltfBuilder.gltf;
   const accessorId = findAccessorByName(gltf, accessorName);
   if (accessorId < 0) {
-    throw new RuntimeError("Accessor named " + accessorName + " not found.");
+    throw new RuntimeError(`Accessor named ${accessorName} not found.`);
   }
 
   this.primitive.indices = accessorId;
@@ -281,7 +281,7 @@ GltfPrimitiveBuilder.prototype.material = function (materialName) {
     }
   }
 
-  throw new RuntimeError("Material named " + materialName + " not found.");
+  throw new RuntimeError(`Material named ${materialName} not found.`);
 };
 
 /**

--- a/Specs/Scene/GoogleEarthEnterpriseImageryProviderSpec.js
+++ b/Specs/Scene/GoogleEarthEnterpriseImageryProviderSpec.js
@@ -65,25 +65,25 @@ describe("Scene/GoogleEarthEnterpriseImageryProvider", function () {
       "getQuadTreePacket"
     ).and.callFake(function (quadKey, version) {
       quadKey = defaultValue(quadKey, "");
-      this._tileInfo[quadKey + "0"] = new GoogleEarthEnterpriseTileInformation(
+      this._tileInfo[`${quadKey}0`] = new GoogleEarthEnterpriseTileInformation(
         0xff,
         1,
         1,
         1
       );
-      this._tileInfo[quadKey + "1"] = new GoogleEarthEnterpriseTileInformation(
+      this._tileInfo[`${quadKey}1`] = new GoogleEarthEnterpriseTileInformation(
         0xff,
         1,
         1,
         1
       );
-      this._tileInfo[quadKey + "2"] = new GoogleEarthEnterpriseTileInformation(
+      this._tileInfo[`${quadKey}2`] = new GoogleEarthEnterpriseTileInformation(
         0xff,
         1,
         1,
         1
       );
-      this._tileInfo[quadKey + "3"] = new GoogleEarthEnterpriseTileInformation(
+      this._tileInfo[`${quadKey}3`] = new GoogleEarthEnterpriseTileInformation(
         0xff,
         1,
         1,

--- a/Specs/Scene/ImageryLayerCollectionSpec.js
+++ b/Specs/Scene/ImageryLayerCollectionSpec.js
@@ -724,7 +724,7 @@ describe(
             const deferred = when.defer();
             setTimeout(function () {
               const featureInfo = new ImageryLayerFeatureInfo();
-              featureInfo.name = "L" + level + "X" + x + "Y" + y;
+              featureInfo.name = `L${level}X${x}Y${y}`;
               deferred.resolve([featureInfo]);
             }, 1);
             return deferred.promise;

--- a/Specs/Scene/LabelCollectionSpec.js
+++ b/Specs/Scene/LabelCollectionSpec.js
@@ -2010,7 +2010,7 @@ describe(
 
         it("filters out soft hyphens from input strings", function () {
           const softHyphen = String.fromCharCode(0xad);
-          const text = "test string" + softHyphen;
+          const text = `test string${softHyphen}`;
           const label = labels.add({
             text: text,
           });

--- a/Specs/Scene/MetadataClassPropertySpec.js
+++ b/Specs/Scene/MetadataClassPropertySpec.js
@@ -1003,7 +1003,7 @@ describe("Scene/MetadataClassProperty", function () {
         },
       });
       expect(property.validate({})).toBe(
-        "value [object Object] does not match type " + types[i]
+        `value [object Object] does not match type ${types[i]}`
       );
     }
   });
@@ -1042,7 +1042,7 @@ describe("Scene/MetadataClassProperty", function () {
         });
         for (let i = 0; i < values.length; ++i) {
           expect(property.validate(values[i])).toBe(
-            "value " + values[i] + " is out of range for type " + type
+            `value ${values[i]} is out of range for type ${type}`
           );
         }
       }
@@ -1084,7 +1084,7 @@ describe("Scene/MetadataClassProperty", function () {
         });
         for (let i = 0; i < values.length; ++i) {
           expect(property.validate(values)).toBe(
-            "value " + values[0] + " is out of range for type " + componentType
+            `value ${values[0]} is out of range for type ${componentType}`
           );
         }
       }

--- a/Specs/Scene/ModelExperimental/CustomShaderSpec.js
+++ b/Specs/Scene/ModelExperimental/CustomShaderSpec.js
@@ -219,7 +219,7 @@ describe("Scene/ModelExperimental/CustomShader", function () {
         vertexShaderText: [
           "void vertexMain(VertexInput vsInput, inout czm_modelVertexOutput vsOutput)",
           "{",
-          "    vsOutput.positionMC = vsInput.attributes." + variableName + ";",
+          `    vsOutput.positionMC = vsInput.attributes.${variableName};`,
           "}",
         ].join("\n"),
       });
@@ -230,7 +230,7 @@ describe("Scene/ModelExperimental/CustomShader", function () {
         fragmentShaderText: [
           "void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)",
           "{",
-          "    material.diffuse = fsInput.attributes." + variableName + ";",
+          `    material.diffuse = fsInput.attributes.${variableName};`,
           "}",
         ].join("\n"),
       });

--- a/Specs/Scene/ModelInstanceCollectionSpec.js
+++ b/Specs/Scene/ModelInstanceCollectionSpec.js
@@ -218,7 +218,7 @@ describe(
         expect(collection._model.ready).toEqual(true);
 
         if (collection._instancingSupported) {
-          expect(collection._model.cacheKey).toEqual(boxUrl + "#instanced");
+          expect(collection._model.cacheKey).toEqual(`${boxUrl}#instanced`);
         }
       });
     });

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -3142,7 +3142,7 @@ describe(
           "    czm_old_main();\n" +
           "    v_color = a_color;\n" +
           "}";
-        return renamedSource + "\n" + newMain;
+        return `${renamedSource}\n${newMain}`;
       }
 
       function fragmentShaderLoaded(fs) {

--- a/Specs/Scene/PostProcessStageCompositeSpec.js
+++ b/Specs/Scene/PostProcessStageCompositeSpec.js
@@ -186,10 +186,9 @@ describe(
       const bgColor = 51; // Choose a factor of 255 to make sure there aren't rounding issues
       s.postProcessStages.add(
         new PostProcessStage({
-          fragmentShader:
-            "void main() { gl_FragColor = vec4(vec3(" +
-            bgColor / 255 +
-            "), 1.0); }",
+          fragmentShader: `void main() { gl_FragColor = vec4(vec3(${
+            bgColor / 255
+          }), 1.0); }`,
         })
       );
 

--- a/Specs/Scene/PostProcessStageSpec.js
+++ b/Specs/Scene/PostProcessStageSpec.js
@@ -207,10 +207,9 @@ describe(
       const bgColor = 51; // Choose a factor of 255 to make sure there aren't rounding issues
       s.postProcessStages.add(
         new PostProcessStage({
-          fragmentShader:
-            "void main() { gl_FragColor = vec4(vec3(" +
-            bgColor / 255 +
-            "), 1.0); }",
+          fragmentShader: `void main() { gl_FragColor = vec4(vec3(${
+            bgColor / 255
+          }), 1.0); }`,
         })
       );
 

--- a/Specs/Scene/ResourceCacheKeySpec.js
+++ b/Specs/Scene/ResourceCacheKeySpec.js
@@ -264,7 +264,7 @@ describe("ResourceCacheKey", function () {
       resource: schemaResource,
     });
 
-    expect(cacheKey).toBe("external-schema:" + schemaUri);
+    expect(cacheKey).toBe(`external-schema:${schemaUri}`);
   });
 
   it("getSchemaCacheKey works for JSON schemas", function () {
@@ -272,7 +272,7 @@ describe("ResourceCacheKey", function () {
       schema: schemaJson,
     });
 
-    expect(cacheKey).toBe("embedded-schema:" + JSON.stringify(schemaJson));
+    expect(cacheKey).toBe(`embedded-schema:${JSON.stringify(schemaJson)}`);
   });
 
   it("getSchemaCacheKey throws if neither options.schema nor options.resource are defined", function () {
@@ -295,7 +295,7 @@ describe("ResourceCacheKey", function () {
       resource: bufferResource,
     });
 
-    expect(cacheKey).toBe("external-buffer:" + bufferUri);
+    expect(cacheKey).toBe(`external-buffer:${bufferUri}`);
   });
 
   it("getExternalBufferCacheKey throws if resource is undefined", function () {
@@ -310,7 +310,7 @@ describe("ResourceCacheKey", function () {
       bufferId: bufferId,
     });
 
-    expect(cacheKey).toBe("embedded-buffer:" + gltfUri + "-buffer-id-0");
+    expect(cacheKey).toBe(`embedded-buffer:${gltfUri}-buffer-id-0`);
   });
 
   it("getEmbeddedBufferCacheKey throws if parentResource is undefined", function () {
@@ -334,7 +334,7 @@ describe("ResourceCacheKey", function () {
       gltfResource: gltfResource,
     });
 
-    expect(cacheKey).toBe("gltf:" + gltfUri);
+    expect(cacheKey).toBe(`gltf:${gltfUri}`);
   });
 
   it("getGltfCacheKey throws if gltfResource is undefined", function () {
@@ -351,9 +351,7 @@ describe("ResourceCacheKey", function () {
       baseResource: baseResource,
     });
 
-    expect(cacheKey).toBe(
-      "buffer-view:" + gltfUri + "-buffer-id-0-range-0-100"
-    );
+    expect(cacheKey).toBe(`buffer-view:${gltfUri}-buffer-id-0-range-0-100`);
   });
 
   it("getBufferViewCacheKey works with external buffer", function () {
@@ -377,9 +375,7 @@ describe("ResourceCacheKey", function () {
       baseResource: baseResource,
     });
 
-    expect(cacheKey).toBe(
-      "buffer-view:" + gltfUri + "-buffer-id-1-range-25-75"
-    );
+    expect(cacheKey).toBe(`buffer-view:${gltfUri}-buffer-id-1-range-25-75`);
   });
 
   it("getBufferViewCacheKey throws if gltf is undefined", function () {

--- a/Specs/Scene/ShadowVolumeAppearanceSpec.js
+++ b/Specs/Scene/ShadowVolumeAppearanceSpec.js
@@ -81,10 +81,12 @@ describe("Scene/ShadowVolumeAppearance", function () {
     eastMostCartesian.x,
     longitudeExtentsEncodeScratch
   );
-  const eastMostYhighDefine =
-    "EAST_MOST_X_HIGH " + encoded.high.toFixed((encoded.high + "").length + 1);
-  const eastMostYlowDefine =
-    "EAST_MOST_X_LOW " + encoded.low.toFixed((encoded.low + "").length + 1);
+  const eastMostYhighDefine = `EAST_MOST_X_HIGH ${encoded.high.toFixed(
+    `${encoded.high}`.length + 1
+  )}`;
+  const eastMostYlowDefine = `EAST_MOST_X_LOW ${encoded.low.toFixed(
+    `${encoded.low}`.length + 1
+  )}`;
 
   const westMostCartographic = new Cartographic();
   westMostCartographic.longitude = -CesiumMath.PI;
@@ -95,10 +97,12 @@ describe("Scene/ShadowVolumeAppearance", function () {
     westMostCartesian.x,
     longitudeExtentsEncodeScratch
   );
-  const westMostYhighDefine =
-    "WEST_MOST_X_HIGH " + encoded.high.toFixed((encoded.high + "").length + 1);
-  const westMostYlowDefine =
-    "WEST_MOST_X_LOW " + encoded.low.toFixed((encoded.low + "").length + 1);
+  const westMostYhighDefine = `WEST_MOST_X_HIGH ${encoded.high.toFixed(
+    `${encoded.high}`.length + 1
+  )}`;
+  const westMostYlowDefine = `WEST_MOST_X_LOW ${encoded.low.toFixed(
+    `${encoded.low}`.length + 1
+  )}`;
 
   it("provides attributes for computing texture coordinates from Spherical extents", function () {
     const attributes = largeRectangleAttributes;

--- a/Specs/Scene/TerrainFillMeshSpec.js
+++ b/Specs/Scene/TerrainFillMeshSpec.js
@@ -1250,7 +1250,7 @@ describe("Scene/TerrainFillMesh", function () {
       }
     }
 
-    fail("Vertex with u=" + u + ", v=" + v + " does not exist.");
+    fail(`Vertex with u=${u}, v=${v} does not exist.`);
   }
 
   function expectVertex(fill, u, v, height) {

--- a/Specs/Scene/TextureAtlasSpec.js
+++ b/Specs/Scene/TextureAtlasSpec.js
@@ -78,14 +78,11 @@ describe(
       const x = textureCoordinates.x + textureCoordinates.width / 2.0;
       const y = textureCoordinates.y + textureCoordinates.height / 2.0;
       const fs =
-        "uniform sampler2D u_texture;" +
-        "void main() {" +
-        "  gl_FragColor = texture2D(u_texture, vec2(" +
-        x +
-        ", " +
-        y +
-        "));" +
-        "}";
+        `${
+          "uniform sampler2D u_texture;" +
+          "void main() {" +
+          "  gl_FragColor = texture2D(u_texture, vec2("
+        }${x}, ${y}));` + `}`;
       const uniformMap = {
         u_texture: function () {
           return texture;

--- a/Specs/Scene/TileMapServiceImageryProviderSpec.js
+++ b/Specs/Scene/TileMapServiceImageryProviderSpec.js
@@ -291,7 +291,7 @@ describe("Scene/TileMapServiceImageryProvider", function () {
     patchRequestScheduler(validSampleXmlString);
     const baseUrl = "made/up/tms/server/";
     const provider = new TileMapServiceImageryProvider({
-      url: baseUrl + "?a=some&b=query",
+      url: `${baseUrl}?a=some&b=query`,
     });
 
     return pollToPromise(function () {

--- a/Specs/Scene/TimeDynamicImagerySpec.js
+++ b/Specs/Scene/TimeDynamicImagerySpec.js
@@ -223,7 +223,7 @@ describe("Scene/TimeDynamicImagery", function () {
           );
           expect(
             timeDynamicImagery._tilesRequestedForInterval[count - 1].key
-          ).toEqual(x + "-" + y + "-" + level);
+          ).toEqual(`${x}-${y}-${level}`);
         }
       }
     }

--- a/Specs/Scene/TimeDynamicPointCloudSpec.js
+++ b/Specs/Scene/TimeDynamicPointCloudSpec.js
@@ -155,7 +155,7 @@ describe(
 
       const uris = [];
       for (let i = 0; i < 5; ++i) {
-        uris.push(folderName + i + ".pnts");
+        uris.push(`${folderName + i}.pnts`);
       }
 
       function dataCallback(interval, index) {
@@ -800,7 +800,7 @@ describe(
       for (i = 0; i < 5; ++i) {
         const arg = spyUpdate.calls.argsFor(i)[0];
         expect(arg).toBeDefined();
-        expect(arg.uri).toContain(i + ".pnts");
+        expect(arg.uri).toContain(`${i}.pnts`);
         expect(arg.message).toBe("404");
       }
     });

--- a/Specs/Scene/UrlTemplateImageryProviderSpec.js
+++ b/Specs/Scene/UrlTemplateImageryProviderSpec.js
@@ -669,18 +669,13 @@ describe("Scene/UrlTemplateImageryProvider", function () {
         deferred
       ) {
         expect(request.url).toEqual(
-          "-90 " +
-            (-Math.PI * Ellipsoid.WGS84.maximumRadius) / 2.0 +
-            " " +
-            "0 " +
-            "0 " +
-            "0 " +
-            "0 " +
-            CesiumMath.toDegrees(
+          `-90 ${(-Math.PI * Ellipsoid.WGS84.maximumRadius) / 2.0} ` +
+            `0 ` +
+            `0 ` +
+            `0 ` +
+            `0 ${CesiumMath.toDegrees(
               WebMercatorProjection.mercatorAngleToGeodeticLatitude(Math.PI / 2)
-            ) +
-            " " +
-            (Math.PI * Ellipsoid.WGS84.maximumRadius) / 2.0
+            )} ${(Math.PI * Ellipsoid.WGS84.maximumRadius) / 2.0}`
         );
 
         // Just return any old image.

--- a/Specs/Scene/Vector3DTileGeometrySpec.js
+++ b/Specs/Scene/Vector3DTileGeometrySpec.js
@@ -331,7 +331,7 @@ describe(
         });
       }
 
-      it("renders a single box" + webglMessage, function () {
+      it(`renders a single box${webglMessage}`, function () {
         const dimensions = new Cartesian3(1000000.0, 1000000.0, 1000000.0);
         const boxes = packBoxes([
           {
@@ -351,7 +351,7 @@ describe(
         });
       });
 
-      it("renders multiple boxes" + webglMessage, function () {
+      it(`renders multiple boxes${webglMessage}`, function () {
         const dimensions = new Cartesian3(500000.0, 500000.0, 500000.0);
         const modelMatrices = [
           Matrix4.fromTranslation(new Cartesian3(dimensions.x, 0.0, 0.0)),
@@ -379,7 +379,7 @@ describe(
         });
       });
 
-      it("renders a single cylinder" + webglMessage, function () {
+      it(`renders a single cylinder${webglMessage}`, function () {
         const radius = 1000000.0;
         const length = 1000000.0;
         const cylinders = packCylinders([
@@ -401,7 +401,7 @@ describe(
         });
       });
 
-      it("renders multiple cylinders" + webglMessage, function () {
+      it(`renders multiple cylinders${webglMessage}`, function () {
         const radius = 500000.0;
         const length = 500000.0;
         const modelMatrices = [
@@ -432,7 +432,7 @@ describe(
         });
       });
 
-      it("renders a single ellipsoid" + webglMessage, function () {
+      it(`renders a single ellipsoid${webglMessage}`, function () {
         const radii = new Cartesian3(500000.0, 500000.0, 500000.0);
         const ellipsoid = packEllipsoids([
           {
@@ -452,7 +452,7 @@ describe(
         });
       });
 
-      it("renders multiple ellipsoids" + webglMessage, function () {
+      it(`renders multiple ellipsoids${webglMessage}`, function () {
         const radii = new Cartesian3(500000.0, 500000.0, 500000.0);
         const modelMatrices = [
           Matrix4.fromTranslation(new Cartesian3(radii.x, 0.0, 0.0)),
@@ -480,7 +480,7 @@ describe(
         });
       });
 
-      it("renders a single sphere" + webglMessage, function () {
+      it(`renders a single sphere${webglMessage}`, function () {
         const radius = 500000.0;
         const sphere = packSpheres([
           {
@@ -497,7 +497,7 @@ describe(
         });
       });
 
-      it("renders multiple spheres" + webglMessage, function () {
+      it(`renders multiple spheres${webglMessage}`, function () {
         const radius = 500000.0;
         const modelMatrices = [
           Matrix4.fromTranslation(new Cartesian3(radius, 0.0, 0.0)),
@@ -522,193 +522,187 @@ describe(
         });
       });
 
-      it(
-        "renders with multiple types of each geometry" + webglMessage,
-        function () {
-          const dimensions = new Cartesian3(125000.0, 125000.0, 125000.0);
-          const modelMatrices = [
-            Matrix4.fromTranslation(new Cartesian3(dimensions.x, 0.0, 0.0)),
-            Matrix4.fromTranslation(new Cartesian3(-dimensions.x, 0.0, 0.0)),
-          ];
-          const boxes = packBoxes([
-            {
-              modelMatrix: modelMatrices[0],
-              dimensions: dimensions,
-            },
-            {
-              modelMatrix: modelMatrices[1],
-              dimensions: dimensions,
-            },
-          ]);
-          const boxBatchIds = new Uint16Array([0, 1]);
+      it(`renders with multiple types of each geometry${webglMessage}`, function () {
+        const dimensions = new Cartesian3(125000.0, 125000.0, 125000.0);
+        const modelMatrices = [
+          Matrix4.fromTranslation(new Cartesian3(dimensions.x, 0.0, 0.0)),
+          Matrix4.fromTranslation(new Cartesian3(-dimensions.x, 0.0, 0.0)),
+        ];
+        const boxes = packBoxes([
+          {
+            modelMatrix: modelMatrices[0],
+            dimensions: dimensions,
+          },
+          {
+            modelMatrix: modelMatrices[1],
+            dimensions: dimensions,
+          },
+        ]);
+        const boxBatchIds = new Uint16Array([0, 1]);
 
-          const radius = 125000.0;
-          const length = 125000.0;
-          modelMatrices.push(
-            Matrix4.fromTranslation(new Cartesian3(radius, 0.0, 0.0)),
-            Matrix4.fromTranslation(new Cartesian3(-radius, 0.0, 0.0))
-          );
-          const cylinders = packCylinders([
-            {
-              modelMatrix: modelMatrices[2],
-              radius: radius,
-              length: length,
-            },
-            {
-              modelMatrix: modelMatrices[3],
-              radius: radius,
-              length: length,
-            },
-          ]);
-          const cylinderBatchIds = new Uint16Array([2, 3]);
+        const radius = 125000.0;
+        const length = 125000.0;
+        modelMatrices.push(
+          Matrix4.fromTranslation(new Cartesian3(radius, 0.0, 0.0)),
+          Matrix4.fromTranslation(new Cartesian3(-radius, 0.0, 0.0))
+        );
+        const cylinders = packCylinders([
+          {
+            modelMatrix: modelMatrices[2],
+            radius: radius,
+            length: length,
+          },
+          {
+            modelMatrix: modelMatrices[3],
+            radius: radius,
+            length: length,
+          },
+        ]);
+        const cylinderBatchIds = new Uint16Array([2, 3]);
 
-          const radii = new Cartesian3(125000.0, 125000.0, 125000.0);
-          modelMatrices.push(
-            Matrix4.fromTranslation(new Cartesian3(radii.x, 0.0, 0.0)),
-            Matrix4.fromTranslation(new Cartesian3(-radii.x, 0.0, 0.0))
-          );
-          const ellipsoids = packEllipsoids([
-            {
-              modelMatrix: modelMatrices[4],
-              radii: radii,
-            },
-            {
-              modelMatrix: modelMatrices[5],
-              radii: radii,
-            },
-          ]);
-          const ellipsoidBatchIds = new Uint16Array([4, 5]);
+        const radii = new Cartesian3(125000.0, 125000.0, 125000.0);
+        modelMatrices.push(
+          Matrix4.fromTranslation(new Cartesian3(radii.x, 0.0, 0.0)),
+          Matrix4.fromTranslation(new Cartesian3(-radii.x, 0.0, 0.0))
+        );
+        const ellipsoids = packEllipsoids([
+          {
+            modelMatrix: modelMatrices[4],
+            radii: radii,
+          },
+          {
+            modelMatrix: modelMatrices[5],
+            radii: radii,
+          },
+        ]);
+        const ellipsoidBatchIds = new Uint16Array([4, 5]);
 
-          modelMatrices.push(
-            Matrix4.fromTranslation(new Cartesian3(radius, 0.0, 0.0)),
-            Matrix4.fromTranslation(new Cartesian3(-radius, 0.0, 0.0))
-          );
-          const spheres = packSpheres([
-            {
-              modelMatrix: modelMatrices[6],
-              radius: radius,
-            },
-            {
-              modelMatrix: modelMatrices[7],
-              radius: radius,
-            },
-          ]);
-          const sphereBatchIds = new Uint16Array([6, 7]);
+        modelMatrices.push(
+          Matrix4.fromTranslation(new Cartesian3(radius, 0.0, 0.0)),
+          Matrix4.fromTranslation(new Cartesian3(-radius, 0.0, 0.0))
+        );
+        const spheres = packSpheres([
+          {
+            modelMatrix: modelMatrices[6],
+            radius: radius,
+          },
+          {
+            modelMatrix: modelMatrices[7],
+            radius: radius,
+          },
+        ]);
+        const sphereBatchIds = new Uint16Array([6, 7]);
 
-          const bv = new BoundingSphere(undefined, 50000000.0);
+        const bv = new BoundingSphere(undefined, 50000000.0);
 
-          return verifyMultipleRender(modelMatrices, {
+        return verifyMultipleRender(modelMatrices, {
+          boxes: boxes,
+          boxBatchIds: boxBatchIds,
+          cylinders: cylinders,
+          cylinderBatchIds: cylinderBatchIds,
+          ellipsoids: ellipsoids,
+          ellipsoidBatchIds: ellipsoidBatchIds,
+          spheres: spheres,
+          sphereBatchIds: sphereBatchIds,
+          boundingVolume: bv,
+        });
+      });
+
+      it(`renders multiple geometries after a re-batch${webglMessage}`, function () {
+        const dimensions = new Cartesian3(125000.0, 125000.0, 125000.0);
+        const modelMatrices = [
+          Matrix4.fromTranslation(new Cartesian3(dimensions.x, 0.0, 0.0)),
+          Matrix4.fromTranslation(new Cartesian3(-dimensions.x, 0.0, 0.0)),
+        ];
+        const boxes = packBoxes([
+          {
+            modelMatrix: modelMatrices[0],
+            dimensions: dimensions,
+          },
+          {
+            modelMatrix: modelMatrices[1],
+            dimensions: dimensions,
+          },
+        ]);
+        const boxBatchIds = new Uint16Array([0, 1]);
+
+        const radius = 125000.0;
+        let length = 125000.0;
+        modelMatrices.push(
+          Matrix4.fromTranslation(new Cartesian3(radius, 0.0, 0.0)),
+          Matrix4.fromTranslation(new Cartesian3(-radius, 0.0, 0.0))
+        );
+        const cylinders = packCylinders([
+          {
+            modelMatrix: modelMatrices[2],
+            radius: radius,
+            length: length,
+          },
+          {
+            modelMatrix: modelMatrices[3],
+            radius: radius,
+            length: length,
+          },
+        ]);
+        const cylinderBatchIds = new Uint16Array([2, 3]);
+
+        const origin = Rectangle.center(rectangle);
+        const center = ellipsoid.cartographicToCartesian(origin);
+        const modelMatrix = Transforms.eastNorthUpToFixedFrame(center);
+
+        const bv = new BoundingSphere(center, 50000000.0);
+
+        length = modelMatrices.length;
+        const batchTable = new Cesium3DTileBatchTable(mockTileset, length);
+        batchTable.update(mockTileset, scene.frameState);
+
+        scene.primitives.add(globePrimitive);
+
+        geometry = scene.primitives.add(
+          new Vector3DTileGeometry({
             boxes: boxes,
             boxBatchIds: boxBatchIds,
             cylinders: cylinders,
             cylinderBatchIds: cylinderBatchIds,
-            ellipsoids: ellipsoids,
-            ellipsoidBatchIds: ellipsoidBatchIds,
-            spheres: spheres,
-            sphereBatchIds: sphereBatchIds,
+            center: center,
+            modelMatrix: modelMatrix,
+            batchTable: batchTable,
             boundingVolume: bv,
-          });
-        }
-      );
+          })
+        );
+        geometry.forceRebatch = true;
+        return loadGeometries(geometry).then(function () {
+          let i;
+          for (i = 0; i < length; ++i) {
+            batchTable.setShow(i, false);
+          }
 
-      it(
-        "renders multiple geometries after a re-batch" + webglMessage,
-        function () {
-          const dimensions = new Cartesian3(125000.0, 125000.0, 125000.0);
-          const modelMatrices = [
-            Matrix4.fromTranslation(new Cartesian3(dimensions.x, 0.0, 0.0)),
-            Matrix4.fromTranslation(new Cartesian3(-dimensions.x, 0.0, 0.0)),
-          ];
-          const boxes = packBoxes([
-            {
-              modelMatrix: modelMatrices[0],
-              dimensions: dimensions,
-            },
-            {
-              modelMatrix: modelMatrices[1],
-              dimensions: dimensions,
-            },
-          ]);
-          const boxBatchIds = new Uint16Array([0, 1]);
+          for (i = 0; i < length; ++i) {
+            const transform = Matrix4.multiply(
+              modelMatrix,
+              modelMatrices[i],
+              new Matrix4()
+            );
+            scene.camera.lookAtTransform(
+              transform,
+              new Cartesian3(0.0, 0.0, 10.0)
+            );
 
-          const radius = 125000.0;
-          let length = 125000.0;
-          modelMatrices.push(
-            Matrix4.fromTranslation(new Cartesian3(radius, 0.0, 0.0)),
-            Matrix4.fromTranslation(new Cartesian3(-radius, 0.0, 0.0))
-          );
-          const cylinders = packCylinders([
-            {
-              modelMatrix: modelMatrices[2],
-              radius: radius,
-              length: length,
-            },
-            {
-              modelMatrix: modelMatrices[3],
-              radius: radius,
-              length: length,
-            },
-          ]);
-          const cylinderBatchIds = new Uint16Array([2, 3]);
+            batchTable.setShow(i, true);
+            batchTable.update(mockTileset, scene.frameState);
+            expect(scene).toRender([255, 255, 255, 255]);
 
-          const origin = Rectangle.center(rectangle);
-          const center = ellipsoid.cartographicToCartesian(origin);
-          const modelMatrix = Transforms.eastNorthUpToFixedFrame(center);
+            batchTable.setColor(i, Color.BLUE);
+            geometry.updateCommands(i, Color.BLUE);
+            batchTable.update(mockTileset, scene.frameState);
+            expect(scene).toRender([0, 0, 255, 255]);
 
-          const bv = new BoundingSphere(center, 50000000.0);
+            batchTable.setShow(i, false);
+          }
+        });
+      });
 
-          length = modelMatrices.length;
-          const batchTable = new Cesium3DTileBatchTable(mockTileset, length);
-          batchTable.update(mockTileset, scene.frameState);
-
-          scene.primitives.add(globePrimitive);
-
-          geometry = scene.primitives.add(
-            new Vector3DTileGeometry({
-              boxes: boxes,
-              boxBatchIds: boxBatchIds,
-              cylinders: cylinders,
-              cylinderBatchIds: cylinderBatchIds,
-              center: center,
-              modelMatrix: modelMatrix,
-              batchTable: batchTable,
-              boundingVolume: bv,
-            })
-          );
-          geometry.forceRebatch = true;
-          return loadGeometries(geometry).then(function () {
-            let i;
-            for (i = 0; i < length; ++i) {
-              batchTable.setShow(i, false);
-            }
-
-            for (i = 0; i < length; ++i) {
-              const transform = Matrix4.multiply(
-                modelMatrix,
-                modelMatrices[i],
-                new Matrix4()
-              );
-              scene.camera.lookAtTransform(
-                transform,
-                new Cartesian3(0.0, 0.0, 10.0)
-              );
-
-              batchTable.setShow(i, true);
-              batchTable.update(mockTileset, scene.frameState);
-              expect(scene).toRender([255, 255, 255, 255]);
-
-              batchTable.setColor(i, Color.BLUE);
-              geometry.updateCommands(i, Color.BLUE);
-              batchTable.update(mockTileset, scene.frameState);
-              expect(scene).toRender([0, 0, 255, 255]);
-
-              batchTable.setShow(i, false);
-            }
-          });
-        }
-      );
-
-      it("renders with inverted classification" + webglMessage, function () {
+      it(`renders with inverted classification${webglMessage}`, function () {
         const radii = new Cartesian3(100.0, 100.0, 1000.0);
         const ellipsoids = packEllipsoids([
           {
@@ -763,7 +757,7 @@ describe(
         });
       });
 
-      it("renders wireframe" + webglMessage, function () {
+      it(`renders wireframe${webglMessage}`, function () {
         const origin = Rectangle.center(rectangle);
         const center = ellipsoid.cartographicToCartesian(origin);
         const modelMatrix = Transforms.eastNorthUpToFixedFrame(center);
@@ -803,7 +797,7 @@ describe(
         });
       });
 
-      it("renders based on classificationType" + webglMessage, function () {
+      it(`renders based on classificationType${webglMessage}`, function () {
         const radii = new Cartesian3(100.0, 100.0, 1000.0);
         const ellipsoids = packEllipsoids([
           {
@@ -873,7 +867,7 @@ describe(
         });
       });
 
-      it("picks geometry" + webglMessage, function () {
+      it(`picks geometry${webglMessage}`, function () {
         const origin = Rectangle.center(rectangle);
         const center = ellipsoid.cartographicToCartesian(origin);
         const modelMatrix = Transforms.eastNorthUpToFixedFrame(center);
@@ -921,7 +915,7 @@ describe(
         });
       });
 
-      it("isDestroyed" + webglMessage, function () {
+      it(`isDestroyed${webglMessage}`, function () {
         geometry = new Vector3DTileGeometry({});
         expect(geometry.isDestroyed()).toEqual(false);
         geometry.destroy();

--- a/Specs/Scene/Vector3DTilePointsSpec.js
+++ b/Specs/Scene/Vector3DTilePointsSpec.js
@@ -304,7 +304,7 @@ describe(
         labelOutlineColor: "rgba(255, 255, 0, 0.5)",
         labelOutlineWidth: "1.0",
         font: '"30px sans-serif"',
-        labelStyle: "" + LabelStyle.FILL_AND_OUTLINE,
+        labelStyle: `${LabelStyle.FILL_AND_OUTLINE}`,
         labelText: '"test"',
         backgroundColor: "rgba(255, 255, 0, 0.2)",
         backgroundPadding: "vec2(10, 11)",
@@ -316,10 +316,10 @@ describe(
         anchorLineEnabled: "true",
         anchorLineColor: "rgba(255, 255, 0, 1.0)",
         disableDepthTestDistance: "1.0e6",
-        horizontalOrigin: "" + HorizontalOrigin.CENTER,
-        verticalOrigin: "" + VerticalOrigin.CENTER,
-        labelHorizontalOrigin: "" + HorizontalOrigin.RIGHT,
-        labelVerticalOrigin: "" + VerticalOrigin.BOTTOM,
+        horizontalOrigin: `${HorizontalOrigin.CENTER}`,
+        verticalOrigin: `${VerticalOrigin.CENTER}`,
+        labelHorizontalOrigin: `${HorizontalOrigin.RIGHT}`,
+        labelVerticalOrigin: `${VerticalOrigin.BOTTOM}`,
       });
 
       return loadPoints(points).then(function () {

--- a/Specs/Scene/Vector3DTilePolygonsSpec.js
+++ b/Specs/Scene/Vector3DTilePolygonsSpec.js
@@ -233,7 +233,7 @@ describe(
         };
       }
 
-      it("renders a single polygon" + webglMessage, function () {
+      it(`renders a single polygon${webglMessage}`, function () {
         const rectangle = Rectangle.fromDegrees(-1.0, -1.0, 1.0, 1.0);
         const polygonOptions = createPolygon(rectangle);
 
@@ -273,7 +273,7 @@ describe(
         });
       });
 
-      it("renders multiple polygons" + webglMessage, function () {
+      it(`renders multiple polygons${webglMessage}`, function () {
         const rectangle1 = Rectangle.fromDegrees(-1.0, -1.0, 1.0, 1.0);
         const rectangle2 = Rectangle.fromDegrees(1.0, -1.0, 2.0, 1.0);
         const cartographicPositions = [
@@ -337,141 +337,134 @@ describe(
         });
       });
 
-      it(
-        "renders multiple polygons after re-batch" + webglMessage,
-        function () {
-          const rectangle1 = Rectangle.fromDegrees(-1.0, -1.0, 1.0, 1.0);
-          const rectangle2 = Rectangle.fromDegrees(1.0, -1.0, 2.0, 1.0);
-          const cartographicPositions = [
-            Rectangle.northwest(rectangle1),
-            Rectangle.southwest(rectangle1),
-            Rectangle.southeast(rectangle1),
-            Rectangle.northeast(rectangle1),
-            Rectangle.northwest(rectangle2),
-            Rectangle.southwest(rectangle2),
-            Rectangle.southeast(rectangle2),
-            Rectangle.northeast(rectangle2),
-          ];
-          const rectangle = Rectangle.fromDegrees(-1.0, -1.0, 2.0, 1.0);
+      it(`renders multiple polygons after re-batch${webglMessage}`, function () {
+        const rectangle1 = Rectangle.fromDegrees(-1.0, -1.0, 1.0, 1.0);
+        const rectangle2 = Rectangle.fromDegrees(1.0, -1.0, 2.0, 1.0);
+        const cartographicPositions = [
+          Rectangle.northwest(rectangle1),
+          Rectangle.southwest(rectangle1),
+          Rectangle.southeast(rectangle1),
+          Rectangle.northeast(rectangle1),
+          Rectangle.northwest(rectangle2),
+          Rectangle.southwest(rectangle2),
+          Rectangle.southeast(rectangle2),
+          Rectangle.northeast(rectangle2),
+        ];
+        const rectangle = Rectangle.fromDegrees(-1.0, -1.0, 2.0, 1.0);
 
-          const batchTable = new Cesium3DTileBatchTable(mockTileset, 2);
-          batchTable.update(mockTileset, scene.frameState);
+        const batchTable = new Cesium3DTileBatchTable(mockTileset, 2);
+        batchTable.update(mockTileset, scene.frameState);
 
-          scene.primitives.add(globePrimitive);
+        scene.primitives.add(globePrimitive);
 
-          const center = ellipsoid.cartographicToCartesian(
-            Rectangle.center(rectangle)
-          );
-          polygons = scene.primitives.add(
-            new Vector3DTilePolygons({
-              positions: encodePositions(rectangle, cartographicPositions),
-              indices: new Uint16Array([0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7]),
-              counts: new Uint32Array([4, 4]),
-              indexCounts: new Uint32Array([6, 6]),
-              minimumHeight: -10000.0,
-              maximumHeight: 10000.0,
-              center: center,
-              rectangle: rectangle,
-              boundingVolume: new BoundingSphere(center, 10000.0),
-              batchTable: batchTable,
-              batchIds: new Uint32Array([0, 1]),
-              isCartographic: true,
-            })
-          );
-          polygons.forceRebatch = true;
-          return loadPolygons(polygons).then(function () {
-            scene.camera.setView({
-              destination: rectangle1,
-            });
-
-            expect(scene).toRender([255, 255, 255, 255]);
-
-            batchTable.setColor(0, Color.BLUE);
-            polygons.updateCommands(0, Color.BLUE);
-            batchTable.update(mockTileset, scene.frameState);
-            expect(scene).toRender([0, 0, 255, 255]);
-
-            scene.camera.setView({
-              destination: rectangle2,
-            });
-
-            expect(scene).toRender([255, 255, 255, 255]);
-
-            batchTable.setColor(1, Color.BLUE);
-            polygons.updateCommands(1, Color.BLUE);
-            batchTable.update(mockTileset, scene.frameState);
-            expect(scene).toRender([0, 0, 255, 255]);
+        const center = ellipsoid.cartographicToCartesian(
+          Rectangle.center(rectangle)
+        );
+        polygons = scene.primitives.add(
+          new Vector3DTilePolygons({
+            positions: encodePositions(rectangle, cartographicPositions),
+            indices: new Uint16Array([0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7]),
+            counts: new Uint32Array([4, 4]),
+            indexCounts: new Uint32Array([6, 6]),
+            minimumHeight: -10000.0,
+            maximumHeight: 10000.0,
+            center: center,
+            rectangle: rectangle,
+            boundingVolume: new BoundingSphere(center, 10000.0),
+            batchTable: batchTable,
+            batchIds: new Uint32Array([0, 1]),
+            isCartographic: true,
+          })
+        );
+        polygons.forceRebatch = true;
+        return loadPolygons(polygons).then(function () {
+          scene.camera.setView({
+            destination: rectangle1,
           });
-        }
-      );
 
-      it(
-        "renders multiple polygons with different minimum and maximum heights" +
-          webglMessage,
-        function () {
-          const rectangle1 = Rectangle.fromDegrees(-1.0, -1.0, 1.0, 1.0);
-          const rectangle2 = Rectangle.fromDegrees(1.0, -1.0, 2.0, 1.0);
-          const cartographicPositions = [
-            Rectangle.northwest(rectangle1),
-            Rectangle.southwest(rectangle1),
-            Rectangle.southeast(rectangle1),
-            Rectangle.northeast(rectangle1),
-            Rectangle.northwest(rectangle2),
-            Rectangle.southwest(rectangle2),
-            Rectangle.southeast(rectangle2),
-            Rectangle.northeast(rectangle2),
-          ];
-          const rectangle = Rectangle.fromDegrees(-1.0, -1.0, 2.0, 1.0);
+          expect(scene).toRender([255, 255, 255, 255]);
 
-          const batchTable = new Cesium3DTileBatchTable(mockTileset, 2);
+          batchTable.setColor(0, Color.BLUE);
+          polygons.updateCommands(0, Color.BLUE);
           batchTable.update(mockTileset, scene.frameState);
+          expect(scene).toRender([0, 0, 255, 255]);
 
-          scene.primitives.add(globePrimitive);
-
-          const center = ellipsoid.cartographicToCartesian(
-            Rectangle.center(rectangle)
-          );
-          polygons = scene.primitives.add(
-            new Vector3DTilePolygons({
-              positions: encodePositions(rectangle, cartographicPositions),
-              indices: new Uint16Array([0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7]),
-              counts: new Uint32Array([4, 4]),
-              indexCounts: new Uint32Array([6, 6]),
-              minimumHeight: -10000.0,
-              maximumHeight: 10000.0,
-              polygonMinimumHeights: new Float32Array([-10000.0, 10.0]),
-              polygonMaximumHeights: new Float32Array([10000.0, 100.0]),
-              center: center,
-              rectangle: rectangle,
-              boundingVolume: new BoundingSphere(center, 10000.0),
-              batchTable: batchTable,
-              batchIds: new Uint32Array([0, 1]),
-              isCartographic: true,
-            })
-          );
-          polygons.forceRebatch = true;
-          return loadPolygons(polygons).then(function () {
-            scene.camera.setView({
-              destination: rectangle1,
-            });
-
-            expect(scene).toRender([255, 255, 255, 255]);
-
-            batchTable.setColor(0, Color.BLUE);
-            polygons.updateCommands(0, Color.BLUE);
-            batchTable.update(mockTileset, scene.frameState);
-            expect(scene).toRender([0, 0, 255, 255]);
-
-            scene.camera.setView({
-              destination: rectangle2,
-            });
-
-            expect(scene).toRender([255, 0, 0, 255]);
+          scene.camera.setView({
+            destination: rectangle2,
           });
-        }
-      );
 
-      it("renders with inverted classification" + webglMessage, function () {
+          expect(scene).toRender([255, 255, 255, 255]);
+
+          batchTable.setColor(1, Color.BLUE);
+          polygons.updateCommands(1, Color.BLUE);
+          batchTable.update(mockTileset, scene.frameState);
+          expect(scene).toRender([0, 0, 255, 255]);
+        });
+      });
+
+      it(`renders multiple polygons with different minimum and maximum heights${webglMessage}`, function () {
+        const rectangle1 = Rectangle.fromDegrees(-1.0, -1.0, 1.0, 1.0);
+        const rectangle2 = Rectangle.fromDegrees(1.0, -1.0, 2.0, 1.0);
+        const cartographicPositions = [
+          Rectangle.northwest(rectangle1),
+          Rectangle.southwest(rectangle1),
+          Rectangle.southeast(rectangle1),
+          Rectangle.northeast(rectangle1),
+          Rectangle.northwest(rectangle2),
+          Rectangle.southwest(rectangle2),
+          Rectangle.southeast(rectangle2),
+          Rectangle.northeast(rectangle2),
+        ];
+        const rectangle = Rectangle.fromDegrees(-1.0, -1.0, 2.0, 1.0);
+
+        const batchTable = new Cesium3DTileBatchTable(mockTileset, 2);
+        batchTable.update(mockTileset, scene.frameState);
+
+        scene.primitives.add(globePrimitive);
+
+        const center = ellipsoid.cartographicToCartesian(
+          Rectangle.center(rectangle)
+        );
+        polygons = scene.primitives.add(
+          new Vector3DTilePolygons({
+            positions: encodePositions(rectangle, cartographicPositions),
+            indices: new Uint16Array([0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7]),
+            counts: new Uint32Array([4, 4]),
+            indexCounts: new Uint32Array([6, 6]),
+            minimumHeight: -10000.0,
+            maximumHeight: 10000.0,
+            polygonMinimumHeights: new Float32Array([-10000.0, 10.0]),
+            polygonMaximumHeights: new Float32Array([10000.0, 100.0]),
+            center: center,
+            rectangle: rectangle,
+            boundingVolume: new BoundingSphere(center, 10000.0),
+            batchTable: batchTable,
+            batchIds: new Uint32Array([0, 1]),
+            isCartographic: true,
+          })
+        );
+        polygons.forceRebatch = true;
+        return loadPolygons(polygons).then(function () {
+          scene.camera.setView({
+            destination: rectangle1,
+          });
+
+          expect(scene).toRender([255, 255, 255, 255]);
+
+          batchTable.setColor(0, Color.BLUE);
+          polygons.updateCommands(0, Color.BLUE);
+          batchTable.update(mockTileset, scene.frameState);
+          expect(scene).toRender([0, 0, 255, 255]);
+
+          scene.camera.setView({
+            destination: rectangle2,
+          });
+
+          expect(scene).toRender([255, 0, 0, 255]);
+        });
+      });
+
+      it(`renders with inverted classification${webglMessage}`, function () {
         const rectangle = Rectangle.fromDegrees(-1.0, -1.0, 1.0, 1.0);
         const polygonOptions = createPolygon(rectangle);
 
@@ -518,7 +511,7 @@ describe(
         });
       });
 
-      it("renders wireframe" + webglMessage, function () {
+      it(`renders wireframe${webglMessage}`, function () {
         const rectangle = Rectangle.fromDegrees(-1.0, -1.0, 1.0, 1.0);
         const polygonOptions = createPolygon(rectangle);
 
@@ -559,7 +552,7 @@ describe(
         });
       });
 
-      it("renders based on classificationType" + webglMessage, function () {
+      it(`renders based on classificationType${webglMessage}`, function () {
         const rectangle = Rectangle.fromDegrees(-1.0, -1.0, 1.0, 1.0);
         const polygonOptions = createPolygon(rectangle);
 
@@ -620,7 +613,7 @@ describe(
         });
       });
 
-      it("picks polygons" + webglMessage, function () {
+      it(`picks polygons${webglMessage}`, function () {
         const rectangle = Rectangle.fromDegrees(-1.0, -1.0, 1.0, 1.0);
         const polygonOptions = createPolygon(rectangle);
 
@@ -669,7 +662,7 @@ describe(
         });
       });
 
-      it("isDestroyed" + webglMessage, function () {
+      it(`isDestroyed${webglMessage}`, function () {
         polygons = new Vector3DTilePolygons({});
         expect(polygons.isDestroyed()).toEqual(false);
         polygons.destroy();

--- a/Specs/Scene/WebMapServiceImageryProviderSpec.js
+++ b/Specs/Scene/WebMapServiceImageryProviderSpec.js
@@ -637,7 +637,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
 
         const rect = tilingScheme.tileXYToNativeRectangle(0, 0, 0);
         expect(params.bbox).toEqual(
-          rect.west + "," + rect.south + "," + rect.east + "," + rect.north
+          `${rect.west},${rect.south},${rect.east},${rect.north}`
         );
 
         Resource._DefaultImplementations.createImage(
@@ -692,7 +692,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
 
         const rect = tilingScheme.tileXYToNativeRectangle(0, 0, 0);
         expect(params.bbox).toEqual(
-          rect.west + "," + rect.south + "," + rect.east + "," + rect.north
+          `${rect.west},${rect.south},${rect.east},${rect.north}`
         );
 
         Resource._DefaultImplementations.createImage(
@@ -744,7 +744,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
 
         const rect = tilingScheme.tileXYToNativeRectangle(0, 0, 0);
         expect(params.bbox).toEqual(
-          rect.west + "," + rect.south + "," + rect.east + "," + rect.north
+          `${rect.west},${rect.south},${rect.east},${rect.north}`
         );
 
         Resource._DefaultImplementations.createImage(
@@ -799,7 +799,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
 
         const rect = tilingScheme.tileXYToNativeRectangle(0, 0, 0);
         expect(params.bbox).toEqual(
-          rect.west + "," + rect.south + "," + rect.east + "," + rect.north
+          `${rect.west},${rect.south},${rect.east},${rect.north}`
         );
 
         Resource._DefaultImplementations.createImage(
@@ -854,7 +854,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
 
         const rect = tilingScheme.tileXYToNativeRectangle(0, 0, 0);
         expect(params.bbox).toEqual(
-          rect.west + "," + rect.south + "," + rect.east + "," + rect.north
+          `${rect.west},${rect.south},${rect.east},${rect.north}`
         );
 
         Resource._DefaultImplementations.createImage(
@@ -909,7 +909,7 @@ describe("Scene/WebMapServiceImageryProvider", function () {
 
         const rect = tilingScheme.tileXYToNativeRectangle(0, 0, 0);
         expect(params.bbox).toEqual(
-          rect.west + "," + rect.south + "," + rect.east + "," + rect.north
+          `${rect.west},${rect.south},${rect.east},${rect.north}`
         );
 
         Resource._DefaultImplementations.createImage(

--- a/Specs/ThirdParty/whenSpec.js
+++ b/Specs/ThirdParty/whenSpec.js
@@ -113,7 +113,7 @@ describe("ThirdParty/when", function () {
   it("chains failure", function () {
     promise
       .then(undefined, function (e) {
-        return when.reject("important" + e);
+        return when.reject(`important${e}`);
       })
       .then(captureValue, captureError);
 

--- a/Specs/Widgets/BaseLayerPicker/BaseLayerPickerSpec.js
+++ b/Specs/Widgets/BaseLayerPicker/BaseLayerPickerSpec.js
@@ -29,29 +29,26 @@ describe("Widgets/BaseLayerPicker/BaseLayerPicker", function () {
   });
 
   function addCloseOnInputSpec(name, func) {
-    it(
-      name + " event closes dropdown if target is not inside container",
-      function () {
-        const container = document.createElement("div");
-        container.id = "testContainer";
-        document.body.appendChild(container);
+    it(`${name} event closes dropdown if target is not inside container`, function () {
+      const container = document.createElement("div");
+      container.id = "testContainer";
+      document.body.appendChild(container);
 
-        const widget = new BaseLayerPicker("testContainer", {
-          globe: new MockGlobe(),
-        });
+      const widget = new BaseLayerPicker("testContainer", {
+        globe: new MockGlobe(),
+      });
 
-        widget.viewModel.dropDownVisible = true;
-        func(document.body);
-        expect(widget.viewModel.dropDownVisible).toEqual(false);
+      widget.viewModel.dropDownVisible = true;
+      func(document.body);
+      expect(widget.viewModel.dropDownVisible).toEqual(false);
 
-        widget.viewModel.dropDownVisible = true;
-        func(container.firstChild);
-        expect(widget.viewModel.dropDownVisible).toEqual(true);
+      widget.viewModel.dropDownVisible = true;
+      func(container.firstChild);
+      expect(widget.viewModel.dropDownVisible).toEqual(true);
 
-        widget.destroy();
-        document.body.removeChild(container);
-      }
-    );
+      widget.destroy();
+      document.body.removeChild(container);
+    });
   }
 
   if (FeatureDetection.supportsPointerEvents()) {

--- a/Specs/Widgets/BaseLayerPicker/BaseLayerPickerViewModelSpec.js
+++ b/Specs/Widgets/BaseLayerPicker/BaseLayerPickerViewModelSpec.js
@@ -190,7 +190,7 @@ describe("Widgets/BaseLayerPicker/BaseLayerPickerViewModel", function () {
 
     viewModel.selectedImagery = testProviderViewModel;
     expect(viewModel.buttonTooltip).toEqual(
-      testProviderViewModel.name + "\n" + testProviderViewModel3.name
+      `${testProviderViewModel.name}\n${testProviderViewModel3.name}`
     );
 
     viewModel.selectedImagery = undefined;

--- a/Specs/Widgets/NavigationHelpButton/NavigationHelpButtonSpec.js
+++ b/Specs/Widgets/NavigationHelpButton/NavigationHelpButtonSpec.js
@@ -38,29 +38,26 @@ describe("Widgets/NavigationHelpButton/NavigationHelpButton", function () {
   });
 
   function addCloseOnInputSpec(name, func) {
-    it(
-      name + " event closes dropdown if target is not inside container",
-      function () {
-        const container = document.createElement("span");
-        container.id = "testContainer";
-        document.body.appendChild(container);
+    it(`${name} event closes dropdown if target is not inside container`, function () {
+      const container = document.createElement("span");
+      container.id = "testContainer";
+      document.body.appendChild(container);
 
-        const widget = new NavigationHelpButton({
-          container: "testContainer",
-        });
+      const widget = new NavigationHelpButton({
+        container: "testContainer",
+      });
 
-        widget.viewModel.showInstructions = true;
-        func(document.body);
-        expect(widget.viewModel.showInstructions).toEqual(false);
+      widget.viewModel.showInstructions = true;
+      func(document.body);
+      expect(widget.viewModel.showInstructions).toEqual(false);
 
-        widget.viewModel.showInstructions = true;
-        func(container.firstChild);
-        expect(widget.viewModel.showInstructions).toEqual(true);
+      widget.viewModel.showInstructions = true;
+      func(container.firstChild);
+      expect(widget.viewModel.showInstructions).toEqual(true);
 
-        widget.destroy();
-        document.body.removeChild(container);
-      }
-    );
+      widget.destroy();
+      document.body.removeChild(container);
+    });
   }
 
   if (FeatureDetection.supportsPointerEvents()) {

--- a/Specs/Widgets/ProjectionPicker/ProjectionPickerSpec.js
+++ b/Specs/Widgets/ProjectionPicker/ProjectionPickerSpec.js
@@ -32,31 +32,28 @@ describe(
     });
 
     function addCloseOnInputSpec(name, func) {
-      it(
-        name + " event closes dropdown if target is not inside container",
-        function () {
-          const container = document.createElement("span");
-          container.id = "testContainer";
-          document.body.appendChild(container);
+      it(`${name} event closes dropdown if target is not inside container`, function () {
+        const container = document.createElement("span");
+        container.id = "testContainer";
+        document.body.appendChild(container);
 
-          const widget = new ProjectionPicker("testContainer", scene);
+        const widget = new ProjectionPicker("testContainer", scene);
 
-          widget.viewModel.dropDownVisible = true;
-          func(document.body);
-          expect(widget.viewModel.dropDownVisible).toEqual(false);
+        widget.viewModel.dropDownVisible = true;
+        func(document.body);
+        expect(widget.viewModel.dropDownVisible).toEqual(false);
 
-          widget.viewModel.dropDownVisible = true;
-          func(container.firstChild);
-          expect(widget.viewModel.dropDownVisible).toEqual(true);
+        widget.viewModel.dropDownVisible = true;
+        func(container.firstChild);
+        expect(widget.viewModel.dropDownVisible).toEqual(true);
 
-          widget.destroy();
-          document.body.removeChild(container);
-        }
-      );
+        widget.destroy();
+        document.body.removeChild(container);
+      });
     }
 
     function addDisabledDuringFlightSpec(name, func) {
-      it(name + " event does nothing during camera flight", function () {
+      it(`${name} event does nothing during camera flight`, function () {
         const container = document.createElement("span");
         container.id = "testContainer";
         document.body.appendChild(container);
@@ -76,7 +73,7 @@ describe(
     }
 
     function addDisabledIn2DSpec(name, func) {
-      it(name + " event does nothing in 2D", function () {
+      it(`${name} event does nothing in 2D`, function () {
         const container = document.createElement("span");
         container.id = "testContainer";
         document.body.appendChild(container);

--- a/Specs/Widgets/SceneModePicker/SceneModePickerSpec.js
+++ b/Specs/Widgets/SceneModePicker/SceneModePickerSpec.js
@@ -32,27 +32,24 @@ describe(
     });
 
     function addCloseOnInputSpec(name, func) {
-      it(
-        name + " event closes dropdown if target is not inside container",
-        function () {
-          const container = document.createElement("span");
-          container.id = "testContainer";
-          document.body.appendChild(container);
+      it(`${name} event closes dropdown if target is not inside container`, function () {
+        const container = document.createElement("span");
+        container.id = "testContainer";
+        document.body.appendChild(container);
 
-          const widget = new SceneModePicker("testContainer", scene);
+        const widget = new SceneModePicker("testContainer", scene);
 
-          widget.viewModel.dropDownVisible = true;
-          func(document.body);
-          expect(widget.viewModel.dropDownVisible).toEqual(false);
+        widget.viewModel.dropDownVisible = true;
+        func(document.body);
+        expect(widget.viewModel.dropDownVisible).toEqual(false);
 
-          widget.viewModel.dropDownVisible = true;
-          func(container.firstChild);
-          expect(widget.viewModel.dropDownVisible).toEqual(true);
+        widget.viewModel.dropDownVisible = true;
+        func(container.firstChild);
+        expect(widget.viewModel.dropDownVisible).toEqual(true);
 
-          widget.destroy();
-          document.body.removeChild(container);
-        }
-      );
+        widget.destroy();
+        document.body.removeChild(container);
+      });
     }
 
     if (FeatureDetection.supportsPointerEvents()) {

--- a/Specs/addDefaultMatchers.js
+++ b/Specs/addDefaultMatchers.js
@@ -20,15 +20,7 @@ function createMissingFunctionMessageFunction(
   expectedInterfacePrototype
 ) {
   return function () {
-    return (
-      "Expected function '" +
-      item +
-      "' to exist on " +
-      actualPrototype.constructor.name +
-      " because it should implement interface " +
-      expectedInterfacePrototype.constructor.name +
-      "."
-    );
+    return `Expected function '${item}' to exist on ${actualPrototype.constructor.name} because it should implement interface ${expectedInterfacePrototype.constructor.name}.`;
   };
 }
 
@@ -58,11 +50,11 @@ function makeThrowFunction(debug, Type, name) {
           let message;
           if (result) {
             message = [
-              "Expected function not to throw " + name + " , but it threw",
+              `Expected function not to throw ${name} , but it threw`,
               exception.message || exception,
             ].join(" ");
           } else {
-            message = "Expected function to throw " + name + ".";
+            message = `Expected function to throw ${name}.`;
           }
 
           return {
@@ -249,13 +241,11 @@ function createDefaultMatchers(debug) {
           } else {
             result.pass = actual instanceof expectedConstructor;
           }
-          result.message =
-            "Expected " +
-            Object.prototype.toString.call(actual) +
-            " to be instance of " +
-            expectedConstructor.name +
-            ", but was instance of " +
-            (actual && actual.constructor.name);
+          result.message = `Expected ${Object.prototype.toString.call(
+            actual
+          )} to be instance of ${
+            expectedConstructor.name
+          }, but was instance of ${actual && actual.constructor.name}`;
           return result;
         },
       };
@@ -573,19 +563,9 @@ function createDefaultMatchers(debug) {
             ) {
               pass = false;
               if (epsilon === 0) {
-                message =
-                  "Expected context to render " +
-                  expected +
-                  ", but rendered: " +
-                  rgba;
+                message = `Expected context to render ${expected}, but rendered: ${rgba}`;
               } else {
-                message =
-                  "Expected context to render " +
-                  expected +
-                  " with epsilon = " +
-                  epsilon +
-                  ", but rendered: " +
-                  rgba;
+                message = `Expected context to render ${expected} with epsilon = ${epsilon}, but rendered: ${rgba}`;
               }
             }
           }
@@ -616,11 +596,7 @@ function createDefaultMatchers(debug) {
               rgba[3] === expected[3]
             ) {
               pass = false;
-              message =
-                "Expected context not to render " +
-                expected +
-                ", but rendered: " +
-                rgba;
+              message = `Expected context not to render ${expected}, but rendered: ${rgba}`;
             }
           }
 
@@ -771,14 +747,11 @@ function renderEquals(
 
   let message;
   if (!pass) {
-    message =
-      "Expected " +
-      (expectEqual ? "" : "not ") +
-      "to render [" +
-      typedArrayToArray(expected) +
-      "], but actually rendered [" +
-      typedArrayToArray(actualRgba) +
-      "].";
+    message = `Expected ${
+      expectEqual ? "" : "not "
+    }to render [${typedArrayToArray(
+      expected
+    )}], but actually rendered [${typedArrayToArray(actualRgba)}].`;
   }
 
   return {
@@ -808,7 +781,7 @@ function pickPrimitiveEquals(actual, expected, x, y, width, height) {
   }
 
   if (!pass) {
-    message = "Expected to pick " + expected + ", but picked: " + result;
+    message = `Expected to pick ${expected}, but picked: ${result}`;
   }
 
   return {
@@ -838,7 +811,7 @@ function drillPickPrimitiveEquals(actual, expected, x, y, width, height) {
   }
 
   if (!pass) {
-    message = "Expected to pick " + expected + ", but picked: " + result;
+    message = `Expected to pick ${expected}, but picked: ${result}`;
   }
 
   return {
@@ -961,11 +934,7 @@ function expectContextToRender(actual, expected, expectEqual) {
       ) {
         return {
           pass: false,
-          message:
-            "After clearing the framebuffer, expected context to render [0, 0, 0, " +
-            expectedAlpha +
-            "], but rendered: " +
-            clearedRgba,
+          message: `After clearing the framebuffer, expected context to render [0, 0, 0, ${expectedAlpha}], but rendered: ${clearedRgba}`,
         };
       }
     }
@@ -983,11 +952,7 @@ function expectContextToRender(actual, expected, expectEqual) {
       ) {
         return {
           pass: false,
-          message:
-            "Expected context to render " +
-            expected +
-            ", but rendered: " +
-            rgba,
+          message: `Expected context to render ${expected}, but rendered: ${rgba}`,
         };
       }
     } else if (
@@ -998,11 +963,7 @@ function expectContextToRender(actual, expected, expectEqual) {
     ) {
       return {
         pass: false,
-        message:
-          "Expected context not to render " +
-          expected +
-          ", but rendered: " +
-          rgba,
+        message: `Expected context not to render ${expected}, but rendered: ${rgba}`,
       };
     }
   }

--- a/Specs/createCanvas.js
+++ b/Specs/createCanvas.js
@@ -7,7 +7,7 @@ function createCanvas(width, height) {
   height = defaultValue(height, 1);
 
   const canvas = document.createElement("canvas");
-  canvas.id = "canvas" + canvasCount++;
+  canvas.id = `canvas${canvasCount++}`;
   canvas.setAttribute("width", width);
   canvas.setAttribute("clientWidth", width);
   canvas.setAttribute("height", height);

--- a/Specs/createPackableArraySpecs.js
+++ b/Specs/createPackableArraySpecs.js
@@ -9,30 +9,30 @@ function createPackableArraySpecs(
 ) {
   namePrefix = defaultValue(namePrefix, "");
 
-  it(namePrefix + " can pack", function () {
+  it(`${namePrefix} can pack`, function () {
     const actualPackedArray = packable.packArray(unpackedArray);
     expect(actualPackedArray.length).toEqual(packedArray.length);
     expect(actualPackedArray).toEqual(packedArray);
   });
 
-  it(namePrefix + " can roundtrip", function () {
+  it(`${namePrefix} can roundtrip`, function () {
     const actualPackedArray = packable.packArray(unpackedArray);
     const result = packable.unpackArray(actualPackedArray);
     expect(result).toEqual(unpackedArray);
   });
 
-  it(namePrefix + " can unpack", function () {
+  it(`${namePrefix} can unpack`, function () {
     const result = packable.unpackArray(packedArray);
     expect(result).toEqual(unpackedArray);
   });
 
-  it(namePrefix + " packArray works with typed arrays", function () {
+  it(`${namePrefix} packArray works with typed arrays`, function () {
     const typedArray = new Float64Array(packedArray.length);
     const result = packable.packArray(unpackedArray, typedArray);
     expect(result).toEqual(new Float64Array(packedArray));
   });
 
-  it(namePrefix + " packArray resizes arrays as needed", function () {
+  it(`${namePrefix} packArray resizes arrays as needed`, function () {
     const emptyArray = [];
     let result = packable.packArray(unpackedArray, emptyArray);
     expect(result).toEqual(packedArray);
@@ -42,39 +42,36 @@ function createPackableArraySpecs(
     expect(result).toEqual(packedArray);
   });
 
-  it(namePrefix + " packArray throws with undefined array", function () {
+  it(`${namePrefix} packArray throws with undefined array`, function () {
     expect(function () {
       packable.packArray(undefined);
     }).toThrowDeveloperError();
   });
 
-  it(
-    namePrefix + " packArray throws for typed arrays of the wrong size",
-    function () {
-      expect(function () {
-        const tooSmall = new Float64Array(0);
-        packable.packArray(unpackedArray, tooSmall);
-      }).toThrowDeveloperError();
+  it(`${namePrefix} packArray throws for typed arrays of the wrong size`, function () {
+    expect(function () {
+      const tooSmall = new Float64Array(0);
+      packable.packArray(unpackedArray, tooSmall);
+    }).toThrowDeveloperError();
 
-      expect(function () {
-        const tooBig = new Float64Array(10);
-        packable.packArray(unpackedArray, tooBig);
-      }).toThrowDeveloperError();
-    }
-  );
+    expect(function () {
+      const tooBig = new Float64Array(10);
+      packable.packArray(unpackedArray, tooBig);
+    }).toThrowDeveloperError();
+  });
 
-  it(namePrefix + " unpackArray works for typed arrays", function () {
+  it(`${namePrefix} unpackArray works for typed arrays`, function () {
     const array = packable.unpackArray(new Float64Array(packedArray));
     expect(array).toEqual(unpackedArray);
   });
 
-  it(namePrefix + " unpackArray throws with undefined array", function () {
+  it(`${namePrefix} unpackArray throws with undefined array`, function () {
     expect(function () {
       packable.unpackArray(undefined);
     }).toThrowDeveloperError();
   });
 
-  it(namePrefix + " unpackArray works with a result parameter", function () {
+  it(`${namePrefix} unpackArray works with a result parameter`, function () {
     let array = [];
     let result = packable.unpackArray(packedArray, array);
     expect(result).toBe(array);
@@ -91,14 +88,11 @@ function createPackableArraySpecs(
     expect(result).toEqual(unpackedArray);
   });
 
-  it(
-    namePrefix + " unpackArray throws with array less than the minimum length",
-    function () {
-      expect(function () {
-        packable.unpackArray([1.0]);
-      }).toThrowDeveloperError();
-    }
-  );
+  it(`${namePrefix} unpackArray throws with array less than the minimum length`, function () {
+    expect(function () {
+      packable.unpackArray([1.0]);
+    }).toThrowDeveloperError();
+  });
 
   it("unpackArray throws with array not multiple of stride", function () {
     expect(function () {

--- a/Specs/createPackableSpecs.js
+++ b/Specs/createPackableSpecs.js
@@ -5,7 +5,7 @@ import { Math as CesiumMath } from "../Source/Cesium.js";
 function createPackableSpecs(packable, instance, packedInstance, namePrefix) {
   namePrefix = defaultValue(namePrefix, "");
 
-  it(namePrefix + " can pack", function () {
+  it(`${namePrefix} can pack`, function () {
     const packedArray = [];
     const returnArray = packable.pack(instance, packedArray);
     expect(returnArray).toBe(packedArray);
@@ -16,52 +16,52 @@ function createPackableSpecs(packable, instance, packedInstance, namePrefix) {
     expect(packedArray).toEqualEpsilon(packedInstance, CesiumMath.EPSILON15);
   });
 
-  it(namePrefix + " can roundtrip", function () {
+  it(`${namePrefix} can roundtrip`, function () {
     const packedArray = [];
     packable.pack(instance, packedArray);
     const result = packable.unpack(packedArray);
     expect(instance).toEqual(result);
   });
 
-  it(namePrefix + " can unpack", function () {
+  it(`${namePrefix} can unpack`, function () {
     const result = packable.unpack(packedInstance);
     expect(result).toEqual(instance);
   });
 
-  it(namePrefix + " can pack with startingIndex", function () {
+  it(`${namePrefix} can pack with startingIndex`, function () {
     const packedArray = [0];
     const expected = packedArray.concat(packedInstance);
     packable.pack(instance, packedArray, 1);
     expect(packedArray).toEqualEpsilon(expected, CesiumMath.EPSILON15);
   });
 
-  it(namePrefix + " can unpack with startingIndex", function () {
+  it(`${namePrefix} can unpack with startingIndex`, function () {
     const packedArray = [0].concat(packedInstance);
     const result = packable.unpack(packedArray, 1);
     expect(instance).toEqual(result);
   });
 
-  it(namePrefix + " pack throws with undefined value", function () {
+  it(`${namePrefix} pack throws with undefined value`, function () {
     const array = [];
     expect(function () {
       packable.pack(undefined, array);
     }).toThrowDeveloperError();
   });
 
-  it(namePrefix + " pack throws with undefined array", function () {
+  it(`${namePrefix} pack throws with undefined array`, function () {
     expect(function () {
       packable.pack(instance, undefined);
     }).toThrowDeveloperError();
   });
 
-  it(namePrefix + " unpack throws with undefined array", function () {
+  it(`${namePrefix} unpack throws with undefined array`, function () {
     expect(function () {
       packable.unpack(undefined);
     }).toThrowDeveloperError();
   });
 
   if (typeof packable.convertPackedArrayForInterpolation === "function") {
-    it(namePrefix + " packs and unpacks for interpolation.", function () {
+    it(`${namePrefix} packs and unpacks for interpolation.`, function () {
       const packedForInterpolation = [];
       packable.convertPackedArrayForInterpolation(
         packedInstance,
@@ -79,32 +79,23 @@ function createPackableSpecs(packable, instance, packedInstance, namePrefix) {
       expect(value).toEqual(result);
     });
 
-    it(
-      namePrefix + " convertPackedArrayForInterpolation throws without array.",
-      function () {
-        expect(function () {
-          packable.convertPackedArrayForInterpolation(undefined);
-        }).toThrowDeveloperError();
-      }
-    );
+    it(`${namePrefix} convertPackedArrayForInterpolation throws without array.`, function () {
+      expect(function () {
+        packable.convertPackedArrayForInterpolation(undefined);
+      }).toThrowDeveloperError();
+    });
 
-    it(
-      namePrefix + " unpackInterpolationResult throws without packed array.",
-      function () {
-        expect(function () {
-          packable.unpackInterpolationResult(undefined, []);
-        }).toThrowDeveloperError();
-      }
-    );
+    it(`${namePrefix} unpackInterpolationResult throws without packed array.`, function () {
+      expect(function () {
+        packable.unpackInterpolationResult(undefined, []);
+      }).toThrowDeveloperError();
+    });
 
-    it(
-      namePrefix + " unpackInterpolationResult throws without source array.",
-      function () {
-        expect(function () {
-          packable.unpackInterpolationResult([], undefined);
-        }).toThrowDeveloperError();
-      }
-    );
+    it(`${namePrefix} unpackInterpolationResult throws without source array.`, function () {
+      expect(function () {
+        packable.unpackInterpolationResult([], undefined);
+      }).toThrowDeveloperError();
+    });
   }
 }
 export default createPackableSpecs;

--- a/Specs/createTileKey.js
+++ b/Specs/createTileKey.js
@@ -12,6 +12,6 @@ function createTileKey(xOrTile, y, level) {
     y = tile.y;
     level = tile.level;
   }
-  return "L" + level + "X" + xOrTile + "Y" + y;
+  return `L${level}X${xOrTile}Y${y}`;
 }
 export default createTileKey;

--- a/Specs/customizeJasmine.js
+++ b/Specs/customizeJasmine.js
@@ -44,7 +44,7 @@ function customizeJasmine(
             done();
           },
           function (e) {
-            done.fail("promise rejected: " + e.toString());
+            done.fail(`promise rejected: ${e.toString()}`);
           }
         );
       },
@@ -64,7 +64,7 @@ function customizeJasmine(
           done();
         },
         function (e) {
-          done.fail("promise rejected: " + e.toString());
+          done.fail(`promise rejected: ${e.toString()}`);
         }
       );
     });
@@ -81,7 +81,7 @@ function customizeJasmine(
           done();
         },
         function (e) {
-          done.fail("promise rejected: " + e.toString());
+          done.fail(`promise rejected: ${e.toString()}`);
         }
       );
     });
@@ -98,7 +98,7 @@ function customizeJasmine(
           done();
         },
         function (e) {
-          done.fail("promise rejected: " + e.toString());
+          done.fail(`promise rejected: ${e.toString()}`);
         }
       );
     });
@@ -115,7 +115,7 @@ function customizeJasmine(
           done();
         },
         function (e) {
-          done.fail("promise rejected: " + e.toString());
+          done.fail(`promise rejected: ${e.toString()}`);
         }
       );
     });

--- a/Specs/getWebGLStub.js
+++ b/Specs/getWebGLStub.js
@@ -229,7 +229,7 @@ function getParameterStub(options) {
     //>>includeStart('debug', pragmas.debug);
     if (!defined(value)) {
       throw new DeveloperError(
-        "A WebGL parameter stub for " + pname + " is not defined. Add it."
+        `A WebGL parameter stub for ${pname} is not defined. Add it.`
       );
     }
     //>>includeEnd('debug');
@@ -255,7 +255,7 @@ function getProgramParameterStub(program, pname) {
 
   //>>includeStart('debug', pragmas.debug);
   throw new DeveloperError(
-    "A WebGL parameter stub for " + pname + " is not defined. Add it."
+    `A WebGL parameter stub for ${pname} is not defined. Add it.`
   );
   //>>includeEnd('debug');
 }
@@ -264,7 +264,7 @@ function getShaderParameterStub(shader, pname) {
   //>>includeStart('debug', pragmas.debug);
   if (pname !== WebGLConstants.COMPILE_STATUS) {
     throw new DeveloperError(
-      "A WebGL parameter stub for " + pname + " is not defined. Add it."
+      `A WebGL parameter stub for ${pname} is not defined. Add it.`
     );
   }
   //>>includeEnd('debug');

--- a/Tools/eslint-config-cesium/browser.js
+++ b/Tools/eslint-config-cesium/browser.js
@@ -13,5 +13,6 @@ module.exports = {
     "no-implicit-globals": "error",
     "no-var": "error",
     "prefer-const": "error",
+    "prefer-template": "error",
   },
 };

--- a/Tools/eslint-config-cesium/node.js
+++ b/Tools/eslint-config-cesium/node.js
@@ -15,5 +15,6 @@ module.exports = {
     "no-new-require": "error",
     "no-var": "error",
     "prefer-const": "error",
+    "prefer-template": "error",
   },
 };

--- a/gulpfile.cjs
+++ b/gulpfile.cjs
@@ -506,7 +506,7 @@ gulp.task(
           }
         })
       )
-      .pipe(gulpZip("Cesium-" + version + ".zip"))
+      .pipe(gulpZip(`Cesium-${version}.zip`))
       .pipe(gulp.dest("."))
       .on("finish", function () {
         rimraf.sync("./Build/package.noprepare.json");
@@ -570,9 +570,7 @@ gulp.task("deploy-s3", function (done) {
 
   // prompt for confirmation
   iface.question(
-    "Files from your computer will be published to the " +
-      bucketName +
-      " bucket. Continue? [y/n] ",
+    `Files from your computer will be published to the ${bucketName} bucket. Continue? [y/n] `,
     function (answer) {
       iface.close();
       if (answer === "y") {
@@ -604,7 +602,7 @@ function deployCesium(bucketName, uploadDirectory, cacheControl, done) {
   let skipped = 0;
   const errors = [];
 
-  const prefix = uploadDirectory + "/";
+  const prefix = `${uploadDirectory}/`;
   return listAll(s3, bucketName, prefix, existingBlobs)
     .then(function () {
       return globby(
@@ -633,7 +631,7 @@ function deployCesium(bucketName, uploadDirectory, cacheControl, done) {
       return Promise.map(
         files,
         function (file) {
-          const blobName = uploadDirectory + "/" + file;
+          const blobName = `${uploadDirectory}/${file}`;
           const mimeLookup = getMimeType(blobName);
           const contentType = mimeLookup.type;
           const compress = mimeLookup.compress;
@@ -652,7 +650,7 @@ function deployCesium(bucketName, uploadDirectory, cacheControl, done) {
                 content[0] === 0x1f && content[1] === 0x8b;
               if (alreadyCompressed) {
                 console.log(
-                  "Skipping compressing already compressed file: " + file
+                  `Skipping compressing already compressed file: ${file}`
                 );
                 return content;
               }
@@ -684,7 +682,7 @@ function deployCesium(bucketName, uploadDirectory, cacheControl, done) {
                 .promise()
                 .then(function (data) {
                   if (
-                    data.ETag !== '"' + hash + '"' ||
+                    data.ETag !== `"${hash}"` ||
                     data.CacheControl !== cacheControl ||
                     data.ContentType !== contentType ||
                     data.ContentEncoding !== contentEncoding
@@ -706,7 +704,7 @@ function deployCesium(bucketName, uploadDirectory, cacheControl, done) {
               }
 
               if (verbose) {
-                console.log("Uploading " + blobName + "...");
+                console.log(`Uploading ${blobName}...`);
               }
               const params = {
                 Bucket: bucketName,
@@ -734,13 +732,9 @@ function deployCesium(bucketName, uploadDirectory, cacheControl, done) {
     })
     .then(function () {
       console.log(
-        "Skipped " +
-          skipped +
-          " files and successfully uploaded " +
-          uploaded +
-          " files of " +
-          (totalFiles - skipped) +
-          " files."
+        `Skipped ${skipped} files and successfully uploaded ${uploaded} files of ${
+          totalFiles - skipped
+        } files.`
       );
       if (existingBlobs.length === 0) {
         return;
@@ -755,7 +749,7 @@ function deployCesium(bucketName, uploadDirectory, cacheControl, done) {
       });
 
       if (objectsToDelete.length > 0) {
-        console.log("Cleaning " + objectsToDelete.length + " files...");
+        console.log(`Cleaning ${objectsToDelete.length} files...`);
 
         // If more than 1000 files, we must issue multiple requests
         const batches = [];
@@ -777,7 +771,7 @@ function deployCesium(bucketName, uploadDirectory, cacheControl, done) {
               .promise()
               .then(function () {
                 if (verbose) {
-                  console.log("Cleaned " + objects.length + " files.");
+                  console.log(`Cleaned ${objects.length} files.`);
                 }
               });
           },
@@ -833,7 +827,7 @@ function getMimeType(filename) {
   // Everything else can be octet-stream compressed but print a warning
   // if we introduce a type we aren't specifically handling.
   if (!/\.(terrain|b3dm|geom|pnts|vctr|cmpt|i3dm|metadata)$/i.test(filename)) {
-    console.log("Unknown mime type for " + filename);
+    console.log(`Unknown mime type for ${filename}`);
   }
 
   return { type: "application/octet-stream", compress: true };
@@ -866,7 +860,7 @@ gulp.task("deploy-set-version", function (done) {
   const buildVersion = yargs.argv.buildVersion;
   if (buildVersion) {
     // NPM versions can only contain alphanumeric and hyphen characters
-    packageJson.version += "-" + buildVersion.replace(/[^[0-9A-Za-z-]/g, "");
+    packageJson.version += `-${buildVersion.replace(/[^[0-9A-Za-z-]/g, "")}`;
     fs.writeFileSync("package.json", JSON.stringify(packageJson, undefined, 2));
   }
   done();
@@ -881,11 +875,12 @@ gulp.task("deploy-status", function () {
   const status = yargs.argv.status;
   const message = yargs.argv.message;
 
-  const deployUrl = travisDeployUrl + process.env.TRAVIS_BRANCH + "/";
-  const zipUrl = deployUrl + "Cesium-" + packageJson.version + ".zip";
-  const npmUrl = deployUrl + "cesium-" + packageJson.version + ".tgz";
-  const coverageUrl =
-    travisDeployUrl + process.env.TRAVIS_BRANCH + "/Build/Coverage/index.html";
+  const deployUrl = `${travisDeployUrl + process.env.TRAVIS_BRANCH}/`;
+  const zipUrl = `${deployUrl}Cesium-${packageJson.version}.zip`;
+  const npmUrl = `${deployUrl}cesium-${packageJson.version}.tgz`;
+  const coverageUrl = `${
+    travisDeployUrl + process.env.TRAVIS_BRANCH
+  }/Build/Coverage/index.html`;
 
   return Promise.join(
     setStatus(status, deployUrl, message, "deployment"),
@@ -903,14 +898,10 @@ function setStatus(state, targetUrl, description, context) {
 
   const requestPost = Promise.promisify(request.post);
   return requestPost({
-    url:
-      "https://api.github.com/repos/" +
-      process.env.TRAVIS_REPO_SLUG +
-      "/statuses/" +
-      process.env.TRAVIS_COMMIT,
+    url: `https://api.github.com/repos/${process.env.TRAVIS_REPO_SLUG}/statuses/${process.env.TRAVIS_COMMIT}`,
     json: true,
     headers: {
-      Authorization: "token " + process.env.TOKEN,
+      Authorization: `token ${process.env.TOKEN}`,
       "User-Agent": "Cesium",
     },
     body: {
@@ -973,19 +964,16 @@ gulp.task("coverage", function (done) {
     function (e) {
       let html = "<!doctype html><html><body><ul>";
       folders.forEach(function (folder) {
-        html +=
-          '<li><a href="' +
-          encodeURIComponent(folder) +
-          '/index.html">' +
-          folder +
-          "</a></li>";
+        html += `<li><a href="${encodeURIComponent(
+          folder
+        )}/index.html">${folder}</a></li>`;
       });
       html += "</ul></body></html>";
       fs.writeFileSync("Build/Coverage/index.html", html);
 
       if (!process.env.TRAVIS) {
         folders.forEach(function (dir) {
-          open("Build/Coverage/" + dir + "/index.html");
+          open(`Build/Coverage/${dir}/index.html`);
         });
       }
       return done(failTaskOnError ? e : undefined);
@@ -1104,8 +1092,7 @@ gulp.task("convertToModules", function () {
       for (let i = 0; i < names.length; ++i) {
         if (names[i].indexOf("//") >= 0 || names[i].indexOf("/*") >= 0) {
           console.log(
-            file +
-              " contains comments in the require list.  Skipping so nothing gets broken."
+            `${file} contains comments in the require list.  Skipping so nothing gets broken.`
           );
           return;
         }
@@ -1122,8 +1109,7 @@ gulp.task("convertToModules", function () {
           identifiers[i].indexOf("/*") >= 0
         ) {
           console.log(
-            file +
-              " contains comments in the require list.  Skipping so nothing gets broken."
+            `${file} contains comments in the require list.  Skipping so nothing gets broken.`
           );
           return;
         }
@@ -1141,7 +1127,7 @@ gulp.task("convertToModules", function () {
       // Convert back to separate lists for the names and identifiers, and add
       // any additional names or identifiers that don't have a corresponding pair.
       const sortedNames = requires.map(function (item) {
-        return item.name.slice(0, -1) + ".js'";
+        return `${item.name.slice(0, -1)}.js'`;
       });
       for (let i = sortedNames.length; i < names.length; ++i) {
         sortedNames.push(names[i].trim());
@@ -1167,44 +1153,22 @@ gulp.task("convertToModules", function () {
               if (modulePath.startsWith("Specs")) {
                 importPath = path.relative(sourceDir, modulePath);
                 if (importPath[0] !== ".") {
-                  importPath = "./" + importPath;
+                  importPath = `./${importPath}`;
                 }
               }
-              modulePath = "'" + importPath + "'";
-              contents +=
-                "import " +
-                sortedIdentifiers[q] +
-                " from " +
-                modulePath +
-                ";" +
-                os.EOL;
+              modulePath = `'${importPath}'`;
+              contents += `import ${sortedIdentifiers[q]} from ${modulePath};${os.EOL}`;
             } else {
               modulePath =
-                "'" + path.relative(sourceDir, "Source") + "/Cesium.js" + "'";
+                `'${path.relative(sourceDir, "Source")}/Cesium.js` + `'`;
               if (sortedIdentifiers[q] === "CesiumMath") {
-                contents +=
-                  "import { Math as CesiumMath } from " +
-                  modulePath +
-                  ";" +
-                  os.EOL;
+                contents += `import { Math as CesiumMath } from ${modulePath};${os.EOL}`;
               } else {
-                contents +=
-                  "import { " +
-                  sortedIdentifiers[q] +
-                  " } from " +
-                  modulePath +
-                  ";" +
-                  os.EOL;
+                contents += `import { ${sortedIdentifiers[q]} } from ${modulePath};${os.EOL}`;
               }
             }
           } else {
-            contents +=
-              "import " +
-              sortedIdentifiers[q] +
-              " from " +
-              modulePath +
-              ";" +
-              os.EOL;
+            contents += `import ${sortedIdentifiers[q]} from ${modulePath};${os.EOL}`;
           }
         }
       }
@@ -1214,20 +1178,19 @@ gulp.task("convertToModules", function () {
       if (file.endsWith("Spec.js")) {
         const indi = codeAndReturn.lastIndexOf("});");
         code = codeAndReturn.slice(0, indi);
-        code = code.trim().replace("'use strict';" + os.EOL, "");
+        code = code.trim().replace(`'use strict';${os.EOL}`, "");
         contents += code + os.EOL;
       } else {
         const returnIndex = codeAndReturn.lastIndexOf("return");
 
         code = codeAndReturn.slice(0, returnIndex);
-        code = code.trim().replace("'use strict';" + os.EOL, "");
+        code = code.trim().replace(`'use strict';${os.EOL}`, "");
         contents += code + os.EOL;
 
         const returnStatement = codeAndReturn.slice(returnIndex);
-        contents +=
-          returnStatement.split(";")[0].replace("return ", "export default ") +
-          ";" +
-          os.EOL;
+        contents += `${returnStatement
+          .split(";")[0]
+          .replace("return ", "export default ")};${os.EOL}`;
       }
 
       return fsWriteFile(file, contents);
@@ -1353,7 +1316,7 @@ function minifyModules(outputDirectory) {
     gulp
       .src("Source/ThirdParty/google-earth-dbroot-parser.js")
       .pipe(gulpTerser())
-      .pipe(gulp.dest(outputDirectory + "/ThirdParty/"))
+      .pipe(gulp.dest(`${outputDirectory}/ThirdParty/`))
   );
 }
 
@@ -1379,7 +1342,7 @@ function combineJavaScript(options) {
 
     //copy to build folder with copyright header added at the top
     let stream = gulp
-      .src([combineOutput + "/**"])
+      .src([`${combineOutput}/**`])
       .pipe(gulp.dest(outputDirectory));
 
     promises.push(streamToPromise(stream));
@@ -1428,7 +1391,7 @@ function glslToJavaScript(minify, minifyStateFilePath) {
   glslFiles.forEach(function (glslFile) {
     glslFile = path.normalize(glslFile);
     const baseName = path.basename(glslFile, ".glsl");
-    const jsFile = path.join(path.dirname(glslFile), baseName) + ".js";
+    const jsFile = `${path.join(path.dirname(glslFile), baseName)}.js`;
 
     // identify built in functions, structs, and constants
     const baseDir = path.join("Source", "Shaders", "Builtin");
@@ -1470,7 +1433,7 @@ function glslToJavaScript(minify, minifyStateFilePath) {
       /\/\*\*(?:[^*\/]|\*(?!\/)|\n)*?@license(?:.|\n)*?\*\//gm
     );
     if (extractedCopyrightComments) {
-      copyrightComments = extractedCopyrightComments.join("\n") + "\n";
+      copyrightComments = `${extractedCopyrightComments.join("\n")}\n`;
     }
 
     if (minify) {
@@ -1483,13 +1446,9 @@ function glslToJavaScript(minify, minifyStateFilePath) {
     }
 
     contents = contents.split('"').join('\\"').replace(/\n/gm, "\\n\\\n");
-    contents =
-      copyrightComments +
-      '\
+    contents = `${copyrightComments}\
 //This file is automatically rebuilt by the Cesium build process.\n\
-export default "' +
-      contents +
-      '";\n';
+export default "${contents}";\n`;
 
     fs.writeFileSync(jsFile, contents);
   });
@@ -1503,9 +1462,9 @@ export default "' +
     for (let i = 0; i < builtins.length; i++) {
       const builtin = builtins[i];
       contents.imports.push(
-        "import czm_" + builtin + " from './" + path + "/" + builtin + ".js'"
+        `import czm_${builtin} from './${path}/${builtin}.js'`
       );
-      contents.builtinLookup.push("czm_" + builtin + " : " + "czm_" + builtin);
+      contents.builtinLookup.push(`czm_${builtin} : ` + `czm_${builtin}`);
     }
   };
 
@@ -1518,12 +1477,9 @@ export default "' +
   generateBuiltinContents(contents, builtinStructs, "Structs");
   generateBuiltinContents(contents, builtinFunctions, "Functions");
 
-  const fileContents =
-    "//This file is automatically rebuilt by the Cesium build process.\n" +
-    contents.imports.join("\n") +
-    "\n\nexport default {\n    " +
-    contents.builtinLookup.join(",\n    ") +
-    "\n};\n";
+  const fileContents = `//This file is automatically rebuilt by the Cesium build process.\n${contents.imports.join(
+    "\n"
+  )}\n\nexport default {\n    ${contents.builtinLookup.join(",\n    ")}\n};\n`;
 
   fs.writeFileSync(
     path.join("Source", "Shaders", "Builtin", "CzmBuiltins.js"),
@@ -1541,16 +1497,10 @@ function createCesiumJs() {
 
     let assignmentName = path.basename(file, path.extname(file));
     if (moduleId.indexOf("Shaders/") === 0) {
-      assignmentName = "_shaders" + assignmentName;
+      assignmentName = `_shaders${assignmentName}`;
     }
     assignmentName = assignmentName.replace(/(\.|-)/g, "_");
-    contents +=
-      "export { default as " +
-      assignmentName +
-      " } from './" +
-      moduleId +
-      ".js';" +
-      os.EOL;
+    contents += `export { default as ${assignmentName} } from './${moduleId}.js';${os.EOL}`;
   });
 
   fs.writeFileSync("Source/Cesium.js", contents);
@@ -1704,8 +1654,9 @@ ${source}
 
   if (publicModules.size !== 0) {
     throw new Error(
-      "Unexpected unexposed modules: " +
-        Array.from(publicModules.values()).join(", ")
+      `Unexpected unexposed modules: ${Array.from(publicModules.values()).join(
+        ", "
+      )}`
     );
   }
 }
@@ -1715,8 +1666,10 @@ function createSpecList() {
 
   let contents = "";
   specFiles.forEach(function (file) {
-    contents +=
-      "import './" + filePathToModuleId(file).replace("Specs/", "") + ".js';\n";
+    contents += `import './${filePathToModuleId(file).replace(
+      "Specs/",
+      ""
+    )}.js';\n`;
   });
 
   fs.writeFileSync(path.join("Specs", "SpecList.js"), contents);
@@ -1737,7 +1690,7 @@ function createGalleryList() {
   const majorMinor = packageJson.version.match(/^(.*)\.(.*)\./);
   const major = majorMinor[1];
   const minor = Number(majorMinor[2]) - 1; // We want the last release, not current release
-  const tagVersion = major + "." + minor;
+  const tagVersion = `${major}.${minor}`;
 
   // Get an array of demos that were added since the last release.
   // This includes newly staged local demos as well.
@@ -1745,9 +1698,7 @@ function createGalleryList() {
   try {
     newDemos = child_process
       .execSync(
-        "git diff --name-only --diff-filter=A " +
-          tagVersion +
-          " Apps/Sandcastle/gallery/*.html",
+        `git diff --name-only --diff-filter=A ${tagVersion} Apps/Sandcastle/gallery/*.html`,
         { stdio: ["pipe", "pipe", "ignore"] }
       )
       .toString()
@@ -1768,8 +1719,8 @@ function createGalleryList() {
       isNew: newDemos.includes(file),
     };
 
-    if (fs.existsSync(file.replace(".html", "") + ".jpg")) {
-      demoObject.img = demo + ".jpg";
+    if (fs.existsSync(`${file.replace(".html", "")}.jpg`)) {
+      demoObject.img = `${demo}.jpg`;
     }
 
     demoObjects.push(demoObject);
@@ -1794,21 +1745,12 @@ function createGalleryList() {
     demoJSONs[i] = JSON.stringify(demoObjects[i], null, 2);
   }
 
-  const contents =
-    "\
+  const contents = `\
 // This file is automatically rebuilt by the Cesium build process.\n\
-const hello_world_index = " +
-    helloWorldIndex +
-    ";\n\
-const VERSION = '" +
-    version +
-    "';\n\
-const gallery_demos = [" +
-    demoJSONs.join(", ") +
-    "];\n\
-const has_new_gallery_demos = " +
-    (newDemos.length > 0 ? "true;" : "false;") +
-    "\n";
+const hello_world_index = ${helloWorldIndex};\n\
+const VERSION = '${version}';\n\
+const gallery_demos = [${demoJSONs.join(", ")}];\n\
+const has_new_gallery_demos = ${newDemos.length > 0 ? "true;" : "false;"}\n`;
 
   fs.writeFileSync(output, contents);
 
@@ -1839,12 +1781,9 @@ function createJsHintOptions() {
   primary.unused = gallery.unused;
   primary.esversion = gallery.esversion;
 
-  const contents =
-    "\
+  const contents = `\
 // This file is automatically rebuilt by the Cesium build process.\n\
-const sandcastleJsHintOptions = " +
-    JSON.stringify(primary, null, 4) +
-    ";\n";
+const sandcastleJsHintOptions = ${JSON.stringify(primary, null, 4)};\n`;
 
   fs.writeFileSync(
     path.join("Apps", "Sandcastle", "jsHintOptions.js"),

--- a/server.cjs
+++ b/server.cjs
@@ -111,7 +111,7 @@
     if (remoteUrl) {
       // add http:// to the URL if no protocol is present
       if (!/^https?:\/\//.test(remoteUrl)) {
-        remoteUrl = "http://" + remoteUrl;
+        remoteUrl = `http://${remoteUrl}`;
       }
       remoteUrl = url.parse(remoteUrl);
       // copy query string


### PR DESCRIPTION
For the 3D Tiles Next/`ModelExperimental` changes I've been working on, it would be very helpful to have ES6 string template literals for dynamic shader code generation. This was easy to do by enabling the eslint `prefer-template` rule and running `npm run eslint -- --fix`

In the discussion from #10066, we decided that if we're to make this change at all, it's best to do it to the entire codebase to avoid fragmentation, so I made this PR, using https://github.com/CesiumGS/cesium/pull/10026 as a guide.

There are 3 commits:

* [Update eslint config](https://github.com/CesiumGS/cesium/commit/16b3ad0b0d006d02c50f7c770402f88ce5af4577)
* [Small update to the Coding Guide](https://github.com/CesiumGS/cesium/commit/12aedb3ac997e6401444b209b8ff6075725d21ca)
* [use eslint to fix the code](https://github.com/CesiumGS/cesium/commit/2fa70153136da99eaf3ea81c0476d930b8532c7a)

@ggetz could you review?