### PR TITLE
Split credits by semicolons instead of commas

### DIFF
--- a/Source/Scene/GltfLoader.js
+++ b/Source/Scene/GltfLoader.js
@@ -1434,7 +1434,7 @@ function parse(loader, gltf, supportedImageFormats, frameState) {
   const asset = new Asset();
   const copyright = gltf.asset.copyright;
   if (defined(copyright)) {
-    const credits = copyright.split(",").map(function (string) {
+    const credits = copyright.split(";").map(function (string) {
       return new Credit(string.trim());
     });
     asset.credits = credits;

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -2221,7 +2221,7 @@ function parseCredits(model) {
     return;
   }
 
-  const credits = copyright.split(",").map(function (string) {
+  const credits = copyright.split(";").map(function (string) {
     return new Credit(string.trim());
   });
 

--- a/Specs/Data/Cesium3DTiles/GltfContentWithCopyright/glTF/lr.gltf
+++ b/Specs/Data/Cesium3DTiles/GltfContentWithCopyright/glTF/lr.gltf
@@ -49,7 +49,7 @@
     }
   ],
   "asset": {
-    "copyright": "Lower Right Copyright 1, Lower Right Copyright 2",
+    "copyright": "Lower Right Copyright 1; Lower Right Copyright 2",
     "generator": "3d-tiles-samples-generator",
     "version": "2.0"
   },

--- a/Specs/Data/Cesium3DTiles/GltfContentWithRepeatedCopyrights/glTF/ll.gltf
+++ b/Specs/Data/Cesium3DTiles/GltfContentWithRepeatedCopyrights/glTF/ll.gltf
@@ -49,7 +49,7 @@
     }
   ],
   "asset": {
-    "copyright": "Most Frequent Copyright, Second Repeated Copyright, Unique Copyright",
+    "copyright": "Most Frequent Copyright; Second Repeated Copyright; Unique Copyright",
     "generator": "3d-tiles-samples-generator",
     "version": "2.0"
   },

--- a/Specs/Data/Cesium3DTiles/GltfContentWithRepeatedCopyrights/glTF/parent.gltf
+++ b/Specs/Data/Cesium3DTiles/GltfContentWithRepeatedCopyrights/glTF/parent.gltf
@@ -49,7 +49,7 @@
     }
   ],
   "asset": {
-    "copyright": "Last Repeated Copyright, Most Frequent Copyright, Second Repeated Copyright",
+    "copyright": "Last Repeated Copyright; Most Frequent Copyright; Second Repeated Copyright",
     "generator": "3d-tiles-samples-generator",
     "version": "2.0"
   },

--- a/Specs/Data/Cesium3DTiles/GltfContentWithRepeatedCopyrights/glTF/ul.gltf
+++ b/Specs/Data/Cesium3DTiles/GltfContentWithRepeatedCopyrights/glTF/ul.gltf
@@ -49,7 +49,7 @@
     }
   ],
   "asset": {
-    "copyright": "Last Repeated Copyright, Most Frequent Copyright",
+    "copyright": "Last Repeated Copyright; Most Frequent Copyright",
     "generator": "3d-tiles-samples-generator",
     "version": "2.0"
   },

--- a/Specs/Data/Cesium3DTiles/GltfContentWithRepeatedCopyrights/glTF/ur.gltf
+++ b/Specs/Data/Cesium3DTiles/GltfContentWithRepeatedCopyrights/glTF/ur.gltf
@@ -49,7 +49,7 @@
     }
   ],
   "asset": {
-    "copyright": "Second Repeated Copyright, Most Frequent Copyright",
+    "copyright": "Second Repeated Copyright; Most Frequent Copyright",
     "generator": "3d-tiles-samples-generator",
     "version": "2.0"
   },

--- a/Specs/Data/Models/Box/CesiumBoxTest-WithCopyright.gltf
+++ b/Specs/Data/Models/Box/CesiumBoxTest-WithCopyright.gltf
@@ -63,7 +63,7 @@
     },
     "animations": {},
     "asset": {
-        "copyright": "First Source, Second Source, Third Source",
+        "copyright": "First Source; Second Source; Third Source",
         "generator": "collada2gltf@",
         "premultipliedAlpha": true,
         "profile": {

--- a/Specs/Data/Models/GltfLoader/BoxWithCopyright/glTF/Box.gltf
+++ b/Specs/Data/Models/GltfLoader/BoxWithCopyright/glTF/Box.gltf
@@ -2,7 +2,7 @@
     "asset": {
         "generator": "COLLADA2GLTF",
         "version": "2.0",
-        "copyright": "First Source, Second Source, Third Source"
+        "copyright": "First Source; Second Source; Third Source"
     },
     "scene": 0,
     "scenes": [


### PR DESCRIPTION
The character used to split credits in the glTF `copyright` field has been changed to semicolons in order to accommodate copyrights with commas in them.

cc @lilleyse for review