### PR TITLE
Affine transformation helpers functions for `Matrix` classes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
 - Added support for `debugColorTiles` in `ModelExperimental`. [#10071](https://github.com/CesiumGS/cesium/pull/10071)
 - Added support for shadows in `ModelExperimental`. [#10077](https://github.com/CesiumGS/cesium/pull/10077)
 - Added `packArray` and `unpackArray` for matrix types. [#10118](https://github.com/CesiumGS/cesium/pull/10118)
+- Added more affine transformation helper functions to `Matrix2`, `Matrix3`, and `Matrix4`. [#10124](https://github.com/CesiumGS/cesium/pull/10124)
+  - Added `setScale`, `setUniformScale`, `setRotation`, `getRotation`, and `multiplyByUniformScale` to `Matrix2`.
+  - Added `setScale`, `setUniformScale`, `setRotation`, and `multiplyByUniformScale` to `Matrix3`.
+  - Added `setUniformScale`, `setRotation`, `getRotation`, and `fromRotation` to `Matrix4`.
 
 ##### Fixes :wrench:
 

--- a/Source/Core/Matrix2.js
+++ b/Source/Core/Matrix2.js
@@ -16,10 +16,12 @@ import DeveloperError from "./DeveloperError.js";
  * @param {Number} [column0Row1=0.0] The value for column 0, row 1.
  * @param {Number} [column1Row1=0.0] The value for column 1, row 1.
  *
+ * @see Matrix2.fromArray
  * @see Matrix2.fromColumnMajorArray
  * @see Matrix2.fromRowMajorArray
  * @see Matrix2.fromScale
  * @see Matrix2.fromUniformScale
+ * @see Matrix2.fromRotation
  * @see Matrix3
  * @see Matrix4
  */
@@ -191,24 +193,7 @@ Matrix2.clone = function (matrix, result) {
  * const v2 = [0.0, 0.0, 1.0, 1.0, 2.0, 2.0];
  * const m2 = Cesium.Matrix2.fromArray(v2, 2);
  */
-Matrix2.fromArray = function (array, startingIndex, result) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.defined("array", array);
-  //>>includeEnd('debug');
-
-  startingIndex = defaultValue(startingIndex, 0);
-
-  if (!defined(result)) {
-    result = new Matrix2();
-  }
-
-  result[0] = array[startingIndex];
-  result[1] = array[startingIndex + 1];
-  result[2] = array[startingIndex + 2];
-  result[3] = array[startingIndex + 3];
-  return result;
-};
-
+Matrix2.fromArray = Matrix2.unpack;
 /**
  * Creates a Matrix2 instance from a column-major order array.
  *
@@ -501,6 +486,80 @@ Matrix2.setRow = function (matrix, index, cartesian, result) {
   return result;
 };
 
+const scaleScratch1 = new Cartesian2();
+
+/**
+ * Computes a new matrix that replaces the scale with the provided scale.
+ * This assumes the matrix is an affine transformation.
+ *
+ * @param {Matrix2} matrix The matrix to use.
+ * @param {Cartesian2} scale The scale that replaces the scale of the provided matrix.
+ * @param {Matrix2} result The object onto which to store the result.
+ * @returns {Matrix2} The modified result parameter.
+ *
+ * @see Matrix2.setUniformScale
+ * @see Matrix2.fromScale
+ * @see Matrix2.fromUniformScale
+ * @see Matrix2.multiplyByScale
+ * @see Matrix2.multiplyByUniformScale
+ * @see Matrix2.getScale
+ */
+Matrix2.setScale = function (matrix, scale, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("matrix", matrix);
+  Check.typeOf.object("scale", scale);
+  Check.typeOf.object("result", result);
+  //>>includeEnd('debug');
+
+  const existingScale = Matrix2.getScale(matrix, scaleScratch1);
+  const scaleRatioX = scale.x / existingScale.x;
+  const scaleRatioY = scale.y / existingScale.y;
+
+  result[0] = matrix[0] * scaleRatioX;
+  result[1] = matrix[1] * scaleRatioX;
+  result[2] = matrix[2] * scaleRatioY;
+  result[3] = matrix[3] * scaleRatioY;
+
+  return result;
+};
+
+const scaleScratch2 = new Cartesian2();
+
+/**
+ * Computes a new matrix that replaces the scale with the provided uniform scale.
+ * This assumes the matrix is an affine transformation.
+ *
+ * @param {Matrix2} matrix The matrix to use.
+ * @param {Number} scale The uniform scale that replaces the scale of the provided matrix.
+ * @param {Matrix2} result The object onto which to store the result.
+ * @returns {Matrix2} The modified result parameter.
+ *
+ * @see Matrix2.setScale
+ * @see Matrix2.fromScale
+ * @see Matrix2.fromUniformScale
+ * @see Matrix2.multiplyByScale
+ * @see Matrix2.multiplyByUniformScale
+ * @see Matrix2.getScale
+ */
+Matrix2.setUniformScale = function (matrix, scale, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("matrix", matrix);
+  Check.typeOf.number("scale", scale);
+  Check.typeOf.object("result", result);
+  //>>includeEnd('debug');
+
+  const existingScale = Matrix2.getScale(matrix, scaleScratch2);
+  const scaleRatioX = scale / existingScale.x;
+  const scaleRatioY = scale / existingScale.y;
+
+  result[0] = matrix[0] * scaleRatioX;
+  result[1] = matrix[1] * scaleRatioX;
+  result[2] = matrix[2] * scaleRatioY;
+  result[3] = matrix[3] * scaleRatioY;
+
+  return result;
+};
+
 const scratchColumn = new Cartesian2();
 
 /**
@@ -509,6 +568,13 @@ const scratchColumn = new Cartesian2();
  * @param {Matrix2} matrix The matrix.
  * @param {Cartesian2} result The object onto which to store the result.
  * @returns {Cartesian2} The modified result parameter.
+ *
+ * @see Matrix2.multiplyByScale
+ * @see Matrix2.multiplyByUniformScale
+ * @see Matrix2.fromScale
+ * @see Matrix2.fromUniformScale
+ * @see Matrix2.setScale
+ * @see Matrix2.setUniformScale
  */
 Matrix2.getScale = function (matrix, result) {
   //>>includeStart('debug', pragmas.debug);
@@ -525,7 +591,7 @@ Matrix2.getScale = function (matrix, result) {
   return result;
 };
 
-const scratchScale = new Cartesian2();
+const scaleScratch3 = new Cartesian2();
 
 /**
  * Computes the maximum scale assuming the matrix is an affine transformation.
@@ -535,8 +601,64 @@ const scratchScale = new Cartesian2();
  * @returns {Number} The maximum scale.
  */
 Matrix2.getMaximumScale = function (matrix) {
-  Matrix2.getScale(matrix, scratchScale);
-  return Cartesian2.maximumComponent(scratchScale);
+  Matrix2.getScale(matrix, scaleScratch3);
+  return Cartesian2.maximumComponent(scaleScratch3);
+};
+
+const scaleScratch4 = new Cartesian2();
+
+/**
+ * Sets the rotation assuming the matrix is an affine transformation.
+ *
+ * @param {Matrix2} matrix The matrix.
+ * @param {Matrix2} rotation The rotation matrix.
+ * @returns {Matrix2} The modified result parameter.
+ *
+ * @see Matrix2.fromRotation
+ * @see Matrix2.getRotation
+ */
+Matrix2.setRotation = function (matrix, rotation, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("matrix", matrix);
+  Check.typeOf.object("result", result);
+  //>>includeEnd('debug');
+
+  const scale = Matrix2.getScale(matrix, scaleScratch4);
+
+  result[0] = rotation[0] * scale.x;
+  result[1] = rotation[1] * scale.x;
+  result[2] = rotation[2] * scale.y;
+  result[3] = rotation[3] * scale.y;
+
+  return result;
+};
+
+const scaleScratch5 = new Cartesian2();
+
+/**
+ * Extracts the rotation matrix assuming the matrix is an affine transformation.
+ *
+ * @param {Matrix2} matrix The matrix.
+ * @param {Matrix2} result The object onto which to store the result.
+ * @returns {Matrix2} The modified result parameter.
+ *
+ * @see Matrix2.setRotation
+ * @see Matrix2.fromRotation
+ */
+Matrix2.getRotation = function (matrix, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("matrix", matrix);
+  Check.typeOf.object("result", result);
+  //>>includeEnd('debug');
+
+  const scale = Matrix2.getScale(matrix, scaleScratch5);
+
+  result[0] = matrix[0] / scale.x;
+  result[1] = matrix[1] / scale.x;
+  result[2] = matrix[2] / scale.y;
+  result[3] = matrix[3] / scale.y;
+
+  return result;
 };
 
 /**
@@ -659,7 +781,7 @@ Matrix2.multiplyByScalar = function (matrix, scalar, result) {
  * Computes the product of a matrix times a (non-uniform) scale, as if the scale were a scale matrix.
  *
  * @param {Matrix2} matrix The matrix on the left-hand side.
- * @param {Cartesian2} scale The non-uniform scale on the right-hand side.
+ * @param {Number} scale The non-uniform scale on the right-hand side.
  * @param {Matrix2} result The object onto which to store the result.
  * @returns {Matrix2} The modified result parameter.
  *
@@ -668,8 +790,12 @@ Matrix2.multiplyByScalar = function (matrix, scalar, result) {
  * // Instead of Cesium.Matrix2.multiply(m, Cesium.Matrix2.fromScale(scale), m);
  * Cesium.Matrix2.multiplyByScale(m, scale, m);
  *
- * @see Matrix2.fromScale
  * @see Matrix2.multiplyByUniformScale
+ * @see Matrix2.fromScale
+ * @see Matrix2.fromUniformScale
+ * @see Matrix2.setScale
+ * @see Matrix2.setUniformScale
+ * @see Matrix2.getScale
  */
 Matrix2.multiplyByScale = function (matrix, scale, result) {
   //>>includeStart('debug', pragmas.debug);
@@ -682,6 +808,41 @@ Matrix2.multiplyByScale = function (matrix, scale, result) {
   result[1] = matrix[1] * scale.x;
   result[2] = matrix[2] * scale.y;
   result[3] = matrix[3] * scale.y;
+
+  return result;
+};
+
+/**
+ * Computes the product of a matrix times a uniform scale, as if the scale were a scale matrix.
+ *
+ * @param {Matrix2} matrix The matrix on the left-hand side.
+ * @param {Number} scale The uniform scale on the right-hand side.
+ * @param {Matrix2} result The object onto which to store the result.
+ * @returns {Matrix2} The modified result parameter.
+ *
+ * @example
+ * // Instead of Cesium.Matrix2.multiply(m, Cesium.Matrix2.fromUniformScale(scale), m);
+ * Cesium.Matrix2.multiplyByUniformScale(m, scale, m);
+ *
+ * @see Matrix2.multiplyByScale
+ * @see Matrix2.fromScale
+ * @see Matrix2.fromUniformScale
+ * @see Matrix2.setScale
+ * @see Matrix2.setUniformScale
+ * @see Matrix2.getScale
+ */
+Matrix2.multiplyByUniformScale = function (matrix, scale, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("matrix", matrix);
+  Check.typeOf.number("scale", scale);
+  Check.typeOf.object("result", result);
+  //>>includeEnd('debug');
+
+  result[0] = matrix[0] * scale;
+  result[1] = matrix[1] * scale;
+  result[2] = matrix[2] * scale;
+  result[3] = matrix[3] * scale;
+
   return result;
 };
 

--- a/Source/Core/Matrix4.js
+++ b/Source/Core/Matrix4.js
@@ -32,14 +32,16 @@ import RuntimeError from "./RuntimeError.js";
  * @param {Number} [column2Row3=0.0] The value for column 2, row 3.
  * @param {Number} [column3Row3=0.0] The value for column 3, row 3.
  *
+ * @see Matrix4.fromArray
  * @see Matrix4.fromColumnMajorArray
  * @see Matrix4.fromRowMajorArray
  * @see Matrix4.fromRotationTranslation
- * @see Matrix4.fromTranslationRotationScale
  * @see Matrix4.fromTranslationQuaternionRotationScale
+ * @see Matrix4.fromTranslationRotationScale
  * @see Matrix4.fromTranslation
  * @see Matrix4.fromScale
  * @see Matrix4.fromUniformScale
+ * @see Matrix4.fromRotation
  * @see Matrix4.fromCamera
  * @see Matrix4.computePerspectiveFieldOfView
  * @see Matrix4.computeOrthographicOffCenter
@@ -669,6 +671,44 @@ Matrix4.fromUniformScale = function (scale, result) {
   return result;
 };
 
+/**
+ * Creates a rotation matrix.
+ *
+ * @param {Matrix3} rotation The rotation matrix.
+ * @param {Matrix4} [result] The object in which the result will be stored, if undefined a new instance will be created.
+ * @returns {Matrix4} The modified result parameter, or a new Matrix4 instance if one was not provided.
+ */
+Matrix4.fromRotation = function (rotation, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("rotation", rotation);
+  //>>includeEnd('debug');
+
+  if (!defined(result)) {
+    result = new Matrix4();
+  }
+  result[0] = rotation[0];
+  result[1] = rotation[1];
+  result[2] = rotation[2];
+  result[3] = 0.0;
+
+  result[4] = rotation[3];
+  result[5] = rotation[4];
+  result[6] = rotation[5];
+  result[7] = 0.0;
+
+  result[8] = rotation[6];
+  result[9] = rotation[7];
+  result[10] = rotation[8];
+  result[11] = 0.0;
+
+  result[12] = 0.0;
+  result[13] = 0.0;
+  result[14] = 0.0;
+  result[15] = 1.0;
+
+  return result;
+};
+
 const fromCameraF = new Cartesian3();
 const fromCameraR = new Cartesian3();
 const fromCameraU = new Cartesian3();
@@ -1069,6 +1109,7 @@ Matrix4.computeViewportTransformation = function (
   result[13] = column3Row1;
   result[14] = column3Row2;
   result[15] = column3Row3;
+
   return result;
 };
 
@@ -1298,71 +1339,6 @@ Matrix4.setColumn = function (matrix, index, cartesian, result) {
 };
 
 /**
- * Computes a new matrix that replaces the translation in the rightmost column of the provided
- * matrix with the provided translation. This assumes the matrix is an affine transformation.
- *
- * @param {Matrix4} matrix The matrix to use.
- * @param {Cartesian3} translation The translation that replaces the translation of the provided matrix.
- * @param {Matrix4} result The object onto which to store the result.
- * @returns {Matrix4} The modified result parameter.
- */
-Matrix4.setTranslation = function (matrix, translation, result) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("matrix", matrix);
-  Check.typeOf.object("translation", translation);
-  Check.typeOf.object("result", result);
-  //>>includeEnd('debug');
-
-  result[0] = matrix[0];
-  result[1] = matrix[1];
-  result[2] = matrix[2];
-  result[3] = matrix[3];
-
-  result[4] = matrix[4];
-  result[5] = matrix[5];
-  result[6] = matrix[6];
-  result[7] = matrix[7];
-
-  result[8] = matrix[8];
-  result[9] = matrix[9];
-  result[10] = matrix[10];
-  result[11] = matrix[11];
-
-  result[12] = translation.x;
-  result[13] = translation.y;
-  result[14] = translation.z;
-  result[15] = matrix[15];
-
-  return result;
-};
-
-const scaleScratch = new Cartesian3();
-/**
- * Computes a new matrix that replaces the scale with the provided scale.
- * This assumes the matrix is an affine transformation.
- *
- * @param {Matrix4} matrix The matrix to use.
- * @param {Cartesian3} scale The scale that replaces the scale of the provided matrix.
- * @param {Matrix4} result The object onto which to store the result.
- * @returns {Matrix4} The modified result parameter.
- */
-Matrix4.setScale = function (matrix, scale, result) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("matrix", matrix);
-  Check.typeOf.object("scale", scale);
-  Check.typeOf.object("result", result);
-  //>>includeEnd('debug');
-
-  const existingScale = Matrix4.getScale(matrix, scaleScratch);
-  const newScale = Cartesian3.divideComponents(
-    scale,
-    existingScale,
-    scaleScratch
-  );
-  return Matrix4.multiplyByScale(matrix, newScale, result);
-};
-
-/**
  * Retrieves a copy of the matrix row at the provided index as a Cartesian4 instance.
  *
  * @param {Matrix4} matrix The matrix to use.
@@ -1456,6 +1432,151 @@ Matrix4.setRow = function (matrix, index, cartesian, result) {
   return result;
 };
 
+/**
+ * Computes a new matrix that replaces the translation in the rightmost column of the provided
+ * matrix with the provided translation. This assumes the matrix is an affine transformation.
+ *
+ * @param {Matrix4} matrix The matrix to use.
+ * @param {Cartesian3} translation The translation that replaces the translation of the provided matrix.
+ * @param {Matrix4} result The object onto which to store the result.
+ * @returns {Matrix4} The modified result parameter.
+ */
+Matrix4.setTranslation = function (matrix, translation, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("matrix", matrix);
+  Check.typeOf.object("translation", translation);
+  Check.typeOf.object("result", result);
+  //>>includeEnd('debug');
+
+  result[0] = matrix[0];
+  result[1] = matrix[1];
+  result[2] = matrix[2];
+  result[3] = matrix[3];
+
+  result[4] = matrix[4];
+  result[5] = matrix[5];
+  result[6] = matrix[6];
+  result[7] = matrix[7];
+
+  result[8] = matrix[8];
+  result[9] = matrix[9];
+  result[10] = matrix[10];
+  result[11] = matrix[11];
+
+  result[12] = translation.x;
+  result[13] = translation.y;
+  result[14] = translation.z;
+  result[15] = matrix[15];
+
+  return result;
+};
+
+const scaleScratch1 = new Cartesian3();
+
+/**
+ * Computes a new matrix that replaces the scale with the provided scale.
+ * This assumes the matrix is an affine transformation.
+ *
+ * @param {Matrix4} matrix The matrix to use.
+ * @param {Cartesian3} scale The scale that replaces the scale of the provided matrix.
+ * @param {Matrix4} result The object onto which to store the result.
+ * @returns {Matrix4} The modified result parameter.
+ *
+ * @see Matrix4.setUniformScale
+ * @see Matrix4.fromScale
+ * @see Matrix4.fromUniformScale
+ * @see Matrix4.multiplyByScale
+ * @see Matrix4.multiplyByUniformScale
+ * @see Matrix4.getScale
+ */
+Matrix4.setScale = function (matrix, scale, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("matrix", matrix);
+  Check.typeOf.object("scale", scale);
+  Check.typeOf.object("result", result);
+  //>>includeEnd('debug');
+
+  const existingScale = Matrix4.getScale(matrix, scaleScratch1);
+  const scaleRatioX = scale.x / existingScale.x;
+  const scaleRatioY = scale.y / existingScale.y;
+  const scaleRatioZ = scale.z / existingScale.y;
+
+  result[0] = matrix[0] * scaleRatioX;
+  result[1] = matrix[1] * scaleRatioX;
+  result[2] = matrix[2] * scaleRatioX;
+  result[3] = matrix[3];
+
+  result[4] = matrix[4] * scaleRatioY;
+  result[5] = matrix[5] * scaleRatioY;
+  result[6] = matrix[6] * scaleRatioY;
+  result[7] = matrix[7];
+
+  result[8] = matrix[8] * scaleRatioZ;
+  result[9] = matrix[9] * scaleRatioZ;
+  result[10] = matrix[10] * scaleRatioZ;
+  result[11] = matrix[11];
+
+  result[12] = matrix[12];
+  result[13] = matrix[13];
+  result[14] = matrix[14];
+  result[15] = matrix[15];
+
+  return result;
+};
+
+const scaleScratch2 = new Cartesian3();
+
+/**
+ * Computes a new matrix that replaces the scale with the provided uniform scale.
+ * This assumes the matrix is an affine transformation.
+ *
+ * @param {Matrix4} matrix The matrix to use.
+ * @param {Number} scale The uniform scale that replaces the scale of the provided matrix.
+ * @param {Matrix4} result The object onto which to store the result.
+ * @returns {Matrix4} The modified result parameter.
+ *
+ * @see Matrix4.setScale
+ * @see Matrix4.fromScale
+ * @see Matrix4.fromUniformScale
+ * @see Matrix4.multiplyByScale
+ * @see Matrix4.multiplyByUniformScale
+ * @see Matrix4.getScale
+ */
+Matrix4.setUniformScale = function (matrix, scale, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("matrix", matrix);
+  Check.typeOf.number("scale", scale);
+  Check.typeOf.object("result", result);
+  //>>includeEnd('debug');
+
+  const existingScale = Matrix4.getScale(matrix, scaleScratch2);
+  const scaleRatioX = scale / existingScale.x;
+  const scaleRatioY = scale / existingScale.y;
+  const scaleRatioZ = scale / existingScale.z;
+
+  result[0] = matrix[0] * scaleRatioX;
+  result[1] = matrix[1] * scaleRatioX;
+  result[2] = matrix[2] * scaleRatioX;
+  result[3] = matrix[3];
+
+  result[4] = matrix[4] * scaleRatioY;
+  result[5] = matrix[5] * scaleRatioY;
+  result[6] = matrix[6] * scaleRatioY;
+  result[7] = matrix[7];
+
+  result[8] = matrix[8] * scaleRatioZ;
+  result[9] = matrix[9] * scaleRatioZ;
+  result[10] = matrix[10] * scaleRatioZ;
+  result[11] = matrix[11];
+
+  result[12] = matrix[12];
+  result[13] = matrix[13];
+  result[14] = matrix[14];
+  result[15] = matrix[15];
+
+  return result;
+};
+
 const scratchColumn = new Cartesian3();
 
 /**
@@ -1464,6 +1585,13 @@ const scratchColumn = new Cartesian3();
  * @param {Matrix4} matrix The matrix.
  * @param {Cartesian3} result The object onto which to store the result.
  * @returns {Cartesian3} The modified result parameter
+ *
+ * @see Matrix4.multiplyByScale
+ * @see Matrix4.multiplyByUniformScale
+ * @see Matrix4.fromScale
+ * @see Matrix4.fromUniformScale
+ * @see Matrix4.setScale
+ * @see Matrix4.setUniformScale
  */
 Matrix4.getScale = function (matrix, result) {
   //>>includeStart('debug', pragmas.debug);
@@ -1483,7 +1611,7 @@ Matrix4.getScale = function (matrix, result) {
   return result;
 };
 
-const scratchScale = new Cartesian3();
+const scaleScratch3 = new Cartesian3();
 
 /**
  * Computes the maximum scale assuming the matrix is an affine transformation.
@@ -1494,8 +1622,86 @@ const scratchScale = new Cartesian3();
  * @returns {Number} The maximum scale.
  */
 Matrix4.getMaximumScale = function (matrix) {
-  Matrix4.getScale(matrix, scratchScale);
-  return Cartesian3.maximumComponent(scratchScale);
+  Matrix4.getScale(matrix, scaleScratch3);
+  return Cartesian3.maximumComponent(scaleScratch3);
+};
+
+const scaleScratch4 = new Cartesian3();
+
+/**
+ * Sets the rotation assuming the matrix is an affine transformation.
+ *
+ * @param {Matrix4} matrix The matrix.
+ * @param {Matrix4} rotation The rotation matrix.
+ * @returns {Matrix4} The modified result parameter.
+ *
+ * @see Matrix4.fromRotation
+ * @see Matrix4.getRotation
+ */
+Matrix4.setRotation = function (matrix, rotation, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("matrix", matrix);
+  Check.typeOf.object("result", result);
+  //>>includeEnd('debug');
+
+  const scale = Matrix4.getScale(matrix, scaleScratch4);
+
+  result[0] = rotation[0] * scale.x;
+  result[1] = rotation[1] * scale.x;
+  result[2] = rotation[2] * scale.x;
+  result[3] = matrix[3];
+
+  result[4] = rotation[3] * scale.y;
+  result[5] = rotation[4] * scale.y;
+  result[6] = rotation[5] * scale.y;
+  result[7] = matrix[7];
+
+  result[8] = rotation[6] * scale.z;
+  result[9] = rotation[7] * scale.z;
+  result[10] = rotation[8] * scale.z;
+  result[11] = matrix[11];
+
+  result[12] = matrix[12];
+  result[13] = matrix[13];
+  result[14] = matrix[14];
+  result[15] = matrix[15];
+
+  return result;
+};
+
+const scaleScratch5 = new Cartesian3();
+
+/**
+ * Extracts the rotation matrix assuming the matrix is an affine transformation.
+ *
+ * @param {Matrix4} matrix The matrix.
+ * @param {Matrix4} result The object onto which to store the result.
+ * @returns {Matrix4} The modified result parameter.
+ *
+ * @see Matrix4.setRotation
+ * @see Matrix4.fromRotation
+ */
+Matrix4.getRotation = function (matrix, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("matrix", matrix);
+  Check.typeOf.object("result", result);
+  //>>includeEnd('debug');
+
+  const scale = Matrix4.getScale(matrix, scaleScratch5);
+
+  result[0] = matrix[0] / scale.x;
+  result[1] = matrix[1] / scale.x;
+  result[2] = matrix[2] / scale.x;
+
+  result[3] = matrix[4] / scale.y;
+  result[4] = matrix[5] / scale.y;
+  result[5] = matrix[6] / scale.y;
+
+  result[6] = matrix[8] / scale.z;
+  result[7] = matrix[9] / scale.z;
+  result[8] = matrix[10] / scale.z;
+
+  return result;
 };
 
 /**
@@ -1880,41 +2086,6 @@ Matrix4.multiplyByTranslation = function (matrix, translation, result) {
   return result;
 };
 
-const uniformScaleScratch = new Cartesian3();
-
-/**
- * Multiplies an affine transformation matrix (with a bottom row of <code>[0.0, 0.0, 0.0, 1.0]</code>)
- * by an implicit uniform scale matrix.  This is an optimization
- * for <code>Matrix4.multiply(m, Matrix4.fromUniformScale(scale), m);</code>, where
- * <code>m</code> must be an affine matrix.
- * This function performs fewer allocations and arithmetic operations.
- *
- * @param {Matrix4} matrix The affine matrix on the left-hand side.
- * @param {Number} scale The uniform scale on the right-hand side.
- * @param {Matrix4} result The object onto which to store the result.
- * @returns {Matrix4} The modified result parameter.
- *
- *
- * @example
- * // Instead of Cesium.Matrix4.multiply(m, Cesium.Matrix4.fromUniformScale(scale), m);
- * Cesium.Matrix4.multiplyByUniformScale(m, scale, m);
- *
- * @see Matrix4.fromUniformScale
- * @see Matrix4.multiplyByScale
- */
-Matrix4.multiplyByUniformScale = function (matrix, scale, result) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.object("matrix", matrix);
-  Check.typeOf.number("scale", scale);
-  Check.typeOf.object("result", result);
-  //>>includeEnd('debug');
-
-  uniformScaleScratch.x = scale;
-  uniformScaleScratch.y = scale;
-  uniformScaleScratch.z = scale;
-  return Matrix4.multiplyByScale(matrix, uniformScaleScratch, result);
-};
-
 /**
  * Multiplies an affine transformation matrix (with a bottom row of <code>[0.0, 0.0, 0.0, 1.0]</code>)
  * by an implicit non-uniform scale matrix. This is an optimization
@@ -1932,8 +2103,12 @@ Matrix4.multiplyByUniformScale = function (matrix, scale, result) {
  * // Instead of Cesium.Matrix4.multiply(m, Cesium.Matrix4.fromScale(scale), m);
  * Cesium.Matrix4.multiplyByScale(m, scale, m);
  *
- * @see Matrix4.fromScale
  * @see Matrix4.multiplyByUniformScale
+ * @see Matrix4.fromScale
+ * @see Matrix4.fromUniformScale
+ * @see Matrix4.setScale
+ * @see Matrix4.setUniformScale
+ * @see Matrix4.getScale
  */
 Matrix4.multiplyByScale = function (matrix, scale, result) {
   //>>includeStart('debug', pragmas.debug);
@@ -1954,19 +2129,72 @@ Matrix4.multiplyByScale = function (matrix, scale, result) {
   result[0] = scaleX * matrix[0];
   result[1] = scaleX * matrix[1];
   result[2] = scaleX * matrix[2];
-  result[3] = 0.0;
+  result[3] = matrix[3];
+
   result[4] = scaleY * matrix[4];
   result[5] = scaleY * matrix[5];
   result[6] = scaleY * matrix[6];
-  result[7] = 0.0;
+  result[7] = matrix[7];
+
   result[8] = scaleZ * matrix[8];
   result[9] = scaleZ * matrix[9];
   result[10] = scaleZ * matrix[10];
-  result[11] = 0.0;
+  result[11] = matrix[11];
+
   result[12] = matrix[12];
   result[13] = matrix[13];
   result[14] = matrix[14];
-  result[15] = 1.0;
+  result[15] = matrix[15];
+
+  return result;
+};
+
+/**
+ * Computes the product of a matrix times a uniform scale, as if the scale were a scale matrix.
+ *
+ * @param {Matrix4} matrix The matrix on the left-hand side.
+ * @param {Number} scale The uniform scale on the right-hand side.
+ * @param {Matrix4} result The object onto which to store the result.
+ * @returns {Matrix4} The modified result parameter.
+ *
+ * @example
+ * // Instead of Cesium.Matrix4.multiply(m, Cesium.Matrix4.fromUniformScale(scale), m);
+ * Cesium.Matrix4.multiplyByUniformScale(m, scale, m);
+ *
+ * @see Matrix4.multiplyByScale
+ * @see Matrix4.fromScale
+ * @see Matrix4.fromUniformScale
+ * @see Matrix4.setScale
+ * @see Matrix4.setUniformScale
+ * @see Matrix4.getScale
+ */
+Matrix4.multiplyByUniformScale = function (matrix, scale, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("matrix", matrix);
+  Check.typeOf.number("scale", scale);
+  Check.typeOf.object("result", result);
+  //>>includeEnd('debug');
+
+  result[0] = matrix[0] * scale;
+  result[1] = matrix[1] * scale;
+  result[2] = matrix[2] * scale;
+  result[3] = matrix[3];
+
+  result[4] = matrix[4] * scale;
+  result[5] = matrix[5] * scale;
+  result[6] = matrix[6] * scale;
+  result[7] = matrix[7];
+
+  result[8] = matrix[8] * scale;
+  result[9] = matrix[9] * scale;
+  result[10] = matrix[10] * scale;
+  result[11] = matrix[11];
+
+  result[12] = matrix[12];
+  result[13] = matrix[13];
+  result[14] = matrix[14];
+  result[15] = matrix[15];
+
   return result;
 };
 

--- a/Specs/Core/BoundingRectangleSpec.js
+++ b/Specs/Core/BoundingRectangleSpec.js
@@ -281,7 +281,7 @@ describe("Core/BoundingRectangle", function () {
     }).toThrowDeveloperError();
   });
 
-  it("intersect  throws with no right parameter", function () {
+  it("intersect throws with no right parameter", function () {
     const left = new BoundingRectangle(1.0, 2.0, 3.0, 4.0);
     expect(function () {
       BoundingRectangle.intersect(left, undefined);

--- a/Specs/Core/Matrix2Spec.js
+++ b/Specs/Core/Matrix2Spec.js
@@ -118,12 +118,6 @@ describe("Core/Matrix2", function () {
     expect(matrix).toEqualEpsilon(expected, CesiumMath.EPSILON15);
   });
 
-  it("fromRotation throws without angle", function () {
-    expect(function () {
-      Matrix2.fromRotation();
-    }).toThrowDeveloperError();
-  });
-
   it("clone works without a result parameter", function () {
     const expected = new Matrix2(1.0, 2.0, 3.0, 4.0);
     const returnedResult = expected.clone();
@@ -254,8 +248,40 @@ describe("Core/Matrix2", function () {
     expect(result).toEqual(expected);
   });
 
+  it("setScale works", function () {
+    const matrix = Matrix2.clone(Matrix2.IDENTITY);
+    const result = new Matrix2();
+    const newScale = new Cartesian2(2.0, 3.0);
+
+    expect(Matrix2.getScale(matrix, new Cartesian2())).toEqual(Cartesian2.ONE);
+
+    const returnedResult = Matrix2.setScale(matrix, newScale, result);
+
+    expect(Matrix2.getScale(returnedResult, new Cartesian2())).toEqual(
+      newScale
+    );
+    expect(result).toBe(returnedResult);
+  });
+
+  it("setUniformScale works", function () {
+    const oldScale = new Cartesian2(2.0, 3.0);
+    const newScale = 4.0;
+
+    const matrix = Matrix2.fromScale(oldScale, new Matrix2());
+    const result = new Matrix2();
+
+    expect(Matrix2.getScale(matrix, new Cartesian2())).toEqual(oldScale);
+
+    const returnedResult = Matrix2.setUniformScale(matrix, newScale, result);
+
+    expect(Matrix2.getScale(returnedResult, new Cartesian2())).toEqual(
+      new Cartesian2(newScale, newScale)
+    );
+    expect(result).toBe(returnedResult);
+  });
+
   it("getScale works", function () {
-    const scale = new Cartesian2(1.0, 2.0);
+    const scale = new Cartesian2(2.0, 3.0);
     const result = new Cartesian2();
     const computedScale = Matrix2.getScale(Matrix2.fromScale(scale), result);
 
@@ -263,24 +289,52 @@ describe("Core/Matrix2", function () {
     expect(computedScale).toEqualEpsilon(scale, CesiumMath.EPSILON14);
   });
 
-  it("getScale throws without a matrix", function () {
-    expect(function () {
-      Matrix2.getScale();
-    }).toThrowDeveloperError();
-  });
-
   it("getMaximumScale works", function () {
-    const m = Matrix2.fromScale(new Cartesian2(1.0, 2.0));
+    const m = Matrix2.fromScale(new Cartesian2(2.0, 3.0));
     expect(Matrix2.getMaximumScale(m)).toEqualEpsilon(
-      2.0,
+      3.0,
       CesiumMath.EPSILON14
     );
   });
 
-  it("getMaximumScale throws without a matrix", function () {
-    expect(function () {
-      Matrix2.getMaximumScale();
-    }).toThrowDeveloperError();
+  it("setRotation works", function () {
+    const scaleVec = new Cartesian2(2.0, 3.0);
+    const scale = Matrix2.fromScale(scaleVec, new Matrix2());
+    const rotation = Matrix2.fromRotation(0.5, new Matrix2());
+    const scaleRotation = Matrix2.setRotation(scale, rotation, new Matrix2());
+
+    const extractedScale = Matrix2.getScale(scaleRotation, new Cartesian2());
+    const extractedRotation = Matrix2.getRotation(scaleRotation, new Matrix2());
+
+    expect(extractedScale).toEqualEpsilon(scaleVec, CesiumMath.EPSILON14);
+    expect(extractedRotation).toEqualEpsilon(rotation, CesiumMath.EPSILON14);
+  });
+
+  it("getRotation returns matrix without scale", function () {
+    const matrix = Matrix2.fromColumnMajorArray([1.0, 2.0, 3.0, 4.0]);
+    const expectedRotation = Matrix2.fromArray([
+      1.0 / Math.sqrt(1.0 * 1.0 + 2.0 * 2.0),
+      2.0 / Math.sqrt(1.0 * 1.0 + 2.0 * 2.0),
+      3.0 / Math.sqrt(3.0 * 3.0 + 4.0 * 4.0),
+      4.0 / Math.sqrt(3.0 * 3.0 + 4.0 * 4.0),
+    ]);
+    const rotation = Matrix2.getRotation(matrix, new Matrix2());
+    expect(rotation).toEqualEpsilon(expectedRotation, CesiumMath.EPSILON14);
+  });
+
+  it("getRotation does not modify rotation matrix", function () {
+    const matrix = Matrix2.fromColumnMajorArray([1.0, 2.0, 3.0, 4.0]);
+    const duplicateMatrix = Matrix2.clone(matrix, new Matrix2());
+    const expectedRotation = Matrix2.fromArray([
+      1.0 / Math.sqrt(1.0 * 1.0 + 2.0 * 2.0),
+      2.0 / Math.sqrt(1.0 * 1.0 + 2.0 * 2.0),
+      3.0 / Math.sqrt(3.0 * 3.0 + 4.0 * 4.0),
+      4.0 / Math.sqrt(3.0 * 3.0 + 4.0 * 4.0),
+    ]);
+    const result = Matrix2.getRotation(matrix, new Matrix2());
+    expect(result).toEqualEpsilon(expectedRotation, CesiumMath.EPSILON14);
+    expect(matrix).toEqual(duplicateMatrix);
+    expect(matrix).not.toBe(result);
   });
 
   it("multiply works", function () {
@@ -367,6 +421,33 @@ describe("Core/Matrix2", function () {
     expect(m).toEqual(expected);
   });
 
+  it("multiplyByUniformScale works", function () {
+    const m = new Matrix2(2, 3, 4, 5);
+    const scale = 2.0;
+    const expected = Matrix2.multiply(
+      m,
+      Matrix2.fromUniformScale(scale),
+      new Matrix2()
+    );
+    const result = new Matrix2();
+    const returnedResult = Matrix2.multiplyByUniformScale(m, scale, result);
+    expect(returnedResult).toBe(result);
+    expect(result).toEqual(expected);
+  });
+
+  it('multiplyByUniformScale works with "this" result parameter', function () {
+    const m = new Matrix2(2, 3, 4, 5);
+    const scale = 2.0;
+    const expected = Matrix2.multiply(
+      m,
+      Matrix2.fromUniformScale(scale),
+      new Matrix2()
+    );
+    const returnedResult = Matrix2.multiplyByUniformScale(m, scale, m);
+    expect(returnedResult).toBe(m);
+    expect(m).toEqual(expected);
+  });
+
   it("multiplyByVector works", function () {
     const left = new Matrix2(1, 2, 3, 4);
     const right = new Cartesian2(5, 6);
@@ -419,12 +500,6 @@ describe("Core/Matrix2", function () {
     const returnedResult = Matrix2.transpose(matrix, matrix);
     expect(matrix).toBe(returnedResult);
     expect(matrix).toEqual(expected);
-  });
-
-  it("abs throws without a matrix", function () {
-    expect(function () {
-      return Matrix2.abs();
-    }).toThrowDeveloperError();
   });
 
   it("abs works", function () {
@@ -546,6 +621,12 @@ describe("Core/Matrix2", function () {
     }).toThrowDeveloperError();
   });
 
+  it("fromRotation throws without angle", function () {
+    expect(function () {
+      Matrix2.fromRotation();
+    }).toThrowDeveloperError();
+  });
+
   it("clone returns undefined without matrix parameter", function () {
     expect(Matrix2.clone(undefined)).toBeUndefined();
   });
@@ -578,7 +659,7 @@ describe("Core/Matrix2", function () {
     }).toThrowDeveloperError();
   });
 
-  it("getColumn throws without of range index parameter", function () {
+  it("getColumn throws with out of range index parameter", function () {
     const matrix = new Matrix2();
     expect(function () {
       Matrix2.getColumn(matrix, 2);
@@ -599,7 +680,7 @@ describe("Core/Matrix2", function () {
     }).toThrowDeveloperError();
   });
 
-  it("setColumn throws without of range index parameter", function () {
+  it("setColumn throws with out of range index parameter", function () {
     const matrix = new Matrix2();
     const cartesian = new Cartesian2();
     expect(function () {
@@ -613,7 +694,7 @@ describe("Core/Matrix2", function () {
     }).toThrowDeveloperError();
   });
 
-  it("getRow throws without of range index parameter", function () {
+  it("getRow throws with out of range index parameter", function () {
     const matrix = new Matrix2();
     expect(function () {
       Matrix2.getRow(matrix, 2);
@@ -634,11 +715,65 @@ describe("Core/Matrix2", function () {
     }).toThrowDeveloperError();
   });
 
-  it("setRow throws without of range index parameter", function () {
+  it("setRow throws with out of range index parameter", function () {
     const matrix = new Matrix2();
     const cartesian = new Cartesian2();
     expect(function () {
       Matrix2.setRow(matrix, 2, cartesian);
+    }).toThrowDeveloperError();
+  });
+
+  it("setScale throws without a matrix", function () {
+    expect(function () {
+      Matrix2.setScale();
+    }).toThrowDeveloperError();
+  });
+
+  it("setScale throws without a scale", function () {
+    expect(function () {
+      Matrix2.setScale(new Matrix2());
+    }).toThrowDeveloperError();
+  });
+
+  it("setUniformScale throws without a matrix", function () {
+    expect(function () {
+      Matrix2.setUniformScale();
+    }).toThrowDeveloperError();
+  });
+
+  it("setUniformScale throws without a scale", function () {
+    expect(function () {
+      Matrix2.setUniformScale(new Matrix2());
+    }).toThrowDeveloperError();
+  });
+
+  it("getScale throws without a matrix", function () {
+    expect(function () {
+      Matrix2.getScale();
+    }).toThrowDeveloperError();
+  });
+
+  it("getMaximumScale throws without a matrix", function () {
+    expect(function () {
+      Matrix2.getMaximumScale();
+    }).toThrowDeveloperError();
+  });
+
+  it("setRotation throws without a matrix", function () {
+    expect(function () {
+      return Matrix2.setRotation();
+    }).toThrowDeveloperError();
+  });
+
+  it("setRotation throws without a rotation", function () {
+    expect(function () {
+      return Matrix2.setRotation(new Matrix2());
+    }).toThrowDeveloperError();
+  });
+
+  it("getRotation throws without a matrix", function () {
+    expect(function () {
+      return Matrix2.getRotation();
     }).toThrowDeveloperError();
   });
 
@@ -666,6 +801,19 @@ describe("Core/Matrix2", function () {
     const m = new Matrix2();
     expect(function () {
       Matrix2.multiplyByScale(m, undefined);
+    }).toThrowDeveloperError();
+  });
+
+  it("multiplyByUniformScale throws with no matrix parameter", function () {
+    expect(function () {
+      Matrix2.multiplyByUniformScale(undefined, new Cartesian2());
+    }).toThrowDeveloperError();
+  });
+
+  it("multiplyByUniformScale throws with no scale parameter", function () {
+    const m = new Matrix2();
+    expect(function () {
+      Matrix2.multiplyByUniformScale(m, undefined);
     }).toThrowDeveloperError();
   });
 
@@ -708,73 +856,109 @@ describe("Core/Matrix2", function () {
     }).toThrowDeveloperError();
   });
 
-  it("getColumn throws without result parameter", function () {
+  it("abs throws without a matrix", function () {
+    expect(function () {
+      return Matrix2.abs();
+    }).toThrowDeveloperError();
+  });
+
+  it("getColumn throws without a result parameter", function () {
     expect(function () {
       Matrix2.getColumn(new Matrix2(), 1);
     }).toThrowDeveloperError();
   });
 
-  it("setColumn throws without result parameter", function () {
+  it("setColumn throws without a result parameter", function () {
     expect(function () {
       Matrix2.setColumn(new Matrix2(), 1, new Cartesian2());
     }).toThrowDeveloperError();
   });
 
-  it("getRow throws without result parameter", function () {
+  it("getRow throws without a result parameter", function () {
     expect(function () {
       Matrix2.getRow(new Matrix2(), 1);
     }).toThrowDeveloperError();
   });
 
-  it("setRow throws without result parameter", function () {
+  it("setRow throws without a result parameter", function () {
     expect(function () {
       Matrix2.setRow(new Matrix2(), 1, new Cartesian2());
     }).toThrowDeveloperError();
   });
 
-  it("getScale throws without result parameter", function () {
+  it("setScale throws without a result parameter", function () {
+    expect(function () {
+      Matrix2.setScale(new Matrix2(), new Cartesian2());
+    }).toThrowDeveloperError();
+  });
+
+  it("setUniformScale throws without a result parameter", function () {
+    expect(function () {
+      Matrix2.setUniformScale(new Matrix2(), 1.0);
+    }).toThrowDeveloperError();
+  });
+
+  it("getScale throws without a result parameter", function () {
     expect(function () {
       Matrix2.getScale(new Matrix2());
     }).toThrowDeveloperError();
   });
 
-  it("multiply throws without result parameter", function () {
+  it("setRotation throws without a result parameter", function () {
+    expect(function () {
+      return Matrix2.setRotation(new Matrix2(), new Matrix2());
+    }).toThrowDeveloperError();
+  });
+
+  it("getRotation throws without a result parameter", function () {
+    expect(function () {
+      return Matrix2.getRotation(new Matrix2());
+    }).toThrowDeveloperError();
+  });
+
+  it("multiply throws without a result parameter", function () {
     expect(function () {
       Matrix2.multiply(new Matrix2(), new Matrix2());
     }).toThrowDeveloperError();
   });
 
-  it("multiplyByScale throws without result parameter", function () {
+  it("multiplyByScale throws without a result parameter", function () {
     expect(function () {
       Matrix2.multiplyByScale(new Matrix2(), new Cartesian2());
     }).toThrowDeveloperError();
   });
 
-  it("multiplyByVector throws without result parameter", function () {
+  it("multiplyByUniformScale throws without a result parameter", function () {
+    expect(function () {
+      Matrix2.multiplyByUniformScale(new Matrix2(), new Cartesian2());
+    }).toThrowDeveloperError();
+  });
+
+  it("multiplyByVector throws without a result parameter", function () {
     expect(function () {
       Matrix2.multiplyByVector(new Matrix2(), new Cartesian2());
     }).toThrowDeveloperError();
   });
 
-  it("multiplyByScalar throws without result parameter", function () {
+  it("multiplyByScalar throws without a result parameter", function () {
     expect(function () {
       Matrix2.multiplyByScalar(new Matrix2(), 2);
     }).toThrowDeveloperError();
   });
 
-  it("negate throws without result parameter", function () {
+  it("negate throws without a result parameter", function () {
     expect(function () {
       Matrix2.negate(new Matrix2());
     }).toThrowDeveloperError();
   });
 
-  it("transpose throws without result parameter", function () {
+  it("transpose throws without a result parameter", function () {
     expect(function () {
       Matrix2.transpose(new Matrix2());
     }).toThrowDeveloperError();
   });
 
-  it("abs throws without result parameter", function () {
+  it("abs throws without a result parameter", function () {
     expect(function () {
       Matrix2.abs(new Matrix2());
     }).toThrowDeveloperError();

--- a/Specs/Core/Matrix3Spec.js
+++ b/Specs/Core/Matrix3Spec.js
@@ -390,12 +390,6 @@ describe("Core/Matrix3", function () {
     expect(matrix).toEqualEpsilon(expected, CesiumMath.EPSILON15);
   });
 
-  it("fromRotationX throws without angle", function () {
-    expect(function () {
-      Matrix3.fromRotationX();
-    }).toThrowDeveloperError();
-  });
-
   it("fromRotationY works without a result parameter", function () {
     const matrix = Matrix3.fromRotationY(0.0);
     expect(matrix).toEqual(Matrix3.IDENTITY);
@@ -409,12 +403,6 @@ describe("Core/Matrix3", function () {
     expect(matrix).toEqualEpsilon(expected, CesiumMath.EPSILON15);
   });
 
-  it("fromRotationY throws without angle", function () {
-    expect(function () {
-      Matrix3.fromRotationY();
-    }).toThrowDeveloperError();
-  });
-
   it("fromRotationZ works without a result parameter", function () {
     const matrix = Matrix3.fromRotationZ(0.0);
     expect(matrix).toEqual(Matrix3.IDENTITY);
@@ -426,12 +414,6 @@ describe("Core/Matrix3", function () {
     const matrix = Matrix3.fromRotationZ(CesiumMath.toRadians(90.0), result);
     expect(matrix).toBe(result);
     expect(matrix).toEqualEpsilon(expected, CesiumMath.EPSILON15);
-  });
-
-  it("fromRotationZ throws without angle", function () {
-    expect(function () {
-      Matrix3.fromRotationZ();
-    }).toThrowDeveloperError();
   });
 
   it("clone works without a result parameter", function () {
@@ -594,8 +576,40 @@ describe("Core/Matrix3", function () {
     expect(result).toEqual(expected);
   });
 
+  it("setScale works", function () {
+    const matrix = Matrix3.clone(Matrix3.IDENTITY);
+    const result = new Matrix3();
+    const newScale = new Cartesian3(2.0, 3.0, 4.0);
+
+    expect(Matrix3.getScale(matrix, new Cartesian3())).toEqual(Cartesian3.ONE);
+
+    const returnedResult = Matrix3.setScale(matrix, newScale, result);
+
+    expect(Matrix3.getScale(returnedResult, new Cartesian3())).toEqual(
+      newScale
+    );
+    expect(result).toBe(returnedResult);
+  });
+
+  it("setUniformScale works", function () {
+    const oldScale = new Cartesian3(2.0, 3.0, 4.0);
+    const newScale = 5.0;
+
+    const matrix = Matrix3.fromScale(oldScale, new Matrix3());
+    const result = new Matrix3();
+
+    expect(Matrix3.getScale(matrix, new Cartesian3())).toEqual(oldScale);
+
+    const returnedResult = Matrix3.setUniformScale(matrix, newScale, result);
+
+    expect(Matrix3.getScale(returnedResult, new Cartesian3())).toEqual(
+      new Cartesian3(newScale, newScale, newScale)
+    );
+    expect(result).toBe(returnedResult);
+  });
+
   it("getScale works", function () {
-    const scale = new Cartesian3(1.0, 2.0, 3.0);
+    const scale = new Cartesian3(2.0, 3.0, 4.0);
     const result = new Cartesian3();
     const computedScale = Matrix3.getScale(Matrix3.fromScale(scale), result);
 
@@ -603,24 +617,82 @@ describe("Core/Matrix3", function () {
     expect(computedScale).toEqualEpsilon(scale, CesiumMath.EPSILON14);
   });
 
-  it("getScale throws without a matrix", function () {
-    expect(function () {
-      Matrix3.getScale();
-    }).toThrowDeveloperError();
-  });
-
   it("getMaximumScale works", function () {
-    const m = Matrix3.fromScale(new Cartesian3(1.0, 2.0, 3.0));
+    const m = Matrix3.fromScale(new Cartesian3(2.0, 3.0, 4.0));
     expect(Matrix3.getMaximumScale(m)).toEqualEpsilon(
-      3.0,
+      4.0,
       CesiumMath.EPSILON14
     );
   });
 
-  it("getMaximumScale throws without a matrix", function () {
-    expect(function () {
-      Matrix3.getMaximumScale();
-    }).toThrowDeveloperError();
+  it("setRotation works", function () {
+    const scaleVec = new Cartesian3(2.0, 3.0, 4.0);
+    const scale = Matrix3.fromScale(scaleVec, new Matrix3());
+    const rotation = Matrix3.fromRotationX(0.5, new Matrix3());
+    const scaleRotation = Matrix3.setRotation(scale, rotation, new Matrix3());
+
+    const extractedScale = Matrix3.getScale(scaleRotation, new Cartesian3());
+    const extractedRotation = Matrix3.getRotation(scaleRotation, new Matrix3());
+
+    expect(extractedScale).toEqualEpsilon(scaleVec, CesiumMath.EPSILON14);
+    expect(extractedRotation).toEqualEpsilon(rotation, CesiumMath.EPSILON14);
+  });
+
+  it("getRotation returns matrix without scale", function () {
+    const matrix = Matrix3.fromColumnMajorArray([
+      1.0,
+      2.0,
+      3.0,
+      4.0,
+      5.0,
+      6.0,
+      7.0,
+      8.0,
+      9.0,
+    ]);
+    const expectedRotation = Matrix3.fromArray([
+      1.0 / Math.sqrt(1.0 * 1.0 + 2.0 * 2.0 + 3.0 * 3.0),
+      2.0 / Math.sqrt(1.0 * 1.0 + 2.0 * 2.0 + 3.0 * 3.0),
+      3.0 / Math.sqrt(1.0 * 1.0 + 2.0 * 2.0 + 3.0 * 3.0),
+      4.0 / Math.sqrt(4.0 * 4.0 + 5.0 * 5.0 + 6.0 * 6.0),
+      5.0 / Math.sqrt(4.0 * 4.0 + 5.0 * 5.0 + 6.0 * 6.0),
+      6.0 / Math.sqrt(4.0 * 4.0 + 5.0 * 5.0 + 6.0 * 6.0),
+      7.0 / Math.sqrt(7.0 * 7.0 + 8.0 * 8.0 + 9.0 * 9.0),
+      8.0 / Math.sqrt(7.0 * 7.0 + 8.0 * 8.0 + 9.0 * 9.0),
+      9.0 / Math.sqrt(7.0 * 7.0 + 8.0 * 8.0 + 9.0 * 9.0),
+    ]);
+    const rotation = Matrix3.getRotation(matrix, new Matrix3());
+    expect(rotation).toEqualEpsilon(expectedRotation, CesiumMath.EPSILON14);
+  });
+
+  it("getRotation does not modify rotation matrix", function () {
+    const matrix = Matrix3.fromColumnMajorArray([
+      1.0,
+      2.0,
+      3.0,
+      4.0,
+      5.0,
+      6.0,
+      7.0,
+      8.0,
+      9.0,
+    ]);
+    const duplicateMatrix = Matrix3.clone(matrix, new Matrix3());
+    const expectedRotation = Matrix3.fromArray([
+      1.0 / Math.sqrt(1.0 * 1.0 + 2.0 * 2.0 + 3.0 * 3.0),
+      2.0 / Math.sqrt(1.0 * 1.0 + 2.0 * 2.0 + 3.0 * 3.0),
+      3.0 / Math.sqrt(1.0 * 1.0 + 2.0 * 2.0 + 3.0 * 3.0),
+      4.0 / Math.sqrt(4.0 * 4.0 + 5.0 * 5.0 + 6.0 * 6.0),
+      5.0 / Math.sqrt(4.0 * 4.0 + 5.0 * 5.0 + 6.0 * 6.0),
+      6.0 / Math.sqrt(4.0 * 4.0 + 5.0 * 5.0 + 6.0 * 6.0),
+      7.0 / Math.sqrt(7.0 * 7.0 + 8.0 * 8.0 + 9.0 * 9.0),
+      8.0 / Math.sqrt(7.0 * 7.0 + 8.0 * 8.0 + 9.0 * 9.0),
+      9.0 / Math.sqrt(7.0 * 7.0 + 8.0 * 8.0 + 9.0 * 9.0),
+    ]);
+    const result = Matrix3.getRotation(matrix, new Matrix3());
+    expect(result).toEqualEpsilon(expectedRotation, CesiumMath.EPSILON14);
+    expect(matrix).toEqual(duplicateMatrix);
+    expect(matrix).not.toBe(result);
   });
 
   it("multiply works", function () {
@@ -707,6 +779,33 @@ describe("Core/Matrix3", function () {
     expect(m).toEqual(expected);
   });
 
+  it("multiplyByUniformScale works", function () {
+    const m = new Matrix3(2, 3, 4, 5, 6, 7, 8, 9, 10);
+    const scale = 2.0;
+    const expected = Matrix3.multiply(
+      m,
+      Matrix3.fromUniformScale(scale),
+      new Matrix3()
+    );
+    const result = new Matrix3();
+    const returnedResult = Matrix3.multiplyByUniformScale(m, scale, result);
+    expect(returnedResult).toBe(result);
+    expect(result).toEqual(expected);
+  });
+
+  it('multiplyByUniformScale works with "this" result parameter', function () {
+    const m = new Matrix3(2, 3, 4, 5, 6, 7, 8, 9, 10);
+    const scale = 2.0;
+    const expected = Matrix3.multiply(
+      m,
+      Matrix3.fromUniformScale(scale),
+      new Matrix3()
+    );
+    const returnedResult = Matrix3.multiplyByUniformScale(m, scale, m);
+    expect(returnedResult).toBe(m);
+    expect(m).toEqual(expected);
+  });
+
   it("multiplyByVector works", function () {
     const left = new Matrix3(1, 2, 3, 4, 5, 6, 7, 8, 9);
     const right = new Cartesian3(10, 11, 12);
@@ -784,52 +883,6 @@ describe("Core/Matrix3", function () {
     expect(result).toEqual(expectedInverseTranspose);
   });
 
-  it("getRotation returns matrix without scale", function () {
-    const matrix = new Matrix3(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
-    let result = new Matrix3();
-    const expected = Matrix3.fromArray([
-      0.12309149097933272,
-      0.4923659639173309,
-      0.8616404368553291,
-      0.20739033894608505,
-      0.5184758473652127,
-      0.8295613557843402,
-      0.2672612419124244,
-      0.5345224838248488,
-      0.8017837257372732,
-    ]);
-    const scale = new Cartesian3();
-    const expectedScale = new Cartesian3(1.0, 1.0, 1.0);
-    result = Matrix3.getRotation(matrix, result);
-    const resultScale = Matrix3.getScale(result, scale);
-    expect(resultScale).toEqualEpsilon(expectedScale, CesiumMath.EPSILON14);
-    expect(result).toEqualEpsilon(expected, CesiumMath.EPSILON14);
-  });
-
-  it("getRotation does not modify rotation matrix", function () {
-    const tmp = new Matrix3();
-    let result = new Matrix3();
-    const rotation = Matrix3.clone(Matrix3.IDENTITY, new Matrix3());
-    Matrix3.multiply(rotation, Matrix3.fromRotationX(1.0, tmp), rotation);
-    Matrix3.multiply(rotation, Matrix3.fromRotationY(2.0, tmp), rotation);
-    Matrix3.multiply(rotation, Matrix3.fromRotationZ(3.0, tmp), rotation);
-    result = Matrix3.getRotation(rotation, result);
-    expect(rotation).toEqualEpsilon(result, CesiumMath.EPSILON14);
-    expect(rotation).not.toBe(result);
-  });
-
-  it("getRotation throws without a matrix", function () {
-    expect(function () {
-      return Matrix3.getRotation();
-    }).toThrowDeveloperError();
-  });
-
-  it("getRotation throws without a result", function () {
-    expect(function () {
-      return Matrix3.getRotation(new Matrix3());
-    }).toThrowDeveloperError();
-  });
-
   it("transpose works with a result parameter that is an input result parameter", function () {
     const matrix = new Matrix3(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
     const expected = new Matrix3(1.0, 4.0, 7.0, 2.0, 5.0, 8.0, 3.0, 6.0, 9.0);
@@ -880,12 +933,6 @@ describe("Core/Matrix3", function () {
     const returnedResult = Matrix3.inverse(matrix, matrix);
     expect(matrix).toBe(returnedResult);
     expect(matrix).toEqual(expected);
-  });
-
-  it("computeEigenDecomposition throws without a matrix", function () {
-    expect(function () {
-      return Matrix3.computeEigenDecomposition();
-    }).toThrowDeveloperError();
   });
 
   it("computes eigenvalues and eigenvectors", function () {
@@ -991,12 +1038,6 @@ describe("Core/Matrix3", function () {
       Matrix3.multiplyByVector(a, v, new Cartesian3()),
       CesiumMath.EPSILON14
     );
-  });
-
-  it("abs throws without a matrix", function () {
-    expect(function () {
-      return Matrix3.abs();
-    }).toThrowDeveloperError();
   });
 
   it("abs works", function () {
@@ -1171,6 +1212,24 @@ describe("Core/Matrix3", function () {
     }).toThrowDeveloperError();
   });
 
+  it("fromRotationX throws without angle", function () {
+    expect(function () {
+      Matrix3.fromRotationX();
+    }).toThrowDeveloperError();
+  });
+
+  it("fromRotationY throws without angle", function () {
+    expect(function () {
+      Matrix3.fromRotationY();
+    }).toThrowDeveloperError();
+  });
+
+  it("fromRotationZ throws without angle", function () {
+    expect(function () {
+      Matrix3.fromRotationZ();
+    }).toThrowDeveloperError();
+  });
+
   it("clone returns undefined without matrix parameter", function () {
     expect(Matrix3.clone(undefined)).toBeUndefined();
   });
@@ -1203,7 +1262,7 @@ describe("Core/Matrix3", function () {
     }).toThrowDeveloperError();
   });
 
-  it("getColumn throws without of range index parameter", function () {
+  it("getColumn throws with out of range index parameter", function () {
     const matrix = new Matrix3();
     expect(function () {
       Matrix3.getColumn(matrix, 3);
@@ -1224,7 +1283,7 @@ describe("Core/Matrix3", function () {
     }).toThrowDeveloperError();
   });
 
-  it("setColumn throws without of range index parameter", function () {
+  it("setColumn throws with out of range index parameter", function () {
     const matrix = new Matrix3();
     const cartesian = new Cartesian3();
     expect(function () {
@@ -1238,7 +1297,7 @@ describe("Core/Matrix3", function () {
     }).toThrowDeveloperError();
   });
 
-  it("getRow throws without of range index parameter", function () {
+  it("getRow throws with out of range index parameter", function () {
     const matrix = new Matrix3();
     expect(function () {
       Matrix3.getRow(matrix, 3);
@@ -1259,11 +1318,65 @@ describe("Core/Matrix3", function () {
     }).toThrowDeveloperError();
   });
 
-  it("setRow throws without of range index parameter", function () {
+  it("setRow throws with out of range index parameter", function () {
     const matrix = new Matrix3();
     const cartesian = new Cartesian3();
     expect(function () {
       Matrix3.setRow(matrix, 3, cartesian);
+    }).toThrowDeveloperError();
+  });
+
+  it("setScale throws without a matrix", function () {
+    expect(function () {
+      Matrix3.setScale();
+    }).toThrowDeveloperError();
+  });
+
+  it("setScale throws without a scale", function () {
+    expect(function () {
+      Matrix3.setScale(new Matrix3());
+    }).toThrowDeveloperError();
+  });
+
+  it("setUniformScale throws without a matrix", function () {
+    expect(function () {
+      Matrix3.setUniformScale();
+    }).toThrowDeveloperError();
+  });
+
+  it("setUniformScale throws without a scale", function () {
+    expect(function () {
+      Matrix3.setUniformScale(new Matrix3());
+    }).toThrowDeveloperError();
+  });
+
+  it("getScale throws without a matrix", function () {
+    expect(function () {
+      Matrix3.getScale();
+    }).toThrowDeveloperError();
+  });
+
+  it("getMaximumScale throws without a matrix", function () {
+    expect(function () {
+      Matrix3.getMaximumScale();
+    }).toThrowDeveloperError();
+  });
+
+  it("setRotation throws without a matrix", function () {
+    expect(function () {
+      return Matrix3.setRotation();
+    }).toThrowDeveloperError();
+  });
+
+  it("setRotation throws without a rotation", function () {
+    expect(function () {
+      return Matrix3.setRotation(new Matrix3());
+    }).toThrowDeveloperError();
+  });
+
+  it("getRotation throws without a matrix", function () {
+    expect(function () {
+      return Matrix3.getRotation();
     }).toThrowDeveloperError();
   });
 
@@ -1291,6 +1404,18 @@ describe("Core/Matrix3", function () {
     const m = new Matrix3();
     expect(function () {
       Matrix3.multiplyByScale(m, undefined);
+    }).toThrowDeveloperError();
+  });
+
+  it("multiplyByUniformScale throws with no matrix parameter", function () {
+    expect(function () {
+      Matrix3.multiplyByUniformScale(undefined, new Cartesian3());
+    }).toThrowDeveloperError();
+  });
+
+  it("multiplyByUniformScale throws with no scale parameter", function () {
+    expect(function () {
+      Matrix3.multiplyByUniformScale(new Matrix3(), undefined);
     }).toThrowDeveloperError();
   });
 
@@ -1333,6 +1458,12 @@ describe("Core/Matrix3", function () {
     }).toThrowDeveloperError();
   });
 
+  it("abs throws without a matrix", function () {
+    expect(function () {
+      return Matrix3.abs();
+    }).toThrowDeveloperError();
+  });
+
   it("determinant throws without matrix parameter", function () {
     expect(function () {
       Matrix3.determinant(undefined);
@@ -1351,6 +1482,12 @@ describe("Core/Matrix3", function () {
         new Matrix3(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         new Matrix3()
       );
+    }).toThrowDeveloperError();
+  });
+
+  it("computeEigenDecomposition throws without a matrix", function () {
+    expect(function () {
+      return Matrix3.computeEigenDecomposition();
     }).toThrowDeveloperError();
   });
 
@@ -1378,79 +1515,109 @@ describe("Core/Matrix3", function () {
     }).toThrowDeveloperError();
   });
 
-  it("getColumn throws without result parameter", function () {
+  it("getColumn throws without a result parameter", function () {
     expect(function () {
       Matrix3.getColumn(new Matrix3(), 2);
     }).toThrowDeveloperError();
   });
 
-  it("setColumn throws without result parameter", function () {
+  it("setColumn throws without a result parameter", function () {
     expect(function () {
       Matrix3.setColumn(new Matrix3(), 2, new Cartesian3());
     }).toThrowDeveloperError();
   });
 
-  it("getRow throws without result parameter", function () {
+  it("getRow throws without a result parameter", function () {
     expect(function () {
       Matrix3.getRow(new Matrix3(), 2);
     }).toThrowDeveloperError();
   });
 
-  it("setRow throws without result parameter", function () {
+  it("setRow throws without a result parameter", function () {
     expect(function () {
       Matrix3.setRow(new Matrix3(), 2, new Cartesian3());
     }).toThrowDeveloperError();
   });
 
-  it("getScale throws without result parameter", function () {
+  it("setScale throws without a result parameter", function () {
+    expect(function () {
+      Matrix3.setScale(new Matrix3(), new Cartesian3());
+    }).toThrowDeveloperError();
+  });
+
+  it("setUniformScale throws without a result parameter", function () {
+    expect(function () {
+      Matrix3.setUniformScale(new Matrix3(), 1.0);
+    }).toThrowDeveloperError();
+  });
+
+  it("getScale throws without a result parameter", function () {
     expect(function () {
       Matrix3.getScale(new Matrix3());
     }).toThrowDeveloperError();
   });
 
-  it("multiply throws without result parameter", function () {
+  it("setRotation throws without a result parameter", function () {
+    expect(function () {
+      return Matrix3.setRotation(new Matrix3(), new Matrix3());
+    }).toThrowDeveloperError();
+  });
+
+  it("getRotation throws without a result parameter", function () {
+    expect(function () {
+      return Matrix3.getRotation(new Matrix3());
+    }).toThrowDeveloperError();
+  });
+
+  it("multiply throws without a result parameter", function () {
     expect(function () {
       Matrix3.multiply(new Matrix3(), new Matrix3());
     }).toThrowDeveloperError();
   });
 
-  it("multiplyByScale throws without result parameter", function () {
+  it("multiplyByScale throws without a result parameter", function () {
     expect(function () {
       Matrix3.multiplyByScale(new Matrix3(), new Cartesian3());
     }).toThrowDeveloperError();
   });
 
-  it("multiplyByVector throws without result parameter", function () {
+  it("multiplyByUniformScale throws without a result parameter", function () {
+    expect(function () {
+      Matrix3.multiplyByUniformScale(new Matrix3(), new Cartesian3());
+    }).toThrowDeveloperError();
+  });
+
+  it("multiplyByVector throws without a result parameter", function () {
     expect(function () {
       Matrix3.multiplyByVector(new Matrix3(), new Cartesian3());
     }).toThrowDeveloperError();
   });
 
-  it("multiplyByScalar throws without result parameter", function () {
+  it("multiplyByScalar throws without a result parameter", function () {
     expect(function () {
       Matrix3.multiplyByScalar(new Matrix3(), 2);
     }).toThrowDeveloperError();
   });
 
-  it("negate throws without result parameter", function () {
+  it("negate throws without a result parameter", function () {
     expect(function () {
       Matrix3.negate(new Matrix3());
     }).toThrowDeveloperError();
   });
 
-  it("transpose throws without result parameter", function () {
+  it("transpose throws without a result parameter", function () {
     expect(function () {
       Matrix3.transpose(new Matrix3());
     }).toThrowDeveloperError();
   });
 
-  it("abs throws without result parameter", function () {
+  it("abs throws without a result parameter", function () {
     expect(function () {
       Matrix3.abs(new Matrix3());
     }).toThrowDeveloperError();
   });
 
-  it("inverse throws without result parameter", function () {
+  it("inverse throws without a result parameter", function () {
     expect(function () {
       Matrix3.inverse(new Matrix3());
     }).toThrowDeveloperError();

--- a/Specs/Core/Matrix4Spec.js
+++ b/Specs/Core/Matrix4Spec.js
@@ -757,6 +757,80 @@ describe("Core/Matrix4", function () {
     expect(returnedResult).toEqual(expected);
   });
 
+  it("fromRotation works without a result parameter", function () {
+    const expected = Matrix4.fromColumnMajorArray([
+      1.0,
+      2.0,
+      3.0,
+      0.0,
+      4.0,
+      5.0,
+      6.0,
+      0.0,
+      7.0,
+      8.0,
+      9.0,
+      0.0,
+      0.0,
+      0.0,
+      0.0,
+      1.0,
+    ]);
+    const returnedResult = Matrix4.fromRotation(
+      Matrix3.fromColumnMajorArray([
+        1.0,
+        2.0,
+        3.0,
+        4.0,
+        5.0,
+        6.0,
+        7.0,
+        8.0,
+        9.0,
+      ])
+    );
+    expect(returnedResult).toEqual(expected);
+  });
+
+  it("fromRotation works with a result parameter", function () {
+    const expected = Matrix4.fromColumnMajorArray([
+      1.0,
+      2.0,
+      3.0,
+      0.0,
+      4.0,
+      5.0,
+      6.0,
+      0.0,
+      7.0,
+      8.0,
+      9.0,
+      0.0,
+      0.0,
+      0.0,
+      0.0,
+      1.0,
+    ]);
+
+    const result = new Matrix4();
+    const returnedResult = Matrix4.fromRotation(
+      Matrix3.fromColumnMajorArray([
+        1.0,
+        2.0,
+        3.0,
+        4.0,
+        5.0,
+        6.0,
+        7.0,
+        8.0,
+        9.0,
+      ]),
+      result
+    );
+    expect(returnedResult).toBe(result);
+    expect(returnedResult).toEqual(expected);
+  });
+
   it("computePerspectiveFieldOfView works", function () {
     const expected = new Matrix4(
       1,
@@ -845,7 +919,39 @@ describe("Core/Matrix4", function () {
     expect(returnedResult).toEqual(expected);
   });
 
-  it("computeViewportTransformation  works", function () {
+  it("computeViewportTransformation works without a result parameter", function () {
+    const expected = new Matrix4(
+      2.0,
+      0.0,
+      0.0,
+      2.0,
+      0.0,
+      3.0,
+      0.0,
+      3.0,
+      0.0,
+      0.0,
+      1.0,
+      1.0,
+      0.0,
+      0.0,
+      0.0,
+      1.0
+    );
+    const returnedResult = Matrix4.computeViewportTransformation(
+      {
+        x: 0,
+        y: 0,
+        width: 4.0,
+        height: 6.0,
+      },
+      0.0,
+      2.0
+    );
+    expect(returnedResult).toEqual(expected);
+  });
+
+  it("computeViewportTransformation works with a result parameter", function () {
     const expected = new Matrix4(
       2.0,
       0.0,
@@ -913,7 +1019,7 @@ describe("Core/Matrix4", function () {
     expect(returnedResult).toBe(result);
   });
 
-  it("computeInfinitePerspectiveOffCenter  works", function () {
+  it("computeInfinitePerspectiveOffCenter works", function () {
     const expected = new Matrix4(
       2,
       0,
@@ -1229,23 +1335,6 @@ describe("Core/Matrix4", function () {
     expect(result).toEqual(expected);
   });
 
-  it("setScale works", function () {
-    const matrix = Matrix4.clone(Matrix4.IDENTITY);
-    const result = new Matrix4();
-    const newScale = new Cartesian3(1.0, 2.0, 3.0);
-
-    expect(Matrix4.getScale(matrix, new Cartesian3())).toEqual(
-      new Cartesian3(1.0, 1.0, 1.0)
-    );
-
-    const returnedResult = Matrix4.setScale(matrix, newScale, result);
-
-    expect(Matrix4.getScale(returnedResult, new Cartesian3())).toEqual(
-      newScale
-    );
-    expect(result).toBe(returnedResult);
-  });
-
   it("getRow works for each row", function () {
     const matrix = new Matrix4(
       1.0,
@@ -1419,8 +1508,40 @@ describe("Core/Matrix4", function () {
     expect(result).toEqual(expected);
   });
 
+  it("setScale works", function () {
+    const matrix = Matrix4.clone(Matrix4.IDENTITY);
+    const result = new Matrix4();
+    const newScale = new Cartesian3(2.0, 3.0, 4.0);
+
+    expect(Matrix4.getScale(matrix, new Cartesian3())).toEqual(Cartesian3.ONE);
+
+    const returnedResult = Matrix4.setScale(matrix, newScale, result);
+
+    expect(Matrix4.getScale(returnedResult, new Cartesian3())).toEqual(
+      newScale
+    );
+    expect(result).toBe(returnedResult);
+  });
+
+  it("setUniformScale works", function () {
+    const oldScale = new Cartesian3(2.0, 3.0, 4.0);
+    const newScale = 5.0;
+
+    const matrix = Matrix4.fromScale(oldScale, new Matrix4());
+    const result = new Matrix4();
+
+    expect(Matrix4.getScale(matrix, new Cartesian3())).toEqual(oldScale);
+
+    const returnedResult = Matrix4.setUniformScale(matrix, newScale, result);
+
+    expect(Matrix4.getScale(returnedResult, new Cartesian3())).toEqual(
+      new Cartesian3(newScale, newScale, newScale)
+    );
+    expect(result).toBe(returnedResult);
+  });
+
   it("getScale works", function () {
-    const scale = new Cartesian3(1.0, 2.0, 3.0);
+    const scale = new Cartesian3(2.0, 3.0, 4.0);
     const result = new Cartesian3();
     const computedScale = Matrix4.getScale(Matrix4.fromScale(scale), result);
 
@@ -1428,24 +1549,86 @@ describe("Core/Matrix4", function () {
     expect(computedScale).toEqualEpsilon(scale, CesiumMath.EPSILON14);
   });
 
-  it("getScale throws without a matrix", function () {
-    expect(function () {
-      Matrix4.getScale();
-    }).toThrowDeveloperError();
-  });
-
   it("getMaximumScale works", function () {
-    const m = Matrix4.fromScale(new Cartesian3(1.0, 2.0, 3.0));
+    const m = Matrix4.fromScale(new Cartesian3(2.0, 3.0, 4.0));
     expect(Matrix4.getMaximumScale(m)).toEqualEpsilon(
-      3.0,
+      4.0,
       CesiumMath.EPSILON14
     );
   });
 
-  it("getMaximumScale throws without a matrix", function () {
-    expect(function () {
-      Matrix4.getMaximumScale();
-    }).toThrowDeveloperError();
+  it("setRotation works", function () {
+    const scaleVec = new Cartesian3(2.0, 3.0, 4.0);
+    const scale = Matrix4.fromScale(scaleVec, new Matrix3());
+    const rotation = Matrix3.fromRotationX(0.5, new Matrix3());
+    const scaleRotation = Matrix4.setRotation(scale, rotation, new Matrix4());
+
+    const extractedScale = Matrix4.getScale(scaleRotation, new Cartesian3());
+    const extractedRotation = Matrix4.getRotation(scaleRotation, new Matrix3());
+
+    expect(extractedScale).toEqualEpsilon(scaleVec, CesiumMath.EPSILON14);
+    expect(extractedRotation).toEqualEpsilon(rotation, CesiumMath.EPSILON14);
+  });
+
+  it("getRotation returns matrix without scale", function () {
+    const matrix = Matrix4.fromRotation(
+      Matrix3.fromColumnMajorArray([
+        1.0,
+        2.0,
+        3.0,
+        4.0,
+        5.0,
+        6.0,
+        7.0,
+        8.0,
+        9.0,
+      ])
+    );
+    const expectedRotation = Matrix3.fromColumnMajorArray([
+      1.0 / Math.sqrt(1.0 * 1.0 + 2.0 * 2.0 + 3.0 * 3.0),
+      2.0 / Math.sqrt(1.0 * 1.0 + 2.0 * 2.0 + 3.0 * 3.0),
+      3.0 / Math.sqrt(1.0 * 1.0 + 2.0 * 2.0 + 3.0 * 3.0),
+      4.0 / Math.sqrt(4.0 * 4.0 + 5.0 * 5.0 + 6.0 * 6.0),
+      5.0 / Math.sqrt(4.0 * 4.0 + 5.0 * 5.0 + 6.0 * 6.0),
+      6.0 / Math.sqrt(4.0 * 4.0 + 5.0 * 5.0 + 6.0 * 6.0),
+      7.0 / Math.sqrt(7.0 * 7.0 + 8.0 * 8.0 + 9.0 * 9.0),
+      8.0 / Math.sqrt(7.0 * 7.0 + 8.0 * 8.0 + 9.0 * 9.0),
+      9.0 / Math.sqrt(7.0 * 7.0 + 8.0 * 8.0 + 9.0 * 9.0),
+    ]);
+    const rotation = Matrix4.getRotation(matrix, new Matrix3());
+    expect(rotation).toEqualEpsilon(expectedRotation, CesiumMath.EPSILON14);
+  });
+
+  it("getRotation does not modify rotation matrix", function () {
+    const matrix = Matrix4.fromRotation(
+      Matrix3.fromColumnMajorArray([
+        1.0,
+        2.0,
+        3.0,
+        4.0,
+        5.0,
+        6.0,
+        7.0,
+        8.0,
+        9.0,
+      ])
+    );
+    const duplicateMatrix = Matrix4.clone(matrix, new Matrix4());
+    const expectedRotation = Matrix3.fromColumnMajorArray([
+      1.0 / Math.sqrt(1.0 * 1.0 + 2.0 * 2.0 + 3.0 * 3.0),
+      2.0 / Math.sqrt(1.0 * 1.0 + 2.0 * 2.0 + 3.0 * 3.0),
+      3.0 / Math.sqrt(1.0 * 1.0 + 2.0 * 2.0 + 3.0 * 3.0),
+      4.0 / Math.sqrt(4.0 * 4.0 + 5.0 * 5.0 + 6.0 * 6.0),
+      5.0 / Math.sqrt(4.0 * 4.0 + 5.0 * 5.0 + 6.0 * 6.0),
+      6.0 / Math.sqrt(4.0 * 4.0 + 5.0 * 5.0 + 6.0 * 6.0),
+      7.0 / Math.sqrt(7.0 * 7.0 + 8.0 * 8.0 + 9.0 * 9.0),
+      8.0 / Math.sqrt(7.0 * 7.0 + 8.0 * 8.0 + 9.0 * 9.0),
+      9.0 / Math.sqrt(7.0 * 7.0 + 8.0 * 8.0 + 9.0 * 9.0),
+    ]);
+    const result = Matrix4.getRotation(matrix, new Matrix3());
+    expect(result).toEqualEpsilon(expectedRotation, CesiumMath.EPSILON14);
+    expect(matrix).toEqual(duplicateMatrix);
+    expect(matrix).not.toBe(result);
   });
 
   it("multiply works", function () {
@@ -1969,13 +2152,43 @@ describe("Core/Matrix4", function () {
   });
 
   it("multiplyByUniformScale works", function () {
-    const m = new Matrix4(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0, 0, 0, 1);
-    const scale = 1.0;
-    const expected = Matrix4.multiply(
-      m,
-      Matrix4.fromUniformScale(scale),
-      new Matrix4()
-    );
+    const m = Matrix4.fromColumnMajorArray([
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15,
+      16,
+      17,
+    ]);
+    const scale = 2.0;
+    const expected = Matrix4.fromColumnMajorArray([
+      2 * scale,
+      3 * scale,
+      4 * scale,
+      5,
+      6 * scale,
+      7 * scale,
+      8 * scale,
+      9,
+      10 * scale,
+      11 * scale,
+      12 * scale,
+      13,
+      14,
+      15,
+      16,
+      17,
+    ]);
     const result = new Matrix4();
     const returnedResult = Matrix4.multiplyByUniformScale(m, scale, result);
     expect(returnedResult).toBe(result);
@@ -1983,13 +2196,43 @@ describe("Core/Matrix4", function () {
   });
 
   it("multiplyByUniformScale works with a result parameter that is an input result parameter", function () {
-    const m = new Matrix4(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0, 0, 0, 1);
+    const m = Matrix4.fromColumnMajorArray([
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15,
+      16,
+      17,
+    ]);
     const scale = 2.0;
-    const expected = Matrix4.multiply(
-      m,
-      Matrix4.fromUniformScale(scale),
-      new Matrix4()
-    );
+    const expected = Matrix4.fromColumnMajorArray([
+      2 * scale,
+      3 * scale,
+      4 * scale,
+      5,
+      6 * scale,
+      7 * scale,
+      8 * scale,
+      9,
+      10 * scale,
+      11 * scale,
+      12 * scale,
+      13,
+      14,
+      15,
+      16,
+      17,
+    ]);
     const returnedResult = Matrix4.multiplyByUniformScale(m, scale, m);
     expect(returnedResult).toBe(m);
     expect(m).toEqual(expected);
@@ -2022,6 +2265,95 @@ describe("Core/Matrix4", function () {
       new Matrix4()
     );
     const returnedResult = Matrix4.multiplyByScale(m, scale, m);
+    expect(returnedResult).toBe(m);
+    expect(m).toEqual(expected);
+  });
+
+  it("multiplyByUniformScale works", function () {
+    const m = Matrix4.fromColumnMajorArray([
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15,
+      16,
+      17,
+    ]);
+    const scale = 2.0;
+    const expected = Matrix4.fromColumnMajorArray([
+      2 * scale,
+      3 * scale,
+      4 * scale,
+      5,
+      6 * scale,
+      7 * scale,
+      8 * scale,
+      9,
+      10 * scale,
+      11 * scale,
+      12 * scale,
+      13,
+      14,
+      15,
+      16,
+      17,
+    ]);
+
+    const result = new Matrix4();
+    const returnedResult = Matrix4.multiplyByUniformScale(m, scale, result);
+    expect(returnedResult).toBe(result);
+    expect(result).toEqual(expected);
+  });
+
+  it('multiplyByUniformScale works with "this" result parameter', function () {
+    const m = Matrix4.fromColumnMajorArray([
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15,
+      16,
+      17,
+    ]);
+    const scale = 2.0;
+    const expected = Matrix4.fromColumnMajorArray([
+      2 * scale,
+      3 * scale,
+      4 * scale,
+      5,
+      6 * scale,
+      7 * scale,
+      8 * scale,
+      9,
+      10 * scale,
+      11 * scale,
+      12 * scale,
+      13,
+      14,
+      15,
+      16,
+      17,
+    ]);
+
+    const returnedResult = Matrix4.multiplyByUniformScale(m, scale, m);
     expect(returnedResult).toBe(m);
     expect(m).toEqual(expected);
   });
@@ -3704,6 +4036,12 @@ describe("Core/Matrix4", function () {
     }).toThrowDeveloperError();
   });
 
+  it("fromRotation throws without rotation parameter", function () {
+    expect(function () {
+      Matrix4.fromRotation(undefined);
+    }).toThrowDeveloperError();
+  });
+
   it("fromCamera throws without camera", function () {
     expect(function () {
       Matrix4.fromCamera(undefined);
@@ -3734,6 +4072,30 @@ describe("Core/Matrix4", function () {
         position: Cartesian3.ZERO,
         direction: Cartesian3.negate(Cartesian3.UNIT_Z, new Cartesian3()),
       });
+    }).toThrowDeveloperError();
+  });
+
+  it("computePerspectiveFieldOfView throws with out of range y field of view", function () {
+    expect(function () {
+      Matrix4.computePerspectiveFieldOfView(0, 1, 2, 3);
+    }).toThrowDeveloperError();
+  });
+
+  it("computePerspectiveFieldOfView throws with out of range aspect", function () {
+    expect(function () {
+      Matrix4.computePerspectiveFieldOfView(1, 0, 2, 3);
+    }).toThrowDeveloperError();
+  });
+
+  it("computePerspectiveFieldOfView throws with out of range near", function () {
+    expect(function () {
+      Matrix4.computePerspectiveFieldOfView(1, 1, 0, 3);
+    }).toThrowDeveloperError();
+  });
+
+  it("computePerspectiveFieldOfView throws with out of range far", function () {
+    expect(function () {
+      Matrix4.computePerspectiveFieldOfView(1, 1, 2, 0);
     }).toThrowDeveloperError();
   });
 
@@ -3953,7 +4315,7 @@ describe("Core/Matrix4", function () {
     }).toThrowDeveloperError();
   });
 
-  it("computeInfinitePerspectiveOffCenter  throws without left", function () {
+  it("computeInfinitePerspectiveOffCenter throws without left", function () {
     expect(function () {
       const right = 0,
         bottom = 0,
@@ -3971,7 +4333,7 @@ describe("Core/Matrix4", function () {
     }).toThrowDeveloperError();
   });
 
-  it("computeInfinitePerspectiveOffCenter  throws without right", function () {
+  it("computeInfinitePerspectiveOffCenter throws without right", function () {
     expect(function () {
       const left = 0,
         bottom = 0,
@@ -3989,7 +4351,7 @@ describe("Core/Matrix4", function () {
     }).toThrowDeveloperError();
   });
 
-  it("computeInfinitePerspectiveOffCenter  throws without bottom", function () {
+  it("computeInfinitePerspectiveOffCenter throws without bottom", function () {
     expect(function () {
       const left = 0,
         right = 0,
@@ -4007,7 +4369,7 @@ describe("Core/Matrix4", function () {
     }).toThrowDeveloperError();
   });
 
-  it("computeInfinitePerspectiveOffCenter  throws without top", function () {
+  it("computeInfinitePerspectiveOffCenter throws without top", function () {
     expect(function () {
       const left = 0,
         right = 0,
@@ -4025,7 +4387,7 @@ describe("Core/Matrix4", function () {
     }).toThrowDeveloperError();
   });
 
-  it("computeInfinitePerspectiveOffCenter  throws without near", function () {
+  it("computeInfinitePerspectiveOffCenter throws without near", function () {
     expect(function () {
       const left = 0,
         right = 0,
@@ -4043,27 +4405,39 @@ describe("Core/Matrix4", function () {
     }).toThrowDeveloperError();
   });
 
-  it("computePerspectiveFieldOfView throws with out of range y field of view", function () {
+  it("computeView throws without position", function () {
     expect(function () {
-      Matrix4.computePerspectiveFieldOfView(0, 1, 2, 3);
+      const direction = Cartesian3.UNIT_Z;
+      const up = Cartesian3.UNIT_Y;
+      const right = Cartesian3.UNIT_X;
+      Matrix4.computeView(undefined, direction, up, right, new Matrix4());
     }).toThrowDeveloperError();
   });
 
-  it("computePerspectiveFieldOfView throws with out of range aspect", function () {
+  it("computeView throws without direction", function () {
     expect(function () {
-      Matrix4.computePerspectiveFieldOfView(1, 0, 2, 3);
+      const position = Cartesian3.ZERO;
+      const up = Cartesian3.UNIT_Y;
+      const right = Cartesian3.UNIT_X;
+      Matrix4.computeView(position, undefined, up, right, new Matrix4());
     }).toThrowDeveloperError();
   });
 
-  it("computePerspectiveFieldOfView throws with out of range near", function () {
+  it("computeView throws without up", function () {
     expect(function () {
-      Matrix4.computePerspectiveFieldOfView(1, 1, 0, 3);
+      const position = Cartesian3.ZERO;
+      const direction = Cartesian3.UNIT_Z;
+      const right = Cartesian3.UNIT_X;
+      Matrix4.computeView(position, direction, undefined, right, new Matrix4());
     }).toThrowDeveloperError();
   });
 
-  it("computePerspectiveFieldOfView throws with out of range far", function () {
+  it("computeView throws without right", function () {
     expect(function () {
-      Matrix4.computePerspectiveFieldOfView(1, 1, 2, 0);
+      const position = Cartesian3.ZERO;
+      const direction = Cartesian3.UNIT_Z;
+      const up = Cartesian3.UNIT_Y;
+      Matrix4.computeView(position, direction, up, undefined, new Matrix4());
     }).toThrowDeveloperError();
   });
 
@@ -4099,7 +4473,7 @@ describe("Core/Matrix4", function () {
     }).toThrowDeveloperError();
   });
 
-  it("getColumn throws without of range index parameter", function () {
+  it("getColumn throws with out of range index parameter", function () {
     const matrix = new Matrix4();
     expect(function () {
       Matrix4.getColumn(matrix, 4);
@@ -4120,7 +4494,7 @@ describe("Core/Matrix4", function () {
     }).toThrowDeveloperError();
   });
 
-  it("setColumn throws without of range index parameter", function () {
+  it("setColumn throws with out of range index parameter", function () {
     const matrix = new Matrix4();
     const cartesian = new Cartesian4();
     expect(function () {
@@ -4147,13 +4521,13 @@ describe("Core/Matrix4", function () {
     }).toThrowDeveloperError();
   });
 
-  it("setTranslation throws without result parameter", function () {
+  it("setTranslation throws without a result parameter", function () {
     expect(function () {
       Matrix4.setTranslation(new Matrix4(), new Cartesian3(), undefined);
     }).toThrowDeveloperError();
   });
 
-  it("getRow throws without of range index parameter", function () {
+  it("getRow throws with out of range index parameter", function () {
     const matrix = new Matrix4();
     expect(function () {
       Matrix4.getRow(matrix, 4);
@@ -4174,11 +4548,65 @@ describe("Core/Matrix4", function () {
     }).toThrowDeveloperError();
   });
 
-  it("setRow throws without of range index parameter", function () {
+  it("setRow throws with out of range index parameter", function () {
     const matrix = new Matrix4();
     const cartesian = new Cartesian4();
     expect(function () {
       Matrix4.setRow(matrix, 4, cartesian);
+    }).toThrowDeveloperError();
+  });
+
+  it("setScale throws without a matrix", function () {
+    expect(function () {
+      Matrix4.setScale();
+    }).toThrowDeveloperError();
+  });
+
+  it("setScale throws without a scale", function () {
+    expect(function () {
+      Matrix4.setScale(new Matrix4());
+    }).toThrowDeveloperError();
+  });
+
+  it("setUniformScale throws without a matrix", function () {
+    expect(function () {
+      Matrix4.setUniformScale();
+    }).toThrowDeveloperError();
+  });
+
+  it("setUniformScale throws without a scale", function () {
+    expect(function () {
+      Matrix4.setUniformScale(new Matrix4());
+    }).toThrowDeveloperError();
+  });
+
+  it("getScale throws without a matrix", function () {
+    expect(function () {
+      Matrix4.getScale();
+    }).toThrowDeveloperError();
+  });
+
+  it("getMaximumScale throws without a matrix", function () {
+    expect(function () {
+      Matrix4.getMaximumScale();
+    }).toThrowDeveloperError();
+  });
+
+  it("setRotation throws without a matrix", function () {
+    expect(function () {
+      return Matrix4.setRotation();
+    }).toThrowDeveloperError();
+  });
+
+  it("setRotation throws without a rotation", function () {
+    expect(function () {
+      return Matrix4.setRotation(new Matrix4());
+    }).toThrowDeveloperError();
+  });
+
+  it("getRotation throws without a matrix", function () {
+    expect(function () {
+      return Matrix4.getRotation();
     }).toThrowDeveloperError();
   });
 
@@ -4210,29 +4638,27 @@ describe("Core/Matrix4", function () {
     }).toThrowDeveloperError();
   });
 
-  it("multiplyByUniformScale throws with no matrix parameter", function () {
-    expect(function () {
-      Matrix4.multiplyByUniformScale(undefined, 2.0);
-    }).toThrowDeveloperError();
-  });
-
-  it("multiplyByUniformScale throws with no scale parameter", function () {
-    const m = new Matrix4();
-    expect(function () {
-      Matrix4.multiplyByUniformScale(m, undefined);
-    }).toThrowDeveloperError();
-  });
-
   it("multiplyByScale throws with no matrix parameter", function () {
     expect(function () {
-      Matrix4.multiplyByScale(undefined, new Cartesian3());
+      Matrix4.multiplyByScale();
     }).toThrowDeveloperError();
   });
 
   it("multiplyByScale throws with no scale parameter", function () {
-    const m = new Matrix4();
     expect(function () {
-      Matrix4.multiplyByScale(m, undefined);
+      Matrix4.multiplyByScale(new Matrix4());
+    }).toThrowDeveloperError();
+  });
+
+  it("multiplyByUniformScale throws with no matrix parameter", function () {
+    expect(function () {
+      Matrix4.multiplyByUniformScale();
+    }).toThrowDeveloperError();
+  });
+
+  it("multiplyByUniformScale throws with no scale parameter", function () {
+    expect(function () {
+      Matrix4.multiplyByUniformScale(new Matrix4());
     }).toThrowDeveloperError();
   });
 
@@ -4337,73 +4763,97 @@ describe("Core/Matrix4", function () {
     }).toThrowDeveloperError();
   });
 
-  it("getColumn throws without result parameter", function () {
+  it("getColumn throws without a result parameter", function () {
     expect(function () {
       Matrix4.getColumn(new Matrix4(), 2);
     }).toThrowDeveloperError();
   });
 
-  it("setColumn throws without result parameter", function () {
+  it("setColumn throws without a result parameter", function () {
     expect(function () {
       Matrix4.setColumn(new Matrix4(), 2, new Cartesian4());
     }).toThrowDeveloperError();
   });
 
-  it("getRow throws without result parameter", function () {
+  it("getRow throws without a result parameter", function () {
     expect(function () {
       Matrix4.getRow(new Matrix4(), 2);
     }).toThrowDeveloperError();
   });
 
-  it("setRow throws without result parameter", function () {
+  it("setRow throws without a result parameter", function () {
     expect(function () {
       Matrix4.setRow(new Matrix4(), 2, new Cartesian4());
     }).toThrowDeveloperError();
   });
 
-  it("getScale throws without result parameter", function () {
+  it("setScale throws without a result parameter", function () {
+    expect(function () {
+      Matrix4.setScale(new Matrix4(), new Cartesian3());
+    }).toThrowDeveloperError();
+  });
+
+  it("setUniformScale throws without a result parameter", function () {
+    expect(function () {
+      Matrix4.setUniformScale(new Matrix4(), 1.0);
+    }).toThrowDeveloperError();
+  });
+
+  it("getScale throws without a result parameter", function () {
     expect(function () {
       Matrix4.getScale(new Matrix4());
     }).toThrowDeveloperError();
   });
 
-  it("multiply throws without result parameter", function () {
+  it("setRotation throws without a result parameter", function () {
+    expect(function () {
+      return Matrix4.setRotation(new Matrix4(), new Matrix3());
+    }).toThrowDeveloperError();
+  });
+
+  it("getRotation throws without a result parameter", function () {
+    expect(function () {
+      return Matrix4.getRotation(new Matrix4());
+    }).toThrowDeveloperError();
+  });
+
+  it("multiply throws without a result parameter", function () {
     expect(function () {
       Matrix4.multiply(new Matrix4(), new Matrix3());
     }).toThrowDeveloperError();
   });
 
-  it("multiplyByVector throws without result parameter", function () {
+  it("multiplyByVector throws without a result parameter", function () {
     expect(function () {
       Matrix4.multiplyByVector(new Matrix4(), new Cartesian4());
     }).toThrowDeveloperError();
   });
 
-  it("multiplyByScalar throws without result parameter", function () {
+  it("multiplyByScalar throws without a result parameter", function () {
     expect(function () {
       Matrix4.multiplyByScalar(new Matrix4(), 2);
     }).toThrowDeveloperError();
   });
 
-  it("negate throws without result parameter", function () {
+  it("negate throws without a result parameter", function () {
     expect(function () {
       Matrix4.negate(new Matrix4());
     }).toThrowDeveloperError();
   });
 
-  it("transpose throws without result parameter", function () {
+  it("transpose throws without a result parameter", function () {
     expect(function () {
       Matrix4.transpose(new Matrix4());
     }).toThrowDeveloperError();
   });
 
-  it("abs throws without result parameter", function () {
+  it("abs throws without a result parameter", function () {
     expect(function () {
       Matrix4.abs(new Matrix4());
     }).toThrowDeveloperError();
   });
 
-  it("inverse throws without result parameter", function () {
+  it("inverse throws without a result parameter", function () {
     expect(function () {
       Matrix4.inverse(new Matrix4());
     }).toThrowDeveloperError();
@@ -4421,7 +4871,7 @@ describe("Core/Matrix4", function () {
     }).toThrowDeveloperError();
   });
 
-  it("multiplyTransformation throws without result parameter", function () {
+  it("multiplyTransformation throws without a result parameter", function () {
     expect(function () {
       Matrix4.multiplyTransformation(new Matrix4(), new Matrix4());
     }).toThrowDeveloperError();
@@ -4445,15 +4895,15 @@ describe("Core/Matrix4", function () {
     }).toThrowDeveloperError();
   });
 
-  it("multiplyByUniformScale throws without result parameter", function () {
+  it("multiplyByScale throws without a result parameter", function () {
     expect(function () {
-      Matrix4.multiplyByUniformScale(new Matrix4(), 2);
+      Matrix4.multiplyByScale(new Matrix4(), new Cartesian3());
     }).toThrowDeveloperError();
   });
 
-  it("multiplyByScale throws without result parameter", function () {
+  it("multiplyByUniformScale throws without a result parameter", function () {
     expect(function () {
-      Matrix4.multiplyByScale(new Matrix4(), new Cartesian3());
+      Matrix4.multiplyByUniformScale(new Matrix4(), 2);
     }).toThrowDeveloperError();
   });
 
@@ -4469,7 +4919,7 @@ describe("Core/Matrix4", function () {
     }).toThrowDeveloperError();
   });
 
-  it("multiplyByPointAsVector throws without result parameter", function () {
+  it("multiplyByPointAsVector throws without a result parameter", function () {
     expect(function () {
       Matrix4.multiplyByPointAsVector(new Matrix4(), new Cartesian3());
     }).toThrowDeveloperError();
@@ -4481,65 +4931,84 @@ describe("Core/Matrix4", function () {
     }).toThrowDeveloperError();
   });
 
-  it("getTranslation throws without result parameter", function () {
+  it("getTranslation throws without a result parameter", function () {
     expect(function () {
       Matrix4.getTranslation(new Matrix4());
     }).toThrowDeveloperError();
   });
 
-  it("getMatrix3 throws without result parameter", function () {
+  it("getMatrix3 throws without a result parameter", function () {
     expect(function () {
       Matrix4.getMatrix3(new Matrix4());
     }).toThrowDeveloperError();
   });
 
-  it("inverseTransformtation throws without result parameter", function () {
+  it("inverseTransformtation throws without a result parameter", function () {
     expect(function () {
       Matrix4.inverseTransformation(new Matrix4());
     }).toThrowDeveloperError();
   });
 
-  it("multiplyByTranslation throws without result parameter", function () {
+  it("multiplyByTranslation throws without a result parameter", function () {
     expect(function () {
       Matrix4.multiplyByTranslation(new Matrix4(), new Cartesian3());
     }).toThrowDeveloperError();
   });
 
-  it("computePerspectiveFieldOfView throws without result parameter", function () {
+  it("computePerspectiveFieldOfView throws without a result parameter", function () {
     expect(function () {
       Matrix4.computePerspectiveFieldOfView(CesiumMath.PI_OVER_TWO, 1, 1, 10);
     }).toThrowDeveloperError();
   });
 
-  it("computeOrthographicOffCenter throws without result parameter", function () {
+  it("computeOrthographicOffCenter throws without a result parameter", function () {
+    expect(function () {
+      const left = 0,
+        right = 0,
+        bottom = 0,
+        top = 0,
+        near = 0,
+        far = 0;
+      Matrix4.computeOrthographicOffCenter(left, right, bottom, top, near, far);
+    }).toThrowDeveloperError();
+  });
+
+  it("computePerspectiveOffCenter throws without a result parameter", function () {
+    expect(function () {
+      const left = 0,
+        right = 0,
+        bottom = 0,
+        top = 0,
+        near = 0,
+        far = 0;
+      Matrix4.computePerspectiveOffCenter(left, right, bottom, top, near, far);
+    }).toThrowDeveloperError();
+  });
+
+  it("computeInfinitePerspectiveOffCenter throws without a result parameter", function () {
     expect(function () {
       const left = 0,
         right = 0,
         bottom = 0,
         top = 0,
         near = 0;
-      Matrix4.computeOrthographicOffCenter(left, right, bottom, top, near, 0);
+      Matrix4.computeInfinitePerspectiveOffCenter(
+        left,
+        right,
+        bottom,
+        top,
+        near
+      );
     }).toThrowDeveloperError();
   });
 
-  it("computePerspectiveOffCenter throws without result parameter", function () {
+  it("computeView throws without a result paramter", function () {
     expect(function () {
-      const left = 0,
-        right = 0,
-        bottom = 0,
-        top = 0,
-        near = 0;
-      Matrix4.computePerspectiveOffCenter(left, right, bottom, top, near, 0);
-    }).toThrowDeveloperError();
-  });
-
-  it("computeInfinitePerspectiveOffCenter throws without near", function () {
-    expect(function () {
-      const left = 0,
-        right = 0,
-        bottom = 0,
-        top = 0;
-      Matrix4.computeInfinitePerspectiveOffCenter(left, right, bottom, top, 0);
+      const position = Cartesian3.ONE;
+      const direction = Cartesian3.UNIT_Z;
+      const up = Cartesian3.UNIT_Y;
+      const right = Cartesian3.UNIT_X;
+      Matrix4.computeView(position, direction, up, right);
     }).toThrowDeveloperError();
   });
 


### PR DESCRIPTION
This PR fills in some gaps in `Matrix2`, `Matrix3`, and `Matrix4` for affine transformations. This includes:

- `setScale` - for `Matrix2`, `Matrix3`
  - exists in `Matrix4` already
- `setUniformScale` - for `Matrix2`, `Matrix3`, `Matrix4`
- `multiplyByUniformScale` - for `Matrix2`, `Matrix3`
  - exists in `Matrix4` already
- `setRotation` - for `Matrix2`, `Matrix3`, `Matrix4`
- `getRotation` - for `Matrix2`, `Matrix4`
  - exists in `Matrix3` already
- `fromRotation` - for `Matrix4`
  - `Matrix2` and `Matrix3` already have their own versions of this

Also did some cleanup in the specs so that all tests are grouped by:
- Capability tests
- Missing parameter tests
- Missing result parameter tests

Misc:
- Inlined most of the math for better performance
- Coverage is 100%


