### PR TITLE
Add unit tests for unnormalizing metadata

### DIFF
--- a/Source/Scene/MetadataClassProperty.js
+++ b/Source/Scene/MetadataClassProperty.js
@@ -570,6 +570,18 @@ function parseType(property, enums) {
 /**
  * Normalizes integer property values. If the property is not normalized
  * the value is returned unmodified.
+ * <p>
+ * Given the way normalization is defined in {@link https://github.com/CesiumGS/3d-tiles/tree/main/specification/Metadata#normalized-values|the 3D Metadata Specification},
+ * normalize and unnormalize are almost, but not quite inverses. In particular,
+ * the smallest signed integer value will be off by one after normalizing and
+ * unnormalizing. See
+ * {@link https://www.desmos.com/calculator/nledg1evut|this Desmos graph} for
+ * an example using INT8.
+ * </p>
+ * <p>
+ * Furthermore, for 64-bit integer types, there may be a loss of precision
+ * due to conversion to Number
+ * </p>
  *
  * @param {*} value The integer value or array of integer values.
  * @returns {*} The normalized value or array of normalized values.
@@ -591,6 +603,18 @@ MetadataClassProperty.prototype.normalize = function (value) {
 /**
  * Unnormalizes integer property values. If the property is not normalized
  * the value is returned unmodified.
+ * <p>
+ * Given the way normalization is defined in {@link https://github.com/CesiumGS/3d-tiles/tree/main/specification/Metadata#normalized-values|the 3D Metadata Specification},
+ * normalize and unnormalize are almost, but not quite inverses. In particular,
+ * the smallest signed integer value will be off by one after normalizing and
+ * unnormalizing. See
+ * {@link https://www.desmos.com/calculator/nledg1evut|this Desmos graph} for
+ * an example using INT8.
+ * </p>
+ * <p>
+ * Furthermore, for 64-bit integer types, there may be a loss of precision
+ * due to conversion to Number
+ * </p>
  *
  * @param {*} value The normalized value or array of normalized values.
  * @returns {*} The integer value or array of integer values.

--- a/Specs/Scene/MetadataClassPropertySpec.js
+++ b/Specs/Scene/MetadataClassPropertySpec.js
@@ -463,20 +463,20 @@ describe("Scene/MetadataClassProperty", function () {
       };
 
       scalarValues = {
-        propertyInt8: [-128, 0, 127],
+        propertyInt8: [-127, 0, 127],
         propertyUint8: [0, 51, 255],
-        propertyInt16: [-32768, 0, 32767],
+        propertyInt16: [-32767, 0, 32767],
         propertyUint16: [0, 13107, 65535],
-        propertyInt32: [-2147483648, 0, 2147483647],
+        propertyInt32: [-2147483647, 0, 2147483647],
         propertyUint32: [0, 858993459, 4294967295],
         propertyInt64: [
-          BigInt("-9223372036854775808"), // eslint-disable-line
+          BigInt("-9223372036854775807"), // eslint-disable-line
           BigInt(0), // eslint-disable-line
           BigInt("9223372036854775807"), // eslint-disable-line
         ],
         propertyUint64: [
           BigInt(0), // eslint-disable-line
-          BigInt("3689348814741910323"), // eslint-disable-line
+          BigInt("3689348814741910528"), // eslint-disable-line
           BigInt("18446744073709551615"), // eslint-disable-line
         ],
       };
@@ -522,7 +522,7 @@ describe("Scene/MetadataClassProperty", function () {
       };
 
       arrayValues = {
-        propertyInt8: [[-128, 0], [127], []],
+        propertyInt8: [[-127, 0], [127], []],
         propertyUint8: [
           [0, 255],
           [0, 51],
@@ -572,8 +572,8 @@ describe("Scene/MetadataClassProperty", function () {
 
       vectorValues = {
         vec4Int8: [
-          [-128, 0, 127, 0],
-          [-128, -128, -128, 0],
+          [-127, 0, 127, 0],
+          [-127, -127, -127, 0],
           [127, 127, 127, 127],
         ],
         mat2Uint8: [
@@ -829,7 +829,9 @@ describe("Scene/MetadataClassProperty", function () {
           for (let i = 0; i < length; ++i) {
             const value = arrayOfVectorValues[propertyId][i];
             const normalizedValue = property.normalize(clone(value, true));
-            expect(normalizedValue).toEqual(arrayOfVectorValues[propertyId][i]);
+            expect(normalizedValue).toEqual(
+              normalizedArrayOfVectorValues[propertyId][i]
+            );
           }
         }
       }


### PR DESCRIPTION
Fixing an omission in the original metadata code, we test `normalize` but not `unnormalize`.

I refactored the unit tests to make use of round-trip values for simplicity. Along the way, I realized that `normalize` and `unnormalize` are intentionally not inverses (they're _almost_ inverses except for the minimum value for signed integers, see [this Desmos graph](https://www.desmos.com/calculator/vgx2m46ons). I left a note in the descriptions to warn about that.

@j9liu could you review?