### PR TITLE
Updates ESLint configuration to remove restrictions to ES5

### DIFF
--- a/Apps/Sandcastle/.eslintrc.json
+++ b/Apps/Sandcastle/.eslintrc.json
@@ -11,7 +11,6 @@
         "Cesium": true
     },
     "parserOptions": {
-        "ecmaVersion": 2015,
         "sourceType": "script"
     },
     "rules": {
@@ -26,7 +25,6 @@
                 "load-cesium-es6.js"
             ],
             "parserOptions": {
-                "ecmaVersion": 2015,
                 "sourceType": "module"
             }
         }

--- a/Apps/TimelineDemo/.eslintrc.json
+++ b/Apps/TimelineDemo/.eslintrc.json
@@ -4,7 +4,6 @@
         "amd": true
     },
     "parserOptions": {
-        "ecmaVersion": 2015,
         "sourceType": "script"
     }
 }

--- a/Source/.eslintrc.json
+++ b/Source/.eslintrc.json
@@ -3,7 +3,6 @@
     "extends": [
         "../Tools/eslint-config-cesium/browser.js",
         "prettier",
-        "plugin:es/no-new-in-es2015",
         "plugin:es/no-new-in-es2016",
         "plugin:es/no-new-in-es2017",
         "plugin:es/no-new-in-es2018",
@@ -15,12 +14,6 @@
         "es"
     ],
     "rules": {
-        "no-unused-vars": ["error", {"vars": "all", "args": "none"}],
-        "es/no-modules": "off",
-        "es/no-typed-arrays": "off",
-        "es/no-block-scoped-variables": "off",
-        "es/no-template-literals": "off",
-        "es/no-promise": "off",
-        "es/no-object-assign": "off"
+        "no-unused-vars": ["error", {"vars": "all", "args": "none"}]
     }
 }

--- a/Source/.eslintrc.json
+++ b/Source/.eslintrc.json
@@ -3,7 +3,12 @@
     "extends": [
         "../Tools/eslint-config-cesium/browser.js",
         "prettier",
-        "plugin:es/restrict-to-es5"
+        "plugin:es/no-new-in-es2015",
+        "plugin:es/no-new-in-es2016",
+        "plugin:es/no-new-in-es2017",
+        "plugin:es/no-new-in-es2018",
+        "plugin:es/no-new-in-es2019",
+        "plugin:es/no-new-in-es2020"
     ],
     "plugins": [
         "html",

--- a/Source/.eslintrc.json
+++ b/Source/.eslintrc.json
@@ -2,12 +2,7 @@
     "root": true,
     "extends": [
         "../Tools/eslint-config-cesium/browser.js",
-        "prettier",
-        "plugin:es/no-new-in-es2016",
-        "plugin:es/no-new-in-es2017",
-        "plugin:es/no-new-in-es2018",
-        "plugin:es/no-new-in-es2019",
-        "plugin:es/no-new-in-es2020"
+        "prettier"
     ],
     "plugins": [
         "html",

--- a/Specs/.eslintrc.json
+++ b/Specs/.eslintrc.json
@@ -4,9 +4,7 @@
         "jasmine": true
     },
     "rules": {
-        "no-self-assign": "off",
-        "es/no-block-scoped-variables": "off",
-        "es/no-template-literals": "off"
+        "no-self-assign": "off"
     },
     "overrides": [
         {


### PR DESCRIPTION
For additional context: https://github.com/CesiumGS/cesium/issues/9718#issuecomment-1134688567

This PR removes the restrictions imposed by the `plugin:es/restrict-to-es5` configuration. It also removes duplicate configuration option.

- [ ] Investigate using [Cascasing and Hierarchy](https://eslint.org/docs/user-guide/configuring/configuration-files#cascading-and-hierarchy) to avoid using `extends` multiple times.