### PR TITLE
Add support for `debugColorizeTiles` in `ModelExperimental`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - glTF contents now use `ModelExperimental` by default. [#10055](https://github.com/CesiumGS/cesium/pull/10055)
 - Added `depthPlaneEllipsoidOffset` to Viewer and Scene constructors to address rendering artefacts below ellipsoid zero elevation. [#9200](https://github.com/CesiumGS/cesium/pull/9200)
+- Added support for `debugColorTiles` in `ModelExperimental`. [#10071](https://github.com/CesiumGS/cesium/pull/10071)
 
 ### 1.90 - 2022-02-01
 

--- a/Source/Scene/ModelExperimental/ModelExperimental3DTileContent.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental3DTileContent.js
@@ -1,4 +1,5 @@
 import Axis from "../Axis.js";
+import Color from "../../Core/Color.js";
 import defined from "../../Core/defined.js";
 import destroyObject from "../../Core/destroyObject.js";
 import Pass from "../../Renderer/Pass.js";
@@ -156,7 +157,12 @@ ModelExperimental3DTileContent.prototype.applyDebugSettings = function (
   enabled,
   color
 ) {
-  return;
+  color = enabled ? color : Color.WHITE;
+  if (this.featuresLength === 0) {
+    this._model.color = color;
+  } else if (defined(this.batchTable)) {
+    this.batchTable.setAllColor(color);
+  }
 };
 
 ModelExperimental3DTileContent.prototype.applyStyle = function (style) {

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -1959,13 +1959,12 @@ describe(
       return checkDebugColorizeTiles(pointCloudUrl);
     });
 
-    // see https://github.com/CesiumGS/cesium/issues/10061
-    xit("debugColorizeTiles for glTF", function () {
+    it("debugColorizeTiles for glTF", function () {
       viewGltfContent();
       return checkDebugColorizeTiles(gltfContentUrl);
     });
 
-    xit("debugColorizeTiles for glb", function () {
+    it("debugColorizeTiles for glb", function () {
       viewGltfContent();
       return checkDebugColorizeTiles(glbContentUrl);
     });


### PR DESCRIPTION
Fixes #10061.

This PR adds support for `debugColorizeTiles` in `ModelExperimental` and re-enables its unit tests. Here's a [sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=bZJBb9swDIX/iuCTU2RSiqGXzQ02tGg3YMWKxejJF0VmbK0yZUh02nTYf58k20Oy5WSReu/TI2Fl0RPba3gBx64Zwgu7Aa+Hjj+lXl5lKtU3FklqBFdli48VVjh6uFeAwBtjt8Br6KktwdPnJkg9leBcOAQuuQGOXfBKgHU+PTU2x+L9bakN+K/oe1Bk3YN+1RhfVCmpnvsx3oOtwQT6BFVnAYmelCnAiKEoATqd+CQAUP6rQsYGZz6wKhObQPPiVpIUJzpxb2gXlwNIojHlnZjY/Ke3WGUV/o7pT7bVO91p0nvwXNZ1PhnGtc5uB7I+PDrbaQ+cWsB8N6AibZHlC5aiTcw3a7vS5rHD5sGWY3U03JfA09g8alLtD4kNTAbGVny1nM/vVvzqb3HJr9jFTORbO2AkbPoWHHAXcIMfpYv4ifHTqNkyKzwdDKxn0Cfd9dZR3GXOuSDoeiMp7G47qOeAVt5HY5QW4tha1HrPdH195idkykjvw81uMGaj36DK1oUI+v+sxqbJv+/BGXmIsvZy/W1scs4LEcrzTrLWbKX7h/wH) with the same glTF model used in the unit test; previously, no colors were applied when `Display > Colorize` as selected in the insepctor.

![image](https://user-images.githubusercontent.com/32226860/152408345-43f32b55-0033-4835-aa18-5f4838a0aad0.png)
