### PR TITLE
Simplify Custom Shader Sandcastle examples

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Next Photogrammetry Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Next Photogrammetry Classification.html
@@ -101,72 +101,72 @@
         const translucentWindowsShader = new Cesium.CustomShader({
           lightingModel: Cesium.LightingModel.UNLIT,
           isTranslucent: true,
-          fragmentShaderText: [
-            "const float WINDOW = 0.0;",
-            "const float SKYLIGHT = 4.0;",
-            "const float TOTAL_FEATURES = 12.0;",
-            "",
-            "void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {",
-            "  float featureId = fsInput.featureIds.featureId_0;",
-            "",
-            "  if (featureId == WINDOW || featureId == SKYLIGHT) {",
-            "    material.alpha = 0.4;",
-            "    material.roughness = 0.1;",
-            "  }",
-            "}",
-          ].join("\n"),
+          fragmentShaderText: `
+            const float WINDOW = 0.0;
+            const float SKYLIGHT = 4.0;
+            const float TOTAL_FEATURES = 12.0;
+            
+            void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {
+              float featureId = fsInput.featureIds.featureId_0;
+            
+              if (featureId == WINDOW || featureId == SKYLIGHT) {
+                material.alpha = 0.4;
+                material.roughness = 0.1;
+              }
+            }
+            `,
         });
 
         const materialShader = new Cesium.CustomShader({
           lightingModel: Cesium.LightingModel.PBR,
           isTranslucent: true,
-          fragmentShaderText: [
-            "const float WINDOW = 0.0;",
-            "const float FRAME = 1.0;",
-            "const float WALL = 2.0;",
-            "const float ROOF = 3.0;",
-            "const float SKYLIGHT = 4.0;",
-            "const float AIR_CONDITIONER_WHITE = 5.0;",
-            "const float AIR_CONDITIONER_BLACK = 6.0;",
-            "const float AIR_CONDITIONER_TALL = 7.0;",
-            "const float CLOCK = 8.0;",
-            "const float PILLARS = 9.0;",
-            "const float STREET_LIGHT = 10.0;",
-            "const float TRAFFIC_LIGHT = 11.0;",
-            "",
-            "void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {",
-            "  float featureId = fsInput.featureIds.featureId_0;",
-            "",
-            "  if (featureId == CLOCK) {",
-            "    // Shiny brass",
-            "    material.specular = vec3(0.98, 0.90, 0.59);",
-            "    material.roughness = 0.3;",
-            "  } else if (",
-            "    featureId == STREET_LIGHT ||",
-            "    featureId == AIR_CONDITIONER_BLACK ||",
-            "    featureId == AIR_CONDITIONER_WHITE ||",
-            "    featureId == AIR_CONDITIONER_TALL ||",
-            "    featureId == ROOF",
-            "  ) {",
-            "    // dull aluminum",
-            "    material.specular = vec3(0.91, 0.92, 0.92);",
-            "    material.roughness = 0.5;",
-            "  } else if (featureId == WINDOW || featureId == SKYLIGHT) {",
-            "    // make translucent, but also set an orange emissive color so it looks like",
-            "    // it's lit from inside",
-            "    material.emissive = vec3(1.0, 0.3, 0.0);",
-            "    material.alpha = 0.5;",
-            "  } else if (featureId == WALL || featureId == FRAME || featureId == PILLARS) {",
-            "    // paint the walls and pillars white to contrast the brass clock",
-            "    material.diffuse = mix(material.diffuse, vec3(1.0), 0.8);",
-            "    material.roughness = 0.9;",
-            "  } else {",
-            "    // brighten everything else",
-            "    material.diffuse += 0.05;",
-            "    material.roughness = 0.9;",
-            "  }",
-            "}",
-          ].join("\n"),
+          fragmentShaderText: `
+            const float WINDOW = 0.0;
+            const float FRAME = 1.0;
+            const float WALL = 2.0;
+            const float ROOF = 3.0;
+            const float SKYLIGHT = 4.0;
+            const float AIR_CONDITIONER_WHITE = 5.0;
+            const float AIR_CONDITIONER_BLACK = 6.0;
+            const float AIR_CONDITIONER_TALL = 7.0;
+            const float CLOCK = 8.0;
+            const float PILLARS = 9.0;
+            const float STREET_LIGHT = 10.0;
+            const float TRAFFIC_LIGHT = 11.0;
+            
+            void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {
+              float featureId = fsInput.featureIds.featureId_0;
+            
+              if (featureId == CLOCK) {
+                // Shiny brass
+                material.specular = vec3(0.98, 0.90, 0.59);
+                material.roughness = 0.3;
+              } else if (
+                featureId == STREET_LIGHT ||
+                featureId == AIR_CONDITIONER_BLACK ||
+                featureId == AIR_CONDITIONER_WHITE ||
+                featureId == AIR_CONDITIONER_TALL ||
+                featureId == ROOF
+              ) {
+                // dull aluminum
+                material.specular = vec3(0.91, 0.92, 0.92);
+                material.roughness = 0.5;
+              } else if (featureId == WINDOW || featureId == SKYLIGHT) {
+                // make translucent, but also set an orange emissive color so it looks like
+                // it's lit from inside
+                material.emissive = vec3(1.0, 0.3, 0.0);
+                material.alpha = 0.5;
+              } else if (featureId == WALL || featureId == FRAME || featureId == PILLARS) {
+                // paint the walls and pillars white to contrast the brass clock
+                material.diffuse = mix(material.diffuse, vec3(1.0), 0.8);
+                material.roughness = 0.9;
+              } else {
+                // brighten everything else
+                material.diffuse += 0.05;
+                material.roughness = 0.9;
+              }
+            }
+            `,
         });
 
         const NOTHING_SELECTED = 12;
@@ -178,17 +178,17 @@
             },
           },
           lightingModel: Cesium.LightingModel.PBR,
-          fragmentShaderText: [
-            "const float NOTHING_SELECTED = 12.0;",
-            "void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {",
-            "  float featureId = fsInput.featureIds.featureId_0;",
-            "",
-            "  if (u_selectedFeature < NOTHING_SELECTED && featureId == u_selectedFeature) {",
-            "    material.specular = vec3(1.00, 0.85, 0.57);",
-            "    material.roughness = 0.3;",
-            "  }",
-            "}",
-          ].join("\n"),
+          fragmentShaderText: `
+            const float NOTHING_SELECTED = 12.0;
+            void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {
+              float featureId = fsInput.featureIds.featureId_0;
+            
+              if (u_selectedFeature < NOTHING_SELECTED && featureId == u_selectedFeature) {
+                material.specular = vec3(1.00, 0.85, 0.57);
+                material.roughness = 0.3;
+              }
+            }
+            `,
         });
 
         const multipleFeatureIdsShader = new Cesium.CustomShader({
@@ -199,30 +199,30 @@
             },
           },
           lightingModel: Cesium.LightingModel.UNLIT,
-          fragmentShaderText: [
-            "const float IDS0_WINDOW = 0.0;",
-            "const float IDS1_FACADE = 2.0;",
-            "const float IDS1_ROOF = 3.0;",
-            "const vec3 PURPLE = vec3(0.5, 0.0, 1.0);",
-            "const vec3 YELLOW = vec3(1.0, 1.0, 0.0);",
-            "const vec3 NO_TINT = vec3(1.0);",
-            "",
-            "void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {",
-            "  float featureId0 = fsInput.featureIds.featureId_0; // fine features",
-            "  float featureId1 = fsInput.featureIds.featureId_1; // coarse features",
-            "",
-            "  // use both feature ID sets to determine where the features are",
-            "  float isWindow = float(featureId0 == IDS0_WINDOW);",
-            "  float isFacade = float(featureId1 == IDS1_FACADE);",
-            "  float isRoof = float(featureId1 == IDS1_ROOF);",
-            "",
-            "  // Tint the roof windows yellow and facade windows purple",
-            "  vec3 tint = NO_TINT;",
-            "  tint = mix(tint, YELLOW, isWindow * isRoof);",
-            "  tint = mix(tint, PURPLE, isWindow * isFacade);",
-            "  material.diffuse *= tint;",
-            "}",
-          ].join("\n"),
+          fragmentShaderText: `
+            const float IDS0_WINDOW = 0.0;
+            const float IDS1_FACADE = 2.0;
+            const float IDS1_ROOF = 3.0;
+            const vec3 PURPLE = vec3(0.5, 0.0, 1.0);
+            const vec3 YELLOW = vec3(1.0, 1.0, 0.0);
+            const vec3 NO_TINT = vec3(1.0);
+            
+            void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {
+              float featureId0 = fsInput.featureIds.featureId_0; // fine features
+              float featureId1 = fsInput.featureIds.featureId_1; // coarse features
+            
+              // use both feature ID sets to determine where the features are
+              float isWindow = float(featureId0 == IDS0_WINDOW);
+              float isFacade = float(featureId1 == IDS1_FACADE);
+              float isRoof = float(featureId1 == IDS1_ROOF);
+            
+              // Tint the roof windows yellow and facade windows purple
+              vec3 tint = NO_TINT;
+              tint = mix(tint, YELLOW, isWindow * isRoof);
+              tint = mix(tint, PURPLE, isWindow * isFacade);
+              material.diffuse *= tint;
+            }
+            `,
         });
 
         // Demo Functions =====================================================================
@@ -296,9 +296,8 @@
                 viewer.canvas.clientHeight - movement.endPosition.y
               }px`;
               nameOverlay.style.left = `${movement.endPosition.x}px`;
-              const message = `Component: ${pickedObject.getProperty(
-                "component"
-              )}\nFeature ID: ${pickedObject.featureId}`;
+              const component = pickedObject.getProperty("component");
+              const message = `Component: ${component}\nFeature ID: ${pickedObject.featureId}`;
               nameOverlay.textContent = message;
             } else {
               nameOverlay.style.display = "none";

--- a/Apps/Sandcastle/gallery/3D Tiles Next S2 Globe.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Next S2 Globe.html
@@ -102,22 +102,22 @@
               value: 0,
             },
           },
-          fragmentShaderText: [
-            "void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)",
-            "{",
-            "  float featureId = fsInput.featureIds.featureId_0;",
-            "  // Use cartesian coordinates but scale to be roughly [-1, 1]",
-            "  vec3 positionWC = fsInput.attributes.positionWC / 6.3e6;",
-            "  if (featureId == 60.0)",
-            "  {",
-            "    // Something like FM synthesis to make irregularly spaced waves",
-            "    float wave = sin(14.0 * positionWC.z - u_time);",
-            "    wave = 0.5 + 0.5 * sin(10.0 * wave * positionWC.z - u_time);",
-            "    // mix in an over-saturated version of the diffuse to make shimmering bands of color",
-            "    material.diffuse = mix(material.diffuse, material.diffuse * 3.0, wave);",
-            "  }",
-            "}",
-          ].join("\n"),
+          fragmentShaderText: `
+            void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
+            {
+              float featureId = fsInput.featureIds.featureId_0;
+              // Use cartesian coordinates but scale to be roughly [-1, 1]
+              vec3 positionWC = fsInput.attributes.positionWC / 6.3e6;
+              if (featureId == 60.0)
+              {
+                // Something like FM synthesis to make irregularly spaced waves
+                float wave = sin(14.0 * positionWC.z - u_time);
+                wave = 0.5 + 0.5 * sin(10.0 * wave * positionWC.z - u_time);
+                // mix in an over-saturated version of the diffuse to make shimmering bands of color
+                material.diffuse = mix(material.diffuse, material.diffuse * 3.0, wave);
+              }
+            }
+            `,
         });
 
         const startTime = performance.now();

--- a/Apps/Sandcastle/gallery/Custom Per-Feature Post Process.html
+++ b/Apps/Sandcastle/gallery/Custom Per-Feature Post Process.html
@@ -57,19 +57,21 @@
         }));
 
         // Shade selected model with highlight.
-        const fragmentShaderSource =
-          "uniform sampler2D colorTexture;\n" +
-          "varying vec2 v_textureCoordinates;\n" +
-          "uniform vec4 highlight;\n" +
-          "void main() {\n" +
-          "    vec4 color = texture2D(colorTexture, v_textureCoordinates);\n" +
-          "    if (czm_selected()) {\n" +
-          "        vec3 highlighted = highlight.a * highlight.rgb + (1.0 - highlight.a) * color.rgb;\n" +
-          "        gl_FragColor = vec4(highlighted, 1.0);\n" +
-          "    } else { \n" +
-          "        gl_FragColor = color;\n" +
-          "    }\n" +
-          "}\n";
+        const fragmentShaderSource = `
+          uniform sampler2D colorTexture;
+          varying vec2 v_textureCoordinates;
+          uniform vec4 highlight;
+          void main() {
+              vec4 color = texture2D(colorTexture, v_textureCoordinates);
+              if (czm_selected()) {
+                  vec3 highlighted = highlight.a * highlight.rgb + (1.0 - highlight.a) * color.rgb;
+                  gl_FragColor = vec4(highlighted, 1.0);
+              } else { 
+                  gl_FragColor = color;
+              }
+          }
+          `;
+
         const stage = scene.postProcessStages.add(
           new Cesium.PostProcessStage({
             fragmentShader: fragmentShaderSource,

--- a/Apps/Sandcastle/gallery/Custom Post Process.html
+++ b/Apps/Sandcastle/gallery/Custom Post Process.html
@@ -52,25 +52,26 @@
           },
         });
 
-        const fragmentShaderSource =
-          "uniform sampler2D colorTexture; \n" +
-          "varying vec2 v_textureCoordinates; \n" +
-          "const int KERNEL_WIDTH = 16; \n" +
-          "void main(void) \n" +
-          "{ \n" +
-          "    vec2 step = czm_pixelRatio / czm_viewport.zw; \n" +
-          "    vec2 integralPos = v_textureCoordinates - mod(v_textureCoordinates, 8.0 * step); \n" +
-          "    vec3 averageValue = vec3(0.0); \n" +
-          "    for (int i = 0; i < KERNEL_WIDTH; i++) \n" +
-          "    { \n" +
-          "        for (int j = 0; j < KERNEL_WIDTH; j++) \n" +
-          "        { \n" +
-          "            averageValue += texture2D(colorTexture, integralPos + step * vec2(i, j)).rgb; \n" +
-          "        } \n" +
-          "    } \n" +
-          "    averageValue /= float(KERNEL_WIDTH * KERNEL_WIDTH); \n" +
-          "    gl_FragColor = vec4(averageValue, 1.0); \n" +
-          "} \n";
+        const fragmentShaderSource = `
+          uniform sampler2D colorTexture; 
+          varying vec2 v_textureCoordinates; 
+          const int KERNEL_WIDTH = 16; 
+          void main(void) 
+          { 
+              vec2 step = czm_pixelRatio / czm_viewport.zw; 
+              vec2 integralPos = v_textureCoordinates - mod(v_textureCoordinates, 8.0 * step); 
+              vec3 averageValue = vec3(0.0); 
+              for (int i = 0; i < KERNEL_WIDTH; i++) 
+              { 
+                  for (int j = 0; j < KERNEL_WIDTH; j++) 
+                  { 
+                      averageValue += texture2D(colorTexture, integralPos + step * vec2(i, j)).rgb; 
+                  } 
+              } 
+              averageValue /= float(KERNEL_WIDTH * KERNEL_WIDTH); 
+              gl_FragColor = vec4(averageValue, 1.0); 
+          }
+          `;
         viewer.scene.postProcessStages.add(
           new Cesium.PostProcessStage({
             fragmentShader: fragmentShaderSource,

--- a/Apps/Sandcastle/gallery/Custom Shaders 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/Custom Shaders 3D Tiles.html
@@ -50,14 +50,14 @@
           url: Cesium.IonResource.fromAssetId(75343),
           customShader: new Cesium.CustomShader({
             lightingModel: Cesium.LightingModel.UNLIT,
-            fragmentShaderText: [
+            fragmentShaderText: `
               // Color tiles by distance to the camera
-              "void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)",
-              "{",
-              "    material.diffuse = vec3(0.0, 0.0, 1.0);",
-              "    material.diffuse.g = -fsInput.attributes.positionEC.z / 1.0e4;",
-              "}",
-            ].join("\n"),
+              void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
+              {
+                  material.diffuse = vec3(0.0, 0.0, 1.0);
+                  material.diffuse.g = -fsInput.attributes.positionEC.z / 1.0e4;
+              }
+              `,
           }),
         });
         viewer.scene.primitives.add(tileset);

--- a/Apps/Sandcastle/gallery/Custom Shaders Models.html
+++ b/Apps/Sandcastle/gallery/Custom Shaders Models.html
@@ -75,14 +75,14 @@
               value: new Cesium.Cartesian2(0.0, 0.0),
             },
           },
-          vertexShaderText: [
+          vertexShaderText: `
             // If the mouse is dragged to the right, the model grows
             // If the mouse is dragged to the left, the model shrinks
-            "void vertexMain(VertexInput vsInput, inout czm_modelVertexOutput vsOutput)",
-            "{",
-            "    vsOutput.positionMC += 0.01 * u_drag.x * vsInput.attributes.normalMC;",
-            "}",
-          ].join("\n"),
+            void vertexMain(VertexInput vsInput, inout czm_modelVertexOutput vsOutput)
+            {
+                vsOutput.positionMC += 0.01 * u_drag.x * vsInput.attributes.normalMC;
+            }
+            `,
         });
 
         const textureUniformShader = new Cesium.CustomShader({
@@ -102,13 +102,13 @@
           },
           // Apply the texture to the model, but move the texture coordinates
           // a bit over time so it's animated.
-          fragmentShaderText: [
-            "void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)",
-            "{",
-            "    vec2 texCoord = fsInput.attributes.texCoord_0 + 0.1 * vec2(u_time, 0.0);",
-            "    material.diffuse = texture2D(u_stripes, texCoord).rgb;",
-            "}",
-          ].join("\n"),
+          fragmentShaderText: `
+            void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
+            {
+                vec2 texCoord = fsInput.attributes.texCoord_0 + 0.1 * vec2(u_time, 0.0);
+                material.diffuse = texture2D(u_stripes, texCoord).rgb;
+            }
+            `,
         });
 
         // make a checkerboard texture with an alpha that increases with the
@@ -153,14 +153,14 @@
               value: checkerboardTexture,
             },
           },
-          fragmentShaderText: [
-            "void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)",
-            "{",
-            "    vec2 texCoord = fsInput.attributes.texCoord_0;",
-            "    vec4 checkerboard = texture2D(u_checkerboard, texCoord);",
-            "    material.diffuse = mix(material.diffuse, vec3(0.0), checkerboard.r);",
-            "}",
-          ].join("\n"),
+          fragmentShaderText: `  
+            void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
+            {
+                vec2 texCoord = fsInput.attributes.texCoord_0;
+                vec4 checkerboard = texture2D(u_checkerboard, texCoord);
+                material.diffuse = mix(material.diffuse, vec3(0.0), checkerboard.r);
+            }
+            `,
         });
 
         // Color like a checkerboard but make the transparency vary with
@@ -174,15 +174,15 @@
           },
           // necessary when setting material.alpha
           isTranslucent: true,
-          fragmentShaderText: [
-            "void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)",
-            "{",
-            "    vec2 texCoord = fsInput.attributes.texCoord_0;",
-            "    vec4 checkerboard = texture2D(u_checkerboard, texCoord);",
-            "    material.diffuse = checkerboard.rgb;",
-            "    material.alpha = checkerboard.a;",
-            "}",
-          ].join("\n"),
+          fragmentShaderText: `
+            void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
+            {
+                vec2 texCoord = fsInput.attributes.texCoord_0;
+                vec4 checkerboard = texture2D(u_checkerboard, texCoord);
+                material.diffuse = checkerboard.rgb;
+                material.alpha = checkerboard.a;
+            }
+            `,
         });
 
         // Use the checkerboard to cut holes in the model
@@ -193,16 +193,16 @@
               value: checkerboardTexture,
             },
           },
-          fragmentShaderText: [
-            "void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)",
-            "{",
-            "    vec2 texCoord = fsInput.attributes.texCoord_0;",
-            "    vec4 checkerboard = texture2D(u_checkerboard, texCoord);",
-            "    if (checkerboard.r > 0.0) {",
-            "        discard;",
-            "    }",
-            "}",
-          ].join("\n"),
+          fragmentShaderText: `
+            void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
+            {
+                vec2 texCoord = fsInput.attributes.texCoord_0;
+                vec4 checkerboard = texture2D(u_checkerboard, texCoord);
+                if (checkerboard.r > 0.0) {
+                    discard;
+                }
+            }
+            `,
         });
 
         // This example is to demonstrate the conventions used for orienting
@@ -242,12 +242,12 @@
               value: gradientTexture,
             },
           },
-          fragmentShaderText: [
-            "void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)",
-            "{",
-            "    material.diffuse = texture2D(u_gradient, fsInput.attributes.texCoord_0).rgb;",
-            "}",
-          ].join("\n"),
+          fragmentShaderText: `
+            void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
+            {
+                material.diffuse = texture2D(u_gradient, fsInput.attributes.texCoord_0).rgb;
+            }
+            `,
         });
 
         // Dragging the mouse will modify the PBR values
@@ -259,20 +259,20 @@
               value: new Cesium.Cartesian2(0.0, 0.0),
             },
           },
-          fragmentShaderText: [
+          fragmentShaderText: `
             // Click and drag to vary the PBR values
-            "void fragmentMain(FragmentInput vsInput, inout czm_modelMaterial material)",
-            "{",
-            "    float dragDistance = length(u_drag);",
-            "    float variation = smoothstep(0.0, 300.0, dragDistance);",
+            void fragmentMain(FragmentInput vsInput, inout czm_modelMaterial material)
+            {
+                float dragDistance = length(u_drag);
+                float variation = smoothstep(0.0, 300.0, dragDistance);
             // variation adds an golden tint to the specular highlights
-            "    material.specular = mix(material.specular, vec3(0.8, 0.5, 0.1), variation);",
+                material.specular = mix(material.specular, vec3(0.8, 0.5, 0.1), variation);
             // variation makes the material glossier
-            "    material.roughness = clamp(1.0 - variation, 0.01, 1.0);",
+                material.roughness = clamp(1.0 - variation, 0.01, 1.0);
             // variation mixes some red into the diffuse color
-            "    material.diffuse += vec3(0.5, 0.0, 0.0) * variation;",
-            "}",
-          ].join("\n"),
+                material.diffuse += vec3(0.5, 0.0, 0.0) * variation;
+            }
+            `,
         });
 
         const pointCloudWaveShader = new Cesium.CustomShader({
@@ -283,40 +283,40 @@
               value: 0,
             },
           },
-          vertexShaderText: [
-            "void vertexMain(VertexInput vsInput, inout czm_modelVertexOutput vsOutput)",
-            "{",
+          vertexShaderText: `
+            void vertexMain(VertexInput vsInput, inout czm_modelVertexOutput vsOutput)
+            {
             // This model's x and y coordinates are in the range [0, 1], which
             // conveniently doubles as UV coordinates.
-            "    vec2 uv = vsInput.attributes.positionMC.xy;",
+                vec2 uv = vsInput.attributes.positionMC.xy;
             // Make the point cloud undulate in a complex wave that varies in
             // both space and time. The amplitude is based on the original shape
             // of the point cloud (which already is a wavy surface). The wave
             // is computed relative to the center of the model, hence the
             // transformations from [0, 1] -> [-1, 1] -> [0, 1]
-            "    float amplitude = 2.0 * vsInput.attributes.positionMC.z - 1.0;",
-            "    float wave = amplitude * sin(2.0 * czm_pi * uv.x - 2.0 * u_time) * sin(u_time);",
-            "    vsOutput.positionMC.z = 0.5 + 0.5 * wave;",
+                float amplitude = 2.0 * vsInput.attributes.positionMC.z - 1.0;
+                float wave = amplitude * sin(2.0 * czm_pi * uv.x - 2.0 * u_time) * sin(u_time);
+                vsOutput.positionMC.z = 0.5 + 0.5 * wave;
             // Make the points pulse in and out by changing their size
-            "    vsOutput.pointSize = 10.0 + 5.0 * sin(u_time);",
-            "}",
-          ].join("\n"),
-          fragmentShaderText: [
-            "void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)",
-            "{",
+                vsOutput.pointSize = 10.0 + 5.0 * sin(u_time);
+            }
+            `,
+          fragmentShaderText: `
+            void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
+            {
             // Make the points circular instead of square
-            "    float distance = length(gl_PointCoord - 0.5);",
-            "    if (distance > 0.5) {",
-            "        discard;",
-            "    }",
+                float distance = length(gl_PointCoord - 0.5);
+                if (distance > 0.5) {
+                    discard;
+                }
             // Make a sinusoid color palette that moves in the general direction
             // of the wave, but at a different speed.
             // Coefficients were chosen arbitrarily
-            "    vec2 uv = fsInput.attributes.positionMC.xy;",
-            "    material.diffuse = 0.2 * fsInput.attributes.color_0.rgb;",
-            "    material.diffuse += vec3(0.2, 0.3, 0.4) + vec3(0.2, 0.3, 0.4) * sin(2.0 * czm_pi * vec3(3.0, 2.0, 1.0) * uv.x - 3.0 * u_time);",
-            "}",
-          ].join("\n"),
+                vec2 uv = fsInput.attributes.positionMC.xy;
+                material.diffuse = 0.2 * fsInput.attributes.color_0.rgb;
+                material.diffuse += vec3(0.2, 0.3, 0.4) + vec3(0.2, 0.3, 0.4) * sin(2.0 * czm_pi * vec3(3.0, 2.0, 1.0) * uv.x - 3.0 * u_time);
+            }
+            `,
         });
 
         // Demos ==============================================================

--- a/Apps/Sandcastle/gallery/Fog Post Process.html
+++ b/Apps/Sandcastle/gallery/Fog Post Process.html
@@ -58,42 +58,43 @@
           endTransform: Cesium.Matrix4.IDENTITY,
         });
 
-        const fragmentShaderSource =
-          "float getDistance(sampler2D depthTexture, vec2 texCoords) \n" +
-          "{ \n" +
-          "    float depth = czm_unpackDepth(texture2D(depthTexture, texCoords)); \n" +
-          "    if (depth == 0.0) { \n" +
-          "        return czm_infinity; \n" +
-          "    } \n" +
-          "    vec4 eyeCoordinate = czm_windowToEyeCoordinates(gl_FragCoord.xy, depth); \n" +
-          "    return -eyeCoordinate.z / eyeCoordinate.w; \n" +
-          "} \n" +
-          "float interpolateByDistance(vec4 nearFarScalar, float distance) \n" +
-          "{ \n" +
-          "    float startDistance = nearFarScalar.x; \n" +
-          "    float startValue = nearFarScalar.y; \n" +
-          "    float endDistance = nearFarScalar.z; \n" +
-          "    float endValue = nearFarScalar.w; \n" +
-          "    float t = clamp((distance - startDistance) / (endDistance - startDistance), 0.0, 1.0); \n" +
-          "    return mix(startValue, endValue, t); \n" +
-          "} \n" +
-          "vec4 alphaBlend(vec4 sourceColor, vec4 destinationColor) \n" +
-          "{ \n" +
-          "    return sourceColor * vec4(sourceColor.aaa, 1.0) + destinationColor * (1.0 - sourceColor.a); \n" +
-          "} \n" +
-          "uniform sampler2D colorTexture; \n" +
-          "uniform sampler2D depthTexture; \n" +
-          "uniform vec4 fogByDistance; \n" +
-          "uniform vec4 fogColor; \n" +
-          "varying vec2 v_textureCoordinates; \n" +
-          "void main(void) \n" +
-          "{ \n" +
-          "    float distance = getDistance(depthTexture, v_textureCoordinates); \n" +
-          "    vec4 sceneColor = texture2D(colorTexture, v_textureCoordinates); \n" +
-          "    float blendAmount = interpolateByDistance(fogByDistance, distance); \n" +
-          "    vec4 finalFogColor = vec4(fogColor.rgb, fogColor.a * blendAmount); \n" +
-          "    gl_FragColor = alphaBlend(finalFogColor, sceneColor); \n" +
-          "} \n";
+        const fragmentShaderSource = `
+          float getDistance(sampler2D depthTexture, vec2 texCoords) 
+          { 
+              float depth = czm_unpackDepth(texture2D(depthTexture, texCoords)); 
+              if (depth == 0.0) { 
+                  return czm_infinity; 
+              } 
+              vec4 eyeCoordinate = czm_windowToEyeCoordinates(gl_FragCoord.xy, depth); 
+              return -eyeCoordinate.z / eyeCoordinate.w; 
+          } 
+          float interpolateByDistance(vec4 nearFarScalar, float distance) 
+          { 
+              float startDistance = nearFarScalar.x; 
+              float startValue = nearFarScalar.y; 
+              float endDistance = nearFarScalar.z; 
+              float endValue = nearFarScalar.w; 
+              float t = clamp((distance - startDistance) / (endDistance - startDistance), 0.0, 1.0); 
+              return mix(startValue, endValue, t); 
+          } 
+          vec4 alphaBlend(vec4 sourceColor, vec4 destinationColor) 
+          { 
+              return sourceColor * vec4(sourceColor.aaa, 1.0) + destinationColor * (1.0 - sourceColor.a); 
+          } 
+          uniform sampler2D colorTexture; 
+          uniform sampler2D depthTexture; 
+          uniform vec4 fogByDistance; 
+          uniform vec4 fogColor; 
+          varying vec2 v_textureCoordinates; 
+          void main(void) 
+          { 
+              float distance = getDistance(depthTexture, v_textureCoordinates); 
+              vec4 sceneColor = texture2D(colorTexture, v_textureCoordinates); 
+              float blendAmount = interpolateByDistance(fogByDistance, distance); 
+              vec4 finalFogColor = vec4(fogColor.rgb, fogColor.a * blendAmount); 
+              gl_FragColor = alphaBlend(finalFogColor, sceneColor); 
+          }
+          `;
 
         const ellipsoid = viewer.scene.globe.ellipsoid;
         const postProcessStage = viewer.scene.postProcessStages.add(

--- a/Apps/Sandcastle/gallery/Materials.html
+++ b/Apps/Sandcastle/gallery/Materials.html
@@ -116,21 +116,22 @@
                   },
                 },
               },
-              source:
-                "czm_material czm_getMaterial(czm_materialInput materialInput) { \n" +
-                "    czm_material material = czm_getDefaultMaterial(materialInput); \n" +
-                "    vec4 color; \n" +
-                "    float heightValue = texture2D(heightField, materialInput.st).r; \n" +
-                "    color.rgb = mix(vec3(0.2, 0.6, 0.2), vec3(1.0, 0.5, 0.2), heightValue); \n" +
-                "    color.a = (1.0 - texture2D(image, materialInput.st).r) * 0.7; \n" +
-                "    color = czm_gammaCorrect(color); \n" +
-                "    material.diffuse = color.rgb; \n" +
-                "    material.alpha = color.a; \n" +
-                "    material.normal = bumpMap.normal; \n" +
-                "    material.specular = step(0.1, heightValue); \n" + // Specular mountain tops
-                "    material.shininess = 8.0; \n" + // Sharpen highlight
-                "    return material; \n" +
-                "} \n",
+              source: `
+                czm_material czm_getMaterial(czm_materialInput materialInput) { 
+                    czm_material material = czm_getDefaultMaterial(materialInput); 
+                    vec4 color; 
+                    float heightValue = texture2D(heightField, materialInput.st).r; 
+                    color.rgb = mix(vec3(0.2, 0.6, 0.2), vec3(1.0, 0.5, 0.2), heightValue); 
+                    color.a = (1.0 - texture2D(image, materialInput.st).r) * 0.7; 
+                    color = czm_gammaCorrect(color); 
+                    material.diffuse = color.rgb; 
+                    material.alpha = color.a; 
+                    material.normal = bumpMap.normal; 
+                    material.specular = step(0.1, heightValue);  // Specular mountain tops
+                    material.shininess = 8.0;  // Sharpen highlight
+                    return material; 
+                }
+                `,
             },
           });
         }

--- a/Apps/Sandcastle/gallery/development/Custom Primitive.html
+++ b/Apps/Sandcastle/gallery/development/Custom Primitive.html
@@ -183,38 +183,40 @@
         function initialize(primitive, context) {
           // Inteference patterns made by two plane waves crossing each
           // other at an angle. The color is based on the height.
-          const vertexShader =
-            "attribute vec3 a_position;\n" +
-            "varying vec3 v_position;\n" +
-            "uniform float u_time;\n" +
-            "void main()\n" +
-            "{\n" +
-            "    vec2 k = vec2(0.0004, 0.0001);\n" +
-            "    vec2 k2 = vec2(0.0001, 0.0004);\n" +
-            "    float z = 0.0;\n" +
-            "    z += 1000.0 * sin(2.0 * czm_pi * dot(a_position.xy, k) - 0.002 * u_time);\n" +
-            "    z += 1000.0 * sin(2.0 * czm_pi * dot(a_position.xy, k2) - 0.002 * u_time);\n" +
-            "    v_position = a_position;\n" +
-            "    gl_Position = czm_modelViewProjection * vec4(a_position.xy, z, 1.0);\n" +
-            "}\n";
+          const vertexShader = `
+            attribute vec3 a_position;
+            varying vec3 v_position;
+            uniform float u_time;
+            void main()
+            {
+                vec2 k = vec2(0.0004, 0.0001);
+                vec2 k2 = vec2(0.0001, 0.0004);
+                float z = 0.0;
+                z += 1000.0 * sin(2.0 * czm_pi * dot(a_position.xy, k) - 0.002 * u_time);
+                z += 1000.0 * sin(2.0 * czm_pi * dot(a_position.xy, k2) - 0.002 * u_time);
+                v_position = a_position;
+                gl_Position = czm_modelViewProjection * vec4(a_position.xy, z, 1.0);
+            }
+            `;
 
-          const fragmentShader =
-            "varying vec3 v_position;\n" +
-            "uniform float u_time;\n" +
-            "uniform sampler2D u_texture;\n" +
-            "void main()\n" +
-            "{\n" +
-            "    vec2 k = vec2(0.0004, 0.0001);\n" +
-            "    vec2 k2 = vec2(0.0001, 0.0004);\n" +
-            "    float z = 0.0;\n" +
-            "    z += sin(2.0 * czm_pi * dot(v_position.xy, k) - 0.002 * u_time);\n" +
-            "    z += sin(2.0 * czm_pi * dot(v_position.xy, k2) - 0.002 * u_time);\n" +
-            // divide by 2 to keep in the range [-1, 1]
-            "    z *= 0.5;\n" +
-            // signed -> unsigned
-            "    z = 0.5 + 0.5 * z;\n" +
-            "    gl_FragColor = texture2D(u_texture, vec2(z, 0.5));\n" +
-            "}\n";
+          const fragmentShader = `
+            varying vec3 v_position;
+            uniform float u_time;
+            uniform sampler2D u_texture;
+            void main()
+            {
+                vec2 k = vec2(0.0004, 0.0001);
+                vec2 k2 = vec2(0.0001, 0.0004);
+                float z = 0.0;
+                z += sin(2.0 * czm_pi * dot(v_position.xy, k) - 0.002 * u_time);
+                z += sin(2.0 * czm_pi * dot(v_position.xy, k2) - 0.002 * u_time);
+                // divide by 2 to keep in the range [-1, 1]
+                z *= 0.5;
+                // signed -> unsigned
+                z = 0.5 + 0.5 * z;
+                gl_FragColor = texture2D(u_texture, vec2(z, 0.5));
+            }
+            `;
 
           const positionLocation = 0;
           const attributeLocations = {


### PR DESCRIPTION
This PR is a draft, this only makes sense if #10067 is merged.

This is a small tweak to some sandcastles. I was using `[].join("\n")` to do multiline shaders, but an ES6 template literal is cleaner. I kept this as a separate PR since these changes can't be detected by `eslint --fix`

@ggetz no rush on this PR