### PR TITLE
Document that materials use linear space colors

### DIFF
--- a/Documentation/CustomShaderGuide/README.md
+++ b/Documentation/CustomShaderGuide/README.md
@@ -693,7 +693,7 @@ This struct contains the output of the custom vertex shader. This includes:
 
 ## `czm_modelMaterial` struct
 
-This struct is a built-in, see the [documentation comment](../../Source/Shaders/Builtin/Structs/modelMaterial.glsl). This is similar to `czm_material` from the old Fabric system, but slightly different fields as this one supports PBR lighting.
+This struct is a built-in, see the [documentation comment](../../Source/Shaders/Builtin/Structs/modelMaterial.glsl). This is similar to `czm_material` from the old Fabric system, but has slightly different fields as this one supports PBR lighting.
 
 This struct serves as the basic input/output of the fragment shader pipeline stages. For example:
 

--- a/Documentation/CustomShaderGuide/README.md
+++ b/Documentation/CustomShaderGuide/README.md
@@ -693,10 +693,18 @@ This struct contains the output of the custom vertex shader. This includes:
 
 ## `czm_modelMaterial` struct
 
-This struct is a built-in, see the [documentation comment](../../../Shaders/Builtin/Structs/modelMaterial.glsl). This is similar to `czm_material` from the old Fabric system, but slightly different fields as this one supports PBR lighting.
+This struct is a built-in, see the [documentation comment](../../Source/Shaders/Builtin/Structs/modelMaterial.glsl). This is similar to `czm_material` from the old Fabric system, but slightly different fields as this one supports PBR lighting.
 
 This struct serves as the basic input/output of the fragment shader pipeline stages. For example:
 
 - the material stage produces a material
 - the lighting stage takes in a material, computes lighting, and stores the result into `material.diffuse`
 - Custom shaders (regardless of where in the pipeline it is) takes in a material (even if it's a material with default values) and modifies this.
+
+### Material color space
+
+Material colors (such as `material.diffuse`) are always in linear color space,
+even when `lightingModel` is `LightingModel.UNLIT`.
+
+When `scene.highDynamicRange` is `false`, the final computed color
+(after custom shaders and lighting) is converted to `sRGB`.

--- a/Source/Shaders/Builtin/Structs/modelMaterial.glsl
+++ b/Source/Shaders/Builtin/Structs/modelMaterial.glsl
@@ -2,7 +2,10 @@
  * Struct for representing a material for a {@link ModelExperimental}. The model
  * rendering pipeline will pass this struct between material, custom shaders,
  * and lighting stages. This is not to be confused with {@link czm_material}
- * which is used by the older Fabric materials system, although they are similar
+ * which is used by the older Fabric materials system, although they are similar.
+ * <p>
+ * All color values (diffuse, specular, emissive) are in linear color space.
+ * </p>
  *
  * @name czm_modelMaterial
  * @glslStruct


### PR DESCRIPTION
Closes #10444

Materials in `ModelExperimental` always use linear color space rather than sRGB. This was not documented, so I added some information both in the code and the Custom Shader Guide

@j9liu could you review when you get a chance?