### PR TITLE
Temporarily disable OIT by default for iOS and iPad

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### 1.93 - 2022-05-02
 
+##### Breaking Changes :mega:
+
+- Temporarily disable `Scene.orderIndependentTranslucency` by default on iPad and iOS due to a WebGL regression, see [#9827](https://github.com/CesiumGS/cesium/issues/9827). The old default will be restored once the issue has been resolved.
+
 ##### Additions :tada:
 
 - `KmlDataSource` now exposes the `camera` and `canvas` properties, which are used to provide information about the state of the Viewer when making network requests for a [Link](https://developers.google.com/kml/documentation/kmlreference#link). Passing these values in the constructor is now optional.

--- a/Source/Core/FeatureDetection.js
+++ b/Source/Core/FeatureDetection.js
@@ -160,6 +160,18 @@ function isWindows() {
   return isWindowsResult;
 }
 
+let isIPadOrIOSResult;
+function isIPadOrIOS() {
+  if (!defined(isIPadOrIOSResult)) {
+    isIPadOrIOSResult =
+      navigator.platform === "iPhone" ||
+      navigator.platform === "iPod" ||
+      navigator.platform === "iPad";
+  }
+
+  return isIPadOrIOSResult;
+}
+
 function firefoxVersion() {
   return isFirefox() && firefoxVersionResult;
 }
@@ -310,6 +322,7 @@ const FeatureDetection = {
   isFirefox: isFirefox,
   firefoxVersion: firefoxVersion,
   isWindows: isWindows,
+  isIPadOrIOS: isIPadOrIOS,
   hardwareConcurrency: defaultValue(theNavigator.hardwareConcurrency, 3),
   supportsPointerEvents: supportsPointerEvents,
   supportsImageRenderingPixelated: supportsImageRenderingPixelated,

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -15,6 +15,7 @@ import destroyObject from "../Core/destroyObject.js";
 import DeveloperError from "../Core/DeveloperError.js";
 import EllipsoidGeometry from "../Core/EllipsoidGeometry.js";
 import Event from "../Core/Event.js";
+import FeatureDetection from "../Core/FeatureDetection.js";
 import GeographicProjection from "../Core/GeographicProjection.js";
 import GeometryInstance from "../Core/GeometryInstance.js";
 import GeometryPipeline from "../Core/GeometryPipeline.js";
@@ -225,7 +226,9 @@ function Scene(options) {
   this._computeCommandList = [];
   this._overlayCommandList = [];
 
-  this._useOIT = defaultValue(options.orderIndependentTranslucency, true);
+  // OIT is temporally disabled by default on iPad and iOS mobile due to https://github.com/CesiumGS/cesium/issues/9827
+  const defaultOIT = !FeatureDetection.isIPadOrIOS();
+  this._useOIT = defaultValue(options.orderIndependentTranslucency, defaultOIT);
   this._executeOITFunction = undefined;
 
   this._depthPlane = new DepthPlane(options.depthPlaneEllipsoidOffset);

--- a/Specs/Core/FeatureDetectionSpec.js
+++ b/Specs/Core/FeatureDetectionSpec.js
@@ -124,6 +124,11 @@ describe("Core/FeatureDetection", function () {
     }
   });
 
+  it("detects iPad or iOS", function () {
+    const iPadOrIOS = FeatureDetection.isIPadOrIOS();
+    expect(typeof iPadOrIOS).toEqual("boolean");
+  });
+
   it("detects imageRendering support", function () {
     const supportsImageRenderingPixelated = FeatureDetection.supportsImageRenderingPixelated();
     expect(typeof supportsImageRenderingPixelated).toEqual("boolean");

--- a/Specs/Scene/SceneSpec.js
+++ b/Specs/Scene/SceneSpec.js
@@ -5,6 +5,7 @@ import { CesiumTerrainProvider } from "../../Source/Cesium.js";
 import { Color } from "../../Source/Cesium.js";
 import { defined } from "../../Source/Cesium.js";
 import { Ellipsoid } from "../../Source/Cesium.js";
+import { FeatureDetection } from "../../Source/Cesium.js";
 import { GeographicProjection } from "../../Source/Cesium.js";
 import { GeometryInstance } from "../../Source/Cesium.js";
 import { HeadingPitchRoll } from "../../Source/Cesium.js";
@@ -124,6 +125,12 @@ describe(
       expect(contextAttributes.premultipliedAlpha).toEqual(true);
       expect(contextAttributes.preserveDrawingBuffer).toEqual(false);
       expect(scene._depthPlane._ellipsoidOffset).toEqual(0);
+    });
+
+    it("constructor default OIT to disabled if running on iPad or iOS", function () {
+      spyOn(FeatureDetection, "isIPadOrIOS").and.returnValue(true);
+      const scene = createScene();
+      expect(scene.orderIndependentTranslucency).toBe(false);
     });
 
     it("constructor sets options", function () {


### PR DESCRIPTION
Due to increased reports of https://github.com/CesiumGS/cesium/issues/9827, this disables `orderIndependentTranslucency` by default on iOS and iPad as a temporary workaround.