### PR TITLE
Link to recent guides from the Contributors README

### DIFF
--- a/Documentation/Contributors/README.md
+++ b/Documentation/Contributors/README.md
@@ -7,6 +7,7 @@
   - [VSCode Guide](VSCodeGuide/README.md) - How to set up VSCode.
 - [Coding Guide](CodingGuide/README.md) - JavaScript and GLSL coding conventions and best practices for design, maintainability, and performance.
 - [Testing Guide](TestingGuide/README.md) - How to run the CesiumJS tests and write awesome tests.
+- [Performance Testing Guide](PerformanceTestingGuide) - Best practices for measuring runtime performance.
 - [Documentation Guide](DocumentationGuide/README.md) - How to write great reference documentation.
 - [Code Review Guide](CodeReviewGuide/README.md) - Best practices for reviewing code in pull requests.
 - [Presenter's Guide](PresentersGuide/README.md) - Tips for giving talks.

--- a/Documentation/Contributors/README.md
+++ b/Documentation/Contributors/README.md
@@ -7,8 +7,9 @@
   - [VSCode Guide](VSCodeGuide/README.md) - How to set up VSCode.
 - [Coding Guide](CodingGuide/README.md) - JavaScript and GLSL coding conventions and best practices for design, maintainability, and performance.
 - [Testing Guide](TestingGuide/README.md) - How to run the CesiumJS tests and write awesome tests.
-- [Performance Testing Guide](PerformanceTestingGuide) - Best practices for measuring runtime performance.
+- [Performance Testing Guide](PerformanceTestingGuide/README.md) - Best practices for measuring runtime performance.
 - [Documentation Guide](DocumentationGuide/README.md) - How to write great reference documentation.
 - [Code Review Guide](CodeReviewGuide/README.md) - Best practices for reviewing code in pull requests.
 - [Presenter's Guide](PresentersGuide/README.md) - Tips for giving talks.
 - [Committer's Guide](CommittersGuide/README.md) - What to do with commit access to the main CesiumJS repo.
+- [Custom Shader Guide](../CustomShaderGuide/README.md) - Usage guide for the `CustomShader` class, which applies custom GLSL code to models and tilesets.

--- a/Documentation/Contributors/README.md
+++ b/Documentation/Contributors/README.md
@@ -12,4 +12,3 @@
 - [Code Review Guide](CodeReviewGuide/README.md) - Best practices for reviewing code in pull requests.
 - [Presenter's Guide](PresentersGuide/README.md) - Tips for giving talks.
 - [Committer's Guide](CommittersGuide/README.md) - What to do with commit access to the main CesiumJS repo.
-- [Custom Shader Guide](../CustomShaderGuide/README.md) - Usage guide for the `CustomShader` class, which applies custom GLSL code to models and tilesets.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,4 @@
+# Documentation
+
+- [Contributors' Guides](Contributors/README.md) - Various guides about CesiumJS on topics such as code style, building CesiumJS, and how to write unit tests.
+- [Custom Shader Guide](CustomShaderGuide/README.md) - Usage guide for the `CustomShader` class, which applies custom GLSL code to models and tilesets.


### PR DESCRIPTION
This PR adds two links to guides:

1. The new Performance guide added in #10316
2. The Custom Shader Guide added a while ago.

I wasn't sure if 2) should be included since the custom shader guide is in the parent directory... is this link okay or do we need another way of organizing guide links?

@ggetz could you review?