### PR TITLE
Re-enable draco quantization

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "cloc": "^2.8.0",
     "compression": "^1.7.4",
     "dompurify": "^2.2.2",
-    "draco3d": "^1.4.1",
+    "draco3d": "^1.5.1",
     "earcut": "^2.2.2",
     "eslint": "^7.29.0",
     "eslint-config-prettier": "^8.3.0",


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/9847

The only changes are to update the Draco version in package.json to 1.5.1 and to revert the changes to the `decodeDraco` worker from https://github.com/CesiumGS/cesium/pull/9904/. 

As a note, this [issue](https://github.com/CesiumGS/cesium/issues/10080) that appeared when we updated Draco does not look like it's fixed after these changes, so it's probably unrelated to quantization.