### PR TITLE
Make `ModelExperimental`'s bounding sphere update with model matrix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@
 - Added `depthPlaneEllipsoidOffset` to Viewer and Scene constructors to address rendering artefacts below ellipsoid zero elevation. [#9200](https://github.com/CesiumGS/cesium/pull/9200)
 - Added support for `debugColorTiles` in `ModelExperimental`. [#10071](https://github.com/CesiumGS/cesium/pull/10071)
 
+##### Fixes :wrench:
+
+- Fixed a bug where updating `ModelExperimental`'s model matrix would not update its bounding sphere. [#10078](https://github.com/CesiumGS/cesium/pull/10078)
+
 ### 1.90 - 2022-02-01
 
 ##### Additions :tada:

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -134,6 +134,7 @@ export default function ModelExperimental(options) {
 
   // Keeps track of resources that need to be destroyed when the Model is destroyed.
   this._resources = [];
+  this._boundingSphere = undefined;
 
   const pointCloudShading = new PointCloudShading(options.pointCloudShading);
   this._attenuation = pointCloudShading.attenuation;
@@ -533,10 +534,7 @@ Object.defineProperties(ModelExperimental.prototype, {
       }
       //>>includeEnd('debug');
 
-      return BoundingSphere.transform(
-        this._sceneGraph.boundingSphere,
-        this.modelMatrix
-      );
+      return this._boundingSphere;
     },
   },
 
@@ -745,6 +743,12 @@ ModelExperimental.prototype.update = function (frameState) {
 
   if (!Matrix4.equals(this.modelMatrix, this._modelMatrix)) {
     this._sceneGraph.updateModelMatrix(this);
+    this._modelMatrix = Matrix4.clone(this.modelMatrix);
+    BoundingSphere.transform(
+      this._sceneGraph.boundingSphere,
+      this.modelMatrix,
+      this._boundingSphere
+    );
   }
 
   if (this._backFaceCullingDirty) {

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -134,7 +134,7 @@ export default function ModelExperimental(options) {
 
   // Keeps track of resources that need to be destroyed when the Model is destroyed.
   this._resources = [];
-  this._boundingSphere = undefined;
+  this._boundingSphere = new BoundingSphere();
 
   const pointCloudShading = new PointCloudShading(options.pointCloudShading);
   this._attenuation = pointCloudShading.attenuation;
@@ -741,6 +741,8 @@ ModelExperimental.prototype.update = function (frameState) {
     this._debugShowBoundingVolumeDirty = false;
   }
 
+  // This is done without a dirty flag so that the model matrix can be update in-place
+  // without needing to use a setter.
   if (!Matrix4.equals(this.modelMatrix, this._modelMatrix)) {
     this._sceneGraph.updateModelMatrix(this);
     this._modelMatrix = Matrix4.clone(this.modelMatrix);

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -1,3 +1,4 @@
+import BoundingSphere from "../../Core/BoundingSphere.js";
 import Check from "../../Core/Check.js";
 import ColorBlendMode from "../ColorBlendMode.js";
 import defined from "../../Core/defined.js";
@@ -133,8 +134,6 @@ export default function ModelExperimental(options) {
 
   // Keeps track of resources that need to be destroyed when the Model is destroyed.
   this._resources = [];
-
-  this._boundingSphere = undefined;
 
   const pointCloudShading = new PointCloudShading(options.pointCloudShading);
   this._attenuation = pointCloudShading.attenuation;
@@ -534,7 +533,10 @@ Object.defineProperties(ModelExperimental.prototype, {
       }
       //>>includeEnd('debug');
 
-      return this._sceneGraph.boundingSphere;
+      return BoundingSphere.transform(
+        this._sceneGraph.boundingSphere,
+        this.modelMatrix
+      );
     },
   },
 

--- a/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
@@ -105,16 +105,6 @@ export default function ModelExperimentalSceneGraph(options) {
   this._drawCommands = [];
 
   /**
-   * The array of bounding spheres of all the primitives in the scene graph.
-   *
-   * @type {BoundingSphere[]}
-   * @readonly
-   *
-   * @private
-   */
-  this._boundingSpheres = [];
-
-  /**
    * Pipeline stages to apply to this model. This
    * is an array of classes, each with a static method called
    * <code>process()</code>
@@ -293,6 +283,7 @@ ModelExperimentalSceneGraph.prototype.buildDrawCommands = function (
     modelPipelineStage.process(modelRenderResources, model, frameState);
   }
 
+  const boundingSpheres = [];
   for (i = 0; i < this._runtimeNodes.length; i++) {
     const runtimeNode = this._runtimeNodes[i];
     runtimeNode.configurePipeline();
@@ -337,7 +328,8 @@ ModelExperimentalSceneGraph.prototype.buildDrawCommands = function (
       runtimePrimitive.boundingSphere = BoundingSphere.clone(
         primitiveRenderResources.boundingSphere
       );
-      this._boundingSpheres.push(primitiveRenderResources.boundingSphere);
+
+      boundingSpheres.push(primitiveRenderResources.boundingSphere);
 
       const drawCommands = buildDrawCommands(
         primitiveRenderResources,
@@ -347,9 +339,8 @@ ModelExperimentalSceneGraph.prototype.buildDrawCommands = function (
       runtimePrimitive.drawCommands = drawCommands;
     }
   }
-  this._boundingSphere = BoundingSphere.fromBoundingSpheres(
-    this._boundingSpheres
-  );
+
+  this._boundingSphere = BoundingSphere.fromBoundingSpheres(boundingSpheres);
 };
 
 /**

--- a/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
@@ -341,6 +341,10 @@ ModelExperimentalSceneGraph.prototype.buildDrawCommands = function (
   }
 
   this._boundingSphere = BoundingSphere.fromBoundingSpheres(boundingSpheres);
+  this._model._boundingSphere = BoundingSphere.transform(
+    this._boundingSphere,
+    this._model.modelMatrix
+  );
 };
 
 /**

--- a/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
@@ -341,9 +341,10 @@ ModelExperimentalSceneGraph.prototype.buildDrawCommands = function (
   }
 
   this._boundingSphere = BoundingSphere.fromBoundingSpheres(boundingSpheres);
-  this._model._boundingSphere = BoundingSphere.transform(
+  BoundingSphere.transform(
     this._boundingSphere,
-    this._model.modelMatrix
+    this._model.modelMatrix,
+    this._model._boundingSphere
   );
 };
 

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -485,6 +485,26 @@ describe(
       });
     });
 
+    it("changing model matrix affects bounding sphere", function () {
+      const translation = new Cartesian3(10, 0, 0);
+      return loadAndZoomToModelExperimental(
+        { gltf: boxTexturedGlbUrl, upAxis: Axis.Z, forwardAxis: Axis.X },
+        scene
+      ).then(function (model) {
+        const transform = Matrix4.fromTranslation(translation);
+        expect(model.boundingSphere.center).toEqual(new Cartesian3());
+
+        Matrix4.multiplyTransformation(
+          model.modelMatrix,
+          transform,
+          model.modelMatrix
+        );
+        scene.renderForSpecs();
+
+        expect(model.boundingSphere.center).toEqual(translation);
+      });
+    });
+
     it("enables back-face culling", function () {
       return loadAndZoomToModelExperimental(
         {


### PR DESCRIPTION
Fixes #10074.

This PR fixes a bug where `ModelExperimental`'s bounding sphere wouldn't be affected by changes in the model matrix. I added a unit test for it and observed that it worked in @lilleyse's [sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=jVVdb9s2FP0rhJ/kwaElW7Edzw3WpG3aYsGC2uiATnugpWuLCEUaJOUkG/Lfd0VKshI7WA1DEsnD+3XOJVMljSV7Dg+gyTsi4YFcg+FlQb+7uSDppW58raRlXIJOev1fE5lIv4emQqX3NC21BmlXvAC0Ulv4WgrO5AdmgW60Kr4YNZuEUZBIQpLeKBxFZ1F0Fl6sRuF8NJ2PpzSMJuEkjqfn43g2mcUX4+mPpJdI7284JLcqA2ESmbqgCzdCd39VFv+tHoRYeLRzNO9DIFdMCKVk0hv4ZdwIAlKEbEqZWq4kCfrNXkL8onMTNHNVsJQO8b9kxU4A5sOG3vfQe6mdvBzRrVi3bqtfdN58V/lU72e3Wj3/dhn6tPLdKyI+A8u43N5xm+bflPCR1Wu3zObUqm+IYNIE0SzsO6Ohf/raebsb/gjZJ80KWGnEbpQuDlS1U4Yin0x4nPrU7rkBpJ5ZpWv6pNI2r/NLeg9g7IEpATU5btQWulvcUosByYFvc1uX3we5U4Y7cBvZNdMWv5gcOxF9gK0GMDU7Z9FoTMNpHE+ii7rUcUzD83A8DSf1hPdSffvoSK12alLMie40L9DlHgzVUKg9vMcKe4ZcDhjJW3iWZXUcDRvVho+PO0AMdgMTLuQbYTdBK7Etjuakyr+ZyWBdbpe5erhSpayY/q5EWcCcWF1Ci3LBIN2aP85PsJa/EkmXu46Um/p2dIl664xqyx+F4DujeEb/vFnO4g7ghIxaXdew53632i5wrC3Lnu6wGtwAtTnI4NCADtF2YXOuoAfNUI3q/r1tMziK/60+YXLbzft0u8Tn/cH/Yc6iFyCfzbpmarnLQQPViC0N+YUcWtx/eB09V6/nqhpLJrOUGSugEs9KKbFm+hZk6WtgfM1Ooq5Ka5XE4/gWNYqN1x5gwYsGshUpgr3sIS+b2KlxdQAEneId2iyIwgGp/n0ffWVXYShCbYOO9U6L0I42j50WpbB8J56CI+ygG+3g2JYr28+U5E5zaUlDCjGOlVYrbxWrSeokpdjrFnQbQW/QWxj7JOCyYfg3XuzwDKw6OcC7wQLeDXjTmeG6TO/B0tSY5pxfDLtbFxnfE569O3GxklQwY3BlUwqx5P8gz5eLIeKPtgrltP7HHrRgTxUsjy5/95OU0sUQh6d3Wl+7V5b/Aw).