### PR TITLE
Fix translucency in custom shaders with features

### DIFF
--- a/Source/Scene/ModelExperimental/CPUStylingPipelineStage.js
+++ b/Source/Scene/ModelExperimental/CPUStylingPipelineStage.js
@@ -62,15 +62,15 @@ CPUStylingPipelineStage.process = function (
     };
   }
 
-  const originalCommandTranslucency =
-    renderResources.alphaOptions.pass === Pass.TRANSLUCENT;
   shaderBuilder.addUniform(
     "bool",
     "model_commandTranslucent",
     ShaderDestination.BOTH
   );
   renderResources.uniformMap.model_commandTranslucent = function () {
-    return originalCommandTranslucency;
+    // always check the current value, because custom shaders may
+    // change the value with the isTranslucent flag
+    return renderResources.alphaOptions.pass === Pass.TRANSLUCENT;
   };
 
   const featureTable = model.featureTables[model.featureTableId];

--- a/Source/Shaders/ModelExperimental/CPUStylingStageFS.glsl
+++ b/Source/Shaders/ModelExperimental/CPUStylingStageFS.glsl
@@ -24,7 +24,7 @@ void cpuStylingStage(inout czm_modelMaterial material, SelectedFeature feature)
 
     // If a feature ID vertex attribute is used, the pass type filter is applied in the vertex shader.
     // So, we only apply in in the fragment shader if the feature ID texture is used.
-    #ifdef HAS_SELECTED_FEAATURE_ID_TEXTURE
+    #ifdef HAS_SELECTED_FEATURE_ID_TEXTURE
     filterByPassType(featureColor);
     #endif
 


### PR DESCRIPTION
Fixes #10108 

For a tileset with a feature table with opaque features but a custom shader with `isTranslucent`

* [Sandcastle for testing](http://localhost:8080/Apps/Sandcastle/index.html#c=bVJtb9owEP4rJz4FKXOoaDWJUbSJtRISbNJg+xRpM8kFrDl25JfQMvHfe4kDCitf4tw9Lz7f3Ryt8CV7eqnQiBKV4/IZufMGLUPFtxJXOkfZx+ERnPH4KVWpyrSyDmqBBzSUV3iAeXD81eaidJC18VyTVCg06WDYUzoh0aK7loZj/HUTwOhfqgC8kZMzYaHVD7TamwxZYXT5xRJtkUcfH8b342Hc0DNvnS7Xe56jmVyZ94DgDJAksKYihN0Yrqz0Gb0TnIaCS4sxbL2QuVA7CwchJeTCVpK/QtBeiSZtZ+KASLHbO5K1DbzUvuxn2c9vy8Wm4xeG75oOh9o2+EJ2fwJUa5Ff8BX1MXrugoWqvIPCtmcMQmkKs2P5u2z8V9zR2GhkZfczDH7du+GSZ7koCm+RBlFjNo5GbBRD+7ljo2Zgt+lsR4IP3e2MO2fE1jtanUpb4YRWT3N2hKQxwfv3LlxWe04OI/bQgaf2wadmhqfm2rBZzFJzkVW0geRakz/P86jbnR7tqHW50X0gVYN4MLXuVeLsfP1nUVbauGajIsYShyWNk4pOtj77i45l1p5fPE360mkuahD5442dhkxyawkpvJRrccR0MJsmxH8nlZo3u/S9RkNL1ND2d7NlSDLGpgmFt5VOa7nl5j/nNw). It should look like this: 
![image](https://user-images.githubusercontent.com/8422414/154329357-6a42f5e6-a9fd-43b5-ace9-906b7b0581dc.png)
* Also check the 3D Tiles Next sandcastles to make sure they work 

To Do:
- [ ] Add a unit test for this case in `CPUStylingPipelineStage`
- [ ] update changelog