### PR TITLE
Replace `maximumLevel` with `availableLevels` in implicit tiling specs

### DIFF
--- a/Specs/Data/Cesium3DTiles/Implicit/ImplicitChildTile/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Implicit/ImplicitChildTile/tileset.json
@@ -39,7 +39,7 @@
           "3DTILES_implicit_tiling": {
             "subdivisionScheme": "QUADTREE",
             "subtreeLevels": 3,
-            "maximumLevel": 2,
+            "availableLevels": 3,
             "subtrees": {
               "uri": "subtrees/{level}/{x}/{y}.subtree"
             }

--- a/Specs/Data/Cesium3DTiles/Implicit/ImplicitMultipleContents/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Implicit/ImplicitMultipleContents/tileset.json
@@ -27,7 +27,7 @@
       "3DTILES_implicit_tiling": {
         "subdivisionScheme": "QUADTREE",
         "subtreeLevels": 2,
-        "maximumLevel": 1,
+        "availableLevels": 2,
         "subtrees": {
           "uri": "subtrees/{level}.{x}.{y}.subtree"
         }

--- a/Specs/Data/Cesium3DTiles/Implicit/ImplicitRootTile/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Implicit/ImplicitRootTile/tileset.json
@@ -27,7 +27,7 @@
       "3DTILES_implicit_tiling": {
         "subdivisionScheme": "OCTREE",
         "subtreeLevels": 2,
-        "maximumLevel": 5,
+        "availableLevels": 6,
         "subtrees": {
           "uri": "subtrees/{level}/{x}/{y}/{z}.subtree"
         }

--- a/Specs/Data/Cesium3DTiles/Implicit/ImplicitTileset/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Implicit/ImplicitTileset/tileset.json
@@ -30,7 +30,7 @@
       "3DTILES_implicit_tiling": {
         "subdivisionScheme": "QUADTREE",
         "subtreeLevels": 2,
-        "maximumLevel": 1,
+        "availableLevels": 2,
         "subtrees": {
           "uri": "subtrees/{level}.{x}.{y}.subtree"
         }

--- a/Specs/Data/Cesium3DTiles/Implicit/ImplicitTilesetWithJsonSubtree/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Implicit/ImplicitTilesetWithJsonSubtree/tileset.json
@@ -30,7 +30,7 @@
       "3DTILES_implicit_tiling": {
         "subdivisionScheme": "QUADTREE",
         "subtreeLevels": 2,
-        "maximumLevel": 1,
+        "availableLevels": 2,
         "subtrees": {
           "uri": "subtrees/{level}.{x}.{y}.json"
         }

--- a/Specs/Data/Cesium3DTiles/Metadata/ImplicitContentBoundingVolumeSemantics/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/ImplicitContentBoundingVolumeSemantics/tileset.json
@@ -62,7 +62,7 @@
           "3DTILES_implicit_tiling": {
             "subdivisionScheme": "OCTREE",
             "subtreeLevels": 3,
-            "maximumLevel": 2,
+            "availableLevels": 3,
             "subtrees": {
               "uri": "subtrees/{level}.{x}.{y}.subtree"
             }

--- a/Specs/Data/Cesium3DTiles/Metadata/ImplicitContentHeightAndRegionSemantics/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/ImplicitContentHeightAndRegionSemantics/tileset.json
@@ -55,7 +55,7 @@
       "3DTILES_implicit_tiling": {
         "subdivisionScheme": "QUADTREE",
         "subtreeLevels": 3,
-        "maximumLevel": 2,
+        "availableLevels": 3,
         "subtrees": {
           "uri": "subtrees/{level}.{x}.{y}.subtree"
         }

--- a/Specs/Data/Cesium3DTiles/Metadata/ImplicitContentHeightSemantics/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/ImplicitContentHeightSemantics/tileset.json
@@ -49,7 +49,7 @@
       "3DTILES_implicit_tiling": {
         "subdivisionScheme": "QUADTREE",
         "subtreeLevels": 3,
-        "maximumLevel": 2,
+        "availableLevels": 3,
         "subtrees": {
           "uri": "subtrees/{level}.{x}.{y}.subtree"
         }

--- a/Specs/Data/Cesium3DTiles/Metadata/ImplicitGeometricErrorSemantics/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/ImplicitGeometricErrorSemantics/tileset.json
@@ -42,7 +42,7 @@
       "3DTILES_implicit_tiling": {
         "subdivisionScheme": "QUADTREE",
         "subtreeLevels": 3,
-        "maximumLevel": 2,
+        "availableLevels": 3,
         "subtrees": {
           "uri": "subtrees/{level}.{x}.{y}.subtree"
         }

--- a/Specs/Data/Cesium3DTiles/Metadata/ImplicitGroupMetadata/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/ImplicitGroupMetadata/tileset.json
@@ -62,7 +62,7 @@
       "3DTILES_implicit_tiling": {
         "subdivisionScheme": "QUADTREE",
         "subtreeLevels": 2,
-        "maximumLevel": 1,
+        "availableLevels": 2,
         "subtrees": {
           "uri": "subtrees/{level}.{x}.{y}.subtree"
         }

--- a/Specs/Data/Cesium3DTiles/Metadata/ImplicitHeightAndRegionSemantics/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/ImplicitHeightAndRegionSemantics/tileset.json
@@ -52,7 +52,7 @@
       "3DTILES_implicit_tiling": {
         "subdivisionScheme": "QUADTREE",
         "subtreeLevels": 3,
-        "maximumLevel": 2,
+        "availableLevels": 3,
         "subtrees": {
           "uri": "subtrees/{level}.{x}.{y}.subtree"
         }

--- a/Specs/Data/Cesium3DTiles/Metadata/ImplicitHeightAndSphereSemantics/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/ImplicitHeightAndSphereSemantics/tileset.json
@@ -52,7 +52,7 @@
       "3DTILES_implicit_tiling": {
         "subdivisionScheme": "QUADTREE",
         "subtreeLevels": 3,
-        "maximumLevel": 2,
+        "availableLevels": 3,
         "subtrees": {
           "uri": "subtrees/{level}.{x}.{y}.subtree"
         }

--- a/Specs/Data/Cesium3DTiles/Metadata/ImplicitHeightSemantics/s2-tileset.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/ImplicitHeightSemantics/s2-tileset.json
@@ -45,7 +45,7 @@
       "3DTILES_implicit_tiling": {
         "subdivisionScheme": "QUADTREE",
         "subtreeLevels": 3,
-        "maximumLevel": 2,
+        "availableLevels": 3,
         "subtrees": {
           "uri": "subtrees/{level}.{x}.{y}.subtree"
         }

--- a/Specs/Data/Cesium3DTiles/Metadata/ImplicitHeightSemantics/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/ImplicitHeightSemantics/tileset.json
@@ -46,7 +46,7 @@
       "3DTILES_implicit_tiling": {
         "subdivisionScheme": "QUADTREE",
         "subtreeLevels": 3,
-        "maximumLevel": 2,
+        "availableLevels": 3,
         "subtrees": {
           "uri": "subtrees/{level}.{x}.{y}.subtree"
         }

--- a/Specs/Data/Cesium3DTiles/Metadata/ImplicitTileBoundingVolumeSemantics/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/ImplicitTileBoundingVolumeSemantics/tileset.json
@@ -59,7 +59,7 @@
           "3DTILES_implicit_tiling": {
             "subdivisionScheme": "OCTREE",
             "subtreeLevels": 4,
-            "maximumLevel": 3,
+            "availableLevels": 4,
             "subtrees": {
               "uri": "subtrees/{level}.{x}.{y}.subtree"
             }

--- a/Specs/Data/Cesium3DTiles/Metadata/ImplicitTileMetadata/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/ImplicitTileMetadata/tileset.json
@@ -74,7 +74,7 @@
       "3DTILES_implicit_tiling": {
         "subdivisionScheme": "QUADTREE",
         "subtreeLevels": 2,
-        "maximumLevel": 1,
+        "availableLevels": 2,
         "subtrees": {
           "uri": "subtrees/{level}.{x}.{y}.subtree"
         }

--- a/Specs/Scene/Implicit3DTileContentSpec.js
+++ b/Specs/Scene/Implicit3DTileContentSpec.js
@@ -52,7 +52,7 @@ describe(
         "3DTILES_implicit_tiling": {
           subdivisionScheme: "QUADTREE",
           subtreeLevels: 2,
-          maximumLevel: 1,
+          availableLevels: 2,
           subtrees: {
             uri: "https://example.com/{level}/{x}/{y}.subtree",
           },

--- a/Specs/Scene/ImplicitSubtreeSpec.js
+++ b/Specs/Scene/ImplicitSubtreeSpec.js
@@ -1201,7 +1201,7 @@ describe("Scene/ImplicitSubtree", function () {
         "3DTILES_implicit_tiling": {
           subdivisionScheme: "QUADTREE",
           subtreeLevels: 2,
-          maximumLevel: 1,
+          availableLevels: 2,
           subtrees: {
             uri: "https://example.com/{level}/{x}/{y}.subtree",
           },

--- a/Specs/Scene/ImplicitTileMetadataSpec.js
+++ b/Specs/Scene/ImplicitTileMetadataSpec.js
@@ -113,7 +113,7 @@ describe("Scene/ImplicitTileMetadata", function () {
       "3DTILES_implicit_tiling": {
         subdivisionScheme: "QUADTREE",
         subtreeLevels: 2,
-        maximumLevel: 1,
+        availableLevels: 2,
         subtrees: {
           uri: "https://example.com/{level}/{x}/{y}.subtree",
         },


### PR DESCRIPTION
In #10083, the `maximumLevel` of implicit subtrees was to be replaced with `availableLevels`. I forgot to update the data in the specs to be consistent with this change -- this PR should have taken care of that.

@ptrgags 