### PR TITLE
Fold `3DTILES_bounding_volume_s2` extension into `boundingVolume`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@
     [#10159](https://github.com/CesiumGS/cesium/pull/10159)
   - Implicit tiling is now specified in `tile.implicitTiling` rather than the `3DTILES_implicit_tiling` extension. [#10169](https://github.com/CesiumGS/cesium/pull/10169)
   - Multiple contents are now provided in `tile.contents` rather than the `3DTILES_multiple_contents` extension. [#10174](https://github.com/CesiumGS/cesium/pull/10174)
+  - S2 cell bounding volumes are now specified in `boundingVolume.s2Cell` rather than the `3DTILES_bounding_volume_s2` extension. [#10176](https://github.com/CesiumGS/cesium/pull/10176)
 
 ### 1.91 - 2022-03-01
 

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -1672,6 +1672,11 @@ Cesium3DTile.prototype.createBoundingVolume = function (
   if (!defined(boundingVolumeHeader)) {
     throw new RuntimeError("boundingVolume must be defined");
   }
+
+  if (defined(boundingVolumeHeader.s2Cell)) {
+    return new TileBoundingS2Cell(boundingVolumeHeader.s2Cell);
+  }
+
   if (hasExtension(boundingVolumeHeader, "3DTILES_bounding_volume_S2")) {
     return new TileBoundingS2Cell(
       boundingVolumeHeader.extensions["3DTILES_bounding_volume_S2"]
@@ -1693,7 +1698,7 @@ Cesium3DTile.prototype.createBoundingVolume = function (
     return createSphere(boundingVolumeHeader.sphere, transform, result);
   }
   throw new RuntimeError(
-    "boundingVolume must contain a sphere, region, or box"
+    "boundingVolume must contain a sphere, region, box, or S2 cell"
   );
 };
 

--- a/Source/Scene/ImplicitTileset.js
+++ b/Source/Scene/ImplicitTileset.js
@@ -69,7 +69,7 @@ export default function ImplicitTileset(
     // Merge the extension with the boundingVolume for consistency with 3D Tiles 1.1
     boundingVolume.s2Cell =
       boundingVolume.extensions["3DTILES_bounding_volume_S2"];
-    delete boundingVolume.extensions;
+    delete boundingVolume.extensions["3DTILES_bounding_volume_S2"];
   }
 
   if (

--- a/Source/Scene/ImplicitTileset.js
+++ b/Source/Scene/ImplicitTileset.js
@@ -64,13 +64,21 @@ export default function ImplicitTileset(
    */
   this.metadataSchema = metadataSchema;
 
+  const boundingVolume = tileJson.boundingVolume;
+  if (hasExtension(boundingVolume, "3DTILES_bounding_volume_S2")) {
+    // Merge the extension with the boundingVolume for consistency with 3D Tiles 1.1
+    boundingVolume.s2Cell =
+      boundingVolume.extensions["3DTILES_bounding_volume_S2"];
+    delete boundingVolume.extensions;
+  }
+
   if (
-    !defined(tileJson.boundingVolume.box) &&
-    !defined(tileJson.boundingVolume.region) &&
-    !hasExtension(tileJson.boundingVolume, "3DTILES_bounding_volume_S2")
+    !defined(boundingVolume.box) &&
+    !defined(boundingVolume.region) &&
+    !defined(boundingVolume.s2Cell)
   ) {
     throw new RuntimeError(
-      "Only box, region and 3DTILES_bounding_volume_S2 are supported for implicit tiling"
+      "Only box, region and S2 cells are supported for implicit tiling"
     );
   }
 
@@ -82,7 +90,7 @@ export default function ImplicitTileset(
    * @readonly
    * @private
    */
-  this.boundingVolume = tileJson.boundingVolume;
+  this.boundingVolume = boundingVolume;
 
   /**
    * The refine strategy as a string, either 'ADD' or 'REPLACE'

--- a/Specs/Data/Cesium3DTiles/Metadata/ImplicitHeightSemantics/s2-tileset_1.1.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/ImplicitHeightSemantics/s2-tileset_1.1.json
@@ -24,12 +24,10 @@
   "root": {
     "geometricError": 2048.0,
     "boundingVolume": {
-      "extensions": {
-        "3DTILES_bounding_volume_S2": {
-          "token": "1",
-          "minimumHeight": 0,
-          "maximumHeight": 10000
-        }
+      "s2Cell": {
+        "token": "1",
+        "minimumHeight": 0,
+        "maximumHeight": 10000
       }
     },
     "implicitTiling": {

--- a/Specs/Scene/Implicit3DTileContentSpec.js
+++ b/Specs/Scene/Implicit3DTileContentSpec.js
@@ -647,9 +647,7 @@ describe(
       );
       const implicitTilesetS2 = {
         boundingVolume: {
-          extensions: {
-            "3DTILES_bounding_volume_S2": simpleBoundingVolumeS2,
-          },
+          s2Cell: simpleBoundingVolumeS2,
         },
         subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
       };
@@ -724,9 +722,7 @@ describe(
         };
         let result = deriveBoundingVolumeS2(false, parentTile, 0, 1, 0, 0);
         expect(result).toEqual({
-          extensions: {
-            "3DTILES_bounding_volume_S2": expected,
-          },
+          s2Cell: expected,
         });
 
         parentTile._boundingVolume = new TileBoundingS2Cell({
@@ -741,9 +737,7 @@ describe(
         };
         result = deriveBoundingVolumeS2(false, parentTile, 0, 1, 0, 0);
         expect(result).toEqual({
-          extensions: {
-            "3DTILES_bounding_volume_S2": expected,
-          },
+          s2Cell: expected,
         });
       });
 
@@ -772,9 +766,7 @@ describe(
           0
         );
         expect(result0).toEqual({
-          extensions: {
-            "3DTILES_bounding_volume_S2": expected0,
-          },
+          s2Cell: expected0,
         });
         const result1 = deriveBoundingVolumeS2(
           false,
@@ -786,9 +778,7 @@ describe(
           0
         );
         expect(result1).toEqual({
-          extensions: {
-            "3DTILES_bounding_volume_S2": expected1,
-          },
+          s2Cell: expected1,
         });
       });
     });
@@ -1365,9 +1355,7 @@ describe(
           const subtreeRootTile = placeholderTile.children[0];
 
           const implicitS2Volume =
-            placeholderTile.implicitTileset.boundingVolume.extensions[
-              "3DTILES_bounding_volume_S2"
-            ];
+            placeholderTile.implicitTileset.boundingVolume.s2Cell;
           const minimumHeight = implicitS2Volume.minimumHeight;
           const maximumHeight = implicitS2Volume.maximumHeight;
 
@@ -1853,9 +1841,7 @@ describe(
           const subtreeRootTile = placeholderTile.children[0];
 
           const implicitS2Volume =
-            placeholderTile.implicitTileset.boundingVolume.extensions[
-              "3DTILES_bounding_volume_S2"
-            ];
+            placeholderTile.implicitTileset.boundingVolume.s2Cell;
           const minimumHeight = implicitS2Volume.minimumHeight;
           const maximumHeight = implicitS2Volume.maximumHeight;
 

--- a/Specs/Scene/ImplicitTilesetSpec.js
+++ b/Specs/Scene/ImplicitTilesetSpec.js
@@ -146,19 +146,16 @@ describe("Scene/ImplicitTileset", function () {
     expect(implicitTileset.contentUriTemplates).toEqual([]);
   });
 
-  it("accepts tilesets with 3DTILES_bounding_volume_S2", function () {
+  it("accepts tilesets with s2 bounding volumes", function () {
     const tileJson = clone(implicitTileJson, true);
     tileJson.boundingVolume = {
-      extensions: {
-        "3DTILES_bounding_volume_S2": {
-          token: "1",
-          minimumHeight: 0,
-          maximumHeight: 100,
-        },
+      s2Cell: {
+        token: "1",
+        minimumHeight: 0,
+        maximumHeight: 100,
       },
     };
-    const tileJsonS2 =
-      tileJson.boundingVolume.extensions["3DTILES_bounding_volume_S2"];
+    const tileJsonS2 = tileJson.boundingVolume.s2Cell;
 
     let metadataSchema;
     const implicitTileset = new ImplicitTileset(
@@ -166,8 +163,7 @@ describe("Scene/ImplicitTileset", function () {
       tileJson,
       metadataSchema
     );
-    const implicitTilesetS2 =
-      implicitTileset.boundingVolume.extensions["3DTILES_bounding_volume_S2"];
+    const implicitTilesetS2 = implicitTileset.boundingVolume.s2Cell;
     expect(implicitTilesetS2.token).toEqual(tileJsonS2.token);
     expect(implicitTilesetS2.minimumHeight).toEqual(tileJsonS2.minimumHeight);
     expect(implicitTilesetS2.maximumHeight).toEqual(tileJsonS2.maximumHeight);
@@ -294,8 +290,7 @@ describe("Scene/ImplicitTileset", function () {
         tileJson,
         metadataSchema
       );
-      const implicitTilesetS2 =
-        implicitTileset.boundingVolume.extensions["3DTILES_bounding_volume_S2"];
+      const implicitTilesetS2 = implicitTileset.boundingVolume.s2Cell;
       expect(implicitTilesetS2.token).toEqual(tileJsonS2.token);
       expect(implicitTilesetS2.minimumHeight).toEqual(tileJsonS2.minimumHeight);
       expect(implicitTilesetS2.maximumHeight).toEqual(tileJsonS2.maximumHeight);


### PR DESCRIPTION
This PR incorporates the `3DTILES_bounding_volume_s2` extension into `boundingVolume` as `boundingVolume.s2Cell`, in accordance with the 3D Tiles 1.1 schema.

cc @ptrgags for review