### PR TITLE
Add support for projecting instanced models to 2D in `ModelExperimental`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Memory statistics for `ModelExperimental` now appear in the `Cesium3DTilesInspector`. This includes binary metadata memory, which is not counted by `Model`. [#10397](https://github.com/CesiumGS/cesium/pull/10397)
 - Added support for rendering individual models in 2D / CV using `ModelExperimental`. [#10419](https://github.com/CesiumGS/cesium/pull/10419)
+- Added support for rendering instanced tilesets in 2D / CV using `ModelExperimental`. [#10433](https://github.com/CesiumGS/cesium/pull/10433/)
 
 ##### Fixes :wrench:
 

--- a/Source/Scene/ModelExperimental/B3dmLoader.js
+++ b/Source/Scene/ModelExperimental/B3dmLoader.js
@@ -49,7 +49,7 @@ const FeatureIdAttribute = ModelComponents.FeatureIdAttribute;
  * @param {Axis} [options.upAxis=Axis.Y] The up-axis of the glTF model.
  * @param {Axis} [options.forwardAxis=Axis.X] The forward-axis of the glTF model.
  * @param {Boolean} [options.loadAttributesAsTypedArray=false] Load all attributes as typed arrays instead of GPU buffers.
- * @param {Boolean} [options.loadPositionsFor2D=false] If true, load the positions buffer as a typed array for accurately projecting models to 2D.
+ * @param {Boolean} [options.loadAttributesFor2D=false] If true, load the positions buffer and any instanced attribute buffers as typed arrays for accurately projecting models to 2D.
  * @param {Boolean} [options.loadIndicesForWireframe=false] Load the index buffer as a typed array. This is useful for creating wireframe indices in WebGL1.
  */
 function B3dmLoader(options) {
@@ -71,7 +71,7 @@ function B3dmLoader(options) {
     options.loadAttributesAsTypedArray,
     false
   );
-  const loadPositionsFor2D = defaultValue(options.loadPositionsFor2D, false);
+  const loadAttributesFor2D = defaultValue(options.loadAttributesFor2D, false);
   const loadIndicesForWireframe = defaultValue(
     options.loadIndicesForWireframe,
     false
@@ -94,7 +94,7 @@ function B3dmLoader(options) {
   this._upAxis = upAxis;
   this._forwardAxis = forwardAxis;
   this._loadAttributesAsTypedArray = loadAttributesAsTypedArray;
-  this._loadPositionsFor2D = loadPositionsFor2D;
+  this._loadAttributesFor2D = loadAttributesFor2D;
   this._loadIndicesForWireframe = loadIndicesForWireframe;
 
   this._state = B3dmLoaderState.UNLOADED;
@@ -226,7 +226,7 @@ B3dmLoader.prototype.load = function () {
     releaseGltfJson: this._releaseGltfJson,
     incrementallyLoadTextures: this._incrementallyLoadTextures,
     loadAttributesAsTypedArray: this._loadAttributesAsTypedArray,
-    loadPositionsFor2D: this._loadPositionsFor2D,
+    loadAttributesFor2D: this._loadAttributesFor2D,
     loadIndicesForWireframe: this._loadIndicesForWireframe,
     renameBatchIdSemantic: true,
   });

--- a/Source/Scene/ModelExperimental/GeometryPipelineStage.js
+++ b/Source/Scene/ModelExperimental/GeometryPipelineStage.js
@@ -140,8 +140,8 @@ GeometryPipelineStage.process = function (
     model._projectTo2D;
 
   // If the model is instanced, the work for 2D projection will have been done
-  // in InstancingPipelineSTage. The attribute struct should still be updated
-  // with position2D, but nothing else should be modified.
+  // in InstancingPipelineSTage. The attribute struct will be updated with
+  // position2D, but nothing else should be modified.
   const instanced = defined(renderResources.runtimeNode.node.instances);
 
   // If the scene is in 3D or the model is instanced, the 2D position attribute

--- a/Source/Scene/ModelExperimental/GeometryPipelineStage.js
+++ b/Source/Scene/ModelExperimental/GeometryPipelineStage.js
@@ -51,7 +51,8 @@ GeometryPipelineStage.FUNCTION_SIGNATURE_SET_DYNAMIC_VARYINGS =
  *
  * If the scene is in either 2D or CV mode, this stage also:
  * <ul>
- *  <li> adds an attribute for the 2D positions
+ *  <li> adds a struct field for the 2D positions
+ *  <li> adds an additional attribute object and declaration if the node containing this primitive is not instanced
  * </ul>
  *
  * @param {PrimitiveRenderResources} renderResources The render resources for this primitive.
@@ -141,7 +142,7 @@ GeometryPipelineStage.process = function (
     model._projectTo2D;
 
   // If the model is instanced, the work for 2D projection will have been done
-  // in InstancingPipelineSTage. The attribute struct will be updated with
+  // in InstancingPipelineStage. The attribute struct will be updated with
   // position2D, but nothing else should be modified.
   const instanced = defined(renderResources.runtimeNode.node.instances);
 

--- a/Source/Scene/ModelExperimental/InstancingPipelineStage.js
+++ b/Source/Scene/ModelExperimental/InstancingPipelineStage.js
@@ -118,7 +118,7 @@ InstancingPipelineStage.process = function (renderResources, node, frameState) {
 
       // modifiedModelView = view * modifiedModel
       return Matrix4.multiplyTransformation(
-        frameState.context.uniformState.view,
+        frameState.context.uniformState.view3D,
         modifiedModelMatrix,
         modelViewScratch
       );

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -1615,7 +1615,7 @@ ModelExperimental.fromGltf = function (options) {
     incrementallyLoadTextures: options.incrementallyLoadTextures,
     upAxis: options.upAxis,
     forwardAxis: options.forwardAxis,
-    loadPositionsFor2D: options.projectTo2D,
+    loadAttributesFor2D: options.projectTo2D,
     loadIndicesForWireframe: options.enableDebugWireframe,
   };
 
@@ -1661,7 +1661,7 @@ ModelExperimental.fromB3dm = function (options) {
     incrementallyLoadTextures: options.incrementallyLoadTextures,
     upAxis: options.upAxis,
     forwardAxis: options.forwardAxis,
-    loadPositionsFor2D: options.projectTo2D,
+    loadAttributesFor2D: options.projectTo2D,
     loadIndicesForWireframe: options.enableDebugWireframe,
   };
 

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -1707,6 +1707,7 @@ ModelExperimental.fromI3dm = function (options) {
     incrementallyLoadTextures: options.incrementallyLoadTextures,
     upAxis: options.upAxis,
     forwardAxis: options.forwardAxis,
+    loadAttributesFor2D: options.projectTo2D,
     loadIndicesForWireframe: options.enableDebugWireframe,
   };
   const loader = new I3dmLoader(loaderOptions);

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -1560,7 +1560,8 @@ ModelExperimental.prototype.destroy = function () {
 };
 
 /**
- * Destroys resources generated in the pipeline stages.
+ * Destroys resources generated in the pipeline stages
+ * that must be destroyed when draw commands are rebuilt.
  * @private
  */
 ModelExperimental.prototype.destroyResources = function () {
@@ -1572,7 +1573,8 @@ ModelExperimental.prototype.destroyResources = function () {
 };
 
 /**
- * Destroys resources generated for the model.
+ * Destroys resources generated in the pipeline stages
+ * that exist for the lifetime of the model.
  * @private
  */
 ModelExperimental.prototype.destroyModelResources = function () {

--- a/Source/Scene/ModelExperimental/ModelExperimentalNode.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalNode.js
@@ -8,6 +8,7 @@ import InstancingPipelineStage from "./InstancingPipelineStage.js";
 import ModelMatrixUpdateStage from "./ModelMatrixUpdateStage.js";
 import TranslationRotationScale from "../../Core/TranslationRotationScale.js";
 import Quaternion from "../../Core/Quaternion.js";
+import NodeStatisticsPipelineStage from "./NodeStatisticsPipelineStage.js";
 
 /**
  * An in-memory representation of a node as part of the {@link ModelExperimentalSceneGraph}.
@@ -99,6 +100,30 @@ export default function ModelExperimentalNode(options) {
    * @private
    */
   this.updateStages = [];
+
+  /**
+   * A buffer containing the instanced transforms projected to 2D world
+   * coordinates. Used for rendering in 2D / CV mode. The memory is managed
+   * by ModelExperimental; this is just a reference.
+   *
+   * @type {Buffer}
+   * @readonly
+   *
+   * @private
+   */
+  this.instancingTransformsBuffer2D = undefined;
+
+  /**
+   * A buffer containing the instanced translation values for the node if
+   * it is instanced. Used for rendering in 2D / CV mode. The memory is
+   * managed by ModelExperimental; this is just a reference.
+   *
+   * @type {Buffer}
+   * @readonly
+   *
+   * @private
+   */
+  this.instancingTranslationBuffer2D = undefined;
 }
 
 Object.defineProperties(ModelExperimentalNode.prototype, {
@@ -446,6 +471,8 @@ ModelExperimentalNode.prototype.configurePipeline = function () {
   if (defined(node.instances)) {
     pipelineStages.push(InstancingPipelineStage);
   }
+
+  pipelineStages.push(NodeStatisticsPipelineStage);
 
   updateStages.push(ModelMatrixUpdateStage);
 };

--- a/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalPrimitive.js
@@ -17,11 +17,11 @@ import ModelExperimentalUtility from "./ModelExperimentalUtility.js";
 import MorphTargetsPipelineStage from "./MorphTargetsPipelineStage.js";
 import PickingPipelineStage from "./PickingPipelineStage.js";
 import PointCloudAttenuationPipelineStage from "./PointCloudAttenuationPipelineStage.js";
+import PrimitiveStatisticsPipelineStage from "./PrimitiveStatisticsPipelineStage.js";
 import SceneMode from "../SceneMode.js";
 import SceneMode2DPipelineStage from "./SceneMode2DPipelineStage.js";
 import SelectedFeatureIdPipelineStage from "./SelectedFeatureIdPipelineStage.js";
 import SkinningPipelineStage from "./SkinningPipelineStage.js";
-import StatisticsPipelineStage from "./StatisticsPipelineStage.js";
 import WireframePipelineStage from "./WireframePipelineStage.js";
 
 /**
@@ -238,7 +238,7 @@ ModelExperimentalPrimitive.prototype.configurePipeline = function (frameState) {
 
   pipelineStages.push(AlphaPipelineStage);
 
-  pipelineStages.push(StatisticsPipelineStage);
+  pipelineStages.push(PrimitiveStatisticsPipelineStage);
 
   return;
 };

--- a/Source/Scene/ModelExperimental/NodeRenderResources.js
+++ b/Source/Scene/ModelExperimental/NodeRenderResources.js
@@ -150,11 +150,13 @@ export default function NodeRenderResources(modelRenderResources, runtimeNode) {
   this.instancingTranslationMin = undefined;
 
   /**
-   * The bounding sphere of the instances in the node, in 2D world space.
+   * If the model is instanced and projected to 2D, the reference point is the
+   * average of the instancing translation max and min. The 2D translations are
+   * defined relative to this point to avoid precision issues on the GPU.
    *
-   * @type {BoundingSphere}
+   * @type {Cartesian3}
    *
    * @private
    */
-  this.instancedBoundingSphere2D = undefined;
+  this.instancingReferencePoint2D = undefined;
 }

--- a/Source/Scene/ModelExperimental/NodeRenderResources.js
+++ b/Source/Scene/ModelExperimental/NodeRenderResources.js
@@ -135,7 +135,6 @@ export default function NodeRenderResources(modelRenderResources, runtimeNode) {
    * The component-wise maximum value of the translations of the instances.
    *
    * @type {Cartesian3}
-   * @readonly
    *
    * @private
    */
@@ -145,9 +144,17 @@ export default function NodeRenderResources(modelRenderResources, runtimeNode) {
    * The component-wise minimum value of the translations of the instances.
    *
    * @type {Cartesian3}
-   * @readonly
    *
    * @private
    */
   this.instancingTranslationMin = undefined;
+
+  /**
+   * The bounding sphere of the instances in the node, in 2D world space.
+   *
+   * @type {BoundingSphere}
+   *
+   * @private
+   */
+  this.instancedBoundingSphere2D = undefined;
 }

--- a/Source/Scene/ModelExperimental/NodeStatisticsPipelineStage.js
+++ b/Source/Scene/ModelExperimental/NodeStatisticsPipelineStage.js
@@ -1,0 +1,68 @@
+import defined from "../../Core/defined.js";
+
+/**
+ * The node statistics update stage updates memory usage statistics for
+ * ModelExperimental on the node level. This counts the binary resources
+ * that exist for the lifetime of the ModelExperimental (e.g. attributes
+ * loaded by GltfLoader). It does not count resources that are created
+ * every time the pipeline is run. The individual pipeline stages are
+ * responsible for keeping track of additional memory they allocate.
+ *
+ * @namespace NodeStatisticsPipelineStage
+ *
+ * @private
+ */
+const NodeStatisticsPipelineStage = {};
+NodeStatisticsPipelineStage.name = "NodeStatisticsPipelineStage"; // Helps with debugging
+
+NodeStatisticsPipelineStage.process = function (
+  renderResources,
+  node,
+  frameState
+) {
+  const model = renderResources.model;
+  const statistics = model.statistics;
+  const runtimeNode = renderResources.runtimeNode;
+
+  countInstancingAttributes(statistics, node.instances);
+  countInstancing2DBuffers(statistics, runtimeNode);
+};
+
+function countInstancingAttributes(statistics, instances) {
+  if (!defined(instances)) {
+    return;
+  }
+
+  const attributes = instances.attributes;
+  const length = attributes.length;
+  for (let i = 0; i < length; i++) {
+    const attribute = attributes[i];
+    if (defined(attribute.buffer)) {
+      // Packed typed arrays are not counted
+      const hasCpuCopy = false;
+      statistics.addBuffer(attribute.buffer, hasCpuCopy);
+    }
+  }
+}
+
+function countInstancing2DBuffers(statistics, runtimeNode) {
+  if (defined(runtimeNode.instancingTransformsBuffer2D)) {
+    // The typed array containing the computed 2D transforms
+    // isn't saved after the buffer is created.
+    const hasCpuCopy = false;
+    statistics.addBuffer(runtimeNode.instancingTransformsBuffer2D, hasCpuCopy);
+  }
+
+  if (defined(runtimeNode.instancingTranslationBuffer2D)) {
+    // The typed array containing the computed 2D translations
+    // isn't saved after the buffer is created.
+    const hasCpuCopy = false;
+    statistics.addBuffer(runtimeNode.instancingTranslationBuffer2D, hasCpuCopy);
+  }
+}
+
+// Exposed for testing
+NodeStatisticsPipelineStage._countInstancingAttributes = countInstancingAttributes;
+NodeStatisticsPipelineStage._countInstancing2DBuffers = countInstancing2DBuffers;
+
+export default NodeStatisticsPipelineStage;

--- a/Source/Scene/ModelExperimental/PrimitiveStatisticsPipelineStage.js
+++ b/Source/Scene/ModelExperimental/PrimitiveStatisticsPipelineStage.js
@@ -5,7 +5,7 @@ import ModelExperimentalUtility from "./ModelExperimentalUtility.js";
 
 /**
  * The primitive statistics update stage updates memory usage statistics
- * on the primitive level. This counts the binary resources that exist 
+ * on the primitive level. This counts the binary resources that exist
  * for the lifetime of the ModelExperimental (e.g. attributes and textures
  * loaded by GltfLoader). It does not count resources that are created
  * every time the pipeline is run. The individual pipeline stages are

--- a/Source/Scene/ModelExperimental/PrimitiveStatisticsPipelineStage.js
+++ b/Source/Scene/ModelExperimental/PrimitiveStatisticsPipelineStage.js
@@ -4,20 +4,21 @@ import ModelComponents from "../ModelComponents.js";
 import ModelExperimentalUtility from "./ModelExperimentalUtility.js";
 
 /**
- * The statistics update stage updates memory usage statistics for binary
- * resources that exist for the lifetime of the ModelExperimental (e.g.
- * resources loaded by GltfLoader). It does not count resources that are
- * created every time the pipeline is run, the individual pipeline stages are
- * responsible for keeping track of additional memory they allocate.
+ * The primitive statistics update stage updates memory usage statistics
+ * on the primitive level. This counts the binary resources that exist 
+ * for the lifetime of the ModelExperimental (e.g. attributes and textures
+ * loaded by GltfLoader). It does not count resources that are created
+ * every time the pipeline is run. The individual pipeline stages are
+ * responsible for tracking the additional memory they allocate.
  *
- * @namespace StatisticsPipelineStage
+ * @namespace PrimitiveStatisticsPipelineStage
  *
  * @private
  */
-const StatisticsPipelineStage = {};
-StatisticsPipelineStage.name = "StatisticsPipelineStage"; // Helps with debugging
+const PrimitiveStatisticsPipelineStage = {};
+PrimitiveStatisticsPipelineStage.name = "PrimitiveStatisticsPipelineStage"; // Helps with debugging
 
-StatisticsPipelineStage.process = function (
+PrimitiveStatisticsPipelineStage.process = function (
   renderResources,
   primitive,
   frameState
@@ -237,11 +238,11 @@ function countPropertyTextures(statistics, structuralMetadata) {
 }
 
 // Exposed for testing
-StatisticsPipelineStage._countGeometry = countGeometry;
-StatisticsPipelineStage._count2DPositions = count2DPositions;
-StatisticsPipelineStage._countMorphTargetAttributes = countMorphTargetAttributes;
-StatisticsPipelineStage._countMaterialTextures = countMaterialTextures;
-StatisticsPipelineStage._countFeatureIdTextures = countFeatureIdTextures;
-StatisticsPipelineStage._countBinaryMetadata = countBinaryMetadata;
+PrimitiveStatisticsPipelineStage._countGeometry = countGeometry;
+PrimitiveStatisticsPipelineStage._count2DPositions = count2DPositions;
+PrimitiveStatisticsPipelineStage._countMorphTargetAttributes = countMorphTargetAttributes;
+PrimitiveStatisticsPipelineStage._countMaterialTextures = countMaterialTextures;
+PrimitiveStatisticsPipelineStage._countFeatureIdTextures = countFeatureIdTextures;
+PrimitiveStatisticsPipelineStage._countBinaryMetadata = countBinaryMetadata;
 
-export default StatisticsPipelineStage;
+export default PrimitiveStatisticsPipelineStage;

--- a/Source/Scene/ModelExperimental/SceneMode2DPipelineStage.js
+++ b/Source/Scene/ModelExperimental/SceneMode2DPipelineStage.js
@@ -13,6 +13,7 @@ import VertexAttributeSemantic from "../VertexAttributeSemantic.js";
 import SceneTransforms from "../SceneTransforms.js";
 
 const scratchModelMatrix = new Matrix4();
+const scratchModelView2D = new Matrix4();
 
 /**
  * The scene mode 2D stage generates resources for rendering a primitive in 2D / CV mode.
@@ -57,17 +58,7 @@ SceneMode2DPipelineStage.process = function (
     VertexAttributeSemantic.POSITION
   );
 
-  // If the model is instanced, 2D projection will be handled in the
-  // InstancingPipelineStage. Unload the typed array and return early.
-  const instanced = defined(renderResources.runtimeNode.node.instances);
-  if (instanced) {
-    positionAttribute.typedArray = undefined;
-    return;
-  }
-
   const shaderBuilder = renderResources.shaderBuilder;
-  const runtimePrimitive = renderResources.runtimePrimitive;
-
   const model = renderResources.model;
   const modelMatrix = model.sceneGraph.computedModelMatrix;
   const nodeComputedTransform = renderResources.runtimeNode.computedTransform;
@@ -83,7 +74,16 @@ SceneMode2DPipelineStage.process = function (
     frameState
   );
 
+  const runtimePrimitive = renderResources.runtimePrimitive;
   runtimePrimitive.boundingSphere2D = boundingSphere2D;
+
+  // If the model is instanced, 2D projection will be handled in the
+  // InstancingPipelineStage. Unload the typed array and return early.
+  const instanced = defined(renderResources.runtimeNode.node.instances);
+  if (instanced) {
+    positionAttribute.typedArray = undefined;
+    return;
+  }
 
   // If the typed array of the position attribute exists, then
   // the positions haven't been projected to 2D yet.
@@ -117,7 +117,6 @@ SceneMode2DPipelineStage.process = function (
     boundingSphere2D.center,
     new Matrix4()
   );
-  const modelView = new Matrix4();
 
   const context = frameState.context;
   const uniformMap = {
@@ -125,7 +124,7 @@ SceneMode2DPipelineStage.process = function (
       return Matrix4.multiplyTransformation(
         context.uniformState.view,
         modelMatrix2D,
-        modelView
+        scratchModelView2D
       );
     },
   };

--- a/Source/Scene/ModelExperimental/SceneMode2DPipelineStage.js
+++ b/Source/Scene/ModelExperimental/SceneMode2DPipelineStage.js
@@ -77,18 +77,23 @@ SceneMode2DPipelineStage.process = function (
     VertexAttributeSemantic.POSITION
   );
 
+  const instanced = defined(renderResources.runtimeNode.node.instances);
+
   // If the typed array of the position attribute exists, then
   // the positions haven't been projected to 2D yet.
   if (defined(positionAttribute.typedArray)) {
-    const buffer2D = createPositionBufferFor2D(
-      positionAttribute,
-      computedModelMatrix,
-      boundingSphere2D,
-      frameState
-    );
+    // Only project the positions if the model is not instanced.
+    if (!instanced) {
+      const buffer2D = createPositionBufferFor2D(
+        positionAttribute,
+        computedModelMatrix,
+        boundingSphere2D,
+        frameState
+      );
 
-    runtimePrimitive.positionBuffer2D = buffer2D;
-    model._modelResources.push(buffer2D);
+      runtimePrimitive.positionBuffer2D = buffer2D;
+      model._modelResources.push(buffer2D);
+    }
 
     // Unload the typed array. This is just a pointer to the array in
     // the vertex buffer loader, so if the typed array is shared by

--- a/Source/Scene/ModelExperimental/SceneMode2DPipelineStage.js
+++ b/Source/Scene/ModelExperimental/SceneMode2DPipelineStage.js
@@ -95,7 +95,7 @@ SceneMode2DPipelineStage.process = function (
     );
 
     // Since this buffer will persist even if the pipeline is re-run,
-    // its memory will be counted in StatisticsPipelineStage
+    // its memory will be counted in PrimitiveStatisticsPipelineStage
     runtimePrimitive.positionBuffer2D = buffer2D;
     model._modelResources.push(buffer2D);
 

--- a/Source/Scene/ModelExperimental/SceneMode2DPipelineStage.js
+++ b/Source/Scene/ModelExperimental/SceneMode2DPipelineStage.js
@@ -78,10 +78,9 @@ SceneMode2DPipelineStage.process = function (
   runtimePrimitive.boundingSphere2D = boundingSphere2D;
 
   // If the model is instanced, 2D projection will be handled in the
-  // InstancingPipelineStage. Unload the typed array and return early.
-  const instanced = defined(renderResources.runtimeNode.node.instances);
-  if (instanced) {
-    positionAttribute.typedArray = undefined;
+  // InstancingPipelineStage.
+  const instances = renderResources.runtimeNode.node.instances;
+  if (defined(instances)) {
     return;
   }
 

--- a/Source/Shaders/ModelExperimental/GeometryStageVS.glsl
+++ b/Source/Shaders/ModelExperimental/GeometryStageVS.glsl
@@ -5,7 +5,7 @@ void geometryStage(inout ProcessedAttributes attributes, mat4 modelView, mat3 no
     v_positionMC = positionMC;
     v_positionEC = (modelView * vec4(positionMC, 1.0)).xyz;
 
-    #ifdef USE_2D_POSITIONS
+    #if defined(USE_2D_POSITIONS) || defined(USE_2D_INSTANCING)
     vec3 position2D = attributes.position2D;
     vec3 positionEC = (u_modelView2D * vec4(position2D, 1.0)).xyz;
     gl_Position = czm_projection * vec4(positionEC, 1.0);

--- a/Source/Shaders/ModelExperimental/InstancingStageCommon.glsl
+++ b/Source/Shaders/ModelExperimental/InstancingStageCommon.glsl
@@ -30,3 +30,36 @@ mat4 getInstancingTransform()
 
     return instancingTransform;
 }
+
+mat4 getInstancingTransform2D()
+{
+    mat4 instancingTransform2D;
+
+    #ifdef HAS_INSTANCE_MATRICES
+    instancingTransform2D = mat4(
+        a_instancingTransform2DRow0.x, a_instancingTransform2DRow1.x, a_instancingTransform2DRow2.x, 0.0, // Column 1
+        a_instancingTransform2DRow0.y, a_instancingTransform2DRow1.y, a_instancingTransform2DRow2.y, 0.0, // Column 2
+        a_instancingTransform2DRow0.z, a_instancingTransform2DRow1.z, a_instancingTransform2DRow2.z, 0.0, // Column 3
+        a_instancingTransform2DRow0.w, a_instancingTransform2DRow1.w, a_instancingTransform2DRow2.w, 1.0  // Column 4
+    );
+    #else
+    vec3 translation2D = vec3(0.0, 0.0, 0.0);
+    vec3 scale = vec3(1.0, 1.0, 1.0);
+    
+        #ifdef HAS_INSTANCE_TRANSLATION
+        translation2D = a_instanceTranslation2D;
+        #endif
+        #ifdef HAS_INSTANCE_SCALE
+        scale = a_instanceScale;
+        #endif
+
+    instancingTransform2D = mat4(
+        scale.x, 0.0, 0.0, 0.0,
+        0.0, scale.y, 0.0, 0.0,
+        0.0, 0.0, scale.z, 0.0,
+        translation2D.x, translation2D.y, translation2D.z, 1.0
+    ); 
+    #endif
+
+    return instancingTransform2D;
+}

--- a/Source/Shaders/ModelExperimental/InstancingStageCommon.glsl
+++ b/Source/Shaders/ModelExperimental/InstancingStageCommon.glsl
@@ -31,6 +31,7 @@ mat4 getInstancingTransform()
     return instancingTransform;
 }
 
+#ifdef USE_2D_INSTANCING
 mat4 getInstancingTransform2D()
 {
     mat4 instancingTransform2D;
@@ -63,3 +64,4 @@ mat4 getInstancingTransform2D()
 
     return instancingTransform2D;
 }
+#endif

--- a/Source/Shaders/ModelExperimental/InstancingStageVS.glsl
+++ b/Source/Shaders/ModelExperimental/InstancingStageVS.glsl
@@ -1,6 +1,12 @@
-void instancingStage(inout vec3 positionMC) 
+void instancingStage(inout ProcessedAttributes attributes) 
 {
+    vec3 positionMC = attributes.positionMC;
+    
     mat4 instancingTransform = getInstancingTransform();
+    attributes.positionMC = (instancingTransform * vec4(positionMC, 1.0)).xyz;
 
-    positionMC = (instancingTransform * vec4(positionMC, 1.0)).xyz;
+    #ifdef USE_2D_INSTANCING
+    mat4 instancingTransform2D = getInstancingTransform2D();
+    attributes.position2D = (instancingTransform * vec4(positionMC, 1.0)).xyz;
+    #endif
 }

--- a/Source/Shaders/ModelExperimental/InstancingStageVS.glsl
+++ b/Source/Shaders/ModelExperimental/InstancingStageVS.glsl
@@ -7,6 +7,6 @@ void instancingStage(inout ProcessedAttributes attributes)
 
     #ifdef USE_2D_INSTANCING
     mat4 instancingTransform2D = getInstancingTransform2D();
-    attributes.position2D = (instancingTransform * vec4(positionMC, 1.0)).xyz;
+    attributes.position2D = (instancingTransform2D * vec4(positionMC, 1.0)).xyz;
     #endif
 }

--- a/Source/Shaders/ModelExperimental/LegacyInstancingStageVS.glsl
+++ b/Source/Shaders/ModelExperimental/LegacyInstancingStageVS.glsl
@@ -1,10 +1,20 @@
-void legacyInstancingStage(inout vec3 positionMC, out mat4 instanceModelView, out mat3 instanceModelViewInverseTranspose)
+void legacyInstancingStage(
+    inout ProcessedAttributes attributes,
+    out mat4 instanceModelView,
+    out mat3 instanceModelViewInverseTranspose)
 {
+    vec3 positionMC = attributes.positionMC;
     mat4 instancingTransform = getInstancingTransform();
 
     mat4 instanceModel = instancingTransform * u_instance_nodeTransform;
     instanceModelView = u_instance_modifiedModelView;
     instanceModelViewInverseTranspose = mat3(u_instance_modifiedModelView * instanceModel);
 
-    positionMC = (instanceModel * vec4(positionMC, 1.0)).xyz;
+    attributes.positionMC = (instanceModel * vec4(positionMC, 1.0)).xyz;
+
+    // TODO: make sure this is accurate
+    #ifdef USE_2D_INSTANCING
+    mat4 instancingTransform2D = getInstancingTransform2D();
+    attributes.position2D = (instancingTransform * vec4(positionMC, 1.0)).xyz;
+    #endif
 }

--- a/Source/Shaders/ModelExperimental/LegacyInstancingStageVS.glsl
+++ b/Source/Shaders/ModelExperimental/LegacyInstancingStageVS.glsl
@@ -15,6 +15,6 @@ void legacyInstancingStage(
     // TODO: make sure this is accurate
     #ifdef USE_2D_INSTANCING
     mat4 instancingTransform2D = getInstancingTransform2D();
-    attributes.position2D = (instancingTransform * vec4(positionMC, 1.0)).xyz;
+    attributes.position2D = (instancingTransform2D * vec4(positionMC, 1.0)).xyz;
     #endif
 }

--- a/Source/Shaders/ModelExperimental/LegacyInstancingStageVS.glsl
+++ b/Source/Shaders/ModelExperimental/LegacyInstancingStageVS.glsl
@@ -11,8 +11,7 @@ void legacyInstancingStage(
     instanceModelViewInverseTranspose = mat3(u_instance_modifiedModelView * instanceModel);
 
     attributes.positionMC = (instanceModel * vec4(positionMC, 1.0)).xyz;
-
-    // TODO: make sure this is accurate
+    
     #ifdef USE_2D_INSTANCING
     mat4 instancingTransform2D = getInstancingTransform2D();
     attributes.position2D = (instancingTransform2D * vec4(positionMC, 1.0)).xyz;

--- a/Source/Shaders/ModelExperimental/ModelExperimentalVS.glsl
+++ b/Source/Shaders/ModelExperimental/ModelExperimentalVS.glsl
@@ -70,12 +70,12 @@ void main()
         mat4 instanceModelView;
         mat3 instanceModelViewInverseTranspose;
         
-        legacyInstancingStage(attributes.positionMC, instanceModelView, instanceModelViewInverseTranspose);
+        legacyInstancingStage(attributes, instanceModelView, instanceModelViewInverseTranspose);
 
         modelView = instanceModelView;
         normal = instanceModelViewInverseTranspose;
         #else
-        instancingStage(attributes.positionMC);
+        instancingStage(attributes);
         #endif
 
         #ifdef USE_PICKING

--- a/Source/Shaders/ModelExperimental/ModelExperimentalVS.glsl
+++ b/Source/Shaders/ModelExperimental/ModelExperimentalVS.glsl
@@ -44,11 +44,11 @@ void main()
     cpuStylingStage(attributes.positionMC, feature);
     #endif
 
-    #ifdef USE_2D_POSITIONS
-    // The scene mode 2D pipeline stage adds a different model view matrix to
-    // accurately project the model's positions in 2D. However, the output
-    // positions and normals should be transformed by the 3D matrices to keep
-    // the data the same for the fragment shader.
+    #if defined(USE_2D_POSITIONS) || defined(USE_2D_INSTANCING)
+    // The scene mode 2D pipeline stage and instancing stage add a different
+    // model view matrix to accurately project the model to 2D. However, the
+    // output positions and normals should be transformed by the 3D matrices
+    // to keep the data the same for the fragment shader.
     mat4 modelView = czm_modelView3D;
     mat3 normal = czm_normal3D;
     #else

--- a/Specs/Scene/GltfLoaderSpec.js
+++ b/Specs/Scene/GltfLoaderSpec.js
@@ -3552,39 +3552,6 @@ describe(
         );
         expect(positionAttribute.buffer).toBeDefined();
         expect(positionAttribute.typedArray).toBeUndefined();
-
-        // All instanced transformation attributes, however, need to be
-        // loaded in as both typed arrays and buffers.
-        const instances = rootNode.instances;
-        const instancedAttributes = instances.attributes;
-        const translationAttribute = getAttribute(
-          instancedAttributes,
-          InstanceAttributeSemantic.TRANSLATION
-        );
-        expect(translationAttribute.packedTypedArray).toBeDefined();
-        expect(translationAttribute.buffer).toBeDefined();
-
-        const rotationAttribute = getAttribute(
-          instancedAttributes,
-          InstanceAttributeSemantic.ROTATION
-        );
-        expect(rotationAttribute.packedTypedArray).toBeDefined();
-        expect(rotationAttribute.buffer).toBeDefined();
-
-        const scaleAttribute = getAttribute(
-          instancedAttributes,
-          InstanceAttributeSemantic.SCALE
-        );
-        expect(scaleAttribute.packedTypedArray).toBeDefined();
-        expect(scaleAttribute.buffer).toBeDefined();
-
-        const featureIdAttribute = getAttribute(
-          instancedAttributes,
-          InstanceAttributeSemantic.FEATURE_ID,
-          0
-        );
-        expect(featureIdAttribute.packedTypedArray).toBeDefined();
-        expect(featureIdAttribute.buffer).toBeUndefined();
       });
     });
 
@@ -3688,7 +3655,109 @@ describe(
       });
     });
 
-    it("loads instanced attributes as buffers and typed arrays for 2D", function () {
+    it("loads instanced attributes as typed arrays only for 2D", function () {
+      if (!scene.context.instancedArrays) {
+        return;
+      }
+
+      const options = {
+        loadAttributesFor2D: true,
+      };
+
+      return loadGltf(boxInstanced, options).then(function (gltfLoader) {
+        // Since the instances have rotation attributes, they should be
+        // loaded in as typed arrays only anyway. This ensures no additional
+        // buffers are created for 2D.
+        const components = gltfLoader.components;
+        const scene = components.scene;
+        const rootNode = scene.nodes[0];
+
+        const instances = rootNode.instances;
+        const instancedAttributes = instances.attributes;
+        const translationAttribute = getAttribute(
+          instancedAttributes,
+          InstanceAttributeSemantic.TRANSLATION
+        );
+        expect(translationAttribute.packedTypedArray).toBeDefined();
+        expect(translationAttribute.buffer).toBeUndefined();
+
+        const rotationAttribute = getAttribute(
+          instancedAttributes,
+          InstanceAttributeSemantic.ROTATION
+        );
+        expect(rotationAttribute.packedTypedArray).toBeDefined();
+        expect(rotationAttribute.buffer).toBeUndefined();
+
+        const scaleAttribute = getAttribute(
+          instancedAttributes,
+          InstanceAttributeSemantic.SCALE
+        );
+        expect(scaleAttribute.packedTypedArray).toBeDefined();
+        expect(scaleAttribute.buffer).toBeUndefined();
+
+        const featureIdAttribute = getAttribute(
+          instancedAttributes,
+          InstanceAttributeSemantic.FEATURE_ID,
+          0
+        );
+        expect(featureIdAttribute.packedTypedArray).toBeDefined();
+        expect(featureIdAttribute.buffer).toBeUndefined();
+      });
+    });
+
+    it("loads instanced translation without min/max as typed array only for 2D", function () {
+      const options = {
+        loadAttributesFor2D: true,
+      };
+
+      return loadGltf(boxInstancedTranslation, options).then(function (
+        gltfLoader
+      ) {
+        // Since the translation attribute has no min / max readily defined,
+        // it will load in as a typed array to find these bounds at runtime.
+        // This ensures no additional buffers are created for 2D.
+        const components = gltfLoader.components;
+        const scene = components.scene;
+        const rootNode = scene.nodes[0];
+        const primitive = rootNode.primitives[0];
+        const attributes = primitive.attributes;
+        const positionAttribute = getAttribute(
+          attributes,
+          VertexAttributeSemantic.POSITION
+        );
+        const normalAttribute = getAttribute(
+          attributes,
+          VertexAttributeSemantic.NORMAL
+        );
+        const instances = rootNode.instances;
+        const instancedAttributes = instances.attributes;
+        const translationAttribute = getAttribute(
+          instancedAttributes,
+          InstanceAttributeSemantic.TRANSLATION
+        );
+
+        expect(positionAttribute).toBeDefined();
+        expect(normalAttribute).toBeDefined();
+
+        expect(translationAttribute.semantic).toBe(
+          InstanceAttributeSemantic.TRANSLATION
+        );
+        expect(translationAttribute.componentDatatype).toBe(
+          ComponentDatatype.FLOAT
+        );
+        expect(translationAttribute.type).toBe(AttributeType.VEC3);
+        expect(translationAttribute.normalized).toBe(false);
+        expect(translationAttribute.count).toBe(4);
+        expect(translationAttribute.constant).toEqual(Cartesian3.ZERO);
+        expect(translationAttribute.quantization).toBeUndefined();
+        expect(translationAttribute.packedTypedArray).toBeDefined();
+        expect(translationAttribute.buffer).toBeUndefined();
+        expect(translationAttribute.byteOffset).toBe(0);
+        expect(translationAttribute.byteStride).toBeUndefined();
+      });
+    });
+
+    it("loads instanced translation with min/max as buffer and typed array for 2D", function () {
       const options = {
         loadAttributesFor2D: true,
       };
@@ -3696,6 +3765,11 @@ describe(
       return loadGltf(boxInstancedTranslationMinMax, options).then(function (
         gltfLoader
       ) {
+        // Since the only instanced attribute is translation, and since its
+        // min / max is defined, this will be loaded as a buffer normally
+        // because it doesn't need further processing with a typed array.
+        // However, typed arrays are necessary for 2D projection, so this
+        // should load both a buffer and a typed array for the attribute.
         const components = gltfLoader.components;
         const scene = components.scene;
         const rootNode = scene.nodes[0];

--- a/Specs/Scene/GltfLoaderSpec.js
+++ b/Specs/Scene/GltfLoaderSpec.js
@@ -41,7 +41,7 @@ import loaderProcess from "../loaderProcess.js";
 import pollToPromise from "../pollToPromise.js";
 import waitForLoaderProcess from "../waitForLoaderProcess.js";
 
-describe(
+fdescribe(
   "Scene/GltfLoader",
   function () {
     const boxWithCredits =
@@ -2831,6 +2831,57 @@ describe(
         });
     });
 
+    it("loads BoxInstancedTranslationWithMinMax for 2D", function () {
+      if (!scene.context.instancedArrays) {
+        return;
+      }
+
+      return loadGltf(boxInstancedTranslationMinMax, {
+        loadAttributesFor2D: true,
+      }).then(function (gltfLoader) {
+        const components = gltfLoader.components;
+        const scene = components.scene;
+        const rootNode = scene.nodes[0];
+        const primitive = rootNode.primitives[0];
+        const attributes = primitive.attributes;
+        const positionAttribute = getAttribute(
+          attributes,
+          VertexAttributeSemantic.POSITION
+        );
+        const normalAttribute = getAttribute(
+          attributes,
+          VertexAttributeSemantic.NORMAL
+        );
+        const instances = rootNode.instances;
+        const instancedAttributes = instances.attributes;
+        const translationAttribute = getAttribute(
+          instancedAttributes,
+          InstanceAttributeSemantic.TRANSLATION
+        );
+
+        expect(positionAttribute).toBeDefined();
+        expect(normalAttribute).toBeDefined();
+
+        expect(translationAttribute.semantic).toBe(
+          InstanceAttributeSemantic.TRANSLATION
+        );
+        expect(translationAttribute.componentDatatype).toBe(
+          ComponentDatatype.FLOAT
+        );
+        expect(translationAttribute.type).toBe(AttributeType.VEC3);
+        expect(translationAttribute.normalized).toBe(false);
+        expect(translationAttribute.count).toBe(4);
+        expect(translationAttribute.min).toEqual(new Cartesian3(-2, -2, 0));
+        expect(translationAttribute.max).toEqual(new Cartesian3(2, 2, 0));
+        expect(translationAttribute.constant).toEqual(Cartesian3.ZERO);
+        expect(translationAttribute.quantization).toBeUndefined();
+        expect(translationAttribute.packedTypedArray).toBeDefined();
+        expect(translationAttribute.buffer).toBeDefined();
+        expect(translationAttribute.byteOffset).toBe(0);
+        expect(translationAttribute.byteStride).toBe(undefined);
+      });
+    });
+
     it("loads Duck", function () {
       return loadGltf(duckDraco).then(function (gltfLoader) {
         const components = gltfLoader.components;
@@ -3571,7 +3622,7 @@ describe(
         expect(translationAttribute.constant).toEqual(Cartesian3.ZERO);
         expect(translationAttribute.quantization).toBeUndefined();
         expect(translationAttribute.packedTypedArray).toBeDefined();
-        expect(translationAttribute.buffer).toBeUndefined();
+        expect(translationAttribute.buffer).toBeDefined();
         expect(translationAttribute.byteOffset).toBe(0);
         expect(translationAttribute.byteStride).toBeUndefined();
       });

--- a/Specs/Scene/GltfLoaderSpec.js
+++ b/Specs/Scene/GltfLoaderSpec.js
@@ -41,7 +41,7 @@ import loaderProcess from "../loaderProcess.js";
 import pollToPromise from "../pollToPromise.js";
 import waitForLoaderProcess from "../waitForLoaderProcess.js";
 
-fdescribe(
+describe(
   "Scene/GltfLoader",
   function () {
     const boxWithCredits =

--- a/Specs/Scene/GltfLoaderSpec.js
+++ b/Specs/Scene/GltfLoaderSpec.js
@@ -3477,6 +3477,66 @@ describe(
       });
     });
 
+    it("loads position attribute as buffer only if model is instanced", function () {
+      if (!scene.context.instancedArrays) {
+        return;
+      }
+
+      const options = {
+        loadAttributesFor2D: true,
+      };
+
+      return loadGltf(boxInstanced, options).then(function (gltfLoader) {
+        const components = gltfLoader.components;
+        const scene = components.scene;
+        const rootNode = scene.nodes[0];
+        const primitive = rootNode.primitives[0];
+        const attributes = primitive.attributes;
+
+        // Projecting instanced models to 2D doesn't require the position
+        // attribute to be loaded as a typed array.
+        const positionAttribute = getAttribute(
+          attributes,
+          VertexAttributeSemantic.POSITION
+        );
+        expect(positionAttribute.buffer).toBeDefined();
+        expect(positionAttribute.typedArray).toBeUndefined();
+
+        // All instanced transformation attributes, however, need to be
+        // loaded in as both typed arrays and buffers.
+        const instances = rootNode.instances;
+        const instancedAttributes = instances.attributes;
+        const translationAttribute = getAttribute(
+          instancedAttributes,
+          InstanceAttributeSemantic.TRANSLATION
+        );
+        expect(translationAttribute.packedTypedArray).toBeDefined();
+        expect(translationAttribute.buffer).toBeDefined();
+
+        const rotationAttribute = getAttribute(
+          instancedAttributes,
+          InstanceAttributeSemantic.ROTATION
+        );
+        expect(rotationAttribute.packedTypedArray).toBeDefined();
+        expect(rotationAttribute.buffer).toBeDefined();
+
+        const scaleAttribute = getAttribute(
+          instancedAttributes,
+          InstanceAttributeSemantic.SCALE
+        );
+        expect(scaleAttribute.packedTypedArray).toBeDefined();
+        expect(scaleAttribute.buffer).toBeDefined();
+
+        const featureIdAttribute = getAttribute(
+          instancedAttributes,
+          InstanceAttributeSemantic.FEATURE_ID,
+          0
+        );
+        expect(featureIdAttribute.packedTypedArray).toBeDefined();
+        expect(featureIdAttribute.buffer).toBeUndefined();
+      });
+    });
+
     it("loads indices in typed array for wireframes in WebGL1", function () {
       return loadGltf(triangle, {
         loadIndicesForWireframe: true,
@@ -3526,7 +3586,7 @@ describe(
       });
     });
 
-    it("loads instanced attributes as typed arrays", function () {
+    it("loads instanced attributes as typed arrays only", function () {
       const options = {
         loadAttributesAsTypedArray: true,
       };
@@ -3577,7 +3637,7 @@ describe(
       });
     });
 
-    it("loads instanced attributes as typed arrays for 2D", function () {
+    it("loads instanced attributes as buffers and typed arrays for 2D", function () {
       const options = {
         loadAttributesFor2D: true,
       };

--- a/Specs/Scene/GltfLoaderSpec.js
+++ b/Specs/Scene/GltfLoaderSpec.js
@@ -41,7 +41,7 @@ import loaderProcess from "../loaderProcess.js";
 import pollToPromise from "../pollToPromise.js";
 import waitForLoaderProcess from "../waitForLoaderProcess.js";
 
-describe(
+fdescribe(
   "Scene/GltfLoader",
   function () {
     const boxWithCredits =
@@ -3392,7 +3392,7 @@ describe(
 
     it("loads position attribute as buffer and typed array for 2D projection", function () {
       const options = {
-        loadPositionsFor2D: true,
+        loadAttributesFor2D: true,
       };
 
       return loadGltf(boxInterleaved, options).then(function (gltfLoader) {
@@ -3478,6 +3478,57 @@ describe(
     it("loads instanced attributes as typed arrays", function () {
       const options = {
         loadAttributesAsTypedArray: true,
+      };
+
+      return loadGltf(boxInstancedTranslationMinMax, options).then(function (
+        gltfLoader
+      ) {
+        const components = gltfLoader.components;
+        const scene = components.scene;
+        const rootNode = scene.nodes[0];
+        const primitive = rootNode.primitives[0];
+        const attributes = primitive.attributes;
+        const positionAttribute = getAttribute(
+          attributes,
+          VertexAttributeSemantic.POSITION
+        );
+        const normalAttribute = getAttribute(
+          attributes,
+          VertexAttributeSemantic.NORMAL
+        );
+        const instances = rootNode.instances;
+        const instancedAttributes = instances.attributes;
+        const translationAttribute = getAttribute(
+          instancedAttributes,
+          InstanceAttributeSemantic.TRANSLATION
+        );
+
+        expect(positionAttribute).toBeDefined();
+        expect(normalAttribute).toBeDefined();
+
+        expect(translationAttribute.semantic).toBe(
+          InstanceAttributeSemantic.TRANSLATION
+        );
+        expect(translationAttribute.componentDatatype).toBe(
+          ComponentDatatype.FLOAT
+        );
+        expect(translationAttribute.type).toBe(AttributeType.VEC3);
+        expect(translationAttribute.normalized).toBe(false);
+        expect(translationAttribute.count).toBe(4);
+        expect(translationAttribute.min).toEqual(new Cartesian3(-2, -2, 0));
+        expect(translationAttribute.max).toEqual(new Cartesian3(2, 2, 0));
+        expect(translationAttribute.constant).toEqual(Cartesian3.ZERO);
+        expect(translationAttribute.quantization).toBeUndefined();
+        expect(translationAttribute.packedTypedArray).toBeDefined();
+        expect(translationAttribute.buffer).toBeUndefined();
+        expect(translationAttribute.byteOffset).toBe(0);
+        expect(translationAttribute.byteStride).toBeUndefined();
+      });
+    });
+
+    it("loads instanced attributes as typed arrays for 2D", function () {
+      const options = {
+        loadAttributesFor2D: true,
       };
 
       return loadGltf(boxInstancedTranslationMinMax, options).then(function (

--- a/Specs/Scene/GltfLoaderSpec.js
+++ b/Specs/Scene/GltfLoaderSpec.js
@@ -112,6 +112,13 @@ describe(
 
     beforeAll(function () {
       scene = createScene();
+
+      // This is set to true in order to test that buffers / typed arrays
+      // are loaded in correctly for instanced models. If this is false,
+      // instanced attributes will always load in as typed arrays, which
+      // will cause several tests to fail.
+      scene.context._instancedArrays = true;
+
       sceneWithWebgl2 = createScene();
       sceneWithWebgl2.context._webgl2 = true;
     });
@@ -2082,10 +2089,6 @@ describe(
     });
 
     it("loads BoxInstanced", function () {
-      if (!scene.context.instancedArrays) {
-        return;
-      }
-
       return loadGltf(boxInstanced).then(function (gltfLoader) {
         const components = gltfLoader.components;
         const scene = components.scene;
@@ -2281,10 +2284,6 @@ describe(
     });
 
     it("loads BoxInstanced with EXT_feature_metadata", function () {
-      if (!scene.context.instancedArrays) {
-        return;
-      }
-
       return loadGltf(boxInstancedLegacy).then(function (gltfLoader) {
         const components = gltfLoader.components;
         const scene = components.scene;
@@ -2567,10 +2566,6 @@ describe(
     });
 
     it("loads BoxInstanced with default feature ids", function () {
-      if (!scene.context.instancedArrays) {
-        return;
-      }
-
       function modifyGltf(gltf) {
         // Delete feature ID accessor's buffer view
         delete gltf.accessors[6].bufferView;
@@ -2687,10 +2682,6 @@ describe(
     });
 
     it("loads BoxInstancedTranslation", function () {
-      if (!scene.context.instancedArrays) {
-        return;
-      }
-
       return loadGltf(boxInstancedTranslation).then(function (gltfLoader) {
         const components = gltfLoader.components;
         const scene = components.scene;
@@ -2738,10 +2729,6 @@ describe(
     });
 
     it("loads BoxInstancedTranslationWithMinMax", function () {
-      if (!scene.context.instancedArrays) {
-        return;
-      }
-
       return loadGltf(boxInstancedTranslationMinMax).then(function (
         gltfLoader
       ) {
@@ -2832,10 +2819,6 @@ describe(
     });
 
     it("loads BoxInstancedTranslationWithMinMax for 2D", function () {
-      if (!scene.context.instancedArrays) {
-        return;
-      }
-
       return loadGltf(boxInstancedTranslationMinMax, {
         loadAttributesFor2D: true,
       }).then(function (gltfLoader) {
@@ -3529,10 +3512,6 @@ describe(
     });
 
     it("loads position attribute as buffer only if model is instanced", function () {
-      if (!scene.context.instancedArrays) {
-        return;
-      }
-
       const options = {
         loadAttributesFor2D: true,
       };
@@ -3656,10 +3635,6 @@ describe(
     });
 
     it("loads instanced attributes as typed arrays only for 2D", function () {
-      if (!scene.context.instancedArrays) {
-        return;
-      }
-
       const options = {
         loadAttributesFor2D: true,
       };

--- a/Specs/Scene/ModelExperimental/GeometryPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/GeometryPipelineStageSpec.js
@@ -15,7 +15,7 @@ import createScene from "../../createScene.js";
 import waitForLoaderProcess from "../../waitForLoaderProcess.js";
 import ShaderBuilderTester from "../../ShaderBuilderTester.js";
 
-fdescribe(
+describe(
   "Scene/ModelExperimental/GeometryPipelineStage",
   function () {
     const positionOnlyPrimitive = {

--- a/Specs/Scene/ModelExperimental/GeometryPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/GeometryPipelineStageSpec.js
@@ -15,7 +15,7 @@ import createScene from "../../createScene.js";
 import waitForLoaderProcess from "../../waitForLoaderProcess.js";
 import ShaderBuilderTester from "../../ShaderBuilderTester.js";
 
-describe(
+fdescribe(
   "Scene/ModelExperimental/GeometryPipelineStage",
   function () {
     const positionOnlyPrimitive = {
@@ -70,6 +70,8 @@ describe(
       "./Data/Models/DracoCompression/CesiumMilkTruck/CesiumMilkTruck.gltf";
     const dracoBoxWithTangents =
       "./Data/Models/DracoCompression/BoxWithTangents/BoxWithTangents.gltf";
+    const boxInstancedTranslationUrl =
+      "./Data/Models/GltfLoader/BoxInstancedTranslation/glTF/box-instanced-translation.gltf";
 
     let scene;
     let scene2D;
@@ -98,6 +100,20 @@ describe(
       gltfLoaders.length = 0;
       ResourceCache.clearForSpecs();
     });
+
+    function mockRenderResources() {
+      return {
+        attributes: [],
+        shaderBuilder: new ShaderBuilder(),
+        attributeIndex: 1,
+        model: {
+          type: ModelExperimentalType.TILE_GLTF,
+        },
+        runtimeNode: {
+          node: {},
+        },
+      };
+    }
 
     function verifyFeatureStruct(shaderBuilder) {
       ShaderBuilderTester.expectHasVertexStruct(
@@ -134,14 +150,7 @@ describe(
     }
 
     it("processes POSITION attribute from primitive", function () {
-      const renderResources = {
-        attributes: [],
-        shaderBuilder: new ShaderBuilder(),
-        attributeIndex: 1,
-        model: {
-          type: ModelExperimentalType.TILE_GLTF,
-        },
-      };
+      const renderResources = mockRenderResources();
 
       GeometryPipelineStage.process(
         renderResources,
@@ -209,14 +218,7 @@ describe(
     });
 
     it("processes POSITION, NORMAL and TEXCOORD attributes from primitive", function () {
-      const renderResources = {
-        attributes: [],
-        shaderBuilder: new ShaderBuilder(),
-        attributeIndex: 1,
-        model: {
-          type: ModelExperimentalType.TILE_GLTF,
-        },
-      };
+      const renderResources = mockRenderResources();
 
       return loadGltf(boxTextured).then(function (gltfLoader) {
         const components = gltfLoader.components;
@@ -328,19 +330,13 @@ describe(
     });
 
     it("processes POSITION attribute from primitive for 2D", function () {
+      const renderResources = mockRenderResources();
+      renderResources.model._projectTo2D = true;
+
       const runtimePrimitive = {
         positionBuffer2D: {},
       };
-      const renderResources = {
-        attributes: [],
-        shaderBuilder: new ShaderBuilder(),
-        attributeIndex: 1,
-        model: {
-          type: ModelExperimentalType.TILE_GLTF,
-          _projectTo2D: true,
-        },
-        runtimePrimitive: runtimePrimitive,
-      };
+      renderResources.runtimePrimitive = runtimePrimitive;
 
       return loadGltf(boxTextured).then(function (gltfLoader) {
         const components = gltfLoader.components;
@@ -425,14 +421,7 @@ describe(
     });
 
     it("processes POSITION, NORMAL, TEXCOORD and TANGENT attributes from primitive", function () {
-      const renderResources = {
-        attributes: [],
-        shaderBuilder: new ShaderBuilder(),
-        attributeIndex: 1,
-        model: {
-          type: ModelExperimentalType.TILE_GLTF,
-        },
-      };
+      const renderResources = mockRenderResources();
 
       return loadGltf(boomBoxSpecularGlossiness).then(function (gltfLoader) {
         const components = gltfLoader.components;
@@ -575,14 +564,7 @@ describe(
     });
 
     it("processes multiple TEXCOORD attributes from primitive", function () {
-      const renderResources = {
-        attributes: [],
-        shaderBuilder: new ShaderBuilder(),
-        attributeIndex: 1,
-        model: {
-          type: ModelExperimentalType.TILE_GLTF,
-        },
-      };
+      const renderResources = mockRenderResources();
 
       return loadGltf(microcosm).then(function (gltfLoader) {
         const components = gltfLoader.components;
@@ -702,14 +684,7 @@ describe(
     });
 
     it("processes POSITION, NORMAL, TEXCOORD and COLOR attributes from primitive", function () {
-      const renderResources = {
-        attributes: [],
-        shaderBuilder: new ShaderBuilder(),
-        attributeIndex: 1,
-        model: {
-          type: ModelExperimentalType.TILE_GLTF,
-        },
-      };
+      const renderResources = mockRenderResources();
 
       return loadGltf(boxVertexColors).then(function (gltfLoader) {
         const components = gltfLoader.components;
@@ -851,14 +826,7 @@ describe(
     });
 
     it("promotes vec3 vertex colors to vec4 in the shader", function () {
-      const renderResources = {
-        attributes: [],
-        shaderBuilder: new ShaderBuilder(),
-        attributeIndex: 1,
-        model: {
-          type: ModelExperimentalType.TILE_GLTF,
-        },
-      };
+      const renderResources = mockRenderResources();
 
       return loadGltf(pointCloudRGB).then(function (gltfLoader) {
         const components = gltfLoader.components;
@@ -957,14 +925,7 @@ describe(
     });
 
     it("processes custom vertex attribute from primitive", function () {
-      const renderResources = {
-        attributes: [],
-        shaderBuilder: new ShaderBuilder(),
-        attributeIndex: 1,
-        model: {
-          type: ModelExperimentalType.TILE_GLTF,
-        },
-      };
+      const renderResources = mockRenderResources();
 
       GeometryPipelineStage.process(
         renderResources,
@@ -1050,14 +1011,7 @@ describe(
     });
 
     it("processes POSITION, NORMAL and _FEATURE_ID_n attributes from primitive", function () {
-      const renderResources = {
-        attributes: [],
-        shaderBuilder: new ShaderBuilder(),
-        attributeIndex: 1,
-        model: {
-          type: ModelExperimentalType.TILE_GLTF,
-        },
-      };
+      const renderResources = mockRenderResources();
 
       return loadGltf(buildingsMetadata).then(function (gltfLoader) {
         const components = gltfLoader.components;
@@ -1154,14 +1108,7 @@ describe(
     });
 
     it("sets PRIMITIVE_TYPE_POINTS for point primitive types", function () {
-      const renderResources = {
-        attributes: [],
-        shaderBuilder: new ShaderBuilder(),
-        attributeIndex: 1,
-        model: {
-          type: ModelExperimentalType.TILE_GLTF,
-        },
-      };
+      const renderResources = mockRenderResources();
 
       return loadGltf(weather).then(function (gltfLoader) {
         const components = gltfLoader.components;
@@ -1242,14 +1189,7 @@ describe(
     });
 
     it("prepares Draco model for dequantization stage", function () {
-      const renderResources = {
-        attributes: [],
-        shaderBuilder: new ShaderBuilder(),
-        attributeIndex: 1,
-        model: {
-          type: ModelExperimentalType.TILE_GLTF,
-        },
-      };
+      const renderResources = mockRenderResources();
 
       return loadGltf(dracoMilkTruck).then(function (gltfLoader) {
         const components = gltfLoader.components;
@@ -1343,14 +1283,7 @@ describe(
     // The tangents in this model aren't quantized, but they still should not
     // cause the model to crash.
     it("prepares Draco model with tangents for dequantization stage", function () {
-      const renderResources = {
-        attributes: [],
-        shaderBuilder: new ShaderBuilder(),
-        attributeIndex: 1,
-        model: {
-          type: ModelExperimentalType.TILE_GLTF,
-        },
-      };
+      const renderResources = mockRenderResources();
 
       return loadGltf(dracoBoxWithTangents).then(function (gltfLoader) {
         const components = gltfLoader.components;
@@ -1469,19 +1402,13 @@ describe(
     });
 
     it("processes Draco model for 2D", function () {
+      const renderResources = mockRenderResources();
+      renderResources.model._projectTo2D = true;
+
       const runtimePrimitive = {
         positionBuffer2D: {},
       };
-      const renderResources = {
-        attributes: [],
-        shaderBuilder: new ShaderBuilder(),
-        attributeIndex: 1,
-        model: {
-          type: ModelExperimentalType.TILE_GLTF,
-          _projectTo2D: true,
-        },
-        runtimePrimitive: runtimePrimitive,
-      };
+      renderResources.runtimePrimitive = runtimePrimitive;
 
       return loadGltf(dracoMilkTruck).then(function (gltfLoader) {
         const components = gltfLoader.components;
@@ -1591,14 +1518,7 @@ describe(
     });
 
     it("processes model with matrix attributes", function () {
-      const renderResources = {
-        attributes: [],
-        shaderBuilder: new ShaderBuilder(),
-        attributeIndex: 1,
-        model: {
-          type: ModelExperimentalType.TILE_GLTF,
-        },
-      };
+      const renderResources = mockRenderResources();
 
       return loadGltf(boxTexturedWithPropertyAttributes).then(function (
         gltfLoader
@@ -1761,6 +1681,69 @@ describe(
             "attribute mat2 a_warp_matrix;",
             "attribute vec2 a_temperatures;",
           ]
+        );
+        verifyFeatureStruct(shaderBuilder);
+      });
+    });
+
+    it("processes POSITION attribute for instanced model for 2D", function () {
+      const renderResources = mockRenderResources();
+      renderResources.model._projectTo2D = true;
+
+      return loadGltf(boxInstancedTranslationUrl).then(function (gltfLoader) {
+        const components = gltfLoader.components;
+        const node = components.nodes[0];
+        renderResources.runtimeNode.node = node;
+        const primitive = node.primitives[0];
+
+        GeometryPipelineStage.process(
+          renderResources,
+          primitive,
+          scene2D.frameState
+        );
+
+        const shaderBuilder = renderResources.shaderBuilder;
+        const attributes = renderResources.attributes;
+
+        expect(attributes.length).toEqual(2);
+
+        const normalAttribute = attributes[1];
+        expect(normalAttribute.index).toEqual(1);
+
+        const positionAttribute = attributes[0];
+        expect(positionAttribute.index).toEqual(0);
+        expect(positionAttribute.vertexBuffer).toBeDefined();
+        expect(positionAttribute.componentsPerAttribute).toEqual(3);
+        expect(positionAttribute.componentDatatype).toEqual(
+          ComponentDatatype.FLOAT
+        );
+        expect(positionAttribute.offsetInBytes).toBe(0);
+        expect(positionAttribute.strideInBytes).toBe(12);
+
+        // Only the attributes struct should be modified for 2D.
+        // Everything else should remain the same.
+        ShaderBuilderTester.expectHasVertexStruct(
+          shaderBuilder,
+          GeometryPipelineStage.STRUCT_ID_PROCESSED_ATTRIBUTES_VS,
+          GeometryPipelineStage.STRUCT_NAME_PROCESSED_ATTRIBUTES,
+          ["    vec3 positionMC;", "    vec3 position2D;", "    vec3 normalMC;"]
+        );
+        ShaderBuilderTester.expectHasVertexFunctionUnordered(
+          shaderBuilder,
+          GeometryPipelineStage.FUNCTION_ID_INITIALIZE_ATTRIBUTES,
+          GeometryPipelineStage.FUNCTION_SIGNATURE_INITIALIZE_ATTRIBUTES,
+          [
+            "    attributes.positionMC = a_positionMC;",
+            "    attributes.normalMC = a_normalMC;",
+          ]
+        );
+        ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
+          "HAS_NORMALS",
+        ]);
+        ShaderBuilderTester.expectHasAttributes(
+          shaderBuilder,
+          "attribute vec3 a_positionMC;",
+          ["attribute vec3 a_normalMC;"]
         );
         verifyFeatureStruct(shaderBuilder);
       });

--- a/Specs/Scene/ModelExperimental/InstancingPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/InstancingPipelineStageSpec.js
@@ -18,7 +18,7 @@ import createScene from "../../createScene.js";
 import waitForLoaderProcess from "../../waitForLoaderProcess.js";
 import ShaderBuilderTester from "../../ShaderBuilderTester.js";
 
-fdescribe("Scene/ModelExperimental/InstancingPipelineStage", function () {
+describe("Scene/ModelExperimental/InstancingPipelineStage", function () {
   const scratchMatrix4 = new Matrix4();
 
   const boxInstanced =

--- a/Specs/Scene/ModelExperimental/InstancingPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/InstancingPipelineStageSpec.js
@@ -291,6 +291,10 @@ fdescribe("Scene/ModelExperimental/InstancingPipelineStage", function () {
         "attribute float a_instanceFeatureId_0;",
       ]);
 
+      ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, [
+        "uniform mat4 u_modelView2D;",
+      ]);
+
       const translationMatrix = Matrix4.fromTranslation(
         renderResources.instancingReferencePoint2D,
         scratchMatrix4

--- a/Specs/Scene/ModelExperimental/InstancingPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/InstancingPipelineStageSpec.js
@@ -318,7 +318,7 @@ describe("Scene/ModelExperimental/InstancingPipelineStage", function () {
         0.3897113800048828,
         0,
       ]);
-      const transforms = InstancingPipelineStage._getInstanceTransformMatrices(
+      const transforms = InstancingPipelineStage._getInstanceTransformsFromMatrices(
         node.instances,
         node.instances.attributes[0].count,
         renderResources

--- a/Specs/Scene/ModelExperimental/InstancingPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/InstancingPipelineStageSpec.js
@@ -19,608 +19,646 @@ import createScene from "../../createScene.js";
 import waitForLoaderProcess from "../../waitForLoaderProcess.js";
 import ShaderBuilderTester from "../../ShaderBuilderTester.js";
 
-describe("Scene/ModelExperimental/InstancingPipelineStage", function () {
-  const scratchMatrix4 = new Matrix4();
+describe(
+  "Scene/ModelExperimental/InstancingPipelineStage",
+  function () {
+    const scratchMatrix4 = new Matrix4();
 
-  const boxInstanced =
-    "./Data/Models/GltfLoader/BoxInstanced/glTF/box-instanced.gltf";
-  const boxInstancedTranslation =
-    "./Data/Models/GltfLoader/BoxInstancedTranslation/glTF/box-instanced-translation.gltf";
-  const boxInstancedTranslationMinMax =
-    "./Data/Models/GltfLoader/BoxInstancedTranslationWithMinMax/glTF/box-instanced-translation-min-max.gltf";
-  const i3dmInstancedOrientation =
-    "./Data/Cesium3DTiles/Instanced/InstancedOrientation/instancedOrientation.i3dm";
+    const boxInstanced =
+      "./Data/Models/GltfLoader/BoxInstanced/glTF/box-instanced.gltf";
+    const boxInstancedTranslation =
+      "./Data/Models/GltfLoader/BoxInstancedTranslation/glTF/box-instanced-translation.gltf";
+    const boxInstancedTranslationMinMax =
+      "./Data/Models/GltfLoader/BoxInstancedTranslationWithMinMax/glTF/box-instanced-translation-min-max.gltf";
+    const i3dmInstancedOrientation =
+      "./Data/Cesium3DTiles/Instanced/InstancedOrientation/instancedOrientation.i3dm";
 
-  let scene;
-  let scene2D;
-  const gltfLoaders = [];
+    let scene;
+    let scene2D;
+    const gltfLoaders = [];
 
-  beforeAll(function () {
-    scene = createScene();
-    scene2D = createScene();
-    scene2D.morphTo2D(0.0);
-  });
+    beforeAll(function () {
+      scene = createScene();
+      // This is set to true to guarantee that buffers / typed arrays
+      // are loaded in as expected for instanced models. If this is false,
+      // instanced attributes will always load in as typed arrays, which
+      // will cause several tests to fail.
+      scene.context._instancedArrays = true;
 
-  afterAll(function () {
-    scene = createScene();
-    scene2D.destroyForSpecs();
-  });
+      scene2D = createScene();
+      scene2D.morphTo2D(0.0);
+    });
 
-  afterEach(function () {
-    const gltfLoadersLength = gltfLoaders.length;
-    for (let i = 0; i < gltfLoadersLength; ++i) {
-      const gltfLoader = gltfLoaders[i];
-      if (!gltfLoader.isDestroyed()) {
-        gltfLoader.destroy();
+    afterAll(function () {
+      scene = createScene();
+      scene2D.destroyForSpecs();
+    });
+
+    afterEach(function () {
+      const gltfLoadersLength = gltfLoaders.length;
+      for (let i = 0; i < gltfLoadersLength; ++i) {
+        const gltfLoader = gltfLoaders[i];
+        if (!gltfLoader.isDestroyed()) {
+          gltfLoader.destroy();
+        }
       }
-    }
-    gltfLoaders.length = 0;
-    ResourceCache.clearForSpecs();
-  });
+      gltfLoaders.length = 0;
+      ResourceCache.clearForSpecs();
+    });
 
-  function mockRenderResources() {
-    return {
-      attributeIndex: 1,
-      attributes: [],
-      instancingTranslationMax: undefined,
-      instancingTranslationMin: undefined,
-      shaderBuilder: new ShaderBuilder(),
-      model: {
-        _modelResources: [],
-        _resources: [],
-        statistics: new ModelExperimentalStatistics(),
-      },
-      runtimeNode: {},
-    };
-  }
-
-  function mockRenderResourcesFor2D() {
-    return {
-      attributeIndex: 1,
-      attributes: [],
-      instancingTranslationMax: undefined,
-      instancingTranslationMin: undefined,
-      shaderBuilder: new ShaderBuilder(),
-      model: {
-        _modelResources: [],
-        _resources: [],
-        statistics: new ModelExperimentalStatistics(),
-        _projectTo2D: true,
-        sceneGraph: {
-          computedModelMatrix: Matrix4.IDENTITY,
-          axisCorrectionMatrix: Matrix4.IDENTITY,
+    function mockRenderResources() {
+      return {
+        attributeIndex: 1,
+        attributes: [],
+        instancingTranslationMax: undefined,
+        instancingTranslationMin: undefined,
+        shaderBuilder: new ShaderBuilder(),
+        model: {
+          _modelResources: [],
+          _resources: [],
+          statistics: new ModelExperimentalStatistics(),
         },
-      },
-      runtimeNode: {
-        computedTransform: Matrix4.IDENTITY,
-      },
-    };
-  }
+        runtimeNode: {},
+      };
+    }
 
-  function getOptions(gltfPath, options) {
-    const resource = new Resource({
-      url: gltfPath,
-    });
+    function mockRenderResourcesFor2D() {
+      return {
+        attributeIndex: 1,
+        attributes: [],
+        instancingTranslationMax: undefined,
+        instancingTranslationMin: undefined,
+        shaderBuilder: new ShaderBuilder(),
+        model: {
+          _modelResources: [],
+          _resources: [],
+          statistics: new ModelExperimentalStatistics(),
+          _projectTo2D: true,
+          sceneGraph: {
+            computedModelMatrix: Matrix4.IDENTITY,
+            axisCorrectionMatrix: Matrix4.IDENTITY,
+          },
+        },
+        runtimeNode: {
+          computedTransform: Matrix4.IDENTITY,
+        },
+      };
+    }
 
-    return combine(options, {
-      gltfResource: resource,
-      incrementallyLoadTexture: false,
-    });
-  }
+    function getOptions(gltfPath, options) {
+      const resource = new Resource({
+        url: gltfPath,
+      });
 
-  function getI3dmOptions(gltfPath, options) {
-    const resource = new Resource({
-      url: gltfPath,
-    });
+      return combine(options, {
+        gltfResource: resource,
+        incrementallyLoadTexture: false,
+      });
+    }
 
-    return combine(options, {
-      i3dmResource: resource,
-      incrementallyLoadTexture: false,
-    });
-  }
+    function getI3dmOptions(gltfPath, options) {
+      const resource = new Resource({
+        url: gltfPath,
+      });
 
-  function loadGltf(gltfPath, options) {
-    const gltfLoader = new GltfLoader(getOptions(gltfPath, options));
-    gltfLoaders.push(gltfLoader);
-    gltfLoader.load();
+      return combine(options, {
+        i3dmResource: resource,
+        incrementallyLoadTexture: false,
+      });
+    }
 
-    return waitForLoaderProcess(gltfLoader, scene);
-  }
+    function loadGltf(gltfPath, options) {
+      const gltfLoader = new GltfLoader(getOptions(gltfPath, options));
+      gltfLoaders.push(gltfLoader);
+      gltfLoader.load();
 
-  function loadI3dm(i3dmPath) {
-    const result = Resource.fetchArrayBuffer(i3dmPath);
+      return waitForLoaderProcess(gltfLoader, scene);
+    }
 
-    return result.then(function (arrayBuffer) {
-      const i3dmLoader = new I3dmLoader(
-        getI3dmOptions(i3dmPath, { arrayBuffer: arrayBuffer })
-      );
-      gltfLoaders.push(i3dmLoader);
-      i3dmLoader.load();
-      return waitForLoaderProcess(i3dmLoader, scene);
-    });
-  }
+    function loadI3dm(i3dmPath) {
+      const result = Resource.fetchArrayBuffer(i3dmPath);
 
-  it("correctly computes instancing TRANSLATION min and max from typed arrays", function () {
-    const renderResources = mockRenderResources();
-
-    return loadGltf(boxInstanced).then(function (gltfLoader) {
-      const components = gltfLoader.components;
-      const node = components.nodes[0];
-
-      scene.renderForSpecs();
-      InstancingPipelineStage.process(renderResources, node, scene.frameState);
-
-      expect(renderResources.instancingTranslationMax).toEqual(
-        new Cartesian3(2, 2, 0)
-      );
-      expect(renderResources.instancingTranslationMin).toEqual(
-        new Cartesian3(-2, -2, 0)
-      );
-      expect(renderResources.attributes.length).toBe(4);
-    });
-  });
-
-  it("sets instancing TRANSLATION min and max from attributes", function () {
-    const renderResources = mockRenderResources();
-
-    return loadGltf(boxInstancedTranslationMinMax).then(function (gltfLoader) {
-      const components = gltfLoader.components;
-      const node = components.nodes[0];
-
-      InstancingPipelineStage.process(renderResources, node, scene.frameState);
-
-      expect(renderResources.instancingTranslationMax).toEqual(
-        new Cartesian3(2, 2, 0)
-      );
-      expect(renderResources.instancingTranslationMin).toEqual(
-        new Cartesian3(-2, -2, 0)
-      );
-      expect(renderResources.attributes.length).toBe(1);
-    });
-  });
-
-  it("creates instancing matrices vertex attributes when ROTATION is present", function () {
-    const renderResources = mockRenderResources();
-
-    return loadGltf(boxInstanced).then(function (gltfLoader) {
-      const components = gltfLoader.components;
-      const node = components.nodes[0];
-
-      scene.renderForSpecs();
-      InstancingPipelineStage.process(renderResources, node, scene.frameState);
-
-      expect(renderResources.attributes.length).toBe(4);
-
-      const shaderBuilder = renderResources.shaderBuilder;
-      ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
-        "HAS_INSTANCING",
-        "HAS_INSTANCE_MATRICES",
-      ]);
-      ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
-        "HAS_INSTANCING",
-        "HAS_INSTANCE_MATRICES",
-      ]);
-      ShaderBuilderTester.expectHasAttributes(shaderBuilder, undefined, [
-        "attribute vec4 a_instancingTransformRow0;",
-        "attribute vec4 a_instancingTransformRow1;",
-        "attribute vec4 a_instancingTransformRow2;",
-        "attribute float a_instanceFeatureId_0;",
-      ]);
-
-      // The model has feature IDs, so a resource will also be created
-      // for those.
-      expect(renderResources.model._resources.length).toEqual(2);
-      expect(renderResources.model._modelResources.length).toEqual(0);
-
-      // Matrices are stored as 3 vec4s, so this is
-      // 4 matrices * 12 floats/matrix * 4 bytes/float = 192
-      const matrixSize = 192;
-      // 4 floats
-      const featureIdSize = 16;
-      expect(renderResources.model.statistics.geometryByteLength).toBe(
-        matrixSize + featureIdSize
-      );
-    });
-  });
-
-  it("creates instance matrices vertex attributes when TRANSLATION min and max are not present", function () {
-    const renderResources = mockRenderResources();
-
-    return loadGltf(boxInstancedTranslation).then(function (gltfLoader) {
-      const components = gltfLoader.components;
-      const node = components.nodes[0];
-
-      scene.renderForSpecs();
-      InstancingPipelineStage.process(renderResources, node, scene.frameState);
-
-      expect(renderResources.attributes.length).toBe(3);
-
-      const shaderBuilder = renderResources.shaderBuilder;
-      ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
-        "HAS_INSTANCING",
-        "HAS_INSTANCE_MATRICES",
-      ]);
-      ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
-        "HAS_INSTANCING",
-        "HAS_INSTANCE_MATRICES",
-      ]);
-      ShaderBuilderTester.expectHasAttributes(shaderBuilder, undefined, [
-        "attribute vec4 a_instancingTransformRow0;",
-        "attribute vec4 a_instancingTransformRow1;",
-        "attribute vec4 a_instancingTransformRow2;",
-      ]);
-
-      expect(renderResources.model._resources.length).toEqual(1);
-      expect(renderResources.model._modelResources.length).toEqual(0);
-
-      // Matrices are stored as 3 vec4s, so this is
-      // 4 matrices * 12 floats/matrix * 4 bytes/float = 192
-      const matrixSize = 192;
-      const featureIdSize = 0;
-      expect(renderResources.model.statistics.geometryByteLength).toBe(
-        matrixSize + featureIdSize
-      );
-    });
-  });
-
-  it("creates instancing matrices vertex attributes for 2D", function () {
-    const renderResources = mockRenderResourcesFor2D();
-    return loadGltf(boxInstanced, {
-      loadAttributesFor2D: true,
-    }).then(function (gltfLoader) {
-      const components = gltfLoader.components;
-      renderResources.model.sceneGraph.components = components;
-      const node = components.nodes[0];
-      const runtimeNode = renderResources.runtimeNode;
-      runtimeNode.node = node;
-
-      scene2D.renderForSpecs();
-      InstancingPipelineStage.process(
-        renderResources,
-        node,
-        scene2D.frameState
-      );
-
-      expect(renderResources.attributes.length).toBe(7);
-
-      const shaderBuilder = renderResources.shaderBuilder;
-      ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
-        "HAS_INSTANCING",
-        "HAS_INSTANCE_MATRICES",
-        "USE_2D_INSTANCING",
-      ]);
-      ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
-        "HAS_INSTANCING",
-        "HAS_INSTANCE_MATRICES",
-      ]);
-
-      ShaderBuilderTester.expectHasAttributes(shaderBuilder, undefined, [
-        "attribute vec4 a_instancingTransformRow0;",
-        "attribute vec4 a_instancingTransformRow1;",
-        "attribute vec4 a_instancingTransformRow2;",
-        "attribute vec4 a_instancingTransform2DRow0;",
-        "attribute vec4 a_instancingTransform2DRow1;",
-        "attribute vec4 a_instancingTransform2DRow2;",
-        "attribute float a_instanceFeatureId_0;",
-      ]);
-
-      ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, [
-        "uniform mat4 u_modelView2D;",
-      ]);
-
-      expect(renderResources.instancingReferencePoint2D).toBeDefined();
-      const translationMatrix = Matrix4.fromTranslation(
-        renderResources.instancingReferencePoint2D,
-        scratchMatrix4
-      );
-      const expectedMatrix = Matrix4.multiplyTransformation(
-        scene2D.context.uniformState.view,
-        translationMatrix,
-        scratchMatrix4
-      );
-      const uniformMap = renderResources.uniformMap;
-      expect(uniformMap.u_modelView2D()).toEqual(expectedMatrix);
-
-      expect(runtimeNode.instancingTransformsBuffer2D).toBeDefined();
-      expect(renderResources.model._resources.length).toEqual(2);
-      expect(renderResources.model._modelResources.length).toEqual(1);
-
-      // The 2D buffer will be counted by NodeStatisticsPipelineStage,
-      // so the memory counted here should stay the same.
-      const matrixSize = 192;
-      const featureIdSize = 16;
-      expect(renderResources.model.statistics.geometryByteLength).toBe(
-        matrixSize + featureIdSize
-      );
-    });
-  });
-
-  it("correctly creates transform matrices", function () {
-    const renderResources = mockRenderResources();
-
-    return loadGltf(boxInstanced).then(function (gltfLoader) {
-      const components = gltfLoader.components;
-      const node = components.nodes[0];
-
-      const expectedTransformsTypedArray = new Float32Array([
-        0.5999999642372131,
-        0,
-        0,
-        -2,
-        0,
-        0.4949747323989868,
-        -0.7071067094802856,
-        2,
-        0,
-        0.49497467279434204,
-        0.7071067690849304,
-        0,
-        0.7071068286895752,
-        4.174155421310388e-8,
-        0.3535534143447876,
-        -2,
-        0.5,
-        0.7071068286895752,
-        -0.2500000298023224,
-        -2,
-        -0.5000000596046448,
-        0.7071068286895752,
-        0.25,
-        0,
-        0.375,
-        -0.10000001639127731,
-        0.3535534143447876,
-        2,
-        0.6401650905609131,
-        0.029289301484823227,
-        -0.2500000298023224,
-        -2,
-        0.10983504354953766,
-        0.1707106977701187,
-        0.25,
-        0,
-        0.4898979365825653,
-        -0.3674234449863434,
-        0.44999992847442627,
-        2,
-        0.5277916193008423,
-        0.028420301154255867,
-        -0.6749999523162842,
-        2,
-        0.3484765887260437,
-        0.4734894633293152,
-        0.3897113800048828,
-        0,
-      ]);
-      const transforms = InstancingPipelineStage._getInstanceTransformsAsMatrices(
-        node.instances,
-        node.instances.attributes[0].count,
-        renderResources
-      );
-      const transformsTypedArray = InstancingPipelineStage._transformsToTypedArray(
-        transforms
-      );
-
-      expect(transformsTypedArray.length).toEqual(
-        expectedTransformsTypedArray.length
-      );
-      for (let i = 0; i < expectedTransformsTypedArray.length; i++) {
-        expect(transformsTypedArray[i]).toEqualEpsilon(
-          expectedTransformsTypedArray[i],
-          CesiumMath.EPSILON10
+      return result.then(function (arrayBuffer) {
+        const i3dmLoader = new I3dmLoader(
+          getI3dmOptions(i3dmPath, { arrayBuffer: arrayBuffer })
         );
-      }
+        gltfLoaders.push(i3dmLoader);
+        i3dmLoader.load();
+        return waitForLoaderProcess(i3dmLoader, scene);
+      });
+    }
+
+    it("correctly computes instancing TRANSLATION min and max from typed arrays", function () {
+      const renderResources = mockRenderResources();
+
+      return loadGltf(boxInstanced).then(function (gltfLoader) {
+        const components = gltfLoader.components;
+        const node = components.nodes[0];
+
+        scene.renderForSpecs();
+        InstancingPipelineStage.process(
+          renderResources,
+          node,
+          scene.frameState
+        );
+
+        expect(renderResources.instancingTranslationMax).toEqual(
+          new Cartesian3(2, 2, 0)
+        );
+        expect(renderResources.instancingTranslationMin).toEqual(
+          new Cartesian3(-2, -2, 0)
+        );
+        expect(renderResources.attributes.length).toBe(4);
+      });
     });
-  });
 
-  it("creates TRANSLATION vertex attributes", function () {
-    const renderResources = mockRenderResources();
+    it("sets instancing TRANSLATION min and max from attributes", function () {
+      const renderResources = mockRenderResources();
 
-    return loadGltf(boxInstancedTranslationMinMax).then(function (gltfLoader) {
-      const components = gltfLoader.components;
-      const node = components.nodes[0];
+      return loadGltf(boxInstancedTranslationMinMax).then(function (
+        gltfLoader
+      ) {
+        const components = gltfLoader.components;
+        const node = components.nodes[0];
 
-      scene.renderForSpecs();
-      InstancingPipelineStage.process(renderResources, node, scene.frameState);
+        InstancingPipelineStage.process(
+          renderResources,
+          node,
+          scene.frameState
+        );
 
-      expect(renderResources.attributes.length).toBe(1);
-
-      const shaderBuilder = renderResources.shaderBuilder;
-      ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
-        "HAS_INSTANCING",
-        "HAS_INSTANCE_TRANSLATION",
-      ]);
-      ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
-        "HAS_INSTANCING",
-        "HAS_INSTANCE_TRANSLATION",
-      ]);
-
-      ShaderBuilderTester.expectHasAttributes(shaderBuilder, undefined, [
-        "attribute vec3 a_instanceTranslation;",
-      ]);
-
-      // No additional buffer was created
-      expect(renderResources.model._resources.length).toEqual(0);
-      expect(renderResources.model._modelResources.length).toEqual(0);
-
-      // Attributes with buffers already loaded in will be counted
-      // in NodeStatisticsPipelineStage
-      expect(renderResources.model.statistics.geometryByteLength).toBe(0);
+        expect(renderResources.instancingTranslationMax).toEqual(
+          new Cartesian3(2, 2, 0)
+        );
+        expect(renderResources.instancingTranslationMin).toEqual(
+          new Cartesian3(-2, -2, 0)
+        );
+        expect(renderResources.attributes.length).toBe(1);
+      });
     });
-  });
 
-  it("creates TRANSLATION vertex attributes for 2D", function () {
-    const renderResources = mockRenderResourcesFor2D();
+    it("creates instancing matrices vertex attributes when ROTATION is present", function () {
+      const renderResources = mockRenderResources();
 
-    return loadGltf(boxInstancedTranslationMinMax, {
-      loadAttributesFor2D: true,
-    }).then(function (gltfLoader) {
-      const components = gltfLoader.components;
-      renderResources.model.sceneGraph.components = components;
-      const node = components.nodes[0];
-      const runtimeNode = renderResources.runtimeNode;
-      runtimeNode.node = node;
+      return loadGltf(boxInstanced).then(function (gltfLoader) {
+        const components = gltfLoader.components;
+        const node = components.nodes[0];
 
-      scene2D.renderForSpecs();
-      InstancingPipelineStage.process(
-        renderResources,
-        node,
-        scene2D.frameState
-      );
+        scene.renderForSpecs();
+        InstancingPipelineStage.process(
+          renderResources,
+          node,
+          scene.frameState
+        );
 
-      expect(renderResources.attributes.length).toBe(2);
+        expect(renderResources.attributes.length).toBe(4);
 
-      const shaderBuilder = renderResources.shaderBuilder;
-      ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
-        "HAS_INSTANCING",
-        "HAS_INSTANCE_TRANSLATION",
-        "USE_2D_INSTANCING",
-      ]);
-      ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
-        "HAS_INSTANCING",
-        "HAS_INSTANCE_TRANSLATION",
-      ]);
+        const shaderBuilder = renderResources.shaderBuilder;
+        ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
+          "HAS_INSTANCING",
+          "HAS_INSTANCE_MATRICES",
+        ]);
+        ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
+          "HAS_INSTANCING",
+          "HAS_INSTANCE_MATRICES",
+        ]);
+        ShaderBuilderTester.expectHasAttributes(shaderBuilder, undefined, [
+          "attribute vec4 a_instancingTransformRow0;",
+          "attribute vec4 a_instancingTransformRow1;",
+          "attribute vec4 a_instancingTransformRow2;",
+          "attribute float a_instanceFeatureId_0;",
+        ]);
 
-      ShaderBuilderTester.expectHasAttributes(shaderBuilder, undefined, [
-        "attribute vec3 a_instanceTranslation;",
-        "attribute vec3 a_instanceTranslation2D;",
-      ]);
+        // The model has feature IDs, so a resource will also be created
+        // for those.
+        expect(renderResources.model._resources.length).toEqual(2);
+        expect(renderResources.model._modelResources.length).toEqual(0);
 
-      ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, [
-        "uniform mat4 u_modelView2D;",
-      ]);
-
-      expect(renderResources.instancingReferencePoint2D).toBeDefined();
-      const translationMatrix = Matrix4.fromTranslation(
-        renderResources.instancingReferencePoint2D,
-        scratchMatrix4
-      );
-      const expectedMatrix = Matrix4.multiplyTransformation(
-        scene2D.context.uniformState.view,
-        translationMatrix,
-        scratchMatrix4
-      );
-      const uniformMap = renderResources.uniformMap;
-      expect(uniformMap.u_modelView2D()).toEqual(expectedMatrix);
-
-      expect(runtimeNode.instancingTranslationBuffer2D).toBeDefined();
-      expect(renderResources.model._resources.length).toEqual(0);
-      expect(renderResources.model._modelResources.length).toEqual(1);
-
-      // Both resources will be counted in NodeStatisticsPipelineStage
-      expect(renderResources.model.statistics.geometryByteLength).toBe(0);
+        // Matrices are stored as 3 vec4s, so this is
+        // 4 matrices * 12 floats/matrix * 4 bytes/float = 192
+        const matrixSize = 192;
+        // 4 floats
+        const featureIdSize = 16;
+        expect(renderResources.model.statistics.geometryByteLength).toBe(
+          matrixSize + featureIdSize
+        );
+      });
     });
-  });
 
-  it("adds uniforms for legacy instancing path", function () {
-    const renderResources = {
-      attributeIndex: 1,
-      attributes: [],
-      instancingTranslationMax: undefined,
-      instancingTranslationMin: undefined,
-      shaderBuilder: new ShaderBuilder(),
-      model: {
-        _resources: [],
-        _modelResources: [],
-        statistics: new ModelExperimentalStatistics(),
-        modelMatrix: Matrix4.fromUniformScale(2.0),
-        sceneGraph: {
-          axisCorrectionMatrix: ModelExperimentalUtility.getAxisCorrectionMatrix(
-            Axis.Y,
-            Axis.Z,
-            new Matrix4()
+    it("creates instance matrices vertex attributes when TRANSLATION min and max are not present", function () {
+      const renderResources = mockRenderResources();
+
+      return loadGltf(boxInstancedTranslation).then(function (gltfLoader) {
+        const components = gltfLoader.components;
+        const node = components.nodes[0];
+
+        scene.renderForSpecs();
+        InstancingPipelineStage.process(
+          renderResources,
+          node,
+          scene.frameState
+        );
+
+        expect(renderResources.attributes.length).toBe(3);
+
+        const shaderBuilder = renderResources.shaderBuilder;
+        ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
+          "HAS_INSTANCING",
+          "HAS_INSTANCE_MATRICES",
+        ]);
+        ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
+          "HAS_INSTANCING",
+          "HAS_INSTANCE_MATRICES",
+        ]);
+        ShaderBuilderTester.expectHasAttributes(shaderBuilder, undefined, [
+          "attribute vec4 a_instancingTransformRow0;",
+          "attribute vec4 a_instancingTransformRow1;",
+          "attribute vec4 a_instancingTransformRow2;",
+        ]);
+
+        expect(renderResources.model._resources.length).toEqual(1);
+        expect(renderResources.model._modelResources.length).toEqual(0);
+
+        // Matrices are stored as 3 vec4s, so this is
+        // 4 matrices * 12 floats/matrix * 4 bytes/float = 192
+        const matrixSize = 192;
+        const featureIdSize = 0;
+        expect(renderResources.model.statistics.geometryByteLength).toBe(
+          matrixSize + featureIdSize
+        );
+      });
+    });
+
+    it("creates instancing matrices vertex attributes for 2D", function () {
+      const renderResources = mockRenderResourcesFor2D();
+      return loadGltf(boxInstanced, {
+        loadAttributesFor2D: true,
+      }).then(function (gltfLoader) {
+        const components = gltfLoader.components;
+        renderResources.model.sceneGraph.components = components;
+        const node = components.nodes[0];
+        const runtimeNode = renderResources.runtimeNode;
+        runtimeNode.node = node;
+
+        scene2D.renderForSpecs();
+        InstancingPipelineStage.process(
+          renderResources,
+          node,
+          scene2D.frameState
+        );
+
+        expect(renderResources.attributes.length).toBe(7);
+
+        const shaderBuilder = renderResources.shaderBuilder;
+        ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
+          "HAS_INSTANCING",
+          "HAS_INSTANCE_MATRICES",
+          "USE_2D_INSTANCING",
+        ]);
+        ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
+          "HAS_INSTANCING",
+          "HAS_INSTANCE_MATRICES",
+        ]);
+
+        ShaderBuilderTester.expectHasAttributes(shaderBuilder, undefined, [
+          "attribute vec4 a_instancingTransformRow0;",
+          "attribute vec4 a_instancingTransformRow1;",
+          "attribute vec4 a_instancingTransformRow2;",
+          "attribute vec4 a_instancingTransform2DRow0;",
+          "attribute vec4 a_instancingTransform2DRow1;",
+          "attribute vec4 a_instancingTransform2DRow2;",
+          "attribute float a_instanceFeatureId_0;",
+        ]);
+
+        ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, [
+          "uniform mat4 u_modelView2D;",
+        ]);
+
+        expect(renderResources.instancingReferencePoint2D).toBeDefined();
+        const translationMatrix = Matrix4.fromTranslation(
+          renderResources.instancingReferencePoint2D,
+          scratchMatrix4
+        );
+        const expectedMatrix = Matrix4.multiplyTransformation(
+          scene2D.context.uniformState.view,
+          translationMatrix,
+          scratchMatrix4
+        );
+        const uniformMap = renderResources.uniformMap;
+        expect(uniformMap.u_modelView2D()).toEqual(expectedMatrix);
+
+        expect(runtimeNode.instancingTransformsBuffer2D).toBeDefined();
+        expect(renderResources.model._resources.length).toEqual(2);
+        expect(renderResources.model._modelResources.length).toEqual(1);
+
+        // The 2D buffer will be counted by NodeStatisticsPipelineStage,
+        // so the memory counted here should stay the same.
+        const matrixSize = 192;
+        const featureIdSize = 16;
+        expect(renderResources.model.statistics.geometryByteLength).toBe(
+          matrixSize + featureIdSize
+        );
+      });
+    });
+
+    it("correctly creates transform matrices", function () {
+      const renderResources = mockRenderResources();
+
+      return loadGltf(boxInstanced).then(function (gltfLoader) {
+        const components = gltfLoader.components;
+        const node = components.nodes[0];
+
+        const expectedTransformsTypedArray = new Float32Array([
+          0.5999999642372131,
+          0,
+          0,
+          -2,
+          0,
+          0.4949747323989868,
+          -0.7071067094802856,
+          2,
+          0,
+          0.49497467279434204,
+          0.7071067690849304,
+          0,
+          0.7071068286895752,
+          4.174155421310388e-8,
+          0.3535534143447876,
+          -2,
+          0.5,
+          0.7071068286895752,
+          -0.2500000298023224,
+          -2,
+          -0.5000000596046448,
+          0.7071068286895752,
+          0.25,
+          0,
+          0.375,
+          -0.10000001639127731,
+          0.3535534143447876,
+          2,
+          0.6401650905609131,
+          0.029289301484823227,
+          -0.2500000298023224,
+          -2,
+          0.10983504354953766,
+          0.1707106977701187,
+          0.25,
+          0,
+          0.4898979365825653,
+          -0.3674234449863434,
+          0.44999992847442627,
+          2,
+          0.5277916193008423,
+          0.028420301154255867,
+          -0.6749999523162842,
+          2,
+          0.3484765887260437,
+          0.4734894633293152,
+          0.3897113800048828,
+          0,
+        ]);
+        const transforms = InstancingPipelineStage._getInstanceTransformsAsMatrices(
+          node.instances,
+          node.instances.attributes[0].count,
+          renderResources
+        );
+        const transformsTypedArray = InstancingPipelineStage._transformsToTypedArray(
+          transforms
+        );
+
+        expect(transformsTypedArray.length).toEqual(
+          expectedTransformsTypedArray.length
+        );
+        for (let i = 0; i < expectedTransformsTypedArray.length; i++) {
+          expect(transformsTypedArray[i]).toEqualEpsilon(
+            expectedTransformsTypedArray[i],
+            CesiumMath.EPSILON10
+          );
+        }
+      });
+    });
+
+    it("creates TRANSLATION vertex attributes", function () {
+      const renderResources = mockRenderResources();
+
+      return loadGltf(boxInstancedTranslationMinMax).then(function (
+        gltfLoader
+      ) {
+        const components = gltfLoader.components;
+        const node = components.nodes[0];
+
+        scene.renderForSpecs();
+        InstancingPipelineStage.process(
+          renderResources,
+          node,
+          scene.frameState
+        );
+
+        expect(renderResources.attributes.length).toBe(1);
+
+        const shaderBuilder = renderResources.shaderBuilder;
+        ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
+          "HAS_INSTANCING",
+          "HAS_INSTANCE_TRANSLATION",
+        ]);
+        ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
+          "HAS_INSTANCING",
+          "HAS_INSTANCE_TRANSLATION",
+        ]);
+
+        ShaderBuilderTester.expectHasAttributes(shaderBuilder, undefined, [
+          "attribute vec3 a_instanceTranslation;",
+        ]);
+
+        // No additional buffer was created
+        expect(renderResources.model._resources.length).toEqual(0);
+        expect(renderResources.model._modelResources.length).toEqual(0);
+
+        // Attributes with buffers already loaded in will be counted
+        // in NodeStatisticsPipelineStage
+        expect(renderResources.model.statistics.geometryByteLength).toBe(0);
+      });
+    });
+
+    it("creates TRANSLATION vertex attributes for 2D", function () {
+      const renderResources = mockRenderResourcesFor2D();
+
+      return loadGltf(boxInstancedTranslationMinMax, {
+        loadAttributesFor2D: true,
+      }).then(function (gltfLoader) {
+        const components = gltfLoader.components;
+        renderResources.model.sceneGraph.components = components;
+        const node = components.nodes[0];
+        const runtimeNode = renderResources.runtimeNode;
+        runtimeNode.node = node;
+
+        scene2D.renderForSpecs();
+        InstancingPipelineStage.process(
+          renderResources,
+          node,
+          scene2D.frameState
+        );
+
+        expect(renderResources.attributes.length).toBe(2);
+
+        const shaderBuilder = renderResources.shaderBuilder;
+        ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
+          "HAS_INSTANCING",
+          "HAS_INSTANCE_TRANSLATION",
+          "USE_2D_INSTANCING",
+        ]);
+        ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
+          "HAS_INSTANCING",
+          "HAS_INSTANCE_TRANSLATION",
+        ]);
+
+        ShaderBuilderTester.expectHasAttributes(shaderBuilder, undefined, [
+          "attribute vec3 a_instanceTranslation;",
+          "attribute vec3 a_instanceTranslation2D;",
+        ]);
+
+        ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, [
+          "uniform mat4 u_modelView2D;",
+        ]);
+
+        expect(renderResources.instancingReferencePoint2D).toBeDefined();
+        const translationMatrix = Matrix4.fromTranslation(
+          renderResources.instancingReferencePoint2D,
+          scratchMatrix4
+        );
+        const expectedMatrix = Matrix4.multiplyTransformation(
+          scene2D.context.uniformState.view,
+          translationMatrix,
+          scratchMatrix4
+        );
+        const uniformMap = renderResources.uniformMap;
+        expect(uniformMap.u_modelView2D()).toEqual(expectedMatrix);
+
+        expect(runtimeNode.instancingTranslationBuffer2D).toBeDefined();
+        expect(renderResources.model._resources.length).toEqual(0);
+        expect(renderResources.model._modelResources.length).toEqual(1);
+
+        // Both resources will be counted in NodeStatisticsPipelineStage
+        expect(renderResources.model.statistics.geometryByteLength).toBe(0);
+      });
+    });
+
+    it("adds uniforms for legacy instancing path", function () {
+      const renderResources = {
+        attributeIndex: 1,
+        attributes: [],
+        instancingTranslationMax: undefined,
+        instancingTranslationMin: undefined,
+        shaderBuilder: new ShaderBuilder(),
+        model: {
+          _resources: [],
+          _modelResources: [],
+          statistics: new ModelExperimentalStatistics(),
+          modelMatrix: Matrix4.fromUniformScale(2.0),
+          sceneGraph: {
+            axisCorrectionMatrix: ModelExperimentalUtility.getAxisCorrectionMatrix(
+              Axis.Y,
+              Axis.Z,
+              new Matrix4()
+            ),
+          },
+        },
+        uniformMap: {},
+        runtimeNode: {
+          computedTransform: Matrix4.fromTranslation(
+            new Cartesian3(0.0, 2.0, 0.0)
           ),
         },
-      },
-      uniformMap: {},
-      runtimeNode: {
-        computedTransform: Matrix4.fromTranslation(
-          new Cartesian3(0.0, 2.0, 0.0)
-        ),
-      },
-    };
+      };
 
-    return loadI3dm(i3dmInstancedOrientation, {
-      i3dmResource: Resource.createIfNeeded(i3dmInstancedOrientation),
-    }).then(function (i3dmLoader) {
-      const components = i3dmLoader.components;
-      const node = components.nodes[0];
-      const shaderBuilder = renderResources.shaderBuilder;
-      const runtimeNode = renderResources.runtimeNode;
+      return loadI3dm(i3dmInstancedOrientation, {
+        i3dmResource: Resource.createIfNeeded(i3dmInstancedOrientation),
+      }).then(function (i3dmLoader) {
+        const components = i3dmLoader.components;
+        const node = components.nodes[0];
+        const shaderBuilder = renderResources.shaderBuilder;
+        const runtimeNode = renderResources.runtimeNode;
 
-      // Add the loaded components to the mocked render resources, as the
-      // uniform callbacks need to access this.
-      renderResources.model.sceneGraph.components = components;
+        // Add the loaded components to the mocked render resources, as the
+        // uniform callbacks need to access this.
+        renderResources.model.sceneGraph.components = components;
 
-      scene.renderForSpecs();
-      InstancingPipelineStage.process(renderResources, node, scene.frameState);
+        scene.renderForSpecs();
+        InstancingPipelineStage.process(
+          renderResources,
+          node,
+          scene.frameState
+        );
 
-      ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
-        "HAS_INSTANCING",
-        "HAS_INSTANCE_MATRICES",
-        "USE_LEGACY_INSTANCING",
-      ]);
+        ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
+          "HAS_INSTANCING",
+          "HAS_INSTANCE_MATRICES",
+          "USE_LEGACY_INSTANCING",
+        ]);
 
-      ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, [
-        "uniform mat4 u_instance_modifiedModelView;",
-        "uniform mat4 u_instance_nodeTransform;",
-      ]);
+        ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, [
+          "uniform mat4 u_instance_modifiedModelView;",
+          "uniform mat4 u_instance_nodeTransform;",
+        ]);
 
-      ShaderBuilderTester.expectVertexLinesEqual(shaderBuilder, [
-        _shadersInstancingStageCommon,
-        _shadersLegacyInstancingStageVS,
-      ]);
+        ShaderBuilderTester.expectVertexLinesEqual(shaderBuilder, [
+          _shadersInstancingStageCommon,
+          _shadersLegacyInstancingStageVS,
+        ]);
 
-      const model = renderResources.model;
-      const sceneGraph = model.sceneGraph;
+        const model = renderResources.model;
+        const sceneGraph = model.sceneGraph;
 
-      // For i3dm, the model view matrix chain has to be broken up so the shader
-      // can insert the instancing transform attribute.
-      //
-      // modifiedModelView = view * modelMatrix * rtcTransform
-      const view = scene.frameState.context.uniformState.view3D;
-      const modelMatrix = model.modelMatrix;
-      const rtcTransform = components.transform;
-      let expectedModelView = Matrix4.multiplyTransformation(
-        view,
-        modelMatrix,
-        new Matrix4()
-      );
-      expectedModelView = Matrix4.multiplyTransformation(
-        expectedModelView,
-        rtcTransform,
-        expectedModelView
-      );
+        // For i3dm, the model view matrix chain has to be broken up so the shader
+        // can insert the instancing transform attribute.
+        //
+        // modifiedModelView = view * modelMatrix * rtcTransform
+        const view = scene.frameState.context.uniformState.view3D;
+        const modelMatrix = model.modelMatrix;
+        const rtcTransform = components.transform;
+        let expectedModelView = Matrix4.multiplyTransformation(
+          view,
+          modelMatrix,
+          new Matrix4()
+        );
+        expectedModelView = Matrix4.multiplyTransformation(
+          expectedModelView,
+          rtcTransform,
+          expectedModelView
+        );
 
-      const uniformMap = renderResources.uniformMap;
-      expect(uniformMap.u_instance_modifiedModelView()).toEqualEpsilon(
-        expectedModelView,
-        CesiumMath.EPSILON8
-      );
+        const uniformMap = renderResources.uniformMap;
+        expect(uniformMap.u_instance_modifiedModelView()).toEqualEpsilon(
+          expectedModelView,
+          CesiumMath.EPSILON8
+        );
 
-      // The second part of the matrix.
-      //
-      // nodeTransform = axisCorrection * computedTransform
-      const axisCorrection = sceneGraph.axisCorrectionMatrix;
-      const computedTransform = runtimeNode.computedTransform;
-      const expectedNodeTransform = Matrix4.multiplyTransformation(
-        axisCorrection,
-        computedTransform,
-        new Matrix4()
-      );
-      expect(uniformMap.u_instance_nodeTransform()).toEqualEpsilon(
-        expectedNodeTransform,
-        CesiumMath.EPSILON8
-      );
+        // The second part of the matrix.
+        //
+        // nodeTransform = axisCorrection * computedTransform
+        const axisCorrection = sceneGraph.axisCorrectionMatrix;
+        const computedTransform = runtimeNode.computedTransform;
+        const expectedNodeTransform = Matrix4.multiplyTransformation(
+          axisCorrection,
+          computedTransform,
+          new Matrix4()
+        );
+        expect(uniformMap.u_instance_nodeTransform()).toEqualEpsilon(
+          expectedNodeTransform,
+          CesiumMath.EPSILON8
+        );
 
-      // Matrices are stored as 3 vec4s, so this is
-      // 25 matrices * 12 floats/matrix * 4 bytes/float = 1200
-      const matrixSize = 1200;
-      // 25 floats
-      const featureIdSize = 100;
-      expect(renderResources.model.statistics.geometryByteLength).toBe(
-        matrixSize + featureIdSize
-      );
+        // Matrices are stored as 3 vec4s, so this is
+        // 25 matrices * 12 floats/matrix * 4 bytes/float = 1200
+        const matrixSize = 1200;
+        // 25 floats
+        const featureIdSize = 100;
+        expect(renderResources.model.statistics.geometryByteLength).toBe(
+          matrixSize + featureIdSize
+        );
+      });
     });
-  });
-});
+  },
+  "WebGL"
+);

--- a/Specs/Scene/ModelExperimental/InstancingPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/InstancingPipelineStageSpec.js
@@ -139,7 +139,7 @@ describe("Scene/ModelExperimental/InstancingPipelineStage", function () {
       const components = gltfLoader.components;
       const node = components.nodes[0];
 
-      InstancingPipelineStage.process(renderResources, node);
+      InstancingPipelineStage.process(renderResources, node, scene.frameState);
 
       expect(renderResources.instancingTranslationMax).toEqual(
         new Cartesian3(2, 2, 0)
@@ -318,10 +318,13 @@ describe("Scene/ModelExperimental/InstancingPipelineStage", function () {
         0.3897113800048828,
         0,
       ]);
-      const transformsTypedArray = InstancingPipelineStage._getInstanceTransformsTypedArray(
+      const transforms = InstancingPipelineStage._getInstanceTransformMatrices(
         node.instances,
         node.instances.attributes[0].count,
         renderResources
+      );
+      const transformsTypedArray = InstancingPipelineStage._transformsToTypedArray(
+        transforms
       );
 
       expect(transformsTypedArray.length).toEqual(

--- a/Specs/Scene/ModelExperimental/ModelExperimentalNodeSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalNodeSpec.js
@@ -7,9 +7,9 @@ import {
   Matrix4,
   ModelExperimentalNode,
   ModelMatrixUpdateStage,
+  NodeStatisticsPipelineStage,
   Quaternion,
 } from "../../../Source/Cesium.js";
-import NodeStatisticsPipelineStage from "../../../Source/Scene/ModelExperimental/NodeStatisticsPipelineStage.js";
 
 describe("Scene/ModelExperimental/ModelExperimentalNode", function () {
   const mockNode = {

--- a/Specs/Scene/ModelExperimental/ModelExperimentalNodeSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalNodeSpec.js
@@ -9,6 +9,7 @@ import {
   ModelMatrixUpdateStage,
   Quaternion,
 } from "../../../Source/Cesium.js";
+import NodeStatisticsPipelineStage from "../../../Source/Scene/ModelExperimental/NodeStatisticsPipelineStage.js";
 
 describe("Scene/ModelExperimental/ModelExperimentalNode", function () {
   const mockNode = {
@@ -131,7 +132,7 @@ describe("Scene/ModelExperimental/ModelExperimentalNode", function () {
     verifyTransforms(transform, transformToRoot, node);
 
     node.configurePipeline();
-    expect(node.pipelineStages).toEqual([]);
+    expect(node.pipelineStages).toEqual([NodeStatisticsPipelineStage]);
     expect(node.updateStages).toEqual([ModelMatrixUpdateStage]);
     expect(node.runtimePrimitives).toEqual([]);
 
@@ -377,8 +378,10 @@ describe("Scene/ModelExperimental/ModelExperimentalNode", function () {
     verifyTransforms(transform, transformToRoot, node);
 
     node.configurePipeline();
-    expect(node.pipelineStages.length).toBe(1);
-    expect(node.pipelineStages[0]).toEqual(InstancingPipelineStage);
+    expect(node.pipelineStages).toEqual([
+      InstancingPipelineStage,
+      NodeStatisticsPipelineStage,
+    ]);
     expect(node.updateStages).toEqual([ModelMatrixUpdateStage]);
     expect(node.runtimePrimitives).toEqual([]);
   });

--- a/Specs/Scene/ModelExperimental/ModelExperimentalPrimitiveSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalPrimitiveSpec.js
@@ -17,11 +17,11 @@ import {
   PickingPipelineStage,
   PointCloudAttenuationPipelineStage,
   PointCloudShading,
+  PrimitiveStatisticsPipelineStage,
   PrimitiveType,
   SceneMode,
   SceneMode2DPipelineStage,
   SelectedFeatureIdPipelineStage,
-  StatisticsPipelineStage,
   SkinningPipelineStage,
   VertexAttributeSemantic,
   WireframePipelineStage,
@@ -135,7 +135,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       LightingPipelineStage,
       PickingPipelineStage,
       AlphaPipelineStage,
-      StatisticsPipelineStage,
+      PrimitiveStatisticsPipelineStage,
     ];
 
     verifyExpectedStages(primitive.pipelineStages, expectedStages);
@@ -157,7 +157,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       MetadataPipelineStage,
       LightingPipelineStage,
       AlphaPipelineStage,
-      StatisticsPipelineStage,
+      PrimitiveStatisticsPipelineStage,
     ];
 
     primitive.configurePipeline(mockFrameState);
@@ -200,7 +200,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       LightingPipelineStage,
       PickingPipelineStage,
       AlphaPipelineStage,
-      StatisticsPipelineStage,
+      PrimitiveStatisticsPipelineStage,
     ];
 
     primitive.configurePipeline(mockFrameState);
@@ -246,7 +246,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       LightingPipelineStage,
       PickingPipelineStage,
       AlphaPipelineStage,
-      StatisticsPipelineStage,
+      PrimitiveStatisticsPipelineStage,
     ];
 
     primitive.configurePipeline(mockFrameState);
@@ -302,7 +302,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       LightingPipelineStage,
       PickingPipelineStage,
       AlphaPipelineStage,
-      StatisticsPipelineStage,
+      PrimitiveStatisticsPipelineStage,
     ]);
   });
 
@@ -329,7 +329,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       CustomShaderPipelineStage,
       LightingPipelineStage,
       AlphaPipelineStage,
-      StatisticsPipelineStage,
+      PrimitiveStatisticsPipelineStage,
     ];
 
     primitive.configurePipeline(mockFrameState);
@@ -359,7 +359,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       CustomShaderPipelineStage,
       LightingPipelineStage,
       AlphaPipelineStage,
-      StatisticsPipelineStage,
+      PrimitiveStatisticsPipelineStage,
     ];
 
     primitive.configurePipeline(mockFrameState);
@@ -389,7 +389,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       CustomShaderPipelineStage,
       LightingPipelineStage,
       AlphaPipelineStage,
-      StatisticsPipelineStage,
+      PrimitiveStatisticsPipelineStage,
     ];
 
     primitive.configurePipeline(mockFrameState);
@@ -428,7 +428,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       MetadataPipelineStage,
       LightingPipelineStage,
       AlphaPipelineStage,
-      StatisticsPipelineStage,
+      PrimitiveStatisticsPipelineStage,
     ];
 
     primitive.configurePipeline(mockFrameState);
@@ -462,7 +462,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       MetadataPipelineStage,
       LightingPipelineStage,
       AlphaPipelineStage,
-      StatisticsPipelineStage,
+      PrimitiveStatisticsPipelineStage,
     ];
 
     primitive.configurePipeline(mockFrameState);
@@ -495,7 +495,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       MetadataPipelineStage,
       LightingPipelineStage,
       AlphaPipelineStage,
-      StatisticsPipelineStage,
+      PrimitiveStatisticsPipelineStage,
     ];
 
     primitive.configurePipeline(mockFrameState);
@@ -525,7 +525,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       MetadataPipelineStage,
       LightingPipelineStage,
       AlphaPipelineStage,
-      StatisticsPipelineStage,
+      PrimitiveStatisticsPipelineStage,
     ];
 
     primitive.configurePipeline(mockFrameState);
@@ -557,7 +557,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       MetadataPipelineStage,
       LightingPipelineStage,
       AlphaPipelineStage,
-      StatisticsPipelineStage,
+      PrimitiveStatisticsPipelineStage,
     ];
 
     primitive.configurePipeline(mockFrameState);
@@ -598,7 +598,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       MetadataPipelineStage,
       LightingPipelineStage,
       AlphaPipelineStage,
-      StatisticsPipelineStage,
+      PrimitiveStatisticsPipelineStage,
     ];
 
     primitive.configurePipeline(mockFrameState);
@@ -630,7 +630,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       MetadataPipelineStage,
       LightingPipelineStage,
       AlphaPipelineStage,
-      StatisticsPipelineStage,
+      PrimitiveStatisticsPipelineStage,
     ];
 
     primitive.configurePipeline(mockFrameState);
@@ -661,7 +661,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       MetadataPipelineStage,
       LightingPipelineStage,
       AlphaPipelineStage,
-      StatisticsPipelineStage,
+      PrimitiveStatisticsPipelineStage,
     ];
 
     primitive.configurePipeline(mockFrameState);
@@ -692,7 +692,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       MetadataPipelineStage,
       LightingPipelineStage,
       AlphaPipelineStage,
-      StatisticsPipelineStage,
+      PrimitiveStatisticsPipelineStage,
     ];
 
     primitive.configurePipeline(mockFrameStateWebgl2);
@@ -722,7 +722,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       MetadataPipelineStage,
       LightingPipelineStage,
       AlphaPipelineStage,
-      StatisticsPipelineStage,
+      PrimitiveStatisticsPipelineStage,
     ];
 
     primitive.configurePipeline(mockFrameStateWebgl2);
@@ -753,7 +753,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       MetadataPipelineStage,
       LightingPipelineStage,
       AlphaPipelineStage,
-      StatisticsPipelineStage,
+      PrimitiveStatisticsPipelineStage,
     ];
 
     primitive.configurePipeline(mockFrameState2D);
@@ -783,7 +783,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       MetadataPipelineStage,
       LightingPipelineStage,
       AlphaPipelineStage,
-      StatisticsPipelineStage,
+      PrimitiveStatisticsPipelineStage,
     ];
 
     primitive.configurePipeline(mockFrameState);
@@ -813,7 +813,7 @@ describe("Scene/ModelExperimental/ModelExperimentalPrimitive", function () {
       MetadataPipelineStage,
       LightingPipelineStage,
       AlphaPipelineStage,
-      StatisticsPipelineStage,
+      PrimitiveStatisticsPipelineStage,
     ];
 
     primitive.configurePipeline(mockFrameState3DOnly);

--- a/Specs/Scene/ModelExperimental/NodeStatisticsPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/NodeStatisticsPipelineStageSpec.js
@@ -23,6 +23,11 @@ describe("Scene/ModelExperimental/NodeStatisticsPipelineStage", function () {
 
   beforeAll(function () {
     scene = createScene();
+    // This is set to true to guarantee that buffers / typed arrays
+    // are loaded in as expected for instanced models. If this is false,
+    // instanced attributes will always load in as typed arrays, which
+    // will cause several tests to fail.
+    scene.context._instancedArrays = true;
   });
 
   afterAll(function () {

--- a/Specs/Scene/ModelExperimental/NodeStatisticsPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/NodeStatisticsPipelineStageSpec.js
@@ -1,0 +1,200 @@
+import {
+  combine,
+  GltfLoader,
+  Matrix4,
+  ModelExperimentalStatistics,
+  NodeStatisticsPipelineStage,
+  Resource,
+  ResourceCache,
+} from "../../../Source/Cesium.js";
+import createScene from "../../createScene.js";
+import waitForLoaderProcess from "../../waitForLoaderProcess.js";
+
+describe("Scene/ModelExperimental/NodeStatisticsPipelineStage", function () {
+  const boxTextured =
+    "./Data/Models/GltfLoader/BoxTextured/glTF-Binary/BoxTextured.glb";
+  const boxInstanced =
+    "./Data/Models/GltfLoader/BoxInstanced/glTF/box-instanced.gltf";
+  const boxInstancedTranslationMinMax =
+    "./Data/Models/GltfLoader/BoxInstancedTranslationWithMinMax/glTF/box-instanced-translation-min-max.gltf";
+
+  let scene;
+  const gltfLoaders = [];
+
+  beforeAll(function () {
+    scene = createScene();
+  });
+
+  afterAll(function () {
+    scene.destroyForSpecs();
+  });
+
+  afterEach(function () {
+    const gltfLoadersLength = gltfLoaders.length;
+    for (let i = 0; i < gltfLoadersLength; ++i) {
+      const gltfLoader = gltfLoaders[i];
+      if (!gltfLoader.isDestroyed()) {
+        gltfLoader.destroy();
+      }
+    }
+    gltfLoaders.length = 0;
+    ResourceCache.clearForSpecs();
+  });
+
+  function getOptions(gltfPath, options) {
+    const resource = new Resource({
+      url: gltfPath,
+    });
+
+    return combine(options, {
+      gltfResource: resource,
+      incrementallyLoadTextures: false, // Default to false if not supplied
+    });
+  }
+
+  function loadGltf(gltfPath, options) {
+    const gltfLoader = new GltfLoader(getOptions(gltfPath, options));
+    gltfLoaders.push(gltfLoader);
+    gltfLoader.load();
+
+    return waitForLoaderProcess(gltfLoader, scene);
+  }
+
+  function mockRenderResources(components) {
+    return {
+      model: {
+        sceneGraph: {
+          components: components,
+          computedModelMatrix: Matrix4.IDENTITY,
+        },
+        statistics: new ModelExperimentalStatistics(),
+      },
+      runtimeNode: {
+        computedTransform: Matrix4.IDENTITY,
+      },
+    };
+  }
+
+  it("does not update statistics for a non-instanced model", function () {
+    return loadGltf(boxTextured).then(function (gltfLoader) {
+      const components = gltfLoader.components;
+      const node = components.nodes[1];
+      const renderResources = mockRenderResources(components);
+
+      NodeStatisticsPipelineStage.process(renderResources, node);
+
+      const statistics = renderResources.model.statistics;
+
+      expect(statistics.pointsLength).toBe(0);
+      expect(statistics.trianglesLength).toBe(0);
+      expect(statistics.geometryByteLength).toBe(0);
+      expect(statistics.texturesByteLength).toBe(0);
+      expect(statistics.propertyTablesByteLength).toBe(0);
+    });
+  });
+
+  it("updates statistics for an instanced model", function () {
+    return loadGltf(boxInstancedTranslationMinMax).then(function (gltfLoader) {
+      const components = gltfLoader.components;
+      const node = components.nodes[0];
+      const renderResources = mockRenderResources(components);
+
+      NodeStatisticsPipelineStage.process(renderResources, node);
+
+      const statistics = renderResources.model.statistics;
+
+      // Model contains four translated instances:
+      // 4 vec3s * 3 floats/vec3 * 4 bytes/float = 48
+      const expectedByteLength = 48;
+
+      expect(statistics.pointsLength).toBe(0);
+      expect(statistics.trianglesLength).toBe(0);
+      expect(statistics.geometryByteLength).toBe(expectedByteLength);
+      expect(statistics.texturesByteLength).toBe(0);
+      expect(statistics.propertyTablesByteLength).toBe(0);
+    });
+  });
+
+  it("_countInstancingAttributes does not count attributes without buffers", function () {
+    // This model contains instanced rotations, so the transformation
+    // attributes will be loaded in as packed typed arrays only.
+    // Feature IDs are also only loaded as packed typed arrays.
+    return loadGltf(boxInstanced).then(function (gltfLoader) {
+      const statistics = new ModelExperimentalStatistics();
+      const components = gltfLoader.components;
+      const node = components.nodes[0];
+
+      NodeStatisticsPipelineStage._countInstancingAttributes(
+        statistics,
+        node.instances
+      );
+
+      expect(statistics.geometryByteLength).toBe(0);
+    });
+  });
+
+  it("_countInstancingAttributes counts attributes with buffers", function () {
+    return loadGltf(boxInstancedTranslationMinMax).then(function (gltfLoader) {
+      const statistics = new ModelExperimentalStatistics();
+      const components = gltfLoader.components;
+      const node = components.nodes[0];
+
+      NodeStatisticsPipelineStage._countInstancingAttributes(
+        statistics,
+        node.instances
+      );
+
+      // Model contains four translated instances:
+      // 4 instances * 3 floats * 4 bytes per float
+      const expectedByteLength = 4 * 12;
+
+      expect(statistics.geometryByteLength).toBe(expectedByteLength);
+    });
+  });
+
+  it("_countInstancing2DBuffers counts instancing transform buffer for 2D", function () {
+    return loadGltf(boxInstanced).then(function (gltfLoader) {
+      const statistics = new ModelExperimentalStatistics();
+      const mockRuntimeNode = {
+        instancingTransformsBuffer2D: {
+          // Matrices are stored as 3 vec4s, so this is
+          // 4 matrices * 12 floats/matrix * 4 bytes/float = 192
+          sizeInBytes: 192,
+        },
+      };
+
+      NodeStatisticsPipelineStage._countInstancing2DBuffers(
+        statistics,
+        mockRuntimeNode
+      );
+
+      const transformsBuffer2D = mockRuntimeNode.instancingTransformsBuffer2D;
+      expect(statistics.geometryByteLength).toBe(
+        transformsBuffer2D.sizeInBytes
+      );
+    });
+  });
+
+  it("_countInstancing2DBuffers counts instancing translation buffer for 2D", function () {
+    return loadGltf(boxInstancedTranslationMinMax).then(function (gltfLoader) {
+      const statistics = new ModelExperimentalStatistics();
+      const mockRuntimeNode = {
+        instancingTranslationBuffer2D: {
+          // Model contains four translated instances:
+          // 4 instances * 3 floats * 4 bytes per float
+          sizeInBytes: 48,
+        },
+      };
+
+      NodeStatisticsPipelineStage._countInstancing2DBuffers(
+        statistics,
+        mockRuntimeNode
+      );
+
+      const translationBuffer2D = mockRuntimeNode.instancingTranslationBuffer2D;
+      expect(statistics.geometryByteLength).toBe(
+        translationBuffer2D.sizeInBytes
+      );
+    });
+  });
+});

--- a/Specs/Scene/ModelExperimental/PrimitiveStatisticsPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/PrimitiveStatisticsPipelineStageSpec.js
@@ -2,14 +2,14 @@ import {
   combine,
   GltfLoader,
   ModelExperimentalStatistics,
-  StatisticsPipelineStage,
+  PrimitiveStatisticsPipelineStage,
   Resource,
   ResourceCache,
 } from "../../../Source/Cesium.js";
 import createScene from "../../createScene.js";
 import waitForLoaderProcess from "../../waitForLoaderProcess.js";
 
-describe("Scene/ModelExperimental/StatisticsPipelineStage", function () {
+describe("Scene/ModelExperimental/PrimitiveStatisticsPipelineStage", function () {
   const animatedMorphCube =
     "./Data/Models/GltfLoader/AnimatedMorphCube/glTF/AnimatedMorphCube.gltf";
   const boomBox = "./Data/Models/PBR/BoomBox/BoomBox.gltf";
@@ -100,7 +100,7 @@ describe("Scene/ModelExperimental/StatisticsPipelineStage", function () {
       const primitive = components.nodes[1].primitives[0];
       const renderResources = mockRenderResources(components);
 
-      StatisticsPipelineStage.process(renderResources, primitive);
+      PrimitiveStatisticsPipelineStage.process(renderResources, primitive);
 
       const statistics = renderResources.model.statistics;
 
@@ -136,7 +136,7 @@ describe("Scene/ModelExperimental/StatisticsPipelineStage", function () {
       const components = gltfLoader.components;
       const primitive = components.nodes[1].primitives[0];
 
-      StatisticsPipelineStage._countGeometry(statistics, primitive);
+      PrimitiveStatisticsPipelineStage._countGeometry(statistics, primitive);
 
       expect(statistics.pointsLength).toBe(0);
       // 6 faces * 2 triangles
@@ -164,7 +164,7 @@ describe("Scene/ModelExperimental/StatisticsPipelineStage", function () {
       const components = gltfLoader.components;
       const primitive = components.nodes[0].primitives[0];
 
-      StatisticsPipelineStage._countGeometry(statistics, primitive);
+      PrimitiveStatisticsPipelineStage._countGeometry(statistics, primitive);
 
       expect(statistics.pointsLength).toBe(0);
       // 1 triangle
@@ -183,7 +183,7 @@ describe("Scene/ModelExperimental/StatisticsPipelineStage", function () {
   it("_countGeometry computes memory usage correctly for attributes with CPU copy", function () {
     // This will create a copy of both the positions and indices on the CPU
     const options = {
-      loadPositionsFor2D: true,
+      loadAttributesFor2D: true,
       loadIndicesForWireframe: true,
     };
 
@@ -192,7 +192,7 @@ describe("Scene/ModelExperimental/StatisticsPipelineStage", function () {
       const components = gltfLoader.components;
       const primitive = components.nodes[1].primitives[0];
 
-      StatisticsPipelineStage._countGeometry(statistics, primitive);
+      PrimitiveStatisticsPipelineStage._countGeometry(statistics, primitive);
 
       expect(statistics.pointsLength).toBe(0);
       // 6 faces * 2 triangles
@@ -223,7 +223,7 @@ describe("Scene/ModelExperimental/StatisticsPipelineStage", function () {
       const components = gltfLoader.components;
       const primitive = components.nodes[0].primitives[0];
 
-      StatisticsPipelineStage._countGeometry(statistics, primitive);
+      PrimitiveStatisticsPipelineStage._countGeometry(statistics, primitive);
 
       expect(statistics.pointsLength).toBe(2500);
       expect(statistics.trianglesLength).toBe(0);
@@ -244,7 +244,7 @@ describe("Scene/ModelExperimental/StatisticsPipelineStage", function () {
       const components = gltfLoader.components;
       const primitive = components.nodes[0].primitives[0];
 
-      StatisticsPipelineStage._countGeometry(statistics, primitive);
+      PrimitiveStatisticsPipelineStage._countGeometry(statistics, primitive);
 
       expect(statistics.pointsLength).toBe(0);
       // 1 face * 2 triangles
@@ -269,7 +269,7 @@ describe("Scene/ModelExperimental/StatisticsPipelineStage", function () {
       const components = gltfLoader.components;
       const primitive = components.nodes[0].primitives[0];
 
-      StatisticsPipelineStage._countGeometry(statistics, primitive);
+      PrimitiveStatisticsPipelineStage._countGeometry(statistics, primitive);
 
       expect(statistics.pointsLength).toBe(0);
       // 1 face * 2 triangles
@@ -295,14 +295,17 @@ describe("Scene/ModelExperimental/StatisticsPipelineStage", function () {
       positionBuffer2D: undefined,
     };
 
-    StatisticsPipelineStage._count2DPositions(statistics, mockRuntimePrimitive);
+    PrimitiveStatisticsPipelineStage._count2DPositions(
+      statistics,
+      mockRuntimePrimitive
+    );
 
     expect(statistics.geometryByteLength).toBe(0);
   });
 
   it("_countPositions2D updates count if 2D positions exist", function () {
     return loadGltf(boxTextured, {
-      loadPositionsFor2D: true,
+      loadAttributesFor2D: true,
     }).then(function (gltfLoader) {
       const statistics = new ModelExperimentalStatistics();
       const components = gltfLoader.components;
@@ -320,7 +323,7 @@ describe("Scene/ModelExperimental/StatisticsPipelineStage", function () {
       // will count it.
       positionAttribute.typedArray = undefined;
 
-      StatisticsPipelineStage._count2DPositions(
+      PrimitiveStatisticsPipelineStage._count2DPositions(
         statistics,
         mockRuntimePrimitive
       );
@@ -338,7 +341,7 @@ describe("Scene/ModelExperimental/StatisticsPipelineStage", function () {
       const components = gltfLoader.components;
       const primitive = components.nodes[0].primitives[0];
 
-      StatisticsPipelineStage._countMorphTargetAttributes(
+      PrimitiveStatisticsPipelineStage._countMorphTargetAttributes(
         statistics,
         primitive
       );
@@ -364,7 +367,7 @@ describe("Scene/ModelExperimental/StatisticsPipelineStage", function () {
       const primitive = components.nodes[0].primitives[0];
       const statistics = new ModelExperimentalStatistics();
 
-      StatisticsPipelineStage._countMaterialTextures(
+      PrimitiveStatisticsPipelineStage._countMaterialTextures(
         statistics,
         primitive.material
       );
@@ -382,7 +385,7 @@ describe("Scene/ModelExperimental/StatisticsPipelineStage", function () {
       const metallicRoughness = material.metallicRoughness;
       const statistics = new ModelExperimentalStatistics();
 
-      StatisticsPipelineStage._countMaterialTextures(
+      PrimitiveStatisticsPipelineStage._countMaterialTextures(
         statistics,
         primitive.material
       );
@@ -407,7 +410,7 @@ describe("Scene/ModelExperimental/StatisticsPipelineStage", function () {
       const specularGlossiness = material.specularGlossiness;
       const statistics = new ModelExperimentalStatistics();
 
-      StatisticsPipelineStage._countMaterialTextures(
+      PrimitiveStatisticsPipelineStage._countMaterialTextures(
         statistics,
         primitive.material
       );
@@ -430,7 +433,7 @@ describe("Scene/ModelExperimental/StatisticsPipelineStage", function () {
       const primitive = node.primitives[0];
       const statistics = new ModelExperimentalStatistics();
 
-      StatisticsPipelineStage._countFeatureIdTextures(
+      PrimitiveStatisticsPipelineStage._countFeatureIdTextures(
         statistics,
         primitive.featureIds
       );
@@ -449,7 +452,7 @@ describe("Scene/ModelExperimental/StatisticsPipelineStage", function () {
       const components = gltfLoader.components;
       const model = mockModel(components);
 
-      StatisticsPipelineStage._countBinaryMetadata(statistics, model);
+      PrimitiveStatisticsPipelineStage._countBinaryMetadata(statistics, model);
 
       expect(statistics.geometryByteLength).toBe(0);
     });
@@ -461,7 +464,7 @@ describe("Scene/ModelExperimental/StatisticsPipelineStage", function () {
       const components = gltfLoader.components;
       const model = mockModel(components);
 
-      StatisticsPipelineStage._countBinaryMetadata(statistics, model);
+      PrimitiveStatisticsPipelineStage._countBinaryMetadata(statistics, model);
 
       const structuralMetadata = model.structuralMetadata;
       const propertyTable = structuralMetadata.getPropertyTable(0);
@@ -480,7 +483,7 @@ describe("Scene/ModelExperimental/StatisticsPipelineStage", function () {
       const components = gltfLoader.components;
       const model = mockModel(components);
 
-      StatisticsPipelineStage._countBinaryMetadata(statistics, model);
+      PrimitiveStatisticsPipelineStage._countBinaryMetadata(statistics, model);
 
       expect(statistics.geometryByteLength).toBe(0);
     });
@@ -492,7 +495,7 @@ describe("Scene/ModelExperimental/StatisticsPipelineStage", function () {
       const components = gltfLoader.components;
       const model = mockModel(components);
 
-      StatisticsPipelineStage._countBinaryMetadata(statistics, model);
+      PrimitiveStatisticsPipelineStage._countBinaryMetadata(statistics, model);
 
       // everything shares the same texture, so the memory is only counted
       // once.

--- a/Specs/Scene/ModelExperimental/SceneMode2DPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/SceneMode2DPipelineStageSpec.js
@@ -200,7 +200,7 @@ describe("Scene/ModelExperimental/SceneMode2DPipelineStage", function () {
         scene.frameState
       );
 
-      // Only the 2D bounding sphere should be computed for the primitive.
+      // Only the 2D bounding sphere will be computed for the primitive.
       const runtimePrimitive = renderResources.runtimePrimitive;
       expect(runtimePrimitive.boundingSphere2D).toBeDefined();
       expect(runtimePrimitive.positionBuffer2D).toBeUndefined();
@@ -212,11 +212,11 @@ describe("Scene/ModelExperimental/SceneMode2DPipelineStage", function () {
       );
       expect(positionAttribute.typedArray).toBeUndefined();
 
-      // The 2D instancing flag should be added in InstancingPipelineStage
+      // The 2D instancing flag will be added in InstancingPipelineStage
       const shaderBuilder = renderResources.shaderBuilder;
       ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, []);
 
-      // The u_modelView2D uniform should be added in InstancingPipelineStage
+      // The u_modelView2D uniform will be added in InstancingPipelineStage
       expect(renderResources.uniformMap).toBeUndefined();
     });
   });

--- a/Specs/Scene/ModelExperimental/SceneMode2DPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/SceneMode2DPipelineStageSpec.js
@@ -92,7 +92,7 @@ describe("Scene/ModelExperimental/SceneMode2DPipelineStage", function () {
     const renderResources = mockRenderResources();
 
     return loadGltf(boxTexturedUrl, {
-      loadPositionsFor2D: true,
+      loadAttributesFor2D: true,
     }).then(function (gltfLoader) {
       const components = gltfLoader.components;
       const primitive = components.nodes[1].primitives[0];
@@ -137,7 +137,7 @@ describe("Scene/ModelExperimental/SceneMode2DPipelineStage", function () {
     const renderResources = mockRenderResources();
 
     return loadGltf(dracoBoxWithTangentsUrl, {
-      loadPositionsFor2D: true,
+      loadAttributesFor2D: true,
     }).then(function (gltfLoader) {
       const components = gltfLoader.components;
       const primitive = components.nodes[0].primitives[0];

--- a/Specs/Scene/ModelExperimental/SceneMode2DPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/SceneMode2DPipelineStageSpec.js
@@ -183,7 +183,7 @@ describe("Scene/ModelExperimental/SceneMode2DPipelineStage", function () {
     });
   });
 
-  it("doesn't modify resources for instanced model in 2D", function () {
+  it("processes resources for instanced model in 2D", function () {
     const renderResources = mockRenderResources();
 
     return loadGltf(boxInstancedTranslationUrl, {
@@ -200,8 +200,9 @@ describe("Scene/ModelExperimental/SceneMode2DPipelineStage", function () {
         scene.frameState
       );
 
+      // Only the 2D bounding sphere should be computed for the primitive.
       const runtimePrimitive = renderResources.runtimePrimitive;
-      expect(runtimePrimitive.boundingSphere2D).toBeUndefined();
+      expect(runtimePrimitive.boundingSphere2D).toBeDefined();
       expect(runtimePrimitive.positionBuffer2D).toBeUndefined();
 
       // Check that the position attribute's typed array has been unloaded.
@@ -211,9 +212,11 @@ describe("Scene/ModelExperimental/SceneMode2DPipelineStage", function () {
       );
       expect(positionAttribute.typedArray).toBeUndefined();
 
+      // The 2D instancing flag should be added in InstancingPipelineStage
       const shaderBuilder = renderResources.shaderBuilder;
       ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, []);
 
+      // The u_modelView2D uniform should be added in InstancingPipelineStage
       expect(renderResources.uniformMap).toBeUndefined();
     });
   });


### PR DESCRIPTION
This PR adds support for projecting instanced models and `.i3dm` tilesets to 2D / CV when they are loaded with `ModelExperimental`. Most of this code is done in `InstancingPipelineStage`, though let me know if it seems better to move this to `SceneMode2DPipelineStage` instead.

Here's a side-by-side comparison with `Model`: with `ModelExperimental` the trees load into the correct places 🌳 

| Model | ModelExperimental |
| ------ | ---------------------- |
| ![i3dm](https://user-images.githubusercontent.com/32226860/172247942-5b2f4de6-34a3-4595-a522-3bf7e21e73c3.png) | ![i3dmexperimental](https://user-images.githubusercontent.com/32226860/172247960-07263ec0-a661-4d09-a88e-cdc19f82591c.png) |

Sandcastles:
- [San Diego CDB dataset (trees)](http://localhost:8080/Apps/Sandcastle/index.html#c=jVRrc+I2FP0rGj7BDJEtS35t2UzDI6mZGLoBkizDTEfYIlGwZSrLBOjkv1d+MN1s006+2NbVPedc3XusAct5kcLRYcckT5lQNLlmVBWS5ZAJuk5YmMUs+XEffAVKFuyXlViJKBO5AnvOXpnUccFewaBmvK9i7VUrqtaDTEO5YHLV6oK/VgKAPGKiIv9yhszOETiY3i7C/mL2x30weliJt04lZhi1EGQHxUTcbmB1sF7g4ZwnLA9EvmORymTID1yUaMOoS+XnnbK+6mi67IY2+pCi4q8ymyLAjaRCNUWPZ4BGGpgDlYFjVkjAMwFonjOVr0RTYZAJGLMNLRJ1VSXPsy0TWnjVYsfx8/om4lM+DhanAE14oKXv7GgQOMF293g/GPtQJ/0Z32x1UnCapNfP4WmZhjPEw5ft8Xb+jYTDUE0fRqfpAG2X6fVL+PD9sEwXx8lDwG8H491Sk02G3/IgTZ5j/R3Ov79O5lconF/ZE2zC2H1MJ+vrIP19hPs2fxo/jhfu0hvSvunu+vnL3XqLflNqPiy2q1bVhZXYFCJS5VmTjMbthK5Z0gWFTDr1dOtuq7KTTL13xrtJMdWu8kGJLT+qWQNgGA0WpvTA0yKdRZIxMdvRiI2kzEq3kSqzGV5lJ7jTJuWK77V7aRy3G46S8q0eXlWtbnvC9rQsv7TjP1O6Y7keYcTgRmbpVTnEIG4jz7F9s1O7qME/5ZUj8k/BXeyRn+Cqhvclj5/Yp0iw5dQkDYXS7cg/i7Q79R90NjpNmaRwkxznWd3+mOWKi6oj4Mu7YVGp9BcVuH1hEdvyHQQdx8KIEGI6XXBBXNdHCEHsEOJj1yZdgIml3wi6FrEc5GPP6XRLkUzy8gJpRJqxa20uWfS/yiYkpo9sREyEfYJ8y9QqFzqKiO05DsIEu0g/7SrqIcsjVrnhENcnXi1eWWz334czoeWZ2LFcBzu2HpmDag3fJB7RRNh1LctzvC4wIbZM7PkuNj0PY2w1Cm/VMy7k+YRmdXO1uq1ero4JuzyX8StPd5lUpePbEBqKpbuE6kKMdRFtteOjPK9/AgB6xo/QXsz3gMdfP7hUQZToS0fvbIokmfGTNtVlz9D5/4KW/uHiabpnMqHHMu0ZXd7WQQhhz9DLj5Eqy5I1lT8x/w0)
- [3D Tile Formats sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=7Vl7Uxs3EP8qqocJ54k5gwmT1naYFkMbWghM7En/wEwj3wmsopOuks7gMP7uXUn30DkO4ZWZTicextZJ+/jtarW7OiLBlUYzSq6JRG8QJ9doQBTNkvCDnQvGjcg+DwTXmHIix40Wuh1zBB81xbG4Vl2kZUbGfNHsjbkTFZIbTXgc5LLcpHvY3h9RRtQhVymJtJDH9IZywxlZKLSYN/qPRUwYwMqFRisFWOmWEoSUACImoqswyqQkXI9oQurW/Z4xivk+1iTovNp5vdPphFs7r17/1GlaIQ6LiggnlXr7CMuMaKQNBKI94pmH1/onJwH3nDl35V5DiOOEdNG4MXIU4NFiRRIlMhmRbjGBgCwM2/A3xEnKCCDG7Zoj27mUctDOFYd/K8FL2YvWl0BIzBXLwLanAtnDOpqSuPj1BD8eUvskxf9AcH0rZE48xOADIR5nTNONSDAhnxfbwIhUD0TznoAREIMfBMsS8szx9CfVU5cMcjVOywMh5uY9r7MMNDsc4Ql7KCJIIBrz6MmYSjnV6HlwtU8khRDFmnpsz4bRE/5AgAORpEJR/dRAK+V4o4chORWU6wET2VP3sBLkDd//tvdoPANh/awHz5AhVoKrKXg0zHdCJpipbwEwF/1oaM+TMFZCK7LIY6HtSxyJbwHMCr4L1rn9VoRB5wN1zBF2UcZjcgHNWeyW/bYMZha2S8kbnysOfZHIdKhB11VQdi1+36OFYBNs+sFYRJDquQ4viT5gxAz35ocxdIU5zbhhGJdl4zRl8z3KY8ovVaWjVUhurkJkoBs9JxNF5MwkTp9z3MjNAo2WUmUTFUk6IcFFxiOTxlBAuGGLm8XmFY2b4wR7coKeWV48DkXd93ehEan5VSUaeoGKhjjfriDf6mazCjfbZYappAnVdEZUKEkiZqQk7eXxUMn8YUloodcT+nlXHebywCll9PSqgNaZ5JUmN6g4/IbYh4pjCI3i2FTNdi3yiQ5uq3OSSdZFOeCwOEetat1tmEV8cJMSUGWKFitj21Etmm7kdtTDCiJxPD+VIqGKFNShnhLu7ZPnp694qur6C/LcE5+ESEYiqOZLBC1/zvPJWwAGp+OUQip6j/klqTEjtNmqP290wuWpY6ynYYJvgq3NzXATbZRGT0Rmj94wnRJJQgmaMtVCQNT0JXgPlePMx2WBVApwuKZEVZaH1aTnBBOEvuCleKx4mujFi3sRgnvo5VT7CP1NqvZX6Tlbutr50TY0y8Ft3W+2a++ipVlrdkxtJJZXNv9zNm6s3TpcC7T7Bv24ba7CcD824oL1NJOQ6deNm3ea48Z56x4SNmsSJInX78n5us4ppImg+zJvdWrMc8KYuL635hovg/N4b7U1zmiO+R2c9o2CTz9h2Rc0Lc8sas+Lpheoi+WEAckgMs2AX0OkFLIWbXoqxTWy871KgF9DygoRLpWHPFfW8og62zz3iu0U85gtv3wZRpIQPkxxRA5mkPHeOqKgeLmB+QwrpzvnB836kKeZ/sXa4RlkqofJmrlNTusFwZDizclZkfDyRWvhiqKVL1f1pZYv5u+gXzIpIyczxfTUXwqKHXFsjPBLPQX6Gn/opnPKCyFRYF67UKDb7MFPP+froZcvqbdbn0NZlnxGz3s+tWAkZOLSS2Af1259jkUXrd2uMCbwiZqLj4WAWoWGr0XrS7s6mqckPDr4dfTX4Ohw8Md/Zj8LY9UU4h42Etp4x/x1a44P9/ePDnx7ijhPAIoJC5tZc0Wa3GjTWm/vI4O0bHaBwZ6jLlpZpWvtRyJkOh2J7f3A1Ldya+lFUOsBaif6f1S1a4nNpT73veTiztNd3Pnu4jtdPDDvxSaZQubkPcXRhSAj57vLPZe7ujmEDBlhpSFxw4Vj5K6Ux4Rngc0xzV6j1ejbxnC3kPQzTVIhtbluBHAr1wRu5VjDNXySRVeAMlKqUNtv+6z9mM4Qjd+s+DcIihhWClYuMsaG9BOcrd1+G+g/Y2XC+vdkRiTDc0M23do9cpNhGPbb8Lias7xll5b0XTShGGu8MYErNlDl96du+S+HVnGlGtnQXDevMKAznWFoorrLrw9K4gG2v0A/mAqhCMIoJwGQ69Y6x1qBMZj71JQppCH9GzdNSXQ1ETfgHx+inSZxF5W3+F00dMOa5d74Xw) -- side note, I found that point clouds are crashing in 2D / CV mode, so I'll have to check that out soon 
- [`ModelExperimental` sandcastle (different instanced models at the top)](http://localhost:8080/Apps/Sandcastle/index.html#c=1Vd7b+M2DP8qQv5KhkZ2Hk3SrFesTR+7ocGKJrsDNg+DYiuxVlkyJLlNd+h3Hy3ZjtPXXRcU24LWkUyK5I+kSCaUQht0y+gdVegDEvQOTahmWYI/2XfNoBHa/UQKQ5igKmjsoS+BQEjHMuPRsWAJMXSMjMroXiAeWt8HIhBOIg65DG9wmClFhZmzhIKOQv5PGWdEnMJZvFQy+ajlaOB3mrnkoNH1u512p9P2D+Zdf9wdjntD7HcG/qDfH+73+qPBqH/QG/4aNALh9HkemsqIch2I0EJK7A7U/ZZLtAYjZOjajEH8R+AgIqQROpFrAOSocI5yGgLHMhOhYVKgZqs8Cngt0Wpplu9yWzH24G9GkpRTgEM8p9oD0ZWerQ1ecbOstOafjl+uczT594OluudrxqO5IkJzklu7KxBvltJQexaDc6Z3AZZeShJRtYWgptRb8fm5t5DrNiupbbMhvxdW9JmZGE2ZQFOy/leA5waAflD/FRe0Ewb/ZL2jK9y1QSeEc7l7rF9KWqelULK9A/sX2+bvv8H82Q0TAuI4iYkiobF15B0RTElp/R+wfGL6Wxx/CvZKNJFJqqjWAMHa8l7mW20bZSUcxm/mKoNa+iSJ3gLlF8GZ+cc177VKZyVXi9JK5H+Tf6Wg75sNVkV9vVsuXyiZiQh9ojEL+buZ7rQUSrZ3b8nn321/dE0xTh81+R8piZhYXTETxteSO8MK2pSYGBt5DRxQy5qdkd+yQn33dJ3XyV2yNY3OFUmoLZBLqZJNo69eaQzTAOGOT55XZy4ojBXESFU0fyGViQt4QeOOarPp85wWrR12lZfrns0U30MxZavYFL53JqZSM8tc2TUhysCKiJ4dQE7pSlGqi9C0O90e9of9/qBzUPi538f+vt8b+oPihdOSr51tqJijsA4BEU4VS0DlLdVY0UTe0mPwr4uPRQCWvMRPoqiwo4xFfuBsnVLggUmKcGty3qSaVX4B8nH+qNLCaoEoKrYePxOM+FHs6yGpJWjpuFq2QRrVdoXkM85ZqiWL8OeL2ahfY3gmO6p03RjLYJDMkivg5TP2FwyUne5oQyXrnDqD9AHKvg+fipYq+SeEfy67p9UUaq9Aqx4a6wwIBInur8B1TFNsYiqam6tqOar7Wg6wYLUikLjy5thUXnnik5euFBGrui+fv1n9/dbe13janS0mh2aRlwTQNUtjqihWwJtp9B3a1DK3KH1QnoP+C2nmJndAYfMtT84qlQBuOt7KvYr5Ekj4+uzq7Hhe+dnmtP16yBXNiIhCog3UKRA8l5IviJpSkTkX61atIuVvXprSe6e21X5rfd26TIlUaTyXvdOmj6sm9DiqS34/lydbTmy+7uNaCL5slghFmbLeGW8qMXjkDS2luzvW7v8F60TyLFlApuY/MXdBXArK5fw3sbvm+/qFgPvQ2GscanPP6VEp6geWpNAG83rehOnAUJgO4Key9hYwBFKDQ61LbYde/ehhxG4Riz4887sdhZxoDZRlxm2NDRpHhx7wPznKpa1hP99Sxcl9zhZ3ji7dS4zxoQfb508aB+6R5L8B)