### PR TITLE
Adds eslint and markdownlint to pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,5 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npx pretty-quick --staged
+npm run eslint
+npm run markdownlint


### PR DESCRIPTION
⚠️ Depends on https://github.com/CesiumGS/cesium/pull/10411 being marged into `main` first. Once that is done, the destination branch can be changed to `main`.

In order to reduce cases where ESLint errors are caught too late in CI process, this PR adds `eslint` and `markdownlint` to the pre-commit hook.

If the `eslint` cache is not built, this means that the first commit will take a while to run, however, subsequent commits will be fast.