### PR TITLE
Require class definition in metadata constructors

### DIFF
--- a/Source/Scene/GroupMetadata.js
+++ b/Source/Scene/GroupMetadata.js
@@ -12,7 +12,7 @@ import MetadataEntity from "./MetadataEntity.js";
  * @param {Object} options Object with the following properties:
  * @param {String} options.id The ID of the group.
  * @param {Object} options.group The group JSON object.
- * @param {MetadataClass} [options.class] The class that group metadata conforms to.
+ * @param {MetadataClass} options.class The class that group metadata conforms to.
  *
  * @alias GroupMetadata
  * @constructor
@@ -23,15 +23,17 @@ function GroupMetadata(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const id = options.id;
   const group = options.group;
+  const metadataClass = options.class;
 
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.string("options.id", id);
   Check.typeOf.object("options.group", group);
+  Check.typeOf.object("options.class", metadataClass);
   //>>includeEnd('debug');
 
   const properties = defined(group.properties) ? group.properties : {};
 
-  this._class = options.class;
+  this._class = metadataClass;
   this._properties = properties;
   this._id = id;
   this._extras = group.extras;

--- a/Source/Scene/ImplicitTileMetadata.js
+++ b/Source/Scene/ImplicitTileMetadata.js
@@ -14,7 +14,7 @@ import defaultValue from "../Core/defaultValue.js";
  *
  * @param {ImplicitSubtree} options.implicitSubtree The implicit subtree the tile belongs to. It is assumed that the subtree's readyPromise has already resolved.
  * @param {ImplicitTileCoordinates} options.implicitCoordinates Implicit tiling coordinates for the tile.
- * @param {MetadataClass} [options.class] The class that the tile metadata conforms to.
+ * @param {MetadataClass} options.class The class that the tile metadata conforms to.
  *
  * @alias ImplicitTileMetadata
  * @constructor
@@ -31,6 +31,7 @@ export default function ImplicitTileMetadata(options) {
     "options.implicitCoordinates",
     options.implicitCoordinates
   );
+  Check.typeOf.object("options.class", options.class);
   //>>includeEnd('debug');
 
   this._class = options.class;

--- a/Source/Scene/JsonMetadataTable.js
+++ b/Source/Scene/JsonMetadataTable.js
@@ -33,7 +33,7 @@ export default function JsonMetadataTable(options) {
  * @private
  */
 JsonMetadataTable.prototype.hasProperty = function (propertyId) {
-  return MetadataEntity.hasProperty(propertyId, this._properties);
+  return MetadataEntity.hasProperty(propertyId, this._properties, {});
 };
 
 /**
@@ -44,7 +44,7 @@ JsonMetadataTable.prototype.hasProperty = function (propertyId) {
  * @private
  */
 JsonMetadataTable.prototype.getPropertyIds = function (results) {
-  return MetadataEntity.getPropertyIds(this._properties, undefined, results);
+  return MetadataEntity.getPropertyIds(this._properties, {}, results);
 };
 
 /**

--- a/Source/Scene/JsonMetadataTable.js
+++ b/Source/Scene/JsonMetadataTable.js
@@ -15,6 +15,9 @@ import MetadataEntity from "./MetadataEntity.js";
  * @constructor
  * @private
  */
+
+const emptyClass = {};
+
 export default function JsonMetadataTable(options) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.number.greaterThan("options.count", options.count, 0);
@@ -33,7 +36,7 @@ export default function JsonMetadataTable(options) {
  * @private
  */
 JsonMetadataTable.prototype.hasProperty = function (propertyId) {
-  return MetadataEntity.hasProperty(propertyId, this._properties, {});
+  return MetadataEntity.hasProperty(propertyId, this._properties, emptyClass);
 };
 
 /**
@@ -44,7 +47,7 @@ JsonMetadataTable.prototype.hasProperty = function (propertyId) {
  * @private
  */
 JsonMetadataTable.prototype.getPropertyIds = function (results) {
-  return MetadataEntity.getPropertyIds(this._properties, {}, results);
+  return MetadataEntity.getPropertyIds(this._properties, emptyClass, results);
 };
 
 /**

--- a/Source/Scene/JsonMetadataTable.js
+++ b/Source/Scene/JsonMetadataTable.js
@@ -16,6 +16,8 @@ import MetadataEntity from "./MetadataEntity.js";
  * @private
  */
 
+// An empty class is used because JsonMetadataTable is an older type of metadata table
+// that does not have a class definition.
 const emptyClass = {};
 
 export default function JsonMetadataTable(options) {

--- a/Source/Scene/MetadataEntity.js
+++ b/Source/Scene/MetadataEntity.js
@@ -126,7 +126,7 @@ MetadataEntity.prototype.setPropertyBySemantic = function (semantic, value) {
  *
  * @param {String} propertyId The case-sensitive ID of the property.
  * @param {Object} properties The dictionary containing properties.
- * @param {MetadataClass} [classDefinition] The class.
+ * @param {MetadataClass} classDefinition The class.
  * @returns {Boolean} Whether the entity has this property.
  *
  * @private
@@ -139,17 +139,21 @@ MetadataEntity.hasProperty = function (
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.string("propertyId", propertyId);
   Check.typeOf.object("properties", properties);
+  Check.typeOf.object("classDefinition", classDefinition);
   //>>includeEnd('debug');
 
   if (defined(properties[propertyId])) {
     return true;
   }
 
-  if (defined(classDefinition)) {
-    const classProperty = classDefinition.properties[propertyId];
-    if (defined(classProperty) && defined(classProperty.default)) {
-      return true;
-    }
+  const classProperties = classDefinition.properties;
+  if (!defined(classProperties)) {
+    return false;
+  }
+
+  const classProperty = classProperties[propertyId];
+  if (defined(classProperty) && defined(classProperty.default)) {
+    return true;
   }
 
   return false;
@@ -160,7 +164,7 @@ MetadataEntity.hasProperty = function (
  *
  * @param {String} semantic The case-sensitive semantic of the property.
  * @param {Object} properties The dictionary containing properties.
- * @param {MetadataClass} [classDefinition] The class.
+ * @param {MetadataClass} classDefinition The class.
  * @returns {Boolean} Whether the entity has a property with the given semantic.
  *
  * @private
@@ -173,13 +177,15 @@ MetadataEntity.hasPropertyBySemantic = function (
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.string("semantic", semantic);
   Check.typeOf.object("properties", properties);
+  Check.typeOf.object("classDefinition", classDefinition);
   //>>includeEnd('debug');
 
-  if (!defined(classDefinition)) {
+  const propertiesBySemantic = classDefinition.propertiesBySemantic;
+  if (!defined(propertiesBySemantic)) {
     return false;
   }
 
-  const property = classDefinition.propertiesBySemantic[semantic];
+  const property = propertiesBySemantic[semantic];
   return defined(property);
 };
 
@@ -187,7 +193,7 @@ MetadataEntity.hasPropertyBySemantic = function (
  * Returns an array of property IDs.
  *
  * @param {Object} properties The dictionary containing properties.
- * @param {MetadataClass} [classDefinition] The class.
+ * @param {MetadataClass} classDefinition The class.
  * @param {String[]} [results] An array into which to store the results.
  * @returns {String[]} The property IDs.
  *
@@ -200,6 +206,7 @@ MetadataEntity.getPropertyIds = function (
 ) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("properties", properties);
+  Check.typeOf.object("classDefinition", classDefinition);
   //>>includeEnd('debug');
 
   results = defined(results) ? results : [];
@@ -216,8 +223,8 @@ MetadataEntity.getPropertyIds = function (
   }
 
   // Add default properties
-  if (defined(classDefinition)) {
-    const classProperties = classDefinition.properties;
+  const classProperties = classDefinition.properties;
+  if (defined(classProperties)) {
     for (const classPropertyId in classProperties) {
       if (
         classProperties.hasOwnProperty(classPropertyId) &&
@@ -240,7 +247,7 @@ MetadataEntity.getPropertyIds = function (
  *
  * @param {String} propertyId The case-sensitive ID of the property.
  * @param {Object} properties The dictionary containing properties.
- * @param {MetadataClass} [classDefinition] The class.
+ * @param {MetadataClass} classDefinition The class.
  * @returns {*} The value of the property or <code>undefined</code> if the entity does not have this property.
  *
  * @private
@@ -253,13 +260,15 @@ MetadataEntity.getProperty = function (
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.string("propertyId", propertyId);
   Check.typeOf.object("properties", properties);
+  Check.typeOf.object("classDefinition", classDefinition);
   //>>includeEnd('debug');
 
   let value = properties[propertyId];
 
   let classProperty;
-  if (defined(classDefinition)) {
-    classProperty = classDefinition.properties[propertyId];
+  const classProperties = classDefinition.properties;
+  if (defined(classProperties)) {
+    classProperty = classProperties[propertyId];
   }
 
   if (!defined(value) && defined(classProperty)) {
@@ -291,7 +300,7 @@ MetadataEntity.getProperty = function (
  * @param {String} propertyId The case-sensitive ID of the property.
  * @param {*} value The value of the property that will be copied.
  * @param {Object} properties The dictionary containing properties.
- * @param {MetadataClass} [classDefinition] The class.
+ * @param {MetadataClass} classDefinition The class.
  * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
  *
  * @private
@@ -306,6 +315,7 @@ MetadataEntity.setProperty = function (
   Check.typeOf.string("propertyId", propertyId);
   Check.defined("value", value);
   Check.typeOf.object("properties", properties);
+  Check.typeOf.object("classDefinition", classDefinition);
   //>>includeEnd('debug');
 
   if (!defined(properties[propertyId])) {
@@ -316,12 +326,15 @@ MetadataEntity.setProperty = function (
     value = value.slice(); // clone
   }
 
-  if (defined(classDefinition)) {
-    const classProperty = classDefinition.properties[propertyId];
-    if (defined(classProperty)) {
-      value = classProperty.packVectorAndMatrixTypes(value);
-      value = classProperty.unnormalize(value);
-    }
+  let classProperty;
+  const classProperties = classDefinition.properties;
+  if (defined(classProperties)) {
+    classProperty = classProperties[propertyId];
+  }
+
+  if (defined(classProperty)) {
+    value = classProperty.packVectorAndMatrixTypes(value);
+    value = classProperty.unnormalize(value);
   }
 
   properties[propertyId] = value;
@@ -346,12 +359,15 @@ MetadataEntity.getPropertyBySemantic = function (
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.string("semantic", semantic);
   Check.typeOf.object("properties", properties);
+  Check.typeOf.object("classDefinition", classDefinition);
   //>>includeEnd('debug');
-  if (!defined(classDefinition)) {
+
+  const propertiesBySemantic = classDefinition.propertiesBySemantic;
+  if (!defined(propertiesBySemantic)) {
     return undefined;
   }
 
-  const property = classDefinition.propertiesBySemantic[semantic];
+  const property = propertiesBySemantic[semantic];
   if (defined(property)) {
     return MetadataEntity.getProperty(property.id, properties, classDefinition);
   }
@@ -380,6 +396,11 @@ MetadataEntity.setPropertyBySemantic = function (
   Check.typeOf.object("properties", properties);
   Check.typeOf.object("classDefinition", classDefinition);
   //>>includeEnd('debug');
+
+  const propertiesBySemantic = classDefinition.propertiesBySemantic;
+  if (!defined(propertiesBySemantic)) {
+    return false;
+  }
 
   const property = classDefinition.propertiesBySemantic[semantic];
   if (defined(property)) {

--- a/Source/Scene/MetadataTable.js
+++ b/Source/Scene/MetadataTable.js
@@ -16,7 +16,7 @@ import MetadataType from "./MetadataType.js";
  * @param {Object} options Object with the following properties:
  * @param {Number} options.count The number of entities in the table.
  * @param {Object} [options.properties] A dictionary containing properties.
- * @param {MetadataClass} [options.class] The class that properties conform to.
+ * @param {MetadataClass} options.class The class that properties conform to.
  * @param {Object.<String, Uint8Array>} [options.bufferViews] An object mapping bufferView IDs to Uint8Array objects.
  *
  * @alias MetadataTable
@@ -28,9 +28,11 @@ import MetadataType from "./MetadataType.js";
 function MetadataTable(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const count = options.count;
+  const metadataClass = options.class;
 
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.number.greaterThan("options.count", count, 0);
+  Check.typeOf.object("options.class", metadataClass);
   //>>includeEnd('debug');
 
   const properties = {};
@@ -40,7 +42,7 @@ function MetadataTable(options) {
         properties[propertyId] = new MetadataTableProperty({
           count: count,
           property: options.properties[propertyId],
-          classProperty: options.class.properties[propertyId],
+          classProperty: metadataClass.properties[propertyId],
           bufferViews: options.bufferViews,
         });
       }
@@ -48,7 +50,7 @@ function MetadataTable(options) {
   }
 
   this._count = count;
-  this._class = options.class;
+  this._class = metadataClass;
   this._properties = properties;
 }
 
@@ -220,12 +222,16 @@ MetadataTable.prototype.getPropertyBySemantic = function (index, semantic) {
   Check.typeOf.string("semantic", semantic);
   //>>includeEnd('debug');
 
-  if (defined(this._class)) {
-    const property = this._class.propertiesBySemantic[semantic];
-    if (defined(property)) {
-      return this.getProperty(index, property.id);
-    }
+  let property;
+  const propertiesBySemantic = this._class.propertiesBySemantic;
+  if (defined(propertiesBySemantic)) {
+    property = propertiesBySemantic[semantic];
   }
+
+  if (defined(property)) {
+    return this.getProperty(index, property.id);
+  }
+
   return undefined;
 };
 
@@ -252,11 +258,14 @@ MetadataTable.prototype.setPropertyBySemantic = function (
   Check.typeOf.string("semantic", semantic);
   //>>includeEnd('debug');
 
-  if (defined(this._class)) {
-    const property = this._class.propertiesBySemantic[semantic];
-    if (defined(property)) {
-      return this.setProperty(index, property.id, value);
-    }
+  let property;
+  const propertiesBySemantic = this._class.propertiesBySemantic;
+  if (defined(propertiesBySemantic)) {
+    property = propertiesBySemantic[semantic];
+  }
+
+  if (defined(property)) {
+    return this.setProperty(index, property.id, value);
   }
 
   return false;
@@ -297,27 +306,33 @@ MetadataTable.prototype.getPropertyTypedArrayBySemantic = function (semantic) {
   Check.typeOf.string("semantic", semantic);
   //>>includeEnd('debug');
 
-  if (defined(this._class)) {
-    const property = this._class.propertiesBySemantic[semantic];
-    if (defined(property)) {
-      return this.getPropertyTypedArray(property.id);
-    }
+  let property;
+  const propertiesBySemantic = this._class.propertiesBySemantic;
+  if (defined(propertiesBySemantic)) {
+    property = propertiesBySemantic[semantic];
+  }
+
+  if (defined(property)) {
+    return this.getPropertyTypedArray(property.id);
   }
 
   return undefined;
 };
 
 function getDefault(classDefinition, propertyId) {
-  if (defined(classDefinition)) {
-    const classProperty = classDefinition.properties[propertyId];
-    if (defined(classProperty) && defined(classProperty.default)) {
-      let value = classProperty.default;
-      if (classProperty.type === MetadataType.ARRAY) {
-        value = value.slice(); // clone
-      }
-      value = classProperty.normalize(value);
-      return classProperty.unpackVectorAndMatrixTypes(value);
+  const classProperties = classDefinition.properties;
+  if (!defined(classProperties)) {
+    return undefined;
+  }
+
+  const classProperty = classProperties[propertyId];
+  if (defined(classProperty) && defined(classProperty.default)) {
+    let value = classProperty.default;
+    if (classProperty.type === MetadataType.ARRAY) {
+      value = value.slice(); // clone
     }
+    value = classProperty.normalize(value);
+    return classProperty.unpackVectorAndMatrixTypes(value);
   }
 }
 

--- a/Source/Scene/TileMetadata.js
+++ b/Source/Scene/TileMetadata.js
@@ -11,7 +11,7 @@ import MetadataEntity from "./MetadataEntity.js";
  *
  * @param {Object} options Object with the following properties:
  * @param {Object} options.tile The extension JSON attached to the tile.
- * @param {MetadataClass} [options.class] The class that the tile metadata conforms to.
+ * @param {MetadataClass} options.class The class that the tile metadata conforms to.
  *
  * @alias TileMetadata
  * @constructor
@@ -20,17 +20,18 @@ import MetadataEntity from "./MetadataEntity.js";
  */
 export default function TileMetadata(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  const tile = options.tile;
+  const metadataClass = options.class;
 
   //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("options.tile", options.tile);
+  Check.typeOf.object("options.tile", tile);
+  Check.typeOf.object("options.class", metadataClass);
   //>>includeEnd('debug');
 
-  this._class = options.class;
-
-  const tileMetadata = options.tile;
-  this._properties = tileMetadata.properties;
-  this._extensions = tileMetadata.extensions;
-  this._extras = tileMetadata.extras;
+  this._class = metadataClass;
+  this._properties = tile.properties;
+  this._extensions = tile.extensions;
+  this._extras = tile.extras;
 }
 
 Object.defineProperties(TileMetadata.prototype, {

--- a/Source/Scene/TilesetMetadata.js
+++ b/Source/Scene/TilesetMetadata.js
@@ -11,7 +11,7 @@ import MetadataEntity from "./MetadataEntity.js";
  *
  * @param {Object} options Object with the following properties:
  * @param {Object} options.tileset The tileset metadata JSON object.
- * @param {MetadataClass} [options.class] The class that tileset metadata conforms to.
+ * @param {MetadataClass} options.class The class that tileset metadata conforms to.
  *
  * @alias TilesetMetadata
  * @constructor
@@ -21,14 +21,16 @@ import MetadataEntity from "./MetadataEntity.js";
 function TilesetMetadata(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const tileset = options.tileset;
+  const metadataClass = options.class;
 
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("options.tileset", tileset);
+  Check.typeOf.object("options.class", metadataClass);
   //>>includeEnd('debug');
 
   const properties = defined(tileset.properties) ? tileset.properties : {};
 
-  this._class = options.class;
+  this._class = metadataClass;
   this._properties = properties;
   this._extras = tileset.extras;
   this._extensions = tileset.extensions;

--- a/Specs/Scene/GroupMetadataSpec.js
+++ b/Specs/Scene/GroupMetadataSpec.js
@@ -5,14 +5,19 @@ import {
 } from "../../Source/Cesium.js";
 
 describe("Scene/GroupMetadata", function () {
+  const buildingClassWithNoProperties = new MetadataClass({
+    id: "building",
+    class: {},
+  });
+
   it("creates group metadata with default values", function () {
     const groupMetadata = new GroupMetadata({
       id: "building",
       group: {},
+      class: buildingClassWithNoProperties,
     });
 
     expect(groupMetadata.id).toBe("building");
-    expect(groupMetadata.class).toBeUndefined();
     expect(groupMetadata.extras).toBeUndefined();
     expect(groupMetadata.extensions).toBeUndefined();
   });
@@ -64,7 +69,9 @@ describe("Scene/GroupMetadata", function () {
   it("constructor throws without id", function () {
     expect(function () {
       return new GroupMetadata({
+        id: undefined,
         group: {},
+        class: buildingClassWithNoProperties,
       });
     }).toThrowDeveloperError();
   });
@@ -73,6 +80,18 @@ describe("Scene/GroupMetadata", function () {
     expect(function () {
       return new GroupMetadata({
         id: "building",
+        group: undefined,
+        class: buildingClassWithNoProperties,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("constructor throws without class", function () {
+    expect(function () {
+      return new GroupMetadata({
+        id: "building",
+        group: {},
+        class: undefined,
       });
     }).toThrowDeveloperError();
   });
@@ -81,6 +100,7 @@ describe("Scene/GroupMetadata", function () {
     const groupMetadata = new GroupMetadata({
       id: "building",
       group: {},
+      class: buildingClassWithNoProperties,
     });
     expect(groupMetadata.hasProperty("height")).toBe(false);
   });
@@ -146,6 +166,7 @@ describe("Scene/GroupMetadata", function () {
         },
       },
     });
+
     const groupMetadata = new GroupMetadata({
       class: buildingClass,
       id: "building",
@@ -159,6 +180,7 @@ describe("Scene/GroupMetadata", function () {
     const groupMetadata = new GroupMetadata({
       id: "building",
       group: {},
+      class: buildingClassWithNoProperties,
     });
 
     expect(function () {
@@ -168,6 +190,7 @@ describe("Scene/GroupMetadata", function () {
 
   it("hasPropertyBySemantic returns false when there's no properties", function () {
     const groupMetadata = new GroupMetadata({
+      class: buildingClassWithNoProperties,
       id: "building",
       group: {},
     });
@@ -237,6 +260,7 @@ describe("Scene/GroupMetadata", function () {
         },
       },
     });
+
     const groupMetadata = new GroupMetadata({
       class: buildingClass,
       id: "building",
@@ -250,6 +274,7 @@ describe("Scene/GroupMetadata", function () {
     const groupMetadata = new GroupMetadata({
       id: "building",
       group: {},
+      class: buildingClassWithNoProperties,
     });
 
     expect(function () {
@@ -261,6 +286,7 @@ describe("Scene/GroupMetadata", function () {
     const groupMetadata = new GroupMetadata({
       id: "building",
       group: {},
+      class: buildingClassWithNoProperties,
     });
 
     expect(groupMetadata.getPropertyIds().length).toBe(0);
@@ -361,6 +387,7 @@ describe("Scene/GroupMetadata", function () {
     const groupMetadata = new GroupMetadata({
       id: "building",
       group: {},
+      class: buildingClassWithNoProperties,
     });
     expect(groupMetadata.getProperty("height")).toBeUndefined();
   });
@@ -448,6 +475,7 @@ describe("Scene/GroupMetadata", function () {
     const groupMetadata = new GroupMetadata({
       id: "building",
       group: {},
+      class: buildingClassWithNoProperties,
     });
 
     expect(function () {
@@ -459,6 +487,7 @@ describe("Scene/GroupMetadata", function () {
     const groupMetadata = new GroupMetadata({
       id: "building",
       group: {},
+      class: buildingClassWithNoProperties,
     });
 
     const position = [0.0, 0.0, 0.0];
@@ -498,6 +527,7 @@ describe("Scene/GroupMetadata", function () {
     const groupMetadata = new GroupMetadata({
       id: "building",
       group: {},
+      class: buildingClassWithNoProperties,
     });
 
     expect(function () {
@@ -509,6 +539,7 @@ describe("Scene/GroupMetadata", function () {
     const groupMetadata = new GroupMetadata({
       id: "building",
       group: {},
+      class: buildingClassWithNoProperties,
     });
 
     expect(function () {
@@ -520,6 +551,7 @@ describe("Scene/GroupMetadata", function () {
     const groupMetadata = new GroupMetadata({
       id: "building",
       group: {},
+      class: buildingClassWithNoProperties,
     });
     expect(groupMetadata.getPropertyBySemantic("_HEIGHT")).toBeUndefined();
   });
@@ -579,6 +611,7 @@ describe("Scene/GroupMetadata", function () {
     const groupMetadata = new GroupMetadata({
       id: "building",
       group: {},
+      class: buildingClassWithNoProperties,
     });
 
     expect(function () {
@@ -642,6 +675,7 @@ describe("Scene/GroupMetadata", function () {
     const groupMetadata = new GroupMetadata({
       id: "building",
       group: {},
+      class: buildingClassWithNoProperties,
     });
 
     expect(function () {

--- a/Specs/Scene/ImplicitTileMetadataSpec.js
+++ b/Specs/Scene/ImplicitTileMetadataSpec.js
@@ -185,6 +185,16 @@ describe("Scene/ImplicitTileMetadata", function () {
     }).toThrowDeveloperError();
   });
 
+  it("throws without class", function () {
+    expect(function () {
+      tileMetadata = new ImplicitTileMetadata({
+        implicitSubtree: subtree,
+        implicitCoordinates: implicitCoordinates,
+        class: undefined,
+      });
+    }).toThrowDeveloperError();
+  });
+
   it("creates tile metadata", function () {
     tileMetadata = new ImplicitTileMetadata({
       implicitSubtree: subtree,

--- a/Specs/Scene/MetadataEntitySpec.js
+++ b/Specs/Scene/MetadataEntitySpec.js
@@ -61,7 +61,7 @@ describe("Scene/MetadataEntity", function () {
     }).toThrowDeveloperError();
   });
 
-  it("hasProperty returns false when there's no properties", function () {
+  it("hasProperty returns false when there are no properties", function () {
     expect(
       MetadataEntity.hasProperty("name", {}, classWithNoPropertiesDefinition)
     ).toBe(false);

--- a/Specs/Scene/MetadataEntitySpec.js
+++ b/Specs/Scene/MetadataEntitySpec.js
@@ -1,6 +1,11 @@
 import { MetadataClass, MetadataEntity } from "../../Source/Cesium.js";
 
 describe("Scene/MetadataEntity", function () {
+  const classWithNoPropertiesDefinition = new MetadataClass({
+    id: "building",
+    class: {},
+  });
+
   const classDefinition = new MetadataClass({
     id: "building",
     class: {
@@ -57,7 +62,9 @@ describe("Scene/MetadataEntity", function () {
   });
 
   it("hasProperty returns false when there's no properties", function () {
-    expect(MetadataEntity.hasProperty("name", {})).toBe(false);
+    expect(
+      MetadataEntity.hasProperty("name", {}, classWithNoPropertiesDefinition)
+    ).toBe(false);
   });
 
   it("hasProperty returns false when there's no property with the given property ID", function () {
@@ -90,13 +97,20 @@ describe("Scene/MetadataEntity", function () {
     }).toThrowDeveloperError();
   });
 
-  it("hasProperty works without classDefinition", function () {
-    expect(MetadataEntity.hasProperty("name", properties)).toBe(true);
-    expect(MetadataEntity.hasProperty("volume", properties)).toBe(false);
+  it("hasProperty throws without classDefinition", function () {
+    expect(function () {
+      MetadataEntity.hasProperty("name", properties, undefined);
+    }).toThrowDeveloperError();
   });
 
   it("hasPropertyBySemantic returns false when there's no properties", function () {
-    expect(MetadataEntity.hasPropertyBySemantic("NAME", {})).toBe(false);
+    expect(
+      MetadataEntity.hasPropertyBySemantic(
+        "NAME",
+        {},
+        classWithNoPropertiesDefinition
+      )
+    ).toBe(false);
   });
 
   it("hasPropertyBySemantic returns false when there's no property with the given property ID", function () {
@@ -107,15 +121,6 @@ describe("Scene/MetadataEntity", function () {
         classDefinition
       )
     ).toBe(false);
-  });
-
-  it("hasPropertyBySemantic returns false when there's no class definition", function () {
-    expect(MetadataEntity.hasPropertyBySemantic("NAME", properties)).toBe(
-      false
-    );
-    expect(MetadataEntity.hasPropertyBySemantic("VOLUME", properties)).toBe(
-      false
-    );
   });
 
   it("hasPropertyBySemantic returns true when there's a property with the given property ID", function () {
@@ -146,8 +151,16 @@ describe("Scene/MetadataEntity", function () {
     }).toThrowDeveloperError();
   });
 
+  it("hasPropertyBySemantic throws without class definition", function () {
+    expect(function () {
+      MetadataEntity.hasPropertyBySemantic("NAME", properties, undefined);
+    }).toThrowDeveloperError();
+  });
+
   it("getPropertyIds returns empty array when there are no properties", function () {
-    expect(MetadataEntity.getPropertyIds({}).length).toBe(0);
+    expect(
+      MetadataEntity.getPropertyIds({}, classWithNoPropertiesDefinition).length
+    ).toBe(0);
   });
 
   it("getPropertyIds returns array of property IDs", function () {
@@ -175,19 +188,17 @@ describe("Scene/MetadataEntity", function () {
     }).toThrowDeveloperError();
   });
 
-  it("getPropertyIds works without classDefinition", function () {
-    const results = [];
-    const returnedResults = MetadataEntity.getPropertyIds(
-      properties,
-      undefined,
-      results
-    );
-    expect(results).toBe(returnedResults);
-    expect(results.sort()).toEqual(["name", "position"]);
+  it("getPropertyIds throws without classDefinition", function () {
+    expect(function () {
+      const results = [];
+      MetadataEntity.getPropertyIds(properties, undefined, results);
+    }).toThrowDeveloperError();
   });
 
   it("getProperty returns undefined when there's no properties", function () {
-    expect(MetadataEntity.getProperty("name", {})).toBeUndefined();
+    expect(
+      MetadataEntity.getProperty("name", {}, classWithNoPropertiesDefinition)
+    ).toBeUndefined();
   });
 
   it("getProperty returns undefined when there's no property with the given property ID", function () {
@@ -223,16 +234,16 @@ describe("Scene/MetadataEntity", function () {
     }).toThrowDeveloperError();
   });
 
-  it("getProperty works without classDefinition", function () {
-    const value = MetadataEntity.getProperty("position", properties, undefined);
-    expect(value).toEqual(properties.position);
-    expect(value).not.toBe(properties.position); // The value is cloned
+  it("getProperty throws without classDefinition", function () {
+    expect(function () {
+      MetadataEntity.getProperty("name", properties, undefined);
+    }).toThrowDeveloperError();
   });
 
   it("setProperty returns false if property doesn't exist", function () {
-    expect(MetadataEntity.setProperty("volume", 100.0, classDefinition)).toBe(
-      false
-    );
+    expect(
+      MetadataEntity.setProperty("volume", 100.0, properties, classDefinition)
+    ).toBe(false);
   });
 
   it("setProperty sets property value", function () {
@@ -287,21 +298,10 @@ describe("Scene/MetadataEntity", function () {
     }).toThrowDeveloperError();
   });
 
-  it("setProperty works without classDefinition", function () {
-    const position = [1.0, 1.0, 1.0];
-    MetadataEntity.setProperty("position", position, properties);
-    const retrievedPosition = MetadataEntity.getProperty(
-      "position",
-      properties
-    );
-    expect(retrievedPosition).toEqual(position);
-    expect(retrievedPosition).not.toBe(position); // The value is cloned
-  });
-
-  it("getPropertyBySemantic returns undefined when there's no class", function () {
-    expect(
-      MetadataEntity.getPropertyBySemantic("NAME", properties)
-    ).toBeUndefined();
+  it("setProperty throws without classDefinition", function () {
+    expect(function () {
+      MetadataEntity.setProperty("name", "Building B", properties, undefined);
+    }).toThrowDeveloperError();
   });
 
   it("getPropertyBySemantic returns undefined when there's no property with the given semantic", function () {
@@ -336,10 +336,10 @@ describe("Scene/MetadataEntity", function () {
     }).toThrowDeveloperError();
   });
 
-  it("getPropertyBySemantic returns undefined without classDefinition", function () {
-    expect(
-      MetadataEntity.getPropertyBySemantic("NAME", properties, undefined)
-    ).toBeUndefined();
+  it("getPropertyBySemantic throws without classDefinition", function () {
+    expect(function () {
+      MetadataEntity.getPropertyBySemantic("NAME", properties, undefined);
+    }).toThrowDeveloperError();
   });
 
   it("setPropertyBySemantic sets property value", function () {

--- a/Specs/Scene/MetadataTableSpec.js
+++ b/Specs/Scene/MetadataTableSpec.js
@@ -28,10 +28,10 @@ describe("Scene/MetadataTable", function () {
   it("creates metadata table with default values", function () {
     const metadataTable = new MetadataTable({
       count: 10,
+      class: {},
     });
 
     expect(metadataTable.count).toBe(10);
-    expect(metadataTable.class).toBeUndefined();
   });
 
   it("creates metadata table", function () {
@@ -64,7 +64,7 @@ describe("Scene/MetadataTable", function () {
     );
   });
 
-  it("constructor throws without count", function () {
+  it("constructor throws without parameters", function () {
     expect(function () {
       return new MetadataTable({});
     }).toThrowDeveloperError();
@@ -74,6 +74,16 @@ describe("Scene/MetadataTable", function () {
     expect(function () {
       return new MetadataTable({
         count: 0,
+        class: {},
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("constructor throws if class is undefined", function () {
+    expect(function () {
+      return new MetadataTable({
+        count: 1,
+        class: undefined,
       });
     }).toThrowDeveloperError();
   });
@@ -81,6 +91,7 @@ describe("Scene/MetadataTable", function () {
   it("hasProperty returns false when there's no properties", function () {
     const metadataTable = new MetadataTable({
       count: 10,
+      class: {},
     });
     expect(metadataTable.hasProperty("height")).toBe(false);
   });
@@ -145,6 +156,7 @@ describe("Scene/MetadataTable", function () {
   it("hasProperty throws without propertyId", function () {
     const metadataTable = new MetadataTable({
       count: 10,
+      class: {},
     });
     expect(function () {
       metadataTable.hasProperty();
@@ -154,6 +166,7 @@ describe("Scene/MetadataTable", function () {
   it("hasPropertyBySemantic returns false when there's no properties", function () {
     const metadataTable = new MetadataTable({
       count: 10,
+      class: {},
     });
     expect(metadataTable.hasPropertyBySemantic("HEIGHT")).toBe(false);
   });
@@ -220,6 +233,7 @@ describe("Scene/MetadataTable", function () {
   it("hasPropertyBySemantic throws without semantic", function () {
     const metadataTable = new MetadataTable({
       count: 10,
+      class: {},
     });
     expect(function () {
       metadataTable.hasPropertyBySemantic(undefined);
@@ -229,6 +243,7 @@ describe("Scene/MetadataTable", function () {
   it("getPropertyIds returns empty array when there are no properties", function () {
     const metadataTable = new MetadataTable({
       count: 10,
+      class: {},
     });
     expect(metadataTable.getPropertyIds().length).toBe(0);
   });
@@ -330,6 +345,7 @@ describe("Scene/MetadataTable", function () {
   it("getProperty returns undefined when there's no properties", function () {
     const metadataTable = new MetadataTable({
       count: 10,
+      class: {},
     });
     expect(metadataTable.getProperty(0, "height")).toBeUndefined();
   });
@@ -586,6 +602,7 @@ describe("Scene/MetadataTable", function () {
   it("getPropertyBySemantic returns undefined when there's no class", function () {
     const metadataTable = new MetadataTable({
       count: 10,
+      class: {},
     });
     expect(metadataTable.getPropertyBySemantic(0, "_HEIGHT")).toBeUndefined();
   });
@@ -695,6 +712,7 @@ describe("Scene/MetadataTable", function () {
   it("setPropertyBySemantic doesn't set property value when there's no class", function () {
     const metadataTable = new MetadataTable({
       count: 10,
+      class: {},
     });
 
     metadataTable.setPropertyBySemantic(0, "_HEIGHT", 20.0);
@@ -867,6 +885,7 @@ describe("Scene/MetadataTable", function () {
   it("getPropertyTypedArray throws if propertyId is undefined", function () {
     const metadataTable = new MetadataTable({
       count: 10,
+      class: {},
     });
 
     expect(function () {
@@ -920,6 +939,7 @@ describe("Scene/MetadataTable", function () {
   it("getPropertyTypedArrayBySemantic throws if semantic is undefined", function () {
     const metadataTable = new MetadataTable({
       count: 10,
+      class: {},
     });
 
     expect(function () {

--- a/Specs/Scene/MetadataTableSpec.js
+++ b/Specs/Scene/MetadataTableSpec.js
@@ -64,9 +64,11 @@ describe("Scene/MetadataTable", function () {
     );
   });
 
-  it("constructor throws without parameters", function () {
+  it("constructor throws without count", function () {
     expect(function () {
-      return new MetadataTable({});
+      return new MetadataTable({
+        class: {},
+      });
     }).toThrowDeveloperError();
   });
 

--- a/Specs/Scene/TileMetadataSpec.js
+++ b/Specs/Scene/TileMetadataSpec.js
@@ -1,6 +1,11 @@
 import { MetadataClass, TileMetadata } from "../../Source/Cesium.js";
 
 describe("Scene/TileMetadata", function () {
+  const tileClassWithNoProperties = new MetadataClass({
+    id: "tile",
+    class: {},
+  });
+
   const tileClass = new MetadataClass({
     id: "tile",
     class: {
@@ -45,12 +50,21 @@ describe("Scene/TileMetadata", function () {
     }).toThrowDeveloperError();
   });
 
+  it("throws without class", function () {
+    expect(function () {
+      tileMetadata = new TileMetadata({
+        tile: {},
+        class: undefined,
+      });
+    }).toThrowDeveloperError();
+  });
+
   it("creates tile metadata with default values", function () {
     const metadata = new TileMetadata({
       tile: {},
+      class: tileClassWithNoProperties,
     });
 
-    expect(metadata.class).toBeUndefined();
     expect(metadata.extras).toBeUndefined();
     expect(metadata.extensions).toBeUndefined();
   });

--- a/Specs/Scene/TilesetMetadataSpec.js
+++ b/Specs/Scene/TilesetMetadataSpec.js
@@ -8,9 +8,9 @@ describe("Scene/TilesetMetadata", function () {
   it("creates tileset metadata with default values", function () {
     const tilesetMetadata = new TilesetMetadata({
       tileset: {},
+      class: {},
     });
 
-    expect(tilesetMetadata.class).toBeUndefined();
     expect(tilesetMetadata.extras).toBeUndefined();
   });
 
@@ -58,13 +58,24 @@ describe("Scene/TilesetMetadata", function () {
 
   it("constructor throws without tileset", function () {
     expect(function () {
-      return new TilesetMetadata();
+      return new TilesetMetadata({
+        class: {},
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("constructor throws without class", function () {
+    expect(function () {
+      return new TilesetMetadata({
+        tileset: {},
+      });
     }).toThrowDeveloperError();
   });
 
   it("hasProperty returns false when there's no properties", function () {
     const tilesetMetadata = new TilesetMetadata({
       tileset: {},
+      class: {},
     });
     expect(tilesetMetadata.hasProperty("height")).toBe(false);
   });
@@ -139,6 +150,7 @@ describe("Scene/TilesetMetadata", function () {
   it("hasProperty throws without propertyId", function () {
     const tilesetMetadata = new TilesetMetadata({
       tileset: {},
+      class: {},
     });
 
     expect(function () {
@@ -149,6 +161,7 @@ describe("Scene/TilesetMetadata", function () {
   it("hasPropertyBySemantic returns false when there's no properties", function () {
     const tilesetMetadata = new TilesetMetadata({
       tileset: {},
+      class: {},
     });
     expect(tilesetMetadata.hasPropertyBySemantic("HEIGHT")).toBe(false);
   });
@@ -225,6 +238,7 @@ describe("Scene/TilesetMetadata", function () {
   it("hasPropertyBySemantic throws without semantic", function () {
     const tilesetMetadata = new TilesetMetadata({
       tileset: {},
+      class: {},
     });
 
     expect(function () {
@@ -235,6 +249,7 @@ describe("Scene/TilesetMetadata", function () {
   it("getPropertyIds returns empty array when there are no properties", function () {
     const tilesetMetadata = new TilesetMetadata({
       tileset: {},
+      class: {},
     });
 
     expect(tilesetMetadata.getPropertyIds().length).toBe(0);
@@ -337,6 +352,7 @@ describe("Scene/TilesetMetadata", function () {
   it("getProperty returns undefined when there's no properties", function () {
     const tilesetMetadata = new TilesetMetadata({
       tileset: {},
+      class: {},
     });
     expect(tilesetMetadata.getProperty("height")).toBeUndefined();
   });
@@ -420,6 +436,7 @@ describe("Scene/TilesetMetadata", function () {
   it("getProperty throws without propertyId", function () {
     const tilesetMetadata = new TilesetMetadata({
       tileset: {},
+      class: {},
     });
 
     expect(function () {
@@ -430,6 +447,7 @@ describe("Scene/TilesetMetadata", function () {
   it("setProperty returns false if property doesn't exist", function () {
     const tilesetMetadata = new TilesetMetadata({
       tileset: {},
+      class: {},
     });
 
     const position = [0.0, 0.0, 0.0];
@@ -467,6 +485,7 @@ describe("Scene/TilesetMetadata", function () {
   it("setProperty throws without propertyId", function () {
     const tilesetMetadata = new TilesetMetadata({
       tileset: {},
+      class: {},
     });
 
     expect(function () {
@@ -477,6 +496,7 @@ describe("Scene/TilesetMetadata", function () {
   it("setProperty throws without value", function () {
     const tilesetMetadata = new TilesetMetadata({
       tileset: {},
+      class: {},
     });
 
     expect(function () {
@@ -487,6 +507,7 @@ describe("Scene/TilesetMetadata", function () {
   it("getPropertyBySemantic returns undefined when there's no class", function () {
     const tilesetMetadata = new TilesetMetadata({
       tileset: {},
+      class: {},
     });
     expect(tilesetMetadata.getPropertyBySemantic("_HEIGHT")).toBeUndefined();
   });
@@ -543,6 +564,7 @@ describe("Scene/TilesetMetadata", function () {
   it("getPropertyBySemantic throws without semantic", function () {
     const tilesetMetadata = new TilesetMetadata({
       tileset: {},
+      class: {},
     });
 
     expect(function () {
@@ -603,6 +625,7 @@ describe("Scene/TilesetMetadata", function () {
   it("setPropertyBySemantic throws without semantic", function () {
     const tilesetMetadata = new TilesetMetadata({
       tileset: {},
+      class: {},
     });
 
     expect(function () {

--- a/Specs/Scene/parseBoundingVolumeSemanticsSpec.js
+++ b/Specs/Scene/parseBoundingVolumeSemanticsSpec.js
@@ -25,6 +25,9 @@ describe("Scene/parseBoundingVolumeSemantics", function () {
       tile: {
         properties: {},
       },
+      class: {
+        properties: {},
+      },
     });
     expect(parseBoundingVolumeSemantics(emptyMetadata)).toEqual({
       tile: {


### PR DESCRIPTION
This PR makes a `MetadataClass` definition a requirement in `MetadataEntity` and consequently, all other metadata-related classes. It deletes the unit tests that expected functionality without a class and updates the others so they don't fail.