### PR TITLE
Handled case where command is undefined in commandList

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### 1.93 - 2022-05-02
 
+##### Fixes :wrench:
+
+- Fixed a Crash in some scenarios when setting `backFaceCulling` of a `Cesium3DTileset` to `false`. [#9273](https://github.com/CesiumGS/cesium/issues/9273)
+
 ##### Additions :tada:
 
 - `KmlDataSource` now exposes the `camera` and `canvas` properties, which are used to provide information about the state of the Viewer when making network requests for a [Link](https://developers.google.com/kml/documentation/kmlreference#link). Passing these values in the constructor is now optional.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -318,3 +318,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [四季留歌](https://github.com/onsummer)
 - [Yuri Chen](https://github.com/yurichen17)
 - [David Ferguson](https://github.com/jdfwarrior)
+- [William Liu](https://github.com/WilliamLiu-1997)

--- a/Source/Scene/Cesium3DTileBatchTable.js
+++ b/Source/Scene/Cesium3DTileBatchTable.js
@@ -870,7 +870,7 @@ Cesium3DTileBatchTable.prototype.addDerivedCommands = function (
 
   for (let i = commandStart; i < commandEnd; ++i) {
     const command = commandList[i];
-    if (command.pass === Pass.COMPUTE) {
+    if (!defined(command) || command.pass === Pass.COMPUTE) {
       continue;
     }
 


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/9273

Cesium3DTileBatchTable.js was missing code to handle the case in addDerivedCommands where commandList[i] === undefined.

I met this problem on **some** of the Cesium3DTileset. And found this is an existing issue https://github.com/CesiumGS/cesium/issues/9273

This PR stops Cesium from throwing an error and crash.