### PR TITLE
Add min and max parsing to property attribute

### DIFF
--- a/Source/Scene/PropertyAttributeProperty.js
+++ b/Source/Scene/PropertyAttributeProperty.js
@@ -31,6 +31,8 @@ export default function PropertyAttributeProperty(options) {
   this._attribute = property.attribute;
   this._offset = property.offset;
   this._scale = property.scale;
+  this._min = property.min;
+  this._max = property.max;
 
   this._extras = property.extras;
   this._extensions = property.extensions;


### PR DESCRIPTION
This is a simple PR: it adds `min` and `max` properties to `PropertyAttributeProperty`. @ptrgags can you take a look?