### PR TITLE
Add light color to `ModelExperimental`

### DIFF
--- a/Source/Renderer/ShaderBuilder.js
+++ b/Source/Renderer/ShaderBuilder.js
@@ -269,7 +269,7 @@ ShaderBuilder.prototype.addFunctionLines = function (functionName, lines) {
  * // creates the line "uniform vec3 u_resolution;"
  * shaderBuilder.addUniform("vec3", "u_resolution", ShaderDestination.FRAGMENT);
  * // creates the line "uniform float u_time;" in both shaders
- * shaderBuilder.addDefine("float", "u_time", ShaderDestination.BOTH);
+ * shaderBuilder.addUniform("float", "u_time", ShaderDestination.BOTH);
  */
 ShaderBuilder.prototype.addUniform = function (type, identifier, destination) {
   //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/ModelExperimental/LightingPipelineStage.js
+++ b/Source/Scene/ModelExperimental/LightingPipelineStage.js
@@ -1,3 +1,4 @@
+import { defined } from "../../Cesium.js";
 import ShaderDestination from "../../Renderer/ShaderDestination.js";
 import LightingStageFS from "../../Shaders/ModelExperimental/LightingStageFS.js";
 import LightingModel from "./LightingModel.js";
@@ -26,8 +27,28 @@ LightingPipelineStage.name = "LightingPipelineStage"; // Helps with debugging
  * @private
  */
 LightingPipelineStage.process = function (renderResources, primitive) {
+  const model = renderResources.model;
   const lightingOptions = renderResources.lightingOptions;
   const shaderBuilder = renderResources.shaderBuilder;
+
+  if (defined(model.lightColor)) {
+    shaderBuilder.addDefine(
+      "USE_CUSTOM_LIGHT_COLOR",
+      undefined,
+      ShaderDestination.FRAGMENT
+    );
+
+    shaderBuilder.addUniform(
+      "vec3",
+      "model_lightColorHdr",
+      ShaderDestination.FRAGMENT
+    );
+
+    const uniformMap = renderResources.uniformMap;
+    uniformMap.model_lightColorHdr = function () {
+      return model.lightColor;
+    };
+  }
 
   // The lighting model is always set by the material. However, custom shaders
   // can override this.

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -1,4 +1,5 @@
 import BoundingSphere from "../../Core/BoundingSphere.js";
+import Cartesian3 from "../../Core/Cartesian3.js";
 import Check from "../../Core/Check.js";
 import ColorBlendMode from "../ColorBlendMode.js";
 import defined from "../../Core/defined.js";
@@ -47,6 +48,7 @@ import ShadowMode from "../ShadowMode.js";
  * @param {String|Number} [options.featureIdLabel="featureId_0"] Label of the feature ID set to use for picking and styling. For EXT_mesh_features, this is the feature ID's label property, or "featureId_N" (where N is the index in the featureIds array) when not specified. EXT_feature_metadata did not have a label field, so such feature ID sets are always labeled "featureId_N" where N is the index in the list of all feature Ids, where feature ID attributes are listed before feature ID textures. If featureIdLabel is an integer N, it is converted to the string "featureId_N" automatically. If both per-primitive and per-instance feature IDs are present, the instance feature IDs take priority.
  * @param {String|Number} [options.instanceFeatureIdLabel="instanceFeatureId_0"] Label of the instance feature ID set used for picking and styling. If instanceFeatureIdLabel is set to an integer N, it is converted to the string "instanceFeatureId_N" automatically. If both per-primitive and per-instance feature IDs are present, the instance feature IDs take priority.
  * @param {Object} [options.pointCloudShading] Options for constructing a {@link PointCloudShading} object to control point attenuation based on geometric error and lighting.
+ * @param {Cartesian3} [options.lightColor] The light color when shading the model. When <code>undefined</code> the scene's light color is used instead.
  * @param {Boolean} [options.backFaceCulling=true] Whether to cull back-facing geometry. When true, back face culling is determined by the material's doubleSided property; when false, back face culling is disabled. Back faces are not culled if the model's color is translucent.
  * @param {ShadowMode} [options.shadows=ShadowMode.ENABLED] Determines whether the model casts or receives shadows from light sources.
  * @param {Boolean} [options.showCreditsOnScreen=false] Whether to display the credits of this model on screen.
@@ -151,6 +153,8 @@ export default function ModelExperimental(options) {
   const pointCloudShading = new PointCloudShading(options.pointCloudShading);
   this._attenuation = pointCloudShading.attenuation;
   this._pointCloudShading = pointCloudShading;
+
+  this._lightColor = Cartesian3.clone(options.lightColor);
 
   this._backFaceCulling = defaultValue(options.backFaceCulling, true);
   this._backFaceCullingDirty = false;
@@ -687,6 +691,27 @@ Object.defineProperties(ModelExperimental.prototype, {
   },
 
   /**
+   * The light color when shading the model. When <code>undefined</code> the scene's light color is used instead.
+   *
+   * @memberof ModelExperimental.prototype
+   *
+   * @type {Cartesian3}
+   * @default undefined
+   */
+  lightColor: {
+    get: function () {
+      return this._lightColor;
+    },
+    set: function (value) {
+      if (defined(value) !== defined(this._lightColor)) {
+        this.resetDrawCommands();
+      }
+
+      this._lightColor = Cartesian3.clone(value, this._lightColor);
+    },
+  },
+
+  /**
    * Whether to cull back-facing geometry. When true, back face culling is
    * determined by the material's doubleSided property; when false, back face
    * culling is disabled. Back faces are not culled if the model's color is
@@ -979,6 +1004,7 @@ ModelExperimental.prototype.destroyResources = function () {
  * @param {String|Number} [options.featureIdLabel="featureId_0"] Label of the feature ID set to use for picking and styling. For EXT_mesh_features, this is the feature ID's label property, or "featureId_N" (where N is the index in the featureIds array) when not specified. EXT_feature_metadata did not have a label field, so such feature ID sets are always labeled "featureId_N" where N is the index in the list of all feature Ids, where feature ID attributes are listed before feature ID textures. If featureIdLabel is an integer N, it is converted to the string "featureId_N" automatically. If both per-primitive and per-instance feature IDs are present, the instance feature IDs take priority.
  * @param {String|Number} [options.instanceFeatureIdLabel="instanceFeatureId_0"] Label of the instance feature ID set used for picking and styling. If instanceFeatureIdLabel is set to an integer N, it is converted to the string "instanceFeatureId_N" automatically. If both per-primitive and per-instance feature IDs are present, the instance feature IDs take priority.
  * @param {Object} [options.pointCloudShading] Options for constructing a {@link PointCloudShading} object to control point attenuation and lighting.
+ * @param {Cartesian3} [options.lightColor] The light color when shading the model. When <code>undefined</code> the scene's light color is used instead.
  * @param {Boolean} [options.backFaceCulling=true] Whether to cull back-facing geometry. When true, back face culling is determined by the material's doubleSided property; when false, back face culling is disabled. Back faces are not culled if the model's color is translucent.
  * @param {ShadowMode} [options.shadows=ShadowMode.ENABLED] Determines whether the model casts or receives shadows from light sources.
  * @param {Boolean} [options.showCreditsOnScreen=false] Whether to display the credits of this model on screen.
@@ -1039,6 +1065,7 @@ ModelExperimental.fromGltf = function (options) {
     featureIdLabel: options.featureIdLabel,
     instanceFeatureIdLabel: options.instanceFeatureIdLabel,
     pointCloudShading: options.pointCloudShading,
+    lightColor: options.lightColor,
     backFaceCulling: options.backFaceCulling,
     shadows: options.shadows,
     showCreditsOnScreen: options.showCreditsOnScreen,

--- a/Source/Scene/ModelExperimental/ModelExperimental3DTileContent.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental3DTileContent.js
@@ -194,6 +194,7 @@ ModelExperimental3DTileContent.prototype.update = function (
   model.pointCloudShading = tileset.pointCloudShading;
   model.featureIdLabel = tileset.featureIdLabel;
   model.instanceFeatureIdLabel = tileset.instanceFeatureIdLabel;
+  model.lightColor = tileset.lightColor;
   model.backFaceCulling = tileset.backFaceCulling;
   model.shadows = tileset.shadows;
   model.showCreditsOnScreen = tileset.showCreditsOnScreen;
@@ -232,8 +233,10 @@ ModelExperimental3DTileContent.fromGltf = function (
     content: content,
     colorBlendMode: tileset.colorBlendMode,
     colorBlendAmount: tileset.colorBlendAmount,
+    lightColor: tileset.lightColor,
     backFaceCulling: tileset.backFaceCulling,
     shadows: tileset.shadows,
+    showCreditsOnScreen: tileset.showCreditsOnScreen,
   };
   content._model = ModelExperimental.fromGltf(modelOptions);
   return content;

--- a/Source/Shaders/ModelExperimental/LightingStageFS.glsl
+++ b/Source/Shaders/ModelExperimental/LightingStageFS.glsl
@@ -6,7 +6,11 @@ vec3 computePbrLighting(czm_modelMaterial inputMaterial)
     pbrParameters.f0 = inputMaterial.specular;
     pbrParameters.roughness = inputMaterial.roughness;
     
-    vec3 lightColorHdr = czm_lightColorHdr;
+    #ifdef USE_CUSTOM_LIGHT_COLOR
+    vec3 lightColorHdr = model_lightColorHdr;
+    #else
+    vec3 lightColorHdr = czm_lightColor;
+    #endif
 
     vec3 color = inputMaterial.diffuse;
     #ifdef HAS_NORMALS

--- a/Specs/Data/Models/GltfLoader/BoxUnlit/glTF/BoxUnlit.gltf
+++ b/Specs/Data/Models/GltfLoader/BoxUnlit/glTF/BoxUnlit.gltf
@@ -1,0 +1,151 @@
+{
+    "asset": {
+        "generator": "COLLADA2GLTF",
+        "version": "2.0"
+    },
+    "extensionsUsed": [
+        "KHR_materials_unlit"
+    ],
+    "extensionsRequired": [
+        "KHR_materials_unlit"
+    ],
+    "scene": 0,
+    "scenes": [
+        {
+            "nodes": [
+                0
+            ]
+        }
+    ],
+    "nodes": [
+        {
+            "children": [
+                1
+            ],
+            "matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                -1.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+            ]
+        },
+        {
+            "mesh": 0
+        }
+    ],
+    "meshes": [
+        {
+            "primitives": [
+                {
+                    "attributes": {
+                        "NORMAL": 1,
+                        "POSITION": 2
+                    },
+                    "indices": 0,
+                    "mode": 4,
+                    "material": 0
+                }
+            ],
+            "name": "Mesh"
+        }
+    ],
+    "accessors": [
+        {
+            "bufferView": 0,
+            "byteOffset": 0,
+            "componentType": 5123,
+            "count": 36,
+            "max": [
+                23
+            ],
+            "min": [
+                0
+            ],
+            "type": "SCALAR"
+        },
+        {
+            "bufferView": 1,
+            "byteOffset": 0,
+            "componentType": 5126,
+            "count": 24,
+            "max": [
+                1.0,
+                1.0,
+                1.0
+            ],
+            "min": [
+                -1.0,
+                -1.0,
+                -1.0
+            ],
+            "type": "VEC3"
+        },
+        {
+            "bufferView": 1,
+            "byteOffset": 288,
+            "componentType": 5126,
+            "count": 24,
+            "max": [
+                0.5,
+                0.5,
+                0.5
+            ],
+            "min": [
+                -0.5,
+                -0.5,
+                -0.5
+            ],
+            "type": "VEC3"
+        }
+    ],
+    "materials": [
+        {
+            "pbrMetallicRoughness": {
+                "baseColorFactor": [
+                    0.0,
+                    1.0,
+                    0.0,
+                    1.0
+                ],
+                "metallicFactor": 1.0
+            },
+            "name": "Unlit Green",
+            "extensions": {
+                "KHR_materials_unlit": {}
+            }
+        }
+    ],
+    "bufferViews": [
+        {
+            "buffer": 0,
+            "byteOffset": 576,
+            "byteLength": 72,
+            "target": 34963
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 0,
+            "byteLength": 576,
+            "byteStride": 12,
+            "target": 34962
+        }
+    ],
+    "buffers": [
+        {
+            "byteLength": 648,
+            "uri": "data:application/octet-stream;base64,AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAvwAAAL8AAAA/AAAAPwAAAL8AAAA/AAAAvwAAAD8AAAA/AAAAPwAAAD8AAAA/AAAAPwAAAL8AAAA/AAAAvwAAAL8AAAA/AAAAPwAAAL8AAAC/AAAAvwAAAL8AAAC/AAAAPwAAAD8AAAA/AAAAPwAAAL8AAAA/AAAAPwAAAD8AAAC/AAAAPwAAAL8AAAC/AAAAvwAAAD8AAAA/AAAAPwAAAD8AAAA/AAAAvwAAAD8AAAC/AAAAPwAAAD8AAAC/AAAAvwAAAL8AAAA/AAAAvwAAAD8AAAA/AAAAvwAAAL8AAAC/AAAAvwAAAD8AAAC/AAAAvwAAAL8AAAC/AAAAvwAAAD8AAAC/AAAAPwAAAL8AAAC/AAAAPwAAAD8AAAC/AAABAAIAAwACAAEABAAFAAYABwAGAAUACAAJAAoACwAKAAkADAANAA4ADwAOAA0AEAARABIAEwASABEAFAAVABYAFwAWABUA"
+        }
+    ]
+}

--- a/Specs/Scene/ModelExperimental/LightingPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/LightingPipelineStageSpec.js
@@ -4,17 +4,42 @@ import {
   LightingPipelineStage,
   ModelLightingOptions,
   ShaderBuilder,
+  Cartesian3,
 } from "../../../Source/Cesium.js";
 
 describe("Scene/ModelExperimental/LightingPipelineStage", function () {
   const mockPrimitive = {};
+  const mockModel = {};
 
   const optionsUnlit = new ModelLightingOptions();
   optionsUnlit.lightingModel = LightingModel.UNLIT;
 
+  it("supports light color", function () {
+    const mockModelWithLightColor = {
+      lightColor: new Cartesian3(1, 0, 0),
+    };
+    const shaderBuilder = new ShaderBuilder();
+    const renderResources = {
+      model: mockModelWithLightColor,
+      shaderBuilder: shaderBuilder,
+      lightingOptions: optionsUnlit,
+      uniformMap: {},
+    };
+    LightingPipelineStage.process(renderResources, mockPrimitive);
+
+    expect(shaderBuilder._vertexShaderParts.defineLines).toEqual([]);
+    expect(shaderBuilder._fragmentShaderParts.defineLines).toEqual([
+      "USE_CUSTOM_LIGHT_COLOR",
+      "LIGHTING_UNLIT",
+    ]);
+
+    expect(renderResources.uniformMap.model_lightColorHdr).toBeDefined();
+  });
+
   it("supports unlit lighting", function () {
     const shaderBuilder = new ShaderBuilder();
     const renderResources = {
+      model: mockModel,
       shaderBuilder: shaderBuilder,
       lightingOptions: optionsUnlit,
     };
@@ -32,6 +57,7 @@ describe("Scene/ModelExperimental/LightingPipelineStage", function () {
 
     const shaderBuilder = new ShaderBuilder();
     const renderResources = {
+      model: mockModel,
       shaderBuilder: shaderBuilder,
       lightingOptions: optionsPbr,
     };
@@ -46,6 +72,7 @@ describe("Scene/ModelExperimental/LightingPipelineStage", function () {
   it("adds the lighting shader function to the shader", function () {
     const shaderBuilder = new ShaderBuilder();
     const renderResources = {
+      model: mockModel,
       shaderBuilder: shaderBuilder,
       lightingOptions: optionsUnlit,
     };

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -698,6 +698,33 @@ describe(
       });
     });
 
+    it("initializes with light color", function () {
+      return loadAndZoomToModelExperimental(
+        { gltf: boxTexturedGltfUrl, lightColor: Cartesian3.ZERO },
+        scene
+      ).then(function (model) {
+        verifyRender(model, false);
+      });
+    });
+
+    it("changing light color works", function () {
+      return loadAndZoomToModelExperimental(
+        { gltf: boxTexturedGltfUrl },
+        scene
+      ).then(function (model) {
+        verifyRender(model, true);
+
+        model.lightColor = Cartesian3.ZERO;
+        verifyRender(model, false);
+
+        model.lightColor = new Cartesian3(1.0, 0.0, 0.0);
+        verifyRender(model, true);
+
+        model.lightColor = undefined;
+        verifyRender(model, true);
+      });
+    });
+
     it("enables back-face culling", function () {
       return loadAndZoomToModelExperimental(
         {

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -37,6 +37,7 @@ describe(
     const microcosm = "./Data/Models/GltfLoader/Microcosm/glTF/microcosm.gltf";
     const boxInstanced =
       "./Data/Models/GltfLoader/BoxInstanced/glTF/box-instanced.gltf";
+    const boxUnlitUrl = "./Data/Models/GltfLoader/BoxUnlit/glTF/BoxUnlit.gltf";
     const boxBackFaceCullingUrl =
       "./Data/Models/Box-Back-Face-Culling/Box-Back-Face-Culling.gltf";
     const boxBackFaceCullingOffset = new HeadingPitchRange(Math.PI / 2, 0, 2.0);
@@ -723,6 +724,17 @@ describe(
         model.lightColor = undefined;
         verifyRender(model, true);
       });
+    });
+
+    it("light color doesn't affect unlit models", function () {
+      return loadAndZoomToModelExperimental({ gltf: boxUnlitUrl }, scene).then(
+        function (model) {
+          verifyRender(model, true);
+
+          model.lightColor = Cartesian3.ZERO;
+          verifyRender(model, true);
+        }
+      );
     });
 
     it("enables back-face culling", function () {

--- a/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
+++ b/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
@@ -20,6 +20,7 @@ function loadAndZoomToModelExperimental(options, scene) {
         featureIdLabel: options.featureIdLabel,
         instanceFeatureIdLabel: options.instanceFeatureIdLabel,
         incrementallyLoadTextures: options.incrementallyLoadTextures,
+        lightColor: options.lightColor,
         backFaceCulling: options.backFaceCulling,
         showCreditsOnScreen: options.showCreditsOnScreen,
       });


### PR DESCRIPTION
This PR closes #10058 by adding the `lightColor` parameter to `ModelExperimental`. The light color can be passed to `ModelExperimental` through the tileset, as demonstrated in [this sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=zZVdb9MwFIb/ipWrVCpOy+g+SjexdQIuKm1at3FBuHCT08bMsSPbaSnT/jvHcdJ1oYIhAVouEjt+zzmPX1t2oqSxZMlhBZocEwkrMgbDy5zeVv/COEiq/lhJy7gEHQedt7FMqjiTgAQM8/G06uJgLAVYYrkAg99jcv+wiUCFBT1RcsFtmbrYV3261z/aP2xLmG0UPbp/dHh48KalwJEadcy0xRaTe3SuVX7FUmybsFWr28rcqUh9xqxozf4jYBK5uOQ2ya6YXEAYS1I9vW7TQvLBwabXfz3wTZ93XsrEciWJUCy99laEpRYdcu9klVW00Dznli/BUA25WsKpEKGLJ1vubVH5z955k+/eV8S0Q/eqWVKYlYtpplZnqpRuFrdKlDkMidUl1BrBF5kdK6H08EmBjZNhn/a6aL1/dVzUg5/ZDniWpmEN/IQeZ8XS9SWuCTdAbQYy3PgS1k406RKWg2ZUKHV3auu167qF8RlbMmfWGUvuVkyn4aDX86KK8OFxWd2+vChcOYNGfnaSuqaFb3ZI4gANJ5WbcVA7g1oQkOBog/pI+mzWZ9EibwXd3cF1UxS4wycwtxXeP6dzlcL+oPcLyU2xLfgd+pXbYP+HvSr1l+AnavXSfD9XK/kn8C/M+d34sfziL4qt0zEOomkBiYnOmWXRk7Mu+iDs3F1BiPWJ22ysirV2xaOFuH4fNcfNV6Okv5+CbjAydi3gpAF7x/NCaevOyZDSyEJeCIaHXTQrkzuMTYxpEEfRdugo5UvC0+MdNyFJBDMGR+alEFP+HR0/GUWo/ynUzRNP4oslaMHWTpb1Tyb+J6V0FGF3d6RVSsyYbmX+AQ). Unit tests were updated accordingly.

@ptrgags when you get the chance, could you review?