### PR TITLE
Reverse winding order for negatively scaled models

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,7 +25,7 @@
 - Fixed crash for zero-area `region` bounding volumes in a 3D Tileset. [#10351](https://github.com/CesiumGS/cesium/pull/10351)
 - Fixed `Cesium3DTileset.debugShowUrl` so that it works for implicit tiles too. [#10372](https://github.com/CesiumGS/cesium/issues/10372)
 - Fixed crash when loading a tileset without a metadata schema but has external tilesets with tile or content metadata. [#10387](https://github.com/CesiumGS/cesium/pull/10387)
-- Fixed winding order for negatively scaled models in `ModelExperimental`.
+- Fixed winding order for negatively scaled models in `ModelExperimental`. [#10405](https://github.com/CesiumGS/cesium/pull/10405)
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@
 - Fixed crash for zero-area `region` bounding volumes in a 3D Tileset. [#10351](https://github.com/CesiumGS/cesium/pull/10351)
 - Fixed `Cesium3DTileset.debugShowUrl` so that it works for implicit tiles too. [#10372](https://github.com/CesiumGS/cesium/issues/10372)
 - Fixed crash when loading a tileset without a metadata schema but has external tilesets with tile or content metadata. [#10387](https://github.com/CesiumGS/cesium/pull/10387)
+- Fixed winding order for negatively scaled models in `ModelExperimental`.
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/Source/Scene/ModelExperimental/ModelExperimentalUtility.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalUtility.js
@@ -279,15 +279,24 @@ ModelExperimentalUtility.getAxisCorrectionMatrix = function (
 
 const scratchMatrix3 = new Matrix3();
 
+/**
+ * Get the cull face to use in the command's render state.
+ * <p>
+ * From the glTF spec section 3.7.4:
+ * When a mesh primitive uses any triangle-based topology (i.e., triangles,
+ * triangle strip, or triangle fan), the determinant of the node’s global
+ * transform defines the winding order of that primitive. If the determinant
+ * is a positive value, the winding order triangle faces is counterclockwise;
+ * in the opposite case, the winding order is clockwise.
+ * </p>
+ *
+ * @param {Matrix4} modelMatrix The model matrix
+ * @param {PrimitiveType} primitiveType The primitive type
+ * @return {CullFace} The cull face
+ *
+ * @private
+ */
 ModelExperimentalUtility.getCullFace = function (modelMatrix, primitiveType) {
-  // From the glTF spec section 3.7.4:
-  //
-  // When a mesh primitive uses any triangle-based topology (i.e., triangles,
-  // triangle strip, or triangle fan), the determinant of the node’s global
-  // transform defines the winding order of that primitive. If the determinant
-  // is a positive value, the winding order triangle faces is counterclockwise;
-  // in the opposite case, the winding order is clockwise.
-
   if (!PrimitiveType.isTriangles(primitiveType)) {
     return CullFace.BACK;
   }

--- a/Source/Scene/ModelExperimental/ModelExperimentalUtility.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalUtility.js
@@ -6,6 +6,9 @@ import RuntimeError from "../../Core/RuntimeError.js";
 import Axis from "../Axis.js";
 import AttributeType from "../AttributeType.js";
 import VertexAttributeSemantic from "../VertexAttributeSemantic.js";
+import CullFace from "../CullFace.js";
+import PrimitiveType from "../../Core/PrimitiveType.js";
+import Matrix3 from "../../Core/Matrix3.js";
 
 /**
  * Utility functions for {@link ModelExperimental}.
@@ -272,4 +275,23 @@ ModelExperimentalUtility.getAxisCorrectionMatrix = function (
   }
 
   return result;
+};
+
+const scratchMatrix3 = new Matrix3();
+
+ModelExperimentalUtility.getCullFace = function (modelMatrix, primitiveType) {
+  // From the glTF spec section 3.7.4:
+  //
+  // When a mesh primitive uses any triangle-based topology (i.e., triangles,
+  // triangle strip, or triangle fan), the determinant of the node’s global
+  // transform defines the winding order of that primitive. If the determinant
+  // is a positive value, the winding order triangle faces is counterclockwise;
+  // in the opposite case, the winding order is clockwise.
+
+  if (!PrimitiveType.isTriangles(primitiveType)) {
+    return CullFace.BACK;
+  }
+
+  const matrix3 = Matrix4.getMatrix3(modelMatrix, scratchMatrix3);
+  return Matrix3.determinant(matrix3) < 0.0 ? CullFace.FRONT : CullFace.BACK;
 };

--- a/Source/Scene/ModelExperimental/ModelMatrixUpdateStage.js
+++ b/Source/Scene/ModelExperimental/ModelMatrixUpdateStage.js
@@ -1,6 +1,9 @@
 import BoundingSphere from "../../Core/BoundingSphere.js";
 import Matrix4 from "../../Core/Matrix4.js";
 import SceneMode from "../SceneMode.js";
+import ModelExperimentalUtility from "./ModelExperimentalUtility.js";
+import clone from "../../Core/clone.js";
+import RenderState from "../../Renderer/RenderState.js";
 
 /**
  * The model matrix update stage is responsible for updating the model matrices and bounding volumes of the draw commands.
@@ -72,6 +75,18 @@ function updateRuntimeNode(runtimeNode, sceneGraph, transformToRoot) {
         drawCommand.modelMatrix,
         drawCommand.boundingVolume
       );
+
+      const cullFace = ModelExperimentalUtility.getCullFace(
+        drawCommand.modelMatrix,
+        drawCommand.primitiveType
+      );
+      let renderState = drawCommand.renderState;
+      if (cullFace !== renderState.cull.face) {
+        renderState = clone(renderState, true);
+        renderState.cull.face = cullFace;
+        renderState = RenderState.fromCache(renderState);
+        drawCommand.renderState = renderState;
+      }
     }
   }
 

--- a/Source/Scene/ModelExperimental/buildDrawCommands.js
+++ b/Source/Scene/ModelExperimental/buildDrawCommands.js
@@ -17,6 +17,7 @@ import BoundingSphere from "../../Core/BoundingSphere.js";
 import Matrix4 from "../../Core/Matrix4.js";
 import ShadowMode from "../ShadowMode.js";
 import SceneMode from "../SceneMode.js";
+import ModelExperimentalUtility from "./ModelExperimentalUtility.js";
 
 /**
  * Builds the DrawCommands for a {@link ModelExperimentalPrimitive} using its render resources.
@@ -49,17 +50,6 @@ export default function buildDrawCommands(
 
   model._resources.push(vertexArray);
 
-  let renderState = primitiveRenderResources.renderStateOptions;
-
-  if (model.opaquePass === Pass.CESIUM_3D_TILE) {
-    // Set stencil values for classification on 3D Tiles
-    renderState = clone(renderState, true);
-    renderState.stencilTest = StencilConstants.setCesium3DTileBit();
-    renderState.stencilMask = StencilConstants.CESIUM_3D_TILE_MASK;
-  }
-
-  renderState = RenderState.fromCache(renderState);
-
   const shaderProgram = shaderBuilder.buildShaderProgram(frameState.context);
   model._resources.push(shaderProgram);
 
@@ -83,6 +73,24 @@ export default function buildDrawCommands(
       primitiveRenderResources.boundingSphere
     );
   }
+
+  // Initialize render state with default values
+  let renderState = clone(
+    RenderState.fromCache(primitiveRenderResources.renderStateOptions),
+    true
+  );
+
+  if (model.opaquePass === Pass.CESIUM_3D_TILE) {
+    // Set stencil values for classification on 3D Tiles
+    renderState.stencilTest = StencilConstants.setCesium3DTileBit();
+    renderState.stencilMask = StencilConstants.CESIUM_3D_TILE_MASK;
+  }
+
+  renderState.cull.face = ModelExperimentalUtility.getCullFace(
+    modelMatrix,
+    primitiveRenderResources.primitiveType
+  );
+  renderState = RenderState.fromCache(renderState);
 
   const count = primitiveRenderResources.count;
 

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -1632,6 +1632,40 @@ describe(
       });
     });
 
+    it("reverses winding order for negatively scaled models", function () {
+      return loadAndZoomToModelExperimental(
+        {
+          gltf: boxTexturedGlbUrl,
+          modelMatrix: Matrix4.fromUniformScale(-1.0),
+        },
+        scene
+      ).then(function (model) {
+        const renderOptions = {
+          scene: scene,
+          time: new JulianDate(2456659.0004050927),
+        };
+
+        // The model should look the same whether it has -1.0 scale or 1.0 scale.
+        // The initial scale is -1.0. Test switching this at runtime.
+        let initialRgba;
+        expect(renderOptions).toRenderAndCall(function (rgba) {
+          initialRgba = rgba;
+        });
+
+        model.modelMatrix = Matrix4.IDENTITY;
+
+        expect(renderOptions).toRenderAndCall(function (rgba) {
+          expect(rgba).toEqual(initialRgba);
+        });
+
+        model.modelMatrix = Matrix4.fromUniformScale(-1.0);
+
+        expect(renderOptions).toRenderAndCall(function (rgba) {
+          expect(rgba).toEqual(initialRgba);
+        });
+      });
+    });
+
     it("throws when given clipping planes attached to another model", function () {
       const plane = new ClippingPlane(Cartesian3.UNIT_X, 0.0);
       const clippingPlanes = new ClippingPlaneCollection({

--- a/Specs/Scene/ModelExperimental/ModelExperimentalUtilitySpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalUtilitySpec.js
@@ -2,9 +2,11 @@ import {
   AttributeType,
   Axis,
   Cartesian3,
+  CullFace,
   InstanceAttributeSemantic,
   Matrix4,
   ModelExperimentalUtility,
+  PrimitiveType,
   Quaternion,
   VertexAttributeSemantic,
 } from "../../../Source/Cesium.js";
@@ -391,5 +393,33 @@ describe("Scene/ModelExperimental/ModelExperimentalUtility", function () {
     expect(
       ModelExperimentalUtility.getFeatureIdsByLabel(featureIds, "other")
     ).not.toBeDefined();
+  });
+
+  function expectCullFace(matrix, primitiveType, cullFace) {
+    expect(ModelExperimentalUtility.getCullFace(matrix, primitiveType)).toBe(
+      cullFace
+    );
+  }
+
+  it("getCullFace returns CullFace.BACK when primitiveType is not triangles", function () {
+    const matrix = Matrix4.fromUniformScale(-1.0);
+    expectCullFace(matrix, PrimitiveType.POINTS, CullFace.BACK);
+    expectCullFace(matrix, PrimitiveType.LINES, CullFace.BACK);
+    expectCullFace(matrix, PrimitiveType.LINE_LOOP, CullFace.BACK);
+    expectCullFace(matrix, PrimitiveType.LINE_STRIP, CullFace.BACK);
+  });
+
+  it("getCullFace return CullFace.BACK when determinant is greater than zero", function () {
+    const matrix = Matrix4.IDENTITY;
+    expectCullFace(matrix, PrimitiveType.TRIANGLES, CullFace.BACK);
+    expectCullFace(matrix, PrimitiveType.TRIANGLE_STRIP, CullFace.BACK);
+    expectCullFace(matrix, PrimitiveType.TRIANGLE_FAN, CullFace.BACK);
+  });
+
+  it("getCullFace return CullFace.FRONT when determinant is less than zero", function () {
+    const matrix = Matrix4.fromUniformScale(-1.0);
+    expectCullFace(matrix, PrimitiveType.TRIANGLES, CullFace.FRONT);
+    expectCullFace(matrix, PrimitiveType.TRIANGLE_STRIP, CullFace.FRONT);
+    expectCullFace(matrix, PrimitiveType.TRIANGLE_FAN, CullFace.FRONT);
   });
 });

--- a/Specs/Scene/ModelExperimental/ModelMatrixUpdateStageSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelMatrixUpdateStageSpec.js
@@ -1,6 +1,7 @@
 import {
   BoundingSphere,
   Cartesian3,
+  CullFace,
   Matrix4,
   Math as CesiumMath,
   ResourceCache,
@@ -324,6 +325,35 @@ describe(
             expectedTransformedChildModelMatrix
           )
         ).toBe(true);
+      });
+    });
+
+    it("updates render state cull face when scale is negative", function () {
+      return loadAndZoomToModelExperimental(
+        {
+          gltf: airplane,
+        },
+        scene
+      ).then(function (model) {
+        const sceneGraph = model._sceneGraph;
+
+        const rootNode = sceneGraph._runtimeNodes[1];
+        const childNode = sceneGraph._runtimeNodes[0];
+
+        const rootPrimitive = rootNode.runtimePrimitives[0];
+        const childPrimitive = childNode.runtimePrimitives[0];
+
+        const rootDrawCommand = rootPrimitive.drawCommands[0];
+        const childDrawCommand = childPrimitive.drawCommands[0];
+
+        expect(rootDrawCommand.renderState.cull.face).toBe(CullFace.BACK);
+        expect(childDrawCommand.renderState.cull.face).toBe(CullFace.BACK);
+
+        model.modelMatrix = Matrix4.fromUniformScale(-1);
+        scene.renderForSpecs();
+
+        expect(rootDrawCommand.renderState.cull.face).toBe(CullFace.FRONT);
+        expect(childDrawCommand.renderState.cull.face).toBe(CullFace.FRONT);
       });
     });
   },


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/6304 for `ModelExperimental`. I don't think it's possible to fix this in `Model` without significant changes.

Sets `renderState.cull.face` to either `CullFace.FRONT` or `CullFace.BACK` depending on whether the model matrix determinant is less than zero. This fixes rendering for models with negative scale like the box on the right.

![image](https://user-images.githubusercontent.com/915398/170499928-c73f5d11-e6d5-45b0-acb8-75134d1235b1.png)

[Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=fVRdb9owFP0rFk+hAieB8FFGq7GWdZ06rSpok6a8mMQQq44d2Q5tN/W/78ZOgDK6lyT2Pff4nnOvk0ihDdoy+kQVukCCPqErqlmZ4x92z4tbiV1fSWEIE1TFrfaHWMTC5eCEy+QRJ6VSVJglyymw1AxfS86IuCaG4rWS+a2W42EQerFAKG71gl7YDcNucL7sBZPeaNIf4SAcBsMoGg360Xg4js77o19xKxbuvMRWWkjNDJNif8oVUQa+iOjbU67pRlGq7SndsNfHwSiKhuF5p9qIIhwMgv4oGNplOMDBW/qsOHLhCyUpE5t7ZpLsQXJueevYN2IybOQDIIjQXjgO2pY2cE/H7HjX7JmmnxXJ6VIBdi1Vvlew29IYzCTc4eTnXc4NBd+Jkar2TkhlsrjVcasnqs3epl1jdAJZuFAsB8O2VGNFc7mlM9CwryuXKeVQyXs5JE3fKK7g8+eCAgLaTbi1/IabtfengiFUKj6BmjJjisnEt3Iyqc1kHAQ9XxtiWOIn5Ypq98QbyK2VIFcNuKrY8+SEOdlRLw4t8hwD2g1Ip9mAlu6+a84556zQkqX4581iHO3CJ7rkQu3q9dpuPLZ1gp8kfbkH/UxTbDIqvHUpEjucnkW0kTWluShAqwh0WD7OTF3uUbHvzR0Rm73A08MXDdqd/yO64QHEKVjJUlSnLIqMKooVIEuNztDgQLVT3GSQpJqLmWA5qeq2A1JNVN19EFdM3gzLDnoHIfwwv5/Plh3nJhC/NjO7ICJNiDacVoxLKfmKqE+lMVLAH+hWbKkySMMwURgW1Pjs1Q672mwYnV3AtcdBQ97qtKbavHB62Uj/yPIC7k81qR7GvqF5weEXpf1VmTxSgxOtq8QKOvUPU6cp2yKWXpz4I6KEE60hsi45X7DfUOXl1Af8P6lc2r5+B0GcvFSwLLy8c5sY46kPy9OZxplyxPwX) using the model provided in https://github.com/CesiumGS/cesium/issues/6304. This checks that negative scaled primitives work on load and at runtime.