### PR TITLE
Tweak Atmosphere Sandcastle example

### DIFF
--- a/Apps/Sandcastle/gallery/Atmosphere.html
+++ b/Apps/Sandcastle/gallery/Atmosphere.html
@@ -668,9 +668,7 @@
       function startup(Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          orderIndependentTranslucency: false,
-        });
+        const viewer = new Cesium.Viewer("cesiumContainer");
         const scene = viewer.scene;
         const globe = scene.globe;
         const skyAtmosphere = scene.skyAtmosphere;


### PR DESCRIPTION
The Atmosphere Sandcastle disabled OIT for no reason. As we've learned in the past, this can lead to users copy and pasting it thinking they need it.