### PR TITLE
Property texture schema revisions

### DIFF
--- a/Source/Scene/GltfLoaderUtil.js
+++ b/Source/Scene/GltfLoaderUtil.js
@@ -189,6 +189,7 @@ GltfLoaderUtil.createModelTextureReader = function (options) {
   }
 
   const modelTextureReader = new ModelComponents.TextureReader();
+  modelTextureReader.index = textureInfo.index;
   modelTextureReader.texture = texture;
   modelTextureReader.texCoord = texCoord;
   modelTextureReader.transform = transform;

--- a/Source/Scene/GltfStructuralMetadataLoader.js
+++ b/Source/Scene/GltfStructuralMetadataLoader.js
@@ -304,16 +304,16 @@ function loadBufferViews(structuralMetadataLoader) {
   });
 }
 
-function gatherUsedTextureIds(extension) {
+function gatherUsedTextureIds(structuralMetadataExtension) {
   // Gather the used textures
   const textureIds = {};
-  const propertyTextures = extension.propertyTextures;
+  const propertyTextures = structuralMetadataExtension.propertyTextures;
   if (defined(propertyTextures)) {
     for (let i = 0; i < propertyTextures.length; i++) {
       const propertyTexture = propertyTextures[i];
-      if (defined(propertyTexture.properties)) {
-        // The property texture JSON is also a glTF textureInfo
-        textureIds[propertyTexture.index] = propertyTexture;
+      const properties = propertyTexture.properties;
+      if (defined(properties)) {
+        gatherTextureIdsFromProperties(properties, textureIds);
       }
     }
   }
@@ -323,8 +323,8 @@ function gatherUsedTextureIds(extension) {
 function gatherTextureIdsFromProperties(properties, textureIds) {
   for (const propertyId in properties) {
     if (properties.hasOwnProperty(propertyId)) {
-      const property = properties[propertyId];
-      const textureInfo = property.texture;
+      // in EXT_structural_metadata the property is a valid textureInfo.
+      const textureInfo = properties[propertyId];
       textureIds[textureInfo.index] = textureInfo;
     }
   }
@@ -340,13 +340,23 @@ function gatherUsedTextureIdsLegacy(extensionLegacy) {
         const featureTexture = featureTextures[featureTextureId];
         const properties = featureTexture.properties;
         if (defined(properties)) {
-          gatherTextureIdsFromProperties(properties, textureIds);
+          gatherTextureIdsFromPropertiesLegacy(properties, textureIds);
         }
       }
     }
   }
 
   return textureIds;
+}
+
+function gatherTextureIdsFromPropertiesLegacy(properties, textureIds) {
+  for (const propertyId in properties) {
+    if (properties.hasOwnProperty(propertyId)) {
+      const property = properties[propertyId];
+      const textureInfo = property.texture;
+      textureIds[textureInfo.index] = textureInfo;
+    }
+  }
 }
 
 function loadTextures(structuralMetadataLoader) {

--- a/Source/Scene/ModelComponents.js
+++ b/Source/Scene/ModelComponents.js
@@ -794,6 +794,16 @@ function TextureReader() {
   this.texture = undefined;
 
   /**
+   * The index of the texture in the glTF. This is useful for determining
+   * when textures are shared to avoid attaching a texture in multiple uniform
+   * slots in the shader.
+   *
+   * @type {Number}
+   * @private
+   */
+  this.index = undefined;
+
+  /**
    * The texture coordinate set.
    *
    * @type {Number}

--- a/Source/Scene/PropertyTexture.js
+++ b/Source/Scene/PropertyTexture.js
@@ -13,7 +13,7 @@ import PropertyTextureProperty from "./PropertyTextureProperty.js";
  * @param {Object} options Object with the following properties:
  * @param {String} [options.name] Optional human-readable name to describe the table
  * @param {String|Number} [options.id] A unique id to identify the feature table, useful for debugging. For <code>EXT_structural_metadata</code>, this is the array index in the feature tables array, for <code>EXT_feature_metadata</code> this is the dictionary key in the feature tables dictionary.
- * @param {Object} options.featureTexture The feature texture JSON. Note that this follows the legacy EXT_feature_metadata schema to allow full backwards compatibility.
+ * @param {Object} options.propertyTexture The property texture JSON, following the EXT_structural_metadata schema.
  * @param {MetadataClass} options.class The class that properties conform to.
  * @param {Object.<String, Texture>} options.textures An object mapping texture IDs to {@link Texture} objects.
  *
@@ -25,25 +25,25 @@ import PropertyTextureProperty from "./PropertyTextureProperty.js";
  */
 function PropertyTexture(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
-  const featureTexture = options.featureTexture;
+  const propertyTexture = options.propertyTexture;
   const classDefinition = options.class;
   const textures = options.textures;
 
   //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("options.featureTexture", featureTexture);
+  Check.typeOf.object("options.propertyTexture", propertyTexture);
   Check.typeOf.object("options.class", classDefinition);
   Check.typeOf.object("options.textures", textures);
   //>>includeEnd('debug');
 
-  const extensions = featureTexture.extensions;
-  const extras = featureTexture.extras;
+  const extensions = propertyTexture.extensions;
+  const extras = propertyTexture.extras;
 
   const properties = {};
-  if (defined(featureTexture.properties)) {
-    for (const propertyId in featureTexture.properties) {
-      if (featureTexture.properties.hasOwnProperty(propertyId)) {
+  if (defined(propertyTexture.properties)) {
+    for (const propertyId in propertyTexture.properties) {
+      if (propertyTexture.properties.hasOwnProperty(propertyId)) {
         properties[propertyId] = new PropertyTextureProperty({
-          property: featureTexture.properties[propertyId],
+          property: propertyTexture.properties[propertyId],
           classProperty: classDefinition.properties[propertyId],
           textures: textures,
         });

--- a/Source/Scene/PropertyTextureProperty.js
+++ b/Source/Scene/PropertyTextureProperty.js
@@ -33,12 +33,18 @@ function PropertyTextureProperty(options) {
   Check.typeOf.object("options.textures", textures);
   //>>includeEnd('debug');
 
-  const textureInfo = property.texture;
+  // in EXT_structural_metadata, the property is a valid glTF textureInfo
+  const textureInfo = property;
   const textureReader = GltfLoaderUtil.createModelTextureReader({
     textureInfo: textureInfo,
-    channels: property.channels,
+    channels: reformatChannels(property.channels),
     texture: textures[textureInfo.index],
   });
+
+  this._offset = property.offset;
+  this._scale = property.scale;
+  this._min = property.min;
+  this._max = property.max;
 
   this._textureReader = textureReader;
   this._classProperty = classProperty;
@@ -89,5 +95,21 @@ Object.defineProperties(PropertyTextureProperty.prototype, {
     },
   },
 });
+
+/**
+ * Reformat from an array of channel indices like <code>[0, 1]</code> to a
+ * string of channels as would be used in GLSL swizzling (e.g. "rg")
+ *
+ * @param {Number[]} channels the channel indices
+ * @return {String} The channels as a string of "r", "g", "b" or "a" characters.
+ * @private
+ */
+function reformatChannels(channels) {
+  return channels
+    .map(function (channelIndex) {
+      return "rgba".charAt(channelIndex);
+    })
+    .join("");
+}
 
 export default PropertyTextureProperty;

--- a/Source/Scene/parseFeatureMetadataLegacy.js
+++ b/Source/Scene/parseFeatureMetadataLegacy.js
@@ -1,4 +1,5 @@
 import Check from "../Core/Check.js";
+import combine from "../Core/combine.js";
 import defaultValue from "../Core/defaultValue.js";
 import defined from "../Core/defined.js";
 import PropertyTable from "./PropertyTable.js";
@@ -76,7 +77,7 @@ export default function parseFeatureMetadataLegacy(options) {
       propertyTextures.push(
         new PropertyTexture({
           id: featureTextureId,
-          featureTexture: featureTexture,
+          propertyTexture: transcodeToPropertyTexture(featureTexture),
           class: schema.classes[featureTexture.class],
           textures: options.textures,
         })
@@ -92,4 +93,45 @@ export default function parseFeatureMetadataLegacy(options) {
     extras: extension.extras,
     extensions: extension.extensions,
   });
+}
+
+function transcodeToPropertyTexture(featureTexture) {
+  const propertyTexture = {
+    class: featureTexture.class,
+    properties: {},
+  };
+
+  const properties = featureTexture.properties;
+  for (const propertyId in properties) {
+    if (properties.hasOwnProperty(propertyId)) {
+      const oldProperty = properties[propertyId];
+      const property = {
+        // EXT_structural_metadata uses numeric channel indices instead of
+        // a string of channel letters like "rgba".
+        channels: reformatChannels(oldProperty.channels),
+        extras: oldProperty.extras,
+        extensions: oldProperty.extensions,
+      };
+
+      // EXT_feature_metadata puts the textureInfo in property.texture.
+      // EXT_structural_metadata flattens this structure; essentially a
+      // textureInfo + channels
+      propertyTexture.properties[propertyId] = combine(
+        oldProperty.texture,
+        property,
+        true
+      );
+    }
+  }
+
+  return propertyTexture;
+}
+
+function reformatChannels(channelsString) {
+  const length = channelsString.length;
+  const result = new Array(length);
+  for (let i = 0; i < length; i++) {
+    result[i] = "rgba".indexOf(channelsString[i]);
+  }
+  return result;
 }

--- a/Source/Scene/parseStructuralMetadata.js
+++ b/Source/Scene/parseStructuralMetadata.js
@@ -1,5 +1,4 @@
 import Check from "../Core/Check.js";
-import clone from "../Core/clone.js";
 import defaultValue from "../Core/defaultValue.js";
 import defined from "../Core/defined.js";
 import PropertyTable from "./PropertyTable.js";
@@ -66,7 +65,7 @@ export default function parseStructuralMetadata(options) {
         new PropertyTexture({
           id: i,
           name: propertyTexture.name,
-          featureTexture: reformatPropertyTexture(propertyTexture),
+          propertyTexture: propertyTexture,
           class: schema.classes[propertyTexture.class],
           textures: options.textures,
         })
@@ -82,52 +81,4 @@ export default function parseStructuralMetadata(options) {
     extras: extension.extras,
     extensions: extension.extensions,
   });
-}
-
-/**
- * The legacy EXT_feature_metadata schema was a bit broad in what it could do.
- * The properties in a feature texture could potentially belong to different
- * textures. For full backwards compatibility, here we transcode <i>backwards</i>
- * from EXT_structural_metadata to EXT_feature_metadata.
- *
- * @param {Object} propertyTexture The property texture JSON from EXT_structural_metadata
- * @return {Object} The corresponding feature texture JSON for the legacy EXT_feature_metadata
- * @private
- */
-function reformatPropertyTexture(propertyTexture) {
-  // in EXT_structural_metadata propertyTexture is a valid glTF textureInfo
-  // since it has an index and a texCoord.
-  const textureInfo = clone(propertyTexture);
-
-  const featureTexture = clone(propertyTexture);
-  featureTexture.properties = {};
-
-  const originalProperties = propertyTexture.properties;
-  for (const propertyId in originalProperties) {
-    if (originalProperties.hasOwnProperty(propertyId)) {
-      const channels = originalProperties[propertyId];
-      featureTexture.properties[propertyId] = {
-        texture: textureInfo,
-        channels: reformatChannels(channels),
-      };
-    }
-  }
-
-  return featureTexture;
-}
-
-/**
- * Reformat from an array of channel indices like <code>[0, 1]</code> to a
- * string of channels as would be used in GLSL swizzling (e.g. "rg")
- *
- * @param {Number[]} channels the channel indices
- * @return {String} The channels as a string of "r", "g", "b" or "a" characters.
- * @private
- */
-function reformatChannels(channels) {
-  return channels
-    .map(function (channelIndex) {
-      return "rgba".charAt(channelIndex);
-    })
-    .join("");
 }

--- a/Specs/Data/Models/GltfLoader/Microcosm/glTF/microcosm.gltf
+++ b/Specs/Data/Models/GltfLoader/Microcosm/glTF/microcosm.gltf
@@ -52,12 +52,12 @@
         {
           "name": "Vegetation",
           "class": "vegetation",
-          "index": 1,
-          "texCoord": 0,
           "properties": {
-            "vegetationDensity": [
-              0
-            ]
+            "vegetationDensity": {
+              "index": 1,
+              "texCoord": 0,
+              "channels": [0]
+            }
           }
         }
       ]

--- a/Specs/Scene/GltfStructuralMetadataLoaderSpec.js
+++ b/Specs/Scene/GltfStructuralMetadataLoaderSpec.js
@@ -116,20 +116,28 @@ describe(
         {
           name: "Map",
           class: "map",
-          index: 0,
-          texCoord: 0,
           properties: {
-            color: [0, 1, 2],
-            intensity: [3],
+            color: {
+              channels: [0, 1, 2],
+              index: 0,
+              texCoord: 0,
+            },
+            intensity: {
+              channels: [3],
+              index: 0,
+              texCoord: 0,
+            },
           },
         },
         {
           name: "Ortho",
           class: "ortho",
-          index: 1,
-          texCoord: 1,
           properties: {
-            vegetation: [0],
+            vegetation: {
+              channels: [0],
+              index: 1,
+              texCoord: 1,
+            },
           },
         },
       ],

--- a/Specs/Scene/PropertyTexturePropertySpec.js
+++ b/Specs/Scene/PropertyTexturePropertySpec.js
@@ -50,24 +50,19 @@ describe("Scene/PropertyTextureProperty", function () {
     };
 
     extensions = {
-      EXT_other_extension: {},
+      KHR_texture_transform: {
+        offset: [0.5, 0.5],
+        scale: [0.1, 0.2],
+        texCoord: 1,
+      },
     };
 
     const property = {
-      channels: "rgb",
-      texture: {
-        index: 0,
-        texCoord: 0,
-        extensions: {
-          KHR_texture_transform: {
-            offset: [0.5, 0.5],
-            scale: [0.1, 0.2],
-            texCoord: 1,
-          },
-        },
-      },
-      extras: extras,
+      channels: [0, 1, 2],
+      index: 0,
+      texCoord: 0,
       extensions: extensions,
+      extras: extras,
     };
 
     propertyTextureProperty = new PropertyTextureProperty({

--- a/Specs/Scene/PropertyTextureSpec.js
+++ b/Specs/Scene/PropertyTextureSpec.js
@@ -14,7 +14,7 @@ describe("Scene/PropertyTexture", function () {
   let texture1;
   let extras;
   let extensions;
-  let featureTexture;
+  let propertyTexture;
 
   beforeAll(function () {
     classDefinition = new MetadataClass({
@@ -72,37 +72,31 @@ describe("Scene/PropertyTexture", function () {
       EXT_other_extension: {},
     };
 
-    const featureTextureJson = {
+    const propertyTextureJson = {
       class: "map",
       extras: extras,
       extensions: extensions,
       properties: {
         color: {
-          channels: "rgb",
-          texture: {
-            index: 0,
-            texCoord: 0,
-          },
+          channels: [0, 1, 2],
+          index: 0,
+          texCoord: 0,
         },
         intensity: {
-          channels: "a",
-          texture: {
-            index: 0,
-            texCoord: 0,
-          },
+          channels: [3],
+          index: 0,
+          texCoord: 0,
         },
         ortho: {
-          channels: "r",
-          texture: {
-            index: 1,
-            texCoord: 0,
-          },
+          channels: [0],
+          index: 1,
+          texCoord: 0,
         },
       },
     };
 
-    featureTexture = new PropertyTexture({
-      featureTexture: featureTextureJson,
+    propertyTexture = new PropertyTexture({
+      propertyTexture: propertyTextureJson,
       class: classDefinition,
       textures: {
         0: texture0,
@@ -117,10 +111,10 @@ describe("Scene/PropertyTexture", function () {
     context.destroyForSpecs();
   });
 
-  it("creates feature texture", function () {
-    expect(featureTexture.class).toBe(classDefinition);
-    expect(featureTexture.extras).toBe(extras);
-    expect(featureTexture.extensions).toBe(extensions);
+  it("creates property texture", function () {
+    expect(propertyTexture.class).toBe(classDefinition);
+    expect(propertyTexture.extras).toBe(extras);
+    expect(propertyTexture.extensions).toBe(extensions);
   });
 
   it("constructor throws without featureTexture", function () {
@@ -151,18 +145,18 @@ describe("Scene/PropertyTexture", function () {
   });
 
   it("getProperty returns feature texture property", function () {
-    expect(featureTexture.getProperty("color")).toBeDefined();
-    expect(featureTexture.getProperty("intensity")).toBeDefined();
-    expect(featureTexture.getProperty("ortho")).toBeDefined();
+    expect(propertyTexture.getProperty("color")).toBeDefined();
+    expect(propertyTexture.getProperty("intensity")).toBeDefined();
+    expect(propertyTexture.getProperty("ortho")).toBeDefined();
   });
 
   it("getProperty returns undefined if the property doesn't exist", function () {
-    expect(featureTexture.getProperty("other")).toBeUndefined();
+    expect(propertyTexture.getProperty("other")).toBeUndefined();
   });
 
   it("getProperty throws if propertyId is undefined", function () {
     expect(function () {
-      featureTexture.getProperty(undefined);
+      propertyTexture.getProperty(undefined);
     }).toThrowDeveloperError();
   });
 });

--- a/Specs/Scene/parseStructuralMetadataSpec.js
+++ b/Specs/Scene/parseStructuralMetadataSpec.js
@@ -193,20 +193,28 @@ describe(
           {
             name: "Map",
             class: "map",
-            index: 0,
-            texCoord: 0,
             properties: {
-              color: [0, 1, 2],
-              intensity: [3],
+              color: {
+                index: 0,
+                texCoord: 0,
+                channels: [0, 1, 2],
+              },
+              intensity: {
+                index: 0,
+                texCoord: 0,
+                channels: [3],
+              },
             },
           },
           {
             name: "Ortho",
             class: "ortho",
-            index: 1,
-            texCoord: 1,
             properties: {
-              vegetation: [0],
+              vegetation: {
+                index: 1,
+                texCoord: 1,
+                channels: [0],
+              },
             },
           },
         ],


### PR DESCRIPTION
This PR updates the parsing of property textures to the latest schema changes from `EXT_structural_metadata`.

See the [spec](https://github.com/CesiumGS/glTF/tree/ext-mesh-features-revision/extensions/2.0/Vendor/EXT_structural_metadata#property-textures) for an example of what property textures looks like.

@lilleyse could you review?