### PR TITLE
Issue 10057: Validate date parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 ##### Fixes :wrench:
 
 - Fixed a bug where updating `ModelExperimental`'s model matrix would not update its bounding sphere. [#10078](https://github.com/CesiumGS/cesium/pull/10078)
+- Fixed a bug where `GregorianDate` constructor would not validate the input parameters for valid date. Also default date is set as 0001-01-01 00:00:00:0000. [#10075](https://github.com/CesiumGS/cesium/pull/10075)
 
 ### 1.90 - 2022-02-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 ##### Fixes :wrench:
 
 - Fixed a bug where updating `ModelExperimental`'s model matrix would not update its bounding sphere. [#10078](https://github.com/CesiumGS/cesium/pull/10078)
-- Fixed a bug where `GregorianDate` constructor would not validate the input parameters for valid date. Also default date is set as 0001-01-01 00:00:00:0000. [#10075](https://github.com/CesiumGS/cesium/pull/10075)
+- Fixed a bug where `GregorianDate` constructor would not validate the input parameters for valid date. [#10075](https://github.com/CesiumGS/cesium/pull/10075)
 
 ### 1.90 - 2022-02-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -313,3 +313,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Jon Beniston](https://github.com/srcejon)
 - [Ugnius Malukas](https://github.com/ugnelis)
 - [Justin Peter](https://github.com/themagicnacho)
+- [Subhajit Saha](https://github.com/subhajits)

--- a/Source/Core/GregorianDate.js
+++ b/Source/Core/GregorianDate.js
@@ -1,3 +1,7 @@
+import defaultValue from "./defaultValue.js";
+import DeveloperError from "./DeveloperError.js";
+import isLeapYear from "./isLeapYear.js";
+
 /**
  * Represents a Gregorian date in a more precise format than the JavaScript Date object.
  * In addition to submillisecond precision, this object can also represent leap seconds.
@@ -25,21 +29,21 @@ function GregorianDate(
   millisecond,
   isLeapSecond
 ) {
-  const minYear = 1;
-  const minMonth = 1;
-  const minDay = 1;
-  const minHour = 0;
-  const minMinute = 0;
-  const minSecond = 0;
-  const minMillisecond = 0;
+  const minimumYear = 1;
+  const minimumMonth = 1;
+  const minimumDay = 1;
+  const minimumHour = 0;
+  const minimumMinute = 0;
+  const minimumSecond = 0;
+  const minimumMillisecond = 0;
 
-  if (!year) year = minYear;
-  if (!month) month = minMonth;
-  if (!day) day = minDay;
-  if (!hour) hour = minHour;
-  if (!minute) minute = minMinute;
-  if (!second) second = minSecond;
-  if (!millisecond) millisecond = minMillisecond;
+  year = defaultValue(year, minimumYear);
+  month = defaultValue(month, minimumMonth);
+  day = defaultValue(day, minimumDay);
+  hour = defaultValue(hour, minimumHour);
+  minute = defaultValue(minute, minimumMinute);
+  second = defaultValue(second, minimumSecond);
+  millisecond = defaultValue(millisecond, minimumMillisecond);
   validateRange();
   validateDate();
 
@@ -85,13 +89,13 @@ function GregorianDate(
   this.isLeapSecond = isLeapSecond;
 
   function validateRange() {
-    const maxYear = 9999;
-    const maxMonth = 12;
-    const maxDay = 31;
-    const maxHour = 23;
-    const maxMinute = 59;
-    const maxSecond = 59;
-    const excludedMaxMilisecond = 1000;
+    const maximumYear = 9999;
+    const maximumMonth = 12;
+    const maximumDay = 31;
+    const maximumHour = 23;
+    const maximumMinute = 59;
+    const maximumSecond = 59;
+    const excludedMaximumMilisecond = 1000;
 
     if (
       isNaN(year) ||
@@ -102,44 +106,48 @@ function GregorianDate(
       isNaN(second) ||
       isNaN(millisecond)
     )
-      throw "Invalid value passed in parameter";
+      throw new DeveloperError("Invalid value passed in parameter");
 
-    if (year < minYear || year > maxYear)
-      throw "Year parameter represent an invalid date";
-    if (month < minMonth || month > maxMonth)
-      throw "Month parameter represent an invalid date";
-    if (day < minDay || day > maxDay)
-      throw "Day parameter represent an invalid date";
-    if (hour < minHour || hour > maxHour)
-      throw "Hour parameter represent an invalid date";
-    if (minute < minMinute || minute > maxMinute)
-      throw "Combination of Minute and IsLeapSecond parameters represent an invalid date";
+    if (year < minimumYear || year > maximumYear)
+      throw new DeveloperError("Year parameter represent an invalid date");
+    if (month < minimumMonth || month > maximumMonth)
+      throw new DeveloperError("Month parameter represent an invalid date");
+    if (day < minimumDay || day > maximumDay)
+      throw new DeveloperError("Day parameter represent an invalid date");
+    if (hour < minimumHour || hour > maximumHour)
+      throw new DeveloperError("Hour parameter represent an invalid date");
+    if (minute < minimumMinute || minute > maximumMinute)
+      throw new DeveloperError(
+        "Combination of Minute and IsLeapSecond parameters represent an invalid date"
+      );
     if (
-      second < minSecond ||
-      (second > maxSecond && !isLeapSecond) ||
-      (second > maxSecond + 1 && isLeapSecond)
+      second < minimumSecond ||
+      (second > maximumSecond && !isLeapSecond) ||
+      (second > maximumSecond + 1 && isLeapSecond)
     )
-      throw "Second parameter represent an invalid date";
-    if (millisecond < minMillisecond || millisecond >= excludedMaxMilisecond)
-      throw "Millisecond parameter represent an invalid date";
+      throw new DeveloperError("Second parameter represent an invalid date");
+    if (
+      millisecond < minimumMillisecond ||
+      millisecond >= excludedMaximumMilisecond
+    )
+      throw new DeveloperError(
+        "Millisecond parameter represent an invalid date"
+      );
   }
 
   // Javascript date object supports only dates greater than 1901. Thus validating with custom logic
   function validateDate() {
-    const minNumberOfDaysInMonth = 28;
-    const monthsWith31Days = [1, 3, 5, 7, 8, 10, 12];
+    const minimumDaysInMonth = 28;
+    const daysInYear = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
     if (
       month === 2 &&
-      ((year % 4 === 0 && day > minNumberOfDaysInMonth + 1) ||
-        (year % 4 !== 0 && day > minNumberOfDaysInMonth))
+      ((isLeapYear(year) && day > minimumDaysInMonth + 1) ||
+        (!isLeapYear(year) && day > minimumDaysInMonth))
     )
-      throw "Year, Month and Day represents invalid date";
-    else if (
-      monthsWith31Days.indexOf(month) === -1 &&
-      day > minNumberOfDaysInMonth + 2
-    )
-      throw "Month and Day represents invalid date";
+      throw new DeveloperError("Year, Month and Day represents invalid date");
+    else if (month !== 2 && day > daysInYear[month - 1])
+      throw new DeveloperError("Month and Day represents invalid date");
   }
 }
 export default GregorianDate;

--- a/Source/Core/GregorianDate.js
+++ b/Source/Core/GregorianDate.js
@@ -1,3 +1,4 @@
+import Check from "./Check.js";
 import defaultValue from "./defaultValue.js";
 import DeveloperError from "./DeveloperError.js";
 import isLeapYear from "./isLeapYear.js";
@@ -44,8 +45,11 @@ function GregorianDate(
   minute = defaultValue(minute, minimumMinute);
   second = defaultValue(second, minimumSecond);
   millisecond = defaultValue(millisecond, minimumMillisecond);
+  isLeapSecond = defaultValue(isLeapSecond, false);
+  //>>includeStart('debug', pragmas.debug);
   validateRange();
   validateDate();
+  //>>includeEnd('debug');
 
   /**
    * Gets or sets the year as a whole number.
@@ -97,56 +101,49 @@ function GregorianDate(
     const maximumSecond = 59;
     const excludedMaximumMilisecond = 1000;
 
-    if (
-      isNaN(year) ||
-      isNaN(month) ||
-      isNaN(day) ||
-      isNaN(hour) ||
-      isNaN(minute) ||
-      isNaN(second) ||
-      isNaN(millisecond)
-    )
-      throw new DeveloperError("Invalid value passed in parameter");
+    Check.typeOf.number.greaterThanOrEquals("Year", year, minimumYear);
+    Check.typeOf.number.lessThanOrEquals("Year", year, maximumYear);
 
-    if (year < minimumYear || year > maximumYear)
-      throw new DeveloperError("Year parameter represent an invalid date");
-    if (month < minimumMonth || month > maximumMonth)
-      throw new DeveloperError("Month parameter represent an invalid date");
-    if (day < minimumDay || day > maximumDay)
-      throw new DeveloperError("Day parameter represent an invalid date");
-    if (hour < minimumHour || hour > maximumHour)
-      throw new DeveloperError("Hour parameter represent an invalid date");
-    if (minute < minimumMinute || minute > maximumMinute)
-      throw new DeveloperError(
-        "Combination of Minute and IsLeapSecond parameters represent an invalid date"
-      );
-    if (
-      second < minimumSecond ||
-      (second > maximumSecond && !isLeapSecond) ||
-      (second > maximumSecond + 1 && isLeapSecond)
-    )
-      throw new DeveloperError("Second parameter represent an invalid date");
-    if (
-      millisecond < minimumMillisecond ||
-      millisecond >= excludedMaximumMilisecond
-    )
-      throw new DeveloperError(
-        "Millisecond parameter represent an invalid date"
-      );
+    Check.typeOf.number.greaterThanOrEquals("Month", month, minimumMonth);
+    Check.typeOf.number.lessThanOrEquals("Month", month, maximumMonth);
+
+    Check.typeOf.number.greaterThanOrEquals("Day", day, minimumDay);
+    Check.typeOf.number.lessThanOrEquals("Day", day, maximumDay);
+
+    Check.typeOf.number.greaterThanOrEquals("Hour", hour, minimumHour);
+    Check.typeOf.number.lessThanOrEquals("Hour", hour, maximumHour);
+
+    Check.typeOf.number.greaterThanOrEquals("Minute", minute, minimumMinute);
+    Check.typeOf.number.lessThanOrEquals("Minute", minute, maximumMinute);
+
+    Check.typeOf.bool("IsLeapSecond", isLeapSecond);
+
+    Check.typeOf.number.greaterThanOrEquals("Second", second, minimumSecond);
+    Check.typeOf.number.lessThanOrEquals(
+      "Second",
+      second,
+      isLeapSecond ? maximumSecond + 1 : maximumSecond
+    );
+
+    Check.typeOf.number.greaterThanOrEquals(
+      "Millisecond",
+      millisecond,
+      minimumMillisecond
+    );
+    Check.typeOf.number.lessThan(
+      "Millisecond",
+      millisecond,
+      excludedMaximumMilisecond
+    );
   }
 
   // Javascript date object supports only dates greater than 1901. Thus validating with custom logic
   function validateDate() {
-    const minimumDaysInMonth = 28;
     const daysInYear = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
-    if (
-      month === 2 &&
-      ((isLeapYear(year) && day > minimumDaysInMonth + 1) ||
-        (!isLeapYear(year) && day > minimumDaysInMonth))
-    )
-      throw new DeveloperError("Year, Month and Day represents invalid date");
-    else if (month !== 2 && day > daysInYear[month - 1])
+    if (month === 2 && isLeapYear(year)) daysInYear[month - 1] += 1;
+
+    if (day > daysInYear[month - 1])
       throw new DeveloperError("Month and Day represents invalid date");
   }
 }

--- a/Source/Core/GregorianDate.js
+++ b/Source/Core/GregorianDate.js
@@ -16,15 +16,30 @@
  * @see JulianDate#toGregorianDate
  */
 function GregorianDate(
-  year = 1,
-  month = 1,
-  day = 1,
-  hour = 0,
-  minute = 0,
-  second = 0,
-  millisecond = 0,
-  isLeapSecond = false
+  year,
+  month,
+  day,
+  hour,
+  minute,
+  second,
+  millisecond,
+  isLeapSecond
 ) {
+  const minYear = 1;
+  const minMonth = 1;
+  const minDay = 1;
+  const minHour = 0;
+  const minMinute = 0;
+  const minSecond = 0;
+  const minMillisecond = 0;
+
+  if (!year) year = minYear;
+  if (!month) month = minMonth;
+  if (!day) day = minDay;
+  if (!hour) hour = minHour;
+  if (!minute) minute = minMinute;
+  if (!second) second = minSecond;
+  if (!millisecond) millisecond = minMillisecond;
   validateRange();
   validateDate();
 
@@ -71,19 +86,23 @@ function GregorianDate(
 
   function validateRange() {
     const maxYear = 9999;
-    const minYear = 1;
-    const minMonth = 1;
     const maxMonth = 12;
     const maxDay = 31;
-    const minDay = 1;
-    const minHour = 0;
     const maxHour = 23;
     const maxMinute = 59;
-    const minMinute = 0;
-    const minSecond = 0;
     const maxSecond = 59;
-    const minMilisecond = 0;
     const excludedMaxMilisecond = 1000;
+
+    if (
+      isNaN(year) ||
+      isNaN(month) ||
+      isNaN(day) ||
+      isNaN(hour) ||
+      isNaN(minute) ||
+      isNaN(second) ||
+      isNaN(millisecond)
+    )
+      throw "Invalid value passed in parameter";
 
     if (year < minYear || year > maxYear)
       throw "Year parameter represent an invalid date";
@@ -101,7 +120,7 @@ function GregorianDate(
       (second > maxSecond + 1 && isLeapSecond)
     )
       throw "Second parameter represent an invalid date";
-    if (millisecond < minMilisecond || millisecond >= excludedMaxMilisecond)
+    if (millisecond < minMillisecond || millisecond >= excludedMaxMilisecond)
       throw "Millisecond parameter represent an invalid date";
   }
 

--- a/Source/Core/GregorianDate.js
+++ b/Source/Core/GregorianDate.js
@@ -26,6 +26,7 @@ function GregorianDate(
   isLeapSecond = false
 ) {
   validateRange();
+  validateDate();
 
   /**
    * Gets or sets the year as a whole number.
@@ -69,22 +70,57 @@ function GregorianDate(
   this.isLeapSecond = isLeapSecond;
 
   function validateRange() {
-    if (year < 1 || year > 9999)
+    const maxYear = 9999;
+    const minYear = 1;
+    const minMonth = 1;
+    const maxMonth = 12;
+    const maxDay = 31;
+    const minDay = 1;
+    const minHour = 0;
+    const maxHour = 23;
+    const maxMinute = 59;
+    const minMinute = 0;
+    const minSecond = 0;
+    const maxSecond = 59;
+    const minMilisecond = 0;
+    const excludedMaxMilisecond = 1000;
+
+    if (year < minYear || year > maxYear)
       throw "Year parameter represent an invalid date";
-    if (month < 1 || month > 12)
+    if (month < minMonth || month > maxMonth)
       throw "Month parameter represent an invalid date";
-    if (day < 1 || day > 31) throw "Day parameter represent an invalid date";
-    if (hour < 0 || hour > 23) throw "Hour parameter represent an invalid date";
-    if (minute < 0 || minute > 59)
+    if (day < minDay || day > maxDay)
+      throw "Day parameter represent an invalid date";
+    if (hour < minHour || hour > maxHour)
+      throw "Hour parameter represent an invalid date";
+    if (minute < minMinute || minute > maxMinute)
       throw "Combination of Minute and IsLeapSecond parameters represent an invalid date";
     if (
-      second < 0 ||
-      (second > 59 && !isLeapSecond) ||
-      (second > 60 && isLeapSecond)
+      second < minSecond ||
+      (second > maxSecond && !isLeapSecond) ||
+      (second > maxSecond + 1 && isLeapSecond)
     )
       throw "Second parameter represent an invalid date";
-    if (millisecond < 0 || millisecond >= 1000)
+    if (millisecond < minMilisecond || millisecond >= excludedMaxMilisecond)
       throw "Millisecond parameter represent an invalid date";
+  }
+
+  // Javascript date object supports only dates greater than 1901. Thus validating with custom logic
+  function validateDate() {
+    const minNumberOfDaysInMonth = 28;
+    const monthsWith31Days = [1, 3, 5, 7, 8, 10, 12];
+
+    if (
+      month === 2 &&
+      ((year % 4 === 0 && day > minNumberOfDaysInMonth + 1) ||
+        (year % 4 !== 0 && day > minNumberOfDaysInMonth))
+    )
+      throw "Year, Month and Day represents invalid date";
+    else if (
+      monthsWith31Days.indexOf(month) === -1 &&
+      day > minNumberOfDaysInMonth + 2
+    )
+      throw "Month and Day represents invalid date";
   }
 }
 export default GregorianDate;

--- a/Source/Core/GregorianDate.js
+++ b/Source/Core/GregorianDate.js
@@ -16,15 +16,17 @@
  * @see JulianDate#toGregorianDate
  */
 function GregorianDate(
-  year,
-  month,
-  day,
-  hour,
-  minute,
-  second,
-  millisecond,
-  isLeapSecond
+  year = 1,
+  month = 1,
+  day = 1,
+  hour = 0,
+  minute = 0,
+  second = 0,
+  millisecond = 0,
+  isLeapSecond = false
 ) {
+  validateRange();
+
   /**
    * Gets or sets the year as a whole number.
    * @type {Number}
@@ -56,7 +58,7 @@ function GregorianDate(
    */
   this.second = second;
   /**
-   * Gets or sets the millisecond of the second as a floating point number with range [0.0, 1000.0).
+   * Gets or sets the millisecond of the second as a floating point number with range [0.0, 1000.0]).
    * @type {Number}
    */
   this.millisecond = millisecond;
@@ -65,5 +67,24 @@ function GregorianDate(
    * @type {Boolean}
    */
   this.isLeapSecond = isLeapSecond;
+
+  function validateRange() {
+    if (year < 1 || year > 9999)
+      throw "Year parameter represent an invalid date";
+    if (month < 1 || month > 12)
+      throw "Month parameter represent an invalid date";
+    if (day < 1 || day > 31) throw "Day parameter represent an invalid date";
+    if (hour < 0 || hour > 23) throw "Hour parameter represent an invalid date";
+    if (minute < 0 || minute > 59)
+      throw "Combination of Minute and IsLeapSecond parameters represent an invalid date";
+    if (
+      second < 0 ||
+      (second > 59 && !isLeapSecond) ||
+      (second > 60 && isLeapSecond)
+    )
+      throw "Second parameter represent an invalid date";
+    if (millisecond < 0 || millisecond >= 1000)
+      throw "Millisecond parameter represent an invalid date";
+  }
 }
 export default GregorianDate;

--- a/Specs/Core/GregorianDateSpec.js
+++ b/Specs/Core/GregorianDateSpec.js
@@ -1,0 +1,300 @@
+import { GregorianDate } from "../../Source/Cesium.js";
+
+describe("Core/GregorianDate", function () {
+  describe("Positive scenarios", function () {
+    it("Constructs any valid date", function () {
+      const validDate = new GregorianDate(2022, 2, 4, 23, 54, 0, 999.9, false);
+      expect(validDate.year).toEqual(2022);
+      expect(validDate.month).toEqual(2);
+      expect(validDate.day).toEqual(4);
+      expect(validDate.hour).toEqual(23);
+      expect(validDate.minute).toEqual(54);
+      expect(validDate.second).toEqual(0);
+      expect(validDate.millisecond).toEqual(999.9);
+      expect(validDate.isLeapSecond).toBeFalsy();
+    });
+
+    it("Constructs valid leap year date", function () {
+      const validDate = new GregorianDate(2024, 2, 29, 23, 54, 0, 999.9, false);
+      expect(validDate.year).toEqual(2024);
+      expect(validDate.month).toEqual(2);
+      expect(validDate.day).toEqual(29);
+      expect(validDate.hour).toEqual(23);
+      expect(validDate.minute).toEqual(54);
+      expect(validDate.second).toEqual(0);
+      expect(validDate.millisecond).toEqual(999.9);
+      expect(validDate.isLeapSecond).toBeFalsy();
+    });
+
+    it("Constructs the minimum date when no parameters are passed", function () {
+      const minimumDate = new GregorianDate();
+      expect(minimumDate.year).toEqual(1);
+      expect(minimumDate.month).toEqual(1);
+      expect(minimumDate.day).toEqual(1);
+      expect(minimumDate.hour).toEqual(0);
+      expect(minimumDate.minute).toEqual(0);
+      expect(minimumDate.second).toEqual(0);
+      expect(minimumDate.millisecond).toEqual(0);
+      expect(minimumDate.isLeapSecond).toBeFalsy();
+    });
+
+    it("Constructs valid dates for edge cases of days", function () {
+      expect(function () {
+        new GregorianDate(2022, 1, 31);
+      }).not.toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 3, 31);
+      }).not.toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 4, 30);
+      }).not.toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 5, 31);
+      }).not.toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 6, 30);
+      }).not.toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 7, 31);
+      }).not.toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 8, 31);
+      }).not.toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 9, 30);
+      }).not.toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 10, 31);
+      }).not.toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 11, 30);
+      }).not.toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 12, 31);
+      }).not.toThrowDeveloperError();
+    });
+
+    it("Constructs the minimum possible date of the year when only year parameter is passed", function () {
+      const minimumDate = new GregorianDate(2022);
+      expect(minimumDate.year).toEqual(2022);
+      expect(minimumDate.month).toEqual(1);
+      expect(minimumDate.day).toEqual(1);
+      expect(minimumDate.hour).toEqual(0);
+      expect(minimumDate.minute).toEqual(0);
+      expect(minimumDate.second).toEqual(0);
+      expect(minimumDate.millisecond).toEqual(0);
+      expect(minimumDate.isLeapSecond).toBeFalsy();
+    });
+
+    it("Constructs the minimum possible day of the month when only year and month parameters are passed", function () {
+      const minimumDate = new GregorianDate(2022, 2);
+      expect(minimumDate.year).toEqual(2022);
+      expect(minimumDate.month).toEqual(2);
+      expect(minimumDate.day).toEqual(1);
+      expect(minimumDate.hour).toEqual(0);
+      expect(minimumDate.minute).toEqual(0);
+      expect(minimumDate.second).toEqual(0);
+      expect(minimumDate.millisecond).toEqual(0);
+      expect(minimumDate.isLeapSecond).toBeFalsy();
+    });
+
+    it("Constructs the minimum possible time of the day when only year, month and day parameters are passed", function () {
+      const minimumDate = new GregorianDate(2022, 2, 28);
+      expect(minimumDate.year).toEqual(2022);
+      expect(minimumDate.month).toEqual(2);
+      expect(minimumDate.day).toEqual(28);
+      expect(minimumDate.hour).toEqual(0);
+      expect(minimumDate.minute).toEqual(0);
+      expect(minimumDate.second).toEqual(0);
+      expect(minimumDate.millisecond).toEqual(0);
+      expect(minimumDate.isLeapSecond).toBeFalsy();
+    });
+
+    it("Constructs the minimum possible time of the day when only year, month, day and hour parameters are passed", function () {
+      const minimumDate = new GregorianDate(2022, 2, 28, 10);
+      expect(minimumDate.year).toEqual(2022);
+      expect(minimumDate.month).toEqual(2);
+      expect(minimumDate.day).toEqual(28);
+      expect(minimumDate.hour).toEqual(10);
+      expect(minimumDate.minute).toEqual(0);
+      expect(minimumDate.second).toEqual(0);
+      expect(minimumDate.millisecond).toEqual(0);
+      expect(minimumDate.isLeapSecond).toBeFalsy();
+    });
+
+    it("Constructs the minimum possible time of the day when only year, month, day, hour and minutes parameters are passed", function () {
+      const minimumDate = new GregorianDate(2022, 2, 28, 10, 59);
+      expect(minimumDate.year).toEqual(2022);
+      expect(minimumDate.month).toEqual(2);
+      expect(minimumDate.day).toEqual(28);
+      expect(minimumDate.hour).toEqual(10);
+      expect(minimumDate.minute).toEqual(59);
+      expect(minimumDate.second).toEqual(0);
+      expect(minimumDate.millisecond).toEqual(0);
+      expect(minimumDate.isLeapSecond).toBeFalsy();
+    });
+
+    it("Constructs the minimum possible time of the day when only year, month, day, hour, minutes and seconds parameters are passed", function () {
+      const minimumDate = new GregorianDate(2022, 2, 28, 10, 59, 59);
+      expect(minimumDate.year).toEqual(2022);
+      expect(minimumDate.month).toEqual(2);
+      expect(minimumDate.day).toEqual(28);
+      expect(minimumDate.hour).toEqual(10);
+      expect(minimumDate.minute).toEqual(59);
+      expect(minimumDate.second).toEqual(59);
+      expect(minimumDate.millisecond).toEqual(0);
+      expect(minimumDate.isLeapSecond).toBeFalsy();
+    });
+
+    it("Constructs the date with leap second", function () {
+      const minimumDate = new GregorianDate(2022, 2, 28, 10, 59, 60, 100, true);
+      expect(minimumDate.year).toEqual(2022);
+      expect(minimumDate.month).toEqual(2);
+      expect(minimumDate.day).toEqual(28);
+      expect(minimumDate.hour).toEqual(10);
+      expect(minimumDate.minute).toEqual(59);
+      expect(minimumDate.second).toEqual(60);
+      expect(minimumDate.millisecond).toEqual(100);
+      expect(minimumDate.isLeapSecond).toBeTruthy();
+    });
+  });
+  describe("Negative scenarios", function () {
+    it("Should throw error if invalid year is passed", function () {
+      expect(function () {
+        new GregorianDate(-1, 2, 4, 23, 54, 0, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(0, 2, 4, 23, 54, 0, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(10000, 2, 4, 23, 54, 0, 999.9, false);
+      }).toThrowDeveloperError();
+    });
+
+    it("Should throw error if invalid month is passed", function () {
+      expect(function () {
+        new GregorianDate(2022, -1, 4, 23, 54, 0, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 0, 4, 23, 54, 0, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 13, 4, 23, 54, 0, 999.9, false);
+      }).toThrowDeveloperError();
+    });
+
+    it("Should throw error if invalid day is passed", function () {
+      expect(function () {
+        new GregorianDate(2022, 12, -10, 23, 54, 0, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 12, 0, 23, 54, 0, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 12, 32, 23, 54, 0, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2020, 2, 30, 23, 54, 0, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 2, 29, 23, 54, 0, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 11, 31, 23, 54, 0, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 4, 31, 23, 54, 0, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 6, 31, 23, 54, 0, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 9, 31, 23, 54, 0, 999.9, false);
+      }).toThrowDeveloperError();
+    });
+
+    it("Should throw error if invalid hours is passed", function () {
+      expect(function () {
+        new GregorianDate(2022, 2, 4, -10, 54, 0, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 2, 4, -1, 54, 0, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 2, 4, 24, 54, 0, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 11, 4, 100, 54, 0, 999.9, false);
+      }).toThrowDeveloperError();
+    });
+
+    it("Should throw error if invalid minute is passed", function () {
+      expect(function () {
+        new GregorianDate(2022, 2, 4, 15, -1, 0, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 2, 4, 15, 60, 0, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 2, 4, 7, 60, 0, 999.9, true);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 11, 4, 0, -1, 0, 999.9, true);
+      }).toThrowDeveloperError();
+    });
+
+    it("Should throw error if invalid second is passed", function () {
+      expect(function () {
+        new GregorianDate(2022, 2, 4, 15, 1, -1, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 2, 4, 15, 59, 60, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 2, 4, 7, 59, 61, 999.9, true);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 11, 4, 0, 1, -1, 999.9, true);
+      }).toThrowDeveloperError();
+    });
+
+    it("Should throw error if invalid millisecond is passed", function () {
+      expect(function () {
+        new GregorianDate(2022, 2, 4, 15, 1, 0, -1, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 2, 4, 15, 59, 59, 1000, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 2, 4, 7, 59, 60, 1000, true);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 11, 4, 0, 1, 0, -12, true);
+      }).toThrowDeveloperError();
+    });
+
+    it("Should throw error if invalid type is passed", function () {
+      expect(function () {
+        new GregorianDate("2022A", 2, 4, 15, 1, 0, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, "Two", 4, 15, 1, 0, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 2, "F0UR", 15, 1, 0, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 2, 4, "15th", 1, 0, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 2, 4, 15, "1st", 0, 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 2, 4, 15, 1, "Zero", 999.9, false);
+      }).toThrowDeveloperError();
+      expect(function () {
+        new GregorianDate(2022, 2, 4, 15, 1, 0, "999,9O", false);
+      }).toThrowDeveloperError();
+    });
+  });
+});

--- a/Specs/Core/GregorianDateSpec.js
+++ b/Specs/Core/GregorianDateSpec.js
@@ -40,37 +40,37 @@ describe("Core/GregorianDate", function () {
 
     it("Constructs valid dates for edge cases of days", function () {
       expect(function () {
-        new GregorianDate(2022, 1, 31);
+        return new GregorianDate(2022, 1, 31);
       }).not.toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 3, 31);
+        return new GregorianDate(2022, 3, 31);
       }).not.toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 4, 30);
+        return new GregorianDate(2022, 4, 30);
       }).not.toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 5, 31);
+        return new GregorianDate(2022, 5, 31);
       }).not.toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 6, 30);
+        return new GregorianDate(2022, 6, 30);
       }).not.toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 7, 31);
+        return new GregorianDate(2022, 7, 31);
       }).not.toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 8, 31);
+        return new GregorianDate(2022, 8, 31);
       }).not.toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 9, 30);
+        return new GregorianDate(2022, 9, 30);
       }).not.toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 10, 31);
+        return new GregorianDate(2022, 10, 31);
       }).not.toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 11, 30);
+        return new GregorianDate(2022, 11, 30);
       }).not.toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 12, 31);
+        return new GregorianDate(2022, 12, 31);
       }).not.toThrowDeveloperError();
     });
 
@@ -161,139 +161,139 @@ describe("Core/GregorianDate", function () {
   describe("Negative scenarios", function () {
     it("Should throw error if invalid year is passed", function () {
       expect(function () {
-        new GregorianDate(-1, 2, 4, 23, 54, 0, 999.9, false);
+        return new GregorianDate(-1, 2, 4, 23, 54, 0, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(0, 2, 4, 23, 54, 0, 999.9, false);
+        return new GregorianDate(0, 2, 4, 23, 54, 0, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(10000, 2, 4, 23, 54, 0, 999.9, false);
+        return new GregorianDate(10000, 2, 4, 23, 54, 0, 999.9, false);
       }).toThrowDeveloperError();
     });
 
     it("Should throw error if invalid month is passed", function () {
       expect(function () {
-        new GregorianDate(2022, -1, 4, 23, 54, 0, 999.9, false);
+        return new GregorianDate(2022, -1, 4, 23, 54, 0, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 0, 4, 23, 54, 0, 999.9, false);
+        return new GregorianDate(2022, 0, 4, 23, 54, 0, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 13, 4, 23, 54, 0, 999.9, false);
+        return new GregorianDate(2022, 13, 4, 23, 54, 0, 999.9, false);
       }).toThrowDeveloperError();
     });
 
     it("Should throw error if invalid day is passed", function () {
       expect(function () {
-        new GregorianDate(2022, 12, -10, 23, 54, 0, 999.9, false);
+        return new GregorianDate(2022, 12, -10, 23, 54, 0, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 12, 0, 23, 54, 0, 999.9, false);
+        return new GregorianDate(2022, 12, 0, 23, 54, 0, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 12, 32, 23, 54, 0, 999.9, false);
+        return new GregorianDate(2022, 12, 32, 23, 54, 0, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2020, 2, 30, 23, 54, 0, 999.9, false);
+        return new GregorianDate(2020, 2, 30, 23, 54, 0, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 2, 29, 23, 54, 0, 999.9, false);
+        return new GregorianDate(2022, 2, 29, 23, 54, 0, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 11, 31, 23, 54, 0, 999.9, false);
+        return new GregorianDate(2022, 11, 31, 23, 54, 0, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 4, 31, 23, 54, 0, 999.9, false);
+        return new GregorianDate(2022, 4, 31, 23, 54, 0, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 6, 31, 23, 54, 0, 999.9, false);
+        return new GregorianDate(2022, 6, 31, 23, 54, 0, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 9, 31, 23, 54, 0, 999.9, false);
+        return new GregorianDate(2022, 9, 31, 23, 54, 0, 999.9, false);
       }).toThrowDeveloperError();
     });
 
     it("Should throw error if invalid hours is passed", function () {
       expect(function () {
-        new GregorianDate(2022, 2, 4, -10, 54, 0, 999.9, false);
+        return new GregorianDate(2022, 2, 4, -10, 54, 0, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 2, 4, -1, 54, 0, 999.9, false);
+        return new GregorianDate(2022, 2, 4, -1, 54, 0, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 2, 4, 24, 54, 0, 999.9, false);
+        return new GregorianDate(2022, 2, 4, 24, 54, 0, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 11, 4, 100, 54, 0, 999.9, false);
+        return new GregorianDate(2022, 11, 4, 100, 54, 0, 999.9, false);
       }).toThrowDeveloperError();
     });
 
     it("Should throw error if invalid minute is passed", function () {
       expect(function () {
-        new GregorianDate(2022, 2, 4, 15, -1, 0, 999.9, false);
+        return new GregorianDate(2022, 2, 4, 15, -1, 0, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 2, 4, 15, 60, 0, 999.9, false);
+        return new GregorianDate(2022, 2, 4, 15, 60, 0, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 2, 4, 7, 60, 0, 999.9, true);
+        return new GregorianDate(2022, 2, 4, 7, 60, 0, 999.9, true);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 11, 4, 0, -1, 0, 999.9, true);
+        return new GregorianDate(2022, 11, 4, 0, -1, 0, 999.9, true);
       }).toThrowDeveloperError();
     });
 
     it("Should throw error if invalid second is passed", function () {
       expect(function () {
-        new GregorianDate(2022, 2, 4, 15, 1, -1, 999.9, false);
+        return new GregorianDate(2022, 2, 4, 15, 1, -1, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 2, 4, 15, 59, 60, 999.9, false);
+        return new GregorianDate(2022, 2, 4, 15, 59, 60, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 2, 4, 7, 59, 61, 999.9, true);
+        return new GregorianDate(2022, 2, 4, 7, 59, 61, 999.9, true);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 11, 4, 0, 1, -1, 999.9, true);
+        return new GregorianDate(2022, 11, 4, 0, 1, -1, 999.9, true);
       }).toThrowDeveloperError();
     });
 
     it("Should throw error if invalid millisecond is passed", function () {
       expect(function () {
-        new GregorianDate(2022, 2, 4, 15, 1, 0, -1, false);
+        return new GregorianDate(2022, 2, 4, 15, 1, 0, -1, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 2, 4, 15, 59, 59, 1000, false);
+        return new GregorianDate(2022, 2, 4, 15, 59, 59, 1000, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 2, 4, 7, 59, 60, 1000, true);
+        return new GregorianDate(2022, 2, 4, 7, 59, 60, 1000, true);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 11, 4, 0, 1, 0, -12, true);
+        return new GregorianDate(2022, 11, 4, 0, 1, 0, -12, true);
       }).toThrowDeveloperError();
     });
 
     it("Should throw error if invalid type is passed", function () {
       expect(function () {
-        new GregorianDate("2022A", 2, 4, 15, 1, 0, 999.9, false);
+        return new GregorianDate("2022A", 2, 4, 15, 1, 0, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, "Two", 4, 15, 1, 0, 999.9, false);
+        return new GregorianDate(2022, "Two", 4, 15, 1, 0, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 2, "F0UR", 15, 1, 0, 999.9, false);
+        return new GregorianDate(2022, 2, "F0UR", 15, 1, 0, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 2, 4, "15th", 1, 0, 999.9, false);
+        return new GregorianDate(2022, 2, 4, "15th", 1, 0, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 2, 4, 15, "1st", 0, 999.9, false);
+        return new GregorianDate(2022, 2, 4, 15, "1st", 0, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 2, 4, 15, 1, "Zero", 999.9, false);
+        return new GregorianDate(2022, 2, 4, 15, 1, "Zero", 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
-        new GregorianDate(2022, 2, 4, 15, 1, 0, "999,9O", false);
+        return new GregorianDate(2022, 2, 4, 15, 1, 0, "999,9O", false);
       }).toThrowDeveloperError();
     });
   });

--- a/Specs/Core/GregorianDateSpec.js
+++ b/Specs/Core/GregorianDateSpec.js
@@ -1,7 +1,7 @@
 import { GregorianDate } from "../../Source/Cesium.js";
 
 describe("Core/GregorianDate", function () {
-  describe("Positive scenarios", function () {
+  describe("With valid parameters", function () {
     it("Constructs any valid date", function () {
       const validDate = new GregorianDate(2022, 2, 4, 23, 54, 0, 999.9, false);
       expect(validDate.year).toEqual(2022);
@@ -11,7 +11,7 @@ describe("Core/GregorianDate", function () {
       expect(validDate.minute).toEqual(54);
       expect(validDate.second).toEqual(0);
       expect(validDate.millisecond).toEqual(999.9);
-      expect(validDate.isLeapSecond).toBeFalsy();
+      expect(validDate.isLeapSecond).toBe(false);
     });
 
     it("Constructs valid leap year date", function () {
@@ -23,7 +23,7 @@ describe("Core/GregorianDate", function () {
       expect(validDate.minute).toEqual(54);
       expect(validDate.second).toEqual(0);
       expect(validDate.millisecond).toEqual(999.9);
-      expect(validDate.isLeapSecond).toBeFalsy();
+      expect(validDate.isLeapSecond).toBe(false);
     });
 
     it("Constructs the minimum date when no parameters are passed", function () {
@@ -35,12 +35,18 @@ describe("Core/GregorianDate", function () {
       expect(minimumDate.minute).toEqual(0);
       expect(minimumDate.second).toEqual(0);
       expect(minimumDate.millisecond).toEqual(0);
-      expect(minimumDate.isLeapSecond).toBeFalsy();
+      expect(minimumDate.isLeapSecond).toBe(false);
     });
 
     it("Constructs valid dates for edge cases of days", function () {
       expect(function () {
         return new GregorianDate(2022, 1, 31);
+      }).not.toThrowDeveloperError();
+      expect(function () {
+        return new GregorianDate(2000, 2, 28);
+      }).not.toThrowDeveloperError();
+      expect(function () {
+        return new GregorianDate(2020, 2, 29);
       }).not.toThrowDeveloperError();
       expect(function () {
         return new GregorianDate(2022, 3, 31);
@@ -83,7 +89,7 @@ describe("Core/GregorianDate", function () {
       expect(minimumDate.minute).toEqual(0);
       expect(minimumDate.second).toEqual(0);
       expect(minimumDate.millisecond).toEqual(0);
-      expect(minimumDate.isLeapSecond).toBeFalsy();
+      expect(minimumDate.isLeapSecond).toBe(false);
     });
 
     it("Constructs the minimum possible day of the month when only year and month parameters are passed", function () {
@@ -95,7 +101,7 @@ describe("Core/GregorianDate", function () {
       expect(minimumDate.minute).toEqual(0);
       expect(minimumDate.second).toEqual(0);
       expect(minimumDate.millisecond).toEqual(0);
-      expect(minimumDate.isLeapSecond).toBeFalsy();
+      expect(minimumDate.isLeapSecond).toBe(false);
     });
 
     it("Constructs the minimum possible time of the day when only year, month and day parameters are passed", function () {
@@ -107,7 +113,7 @@ describe("Core/GregorianDate", function () {
       expect(minimumDate.minute).toEqual(0);
       expect(minimumDate.second).toEqual(0);
       expect(minimumDate.millisecond).toEqual(0);
-      expect(minimumDate.isLeapSecond).toBeFalsy();
+      expect(minimumDate.isLeapSecond).toBe(false);
     });
 
     it("Constructs the minimum possible time of the day when only year, month, day and hour parameters are passed", function () {
@@ -119,7 +125,7 @@ describe("Core/GregorianDate", function () {
       expect(minimumDate.minute).toEqual(0);
       expect(minimumDate.second).toEqual(0);
       expect(minimumDate.millisecond).toEqual(0);
-      expect(minimumDate.isLeapSecond).toBeFalsy();
+      expect(minimumDate.isLeapSecond).toBe(false);
     });
 
     it("Constructs the minimum possible time of the day when only year, month, day, hour and minutes parameters are passed", function () {
@@ -131,7 +137,7 @@ describe("Core/GregorianDate", function () {
       expect(minimumDate.minute).toEqual(59);
       expect(minimumDate.second).toEqual(0);
       expect(minimumDate.millisecond).toEqual(0);
-      expect(minimumDate.isLeapSecond).toBeFalsy();
+      expect(minimumDate.isLeapSecond).toBe(false);
     });
 
     it("Constructs the minimum possible time of the day when only year, month, day, hour, minutes and seconds parameters are passed", function () {
@@ -143,7 +149,7 @@ describe("Core/GregorianDate", function () {
       expect(minimumDate.minute).toEqual(59);
       expect(minimumDate.second).toEqual(59);
       expect(minimumDate.millisecond).toEqual(0);
-      expect(minimumDate.isLeapSecond).toBeFalsy();
+      expect(minimumDate.isLeapSecond).toBe(false);
     });
 
     it("Constructs the date with leap second", function () {
@@ -155,10 +161,10 @@ describe("Core/GregorianDate", function () {
       expect(minimumDate.minute).toEqual(59);
       expect(minimumDate.second).toEqual(60);
       expect(minimumDate.millisecond).toEqual(100);
-      expect(minimumDate.isLeapSecond).toBeTruthy();
+      expect(minimumDate.isLeapSecond).toBe(true);
     });
   });
-  describe("Negative scenarios", function () {
+  describe("With invalid parameters", function () {
     it("Should throw error if invalid year is passed", function () {
       expect(function () {
         return new GregorianDate(-1, 2, 4, 23, 54, 0, 999.9, false);
@@ -193,11 +199,11 @@ describe("Core/GregorianDate", function () {
       expect(function () {
         return new GregorianDate(2022, 12, 32, 23, 54, 0, 999.9, false);
       }).toThrowDeveloperError();
+    });
+
+    it("Should throw error if day is out of range for month", function () {
       expect(function () {
         return new GregorianDate(2020, 2, 30, 23, 54, 0, 999.9, false);
-      }).toThrowDeveloperError();
-      expect(function () {
-        return new GregorianDate(2022, 2, 29, 23, 54, 0, 999.9, false);
       }).toThrowDeveloperError();
       expect(function () {
         return new GregorianDate(2022, 11, 31, 23, 54, 0, 999.9, false);
@@ -210,6 +216,12 @@ describe("Core/GregorianDate", function () {
       }).toThrowDeveloperError();
       expect(function () {
         return new GregorianDate(2022, 9, 31, 23, 54, 0, 999.9, false);
+      }).toThrowDeveloperError();
+    });
+
+    it("Should throw error if leap day is given for non-leap year", function () {
+      expect(function () {
+        return new GregorianDate(2022, 2, 29, 23, 54, 0, 999.9, false);
       }).toThrowDeveloperError();
     });
 


### PR DESCRIPTION
Fixes #10057 

Following are the use cases covered:
- Validate inclusive range for year (0001 to 9999)
- Validate inclusive range for month (1 to 12)
- Validate inclusive range for month (1 to 28/29/30/31 depending on month & year)
- Validate inclusive range for hour (0 to 23)
- Validate inclusive range for minute (0 to 59)
- Validate inclusive range for second (1 to 59/60 depending on isLeapSecond)
 