### PR TITLE
Ensure arrays exist in `ModelComponents`

### DIFF
--- a/Source/Scene/ModelComponents.js
+++ b/Source/Scene/ModelComponents.js
@@ -688,7 +688,7 @@ function Skin() {
    * @type {ModelComponents.Node[]}
    * @private
    */
-  this.joints = undefined;
+  this.joints = [];
 
   /**
    * The inverse bind matrices of the joints.
@@ -696,7 +696,7 @@ function Skin() {
    * @type {Matrix4[]}
    * @private
    */
-  this.inverseBindMatrices = undefined;
+  this.inverseBindMatrices = [];
 }
 
 /**
@@ -855,7 +855,7 @@ function AnimationSampler() {
    * @type {Number[]}
    * @private
    */
-  this.input = undefined;
+  this.input = [];
 
   /**
    * The method used to interpolate between the animation's keyframe data.
@@ -871,7 +871,7 @@ function AnimationSampler() {
    * @type {Number[]|Cartesian3[]|Quaternion[]}
    * @private
    */
-  this.output = undefined;
+  this.output = [];
 }
 
 /**
@@ -1008,21 +1008,21 @@ function Components() {
    *
    * @type {ModelComponents.Node[]}
    */
-  this.nodes = undefined;
+  this.nodes = [];
 
   /**
    * All skins in the model.
    *
    * @type {ModelComponents.Skin[]}
    */
-  this.skins = undefined;
+  this.skins = [];
 
   /**
    * All animations in the model.
    *
    * @type {ModelComponents.Animation[]}
    */
-  this.animations = undefined;
+  this.animations = [];
 
   /**
    * Structural metadata containing the schema, property tables, property

--- a/Source/Scene/ModelExperimental/B3dmLoader.js
+++ b/Source/Scene/ModelExperimental/B3dmLoader.js
@@ -304,32 +304,23 @@ function createStructuralMetadata(loader, components) {
 
 // Recursive function to add the feature ID attribute to all primitives that have a feature ID vertex attribute.
 function processNode(node) {
-  if (!defined(node.children) && !defined(node.primitives)) {
-    return;
+  for (let i = 0; i < node.children.length; i++) {
+    processNode(node.children[i]);
   }
 
-  let i;
-  if (defined(node.children)) {
-    for (i = 0; i < node.children.length; i++) {
-      processNode(node.children[i]);
-    }
-  }
-
-  if (defined(node.primitives)) {
-    for (i = 0; i < node.primitives.length; i++) {
-      const primitive = node.primitives[i];
-      const featureIdVertexAttribute = ModelExperimentalUtility.getAttributeBySemantic(
-        primitive,
-        VertexAttributeSemantic.FEATURE_ID
-      );
-      if (defined(featureIdVertexAttribute)) {
-        featureIdVertexAttribute.setIndex = 0;
-        const featureIdAttribute = new FeatureIdAttribute();
-        featureIdAttribute.propertyTableId = 0;
-        featureIdAttribute.setIndex = 0;
-        featureIdAttribute.positionalLabel = "featureId_0";
-        primitive.featureIds.push(featureIdAttribute);
-      }
+  for (let i = 0; i < node.primitives.length; i++) {
+    const primitive = node.primitives[i];
+    const featureIdVertexAttribute = ModelExperimentalUtility.getAttributeBySemantic(
+      primitive,
+      VertexAttributeSemantic.FEATURE_ID
+    );
+    if (defined(featureIdVertexAttribute)) {
+      featureIdVertexAttribute.setIndex = 0;
+      const featureIdAttribute = new FeatureIdAttribute();
+      featureIdAttribute.propertyTableId = 0;
+      featureIdAttribute.setIndex = 0;
+      featureIdAttribute.positionalLabel = "featureId_0";
+      primitive.featureIds.push(featureIdAttribute);
     }
   }
 }

--- a/Source/Scene/ModelExperimental/B3dmLoader.js
+++ b/Source/Scene/ModelExperimental/B3dmLoader.js
@@ -296,7 +296,8 @@ function createStructuralMetadata(loader, components) {
 
   // Add the feature ID attribute to the primitives.
   const nodes = components.scene.nodes;
-  for (let i = 0; i < nodes.length; i++) {
+  const length = nodes.length;
+  for (let i = 0; i < length; i++) {
     processNode(nodes[i]);
   }
   components.structuralMetadata = structuralMetadata;
@@ -304,11 +305,13 @@ function createStructuralMetadata(loader, components) {
 
 // Recursive function to add the feature ID attribute to all primitives that have a feature ID vertex attribute.
 function processNode(node) {
-  for (let i = 0; i < node.children.length; i++) {
+  const childrenLength = node.children.length;
+  for (let i = 0; i < childrenLength; i++) {
     processNode(node.children[i]);
   }
 
-  for (let i = 0; i < node.primitives.length; i++) {
+  const primitivesLength = node.primitives.length;
+  for (let i = 0; i < primitivesLength; i++) {
     const primitive = node.primitives[i];
     const featureIdVertexAttribute = ModelExperimentalUtility.getAttributeBySemantic(
       primitive,

--- a/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
@@ -317,24 +317,21 @@ function traverseSceneGraph(sceneGraph, node, transformToRoot) {
   const transform = ModelExperimentalUtility.getNodeTransform(node);
 
   // Traverse through scene graph.
-  let i;
-  if (defined(node.children)) {
-    const childrenLength = node.children.length;
-    for (i = 0; i < childrenLength; i++) {
-      const childNode = node.children[i];
-      const childNodeTransformToRoot = Matrix4.multiplyTransformation(
-        transformToRoot,
-        transform,
-        new Matrix4()
-      );
+  const childrenLength = node.children.length;
+  for (let i = 0; i < childrenLength; i++) {
+    const childNode = node.children[i];
+    const childNodeTransformToRoot = Matrix4.multiplyTransformation(
+      transformToRoot,
+      transform,
+      new Matrix4()
+    );
 
-      const childIndex = traverseSceneGraph(
-        sceneGraph,
-        childNode,
-        childNodeTransformToRoot
-      );
-      childrenIndices.push(childIndex);
-    }
+    const childIndex = traverseSceneGraph(
+      sceneGraph,
+      childNode,
+      childNodeTransformToRoot
+    );
+    childrenIndices.push(childIndex);
   }
 
   // Process node and mesh primitives.
@@ -346,17 +343,15 @@ function traverseSceneGraph(sceneGraph, node, transformToRoot) {
     sceneGraph: sceneGraph,
   });
 
-  if (defined(node.primitives)) {
-    const primitivesLength = node.primitives.length;
-    for (i = 0; i < primitivesLength; i++) {
-      runtimeNode.runtimePrimitives.push(
-        new ModelExperimentalPrimitive({
-          primitive: node.primitives[i],
-          node: node,
-          model: sceneGraph._model,
-        })
-      );
-    }
+  const primitivesLength = node.primitives.length;
+  for (let i = 0; i < primitivesLength; i++) {
+    runtimeNode.runtimePrimitives.push(
+      new ModelExperimentalPrimitive({
+        primitive: node.primitives[i],
+        node: node,
+        model: sceneGraph._model,
+      })
+    );
   }
 
   const index = node.index;

--- a/Source/Scene/ModelExperimental/ModelMatrixUpdateStage.js
+++ b/Source/Scene/ModelExperimental/ModelMatrixUpdateStage.js
@@ -49,9 +49,11 @@ function updateRuntimeNode(runtimeNode, sceneGraph, transformToRoot) {
 
   runtimeNode.updateComputedTransform();
 
-  for (i = 0; i < runtimeNode.runtimePrimitives.length; i++) {
+  const primitivesLength = runtimeNode.runtimePrimitives.length;
+  for (i = 0; i < primitivesLength; i++) {
     const runtimePrimitive = runtimeNode.runtimePrimitives[i];
-    for (j = 0; j < runtimePrimitive.drawCommands.length; j++) {
+    const drawCommandsLength = runtimePrimitive.drawCommands.length;
+    for (j = 0; j < drawCommandsLength; j++) {
       const drawCommand = runtimePrimitive.drawCommands[j];
 
       drawCommand.modelMatrix = Matrix4.multiplyTransformation(
@@ -67,7 +69,8 @@ function updateRuntimeNode(runtimeNode, sceneGraph, transformToRoot) {
     }
   }
 
-  for (i = 0; i < runtimeNode.children.length; i++) {
+  const childrenLength = runtimeNode.children.length;
+  for (i = 0; i < childrenLength; i++) {
     const childRuntimeNode = sceneGraph._runtimeNodes[runtimeNode.children[i]];
 
     // Update transformToRoot to accommodate changes in the transforms of this node and its ancestors

--- a/Source/Scene/ModelExperimental/ModelMatrixUpdateStage.js
+++ b/Source/Scene/ModelExperimental/ModelMatrixUpdateStage.js
@@ -1,5 +1,4 @@
 import BoundingSphere from "../../Core/BoundingSphere.js";
-import defined from "../../Core/defined.js";
 import Matrix4 from "../../Core/Matrix4.js";
 
 /**
@@ -68,20 +67,17 @@ function updateRuntimeNode(runtimeNode, sceneGraph, transformToRoot) {
     }
   }
 
-  if (defined(runtimeNode.children)) {
-    for (i = 0; i < runtimeNode.children.length; i++) {
-      const childRuntimeNode =
-        sceneGraph._runtimeNodes[runtimeNode.children[i]];
+  for (i = 0; i < runtimeNode.children.length; i++) {
+    const childRuntimeNode = sceneGraph._runtimeNodes[runtimeNode.children[i]];
 
-      // Update transformToRoot to accommodate changes in the transforms of this node and its ancestors
-      childRuntimeNode._transformToRoot = Matrix4.clone(
-        transformToRoot,
-        childRuntimeNode._transformToRoot
-      );
+    // Update transformToRoot to accommodate changes in the transforms of this node and its ancestors
+    childRuntimeNode._transformToRoot = Matrix4.clone(
+      transformToRoot,
+      childRuntimeNode._transformToRoot
+    );
 
-      updateRuntimeNode(childRuntimeNode, sceneGraph, transformToRoot);
-      childRuntimeNode._transformDirty = false;
-    }
+    updateRuntimeNode(childRuntimeNode, sceneGraph, transformToRoot);
+    childRuntimeNode._transformDirty = false;
   }
 }
 

--- a/Source/Scene/ModelExperimental/PntsLoader.js
+++ b/Source/Scene/ModelExperimental/PntsLoader.js
@@ -526,6 +526,7 @@ function makeComponents(loader, context) {
   }
 
   const node = new Node();
+  node.index = 0;
   node.primitives = [primitive];
 
   const scene = new Scene();


### PR DESCRIPTION
I noticed a regression today, while loading a `.pnts` tileset with `ModelExperimental`, a line that was accessing `node.skins.length` was failing because `PntsLoader` doesn't set `node.skins` and it defaults to `undefined` in `ModelComponents`. 

I did a sweep through `ModelComponents` and related code to ensure array properties default to an empty array, so it's always safe to do `component.property.length` or loop over the array. This simplifies the code in a few places, one less `define()` check.

@j9liu could you review when you get a chance?