### PR TITLE
Remove buildModuleUrl from .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,6 +11,5 @@ ThirdParty/**
 Tools/**
 Apps/Sandcastle/jsHintOptions.js
 Apps/Sandcastle/gallery/gallery-index.js
-Source/Core/buildModuleUrl.js
 Specs/spec-main.js
 index.release.html

--- a/Source/Core/buildModuleUrl.js
+++ b/Source/Core/buildModuleUrl.js
@@ -3,7 +3,7 @@ import DeveloperError from "./DeveloperError.js";
 import getAbsoluteUri from "./getAbsoluteUri.js";
 import Resource from "./Resource.js";
 
-/*global CESIUM_BASE_URL*/
+/*global CESIUM_BASE_URL,define,require*/
 
 const cesiumScriptRegex = /((?:.*\/)|^)Cesium\.js(?:\?|\#|$)/;
 function getBaseUrlFromCesiumScript() {
@@ -77,7 +77,7 @@ function getCesiumBaseUrl() {
 
 function buildModuleUrlFromRequireToUrl(moduleID) {
   //moduleID will be non-relative, so require it relative to this module, in Core.
-  return tryMakeAbsolute(require.toUrl("../" + moduleID));
+  return tryMakeAbsolute(require.toUrl(`../${moduleID}`));
 }
 
 function buildModuleUrlFromBaseUrl(moduleID) {


### PR DESCRIPTION
`buildModuleUrl` was incorrectly left in `.eslintignore`. There were only a few fixes needed to re-enable linting for the file.

@IanLilleyT Could you please review?