### PR TITLE
Allow version 1.1 tilesets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@
   - `3DTILES_metadata`:
     - Added support for explicit content metadata. [#10150](https://github.com/CesiumGS/cesium/pull/10150)
 - Updated extensions to match the latest 3D Tiles 1.1 schema. See the [latest schema PR](https://github.com/CesiumGS/3d-tiles/pull/634):
-  - Version 1.1 tilesets are now accepted. [#10155](https://github.com/CesiumGS/cesium/pull/10155)
+  - Version 1.1 tilesets are now supported. [#10155](https://github.com/CesiumGS/cesium/pull/10155)
   - Tileset metadata is now stored in `tilesetJson.metadata` rather than the `3DTILES_metadata` extension. [#10153](https://github.com/CesiumGS/cesium/pull/10153)
 
 ### 1.91 - 2022-03-01

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
   - `3DTILES_metadata`:
     - Added support for explicit content metadata. [#10150](https://github.com/CesiumGS/cesium/pull/10150)
 - Updated extensions to match the latest 3D Tiles 1.1 schema. See the [latest schema PR](https://github.com/CesiumGS/3d-tiles/pull/634):
+  - Version 1.1 tilesets are now accepted. [#10155](https://github.com/CesiumGS/cesium/pull/10155)
   - Tileset metadata is now stored in `tilesetJson.metadata` rather than the `3DTILES_metadata` extension. [#10153](https://github.com/CesiumGS/cesium/pull/10153)
 
 ### 1.91 - 2022-03-01

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1889,8 +1889,14 @@ Cesium3DTileset.prototype.loadTileset = function (
   if (!defined(asset)) {
     throw new RuntimeError("Tileset must have an asset property.");
   }
-  if (asset.version !== "0.0" && asset.version !== "1.0") {
-    throw new RuntimeError("The tileset must be 3D Tiles version 0.0 or 1.0.");
+  if (
+    asset.version !== "0.0" &&
+    asset.version !== "1.0" &&
+    asset.version !== "1.1"
+  ) {
+    throw new RuntimeError(
+      "The tileset must be 3D Tiles version 0.0, 1.0, or 1.1"
+    );
   }
 
   if (defined(tilesetJson.extensionsRequired)) {

--- a/Specs/Data/Cesium3DTiles/Metadata/AllMetadataTypes/1.1/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/AllMetadataTypes/1.1/tileset.json
@@ -1,6 +1,6 @@
 {
   "asset": {
-    "version": "1.0",
+    "version": "1.1",
     "tilesetVersion": "1.2.3"
   },
   "extensionsUsed": [

--- a/Specs/Data/Cesium3DTiles/Metadata/ExternalSchema/1.1/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/ExternalSchema/1.1/tileset.json
@@ -1,6 +1,6 @@
 {
   "asset": {
-    "version": "1.0",
+    "version": "1.1",
     "tilesetVersion": "1.2.3"
   },
   "extensionsUsed": [

--- a/Specs/Data/Cesium3DTiles/Metadata/TilesetMetadata/1.1/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/TilesetMetadata/1.1/tileset.json
@@ -1,6 +1,6 @@
 {
   "asset": {
-    "version": "1.0",
+    "version": "1.1",
     "tilesetVersion": "1.2.3"
   },
   "schema": {


### PR DESCRIPTION
This is a small PR to accept tilesets with `version: 1.1` in their `asset` object.

cc @ptrgags 