### PR TITLE
Remove individual image-based lighting parameters

### DIFF
--- a/Apps/Sandcastle/gallery/Image-Based Lighting.html
+++ b/Apps/Sandcastle/gallery/Image-Based Lighting.html
@@ -145,8 +145,6 @@
           })
         );
 
-        const ibl = model.imageBasedLighting;
-
         model.readyPromise
           .then(function (model) {
             const camera = viewer.camera;
@@ -170,6 +168,7 @@
             );
             camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
 
+            const ibl = model.imageBasedLighting;
             ibl.sphericalHarmonicCoefficients = coefficients;
             ibl.specularEnvironmentMaps = environmentMapURL;
 

--- a/Apps/Sandcastle/gallery/Image-Based Lighting.html
+++ b/Apps/Sandcastle/gallery/Image-Based Lighting.html
@@ -145,6 +145,8 @@
           })
         );
 
+        const ibl = model.imageBasedLighting;
+
         model.readyPromise
           .then(function (model) {
             const camera = viewer.camera;
@@ -168,12 +170,12 @@
             );
             camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
 
-            model.sphericalHarmonicCoefficients = coefficients;
-            model.specularEnvironmentMaps = environmentMapURL;
+            ibl.sphericalHarmonicCoefficients = coefficients;
+            ibl.specularEnvironmentMaps = environmentMapURL;
 
             // The viewModel tracks the state of our mini application.
             const viewModel = {
-              luminanceAtZenith: model.luminanceAtZenith,
+              luminanceAtZenith: ibl.luminanceAtZenith,
             };
             // Convert the viewModel members into knockout observables.
             Cesium.knockout.track(viewModel);
@@ -186,7 +188,7 @@
               Cesium.knockout
                 .getObservable(viewModel, name)
                 .subscribe(function (newValue) {
-                  model[name] = newValue;
+                  ibl[name] = newValue;
                 });
             }
 
@@ -197,11 +199,11 @@
               false,
               function (checked) {
                 if (!checked) {
-                  model.sphericalHarmonicCoefficients = coefficients;
-                  model.specularEnvironmentMaps = environmentMapURL;
+                  ibl.sphericalHarmonicCoefficients = coefficients;
+                  ibl.specularEnvironmentMaps = environmentMapURL;
                 } else {
-                  model.sphericalHarmonicCoefficients = undefined;
-                  model.specularEnvironmentMaps = undefined;
+                  ibl.sphericalHarmonicCoefficients = undefined;
+                  ibl.specularEnvironmentMaps = undefined;
                 }
               }
             );

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ##### Breaking Changes :mega:
 
+- Removed individual image-based lighting parameters from `Model` and `Cesium3DTileset`. [#10388](https://github.com/CesiumGS/cesium/pull/10388)
 - Models and tilesets rendered with `ModelExperimental` must set `enableDebugWireframe` to true in order for `debugWireframe` to work in WebGL1. [#10344](https://github.com/CesiumGS/cesium/pull/10344)
 
 ##### Additions :tada:

--- a/Source/DataSources/ModelVisualizer.js
+++ b/Source/DataSources/ModelVisualizer.js
@@ -204,7 +204,7 @@ ModelVisualizer.prototype.update = function (time) {
       time,
       defaultClampAnimations
     );
-    model.imageBasedLighting.imageBasedLightingFactor = Property.getValueOrDefault(
+    model.imageBasedLightingFactor = Property.getValueOrDefault(
       modelGraphics._imageBasedLightingFactor,
       time,
       defaultImageBasedLightingFactor

--- a/Source/DataSources/ModelVisualizer.js
+++ b/Source/DataSources/ModelVisualizer.js
@@ -204,7 +204,7 @@ ModelVisualizer.prototype.update = function (time) {
       time,
       defaultClampAnimations
     );
-    model.imageBasedLightingFactor = Property.getValueOrDefault(
+    model.imageBasedLighting.imageBasedLightingFactor = Property.getValueOrDefault(
       modelGraphics._imageBasedLightingFactor,
       time,
       defaultImageBasedLightingFactor

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -95,10 +95,6 @@ import TileOrientedBoundingBox from "./TileOrientedBoundingBox.js";
  * @param {Object} [options.pointCloudShading] Options for constructing a {@link PointCloudShading} object to control point attenuation based on geometric error and lighting.
  * @param {Cartesian3} [options.lightColor] The light color when shading models. When <code>undefined</code> the scene's light color is used instead.
  * @param {ImageBasedLighting} [options.imageBasedLighting] The properties for managing image-based lighting for this tileset.
- * @param {Cartesian2} [options.imageBasedLightingFactor=new Cartesian2(1.0, 1.0)] Scales the diffuse and specular image-based lighting from the earth, sky, atmosphere and star skybox. Deprecated in Cesium 1.92, will be removed in Cesium 1.94.
- * @param {Number} [options.luminanceAtZenith=0.2] The sun's luminance at the zenith in kilo candela per meter squared to use for this model's procedural environment map. Deprecated in Cesium 1.92, will be removed in Cesium 1.94.
- * @param {Cartesian3[]} [options.sphericalHarmonicCoefficients] The third order spherical harmonic coefficients used for the diffuse color of image-based lighting. Deprecated in Cesium 1.92, will be removed in Cesium 1.94.
- * @param {String} [options.specularEnvironmentMaps] A URL to a KTX2 file that contains a cube map of the specular lighting and the convoluted specular mipmaps. Deprecated in Cesium 1.92, will be removed in Cesium 1.94.
  * @param {Boolean} [options.backFaceCulling=true] Whether to cull back-facing geometry. When true, back face culling is determined by the glTF material's doubleSided property; when false, back face culling is disabled.
  * @param {Boolean} [options.showOutline=true] Whether to display the outline for models using the {@link https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Vendor/CESIUM_primitive_outline|CESIUM_primitive_outline} extension. When true, outlines are displayed. When false, outlines are not displayed.
  * @param {Boolean} [options.vectorClassificationOnly=false] Indicates that only the tileset's vector tiles should be used for classification.
@@ -724,28 +720,9 @@ function Cesium3DTileset(options) {
   this._clippingPlanes = undefined;
   this.clippingPlanes = options.clippingPlanes;
 
-  const hasIndividualIBLParameters =
-    defined(options.imageBasedLightingFactor) ||
-    defined(options.luminanceAtZenith) ||
-    defined(options.sphericalHarmonicCoefficients) ||
-    defined(options.specularEnvironmentMaps);
-
   if (defined(options.imageBasedLighting)) {
     this._imageBasedLighting = options.imageBasedLighting;
     this._shouldDestroyImageBasedLighting = false;
-  } else if (hasIndividualIBLParameters) {
-    deprecationWarning(
-      "ImageBasedLightingConstructor",
-      "Individual image-based lighting parameters were deprecated in Cesium 1.92. They will be removed in version 1.94. Use options.imageBasedLighting instead."
-    );
-    // Create image-based lighting from the old constructor parameters.
-    this._imageBasedLighting = new ImageBasedLighting({
-      imageBasedLightingFactor: options.imageBasedLightingFactor,
-      luminanceAtZenith: options.luminanceAtZenith,
-      sphericalHarmonicCoefficients: options.sphericalHarmonicCoefficients,
-      specularEnvironmentMaps: options.specularEnvironmentMaps,
-    });
-    this._shouldDestroyImageBasedLighting = true;
   } else {
     this._imageBasedLighting = new ImageBasedLighting();
     this._shouldDestroyImageBasedLighting = true;
@@ -754,8 +731,9 @@ function Cesium3DTileset(options) {
   /**
    * The light color when shading models. When <code>undefined</code> the scene's light color is used instead.
    * <p>
-   * For example, disabling additional light sources by setting <code>model.imageBasedLighting.imageBasedLightingFactor = new Cartesian2(0.0, 0.0)</code> will make the
-   * model much darker. Here, increasing the intensity of the light source will make the model brighter.
+   * For example, disabling additional light sources by setting
+   * <code>tileset.imageBasedLighting.imageBasedLighting.imageBasedLightingFactor = new Cartesian2(0.0, 0.0)</code>
+   * will make the model much darker. Here, increasing the intensity of the light source will make the model brighter.
    * </p>
    *
    * @type {Cartesian3}
@@ -1845,89 +1823,6 @@ Object.defineProperties(Cesium3DTileset.prototype, {
         this._imageBasedLighting = value;
         this._shouldDestroyImageBasedLighting = false;
       }
-    },
-  },
-
-  /**
-   * Cesium adds lighting from the earth, sky, atmosphere, and star skybox. This cartesian is used to scale the final
-   * diffuse and specular lighting contribution from those sources to the final color. A value of 0.0 will disable those light sources.
-   *
-   * @memberof Cesium3DTileset.prototype
-   *
-   * @type {Cartesian2}
-   * @default Cartesian2(1.0, 1.0)
-   */
-  imageBasedLightingFactor: {
-    get: function () {
-      return this._imageBasedLighting.imageBasedLightingFactor;
-    },
-    set: function (value) {
-      this._imageBasedLighting.imageBasedLightingFactor = value;
-    },
-  },
-
-  /**
-   * The sun's luminance at the zenith in kilo candela per meter squared to use for this model's procedural environment map.
-   * This is used when {@link Cesium3DTileset#specularEnvironmentMaps} and {@link Cesium3DTileset#sphericalHarmonicCoefficients} are not defined.
-   *
-   * @memberof Cesium3DTileset.prototype
-   *
-   * @type {Number}
-   * @default 0.2
-   */
-  luminanceAtZenith: {
-    get: function () {
-      return this._imageBasedLighting.luminanceAtZenith;
-    },
-    set: function (value) {
-      this._imageBasedLighting.luminanceAtZenith = value;
-    },
-  },
-
-  /**
-   * The third order spherical harmonic coefficients used for the diffuse color of image-based lighting. When <code>undefined</code>, a diffuse irradiance
-   * computed from the atmosphere color is used.
-   * <p>
-   * There are nine <code>Cartesian3</code> coefficients.
-   * The order of the coefficients is: L<sub>0,0</sub>, L<sub>1,-1</sub>, L<sub>1,0</sub>, L<sub>1,1</sub>, L<sub>2,-2</sub>, L<sub>2,-1</sub>, L<sub>2,0</sub>, L<sub>2,1</sub>, L<sub>2,2</sub>
-   * </p>
-   *
-   * These values can be obtained by preprocessing the environment map using the <code>cmgen</code> tool of
-   * {@link https://github.com/google/filament/releases|Google's Filament project}. This will also generate a KTX file that can be
-   * supplied to {@link Cesium3DTileset#specularEnvironmentMaps}.
-   *
-   * @memberof Cesium3DTileset.prototype
-   *
-   * @type {Cartesian3[]}
-   *
-   * @demo {@link https://sandcastle.cesium.com/index.html?src=Image-Based Lighting.html|Sandcastle Image Based Lighting Demo}
-   * @see {@link https://graphics.stanford.edu/papers/envmap/envmap.pdf|An Efficient Representation for Irradiance Environment Maps}
-   */
-  sphericalHarmonicCoefficients: {
-    get: function () {
-      return this._imageBasedLighting.sphericalHarmonicCoefficients;
-    },
-    set: function (value) {
-      this._imageBasedLighting.sphericalHarmonicCoefficients = value;
-    },
-  },
-
-  /**
-   * A URL to a KTX file that contains a cube map of the specular lighting and the convoluted specular mipmaps.
-   *
-   * @memberof Cesium3DTileset.prototype
-   *
-   * @type {String}
-   *
-   * @demo {@link https://sandcastle.cesium.com/index.html?src=Image-Based Lighting.html|Sandcastle Image Based Lighting Demo}
-   * @see Cesium3DTileset#sphericalHarmonicCoefficients
-   */
-  specularEnvironmentMaps: {
-    get: function () {
-      return this._imageBasedLighting.specularEnvironmentMaps;
-    },
-    set: function (value) {
-      this._imageBasedLighting.specularEnvironmentMaps = value;
     },
   },
 

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -732,8 +732,8 @@ function Cesium3DTileset(options) {
    * The light color when shading models. When <code>undefined</code> the scene's light color is used instead.
    * <p>
    * For example, disabling additional light sources by setting
-   * <code>tileset.imageBasedLighting.imageBasedLighting.imageBasedLightingFactor = new Cartesian2(0.0, 0.0)</code>
-   * will make the model much darker. Here, increasing the intensity of the light source will make the model brighter.
+   * <code>tileset.imageBasedLighting.imageBasedLightingFactor = new Cartesian2(0.0, 0.0)</code>
+   * will make the tileset much darker. Here, increasing the intensity of the light source will make the tileset brighter.
    * </p>
    *
    * @type {Cartesian3}

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -223,7 +223,6 @@ function initialize(content, arrayBuffer, byteOffset) {
     opaquePass: Pass.CESIUM_3D_TILE, // Draw opaque portions during the 3D Tiles pass
     pickIdLoaded: getPickIdCallback(content),
     imageBasedLighting: tileset.imageBasedLighting,
-    specularEnvironmentMaps: tileset.specularEnvironmentMaps,
     backFaceCulling: tileset.backFaceCulling,
     showOutline: tileset.showOutline,
     showCreditsOnScreen: tileset.showCreditsOnScreen,

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -1152,8 +1152,9 @@ Object.defineProperties(Model.prototype, {
   /**
    * The light color when shading the model. When <code>undefined</code> the scene's light color is used instead.
    * <p>
-   * For example, disabling additional light sources by setting <code>model.imageBasedLightingFactor = new Cesium.Cartesian2(0.0, 0.0)</code> will make the
-   * model much darker. Here, increasing the intensity of the light source will make the model brighter.
+   * For example, disabling additional light sources by setting
+   * <code>model.imageBasedLighting.imageBasedLightingFactor = new Cesium.Cartesian2(0.0, 0.0)</code>
+   * will make the model much darker. Here, increasing the intensity of the light source will make the model brighter.
    * </p>
    *
    * @memberof Model.prototype

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -873,8 +873,9 @@ Object.defineProperties(ModelExperimental.prototype, {
   /**
    * The light color when shading the model. When <code>undefined</code> the scene's light color is used instead.
    * <p>
-   * Disabling additional light sources by setting <code>model.imageBasedLightingFactor = new Cartesian2(0.0, 0.0)</code> will make the
-   * model much darker. Here, increasing the intensity of the light source will make the model brighter.
+   * Disabling additional light sources by setting
+   * <code>model.imageBasedLighting.imageBasedLightingFactor = new Cartesian2(0.0, 0.0)</code>
+   * will make the model much darker. Here, increasing the intensity of the light source will make the model brighter.
    * </p>
    * @memberof ModelExperimental.prototype
    *

--- a/Source/Scene/ModelInstanceCollection.js
+++ b/Source/Scene/ModelInstanceCollection.js
@@ -60,10 +60,6 @@ const LoadState = {
  * @param {ShadowMode} [options.shadows=ShadowMode.ENABLED] Determines whether the collection casts or receives shadows from light sources.
  * @param {Cartesian3} [options.lightColor] The light color when shading models. When <code>undefined</code> the scene's light color is used instead.
  * @param {ImageBasedLighting} [options.imageBasedLighting] The properties for managing image-based lighting for this tileset.
- * @param {Cartesian2} [options.imageBasedLightingFactor=new Cartesian2(1.0, 1.0)] Scales diffuse and specular image-based lighting from the earth, sky, atmosphere and star skybox. Deprecated in Cesium 1.92, will be removed in Cesium 1.94.
- * @param {Number} [options.luminanceAtZenith=0.2] The sun's luminance at the zenith in kilo candela per meter squared to use for this model's procedural environment map. Deprecated in Cesium 1.92, will be removed in Cesium 1.94.
- * @param {Cartesian3[]} [options.sphericalHarmonicCoefficients] The third order spherical harmonic coefficients used for the diffuse color of image-based lighting. Deprecated in Cesium 1.92, will be removed in Cesium 1.94.
- * @param {String} [options.specularEnvironmentMaps] A URL to a KTX2 file that contains a cube map of the specular lighting and the convoluted specular mipmaps. Deprecated in Cesium 1.92, will be removed in Cesium 1.94.
  * @param {Boolean} [options.backFaceCulling=true] Whether to cull back-facing geometry. When true, back face culling is determined by the glTF material's doubleSided property; when false, back face culling is disabled.
  * @param {Boolean} [options.showCreditsOnScreen=false] Whether to display the credits of this model on screen.
  * @param {SplitDirection} [options.splitDirection=SplitDirection.NONE] The {@link SplitDirection} split to apply to this collection.
@@ -170,13 +166,7 @@ function ModelInstanceCollection(options) {
     this._imageBasedLighting = options.imageBasedLighting;
     this._shouldDestroyImageBasedLighting = false;
   } else {
-    // Create image-based lighting from the old constructor parameters.
-    this._imageBasedLighting = new ImageBasedLighting({
-      imageBasedLightingFactor: options.imageBasedLightingFactor,
-      luminanceAtZenith: options.luminanceAtZenith,
-      sphericalHarmonicCoefficients: options.sphericalHarmonicCoefficients,
-      specularEnvironmentMaps: options.specularEnvironmentMaps,
-    });
+    this._imageBasedLighting = new ImageBasedLighting();
     this._shouldDestroyImageBasedLighting = true;
   }
 

--- a/Source/Scene/ModelInstanceCollection.js
+++ b/Source/Scene/ModelInstanceCollection.js
@@ -218,38 +218,6 @@ Object.defineProperties(ModelInstanceCollection.prototype, {
       }
     },
   },
-  imageBasedLightingFactor: {
-    get: function () {
-      return this._imageBasedLighting.imageBasedLightingFactor;
-    },
-    set: function (value) {
-      this._imageBasedLighting.imageBasedLightingFactor = value;
-    },
-  },
-  luminanceAtZenith: {
-    get: function () {
-      return this._imageBasedLighting.luminanceAtZenith;
-    },
-    set: function (value) {
-      this._imageBasedLighting.luminanceAtZenith = value;
-    },
-  },
-  sphericalHarmonicCoefficients: {
-    get: function () {
-      return this._imageBasedLighting.sphericalHarmonicCoefficients;
-    },
-    set: function (value) {
-      this._imageBasedLighting.sphericalHarmonicCoefficients = value;
-    },
-  },
-  specularEnvironmentMaps: {
-    get: function () {
-      return this._imageBasedLighting.specularEnvironmentMaps;
-    },
-    set: function (value) {
-      this._imageBasedLighting.specularEnvironmentMaps = value;
-    },
-  },
 });
 
 function createInstances(collection, instancesOptions) {

--- a/Specs/DataSources/ModelVisualizerSpec.js
+++ b/Specs/DataSources/ModelVisualizerSpec.js
@@ -176,7 +176,7 @@ describe(
       expect(primitive.clippingPlanes._planes[0].distance).toEqual(
         clippingPlanes._planes[0].distance
       );
-      expect(primitive.imageBasedLightingFactor).toEqual(
+      expect(primitive.imageBasedLighting.imageBasedLightingFactor).toEqual(
         new Cartesian2(0.5, 0.5)
       );
       expect(primitive.lightColor).toEqual(new Color(1.0, 1.0, 0.0, 1.0));

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -2552,9 +2552,10 @@ describe(
       };
       return Cesium3DTilesTester.loadTileset(scene, withoutBatchTableUrl).then(
         function (tileset) {
+          const ibl = tileset.imageBasedLighting;
           expect(renderOptions).toRenderAndCall(function (rgba) {
             expect(rgba).not.toEqual([0, 0, 0, 255]);
-            tileset.imageBasedLightingFactor = new Cartesian2(0.0, 0.0);
+            ibl.imageBasedLightingFactor = new Cartesian2(0.0, 0.0);
             expect(renderOptions).notToRender(rgba);
           });
         }
@@ -2568,9 +2569,10 @@ describe(
       };
       return Cesium3DTilesTester.loadTileset(scene, withoutBatchTableUrl).then(
         function (tileset) {
+          const ibl = tileset.imageBasedLighting;
           expect(renderOptions).toRenderAndCall(function (rgba) {
             expect(rgba).not.toEqual([0, 0, 0, 255]);
-            tileset.imageBasedLightingFactor = new Cartesian2(0.0, 0.0);
+            ibl.imageBasedLightingFactor = new Cartesian2(0.0, 0.0);
             expect(renderOptions).toRenderAndCall(function (rgba2) {
               expect(rgba2).not.toEqual(rgba);
               tileset.lightColor = new Cartesian3(5.0, 5.0, 5.0);

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -1,4 +1,4 @@
-import { Cartesian2, ImageBasedLighting } from "../../Source/Cesium.js";
+import { Cartesian2 } from "../../Source/Cesium.js";
 import { Cartesian3 } from "../../Source/Cesium.js";
 import { Cartesian4 } from "../../Source/Cesium.js";
 import { CesiumTerrainProvider } from "../../Source/Cesium.js";
@@ -12,6 +12,7 @@ import { Ellipsoid } from "../../Source/Cesium.js";
 import { Event } from "../../Source/Cesium.js";
 import { FeatureDetection } from "../../Source/Cesium.js";
 import { HeadingPitchRange } from "../../Source/Cesium.js";
+import { ImageBasedLighting } from "../../Source/Cesium.js";
 import { JulianDate } from "../../Source/Cesium.js";
 import { Math as CesiumMath } from "../../Source/Cesium.js";
 import { Matrix3 } from "../../Source/Cesium.js";
@@ -3874,9 +3875,10 @@ describe(
       return loadModel(boxPbrUrl).then(function (model) {
         model.show = true;
         model.zoomTo();
+        const ibl = model.imageBasedLighting;
         expect(scene).toRenderAndCall(function (rgba) {
           expect(rgba).not.toEqual([0, 0, 0, 255]);
-          model.imageBasedLightingFactor = new Cartesian2(0.0, 0.0);
+          ibl.imageBasedLightingFactor = new Cartesian2(0.0, 0.0);
           expect(scene).notToRender(rgba);
 
           primitives.remove(model);
@@ -3888,9 +3890,10 @@ describe(
       return loadModel(boxPbrUrl).then(function (model) {
         model.show = true;
         model.zoomTo();
+        const ibl = model.imageBasedLighting;
         expect(scene).toRenderAndCall(function (rgba) {
           expect(rgba).not.toEqual([0, 0, 0, 255]);
-          model.luminanceAtZenith = 0.0;
+          ibl.luminanceAtZenith = 0.0;
           expect(scene).notToRender(rgba);
 
           primitives.remove(model);
@@ -3903,8 +3906,9 @@ describe(
         return;
       }
 
-      return loadModel(boomBoxUrl).then(function (m) {
-        m.scale = 20.0; // Source model is very small, so scale up a bit
+      return loadModel(boomBoxUrl).then(function (model) {
+        model.scale = 20.0; // Source model is very small, so scale up a bit
+        const ibl = model.imageBasedLighting;
 
         const L00 = new Cartesian3(
           0.692622075009195,
@@ -3951,7 +3955,7 @@ describe(
           0.120896423762313,
           0.121102528320197
         ); // L22, irradiance, pre-scaled base
-        m.sphericalHarmonicCoefficients = [
+        ibl.sphericalHarmonicCoefficients = [
           L00,
           L1_1,
           L10,
@@ -3964,8 +3968,8 @@ describe(
         ];
 
         scene.highDynamicRange = true;
-        verifyRender(m);
-        primitives.remove(m);
+        verifyRender(model);
+        primitives.remove(model);
         scene.highDynamicRange = false;
       });
     });
@@ -3975,24 +3979,23 @@ describe(
         return;
       }
 
-      return loadModel(boomBoxUrl).then(function (m) {
-        m.scale = 20.0; // Source model is very small, so scale up a bit
-        m.specularEnvironmentMaps =
+      return loadModel(boomBoxUrl).then(function (model) {
+        model.scale = 20.0; // Source model is very small, so scale up a bit
+
+        const ibl = model.imageBasedLighting;
+        ibl.specularEnvironmentMaps =
           "./Data/EnvironmentMap/kiara_6_afternoon_2k_ibl.ktx2";
 
-        const ibl = m.imageBasedLighting;
         return pollToPromise(function () {
-          scene.highDynamicRange = true;
           scene.render();
-          scene.highDynamicRange = false;
           return (
             defined(ibl.specularEnvironmentMapAtlas) &&
             ibl.specularEnvironmentMapAtlas.ready
           );
         }).then(function () {
           scene.highDynamicRange = true;
-          verifyRender(m);
-          primitives.remove(m);
+          verifyRender(model);
+          primitives.remove(model);
           scene.highDynamicRange = false;
         });
       });
@@ -4012,7 +4015,8 @@ describe(
           expect(rgba).toEqualEpsilon([131, 9, 9, 255], 5);
         });
 
-        model.imageBasedLightingFactor = new Cartesian2(0.0, 0.0);
+        const ibl = model.imageBasedLighting;
+        ibl.imageBasedLightingFactor = new Cartesian2(0.0, 0.0);
         expect(sceneArgs).toRenderAndCall(function (rgba) {
           expect(rgba).toEqualEpsilon([102, 9, 9, 255], 5);
         });


### PR DESCRIPTION
Will close #10232 . Individual image-based lighting parameters were deprecated and are to be removed in Cesium 1.94. This PR removes those from the constructor options in `Model` and `Cesium3DTileset.` It also updates the image-based lighting sandcastle and updates `ModelVisualizer`, which is relevant for creating models with the `Entity` class.

To test the entity changes, I added a field to [this sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=xVl5b9s2FP8qhPdHFECR7TTZOtfJFqfdGqBZt6btjroYaIm2iVCkQFI5VuS77/HQrR5OnS1oEPF67/fuRzYWXGl0Rck1kegIcXKNTomieRq9tXPBfBDb8angGlNO5HwQog9zjhDlSzETNxO0xEyR0EwpwkisqeBnPKEx1kI2Vtc4EddqgrTMixmRs+SE0xRrUs7f7T6Z8zlnRCPCNdW3drjMuSWNVkSfCibkjBGenIuEBHFjuOvgSaJzyQtpmifeNU9EWrzJMiJPsSLB7ntgd9fL0TH6BackRJhla+xZxVaJdhF0WOf4rjzR5dELMVpKkZ4Y2o5ZiDIsFfmJCawDx3O3wDccotdrYo1npGCgPxxfKqRhUmnQKBJLJHKJUsopwlnGjE1AoGjO49Lu7uhRIQkzNpsPXpEEDF1OgdHezQe/r6kmxv7FOnz8LAnh7nPGcr/6J2FMXBcb8O188N7SsgJM0DgaVaRLKxi2z+lqzeBX15mXOxyK+h6LJGM49ozP6U3Bqzp6koqc6wkaRYe9K884XjCSNFyVMnBNojU57WqktehQ3U8hFamTpmqqhQv6D6hm387fPfF2h2i8IlJbU1dGTEm6IFJBZGqBLrmIL0WukVgoIq+MiAoM752tWI2szwQljd2Cw4zypEUeiJqJpy/PEcR5CrGpjIeZuTdn8AdDDGDG0BLCgOrSybQQbIFNZCQizs2xCALqmaMwuz1LIMf4PfOB4d+GaDz31uChfKUqqGFB2WFunTJKNHxeltLXT0JWM6YDfnafyhcqlnRBgjLmA0iFbzEY0Mc48rkoSg2FqAj2MjUU28NKYZGLVxvqd/cCaQlsEWQFzSeX8vxXgGzG6EZoa4mzJFDDW2X4Js4+MevnmxP+SEv2bvyjI7cRdQAdHfWXkej87I+tKM7h+EpD1yiBDmplYxtGbuW8+0NtEap7Z6H+MpSKicp0rXzpNmxHrpOvi7UvkKtPDLsjbEu+TblM/diGWIbOF/hVo3GKJYE2xIIKcgnA1sQUbs/KdZ2R5UehOEmSiiuwAwscqSI/ZEJRS64KQyw1fGH+yPZLT8kKiq7yit4b7z+KRt8dHHw7/t5r9uAgGh2OHn03+tZPOBzm24F3jNYEmxpT8TnHeg2N2yuYxlwF40eH9e0Z1fEaNo9qc1Iw1ppaZ63O+rlj86s5/gr2B55v6CiGlkidkZAUlISbOngtARKU2lRF6xbB33LQuuSw3auk0GAhfSYL0c1fZ3Cg3DYITpLAOwWHFnaCjA2bFCdt2jWsk/rAL1uvmhSuhoAirZNFtldN8/RXekOYa33G+4+rVXxjVi+gzzBN0Qh+wkbWnnyi2LULc9if7yc99aeveNi7Rg+Not2sRcrHa09FoNNydvLHl2SQzyZLMHsPS6fpXsTNTcXhu7CM+TKQbStJkmeFO5WXN3tb8a6cGWdQsPrOnPR+oMmNNj32CZWxxMui+wdv4u5KCb15mbB2K++p55dKA/NBFA3h3wVOM0aeYo2H1u3U0IUOcPFff8NntGKLkp/5OQSnikaltp40BA57UP8swZIJekvWNGbkobA7Lp5Jc9QRYRP0z4VGoAY0g9ZdCP6wqvdMmqMO/PGmFjin7BK9lnl8+bDwDR/Lpj3+KgtcXFLOof88XWOIIG2fWB5SCFzo/2/43AT5e1swLjBPYqw0+B0UiNfuDnZOeB744N7t3bZaMTLLtTZFaXDhnoLMhdgnD/84FNYktQVwTUxOmfNmz+B3m17fbXhSPht9ku/Z7IXhaR+aPsOJLgM/1d8Z0RSvyAwrkrwwvQTU35/AeKJV68tOZT8wV3tzv/ftEtyhFdmUcodq9NezVy8dwVIDcz4IB1Olbxk5Loz5I00zIbUptQH4hibgG+A7argA7yU6ipUq7I3QN8WV/UPlFgvI7SubdCZIrhY4ONgPUfE7ih5Xp6E5AMUD6gk6yG5q0wshEyL3JDQruWou3nVYU57lug7AvHdQqPt7mNEV9BYpTRJGulz3tMigNWhwLpYWAvwgba52Wdt+ijSkXwqu965t0zgBOVjSPj4d1vU9TegVoslRz+MpihlWClaWOWOuNz+eDmF/5yjUYQP6JQjOzIvR8XQ9Pn7hJqMomg5h2H+yfE0pzT/V5opwXAk01QuR3NYmzJRsjM1MUsJ1OgGS7i3Idh3ToU6aJIYtGr00LYnOWbfUnIE5lwBRAmlsb0G5Ec+nmUn7dRByibmOtOetgh2ZNsN74u8X3q19HnALZx3efQHZ/u5LNeoiS99mBKDBJWIFGjJtN4xM1R2YJhu+x/ZbaZK5hTGM6kJ5GWwr7SV6kyX2HX/Hstip+V8/c1MADQ+IAhgdfoJBh9Q9NdVgYCMW7iLFzeFj70I/oJ0dBFKtJL7dueuRyrw6fxrdf2KKNv5+q4RQbIxcH5V3O2brgtmU7X1N/JGMdVHeYx4i7DfKW+3/QCgTQueVbduZ639MFK3b6EOmjM6j3pa0Z8r1tpU32lR7BsR/ozzfnWymOxg2OgsY11qPer/yLw) to toggle the image based lighting factor. Seems to be the only IBL-related parameter to apply to models created with the `Entity` class. Maybe we should add the others in at a later time?

EDIT: I am not sure why Github isn't showing it under files changed, but I edited `Source/DataSources/ModelVisualizer.js` for this PR.