### PR TITLE
Fix vector polyline clamping

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 1.94.3 - 2022-06-10
+
+- Fixed a crash with vector tilesets with lines when clamping to terrain or 3D tiles. [#10447](https://github.com/CesiumGS/cesium/pull/10447)
+
 ### 1.94.2 - 2022-06-03
 
 - This is an npm only release to fix the improperly published 1.94.1.

--- a/Source/Scene/Vector3DTileClampedPolylines.js
+++ b/Source/Scene/Vector3DTileClampedPolylines.js
@@ -723,7 +723,7 @@ function initialize(polylines) {
 
         promise
           .then(function () {
-            finishVertexArray(polylines, frameState);
+            finishVertexArray(polylines, context);
             resolve(polylines);
           })
           .catch(function (e) {

--- a/Source/Scene/Vector3DTileClampedPolylines.js
+++ b/Source/Scene/Vector3DTileClampedPolylines.js
@@ -723,7 +723,7 @@ function initialize(polylines) {
 
         promise
           .then(function () {
-            finishVertexArray(polylines);
+            finishVertexArray(polylines, frameState);
             resolve(polylines);
           })
           .catch(function (e) {


### PR DESCRIPTION
This fixes a regression from https://github.com/CesiumGS/cesium/commit/6e5e7a064dc45e0084c1bb1a20b8617ddd0b4c53#diff-9c322fcbd2bf3549f60528f6659332e11465537ef57caefcc5bae56e7af3a356 which occurs when clamping a vector tileset.

We plan on releasing this as a patch release, so this is targeted for  a `1.94.3-release` branch. After this is merged and release, we will also merge it into `main`.