### PR TITLE
Fixes regex for Edge browser detection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 1.95 - 2022-07-01
+
+##### Fixes :wrench:
+
+- Fixed `FeatureDetection` for Microsoft Edge. [#10429](https://github.com/CesiumGS/cesium/pull/10429)
+
 ### 1.94.1 - 2022-06-03
 
 ##### Additions :tada:

--- a/Source/Core/FeatureDetection.js
+++ b/Source/Core/FeatureDetection.js
@@ -124,7 +124,7 @@ let edgeVersionResult;
 function isEdge() {
   if (!defined(isEdgeResult)) {
     isEdgeResult = false;
-    const fields = / Edge\/([\.0-9]+)/.exec(theNavigator.userAgent);
+    const fields = / Edg\/([\.0-9]+)/.exec(theNavigator.userAgent);
     if (fields !== null) {
       isEdgeResult = true;
       edgeVersionResult = extractVersion(fields[1]);


### PR DESCRIPTION
As tested on macOS 12.4 with Edge version 102.0.1245.30, `navigator.userAgent` returns the following string:

`Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.63 Safari/537.36 `**`Edg/102.0.1245.30`**, which does not match the current regex.

Use this [Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=dY/BSgMxEIZfJQQPW5AErzZdhNqeBA+CpxyaJuM2OJuUZLKliu9udldBtM5t/vm+GcbGkIkNHk6Q2IoFOLE1ZF968TxljeZ26tcxkPEBkuaLpQ528nzeuA6q9+VswVBJcA8ElnwMYgaabyMiCIxds/sXZAnqIIC7ZVfvc/ixWyz5NVeZzgitDmyqO98fYyJWEjZCSIL+iIYgy32xr0DC5jxeHVElf6rK+YF5t7rwGLNocq6Tl4L45N9A81bJyv9RMRrnQ/c4QEJzHrHDTfswh0IIJWt72aQYcW/Sr82f) to test.