### PR TITLE
Various OrientedBoundingBox, AxisAlignedBoundingBox, BoundingSphere, and Rectangle functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@
   - Added `setScale`, `setUniformScale`, `setRotation`, `getRotation`, and `multiplyByUniformScale` to `Matrix2`.
   - Added `setScale`, `setUniformScale`, `setRotation`, and `multiplyByUniformScale` to `Matrix3`.
   - Added `setUniformScale`, `setRotation`, `getRotation`, and `fromRotation` to `Matrix4`.
+- Added `AxisAlignedBoundingBox.fromCorners`. [#10130](https://github.com/CesiumGS/cesium/pull/10130)
+- Added `BoundingSphere.fromTransformation`. [#10130](https://github.com/CesiumGS/cesium/pull/10130)
+- Added `OrientedBoundingBox.fromTransformation`, `OrientedBoundingBox.computeCorners`, and `OrientedBoundingBox.computeTransformation`. [#10130](https://github.com/CesiumGS/cesium/pull/10130)
+- Added `Rectangle.subsection`. [#10130](https://github.com/CesiumGS/cesium/pull/10130)
 
 ##### Fixes :wrench:
 

--- a/Source/Core/AxisAlignedBoundingBox.js
+++ b/Source/Core/AxisAlignedBoundingBox.js
@@ -55,7 +55,7 @@ function AxisAlignedBoundingBox(minimum, maximum, center) {
  *
  * @example
  * // Compute an axis aligned bounding box from the two corners.
- * var box = Cesium.AxisAlignedBoundingBox.fromCorners(new Cesium.Cartesian3(-1, -1, -1), new Cesium.Cartesian3(1, 1, 1));
+ * const box = Cesium.AxisAlignedBoundingBox.fromCorners(new Cesium.Cartesian3(-1, -1, -1), new Cesium.Cartesian3(1, 1, 1));
  */
 AxisAlignedBoundingBox.fromCorners = function (minimum, maximum, result) {
   //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/AxisAlignedBoundingBox.js
+++ b/Source/Core/AxisAlignedBoundingBox.js
@@ -31,7 +31,7 @@ function AxisAlignedBoundingBox(minimum, maximum, center) {
    */
   this.maximum = Cartesian3.clone(defaultValue(maximum, Cartesian3.ZERO));
 
-  //If center was not defined, compute it.
+  // If center was not defined, compute it.
   if (!defined(center)) {
     center = Cartesian3.midpoint(this.minimum, this.maximum, new Cartesian3());
   } else {
@@ -44,6 +44,35 @@ function AxisAlignedBoundingBox(minimum, maximum, center) {
    */
   this.center = center;
 }
+
+/**
+ * Creates an instance of an AxisAlignedBoundingBox from its corners.
+ *
+ * @param {Cartesian3} minimum The minimum point along the x, y, and z axes.
+ * @param {Cartesian3} maximum The maximum point along the x, y, and z axes.
+ * @param {AxisAlignedBoundingBox} [result] The object onto which to store the result.
+ * @returns {AxisAlignedBoundingBox} The modified result parameter or a new AxisAlignedBoundingBox instance if one was not provided.
+ *
+ * @example
+ * // Compute an axis aligned bounding box from the two corners.
+ * var box = Cesium.AxisAlignedBoundingBox.fromCorners(new Cesium.Cartesian3(-1, -1, -1), new Cesium.Cartesian3(1, 1, 1));
+ */
+AxisAlignedBoundingBox.fromCorners = function (minimum, maximum, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.defined("minimum", minimum);
+  Check.defined("maximum", maximum);
+  //>>includeEnd('debug');
+
+  if (!defined(result)) {
+    result = new AxisAlignedBoundingBox();
+  }
+
+  result.minimum = Cartesian3.clone(minimum, result.minimum);
+  result.maximum = Cartesian3.clone(maximum, result.maximum);
+  result.center = Cartesian3.midpoint(minimum, maximum, result.center);
+
+  return result;
+};
 
 /**
  * Computes an instance of an AxisAlignedBoundingBox. The box is determined by

--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -879,6 +879,40 @@ BoundingSphere.fromOrientedBoundingBox = function (
   return result;
 };
 
+const scratchFromTransformationCenter = new Cartesian3();
+const scratchFromTransformationScale = new Cartesian3();
+
+/**
+ * Computes a tight-fitting bounding sphere enclosing the provided affine transformation.
+ *
+ * @param {Matrix4} transformation The affine transformation.
+ * @param {BoundingSphere} [result] The object onto which to store the result.
+ * @returns {BoundingSphere} The modified result parameter or a new BoundingSphere instance if none was provided.
+ */
+BoundingSphere.fromTransformation = function (transformation, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("transformation", transformation);
+  //>>includeEnd('debug');
+
+  if (!defined(result)) {
+    result = new BoundingSphere();
+  }
+
+  const center = Matrix4.getTranslation(
+    transformation,
+    scratchFromTransformationCenter
+  );
+  const scale = Matrix4.getScale(
+    transformation,
+    scratchFromTransformationScale
+  );
+  const radius = 0.5 * Cartesian3.magnitude(scale);
+  result.center = Cartesian3.clone(center, result.center);
+  result.radius = radius;
+
+  return result;
+};
+
 /**
  * Duplicates a BoundingSphere instance.
  *

--- a/Source/Core/OrientedBoundingBox.js
+++ b/Source/Core/OrientedBoundingBox.js
@@ -12,6 +12,7 @@ import Intersect from "./Intersect.js";
 import Interval from "./Interval.js";
 import CesiumMath from "./Math.js";
 import Matrix3 from "./Matrix3.js";
+import Matrix4 from "./Matrix4.js";
 import Plane from "./Plane.js";
 import Rectangle from "./Rectangle.js";
 
@@ -608,6 +609,32 @@ OrientedBoundingBox.fromRectangle = function (
 };
 
 /**
+ * Computes an OrientedBoundingBox that bounds an affine transformation.
+ *
+ * @param {Matrix4} transformation The affine transformation.
+ * @param {OrientedBoundingBox} [result] The object onto which to store the result.
+ * @returns {OrientedBoundingBox} The modified result parameter or a new OrientedBoundingBox instance if none was provided.
+ */
+OrientedBoundingBox.fromTransformation = function (transformation, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("transformation", transformation);
+  //>>includeEnd('debug');
+
+  if (!defined(result)) {
+    result = new OrientedBoundingBox();
+  }
+
+  result.center = Matrix4.getTranslation(transformation, result.center);
+  result.halfAxes = Matrix4.getMatrix3(transformation, result.halfAxes);
+  result.halfAxes = Matrix3.multiplyByScalar(
+    result.halfAxes,
+    0.5,
+    result.halfAxes
+  );
+  return result;
+};
+
+/**
  * Duplicates a OrientedBoundingBox instance.
  *
  * @param {OrientedBoundingBox} box The bounding box to duplicate.
@@ -987,6 +1014,111 @@ OrientedBoundingBox.computePlaneDistances = function (
   return result;
 };
 
+const scratchXAxis = new Cartesian3();
+const scratchYAxis = new Cartesian3();
+const scratchZAxis = new Cartesian3();
+
+/**
+ * Computes the eight corners of an oriented bounding box. The corners are ordered by (-X, -Y, -Z), (-X, -Y, +Z), (-X, +Y, -Z), (-X, +Y, +Z), (+X, -Y, -Z), (+X, -Y, +Z), (+X, +Y, -Z), (+X, +Y, +Z).
+ *
+ * @param {OrientedBoundingBox} box The oriented bounding box.
+ * @param {Cartesian3[]} [result] An array of eight {@link Cartesian3} instances onto which to store the corners.
+ * @returns {Cartesian3[]} The modified result parameter or a new array if none was provided.
+ */
+OrientedBoundingBox.computeCorners = function (box, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("box", box);
+  //>>includeEnd('debug');
+
+  if (!defined(result)) {
+    result = [
+      new Cartesian3(),
+      new Cartesian3(),
+      new Cartesian3(),
+      new Cartesian3(),
+      new Cartesian3(),
+      new Cartesian3(),
+      new Cartesian3(),
+      new Cartesian3(),
+    ];
+  }
+
+  const center = box.center;
+  const halfAxes = box.halfAxes;
+  const xAxis = Matrix3.getColumn(halfAxes, 0, scratchXAxis);
+  const yAxis = Matrix3.getColumn(halfAxes, 1, scratchYAxis);
+  const zAxis = Matrix3.getColumn(halfAxes, 2, scratchZAxis);
+
+  Cartesian3.clone(center, result[0]);
+  Cartesian3.subtract(result[0], xAxis, result[0]);
+  Cartesian3.subtract(result[0], yAxis, result[0]);
+  Cartesian3.subtract(result[0], zAxis, result[0]);
+
+  Cartesian3.clone(center, result[1]);
+  Cartesian3.subtract(result[1], xAxis, result[1]);
+  Cartesian3.subtract(result[1], yAxis, result[1]);
+  Cartesian3.add(result[1], zAxis, result[1]);
+
+  Cartesian3.clone(center, result[2]);
+  Cartesian3.subtract(result[2], xAxis, result[2]);
+  Cartesian3.add(result[2], yAxis, result[2]);
+  Cartesian3.subtract(result[2], zAxis, result[2]);
+
+  Cartesian3.clone(center, result[3]);
+  Cartesian3.subtract(result[3], xAxis, result[3]);
+  Cartesian3.add(result[3], yAxis, result[3]);
+  Cartesian3.add(result[3], zAxis, result[3]);
+
+  Cartesian3.clone(center, result[4]);
+  Cartesian3.add(result[4], xAxis, result[4]);
+  Cartesian3.subtract(result[4], yAxis, result[4]);
+  Cartesian3.subtract(result[4], zAxis, result[4]);
+
+  Cartesian3.clone(center, result[5]);
+  Cartesian3.add(result[5], xAxis, result[5]);
+  Cartesian3.subtract(result[5], yAxis, result[5]);
+  Cartesian3.add(result[5], zAxis, result[5]);
+
+  Cartesian3.clone(center, result[6]);
+  Cartesian3.add(result[6], xAxis, result[6]);
+  Cartesian3.add(result[6], yAxis, result[6]);
+  Cartesian3.subtract(result[6], zAxis, result[6]);
+
+  Cartesian3.clone(center, result[7]);
+  Cartesian3.add(result[7], xAxis, result[7]);
+  Cartesian3.add(result[7], yAxis, result[7]);
+  Cartesian3.add(result[7], zAxis, result[7]);
+
+  return result;
+};
+
+const scratchRotationScale = new Matrix3();
+
+/**
+ * Computes a transformation matrix from an oriented bounding box.
+ *
+ * @param {OrientedBoundingBox} box The oriented bounding box.
+ * @param {Matrix4} result The object onto which to store the result.
+ * @returns {Matrix4} The modified result parameter or a new {@link Matrix4} instance if none was provided.
+ */
+OrientedBoundingBox.computeTransformation = function (box, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("box", box);
+  //>>includeEnd('debug');
+
+  if (!defined(result)) {
+    result = new Matrix4();
+  }
+
+  const translation = box.center;
+  const rotationScale = Matrix3.multiplyByUniformScale(
+    box.halfAxes,
+    2.0,
+    scratchRotationScale
+  );
+  return Matrix4.fromRotationTranslation(rotationScale, translation, result);
+};
+
 const scratchBoundingSphere = new BoundingSphere();
 
 /**
@@ -1065,6 +1197,26 @@ OrientedBoundingBox.prototype.computePlaneDistances = function (
     direction,
     result
   );
+};
+
+/**
+ * Computes the eight corners of an oriented bounding box. The corners are ordered by (-X, -Y, -Z), (-X, -Y, +Z), (-X, +Y, -Z), (-X, +Y, +Z), (+X, -Y, -Z), (+X, -Y, +Z), (+X, +Y, -Z), (+X, +Y, +Z).
+ *
+ * @param {Cartesian3[]} [result] An array of eight {@link Cartesian3} instances onto which to store the corners.
+ * @returns {Cartesian3[]} The modified result parameter or a new array if none was provided.
+ */
+OrientedBoundingBox.prototype.computeCorners = function (result) {
+  return OrientedBoundingBox.computeCorners(this, result);
+};
+
+/**
+ * Computes a transformation matrix from an oriented bounding box.
+ *
+ * @param {Matrix4} result The object onto which to store the result.
+ * @returns {Matrix4} The modified result parameter or a new {@link Matrix4} instance if none was provided.
+ */
+OrientedBoundingBox.prototype.computeTransformation = function (result) {
+  return OrientedBoundingBox.computeTransformation(this, result);
 };
 
 /**

--- a/Specs/Core/AxisAlignedBoundingBoxSpec.js
+++ b/Specs/Core/AxisAlignedBoundingBoxSpec.js
@@ -45,6 +45,44 @@ describe("Core/AxisAlignedBoundingBox", function () {
     expect(box.center).toEqual(expectedCenter);
   });
 
+  it("fromCorners works with a result parameter", function () {
+    const minimum = new Cartesian3(0, 0, 0);
+    const maximum = new Cartesian3(1, 1, 1);
+    const expectedCenter = new Cartesian3(0.5, 0.5, 0.5);
+
+    const box = new AxisAlignedBoundingBox();
+    const result = AxisAlignedBoundingBox.fromCorners(minimum, maximum, box);
+
+    expect(result.minimum).toEqual(minimum);
+    expect(result.maximum).toEqual(maximum);
+    expect(result.center).toEqual(expectedCenter);
+    expect(result).toBe(box);
+  });
+
+  it("fromCorners works without a result parameter", function () {
+    const minimum = new Cartesian3(0, 0, 0);
+    const maximum = new Cartesian3(1, 1, 1);
+    const expectedCenter = new Cartesian3(0.5, 0.5, 0.5);
+
+    const box = AxisAlignedBoundingBox.fromCorners(minimum, maximum);
+
+    expect(box.minimum).toEqual(minimum);
+    expect(box.maximum).toEqual(maximum);
+    expect(box.center).toEqual(expectedCenter);
+  });
+
+  it("fromCorners throws without a minimum", function () {
+    expect(function () {
+      AxisAlignedBoundingBox.fromCorners(undefined, Cartesian3.ZERO);
+    }).toThrowDeveloperError();
+  });
+
+  it("fromCorners throws without a maximum", function () {
+    expect(function () {
+      AxisAlignedBoundingBox.fromCorners(Cartesian3.ZERO, undefined);
+    }).toThrowDeveloperError();
+  });
+
   it("fromPoints constructs empty box with undefined positions", function () {
     const box = AxisAlignedBoundingBox.fromPoints(undefined);
     expect(box.minimum).toEqual(Cartesian3.ZERO);

--- a/Specs/Core/BoundingSphereSpec.js
+++ b/Specs/Core/BoundingSphereSpec.js
@@ -10,6 +10,7 @@ import { Math as CesiumMath } from "../../Source/Cesium.js";
 import { Matrix4 } from "../../Source/Cesium.js";
 import { OrientedBoundingBox } from "../../Source/Cesium.js";
 import { Plane } from "../../Source/Cesium.js";
+import { Quaternion } from "../../Source/Cesium.js";
 import { Rectangle } from "../../Source/Cesium.js";
 import createPackableSpecs from "../createPackableSpecs.js";
 
@@ -578,6 +579,56 @@ describe("Core/BoundingSphere", function () {
   it("throws from fromOrientedBoundingBox with undefined orientedBoundingBox parameter", function () {
     expect(function () {
       BoundingSphere.fromOrientedBoundingBox(undefined);
+    }).toThrowDeveloperError();
+  });
+
+  it("fromTransformation works with a result parameter", function () {
+    const translation = new Cartesian3(1.0, 2.0, 3.0);
+    const rotation = Quaternion.fromAxisAngle(Cartesian3.UNIT_Z, 0.4);
+    const scale = new Cartesian3(1.0, 2.0, 3.0);
+    const expectedRadius = 0.5 * Cartesian3.magnitude(scale);
+    const transformation = Matrix4.fromTranslationQuaternionRotationScale(
+      translation,
+      rotation,
+      scale
+    );
+
+    const sphere = new BoundingSphere();
+    const result = BoundingSphere.fromTransformation(transformation, sphere);
+
+    expect(result.center).toEqual(translation);
+    expect(result.radius).toEqualEpsilon(expectedRadius, CesiumMath.EPSILON14);
+    expect(result).toBe(sphere);
+  });
+
+  it("fromTransformation works without a result parameter", function () {
+    const translation = new Cartesian3(1.0, 2.0, 3.0);
+    const rotation = Quaternion.fromAxisAngle(Cartesian3.UNIT_Z, 0.4);
+    const scale = new Cartesian3(1.0, 2.0, 3.0);
+    const expectedRadius = 0.5 * Cartesian3.magnitude(scale);
+    const transformation = Matrix4.fromTranslationQuaternionRotationScale(
+      translation,
+      rotation,
+      scale
+    );
+
+    const sphere = BoundingSphere.fromTransformation(transformation);
+    expect(sphere.center).toEqual(translation);
+    expect(sphere.radius).toEqualEpsilon(expectedRadius, CesiumMath.EPSILON14);
+  });
+
+  it("fromTransformation works with a transformation that has zero scale", function () {
+    const transformation = Matrix4.fromScale(Cartesian3.ZERO);
+
+    const sphere = BoundingSphere.fromTransformation(transformation);
+
+    expect(sphere.center).toEqual(Cartesian3.ZERO);
+    expect(sphere.radius).toEqual(0.0);
+  });
+
+  it("throws from fromTransformation with undefined transformation parameter", function () {
+    expect(function () {
+      BoundingSphere.fromTransformation(undefined);
     }).toThrowDeveloperError();
   });
 

--- a/Specs/Core/Matrix4Spec.js
+++ b/Specs/Core/Matrix4Spec.js
@@ -5002,7 +5002,7 @@ describe("Core/Matrix4", function () {
     }).toThrowDeveloperError();
   });
 
-  it("computeView throws without a result paramter", function () {
+  it("computeView throws without a result parameter", function () {
     expect(function () {
       const position = Cartesian3.ONE;
       const direction = Cartesian3.UNIT_Z;

--- a/Specs/Core/PlaneSpec.js
+++ b/Specs/Core/PlaneSpec.js
@@ -173,7 +173,7 @@ describe("Core/Plane", function () {
     expect(result.distance).toEqual(distance);
   });
 
-  it("clones a plane instance into a result paramter", function () {
+  it("clones a plane instance into a result parameter", function () {
     let normal = new Cartesian3(1.0, 2.0, 3.0);
     normal = Cartesian3.normalize(normal, normal);
     const distance = 4.0;

--- a/Specs/Core/RectangleSpec.js
+++ b/Specs/Core/RectangleSpec.js
@@ -1041,6 +1041,361 @@ describe("Core/Rectangle", function () {
     }).toThrowDeveloperError();
   });
 
+  it("subsection works with a result parameter", function () {
+    const west = 0.0;
+    const east = 0.5;
+    const south = 0.0;
+    const north = 0.5;
+    const rectangle = new Rectangle(west, south, east, north);
+
+    const westLerp = 0.25;
+    const eastLerp = 0.75;
+    const southLerp = 0.25;
+    const northLerp = 0.75;
+
+    const expectedWest = 0.125;
+    const expectedEast = 0.375;
+    const expectedSouth = 0.125;
+    const expectedNorth = 0.375;
+    const expectedRectangle = new Rectangle(
+      expectedWest,
+      expectedSouth,
+      expectedEast,
+      expectedNorth
+    );
+
+    const subsection = new Rectangle();
+    const result = Rectangle.subsection(
+      rectangle,
+      westLerp,
+      southLerp,
+      eastLerp,
+      northLerp,
+      subsection
+    );
+
+    expect(result).toEqual(expectedRectangle);
+    expect(result).toBe(subsection);
+  });
+
+  it("subsection works with no result parameter", function () {
+    const west = 0.0;
+    const east = 0.5;
+    const south = 0.0;
+    const north = 0.5;
+    const rectangle = new Rectangle(west, south, east, north);
+
+    const westLerp = 0.25;
+    const eastLerp = 0.75;
+    const southLerp = 0.25;
+    const northLerp = 0.75;
+
+    const expectedWest = 0.125;
+    const expectedEast = 0.375;
+    const expectedSouth = 0.125;
+    const expectedNorth = 0.375;
+    const expectedRectangle = new Rectangle(
+      expectedWest,
+      expectedSouth,
+      expectedEast,
+      expectedNorth
+    );
+
+    const subsection = Rectangle.subsection(
+      rectangle,
+      westLerp,
+      southLerp,
+      eastLerp,
+      northLerp
+    );
+
+    expect(subsection).toEqual(expectedRectangle);
+  });
+
+  it("subsection works with empty range", function () {
+    const west = 0.0;
+    const east = 0.5;
+    const south = 0.0;
+    const north = 0.5;
+    const rectangle = new Rectangle(west, south, east, north);
+
+    const westLerp = 0.0;
+    const eastLerp = 0.0;
+    const southLerp = 0.0;
+    const northLerp = 0.0;
+
+    const expectedWest = west;
+    const expectedEast = west;
+    const expectedSouth = south;
+    const expectedNorth = south;
+    const expectedRectangle = new Rectangle(
+      expectedWest,
+      expectedSouth,
+      expectedEast,
+      expectedNorth
+    );
+
+    const subsection = Rectangle.subsection(
+      rectangle,
+      westLerp,
+      southLerp,
+      eastLerp,
+      northLerp
+    );
+
+    expect(subsection).toEqual(expectedRectangle);
+  });
+
+  it("subsection works with full range", function () {
+    const west = 0.1;
+    const east = 0.9;
+    const south = 0.1;
+    const north = 0.9;
+    const rectangle = new Rectangle(west, south, east, north);
+
+    const westLerp = 0.0;
+    const eastLerp = 1.0;
+    const southLerp = 0.0;
+    const northLerp = 1.0;
+
+    const expectedWest = west;
+    const expectedEast = east;
+    const expectedSouth = south;
+    const expectedNorth = north;
+    const expectedRectangle = new Rectangle(
+      expectedWest,
+      expectedSouth,
+      expectedEast,
+      expectedNorth
+    );
+
+    const subsection = Rectangle.subsection(
+      rectangle,
+      westLerp,
+      southLerp,
+      eastLerp,
+      northLerp
+    );
+
+    expect(subsection).toEqual(expectedRectangle);
+  });
+
+  it("subsection works with zero area rectangle", function () {
+    const west = 0.1;
+    const east = 0.1;
+    const south = 0.1;
+    const north = 0.1;
+    const rectangle = new Rectangle(west, south, east, north);
+
+    // These values should have no effect on the final result
+    // because the rectangle has zero area.
+    const westLerp = 0.22;
+    const eastLerp = 0.88;
+    const southLerp = 0.22;
+    const northLerp = 0.88;
+
+    const expectedWest = west;
+    const expectedEast = east;
+    const expectedSouth = south;
+    const expectedNorth = north;
+    const expectedRectangle = new Rectangle(
+      expectedWest,
+      expectedSouth,
+      expectedEast,
+      expectedNorth
+    );
+
+    const subsection = Rectangle.subsection(
+      rectangle,
+      westLerp,
+      southLerp,
+      eastLerp,
+      northLerp
+    );
+
+    expect(subsection).toEqual(expectedRectangle);
+  });
+
+  it("subsection works with rectangle that crosses IDL and subsection that crosses IDL", function () {
+    const west = CesiumMath.toRadians(+45);
+    const east = CesiumMath.toRadians(-45);
+    const south = CesiumMath.toRadians(-90);
+    const north = CesiumMath.toRadians(+90);
+    const rectangle = new Rectangle(west, south, east, north);
+
+    const westLerp = 0.25;
+    const eastLerp = 0.75;
+    const southLerp = 0.0;
+    const northLerp = 1.0;
+
+    const expectedWest = CesiumMath.toRadians(+112.5);
+    const expectedEast = CesiumMath.toRadians(-112.5);
+    const expectedSouth = south;
+    const expectedNorth = north;
+    const expectedRectangle = new Rectangle(
+      expectedWest,
+      expectedSouth,
+      expectedEast,
+      expectedNorth
+    );
+
+    const subsection = Rectangle.subsection(
+      rectangle,
+      westLerp,
+      southLerp,
+      eastLerp,
+      northLerp
+    );
+
+    expect(subsection).toEqualEpsilon(expectedRectangle, CesiumMath.EPSILON14);
+  });
+
+  it("subsection works with rectangle that crosses IDL and subsection that doesn't cross IDL", function () {
+    const west = CesiumMath.toRadians(+45);
+    const east = CesiumMath.toRadians(-45);
+    const south = CesiumMath.toRadians(-90);
+    const north = CesiumMath.toRadians(+90);
+    const rectangle = new Rectangle(west, south, east, north);
+
+    const westLerp = 0.75;
+    const eastLerp = 1.0;
+    const southLerp = 0.0;
+    const northLerp = 1.0;
+
+    const expectedWest = CesiumMath.toRadians(-112.5);
+    const expectedEast = east;
+    const expectedSouth = south;
+    const expectedNorth = north;
+    const expectedRectangle = new Rectangle(
+      expectedWest,
+      expectedSouth,
+      expectedEast,
+      expectedNorth
+    );
+
+    const subsection = Rectangle.subsection(
+      rectangle,
+      westLerp,
+      southLerp,
+      eastLerp,
+      northLerp
+    );
+
+    expect(subsection).toEqualEpsilon(expectedRectangle, CesiumMath.EPSILON14);
+  });
+
+  it("subsection works with rectangle that crosses IDL and subsection with full range", function () {
+    const west = CesiumMath.toRadians(+45);
+    const east = CesiumMath.toRadians(-45);
+    const south = CesiumMath.toRadians(-90);
+    const north = CesiumMath.toRadians(+90);
+    const rectangle = new Rectangle(west, south, east, north);
+
+    const westLerp = 0.0;
+    const eastLerp = 1.0;
+    const southLerp = 0.0;
+    const northLerp = 1.0;
+
+    const expectedWest = west;
+    const expectedEast = east;
+    const expectedSouth = south;
+    const expectedNorth = north;
+    const expectedRectangle = new Rectangle(
+      expectedWest,
+      expectedSouth,
+      expectedEast,
+      expectedNorth
+    );
+
+    const subsection = Rectangle.subsection(
+      rectangle,
+      westLerp,
+      southLerp,
+      eastLerp,
+      northLerp
+    );
+
+    expect(subsection).toEqualEpsilon(expectedRectangle, CesiumMath.EPSILON14);
+  });
+
+  it("subsection throws with no rectangle", function () {
+    expect(function () {
+      Rectangle.subsection(undefined);
+    }).toThrowDeveloperError();
+  });
+
+  it("subsection throws with no westLerp", function () {
+    expect(function () {
+      Rectangle.subsection(new Rectangle(), undefined, 0.0, 0.0, 0.0);
+    }).toThrowDeveloperError();
+  });
+
+  it("subsection throws with no southLerp", function () {
+    expect(function () {
+      Rectangle.subsection(new Rectangle(), 0.0, undefined, 0.0, 0.0);
+    }).toThrowDeveloperError();
+  });
+
+  it("subsection throws with no eastLerp", function () {
+    expect(function () {
+      Rectangle.subsection(new Rectangle(), 0.0, 0.0, undefined, 0.0);
+    }).toThrowDeveloperError();
+  });
+
+  it("subsection throws with no northLerp", function () {
+    expect(function () {
+      Rectangle.subsection(new Rectangle(), 0.0, 0.0, 0.0, undefined);
+    }).toThrowDeveloperError();
+  });
+
+  it("subsection throws with out of range westLerp", function () {
+    expect(function () {
+      Rectangle.subsection(new Rectangle(), -0.1, 0.0, 0.0, 0.0);
+    }).toThrowDeveloperError();
+    expect(function () {
+      Rectangle.subsection(new Rectangle(), 1.1, 0.0, 0.0, 0.0);
+    }).toThrowDeveloperError();
+    expect(function () {
+      Rectangle.subsection(new Rectangle(), 0.5, 0.0, 0.4, 0.0);
+    }).toThrowDeveloperError();
+  });
+
+  it("subsection throws with out of range southLerp", function () {
+    expect(function () {
+      Rectangle.subsection(new Rectangle(), 0.0, -0.1, 0.0, 0.0);
+    }).toThrowDeveloperError();
+    expect(function () {
+      Rectangle.subsection(new Rectangle(), 0.0, 1.1, 0.0, 0.0);
+    }).toThrowDeveloperError();
+    expect(function () {
+      Rectangle.subsection(new Rectangle(), 0.0, 0.5, 0.0, 0.4);
+    }).toThrowDeveloperError();
+  });
+
+  it("subsection throws with out of range eastLerp", function () {
+    expect(function () {
+      Rectangle.subsection(new Rectangle(), 0.0, 0.0, -0.1, 0.0);
+    }).toThrowDeveloperError();
+    expect(function () {
+      Rectangle.subsection(new Rectangle(), 0.0, 0.0, 1.1, 0.0);
+    }).toThrowDeveloperError();
+    expect(function () {
+      Rectangle.subsection(new Rectangle(), 0.5, 0.0, 0.4, 0.0);
+    }).toThrowDeveloperError();
+  });
+
+  it("subsection throws with out of range northLerp", function () {
+    expect(function () {
+      Rectangle.subsection(new Rectangle(), 0.0, 0.0, 0.0, -0.1);
+    }).toThrowDeveloperError();
+    expect(function () {
+      Rectangle.subsection(new Rectangle(), 0.0, 0.0, 0.0, 1.1);
+    }).toThrowDeveloperError();
+    expect(function () {
+      Rectangle.subsection(new Rectangle(), 0.0, 0.5, 0.0, 0.4);
+    }).toThrowDeveloperError();
+  });
+
   it("intersection throws with no rectangle", function () {
     expect(function () {
       Rectangle.intersection(undefined);


### PR DESCRIPTION
Merge https://github.com/CesiumGS/cesium/pull/10124 first.

This could have been split up into 6 small PRs, but they're all kinda similar and hopefully non-controversial. These functions aren't used in CesiumJS yet, but I have a private branch that does use all of them. Plus, I think these functions will be useful for other things. They all have 100% coverage.

I put a :question: where I wasn't sure about naming. Let me know.

#### `AxisAlignedBoundingBox.fromCorners`
Basically identical to the `AxisAlignedBoundingBox` constructor. It exists so that you can use a result parameter instead of allocating.
#### `BoundingSphere.fromTransformation`
Pretty similar to `BoundingSphere.fromOrientedBoundingBox`, but avoids the intermediate conversion to an `OrientedBoundingBox`.
#### `OrientedBoundingBox.fromTransformation`
The box's center becomes the translation and the half axes become the top left `Matrix3` (but with half the scale).
#### `OrientedBoundingBox.computeTransformation`
Opposite of `OrientedBoundingBox.fromTransformation`. Is this a good name :question: 
#### `OrientedBoundingBox.computeCorners`
Computes the eight corners of the `OrientedBoundingBox` and stores them in an array. Useful for debug visualizations or as an intermediate step for other algorithms.
#### `Rectangle.subsection`
Returns a subsection (aka patch / subregion / etc) of a rectangle given interpolation factors for west, south, east, and north. Is this a good name :question: