### PR TITLE
Remove group ID requirement from `GroupMetadata`

### DIFF
--- a/Source/Scene/Cesium3DTilesetMetadata.js
+++ b/Source/Scene/Cesium3DTilesetMetadata.js
@@ -54,10 +54,8 @@ function Cesium3DTilesetMetadata(options) {
     const length = groupsJson.length;
     for (let i = 0; i < length; i++) {
       const group = groupsJson[i];
-      groupIds.push(group.id);
       groups.push(
         new GroupMetadata({
-          id: group.id,
           group: group,
           class: schema.classes[group.class],
         })
@@ -123,7 +121,8 @@ Object.defineProperties(Cesium3DTilesetMetadata.prototype, {
   },
 
   /**
-   * The IDs of the group metadata in the corresponding groups array.
+   * The IDs of the group metadata in the corresponding groups dictionary.
+   * Only populated if using the legacy schema.
    *
    * @memberof Cesium3DTilesetMetadata.prototype
    * @type {String[]}

--- a/Source/Scene/GroupMetadata.js
+++ b/Source/Scene/GroupMetadata.js
@@ -26,7 +26,6 @@ function GroupMetadata(options) {
   const metadataClass = options.class;
 
   //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.string("options.id", id);
   Check.typeOf.object("options.group", group);
   Check.typeOf.object("options.class", metadataClass);
   //>>includeEnd('debug');

--- a/Specs/Data/Cesium3DTiles/Metadata/AllMetadataTypes/tileset_1.1.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/AllMetadataTypes/tileset_1.1.json
@@ -137,7 +137,6 @@
   },
   "groups": [
     {
-      "id": "residentialDistrict",
       "class": "residential",
       "properties": {
         "name": "residential",
@@ -147,7 +146,6 @@
       }
     },
     {
-      "id": "commercialDistrict",
       "class": "commercial",
       "properties": {
         "name": "commercial",

--- a/Specs/Data/Cesium3DTiles/Metadata/GroupMetadata/tileset_1.1.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/GroupMetadata/tileset_1.1.json
@@ -33,7 +33,6 @@
   },
   "groups": [
     {
-      "id": "residentialDistrict",
       "class": "residential",
       "properties": {
         "population": 300000,
@@ -41,7 +40,6 @@
       }
     },
     {
-      "id": "commercialDistrict",
       "class": "commercial",
       "properties": {
         "businessCount": 143

--- a/Specs/Data/Cesium3DTiles/Metadata/ImplicitGroupMetadata/tileset_1.1.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/ImplicitGroupMetadata/tileset_1.1.json
@@ -20,7 +20,6 @@
   },
   "groups": [
     {
-      "id": "ground",
       "class": "layer",
       "properties": {
         "color": [120, 68, 32],
@@ -28,7 +27,6 @@
       }
     },
     {
-      "id": "sky",
       "class": "layer",
       "properties": {
         "color": [206, 237, 242],

--- a/Specs/Data/Cesium3DTiles/MultipleContents/GroupMetadata/tileset_1.1.json
+++ b/Specs/Data/Cesium3DTiles/MultipleContents/GroupMetadata/tileset_1.1.json
@@ -41,7 +41,6 @@
   },
   "groups": [
     {
-      "id": "buildings",
       "class": "layer",
       "properties": {
         "color": [255, 127, 0],
@@ -50,7 +49,6 @@
       }
     },
     {
-      "id": "cubes",
       "class": "layer",
       "properties": {
         "color": [0, 255, 127],

--- a/Specs/Scene/Cesium3DTilesetMetadataSpec.js
+++ b/Specs/Scene/Cesium3DTilesetMetadataSpec.js
@@ -74,14 +74,12 @@ describe("Scene/Cesium3DTilesetMetadata", function () {
       schema: schemaJson,
       groups: [
         {
-          id: "neighborhoodA",
           class: "neighborhood",
           properties: {
             color: "RED",
           },
         },
         {
-          id: "neighborhoodB",
           class: "neighborhood",
           properties: {
             color: "GREEN",
@@ -121,11 +119,9 @@ describe("Scene/Cesium3DTilesetMetadata", function () {
     const neighborhoodA = metadata.groups[0];
     const neighborhoodB = metadata.groups[1];
 
-    expect(neighborhoodA.id).toBe(metadata.groupIds[0]);
     expect(neighborhoodA.class).toBe(neighborhoodClass);
     expect(neighborhoodA.getProperty("color")).toBe("RED");
     expect(neighborhoodB.class).toBe(neighborhoodClass);
-    expect(neighborhoodB.id).toBe(metadata.groupIds[1]);
     expect(neighborhoodB.getProperty("color")).toBe("GREEN");
 
     expect(metadata.statistics).toBe(statistics);

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -6231,12 +6231,7 @@ describe(
           expect(metadata).toBeDefined();
 
           const groups = metadata.groups;
-          const groupIds = metadata.groupIds;
           expect(groups).toBeDefined();
-          expect(groupIds).toEqual([
-            "residentialDistrict",
-            "commercialDistrict",
-          ]);
 
           let group = groups[1];
           expect(group).toBeDefined();

--- a/Specs/Scene/GroupMetadataSpec.js
+++ b/Specs/Scene/GroupMetadataSpec.js
@@ -66,16 +66,6 @@ describe("Scene/GroupMetadata", function () {
     );
   });
 
-  it("constructor handles undefined id", function () {
-    expect(function () {
-      return new GroupMetadata({
-        id: undefined,
-        group: {},
-        class: buildingClassWithNoProperties,
-      });
-    }).not.toThrowDeveloperError();
-  });
-
   it("constructor throws without group", function () {
     expect(function () {
       return new GroupMetadata({

--- a/Specs/Scene/GroupMetadataSpec.js
+++ b/Specs/Scene/GroupMetadataSpec.js
@@ -66,14 +66,14 @@ describe("Scene/GroupMetadata", function () {
     );
   });
 
-  it("constructor throws without id", function () {
+  it("constructor handles undefined id", function () {
     expect(function () {
       return new GroupMetadata({
         id: undefined,
         group: {},
         class: buildingClassWithNoProperties,
       });
-    }).toThrowDeveloperError();
+    }).not.toThrowDeveloperError();
   });
 
   it("constructor throws without group", function () {


### PR DESCRIPTION
Closes #10223. This PR removes the requirement for `options.id` in `GroupMetadata` and updates the specs / sample tilesets in accordance with these changes.