### PR TITLE
Refactor Cesium3DTilesStyle so that its always synchronous, add fromUrl

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,19 @@
 
 ### 1.94 - 2022-06-01
 
+##### Additions :tada:
+
+- Added `Cesium3DTileStyle.fromUrl` for loading a style from a url.
+
 ##### Fixes :wrench:
 
 - Fixed the inaccurate computation of bounding spheres for `ModelExperimental`. [#10339](https://github.com/CesiumGS/cesium/pull/10339/)
+- Fixed race condition which can occur when updating `Cesium3DTileStyle` before its `readyPromise` has resolved. [#10345](https://github.com/CesiumGS/cesium/issues/10345)
+
+##### Deprecated :hourglass_flowing_sand:
+
+- `Cesium3DTileStyle` constructor parameters of `string` or `Resource` type have been deprecated and will be removed in CesiumJS 1.95. Use `Cesium3DTileStyle.fromUrl` instead if loading a style from a url.
+- `Cesium3DTileStyle.readyPromise` and `Cesium3DTileStyle.ready` have been deprecated and will be removed in CesiumJS 1.95. Use `Cesium3DTileStyle.fromUrl` instead if loading a style from a url.
 
 ### 1.93 - 2022-05-02
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ##### Additions :tada:
 
-- Added `Cesium3DTileStyle.fromUrl` for loading a style from a url.
+- Added `Cesium3DTileStyle.fromUrl` for loading a style from a url. [#10339](https://github.com/CesiumGS/cesium/pull/10339/)
 
 ##### Fixes :wrench:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,8 +13,8 @@
 
 ##### Deprecated :hourglass_flowing_sand:
 
-- `Cesium3DTileStyle` constructor parameters of `string` or `Resource` type have been deprecated and will be removed in CesiumJS 1.95. Use `Cesium3DTileStyle.fromUrl` instead if loading a style from a url.
-- `Cesium3DTileStyle.readyPromise` and `Cesium3DTileStyle.ready` have been deprecated and will be removed in CesiumJS 1.95. Use `Cesium3DTileStyle.fromUrl` instead if loading a style from a url.
+- `Cesium3DTileStyle` constructor parameters of `string` or `Resource` type have been deprecated and will be removed in CesiumJS 1.96. If loading a style from a url, use `Cesium3DTileStyle.fromUrl` instead.
+- `Cesium3DTileStyle.readyPromise` and `Cesium3DTileStyle.ready` have been deprecated and will be removed in CesiumJS 1.96. If loading a style from a url, use `Cesium3DTileStyle.fromUrl` instead.
 
 ### 1.93 - 2022-05-02
 

--- a/Source/Scene/Cesium3DTileStyle.js
+++ b/Source/Scene/Cesium3DTileStyle.js
@@ -87,7 +87,7 @@ function Cesium3DTileStyle(style) {
     //>>includeStart('debug', pragmas.debug);
     deprecationWarning(
       "Cesium3DTileStyle constructor",
-      "string or Resource style parameter in the Cesium3DTileStyle constructor was deprecated in Cesium 1.94.  It will be removed in 1.96.  Use Cesium3DTileStyle.fromUrl instead."
+      "string or Resource style parameter in the Cesium3DTileStyle constructor was deprecated in Cesium 1.94.  If loading a style from a url, use Cesium3DTileStyle.fromUrl instead."
     );
     //>>includeEnd('debug');
 
@@ -222,7 +222,7 @@ Object.defineProperties(Cesium3DTileStyle.prototype, {
       //>>includeStart('debug', pragmas.debug);
       deprecationWarning(
         "ready",
-        "ready was deprecated in Cesium 1.94.  It will be removed in 1.96.  Use Cesium3DTileStyle.fromUrl instead if loading a style from a url."
+        "ready was deprecated in Cesium 1.94.  It will be removed in 1.96.  If loading a style from a url, use Cesium3DTileStyle.fromUrl instead."
       );
       //>>includeEnd('debug');
       return this._ready;
@@ -243,7 +243,7 @@ Object.defineProperties(Cesium3DTileStyle.prototype, {
       //>>includeStart('debug', pragmas.debug);
       deprecationWarning(
         "readyPromise",
-        "readyPromise was deprecated in Cesium 1.94.  It will be removed in 1.96.  Use Cesium3DTileStyle.fromUrl instead if loading a style from a url."
+        "readyPromise was deprecated in Cesium 1.94.  It will be removed in 1.96.  If loading a style from a url, use Cesium3DTileStyle.fromUrl instead."
       );
       //>>includeEnd('debug');
       return this._readyPromise;

--- a/Source/Scene/Cesium3DTileStyleEngine.js
+++ b/Source/Scene/Cesium3DTileStyleEngine.js
@@ -37,7 +37,7 @@ Cesium3DTileStyleEngine.prototype.applyStyle = function (tileset) {
     return;
   }
 
-  if (defined(this._style) && !this._style.ready) {
+  if (defined(this._style) && !this._style._ready) {
     return;
   }
 

--- a/Specs/Scene/Cesium3DTileStyleSpec.js
+++ b/Specs/Scene/Cesium3DTileStyleSpec.js
@@ -48,240 +48,194 @@ describe("Scene/Cesium3DTileStyle", function () {
 
   const styleUrl = "./Data/Cesium3DTiles/Style/style.json";
 
-  it("rejects readyPromise with undefined url", function () {
-    const tileStyle = new Cesium3DTileStyle("invalid.json");
-
-    return tileStyle.readyPromise
+  it("fromUrl rejects with undefined url", function () {
+    return Cesium3DTileStyle.fromUrl("invalid.json")
       .then(function (style) {
         fail("should not resolve");
       })
       .catch(function (error) {
-        expect(tileStyle.ready).toEqual(false);
         expect(error.statusCode).toEqual(404);
       });
   });
 
   it("loads style from uri", function () {
-    const tileStyle = new Cesium3DTileStyle(styleUrl);
-
-    return tileStyle.readyPromise
-      .then(function (style) {
-        expect(style.style).toEqual({
-          color: "color('red')",
-          show: "${id} < 100.0",
-          pointSize: "${id} / 100.0",
-          pointOutlineColor: "color('blue')",
-          pointOutlineWidth: "5.0",
-          labelColor: "color('yellow')",
-          labelOutlineColor: "color('orange')",
-          labelOutlineWidth: "6.0",
-          font: "'24px Helvetica'",
-          labelStyle: "1",
-          labelText: "'label text'",
-          backgroundColor: "color('coral')",
-          backgroundPadding: "vec2(1.0, 2.0)",
-          backgroundEnabled: "true",
-          scaleByDistance: "vec4(1.0, 2.0, 3.0, 4.0)",
-          translucencyByDistance: "vec4(5.0, 6.0, 7.0, 8.0)",
-          distanceDisplayCondition: "vec2(3.0, 4.0)",
-          heightOffset: "10.0",
-          anchorLineEnabled: "true",
-          anchorLineColor: "color('fuchsia')",
-          image: "'url/to/invalid/image'",
-          disableDepthTestDistance: "1000.0",
-          horizontalOrigin: "0",
-          verticalOrigin: "0",
-          labelHorizontalOrigin: "0",
-          labelVerticalOrigin: "0",
-        });
-        expect(style.color).toEqual(new Expression("color('red')"));
-        expect(style.show).toEqual(new Expression("${id} < 100.0"));
-        expect(style.pointSize).toEqual(new Expression("${id} / 100.0"));
-        expect(style.pointOutlineColor).toEqual(
-          new Expression("color('blue')")
-        );
-        expect(style.pointOutlineWidth).toEqual(new Expression("5.0"));
-        expect(style.labelColor).toEqual(new Expression("color('yellow')"));
-        expect(style.labelOutlineColor).toEqual(
-          new Expression("color('orange')")
-        );
-        expect(style.labelOutlineWidth).toEqual(new Expression("6.0"));
-        expect(style.font).toEqual(new Expression("'24px Helvetica'"));
-        expect(style.labelStyle).toEqual(new Expression("1"));
-        expect(style.labelText).toEqual(new Expression("'label text'"));
-        expect(style.backgroundColor).toEqual(new Expression("color('coral')"));
-        expect(style.backgroundPadding).toEqual(
-          new Expression("vec2(1.0, 2.0)")
-        );
-        expect(style.backgroundEnabled).toEqual(new Expression("true"));
-        expect(style.scaleByDistance).toEqual(
-          new Expression("vec4(1.0, 2.0, 3.0, 4.0)")
-        );
-        expect(style.translucencyByDistance).toEqual(
-          new Expression("vec4(5.0, 6.0, 7.0, 8.0)")
-        );
-        expect(style.distanceDisplayCondition).toEqual(
-          new Expression("vec2(3.0, 4.0)")
-        );
-        expect(style.heightOffset).toEqual(new Expression("10.0"));
-        expect(style.anchorLineEnabled).toEqual(new Expression("true"));
-        expect(style.anchorLineColor).toEqual(
-          new Expression("color('fuchsia')")
-        );
-        expect(style.image).toEqual(new Expression("'url/to/invalid/image'"));
-        expect(style.disableDepthTestDistance).toEqual(
-          new Expression("1000.0")
-        );
-        expect(style.horizontalOrigin).toEqual(new Expression("0"));
-        expect(style.verticalOrigin).toEqual(new Expression("0"));
-        expect(style.labelHorizontalOrigin).toEqual(new Expression("0"));
-        expect(style.labelVerticalOrigin).toEqual(new Expression("0"));
-        expect(tileStyle.ready).toEqual(true);
-      })
-      .catch(function () {
-        fail("should load style.json");
+    return Cesium3DTileStyle.fromUrl(styleUrl).then(function (style) {
+      expect(style.style).toEqual({
+        color: "color('red')",
+        show: "${id} < 100.0",
+        pointSize: "${id} / 100.0",
+        pointOutlineColor: "color('blue')",
+        pointOutlineWidth: "5.0",
+        labelColor: "color('yellow')",
+        labelOutlineColor: "color('orange')",
+        labelOutlineWidth: "6.0",
+        font: "'24px Helvetica'",
+        labelStyle: "1",
+        labelText: "'label text'",
+        backgroundColor: "color('coral')",
+        backgroundPadding: "vec2(1.0, 2.0)",
+        backgroundEnabled: "true",
+        scaleByDistance: "vec4(1.0, 2.0, 3.0, 4.0)",
+        translucencyByDistance: "vec4(5.0, 6.0, 7.0, 8.0)",
+        distanceDisplayCondition: "vec2(3.0, 4.0)",
+        heightOffset: "10.0",
+        anchorLineEnabled: "true",
+        anchorLineColor: "color('fuchsia')",
+        image: "'url/to/invalid/image'",
+        disableDepthTestDistance: "1000.0",
+        horizontalOrigin: "0",
+        verticalOrigin: "0",
+        labelHorizontalOrigin: "0",
+        labelVerticalOrigin: "0",
       });
+      expect(style.color).toEqual(new Expression("color('red')"));
+      expect(style.show).toEqual(new Expression("${id} < 100.0"));
+      expect(style.pointSize).toEqual(new Expression("${id} / 100.0"));
+      expect(style.pointOutlineColor).toEqual(new Expression("color('blue')"));
+      expect(style.pointOutlineWidth).toEqual(new Expression("5.0"));
+      expect(style.labelColor).toEqual(new Expression("color('yellow')"));
+      expect(style.labelOutlineColor).toEqual(
+        new Expression("color('orange')")
+      );
+      expect(style.labelOutlineWidth).toEqual(new Expression("6.0"));
+      expect(style.font).toEqual(new Expression("'24px Helvetica'"));
+      expect(style.labelStyle).toEqual(new Expression("1"));
+      expect(style.labelText).toEqual(new Expression("'label text'"));
+      expect(style.backgroundColor).toEqual(new Expression("color('coral')"));
+      expect(style.backgroundPadding).toEqual(new Expression("vec2(1.0, 2.0)"));
+      expect(style.backgroundEnabled).toEqual(new Expression("true"));
+      expect(style.scaleByDistance).toEqual(
+        new Expression("vec4(1.0, 2.0, 3.0, 4.0)")
+      );
+      expect(style.translucencyByDistance).toEqual(
+        new Expression("vec4(5.0, 6.0, 7.0, 8.0)")
+      );
+      expect(style.distanceDisplayCondition).toEqual(
+        new Expression("vec2(3.0, 4.0)")
+      );
+      expect(style.heightOffset).toEqual(new Expression("10.0"));
+      expect(style.anchorLineEnabled).toEqual(new Expression("true"));
+      expect(style.anchorLineColor).toEqual(new Expression("color('fuchsia')"));
+      expect(style.image).toEqual(new Expression("'url/to/invalid/image'"));
+      expect(style.disableDepthTestDistance).toEqual(new Expression("1000.0"));
+      expect(style.horizontalOrigin).toEqual(new Expression("0"));
+      expect(style.verticalOrigin).toEqual(new Expression("0"));
+      expect(style.labelHorizontalOrigin).toEqual(new Expression("0"));
+      expect(style.labelVerticalOrigin).toEqual(new Expression("0"));
+    });
   });
 
-  it("loads style from Resource", function () {
-    const tileStyle = new Cesium3DTileStyle(
+  it("fromUrl loads style from Resource", function () {
+    return Cesium3DTileStyle.fromUrl(
       new Resource({
         url: styleUrl,
       })
-    );
-
-    return tileStyle.readyPromise
-      .then(function (style) {
-        expect(style.style).toEqual({
-          color: "color('red')",
-          show: "${id} < 100.0",
-          pointSize: "${id} / 100.0",
-          pointOutlineColor: "color('blue')",
-          pointOutlineWidth: "5.0",
-          labelColor: "color('yellow')",
-          labelOutlineColor: "color('orange')",
-          labelOutlineWidth: "6.0",
-          font: "'24px Helvetica'",
-          labelStyle: "1",
-          labelText: "'label text'",
-          backgroundColor: "color('coral')",
-          backgroundPadding: "vec2(1.0, 2.0)",
-          backgroundEnabled: "true",
-          scaleByDistance: "vec4(1.0, 2.0, 3.0, 4.0)",
-          translucencyByDistance: "vec4(5.0, 6.0, 7.0, 8.0)",
-          distanceDisplayCondition: "vec2(3.0, 4.0)",
-          heightOffset: "10.0",
-          anchorLineEnabled: "true",
-          anchorLineColor: "color('fuchsia')",
-          image: "'url/to/invalid/image'",
-          disableDepthTestDistance: "1000.0",
-          horizontalOrigin: "0",
-          verticalOrigin: "0",
-          labelHorizontalOrigin: "0",
-          labelVerticalOrigin: "0",
-        });
-        expect(style.color).toEqual(new Expression("color('red')"));
-        expect(style.show).toEqual(new Expression("${id} < 100.0"));
-        expect(style.pointSize).toEqual(new Expression("${id} / 100.0"));
-        expect(style.pointOutlineColor).toEqual(
-          new Expression("color('blue')")
-        );
-        expect(style.pointOutlineWidth).toEqual(new Expression("5.0"));
-        expect(style.labelColor).toEqual(new Expression("color('yellow')"));
-        expect(style.labelOutlineColor).toEqual(
-          new Expression("color('orange')")
-        );
-        expect(style.labelOutlineWidth).toEqual(new Expression("6.0"));
-        expect(style.font).toEqual(new Expression("'24px Helvetica'"));
-        expect(style.labelStyle).toEqual(new Expression("1"));
-        expect(style.labelText).toEqual(new Expression("'label text'"));
-        expect(style.backgroundColor).toEqual(new Expression("color('coral')"));
-        expect(style.backgroundPadding).toEqual(
-          new Expression("vec2(1.0, 2.0)")
-        );
-        expect(style.backgroundEnabled).toEqual(new Expression("true"));
-        expect(style.scaleByDistance).toEqual(
-          new Expression("vec4(1.0, 2.0, 3.0, 4.0)")
-        );
-        expect(style.translucencyByDistance).toEqual(
-          new Expression("vec4(5.0, 6.0, 7.0, 8.0)")
-        );
-        expect(style.distanceDisplayCondition).toEqual(
-          new Expression("vec2(3.0, 4.0)")
-        );
-        expect(style.heightOffset).toEqual(new Expression("10.0"));
-        expect(style.anchorLineEnabled).toEqual(new Expression("true"));
-        expect(style.anchorLineColor).toEqual(
-          new Expression("color('fuchsia')")
-        );
-        expect(style.image).toEqual(new Expression("'url/to/invalid/image'"));
-        expect(style.disableDepthTestDistance).toEqual(
-          new Expression("1000.0")
-        );
-        expect(style.horizontalOrigin).toEqual(new Expression("0"));
-        expect(style.verticalOrigin).toEqual(new Expression("0"));
-        expect(style.labelHorizontalOrigin).toEqual(new Expression("0"));
-        expect(style.labelVerticalOrigin).toEqual(new Expression("0"));
-        expect(tileStyle.ready).toEqual(true);
-      })
-      .catch(function () {
-        fail("should load style.json");
+    ).then(function (style) {
+      expect(style.style).toEqual({
+        color: "color('red')",
+        show: "${id} < 100.0",
+        pointSize: "${id} / 100.0",
+        pointOutlineColor: "color('blue')",
+        pointOutlineWidth: "5.0",
+        labelColor: "color('yellow')",
+        labelOutlineColor: "color('orange')",
+        labelOutlineWidth: "6.0",
+        font: "'24px Helvetica'",
+        labelStyle: "1",
+        labelText: "'label text'",
+        backgroundColor: "color('coral')",
+        backgroundPadding: "vec2(1.0, 2.0)",
+        backgroundEnabled: "true",
+        scaleByDistance: "vec4(1.0, 2.0, 3.0, 4.0)",
+        translucencyByDistance: "vec4(5.0, 6.0, 7.0, 8.0)",
+        distanceDisplayCondition: "vec2(3.0, 4.0)",
+        heightOffset: "10.0",
+        anchorLineEnabled: "true",
+        anchorLineColor: "color('fuchsia')",
+        image: "'url/to/invalid/image'",
+        disableDepthTestDistance: "1000.0",
+        horizontalOrigin: "0",
+        verticalOrigin: "0",
+        labelHorizontalOrigin: "0",
+        labelVerticalOrigin: "0",
       });
+      expect(style.color).toEqual(new Expression("color('red')"));
+      expect(style.show).toEqual(new Expression("${id} < 100.0"));
+      expect(style.pointSize).toEqual(new Expression("${id} / 100.0"));
+      expect(style.pointOutlineColor).toEqual(new Expression("color('blue')"));
+      expect(style.pointOutlineWidth).toEqual(new Expression("5.0"));
+      expect(style.labelColor).toEqual(new Expression("color('yellow')"));
+      expect(style.labelOutlineColor).toEqual(
+        new Expression("color('orange')")
+      );
+      expect(style.labelOutlineWidth).toEqual(new Expression("6.0"));
+      expect(style.font).toEqual(new Expression("'24px Helvetica'"));
+      expect(style.labelStyle).toEqual(new Expression("1"));
+      expect(style.labelText).toEqual(new Expression("'label text'"));
+      expect(style.backgroundColor).toEqual(new Expression("color('coral')"));
+      expect(style.backgroundPadding).toEqual(new Expression("vec2(1.0, 2.0)"));
+      expect(style.backgroundEnabled).toEqual(new Expression("true"));
+      expect(style.scaleByDistance).toEqual(
+        new Expression("vec4(1.0, 2.0, 3.0, 4.0)")
+      );
+      expect(style.translucencyByDistance).toEqual(
+        new Expression("vec4(5.0, 6.0, 7.0, 8.0)")
+      );
+      expect(style.distanceDisplayCondition).toEqual(
+        new Expression("vec2(3.0, 4.0)")
+      );
+      expect(style.heightOffset).toEqual(new Expression("10.0"));
+      expect(style.anchorLineEnabled).toEqual(new Expression("true"));
+      expect(style.anchorLineColor).toEqual(new Expression("color('fuchsia')"));
+      expect(style.image).toEqual(new Expression("'url/to/invalid/image'"));
+      expect(style.disableDepthTestDistance).toEqual(new Expression("1000.0"));
+      expect(style.horizontalOrigin).toEqual(new Expression("0"));
+      expect(style.verticalOrigin).toEqual(new Expression("0"));
+      expect(style.labelHorizontalOrigin).toEqual(new Expression("0"));
+      expect(style.labelVerticalOrigin).toEqual(new Expression("0"));
+    });
   });
 
   it("sets show value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.show).toBeUndefined();
 
-        style = new Cesium3DTileStyle();
-      })
-      .then(function () {
-        expect(style.show).toBeUndefined();
-      });
+    expect(style.show).toBeUndefined();
+
+    style = new Cesium3DTileStyle();
+
+    expect(style.show).toBeUndefined();
   });
 
   it("sets show value to expression", function () {
     let style = new Cesium3DTileStyle({
       show: "true",
     });
-    return style.readyPromise
-      .then(function () {
-        expect(style.show).toEqual(new Expression("true"));
 
-        style = new Cesium3DTileStyle({
-          show: "false",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.show).toEqual(new Expression("false"));
+    expect(style.show).toEqual(new Expression("true"));
 
-        style = new Cesium3DTileStyle({
-          show: "${height} * 10 >= 1000",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.show).toEqual(new Expression("${height} * 10 >= 1000"));
+    style = new Cesium3DTileStyle({
+      show: "false",
+    });
 
-        style = new Cesium3DTileStyle({
-          show: true,
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.show).toEqual(new Expression("true"));
+    expect(style.show).toEqual(new Expression("false"));
 
-        style = new Cesium3DTileStyle({
-          show: false,
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.show).toEqual(new Expression("false"));
-      });
+    style = new Cesium3DTileStyle({
+      show: "${height} * 10 >= 1000",
+    });
+
+    expect(style.show).toEqual(new Expression("${height} * 10 >= 1000"));
+
+    style = new Cesium3DTileStyle({
+      show: true,
+    });
+
+    expect(style.show).toEqual(new Expression("true"));
+
+    style = new Cesium3DTileStyle({
+      show: false,
+    });
+
+    expect(style.show).toEqual(new Expression("false"));
   });
 
   it("sets show value to conditional", function () {
@@ -295,28 +249,25 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       show: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.show).toEqual(new ConditionsExpression(jsonExp));
-    });
+    expect(style.show).toEqual(new ConditionsExpression(jsonExp));
   });
 
   it("sets show expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", "false"],
-          ["true", "true"],
-        ],
-      });
 
-      style.show = condExp;
-      expect(style.show).toEqual(condExp);
-
-      const exp = new Expression("false");
-      style.show = exp;
-      expect(style.show).toEqual(exp);
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", "false"],
+        ["true", "true"],
+      ],
     });
+
+    style.show = condExp;
+    expect(style.show).toEqual(condExp);
+
+    const exp = new Expression("false");
+    style.show = exp;
+    expect(style.show).toEqual(exp);
   });
 
   it("sets show values in setter", function () {
@@ -324,97 +275,81 @@ describe("Scene/Cesium3DTileStyle", function () {
       showFactor: 10,
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.show = "${height} * ${showFactor} >= 1000";
-      expect(style.show).toEqual(
-        new Expression("${height} * ${showFactor} >= 1000", defines)
-      );
+    style.show = "${height} * ${showFactor} >= 1000";
+    expect(style.show).toEqual(
+      new Expression("${height} * ${showFactor} >= 1000", defines)
+    );
 
-      style.show = false;
-      expect(style.show).toEqual(new Expression("false"));
+    style.show = false;
+    expect(style.show).toEqual(new Expression("false"));
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > ${showFactor}", "false"],
-          ["true", "true"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > ${showFactor}", "false"],
+        ["true", "true"],
+      ],
+    };
 
-      style.show = jsonExp;
-      expect(style.show).toEqual(new ConditionsExpression(jsonExp, defines));
+    style.show = jsonExp;
+    expect(style.show).toEqual(new ConditionsExpression(jsonExp, defines));
 
-      style.show = undefined;
-      expect(style.show).toBeUndefined();
-    });
+    style.show = undefined;
+    expect(style.show).toBeUndefined();
   });
 
   it("sets style.show values in setter", function () {
     const style = new Cesium3DTileStyle({});
-    return style.readyPromise.then(function () {
-      style.show = "${height} * ${showFactor} >= 1000";
-      expect(style.style.show).toEqual("${height} * ${showFactor} >= 1000");
+    style.show = "${height} * ${showFactor} >= 1000";
+    expect(style.style.show).toEqual("${height} * ${showFactor} >= 1000");
 
-      style.show = false;
-      expect(style.style.show).toEqual("false");
+    style.show = false;
+    expect(style.style.show).toEqual("false");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > ${showFactor}", "false"],
-          ["true", "true"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > ${showFactor}", "false"],
+        ["true", "true"],
+      ],
+    };
 
-      style.show = jsonExp;
-      expect(style.style.show).toEqual(jsonExp);
+    style.show = jsonExp;
+    expect(style.style.show).toEqual(jsonExp);
 
-      style.show = undefined;
-      expect(style.style.show).toBeUndefined();
-    });
+    style.show = undefined;
+    expect(style.style.show).toBeUndefined();
   });
 
   it("sets color value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.color).toBeUndefined();
+    expect(style.color).toBeUndefined();
 
-        style = new Cesium3DTileStyle();
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.color).toBeUndefined();
-      });
+    style = new Cesium3DTileStyle();
+    expect(style.color).toBeUndefined();
   });
 
   it("sets color value to expression", function () {
     let style = new Cesium3DTileStyle({
       color: 'color("red")',
     });
-    return style.readyPromise
-      .then(function () {
-        expect(style.color).toEqual(new Expression('color("red")'));
 
-        style = new Cesium3DTileStyle({
-          color: "rgba(30, 30, 30, 0.5)",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.color).toEqual(new Expression("rgba(30, 30, 30, 0.5)"));
+    expect(style.color).toEqual(new Expression('color("red")'));
 
-        style = new Cesium3DTileStyle({
-          color:
-            '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")',
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.color).toEqual(
-          new Expression(
-            '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")'
-          )
-        );
-      });
+    style = new Cesium3DTileStyle({
+      color: "rgba(30, 30, 30, 0.5)",
+    });
+
+    expect(style.color).toEqual(new Expression("rgba(30, 30, 30, 0.5)"));
+
+    style = new Cesium3DTileStyle({
+      color:
+        '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")',
+    });
+
+    expect(style.color).toEqual(
+      new Expression(
+        '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")'
+      )
+    );
   });
 
   it("sets color value to conditional", function () {
@@ -428,53 +363,49 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       color: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.color).toEqual(new ConditionsExpression(jsonExp));
-    });
+
+    expect(style.color).toEqual(new ConditionsExpression(jsonExp));
   });
 
   it("sets color expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      const exp = new Expression('color("red")');
-      style.color = exp;
-      expect(style.color).toEqual(exp);
 
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("blue")'],
-        ],
-      });
+    const exp = new Expression('color("red")');
+    style.color = exp;
+    expect(style.color).toEqual(exp);
 
-      style.color = condExp;
-      expect(style.color).toEqual(condExp);
-
-      style.color = undefined;
-      expect(style.color).toBeUndefined();
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("blue")'],
+      ],
     });
+
+    style.color = condExp;
+    expect(style.color).toEqual(condExp);
+
+    style.color = undefined;
+    expect(style.color).toBeUndefined();
   });
 
   it("sets style.color expression in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      const stringExp = 'color("red")';
-      style.color = new Expression(stringExp);
-      expect(style.style.color).toEqual(stringExp);
+    const stringExp = 'color("red")';
+    style.color = new Expression(stringExp);
+    expect(style.style.color).toEqual(stringExp);
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("blue")'],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("blue")'],
+      ],
+    };
 
-      style.color = new ConditionsExpression(jsonExp);
-      expect(style.style.color).toEqual(jsonExp);
+    style.color = new ConditionsExpression(jsonExp);
+    expect(style.style.color).toEqual(jsonExp);
 
-      style.color = undefined;
-      expect(style.style.color).toBeUndefined();
-    });
+    style.color = undefined;
+    expect(style.style.color).toBeUndefined();
   });
 
   it("sets color values in setter", function () {
@@ -482,80 +413,61 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetColor: "red",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.color = 'color("${targetColor}")';
-      expect(style.color).toEqual(
-        new Expression('color("${targetColor}")', defines)
-      );
+    style.color = 'color("${targetColor}")';
+    expect(style.color).toEqual(
+      new Expression('color("${targetColor}")', defines)
+    );
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("${targetColor}")'],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("${targetColor}")'],
+      ],
+    };
 
-      style.color = jsonExp;
-      expect(style.color).toEqual(new ConditionsExpression(jsonExp, defines));
-    });
+    style.color = jsonExp;
+    expect(style.color).toEqual(new ConditionsExpression(jsonExp, defines));
   });
 
   it("sets style.color values in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.color = 'color("${targetColor}")';
-      expect(style.style.color).toEqual('color("${targetColor}")');
+    style.color = 'color("${targetColor}")';
+    expect(style.style.color).toEqual('color("${targetColor}")');
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("${targetColor}")'],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("${targetColor}")'],
+      ],
+    };
 
-      style.color = jsonExp;
-      expect(style.style.color).toEqual(jsonExp);
-    });
+    style.color = jsonExp;
+    expect(style.style.color).toEqual(jsonExp);
   });
 
   it("sets pointSize value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.pointSize).toBeUndefined();
+    expect(style.pointSize).toBeUndefined();
 
-        style = new Cesium3DTileStyle();
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.pointSize).toBeUndefined();
-      });
+    style = new Cesium3DTileStyle();
+    expect(style.pointSize).toBeUndefined();
   });
 
   it("sets pointSize value to expression", function () {
     let style = new Cesium3DTileStyle({
       pointSize: "2",
     });
-    return style.readyPromise
-      .then(function () {
-        expect(style.pointSize).toEqual(new Expression("2"));
+    expect(style.pointSize).toEqual(new Expression("2"));
 
-        style = new Cesium3DTileStyle({
-          pointSize: "${height} / 10",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.pointSize).toEqual(new Expression("${height} / 10"));
+    style = new Cesium3DTileStyle({
+      pointSize: "${height} / 10",
+    });
+    expect(style.pointSize).toEqual(new Expression("${height} / 10"));
 
-        style = new Cesium3DTileStyle({
-          pointSize: 2,
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.pointSize).toEqual(new Expression("2"));
-      });
+    style = new Cesium3DTileStyle({
+      pointSize: 2,
+    });
+    expect(style.pointSize).toEqual(new Expression("2"));
   });
 
   it("sets pointSize value to conditional", function () {
@@ -569,62 +481,56 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       pointSize: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.pointSize).toEqual(new ConditionsExpression(jsonExp));
-    });
+    expect(style.pointSize).toEqual(new ConditionsExpression(jsonExp));
   });
 
   it("sets pointSize expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.pointSize = 2;
-      expect(style.pointSize).toEqual(new Expression("2"));
+    style.pointSize = 2;
+    expect(style.pointSize).toEqual(new Expression("2"));
 
-      const exp = new Expression("2");
-      style.pointSize = exp;
-      expect(style.pointSize).toEqual(exp);
+    const exp = new Expression("2");
+    style.pointSize = exp;
+    expect(style.pointSize).toEqual(exp);
 
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", "1.0"],
-          ["true", "2.0"],
-        ],
-      });
-
-      style.pointSize = condExp;
-      expect(style.pointSize).toEqual(condExp);
-
-      style.pointSize = undefined;
-      expect(style.pointSize).toBeUndefined();
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", "1.0"],
+        ["true", "2.0"],
+      ],
     });
+
+    style.pointSize = condExp;
+    expect(style.pointSize).toEqual(condExp);
+
+    style.pointSize = undefined;
+    expect(style.pointSize).toBeUndefined();
   });
 
   it("sets style.pointSize expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.pointSize = new Expression("2");
-      expect(style.style.pointSize).toEqual("2");
+    style.pointSize = new Expression("2");
+    expect(style.style.pointSize).toEqual("2");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1.0"],
-          ["true", "2.0"],
-        ],
-      };
-      style.pointSize = new ConditionsExpression(jsonExp);
-      expect(style.style.pointSize).toEqual(jsonExp);
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1.0"],
+        ["true", "2.0"],
+      ],
+    };
+    style.pointSize = new ConditionsExpression(jsonExp);
+    expect(style.style.pointSize).toEqual(jsonExp);
 
-      const customExpression = {
-        evaluate: function () {
-          return 1;
-        },
-      };
-      style.pointSize = customExpression;
-      expect(style.style.pointSize).toEqual(customExpression);
+    const customExpression = {
+      evaluate: function () {
+        return 1;
+      },
+    };
+    style.pointSize = customExpression;
+    expect(style.style.pointSize).toEqual(customExpression);
 
-      style.pointSize = undefined;
-      expect(style.style.pointSize).toBeUndefined();
-    });
+    style.pointSize = undefined;
+    expect(style.style.pointSize).toBeUndefined();
   });
 
   it("sets pointSize values in setter", function () {
@@ -632,27 +538,23 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetPointSize: "2.0",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.pointSize = 2;
-      expect(style.pointSize).toEqual(new Expression("2"));
+    style.pointSize = 2;
+    expect(style.pointSize).toEqual(new Expression("2"));
 
-      style.pointSize = "${targetPointSize} + 1.0";
-      expect(style.pointSize).toEqual(
-        new Expression("${targetPointSize} + 1.0", defines)
-      );
+    style.pointSize = "${targetPointSize} + 1.0";
+    expect(style.pointSize).toEqual(
+      new Expression("${targetPointSize} + 1.0", defines)
+    );
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1.0"],
-          ["true", "${targetPointSize}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1.0"],
+        ["true", "${targetPointSize}"],
+      ],
+    };
 
-      style.pointSize = jsonExp;
-      expect(style.pointSize).toEqual(
-        new ConditionsExpression(jsonExp, defines)
-      );
-    });
+    style.pointSize = jsonExp;
+    expect(style.pointSize).toEqual(new ConditionsExpression(jsonExp, defines));
   });
 
   it("sets style.pointSize values in setter", function () {
@@ -660,70 +562,53 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetPointSize: "2.0",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.pointSize = 2;
-      expect(style.style.pointSize).toEqual("2");
+    style.pointSize = 2;
+    expect(style.style.pointSize).toEqual("2");
 
-      style.pointSize = "${targetPointSize} + 1.0";
-      expect(style.style.pointSize).toEqual("${targetPointSize} + 1.0");
+    style.pointSize = "${targetPointSize} + 1.0";
+    expect(style.style.pointSize).toEqual("${targetPointSize} + 1.0");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1.0"],
-          ["true", "${targetPointSize}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1.0"],
+        ["true", "${targetPointSize}"],
+      ],
+    };
 
-      style.pointSize = jsonExp;
-      expect(style.style.pointSize).toEqual(jsonExp);
-    });
+    style.pointSize = jsonExp;
+    expect(style.style.pointSize).toEqual(jsonExp);
   });
 
   it("sets pointOutlineColor value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.pointOutlineColor).toBeUndefined();
+    expect(style.pointOutlineColor).toBeUndefined();
 
-        style = new Cesium3DTileStyle();
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.pointOutlineColor).toBeUndefined();
-      });
+    style = new Cesium3DTileStyle();
+    expect(style.pointOutlineColor).toBeUndefined();
   });
 
   it("sets pointOutlineColor value to expression", function () {
     let style = new Cesium3DTileStyle({
       pointOutlineColor: 'color("red")',
     });
-    return style.readyPromise
-      .then(function () {
-        expect(style.pointOutlineColor).toEqual(new Expression('color("red")'));
+    expect(style.pointOutlineColor).toEqual(new Expression('color("red")'));
 
-        style = new Cesium3DTileStyle({
-          pointOutlineColor: "rgba(30, 30, 30, 0.5)",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.pointOutlineColor).toEqual(
-          new Expression("rgba(30, 30, 30, 0.5)")
-        );
+    style = new Cesium3DTileStyle({
+      pointOutlineColor: "rgba(30, 30, 30, 0.5)",
+    });
+    expect(style.pointOutlineColor).toEqual(
+      new Expression("rgba(30, 30, 30, 0.5)")
+    );
 
-        style = new Cesium3DTileStyle({
-          pointOutlineColor:
-            '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")',
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.pointOutlineColor).toEqual(
-          new Expression(
-            '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")'
-          )
-        );
-      });
+    style = new Cesium3DTileStyle({
+      pointOutlineColor:
+        '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")',
+    });
+    expect(style.pointOutlineColor).toEqual(
+      new Expression(
+        '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")'
+      )
+    );
   });
 
   it("sets pointOutlineColor value to conditional", function () {
@@ -737,65 +622,57 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       pointOutlineColor: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.pointOutlineColor).toEqual(
-        new ConditionsExpression(jsonExp)
-      );
-    });
+    expect(style.pointOutlineColor).toEqual(new ConditionsExpression(jsonExp));
   });
 
   it("sets pointOutlineColor expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      const exp = new Expression('color("red")');
-      style.pointOutlineColor = exp;
-      expect(style.pointOutlineColor).toEqual(exp);
+    const exp = new Expression('color("red")');
+    style.pointOutlineColor = exp;
+    expect(style.pointOutlineColor).toEqual(exp);
 
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("blue")'],
-        ],
-      });
-
-      style.pointOutlineColor = condExp;
-      expect(style.pointOutlineColor).toEqual(condExp);
-
-      style.pointOutlineColor = undefined;
-      expect(style.pointOutlineColor).toBeUndefined();
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("blue")'],
+      ],
     });
+
+    style.pointOutlineColor = condExp;
+    expect(style.pointOutlineColor).toEqual(condExp);
+
+    style.pointOutlineColor = undefined;
+    expect(style.pointOutlineColor).toBeUndefined();
   });
 
   it("sets style.pointOutlineColor expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.pointOutlineColor = new Expression('color("red")');
-      expect(style.style.pointOutlineColor).toEqual('color("red")');
+    style.pointOutlineColor = new Expression('color("red")');
+    expect(style.style.pointOutlineColor).toEqual('color("red")');
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("blue")'],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("blue")'],
+      ],
+    };
 
-      style.pointOutlineColor = new ConditionsExpression(jsonExp);
-      expect(style.style.pointOutlineColor).toEqual(jsonExp);
+    style.pointOutlineColor = new ConditionsExpression(jsonExp);
+    expect(style.style.pointOutlineColor).toEqual(jsonExp);
 
-      const customExpression = {
-        evaluate: function () {
-          return Color.RED;
-        },
-        evaluateColor: function () {
-          return Color.RED;
-        },
-      };
-      style.pointOutlineColor = customExpression;
-      expect(style.style.pointOutlineColor).toEqual(customExpression);
+    const customExpression = {
+      evaluate: function () {
+        return Color.RED;
+      },
+      evaluateColor: function () {
+        return Color.RED;
+      },
+    };
+    style.pointOutlineColor = customExpression;
+    expect(style.style.pointOutlineColor).toEqual(customExpression);
 
-      style.pointOutlineColor = undefined;
-      expect(style.style.pointOutlineColor).toBeUndefined();
-    });
+    style.pointOutlineColor = undefined;
+    expect(style.style.pointOutlineColor).toBeUndefined();
   });
 
   it("sets pointOutlineColor values in setter", function () {
@@ -803,24 +680,22 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetColor: "red",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.pointOutlineColor = 'color("${targetColor}")';
-      expect(style.pointOutlineColor).toEqual(
-        new Expression('color("${targetColor}")', defines)
-      );
+    style.pointOutlineColor = 'color("${targetColor}")';
+    expect(style.pointOutlineColor).toEqual(
+      new Expression('color("${targetColor}")', defines)
+    );
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("${targetColor}")'],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("${targetColor}")'],
+      ],
+    };
 
-      style.pointOutlineColor = jsonExp;
-      expect(style.pointOutlineColor).toEqual(
-        new ConditionsExpression(jsonExp, defines)
-      );
-    });
+    style.pointOutlineColor = jsonExp;
+    expect(style.pointOutlineColor).toEqual(
+      new ConditionsExpression(jsonExp, defines)
+    );
   });
 
   it("sets style.pointOutlineColor values in setter", function () {
@@ -828,62 +703,43 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetColor: "red",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.pointOutlineColor = 'color("${targetColor}")';
-      expect(style.style.pointOutlineColor).toEqual('color("${targetColor}")');
+    style.pointOutlineColor = 'color("${targetColor}")';
+    expect(style.style.pointOutlineColor).toEqual('color("${targetColor}")');
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("${targetColor}")'],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("${targetColor}")'],
+      ],
+    };
 
-      style.pointOutlineColor = jsonExp;
-      expect(style.style.pointOutlineColor).toEqual(jsonExp);
-    });
+    style.pointOutlineColor = jsonExp;
+    expect(style.style.pointOutlineColor).toEqual(jsonExp);
   });
 
   it("sets pointOutlineWidth value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.pointOutlineWidth).toBeUndefined();
+    expect(style.pointOutlineWidth).toBeUndefined();
 
-        style = new Cesium3DTileStyle();
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.pointOutlineWidth).toBeUndefined();
-      });
+    style = new Cesium3DTileStyle();
+    expect(style.pointOutlineWidth).toBeUndefined();
   });
 
   it("sets pointOutlineWidth value to expression", function () {
     let style = new Cesium3DTileStyle({
       pointOutlineWidth: "2",
     });
-    return style.readyPromise
-      .then(function () {
-        expect(style.pointOutlineWidth).toEqual(new Expression("2"));
+    expect(style.pointOutlineWidth).toEqual(new Expression("2"));
 
-        style = new Cesium3DTileStyle({
-          pointOutlineWidth: "${height} / 10",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.pointOutlineWidth).toEqual(
-          new Expression("${height} / 10")
-        );
+    style = new Cesium3DTileStyle({
+      pointOutlineWidth: "${height} / 10",
+    });
+    expect(style.pointOutlineWidth).toEqual(new Expression("${height} / 10"));
 
-        style = new Cesium3DTileStyle({
-          pointOutlineWidth: 2,
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.pointOutlineWidth).toEqual(new Expression("2"));
-      });
+    style = new Cesium3DTileStyle({
+      pointOutlineWidth: 2,
+    });
+    expect(style.pointOutlineWidth).toEqual(new Expression("2"));
   });
 
   it("sets pointOutlineWidth value to conditional", function () {
@@ -897,64 +753,56 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       pointOutlineWidth: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.pointOutlineWidth).toEqual(
-        new ConditionsExpression(jsonExp)
-      );
-    });
+    expect(style.pointOutlineWidth).toEqual(new ConditionsExpression(jsonExp));
   });
 
   it("sets pointOutlineWidth expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.pointOutlineWidth = 2;
-      expect(style.pointOutlineWidth).toEqual(new Expression("2"));
+    style.pointOutlineWidth = 2;
+    expect(style.pointOutlineWidth).toEqual(new Expression("2"));
 
-      const exp = new Expression("2");
-      style.pointOutlineWidth = exp;
-      expect(style.pointOutlineWidth).toEqual(exp);
+    const exp = new Expression("2");
+    style.pointOutlineWidth = exp;
+    expect(style.pointOutlineWidth).toEqual(exp);
 
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", "1.0"],
-          ["true", "2.0"],
-        ],
-      });
-
-      style.pointOutlineWidth = condExp;
-      expect(style.pointOutlineWidth).toEqual(condExp);
-
-      style.pointOutlineWidth = undefined;
-      expect(style.pointOutlineWidth).toBeUndefined();
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", "1.0"],
+        ["true", "2.0"],
+      ],
     });
+
+    style.pointOutlineWidth = condExp;
+    expect(style.pointOutlineWidth).toEqual(condExp);
+
+    style.pointOutlineWidth = undefined;
+    expect(style.pointOutlineWidth).toBeUndefined();
   });
 
   it("sets style.pointOutlineWidth expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.pointOutlineWidth = new Expression("2");
-      expect(style.style.pointOutlineWidth).toEqual("2");
+    style.pointOutlineWidth = new Expression("2");
+    expect(style.style.pointOutlineWidth).toEqual("2");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1.0"],
-          ["true", "2.0"],
-        ],
-      };
-      style.pointOutlineWidth = new ConditionsExpression(jsonExp);
-      expect(style.style.pointOutlineWidth).toEqual(jsonExp);
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1.0"],
+        ["true", "2.0"],
+      ],
+    };
+    style.pointOutlineWidth = new ConditionsExpression(jsonExp);
+    expect(style.style.pointOutlineWidth).toEqual(jsonExp);
 
-      const customExpression = {
-        evaluate: function () {
-          return 1;
-        },
-      };
-      style.pointOutlineWidth = customExpression;
-      expect(style.style.pointOutlineWidth).toEqual(customExpression);
+    const customExpression = {
+      evaluate: function () {
+        return 1;
+      },
+    };
+    style.pointOutlineWidth = customExpression;
+    expect(style.style.pointOutlineWidth).toEqual(customExpression);
 
-      style.pointOutlineWidth = undefined;
-      expect(style.style.pointOutlineWidth).toBeUndefined();
-    });
+    style.pointOutlineWidth = undefined;
+    expect(style.style.pointOutlineWidth).toBeUndefined();
   });
 
   it("sets pointOutlineWidth values in setter", function () {
@@ -962,27 +810,25 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetPointSize: "2.0",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.pointOutlineWidth = 2;
-      expect(style.pointOutlineWidth).toEqual(new Expression("2"));
+    style.pointOutlineWidth = 2;
+    expect(style.pointOutlineWidth).toEqual(new Expression("2"));
 
-      style.pointOutlineWidth = "${targetPointSize} + 1.0";
-      expect(style.pointOutlineWidth).toEqual(
-        new Expression("${targetPointSize} + 1.0", defines)
-      );
+    style.pointOutlineWidth = "${targetPointSize} + 1.0";
+    expect(style.pointOutlineWidth).toEqual(
+      new Expression("${targetPointSize} + 1.0", defines)
+    );
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1.0"],
-          ["true", "${targetPointSize}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1.0"],
+        ["true", "${targetPointSize}"],
+      ],
+    };
 
-      style.pointOutlineWidth = jsonExp;
-      expect(style.pointOutlineWidth).toEqual(
-        new ConditionsExpression(jsonExp, defines)
-      );
-    });
+    style.pointOutlineWidth = jsonExp;
+    expect(style.pointOutlineWidth).toEqual(
+      new ConditionsExpression(jsonExp, defines)
+    );
   });
 
   it("sets style.pointOutlineWidth values in setter", function () {
@@ -990,70 +836,51 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetPointSize: "2.0",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.pointOutlineWidth = 2;
-      expect(style.style.pointOutlineWidth).toEqual("2");
+    style.pointOutlineWidth = 2;
+    expect(style.style.pointOutlineWidth).toEqual("2");
 
-      style.pointOutlineWidth = "${targetPointSize} + 1.0";
-      expect(style.style.pointOutlineWidth).toEqual("${targetPointSize} + 1.0");
+    style.pointOutlineWidth = "${targetPointSize} + 1.0";
+    expect(style.style.pointOutlineWidth).toEqual("${targetPointSize} + 1.0");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1.0"],
-          ["true", "${targetPointSize}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1.0"],
+        ["true", "${targetPointSize}"],
+      ],
+    };
 
-      style.pointOutlineWidth = jsonExp;
-      expect(style.style.pointOutlineWidth).toEqual(jsonExp);
-    });
+    style.pointOutlineWidth = jsonExp;
+    expect(style.style.pointOutlineWidth).toEqual(jsonExp);
   });
 
   it("sets labelColor value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.labelColor).toBeUndefined();
+    expect(style.labelColor).toBeUndefined();
 
-        style = new Cesium3DTileStyle();
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.labelColor).toBeUndefined();
-      });
+    style = new Cesium3DTileStyle();
+    expect(style.labelColor).toBeUndefined();
   });
 
   it("sets labelColor value to expression", function () {
     let style = new Cesium3DTileStyle({
       labelColor: 'color("red")',
     });
-    return style.readyPromise
-      .then(function () {
-        expect(style.labelColor).toEqual(new Expression('color("red")'));
+    expect(style.labelColor).toEqual(new Expression('color("red")'));
 
-        style = new Cesium3DTileStyle({
-          labelColor: "rgba(30, 30, 30, 0.5)",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.labelColor).toEqual(
-          new Expression("rgba(30, 30, 30, 0.5)")
-        );
+    style = new Cesium3DTileStyle({
+      labelColor: "rgba(30, 30, 30, 0.5)",
+    });
+    expect(style.labelColor).toEqual(new Expression("rgba(30, 30, 30, 0.5)"));
 
-        style = new Cesium3DTileStyle({
-          labelColor:
-            '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")',
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.labelColor).toEqual(
-          new Expression(
-            '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")'
-          )
-        );
-      });
+    style = new Cesium3DTileStyle({
+      labelColor:
+        '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")',
+    });
+    expect(style.labelColor).toEqual(
+      new Expression(
+        '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")'
+      )
+    );
   });
 
   it("sets labelColor value to conditional", function () {
@@ -1067,62 +894,56 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       labelColor: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.labelColor).toEqual(new ConditionsExpression(jsonExp));
-    });
+    expect(style.labelColor).toEqual(new ConditionsExpression(jsonExp));
   });
 
   it("sets labelColor expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      const exp = new Expression('color("red")');
-      style.labelColor = exp;
-      expect(style.labelColor).toEqual(exp);
+    const exp = new Expression('color("red")');
+    style.labelColor = exp;
+    expect(style.labelColor).toEqual(exp);
 
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("blue")'],
-        ],
-      });
-
-      style.labelColor = condExp;
-      expect(style.labelColor).toEqual(condExp);
-
-      style.labelColor = undefined;
-      expect(style.labelColor).toBeUndefined();
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("blue")'],
+      ],
     });
+
+    style.labelColor = condExp;
+    expect(style.labelColor).toEqual(condExp);
+
+    style.labelColor = undefined;
+    expect(style.labelColor).toBeUndefined();
   });
 
   it("sets style.labelColor expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.labelColor = new Expression('color("red")');
-      expect(style.style.labelColor).toEqual('color("red")');
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("blue")'],
-        ],
-      };
+    style.labelColor = new Expression('color("red")');
+    expect(style.style.labelColor).toEqual('color("red")');
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("blue")'],
+      ],
+    };
 
-      style.labelColor = new ConditionsExpression(jsonExp);
-      expect(style.style.labelColor).toEqual(jsonExp);
+    style.labelColor = new ConditionsExpression(jsonExp);
+    expect(style.style.labelColor).toEqual(jsonExp);
 
-      const customExpression = {
-        evaluate: function () {
-          return Color.RED;
-        },
-        evaluateColor: function () {
-          return Color.RED;
-        },
-      };
-      style.labelColor = customExpression;
-      expect(style.style.labelColor).toEqual(customExpression);
+    const customExpression = {
+      evaluate: function () {
+        return Color.RED;
+      },
+      evaluateColor: function () {
+        return Color.RED;
+      },
+    };
+    style.labelColor = customExpression;
+    expect(style.style.labelColor).toEqual(customExpression);
 
-      style.labelColor = undefined;
-      expect(style.style.labelColor).toBeUndefined();
-    });
+    style.labelColor = undefined;
+    expect(style.style.labelColor).toBeUndefined();
   });
 
   it("sets labelColor values in setter", function () {
@@ -1130,24 +951,22 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetColor: "red",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.labelColor = 'color("${targetColor}")';
-      expect(style.labelColor).toEqual(
-        new Expression('color("${targetColor}")', defines)
-      );
+    style.labelColor = 'color("${targetColor}")';
+    expect(style.labelColor).toEqual(
+      new Expression('color("${targetColor}")', defines)
+    );
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("${targetColor}")'],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("${targetColor}")'],
+      ],
+    };
 
-      style.labelColor = jsonExp;
-      expect(style.labelColor).toEqual(
-        new ConditionsExpression(jsonExp, defines)
-      );
-    });
+    style.labelColor = jsonExp;
+    expect(style.labelColor).toEqual(
+      new ConditionsExpression(jsonExp, defines)
+    );
   });
 
   it("sets style.labelColor values in setter", function () {
@@ -1155,67 +974,50 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetColor: "red",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.labelColor = 'color("${targetColor}")';
-      expect(style.style.labelColor).toEqual('color("${targetColor}")');
+    style.labelColor = 'color("${targetColor}")';
+    expect(style.style.labelColor).toEqual('color("${targetColor}")');
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("${targetColor}")'],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("${targetColor}")'],
+      ],
+    };
 
-      style.labelColor = jsonExp;
-      expect(style.style.labelColor).toEqual(jsonExp);
-    });
+    style.labelColor = jsonExp;
+    expect(style.style.labelColor).toEqual(jsonExp);
   });
 
   it("sets labelOutlineColor value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.labelOutlineColor).toBeUndefined();
+    expect(style.labelOutlineColor).toBeUndefined();
 
-        style = new Cesium3DTileStyle();
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.labelOutlineColor).toBeUndefined();
-      });
+    style = new Cesium3DTileStyle();
+    expect(style.labelOutlineColor).toBeUndefined();
   });
 
   it("sets labelOutlineColor value to expression", function () {
     let style = new Cesium3DTileStyle({
       labelOutlineColor: 'color("red")',
     });
-    return style.readyPromise
-      .then(function () {
-        expect(style.labelOutlineColor).toEqual(new Expression('color("red")'));
+    expect(style.labelOutlineColor).toEqual(new Expression('color("red")'));
 
-        style = new Cesium3DTileStyle({
-          labelOutlineColor: "rgba(30, 30, 30, 0.5)",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.labelOutlineColor).toEqual(
-          new Expression("rgba(30, 30, 30, 0.5)")
-        );
+    style = new Cesium3DTileStyle({
+      labelOutlineColor: "rgba(30, 30, 30, 0.5)",
+    });
+    expect(style.labelOutlineColor).toEqual(
+      new Expression("rgba(30, 30, 30, 0.5)")
+    );
 
-        style = new Cesium3DTileStyle({
-          labelOutlineColor:
-            '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")',
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.labelOutlineColor).toEqual(
-          new Expression(
-            '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")'
-          )
-        );
-      });
+    style = new Cesium3DTileStyle({
+      labelOutlineColor:
+        '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")',
+    });
+    expect(style.labelOutlineColor).toEqual(
+      new Expression(
+        '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")'
+      )
+    );
   });
 
   it("sets labelOutlineColor value to conditional", function () {
@@ -1229,65 +1031,57 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       labelOutlineColor: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.labelOutlineColor).toEqual(
-        new ConditionsExpression(jsonExp)
-      );
-    });
+    expect(style.labelOutlineColor).toEqual(new ConditionsExpression(jsonExp));
   });
 
   it("sets labelOutlineColor expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      const exp = new Expression('color("red")');
-      style.labelOutlineColor = exp;
-      expect(style.labelOutlineColor).toEqual(exp);
+    const exp = new Expression('color("red")');
+    style.labelOutlineColor = exp;
+    expect(style.labelOutlineColor).toEqual(exp);
 
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("blue")'],
-        ],
-      });
-
-      style.labelOutlineColor = condExp;
-      expect(style.labelOutlineColor).toEqual(condExp);
-
-      style.labelOutlineColor = undefined;
-      expect(style.labelOutlineColor).toBeUndefined();
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("blue")'],
+      ],
     });
+
+    style.labelOutlineColor = condExp;
+    expect(style.labelOutlineColor).toEqual(condExp);
+
+    style.labelOutlineColor = undefined;
+    expect(style.labelOutlineColor).toBeUndefined();
   });
 
   it("sets style.labelOutlineColor expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.labelOutlineColor = new Expression('color("red")');
-      expect(style.style.labelOutlineColor).toEqual('color("red")');
+    style.labelOutlineColor = new Expression('color("red")');
+    expect(style.style.labelOutlineColor).toEqual('color("red")');
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("blue")'],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("blue")'],
+      ],
+    };
 
-      style.labelOutlineColor = new ConditionsExpression(jsonExp);
-      expect(style.style.labelOutlineColor).toEqual(jsonExp);
+    style.labelOutlineColor = new ConditionsExpression(jsonExp);
+    expect(style.style.labelOutlineColor).toEqual(jsonExp);
 
-      const customExpression = {
-        evaluate: function () {
-          return Color.RED;
-        },
-        evaluateColor: function () {
-          return Color.RED;
-        },
-      };
-      style.labelOutlineColor = customExpression;
-      expect(style.style.labelOutlineColor).toEqual(customExpression);
+    const customExpression = {
+      evaluate: function () {
+        return Color.RED;
+      },
+      evaluateColor: function () {
+        return Color.RED;
+      },
+    };
+    style.labelOutlineColor = customExpression;
+    expect(style.style.labelOutlineColor).toEqual(customExpression);
 
-      style.labelOutlineColor = undefined;
-      expect(style.style.labelOutlineColor).toBeUndefined();
-    });
+    style.labelOutlineColor = undefined;
+    expect(style.style.labelOutlineColor).toBeUndefined();
   });
 
   it("sets labelOutlineColor values in setter", function () {
@@ -1295,24 +1089,22 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetColor: "red",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.labelOutlineColor = 'color("${targetColor}")';
-      expect(style.labelOutlineColor).toEqual(
-        new Expression('color("${targetColor}")', defines)
-      );
+    style.labelOutlineColor = 'color("${targetColor}")';
+    expect(style.labelOutlineColor).toEqual(
+      new Expression('color("${targetColor}")', defines)
+    );
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("${targetColor}")'],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("${targetColor}")'],
+      ],
+    };
 
-      style.labelOutlineColor = jsonExp;
-      expect(style.labelOutlineColor).toEqual(
-        new ConditionsExpression(jsonExp, defines)
-      );
-    });
+    style.labelOutlineColor = jsonExp;
+    expect(style.labelOutlineColor).toEqual(
+      new ConditionsExpression(jsonExp, defines)
+    );
   });
 
   it("sets style.labelOutlineColor values in setter", function () {
@@ -1320,62 +1112,43 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetColor: "red",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.labelOutlineColor = 'color("${targetColor}")';
-      expect(style.style.labelOutlineColor).toEqual('color("${targetColor}")');
+    style.labelOutlineColor = 'color("${targetColor}")';
+    expect(style.style.labelOutlineColor).toEqual('color("${targetColor}")');
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("${targetColor}")'],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("${targetColor}")'],
+      ],
+    };
 
-      style.labelOutlineColor = jsonExp;
-      expect(style.style.labelOutlineColor).toEqual(jsonExp);
-    });
+    style.labelOutlineColor = jsonExp;
+    expect(style.style.labelOutlineColor).toEqual(jsonExp);
   });
 
   it("sets labelOutlineWidth value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.labelOutlineWidth).toBeUndefined();
+    expect(style.labelOutlineWidth).toBeUndefined();
 
-        style = new Cesium3DTileStyle();
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.labelOutlineWidth).toBeUndefined();
-      });
+    style = new Cesium3DTileStyle();
+    expect(style.labelOutlineWidth).toBeUndefined();
   });
 
   it("sets labelOutlineWidth value to expression", function () {
     let style = new Cesium3DTileStyle({
       labelOutlineWidth: "2",
     });
-    return style.readyPromise
-      .then(function () {
-        expect(style.labelOutlineWidth).toEqual(new Expression("2"));
+    expect(style.labelOutlineWidth).toEqual(new Expression("2"));
 
-        style = new Cesium3DTileStyle({
-          labelOutlineWidth: "${height} / 10",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.labelOutlineWidth).toEqual(
-          new Expression("${height} / 10")
-        );
+    style = new Cesium3DTileStyle({
+      labelOutlineWidth: "${height} / 10",
+    });
+    expect(style.labelOutlineWidth).toEqual(new Expression("${height} / 10"));
 
-        style = new Cesium3DTileStyle({
-          labelOutlineWidth: 2,
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.labelOutlineWidth).toEqual(new Expression("2"));
-      });
+    style = new Cesium3DTileStyle({
+      labelOutlineWidth: 2,
+    });
+    expect(style.labelOutlineWidth).toEqual(new Expression("2"));
   });
 
   it("sets labelOutlineWidth value to conditional", function () {
@@ -1389,63 +1162,55 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       labelOutlineWidth: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.labelOutlineWidth).toEqual(
-        new ConditionsExpression(jsonExp)
-      );
-    });
+    expect(style.labelOutlineWidth).toEqual(new ConditionsExpression(jsonExp));
   });
 
   it("sets labelOutlineWidth expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.labelOutlineWidth = 2;
-      expect(style.labelOutlineWidth).toEqual(new Expression("2"));
+    style.labelOutlineWidth = 2;
+    expect(style.labelOutlineWidth).toEqual(new Expression("2"));
 
-      const exp = new Expression("2");
-      style.labelOutlineWidth = exp;
-      expect(style.labelOutlineWidth).toEqual(exp);
+    const exp = new Expression("2");
+    style.labelOutlineWidth = exp;
+    expect(style.labelOutlineWidth).toEqual(exp);
 
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", "1.0"],
-          ["true", "2.0"],
-        ],
-      });
-
-      style.labelOutlineWidth = condExp;
-      expect(style.labelOutlineWidth).toEqual(condExp);
-
-      style.labelOutlineWidth = undefined;
-      expect(style.labelOutlineWidth).toBeUndefined();
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", "1.0"],
+        ["true", "2.0"],
+      ],
     });
+
+    style.labelOutlineWidth = condExp;
+    expect(style.labelOutlineWidth).toEqual(condExp);
+
+    style.labelOutlineWidth = undefined;
+    expect(style.labelOutlineWidth).toBeUndefined();
   });
 
   it("sets style.labelOutlineWidth expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.labelOutlineWidth = new Expression("2");
-      expect(style.style.labelOutlineWidth).toEqual("2");
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1.0"],
-          ["true", "2.0"],
-        ],
-      };
-      style.labelOutlineWidth = new ConditionsExpression(jsonExp);
-      expect(style.style.labelOutlineWidth).toEqual(jsonExp);
+    style.labelOutlineWidth = new Expression("2");
+    expect(style.style.labelOutlineWidth).toEqual("2");
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1.0"],
+        ["true", "2.0"],
+      ],
+    };
+    style.labelOutlineWidth = new ConditionsExpression(jsonExp);
+    expect(style.style.labelOutlineWidth).toEqual(jsonExp);
 
-      const customExpression = {
-        evaluate: function () {
-          return 1;
-        },
-      };
-      style.labelOutlineWidth = customExpression;
-      expect(style.style.labelOutlineWidth).toEqual(customExpression);
+    const customExpression = {
+      evaluate: function () {
+        return 1;
+      },
+    };
+    style.labelOutlineWidth = customExpression;
+    expect(style.style.labelOutlineWidth).toEqual(customExpression);
 
-      style.labelOutlineWidth = undefined;
-      expect(style.style.labelOutlineWidth).toBeUndefined();
-    });
+    style.labelOutlineWidth = undefined;
+    expect(style.style.labelOutlineWidth).toBeUndefined();
   });
 
   it("sets labelOutlineWidth values in setter", function () {
@@ -1453,27 +1218,25 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetLabelSize: "2.0",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.labelOutlineWidth = 2;
-      expect(style.labelOutlineWidth).toEqual(new Expression("2"));
+    style.labelOutlineWidth = 2;
+    expect(style.labelOutlineWidth).toEqual(new Expression("2"));
 
-      style.labelOutlineWidth = "${targetLabelSize} + 1.0";
-      expect(style.labelOutlineWidth).toEqual(
-        new Expression("${targetLabelSize} + 1.0", defines)
-      );
+    style.labelOutlineWidth = "${targetLabelSize} + 1.0";
+    expect(style.labelOutlineWidth).toEqual(
+      new Expression("${targetLabelSize} + 1.0", defines)
+    );
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1.0"],
-          ["true", "${targetLabelSize}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1.0"],
+        ["true", "${targetLabelSize}"],
+      ],
+    };
 
-      style.labelOutlineWidth = jsonExp;
-      expect(style.labelOutlineWidth).toEqual(
-        new ConditionsExpression(jsonExp, defines)
-      );
-    });
+    style.labelOutlineWidth = jsonExp;
+    expect(style.labelOutlineWidth).toEqual(
+      new ConditionsExpression(jsonExp, defines)
+    );
   });
 
   it("sets style.labelOutlineWidth values in setter", function () {
@@ -1481,63 +1244,46 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetLabelSize: "2.0",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.labelOutlineWidth = 2;
-      expect(style.style.labelOutlineWidth).toEqual("2");
+    style.labelOutlineWidth = 2;
+    expect(style.style.labelOutlineWidth).toEqual("2");
 
-      style.labelOutlineWidth = "${targetLabelSize} + 1.0";
-      expect(style.style.labelOutlineWidth).toEqual("${targetLabelSize} + 1.0");
+    style.labelOutlineWidth = "${targetLabelSize} + 1.0";
+    expect(style.style.labelOutlineWidth).toEqual("${targetLabelSize} + 1.0");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1.0"],
-          ["true", "${targetLabelSize}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1.0"],
+        ["true", "${targetLabelSize}"],
+      ],
+    };
 
-      style.labelOutlineWidth = jsonExp;
-      expect(style.style.labelOutlineWidth).toEqual(jsonExp);
-    });
+    style.labelOutlineWidth = jsonExp;
+    expect(style.style.labelOutlineWidth).toEqual(jsonExp);
   });
 
   it("sets font value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.font).toBeUndefined();
+    expect(style.font).toBeUndefined();
 
-        style = new Cesium3DTileStyle();
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.font).toBeUndefined();
-      });
+    style = new Cesium3DTileStyle();
+    expect(style.font).toBeUndefined();
   });
 
   it("sets font value to expression", function () {
     let style = new Cesium3DTileStyle({
       font: "'24px Helvetica'",
     });
-    return style.readyPromise
-      .then(function () {
-        expect(style.font).toEqual(new Expression("'24px Helvetica'"));
+    expect(style.font).toEqual(new Expression("'24px Helvetica'"));
 
-        style = new Cesium3DTileStyle({
-          font: "${font}",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.font).toEqual(new Expression("${font}"));
+    style = new Cesium3DTileStyle({
+      font: "${font}",
+    });
+    expect(style.font).toEqual(new Expression("${font}"));
 
-        style = new Cesium3DTileStyle({
-          font: "'24px Helvetica'",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.font).toEqual(new Expression("'24px Helvetica'"));
-      });
+    style = new Cesium3DTileStyle({
+      font: "'24px Helvetica'",
+    });
+    expect(style.font).toEqual(new Expression("'24px Helvetica'"));
   });
 
   it("sets font value to conditional", function () {
@@ -1551,63 +1297,57 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       font: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.font).toEqual(new ConditionsExpression(jsonExp));
-    });
+    expect(style.font).toEqual(new ConditionsExpression(jsonExp));
   });
 
   it("sets font expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.font = "'24px Helvetica'";
-      expect(style.font).toEqual(new Expression("'24px Helvetica'"));
+    style.font = "'24px Helvetica'";
+    expect(style.font).toEqual(new Expression("'24px Helvetica'"));
 
-      const exp = new Expression("'24px Helvetica'");
-      style.font = exp;
-      expect(style.font).toEqual(exp);
+    const exp = new Expression("'24px Helvetica'");
+    style.font = exp;
+    expect(style.font).toEqual(exp);
 
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", "'30px Helvetica'"],
-          ["true", "'24px Helvetica'"],
-        ],
-      });
-
-      style.font = condExp;
-      expect(style.font).toEqual(condExp);
-
-      style.font = undefined;
-      expect(style.font).toBeUndefined();
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", "'30px Helvetica'"],
+        ["true", "'24px Helvetica'"],
+      ],
     });
+
+    style.font = condExp;
+    expect(style.font).toEqual(condExp);
+
+    style.font = undefined;
+    expect(style.font).toBeUndefined();
   });
 
   it("sets style.font expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.font = new Expression("'24px Helvetica'");
-      expect(style.style.font).toEqual("'24px Helvetica'");
+    style.font = new Expression("'24px Helvetica'");
+    expect(style.style.font).toEqual("'24px Helvetica'");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "'30px Helvetica'"],
-          ["true", "'24px Helvetica'"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "'30px Helvetica'"],
+        ["true", "'24px Helvetica'"],
+      ],
+    };
 
-      style.font = new ConditionsExpression(jsonExp);
-      expect(style.style.font).toEqual(jsonExp);
+    style.font = new ConditionsExpression(jsonExp);
+    expect(style.style.font).toEqual(jsonExp);
 
-      const customExpression = {
-        evaluate: function () {
-          return "'24px Helvetica'";
-        },
-      };
-      style.font = customExpression;
-      expect(style.style.font).toEqual(customExpression);
+    const customExpression = {
+      evaluate: function () {
+        return "'24px Helvetica'";
+      },
+    };
+    style.font = customExpression;
+    expect(style.style.font).toEqual(customExpression);
 
-      style.font = undefined;
-      expect(style.style.font).toBeUndefined();
-    });
+    style.font = undefined;
+    expect(style.style.font).toBeUndefined();
   });
 
   it("sets font values in setter", function () {
@@ -1615,23 +1355,21 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetFont: "'30px Helvetica'",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.font = "'24px Helvetica'";
-      expect(style.font).toEqual(new Expression("'24px Helvetica'"));
+    style.font = "'24px Helvetica'";
+    expect(style.font).toEqual(new Expression("'24px Helvetica'"));
 
-      style.font = "${targetFont}";
-      expect(style.font).toEqual(new Expression("${targetFont}", defines));
+    style.font = "${targetFont}";
+    expect(style.font).toEqual(new Expression("${targetFont}", defines));
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "'24px Helvetica'"],
-          ["true", "${targetFont}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "'24px Helvetica'"],
+        ["true", "${targetFont}"],
+      ],
+    };
 
-      style.font = jsonExp;
-      expect(style.font).toEqual(new ConditionsExpression(jsonExp, defines));
-    });
+    style.font = jsonExp;
+    expect(style.font).toEqual(new ConditionsExpression(jsonExp, defines));
   });
 
   it("sets style.font values in setter", function () {
@@ -1639,46 +1377,36 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetFont: "'30px Helvetica'",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.font = "'24px Helvetica'";
-      expect(style.style.font).toEqual("'24px Helvetica'");
+    style.font = "'24px Helvetica'";
+    expect(style.style.font).toEqual("'24px Helvetica'");
 
-      style.font = "${targetFont}";
-      expect(style.style.font).toEqual("${targetFont}");
+    style.font = "${targetFont}";
+    expect(style.style.font).toEqual("${targetFont}");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "'24px Helvetica'"],
-          ["true", "${targetFont}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "'24px Helvetica'"],
+        ["true", "${targetFont}"],
+      ],
+    };
 
-      style.font = jsonExp;
-      expect(style.style.font).toEqual(jsonExp);
-    });
+    style.font = jsonExp;
+    expect(style.style.font).toEqual(jsonExp);
   });
 
   it("sets labelStyle value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.labelStyle).toBeUndefined();
+    expect(style.labelStyle).toBeUndefined();
 
-        style = new Cesium3DTileStyle();
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.labelStyle).toBeUndefined();
-      });
+    style = new Cesium3DTileStyle();
+    expect(style.labelStyle).toBeUndefined();
   });
 
   it("sets labelStyle value to expression", function () {
     const style = new Cesium3DTileStyle({
       labelStyle: "2",
     });
-    return style.readyPromise.then(function () {
-      expect(style.labelStyle).toEqual(new Expression("2"));
-    });
+    expect(style.labelStyle).toEqual(new Expression("2"));
   });
 
   it("sets labelStyle value to conditional", function () {
@@ -1692,62 +1420,56 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       labelStyle: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.labelStyle).toEqual(new ConditionsExpression(jsonExp));
-    });
+    expect(style.labelStyle).toEqual(new ConditionsExpression(jsonExp));
   });
 
   it("sets labelStyle expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.labelStyle = 2;
-      expect(style.labelStyle).toEqual(new Expression("2"));
+    style.labelStyle = 2;
+    expect(style.labelStyle).toEqual(new Expression("2"));
 
-      const exp = new Expression("2");
-      style.labelStyle = exp;
-      expect(style.labelStyle).toEqual(exp);
+    const exp = new Expression("2");
+    style.labelStyle = exp;
+    expect(style.labelStyle).toEqual(exp);
 
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", "1"],
-          ["true", "2"],
-        ],
-      });
-
-      style.labelStyle = condExp;
-      expect(style.labelStyle).toEqual(condExp);
-
-      style.labelStyle = undefined;
-      expect(style.labelStyle).toBeUndefined();
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", "1"],
+        ["true", "2"],
+      ],
     });
+
+    style.labelStyle = condExp;
+    expect(style.labelStyle).toEqual(condExp);
+
+    style.labelStyle = undefined;
+    expect(style.labelStyle).toBeUndefined();
   });
 
   it("sets style.labelStyle expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.labelStyle = new Expression("2");
-      expect(style.style.labelStyle).toEqual("2");
+    style.labelStyle = new Expression("2");
+    expect(style.style.labelStyle).toEqual("2");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1"],
-          ["true", "2"],
-        ],
-      };
-      style.labelStyle = new ConditionsExpression(jsonExp);
-      expect(style.style.labelStyle).toEqual(jsonExp);
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1"],
+        ["true", "2"],
+      ],
+    };
+    style.labelStyle = new ConditionsExpression(jsonExp);
+    expect(style.style.labelStyle).toEqual(jsonExp);
 
-      const customExpression = {
-        evaluate: function () {
-          return 0;
-        },
-      };
-      style.labelStyle = customExpression;
-      expect(style.style.labelStyle).toEqual(customExpression);
+    const customExpression = {
+      evaluate: function () {
+        return 0;
+      },
+    };
+    style.labelStyle = customExpression;
+    expect(style.style.labelStyle).toEqual(customExpression);
 
-      style.labelStyle = undefined;
-      expect(style.style.labelStyle).toBeUndefined();
-    });
+    style.labelStyle = undefined;
+    expect(style.style.labelStyle).toBeUndefined();
   });
 
   it("sets labelStyle values in setter", function () {
@@ -1755,27 +1477,25 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetLabelStyle: "2",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.labelStyle = 2;
-      expect(style.labelStyle).toEqual(new Expression("2"));
+    style.labelStyle = 2;
+    expect(style.labelStyle).toEqual(new Expression("2"));
 
-      style.labelStyle = "${targetLabelStyle}";
-      expect(style.labelStyle).toEqual(
-        new Expression("${targetLabelStyle}", defines)
-      );
+    style.labelStyle = "${targetLabelStyle}";
+    expect(style.labelStyle).toEqual(
+      new Expression("${targetLabelStyle}", defines)
+    );
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1.0"],
-          ["true", "${targetLabelStyle}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1.0"],
+        ["true", "${targetLabelStyle}"],
+      ],
+    };
 
-      style.labelStyle = jsonExp;
-      expect(style.labelStyle).toEqual(
-        new ConditionsExpression(jsonExp, defines)
-      );
-    });
+    style.labelStyle = jsonExp;
+    expect(style.labelStyle).toEqual(
+      new ConditionsExpression(jsonExp, defines)
+    );
   });
 
   it("sets style.labelStyle values in setter", function () {
@@ -1783,63 +1503,46 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetLabelStyle: "2",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.labelStyle = 2;
-      expect(style.style.labelStyle).toEqual("2");
+    style.labelStyle = 2;
+    expect(style.style.labelStyle).toEqual("2");
 
-      style.labelStyle = "${targetLabelStyle}";
-      expect(style.style.labelStyle).toEqual("${targetLabelStyle}");
+    style.labelStyle = "${targetLabelStyle}";
+    expect(style.style.labelStyle).toEqual("${targetLabelStyle}");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1.0"],
-          ["true", "${targetLabelStyle}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1.0"],
+        ["true", "${targetLabelStyle}"],
+      ],
+    };
 
-      style.labelStyle = jsonExp;
-      expect(style.style.labelStyle).toEqual(jsonExp);
-    });
+    style.labelStyle = jsonExp;
+    expect(style.style.labelStyle).toEqual(jsonExp);
   });
 
   it("sets labelText value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.labelText).toBeUndefined();
+    expect(style.labelText).toBeUndefined();
 
-        style = new Cesium3DTileStyle();
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.labelText).toBeUndefined();
-      });
+    style = new Cesium3DTileStyle();
+    expect(style.labelText).toBeUndefined();
   });
 
   it("sets labelText value to expression", function () {
     let style = new Cesium3DTileStyle({
       labelText: "'test text'",
     });
-    return style.readyPromise
-      .then(function () {
-        expect(style.labelText).toEqual(new Expression("'test text'"));
+    expect(style.labelText).toEqual(new Expression("'test text'"));
 
-        style = new Cesium3DTileStyle({
-          labelText: "${text}",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.labelText).toEqual(new Expression("${text}"));
+    style = new Cesium3DTileStyle({
+      labelText: "${text}",
+    });
+    expect(style.labelText).toEqual(new Expression("${text}"));
 
-        style = new Cesium3DTileStyle({
-          labelText: "'test text'",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.labelText).toEqual(new Expression("'test text'"));
-      });
+    style = new Cesium3DTileStyle({
+      labelText: "'test text'",
+    });
+    expect(style.labelText).toEqual(new Expression("'test text'"));
   });
 
   it("sets labelText value to conditional", function () {
@@ -1853,63 +1556,57 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       labelText: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.labelText).toEqual(new ConditionsExpression(jsonExp));
-    });
+    expect(style.labelText).toEqual(new ConditionsExpression(jsonExp));
   });
 
   it("sets labelText expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.labelText = "'test text'";
-      expect(style.labelText).toEqual(new Expression("'test text'"));
+    style.labelText = "'test text'";
+    expect(style.labelText).toEqual(new Expression("'test text'"));
 
-      const exp = new Expression("'test text'");
-      style.labelText = exp;
-      expect(style.labelText).toEqual(exp);
+    const exp = new Expression("'test text'");
+    style.labelText = exp;
+    expect(style.labelText).toEqual(exp);
 
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", "'test text 1'"],
-          ["true", "'test text 2'"],
-        ],
-      });
-
-      style.labelText = condExp;
-      expect(style.labelText).toEqual(condExp);
-
-      style.labelText = undefined;
-      expect(style.labelText).toBeUndefined();
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", "'test text 1'"],
+        ["true", "'test text 2'"],
+      ],
     });
+
+    style.labelText = condExp;
+    expect(style.labelText).toEqual(condExp);
+
+    style.labelText = undefined;
+    expect(style.labelText).toBeUndefined();
   });
 
   it("sets style.labelText expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.labelText = new Expression("'test text'");
-      expect(style.style.labelText).toEqual("'test text'");
+    style.labelText = new Expression("'test text'");
+    expect(style.style.labelText).toEqual("'test text'");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "'test text 1'"],
-          ["true", "'test text 2'"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "'test text 1'"],
+        ["true", "'test text 2'"],
+      ],
+    };
 
-      style.labelText = new ConditionsExpression(jsonExp);
-      expect(style.style.labelText).toEqual(jsonExp);
+    style.labelText = new ConditionsExpression(jsonExp);
+    expect(style.style.labelText).toEqual(jsonExp);
 
-      const customExpression = {
-        evaluate: function () {
-          return "'test text 1'";
-        },
-      };
-      style.labelText = customExpression;
-      expect(style.style.labelText).toEqual(customExpression);
+    const customExpression = {
+      evaluate: function () {
+        return "'test text 1'";
+      },
+    };
+    style.labelText = customExpression;
+    expect(style.style.labelText).toEqual(customExpression);
 
-      style.labelText = undefined;
-      expect(style.style.labelText).toBeUndefined();
-    });
+    style.labelText = undefined;
+    expect(style.style.labelText).toBeUndefined();
   });
 
   it("sets labelText values in setter", function () {
@@ -1917,25 +1614,21 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetText: "'test text 1'",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.labelText = "'test text'";
-      expect(style.labelText).toEqual(new Expression("'test text'"));
+    style.labelText = "'test text'";
+    expect(style.labelText).toEqual(new Expression("'test text'"));
 
-      style.labelText = "${targetText}";
-      expect(style.labelText).toEqual(new Expression("${targetText}", defines));
+    style.labelText = "${targetText}";
+    expect(style.labelText).toEqual(new Expression("${targetText}", defines));
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "'test text 2'"],
-          ["true", "${targetText}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "'test text 2'"],
+        ["true", "${targetText}"],
+      ],
+    };
 
-      style.labelText = jsonExp;
-      expect(style.labelText).toEqual(
-        new ConditionsExpression(jsonExp, defines)
-      );
-    });
+    style.labelText = jsonExp;
+    expect(style.labelText).toEqual(new ConditionsExpression(jsonExp, defines));
   });
 
   it("sets style.labelText values in setter", function () {
@@ -1943,70 +1636,53 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetText: "'test text 1'",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.labelText = "'test text'";
-      expect(style.style.labelText).toEqual("'test text'");
+    style.labelText = "'test text'";
+    expect(style.style.labelText).toEqual("'test text'");
 
-      style.labelText = "${targetText}";
-      expect(style.style.labelText).toEqual("${targetText}");
+    style.labelText = "${targetText}";
+    expect(style.style.labelText).toEqual("${targetText}");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "'test text 2'"],
-          ["true", "${targetText}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "'test text 2'"],
+        ["true", "${targetText}"],
+      ],
+    };
 
-      style.labelText = jsonExp;
-      expect(style.style.labelText).toEqual(jsonExp);
-    });
+    style.labelText = jsonExp;
+    expect(style.style.labelText).toEqual(jsonExp);
   });
 
   it("sets backgroundColor value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.backgroundColor).toBeUndefined();
+    expect(style.backgroundColor).toBeUndefined();
 
-        style = new Cesium3DTileStyle();
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.backgroundColor).toBeUndefined();
-      });
+    style = new Cesium3DTileStyle();
+    expect(style.backgroundColor).toBeUndefined();
   });
 
   it("sets backgroundColor value to expression", function () {
     let style = new Cesium3DTileStyle({
       backgroundColor: 'color("red")',
     });
-    return style.readyPromise
-      .then(function () {
-        expect(style.backgroundColor).toEqual(new Expression('color("red")'));
+    expect(style.backgroundColor).toEqual(new Expression('color("red")'));
 
-        style = new Cesium3DTileStyle({
-          backgroundColor: "rgba(30, 30, 30, 0.5)",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.backgroundColor).toEqual(
-          new Expression("rgba(30, 30, 30, 0.5)")
-        );
+    style = new Cesium3DTileStyle({
+      backgroundColor: "rgba(30, 30, 30, 0.5)",
+    });
+    expect(style.backgroundColor).toEqual(
+      new Expression("rgba(30, 30, 30, 0.5)")
+    );
 
-        style = new Cesium3DTileStyle({
-          backgroundColor:
-            '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")',
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.backgroundColor).toEqual(
-          new Expression(
-            '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")'
-          )
-        );
-      });
+    style = new Cesium3DTileStyle({
+      backgroundColor:
+        '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")',
+    });
+    expect(style.backgroundColor).toEqual(
+      new Expression(
+        '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")'
+      )
+    );
   });
 
   it("sets backgroundColor value to conditional", function () {
@@ -2020,63 +1696,57 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       backgroundColor: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.backgroundColor).toEqual(new ConditionsExpression(jsonExp));
-    });
+    expect(style.backgroundColor).toEqual(new ConditionsExpression(jsonExp));
   });
 
   it("sets backgroundColor expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      const exp = new Expression('color("red")');
-      style.backgroundColor = exp;
-      expect(style.backgroundColor).toEqual(exp);
+    const exp = new Expression('color("red")');
+    style.backgroundColor = exp;
+    expect(style.backgroundColor).toEqual(exp);
 
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("blue")'],
-        ],
-      });
-
-      style.backgroundColor = condExp;
-      expect(style.backgroundColor).toEqual(condExp);
-
-      style.backgroundColor = undefined;
-      expect(style.backgroundColor).toBeUndefined();
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("blue")'],
+      ],
     });
+
+    style.backgroundColor = condExp;
+    expect(style.backgroundColor).toEqual(condExp);
+
+    style.backgroundColor = undefined;
+    expect(style.backgroundColor).toBeUndefined();
   });
 
   it("sets style.backgroundColor expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.backgroundColor = new Expression('color("red")');
-      expect(style.style.backgroundColor).toEqual('color("red")');
+    style.backgroundColor = new Expression('color("red")');
+    expect(style.style.backgroundColor).toEqual('color("red")');
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("blue")'],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("blue")'],
+      ],
+    };
 
-      style.backgroundColor = new ConditionsExpression(jsonExp);
-      expect(style.style.backgroundColor).toEqual(jsonExp);
+    style.backgroundColor = new ConditionsExpression(jsonExp);
+    expect(style.style.backgroundColor).toEqual(jsonExp);
 
-      const customExpression = {
-        evaluate: function () {
-          return Color.RED;
-        },
-        evaluateColor: function () {
-          return Color.RED;
-        },
-      };
-      style.backgroundColor = customExpression;
-      expect(style.style.backgroundColor).toEqual(customExpression);
+    const customExpression = {
+      evaluate: function () {
+        return Color.RED;
+      },
+      evaluateColor: function () {
+        return Color.RED;
+      },
+    };
+    style.backgroundColor = customExpression;
+    expect(style.style.backgroundColor).toEqual(customExpression);
 
-      style.backgroundColor = undefined;
-      expect(style.style.backgroundColor).toBeUndefined();
-    });
+    style.backgroundColor = undefined;
+    expect(style.style.backgroundColor).toBeUndefined();
   });
 
   it("sets backgroundColor values in setter", function () {
@@ -2084,24 +1754,22 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetColor: "red",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.backgroundColor = 'color("${targetColor}")';
-      expect(style.backgroundColor).toEqual(
-        new Expression('color("${targetColor}")', defines)
-      );
+    style.backgroundColor = 'color("${targetColor}")';
+    expect(style.backgroundColor).toEqual(
+      new Expression('color("${targetColor}")', defines)
+    );
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("${targetColor}")'],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("${targetColor}")'],
+      ],
+    };
 
-      style.backgroundColor = jsonExp;
-      expect(style.backgroundColor).toEqual(
-        new ConditionsExpression(jsonExp, defines)
-      );
-    });
+    style.backgroundColor = jsonExp;
+    expect(style.backgroundColor).toEqual(
+      new ConditionsExpression(jsonExp, defines)
+    );
   });
 
   it("sets style.backgroundColor values in setter", function () {
@@ -2109,69 +1777,48 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetColor: "red",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.backgroundColor = 'color("${targetColor}")';
-      expect(style.style.backgroundColor).toEqual('color("${targetColor}")');
+    style.backgroundColor = 'color("${targetColor}")';
+    expect(style.style.backgroundColor).toEqual('color("${targetColor}")');
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("${targetColor}")'],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("${targetColor}")'],
+      ],
+    };
 
-      style.backgroundColor = jsonExp;
-      expect(style.style.backgroundColor).toEqual(jsonExp);
-    });
+    style.backgroundColor = jsonExp;
+    expect(style.style.backgroundColor).toEqual(jsonExp);
   });
 
   it("sets backgroundPadding value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.backgroundPadding).toBeUndefined();
+    expect(style.backgroundPadding).toBeUndefined();
 
-        style = new Cesium3DTileStyle();
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.backgroundPadding).toBeUndefined();
-      });
+    style = new Cesium3DTileStyle();
+    expect(style.backgroundPadding).toBeUndefined();
   });
 
   it("sets backgroundPadding value to expression", function () {
     let style = new Cesium3DTileStyle({
       backgroundPadding: "vec2(1.0, 2.0)",
     });
-    return style.readyPromise
-      .then(function () {
-        expect(style.backgroundPadding).toEqual(
-          new Expression("vec2(1.0, 2.0)")
-        );
+    expect(style.backgroundPadding).toEqual(new Expression("vec2(1.0, 2.0)"));
 
-        style = new Cesium3DTileStyle({
-          backgroundPadding: "vec2(3.0, 4.0)",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.backgroundPadding).toEqual(
-          new Expression("vec2(3.0, 4.0)")
-        );
+    style = new Cesium3DTileStyle({
+      backgroundPadding: "vec2(3.0, 4.0)",
+    });
+    expect(style.backgroundPadding).toEqual(new Expression("vec2(3.0, 4.0)"));
 
-        style = new Cesium3DTileStyle({
-          backgroundPadding:
-            "(${height} * 10 >= 1000) ? vec2(1.0, 2.0) : vec2(3.0, 4.0)",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.backgroundPadding).toEqual(
-          new Expression(
-            "(${height} * 10 >= 1000) ? vec2(1.0, 2.0) : vec2(3.0, 4.0)"
-          )
-        );
-      });
+    style = new Cesium3DTileStyle({
+      backgroundPadding:
+        "(${height} * 10 >= 1000) ? vec2(1.0, 2.0) : vec2(3.0, 4.0)",
+    });
+    expect(style.backgroundPadding).toEqual(
+      new Expression(
+        "(${height} * 10 >= 1000) ? vec2(1.0, 2.0) : vec2(3.0, 4.0)"
+      )
+    );
   });
 
   it("sets backgroundPadding value to conditional", function () {
@@ -2185,62 +1832,54 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       backgroundPadding: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.backgroundPadding).toEqual(
-        new ConditionsExpression(jsonExp)
-      );
-    });
+    expect(style.backgroundPadding).toEqual(new ConditionsExpression(jsonExp));
   });
 
   it("sets backgroundPadding expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      const exp = new Expression("vec2(1.0, 2.0)");
-      style.backgroundPadding = exp;
-      expect(style.backgroundPadding).toEqual(exp);
+    const exp = new Expression("vec2(1.0, 2.0)");
+    style.backgroundPadding = exp;
+    expect(style.backgroundPadding).toEqual(exp);
 
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", "vec2(1.0, 2.0)"],
-          ["true", "vec2(3.0, 4.0)"],
-        ],
-      });
-
-      style.backgroundPadding = condExp;
-      expect(style.backgroundPadding).toEqual(condExp);
-
-      style.backgroundPadding = undefined;
-      expect(style.backgroundPadding).toBeUndefined();
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", "vec2(1.0, 2.0)"],
+        ["true", "vec2(3.0, 4.0)"],
+      ],
     });
+
+    style.backgroundPadding = condExp;
+    expect(style.backgroundPadding).toEqual(condExp);
+
+    style.backgroundPadding = undefined;
+    expect(style.backgroundPadding).toBeUndefined();
   });
 
   it("sets style.backgroundPadding expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.backgroundPadding = new Expression("vec2(1.0, 2.0)");
-      expect(style.style.backgroundPadding).toEqual("vec2(1.0, 2.0)");
+    style.backgroundPadding = new Expression("vec2(1.0, 2.0)");
+    expect(style.style.backgroundPadding).toEqual("vec2(1.0, 2.0)");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "vec2(1.0, 2.0)"],
-          ["true", "vec2(3.0, 4.0)"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "vec2(1.0, 2.0)"],
+        ["true", "vec2(3.0, 4.0)"],
+      ],
+    };
 
-      const customExpression = {
-        evaluate: function () {
-          return new Cartesian2(1.0, 2.0);
-        },
-      };
-      style.labelText = customExpression;
-      expect(style.style.labelText).toEqual(customExpression);
+    const customExpression = {
+      evaluate: function () {
+        return new Cartesian2(1.0, 2.0);
+      },
+    };
+    style.labelText = customExpression;
+    expect(style.style.labelText).toEqual(customExpression);
 
-      style.backgroundPadding = new ConditionsExpression(jsonExp);
-      expect(style.style.backgroundPadding).toEqual(jsonExp);
+    style.backgroundPadding = new ConditionsExpression(jsonExp);
+    expect(style.style.backgroundPadding).toEqual(jsonExp);
 
-      style.backgroundPadding = undefined;
-      expect(style.style.backgroundPadding).toBeUndefined();
-    });
+    style.backgroundPadding = undefined;
+    expect(style.style.backgroundPadding).toBeUndefined();
   });
 
   it("sets backgroundPadding values in setter", function () {
@@ -2248,24 +1887,22 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetPadding: "3.0, 4.0",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.backgroundPadding = 'vec2("${targetPadding}")';
-      expect(style.backgroundPadding).toEqual(
-        new Expression('vec2("${targetPadding}")', defines)
-      );
+    style.backgroundPadding = 'vec2("${targetPadding}")';
+    expect(style.backgroundPadding).toEqual(
+      new Expression('vec2("${targetPadding}")', defines)
+    );
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "vec2(1.0, 2.0)"],
-          ["true", 'vec2("${targetPadding}")'],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "vec2(1.0, 2.0)"],
+        ["true", 'vec2("${targetPadding}")'],
+      ],
+    };
 
-      style.backgroundPadding = jsonExp;
-      expect(style.backgroundPadding).toEqual(
-        new ConditionsExpression(jsonExp, defines)
-      );
-    });
+    style.backgroundPadding = jsonExp;
+    expect(style.backgroundPadding).toEqual(
+      new ConditionsExpression(jsonExp, defines)
+    );
   });
 
   it("sets style.backgroundPadding values in setter", function () {
@@ -2273,78 +1910,55 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetPadding: "3.0, 4.0",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.backgroundPadding = 'vec2("${targetPadding}")';
-      expect(style.style.backgroundPadding).toEqual('vec2("${targetPadding}")');
+    style.backgroundPadding = 'vec2("${targetPadding}")';
+    expect(style.style.backgroundPadding).toEqual('vec2("${targetPadding}")');
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "vec2(1.0, 2.0)"],
-          ["true", 'vec2("${targetPadding}")'],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "vec2(1.0, 2.0)"],
+        ["true", 'vec2("${targetPadding}")'],
+      ],
+    };
 
-      style.backgroundPadding = jsonExp;
-      expect(style.style.backgroundPadding).toEqual(jsonExp);
-    });
+    style.backgroundPadding = jsonExp;
+    expect(style.style.backgroundPadding).toEqual(jsonExp);
   });
 
   it("sets backgroundEnabled value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.backgroundEnabled).toBeUndefined();
+    expect(style.backgroundEnabled).toBeUndefined();
 
-        style = new Cesium3DTileStyle();
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.backgroundEnabled).toBeUndefined();
-      });
+    style = new Cesium3DTileStyle();
+    expect(style.backgroundEnabled).toBeUndefined();
   });
 
   it("sets backgroundEnabled value to expression", function () {
     let style = new Cesium3DTileStyle({
       backgroundEnabled: "true",
     });
-    return style.readyPromise
-      .then(function () {
-        expect(style.backgroundEnabled).toEqual(new Expression("true"));
+    expect(style.backgroundEnabled).toEqual(new Expression("true"));
 
-        style = new Cesium3DTileStyle({
-          backgroundEnabled: "false",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.backgroundEnabled).toEqual(new Expression("false"));
+    style = new Cesium3DTileStyle({
+      backgroundEnabled: "false",
+    });
+    expect(style.backgroundEnabled).toEqual(new Expression("false"));
 
-        style = new Cesium3DTileStyle({
-          backgroundEnabled: "${height} * 10 >= 1000",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.backgroundEnabled).toEqual(
-          new Expression("${height} * 10 >= 1000")
-        );
+    style = new Cesium3DTileStyle({
+      backgroundEnabled: "${height} * 10 >= 1000",
+    });
+    expect(style.backgroundEnabled).toEqual(
+      new Expression("${height} * 10 >= 1000")
+    );
 
-        style = new Cesium3DTileStyle({
-          backgroundEnabled: true,
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.backgroundEnabled).toEqual(new Expression("true"));
+    style = new Cesium3DTileStyle({
+      backgroundEnabled: true,
+    });
+    expect(style.backgroundEnabled).toEqual(new Expression("true"));
 
-        style = new Cesium3DTileStyle({
-          backgroundEnabled: false,
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.backgroundEnabled).toEqual(new Expression("false"));
-      });
+    style = new Cesium3DTileStyle({
+      backgroundEnabled: false,
+    });
+    expect(style.backgroundEnabled).toEqual(new Expression("false"));
   });
 
   it("sets backgroundEnabled value to conditional", function () {
@@ -2358,56 +1972,48 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       backgroundEnabled: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.backgroundEnabled).toEqual(
-        new ConditionsExpression(jsonExp)
-      );
-    });
+    expect(style.backgroundEnabled).toEqual(new ConditionsExpression(jsonExp));
   });
 
   it("sets backgroundEnabled expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", "false"],
-          ["true", "true"],
-        ],
-      });
-
-      style.backgroundEnabled = condExp;
-      expect(style.backgroundEnabled).toEqual(condExp);
-
-      const exp = new Expression("false");
-      style.backgroundEnabled = exp;
-      expect(style.backgroundEnabled).toEqual(exp);
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", "false"],
+        ["true", "true"],
+      ],
     });
+
+    style.backgroundEnabled = condExp;
+    expect(style.backgroundEnabled).toEqual(condExp);
+
+    const exp = new Expression("false");
+    style.backgroundEnabled = exp;
+    expect(style.backgroundEnabled).toEqual(exp);
   });
 
   it("sets style.backgroundEnabled expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.backgroundEnabled = new Expression("false");
-      expect(style.style.backgroundEnabled).toEqual("false");
+    style.backgroundEnabled = new Expression("false");
+    expect(style.style.backgroundEnabled).toEqual("false");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "false"],
-          ["true", "true"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "false"],
+        ["true", "true"],
+      ],
+    };
 
-      style.backgroundEnabled = new ConditionsExpression(jsonExp);
-      expect(style.style.backgroundEnabled).toEqual(jsonExp);
+    style.backgroundEnabled = new ConditionsExpression(jsonExp);
+    expect(style.style.backgroundEnabled).toEqual(jsonExp);
 
-      const customExpression = {
-        evaluate: function () {
-          return true;
-        },
-      };
-      style.backgroundEnabled = customExpression;
-      expect(style.style.backgroundEnabled).toEqual(customExpression);
-    });
+    const customExpression = {
+      evaluate: function () {
+        return true;
+      },
+    };
+    style.backgroundEnabled = customExpression;
+    expect(style.style.backgroundEnabled).toEqual(customExpression);
   });
 
   it("sets backgroundEnabled values in setter", function () {
@@ -2415,30 +2021,28 @@ describe("Scene/Cesium3DTileStyle", function () {
       backgroundFactor: 10,
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.backgroundEnabled = "${height} * ${backgroundFactor} >= 1000";
-      expect(style.backgroundEnabled).toEqual(
-        new Expression("${height} * ${backgroundFactor} >= 1000", defines)
-      );
+    style.backgroundEnabled = "${height} * ${backgroundFactor} >= 1000";
+    expect(style.backgroundEnabled).toEqual(
+      new Expression("${height} * ${backgroundFactor} >= 1000", defines)
+    );
 
-      style.backgroundEnabled = false;
-      expect(style.backgroundEnabled).toEqual(new Expression("false"));
+    style.backgroundEnabled = false;
+    expect(style.backgroundEnabled).toEqual(new Expression("false"));
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > ${backgroundFactor}", "false"],
-          ["true", "true"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > ${backgroundFactor}", "false"],
+        ["true", "true"],
+      ],
+    };
 
-      style.backgroundEnabled = jsonExp;
-      expect(style.backgroundEnabled).toEqual(
-        new ConditionsExpression(jsonExp, defines)
-      );
+    style.backgroundEnabled = jsonExp;
+    expect(style.backgroundEnabled).toEqual(
+      new ConditionsExpression(jsonExp, defines)
+    );
 
-      style.backgroundEnabled = undefined;
-      expect(style.backgroundEnabled).toBeUndefined();
-    });
+    style.backgroundEnabled = undefined;
+    expect(style.backgroundEnabled).toBeUndefined();
   });
 
   it("sets style.backgroundEnabled values in setter", function () {
@@ -2446,42 +2050,34 @@ describe("Scene/Cesium3DTileStyle", function () {
       backgroundFactor: 10,
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.backgroundEnabled = "${height} * ${backgroundFactor} >= 1000";
-      expect(style.style.backgroundEnabled).toEqual(
-        "${height} * ${backgroundFactor} >= 1000"
-      );
+    style.backgroundEnabled = "${height} * ${backgroundFactor} >= 1000";
+    expect(style.style.backgroundEnabled).toEqual(
+      "${height} * ${backgroundFactor} >= 1000"
+    );
 
-      style.backgroundEnabled = false;
-      expect(style.style.backgroundEnabled).toEqual("false");
+    style.backgroundEnabled = false;
+    expect(style.style.backgroundEnabled).toEqual("false");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > ${backgroundFactor}", "false"],
-          ["true", "true"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > ${backgroundFactor}", "false"],
+        ["true", "true"],
+      ],
+    };
 
-      style.backgroundEnabled = jsonExp;
-      expect(style.style.backgroundEnabled).toEqual(jsonExp);
+    style.backgroundEnabled = jsonExp;
+    expect(style.style.backgroundEnabled).toEqual(jsonExp);
 
-      style.backgroundEnabled = undefined;
-      expect(style.style.backgroundEnabled).toBeUndefined();
-    });
+    style.backgroundEnabled = undefined;
+    expect(style.style.backgroundEnabled).toBeUndefined();
   });
 
   it("sets scaleByDistance value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.scaleByDistance).toBeUndefined();
+    expect(style.scaleByDistance).toBeUndefined();
 
-        style = new Cesium3DTileStyle();
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.scaleByDistance).toBeUndefined();
-      });
+    style = new Cesium3DTileStyle();
+    expect(style.scaleByDistance).toBeUndefined();
   });
 
   it("sets scaleByDistance value to expression", function () {
@@ -2489,36 +2085,27 @@ describe("Scene/Cesium3DTileStyle", function () {
       scaleByDistance: "vec4(1.0, 2.0, 3.0, 4.0)",
     });
 
-    return style.readyPromise
-      .then(function () {
-        expect(style.scaleByDistance).toEqual(
-          new Expression("vec4(1.0, 2.0, 3.0, 4.0)")
-        );
+    expect(style.scaleByDistance).toEqual(
+      new Expression("vec4(1.0, 2.0, 3.0, 4.0)")
+    );
 
-        style = new Cesium3DTileStyle({
-          scaleByDistance: "vec4(5.0, 6.0, 7.0, 8.0)",
-        });
+    style = new Cesium3DTileStyle({
+      scaleByDistance: "vec4(5.0, 6.0, 7.0, 8.0)",
+    });
 
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.scaleByDistance).toEqual(
-          new Expression("vec4(5.0, 6.0, 7.0, 8.0)")
-        );
+    expect(style.scaleByDistance).toEqual(
+      new Expression("vec4(5.0, 6.0, 7.0, 8.0)")
+    );
 
-        style = new Cesium3DTileStyle({
-          scaleByDistance:
-            "(${height} * 10 >= 1000) ? vec4(1.0, 2.0, 3.0, 4.0) : vec4(5.0, 6.0, 7.0, 8.0)",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.scaleByDistance).toEqual(
-          new Expression(
-            "(${height} * 10 >= 1000) ? vec4(1.0, 2.0, 3.0, 4.0) : vec4(5.0, 6.0, 7.0, 8.0)"
-          )
-        );
-      });
+    style = new Cesium3DTileStyle({
+      scaleByDistance:
+        "(${height} * 10 >= 1000) ? vec4(1.0, 2.0, 3.0, 4.0) : vec4(5.0, 6.0, 7.0, 8.0)",
+    });
+    expect(style.scaleByDistance).toEqual(
+      new Expression(
+        "(${height} * 10 >= 1000) ? vec4(1.0, 2.0, 3.0, 4.0) : vec4(5.0, 6.0, 7.0, 8.0)"
+      )
+    );
   });
 
   it("sets scaleByDistance value to conditional", function () {
@@ -2532,61 +2119,55 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       scaleByDistance: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.scaleByDistance).toEqual(new ConditionsExpression(jsonExp));
-    });
+    expect(style.scaleByDistance).toEqual(new ConditionsExpression(jsonExp));
   });
 
   it("sets scaleByDistance expressions in setter", function () {
     const style = new Cesium3DTileStyle();
 
     const exp = new Expression("vec4(5.0, 6.0, 7.0, 8.0)");
-    return style.readyPromise.then(function () {
-      style.scaleByDistance = exp;
-      expect(style.scaleByDistance).toEqual(exp);
+    style.scaleByDistance = exp;
+    expect(style.scaleByDistance).toEqual(exp);
 
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", "vec4(1.0, 2.0, 3.0, 4.0)"],
-          ["true", "vec4(5.0, 6.0, 7.0, 8.0)"],
-        ],
-      });
-
-      style.scaleByDistance = condExp;
-      expect(style.scaleByDistance).toEqual(condExp);
-
-      style.scaleByDistance = undefined;
-      expect(style.scaleByDistance).toBeUndefined();
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", "vec4(1.0, 2.0, 3.0, 4.0)"],
+        ["true", "vec4(5.0, 6.0, 7.0, 8.0)"],
+      ],
     });
+
+    style.scaleByDistance = condExp;
+    expect(style.scaleByDistance).toEqual(condExp);
+
+    style.scaleByDistance = undefined;
+    expect(style.scaleByDistance).toBeUndefined();
   });
 
   it("sets style.scaleByDistance expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.scaleByDistance = new Expression("vec4(5.0, 6.0, 7.0, 8.0)");
-      expect(style.style.scaleByDistance).toEqual("vec4(5.0, 6.0, 7.0, 8.0)");
+    style.scaleByDistance = new Expression("vec4(5.0, 6.0, 7.0, 8.0)");
+    expect(style.style.scaleByDistance).toEqual("vec4(5.0, 6.0, 7.0, 8.0)");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "vec4(1.0, 2.0, 3.0, 4.0)"],
-          ["true", "vec4(5.0, 6.0, 7.0, 8.0)"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "vec4(1.0, 2.0, 3.0, 4.0)"],
+        ["true", "vec4(5.0, 6.0, 7.0, 8.0)"],
+      ],
+    };
 
-      style.scaleByDistance = new ConditionsExpression(jsonExp);
-      expect(style.style.scaleByDistance).toEqual(jsonExp);
+    style.scaleByDistance = new ConditionsExpression(jsonExp);
+    expect(style.style.scaleByDistance).toEqual(jsonExp);
 
-      const customExpression = {
-        evaluate: function () {
-          return new Cartesian4(1.0, 2.0, 3.0, 4.0);
-        },
-      };
-      style.scaleByDistance = customExpression;
-      expect(style.style.scaleByDistance).toEqual(customExpression);
+    const customExpression = {
+      evaluate: function () {
+        return new Cartesian4(1.0, 2.0, 3.0, 4.0);
+      },
+    };
+    style.scaleByDistance = customExpression;
+    expect(style.style.scaleByDistance).toEqual(customExpression);
 
-      style.scaleByDistance = undefined;
-      expect(style.style.scaleByDistance).toBeUndefined();
-    });
+    style.scaleByDistance = undefined;
+    expect(style.style.scaleByDistance).toBeUndefined();
   });
 
   it("sets scaleByDistance values in setter", function () {
@@ -2594,24 +2175,22 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetScale: "1.0, 2.0, 3.0, 4.",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.scaleByDistance = 'vec4("${targetScale}")';
-      expect(style.scaleByDistance).toEqual(
-        new Expression('vec4("${targetScale}")', defines)
-      );
+    style.scaleByDistance = 'vec4("${targetScale}")';
+    expect(style.scaleByDistance).toEqual(
+      new Expression('vec4("${targetScale}")', defines)
+    );
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "vec4(5.0, 6.0, 7.0, 8.0)"],
-          ["true", 'vec4("${targetScale}")'],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "vec4(5.0, 6.0, 7.0, 8.0)"],
+        ["true", 'vec4("${targetScale}")'],
+      ],
+    };
 
-      style.scaleByDistance = jsonExp;
-      expect(style.scaleByDistance).toEqual(
-        new ConditionsExpression(jsonExp, defines)
-      );
-    });
+    style.scaleByDistance = jsonExp;
+    expect(style.scaleByDistance).toEqual(
+      new ConditionsExpression(jsonExp, defines)
+    );
   });
 
   it("sets style.scaleByDistance values in setter", function () {
@@ -2619,69 +2198,52 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetScale: "1.0, 2.0, 3.0, 4.",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.scaleByDistance = 'vec4("${targetScale}")';
-      expect(style.style.scaleByDistance).toEqual('vec4("${targetScale}")');
+    style.scaleByDistance = 'vec4("${targetScale}")';
+    expect(style.style.scaleByDistance).toEqual('vec4("${targetScale}")');
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "vec4(5.0, 6.0, 7.0, 8.0)"],
-          ["true", 'vec4("${targetScale}")'],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "vec4(5.0, 6.0, 7.0, 8.0)"],
+        ["true", 'vec4("${targetScale}")'],
+      ],
+    };
 
-      style.scaleByDistance = jsonExp;
-      expect(style.style.scaleByDistance).toEqual(jsonExp);
-    });
+    style.scaleByDistance = jsonExp;
+    expect(style.style.scaleByDistance).toEqual(jsonExp);
   });
 
   it("sets distanceDisplayCondition value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.distanceDisplayCondition).toBeUndefined();
+    expect(style.distanceDisplayCondition).toBeUndefined();
 
-        style = new Cesium3DTileStyle();
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.distanceDisplayCondition).toBeUndefined();
-      });
+    style = new Cesium3DTileStyle();
+    expect(style.distanceDisplayCondition).toBeUndefined();
   });
 
   it("sets distanceDisplayCondition value to expression", function () {
     let style = new Cesium3DTileStyle({
       distanceDisplayCondition: "vec4(1.0, 2.0, 3.0, 4.0)",
     });
-    return style.readyPromise
-      .then(function () {
-        expect(style.distanceDisplayCondition).toEqual(
-          new Expression("vec4(1.0, 2.0, 3.0, 4.0)")
-        );
+    expect(style.distanceDisplayCondition).toEqual(
+      new Expression("vec4(1.0, 2.0, 3.0, 4.0)")
+    );
 
-        style = new Cesium3DTileStyle({
-          distanceDisplayCondition: "vec4(5.0, 6.0, 7.0, 8.0)",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.distanceDisplayCondition).toEqual(
-          new Expression("vec4(5.0, 6.0, 7.0, 8.0)")
-        );
+    style = new Cesium3DTileStyle({
+      distanceDisplayCondition: "vec4(5.0, 6.0, 7.0, 8.0)",
+    });
+    expect(style.distanceDisplayCondition).toEqual(
+      new Expression("vec4(5.0, 6.0, 7.0, 8.0)")
+    );
 
-        style = new Cesium3DTileStyle({
-          distanceDisplayCondition:
-            "(${height} * 10 >= 1000) ? vec4(1.0, 2.0, 3.0, 4.0) : vec4(5.0, 6.0, 7.0, 8.0)",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.distanceDisplayCondition).toEqual(
-          new Expression(
-            "(${height} * 10 >= 1000) ? vec4(1.0, 2.0, 3.0, 4.0) : vec4(5.0, 6.0, 7.0, 8.0)"
-          )
-        );
-      });
+    style = new Cesium3DTileStyle({
+      distanceDisplayCondition:
+        "(${height} * 10 >= 1000) ? vec4(1.0, 2.0, 3.0, 4.0) : vec4(5.0, 6.0, 7.0, 8.0)",
+    });
+    expect(style.distanceDisplayCondition).toEqual(
+      new Expression(
+        "(${height} * 10 >= 1000) ? vec4(1.0, 2.0, 3.0, 4.0) : vec4(5.0, 6.0, 7.0, 8.0)"
+      )
+    );
   });
 
   it("sets distanceDisplayCondition value to conditional", function () {
@@ -2695,66 +2257,58 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       distanceDisplayCondition: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.distanceDisplayCondition).toEqual(
-        new ConditionsExpression(jsonExp)
-      );
-    });
+    expect(style.distanceDisplayCondition).toEqual(
+      new ConditionsExpression(jsonExp)
+    );
   });
 
   it("sets distanceDisplayCondition expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      const exp = new Expression("vec4(5.0, 6.0, 7.0, 8.0)");
-      style.distanceDisplayCondition = exp;
-      expect(style.distanceDisplayCondition).toEqual(exp);
+    const exp = new Expression("vec4(5.0, 6.0, 7.0, 8.0)");
+    style.distanceDisplayCondition = exp;
+    expect(style.distanceDisplayCondition).toEqual(exp);
 
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", "vec4(1.0, 2.0, 3.0, 4.0)"],
-          ["true", "vec4(5.0, 6.0, 7.0, 8.0)"],
-        ],
-      });
-
-      style.distanceDisplayCondition = condExp;
-      expect(style.distanceDisplayCondition).toEqual(condExp);
-
-      style.distanceDisplayCondition = undefined;
-      expect(style.distanceDisplayCondition).toBeUndefined();
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", "vec4(1.0, 2.0, 3.0, 4.0)"],
+        ["true", "vec4(5.0, 6.0, 7.0, 8.0)"],
+      ],
     });
+
+    style.distanceDisplayCondition = condExp;
+    expect(style.distanceDisplayCondition).toEqual(condExp);
+
+    style.distanceDisplayCondition = undefined;
+    expect(style.distanceDisplayCondition).toBeUndefined();
   });
 
   it("sets style.distanceDisplayCondition expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.distanceDisplayCondition = new Expression(
-        "vec4(5.0, 6.0, 7.0, 8.0)"
-      );
-      expect(style.style.distanceDisplayCondition).toEqual(
-        "vec4(5.0, 6.0, 7.0, 8.0)"
-      );
+    style.distanceDisplayCondition = new Expression("vec4(5.0, 6.0, 7.0, 8.0)");
+    expect(style.style.distanceDisplayCondition).toEqual(
+      "vec4(5.0, 6.0, 7.0, 8.0)"
+    );
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "vec4(1.0, 2.0, 3.0, 4.0)"],
-          ["true", "vec4(5.0, 6.0, 7.0, 8.0)"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "vec4(1.0, 2.0, 3.0, 4.0)"],
+        ["true", "vec4(5.0, 6.0, 7.0, 8.0)"],
+      ],
+    };
 
-      style.distanceDisplayCondition = new ConditionsExpression(jsonExp);
-      expect(style.style.distanceDisplayCondition).toEqual(jsonExp);
+    style.distanceDisplayCondition = new ConditionsExpression(jsonExp);
+    expect(style.style.distanceDisplayCondition).toEqual(jsonExp);
 
-      const customExpression = {
-        evaluate: function () {
-          return new Cartesian4(1.0, 2.0, 3.0, 4.0);
-        },
-      };
-      style.distanceDisplayCondition = customExpression;
-      expect(style.style.distanceDisplayCondition).toEqual(customExpression);
+    const customExpression = {
+      evaluate: function () {
+        return new Cartesian4(1.0, 2.0, 3.0, 4.0);
+      },
+    };
+    style.distanceDisplayCondition = customExpression;
+    expect(style.style.distanceDisplayCondition).toEqual(customExpression);
 
-      style.distanceDisplayCondition = undefined;
-      expect(style.style.distanceDisplayCondition).toBeUndefined();
-    });
+    style.distanceDisplayCondition = undefined;
+    expect(style.style.distanceDisplayCondition).toBeUndefined();
   });
 
   it("sets distanceDisplayCondition values in setter", function () {
@@ -2762,24 +2316,22 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetTranslucency: "1.0, 2.0, 3.0, 4.",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.distanceDisplayCondition = 'vec4("${targetTranslucency}")';
-      expect(style.distanceDisplayCondition).toEqual(
-        new Expression('vec4("${targetTranslucency}")', defines)
-      );
+    style.distanceDisplayCondition = 'vec4("${targetTranslucency}")';
+    expect(style.distanceDisplayCondition).toEqual(
+      new Expression('vec4("${targetTranslucency}")', defines)
+    );
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "vec4(5.0, 6.0, 7.0, 8.0)"],
-          ["true", 'vec4("${targetTranslucency}")'],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "vec4(5.0, 6.0, 7.0, 8.0)"],
+        ["true", 'vec4("${targetTranslucency}")'],
+      ],
+    };
 
-      style.distanceDisplayCondition = jsonExp;
-      expect(style.distanceDisplayCondition).toEqual(
-        new ConditionsExpression(jsonExp, defines)
-      );
-    });
+    style.distanceDisplayCondition = jsonExp;
+    expect(style.distanceDisplayCondition).toEqual(
+      new ConditionsExpression(jsonExp, defines)
+    );
   });
 
   it("sets style.distanceDisplayCondition values in setter", function () {
@@ -2787,62 +2339,45 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetTranslucency: "1.0, 2.0, 3.0, 4.",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.distanceDisplayCondition = 'vec4("${targetTranslucency}")';
-      expect(style.style.distanceDisplayCondition).toEqual(
-        'vec4("${targetTranslucency}")'
-      );
+    style.distanceDisplayCondition = 'vec4("${targetTranslucency}")';
+    expect(style.style.distanceDisplayCondition).toEqual(
+      'vec4("${targetTranslucency}")'
+    );
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "vec4(5.0, 6.0, 7.0, 8.0)"],
-          ["true", 'vec4("${targetTranslucency}")'],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "vec4(5.0, 6.0, 7.0, 8.0)"],
+        ["true", 'vec4("${targetTranslucency}")'],
+      ],
+    };
 
-      style.distanceDisplayCondition = jsonExp;
-      expect(style.style.distanceDisplayCondition).toEqual(jsonExp);
-    });
+    style.distanceDisplayCondition = jsonExp;
+    expect(style.style.distanceDisplayCondition).toEqual(jsonExp);
   });
 
   it("sets heightOffset value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.heightOffset).toBeUndefined();
+    expect(style.heightOffset).toBeUndefined();
 
-        style = new Cesium3DTileStyle();
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.heightOffset).toBeUndefined();
-      });
+    style = new Cesium3DTileStyle();
+    expect(style.heightOffset).toBeUndefined();
   });
 
   it("sets heightOffset value to expression", function () {
     let style = new Cesium3DTileStyle({
       heightOffset: "2",
     });
-    return style.readyPromise
-      .then(function () {
-        expect(style.heightOffset).toEqual(new Expression("2"));
+    expect(style.heightOffset).toEqual(new Expression("2"));
 
-        style = new Cesium3DTileStyle({
-          heightOffset: "${height} / 10",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.heightOffset).toEqual(new Expression("${height} / 10"));
+    style = new Cesium3DTileStyle({
+      heightOffset: "${height} / 10",
+    });
+    expect(style.heightOffset).toEqual(new Expression("${height} / 10"));
 
-        style = new Cesium3DTileStyle({
-          heightOffset: 2,
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.heightOffset).toEqual(new Expression("2"));
-      });
+    style = new Cesium3DTileStyle({
+      heightOffset: 2,
+    });
+    expect(style.heightOffset).toEqual(new Expression("2"));
   });
 
   it("sets heightOffset value to conditional", function () {
@@ -2856,63 +2391,57 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       heightOffset: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.heightOffset).toEqual(new ConditionsExpression(jsonExp));
-    });
+    expect(style.heightOffset).toEqual(new ConditionsExpression(jsonExp));
   });
 
   it("sets heightOffset expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.heightOffset = 2;
-      expect(style.heightOffset).toEqual(new Expression("2"));
+    style.heightOffset = 2;
+    expect(style.heightOffset).toEqual(new Expression("2"));
 
-      const exp = new Expression("2");
-      style.heightOffset = exp;
-      expect(style.heightOffset).toEqual(exp);
+    const exp = new Expression("2");
+    style.heightOffset = exp;
+    expect(style.heightOffset).toEqual(exp);
 
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", "1.0"],
-          ["true", "2.0"],
-        ],
-      });
-
-      style.heightOffset = condExp;
-      expect(style.heightOffset).toEqual(condExp);
-
-      style.heightOffset = undefined;
-      expect(style.heightOffset).toBeUndefined();
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", "1.0"],
+        ["true", "2.0"],
+      ],
     });
+
+    style.heightOffset = condExp;
+    expect(style.heightOffset).toEqual(condExp);
+
+    style.heightOffset = undefined;
+    expect(style.heightOffset).toBeUndefined();
   });
 
   it("sets style.heightOffset expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.heightOffset = new Expression("2");
-      expect(style.style.heightOffset).toEqual("2");
+    style.heightOffset = new Expression("2");
+    expect(style.style.heightOffset).toEqual("2");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1.0"],
-          ["true", "2.0"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1.0"],
+        ["true", "2.0"],
+      ],
+    };
 
-      style.heightOffset = new ConditionsExpression(jsonExp);
-      expect(style.style.heightOffset).toEqual(jsonExp);
+    style.heightOffset = new ConditionsExpression(jsonExp);
+    expect(style.style.heightOffset).toEqual(jsonExp);
 
-      const customExpression = {
-        evaluate: function () {
-          return 2;
-        },
-      };
-      style.heightOffset = customExpression;
-      expect(style.style.heightOffset).toEqual(customExpression);
+    const customExpression = {
+      evaluate: function () {
+        return 2;
+      },
+    };
+    style.heightOffset = customExpression;
+    expect(style.style.heightOffset).toEqual(customExpression);
 
-      style.heightOffset = undefined;
-      expect(style.style.heightOffset).toBeUndefined();
-    });
+    style.heightOffset = undefined;
+    expect(style.style.heightOffset).toBeUndefined();
   });
 
   it("sets heightOffset values in setter", function () {
@@ -2920,27 +2449,25 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetHeight: "2.0",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.heightOffset = 2;
-      expect(style.heightOffset).toEqual(new Expression("2"));
+    style.heightOffset = 2;
+    expect(style.heightOffset).toEqual(new Expression("2"));
 
-      style.heightOffset = "${targetHeight} + 1.0";
-      expect(style.heightOffset).toEqual(
-        new Expression("${targetHeight} + 1.0", defines)
-      );
+    style.heightOffset = "${targetHeight} + 1.0";
+    expect(style.heightOffset).toEqual(
+      new Expression("${targetHeight} + 1.0", defines)
+    );
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1.0"],
-          ["true", "${targetHeight}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1.0"],
+        ["true", "${targetHeight}"],
+      ],
+    };
 
-      style.heightOffset = jsonExp;
-      expect(style.heightOffset).toEqual(
-        new ConditionsExpression(jsonExp, defines)
-      );
-    });
+    style.heightOffset = jsonExp;
+    expect(style.heightOffset).toEqual(
+      new ConditionsExpression(jsonExp, defines)
+    );
   });
 
   it("sets style.heightOffset values in setter", function () {
@@ -2948,78 +2475,55 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetHeight: "2.0",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.heightOffset = "${targetHeight} + 1.0";
-      expect(style.style.heightOffset).toEqual("${targetHeight} + 1.0");
+    style.heightOffset = "${targetHeight} + 1.0";
+    expect(style.style.heightOffset).toEqual("${targetHeight} + 1.0");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1.0"],
-          ["true", "${targetHeight}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1.0"],
+        ["true", "${targetHeight}"],
+      ],
+    };
 
-      style.heightOffset = jsonExp;
-      expect(style.style.heightOffset).toEqual(jsonExp);
-    });
+    style.heightOffset = jsonExp;
+    expect(style.style.heightOffset).toEqual(jsonExp);
   });
 
   it("sets anchorLineEnabled value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.anchorLineEnabled).toBeUndefined();
+    expect(style.anchorLineEnabled).toBeUndefined();
 
-        style = new Cesium3DTileStyle();
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.anchorLineEnabled).toBeUndefined();
-      });
+    style = new Cesium3DTileStyle();
+    expect(style.anchorLineEnabled).toBeUndefined();
   });
 
   it("sets anchorLineEnabled value to expression", function () {
     let style = new Cesium3DTileStyle({
       anchorLineEnabled: "true",
     });
-    return style.readyPromise
-      .then(function () {
-        expect(style.anchorLineEnabled).toEqual(new Expression("true"));
+    expect(style.anchorLineEnabled).toEqual(new Expression("true"));
 
-        style = new Cesium3DTileStyle({
-          anchorLineEnabled: "false",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.anchorLineEnabled).toEqual(new Expression("false"));
+    style = new Cesium3DTileStyle({
+      anchorLineEnabled: "false",
+    });
+    expect(style.anchorLineEnabled).toEqual(new Expression("false"));
 
-        style = new Cesium3DTileStyle({
-          anchorLineEnabled: "${height} * 10 >= 1000",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.anchorLineEnabled).toEqual(
-          new Expression("${height} * 10 >= 1000")
-        );
+    style = new Cesium3DTileStyle({
+      anchorLineEnabled: "${height} * 10 >= 1000",
+    });
+    expect(style.anchorLineEnabled).toEqual(
+      new Expression("${height} * 10 >= 1000")
+    );
 
-        style = new Cesium3DTileStyle({
-          anchorLineEnabled: true,
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.anchorLineEnabled).toEqual(new Expression("true"));
+    style = new Cesium3DTileStyle({
+      anchorLineEnabled: true,
+    });
+    expect(style.anchorLineEnabled).toEqual(new Expression("true"));
 
-        style = new Cesium3DTileStyle({
-          anchorLineEnabled: false,
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.anchorLineEnabled).toEqual(new Expression("false"));
-      });
+    style = new Cesium3DTileStyle({
+      anchorLineEnabled: false,
+    });
+    expect(style.anchorLineEnabled).toEqual(new Expression("false"));
   });
 
   it("sets anchorLineEnabled value to conditional", function () {
@@ -3033,56 +2537,48 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       anchorLineEnabled: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.anchorLineEnabled).toEqual(
-        new ConditionsExpression(jsonExp)
-      );
-    });
+    expect(style.anchorLineEnabled).toEqual(new ConditionsExpression(jsonExp));
   });
 
   it("sets anchorLineEnabled expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", "false"],
-          ["true", "true"],
-        ],
-      });
-
-      style.anchorLineEnabled = condExp;
-      expect(style.anchorLineEnabled).toEqual(condExp);
-
-      const exp = new Expression("false");
-      style.anchorLineEnabled = exp;
-      expect(style.anchorLineEnabled).toEqual(exp);
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", "false"],
+        ["true", "true"],
+      ],
     });
+
+    style.anchorLineEnabled = condExp;
+    expect(style.anchorLineEnabled).toEqual(condExp);
+
+    const exp = new Expression("false");
+    style.anchorLineEnabled = exp;
+    expect(style.anchorLineEnabled).toEqual(exp);
   });
 
   it("sets style.anchorLineEnabled expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.anchorLineEnabled = new Expression("false");
-      expect(style.style.anchorLineEnabled).toEqual("false");
+    style.anchorLineEnabled = new Expression("false");
+    expect(style.style.anchorLineEnabled).toEqual("false");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "false"],
-          ["true", "true"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "false"],
+        ["true", "true"],
+      ],
+    };
 
-      style.anchorLineEnabled = new ConditionsExpression(jsonExp);
-      expect(style.style.anchorLineEnabled).toEqual(jsonExp);
+    style.anchorLineEnabled = new ConditionsExpression(jsonExp);
+    expect(style.style.anchorLineEnabled).toEqual(jsonExp);
 
-      const customExpression = {
-        evaluate: function () {
-          return true;
-        },
-      };
-      style.anchorLineEnabled = customExpression;
-      expect(style.style.anchorLineEnabled).toEqual(customExpression);
-    });
+    const customExpression = {
+      evaluate: function () {
+        return true;
+      },
+    };
+    style.anchorLineEnabled = customExpression;
+    expect(style.style.anchorLineEnabled).toEqual(customExpression);
   });
 
   it("sets anchorLineEnabled values in setter", function () {
@@ -3090,30 +2586,28 @@ describe("Scene/Cesium3DTileStyle", function () {
       anchorFactor: 10,
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.anchorLineEnabled = "${height} * ${anchorFactor} >= 1000";
-      expect(style.anchorLineEnabled).toEqual(
-        new Expression("${height} * ${anchorFactor} >= 1000", defines)
-      );
+    style.anchorLineEnabled = "${height} * ${anchorFactor} >= 1000";
+    expect(style.anchorLineEnabled).toEqual(
+      new Expression("${height} * ${anchorFactor} >= 1000", defines)
+    );
 
-      style.anchorLineEnabled = false;
-      expect(style.anchorLineEnabled).toEqual(new Expression("false"));
+    style.anchorLineEnabled = false;
+    expect(style.anchorLineEnabled).toEqual(new Expression("false"));
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > ${anchorFactor}", "false"],
-          ["true", "true"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > ${anchorFactor}", "false"],
+        ["true", "true"],
+      ],
+    };
 
-      style.anchorLineEnabled = jsonExp;
-      expect(style.anchorLineEnabled).toEqual(
-        new ConditionsExpression(jsonExp, defines)
-      );
+    style.anchorLineEnabled = jsonExp;
+    expect(style.anchorLineEnabled).toEqual(
+      new ConditionsExpression(jsonExp, defines)
+    );
 
-      style.anchorLineEnabled = undefined;
-      expect(style.anchorLineEnabled).toBeUndefined();
-    });
+    style.anchorLineEnabled = undefined;
+    expect(style.anchorLineEnabled).toBeUndefined();
   });
 
   it("sets style.anchorLineEnabled values in setter", function () {
@@ -3121,75 +2615,58 @@ describe("Scene/Cesium3DTileStyle", function () {
       anchorFactor: 10,
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.anchorLineEnabled = "${height} * ${anchorFactor} >= 1000";
-      expect(style.style.anchorLineEnabled).toEqual(
-        "${height} * ${anchorFactor} >= 1000"
-      );
+    style.anchorLineEnabled = "${height} * ${anchorFactor} >= 1000";
+    expect(style.style.anchorLineEnabled).toEqual(
+      "${height} * ${anchorFactor} >= 1000"
+    );
 
-      style.anchorLineEnabled = false;
-      expect(style.style.anchorLineEnabled).toEqual("false");
+    style.anchorLineEnabled = false;
+    expect(style.style.anchorLineEnabled).toEqual("false");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > ${anchorFactor}", "false"],
-          ["true", "true"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > ${anchorFactor}", "false"],
+        ["true", "true"],
+      ],
+    };
 
-      style.anchorLineEnabled = jsonExp;
-      expect(style.style.anchorLineEnabled).toEqual(jsonExp);
+    style.anchorLineEnabled = jsonExp;
+    expect(style.style.anchorLineEnabled).toEqual(jsonExp);
 
-      style.anchorLineEnabled = undefined;
-      expect(style.style.anchorLineEnabled).toBeUndefined();
-    });
+    style.anchorLineEnabled = undefined;
+    expect(style.style.anchorLineEnabled).toBeUndefined();
   });
 
   it("sets anchorLineColor value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.anchorLineColor).toBeUndefined();
+    expect(style.anchorLineColor).toBeUndefined();
 
-        style = new Cesium3DTileStyle();
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.anchorLineColor).toBeUndefined();
-      });
+    style = new Cesium3DTileStyle();
+    expect(style.anchorLineColor).toBeUndefined();
   });
 
   it("sets anchorLineColor value to expression", function () {
     let style = new Cesium3DTileStyle({
       anchorLineColor: 'color("red")',
     });
-    return style.readyPromise
-      .then(function () {
-        expect(style.anchorLineColor).toEqual(new Expression('color("red")'));
+    expect(style.anchorLineColor).toEqual(new Expression('color("red")'));
 
-        style = new Cesium3DTileStyle({
-          anchorLineColor: "rgba(30, 30, 30, 0.5)",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.anchorLineColor).toEqual(
-          new Expression("rgba(30, 30, 30, 0.5)")
-        );
+    style = new Cesium3DTileStyle({
+      anchorLineColor: "rgba(30, 30, 30, 0.5)",
+    });
+    expect(style.anchorLineColor).toEqual(
+      new Expression("rgba(30, 30, 30, 0.5)")
+    );
 
-        style = new Cesium3DTileStyle({
-          anchorLineColor:
-            '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")',
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.anchorLineColor).toEqual(
-          new Expression(
-            '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")'
-          )
-        );
-      });
+    style = new Cesium3DTileStyle({
+      anchorLineColor:
+        '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")',
+    });
+    expect(style.anchorLineColor).toEqual(
+      new Expression(
+        '(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")'
+      )
+    );
   });
 
   it("sets anchorLineColor value to conditional", function () {
@@ -3203,63 +2680,57 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       anchorLineColor: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.anchorLineColor).toEqual(new ConditionsExpression(jsonExp));
-    });
+    expect(style.anchorLineColor).toEqual(new ConditionsExpression(jsonExp));
   });
 
   it("sets anchorLineColor expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      const exp = new Expression('color("red")');
-      style.anchorLineColor = exp;
-      expect(style.anchorLineColor).toEqual(exp);
+    const exp = new Expression('color("red")');
+    style.anchorLineColor = exp;
+    expect(style.anchorLineColor).toEqual(exp);
 
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("blue")'],
-        ],
-      });
-
-      style.anchorLineColor = condExp;
-      expect(style.anchorLineColor).toEqual(condExp);
-
-      style.anchorLineColor = undefined;
-      expect(style.anchorLineColor).toBeUndefined();
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("blue")'],
+      ],
     });
+
+    style.anchorLineColor = condExp;
+    expect(style.anchorLineColor).toEqual(condExp);
+
+    style.anchorLineColor = undefined;
+    expect(style.anchorLineColor).toBeUndefined();
   });
 
   it("sets style.anchorLineColor expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.anchorLineColor = new Expression('color("red")');
-      expect(style.style.anchorLineColor).toEqual('color("red")');
+    style.anchorLineColor = new Expression('color("red")');
+    expect(style.style.anchorLineColor).toEqual('color("red")');
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("blue")'],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("blue")'],
+      ],
+    };
 
-      style.anchorLineColor = new ConditionsExpression(jsonExp);
-      expect(style.style.anchorLineColor).toEqual(jsonExp);
+    style.anchorLineColor = new ConditionsExpression(jsonExp);
+    expect(style.style.anchorLineColor).toEqual(jsonExp);
 
-      const customExpression = {
-        evaluate: function () {
-          return Color.RED;
-        },
-        evaluateColor: function () {
-          return Color.RED;
-        },
-      };
-      style.anchorLineColor = customExpression;
-      expect(style.style.anchorLineColor).toEqual(customExpression);
+    const customExpression = {
+      evaluate: function () {
+        return Color.RED;
+      },
+      evaluateColor: function () {
+        return Color.RED;
+      },
+    };
+    style.anchorLineColor = customExpression;
+    expect(style.style.anchorLineColor).toEqual(customExpression);
 
-      style.anchorLineColor = undefined;
-      expect(style.style.anchorLineColor).toBeUndefined();
-    });
+    style.anchorLineColor = undefined;
+    expect(style.style.anchorLineColor).toBeUndefined();
   });
 
   it("sets anchorLineColor values in setter", function () {
@@ -3267,24 +2738,22 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetColor: "red",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.anchorLineColor = 'color("${targetColor}")';
-      expect(style.anchorLineColor).toEqual(
-        new Expression('color("${targetColor}")', defines)
-      );
+    style.anchorLineColor = 'color("${targetColor}")';
+    expect(style.anchorLineColor).toEqual(
+      new Expression('color("${targetColor}")', defines)
+    );
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("${targetColor}")'],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("${targetColor}")'],
+      ],
+    };
 
-      style.anchorLineColor = jsonExp;
-      expect(style.anchorLineColor).toEqual(
-        new ConditionsExpression(jsonExp, defines)
-      );
-    });
+    style.anchorLineColor = jsonExp;
+    expect(style.anchorLineColor).toEqual(
+      new ConditionsExpression(jsonExp, defines)
+    );
   });
 
   it("sets style.anchorLineColor values in setter", function () {
@@ -3292,60 +2761,43 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetColor: "red",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.anchorLineColor = 'color("${targetColor}")';
-      expect(style.style.anchorLineColor).toEqual('color("${targetColor}")');
+    style.anchorLineColor = 'color("${targetColor}")';
+    expect(style.style.anchorLineColor).toEqual('color("${targetColor}")');
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", 'color("cyan")'],
-          ["true", 'color("${targetColor}")'],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", 'color("cyan")'],
+        ["true", 'color("${targetColor}")'],
+      ],
+    };
 
-      style.anchorLineColor = jsonExp;
-      expect(style.style.anchorLineColor).toEqual(jsonExp);
-    });
+    style.anchorLineColor = jsonExp;
+    expect(style.style.anchorLineColor).toEqual(jsonExp);
   });
 
   it("sets image value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.image).toBeUndefined();
+    expect(style.image).toBeUndefined();
 
-        style = new Cesium3DTileStyle();
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.image).toBeUndefined();
-      });
+    style = new Cesium3DTileStyle();
+    expect(style.image).toBeUndefined();
   });
 
   it("sets image value to expression", function () {
     let style = new Cesium3DTileStyle({
       image: "'url/to/image'",
     });
-    return style.readyPromise
-      .then(function () {
-        expect(style.image).toEqual(new Expression("'url/to/image'"));
+    expect(style.image).toEqual(new Expression("'url/to/image'"));
 
-        style = new Cesium3DTileStyle({
-          image: "${url}",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.image).toEqual(new Expression("${url}"));
+    style = new Cesium3DTileStyle({
+      image: "${url}",
+    });
+    expect(style.image).toEqual(new Expression("${url}"));
 
-        style = new Cesium3DTileStyle({
-          image: "'url/to/image'",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.image).toEqual(new Expression("'url/to/image'"));
-      });
+    style = new Cesium3DTileStyle({
+      image: "'url/to/image'",
+    });
+    expect(style.image).toEqual(new Expression("'url/to/image'"));
   });
 
   it("sets image value to conditional", function () {
@@ -3359,63 +2811,57 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       image: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.image).toEqual(new ConditionsExpression(jsonExp));
-    });
+    expect(style.image).toEqual(new ConditionsExpression(jsonExp));
   });
 
   it("sets image expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.image = "'url/to/image'";
-      expect(style.image).toEqual(new Expression("'url/to/image'"));
+    style.image = "'url/to/image'";
+    expect(style.image).toEqual(new Expression("'url/to/image'"));
 
-      const exp = new Expression("'url/to/image'");
-      style.image = exp;
-      expect(style.image).toEqual(exp);
+    const exp = new Expression("'url/to/image'");
+    style.image = exp;
+    expect(style.image).toEqual(exp);
 
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", "'url/to/image1'"],
-          ["true", "'url/to/image2'"],
-        ],
-      });
-
-      style.image = condExp;
-      expect(style.image).toEqual(condExp);
-
-      style.image = undefined;
-      expect(style.image).toBeUndefined();
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", "'url/to/image1'"],
+        ["true", "'url/to/image2'"],
+      ],
     });
+
+    style.image = condExp;
+    expect(style.image).toEqual(condExp);
+
+    style.image = undefined;
+    expect(style.image).toBeUndefined();
   });
 
   it("sets style.image expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.image = new Expression("'url/to/image'");
-      expect(style.style.image).toEqual("'url/to/image'");
+    style.image = new Expression("'url/to/image'");
+    expect(style.style.image).toEqual("'url/to/image'");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "'url/to/image1'"],
-          ["true", "'url/to/image2'"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "'url/to/image1'"],
+        ["true", "'url/to/image2'"],
+      ],
+    };
 
-      style.image = new ConditionsExpression(jsonExp);
-      expect(style.style.image).toEqual(jsonExp);
+    style.image = new ConditionsExpression(jsonExp);
+    expect(style.style.image).toEqual(jsonExp);
 
-      const customExpression = {
-        evaluate: function () {
-          return "'url/to/image1'";
-        },
-      };
-      style.image = customExpression;
-      expect(style.style.image).toEqual(customExpression);
+    const customExpression = {
+      evaluate: function () {
+        return "'url/to/image1'";
+      },
+    };
+    style.image = customExpression;
+    expect(style.style.image).toEqual(customExpression);
 
-      style.image = undefined;
-      expect(style.style.image).toBeUndefined();
-    });
+    style.image = undefined;
+    expect(style.style.image).toBeUndefined();
   });
 
   it("sets image values in setter", function () {
@@ -3423,23 +2869,21 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetUrl: "'url/to/image1'",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.image = "'url/to/image'";
-      expect(style.image).toEqual(new Expression("'url/to/image'"));
+    style.image = "'url/to/image'";
+    expect(style.image).toEqual(new Expression("'url/to/image'"));
 
-      style.image = "${targetUrl}";
-      expect(style.image).toEqual(new Expression("${targetUrl}", defines));
+    style.image = "${targetUrl}";
+    expect(style.image).toEqual(new Expression("${targetUrl}", defines));
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "'url/to/image2'"],
-          ["true", "${targetUrl}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "'url/to/image2'"],
+        ["true", "${targetUrl}"],
+      ],
+    };
 
-      style.image = jsonExp;
-      expect(style.image).toEqual(new ConditionsExpression(jsonExp, defines));
-    });
+    style.image = jsonExp;
+    expect(style.image).toEqual(new ConditionsExpression(jsonExp, defines));
   });
 
   it("sets style.image values in setter", function () {
@@ -3447,65 +2891,48 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetUrl: "'url/to/image1'",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.image = "'url/to/image'";
-      expect(style.style.image).toEqual("'url/to/image'");
+    style.image = "'url/to/image'";
+    expect(style.style.image).toEqual("'url/to/image'");
 
-      style.image = "${targetUrl}";
-      expect(style.style.image).toEqual("${targetUrl}");
+    style.image = "${targetUrl}";
+    expect(style.style.image).toEqual("${targetUrl}");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "'url/to/image2'"],
-          ["true", "${targetUrl}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "'url/to/image2'"],
+        ["true", "${targetUrl}"],
+      ],
+    };
 
-      style.image = jsonExp;
-      expect(style.style.image).toEqual(jsonExp);
-    });
+    style.image = jsonExp;
+    expect(style.style.image).toEqual(jsonExp);
   });
 
   it("sets disableDepthTestDistance value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.disableDepthTestDistance).toBeUndefined();
+    expect(style.disableDepthTestDistance).toBeUndefined();
 
-        style = new Cesium3DTileStyle();
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.disableDepthTestDistance).toBeUndefined();
-      });
+    style = new Cesium3DTileStyle();
+    expect(style.disableDepthTestDistance).toBeUndefined();
   });
 
   it("sets disableDepthTestDistance value to expression", function () {
     let style = new Cesium3DTileStyle({
       disableDepthTestDistance: "2",
     });
-    return style.readyPromise
-      .then(function () {
-        expect(style.disableDepthTestDistance).toEqual(new Expression("2"));
+    expect(style.disableDepthTestDistance).toEqual(new Expression("2"));
 
-        style = new Cesium3DTileStyle({
-          disableDepthTestDistance: "${height} / 10",
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.disableDepthTestDistance).toEqual(
-          new Expression("${height} / 10")
-        );
+    style = new Cesium3DTileStyle({
+      disableDepthTestDistance: "${height} / 10",
+    });
+    expect(style.disableDepthTestDistance).toEqual(
+      new Expression("${height} / 10")
+    );
 
-        style = new Cesium3DTileStyle({
-          disableDepthTestDistance: 2,
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.disableDepthTestDistance).toEqual(new Expression("2"));
-      });
+    style = new Cesium3DTileStyle({
+      disableDepthTestDistance: 2,
+    });
+    expect(style.disableDepthTestDistance).toEqual(new Expression("2"));
   });
 
   it("sets disableDepthTestDistance value to conditional", function () {
@@ -3519,65 +2946,59 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       disableDepthTestDistance: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.disableDepthTestDistance).toEqual(
-        new ConditionsExpression(jsonExp)
-      );
-    });
+    expect(style.disableDepthTestDistance).toEqual(
+      new ConditionsExpression(jsonExp)
+    );
   });
 
   it("sets disableDepthTestDistance expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.disableDepthTestDistance = 2;
-      expect(style.disableDepthTestDistance).toEqual(new Expression("2"));
+    style.disableDepthTestDistance = 2;
+    expect(style.disableDepthTestDistance).toEqual(new Expression("2"));
 
-      const exp = new Expression("2");
-      style.disableDepthTestDistance = exp;
-      expect(style.disableDepthTestDistance).toEqual(exp);
+    const exp = new Expression("2");
+    style.disableDepthTestDistance = exp;
+    expect(style.disableDepthTestDistance).toEqual(exp);
 
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", "1.0"],
-          ["true", "2.0"],
-        ],
-      });
-
-      style.disableDepthTestDistance = condExp;
-      expect(style.disableDepthTestDistance).toEqual(condExp);
-
-      style.disableDepthTestDistance = undefined;
-      expect(style.disableDepthTestDistance).toBeUndefined();
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", "1.0"],
+        ["true", "2.0"],
+      ],
     });
+
+    style.disableDepthTestDistance = condExp;
+    expect(style.disableDepthTestDistance).toEqual(condExp);
+
+    style.disableDepthTestDistance = undefined;
+    expect(style.disableDepthTestDistance).toBeUndefined();
   });
 
   it("sets style.disableDepthTestDistance expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.disableDepthTestDistance = new Expression("2");
-      expect(style.style.disableDepthTestDistance).toEqual("2");
+    style.disableDepthTestDistance = new Expression("2");
+    expect(style.style.disableDepthTestDistance).toEqual("2");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1.0"],
-          ["true", "2.0"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1.0"],
+        ["true", "2.0"],
+      ],
+    };
 
-      style.disableDepthTestDistance = new ConditionsExpression(jsonExp);
-      expect(style.style.disableDepthTestDistance).toEqual(jsonExp);
+    style.disableDepthTestDistance = new ConditionsExpression(jsonExp);
+    expect(style.style.disableDepthTestDistance).toEqual(jsonExp);
 
-      const customExpression = {
-        evaluate: function () {
-          return 1.0;
-        },
-      };
-      style.disableDepthTestDistance = customExpression;
-      expect(style.style.disableDepthTestDistance).toEqual(customExpression);
+    const customExpression = {
+      evaluate: function () {
+        return 1.0;
+      },
+    };
+    style.disableDepthTestDistance = customExpression;
+    expect(style.style.disableDepthTestDistance).toEqual(customExpression);
 
-      style.disableDepthTestDistance = undefined;
-      expect(style.style.disableDepthTestDistance).toBeUndefined();
-    });
+    style.disableDepthTestDistance = undefined;
+    expect(style.style.disableDepthTestDistance).toBeUndefined();
   });
 
   it("sets disableDepthTestDistance values in setter", function () {
@@ -3585,49 +3006,40 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetDistance: "2.0",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.disableDepthTestDistance = 2;
-      expect(style.disableDepthTestDistance).toEqual(new Expression("2"));
+    style.disableDepthTestDistance = 2;
+    expect(style.disableDepthTestDistance).toEqual(new Expression("2"));
 
-      style.disableDepthTestDistance = "${targetDistance} + 1.0";
-      expect(style.disableDepthTestDistance).toEqual(
-        new Expression("${targetDistance} + 1.0", defines)
-      );
+    style.disableDepthTestDistance = "${targetDistance} + 1.0";
+    expect(style.disableDepthTestDistance).toEqual(
+      new Expression("${targetDistance} + 1.0", defines)
+    );
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1.0"],
-          ["true", "${targetDistance}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1.0"],
+        ["true", "${targetDistance}"],
+      ],
+    };
 
-      style.disableDepthTestDistance = jsonExp;
-      expect(style.disableDepthTestDistance).toEqual(
-        new ConditionsExpression(jsonExp, defines)
-      );
-    });
+    style.disableDepthTestDistance = jsonExp;
+    expect(style.disableDepthTestDistance).toEqual(
+      new ConditionsExpression(jsonExp, defines)
+    );
   });
 
   it("sets horizontalOrigin value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.horizontalOrigin).toBeUndefined();
+    expect(style.horizontalOrigin).toBeUndefined();
 
-        style = new Cesium3DTileStyle();
-      })
-      .then(function () {
-        expect(style.horizontalOrigin).toBeUndefined();
-      });
+    style = new Cesium3DTileStyle();
+    expect(style.horizontalOrigin).toBeUndefined();
   });
 
   it("sets horizontalOrigin value to expression", function () {
     const style = new Cesium3DTileStyle({
       horizontalOrigin: "1",
     });
-    return style.readyPromise.then(function () {
-      expect(style.horizontalOrigin).toEqual(new Expression("1"));
-    });
+    expect(style.horizontalOrigin).toEqual(new Expression("1"));
   });
 
   it("sets horizontalOrigin value to conditional", function () {
@@ -3641,63 +3053,57 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       horizontalOrigin: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.horizontalOrigin).toEqual(new ConditionsExpression(jsonExp));
-    });
+    expect(style.horizontalOrigin).toEqual(new ConditionsExpression(jsonExp));
   });
 
   it("sets horizontalOrigin expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.horizontalOrigin = 1;
-      expect(style.horizontalOrigin).toEqual(new Expression("1"));
+    style.horizontalOrigin = 1;
+    expect(style.horizontalOrigin).toEqual(new Expression("1"));
 
-      const exp = new Expression("1");
-      style.horizontalOrigin = exp;
-      expect(style.horizontalOrigin).toEqual(exp);
+    const exp = new Expression("1");
+    style.horizontalOrigin = exp;
+    expect(style.horizontalOrigin).toEqual(exp);
 
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", "1"],
-          ["true", "-1"],
-        ],
-      });
-
-      style.horizontalOrigin = condExp;
-      expect(style.horizontalOrigin).toEqual(condExp);
-
-      style.horizontalOrigin = undefined;
-      expect(style.horizontalOrigin).toBeUndefined();
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", "1"],
+        ["true", "-1"],
+      ],
     });
+
+    style.horizontalOrigin = condExp;
+    expect(style.horizontalOrigin).toEqual(condExp);
+
+    style.horizontalOrigin = undefined;
+    expect(style.horizontalOrigin).toBeUndefined();
   });
 
   it("sets style.horizontalOrigin expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.horizontalOrigin = new Expression("1");
-      expect(style.style.horizontalOrigin).toEqual("1");
+    style.horizontalOrigin = new Expression("1");
+    expect(style.style.horizontalOrigin).toEqual("1");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1"],
-          ["true", "-1"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1"],
+        ["true", "-1"],
+      ],
+    };
 
-      style.horizontalOrigin = new ConditionsExpression(jsonExp);
-      expect(style.style.horizontalOrigin).toEqual(jsonExp);
+    style.horizontalOrigin = new ConditionsExpression(jsonExp);
+    expect(style.style.horizontalOrigin).toEqual(jsonExp);
 
-      const customExpression = {
-        evaluate: function () {
-          return 1;
-        },
-      };
-      style.horizontalOrigin = customExpression;
-      expect(style.style.horizontalOrigin).toEqual(customExpression);
+    const customExpression = {
+      evaluate: function () {
+        return 1;
+      },
+    };
+    style.horizontalOrigin = customExpression;
+    expect(style.style.horizontalOrigin).toEqual(customExpression);
 
-      style.horizontalOrigin = undefined;
-      expect(style.style.horizontalOrigin).toBeUndefined();
-    });
+    style.horizontalOrigin = undefined;
+    expect(style.style.horizontalOrigin).toBeUndefined();
   });
 
   it("sets horizontalOrigin values in setter", function () {
@@ -3705,27 +3111,25 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetOrigin: "-1",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.horizontalOrigin = -1;
-      expect(style.horizontalOrigin).toEqual(new Expression("-1"));
+    style.horizontalOrigin = -1;
+    expect(style.horizontalOrigin).toEqual(new Expression("-1"));
 
-      style.horizontalOrigin = "${targetOrigin}";
-      expect(style.horizontalOrigin).toEqual(
-        new Expression("${targetOrigin}", defines)
-      );
+    style.horizontalOrigin = "${targetOrigin}";
+    expect(style.horizontalOrigin).toEqual(
+      new Expression("${targetOrigin}", defines)
+    );
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1"],
-          ["true", "${targetOrigin}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1"],
+        ["true", "${targetOrigin}"],
+      ],
+    };
 
-      style.horizontalOrigin = jsonExp;
-      expect(style.horizontalOrigin).toEqual(
-        new ConditionsExpression(jsonExp, defines)
-      );
-    });
+    style.horizontalOrigin = jsonExp;
+    expect(style.horizontalOrigin).toEqual(
+      new ConditionsExpression(jsonExp, defines)
+    );
   });
 
   it("sets style.horizontalOrigin values in setter", function () {
@@ -3733,45 +3137,35 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetOrigin: "-1",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.horizontalOrigin = -1;
-      expect(style.style.horizontalOrigin).toEqual("-1");
+    style.horizontalOrigin = -1;
+    expect(style.style.horizontalOrigin).toEqual("-1");
 
-      style.horizontalOrigin = "${targetOrigin}";
-      expect(style.style.horizontalOrigin).toEqual("${targetOrigin}");
+    style.horizontalOrigin = "${targetOrigin}";
+    expect(style.style.horizontalOrigin).toEqual("${targetOrigin}");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1"],
-          ["true", "${targetOrigin}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1"],
+        ["true", "${targetOrigin}"],
+      ],
+    };
 
-      style.horizontalOrigin = jsonExp;
-      expect(style.style.horizontalOrigin).toEqual(jsonExp);
-    });
+    style.horizontalOrigin = jsonExp;
+    expect(style.style.horizontalOrigin).toEqual(jsonExp);
   });
 
   it("sets verticalOrigin value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.verticalOrigin).toBeUndefined();
-        style = new Cesium3DTileStyle();
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.verticalOrigin).toBeUndefined();
-      });
+    expect(style.verticalOrigin).toBeUndefined();
+    style = new Cesium3DTileStyle();
+    expect(style.verticalOrigin).toBeUndefined();
   });
 
   it("sets verticalOrigin value to expression", function () {
     const style = new Cesium3DTileStyle({
       verticalOrigin: "1",
     });
-    return style.readyPromise.then(function () {
-      expect(style.verticalOrigin).toEqual(new Expression("1"));
-    });
+    expect(style.verticalOrigin).toEqual(new Expression("1"));
   });
 
   it("sets verticalOrigin value to conditional", function () {
@@ -3785,63 +3179,57 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       verticalOrigin: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.verticalOrigin).toEqual(new ConditionsExpression(jsonExp));
-    });
+    expect(style.verticalOrigin).toEqual(new ConditionsExpression(jsonExp));
   });
 
   it("sets verticalOrigin expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.verticalOrigin = 1;
-      expect(style.verticalOrigin).toEqual(new Expression("1"));
+    style.verticalOrigin = 1;
+    expect(style.verticalOrigin).toEqual(new Expression("1"));
 
-      const exp = new Expression("1");
-      style.verticalOrigin = exp;
-      expect(style.verticalOrigin).toEqual(exp);
+    const exp = new Expression("1");
+    style.verticalOrigin = exp;
+    expect(style.verticalOrigin).toEqual(exp);
 
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", "1"],
-          ["true", "-1"],
-        ],
-      });
-
-      style.verticalOrigin = condExp;
-      expect(style.verticalOrigin).toEqual(condExp);
-
-      style.verticalOrigin = undefined;
-      expect(style.verticalOrigin).toBeUndefined();
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", "1"],
+        ["true", "-1"],
+      ],
     });
+
+    style.verticalOrigin = condExp;
+    expect(style.verticalOrigin).toEqual(condExp);
+
+    style.verticalOrigin = undefined;
+    expect(style.verticalOrigin).toBeUndefined();
   });
 
   it("sets style.verticalOrigin expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.verticalOrigin = new Expression("1");
-      expect(style.style.verticalOrigin).toEqual("1");
+    style.verticalOrigin = new Expression("1");
+    expect(style.style.verticalOrigin).toEqual("1");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1"],
-          ["true", "-1"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1"],
+        ["true", "-1"],
+      ],
+    };
 
-      style.verticalOrigin = new ConditionsExpression(jsonExp);
-      expect(style.style.verticalOrigin).toEqual(jsonExp);
+    style.verticalOrigin = new ConditionsExpression(jsonExp);
+    expect(style.style.verticalOrigin).toEqual(jsonExp);
 
-      const customExpression = {
-        evaluate: function () {
-          return 1;
-        },
-      };
-      style.verticalOrigin = customExpression;
-      expect(style.style.verticalOrigin).toEqual(customExpression);
+    const customExpression = {
+      evaluate: function () {
+        return 1;
+      },
+    };
+    style.verticalOrigin = customExpression;
+    expect(style.style.verticalOrigin).toEqual(customExpression);
 
-      style.verticalOrigin = undefined;
-      expect(style.style.verticalOrigin).toBeUndefined();
-    });
+    style.verticalOrigin = undefined;
+    expect(style.style.verticalOrigin).toBeUndefined();
   });
 
   it("sets verticalOrigin values in setter", function () {
@@ -3849,27 +3237,25 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetOrigin: "-1",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.verticalOrigin = -1;
-      expect(style.verticalOrigin).toEqual(new Expression("-1"));
+    style.verticalOrigin = -1;
+    expect(style.verticalOrigin).toEqual(new Expression("-1"));
 
-      style.verticalOrigin = "${targetOrigin}";
-      expect(style.verticalOrigin).toEqual(
-        new Expression("${targetOrigin}", defines)
-      );
+    style.verticalOrigin = "${targetOrigin}";
+    expect(style.verticalOrigin).toEqual(
+      new Expression("${targetOrigin}", defines)
+    );
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1"],
-          ["true", "${targetOrigin}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1"],
+        ["true", "${targetOrigin}"],
+      ],
+    };
 
-      style.verticalOrigin = jsonExp;
-      expect(style.verticalOrigin).toEqual(
-        new ConditionsExpression(jsonExp, defines)
-      );
-    });
+    style.verticalOrigin = jsonExp;
+    expect(style.verticalOrigin).toEqual(
+      new ConditionsExpression(jsonExp, defines)
+    );
   });
 
   it("sets style.verticalOrigin values in setter", function () {
@@ -3877,45 +3263,35 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetOrigin: "-1",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.verticalOrigin = -1;
-      expect(style.style.verticalOrigin).toEqual("-1");
+    style.verticalOrigin = -1;
+    expect(style.style.verticalOrigin).toEqual("-1");
 
-      style.verticalOrigin = "${targetOrigin}";
-      expect(style.style.verticalOrigin).toEqual("${targetOrigin}");
+    style.verticalOrigin = "${targetOrigin}";
+    expect(style.style.verticalOrigin).toEqual("${targetOrigin}");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1"],
-          ["true", "${targetOrigin}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1"],
+        ["true", "${targetOrigin}"],
+      ],
+    };
 
-      style.verticalOrigin = jsonExp;
-      expect(style.style.verticalOrigin).toEqual(jsonExp);
-    });
+    style.verticalOrigin = jsonExp;
+    expect(style.style.verticalOrigin).toEqual(jsonExp);
   });
 
   it("sets labelHorizontalOrigin value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.labelHorizontalOrigin).toBeUndefined();
-        style = new Cesium3DTileStyle();
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.labelHorizontalOrigin).toBeUndefined();
-      });
+    expect(style.labelHorizontalOrigin).toBeUndefined();
+    style = new Cesium3DTileStyle();
+    expect(style.labelHorizontalOrigin).toBeUndefined();
   });
 
   it("sets labelHorizontalOrigin value to expression", function () {
     const style = new Cesium3DTileStyle({
       labelHorizontalOrigin: "1",
     });
-    return style.readyPromise.then(function () {
-      expect(style.labelHorizontalOrigin).toEqual(new Expression("1"));
-    });
+    expect(style.labelHorizontalOrigin).toEqual(new Expression("1"));
   });
 
   it("sets labelHorizontalOrigin value to conditional", function () {
@@ -3929,65 +3305,59 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       labelHorizontalOrigin: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.labelHorizontalOrigin).toEqual(
-        new ConditionsExpression(jsonExp)
-      );
-    });
+    expect(style.labelHorizontalOrigin).toEqual(
+      new ConditionsExpression(jsonExp)
+    );
   });
 
   it("sets labelHorizontalOrigin expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.labelHorizontalOrigin = 1;
-      expect(style.labelHorizontalOrigin).toEqual(new Expression("1"));
+    style.labelHorizontalOrigin = 1;
+    expect(style.labelHorizontalOrigin).toEqual(new Expression("1"));
 
-      const exp = new Expression("1");
-      style.labelHorizontalOrigin = exp;
-      expect(style.labelHorizontalOrigin).toEqual(exp);
+    const exp = new Expression("1");
+    style.labelHorizontalOrigin = exp;
+    expect(style.labelHorizontalOrigin).toEqual(exp);
 
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", "1"],
-          ["true", "-1"],
-        ],
-      });
-
-      style.labelHorizontalOrigin = condExp;
-      expect(style.labelHorizontalOrigin).toEqual(condExp);
-
-      style.labelHorizontalOrigin = undefined;
-      expect(style.labelHorizontalOrigin).toBeUndefined();
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", "1"],
+        ["true", "-1"],
+      ],
     });
+
+    style.labelHorizontalOrigin = condExp;
+    expect(style.labelHorizontalOrigin).toEqual(condExp);
+
+    style.labelHorizontalOrigin = undefined;
+    expect(style.labelHorizontalOrigin).toBeUndefined();
   });
 
   it("sets style.labelHorizontalOrigin expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.labelHorizontalOrigin = new Expression("1");
-      expect(style.style.labelHorizontalOrigin).toEqual("1");
+    style.labelHorizontalOrigin = new Expression("1");
+    expect(style.style.labelHorizontalOrigin).toEqual("1");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1"],
-          ["true", "-1"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1"],
+        ["true", "-1"],
+      ],
+    };
 
-      style.labelHorizontalOrigin = new ConditionsExpression(jsonExp);
-      expect(style.style.labelHorizontalOrigin).toEqual(jsonExp);
+    style.labelHorizontalOrigin = new ConditionsExpression(jsonExp);
+    expect(style.style.labelHorizontalOrigin).toEqual(jsonExp);
 
-      const customExpression = {
-        evaluate: function () {
-          return 1;
-        },
-      };
-      style.labelHorizontalOrigin = customExpression;
-      expect(style.style.labelHorizontalOrigin).toEqual(customExpression);
+    const customExpression = {
+      evaluate: function () {
+        return 1;
+      },
+    };
+    style.labelHorizontalOrigin = customExpression;
+    expect(style.style.labelHorizontalOrigin).toEqual(customExpression);
 
-      style.labelHorizontalOrigin = undefined;
-      expect(style.style.labelHorizontalOrigin).toBeUndefined();
-    });
+    style.labelHorizontalOrigin = undefined;
+    expect(style.style.labelHorizontalOrigin).toBeUndefined();
   });
 
   it("sets labelHorizontalOrigin values in setter", function () {
@@ -3995,27 +3365,25 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetOrigin: "-1",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.labelHorizontalOrigin = -1;
-      expect(style.labelHorizontalOrigin).toEqual(new Expression("-1"));
+    style.labelHorizontalOrigin = -1;
+    expect(style.labelHorizontalOrigin).toEqual(new Expression("-1"));
 
-      style.labelHorizontalOrigin = "${targetOrigin}";
-      expect(style.labelHorizontalOrigin).toEqual(
-        new Expression("${targetOrigin}", defines)
-      );
+    style.labelHorizontalOrigin = "${targetOrigin}";
+    expect(style.labelHorizontalOrigin).toEqual(
+      new Expression("${targetOrigin}", defines)
+    );
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1"],
-          ["true", "${targetOrigin}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1"],
+        ["true", "${targetOrigin}"],
+      ],
+    };
 
-      style.labelHorizontalOrigin = jsonExp;
-      expect(style.labelHorizontalOrigin).toEqual(
-        new ConditionsExpression(jsonExp, defines)
-      );
-    });
+    style.labelHorizontalOrigin = jsonExp;
+    expect(style.labelHorizontalOrigin).toEqual(
+      new ConditionsExpression(jsonExp, defines)
+    );
   });
 
   it("sets style.labelHorizontalOrigin values in setter", function () {
@@ -4023,45 +3391,35 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetOrigin: "-1",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.labelHorizontalOrigin = -1;
-      expect(style.style.labelHorizontalOrigin).toEqual("-1");
+    style.labelHorizontalOrigin = -1;
+    expect(style.style.labelHorizontalOrigin).toEqual("-1");
 
-      style.labelHorizontalOrigin = "${targetOrigin}";
-      expect(style.style.labelHorizontalOrigin).toEqual("${targetOrigin}");
+    style.labelHorizontalOrigin = "${targetOrigin}";
+    expect(style.style.labelHorizontalOrigin).toEqual("${targetOrigin}");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1"],
-          ["true", "${targetOrigin}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1"],
+        ["true", "${targetOrigin}"],
+      ],
+    };
 
-      style.labelHorizontalOrigin = jsonExp;
-      expect(style.style.labelHorizontalOrigin).toEqual(jsonExp);
-    });
+    style.labelHorizontalOrigin = jsonExp;
+    expect(style.style.labelHorizontalOrigin).toEqual(jsonExp);
   });
 
   it("sets labelVerticalOrigin value to undefined if value not present", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.labelVerticalOrigin).toBeUndefined();
-        style = new Cesium3DTileStyle();
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.labelVerticalOrigin).toBeUndefined();
-      });
+    expect(style.labelVerticalOrigin).toBeUndefined();
+    style = new Cesium3DTileStyle();
+    expect(style.labelVerticalOrigin).toBeUndefined();
   });
 
   it("sets labelVerticalOrigin value to expression", function () {
     const style = new Cesium3DTileStyle({
       labelVerticalOrigin: "1",
     });
-    return style.readyPromise.then(function () {
-      expect(style.labelVerticalOrigin).toEqual(new Expression("1"));
-    });
+    expect(style.labelVerticalOrigin).toEqual(new Expression("1"));
   });
 
   it("sets labelVerticalOrigin value to conditional", function () {
@@ -4075,65 +3433,59 @@ describe("Scene/Cesium3DTileStyle", function () {
     const style = new Cesium3DTileStyle({
       labelVerticalOrigin: jsonExp,
     });
-    return style.readyPromise.then(function () {
-      expect(style.labelVerticalOrigin).toEqual(
-        new ConditionsExpression(jsonExp)
-      );
-    });
+    expect(style.labelVerticalOrigin).toEqual(
+      new ConditionsExpression(jsonExp)
+    );
   });
 
   it("sets labelVerticalOrigin expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.labelVerticalOrigin = 1;
-      expect(style.labelVerticalOrigin).toEqual(new Expression("1"));
+    style.labelVerticalOrigin = 1;
+    expect(style.labelVerticalOrigin).toEqual(new Expression("1"));
 
-      const exp = new Expression("1");
-      style.labelVerticalOrigin = exp;
-      expect(style.labelVerticalOrigin).toEqual(exp);
+    const exp = new Expression("1");
+    style.labelVerticalOrigin = exp;
+    expect(style.labelVerticalOrigin).toEqual(exp);
 
-      const condExp = new ConditionsExpression({
-        conditions: [
-          ["${height} > 2", "1"],
-          ["true", "-1"],
-        ],
-      });
-
-      style.labelVerticalOrigin = condExp;
-      expect(style.labelVerticalOrigin).toEqual(condExp);
-
-      style.labelVerticalOrigin = undefined;
-      expect(style.labelVerticalOrigin).toBeUndefined();
+    const condExp = new ConditionsExpression({
+      conditions: [
+        ["${height} > 2", "1"],
+        ["true", "-1"],
+      ],
     });
+
+    style.labelVerticalOrigin = condExp;
+    expect(style.labelVerticalOrigin).toEqual(condExp);
+
+    style.labelVerticalOrigin = undefined;
+    expect(style.labelVerticalOrigin).toBeUndefined();
   });
 
   it("sets style.labelVerticalOrigin expressions in setter", function () {
     const style = new Cesium3DTileStyle();
-    return style.readyPromise.then(function () {
-      style.labelVerticalOrigin = new Expression("1");
-      expect(style.style.labelVerticalOrigin).toEqual("1");
+    style.labelVerticalOrigin = new Expression("1");
+    expect(style.style.labelVerticalOrigin).toEqual("1");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1"],
-          ["true", "-1"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1"],
+        ["true", "-1"],
+      ],
+    };
 
-      style.labelVerticalOrigin = new ConditionsExpression(jsonExp);
-      expect(style.style.labelVerticalOrigin).toEqual(jsonExp);
+    style.labelVerticalOrigin = new ConditionsExpression(jsonExp);
+    expect(style.style.labelVerticalOrigin).toEqual(jsonExp);
 
-      const customExpression = {
-        evaluate: function () {
-          return 1;
-        },
-      };
-      style.labelVerticalOrigin = customExpression;
-      expect(style.style.labelVerticalOrigin).toEqual(customExpression);
+    const customExpression = {
+      evaluate: function () {
+        return 1;
+      },
+    };
+    style.labelVerticalOrigin = customExpression;
+    expect(style.style.labelVerticalOrigin).toEqual(customExpression);
 
-      style.labelVerticalOrigin = undefined;
-      expect(style.style.labelVerticalOrigin).toBeUndefined();
-    });
+    style.labelVerticalOrigin = undefined;
+    expect(style.style.labelVerticalOrigin).toBeUndefined();
   });
 
   it("sets labelVerticalOrigin values in setter", function () {
@@ -4142,27 +3494,25 @@ describe("Scene/Cesium3DTileStyle", function () {
     };
     const style = new Cesium3DTileStyle({ defines: defines });
 
-    return style.readyPromise.then(function () {
-      style.labelVerticalOrigin = -1;
-      expect(style.labelVerticalOrigin).toEqual(new Expression("-1"));
+    style.labelVerticalOrigin = -1;
+    expect(style.labelVerticalOrigin).toEqual(new Expression("-1"));
 
-      style.labelVerticalOrigin = "${targetOrigin}";
-      expect(style.labelVerticalOrigin).toEqual(
-        new Expression("${targetOrigin}", defines)
-      );
+    style.labelVerticalOrigin = "${targetOrigin}";
+    expect(style.labelVerticalOrigin).toEqual(
+      new Expression("${targetOrigin}", defines)
+    );
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1"],
-          ["true", "${targetOrigin}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1"],
+        ["true", "${targetOrigin}"],
+      ],
+    };
 
-      style.labelVerticalOrigin = jsonExp;
-      expect(style.labelVerticalOrigin).toEqual(
-        new ConditionsExpression(jsonExp, defines)
-      );
-    });
+    style.labelVerticalOrigin = jsonExp;
+    expect(style.labelVerticalOrigin).toEqual(
+      new ConditionsExpression(jsonExp, defines)
+    );
   });
 
   it("sets style.labelVerticalOrigin values in setter", function () {
@@ -4170,23 +3520,21 @@ describe("Scene/Cesium3DTileStyle", function () {
       targetOrigin: "-1",
     };
     const style = new Cesium3DTileStyle({ defines: defines });
-    return style.readyPromise.then(function () {
-      style.labelVerticalOrigin = -1;
-      expect(style.style.labelVerticalOrigin).toEqual("-1");
+    style.labelVerticalOrigin = -1;
+    expect(style.style.labelVerticalOrigin).toEqual("-1");
 
-      style.labelVerticalOrigin = "${targetOrigin}";
-      expect(style.style.labelVerticalOrigin).toEqual("${targetOrigin}");
+    style.labelVerticalOrigin = "${targetOrigin}";
+    expect(style.style.labelVerticalOrigin).toEqual("${targetOrigin}");
 
-      const jsonExp = {
-        conditions: [
-          ["${height} > 2", "1"],
-          ["true", "${targetOrigin}"],
-        ],
-      };
+    const jsonExp = {
+      conditions: [
+        ["${height} > 2", "1"],
+        ["true", "${targetOrigin}"],
+      ],
+    };
 
-      style.labelVerticalOrigin = jsonExp;
-      expect(style.style.labelVerticalOrigin).toEqual(jsonExp);
-    });
+    style.labelVerticalOrigin = jsonExp;
+    expect(style.style.labelVerticalOrigin).toEqual(jsonExp);
   });
 
   it("throws on accessing style if not ready", function () {
@@ -4438,42 +3786,28 @@ describe("Scene/Cesium3DTileStyle", function () {
         description: '"Hello, ${name}"',
       },
     });
-    return style.readyPromise
-      .then(function () {
-        expect(style.meta.description.evaluate(feature1)).toEqual(
-          "Hello, Hello"
-        );
+    expect(style.meta.description.evaluate(feature1)).toEqual("Hello, Hello");
 
-        style = new Cesium3DTileStyle({
-          meta: {
-            featureColor: "rgb(${red}, ${green}, ${blue})",
-            volume: "${Height} * ${Width} * ${Depth}",
-          },
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.meta.featureColor.evaluateColor(feature1)).toEqual(
-          Color.fromBytes(38, 255, 82)
-        );
-        expect(style.meta.volume.evaluate(feature1)).toEqual(20 * 20 * 100);
-      });
+    style = new Cesium3DTileStyle({
+      meta: {
+        featureColor: "rgb(${red}, ${green}, ${blue})",
+        volume: "${Height} * ${Width} * ${Depth}",
+      },
+    });
+    expect(style.meta.featureColor.evaluateColor(feature1)).toEqual(
+      Color.fromBytes(38, 255, 82)
+    );
+    expect(style.meta.volume.evaluate(feature1)).toEqual(20 * 20 * 100);
   });
 
   it("default meta has no properties", function () {
     let style = new Cesium3DTileStyle({});
-    return style.readyPromise
-      .then(function () {
-        expect(style.meta).toEqual({});
+    expect(style.meta).toEqual({});
 
-        style = new Cesium3DTileStyle({
-          meta: {},
-        });
-        return style.readyPromise;
-      })
-      .then(function () {
-        expect(style.meta).toEqual({});
-      });
+    style = new Cesium3DTileStyle({
+      meta: {},
+    });
+    expect(style.meta).toEqual({});
   });
 
   it("throws on accessing meta if not ready", function () {
@@ -4494,11 +3828,9 @@ describe("Scene/Cesium3DTileStyle", function () {
       pointSize: "1.0",
     });
 
-    return style.readyPromise.then(function () {
-      expect(style.show.evaluate(undefined)).toEqual(true);
-      expect(style.color.evaluateColor(undefined)).toEqual(Color.WHITE);
-      expect(style.pointSize.evaluate(undefined)).toEqual(1.0);
-    });
+    expect(style.show.evaluate(undefined)).toEqual(true);
+    expect(style.color.evaluateColor(undefined)).toEqual(Color.WHITE);
+    expect(style.pointSize.evaluate(undefined)).toEqual(1.0);
   });
 
   it("applies show style with variable", function () {
@@ -4506,10 +3838,8 @@ describe("Scene/Cesium3DTileStyle", function () {
       show: "${ZipCode} === '19341'",
     });
 
-    return style.readyPromise.then(function () {
-      expect(style.show.evaluate(feature1)).toEqual(true);
-      expect(style.show.evaluate(feature2)).toEqual(false);
-    });
+    expect(style.show.evaluate(feature1)).toEqual(true);
+    expect(style.show.evaluate(feature2)).toEqual(false);
   });
 
   it("applies show style with regexp and variables", function () {
@@ -4517,10 +3847,8 @@ describe("Scene/Cesium3DTileStyle", function () {
       show: "(regExp('^Chest').test(${County})) && (${YearBuilt} >= 1970)",
     });
 
-    return style.readyPromise.then(function () {
-      expect(style.show.evaluate(feature1)).toEqual(true);
-      expect(style.show.evaluate(feature2)).toEqual(false);
-    });
+    expect(style.show.evaluate(feature1)).toEqual(true);
+    expect(style.show.evaluate(feature2)).toEqual(false);
   });
 
   it("applies show style with conditional", function () {
@@ -4536,34 +3864,28 @@ describe("Scene/Cesium3DTileStyle", function () {
         ],
       },
     });
-    return style.readyPromise.then(function () {
-      expect(style.show.evaluate(feature1)).toEqual(false);
-      expect(style.show.evaluate(feature2)).toEqual(true);
-    });
+    expect(style.show.evaluate(feature1)).toEqual(false);
+    expect(style.show.evaluate(feature2)).toEqual(true);
   });
 
   it("applies color style variables", function () {
     const style = new Cesium3DTileStyle({
       color: "(${Temperature} > 90) ? color('red') : color('white')",
     });
-    return style.readyPromise.then(function () {
-      expect(style.color.evaluateColor(feature1)).toEqual(Color.WHITE);
-      expect(style.color.evaluateColor(feature2)).toEqual(Color.RED);
-    });
+    expect(style.color.evaluateColor(feature1)).toEqual(Color.WHITE);
+    expect(style.color.evaluateColor(feature2)).toEqual(Color.RED);
   });
 
   it("applies color style with new color", function () {
     const style = new Cesium3DTileStyle({
       color: "rgba(${red}, ${green}, ${blue}, (${volume} > 100 ? 0.5 : 1.0))",
     });
-    return style.readyPromise.then(function () {
-      expect(style.color.evaluateColor(feature1)).toEqual(
-        new Color(38 / 255, 255 / 255, 82 / 255, 0.5)
-      );
-      expect(style.color.evaluateColor(feature2)).toEqual(
-        new Color(255 / 255, 30 / 255, 30 / 255, 1.0)
-      );
-    });
+    expect(style.color.evaluateColor(feature1)).toEqual(
+      new Color(38 / 255, 255 / 255, 82 / 255, 0.5)
+    );
+    expect(style.color.evaluateColor(feature2)).toEqual(
+      new Color(255 / 255, 30 / 255, 30 / 255, 1.0)
+    );
   });
 
   it("applies color style that maps id to color", function () {
@@ -4579,10 +3901,8 @@ describe("Scene/Cesium3DTileStyle", function () {
         ],
       },
     });
-    return style.readyPromise.then(function () {
-      expect(style.color.evaluateColor(feature1)).toEqual(Color.RED);
-      expect(style.color.evaluateColor(feature2)).toEqual(Color.LIME);
-    });
+    expect(style.color.evaluateColor(feature1)).toEqual(Color.RED);
+    expect(style.color.evaluateColor(feature2)).toEqual(Color.LIME);
   });
 
   it("applies color style with conditional", function () {
@@ -4598,20 +3918,16 @@ describe("Scene/Cesium3DTileStyle", function () {
         ],
       },
     });
-    return style.readyPromise.then(function () {
-      expect(style.color.evaluateColor(feature1)).toEqual(Color.BLUE);
-      expect(style.color.evaluateColor(feature2)).toEqual(Color.YELLOW);
-    });
+    expect(style.color.evaluateColor(feature1)).toEqual(Color.BLUE);
+    expect(style.color.evaluateColor(feature2)).toEqual(Color.YELLOW);
   });
 
   it("applies pointSize style with variable", function () {
     const style = new Cesium3DTileStyle({
       pointSize: "${Temperature} / 10.0",
     });
-    return style.readyPromise.then(function () {
-      expect(style.pointSize.evaluate(feature1)).toEqual(7.8);
-      expect(style.pointSize.evaluate(feature2)).toEqual(9.2);
-    });
+    expect(style.pointSize.evaluate(feature1)).toEqual(7.8);
+    expect(style.pointSize.evaluate(feature2)).toEqual(9.2);
   });
 
   it("applies pointSize style with regexp and variables", function () {
@@ -4619,10 +3935,8 @@ describe("Scene/Cesium3DTileStyle", function () {
       pointSize: "(regExp('^Chest').test(${County})) ? 2.0 : 1.0",
     });
 
-    return style.readyPromise.then(function () {
-      expect(style.pointSize.evaluate(feature1)).toEqual(2.0);
-      expect(style.pointSize.evaluate(feature2)).toEqual(1.0);
-    });
+    expect(style.pointSize.evaluate(feature1)).toEqual(2.0);
+    expect(style.pointSize.evaluate(feature2)).toEqual(1.0);
   });
 
   it("applies pointSize style with conditional", function () {
@@ -4639,10 +3953,8 @@ describe("Scene/Cesium3DTileStyle", function () {
       },
     });
 
-    return style.readyPromise.then(function () {
-      expect(style.pointSize.evaluate(feature1)).toEqual(6);
-      expect(style.pointSize.evaluate(feature2)).toEqual(3);
-    });
+    expect(style.pointSize.evaluate(feature1)).toEqual(6);
+    expect(style.pointSize.evaluate(feature2)).toEqual(3);
   });
 
   it("applies with defines", function () {
@@ -4665,38 +3977,34 @@ describe("Scene/Cesium3DTileStyle", function () {
       },
     });
 
-    return style.readyPromise.then(function () {
-      expect(style.color.evaluateColor(feature1)).toEqual(Color.RED);
-      expect(style.color.evaluateColor(feature2)).toEqual(Color.BLUE);
-      expect(style.show.evaluate(feature1)).toEqual(true);
-      expect(style.show.evaluate(feature2)).toEqual(false);
-      expect(style.pointSize.evaluate(feature1)).toEqual(114);
-      expect(style.pointSize.evaluate(feature2)).toEqual(44);
-      expect(style.meta.description.evaluate(feature1)).toEqual(
-        "Half height is 50"
-      );
-      expect(style.meta.description.evaluate(feature2)).toEqual(
-        "Half height is 19"
-      );
-    });
+    expect(style.color.evaluateColor(feature1)).toEqual(Color.RED);
+    expect(style.color.evaluateColor(feature2)).toEqual(Color.BLUE);
+    expect(style.show.evaluate(feature1)).toEqual(true);
+    expect(style.show.evaluate(feature2)).toEqual(false);
+    expect(style.pointSize.evaluate(feature1)).toEqual(114);
+    expect(style.pointSize.evaluate(feature2)).toEqual(44);
+    expect(style.meta.description.evaluate(feature1)).toEqual(
+      "Half height is 50"
+    );
+    expect(style.meta.description.evaluate(feature2)).toEqual(
+      "Half height is 19"
+    );
   });
 
   it("return undefined shader functions when the style is empty", function () {
     // The default color style is white, the default show style is true, and the default pointSize is 1.0,
     // but the generated generated shader functions should just be undefined. We don't want all the points to be white.
     const style = new Cesium3DTileStyle({});
-    return style.readyPromise.then(function () {
-      const colorFunction = style.getColorShaderFunction("getColor", {}, {});
-      const showFunction = style.getShowShaderFunction("getShow", {}, {});
-      const pointSizeFunction = style.getPointSizeShaderFunction(
-        "getPointSize",
-        {},
-        {}
-      );
-      expect(colorFunction).toBeUndefined();
-      expect(showFunction).toBeUndefined();
-      expect(pointSizeFunction).toBeUndefined();
-    });
+    const colorFunction = style.getColorShaderFunction("getColor", {}, {});
+    const showFunction = style.getShowShaderFunction("getShow", {}, {});
+    const pointSizeFunction = style.getPointSizeShaderFunction(
+      "getPointSize",
+      {},
+      {}
+    );
+    expect(colorFunction).toBeUndefined();
+    expect(showFunction).toBeUndefined();
+    expect(pointSizeFunction).toBeUndefined();
   });
 
   it("gets variables", function () {
@@ -4710,9 +4018,7 @@ describe("Scene/Cesium3DTileStyle", function () {
       color: "${Height} * color('red')",
       show: "${Floors} > 10",
     });
-    return style.readyPromise.then(function () {
-      const variables = style.getVariables();
-      expect(variables.sort()).toEqual(["Floors", "Height", "PointSize"]);
-    });
+    const variables = style.getVariables();
+    expect(variables.sort()).toEqual(["Floors", "Height", "PointSize"]);
   });
 });

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -2682,131 +2682,101 @@ describe(
 
     it("applies show style to a tileset", function () {
       let tileset, hideStyle;
-      return Cesium3DTilesTester.loadTileset(scene, withoutBatchTableUrl)
-        .then(function (t) {
+      return Cesium3DTilesTester.loadTileset(scene, withoutBatchTableUrl).then(
+        function (t) {
           tileset = t;
           hideStyle = new Cesium3DTileStyle({ show: "false" });
           tileset.style = hideStyle;
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           expect(tileset.style).toBe(hideStyle);
           expect(scene).toRender([0, 0, 0, 255]);
           tileset.style = new Cesium3DTileStyle({ show: "true" });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           expect(scene).notToRender([0, 0, 0, 255]);
-        });
+        }
+      );
     });
 
     it("applies show style to a tileset without features", function () {
       let tileset;
       let hideStyle;
-      return Cesium3DTilesTester.loadTileset(scene, noBatchIdsUrl)
-        .then(function (t) {
+      return Cesium3DTilesTester.loadTileset(scene, noBatchIdsUrl).then(
+        function (t) {
           tileset = t;
           hideStyle = new Cesium3DTileStyle({ show: "false" });
           tileset.style = hideStyle;
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           expect(tileset.style).toBe(hideStyle);
           expect(scene).toRender([0, 0, 0, 255]);
 
           tileset.style = new Cesium3DTileStyle({ show: "true" });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           expect(scene).notToRender([0, 0, 0, 255]);
-        });
+        }
+      );
     });
 
     it("applies style with complex show expression to a tileset", function () {
       let tileset;
-      return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl)
-        .then(function (t) {
+      return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl).then(
+        function (t) {
           tileset = t;
           // Each feature in the b3dm file has an id property from 0 to 9
           // ${id} >= 10 will always evaluate to false
           tileset.style = new Cesium3DTileStyle({ show: "${id} >= 50 * 2" });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           expect(scene).toRender([0, 0, 0, 255]);
 
           // ${id} < 10 will always evaluate to true
           tileset.style = new Cesium3DTileStyle({ show: "${id} < 200 / 2" });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           expect(scene).notToRender([0, 0, 0, 255]);
-        });
+        }
+      );
     });
 
     it("applies show style to a tileset with a composite tile", function () {
       let tileset;
-      return Cesium3DTilesTester.loadTileset(scene, compositeUrl)
-        .then(function (t) {
+      return Cesium3DTilesTester.loadTileset(scene, compositeUrl).then(
+        function (t) {
           tileset = t;
           tileset.style = new Cesium3DTileStyle({ show: "false" });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           expect(scene).toRender([0, 0, 0, 255]);
 
           tileset.style = new Cesium3DTileStyle({ show: "true" });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           expect(scene).notToRender([0, 0, 0, 255]);
-        });
+        }
+      );
     });
 
     it("applies show style to a tileset with glTF content", function () {
       let tileset;
       let hideStyle;
-      return Cesium3DTilesTester.loadTileset(scene, gltfContentUrl)
-        .then(function (t) {
+      return Cesium3DTilesTester.loadTileset(scene, gltfContentUrl).then(
+        function (t) {
           tileset = t;
           viewGltfContent();
           hideStyle = new Cesium3DTileStyle({ show: "false" });
           tileset.style = hideStyle;
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           expect(tileset.style).toBe(hideStyle);
           expect(scene).toRender([0, 0, 0, 255]);
 
           tileset.style = new Cesium3DTileStyle({ show: "true" });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           expect(scene).notToRender([0, 0, 0, 255]);
-        });
+        }
+      );
     });
 
     it("applies show style to a tileset with glb content", function () {
       let tileset;
       let hideStyle;
-      return Cesium3DTilesTester.loadTileset(scene, glbContentUrl)
-        .then(function (t) {
+      return Cesium3DTilesTester.loadTileset(scene, glbContentUrl).then(
+        function (t) {
           tileset = t;
           viewGltfContent();
           hideStyle = new Cesium3DTileStyle({ show: "false" });
           tileset.style = hideStyle;
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           expect(tileset.style).toBe(hideStyle);
           expect(scene).toRender([0, 0, 0, 255]);
 
           tileset.style = new Cesium3DTileStyle({ show: "true" });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           expect(scene).notToRender([0, 0, 0, 255]);
-        });
+        }
+      );
     });
 
     function expectColorStyle(tileset) {
@@ -2816,39 +2786,30 @@ describe(
       });
 
       tileset.style = new Cesium3DTileStyle({ color: 'color("blue")' });
-      return tileset.style.readyPromise
-        .then(function () {
-          expect(scene).toRenderAndCall(function (rgba) {
-            expect(rgba[0]).toEqual(0);
-            expect(rgba[1]).toEqual(0);
-            expect(rgba[2]).toBeGreaterThan(0);
-            expect(rgba[3]).toEqual(255);
-          });
+      expect(scene).toRenderAndCall(function (rgba) {
+        expect(rgba[0]).toEqual(0);
+        expect(rgba[1]).toEqual(0);
+        expect(rgba[2]).toBeGreaterThan(0);
+        expect(rgba[3]).toEqual(255);
+      });
 
-          // set color to transparent
-          tileset.style = new Cesium3DTileStyle({
-            color: 'color("blue", 0.0)',
-          });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          expect(scene).toRender([0, 0, 0, 255]);
+      // set color to transparent
+      tileset.style = new Cesium3DTileStyle({
+        color: 'color("blue", 0.0)',
+      });
+      expect(scene).toRender([0, 0, 0, 255]);
 
-          tileset.style = new Cesium3DTileStyle({ color: 'color("cyan")' });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          expect(scene).toRenderAndCall(function (rgba) {
-            expect(rgba[0]).toEqual(0);
-            expect(rgba[1]).toBeGreaterThan(0);
-            expect(rgba[2]).toBeGreaterThan(0);
-            expect(rgba[3]).toEqual(255);
-          });
+      tileset.style = new Cesium3DTileStyle({ color: 'color("cyan")' });
+      expect(scene).toRenderAndCall(function (rgba) {
+        expect(rgba[0]).toEqual(0);
+        expect(rgba[1]).toBeGreaterThan(0);
+        expect(rgba[2]).toBeGreaterThan(0);
+        expect(rgba[3]).toEqual(255);
+      });
 
-          // Remove style
-          tileset.style = undefined;
-          expect(scene).toRender(color);
-        });
+      // Remove style
+      tileset.style = undefined;
+      expect(scene).toRender(color);
     }
 
     it("applies color style to a tileset", function () {
@@ -2904,14 +2865,11 @@ describe(
 
     it("applies style when feature properties change", function () {
       let tileset;
-      return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl)
-        .then(function (t) {
+      return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl).then(
+        function (t) {
           tileset = t;
           // Initially, all feature ids are less than 10
           tileset.style = new Cesium3DTileStyle({ show: "${id} < 10" });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           expect(scene).notToRender([0, 0, 0, 255]);
 
           // Change feature ids so the show expression will evaluate to false
@@ -2931,35 +2889,27 @@ describe(
             feature.setProperty("id", feature.getProperty("id") - 10);
           }
           expect(scene).notToRender([0, 0, 0, 255]);
-        });
+        }
+      );
     });
 
     it("applies style when tile is selected after new style is applied", function () {
       let tileset;
       let feature;
-      return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl)
-        .then(function (t) {
+      return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl).then(
+        function (t) {
           tileset = t;
           feature = tileset.root.content.getFeature(0);
           tileset.style = new Cesium3DTileStyle({ color: 'color("red")' });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           scene.renderForSpecs();
           expect(feature.color).toEqual(Color.RED);
 
           tileset.style = new Cesium3DTileStyle({ color: 'color("blue")' });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           scene.renderForSpecs();
           expect(feature.color).toEqual(Color.BLUE);
 
           viewNothing();
           tileset.style = new Cesium3DTileStyle({ color: 'color("lime")' });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           scene.renderForSpecs();
           expect(feature.color).toEqual(Color.BLUE); // Hasn't been selected yet
 
@@ -2976,18 +2926,16 @@ describe(
           expect(feature.show).toBe(false);
           viewAllTiles();
           expect(feature.show).toBe(false);
-        });
+        }
+      );
     });
 
     it("does not reapply style during pick pass", function () {
       let tileset;
-      return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl)
-        .then(function (t) {
+      return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl).then(
+        function (t) {
           tileset = t;
           tileset.style = new Cesium3DTileStyle({ color: 'color("red")' });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           scene.renderForSpecs();
           expect(
             tileset._statisticsPerPass[Cesium3DTilePass.RENDER]
@@ -2998,22 +2946,20 @@ describe(
             tileset._statisticsPerPass[Cesium3DTilePass.PICK]
               .numberOfTilesStyled
           ).toBe(0);
-        });
+        }
+      );
     });
 
     it("applies style with complex color expression to a tileset", function () {
       let tileset;
-      return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl)
-        .then(function (t) {
+      return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl).then(
+        function (t) {
           tileset = t;
           // Each feature in the b3dm file has an id property from 0 to 9
           // ${id} >= 10 will always evaluate to false
           tileset.style = new Cesium3DTileStyle({
             color: '(${id} >= 50 * 2) ? color("red") : color("blue")',
           });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           expect(scene).toRenderAndCall(function (rgba) {
             expect(rgba[0]).toEqual(0);
             expect(rgba[1]).toEqual(0);
@@ -3025,22 +2971,20 @@ describe(
           tileset.style = new Cesium3DTileStyle({
             color: '(${id} < 50 * 2) ? color("red") : color("blue")',
           });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           expect(scene).toRenderAndCall(function (rgba) {
             expect(rgba[0]).toBeGreaterThan(0);
             expect(rgba[1]).toEqual(0);
             expect(rgba[2]).toEqual(0);
             expect(rgba[3]).toEqual(255);
           });
-        });
+        }
+      );
     });
 
     it("applies conditional color style to a tileset", function () {
       let tileset;
-      return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl)
-        .then(function (t) {
+      return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl).then(
+        function (t) {
           tileset = t;
           // ${id} < 10 will always evaluate to true
           tileset.style = new Cesium3DTileStyle({
@@ -3051,9 +2995,6 @@ describe(
               ],
             },
           });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           expect(scene).toRenderAndCall(function (rgba) {
             expect(rgba[0]).toBeGreaterThan(0);
             expect(rgba[1]).toEqual(0);
@@ -3070,50 +3011,43 @@ describe(
               ],
             },
           });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           expect(scene).toRenderAndCall(function (rgba) {
             expect(rgba[0]).toEqual(0);
             expect(rgba[1]).toEqual(0);
             expect(rgba[2]).toBeGreaterThan(0);
             expect(rgba[3]).toEqual(255);
           });
-        });
+        }
+      );
     });
 
     it("handle else case when applying conditional color style to a tileset", function () {
       let tileset;
-      return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl)
-        .then(function (t) {
+      return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl).then(
+        function (t) {
           tileset = t;
           tileset.style = new Cesium3DTileStyle({
             color: {
               conditions: [["${id} > 0", 'color("black")']],
             },
           });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           scene.renderForSpecs();
           expect(tileset.root.content.getFeature(0).color).toEqual(Color.WHITE);
           expect(tileset.root.content.getFeature(1).color).toEqual(Color.BLACK);
-        });
+        }
+      );
     });
 
     it("handle else case when applying conditional show to a tileset", function () {
       let tileset;
-      return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl)
-        .then(function (t) {
+      return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl).then(
+        function (t) {
           tileset = t;
           tileset.style = new Cesium3DTileStyle({
             show: {
               conditions: [["${id} > 0", "true"]],
             },
           });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           scene.renderForSpecs();
           expect(tileset.root.content.getFeature(0).show).toBe(true);
           expect(tileset.root.content.getFeature(1).show).toBe(true);
@@ -3123,32 +3057,26 @@ describe(
               conditions: [["${id} > 0", "false"]],
             },
           });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
           scene.renderForSpecs();
           expect(tileset.root.content.getFeature(0).show).toBe(true);
           expect(tileset.root.content.getFeature(1).show).toBe(false);
-        });
+        }
+      );
     });
 
     it("loads style from uri", function () {
       return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl).then(
         function (tileset) {
           // ${id} < 10 will always evaluate to true
-          tileset.style = new Cesium3DTileStyle(styleUrl);
-          return tileset.style.readyPromise
-            .then(function (style) {
-              expect(scene).toRenderAndCall(function (rgba) {
-                expect(rgba[0]).toBeGreaterThan(0);
-                expect(rgba[1]).toEqual(0);
-                expect(rgba[2]).toEqual(0);
-                expect(rgba[3]).toEqual(255);
-              });
-            })
-            .catch(function (error) {
-              expect(error).not.toBeDefined();
+          return Cesium3DTileStyle.fromUrl(styleUrl).then(function (style) {
+            tileset.style = style;
+            expect(scene).toRenderAndCall(function (rgba) {
+              expect(rgba[0]).toBeGreaterThan(0);
+              expect(rgba[1]).toEqual(0);
+              expect(rgba[2]).toEqual(0);
+              expect(rgba[3]).toEqual(255);
             });
+          });
         }
       );
     });
@@ -3182,15 +3110,13 @@ describe(
 
     it("doesn't re-evaluate style during the next update", function () {
       let tileset;
-      return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl)
-        .then(function (t) {
+      return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl).then(
+        function (t) {
           tileset = t;
           tileset.show = false;
           tileset.preloadWhenHidden = true;
           tileset.style = new Cesium3DTileStyle({ color: 'color("red")' });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
+
           scene.renderForSpecs();
 
           const statistics =
@@ -3199,20 +3125,19 @@ describe(
 
           scene.renderForSpecs();
           expect(statistics.numberOfTilesStyled).toBe(0);
-        });
+        }
+      );
     });
 
     it("doesn't re-evaluate style if the style being set is the same as the active style", function () {
       let tileset;
       let style;
-      return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl)
-        .then(function (t) {
+      return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl).then(
+        function (t) {
           tileset = t;
           style = new Cesium3DTileStyle({ color: 'color("red")' });
           tileset.style = style;
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
+
           scene.renderForSpecs();
 
           const statistics =
@@ -3222,7 +3147,8 @@ describe(
           tileset.style = style;
           scene.renderForSpecs();
           expect(statistics.numberOfTilesStyled).toBe(0);
-        });
+        }
+      );
     });
 
     function testColorBlendMode(url) {
@@ -3236,161 +3162,148 @@ describe(
         time: new JulianDate(2457522.154792),
       };
       let tileset;
-      return Cesium3DTilesTester.loadTileset(scene, url)
-        .then(function (t) {
-          tileset = t;
-          tileset.luminanceAtZenith = undefined;
+      return Cesium3DTilesTester.loadTileset(scene, url).then(function (t) {
+        tileset = t;
+        tileset.luminanceAtZenith = undefined;
 
-          expect(renderOptions).toRenderAndCall(function (rgba) {
-            sourceRed = rgba[0];
-            sourceGreen = rgba[1];
-          });
-
-          expect(renderOptions).toRenderAndCall(function (rgba) {
-            expect(rgba[0]).toBeGreaterThan(200);
-            expect(rgba[1]).toBeLessThan(25);
-            expect(rgba[2]).toBeLessThan(25);
-            expect(rgba[3]).toEqual(255);
-          });
-
-          // Use HIGHLIGHT blending
-          tileset.colorBlendMode = Cesium3DTileColorBlendMode.HIGHLIGHT;
-
-          // Style with dark yellow. Expect the red channel to be darker than before.
-          tileset.style = new Cesium3DTileStyle({
-            color: "rgb(128, 128, 0)",
-          });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          expect(renderOptions).toRenderAndCall(function (rgba) {
-            expect(rgba[0]).toBeGreaterThan(100);
-            expect(rgba[0]).toBeLessThan(sourceRed);
-            expect(rgba[1]).toBeLessThan(25);
-            expect(rgba[2]).toBeLessThan(25);
-            expect(rgba[3]).toEqual(255);
-          });
-
-          // Style with yellow + alpha. Expect the red channel to be darker than before.
-          tileset.style = new Cesium3DTileStyle({
-            color: "rgba(255, 255, 0, 0.5)",
-          });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          expect(renderOptions).toRenderAndCall(function (rgba) {
-            expect(rgba[0]).toBeGreaterThan(100);
-            expect(rgba[0]).toBeLessThan(sourceRed);
-            expect(rgba[1]).toBeLessThan(25);
-            expect(rgba[2]).toBeLessThan(25);
-            expect(rgba[3]).toEqual(255);
-          });
-
-          // Use REPLACE blending
-          tileset.colorBlendMode = Cesium3DTileColorBlendMode.REPLACE;
-
-          // Style with dark yellow. Expect the red and green channels to be roughly dark yellow.
-          tileset.style = new Cesium3DTileStyle({
-            color: "rgb(128, 128, 0)",
-          });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          expect(renderOptions).toRenderAndCall(function (rgba) {
-            replaceRed = rgba[0];
-            replaceGreen = rgba[1];
-            expect(rgba[0]).toBeGreaterThan(100);
-            expect(rgba[0]).toBeLessThan(255);
-            expect(rgba[1]).toBeGreaterThan(100);
-            expect(rgba[1]).toBeLessThan(255);
-            expect(rgba[2]).toBeLessThan(25);
-            expect(rgba[3]).toEqual(255);
-          });
-
-          // Style with yellow + alpha. Expect the red and green channels to be a shade of yellow.
-          tileset.style = new Cesium3DTileStyle({
-            color: "rgba(255, 255, 0, 0.5)",
-          });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          expect(renderOptions).toRenderAndCall(function (rgba) {
-            expect(rgba[0]).toBeGreaterThan(100);
-            expect(rgba[0]).toBeLessThan(255);
-            expect(rgba[1]).toBeGreaterThan(100);
-            expect(rgba[1]).toBeLessThan(255);
-            expect(rgba[2]).toBeLessThan(25);
-            expect(rgba[3]).toEqual(255);
-          });
-
-          // Use MIX blending
-          tileset.colorBlendMode = Cesium3DTileColorBlendMode.MIX;
-          tileset.colorBlendAmount = 0.5;
-
-          // Style with dark yellow. Expect color to be a mix of the source and style colors.
-          tileset.style = new Cesium3DTileStyle({
-            color: "rgb(128, 128, 0)",
-          });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          let mixRed;
-          let mixGreen;
-          expect(renderOptions).toRenderAndCall(function (rgba) {
-            mixRed = rgba[0];
-            mixGreen = rgba[1];
-            expect(rgba[0]).toBeGreaterThan(replaceRed);
-            expect(rgba[0]).toBeLessThan(sourceRed);
-            expect(rgba[1]).toBeGreaterThan(sourceGreen);
-            expect(rgba[1]).toBeLessThan(replaceGreen);
-            expect(rgba[2]).toBeLessThan(25);
-            expect(rgba[3]).toEqual(255);
-          });
-
-          // Set colorBlendAmount to 0.25. Expect color to be closer to the source color.
-          tileset.colorBlendAmount = 0.25;
-          expect(renderOptions).toRenderAndCall(function (rgba) {
-            expect(rgba[0]).toBeGreaterThan(mixRed);
-            expect(rgba[0]).toBeLessThan(sourceRed);
-            expect(rgba[1]).toBeGreaterThan(0);
-            expect(rgba[1]).toBeLessThan(mixGreen);
-            expect(rgba[2]).toBeLessThan(25);
-            expect(rgba[3]).toEqual(255);
-          });
-
-          // Set colorBlendAmount to 0.0. Expect color to equal the source color
-          tileset.colorBlendAmount = 0.0;
-          expect(renderOptions).toRenderAndCall(function (rgba) {
-            expect(rgba[0]).toEqual(sourceRed);
-            expect(rgba[1]).toBeLessThan(25);
-            expect(rgba[2]).toBeLessThan(25);
-            expect(rgba[3]).toEqual(255);
-          });
-
-          // Set colorBlendAmount to 1.0. Expect color to equal the style color
-          tileset.colorBlendAmount = 1.0;
-          expect(renderOptions).toRenderAndCall(function (rgba) {
-            expect(rgba[0]).toEqual(replaceRed);
-            expect(rgba[1]).toEqual(replaceGreen);
-            expect(rgba[2]).toBeLessThan(25);
-            expect(rgba[3]).toEqual(255);
-          });
-
-          // Style with yellow + alpha. Expect color to be a mix of the source and style colors.
-          tileset.colorBlendAmount = 0.5;
-          tileset.style = new Cesium3DTileStyle({
-            color: "rgba(255, 255, 0, 0.5)",
-          });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          expect(renderOptions).toRenderAndCall(function (rgba) {
-            expect(rgba[0]).toBeGreaterThan(0);
-            expect(rgba[1]).toBeGreaterThan(0);
-            expect(rgba[2]).toBeLessThan(25);
-            expect(rgba[3]).toEqual(255);
-          });
+        expect(renderOptions).toRenderAndCall(function (rgba) {
+          sourceRed = rgba[0];
+          sourceGreen = rgba[1];
         });
+
+        expect(renderOptions).toRenderAndCall(function (rgba) {
+          expect(rgba[0]).toBeGreaterThan(200);
+          expect(rgba[1]).toBeLessThan(25);
+          expect(rgba[2]).toBeLessThan(25);
+          expect(rgba[3]).toEqual(255);
+        });
+
+        // Use HIGHLIGHT blending
+        tileset.colorBlendMode = Cesium3DTileColorBlendMode.HIGHLIGHT;
+
+        // Style with dark yellow. Expect the red channel to be darker than before.
+        tileset.style = new Cesium3DTileStyle({
+          color: "rgb(128, 128, 0)",
+        });
+
+        expect(renderOptions).toRenderAndCall(function (rgba) {
+          expect(rgba[0]).toBeGreaterThan(100);
+          expect(rgba[0]).toBeLessThan(sourceRed);
+          expect(rgba[1]).toBeLessThan(25);
+          expect(rgba[2]).toBeLessThan(25);
+          expect(rgba[3]).toEqual(255);
+        });
+
+        // Style with yellow + alpha. Expect the red channel to be darker than before.
+        tileset.style = new Cesium3DTileStyle({
+          color: "rgba(255, 255, 0, 0.5)",
+        });
+
+        expect(renderOptions).toRenderAndCall(function (rgba) {
+          expect(rgba[0]).toBeGreaterThan(100);
+          expect(rgba[0]).toBeLessThan(sourceRed);
+          expect(rgba[1]).toBeLessThan(25);
+          expect(rgba[2]).toBeLessThan(25);
+          expect(rgba[3]).toEqual(255);
+        });
+
+        // Use REPLACE blending
+        tileset.colorBlendMode = Cesium3DTileColorBlendMode.REPLACE;
+
+        // Style with dark yellow. Expect the red and green channels to be roughly dark yellow.
+        tileset.style = new Cesium3DTileStyle({
+          color: "rgb(128, 128, 0)",
+        });
+
+        expect(renderOptions).toRenderAndCall(function (rgba) {
+          replaceRed = rgba[0];
+          replaceGreen = rgba[1];
+          expect(rgba[0]).toBeGreaterThan(100);
+          expect(rgba[0]).toBeLessThan(255);
+          expect(rgba[1]).toBeGreaterThan(100);
+          expect(rgba[1]).toBeLessThan(255);
+          expect(rgba[2]).toBeLessThan(25);
+          expect(rgba[3]).toEqual(255);
+        });
+
+        // Style with yellow + alpha. Expect the red and green channels to be a shade of yellow.
+        tileset.style = new Cesium3DTileStyle({
+          color: "rgba(255, 255, 0, 0.5)",
+        });
+
+        expect(renderOptions).toRenderAndCall(function (rgba) {
+          expect(rgba[0]).toBeGreaterThan(100);
+          expect(rgba[0]).toBeLessThan(255);
+          expect(rgba[1]).toBeGreaterThan(100);
+          expect(rgba[1]).toBeLessThan(255);
+          expect(rgba[2]).toBeLessThan(25);
+          expect(rgba[3]).toEqual(255);
+        });
+
+        // Use MIX blending
+        tileset.colorBlendMode = Cesium3DTileColorBlendMode.MIX;
+        tileset.colorBlendAmount = 0.5;
+
+        // Style with dark yellow. Expect color to be a mix of the source and style colors.
+        tileset.style = new Cesium3DTileStyle({
+          color: "rgb(128, 128, 0)",
+        });
+
+        let mixRed;
+        let mixGreen;
+        expect(renderOptions).toRenderAndCall(function (rgba) {
+          mixRed = rgba[0];
+          mixGreen = rgba[1];
+          expect(rgba[0]).toBeGreaterThan(replaceRed);
+          expect(rgba[0]).toBeLessThan(sourceRed);
+          expect(rgba[1]).toBeGreaterThan(sourceGreen);
+          expect(rgba[1]).toBeLessThan(replaceGreen);
+          expect(rgba[2]).toBeLessThan(25);
+          expect(rgba[3]).toEqual(255);
+        });
+
+        // Set colorBlendAmount to 0.25. Expect color to be closer to the source color.
+        tileset.colorBlendAmount = 0.25;
+        expect(renderOptions).toRenderAndCall(function (rgba) {
+          expect(rgba[0]).toBeGreaterThan(mixRed);
+          expect(rgba[0]).toBeLessThan(sourceRed);
+          expect(rgba[1]).toBeGreaterThan(0);
+          expect(rgba[1]).toBeLessThan(mixGreen);
+          expect(rgba[2]).toBeLessThan(25);
+          expect(rgba[3]).toEqual(255);
+        });
+
+        // Set colorBlendAmount to 0.0. Expect color to equal the source color
+        tileset.colorBlendAmount = 0.0;
+        expect(renderOptions).toRenderAndCall(function (rgba) {
+          expect(rgba[0]).toEqual(sourceRed);
+          expect(rgba[1]).toBeLessThan(25);
+          expect(rgba[2]).toBeLessThan(25);
+          expect(rgba[3]).toEqual(255);
+        });
+
+        // Set colorBlendAmount to 1.0. Expect color to equal the style color
+        tileset.colorBlendAmount = 1.0;
+        expect(renderOptions).toRenderAndCall(function (rgba) {
+          expect(rgba[0]).toEqual(replaceRed);
+          expect(rgba[1]).toEqual(replaceGreen);
+          expect(rgba[2]).toBeLessThan(25);
+          expect(rgba[3]).toEqual(255);
+        });
+
+        // Style with yellow + alpha. Expect color to be a mix of the source and style colors.
+        tileset.colorBlendAmount = 0.5;
+        tileset.style = new Cesium3DTileStyle({
+          color: "rgba(255, 255, 0, 0.5)",
+        });
+
+        expect(renderOptions).toRenderAndCall(function (rgba) {
+          expect(rgba[0]).toBeGreaterThan(0);
+          expect(rgba[1]).toBeGreaterThan(0);
+          expect(rgba[2]).toBeLessThan(25);
+          expect(rgba[3]).toEqual(255);
+        });
+      });
     }
 
     it("sets colorBlendMode", function () {

--- a/Specs/Scene/Geometry3DTileContentSpec.js
+++ b/Specs/Scene/Geometry3DTileContentSpec.js
@@ -331,26 +331,20 @@ describe(
       tileset.style = new Cesium3DTileStyle({
         show: "false",
       });
-      return tileset.style.readyPromise
-        .then(function () {
-          expectRender(scene, [255, 0, 0, 255]);
-          tileset.style = new Cesium3DTileStyle({
-            show: "true",
-          });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          expectRender(scene, [255, 255, 255, 255]);
 
-          tileset.style = new Cesium3DTileStyle({
-            color: "rgba(0, 0, 255, 1.0)",
-          });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          expectRender(scene, [0, 0, 255, 255]);
-          return tileset;
-        });
+      expectRender(scene, [255, 0, 0, 255]);
+      tileset.style = new Cesium3DTileStyle({
+        show: "true",
+      });
+
+      expectRender(scene, [255, 255, 255, 255]);
+
+      tileset.style = new Cesium3DTileStyle({
+        color: "rgba(0, 0, 255, 1.0)",
+      });
+
+      expectRender(scene, [0, 0, 255, 255]);
+      return tileset;
     }
 
     it("renders on 3D Tiles", function () {

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSceneGraphSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSceneGraphSpec.js
@@ -64,30 +64,27 @@ describe(
           conditions: [["${height} > 1", "color('red')"]],
         },
       });
-      return style.readyPromise
-        .then(function () {
-          return loadAndZoomToModelExperimental(
-            {
-              gltf: buildingsMetadata,
-            },
-            scene
-          );
-        })
-        .then(function (model) {
-          model.style = style;
-          const frameState = scene.frameState;
-          const sceneGraph = model._sceneGraph;
-          // Reset the draw commands so we can inspect the draw command generation.
-          model._drawCommandsBuilt = false;
-          frameState.commandList = [];
-          scene.renderForSpecs();
 
-          const drawCommands = sceneGraph.getDrawCommands();
+      return loadAndZoomToModelExperimental(
+        {
+          gltf: buildingsMetadata,
+        },
+        scene
+      ).then(function (model) {
+        model.style = style;
+        const frameState = scene.frameState;
+        const sceneGraph = model._sceneGraph;
+        // Reset the draw commands so we can inspect the draw command generation.
+        model._drawCommandsBuilt = false;
+        frameState.commandList = [];
+        scene.renderForSpecs();
 
-          expect(drawCommands.length).toEqual(1);
-          expect(drawCommands[0].pass).toEqual(Pass.OPAQUE);
-          expect(frameState.commandList.length).toEqual(1);
-        });
+        const drawCommands = sceneGraph.getDrawCommands();
+
+        expect(drawCommands.length).toEqual(1);
+        expect(drawCommands[0].pass).toEqual(Pass.OPAQUE);
+        expect(frameState.commandList.length).toEqual(1);
+      });
     });
 
     it("builds draw commands for all translucent styled features", function () {
@@ -96,30 +93,26 @@ describe(
           conditions: [["${height} > 1", "color('red', 0.1)"]],
         },
       });
-      return style.readyPromise
-        .then(function () {
-          return loadAndZoomToModelExperimental(
-            {
-              gltf: buildingsMetadata,
-            },
-            scene
-          );
-        })
-        .then(function (model) {
-          model.style = style;
-          const frameState = scene.frameState;
-          const sceneGraph = model._sceneGraph;
-          // Reset the draw commands so we can inspect the draw command generation.
-          model._drawCommandsBuilt = false;
-          frameState.commandList = [];
-          scene.renderForSpecs();
+      return loadAndZoomToModelExperimental(
+        {
+          gltf: buildingsMetadata,
+        },
+        scene
+      ).then(function (model) {
+        model.style = style;
+        const frameState = scene.frameState;
+        const sceneGraph = model._sceneGraph;
+        // Reset the draw commands so we can inspect the draw command generation.
+        model._drawCommandsBuilt = false;
+        frameState.commandList = [];
+        scene.renderForSpecs();
 
-          const drawCommands = sceneGraph.getDrawCommands();
+        const drawCommands = sceneGraph.getDrawCommands();
 
-          expect(drawCommands.length).toEqual(1);
-          expect(drawCommands[0].pass).toEqual(Pass.TRANSLUCENT);
-          expect(frameState.commandList.length).toEqual(1);
-        });
+        expect(drawCommands.length).toEqual(1);
+        expect(drawCommands[0].pass).toEqual(Pass.TRANSLUCENT);
+        expect(frameState.commandList.length).toEqual(1);
+      });
     });
 
     it("builds draw commands for both opaque and translucent styled features", function () {
@@ -131,30 +124,27 @@ describe(
           ],
         },
       });
-      return style.readyPromise
-        .then(function () {
-          return loadAndZoomToModelExperimental(
-            {
-              gltf: buildingsMetadata,
-            },
-            scene
-          );
-        })
-        .then(function (model) {
-          model.style = style;
-          const frameState = scene.frameState;
-          const sceneGraph = model._sceneGraph;
-          // Reset the draw commands so we can inspect the draw command generation.
-          model._drawCommandsBuilt = false;
-          frameState.commandList = [];
-          scene.renderForSpecs();
 
-          const drawCommands = sceneGraph.getDrawCommands();
-          expect(drawCommands.length).toEqual(2);
-          expect(drawCommands[0].pass).toEqual(Pass.OPAQUE);
-          expect(drawCommands[1].pass).toEqual(Pass.TRANSLUCENT);
-          expect(frameState.commandList.length).toEqual(2);
-        });
+      return loadAndZoomToModelExperimental(
+        {
+          gltf: buildingsMetadata,
+        },
+        scene
+      ).then(function (model) {
+        model.style = style;
+        const frameState = scene.frameState;
+        const sceneGraph = model._sceneGraph;
+        // Reset the draw commands so we can inspect the draw command generation.
+        model._drawCommandsBuilt = false;
+        frameState.commandList = [];
+        scene.renderForSpecs();
+
+        const drawCommands = sceneGraph.getDrawCommands();
+        expect(drawCommands.length).toEqual(2);
+        expect(drawCommands[0].pass).toEqual(Pass.OPAQUE);
+        expect(drawCommands[1].pass).toEqual(Pass.TRANSLUCENT);
+        expect(frameState.commandList.length).toEqual(2);
+      });
     });
 
     it("builds draw commands for each primitive", function () {

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -643,62 +643,58 @@ describe(
     it("renders model with style", function () {
       let model;
       let style;
-      return loadAndZoomToModelExperimental({ gltf: buildingsMetadata }, scene)
-        .then(function (result) {
-          model = result;
-          // Renders without style.
-          verifyRender(model, true, {
-            zoomToModel: false,
-          });
-
-          // Renders with opaque style.
-          style = new Cesium3DTileStyle({
-            color: {
-              conditions: [["${height} > 1", "color('red')"]],
-            },
-          });
-          return style.readyPromise;
-        })
-        .then(function () {
-          model.style = style;
-          verifyRender(model, true, {
-            zoomToModel: false,
-          });
-
-          // Renders with translucent style.
-          style = new Cesium3DTileStyle({
-            color: {
-              conditions: [["${height} > 1", "color('red', 0.5)"]],
-            },
-          });
-          return style.readyPromise;
-        })
-        .then(function () {
-          model.style = style;
-          verifyRender(model, true, {
-            zoomToModel: false,
-          });
-
-          // Does not render when style disables show.
-          style = new Cesium3DTileStyle({
-            color: {
-              conditions: [["${height} > 1", "color('red', 0.0)"]],
-            },
-          });
-          return style.readyPromise;
-        })
-        .then(function () {
-          model.style = style;
-          verifyRender(model, false, {
-            zoomToModel: false,
-          });
-
-          // Render when style is removed.
-          model.style = undefined;
-          verifyRender(model, true, {
-            zoomToModel: false,
-          });
+      return loadAndZoomToModelExperimental(
+        { gltf: buildingsMetadata },
+        scene
+      ).then(function (result) {
+        model = result;
+        // Renders without style.
+        verifyRender(model, true, {
+          zoomToModel: false,
         });
+
+        // Renders with opaque style.
+        style = new Cesium3DTileStyle({
+          color: {
+            conditions: [["${height} > 1", "color('red')"]],
+          },
+        });
+
+        model.style = style;
+        verifyRender(model, true, {
+          zoomToModel: false,
+        });
+
+        // Renders with translucent style.
+        style = new Cesium3DTileStyle({
+          color: {
+            conditions: [["${height} > 1", "color('red', 0.5)"]],
+          },
+        });
+
+        model.style = style;
+        verifyRender(model, true, {
+          zoomToModel: false,
+        });
+
+        // Does not render when style disables show.
+        style = new Cesium3DTileStyle({
+          color: {
+            conditions: [["${height} > 1", "color('red', 0.0)"]],
+          },
+        });
+
+        model.style = style;
+        verifyRender(model, false, {
+          zoomToModel: false,
+        });
+
+        // Render when style is removed.
+        model.style = undefined;
+        verifyRender(model, true, {
+          zoomToModel: false,
+        });
+      });
     });
 
     it("fromGltf throws with undefined options", function () {

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -282,22 +282,21 @@ describe(
     });
 
     it("renders point cloud with draco encoded positions, normals, colors, and batch table properties", function () {
-      return Cesium3DTilesTester.loadTileset(scene, pointCloudDracoUrl)
-        .then(function (tileset) {
+      return Cesium3DTilesTester.loadTileset(scene, pointCloudDracoUrl).then(
+        function (tileset) {
           Cesium3DTilesTester.expectRender(scene, tileset);
           // Test that Draco-encoded batch table properties are functioning correctly
           tileset.style = new Cesium3DTileStyle({
             color: "vec4(Number(${secondaryColor}[0] < 1.0), 0.0, 0.0, 1.0)",
           });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
+
           expect(scene).toRenderAndCall(function (rgba) {
             // Produces a red color
             expect(rgba[0]).toBeGreaterThan(rgba[1]);
             expect(rgba[0]).toBeGreaterThan(rgba[2]);
           });
-        });
+        }
+      );
     });
 
     it("renders point cloud with draco encoded positions and uncompressed normals and colors", function () {
@@ -705,176 +704,148 @@ describe(
       return Cesium3DTilesTester.loadTileset(
         scene,
         pointCloudWithPerPointPropertiesUrl
-      )
-        .then(function (t) {
-          tileset = t;
-          content = tileset.root.content;
+      ).then(function (t) {
+        tileset = t;
+        content = tileset.root.content;
 
-          // Solid red color
-          tileset.style = new Cesium3DTileStyle({
-            color: 'color("red")',
-          });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          expect(scene).toRender([255, 0, 0, 255]);
-          expect(content._pointCloud._styleTranslucent).toBe(false);
-
-          // Applies translucency
-          tileset.style = new Cesium3DTileStyle({
-            color: "rgba(255, 0, 0, 0.005)",
-          });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          expect(scene).toRenderAndCall(function (rgba) {
-            // Pixel is a darker red
-            expect(rgba[0]).toBeLessThan(255);
-            expect(rgba[1]).toBe(0);
-            expect(rgba[2]).toBe(0);
-            expect(rgba[3]).toBe(255);
-            expect(content._pointCloud._styleTranslucent).toBe(true);
-          });
-
-          // Style with property
-          tileset.style = new Cesium3DTileStyle({
-            color: "color() * ${temperature}",
-          });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          expect(scene).toRenderAndCall(function (rgba) {
-            // Pixel color is some shade of gray
-            expect(rgba[0]).toBe(rgba[1]);
-            expect(rgba[0]).toBe(rgba[2]);
-            expect(rgba[0]).toBeGreaterThan(0);
-            expect(rgba[0]).toBeLessThan(255);
-          });
-
-          // When no conditions are met the default color is white
-          tileset.style = new Cesium3DTileStyle({
-            color: {
-              conditions: [
-                ["${secondaryColor}[0] > 1.0", 'color("red")'], // This condition will not be met
-              ],
-            },
-          });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          expect(scene).toRender([255, 255, 255, 255]);
-
-          // Apply style with conditions
-          tileset.style = new Cesium3DTileStyle({
-            color: {
-              conditions: [
-                ["${temperature} < 0.1", 'color("#000099")'],
-                ["${temperature} < 0.2", 'color("#00cc99", 1.0)'],
-                ["${temperature} < 0.3", 'color("#66ff33", 0.5)'],
-                ["${temperature} < 0.4", "rgba(255, 255, 0, 0.1)"],
-                ["${temperature} < 0.5", "rgb(255, 128, 0)"],
-                ["${temperature} < 0.6", 'color("red")'],
-                ["${temperature} < 0.7", 'color("rgb(255, 102, 102)")'],
-                ["${temperature} < 0.8", "hsl(0.875, 1.0, 0.6)"],
-                ["${temperature} < 0.9", "hsla(0.83, 1.0, 0.5, 0.1)"],
-                ["true", 'color("#FFFFFF", 1.0)'],
-              ],
-            },
-          });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          expect(scene).notToRender([0, 0, 0, 255]);
-
-          // Apply show style
-          tileset.style = new Cesium3DTileStyle({
-            show: true,
-          });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          expect(scene).notToRender([0, 0, 0, 255]);
-
-          // Apply show style that hides all points
-          tileset.style = new Cesium3DTileStyle({
-            show: false,
-          });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          expect(scene).toRender([0, 0, 0, 255]);
-
-          // Apply show style with property
-          tileset.style = new Cesium3DTileStyle({
-            show: "${temperature} > 0.1",
-          });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          expect(scene).notToRender([0, 0, 0, 255]);
-          tileset.style = new Cesium3DTileStyle({
-            show: "${temperature} > 1.0",
-          });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          expect(scene).toRender([0, 0, 0, 255]);
-
-          // Apply style with point cloud semantics
-          tileset.style = new Cesium3DTileStyle({
-            color: "${COLOR} / 2.0",
-            show: "${POSITION}[0] > 0.5",
-          });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          expect(scene).notToRender([0, 0, 0, 255]);
-
-          // Apply pointSize style
-          tileset.style = new Cesium3DTileStyle({
-            pointSize: 5.0,
-          });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          expect(scene).notToRender([0, 0, 0, 255]);
+        // Solid red color
+        tileset.style = new Cesium3DTileStyle({
+          color: 'color("red")',
         });
+
+        expect(scene).toRender([255, 0, 0, 255]);
+        expect(content._pointCloud._styleTranslucent).toBe(false);
+
+        // Applies translucency
+        tileset.style = new Cesium3DTileStyle({
+          color: "rgba(255, 0, 0, 0.005)",
+        });
+
+        expect(scene).toRenderAndCall(function (rgba) {
+          // Pixel is a darker red
+          expect(rgba[0]).toBeLessThan(255);
+          expect(rgba[1]).toBe(0);
+          expect(rgba[2]).toBe(0);
+          expect(rgba[3]).toBe(255);
+          expect(content._pointCloud._styleTranslucent).toBe(true);
+        });
+
+        // Style with property
+        tileset.style = new Cesium3DTileStyle({
+          color: "color() * ${temperature}",
+        });
+
+        expect(scene).toRenderAndCall(function (rgba) {
+          // Pixel color is some shade of gray
+          expect(rgba[0]).toBe(rgba[1]);
+          expect(rgba[0]).toBe(rgba[2]);
+          expect(rgba[0]).toBeGreaterThan(0);
+          expect(rgba[0]).toBeLessThan(255);
+        });
+
+        // When no conditions are met the default color is white
+        tileset.style = new Cesium3DTileStyle({
+          color: {
+            conditions: [
+              ["${secondaryColor}[0] > 1.0", 'color("red")'], // This condition will not be met
+            ],
+          },
+        });
+
+        expect(scene).toRender([255, 255, 255, 255]);
+
+        // Apply style with conditions
+        tileset.style = new Cesium3DTileStyle({
+          color: {
+            conditions: [
+              ["${temperature} < 0.1", 'color("#000099")'],
+              ["${temperature} < 0.2", 'color("#00cc99", 1.0)'],
+              ["${temperature} < 0.3", 'color("#66ff33", 0.5)'],
+              ["${temperature} < 0.4", "rgba(255, 255, 0, 0.1)"],
+              ["${temperature} < 0.5", "rgb(255, 128, 0)"],
+              ["${temperature} < 0.6", 'color("red")'],
+              ["${temperature} < 0.7", 'color("rgb(255, 102, 102)")'],
+              ["${temperature} < 0.8", "hsl(0.875, 1.0, 0.6)"],
+              ["${temperature} < 0.9", "hsla(0.83, 1.0, 0.5, 0.1)"],
+              ["true", 'color("#FFFFFF", 1.0)'],
+            ],
+          },
+        });
+
+        expect(scene).notToRender([0, 0, 0, 255]);
+
+        // Apply show style
+        tileset.style = new Cesium3DTileStyle({
+          show: true,
+        });
+
+        expect(scene).notToRender([0, 0, 0, 255]);
+
+        // Apply show style that hides all points
+        tileset.style = new Cesium3DTileStyle({
+          show: false,
+        });
+
+        expect(scene).toRender([0, 0, 0, 255]);
+
+        // Apply show style with property
+        tileset.style = new Cesium3DTileStyle({
+          show: "${temperature} > 0.1",
+        });
+
+        expect(scene).notToRender([0, 0, 0, 255]);
+        tileset.style = new Cesium3DTileStyle({
+          show: "${temperature} > 1.0",
+        });
+
+        expect(scene).toRender([0, 0, 0, 255]);
+
+        // Apply style with point cloud semantics
+        tileset.style = new Cesium3DTileStyle({
+          color: "${COLOR} / 2.0",
+          show: "${POSITION}[0] > 0.5",
+        });
+
+        expect(scene).notToRender([0, 0, 0, 255]);
+
+        // Apply pointSize style
+        tileset.style = new Cesium3DTileStyle({
+          pointSize: 5.0,
+        });
+
+        expect(scene).notToRender([0, 0, 0, 255]);
+      });
     });
 
     it("applies shader style with unicode property names", function () {
       return Cesium3DTilesTester.loadTileset(
         scene,
         pointCloudWithUnicodePropertyNamesUrl
-      )
-        .then(function (tileset) {
-          tileset.style = new Cesium3DTileStyle({
-            color: "color() * ${feature['temperature ℃']}",
-          });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          expect(scene).toRenderAndCall(function (rgba) {
-            // Pixel color is some shade of gray
-            expect(rgba[0]).toBe(rgba[1]);
-            expect(rgba[0]).toBe(rgba[2]);
-            expect(rgba[0]).toBeGreaterThan(0);
-            expect(rgba[0]).toBeLessThan(255);
-          });
+      ).then(function (tileset) {
+        tileset.style = new Cesium3DTileStyle({
+          color: "color() * ${feature['temperature ℃']}",
         });
+
+        expect(scene).toRenderAndCall(function (rgba) {
+          // Pixel color is some shade of gray
+          expect(rgba[0]).toBe(rgba[1]);
+          expect(rgba[0]).toBe(rgba[2]);
+          expect(rgba[0]).toBeGreaterThan(0);
+          expect(rgba[0]).toBeLessThan(255);
+        });
+      });
     });
 
     it("rebuilds shader style when expression changes", function () {
       let tileset;
-      return Cesium3DTilesTester.loadTileset(scene, pointCloudTilesetUrl)
-        .then(function (t) {
+      return Cesium3DTilesTester.loadTileset(scene, pointCloudTilesetUrl).then(
+        function (t) {
           tileset = t;
           // Solid red color
           tileset.style = new Cesium3DTileStyle({
             color: 'color("red")',
           });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
+
           expect(scene).toRender([255, 0, 0, 255]);
 
           tileset.style.color = new Expression('color("lime")');
@@ -904,86 +875,77 @@ describe(
           for (i = 0; i < commandsLength; ++i) {
             expect(commands[i].pass).not.toBe(Pass.TRANSLUCENT);
           }
-        });
+        }
+      );
     });
 
     it("applies shader style to point cloud with normals", function () {
       return Cesium3DTilesTester.loadTileset(
         scene,
         pointCloudQuantizedOctEncodedUrl
-      )
-        .then(function (tileset) {
-          tileset.style = new Cesium3DTileStyle({
-            color: 'color("red")',
-          });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          expect(scene).toRenderAndCall(function (rgba) {
-            expect(rgba[0]).toBeGreaterThan(0);
-            expect(rgba[0]).toBeLessThan(255);
-          });
+      ).then(function (tileset) {
+        tileset.style = new Cesium3DTileStyle({
+          color: 'color("red")',
         });
+
+        expect(scene).toRenderAndCall(function (rgba) {
+          expect(rgba[0]).toBeGreaterThan(0);
+          expect(rgba[0]).toBeLessThan(255);
+        });
+      });
     });
 
     it("applies shader style to point cloud with normals", function () {
       return Cesium3DTilesTester.loadTileset(
         scene,
         pointCloudQuantizedOctEncodedUrl
-      )
-        .then(function (tileset) {
-          tileset.style = new Cesium3DTileStyle({
-            color: 'color("red")',
-          });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
-          expect(scene).toRenderAndCall(function (rgba) {
-            expect(rgba[0]).toBeGreaterThan(0);
-          });
+      ).then(function (tileset) {
+        tileset.style = new Cesium3DTileStyle({
+          color: 'color("red")',
         });
+
+        expect(scene).toRenderAndCall(function (rgba) {
+          expect(rgba[0]).toBeGreaterThan(0);
+        });
+      });
     });
 
     it("applies shader style to point cloud without colors", function () {
-      return Cesium3DTilesTester.loadTileset(scene, pointCloudNoColorUrl)
-        .then(function (tileset) {
+      return Cesium3DTilesTester.loadTileset(scene, pointCloudNoColorUrl).then(
+        function (tileset) {
           tileset.style = new Cesium3DTileStyle({
             color: 'color("red")',
           });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
+
           expect(scene).toRender([255, 0, 0, 255]);
-        });
+        }
+      );
     });
 
     it("throws if style references the NORMAL semantic but the point cloud does not have per-point normals", function () {
-      return Cesium3DTilesTester.loadTileset(scene, pointCloudRGBUrl)
-        .then(function (tileset) {
+      return Cesium3DTilesTester.loadTileset(scene, pointCloudRGBUrl).then(
+        function (tileset) {
           tileset.style = new Cesium3DTileStyle({
             color: "${NORMAL}[0] > 0.5",
           });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
+
           expect(function () {
             scene.renderForSpecs();
           }).toThrowError(RuntimeError);
-        });
+        }
+      );
     });
 
     it("does not apply shader style if the point cloud has a batch table", function () {
       let content, shaderProgram;
-      return Cesium3DTilesTester.loadTileset(scene, pointCloudBatchedUrl)
-        .then(function (tileset) {
+      return Cesium3DTilesTester.loadTileset(scene, pointCloudBatchedUrl).then(
+        function (tileset) {
           content = tileset.root.content;
           shaderProgram = content._pointCloud._drawCommand.shaderProgram;
           tileset.style = new Cesium3DTileStyle({
             color: 'color("red")',
           });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
+
           scene.renderForSpecs();
           expect(content._pointCloud._drawCommand.shaderProgram).toBe(
             shaderProgram
@@ -991,22 +953,22 @@ describe(
 
           // Point cloud is styled through the batch table
           expect(scene).notToRender([0, 0, 0, 255]);
-        });
+        }
+      );
     });
 
     it("throws when shader style is invalid", function () {
-      return Cesium3DTilesTester.loadTileset(scene, pointCloudRGBUrl)
-        .then(function (tileset) {
+      return Cesium3DTilesTester.loadTileset(scene, pointCloudRGBUrl).then(
+        function (tileset) {
           tileset.style = new Cesium3DTileStyle({
             show: '1 < "2"',
           });
-          return tileset.style.readyPromise;
-        })
-        .then(function () {
+
           expect(function () {
             scene.renderForSpecs();
           }).toThrowError(RuntimeError);
-        });
+        }
+      );
     });
 
     it("gets memory usage", function () {

--- a/Specs/Scene/PointCloudEyeDomeLightingSpec.js
+++ b/Specs/Scene/PointCloudEyeDomeLightingSpec.js
@@ -105,18 +105,16 @@ describe(
             color: "color('red')",
           });
 
-          return tileset.style.readyPromise.then(function () {
-            scene.renderForSpecs();
+          scene.renderForSpecs();
 
-            // Forces destroyed shaders to be released
-            scene.context.shaderCache.destroyReleasedShaderPrograms();
+          // Forces destroyed shaders to be released
+          scene.context.shaderCache.destroyReleasedShaderPrograms();
 
-            tileset.pointCloudShading.eyeDomeLighting = true;
+          tileset.pointCloudShading.eyeDomeLighting = true;
 
-            scene.renderForSpecs();
+          scene.renderForSpecs();
 
-            expect(scene.frameState.commandList.length).toBe(3);
-          });
+          expect(scene.frameState.commandList.length).toBe(3);
         }
       );
     });

--- a/Specs/Scene/TimeDynamicPointCloudSpec.js
+++ b/Specs/Scene/TimeDynamicPointCloudSpec.js
@@ -466,20 +466,17 @@ describe(
           pointSize: 10,
         }),
       });
-      return loadAllFrames(pointCloud)
-        .then(function () {
-          expect(scene).toRender([0, 0, 255, 255]);
-          pointCloud.style = new Cesium3DTileStyle({
-            color: 'color("lime")',
-            pointSize: 10,
-          });
-          return pointCloud.style.readyPromise;
-        })
-        .then(function () {
-          expect(scene).toRender([0, 255, 0, 255]);
-          goToFrame(1); // Also check that the style is updated for the next frame
-          expect(scene).toRender([0, 255, 0, 255]);
+      return loadAllFrames(pointCloud).then(function () {
+        expect(scene).toRender([0, 0, 255, 255]);
+        pointCloud.style = new Cesium3DTileStyle({
+          color: 'color("lime")',
+          pointSize: 10,
         });
+
+        expect(scene).toRender([0, 255, 0, 255]);
+        goToFrame(1); // Also check that the style is updated for the next frame
+        expect(scene).toRender([0, 255, 0, 255]);
+      });
     });
 
     it("make style dirty", function () {

--- a/Specs/Scene/Vector3DTilePointsSpec.js
+++ b/Specs/Scene/Vector3DTilePointsSpec.js
@@ -356,10 +356,7 @@ describe(
         labelVerticalOrigin: `${VerticalOrigin.BOTTOM}`,
       });
 
-      return style.readyPromise
-        .then(function () {
-          return loadPoints(points);
-        })
+      return loadPoints(points)
         .then(function () {
           const features = [];
           points.createFeatures(mockTilesetClone, features);

--- a/Specs/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModelSpec.js
+++ b/Specs/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModelSpec.js
@@ -300,10 +300,7 @@ describe(
           url: tilesetUrl,
         });
 
-        return Promise.all([
-          viewModel.tileset.readyPromise,
-          style.readyPromise,
-        ]);
+        return viewModel.tileset.readyPromise;
       });
 
       afterAll(function () {
@@ -333,12 +330,10 @@ describe(
         viewModel.styleString = JSON.stringify(s);
         viewModel.compileStyle();
         viewModel._update();
-        return style.readyPromise.then(function () {
-          expect(viewModel.tileset.style.style.color).toBe("color('red')");
-          expect(viewModel.tileset.style.style.meta.description).toBe(
-            "'Building id ${id} has height ${Height}.'"
-          );
-        });
+        expect(viewModel.tileset.style.style.color).toBe("color('red')");
+        expect(viewModel.tileset.style.style.meta.description).toBe(
+          "'Building id ${id} has height ${Height}.'"
+        );
       });
 
       it("does not throw on invalid value", function () {


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/10345

This refactors `Cesium3DTilesStyle` so we can treat the object as completely synchronous, and removes the need for `ready` and `readyPromise` properties, which become deprecated. It also removes the `string` and `Resource` types from the constructor, again, deprecating them. Instead, this adds a `fromUrl` static function to asynchronously create a new style from a url.

This also allows us to clean up many of our specs, as we no longer need to wait on the style's `readyPromise` to be fulfilled.

TODO:
- [x] Create `remove in` issue