### PR TITLE
ShadowMap: change pointLightRadius of type to number

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
 ##### Fixes :wrench:
 
 - Fixed a bug where `pnts` tiles would crash when `Cesium.ExperimentalFeatures.enableModelExperimental` was true. [#10183](https://github.com/CesiumGS/cesium/pull/10183)
-- Fixed `ShadowMap` of `options.pointLightRadius` changed to number.[#10195](https://github.com/CesiumGS/cesium/pull/10195)
+- Fixed `ShadowMap` documentation for `options.pointLightRadius` type.[#10195](https://github.com/CesiumGS/cesium/pull/10195)
 
 ### 1.91 - 2022-03-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 ##### Fixes :wrench:
 
 - Fixed a bug where `pnts` tiles would crash when `Cesium.ExperimentalFeatures.enableModelExperimental` was true. [#10183](https://github.com/CesiumGS/cesium/pull/10183)
+- Fixed `ShadowMap` of `options.pointLightRadius` changed to number.[#10195](https://github.com/CesiumGS/cesium/pull/10195)
 
 ### 1.91 - 2022-03-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -314,3 +314,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Ugnius Malukas](https://github.com/ugnelis)
 - [Justin Peter](https://github.com/themagicnacho)
 - [Gu Miao](https://github.com/Gu-Miao)
+- [Shen WeiQun](https://github.com/ShenWeiQun)

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -61,7 +61,7 @@ import ShadowMapShader from "./ShadowMapShader.js";
  * @param {Camera} options.lightCamera A camera representing the light source.
  * @param {Boolean} [options.enabled=true] Whether the shadow map is enabled.
  * @param {Boolean} [options.isPointLight=false] Whether the light source is a point light. Point light shadows do not use cascades.
- * @param {Boolean} [options.pointLightRadius=100.0] Radius of the point light.
+ * @param {Number} [options.pointLightRadius=100.0] Radius of the point light.
  * @param {Boolean} [options.cascadesEnabled=true] Use multiple shadow maps to cover different partitions of the view frustum.
  * @param {Number} [options.numberOfCascades=4] The number of cascades to use for the shadow map. Supported values are one and four.
  * @param {Number} [options.maximumDistance=5000.0] The maximum distance used for generating cascaded shadows. Lower values improve shadow quality.


### PR DESCRIPTION
Before in ShadowMap , options.pointLightRadius is a Boolean
```
 * @param {Boolean} [options.pointLightRadius=100.0] Radius of the point light.
```

But options.pointLightRadius should be a number , [e.g. options.pointLightRadius=100.0]
So:
```
 * @param {Boolean} [options.pointLightRadius=100.0] Radius of the point light.
 * @param {Number} [options.pointLightRadius=100.0] Radius of the point light.
 ```