### PR TITLE
Warn if Cesium3DTile content.uri is empty, and load empty tile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 
 - Fixed `FeatureDetection` for Microsoft Edge. [#10429](https://github.com/CesiumGS/cesium/pull/10429)
 - Fixed broken links in documentation of `CesiumTerrainProvider`. [#7478](https://github.com/CesiumGS/cesium/issues/7478)
+- Warn if `Cesium3DTile` content.uri property is empty, and load empty tile. [#7263](https://github.com/CesiumGS/cesium/issues/7263)
 
 ### 1.94.3 - 2022-06-10
 

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -229,13 +229,23 @@ function Cesium3DTile(tileset, baseResource, header, parent) {
       );
       contentHeaderUri = contentHeader.url;
     }
-    contentState = Cesium3DTileContentState.UNLOADED;
-    contentResource = baseResource.getDerivedResource({
-      url: contentHeaderUri,
-    });
-    serverKey = RequestScheduler.getServerKey(
-      contentResource.getUrlComponent()
-    );
+    if (contentHeaderUri === "") {
+      Cesium3DTile._deprecationWarning(
+        "contentUriEmpty",
+        "content.uri property is an empty string, which creates a circular dependency, making this tileset invalid. Omit the content property instead"
+      );
+      content = new Empty3DTileContent(tileset, this);
+      hasEmptyContent = true;
+      contentState = Cesium3DTileContentState.READY;
+    } else {
+      contentState = Cesium3DTileContentState.UNLOADED;
+      contentResource = baseResource.getDerivedResource({
+        url: contentHeaderUri,
+      });
+      serverKey = RequestScheduler.getServerKey(
+        contentResource.getUrlComponent()
+      );
+    }
   } else {
     content = new Empty3DTileContent(tileset, this);
     hasEmptyContent = true;

--- a/Specs/Scene/Cesium3DTileSpec.js
+++ b/Specs/Scene/Cesium3DTileSpec.js
@@ -1,4 +1,4 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
+import { Cartesian3, Empty3DTileContent } from "../../Source/Cesium.js";
 import { clone } from "../../Source/Cesium.js";
 import { HeadingPitchRoll } from "../../Source/Cesium.js";
 import { Math as CesiumMath } from "../../Source/Cesium.js";
@@ -60,6 +60,18 @@ describe(
         boundingVolume: {
           region: [-1.2, -1.2, 0, 0, -30, -34],
         },
+      },
+      boundingVolume: {
+        region: [-1.2, -1.2, 0, 0, -30, -34],
+      },
+    };
+
+    const tileWithEmptyContentUri = {
+      geometricError: 1,
+      refine: "REPLACE",
+      children: [],
+      content: {
+        uri: "",
       },
       boundingVolume: {
         region: [-1.2, -1.2, 0, 0, -30, -34],
@@ -172,6 +184,20 @@ describe(
         undefined
       );
       expect(tile.refine).toBe(Cesium3DTileRefine.REPLACE);
+      expect(Cesium3DTile._deprecationWarning).toHaveBeenCalled();
+    });
+
+    it("logs deprecation warning and loads empty tile if content.uri is an empty string", function () {
+      spyOn(Cesium3DTile, "_deprecationWarning");
+      const header = clone(tileWithEmptyContentUri, true);
+      const tile = new Cesium3DTile(
+        mockTileset,
+        "/some_url",
+        header,
+        undefined
+      );
+      expect(tile.content).toBeDefined();
+      expect(tile.content).toBeInstanceOf(Empty3DTileContent);
       expect(Cesium3DTile._deprecationWarning).toHaveBeenCalled();
     });
 


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/7263.
If `content.uri` is empty, print a warning to the console, and load an empty tile