### PR TITLE
Add default value for `ContextLimits.maximumSamples` 

### DIFF
--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -256,7 +256,9 @@ function Context(canvas, options) {
     gl.MAX_VERTEX_UNIFORM_VECTORS
   ); // min: 128
 
-  ContextLimits._maximumSamples = gl.getParameter(gl.MAX_SAMPLES);
+  ContextLimits._maximumSamples = this._webgl2
+    ? gl.getParameter(gl.MAX_SAMPLES)
+    : 0;
 
   const aliasedLineWidthRange = gl.getParameter(gl.ALIASED_LINE_WIDTH_RANGE); // must include 1
   ContextLimits._minimumAliasedLineWidth = aliasedLineWidthRange[0];


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/10167

When adding the `maximumSamples` property I missed that it was [only available in WebGL2](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/getParameter#webgl_2). Without a WebGL2 context, the browser prints a warning: `WebGL: INVALID_ENUM: getParameter: invalid parameter name`. This fix defaults `ContextLimits._maximumSamples` to 0 when a WebGL2 context is not requested or unavailable.

To reproduce, see the console in `main` and this branch when loading [http://localhost:8080/Apps/Sandcastle/index.html](http://localhost:8080/Apps/Sandcastle/index.html).