### PR TITLE
Add `distanceDisplayCondition` to `ModelExperimental`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 - Added `modelUpAxis` and `modelForwardAxis` constructor options to `Cesium3DTileset` [#10439](https://github.com/CesiumGS/cesium/pull/10439)
 - Added `heightReference` to `ModelExperimental`. [#10448](https://github.com/CesiumGS/cesium/pull/10448)
 - Added `silhouetteSize` and `silhouetteColor` to `ModelExperimental`. [#10457](https://github.com/CesiumGS/cesium/pull/10457)
+- Added `distanceDisplayCondition` to `ModelExperimental`. [#10481](https://github.com/CesiumGS/cesium/pull/10481)
 
 ##### Fixes :wrench:
 

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -1819,13 +1819,13 @@ function getUpdateHeightCallback(model, ellipsoid, cartoPosition) {
 const scratchDisplayConditionCartesian = new Cartesian3();
 
 function passesDistanceDisplayCondition(model, frameState) {
-  const ddc = model.distanceDisplayCondition;
-  if (!defined(ddc)) {
+  const condition = model.distanceDisplayCondition;
+  if (!defined(condition)) {
     return true;
   }
 
-  const nearSquared = ddc.near * ddc.near;
-  const farSquared = ddc.far * ddc.far;
+  const nearSquared = condition.near * condition.near;
+  const farSquared = condition.far * condition.far;
   let distanceSquared;
 
   if (frameState.mode === SceneMode.SCENE2D) {

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -7,6 +7,7 @@ import ClippingPlaneCollection from "../ClippingPlaneCollection.js";
 import defined from "../../Core/defined.js";
 import defaultValue from "../../Core/defaultValue.js";
 import DeveloperError from "../../Core/DeveloperError.js";
+import DistanceDisplayCondition from "../../Core/DistanceDisplayCondition.js";
 import GltfLoader from "../GltfLoader.js";
 import HeightReference from "../HeightReference.js";
 import ImageBasedLighting from "../ImageBasedLighting.js";
@@ -49,33 +50,34 @@ import SplitDirection from "../SplitDirection.js";
  * @param {Number} [options.scale=1.0] A uniform scale applied to this model.
  * @param {Number} [options.minimumPixelSize=0.0] The approximate minimum pixel size of the model regardless of zoom.
  * @param {Number} [options.maximumScale] The maximum scale size of a model. An upper limit for minimumPixelSize.
+ * @param {Boolean} [options.allowPicking=true] When <code>true</code>, each primitive is pickable with {@link Scene#pick}.
  * @param {Boolean} [options.clampAnimations=true] Determines if the model's animations should hold a pose over frames where no keyframes are specified.
+ * @param {ShadowMode} [options.shadows=ShadowMode.ENABLED] Determines whether the model casts or receives shadows from light sources.
  * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for each draw command in the model.
  * @param {Boolean} [options.enableDebugWireframe=false] For debugging only. This must be set to true for debugWireframe to work in WebGL1. This cannot be set after the model has loaded.
  * @param {Boolean} [options.debugWireframe=false] For debugging only. Draws the model in wireframe. Will only work for WebGL1 if enableDebugWireframe is set to true.
  * @param {Boolean} [options.cull=true]  Whether or not to cull the model using frustum/horizon culling. If the model is part of a 3D Tiles tileset, this property will always be false, since the 3D Tiles culling system is used.
  * @param {Boolean} [options.opaquePass=Pass.OPAQUE] The pass to use in the {@link DrawCommand} for the opaque portions of the model.
- * @param {Boolean} [options.allowPicking=true] When <code>true</code>, each primitive is pickable with {@link Scene#pick}.
  * @param {CustomShader} [options.customShader] A custom shader. This will add user-defined GLSL code to the vertex and fragment shaders. Using custom shaders with a {@link Cesium3DTileStyle} may lead to undefined behavior.
  * @param {Cesium3DTileContent} [options.content] The tile content this model belongs to. This property will be undefined if model is not loaded as part of a tileset.
  * @param {HeightReference} [options.heightReference=HeightReference.NONE] Determines how the model is drawn relative to terrain.
  * @param {Scene} [options.scene] Must be passed in for models that use the height reference property.
+ * @param {DistanceDisplayCondition} [options.distanceDisplayCondition] The condition specifying at what distance from the camera that this model will be displayed.
  * @param {Color} [options.color] A color that blends with the model's rendered color.
  * @param {ColorBlendMode} [options.colorBlendMode=ColorBlendMode.HIGHLIGHT] Defines how the color blends with the model.
  * @param {Number} [options.colorBlendAmount=0.5] Value used to determine the color strength when the <code>colorBlendMode</code> is <code>MIX</code>. A value of 0.0 results in the model's rendered color while a value of 1.0 results in a solid color, with any value in-between resulting in a mix of the two.
  * @param {Color} [options.silhouetteColor=Color.RED] The silhouette color. If more than 256 models have silhouettes enabled, there is a small chance that overlapping models will have minor artifacts.
  * @param {Number} [options.silhouetteSize=0.0] The size of the silhouette in pixels.
- * @param {String|Number} [options.featureIdLabel="featureId_0"] Label of the feature ID set to use for picking and styling. For EXT_mesh_features, this is the feature ID's label property, or "featureId_N" (where N is the index in the featureIds array) when not specified. EXT_feature_metadata did not have a label field, so such feature ID sets are always labeled "featureId_N" where N is the index in the list of all feature Ids, where feature ID attributes are listed before feature ID textures. If featureIdLabel is an integer N, it is converted to the string "featureId_N" automatically. If both per-primitive and per-instance feature IDs are present, the instance feature IDs take priority.
- * @param {String|Number} [options.instanceFeatureIdLabel="instanceFeatureId_0"] Label of the instance feature ID set used for picking and styling. If instanceFeatureIdLabel is set to an integer N, it is converted to the string "instanceFeatureId_N" automatically. If both per-primitive and per-instance feature IDs are present, the instance feature IDs take priority.
- * @param {Object} [options.pointCloudShading] Options for constructing a {@link PointCloudShading} object to control point attenuation based on geometric error and lighting.
  * @param {ClippingPlaneCollection} [options.clippingPlanes] The {@link ClippingPlaneCollection} used to selectively disable rendering the model.
  * @param {Cartesian3} [options.lightColor] The light color when shading the model. When <code>undefined</code> the scene's light color is used instead.
  * @param {ImageBasedLighting} [options.imageBasedLighting] The properties for managing image-based lighting on this model.
  * @param {Boolean} [options.backFaceCulling=true] Whether to cull back-facing geometry. When true, back face culling is determined by the material's doubleSided property; when false, back face culling is disabled. Back faces are not culled if the model's color is translucent.
- * @param {ShadowMode} [options.shadows=ShadowMode.ENABLED] Determines whether the model casts or receives shadows from light sources.
  * @param {Boolean} [options.showCreditsOnScreen=false] Whether to display the credits of this model on screen.
  * @param {SplitDirection} [options.splitDirection=SplitDirection.NONE] The {@link SplitDirection} split to apply to this model.
  * @param {Boolean} [options.projectTo2D=false] Whether to accurately project the model's positions in 2D. If this is true, the model will be projected accurately to 2D, but it will use more memory to do so. If this is false, the model will use less memory and will still render in 2D / CV mode, but its positions may be inaccurate. This disables minimumPixelSize and prevents future modification to the model matrix. This also cannot be set after the model has loaded.
+ * @param {String|Number} [options.featureIdLabel="featureId_0"] Label of the feature ID set to use for picking and styling. For EXT_mesh_features, this is the feature ID's label property, or "featureId_N" (where N is the index in the featureIds array) when not specified. EXT_feature_metadata did not have a label field, so such feature ID sets are always labeled "featureId_N" where N is the index in the list of all feature Ids, where feature ID attributes are listed before feature ID textures. If featureIdLabel is an integer N, it is converted to the string "featureId_N" automatically. If both per-primitive and per-instance feature IDs are present, the instance feature IDs take priority.
+ * @param {String|Number} [options.instanceFeatureIdLabel="instanceFeatureId_0"] Label of the instance feature ID set used for picking and styling. If instanceFeatureIdLabel is set to an integer N, it is converted to the string "instanceFeatureId_N" automatically. If both per-primitive and per-instance feature IDs are present, the instance feature IDs take priority.
+ * @param {Object} [options.pointCloudShading] Options for constructing a {@link PointCloudShading} object to control point attenuation based on geometric error and lighting.
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function ModelExperimental(options) {
@@ -247,6 +249,8 @@ export default function ModelExperimental(options) {
     );
   }
   this._scene = scene;
+
+  this._distanceDisplayCondition = options.distanceDisplayCondition;
 
   const pointCloudShading = new PointCloudShading(options.pointCloudShading);
   this._attenuation = pointCloudShading.attenuation;
@@ -682,6 +686,33 @@ Object.defineProperties(ModelExperimental.prototype, {
         this._heightDirty = true;
       }
       this._heightReference = value;
+    },
+  },
+
+  /**
+   * Gets or sets the distance display condition, which specifies at what distance
+   * from the camera this model will be displayed.
+   *
+   * @memberof ModelExperimental.prototype
+   *
+   * @type {DistanceDisplayCondition}
+   * @default undefined
+   *
+   */
+  distanceDisplayCondition: {
+    get: function () {
+      return this._distanceDisplayCondition;
+    },
+    set: function (value) {
+      //>>includeStart('debug', pragmas.debug);
+      if (defined(value) && value.far <= value.near) {
+        throw new DeveloperError("far must be greater than near");
+      }
+      //>>includeEnd('debug');
+      this._distanceDisplayCondition = DistanceDisplayCondition.clone(
+        value,
+        this._distanceDisplayCondition
+      );
     },
   },
 
@@ -1672,13 +1703,22 @@ function submitDrawCommands(model, frameState) {
   // we want the user to be able to instantly see the model
   // when show is set to true.
 
+  const displayConditionPassed = passesDistanceDisplayCondition(
+    model,
+    frameState
+  );
+
   const invisible = model.isInvisible();
   const silhouette = model.hasSilhouette(frameState);
+
   // If the model is invisible but has a silhouette, it still
   // needs to draw in order to write to the stencil buffer and
   // render the silhouette.
   const showModel =
-    model._show && model._computedScale !== 0 && (!invisible || silhouette);
+    model._show &&
+    model._computedScale !== 0 &&
+    displayConditionPassed &&
+    (!invisible || silhouette);
 
   if (showModel) {
     const asset = model._sceneGraph.components.asset;
@@ -1774,6 +1814,43 @@ function getUpdateHeightCallback(model, ellipsoid, cartoPosition) {
 
     model._heightChanged = true;
   };
+}
+
+const scratchDisplayConditionCartesian = new Cartesian3();
+
+function passesDistanceDisplayCondition(model, frameState) {
+  const ddc = model.distanceDisplayCondition;
+  if (!defined(ddc)) {
+    return true;
+  }
+
+  const nearSquared = ddc.near * ddc.near;
+  const farSquared = ddc.far * ddc.far;
+  let distanceSquared;
+
+  if (frameState.mode === SceneMode.SCENE2D) {
+    const frustum2DWidth =
+      frameState.camera.frustum.right - frameState.camera.frustum.left;
+    const distance = frustum2DWidth * 0.5;
+    distanceSquared = distance * distance;
+  } else {
+    // Distance to center of primitive's reference frame
+    const position = Matrix4.getTranslation(
+      model.modelMatrix,
+      scratchDisplayConditionCartesian
+    );
+
+    // This will project the position if the scene is in Columbus View,
+    // but leave the position as-is in 3D mode.
+    SceneTransforms.computeActualWgs84Position(frameState, position, position);
+
+    distanceSquared = Cartesian3.distanceSquared(
+      position,
+      frameState.camera.positionWC
+    );
+  }
+
+  return distanceSquared >= nearSquared && distanceSquared <= farSquared;
 }
 
 /**
@@ -1959,6 +2036,9 @@ ModelExperimental.prototype.destroyModelResources = function () {
  * @param {Number} [options.minimumPixelSize=0.0] The approximate minimum pixel size of the model regardless of zoom.
  * @param {Number} [options.maximumScale] The maximum scale size of a model. An upper limit for minimumPixelSize.
  * @param {Boolean} [options.incrementallyLoadTextures=true] Determine if textures may continue to stream in after the model is loaded.
+ * @param {Boolean} [options.allowPicking=true] When <code>true</code>, each primitive is pickable with {@link Scene#pick}.
+ * @param {Boolean} [options.clampAnimations=true] Determines if the model's animations should hold a pose over frames where no keyframes are specified.
+ * @param {ShadowMode} [options.shadows=ShadowMode.ENABLED] Determines whether the model casts or receives shadows from light sources.
  * @param {Boolean} [options.releaseGltfJson=false] When true, the glTF JSON is released once the glTF is loaded. This is is especially useful for cases like 3D Tiles, where each .gltf model is unique and caching the glTF JSON is not effective.
  * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for each draw command in the model.
  * @param {Boolean} [options.enableDebugWireframe=false] For debugging only. This must be set to true for debugWireframe to work in WebGL1. This cannot be set after the model has loaded.
@@ -1967,27 +2047,26 @@ ModelExperimental.prototype.destroyModelResources = function () {
  * @param {Boolean} [options.opaquePass=Pass.OPAQUE] The pass to use in the {@link DrawCommand} for the opaque portions of the model.
  * @param {Axis} [options.upAxis=Axis.Y] The up-axis of the glTF model.
  * @param {Axis} [options.forwardAxis=Axis.Z] The forward-axis of the glTF model.
- * @param {Boolean} [options.allowPicking=true] When <code>true</code>, each primitive is pickable with {@link Scene#pick}.
  * @param {CustomShader} [options.customShader] A custom shader. This will add user-defined GLSL code to the vertex and fragment shaders. Using custom shaders with a {@link Cesium3DTileStyle} may lead to undefined behavior.
  * @param {Cesium3DTileContent} [options.content] The tile content this model belongs to. This property will be undefined if model is not loaded as part of a tileset.
  * @param {HeightReference} [options.heightReference=HeightReference.NONE] Determines how the model is drawn relative to terrain.
  * @param {Scene} [options.scene] Must be passed in for models that use the height reference property.
+ * @param {DistanceDisplayCondition} [options.distanceDisplayCondition] The condition specifying at what distance from the camera that this model will be displayed.
  * @param {Color} [options.color] A color that blends with the model's rendered color.
  * @param {ColorBlendMode} [options.colorBlendMode=ColorBlendMode.HIGHLIGHT] Defines how the color blends with the model.
  * @param {Number} [options.colorBlendAmount=0.5] Value used to determine the color strength when the <code>colorBlendMode</code> is <code>MIX</code>. A value of 0.0 results in the model's rendered color while a value of 1.0 results in a solid color, with any value in-between resulting in a mix of the two.
  * @param {Color} [options.silhouetteColor=Color.RED] The silhouette color. If more than 256 models have silhouettes enabled, there is a small chance that overlapping models will have minor artifacts.
  * @param {Number} [options.silhouetteSize=0.0] The size of the silhouette in pixels.
- * @param {String|Number} [options.featureIdLabel="featureId_0"] Label of the feature ID set to use for picking and styling. For EXT_mesh_features, this is the feature ID's label property, or "featureId_N" (where N is the index in the featureIds array) when not specified. EXT_feature_metadata did not have a label field, so such feature ID sets are always labeled "featureId_N" where N is the index in the list of all feature Ids, where feature ID attributes are listed before feature ID textures. If featureIdLabel is an integer N, it is converted to the string "featureId_N" automatically. If both per-primitive and per-instance feature IDs are present, the instance feature IDs take priority.
- * @param {String|Number} [options.instanceFeatureIdLabel="instanceFeatureId_0"] Label of the instance feature ID set used for picking and styling. If instanceFeatureIdLabel is set to an integer N, it is converted to the string "instanceFeatureId_N" automatically. If both per-primitive and per-instance feature IDs are present, the instance feature IDs take priority.
- * @param {Object} [options.pointCloudShading] Options for constructing a {@link PointCloudShading} object to control point attenuation and lighting.
  * @param {ClippingPlaneCollection} [options.clippingPlanes] The {@link ClippingPlaneCollection} used to selectively disable rendering the model.
  * @param {Cartesian3} [options.lightColor] The light color when shading the model. When <code>undefined</code> the scene's light color is used instead.
  * @param {ImageBasedLighting} [options.imageBasedLighting] The properties for managing image-based lighting on this model.
  * @param {Boolean} [options.backFaceCulling=true] Whether to cull back-facing geometry. When true, back face culling is determined by the material's doubleSided property; when false, back face culling is disabled. Back faces are not culled if the model's color is translucent.
- * @param {ShadowMode} [options.shadows=ShadowMode.ENABLED] Determines whether the model casts or receives shadows from light sources.
  * @param {Boolean} [options.showCreditsOnScreen=false] Whether to display the credits of this model on screen.
  * @param {SplitDirection} [options.splitDirection=SplitDirection.NONE] The {@link SplitDirection} split to apply to this model.
  * @param {Boolean} [options.projectTo2D=false] Whether to accurately project the model's positions in 2D. If this is true, the model will be projected accurately to 2D, but it will use more memory to do so. If this is false, the model will use less memory and will still render in 2D / CV mode, but its positions may be inaccurate. This disables minimumPixelSize and prevents future modification to the model matrix. This also cannot be set after the model has loaded.
+ * @param {String|Number} [options.featureIdLabel="featureId_0"] Label of the feature ID set to use for picking and styling. For EXT_mesh_features, this is the feature ID's label property, or "featureId_N" (where N is the index in the featureIds array) when not specified. EXT_feature_metadata did not have a label field, so such feature ID sets are always labeled "featureId_N" where N is the index in the list of all feature Ids, where feature ID attributes are listed before feature ID textures. If featureIdLabel is an integer N, it is converted to the string "featureId_N" automatically. If both per-primitive and per-instance feature IDs are present, the instance feature IDs take priority.
+ * @param {String|Number} [options.instanceFeatureIdLabel="instanceFeatureId_0"] Label of the instance feature ID set used for picking and styling. If instanceFeatureIdLabel is set to an integer N, it is converted to the string "instanceFeatureId_N" automatically. If both per-primitive and per-instance feature IDs are present, the instance feature IDs take priority.
+ * @param {Object} [options.pointCloudShading] Options for constructing a {@link PointCloudShading} object to control point attenuation and lighting.
  * @returns {ModelExperimental} The newly created model.
  */
 ModelExperimental.fromGltf = function (options) {
@@ -2200,5 +2279,6 @@ function makeModelOptions(loader, modelType, options) {
     showCreditsOnScreen: options.showCreditsOnScreen,
     splitDirection: options.splitDirection,
     projectTo2D: options.projectTo2D,
+    distanceDisplayCondition: options.distanceDisplayCondition,
   };
 }

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -1564,6 +1564,9 @@ describe(
 
         model.distanceDisplayCondition = ddc;
         verifyRender(model, false);
+
+        model.distanceDisplayCondition = undefined;
+        verifyRender(model, true);
       });
     });
 

--- a/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalSpec.js
@@ -1538,11 +1538,11 @@ describe(
     it("initializes with distance display condition", function () {
       const near = 10.0;
       const far = 100.0;
-      const ddc = new DistanceDisplayCondition(near, far);
+      const condition = new DistanceDisplayCondition(near, far);
       return loadAndZoomToModelExperimental(
         {
           gltf: boxTexturedGltfUrl,
-          distanceDisplayCondition: ddc,
+          distanceDisplayCondition: condition,
         },
         scene
       ).then(function (model) {
@@ -1553,7 +1553,7 @@ describe(
     it("changing distance display condition works", function () {
       const near = 10.0;
       const far = 100.0;
-      const ddc = new DistanceDisplayCondition(near, far);
+      const condition = new DistanceDisplayCondition(near, far);
       return loadAndZoomToModelExperimental(
         {
           gltf: boxTexturedGltfUrl,
@@ -1562,7 +1562,7 @@ describe(
       ).then(function (model) {
         verifyRender(model, true);
 
-        model.distanceDisplayCondition = ddc;
+        model.distanceDisplayCondition = condition;
         verifyRender(model, false);
 
         model.distanceDisplayCondition = undefined;
@@ -1573,7 +1573,7 @@ describe(
     it("distanceDisplayCondition works with camera movement", function () {
       const near = 10.0;
       const far = 100.0;
-      const ddc = new DistanceDisplayCondition(near, far);
+      const condition = new DistanceDisplayCondition(near, far);
       return loadAndZoomToModelExperimental(
         {
           gltf: boxTexturedGltfUrl,
@@ -1583,7 +1583,7 @@ describe(
         verifyRender(model, true);
 
         // Model distance is smaller than near value, should not render
-        model.distanceDisplayCondition = ddc;
+        model.distanceDisplayCondition = condition;
         verifyRender(model, false);
 
         const frameState = scene.frameState;
@@ -1611,7 +1611,7 @@ describe(
     it("distanceDisplayCondition throws when near >= far", function () {
       const near = 101.0;
       const far = 100.0;
-      const ddc = new DistanceDisplayCondition(near, far);
+      const condition = new DistanceDisplayCondition(near, far);
       return loadAndZoomToModelExperimental(
         {
           gltf: boxTexturedGltfUrl,
@@ -1619,7 +1619,7 @@ describe(
         scene
       ).then(function (model) {
         expect(function () {
-          model.distanceDisplayCondition = ddc;
+          model.distanceDisplayCondition = condition;
         }).toThrowDeveloperError();
       });
     });

--- a/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
+++ b/Specs/Scene/ModelExperimental/loadAndZoomToModelExperimental.js
@@ -38,6 +38,7 @@ function loadAndZoomToModelExperimental(options, scene) {
         projectTo2D: options.projectTo2D,
         heightReference: options.heightReference,
         scene: options.scene,
+        distanceDisplayCondition: options.distanceDisplayCondition,
       });
     } catch (error) {
       reject(error);


### PR DESCRIPTION
This PR adds `distanceDisplayCondition` to `ModelExperimental`. Pretty straightforward, just mimics the implementation in `Model.js`. Here's the [Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=rVRRT9swEP4rVp5SqXO6saqsFDTUAnugAwnGNC17MPa1tebYke2UMsR/39lpstCyPa1qq5x93+fzd9+FG+08WUt4AEuOiYYHMgUnq4LexbU0T3iMp0Z7JjXYPOkd5ZpHnOOgAWE1nsYQN3O9qDT30mjChLg2UvtTLeZGgEp75CnXhNwwLThzXgEVwBWzkO6m9iITIfVRpXEyMh43BU6Z9fjE9AFdWFPMYGkBXPpmNKTDD6PRqE/eD+jg4PDwYJcJD7m2skC+NTgkjHXTsl2iWEoaAKQryPUL3NQoBfGOaS+khjPILnckeqqZuFHGjtviQ0S/nV1eXn3t1wnNDcft03ZDSOeZ5jCTrlTsETshtomd6mZ/Sdreg5B3wwEd1kEvEj83svzj+lvy2I+zTQmYA+gDFRW/UH7R3I6QyqoxyRNKM/zesKJUMGOeZUXAuuzCmkqLO1hJruBlRJfqPk/6DVEEzJm3ctPKdWuZdgtjC0cBXfPZWL/6Ut6ac7kBcW5ZAWkjWq8l+j+6EYIu6v+JOjo2SgYtGw88B0077kYtb41R98zOQVfp95C31czDxgfJorEIQkjUuZUC3QrBY2PSjlMzPuGzP1pHzVbn/JVcrhT+/KvzFWuv3YD/P2pHdNAWHHickL0CthPPUXnL6EI9fjLYg0HNuWcoC4VZw6mqa3yOpyT9ZOL8o4KTpuqPsiixscFJKXrIA3qI4Yhn9xX/CZ5y55qaJ1kXOhFyTaQ4fuVdRfDd4hzuLCqlbuQvyJOTSYb5e1BlmJB6ebUGiz4Iaau3J5f1IqV0kmH4OtLX/d1h/g0) for testing.

<img src="https://user-images.githubusercontent.com/32226860/175660057-54e9f840-3d7e-429e-a844-044f8aa1b9a8.gif" width="350" />

I ended up reorganizing the documentation for the constructor / `fromGltf` function, but it was to match the order of the parameters in `Model`. This way it's easier to see the differences between the APIs.