### PR TITLE
Revert `3DTILES_bounding_volume_S2` changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,7 +32,6 @@
     [#10159](https://github.com/CesiumGS/cesium/pull/10159)
   - Implicit tiling is now specified in `tile.implicitTiling` rather than the `3DTILES_implicit_tiling` extension. [#10169](https://github.com/CesiumGS/cesium/pull/10169)
   - Multiple contents are now provided in `tile.contents` rather than the `3DTILES_multiple_contents` extension. [#10174](https://github.com/CesiumGS/cesium/pull/10174)
-  - S2 cell bounding volumes are now specified in `boundingVolume.s2Cell` rather than the `3DTILES_bounding_volume_s2` extension. [#10176](https://github.com/CesiumGS/cesium/pull/10176)
 
 ##### Fixes :wrench:
 

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -1673,10 +1673,6 @@ Cesium3DTile.prototype.createBoundingVolume = function (
     throw new RuntimeError("boundingVolume must be defined");
   }
 
-  if (defined(boundingVolumeHeader.s2Cell)) {
-    return new TileBoundingS2Cell(boundingVolumeHeader.s2Cell);
-  }
-
   if (hasExtension(boundingVolumeHeader, "3DTILES_bounding_volume_S2")) {
     return new TileBoundingS2Cell(
       boundingVolumeHeader.extensions["3DTILES_bounding_volume_S2"]
@@ -1698,7 +1694,7 @@ Cesium3DTile.prototype.createBoundingVolume = function (
     return createSphere(boundingVolumeHeader.sphere, transform, result);
   }
   throw new RuntimeError(
-    "boundingVolume must contain a sphere, region, box, or S2 cell"
+    "boundingVolume must contain a sphere, region, or box"
   );
 };
 

--- a/Source/Scene/Implicit3DTileContent.js
+++ b/Source/Scene/Implicit3DTileContent.js
@@ -527,21 +527,6 @@ function deriveChildTile(
 }
 
 /**
- * Checks whether the bounding volume is an S2 cell, either specified by
- * boundingVolume.s2Cell (3D Tiles 1.1) or by the 3DTILES_bounding_volume_S2 extension.
- *
- * @param {Object} [boundingVolume] The bounding volume
- * @returns {Boolean} Whether the bounding volume is an S2 cell
- * @private
- */
-function hasS2BoundingVolume(boundingVolume) {
-  return (
-    defined(boundingVolume.s2Cell) ||
-    hasExtension(boundingVolume, "3DTILES_bounding_volume_S2")
-  );
-}
-
-/**
  * Checks whether the bounding volume's heights can be updated.
  * Returns true if the minimumHeight/maximumHeight parameter
  * is defined and the bounding volume is a region or S2 cell.
@@ -558,7 +543,8 @@ function canUpdateHeights(boundingVolume, tileBounds) {
     defined(boundingVolume) &&
     defined(tileBounds) &&
     (defined(tileBounds.minimumHeight) || defined(tileBounds.maximumHeight)) &&
-    (hasS2BoundingVolume(boundingVolume) || defined(boundingVolume.region))
+    (hasExtension(boundingVolume, "3DTILES_bounding_volume_S2") ||
+      defined(boundingVolume.region))
   );
 }
 
@@ -570,7 +556,7 @@ function canUpdateHeights(boundingVolume, tileBounds) {
  * minimumHeight/maximumHeight parameter is defined and the
  * bounding volume is a region or S2 cell.
  *
- * @param {Object} boundingVolume The bounding voume
+ * @param {Object} boundingVolume The bounding volume
  * @param {Object} [tileBounds] The tile bounds
  * @param {Number} [tileBounds.minimumHeight] The new minimum height
  * @param {Number} [tileBounds.maximumHeight] The new maximum height
@@ -581,13 +567,7 @@ function updateHeights(boundingVolume, tileBounds) {
     return;
   }
 
-  if (defined(boundingVolume.s2Cell)) {
-    updateS2CellHeights(
-      boundingVolume.s2Cell,
-      tileBounds.minimumHeight,
-      tileBounds.maximumHeight
-    );
-  } else if (hasExtension(boundingVolume, "3DTILES_bounding_volume_S2")) {
+  if (hasExtension(boundingVolume, "3DTILES_bounding_volume_S2")) {
     updateS2CellHeights(
       boundingVolume.extensions["3DTILES_bounding_volume_S2"],
       tileBounds.minimumHeight,
@@ -776,7 +756,7 @@ function deriveBoundingVolume(
 ) {
   const rootBoundingVolume = implicitTileset.boundingVolume;
 
-  if (hasS2BoundingVolume(rootBoundingVolume)) {
+  if (hasExtension(rootBoundingVolume, "3DTILES_bounding_volume_S2")) {
     return deriveBoundingVolumeS2(
       parentIsPlaceholderTile,
       parentTile,
@@ -833,7 +813,7 @@ function deriveBoundingVolume(
  * @param {Number} x The x coordinate of the descendant tile
  * @param {Number} y The y coordinate of the descendant tile
  * @param {Number} [z] The z coordinate of the descendant tile (octree only)
- * @returns {Object} An object with s2Cell defined.
+ * @returns {Object} An object with the 3DTILES_bounding_volume_S2 extension.
  * @private
  */
 function deriveBoundingVolumeS2(
@@ -862,10 +842,12 @@ function deriveBoundingVolumeS2(
   // Handle the placeholder tile case, where we just duplicate the placeholder's bounding volume.
   if (parentIsPlaceholderTile) {
     return {
-      s2Cell: {
-        token: S2Cell.getTokenFromId(boundingVolumeS2.s2Cell._cellId),
-        minimumHeight: boundingVolumeS2.minimumHeight,
-        maximumHeight: boundingVolumeS2.maximumHeight,
+      extensions: {
+        "3DTILES_bounding_volume_S2": {
+          token: S2Cell.getTokenFromId(boundingVolumeS2.s2Cell._cellId),
+          minimumHeight: boundingVolumeS2.minimumHeight,
+          maximumHeight: boundingVolumeS2.maximumHeight,
+        },
       },
     };
   }
@@ -896,10 +878,12 @@ function deriveBoundingVolumeS2(
   }
 
   return {
-    s2Cell: {
-      token: S2Cell.getTokenFromId(cell._cellId),
-      minimumHeight: minHeight,
-      maximumHeight: maxHeight,
+    extensions: {
+      "3DTILES_bounding_volume_S2": {
+        token: S2Cell.getTokenFromId(cell._cellId),
+        minimumHeight: minHeight,
+        maximumHeight: maxHeight,
+      },
     },
   };
 }

--- a/Source/Scene/ImplicitTileset.js
+++ b/Source/Scene/ImplicitTileset.js
@@ -65,17 +65,10 @@ export default function ImplicitTileset(
   this.metadataSchema = metadataSchema;
 
   const boundingVolume = tileJson.boundingVolume;
-  if (hasExtension(boundingVolume, "3DTILES_bounding_volume_S2")) {
-    // Merge the extension with the boundingVolume for consistency with 3D Tiles 1.1
-    boundingVolume.s2Cell =
-      boundingVolume.extensions["3DTILES_bounding_volume_S2"];
-    delete boundingVolume.extensions["3DTILES_bounding_volume_S2"];
-  }
-
   if (
     !defined(boundingVolume.box) &&
     !defined(boundingVolume.region) &&
-    !defined(boundingVolume.s2Cell)
+    !hasExtension(boundingVolume, "3DTILES_bounding_volume_S2")
   ) {
     throw new RuntimeError(
       "Only box, region and S2 cells are supported for implicit tiling"

--- a/Specs/Data/Cesium3DTiles/Metadata/ImplicitHeightSemantics/s2-tileset_1.1.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/ImplicitHeightSemantics/s2-tileset_1.1.json
@@ -24,10 +24,12 @@
   "root": {
     "geometricError": 2048.0,
     "boundingVolume": {
-      "s2Cell": {
-        "token": "1",
-        "minimumHeight": 0,
-        "maximumHeight": 10000
+      "extensions": {
+        "3DTILES_bounding_volume_S2": {
+          "token": "1",
+          "minimumHeight": 0,
+          "maximumHeight": 10000
+        }
       }
     },
     "implicitTiling": {

--- a/Specs/Scene/Implicit3DTileContentSpec.js
+++ b/Specs/Scene/Implicit3DTileContentSpec.js
@@ -647,7 +647,9 @@ describe(
       );
       const implicitTilesetS2 = {
         boundingVolume: {
-          s2Cell: simpleBoundingVolumeS2,
+          extensions: {
+            "3DTILES_bounding_volume_S2": simpleBoundingVolumeS2,
+          },
         },
         subdivisionScheme: ImplicitSubdivisionScheme.QUADTREE,
       };
@@ -722,7 +724,9 @@ describe(
         };
         let result = deriveBoundingVolumeS2(false, parentTile, 0, 1, 0, 0);
         expect(result).toEqual({
-          s2Cell: expected,
+          extensions: {
+            "3DTILES_bounding_volume_S2": expected,
+          },
         });
 
         parentTile._boundingVolume = new TileBoundingS2Cell({
@@ -737,7 +741,9 @@ describe(
         };
         result = deriveBoundingVolumeS2(false, parentTile, 0, 1, 0, 0);
         expect(result).toEqual({
-          s2Cell: expected,
+          extensions: {
+            "3DTILES_bounding_volume_S2": expected,
+          },
         });
       });
 
@@ -766,7 +772,9 @@ describe(
           0
         );
         expect(result0).toEqual({
-          s2Cell: expected0,
+          extensions: {
+            "3DTILES_bounding_volume_S2": expected0,
+          },
         });
         const result1 = deriveBoundingVolumeS2(
           false,
@@ -778,7 +786,9 @@ describe(
           0
         );
         expect(result1).toEqual({
-          s2Cell: expected1,
+          extensions: {
+            "3DTILES_bounding_volume_S2": expected1,
+          },
         });
       });
     });
@@ -1355,7 +1365,9 @@ describe(
           const subtreeRootTile = placeholderTile.children[0];
 
           const implicitS2Volume =
-            placeholderTile.implicitTileset.boundingVolume.s2Cell;
+            placeholderTile.implicitTileset.boundingVolume.extensions[
+              "3DTILES_bounding_volume_S2"
+            ];
           const minimumHeight = implicitS2Volume.minimumHeight;
           const maximumHeight = implicitS2Volume.maximumHeight;
 
@@ -1841,7 +1853,9 @@ describe(
           const subtreeRootTile = placeholderTile.children[0];
 
           const implicitS2Volume =
-            placeholderTile.implicitTileset.boundingVolume.s2Cell;
+            placeholderTile.implicitTileset.boundingVolume.extensions[
+              "3DTILES_bounding_volume_S2"
+            ];
           const minimumHeight = implicitS2Volume.minimumHeight;
           const maximumHeight = implicitS2Volume.maximumHeight;
 

--- a/Specs/Scene/ImplicitTilesetSpec.js
+++ b/Specs/Scene/ImplicitTilesetSpec.js
@@ -146,16 +146,19 @@ describe("Scene/ImplicitTileset", function () {
     expect(implicitTileset.contentUriTemplates).toEqual([]);
   });
 
-  it("accepts tilesets with s2 bounding volumes", function () {
-    const tileJson = clone(implicitTileJson, true);
+  it("accepts tilesets with 3DTILES_bounding_volume_S2", function () {
+    const tileJson = clone(implicitTileLegacyJson, true);
     tileJson.boundingVolume = {
-      s2Cell: {
-        token: "1",
-        minimumHeight: 0,
-        maximumHeight: 100,
+      extensions: {
+        "3DTILES_bounding_volume_S2": {
+          token: "1",
+          minimumHeight: 0,
+          maximumHeight: 100,
+        },
       },
     };
-    const tileJsonS2 = tileJson.boundingVolume.s2Cell;
+    const tileJsonS2 =
+      tileJson.boundingVolume.extensions["3DTILES_bounding_volume_S2"];
 
     let metadataSchema;
     const implicitTileset = new ImplicitTileset(
@@ -163,7 +166,8 @@ describe("Scene/ImplicitTileset", function () {
       tileJson,
       metadataSchema
     );
-    const implicitTilesetS2 = implicitTileset.boundingVolume.s2Cell;
+    const implicitTilesetS2 =
+      implicitTileset.boundingVolume.extensions["3DTILES_bounding_volume_S2"];
     expect(implicitTilesetS2.token).toEqual(tileJsonS2.token);
     expect(implicitTilesetS2.minimumHeight).toEqual(tileJsonS2.minimumHeight);
     expect(implicitTilesetS2.maximumHeight).toEqual(tileJsonS2.maximumHeight);
@@ -268,32 +272,6 @@ describe("Scene/ImplicitTileset", function () {
         metadataSchema
       );
       expect(implicitTileset.contentUriTemplates).toEqual([]);
-    });
-
-    it("accepts tilesets with 3DTILES_bounding_volume_S2 (legacy)", function () {
-      const tileJson = clone(implicitTileLegacyJson, true);
-      tileJson.boundingVolume = {
-        extensions: {
-          "3DTILES_bounding_volume_S2": {
-            token: "1",
-            minimumHeight: 0,
-            maximumHeight: 100,
-          },
-        },
-      };
-      const tileJsonS2 =
-        tileJson.boundingVolume.extensions["3DTILES_bounding_volume_S2"];
-
-      let metadataSchema;
-      const implicitTileset = new ImplicitTileset(
-        baseResource,
-        tileJson,
-        metadataSchema
-      );
-      const implicitTilesetS2 = implicitTileset.boundingVolume.s2Cell;
-      expect(implicitTilesetS2.token).toEqual(tileJsonS2.token);
-      expect(implicitTilesetS2.minimumHeight).toEqual(tileJsonS2.minimumHeight);
-      expect(implicitTilesetS2.maximumHeight).toEqual(tileJsonS2.maximumHeight);
     });
 
     it("rejects bounding spheres (legacy)", function () {


### PR DESCRIPTION
This PR reverts #10176 after it was decided in [3d-tiles#662](https://github.com/CesiumGS/3d-tiles/pull/662) that S2 volumes would be kept as an extension.

cc @ptrgags can you review?