### PR TITLE
Add link to documentation in CustomShader.js

### DIFF
--- a/Source/Scene/ModelExperimental/CustomShader.js
+++ b/Source/Scene/ModelExperimental/CustomShader.js
@@ -70,6 +70,9 @@ import TextureManager from "./TextureManager.js";
  * <p>
  * To enable the use of {@link ModelExperimental} in {@link Cesium3DTileset}, set {@link ExperimentalFeatures.enableModelExperimental} to <code>true</code> or tileset.enableModelExperimental to <code>true</code>.
  * </p>
+ * <p>
+ * See the {@link https://github.com/CesiumGS/cesium/tree/main/Documentation/CustomShaderGuide|Custom Shader Guide} for more detailed documentation.
+ * </p>
  *
  * @param {Object} options An object with the following options
  * @param {CustomShaderMode} [options.mode=CustomShaderMode.MODIFY_MATERIAL] The custom shader mode, which determines how the custom shader code is inserted into the fragment shader.


### PR DESCRIPTION
We have more detailed documentation for `CustomShader` in the [Custom Shaders Guide](https://github.com/CesiumGS/cesium/tree/main/Documentation/CustomShaderGuide), but this is not discoverable from the API documentation.

Added a link to the CustomShader constructor.

@lilleyse could you review?