### PR TITLE
Fix vector tile crash by making sure billboardCollection is defined

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Fixes :wrench:
 
 - Fixed `Cesium3DTileColorBlendMode.REPLACE` for certain tilesets. [#10424](https://github.com/CesiumGS/cesium/pull/10424)
+- Fixed a crash when applying a style to a vector tileset with point features. [#10427](https://github.com/CesiumGS/cesium/pull/10427)
 
 ### 1.94 - 2022-06-01
 

--- a/Source/Scene/Vector3DTilePoints.js
+++ b/Source/Scene/Vector3DTilePoints.js
@@ -44,9 +44,6 @@ function Vector3DTilePoints(options) {
   this._minHeight = options.minimumHeight;
   this._maxHeight = options.maximumHeight;
 
-  this._billboardCollection = undefined;
-  this._labelCollection = undefined;
-  this._polylineCollection = undefined;
   this._billboardCollection = new BillboardCollection({
     batchTable: options.batchTable,
   });

--- a/Source/Scene/Vector3DTilePoints.js
+++ b/Source/Scene/Vector3DTilePoints.js
@@ -166,42 +166,35 @@ function createPoints(points, ellipsoid) {
 
     return verticesPromise.then(function (result) {
       points._positions = new Float64Array(result.positions);
+      const billboardCollection = points._billboardCollection;
+      const labelCollection = points._labelCollection;
+      const polylineCollection = points._polylineCollection;
+      positions = points._positions;
+      const batchIds = points._batchIds;
+      const numberOfPoints = positions.length / 3;
+
+      for (let i = 0; i < numberOfPoints; ++i) {
+        const id = batchIds[i];
+
+        const position = Cartesian3.unpack(positions, i * 3, scratchPosition);
+
+        const b = billboardCollection.add();
+        b.position = position;
+        b._batchIndex = id;
+
+        const l = labelCollection.add();
+        l.text = " ";
+        l.position = position;
+        l._batchIndex = id;
+
+        const p = polylineCollection.add();
+        p.positions = [Cartesian3.clone(position), Cartesian3.clone(position)];
+      }
+
+      points._positions = undefined;
+      points._packedBuffer = undefined;
       points._ready = true;
     });
-  }
-
-  const billboardCollection = points._billboardCollection;
-  const labelCollection = points._labelCollection;
-  const polylineCollection = points._polylineCollection;
-  if (points._ready && defined(points._positions)) {
-    positions = points._positions;
-    const batchIds = points._batchIds;
-    const numberOfPoints = positions.length / 3;
-
-    if (billboardCollection.length === numberOfPoints) {
-      return;
-    }
-
-    for (let i = 0; i < numberOfPoints; ++i) {
-      const id = batchIds[i];
-
-      const position = Cartesian3.unpack(positions, i * 3, scratchPosition);
-
-      const b = billboardCollection.add();
-      b.position = position;
-      b._batchIndex = id;
-
-      const l = labelCollection.add();
-      l.text = " ";
-      l.position = position;
-      l._batchIndex = id;
-
-      const p = polylineCollection.add();
-      p.positions = [Cartesian3.clone(position), Cartesian3.clone(position)];
-    }
-
-    points._positions = undefined;
-    points._packedBuffer = undefined;
   }
 }
 


### PR DESCRIPTION
Fixes a regression from https://github.com/CesiumGS/cesium/pull/10361 which can cause vector tile points to crash under certain circumstances.

I'd like to verify this works with an example, but in the meantime, I think this should fix the issue. The exception itself is in `Vector3DTilePoints.pointsLength` where it's trying to access an undefined `this._billboardCollection`.  I don't think there is a reason to wait to define the collection until after the internal promise resolves.