### PR TITLE
10445 update default documented value for Scene.highDynamicRange

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -325,3 +325,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [四季留歌](https://github.com/onsummer)
 - [Yuri Chen](https://github.com/yurichen17)
 - [David Ferguson](https://github.com/jdfwarrior)
+- [Karthik Vaithin](https://github.com/kvaithin)

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1550,7 +1550,7 @@ Object.defineProperties(Scene.prototype, {
    * Whether or not to use high dynamic range rendering.
    * @memberof Scene.prototype
    * @type {Boolean}
-   * @default true
+   * @default false
    */
   highDynamicRange: {
     get: function () {


### PR DESCRIPTION
Closes: #10445 

Updated the documented default value to be false for Scene.highDynamicRange.