### PR TITLE
typescript export for defer

### DIFF
--- a/Source/Core/defer.js
+++ b/Source/Core/defer.js
@@ -1,30 +1,31 @@
 /**
  * A function used to resolve a promise upon completion .
- * @callback defer.resolve
+ * @callback resolve
  *
  * @param {*} value The resulting value.
  */
 
 /**
  * A function used to reject a promise upon failure.
- * @callback defer.reject
+ * @callback reject
  *
  * @param {*} error The error.
  */
 
 /**
  * An object which contains a promise object, and functions to resolve or reject the promise.
- *
- * @typedef {Object} defer.deferred
- * @property {defer.resolve} resolve Resolves the promise when called.
- * @property {defer.reject} reject Rejects the promise when called.
- * @property {Promise} promise Promise object.
+ * @typedef {Object} deferred
+ * @property {resolve} resolve Resolves the promise when called.
+ * @property {reject} reject Rejects the promise when called.
+ * @property {Promise<any>} promise Promise object.
  */
 
 /**
  * Creates a deferred object, containing a promise object, and functions to resolve or reject the promise.
- * @returns {defer.deferred}
- * @private
+ *
+ * @function
+ *
+ * @returns {deferred}
  */
 function defer() {
   let resolve;


### PR DESCRIPTION
For your consideration, `defer()` can be useful for upgrading legacy client code that was using `when.defer()` when working with Cesium promises.  It is currently exported in the library but not showing up in the typescript definitions.

Feel free to close this PR if you would prefer not to support a public `defer()`.

The changes proposed here produce the following types:

```
/**
 * A function used to resolve a promise upon completion .
 * @param value - The resulting value.
 */
export type resolve = (value: any) => void;

/**
 * A function used to reject a promise upon failure.
 * @param error - The error.
 */
export type reject = (error: any) => void;

/**
 * An object which contains a promise object, and functions to resolve or reject the promise.
 * @property resolve - Resolves the promise when called.
 * @property reject - Rejects the promise when called.
 * @property promise - Promise object.
 */
export type deferred = {
    resolve: resolve;
    reject: reject;
    promise: Promise<any>;
};

/**
 * Creates a deferred object, containing a promise object, and functions to resolve or reject the promise.
 */
export function defer(): deferred;
```