### PR TITLE
Only queue billboards for update if they are dirty.

### DIFF
--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -566,7 +566,7 @@ BillboardCollection.prototype._updateBillboard = function (
   billboard,
   propertyChanged
 ) {
-  if (!billboard._dirty) {
+  if (billboard._dirty) {
     this._billboardsToUpdate[this._billboardsToUpdateIndex++] = billboard;
   }
 


### PR DESCRIPTION
BillboardCollection.prototype._updateBillboard function queues billboards for update if their dirty flag is FALSE. This leads to iteration over the entire BillboardCollection whenever a new billboard is added. This is a huge performance hit when the number of billboards starts to grow into the tens of thousands within a single collection and billboards are added frequently to the collection (multiple times a second). 
If this change is incorrect for some reason, then I would recommend adding a comment to this IF check as it is extremely unintuitive why we would queue billboards for update if they are not dirty.