### PR TITLE
Add label background image asynchronously

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Fixes :wrench:
 
 - Fixed the inaccurate computation of bounding spheres for `ModelExperimental`. [#10339](https://github.com/CesiumGS/cesium/pull/10339/)
+- Fixed [#10342](https://github.com/CesiumGS/cesium/issues/10342)
 
 ### 1.93 - 2022-05-02
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 ##### Fixes :wrench:
 
 - Fixed the inaccurate computation of bounding spheres for `ModelExperimental`. [#10339](https://github.com/CesiumGS/cesium/pull/10339/)
-- Fixed [#10342](https://github.com/CesiumGS/cesium/issues/10342)
+- Fixed label background rendering. [#10342](https://github.com/CesiumGS/cesium/issues/10342)
 
 ### 1.93 - 2022-05-02
 

--- a/Source/Scene/LabelCollection.js
+++ b/Source/Scene/LabelCollection.js
@@ -54,9 +54,7 @@ function addWhitePixelCanvas(textureAtlas, labelCollection) {
   context2D.fillStyle = "#fff";
   context2D.fillRect(0, 0, canvas.width, canvas.height);
 
-  textureAtlas.addImage(whitePixelCanvasId, canvas).then(function (index) {
-    labelCollection._whitePixelIndex = index;
-  });
+  textureAtlas.addImage(whitePixelCanvasId, canvas);
 }
 
 // reusable object for calling writeTextToCanvas
@@ -598,7 +596,6 @@ function LabelCollection(options) {
 
   this._textureAtlas = undefined;
   this._backgroundTextureAtlas = undefined;
-  this._whitePixelIndex = undefined;
 
   this._backgroundBillboardCollection = new BillboardCollection({
     scene: this._scene,

--- a/Source/Scene/LabelCollection.js
+++ b/Source/Scene/LabelCollection.js
@@ -54,8 +54,9 @@ function addWhitePixelCanvas(textureAtlas, labelCollection) {
   context2D.fillStyle = "#fff";
   context2D.fillRect(0, 0, canvas.width, canvas.height);
 
-  const index = textureAtlas.addImageSync(whitePixelCanvasId, canvas);
-  labelCollection._whitePixelIndex = index;
+  textureAtlas.addImage(whitePixelCanvasId, canvas).then(function (index) {
+    labelCollection._whitePixelIndex = index;
+  });
 }
 
 // reusable object for calling writeTextToCanvas

--- a/Source/Scene/LabelCollection.js
+++ b/Source/Scene/LabelCollection.js
@@ -45,7 +45,7 @@ const whitePixelCanvasId = "ID_WHITE_PIXEL";
 const whitePixelSize = new Cartesian2(4, 4);
 const whitePixelBoundingRegion = new BoundingRectangle(1, 1, 1, 1);
 
-function addWhitePixelCanvas(textureAtlas, labelCollection) {
+function addWhitePixelCanvas(textureAtlas) {
   const canvas = document.createElement("canvas");
   canvas.width = whitePixelSize.x;
   canvas.height = whitePixelSize.y;
@@ -54,6 +54,8 @@ function addWhitePixelCanvas(textureAtlas, labelCollection) {
   context2D.fillStyle = "#fff";
   context2D.fillRect(0, 0, canvas.width, canvas.height);
 
+  // Canvas operations take a frame to draw. Use the asynchronous add function which resolves a promise and allows the draw to complete,
+  // but there's no need to wait on the promise before operation can continue
   textureAtlas.addImage(whitePixelCanvasId, canvas);
 }
 
@@ -908,7 +910,7 @@ LabelCollection.prototype.update = function (frameState) {
       initialSize: whitePixelSize,
     });
     backgroundBillboardCollection.textureAtlas = this._backgroundTextureAtlas;
-    addWhitePixelCanvas(this._backgroundTextureAtlas, this);
+    addWhitePixelCanvas(this._backgroundTextureAtlas);
   }
 
   const len = this._labelsToUpdate.length;


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/10342

[Here's a local sandcastle that easily shows the issue.](http://localhost:8080/Apps/Sandcastle/index.html#c=bZBRT8IwFIX/ys2eRjK7IIJhDqJME40kPmj0pS/ddoGGriVtx0TDf7fdUIzSh6b33POdm95CSWNhy7FBDROQ2ECGhtcVeW21kAZFW2dKWsYlahr0rqiksmMISsstR0NYWYafVAJslHGKksl3Usa0dS8mB2ShVXWLS41owrPLIemPLvqj0WUEgzEZD8/96UU+RLAcRQJtIIDFd5sADeZehYbbFcxYsV5qVcuSBlHnWnAhMiWUPk72FZnNb7LHg8esVHNEE7C6xkMr/5FPhbzdP7zctc69u/d+B0EUpMbuBE67AIBrXm2UtlBrERISW6w2grm/x3ldrNGSwhgPemsa/0bTkm+Bl5MT24ZCMGNcZ1EL8cw/kAbTNHb+f6hQrORy+bRFLdjO21b96bwTCSFp7MrTpFVK5Ez/Sf4C)

This arose during https://github.com/CesiumGS/cesium/pull/10275. I've confirmed that this fixes the above issue while still maintaining the 3d tileset inspector  label behavior that was restored as part of that pull request. 

I also removed `_whitePixelIndex` as it was assigned but never read anywhere as far as I could tell.

However, I'm having trouble understanding _why_ this fix works. The canvas `canvas` passed to the `addImage` function does not require loading and therefore does not require awaiting a promise in order to add it to the texture atlas.

@lilleyse Would you be able to give this a look?
