### PR TITLE
Remove unused parameter in `InstancingPipelineStage`

### DIFF
--- a/Source/Scene/ModelExperimental/InstancingPipelineStage.js
+++ b/Source/Scene/ModelExperimental/InstancingPipelineStage.js
@@ -660,8 +660,7 @@ function processTransformAttributes(
     transforms = getInstanceTransformsAsMatrices(
       instances,
       count,
-      renderResources,
-      use2D
+      renderResources
     );
 
     const transformsTypedArray = transformsToTypedArray(transforms);


### PR DESCRIPTION
In #10433, I unknowingly left an unused parameter in a function call, after refactoring the function to not need it anymore. This PR removes it.

@ptrgags can you take a look?