### PR TITLE
Remove obsolete git configuration from recommended settings

### DIFF
--- a/Documentation/Contributors/BuildGuide/README.md
+++ b/Documentation/Contributors/BuildGuide/README.md
@@ -40,7 +40,6 @@ _NOTE: If you change branches, you might have to rebuild._
   - Make sure your SSH keys are configured ([linux](https://help.github.com/articles/generating-ssh-keys#platform-linux) | [mac](https://help.github.com/articles/generating-ssh-keys#platform-mac) | [windows](https://help.github.com/articles/generating-ssh-keys#platform-windows)).
   - Double-check your settings for name and email: `git config --get-regexp user.*`.
   - Recommended Git settings:
-    - `git config --global pull.rebase preserve` - when pulling remote changes, rebase your local changes on top of the remote changes, to avoid unnecessary merge commits.
     - `git config --global fetch.prune true` - when fetching remote changes, remove any remote branches that no longer exist on the remote.
 - Have [commit access](https://github.com/CesiumGS/cesium/blob/main/Documentation/Contributors/CommittersGuide/README.md) to CesiumJS?
   - No


### PR DESCRIPTION
This PR changes BuildGuide to remove an obsolete git configuration.

The BuildGuide was recommending the following git setting:
```bash
git config --global pull.rebase preserve
```

This value was recommended to avoid unnecessary merge commits. But the [documentation](https://git-scm.com/docs/git-config#Documentation/git-config.txt-pullrebase) shows that this value should now be either `true` or `false`. It warns that setting it to `true` is "possibly dangerous"