### PR TITLE
Add missing lines to `ModelAnimation` documentation

### DIFF
--- a/Source/Scene/ModelAnimation.js
+++ b/Source/Scene/ModelAnimation.js
@@ -236,6 +236,8 @@ Object.defineProperties(ModelAnimation.prototype, {
    * If this is defined, it will be used to compute the local animation time
    * instead of the scene's time.
    *
+   * @memberof ModelAnimation.prototype
+   *
    * @type {ModelAnimation.AnimationTimeCallback}
    * @default undefined
    */
@@ -260,8 +262,7 @@ Object.defineProperties(ModelAnimation.prototype, {
  * }
  *
  * @example
- * // Offset the phase of the animation, so it starts halfway
- * // through its cycle.
+ * // Offset the phase of the animation, so it starts halfway through its cycle.
  * function animationTime(duration, seconds) {
  *     return seconds / duration + 0.5;
  * }

--- a/Source/Scene/ModelExperimental/ModelExperimentalAnimation.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalAnimation.js
@@ -330,6 +330,8 @@ Object.defineProperties(ModelExperimentalAnimation.prototype, {
    * If this is defined, it will be used to compute the local animation time
    * instead of the scene's time.
    *
+   * @memberof ModelExperimentalAnimation.prototype
+   *
    * @type {ModelExperimentalAnimation.AnimationTimeCallback}
    * @default undefined
    */
@@ -411,8 +413,7 @@ ModelExperimentalAnimation.prototype.animate = function (time) {
  * }
  *
  * @example
- * // Offset the phase of the animation, so it starts halfway
- * // through its cycle.
+ * // Offset the phase of the animation, so it starts halfway through its cycle.
  * function animationTime(duration, seconds) {
  *     return seconds / duration + 0.5;
  * }


### PR DESCRIPTION
The `animationTime` documentation was missing a line in `ModelAnimation` and `ModelExperimentalAnimation` that caused it to appear under the global documentation instead of the animation classes. This PR fixes that.

I also made a minor adjustment to a code example so it looked nicer in the documentation.