### PR TITLE
Add support for `AGI_articulations` to `ModelExperimental`

### DIFF
--- a/Source/Core/ArticulationMotionType.js
+++ b/Source/Core/ArticulationMotionType.js
@@ -1,0 +1,23 @@
+/**
+ * An enum describing the type of motion that is defined by an articulation stage
+ * in the AGI_articulations extension.
+ *
+ * @alias {ArticulationMotionType}
+ * @enum {String}
+ *
+ * @private
+ */
+const ArticulationMotionType = {
+  XTRANSLATE: "xTranslate",
+  YTRANSLATE: "yTranslate",
+  ZTRANSLATE: "zTranslate",
+  XROTATE: "xRotate",
+  YROTATE: "yRotate",
+  ZROTATE: "zRotate",
+  XSCALE: "xScale",
+  YSCALE: "yScale",
+  ZSCALE: "zScale",
+  UNIFORMSCALE: "uniformScale",
+};
+
+export default Object.freeze(ArticulationMotionType);

--- a/Source/Core/ArticulationStageType.js
+++ b/Source/Core/ArticulationStageType.js
@@ -2,12 +2,12 @@
  * An enum describing the type of motion that is defined by an articulation stage
  * in the AGI_articulations extension.
  *
- * @alias {ArticulationMotionType}
+ * @alias {ArticulationStageType}
  * @enum {String}
  *
  * @private
  */
-const ArticulationMotionType = {
+const ArticulationStageType = {
   XTRANSLATE: "xTranslate",
   YTRANSLATE: "yTranslate",
   ZTRANSLATE: "zTranslate",
@@ -20,4 +20,4 @@ const ArticulationMotionType = {
   UNIFORMSCALE: "uniformScale",
 };
 
-export default Object.freeze(ArticulationMotionType);
+export default Object.freeze(ArticulationStageType);

--- a/Source/Scene/GltfLoader.js
+++ b/Source/Scene/GltfLoader.js
@@ -1,5 +1,5 @@
 import arrayFill from "../Core/arrayFill.js";
-import ArticulationMotionType from "../Core/ArticulationMotionType.js";
+import ArticulationStageType from "../Core/ArticulationStageType.js";
 import AttributeType from "./AttributeType.js";
 import Axis from "./Axis.js";
 import Cartesian3 from "../Core/Cartesian3.js";
@@ -1826,7 +1826,7 @@ function loadArticulationStage(gltfStage) {
   stage.name = gltfStage.name;
 
   const type = gltfStage.type.toUpperCase();
-  stage.type = ArticulationMotionType[type];
+  stage.type = ArticulationStageType[type];
 
   stage.minimumValue = gltfStage.minimumValue;
   stage.maximumValue = gltfStage.maximumValue;
@@ -1862,8 +1862,11 @@ function loadArticulations(gltf) {
   }
 
   const gltfArticulations = articulationsExtension.articulations;
-  const gltfArticulationsLength = gltfArticulations.length;
+  if (!defined(gltfArticulations)) {
+    return [];
+  }
 
+  const gltfArticulationsLength = gltfArticulations.length;
   const articulations = new Array(gltfArticulationsLength);
   for (let i = 0; i < gltfArticulationsLength; i++) {
     const articulation = loadArticulation(gltfArticulations[i]);

--- a/Source/Scene/ModelComponents.js
+++ b/Source/Scene/ModelComponents.js
@@ -979,9 +979,9 @@ function ArticulationStage() {
   this.name = undefined;
 
   /**
-   * The type of motion being modified by the articulation stage.
+   * The type of the articulation stage, defined by the type of motion it modifies.
    *
-   * @type {ArticulationMotionType}
+   * @type {ArticulationStageType}
    * @private
    */
   this.type = undefined;

--- a/Source/Scene/ModelComponents.js
+++ b/Source/Scene/ModelComponents.js
@@ -794,6 +794,15 @@ function Node() {
    * @private
    */
   this.morphWeights = [];
+
+  /**
+   * The name of the articulation affecting this node, as defined by the
+   * AGI_articulations extension.
+   *
+   * @type {String}
+   * @private
+   */
+  this.articulationName = undefined;
 }
 
 /**
@@ -952,29 +961,8 @@ function Animation() {
 }
 
 /**
- * The motion of the node that is targeted by an articulation stage. The values of
- * this enum are used to modify the appropriate property on the runtime node.
- *
- * @alias {ModelComponents.ArticulationMotionType}
- * @enum {String}
- *
- * @private
- */
-const ArticulationMotionType = {
-  XTRANSLATE: "xTranslate",
-  YTRANSLATE: "yTranslate",
-  ZTRANSLATE: "zTranslate",
-  XROTATE: "xRotate",
-  YROTATE: "yRotate",
-  ZROTATE: "zRotate",
-  XSCALE: "xScale",
-  YSCALE: "yScale",
-  ZSCALE: "zScale",
-  UNIFORMSCALE: "uniformScale",
-};
-
-/**
- * An articulation stage belonging to an articulation from the AGI_articulations extension.
+ * An articulation stage belonging to an articulation from the
+ * AGI_articulations extension.
  *
  * @alias {ModelComponents.ArticulationStage}
  * @constructor
@@ -993,7 +981,7 @@ function ArticulationStage() {
   /**
    * The type of motion being modified by the articulation stage.
    *
-   * @type {ModelComponents.ArticulationMotionType}
+   * @type {ArticulationMotionType}
    * @private
    */
   this.type = undefined;
@@ -1024,7 +1012,7 @@ function ArticulationStage() {
 }
 
 /**
- * An articulation for the model, as specified in the AGI_articulations extension.
+ * An articulation for the model, as defined by the AGI_articulations extension.
  *
  * @alias {ModelComponents.Articulation}
  * @constructor
@@ -1040,9 +1028,9 @@ function Articulation() {
    */
   this.name = undefined;
 
-  // TODO: update
   /**
-   * The stages belonging to this articulation.
+   * The stages belonging to this articulation. The stages are applied to
+   * the model in order of appearance.
    *
    * @type {ModelComponents.ArticulationStage[]}
    * @private
@@ -1116,10 +1104,8 @@ function Components() {
 
   /**
    * All articulations in the model as defined by the AGI_articulations extension.
-   * These are stored in a dictionary where the key is the name of the articulation,
-   * and the value is the parsed articulation component.
    *
-   * @type {Object}
+   * @type {ModelComponents.Articulation[]}
    */
   this.articulations = [];
 
@@ -1468,7 +1454,6 @@ ModelComponents.AnimationSampler = AnimationSampler;
 ModelComponents.AnimationTarget = AnimationTarget;
 ModelComponents.AnimationChannel = AnimationChannel;
 ModelComponents.Animation = Animation;
-ModelComponents.ArticulationMotionType = Object.freeze(ArticulationMotionType);
 ModelComponents.ArticulationStage = ArticulationStage;
 ModelComponents.Articulation = Articulation;
 ModelComponents.Asset = Asset;

--- a/Source/Scene/ModelComponents.js
+++ b/Source/Scene/ModelComponents.js
@@ -952,6 +952,105 @@ function Animation() {
 }
 
 /**
+ * The motion of the node that is targeted by an articulation stage. The values of
+ * this enum are used to modify the appropriate property on the runtime node.
+ *
+ * @alias {ModelComponents.ArticulationMotionType}
+ * @enum {String}
+ *
+ * @private
+ */
+const ArticulationMotionType = {
+  XTRANSLATE: "xTranslate",
+  YTRANSLATE: "yTranslate",
+  ZTRANSLATE: "zTranslate",
+  XROTATE: "xRotate",
+  YROTATE: "yRotate",
+  ZROTATE: "zRotate",
+  XSCALE: "xScale",
+  YSCALE: "yScale",
+  ZSCALE: "zScale",
+  UNIFORMSCALE: "uniformScale",
+};
+
+/**
+ * An articulation stage belonging to an articulation from the AGI_articulations extension.
+ *
+ * @alias {ModelComponents.ArticulationStage}
+ * @constructor
+ *
+ * @private
+ */
+function ArticulationStage() {
+  /**
+   * The name of the articulation stage.
+   *
+   * @type {String}
+   * @private
+   */
+  this.name = undefined;
+
+  /**
+   * The type of motion being modified by the articulation stage.
+   *
+   * @type {ModelComponents.ArticulationMotionType}
+   * @private
+   */
+  this.type = undefined;
+
+  /**
+   * The minimum value for the range of motion of this articulation stage.
+   *
+   * @type {Number}
+   * @private
+   */
+  this.minimumValue = undefined;
+
+  /**
+   * The maximum value for the range of motion of this articulation stage.
+   *
+   * @type {Number}
+   * @private
+   */
+  this.maximumValue = undefined;
+
+  /**
+   * The initial value for this articulation stage.
+   *
+   * @type {Number}
+   * @private
+   */
+  this.initialValue = undefined;
+}
+
+/**
+ * An articulation for the model, as specified in the AGI_articulations extension.
+ *
+ * @alias {ModelComponents.Articulation}
+ * @constructor
+ *
+ * @private
+ */
+function Articulation() {
+  /**
+   * The name of the articulation.
+   *
+   * @type {String}
+   * @private
+   */
+  this.name = undefined;
+
+  // TODO: update
+  /**
+   * The stages belonging to this articulation.
+   *
+   * @type {ModelComponents.ArticulationStage[]}
+   * @private
+   */
+  this.stages = [];
+}
+
+/**
  * The asset of the model.
  *
  * @alias {ModelComponents.Asset}
@@ -1014,6 +1113,15 @@ function Components() {
    * @type {ModelComponents.Animation[]}
    */
   this.animations = [];
+
+  /**
+   * All articulations in the model as defined by the AGI_articulations extension.
+   * These are stored in a dictionary where the key is the name of the articulation,
+   * and the value is the parsed articulation component.
+   *
+   * @type {Object}
+   */
+  this.articulations = [];
 
   /**
    * Structural metadata containing the schema, property tables, property
@@ -1360,6 +1468,9 @@ ModelComponents.AnimationSampler = AnimationSampler;
 ModelComponents.AnimationTarget = AnimationTarget;
 ModelComponents.AnimationChannel = AnimationChannel;
 ModelComponents.Animation = Animation;
+ModelComponents.ArticulationMotionType = Object.freeze(ArticulationMotionType);
+ModelComponents.ArticulationStage = ArticulationStage;
+ModelComponents.Articulation = Articulation;
 ModelComponents.Asset = Asset;
 ModelComponents.Components = Components;
 ModelComponents.TextureReader = TextureReader;

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -1214,6 +1214,51 @@ Object.defineProperties(ModelExperimental.prototype, {
 });
 
 /**
+ * Sets the current value of an articulation stage.  After setting one or multiple stage values, call
+ * ModelExperimental.applyArticulations() to cause the node matrices to be recalculated.
+ *
+ * @param {String} articulationStageKey The name of the articulation, a space, and the name of the stage.
+ * @param {Number} value The numeric value of this stage of the articulation.
+ *
+ * @exception {DeveloperError} The model is not loaded. Use ModelExperimental.readyPromise or wait for ModelExperimental.ready to be true.
+ *
+ * @see ModelExperimental#applyArticulations
+ */
+ModelExperimental.prototype.setArticulationStage = function (
+  articulationStageKey,
+  value
+) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.number("value", value);
+  if (!this._ready) {
+    throw new DeveloperError(
+      "The model is not loaded. Use ModelExperimental.readyPromise or wait for ModelExperimental.ready to be true."
+    );
+  }
+  //>>includeEnd('debug');
+
+  this._sceneGraph.setArticulationStage(articulationStageKey, value);
+};
+
+/**
+ * Applies any modified articulation stages to the matrix of each node that participates
+ * in any articulation.  Note that this will overwrite any nodeTransformations on participating nodes.
+ *
+ * @exception {DeveloperError} The model is not loaded. Use ModelExperimental.readyPromise or wait for ModelExperimental.ready to be true.
+ */
+ModelExperimental.prototype.applyArticulations = function () {
+  //>>includeStart('debug', pragmas.debug);
+  if (!this._ready) {
+    throw new DeveloperError(
+      "The model is not loaded. Use ModelExperimental.readyPromise or wait for ModelExperimental.ready to be true."
+    );
+  }
+  //>>includeEnd('debug');
+
+  this._sceneGraph.applyArticulations();
+};
+
+/**
  * Resets the draw commands for this model.
  *
  * @private

--- a/Source/Scene/ModelExperimental/ModelExperimentalArticulation.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalArticulation.js
@@ -1,0 +1,188 @@
+import Check from "../../Core/Check.js";
+import defaultValue from "../../Core/defaultValue.js";
+import defined from "../../Core/defined.js";
+import Matrix4 from "../../Core/Matrix4.js";
+import ModelExperimentalArticulationStage from "./ModelExperimentalArticulationStage.js";
+
+/**
+ * An in-memory representation of an articulation that affects nodes in the
+ * {@link ModelExperimentalSceneGraph}. This is defined in a model by the
+ * <code>AGI_articulations</code> extension.
+ *
+ * @param {Object} options An object containing the following options:
+ * @param {ModelComponents.Articulation} options.articulation The articulation components from the 3D model.
+ * @param {ModelExperimentalSceneGraph} options.sceneGraph The scene graph this articulation belongs to.
+ *
+ * @alias ModelExperimentalArticulation
+ * @constructor
+ *
+ * @private
+ */
+export default function ModelExperimentalArticulation(options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+
+  const articulation = options.articulation;
+  const sceneGraph = options.sceneGraph;
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.articulation", articulation);
+  Check.typeOf.object("options.sceneGraph", sceneGraph);
+  //>>includeEnd('debug');
+
+  this._articulation = articulation;
+  this._sceneGraph = sceneGraph;
+
+  this._name = undefined;
+  this._runtimeStages = [];
+  this._runtimeStagesByName = {};
+  this._runtimeNodes = [];
+
+  this._dirty = false;
+
+  initialize(this);
+}
+
+Object.defineProperties(ModelExperimentalArticulation.prototype, {
+  /**
+   * The internal articulation that this runtime articulation represents.
+   *
+   * @memberof ModelExperimentalArticulation.prototype
+   * @type {ModelComponents.Articulation}
+   * @readonly
+   *
+   * @private
+   */
+  articulation: {
+    get: function () {
+      return this._articulation;
+    },
+  },
+
+  /**
+   * The scene graph that this articulation belongs to.
+   *
+   * @memberof ModelExperimentalArticulation.prototype
+   * @type {ModelExperimentalSceneGraph}
+   * @readonly
+   *
+   * @private
+   */
+  sceneGraph: {
+    get: function () {
+      return this._sceneGraph;
+    },
+  },
+
+  /**
+   * The name of this articulation.
+   *
+   * @memberof ModelExperimentalArticulation.prototype
+   * @type {String}
+   * @readonly
+   *
+   * @private
+   */
+  name: {
+    get: function () {
+      return this._name;
+    },
+  },
+
+  /**
+   * The runtime nodes that are affected by this articulation.
+   *
+   * @memberof ModelExperimentalArticulation.prototype
+   * @type {ModelExperimentalNode[]}
+   * @readonly
+   *
+   * @private
+   */
+  runtimeNodes: {
+    get: function () {
+      return this._runtimeNodes;
+    },
+  },
+});
+
+function initialize(runtimeArticulation) {
+  const articulation = runtimeArticulation.articulation;
+  runtimeArticulation._name = articulation.name;
+
+  const stages = articulation.stages;
+  const length = stages.length;
+
+  const runtimeStages = runtimeArticulation._runtimeStages;
+  const runtimeStagesByName = runtimeArticulation._runtimeStagesByName;
+  for (let i = 0; i < length; i++) {
+    const stage = stages[i];
+    const runtimeStage = new ModelExperimentalArticulationStage({
+      stage: stage,
+      runtimeArticulation: runtimeArticulation,
+    });
+
+    // Store the stages in an array to preserve the order in which
+    // they appeared in the 3D model.
+    runtimeStages.push(runtimeStage);
+
+    // Store the stages in a dictionary for retrieval by name.
+    const stageName = stage.name;
+    runtimeStagesByName[stageName] = runtimeStage;
+  }
+}
+
+/**
+ * Sets the current value of an articulation stage.
+ *
+ * @param {String} stageName The name of the articulation stage.
+ * @param {Number} value The numeric value of this stage of the articulation.
+ *
+ * @private
+ */
+ModelExperimentalArticulation.prototype.setArticulationStage = function (
+  stageName,
+  value
+) {
+  const stage = this._runtimeStagesByName[stageName];
+  if (defined(stage)) {
+    stage.currentValue = value;
+  }
+};
+
+const scratchArticulationMatrix = new Matrix4();
+const scratchNodeMatrix = new Matrix4();
+
+/**
+ * Applies the chain of articulation stages to the matrix of each node that
+ * participates in any articulation. Note that this will overwrite any existing
+ * transformations on participating nodes.
+ *
+ * @private
+ */
+ModelExperimentalArticulation.prototype.applyArticulation = function () {
+  let articulationMatrix = Matrix4.clone(
+    Matrix4.IDENTITY,
+    scratchArticulationMatrix
+  );
+
+  let i;
+  const stages = this._runtimeStages;
+  const stagesLength = stages.length;
+
+  // Compute the result of the articulation stages...
+  for (i = 0; i < stagesLength; i++) {
+    const stage = stages[i];
+    articulationMatrix = stage.applyStageToMatrix(articulationMatrix);
+  }
+
+  // ...then apply it to the transforms of the affected nodes.
+  const nodes = this._runtimeNodes;
+  const nodesLength = nodes.length;
+  for (i = 0; i < nodesLength; i++) {
+    const node = nodes[i];
+    const transform = Matrix4.multiplyTransformation(
+      node.originalTransform,
+      articulationMatrix,
+      scratchNodeMatrix
+    );
+    node.transform = transform;
+  }
+};

--- a/Source/Scene/ModelExperimental/ModelExperimentalArticulationStage.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalArticulationStage.js
@@ -1,0 +1,261 @@
+import ArticulationStageType from "../../Core/ArticulationStageType.js";
+import Cartesian3 from "../../Core/Cartesian3.js";
+import CesiumMath from "../../Core/Math.js";
+import Check from "../../Core/Check.js";
+import defaultValue from "../../Core/defaultValue.js";
+import Matrix3 from "../../Core/Matrix3";
+import Matrix4 from "../../Core/Matrix4.js";
+
+const articulationEpsilon = CesiumMath.EPSILON16;
+
+/**
+ * An in-memory representation of an articulation stage belonging to a
+ * {@link ModelExperimentalArticulation}. that affects nodes
+ * in the {@link ModelExperimentalSceneGraph}.
+ *
+ * @param {Object} options An object containing the following options:
+ * @param {ModelComponents.ArticulationStage} options.stage The articulation stage components from the 3D model.
+ * @param {ModelExperimentalArticulation} options.runtimeArticulation The runtime articulation that this stage belongs to.
+ *
+ * @alias ModelExperimentalArticulationStage
+ * @constructor
+ *
+ * @private
+ */
+export default function ModelExperimentalArticulationStage(options) {
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+
+  const stage = options.stage;
+  const runtimeArticulation = options.runtimeArticulation;
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("options.stage", stage);
+  Check.typeOf.object("options.runtimeArticulation", runtimeArticulation);
+  //>>includeEnd('debug');
+
+  this._stage = stage;
+  this._runtimeArticulation = runtimeArticulation;
+
+  this._name = stage.name;
+  this._type = stage.type;
+  this._minimumValue = stage.minimumValue;
+  this._maximumValue = stage.maximumValue;
+  this._currentValue = stage.initialValue;
+}
+
+Object.defineProperties(ModelExperimentalArticulationStage.prototype, {
+  /**
+   * The internal articulation stage that this runtime stage represents.
+   *
+   * @memberof ModelExperimentalArticulationStage.prototype
+   * @type {ModelComponents.ArticulationStage}
+   * @readonly
+   *
+   * @private
+   */
+  stage: {
+    get: function () {
+      return this._stage;
+    },
+  },
+
+  /**
+   * The runtime articulation that this stage belongs to.
+   *
+   * @memberof ModelExperimentalArticulationStage.prototype
+   * @type {ModelExperimentalArticulation}
+   * @readonly
+   *
+   * @private
+   */
+  runtimeArticulation: {
+    get: function () {
+      return this._runtimeArticulation;
+    },
+  },
+
+  /**
+   * The name of this articulation stage.
+   *
+   * @memberof ModelExperimentalArticulationStage.prototype
+   * @type {String}
+   * @readonly
+   *
+   * @private
+   */
+  name: {
+    get: function () {
+      return this._name;
+    },
+  },
+
+  /**
+   * The type of this articulation stage. This specifies which of the
+   * node's properties is modified by the stage's value.
+   *
+   * @memberof ModelExperimentalArticulationStage.prototype
+   * @type {ArticulationStageType}
+   * @readonly
+   *
+   * @private
+   */
+  type: {
+    get: function () {
+      return this._type;
+    },
+  },
+
+  /**
+   * The minimum value of this articulation stage.
+   *
+   * @memberof ModelExperimentalArticulationStage.prototype
+   * @type {Number}
+   * @readonly
+   *
+   * @private
+   */
+  minimumValue: {
+    get: function () {
+      return this._minimumValue;
+    },
+  },
+
+  /**
+   * The maximum value of this articulation stage.
+   *
+   * @memberof ModelExperimentalArticulationStage.prototype
+   * @type {Number}
+   * @readonly
+   *
+   * @private
+   */
+  maximumValue: {
+    get: function () {
+      return this._maximumValue;
+    },
+  },
+
+  /**
+   * The current value of this articulation stage.
+   *
+   * @memberof ModelExperimentalArticulationStage.prototype
+   * @type {Number}
+   *
+   * @private
+   */
+  currentValue: {
+    get: function () {
+      return this._currentValue;
+    },
+    set: function (value) {
+      //>>includeStart('debug', pragmas.debug);
+      Check.typeOf.number("value", value);
+      //>>includeEnd('debug');
+
+      value = CesiumMath.clamp(value, this.minimumValue, this.maximumValue);
+      if (
+        !CesiumMath.equalsEpsilon(
+          this._currentValue,
+          value,
+          articulationEpsilon
+        )
+      ) {
+        this._currentValue = value;
+        this.runtimeArticulation._dirty = true;
+      }
+    },
+  },
+});
+
+const scratchArticulationCartesian = new Cartesian3();
+const scratchArticulationRotation = new Matrix3();
+
+/**
+ * Modifies a Matrix4 by applying a transformation for a given value of a stage.
+ * Note this is different usage from the typical <code>result</code> parameter,
+ * in that the incoming value of <code>result</code> is meaningful. Various stages
+ * of an articulation can be multiplied together, so their transformations are
+ * all merged into a composite Matrix4 representing them all.
+ *
+ * @param {Matrix4} result The matrix to be modified.
+ * @returns {Matrix4} The transformed matrix as requested by the articulation stage.
+ *
+ * @private
+ */
+ModelExperimentalArticulationStage.prototype.applyStageToMatrix = function (
+  result
+) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.object("result", result);
+  //>>includeEnd('debug');
+
+  const type = this.type;
+  const value = this.currentValue;
+  const cartesian = scratchArticulationCartesian;
+  let rotation;
+  switch (type) {
+    case ArticulationStageType.XROTATE:
+      rotation = Matrix3.fromRotationX(
+        CesiumMath.toRadians(value),
+        scratchArticulationRotation
+      );
+      Matrix4.multiplyByMatrix3(result, rotation, result);
+      break;
+    case ArticulationStageType.YROTATE:
+      rotation = Matrix3.fromRotationY(
+        CesiumMath.toRadians(value),
+        scratchArticulationRotation
+      );
+      Matrix4.multiplyByMatrix3(result, rotation, result);
+      break;
+    case ArticulationStageType.ZROTATE:
+      rotation = Matrix3.fromRotationZ(
+        CesiumMath.toRadians(value),
+        scratchArticulationRotation
+      );
+      Matrix4.multiplyByMatrix3(result, rotation, result);
+      break;
+    case ArticulationStageType.XTRANSLATE:
+      cartesian.x = value;
+      cartesian.y = 0.0;
+      cartesian.z = 0.0;
+      Matrix4.multiplyByTranslation(result, cartesian, result);
+      break;
+    case ArticulationStageType.YTRANSLATE:
+      cartesian.x = 0.0;
+      cartesian.y = value;
+      cartesian.z = 0.0;
+      Matrix4.multiplyByTranslation(result, cartesian, result);
+      break;
+    case ArticulationStageType.ZTRANSLATE:
+      cartesian.x = 0.0;
+      cartesian.y = 0.0;
+      cartesian.z = value;
+      Matrix4.multiplyByTranslation(result, cartesian, result);
+      break;
+    case ArticulationStageType.XSCALE:
+      cartesian.x = value;
+      cartesian.y = 1.0;
+      cartesian.z = 1.0;
+      Matrix4.multiplyByScale(result, cartesian, result);
+      break;
+    case ArticulationStageType.YSCALE:
+      cartesian.x = 1.0;
+      cartesian.y = value;
+      cartesian.z = 1.0;
+      Matrix4.multiplyByScale(result, cartesian, result);
+      break;
+    case ArticulationStageType.ZSCALE:
+      cartesian.x = 1.0;
+      cartesian.y = 1.0;
+      cartesian.z = value;
+      Matrix4.multiplyByScale(result, cartesian, result);
+      break;
+    case ArticulationStageType.UNIFORMSCALE:
+      Matrix4.multiplyByUniformScale(result, value, result);
+      break;
+    default:
+      break;
+  }
+
+  return result;
+};

--- a/Source/Scene/ModelExperimental/ModelExperimentalArticulationStage.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalArticulationStage.js
@@ -3,15 +3,14 @@ import Cartesian3 from "../../Core/Cartesian3.js";
 import CesiumMath from "../../Core/Math.js";
 import Check from "../../Core/Check.js";
 import defaultValue from "../../Core/defaultValue.js";
-import Matrix3 from "../../Core/Matrix3";
+import Matrix3 from "../../Core/Matrix3.js";
 import Matrix4 from "../../Core/Matrix4.js";
 
 const articulationEpsilon = CesiumMath.EPSILON16;
 
 /**
  * An in-memory representation of an articulation stage belonging to a
- * {@link ModelExperimentalArticulation}. that affects nodes
- * in the {@link ModelExperimentalSceneGraph}.
+ * {@link ModelExperimentalArticulation}.
  *
  * @param {Object} options An object containing the following options:
  * @param {ModelComponents.ArticulationStage} options.stage The articulation stage components from the 3D model.

--- a/Source/Scene/ModelExperimental/ModelExperimentalNode.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalNode.js
@@ -62,11 +62,6 @@ export default function ModelExperimentalNode(options) {
   this._runtimeSkin = undefined;
   this._computedJointMatrices = [];
 
-  // Used for the AGI_articulations extension
-  this._runtimeArticulation = undefined;
-
-  initialize(this);
-
   /**
    * Pipeline stages to apply across all the mesh primitives of this node. This
    * is an array of classes, each with a static method called
@@ -119,6 +114,8 @@ export default function ModelExperimentalNode(options) {
    * @private
    */
   this.instancingTranslationBuffer2D = undefined;
+
+  initialize(this);
 }
 
 Object.defineProperties(ModelExperimentalNode.prototype, {
@@ -436,10 +433,12 @@ function initialize(runtimeNode) {
     runtimeNode._morphWeights = node.morphWeights.slice();
   }
 
+  // If this node is affected by an articulation from the AGI_articulations
+  // extension, add this node to its list of affected nodes.
   const articulationName = node.articulationName;
   if (defined(articulationName)) {
     const sceneGraph = runtimeNode.sceneGraph;
-    const runtimeArticulations = sceneGraph.runtimeArticulations;
+    const runtimeArticulations = sceneGraph._runtimeArticulations;
 
     const runtimeArticulation = runtimeArticulations[articulationName];
     if (defined(runtimeArticulation)) {

--- a/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalSceneGraph.js
@@ -6,6 +6,7 @@ import defaultValue from "../../Core/defaultValue.js";
 import defined from "../../Core/defined.js";
 import ImageBasedLightingPipelineStage from "./ImageBasedLightingPipelineStage.js";
 import Matrix4 from "../../Core/Matrix4.js";
+import ModelExperimentalArticulation from "./ModelExperimentalArticulation.js";
 import ModelColorPipelineStage from "./ModelColorPipelineStage.js";
 import ModelClippingPlanesPipelineStage from "./ModelClippingPlanesPipelineStage.js";
 import ModelExperimentalPrimitive from "./ModelExperimentalPrimitive.js";
@@ -154,6 +155,10 @@ export default function ModelExperimentalSceneGraph(options) {
     new Matrix4()
   );
 
+  // Store articulations from the AGI_articulations extension
+  // by name in a dictionary for easy retrieval.
+  this._runtimeArticulations = {};
+
   initialize(this);
 }
 
@@ -218,6 +223,7 @@ Object.defineProperties(ModelExperimentalSceneGraph.prototype, {
 });
 
 function initialize(sceneGraph) {
+  let i;
   const components = sceneGraph._components;
   const scene = components.scene;
 
@@ -225,6 +231,21 @@ function initialize(sceneGraph) {
   // it will be accounted for in updateModelMatrix.
   const modelMatrix = sceneGraph._model.modelMatrix;
   computeModelMatrix(sceneGraph, modelMatrix);
+
+  const articulations = components.articulations;
+  const articulationsLength = articulations.length;
+
+  const runtimeArticulations = sceneGraph._runtimeArticulations;
+  for (i = 0; i < articulationsLength; i++) {
+    const articulation = articulations[i];
+    const runtimeArticulation = new ModelExperimentalArticulation({
+      articulation: articulation,
+      sceneGraph: sceneGraph,
+    });
+
+    const name = runtimeArticulation.name;
+    runtimeArticulations[name] = runtimeArticulation;
+  }
 
   const nodes = components.nodes;
   const nodesLength = nodes.length;
@@ -237,7 +258,7 @@ function initialize(sceneGraph) {
   const rootNodes = scene.nodes;
   const rootNodesLength = rootNodes.length;
   const transformToRoot = Matrix4.IDENTITY;
-  for (let i = 0; i < rootNodesLength; i++) {
+  for (i = 0; i < rootNodesLength; i++) {
     const rootNode = scene.nodes[i];
 
     const rootNodeIndex = traverseSceneGraph(
@@ -254,7 +275,7 @@ function initialize(sceneGraph) {
   const runtimeSkins = sceneGraph._runtimeSkins;
 
   const skinsLength = skins.length;
-  for (let i = 0; i < skinsLength; i++) {
+  for (i = 0; i < skinsLength; i++) {
     const skin = skins[i];
     runtimeSkins.push(
       new ModelExperimentalSkin({
@@ -266,7 +287,7 @@ function initialize(sceneGraph) {
 
   const skinnedNodes = sceneGraph._skinnedNodes;
   const skinnedNodesLength = skinnedNodes.length;
-  for (let i = 0; i < skinnedNodesLength; i++) {
+  for (i = 0; i < skinnedNodesLength; i++) {
     const skinnedNodeIndex = skinnedNodes[i];
     const skinnedNode = sceneGraph._runtimeNodes[skinnedNodeIndex];
 
@@ -716,4 +737,46 @@ ModelExperimentalSceneGraph.prototype.getDrawCommands = function (frameState) {
     drawCommands.push.apply(drawCommands, result);
   });
   return drawCommands;
+};
+
+/**
+ * Sets the current value of an articulation stage.
+ *
+ * @param {String} articulationStageKey The name of the articulation, a space, and the name of the stage.
+ * @param {Number} value The numeric value of this stage of the articulation.
+ *
+ * @private
+ */
+ModelExperimentalSceneGraph.prototype.setArticulationStage = function (
+  articulationStageKey,
+  value
+) {
+  const names = articulationStageKey.split(" ");
+  if (names.length !== 2) {
+    return;
+  }
+
+  const articulationName = names[0];
+  const stageName = names[1];
+
+  const runtimeArticulation = this._runtimeArticulations[articulationName];
+  if (defined(runtimeArticulation)) {
+    runtimeArticulation.setArticulationStage(stageName, value);
+  }
+};
+
+/**
+ * Applies any modified articulation stages to the matrix of each node that participates
+ * in any articulation.  Note that this will overwrite any nodeTransformations on participating nodes.
+ *
+ * @private
+ */
+ModelExperimentalSceneGraph.prototype.applyArticulations = function () {
+  const runtimeArticulations = this._runtimeArticulations;
+  for (const articulationName in runtimeArticulations) {
+    if (runtimeArticulations.hasOwnProperty(articulationName)) {
+      const articulation = runtimeArticulations[articulationName];
+      articulation.apply();
+    }
+  }
 };

--- a/Source/Scene/ModelExperimental/ModelExperimentalSkin.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalSkin.js
@@ -54,6 +54,7 @@ Object.defineProperties(ModelExperimentalSkin.prototype, {
   /**
    * The scene graph this skin belongs to.
    *
+   * @memberof ModelExperimentalSkin.prototype
    * @type {ModelExperimentalSceneGraph}
    * @readonly
    *

--- a/Specs/Scene/GltfLoaderSpec.js
+++ b/Specs/Scene/GltfLoaderSpec.js
@@ -1,5 +1,5 @@
 import {
-  ArticulationMotionType,
+  ArticulationStageType,
   AttributeType,
   Axis,
   Cartesian2,
@@ -3086,42 +3086,42 @@ describe(
 
         const xTranslateStage = stages[0];
         expect(xTranslateStage.name).toEqual("MoveX");
-        expect(xTranslateStage.type).toEqual(ArticulationMotionType.XTRANSLATE);
+        expect(xTranslateStage.type).toEqual(ArticulationStageType.XTRANSLATE);
         expect(xTranslateStage.minimumValue).toEqual(-1000.0);
         expect(xTranslateStage.maximumValue).toEqual(1000.0);
         expect(xTranslateStage.initialValue).toEqual(0.0);
 
         const yTranslateStage = stages[1];
         expect(yTranslateStage.name).toEqual("MoveY");
-        expect(yTranslateStage.type).toEqual(ArticulationMotionType.YTRANSLATE);
+        expect(yTranslateStage.type).toEqual(ArticulationStageType.YTRANSLATE);
         expect(yTranslateStage.minimumValue).toEqual(-1000.0);
         expect(yTranslateStage.maximumValue).toEqual(1000.0);
         expect(yTranslateStage.initialValue).toEqual(0.0);
 
         const zTranslateStage = stages[2];
         expect(zTranslateStage.name).toEqual("MoveZ");
-        expect(zTranslateStage.type).toEqual(ArticulationMotionType.ZTRANSLATE);
+        expect(zTranslateStage.type).toEqual(ArticulationStageType.ZTRANSLATE);
         expect(zTranslateStage.minimumValue).toEqual(-1000.0);
         expect(zTranslateStage.maximumValue).toEqual(1000.0);
         expect(zTranslateStage.initialValue).toEqual(0.0);
 
         const yRotateStage = stages[3];
         expect(yRotateStage.name).toEqual("Yaw");
-        expect(yRotateStage.type).toEqual(ArticulationMotionType.YROTATE);
+        expect(yRotateStage.type).toEqual(ArticulationStageType.YROTATE);
         expect(yRotateStage.minimumValue).toEqual(-360.0);
         expect(yRotateStage.maximumValue).toEqual(360.0);
         expect(yRotateStage.initialValue).toEqual(0.0);
 
         const xRotateStage = stages[4];
         expect(xRotateStage.name).toEqual("Pitch");
-        expect(xRotateStage.type).toEqual(ArticulationMotionType.XROTATE);
+        expect(xRotateStage.type).toEqual(ArticulationStageType.XROTATE);
         expect(xRotateStage.minimumValue).toEqual(-360.0);
         expect(xRotateStage.maximumValue).toEqual(360.0);
         expect(xRotateStage.initialValue).toEqual(0.0);
 
         const zRotateStage = stages[5];
         expect(zRotateStage.name).toEqual("Roll");
-        expect(zRotateStage.type).toEqual(ArticulationMotionType.ZROTATE);
+        expect(zRotateStage.type).toEqual(ArticulationStageType.ZROTATE);
         expect(zRotateStage.minimumValue).toEqual(-360.0);
         expect(zRotateStage.maximumValue).toEqual(360.0);
         expect(zRotateStage.initialValue).toEqual(0.0);
@@ -3129,7 +3129,7 @@ describe(
         const uniformScaleStage = stages[6];
         expect(uniformScaleStage.name).toEqual("Size");
         expect(uniformScaleStage.type).toEqual(
-          ArticulationMotionType.UNIFORMSCALE
+          ArticulationStageType.UNIFORMSCALE
         );
         expect(uniformScaleStage.minimumValue).toEqual(0.0);
         expect(uniformScaleStage.maximumValue).toEqual(1.0);
@@ -3137,21 +3137,21 @@ describe(
 
         const xScaleStage = stages[7];
         expect(xScaleStage.name).toEqual("SizeX");
-        expect(xScaleStage.type).toEqual(ArticulationMotionType.XSCALE);
+        expect(xScaleStage.type).toEqual(ArticulationStageType.XSCALE);
         expect(xScaleStage.minimumValue).toEqual(0.0);
         expect(xScaleStage.maximumValue).toEqual(1.0);
         expect(xScaleStage.initialValue).toEqual(1.0);
 
         const yScaleStage = stages[8];
         expect(yScaleStage.name).toEqual("SizeY");
-        expect(yScaleStage.type).toEqual(ArticulationMotionType.YSCALE);
+        expect(yScaleStage.type).toEqual(ArticulationStageType.YSCALE);
         expect(yScaleStage.minimumValue).toEqual(0.0);
         expect(yScaleStage.maximumValue).toEqual(1.0);
         expect(yScaleStage.initialValue).toEqual(1.0);
 
         const zScaleStage = stages[9];
         expect(zScaleStage.name).toEqual("SizeZ");
-        expect(zScaleStage.type).toEqual(ArticulationMotionType.ZSCALE);
+        expect(zScaleStage.type).toEqual(ArticulationStageType.ZSCALE);
         expect(zScaleStage.minimumValue).toEqual(0.0);
         expect(zScaleStage.maximumValue).toEqual(1.0);
         expect(zScaleStage.initialValue).toEqual(1.0);

--- a/Specs/Scene/GltfLoaderSpec.js
+++ b/Specs/Scene/GltfLoaderSpec.js
@@ -105,6 +105,8 @@ describe(
       "./Data/Models/GltfLoader/BoomBox/glTF-pbrSpecularGlossiness/BoomBox.gltf";
     const largeFeatureIdTexture =
       "./Data/Models/GltfLoader/LargeFeatureIdTexture/glTF/LargeFeatureIdTexture.gltf";
+    const boxArticulations =
+      "./Data/Models/Box-Articulations/Box-Articulations.gltf";
 
     let scene;
     let sceneWithWebgl2;
@@ -3062,6 +3064,49 @@ describe(
 
         // Does not load metallic roughness textures
         expect(textureCreate.calls.count()).toBe(5);
+      });
+    });
+
+    it("loads BoxArticulations", function () {
+      return loadGltf(boxArticulations).then(function (gltfLoader) {
+        const components = gltfLoader.components;
+        const scene = components.scene;
+        const rootNode = scene.nodes[0];
+        expect(rootNode).toBeDefined();
+        /*
+        const animation = animations[0];
+        expect(animation.samplers.length).toEqual(1);
+
+        const sampler = animation.samplers[0];
+        const expectedInput = [0, 0.25, 0.5, 0.75, 1.0];
+        const expectedOutput = [
+          new Quaternion(0.0, 0.0, 0.0, 1.0),
+          new Quaternion(0.0, 0.0, 0.707, 0.707),
+          new Quaternion(0.0, 0.0, 1.0, 0.0),
+          new Quaternion(0.0, 0.0, 0.707, -0.707),
+          new Quaternion(0.0, 0.0, 0.0, 1.0),
+        ];
+        expect(sampler.input).toEqual(expectedInput);
+        expect(sampler.interpolation).toEqual(InterpolationType.LINEAR);
+
+        const length = expectedOutput.length;
+        for (let i = 0; i < length; i++) {
+          expect(
+            Quaternion.equalsEpsilon(
+              sampler.output[i],
+              expectedOutput[i],
+              CesiumMath.EPSILON3
+            )
+          ).toBe(true);
+        }
+
+        expect(animation.channels.length).toEqual(1);
+        const channel = animation.channels[0];
+        expect(channel.sampler).toBe(sampler);
+        expect(channel.target.node).toBe(rootNode);
+        expect(channel.target.path).toEqual(
+          ModelComponents.AnimatedPropertyType.ROTATION
+        );*/
       });
     });
 

--- a/Specs/Scene/GltfLoaderSpec.js
+++ b/Specs/Scene/GltfLoaderSpec.js
@@ -1,4 +1,5 @@
 import {
+  ArticulationMotionType,
   AttributeType,
   Axis,
   Cartesian2,
@@ -3072,41 +3073,88 @@ describe(
         const components = gltfLoader.components;
         const scene = components.scene;
         const rootNode = scene.nodes[0];
-        expect(rootNode).toBeDefined();
-        /*
-        const animation = animations[0];
-        expect(animation.samplers.length).toEqual(1);
+        expect(rootNode.articulationName).toEqual("SampleArticulation");
 
-        const sampler = animation.samplers[0];
-        const expectedInput = [0, 0.25, 0.5, 0.75, 1.0];
-        const expectedOutput = [
-          new Quaternion(0.0, 0.0, 0.0, 1.0),
-          new Quaternion(0.0, 0.0, 0.707, 0.707),
-          new Quaternion(0.0, 0.0, 1.0, 0.0),
-          new Quaternion(0.0, 0.0, 0.707, -0.707),
-          new Quaternion(0.0, 0.0, 0.0, 1.0),
-        ];
-        expect(sampler.input).toEqual(expectedInput);
-        expect(sampler.interpolation).toEqual(InterpolationType.LINEAR);
+        const articulations = components.articulations;
+        expect(articulations.length).toEqual(1);
 
-        const length = expectedOutput.length;
-        for (let i = 0; i < length; i++) {
-          expect(
-            Quaternion.equalsEpsilon(
-              sampler.output[i],
-              expectedOutput[i],
-              CesiumMath.EPSILON3
-            )
-          ).toBe(true);
-        }
+        const articulation = articulations[0];
+        expect(articulation.name).toEqual("SampleArticulation");
 
-        expect(animation.channels.length).toEqual(1);
-        const channel = animation.channels[0];
-        expect(channel.sampler).toBe(sampler);
-        expect(channel.target.node).toBe(rootNode);
-        expect(channel.target.path).toEqual(
-          ModelComponents.AnimatedPropertyType.ROTATION
-        );*/
+        const stages = articulation.stages;
+        expect(stages.length).toEqual(10);
+
+        const xTranslateStage = stages[0];
+        expect(xTranslateStage.name).toEqual("MoveX");
+        expect(xTranslateStage.type).toEqual(ArticulationMotionType.XTRANSLATE);
+        expect(xTranslateStage.minimumValue).toEqual(-1000.0);
+        expect(xTranslateStage.maximumValue).toEqual(1000.0);
+        expect(xTranslateStage.initialValue).toEqual(0.0);
+
+        const yTranslateStage = stages[1];
+        expect(yTranslateStage.name).toEqual("MoveY");
+        expect(yTranslateStage.type).toEqual(ArticulationMotionType.YTRANSLATE);
+        expect(yTranslateStage.minimumValue).toEqual(-1000.0);
+        expect(yTranslateStage.maximumValue).toEqual(1000.0);
+        expect(yTranslateStage.initialValue).toEqual(0.0);
+
+        const zTranslateStage = stages[2];
+        expect(zTranslateStage.name).toEqual("MoveZ");
+        expect(zTranslateStage.type).toEqual(ArticulationMotionType.ZTRANSLATE);
+        expect(zTranslateStage.minimumValue).toEqual(-1000.0);
+        expect(zTranslateStage.maximumValue).toEqual(1000.0);
+        expect(zTranslateStage.initialValue).toEqual(0.0);
+
+        const yRotateStage = stages[3];
+        expect(yRotateStage.name).toEqual("Yaw");
+        expect(yRotateStage.type).toEqual(ArticulationMotionType.YROTATE);
+        expect(yRotateStage.minimumValue).toEqual(-360.0);
+        expect(yRotateStage.maximumValue).toEqual(360.0);
+        expect(yRotateStage.initialValue).toEqual(0.0);
+
+        const xRotateStage = stages[4];
+        expect(xRotateStage.name).toEqual("Pitch");
+        expect(xRotateStage.type).toEqual(ArticulationMotionType.XROTATE);
+        expect(xRotateStage.minimumValue).toEqual(-360.0);
+        expect(xRotateStage.maximumValue).toEqual(360.0);
+        expect(xRotateStage.initialValue).toEqual(0.0);
+
+        const zRotateStage = stages[5];
+        expect(zRotateStage.name).toEqual("Roll");
+        expect(zRotateStage.type).toEqual(ArticulationMotionType.ZROTATE);
+        expect(zRotateStage.minimumValue).toEqual(-360.0);
+        expect(zRotateStage.maximumValue).toEqual(360.0);
+        expect(zRotateStage.initialValue).toEqual(0.0);
+
+        const uniformScaleStage = stages[6];
+        expect(uniformScaleStage.name).toEqual("Size");
+        expect(uniformScaleStage.type).toEqual(
+          ArticulationMotionType.UNIFORMSCALE
+        );
+        expect(uniformScaleStage.minimumValue).toEqual(0.0);
+        expect(uniformScaleStage.maximumValue).toEqual(1.0);
+        expect(uniformScaleStage.initialValue).toEqual(1.0);
+
+        const xScaleStage = stages[7];
+        expect(xScaleStage.name).toEqual("SizeX");
+        expect(xScaleStage.type).toEqual(ArticulationMotionType.XSCALE);
+        expect(xScaleStage.minimumValue).toEqual(0.0);
+        expect(xScaleStage.maximumValue).toEqual(1.0);
+        expect(xScaleStage.initialValue).toEqual(1.0);
+
+        const yScaleStage = stages[8];
+        expect(yScaleStage.name).toEqual("SizeY");
+        expect(yScaleStage.type).toEqual(ArticulationMotionType.YSCALE);
+        expect(yScaleStage.minimumValue).toEqual(0.0);
+        expect(yScaleStage.maximumValue).toEqual(1.0);
+        expect(yScaleStage.initialValue).toEqual(1.0);
+
+        const zScaleStage = stages[9];
+        expect(zScaleStage.name).toEqual("SizeZ");
+        expect(zScaleStage.type).toEqual(ArticulationMotionType.ZSCALE);
+        expect(zScaleStage.minimumValue).toEqual(0.0);
+        expect(zScaleStage.maximumValue).toEqual(1.0);
+        expect(zScaleStage.initialValue).toEqual(1.0);
       });
     });
 

--- a/Specs/Scene/ModelExperimental/ModelExperimentalArticulationSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalArticulationSpec.js
@@ -1,0 +1,258 @@
+import {
+  ArticulationStageType,
+  Cartesian3,
+  Math as CesiumMath,
+  Matrix3,
+  Matrix4,
+  ModelExperimentalArticulation,
+} from "../../../Source/Cesium.js";
+
+describe("Scene/ModelExperimental/ModelExperimentalArticulation", function () {
+  const mockSceneGraph = {};
+
+  const articulation = {
+    name: "SampleArticulation",
+    stages: [],
+  };
+
+  function createTranslateStage(name, value) {
+    return {
+      name: name,
+      type: ArticulationStageType.XTRANSLATE,
+      minimumValue: -100.0,
+      maximumValue: 100.0,
+      initialValue: value,
+    };
+  }
+
+  function createRotateStage(name, value) {
+    return {
+      name: name,
+      type: ArticulationStageType.ZROTATE,
+      minimumValue: -360.0,
+      maximumValue: 360.0,
+      initialValue: value,
+    };
+  }
+
+  function createScaleStage(name, value) {
+    return {
+      name: name,
+      type: ArticulationStageType.UNIFORMSCALE,
+      minimumValue: 0.0,
+      maximumValue: 1.0,
+      initialValue: value,
+    };
+  }
+
+  function mockRuntimeNode(transform) {
+    return {
+      originalTransform: Matrix4.clone(transform),
+      transform: Matrix4.clone(transform),
+    };
+  }
+
+  beforeEach(function () {
+    const stages = articulation.stages;
+    stages.length = 0;
+
+    stages.push(createTranslateStage("MoveX", 50.0));
+    stages.push(createRotateStage("RotateZ", 180.0));
+    stages.push(createScaleStage("Size", 0.5));
+  });
+
+  it("throws for undefined articulation", function () {
+    expect(function () {
+      return new ModelExperimentalArticulation({
+        articulation: undefined,
+        sceneGraph: mockSceneGraph,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("throws for undefined scene graph", function () {
+    expect(function () {
+      return new ModelExperimentalArticulation({
+        articulation: {},
+        sceneGraph: undefined,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("constructs", function () {
+    const runtimeArticulation = new ModelExperimentalArticulation({
+      articulation: articulation,
+      sceneGraph: mockSceneGraph,
+    });
+
+    expect(runtimeArticulation.articulation).toBe(articulation);
+    expect(runtimeArticulation.sceneGraph).toBe(mockSceneGraph);
+
+    expect(runtimeArticulation.name).toEqual("SampleArticulation");
+
+    const runtimeStages = runtimeArticulation.runtimeStages;
+    expect(runtimeStages.length).toEqual(3);
+
+    const runtimeStagesByName = runtimeArticulation._runtimeStagesByName;
+
+    const xTranslateStage = runtimeStages[0];
+    expect(xTranslateStage.name).toBe("MoveX");
+    expect(xTranslateStage.runtimeArticulation).toBe(runtimeArticulation);
+    expect(runtimeStagesByName[xTranslateStage.name]).toBe(xTranslateStage);
+
+    const zRotateStage = runtimeStages[1];
+    expect(zRotateStage.name).toBe("RotateZ");
+    expect(zRotateStage.runtimeArticulation).toBe(runtimeArticulation);
+    expect(runtimeStagesByName[zRotateStage.name]).toBe(zRotateStage);
+
+    const uniformScaleStage = runtimeStages[2];
+    expect(uniformScaleStage.name).toBe("Size");
+    expect(uniformScaleStage.runtimeArticulation).toBe(runtimeArticulation);
+    expect(runtimeStagesByName[uniformScaleStage.name]).toBe(uniformScaleStage);
+
+    expect(runtimeArticulation.runtimeNodes.length).toBe(0);
+    expect(runtimeArticulation._dirty).toBe(true);
+  });
+
+  it("setArticulationStage does not throw if stage name doesn't exist", function () {
+    const runtimeArticulation = new ModelExperimentalArticulation({
+      articulation: articulation,
+      sceneGraph: mockSceneGraph,
+    });
+
+    const runtimeStages = runtimeArticulation.runtimeStages;
+    expect(runtimeStages.length).toEqual(3);
+
+    const xTranslateStage = runtimeStages[0];
+    const zRotateStage = runtimeStages[1];
+    const uniformScaleStage = runtimeStages[2];
+
+    expect(xTranslateStage.currentValue).toBe(50.0);
+    expect(zRotateStage.currentValue).toBe(180.0);
+    expect(uniformScaleStage.currentValue).toBe(0.5);
+    runtimeArticulation._dirty = false;
+
+    expect(function () {
+      runtimeArticulation.setArticulationStage("NonexistentStage", 100.0);
+    }).not.toThrowDeveloperError();
+
+    expect(xTranslateStage.currentValue).toBe(50.0);
+    expect(zRotateStage.currentValue).toBe(180.0);
+    expect(uniformScaleStage.currentValue).toBe(0.5);
+    expect(runtimeArticulation._dirty).toBe(false);
+  });
+
+  it("setArticulationStage works", function () {
+    const runtimeArticulation = new ModelExperimentalArticulation({
+      articulation: articulation,
+      sceneGraph: mockSceneGraph,
+    });
+
+    runtimeArticulation._dirty = false;
+    const runtimeStages = runtimeArticulation.runtimeStages;
+    expect(runtimeStages.length).toEqual(3);
+
+    const xTranslateStage = runtimeStages[0];
+    const zRotateStage = runtimeStages[1];
+    const uniformScaleStage = runtimeStages[2];
+
+    expect(xTranslateStage.currentValue).toBe(50.0);
+    expect(zRotateStage.currentValue).toBe(180.0);
+    expect(uniformScaleStage.currentValue).toBe(0.5);
+
+    runtimeArticulation.setArticulationStage("MoveX", 0.0);
+
+    expect(xTranslateStage.currentValue).toBe(0.0);
+    expect(zRotateStage.currentValue).toBe(180.0);
+    expect(uniformScaleStage.currentValue).toBe(0.5);
+    expect(runtimeArticulation._dirty).toBe(true);
+
+    runtimeArticulation._dirty = false;
+
+    // This value should be clamped by the stage's minimum value
+    runtimeArticulation.setArticulationStage("RotateZ", -480.0);
+    expect(xTranslateStage.currentValue).toBe(0.0);
+    expect(zRotateStage.currentValue).toBe(-360.0);
+    expect(uniformScaleStage.currentValue).toBe(0.5);
+    expect(runtimeArticulation._dirty).toBe(true);
+
+    runtimeArticulation._dirty = false;
+
+    // This value should be clamped by the stage's maximum value
+    runtimeArticulation.setArticulationStage("Size", 2.0);
+    expect(xTranslateStage.currentValue).toBe(0.0);
+    expect(zRotateStage.currentValue).toBe(-360.0);
+    expect(uniformScaleStage.currentValue).toBe(1.0);
+    expect(runtimeArticulation._dirty).toBe(true);
+  });
+
+  it("apply does nothing if articulation is not dirty", function () {
+    const runtimeArticulation = new ModelExperimentalArticulation({
+      articulation: articulation,
+      sceneGraph: mockSceneGraph,
+    });
+    runtimeArticulation._dirty = false;
+
+    const transform = Matrix4.fromTranslation(
+      new Cartesian3(1.0, 2.0, 3.0),
+      new Matrix4()
+    );
+
+    const node = mockRuntimeNode(transform);
+    runtimeArticulation.runtimeNodes.push(node);
+
+    expect(node.transform).toEqual(transform);
+    expect(runtimeArticulation._dirty).toBe(false);
+
+    runtimeArticulation.apply();
+    expect(node.transform).toEqual(transform);
+  });
+
+  it("apply works", function () {
+    const runtimeArticulation = new ModelExperimentalArticulation({
+      articulation: articulation,
+      sceneGraph: mockSceneGraph,
+    });
+
+    const transform = Matrix4.fromTranslation(
+      new Cartesian3(1.0, 2.0, 3.0),
+      new Matrix4()
+    );
+
+    const node = mockRuntimeNode(transform);
+    runtimeArticulation.runtimeNodes.push(node);
+
+    expect(runtimeArticulation._dirty).toBe(true);
+
+    let expectedMatrix = Matrix4.fromTranslation(
+      new Cartesian3(50.0, 0.0, 0.0),
+      new Matrix4()
+    );
+
+    const rotation = CesiumMath.toRadians(180.0);
+    const expectedRotation = Matrix3.fromRotationZ(rotation, new Matrix3());
+
+    expectedMatrix = Matrix4.multiplyByMatrix3(
+      expectedMatrix,
+      expectedRotation,
+      expectedMatrix
+    );
+
+    expectedMatrix = Matrix4.multiplyByUniformScale(
+      expectedMatrix,
+      0.5,
+      expectedMatrix
+    );
+
+    expectedMatrix = Matrix4.multiplyTransformation(
+      transform,
+      expectedMatrix,
+      expectedMatrix
+    );
+
+    runtimeArticulation.apply();
+    expect(runtimeArticulation._dirty).toBe(false);
+    expect(node.transform).toEqual(expectedMatrix);
+    expect(node.originalTransform).toEqual(transform);
+  });
+});

--- a/Specs/Scene/ModelExperimental/ModelExperimentalArticulationStageSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalArticulationStageSpec.js
@@ -1,0 +1,456 @@
+import {
+  ArticulationStageType,
+  Cartesian3,
+  Math as CesiumMath,
+  Matrix3,
+  Matrix4,
+  ModelExperimentalArticulationStage,
+} from "../../../Source/Cesium.js";
+
+describe("Scene/ModelExperimental/ModelExperimentalArticulationStage", function () {
+  const scratchCartesian3 = new Cartesian3();
+  const scratchMatrix3 = new Matrix3();
+  const scratchExpectedMatrix = new Matrix4();
+  const scratchResultMatrix = new Matrix4();
+
+  function mockRuntimeArticulation() {
+    return {
+      name: "SampleArticulation",
+      _runtimeStages: [],
+      _runtimeStagesByName: {},
+      _dirty: false,
+    };
+  }
+
+  it("throws for undefined stage", function () {
+    expect(function () {
+      return new ModelExperimentalArticulationStage({
+        stage: undefined,
+        runtimeArticulation: {},
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("throws for undefined runtime articulation", function () {
+    expect(function () {
+      return new ModelExperimentalArticulationStage({
+        stage: {},
+        runtimeArticulation: undefined,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("constructs", function () {
+    const stage = {
+      name: "SampleStage",
+      type: ArticulationStageType.XTRANSLATE,
+      minimumValue: -100.0,
+      maximumValue: 100.0,
+      initialValue: 0.0,
+    };
+
+    const runtimeArticulation = mockRuntimeArticulation();
+    const runtimeStage = new ModelExperimentalArticulationStage({
+      stage: stage,
+      runtimeArticulation: runtimeArticulation,
+    });
+
+    expect(runtimeStage.stage).toBe(stage);
+    expect(runtimeStage.runtimeArticulation).toBe(runtimeArticulation);
+
+    expect(runtimeStage.name).toBe("SampleStage");
+    expect(runtimeStage.type).toBe(ArticulationStageType.XTRANSLATE);
+    expect(runtimeStage.minimumValue).toBe(-100.0);
+    expect(runtimeStage.maximumValue).toBe(100.0);
+    expect(runtimeStage.currentValue).toBe(0.0);
+  });
+
+  it("currentValue sets new value", function () {
+    const stage = {
+      name: "SampleStage",
+      type: ArticulationStageType.XTRANSLATE,
+      minimumValue: -100.0,
+      maximumValue: 100.0,
+      initialValue: 0.0,
+    };
+
+    const runtimeArticulation = mockRuntimeArticulation();
+    const runtimeStage = new ModelExperimentalArticulationStage({
+      stage: stage,
+      runtimeArticulation: runtimeArticulation,
+    });
+
+    expect(runtimeStage.currentValue).toBe(0.0);
+
+    runtimeStage.currentValue = 50.0;
+    expect(runtimeStage.currentValue).toBe(50.0);
+    expect(runtimeArticulation._dirty).toBe(true);
+  });
+
+  it("currentValue clamps new value", function () {
+    const stage = {
+      name: "SampleStage",
+      type: ArticulationStageType.XTRANSLATE,
+      minimumValue: -100.0,
+      maximumValue: 100.0,
+      initialValue: 0.0,
+    };
+
+    const runtimeArticulation = mockRuntimeArticulation();
+    const runtimeStage = new ModelExperimentalArticulationStage({
+      stage: stage,
+      runtimeArticulation: runtimeArticulation,
+    });
+
+    expect(runtimeStage.currentValue).toBe(0.0);
+
+    runtimeStage.currentValue = 150.0;
+    expect(runtimeStage.currentValue).toBe(100.0);
+    expect(runtimeArticulation._dirty).toBe(true);
+
+    runtimeArticulation._dirty = false;
+    runtimeStage.currentValue = -150.0;
+    expect(runtimeStage.currentValue).toBe(-100.0);
+    expect(runtimeArticulation._dirty).toBe(true);
+  });
+
+  it("currentValue has no effect if given value is the same", function () {
+    const stage = {
+      name: "SampleStage",
+      type: ArticulationStageType.XTRANSLATE,
+      minimumValue: -100.0,
+      maximumValue: 100.0,
+      initialValue: 0.0,
+    };
+
+    const runtimeArticulation = mockRuntimeArticulation();
+    const runtimeStage = new ModelExperimentalArticulationStage({
+      stage: stage,
+      runtimeArticulation: runtimeArticulation,
+    });
+
+    expect(runtimeStage.currentValue).toBe(0.0);
+
+    runtimeStage.currentValue = 0.0;
+    expect(runtimeStage.currentValue).toBe(0.0);
+    expect(runtimeArticulation._dirty).toBe(false);
+  });
+
+  it("applyStageToMatrix works for xTranslate", function () {
+    const stage = {
+      name: "SampleStage",
+      type: ArticulationStageType.XTRANSLATE,
+      minimumValue: -100.0,
+      maximumValue: 100.0,
+      initialValue: 50.0,
+    };
+
+    const runtimeArticulation = mockRuntimeArticulation();
+    const runtimeStage = new ModelExperimentalArticulationStage({
+      stage: stage,
+      runtimeArticulation: runtimeArticulation,
+    });
+
+    expect(runtimeStage.currentValue).toBe(50.0);
+
+    const expectedTranslation = Cartesian3.fromElements(
+      50.0,
+      0.0,
+      0.0,
+      scratchCartesian3
+    );
+    const expectedMatrix = Matrix4.fromTranslation(
+      expectedTranslation,
+      scratchExpectedMatrix
+    );
+
+    let resultMatrix = Matrix4.clone(Matrix4.IDENTITY, scratchResultMatrix);
+    resultMatrix = runtimeStage.applyStageToMatrix(resultMatrix);
+
+    expect(resultMatrix).toEqual(expectedMatrix);
+  });
+
+  it("applyStageToMatrix works for yTranslate", function () {
+    const stage = {
+      name: "SampleStage",
+      type: ArticulationStageType.YTRANSLATE,
+      minimumValue: -100.0,
+      maximumValue: 100.0,
+      initialValue: 50.0,
+    };
+
+    const runtimeArticulation = mockRuntimeArticulation();
+    const runtimeStage = new ModelExperimentalArticulationStage({
+      stage: stage,
+      runtimeArticulation: runtimeArticulation,
+    });
+
+    expect(runtimeStage.currentValue).toBe(50.0);
+
+    const expectedTranslation = Cartesian3.fromElements(
+      0.0,
+      50.0,
+      0.0,
+      scratchCartesian3
+    );
+    const expectedMatrix = Matrix4.fromTranslation(
+      expectedTranslation,
+      scratchExpectedMatrix
+    );
+
+    let resultMatrix = Matrix4.clone(Matrix4.IDENTITY, scratchResultMatrix);
+    resultMatrix = runtimeStage.applyStageToMatrix(resultMatrix);
+
+    expect(resultMatrix).toEqual(expectedMatrix);
+  });
+
+  it("applyStageToMatrix works for zTranslate", function () {
+    const stage = {
+      name: "SampleStage",
+      type: ArticulationStageType.ZTRANSLATE,
+      minimumValue: -100.0,
+      maximumValue: 100.0,
+      initialValue: 50.0,
+    };
+
+    const runtimeArticulation = mockRuntimeArticulation();
+    const runtimeStage = new ModelExperimentalArticulationStage({
+      stage: stage,
+      runtimeArticulation: runtimeArticulation,
+    });
+
+    expect(runtimeStage.currentValue).toBe(50.0);
+
+    const expectedTranslation = Cartesian3.fromElements(
+      0.0,
+      0.0,
+      50.0,
+      scratchCartesian3
+    );
+    const expectedMatrix = Matrix4.fromTranslation(
+      expectedTranslation,
+      scratchExpectedMatrix
+    );
+
+    let resultMatrix = Matrix4.clone(Matrix4.IDENTITY, scratchResultMatrix);
+    resultMatrix = runtimeStage.applyStageToMatrix(resultMatrix);
+
+    expect(resultMatrix).toEqual(expectedMatrix);
+  });
+
+  it("applyStageToMatrix works for xRotate", function () {
+    const stage = {
+      name: "SampleStage",
+      type: ArticulationStageType.XROTATE,
+      minimumValue: -360.0,
+      maximumValue: 360.0,
+      initialValue: 180.0,
+    };
+
+    const runtimeArticulation = mockRuntimeArticulation();
+    const runtimeStage = new ModelExperimentalArticulationStage({
+      stage: stage,
+      runtimeArticulation: runtimeArticulation,
+    });
+    expect(runtimeStage.currentValue).toBe(180.0);
+
+    const value = CesiumMath.toRadians(180.0);
+    const expectedRotation = Matrix3.fromRotationX(value, scratchMatrix3);
+    const expectedMatrix = Matrix4.fromRotation(
+      expectedRotation,
+      scratchExpectedMatrix
+    );
+
+    let resultMatrix = Matrix4.clone(Matrix4.IDENTITY, scratchResultMatrix);
+    resultMatrix = runtimeStage.applyStageToMatrix(resultMatrix);
+
+    expect(resultMatrix).toEqual(expectedMatrix);
+  });
+
+  it("applyStageToMatrix works for yRotate", function () {
+    const stage = {
+      name: "SampleStage",
+      type: ArticulationStageType.YROTATE,
+      minimumValue: -360.0,
+      maximumValue: 360.0,
+      initialValue: 180.0,
+    };
+
+    const runtimeArticulation = mockRuntimeArticulation();
+    const runtimeStage = new ModelExperimentalArticulationStage({
+      stage: stage,
+      runtimeArticulation: runtimeArticulation,
+    });
+
+    expect(runtimeStage.currentValue).toBe(180.0);
+
+    const value = CesiumMath.toRadians(180.0);
+    const expectedRotation = Matrix3.fromRotationY(value, scratchMatrix3);
+    const expectedMatrix = Matrix4.fromRotation(
+      expectedRotation,
+      scratchExpectedMatrix
+    );
+
+    let resultMatrix = Matrix4.clone(Matrix4.IDENTITY, scratchResultMatrix);
+    resultMatrix = runtimeStage.applyStageToMatrix(resultMatrix);
+
+    expect(resultMatrix).toEqual(expectedMatrix);
+  });
+
+  it("applyStageToMatrix works for zRotate", function () {
+    const stage = {
+      name: "SampleStage",
+      type: ArticulationStageType.ZROTATE,
+      minimumValue: -360.0,
+      maximumValue: 360.0,
+      initialValue: 180.0,
+    };
+
+    const runtimeArticulation = mockRuntimeArticulation();
+    const runtimeStage = new ModelExperimentalArticulationStage({
+      stage: stage,
+      runtimeArticulation: runtimeArticulation,
+    });
+
+    expect(runtimeStage.currentValue).toBe(180.0);
+
+    const value = CesiumMath.toRadians(180.0);
+    const expectedRotation = Matrix3.fromRotationZ(value, scratchMatrix3);
+    const expectedMatrix = Matrix4.fromRotation(
+      expectedRotation,
+      scratchExpectedMatrix
+    );
+
+    let resultMatrix = Matrix4.clone(Matrix4.IDENTITY, scratchResultMatrix);
+    resultMatrix = runtimeStage.applyStageToMatrix(resultMatrix);
+
+    expect(resultMatrix).toEqual(expectedMatrix);
+  });
+
+  it("applyStageToMatrix works for xScale", function () {
+    const stage = {
+      name: "SampleStage",
+      type: ArticulationStageType.XSCALE,
+      minimumValue: 0.0,
+      maximumValue: 1.0,
+      initialValue: 0.5,
+    };
+
+    const runtimeArticulation = mockRuntimeArticulation();
+    const runtimeStage = new ModelExperimentalArticulationStage({
+      stage: stage,
+      runtimeArticulation: runtimeArticulation,
+    });
+
+    expect(runtimeStage.currentValue).toBe(0.5);
+
+    const expectedScale = Cartesian3.fromElements(
+      0.5,
+      1.0,
+      1.0,
+      scratchCartesian3
+    );
+    const expectedMatrix = Matrix4.fromScale(
+      expectedScale,
+      scratchExpectedMatrix
+    );
+
+    let resultMatrix = Matrix4.clone(Matrix4.IDENTITY, scratchResultMatrix);
+    resultMatrix = runtimeStage.applyStageToMatrix(resultMatrix);
+
+    expect(resultMatrix).toEqual(expectedMatrix);
+  });
+
+  it("applyStageToMatrix works for yScale", function () {
+    const stage = {
+      name: "SampleStage",
+      type: ArticulationStageType.YSCALE,
+      minimumValue: 0.0,
+      maximumValue: 1.0,
+      initialValue: 0.5,
+    };
+
+    const runtimeArticulation = mockRuntimeArticulation();
+    const runtimeStage = new ModelExperimentalArticulationStage({
+      stage: stage,
+      runtimeArticulation: runtimeArticulation,
+    });
+
+    expect(runtimeStage.currentValue).toBe(0.5);
+
+    const expectedScale = Cartesian3.fromElements(
+      1.0,
+      0.5,
+      1.0,
+      scratchCartesian3
+    );
+    const expectedMatrix = Matrix4.fromScale(
+      expectedScale,
+      scratchExpectedMatrix
+    );
+
+    let resultMatrix = Matrix4.clone(Matrix4.IDENTITY, scratchResultMatrix);
+    resultMatrix = runtimeStage.applyStageToMatrix(resultMatrix);
+
+    expect(resultMatrix).toEqual(expectedMatrix);
+  });
+
+  it("applyStageToMatrix works for zScale", function () {
+    const stage = {
+      name: "SampleStage",
+      type: ArticulationStageType.ZSCALE,
+      minimumValue: 0.0,
+      maximumValue: 1.0,
+      initialValue: 0.5,
+    };
+
+    const runtimeArticulation = mockRuntimeArticulation();
+    const runtimeStage = new ModelExperimentalArticulationStage({
+      stage: stage,
+      runtimeArticulation: runtimeArticulation,
+    });
+
+    expect(runtimeStage.currentValue).toBe(0.5);
+
+    const expectedScale = Cartesian3.fromElements(
+      1.0,
+      1.0,
+      0.5,
+      scratchCartesian3
+    );
+    const expectedMatrix = Matrix4.fromScale(
+      expectedScale,
+      scratchExpectedMatrix
+    );
+
+    let resultMatrix = Matrix4.clone(Matrix4.IDENTITY, scratchResultMatrix);
+    resultMatrix = runtimeStage.applyStageToMatrix(resultMatrix);
+
+    expect(resultMatrix).toEqual(expectedMatrix);
+  });
+
+  it("applyStageToMatrix works for uniformScale", function () {
+    const stage = {
+      name: "SampleStage",
+      type: ArticulationStageType.UNIFORMSCALE,
+      minimumValue: 0.0,
+      maximumValue: 1.0,
+      initialValue: 0.5,
+    };
+
+    const runtimeArticulation = mockRuntimeArticulation();
+    const runtimeStage = new ModelExperimentalArticulationStage({
+      stage: stage,
+      runtimeArticulation: runtimeArticulation,
+    });
+
+    expect(runtimeStage.currentValue).toBe(0.5);
+
+    const expectedMatrix = Matrix4.fromUniformScale(0.5, scratchExpectedMatrix);
+
+    let resultMatrix = Matrix4.clone(Matrix4.IDENTITY, scratchResultMatrix);
+    resultMatrix = runtimeStage.applyStageToMatrix(resultMatrix);
+
+    expect(resultMatrix).toEqual(expectedMatrix);
+  });
+});

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSceneGraphSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSceneGraphSpec.js
@@ -4,6 +4,7 @@ import {
   Color,
   CustomShader,
   CustomShaderPipelineStage,
+  Math as CesiumMath,
   Matrix4,
   ModelColorPipelineStage,
   ModelExperimentalSceneGraph,
@@ -24,6 +25,8 @@ describe(
       "./Data/Models/GltfLoader/BuildingsMetadata/glTF/buildings-metadata.gltf";
     const simpleSkinGltfUrl =
       "./Data/Models/GltfLoader/SimpleSkin/glTF/SimpleSkin.gltf";
+    const boxArticulationsUrl =
+      "./Data/Models/Box-Articulations/Box-Articulations.gltf";
 
     let scene;
 
@@ -270,6 +273,71 @@ describe(
         expect(skinnedNodes[0]).toEqual(0);
 
         expect(runtimeNodes[0].computedJointMatrices.length).toEqual(2);
+      });
+    });
+
+    it("creates articulation from model", function () {
+      return loadAndZoomToModelExperimental(
+        { gltf: boxArticulationsUrl },
+        scene
+      ).then(function (model) {
+        const sceneGraph = model._sceneGraph;
+        const components = sceneGraph._components;
+        const runtimeNodes = sceneGraph._runtimeNodes;
+
+        expect(runtimeNodes[0].node).toEqual(components.nodes[0]);
+
+        const rootNodes = sceneGraph._rootNodes;
+        expect(rootNodes[0]).toEqual(0);
+
+        const runtimeArticulations = sceneGraph._runtimeArticulations;
+        const runtimeArticulation = runtimeArticulations["SampleArticulation"];
+        expect(runtimeArticulation).toBeDefined();
+        expect(runtimeArticulation.name).toBe("SampleArticulation");
+        expect(runtimeArticulation.runtimeNodes.length).toBe(1);
+        expect(runtimeArticulation.runtimeStages.length).toBe(10);
+      });
+    });
+
+    it("applies articulations", function () {
+      return loadAndZoomToModelExperimental(
+        {
+          gltf: boxArticulationsUrl,
+        },
+        scene
+      ).then(function (model) {
+        const sceneGraph = model._sceneGraph;
+        const runtimeNodes = sceneGraph._runtimeNodes;
+        const rootNode = runtimeNodes[0];
+
+        expect(rootNode.transform).toEqual(rootNode.originalTransform);
+
+        sceneGraph.setArticulationStage("SampleArticulation MoveX", 1.0);
+        sceneGraph.setArticulationStage("SampleArticulation MoveY", 2.0);
+        sceneGraph.setArticulationStage("SampleArticulation MoveZ", 3.0);
+        sceneGraph.setArticulationStage("SampleArticulation Yaw", 4.0);
+        sceneGraph.setArticulationStage("SampleArticulation Pitch", 5.0);
+        sceneGraph.setArticulationStage("SampleArticulation Roll", 6.0);
+        sceneGraph.setArticulationStage("SampleArticulation Size", 0.9);
+        sceneGraph.setArticulationStage("SampleArticulation SizeX", 0.8);
+        sceneGraph.setArticulationStage("SampleArticulation SizeY", 0.7);
+        sceneGraph.setArticulationStage("SampleArticulation SizeZ", 0.6);
+
+        // Articulations shouldn't affect the node until applyArticulations is called.
+        expect(rootNode.transform).toEqual(rootNode.originalTransform);
+
+        sceneGraph.applyArticulations();
+
+        // prettier-ignore
+        const expected = [  0.714769048324, -0.0434061192623, -0.074974104652,  0,
+                          -0.0618833029577,  0.0590679731276, -0.624164586760,  0,
+                           0.0375251558227,  0.5366347296529,  0.047064101083,  0,
+                                         1,                3,              -2,  1, ];
+
+        expect(rootNode.transform).toEqualEpsilon(
+          expected,
+          CesiumMath.EPSILON10
+        );
       });
     });
 

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -72,6 +72,8 @@ describe(
     );
     const pointCloudUrl =
       "./Data/Models/GltfLoader/PointCloudWithRGBColors/glTF-Binary/PointCloudWithRGBColors.glb";
+    const boxArticulationsUrl =
+      "./Data/Models/Box-Articulations/Box-Articulations.gltf";
 
     const fixedFrameTransform = Transforms.localFrameToFixedFrameGenerator(
       "north",
@@ -2263,6 +2265,33 @@ describe(
 
         model.clippingPlanes.unionClippingRegions = false;
         scene.renderForSpecs();
+        verifyRender(model, true);
+      });
+    });
+
+    it("applies articulations", function () {
+      return loadAndZoomToModelExperimental(
+        {
+          gltf: boxArticulationsUrl,
+        },
+        scene
+      ).then(function (model) {
+        verifyRender(model, true);
+
+        model.setArticulationStage("SampleArticulation MoveX", 10.0);
+        model.applyArticulations();
+        verifyRender(model, false);
+
+        model.setArticulationStage("SampleArticulation MoveX", 0.0);
+        model.applyArticulations();
+        verifyRender(model, true);
+
+        model.setArticulationStage("SampleArticulation Size", 0.0);
+        model.applyArticulations();
+        verifyRender(model, false);
+
+        model.setArticulationStage("SampleArticulation Size", 1.0);
+        model.applyArticulations();
         verifyRender(model, true);
       });
     });


### PR DESCRIPTION
This PR adds support for the `AGI_articulations` extension in `ModelExperimental`. It adds `setArticulationStage` and `applyArticulations` to the public `ModelExperimental` API, which are both present in `Model`.

![articulations](https://user-images.githubusercontent.com/32226860/175617460-d1fd2405-bc82-4fad-a9fb-dd03909ac251.gif)

The public "CZML Model Articulations" sandcastle uses the CZML API, which hasn't been integrated / confirmed to work with `ModelExperimental` yet, so I repurposed the [development sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=nVd7b9s2EP8qhFeg8mrTiRtsneIG69LHBqxL0KT9o3WxUhJjcZFIgaRSe4W/+44PSZTkZt0MBBF5D9797sHjYoF0zhRKCUcJRWlO+IZmSAtE+A5tiuuXqBQZLdY8FVxpt3grC/QUrSe51pWKFwuiFNUKkw3DqSgXlkctClLzNL+jOUsLijdFsp6crnmj6I7Rz68NI2j6suYIEalZWhdEM6DH6MPHmdlVmmxosKQFTTXNngXMMap5Rm8Ypxnw7O0Z51SxusS3XKS3otZYS5LeRu2Z00NMRj/eUH2RKCrvSFLQTmAG3h46ez2ZWjFVJyqVLKHRDThtKCji9HPIOnVuos5z7JwDAAasnnBq+PfTADQtRJEQCRKZSOuScm0MflFQ8/nL7rcsWk88D1h2OsaBVFWx+4XxjPGNCt3zUtNBhKh01iGv6J3dg1NSuz4XXBMA3p/m5FRKOQUxJ4/tMlCbU7bJNdCXyyP44aNWUEi2YRwo/rBzSAn4IvwxvpGifE43klIVzX88wT/89HiGlk/w8gT+O42dATb/XhMt2bZTdi0JVzdClgrnlBj/L5lO8zeiKK7FS7al2UtJShoZzJ0hNuEC338diEUQ+hCv0mezdRhXkpVMszsKdZFlVq3XYxF/sa0ocEDYSGG9e1Xom8hnSC2LuK20mdsLnIrDRUNmnJV1eQmOFFfsbxqj4+WTmUugxkwrhSW4sbuEE5miNnd1TnmQtparTVbnWgrISNLF1K2tUsO0WKD3QpSma/hmEYhCikhAy2aSgwYqhVJ+VZGUnltF5y3PaSgKEm6J0BIfoe8ReJzjkmydjTgRtU3kqyqnkmIJ4anVzBsLoNZKA9ycurT2ev1B2ANm7H7OoN54anJWwilHeNl65n2AMFn7mwha5E9wWReamYLaXQrGddRY68wbBwkdyOz3L95ctOQg2zqWaOrI0x44Pol7RuVYizewDZkeQWH1BSqTt19lnx+HAg7BQojbZ51XDoVDtvYqw1wgkbdu5k6deVyf9DwJjes1fzDSIWjT5ZUkVY7/lDXXUC9hm1Q+TMO2OlR2kfwFjRvf0p1qnenxeKsgtaqgEEKWPwCRtiYQklTXkndrQAMYYjQUmXUMzUXWO/hDR0cj4Y72EXvvr6ySgZ1W8zQ0pkHVUnqXbPdzBlsOzPumBv2k4fDLd6SoR5xk2+N0y0OcaS0l5FDD6Zdjzv1puDp8lXeuTe/ldoMBtDtot3oXiJkb3VtwTbd6PZkNEYKbNUYdzNMhvU2DTmnjExTWFdQ930R968C3ASaqf8idAePASdBhU0El9CjLoUyr5XWZwM074BwbA7F/ZKXuNWV/L459ycGUdBBUPxkFQl+Zkd59xWXfAqgOS94WQDRkRejTgy/D8tmjB1+69N5/mo2lHo3BGjIN49fYZQepXjMah7q/MUqWgLqfttY1yd9KB+PigQHU38kHGt+Ho4+nzf0P6KcEGnGAPJVSyN41L2BKt7ueFo6fk9lkpfSuoGeNnT+zshJSm1klwnihaVnBwVQtkjq9pRqnSnX+f9cMrkGUEyjjjTRXeIzkJiHRyXKGmj9zVwT4VDBCQTXF6KTaBtuJkBmVc3fx94n70dGMV7UODbijBi5SzEnBNvCKKFmWFXR86lyLKkbL3skNKRFai7JP9UevFiFgq4zdIZY9PTA5o7SABxRQburCzm7rydlqAfwj0ULYW/UCLC/IzrDlx2e/u02M8WoBy8OS7aOgjd+qYzO/3oOq2165nGtNdMbPkxrchscPyogm8wTeE0ATlX+69dLwQNn9689rMn05Rg9N+T78P2ps04vR4XcbAOUIHSKLEJKVNr0tQGilE5Hteh7Dc4KSNPcXmgrQdQLyrG/1Smc9eW0dNP5Ze3Q25j8b+r1yeax3FQUN0kxbEAe4n2E1f2w+yRY+zZfStIJPGOyOB6HyyPie983YWrG3FWgC4YfWkG8PDNFaxuM2f98PvIqbSeQ/JQBgEDeDybfK7QfhG4Ot7ZyAFJQorJb3YupmimE8hyGGjTBHYGlyLMjIMAnD/PwH) to test the `ModelExperimental` functionality.