### PR TITLE
Fix shadow artifacts in `ModelExperimental`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@
 - Warn if `Cesium3DTile` content.uri property is empty, and load empty tile. [#7263](https://github.com/CesiumGS/cesium/issues/7263)
 - Updated text highlighting for code examples in documentation. [#10051](https://github.com/CesiumGS/cesium/issues/10051)
 - Updated ModelExperimental shader defaults to match glTF spec. [#9992](https://github.com/CesiumGS/cesium/issues/9992)
+- Fixed shadow rendering artifacts that appeared in `ModelExperimental`. [#10501](https://github.com/CesiumGS/cesium/pull/10501/)
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/Source/Renderer/ShaderSource.js
+++ b/Source/Renderer/ShaderSource.js
@@ -443,6 +443,17 @@ ShaderSource.createPickFragmentShaderSource = function (
   return `${renamedFS}\n${pickMain}`;
 };
 
+function containsDefine(shaderSource, define) {
+  const defines = shaderSource.defines;
+  const definesLength = defines.length;
+  for (let i = 0; i < definesLength; ++i) {
+    if (defines[i] === define) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function containsString(shaderSource, string) {
   const sources = shaderSource.sources;
   const sourcesLength = sources.length;
@@ -471,7 +482,7 @@ ShaderSource.findNormalVarying = function (shaderSource) {
   // Fix for ModelExperimental: the shader text always has the word v_normalEC
   // wrapped in an #ifdef so instead of looking for v_normalEC look for the define
   if (containsString(shaderSource, "#ifdef HAS_NORMALS")) {
-    if (containsString(shaderSource, "#define HAS_NORMALS")) {
+    if (containsDefine(shaderSource, "HAS_NORMALS")) {
       return "v_normalEC";
     }
     return undefined;


### PR DESCRIPTION
This PR removes the shadow artifacts that appeared whenever shadows were toggled for `ModelExperimental`.

| `ModelExperimental` | `Model` |
| ---------------------- | --------- |
| ![image](https://user-images.githubusercontent.com/32226860/175663403-3f40f41d-bb36-4944-98a3-abda27cfce42.png) |![image](https://user-images.githubusercontent.com/32226860/176726049-813eae1e-960c-43e0-b437-4ce3a9de7148.png) |

(The shadows are in a different place because these were taken at different times of day.)

The bug resulted from a fix in #10097. The shader had to be checked for `#define HAS_NORMALS` in order to confirm that normals did exist for the model, and thus had a varying in the fragment shader. However, the actual shader text doesn't contain defines; these are stored in a separate `defines` array under `ShaderSource`. So this was incorrectly assuming that the model didn't provide its own normals, and the shadow shader would use a dummy value `vec3(1.0)` as the normal instead.