### PR TITLE
Add debug wireframe to `ModelExperimental`

### DIFF
--- a/Source/Core/PrimitiveType.js
+++ b/Source/Core/PrimitiveType.js
@@ -70,6 +70,17 @@ const PrimitiveType = {
 /**
  * @private
  */
+PrimitiveType.isLines = function (primitiveType) {
+  return (
+    primitiveType === PrimitiveType.LINES ||
+    primitiveType === PrimitiveType.LINE_LOOP ||
+    primitiveType === PrimitiveType.LINE_STRIP
+  );
+};
+
+/**
+ * @private
+ */
 PrimitiveType.validate = function (primitiveType) {
   return (
     primitiveType === PrimitiveType.POINTS ||

--- a/Source/Scene/GltfIndexBufferLoader.js
+++ b/Source/Scene/GltfIndexBufferLoader.js
@@ -334,7 +334,11 @@ GltfIndexBufferLoader.prototype.process = function (frameState) {
     return;
   }
 
-  if (this._loadAsTypedArray) {
+  // WebGL1 has no way to retrieve the contents of buffers that are
+  // on the GPU. Therefore, the index buffer is stored in CPU memory
+  // in case it needs to be referenced later.
+  const useWebgl2 = frameState.context.webgl2;
+  if (this._loadAsTypedArray || !useWebgl2) {
     // Unload everything except the typed array
     this.unload();
 

--- a/Source/Scene/GltfLoader.js
+++ b/Source/Scene/GltfLoader.js
@@ -646,6 +646,8 @@ function loadAttribute(
       attribute.buffer = vertexBufferLoader.buffer;
     }
 
+    attribute.count = accessor.count;
+
     if (
       defined(draco) &&
       defined(draco.attributes) &&
@@ -725,10 +727,10 @@ function loadIndices(loader, gltf, accessorId, draco) {
 
     indices.indexDatatype = indexBufferLoader.indexDatatype;
 
-    if (loadAsTypedArray) {
-      indices.typedArray = indexBufferLoader.typedArray;
-    } else {
+    if (defined(indexBufferLoader.buffer)) {
       indices.buffer = indexBufferLoader.buffer;
+    } else {
+      indices.typedArray = indexBufferLoader.typedArray;
     }
   });
 

--- a/Source/Scene/ModelExperimental/GeometryPipelineStage.js
+++ b/Source/Scene/ModelExperimental/GeometryPipelineStage.js
@@ -234,6 +234,7 @@ function addAttributeToRenderResources(
     index: attributeIndex,
     value: defined(attribute.buffer) ? undefined : attribute.constant,
     vertexBuffer: attribute.buffer,
+    count: attribute.count,
     componentsPerAttribute: AttributeType.getNumberOfComponents(type),
     componentDatatype: componentDatatype,
     offsetInBytes: attribute.byteOffset,

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -45,6 +45,7 @@ import SplitDirection from "../SplitDirection.js";
  * @param {Number} [options.maximumScale] The maximum scale size of a model. An upper limit for minimumPixelSize.
  * @param {Boolean} [options.clampAnimations=true] Determines if the model's animations should hold a pose over frames where no keyframes are specified.
  * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for each draw command in the model.
+ * @param {Boolean} [options.debugWireframe=false] For debugging only. Draws the model in wireframe.
  * @param {Boolean} [options.cull=true]  Whether or not to cull the model using frustum/horizon culling. If the model is part of a 3D Tiles tileset, this property will always be false, since the 3D Tiles culling system is used.
  * @param {Boolean} [options.opaquePass=Pass.OPAQUE] The pass to use in the {@link DrawCommand} for the opaque portions of the model.
  * @param {Boolean} [options.allowPicking=true] When <code>true</code>, each primitive is pickable with {@link Scene#pick}.
@@ -241,6 +242,8 @@ export default function ModelExperimental(options) {
     options.debugShowBoundingVolume,
     false
   );
+
+  this._debugWireframe = defaultValue(options.debugWireframe, false);
 
   this._showCreditsOnScreen = defaultValue(options.showCreditsOnScreen, false);
 
@@ -713,6 +716,30 @@ Object.defineProperties(ModelExperimental.prototype, {
         this._debugShowBoundingVolumeDirty = true;
       }
       this._debugShowBoundingVolume = value;
+    },
+  },
+
+  /**
+   * This property is for debugging only; it is not for production use nor is it optimized.
+   * <p>
+   * Draws the model in wireframe.
+   * </p>
+   *
+   * @memberof ModelExperimental.prototype
+   *
+   * @type {Boolean}
+   *
+   * @default false
+   */
+  debugWireframe: {
+    get: function () {
+      return this._debugWireframe;
+    },
+    set: function (value) {
+      if (this._debugWireframe !== value) {
+        this.resetDrawCommands();
+      }
+      this._debugWireframe = value;
     },
   },
 
@@ -1449,6 +1476,7 @@ ModelExperimental.prototype.destroyResources = function () {
  * @param {Boolean} [options.incrementallyLoadTextures=true] Determine if textures may continue to stream in after the model is loaded.
  * @param {Boolean} [options.releaseGltfJson=false] When true, the glTF JSON is released once the glTF is loaded. This is is especially useful for cases like 3D Tiles, where each .gltf model is unique and caching the glTF JSON is not effective.
  * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for each draw command in the model.
+ * @param {Boolean} [options.debugWireframe=false] For debugging only. Draws the model in wireframe.
  * @param {Boolean} [options.cull=true]  Whether or not to cull the model using frustum/horizon culling. If the model is part of a 3D Tiles tileset, this property will always be false, since the 3D Tiles culling system is used.
  * @param {Boolean} [options.opaquePass=Pass.OPAQUE] The pass to use in the {@link DrawCommand} for the opaque portions of the model.
  * @param {Axis} [options.upAxis=Axis.Y] The up-axis of the glTF model.
@@ -1634,6 +1662,7 @@ function makeModelOptions(loader, modelType, options) {
     minimumPixelSize: options.minimumPixelSize,
     maximumScale: options.maximumScale,
     debugShowBoundingVolume: options.debugShowBoundingVolume,
+    debugWireframe: options.debugWireframe,
     cull: options.cull,
     opaquePass: options.opaquePass,
     allowPicking: options.allowPicking,

--- a/Source/Scene/ModelExperimental/ModelExperimental3DTileContent.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental3DTileContent.js
@@ -201,6 +201,7 @@ ModelExperimental3DTileContent.prototype.update = function (
   model.shadows = tileset.shadows;
   model.showCreditsOnScreen = tileset.showCreditsOnScreen;
   model.splitDirection = tileset.splitDirection;
+  model.debugWireframe = tileset.debugWireframe;
 
   // Updating clipping planes requires more effort because of ownership checks
   const tilesetClippingPlanes = tileset.clippingPlanes;
@@ -357,6 +358,7 @@ function makeModelOptions(tileset, tile, content, additionalOptions) {
     shadows: tileset.shadows,
     showCreditsOnScreen: tileset.showCreditsOnScreen,
     splitDirection: tileset.splitDirection,
+    debugWireframe: tileset.debugWireframe,
   };
 
   return combine(additionalOptions, mainOptions);

--- a/Source/Scene/ModelExperimental/buildDrawCommands.js
+++ b/Source/Scene/ModelExperimental/buildDrawCommands.js
@@ -218,12 +218,12 @@ function createWireframeIndexBuffer(primitiveRenderResources, frameState) {
 
   let wireframeIndices;
   if (defined(indices)) {
+    const indicesBuffer = indices.buffer;
     const indicesCount = indices.count;
     const useWebgl2 = context.webgl2;
 
     let originalIndices;
-    if (useWebgl2) {
-      const indicesBuffer = indices.buffer;
+    if (useWebgl2 && defined(indicesBuffer)) {
       originalIndices = IndexDatatype.createTypedArray(
         vertexCount,
         indicesCount

--- a/Source/Scene/ModelExperimental/buildDrawCommands.js
+++ b/Source/Scene/ModelExperimental/buildDrawCommands.js
@@ -202,16 +202,25 @@ function getIndexBuffer(primitiveRenderResources, debugWireframe, frameState) {
  * @private
  */
 function createWireframeIndexBuffer(primitiveRenderResources, frameState) {
-  const positionAttribute = primitiveRenderResources.attributes[0];
+  let positionAttribute;
+  const attributes = primitiveRenderResources.attributes;
+  const length = attributes.length;
+  for (let i = 0; i < length; i++) {
+    if (attributes[i].index === 0) {
+      positionAttribute = attributes[i];
+      break;
+    }
+  }
+
   const vertexCount = positionAttribute.count;
   const indices = primitiveRenderResources.indices;
-
   const context = frameState.context;
 
   let wireframeIndices;
   if (defined(indices)) {
     const indicesCount = indices.count;
     const useWebgl2 = context.webgl2;
+
     let originalIndices;
     if (useWebgl2) {
       const indicesBuffer = indices.buffer;

--- a/Source/Scene/ModelExperimental/buildDrawCommands.js
+++ b/Source/Scene/ModelExperimental/buildDrawCommands.js
@@ -36,10 +36,16 @@ export default function buildDrawCommands(
   shaderBuilder.addVertexLines([ModelExperimentalVS]);
   shaderBuilder.addFragmentLines([ModelExperimentalFS]);
 
-  const indexBuffer = getIndexBuffer(primitiveRenderResources, frameState);
-
   const model = primitiveRenderResources.model;
-  const debugWireframe = model.debugWireframe;
+  let primitiveType = primitiveRenderResources.primitiveType;
+  const debugWireframe =
+    model.debugWireframe && !PrimitiveType.isLines(primitiveType);
+
+  const indexBuffer = getIndexBuffer(
+    primitiveRenderResources,
+    debugWireframe,
+    frameState
+  );
 
   const vertexArray = new VertexArray({
     context: frameState.context,
@@ -79,7 +85,6 @@ export default function buildDrawCommands(
     primitiveRenderResources.boundingSphere
   );
 
-  let primitiveType = primitiveRenderResources.primitiveType;
   let count = primitiveRenderResources.count;
   if (debugWireframe) {
     primitiveType = PrimitiveType.LINES;
@@ -166,10 +171,7 @@ function deriveTranslucentCommand(command) {
   return derivedCommand;
 }
 
-function getIndexBuffer(primitiveRenderResources, frameState) {
-  const model = primitiveRenderResources.model;
-  const debugWireframe = model.debugWireframe;
-
+function getIndexBuffer(primitiveRenderResources, debugWireframe, frameState) {
   if (debugWireframe) {
     return createWireframeIndexBuffer(primitiveRenderResources, frameState);
   }

--- a/Specs/Scene/GltfIndexBufferLoaderSpec.js
+++ b/Specs/Scene/GltfIndexBufferLoaderSpec.js
@@ -16,7 +16,7 @@ import createScene from "../createScene.js";
 import loaderProcess from "../loaderProcess.js";
 import waitForLoaderProcess from "../waitForLoaderProcess.js";
 
-fdescribe(
+describe(
   "Scene/GltfIndexBufferLoader",
   function () {
     const dracoBufferTypedArray = new Uint8Array([
@@ -256,15 +256,15 @@ fdescribe(
       ],
     };
 
+    // Index buffers will only load as typed arrays in WebGL1.
+    // In order to load them as buffers, the scene must have WebGL2 enabled.
     let scene;
+    let sceneWithWebgl2;
 
     beforeAll(function () {
-      const contextOptions = {
-        requestWebgl2: true,
-      };
-      scene = createScene({
-        contextOptions: contextOptions,
-      });
+      scene = createScene();
+      sceneWithWebgl2 = createScene();
+      sceneWithWebgl2.context._webgl2 = true;
     });
 
     afterAll(function () {
@@ -394,11 +394,7 @@ fdescribe(
         });
     });
 
-    it("loads from accessor", function () {
-      if (!scene.context.webgl2) {
-        return;
-      }
-
+    it("loads from accessor into buffer", function () {
       spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
         Promise.resolve(arrayBuffer)
       );
@@ -428,47 +424,18 @@ fdescribe(
 
       indexBufferLoader.load();
 
-      return waitForLoaderProcess(indexBufferLoader, scene).then(function (
-        indexBufferLoader
-      ) {
-        loaderProcess(indexBufferLoader, scene); // Check that calling process after load doesn't break anything
-        expect(indexBufferLoader.buffer.sizeInBytes).toBe(
-          indicesUint16.byteLength
-        );
-        expect(indexBufferLoader.typedArray).toBeUndefined();
-      });
-    });
-
-    it("creates index buffer synchronously", function () {
-      if (!scene.context.webgl2) {
-        return;
-      }
-
-      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
-        Promise.resolve(arrayBuffer)
+      return waitForLoaderProcess(indexBufferLoader, sceneWithWebgl2).then(
+        function (indexBufferLoader) {
+          loaderProcess(indexBufferLoader, sceneWithWebgl2); // Check that calling process after load doesn't break anything
+          expect(indexBufferLoader.buffer.sizeInBytes).toBe(
+            indicesUint16.byteLength
+          );
+          expect(indexBufferLoader.typedArray).toBeUndefined();
+        }
       );
-
-      const indexBufferLoader = new GltfIndexBufferLoader({
-        resourceCache: ResourceCache,
-        gltf: gltfUncompressed,
-        accessorId: 3,
-        gltfResource: gltfResource,
-        baseResource: gltfResource,
-        asynchronous: false,
-      });
-
-      indexBufferLoader.load();
-
-      return waitForLoaderProcess(indexBufferLoader, scene).then(function (
-        indexBufferLoader
-      ) {
-        expect(indexBufferLoader.buffer.sizeInBytes).toBe(
-          indicesUint16.byteLength
-        );
-      });
     });
 
-    it("loads as typed array", function () {
+    it("loads from accessor as typed array using option", function () {
       spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
         Promise.resolve(arrayBuffer)
       );
@@ -486,19 +453,18 @@ fdescribe(
 
       indexBufferLoader.load();
 
-      return waitForLoaderProcess(indexBufferLoader, scene).then(function (
-        indexBufferLoader
-      ) {
-        expect(indexBufferLoader.typedArray.byteLength).toBe(
-          indicesUint16.byteLength
-        );
-        expect(indexBufferLoader.buffer).toBeUndefined();
-        expect(Buffer.createIndexBuffer.calls.count()).toBe(0);
-      });
+      return waitForLoaderProcess(indexBufferLoader, sceneWithWebgl2).then(
+        function (indexBufferLoader) {
+          expect(indexBufferLoader.typedArray.byteLength).toBe(
+            indicesUint16.byteLength
+          );
+          expect(indexBufferLoader.buffer).toBeUndefined();
+          expect(Buffer.createIndexBuffer.calls.count()).toBe(0);
+        }
+      );
     });
 
-    it("loads as typed array if using WebGL1", function () {
-      scene.context._webgl2 = false;
+    it("loads from accessor as typed array for WebGL1", function () {
       spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
         Promise.resolve(arrayBuffer)
       );
@@ -524,9 +490,32 @@ fdescribe(
         );
         expect(indexBufferLoader.buffer).toBeUndefined();
         expect(Buffer.createIndexBuffer.calls.count()).toBe(0);
-
-        scene.context._webgl2 = true;
       });
+    });
+
+    it("creates index buffer synchronously", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        Promise.resolve(arrayBuffer)
+      );
+
+      const indexBufferLoader = new GltfIndexBufferLoader({
+        resourceCache: ResourceCache,
+        gltf: gltfUncompressed,
+        accessorId: 3,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        asynchronous: false,
+      });
+
+      indexBufferLoader.load();
+
+      return waitForLoaderProcess(indexBufferLoader, sceneWithWebgl2).then(
+        function (indexBufferLoader) {
+          expect(indexBufferLoader.buffer.sizeInBytes).toBe(
+            indicesUint16.byteLength
+          );
+        }
+      );
     });
 
     function loadIndices(accessorId, expectedByteLength) {
@@ -544,11 +533,11 @@ fdescribe(
 
       indexBufferLoader.load();
 
-      return waitForLoaderProcess(indexBufferLoader, scene).then(function (
-        indexBufferLoader
-      ) {
-        expect(indexBufferLoader.buffer.sizeInBytes).toBe(expectedByteLength);
-      });
+      return waitForLoaderProcess(indexBufferLoader, sceneWithWebgl2).then(
+        function (indexBufferLoader) {
+          expect(indexBufferLoader.buffer.sizeInBytes).toBe(expectedByteLength);
+        }
+      );
     }
 
     it("loads uint32 indices", function () {
@@ -593,14 +582,14 @@ fdescribe(
 
       indexBufferLoader.load();
 
-      return waitForLoaderProcess(indexBufferLoader, scene).then(function (
-        indexBufferLoader
-      ) {
-        loaderProcess(indexBufferLoader, scene); // Check that calling process after load doesn't break anything
-        expect(indexBufferLoader.buffer.sizeInBytes).toBe(
-          decodedIndices.byteLength
-        );
-      });
+      return waitForLoaderProcess(indexBufferLoader, sceneWithWebgl2).then(
+        function (indexBufferLoader) {
+          loaderProcess(indexBufferLoader, scene); // Check that calling process after load doesn't break anything
+          expect(indexBufferLoader.buffer.sizeInBytes).toBe(
+            decodedIndices.byteLength
+          );
+        }
+      );
     });
 
     it("uses the decoded data's type instead of the accessor component type", function () {
@@ -626,12 +615,12 @@ fdescribe(
 
       indexBufferLoader.load();
 
-      return waitForLoaderProcess(indexBufferLoader, scene).then(function (
-        indexBufferLoader
-      ) {
-        expect(indexBufferLoader.indexDatatype).toBe(5123);
-        expect(indexBufferLoader.buffer.indexDatatype).toBe(5123);
-      });
+      return waitForLoaderProcess(indexBufferLoader, sceneWithWebgl2).then(
+        function (indexBufferLoader) {
+          expect(indexBufferLoader.indexDatatype).toBe(5123);
+          expect(indexBufferLoader.buffer.indexDatatype).toBe(5123);
+        }
+      );
     });
 
     it("destroys index buffer loaded from buffer view", function () {
@@ -659,19 +648,19 @@ fdescribe(
 
       indexBufferLoader.load();
 
-      return waitForLoaderProcess(indexBufferLoader, scene).then(function (
-        indexBufferLoader
-      ) {
-        expect(indexBufferLoader.buffer).toBeDefined();
-        expect(indexBufferLoader.isDestroyed()).toBe(false);
+      return waitForLoaderProcess(indexBufferLoader, sceneWithWebgl2).then(
+        function (indexBufferLoader) {
+          expect(indexBufferLoader.buffer).toBeDefined();
+          expect(indexBufferLoader.isDestroyed()).toBe(false);
 
-        indexBufferLoader.destroy();
+          indexBufferLoader.destroy();
 
-        expect(indexBufferLoader.buffer).not.toBeDefined();
-        expect(indexBufferLoader.isDestroyed()).toBe(true);
-        expect(unloadBufferView).toHaveBeenCalled();
-        expect(destroyIndexBuffer).toHaveBeenCalled();
-      });
+          expect(indexBufferLoader.buffer).not.toBeDefined();
+          expect(indexBufferLoader.isDestroyed()).toBe(true);
+          expect(unloadBufferView).toHaveBeenCalled();
+          expect(destroyIndexBuffer).toHaveBeenCalled();
+        }
+      );
     });
 
     it("destroys index buffer loaded from draco", function () {
@@ -704,19 +693,19 @@ fdescribe(
 
       indexBufferLoader.load();
 
-      return waitForLoaderProcess(indexBufferLoader, scene).then(function (
-        indexBufferLoader
-      ) {
-        expect(indexBufferLoader.buffer).toBeDefined();
-        expect(indexBufferLoader.isDestroyed()).toBe(false);
+      return waitForLoaderProcess(indexBufferLoader, sceneWithWebgl2).then(
+        function (indexBufferLoader) {
+          expect(indexBufferLoader.buffer).toBeDefined();
+          expect(indexBufferLoader.isDestroyed()).toBe(false);
 
-        indexBufferLoader.destroy();
+          indexBufferLoader.destroy();
 
-        expect(indexBufferLoader.buffer).not.toBeDefined();
-        expect(indexBufferLoader.isDestroyed()).toBe(true);
-        expect(unloadDraco).toHaveBeenCalled();
-        expect(destroyIndexBuffer).toHaveBeenCalled();
-      });
+          expect(indexBufferLoader.buffer).not.toBeDefined();
+          expect(indexBufferLoader.isDestroyed()).toBe(true);
+          expect(unloadDraco).toHaveBeenCalled();
+          expect(destroyIndexBuffer).toHaveBeenCalled();
+        }
+      );
     });
 
     function resolveBufferViewAfterDestroy(reject) {
@@ -792,7 +781,7 @@ fdescribe(
 
       let promise = new Promise(function (resolve, reject) {
         setTimeout(function () {
-          loaderProcess(indexBufferLoader, scene);
+          loaderProcess(indexBufferLoader, sceneWithWebgl2);
           if (rejectPromise) {
             reject(new Error());
           } else {
@@ -816,7 +805,7 @@ fdescribe(
       expect(indexBufferLoader.buffer).not.toBeDefined();
 
       indexBufferLoader.load();
-      loaderProcess(indexBufferLoader, scene);
+      loaderProcess(indexBufferLoader, sceneWithWebgl2);
       return promise.finally(function () {
         expect(decodeBufferView).toHaveBeenCalled(); // Make sure the decode actually starts
 

--- a/Specs/Scene/GltfIndexBufferLoaderSpec.js
+++ b/Specs/Scene/GltfIndexBufferLoaderSpec.js
@@ -256,7 +256,7 @@ describe(
       ],
     };
 
-    // Index buffers will only load as typed arrays in WebGL1.
+    // Index buffers will load as typed arrays only in WebGL1.
     // In order to load them as buffers, the scene must have WebGL2 enabled.
     let scene;
     let sceneWithWebgl2;

--- a/Specs/Scene/GltfLoaderSpec.js
+++ b/Specs/Scene/GltfLoaderSpec.js
@@ -360,8 +360,8 @@ describe(
 
         expect(indices.indexDatatype).toBe(IndexDatatype.UNSIGNED_SHORT);
         expect(indices.count).toBe(36);
-        expect(indices.buffer).toBeDefined();
-        expect(indices.buffer.sizeInBytes).toBe(72);
+        expect(indices.typedArray).toBeDefined();
+        expect(indices.typedArray.byteLength).toBe(72);
 
         expect(positionAttribute.buffer).toBe(normalAttribute.buffer);
         expect(positionAttribute.buffer).not.toBe(texcoordAttribute.buffer);
@@ -926,7 +926,7 @@ describe(
           IndexDatatype.UNSIGNED_SHORT
         );
         expect(primitive.indices.count).toBe(3);
-        expect(primitive.indices.buffer).toBeDefined();
+        expect(primitive.indices.typedArray).toBeDefined();
       });
     });
 
@@ -1982,8 +1982,8 @@ describe(
 
         expect(indices.indexDatatype).toBe(IndexDatatype.UNSIGNED_SHORT);
         expect(indices.count).toBe(36);
-        expect(indices.buffer).toBeDefined();
-        expect(indices.buffer.sizeInBytes).toBe(72);
+        expect(indices.typedArray).toBeDefined();
+        expect(indices.typedArray.byteLength).toBe(72);
 
         expect(positionAttribute.buffer).toBe(normalAttribute.buffer);
         expect(positionAttribute.buffer).not.toBe(texcoordAttribute.buffer);
@@ -2980,8 +2980,8 @@ describe(
 
         expect(indices.indexDatatype).toBe(IndexDatatype.UNSIGNED_SHORT);
         expect(indices.count).toBe(12636);
-        expect(indices.buffer).toBeDefined();
-        expect(indices.buffer.sizeInBytes).toBe(25272);
+        expect(indices.typedArray).toBeDefined();
+        expect(indices.typedArray.byteLength).toBe(25272);
 
         expect(positionAttribute.buffer).not.toBe(normalAttribute.buffer);
         expect(positionAttribute.buffer).not.toBe(texcoordAttribute.buffer);
@@ -3044,7 +3044,7 @@ describe(
           IndexDatatype.UNSIGNED_SHORT
         );
         expect(primitive.indices.count).toBe(3);
-        expect(primitive.indices.buffer).toBeDefined();
+        expect(primitive.indices.typedArray).toBeDefined();
       });
     });
 

--- a/Specs/Scene/ResourceCacheSpec.js
+++ b/Specs/Scene/ResourceCacheSpec.js
@@ -247,10 +247,15 @@ describe(
       ],
     };
 
+    // Index buffers will load as typed arrays only in WebGL1.
+    // In order to load them as buffers, the scene must have WebGL2 enabled.
     let scene;
+    let sceneWithWebgl2;
 
     beforeAll(function () {
       scene = createScene();
+      sceneWithWebgl2 = createScene();
+      sceneWithWebgl2.context._webgl2 = true;
     });
 
     afterAll(function () {
@@ -1047,7 +1052,7 @@ describe(
       }).toThrowDeveloperError();
     });
 
-    it("loads index buffer from accessor", function () {
+    it("loads index buffer from accessor as buffer", function () {
       spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
         Promise.resolve(bufferArrayBuffer)
       );
@@ -1081,11 +1086,11 @@ describe(
 
       expect(cacheEntry.referenceCount).toBe(2);
 
-      return waitForLoaderProcess(indexBufferLoader, scene).then(function (
-        indexBufferLoader
-      ) {
-        expect(indexBufferLoader.buffer).toBeDefined();
-      });
+      return waitForLoaderProcess(indexBufferLoader, sceneWithWebgl2).then(
+        function (indexBufferLoader) {
+          expect(indexBufferLoader.buffer).toBeDefined();
+        }
+      );
     });
 
     it("loads index buffer from draco", function () {
@@ -1129,14 +1134,14 @@ describe(
 
       expect(cacheEntry.referenceCount).toBe(2);
 
-      return waitForLoaderProcess(indexBufferLoader, scene).then(function (
-        indexBufferLoader
-      ) {
-        expect(indexBufferLoader.buffer).toBeDefined();
-      });
+      return waitForLoaderProcess(indexBufferLoader, sceneWithWebgl2).then(
+        function (indexBufferLoader) {
+          expect(indexBufferLoader.buffer).toBeDefined();
+        }
+      );
     });
 
-    it("loads index buffer as typed array", function () {
+    it("loads index buffer as typed array using option", function () {
       spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
         Promise.resolve(bufferArrayBuffer)
       );
@@ -1158,12 +1163,12 @@ describe(
 
       expect(indexBufferLoader.cacheKey).toBe(expectedCacheKey);
 
-      return waitForLoaderProcess(indexBufferLoader, scene).then(function (
-        indexBufferLoader
-      ) {
-        expect(indexBufferLoader.typedArray).toBeDefined();
-        expect(indexBufferLoader.buffer).toBeUndefined();
-      });
+      return waitForLoaderProcess(indexBufferLoader, sceneWithWebgl2).then(
+        function (indexBufferLoader) {
+          expect(indexBufferLoader.typedArray).toBeDefined();
+          expect(indexBufferLoader.buffer).toBeUndefined();
+        }
+      );
     });
 
     it("loadIndexBuffer throws if gltf is undefined", function () {


### PR DESCRIPTION
Closes #9066. This PR adds the `debugWireframe` option to `ModelExperimental`. The current wireframe code in `Model` leads to tangled / incorrect wireframes, but `ModelExperimental` implements it properly.

| `Model` | `Model Experimental |
| -------- | ----------------------- |
| ![image](https://user-images.githubusercontent.com/32226860/165577440-59a96ee9-8492-4f67-b9f5-5b4a2863348b.png) | ![image](https://user-images.githubusercontent.com/32226860/165578070-2947b90e-5b5c-4bfc-8bc9-eaa28840bcf8.png) |
| ![image](https://user-images.githubusercontent.com/32226860/165579037-8f869acc-f931-475b-b0d5-52e5b495a8c7.png) | ![image](https://user-images.githubusercontent.com/32226860/165579210-7fd21846-928d-4d0c-8618-6b919f268070.png) |
| ![image](https://user-images.githubusercontent.com/32226860/165579125-3de4680a-09ca-4a14-9916-891fb9abcd8b.png) | ![image](https://user-images.githubusercontent.com/32226860/165579352-c6c5d88c-23ff-49ef-ac3f-ccee2f98a093.png) |

Here's a modified version of the [Model Experimental sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=tVdtb9s2EP4rhPehzmDTsuMkrpcWS9I07dCgQZ22wKZhoKSzRZgiBZJynBX57ztSL5Zjd+taJK98ueM9d/fwjo6VNJasONyBJi+IhDtyAYYXGf3k17phJ/bzCyUt4xJ02OmRL6EkxKSqEMmZ5BmzMCVWF9AL5cPBL6EMZXkijYWKlzQutAZpb3kGaKM6/7dCcCZfoS6da5W9NWpyHAy77uSwMwpGw/5w2A+e346C6ehkenhCg+FxcDwenxwdjifHk/Hzw5Pfw04oS3uDAblWCQgTyti7lPkZmvvDnegBE2Jhbad4fAmBnDMhlJLoUbmNiiAgRpF5IWPLlSTdg1oXHfab3ky3XnNgKR3gz4xluQD0hw1K24PSSmVke0YXImrMuq/hUT12/rj/D363/PsI/mzJpYSEXKRMs9j6nDyhB9esRv8XDnegB/8D+SvEq8iFynINxqALHstTwffWNsZqd7hY3uoCebkQdv7drnyUgltyrtbfhf6rmPFAf3IzqFGS4JviqyQ8LRu8ifb4x7h8pVUhE/IJUh6LJ4NeWqmMbM9+iM9vsdQwGSORv5cI3wAej27sbE12Cfxvof/TF8q4KfgeABZIjyuBqFh85hrmmmVwKVkkIEH8TBhf1Vu6af6oU7wBlnC5uOE2Tj8oUTpV7V0zm1KrPqAEk6Y7nAQHHlBQ/i3Ld3nunK8hee3M32qUnSudbbpFs2QothQmSjn1utG5AuxNzCpddRCptE2r2ISdOzB20ywEVP0BZ02G2lkptOiRFPgitVXeSoi5MtwLN7gumLY4YvLQd7FXsNAApkprfzg6pMHJeHw8fF4laTymwVFweBIcVwulFTcusZGqGVMTo0c01zxDkyswVEOmVnCG8S1zm1X5+5o8S5IKR50Lp3C5zgFlsB0z4SFfIYe6DTcdo6bE+V+veDOYRs3X0z3ZSB8lv52TFrvryLW4ijxqzaqTL4XguVE8oZ+vZpNxS2APPRqub8ByfI4U2Q3Kihn/G58lw9Fks8vWbneG/MGdUYBfzd72BZhubgjdezWqy3XQTpyPFKaJJfc3GFhugNoUZHdTBLxEUwnqNxKeqhnSWi3PbBOynYB97cIxuWgHev+9Gx8d9P5Lpj/cEiq9iVylRFuzPAUNVKNsYcjPZFNnykEdg1oPnyVIwvJxiF54NjrqNkRDd/PpFjMb4Xe4RT9c3lye3fbqOHvG+38PztCMySRmxmL5xoNvlRIR09cgizLEpnkUIlfiJUFpEmNiLBDMCIm498kQJJFfcJkogdfFyJZH4vVKVFy460IXYC8FuOH5/Vu8Wp1KJuw4a5UnS4kPXlVYap3hbsOifSIsz8X9eYVlI9qrje/RcVFwQN5HBvTKMbGtF3b2c7Xjk0RNEZlY8whajFwxUUDDyGwP4V2FcUKbDLjvTq9zauy9gJd1Qn/lWY4119WOLrYxC9jGMOBmEOFTCyyNjal7EiE/1fH9siFchAFb+M48JXoRse541CP1b0AnG228HZh1jNqUjPN1azlSOgHdL1m6vfmwY5rLvLBtACvQlmNt6DPBF3KKxSRJBOxa7VtH3dGW5XorUtaqbHt317SvmrDl/Rw/X/XvfDOYoh8ieax+OmjH+zThK8KTF3s+npFYMGNwZ14IXwTDzsvTAcrvqArl68h7dFyweyeWDl++KxcppacDnO7XbKjfpP+0DKe9z8GBSiFeRu5JVJLHoXFPCZwn+LLpuxtYi7l3xl7e9krdj3niP2A+8xaetWzOUnVH7mqtOkwbvP8A) that allows you to toggle the wireframe.

This should also work for tilesets with `Cesium.ExperimentalFeatures.enableModelExperimental = true.` For example, here's the result of the changes in the [3D Tiles Inspector sandcastle (localhost)](http://localhost:8080/Apps/Sandcastle/index.html?src=3D%20Tiles%20Inspector.html&label=3D%20Tiles)

| With `Model` | With `ModelExperimental` |
| -------------- | ----------------------------- |
| ![image](https://user-images.githubusercontent.com/32226860/165579735-58f96fed-1da7-4b1d-86d0-c1474fcb163c.png) | ![image](https://user-images.githubusercontent.com/32226860/165579973-e231445d-bed2-431b-b6a5-5942065866a3.png) |

**Note:** this required changes to `GltfIndexBufferLoader` because implementing the wireframe required the index buffer to be available on the CPU. Index buffers are now loaded as typed arrays only in WebGL1 since it's not possible to get data from the buffer directly. With WebGL2, either buffers or typed arrays are fine.