### PR TITLE
CPU Metadata API consistency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 - Added experimental support for the [3D Tiles 1.1 draft](https://github.com/CesiumGS/3d-tiles/pull/666). [#10189](https://github.com/CesiumGS/cesium/pull/10189)
 - Added `lightColor` to `ModelExperimental` [#10207](https://github.com/CesiumGS/cesium/pull/10207)
 - Added a 'renderable' property to 'Fog' to disable its visual rendering while preserving tiles culling at a distance
+- Refactored metadata API so `tileset.metadata` and `content.group.metadata` are more symmetric with `content.metadata` and `tile.metadata`. [#10224](https://github.com/CesiumGS/cesium/pull/10224)
 
 ##### Fixes :wrench:
 

--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -59,7 +59,7 @@ function Batched3DModel3DTileContent(
   this._contentModelMatrix = undefined;
 
   this.featurePropertiesDirty = false;
-  this._groupMetadata = undefined;
+  this._group = undefined;
 
   initialize(this, arrayBuffer, byteOffset);
 }
@@ -149,12 +149,12 @@ Object.defineProperties(Batched3DModel3DTileContent.prototype, {
     },
   },
 
-  groupMetadata: {
+  group: {
     get: function () {
-      return this._groupMetadata;
+      return this._group;
     },
     set: function (value) {
-      this._groupMetadata = value;
+      this._group = value;
     },
   },
 });

--- a/Source/Scene/Cesium3DContentGroup.js
+++ b/Source/Scene/Cesium3DContentGroup.js
@@ -1,0 +1,42 @@
+import Check from "../Core/Check.js";
+import defaultValue from "../Core/defaultValue.js";
+
+/**
+ * Simple abstraction for a group. This class exists to make the metadata API
+ * more consistent, i.e. metadata can be accessed via
+ * <code>content.group.metadata</code> much like tile metadata is accessed as
+ * <code>tile.metadata</code>.
+ *
+ * @param {Object} options Object with the following properties:
+ * @param {GroupMetadata} options.metadata The metadata associated with this group.
+ *
+ * @alias Cesium3DContentGroup
+ * @constructor
+ * @private
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
+ */
+export default function Cesium3DContentGroup(options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.metadata", options.metadata);
+  //>>includeEnd('debug');
+
+  this._metadata = options.metadata;
+}
+
+Object.defineProperties(Cesium3DContentGroup.prototype, {
+  /**
+   * Get the metadata for this group
+   *
+   * @memberof Cesium3DContentGroup.prototype
+   *
+   * @type {GroupMetadata}
+   *
+   * @readonly
+   */
+  metadata: {
+    get: function () {
+      return this._metadata;
+    },
+  },
+});

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -23,6 +23,7 @@ import RequestState from "../Core/RequestState.js";
 import RequestType from "../Core/RequestType.js";
 import Resource from "../Core/Resource.js";
 import RuntimeError from "../Core/RuntimeError.js";
+import Cesium3DContentGroup from "./Cesium3DContentGroup.js";
 import Cesium3DTileContentFactory from "./Cesium3DTileContentFactory.js";
 import Cesium3DTileContentState from "./Cesium3DTileContentState.js";
 import Cesium3DTileContentType from "./Cesium3DTileContentType.js";
@@ -1317,7 +1318,13 @@ function makeContent(tile, arrayBuffer) {
     content.metadata = findContentMetadata(tileset, contentHeader);
   }
 
-  content.groupMetadata = findGroupMetadata(tileset, contentHeader);
+  const groupMetadata = findGroupMetadata(tileset, contentHeader);
+  if (defined(groupMetadata)) {
+    content.group = new Cesium3DContentGroup({
+      metadata: groupMetadata,
+    });
+  }
+
   return content;
 }
 

--- a/Source/Scene/Cesium3DTileContent.js
+++ b/Source/Scene/Cesium3DTileContent.js
@@ -245,7 +245,7 @@ Object.defineProperties(Cesium3DTileContent.prototype, {
   },
 
   /**
-   * Gets the group metadata for this content if the content has metadata (3D Tiles 1.1) or
+   * Gets the group for this content if the content has metadata (3D Tiles 1.1) or
    * if it uses the <code>3DTILES_metadata</code> extension. If neither are present,
    * this property should be undefined.
    * <p>
@@ -253,12 +253,12 @@ Object.defineProperties(Cesium3DTileContent.prototype, {
    * not part of the public Cesium API.
    * </p>
    *
-   * @type {GroupMetadata|undefined}
+   * @type {Cesium3DTileContentGroup|undefined}
    *
    * @private
    * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
-  groupMetadata: {
+  group: {
     // eslint-disable-next-line getter-return
     get: function () {
       DeveloperError.throwInstantiationError();

--- a/Source/Scene/Cesium3DTileFeature.js
+++ b/Source/Scene/Cesium3DTileFeature.js
@@ -326,9 +326,8 @@ Cesium3DTileFeature.getPropertyInherited = function (content, batchId, name) {
     }
   }
 
-  let tilesetMetadata = content.tileset.metadata;
-  if (defined(tilesetMetadata) && defined(tilesetMetadata.tileset)) {
-    tilesetMetadata = tilesetMetadata.tileset;
+  const tilesetMetadata = content.tileset.metadata;
+  if (defined(tilesetMetadata)) {
     if (tilesetMetadata.hasPropertyBySemantic(name)) {
       return tilesetMetadata.getPropertyBySemantic(name);
     }

--- a/Source/Scene/Cesium3DTileFeature.js
+++ b/Source/Scene/Cesium3DTileFeature.js
@@ -315,7 +315,9 @@ Cesium3DTileFeature.getPropertyInherited = function (content, batchId, name) {
     }
   }
 
-  const groupMetadata = content.groupMetadata;
+  const groupMetadata = defined(content.group)
+    ? content.group.metadata
+    : undefined;
   if (defined(groupMetadata)) {
     if (groupMetadata.hasPropertyBySemantic(name)) {
       return groupMetadata.getPropertyBySemantic(name);

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -955,15 +955,10 @@ function Cesium3DTileset(options) {
    */
   this.examineVectorLinesFunction = undefined;
 
-  /**
-   * If metadata is present (3D Tiles 1.1) or the 3DTILES_metadata extension is used,
-   * this stores a {@link Cesium3DTilesetMetadata} object to access metadata.
-   *
-   * @type {Cesium3DTilesetMetadata|undefined}
-   * @private
-   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
-   */
-  this.metadata = undefined;
+  // this is the underlying Cesium3DTileMetadata object, whether it came from
+  // the 3DTILES_metadata extension or a 3D Tiles 1.1 tileset JSON. Getters
+  // like tileset.metadata and tileset.schema will delegate to this object.
+  this._metadataExtension = undefined;
 
   this._customShader = options.customShader;
 
@@ -1382,6 +1377,65 @@ Object.defineProperties(Cesium3DTileset.prototype, {
     },
     set: function (value) {
       this._customShader = value;
+    },
+  },
+
+  /**
+   * The tileset's schema, groups, tileset metadata and other details from the
+   * 3DTILES_metadata extension or a 3D Tiles 1.1 tileset JSON. This getter is
+   * for internal use by other classes.
+   *
+   * @memberof Cesium3DTileset.prototype
+   * @type {Cesium3DTilesetMetadata}
+   * @private
+   * @readonly
+   *
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
+   */
+  metadataExtension: {
+    get: function () {
+      return this._metadataExtension;
+    },
+  },
+
+  /**
+   * The metadata properties attached to the tileset as a whole.
+   *
+   * @memberof Cesium3DTileset.prototype
+   *
+   * @type {TilesetMetadata}
+   * @readonly
+   *
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
+   */
+  metadata: {
+    get: function () {
+      if (defined(this._metadataExtension)) {
+        return this._metadataExtension.tileset;
+      }
+
+      return undefined;
+    },
+  },
+
+  /**
+   * The metadata schema used in this tileset. Shorthand for
+   * <code>tileset.metadataExtension.schema</code>
+   *
+   * @memberof Cesium3DTileset.prototype
+   *
+   * @type {MetadataSchema}
+   * @readonly
+   *
+   * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
+   */
+  schema: {
+    get: function () {
+      if (defined(this._metadataExtension)) {
+        return this._metadataExtension.schema;
+      }
+
+      return undefined;
     },
   },
 
@@ -2052,9 +2106,7 @@ function makeTile(tileset, baseResource, tileHeader, parentTile) {
     hasExtension(tileHeader, "3DTILES_implicit_tiling");
 
   if (hasImplicitTiling) {
-    const metadataSchema = defined(tileset.metadata)
-      ? tileset.metadata.schema
-      : undefined;
+    const metadataSchema = tileset.schema;
 
     const implicitTileset = new ImplicitTileset(
       baseResource,
@@ -2135,7 +2187,7 @@ function processMetadataExtension(tileset, tilesetJson) {
   tileset._schemaLoader = schemaLoader;
 
   return schemaLoader.promise.then(function (schemaLoader) {
-    tileset.metadata = new Cesium3DTilesetMetadata({
+    tileset._metadataExtension = new Cesium3DTilesetMetadata({
       schema: schemaLoader.schema,
       metadataJson: metadataJson,
     });

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1404,6 +1404,7 @@ Object.defineProperties(Cesium3DTileset.prototype, {
    * @memberof Cesium3DTileset.prototype
    *
    * @type {TilesetMetadata}
+   * @private
    * @readonly
    *
    * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
@@ -1425,6 +1426,7 @@ Object.defineProperties(Cesium3DTileset.prototype, {
    * @memberof Cesium3DTileset.prototype
    *
    * @type {MetadataSchema}
+   * @private
    * @readonly
    *
    * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.

--- a/Source/Scene/Composite3DTileContent.js
+++ b/Source/Scene/Composite3DTileContent.js
@@ -33,7 +33,7 @@ function Composite3DTileContent(
   this._readyPromise = defer();
 
   this._metadata = undefined;
-  this._groupMetadata = undefined;
+  this._group = undefined;
 
   initialize(this, arrayBuffer, byteOffset, factory);
 }
@@ -195,16 +195,16 @@ Object.defineProperties(Composite3DTileContent.prototype, {
    * @private
    * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
    */
-  groupMetadata: {
+  group: {
     get: function () {
-      return this._groupMetadata;
+      return this._group;
     },
     set: function (value) {
-      this._groupMetadata = value;
+      this._group = value;
       const contents = this._contents;
       const length = contents.length;
       for (let i = 0; i < length; ++i) {
-        contents[i].groupMetadata = value;
+        contents[i].group = value;
       }
     },
   },

--- a/Source/Scene/Empty3DTileContent.js
+++ b/Source/Scene/Empty3DTileContent.js
@@ -107,7 +107,7 @@ Object.defineProperties(Empty3DTileContent.prototype, {
     },
   },
 
-  groupMetadata: {
+  group: {
     get: function () {
       return undefined;
     },

--- a/Source/Scene/Geometry3DTileContent.js
+++ b/Source/Scene/Geometry3DTileContent.js
@@ -44,7 +44,7 @@ function Geometry3DTileContent(
    * Part of the {@link Cesium3DTileContent} interface.
    */
   this.featurePropertiesDirty = false;
-  this._groupMetadata = undefined;
+  this._group = undefined;
 
   initialize(this, arrayBuffer, byteOffset);
 }
@@ -137,12 +137,12 @@ Object.defineProperties(Geometry3DTileContent.prototype, {
     },
   },
 
-  groupMetadata: {
+  group: {
     get: function () {
-      return this._groupMetadata;
+      return this._group;
     },
     set: function (value) {
-      this._groupMetadata = value;
+      this._group = value;
     },
   },
 });

--- a/Source/Scene/Implicit3DTileContent.js
+++ b/Source/Scene/Implicit3DTileContent.js
@@ -73,7 +73,7 @@ export default function Implicit3DTileContent(
   this._metadata = undefined;
 
   this.featurePropertiesDirty = false;
-  this._groupMetadata = undefined;
+  this._group = undefined;
 
   const templateValues = implicitCoordinates.getTemplateValues();
   const subtreeResource = implicitTileset.subtreeUriTemplate.getDerivedResource(
@@ -176,12 +176,12 @@ Object.defineProperties(Implicit3DTileContent.prototype, {
     },
   },
 
-  groupMetadata: {
+  group: {
     get: function () {
-      return this._groupMetadata;
+      return this._group;
     },
     set: function (value) {
-      this._groupMetadata = value;
+      this._group = value;
     },
   },
 });

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -55,7 +55,7 @@ function Instanced3DModel3DTileContent(
   this._features = undefined;
 
   this.featurePropertiesDirty = false;
-  this._groupMetadata = undefined;
+  this._group = undefined;
 
   initialize(this, arrayBuffer, byteOffset);
 }
@@ -157,12 +157,12 @@ Object.defineProperties(Instanced3DModel3DTileContent.prototype, {
     },
   },
 
-  groupMetadata: {
+  group: {
     get: function () {
-      return this._groupMetadata;
+      return this._group;
     },
     set: function (value) {
-      this._groupMetadata = value;
+      this._group = value;
     },
   },
 });

--- a/Source/Scene/ModelExperimental/ModelExperimental3DTileContent.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental3DTileContent.js
@@ -28,7 +28,7 @@ export default function ModelExperimental3DTileContent(
 
   this._model = undefined;
   this._metadata = undefined;
-  this._groupMetadata = undefined;
+  this._group = undefined;
 }
 
 Object.defineProperties(ModelExperimental3DTileContent.prototype, {
@@ -129,12 +129,12 @@ Object.defineProperties(ModelExperimental3DTileContent.prototype, {
     },
   },
 
-  groupMetadata: {
+  group: {
     get: function () {
-      return this._groupMetadata;
+      return this._group;
     },
     set: function (value) {
-      this._groupMetadata = value;
+      this._group = value;
     },
   },
 });

--- a/Source/Scene/Multiple3DTileContent.js
+++ b/Source/Scene/Multiple3DTileContent.js
@@ -7,6 +7,7 @@ import RequestScheduler from "../Core/RequestScheduler.js";
 import RequestState from "../Core/RequestState.js";
 import RequestType from "../Core/RequestType.js";
 import RuntimeError from "../Core/RuntimeError.js";
+import Cesium3DContentGroup from "./Cesium3DContentGroup.js";
 import Cesium3DTileContentType from "./Cesium3DTileContentType.js";
 import Cesium3DTileContentFactory from "./Cesium3DTileContentFactory.js";
 import findContentMetadata from "./findContentMetadata.js";
@@ -253,11 +254,11 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
 
   /**
    * Part of the {@link Cesium3DTileContent} interface. <code>Multiple3DTileContent</code>
-   * always returns <code>undefined</code>.  Instead call <code>groupMetadata</code> for a specific inner content.
+   * always returns <code>undefined</code>.  Instead call <code>group</code> for a specific inner content.
    * @memberof Multiple3DTileContent.prototype
    * @private
    */
-  groupMetadata: {
+  group: {
     get: function () {
       return undefined;
     },
@@ -550,7 +551,12 @@ function createInnerContent(multipleContents, arrayBuffer, index) {
     content.metadata = findContentMetadata(tileset, contentHeader);
   }
 
-  content.groupMetadata = findGroupMetadata(tileset, contentHeader);
+  const groupMetadata = findGroupMetadata(tileset, contentHeader);
+  if (defined(groupMetadata)) {
+    content.group = new Cesium3DContentGroup({
+      metadata: groupMetadata,
+    });
+  }
   return content;
 }
 

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -44,7 +44,7 @@ function PointCloud3DTileContent(
   this._styleDirty = false;
   this._features = undefined;
   this.featurePropertiesDirty = false;
-  this._groupMetadata = undefined;
+  this._group = undefined;
 
   this._pointCloud = new PointCloud({
     arrayBuffer: arrayBuffer,
@@ -147,12 +147,12 @@ Object.defineProperties(PointCloud3DTileContent.prototype, {
     },
   },
 
-  groupMetadata: {
+  group: {
     get: function () {
-      return this._groupMetadata;
+      return this._group;
     },
     set: function (value) {
-      this._groupMetadata = value;
+      this._group = value;
     },
   },
 });

--- a/Source/Scene/Tileset3DTileContent.js
+++ b/Source/Scene/Tileset3DTileContent.js
@@ -23,7 +23,7 @@ function Tileset3DTileContent(tileset, tile, resource, json) {
   this.featurePropertiesDirty = false;
 
   this._metadata = undefined;
-  this._groupMetadata = undefined;
+  this._group = undefined;
 
   initialize(this, json);
 }
@@ -110,12 +110,12 @@ Object.defineProperties(Tileset3DTileContent.prototype, {
     },
   },
 
-  groupMetadata: {
+  group: {
     get: function () {
-      return this._groupMetadata;
+      return this._group;
     },
     set: function (value) {
-      this._groupMetadata = value;
+      this._group = value;
     },
   },
 });

--- a/Source/Scene/Vector3DTileContent.js
+++ b/Source/Scene/Vector3DTileContent.js
@@ -53,7 +53,7 @@ function Vector3DTileContent(tileset, tile, resource, arrayBuffer, byteOffset) {
    * Part of the {@link Cesium3DTileContent} interface.
    */
   this.featurePropertiesDirty = false;
-  this._groupMetadata = undefined;
+  this._group = undefined;
 
   initialize(this, arrayBuffer, byteOffset);
 }
@@ -160,12 +160,12 @@ Object.defineProperties(Vector3DTileContent.prototype, {
     },
   },
 
-  groupMetadata: {
+  group: {
     get: function () {
-      return this._groupMetadata;
+      return this._group;
     },
     set: function (value) {
-      this._groupMetadata = value;
+      this._group = value;
     },
   },
 });

--- a/Source/Scene/findContentMetadata.js
+++ b/Source/Scene/findContentMetadata.js
@@ -24,7 +24,7 @@ export default function findContentMetadata(tileset, contentHeader) {
     return undefined;
   }
 
-  const classes = tileset.metadata.schema.classes;
+  const classes = tileset.schema.classes;
   if (defined(metadataJson.class)) {
     const contentClass = classes[metadataJson.class];
     return new ContentMetadata({

--- a/Source/Scene/findGroupMetadata.js
+++ b/Source/Scene/findGroupMetadata.js
@@ -15,10 +15,11 @@ import hasExtension from "./hasExtension.js";
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function findGroupMetadata(tileset, contentHeader) {
-  if (!defined(tileset.metadata)) {
+  const metadataExtension = tileset.metadataExtension;
+  if (!defined(metadataExtension)) {
     return undefined;
   }
-  const groups = tileset.metadata.groups;
+  const groups = metadataExtension.groups;
 
   const group = hasExtension(contentHeader, "3DTILES_metadata")
     ? contentHeader.extensions["3DTILES_metadata"].group
@@ -28,7 +29,7 @@ export default function findGroupMetadata(tileset, contentHeader) {
     return groups[group];
   }
 
-  const index = tileset.metadata.groupIds.findIndex(function (id) {
+  const index = metadataExtension.groupIds.findIndex(function (id) {
     return id === group;
   });
 

--- a/Source/Scene/findTileMetadata.js
+++ b/Source/Scene/findTileMetadata.js
@@ -26,7 +26,7 @@ export default function findTileMetadata(tileset, tileHeader) {
     return undefined;
   }
 
-  const classes = tileset.metadata.schema.classes;
+  const classes = tileset.schema.classes;
   if (defined(metadataJson.class)) {
     const tileClass = classes[metadataJson.class];
     return new TileMetadata({

--- a/Specs/Scene/Batched3DModel3DTileContentSpec.js
+++ b/Specs/Scene/Batched3DModel3DTileContentSpec.js
@@ -1,6 +1,7 @@
 import {
   B3dmParser,
   Cartesian3,
+  Cesium3DContentGroup,
   ContentMetadata,
   Color,
   HeadingPitchRange,
@@ -527,8 +528,8 @@ describe(
           withoutBatchTableUrl
         ).then(function (tileset) {
           const content = tileset.root.content;
-          content.groupMetadata = groupMetadata;
-          expect(content.groupMetadata).toBe(groupMetadata);
+          content.group = new Cesium3DContentGroup({ metadata: groupMetadata });
+          expect(content.group.metadata).toBe(groupMetadata);
         });
       });
 

--- a/Specs/Scene/Cesium3DContentGroupSpec.js
+++ b/Specs/Scene/Cesium3DContentGroupSpec.js
@@ -1,0 +1,20 @@
+import { Cesium3DContentGroup } from "../../Source/Cesium.js";
+
+describe("Scene/Cesium3DContentGroup", function () {
+  const mockMetadata = {};
+
+  it("constructs", function () {
+    const group = new Cesium3DContentGroup({
+      metadata: mockMetadata,
+    });
+    expect(group.metadata).toBe(mockMetadata);
+  });
+
+  it("throws without metadata", function () {
+    expect(function () {
+      return new Cesium3DContentGroup({
+        metadata: undefined,
+      });
+    }).toThrowDeveloperError();
+  });
+});

--- a/Specs/Scene/Cesium3DTileContentSpec.js
+++ b/Specs/Scene/Cesium3DTileContentSpec.js
@@ -40,10 +40,10 @@ describe("Scene/Cesium3DTileContent", function () {
       return content.batchTable;
     }).toThrowDeveloperError();
     expect(function () {
-      return content.groupMetadata;
+      return content.group;
     }).toThrowDeveloperError();
     expect(function () {
-      content.groupMetadata = {};
+      content.group = {};
     }).toThrowDeveloperError();
     expect(function () {
       return content.hasProperty(0, "height");

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -6202,10 +6202,7 @@ describe(
       it("loads tileset metadata", function () {
         return Cesium3DTilesTester.loadTileset(scene, tilesetMetadataUrl).then(
           function (tileset) {
-            const metadata = tileset.metadata;
-            expect(metadata).toBeDefined();
-
-            const tilesetMetadata = metadata.tileset;
+            const tilesetMetadata = tileset.metadata;
             expect(function () {
               return tilesetMetadata.getProperty("name");
             }).toThrowDeveloperError();
@@ -6230,7 +6227,7 @@ describe(
           scene,
           tilesetWithGroupMetadataUrl
         ).then(function (tileset) {
-          const metadata = tileset.metadata;
+          const metadata = tileset.metadataExtension;
           expect(metadata).toBeDefined();
 
           const groups = metadata.groups;
@@ -6261,7 +6258,7 @@ describe(
           scene,
           tilesetWithGroupMetadataUrl
         ).then(function (tileset) {
-          const metadata = tileset.metadata;
+          const metadata = tileset.metadataExtension;
           const commercialDistrict = metadata.groups[1];
           const residentialDistrict = metadata.groups[0];
 
@@ -6289,7 +6286,7 @@ describe(
       it("loads metadata with embedded schema", function () {
         return Cesium3DTilesTester.loadTileset(scene, tilesetMetadataUrl).then(
           function (tileset) {
-            const schema = tileset.metadata.schema;
+            const schema = tileset.schema;
             expect(schema).toBeDefined();
 
             const classes = schema.classes;
@@ -6303,7 +6300,7 @@ describe(
           scene,
           tilesetWithExternalSchemaUrl
         ).then(function (tileset) {
-          const schema = tileset.metadata.schema;
+          const schema = tileset.schema;
           expect(schema).toBeDefined();
 
           const classes = schema.classes;
@@ -6660,7 +6657,7 @@ describe(
           scene,
           tilesetMetadataLegacyUrl
         ).then(function (tileset) {
-          const metadata = tileset.metadata;
+          const metadata = tileset.metadataExtension;
           expect(metadata).toBeDefined();
 
           const tilesetMetadata = metadata.tileset;
@@ -6687,7 +6684,7 @@ describe(
           scene,
           tilesetWithGroupMetadataLegacyUrl
         ).then(function (tileset) {
-          const metadata = tileset.metadata;
+          const metadata = tileset.metadataExtension;
           expect(metadata).toBeDefined();
 
           const groups = metadata.groups;
@@ -6718,7 +6715,7 @@ describe(
           scene,
           tilesetWithGroupMetadataLegacyUrl
         ).then(function (tileset) {
-          const metadata = tileset.metadata;
+          const metadata = tileset.metadataExtension;
           const commercialDistrict = metadata.groups[0];
           const residentialDistrict = metadata.groups[1];
 
@@ -6748,7 +6745,7 @@ describe(
           scene,
           tilesetMetadataLegacyUrl
         ).then(function (tileset) {
-          const schema = tileset.metadata.schema;
+          const schema = tileset.schema;
           expect(schema).toBeDefined();
 
           const classes = schema.classes;
@@ -6761,7 +6758,7 @@ describe(
           scene,
           tilesetWithExternalSchemaLegacyUrl
         ).then(function (tileset) {
-          const schema = tileset.metadata.schema;
+          const schema = tileset.schema;
           expect(schema).toBeDefined();
 
           const classes = schema.classes;

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -6265,7 +6265,7 @@ describe(
           // the parent tile in this dataset does not have a group defined,
           // but its children do.
           const parent = tileset.root;
-          const group = parent.content.groupMetadata;
+          const group = parent.content.group;
           expect(group).not.toBeDefined();
 
           const expected = {
@@ -6278,7 +6278,7 @@ describe(
           const childrenTiles = parent.children;
           childrenTiles.forEach(function (tile) {
             const uri = tile._header.content.uri;
-            expect(tile.content.groupMetadata).toBe(expected[uri]);
+            expect(tile.content.group.metadata).toBe(expected[uri]);
           });
         });
       });
@@ -6722,7 +6722,7 @@ describe(
           // the parent tile in this dataset does not have a group defined,
           // but its children do.
           const parent = tileset.root;
-          const group = parent.content.groupMetadata;
+          const group = parent.content.group;
           expect(group).not.toBeDefined();
 
           const expected = {
@@ -6735,7 +6735,7 @@ describe(
           const childrenTiles = parent.children;
           childrenTiles.forEach(function (tile) {
             const uri = tile._header.content.uri;
-            expect(tile.content.groupMetadata).toBe(expected[uri]);
+            expect(tile.content.group.metadata).toBe(expected[uri]);
           });
         });
       });

--- a/Specs/Scene/Composite3DTileContentSpec.js
+++ b/Specs/Scene/Composite3DTileContentSpec.js
@@ -1,5 +1,6 @@
 import {
   Cartesian3,
+  Cesium3DContentGroup,
   Color,
   ContentMetadata,
   HeadingPitchRange,
@@ -213,16 +214,18 @@ describe(
         });
       });
 
-      it("assigning groupMetadata propagates to inner contents", function () {
+      it("assigning group metadata propagates to inner contents", function () {
         return Cesium3DTilesTester.loadTileset(scene, compositeUrl).then(
           function (tileset) {
             const content = tileset.root.content;
-            content.groupMetadata = groupMetadata;
-            expect(content.groupMetadata).toBe(groupMetadata);
+            content.group = new Cesium3DContentGroup({
+              metadata: groupMetadata,
+            });
+            expect(content.group.metadata).toBe(groupMetadata);
 
             const innerContents = content.innerContents;
             for (let i = 0; i < innerContents.length; i++) {
-              expect(innerContents[i].groupMetadata).toBe(groupMetadata);
+              expect(innerContents[i].group.metadata).toBe(groupMetadata);
             }
           }
         );

--- a/Specs/Scene/Empty3DTileContentSpec.js
+++ b/Specs/Scene/Empty3DTileContentSpec.js
@@ -38,15 +38,15 @@ describe("Scene/Empty3DTileContent", function () {
       const mockTileset = {};
       const mockTile = {};
       const content = new Empty3DTileContent(mockTileset, mockTile);
-      expect(content.groupMetadata).not.toBeDefined();
+      expect(content.group).not.toBeDefined();
     });
 
-    it("assigning groupMetadata throws", function () {
+    it("assigning group throws", function () {
       expect(function () {
         const mockTileset = {};
         const mockTile = {};
         const content = new Empty3DTileContent(mockTileset, mockTile);
-        content.groupMetadata = {};
+        content.group = {};
       }).toThrowDeveloperError();
     });
 

--- a/Specs/Scene/Geometry3DTileContentSpec.js
+++ b/Specs/Scene/Geometry3DTileContentSpec.js
@@ -1,5 +1,6 @@
 import {
   Cartesian3,
+  Cesium3DContentGroup,
   Cesium3DTileStyle,
   ClassificationType,
   Color,
@@ -929,12 +930,14 @@ describe(
         });
       });
 
-      it("assigns groupMetadata", function () {
+      it("assigns group metadata", function () {
         return Cesium3DTilesTester.loadTileset(scene, geometryAll).then(
           function (tileset) {
             const content = tileset.root.content;
-            content.groupMetadata = groupMetadata;
-            expect(content.groupMetadata).toBe(groupMetadata);
+            content.group = new Cesium3DContentGroup({
+              metadata: groupMetadata,
+            });
+            expect(content.group.metadata).toBe(groupMetadata);
           }
         );
       });

--- a/Specs/Scene/Implicit3DTileContentSpec.js
+++ b/Specs/Scene/Implicit3DTileContentSpec.js
@@ -1,6 +1,7 @@
 import {
   Batched3DModel3DTileContent,
   Cartesian3,
+  Cesium3DContentGroup,
   Cesium3DTile,
   Cesium3DTileRefine,
   Cesium3DTileset,
@@ -1168,12 +1169,14 @@ describe(
         });
       });
 
-      it("assigns groupMetadata", function () {
+      it("assigns group metadata", function () {
         return Cesium3DTilesTester.loadTileset(scene, implicitTilesetUrl).then(
           function (tileset) {
             const content = tileset.root.content;
-            content.groupMetadata = groupMetadata;
-            expect(content.groupMetadata).toBe(groupMetadata);
+            content.group = new Cesium3DContentGroup({
+              metadata: groupMetadata,
+            });
+            expect(content.group.metadata).toBe(groupMetadata);
           }
         );
       });
@@ -1188,7 +1191,7 @@ describe(
           const tiles = [];
           gatherTilesPreorder(subtreeRootTile, 0, 2, tiles);
 
-          const groups = tileset.metadata.groups;
+          const groups = tileset.metadataExtension.groups;
           const ground = groups[0];
           expect(ground.getProperty("color")).toEqual(
             new Cartesian3(120, 68, 32)
@@ -1205,11 +1208,11 @@ describe(
             if (tile.hasMultipleContents) {
               // child tiles have multiple contents
               const contents = tile.content.innerContents;
-              expect(contents[0].groupMetadata).toBe(ground);
-              expect(contents[1].groupMetadata).toBe(sky);
+              expect(contents[0].group.metadata).toBe(ground);
+              expect(contents[1].group.metadata).toBe(sky);
             } else {
               // parent tile is a single b3dm tile
-              expect(tile.content.groupMetadata).toBe(ground);
+              expect(tile.content.group.metadata).toBe(ground);
             }
           });
         });
@@ -1687,7 +1690,7 @@ describe(
           const tiles = [];
           gatherTilesPreorder(subtreeRootTile, 0, 2, tiles);
 
-          const groups = tileset.metadata.groups;
+          const groups = tileset.metadataExtension.groups;
           const ground = groups[0];
           expect(ground.getProperty("color")).toEqual(
             new Cartesian3(120, 68, 32)
@@ -1704,11 +1707,11 @@ describe(
             if (tile.hasMultipleContents) {
               // child tiles have multiple contents
               const contents = tile.content.innerContents;
-              expect(contents[0].groupMetadata).toBe(ground);
-              expect(contents[1].groupMetadata).toBe(sky);
+              expect(contents[0].group.metadata).toBe(ground);
+              expect(contents[1].group.metadata).toBe(sky);
             } else {
               // parent tile is a single b3dm tile
-              expect(tile.content.groupMetadata).toBe(ground);
+              expect(tile.content.group.metadata).toBe(ground);
             }
           });
         });

--- a/Specs/Scene/Instanced3DModel3DTileContentSpec.js
+++ b/Specs/Scene/Instanced3DModel3DTileContentSpec.js
@@ -1,5 +1,6 @@
 import {
   Cartesian3,
+  Cesium3DContentGroup,
   Color,
   ContentMetadata,
   HeadingPitchRange,
@@ -557,14 +558,14 @@ describe(
         });
       });
 
-      it("assigns groupMetadata", function () {
+      it("assigns group metadata", function () {
         return Cesium3DTilesTester.loadTileset(
           scene,
           withoutBatchTableUrl
         ).then(function (tileset) {
           const content = tileset.root.content;
-          content.groupMetadata = groupMetadata;
-          expect(content.groupMetadata).toBe(groupMetadata);
+          content.group = new Cesium3DContentGroup({ metadata: groupMetadata });
+          expect(content.group.metadata).toBe(groupMetadata);
         });
       });
 

--- a/Specs/Scene/ModelExperimental/ModelExperimental3DTileContentSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimental3DTileContentSpec.js
@@ -1,5 +1,6 @@
 import {
   Cartesian3,
+  Cesium3DContentGroup,
   ContentMetadata,
   defined,
   ExperimentalFeatures,
@@ -300,13 +301,13 @@ describe("Scene/ModelExperimental/ModelExperimental3DTileContent", function () {
       });
     });
 
-    it("assigns groupMetadata", function () {
+    it("assigns group metadata", function () {
       setCamera(centerLongitude, centerLatitude, 15.0);
       return Cesium3DTilesTester.loadTileset(scene, withoutBatchTableUrl).then(
         function (tileset) {
           const content = tileset.root.content;
-          content.groupMetadata = groupMetadata;
-          expect(content.groupMetadata).toBe(groupMetadata);
+          content.group = new Cesium3DContentGroup({ metadata: groupMetadata });
+          expect(content.group.metadata).toBe(groupMetadata);
         }
       );
     });

--- a/Specs/Scene/Multiple3DTileContentSpec.js
+++ b/Specs/Scene/Multiple3DTileContentSpec.js
@@ -1,5 +1,6 @@
 import {
   Cartesian3,
+  Cesium3DContentGroup,
   Cesium3DTileset,
   Color,
   HeadingPitchRange,
@@ -397,27 +398,29 @@ describe(
         });
       });
 
-      it("groupMetadata returns undefined", function () {
+      it("group metadata returns undefined", function () {
         return Cesium3DTilesTester.loadTileset(scene, multipleContentsUrl).then(
           function (tileset) {
             const content = tileset.root.content;
-            expect(content.groupMetadata).not.toBeDefined();
+            expect(content.group).not.toBeDefined();
           }
         );
       });
 
-      it("assigning groupMetadata throws", function () {
+      it("assigning group metadata throws", function () {
         return Cesium3DTilesTester.loadTileset(scene, multipleContentsUrl).then(
           function (tileset) {
             expect(function () {
               const content = tileset.root.content;
-              content.groupMetadata = groupMetadata;
+              content.group = new Cesium3DContentGroup({
+                metadata: groupMetadata,
+              });
             }).toThrowDeveloperError();
           }
         );
       });
 
-      it("initializes groupMetadata for inner contents", function () {
+      it("initializes group metadata for inner contents", function () {
         return Cesium3DTilesTester.loadTileset(
           scene,
           withGroupMetadataUrl
@@ -426,7 +429,7 @@ describe(
           const innerContents = multipleContents.innerContents;
 
           const buildingsContent = innerContents[0];
-          let groupMetadata = buildingsContent.groupMetadata;
+          let groupMetadata = buildingsContent.group.metadata;
           expect(groupMetadata).toBeDefined();
           expect(groupMetadata.getProperty("color")).toEqual(
             new Cartesian3(255, 127, 0)
@@ -435,7 +438,7 @@ describe(
           expect(groupMetadata.getProperty("isInstanced")).toBe(false);
 
           const cubesContent = innerContents[1];
-          groupMetadata = cubesContent.groupMetadata;
+          groupMetadata = cubesContent.group.metadata;
           expect(groupMetadata).toBeDefined();
           expect(groupMetadata.getProperty("color")).toEqual(
             new Cartesian3(0, 255, 127)
@@ -445,7 +448,7 @@ describe(
         });
       });
 
-      it("initializes groupMetadata for inner contents (legacy)", function () {
+      it("initializes group metadata for inner contents (legacy)", function () {
         return Cesium3DTilesTester.loadTileset(
           scene,
           withGroupMetadataLegacyUrl
@@ -454,7 +457,7 @@ describe(
           const innerContents = multipleContents.innerContents;
 
           const buildingsContent = innerContents[0];
-          let groupMetadata = buildingsContent.groupMetadata;
+          let groupMetadata = buildingsContent.group.metadata;
           expect(groupMetadata).toBeDefined();
           expect(groupMetadata.getProperty("color")).toEqual(
             new Cartesian3(255, 127, 0)
@@ -463,7 +466,7 @@ describe(
           expect(groupMetadata.getProperty("isInstanced")).toBe(false);
 
           const cubesContent = innerContents[1];
-          groupMetadata = cubesContent.groupMetadata;
+          groupMetadata = cubesContent.group.metadata;
           expect(groupMetadata).toBeDefined();
           expect(groupMetadata.getProperty("color")).toEqual(
             new Cartesian3(0, 255, 127)

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -1,5 +1,6 @@
 import {
   Cartesian3,
+  Cesium3DContentGroup,
   Cesium3DTilePass,
   Cesium3DTileRefine,
   Cesium3DTileStyle,
@@ -1299,8 +1300,10 @@ describe(
         return Cesium3DTilesTester.loadTileset(scene, pointCloudRGBUrl).then(
           function (tileset) {
             const content = tileset.root.content;
-            content.groupMetadata = groupMetadata;
-            expect(content.groupMetadata).toBe(groupMetadata);
+            content.group = new Cesium3DContentGroup({
+              metadata: groupMetadata,
+            });
+            expect(content.group.metadata).toBe(groupMetadata);
           }
         );
       });

--- a/Specs/Scene/Tileset3DTileContentSpec.js
+++ b/Specs/Scene/Tileset3DTileContentSpec.js
@@ -1,5 +1,6 @@
 import {
   Cartesian3,
+  Cesium3DContentGroup,
   HeadingPitchRange,
   MetadataClass,
   ContentMetadata,
@@ -127,14 +128,14 @@ describe(
         });
       });
 
-      it("assigns groupMetadata", function () {
+      it("assigns group metadata", function () {
         return Cesium3DTilesTester.loadTileset(
           scene,
           tilesetOfTilesetsUrl
         ).then(function (tileset) {
           const content = tileset.root.content;
-          content.groupMetadata = groupMetadata;
-          expect(content.groupMetadata).toBe(groupMetadata);
+          content.group = new Cesium3DContentGroup({ metadata: groupMetadata });
+          expect(content.group.metadata).toBe(groupMetadata);
         });
       });
 

--- a/Specs/Scene/Vector3DTileContentSpec.js
+++ b/Specs/Scene/Vector3DTileContentSpec.js
@@ -1,5 +1,6 @@
 import {
   Cartesian3,
+  Cesium3DContentGroup,
   Cesium3DTileset,
   Cesium3DTileStyle,
   ClassificationType,
@@ -1133,12 +1134,14 @@ xdescribe(
         });
       });
 
-      it("assigns groupMetadata", function () {
+      it("assigns group metadata", function () {
         return Cesium3DTilesTester.loadTileset(scene, vectorPoints).then(
           function (tileset) {
             const content = tileset.root.content;
-            content.groupMetadata = groupMetadata;
-            expect(content.groupMetadata).toBe(groupMetadata);
+            content.group = new Cesium3DContentGroup({
+              metadata: groupMetadata,
+            });
+            expect(content.group.metadata).toBe(groupMetadata);
           }
         );
       });

--- a/Specs/Scene/findContentMetadataSpec.js
+++ b/Specs/Scene/findContentMetadataSpec.js
@@ -24,11 +24,9 @@ describe("Scene/findContentMetadata", function () {
       },
     });
     mockTileset = {
-      metadata: {
-        schema: {
-          classes: {
-            content: contentClass,
-          },
+      schema: {
+        classes: {
+          content: contentClass,
         },
       },
     };

--- a/Specs/Scene/findGroupMetadataSpec.js
+++ b/Specs/Scene/findGroupMetadataSpec.js
@@ -25,7 +25,7 @@ describe("Scene/findGroupMetadata", function () {
     });
 
     mockTileset = {
-      metadata: {
+      metadataExtension: {
         groups: [
           new GroupMetadata({
             id: "testGroup",

--- a/Specs/Scene/findTileMetadataSpec.js
+++ b/Specs/Scene/findTileMetadataSpec.js
@@ -4,7 +4,7 @@ import {
   MetadataClass,
 } from "../../Source/Cesium.js";
 
-describe("Scene/findTileMetadata", function () {
+fdescribe("Scene/findTileMetadata", function () {
   let tileClass;
   let mockTileset;
   beforeAll(function () {
@@ -25,11 +25,9 @@ describe("Scene/findTileMetadata", function () {
     });
 
     mockTileset = {
-      metadata: {
-        schema: {
-          classes: {
-            tile: tileClass,
-          },
+      schema: {
+        classes: {
+          tile: tileClass,
         },
       },
     };

--- a/Specs/Scene/findTileMetadataSpec.js
+++ b/Specs/Scene/findTileMetadataSpec.js
@@ -4,7 +4,7 @@ import {
   MetadataClass,
 } from "../../Source/Cesium.js";
 
-fdescribe("Scene/findTileMetadata", function () {
+describe("Scene/findTileMetadata", function () {
   let tileClass;
   let mockTileset;
   beforeAll(function () {


### PR DESCRIPTION
This PR addresses the inconsistency in the API across the different metadata granularities. See https://github.com/CesiumGS/3d-tiles-samples/pull/43#discussion_r832694763

This PR makes these changes:

* In `Cesium3DTileset`, I moved the `Cesium3DTilesetMetadata` object to a separate `metadataExtension` field (intended for internal use). This contains the schema, groups, tileset metadata. 
* Added `tileset.metadata` and `tileset.schema` getters since those are the two most common things the user will need to fetch from the tileset. I could add more like groups, but for now I'd rather keep the API surface area small.
* Added a small wrapper object, `Cesium3DContentGroup` so you can access metadata as `content.group.metadata` rather than the asymmetric `content.groupMetadata`. It may feel a bit like overkill, but this way is better documented and future-proof.

To Do:

- [x] Update CHANGES.md
- [x] Double check sandcastles