### PR TITLE
Support skinning in `ModelExperimental`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Additions :tada:
 
 - Added support for morph targets in `ModelExperimental`. [#10271](https://github.com/CesiumGS/cesium/pull/10271)
+- Added support for skins in `ModelExperimental`. [#10282](https://github.com/CesiumGS/cesium/pull/10282)
 
 ### 1.92 - 2022-04-01
 

--- a/Source/Scene/GltfLoader.js
+++ b/Source/Scene/GltfLoader.js
@@ -1440,7 +1440,9 @@ function loadSkin(loader, gltf, gltfSkin, nodes) {
         skin.inverseBindMatrices = inverseBindMatrices;
       });
     }
-  } else {
+  }
+
+  if (!defined(skin.inverseBindMatrices)) {
     skin.inverseBindMatrices = arrayFill(
       new Array(jointsLength),
       Matrix4.IDENTITY

--- a/Source/Scene/GltfLoader.js
+++ b/Source/Scene/GltfLoader.js
@@ -1417,11 +1417,13 @@ function loadSkin(loader, gltf, gltfSkin, nodes) {
   }
   skin.joints = joints;
 
+  let useDefaultBindMatrices = true;
   const inverseBindMatricesAccessorId = gltfSkin.inverseBindMatrices;
   if (defined(inverseBindMatricesAccessorId)) {
     const accessor = gltf.accessors[inverseBindMatricesAccessorId];
     const bufferViewId = accessor.bufferView;
     if (defined(bufferViewId)) {
+      useDefaultBindMatrices = false;
       const bufferViewLoader = loadBufferView(loader, gltf, bufferViewId);
       bufferViewLoader.promise.then(function (bufferViewLoader) {
         if (loader.isDestroyed()) {
@@ -1442,7 +1444,7 @@ function loadSkin(loader, gltf, gltfSkin, nodes) {
     }
   }
 
-  if (!defined(skin.inverseBindMatrices)) {
+  if (useDefaultBindMatrices) {
     skin.inverseBindMatrices = arrayFill(
       new Array(jointsLength),
       Matrix4.IDENTITY

--- a/Source/Scene/GltfLoader.js
+++ b/Source/Scene/GltfLoader.js
@@ -1333,52 +1333,10 @@ function loadInstanceFeaturesLegacy(
   }
 }
 
-function loadSkin(loader, gltf, gltfSkin, nodes) {
-  const skin = new Skin();
-
-  const jointIds = gltfSkin.joints;
-  const jointsLength = jointIds.length;
-  const joints = new Array(jointsLength);
-  for (let i = 0; i < jointsLength; ++i) {
-    joints[i] = nodes[jointIds[i]];
-  }
-  skin.joints = joints;
-
-  const inverseBindMatricesAccessorId = gltfSkin.inverseBindMatrices;
-  if (defined(inverseBindMatricesAccessorId)) {
-    const accessor = gltf.accessors[inverseBindMatricesAccessorId];
-    const bufferViewId = accessor.bufferView;
-    if (defined(bufferViewId)) {
-      const bufferViewLoader = loadBufferView(loader, gltf, bufferViewId);
-      bufferViewLoader.promise.then(function (bufferViewLoader) {
-        if (loader.isDestroyed()) {
-          return;
-        }
-        const bufferViewTypedArray = bufferViewLoader.typedArray;
-        const packedTypedArray = getPackedTypedArray(
-          gltf,
-          accessor,
-          bufferViewTypedArray
-        );
-        const inverseBindMatrices = new Array(jointsLength);
-        for (let i = 0; i < jointsLength; ++i) {
-          inverseBindMatrices[i] = Matrix4.unpack(packedTypedArray, i * 16);
-        }
-        skin.inverseBindMatrices = inverseBindMatrices;
-      });
-    }
-  } else {
-    skin.inverseBindMatrices = arrayFill(
-      new Array(jointsLength),
-      Matrix4.IDENTITY
-    );
-  }
-
-  return skin;
-}
-
 function loadNode(loader, gltf, gltfNode, supportedImageFormats, frameState) {
   const node = new Node();
+
+  node.name = gltfNode.name;
 
   node.matrix = fromArray(Matrix4, gltfNode.matrix);
   node.translation = fromArray(Cartesian3, gltfNode.translation);
@@ -1424,13 +1382,15 @@ function loadNodes(loader, gltf, supportedImageFormats, frameState) {
   const nodesLength = gltf.nodes.length;
   const nodes = new Array(nodesLength);
   for (i = 0; i < nodesLength; ++i) {
-    nodes[i] = loadNode(
+    const node = loadNode(
       loader,
       gltf,
       gltf.nodes[i],
       supportedImageFormats,
       frameState
     );
+    node.index = i;
+    nodes[i] = node;
   }
 
   for (i = 0; i < nodesLength; ++i) {
@@ -1443,14 +1403,78 @@ function loadNodes(loader, gltf, supportedImageFormats, frameState) {
     }
   }
 
+  return nodes;
+}
+
+function loadSkin(loader, gltf, gltfSkin, nodes) {
+  const skin = new Skin();
+
+  const jointIds = gltfSkin.joints;
+  const jointsLength = jointIds.length;
+  const joints = new Array(jointsLength);
+  for (let i = 0; i < jointsLength; ++i) {
+    joints[i] = nodes[jointIds[i]];
+  }
+  skin.joints = joints;
+
+  const inverseBindMatricesAccessorId = gltfSkin.inverseBindMatrices;
+  if (defined(inverseBindMatricesAccessorId)) {
+    const accessor = gltf.accessors[inverseBindMatricesAccessorId];
+    const bufferViewId = accessor.bufferView;
+    if (defined(bufferViewId)) {
+      const bufferViewLoader = loadBufferView(loader, gltf, bufferViewId);
+      bufferViewLoader.promise.then(function (bufferViewLoader) {
+        if (loader.isDestroyed()) {
+          return;
+        }
+        const bufferViewTypedArray = bufferViewLoader.typedArray;
+        const packedTypedArray = getPackedTypedArray(
+          gltf,
+          accessor,
+          bufferViewTypedArray
+        );
+        const inverseBindMatrices = new Array(jointsLength);
+        for (let i = 0; i < jointsLength; ++i) {
+          inverseBindMatrices[i] = Matrix4.unpack(packedTypedArray, i * 16);
+        }
+        skin.inverseBindMatrices = inverseBindMatrices;
+      });
+    }
+  } else {
+    skin.inverseBindMatrices = arrayFill(
+      new Array(jointsLength),
+      Matrix4.IDENTITY
+    );
+  }
+
+  return skin;
+}
+
+function loadSkins(loader, gltf, nodes) {
+  let i;
+
+  const gltfSkins = gltf.skins;
+  if (!defined(gltfSkins)) {
+    return [];
+  }
+
+  const skinsLength = gltf.skins.length;
+  const skins = new Array(skinsLength);
+  for (i = 0; i < skinsLength; ++i) {
+    const skin = loadSkin(loader, gltf, gltf.skins[i], nodes);
+    skin.index = i;
+    skins[i] = skin;
+  }
+
+  const nodesLength = nodes.length;
   for (i = 0; i < nodesLength; ++i) {
     const skinId = gltf.nodes[i].skin;
     if (defined(skinId)) {
-      nodes[i].skin = loadSkin(loader, gltf, gltf.skins[skinId], nodes);
+      nodes[i].skin = skins[skinId];
     }
   }
 
-  return nodes;
+  return skins;
 }
 
 function loadStructuralMetadata(
@@ -1518,6 +1542,7 @@ function parse(loader, gltf, supportedImageFormats, frameState) {
   }
 
   const nodes = loadNodes(loader, gltf, supportedImageFormats, frameState);
+  const skins = loadSkins(loader, gltf, nodes);
   const scene = loadScene(gltf, nodes);
 
   const components = new Components();
@@ -1533,6 +1558,7 @@ function parse(loader, gltf, supportedImageFormats, frameState) {
   components.asset = asset;
   components.scene = scene;
   components.nodes = nodes;
+  components.skins = skins;
   components.upAxis = loader._upAxis;
   components.forwardAxis = loader._forwardAxis;
 

--- a/Source/Scene/ModelComponents.js
+++ b/Source/Scene/ModelComponents.js
@@ -674,6 +674,15 @@ function Instances() {
  */
 function Skin() {
   /**
+   * The index of the skin in the glTF. This is useful for finding the skin
+   * that applies to a node after the skin is instantiated at runtime.
+   *
+   * @type {Number}
+   * @private
+   */
+  this.index = undefined;
+
+  /**
    * The joints.
    *
    * @type {ModelComponents.Node[]}
@@ -699,6 +708,23 @@ function Skin() {
  * @private
  */
 function Node() {
+  /**
+   * The name of the node.
+   *
+   * @type {String}
+   * @private
+   */
+  this.name = undefined;
+
+  /**
+   * The index of the node in the glTF. This is useful for finding the nodes
+   * that belong to a skin after they have been instantiated at runtime.
+   *
+   * @type {Number}
+   * @private
+   */
+  this.index = undefined;
+
   /**
    * The children nodes.
    *
@@ -833,6 +859,13 @@ function Components() {
    * @type {ModelComponents.Node[]}
    */
   this.nodes = undefined;
+
+  /**
+   * All skins in the model.
+   *
+   * @type {ModelComponents.Skin[]}
+   */
+  this.skins = undefined;
 
   /**
    * Structural metadata containing the schema, property tables, property

--- a/Source/Scene/ModelExperimental/ModelExperimentalNode.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalNode.js
@@ -305,8 +305,14 @@ ModelExperimentalNode.prototype.updateJointMatrices = function () {
       this.transform,
       computedJointMatrices[i]
     );
-    computedJointMatrices[i] = Matrix4.multiplyTransformation(
+
+    const inverseNodeWorldTransform = Matrix4.inverseTransformation(
       nodeWorldTransform,
+      computedJointMatrices[i]
+    );
+
+    computedJointMatrices[i] = Matrix4.multiplyTransformation(
+      inverseNodeWorldTransform,
       skinJointMatrices[i],
       computedJointMatrices[i]
     );

--- a/Source/Scene/ModelExperimental/ModelExperimentalNode.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalNode.js
@@ -6,7 +6,6 @@ import Matrix4 from "../../Core/Matrix4.js";
 import InstancingPipelineStage from "./InstancingPipelineStage.js";
 import ModelMatrixUpdateStage from "./ModelMatrixUpdateStage.js";
 import ModelExperimentalUtility from "./ModelExperimentalUtility.js";
-import SkinningPipelineStage from "./SkinningPipelineStage.js";
 /**
  * An in-memory representation of a node as part of the {@link ModelExperimentalSceneGraph}.
  *
@@ -276,10 +275,6 @@ ModelExperimentalNode.prototype.configurePipeline = function () {
 
   if (defined(node.instances)) {
     pipelineStages.push(InstancingPipelineStage);
-  }
-
-  if (defined(node.skin)) {
-    pipelineStages.push(SkinningPipelineStage);
   }
 
   updateStages.push(ModelMatrixUpdateStage);

--- a/Source/Scene/ModelExperimental/ModelExperimentalNode.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalNode.js
@@ -6,6 +6,7 @@ import Matrix4 from "../../Core/Matrix4.js";
 import InstancingPipelineStage from "./InstancingPipelineStage.js";
 import ModelMatrixUpdateStage from "./ModelMatrixUpdateStage.js";
 import ModelExperimentalUtility from "./ModelExperimentalUtility.js";
+
 /**
  * An in-memory representation of a node as part of the {@link ModelExperimentalSceneGraph}.
  *

--- a/Source/Scene/ModelExperimental/ModelExperimentalNode.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalNode.js
@@ -283,7 +283,7 @@ ModelExperimentalNode.prototype.configurePipeline = function () {
 
 /**
  * Updates the joint matrices for this node, where each matrix is computed as
- * [computedJointMatrix] = [nodeWorldTransform]^-1 * [skinjointMatrix].
+ * computedJointMatrix = nodeWorldTransform^(-1) * skinJointMatrix.
  *
  * @private
  */

--- a/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
@@ -18,6 +18,7 @@ import MorphTargetsPipelineStage from "./MorphTargetsPipelineStage.js";
 import PickingPipelineStage from "./PickingPipelineStage.js";
 import PointCloudAttenuationPipelineStage from "./PointCloudAttenuationPipelineStage.js";
 import SelectedFeatureIdPipelineStage from "./SelectedFeatureIdPipelineStage.js";
+import SkinningPipelineStage from "./SkinningPipelineStage.js";
 
 /**
  * In memory representation of a single primitive, that is, a primitive
@@ -123,6 +124,7 @@ ModelExperimentalPrimitive.prototype.configurePipeline = function () {
 
   const hasMorphTargets =
     defined(primitive.morphTargets) && primitive.morphTargets.length > 0;
+  const hasSkinning = defined(node.skin);
   const hasCustomShader = defined(customShader);
   const hasCustomFragmentShader =
     hasCustomShader && defined(customShader.fragmentShaderText);
@@ -145,6 +147,10 @@ ModelExperimentalPrimitive.prototype.configurePipeline = function () {
 
   if (hasMorphTargets) {
     pipelineStages.push(MorphTargetsPipelineStage);
+  }
+
+  if (hasSkinning) {
+    pipelineStages.push(SkinningPipelineStage);
   }
 
   if (hasAttenuation && primitive.primitiveType === PrimitiveType.POINTS) {

--- a/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
@@ -101,7 +101,7 @@ export default function ModelExperimentalSceneGraph(options) {
 
   /**
    * The indices of the skinned nodes in the runtime nodes array. These refer
-   * to the nodes that will be manipulated by their skin, as oppose to the nodes
+   * to the nodes that will be manipulated by their skin, as opposed to the nodes
    * acting as joints for the skin.
    *
    * @type {Number[]}
@@ -225,8 +225,8 @@ function initialize(sceneGraph) {
   const skins = components.skins;
   const runtimeSkins = sceneGraph._runtimeSkins;
 
-  const length = skins.length;
-  for (let i = 0; i < length; i++) {
+  const skinsLength = skins.length;
+  for (let i = 0; i < skinsLength; i++) {
     const skin = skins[i];
     runtimeSkins.push(
       new ModelExperimentalSkin({
@@ -237,7 +237,8 @@ function initialize(sceneGraph) {
   }
 
   const skinnedNodes = sceneGraph._skinnedNodes;
-  for (let i = 0; i < skinnedNodes.length; i++) {
+  const skinnedNodesLength = skinnedNodes.length;
+  for (let i = 0; i < skinnedNodesLength; i++) {
     const skinnedNodeIndex = skinnedNodes[i];
     const skinnedNode = sceneGraph._runtimeNodes[skinnedNodeIndex];
 
@@ -295,7 +296,8 @@ function traverseSceneGraph(sceneGraph, node, transformToRoot) {
   // Traverse through scene graph.
   let i;
   if (defined(node.children)) {
-    for (i = 0; i < node.children.length; i++) {
+    const childrenLength = node.children.length;
+    for (i = 0; i < childrenLength; i++) {
       const childNode = node.children[i];
       const childNodeTransformToRoot = Matrix4.multiplyTransformation(
         transformToRoot,
@@ -322,7 +324,8 @@ function traverseSceneGraph(sceneGraph, node, transformToRoot) {
   });
 
   if (defined(node.primitives)) {
-    for (i = 0; i < node.primitives.length; i++) {
+    const primitivesLength = node.primitives.length;
+    for (i = 0; i < primitivesLength; i++) {
       runtimeNode.runtimePrimitives.push(
         new ModelExperimentalPrimitive({
           primitive: node.primitives[i],

--- a/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
@@ -216,13 +216,18 @@ function initialize(sceneGraph) {
   }
 
   // Handle skins after all runtime nodes are created
-  const skins = sceneGraph.components.skins;
+  const skins = components.skins;
   const runtimeSkins = sceneGraph._runtimeSkins;
 
   const length = skins.length;
   for (let i = 0; i < length; i++) {
     const skin = skins[i];
-    runtimeSkins.push(new ModelExperimentalSkin(skin, sceneGraph));
+    runtimeSkins.push(
+      new ModelExperimentalSkin({
+        skin: skin,
+        sceneGraph: sceneGraph,
+      })
+    );
   }
 
   const skinnedNodes = sceneGraph._skinnedNodes;
@@ -236,6 +241,7 @@ function initialize(sceneGraph) {
     const skinIndex = skin.index;
 
     skinnedNode._runtimeSkin = runtimeSkins[skinIndex];
+    skinnedNode.updateJointMatrices();
   }
 }
 

--- a/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
@@ -207,8 +207,9 @@ function initialize(sceneGraph) {
   sceneGraph._runtimeNodes = new Array(nodesLength);
 
   const rootNodes = scene.nodes;
+  const rootNodesLength = rootNodes.length;
   const transformToRoot = Matrix4.IDENTITY;
-  for (let i = 0; i < rootNodes.length; i++) {
+  for (let i = 0; i < rootNodesLength; i++) {
     const rootNode = scene.nodes[i];
 
     const rootNodeIndex = traverseSceneGraph(
@@ -502,8 +503,9 @@ ModelExperimentalSceneGraph.prototype.updateModelMatrix = function () {
 ModelExperimentalSceneGraph.prototype.updateJointMatrices = function () {
   const model = this._model;
   const skinnedNodes = model._skinnedNodes;
+  const length = skinnedNodes.length;
 
-  for (let i = 0; i < skinnedNodes.length; i++) {
+  for (let i = 0; i < length; i++) {
     const node = skinnedNodes[i];
     node.updateJointMatrices();
   }

--- a/Source/Scene/ModelExperimental/ModelExperimentalSkin.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalSkin.js
@@ -1,0 +1,137 @@
+import Check from "../../Core/Check.js";
+import defaultValue from "../../Core/defaultValue.js";
+
+/**
+ * An in-memory representation of a skin that affects nodes in the {@link ModelExperimentalSceneGraph}.
+ * Skins should only be initialized after all of the {@link ModelExperimentalNode}s have been instantiated
+ * by the scene graph.
+ *
+ * @param {Object} options An object containing the following options:
+ * @param {ModelComponents.Skin} options.skin The corresponding skin components from the 3D model
+ * @param {ModelExperimentalSceneGraph} options.sceneGraph The scene graph this skin belongs to.
+ *
+ * @alias ModelExperimentalSkin
+ * @constructor
+ *
+ * @private
+ */
+export default function ModelExperimentalSkin(options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.skin", options.skin);
+  Check.typeOf.object("options.sceneGraph", options.sceneGraph);
+  //>>includeEnd('debug');
+
+  this._sceneGraph = options.sceneGraph;
+  const skin = options.skin;
+
+  this._skin = skin;
+
+  this._inverseBindMatrices = undefined;
+  this._joints = [];
+  this._computedJointMatrices = [];
+
+  initialize(this);
+}
+
+Object.defineProperties(ModelExperimentalSkin.prototype, {
+  /**
+   * The internal skin this runtime skin represents.
+   *
+   * @memberof ModelExperimentalSkin.prototype
+   * @type {ModelComponents.Skin}
+   * @readonly
+   *
+   * @private
+   */
+  skin: {
+    get: function () {
+      return this._skin;
+    },
+  },
+
+  /**
+   * The scene graph this skin belongs to.
+   *
+   * @type {ModelExperimentalSceneGraph}
+   * @readonly
+   *
+   * @private
+   */
+  sceneGraph: {
+    get: function () {
+      return this._sceneGraph;
+    },
+  },
+
+  /**
+   * The inverse bind matrices of the skin.
+   *
+   * @memberof ModelExperimentalSkin.prototype
+   * @type {Matrix4[]}
+   * @readonly
+   *
+   * @private
+   */
+  inverseBindMatrices: {
+    get: function () {
+      return this._inverseBindMatrices;
+    },
+  },
+
+  /**
+   * The joints of the skin.
+   *
+   * @memberof ModelExperimentalSkin.prototype
+   * @type {ModelExperimentalNode[]}
+   * @readonly
+   *
+   * @private
+   */
+  joints: {
+    get: function () {
+      return this._joints;
+    },
+  },
+
+  /**
+   * The computed joint matrices for the skin.
+   *
+   * @memberof ModelExperimentalSkin.prototype
+   * @type {Matrix4[]}
+   * @readonly
+   *
+   * @private
+   */
+  computedJointMatrices: {
+    get: function () {
+      return this._computedJointMatrices;
+    },
+  },
+});
+
+function initialize(runtimeSkin) {
+  const skin = runtimeSkin._skin;
+  runtimeSkin._inverseBindMatrices = skin.inverseBindMatrices;
+
+  const joints = skin.joints;
+  const length = joints.length;
+
+  const runtimeNodes = runtimeSkin._sceneGraph._runtimeNodes;
+  const runtimeJoints = runtimeSkin.joints;
+  for (let i = 0; i < length; i++) {
+    const jointIndex = joints[i].index;
+    const runtimeNode = runtimeNodes[jointIndex];
+    runtimeJoints.push(runtimeNode);
+  }
+
+  // TODO: compute matrices
+  runtimeSkin._computedJointMatrices = new Array(length);
+}
+
+/**
+ * Updates the joint matrices for the skin.
+ *
+ * @private
+ */
+ModelExperimentalSkin.prototype.updateSkin = function () {};

--- a/Source/Scene/ModelExperimental/SkinningPipelineStage.js
+++ b/Source/Scene/ModelExperimental/SkinningPipelineStage.js
@@ -69,7 +69,7 @@ function addGetSkinningMatrixFunction(shaderBuilder, node) {
   );
 
   const initialLine = "mat4 skinnedMatrix = mat4(0);";
-  shaderBuilder.addFunction(
+  shaderBuilder.addFunctionLines(
     SkinningPipelineStage.FUNCTION_ID_GET_SKINNING_MATRIX,
     [initialLine]
   );
@@ -81,7 +81,7 @@ function addGetSkinningMatrixFunction(shaderBuilder, node) {
   for (let i = 0; i < length; i++) {
     const component = componentStrings[componentIndex];
     const line = `skinnedMatrix += a_weights_${attributeIndex}.${component} * u_jointMatrices[int(a_joints_${attributeIndex}.${component})];`;
-    shaderBuilder.addFunction(
+    shaderBuilder.addFunctionLines(
       SkinningPipelineStage.FUNCTION_ID_GET_SKINNING_MATRIX,
       [line]
     );
@@ -95,7 +95,7 @@ function addGetSkinningMatrixFunction(shaderBuilder, node) {
   }
 
   const returnLine = "return skinnedMatrix;";
-  shaderBuilder.addFunction(
+  shaderBuilder.addFunctionLines(
     SkinningPipelineStage.FUNCTION_ID_GET_SKINNING_MATRIX,
     [returnLine]
   );

--- a/Source/Scene/ModelExperimental/SkinningPipelineStage.js
+++ b/Source/Scene/ModelExperimental/SkinningPipelineStage.js
@@ -25,15 +25,14 @@ SkinningPipelineStage.FUNCTION_SIGNATURE_GET_SKINNING_MATRIX =
  *
  * Processes a primitive. This stage modifies the following parts of the render resources:
  * <ul>
- *  <li> adds the uniform declaration for the joint matrices in the vertex shader
- *  <li> adds the function to compute the skinning matrix in the vertex shader
+ *  <li> adds the uniform declaration for the joint matrices in the vertex shader</li>
+ *  <li> adds the function to compute the skinning matrix in the vertex shader</li>
  * </ul>
  *
  * @param {PrimitiveRenderResources} renderResources The render resources for this primitive.
  * @param {ModelComponents.Primitive} primitive The primitive.
  * @private
  */
-
 SkinningPipelineStage.process = function (renderResources, primitive) {
   const shaderBuilder = renderResources.shaderBuilder;
 
@@ -53,7 +52,7 @@ SkinningPipelineStage.process = function (renderResources, primitive) {
 
   const uniformMap = {
     u_jointMatrices: function () {
-      return jointMatrices;
+      return runtimeNode.computedJointMatrices;
     },
   };
 
@@ -100,6 +99,7 @@ function addGetSkinningMatrixFunction(shaderBuilder, primitive) {
   for (setIndex = 0; setIndex <= maximumSetIndex; setIndex++) {
     for (componentIndex = 0; componentIndex <= 3; componentIndex++) {
       const component = componentStrings[componentIndex];
+      // Example: skinnedMatrix += a_weights_0.x * u_jointMatrices[int(a_joints_0.x)];
       const line = `skinnedMatrix += a_weights_${setIndex}.${component} * u_jointMatrices[int(a_joints_${setIndex}.${component})];`;
       shaderBuilder.addFunctionLines(
         SkinningPipelineStage.FUNCTION_ID_GET_SKINNING_MATRIX,

--- a/Source/Scene/ModelExperimental/SkinningPipelineStage.js
+++ b/Source/Scene/ModelExperimental/SkinningPipelineStage.js
@@ -118,5 +118,3 @@ function addGetSkinningMatrixFunction(shaderBuilder, primitive) {
 }
 
 export default SkinningPipelineStage;
-
-// TODO: testing (sandcastle + additional unit tests?)

--- a/Source/Scene/ModelExperimental/SkinningPipelineStage.js
+++ b/Source/Scene/ModelExperimental/SkinningPipelineStage.js
@@ -1,0 +1,104 @@
+import combine from "../../Core/combine.js";
+import ShaderDestination from "../../Renderer/ShaderDestination.js";
+import SkinningStageVS from "../../Shaders/ModelExperimental/SkinningStageVS.js";
+
+/**
+ * The skinning pipeline stage processes the joint matrices of a skinned node.
+ *
+ * @namespace SkinningPipelineStage
+ *
+ * @private
+ */
+
+const SkinningPipelineStage = {};
+SkinningPipelineStage.name = "SkinningPipelineStage"; // Helps with debugging
+
+SkinningPipelineStage.FUNCTION_ID_GET_SKINNING_MATRIX = "getSkinningMatrix";
+SkinningPipelineStage.FUNCTION_SIGNATURE_GET_SKINNING_MATRIX =
+  "mat4 getSkinningMatrix()";
+
+/**
+ * This pipeline stage processes the joint matrices of a skinned node, adding the relevant functions
+ * and uniforms to the shaders. The joint and weight attributes of the primitive itself will be
+ * processed in the geometry pipeline stage.
+ *
+ * Processes a node. This stage modifies the following parts of the render resources:
+ * <ul>
+ *  <li> adds the uniform declaration for the joint matrices in the vertex shader
+ *  <li> adds the function to compute the skinning matrix in the vertex shader
+ * </ul>
+ *
+ * @param {NodeRenderResources} renderResources The render resources for this node.
+ * @param {ModelComponents.Node} node The node.
+ * @param {FrameState} frameState The frame state.
+ * @private
+ */
+
+SkinningPipelineStage.process = function (renderResources, node, frameState) {
+  const shaderBuilder = renderResources.shaderBuilder;
+
+  shaderBuilder.addDefine("HAS_SKINNING", undefined, ShaderDestination.VERTEX);
+
+  addGetSkinningMatrixFunction(shaderBuilder, node);
+
+  const runtimeNode = renderResources.runtimeNode;
+  const jointMatrices = runtimeNode.computedJointMatrices;
+
+  shaderBuilder.addUniform(
+    "mat4",
+    `u_jointMatrices[${jointMatrices.length}]`,
+    ShaderDestination.VERTEX
+  );
+
+  shaderBuilder.addVertexLines([SkinningStageVS]);
+
+  const uniformMap = {
+    u_jointMatrices: function () {
+      return jointMatrices;
+    },
+  };
+
+  renderResources.uniformMap = combine(uniformMap, renderResources.uniformMap);
+};
+
+function addGetSkinningMatrixFunction(shaderBuilder, node) {
+  shaderBuilder.addFunction(
+    SkinningPipelineStage.FUNCTION_ID_GET_SKINNING_MATRIX,
+    SkinningPipelineStage.FUNCTION_SIGNATURE_GET_SKINNING_MATRIX,
+    ShaderDestination.VERTEX
+  );
+
+  const initialLine = "mat4 skinnedMatrix = mat4(0);";
+  shaderBuilder.addFunction(
+    SkinningPipelineStage.FUNCTION_ID_GET_SKINNING_MATRIX,
+    [initialLine]
+  );
+
+  let attributeIndex = 0;
+  let componentIndex = 0;
+  const componentStrings = ["x", "y", "z", "w"];
+  const length = node.skin.joints.length;
+  for (let i = 0; i < length; i++) {
+    const component = componentStrings[componentIndex];
+    const line = `skinnedMatrix += a_weights_${attributeIndex}.${component} * u_jointMatrices[int(a_joints_${attributeIndex}.${component})];`;
+    shaderBuilder.addFunction(
+      SkinningPipelineStage.FUNCTION_ID_GET_SKINNING_MATRIX,
+      [line]
+    );
+
+    if (componentIndex === 3) {
+      componentIndex = 0;
+      attributeIndex++;
+    } else {
+      componentIndex++;
+    }
+  }
+
+  const returnLine = "return skinnedMatrix;";
+  shaderBuilder.addFunction(
+    SkinningPipelineStage.FUNCTION_ID_GET_SKINNING_MATRIX,
+    [returnLine]
+  );
+}
+
+export default SkinningPipelineStage;

--- a/Source/Scene/ModelExperimental/SkinningPipelineStage.js
+++ b/Source/Scene/ModelExperimental/SkinningPipelineStage.js
@@ -74,9 +74,7 @@ function getMaximumAttributeSetIndex(primitive) {
       continue;
     }
 
-    if (attribute.setIndex > setIndex) {
-      setIndex = attribute.setIndex;
-    }
+    setIndex = Math.max(setIndex, attribute.setIndex);
   }
 
   return setIndex;

--- a/Source/Shaders/ModelExperimental/ModelExperimentalVS.glsl
+++ b/Source/Shaders/ModelExperimental/ModelExperimentalVS.glsl
@@ -24,6 +24,10 @@ void main()
     morphTargetsStage(attributes);
     #endif
 
+    #ifdef HAS_SKINNING
+    skinningStage(attributes);
+    #endif
+
     FeatureIds featureIds;
     featureIdStage(featureIds, attributes);
 

--- a/Source/Shaders/ModelExperimental/SkinningStageVS.glsl
+++ b/Source/Shaders/ModelExperimental/SkinningStageVS.glsl
@@ -3,8 +3,8 @@ void skinningStage(inout ProcessedAttributes attributes)
     mat4 skinningMatrix = getSkinningMatrix();
     mat3 skinningMatrixMat3 = mat3(skinningMatrix);
 
-    vec3 positionMC = attributes.positionMC;
-    attributes.positionMC = skinningMatrix * positionMC;
+    vec4 positionMC = vec4(attributes.positionMC, 1.0);
+    attributes.positionMC = vec3(skinningMatrix * positionMC);
 
     #ifdef HAS_NORMALS
     vec3 normalMC = attributes.normalMC;

--- a/Source/Shaders/ModelExperimental/SkinningStageVS.glsl
+++ b/Source/Shaders/ModelExperimental/SkinningStageVS.glsl
@@ -1,0 +1,18 @@
+void skinningStage(inout ProcessedAttributes attributes) 
+{
+    mat4 skinningMatrix = getSkinningMatrix();
+    mat3 skinningMatrixMat3 = mat3(skinningMatrix);
+
+    vec3 positionMC = attributes.positionMC;
+    attributes.positionMC = skinningMatrix * positionMC;
+
+    #ifdef HAS_NORMALS
+    vec3 normalMC = attributes.normalMC;
+    attributes.normalMC = skinningMatrixMat3 * normalMC;
+    #endif
+
+    #ifdef HAS_TANGENTS
+    vec3 tangentMC = attributes.tangentMC;
+    attributes.tangentMC = skinningMatrixMat3 * tangentMC;
+    #endif
+}

--- a/Specs/Scene/GltfLoaderSpec.js
+++ b/Specs/Scene/GltfLoaderSpec.js
@@ -709,6 +709,8 @@ describe(
         expect(weightsAttribute.byteOffset).toBe(160);
         expect(weightsAttribute.byteStride).toBe(16);
 
+        expect(components.skins).toEqual([skin]);
+
         expect(skin.joints.length).toBe(2);
         expect(skin.joints[0]).toBe(nodes[1]);
         expect(skin.joints[1]).toBe(nodes[2]);

--- a/Specs/Scene/ModelExperimental/ModelExperimentalNodeSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalNodeSpec.js
@@ -5,7 +5,6 @@ import {
   Matrix4,
   ModelExperimentalNode,
   ModelMatrixUpdateStage,
-  SkinningPipelineStage,
 } from "../../../Source/Cesium.js";
 
 describe("Scene/ModelExperimental/ModelExperimentalNode", function () {
@@ -134,40 +133,6 @@ describe("Scene/ModelExperimental/ModelExperimentalNode", function () {
 
     expect(node.pipelineStages.length).toBe(1);
     expect(node.pipelineStages[0]).toEqual(InstancingPipelineStage);
-    expect(node.updateStages).toEqual([ModelMatrixUpdateStage]);
-    expect(node.runtimePrimitives).toEqual([]);
-  });
-
-  it("adds skinning pipeline stage if node is skinned", function () {
-    const mockSkin = {
-      index: 0,
-      inverseBindMatrices: [
-        Matrix4.clone(Matrix4.IDENTITY),
-        Matrix4.clone(Matrix4.IDENTITY),
-      ],
-      joints: [],
-    };
-
-    const skinnedMockNode = {
-      skin: mockSkin,
-    };
-
-    const node = new ModelExperimentalNode({
-      node: skinnedMockNode,
-      transform: transform,
-      transformToRoot: transformToRoot,
-      sceneGraph: mockSceneGraph,
-      children: [],
-    });
-
-    expect(node.node).toBe(skinnedMockNode);
-    expect(node.sceneGraph).toBe(mockSceneGraph);
-    expect(node.children.length).toEqual(0);
-
-    verifyTransforms(transform, transformToRoot, node);
-
-    expect(node.pipelineStages.length).toBe(1);
-    expect(node.pipelineStages[0]).toEqual(SkinningPipelineStage);
     expect(node.updateStages).toEqual([ModelMatrixUpdateStage]);
     expect(node.runtimePrimitives).toEqual([]);
   });

--- a/Specs/Scene/ModelExperimental/ModelExperimentalPrimitiveSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalPrimitiveSpec.js
@@ -10,7 +10,6 @@ import {
   GeometryPipelineStage,
   LightingPipelineStage,
   MaterialPipelineStage,
-  Matrix4,
   MetadataPipelineStage,
   ModelExperimentalPrimitive,
   ModelExperimentalType,

--- a/Specs/Scene/ModelExperimental/ModelExperimentalPrimitiveSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalPrimitiveSpec.js
@@ -1,5 +1,6 @@
 import {
   AlphaPipelineStage,
+  BatchTexturePipelineStage,
   CustomShader,
   CustomShaderMode,
   CustomShaderPipelineStage,
@@ -9,7 +10,9 @@ import {
   GeometryPipelineStage,
   LightingPipelineStage,
   MaterialPipelineStage,
+  Matrix4,
   MetadataPipelineStage,
+  ModelExperimentalPrimitive,
   ModelExperimentalType,
   MorphTargetsPipelineStage,
   PickingPipelineStage,
@@ -17,9 +20,8 @@ import {
   PointCloudShading,
   PrimitiveType,
   SelectedFeatureIdPipelineStage,
+  SkinningPipelineStage,
   VertexAttributeSemantic,
-  BatchTexturePipelineStage,
-  ModelExperimentalPrimitive,
 } from "../../../Source/Cesium.js";
 
 describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
@@ -496,6 +498,45 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
     const expectedStages = [
       GeometryPipelineStage,
       MorphTargetsPipelineStage,
+      MaterialPipelineStage,
+      FeatureIdPipelineStage,
+      MetadataPipelineStage,
+      LightingPipelineStage,
+      AlphaPipelineStage,
+    ];
+
+    verifyExpectedStages(primitive.pipelineStages, expectedStages);
+  });
+
+  it("configures the pipeline stages for skinning", function () {
+    const mockSkin = {
+      index: 0,
+      inverseBindMatrices: [],
+      joints: [],
+    };
+
+    const mockNode = {
+      skin: mockSkin,
+    };
+
+    const primitive = new ModelExperimentalPrimitive({
+      primitive: {
+        featureIds: [],
+        featureIdTextures: [],
+        attributes: [],
+        primitiveType: PrimitiveType.GLTF,
+      },
+      node: mockNode,
+      model: {
+        type: ModelExperimentalType.GLTF,
+        featureIdLabel: "featureId_0",
+        pointCloudShading: undefined,
+      },
+    });
+
+    const expectedStages = [
+      GeometryPipelineStage,
+      SkinningPipelineStage,
       MaterialPipelineStage,
       FeatureIdPipelineStage,
       MetadataPipelineStage,

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSceneGraphSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSceneGraphSpec.js
@@ -212,8 +212,8 @@ describe(
         const modelComponents = sceneGraph._modelComponents;
         const runtimeNodes = sceneGraph._runtimeNodes;
 
-        expect(runtimeNodes[1].node).toEqual(modelComponents.nodes[0]);
-        expect(runtimeNodes[0].node).toEqual(modelComponents.nodes[1]);
+        expect(runtimeNodes[0].node).toEqual(modelComponents.nodes[0]);
+        expect(runtimeNodes[1].node).toEqual(modelComponents.nodes[1]);
       });
     });
 
@@ -239,10 +239,10 @@ describe(
         const childTransform = ModelExperimentalUtility.getNodeTransform(
           modelComponents.nodes[1]
         );
-        expect(runtimeNodes[1].transform).toEqual(parentTransform);
-        expect(runtimeNodes[1].transformToRoot).toEqual(Matrix4.IDENTITY);
-        expect(runtimeNodes[0].transform).toEqual(childTransform);
-        expect(runtimeNodes[0].transformToRoot).toEqual(parentTransform);
+        expect(runtimeNodes[0].transform).toEqual(parentTransform);
+        expect(runtimeNodes[0].transformToRoot).toEqual(Matrix4.IDENTITY);
+        expect(runtimeNodes[1].transform).toEqual(childTransform);
+        expect(runtimeNodes[1].transformToRoot).toEqual(parentTransform);
       });
     });
 

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSceneGraphSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSceneGraphSpec.js
@@ -274,11 +274,15 @@ describe(
           runtimeNodes[1],
           runtimeNodes[2],
         ]);
+        expect(runtimeSkins[0].jointMatrices.length).toEqual(2);
 
         const skinnedNodes = sceneGraph._skinnedNodes;
         expect(skinnedNodes[0]).toEqual(0);
+
+        expect(runtimeNodes[0].computedJointMatrices.length).toEqual(2);
       });
     });
+
     it("adds ModelColorPipelineStage when color is set on the model", function () {
       spyOn(ModelColorPipelineStage, "process");
       return loadAndZoomToModelExperimental(

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSceneGraphSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSceneGraphSpec.js
@@ -22,6 +22,8 @@ describe(
       "./Data/Models/PBR/VertexColorTest/VertexColorTest.gltf";
     const buildingsMetadata =
       "./Data/Models/GltfLoader/BuildingsMetadata/glTF/buildings-metadata.gltf";
+    const simpleSkinGltfUrl =
+      "./Data/Models/GltfLoader/SimpleSkin/glTF/SimpleSkin.gltf";
 
     let scene;
 
@@ -203,7 +205,7 @@ describe(
       });
     });
 
-    it("traverses scene graph correctly", function () {
+    it("stores runtime nodes correctly", function () {
       return loadAndZoomToModelExperimental(
         { gltf: parentGltfUrl },
         scene
@@ -214,6 +216,9 @@ describe(
 
         expect(runtimeNodes[0].node).toEqual(modelComponents.nodes[0]);
         expect(runtimeNodes[1].node).toEqual(modelComponents.nodes[1]);
+
+        const rootNodes = sceneGraph._rootNodes;
+        expect(rootNodes[0]).toEqual(0);
       });
     });
 
@@ -246,6 +251,34 @@ describe(
       });
     });
 
+    it("creates runtime skin from model", function () {
+      return loadAndZoomToModelExperimental(
+        { gltf: simpleSkinGltfUrl },
+        scene
+      ).then(function (model) {
+        const sceneGraph = model._sceneGraph;
+        const modelComponents = sceneGraph._modelComponents;
+        const runtimeNodes = sceneGraph._runtimeNodes;
+
+        expect(runtimeNodes[0].node).toEqual(modelComponents.nodes[0]);
+        expect(runtimeNodes[1].node).toEqual(modelComponents.nodes[1]);
+        expect(runtimeNodes[2].node).toEqual(modelComponents.nodes[2]);
+
+        const rootNodes = sceneGraph._rootNodes;
+        expect(rootNodes[0]).toEqual(0);
+        expect(rootNodes[1]).toEqual(1);
+
+        const runtimeSkins = sceneGraph._runtimeSkins;
+        expect(runtimeSkins[0].skin).toEqual(modelComponents.skins[0]);
+        expect(runtimeSkins[0].joints).toEqual([
+          runtimeNodes[1],
+          runtimeNodes[2],
+        ]);
+
+        const skinnedNodes = sceneGraph._skinnedNodes;
+        expect(skinnedNodes[0]).toEqual(0);
+      });
+    });
     it("adds ModelColorPipelineStage when color is set on the model", function () {
       spyOn(ModelColorPipelineStage, "process");
       return loadAndZoomToModelExperimental(

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSkinSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSkinSpec.js
@@ -5,12 +5,18 @@ describe("Scene/ModelExperimental/ModelExperimentalSkin", function () {
   const mockRuntimeNodes = [
     {
       node: mockNodes[0],
+      transform: Matrix4.clone(Matrix4.IDENTITY),
+      transformToRoot: Matrix4.clone(Matrix4.IDENTITY),
     },
     {
       node: mockNodes[1],
+      transform: Matrix4.clone(Matrix4.IDENTITY),
+      transformToRoot: Matrix4.clone(Matrix4.IDENTITY),
     },
     {
       node: mockNodes[2],
+      transform: Matrix4.clone(Matrix4.IDENTITY),
+      transformToRoot: Matrix4.clone(Matrix4.IDENTITY),
     },
   ];
 
@@ -55,5 +61,7 @@ describe("Scene/ModelExperimental/ModelExperimentalSkin", function () {
 
     expect(skin.inverseBindMatrices).toEqual(mockSkin.inverseBindMatrices);
     expect(skin.joints).toEqual([mockRuntimeNodes[1], mockRuntimeNodes[2]]);
+
+    expect(skin.jointMatrices).toEqual([Matrix4.IDENTITY, Matrix4.IDENTITY]);
   });
 });

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSkinSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSkinSpec.js
@@ -1,0 +1,59 @@
+import { Matrix4, ModelExperimentalSkin } from "../../../Source/Cesium.js";
+
+describe("Scene/ModelExperimental/ModelExperimentalSkin", function () {
+  const mockNodes = [{ index: 0 }, { index: 1 }, { index: 2 }];
+  const mockRuntimeNodes = [
+    {
+      node: mockNodes[0],
+    },
+    {
+      node: mockNodes[1],
+    },
+    {
+      node: mockNodes[2],
+    },
+  ];
+
+  const mockSceneGraph = {
+    _runtimeNodes: mockRuntimeNodes,
+  };
+
+  const mockSkin = {
+    inverseBindMatrices: [
+      Matrix4.clone(Matrix4.IDENTITY),
+      Matrix4.clone(Matrix4.IDENTITY),
+    ],
+    joints: [mockNodes[1], mockNodes[2]],
+  };
+
+  it("throws for undefined skin", function () {
+    expect(function () {
+      return new ModelExperimentalSkin({
+        skin: undefined,
+        sceneGraph: mockSceneGraph,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("throws for undefined scene graph", function () {
+    expect(function () {
+      return new ModelExperimentalSkin({
+        skin: mockSkin,
+        sceneGraph: undefined,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("constructs", function () {
+    const skin = new ModelExperimentalSkin({
+      skin: mockSkin,
+      sceneGraph: mockSceneGraph,
+    });
+
+    expect(skin.skin).toBe(mockSkin);
+    expect(skin.sceneGraph).toBe(mockSceneGraph);
+
+    expect(skin.inverseBindMatrices).toEqual(mockSkin.inverseBindMatrices);
+    expect(skin.joints).toEqual([mockRuntimeNodes[1], mockRuntimeNodes[2]]);
+  });
+});

--- a/Specs/Scene/ModelExperimental/ModelMatrixUpdateStageSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelMatrixUpdateStageSpec.js
@@ -117,11 +117,11 @@ describe(
         const sceneGraph = model._sceneGraph;
 
         // The root node is transformed.
-        const rootNode = sceneGraph._runtimeNodes[2];
+        const rootNode = sceneGraph._runtimeNodes[1];
         // The static child node is not transformed relative to the parent.
-        const staticChildNode = sceneGraph._runtimeNodes[0];
+        const staticChildNode = sceneGraph._runtimeNodes[2];
         // The transformed child node is transformed relative to the parent.
-        const transformedChildNode = sceneGraph._runtimeNodes[1];
+        const transformedChildNode = sceneGraph._runtimeNodes[0];
 
         const childTransformation = Matrix4.fromTranslation(
           new Cartesian3(0, 5, 0)
@@ -198,9 +198,9 @@ describe(
           new Cartesian3(1, 1, 1)
         );
 
-        const rootNode = sceneGraph._runtimeNodes[2];
-        const staticChildNode = sceneGraph._runtimeNodes[0];
-        const transformedChildNode = sceneGraph._runtimeNodes[1];
+        const rootNode = sceneGraph._runtimeNodes[1];
+        const staticChildNode = sceneGraph._runtimeNodes[2];
+        const transformedChildNode = sceneGraph._runtimeNodes[0];
 
         const rootPrimitive = rootNode.runtimePrimitives[0];
         const staticChildPrimitive = staticChildNode.runtimePrimitives[0];
@@ -275,9 +275,9 @@ describe(
           new Matrix4()
         );
 
-        const rootNode = sceneGraph._runtimeNodes[2];
-        const staticChildNode = sceneGraph._runtimeNodes[0];
-        const transformedChildNode = sceneGraph._runtimeNodes[1];
+        const rootNode = sceneGraph._runtimeNodes[1];
+        const staticChildNode = sceneGraph._runtimeNodes[2];
+        const transformedChildNode = sceneGraph._runtimeNodes[0];
 
         const rootPrimitive = rootNode.runtimePrimitives[0];
         const staticChildPrimitive = staticChildNode.runtimePrimitives[0];

--- a/Specs/Scene/ModelExperimental/SkinningPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/SkinningPipelineStageSpec.js
@@ -1,6 +1,7 @@
 import {
   combine,
   GltfLoader,
+  Matrix4,
   ModelExperimentalType,
   Resource,
   ResourceCache,
@@ -60,13 +61,20 @@ describe(
     const simpleSkinUrl =
       "./Data/Models/GltfLoader/SimpleSkin/glTF/SimpleSkin.gltf";
 
-    /*it("processes simple skin", function () {
+    it("processes simple skin", function () {
+      const mockJointMatrices = [
+        new Matrix4(),
+        Matrix4.clone(Matrix4.IDENTITY),
+      ];
       const renderResources = {
         attributes: [],
         shaderBuilder: new ShaderBuilder(),
         attributeIndex: 1,
         model: {
           type: ModelExperimentalType.TILE_GLTF,
+        },
+        runtimeNode: {
+          computedJointMatrices: mockJointMatrices,
         },
       };
 
@@ -101,10 +109,13 @@ describe(
           "uniform mat4 u_jointMatrices[2];",
         ]);
 
+        const runtimeNode = renderResources.runtimeNode;
         const uniformMap = renderResources.uniformMap;
-        expect(uniformMap.u_jointMatrices()).toBe(node.computedJointMatrices);
+        expect(uniformMap.u_jointMatrices()).toBe(
+          runtimeNode.computedJointMatrices
+        );
       });
-    });*/
+    });
   },
   "WebGL"
 );

--- a/Specs/Scene/ModelExperimental/SkinningPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/SkinningPipelineStageSpec.js
@@ -60,8 +60,10 @@ describe(
 
     const simpleSkinUrl =
       "./Data/Models/GltfLoader/SimpleSkin/glTF/SimpleSkin.gltf";
+    const cesiumManUrl =
+      "./Data/Models/DracoCompression/CesiumMan/CesiumMan.gltf";
 
-    it("processes simple skin", function () {
+    it("processes skin with two joints", function () {
       const mockJointMatrices = [
         new Matrix4(),
         Matrix4.clone(Matrix4.IDENTITY),
@@ -80,9 +82,9 @@ describe(
 
       return loadGltf(simpleSkinUrl).then(function (gltfLoader) {
         const components = gltfLoader.components;
-        const node = components.nodes[0];
+        const primitive = components.nodes[0].primitives[0];
 
-        SkinningPipelineStage.process(renderResources, node, scene.frameState);
+        SkinningPipelineStage.process(renderResources, primitive);
 
         const shaderBuilder = renderResources.shaderBuilder;
 
@@ -98,6 +100,8 @@ describe(
             "    mat4 skinnedMatrix = mat4(0);",
             "    skinnedMatrix += a_weights_0.x * u_jointMatrices[int(a_joints_0.x)];",
             "    skinnedMatrix += a_weights_0.y * u_jointMatrices[int(a_joints_0.y)];",
+            "    skinnedMatrix += a_weights_0.z * u_jointMatrices[int(a_joints_0.z)];",
+            "    skinnedMatrix += a_weights_0.w * u_jointMatrices[int(a_joints_0.w)];",
             "    return skinnedMatrix;",
           ]
         );
@@ -107,6 +111,64 @@ describe(
 
         ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, [
           "uniform mat4 u_jointMatrices[2];",
+        ]);
+
+        const runtimeNode = renderResources.runtimeNode;
+        const uniformMap = renderResources.uniformMap;
+        expect(uniformMap.u_jointMatrices()).toBe(
+          runtimeNode.computedJointMatrices
+        );
+      });
+    });
+
+    it("processes skin with many joints", function () {
+      const jointCount = 19; // Counted from model
+      const mockJointMatrices = new Array(jointCount);
+      const renderResources = {
+        attributes: [],
+        shaderBuilder: new ShaderBuilder(),
+        attributeIndex: 1,
+        model: {
+          type: ModelExperimentalType.TILE_GLTF,
+        },
+        runtimeNode: {
+          computedJointMatrices: mockJointMatrices,
+        },
+      };
+
+      return loadGltf(cesiumManUrl).then(function (gltfLoader) {
+        const components = gltfLoader.components;
+        const primitive = components.nodes[1].primitives[0];
+        console.log(components);
+
+        SkinningPipelineStage.process(renderResources, primitive);
+
+        const shaderBuilder = renderResources.shaderBuilder;
+
+        ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
+          "HAS_SKINNING",
+        ]);
+
+        // Even though the skin has many joints, the mesh only has one joints / weights attribute
+        ShaderBuilderTester.expectHasVertexFunction(
+          shaderBuilder,
+          SkinningPipelineStage.FUNCTION_ID_GET_SKINNING_MATRIX,
+          SkinningPipelineStage.FUNCTION_SIGNATURE_GET_SKINNING_MATRIX,
+          [
+            "    mat4 skinnedMatrix = mat4(0);",
+            "    skinnedMatrix += a_weights_0.x * u_jointMatrices[int(a_joints_0.x)];",
+            "    skinnedMatrix += a_weights_0.y * u_jointMatrices[int(a_joints_0.y)];",
+            "    skinnedMatrix += a_weights_0.z * u_jointMatrices[int(a_joints_0.z)];",
+            "    skinnedMatrix += a_weights_0.w * u_jointMatrices[int(a_joints_0.w)];",
+            "    return skinnedMatrix;",
+          ]
+        );
+        ShaderBuilderTester.expectVertexLinesEqual(shaderBuilder, [
+          _shadersSkinningStageVS,
+        ]);
+
+        ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, [
+          `uniform mat4 u_jointMatrices[${jointCount}];`,
         ]);
 
         const runtimeNode = renderResources.runtimeNode;

--- a/Specs/Scene/ModelExperimental/SkinningPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/SkinningPipelineStageSpec.js
@@ -13,7 +13,7 @@ import createScene from "../../createScene.js";
 import waitForLoaderProcess from "../../waitForLoaderProcess.js";
 import ShaderBuilderTester from "../../ShaderBuilderTester.js";
 
-describe(
+fdescribe(
   "Scene/ModelExperimental/SkinningPipelineStage",
   function () {
     let scene;

--- a/Specs/Scene/ModelExperimental/SkinningPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/SkinningPipelineStageSpec.js
@@ -13,7 +13,7 @@ import createScene from "../../createScene.js";
 import waitForLoaderProcess from "../../waitForLoaderProcess.js";
 import ShaderBuilderTester from "../../ShaderBuilderTester.js";
 
-fdescribe(
+describe(
   "Scene/ModelExperimental/SkinningPipelineStage",
   function () {
     let scene;

--- a/Specs/Scene/ModelExperimental/SkinningPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/SkinningPipelineStageSpec.js
@@ -1,0 +1,110 @@
+import {
+  combine,
+  GltfLoader,
+  ModelExperimentalType,
+  Resource,
+  ResourceCache,
+  ShaderBuilder,
+  _shadersSkinningStageVS,
+  SkinningPipelineStage,
+} from "../../../Source/Cesium.js";
+import createScene from "../../createScene.js";
+import waitForLoaderProcess from "../../waitForLoaderProcess.js";
+import ShaderBuilderTester from "../../ShaderBuilderTester.js";
+
+describe(
+  "Scene/ModelExperimental/SkinningPipelineStage",
+  function () {
+    let scene;
+    const gltfLoaders = [];
+
+    beforeAll(function () {
+      scene = createScene();
+    });
+
+    afterAll(function () {
+      scene.destroyForSpecs();
+    });
+
+    afterEach(function () {
+      const gltfLoadersLength = gltfLoaders.length;
+      for (let i = 0; i < gltfLoadersLength; ++i) {
+        const gltfLoader = gltfLoaders[i];
+        if (!gltfLoader.isDestroyed()) {
+          gltfLoader.destroy();
+        }
+      }
+      gltfLoaders.length = 0;
+      ResourceCache.clearForSpecs();
+    });
+
+    function getOptions(gltfPath, options) {
+      const resource = new Resource({
+        url: gltfPath,
+      });
+
+      return combine(options, {
+        gltfResource: resource,
+        incrementallyLoadTextures: false, // Default to false if not supplied
+      });
+    }
+
+    function loadGltf(gltfPath, options) {
+      const gltfLoader = new GltfLoader(getOptions(gltfPath, options));
+      gltfLoaders.push(gltfLoader);
+      gltfLoader.load();
+
+      return waitForLoaderProcess(gltfLoader, scene);
+    }
+
+    const simpleSkinUrl =
+      "./Data/Models/GltfLoader/SimpleSkin/glTF/SimpleSkin.gltf";
+
+    /*it("processes simple skin", function () {
+      const renderResources = {
+        attributes: [],
+        shaderBuilder: new ShaderBuilder(),
+        attributeIndex: 1,
+        model: {
+          type: ModelExperimentalType.TILE_GLTF,
+        },
+      };
+
+      return loadGltf(simpleSkinUrl).then(function (gltfLoader) {
+        const components = gltfLoader.components;
+        const node = components.nodes[0];
+
+        SkinningPipelineStage.process(renderResources, node, scene.frameState);
+
+        const shaderBuilder = renderResources.shaderBuilder;
+
+        ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
+          "HAS_SKINNING",
+        ]);
+
+        ShaderBuilderTester.expectHasVertexFunction(
+          shaderBuilder,
+          SkinningPipelineStage.FUNCTION_ID_GET_SKINNING_MATRIX,
+          SkinningPipelineStage.FUNCTION_SIGNATURE_GET_SKINNING_MATRIX,
+          [
+            "    mat4 skinnedMatrix = mat4(0);",
+            "    skinnedMatrix += a_weights_0.x * u_jointMatrices[int(a_joints_0.x)];",
+            "    skinnedMatrix += a_weights_0.y * u_jointMatrices[int(a_joints_0.y)];",
+            "    return skinnedMatrix;",
+          ]
+        );
+        ShaderBuilderTester.expectVertexLinesEqual(shaderBuilder, [
+          _shadersSkinningStageVS,
+        ]);
+
+        ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, [
+          "uniform mat4 u_jointMatrices[2];",
+        ]);
+
+        const uniformMap = renderResources.uniformMap;
+        expect(uniformMap.u_jointMatrices()).toBe(node.computedJointMatrices);
+      });
+    });*/
+  },
+  "WebGL"
+);


### PR DESCRIPTION
This PR adds support for glTF 2.0 skins in `ModelExperimental`. Although `ModelExperimental` currently does not support animations, the skinned mesh should at least appear in its default, unanimated position, without any incorrect transformations. For example, Cesium Man should look the same in the [ModelExperimental 3D Models sandcastle](http://localhost:8080/Apps/Sandcastle/index.html?src=Model%20Experimental%203D%20Models.html&label=3D%20Tiles%20Next).

Some notes:
- Although skins are assigned at the `node` level, the shader code is based on the number of joint and weight attributes there are in the primitive. I checked through the specs to see if this number was required to be consistent across primitives, but it doesn't seem to disallow two primitives with the same skin to have different numbers of `JOINTS_n` attributes. Thus, it makes more sense for `SkinningPipelineStage` to be processed at the primitive level.
- I'm not sure what kind of unit test to add to `ModelExperimental` for this -- the model will render regardless of its skin. Let me know if there are any ideas.
- I anticipate that `updateJointMatrices` in `ModelExperimentalSkin` and `ModelExperimentalNode` will need to be called for animations, but I haven't figured out where / when, so it's not included in the `ModelExperimental` update code for the time being.

@ptrgags - could you review?