### PR TITLE
Change `groups` metadata from dictionary to array

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
     - Added support for properties with `required`, `noData` and `default`. [#10172](https://github.com/CesiumGS/cesium/pull/10172)
   - `3DTILES_metadata`:
     - Added support for explicit content metadata. [#10150](https://github.com/CesiumGS/cesium/pull/10150)
+    - `tileset.groups` now stores group objects in an array instead of a dictionary. [#10179](https://github.com/CesiumGS/cesium/pull/10179)
   - `3DTILES_multiple_contents`:
     - Renamed `extension.content` as `extension.contents`. [#10174](https://github.com/CesiumGS/cesium/pull/10174)
 - Updated extensions to match the latest 3D Tiles 1.1 schema. See the [latest schema PR](https://github.com/CesiumGS/3d-tiles/pull/634):

--- a/Source/Scene/Cesium3DTilesetMetadata.js
+++ b/Source/Scene/Cesium3DTilesetMetadata.js
@@ -64,7 +64,7 @@ function Cesium3DTilesetMetadata(options) {
       );
     }
   } else if (defined(groupsJson)) {
-    // An older version of groups metadata stored groups in a dictionary
+    // An older version of group metadata stored groups in a dictionary
     // instead of an array.
     groupIds = Object.keys(groupsJson).sort();
     const length = groupIds.length;

--- a/Source/Scene/Cesium3DTilesetMetadata.js
+++ b/Source/Scene/Cesium3DTilesetMetadata.js
@@ -47,23 +47,45 @@ function Cesium3DTilesetMetadata(options) {
     });
   }
 
+  let groupIds = [];
+  const groups = [];
   const groupsJson = metadataJson.groups;
-  const groups = {};
-  if (defined(groupsJson)) {
-    for (const groupId in groupsJson) {
+  if (Array.isArray(groupsJson)) {
+    const length = groupsJson.length;
+    for (let i = 0; i < length; i++) {
+      const group = groupsJson[i];
+      groupIds.push(group.id);
+      groups.push(
+        new GroupMetadata({
+          id: group.id,
+          group: group,
+          class: schema.classes[group.class],
+        })
+      );
+    }
+  } else if (defined(groupsJson)) {
+    // An older version of groups metadata stored groups in a dictionary
+    // instead of an array.
+    groupIds = Object.keys(groupsJson).sort();
+    const length = groupIds.length;
+    for (let i = 0; i < length; i++) {
+      const groupId = groupIds[i];
       if (groupsJson.hasOwnProperty(groupId)) {
         const group = groupsJson[groupId];
-        groups[groupId] = new GroupMetadata({
-          id: groupId,
-          group: groupsJson[groupId],
-          class: schema.classes[group.class],
-        });
+        groups.push(
+          new GroupMetadata({
+            id: groupId,
+            group: groupsJson[groupId],
+            class: schema.classes[group.class],
+          })
+        );
       }
     }
   }
 
   this._schema = schema;
   this._groups = groups;
+  this._groupIds = groupIds;
   this._tileset = tileset;
 
   this._statistics = metadataJson.statistics;
@@ -90,13 +112,27 @@ Object.defineProperties(Cesium3DTilesetMetadata.prototype, {
    * Metadata about groups of content.
    *
    * @memberof Cesium3DTilesetMetadata.prototype
-   * @type {Object.<String, GroupMetadata>}
+   * @type {GroupMetadata[]}
    * @readonly
    * @private
    */
   groups: {
     get: function () {
       return this._groups;
+    },
+  },
+
+  /**
+   * The IDs of the group metadata in the corresponding groups array.
+   *
+   * @memberof Cesium3DTilesetMetadata.prototype
+   * @type {String[]}
+   * @readonly
+   * @private
+   */
+  groupIds: {
+    get: function () {
+      return this._groupIds;
     },
   },
 

--- a/Source/Scene/findGroupMetadata.js
+++ b/Source/Scene/findGroupMetadata.js
@@ -18,10 +18,19 @@ export default function findGroupMetadata(tileset, contentHeader) {
   if (!defined(tileset.metadata)) {
     return undefined;
   }
+  const groups = tileset.metadata.groups;
 
   const group = hasExtension(contentHeader, "3DTILES_metadata")
     ? contentHeader.extensions["3DTILES_metadata"].group
     : contentHeader.group;
 
-  return tileset.metadata.groups[group];
+  if (typeof group === "number") {
+    return groups[group];
+  }
+
+  const index = tileset.metadata.groupIds.findIndex(function (id) {
+    return id === group;
+  });
+
+  return index >= 0 ? groups[index] : undefined;
 }

--- a/Specs/Data/Cesium3DTiles/Metadata/AllMetadataTypes/tileset_1.1.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/AllMetadataTypes/tileset_1.1.json
@@ -135,8 +135,9 @@
       "tileCount": 5
     }
   },
-  "groups": {
-    "residentialDistrict": {
+  "groups": [
+    {
+      "id": "residentialDistrict",
       "class": "residential",
       "properties": {
         "name": "residential",
@@ -145,7 +146,8 @@
         "tileCount": 2
       }
     },
-    "commercialDistrict": {
+    {
+      "id": "commercialDistrict",
       "class": "commercial",
       "properties": {
         "name": "commercial",
@@ -153,7 +155,7 @@
         "majorIndustries": ["Finance", "Manufacturing"]
       }
     }
-  },
+  ],
   "geometricError": 240,
   "root": {
     "boundingVolume": {
@@ -205,7 +207,7 @@
         "geometricError": 0,
         "content": {
           "uri": "ll.b3dm",
-          "group": "residentialDistrict",
+          "group": 0,
           "metadata": {
             "class": "content",
             "properties": {
@@ -239,7 +241,7 @@
         "geometricError": 0,
         "content": {
           "uri": "lr.b3dm",
-          "group": "commercialDistrict",
+          "group": 1,
           "metadata": {
             "class": "content",
             "properties": {
@@ -273,7 +275,7 @@
         "geometricError": 0,
         "content": {
           "uri": "ur.b3dm",
-          "group": "commercialDistrict",
+          "group": 1,
           "metadata": {
             "class": "content",
             "properties": {
@@ -307,7 +309,7 @@
         "geometricError": 0,
         "content": {
           "uri": "ul.b3dm",
-          "group": "residentialDistrict",
+          "group": 0,
           "metadata": {
             "class": "content",
             "properties": {

--- a/Specs/Data/Cesium3DTiles/Metadata/GroupMetadata/tileset_1.1.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/GroupMetadata/tileset_1.1.json
@@ -31,21 +31,23 @@
       }
     }
   },
-  "groups": {
-    "residentialDistrict": {
+  "groups": [
+    {
+      "id": "residentialDistrict",
       "class": "residential",
       "properties": {
         "population": 300000,
         "neighborhoods": ["Hillside", "Middletown", "Western Heights"]
       }
     },
-    "commercialDistrict": {
+    {
+      "id": "commercialDistrict",
       "class": "commercial",
       "properties": {
         "businessCount": 143
       }
     }
-  },
+  ],
   "geometricError": 240,
   "root": {
     "boundingVolume": {
@@ -88,7 +90,7 @@
         "geometricError": 0,
         "content": {
           "uri": "ll.b3dm",
-          "group": "residentialDistrict"
+          "group": 0
         }
       },
       {
@@ -105,7 +107,7 @@
         "geometricError": 0,
         "content": {
           "uri": "ul.b3dm",
-          "group": "residentialDistrict"
+          "group": 0
         }
       },
       {
@@ -122,7 +124,7 @@
         "geometricError": 0,
         "content": {
           "uri": "lr.b3dm",
-          "group": "commercialDistrict"
+          "group": 1
         }
       },
       {
@@ -139,7 +141,7 @@
         "geometricError": 0,
         "content": {
           "uri": "ur.b3dm",
-          "group": "commercialDistrict"
+          "group": 1
         }
       }
     ]

--- a/Specs/Data/Cesium3DTiles/Metadata/ImplicitGroupMetadata/tileset_1.1.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/ImplicitGroupMetadata/tileset_1.1.json
@@ -18,22 +18,24 @@
       }
     }
   },
-  "groups": {
-    "ground": {
+  "groups": [
+    {
+      "id": "ground",
       "class": "layer",
       "properties": {
         "color": [120, 68, 32],
         "priority": 0
       }
     },
-    "sky": {
+    {
+      "id": "sky",
       "class": "layer",
       "properties": {
         "color": [206, 237, 242],
         "priority": 1
       }
     }
-  },
+  ],
   "root": {
     "boundingVolume": {
       "region": [
@@ -56,11 +58,11 @@
     "contents": [
       {
         "uri": "ground/{level}/{x}/{y}.b3dm",
-        "group": "ground"
+        "group": 0
       },
       {
         "uri": "sky/{level}/{x}/{y}.b3dm",
-        "group": "sky"
+        "group": 1
       }
     ],
     "geometricError": 70,

--- a/Specs/Data/Cesium3DTiles/MultipleContents/GroupMetadata/tileset_1.1.json
+++ b/Specs/Data/Cesium3DTiles/MultipleContents/GroupMetadata/tileset_1.1.json
@@ -39,8 +39,9 @@
       }
     }
   },
-  "groups": {
-    "buildings": {
+  "groups": [
+    {
+      "id": "buildings",
       "class": "layer",
       "properties": {
         "color": [255, 127, 0],
@@ -48,7 +49,8 @@
         "isInstanced": false
       }
     },
-    "cubes": {
+    {
+      "id": "cubes",
       "class": "layer",
       "properties": {
         "color": [0, 255, 127],
@@ -56,7 +58,7 @@
         "isInstanced": true
       }
     }
-  },
+  ],
   "geometricError": 70,
   "root": {
     "refine": "ADD",
@@ -74,11 +76,11 @@
     "contents": [
       {
         "uri": "batched.b3dm",
-        "group": "buildings"
+        "group": 0
       },
       {
         "uri": "instanced.i3dm",
-        "group": "cubes"
+        "group": 1
       }
     ]
   }

--- a/Specs/Scene/Cesium3DTilesetMetadataSpec.js
+++ b/Specs/Scene/Cesium3DTilesetMetadataSpec.js
@@ -39,7 +39,8 @@ describe("Scene/Cesium3DTilesetMetadata", function () {
     });
 
     expect(metadata.schema).toBe(schema);
-    expect(metadata.groups).toEqual({});
+    expect(metadata.groups).toEqual([]);
+    expect(metadata.groupIds).toEqual([]);
     expect(metadata.tileset).toBeUndefined();
     expect(metadata.statistics).toBeUndefined();
     expect(metadata.extras).toBeUndefined();
@@ -71,20 +72,22 @@ describe("Scene/Cesium3DTilesetMetadata", function () {
 
     const tilesetJson = {
       schema: schemaJson,
-      groups: {
-        neighborhoodA: {
+      groups: [
+        {
+          id: "neighborhoodA",
           class: "neighborhood",
           properties: {
             color: "RED",
           },
         },
-        neighborhoodB: {
+        {
+          id: "neighborhoodB",
           class: "neighborhood",
           properties: {
             color: "GREEN",
           },
         },
-      },
+      ],
       metadata: {
         class: "city",
         properties: {
@@ -115,12 +118,14 @@ describe("Scene/Cesium3DTilesetMetadata", function () {
     expect(tilesetMetadata.class).toBe(cityClass);
     expect(tilesetMetadata.getProperty("name")).toBe("City");
 
-    const neighborhoodA = metadata.groups.neighborhoodA;
-    const neighborhoodB = metadata.groups.neighborhoodB;
+    const neighborhoodA = metadata.groups[0];
+    const neighborhoodB = metadata.groups[1];
 
+    expect(neighborhoodA.id).toBe(metadata.groupIds[0]);
     expect(neighborhoodA.class).toBe(neighborhoodClass);
     expect(neighborhoodA.getProperty("color")).toBe("RED");
     expect(neighborhoodB.class).toBe(neighborhoodClass);
+    expect(neighborhoodB.id).toBe(metadata.groupIds[1]);
     expect(neighborhoodB.getProperty("color")).toBe("GREEN");
 
     expect(metadata.statistics).toBe(statistics);
@@ -197,11 +202,13 @@ describe("Scene/Cesium3DTilesetMetadata", function () {
     expect(tilesetMetadata.class).toBe(cityClass);
     expect(tilesetMetadata.getProperty("name")).toBe("City");
 
-    const neighborhoodA = metadata.groups.neighborhoodA;
-    const neighborhoodB = metadata.groups.neighborhoodB;
+    const neighborhoodA = metadata.groups[0];
+    const neighborhoodB = metadata.groups[1];
 
+    expect(neighborhoodA.id).toBe("neighborhoodA");
     expect(neighborhoodA.class).toBe(neighborhoodClass);
     expect(neighborhoodA.getProperty("color")).toBe("RED");
+    expect(neighborhoodB.id).toBe("neighborhoodB");
     expect(neighborhoodB.class).toBe(neighborhoodClass);
     expect(neighborhoodB.getProperty("color")).toBe("GREEN");
 

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -5989,13 +5989,18 @@ describe(
           expect(metadata).toBeDefined();
 
           const groups = metadata.groups;
+          const groupIds = metadata.groupIds;
           expect(groups).toBeDefined();
+          expect(groupIds).toEqual([
+            "residentialDistrict",
+            "commercialDistrict",
+          ]);
 
-          let group = groups.commercialDistrict;
+          let group = groups[1];
           expect(group).toBeDefined();
           expect(group.getProperty("businessCount")).toBe(143);
 
-          group = groups.residentialDistrict;
+          group = groups[0];
           expect(group).toBeDefined();
           expect(group.getProperty("population")).toBe(300000);
           expect(group.getProperty("neighborhoods")).toEqual([
@@ -6003,9 +6008,6 @@ describe(
             "Middletown",
             "Western Heights",
           ]);
-
-          group = groups.port;
-          expect(group).not.toBeDefined();
         });
       });
 
@@ -6015,8 +6017,8 @@ describe(
           tilesetWithGroupMetadataUrl
         ).then(function (tileset) {
           const metadata = tileset.metadata;
-          const commercialDistrict = metadata.groups.commercialDistrict;
-          const residentialDistrict = metadata.groups.residentialDistrict;
+          const commercialDistrict = metadata.groups[1];
+          const residentialDistrict = metadata.groups[0];
 
           // the parent tile in this dataset does not have a group defined,
           // but its children do.
@@ -6434,13 +6436,18 @@ describe(
           expect(metadata).toBeDefined();
 
           const groups = metadata.groups;
+          const groupIds = metadata.groupIds;
           expect(groups).toBeDefined();
+          expect(groupIds).toEqual([
+            "commercialDistrict",
+            "residentialDistrict",
+          ]);
 
-          let group = groups.commercialDistrict;
+          let group = groups[0];
           expect(group).toBeDefined();
           expect(group.getProperty("businessCount")).toBe(143);
 
-          group = groups.residentialDistrict;
+          group = groups[1];
           expect(group).toBeDefined();
           expect(group.getProperty("population")).toBe(300000);
           expect(group.getProperty("neighborhoods")).toEqual([
@@ -6448,9 +6455,6 @@ describe(
             "Middletown",
             "Western Heights",
           ]);
-
-          group = groups.port;
-          expect(group).not.toBeDefined();
         });
       });
 
@@ -6460,8 +6464,8 @@ describe(
           tilesetWithGroupMetadataLegacyUrl
         ).then(function (tileset) {
           const metadata = tileset.metadata;
-          const commercialDistrict = metadata.groups.commercialDistrict;
-          const residentialDistrict = metadata.groups.residentialDistrict;
+          const commercialDistrict = metadata.groups[0];
+          const residentialDistrict = metadata.groups[1];
 
           // the parent tile in this dataset does not have a group defined,
           // but its children do.

--- a/Specs/Scene/Implicit3DTileContentSpec.js
+++ b/Specs/Scene/Implicit3DTileContentSpec.js
@@ -1174,13 +1174,13 @@ describe(
           gatherTilesPreorder(subtreeRootTile, 0, 2, tiles);
 
           const groups = tileset.metadata.groups;
-          const ground = groups.ground;
+          const ground = groups[0];
           expect(ground.getProperty("color")).toEqual(
             new Cartesian3(120, 68, 32)
           );
           expect(ground.getProperty("priority")).toBe(0);
 
-          const sky = groups.sky;
+          const sky = groups[1];
           expect(sky.getProperty("color")).toEqual(
             new Cartesian3(206, 237, 242)
           );
@@ -1673,13 +1673,13 @@ describe(
           gatherTilesPreorder(subtreeRootTile, 0, 2, tiles);
 
           const groups = tileset.metadata.groups;
-          const ground = groups.ground;
+          const ground = groups[0];
           expect(ground.getProperty("color")).toEqual(
             new Cartesian3(120, 68, 32)
           );
           expect(ground.getProperty("priority")).toBe(0);
 
-          const sky = groups.sky;
+          const sky = groups[1];
           expect(sky.getProperty("color")).toEqual(
             new Cartesian3(206, 237, 242)
           );

--- a/Specs/Scene/findGroupMetadataSpec.js
+++ b/Specs/Scene/findGroupMetadataSpec.js
@@ -26,8 +26,8 @@ describe("Scene/findGroupMetadata", function () {
 
     mockTileset = {
       metadata: {
-        groups: {
-          testGroup: new GroupMetadata({
+        groups: [
+          new GroupMetadata({
             id: "testGroup",
             class: layerClass,
             group: {
@@ -37,7 +37,8 @@ describe("Scene/findGroupMetadata", function () {
               },
             },
           }),
-        },
+        ],
+        groupIds: ["testGroup"],
       },
     };
   });
@@ -50,7 +51,18 @@ describe("Scene/findGroupMetadata", function () {
     expect(group).not.toBeDefined();
   });
 
-  it("returns the group metadata if there is a group", function () {
+  it("returns the group metadata if there is a group index", function () {
+    const contentHeader = {
+      uri: "https://example.com/model.b3dm",
+      group: 0,
+    };
+    const group = findGroupMetadata(mockTileset, contentHeader);
+    expect(group).toBeDefined();
+    expect(group.getProperty("name")).toBe("Test Layer testGroup");
+    expect(group.getProperty("elevation")).toBe(150.0);
+  });
+
+  it("returns the group metadata if there is a group with the same id (legacy)", function () {
     const contentHeader = {
       uri: "https://example.com/model.b3dm",
       group: "testGroup",
@@ -61,7 +73,7 @@ describe("Scene/findGroupMetadata", function () {
     expect(group.getProperty("elevation")).toBe(150.0);
   });
 
-  it("returns the group metadata if there is an extension", function () {
+  it("returns the group metadata if there is an extension (legacy)", function () {
     const contentHeader = {
       uri: "https://example.com/model.b3dm",
       extensions: {


### PR DESCRIPTION
This PR implements the changes made in the 3D Tiles repository in [#648](https://github.com/CesiumGS/3d-tiles/pull/648). In both schema and implementation, the tileset's `groups` are defined as an array of groups, instead of as a dictionary. 

cc @ptrgags for review