### PR TITLE
Fix inaccurate computation of `ModelExperimental`'s bounding sphere

### DIFF
--- a/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
@@ -330,7 +330,8 @@ ModelExperimentalSceneGraph.prototype.buildDrawCommands = function (
         primitiveRenderResources.boundingSphere
       );
 
-      boundingSpheres.push(primitiveRenderResources.boundingSphere);
+      //boundingSpheres.push(runtimePrimitive.boundingSphere);
+      boundingSpheres.push(runtimePrimitive.boundingSphere);
 
       const drawCommands = buildDrawCommands(
         primitiveRenderResources,
@@ -344,8 +345,8 @@ ModelExperimentalSceneGraph.prototype.buildDrawCommands = function (
   this._boundingSphere = BoundingSphere.fromBoundingSpheres(boundingSpheres);
   BoundingSphere.transform(
     this._boundingSphere,
-    this._model.modelMatrix,
-    this._model._boundingSphere
+    model.modelMatrix,
+    model._boundingSphere
   );
 };
 

--- a/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
@@ -330,7 +330,6 @@ ModelExperimentalSceneGraph.prototype.buildDrawCommands = function (
         primitiveRenderResources.boundingSphere
       );
 
-      //boundingSpheres.push(runtimePrimitive.boundingSphere);
       boundingSpheres.push(runtimePrimitive.boundingSphere);
 
       const drawCommands = buildDrawCommands(

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -480,6 +480,8 @@ describe(
         );
         verifyRender(model, false);
         expect(model.boundingSphere.center).toEqual(translation);
+
+        expect(sceneGraph.computedModelMatrix).not.toBe(transform);
         expect(model.modelMatrix).not.toBe(transform);
       });
     });

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -463,15 +463,13 @@ describe(
     it("initializes with model matrix", function () {
       const translation = new Cartesian3(10, 0, 0);
       const transform = Matrix4.fromTranslation(translation);
-      const modelMatrix = new Matrix4();
-      Matrix4.multiplyTransformation(Matrix4.IDENTITY, transform, modelMatrix);
 
       return loadAndZoomToModelExperimental(
         {
           gltf: boxTexturedGlbUrl,
           upAxis: Axis.Z,
           forwardAxis: Axis.X,
-          modelMatrix: modelMatrix,
+          modelMatrix: transform,
         },
         scene
       ).then(function (model) {
@@ -482,6 +480,7 @@ describe(
         );
         verifyRender(model, false);
         expect(model.boundingSphere.center).toEqual(translation);
+        expect(model.modelMatrix).not.toBe(transform);
       });
     });
 

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -266,7 +266,8 @@ describe(
       });
     });
 
-    it("renders model with style", function () {
+    // see https://github.com/CesiumGS/cesium/pull/10115
+    xit("renders model with style", function () {
       return loadAndZoomToModelExperimental(
         { gltf: buildingsMetadata },
         scene

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -459,6 +459,31 @@ describe(
       });
     });
 
+    it("initializes with model matrix", function () {
+      const translation = new Cartesian3(10, 0, 0);
+      const transform = Matrix4.fromTranslation(translation);
+      const modelMatrix = new Matrix4();
+      Matrix4.multiplyTransformation(Matrix4.IDENTITY, transform, modelMatrix);
+
+      return loadAndZoomToModelExperimental(
+        {
+          gltf: boxTexturedGlbUrl,
+          upAxis: Axis.Z,
+          forwardAxis: Axis.X,
+          modelMatrix: modelMatrix,
+        },
+        scene
+      ).then(function (model) {
+        const sceneGraph = model.sceneGraph;
+        scene.renderForSpecs();
+        expect(Matrix4.equals(sceneGraph.computedModelMatrix, transform)).toBe(
+          true
+        );
+        verifyRender(model, false);
+        expect(model.boundingSphere.center).toEqual(translation);
+      });
+    });
+
     it("changing model matrix works", function () {
       const updateModelMatrix = spyOn(
         ModelExperimentalSceneGraph.prototype,
@@ -468,6 +493,7 @@ describe(
         { gltf: boxTexturedGlbUrl, upAxis: Axis.Z, forwardAxis: Axis.X },
         scene
       ).then(function (model) {
+        verifyRender(model, true);
         const sceneGraph = model.sceneGraph;
 
         const transform = Matrix4.fromTranslation(new Cartesian3(10, 0, 0));
@@ -483,6 +509,7 @@ describe(
         expect(Matrix4.equals(sceneGraph.computedModelMatrix, transform)).toBe(
           true
         );
+        verifyRender(model, false);
       });
     });
 
@@ -493,7 +520,7 @@ describe(
         scene
       ).then(function (model) {
         const transform = Matrix4.fromTranslation(translation);
-        expect(model.boundingSphere.center).toEqual(new Cartesian3());
+        expect(model.boundingSphere.center).toEqual(Cartesian3.ZERO);
 
         Matrix4.multiplyTransformation(
           model.modelMatrix,
@@ -503,6 +530,7 @@ describe(
         scene.renderForSpecs();
 
         expect(model.boundingSphere.center).toEqual(translation);
+        verifyRender(model, false);
       });
     });
 


### PR DESCRIPTION
This PR intends to fix #10114 but is still a draft.

The bug I discovered in the issue was because the model matrix was being applied twice to the bounding sphere, resulting in an extreme transformation. When I made changes in #10078, I did not realize that during model initialization, the model matrix was already being applied to the bounding sphere (via `buildDrawCommands.js`, which transforms `primitiveRenderingResources.boundingSphere` in place). I was making a bounding sphere from the transformed primitives, and transforming it again by the model matrix.

Even with that fixed, however, I noticed that there is a difference between the bounding sphere drawn by model, and the actual bounding sphere. I added a sphere entity to the scene with the bounding sphere's position and radius, and they are not aligned at all. Here's the [sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=1VZtT+M4EP4rVj+lp+AmtLRQWHTAstzdghZt0a721C9uMm0sHLuyHQqH+O87iZ00LV1uddLpdFIV+eXxeOaZZ8ZNlDSWPHBYgSbviIQVuQDDi5x+qdaCaSep5hdKWsYl6GmnezyVU+nO0ESo5J4mhdYg7R3PAa14C38UgjP5nlmgc63y3406HEZxMJWETDv70X68F8d70dHdfjTeH437IxrFw2g4GIwO+oPD4eHgqD/6c9qZSndfUnmaLbfc/A1YyuXiltsk+6yEqMz7vRtmM2rVZ0QwaYL4MOqG5Xbkvs6yszvnj5B+0CyHO43YudL5OpBmyVCMlgmHUx+aM1eAxDCrtA9OKm2zaSd0sxUYu45DgCW5SkEcu7Gazw1YP1kq40canS5MdWJeyMRyJYkBAYm9KQ8HhRYhyYAvMtslz+VFLhC0wCtw4/0F0xZHTParNLyHhQYwlaeE7MX7fRqNBoNhfBS6pcGARgdRfxQN/YK7pRy7CIjXCzUJxk2Xmud45QMYqiFXD3CGWSiRxMWJnvwIz9LU+1FnrDxw+bgExKCemKhcvhJ2Hjw7ICELnI1JGX+9ksKsWEwytTpXhSzV8EWJIocxsbqABlU5g5LQ/HG8I7PZlpDa+Q1qG6ThN1wvoSZbM2/5Ugi+NIqn9OvV5HDQAuyQWr3Z9bCXbs026qfmEdll6dMt8sENUJuBDBplBBXCC4F4Tb1RKEwu2kHtrpfBQTf8O8xevAFyjs58GibLDDRQJ2XyCzlo4jx2o7qHIBeaYW2p+zPbuPWKaReVm9UW3BehGOzOy1FyFrRHe082eFmXR/CG9yH5p5tbsaI7GJXXfqNpyUq5TjvfQAi1IqYyQFbcZmQmWHJPVGEFdl/fU9r0jMtRswq17MbkeZ2W0hM+9uG304W9WXMmmnq4UEJp+u3y+vrTV1pefyaWGQsiupFl78xWfTXrlZEtk+fXZxcfG+hLo3NHTvmpxi9lf2m3OddBKe3hb8LypQB8T1iv4tv03BXnDElTcnNGF2Lm2YoP6t47YTJNmLECSvrvlBIzps8La5XEh+4GexeprsWDpK6tYKO92rJkBdvssK6pDKpedbcGBLtVFkchKX9dF3xpV6FDQi2ClvVWA6WtzvX60rwQli/FU/AKG7a9DV/bqgj/aWK8NJ22dxG0LfDtx+C/K75/r/TeaDn/55L8KVXcai4tqWOviau5+VEJ1VJ/gznvQSfsnBj7JOC09vFXni/xn1X59gfYDyxgP0C6TG9WJPdgaWKabnvSax89SfkD4em7HX9mSSKYMbgzL4SY8L8wz6cnPcS/OipU9YB+egAt2FMJy+LTa7dIKT3p4XT3SeuY27L8HQ).

![image](https://user-images.githubusercontent.com/32226860/154582462-cc86ddb1-df38-4c58-83a5-bc9410a755db.png)

For comparison, this is what it looks like for the original `Model` class. [Sandcastle here.](http://localhost:8080/Apps/Sandcastle/index.html#c=7VZdb9s2FP0rhJ/kQaElW7ET5wNL0jbbmqBBbbTo4Bdaoi0iFGmQlN0syH/vpUjJiuNkxR62lwGCwI/Ly3vPPedKqRTaoDWjG6rQGRJ0g66oZmWBv1RrwayTVvMrKQxhgqpZp3syEzPhzuCUy/Qep6VSVJgpKyh48R7+KDkj4h0xFC+ULH7X8mgYxcFMIDTr9KN+fBDHB9HxtB+N+6PxYISjeBgNk2R0OEiOhkfJ8WD056wzE+6+tIo0X+2E+RslGRPLO2bS/LPkvHLv926JybGRn8GCCB3ER1E3tNuRezvPzu+CfafZB0UKOlVgu5Cq2CbSLGkM2RLu7OSH5sw1BWCIkconJ6Qy+awTutmGarPNg1ODCplRfuLGcrHQ1PjJSmo/UhB0qasTi1KkhkmBNOU0Nbf2cFAqHqKcsmVuuujRXuQSAQ+sMm6ivyLKwIiIQVWGd3SpKNVVpAgdxP0BjkZJMoyPQ7eUJDg6jAajaOgX3C127DJAni9Yp5A3XilWwJVrqrGihVzTC6iCtUQuT4jkNXuSZT6OumL2QBXmNTeL4NFtIgTZju0rrBcyOi+Xk1xuLmUpLAG+SF4WdIyMKmljVd0PLFDs+3hPMfMd7rRLGtQ+UANpuF0CGrZm3vN7ztlKS5bhr9eTo6RlsIdd9WbXmz11a4CBMjV0ACjJHu4ADqYpNjkVQUOGoLLwtUeeRm9og4hlO6n9EkkOu+Hf2RzEz4xcoHNfhskqp4pix170Czps8jxxo7ptABaKgJzk/YVpwnqBtMvKzWoP7g2mW4q7Eie4KLlhK/5w+XAnmTAOItxiQbg/XOCloSpsY7dVTdCtb/ZZnb1i9wYSIfqnmzu4QaCAkJdOIw9BLPVnnW+Uc7lBunKANszkaM5Jeo9kaTg0b9+S2lCP7ahZpTWFx+hxW2IbCRv79Nulh9auGOGNtq4klwp/e39z8+krttdf8FVOggg/Y4wPZkerzXrlZMfl5c3F1cfG9KnRjAPHvqrxk21P7S7pGjDGPXgmpFhxCp8j0qvw1j13xSUB0KR4PsNLPvdoxYd1654QkaVEG04t/FMp+Zyoy9IYKeA7eQutD1XXwkFU6zR41p2NlT8nzxt0zV7b9qZbg2A/y+IoRPbxrLR+JQTE5TJoeW/13zb/X5fMPq20/IUvfVWA/zQwnpqO2/sA+vcFvSup3a/Xfyf3/8X+ith/im93CqiCanhrgGoMXhNnLaI3+OQj6ISdU20eOD2vY/yVFSv45bN/KAF0GkOh0wBcujcv03tqcKqbPn7aax89zdgasexsz182SjnRGnYWJecT9hfU8/y0B/YvjnJZfeY/rani5MGa5fH5jVvEGJ/2YLr/pHHI7Xj+AQ)

![image](https://user-images.githubusercontent.com/32226860/154582833-937cdba0-e911-449b-a78e-23d49fabd836.png)

The original code that my PR tried to fix results in this bounding sphere at initialization:
![image](https://user-images.githubusercontent.com/32226860/154583306-6ef6b84f-c695-4980-b689-169314220633.png)

So after going through the code with @ptrgags, we identified some things going on:
1. The bounding spheres passed to the draw commands are separate from the bounding sphere for `ModelExperimental`, at least in my fix. `ModelExperimentalSceneGraph` has a bounding sphere that is intended to be in model space, which would then be transformed by the model's `modelMatrix`.
2. `ModelExperimental` builds its bounding sphere from the ones in the scene graph, using `fromBoundingSpheres`. Using `fromBoundingSpheres` on the untransformed bounding sphere array, and then transforming the resulting sphere, results in a different bounding sphere than using `fromBoundingSpheres` on the transformed bounding spheres themselves.
3. `Model` uses `fromPoints` for its computation, which seems to result in a tighter bounding sphere compared to `ModelExperimental`.

We're going to have to rewrite `ModelExperimental`'s handling of bounding spheres in some way but not sure what the best way is to go about it, hence opening this PR for review and / or thoughts.