### PR TITLE
Add check for double sided materials in `ModelExperimental`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@
 - Warn if `Cesium3DTile` content.uri property is empty, and load empty tile. [#7263](https://github.com/CesiumGS/cesium/issues/7263)
 - Updated text highlighting for code examples in documentation. [#10051](https://github.com/CesiumGS/cesium/issues/10051)
 - Updated ModelExperimental shader defaults to match glTF spec. [#9992](https://github.com/CesiumGS/cesium/issues/9992)
+- Fixed shadow rendering artifacts that appeared in `ModelExperimental`. [#10501](https://github.com/CesiumGS/cesium/pull/10501/)
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,10 @@
 ##### Deprecated :hourglass_flowing_sand:
 
 - The `.getPropertyNames` methods of `Cesium3DTileFeature`, `Cesium3DTilePointFeature`, and `ModelFeature` have been deprecated and will be removed in 1.98. Use the `.getPropertyIds` methods instead.
+- Support for glTF 1.0 assets has been deprecated and will be removed in CesiumJS 1.96. Please convert any glTF 1.0 assets to glTF 2.0. [#10414](https://github.com/CesiumGS/cesium/pull/10414)
+- Support for the glTF extension `KHR_techniques_webgl` has been deprecated and will be removed in CesiumJS 1.96. If custom GLSL shaders are needed, use `CustomShader` instead. [#10414](https://github.com/CesiumGS/cesium/pull/10414)
+- `Model.gltf`, `Model.basePath`, `Model.pendingTextureLoads` (properties), and `Model.dequantizeInShader` (constructor option) were deprecate in CesiumJS 1.94 and will be removed in CesiumJS 1.96. [#10415](https://github.com/CesiumGS/cesium/pull/10415)
+- `Model.boundingSphere` currently returns results in the model's local coordinate system, but in CesiumJS 1.96 it will be changed to return results in ECEF coordinates. [#10415](https://github.com/CesiumGS/cesium/pull/10415)
 
 ### 1.94.3 - 2022-06-10
 
@@ -89,10 +93,6 @@
 
 ##### Deprecated :hourglass_flowing_sand:
 
-- Support for glTF 1.0 assets has been deprecated and will be removed in CesiumJS 1.95. Please convert any glTF 1.0 assets to glTF 2.0. [#10414](https://github.com/CesiumGS/cesium/pull/10414)
-- Support for the glTF extension `KHR_techniques_webgl` has been deprecated and will be removed in CesiumJS 1.95. If custom GLSL shaders are needed, use `CustomShader` instead. [#10414](https://github.com/CesiumGS/cesium/pull/10414)
-- `Model.gltf`, `Model.basePath`, `Model.pendingTextureLoads` (properties), and `Model.dequantizeInShader` (constructor option) were deprecate in CesiumJS 1.94 and will be removed in CesiumJS 1.95. [#10415](https://github.com/CesiumGS/cesium/pull/10415)
-- `Model.boundingSphere` currently returns results in the model's local coordinate system, but in CesiumJS 1.95 it will be changed to return results in ECEF coordinates. [#10415](https://github.com/CesiumGS/cesium/pull/10415)
 - `Cesium3DTileStyle` constructor parameters of `string` or `Resource` type have been deprecated and will be removed in CesiumJS 1.96. If loading a style from a url, use `Cesium3DTileStyle.fromUrl` instead. [#10348](https://github.com/CesiumGS/cesium/pull/10348)
 - `Cesium3DTileStyle.readyPromise` and `Cesium3DTileStyle.ready` have been deprecated and will be removed in CesiumJS 1.96. If loading a style from a url, use `Cesium3DTileStyle.fromUrl` instead. [#10348](https://github.com/CesiumGS/cesium/pull/10348)
 

--- a/Source/Core/GoogleEarthEnterpriseTerrainProvider.js
+++ b/Source/Core/GoogleEarthEnterpriseTerrainProvider.js
@@ -82,7 +82,7 @@ TerrainCache.prototype.tidy = function () {
  * @see CesiumTerrainProvider
  *
  * @example
- * const geeMetadata = new GoogleEarthEnterpriseMetadata('http://www.earthenterprise.org/3d');
+ * const geeMetadata = new GoogleEarthEnterpriseMetadata('http://www.example.com');
  * const gee = new Cesium.GoogleEarthEnterpriseTerrainProvider({
  *     metadata : geeMetadata
  * });

--- a/Source/Core/Ion.js
+++ b/Source/Core/Ion.js
@@ -4,7 +4,8 @@ import Resource from "./Resource.js";
 
 let defaultTokenCredit;
 const defaultAccessToken =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI5MTdhODgxYi1hNzE4LTRlYjAtOWY4Zi0yN2RjNmIxMDA3MWEiLCJpZCI6MjU5LCJpYXQiOjE2NTQwOTk1ODB9.6fgeb1wewbbv88IZBRvjGM6tqNXXc_3x0Lawo8lCt7c";
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIwNzAxODk2YS03MTc4LTQxYmYtOWYwMC0xZmUwNTQ5ZWYwMDYiLCJpZCI6MjU5LCJpYXQiOjE2NTY2ODI5ODF9.9O2dVq-nQdlJbXG3lZYFNpzv_tR0jF_xjr0gb02x9M4";
+
 /**
  * Default settings for accessing the Cesium ion API.
  *

--- a/Source/Renderer/ShaderSource.js
+++ b/Source/Renderer/ShaderSource.js
@@ -443,6 +443,17 @@ ShaderSource.createPickFragmentShaderSource = function (
   return `${renamedFS}\n${pickMain}`;
 };
 
+function containsDefine(shaderSource, define) {
+  const defines = shaderSource.defines;
+  const definesLength = defines.length;
+  for (let i = 0; i < definesLength; ++i) {
+    if (defines[i] === define) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function containsString(shaderSource, string) {
   const sources = shaderSource.sources;
   const sourcesLength = sources.length;
@@ -471,7 +482,7 @@ ShaderSource.findNormalVarying = function (shaderSource) {
   // Fix for ModelExperimental: the shader text always has the word v_normalEC
   // wrapped in an #ifdef so instead of looking for v_normalEC look for the define
   if (containsString(shaderSource, "#ifdef HAS_NORMALS")) {
-    if (containsString(shaderSource, "#define HAS_NORMALS")) {
+    if (containsDefine(shaderSource, "HAS_NORMALS")) {
       return "v_normalEC";
     }
     return undefined;

--- a/Source/Scene/GoogleEarthEnterpriseImageryProvider.js
+++ b/Source/Scene/GoogleEarthEnterpriseImageryProvider.js
@@ -79,7 +79,7 @@ GoogleEarthEnterpriseDiscardPolicy.prototype.shouldDiscardImage = function (
  *
  *
  * @example
- * const geeMetadata = new GoogleEarthEnterpriseMetadata('http://www.earthenterprise.org/3d');
+ * const geeMetadata = new GoogleEarthEnterpriseMetadata('http://www.example.com');
  * const gee = new Cesium.GoogleEarthEnterpriseImageryProvider({
  *     metadata : geeMetadata
  * });

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -221,7 +221,7 @@ const uriToGuid = {};
  * @param {Color} [options.silhouetteColor=Color.RED] The silhouette color. If more than 256 models have silhouettes enabled, there is a small chance that overlapping models will have minor artifacts.
  * @param {Number} [options.silhouetteSize=0.0] The size of the silhouette in pixels.
  * @param {ClippingPlaneCollection} [options.clippingPlanes] The {@link ClippingPlaneCollection} used to selectively disable rendering the model.
- * @param {Boolean} [options.dequantizeInShader=true] Determines if a {@link https://github.com/google/draco|Draco} encoded model is dequantized on the GPU. This decreases total memory usage for encoded models. Deprecated in CesiumJS 1.94, will be removed in CesiumJS 1.95.
+ * @param {Boolean} [options.dequantizeInShader=true] Determines if a {@link https://github.com/google/draco|Draco} encoded model is dequantized on the GPU. This decreases total memory usage for encoded models. Deprecated in CesiumJS 1.94, will be removed in CesiumJS 1.96.
  * @param {Cartesian3} [options.lightColor] The light color when shading the model. When <code>undefined</code> the scene's light color is used instead.
  * @param {ImageBasedLighting} [options.imageBasedLighting] The properties for managing image-based lighting on this model.
  * @param {Credit|String} [options.credit] A credit for the data source, which is displayed on the canvas.
@@ -659,7 +659,7 @@ function Model(options) {
   if (options.dequantizeInShader) {
     deprecationWarning(
       "Model.dequantizeInShader",
-      "The Model dequantizeInShader constructor parameter was deprecated in CesiumJS 1.94 and will be removed in 1.95"
+      "The Model dequantizeInShader constructor parameter was deprecated in CesiumJS 1.94 and will be removed in 1.96"
     );
   }
 
@@ -722,7 +722,7 @@ Object.defineProperties(Model.prototype, {
     get: function () {
       deprecationWarning(
         "Model.gltf",
-        "Model.gltf getter was deprecated in CesiumJS 1.94 and will be removed in 1.95"
+        "Model.gltf getter was deprecated in CesiumJS 1.94 and will be removed in 1.96"
       );
 
       return this.gltfInternal;
@@ -803,7 +803,7 @@ Object.defineProperties(Model.prototype, {
     get: function () {
       deprecationWarning(
         "model.basePath",
-        "Model.basePath getter is deprecated in CesiumJS 1.94. It will be removed in CesiumJS 1.95"
+        "Model.basePath getter is deprecated in CesiumJS 1.94. It will be removed in CesiumJS 1.96"
       );
       return this.basePathInternal;
     },
@@ -840,7 +840,7 @@ Object.defineProperties(Model.prototype, {
     get: function () {
       deprecationWarning(
         "model.boundingSphere",
-        "Model.boundingSphere currently returns results in model space. In CesiumJS 1.95, model.boundingSphere will be changed to return results in world space. The calling code will no longer need to multiply the bounding sphere by the model matrix"
+        "Model.boundingSphere currently returns results in model space. In CesiumJS 1.96, model.boundingSphere will be changed to return results in world space. The calling code will no longer need to multiply the bounding sphere by the model matrix"
       );
       return this.boundingSphereInternal;
     },
@@ -1008,7 +1008,7 @@ Object.defineProperties(Model.prototype, {
     get: function () {
       deprecationWarning(
         "Model.pendingTextureLoads",
-        "The Model.pendingTextureLoads getter was deprecated in CesiumJS 1.94 and will be removed in CesiumJS 1.95"
+        "The Model.pendingTextureLoads getter was deprecated in CesiumJS 1.94 and will be removed in CesiumJS 1.96"
       );
 
       return this.pendingTextureLoadsInternal;
@@ -1427,7 +1427,7 @@ function containsGltfMagic(uint8Array) {
  * @param {Color} [options.silhouetteColor=Color.RED] The silhouette color. If more than 256 models have silhouettes enabled, there is a small chance that overlapping models will have minor artifacts.
  * @param {Number} [options.silhouetteSize=0.0] The size of the silhouette in pixels.
  * @param {ClippingPlaneCollection} [options.clippingPlanes] The {@link ClippingPlaneCollection} used to selectively disable rendering the model.
- * @param {Boolean} [options.dequantizeInShader=true] Determines if a {@link https://github.com/google/draco|Draco} encoded model is dequantized on the GPU. This decreases total memory usage for encoded models. Deprecated in CesiumJS 1.94, will be removed in CesiumJS 1.95.
+ * @param {Boolean} [options.dequantizeInShader=true] Determines if a {@link https://github.com/google/draco|Draco} encoded model is dequantized on the GPU. This decreases total memory usage for encoded models. Deprecated in CesiumJS 1.94, will be removed in CesiumJS 1.96.
  * @param {Cartesian3} [options.lightColor] The light color when shading the model. When <code>undefined</code> the scene's light color is used instead.
  * @param {ImageBasedLighting} [options.imageBasedLighting] The properties for managing image-based lighting for this tileset.
  * @param {Credit|String} [options.credit] A credit for the model, which is displayed on the canvas.
@@ -5319,14 +5319,14 @@ Model.prototype.update = function (frameState) {
           if (sourceVersion !== "2.0") {
             deprecationWarning(
               "gltf-1.0",
-              "glTF 1.0 assets were deprecated in CesiumJS 1.94. They will be removed in 1.95. Please convert any glTF 1.0 assets to glTF 2.0."
+              "glTF 1.0 assets were deprecated in CesiumJS 1.94. They will be removed in 1.96. Please convert any glTF 1.0 assets to glTF 2.0."
             );
           }
 
           if (sourceKHRTechniquesWebGL) {
             deprecationWarning(
               "KHR_techniques_webgl",
-              "Support for glTF 1.0 techniques and the KHR_techniques_webgl glTF extension were deprecated in CesiumJS 1.94. It will be removed in 1.95. If custom GLSL shaders are needed, use CustomShader instead."
+              "Support for glTF 1.0 techniques and the KHR_techniques_webgl glTF extension were deprecated in CesiumJS 1.94. It will be removed in 1.96. If custom GLSL shaders are needed, use CustomShader instead."
             );
           }
 

--- a/Source/Scene/ModelExperimental/MaterialPipelineStage.js
+++ b/Source/Scene/ModelExperimental/MaterialPipelineStage.js
@@ -130,6 +130,14 @@ MaterialPipelineStage.process = function (
       ShaderDestination.FRAGMENT
     );
   }
+
+  if (material.doubleSided) {
+    shaderBuilder.addDefine(
+      "HAS_DOUBLE_SIDED_MATERIAL",
+      undefined,
+      ShaderDestination.FRAGMENT
+    );
+  }
 };
 
 /**

--- a/Source/Shaders/ModelExperimental/MaterialStageFS.glsl
+++ b/Source/Shaders/ModelExperimental/MaterialStageFS.glsl
@@ -52,6 +52,12 @@ vec3 computeNormal(ProcessedAttributes attributes)
         #endif
     #endif
 
+    #ifdef HAS_DOUBLE_SIDED_MATERIAL
+    if (czm_backFacing()) {
+        normal = -normal;
+    }
+    #endif
+
     return normal;
 }
 #endif

--- a/Specs/Scene/ModelExperimental/MaterialPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/MaterialPipelineStageSpec.js
@@ -80,6 +80,8 @@ describe(
     const boxNoNormals =
       "./Data/Models/GltfLoader/BoxNoNormals/glTF/BoxNoNormals.gltf";
     const triangle = "./Data/Models/GltfLoader/Triangle/glTF/Triangle.gltf";
+    const twoSidedPlane =
+      "./Data/Models/GltfLoader/TwoSidedPlane/glTF/TwoSidedPlane.gltf";
 
     function expectShaderLines(shaderLines, expected) {
       for (let i = 0; i < expected.length; i++) {
@@ -738,14 +740,37 @@ describe(
         );
 
         expectShaderLines(shaderBuilder._fragmentShaderParts.defineLines, [
-          "HAS_EMISSIVE_TEXTURE",
-          "TEXCOORD_EMISSIVE v_texCoord_0",
-          "HAS_EMISSIVE_FACTOR",
-          "HAS_NORMAL_TEXTURE",
-          "TEXCOORD_NORMAL v_texCoord_0",
-          "HAS_OCCLUSION_TEXTURE",
-          "TEXCOORD_OCCLUSION v_texCoord_0",
           "USE_WIREFRAME",
+        ]);
+      });
+    });
+
+    it("adds define to shader if material is double-sided", function () {
+      return loadGltf(twoSidedPlane).then(function (gltfLoader) {
+        const components = gltfLoader.components;
+        const primitive = components.nodes[0].primitives[0];
+        const shaderBuilder = new ShaderBuilder();
+        const uniformMap = {};
+        const renderResources = {
+          shaderBuilder: shaderBuilder,
+          uniformMap: uniformMap,
+          lightingOptions: new ModelLightingOptions(),
+          alphaOptions: new ModelAlphaOptions(),
+          renderStateOptions: {},
+          model: {
+            statistics: new ModelExperimentalStatistics(),
+            debugWireframe: true,
+          },
+        };
+
+        MaterialPipelineStage.process(
+          renderResources,
+          primitive,
+          mockFrameState
+        );
+
+        expectShaderLines(shaderBuilder._fragmentShaderParts.defineLines, [
+          "HAS_DOUBLE_SIDED_MATERIAL",
         ]);
       });
     });

--- a/Specs/Scene/ModelExperimental/TextureManagerSpec.js
+++ b/Specs/Scene/ModelExperimental/TextureManagerSpec.js
@@ -55,7 +55,7 @@ describe(
     const blueUrl = "Data/Images/Blue2x2.png";
     const greenUrl = "Data/Images/Green1x4.png";
     const redUrl = "Data/Images/Red16x16.png";
-    const blue10x10Url = "/Data/Images/Blue10x10.png";
+    const blue10x10Url = "Data/Images/Blue10x10.png";
 
     it("constructs", function () {
       const textureManager = new TextureManager();

--- a/ThirdParty.json
+++ b/ThirdParty.json
@@ -4,7 +4,7 @@
     "license": [
       "BSD-3-Clause"
     ],
-    "version": "2.4.12",
+    "version": "2.4.26",
     "url": "https://www.npmjs.com/package/@zip.js/zip.js"
   },
   {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cesium",
-  "version": "1.95",
+  "version": "1.95.0",
   "description": "CesiumJS is a JavaScript library for creating 3D globes and 2D maps in a web browser without a plugin.",
   "homepage": "http://cesium.com/cesiumjs/",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cesium",
-  "version": "1.94.3",
+  "version": "1.95",
   "description": "CesiumJS is a JavaScript library for creating 3D globes and 2D maps in a web browser without a plugin.",
   "homepage": "http://cesium.com/cesiumjs/",
   "license": "Apache-2.0",


### PR DESCRIPTION
Some of the sample model from [glTF-Sample-Models](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0) weren't rendering properly in `ModelExperimental`. These models used double-sided materials, which `MaterialStageFS` did not account for.

This now results in the correct rendering of the following models:
- [TwoSidedPlane](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/TwoSidedPlane)
- [NormalTangentMirrorTest](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/NormalTangentMirrorTest)
- [NormalTangentTest](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/NormalTangentTest)

See [the comment on the roadmap issue](https://github.com/CesiumGS/cesium/issues/10346#issuecomment-1171566482) for screenshots of the old `ModelExperimental` result vs. the expected result in `Model` (which matches glTF-Sample-Viewer).