### PR TITLE
Add missing `hasPropertyBySemantic()`

### DIFF
--- a/Source/Scene/ModelExperimental/ModelFeature.js
+++ b/Source/Scene/ModelExperimental/ModelFeature.js
@@ -147,6 +147,16 @@ ModelFeature.prototype.hasProperty = function (name) {
 };
 
 /**
+ * Returns whether the feature has a property with the given semantic.
+ *
+ * @param {String} semantic The case-sensitive semantic of the property.
+ * @returns {Boolean} Whether the feature has a property with the given semantic.
+ */
+ModelFeature.prototype.hasPropertyBySemantic = function (name) {
+  return this._featureTable.hasProperty(this._featureId, name);
+};
+
+/**
  * Returns a copy of the value of the feature's property with the given name.
  *
  * @param {String} name The case-sensitive name of the property.
@@ -185,9 +195,8 @@ ModelFeature.prototype.getProperty = function (name) {
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 ModelFeature.prototype.getPropertyInherited = function (name) {
-  const value = this._featureTable.getPropertyBySemantic(this._featureId, name);
-  if (defined(value)) {
-    return value;
+  if (this._featureTable.hasPropertyBySemantic(this._featureId, name)) {
+    return this._featureTable.getPropertyBySemantic(this._featureId, name);
   }
 
   return this._featureTable.getProperty(this._featureId, name);

--- a/Source/Scene/ModelExperimental/ModelFeature.js
+++ b/Source/Scene/ModelExperimental/ModelFeature.js
@@ -147,16 +147,6 @@ ModelFeature.prototype.hasProperty = function (name) {
 };
 
 /**
- * Returns whether the feature has a property with the given semantic.
- *
- * @param {String} semantic The case-sensitive semantic of the property.
- * @returns {Boolean} Whether the feature has a property with the given semantic.
- */
-ModelFeature.prototype.hasPropertyBySemantic = function (name) {
-  return this._featureTable.hasProperty(this._featureId, name);
-};
-
-/**
  * Returns a copy of the value of the feature's property with the given name.
  *
  * @param {String} name The case-sensitive name of the property.

--- a/Source/Scene/ModelExperimental/ModelFeatureTable.js
+++ b/Source/Scene/ModelExperimental/ModelFeatureTable.js
@@ -193,6 +193,13 @@ ModelFeatureTable.prototype.hasProperty = function (featureId, propertyName) {
   return this._propertyTable.hasProperty(featureId, propertyName);
 };
 
+ModelFeatureTable.prototype.hasPropertyBySemantic = function (
+  featureId,
+  propertyName
+) {
+  return this._propertyTable.hasPropertyBySemantic(featureId, propertyName);
+};
+
 ModelFeatureTable.prototype.getProperty = function (featureId, name) {
   return this._propertyTable.getProperty(featureId, name);
 };

--- a/Specs/Scene/ModelExperimental/ModelFeatureTableSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelFeatureTableSpec.js
@@ -95,9 +95,8 @@ describe("Scene/ModelExperimental/ModelFeatureTable", function () {
     });
     const modelFeatures = table._features;
     for (let i = 0; i < modelFeatures.length; i++) {
-      const feature = modelFeatures[i];
-      expect(feature.hasPropertyBySemantic("HEIGHT_SEMANTIC")).toEqual(true);
-      expect(feature.hasPropertyBySemantic("WIDTH_SEMANTIC")).toEqual(false);
+      expect(table.hasPropertyBySemantic(i, "HEIGHT_SEMANTIC")).toEqual(true);
+      expect(table.hasPropertyBySemantic(i, "WIDTH_SEMANTIC")).toEqual(false);
     }
   });
 

--- a/Specs/Scene/ModelExperimental/ModelFeatureTableSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelFeatureTableSpec.js
@@ -86,6 +86,21 @@ describe("Scene/ModelExperimental/ModelFeatureTable", function () {
     }
   });
 
+  it("hasPropertyBySemantic works", function () {
+    const table = new ModelFeatureTable({
+      model: {
+        type: ModelExperimentalType.GLTF,
+      },
+      propertyTable: mockPropertyTable,
+    });
+    const modelFeatures = table._features;
+    for (let i = 0; i < modelFeatures.length; i++) {
+      const feature = modelFeatures[i];
+      expect(feature.hasPropertyBySemantic("HEIGHT_SEMANTIC")).toEqual(true);
+      expect(feature.hasPropertyBySemantic("WIDTH_SEMANTIC")).toEqual(false);
+    }
+  });
+
   it("getFeature works", function () {
     const table = new ModelFeatureTable({
       model: {


### PR DESCRIPTION
(ack I just realized the branch name is horribly incorrect, sorry about that :sweat_smile:)

I noticed that I missed some spots in https://github.com/CesiumGS/cesium/pull/10172. 

In particular, if you load [this Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html?src=3D%20Tiles%20Next%20S2%20Globe.html&label=3D%20Tiles%20Next) and choose the dropdown option "Apply Style", in `extension-revisions` this breaks because `ModelFeatureTable` was missing `hasPropertyBySemantic()`. I added this, so the sandcastle should work again.