### PR TITLE
Add height reference (clamp-to-ground) to `ModelExperimental`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,8 +7,9 @@
 - Memory statistics for `ModelExperimental` now appear in the `Cesium3DTilesInspector`. This includes binary metadata memory, which is not counted by `Model`. [#10397](https://github.com/CesiumGS/cesium/pull/10397)
 - Memory statistics for `ResourceCache` (used by `ModelExperimental`) now appear in the `Cesium3DTilesInspector`. [#10413](https://github.com/CesiumGS/cesium/pull/10413)
 - Added support for rendering individual models in 2D / CV using `ModelExperimental`. [#10419](https://github.com/CesiumGS/cesium/pull/10419)
-- Added support for rendering instanced tilesets in 2D / CV using `ModelExperimental`. [#10433](https://github.com/CesiumGS/cesium/pull/10433/)
+- Added support for rendering instanced tilesets in 2D / CV using `ModelExperimental`. [#10433](https://github.com/CesiumGS/cesium/pull/10433)
 - Added `modelUpAxis` and `modelForwardAxis` constructor options to `Cesium3DTileset` [#10439](https://github.com/CesiumGS/cesium/pull/10439)
+- Added `heightReference` to `ModelExperimental`. [#10448](https://github.com/CesiumGS/cesium/pull/10448)
 
 ##### Fixes :wrench:
 

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -1380,7 +1380,7 @@ ModelExperimental.prototype.update = function (frameState) {
   // without needing to use a setter.
   if (!Matrix4.equals(this.modelMatrix, this._modelMatrix)) {
     //>>includeStart('debug', pragmas.debug);
-    if (frameState.mode === SceneMode.SCENE3D && this._projectTo2D) {
+    if (frameState.mode !== SceneMode.SCENE3D && this._projectTo2D) {
       throw new DeveloperError(
         "ModelExperimental.modelMatrix cannot be changed in 2D or Columbus View if projectTo2D is true."
       );

--- a/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
@@ -221,13 +221,17 @@ function initialize(sceneGraph) {
   const components = sceneGraph._components;
   const scene = components.scene;
 
-  computeModelMatrix(sceneGraph);
+  // If the model has a height reference that modifies the model matrix,
+  // it will be accounted for in updateModelMatrix.
+  const modelMatrix = sceneGraph._model.modelMatrix;
+  computeModelMatrix(sceneGraph, modelMatrix);
 
   const nodes = components.nodes;
   const nodesLength = nodes.length;
 
-  // Initialize this array to be the same size as the nodes array in the model's file.
-  // This is so nodes can be stored by their index in the file, for future ease of access.
+  // Initialize this array to be the same size as the nodes array in
+  // the model's file. This is so nodes can be stored by their index
+  // in the file, for future ease of access.
   sceneGraph._runtimeNodes = new Array(nodesLength);
 
   const rootNodes = scene.nodes;
@@ -276,12 +280,12 @@ function initialize(sceneGraph) {
   }
 }
 
-function computeModelMatrix(sceneGraph) {
+function computeModelMatrix(sceneGraph, modelMatrix) {
   const components = sceneGraph._components;
   const model = sceneGraph._model;
 
   sceneGraph._computedModelMatrix = Matrix4.multiplyTransformation(
-    model.modelMatrix,
+    modelMatrix,
     components.transform,
     sceneGraph._computedModelMatrix
   );
@@ -605,9 +609,10 @@ ModelExperimentalSceneGraph.prototype.update = function (
 };
 
 ModelExperimentalSceneGraph.prototype.updateModelMatrix = function (
+  modelMatrix,
   frameState
 ) {
-  computeModelMatrix(this);
+  computeModelMatrix(this, modelMatrix);
   if (frameState.mode !== SceneMode.SCENE3D) {
     computeModelMatrix2D(this, frameState);
   }

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -9,9 +9,11 @@ import {
   defaultValue,
   defined,
   Ellipsoid,
+  Event,
   FeatureDetection,
   HeadingPitchRange,
   HeadingPitchRoll,
+  HeightReference,
   ImageBasedLighting,
   JulianDate,
   Math as CesiumMath,
@@ -83,37 +85,47 @@ describe(
     );
 
     let scene;
-    let sceneWithWebgl2;
     let scene2D;
     let sceneCV;
+    let sceneWithMockGlobe;
+    let sceneWithWebgl2;
 
     beforeAll(function () {
       scene = createScene();
-      sceneWithWebgl2 = createScene({
-        contextOptions: {
-          requestWebgl2: true,
-        },
-      });
 
       scene2D = createScene();
       scene2D.morphTo2D(0.0);
 
       sceneCV = createScene();
       sceneCV.morphToColumbusView(0.0);
+
+      sceneWithMockGlobe = createScene();
+
+      sceneWithWebgl2 = createScene({
+        contextOptions: {
+          requestWebgl2: true,
+        },
+      });
+    });
+
+    beforeEach(function () {
+      sceneWithMockGlobe.globe = createMockGlobe();
     });
 
     afterAll(function () {
       scene.destroyForSpecs();
-      sceneWithWebgl2.destroyForSpecs();
       scene2D.destroyForSpecs();
       sceneCV.destroyForSpecs();
+      sceneWithMockGlobe.destroyForSpecs();
+      sceneWithWebgl2.destroyForSpecs();
     });
 
     afterEach(function () {
       scene.primitives.removeAll();
-      sceneWithWebgl2.primitives.removeAll();
       scene2D.primitives.removeAll();
       sceneCV.primitives.removeAll();
+      sceneWithMockGlobe.primitives.removeAll();
+      sceneWithWebgl2.primitives.removeAll();
       ResourceCache.clearForSpecs();
     });
 
@@ -214,6 +226,55 @@ describe(
         }
         expect(command.count).toEqual(commandCounts[i]);
       }
+    }
+
+    function createMockGlobe() {
+      const globe = {
+        callback: undefined,
+        removedCallback: false,
+        ellipsoid: Ellipsoid.WGS84,
+        update: function () {},
+        render: function () {},
+        getHeight: function () {
+          return 0.0;
+        },
+        _surface: {
+          tileProvider: {
+            ready: true,
+          },
+          _tileLoadQueueHigh: [],
+          _tileLoadQueueMedium: [],
+          _tileLoadQueueLow: [],
+          _debug: {
+            tilesWaitingForChildren: 0,
+          },
+        },
+        imageryLayersUpdatedEvent: new Event(),
+        destroy: function () {},
+      };
+
+      globe.beginFrame = function () {};
+
+      globe.endFrame = function () {};
+
+      globe.terrainProviderChanged = new Event();
+      Object.defineProperties(globe, {
+        terrainProvider: {
+          set: function (value) {
+            this.terrainProviderChanged.raiseEvent(value);
+          },
+        },
+      });
+
+      globe._surface.updateHeight = function (position, callback) {
+        globe.callback = callback;
+        return function () {
+          globe.removedCallback = true;
+          globe.callback = undefined;
+        };
+      };
+
+      return globe;
     }
 
     it("initializes and renders from Uint8Array", function () {
@@ -1210,6 +1271,156 @@ describe(
       });
     });
 
+    it("initializes with height reference", function () {
+      return loadAndZoomToModelExperimental(
+        {
+          gltf: boxTexturedGltfUrl,
+          heightReference: HeightReference.CLAMP_TO_GROUND,
+          scene: sceneWithMockGlobe,
+        },
+        sceneWithMockGlobe
+      ).then(function (model) {
+        expect(model.heightReference).toEqual(HeightReference.CLAMP_TO_GROUND);
+        expect(model._scene).toBe(sceneWithMockGlobe);
+        expect(model._clampedModelMatrix).toBeDefined();
+      });
+    });
+
+    it("changing height reference works", function () {
+      return loadAndZoomToModelExperimental(
+        {
+          gltf: boxTexturedGltfUrl,
+          heightReference: HeightReference.CLAMP_TO_GROUND,
+          scene: sceneWithMockGlobe,
+        },
+        sceneWithMockGlobe
+      ).then(function (model) {
+        expect(model.heightReference).toEqual(HeightReference.CLAMP_TO_GROUND);
+        expect(model._clampedModelMatrix).toBeDefined();
+
+        model.heightReference = HeightReference.NONE;
+        expect(model._heightDirty).toBe(true);
+        expect(model.heightReference).toEqual(HeightReference.NONE);
+        expect(model._clampedModelMatrix).toBeUndefined();
+      });
+    });
+
+    it("creates height update callback when initializing with height reference", function () {
+      return loadAndZoomToModelExperimental(
+        {
+          gltf: boxTexturedGltfUrl,
+          modelMatrix: Transforms.eastNorthUpToFixedFrame(
+            Cartesian3.fromDegrees(-72.0, 40.0)
+          ),
+          heightReference: HeightReference.CLAMP_TO_GROUND,
+          scene: sceneWithMockGlobe,
+        },
+        sceneWithMockGlobe
+      ).then(function (model) {
+        expect(model.heightReference).toEqual(HeightReference.CLAMP_TO_GROUND);
+        expect(sceneWithMockGlobe.globe.callback).toBeDefined();
+      });
+    });
+
+    it("creates height update callback after setting height reference", function () {
+      return loadAndZoomToModelExperimental(
+        {
+          gltf: boxTexturedGltfUrl,
+          modelMatrix: Transforms.eastNorthUpToFixedFrame(
+            Cartesian3.fromDegrees(-72.0, 40.0)
+          ),
+          heightReference: HeightReference.NONE,
+          scene: sceneWithMockGlobe,
+        },
+        sceneWithMockGlobe
+      ).then(function (model) {
+        expect(model.heightReference).toEqual(HeightReference.NONE);
+        expect(sceneWithMockGlobe.globe.callback).toBeUndefined();
+
+        model.heightReference = HeightReference.CLAMP_TO_GROUND;
+        expect(model.heightReference).toEqual(HeightReference.CLAMP_TO_GROUND);
+        sceneWithMockGlobe.renderForSpecs();
+        expect(sceneWithMockGlobe.globe.callback).toBeDefined();
+      });
+    });
+
+    it("updates the callback when the height reference changes", function () {
+      return loadAndZoomToModelExperimental(
+        {
+          gltf: boxTexturedGltfUrl,
+          modelMatrix: Transforms.eastNorthUpToFixedFrame(
+            Cartesian3.fromDegrees(-72.0, 40.0)
+          ),
+          heightReference: HeightReference.CLAMP_TO_GROUND,
+          scene: sceneWithMockGlobe,
+        },
+        sceneWithMockGlobe
+      ).then(function (model) {
+        expect(sceneWithMockGlobe.globe.callback).toBeDefined();
+
+        model.heightReference = HeightReference.RELATIVE_TO_GROUND;
+        sceneWithMockGlobe.renderForSpecs();
+        expect(sceneWithMockGlobe.globe.removedCallback).toEqual(true);
+        expect(sceneWithMockGlobe.globe.callback).toBeDefined();
+
+        sceneWithMockGlobe.globe.removedCallback = false;
+        model.heightReference = HeightReference.NONE;
+        sceneWithMockGlobe.renderForSpecs();
+        expect(sceneWithMockGlobe.globe.removedCallback).toEqual(true);
+        expect(sceneWithMockGlobe.globe.callback).toBeUndefined();
+      });
+    });
+
+    it("updates the callback when the model matrix changes", function () {
+      return loadAndZoomToModelExperimental(
+        {
+          gltf: boxTexturedGltfUrl,
+          modelMatrix: Transforms.eastNorthUpToFixedFrame(
+            Cartesian3.fromDegrees(-72.0, 40.0)
+          ),
+          heightReference: HeightReference.CLAMP_TO_GROUND,
+          scene: sceneWithMockGlobe,
+        },
+        sceneWithMockGlobe
+      ).then(function (model) {
+        expect(sceneWithMockGlobe.globe.callback).toBeDefined();
+
+        const position = Cartesian3.fromDegrees(-73.0, 40.0);
+        model.modelMatrix[12] = position.x;
+        model.modelMatrix[13] = position.y;
+        model.modelMatrix[14] = position.z;
+
+        sceneWithMockGlobe.renderForSpecs();
+        expect(sceneWithMockGlobe.globe.removedCallback).toEqual(true);
+        expect(sceneWithMockGlobe.globe.callback).toBeDefined();
+      });
+    });
+
+    it("callback updates the position", function () {
+      return loadAndZoomToModelExperimental(
+        {
+          gltf: boxTexturedGltfUrl,
+          modelMatrix: Transforms.eastNorthUpToFixedFrame(
+            Cartesian3.fromDegrees(-72.0, 40.0)
+          ),
+          heightReference: HeightReference.CLAMP_TO_GROUND,
+          scene: sceneWithMockGlobe,
+        },
+        sceneWithMockGlobe
+      ).then(function (model) {
+        expect(sceneWithMockGlobe.globe.callback).toBeDefined();
+
+        sceneWithMockGlobe.globe.callback(
+          Cartesian3.fromDegrees(-72.0, 40.0, 100.0)
+        );
+        const matrix = model._clampedModelMatrix;
+        const position = new Cartesian3(matrix[12], matrix[13], matrix[14]);
+        const ellipsoid = sceneWithMockGlobe.globe.ellipsoid;
+        const cartographic = ellipsoid.cartesianToCartographic(position);
+        expect(cartographic.height).toEqualEpsilon(100.0, CesiumMath.EPSILON9);
+      });
+    });
+
     it("initializes with light color", function () {
       return loadAndZoomToModelExperimental(
         { gltf: boxTexturedGltfUrl, lightColor: Cartesian3.ZERO },
@@ -2017,6 +2228,26 @@ describe(
 
         model.clippingPlanes = undefined;
         expect(clippingPlanes.isDestroyed()).toBe(true);
+      });
+    });
+
+    it("destroys height reference callback", function () {
+      return loadAndZoomToModelExperimental(
+        {
+          gltf: boxTexturedGlbUrl,
+          modelMatrix: Transforms.eastNorthUpToFixedFrame(
+            Cartesian3.fromDegrees(-72.0, 40.0)
+          ),
+          heightReference: HeightReference.CLAMP_TO_GROUND,
+          scene: sceneWithMockGlobe,
+        },
+        sceneWithMockGlobe
+      ).then(function (model) {
+        expect(sceneWithMockGlobe.globe.callback).toBeDefined();
+
+        model.destroy();
+        expect(model.isDestroyed()).toBe(true);
+        expect(sceneWithMockGlobe.globe.callback).toBeUndefined();
       });
     });
 

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -1376,12 +1376,13 @@ describe(
     });
 
     it("updates height reference callback when the model matrix changes", function () {
+      const modelMatrix = Transforms.eastNorthUpToFixedFrame(
+        Cartesian3.fromDegrees(-72.0, 40.0)
+      );
       return loadAndZoomToModelExperimental(
         {
           gltf: boxTexturedGltfUrl,
-          modelMatrix: Transforms.eastNorthUpToFixedFrame(
-            Cartesian3.fromDegrees(-72.0, 40.0)
-          ),
+          modelMatrix: Matrix4.clone(modelMatrix),
           heightReference: HeightReference.CLAMP_TO_GROUND,
           scene: sceneWithMockGlobe,
         },
@@ -1389,15 +1390,20 @@ describe(
       ).then(function (model) {
         expect(sceneWithMockGlobe.globe.callback).toBeDefined();
 
-        const matrix = Matrix4.clone(model.modelMatrix);
+        // Modify the model matrix in place
         const position = Cartesian3.fromDegrees(-73.0, 40.0);
-        matrix[12] = position.x;
-        matrix[13] = position.y;
-        matrix[14] = position.z;
+        model.modelMatrix[12] = position.x;
+        model.modelMatrix[13] = position.y;
+        model.modelMatrix[14] = position.z;
 
-        model.modelMatrix = matrix;
         sceneWithMockGlobe.renderForSpecs();
+        expect(sceneWithMockGlobe.globe.removedCallback).toEqual(true);
+        expect(sceneWithMockGlobe.globe.callback).toBeDefined();
 
+        // Replace the model matrix entirely
+        model.modelMatrix = modelMatrix;
+
+        sceneWithMockGlobe.renderForSpecs();
         expect(sceneWithMockGlobe.globe.removedCallback).toEqual(true);
         expect(sceneWithMockGlobe.globe.callback).toBeDefined();
       });

--- a/Specs/Scene/ModelExperimental/ModelMatrixUpdateStageSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelMatrixUpdateStageSpec.js
@@ -92,7 +92,7 @@ describe(
       });
     });
 
-    function applyTransform(sceneGraph, node, transform) {
+    function applyTransform(node, transform) {
       const expectedOriginalTransform = Matrix4.clone(node.originalTransform);
       expect(node._transformDirty).toEqual(false);
 
@@ -115,6 +115,8 @@ describe(
         },
         scene
       ).then(function (model) {
+        scene.renderForSpecs();
+
         const sceneGraph = model._sceneGraph;
 
         // The root node is transformed.
@@ -127,12 +129,12 @@ describe(
         const childTransformation = Matrix4.fromTranslation(
           new Cartesian3(0, 5, 0)
         );
-        applyTransform(sceneGraph, transformedChildNode, childTransformation);
+        applyTransform(transformedChildNode, childTransformation);
 
         const rootTransformation = Matrix4.fromTranslation(
           new Cartesian3(12, 5, 0)
         );
-        applyTransform(sceneGraph, rootNode, rootTransformation);
+        applyTransform(rootNode, rootTransformation);
 
         const rootPrimitive = rootNode.runtimePrimitives[0];
         const staticChildPrimitive = staticChildNode.runtimePrimitives[0];

--- a/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
+++ b/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
@@ -32,6 +32,8 @@ function loadAndZoomToModelExperimental(options, scene) {
         backFaceCulling: options.backFaceCulling,
         showCreditsOnScreen: options.showCreditsOnScreen,
         projectTo2D: options.projectTo2D,
+        heightReference: options.heightReference,
+        scene: options.scene,
       });
     } catch (error) {
       reject(error);


### PR DESCRIPTION
This PR adds a `heightReference` option to `ModelExperimental` to allow for clamp-to-ground behavior. Most of the code is taken from `Model`, though `ModelExperimental.update` had to be reorganized so things could be updated in the right order (model matrix, bounding spheres, reference matrices).

Sandcastle for [`ModelExperimental`](http://localhost:8080/Apps/Sandcastle/index.html#c=tVdtb+I4EP4rEZ/g1JoEKFDara6lbLenvgmyPWmPU+Umhljr2Mh2Wrqn/veb2Hmjpd2+IgROPJ55ZubJzCQQXGnnhpJbIp0vDie3zpAomsTo0tyrT2uBuR4KrjHlRE5rG85/U+44KhIJC/c5jbEmA0fLhGxM+X1jZ8qn3GpEARPBTxQkUhKufRoTsJHp/ythFPNDOItmUsTHSvS7rldPNU9rLbflbXreprvtt9xBqzdo95Drdd1up9Pbanf63X5nu937Ma1NubXXbDqnIiRMTXlgXIrNFZj7J9VoADuOJks9APUWgnOAGROCg0d2Gw4SRgIQmSU80FRwp97Iz4LDZtOYqef3UrAINeE7wfGCEfAHN63tprWSGVm9QnN2XZhNP95Wvk79Sf/vza79fQB/8pNyTkJnGGGJA21y8okenOIc/RUsH0Fvua+AfgiAhTMU8UISpcAHA+az8BtrpbHcH8p++jIBYs6Znr3dl++cUe0ciOWb4D8JGhQazcUihwnoXhRhwcnnEsKYqK7fR+cjKRIeOpckogH7NOjWSmZk9ep9lD6GcoN5AFx+KxVegB5UF3ZWLh5z+LnY/2uKpa2Q0eJBxf9GcEj5/ILqIBoLZoFle6dYR0iLMUhgrupe320Ypa79tWXY6p3RJQm/ShwTX4LsTMi4rPrFLYWgNWBm5cTX4swRgR6DtZBZJ+BC6ijzb1q7JUqXRZ+RrM7v2HXAIG5pTEt73widR3pMZgQ6UEDQ2fnZyJwtslLNRCLZhhOZI1murEsLoagRLvQOsdSwwrxtutchmUtCVJbKTa/VRm6v0+l621liOh3kbrntntvNblgr6dr64mRNGKkAIoAWksZg8oYoJEksbsg+5MPm03gMSJ6Sx2GY4chzlx4YLRcEZKANY2YgHwFv6gUfwfNB+lPwyFiBrEu6HKxJXvSAK9UUVgidB65CT6Bd5SrTPGKMLpSgIfr7aNLvVATWsKmgdwmWwhSSxBcgyyb0F0wjXqtf7uJlujsBusFOy4VPsRet8mNQcqgQMQEerIQ727tvVPNnIgbZwuHdBcSXKoJ0RHi9fP6NRFEEfgkR+8ISL39SrQ7o6ZBJO1nBQZPSNP9FtmCEWAxW0lsIn8AWGo8uRvt+gdIoN3/3KdQJ5mGAlYbCB4p9Idg1lqeEJxagalSKRBGOp0aps1d0m5c/nxUOogcpgrOFnt8X52EqSsIPRDg82T+9uPLPr47G59/PDj8S7JgwnGb+A9GORyf7/vHl6EMA2+7xNH1KslQpFD/DnvbhS31dqXaxkIvIF+3DuouKmWj9E/VMuFvvMt56n/Hh5XuMDwVL4utEpS9pr4HxuwzGZfIKLCsaLaz87Q6qssRoxu58cZDOU9ARJosImGQrCbpeubmR+xQm0tSqgZMXYjGbKQIBeGoawXxetpX1I0lnq+wH6yU2vYrIOoBIgmSinD+cbIRqVAsnzB/rI3eQaC04TPQ/IFKOL4p3mmroGju1jdqu0neM7OUY/qTxAsabtO/WYerTBKY+eB9WzWt4OSEaBUrlKdxtVo/uhvTGoeGXNS/n6eOrFOzMEmZ64bS2t9sE+UdHmTABPr8hkuG7VCzy9k7sTYTQbhMu15/U1u8Hmv8H), and a sandcastle for [`Model`](http://localhost:8080/Apps/Sandcastle/index.html#c=tVj7T+M4EP5XrP7UnoqbPihQWHRQWJYTL7VdTtrrCZnEJdY6dmU7PPbE/34TO89SlvKqUOvE45lvZr7MTPCl0AbdMnpHFfqCBL1DQ6pZHOFLe68+rfn2eiiFIUxQNa010X9TgZAOZcyDPcEiYugAGRXT5lQ8NranYiqcRuxz6f/EfqwUFWbCIgo2Uv1/xZwRcQBn8UzJ6FjLzb7Xrieap7WO12mvtdtr3tak4w06G4PuBvbafa/f622sd3ub/c3eVnfjx7Q2Fc5eq4VOZUC5ngrfuhTZKzD3T6LRAkbI0HszAPUOAtonnEspwCO3DQcppz6IzGLhGyYFqjeys+Cw3bRm6tm9BCzGLfgbk2jOKfhDWs52y1lJjVSv8A2/zs0mn/Z6tk78SX4f7a77XoA//smEoAEahkQR39icfKIHpyRDfwXLJ9A73iugHwBgiYYymiuqNfhgwXwWfmutMJb5w/jPiYqBmDfczN7uy3fBmUH78v5N8J8FDQqt5nyRwQR0K0VYCvq5hLAmyuv30flIyVgE6JKGzOefBt1ZSY1Ur95H6WMoN0T4wOW3UmEF9KA6t1O5eMrh38X+X1ssXYUM5wsV/xslARM3F8z44UhyByzdOyUmxEaOQIIIXW9veg2r1HPfrgw7vTN2T4OvikR0okB2JlVUVP38lsbQGgh3cvJrfuaIQo8hRqq0EwipTJj6N63dUW2Kos9pWue33drnELckpoW9b5TdhGZEZxQ6kE/x2fnZoT2bZ6WciVjxJgrtkTRXzqW51MwK53qHRBlYEdG13euA3ihKdZrKtXani72NXq/f3koT0+thb93rbnj99IazkqydLyhtwlj7EAE8VywCk7dUY0UjeUv3IB8un9ZjQPKcPAmCFEeWu+SAhXkEXKnnHARvB8lXzh2rGTKt2P1gScLCBX6U01YicRasEiWBaqWrVPMh52yuJQvw30fjzV5JYAmDckoXYBlMHnF0AbJ8zH7BBNLubBa75D7ZHQPFYKfjwSffC6ucGBS8yUVsUAeVEKd7j41yzmzEIEMkeLiA+DJNsQmpqBfPvJXIH/xsLALXFMEz/jCR+0khgrCO5yHgcfL4unKzWdSNIIaHAxQPUOGPnM00hULz3KNMxE05P8uf6N56o/mSzFq7IrQMKlYgG2v0ByqqUBa4tBq5YzC3AFvd9Aj+WNomHM89hTFpPqhQOBc+gS08Orw43Js0K8rtz2OSmjERgU+0geIOiidS8muiTqmIXYB1o1QI8/Q/Ny6evaKjrl6DykFcoCSczfW83ICGiSgNPhDh8GTv9OJqcn51NDr/fnbwkWBHlJMk8x+IdnR4sjc5vjz8EMCuQz5Pn4IsZQpFv2FP92BVXysVPZJqHk5k96Du4XzuQ+iXlNFEuna1wnDSeZfxzvuMDy/fY3woeRxdxzp5EX0NjJcyGC0mr1rBxj5UWD+sjkYLRTo5nftRQVOeGqp6C/5WlWGT9bh6uT4udIDyVqlNp/eXepD1qVW6zjP95mm3eVWvebnTrNBnVuoyjXL1h0Fxefr3Y2OkgFevH5AyNJH5y2c5h43tWrO2o80Dp7sZhj9ZNIc5NBmW6jCeGwrjOYH5r3UNb5HUYF/rjIc7rfLRnYDdIhZ8WfJflKQGaQ07s5jbAWZa291pgfyTo1zaAJ/fUsXJQyIWtndP3E2M8U4LLpefNM7vBc3/Aw) for comparison in behavior.

I tried to add rendering tests for this but it was difficult to because of the globe. Even if the `Model` is positioned very high, the globe still peeks over the horizon. Then, `globe.show` to false disables the clamp-to-ground behavior, so I can't prevent it from rendering during the unit test.