### PR TITLE
Add `enableDebugWireframe` to use wireframes for ModelExperimental in WebGL1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### 1.94 - 2022-06-01
 
+##### Breaking Changes :mega:
+
+- Models and tilesets rendered with `ModelExperimental` must set `enableDebugWireframe` to true in order for `debugWireframe` to work in WebGL1. [#10344](https://github.com/CesiumGS/cesium/pull/10344)
+
 ##### Fixes :wrench:
 
 - Fixed the inaccurate computation of bounding spheres for `ModelExperimental`. [#10339](https://github.com/CesiumGS/cesium/pull/10339/)

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -110,6 +110,7 @@ import TileOrientedBoundingBox from "./TileOrientedBoundingBox.js";
  * @param {String} [options.debugHeatmapTilePropertyName] The tile variable to colorize as a heatmap. All rendered tiles will be colorized relative to each other's specified variable value.
  * @param {Boolean} [options.debugFreezeFrame=false] For debugging only. Determines if only the tiles from last frame should be used for rendering.
  * @param {Boolean} [options.debugColorizeTiles=false] For debugging only. When true, assigns a random color to each tile.
+ * @param {Boolean} [options.enableDebugWireframe] For debugging only. This must be true for debugWireframe to work for ModelExperimental in WebGL1. This cannot be set after the tileset has loaded.
  * @param {Boolean} [options.debugWireframe=false] For debugging only. When true, render's each tile's content as a wireframe.
  * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. When true, renders the bounding volume for each tile.
  * @param {Boolean} [options.debugShowContentBoundingVolume=false] For debugging only. When true, renders the bounding volume for each tile's content.
@@ -819,6 +820,11 @@ function Cesium3DTileset(options) {
    * @default false
    */
   this.debugColorizeTiles = defaultValue(options.debugColorizeTiles, false);
+
+  this._enableDebugWireframe = defaultValue(
+    options.enableDebugWireframe,
+    false
+  );
 
   /**
    * This property is for debugging only; it is not optimized for production use.

--- a/Source/Scene/GltfIndexBufferLoader.js
+++ b/Source/Scene/GltfIndexBufferLoader.js
@@ -29,8 +29,8 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {Object} [options.draco] The Draco extension object.
  * @param {String} [options.cacheKey] The cache key of the resource.
  * @param {Boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
- * @param {Boolean} [loadAsTypedArray=false] Load index buffer as a typed array instead of a GPU index buffer.
- *
+ * @param {Boolean} [options.loadAsTypedArray=false] Load index buffer as a typed array instead of a GPU index buffer.
+ * @param {Boolean} [options.loadForWireframe=false] Load index buffer as a typed array in order to generate wireframes in WebGL1. This will be ignored if using WebGL2.
  * @private
  */
 export default function GltfIndexBufferLoader(options) {
@@ -44,6 +44,7 @@ export default function GltfIndexBufferLoader(options) {
   const cacheKey = options.cacheKey;
   const asynchronous = defaultValue(options.asynchronous, true);
   const loadAsTypedArray = defaultValue(options.loadAsTypedArray, false);
+  const loadForWireframe = defaultValue(options.loadForWireframe, false);
 
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.func("options.resourceCache", resourceCache);
@@ -65,6 +66,7 @@ export default function GltfIndexBufferLoader(options) {
   this._cacheKey = cacheKey;
   this._asynchronous = asynchronous;
   this._loadAsTypedArray = loadAsTypedArray;
+  this._loadForWireframe = loadForWireframe;
   this._bufferViewLoader = undefined;
   this._dracoLoader = undefined;
   this._typedArray = undefined;
@@ -108,7 +110,8 @@ Object.defineProperties(GltfIndexBufferLoader.prototype, {
     },
   },
   /**
-   * The index buffer. This is only defined when <code>loadAsTypedArray</code> is false.
+   * The index buffer. This is only defined when <code>loadAsTypedArray</code> is false
+   * or when <code>loadForWireframe</code> is false while using WebGL1.
    *
    * @memberof GltfIndexBufferLoader.prototype
    *
@@ -122,7 +125,8 @@ Object.defineProperties(GltfIndexBufferLoader.prototype, {
     },
   },
   /**
-   * The typed array containing indices. This is only defined when <code>loadAsTypedArray</code> is true.
+   * The typed array containing indices. This is only defined when <code>loadAsTypedArray</code> is true
+   * or when <code>loadForWireframe</code> is true while using WebGL1.
    *
    * @memberof GltfIndexBufferLoader.prototype
    *
@@ -335,10 +339,11 @@ GltfIndexBufferLoader.prototype.process = function (frameState) {
   }
 
   // WebGL1 has no way to retrieve the contents of buffers that are
-  // on the GPU. Therefore, the index buffer is stored in CPU memory
-  // in case it needs to be referenced later.
+  // on the GPU. Therefore, the index buffer must be stored in CPU memory
+  // to generate wireframes for models.
   const useWebgl2 = frameState.context.webgl2;
-  if (this._loadAsTypedArray || !useWebgl2) {
+  const loadTypedArrayForWireframe = !useWebgl2 && this._loadForWireframe;
+  if (this._loadAsTypedArray || loadTypedArrayForWireframe) {
     // Unload everything except the typed array
     this.unload();
 

--- a/Source/Scene/GltfLoader.js
+++ b/Source/Scene/GltfLoader.js
@@ -80,7 +80,7 @@ const GltfLoaderState = {
  * @param {Axis} [options.forwardAxis=Axis.Z] The forward-axis of the glTF model.
  * @param {Boolean} [options.loadAsTypedArray=false] Load all attributes and indices as typed arrays instead of GPU buffers.
  * @param {Boolean} [options.renameBatchIdSemantic=false] If true, rename _BATCHID or BATCHID to _FEATURE_ID_0. This is used for .b3dm models
- * @param {Boolean} [options.loadIndicesForWireframe=false] If true, load in the index buffer as a typed array so the wireframe indices can be created later.
+ * @param {Boolean} [options.loadIndicesForWireframe=false] If true, load the index buffer as a typed array so wireframe indices can be created for WebGL1.
  * @private
  */
 export default function GltfLoader(options) {

--- a/Source/Scene/ModelExperimental/B3dmLoader.js
+++ b/Source/Scene/ModelExperimental/B3dmLoader.js
@@ -50,6 +50,7 @@ const FeatureIdAttribute = ModelComponents.FeatureIdAttribute;
  * @param {Axis} [options.upAxis=Axis.Y] The up-axis of the glTF model.
  * @param {Axis} [options.forwardAxis=Axis.X] The forward-axis of the glTF model.
  * @param {Boolean} [options.loadAsTypedArray=false] Load all attributes as typed arrays instead of GPU buffers.
+ * @param {Boolean} [options.loadIndicesForWireframe=false] Load the index buffer as a typed array so wireframe indices can be created for WebGL1.
  */
 function B3dmLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -67,6 +68,10 @@ function B3dmLoader(options) {
   const upAxis = defaultValue(options.upAxis, Axis.Y);
   const forwardAxis = defaultValue(options.forwardAxis, Axis.X);
   const loadAsTypedArray = defaultValue(options.loadAsTypedArray, false);
+  const loadIndicesForWireframe = defaultValue(
+    options.loadIndicesForWireframe,
+    false
+  );
 
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("options.b3dmResource", b3dmResource);
@@ -85,6 +90,7 @@ function B3dmLoader(options) {
   this._upAxis = upAxis;
   this._forwardAxis = forwardAxis;
   this._loadAsTypedArray = loadAsTypedArray;
+  this._loadIndicesForWireframe = loadIndicesForWireframe;
 
   this._state = B3dmLoaderState.UNLOADED;
 
@@ -214,6 +220,7 @@ B3dmLoader.prototype.load = function () {
     releaseGltfJson: this._releaseGltfJson,
     incrementallyLoadTextures: this._incrementallyLoadTextures,
     loadAsTypedArray: this._loadAsTypedArray,
+    loadIndicesForWireframe: this._loadIndicesForWireframe,
     renameBatchIdSemantic: true,
   });
 

--- a/Source/Scene/ModelExperimental/I3dmLoader.js
+++ b/Source/Scene/ModelExperimental/I3dmLoader.js
@@ -60,6 +60,7 @@ const Instances = ModelComponents.Instances;
  * @param {Axis} [options.upAxis=Axis.Y] The up-axis of the glTF model.
  * @param {Axis} [options.forwardAxis=Axis.X] The forward-axis of the glTF model.
  * @param {Boolean} [options.loadAsTypedArray=false] Load all attributes as typed arrays instead of GPU buffers.
+ * @param {Boolean} [options.loadIndicesForWireframe=false] Load the index buffer as a typed array so wireframe indices can be created for WebGL1.
  */
 function I3dmLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -77,6 +78,10 @@ function I3dmLoader(options) {
   const upAxis = defaultValue(options.upAxis, Axis.Y);
   const forwardAxis = defaultValue(options.forwardAxis, Axis.X);
   const loadAsTypedArray = defaultValue(options.loadAsTypedArray, false);
+  const loadIndicesForWireframe = defaultValue(
+    options.loadIndicesForWireframe,
+    false
+  );
 
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("options.i3dmResource", i3dmResource);
@@ -95,6 +100,7 @@ function I3dmLoader(options) {
   this._upAxis = upAxis;
   this._forwardAxis = forwardAxis;
   this._loadAsTypedArray = loadAsTypedArray;
+  this._loadIndicesForWireframe = loadIndicesForWireframe;
 
   this._state = I3dmLoaderState.UNLOADED;
   this._promise = defer();
@@ -229,6 +235,7 @@ I3dmLoader.prototype.load = function () {
     releaseGltfJson: this._releaseGltfJson,
     incrementallyLoadTextures: this._incrementallyLoadTextures,
     loadAsTypedArray: this._loadAsTypedArray,
+    loadIndicesForWireframe: this._loadIndicesForWireframe,
   };
 
   if (gltfFormat === 0) {

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -45,7 +45,8 @@ import SplitDirection from "../SplitDirection.js";
  * @param {Number} [options.maximumScale] The maximum scale size of a model. An upper limit for minimumPixelSize.
  * @param {Boolean} [options.clampAnimations=true] Determines if the model's animations should hold a pose over frames where no keyframes are specified.
  * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for each draw command in the model.
- * @param {Boolean} [options.debugWireframe=false] For debugging only. Draws the model in wireframe.
+ * @param {Boolean} [options.enableDebugWireframe=false] For debugging only. This must be set to true for debugWireframe to work in WebGL1. This cannot be set after the model has loaded.
+ * @param {Boolean} [options.debugWireframe=false] For debugging only. Draws the model in wireframe. Will only work for WebGL1 if enableDebugWireframe is set to true.
  * @param {Boolean} [options.cull=true]  Whether or not to cull the model using frustum/horizon culling. If the model is part of a 3D Tiles tileset, this property will always be false, since the 3D Tiles culling system is used.
  * @param {Boolean} [options.opaquePass=Pass.OPAQUE] The pass to use in the {@link DrawCommand} for the opaque portions of the model.
  * @param {Boolean} [options.allowPicking=true] When <code>true</code>, each primitive is pickable with {@link Scene#pick}.
@@ -243,6 +244,10 @@ export default function ModelExperimental(options) {
     false
   );
 
+  this._enableDebugWireframe = defaultValue(
+    options.enableDebugWireframe,
+    false
+  );
   this._debugWireframe = defaultValue(options.debugWireframe, false);
 
   this._showCreditsOnScreen = defaultValue(options.showCreditsOnScreen, false);
@@ -1479,7 +1484,8 @@ ModelExperimental.prototype.destroyResources = function () {
  * @param {Boolean} [options.incrementallyLoadTextures=true] Determine if textures may continue to stream in after the model is loaded.
  * @param {Boolean} [options.releaseGltfJson=false] When true, the glTF JSON is released once the glTF is loaded. This is is especially useful for cases like 3D Tiles, where each .gltf model is unique and caching the glTF JSON is not effective.
  * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for each draw command in the model.
- * @param {Boolean} [options.debugWireframe=false] For debugging only. Draws the model in wireframe.
+ * @param {Boolean} [options.enableDebugWireframe=false] For debugging only. This must be set to true for debugWireframe to work in WebGL1. This cannot be set after the model has loaded.
+ * @param {Boolean} [options.debugWireframe=false] For debugging only. Draws the model in wireframe. Will only work for WebGL1 if enableDebugWireframe is set to true.
  * @param {Boolean} [options.cull=true]  Whether or not to cull the model using frustum/horizon culling. If the model is part of a 3D Tiles tileset, this property will always be false, since the 3D Tiles culling system is used.
  * @param {Boolean} [options.opaquePass=Pass.OPAQUE] The pass to use in the {@link DrawCommand} for the opaque portions of the model.
  * @param {Axis} [options.upAxis=Axis.Y] The up-axis of the glTF model.
@@ -1514,6 +1520,7 @@ ModelExperimental.fromGltf = function (options) {
     incrementallyLoadTextures: options.incrementallyLoadTextures,
     upAxis: options.upAxis,
     forwardAxis: options.forwardAxis,
+    loadIndicesForWireframe: options.enableDebugWireframe,
   };
 
   const gltf = options.gltf;
@@ -1560,6 +1567,7 @@ ModelExperimental.fromB3dm = function (options) {
     incrementallyLoadTextures: options.incrementallyLoadTextures,
     upAxis: options.upAxis,
     forwardAxis: options.forwardAxis,
+    loadIndicesForWireframe: options.enableDebugWireframe,
   };
 
   const loader = new B3dmLoader(loaderOptions);
@@ -1604,6 +1612,7 @@ ModelExperimental.fromI3dm = function (options) {
     incrementallyLoadTextures: options.incrementallyLoadTextures,
     upAxis: options.upAxis,
     forwardAxis: options.forwardAxis,
+    loadIndicesForWireframe: options.enableDebugWireframe,
   };
   const loader = new I3dmLoader(loaderOptions);
 
@@ -1665,6 +1674,7 @@ function makeModelOptions(loader, modelType, options) {
     minimumPixelSize: options.minimumPixelSize,
     maximumScale: options.maximumScale,
     debugShowBoundingVolume: options.debugShowBoundingVolume,
+    enableDebugWireframe: options.enableDebugWireframe,
     debugWireframe: options.debugWireframe,
     cull: options.cull,
     opaquePass: options.opaquePass,

--- a/Source/Scene/ModelExperimental/ModelExperimental3DTileContent.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental3DTileContent.js
@@ -358,6 +358,7 @@ function makeModelOptions(tileset, tile, content, additionalOptions) {
     shadows: tileset.shadows,
     showCreditsOnScreen: tileset.showCreditsOnScreen,
     splitDirection: tileset.splitDirection,
+    enableDebugWireframe: tileset._enableDebugWireframe,
     debugWireframe: tileset.debugWireframe,
   };
 

--- a/Source/Scene/ModelExperimental/buildDrawCommands.js
+++ b/Source/Scene/ModelExperimental/buildDrawCommands.js
@@ -39,18 +39,24 @@ export default function buildDrawCommands(
 
   const model = primitiveRenderResources.model;
   let primitiveType = primitiveRenderResources.primitiveType;
-  const debugWireframe =
+  let debugWireframe =
     model.debugWireframe && PrimitiveType.isTriangles(primitiveType);
 
+  const context = frameState.context;
+  const useWebgl2 = context.webgl2;
+
+  // Generating index buffers for wireframes is always possible in WebGL2.
+  // However, this will only work in WebGL1 if the model was constructed with
+  // enableDebugWireframe set to true.
+  debugWireframe = debugWireframe && (model._enableDebugWireframe || useWebgl2);
   const indexBuffer = getIndexBuffer(
     primitiveRenderResources,
-    model,
     debugWireframe,
     frameState
   );
 
   const vertexArray = new VertexArray({
-    context: frameState.context,
+    context: context,
     indexBuffer: indexBuffer,
     attributes: primitiveRenderResources.attributes,
   });
@@ -176,18 +182,8 @@ function deriveTranslucentCommand(command) {
   return derivedCommand;
 }
 
-function getIndexBuffer(
-  primitiveRenderResources,
-  model,
-  debugWireframe,
-  frameState
-) {
-  const context = frameState.context;
-  const useWebgl2 = context.webgl2;
-  // It is always possible to generate the wireframe index buffer in WebGL2.
-  // However, in WebGL1, this will only work  if the model was constructed with
-  // enableDebugWireframe set to true.
-  if (debugWireframe && (model._enableDebugWireframe || useWebgl2)) {
+function getIndexBuffer(primitiveRenderResources, debugWireframe, frameState) {
+  if (debugWireframe) {
     return createWireframeIndexBuffer(primitiveRenderResources, frameState);
   }
 
@@ -229,17 +225,17 @@ function createWireframeIndexBuffer(primitiveRenderResources, frameState) {
 
   const vertexCount = positionAttribute.count;
   const indices = primitiveRenderResources.indices;
-  const context = frameState.context;
+
   let originalIndices;
   if (defined(indices)) {
     const indicesBuffer = indices.buffer;
     const indicesCount = indices.count;
-    const useWebgl2 = context.webgl2;
-    if (useWebgl2 && defined(indicesBuffer)) {
-      originalIndices = IndexDatatype.createTypedArray(
-        vertexCount,
-        indicesCount
-      );
+    if (defined(indicesBuffer)) {
+      const useUint8Array = indicesBuffer.sizeInBytes === indicesCount;
+      originalIndices = useUint8Array
+        ? new Uint8Array(indicesCount)
+        : IndexDatatype.createTypedArray(vertexCount, indicesCount);
+
       indicesBuffer.getBufferData(originalIndices);
     } else {
       originalIndices = indices.typedArray;
@@ -257,7 +253,7 @@ function createWireframeIndexBuffer(primitiveRenderResources, frameState) {
   );
 
   return Buffer.createIndexBuffer({
-    context: context,
+    context: frameState.context,
     typedArray: wireframeIndices,
     usage: BufferUsage.STATIC_DRAW,
     indexDatatype: indexDatatype,

--- a/Source/Scene/ModelExperimental/buildDrawCommands.js
+++ b/Source/Scene/ModelExperimental/buildDrawCommands.js
@@ -44,6 +44,7 @@ export default function buildDrawCommands(
 
   const indexBuffer = getIndexBuffer(
     primitiveRenderResources,
+    model,
     debugWireframe,
     frameState
   );
@@ -175,8 +176,18 @@ function deriveTranslucentCommand(command) {
   return derivedCommand;
 }
 
-function getIndexBuffer(primitiveRenderResources, debugWireframe, frameState) {
-  if (debugWireframe) {
+function getIndexBuffer(
+  primitiveRenderResources,
+  model,
+  debugWireframe,
+  frameState
+) {
+  const context = frameState.context;
+  const useWebgl2 = context.webgl2;
+  // It is always possible to generate the wireframe index buffer in WebGL2.
+  // However, in WebGL1, this will only work  if the model was constructed with
+  // enableDebugWireframe set to true.
+  if (debugWireframe && (model._enableDebugWireframe || useWebgl2)) {
     return createWireframeIndexBuffer(primitiveRenderResources, frameState);
   }
 

--- a/Source/Scene/ResourceCache.js
+++ b/Source/Scene/ResourceCache.js
@@ -536,8 +536,8 @@ ResourceCache.loadVertexBuffer = function (options) {
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {Object} [options.draco] The Draco extension object.
  * @param {Boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
- * @param {Boolean} [loadAsTypedArray=false] Load index buffer as a typed array instead of a GPU index buffer.
- *
+ * @param {Boolean} [options.loadAsTypedArray=false] Load index buffer as a typed array instead of a GPU index buffer.
+ * @param {Boolean} [options.loadForWireframe=false] Load index buffer as a typed array in order to generate wireframes in WebGL1. This will be ignored if using WebGL2.
  * @returns {GltfIndexBufferLoader} The index buffer loader.
  * @private
  */
@@ -550,6 +550,7 @@ ResourceCache.loadIndexBuffer = function (options) {
   const draco = options.draco;
   const asynchronous = defaultValue(options.asynchronous, true);
   const loadAsTypedArray = defaultValue(options.loadAsTypedArray, false);
+  const loadForWireframe = defaultValue(options.loadForWireframe, false);
 
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("options.gltf", gltf);
@@ -582,6 +583,7 @@ ResourceCache.loadIndexBuffer = function (options) {
     cacheKey: cacheKey,
     asynchronous: asynchronous,
     loadAsTypedArray: loadAsTypedArray,
+    loadForWireframe: loadForWireframe,
   });
 
   ResourceCache.load({

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -2002,9 +2002,9 @@ describe(
     });
 
     it("debugWireframe", function () {
-      return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function (
-        tileset
-      ) {
+      return Cesium3DTilesTester.loadTileset(scene, tilesetUrl, {
+        enableDebugWireframe: true,
+      }).then(function (tileset) {
         viewRootOnly();
         tileset.debugWireframe = true;
         scene.renderForSpecs();

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -143,7 +143,7 @@ describe(
       const modelHasIndices = defaultValue(options.hasIndices, true);
       const targetScene = defaultValue(options.scene, scene);
 
-      const commandList = scene.frameState;
+      const commandList = targetScene.frameState;
       const commandCounts = [];
       let i, command;
 

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -78,10 +78,12 @@ describe(
 
     afterAll(function () {
       scene.destroyForSpecs();
+      sceneWithWebgl2.destroyForSpecs();
     });
 
     afterEach(function () {
       scene.primitives.removeAll();
+      sceneWithWebgl2.primitives.removeAll();
       ResourceCache.clearForSpecs();
     });
 
@@ -517,15 +519,46 @@ describe(
       });
     });
 
-    it("debugWireframe works", function () {
+    it("debugWireframe works for WebGL1 if enableDebugWireframe is true", function () {
       const resource = Resource.createIfNeeded(boxTexturedGlbUrl);
       const loadPromise = resource.fetchArrayBuffer();
       return loadPromise.then(function (buffer) {
         return loadAndZoomToModelExperimental(
-          { gltf: new Uint8Array(buffer) },
+          { gltf: new Uint8Array(buffer), enableDebugWireframe: true },
           scene
         ).then(function (model) {
           verifyDebugWireframe(model, PrimitiveType.TRIANGLES);
+        });
+      });
+    });
+
+    it("debugWireframe does nothing in WebGL1 if enableDebugWireframe is false", function () {
+      const resource = Resource.createIfNeeded(boxTexturedGlbUrl);
+      const loadPromise = resource.fetchArrayBuffer();
+      return loadPromise.then(function (buffer) {
+        return loadAndZoomToModelExperimental(
+          { gltf: new Uint8Array(buffer), enableDebugWireframe: false },
+          scene
+        ).then(function (model) {
+          const commandList = scene.frameState;
+          const commandCounts = [];
+          let i, command;
+          scene.renderForSpecs();
+          for (i = 0; i < commandList.length; i++) {
+            command = commandList[i];
+            expect(command.primitiveType).toBe(PrimitiveType.TRIANGLES);
+            commandCounts.push(command.count);
+          }
+
+          model.debugWireframe = true;
+          expect(model._drawCommandsBuilt).toBe(false);
+
+          scene.renderForSpecs();
+          for (i = 0; i < commandList.length; i++) {
+            command = commandList[i];
+            expect(command.primitiveType).toBe(PrimitiveType.TRIANGLES);
+            expect(command.count).toEqual(commandCounts[i]);
+          }
         });
       });
     });
@@ -550,7 +583,7 @@ describe(
 
     it("debugWireframe works for model without indices", function () {
       return loadAndZoomToModelExperimental(
-        { gltf: triangleWithoutIndicesUrl },
+        { gltf: triangleWithoutIndicesUrl, enableDebugWireframe: true },
         scene
       ).then(function (model) {
         verifyDebugWireframe(model, PrimitiveType.TRIANGLES, {
@@ -561,7 +594,7 @@ describe(
 
     it("debugWireframe works for model with triangle strip", function () {
       return loadAndZoomToModelExperimental(
-        { gltf: triangleStripUrl },
+        { gltf: triangleStripUrl, enableDebugWireframe: true },
         scene
       ).then(function (model) {
         verifyDebugWireframe(model, PrimitiveType.TRIANGLE_STRIP);
@@ -570,7 +603,7 @@ describe(
 
     it("debugWireframe works for model with triangle fan", function () {
       return loadAndZoomToModelExperimental(
-        { gltf: triangleFanUrl },
+        { gltf: triangleFanUrl, enableDebugWireframe: true },
         scene
       ).then(function (model) {
         verifyDebugWireframe(model, PrimitiveType.TRIANGLE_FAN);
@@ -579,7 +612,7 @@ describe(
 
     it("debugWireframe ignores points", function () {
       return loadAndZoomToModelExperimental(
-        { gltf: pointCloudUrl },
+        { gltf: pointCloudUrl, enableDebugWireframe: true },
         scene
       ).then(function (model) {
         const commandList = scene.frameState;

--- a/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
+++ b/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
@@ -20,6 +20,8 @@ function loadAndZoomToModelExperimental(options, scene) {
         upAxis: options.upAxis,
         forwardAxis: options.forwardAxis,
         debugShowBoundingVolume: options.debugShowBoundingVolume,
+        enableDebugWireframe: options.enableDebugWireframe,
+        debugWireframe: options.debugWireframe,
         featureIdLabel: options.featureIdLabel,
         instanceFeatureIdLabel: options.instanceFeatureIdLabel,
         incrementallyLoadTextures: options.incrementallyLoadTextures,

--- a/Specs/Scene/ResourceCacheSpec.js
+++ b/Specs/Scene/ResourceCacheSpec.js
@@ -1241,6 +1241,7 @@ describe(
 
       return waitForLoaderProcess(indexBufferLoader, sceneWithWebgl2).then(
         function (indexBufferLoader) {
+          expect(indexBufferLoader.typedArray).toBeUndefined();
           expect(indexBufferLoader.buffer).toBeDefined();
         }
       );


### PR DESCRIPTION
Closes #10340. Currently wireframes in `ModelExperimental` require the indices to be loaded as typed arrays for WebGL1. However, this will result in performance costs for users that don't need the `debugWireframe` option.

The preferred solution is to require an option, `enableDebugWireframe`, to be explicitly set as `true` in the `ModelExperimental` constructors. If this is true, then `debugWireframe` will work for models in WebGL1. However, if this is not true, then toggling `debugWireframe` will have no effect. This will not affect models in WebGL2 because in WebGL2, data can be pulled from GPU buffers.

[`ModelExperimental` Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=tVdtb9s2EP4rhPehzmDLsuMkrpcWy1uzDg0a1GkLbB4GSjpbhClSIynbWZH/viMpyXLsbF2LOLEtkkfec3cP786xFNqQJYMVKPKKCFiRC9CsyIJPbq49bcVufCGFoUyAmrY65MtUEKJTWfDkTLCMGhgTowro2PkYJWFt3ueG4eFjL0xIr0c+ilhmGQhDjCQGULFJqSErpmCmaAaarKRakJlU5DNE1+8G1U4FfxUojpNzPvCq7NLDVDwc/DQVU+ENCGIu40UQF0qhkjuWAZpUmvNrwRkVlwg1mCmZvdVydBz22/aYaWsQDvrdfr8bvrwbhOPByfjwJAj7x+HxcHhydDgcHY+GLw9Pfpu2psLrQ2NuZAJcT9Ek68HMjVDd7/bE0mTrhjEe7yGQc8q5lAId6JdxI3CIUWRWiNh6i7QPqr3oX7fo1LSrOQs2CHr4P6FZzgHtoT2vu+e1lEq2R8GcR7Va++ofVc/WHvv94Fb95yP4kwUTAhJykVJFY+Mo8IwW3NAK/Z/4uAM9/B/ILxGvJBcyyxVojSY4LM8F32nbKKvMYXxxpwrk5Zyb2Teb8lFwZsi5XH8T+icx44Hu5PqhQknCr/KvFPC8bHAqms/fx+VrJQuRkE+Qspg/G3SvpVSyPfouPr/FVENFjET+ViJ8BXg8utazNdgl8L+5/g+XKOO6vjgAmCAdrgSiYv65yvtXgkYcEsRPubZF5KGxN80fFaZfgCZMzG+ZidMPknujyrUbatLAyA8oQYVu90fhgQMU+k+fvv25M7aG5I1Vf6dQFotOtqkW9ZQOsKRQ7uXkm3rPNWAppEaqsoIIqUxa+mbaWmGx2hQLDmV9wFEdoWZUCsU7JAU2T00ZNw8xl5o54RrXBVVYN9G2Q1fFLmGuAHQZ1m5/cBiEJ8Phcf9lGaThMAiPwsOT8Lic8Frss8dGytof6BgtCnLFMlS5BB0oyOQSztC/PrZZGb+n5GmSlDiqWNgNV+scUAbLMeUO8jVyqF1z0zJqTKz91YxTg2FUbD3eE430UfCbMWmwu/Jcg6vIo8aoPPmKc5ZryZLg8/VkNGwI7KFHzfUNWIbdT5HdoiyfsL+xC+oPRptVurarE+QPrgxCfNVr2EBcVL1QyjSRxdNNEVVAEqbdHSFM+N6oX50E7vJcbl2oRjdmX8mjxfo6BnvvYXmTD5oscWFBTtDk/hajyDQEJgXR3mQcJ1Gnnaohw1MVxTskF2emjs9OdJ663VTMm1Hdf8mHRwed/5Lp9reEvDWRTcuoa5KnoCBQKFto8iPZJDX/UPmg2oc9EDLeN762xbXUt/ekZjWam4+3rkEt/A6Xgg9Xt1dnd53Kz+56ua8Hq2hCRRJTbbBW4MF3UvKIqhsQhXexrjtQJGa8IChNYgyMASQOkIg5m7Trou2EjYQHXmU+44/Eu5zIuLAcDOZgrjjYx/P7t3iPW6XMtGW1lZYsBHbXSNTAWMXtmkX7RGie8/vzEstGtFMp37PHesECeR9pUEvLxOa+aWs/V1suSIEuIh0rFkGDkUvKC6gZme0hvE1nVmgTAfvX6rROtbnn8LoK6M8syzHB20TVxpppAGsmOlz3IuzrwASx1lUBJOSHyr9fNoSL0GFz1waMiZpHtD0cdEj1DoPRZjfeDow6em1Mhvm6MR1JlYDqepZuLz7sqGYix4TSALAEZRgmoi7lbC7GmLmShMOu1q6x1B1saa6WImmMzLZXd1W7FA1b1s/wF2F35SrPGO3gyePtp72mv08TtiQsebXnpyeJOdUaV2YFdxl32np92kP5na1cujzyHg3n9N6Kpf3X7/xkEASnPRzu31lTvw7/qXenuc/BgkohXkS2//LksWhs34LjBNuorr2BlZhtavbytuP3fswT9+P5hdPwoqFzksrVpghUbtrg/Qc) and [3D Tiles sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=zVh7Uxs3EP8qqicTzhNzBidMWtswLYYktBCY4CZ/YKaR74RPQZauks7gMP7uXUn30Dkm4ZWZZphYt9rHb1d7q90bEEWzabh/nRJJp4RrzN4QrDNJVEg4HjNyJGLC/H20jbTMSG/EI8GVRjNKrogEKidXaOD0fbS0YNSI7PNAgCDlRI4aLXQz4gipBMfiSnWtqpahgDJNrvVxqimo7To2hNpt9DcYmhrbSAukCZjUCdboikpyIfGUKHQl5CW6EBJ9IuO3h51CUpJ/M2AH4oR1nCmztRjxRRPgO+AhGCU8DnLkjugeXu4NKSPqgKuURFrII3pNebN0nBZ0460NEwQhVxqtVGC1W05QUgKImIguwyiTEnwcQpTrsfwzYxTzPaxJ0Hm19Xqr0wk3t169/q3TtEocFhURTirz9hG2GYFgGQhEe8wzD68Nc84CUT9zscuDjxCH+HbRqDF0HHB+xQ5kiMhkRLoFAQFbGLbh7xRPU0YAMW7XAtnOtZSLdm44/KIEL3UvWreBkJgrloFvjwWyi3WUkLj49RQ/HFL7OMWQbz8NmVMPOXhPiEcZ03Q9EkzIp8U2MCrVPdF8cO8k+ihYNiVPnE+fqE5c6cnNOCv3hJi797TBMtDscmiK6j0RQQHRmEePxlTqqVZPg6t9LKm5HEztfnqMnvJ7AhyIaSoU1Y9NtFKPt7ofkhNBuR4wkT32DCtF3vLD290H4xkIG2c9eIIKsRJczcCDYb4XcoqZ+hkAc9UPhvY0BWMltKKKPBTansSR+BnArOLvwTq3/yvCoPOBe8wxdlHGY3IBrWDcWtUGLmyXkjc+lxz6IpHpUIOty6DsWvy+RwvBxth0n7GIMtMkhhOi9xkxy935QQw9aM4zahjBZd04Tdl8l/KY8omqbLQKzc1ViAx0Y+d4rIicmcLpS44auVtg0XKqbKwiScckuMh4ZMoYClxzHTeLwysaNycJ/uQMPduxPgxFPfbfQyNc112ioReoaIjz4wryo242q3SzXWaYwmBANZ3BxCDJVMxIydrL86HS+cuS0sKup/TbrjrM9UFQyuzpVQkNwwqvLLlFJeE3xD5UHENqFK9N1WzXMp/o4KZ6TzLJuigHHBbvUavah0llUMwpCVUITujWgQVLgmKq7AmDx25u2ax0ucPfI+Ns8qmQ8mYl62vTrVxqeE4DNhzPT6SYUkUK7lAnhHsH7gX8ByGvxoeCPQ/pVyGmQxFU9BJBy6d5wX0HwOA1O6FQ0z5gPiE1YYQ2WvXn9U64TDrCOgmn+DrY3NgIN9B66fRYZPYdPk0TIkkowVKmWgiYmr4G76EKnPnnykkqBQy6mhJVeR5WRC8IJpt9xUuJXck00fPnd2KE8NBJon2E/iFV56v0nC3NiH7anprt4KYeN9v+d9ES1bod03ziPlveREBqPLtxuBZoZxv9+tJM8DDWG3XBWppJuDLWTJi3mqPGeesOGjZqGiSJ1+4o+bouKaTJoLsKb3ZqwnPCmLi6s+WaLIMJ/c5ma5LRHPPvSNrvEz7/mGW3WFqmLGrPi6aXqIvlggHFIDJdhX8ZSSlkLdt0IsUVsvRepcC/jMqrJly6Z/KiW6sj6mzj3Lu1E8xjtvzN6DSShPDTFEdkfwZV9J1jCoqvJJjPsHK2c3mwrA94muk/rB+eQ+YaMpU498lZvXAftsDqioKXb1oPV9x++XZ1UdXqxfy9rerbhQlzK5/4W0FxIk6MET7RCfDX5ENHzjnN56zAfL+hwLfRg59+LtdDL15Q77S+hbKs+Yye93xuwUjIxMQrYJ+f3fgSiy56drPCmcBnai4+FwpqV735vta67VSH85SEh/tvhv8MDg8Gf/1vzrNwViWQ93CQMA844R97c3Swt3e4X/nTaDX6tkbvFOH5ncLQKLVpIQLotDWBThtDY9AeZ9ElVPRIqSKC/bYv2o/pDNF4e8WHVBQxrBTsXGSMndKvUDp2+m3g/0aUCXvtHs+IZHhu2JLNnUNHDMOw34bH1ZJl51x60ncvO4phTFgfQ9sMXKL4ZFu87K2iTRqSa2j518xYApfEDEM96y6PBCXzANtf4B8kQiiCMMpZAOSa9c6JVmAM5j41GYM0nIQJU0Kiy7G4hvj4EC2ZxF1UduY76NQta5576/8A) for testing. I left comments for the lines that should be toggled on / off for testing.