### PR TITLE
Sort credits by frequency of occurences

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 - Added support for shadows in `ModelExperimental`. [#10077](https://github.com/CesiumGS/cesium/pull/10077)
 - Added `packArray` and `unpackArray` for matrix types. [#10118](https://github.com/CesiumGS/cesium/pull/10118)
 - glTF copyrights now appear under the credits display. [#10138](https://github.com/CesiumGS/cesium/pull/10138)
+- Credits are now sorted based on their number of occurrences. [#10141](https://github.com/CesiumGS/cesium/pull/10141)
 - Added more affine transformation helper functions to `Matrix2`, `Matrix3`, and `Matrix4`. [#10124](https://github.com/CesiumGS/cesium/pull/10124)
   - Added `setScale`, `setUniformScale`, `setRotation`, `getRotation`, and `multiplyByUniformScale` to `Matrix2`.
   - Added `setScale`, `setUniformScale`, `setRotation`, and `multiplyByUniformScale` to `Matrix3`.

--- a/Source/Scene/CreditDisplay.js
+++ b/Source/Scene/CreditDisplay.js
@@ -12,6 +12,20 @@ const lightboxHeight = 100;
 const textColor = "#ffffff";
 const highlightColor = "#48b";
 
+/**
+ * Used to sort the credits by frequency of appearance
+ * when they are later displayed.
+ *
+ * @alias CreditDisplay.CreditDisplayElement
+ * @constructor
+ *
+ * @private
+ */
+function CreditDisplayElement(credit, count) {
+  this.credit = credit;
+  this.count = defaultValue(count, 1);
+}
+
 function contains(credits, credit) {
   const len = credits.length;
   for (let i = 0; i < len; i++) {
@@ -70,12 +84,11 @@ function displayCredits(container, credits, delimiter, elementWrapperTagName) {
   // Sort the credits such that more frequent credits appear first
   const creditsSorted = credits.slice();
   creditsSorted.sort(function (credit1, credit2) {
-    return credit2[1] - credit1[1];
+    return credit2.count - credit1.count;
   });
 
   for (let creditIndex = 0; creditIndex < credits.length; ++creditIndex) {
-    const creditInfo = creditsSorted[creditIndex];
-    const credit = creditInfo[0];
+    const credit = creditsSorted[creditIndex].credit;
     if (defined(credit)) {
       domIndex = creditIndex;
       if (defined(delimiter)) {
@@ -350,9 +363,6 @@ function CreditDisplay(container, delimiter, viewport) {
   this._previousCesiumCredit = undefined;
   this._currentCesiumCredit = cesiumCredit;
 
-  // Each AssociativeArray contains both the credit and the number of times
-  // it has been added to the display. This is used to sort the credits by
-  // frequency of appearance when they are later displayed.
   this._currentFrameCredits = {
     screenCredits: new AssociativeArray(),
     lightboxCredits: new AssociativeArray(),
@@ -397,11 +407,10 @@ CreditDisplay.prototype.addCredit = function (credit) {
   }
 
   if (credits.contains(credit.id)) {
-    const creditInfo = credits.get(credit.id);
-    const creditCount = creditInfo[1];
-    credits.set(credit.id, [credit, creditCount + 1]);
+    const creditCount = credits.get(credit.id).count;
+    credits.set(credit.id, new CreditDisplayElement(credit, creditCount + 1));
   } else {
-    credits.set(credit.id, [credit, 1]);
+    credits.set(credit.id, new CreditDisplayElement(credit));
   }
 };
 
@@ -468,7 +477,10 @@ CreditDisplay.prototype.beginFrame = function () {
   const defaultCredits = this._defaultCredits;
   for (let i = 0; i < defaultCredits.length; ++i) {
     const defaultCredit = defaultCredits[i];
-    screenCredits.set(defaultCredit.id, [defaultCredit, Number.MAX_VALUE]);
+    screenCredits.set(
+      defaultCredit.id,
+      new CreditDisplayElement(defaultCredit, Number.MAX_VALUE)
+    );
   }
 
   currentFrameCredits.lightboxCredits.removeAll();
@@ -579,4 +591,6 @@ Object.defineProperties(CreditDisplay, {
     },
   },
 });
+
+CreditDisplay.CreditDisplayElement = CreditDisplayElement;
 export default CreditDisplay;

--- a/Specs/Data/Cesium3DTiles/GltfContentWithRepeatedCopyrights/glTF/ll.gltf
+++ b/Specs/Data/Cesium3DTiles/GltfContentWithRepeatedCopyrights/glTF/ll.gltf
@@ -1,0 +1,164 @@
+{
+  "accessors": [
+    {
+      "bufferView": 0,
+      "byteOffset": 0,
+      "componentType": 5126,
+      "count": 240,
+      "type": "VEC3",
+      "min": [
+        -69.262685040012,
+        -63.42564369086176,
+        -51.21932876482606
+      ],
+      "max": [
+        84.98775890329853,
+        61.14907375629991,
+        46.49423664715141
+      ]
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 0,
+      "componentType": 5126,
+      "count": 240,
+      "type": "VEC3",
+      "min": [
+        -0.9686407230533828,
+        -0.7415693003175017,
+        -0.7655772493024053
+      ],
+      "max": [
+        0.9686407230533828,
+        0.7415693003175017,
+        0.7655772493024053
+      ]
+    },
+    {
+      "bufferView": 2,
+      "byteOffset": 0,
+      "componentType": 5123,
+      "count": 360,
+      "type": "SCALAR",
+      "min": [
+        0
+      ],
+      "max": [
+        239
+      ]
+    }
+  ],
+  "asset": {
+    "copyright": "Most Frequent Copyright, Second Repeated Copyright, Unique Copyright",
+    "generator": "3d-tiles-samples-generator",
+    "version": "2.0"
+  },
+  "buffers": [
+    {
+      "name": "buffer",
+      "byteLength": 6480,
+      "uri": "data:application/octet-stream;base64,Dd50Qb0KqsEC/5XB6nO7QSpdmcEC/5XBiD+wQZxdW8F1qkDBSXVeQcG4fMF1qkDBWzFRQcEBScHoUtLBkZ2pQZumJ8HoUtLBL2meQcSToMAgqZzBl8g6QQ9K48AgqZzBkZ2pQZumJ8HoUtLBL2meQcSToMAgqZzBiD+wQZxdW8F1qkDB6nO7QSpdmcEC/5XBWzFRQcEBScHoUtLBl8g6QQ9K48AgqZzBSXVeQcG4fMF1qkDBDd50Qb0KqsEC/5XBl8g6QQ9K48AgqZzBL2meQcSToMAgqZzBiD+wQZxdW8F1qkDBSXVeQcG4fMF1qkDBWzFRQcEBScHoUtLBkZ2pQZumJ8HoUtLB6nO7QSpdmcEC/5XBDd50Qb0KqsEC/5XBRwaIwKI0N8HZy8C8P7XIQJ4EDMHZy8C8gziQQM5I77+Z5AZBA4PAwDsyksCZ5AZB/c3VwJq+/L836APBE9t1QASDOT836APBm+EEQGln80DpMVc+XSUHwWIHnUDpMVc+E9t1QASDOT836APBm+EEQGln80DpMVc+gziQQM5I77+Z5AZBP7XIQJ4EDMHZy8C8/c3VwJq+/L836APBXSUHwWIHnUDpMVc+A4PAwDsyksCZ5AZBRwaIwKI0N8HZy8C8XSUHwWIHnUDpMVc+m+EEQGln80DpMVc+gziQQM5I77+Z5AZBA4PAwDsyksCZ5AZB/c3VwJq+/L836APBE9t1QASDOT836APBP7XIQJ4EDMHZy8C8RwaIwKI0N8HZy8C8BP0UwuKjmEEOUh9CdPDiwancqkEOUh9CGxLuwQNC1kEZ+jlC2I0awjwJxEEZ+jlCnDccwuoA0UEl3wZCo2XxwbE540El3wZCS4f8wYVPB0IwhyFCcMghwkRm/EEwhyFCo2XxwbE540El3wZCS4f8wYVPB0IwhyFCGxLuwQNC1kEZ+jlCdPDiwancqkEOUh9CnDccwuoA0UEl3wZCcMghwkRm/EEwhyFC2I0awjwJxEEZ+jlCBP0UwuKjmEEOUh9CcMghwkRm/EEwhyFCS4f8wYVPB0IwhyFCGxLuwQNC1kEZ+jlC2I0awjwJxEEZ+jlCnDccwuoA0UEl3wZCo2XxwbE540El3wZCdPDiwancqkEOUh9CBP0UwuKjmEEOUh9C5c6wwAmez8HjD7zBJgmbv7zDxsHjD7zB7Q0OwLJQp8EBbZXBkhPRwP8qsMEBbZXBkZviwOUUn8E+K+bB6x0xwJg6lsE+K+bBRKdxwBuPbcFciL/BH3ABwbVDf8FciL/B6x0xwJg6lsE+K+bBRKdxwBuPbcFciL/B7Q0OwLJQp8EBbZXBJgmbv7zDxsHjD7zBkZviwOUUn8E+K+bBH3ABwbVDf8FciL/BkhPRwP8qsMEBbZXB5c6wwAmez8HjD7zBH3ABwbVDf8FciL/BRKdxwBuPbcFciL/B7Q0OwLJQp8EBbZXBkhPRwP8qsMEBbZXBkZviwOUUn8E+K+bB6x0xwJg6lsE+K+bBJgmbv7zDxsHjD7zB5c6wwAmez8HjD7zBigIEQfONXMHU6CXBOBWSQRZ5M8HU6CXBdUWDQTvzf8CcQ8C/CsbMQFgj0sCcQ8C/FL7JQERSxsCrnIfBd4OCQRRRaMCrnIfBamdnQQqgZUD1WAHBCn+OQCqZgj/1WAHBd4OCQRRRaMCrnIfBamdnQQqgZUD1WAHBdUWDQTvzf8CcQ8C/OBWSQRZ5M8HU6CXBFL7JQERSxsCrnIfBCn+OQCqZgj/1WAHBCsbMQFgj0sCcQ8C/igIEQfONXMHU6CXBCn+OQCqZgj/1WAHBamdnQQqgZUD1WAHBdUWDQTvzf8CcQ8C/CsbMQFgj0sCcQ8C/FL7JQERSxsCrnIfBd4OCQRRRaMCrnIfBOBWSQRZ5M8HU6CXBigIEQfONXMHU6CXB9Td3wtyzfcKGOSzCnotbwqiadsKGOSzCXDNhwqeOYMK9IxHCs998wtunZ8K9IxHCwW+AwogQWMKY4EzCLDNlwlX3UMKY4EzC6dpqwlTrOsLPyjHCoEODwocEQsLPyjHCLDNlwlX3UMKY4EzC6dpqwlTrOsLPyjHCXDNhwqeOYMK9IxHCnotbwqiadsKGOSzCwW+AwogQWMKY4EzCoEODwocEQsLPyjHCs998wtunZ8K9IxHC9Td3wtyzfcKGOSzCoEODwocEQsLPyjHC6dpqwlTrOsLPyjHCXDNhwqeOYMK9IxHCs998wtunZ8K9IxHCwW+AwogQWMKY4EzCLDNlwlX3UMKY4EzCnotbwqiadsKGOSzC9Td3wtyzfcKGOSzCkDWjwXaImkGzdO9BZZ99wZXeo0GzdO9BZZOFwZc9vkE87QdCQ/mpwXjntEE87QdC/pWswYQWv0Etvs9BITCIwaNsyEEtvs9B1POOwaXL4kHxI/BBsVmzwYZ12UHxI/BBITCIwaNsyEEtvs9B1POOwaXL4kHxI/BBZZOFwZc9vkE87QdCZZ99wZXeo0GzdO9B/pWswYQWv0Etvs9BsVmzwYZ12UHxI/BBQ/mpwXjntEE87QdCkDWjwXaImkGzdO9BsVmzwYZ12UHxI/BB1POOwaXL4kHxI/BBZZOFwZc9vkE87QdCQ/mpwXjntEE87QdC/pWswYQWv0Etvs9BITCIwaNsyEEtvs9BZZ99wZXeo0GzdO9BkDWjwXaImkGzdO9BHQmSQh0NNEL4sQVCdJ6oQg2jP0L4sQVCVYmkQtR3X0LszCxC//ONQuThU0LszCxCaFOPQvAtSUInu+ZBv+ilQuDDVEInu+ZBoNOhQqeYdEKIeBpCST6LQrcCaUKIeBpCv+ilQuDDVEInu+ZBoNOhQqeYdEKIeBpCVYmkQtR3X0LszCxCdJ6oQg2jP0L4sQVCaFOPQvAtSUInu+ZBST6LQrcCaUKIeBpC//ONQuThU0LszCxCHQmSQh0NNEL4sQVCST6LQrcCaUKIeBpCoNOhQqeYdEKIeBpCVYmkQtR3X0LszCxC//ONQuThU0LszCxCaFOPQvAtSUInu+ZBv+ilQuDDVEInu+ZBdJ6oQg2jP0L4sQVCHQmSQh0NNEL4sQVCPQ+TQrM3T8HpysrBvPmpQjQxIMHpysrBQzqmQhI1LcDN/YLBxE+PQointMDN/YLBOliOQi+ucMDySQXCuUKlQsdQUr/ySQXCQIOhQsZ9z0DIxsLBwZiKQo/hYkDIxsLBuUKlQsdQUr/ySQXCQIOhQsZ9z0DIxsLBQzqmQhI1LcDN/YLBvPmpQjQxIMHpysrBOliOQi+ucMDySQXCwZiKQo/hYkDIxsLBxE+PQointMDN/YLBPQ+TQrM3T8HpysrBwZiKQo/hYkDIxsLBQIOhQsZ9z0DIxsLBQzqmQhI1LcDN/YLBxE+PQointMDN/YLBOliOQi+ucMDySQXCuUKlQsdQUr/ySQXCvPmpQjQxIMHpysrBPQ+TQrM3T8HpysrBNzWDwjBVSsEKU2pB1chmwr/gKcEKU2pBzbhswsSUmsD2CK5BMy2Gwqd928D2CK5Bgo6HwpFnhcBjUelAbHtvwlz9CMBjUelAZWt1whZcaUCTZ2ZBf4aKwqIUzz+TZ2ZBbHtvwlz9CMBjUelAZWt1whZcaUCTZ2ZBzbhswsSUmsD2CK5B1chmwr/gKcEKU2pBgo6HwpFnhcBjUelAf4aKwqIUzz+TZ2ZBMy2Gwqd928D2CK5BNzWDwjBVSsEKU2pBf4aKwqIUzz+TZ2ZBZWt1whZcaUCTZ2ZBzbhswsSUmsD2CK5BMy2Gwqd928D2CK5Bgo6HwpFnhcBjUelAbHtvwlz9CMBjUelA1chmwr/gKcEKU2pBNzWDwjBVSsEKU2pB7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAAaq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAAaq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAAaq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/1/h3P8Rtfj5tup6j1/h3P8Rtfj5tup6j1/h3P8Rtfj5tup6j1/h3P8Rtfj5tup6j1/h3v8Rtfr5tup4j1/h3v8Rtfr5tup4j1/h3v8Rtfr5tup4j1/h3v8Rtfr5tup4jaq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/1/h3P8Rtfj5UQoqj1/h3P8Rtfj5UQoqj1/h3P8Rtfj5UQoqj1/h3P8Rtfj5UQoqj1/h3v8Rtfr5UQooj1/h3v8Rtfr5UQooj1/h3v8Rtfr5UQooj1/h3v8Rtfr5UQoojaq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAAaq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/1/h3P8Rtfj7MVfuj1/h3P8Rtfj7MVfuj1/h3P8Rtfj7MVfuj1/h3P8Rtfj7MVfuj1/h3v8Rtfr7MVfsj1/h3v8Rtfr7MVfsj1/h3v8Rtfr7MVfsj1/h3v8Rtfr7MVfsjaq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAAaq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAAaq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCPnzXPb8xsiQ/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/7chCvnzXPT8xsiS/1/h3P8Rtfj7IWZoj1/h3P8Rtfj7IWZoj1/h3P8Rtfj7IWZoj1/h3P8Rtfj7IWZoj1/h3v8Rtfr7IWZqj1/h3v8Rtfr7IWZqj1/h3v8Rtfr7IWZqj1/h3v8Rtfr7IWZqjaq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jvgSIHz/f/EM/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/aq8jPgSIH7/f/EO/AAABAAIAAAACAAMABgAFAAQABwAGAAQACAAJAAoACAAKAAsADgANAAwADwAOAAwAEgARABAAEwASABAAFAAVABYAFAAWABcAGAAZABoAGAAaABsAHgAdABwAHwAeABwAIAAhACIAIAAiACMAJgAlACQAJwAmACQAKgApACgAKwAqACgALAAtAC4ALAAuAC8AMAAxADIAMAAyADMANgA1ADQANwA2ADQAOAA5ADoAOAA6ADsAPgA9ADwAPwA+ADwAQgBBAEAAQwBCAEAARABFAEYARABGAEcASABJAEoASABKAEsATgBNAEwATwBOAEwAUABRAFIAUABSAFMAVgBVAFQAVwBWAFQAWgBZAFgAWwBaAFgAXABdAF4AXABeAF8AYABhAGIAYABiAGMAZgBlAGQAZwBmAGQAaABpAGoAaABqAGsAbgBtAGwAbwBuAGwAcgBxAHAAcwByAHAAdAB1AHYAdAB2AHcAeAB5AHoAeAB6AHsAfgB9AHwAfwB+AHwAgACBAIIAgACCAIMAhgCFAIQAhwCGAIQAigCJAIgAiwCKAIgAjACNAI4AjACOAI8AkACRAJIAkACSAJMAlgCVAJQAlwCWAJQAmACZAJoAmACaAJsAngCdAJwAnwCeAJwAogChAKAAowCiAKAApAClAKYApACmAKcAqACpAKoAqACqAKsArgCtAKwArwCuAKwAsACxALIAsACyALMAtgC1ALQAtwC2ALQAugC5ALgAuwC6ALgAvAC9AL4AvAC+AL8AwADBAMIAwADCAMMAxgDFAMQAxwDGAMQAyADJAMoAyADKAMsAzgDNAMwAzwDOAMwA0gDRANAA0wDSANAA1ADVANYA1ADWANcA2ADZANoA2ADaANsA3gDdANwA3wDeANwA4ADhAOIA4ADiAOMA5gDlAOQA5wDmAOQA6gDpAOgA6wDqAOgA7ADtAO4A7ADuAO8A"
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteLength": 2880,
+      "byteOffset": 0,
+      "target": 34962,
+      "byteStride": 12
+    },
+    {
+      "buffer": 0,
+      "byteLength": 2880,
+      "byteOffset": 2880,
+      "target": 34962,
+      "byteStride": 12
+    },
+    {
+      "buffer": 0,
+      "byteLength": 720,
+      "byteOffset": 5760,
+      "target": 34963
+    }
+  ],
+  "materials": [
+    {
+      "pbrMetallicRoughness": {
+        "baseColorFactor": [
+          1,
+          1,
+          1,
+          1
+        ],
+        "roughnessFactor": 1,
+        "metallicFactor": 0
+      },
+      "alphaMode": "OPAQUE",
+      "doubleSided": false,
+      "emissiveFactor": [
+        0,
+        0,
+        0
+      ]
+    }
+  ],
+  "meshes": [
+    {
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 0,
+            "NORMAL": 1
+          },
+          "indices": 2,
+          "material": 0,
+          "mode": 4
+        }
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "Z_UP_TO_Y_UP",
+      "matrix": [
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        -1,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1
+      ],
+      "children": [
+        1
+      ]
+    },
+    {
+      "name": "RTC_CENTER",
+      "translation": [
+        1214914.5525041146,
+        -4736388.031625768,
+        4081548.0407588882
+      ],
+      "mesh": 0
+    }
+  ],
+  "scene": 0,
+  "scenes": [
+    {
+      "nodes": [
+        0
+      ]
+    }
+  ]
+}

--- a/Specs/Data/Cesium3DTiles/GltfContentWithRepeatedCopyrights/glTF/lr.gltf
+++ b/Specs/Data/Cesium3DTiles/GltfContentWithRepeatedCopyrights/glTF/lr.gltf
@@ -1,0 +1,164 @@
+{
+  "accessors": [
+    {
+      "bufferView": 0,
+      "byteOffset": 0,
+      "componentType": 5126,
+      "count": 240,
+      "type": "VEC3",
+      "min": [
+        -87.06357805873267,
+        -58.17450781259686,
+        -54.20209496608004
+      ],
+      "max": [
+        83.14743960183114,
+        71.10079883225262,
+        58.70444464450702
+      ]
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 0,
+      "componentType": 5126,
+      "count": 240,
+      "type": "VEC3",
+      "min": [
+        -0.9686305452941167,
+        -0.7415615084565588,
+        -0.7655772493024053
+      ],
+      "max": [
+        0.9686305452941167,
+        0.7415615084565588,
+        0.7655772493024053
+      ]
+    },
+    {
+      "bufferView": 2,
+      "byteOffset": 0,
+      "componentType": 5123,
+      "count": 360,
+      "type": "SCALAR",
+      "min": [
+        0
+      ],
+      "max": [
+        239
+      ]
+    }
+  ],
+  "asset": {
+    "copyright": "Most Frequent Copyright",
+    "generator": "3d-tiles-samples-generator",
+    "version": "2.0"
+  },
+  "buffers": [
+    {
+      "name": "buffer",
+      "byteLength": 6480,
+      "uri": "data:application/octet-stream;base64,/nYWQTpE/sDcBhvArRSEQZHtw8DcBhvA+U5wQbyln77K7pZAOzn9QAiiCMDK7pZAp1HlQEzgRj/E1R/BL1tkQWRlJkDE1R/BzoBMQfSSBkGgcjbA5Zy1QD/P0kCgcjbAL1tkQWRlJkDE1R/BzoBMQfSSBkGgcjbA+U5wQbyln77K7pZArRSEQZHtw8DcBhvAp1HlQEzgRj/E1R/B5Zy1QD/P0kCgcjbAOzn9QAiiCMDK7pZA/nYWQTpE/sDcBhvA5Zy1QD/P0kCgcjbAzoBMQfSSBkGgcjbA+U5wQbyln77K7pZAOzn9QAiiCMDK7pZAp1HlQEzgRj/E1R/BL1tkQWRlJkDE1R/BrRSEQZHtw8DcBhvA/nYWQTpE/sDcBhvATNBFwrKyaMLNyh3CHlgywv2zY8LNyh3CUw01wv0lWcJM0xDCgYVIwrIkXsJM0xDCOnZQwoAxP8K5zEHCDP48wssyOsK5zEHCQbM/wsqkL8I41TTCbytTwn+jNMI41TTCDP48wssyOsK5zEHCQbM/wsqkL8I41TTCUw01wv0lWcJM0xDCHlgywv2zY8LNyh3COnZQwoAxP8K5zEHCbytTwn+jNMI41TTCgYVIwrIkXsJM0xDCTNBFwrKyaMLNyh3CbytTwn+jNMI41TTCQbM/wsqkL8I41TTCUw01wv0lWcJM0xDCgYVIwrIkXsJM0xDCOnZQwoAxP8K5zEHCDP48wssyOsK5zEHCHlgywv2zY8LNyh3CTNBFwrKyaMLNyh3CHnbqwFy63cGpO9fBuCgvwKVO1MGpO9fBoWlbwOG+vsFvvrzBSUsAwZgqyMFvvrzBzwcMwQlLscFbyP3B3C2FwFPfp8FbyP3BUU6bwI9PksEhS+PBCRgXwUW7m8EhS+PB3C2FwFPfp8FbyP3BUU6bwI9PksEhS+PBoWlbwOG+vsFvvrzBuCgvwKVO1MGpO9fBzwcMwQlLscFbyP3BCRgXwUW7m8EhS+PBSUsAwZgqyMFvvrzBHnbqwFy63cGpO9fBCRgXwUW7m8EhS+PBUU6bwI9PksEhS+PBoWlbwOG+vsFvvrzBSUsAwZgqyMFvvrzBzwcMwQlLscFbyP3B3C2FwFPfp8FbyP3BuCgvwKVO1MGpO9fBHnbqwFy63cGpO9fBXGWlQA3xDkLhbE9ChbpjQV4+GELhbE9C59hMQVyKLkJa0WpCQERvQAs9JUJa0WpCXpsmQHzwNkKguSxCrq46Qc09QEKguSxCEM0jQcuJVkIZHkhCyymWP3o8TUIZHkhCrq46Qc09QEKguSxCEM0jQcuJVkIZHkhC59hMQVyKLkJa0WpChbpjQV4+GELhbE9CXpsmQHzwNkKguSxCyymWP3o8TUIZHkhCQERvQAs9JUJa0WpCXGWlQA3xDkLhbE9CyymWP3o8TUIZHkhCEM0jQcuJVkIZHkhC59hMQVyKLkJa0WpCQERvQAs9JUJa0WpCXpsmQHzwNkKguSxCrq46Qc09QEKguSxChbpjQV4+GELhbE9CXGWlQA3xDkLhbE9CJKW6Qb4HKsLyQjvCzKDzQX24IsLyQjvCoS3rQalAEsKoByfC+TGyQeqPGcKoByfCeyupQfj4B8LyzljCIyfiQbapAMLyzljC+LPZQcZj4MGok0TCULigQUgC78Gok0TCIyfiQbapAMLyzljC+LPZQcZj4MGok0TCoS3rQalAEsKoByfCzKDzQX24IsLyQjvCeyupQfj4B8LyzljCULigQUgC78Gok0TC+TGyQeqPGcKoByfCJKW6Qb4HKsLyQjvCULigQUgC78Gok0TC+LPZQcZj4MGok0TCoS3rQalAEsKoByfC+TGyQeqPGcKoByfCeyupQfj4B8LyzljCIyfiQbapAMLyzljCzKDzQX24IsLyQjvCJKW6Qb4HKsLyQjvClT+owoRtwcEhYtg+bKCZwj1sssEhYtg+C4acwmpBhcF+e+tANCWrwrFClMF+e+tA7zqrwujvksH9zpPAxpucwqDug8H9zpPAZIGfwpqHLcG9TBRAjSCuwiiKS8G9TBRAxpucwqDug8H9zpPAZIGfwpqHLcG9TBRAC4acwmpBhcF+e+tAbKCZwj1sssEhYtg+7zqrwujvksH9zpPAjSCuwiiKS8G9TBRANCWrwrFClMF+e+tAlT+owoRtwcEhYtg+jSCuwiiKS8G9TBRAZIGfwpqHLcG9TBRAC4acwmpBhcF+e+tANCWrwrFClMF+e+tA7zqrwujvksH9zpPAxpucwqDug8H9zpPAbKCZwj1sssEhYtg+lT+owoRtwcEhYtg+DIgEwGfG3r9cYotAdfnfQHQlFj9cYotANJmnQByD7kB0rExBjUh1wNQMpEB0rExBejx2wDfopUASd9O/PR+nQIBe8EASd9O/+X1dQHcOZkHHGNlAfn6zwFLTQEHHGNlAPR+nQIBe8EASd9O/+X1dQHcOZkHHGNlANJmnQByD7kB0rExBdfnfQHQlFj9cYotAejx2wDfopUASd9O/fn6zwFLTQEHHGNlAjUh1wNQMpEB0rExBDIgEwGfG3r9cYotAfn6zwFLTQEHHGNlA+X1dQHcOZkHHGNlANJmnQByD7kB0rExBjUh1wNQMpEB0rExBejx2wDfopUASd9O/PR+nQIBe8EASd9O/dfnfQHQlFj9cYotADIgEwGfG3r9cYotAdd9nwsl8N0HsZSpCWAZLwnwXVUHsZSpCyN1OwkZ+iEE5yzxC5bZrwtlhc0E5yzxCAyhywt3oq0HCnwdC5k5Vwja2ukHCnwdCVSZZwr6o2EEPBRpCcv91wmXbyUEPBRpC5k5Vwja2ukHCnwdCVSZZwr6o2EEPBRpCyN1OwkZ+iEE5yzxCWAZLwnwXVUHsZSpCAyhywt3oq0HCnwdCcv91wmXbyUEPBRpC5bZrwtlhc0E5yzxCdd9nwsl8N0HsZSpCcv91wmXbyUEPBRpCVSZZwr6o2EEPBRpCyN1OwkZ+iEE5yzxC5bZrwtlhc0E5yzxCAyhywt3oq0HCnwdC5k5Vwja2ukHCnwdCWAZLwnwXVUHsZSpCdd9nwsl8N0HsZSpCxSKSQqzhlMG3qvPBfUumQq0xgMG3qvPB/bCiQmIFEMG2pK7BRYiOQmBlOcG2pK7By+eMQniqBsERNR3CgxChQvaUusARNR3CAnadQu+bmD8hZPXBS02JQvxjsr8hZPXBgxChQvaUusARNR3CAnadQu+bmD8hZPXB/bCiQmIFEMG2pK7BfUumQq0xgMG3qvPBy+eMQniqBsERNR3CS02JQvxjsr8hZPXBRYiOQmBlOcG2pK7BxSKSQqzhlMG3qvPBS02JQvxjsr8hZPXBAnadQu+bmD8hZPXB/bCiQmIFEMG2pK7BRYiOQmBlOcG2pK7By+eMQniqBsERNR3CgxChQvaUusARNR3CfUumQq0xgMG3qvPBxSKSQqzhlMG3qvPB15WOQnHba0JdjFdCycWXQj2ScEJdjFdCnwKWQltPfkJEbWhCrdKMQo6YeUJEbWhCnrmKQqf5hELacD1Cj+mTQg1Vh0LacD1CZSaSQpwzjkLBUU5CdPaIQjbYi0LBUU5Cj+mTQg1Vh0LacD1CZSaSQpwzjkLBUU5CnwKWQltPfkJEbWhCycWXQj2ScEJdjFdCnrmKQqf5hELacD1CdPaIQjbYi0LBUU5CrdKMQo6YeUJEbWhC15WOQnHba0JdjFdCdPaIQjbYi0LBUU5CZSaSQpwzjkLBUU5CnwKWQltPfkJEbWhCrdKMQo6YeUJEbWhCnrmKQqf5hELacD1Cj+mTQg1Vh0LacD1CycWXQj2ScEJdjFdC15WOQnHba0JdjFdC5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/LPh3Pyp4fj54X5UjLPh3Pyp4fj54X5UjLPh3Pyp4fj54X5UjLPh3Pyp4fj54X5UjLPh3vyp4fr54X5WjLPh3vyp4fr54X5WjLPh3vyp4fr54X5WjLPh3vyp4fr54X5WjG7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/LPh3Pyp4fj4hRIojLPh3Pyp4fj4hRIojLPh3Pyp4fj4hRIojLPh3Pyp4fj4hRIojLPh3vyp4fr4hRIqjLPh3vyp4fr4hRIqjLPh3vyp4fr4hRIqjLPh3vyp4fr4hRIqjG7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/LPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAAG7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/LPh3Pyp4fj6K1YcjLPh3Pyp4fj6K1YcjLPh3Pyp4fj6K1YcjLPh3Pyp4fj6K1YcjLPh3vyp4fr6K1YejLPh3vyp4fr6K1YejLPh3vyp4fr6K1YejLPh3vyp4fr6K1YejG7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/LPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAAG7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/LPh3Pyp4fj5NwuYjLPh3Pyp4fj5NwuYjLPh3Pyp4fj5NwuYjLPh3Pyp4fj5NwuYjLPh3vyp4fr5NwuajLPh3vyp4fr5NwuajLPh3vyp4fr5NwuajLPh3vyp4fr5NwuajG7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/LPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAAG7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/LPh3Pyp4fj4s1skjLPh3Pyp4fj4s1skjLPh3Pyp4fj4s1skjLPh3Pyp4fj4s1skjLPh3vyp4fr4s1smjLPh3vyp4fr4s1smjLPh3vyp4fr4s1smjLPh3vyp4fr4s1smjG7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/LPh3Pyp4fj5QhdMjLPh3Pyp4fj5QhdMjLPh3Pyp4fj5QhdMjLPh3Pyp4fj5QhdMjLPh3vyp4fr5QhdOjLPh3vyp4fr5QhdOjLPh3vyp4fr5QhdOjLPh3vyp4fr5QhdOjG7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCPvrWPb8xsiQ/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/5NBCvvrWPT8xsiS/LPh3Pyp4fj56gJIjLPh3Pyp4fj56gJIjLPh3Pyp4fj56gJIjLPh3Pyp4fj56gJIjLPh3vyp4fr56gJKjLPh3vyp4fr56gJKjLPh3vyp4fr56gJKjLPh3vyp4fr56gJKjG7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjvpaHHz/f/EM/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/G7YjPpaHH7/f/EO/AAABAAIAAAACAAMABgAFAAQABwAGAAQACAAJAAoACAAKAAsADgANAAwADwAOAAwAEgARABAAEwASABAAFAAVABYAFAAWABcAGAAZABoAGAAaABsAHgAdABwAHwAeABwAIAAhACIAIAAiACMAJgAlACQAJwAmACQAKgApACgAKwAqACgALAAtAC4ALAAuAC8AMAAxADIAMAAyADMANgA1ADQANwA2ADQAOAA5ADoAOAA6ADsAPgA9ADwAPwA+ADwAQgBBAEAAQwBCAEAARABFAEYARABGAEcASABJAEoASABKAEsATgBNAEwATwBOAEwAUABRAFIAUABSAFMAVgBVAFQAVwBWAFQAWgBZAFgAWwBaAFgAXABdAF4AXABeAF8AYABhAGIAYABiAGMAZgBlAGQAZwBmAGQAaABpAGoAaABqAGsAbgBtAGwAbwBuAGwAcgBxAHAAcwByAHAAdAB1AHYAdAB2AHcAeAB5AHoAeAB6AHsAfgB9AHwAfwB+AHwAgACBAIIAgACCAIMAhgCFAIQAhwCGAIQAigCJAIgAiwCKAIgAjACNAI4AjACOAI8AkACRAJIAkACSAJMAlgCVAJQAlwCWAJQAmACZAJoAmACaAJsAngCdAJwAnwCeAJwAogChAKAAowCiAKAApAClAKYApACmAKcAqACpAKoAqACqAKsArgCtAKwArwCuAKwAsACxALIAsACyALMAtgC1ALQAtwC2ALQAugC5ALgAuwC6ALgAvAC9AL4AvAC+AL8AwADBAMIAwADCAMMAxgDFAMQAxwDGAMQAyADJAMoAyADKAMsAzgDNAMwAzwDOAMwA0gDRANAA0wDSANAA1ADVANYA1ADWANcA2ADZANoA2ADaANsA3gDdANwA3wDeANwA4ADhAOIA4ADiAOMA5gDlAOQA5wDmAOQA6gDpAOgA6wDqAOgA7ADtAO4A7ADuAO8A"
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteLength": 2880,
+      "byteOffset": 0,
+      "target": 34962,
+      "byteStride": 12
+    },
+    {
+      "buffer": 0,
+      "byteLength": 2880,
+      "byteOffset": 2880,
+      "target": 34962,
+      "byteStride": 12
+    },
+    {
+      "buffer": 0,
+      "byteLength": 720,
+      "byteOffset": 5760,
+      "target": 34963
+    }
+  ],
+  "materials": [
+    {
+      "pbrMetallicRoughness": {
+        "baseColorFactor": [
+          1,
+          1,
+          1,
+          1
+        ],
+        "roughnessFactor": 1,
+        "metallicFactor": 0
+      },
+      "alphaMode": "OPAQUE",
+      "doubleSided": false,
+      "emissiveFactor": [
+        0,
+        0,
+        0
+      ]
+    }
+  ],
+  "meshes": [
+    {
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 0,
+            "NORMAL": 1
+          },
+          "indices": 2,
+          "material": 0,
+          "mode": 4
+        }
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "Z_UP_TO_Y_UP",
+      "matrix": [
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        -1,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1
+      ],
+      "children": [
+        1
+      ]
+    },
+    {
+      "name": "RTC_CENTER",
+      "translation": [
+        1215115.0145358627,
+        -4736351.649427437,
+        4081531.524444658
+      ],
+      "mesh": 0
+    }
+  ],
+  "scene": 0,
+  "scenes": [
+    {
+      "nodes": [
+        0
+      ]
+    }
+  ]
+}

--- a/Specs/Data/Cesium3DTiles/GltfContentWithRepeatedCopyrights/glTF/parent.gltf
+++ b/Specs/Data/Cesium3DTiles/GltfContentWithRepeatedCopyrights/glTF/parent.gltf
@@ -1,0 +1,175 @@
+{
+  "accessors": [
+    {
+      "bufferView": 0,
+      "byteOffset": 0,
+      "componentType": 5126,
+      "count": 240,
+      "type": "VEC3",
+      "min": [
+        -103.97583675780334,
+        -114.61250572279096,
+        -102.50925003085285
+      ],
+      "max": [
+        118.4458890708629,
+        106.54341480974108,
+        93.78807587129995
+      ]
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 0,
+      "componentType": 5126,
+      "count": 240,
+      "type": "VEC3",
+      "min": [
+        -0.9686356343768793,
+        -0.7415555652213446,
+        -0.765567091384559
+      ],
+      "max": [
+        0.9686356343768793,
+        0.7415555652213446,
+        0.765567091384559
+      ]
+    },
+    {
+      "bufferView": 2,
+      "byteOffset": 0,
+      "componentType": 5123,
+      "count": 360,
+      "type": "SCALAR",
+      "min": [
+        0
+      ],
+      "max": [
+        239
+      ]
+    }
+  ],
+  "asset": {
+    "copyright": "Last Repeated Copyright, Most Frequent Copyright, Second Repeated Copyright",
+    "generator": "3d-tiles-samples-generator",
+    "version": "2.0"
+  },
+  "buffers": [
+    {
+      "name": "buffer",
+      "byteLength": 6480,
+      "uri": "data:application/octet-stream;base64,1T3LPhOMC8LSgpJBH1aKQd5r9MHSgpJBuXlsQdQSpsGuwvJBWWIHwBy/yMGuwvJBZYhnwYaPuEG8vv/BqycbQM4720G8vv/BHE20vWzKFELgfp/Bdd2HwUh0A0Lgfp/BqycbQM4720G8vv/BHE20vWzKFELgfp/BuXlsQdQSpsGuwvJBH1aKQd5r9MHSgpJBZYhnwYaPuEG8vv/Bdd2HwUh0A0Lgfp/BWWIHwBy/yMGuwvJB1T3LPhOMC8LSgpJBdd2HwUh0A0Lgfp/BHE20vWzKFELgfp/BuXlsQdQSpsGuwvJBWWIHwBy/yMGuwvJBZYhnwYaPuEG8vv/BqycbQM4720G8vv/BH1aKQd5r9MHSgpJB1T3LPhOMC8LSgpJBCJRkv6SdvMIpFBrCROCAQXrks8IpFBrCoY1SQdjknMK8JMPBnvB1wAKepcK8JMPBGSCJwYHF98ET8LrCHJoNvtrg1MET8LrCPqVFwKHEccEur57CjLmgwffGm8Eur57CHJoNvtrg1MET8LrCPqVFwKHEccEur57CoY1SQdjknMK8JMPBROCAQXrks8IpFBrCGSCJwYHF98ET8LrCjLmgwffGm8Eur57CnvB1wAKepcK8JMPBCJRkv6SdvMIpFBrCjLmgwffGm8Eur57CPqVFwKHEccEur57CoY1SQdjknMK8JMPBnvB1wAKepcK8JMPBGSCJwYHF98ET8LrCHJoNvtrg1MET8LrCROCAQXrks8IpFBrCCJRkv6SdvMIpFBrCbkWZQqbfj8HOuXJBccq/QgiyUMHOuXJBxsi5QlYLq7+La+xBw0OTQl/dyMCLa+xBthx3Qli7H0ILTwzCXhOiQql+M0ILTwzCsxGcQtBSYkJzj6XBYBlrQn+PTkJzj6XBXhOiQql+M0ILTwzCsxGcQtBSYkJzj6XBxsi5QlYLq7+La+xBccq/QgiyUMHOuXJBthx3Qli7H0ILTwzCYBlrQn+PTkJzj6XBw0OTQl/dyMCLa+xBbkWZQqbfj8HOuXJBYBlrQn+PTkJzj6XBsxGcQtBSYkJzj6XBxsi5QlYLq7+La+xBw0OTQl/dyMCLa+xBthx3Qli7H0ILTwzCXhOiQql+M0ILTwzCccq/QgiyUMHOuXJBbkWZQqbfj8HOuXJBaMlYQia92kFKF5ZCqzGYQofXA0JKF5ZCa2aQQhybQEI5artC6TJJQigiKkI5artCid4cQvZ3q0KSFsNBd3h0QnC0tkKSFsNB+OFkQjoW1UIoMSxCCkgNQsDZyUIoMSxCd3h0QnC0tkKSFsNB+OFkQjoW1UIoMSxCa2aQQhybQEI5artCqzGYQofXA0JKF5ZCid4cQvZ3q0KSFsNBCkgNQsDZyUIoMSxC6TJJQigiKkI5artCaMlYQia92kFKF5ZCCkgNQsDZyUIoMSxC+OFkQjoW1UIoMSxCa2aQQhybQEI5artC6TJJQigiKkI5artCid4cQvZ3q0KSFsNBd3h0QnC0tkKSFsNBqzGYQofXA0JKF5ZCaMlYQia92kFKF5ZC1qciwY2LPUHS05hC7dEvQfcvikHS05hCiorrQJBU+0F/k7tCfrRcwV/qz0F/k7tCSVvJwXyqjELaYM1Bn3mAwAiFl0LaYM1B7pL0wC7Os0LGLyxCnWHmwaLzqELGLyxCn3mAwAiFl0LaYM1B7pL0wC7Os0LGLyxCiorrQJBU+0F/k7tC7dEvQfcvikHS05hCSVvJwXyqjELaYM1BnWHmwaLzqELGLyxCfrRcwV/qz0F/k7tC1qciwY2LPUHS05hCnWHmwaLzqELGLyxC7pL0wC7Os0LGLyxCiorrQJBU+0F/k7tCfrRcwV/qz0F/k7tCSVvJwXyqjELaYM1Bn3mAwAiFl0LaYM1B7dEvQfcvikHS05hC1qciwY2LPUHS05hCuMuRwg3Q48HFwllCM0FNwjiEt8HFwllC12pcwmmbAsGtL5FCimCZwhQzW8GtL5FCvUKxwndnA0I+7Z0/nxeGwmKNGUI+7Z0/cayNwqSoVEIBGJtBj9e4wrmCPkIBGJtBnxeGwmKNGUI+7Z0/cayNwqSoVEIBGJtB12pcwmmbAsGtL5FCM0FNwjiEt8HFwllCvUKxwndnA0I+7Z0/j9e4wrmCPkIBGJtBimCZwhQzW8GtL5FCuMuRwg3Q48HFwllCj9e4wrmCPkIBGJtBcayNwqSoVEIBGJtB12pcwmmbAsGtL5FCimCZwhQzW8GtL5FCvUKxwndnA0I+7Z0/nxeGwmKNGUI+7Z0/M0FNwjiEt8HFwllCuMuRwg3Q48HFwllCbRjEQjQIe8I2sSrCTOTsQtgZZsI2sSrCJvDlQkHjL8IGL9DBSCS9Qp3RRMIGL9DBWlumQvJxmcCn67nCOCfPQu4O4D6n67nCEjPIQtTaX0HNnpjCNGefQmQhDEHNnpjCOCfPQu4O4D6n67nCEjPIQtTaX0HNnpjCJvDlQkHjL8IGL9DBTOTsQtgZZsI2sSrCWlumQvJxmcCn67nCNGefQmQhDEHNnpjCSCS9Qp3RRMIGL9DBbRjEQjQIe8I2sSrCNGefQmQhDEHNnpjCEjPIQtTaX0HNnpjCJvDlQkHjL8IGL9DBSCS9Qp3RRMIGL9DBWlumQvJxmcCn67nCOCfPQu4O4D6n67nCTOTsQtgZZsI2sSrCbRjEQjQIe8I2sSrCpHxUwpo55cJxSkHCKLTvwddX2cJxSkHCtqsGwsB1vMKkpvTBRk5jwoNXyMKkpvTBukmKwteeUMK8BM3C5PA3wlDbOMK8BM3ChsJGwkMu/sEtianCi7KRwqnaFsItianC5PA3wlDbOMK8BM3ChsJGwkMu/sEtianCtqsGwsB1vMKkpvTBKLTvwddX2cJxSkHCukmKwteeUMK8BM3Ci7KRwqnaFsItianCRk5jwoNXyMKkpvTBpHxUwpo55cJxSkHCi7KRwqnaFsItianChsJGwkMu/sEtianCtqsGwsB1vMKkpvTBRk5jwoNXyMKkpvTBukmKwteeUMK8BM3C5PA3wlDbOMK8BM3CKLTvwddX2cJxSkHCpHxUwpo55cJxSkHCnXFEwZf/hMKoLY7AGKERQQYPdMKoLY7A1LmpQOjWOMJW6VtB5pqAwRHHTsJW6VtBpOPiwXJsc8B1WGvCJ2nfwC4s1z91WGvCwngswf7ig0FrmCLC3qIAwloFMEFrmCLCJ2nfwC4s1z91WGvCwngswf7ig0FrmCLC1LmpQOjWOMJW6VtBGKERQQYPdMKoLY7ApOPiwXJsc8B1WGvC3qIAwloFMEFrmCLC5pqAwRHHTsJW6VtBnXFEwZf/hMKoLY7A3qIAwloFMEFrmCLCwngswf7ig0FrmCLC1LmpQOjWOMJW6VtB5pqAwRHHTsJW6VtBpOPiwXJsc8B1WGvCJ2nfwC4s1z91WGvCGKERQQYPdMKoLY7AnXFEwZf/hMKoLY7ADEmswgwhJMGaK5VCVVmKwln3vMCaK5VC1rePwizpkUDj4a5CjaexwtLNUz7j4a5CIJXKwpYsQ0K407pBaaWowu6VVEK407pB6gOuwv5xfkJv1hBCofPPwqcIbUJv1hBCaaWowu6VVEK407pB6gOuwv5xfkJv1hBC1rePwizpkUDj4a5CVVmKwln3vMCaK5VCIJXKwpYsQ0K407pBofPPwqcIbUJv1hBCjaexwtLNUz7j4a5CDEmswgwhJMGaK5VCofPPwqcIbUJv1hBC6gOuwv5xfkJv1hBC1rePwizpkUDj4a5CjaexwtLNUz7j4a5CIJXKwpYsQ0K407pBaaWowu6VVEK407pBVVmKwln3vMCaK5VCDEmswgwhJMGaK5VCP8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/gfh3P/dyfj7bbdWjgfh3P/dyfj7bbdWjgfh3P/dyfj7bbdWjgfh3P/dyfj7bbdWjgfh3v/dyfr7bbdUjgfh3v/dyfr7bbdUjgfh3v/dyfr7bbdUjgfh3v/dyfr7bbdUjjLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjPpGIH780/EO/jLMjPpGIH780/EO/jLMjPpGIH780/EO/jLMjPpGIH780/EO/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/gfh3P/dyfj4AAAAAgfh3P/dyfj4AAAAAgfh3P/dyfj4AAAAAgfh3P/dyfj4AAAAAgfh3v/dyfr4AAAAAgfh3v/dyfr4AAAAAgfh3v/dyfr4AAAAAgfh3v/dyfr4AAAAAjLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjPpGIH780/EO/jLMjPpGIH780/EO/jLMjPpGIH780/EO/jLMjPpGIH780/EO/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/gfh3P/dyfj4AAAAAgfh3P/dyfj4AAAAAgfh3P/dyfj4AAAAAgfh3P/dyfj4AAAAAgfh3v/dyfr4AAAAAgfh3v/dyfr4AAAAAgfh3v/dyfr4AAAAAgfh3v/dyfr4AAAAAjLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjPpGIH780/EO/jLMjPpGIH780/EO/jLMjPpGIH780/EO/jLMjPpGIH780/EO/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/gfh3P/dyfj7+kYgjgfh3P/dyfj7+kYgjgfh3P/dyfj7+kYgjgfh3P/dyfj7+kYgjgfh3v/dyfr7+kYijgfh3v/dyfr7+kYijgfh3v/dyfr7+kYijgfh3v/dyfr7+kYijjLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjPpGIH780/EO/jLMjPpGIH780/EO/jLMjPpGIH780/EO/jLMjPpGIH780/EO/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/gfh3P/dyfj5hdJIjgfh3P/dyfj5hdJIjgfh3P/dyfj5hdJIjgfh3P/dyfj5hdJIjgfh3v/dyfr5hdJKjgfh3v/dyfr5hdJKjgfh3v/dyfr5hdJKjgfh3v/dyfr5hdJKjjLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjPpGIH780/EO/jLMjPpGIH780/EO/jLMjPpGIH780/EO/jLMjPpGIH780/EO/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/gfh3P/dyfj7prYUjgfh3P/dyfj7prYUjgfh3P/dyfj7prYUjgfh3P/dyfj7prYUjgfh3v/dyfr7prYWjgfh3v/dyfr7prYWjgfh3v/dyfr7prYWjgfh3v/dyfr7prYWjjLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjPpGIH780/EO/jLMjPpGIH780/EO/jLMjPpGIH780/EO/jLMjPpGIH780/EO/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/gfh3P/dyfj4AAAAAgfh3P/dyfj4AAAAAgfh3P/dyfj4AAAAAgfh3P/dyfj4AAAAAgfh3v/dyfr4AAAAAgfh3v/dyfr4AAAAAgfh3v/dyfr4AAAAAgfh3v/dyfr4AAAAAjLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjPpGIH780/EO/jLMjPpGIH780/EO/jLMjPpGIH780/EO/jLMjPpGIH780/EO/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/gfh3P/dyfj4AAAAAgfh3P/dyfj4AAAAAgfh3P/dyfj4AAAAAgfh3P/dyfj4AAAAAgfh3v/dyfr4AAAAAgfh3v/dyfr4AAAAAgfh3v/dyfr4AAAAAgfh3v/dyfr4AAAAAjLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjPpGIH780/EO/jLMjPpGIH780/EO/jLMjPpGIH780/EO/jLMjPpGIH780/EO/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/gfh3P/dyfj5ug4Ijgfh3P/dyfj5ug4Ijgfh3P/dyfj5ug4Ijgfh3P/dyfj5ug4Ijgfh3v/dyfr5ug4Kjgfh3v/dyfr5ug4Kjgfh3v/dyfr5ug4Kjgfh3v/dyfr5ug4KjjLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjPpGIH780/EO/jLMjPpGIH780/EO/jLMjPpGIH780/EO/jLMjPpGIH780/EO/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCPpbWPb/8siQ/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/P8xCvpbWPT/8siS/gfh3P/dyfj5aCEQkgfh3P/dyfj5aCEQkgfh3P/dyfj5aCEQkgfh3P/dyfj5aCEQkgfh3v/dyfr5aCESkgfh3v/dyfr5aCESkgfh3v/dyfr5aCESkgfh3v/dyfr5aCESkjLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjvpGIHz80/EM/jLMjPpGIH780/EO/jLMjPpGIH780/EO/jLMjPpGIH780/EO/jLMjPpGIH780/EO/AAABAAIAAAACAAMABgAFAAQABwAGAAQACAAJAAoACAAKAAsADgANAAwADwAOAAwAEgARABAAEwASABAAFAAVABYAFAAWABcAGAAZABoAGAAaABsAHgAdABwAHwAeABwAIAAhACIAIAAiACMAJgAlACQAJwAmACQAKgApACgAKwAqACgALAAtAC4ALAAuAC8AMAAxADIAMAAyADMANgA1ADQANwA2ADQAOAA5ADoAOAA6ADsAPgA9ADwAPwA+ADwAQgBBAEAAQwBCAEAARABFAEYARABGAEcASABJAEoASABKAEsATgBNAEwATwBOAEwAUABRAFIAUABSAFMAVgBVAFQAVwBWAFQAWgBZAFgAWwBaAFgAXABdAF4AXABeAF8AYABhAGIAYABiAGMAZgBlAGQAZwBmAGQAaABpAGoAaABqAGsAbgBtAGwAbwBuAGwAcgBxAHAAcwByAHAAdAB1AHYAdAB2AHcAeAB5AHoAeAB6AHsAfgB9AHwAfwB+AHwAgACBAIIAgACCAIMAhgCFAIQAhwCGAIQAigCJAIgAiwCKAIgAjACNAI4AjACOAI8AkACRAJIAkACSAJMAlgCVAJQAlwCWAJQAmACZAJoAmACaAJsAngCdAJwAnwCeAJwAogChAKAAowCiAKAApAClAKYApACmAKcAqACpAKoAqACqAKsArgCtAKwArwCuAKwAsACxALIAsACyALMAtgC1ALQAtwC2ALQAugC5ALgAuwC6ALgAvAC9AL4AvAC+AL8AwADBAMIAwADCAMMAxgDFAMQAxwDGAMQAyADJAMoAyADKAMsAzgDNAMwAzwDOAMwA0gDRANAA0wDSANAA1ADVANYA1ADWANcA2ADZANoA2ADaANsA3gDdANwA3wDeANwA4ADhAOIA4ADiAOMA5gDlAOQA5wDmAOQA6gDpAOgA6wDqAOgA7ADtAO4A7ADuAO8A"
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteLength": 2880,
+      "byteOffset": 0,
+      "target": 34962,
+      "byteStride": 12
+    },
+    {
+      "buffer": 0,
+      "byteLength": 2880,
+      "byteOffset": 2880,
+      "target": 34962,
+      "byteStride": 12
+    },
+    {
+      "buffer": 0,
+      "byteLength": 720,
+      "byteOffset": 5760,
+      "target": 34963
+    }
+  ],
+  "materials": [
+    {
+      "pbrMetallicRoughness": {
+        "baseColorFactor": [
+          1,
+          1,
+          1,
+          1
+        ],
+        "roughnessFactor": 1,
+        "metallicFactor": 0
+      },
+      "alphaMode": "OPAQUE",
+      "doubleSided": false,
+      "emissiveFactor": [
+        0,
+        0,
+        0
+      ]
+    }
+  ],
+  "meshes": [
+    {
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 0,
+            "NORMAL": 1
+          },
+          "indices": 2,
+          "material": 0,
+          "mode": 4
+        }
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "Z_UP_TO_Y_UP",
+      "matrix": [
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        -1,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1
+      ],
+      "children": [
+        1
+      ]
+    },
+    {
+      "name": "RTC_CENTER",
+      "translation": [
+        1215019.2111447915,
+        -4736339.477299974,
+        4081627.9570209784
+      ],
+      "rotation": [
+        0,
+        0,
+        0,
+        1
+      ],
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "mesh": 0
+    }
+  ],
+  "scene": 0,
+  "scenes": [
+    {
+      "nodes": [
+        0
+      ]
+    }
+  ]
+}

--- a/Specs/Data/Cesium3DTiles/GltfContentWithRepeatedCopyrights/glTF/tileset.json
+++ b/Specs/Data/Cesium3DTiles/GltfContentWithRepeatedCopyrights/glTF/tileset.json
@@ -1,0 +1,101 @@
+{
+  "asset": {
+    "version": "1.0"
+  },
+  "extensionsUsed": ["3DTILES_content_gltf"],
+  "extensionsRequired": ["3DTILES_content_gltf"],
+  "geometricError": 240,
+  "root": {
+    "boundingVolume": {
+      "region": [
+        -1.3197209591796106,
+        0.6988424218,
+        -1.3196390408203893,
+        0.6989055782,
+        0,
+        88
+      ]
+    },
+    "geometricError": 70,
+    "refine": "ADD",
+    "content": {
+      "uri": "parent.gltf",
+      "boundingVolume": {
+        "region": [
+          -1.3197004795898053,
+          0.6988582109,
+          -1.3196595204101946,
+          0.6988897891,
+          0,
+          88
+        ]
+      }
+    },
+    "children": [
+      {
+        "boundingVolume": {
+          "region": [
+            -1.3197209591796106,
+            0.6988424218,
+            -1.31968,
+            0.698874,
+            0,
+            20
+          ]
+        },
+        "geometricError": 0,
+        "content": {
+          "uri": "ll.gltf"
+        }
+      },
+      {
+        "boundingVolume": {
+          "region": [
+            -1.31968,
+            0.6988424218,
+            -1.3196390408203893,
+            0.698874,
+            0,
+            20
+          ]
+        },
+        "geometricError": 0,
+        "content": {
+          "uri": "lr.gltf"
+        }
+      },
+      {
+        "boundingVolume": {
+          "region": [
+            -1.31968,
+            0.698874,
+            -1.3196390408203893,
+            0.6989055782,
+            0,
+            20
+          ]
+        },
+        "geometricError": 0,
+        "content": {
+          "uri": "ur.gltf"
+        }
+      },
+      {
+        "boundingVolume": {
+          "region": [
+            -1.3197209591796106,
+            0.698874,
+            -1.31968,
+            0.6989055782,
+            0,
+            20
+          ]
+        },
+        "geometricError": 0,
+        "content": {
+          "uri": "ul.gltf"
+        }
+      }
+    ]
+  }
+}

--- a/Specs/Data/Cesium3DTiles/GltfContentWithRepeatedCopyrights/glTF/ul.gltf
+++ b/Specs/Data/Cesium3DTiles/GltfContentWithRepeatedCopyrights/glTF/ul.gltf
@@ -1,0 +1,164 @@
+{
+  "accessors": [
+    {
+      "bufferView": 0,
+      "byteOffset": 0,
+      "componentType": 5126,
+      "count": 240,
+      "type": "VEC3",
+      "min": [
+        -91.84075295971707,
+        -70.59622491057962,
+        -55.74257782660425
+      ],
+      "max": [
+        76.89407575502992,
+        34.79088567662984,
+        40.11992733273655
+      ]
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 0,
+      "componentType": 5126,
+      "count": 240,
+      "type": "VEC3",
+      "min": [
+        -0.9686407230533828,
+        -0.7415496213868593,
+        -0.76555693327586
+      ],
+      "max": [
+        0.9686407230533828,
+        0.7415496213868593,
+        0.76555693327586
+      ]
+    },
+    {
+      "bufferView": 2,
+      "byteOffset": 0,
+      "componentType": 5123,
+      "count": 360,
+      "type": "SCALAR",
+      "min": [
+        0
+      ],
+      "max": [
+        239
+      ]
+    }
+  ],
+  "asset": {
+    "copyright": "Last Repeated Copyright, Most Frequent Copyright",
+    "generator": "3d-tiles-samples-generator",
+    "version": "2.0"
+  },
+  "buffers": [
+    {
+      "name": "buffer",
+      "byteLength": 6480,
+      "uri": "data:application/octet-stream;base64,+QzswIyJWcFy0hvAeCREPz4eOMFy0hvAOTSbvmbW6sB17CtAZiIHwYHWFsF17CtADYcZwb1DnsAfCR/BRvK5v0PaNsAfCR/ByGghwNDjpz/KMprA9qIqwTftRr/KMprARvK5v0PaNsAfCR/ByGghwNDjpz/KMprAOTSbvmbW6sB17CtAeCREPz4eOMFy0hvADYcZwb1DnsAfCR/B9qIqwTftRr/KMprAZiIHwYHWFsF17CtA+QzswIyJWcFy0hvA9qIqwTftRr/KMprAyGghwNDjpz/KMprAOTSbvmbW6sB17CtAZiIHwYHWFsF17CtADYcZwb1DnsAfCR/BRvK5v0PaNsAfCR/BeCREPz4eOMFy0hvA+QzswIyJWcFy0hvAnSiQQsO4EL4VUELBxMmZQmD+iz8VUELBZi+YQrn8hkDF5QTBPo6OQrbuPkDF5QTBtiSMQmDu9UDUepfB3sWVQt+5DkHUepfBfyuUQnC4QEFXi3HBWIqKQsH1LEFXi3HB3sWVQt+5DkHUepfBfyuUQnC4QEFXi3HBZi+YQrn8hkDF5QTBxMmZQmD+iz8VUELBtiSMQmDu9UDUepfBWIqKQsH1LEFXi3HBPo6OQrbuPkDF5QTBnSiQQsO4EL4VUELBWIqKQsH1LEFXi3HBfyuUQnC4QEFXi3HBZi+YQrn8hkDF5QTBPo6OQrbuPkDF5QTBtiSMQmDu9UDUepfB3sWVQt+5DkHUepfBxMmZQmD+iz8VUELBnSiQQsO4EL4VUELBlw+ywkQxjcKn8UzCuWucwj2kh8Kn8UzCamCfwpM8eML0oTDCSAS1wlGrgcL0oTDCxrm0wsfNgsJm+F7C6RWfwn6BesJm+F7CmQqiwpd1Y8KzqELCd663wqaPbsKzqELC6RWfwn6BesJm+F7CmQqiwpd1Y8KzqELCamCfwpM8eML0oTDCuWucwj2kh8Kn8UzCxrm0wsfNgsJm+F7Cd663wqaPbsKzqELCSAS1wlGrgcL0oTDClw+ywkQxjcKn8UzCd663wqaPbsKzqELCmQqiwpd1Y8KzqELCamCfwpM8eML0oTDCSAS1wlGrgcL0oTDCxrm0wsfNgsJm+F7C6RWfwn6BesJm+F7CuWucwj2kh8Kn8UzClw+ywkQxjcKn8UzCqkTIwVeKR0GagslBheeZwXBTX0GagslB60KfwRqMhEFVKuNBEKDNwRtPcUFVKuNBkonSwfHNi0HGxqZBbSykwX2yl0HGxqZB04epwd+UrEGBbsBB+OTXwVOwoEGBbsBBbSykwX2yl0HGxqZB04epwd+UrEGBbsBB60KfwRqMhEFVKuNBheeZwXBTX0GagslBkonSwfHNi0HGxqZB+OTXwVOwoEGBbsBBEKDNwRtPcUFVKuNBqkTIwVeKR0GagslB+OTXwVOwoEGBbsBB04epwd+UrEGBbsBB60KfwRqMhEFVKuNBEKDNwRtPcUFVKuNBkonSwfHNi0HGxqZBbSykwX2yl0HGxqZBheeZwXBTX0GagslBqkTIwVeKR0GagslBwB6fwfcpvEDitKRBA4t8wSze3UDitKRB4+CBwakOC0EE+7VBIrqiwR1p9EAE+7VB0c+twfGhUEFxB2ZBkvaMwQx8YUFxB2ZB85GQwZ+bfUHbSYRBM2uxwYTBbEHbSYRBkvaMwQx8YUFxB2ZB85GQwZ+bfUHbSYRB4+CBwakOC0EE+7VBA4t8wSze3UDitKRB0c+twfGhUEFxB2ZBM2uxwYTBbEHbSYRBIrqiwR1p9EAE+7VBwB6fwfcpvEDitKRBM2uxwYTBbEHbSYRB85GQwZ+bfUHbSYRB4+CBwakOC0EE+7VBIrqiwR1p9EAE+7VB0c+twfGhUEFxB2ZBkvaMwQx8YUFxB2ZBA4t8wSze3UDitKRBwB6fwfcpvEDitKRBEe7cQXKcL8DIqpXANqUEQqsoqb/IqpXALo0BQpXO2D/5D3m/Ab7WQXD5ij75D3m/xn3PQSWDc0DLvSXBIdr7QaFFp0DLvSXBEar1QbjhA0HN8tTAtk3JQWM/2kDN8tTAIdr7QaFFp0DLvSXBEar1QbjhA0HN8tTALo0BQpXO2D/5D3m/NqUEQqsoqb/IqpXAxn3PQSWDc0DLvSXBtk3JQWM/2kDN8tTAAb7WQXD5ij75D3m/Ee7cQXKcL8DIqpXAtk3JQWM/2kDN8tTAEar1QbjhA0HN8tTALo0BQpXO2D/5D3m/Ab7WQXD5ij75D3m/xn3PQSWDc0DLvSXBIdr7QaFFp0DLvSXBNqUEQqsoqb/IqpXAEe7cQXKcL8DIqpXAoFolQqEWHUFwOdI/vSpHQiHIP0FwOdI/modAQi6kk0FObBlBfrceQm5LgkFObBlBlKQgQrGNZkFH1xXAsHRCQpifhEFH1xXAjtE7QrZfuEGdXrNAcgEaQvYGp0GdXrNAsHRCQpifhEFH1xXAjtE7QrZfuEGdXrNAmodAQi6kk0FObBlBvSpHQiHIP0FwOdI/lKQgQrGNZkFH1xXAcgEaQvYGp0GdXrNAfrceQm5LgkFObBlBoFolQqEWHUFwOdI/cgEaQvYGp0GdXrNAjtE7QrZfuEGdXrNAmodAQi6kk0FObBlBfrceQm5LgkFObBlBlKQgQrGNZkFH1xXAsHRCQpifhEFH1xXAvSpHQiHIP0FwOdI/oFolQqEWHUFwOdI/x0XawfMfMsFaOR9AV9V9wetBA8FaOR9A+8KMwQZ4ur9FaixBFh7owRJajMBFaixBFU3owUB9icBmXlzA+fGMwb4Er79mXlzASMqawaQkrECqCJtAZCX2wSjRHECqCJtA+fGMwb4Er79mXlzASMqawaQkrECqCJtA+8KMwQZ4ur9FaixBV9V9wetBA8FaOR9AFU3owUB9icBmXlzAZCX2wSjRHECqCJtAFh7owRJajMBFaixBx0XawfMfMsFaOR9AZCX2wSjRHECqCJtASMqawaQkrECqCJtA+8KMwQZ4ur9FaixBFh7owRJajMBFaixBFU3owUB9icBmXlzA+fGMwb4Er79mXlzAV9V9wetBA8FaOR9Ax0XawfMfMsFaOR9A05lDQW/Hf8GPvjLBn1+SQTHcZsGPvjLBGVmLQSIVMMEM6N7Ax4w1QWAAScEM6N7A0nYgQfeY7cBQy5TBHs6AQXvCu8BQy5TBMI9zQb1oHMAYTGbBxWkSQdsKgMAYTGbBHs6AQXvCu8BQy5TBMI9zQb1oHMAYTGbBGVmLQSIVMMEM6N7An1+SQTHcZsGPvjLB0nYgQfeY7cBQy5TBxWkSQdsKgMAYTGbBx4w1QWAAScEM6N7A05lDQW/Hf8GPvjLBxWkSQdsKgMAYTGbBMI9zQb1oHMAYTGbBGVmLQSIVMMEM6N7Ax4w1QWAAScEM6N7A0nYgQfeY7cBQy5TBHs6AQXvCu8BQy5TBn1+SQTHcZsGPvjLB05lDQW/Hf8GPvjLBxsXNwDnFuEHoshFCHNPZvtEXxUHoshFCUjiZv0so3UHOeiBCqHbmwLTV0EHOeiBCJjcEwarw8UEczPFBbosQwEJD/kEczPFBNO1BwN4pC0L0rQdCl48QwZIABUL0rQdCbosQwEJD/kEczPFBNO1BwN4pC0L0rQdCUjiZv0so3UHOeiBCHNPZvtEXxUHoshFCJjcEwarw8UEczPFBl48QwZIABUL0rQdCqHbmwLTV0EHOeiBCxsXNwDnFuEHoshFCl48QwZIABUL0rQdCNO1BwN4pC0L0rQdCUjiZv0so3UHOeiBCqHbmwLTV0EHOeiBCJjcEwarw8UEczPFBbosQwEJD/kEczPFBHNPZvtEXxUHoshFCxsXNwDnFuEHoshFCm8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA/bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA/bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/1/h3P8Rtfj4//nyj1/h3P8Rtfj4//nyj1/h3P8Rtfj4//nyj1/h3P8Rtfj4//nyj1/h3v8Rtfr4//nwj1/h3v8Rtfr4//nwj1/h3v8Rtfr4//nwj1/h3v8Rtfr4//nwj/bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA/bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA/bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA/bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/1/h3P8Rtfj6G6n6j1/h3P8Rtfj6G6n6j1/h3P8Rtfj6G6n6j1/h3P8Rtfj6G6n6j1/h3v8Rtfr6G6n4j1/h3v8Rtfr6G6n4j1/h3v8Rtfr6G6n4j1/h3v8Rtfr6G6n4j/bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA/bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3P8Rtfj4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA1/h3v8Rtfr4AAAAA/bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCPjLWPb/GsyQ/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/m8dCvjLWPT/GsyS/1/h3P8Rtfj4BHbAj1/h3P8Rtfj4BHbAj1/h3P8Rtfj4BHbAj1/h3P8Rtfj4BHbAj1/h3v8Rtfr4BHbCj1/h3v8Rtfr4BHbCj1/h3v8Rtfr4BHbCj1/h3v8Rtfr4BHbCj/bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjvo2JHz+K+0M//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O//bAjPo2JH7+K+0O/AAABAAIAAAACAAMABgAFAAQABwAGAAQACAAJAAoACAAKAAsADgANAAwADwAOAAwAEgARABAAEwASABAAFAAVABYAFAAWABcAGAAZABoAGAAaABsAHgAdABwAHwAeABwAIAAhACIAIAAiACMAJgAlACQAJwAmACQAKgApACgAKwAqACgALAAtAC4ALAAuAC8AMAAxADIAMAAyADMANgA1ADQANwA2ADQAOAA5ADoAOAA6ADsAPgA9ADwAPwA+ADwAQgBBAEAAQwBCAEAARABFAEYARABGAEcASABJAEoASABKAEsATgBNAEwATwBOAEwAUABRAFIAUABSAFMAVgBVAFQAVwBWAFQAWgBZAFgAWwBaAFgAXABdAF4AXABeAF8AYABhAGIAYABiAGMAZgBlAGQAZwBmAGQAaABpAGoAaABqAGsAbgBtAGwAbwBuAGwAcgBxAHAAcwByAHAAdAB1AHYAdAB2AHcAeAB5AHoAeAB6AHsAfgB9AHwAfwB+AHwAgACBAIIAgACCAIMAhgCFAIQAhwCGAIQAigCJAIgAiwCKAIgAjACNAI4AjACOAI8AkACRAJIAkACSAJMAlgCVAJQAlwCWAJQAmACZAJoAmACaAJsAngCdAJwAnwCeAJwAogChAKAAowCiAKAApAClAKYApACmAKcAqACpAKoAqACqAKsArgCtAKwArwCuAKwAsACxALIAsACyALMAtgC1ALQAtwC2ALQAugC5ALgAuwC6ALgAvAC9AL4AvAC+AL8AwADBAMIAwADCAMMAxgDFAMQAxwDGAMQAyADJAMoAyADKAMsAzgDNAMwAzwDOAMwA0gDRANAA0wDSANAA1ADVANYA1ADWANcA2ADZANoA2ADaANsA3gDdANwA3wDeANwA4ADhAOIA4ADiAOMA5gDlAOQA5wDmAOQA6gDpAOgA6wDqAOgA7ADtAO4A7ADuAO8A"
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteLength": 2880,
+      "byteOffset": 0,
+      "target": 34962,
+      "byteStride": 12
+    },
+    {
+      "buffer": 0,
+      "byteLength": 2880,
+      "byteOffset": 2880,
+      "target": 34962,
+      "byteStride": 12
+    },
+    {
+      "buffer": 0,
+      "byteLength": 720,
+      "byteOffset": 5760,
+      "target": 34963
+    }
+  ],
+  "materials": [
+    {
+      "pbrMetallicRoughness": {
+        "baseColorFactor": [
+          1,
+          1,
+          1,
+          1
+        ],
+        "roughnessFactor": 1,
+        "metallicFactor": 0
+      },
+      "alphaMode": "OPAQUE",
+      "doubleSided": false,
+      "emissiveFactor": [
+        0,
+        0,
+        0
+      ]
+    }
+  ],
+  "meshes": [
+    {
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 0,
+            "NORMAL": 1
+          },
+          "indices": 2,
+          "material": 0,
+          "mode": 4
+        }
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "Z_UP_TO_Y_UP",
+      "matrix": [
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        -1,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1
+      ],
+      "children": [
+        1
+      ]
+    },
+    {
+      "name": "RTC_CENTER",
+      "translation": [
+        1214904.9355808275,
+        -4736269.810390115,
+        4081686.2829379616
+      ],
+      "mesh": 0
+    }
+  ],
+  "scene": 0,
+  "scenes": [
+    {
+      "nodes": [
+        0
+      ]
+    }
+  ]
+}

--- a/Specs/Data/Cesium3DTiles/GltfContentWithRepeatedCopyrights/glTF/ur.gltf
+++ b/Specs/Data/Cesium3DTiles/GltfContentWithRepeatedCopyrights/glTF/ur.gltf
@@ -1,0 +1,164 @@
+{
+  "accessors": [
+    {
+      "bufferView": 0,
+      "byteOffset": 0,
+      "componentType": 5126,
+      "count": 240,
+      "type": "VEC3",
+      "min": [
+        -77.14447077619843,
+        -42.96283542830497,
+        -67.52034310717136
+      ],
+      "max": [
+        77.76364028593525,
+        46.61669829953462,
+        72.33625365514308
+      ]
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 0,
+      "componentType": 5126,
+      "count": 240,
+      "type": "VEC3",
+      "min": [
+        -0.9686305452941167,
+        -0.741541829732688,
+        -0.76555693327586
+      ],
+      "max": [
+        0.9686305452941167,
+        0.741541829732688,
+        0.76555693327586
+      ]
+    },
+    {
+      "bufferView": 2,
+      "byteOffset": 0,
+      "componentType": 5123,
+      "count": 360,
+      "type": "SCALAR",
+      "min": [
+        0
+      ],
+      "max": [
+        239
+      ]
+    }
+  ],
+  "asset": {
+    "copyright": "Second Repeated Copyright, Most Frequent Copyright",
+    "generator": "3d-tiles-samples-generator",
+    "version": "2.0"
+  },
+  "buffers": [
+    {
+      "name": "buffer",
+      "byteLength": 6480,
+      "uri": "data:application/octet-stream;base64,7oSsQWwNBsCxSsHANovmQephb76xSsHA2pPeQXFyaUBg2aK/ko2kQUe25D9g2aK/ZBKjQQSLIEBWiyDBqxjdQSnRi0BWiyDBTyHVQbgCBEFTgqjACBubQcp5zEBTgqjAqxjdQSnRi0BWiyDBTyHVQbgCBEFTgqjA2pPeQXFyaUBg2aK/NovmQephb76xSsHAZBKjQQSLIEBWiyDBCBubQcp5zEBTgqjAko2kQUe25D9g2aK/7oSsQWwNBsCxSsHACBubQcp5zEBTgqjATyHVQbgCBEFTgqjA2pPeQXFyaUBg2aK/ko2kQUe25D9g2aK/ZBKjQQSLIEBWiyDBqxjdQSnRi0BWiyDBNovmQephb76xSsHA7oSsQWwNBsCxSsHA1/0vQQT0BMKDbQTCeL6xQZXh8sGDbQTC4EKjQQluusHtgcPBqQYTQXx00cHtgcPBe+wRQYtOz8E52R3CyrWiQRhIuME52R3CMzqUQRipf8FZWfbBmurpQP/alsFZWfbByrWiQRhIuME52R3CMzqUQRipf8FZWfbB4EKjQQluusHtgcPBeL6xQZXh8sGDbQTCe+wRQYtOz8E52R3CmurpQP/alsFZWfbBqQYTQXx00cHtgcPB1/0vQQT0BMKDbQTCmurpQP/alsFZWfbBMzqUQRipf8FZWfbB4EKjQQluusHtgcPBqQYTQXx00cHtgcPBe+wRQYtOz8E52R3CyrWiQRhIuME52R3CeL6xQZXh8sGDbQTC1/0vQQT0BMKDbQTCH4VjQj4CsEEZMFhB2EF9QvY2vUEZMFhBoeR5QrZw10GaT4xB5ydgQv87ykGaT4xBULVdQqxQ3UFOkglBCnJ3QmSF6kFOkglB0hR0QpJfAkJoAUpBGVhaQmyK90FoAUpBCnJ3QmSF6kFOkglB0hR0QpJfAkJoAUpBoeR5QrZw10GaT4xB2EF9QvY2vUEZMFhBULVdQqxQ3UFOkglBGVhaQmyK90FoAUpB5ydgQv87ykGaT4xBH4VjQj4CsEEZMFhBGVhaQmyK90FoAUpB0hR0QpJfAkJoAUpBoeR5QrZw10GaT4xB5ydgQv87ykGaT4xBULVdQqxQ3UFOkglBCnJ3QmSF6kFOkglB2EF9QvY2vUEZMFhBH4VjQj4CsEEZMFhB0L7QwSUzjD/kg4tBLFCqwaf6FEDkg4tBuKGvwaNpnUBo+6RBXBDWwTLya0Bo+6RB0sjfwb3DBkHxTzFBLlq5wQJ8GkHxTzFBuqu+wSryQ0H4PmRBXxrlweU5MEH4PmRBLlq5wQJ8GkHxTzFBuqu+wSryQ0H4PmRBuKGvwaNpnUBo+6RBLFCqwaf6FEDkg4tB0sjfwb3DBkHxTzFBXxrlweU5MEH4PmRBXBDWwTLya0Bo+6RB0L7QwSUzjD/kg4tBXxrlweU5MEH4PmRBuqu+wSryQ0H4PmRBuKGvwaNpnUBo+6RBXBDWwTLya0Bo+6RB0sjfwb3DBkHxTzFBLlq5wQJ8GkHxTzFBLFCqwaf6FEDkg4tB0L7QwSUzjD/kg4tB4CaKQvLZK8Imv3PC/IabQpfvIsImv3PCl0CYQsBnCcInYlTCeuCGQhpSEsInYlTCHEKGQoZ/DcJqCofCOaKXQiyVBMJqCofC01uUQqka1sHWt27Ct/uCQl7v58HWt27COaKXQiyVBMJqCofC01uUQqka1sHWt27Cl0CYQsBnCcInYlTC/IabQpfvIsImv3PCHEKGQoZ/DcJqCofCt/uCQl7v58HWt27CeuCGQhpSEsInYlTC4CaKQvLZK8Imv3PCt/uCQl7v58HWt27C01uUQqka1sHWt27Cl0CYQsBnCcInYlTCeuCGQhpSEsInYlTCHEKGQoZ/DcJqCofCOaKXQiyVBMJqCofC/IabQpfvIsImv3PC4CaKQvLZK8Imv3PCD1o3wrUBtUDIY+5BdGYYwlGI9EDIY+5BNIsdwvl1SkHj0g9Czn48wquyKkHj0g9CcH0/wnljWUGuWLdB1YkgwscmeUGuWLdBla4lwkyspEGsmuhBL6JEwqXKlEGsmuhB1YkgwscmeUGuWLdBla4lwkyspEGsmuhBNIsdwvl1SkHj0g9CdGYYwlGI9EDIY+5BcH0/wnljWUGuWLdBL6JEwqXKlEGsmuhBzn48wquyKkHj0g9CD1o3wrUBtUDIY+5BL6JEwqXKlEGsmuhBla4lwkyspEGsmuhBNIsdwvl1SkHj0g9Czn48wquyKkHj0g9CcH0/wnljWUGuWLdB1YkgwscmeUGuWLdBdGYYwlGI9EDIY+5BD1o3wrUBtUDIY+5BwNX2Qfqe18D/83XACkIjQvXZhcD/83XAvEwdQt/Dzz/4hVJAJevqQW2gbr/4hVJANE7jQQW9MUDTk0HBRH4ZQoijqkDTk0HB9ogTQjo3MkGs6p7AmWPXQbdUCUGs6p7ARH4ZQoijqkDTk0HB9ogTQjo3MkGs6p7AvEwdQt/Dzz/4hVJACkIjQvXZhcD/83XANE7jQQW9MUDTk0HBmWPXQbdUCUGs6p7AJevqQW2gbr/4hVJAwNX2Qfqe18D/83XAmWPXQbdUCUGs6p7A9ogTQjo3MkGs6p7AvEwdQt/Dzz/4hVJAJevqQW2gbr/4hVJANE7jQQW9MUDTk0HBRH4ZQoijqkDTk0HBCkIjQvXZhcD/83XAwNX2Qfqe18D/83XA+rOUwrm0B0K9b4NCOaSGwsjrDkK9b4NC3meJwlZ4JEIprJBCn3eXwkdBHUIprJBCU4aXwuOzHULUyXNCknaJwvHqJELUyXNCNzqMwoB3OkJXIYdC+EmawnFAM0JXIYdCknaJwvHqJELUyXNCNzqMwoB3OkJXIYdC3meJwlZ4JEIprJBCOaSGwsjrDkK9b4NCU4aXwuOzHULUyXNC+EmawnFAM0JXIYdCn3eXwkdBHUIprJBC+rOUwrm0B0K9b4NC+EmawnFAM0JXIYdCNzqMwoB3OkJXIYdC3meJwlZ4JEIprJBCn3eXwkdBHUIprJBCU4aXwuOzHULUyXNCknaJwvHqJELUyXNCOaSGwsjrDkK9b4NC+rOUwrm0B0K9b4NCHOKKwcKvscHrz4nBoCEZweOyocHrz4nBXKArwZdOe8FwEDvBeyGUwSqkjcFwEDvBVs+UwYD+isHOYavBE/wswUIDdsHOYavB0Ho/wRLsLcE3NH7BtA6ewc/lTcE3NH7BE/wswUIDdsHOYavB0Ho/wRLsLcE3NH7BXKArwZdOe8FwEDvBoCEZweOyocHrz4nBVs+UwYD+isHOYavBtA6ewc/lTcE3NH7BeyGUwSqkjcFwEDvBHOKKwcKvscHrz4nBtA6ewc/lTcE3NH7B0Ho/wRLsLcE3NH7BXKArwZdOe8FwEDvBeyGUwSqkjcFwEDvBVs+UwYD+isHOYavBE/wswUIDdsHOYavBoCEZweOyocHrz4nBHOKKwcKvscHrz4nBsvNEwv5IqMGq7p/AMNoxwid8nsGq7p/ABvkzwmr0jcFBaR3AhxJHwkDBl8FBaR3AyJ9KwhgieMHlsRzBRoY3wmuIZMHlsRzBG6U5wvB4Q8HCKejAnb5Mwp0SV8HCKejARoY3wmuIZMHlsRzBG6U5wvB4Q8HCKejABvkzwmr0jcFBaR3AMNoxwid8nsGq7p/AyJ9KwhgieMHlsRzBnb5Mwp0SV8HCKejAhxJHwkDBl8FBaR3AsvNEwv5IqMGq7p/Anb5Mwp0SV8HCKejAG6U5wvB4Q8HCKejABvkzwmr0jcFBaR3AhxJHwkDBl8FBaR3AyJ9KwhgieMHlsRzBRoY3wmuIZMHlsRzBMNoxwid8nsGq7p/AsvNEwv5IqMGq7p/Akc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/LPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAArrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/LPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAArrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/LPh3Pyp4fj4A6csjLPh3Pyp4fj4A6csjLPh3Pyp4fj4A6csjLPh3Pyp4fj4A6csjLPh3vyp4fr4A6cujLPh3vyp4fr4A6cujLPh3vyp4fr4A6cujLPh3vyp4fr4A6cujrrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/LPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAArrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/LPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAArrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/LPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAArrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/LPh3Pyp4fj4vDImjLPh3Pyp4fj4vDImjLPh3Pyp4fj4vDImjLPh3Pyp4fj4vDImjLPh3vyp4fr4vDIkjLPh3vyp4fr4vDIkjLPh3vyp4fr4vDIkjLPh3vyp4fr4vDIkjrrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/LPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAArrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/LPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAArrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9CPq/VPb/GsyQ/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/kc9Cvq/VPT/GsyS/LPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3Pyp4fj4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAALPh3vyp4fr4AAAAArrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjvh+JHz+K+0M/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/rrcjPh+JH7+K+0O/AAABAAIAAAACAAMABgAFAAQABwAGAAQACAAJAAoACAAKAAsADgANAAwADwAOAAwAEgARABAAEwASABAAFAAVABYAFAAWABcAGAAZABoAGAAaABsAHgAdABwAHwAeABwAIAAhACIAIAAiACMAJgAlACQAJwAmACQAKgApACgAKwAqACgALAAtAC4ALAAuAC8AMAAxADIAMAAyADMANgA1ADQANwA2ADQAOAA5ADoAOAA6ADsAPgA9ADwAPwA+ADwAQgBBAEAAQwBCAEAARABFAEYARABGAEcASABJAEoASABKAEsATgBNAEwATwBOAEwAUABRAFIAUABSAFMAVgBVAFQAVwBWAFQAWgBZAFgAWwBaAFgAXABdAF4AXABeAF8AYABhAGIAYABiAGMAZgBlAGQAZwBmAGQAaABpAGoAaABqAGsAbgBtAGwAbwBuAGwAcgBxAHAAcwByAHAAdAB1AHYAdAB2AHcAeAB5AHoAeAB6AHsAfgB9AHwAfwB+AHwAgACBAIIAgACCAIMAhgCFAIQAhwCGAIQAigCJAIgAiwCKAIgAjACNAI4AjACOAI8AkACRAJIAkACSAJMAlgCVAJQAlwCWAJQAmACZAJoAmACaAJsAngCdAJwAnwCeAJwAogChAKAAowCiAKAApAClAKYApACmAKcAqACpAKoAqACqAKsArgCtAKwArwCuAKwAsACxALIAsACyALMAtgC1ALQAtwC2ALQAugC5ALgAuwC6ALgAvAC9AL4AvAC+AL8AwADBAMIAwADCAMMAxgDFAMQAxwDGAMQAyADJAMoAyADKAMsAzgDNAMwAzwDOAMwA0gDRANAA0wDSANAA1ADVANYA1ADWANcA2ADZANoA2ADaANsA3gDdANwA3wDeANwA4ADhAOIA4ADiAOMA5gDlAOQA5wDmAOQA6gDpAOgA6wDqAOgA7ADtAO4A7ADuAO8A"
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteLength": 2880,
+      "byteOffset": 0,
+      "target": 34962,
+      "byteStride": 12
+    },
+    {
+      "buffer": 0,
+      "byteLength": 2880,
+      "byteOffset": 2880,
+      "target": 34962,
+      "byteStride": 12
+    },
+    {
+      "buffer": 0,
+      "byteLength": 720,
+      "byteOffset": 5760,
+      "target": 34963
+    }
+  ],
+  "materials": [
+    {
+      "pbrMetallicRoughness": {
+        "baseColorFactor": [
+          1,
+          1,
+          1,
+          1
+        ],
+        "roughnessFactor": 1,
+        "metallicFactor": 0
+      },
+      "alphaMode": "OPAQUE",
+      "doubleSided": false,
+      "emissiveFactor": [
+        0,
+        0,
+        0
+      ]
+    }
+  ],
+  "meshes": [
+    {
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 0,
+            "NORMAL": 1
+          },
+          "indices": 2,
+          "material": 0,
+          "mode": 4
+        }
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "Z_UP_TO_Y_UP",
+      "matrix": [
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        -1,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1
+      ],
+      "children": [
+        1
+      ]
+    },
+    {
+      "name": "RTC_CENTER",
+      "translation": [
+        1215069.3569947367,
+        -4736227.241794692,
+        4081686.5536876773
+      ],
+      "mesh": 0
+    }
+  ],
+  "scene": 0,
+  "scenes": [
+    {
+      "nodes": [
+        0
+      ]
+    }
+  ]
+}

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -4955,7 +4955,7 @@ describe(
         expect(length).toEqual(expectedCredits.length);
         for (let i = 0; i < length; i++) {
           const creditInfo = credits[i];
-          const creditString = creditInfo[0].html;
+          const creditString = creditInfo.credit.html;
           expect(expectedCredits.includes(creditString)).toBe(true);
         }
       });
@@ -4974,29 +4974,33 @@ describe(
         scene.camera.moveDown(150);
         scene.renderForSpecs();
         expect(credits.values.length).toEqual(1);
-        expect(credits.values[0][0].html).toEqual("Lower Left Copyright");
+        expect(credits.values[0].credit.html).toEqual("Lower Left Copyright");
 
         setZoom(10.0);
         scene.camera.moveRight(150);
         scene.camera.moveDown(150);
         scene.renderForSpecs();
         expect(credits.values.length).toEqual(2);
-        expect(credits.values[0][0].html).toEqual("Lower Right Copyright 1");
-        expect(credits.values[1][0].html).toEqual("Lower Right Copyright 2");
+        expect(credits.values[0].credit.html).toEqual(
+          "Lower Right Copyright 1"
+        );
+        expect(credits.values[1].credit.html).toEqual(
+          "Lower Right Copyright 2"
+        );
 
         setZoom(10.0);
         scene.camera.moveRight(150);
         scene.camera.moveUp(150);
         scene.renderForSpecs();
         expect(credits.values.length).toEqual(1);
-        expect(credits.values[0][0].html).toEqual("Upper Right Copyright");
+        expect(credits.values[0].credit.html).toEqual("Upper Right Copyright");
 
         setZoom(10.0);
         scene.camera.moveLeft(150);
         scene.camera.moveUp(150);
         scene.renderForSpecs();
         expect(credits.values.length).toEqual(1);
-        expect(credits.values[0][0].html).toEqual("Upper Left Copyright");
+        expect(credits.values[0].credit.html).toEqual("Upper Left Copyright");
       });
     });
 

--- a/Specs/Scene/CreditDisplaySpec.js
+++ b/Specs/Scene/CreditDisplaySpec.js
@@ -255,6 +255,85 @@ describe("Scene/CreditDisplay", function () {
     expect(creditContainer.childNodes[0].innerHTML).toEqual("credit1");
   });
 
+  it("credit display keeps count of repeated credits", function () {
+    const repeatedCreditCount = 4;
+    creditDisplay = new CreditDisplay(container);
+    beginFrame(creditDisplay);
+
+    for (let i = 0; i < repeatedCreditCount; i++) {
+      creditDisplay.addCredit(new Credit("credit1", true));
+    }
+    creditDisplay.addCredit(new Credit("credit2", true));
+
+    const credits = creditDisplay._currentFrameCredits.screenCredits.values;
+    expect(credits.length).toEqual(2);
+
+    const firstCredit = credits[0];
+    expect(firstCredit[0].html).toEqual("credit1");
+    expect(firstCredit[1]).toEqual(repeatedCreditCount);
+
+    const secondCredit = credits[1];
+    expect(secondCredit[0].html).toEqual("credit2");
+    expect(secondCredit[1]).toEqual(1);
+  });
+
+  it("credit display sorts credits by frequency", function () {
+    const creditCounts = [2, 10, 6, 1];
+    const credit1 = new Credit("credit1", true);
+    const credit2 = new Credit("credit2", true);
+    const credit3 = new Credit("credit3", true);
+    const credit4 = new Credit("credit4", true);
+
+    creditDisplay = new CreditDisplay(container);
+    beginFrame(creditDisplay);
+
+    for (let i = 0; i < creditCounts.length; i++) {
+      const creditString = "credit".concat((i + 1).toString());
+      const count = creditCounts[i];
+      for (let j = 0; j < count; j++) {
+        creditDisplay.addCredit(new Credit(creditString, true));
+      }
+    }
+    creditDisplay.endFrame();
+
+    const creditContainer = container.childNodes[1];
+    expect(creditContainer.childNodes.length).toEqual(7);
+    expect(creditContainer.childNodes[0]).toEqual(credit2.element);
+    expect(creditContainer.childNodes[2]).toEqual(credit3.element);
+    expect(creditContainer.childNodes[4]).toEqual(credit1.element);
+    expect(creditContainer.childNodes[6]).toEqual(credit4.element);
+  });
+
+  it("credit display sorts credits by frequency with default credit", function () {
+    const defaultCredit = new Credit("default credit", true);
+    const creditCounts = [2, 10, 6, 1];
+    const credit1 = new Credit("credit1", true);
+    const credit2 = new Credit("credit2", true);
+    const credit3 = new Credit("credit3", true);
+    const credit4 = new Credit("credit4", true);
+
+    creditDisplay = new CreditDisplay(container);
+    creditDisplay.addDefaultCredit(defaultCredit);
+    beginFrame(creditDisplay);
+
+    for (let i = 0; i < creditCounts.length; i++) {
+      const creditString = "credit".concat((i + 1).toString());
+      const count = creditCounts[i];
+      for (let j = 0; j < count; j++) {
+        creditDisplay.addCredit(new Credit(creditString, true));
+      }
+    }
+    creditDisplay.endFrame();
+
+    const creditContainer = container.childNodes[1];
+    expect(creditContainer.childNodes.length).toEqual(9);
+    expect(creditContainer.childNodes[0]).toEqual(defaultCredit.element);
+    expect(creditContainer.childNodes[2]).toEqual(credit2.element);
+    expect(creditContainer.childNodes[4]).toEqual(credit3.element);
+    expect(creditContainer.childNodes[6]).toEqual(credit1.element);
+    expect(creditContainer.childNodes[8]).toEqual(credit4.element);
+  });
+
   it("displays credits in a lightbox", function () {
     const credit1 = new Credit("credit1");
     const credit2 = new Credit(`<img src="${imageUrl}"/>`);

--- a/Specs/Scene/CreditDisplaySpec.js
+++ b/Specs/Scene/CreditDisplaySpec.js
@@ -269,12 +269,12 @@ describe("Scene/CreditDisplay", function () {
     expect(credits.length).toEqual(2);
 
     const firstCredit = credits[0];
-    expect(firstCredit[0].html).toEqual("credit1");
-    expect(firstCredit[1]).toEqual(repeatedCreditCount);
+    expect(firstCredit.credit.html).toEqual("credit1");
+    expect(firstCredit.count).toEqual(repeatedCreditCount);
 
     const secondCredit = credits[1];
-    expect(secondCredit[0].html).toEqual("credit2");
-    expect(secondCredit[1]).toEqual(1);
+    expect(secondCredit.credit.html).toEqual("credit2");
+    expect(secondCredit.count).toEqual(1);
   });
 
   it("credit display sorts credits by frequency", function () {

--- a/Specs/Scene/GlobeSurfaceTileProviderSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileProviderSpec.js
@@ -1,4 +1,4 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
+import { Cartesian3, CreditDisplay } from "../../Source/Cesium.js";
 import { Cartesian4 } from "../../Source/Cesium.js";
 import { CesiumTerrainProvider } from "../../Source/Cesium.js";
 import { Color } from "../../Source/Cesium.js";
@@ -853,6 +853,7 @@ describe(
     });
 
     it("adds terrain and imagery credits to the CreditDisplay", function () {
+      const CreditDisplayElement = CreditDisplay.CreditDisplayElement;
       const imageryCredit = new Credit("imagery credit");
       scene.imageryLayers.addImageryProvider(
         new SingleTileImageryProvider({
@@ -872,10 +873,10 @@ describe(
         creditDisplay.showLightbox();
         expect(
           creditDisplay._currentFrameCredits.lightboxCredits.values
-        ).toContain([imageryCredit, 1]);
+        ).toContain(new CreditDisplayElement(imageryCredit));
         expect(
           creditDisplay._currentFrameCredits.lightboxCredits.values
-        ).toContain([terrainCredit, 1]);
+        ).toContain(new CreditDisplayElement(terrainCredit));
         creditDisplay.hideLightbox();
       });
     });

--- a/Specs/Scene/GlobeSurfaceTileProviderSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileProviderSpec.js
@@ -872,10 +872,10 @@ describe(
         creditDisplay.showLightbox();
         expect(
           creditDisplay._currentFrameCredits.lightboxCredits.values
-        ).toContain(imageryCredit);
+        ).toContain([imageryCredit, 1]);
         expect(
           creditDisplay._currentFrameCredits.lightboxCredits.values
-        ).toContain(terrainCredit);
+        ).toContain([terrainCredit, 1]);
         creditDisplay.hideLightbox();
       });
     });

--- a/Specs/Scene/GlobeSurfaceTileProviderSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileProviderSpec.js
@@ -1,8 +1,9 @@
-import { Cartesian3, CreditDisplay } from "../../Source/Cesium.js";
+import { Cartesian3 } from "../../Source/Cesium.js";
 import { Cartesian4 } from "../../Source/Cesium.js";
 import { CesiumTerrainProvider } from "../../Source/Cesium.js";
 import { Color } from "../../Source/Cesium.js";
 import { Credit } from "../../Source/Cesium.js";
+import { CreditDisplay } from "../../Source/Cesium.js";
 import { defined } from "../../Source/Cesium.js";
 import { Ellipsoid } from "../../Source/Cesium.js";
 import { EllipsoidTerrainProvider } from "../../Source/Cesium.js";

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -229,7 +229,7 @@ describe(
           const length = credits.length;
           expect(credits.length).toEqual(expectedCredits.length);
           for (let i = 0; i < length; i++) {
-            expect(credits[i].html).toEqual(expectedCredits[i]);
+            expect(credits[i][0].html).toEqual(expectedCredits[i]);
           }
         });
       });

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -229,7 +229,7 @@ describe(
           const length = credits.length;
           expect(credits.length).toEqual(expectedCredits.length);
           for (let i = 0; i < length; i++) {
-            expect(credits[i][0].html).toEqual(expectedCredits[i]);
+            expect(credits[i].credit.html).toEqual(expectedCredits[i]);
           }
         });
       });


### PR DESCRIPTION
Closes #10128.

This PR makes `CreditsDisplay` sort its credits by their number of occurrences, with more frequently occurring credits appearing first. I added a tileset with duplicate copyrights (a modified version of the one added in #10138) to test this, which when put in a [Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=xVRRb9owEP4rVp6CxBwYo6UtRWtB2x6QVgHtXvJinCPx6tiRfQHRaf99dkImmnYPq5Cal/h8d99999k+rpVFshWwA0OuiYIdmYIVZU4fqr0wDnhlT7VCJhSYOOhcxYpXeZaDApdW59PKdM7GjUKCBXyOW/8Gs1XtDH/FipDSyEsSB9GyAG6jGUMWPYuLvkrceAqg8IfAbAEFMIRkqou9EWmGNkrl6kt0qEh/Wq3ioOuhE1iX6TLTu1tdqkSo9EHLModLgqaEWP3uVIQr6rQwIhcotmApS5LwgNY5asmFIZi5VqnAMvG9f+jTQf/ibHTVCmHYRPTo2cVodP6pFeE8jSTMoFsxNaAbo/MFS9zahq1a3RbyMa2saJ3eN2C+1zuBPFswlULotfBfr9usHPPh+V+r/3FYLz1uo6NxMPs7x0lYoJiBCjel4ii0ImGHVEdXK8dZDoZRqfXjDR6Ydz0tj3bQeMlUwplFCV7dldZyzcxtiaiVu2Y3UpLqrN25kabKqYvcF4UTfg4brGq9sVQrKNdb8JBhf9j7h/u+aJz/QXPhL/aJeVaYpyM617t30XOmd+oNRN9D0RdUg24wtriXMGme3meRF9qgn4IhpRFCXkg33Wy0Lvmje4Xc2hqckHF0nDpOxJaI5PqVIU24ZNY6z6aUcimeXMeTceTiX6RKXY2K71swku19WNafzOtNSuk4cubrmViL3EL+Aw) results in the following:

![image](https://user-images.githubusercontent.com/32226860/155614229-af8455e4-8000-4238-a932-0078781f066c.png)


