### PR TITLE
Add shadows to `ModelExperimental`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - Added the ability to toggle back-face culling in `ModelExperimental`. [#10070](https://github.com/CesiumGS/cesium/pull/10070)
 - Added `depthPlaneEllipsoidOffset` to Viewer and Scene constructors to address rendering artefacts below ellipsoid zero elevation. [#9200](https://github.com/CesiumGS/cesium/pull/9200)
 - Added support for `debugColorTiles` in `ModelExperimental`. [#10071](https://github.com/CesiumGS/cesium/pull/10071)
+- Added support for shadows in `ModelExperimental`. [#10077](https://github.com/CesiumGS/cesium/pull/10077)
 
 ### 1.90 - 2022-02-01
 

--- a/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
@@ -13,6 +13,7 @@ import ModelRenderResources from "./ModelRenderResources.js";
 import NodeRenderResources from "./NodeRenderResources.js";
 import PrimitiveRenderResources from "./PrimitiveRenderResources.js";
 import RenderState from "../../Renderer/RenderState.js";
+import ShadowMode from "../ShadowMode.js";
 
 /**
  * An in memory representation of the scene graph for a {@link ModelExperimental}
@@ -441,6 +442,26 @@ ModelExperimentalSceneGraph.prototype.updateBackFaceCulling = function (
       renderState.cull.enabled =
         backFaceCulling && !doubleSided && !translucent;
       drawCommand.renderState = RenderState.fromCache(renderState);
+    }
+  });
+};
+
+/**
+ * Traverses through all draw commands and changes the shadow settings.
+ *
+ * @param {ShadowMode} shadowMode The new shadow settings.
+ *
+ * @private
+ */
+ModelExperimentalSceneGraph.prototype.updateShadows = function (shadowMode) {
+  const model = this._model;
+  const castShadows = ShadowMode.castShadows(model.shadows);
+  const receiveShadows = ShadowMode.receiveShadows(model.shadows);
+  forEachRuntimePrimitive(this, function (runtimePrimitive) {
+    for (let k = 0; k < runtimePrimitive.drawCommands.length; k++) {
+      const drawCommand = runtimePrimitive.drawCommands[k];
+      drawCommand.castShadows = castShadows;
+      drawCommand.receiveShadows = receiveShadows;
     }
   });
 };

--- a/Source/Scene/ModelExperimental/buildDrawCommands.js
+++ b/Source/Scene/ModelExperimental/buildDrawCommands.js
@@ -12,6 +12,7 @@ import StyleCommandsNeeded from "./StyleCommandsNeeded.js";
 import VertexArray from "../../Renderer/VertexArray.js";
 import BoundingSphere from "../../Core/BoundingSphere.js";
 import Matrix4 from "../../Core/Matrix4.js";
+import ShadowMode from "../ShadowMode.js";
 
 /**
  * Builds the DrawCommands for a {@link ModelExperimentalPrimitive} using its render resources.
@@ -87,6 +88,8 @@ export default function buildDrawCommands(
     instanceCount: primitiveRenderResources.instanceCount,
     primitiveType: primitiveRenderResources.primitiveType,
     debugShowBoundingVolume: model.debugShowBoundingVolume,
+    castShadows: ShadowMode.castShadows(model.shadows),
+    receiveShadows: ShadowMode.receiveShadows(model.shadows),
   });
 
   const styleCommandsNeeded = primitiveRenderResources.styleCommandsNeeded;

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -18,6 +18,7 @@ import {
   Color,
   StyleCommandsNeeded,
   ModelExperimentalSceneGraph,
+  DirectionalLight,
 } from "../../../Source/Cesium.js";
 import createScene from "../../createScene.js";
 import loadAndZoomToModelExperimental from "./loadAndZoomToModelExperimental.js";
@@ -39,6 +40,10 @@ describe(
     const boxBackFaceCullingUrl =
       "./Data/Models/Box-Back-Face-Culling/Box-Back-Face-Culling.gltf";
     const boxBackFaceCullingOffset = new HeadingPitchRange(Math.PI / 2, 0, 2.0);
+    const boxShadowsUrl = "./Data/Models/Shadows/Box.gltf";
+    const boxShadowsOffset = new HeadingPitchRange(Math.PI / 2, 0, 2.0);
+    const boxShadowsLightDirection = new Cartesian3(1.0, 0.0, 0.0);
+
     let scene;
 
     beforeAll(function () {
@@ -607,6 +612,27 @@ describe(
 
         expect(renderOptions).toRenderAndCall(function (rgba) {
           expect(rgba).not.toEqual([0, 0, 0, 255]);
+        });
+      });
+    });
+
+    it("enables shadows", function () {
+      return loadAndZoomToModelExperimental(
+        {
+          gltf: boxShadowsUrl,
+          shadows: true,
+          offset: boxShadowsOffset,
+        },
+        scene
+      ).then(function (model) {
+        scene.light = new DirectionalLight(boxShadowsLightDirection);
+        const renderOptions = {
+          scene: scene,
+          time: new JulianDate(2456659.0004050927),
+        };
+
+        expect(renderOptions).toRenderAndCall(function (rgba) {
+          expect(rgba).toEqual([0, 0, 0, 255]);
         });
       });
     });

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -18,7 +18,6 @@ import {
   Color,
   StyleCommandsNeeded,
   ModelExperimentalSceneGraph,
-  DirectionalLight,
 } from "../../../Source/Cesium.js";
 import createScene from "../../createScene.js";
 import loadAndZoomToModelExperimental from "./loadAndZoomToModelExperimental.js";
@@ -40,9 +39,6 @@ describe(
     const boxBackFaceCullingUrl =
       "./Data/Models/Box-Back-Face-Culling/Box-Back-Face-Culling.gltf";
     const boxBackFaceCullingOffset = new HeadingPitchRange(Math.PI / 2, 0, 2.0);
-    const boxShadowsUrl = "./Data/Models/Shadows/Box.gltf";
-    const boxShadowsOffset = new HeadingPitchRange(Math.PI / 2, 0, 2.0);
-    const boxShadowsLightDirection = new Cartesian3(1.0, 0.0, 0.0);
 
     let scene;
 
@@ -612,27 +608,6 @@ describe(
 
         expect(renderOptions).toRenderAndCall(function (rgba) {
           expect(rgba).not.toEqual([0, 0, 0, 255]);
-        });
-      });
-    });
-
-    it("enables shadows", function () {
-      return loadAndZoomToModelExperimental(
-        {
-          gltf: boxShadowsUrl,
-          shadows: true,
-          offset: boxShadowsOffset,
-        },
-        scene
-      ).then(function (model) {
-        scene.light = new DirectionalLight(boxShadowsLightDirection);
-        const renderOptions = {
-          scene: scene,
-          time: new JulianDate(2456659.0004050927),
-        };
-
-        expect(renderOptions).toRenderAndCall(function (rgba) {
-          expect(rgba).toEqual([0, 0, 0, 255]);
         });
       });
     });

--- a/Specs/Scene/ShadowMapSpec.js
+++ b/Specs/Scene/ShadowMapSpec.js
@@ -11,6 +11,7 @@ import { HeadingPitchRoll } from "../../Source/Cesium.js";
 import { HeightmapTerrainData } from "../../Source/Cesium.js";
 import { JulianDate } from "../../Source/Cesium.js";
 import { Math as CesiumMath } from "../../Source/Cesium.js";
+import { Matrix4 } from "../../Source/Cesium.js";
 import { OrthographicOffCenterFrustum } from "../../Source/Cesium.js";
 import { PixelFormat } from "../../Source/Cesium.js";
 import { Transforms } from "../../Source/Cesium.js";
@@ -23,6 +24,7 @@ import { Camera } from "../../Source/Cesium.js";
 import { DirectionalLight } from "../../Source/Cesium.js";
 import { Globe } from "../../Source/Cesium.js";
 import { Model } from "../../Source/Cesium.js";
+import { ModelExperimental } from "../../Source/Cesium.js";
 import { PerInstanceColorAppearance } from "../../Source/Cesium.js";
 import { Primitive } from "../../Source/Cesium.js";
 import { ShadowMap } from "../../Source/Cesium.js";
@@ -52,6 +54,10 @@ describe(
     let box;
     let boxTranslucent;
     let boxCutout;
+
+    let boxExperimental;
+    let boxTranslucentExperimental;
+
     let room;
     let floor;
     let floorTranslucent;
@@ -79,6 +85,15 @@ describe(
         new HeadingPitchRoll()
       );
 
+      const boxScale = 0.5;
+      const boxScaleCartesian = new Cartesian3(boxScale, boxScale, boxScale);
+      const boxTransformExperimental = new Matrix4();
+      Matrix4.setScale(
+        boxTransform,
+        boxScaleCartesian,
+        boxTransformExperimental
+      );
+
       const floorOrigin = new Cartesian3.fromRadians(
         longitude,
         latitude,
@@ -104,7 +119,7 @@ describe(
         loadModel({
           url: boxUrl,
           modelMatrix: boxTransform,
-          scale: 0.5,
+          scale: boxScale,
           show: false,
         }).then(function (model) {
           box = model;
@@ -114,7 +129,7 @@ describe(
         loadModel({
           url: boxTranslucentUrl,
           modelMatrix: boxTransform,
-          scale: 0.5,
+          scale: boxScale,
           show: false,
         }).then(function (model) {
           boxTranslucent = model;
@@ -124,11 +139,29 @@ describe(
         loadModel({
           url: boxCutoutUrl,
           modelMatrix: boxTransform,
-          scale: 0.5,
+          scale: boxScale,
           incrementallyLoadTextures: false,
           show: false,
         }).then(function (model) {
           boxCutout = model;
+        })
+      );
+      modelPromises.push(
+        loadModelExperimental({
+          gltf: boxUrl,
+          modelMatrix: boxTransformExperimental,
+          show: false,
+        }).then(function (model) {
+          boxExperimental = model;
+        })
+      );
+      modelPromises.push(
+        loadModelExperimental({
+          gltf: boxTranslucentUrl,
+          modelMatrix: boxTransformExperimental,
+          show: false,
+        }).then(function (model) {
+          boxTranslucentExperimental = model;
         })
       );
       modelPromises.push(
@@ -246,6 +279,20 @@ describe(
 
     function loadModel(options) {
       const model = scene.primitives.add(Model.fromGltf(options));
+      return pollToPromise(
+        function () {
+          // Render scene to progressively load the model
+          scene.render();
+          return model.ready;
+        },
+        { timeout: 10000 }
+      ).then(function () {
+        return model;
+      });
+    }
+
+    function loadModelExperimental(options) {
+      const model = scene.primitives.add(ModelExperimental.fromGltf(options));
       return pollToPromise(
         function () {
           // Render scene to progressively load the model
@@ -507,11 +554,25 @@ describe(
       verifyShadows(box, floor);
     });
 
+    it("model experimental casts shadows onto another model", function () {
+      boxExperimental.show = true;
+      floor.show = true;
+      createCascadedShadowMap();
+      verifyShadows(boxExperimental, floor);
+    });
+
     it("translucent model casts shadows onto another model", function () {
       boxTranslucent.show = true;
       floor.show = true;
       createCascadedShadowMap();
       verifyShadows(boxTranslucent, floor);
+    });
+
+    it("translucent model experimental casts shadows onto another model", function () {
+      boxTranslucentExperimental.show = true;
+      floor.show = true;
+      createCascadedShadowMap();
+      verifyShadows(boxTranslucentExperimental, floor);
     });
 
     it("model with cutout texture casts shadows onto another model", function () {


### PR DESCRIPTION
Fixes #10062.

This PR adds the option to enable and disable shadows for models loaded in with `ModelExperimental`. I put together this [sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=jVRtT9swEP4rVj4lUuakowMGBW1QYJNgQ7TbvkRCbnJtrLl2ZTst3cR/38VO2rT0w6KqyZ3vuZfn7pwraSxZcliBJhdEwopcg+HVnP50ujALcidfK2kZl6CzIDrPZO5wJgcJCPN46kQ8dG9qSlao1QNbUJBsIqBAQ6ur2qDFCz4r7ZBryC1Xcjf+NdMWv5g8Cns0jUna/EWbAA69C9r4YuK+Pg3/ZpKQotWe7UXM5Gvk0kkS8qAKEG1i81r4oQV6zwJKE/yN2HwhYMgsS9ypSUauwDEYC7oRnr303KczMcmCTqkO86gMbyp9UyWdajUfwkwDmLDO+l3v/RFNT/r9497HuFb0+zT9kB6dpMdOTDMZdQKUi70GfgFWcDl75DYvn5QQzmlz9sBsSa16QgsmTdg7TSPvs+vZ+53yFyhuNZvDWKPtVOn5Nv2NylChcia8nbrdYO6wUZpZpV30LJBK2zILYi+tkK0s2K3DEbU3U3Sh+RyZW4KhrCicr20tNeDmZQFoAzikwjF5J+zUd79+Ziidbboat2qnQC40fzk7UFK5x2C3sLD1QXZbG2/12JGO1Li/EYIvjOIF/XU3Ou13DA4Q3R5GjdlrVL89Wy4q1Zji+hHr5QaoLUGG00r6bQqdRUQcCQ2bOXrXjE7FeqyuVCXr8kaLEjR4azrZUcakYbCosIlugfyEuLUhzfKMmCxyZqyAujljNZsJuKqsVRJvDy8Svx4GO+/pam4HE5NtvrXjvIT8NxQ4Ej40n4aNKmpz2cFvR9FHqIeB3nz7fHV/Mzx3mRJcVfh/7PDrqAN2F0QQBwNj1wIu23584vMFDjKptAjxarCAVwPDPU4mFaZqaW6MIwifQdKFDgq+JLy4OHCrklwwY/BkWgkx4n8gCy4HCdq/gQrlxvL7ErRg69qs7F3eeyWldJCgeBhplRITpvc8/wM) to demonstrate that shadows can be toggled at runtime.

There was one thing that came up: when writing unit tests in `ShadowMapSpec.js` for `ModelExperimental`, the `"model with cutout texture casts shadows onto another model"` test. It uses `Specs/Data/Models/Shadows/BoxCutOut.gltf`, which is supposed to be a cube with a transparent cut-out in the texture (essentially, a cube with square holes on all sides). Looking at it in Sandcastle, it makes sense why the test failed:

![image](https://user-images.githubusercontent.com/32226860/152597978-64467365-0261-45e5-afd6-a2947297ac3e.png)

`ModelExperimental` isn't properly handling the texture, so it appears as a solid cube. However, @ptrgags and I looked at the glTF file and it seems to be version 1.0 glTF, so it made sense that it wasn't properly handled. But I created a version 2.0 glTF similar to it, and the shadows are still wrong:

![image](https://user-images.githubusercontent.com/32226860/152598240-0c866e16-814e-48db-971e-1ba4ced1b7e8.png)

I'm not very familiar with the shadowmapping code, so @ptrgags or @lilleyse do you have any insights? Other than this particular case, I think everything else is working fine.