### PR TITLE
Fix `pnts` crash when using `ModelExperimental`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 1.92 - 2022-04-01
+
+##### Fixes :wrench:
+
+- Fixed a bug where `pnts` tiles would crash when `Cesium.ExperimentalFeatures.enableModelExperimental` was true. [#10183](https://github.com/CesiumGS/cesium/pull/10183)
+
 ### 1.91 - 2022-03-01
 
 ##### Breaking Changes :mega:

--- a/Source/Scene/ModelComponents.js
+++ b/Source/Scene/ModelComponents.js
@@ -702,7 +702,7 @@ function Components() {
    * @type {ModelComponents.Asset}
    * @private
    */
-  this.asset = undefined;
+  this.asset = new Asset();
 
   /**
    * The default scene.


### PR DESCRIPTION
https://github.com/CesiumGS/cesium/pull/10138 introduced a small regression where `pnts` tiles would crash when using `ModelExperimental`. This is because the code that adds credits expects the `asset` property to exist, which it does for anything going through `GltfLoader`, but not other things that create `ModelComponents` directly like `pnts`.

https://github.com/CesiumGS/cesium/blob/2d5fa80f61b47a5266478e57cee25353096c5000/Source/Scene/ModelExperimental/ModelExperimental.js#L815-L823

The quick fix is to always just initialize the `asset` property with a default constructed `Asset`