### PR TITLE
camera.getPickRay exception when Scene is not rendered

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@
 - Fixed a bug where updating `ModelExperimental`'s model matrix would not update its bounding sphere. [#10078](https://github.com/CesiumGS/cesium/pull/10078)
 - Fixed feature ID texture artifacts on Safari. [#10111](https://github.com/CesiumGS/cesium/pull/10111)
 - Fixed a bug where a translucent shader applied to a `ModelExperimental` with opaque features was not being rendered. [#10110](https://github.com/CesiumGS/cesium/pull/10110)
-- Fixed an inconsitenly handled exception in `camera.getPickRay` that arrises when the scene is not rendered. [#10139](https://github.com/CesiumGS/cesium/pull/10139)
+- Fixed an inconsistently handled exception in `camera.getPickRay` that arises when the scene is not rendered. [#10139](https://github.com/CesiumGS/cesium/pull/10139)
 
 ### 1.90 - 2022-02-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 - Fixed a bug where updating `ModelExperimental`'s model matrix would not update its bounding sphere. [#10078](https://github.com/CesiumGS/cesium/pull/10078)
 - Fixed feature ID texture artifacts on Safari. [#10111](https://github.com/CesiumGS/cesium/pull/10111)
 - Fixed a bug where a translucent shader applied to a `ModelExperimental` with opaque features was not being rendered. [#10110](https://github.com/CesiumGS/cesium/pull/10110)
+- Fixed an inconsitenly handled exception in `camera.getPickRay` that arrises when the scene is not rendered. [#10139](https://github.com/CesiumGS/cesium/pull/10139)
 
 ### 1.90 - 2022-02-01
 

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -2974,6 +2974,8 @@ function getPickRayOrthographic(camera, windowPosition, result) {
  * @returns {Ray} Returns the {@link Cartesian3} position and direction of the ray.
  */
 Camera.prototype.getPickRay = function (windowPosition, result) {
+  //TODO: remove this
+  console.log("At the top of getPickRay");
   //>>includeStart('debug', pragmas.debug);
   if (!defined(windowPosition)) {
     throw new DeveloperError("windowPosition is required.");
@@ -2983,9 +2985,14 @@ Camera.prototype.getPickRay = function (windowPosition, result) {
   if (!defined(result)) {
     result = new Ray();
   }
-
+  //TODO: check if the display is 'none'
+  const scene = this._scene;
   const frustum = this.frustum;
-  if (
+  console.log("this._scene.canvas.style['display']");
+  console.log(scene.canvas.style["display"]);
+  if (scene.canvas.style["display"] === "none") {
+    return undefined;
+  } else if (
     defined(frustum.aspectRatio) &&
     defined(frustum.fov) &&
     defined(frustum.near)

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -2971,8 +2971,7 @@ function getPickRayOrthographic(camera, windowPosition, result) {
  *
  * @param {Cartesian2} windowPosition The x and y coordinates of a pixel.
  * @param {Ray} [result] The object onto which to store the result.
- * @returns {Ray} Returns the {@link Cartesian3} position and direction of the ray.
- * If the Scene is not rendered or the pickRay cannot be determined, returns undefined.
+ * @returns {Ray|undefined} Returns the {@link Cartesian3} position and direction of the ray, or undefined if the pick ray cannot be determined.
  */
 Camera.prototype.getPickRay = function (windowPosition, result) {
   //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -2985,9 +2985,9 @@ Camera.prototype.getPickRay = function (windowPosition, result) {
     result = new Ray();
   }
 
-  const scene = this._scene;
+  const canvas = this._scene.canvas;
   const frustum = this.frustum;
-  if (defined(scene.canvas.style) && scene.canvas.style["display"] === "none") {
+  if (canvas.clientWidth <= 0 || canvas.clientHeight <= 0) {
     return undefined;
   } else if (
     defined(frustum.aspectRatio) &&
@@ -2995,9 +2995,9 @@ Camera.prototype.getPickRay = function (windowPosition, result) {
     defined(frustum.near)
   ) {
     return getPickRayPerspective(this, windowPosition, result);
+  } else {
+    return getPickRayOrthographic(this, windowPosition, result);
   }
-
-  return getPickRayOrthographic(this, windowPosition, result);
 };
 
 const scratchToCenter = new Cartesian3();

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -2974,7 +2974,6 @@ function getPickRayOrthographic(camera, windowPosition, result) {
  * @returns {Ray} Returns the {@link Cartesian3} position and direction of the ray.
  */
 Camera.prototype.getPickRay = function (windowPosition, result) {
-  //TODO: remove this
   //>>includeStart('debug', pragmas.debug);
   if (!defined(windowPosition)) {
     throw new DeveloperError("windowPosition is required.");
@@ -2984,7 +2983,7 @@ Camera.prototype.getPickRay = function (windowPosition, result) {
   if (!defined(result)) {
     result = new Ray();
   }
-  //TODO: check if the display is 'none'
+
   const scene = this._scene;
   const frustum = this.frustum;
   if (scene.canvas.style["display"] === "none") {

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -2972,6 +2972,7 @@ function getPickRayOrthographic(camera, windowPosition, result) {
  * @param {Cartesian2} windowPosition The x and y coordinates of a pixel.
  * @param {Ray} [result] The object onto which to store the result.
  * @returns {Ray} Returns the {@link Cartesian3} position and direction of the ray.
+ * If the Scene is not rendered or the pickRay cannot be determined, returns undefined.
  */
 Camera.prototype.getPickRay = function (windowPosition, result) {
   //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -2994,9 +2994,9 @@ Camera.prototype.getPickRay = function (windowPosition, result) {
     defined(frustum.near)
   ) {
     return getPickRayPerspective(this, windowPosition, result);
-  } else {
-    return getPickRayOrthographic(this, windowPosition, result);
   }
+
+  return getPickRayOrthographic(this, windowPosition, result);
 };
 
 const scratchToCenter = new Cartesian3();

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -2975,7 +2975,6 @@ function getPickRayOrthographic(camera, windowPosition, result) {
  */
 Camera.prototype.getPickRay = function (windowPosition, result) {
   //TODO: remove this
-  console.log("At the top of getPickRay");
   //>>includeStart('debug', pragmas.debug);
   if (!defined(windowPosition)) {
     throw new DeveloperError("windowPosition is required.");
@@ -2988,8 +2987,6 @@ Camera.prototype.getPickRay = function (windowPosition, result) {
   //TODO: check if the display is 'none'
   const scene = this._scene;
   const frustum = this.frustum;
-  console.log("this._scene.canvas.style['display']");
-  console.log(scene.canvas.style["display"]);
   if (scene.canvas.style["display"] === "none") {
     return undefined;
   } else if (

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -2986,7 +2986,7 @@ Camera.prototype.getPickRay = function (windowPosition, result) {
 
   const scene = this._scene;
   const frustum = this.frustum;
-  if (scene.canvas.style["display"] === "none") {
+  if (defined(scene.canvas.style) && scene.canvas.style["display"] === "none") {
     return undefined;
   } else if (
     defined(frustum.aspectRatio) &&

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -2985,10 +2985,12 @@ Camera.prototype.getPickRay = function (windowPosition, result) {
   }
 
   const canvas = this._scene.canvas;
-  const frustum = this.frustum;
   if (canvas.clientWidth <= 0 || canvas.clientHeight <= 0) {
     return undefined;
-  } else if (
+  }
+
+  const frustum = this.frustum;
+  if (
     defined(frustum.aspectRatio) &&
     defined(frustum.fov) &&
     defined(frustum.near)

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -3148,6 +3148,17 @@ describe("Scene/Camera", function () {
     }).toThrowDeveloperError();
   });
 
+  it("get pick ray returns undefined if the Scene is not fully rendered", function () {
+    const windowCoord = new Cartesian2(
+      scene.canvas.clientWidth / 2,
+      scene.canvas.clientHeight
+    );
+
+    scene.canvas.clientWidth = 0;
+    const ray = camera.getPickRay(windowCoord);
+    expect(ray).toEqual(undefined);
+  });
+
   it("get pick ray perspective", function () {
     const windowCoord = new Cartesian2(
       scene.canvas.clientWidth / 2,

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -3156,7 +3156,7 @@ describe("Scene/Camera", function () {
 
     scene.canvas.clientWidth = 0;
     const ray = camera.getPickRay(windowCoord);
-    expect(ray).toEqual(undefined);
+    expect(ray).toBeUndefined();
   });
 
   it("get pick ray perspective", function () {


### PR DESCRIPTION
The goal of this pull request is to address the issue with `camera.getPickRay` outlined in #10125

`camera.getPickRay` is currently throwing an exception that is not consistent with the rest of our `Camera` spec when `Scene` is not rendered. Based on the documentation (see [pickEllipsoid](https://cesium.com/learn/cesiumjs/ref-doc/Camera.html?classFilter=came#pickEllipsoid), etc.) and various tests that I ran, pick operations are supposed to return `undefined` if the pick fails.

Currently, after the viewer is updated as follows:
```
viewer.scene.canvas.style.display = 'none';
```
I receive this error:
```
Uncaught DeveloperError: normalized result is not a number
Error
    at new DeveloperError (http://localhost:8080/Source/Core/DeveloperError.js:39:11)
    at Function.Cartesian3.normalize (http://localhost:8080/Source/Core/Cartesian3.js:422:11)
    at getPickRayPerspective (http://localhost:8080/Source/Scene/Camera.js:2922:14)
    at Camera.getPickRay (http://localhost:8080/Source/Scene/Camera.js:2994:12)
    at <anonymous>:7:37
    at HTMLButtonElement.button.onclick (http://localhost:8080/Apps/Sandcastle/Sandcastle-header.js:62:9) (on line 422 of http://localhost:8080/Source/Core/Cartesian3.js)
```

I am using [this sandcastle demo](http://localhost:8080/Apps/Sandcastle/index.html#c=nVE9b8IwEP0rVpYECTm0awOqytKhUqtSdcpy2AdYOGdkX4Jo1f/eS7IgYKjqyfd870PPJlBi1Tk8YlRzRXhUS0yubfTngBV1ZoZ5GYjBEcY6mzzUVNMKyBpI7FGDtR8h+DXEp5Y5UJG/ObPPp2rTkmEnwOS7JqXMYBbhJE6jpU4GCbWBBiPoLXJPfIdTcRZkCZHlBnRfzKazSe8+SgWx9mFbiGAP/vwh17OzeJ3rIgt1kHTikyhYlw5+yJtTIMz/aLPaheM/bdY+SHWjTzbNqmFh0dP78+iaQ4is2ugLrUvGRnjSTrluzR5Zm5TGfpSqynNqZV2nnJ3f+E5lPKQkL5vW+5X7wjpbVKXsX1F9AOto+9phlLT92u5u8TKCWuuqlPE2k8d+LpR/AQ) for my testing.

A few lingering TODO items:

- [X] Update `CHANGES.md`
- [x] Update the `Camera` spec for `getPickRay`
- [x] Fix specs that I broke