### PR TITLE
Fix `HeadingPitchRollValues` type

### DIFF
--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -42,9 +42,9 @@ import SceneMode from "./SceneMode.js";
  *
  * An orientation given by numeric heading, pitch, and roll
  *
- * @property {number} [heading] The heading in radians
- * @property {number} [pitch] The pitch in radians
- * @property {number} [roll] The roll in meters
+ * @property {number} [heading=0.0] The heading in radians
+ * @property {number} [pitch=-CesiumMath.PI_OVER_TWO] The pitch in radians
+ * @property {number} [roll=0.0] The roll in meters
  **/
 
 /**

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -42,9 +42,9 @@ import SceneMode from "./SceneMode.js";
  *
  * An orientation given by numeric heading, pitch, and roll
  *
- * @property {number} heading The heading in radians
- * @property {number} pitch The pitch in radians
- * @property {number} roll The roll in meters
+ * @property {number} [heading] The heading in radians
+ * @property {number} [pitch] The pitch in radians
+ * @property {number} [roll] The roll in meters
  **/
 
 /**


### PR DESCRIPTION
Make all the properties optional.

Fix issue: #10359