### PR TITLE
Only build-ts once in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ script:
   - npm --silent run prettier-check
 
   - npm --silent run build
-  - npm --silent run build-ts
   - npm --silent run coverage -- --browsers FirefoxHeadless --webgl-stub --failTaskOnError --suppressPassed
 
   - travis_wait 20 npm --silent run makeZipFile -- --concurrency 1


### PR DESCRIPTION
It looks like we're currently running `build-ts` twice in CI. Once by itself and once as part of `makeZipFile`. It's not a dependency for any task that comes after it, so I don't see why we shouldn't remove the first run.