### PR TITLE
fix MinimumLevel evaluation in TileMapServiceImageryProvider

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 - Fixed a bug where `pnts` tiles would crash when `Cesium.ExperimentalFeatures.enableModelExperimental` was true. [#10183](https://github.com/CesiumGS/cesium/pull/10183)
 - Fixed an issue with Firefox and dimensionless SVG images. [#9188](https://github.com/CesiumGS/cesium/9188)
 - Fixed `ShadowMap` documentation for `options.pointLightRadius` type. [#10195](https://github.com/CesiumGS/cesium/pull/10195)
+- Fixed evaluation of `minimumLevel` on metadataFailure for TileMapServiceImageryProvider.
 
 ### 1.91 - 2022-03-01
 

--- a/Source/Scene/TileMapServiceImageryProvider.js
+++ b/Source/Scene/TileMapServiceImageryProvider.js
@@ -385,7 +385,7 @@ TileMapServiceImageryProvider.prototype._metadataFailure = function (error) {
   const minimumLevel = calculateSafeMinimumDetailLevel(
     tilingScheme,
     rectangle,
-    options.maximumLevel
+    options.minimumLevel
   );
 
   const templateResource = this._tmsResource.getDerivedResource({

--- a/Specs/Scene/TileMapServiceImageryProviderSpec.js
+++ b/Specs/Scene/TileMapServiceImageryProviderSpec.js
@@ -890,7 +890,7 @@ describe("Scene/TileMapServiceImageryProvider", function () {
     patchRequestSchedulerToRejectRequest();
     const provider = new TileMapServiceImageryProvider({
       url: "made/up/tms/server/",
-      maximumLevel: 10,
+      minimumLevel: 10,
     });
 
     // we expect that our minimum detail level was forced to 0, even though we requested 10.
@@ -907,7 +907,7 @@ describe("Scene/TileMapServiceImageryProvider", function () {
     const provider = new TileMapServiceImageryProvider({
       url: "made/up/tms/server/",
       // a high minimum detail level
-      maximumLevel: 12,
+      minimumLevel: 12,
       // and a very small rectangle
       rectangle: new Rectangle(
         CesiumMath.toRadians(131.020889),


### PR DESCRIPTION
This fixes a bug where the TileMapServiceImageryProvider does not evaluate the given `minimumLevel` when requesting meta data fails. 