### PR TITLE
Gracefully handle external tilesets with metadata but no root tileset schema

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 - Fixed label background rendering. [#10342](https://github.com/CesiumGS/cesium/issues/10342)
 - Fixed crash for zero-area `region` bounding volumes in a 3D Tileset. [#10351](https://github.com/CesiumGS/cesium/pull/10351)
 - Fixed `Cesium3DTileset.debugShowUrl` so that it works for implicit tiles too. [#10372](https://github.com/CesiumGS/cesium/issues/10372)
+- Fixed crash when an external tileset has tile or content metadata but the root tileset does not have a metadata schema. [#10387](https://github.com/CesiumGS/cesium/pull/10387)
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@
 - Fixed label background rendering. [#10342](https://github.com/CesiumGS/cesium/issues/10342)
 - Fixed crash for zero-area `region` bounding volumes in a 3D Tileset. [#10351](https://github.com/CesiumGS/cesium/pull/10351)
 - Fixed `Cesium3DTileset.debugShowUrl` so that it works for implicit tiles too. [#10372](https://github.com/CesiumGS/cesium/issues/10372)
-- Fixed crash when an external tileset has tile or content metadata but the root tileset does not have a metadata schema. [#10387](https://github.com/CesiumGS/cesium/pull/10387)
+- Fixed crash when loading a tileset without a metadata schema but has external tilesets with tile or content metadata. [#10387](https://github.com/CesiumGS/cesium/pull/10387)
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/Source/Scene/findContentMetadata.js
+++ b/Source/Scene/findContentMetadata.js
@@ -29,7 +29,7 @@ function findContentMetadata(tileset, contentHeader) {
   if (!defined(tileset.schema)) {
     findContentMetadata._oneTimeWarning(
       "findContentMetadata-missing-root-schema",
-      "Could not find a metadata schema for content metadata. For external tilesets, make sure the schema is added to the root tileset.json"
+      "Could not find a metadata schema for content metadata. For tilesets that contain external tilesets, make sure the schema is added to the root tileset.json."
     );
     return undefined;
   }

--- a/Source/Scene/findContentMetadata.js
+++ b/Source/Scene/findContentMetadata.js
@@ -1,6 +1,8 @@
 import ContentMetadata from "./ContentMetadata.js";
+import defaultValue from "../Core/defaultValue.js";
 import defined from "../Core/defined.js";
 import hasExtension from "./hasExtension.js";
+import oneTimeWarning from "../Core/oneTimeWarning.js";
 
 /**
  * Check if a content has metadata, either defined in its metadata field (3D Tiles 1.1) or in
@@ -15,7 +17,7 @@ import hasExtension from "./hasExtension.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function findContentMetadata(tileset, contentHeader) {
+function findContentMetadata(tileset, contentHeader) {
   const metadataJson = hasExtension(contentHeader, "3DTILES_metadata")
     ? contentHeader.extensions["3DTILES_metadata"]
     : contentHeader.metadata;
@@ -24,7 +26,18 @@ export default function findContentMetadata(tileset, contentHeader) {
     return undefined;
   }
 
-  const classes = tileset.schema.classes;
+  if (!defined(tileset.schema)) {
+    findContentMetadata._oneTimeWarning(
+      "findContentMetadata-missing-root-schema",
+      "Could not find a metadata schema for content metadata. For external tilesets, make sure the schema is added to the root tileset.json"
+    );
+    return undefined;
+  }
+
+  const classes = defaultValue(
+    tileset.schema.classes,
+    defaultValue.EMPTY_OBJECT
+  );
   if (defined(metadataJson.class)) {
     const contentClass = classes[metadataJson.class];
     return new ContentMetadata({
@@ -35,3 +48,7 @@ export default function findContentMetadata(tileset, contentHeader) {
 
   return undefined;
 }
+
+// Exposed for testing
+findContentMetadata._oneTimeWarning = oneTimeWarning;
+export default findContentMetadata;

--- a/Source/Scene/findTileMetadata.js
+++ b/Source/Scene/findTileMetadata.js
@@ -31,7 +31,7 @@ function findTileMetadata(tileset, tileHeader) {
   if (!defined(tileset.schema)) {
     findTileMetadata._oneTimeWarning(
       "findTileMetadata-missing-root-schema",
-      "Could not find a metadata schema for tile metadata. For external tilesets, make sure the schema is added to the root tileset.json"
+      "Could not find a metadata schema for tile metadata. For tilesets that contain external tilesets, make sure the schema is added to the root tileset.json."
     );
     return undefined;
   }

--- a/Source/Scene/findTileMetadata.js
+++ b/Source/Scene/findTileMetadata.js
@@ -1,6 +1,8 @@
+import defaultValue from "../Core/defaultValue.js";
 import defined from "../Core/defined.js";
 import hasExtension from "./hasExtension.js";
 import TileMetadata from "./TileMetadata.js";
+import oneTimeWarning from "../Core/oneTimeWarning.js";
 
 /**
  * Check if a tile has metadata, either defined in its metadata field (3D Tiles 1.1)
@@ -17,7 +19,7 @@ import TileMetadata from "./TileMetadata.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function findTileMetadata(tileset, tileHeader) {
+function findTileMetadata(tileset, tileHeader) {
   const metadataJson = hasExtension(tileHeader, "3DTILES_metadata")
     ? tileHeader.extensions["3DTILES_metadata"]
     : tileHeader.metadata;
@@ -26,7 +28,18 @@ export default function findTileMetadata(tileset, tileHeader) {
     return undefined;
   }
 
-  const classes = tileset.schema.classes;
+  if (!defined(tileset.schema)) {
+    findTileMetadata._oneTimeWarning(
+      "findTileMetadata-missing-root-schema",
+      "Could not find a metadata schema for tile metadata. For external tilesets, make sure the schema is added to the root tileset.json"
+    );
+    return undefined;
+  }
+
+  const classes = defaultValue(
+    tileset.schema.classes,
+    defaultValue.EMPTY_OBJECT
+  );
   if (defined(metadataJson.class)) {
     const tileClass = classes[metadataJson.class];
     return new TileMetadata({
@@ -37,3 +50,7 @@ export default function findTileMetadata(tileset, tileHeader) {
 
   return undefined;
 }
+
+// Exposed for testing
+findTileMetadata._oneTimeWarning = oneTimeWarning;
+export default findTileMetadata;

--- a/Specs/Data/Cesium3DTiles/Metadata/ExternalTilesetNoRootSchema/ExternalContentMetadata.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/ExternalTilesetNoRootSchema/ExternalContentMetadata.json
@@ -1,0 +1,34 @@
+{
+  "asset": {
+    "version": "1.1",
+    "tilesetVersion": "1.2.3"
+  },
+  "geometricError": 240,
+  "root": {
+    "boundingVolume": {
+      "region": [
+        -1.3197209591796106,
+        0.6988424218,
+        -1.3196390408203893,
+        0.6989055782,
+        0,
+        88
+      ]
+    },
+    "geometricError": 70,
+    "refine": "ADD",
+    "content": {
+      "uri": "../ContentMetadata/tileset_1.1.json",
+      "boundingVolume": {
+        "region": [
+          -1.3197004795898053,
+          0.6988582109,
+          -1.3196595204101946,
+          0.6988897891,
+          0,
+          88
+        ]
+      }
+    }
+  }
+}

--- a/Specs/Data/Cesium3DTiles/Metadata/ExternalTilesetNoRootSchema/ExternalTileMetadata.json
+++ b/Specs/Data/Cesium3DTiles/Metadata/ExternalTilesetNoRootSchema/ExternalTileMetadata.json
@@ -1,0 +1,34 @@
+{
+  "asset": {
+    "version": "1.1",
+    "tilesetVersion": "1.2.3"
+  },
+  "geometricError": 240,
+  "root": {
+    "boundingVolume": {
+      "region": [
+        -1.3197209591796106,
+        0.6988424218,
+        -1.3196390408203893,
+        0.6989055782,
+        0,
+        88
+      ]
+    },
+    "geometricError": 70,
+    "refine": "ADD",
+    "content": {
+      "uri": "../TileMetadata/tileset_1.1.json",
+      "boundingVolume": {
+        "region": [
+          -1.3197004795898053,
+          0.6988582109,
+          -1.3196595204101946,
+          0.6988897891,
+          0,
+          88
+        ]
+      }
+    }
+  }
+}

--- a/Specs/Scene/findContentMetadataSpec.js
+++ b/Specs/Scene/findContentMetadataSpec.js
@@ -40,6 +40,25 @@ describe("Scene/findContentMetadata", function () {
     expect(metadata).not.toBeDefined();
   });
 
+  it("logs a warning and returns undefined if the tileset is missing a schema", function () {
+    const contentHeader = {
+      uri: "https://example.com/model.b3dm",
+      metadata: {
+        class: "content",
+        properties: {
+          name: "Sample Content",
+          color: [255, 255, 0],
+        },
+      },
+    };
+
+    spyOn(findContentMetadata, "_oneTimeWarning");
+    const tilesetWithoutSchema = {};
+    const metadata = findContentMetadata(tilesetWithoutSchema, contentHeader);
+    expect(metadata).not.toBeDefined();
+    expect(findContentMetadata._oneTimeWarning).toHaveBeenCalled();
+  });
+
   it("returns metadata if there is metadata", function () {
     const contentHeader = {
       uri: "https://example.com/model.b3dm",

--- a/Specs/Scene/findTileMetadataSpec.js
+++ b/Specs/Scene/findTileMetadataSpec.js
@@ -44,6 +44,26 @@ describe("Scene/findTileMetadata", function () {
     expect(metadata).not.toBeDefined();
   });
 
+  it("logs a warning and returns undefined if the tileset is missing a schema", function () {
+    const tileHeader = {
+      boundingVolume: mockBoundingVolume,
+      geometricError: 64,
+      metadata: {
+        class: "tile",
+        properties: {
+          height: 250.5,
+          color: [255, 255, 0],
+        },
+      },
+    };
+
+    spyOn(findTileMetadata, "_oneTimeWarning");
+    const tilesetWithoutSchema = {};
+    const metadata = findTileMetadata(tilesetWithoutSchema, tileHeader);
+    expect(metadata).not.toBeDefined();
+    expect(findTileMetadata._oneTimeWarning).toHaveBeenCalled();
+  });
+
   it("returns metadata if there is metadata", function () {
     const tileHeader = {
       boundingVolume: mockBoundingVolume,


### PR DESCRIPTION
When using 3D Tiles Next metadata in external tilesets, the schema must appear in the root `tileset.json`. Right now, if the root schema is missing, the viewer would crash due to an undefined value. 

This PR detects this case, logs a one-time warning, and returns undefined metadata. This way the tileset at least doesn't crash the viewer.

[Local Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=bZDNTsMwEIRfxfIpkSpbiBtNI6SWGz8SqTj54joLNTjeyN6ktIh3J06K1EJ9sXZ2vtFoDfpIrLewg8AWzMOOLSHarhEvo5YpbsZ5iZ609RAUz+fKK29GkqyDCDSgU4aIBjyINtjGku0hCl3X2Uns9F2v1hOYfSnPWBfcDVNcVi2YKFeatDzzyQcgXSf57pMgeO2O+CM+I1JlttCc734B8R7RKz5T/jufeh97HhCbNWbH/vmcz3gRae+gTIXSu7VNi4FSuUwISdC0TtNQZtOZDyBhYkyJyVrIU7Sobc9svbhwOmacjnHYvHbOVfYAipeFHPz/UIe6tv7tqYfg9D7Ztlfl/SQKIQo5jJdJQnQbHf4k/wA) for testing.

@j9liu could you review?