### PR TITLE
Fixed private tag for defer.js

### DIFF
--- a/Source/Core/defer.js
+++ b/Source/Core/defer.js
@@ -22,9 +22,9 @@
  */
 
 /**
- * @private
  * Creates a deferred object, containing a promise object, and functions to resolve or reject the promise.
  * @returns {defer.deferred}
+ * @private
  */
 function defer() {
   let resolve;


### PR DESCRIPTION
This fixes a warning when doing `npm run generateDocumentation`:

```
WARNING: The @private tag does not permit a value; the value will be ignored. File: defer.js, line: 24
WARNING: The @private tag does not permit a value; the value will be ignored. File: defer.js, line: 29
```
See https://app.travis-ci.com/github/CesiumGS/cesium/builds/248010115 for an example