### PR TITLE
Gracefully fall back to unlit shading in ModelExperimental for models without normals

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@
 - Fixed an issue with Firefox and dimensionless SVG images. [#9191](https://github.com/CesiumGS/cesium/pull/9191)
 - Fixed `ShadowMap` documentation for `options.pointLightRadius` type. [#10195](https://github.com/CesiumGS/cesium/pull/10195)
 - Fixed evaluation of `minimumLevel` on metadataFailure for TileMapServiceImageryProvider.
+- Fixed a bug where models without normals would render as solid black. Now such models will fall back to unlit shading. [#10237](https://github.com/CesiumGS/cesium/pull/10237)
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,7 +26,7 @@
 - Fixed an issue with Firefox and dimensionless SVG images. [#9191](https://github.com/CesiumGS/cesium/pull/9191)
 - Fixed `ShadowMap` documentation for `options.pointLightRadius` type. [#10195](https://github.com/CesiumGS/cesium/pull/10195)
 - Fixed evaluation of `minimumLevel` on metadataFailure for TileMapServiceImageryProvider.
-- Fixed a bug where models without normals would render as solid black. Now such models will fall back to unlit shading. [#10237](https://github.com/CesiumGS/cesium/pull/10237)
+- Fixed a bug where models without normals would render as solid black. Now, such models will use unlit shading. [#10237](https://github.com/CesiumGS/cesium/pull/10237)
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/Source/Scene/ModelExperimental/CustomShaderPipelineStage.js
+++ b/Source/Scene/ModelExperimental/CustomShaderPipelineStage.js
@@ -71,6 +71,26 @@ CustomShaderPipelineStage.process = function (
   const shaderBuilder = renderResources.shaderBuilder;
   const customShader = renderResources.model.customShader;
 
+  // Check the lighting model and translucent options first, as sometimes
+  // these are used even if there is no vertex or fragment shader text.
+
+  // if present, the lighting model overrides the material's lighting model.
+  if (defined(customShader.lightingModel)) {
+    renderResources.lightingOptions.lightingModel = customShader.lightingModel;
+  }
+
+  const alphaOptions = renderResources.alphaOptions;
+  if (customShader.isTranslucent) {
+    alphaOptions.pass = Pass.TRANSLUCENT;
+    alphaOptions.alphaMode = AlphaMode.BLEND;
+  } else {
+    // Use the default pass (either OPAQUE or 3D_TILES), regardless of whether
+    // the material pipeline stage used translucent. The default is configured
+    // in AlphaPipelineStage
+    alphaOptions.pass = undefined;
+    alphaOptions.alphaMode = AlphaMode.OPAQUE;
+  }
+
   // Generate lines of code for the shader, but don't add them to the shader
   // yet.
   const generatedCode = generateShaderLines(customShader, primitive);
@@ -129,23 +149,6 @@ CustomShaderPipelineStage.process = function (
       const varyingType = varyings[varyingName];
       shaderBuilder.addVarying(varyingType, varyingName);
     }
-  }
-
-  // if present, the lighting model overrides the material's lighting model.
-  if (defined(customShader.lightingModel)) {
-    renderResources.lightingOptions.lightingModel = customShader.lightingModel;
-  }
-
-  const alphaOptions = renderResources.alphaOptions;
-  if (customShader.isTranslucent) {
-    alphaOptions.pass = Pass.TRANSLUCENT;
-    alphaOptions.alphaMode = AlphaMode.BLEND;
-  } else {
-    // Use the default pass (either OPAQUE or 3D_TILES), regardless of whether
-    // the material pipeline stage used translucent. The default is configured
-    // in AlphaPipelineStage
-    alphaOptions.pass = undefined;
-    alphaOptions.alphaMode = AlphaMode.OPAQUE;
   }
 
   renderResources.uniformMap = combine(

--- a/Source/Scene/ModelExperimental/MaterialPipelineStage.js
+++ b/Source/Scene/ModelExperimental/MaterialPipelineStage.js
@@ -9,6 +9,8 @@ import Matrix3 from "../../Core/Matrix3.js";
 import Cartesian3 from "../../Core/Cartesian3.js";
 import Cartesian4 from "../../Core/Cartesian4.js";
 import ModelComponents from "../ModelComponents.js";
+import VertexAttributeSemantic from "../VertexAttributeSemantic.js";
+import ModelExperimentalUtility from "./ModelExperimentalUtility.js";
 
 const Material = ModelComponents.Material;
 const MetallicRoughness = ModelComponents.MetallicRoughness;
@@ -84,8 +86,14 @@ MaterialPipelineStage.process = function (
     );
   }
 
+  // If the primitive does not have normals, fall back to unlit lighting.
+  const hasNormals = ModelExperimentalUtility.getAttributeBySemantic(
+    primitive,
+    VertexAttributeSemantic.NORMAL
+  );
+
   const lightingOptions = renderResources.lightingOptions;
-  if (material.unlit) {
+  if (material.unlit || !hasNormals) {
     lightingOptions.lightingModel = LightingModel.UNLIT;
   } else {
     lightingOptions.lightingModel = LightingModel.PBR;

--- a/Specs/Data/Models/GltfLoader/BoxNoNormals/README.md
+++ b/Specs/Data/Models/GltfLoader/BoxNoNormals/README.md
@@ -1,5 +1,6 @@
 # A Box Without Normals
 
-This model is a variation on Box-Gltf-2 except with the `NORMAL` attribute
-is removed. No `KHR_materials_unlit` is added. This is intentional to test
-fallback behavior to unlit shading.
+This model is a variation on Box-Gltf-2 except the `NORMAL` attribute has been
+removed. `KHR_materials_unlit` has not been added. This is to intentionally test
+the fallback behavior when a model without normals is loaded in -- it should
+instead use unlit shading.

--- a/Specs/Data/Models/GltfLoader/BoxNoNormals/README.md
+++ b/Specs/Data/Models/GltfLoader/BoxNoNormals/README.md
@@ -1,0 +1,5 @@
+# A Box Without Normals
+
+This model is a variation on Box-Gltf-2 except with the `NORMAL` attribute
+is removed. No `KHR_materials_unlit` is added. This is intentional to test
+fallback behavior to unlit shading.

--- a/Specs/Data/Models/GltfLoader/BoxNoNormals/glTF/BoxNoNormals.gltf
+++ b/Specs/Data/Models/GltfLoader/BoxNoNormals/glTF/BoxNoNormals.gltf
@@ -1,0 +1,133 @@
+{
+  "asset": {
+    "generator": "COLLADA2GLTF",
+    "version": "2.0"
+  },
+  "scene": 0,
+  "scenes": [
+    {
+      "nodes": [
+        0
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "children": [
+        1
+      ],
+      "matrix": [
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        -1,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1
+      ]
+    },
+    {
+      "mesh": 0
+    }
+  ],
+  "meshes": [
+    {
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 1
+          },
+          "indices": 0,
+          "mode": 4,
+          "material": 0
+        }
+      ],
+      "name": "Mesh"
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "byteOffset": 0,
+      "componentType": 5123,
+      "count": 36,
+      "max": [
+        23
+      ],
+      "min": [
+        0
+      ],
+      "type": "SCALAR"
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 288,
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        0.5,
+        0.5,
+        0.5
+      ],
+      "min": [
+        -0.5,
+        -0.5,
+        -0.5
+      ],
+      "type": "VEC3"
+    }
+  ],
+  "materials": [
+    {
+      "pbrMetallicRoughness": {
+        "baseColorFactor": [
+          0.800000011920929,
+          0,
+          0,
+          1
+        ],
+        "metallicFactor": 0,
+        "roughnessFactor": 1
+      },
+      "name": "Red",
+      "emissiveFactor": [
+        0,
+        0,
+        0
+      ],
+      "alphaMode": "OPAQUE",
+      "doubleSided": false
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 72,
+      "target": 34963
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 72,
+      "byteLength": 576,
+      "byteStride": 12,
+      "target": 34962
+    }
+  ],
+  "buffers": [
+    {
+      "name": "Box0",
+      "byteLength": 648,
+      "uri": "data:application/octet-stream;base64,AAABAAIAAwACAAEABAAFAAYABwAGAAUACAAJAAoACwAKAAkADAANAA4ADwAOAA0AEAARABIAEwASABEAFAAVABYAFwAWABUAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAvwAAAL8AAAA/AAAAPwAAAL8AAAA/AAAAvwAAAD8AAAA/AAAAPwAAAD8AAAA/AAAAPwAAAL8AAAA/AAAAvwAAAL8AAAA/AAAAPwAAAL8AAAC/AAAAvwAAAL8AAAC/AAAAPwAAAD8AAAA/AAAAPwAAAL8AAAA/AAAAPwAAAD8AAAC/AAAAPwAAAL8AAAC/AAAAvwAAAD8AAAA/AAAAPwAAAD8AAAA/AAAAvwAAAD8AAAC/AAAAPwAAAD8AAAC/AAAAvwAAAL8AAAA/AAAAvwAAAD8AAAA/AAAAvwAAAL8AAAC/AAAAvwAAAD8AAAC/AAAAvwAAAL8AAAC/AAAAvwAAAD8AAAC/AAAAPwAAAL8AAAC/AAAAPwAAAD8AAAC/"
+    }
+  ]
+}

--- a/Specs/Scene/ModelExperimental/CustomShaderPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/CustomShaderPipelineStageSpec.js
@@ -237,6 +237,35 @@ describe("Scene/ModelExperimental/CustomShaderPipelineStage", function () {
     expect(renderResources.alphaOptions.alphaMode).toBe(AlphaMode.BLEND);
   });
 
+  it("unlit and translucency work even if no shader code is present", function () {
+    const shaderBuilder = new ShaderBuilder();
+    const model = {
+      customShader: new CustomShader({
+        lightingModel: LightingModel.PBR,
+        isTranslucent: true,
+      }),
+    };
+    const renderResources = {
+      shaderBuilder: shaderBuilder,
+      model: model,
+      lightingOptions: new ModelLightingOptions(),
+      alphaOptions: new ModelAlphaOptions(),
+    };
+
+    CustomShaderPipelineStage.process(renderResources, primitive);
+
+    expect(renderResources.alphaOptions.pass).toBe(Pass.TRANSLUCENT);
+    expect(renderResources.alphaOptions.alphaMode).toBe(AlphaMode.BLEND);
+
+    expect(renderResources.lightingOptions.lightingModel).toBe(
+      LightingModel.PBR
+    );
+
+    // the shader code proper gets optimized out
+    ShaderBuilderTester.expectVertexLinesEqual(shaderBuilder, []);
+    ShaderBuilderTester.expectFragmentLinesEqual(shaderBuilder, []);
+  });
+
   it("generates shader code from built-in attributes", function () {
     const shaderBuilder = new ShaderBuilder();
     const model = {

--- a/Specs/Scene/ModelExperimental/MaterialPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/MaterialPipelineStageSpec.js
@@ -76,6 +76,8 @@ describe(
     const boomBoxSpecularGlossiness =
       "./Data/Models/PBR/BoomBoxSpecularGlossiness/BoomBox.gltf";
     const boxUnlit = "./Data/Models/GltfLoader/UnlitTest/glTF/UnlitTest.gltf";
+    const boxNoNormals =
+      "./Data/Models/GltfLoader/BoxNoNormals/glTF/BoxNoNormals.gltf";
 
     function expectShaderLines(shaderLines, expected) {
       for (let i = 0; i < expected.length; i++) {
@@ -396,6 +398,29 @@ describe(
 
     it("enables unlit lighting when KHR_materials_unlit is present", function () {
       return loadGltf(boxUnlit).then(function (gltfLoader) {
+        const components = gltfLoader.components;
+        const primitive = components.nodes[1].primitives[0];
+        const lightingOptions = new ModelLightingOptions();
+        const renderResources = {
+          shaderBuilder: new ShaderBuilder(),
+          uniformMap: {},
+          lightingOptions: lightingOptions,
+          alphaOptions: new ModelAlphaOptions(),
+          renderStateOptions: {},
+          model: {},
+        };
+
+        MaterialPipelineStage.process(
+          renderResources,
+          primitive,
+          mockFrameState
+        );
+        expect(lightingOptions.lightingModel).toBe(LightingModel.UNLIT);
+      });
+    });
+
+    it("gracefully falls back to unlit shading for models without normals", function () {
+      return loadGltf(boxNoNormals).then(function (gltfLoader) {
         const components = gltfLoader.components;
         const primitive = components.nodes[1].primitives[0];
         const lightingOptions = new ModelLightingOptions();


### PR DESCRIPTION
This PR makes two changes to make rendering models handle edge cases more gracefully:

1. If a primitive in a `ModelExperimental` does not have normals, now the lighting mode falls back gracefully to UNLIT, since this looks better than attempting to render PBR with default settings (which often results in everything turning solid black). Technically speaking, this behavior is not correct by the glTF spec, but in Cesium the unlit behavior is consistent with the old `Model`. Unlit shading is very common in geospatial data (e.g. photogrammetry) where we want to render the textures directly. 
2. For `CustomShader`, I noticed that if you specify the `lightingModel` or `isTranslucent` but do not include `vertexShaderText`/`fragmentShaderText`, these settings were being optimized out. I moved the if checks earlier in `CustomShaderPipelineStage` so they always get applied, this is more useful.

[Local Sandcastle for testing](http://localhost:8080/Apps/Sandcastle/index.html#c=tVVdb9s2FP0rhJ7sIaYkW7Ed1w3WpU22ocmK2tiATXtgpGuLCEUKJOU4G/LfdylKipq62F7mB4kf536de66cKWksOXB4BE3eEgmP5AoMr0v6a3M2SoOs2V8paRmXoNNg/CaVqfQ2NBMqe6BZrTVIu+UloJfWw8+14Ey+ZxboTqvyJ6OW8ygepZKQNJhG03gSx5PoYjuNVtPFaragUTyP5kmyOJ8ly/kyuZgtfk+DVPp4YUhuVQ7CpDJrki6bHYb7w3n82z0IsXC0K3T/gzqS0Z0id0qXDFETYgpVi5zcA6ml4HacBmfeBJ2BgAzNdrXMLFeSjMadP0L8ZRN61J25AsJNBZkJsTwW+sTCG2F3HxXLQYcY/061wcO92F5/cUL3iOwTcL+oW7pi3fu5ufTPU7VdK00yVVZMc6Pk/1ENhpm4iiZTt/zvKafyz6ZhvktF9UpXPwLLudx/4jYrPivh02jvbpktqFWfEcGkGcXLaNz4jPzTS8H73fEj5NealbDViN0hsS/K648MRXky4XHqure5AVQys0q3apRK26KtLg0ewdgX4fU8DrmrtTgjBfB9YVt2fVqVMrwB97lcMW1xxeSsmYL3sNcApiV/Ek9nNFokyTy+aKlNEhqdR7NFNG8PfBS39vmQdlypybAKWmleYsgDGKqhVAd4h5z6lgzmBPP5lhXL8zabrgvO4MOxAsTgUDPRJO6kMOp15NSwIo6F7qQJgw3U/Lg60YfiVduH3RgoseNvoDNU0GDXev4gBK+M4jn97WazTAaAE8LohdrCnsdDNpvEkTuWP33COrkBaguQo5f5aRD9EHUfPoygGepLPbyzfQVf5f8t5TO5H9Z9egCS8/HZv2Em8RcgX829qqWLtakK0EA1YmtDviPnPRV+4XXy7F7Pjo0Nk3nGjBXgZLFVStwzfQuy9hyY8ZvgLFgb+yTgsnP1PS8rHB8nhhGloYWyEvjNN+F9nT2ApZkx3RdiHQ5N1zk/EJ6/PfEXQzLBjMGbXS3Ehv8FaXC5DhH/lalQDam/HEAL9uRgRXz50R9SStchbk9bWl/dK8//AA)

@j9liu could you review when you get a chance?