### PR TITLE
Separate reference matrix computation from `ImageBasedLighting`

### DIFF
--- a/Source/Scene/ModelExperimental/ImageBasedLightingPipelineStage.js
+++ b/Source/Scene/ModelExperimental/ImageBasedLightingPipelineStage.js
@@ -121,7 +121,7 @@ ImageBasedLightingPipelineStage.process = function (
       return imageBasedLighting.imageBasedLightingFactor;
     },
     model_iblReferenceFrameMatrix: function () {
-      return imageBasedLighting.iblReferenceFrameMatrix;
+      return model._iblReferenceFrameMatrix;
     },
     model_luminanceAtZenith: function () {
       return imageBasedLighting.luminanceAtZenith;


### PR DESCRIPTION
When `ImageBasedLighting` was introduced in #10226, it included a `referenceMatrix` getter and setter that was used in recomputing `iblReferenceFrameMatrix`. However, the `referenceMatrix` will be different for different models, so if multiple models use the same IBL with different model matrices, the IBL matrix that they use will be incorrect. Instead, models should manage their own `iblReferenceFrameMatrix` variables.

@ptrgags can you review?