### PR TITLE
Add `options.url` to `ModelExperimental.fromGltf`

### DIFF
--- a/Apps/Sandcastle/gallery/Custom Shaders Models.html
+++ b/Apps/Sandcastle/gallery/Custom Shaders Models.html
@@ -397,7 +397,7 @@
           viewer.scene.primitives.removeAll();
           const model = viewer.scene.primitives.add(
             Cesium.ModelExperimental.fromGltf({
-              gltf: url,
+              url: url,
               customShader: customShader,
               modelMatrix: Cesium.Transforms.headingPitchRollToFixedFrame(
                 position,

--- a/Apps/Sandcastle/gallery/Model Experimental 3D Models.html
+++ b/Apps/Sandcastle/gallery/Model Experimental 3D Models.html
@@ -128,7 +128,7 @@
           viewer.scene.primitives.removeAll();
           const model = viewer.scene.primitives.add(
             Cesium.ModelExperimental.fromGltf({
-              gltf: url,
+              url: url,
               modelMatrix: Cesium.Transforms.headingPitchRollToFixedFrame(
                 position,
                 hpr,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
 - Added `Cesium3DTileStyle.fromUrl` for loading a style from a url. [#10348](https://github.com/CesiumGS/cesium/pull/10348)
 - Added `IndexDatatype.fromTypedArray`. [#10350](https://github.com/CesiumGS/cesium/pull/10350)
 - Added `ModelAnimationCollection.animateWhilePaused` and `ModelAnimation.animationTime` to allow explicit control over a model's animations. [#9339](https://github.com/CesiumGS/cesium/pull/9339)
-- Added `url` to `ModelExperimental.fromGltf` to match the option in `Model.fromGltf`. [#10371](https://github.com/CesiumGS/cesium/pull/10371)
+- Replaced `options.gltf` with `options.url` in `ModelExperimental.fromGltf`. [#10371](https://github.com/CesiumGS/cesium/pull/10371)
 
 ##### Fixes :wrench:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 - Added `Cesium3DTileStyle.fromUrl` for loading a style from a url. [#10348](https://github.com/CesiumGS/cesium/pull/10348)
 - Added `IndexDatatype.fromTypedArray`. [#10350](https://github.com/CesiumGS/cesium/pull/10350)
 - Added `ModelAnimationCollection.animateWhilePaused` and `ModelAnimation.animationTime` to allow explicit control over a model's animations. [#9339](https://github.com/CesiumGS/cesium/pull/9339)
+- Added `url` to `ModelExperimental.fromGltf` to match the option in `Model.fromGltf`. [#10371](https://github.com/CesiumGS/cesium/pull/10371)
 
 ##### Fixes :wrench:
 

--- a/Documentation/CustomShaderGuide/README.md
+++ b/Documentation/CustomShaderGuide/README.md
@@ -76,7 +76,7 @@ const tileset = viewer.scene.primitives.add(new Cesium.Cesium3DTileset({
 
 // Applying to a model directly
 const model = Cesium.ModelExperimental.fromGltf({,
-  gltf: "http://example.com/model.gltf",
+  url: "http://example.com/model.gltf",
   customShader: customShader
 });
 ```

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -6,7 +6,6 @@ import ClippingPlaneCollection from "../ClippingPlaneCollection.js";
 import defined from "../../Core/defined.js";
 import defer from "../../Core/defer.js";
 import defaultValue from "../../Core/defaultValue.js";
-import deprecationWarning from "../../Core/deprecationWarning.js";
 import DeveloperError from "../../Core/DeveloperError.js";
 import GltfLoader from "../GltfLoader.js";
 import ImageBasedLighting from "../ImageBasedLighting.js";
@@ -1477,8 +1476,7 @@ ModelExperimental.prototype.destroyResources = function () {
  * The model can be a traditional glTF asset with a .gltf extension or a Binary glTF using the .glb extension.
  *
  * @param {Object} options Object with the following properties:
- * @param {String|Resource|Uint8Array|Object} options.gltf A Resource/URL to a glTF/glb file, a binary glTF buffer, or a JSON object containing the glTF contents
- * @param {String|Resource} [options.url] The url to the .gltf file. Deprecated, use options.gltf instead.
+ * @param {String|Resource} options.url The url to the .gltf or .glb file.
  * @param {String|Resource} [options.basePath=''] The base path that paths in the glTF JSON are relative to.
  * @param {Matrix4} [options.modelMatrix=Matrix4.IDENTITY] The 4x4 transformation matrix that transforms the model from model to world coordinates.
  * @param {Number} [options.scale=1.0] A uniform scale applied to this model.
@@ -1516,19 +1514,15 @@ ModelExperimental.fromGltf = function (options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
   //>>includeStart('debug', pragmas.debug);
-  if (!defined(options.gltf) && !defined(options.url)) {
-    throw new DeveloperError("options.gltf is required.");
+  if (!defined(options.url) && !defined(options.gltf)) {
+    throw new DeveloperError("options.url is required.");
   }
   //>>includeEnd('debug');
 
-  if (defined(options.url)) {
-    deprecationWarning(
-      "ModelExperimental.fromGltf",
-      "options.url is deprecated. Use options.gltf instead."
-    );
-  }
-
-  const gltf = defaultValue(options.gltf, options.url);
+  // options.gltf is used internally for 3D Tiles. It can be a Resource, a URL
+  // to a glTF/glb file, a binary glTF buffer, or a JSON object containing the
+  // glTF contents.
+  const gltf = defaultValue(options.url, options.gltf);
 
   const loaderOptions = {
     releaseGltfJson: options.releaseGltfJson,

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -267,6 +267,20 @@ describe(
       });
     });
 
+    it("initializes and renders with url", function () {
+      return loadAndZoomToModelExperimental(
+        {
+          url: boxTexturedGltfUrl,
+        },
+        scene
+      ).then(function (model) {
+        expect(model.ready).toEqual(true);
+        expect(model._sceneGraph).toBeDefined();
+        expect(model._resourcesLoaded).toEqual(true);
+        verifyRender(model, true);
+      });
+    });
+
     // Throws an extraneous promise through the texture loader which cannot be cleanly caught
     // https://github.com/CesiumGS/cesium/issues/10178
     xit("rejects ready promise when texture fails to load", function () {

--- a/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
+++ b/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
@@ -9,6 +9,7 @@ function loadAndZoomToModelExperimental(options, scene) {
         content: options.content,
         color: options.color,
         gltf: options.gltf,
+        url: options.url,
         show: options.show,
         customShader: options.customShader,
         basePath: options.basePath,


### PR DESCRIPTION
This PR adds a `url` option to `ModelExperimental.fromGltf` to match the options in `Model.fromGltf`. There's a deprecation warning to indicate that `gltf` is preferred over `url`.