### PR TITLE
Update normalization equations for 3D Tiles metadata

### DIFF
--- a/Source/Scene/MetadataClassProperty.js
+++ b/Source/Scene/MetadataClassProperty.js
@@ -426,7 +426,7 @@ function parseType(property, enums) {
     arrayLength = property.count;
     isVariableLengthArray = !defined(property.count);
   } else {
-    // Could be either extension. Some cases are impossible to distinguished
+    // Could be either extension. Some cases are impossible to distinguish
     // Default to a single value
     isArray = false;
     arrayLength = undefined;

--- a/Source/Scene/MetadataComponentType.js
+++ b/Source/Scene/MetadataComponentType.js
@@ -340,16 +340,9 @@ MetadataComponentType.normalize = function (value, type) {
   }
   //>>includeEnd('debug');
 
-  if (value >= 0) {
-    return Math.min(
-      Number(value) / Number(MetadataComponentType.getMaximum(type)),
-      1.0
-    );
-  }
-
-  return -Math.min(
-    Number(value) / Number(MetadataComponentType.getMinimum(type)),
-    1.0
+  return Math.max(
+    Number(value) / Number(MetadataComponentType.getMaximum(type)),
+    -1.0
   );
 };
 
@@ -377,8 +370,8 @@ MetadataComponentType.unnormalize = function (value, type) {
   }
   //>>includeEnd('debug');
 
-  const min = MetadataComponentType.getMinimum(type);
   const max = MetadataComponentType.getMaximum(type);
+  const min = MetadataComponentType.isUnsignedIntegerType(type) ? 0 : -max;
 
   if (value >= 0.0) {
     value = value * Number(max);

--- a/Source/Scene/MetadataComponentType.js
+++ b/Source/Scene/MetadataComponentType.js
@@ -1,3 +1,4 @@
+import CesiumMath from "../Core/Math.js";
 import Check from "../Core/Check.js";
 import DeveloperError from "../Core/DeveloperError.js";
 import FeatureDetection from "../Core/FeatureDetection.js";
@@ -373,11 +374,7 @@ MetadataComponentType.unnormalize = function (value, type) {
   const max = MetadataComponentType.getMaximum(type);
   const min = MetadataComponentType.isUnsignedIntegerType(type) ? 0 : -max;
 
-  if (value >= 0.0) {
-    value = value * Number(max);
-  } else {
-    value = -value * Number(min);
-  }
+  value = CesiumMath.sign(value) * Math.round(Math.abs(value) * Number(max));
 
   if (
     (type === MetadataComponentType.INT64 ||

--- a/Specs/Scene/MetadataComponentTypeSpec.js
+++ b/Specs/Scene/MetadataComponentTypeSpec.js
@@ -255,12 +255,17 @@ describe("Scene/MetadataComponentType", function () {
 
   it("normalizes signed integers", function () {
     const signedTypes = ["INT8", "INT16", "INT32"];
+
+    // Aside from -1.0, 0.0, and -1.0 there's no common normalized value that
+    // can be checked for signed types. So hardcode some values.
+    const middle = [0.5039370078740157, 0.500015259254738, 0.5000000002328306];
+
     for (let i = 0; i < signedTypes.length; ++i) {
       const type = signedTypes[i];
       const min = MetadataComponentType.getMinimum(MetadataComponentType[type]);
       const max = MetadataComponentType.getMaximum(MetadataComponentType[type]);
-      const values = [min, min / 2, 0, max / 2, max];
-      const expectedResults = [-1.0, -0.5, 0.0, 0.5, 1.0];
+      const values = [min, min + 1, min / 2, 0, (max + 1) / 2, max];
+      const expectedResults = [-1.0, -1.0, -middle[i], 0.0, middle[i], 1.0];
       for (let j = 0; j < values.length; ++j) {
         const result = MetadataComponentType.normalize(values[j], type);
         expect(result).toBe(expectedResults[j]);
@@ -273,8 +278,8 @@ describe("Scene/MetadataComponentType", function () {
     for (let i = 0; i < unsignedTypes.length; ++i) {
       const type = unsignedTypes[i];
       const max = MetadataComponentType.getMaximum(MetadataComponentType[type]);
-      const values = [0, max / 4, max / 2, max];
-      const expectedResults = [0.0, 0.25, 0.5, 1.0];
+      const values = [0, max / 5, max];
+      const expectedResults = [0.0, 0.2, 1.0];
       for (let j = 0; j < values.length; ++j) {
         const result = MetadataComponentType.normalize(values[j], type);
         expect(result).toBe(expectedResults[j]);
@@ -289,8 +294,15 @@ describe("Scene/MetadataComponentType", function () {
 
     const min = MetadataComponentType.getMinimum(MetadataComponentType.INT64);
     const max = MetadataComponentType.getMaximum(MetadataComponentType.INT64);
-    var values = [min, min / BigInt(2), 0, max / BigInt(2), max]; // eslint-disable-line
-    const expectedResults = [-1.0, -0.5, 0.0, 0.5, 1.0];
+    const values = [
+      min,
+      min + BigInt(1), // eslint-disable-line
+      min / BigInt(2), // eslint-disable-line
+      0,
+      (max + BigInt(1)) / BigInt(2), // eslint-disable-line
+      max,
+    ];
+    const expectedResults = [-1.0, -1.0, -0.5, 0.0, 0.5, 1.0];
     for (let j = 0; j < values.length; ++j) {
       const result = MetadataComponentType.normalize(
         values[j],
@@ -306,8 +318,8 @@ describe("Scene/MetadataComponentType", function () {
     }
 
     const max = MetadataComponentType.getMaximum(MetadataComponentType.UINT64);
-    var values = [BigInt(0), max / BigInt(4), max / BigInt(2), max]; // eslint-disable-line
-    const expectedResults = [0.0, 0.25, 0.5, 1.0];
+    var values = [BigInt(0), max / BigInt(5), max]; // eslint-disable-line
+    const expectedResults = [0.0, 0.2, 1.0];
     for (let j = 0; j < values.length; ++j) {
       const result = MetadataComponentType.normalize(
         values[j],
@@ -343,12 +355,17 @@ describe("Scene/MetadataComponentType", function () {
 
   it("unnormalizes signed numbers", function () {
     const signedTypes = ["INT8", "INT16", "INT32"];
+
+    // Aside from -1.0, 0.0, and -1.0 there's no common normalized value that
+    // can be checked for signed types. So hardcode some values.
+    const middle = [0.5039370078740157, 0.500015259254738, 0.5000000002328306];
+
     for (let i = 0; i < signedTypes.length; ++i) {
       const type = signedTypes[i];
       const min = MetadataComponentType.getMinimum(MetadataComponentType[type]);
       const max = MetadataComponentType.getMaximum(MetadataComponentType[type]);
-      const values = [-1.0, -0.5, 0.0, 0.5, 1.0];
-      const expectedResults = [min, min / 2, 0, max / 2, max];
+      const values = [-1.0, -middle[i], 0.0, middle[i], 1.0];
+      const expectedResults = [min + 1, min / 2, 0, (max + 1) / 2, max];
       for (let j = 0; j < values.length; ++j) {
         const result = MetadataComponentType.unnormalize(values[j], type);
         expect(result).toBe(expectedResults[j]);
@@ -361,8 +378,8 @@ describe("Scene/MetadataComponentType", function () {
     for (let i = 0; i < unsignedTypes.length; ++i) {
       const type = unsignedTypes[i];
       const max = MetadataComponentType.getMaximum(MetadataComponentType[type]);
-      const values = [0.0, 0.25, 0.5, 1.0];
-      const expectedResults = [0, max / 4, max / 2, max];
+      const values = [0.0, 0.2, 1.0];
+      const expectedResults = [0, max / 5, max];
       for (let j = 0; j < values.length; ++j) {
         const result = MetadataComponentType.unnormalize(values[j], type);
         expect(result).toBe(expectedResults[j]);
@@ -379,15 +396,14 @@ describe("Scene/MetadataComponentType", function () {
     const max = MetadataComponentType.getMaximum(MetadataComponentType.INT64);
     const values = [-1.0, -0.5, 0.0, 0.5, 1.0];
 
-    // Unnormalization is not always exact since it must be through Float64 math
-    // first, hence the + BigInt(1)
     const expectedResults = [
-      min,
+      min + BigInt(1), // eslint-disable-line
       min / BigInt(2), // eslint-disable-line
       BigInt(0), // eslint-disable-line
-      max / BigInt(2) + BigInt(1), // eslint-disable-line
+      (max + BigInt(1)) / BigInt(2), // eslint-disable-line
       max,
     ];
+
     for (let i = 0; i < values.length; ++i) {
       const result = MetadataComponentType.unnormalize(
         values[i],
@@ -403,14 +419,12 @@ describe("Scene/MetadataComponentType", function () {
     }
 
     const max = MetadataComponentType.getMaximum(MetadataComponentType.UINT64);
-    const values = [0.0, 0.25, 0.5, 1.0];
+    const values = [0.0, 0.2, 1.0];
 
-    // Unnormalization is not always exact since it must be through Float64 math
-    // first, hence the + BigInt(1)
+    // Second result is max / 5
     const expectedResults = [
       BigInt(0), // eslint-disable-line
-      max / BigInt(4) + BigInt(1), // eslint-disable-line
-      max / BigInt(2) + BigInt(1), // eslint-disable-line
+      BigInt(3689348814741910323), // eslint-disable-line
       max,
     ];
     for (let i = 0; i < values.length; ++i) {
@@ -425,7 +439,7 @@ describe("Scene/MetadataComponentType", function () {
   it("unnormalize clamps values outside the range", function () {
     expect(
       MetadataComponentType.unnormalize(-1.1, MetadataComponentType.INT8)
-    ).toBe(-128);
+    ).toBe(-127);
     expect(
       MetadataComponentType.unnormalize(-0.1, MetadataComponentType.UINT8)
     ).toBe(0);

--- a/Specs/Scene/MetadataComponentTypeSpec.js
+++ b/Specs/Scene/MetadataComponentTypeSpec.js
@@ -364,8 +364,16 @@ describe("Scene/MetadataComponentType", function () {
       const type = signedTypes[i];
       const min = MetadataComponentType.getMinimum(MetadataComponentType[type]);
       const max = MetadataComponentType.getMaximum(MetadataComponentType[type]);
-      const values = [-1.0, -middle[i], 0.0, middle[i], 1.0];
-      const expectedResults = [min + 1, min / 2, 0, (max + 1) / 2, max];
+      const values = [-1.0, -middle[i], -0.5, 0.0, middle[i], 0.5, 1.0];
+      const expectedResults = [
+        min + 1,
+        min / 2,
+        min / 2,
+        0,
+        (max + 1) / 2,
+        (max + 1) / 2,
+        max,
+      ];
       for (let j = 0; j < values.length; ++j) {
         const result = MetadataComponentType.unnormalize(values[j], type);
         expect(result).toBe(expectedResults[j]);
@@ -378,8 +386,8 @@ describe("Scene/MetadataComponentType", function () {
     for (let i = 0; i < unsignedTypes.length; ++i) {
       const type = unsignedTypes[i];
       const max = MetadataComponentType.getMaximum(MetadataComponentType[type]);
-      const values = [0.0, 0.2, 1.0];
-      const expectedResults = [0, max / 5, max];
+      const values = [0.0, 0.2, 0.5, 1.0];
+      const expectedResults = [0, max / 5, (max + 1) / 2, max];
       for (let j = 0; j < values.length; ++j) {
         const result = MetadataComponentType.unnormalize(values[j], type);
         expect(result).toBe(expectedResults[j]);
@@ -419,12 +427,14 @@ describe("Scene/MetadataComponentType", function () {
     }
 
     const max = MetadataComponentType.getMaximum(MetadataComponentType.UINT64);
-    const values = [0.0, 0.2, 1.0];
+    const values = [0.0, 0.2, 0.5, 1.0];
 
     // Second result is max / 5
+    // Third result is (max + 1) / 2
     const expectedResults = [
       BigInt(0), // eslint-disable-line
       BigInt(3689348814741910323), // eslint-disable-line
+      BigInt(9223372036854775808), // eslint-disable-line
       max,
     ];
     for (let i = 0; i < values.length; ++i) {


### PR DESCRIPTION
The 3D Metadata Specification now has equations for normalization, defined [here](https://github.com/CesiumGS/3d-tiles/tree/extension-revisions/specification/Metadata#normalized-values). These are the same as the equations defined by glTF for animations ([link](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#animations)). The main change is that the `min` value and the `min + 1` value both map to `-1.0` 

* E.g. for `INT8` — `-128` and `-127` both map to `-1.0`