### PR TITLE
Add `enableDebugWireframe` to 3D Tiles sandcastles

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Formats.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Formats.html
@@ -154,6 +154,7 @@
             tileset = viewer.scene.primitives.add(
               new Cesium.Cesium3DTileset({
                 url: options.resource,
+                enableDebugWireframe: true,
               })
             );
 

--- a/Apps/Sandcastle/gallery/3D Tiles Inspector.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Inspector.html
@@ -48,6 +48,7 @@
 
         const tileset = new Cesium.Cesium3DTileset({
           url: Cesium.IonResource.fromAssetId(75343),
+          enableDebugWireframe: true,
         });
         viewer.scene.primitives.add(tileset);
 

--- a/Apps/Sandcastle/gallery/development/3D Tiles Split.html
+++ b/Apps/Sandcastle/gallery/development/3D Tiles Split.html
@@ -12,7 +12,7 @@
       name="description"
       content="Show 3D Tiles in various formats on only one side of the screen."
     />
-    <meta name="cesium-sandcastle-labels" content="3D Tiles" />
+    <meta name="cesium-sandcastle-labels" content="Development" />
     <title>Cesium Demo</title>
     <script type="text/javascript" src="../Sandcastle-header.js"></script>
     <script
@@ -196,6 +196,7 @@
             tileset = viewer.scene.primitives.add(
               new Cesium.Cesium3DTileset({
                 url: options.resource,
+                enableDebugWireframe: true,
               })
             );
 

--- a/Apps/Sandcastle/gallery/development/Many Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/development/Many Clipping Planes.html
@@ -223,6 +223,7 @@
             new Cesium.Cesium3DTileset({
               url: url,
               clippingPlanes: modelEntityClippingPlanes,
+              enableDebugWireframe: true,
             })
           );
 


### PR DESCRIPTION
`ModelExperimental` requires a user to specify `enableDebugWireframe: true` in the constructor of a tileset, in order for the debug wireframe to work. In preparation for enabling `ModelExperimental` by default, this PR adds that flag to the sandcastles that use the 3D Tiles Inspector.