### PR TITLE
Improve initial view in custom shaders sandcastle

### DIFF
--- a/Apps/Sandcastle/gallery/Custom Shaders 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/Custom Shaders 3D Tiles.html
@@ -61,7 +61,21 @@
           }),
         });
         viewer.scene.primitives.add(tileset);
-        viewer.zoomTo(tileset);
+        const initialPosition = Cesium.Cartesian3.fromDegrees(
+          -74.01881302800248,
+          40.69114333714821,
+          753
+        );
+        const initialOrientation = new Cesium.HeadingPitchRoll.fromDegrees(
+          21.27879878293835,
+          -21.34390550872461,
+          0.0716951918898415
+        );
+        viewer.scene.camera.setView({
+          destination: initialPosition,
+          orientation: initialOrientation,
+          endTransform: Cesium.Matrix4.IDENTITY,
+        });
 
         //Sandcastle_End
         Sandcastle.finishedLoading();


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/10454. The initial view position was modified to give a prettier view of the south end of Manhattan, which makes more of the interesting features visible.