### PR TITLE
Fix crash for zero-area `region` bounding volumes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 - Models and tilesets rendered with `ModelExperimental` must set `enableDebugWireframe` to true in order for `debugWireframe` to work in WebGL1. [#10344](https://github.com/CesiumGS/cesium/pull/10344)
 
+##### Additions :tada:
+
+- Fixed crash for zero-area `region` bounding volumes in a 3D Tileset.
+
 ##### Fixes :wrench:
 
 - Fixed the inaccurate computation of bounding spheres for `ModelExperimental`. [#10339](https://github.com/CesiumGS/cesium/pull/10339/)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,13 +6,10 @@
 
 - Models and tilesets rendered with `ModelExperimental` must set `enableDebugWireframe` to true in order for `debugWireframe` to work in WebGL1. [#10344](https://github.com/CesiumGS/cesium/pull/10344)
 
-##### Additions :tada:
-
-- Fixed crash for zero-area `region` bounding volumes in a 3D Tileset. [#10351](https://github.com/CesiumGS/cesium/pull/10351)
-
 ##### Fixes :wrench:
 
 - Fixed the inaccurate computation of bounding spheres for `ModelExperimental`. [#10339](https://github.com/CesiumGS/cesium/pull/10339/)
+- Fixed crash for zero-area `region` bounding volumes in a 3D Tileset. [#10351](https://github.com/CesiumGS/cesium/pull/10351)
 
 ### 1.93 - 2022-05-02
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
 
 ##### Additions :tada:
 
-- Fixed crash for zero-area `region` bounding volumes in a 3D Tileset.
+- Fixed crash for zero-area `region` bounding volumes in a 3D Tileset. [#10351](https://github.com/CesiumGS/cesium/pull/10351)
 
 ##### Fixes :wrench:
 

--- a/Specs/Scene/TileBoundingRegionSpec.js
+++ b/Specs/Scene/TileBoundingRegionSpec.js
@@ -67,6 +67,18 @@ describe("Scene/TileBoundingRegion", function () {
     expect(tbr.maximumHeight).toBeDefined();
   });
 
+  it("can be instantiated from a zero-area rectangle", function () {
+    const zeroAreaRectangle = new Rectangle(0.0, 0.0, 0.0, 0.0);
+
+    const tbr = new TileBoundingRegion({ rectangle: zeroAreaRectangle });
+    expect(tbr).toBeDefined();
+    expect(tbr.boundingVolume).toBeDefined();
+    expect(tbr.boundingSphere).toBeDefined();
+    expect(tbr.rectangle).toEqual(zeroAreaRectangle);
+    expect(tbr.minimumHeight).toBeDefined();
+    expect(tbr.maximumHeight).toBeDefined();
+  });
+
   it("distanceToCamera throws when frameState is undefined", function () {
     expect(function () {
       return tileBoundingRegion.distanceToCamera();


### PR DESCRIPTION
One tileset I was looking at had a `region` bounding volume where west and east were the same value. This caused a divide by zero in the `TileBoundingRegion` math.

This isn't disallowed in the spec and it's a pretty straightforward fix. If the east-to-west vector has a magnitude of zero the west normal is used instead. This is fine to do because when a region is infinitesimally small the west vector and east-to-west vector have the same direction.