### PR TITLE
Billboard clamping

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 - Fixed debug label rendering in `Cesium3dTilesInspector`. [#10246](https://github.com/CesiumGS/cesium/issues/10246)
 - Fixed a crash that occurred in `ModelExperimental` when loading a Draco-compressed model with tangents. [#10294](https://github.com/CesiumGS/cesium/pull/10294)
 - Fixed an incorrect model matrix computation for `i3dm` tilesets that are loaded using `ModelExperimental`. [#10302](https://github.com/CesiumGS/cesium/pull/10302)
+- Fixed clamping issues with billboards after using mode "Disable depth test when clamped to ground." [#10191](https://github.com/CesiumGS/cesium/issues/10191)
 
 ### 1.92 - 2022-04-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@
 - Fixed debug label rendering in `Cesium3dTilesInspector`. [#10246](https://github.com/CesiumGS/cesium/issues/10246)
 - Fixed a crash that occurred in `ModelExperimental` when loading a Draco-compressed model with tangents. [#10294](https://github.com/CesiumGS/cesium/pull/10294)
 - Fixed an incorrect model matrix computation for `i3dm` tilesets that are loaded using `ModelExperimental`. [#10302](https://github.com/CesiumGS/cesium/pull/10302)
-- Fixed clamping issues with billboards after using mode "Disable depth test when clamped to ground." [#10191](https://github.com/CesiumGS/cesium/issues/10191)
+- Fixed race condition during billboard clamping when the height reference changes. [#10191](https://github.com/CesiumGS/cesium/issues/10191)
 
 ### 1.92 - 2022-04-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -316,3 +316,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Gu Miao](https://github.com/Gu-Miao)
 - [Shen WeiQun](https://github.com/ShenWeiQun)
 - [四季留歌](https://github.com/onsummer)
+- [Yuri Chen](https://github.com/yurichen17)

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -296,6 +296,9 @@ QuadtreePrimitive.prototype.updateHeight = function (cartographic, callback) {
       }
     }
     primitive._removeHeightCallbacks.push(object);
+    if (object.callback) {
+      object.callback = undefined;
+    }
   };
 
   primitive._addHeightCallbacks.push(object);
@@ -1503,7 +1506,9 @@ function updateHeights(primitive, frameState) {
           scratchPosition
         );
         if (defined(position)) {
-          data.callback(position);
+          if (defined(data.callback)) {
+            data.callback(position);
+          }
           data.level = tile.level;
         }
       }

--- a/Specs/Scene/BillboardCollectionSpec.js
+++ b/Specs/Scene/BillboardCollectionSpec.js
@@ -2491,6 +2491,21 @@ describe(
         expect(b._clampedPosition).toBeUndefined();
       });
 
+      it("disableDepthTest after another function", function () {
+        const b = billboardsWithHeight.add({
+          heightReference: HeightReference.CLAMP_TO_GROUND,
+          position: Cartesian3.fromDegrees(-122, 46.0),
+          disableDepthTestDistance: Number.POSITIVE_INFINITY,
+        });
+        expect(scene.globe.callback).toBeDefined();
+
+        //after changing disableDepthTestDistance and heightReference, the callback should be undefined
+        b.disableDepthTestDistance = undefined;
+        b.heightReference = HeightReference.NONE;
+
+        expect(scene.globe.callback).toBeUndefined();
+      });
+
       it("changing the terrain provider", function () {
         const b = billboardsWithHeight.add({
           heightReference: HeightReference.CLAMP_TO_GROUND,

--- a/Specs/Scene/BillboardCollectionSpec.js
+++ b/Specs/Scene/BillboardCollectionSpec.js
@@ -2497,13 +2497,17 @@ describe(
           position: Cartesian3.fromDegrees(-122, 46.0),
           disableDepthTestDistance: Number.POSITIVE_INFINITY,
         });
+        scene.renderForSpecs();
         expect(scene.globe.callback).toBeDefined();
+        expect(b._clampedPosition).toBeDefined();
 
-        //after changing disableDepthTestDistance and heightReference, the callback should be undefined
+        //After changing disableDepthTestDistance and heightReference, the callback should be undefined
         b.disableDepthTestDistance = undefined;
         b.heightReference = HeightReference.NONE;
 
+        scene.renderForSpecs();
         expect(scene.globe.callback).toBeUndefined();
+        expect(b._clampedPosition).toBeUndefined();
       });
 
       it("changing the terrain provider", function () {


### PR DESCRIPTION
Fixes issue [#10191 ](https://github.com/CesiumGS/cesium/issues/10191)

This is my first pull request so I am very open to feedback! It was a challenge but I hope that I helped fix this bug.

**Context:** 
Inside QuadtreePrimitive.js, there is updateHeight function that is called inside Billboards.js that takes in a position and the function updateFunction. The issue that arises is that updateHeight creates an object that stores the updateFunction and an old position, which gets recalled during updates and therefore changes the position of the billboard to the wrong place, and appear to "clamp." To combat this, inside object.removeFunc, I set the object callback to undefined. Because of this change, I have to add an "if" check on line 1509 in QuadtreePrimitive.js to only run the callback function if it is defined. With the combined changes, the callback function is actually changed to "undefined" rather than keeping it's original value that contained old positioning of the billboards. 

I added a test but I struggled with making a test that imitated the structure from the issue. I would love to get some help on that front!