### PR TITLE
Issue #10394: Compute boundingSphere correctly for models created from glTF

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 
 ##### Fixes :wrench:
 
+- Fixed the inaccurate computation of bounding spheres for models not centered at (0,0,0) in their local space. Models were rendered correctly previously, but their bounding spheres ended up in the wrong place. [#10394](https://github.com/CesiumGS/cesium/issues/10394)
 - Fixed the inaccurate computation of bounding spheres for `ModelExperimental`. [#10339](https://github.com/CesiumGS/cesium/pull/10339/)
 - Fixed race condition which can occur when updating `Cesium3DTileStyle` before its `readyPromise` has resolved. [#10345](https://github.com/CesiumGS/cesium/issues/10345)
 - Fixed label background rendering. [#10342](https://github.com/CesiumGS/cesium/issues/10342)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@
 
 ##### Fixes :wrench:
 
-- Fixed the inaccurate computation of bounding spheres for models not centered at (0,0,0) in their local space. Models were rendered correctly previously, but their bounding spheres ended up in the wrong place. [#10394](https://github.com/CesiumGS/cesium/issues/10394)
+- Fixed the inaccurate computation of bounding spheres for models not centered at (0,0,0) in their local space. [#10395](https://github.com/CesiumGS/cesium/pull/10395)
 - Fixed the inaccurate computation of bounding spheres for `ModelExperimental`. [#10339](https://github.com/CesiumGS/cesium/pull/10339/)
 - Fixed race condition which can occur when updating `Cesium3DTileStyle` before its `readyPromise` has resolved. [#10345](https://github.com/CesiumGS/cesium/issues/10345)
 - Fixed label background rendering. [#10342](https://github.com/CesiumGS/cesium/issues/10342)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -174,6 +174,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
   - [Tang Xiaofei](https://github.com/vtxf)
 - [Maxar](https://www.maxar.com)
   - [Erik Dahlström](https://github.com/erikdahlstrom)
+- [Novatron Oy](https://novatron.fi/en/)
+  - [Jussi Hirvonen](https://github.com/VsKatshuma)
 
 ## [Individual CLA](Documentation/Contributors/CLAs/individual-contributor-license-agreement-v1.0.pdf)
 

--- a/Source/Scene/ModelUtility.js
+++ b/Source/Scene/ModelUtility.js
@@ -267,7 +267,7 @@ ModelUtility.computeBoundingSphere = function (model) {
   }
 
   const boundingSphere = BoundingSphere.fromCornerPoints(min, max);
-  if (model._forwardAxis === Axis.Z) {
+  if (model.forwardAxis === Axis.Z) {
     // glTF 2.0 has a Z-forward convention that must be adapted here to X-forward.
     BoundingSphere.transformWithoutScale(
       boundingSphere,

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -1058,6 +1058,18 @@ describe(
       texturedBoxModel.modelMatrix = originalMatrix;
     });
 
+    it("boundingSphere transforms from z-forward to x-forward (glTF 2.0)", function () {
+      const boundingSphere = riggedFigureModel.boundingSphere;
+      expect(boundingSphere.center).toEqualEpsilon(
+        new Cartesian3(0.0320296511054039, 0, 0.7249599695205688),
+        CesiumMath.EPSILON3
+      );
+      expect(boundingSphere.radius).toEqualEpsilon(
+        0.9484635280120018,
+        CesiumMath.EPSILON3
+      );
+    });
+
     it("destroys", function () {
       return loadModel(boxUrl).then(function (m) {
         expect(m.isDestroyed()).toEqual(false);


### PR DESCRIPTION
This is a pull request aiming to fix #10394. When glTF version 2.0 support was added for models, most likely the only part of the code that was tested was the modelMatrix that determines where the models are drawn, but the logic for bounding spheres was broken.

In current version of Cesium, models created from glTFs that are model-to-world transformed have their bounding spheres in a different place than where the models actually are.