### PR TITLE
"3D Models Coloring" Fix with `ModelExperimental`

### DIFF
--- a/Apps/Sandcastle/gallery/development/3D Models.html
+++ b/Apps/Sandcastle/gallery/development/3D Models.html
@@ -157,7 +157,7 @@
         Cesium.knockout
           .getObservable(viewModel, "colorBlendAmount")
           .subscribe(function (newValue) {
-            model.colorBlendAmount = newValue;
+            model.colorBlendAmount = Number(newValue);
           });
 
         function createModel(url, height, heading, pitch, roll) {

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 - Fixed a crash in the 3D Tiles Feature Styling sandcastle that occurred when using `ModelExperimental`. [#10514](https://github.com/CesiumGS/cesium/pull/10514)
 - Fixed improper handling of double-sided materials in `ModelExperimental`. [#10507](https://github.com/CesiumGS/cesium/pull/10507)
-- Fixed a bug where the color alpha wouldn't change in the 3D Models Coloring sandcastle when using `ModelExperimental`. [#10519](https://github.com/CesiumGS/cesium/pull/10519/)
+- Fixed a bug where the alpha component of `model.color` would not update in the 3D Models Coloring sandcastle when using `ModelExperimental`. [#10519](https://github.com/CesiumGS/cesium/pull/10519)
 
 ### 1.95 - 2022-07-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Fixed a crash in the 3D Tiles Feature Styling sandcastle that occurred when using `ModelExperimental`. [#10514](https://github.com/CesiumGS/cesium/pull/10514)
 - Fixed improper handling of double-sided materials in `ModelExperimental`. [#10507](https://github.com/CesiumGS/cesium/pull/10507)
+- Fixed a bug where the color alpha wouldn't change in the 3D Models Coloring sandcastle when using `ModelExperimental`. [#10519](https://github.com/CesiumGS/cesium/pull/10519/)
 
 ### 1.95 - 2022-07-01
 

--- a/Source/DataSources/ModelVisualizer.js
+++ b/Source/DataSources/ModelVisualizer.js
@@ -33,6 +33,7 @@ const defaultImageBasedLightingFactor = new Cartesian2(1.0, 1.0);
 const modelMatrixScratch = new Matrix4();
 const nodeMatrixScratch = new Matrix4();
 
+const scratchColor = new Color();
 /**
  * A {@link Visualizer} which maps {@link Entity#model} to a {@link Model}.
  * @alias ModelVisualizer
@@ -179,7 +180,7 @@ ModelVisualizer.prototype.update = function (time) {
       modelGraphics._silhouetteColor,
       time,
       defaultSilhouetteColor,
-      model._silhouetteColor
+      scratchColor
     );
     model.silhouetteSize = Property.getValueOrDefault(
       modelGraphics._silhouetteSize,
@@ -190,7 +191,7 @@ ModelVisualizer.prototype.update = function (time) {
       modelGraphics._color,
       time,
       defaultColor,
-      model._color
+      scratchColor
     );
     model.colorBlendMode = Property.getValueOrDefault(
       modelGraphics._colorBlendMode,

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -188,7 +188,7 @@ export default function ModelExperimental(options) {
   this._idDirty = false;
 
   const color = options.color;
-  this._color = defaultValue(color) ? Color.clone(color) : undefined;
+  this._color = defined(color) ? Color.clone(color) : undefined;
   this._colorBlendMode = defaultValue(
     options.colorBlendMode,
     ColorBlendMode.HIGHLIGHT
@@ -199,6 +199,10 @@ export default function ModelExperimental(options) {
   this._silhouetteColor = Color.clone(silhouetteColor);
   this._silhouetteSize = defaultValue(options.silhouetteSize, 0.0);
   this._silhouetteDirty = false;
+
+  // If silhouettes are used for the model, this set to a number coresponding to
+  // the stencil buffer used for rendering the silhouette.
+  this._silhouetteId = undefined;
 
   this._cull = defaultValue(options.cull, true);
   this._opaquePass = defaultValue(options.opaquePass, Pass.OPAQUE);
@@ -404,7 +408,10 @@ function selectFeatureTableId(components, model) {
   }
 }
 
-// Returns whether the color alpha state has changed between invisible, translucent, or opaque
+/**
+ *  Returns whether the alpha state has changed between invisible,
+ *  translucent, or opaque.
+ */
 function isColorAlphaDirty(currentColor, previousColor) {
   if (!defined(currentColor) && !defined(previousColor)) {
     return false;
@@ -886,7 +893,7 @@ Object.defineProperties(ModelExperimental.prototype, {
       return this._color;
     },
     set: function (value) {
-      if (!Color.equals(this._color, value)) {
+      if (isColorAlphaDirty(value, this._color)) {
         this.resetDrawCommands();
       }
       this._color = Color.clone(value, this._color);

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -411,6 +411,8 @@ function selectFeatureTableId(components, model) {
 /**
  *  Returns whether the alpha state has changed between invisible,
  *  translucent, or opaque.
+ *
+ *  @private
  */
 function isColorAlphaDirty(currentColor, previousColor) {
   if (!defined(currentColor) && !defined(previousColor)) {

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -200,8 +200,9 @@ export default function ModelExperimental(options) {
   this._silhouetteSize = defaultValue(options.silhouetteSize, 0.0);
   this._silhouetteDirty = false;
 
-  // If silhouettes are used for the model, this set to a number coresponding to
-  // the stencil buffer used for rendering the silhouette.
+  // If silhouettes are used for the model, this will be set to the number
+  // of the stencil buffer used for rendering the silhouette. This is set
+  // by ModelSilhouettePipelineStage, not by ModelExperimental itself.
   this._silhouetteId = undefined;
 
   this._cull = defaultValue(options.cull, true);

--- a/Source/Scene/ModelExperimental/ModelExperimentalDrawCommand.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalDrawCommand.js
@@ -46,8 +46,8 @@ function ModelExperimentalDrawCommand(options) {
 
   this._command = command;
 
-  // Only derived if the original command wasn't translucent and the model's style
-  // has translucency.
+  // Only derived if the original command wasn't translucent and
+  // the model's style has translucency.
   this._translucentCommand = undefined;
 
   this._modelMatrix = Matrix4.clone(command.modelMatrix, new Matrix4());
@@ -64,9 +64,22 @@ function ModelExperimentalDrawCommand(options) {
   this._debugShowBoundingVolume = command.debugShowBoundingVolume;
   this._useSilhouetteCommands = useSilhouetteCommands;
 
-  // TODO: reorganize
+  // The command list contains one or more of the following commands:
+  // - the original draw command
+  // - the translucent derived command
+  //
+  // When silhouettes are enabled, these are replaced by derived commands
+  // that render the primitive to the stencil buffer.
   this._commandList = [];
+
+  // The above commands are duplicated for rendering over the IDL in 2D.
   this._commandList2D = [];
+
+  // These commands are only derived if the model uses silhouettes.
+  // They are stored separately so that the entire model can be drawn
+  // before the silhouette is rendered.
+  this._silhouetteCommandList = [];
+  this._silhouetteCommandList2D = [];
 
   this._runtimePrimitive = renderResources.runtimePrimitive;
   this._model = renderResources.model;
@@ -335,21 +348,17 @@ function buildCommandList(drawCommand) {
         command,
         model
       );
-      silhouetteCommands.push(silhouetteModelCommand);
+
+      // Replace the original command with the derived one.
+      commandList[i] = silhouetteModelCommand;
+
+      // Store the silhouette-pass commands separately.
       silhouetteCommands.push(silhouetteColorCommand);
     }
 
-    // Replace the original command list.
-    commandList.length = 0;
-    commandList.push.apply(commandList, silhouetteCommands);
+    const silhouetteCommandList = drawCommand._silhouetteCommandList;
+    silhouetteCommandList.push.apply(silhouetteCommandList, silhouetteCommands);
   }
-}
-
-function getAllCommands(drawCommand) {
-  const commandList = [];
-  commandList.push.apply(commandList, drawCommand._commandList);
-  commandList.push.apply(commandList, drawCommand._commandList2D);
-  return commandList;
 }
 
 const scratchMatrix2D = new Matrix4();
@@ -369,12 +378,31 @@ function updateModelMatrix(drawCommand) {
       command.boundingVolume
     );
   }
+
+  if (!drawCommand._useSilhouetteCommands) {
+    return;
+  }
+
+  const silhouetteCommandList = drawCommand._silhouetteCommandList;
+  for (let i = 0; i < length; i++) {
+    const silhouetteCommand = silhouetteCommandList[i];
+    silhouetteCommand.modelMatrix = Matrix4.clone(
+      modelMatrix,
+      silhouetteCommand.modelMatrix
+    );
+    silhouetteCommand.boundingVolume = BoundingSphere.transform(
+      boundingSphere,
+      silhouetteCommand.modelMatrix,
+      silhouetteCommand.boundingVolume
+    );
+  }
 }
 
 function updateModelMatrix2D(drawCommand, frameState) {
   const modelMatrix = drawCommand.modelMatrix;
   const boundingSphere = drawCommand.runtimePrimitive.boundingSphere;
   const commandList2D = drawCommand._commandList2D;
+
   const length2D = commandList2D.length;
   if (length2D === 0) {
     return;
@@ -399,6 +427,24 @@ function updateModelMatrix2D(drawCommand, frameState) {
       command.boundingVolume
     );
   }
+
+  if (!drawCommand._useSilhouetteCommands) {
+    return;
+  }
+
+  const silhouetteCommandList2D = drawCommand._silhouetteCommandList2D;
+  for (let i = 0; i < length2D; i++) {
+    const silhouetteCommand = silhouetteCommandList2D[i];
+    silhouetteCommand.modelMatrix = Matrix4.clone(
+      modelMatrix2D,
+      silhouetteCommand.modelMatrix
+    );
+    silhouetteCommand.boundingVolume = BoundingSphere.transform(
+      boundingSphere,
+      silhouetteCommand.modelMatrix,
+      silhouetteCommand.boundingVolume
+    );
+  }
 }
 
 function updateShadows(drawCommand) {
@@ -406,7 +452,7 @@ function updateShadows(drawCommand) {
   const castShadows = ShadowMode.castShadows(shadows);
   const receiveShadows = ShadowMode.receiveShadows(shadows);
 
-  const commandList = getAllCommands(drawCommand);
+  const commandList = drawCommand.getAllCommands();
   const commandLength = commandList.length;
   for (let i = 0; i < commandLength; i++) {
     const command = commandList[i];
@@ -431,7 +477,7 @@ function updateBackFaceCulling(drawCommand) {
   backFaceCulling =
     backFaceCulling && !doubleSided && !translucent && !useSilhouetteCommands;
 
-  const commandList = getAllCommands(drawCommand);
+  const commandList = drawCommand.getAllCommands();
   const commandLength = commandList.length;
   for (let i = 0; i < commandLength; i++) {
     const command = commandList[i];
@@ -450,7 +496,7 @@ function updateBackFaceCulling(drawCommand) {
 
 function updateCullFace(drawCommand) {
   const cullFace = drawCommand.cullFace;
-  const commandList = getAllCommands(drawCommand);
+  const commandList = drawCommand.getAllCommands();
   const commandLength = commandList.length;
 
   for (let i = 0; i < commandLength; i++) {
@@ -464,7 +510,7 @@ function updateCullFace(drawCommand) {
 function updateShowBoundingVolume(drawCommand) {
   const debugShowBoundingVolume = drawCommand.debugShowBoundingVolume;
 
-  const commandList = getAllCommands(drawCommand);
+  const commandList = drawCommand.getAllCommands();
   const commandLength = commandList.length;
   for (let i = 0; i < commandLength; i++) {
     const command = commandList[i];
@@ -474,6 +520,7 @@ function updateShowBoundingVolume(drawCommand) {
 
 /**
  * Returns an array of the draw commands necessary to render the primitive.
+ * This does not include the draw commands that render its silhouette.
  *
  * @param {FrameState} frameState The frame state.
  *
@@ -494,6 +541,17 @@ ModelExperimentalDrawCommand.prototype.getCommands = function (frameState) {
       commandList2D.push(command2D);
     }
 
+    // Derive 2D silhouette commands here to avoid duplicate
+    // computation in getSilhouetteCommands.
+    if (this._useSilhouetteCommands) {
+      const silhouetteCommands = this._silhouetteCommandList;
+      const silhouetteCommands2D = this._silhouetteCommandList2D;
+      for (let i = 0; i < length; i++) {
+        const silhouetteCommand2D = derive2DCommand(silhouetteCommands[i]);
+        silhouetteCommands2D.push(silhouetteCommand2D);
+      }
+    }
+
     this._modelMatrix2DDirty = true;
   }
 
@@ -508,6 +566,67 @@ ModelExperimentalDrawCommand.prototype.getCommands = function (frameState) {
   if (use2D) {
     commands.push.apply(commands, commandList2D);
   }
+
+  return commands;
+};
+
+/**
+ * Returns an array of the draw commands necessary to render the silhouette.
+ * These should be added to the command list after the draw commands of all
+ * primitives in the model have been added. This way, the silhouette won't
+ * render on top of the model.
+ *
+ * This should only be called after getCommands() has been invoked for
+ * the ModelExperimentalDrawCommand this frame. Otherwise, the silhouette
+ * commands may not have been derived for 2D. The model matrix will also
+ * not have been updated for 2D commands.
+ *
+ * @param {FrameState} frameState The frame state.
+ *
+ * @returns {DrawCommand[]} The draw commands.
+ *
+ * @private
+ */
+ModelExperimentalDrawCommand.prototype.getSilhouetteCommands = function (
+  frameState
+) {
+  if (!this._useSilhouetteCommands) {
+    return [];
+  }
+
+  const commands = [];
+  const commandList = this._silhouetteCommandList;
+  const commandList2D = this._silhouetteCommandList2D;
+
+  commands.push.apply(commands, commandList);
+
+  // Assumes that 2D commands were already generated / updated
+  // in getCommands()
+  if (shouldUse2DCommands(this, frameState)) {
+    commands.push.apply(commands, commandList2D);
+  }
+
+  return commands;
+};
+
+/**
+ * Returns an array of all the draw commands currently managed by the
+ * ModelExperimentalDrawCommand. This only includes commands that are
+ * in a command list, so it may exclude the original draw command.
+ * This is used internally for updating all derived commands, and for
+ * testing.
+ *
+ * @returns {DrawCommand[]} The draw commands.
+ *
+ * @private
+ */
+ModelExperimentalDrawCommand.prototype.getAllCommands = function () {
+  const commands = [];
+
+  commands.push.apply(commands, this._commandList);
+  commands.push.apply(commands, this._commandList2D);
+  commands.push.apply(commands, this._silhouetteCommandList);
+  commands.push.apply(commands, this._silhouetteCommandList2D);
 
   return commands;
 };

--- a/Source/Scene/ModelExperimental/ModelExperimentalDrawCommand.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalDrawCommand.js
@@ -64,6 +64,7 @@ function ModelExperimentalDrawCommand(options) {
   this._debugShowBoundingVolume = command.debugShowBoundingVolume;
   this._useSilhouetteCommands = useSilhouetteCommands;
 
+  // TODO: reorganize
   this._commandList = [];
   this._commandList2D = [];
 
@@ -549,20 +550,10 @@ function derive2DCommand(command) {
   return derivedCommand;
 }
 
-/**
- * Tracks how many silhouettes have been created. This value is used to
- * assign a reference number to the stencil.
- *
- * @type {Number}
- * @private
- */
-ModelExperimentalDrawCommand.silhouettesLength = 0;
-
 function deriveSilhouetteModelCommand(command, model) {
   // Wrap around after exceeding the 8-bit stencil limit.
   // The reference is unique to each model until this point.
-  const stencilReference =
-    ++ModelExperimentalDrawCommand.silhouettesLength % 255;
+  const stencilReference = model._silhouetteId % 255;
   const silhouetteModelCommand = DrawCommand.shallowClone(command);
   let renderState = clone(command.renderState, true);
 
@@ -606,7 +597,7 @@ function deriveSilhouetteModelCommand(command, model) {
 function deriveSilhouetteColorCommand(command, model) {
   // Wrap around after exceeding the 8-bit stencil limit.
   // The reference is unique to each model until this point.
-  const stencilReference = ModelExperimentalDrawCommand.silhouettesLength % 255;
+  const stencilReference = model._silhouetteId % 255;
   const silhouetteColorCommand = DrawCommand.shallowClone(command);
   let renderState = clone(command.renderState, true);
   renderState.depthTest.enabled = true;

--- a/Source/Scene/ModelExperimental/ModelSilhouettePipelineStage.js
+++ b/Source/Scene/ModelExperimental/ModelSilhouettePipelineStage.js
@@ -1,4 +1,5 @@
 import combine from "../../Core/combine.js";
+import defined from "../../Core/defined.js";
 import ShaderDestination from "../../Renderer/ShaderDestination.js";
 import ModelSilhouetteStageFS from "../../Shaders/ModelExperimental/ModelSilhouetteStageFS.js";
 import ModelSilhouetteStageVS from "../../Shaders/ModelExperimental/ModelSilhouetteStageVS.js";
@@ -14,9 +15,19 @@ const ModelSilhouettePipelineStage = {};
 ModelSilhouettePipelineStage.name = "ModelSilhouettePipelineStage"; // Helps with debugging
 
 /**
+ * Tracks how many silhouettes have been created. This value is used to
+ * assign a reference number to the stencil.
+ *
+ * @type {Number}
+ * @private
+ */
+ModelSilhouettePipelineStage.silhouettesLength = 0;
+
+/**
  * Process a model. This modifies the following parts of the render resources:
  *
  * <ul>
+ *  <li>defines the silhouette ID for the model, if it doesn't yet exist
  *  <li>adds a define to the shaders to indicate that the model uses silhouettes</li>
  *  <li>adds a function to the vertex shader to create the silhouette around the model</li>
  *  <li>adds a function to the fragment shader to apply color to the silhouette</li>
@@ -40,6 +51,10 @@ ModelSilhouettePipelineStage.process = function (
   model,
   frameState
 ) {
+  if (!defined(model._silhouetteId)) {
+    model._silhouetteId = ++ModelSilhouettePipelineStage.silhouettesLength;
+  }
+
   const shaderBuilder = renderResources.shaderBuilder;
   shaderBuilder.addDefine("HAS_SILHOUETTE", undefined, ShaderDestination.BOTH);
 

--- a/Specs/Scene/ModelExperimental/ModelExperimentalDrawCommandSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalDrawCommandSpec.js
@@ -41,11 +41,6 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
     mapProjection: scratchProjection,
   };
 
-  afterEach(function () {
-    // Reset so this doesn't interfere with other tests.
-    ModelExperimentalDrawCommand.silhouettesLength = 0;
-  });
-
   function mockRenderResources(options) {
     options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
@@ -69,6 +64,7 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
         },
         silhouetteSize: silhouetteSize,
         silhouetteColor: silhouetteColor,
+        _silhouetteId: 1,
       },
       runtimePrimitive: {
         primitive: {
@@ -401,9 +397,6 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
       stencilReference,
       false
     );
-
-    // Reset so this doesn't interfere with other tests.
-    ModelExperimentalDrawCommand.silhouettesLength = 0;
   });
 
   it("constructs silhouette commands correctly for translucent silhouette color", function () {
@@ -436,9 +429,6 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
       stencilReference,
       true
     );
-
-    // Reset so this doesn't interfere with other tests.
-    ModelExperimentalDrawCommand.silhouettesLength = 0;
   });
 
   it("uses opaque command only", function () {

--- a/Specs/Scene/ModelExperimental/ModelExperimentalDrawCommandSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalDrawCommandSpec.js
@@ -131,7 +131,8 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
     return result;
   }
 
-  // Creates a ModelExperimentalDrawCommand with the specified derived commands.
+  // Creates a ModelExperimentalDrawCommand with the specified
+  // derived commands.
   function createModelExperimentalDrawCommand(options) {
     const deriveTranslucent = options.deriveTranslucent;
     const derive2D = options.derive2D;
@@ -293,8 +294,11 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
 
     // No other commands should be derived.
     expect(drawCommand._translucentCommand).toBeUndefined();
-    expect(drawCommand._commandList2D.length).toEqual(0);
     expect(drawCommand._useSilhouetteCommands).toBe(false);
+
+    expect(drawCommand._commandList2D.length).toEqual(0);
+    expect(drawCommand._silhouetteCommandList.length).toEqual(0);
+    expect(drawCommand._silhouetteCommandList2D.length).toEqual(0);
   });
 
   it("constructs with silhouette commands", function () {
@@ -314,27 +318,35 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
     expect(drawCommand.modelMatrix).not.toBe(command.modelMatrix);
 
     expect(drawCommand._useSilhouetteCommands).toBe(true);
-    expect(drawCommand._commandList.length).toEqual(2);
 
-    const silhouetteModelCommand = drawCommand._commandList[0];
+    const commands = drawCommand._commandList;
+    const silhouetteCommands = drawCommand._silhouetteCommandList;
+    expect(commands.length).toEqual(1);
+    expect(silhouetteCommands.length).toEqual(1);
+
+    const silhouetteModelCommand = commands[0];
     expect(silhouetteModelCommand).not.toBe(command);
 
     const stencilReference = 1;
+    const modelIsInvisible = false;
     verifySilhouetteModelCommand(
       silhouetteModelCommand,
       stencilReference,
-      false
+      modelIsInvisible
     );
-    const silhouetteColorCommand = drawCommand._commandList[1];
+
+    const silhouetteColorCommand = silhouetteCommands[0];
+    const silhouetteIsTranslucent = false;
     verifySilhouetteColorCommand(
       silhouetteColorCommand,
       stencilReference,
-      false
+      silhouetteIsTranslucent
     );
 
     // No other commands should be derived.
     expect(drawCommand._translucentCommand).toBeUndefined();
     expect(drawCommand._commandList2D.length).toEqual(0);
+    expect(drawCommand._silhouetteCommandList2D.length).toEqual(0);
   });
 
   it("constructs silhouette commands correctly for translucent model", function () {
@@ -348,23 +360,32 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
       useSilhouetteCommands: true,
     });
 
+    // Model is already translucent, so no translucent command should be derived
+    expect(drawCommand._translucentCommand).toBeUndefined();
     expect(drawCommand._useSilhouetteCommands).toBe(true);
-    expect(drawCommand._commandList.length).toEqual(2);
 
-    const silhouetteModelCommand = drawCommand._commandList[0];
+    const commands = drawCommand._commandList;
+    const silhouetteCommands = drawCommand._silhouetteCommandList;
+    expect(commands.length).toEqual(1);
+    expect(silhouetteCommands.length).toEqual(1);
+
+    const silhouetteModelCommand = commands[0];
     expect(silhouetteModelCommand).not.toBe(command);
 
     const stencilReference = 1;
+    const modelIsInvisible = false;
     verifySilhouetteModelCommand(
       silhouetteModelCommand,
       stencilReference,
-      false
+      modelIsInvisible
     );
-    const silhouetteColorCommand = drawCommand._commandList[1];
+
+    const silhouetteColorCommand = silhouetteCommands[0];
+    const silhouetteIsTranslucent = true;
     verifySilhouetteColorCommand(
       silhouetteColorCommand,
       stencilReference,
-      true
+      silhouetteIsTranslucent
     );
   });
 
@@ -380,22 +401,29 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
     });
 
     expect(drawCommand._useSilhouetteCommands).toBe(true);
-    expect(drawCommand._commandList.length).toEqual(2);
 
-    const silhouetteModelCommand = drawCommand._commandList[0];
+    const commands = drawCommand._commandList;
+    const silhouetteCommands = drawCommand._silhouetteCommandList;
+    expect(commands.length).toEqual(1);
+    expect(silhouetteCommands.length).toEqual(1);
+
+    const silhouetteModelCommand = commands[0];
     expect(silhouetteModelCommand).not.toBe(command);
 
     const stencilReference = 1;
+    const modelIsInvisible = true;
     verifySilhouetteModelCommand(
       silhouetteModelCommand,
       stencilReference,
-      true
+      modelIsInvisible
     );
-    const silhouetteColorCommand = drawCommand._commandList[1];
+
+    const silhouetteColorCommand = silhouetteCommands[0];
+    const silhouetteIsTranslucent = false;
     verifySilhouetteColorCommand(
       silhouetteColorCommand,
       stencilReference,
-      false
+      silhouetteIsTranslucent
     );
   });
 
@@ -412,22 +440,29 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
     });
 
     expect(drawCommand._useSilhouetteCommands).toBe(true);
-    expect(drawCommand._commandList.length).toEqual(2);
 
-    const silhouetteModelCommand = drawCommand._commandList[0];
+    const commands = drawCommand._commandList;
+    const silhouetteCommands = drawCommand._silhouetteCommandList;
+    expect(commands.length).toEqual(1);
+    expect(silhouetteCommands.length).toEqual(1);
+
+    const silhouetteModelCommand = commands[0];
     expect(silhouetteModelCommand).not.toBe(command);
 
     const stencilReference = 1;
+    const modelIsInvisible = false;
     verifySilhouetteModelCommand(
       silhouetteModelCommand,
       stencilReference,
-      false
+      modelIsInvisible
     );
-    const silhouetteColorCommand = drawCommand._commandList[1];
+
+    const silhouetteColorCommand = silhouetteCommands[0];
+    const silhouetteIsTranslucent = true;
     verifySilhouetteColorCommand(
       silhouetteColorCommand,
       stencilReference,
-      true
+      silhouetteIsTranslucent
     );
   });
 
@@ -444,6 +479,10 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
     expect(drawCommand._commandList.length).toEqual(1);
     expect(drawCommand._commandList[0]).toBe(command);
     expect(drawCommand._translucentCommand).toBeUndefined();
+
+    expect(drawCommand._commandList2D.length).toEqual(0);
+    expect(drawCommand._silhouetteCommandList.length).toEqual(0);
+    expect(drawCommand._silhouetteCommandList2D.length).toEqual(0);
   });
 
   it("derives translucent command, draws translucent only", function () {
@@ -478,6 +517,8 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
     expect(renderState.blending).toEqual(expectedBlending);
 
     expect(drawCommand._commandList2D.length).toEqual(0);
+    expect(drawCommand._silhouetteCommandList.length).toEqual(0);
+    expect(drawCommand._silhouetteCommandList2D.length).toEqual(0);
   });
 
   it("derives translucent command, draws opaque and translucent", function () {
@@ -512,6 +553,8 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
     expect(renderState.blending).toEqual(expectedBlending);
 
     expect(drawCommand._commandList2D.length).toEqual(0);
+    expect(drawCommand._silhouetteCommandList.length).toEqual(0);
+    expect(drawCommand._silhouetteCommandList2D.length).toEqual(0);
   });
 
   it("doesn't derive translucent command if original command is translucent", function () {
@@ -531,6 +574,8 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
 
     expect(drawCommand._translucentCommand).toBeUndefined();
     expect(drawCommand._commandList2D.length).toEqual(0);
+    expect(drawCommand._silhouetteCommandList.length).toEqual(0);
+    expect(drawCommand._silhouetteCommandList2D.length).toEqual(0);
   });
 
   it("getCommands works for original command", function () {
@@ -571,6 +616,29 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
     expect(result[1]).toBe(translucentCommand);
   });
 
+  it("getCommands doesn't return silhouette commands", function () {
+    const renderResources = mockRenderResources({
+      styleCommandsNeeded: StyleCommandsNeeded.OPAQUE_AND_TRANSLUCENT,
+    });
+    const command = createDrawCommand();
+    const drawCommand = new ModelExperimentalDrawCommand({
+      primitiveRenderResources: renderResources,
+      command: command,
+      useSilhouetteCommands: true,
+    });
+
+    expect(drawCommand._commandList.length).toEqual(2);
+    expect(drawCommand._silhouetteCommandList.length).toEqual(2);
+
+    const result = drawCommand.getCommands(mockFrameState);
+    expect(result.length).toEqual(2);
+
+    const stencilReference = 1;
+    const modelIsInvisible = false;
+    verifySilhouetteModelCommand(result[0], stencilReference, modelIsInvisible);
+    verifySilhouetteModelCommand(result[1], stencilReference, modelIsInvisible);
+  });
+
   it("getCommands derives 2D commands if primitive is near IDL", function () {
     const modelMatrix = Matrix4.fromTranslation(
       Cartesian3.fromDegrees(180, 0),
@@ -602,6 +670,44 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
     expect(drawCommand._commandList2D.length).toEqual(2);
   });
 
+  it("getCommands derives 2D commands for silhouettes if primitive is near IDL", function () {
+    const modelMatrix = Matrix4.fromTranslation(
+      Cartesian3.fromDegrees(180, 0),
+      scratchModelMatrix
+    );
+    const modelMatrix2D = Transforms.basisTo2D(
+      mockFrameState2D.mapProjection,
+      modelMatrix,
+      modelMatrix
+    );
+    const renderResources = mockRenderResources({
+      styleCommandsNeeded: StyleCommandsNeeded.OPAQUE_AND_TRANSLUCENT,
+      boundingSphere2DTransform: modelMatrix2D,
+    });
+    const command = createDrawCommand({
+      modelMatrix: modelMatrix2D,
+    });
+    const drawCommand = new ModelExperimentalDrawCommand({
+      primitiveRenderResources: renderResources,
+      command: command,
+      useSilhouetteCommands: true,
+    });
+
+    // 2D commands aren't derived until getCommands is called
+    expect(drawCommand._commandList.length).toEqual(2);
+    expect(drawCommand._silhouetteCommandList.length).toEqual(2);
+    expect(drawCommand._commandList2D.length).toEqual(0);
+    expect(drawCommand._silhouetteCommandList2D.length).toEqual(0);
+
+    // Silhouette commands are generated for 2D, but only the
+    // non-silhouette commands are retrieved.
+    const result = drawCommand.getCommands(mockFrameState2D);
+    expect(result.length).toEqual(4);
+
+    expect(drawCommand._commandList2D.length).toEqual(2);
+    expect(drawCommand._silhouetteCommandList2D.length).toEqual(2);
+  });
+
   it("getCommands doesn't derive 2D commands if primitive is not near IDL", function () {
     const modelMatrix = Matrix4.fromTranslation(
       Cartesian3.fromDegrees(100, 250),
@@ -622,14 +728,18 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
     const drawCommand = new ModelExperimentalDrawCommand({
       primitiveRenderResources: renderResources,
       command: command,
+      useSilhouetteCommands: true,
     });
 
     expect(drawCommand._commandList.length).toEqual(2);
     expect(drawCommand._commandList2D.length).toEqual(0);
+    expect(drawCommand._silhouetteCommandList.length).toEqual(2);
+    expect(drawCommand._silhouetteCommandList2D.length).toEqual(0);
 
     const result = drawCommand.getCommands(mockFrameState2D);
     expect(result.length).toEqual(2);
     expect(drawCommand._commandList2D.length).toEqual(0);
+    expect(drawCommand._silhouetteCommandList2D.length).toEqual(0);
   });
 
   it("getCommands updates model matrix for 2D commands", function () {
@@ -647,11 +757,15 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
 
     const commandList = drawCommand._commandList;
     const commandList2D = drawCommand._commandList2D;
-    expect(commandList.length).toEqual(4);
-    expect(commandList2D.length).toEqual(4);
+    const silhouetteCommandList = drawCommand._silhouetteCommandList;
+    const silhouetteCommandList2D = drawCommand._silhouetteCommandList2D;
+    expect(commandList.length).toEqual(2);
+    expect(commandList2D.length).toEqual(2);
+    expect(silhouetteCommandList.length).toEqual(2);
+    expect(silhouetteCommandList2D.length).toEqual(2);
 
     const result = drawCommand.getCommands(mockFrameState2D);
-    expect(result.length).toEqual(8);
+    expect(result.length).toEqual(4);
 
     const expectedModelMatrix = computeExpected2DMatrix(
       modelMatrix2D,
@@ -663,19 +777,111 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
       scratchExpectedTranslation
     );
 
-    // The first four commands should be drawn with the given model matrix
-    for (let i = 0; i < 4; i++) {
+    // The first two commands should be drawn with the given model matrix
+    for (let i = 0; i < 2; i++) {
       const command = result[i];
       expect(command.modelMatrix).toEqual(modelMatrix2D);
       expect(command.boundingVolume.center).toEqual(translation);
     }
 
-    // The last four commands are the 2D commands derived from the original ones
-    for (let i = 4; i < 8; i++) {
+    // The last two commands are the 2D commands derived from the original ones
+    for (let i = 2; i < 4; i++) {
       const command2D = result[i];
       expect(command2D.modelMatrix).toEqual(expectedModelMatrix);
       expect(command2D.boundingVolume.center).toEqual(expectedTranslation);
     }
+
+    // The silhouette commands should be affected in the same way.
+    for (let i = 0; i < 2; i++) {
+      const command = silhouetteCommandList[i];
+      expect(command.modelMatrix).toEqual(modelMatrix2D);
+      expect(command.boundingVolume.center).toEqual(translation);
+
+      const command2D = silhouetteCommandList2D[i];
+      expect(command2D.modelMatrix).toEqual(expectedModelMatrix);
+      expect(command2D.boundingVolume.center).toEqual(expectedTranslation);
+    }
+  });
+
+  it("getSilhouetteCommands returns silhouette-pass commands", function () {
+    const drawCommand = createModelExperimentalDrawCommand({
+      deriveTranslucent: true,
+      deriveSilhouette: true,
+    });
+
+    expect(drawCommand._commandList.length).toEqual(2);
+    expect(drawCommand._silhouetteCommandList.length).toEqual(2);
+
+    const result = drawCommand.getCommands(mockFrameState);
+    expect(result.length).toEqual(2);
+
+    const silhouetteResult = drawCommand.getSilhouetteCommands(mockFrameState);
+    expect(silhouetteResult.length).toEqual(2);
+
+    expect(silhouetteResult[0]).not.toEqual(result[0]);
+    expect(silhouetteResult[1]).not.toEqual(result[1]);
+
+    const stencilReference = 1;
+    const silhouetteIsTranslucent = false;
+    verifySilhouetteColorCommand(
+      silhouetteResult[0],
+      stencilReference,
+      silhouetteIsTranslucent
+    );
+    verifySilhouetteColorCommand(
+      silhouetteResult[1],
+      stencilReference,
+      silhouetteIsTranslucent
+    );
+  });
+
+  it("getSilhouetteCommands returns 2D silhouette-pass commands", function () {
+    const drawCommand = createModelExperimentalDrawCommand({
+      deriveTranslucent: true,
+      derive2D: true,
+      deriveSilhouette: true,
+    });
+
+    expect(drawCommand._commandList.length).toEqual(2);
+    expect(drawCommand._commandList2D.length).toEqual(2);
+    expect(drawCommand._silhouetteCommandList.length).toEqual(2);
+    expect(drawCommand._silhouetteCommandList2D.length).toEqual(2);
+
+    const result = drawCommand.getCommands(mockFrameState2D);
+    expect(result.length).toEqual(4);
+
+    const silhouetteResult = drawCommand.getSilhouetteCommands(
+      mockFrameState2D
+    );
+    expect(silhouetteResult.length).toEqual(4);
+
+    const stencilReference = 1;
+    const silhouetteIsTranslucent = false;
+
+    const length = silhouetteResult.length;
+    for (let i = 0; i < length; i++) {
+      expect(silhouetteResult[i]).not.toEqual(result[i]);
+      verifySilhouetteColorCommand(
+        silhouetteResult[i],
+        stencilReference,
+        silhouetteIsTranslucent
+      );
+    }
+  });
+
+  it("getSilhouetteCommands returns empty if model doesn't have silhouette", function () {
+    const drawCommand = createModelExperimentalDrawCommand({
+      deriveTranslucent: true,
+    });
+
+    expect(drawCommand._commandList.length).toEqual(2);
+    expect(drawCommand._silhouetteCommandList.length).toEqual(0);
+
+    const result = drawCommand.getCommands(mockFrameState);
+    expect(result.length).toEqual(2);
+
+    const silhouetteResult = drawCommand.getSilhouetteCommands(mockFrameState);
+    expect(silhouetteResult.length).toEqual(0);
   });
 
   it("updates model matrix", function () {
@@ -725,15 +931,17 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
     });
 
     const commandList = drawCommand._commandList;
-    const length = commandList.length;
-    expect(length).toEqual(4);
+    const silhouetteCommandList = drawCommand._silhouetteCommandList;
+    expect(commandList.length).toEqual(2);
+    expect(silhouetteCommandList.length).toEqual(2);
 
     // Derive the 2D commands
     drawCommand.getCommands(mockFrameState2D);
 
     const commandList2D = drawCommand._commandList2D;
-    const length2D = commandList2D.length;
-    expect(length2D).toEqual(4);
+    const silhouetteCommandList2D = drawCommand._silhouetteCommandList2D;
+    expect(commandList2D.length).toEqual(2);
+    expect(silhouetteCommandList2D.length).toEqual(2);
 
     let modelMatrix2D = Matrix4.fromTranslation(
       Cartesian3.fromDegrees(100, 25),
@@ -753,10 +961,15 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
     drawCommand.modelMatrix = modelMatrix2D;
     expect(drawCommand.modelMatrix).toEqual(modelMatrix2D);
 
+    const length = commandList.length;
     for (let i = 0; i < length; i++) {
       const command = commandList[i];
       expect(command.modelMatrix).toEqual(modelMatrix2D);
       expect(command.boundingVolume.center).toEqual(translation);
+
+      const silhouetteCommand = silhouetteCommandList[i];
+      expect(silhouetteCommand.modelMatrix).toEqual(modelMatrix2D);
+      expect(silhouetteCommand.boundingVolume.center).toEqual(translation);
     }
 
     // Update the model matrix for the 2D commands
@@ -771,10 +984,17 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
       scratchExpectedTranslation
     );
 
+    const length2D = commandList2D.length;
     for (let i = 0; i < length2D; i++) {
       const command = commandList2D[i];
       expect(command.modelMatrix).toEqual(expectedModelMatrix);
       expect(command.boundingVolume.center).toEqual(expectedTranslation);
+
+      const silhouetteCommand = silhouetteCommandList2D[i];
+      expect(silhouetteCommand.modelMatrix).toEqual(expectedModelMatrix);
+      expect(silhouetteCommand.boundingVolume.center).toEqual(
+        expectedTranslation
+      );
     }
   });
 
@@ -785,7 +1005,7 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
       deriveSilhouette: true,
     });
 
-    let result = drawCommand.getCommands(mockFrameState2D);
+    let result = drawCommand.getAllCommands();
     const length = result.length;
     expect(length).toEqual(8);
 
@@ -796,7 +1016,7 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
     }
 
     drawCommand.shadows = ShadowMode.ENABLED;
-    result = drawCommand.getCommands(mockFrameState2D);
+    result = drawCommand.getAllCommands();
 
     for (let i = 0; i < length; i++) {
       const command = result[i];
@@ -850,7 +1070,7 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
       deriveSilhouette: true,
     });
 
-    let result = drawCommand.getCommands(mockFrameState2D);
+    let result = drawCommand.getAllCommands();
     const length = result.length;
     expect(length).toEqual(8);
 
@@ -860,7 +1080,7 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
     }
 
     drawCommand.backFaceCulling = true;
-    result = drawCommand.getCommands(mockFrameState2D);
+    result = drawCommand.getAllCommands();
 
     for (let i = 0; i < length; i++) {
       const command = result[i];
@@ -875,7 +1095,7 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
       deriveSilhouette: true,
     });
 
-    let result = drawCommand.getCommands(mockFrameState2D);
+    let result = drawCommand.getAllCommands();
     const length = result.length;
     expect(length).toEqual(8);
 
@@ -885,7 +1105,7 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
     }
 
     drawCommand.cullFace = CullFace.FRONT;
-    result = drawCommand.getCommands(mockFrameState2D);
+    result = drawCommand.getAllCommands();
 
     for (let i = 0; i < length; i++) {
       const command = result[i];
@@ -900,7 +1120,7 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
       deriveSilhouette: true,
     });
 
-    let result = drawCommand.getCommands(mockFrameState2D);
+    let result = drawCommand.getAllCommands();
     const length = result.length;
     expect(length).toEqual(8);
 
@@ -910,7 +1130,7 @@ describe("Scene/ModelExperimental/ModelExperimentalDrawCommand", function () {
     }
 
     drawCommand.debugShowBoundingVolume = true;
-    result = drawCommand.getCommands(mockFrameState2D);
+    result = drawCommand.getAllCommands();
 
     for (let i = 0; i < length; i++) {
       const command = result[i];

--- a/Specs/Scene/ModelExperimental/ModelSilhouettePipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelSilhouettePipelineStageSpec.js
@@ -8,7 +8,7 @@ import {
 import ShaderBuilderTester from "../../ShaderBuilderTester.js";
 
 describe("Scene/ModelExperimental/ModelSilhouettePipelineStage", function () {
-  beforeAll(function () {
+  beforeEach(function () {
     // Reset this, in case it was modified by other tests
     ModelSilhouettePipelineStage.silhouettesLength = 0;
   });

--- a/Specs/Scene/ModelExperimental/ModelSilhouettePipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelSilhouettePipelineStageSpec.js
@@ -8,10 +8,16 @@ import {
 import ShaderBuilderTester from "../../ShaderBuilderTester.js";
 
 describe("Scene/ModelExperimental/ModelSilhouettePipelineStage", function () {
+  beforeAll(function () {
+    // Reset this, in case it was modified by other tests
+    ModelSilhouettePipelineStage.silhouettesLength = 0;
+  });
+
   it("configures the render resources for silhouette", function () {
     const mockModel = {
       silhouetteColor: Color.RED,
       silhouetteSize: 1.0,
+      _silhouetteId: undefined,
     };
 
     const renderResources = {
@@ -22,6 +28,9 @@ describe("Scene/ModelExperimental/ModelSilhouettePipelineStage", function () {
 
     const shaderBuilder = renderResources.shaderBuilder;
     ModelSilhouettePipelineStage.process(renderResources, mockModel);
+
+    expect(ModelSilhouettePipelineStage.silhouettesLength).toEqual(1);
+    expect(mockModel._silhouetteId).toEqual(1);
 
     ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
       "HAS_SILHOUETTE",


### PR DESCRIPTION
This PR includes a number of fixes to `ModelExperimental`. It:

- fixes a crash in the ["development/3D Models" sandcastle](http://localhost:8080/Apps/Sandcastle/index.html?src=development%2F3D%20Models.html&label=Development) that was happening for both `Model` and `ModelExperimental`. Basically the value of the "Mix" slider was not being converted properly to a number.
- fixes the broken alpha sliders in the ["3D Models Coloring" sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=xVl7Uxs3EP8qGvcPzMxxtnkkqTG0QEjCTGnSQNJ2cKYj38m2Bp10I+kAN+Pv3pV07zsSDCZlwnBaSbu/3dU+pJwQRZPIP72LiaQR4RqzNwTrRBLlE44njJyLkLDyPDpAWiZkf8zHPBBcaXRDyS2RQOfkFp04jp8trTvuBHZ8ImAr5USOOx76OuYIUT4Vx+JuiKaYKeIZkiKMBJoKfsZDGmAtZGV2jkNxq4ZWekoRCQuPOI2wJjl9uWmhMaIR4KV6YYfThFvWaEb0iWBCHjPCQ6NcN6gMNx08ScAIPNOmuuOqusPX4lMM9jnBinQ3v4C4ZatEJ+h3HBEPYRbPcSrKGdFOgg3LEq/yHU0ZrRD9qRTRkeHthHkoxlKRN0xg3XUyNzN8vR66nBPrPOtjsB8OrhXSQFQaLIrEFIlEoohyinAcM+MTUMgv+91tPcg0YcZn485HEoKjcxI47Wrc+XNONTH+z+bh460khLvPY5aks38TxsRttgAvxp0vlpdVYIgGfr9gnXvBiH1HZ3MGv7osPF/hUJTXWCQxw0Eq+JzeZbKKrUeRSLgeor6/1zpzasMkrBxVyuBoEq3JSdMitUmH6nEGKVgdVU1TTFzQf8E025a+3E/9DtF4Q6S2ri6cGJFoQqSCyNQCXXMRXItEIzFRRN4YFRU4Pj1s2axvz0w357GZSTimPKyxB6aG8Pr9OYI4N7lEmRNmaJ/O4A+GGMCMoSmEAdX5IdNCsAk2kRGKIDHbfAioU8fheHEWQo5J14w7Rn4dojm5C4OH8pkqoHoZZ4e5tssY0ch5n2tf3glZzbgO5Nl1KpmoQNIJ6eYx34VU+BmDA9MYR2ku8iPDwc+CPU8N2XKvMJjv4tWG+vJRIC2DNYIsoKXJJd//BJDVGF0JbSlx5gxKeIsMX8XZpmZ5f5WQbqnp3ox/dOAWogagg4P2MuKfn/21FsM5HE90dIkT2KBUNtbh5FrOezzUGqPy6czMn4dSRihcV8uXbsF69Dp6Wqw9QK82NewKr675OvUy9WMdahk+DzhXOeNAQhvqms9uIgHUnJiinYpxHadvZVEoTJJE4gZ8wLqOTZYbYqGoZVeEIJYavjDfsb3SazKDgqtSI28Ntnf8/svd3ReDn1Or7u76/b3+zsv+i5TgcJhvB9wJmhNs6ksh5xzrOTRtH4GMueoOdvbKy2Oqgzks7pdoUjBWI83jWlf9zon5YLZ/hPXdVK7nOHqWSVmQkNQ07VUbXEqABGU2Uv68xvCPBKwuOSxPTZJZMNM+lpnq5q9zNnCuOwSHYTc9EBza1yEyPqxyHNZ5l7AOy4N02p6oYXbMEHCkZbbI9qlREn2gd4S5tmew/aqYxXdm9gJ6DNMQ9eHHq2Ts4TcKXb0oe+25fthSe9oKh71ntPDIWs1SlNxfdwoGjXazkTsekj2+myjB7S0inaVbEVcXZZuXXh7veSDbNpKEp9lxyi9uy+KWKWJzGBTMXpmd6TnQ5E6b/vqIykDiadb5w2ni7joJfXmerDaL01POL4UFxh3f78G/CxzFjLzGGvfssVM9FzogJf36Bz79GZvk8szPHhwqv59ba7+isNeC+q0ET4boM5nTgJHnwu6kpEKqo4YKq6B/JzQCM6BjaNuF4M9r+lRIddSAP1jVA+eUXaNLmQTXzwvfyLFi6uMneeDimnIOvefJHEMEafu88pxK4Mz+/8DnKsi/2IJxgXkYYKXh3EGBuHT3r3PCk24a3Juty2YzRo4TrU1R6ly4ZyBzGU6TR/ow5JU0tQVwTkxOGfNqz5CuNn2+W7CfPxl1vM5I6QUjh5kiv9IoFnBRhjLTBbtoAnYBu6neBDxHtB8olemK0E/ZVfVrYZIJ5LWZDbghkrMJ7u5ueyj77fuvit1QGEFZqMVDtBvflcgTIUMityQU6kRVJ5cN0ZTHcGcvATD3fAo1bwszOoO6GtEwZKQpdUuLGMpiRXI2NRFg+6g62xRtewlS0X4quN66tQ3TEPRgYX37qFe29yikN4iGBy2PhihgWCmYmSaMuZ70cNSD9Y2tUIMM6PegODMvJYej+eDwN0f0fX/Ug2H7zvwVIXf/SJvW+LBQaKQnIlyUCIYkK2NDCXO4zibA0r2B2Io76umwyqJX49HK07Jo7HVTVQrQXPCjEEJ4a0K5US8NsWH9VQziyLThdbo1sGNTF/hI/O3Ku7nvA67hLMN7LCDb2zzUoi6y9CImAA0a6BlYyLScMDIVp2MaTPge2G+lSewmBjAqK5XqYNvIVKNPcWjfrzesiI3S+WsXbpK/kQFRAKO9bwhosHqkpSoCbMRCH551zfe9h/yCNjYQaDWTeLGxbNHKvLZ+G90PcUUdf7tXPOT+O+RefdfjtiaYVcU+1sX3ZKyLvId/jrBfKW/VH87zhNB4XVp35vofE0XtJvacKaPxmLUm65lyvW7j9Ve1ngHxY4yXdier2Q6Glc4CxqXWo9yv/Ac) with `ModelExperimental` enabled. These sliders were not working for either model or silhouette color.
- fixes some rendering differences between silhouettes in `Model` vs. `ModelExperimental`. In `Model`, the draw commands for one primitive all use one stencil buffer, but each primitive in `ModelExperimental` was mistakenly using separate stencil buffers.

| *Before* | *After* |
| --------- | -------- |
| ![image](https://user-images.githubusercontent.com/32226860/177839243-499100fc-38a0-443f-8748-107ae5856c4d.png) | ![image](https://user-images.githubusercontent.com/32226860/177839370-65a2a7b3-4db7-4b9d-9636-a800865866ad.png) |

This required refactoring `ModelExperimentalDrawCommands` again so that the silhouette commands were returned separately from the regular ones. The silhouette can only be drawn after _all_ of the model has been drawn first.
 
[`ModelExperimental` silhouette sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=tVhtTxs5EP4rVr50cwJnE8JLQ4oOKKWcQKAmbXV3OZ2cXSex8Np7tjckd+K/39jet4RQoC0ILX4Zzzwz+3hmlkgKbdCc0Tuq0Dsk6B06pZplCf7i1oJRI3LzUykMYYKqUWML/TcSCOmZzHh8LFhCDO0hozK6NRL3zcORGAmvEUdcRrc4ypSiwgxZQsFGrv+3jDMi3sNZPFEyudDyYC9sB1bzqNEJO+3tdns7fDvshL3Ofm9nH4ftvXCv293f3eke7B103+7s/zFqjIS312qhKxlTrkcici4lbgbm/rQaHWCEDF2YHqj3ENAJ4VxKAR75bThIOY1AZJKJyDApUNAszoLDbtOZCYo1CxbjFvwOSJJyCv6Qlrfd8lZyI6szPOXj0qz9ae8WY+uP/Xvvdv1zDf7glglBY3Q6I4pExr2TV/TgihTo/4bhA+jhC5C/B7wSncokVVRrcMFheS34zlplrHCH8duhyoCXU24m3+3KZ8GZQSdy8V3oH8UMCp3mclCgROGz4isFfV02OBP18Y9x+VzJTMToC52xiL8adG8lN7I6+yE+X0CqISICIn8vEZ4BHlSXdlYmDwn8rdD/5RKlz46zdC3bf6QkZmJ6w0w0+yS5B5bvXREzw0Z+AgkidNA+CJtOaeifPgV7vRO2oPEHRRI6VCA7kSqpMn65pDGUBcK9nPxQnjmnUF+IkSqvAkIqM8v9GzXuqDZVwo/KwuUCCVZ8UWIcyhI1hg7Yv1CVOtiivHdHchi3AmqSzAw2kB5ug1JF5YWRko+JjVAsoyyB0oWn1Jxxaocny4sY7m8uM2rYY+uaSZry5QkTNqS6srBVaLZnIBAo8PYE+I6YqLzJycImqDqMZ0Rf34kbJVOqzDKwh5olq9YQFCywuK/Hmqo5GXNaR+KOl2I6G+tIsTENsjQmNnj1MHou3UMcbRhLTm8SLXjuqItX3wbEs/Jmdesw181pXrkPa+NTyaWqaOSm+OvHi+FZLlXp2ij6+9nl5fXXwxry+g3MFERjRtl0ZnLs/qWkUjMnXGkjysCIiB3XsbynU0Wpzq/wdruzg8P9bnev/Ta/kN0uDnfDnf1wL1/wVuzYcxjljRfWETAfp4olYHJONVY0kXN6DPfQxz7JOf6YPInjYIUIzrezBVCFWdIS7iCfQ74IyjwEnvfso8wfzgrcdsUWvQ2XdraWI+pXt5bIisDV0hKkm9os13zGOUu1ZDH+ej446NYENmSRMq1VYBl0nllyA7Lc3/V256DaJQu7O4A0Y7NACD/lXmRZ0atxq9xZzx6P0XXDgVOvdG0hF7xv1l+6vxsKormE25wwTbGZURFUxSKpJYGSJBHEQxFInfL22JTxfhDtx5I6EdP6W9qc27u7za2nZLbbK0Lem7GtqGBrkM6ooliBbKbRL6iqR35QxKA4B+0rENh/RIAXjsmW9iVJwd20t8LqUvgStvCns5uz42EZZ5+pmkU+qX0LuPfx2AfBdUr+yejLutGnc1M9QFEuWJ16urtw7OcZXHbzA9BqhHBLQRtqIqoeId5t/gSwF/DNpxlUmVeFGr4U6mrfs3Y9n6BDVdqe3do9sxLVPXh4Zm3lZUT5GaA3v4ew9ug84MzL3fAvZkBEHBFtoBOHuz/0DdIVFZnPgtraeULGv8tvC66/eZ+IRqKx1ehrs+T0qHDnV5ak0HjayhhAP24o9OPQ5+jWGL4ZqcGR1oXv/Vb9aD9mc8Tidxv+ZYIiTrSGnUnGXbUaNY76LZB/cJRLl7Ov51RxsrRis/bRpV/EGPdbMN18suxIS0/6Rh1Vibpv4qOKHMii6LdgbVWimsGciTSDdniZUtCvbAUBV6Dwwiy0I7KAUdsOtaGpXcW7MIG2kGyPof2FlTnhGe2tVdYt5JY/uwayh944O29qyG1oa2BgYj2p+/0/)