### PR TITLE
Workaround ambiant const enum errors as per TS docs

### DIFF
--- a/Specs/TypeScript/tsconfig.json
+++ b/Specs/TypeScript/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "noEmit": true,
     "types": [],
-    "strict": true
+    "strict": true,
+    "isolatedModules": true
   },
   "include": [
     "index.ts",

--- a/Tools/jsdoc/tsconfig.json
+++ b/Tools/jsdoc/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
       "noEmit": true,
-      "types": []
+      "types": [],
+      "preserveConstEnums": true
   },
   "files": [
     "../../Source/Cesium.d.ts"

--- a/gulpfile.cjs
+++ b/gulpfile.cjs
@@ -1599,7 +1599,9 @@ function createTypeScriptDefinitions() {
       /= "WebGLConstants\.(.+)"/gm,
       // eslint-disable-next-line no-unused-vars
       (match, p1) => `= WebGLConstants.${p1}`
-    );
+    )
+    // Strip const enums which can cause errors - https://www.typescriptlang.org/docs/handbook/enums.html#const-enum-pitfalls
+    .replace(/^(\s*)(export )?const enum (\S+) {(\s*)$/gm, "$1$2enum $3 {$4");
 
   // Wrap the source to actually be inside of a declared cesium module
   // and add any workaround and private utility types.


### PR DESCRIPTION
Fixes #10069

This provides a workaround for the ambiant `const enum` errors that arise in TypeScript projects that use the `isolatedModules` flag.

[As per TypeScript documentation](https://www.typescriptlang.org/docs/handbook/enums.html#const-enum-pitfalls), this adds the `preserveConstEnums` to our `tsconfig.json`, then strips out the `const` from the `.d.ts` file [the same way as TypeScript themselves do it](https://github.com/microsoft/TypeScript/blob/1a981d1df1810c868a66b3828497f049a944951c/Gulpfile.js#L144).

I also added `isolatedModules` to the spec `tsconfig.json`, so this can be tested by running `build-ts`.

@mramato Could you please review?