### PR TITLE
Add missing lines to `ModelExperimental` unit tests

### DIFF
--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -790,8 +790,8 @@ describe(
         };
 
         let result;
+        verifyRender(model, true);
         expect(renderOptions).toRenderAndCall(function (rgba) {
-          expect(rgba).not.toEqual([0, 0, 0, 255]);
           result = rgba;
         });
 
@@ -1321,6 +1321,7 @@ describe(
       ).then(function (model) {
         let modelColor;
         scene.renderForSpecs();
+        verifyRender(model, true);
         expect(scene).toRenderAndCall(function (rgba) {
           modelColor = rgba;
         });
@@ -1355,6 +1356,7 @@ describe(
       ).then(function (model) {
         let modelColor;
         scene.renderForSpecs();
+        verifyRender(model, true);
         expect(scene).toRenderAndCall(function (rgba) {
           modelColor = rgba;
         });


### PR DESCRIPTION
Some of the new unit tests in `ModelExperimental` were missing calls to a function that moves the camera, such that the model was guaranteed to show up. (calling `camera.flyToBoundingSphere` has some inconsistency due to #10244). This PR adds those missing lines.