### PR TITLE
Remove `xdescribe` from `Vector3DTileContentSpec`

### DIFF
--- a/Specs/Scene/Vector3DTileContentSpec.js
+++ b/Specs/Scene/Vector3DTileContentSpec.js
@@ -23,7 +23,7 @@ import Cesium3DTilesTester from "../Cesium3DTilesTester.js";
 import createScene from "../createScene.js";
 
 // See https://github.com/CesiumGS/cesium/issues/7249#issuecomment-546347729
-xdescribe(
+describe(
   "Scene/Vector3DTileContent",
   function () {
     const tilesetRectangle = Rectangle.fromDegrees(-0.01, -0.01, 0.01, 0.01);

--- a/Specs/Scene/Vector3DTileContentSpec.js
+++ b/Specs/Scene/Vector3DTileContentSpec.js
@@ -22,7 +22,6 @@ import {
 import Cesium3DTilesTester from "../Cesium3DTilesTester.js";
 import createScene from "../createScene.js";
 
-// See https://github.com/CesiumGS/cesium/issues/7249#issuecomment-546347729
 describe(
   "Scene/Vector3DTileContent",
   function () {


### PR DESCRIPTION
This `xdescribe` was from [this comment](https://github.com/CesiumGS/cesium/issues/7249#issuecomment-548177981) in #7249. I ran Travis three times on this branch and all three builds passed; there will be a fourth run for the second commit. If that passes too this should be safe to merge to `main`. 

I don't want to use the "fixes" keyword since #7249 has more than this test failure but that issue can probably be closed after this is merged.

@ggetz Could you please review/merge once CI passes? Thanks!