### PR TITLE
fix `sampleTerrain` from exploding if RequestScheduler throttles it 💣

### DIFF
--- a/Apps/Sandcastle/gallery/Terrain.html
+++ b/Apps/Sandcastle/gallery/Terrain.html
@@ -325,7 +325,7 @@
               );
               return;
             }
-            const terrainSamplePositions = createGrid(0.0005);
+            const terrainSamplePositions = createGrid(0.005);
             Promise.resolve(
               Cesium.sampleTerrainMostDetailed(
                 viewer.terrainProvider,


### PR DESCRIPTION
Bug: If you call `sampleTerrain` with positions spread over too large an area, too many tile requests may be made, and if `throttleByServer` is set to `true` for the request, eventually `requestTileGeometry` will return `undefined` and explode the whole task (unhandled exception).

### The error I'm seeing
![image](https://user-images.githubusercontent.com/8600684/171794245-22bc5893-2dc1-42a3-aae8-00350f304bb1.png)

[The sandcastle to reproduce](https://sandcastle.cesium.com/#c=jVdbb9s2FP4rnJ9k1KEs3+WkxZI0a4O1S1EbK4Z6D7R0LBGlSYGknLhD/vuOrpZsp+1LQpHn8p37caCksYTp4B03n7Ta8RA0eU0kPJJbMDzd0mt8u18suYDwTsCOWa7kErRmXFYMzn8rSUiqxTz7T8iqE1ubmLnrQsUxDCkqibihgdq6xdHVYKxrQO94AMb9orQ4qBi+dUsteLrfsggWSAh61emt5HP3ciVXMsjB7zg8HoP+O79zVp0g/75V0qKknJvkYG3bgvmRCw46VlKArcgXbJsI+KQMzyCanGCTyiD7IkKpb9f2o71DlGiY0y00FSAt0xHKaYG8ZdriicmhU/ht2O9Pp3067s+mg+HMH85GveJhPBmOfG9AvaE39Efj2bi8H/jTmTce0MFsMh6Pxp43ye4z4JVetdmYn+pF6SPqT0d9fzaZzsaTQSn+YuoP6XDk+VN/1p9505FX6R35PvUR52zSn06G3mRw0FuEgwZsC5rRwilOYX6vhPMy4VIzaTZKb50S60dmNX8a0fu3d38t75f/ZKzPLbebPCZlrizSACNunPPxakUEhOCJUTxE55TK7qor+uXdYjbKw0uI697sSQgblgq0oCAloQJDpEIHr02qgUSgtmD1vmBYQ8xlWGUNJQuwlsuI2JgbshEsIiDZWqAIGzNLG94wAUigkVBroCEkNl5iKl1HKMXY0kbEa3UKJbqSD6RFG8FQk5oEZIhJKK1xWp6uaTRs1Q6uhXC6pRR0OXGyROcovX+J/65eyHkqQEY2viSvXvHSn5VHk5ImA3iW9yv/t9R3iomFoVNKI0RiTsxreTQGHsWWWvUHf4LQ8bq9irAimR/CiQmlrYo0S2IeLFWd7E5Fe+BecyHWiulwTmrViAy05QETD5pHHCVXLaV1TW8elsuHj70Dm8E3BN2n08YlzxrXHBsipW5+Nu6GBVxwu6cR3+TNrKB8rk+CrUG0EFl4sr/kjiyQ0mb6vH5iyVZJZRIWQEMPIbHS/HvWEI8tfH/0QG+x5u4+N1gTVCge8hqen+0oA6ffIxfeqAUJvXyrhNK1ovyL3ny4vv2zQadSK7BH/wqpidXjDQu+RVqlEqOX1UPjeV0/lcKaULMbp0/9Hmn+mXbP8n/CtMTCfcnYUY8MuychfC6q7vl86Zl0C43qbDezQAOz8E7z0NEQWCYjAe+Z2Cz4d2h1rwhJvvDQxlhsI++y/fA+T5DjFyjm0gccrzYN4dD2sMfGmE2fWYhGGWcwpf5sNhhPu2eYlYx+zD2bUH8w9kbjFnd7AH2uTCvnz4nwC3Jifa9NWhnxc8pa6KtfFnqG8niunm9waObXfy9bDXVfNNQ9NtRDaLLuua+7Z037VNA+lbR5fDPSp+6hGxTqxQtxEKAT55DIQB/Rrl7zAljr4om4xDkk0wXxutVjYW5D5/nEOVFpsJDjlk6pdOtmXyktE/VHWhtD5agGqx7v1M7o1RgPUl6YYklq4sNEKKmf67LVYFMtX1778qpdMBkG6E4B2fRaKiXWTN+k1iqZO2TVKRjJR4WGvAVcQXGJJuV+SMpxXvbmugU4dbD5hji/lQbj/oG9MXTKfnK0vlK2Q9lsnQ+WbiNbHnENUY8UJ5O2jSCtOq2tKcNXw+PFXmPSJMGw4UWWnjYGYnCZD7KLUjlJSu2rzmnwCgc2/frTymn0vj7t98eVMDRyyw1krVOJHdRmlJ550ZKGvee91mtO2HOgarOKQ5eiG6RzbuGssJ78BigmQa9Ih4KzyBCTea1Yv84xrWSn17kydi/gTQXjd77NQpL90HJwn7CA0tBjxl2nwTewNDjguHKbrFch3xEevj7zc4gEghmDL5tUiLzRdd5cuUh/wioUy0bhA4IUbJ+Rxd6bD8UlpfTKxc/znLaoDGSpLDm8HbmkLaFx/h8) (just hit the Sample Terrain button)


### The lines of code causing the actual issue:
`requestTileGeometry` will return `undefined` if the throttling takes place by `RequestScheduler`
https://github.com/CesiumGS/cesium/blob/f40912628795422f42fbc4db586daa38bf6e7f87/Source/Core/sampleTerrain.js#L85-L92


### The spot that `throttleByServer` is enforced to `true`, for ArcGIS terrain at least
https://github.com/CesiumGS/cesium/blob/f40912628795422f42fbc4db586daa38bf6e7f87/Source/Core/ArcGISTiledElevationTerrainProvider.js#L641-L645


### The bit of `RequestScheduler` which is doing the throttling 
https://github.com/CesiumGS/cesium/blob/f40912628795422f42fbc4db586daa38bf6e7f87/Source/Core/RequestScheduler.js#L402-L409



#### Left to do
If you guys are happy with the implementation, I'll button it up with some tests, a mention in the changelog, remove the debug logs, and revert the sandcastle change. I haven't yet as the implementation is questionable.

Cheers! 👍 

