### PR TITLE
Disable text selection in timeline and credits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - Added support for morph targets in `ModelExperimental`. [#10271](https://github.com/CesiumGS/cesium/pull/10271)
 - Added support for skins in `ModelExperimental`. [#10282](https://github.com/CesiumGS/cesium/pull/10282)
 - Improved rendering of ground and sky atmosphere. [#10063](https://github.com/CesiumGS/cesium/pull/10063)
+- Prevent text selection in the Timeline [#10325](https://github.com/CesiumGS/cesium/pull/10325)
 
 ##### Fixes :wrench:
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -317,3 +317,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Shen WeiQun](https://github.com/ShenWeiQun)
 - [四季留歌](https://github.com/onsummer)
 - [Yuri Chen](https://github.com/yurichen17)
+- [David Ferguson](https://github.com/jdfwarrior)

--- a/Source/Widgets/CesiumWidget/CesiumWidget.css
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.css
@@ -18,7 +18,6 @@
   font-size: 10px;
   text-shadow: 0px 0px 2px #000000;
   padding-right: 5px;
-  user-select: none;
 }
 
 .cesium-widget-credits a,

--- a/Source/Widgets/CesiumWidget/CesiumWidget.css
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.css
@@ -18,6 +18,7 @@
   font-size: 10px;
   text-shadow: 0px 0px 2px #000000;
   padding-right: 5px;
+  user-select: none;
 }
 
 .cesium-widget-credits a,

--- a/Source/Widgets/Timeline/Timeline.css
+++ b/Source/Widgets/Timeline/Timeline.css
@@ -4,6 +4,9 @@
   bottom: 0;
   overflow: hidden;
   border: solid 1px #888;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
   user-select: none;
 }
 

--- a/Source/Widgets/Timeline/Timeline.css
+++ b/Source/Widgets/Timeline/Timeline.css
@@ -4,6 +4,7 @@
   bottom: 0;
   overflow: hidden;
   border: solid 1px #888;
+  user-select: none;
 }
 
 .cesium-timeline-trackContainer {


### PR DESCRIPTION
This has bugged me for a long time. Pressing Ctrl + A to select all text selects the text in the timeline and the credits area. Maybe you actually want the credits area? But it seems like the timeline shouldn't be selectable because, once you get it selected, you have to click very specific areas to deselect and it's annoying.

Text in the animation controller can still be selected right now. I may try to figure out how to resolve that as well.

No changes to the changelog necessary (in my opinion) since it's something some people may have never noticed in the first place and doesn't modify the API at all.
