### PR TITLE
fix Cesium3DTile singleContentFailed have no error

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -315,3 +315,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Justin Peter](https://github.com/themagicnacho)
 - [Gu Miao](https://github.com/Gu-Miao)
 - [Shen WeiQun](https://github.com/ShenWeiQun)
+- [Jiang Heng](https://github.com/jiangheng90)

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -1197,7 +1197,11 @@ function requestSingleContent(tile) {
     .then(function (arrayBuffer) {
       if (tile.isDestroyed()) {
         // Tile is unloaded before the content finishes loading
-        singleContentFailed(tile, tileset);
+        singleContentFailed(
+          tile,
+          tileset,
+          "Tile is unloaded before the content finishes loading"
+        );
         return;
       }
 
@@ -1215,7 +1219,11 @@ function requestSingleContent(tile) {
       return content.readyPromise.then(function (content) {
         if (tile.isDestroyed()) {
           // Tile is unloaded before the content finishes processing
-          singleContentFailed(tile, tileset);
+          singleContentFailed(
+            tile,
+            tileset,
+            "Tile is unloaded before the content finishes processing"
+          );
           return;
         }
         updateExpireDate(tile);


### PR DESCRIPTION
First time pull request, I have many useless commit, so I close the previouse pr.
So back to the point. This problem is found by a modify in 3dtiles traversal. 
when ```Cesium3DTile.requestSingleContent``` called, the code will go into ```  if (tile.isDestroyed()) {```
```javascript
// Cesium3DTile.js
promise
    .then(function (arrayBuffer) {
      if (tile.isDestroyed()) {
        // Tile is unloaded before the content finishes loading
        singleContentFailed(tile, tileset);
        return;
      }

      const content = makeContent(tile, arrayBuffer);

      if (expired) {
        tile.expireDate = undefined;
      }

      tile._content = content;
      tile._contentState = Cesium3DTileContentState.PROCESSING;
      tile._contentReadyToProcessPromise.resolve(content);
      --tileset.statistics.numberOfPendingRequests;

      return content.readyPromise.then(function (content) {
        if (tile.isDestroyed()) {
          // Tile is unloaded before the content finishes processing
          singleContentFailed(tile, tileset,);
          return;
        }
      ........
```
the third params is empty, so ```handleTileFailure``` in ```Cesium3DTilset```
```javascript
function handleTileFailure(tileset, tile) {
  return function (error) {
    const url = tile._contentResource.url;
    const message = defined(error.message) ? error.message : error.toString();
    if (tileset.tileFailed.numberOfListeners > 0) {
      tileset.tileFailed.raiseEvent({
        url: url,
        message: message,
      });
    } else {
      console.log(`A 3D tile failed to load: ${url}`);
      console.log(`Error: ${message}`);
    }
  };
}
```

the ```error``` will be undefined and throw error, so I just add params in ``` singleContentFailed```


