### PR TITLE
Fix REPLACE styling for glTF without pbrMetallicRoughness object

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 1.95 - 2022-07-01
+
+##### Fixes :wrench:
+
+- Fixed `Cesium3DTileColorBlendMode.REPLACE` for certain tilesets. [#10424](https://github.com/CesiumGS/cesium/pull/10424)
+
 ### 1.94 - 2022-06-01
 
 ##### Breaking Changes :mega:

--- a/Source/Scene/processPbrMaterials.js
+++ b/Source/Scene/processPbrMaterials.js
@@ -164,19 +164,26 @@ function generateTechnique(
   let uniformName;
   let parameterName;
   let value;
-  const pbrMetallicRoughness = material.pbrMetallicRoughness;
-  if (defined(pbrMetallicRoughness) && !useSpecGloss) {
-    for (parameterName in pbrMetallicRoughness) {
-      if (pbrMetallicRoughness.hasOwnProperty(parameterName)) {
-        value = pbrMetallicRoughness[parameterName];
-        uniformName = `u_${parameterName}`;
-        generatedMaterialValues[uniformName] = value;
-        handleKHRTextureTransform(
-          parameterName,
-          value,
-          generatedMaterialValues
-        );
+  if (!useSpecGloss) {
+    const pbrMetallicRoughness = material.pbrMetallicRoughness;
+    if (defined(pbrMetallicRoughness)) {
+      for (parameterName in pbrMetallicRoughness) {
+        if (pbrMetallicRoughness.hasOwnProperty(parameterName)) {
+          value = pbrMetallicRoughness[parameterName];
+          uniformName = `u_${parameterName}`;
+          generatedMaterialValues[uniformName] = value;
+          handleKHRTextureTransform(
+            parameterName,
+            value,
+            generatedMaterialValues
+          );
+        }
       }
+    } else {
+      // Add a uniform for baseColorFactor and set the default value. Otherwise
+      // glTFs without a pbrMetallicRoughness object will not be styled correctly
+      // when using Cesium3DTileColorBlendMode.REPLACE.
+      generatedMaterialValues["u_baseColorFactor"] = [1.0, 1.0, 1.0, 1.0];
     }
   }
 


### PR DESCRIPTION
We noticed that `Cesium3DTileColorBlendMode.REPLACE` wasn't working for certain tilesets. Specifically, if a glTF material omitted the `pbrMetallicRoughness` object then the style would not get applied.

Why....? The code uses a special `_3DTILESDIFFUSE` semantic to figure out which attribute or uniform should be replaced with the feature color. Usually it attaches itself to the vertex color attribute, base color texture, or base color factor, but in this case none of those could be found.

The fix was to add a uniform for the default `baseColorFactor` value. The semantic gets added to that and everything works again.

As a side note, this bug doesn't seem to affect `ModelExperimental` which handles things very differently.