### PR TITLE
Handle arrays of vectors correctly for JSON metadata

### DIFF
--- a/Source/Scene/MetadataClassProperty.js
+++ b/Source/Scene/MetadataClassProperty.js
@@ -567,16 +567,10 @@ MetadataClassProperty.prototype.normalize = function (value) {
   }
 
   const valueType = this._valueType;
-  const valueTransform = function (x) {
+  const normalizeFunction = function (x) {
     return MetadataComponentType.normalize(x, valueType);
   };
-
-  if (Array.isArray(value)) {
-    transformValuesInPlace(value, valueTransform);
-    return value;
-  }
-
-  return valueTransform(value);
+  return transformInPlace(value, normalizeFunction);
 };
 
 /**
@@ -594,16 +588,10 @@ MetadataClassProperty.prototype.unnormalize = function (value) {
   }
 
   const valueType = this._valueType;
-  const valueTransform = function (x) {
+  const unnormalizeFunction = function (x) {
     return MetadataComponentType.unnormalize(x, valueType);
   };
-
-  if (Array.isArray(value)) {
-    transformValuesInPlace(value, valueTransform);
-    return value;
-  }
-
-  return valueTransform(value);
+  return transformInPlace(value, unnormalizeFunction);
 };
 
 /**
@@ -865,37 +853,16 @@ function getNonFiniteErrorMessage(value, type) {
   return `value ${value} of type ${type} must be finite`;
 }
 
-function normalize(classProperty, value, normalizeFunction) {
-  if (!classProperty._normalized) {
-    return value;
+function transformInPlace(value, transformationFunction) {
+  if (!Array.isArray(value)) {
+    return transformationFunction(value);
   }
 
-  const type = classProperty._type;
-  const valueType = classProperty._valueType;
-  const isArray = classProperty._isArray;
-  const componentCount = MetadataType.getComponentCount(type);
-
-  if (isArray || componentCount > 1) {
-    const length = value.length;
-    for (let i = 0; i < length; ++i) {
-      value[i] = normalizeFunction(value[i], valueType);
-    }
-  } else {
-    value = normalizeFunction(value, valueType);
+  for (let i = 0; i < value.length; i++) {
+    value[i] = transformInPlace(value[i], transformationFunction);
   }
 
   return value;
-}
-
-function transformValuesInPlace(valuesArray, valueTransformation) {
-  for (let i = 0; i < valuesArray.length; i++) {
-    const oldValue = valuesArray[i];
-    if (Array.isArray(oldValue)) {
-      transformValuesInPlace(oldValue, valueTransformation);
-    } else {
-      valuesArray[i] = valueTransformation(oldValue);
-    }
-  }
 }
 
 export default MetadataClassProperty;

--- a/Source/Scene/MetadataClassProperty.js
+++ b/Source/Scene/MetadataClassProperty.js
@@ -562,7 +562,21 @@ function parseType(property, enums) {
  * @private
  */
 MetadataClassProperty.prototype.normalize = function (value) {
-  return normalize(this, value, MetadataComponentType.normalize);
+  if (!this._normalized) {
+    return value;
+  }
+
+  const valueType = this._valueType;
+  const valueTransform = function (x) {
+    return MetadataComponentType.normalize(x, valueType);
+  };
+
+  if (Array.isArray(value)) {
+    transformValuesInPlace(value, valueTransform);
+    return value;
+  }
+
+  return valueTransform(value);
 };
 
 /**
@@ -575,7 +589,21 @@ MetadataClassProperty.prototype.normalize = function (value) {
  * @private
  */
 MetadataClassProperty.prototype.unnormalize = function (value) {
-  return normalize(this, value, MetadataComponentType.unnormalize);
+  if (!this._normalized) {
+    return value;
+  }
+
+  const valueType = this._valueType;
+  const valueTransform = function (x) {
+    return MetadataComponentType.unnormalize(x, valueType);
+  };
+
+  if (Array.isArray(value)) {
+    transformValuesInPlace(value, valueTransform);
+    return value;
+  }
+
+  return valueTransform(value);
 };
 
 /**
@@ -857,6 +885,17 @@ function normalize(classProperty, value, normalizeFunction) {
   }
 
   return value;
+}
+
+function transformValuesInPlace(valuesArray, valueTransformation) {
+  for (let i = 0; i < valuesArray.length; i++) {
+    const oldValue = valuesArray[i];
+    if (Array.isArray(oldValue)) {
+      transformValuesInPlace(oldValue, valueTransformation);
+    } else {
+      valuesArray[i] = valueTransformation(oldValue);
+    }
+  }
 }
 
 export default MetadataClassProperty;

--- a/Source/Scene/MetadataClassProperty.js
+++ b/Source/Scene/MetadataClassProperty.js
@@ -585,15 +585,28 @@ MetadataClassProperty.prototype.unnormalize = function (value) {
  * other sizes) are passed through unaltered.
  *
  * @param {*} value the original, normalized values.
+ * @param {Boolean} [enableNestedArrays=false] If true, arrays of vectors are represented as nested arrays. This is used for JSON encoding but not binary encoding
  * @returns {*} The appropriate vector or matrix type if the value is a vector or matrix type, respectively. If the property is an array of vectors or matrices, an array of the appropriate vector or matrix type is returned. Otherwise, the value is returned unaltered.
  * @private
  */
-MetadataClassProperty.prototype.unpackVectorAndMatrixTypes = function (value) {
+MetadataClassProperty.prototype.unpackVectorAndMatrixTypes = function (
+  value,
+  enableNestedArrays
+) {
+  enableNestedArrays = defaultValue(enableNestedArrays, false);
   const MathType = MetadataType.getMathType(this._type);
   const isArray = this._isArray;
+  const componentCount = MetadataType.getComponentCount(this._type);
+  const isNested = isArray && componentCount > 1;
 
   if (!defined(MathType)) {
     return value;
+  }
+
+  if (enableNestedArrays && isNested) {
+    return value.map(function (x) {
+      return MathType.unpack(x);
+    });
   }
 
   if (isArray) {
@@ -611,15 +624,28 @@ MetadataClassProperty.prototype.unpackVectorAndMatrixTypes = function (value) {
  * All other values (including arrays of other sizes) are passed through unaltered.
  *
  * @param {*} value The value of this property
+ * @param {Boolean} [enableNestedArrays=false] If true, arrays of vectors are represented as nested arrays. This is used for JSON encoding but not binary encoding
  * @returns {*} An array of the appropriate length if the property is a vector or matrix type. Otherwise, the value is returned unaltered.
  * @private
  */
-MetadataClassProperty.prototype.packVectorAndMatrixTypes = function (value) {
+MetadataClassProperty.prototype.packVectorAndMatrixTypes = function (
+  value,
+  enableNestedArrays
+) {
+  enableNestedArrays = defaultValue(enableNestedArrays, false);
   const MathType = MetadataType.getMathType(this._type);
   const isArray = this._isArray;
+  const componentCount = MetadataType.getComponentCount(this._type);
+  const isNested = isArray && componentCount > 1;
 
   if (!defined(MathType)) {
     return value;
+  }
+
+  if (enableNestedArrays && isNested) {
+    return value.map(function (x) {
+      return MathType.pack(x, []);
+    });
   }
 
   if (isArray) {

--- a/Source/Scene/MetadataEntity.js
+++ b/Source/Scene/MetadataEntity.js
@@ -332,8 +332,10 @@ MetadataEntity.setProperty = function (
     classProperty = classProperties[propertyId];
   }
 
+  // arrays of vectors are represented as nested arrays in JSON
+  const enableNestedArrays = true;
   if (defined(classProperty)) {
-    value = classProperty.packVectorAndMatrixTypes(value);
+    value = classProperty.packVectorAndMatrixTypes(value, enableNestedArrays);
     value = classProperty.unnormalize(value);
   }
 

--- a/Source/Scene/MetadataEntity.js
+++ b/Source/Scene/MetadataEntity.js
@@ -283,9 +283,11 @@ MetadataEntity.getProperty = function (
     value = value.slice(); // clone
   }
 
+  // Arrays of vectors are represented as nested arrays in JSON
+  const enableNestedArrays = true;
   if (defined(classProperty)) {
     value = classProperty.normalize(value);
-    value = classProperty.unpackVectorAndMatrixTypes(value);
+    value = classProperty.unpackVectorAndMatrixTypes(value, enableNestedArrays);
   }
 
   return value;

--- a/Specs/Scene/MetadataClassPropertySpec.js
+++ b/Specs/Scene/MetadataClassPropertySpec.js
@@ -629,6 +629,79 @@ describe("Scene/MetadataClassProperty", function () {
     }
   });
 
+  it("normalizes nested arrays of vectors", function () {
+    const properties = {
+      propertyVector: {
+        type: "VEC3",
+        componentType: "UINT8",
+        normalized: true,
+        array: true,
+        count: 2,
+      },
+      propertyMatrix: {
+        type: "MAT2",
+        componentType: "UINT8",
+        normalized: true,
+        array: true,
+      },
+    };
+
+    const propertyValues = {
+      propertyVector: [
+        [
+          [255, 0, 0],
+          [0, 255, 0],
+        ],
+        [
+          [0, 0, 255],
+          [255, 255, 0],
+        ],
+      ],
+      propertyMatrix: [
+        [
+          [255, 255, 255, 255],
+          [51, 0, 0, 51],
+        ],
+        [],
+      ],
+    };
+
+    const normalizedValues = {
+      propertyVector: [
+        [
+          [1.0, 0.0, 0.0],
+          [0.0, 1.0, 0.0],
+        ],
+        [
+          [0.0, 0.0, 1.0],
+          [1.0, 1.0, 0.0],
+        ],
+      ],
+      propertyMatrix: [
+        [
+          [1.0, 1.0, 1.0, 1.0],
+          [0.2, 0.0, 0.0, 0.2],
+        ],
+        [],
+      ],
+    };
+
+    for (const propertyId in properties) {
+      if (properties.hasOwnProperty(propertyId)) {
+        const property = new MetadataClassProperty({
+          id: propertyId,
+          property: properties[propertyId],
+        });
+        const length = normalizedValues[propertyId].length;
+        for (let i = 0; i < length; ++i) {
+          const value = propertyValues[propertyId][i];
+          const normalizedValue = property.normalize(value);
+          expect(normalizedValue).toEqual(normalizedValues[propertyId][i]);
+        }
+      }
+    }
+  });
+
   it("does not normalize non integer types", function () {
     const myEnum = new MetadataEnum({
       id: "myEnum",

--- a/Specs/Scene/MetadataClassPropertySpec.js
+++ b/Specs/Scene/MetadataClassPropertySpec.js
@@ -931,6 +931,128 @@ describe("Scene/MetadataClassProperty", function () {
     }
   });
 
+  it("packVectorAndMatrixTypes packs nested arrays of vectors", function () {
+    const properties = {
+      propertyVec2: {
+        type: "VEC2",
+        componentType: "FLOAT32",
+        array: true,
+      },
+      propertyIVec3: {
+        type: "VEC3",
+        componentType: "INT32",
+        array: true,
+        count: 3,
+      },
+      propertyDVec4: {
+        type: "VEC4",
+        componentType: "FLOAT64",
+        array: true,
+      },
+      propertyMat4: {
+        type: "MAT4",
+        componentType: "FLOAT32",
+        array: true,
+      },
+      propertyIMat3: {
+        type: "MAT3",
+        componentType: "FLOAT32",
+        array: true,
+        count: 3,
+      },
+      propertyDMat2: {
+        type: "MAT2",
+        componentType: "FLOAT32",
+        array: true,
+        count: 3,
+      },
+    };
+
+    const propertyValues = {
+      propertyVec2: [
+        new Cartesian2(0.1, 0.8),
+        new Cartesian2(0.3, 0.5),
+        new Cartesian2(0.7, 0.2),
+      ],
+      propertyIVec3: [
+        new Cartesian3(1, 2, 3),
+        new Cartesian3(4, 5, 6),
+        new Cartesian3(7, 8, 9),
+      ],
+      propertyDVec4: [
+        new Cartesian4(0.1, 0.2, 0.3, 0.4),
+        new Cartesian4(0.3, 0.2, 0.1, 0.0),
+        new Cartesian4(0.1, 0.2, 0.4, 0.5),
+      ],
+      propertyMat4: [
+        new Matrix4(1.5, 0, 0, 0, 0, 1.5, 0, 0, 0, 0, 1.5, 0, 0, 0, 0, 1),
+        new Matrix4(0, 2.5, 0, 0, 0, 0.5, 0.25, 0, 0, 0, 3.5, 0, 0, 0, 0, 1),
+        new Matrix4(1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0),
+      ],
+      propertyIMat3: [
+        new Matrix3(2, 0, 0, 0, 2, 0, 0, 0, 2),
+        new Matrix3(1, 0, 0, 0, 1, 0, 0, 0, 1),
+        new Matrix3(1, 2, 3, 2, 3, 1, 3, 1, 2),
+      ],
+      propertyDMat2: [
+        new Matrix2(1.5, 0.0, 0.0, 2.5),
+        new Matrix2(1.0, 0.0, 0.0, 1.0),
+        new Matrix2(1.5, 2.5, 3.5, 4.5),
+      ],
+    };
+
+    // prettier-ignore
+    const packedValues = {
+      propertyVec2: [
+        [0.1, 0.8],
+        [0.3, 0.5],
+        [0.7, 0.2],
+      ],
+      propertyIVec3: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ],
+      propertyDVec4: [
+        [0.1, 0.2, 0.3, 0.4],
+        [0.3, 0.2, 0.1, 0.0],
+        [0.1, 0.2, 0.4, 0.5],
+      ],
+      propertyMat4: [
+        // the MatrixN constructor is row-major, but internally things are
+        // stored column-major. So these are the transpose of the above
+        [1.5, 0, 0, 0, 0, 1.5, 0, 0, 0, 0, 1.5, 0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 2.5, 0.5, 0, 0, 0, 0.25, 3.5, 0, 0, 0, 0, 1],
+        [1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 0, 0, 0, 0],
+      ],
+      propertyIMat3: [
+        [2, 0, 0, 0, 2, 0, 0, 0, 2],
+        [1, 0, 0, 0, 1, 0, 0, 0, 1],
+        [1, 2, 3, 2, 3, 1, 3, 1, 2],
+      ],
+      propertyDMat2: [
+        [1.5, 0.0, 0.0, 2.5],
+        [1.0, 0.0, 0.0, 1.0],
+        [1.5, 3.5, 2.5, 4.5],
+      ],
+    };
+
+    for (const propertyId in properties) {
+      if (properties.hasOwnProperty(propertyId)) {
+        const property = new MetadataClassProperty({
+          id: propertyId,
+          property: properties[propertyId],
+        });
+
+        const value = propertyValues[propertyId];
+        const nested = true;
+        const packed = property.packVectorAndMatrixTypes(value, nested);
+        const expected = packedValues[propertyId];
+        expect(packed).toEqual(expected);
+      }
+    }
+  });
+
   it("packVectorAndMatrixTypes does not affect other types", function () {
     if (!FeatureDetection.supportsBigInt()) {
       return;
@@ -1215,6 +1337,128 @@ describe("Scene/MetadataClassProperty", function () {
 
         const packed = packedValues[propertyId];
         const unpacked = property.unpackVectorAndMatrixTypes(packed);
+        const expected = propertyValues[propertyId];
+        expect(unpacked).toEqual(expected);
+      }
+    }
+  });
+
+  it("unpackVectorAndMatrixTypes unpacks nested arrays of vectors", function () {
+    const properties = {
+      propertyVec2: {
+        type: "VEC2",
+        componentType: "FLOAT32",
+        array: true,
+      },
+      propertyIVec3: {
+        type: "VEC3",
+        componentType: "INT32",
+        array: true,
+        count: 3,
+      },
+      propertyDVec4: {
+        type: "VEC4",
+        componentType: "FLOAT64",
+        array: true,
+      },
+      propertyMat4: {
+        type: "MAT4",
+        componentType: "FLOAT32",
+        array: true,
+      },
+      propertyIMat3: {
+        type: "MAT3",
+        componentType: "FLOAT32",
+        array: true,
+        count: 3,
+      },
+      propertyDMat2: {
+        type: "MAT2",
+        componentType: "FLOAT32",
+        array: true,
+        count: 3,
+      },
+    };
+
+    const propertyValues = {
+      propertyVec2: [
+        new Cartesian2(0.1, 0.8),
+        new Cartesian2(0.3, 0.5),
+        new Cartesian2(0.7, 0.2),
+      ],
+      propertyIVec3: [
+        new Cartesian3(1, 2, 3),
+        new Cartesian3(4, 5, 6),
+        new Cartesian3(7, 8, 9),
+      ],
+      propertyDVec4: [
+        new Cartesian4(0.1, 0.2, 0.3, 0.4),
+        new Cartesian4(0.3, 0.2, 0.1, 0.0),
+        new Cartesian4(0.1, 0.2, 0.4, 0.5),
+      ],
+      propertyMat4: [
+        new Matrix4(1.5, 0, 0, 0, 0, 1.5, 0, 0, 0, 0, 1.5, 0, 0, 0, 0, 1),
+        new Matrix4(0, 2.5, 0, 0, 0, 0.5, 0.25, 0, 0, 0, 3.5, 0, 0, 0, 0, 1),
+        new Matrix4(1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0),
+      ],
+      propertyIMat3: [
+        new Matrix3(2, 0, 0, 0, 2, 0, 0, 0, 2),
+        new Matrix3(1, 0, 0, 0, 1, 0, 0, 0, 1),
+        new Matrix3(1, 2, 3, 2, 3, 1, 3, 1, 2),
+      ],
+      propertyDMat2: [
+        new Matrix2(1.5, 0.0, 0.0, 2.5),
+        new Matrix2(1.0, 0.0, 0.0, 1.0),
+        new Matrix2(1.5, 2.5, 3.5, 4.5),
+      ],
+    };
+
+    // prettier-ignore
+    const packedValues = {
+      propertyVec2: [
+        [0.1, 0.8],
+        [0.3, 0.5],
+        [0.7, 0.2],
+      ],
+      propertyIVec3: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ],
+      propertyDVec4: [
+        [0.1, 0.2, 0.3, 0.4],
+        [0.3, 0.2, 0.1, 0.0],
+        [0.1, 0.2, 0.4, 0.5],
+      ],
+      propertyMat4: [
+        // the MatrixN constructor is row-major, but internally things are
+        // stored column-major. So these are the transpose of the above
+        [1.5, 0, 0, 0, 0, 1.5, 0, 0, 0, 0, 1.5, 0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 2.5, 0.5, 0, 0, 0, 0.25, 3.5, 0, 0, 0, 0, 1],
+        [1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 0, 0, 0, 0],
+      ],
+      propertyIMat3: [
+        [2, 0, 0, 0, 2, 0, 0, 0, 2],
+        [1, 0, 0, 0, 1, 0, 0, 0, 1],
+        [1, 2, 3, 2, 3, 1, 3, 1, 2],
+      ],
+      propertyDMat2: [
+        [1.5, 0.0, 0.0, 2.5],
+        [1.0, 0.0, 0.0, 1.0],
+        [1.5, 3.5, 2.5, 4.5],
+      ],
+    };
+
+    for (const propertyId in properties) {
+      if (properties.hasOwnProperty(propertyId)) {
+        const property = new MetadataClassProperty({
+          id: propertyId,
+          property: properties[propertyId],
+        });
+
+        const packed = packedValues[propertyId];
+        const nested = true;
+        const unpacked = property.unpackVectorAndMatrixTypes(packed, nested);
         const expected = propertyValues[propertyId];
         expect(unpacked).toEqual(expected);
       }


### PR DESCRIPTION
Back in #10116 I had added support for arrays of vectors, but I had incorrectly implemented it for JSON properties. Arrays of vectors are represented as nested JSON arrays:

```
properties:
  arrayOfVectors: [
    [1, 2, 3],
    [4, 5, 6]
  ]
```

Unlike property tables where everything is stored as one big flat array:

```
properties:
  arrayOfVectors: [1, 2, 3, 4, 5, 6]
```

This required some modifications to `MetadataClassProperty` and `MetadataEntity`. 

One nice side-effect is I made a more general "transformInPlace()" function that will be reusable when I get to transforming values with offset/scale.

@lilleyse could your review?