### PR TITLE
A proposed implementation for passing imagery layers data to Fragment Shaders

### DIFF
--- a/Source/Scene/GlobeSurfaceShaderSet.js
+++ b/Source/Scene/GlobeSurfaceShaderSet.js
@@ -334,6 +334,9 @@ GlobeSurfaceShaderSet.prototype.getShaderProgram = function (options) {
       computeDayColor +=
         "\
             color,\n\
+            u_layerIndex[" +
+        i +
+        "],\n\
             u_dayTextures[" +
         i +
         "],\n\

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -1589,6 +1589,9 @@ const scratchClippingPlanesMatrix = new Matrix4();
 const scratchInverseTransposeClippingPlanesMatrix = new Matrix4();
 function createTileUniformMap(frameState, globeSurfaceTileProvider) {
   const uniformMap = {
+    u_layerIndex: function () {
+      return this.properties.layerIndex;
+    },
     u_initialColor: function () {
       return this.properties.initialColor;
     },
@@ -1786,6 +1789,7 @@ function createTileUniformMap(frameState, globeSurfaceTileProvider) {
 
       terrainExaggerationAndRelativeHeight: new Cartesian2(1.0, 0.0),
 
+      layerIndex: [],
       dayTextures: [],
       dayTextureTranslationAndScale: [],
       dayTextureTexCoordsRectangle: [],
@@ -2505,7 +2509,8 @@ function addDrawCommandsForTile(tileProvider, tile, frameState) {
           tileImagery
         );
       }
-
+      uniformMapProperties.layerIndex[numberOfDayTextures] =
+        imageryLayer._layerIndex;
       uniformMapProperties.dayTextures[numberOfDayTextures] = texture;
       uniformMapProperties.dayTextureTranslationAndScale[numberOfDayTextures] =
         tileImagery.textureTranslationAndScale;

--- a/Source/Shaders/Builtin/Structs/materialInput.glsl
+++ b/Source/Shaders/Builtin/Structs/materialInput.glsl
@@ -25,4 +25,5 @@ struct czm_materialInput
     float height;
     float slope;
     float aspect;
+    vec4 layerColor[czm_layerColorNumber];
 };


### PR DESCRIPTION
A proposed implementation for passing imagery layers raster data to a globe material vertex shader for further processing. A current limitation is the way the layers are being iterated in GlobeFS.glsl before setting values to the czm_materialInput->layerColor array. This induces long shader compilation times and requires to set a fixed number of processed layers (set as the GLSL constant layerColorNumber)