### PR TITLE
Fix TextureManager test failure on Linux

### DIFF
--- a/Specs/Scene/ModelExperimental/TextureManagerSpec.js
+++ b/Specs/Scene/ModelExperimental/TextureManagerSpec.js
@@ -55,7 +55,7 @@ describe(
     const blueUrl = "Data/Images/Blue2x2.png";
     const greenUrl = "Data/Images/Green1x4.png";
     const redUrl = "Data/Images/Red16x16.png";
-    const blue10x10Url = "/Data/Images/Blue10x10.png";
+    const blue10x10Url = "Data/Images/Blue10x10.png";
 
     it("constructs", function () {
       const textureManager = new TextureManager();


### PR DESCRIPTION
Resolves #10493.

Removes an extra `/` in the URL to one of the testing datasets, which made the in-browser SpecRunner fail with an HTTP 404 on Linux.