### PR TITLE
Fix broken links in CesiumTerrainProvider docs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
 ##### Fixes :wrench:
 
 - Fixed `FeatureDetection` for Microsoft Edge. [#10429](https://github.com/CesiumGS/cesium/pull/10429)
+- Fixed broken links in documentation of `CesiumTerrainProvider`. [#7478](https://github.com/CesiumGS/cesium/issues/7478)
 
 ### 1.94.3 - 2022-06-10
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -158,6 +158,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
   - [Janine Liu](https://github.com/j9liu)
   - [Sam Rothstein](https://github.com/srothst1)
   - [Daniel Krupka](https://github.com/krupkad)
+  - [Jeshurun Hembd](https://github.com/jjhembd)
 - [Northrop Grumman](http://www.northropgrumman.com)
   - [Joseph Stein](https://github.com/nahgrin)
 - [EOX IT Services GmbH](https://eox.at)

--- a/Source/Core/CesiumTerrainProvider.js
+++ b/Source/Core/CesiumTerrainProvider.js
@@ -39,6 +39,11 @@ function LayerInformation(layer) {
 
 /**
  * A {@link TerrainProvider} that accesses terrain data in a Cesium terrain format.
+ * Terrain formats can be one of the following:
+ * <ul>
+ * <li> {@link https://github.com/AnalyticalGraphicsInc/quantized-mesh Quantized Mesh} </li>
+ * <li> {@link https://github.com/AnalyticalGraphicsInc/cesium/wiki/heightmap-1.0 Height Map} </li>
+ * </ul>
  *
  * @alias CesiumTerrainProvider
  * @constructor


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/7478

Added a comment to the constructor doc linking to references on the accepted terrain formats.