### PR TITLE
Remove uneeded flag in tsconfig

### DIFF
--- a/Tools/jsdoc/tsconfig.json
+++ b/Tools/jsdoc/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
       "noEmit": true,
-      "types": [],
-      "preserveConstEnums": true
+      "types": []
   },
   "files": [
     "../../Source/Cesium.d.ts"


### PR DESCRIPTION
Follow up from https://github.com/CesiumGS/cesium/pull/10072 -- 

We believe this flag is not actually necessary to workaround the issue, and that stripping the `const enum`s out of the `.d.ts` file is sufficient.