### PR TITLE
Fixed leftover `var` 

### DIFF
--- a/Apps/HelloWorld.html
+++ b/Apps/HelloWorld.html
@@ -28,7 +28,7 @@
   <body>
     <div id="cesiumContainer"></div>
     <script>
-      var viewer = new Cesium.Viewer("cesiumContainer");
+      const viewer = new Cesium.Viewer("cesiumContainer");
     </script>
   </body>
 </html>

--- a/Source/Core/S2Cell.js
+++ b/Source/Core/S2Cell.js
@@ -216,7 +216,8 @@ S2Cell.isValidId = function (cellId) {
   }
 
   // Check trailing 1 bit is in one of the even bit positions allowed for the 30 levels, using a bitmask.
-  var lowestSetBit = cellId & (~cellId + BigInt(1)); // eslint-disable-line
+  // eslint-disable-next-line no-undef
+  const lowestSetBit = cellId & (~cellId + BigInt(1));
   // eslint-disable-next-line
   if (!(lowestSetBit & BigInt("0x1555555555555555"))) {
     return false;
@@ -329,9 +330,11 @@ S2Cell.prototype.getChild = function (index) {
   //>>includeEnd('debug');
 
   // Shift sentinel bit 2 positions to the right.
-  var newLsb = lsb(this._cellId) >> BigInt(2); // eslint-disable-line
+  // eslint-disable-next-line no-undef
+  const newLsb = lsb(this._cellId) >> BigInt(2);
   // Insert child index before the sentinel bit.
-  var childCellId = this._cellId + BigInt(2 * index + 1 - 4) * newLsb; // eslint-disable-line
+  // eslint-disable-next-line no-undef
+  const childCellId = this._cellId + BigInt(2 * index + 1 - 4) * newLsb;
   return new S2Cell(childCellId);
 };
 
@@ -348,9 +351,11 @@ S2Cell.prototype.getParent = function () {
   }
   //>>includeEnd('debug');
   // Shift the sentinel bit 2 positions to the left.
-  var newLsb = lsb(this._cellId) << BigInt(2); // eslint-disable-line
+  // eslint-disable-next-line no-undef
+  const newLsb = lsb(this._cellId) << BigInt(2);
   // Erase the left over bits to the right of the sentinel bit.
-  return new S2Cell((this._cellId & (~newLsb + BigInt(1))) | newLsb); // eslint-disable-line
+  // eslint-disable-next-line no-undef
+  return new S2Cell((this._cellId & (~newLsb + BigInt(1))) | newLsb);
 };
 
 /**
@@ -451,8 +456,8 @@ S2Cell.fromFacePositionLevel = function (face, position, level) {
   ).join("0");
   const positionSuffixPadding = Array(S2_POSITION_BITS - 2 * level).join("0");
 
-  // eslint-disable-next-line
-  var cellId = BigInt(
+  // eslint-disable-next-line no-undef
+  const cellId = BigInt(
     `0b${faceBitString}${positionPrefixPadding}${positionBitString}1${
       // Adding the sentinel bit that always follows the position bits.
       positionSuffixPadding
@@ -511,7 +516,8 @@ function convertCellIdToFaceIJ(cellId) {
     generateLookupTable();
   }
 
-  var face = Number(cellId >> BigInt(S2_POSITION_BITS)); // eslint-disable-line
+  // eslint-disable-next-line no-undef
+  const face = Number(cellId >> BigInt(S2_POSITION_BITS));
   let bits = face & S2_SWAP_MASK;
   const lookupMask = (1 << S2_LOOKUP_BITS) - 1;
 

--- a/Source/Core/buildModuleUrl.js
+++ b/Source/Core/buildModuleUrl.js
@@ -5,12 +5,12 @@ import Resource from "./Resource.js";
 
 /*global CESIUM_BASE_URL*/
 
-var cesiumScriptRegex = /((?:.*\/)|^)Cesium\.js(?:\?|\#|$)/;
+const cesiumScriptRegex = /((?:.*\/)|^)Cesium\.js(?:\?|\#|$)/;
 function getBaseUrlFromCesiumScript() {
-  var scripts = document.getElementsByTagName("script");
-  for (var i = 0, len = scripts.length; i < len; ++i) {
-    var src = scripts[i].getAttribute("src");
-    var result = cesiumScriptRegex.exec(src);
+  const scripts = document.getElementsByTagName("script");
+  for (let i = 0, len = scripts.length; i < len; ++i) {
+    const src = scripts[i].getAttribute("src");
+    const result = cesiumScriptRegex.exec(src);
     if (result !== null) {
       return result[1];
     }
@@ -18,7 +18,7 @@ function getBaseUrlFromCesiumScript() {
   return undefined;
 }
 
-var a;
+let a;
 function tryMakeAbsolute(url) {
   if (typeof document === "undefined") {
     //Node.js and Web Workers. In both cases, the URL will already be absolute.
@@ -36,13 +36,13 @@ function tryMakeAbsolute(url) {
   return a.href;
 }
 
-var baseResource;
+let baseResource;
 function getCesiumBaseUrl() {
   if (defined(baseResource)) {
     return baseResource;
   }
 
-  var baseUrlString;
+  let baseUrlString;
   if (typeof CESIUM_BASE_URL !== "undefined") {
     baseUrlString = CESIUM_BASE_URL;
   } else if (
@@ -81,13 +81,13 @@ function buildModuleUrlFromRequireToUrl(moduleID) {
 }
 
 function buildModuleUrlFromBaseUrl(moduleID) {
-  var resource = getCesiumBaseUrl().getDerivedResource({
+  const resource = getCesiumBaseUrl().getDerivedResource({
     url: moduleID,
   });
   return resource.url;
 }
 
-var implementation;
+let implementation;
 
 /**
  * Given a relative URL under the Cesium base URL, returns an absolute URL.
@@ -119,7 +119,7 @@ function buildModuleUrl(relativeUrl) {
     }
   }
 
-  var url = implementation(relativeUrl);
+  const url = implementation(relativeUrl);
   return url;
 }
 

--- a/Source/Scene/Implicit3DTileContent.js
+++ b/Source/Scene/Implicit3DTileContent.js
@@ -821,16 +821,16 @@ function deriveBoundingVolumeS2(
   }
 
   // Extract the first 3 face bits from the 64-bit S2 cell ID.
-  // eslint-disable-next-line
-  var face = Number(parentTile._boundingVolume.s2Cell._cellId >> BigInt(61));
+  // eslint-disable-next-line no-undef
+  const face = Number(parentTile._boundingVolume.s2Cell._cellId >> BigInt(61));
   // The Hilbert curve is rotated for the "odd" faces on the S2 Earthcube.
   // See http://s2geometry.io/devguide/img/s2cell_global.jpg
   const position =
     face % 2 === 0
       ? HilbertOrder.encode2D(level, x, y)
       : HilbertOrder.encode2D(level, y, x);
-  // eslint-disable-next-line
-  var cell = S2Cell.fromFacePositionLevel(face, BigInt(position), level);
+  // eslint-disable-next-line no-undef
+  const cell = S2Cell.fromFacePositionLevel(face, BigInt(position), level);
 
   let minHeight, maxHeight;
   if (defined(z)) {

--- a/Source/Scene/MetadataTableProperty.js
+++ b/Source/Scene/MetadataTableProperty.js
@@ -412,7 +412,8 @@ function getInt64NumberFallback(index, values) {
 function getInt64BigIntFallback(index, values) {
   const dataView = values.dataView;
   const byteOffset = index * 8;
-  var value = BigInt(0); // eslint-disable-line
+  // eslint-disable-next-line no-undef
+  let value = BigInt(0);
   const isNegative = (dataView.getUint8(byteOffset + 7) & 0x80) > 0;
   let carrying = true;
   for (let i = 0; i < 8; ++i) {
@@ -454,11 +455,15 @@ function getUint64BigIntFallback(index, values) {
   const byteOffset = index * 8;
 
   // Split 64-bit number into two 32-bit (4-byte) parts
-  var left = BigInt(dataView.getUint32(byteOffset, true)); // eslint-disable-line
-  var right = BigInt(dataView.getUint32(byteOffset + 4, true)); // eslint-disable-line
+  // eslint-disable-next-line no-undef
+  const left = BigInt(dataView.getUint32(byteOffset, true));
+
+  // eslint-disable-next-line no-undef
+  const right = BigInt(dataView.getUint32(byteOffset + 4, true));
 
   // Combine the two 32-bit values
-  var value = left + BigInt(4294967296) * right; // eslint-disable-line
+  // eslint-disable-next-line no-undef
+  const value = left + BigInt(4294967296) * right;
 
   return value;
 }

--- a/Source/Scene/PointCloudEyeDomeLighting.js
+++ b/Source/Scene/PointCloudEyeDomeLighting.js
@@ -196,11 +196,6 @@ PointCloudEyeDomeLighting.prototype.update = function (
       continue;
     }
 
-    // These variables need to get reset for each iteration. It has to be
-    // done manually since var is function scope not block scope.
-    derivedCommand = undefined;
-    originalShaderProgram = undefined;
-
     let derivedCommandObject = command.derivedCommands.pointCloudProcessor;
     if (defined(derivedCommandObject)) {
       derivedCommand = derivedCommandObject.command;

--- a/Source/Scene/PointCloudEyeDomeLighting.js
+++ b/Source/Scene/PointCloudEyeDomeLighting.js
@@ -184,9 +184,6 @@ PointCloudEyeDomeLighting.prototype.update = function (
   const commandList = frameState.commandList;
   const commandEnd = commandList.length;
 
-  let derivedCommand;
-  let originalShaderProgram;
-
   for (i = commandStart; i < commandEnd; ++i) {
     const command = commandList[i];
     if (
@@ -195,6 +192,9 @@ PointCloudEyeDomeLighting.prototype.update = function (
     ) {
       continue;
     }
+
+    let derivedCommand;
+    let originalShaderProgram;
 
     let derivedCommandObject = command.derivedCommands.pointCloudProcessor;
     if (defined(derivedCommandObject)) {

--- a/Specs/Core/JulianDateSpec.js
+++ b/Specs/Core/JulianDateSpec.js
@@ -251,7 +251,7 @@ describe("Core/JulianDate", function () {
   it("Construct from ISO8601 UTC calendar date and time fractional seconds, basic format", function () {
     //Date is only accurate to milliseconds, while JulianDate, much more so.  The below date gets
     //rounded to 513, so we need to construct a JulianDate directly.
-    //var expectedDate = JulianDate.fromDate(new Date(Date.UTC(2009, 7, 1, 12, 30, 25, 5125423)));
+    //const expectedDate = JulianDate.fromDate(new Date(Date.UTC(2009, 7, 1, 12, 30, 25, 5125423)));
     const expectedDate = new JulianDate(
       2455045,
       1825.5125423,
@@ -276,7 +276,7 @@ describe("Core/JulianDate", function () {
   it('Construct from ISO8601 UTC calendar date and time fractional seconds, basic format, "," instead of "."', function () {
     //Date is only accurate to milliseconds, while JulianDate, much more so.  The below date gets
     //rounded to 513, so we need to construct a JulianDate directly.
-    //var expectedDate = JulianDate.fromDate(new Date(Date.UTC(2009, 7, 1, 12, 30, 25, 5125423)));
+    //const expectedDate = JulianDate.fromDate(new Date(Date.UTC(2009, 7, 1, 12, 30, 25, 5125423)));
     const expectedDate = new JulianDate(
       2455045,
       1825.5125423,

--- a/Specs/Core/ResourceSpec.js
+++ b/Specs/Core/ResourceSpec.js
@@ -2614,7 +2614,7 @@ describe("Core/Resource", function () {
 
     describe("retries when Resource has the callback set", function () {
       it("rejects after too many retries", function () {
-        //var cb = jasmine.createSpy('retry').and.returnValue(true);
+        //const cb = jasmine.createSpy('retry').and.returnValue(true);
         const cb = jasmine
           .createSpy("retry")
           .and.callFake(function (resource, error) {

--- a/Specs/Scene/MetadataComponentTypeSpec.js
+++ b/Specs/Scene/MetadataComponentTypeSpec.js
@@ -322,7 +322,8 @@ describe("Scene/MetadataComponentType", function () {
 
     const min = MetadataComponentType.getMinimum(MetadataComponentType.INT64);
     const max = MetadataComponentType.getMaximum(MetadataComponentType.INT64);
-    var values = [min, min / BigInt(2), 0, max / BigInt(2), max]; // eslint-disable-line
+    // eslint-disable-next-line no-undef
+    const values = [min, min / BigInt(2), 0, max / BigInt(2), max];
     const expectedResults = [-1.0, -0.5, 0.0, 0.5, 1.0];
     for (let j = 0; j < values.length; ++j) {
       const result = MetadataComponentType.normalize(
@@ -339,7 +340,8 @@ describe("Scene/MetadataComponentType", function () {
     }
 
     const max = MetadataComponentType.getMaximum(MetadataComponentType.UINT64);
-    var values = [BigInt(0), max / BigInt(4), max / BigInt(2), max]; // eslint-disable-line
+    // eslint-disable-next-line no-undef
+    const values = [BigInt(0), max / BigInt(4), max / BigInt(2), max];
     const expectedResults = [0.0, 0.25, 0.5, 1.0];
     for (let j = 0; j < values.length; ++j) {
       const result = MetadataComponentType.normalize(


### PR DESCRIPTION
The `var` -> `const`/`let` tool didn't catch places that had:
- `eslint-disable-next-line`
- `eslint-disable-line`

This PR fixes this and uses `eslint-disable-next-line` instead of `eslint-disable-line`.