### PR TITLE
Update to Jasmine 4.0.1

### DIFF
--- a/Specs/Core/BingMapsGeocoderServiceSpec.js
+++ b/Specs/Core/BingMapsGeocoderServiceSpec.js
@@ -76,7 +76,7 @@ describe("Core/BingMapsGeocoderService", function () {
     });
   });
 
-  it("returns no geocoder results if Bing has no results", function (done) {
+  it("returns no geocoder results if Bing has no results", function () {
     const query = "some query";
     const data = {
       resourceSets: [],
@@ -89,13 +89,12 @@ describe("Core/BingMapsGeocoderService", function () {
       deferred.resolve(data);
     };
     const service = new BingMapsGeocoderService({ key: "" });
-    service.geocode(query).then(function (results) {
+    return service.geocode(query).then(function (results) {
       expect(results.length).toEqual(0);
-      done();
     });
   });
 
-  it("returns no geocoder results if Bing has results but no resources", function (done) {
+  it("returns no geocoder results if Bing has results but no resources", function () {
     const query = "some query";
     const data = {
       resourceSets: [
@@ -112,9 +111,8 @@ describe("Core/BingMapsGeocoderService", function () {
       deferred.resolve(data);
     };
     const service = new BingMapsGeocoderService({ key: "" });
-    service.geocode(query).then(function (results) {
+    return service.geocode(query).then(function (results) {
       expect(results.length).toEqual(0);
-      done();
     });
   });
 });

--- a/Specs/Core/CartographicGeocoderServiceSpec.js
+++ b/Specs/Core/CartographicGeocoderServiceSpec.js
@@ -4,80 +4,72 @@ import { CartographicGeocoderService } from "../../Source/Cesium.js";
 describe("Core/CartographicGeocoderService", function () {
   const service = new CartographicGeocoderService();
 
-  it("returns cartesian with matching coordinates for NS/EW input", function (done) {
+  it("returns cartesian with matching coordinates for NS/EW input", function () {
     const query = "35N 75W";
-    service.geocode(query).then(function (results) {
+    return service.geocode(query).then(function (results) {
       expect(results.length).toEqual(1);
       expect(results[0].destination).toEqual(
         Cartesian3.fromDegrees(-75.0, 35.0, 300.0)
       );
-      done();
     });
   });
 
-  it("returns cartesian with matching coordinates for EW/NS input", function (done) {
+  it("returns cartesian with matching coordinates for EW/NS input", function () {
     const query = "75W 35N";
-    service.geocode(query).then(function (results) {
+    return service.geocode(query).then(function (results) {
       expect(results.length).toEqual(1);
       expect(results[0].destination).toEqual(
         Cartesian3.fromDegrees(-75.0, 35.0, 300.0)
       );
-      done();
     });
   });
 
-  it("returns cartesian with matching coordinates for long/lat/height input", function (done) {
+  it("returns cartesian with matching coordinates for long/lat/height input", function () {
     const query = " 1.0, 2.0, 3.0 ";
-    service.geocode(query).then(function (results) {
+    return service.geocode(query).then(function (results) {
       expect(results.length).toEqual(1);
       expect(results[0].destination).toEqual(
         Cartesian3.fromDegrees(1.0, 2.0, 3.0)
       );
-      done();
     });
   });
 
-  it("returns cartesian with matching coordinates for long/lat input", function (done) {
+  it("returns cartesian with matching coordinates for long/lat input", function () {
     const query = " 1.0, 2.0 ";
     const defaultHeight = 300.0;
-    service.geocode(query).then(function (results) {
+    return service.geocode(query).then(function (results) {
       expect(results.length).toEqual(1);
       expect(results[0].destination).toEqual(
         Cartesian3.fromDegrees(1.0, 2.0, defaultHeight)
       );
-      done();
     });
   });
 
-  it("returns empty array for input with only longitudinal coordinates", function (done) {
+  it("returns empty array for input with only longitudinal coordinates", function () {
     const query = " 1e 1e ";
-    service.geocode(query).then(function (results) {
+    return service.geocode(query).then(function (results) {
       expect(results.length).toEqual(0);
-      done();
     });
   });
 
-  it("returns empty array for input with only one NSEW coordinate", function (done) {
+  it("returns empty array for input with only one NSEW coordinate", function () {
     const query = " 1e 1 ";
-    service.geocode(query).then(function (results) {
+    return service.geocode(query).then(function (results) {
       expect(results.length).toEqual(0);
-      done();
     });
   });
 
-  it("returns empty array for input with only one number", function (done) {
+  it("returns empty array for input with only one number", function () {
     const query = " 2.0 ";
-    service.geocode(query).then(function (results) {
+    return service.geocode(query).then(function (results) {
       expect(results.length).toEqual(0);
-      done();
     });
   });
 
-  it("returns empty array for with string", function (done) {
+  it("returns empty array for with string", function () {
     const query = " aoeu ";
-    service.geocode(query).then(function (results) {
+    return service.geocode(query).then(function (results) {
       expect(results.length).toEqual(0);
-      done();
     });
   });
 });

--- a/Specs/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorSpec.js
+++ b/Specs/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorSpec.js
@@ -1,5 +1,4 @@
 import { Ellipsoid } from "../../../Source/Cesium.js";
-import { Cesium3DTileset } from "../../../Source/Cesium.js";
 import { Globe } from "../../../Source/Cesium.js";
 import createScene from "../../createScene.js";
 import { Cesium3DTilesInspector } from "../../../Source/Cesium.js";
@@ -7,9 +6,6 @@ import { Cesium3DTilesInspector } from "../../../Source/Cesium.js";
 describe(
   "Widgets/Cesium3DTilesInspector/Cesium3DTilesInspector",
   function () {
-    // Parent tile with content and four child tiles with content
-    const tilesetUrl = "./Data/Cesium3DTiles/Tilesets/Tileset/tileset.json";
-
     let scene;
     beforeAll(function () {
       scene = createScene();

--- a/Specs/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorSpec.js
+++ b/Specs/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorSpec.js
@@ -53,29 +53,6 @@ describe(
         return new Cesium3DTilesInspector(document.body);
       }).toThrowDeveloperError();
     });
-
-    describe("logging", function () {
-      let widget;
-      let container;
-
-      beforeAll(function () {
-        container = document.createElement("div");
-        container.id = "testContainer";
-        document.body.appendChild(container);
-        widget = new Cesium3DTilesInspector("testContainer", scene);
-
-        const viewModel = widget.viewModel;
-        viewModel.tileset = new Cesium3DTileset({
-          url: tilesetUrl,
-        });
-        return viewModel.tileset.readyPromise;
-      });
-
-      afterAll(function () {
-        widget.destroy();
-        document.body.removeChild(container);
-      });
-    });
   },
   "WebGL"
 );

--- a/Specs/addDefaultMatchers.js
+++ b/Specs/addDefaultMatchers.js
@@ -167,6 +167,21 @@ function createDefaultMatchers(debug) {
               return Math.abs(a - b) <= epsilon;
             }
 
+            if (defined(a) && defined(b)) {
+              const keys = Object.keys(a);
+              for (let i = 0; i < keys.length; i++) {
+                if (!b.hasOwnProperty(keys[i])) {
+                  return false;
+                }
+                const aVal = a[keys[i]];
+                const bVal = b[keys[i]];
+                if (!equalityTester(aVal, bVal)) {
+                  return false;
+                }
+              }
+              return true;
+            }
+
             return equals(util, a, b);
           }
 

--- a/Specs/addDefaultMatchers.js
+++ b/Specs/addDefaultMatchers.js
@@ -25,7 +25,7 @@ function createMissingFunctionMessageFunction(
 
 function makeThrowFunction(debug, Type, name) {
   if (debug) {
-    return function (util, customEqualityTesters) {
+    return function (util) {
       return {
         compare: function (actual, expected) {
           // based on the built-in Jasmine toThrow matcher
@@ -79,7 +79,7 @@ function makeThrowFunction(debug, Type, name) {
 
 function createDefaultMatchers(debug) {
   return {
-    toBeBetween: function (util, customEqualityTesters) {
+    toBeBetween: function (util) {
       return {
         compare: function (actual, lower, upper) {
           if (lower > upper) {
@@ -92,7 +92,7 @@ function createDefaultMatchers(debug) {
       };
     },
 
-    toStartWith: function (util, customEqualityTesters) {
+    toStartWith: function (util) {
       return {
         compare: function (actual, expected) {
           return { pass: actual.slice(0, expected.length) === expected };
@@ -100,7 +100,7 @@ function createDefaultMatchers(debug) {
       };
     },
 
-    toEndWith: function (util, customEqualityTesters) {
+    toEndWith: function (util) {
       return {
         compare: function (actual, expected) {
           return { pass: actual.slice(-expected.length) === expected };
@@ -108,20 +108,22 @@ function createDefaultMatchers(debug) {
       };
     },
 
-    toEqual: function (util, customEqualityTesters) {
+    toEqual: function (util) {
       return {
         compare: function (actual, expected) {
           return {
-            pass: equals(util, customEqualityTesters, actual, expected),
+            pass: equals(util, actual, expected),
           };
         },
       };
     },
 
-    toEqualEpsilon: function (util, customEqualityTesters) {
+    toEqualEpsilon: function (util) {
       return {
         compare: function (actual, expected, epsilon) {
           function equalityTester(a, b) {
+            a = typedArrayToArray(a);
+            b = typedArrayToArray(b);
             if (Array.isArray(a) && Array.isArray(b)) {
               if (a.length !== b.length) {
                 return false;
@@ -165,17 +167,16 @@ function createDefaultMatchers(debug) {
               return Math.abs(a - b) <= epsilon;
             }
 
-            return undefined;
+            return equals(util, a, b);
           }
 
-          const result = equals(util, [equalityTester], actual, expected);
-
+          const result = equalityTester(actual, expected);
           return { pass: result };
         },
       };
     },
 
-    toConformToInterface: function (util, customEqualityTesters) {
+    toConformToInterface: function (util) {
       return {
         compare: function (actual, expectedInterface) {
           // All function properties on the prototype should also exist on the actual's prototype.
@@ -204,35 +205,23 @@ function createDefaultMatchers(debug) {
       };
     },
 
-    toRender: function (util, customEqualityTesters) {
+    toRender: function (util) {
       return {
         compare: function (actual, expected) {
-          return renderEquals(
-            util,
-            customEqualityTesters,
-            actual,
-            expected,
-            true
-          );
+          return renderEquals(util, actual, expected, true);
         },
       };
     },
 
-    notToRender: function (util, customEqualityTesters) {
+    notToRender: function (util) {
       return {
         compare: function (actual, expected) {
-          return renderEquals(
-            util,
-            customEqualityTesters,
-            actual,
-            expected,
-            false
-          );
+          return renderEquals(util, actual, expected, false);
         },
       };
     },
 
-    toRenderAndCall: function (util, customEqualityTesters) {
+    toRenderAndCall: function (util) {
       return {
         compare: function (actual, expected) {
           const actualRgba = renderAndReadPixels(actual);
@@ -252,7 +241,7 @@ function createDefaultMatchers(debug) {
       };
     },
 
-    toRenderPixelCountAndCall: function (util, customEqualityTesters) {
+    toRenderPixelCountAndCall: function (util) {
       return {
         compare: function (actual, expected) {
           const actualRgba = renderAndReadPixels(actual);
@@ -272,7 +261,7 @@ function createDefaultMatchers(debug) {
       };
     },
 
-    toPickPrimitive: function (util, customEqualityTesters) {
+    toPickPrimitive: function (util) {
       return {
         compare: function (actual, expected, x, y, width, height) {
           return pickPrimitiveEquals(actual, expected, x, y, width, height);
@@ -280,7 +269,7 @@ function createDefaultMatchers(debug) {
       };
     },
 
-    notToPick: function (util, customEqualityTesters) {
+    notToPick: function (util) {
       return {
         compare: function (actual, x, y, width, height) {
           return pickPrimitiveEquals(actual, undefined, x, y, width, height);
@@ -288,7 +277,7 @@ function createDefaultMatchers(debug) {
       };
     },
 
-    toDrillPickPrimitive: function (util, customEqualityTesters) {
+    toDrillPickPrimitive: function (util) {
       return {
         compare: function (actual, expected, x, y, width, height) {
           return drillPickPrimitiveEquals(actual, 1, x, y, width, height);
@@ -296,7 +285,7 @@ function createDefaultMatchers(debug) {
       };
     },
 
-    notToDrillPick: function (util, customEqualityTesters) {
+    notToDrillPick: function (util) {
       return {
         compare: function (actual, x, y, width, height) {
           return drillPickPrimitiveEquals(actual, 0, x, y, width, height);
@@ -304,7 +293,7 @@ function createDefaultMatchers(debug) {
       };
     },
 
-    toPickAndCall: function (util, customEqualityTesters) {
+    toPickAndCall: function (util) {
       return {
         compare: function (actual, expected, args) {
           const scene = actual;
@@ -325,7 +314,7 @@ function createDefaultMatchers(debug) {
       };
     },
 
-    toDrillPickAndCall: function (util, customEqualityTesters) {
+    toDrillPickAndCall: function (util) {
       return {
         compare: function (actual, expected, limit) {
           const scene = actual;
@@ -346,7 +335,7 @@ function createDefaultMatchers(debug) {
       };
     },
 
-    toPickFromRayAndCall: function (util, customEqualityTesters) {
+    toPickFromRayAndCall: function (util) {
       return {
         compare: function (actual, expected, ray, objectsToExclude, width) {
           const scene = actual;
@@ -367,7 +356,7 @@ function createDefaultMatchers(debug) {
       };
     },
 
-    toDrillPickFromRayAndCall: function (util, customEqualityTesters) {
+    toDrillPickFromRayAndCall: function (util) {
       return {
         compare: function (
           actual,
@@ -400,7 +389,7 @@ function createDefaultMatchers(debug) {
       };
     },
 
-    toSampleHeightAndCall: function (util, customEqualityTesters) {
+    toSampleHeightAndCall: function (util) {
       return {
         compare: function (
           actual,
@@ -427,7 +416,7 @@ function createDefaultMatchers(debug) {
       };
     },
 
-    toClampToHeightAndCall: function (util, customEqualityTesters) {
+    toClampToHeightAndCall: function (util) {
       return {
         compare: function (
           actual,
@@ -458,7 +447,7 @@ function createDefaultMatchers(debug) {
       };
     },
 
-    toPickPositionAndCall: function (util, customEqualityTesters) {
+    toPickPositionAndCall: function (util) {
       return {
         compare: function (actual, expected, x, y) {
           const scene = actual;
@@ -482,7 +471,7 @@ function createDefaultMatchers(debug) {
       };
     },
 
-    toReadPixels: function (util, customEqualityTesters) {
+    toReadPixels: function (util) {
       return {
         compare: function (actual, expected) {
           let context;
@@ -531,7 +520,7 @@ function createDefaultMatchers(debug) {
       };
     },
 
-    notToReadPixels: function (util, customEqualityTesters) {
+    notToReadPixels: function (util) {
       return {
         compare: function (actual, expected) {
           const context = actual;
@@ -561,7 +550,7 @@ function createDefaultMatchers(debug) {
       };
     },
 
-    contextToRenderAndCall: function (util, customEqualityTesters) {
+    contextToRenderAndCall: function (util) {
       return {
         compare: function (actual, expected) {
           const actualRgba = contextRenderAndReadPixels(actual).color;
@@ -581,7 +570,7 @@ function createDefaultMatchers(debug) {
       };
     },
 
-    contextToRender: function (util, customEqualityTesters) {
+    contextToRender: function (util) {
       return {
         compare: function (actual, expected) {
           return expectContextToRender(actual, expected, true);
@@ -589,7 +578,7 @@ function createDefaultMatchers(debug) {
       };
     },
 
-    notContextToRender: function (util, customEqualityTesters) {
+    notContextToRender: function (util) {
       return {
         compare: function (actual, expected) {
           return expectContextToRender(actual, expected, false);
@@ -597,7 +586,7 @@ function createDefaultMatchers(debug) {
       };
     },
 
-    toBeImageOrImageBitmap: function (util, customEqualityTesters) {
+    toBeImageOrImageBitmap: function (util) {
       return {
         compare: function (actual) {
           if (typeof createImageBitmap !== "function") {
@@ -673,13 +662,7 @@ function typedArrayToArray(array) {
   return array;
 }
 
-function renderEquals(
-  util,
-  customEqualityTesters,
-  actual,
-  expected,
-  expectEqual
-) {
+function renderEquals(util, actual, expected, expectEqual) {
   const actualRgba = renderAndReadPixels(actual);
 
   // When the WebGL stub is used, all WebGL function calls are noops so
@@ -692,7 +675,7 @@ function renderEquals(
     };
   }
 
-  const eq = equals(util, customEqualityTesters, actualRgba, expected);
+  const eq = equals(util, actualRgba, expected);
   const pass = expectEqual ? eq : !eq;
 
   let message;

--- a/Specs/equals.js
+++ b/Specs/equals.js
@@ -13,9 +13,9 @@ function typedArrayToArray(array) {
   return array;
 }
 
-function equals(util, customEqualiyTesters, a, b) {
+function equals(util, a, b) {
   a = typedArrayToArray(a);
   b = typedArrayToArray(b);
-  return util.equals(a, b, customEqualiyTesters);
+  return util.equals(a, b);
 }
 export default equals;

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "gulp-terser": "^2.0.1",
     "gulp-zip": "^5.1.0",
     "husky": "^7.0.2",
-    "jasmine-core": "^3.7.1",
+    "jasmine-core": "^4.0.1",
     "jsdoc": "^3.6.7",
     "jsep": "^0.3.1",
     "karma": "^5.2.3",


### PR DESCRIPTION
Most deprecation warnings we have are from `customEqualityTesters` no longer being passed as an argument. Instead, they're now added to the `MatchersUtil` object before tests run (see [docs](https://jasmine.github.io/tutorials/upgrading_to_Jasmine_4.0#matchers-cet) for more info). Removing the argument from our matchers and `equals.js` should work for everything as is except for `toEqualEpsilon`, which has some changes:

- Uses its own `equalityTester` function instead of `equals.js` in case it passes or fails; this mimics Jasmine's behavior of trying custom matchers before the built-in `equals` check.
- First the tester function converts `a` and `b` to mimic the behavior in `equals.js`. 
- Adds a loop over `a`'s object keys if the arguments are not arrays and don't have `equalsEpsilon` member functions; this loop recursively calls the equality tester on keys that both `a` and `b` have.
- If none of the early returns are hit, checks for exact equality using `equals.js`


There is one last deprecation warning because of an empty describe in [Cesium3DTilesInspectorSpec](https://github.com/CesiumGS/cesium-analytics/blob/4c5a2824c29c29d36ff6510b42f33c0b0fb4437d/Specs/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorSpec.js#L57) -

```
'DEPRECATION: describe with no children (describe() or it()) is deprecated and will be removed in a future version of Jasmine. Please either remove the describe or add children to it.
    at <Jasmine>
    at window.describe (http://localhost:9876/base/Specs/customizeJasmine.js:36:5)
    at Proxy.<anonymous> (http://localhost:9876/base/Specs/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorSpec.js?e3399e5268c227836e31512241a0d2df36611c45:57:5)
    at <Jasmine>
Note: This message will be shown only once. Set the verboseDeprecations config property to true to see every occurrence.'
```

I wasn't sure right away how we wanted to handle this describe block - @ggetz any thoughts on this one?