### PR TITLE
Refactor wireframe indices to `WireframePipelineStage`

### DIFF
--- a/Source/Scene/ModelExperimental/ModelExperimentalNode.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalNode.js
@@ -99,8 +99,6 @@ export default function ModelExperimentalNode(options) {
    * @private
    */
   this.updateStages = [];
-
-  this.configurePipeline();
 }
 
 Object.defineProperties(ModelExperimentalNode.prototype, {

--- a/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
@@ -110,8 +110,6 @@ export default function ModelExperimentalPrimitive(options) {
    * @private
    */
   this.updateStages = [];
-
-  //this.configurePipeline();
 }
 
 /**

--- a/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
@@ -19,6 +19,7 @@ import PickingPipelineStage from "./PickingPipelineStage.js";
 import PointCloudAttenuationPipelineStage from "./PointCloudAttenuationPipelineStage.js";
 import SelectedFeatureIdPipelineStage from "./SelectedFeatureIdPipelineStage.js";
 import SkinningPipelineStage from "./SkinningPipelineStage.js";
+import WireframePipelineStage from "./WireframePipelineStage.js";
 
 /**
  * In memory representation of a single primitive, that is, a primitive
@@ -110,7 +111,7 @@ export default function ModelExperimentalPrimitive(options) {
    */
   this.updateStages = [];
 
-  this.configurePipeline();
+  //this.configurePipeline();
 }
 
 /**
@@ -118,9 +119,11 @@ export default function ModelExperimentalPrimitive(options) {
  * this method again to ensure the correct sequence of pipeline stages are
  * used.
  *
+ * @param {FrameState} frameState The frame state.
+ *
  * @private
  */
-ModelExperimentalPrimitive.prototype.configurePipeline = function () {
+ModelExperimentalPrimitive.prototype.configurePipeline = function (frameState) {
   const pipelineStages = this.pipelineStages;
   pipelineStages.length = 0;
 
@@ -128,6 +131,8 @@ ModelExperimentalPrimitive.prototype.configurePipeline = function () {
   const node = this.node;
   const model = this.model;
   const customShader = model.customShader;
+  const context = frameState.context;
+  const useWebgl2 = context.webgl2;
 
   const hasMorphTargets =
     defined(primitive.morphTargets) && primitive.morphTargets.length > 0;
@@ -141,6 +146,13 @@ ModelExperimentalPrimitive.prototype.configurePipeline = function () {
   const hasQuantization = ModelExperimentalUtility.hasQuantizedAttributes(
     primitive.attributes
   );
+  const generateWireframeIndices =
+    model.debugWireframe &&
+    PrimitiveType.isTriangles(primitive.primitiveType) &&
+    // Generating index buffers for wireframes is always possible in WebGL2.
+    // However, this will only work in WebGL1 if the model was constructed with
+    // enableDebugWireframe set to true.
+    (model._enableDebugWireframe || useWebgl2);
 
   const pointCloudShading = model.pointCloudShading;
   const hasAttenuation =
@@ -151,6 +163,10 @@ ModelExperimentalPrimitive.prototype.configurePipeline = function () {
   // Start of pipeline -----------------------------------------------------
 
   pipelineStages.push(GeometryPipelineStage);
+
+  if (generateWireframeIndices) {
+    pipelineStages.push(WireframePipelineStage);
+  }
 
   if (hasMorphTargets) {
     pipelineStages.push(MorphTargetsPipelineStage);

--- a/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
@@ -428,7 +428,7 @@ ModelExperimentalSceneGraph.prototype.buildDrawCommands = function (
     for (j = 0; j < runtimeNode.runtimePrimitives.length; j++) {
       const runtimePrimitive = runtimeNode.runtimePrimitives[j];
 
-      runtimePrimitive.configurePipeline();
+      runtimePrimitive.configurePipeline(frameState);
       const primitivePipelineStages = runtimePrimitive.pipelineStages;
 
       const primitiveRenderResources = new PrimitiveRenderResources(

--- a/Source/Scene/ModelExperimental/PrimitiveRenderResources.js
+++ b/Source/Scene/ModelExperimental/PrimitiveRenderResources.js
@@ -179,6 +179,16 @@ export default function PrimitiveRenderResources(
   this.indices = primitive.indices;
 
   /**
+   * Additional index buffer for wireframe mode (if enabled)
+   *
+   * @type {Buffer}
+   * @readonly
+   *
+   * @private
+   */
+  this.wireframeIndexBuffer = undefined;
+
+  /**
    * The primitive type such as TRIANGLES or POINTS
    *
    * @type {PrimitiveType}

--- a/Source/Scene/ModelExperimental/WireframePipelineStage.js
+++ b/Source/Scene/ModelExperimental/WireframePipelineStage.js
@@ -4,6 +4,8 @@ import defined from "../../Core/defined.js";
 import IndexDatatype from "../../Core/IndexDatatype.js";
 import PrimitiveType from "../../Core/PrimitiveType.js";
 import WireframeIndexGenerator from "../../Core/WireframeIndexGenerator.js";
+import VertexAttributeSemantic from "../VertexAttributeSemantic.js";
+import ModelExperimentalUtility from "./ModelExperimentalUtility.js";
 
 /**
  * The wireframe pipeline stage generates a new index buffer for rendering the
@@ -32,7 +34,8 @@ WireframePipelineStage.process = function (
   frameState
 ) {
   const wireframeIndexBuffer = createWireframeIndexBuffer(
-    renderResources,
+    primitive,
+    renderResources.indices,
     frameState
   );
   renderResources.model._resources.push(wireframeIndexBuffer);
@@ -48,19 +51,12 @@ WireframePipelineStage.process = function (
   );
 };
 
-function createWireframeIndexBuffer(renderResources, frameState) {
-  let positionAttribute;
-  const attributes = renderResources.attributes;
-  const length = attributes.length;
-  for (let i = 0; i < length; i++) {
-    if (attributes[i].index === 0) {
-      positionAttribute = attributes[i];
-      break;
-    }
-  }
-
+function createWireframeIndexBuffer(primitive, indices, frameState) {
+  const positionAttribute = ModelExperimentalUtility.getAttributeBySemantic(
+    primitive,
+    VertexAttributeSemantic.POSITION
+  );
   const vertexCount = positionAttribute.count;
-  const indices = renderResources.indices;
 
   let originalIndices;
   if (defined(indices)) {
@@ -78,7 +74,7 @@ function createWireframeIndexBuffer(renderResources, frameState) {
     }
   }
 
-  const primitiveType = renderResources.primitiveType;
+  const primitiveType = primitive.primitiveType;
   const wireframeIndices = WireframeIndexGenerator.createWireframeIndices(
     primitiveType,
     vertexCount,

--- a/Source/Scene/ModelExperimental/WireframePipelineStage.js
+++ b/Source/Scene/ModelExperimental/WireframePipelineStage.js
@@ -9,7 +9,7 @@ import ModelExperimentalUtility from "./ModelExperimentalUtility.js";
 
 /**
  * The wireframe pipeline stage generates a new index buffer for rendering the
- * outline of the mesh with gl.LINES.
+ * structure of the mesh with gl.LINES.
  *
  * @namespace WireframePipelineStage
  * @private
@@ -21,7 +21,7 @@ WireframePipelineStage.name = "WireframePipelineStage"; // Helps with debugging
  * Process a primitive. This modifies the render resources as follows:
  * <ul>
  *   <li>Adds a separate index buffer for wireframe indices</li>
- *   <li>Updates the primitive type and count for rendering gl.LINES</li>
+ *   <li>Updates the primitive type and count for rendering with gl.LINES</li>
  * </ul>
  *
  * @param {PrimitiveRenderResources} renderResources The render resources for this node
@@ -41,7 +41,7 @@ WireframePipelineStage.process = function (
   renderResources.model._resources.push(wireframeIndexBuffer);
   renderResources.wireframeIndexBuffer = wireframeIndexBuffer;
 
-  // Update state so we render LINES with the correct index count
+  // Update render resources so we render LINES with the correct index count
   const originalPrimitiveType = renderResources.primitiveType;
   const originalCount = renderResources.count;
   renderResources.primitiveType = PrimitiveType.LINES;

--- a/Source/Scene/ModelExperimental/WireframePipelineStage.js
+++ b/Source/Scene/ModelExperimental/WireframePipelineStage.js
@@ -36,6 +36,7 @@ WireframePipelineStage.process = function (
     frameState
   );
   renderResources.model._resources.push(wireframeIndexBuffer);
+  renderResources.wireframeIndexBuffer = wireframeIndexBuffer;
 
   // Update state so we render LINES with the correct index count
   const originalPrimitiveType = renderResources.primitiveType;

--- a/Source/Scene/ModelExperimental/WireframePipelineStage.js
+++ b/Source/Scene/ModelExperimental/WireframePipelineStage.js
@@ -1,0 +1,98 @@
+import Buffer from "../../Renderer/Buffer.js";
+import BufferUsage from "../../Renderer/BufferUsage.js";
+import defined from "../../Core/defined.js";
+import IndexDatatype from "../../Core/IndexDatatype.js";
+import PrimitiveType from "../../Core/PrimitiveType.js";
+import WireframeIndexGenerator from "../../Core/WireframeIndexGenerator.js";
+
+/**
+ * The wireframe pipeline stage generates a new index buffer for rendering the
+ * outline of the mesh with gl.LINES.
+ *
+ * @namespace WireframePipelineStage
+ * @private
+ */
+const WireframePipelineStage = {};
+WireframePipelineStage.name = "WireframePipelineStage"; // Helps with debugging
+
+/**
+ * Process a primitive. This modifies the render resources as follows:
+ * <ul>
+ *   <li>Adds a separate index buffer for wireframe indices</li>
+ *   <li>Updates the primitive type and count for rendering gl.LINES</li>
+ * </ul>
+ *
+ * @param {PrimitiveRenderResources} renderResources The render resources for this node
+ * @param {ModelComponents.primitive} primitive The primitive
+ * @param {FrameState} frameState The frame state
+ */
+WireframePipelineStage.process = function (
+  renderResources,
+  primitive,
+  frameState
+) {
+  const wireframeIndexBuffer = createWireframeIndexBuffer(
+    renderResources,
+    frameState
+  );
+  renderResources.model._resources.push(wireframeIndexBuffer);
+
+  // Update state so we render LINES with the correct index count
+  const originalPrimitiveType = renderResources.primitiveType;
+  const originalCount = renderResources.count;
+  renderResources.primitiveType = PrimitiveType.LINES;
+  renderResources.count = WireframeIndexGenerator.getWireframeIndicesCount(
+    originalPrimitiveType,
+    originalCount
+  );
+};
+
+function createWireframeIndexBuffer(renderResources, frameState) {
+  let positionAttribute;
+  const attributes = renderResources.attributes;
+  const length = attributes.length;
+  for (let i = 0; i < length; i++) {
+    if (attributes[i].index === 0) {
+      positionAttribute = attributes[i];
+      break;
+    }
+  }
+
+  const vertexCount = positionAttribute.count;
+  const indices = renderResources.indices;
+
+  let originalIndices;
+  if (defined(indices)) {
+    const indicesBuffer = indices.buffer;
+    const indicesCount = indices.count;
+    if (defined(indicesBuffer)) {
+      const useUint8Array = indicesBuffer.sizeInBytes === indicesCount;
+      originalIndices = useUint8Array
+        ? new Uint8Array(indicesCount)
+        : IndexDatatype.createTypedArray(vertexCount, indicesCount);
+
+      indicesBuffer.getBufferData(originalIndices);
+    } else {
+      originalIndices = indices.typedArray;
+    }
+  }
+
+  const primitiveType = renderResources.primitiveType;
+  const wireframeIndices = WireframeIndexGenerator.createWireframeIndices(
+    primitiveType,
+    vertexCount,
+    originalIndices
+  );
+  const indexDatatype = IndexDatatype.fromSizeInBytes(
+    wireframeIndices.BYTES_PER_ELEMENT
+  );
+
+  return Buffer.createIndexBuffer({
+    context: frameState.context,
+    typedArray: wireframeIndices,
+    usage: BufferUsage.STATIC_DRAW,
+    indexDatatype: indexDatatype,
+  });
+}
+
+export default WireframePipelineStage;

--- a/Source/Scene/ModelExperimental/buildDrawCommands.js
+++ b/Source/Scene/ModelExperimental/buildDrawCommands.js
@@ -160,6 +160,9 @@ function deriveTranslucentCommand(command) {
   return derivedCommand;
 }
 
+/**
+ * @private
+ */
 function getIndexBuffer(primitiveRenderResources, frameState) {
   const wireframeIndexBuffer = primitiveRenderResources.wireframeIndexBuffer;
   if (defined(wireframeIndexBuffer)) {

--- a/Specs/Scene/ModelExperimental/ModelExperimentalNodeSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalNodeSpec.js
@@ -130,6 +130,7 @@ describe("Scene/ModelExperimental/ModelExperimentalNode", function () {
 
     verifyTransforms(transform, transformToRoot, node);
 
+    node.configurePipeline();
     expect(node.pipelineStages).toEqual([]);
     expect(node.updateStages).toEqual([ModelMatrixUpdateStage]);
     expect(node.runtimePrimitives).toEqual([]);
@@ -375,6 +376,7 @@ describe("Scene/ModelExperimental/ModelExperimentalNode", function () {
 
     verifyTransforms(transform, transformToRoot, node);
 
+    node.configurePipeline();
     expect(node.pipelineStages.length).toBe(1);
     expect(node.pipelineStages[0]).toEqual(InstancingPipelineStage);
     expect(node.updateStages).toEqual([ModelMatrixUpdateStage]);

--- a/Specs/Scene/ModelExperimental/ModelExperimentalPrimitiveSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalPrimitiveSpec.js
@@ -21,6 +21,7 @@ import {
   SelectedFeatureIdPipelineStage,
   SkinningPipelineStage,
   VertexAttributeSemantic,
+  WireframePipelineStage,
 } from "../../../Source/Cesium.js";
 
 describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
@@ -37,6 +38,12 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
   const mockFrameState = {
     context: {
       webgl2: false,
+    },
+  };
+
+  const mockFrameStateWebgl2 = {
+    context: {
+      webgl2: true,
     },
   };
 
@@ -502,7 +509,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
         featureIds: [],
         featureIdTextures: [],
         attributes: [],
-        primitiveType: PrimitiveType.GLTF,
+        primitiveType: PrimitiveType.TRIANGLES,
       },
       node: mockNode,
       model: {
@@ -541,7 +548,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
         featureIds: [],
         featureIdTextures: [],
         attributes: [],
-        primitiveType: PrimitiveType.GLTF,
+        primitiveType: PrimitiveType.TRIANGLES,
       },
       node: mockNode,
       model: {
@@ -562,6 +569,126 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
     ];
 
     primitive.configurePipeline(mockFrameState);
+    verifyExpectedStages(primitive.pipelineStages, expectedStages);
+  });
+
+  it("configures pipeline for debugWireframe (WebGL 1)", function () {
+    const primitive = new ModelExperimentalPrimitive({
+      primitive: {
+        featureIds: [],
+        featureIdTextures: [],
+        attributes: [],
+        primitiveType: PrimitiveType.TRIANGLES,
+      },
+      node: mockNode,
+      model: {
+        debugWireframe: true,
+        _enableDebugWireframe: true,
+        type: ModelExperimentalType.GLTF,
+        featureIdLabel: "featureId_0",
+      },
+    });
+
+    const expectedStages = [
+      GeometryPipelineStage,
+      WireframePipelineStage,
+      MaterialPipelineStage,
+      FeatureIdPipelineStage,
+      MetadataPipelineStage,
+      LightingPipelineStage,
+      AlphaPipelineStage,
+    ];
+
+    primitive.configurePipeline(mockFrameState);
+    verifyExpectedStages(primitive.pipelineStages, expectedStages);
+  });
+
+  it("Does not include wireframe stage if model.enableDebugWireframe is false (WebGL 1)", function () {
+    const primitive = new ModelExperimentalPrimitive({
+      primitive: {
+        featureIds: [],
+        featureIdTextures: [],
+        attributes: [],
+        primitiveType: PrimitiveType.TRIANGLES,
+      },
+      node: mockNode,
+      model: {
+        debugWireframe: true,
+        _enableDebugWireframe: false,
+        type: ModelExperimentalType.GLTF,
+        featureIdLabel: "featureId_0",
+      },
+    });
+
+    const expectedStages = [
+      GeometryPipelineStage,
+      MaterialPipelineStage,
+      FeatureIdPipelineStage,
+      MetadataPipelineStage,
+      LightingPipelineStage,
+      AlphaPipelineStage,
+    ];
+
+    primitive.configurePipeline(mockFrameState);
+    verifyExpectedStages(primitive.pipelineStages, expectedStages);
+  });
+
+  it("configures pipeline for debugWireframe (WebGL 2)", function () {
+    const primitive = new ModelExperimentalPrimitive({
+      primitive: {
+        featureIds: [],
+        featureIdTextures: [],
+        attributes: [],
+        primitiveType: PrimitiveType.TRIANGLES,
+      },
+      node: mockNode,
+      model: {
+        debugWireframe: true,
+        type: ModelExperimentalType.GLTF,
+        featureIdLabel: "featureId_0",
+      },
+    });
+
+    const expectedStages = [
+      GeometryPipelineStage,
+      WireframePipelineStage,
+      MaterialPipelineStage,
+      FeatureIdPipelineStage,
+      MetadataPipelineStage,
+      LightingPipelineStage,
+      AlphaPipelineStage,
+    ];
+
+    primitive.configurePipeline(mockFrameStateWebgl2);
+    verifyExpectedStages(primitive.pipelineStages, expectedStages);
+  });
+
+  it("Does not include wireframe stage for non-triangle primitives", function () {
+    const primitive = new ModelExperimentalPrimitive({
+      primitive: {
+        featureIds: [],
+        featureIdTextures: [],
+        attributes: [],
+        primitiveType: PrimitiveType.POINTS,
+      },
+      node: mockNode,
+      model: {
+        debugWireframe: true,
+        type: ModelExperimentalType.GLTF,
+        featureIdLabel: "featureId_0",
+      },
+    });
+
+    const expectedStages = [
+      GeometryPipelineStage,
+      MaterialPipelineStage,
+      FeatureIdPipelineStage,
+      MetadataPipelineStage,
+      LightingPipelineStage,
+      AlphaPipelineStage,
+    ];
+
+    primitive.configurePipeline(mockFrameStateWebgl2);
     verifyExpectedStages(primitive.pipelineStages, expectedStages);
   });
 });

--- a/Specs/Scene/ModelExperimental/ModelExperimentalPrimitiveSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalPrimitiveSpec.js
@@ -34,6 +34,11 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
     allowPicking: true,
     featureIdLabel: "featureId_0",
   };
+  const mockFrameState = {
+    context: {
+      webgl2: false,
+    },
+  };
 
   const emptyVertexShader =
     "void vertexMain(VertexInput vsInput, inout vec3 position) {}";
@@ -127,6 +132,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       AlphaPipelineStage,
     ];
 
+    primitive.configurePipeline(mockFrameState);
     verifyExpectedStages(primitive.pipelineStages, expectedStages);
   });
 
@@ -168,6 +174,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       AlphaPipelineStage,
     ];
 
+    primitive.configurePipeline(mockFrameState);
     verifyExpectedStages(primitive.pipelineStages, expectedStages);
   });
 
@@ -212,6 +219,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       AlphaPipelineStage,
     ];
 
+    primitive.configurePipeline(mockFrameState);
     verifyExpectedStages(primitive.pipelineStages, expectedStages);
 
     primitive = new ModelExperimentalPrimitive({
@@ -231,6 +239,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       },
     });
 
+    primitive.configurePipeline(mockFrameState);
     verifyExpectedStages(primitive.pipelineStages, expectedStages);
   });
 
@@ -253,6 +262,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       model: mockModel,
     });
 
+    primitive.configurePipeline(mockFrameState);
     expect(primitive.pipelineStages).toEqual([
       GeometryPipelineStage,
       DequantizationPipelineStage,
@@ -290,6 +300,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       AlphaPipelineStage,
     ];
 
+    primitive.configurePipeline(mockFrameState);
     verifyExpectedStages(primitive.pipelineStages, expectedStages);
   });
 
@@ -318,6 +329,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       AlphaPipelineStage,
     ];
 
+    primitive.configurePipeline(mockFrameState);
     verifyExpectedStages(primitive.pipelineStages, expectedStages);
   });
 
@@ -346,6 +358,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       AlphaPipelineStage,
     ];
 
+    primitive.configurePipeline(mockFrameState);
     verifyExpectedStages(primitive.pipelineStages, expectedStages);
   });
 
@@ -383,6 +396,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       AlphaPipelineStage,
     ];
 
+    primitive.configurePipeline(mockFrameState);
     verifyExpectedStages(primitive.pipelineStages, expectedStages);
   });
 
@@ -415,6 +429,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       AlphaPipelineStage,
     ];
 
+    primitive.configurePipeline(mockFrameState);
     verifyExpectedStages(primitive.pipelineStages, expectedStages);
   });
 
@@ -446,6 +461,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       AlphaPipelineStage,
     ];
 
+    primitive.configurePipeline(mockFrameState);
     verifyExpectedStages(primitive.pipelineStages, expectedStages);
   });
 
@@ -474,6 +490,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       AlphaPipelineStage,
     ];
 
+    primitive.configurePipeline(mockFrameState);
     verifyExpectedStages(primitive.pipelineStages, expectedStages);
   });
 
@@ -504,6 +521,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       AlphaPipelineStage,
     ];
 
+    primitive.configurePipeline(mockFrameState);
     verifyExpectedStages(primitive.pipelineStages, expectedStages);
   });
 
@@ -543,6 +561,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       AlphaPipelineStage,
     ];
 
+    primitive.configurePipeline(mockFrameState);
     verifyExpectedStages(primitive.pipelineStages, expectedStages);
   });
 });

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -72,7 +72,9 @@ describe(
     beforeAll(function () {
       scene = createScene();
       sceneWithWebgl2 = createScene({
-        requestWebgl2: true,
+        contextOptions: {
+          requestWebgl2: true,
+        },
       });
     });
 

--- a/Specs/Scene/ModelExperimental/WireframePipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/WireframePipelineStageSpec.js
@@ -1,0 +1,130 @@
+import {
+  combine,
+  GltfLoader,
+  PrimitiveType,
+  Resource,
+  ResourceCache,
+  WireframePipelineStage,
+} from "../../../Source/Cesium.js";
+import createScene from "../../createScene.js";
+import waitForLoaderProcess from "../../waitForLoaderProcess.js";
+
+describe(
+  "Scene/ModelExperimental/WireframePipelineStage",
+  function () {
+    const boxTexturedBinary =
+      "./Data/Models/GltfLoader/BoxTextured/glTF-Binary/BoxTextured.glb";
+
+    const resources = [];
+    const gltfLoaders = [];
+
+    let scene;
+    let sceneWithWebgl2;
+    beforeAll(function () {
+      scene = createScene();
+      sceneWithWebgl2 = createScene({
+        contextOptions: {
+          requestWebgl2: true,
+        },
+      });
+    });
+
+    afterAll(function () {
+      scene.destroyForSpecs();
+      sceneWithWebgl2.destroyForSpecs();
+    });
+
+    function cleanup(resourcesArray) {
+      for (let i = 0; i < resourcesArray.length; i++) {
+        const resource = resourcesArray[i];
+        if (!resource.isDestroyed()) {
+          resource.destroy();
+        }
+      }
+      resourcesArray.length = 0;
+    }
+
+    afterEach(function () {
+      cleanup(resources);
+      cleanup(gltfLoaders);
+      ResourceCache.clearForSpecs();
+    });
+
+    function getOptions(gltfPath, options) {
+      const resource = new Resource({
+        url: gltfPath,
+      });
+
+      return combine(options, {
+        gltfResource: resource,
+        incrementallyLoadTextures: false, // Default to false if not supplied
+      });
+    }
+
+    function loadGltf(gltfPath, scene, options) {
+      const gltfLoader = new GltfLoader(getOptions(gltfPath, options));
+      gltfLoaders.push(gltfLoader);
+      gltfLoader.load();
+
+      return waitForLoaderProcess(gltfLoader, scene);
+    }
+
+    function mockRenderResources(primitive) {
+      return {
+        indices: primitive.indices,
+        count: primitive.indices.count,
+        primitiveType: primitive.primitiveType,
+        wireframeIndexBuffer: undefined,
+        model: {
+          _resources: resources,
+        },
+      };
+    }
+
+    it("Creates wireframe indices from buffer (WebGL 2)", function () {
+      return loadGltf(boxTexturedBinary, sceneWithWebgl2).then(function (
+        gltfLoader
+      ) {
+        const components = gltfLoader.components;
+        const node = components.nodes[1];
+        const primitive = node.primitives[0];
+        const frameState = sceneWithWebgl2.frameState;
+
+        const renderResources = mockRenderResources(primitive);
+
+        expect(renderResources.count).toBe(36);
+        expect(renderResources.primitiveType).toBe(PrimitiveType.TRIANGLES);
+
+        WireframePipelineStage.process(renderResources, primitive, frameState);
+        expect(renderResources.wireframeIndexBuffer).toBeDefined();
+        expect(renderResources.primitiveType).toBe(PrimitiveType.LINES);
+        expect(renderResources.count).toBe(72);
+      });
+    });
+
+    it("Creates wireframe indices from typedArray (WebGL 1)", function () {
+      const options = {
+        loadAsTypedArray: true,
+      };
+      return loadGltf(boxTexturedBinary, scene, options).then(function (
+        gltfLoader
+      ) {
+        const components = gltfLoader.components;
+        const node = components.nodes[1];
+        const primitive = node.primitives[0];
+        const frameState = scene.frameState;
+
+        const renderResources = mockRenderResources(primitive);
+
+        expect(renderResources.count).toBe(36);
+        expect(renderResources.primitiveType).toBe(PrimitiveType.TRIANGLES);
+
+        WireframePipelineStage.process(renderResources, primitive, frameState);
+        expect(renderResources.wireframeIndexBuffer).toBeDefined();
+        expect(renderResources.primitiveType).toBe(PrimitiveType.LINES);
+        expect(renderResources.count).toBe(72);
+      });
+    });
+  },
+  "WebGL"
+);

--- a/Specs/Scene/ModelExperimental/WireframePipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/WireframePipelineStageSpec.js
@@ -82,6 +82,10 @@ describe(
     }
 
     it("Creates wireframe indices from buffer (WebGL 2)", function () {
+      if (!sceneWithWebgl2.context.webgl2) {
+        return;
+      }
+
       return loadGltf(boxTexturedBinary, sceneWithWebgl2).then(function (
         gltfLoader
       ) {


### PR DESCRIPTION
This PR refactors the generation of wireframe indices to be its own stage in the `ModelExperimental`. This way, `buildDrawCommands()` has less complexity.

Along the way I fixed a couple of minor issues:

* `ModelExperimentalPrimitive` and `ModelExperimentalNode` were configuring the pipeline in the constructor. This really isn't necessary.
* I noticed some tests in `ModelExperimental` were incorrectly requesting a WebGL 2 context. It was easily fixed by changing the request to `createScene({contextOptions: {requestWebgl2: true}})`

[Local sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=bVPva9swEP1XRD45kEopaRlkaVmXDBZY19KGlYG/yNLFOSZLRjrnR8f+90m2U5Ktn6w7vffu7p0sBPvcoNFoS6YlSaZc4wnCgbk1+/5zzh5qsIt0UTtP0kzZhqieCrHb7S65PSheuq0ISCC0QyKBFgkl4RaCmOiLohfntSwht8rZQGyLsAPPbpiFHZtDwKbiP9pclg9UG8+dJYkWfD4Ysd+5ZYzA+5h59G6LGvz0SFQeJMGL80avOkg2HOX2z/BjbnPbleJBgQVeGlcA11DTZgWB7soIDtSzYjvkGzhlwZ7A6qwv1CW7YLJYoYGwtKEGRc7f4x5tqtgNiMd8mureaTBRvRdV7wq06i2ybaCToQQBOjfqrAGgrDWn8ebNkKWzTxDiGhXwtXfVXYiwpc4+XE+uJskaxsDKwkBb7su+Bo8V2Ha5yYETxAKKpnxBD2svK+iue2vPjK2jArY751LrrO+720Af8LgmfYjbqzAApw3YbN1YRegsy4bdinvNV+eqlctShh09GHXRiQ9fo158WI9IavMkbQk9gbExH4+O54sxv34Ljq0UrrGJ+1xvwAP3UagJTLArPu6gw/RJ7bejDkaDWaCDgduj0Ces0u+QbM84FwRVbeIjDKJo1K9YQIWQiAk6E6fUmcYtQ33zzjNnysgQ4s26MeYZXyEf3M5ExP9HNa6d/GEL3shDgm0ub791Sc75TMTwfSY5Zwrp/1H+Cw)

@j9liu could you review when you get a chance?