### PR TITLE
Remove duplicate assignment code in Viewer class

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -315,3 +315,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Justin Peter](https://github.com/themagicnacho)
 - [Gu Miao](https://github.com/Gu-Miao)
 - [Shen WeiQun](https://github.com/ShenWeiQun)
+- [四季留歌](https://github.com/onsummer)

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -847,7 +847,6 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
   this._trackedEntity = undefined;
   this._needTrackedEntityUpdate = false;
   this._selectedEntity = undefined;
-  this._clockTrackedDataSource = undefined;
   this._zoomIsFlight = false;
   this._zoomTarget = undefined;
   this._zoomPromise = undefined;


### PR DESCRIPTION
In `Viewer` constructor, the private field `_clockTrackedDataSource` is assignment twice.