### PR TITLE
Remove wasm workaround for Edge

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
 - Fixed the inaccurate computation of bounding spheres for `ModelExperimental`. [#10339](https://github.com/CesiumGS/cesium/pull/10339/)
 - Fixed race condition which can occur when updating `Cesium3DTileStyle` before its `readyPromise` has resolved. [#10345](https://github.com/CesiumGS/cesium/issues/10345)
 - Fixed label background rendering. [#10342](https://github.com/CesiumGS/cesium/issues/10342)
+- Enabled support for loading web assembly modules in Edge. [#6541](https://github.com/CesiumGS/cesium/pull/6541)
 - Fixed crash for zero-area `region` bounding volumes in a 3D Tileset. [#10351](https://github.com/CesiumGS/cesium/pull/10351)
 
 ##### Deprecated :hourglass_flowing_sand:

--- a/Source/Core/FeatureDetection.js
+++ b/Source/Core/FeatureDetection.js
@@ -416,6 +416,6 @@ FeatureDetection.supportsWebWorkers = function () {
  * @see {@link https://developer.mozilla.org/en-US/docs/WebAssembly}
  */
 FeatureDetection.supportsWebAssembly = function () {
-  return typeof WebAssembly !== "undefined" && !FeatureDetection.isEdge();
+  return typeof WebAssembly !== "undefined";
 };
 export default FeatureDetection;


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/6542

Removes the exception for Edge for web assembly module support.

@sanjeetsuhag Can you very this in Edge? You should be able to load a Draco module such as in https://sandcastle.cesium.com/?src=3D%20Models.html without error.