### PR TITLE
Fix shadows for ModelExperimental models without normals

### DIFF
--- a/Source/Renderer/ShaderSource.js
+++ b/Source/Renderer/ShaderSource.js
@@ -441,33 +441,46 @@ ShaderSource.createPickFragmentShaderSource = function (
   return `${renamedFS}\n${pickMain}`;
 };
 
-ShaderSource.findVarying = function (shaderSource, names) {
+function containsString(shaderSource, string) {
   const sources = shaderSource.sources;
-
-  const namesLength = names.length;
-  for (let i = 0; i < namesLength; ++i) {
-    const name = names[i];
-
-    const sourcesLength = sources.length;
-    for (let j = 0; j < sourcesLength; ++j) {
-      if (sources[j].indexOf(name) !== -1) {
-        return name;
-      }
+  const sourcesLength = sources.length;
+  for (let i = 0; i < sourcesLength; ++i) {
+    if (sources[i].indexOf(string) !== -1) {
+      return true;
     }
   }
+  return false;
+}
 
+function findFirstString(shaderSource, strings) {
+  const stringsLength = strings.length;
+  for (let i = 0; i < stringsLength; ++i) {
+    const string = strings[i];
+    if (containsString(shaderSource, string)) {
+      return string;
+    }
+  }
   return undefined;
-};
+}
 
 const normalVaryingNames = ["v_normalEC", "v_normal"];
 
 ShaderSource.findNormalVarying = function (shaderSource) {
-  return ShaderSource.findVarying(shaderSource, normalVaryingNames);
+  // Fix for ModelExperimental: the shader text always has the word v_normalEC
+  // wrapped in an #ifdef so instead of looking for v_normalEC look for the define
+  if (containsString(shaderSource, "#ifdef HAS_NORMALS")) {
+    if (containsString(shaderSource, "#define HAS_NORMALS")) {
+      return "v_normalEC";
+    }
+    return undefined;
+  }
+
+  return findFirstString(shaderSource, normalVaryingNames);
 };
 
 const positionVaryingNames = ["v_positionEC"];
 
 ShaderSource.findPositionVarying = function (shaderSource) {
-  return ShaderSource.findVarying(shaderSource, positionVaryingNames);
+  return findFirstString(shaderSource, positionVaryingNames);
 };
 export default ShaderSource;

--- a/Specs/Data/Models/Shadows/BoxNoNormals.gltf
+++ b/Specs/Data/Models/Shadows/BoxNoNormals.gltf
@@ -1,0 +1,154 @@
+{
+  "accessors": [
+    {
+      "bufferView": 0,
+      "byteOffset": 0,
+      "componentType": 5123,
+      "count": 36,
+      "type": "SCALAR",
+      "name": "accessor_21"
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 0,
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        0.5,
+        0.5,
+        0.5
+      ],
+      "min": [
+        -0.5,
+        -0.5,
+        -0.5
+      ],
+      "type": "VEC3",
+      "name": "accessor_23"
+    },
+    {
+      "bufferView": 2,
+      "byteOffset": 0,
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        1,
+        1
+      ],
+      "min": [
+        0,
+        0
+      ],
+      "type": "VEC2",
+      "name": "accessor_27"
+    }
+  ],
+  "asset": {
+    "generator": "collada2gltf@",
+    "version": "2.0"
+  },
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteLength": 72,
+      "byteOffset": 0,
+      "target": 34963,
+      "name": "bufferView_29"
+    },
+    {
+      "buffer": 0,
+      "byteLength": 576,
+      "byteOffset": 72,
+      "target": 34962,
+      "name": "bufferView_30",
+      "byteStride": 12
+    },
+    {
+      "buffer": 0,
+      "byteLength": 192,
+      "byteOffset": 648,
+      "target": 34962,
+      "name": "bufferView_30",
+      "byteStride": 8
+    }
+  ],
+  "buffers": [
+    {
+      "name": "Box-processed-processed",
+      "byteLength": 840,
+      "uri": "data:application/octet-stream;base64,AAABAAIAAwACAAEABAAFAAYABwAGAAUACAAJAAoACwAKAAkADAANAA4ADwAOAA0AEAARABIAEwASABEAFAAVABYAFwAWABUAAAAAvwAAAL8AAAA/AAAAPwAAAL8AAAA/AAAAvwAAAD8AAAA/AAAAPwAAAD8AAAA/AAAAPwAAAL8AAAA/AAAAvwAAAL8AAAA/AAAAPwAAAL8AAAC/AAAAvwAAAL8AAAC/AAAAPwAAAD8AAAA/AAAAPwAAAL8AAAA/AAAAPwAAAD8AAAC/AAAAPwAAAL8AAAC/AAAAvwAAAD8AAAA/AAAAPwAAAD8AAAA/AAAAvwAAAD8AAAC/AAAAPwAAAD8AAAC/AAAAvwAAAL8AAAA/AAAAvwAAAD8AAAA/AAAAvwAAAL8AAAC/AAAAvwAAAD8AAAC/AAAAvwAAAL8AAAC/AAAAvwAAAD8AAAC/AAAAPwAAAL8AAAC/AAAAPwAAAD8AAAC/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AACAPgAAAAAAAIA+oKqqPgAAAD8AAAAAAAAAP6Cqqj4AAIA+oKqqPgAAAACgqqo+AACAPrCqKj8AAAAAsKoqPwAAAD+gqqo+AACAPqCqqj4AAAA/sKoqPwAAgD6wqio/AABAP6Cqqj4AAAA/oKqqPgAAQD+wqio/AAAAP7CqKj8AAIA/oKqqPgAAQD+gqqo+AACAP7CqKj8AAEA/sKoqPwAAgD4AAIA/AAAAPwAAgD8AAIA+sKoqPwAAAD+wqio/"
+    }
+  ],
+  "materials": [
+    {
+      "alphaMode": "OPAQUE",
+      "doubleSided": false,
+      "extensions": {
+        "KHR_materials_unlit": {}
+      },
+      "emissiveFactor": [
+        0,
+        0,
+        0
+      ]
+    }
+  ],
+  "meshes": [
+    {
+      "name": "Mesh",
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 1,
+            "TEXCOORD_0": 2
+          },
+          "indices": 0,
+          "material": 0,
+          "mode": 4
+        }
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "Mesh",
+      "mesh": 0
+    },
+    {
+      "children": [
+        0
+      ],
+      "matrix": [
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        -1,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1
+      ],
+      "name": "Y_UP_Transform"
+    }
+  ],
+  "scene": 0,
+  "scenes": [
+    {
+      "nodes": [
+        1
+      ],
+      "name": "defaultScene"
+    }
+  ],
+  "extensionsUsed": [
+    "KHR_materials_unlit"
+  ]
+}

--- a/Specs/Scene/ShadowMapSpec.js
+++ b/Specs/Scene/ShadowMapSpec.js
@@ -48,6 +48,7 @@ describe(
 
     const boxUrl = "./Data/Models/Shadows/Box.gltf";
     const boxTranslucentUrl = "./Data/Models/Shadows/BoxTranslucent.gltf";
+    const boxNoNormalsUrl = "./Data/Models/Shadows/BoxNoNormals.gltf";
     const boxCutoutUrl = "./Data/Models/Shadows/BoxCutout.gltf";
     const boxInvertedUrl = "./Data/Models/Shadows/BoxInverted.gltf";
 
@@ -57,6 +58,7 @@ describe(
 
     let boxExperimental;
     let boxTranslucentExperimental;
+    let boxNoNormalsExperimental;
 
     let room;
     let floor;
@@ -162,6 +164,15 @@ describe(
           show: false,
         }).then(function (model) {
           boxTranslucentExperimental = model;
+        })
+      );
+      modelPromises.push(
+        loadModelExperimental({
+          gltf: boxNoNormalsUrl,
+          modelMatrix: boxTransformExperimental,
+          show: false,
+        }).then(function (model) {
+          boxNoNormalsExperimental = model;
         })
       );
       modelPromises.push(
@@ -573,6 +584,13 @@ describe(
       floor.show = true;
       createCascadedShadowMap();
       verifyShadows(boxTranslucentExperimental, floor);
+    });
+
+    it("model without normals casts shadows onto another model", function () {
+      boxNoNormalsExperimental.show = true;
+      floor.show = true;
+      createCascadedShadowMap();
+      verifyShadows(boxNoNormalsExperimental, floor);
     });
 
     it("model with cutout texture casts shadows onto another model", function () {


### PR DESCRIPTION
ModelExperimental models without normals crash when shadows are enabled. 

![image](https://user-images.githubusercontent.com/915398/153674640-e6a12051-aca5-4ca0-a5ad-2b825af85486.png)

`ShadowMapShader` checks for the existence of normals by doing a keyword search over the shader text for words like `v_normalEC` or `v_normal`. When it finds a match it applies some additional shadow techniques that use the normal.

This check is pretty fragile and it produces false positives for ModelExperimental. That's because ModelExperimental  shaders always have something like

```
#ifdef HAS_NORMALS
v_normalEC = normal
#endif
```

So the shadow code thinks these models have normals, but some may not, and that leads to a shader compilation error when it tries to use the nonexistent varying.

The fix here is to first check for `#ifdef HAS_NORMALS`, then check for `#define HAS_NORMALS`.

The proper long term fix would be to include shadow code as a model shader stage instead of as a derived command.

Sandcastles for testing:

[Sandcastle 1](http://localhost:8080/Apps/Sandcastle/index.html#c=fVJRb9MwEP4rVp5SKTibeEE0q9BaBA9DTGu1J7+49i0xOHYUn1s6xH/n7KRTgYkocny+77v7fF+UdwHZwcARRnbDHBzZGoKJPX/MZ6UoVI7X3qE0DkZRLJbCqcwLChwQbeLzHL4k42gpJQrOa3q3sh8sbCTKemrwdrMzFkJ9743DtfVRX2wfPt3WmNKA/FvwThRU9lx4TlDx3JAPo+kNmgMELrUuL+7wRyfA8qdwLOl6n5YqBeDk3sIXr8F+/DEAVQK6JwFwjCDcr8UiNz5rGV4UbjupjWu5RAQXJRrvSFBiLf8HhxNsfA93pu2QYqI8SRsgN5mn+Ox9v/PlXKO69OQz5Cr3BlX3IF0L5RW/qtib67S+o/0sdyudVjKghTSRnW9bC7cR0TvyM0nxxyCKaupNn+hUukCpOlDfQS9YHtTZ1QlPUuf0Ms1lWVRFE/BkYZWw6flg+sGP2fiSHEcgxyWSxftINOQqhCQvQZv6ktpoc2BG37zyrzFlZQiUeYrWbs0ziGLV1IT/h2p9ns3XA4xWnhKsu17dTYec86am8HUmem/3cvyr8m8)
[Sandcastle 2](http://localhost:8080/Apps/Sandcastle/index.html#c=tVZ/b9s2EP0qhP+yh4SWbMV2PDdY67RphwUraq8DNg0DI50tIhRpkJTjtMh334mUZCVxti5FDMPmj+O9d8fHIxMljSVbDjegySsi4YbMwfAip5/dWDfuJK4/V9IyLkHHnSPyNZaEmIyl6sZMidUFxPKu92MsY+ld0USo5JomhdYg7ZLngM4rxz8XgjN5zizQlVb5B6MmoyDsli7jziAYhMdheBycLgfBdDCeDsc0CEfBKIrGJ8NoMppEp8PxH3Enlh6v3yeXKgVhYpm4WHLXQ7g/S4+OKSEWdnaK7j0F8oYJoZTEUPw0LgQBCZqsCplYriTp9uq1GKmbdDDdeqwkS2kfvwuWbwRgPKzvsfsepQK536NrcdXAlp/wpG6X8ZT/d27W/z6gv7jmUkJK5hnTLLFuM14wgktWs/8bm4+oB/+D+TnyVWSu8o0GYzAEx+Wl6Du0PVgdDhfXS12gLtfCrp4dym9ScEveqN2z2D/JGR06z02jZkmCb8qvkvCyanAQ7fb3aflCq0Km5DNkPBEvRt2jVCD3e9+l5w9YaphMUMjPFcI3kEfXDc69zmMB/1vq/3KF0lfHbPOgzL8HlnK5/shtkn1SwhOr5i6ZzahVn9CCSdMNJ0HPOQ38ry/B3u+K7yB9p1kOS422K6XzfcVvhgzFa4EJb6feNWsuAC8WZpWubgGptM2q+OLODRi7L/hNZtvZLLQ4IhnwdWarfHtaG2W4M264zJm22GJy6G6fc1hrAFNtx3E4GNJgHEWj8LRKbhTR4CQYjoNRNeBRyrbnQ6rbk5oEo6AbzXOE3IKhGnK1hdeYU78nrfsJ+Ty1iqVpxabehXLB290G0AYvUyYc8QtUQLdRVqmHKSmzUI84GNxAzXfTA/uQPdj29m60tFnnr6U0VFCrV3l+KwTfGMVT+vvFYhK1DA4Io1FqZXbXa2fTEcfcsfT2I8bJDVCbgezuT5SzaI5V/eBABM1QX+r6tW0ieMT/KeUzuW7HffgARCe9o/+yOQ7vGflorsqyg1iLTQYaqEbbwpAfyP7Q+obXiXtJ3ZXZWDCZJsxYLFYoi6VS4orpS5CFz4HxOescdWbG3go4q939xPMNHqFSEF2sLBawsuB7y/Sv8PYDSxNj6jIx67eXzlK+JTx9deDVRxLBjMGZVSHEgn/Bkn0266P9o6VCucT+ugUt2G1ploVnv/hBSumsj93DK62P8IHnfwA)

