### PR TITLE
Cartesian2/3/4 clamp function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,11 +6,15 @@
 
 - Removed links to SpecRunner.html and related Jasmine files for running unit tests in browsers.
 
+##### Additions :tada:
+
+- Added `Cartesian2.clamp`, `Cartesian3.clamp`, and `Cartesian4.clamp`. [#10197](https://github.com/CesiumGS/cesium/pull/10197)
+
 ##### Fixes :wrench:
 
 - Fixed a bug where `pnts` tiles would crash when `Cesium.ExperimentalFeatures.enableModelExperimental` was true. [#10183](https://github.com/CesiumGS/cesium/pull/10183)
 - Fixed an issue with Firefox and dimensionless SVG images. [#9188](https://github.com/CesiumGS/cesium/9188)
-- Fixed `ShadowMap` documentation for `options.pointLightRadius` type.[#10195](https://github.com/CesiumGS/cesium/pull/10195)
+- Fixed `ShadowMap` documentation for `options.pointLightRadius` type. [#10195](https://github.com/CesiumGS/cesium/pull/10195)
 
 ### 1.91 - 2022-03-01
 

--- a/Source/Core/Cartesian2.js
+++ b/Source/Core/Cartesian2.js
@@ -296,6 +296,32 @@ Cartesian2.maximumByComponent = function (first, second, result) {
 };
 
 /**
+ * Constrain a value to lie between two values.
+ *
+ * @param {Cartesian2} value The value to clamp.
+ * @param {Cartesian2} min The minimum bound.
+ * @param {Cartesian2} max The maximum bound.
+ * @param {Cartesian2} result The object into which to store the result.
+ * @returns {Cartesian2} The clamped value such that min <= result <= max.
+ */
+Cartesian2.clamp = function (value, min, max, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("value", value);
+  Check.typeOf.object("min", min);
+  Check.typeOf.object("max", max);
+  Check.typeOf.object("result", result);
+  //>>includeEnd('debug');
+
+  const x = CesiumMath.clamp(value.x, min.x, max.x);
+  const y = CesiumMath.clamp(value.y, min.y, max.y);
+
+  result.x = x;
+  result.y = y;
+
+  return result;
+};
+
+/**
  * Computes the provided Cartesian's squared magnitude.
  *
  * @param {Cartesian2} cartesian The Cartesian instance whose squared magnitude is to be computed.

--- a/Source/Core/Cartesian3.js
+++ b/Source/Core/Cartesian3.js
@@ -326,6 +326,34 @@ Cartesian3.maximumByComponent = function (first, second, result) {
 };
 
 /**
+ * Constrain a value to lie between two values.
+ *
+ * @param {Cartesian3} cartesian The value to clamp.
+ * @param {Cartesian3} min The minimum bound.
+ * @param {Cartesian3} max The maximum bound.
+ * @param {Cartesian3} result The object into which to store the result.
+ * @returns {Cartesian3} The clamped value such that min <= value <= max.
+ */
+Cartesian3.clamp = function (value, min, max, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("value", value);
+  Check.typeOf.object("min", min);
+  Check.typeOf.object("max", max);
+  Check.typeOf.object("result", result);
+  //>>includeEnd('debug');
+
+  const x = CesiumMath.clamp(value.x, min.x, max.x);
+  const y = CesiumMath.clamp(value.y, min.y, max.y);
+  const z = CesiumMath.clamp(value.z, min.z, max.z);
+
+  result.x = x;
+  result.y = y;
+  result.z = z;
+
+  return result;
+};
+
+/**
  * Computes the provided Cartesian's squared magnitude.
  *
  * @param {Cartesian3} cartesian The Cartesian instance whose squared magnitude is to be computed.

--- a/Source/Core/Cartesian4.js
+++ b/Source/Core/Cartesian4.js
@@ -329,6 +329,36 @@ Cartesian4.maximumByComponent = function (first, second, result) {
 };
 
 /**
+ * Constrain a value to lie between two values.
+ *
+ * @param {Cartesian4} value The value to clamp.
+ * @param {Cartesian4} min The minimum bound.
+ * @param {Cartesian4} max The maximum bound.
+ * @param {Cartesian4} result The object into which to store the result.
+ * @returns {Cartesian4} The clamped value such that min <= result <= max.
+ */
+Cartesian4.clamp = function (value, min, max, result) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("value", value);
+  Check.typeOf.object("min", min);
+  Check.typeOf.object("max", max);
+  Check.typeOf.object("result", result);
+  //>>includeEnd('debug');
+
+  const x = CesiumMath.clamp(value.x, min.x, max.x);
+  const y = CesiumMath.clamp(value.y, min.y, max.y);
+  const z = CesiumMath.clamp(value.z, min.z, max.z);
+  const w = CesiumMath.clamp(value.w, min.w, max.w);
+
+  result.x = x;
+  result.y = y;
+  result.z = z;
+  result.w = w;
+
+  return result;
+};
+
+/**
  * Computes the provided Cartesian's squared magnitude.
  *
  * @param {Cartesian4} cartesian The Cartesian instance whose squared magnitude is to be computed.

--- a/Source/Core/Math.js
+++ b/Source/Core/Math.js
@@ -897,23 +897,18 @@ CesiumMath.previousPowerOfTwo = function (n) {
 /**
  * Constraint a value to lie between two values.
  *
- * @param {Number} value The value to constrain.
+ * @param {Number} value The value to clamp.
  * @param {Number} min The minimum value.
  * @param {Number} max The maximum value.
- * @returns {Number} The value clamped so that min <= value <= max.
+ * @returns {Number} The clamped value such that min <= result <= max.
  */
 CesiumMath.clamp = function (value, min, max) {
   //>>includeStart('debug', pragmas.debug);
-  if (!defined(value)) {
-    throw new DeveloperError("value is required");
-  }
-  if (!defined(min)) {
-    throw new DeveloperError("min is required.");
-  }
-  if (!defined(max)) {
-    throw new DeveloperError("max is required.");
-  }
+  Check.typeOf.number("value", value);
+  Check.typeOf.number("min", min);
+  Check.typeOf.number("max", max);
   //>>includeEnd('debug');
+
   return value < min ? min : value > max ? max : value;
 };
 

--- a/Specs/Core/Cartesian2Spec.js
+++ b/Specs/Core/Cartesian2Spec.js
@@ -144,21 +144,6 @@ describe("Core/Cartesian2", function () {
 
     first.x = 1.0;
     second.x = 2.0;
-    expect(Cartesian2.minimumByComponent(first, second, first)).toEqual(
-      expected
-    );
-  });
-
-  it("minimumByComponent with a result parameter that is an input parameter", function () {
-    const first = new Cartesian2(2.0, 0.0);
-    const second = new Cartesian2(1.0, 0.0);
-    const expected = new Cartesian2(1.0, 0.0);
-    expect(Cartesian2.minimumByComponent(first, second, second)).toEqual(
-      expected
-    );
-
-    first.x = 1.0;
-    second.x = 2.0;
     expect(Cartesian2.minimumByComponent(first, second, second)).toEqual(
       expected
     );
@@ -271,21 +256,6 @@ describe("Core/Cartesian2", function () {
     const second = new Cartesian2(1.0, 0.0);
     const expected = new Cartesian2(2.0, 0.0);
     expect(Cartesian2.maximumByComponent(first, second, first)).toEqual(
-      expected
-    );
-
-    first.x = 1.0;
-    second.x = 2.0;
-    expect(Cartesian2.maximumByComponent(first, second, first)).toEqual(
-      expected
-    );
-  });
-
-  it("maximumByComponent with a result parameter that is an input parameter", function () {
-    const first = new Cartesian2(2.0, 0.0);
-    const second = new Cartesian2(1.0, 0.0);
-    const expected = new Cartesian2(2.0, 0.0);
-    expect(Cartesian2.maximumByComponent(first, second, second)).toEqual(
       expected
     );
 
@@ -413,21 +383,11 @@ describe("Core/Cartesian2", function () {
     const max = new Cartesian2(1.0, 1.0);
     const expected = new Cartesian2(0.0, 0.0);
     expect(Cartesian2.clamp(value, min, max, value)).toEqual(expected);
-  });
 
-  it("clamp with a result parameter that is an input parameter", function () {
-    const value = new Cartesian2(-1.0, -1.0);
-    const min = new Cartesian2(0.0, 0.0);
-    const max = new Cartesian2(1.0, 1.0);
-    const expected = new Cartesian2(0.0, 0.0);
+    Cartesian2.fromElements(-1.0, -1.0, value);
     expect(Cartesian2.clamp(value, min, max, min)).toEqual(expected);
-  });
 
-  it("clamp with a result parameter that is an input parameter", function () {
-    const value = new Cartesian2(-1.0, -1.0);
-    const min = new Cartesian2(0.0, 0.0);
-    const max = new Cartesian2(1.0, 1.0);
-    const expected = new Cartesian2(0.0, 0.0);
+    Cartesian2.fromElements(0.0, 0.0, value);
     expect(Cartesian2.clamp(value, min, max, max)).toEqual(expected);
   });
 

--- a/Specs/Core/Cartesian2Spec.js
+++ b/Specs/Core/Cartesian2Spec.js
@@ -76,37 +76,46 @@ describe("Core/Cartesian2", function () {
   });
 
   it("minimumByComponent", function () {
-    let first = new Cartesian2(2.0, 0.0);
-    let second = new Cartesian2(1.0, 0.0);
+    let first;
+    let second;
+    let expected;
     const result = new Cartesian2();
-    let expected = new Cartesian2(1.0, 0.0);
+
+    first = new Cartesian2(2.0, 0.0);
+    second = new Cartesian2(1.0, 0.0);
+    expected = new Cartesian2(1.0, 0.0);
     expect(Cartesian2.minimumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian2(1.0, 0.0);
     second = new Cartesian2(2.0, 0.0);
     expected = new Cartesian2(1.0, 0.0);
     expect(Cartesian2.minimumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian2(2.0, -15.0);
     second = new Cartesian2(1.0, -20.0);
     expected = new Cartesian2(1.0, -20.0);
     expect(Cartesian2.minimumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian2(2.0, -20.0);
     second = new Cartesian2(1.0, -15.0);
     expected = new Cartesian2(1.0, -20.0);
     expect(Cartesian2.minimumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian2(2.0, -15.0);
     second = new Cartesian2(1.0, -20.0);
     expected = new Cartesian2(1.0, -20.0);
     expect(Cartesian2.minimumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian2(2.0, -15.0);
     second = new Cartesian2(1.0, -20.0);
     expected = new Cartesian2(1.0, -20.0);
@@ -115,27 +124,43 @@ describe("Core/Cartesian2", function () {
     );
   });
 
-  it("minimumByComponent with a result parameter that is an input parameter", function () {
+  it("minimumByComponent with a result parameter", function () {
     const first = new Cartesian2(2.0, 0.0);
     const second = new Cartesian2(1.0, 0.0);
-    const result = new Cartesian2(1.0, 0.0);
-    expect(Cartesian2.minimumByComponent(first, second, first)).toEqual(result);
-    first.x = 1.0;
-    second.x = 2.0;
-    expect(Cartesian2.minimumByComponent(first, second, first)).toEqual(result);
+    const expected = new Cartesian2(1.0, 0.0);
+    const result = new Cartesian2();
+    const returnedResult = Cartesian2.minimumByComponent(first, second, result);
+    expect(returnedResult).toBe(result);
+    expect(returnedResult).toEqual(expected);
   });
 
   it("minimumByComponent with a result parameter that is an input parameter", function () {
     const first = new Cartesian2(2.0, 0.0);
     const second = new Cartesian2(1.0, 0.0);
-    const result = new Cartesian2(1.0, 0.0);
-    expect(Cartesian2.minimumByComponent(first, second, second)).toEqual(
-      result
+    const expected = new Cartesian2(1.0, 0.0);
+    expect(Cartesian2.minimumByComponent(first, second, first)).toEqual(
+      expected
     );
+
+    first.x = 1.0;
+    second.x = 2.0;
+    expect(Cartesian2.minimumByComponent(first, second, first)).toEqual(
+      expected
+    );
+  });
+
+  it("minimumByComponent with a result parameter that is an input parameter", function () {
+    const first = new Cartesian2(2.0, 0.0);
+    const second = new Cartesian2(1.0, 0.0);
+    const expected = new Cartesian2(1.0, 0.0);
+    expect(Cartesian2.minimumByComponent(first, second, second)).toEqual(
+      expected
+    );
+
     first.x = 1.0;
     second.x = 2.0;
     expect(Cartesian2.minimumByComponent(first, second, second)).toEqual(
-      result
+      expected
     );
   });
 
@@ -154,63 +179,75 @@ describe("Core/Cartesian2", function () {
   it("minimumByComponent works when first's or second's X is lesser", function () {
     const first = new Cartesian2(2.0, 0.0);
     const second = new Cartesian2(1.0, 0.0);
-    const result = new Cartesian2(1.0, 0.0);
-    expect(Cartesian2.minimumByComponent(first, second, result)).toEqual(
-      result
+    const expected = new Cartesian2(1.0, 0.0);
+    expect(Cartesian2.minimumByComponent(first, second, expected)).toEqual(
+      expected
     );
+
     second.x = 3.0;
-    result.x = 2.0;
-    expect(Cartesian2.minimumByComponent(first, second, result)).toEqual(
-      result
+    expected.x = 2.0;
+    expect(Cartesian2.minimumByComponent(first, second, expected)).toEqual(
+      expected
     );
   });
 
   it("minimumByComponent works when first's or second's Y is lesser", function () {
     const first = new Cartesian2(0.0, 2.0);
     const second = new Cartesian2(0.0, 1.0);
-    const result = new Cartesian2(0.0, 1.0);
+    const expected = new Cartesian2(0.0, 1.0);
+    const result = new Cartesian2();
     expect(Cartesian2.minimumByComponent(first, second, result)).toEqual(
-      result
+      expected
     );
+
     second.y = 3.0;
-    result.y = 2.0;
+    expected.y = 2.0;
     expect(Cartesian2.minimumByComponent(first, second, result)).toEqual(
-      result
+      expected
     );
   });
 
   it("maximumByComponent", function () {
-    let first = new Cartesian2(2.0, 0.0);
-    let second = new Cartesian2(1.0, 0.0);
+    let first;
+    let second;
+    let expected;
     const result = new Cartesian2();
-    let expected = new Cartesian2(2.0, 0.0);
+
+    first = new Cartesian2(2.0, 0.0);
+    second = new Cartesian2(1.0, 0.0);
+    expected = new Cartesian2(2.0, 0.0);
     expect(Cartesian2.maximumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian2(1.0, 0.0);
     second = new Cartesian2(2.0, 0.0);
     expected = new Cartesian2(2.0, 0.0);
     expect(Cartesian2.maximumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian2(2.0, -15.0);
     second = new Cartesian2(1.0, -20.0);
     expected = new Cartesian2(2.0, -15.0);
     expect(Cartesian2.maximumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian2(2.0, -20.0);
     second = new Cartesian2(1.0, -15.0);
     expected = new Cartesian2(2.0, -15.0);
     expect(Cartesian2.maximumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian2(2.0, -15.0);
     second = new Cartesian2(1.0, -20.0);
     expected = new Cartesian2(2.0, -15.0);
     expect(Cartesian2.maximumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian2(2.0, -15.0);
     second = new Cartesian2(1.0, -20.0);
     expected = new Cartesian2(2.0, -15.0);
@@ -219,27 +256,43 @@ describe("Core/Cartesian2", function () {
     );
   });
 
-  it("maximumByComponent with a result parameter that is an input parameter", function () {
+  it("maximumByComponent with a result parameter", function () {
     const first = new Cartesian2(2.0, 0.0);
     const second = new Cartesian2(1.0, 0.0);
-    const result = new Cartesian2(2.0, 0.0);
-    expect(Cartesian2.maximumByComponent(first, second, first)).toEqual(result);
-    first.x = 1.0;
-    second.x = 2.0;
-    expect(Cartesian2.maximumByComponent(first, second, first)).toEqual(result);
+    const expected = new Cartesian2(2.0, 0.0);
+    const result = new Cartesian2();
+    const returnedResult = Cartesian2.maximumByComponent(first, second, result);
+    expect(returnedResult).toBe(result);
+    expect(returnedResult).toEqual(expected);
   });
 
   it("maximumByComponent with a result parameter that is an input parameter", function () {
     const first = new Cartesian2(2.0, 0.0);
     const second = new Cartesian2(1.0, 0.0);
-    const result = new Cartesian2(2.0, 0.0);
-    expect(Cartesian2.maximumByComponent(first, second, second)).toEqual(
-      result
+    const expected = new Cartesian2(2.0, 0.0);
+    expect(Cartesian2.maximumByComponent(first, second, first)).toEqual(
+      expected
     );
+
+    first.x = 1.0;
+    second.x = 2.0;
+    expect(Cartesian2.maximumByComponent(first, second, first)).toEqual(
+      expected
+    );
+  });
+
+  it("maximumByComponent with a result parameter that is an input parameter", function () {
+    const first = new Cartesian2(2.0, 0.0);
+    const second = new Cartesian2(1.0, 0.0);
+    const expected = new Cartesian2(2.0, 0.0);
+    expect(Cartesian2.maximumByComponent(first, second, second)).toEqual(
+      expected
+    );
+
     first.x = 1.0;
     second.x = 2.0;
     expect(Cartesian2.maximumByComponent(first, second, second)).toEqual(
-      result
+      expected
     );
   });
 
@@ -258,29 +311,142 @@ describe("Core/Cartesian2", function () {
   it("maximumByComponent works when first's or second's X is greater", function () {
     const first = new Cartesian2(2.0, 0.0);
     const second = new Cartesian2(1.0, 0.0);
-    const result = new Cartesian2(2.0, 0.0);
+    const expected = new Cartesian2(2.0, 0.0);
+    const result = new Cartesian2();
     expect(Cartesian2.maximumByComponent(first, second, result)).toEqual(
-      result
+      expected
     );
+
     second.x = 3.0;
-    result.x = 3.0;
+    expected.x = 3.0;
     expect(Cartesian2.maximumByComponent(first, second, result)).toEqual(
-      result
+      expected
     );
   });
 
   it("maximumByComponent works when first's or second's Y is greater", function () {
     const first = new Cartesian2(0.0, 2.0);
     const second = new Cartesian2(0.0, 1.0);
-    const result = new Cartesian2(0.0, 2.0);
+    const expected = new Cartesian2(0.0, 2.0);
+    const result = new Cartesian2();
     expect(Cartesian2.maximumByComponent(first, second, result)).toEqual(
-      result
+      expected
     );
+
     second.y = 3.0;
-    result.y = 3.0;
+    expected.y = 3.0;
     expect(Cartesian2.maximumByComponent(first, second, result)).toEqual(
-      result
+      expected
     );
+  });
+
+  it("clamp", function () {
+    let value;
+    let min;
+    let max;
+    let expected;
+    const result = new Cartesian2();
+
+    value = new Cartesian2(-1.0, 0.0);
+    min = new Cartesian2(0.0, 0.0);
+    max = new Cartesian2(1.0, 1.0);
+    expected = new Cartesian2(0.0, 0.0);
+    expect(Cartesian2.clamp(value, min, max, result)).toEqual(expected);
+
+    value = new Cartesian2(2.0, 0.0);
+    min = new Cartesian2(0.0, 0.0);
+    max = new Cartesian2(1.0, 1.0);
+    expected = new Cartesian2(1.0, 0.0);
+    expect(Cartesian2.clamp(value, min, max, result)).toEqual(expected);
+
+    value = new Cartesian2(0.0, -1.0);
+    min = new Cartesian2(0.0, 0.0);
+    max = new Cartesian2(1.0, 1.0);
+    expected = new Cartesian2(0.0, 0.0);
+    expect(Cartesian2.clamp(value, min, max, result)).toEqual(expected);
+
+    value = new Cartesian2(0.0, 2.0);
+    min = new Cartesian2(0.0, 0.0);
+    max = new Cartesian2(1.0, 1.0);
+    expected = new Cartesian2(0.0, 1.0);
+    expect(Cartesian2.clamp(value, min, max, result)).toEqual(expected);
+
+    value = new Cartesian2(0.0, 0.0);
+    min = new Cartesian2(0.0, 0.0);
+    max = new Cartesian2(1.0, 1.0);
+    expected = new Cartesian2(0.0, 0.0);
+    expect(Cartesian2.clamp(value, min, max, result)).toEqual(expected);
+
+    value = new Cartesian2(0.0, 0.0);
+    min = new Cartesian2(0.0, 0.0);
+    max = new Cartesian2(1.0, 1.0);
+    expected = new Cartesian2(0.0, 0.0);
+    expect(Cartesian2.clamp(value, min, max, result)).toEqual(expected);
+
+    value = new Cartesian2(-2.0, 3.0);
+    min = new Cartesian2(0.0, 0.0);
+    max = new Cartesian2(1.0, 1.0);
+    expected = new Cartesian2(0.0, 1.0);
+    expect(Cartesian2.clamp(value, min, max, result)).toEqual(expected);
+
+    value = new Cartesian2(0.0, 0.0);
+    min = new Cartesian2(1.0, 2.0);
+    max = new Cartesian2(1.0, 2.0);
+    expected = new Cartesian2(1.0, 2.0);
+    expect(Cartesian2.clamp(value, min, max, result)).toEqual(expected);
+  });
+
+  it("clamp with a result parameter", function () {
+    const value = new Cartesian2(-1.0, -1.0);
+    const min = new Cartesian2(0.0, 0.0);
+    const max = new Cartesian2(1.0, 1.0);
+    const expected = new Cartesian2(0.0, 0.0);
+    const result = new Cartesian2();
+    const returnedResult = Cartesian2.clamp(value, min, max, result);
+    expect(returnedResult).toBe(result);
+    expect(returnedResult).toEqual(expected);
+  });
+
+  it("clamp with a result parameter that is an input parameter", function () {
+    const value = new Cartesian2(-1.0, -1.0);
+    const min = new Cartesian2(0.0, 0.0);
+    const max = new Cartesian2(1.0, 1.0);
+    const expected = new Cartesian2(0.0, 0.0);
+    expect(Cartesian2.clamp(value, min, max, value)).toEqual(expected);
+  });
+
+  it("clamp with a result parameter that is an input parameter", function () {
+    const value = new Cartesian2(-1.0, -1.0);
+    const min = new Cartesian2(0.0, 0.0);
+    const max = new Cartesian2(1.0, 1.0);
+    const expected = new Cartesian2(0.0, 0.0);
+    expect(Cartesian2.clamp(value, min, max, min)).toEqual(expected);
+  });
+
+  it("clamp with a result parameter that is an input parameter", function () {
+    const value = new Cartesian2(-1.0, -1.0);
+    const min = new Cartesian2(0.0, 0.0);
+    const max = new Cartesian2(1.0, 1.0);
+    const expected = new Cartesian2(0.0, 0.0);
+    expect(Cartesian2.clamp(value, min, max, max)).toEqual(expected);
+  });
+
+  it("clamp throws without value", function () {
+    expect(function () {
+      Cartesian2.clamp();
+    }).toThrowDeveloperError();
+  });
+
+  it("clamp throws without min", function () {
+    expect(function () {
+      Cartesian2.clamp(new Cartesian2());
+    }).toThrowDeveloperError();
+  });
+
+  it("clamp throws without max", function () {
+    expect(function () {
+      Cartesian2.clamp(new Cartesian2(), new Cartesian2());
+    }).toThrowDeveloperError();
   });
 
   it("magnitudeSquared", function () {
@@ -894,6 +1060,12 @@ describe("Core/Cartesian2", function () {
   it("maximumByComponent throws with no result", function () {
     expect(function () {
       Cartesian2.maximumByComponent(new Cartesian2(), new Cartesian2());
+    }).toThrowDeveloperError();
+  });
+
+  it("clamp throws with no result", function () {
+    expect(function () {
+      Cartesian2.clamp(new Cartesian2(), new Cartesian2(), new Cartesian2());
     }).toThrowDeveloperError();
   });
 

--- a/Specs/Core/Cartesian3Spec.js
+++ b/Specs/Core/Cartesian3Spec.js
@@ -163,26 +163,15 @@ describe("Core/Cartesian3", function () {
   it("minimumByComponent with a result parameter that is an input parameter", function () {
     const first = new Cartesian3(2.0, 0.0, 0.0);
     const second = new Cartesian3(1.0, 0.0, 0.0);
-    const result = new Cartesian3(1.0, 0.0, 0.0);
-    expect(Cartesian3.minimumByComponent(first, second, first)).toEqual(result);
-
-    first.x = 1.0;
-    second.x = 2.0;
-    expect(Cartesian3.minimumByComponent(first, second, first)).toEqual(result);
-  });
-
-  it("minimumByComponent with a result parameter that is an input parameter", function () {
-    const first = new Cartesian3(2.0, 0.0, 0.0);
-    const second = new Cartesian3(1.0, 0.0, 0.0);
-    const result = new Cartesian3(1.0, 0.0, 0.0);
-    expect(Cartesian3.minimumByComponent(first, second, second)).toEqual(
-      result
+    const expected = new Cartesian3(1.0, 0.0, 0.0);
+    expect(Cartesian3.minimumByComponent(first, second, first)).toEqual(
+      expected
     );
 
     first.x = 1.0;
     second.x = 2.0;
     expect(Cartesian3.minimumByComponent(first, second, second)).toEqual(
-      result
+      expected
     );
   });
 
@@ -310,21 +299,6 @@ describe("Core/Cartesian3", function () {
     const second = new Cartesian3(1.0, 0.0, 0.0);
     const expected = new Cartesian3(2.0, 0.0, 0.0);
     expect(Cartesian3.maximumByComponent(first, second, first)).toEqual(
-      expected
-    );
-
-    first.x = 1.0;
-    second.x = 2.0;
-    expect(Cartesian3.maximumByComponent(first, second, first)).toEqual(
-      expected
-    );
-  });
-
-  it("maximumByComponent with a result parameter that is an input parameter", function () {
-    const first = new Cartesian3(2.0, 0.0, 0.0);
-    const second = new Cartesian3(1.0, 0.0, 0.0);
-    const expected = new Cartesian3(2.0, 0.0, 0.0);
-    expect(Cartesian3.maximumByComponent(first, second, second)).toEqual(
       expected
     );
 
@@ -468,21 +442,11 @@ describe("Core/Cartesian3", function () {
     const max = new Cartesian3(1.0, 1.0, 1.0);
     const expected = new Cartesian3(0.0, 0.0, 0.0);
     expect(Cartesian3.clamp(value, min, max, value)).toEqual(expected);
-  });
 
-  it("clamp with a result parameter that is an input parameter", function () {
-    const value = new Cartesian3(-1.0, -1.0, -1.0);
-    const min = new Cartesian3(0.0, 0.0, 0.0);
-    const max = new Cartesian3(1.0, 1.0, 1.0);
-    const expected = new Cartesian3(0.0, 0.0, 0.0);
+    Cartesian3.fromElements(-1.0, -1.0, -1.0, value);
     expect(Cartesian3.clamp(value, min, max, min)).toEqual(expected);
-  });
 
-  it("clamp with a result parameter that is an input parameter", function () {
-    const value = new Cartesian3(-1.0, -1.0, -1.0);
-    const min = new Cartesian3(0.0, 0.0, 0.0);
-    const max = new Cartesian3(1.0, 1.0, 1.0);
-    const expected = new Cartesian3(0.0, 0.0, 0.0);
+    Cartesian3.fromElements(0.0, 0.0, 0.0, min);
     expect(Cartesian3.clamp(value, min, max, max)).toEqual(expected);
   });
 

--- a/Specs/Core/Cartesian3Spec.js
+++ b/Specs/Core/Cartesian3Spec.js
@@ -102,42 +102,62 @@ describe("Core/Cartesian3", function () {
   });
 
   it("minimumByComponent", function () {
-    let first = new Cartesian3(2.0, 0.0, 0.0);
-    let second = new Cartesian3(1.0, 0.0, 0.0);
-    let result = new Cartesian3(1.0, 0.0, 0.0);
+    let first;
+    let second;
+    let expected;
+    const result = new Cartesian3();
+
+    first = new Cartesian3(2.0, 0.0, 0.0);
+    second = new Cartesian3(1.0, 0.0, 0.0);
+    expected = new Cartesian3(1.0, 0.0, 0.0);
     expect(Cartesian3.minimumByComponent(first, second, result)).toEqual(
-      result
+      expected
     );
+
     first = new Cartesian3(1.0, 0.0, 0.0);
     second = new Cartesian3(2.0, 0.0, 0.0);
-    result = new Cartesian3(1.0, 0.0, 0.0);
+    expected = new Cartesian3(1.0, 0.0, 0.0);
     expect(Cartesian3.minimumByComponent(first, second, result)).toEqual(
-      result
+      expected
     );
+
     first = new Cartesian3(2.0, -15.0, 0.0);
     second = new Cartesian3(1.0, -20.0, 0.0);
-    result = new Cartesian3(1.0, -20.0, 0.0);
+    expected = new Cartesian3(1.0, -20.0, 0.0);
     expect(Cartesian3.minimumByComponent(first, second, result)).toEqual(
-      result
+      expected
     );
+
     first = new Cartesian3(2.0, -20.0, 0.0);
     second = new Cartesian3(1.0, -15.0, 0.0);
-    result = new Cartesian3(1.0, -20.0, 0.0);
+    expected = new Cartesian3(1.0, -20.0, 0.0);
     expect(Cartesian3.minimumByComponent(first, second, result)).toEqual(
-      result
+      expected
     );
+
     first = new Cartesian3(2.0, -15.0, 26.4);
     second = new Cartesian3(1.0, -20.0, 26.5);
-    result = new Cartesian3(1.0, -20.0, 26.4);
+    expected = new Cartesian3(1.0, -20.0, 26.4);
     expect(Cartesian3.minimumByComponent(first, second, result)).toEqual(
-      result
+      expected
     );
+
     first = new Cartesian3(2.0, -15.0, 26.5);
     second = new Cartesian3(1.0, -20.0, 26.4);
-    result = new Cartesian3(1.0, -20.0, 26.4);
+    expected = new Cartesian3(1.0, -20.0, 26.4);
     expect(Cartesian3.minimumByComponent(first, second, result)).toEqual(
-      result
+      expected
     );
+  });
+
+  it("minimumByComponent with a result parameter", function () {
+    const first = new Cartesian3(2.0, 0.0, 0.0);
+    const second = new Cartesian3(1.0, 0.0, 0.0);
+    const expected = new Cartesian3(1.0, 0.0, 0.0);
+    const result = new Cartesian3();
+    const returnedResult = Cartesian3.minimumByComponent(first, second, result);
+    expect(returnedResult).toBe(result);
+    expect(returnedResult).toEqual(expected);
   });
 
   it("minimumByComponent with a result parameter that is an input parameter", function () {
@@ -145,6 +165,7 @@ describe("Core/Cartesian3", function () {
     const second = new Cartesian3(1.0, 0.0, 0.0);
     const result = new Cartesian3(1.0, 0.0, 0.0);
     expect(Cartesian3.minimumByComponent(first, second, first)).toEqual(result);
+
     first.x = 1.0;
     second.x = 2.0;
     expect(Cartesian3.minimumByComponent(first, second, first)).toEqual(result);
@@ -157,6 +178,7 @@ describe("Core/Cartesian3", function () {
     expect(Cartesian3.minimumByComponent(first, second, second)).toEqual(
       result
     );
+
     first.x = 1.0;
     second.x = 2.0;
     expect(Cartesian3.minimumByComponent(first, second, second)).toEqual(
@@ -179,105 +201,137 @@ describe("Core/Cartesian3", function () {
   it("minimumByComponent works when first's or second's X is lesser", function () {
     const first = new Cartesian3(2.0, 0.0, 0.0);
     const second = new Cartesian3(1.0, 0.0, 0.0);
-    const result = new Cartesian3(1.0, 0.0, 0.0);
-    expect(
-      Cartesian3.minimumByComponent(first, second, new Cartesian3())
-    ).toEqual(result);
+    const expected = new Cartesian3(1.0, 0.0, 0.0);
+    const result = new Cartesian3();
+    expect(Cartesian3.minimumByComponent(first, second, result)).toEqual(
+      expected
+    );
+
     second.x = 3.0;
-    result.x = 2.0;
-    expect(
-      Cartesian3.minimumByComponent(first, second, new Cartesian3())
-    ).toEqual(result);
+    expected.x = 2.0;
+    expect(Cartesian3.minimumByComponent(first, second, result)).toEqual(
+      expected
+    );
   });
 
   it("minimumByComponent works when first's or second's Y is lesser", function () {
     const first = new Cartesian3(0.0, 2.0, 0.0);
     const second = new Cartesian3(0.0, 1.0, 0.0);
-    const result = new Cartesian3(0.0, 1.0, 0.0);
-    expect(
-      Cartesian3.minimumByComponent(first, second, new Cartesian3())
-    ).toEqual(result);
+    const expected = new Cartesian3(0.0, 1.0, 0.0);
+    const result = new Cartesian3();
+    expect(Cartesian3.minimumByComponent(first, second, result)).toEqual(
+      expected
+    );
+
     second.y = 3.0;
-    result.y = 2.0;
-    expect(
-      Cartesian3.minimumByComponent(first, second, new Cartesian3())
-    ).toEqual(result);
+    expected.y = 2.0;
+    expect(Cartesian3.minimumByComponent(first, second, result)).toEqual(
+      expected
+    );
   });
 
   it("minimumByComponent works when first's or second's Z is lesser", function () {
     const first = new Cartesian3(0.0, 0.0, 2.0);
     const second = new Cartesian3(0.0, 0.0, 1.0);
-    const result = new Cartesian3(0.0, 0.0, 1.0);
-    expect(
-      Cartesian3.minimumByComponent(first, second, new Cartesian3())
-    ).toEqual(result);
+    const expected = new Cartesian3(0.0, 0.0, 1.0);
+    const result = new Cartesian3();
+    expect(Cartesian3.minimumByComponent(first, second, result)).toEqual(
+      expected
+    );
+
     second.z = 3.0;
-    result.z = 2.0;
-    expect(
-      Cartesian3.minimumByComponent(first, second, new Cartesian3())
-    ).toEqual(result);
+    expected.z = 2.0;
+    expect(Cartesian3.minimumByComponent(first, second, result)).toEqual(
+      expected
+    );
   });
 
   it("maximumByComponent", function () {
-    let first = new Cartesian3(2.0, 0.0, 0.0);
-    let second = new Cartesian3(1.0, 0.0, 0.0);
-    let result = new Cartesian3(2.0, 0.0, 0.0);
+    let first;
+    let second;
+    let expected;
+    const result = new Cartesian3();
+
+    first = new Cartesian3(2.0, 0.0, 0.0);
+    second = new Cartesian3(1.0, 0.0, 0.0);
+    expected = new Cartesian3(2.0, 0.0, 0.0);
     expect(Cartesian3.maximumByComponent(first, second, result)).toEqual(
-      result
+      expected
     );
+
     first = new Cartesian3(1.0, 0.0, 0.0);
     second = new Cartesian3(2.0, 0.0, 0.0);
-    result = new Cartesian3(2.0, 0.0, 0.0);
+    expected = new Cartesian3(2.0, 0.0, 0.0);
     expect(Cartesian3.maximumByComponent(first, second, result)).toEqual(
-      result
+      expected
     );
+
     first = new Cartesian3(2.0, -15.0, 0.0);
     second = new Cartesian3(1.0, -20.0, 0.0);
-    result = new Cartesian3(2.0, -15.0, 0.0);
+    expected = new Cartesian3(2.0, -15.0, 0.0);
     expect(Cartesian3.maximumByComponent(first, second, result)).toEqual(
-      result
+      expected
     );
+
     first = new Cartesian3(2.0, -20.0, 0.0);
     second = new Cartesian3(1.0, -15.0, 0.0);
-    result = new Cartesian3(2.0, -15.0, 0.0);
+    expected = new Cartesian3(2.0, -15.0, 0.0);
     expect(Cartesian3.maximumByComponent(first, second, result)).toEqual(
-      result
+      expected
     );
+
     first = new Cartesian3(2.0, -15.0, 26.4);
     second = new Cartesian3(1.0, -20.0, 26.5);
-    result = new Cartesian3(2.0, -15.0, 26.5);
+    expected = new Cartesian3(2.0, -15.0, 26.5);
     expect(Cartesian3.maximumByComponent(first, second, result)).toEqual(
-      result
+      expected
     );
+
     first = new Cartesian3(2.0, -15.0, 26.5);
     second = new Cartesian3(1.0, -20.0, 26.4);
-    result = new Cartesian3(2.0, -15.0, 26.5);
+    expected = new Cartesian3(2.0, -15.0, 26.5);
     expect(Cartesian3.maximumByComponent(first, second, result)).toEqual(
-      result
+      expected
+    );
+  });
+
+  it("maximumByComponent with a result parameter", function () {
+    const first = new Cartesian3(2.0, 0.0, 0.0);
+    const second = new Cartesian3(1.0, 0.0, 0.0);
+    const expected = new Cartesian3(2.0, 0.0, 0.0);
+    const result = new Cartesian3();
+    const returnedResult = Cartesian3.maximumByComponent(first, second, result);
+    expect(returnedResult).toBe(result);
+    expect(returnedResult).toEqual(expected);
+  });
+
+  it("maximumByComponent with a result parameter that is an input parameter", function () {
+    const first = new Cartesian3(2.0, 0.0, 0.0);
+    const second = new Cartesian3(1.0, 0.0, 0.0);
+    const expected = new Cartesian3(2.0, 0.0, 0.0);
+    expect(Cartesian3.maximumByComponent(first, second, first)).toEqual(
+      expected
+    );
+
+    first.x = 1.0;
+    second.x = 2.0;
+    expect(Cartesian3.maximumByComponent(first, second, first)).toEqual(
+      expected
     );
   });
 
   it("maximumByComponent with a result parameter that is an input parameter", function () {
     const first = new Cartesian3(2.0, 0.0, 0.0);
     const second = new Cartesian3(1.0, 0.0, 0.0);
-    const result = new Cartesian3(2.0, 0.0, 0.0);
-    expect(Cartesian3.maximumByComponent(first, second, first)).toEqual(result);
-    first.x = 1.0;
-    second.x = 2.0;
-    expect(Cartesian3.maximumByComponent(first, second, first)).toEqual(result);
-  });
-
-  it("maximumByComponent with a result parameter that is an input parameter", function () {
-    const first = new Cartesian3(2.0, 0.0, 0.0);
-    const second = new Cartesian3(1.0, 0.0, 0.0);
-    const result = new Cartesian3(2.0, 0.0, 0.0);
+    const expected = new Cartesian3(2.0, 0.0, 0.0);
     expect(Cartesian3.maximumByComponent(first, second, second)).toEqual(
-      result
+      expected
     );
+
     first.x = 1.0;
     second.x = 2.0;
     expect(Cartesian3.maximumByComponent(first, second, second)).toEqual(
-      result
+      expected
     );
   });
 
@@ -296,43 +350,158 @@ describe("Core/Cartesian3", function () {
   it("maximumByComponent works when first's or second's X is greater", function () {
     const first = new Cartesian3(2.0, 0.0, 0.0);
     const second = new Cartesian3(1.0, 0.0, 0.0);
-    const result = new Cartesian3(2.0, 0.0, 0.0);
+    const expected = new Cartesian3(2.0, 0.0, 0.0);
+    const result = new Cartesian3();
     expect(Cartesian3.maximumByComponent(first, second, result)).toEqual(
-      result
+      expected
     );
+
     second.x = 3.0;
-    result.x = 3.0;
+    expected.x = 3.0;
     expect(Cartesian3.maximumByComponent(first, second, result)).toEqual(
-      result
+      expected
     );
   });
 
   it("maximumByComponent works when first's or second's Y is greater", function () {
     const first = new Cartesian3(0.0, 2.0, 0.0);
     const second = new Cartesian3(0.0, 1.0, 0.0);
-    const result = new Cartesian3(0.0, 2.0, 0.0);
+    const expected = new Cartesian3(0.0, 2.0, 0.0);
+    const result = new Cartesian3();
     expect(Cartesian3.maximumByComponent(first, second, result)).toEqual(
-      result
+      expected
     );
+
     second.y = 3.0;
-    result.y = 3.0;
+    expected.y = 3.0;
     expect(Cartesian3.maximumByComponent(first, second, result)).toEqual(
-      result
+      expected
     );
   });
 
   it("maximumByComponent works when first's or second's Z is greater", function () {
     const first = new Cartesian3(0.0, 0.0, 2.0);
     const second = new Cartesian3(0.0, 0.0, 1.0);
-    const result = new Cartesian3(0.0, 0.0, 2.0);
+    const expected = new Cartesian3(0.0, 0.0, 2.0);
+    const result = new Cartesian3();
     expect(Cartesian3.maximumByComponent(first, second, result)).toEqual(
-      result
+      expected
     );
+
     second.z = 3.0;
-    result.z = 3.0;
+    expected.z = 3.0;
     expect(Cartesian3.maximumByComponent(first, second, result)).toEqual(
-      result
+      expected
     );
+  });
+
+  it("clamp", function () {
+    let value;
+    let min;
+    let max;
+    let expected;
+    const result = new Cartesian3();
+
+    value = new Cartesian3(-1.0, 0.0, 0.0);
+    min = new Cartesian3(0.0, 0.0, 0.0);
+    max = new Cartesian3(1.0, 1.0, 1.0);
+    expected = new Cartesian3(0.0, 0.0, 0.0);
+    expect(Cartesian3.clamp(value, min, max, result)).toEqual(expected);
+
+    value = new Cartesian3(2.0, 0.0, 0.0);
+    min = new Cartesian3(0.0, 0.0, 0.0);
+    max = new Cartesian3(1.0, 1.0, 1.0);
+    expected = new Cartesian3(1.0, 0.0, 0.0);
+    expect(Cartesian3.clamp(value, min, max, result)).toEqual(expected);
+
+    value = new Cartesian3(0.0, -1.0, 0.0);
+    min = new Cartesian3(0.0, 0.0, 0.0);
+    max = new Cartesian3(1.0, 1.0, 1.0);
+    expected = new Cartesian3(0.0, 0.0, 0.0);
+    expect(Cartesian3.clamp(value, min, max, result)).toEqual(expected);
+
+    value = new Cartesian3(0.0, 2.0, 0.0);
+    min = new Cartesian3(0.0, 0.0, 0.0);
+    max = new Cartesian3(1.0, 1.0, 1.0);
+    expected = new Cartesian3(0.0, 1.0, 0.0);
+    expect(Cartesian3.clamp(value, min, max, result)).toEqual(expected);
+
+    value = new Cartesian3(0.0, 0.0, -1.0);
+    min = new Cartesian3(0.0, 0.0, 0.0);
+    max = new Cartesian3(1.0, 1.0, 1.0);
+    expected = new Cartesian3(0.0, 0.0, 0.0);
+    expect(Cartesian3.clamp(value, min, max, result)).toEqual(expected);
+
+    value = new Cartesian3(0.0, 0.0, 2.0);
+    min = new Cartesian3(0.0, 0.0, 0.0);
+    max = new Cartesian3(1.0, 1.0, 1.0);
+    expected = new Cartesian3(0.0, 0.0, 1.0);
+    expect(Cartesian3.clamp(value, min, max, result)).toEqual(expected);
+
+    value = new Cartesian3(-2.0, 3.0, 4.0);
+    min = new Cartesian3(0.0, 0.0, 0.0);
+    max = new Cartesian3(1.0, 1.0, 1.0);
+    expected = new Cartesian3(0.0, 1.0, 1.0);
+    expect(Cartesian3.clamp(value, min, max, result)).toEqual(expected);
+
+    value = new Cartesian3(0.0, 0.0, 0.0);
+    min = new Cartesian3(1.0, 2.0, 3.0);
+    max = new Cartesian3(1.0, 2.0, 3.0);
+    expected = new Cartesian3(1.0, 2.0, 3.0);
+    expect(Cartesian3.clamp(value, min, max, result)).toEqual(expected);
+  });
+
+  it("clamp with a result parameter", function () {
+    const value = new Cartesian3(-1.0, -1.0, -1.0);
+    const min = new Cartesian3(0.0, 0.0, 0.0);
+    const max = new Cartesian3(1.0, 1.0, 1.0);
+    const expected = new Cartesian3(0.0, 0.0, 0.0);
+    const result = new Cartesian3();
+    const returnedResult = Cartesian3.clamp(value, min, max, result);
+    expect(returnedResult).toBe(result);
+    expect(returnedResult).toEqual(expected);
+  });
+
+  it("clamp with a result parameter that is an input parameter", function () {
+    const value = new Cartesian3(-1.0, -1.0, -1.0);
+    const min = new Cartesian3(0.0, 0.0, 0.0);
+    const max = new Cartesian3(1.0, 1.0, 1.0);
+    const expected = new Cartesian3(0.0, 0.0, 0.0);
+    expect(Cartesian3.clamp(value, min, max, value)).toEqual(expected);
+  });
+
+  it("clamp with a result parameter that is an input parameter", function () {
+    const value = new Cartesian3(-1.0, -1.0, -1.0);
+    const min = new Cartesian3(0.0, 0.0, 0.0);
+    const max = new Cartesian3(1.0, 1.0, 1.0);
+    const expected = new Cartesian3(0.0, 0.0, 0.0);
+    expect(Cartesian3.clamp(value, min, max, min)).toEqual(expected);
+  });
+
+  it("clamp with a result parameter that is an input parameter", function () {
+    const value = new Cartesian3(-1.0, -1.0, -1.0);
+    const min = new Cartesian3(0.0, 0.0, 0.0);
+    const max = new Cartesian3(1.0, 1.0, 1.0);
+    const expected = new Cartesian3(0.0, 0.0, 0.0);
+    expect(Cartesian3.clamp(value, min, max, max)).toEqual(expected);
+  });
+
+  it("clamp throws without value", function () {
+    expect(function () {
+      Cartesian3.clamp();
+    }).toThrowDeveloperError();
+  });
+
+  it("clamp throws without min", function () {
+    expect(function () {
+      Cartesian3.clamp(new Cartesian3());
+    }).toThrowDeveloperError();
+  });
+
+  it("clamp throws without max", function () {
+    expect(function () {
+      Cartesian3.clamp(new Cartesian3(), new Cartesian3());
+    }).toThrowDeveloperError();
   });
 
   it("magnitudeSquared", function () {
@@ -1363,6 +1532,12 @@ describe("Core/Cartesian3", function () {
   it("maximumByComponent throws with no result", function () {
     expect(function () {
       Cartesian3.maximumByComponent(new Cartesian3(), new Cartesian3());
+    }).toThrowDeveloperError();
+  });
+
+  it("clamp throws with no result", function () {
+    expect(function () {
+      Cartesian3.clamp(new Cartesian3(), new Cartesian3(), new Cartesian3());
     }).toThrowDeveloperError();
   });
 

--- a/Specs/Core/Cartesian4Spec.js
+++ b/Specs/Core/Cartesian4Spec.js
@@ -140,50 +140,61 @@ describe("Core/Cartesian4", function () {
     expect(Cartesian4.minimumComponent(cartesian)).toEqual(cartesian.w);
   });
 
-  it("minimumByComponent without a result parameter", function () {
-    let first = new Cartesian4(2.0, 0.0, 0.0, 0.0);
-    let second = new Cartesian4(1.0, 0.0, 0.0, 0.0);
+  it("minimumByComponent", function () {
+    let first;
+    let second;
+    let expected;
     const result = new Cartesian4();
-    let expected = new Cartesian4(1.0, 0.0, 0.0, 0.0);
+
+    first = new Cartesian4(2.0, 0.0, 0.0, 0.0);
+    second = new Cartesian4(1.0, 0.0, 0.0, 0.0);
+    expected = new Cartesian4(1.0, 0.0, 0.0, 0.0);
     expect(Cartesian4.minimumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian4(1.0, 0.0, 0.0, 0.0);
     second = new Cartesian4(2.0, 0.0, 0.0, 0.0);
     expected = new Cartesian4(1.0, 0.0, 0.0, 0.0);
     expect(Cartesian4.minimumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian4(2.0, -15.0, 0.0, 0.0);
     second = new Cartesian4(1.0, -20.0, 0.0, 0.0);
     expected = new Cartesian4(1.0, -20.0, 0.0, 0.0);
     expect(Cartesian4.minimumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian4(2.0, -20.0, 0.0, 0.0);
     second = new Cartesian4(1.0, -15.0, 0.0, 0.0);
     expected = new Cartesian4(1.0, -20.0, 0.0, 0.0);
     expect(Cartesian4.minimumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian4(2.0, -15.0, 26.4, 0.0);
     second = new Cartesian4(1.0, -20.0, 26.5, 0.0);
     expected = new Cartesian4(1.0, -20.0, 26.4, 0.0);
     expect(Cartesian4.minimumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian4(2.0, -15.0, 26.5, 0.0);
     second = new Cartesian4(1.0, -20.0, 26.4, 0.0);
     expected = new Cartesian4(1.0, -20.0, 26.4, 0.0);
     expect(Cartesian4.minimumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian4(2.0, -15.0, 26.4, -450.0);
     second = new Cartesian4(1.0, -20.0, 26.5, 450.0);
     expected = new Cartesian4(1.0, -20.0, 26.4, -450.0);
     expect(Cartesian4.minimumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian4(2.0, -15.0, 26.5, 450.0);
     second = new Cartesian4(1.0, -20.0, 26.4, -450.0);
     expected = new Cartesian4(1.0, -20.0, 26.4, -450.0);
@@ -195,33 +206,40 @@ describe("Core/Cartesian4", function () {
   it("minimumByComponent with a result parameter", function () {
     const first = new Cartesian4(2.0, 0.0, 0.0, 0.0);
     const second = new Cartesian4(1.0, 0.0, 0.0, 0.0);
+    const expected = new Cartesian4(1.0, 0.0, 0.0, 0.0);
     const result = new Cartesian4();
     const returnedResult = Cartesian4.minimumByComponent(first, second, result);
     expect(returnedResult).toBe(result);
-    expect(returnedResult).toEqual(result);
+    expect(returnedResult).toEqual(expected);
   });
 
   it("minimumByComponent with a result parameter that is an input parameter", function () {
     const first = new Cartesian4(2.0, 0.0, 0.0, 0.0);
     const second = new Cartesian4(1.0, 0.0, 0.0, 0.0);
-    const result = new Cartesian4(1.0, 0.0, 0.0, 0.0);
-    expect(Cartesian4.minimumByComponent(first, second, first)).toEqual(result);
-    first.x = 1.0;
-    second.x = 2.0;
-    expect(Cartesian4.minimumByComponent(first, second, first)).toEqual(result);
-  });
-
-  it("minimumByComponent with a result parameter that is an input parameter", function () {
-    const first = new Cartesian4(2.0, 0.0, 0.0, 0.0);
-    const second = new Cartesian4(1.0, 0.0, 0.0, 0.0);
-    const result = new Cartesian4(1.0, 0.0, 0.0, 0.0);
-    expect(Cartesian4.minimumByComponent(first, second, second)).toEqual(
-      result
+    const expected = new Cartesian4(1.0, 0.0, 0.0, 0.0);
+    expect(Cartesian4.minimumByComponent(first, second, first)).toEqual(
+      expected
     );
+
+    first.x = 1.0;
+    second.x = 2.0;
+    expect(Cartesian4.minimumByComponent(first, second, first)).toEqual(
+      expected
+    );
+  });
+
+  it("minimumByComponent with a result parameter that is an input parameter", function () {
+    const first = new Cartesian4(2.0, 0.0, 0.0, 0.0);
+    const second = new Cartesian4(1.0, 0.0, 0.0, 0.0);
+    const expected = new Cartesian4(1.0, 0.0, 0.0, 0.0);
+    expect(Cartesian4.minimumByComponent(first, second, second)).toEqual(
+      expected
+    );
+
     first.x = 1.0;
     second.x = 2.0;
     expect(Cartesian4.minimumByComponent(first, second, second)).toEqual(
-      result
+      expected
     );
   });
 
@@ -240,91 +258,122 @@ describe("Core/Cartesian4", function () {
   it("minimumByComponent works when first's or second's X is lesser", function () {
     const first = new Cartesian4(2.0, 0.0, 0.0, 0.0);
     const second = new Cartesian4(1.0, 0.0, 0.0, 0.0);
-    const result = new Cartesian4(1.0, 0.0, 0.0, 0.0);
-    const r = new Cartesian4();
-    expect(Cartesian4.minimumByComponent(first, second, r)).toEqual(result);
+    const expected = new Cartesian4(1.0, 0.0, 0.0, 0.0);
+    const result = new Cartesian4();
+    expect(Cartesian4.minimumByComponent(first, second, result)).toEqual(
+      expected
+    );
+
     second.x = 3.0;
-    result.x = 2.0;
-    expect(Cartesian4.minimumByComponent(first, second, r)).toEqual(result);
+    expected.x = 2.0;
+    expect(Cartesian4.minimumByComponent(first, second, result)).toEqual(
+      expected
+    );
   });
 
   it("minimumByComponent works when first's or second's Y is lesser", function () {
     const first = new Cartesian4(0.0, 2.0, 0.0, 0.0);
     const second = new Cartesian4(0.0, 1.0, 0.0, 0.0);
-    const result = new Cartesian4(0.0, 1.0, 0.0, 0.0);
-    const r = new Cartesian4();
-    expect(Cartesian4.minimumByComponent(first, second, r)).toEqual(result);
+    const expected = new Cartesian4(0.0, 1.0, 0.0, 0.0);
+    const result = new Cartesian4();
+    expect(Cartesian4.minimumByComponent(first, second, result)).toEqual(
+      expected
+    );
+
     second.y = 3.0;
-    result.y = 2.0;
-    expect(Cartesian4.minimumByComponent(first, second, r)).toEqual(result);
+    expected.y = 2.0;
+    expect(Cartesian4.minimumByComponent(first, second, result)).toEqual(
+      expected
+    );
   });
 
   it("minimumByComponent works when first's or second's Z is lesser", function () {
     const first = new Cartesian4(0.0, 0.0, 2.0, 0.0);
     const second = new Cartesian4(0.0, 0.0, 1.0, 0.0);
-    const result = new Cartesian4(0.0, 0.0, 1.0, 0.0);
-    const r = new Cartesian4();
-    expect(Cartesian4.minimumByComponent(first, second, r)).toEqual(result);
+    const expected = new Cartesian4(0.0, 0.0, 1.0, 0.0);
+    const result = new Cartesian4();
+    expect(Cartesian4.minimumByComponent(first, second, result)).toEqual(
+      expected
+    );
+
     second.z = 3.0;
-    result.z = 2.0;
-    expect(Cartesian4.minimumByComponent(first, second, r)).toEqual(result);
+    expected.z = 2.0;
+    expect(Cartesian4.minimumByComponent(first, second, result)).toEqual(
+      expected
+    );
   });
 
   it("minimumByComponent works when first's or second's W is lesser", function () {
     const first = new Cartesian4(0.0, 0.0, 0.0, 2.0);
     const second = new Cartesian4(0.0, 0.0, 0.0, 1.0);
-    const result = new Cartesian4(0.0, 0.0, 0.0, 1.0);
-    const r = new Cartesian4();
-    expect(Cartesian4.minimumByComponent(first, second, r)).toEqual(result);
+    const expected = new Cartesian4(0.0, 0.0, 0.0, 1.0);
+    const result = new Cartesian4();
+    expect(Cartesian4.minimumByComponent(first, second, result)).toEqual(
+      expected
+    );
+
     second.w = 3.0;
-    result.w = 2.0;
-    expect(Cartesian4.minimumByComponent(first, second, r)).toEqual(result);
+    expected.w = 2.0;
+    expect(Cartesian4.minimumByComponent(first, second, result)).toEqual(
+      expected
+    );
   });
 
   it("maximumByComponent", function () {
-    let first = new Cartesian4(2.0, 0.0, 0.0, 0.0);
-    let second = new Cartesian4(1.0, 0.0, 0.0, 0.0);
+    let first;
+    let second;
+    let expected;
+
+    first = new Cartesian4(2.0, 0.0, 0.0, 0.0);
+    second = new Cartesian4(1.0, 0.0, 0.0, 0.0);
+    expected = new Cartesian4(2.0, 0.0, 0.0, 0.0);
     const result = new Cartesian4();
-    let expected = new Cartesian4(2.0, 0.0, 0.0, 0.0);
     expect(Cartesian4.maximumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian4(1.0, 0.0, 0.0, 0.0);
     second = new Cartesian4(2.0, 0.0, 0.0, 0.0);
     expected = new Cartesian4(2.0, 0.0, 0.0, 0.0);
     expect(Cartesian4.maximumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian4(2.0, -15.0, 0.0, 0.0);
     second = new Cartesian4(1.0, -20.0, 0.0, 0.0);
     expected = new Cartesian4(2.0, -15.0, 0.0, 0.0);
     expect(Cartesian4.maximumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian4(2.0, -20.0, 0.0, 0.0);
     second = new Cartesian4(1.0, -15.0, 0.0, 0.0);
     expected = new Cartesian4(2.0, -15.0, 0.0, 0.0);
     expect(Cartesian4.maximumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian4(2.0, -15.0, 26.4, 0.0);
     second = new Cartesian4(1.0, -20.0, 26.5, 0.0);
     expected = new Cartesian4(2.0, -15.0, 26.5, 0.0);
     expect(Cartesian4.maximumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian4(2.0, -15.0, 26.5, 0.0);
     second = new Cartesian4(1.0, -20.0, 26.4, 0.0);
     expected = new Cartesian4(2.0, -15.0, 26.5, 0.0);
     expect(Cartesian4.maximumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian4(2.0, -15.0, 26.5, 450.0);
     second = new Cartesian4(1.0, -20.0, 26.4, -450.0);
     expected = new Cartesian4(2.0, -15.0, 26.5, 450.0);
     expect(Cartesian4.maximumByComponent(first, second, result)).toEqual(
       expected
     );
+
     first = new Cartesian4(2.0, -15.0, 26.5, -450.0);
     second = new Cartesian4(1.0, -20.0, 26.4, 450.0);
     expected = new Cartesian4(2.0, -15.0, 26.5, 450.0);
@@ -333,27 +382,43 @@ describe("Core/Cartesian4", function () {
     );
   });
 
-  it("maximumByComponent with a result parameter that is an input parameter", function () {
+  it("maximumByComponent with a result parameter", function () {
     const first = new Cartesian4(2.0, 0.0, 0.0, 0.0);
     const second = new Cartesian4(1.0, 0.0, 0.0, 0.0);
-    const result = new Cartesian4(2.0, 0.0, 0.0, 0.0);
-    expect(Cartesian4.maximumByComponent(first, second, first)).toEqual(result);
-    first.x = 1.0;
-    second.x = 2.0;
-    expect(Cartesian4.maximumByComponent(first, second, first)).toEqual(result);
+    const expected = new Cartesian4(2.0, 0.0, 0.0, 0.0);
+    const result = new Cartesian4();
+    const returnedResult = Cartesian4.maximumByComponent(first, second, result);
+    expect(returnedResult).toBe(result);
+    expect(returnedResult).toEqual(expected);
   });
 
   it("maximumByComponent with a result parameter that is an input parameter", function () {
     const first = new Cartesian4(2.0, 0.0, 0.0, 0.0);
     const second = new Cartesian4(1.0, 0.0, 0.0, 0.0);
-    const result = new Cartesian4(2.0, 0.0, 0.0, 0.0);
-    expect(Cartesian4.maximumByComponent(first, second, second)).toEqual(
-      result
+    const expected = new Cartesian4(2.0, 0.0, 0.0, 0.0);
+    expect(Cartesian4.maximumByComponent(first, second, first)).toEqual(
+      expected
     );
+
+    first.x = 1.0;
+    second.x = 2.0;
+    expect(Cartesian4.maximumByComponent(first, second, first)).toEqual(
+      expected
+    );
+  });
+
+  it("maximumByComponent with a result parameter that is an input parameter", function () {
+    const first = new Cartesian4(2.0, 0.0, 0.0, 0.0);
+    const second = new Cartesian4(1.0, 0.0, 0.0, 0.0);
+    const expected = new Cartesian4(2.0, 0.0, 0.0, 0.0);
+    expect(Cartesian4.maximumByComponent(first, second, second)).toEqual(
+      expected
+    );
+
     first.x = 1.0;
     second.x = 2.0;
     expect(Cartesian4.maximumByComponent(first, second, second)).toEqual(
-      result
+      expected
     );
   });
 
@@ -372,45 +437,174 @@ describe("Core/Cartesian4", function () {
   it("maximumByComponent works when first's or second's X is greater", function () {
     const first = new Cartesian4(2.0, 0.0, 0.0, 0.0);
     const second = new Cartesian4(1.0, 0.0, 0.0, 0.0);
-    const result = new Cartesian4(2.0, 0.0, 0.0, 0.0);
-    const r = new Cartesian4();
-    expect(Cartesian4.maximumByComponent(first, second, r)).toEqual(result);
+    const expected = new Cartesian4(2.0, 0.0, 0.0, 0.0);
+    const result = new Cartesian4();
+    expect(Cartesian4.maximumByComponent(first, second, result)).toEqual(
+      expected
+    );
+
     second.x = 3.0;
-    result.x = 3.0;
-    expect(Cartesian4.maximumByComponent(first, second, r)).toEqual(result);
+    expected.x = 3.0;
+    expect(Cartesian4.maximumByComponent(first, second, result)).toEqual(
+      expected
+    );
   });
 
   it("maximumByComponent works when first's or second's Y is greater", function () {
     const first = new Cartesian4(0.0, 2.0, 0.0, 0.0);
     const second = new Cartesian4(0.0, 1.0, 0.0, 0.0);
-    const result = new Cartesian4(0.0, 2.0, 0.0, 0.0);
-    const r = new Cartesian4();
-    expect(Cartesian4.maximumByComponent(first, second, r)).toEqual(result);
+    const expected = new Cartesian4(0.0, 2.0, 0.0, 0.0);
+    const result = new Cartesian4();
+    expect(Cartesian4.maximumByComponent(first, second, result)).toEqual(
+      expected
+    );
+
     second.y = 3.0;
-    result.y = 3.0;
-    expect(Cartesian4.maximumByComponent(first, second, r)).toEqual(result);
+    expected.y = 3.0;
+    expect(Cartesian4.maximumByComponent(first, second, result)).toEqual(
+      expected
+    );
   });
 
   it("maximumByComponent works when first's or second's Z is greater", function () {
     const first = new Cartesian4(0.0, 0.0, 2.0, 0.0);
     const second = new Cartesian4(0.0, 0.0, 1.0, 0.0);
-    const result = new Cartesian4(0.0, 0.0, 2.0, 0.0);
-    const r = new Cartesian4();
-    expect(Cartesian4.maximumByComponent(first, second, r)).toEqual(result);
+    const expected = new Cartesian4(0.0, 0.0, 2.0, 0.0);
+    const result = new Cartesian4();
+    expect(Cartesian4.maximumByComponent(first, second, result)).toEqual(
+      expected
+    );
+
     second.z = 3.0;
-    result.z = 3.0;
-    expect(Cartesian4.maximumByComponent(first, second, r)).toEqual(result);
+    expected.z = 3.0;
+    expect(Cartesian4.maximumByComponent(first, second, result)).toEqual(
+      expected
+    );
   });
 
   it("maximumByComponent works when first's or second's W is greater", function () {
     const first = new Cartesian4(0.0, 0.0, 0.0, 2.0);
     const second = new Cartesian4(0.0, 0.0, 0.0, 1.0);
-    const result = new Cartesian4(0.0, 0.0, 0.0, 2.0);
-    const r = new Cartesian4();
-    expect(Cartesian4.maximumByComponent(first, second, r)).toEqual(result);
+    const expected = new Cartesian4(0.0, 0.0, 0.0, 2.0);
+    const result = new Cartesian4();
+    expect(Cartesian4.maximumByComponent(first, second, result)).toEqual(
+      expected
+    );
+
     second.w = 3.0;
-    result.w = 3.0;
-    expect(Cartesian4.maximumByComponent(first, second, r)).toEqual(result);
+    expected.w = 3.0;
+    expect(Cartesian4.maximumByComponent(first, second, result)).toEqual(
+      expected
+    );
+  });
+
+  it("clamp", function () {
+    let value;
+    let min;
+    let max;
+    let expected;
+    const result = new Cartesian4();
+
+    value = new Cartesian4(-1.0, 0.0, 0.0);
+    min = new Cartesian4(0.0, 0.0, 0.0);
+    max = new Cartesian4(1.0, 1.0, 1.0);
+    expected = new Cartesian4(0.0, 0.0, 0.0);
+    expect(Cartesian4.clamp(value, min, max, result)).toEqual(expected);
+
+    value = new Cartesian4(2.0, 0.0, 0.0);
+    min = new Cartesian4(0.0, 0.0, 0.0);
+    max = new Cartesian4(1.0, 1.0, 1.0);
+    expected = new Cartesian4(1.0, 0.0, 0.0);
+    expect(Cartesian4.clamp(value, min, max, result)).toEqual(expected);
+
+    value = new Cartesian4(0.0, -1.0, 0.0);
+    min = new Cartesian4(0.0, 0.0, 0.0);
+    max = new Cartesian4(1.0, 1.0, 1.0);
+    expected = new Cartesian4(0.0, 0.0, 0.0);
+    expect(Cartesian4.clamp(value, min, max, result)).toEqual(expected);
+
+    value = new Cartesian4(0.0, 2.0, 0.0);
+    min = new Cartesian4(0.0, 0.0, 0.0);
+    max = new Cartesian4(1.0, 1.0, 1.0);
+    expected = new Cartesian4(0.0, 1.0, 0.0);
+    expect(Cartesian4.clamp(value, min, max, result)).toEqual(expected);
+
+    value = new Cartesian4(0.0, 0.0, -1.0);
+    min = new Cartesian4(0.0, 0.0, 0.0);
+    max = new Cartesian4(1.0, 1.0, 1.0);
+    expected = new Cartesian4(0.0, 0.0, 0.0);
+    expect(Cartesian4.clamp(value, min, max, result)).toEqual(expected);
+
+    value = new Cartesian4(0.0, 0.0, 2.0);
+    min = new Cartesian4(0.0, 0.0, 0.0);
+    max = new Cartesian4(1.0, 1.0, 1.0);
+    expected = new Cartesian4(0.0, 0.0, 1.0);
+    expect(Cartesian4.clamp(value, min, max, result)).toEqual(expected);
+
+    value = new Cartesian4(-2.0, 3.0, 4.0);
+    min = new Cartesian4(0.0, 0.0, 0.0);
+    max = new Cartesian4(1.0, 1.0, 1.0);
+    expected = new Cartesian4(0.0, 1.0, 1.0);
+    expect(Cartesian4.clamp(value, min, max, result)).toEqual(expected);
+
+    value = new Cartesian4(0.0, 0.0, 0.0);
+    min = new Cartesian4(1.0, 2.0, 3.0);
+    max = new Cartesian4(1.0, 2.0, 3.0);
+    expected = new Cartesian4(1.0, 2.0, 3.0);
+    expect(Cartesian4.clamp(value, min, max, result)).toEqual(expected);
+  });
+
+  it("clamp with a result parameter", function () {
+    const value = new Cartesian4(-1.0, -1.0, -1.0, -1.0);
+    const min = new Cartesian4(0.0, 0.0, 0.0, 0.0);
+    const max = new Cartesian4(1.0, 1.0, 1.0, 1.0);
+    const expected = new Cartesian4(0.0, 0.0, 0.0, 0.0);
+    const result = new Cartesian4();
+    const returnedResult = Cartesian4.clamp(value, min, max, result);
+    expect(returnedResult).toBe(result);
+    expect(returnedResult).toEqual(expected);
+  });
+
+  it("clamp with a result parameter that is an input parameter", function () {
+    const value = new Cartesian4(-1.0, -1.0, -1.0, -1.0);
+    const min = new Cartesian4(0.0, 0.0, 0.0, 0.0);
+    const max = new Cartesian4(1.0, 1.0, 1.0, 1.0);
+    const expected = new Cartesian4(0.0, 0.0, 0.0, 0.0);
+    expect(Cartesian4.clamp(value, min, max, value)).toEqual(expected);
+  });
+
+  it("clamp with a result parameter that is an input parameter", function () {
+    const value = new Cartesian4(-1.0, -1.0, -1.0, -1.0);
+    const min = new Cartesian4(0.0, 0.0, 0.0, 0.0);
+    const max = new Cartesian4(1.0, 1.0, 1.0, 1.0);
+    const expected = new Cartesian4(0.0, 0.0, 0.0, 0.0);
+    expect(Cartesian4.clamp(value, min, max, min)).toEqual(expected);
+  });
+
+  it("clamp with a result parameter that is an input parameter", function () {
+    const value = new Cartesian4(-1.0, -1.0, -1.0, -1.0);
+    const min = new Cartesian4(0.0, 0.0, 0.0, 0.0);
+    const max = new Cartesian4(1.0, 1.0, 1.0, 1.0);
+    const expected = new Cartesian4(0.0, 0.0, 0.0, 0.0);
+    expect(Cartesian4.clamp(value, min, max, max)).toEqual(expected);
+  });
+
+  it("clamp throws without value", function () {
+    expect(function () {
+      Cartesian4.clamp();
+    }).toThrowDeveloperError();
+  });
+
+  it("clamp throws without min", function () {
+    expect(function () {
+      Cartesian4.clamp(new Cartesian4());
+    }).toThrowDeveloperError();
+  });
+
+  it("clamp throws without max", function () {
+    expect(function () {
+      Cartesian4.clamp(new Cartesian4(), new Cartesian4());
+    }).toThrowDeveloperError();
   });
 
   it("magnitudeSquared", function () {
@@ -1024,6 +1218,12 @@ describe("Core/Cartesian4", function () {
   it("maximumByComponent throws with no result", function () {
     expect(function () {
       Cartesian4.maximumByComponent(new Cartesian4(), new Cartesian4());
+    }).toThrowDeveloperError();
+  });
+
+  it("clamp throws with no result", function () {
+    expect(function () {
+      Cartesian4.clamp(new Cartesian4(), new Cartesian4(), new Cartesian4());
     }).toThrowDeveloperError();
   });
 

--- a/Specs/Core/Cartesian4Spec.js
+++ b/Specs/Core/Cartesian4Spec.js
@@ -223,21 +223,6 @@ describe("Core/Cartesian4", function () {
 
     first.x = 1.0;
     second.x = 2.0;
-    expect(Cartesian4.minimumByComponent(first, second, first)).toEqual(
-      expected
-    );
-  });
-
-  it("minimumByComponent with a result parameter that is an input parameter", function () {
-    const first = new Cartesian4(2.0, 0.0, 0.0, 0.0);
-    const second = new Cartesian4(1.0, 0.0, 0.0, 0.0);
-    const expected = new Cartesian4(1.0, 0.0, 0.0, 0.0);
-    expect(Cartesian4.minimumByComponent(first, second, second)).toEqual(
-      expected
-    );
-
-    first.x = 1.0;
-    second.x = 2.0;
     expect(Cartesian4.minimumByComponent(first, second, second)).toEqual(
       expected
     );
@@ -402,7 +387,7 @@ describe("Core/Cartesian4", function () {
 
     first.x = 1.0;
     second.x = 2.0;
-    expect(Cartesian4.maximumByComponent(first, second, first)).toEqual(
+    expect(Cartesian4.maximumByComponent(first, second, second)).toEqual(
       expected
     );
   });
@@ -571,21 +556,11 @@ describe("Core/Cartesian4", function () {
     const max = new Cartesian4(1.0, 1.0, 1.0, 1.0);
     const expected = new Cartesian4(0.0, 0.0, 0.0, 0.0);
     expect(Cartesian4.clamp(value, min, max, value)).toEqual(expected);
-  });
 
-  it("clamp with a result parameter that is an input parameter", function () {
-    const value = new Cartesian4(-1.0, -1.0, -1.0, -1.0);
-    const min = new Cartesian4(0.0, 0.0, 0.0, 0.0);
-    const max = new Cartesian4(1.0, 1.0, 1.0, 1.0);
-    const expected = new Cartesian4(0.0, 0.0, 0.0, 0.0);
+    Cartesian4.fromElements(-1.0, -1.0, -1.0, -1.0, value);
     expect(Cartesian4.clamp(value, min, max, min)).toEqual(expected);
-  });
 
-  it("clamp with a result parameter that is an input parameter", function () {
-    const value = new Cartesian4(-1.0, -1.0, -1.0, -1.0);
-    const min = new Cartesian4(0.0, 0.0, 0.0, 0.0);
-    const max = new Cartesian4(1.0, 1.0, 1.0, 1.0);
-    const expected = new Cartesian4(0.0, 0.0, 0.0, 0.0);
+    Cartesian4.fromElements(0.0, 0.0, 0.0, 0.0, min);
     expect(Cartesian4.clamp(value, min, max, max)).toEqual(expected);
   });
 


### PR DESCRIPTION
This PR adds `Cartesian2.clamp`, `Cartesian3.clamp`, and `Cartesian4.clamp`. It's the same behavior as the `clamp` function in `Math.js`

Most of the diff is unit tests, which are now more consistent between the three files for `minimumByComponent` and `maximumByComponent`. Also fixed some faulty unit tests like:

```
const first = new Cartesian2(0.0, 2.0);
const second = new Cartesian2(0.0, 1.0);
const result = new Cartesian2(0.0, 1.0);
expect(Cartesian2.minimumByComponent(first, second, result)).toEqual(result);
```

`result` is always going to equal itself, so the test isn't working as expected.

Now it is:
```
const first = new Cartesian2(0.0, 2.0);
const second = new Cartesian2(0.0, 1.0);
const expected = new Cartesian2(0.0, 1.0);
const result = new Cartesian2();
expect(Cartesian2.minimumByComponent(first, second, result)).toEqual(expected);
```