### PR TITLE
Set `ExperimentalFeatures.enableModelExperimental` to true

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles BIM.html
+++ b/Apps/Sandcastle/gallery/3D Tiles BIM.html
@@ -35,6 +35,8 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        Cesium.ExperimentalFeatures.enableModelExperimental = false;
+
         // Power Plant design model provided by Bentley Systems
         const viewer = new Cesium.Viewer("cesiumContainer");
         const scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
@@ -65,6 +65,8 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        Cesium.ExperimentalFeatures.enableModelExperimental = false;
+
         // Add a clipping plane, a plane geometry to show the representation of the
         // plane, and control the magnitude of the plane distance with the mouse.
 

--- a/Apps/Sandcastle/gallery/3D Tiles Photogrammetry Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Photogrammetry Classification.html
@@ -36,6 +36,8 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        Cesium.ExperimentalFeatures.enableModelExperimental = false;
+
         // An example of using a b3dm tilset to classify another b3dm tileset.
         const viewer = new Cesium.Viewer("cesiumContainer", {
           terrainProvider: Cesium.createWorldTerrain(),

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
@@ -39,6 +39,7 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        Cesium.ExperimentalFeatures.enableModelExperimental = false;
 
         const viewer = new Cesium.Viewer("cesiumContainer");
         viewer.clock.currentTime = new Cesium.JulianDate(2457522.154792);

--- a/Apps/Sandcastle/gallery/Ambient Occlusion.html
+++ b/Apps/Sandcastle/gallery/Ambient Occlusion.html
@@ -113,6 +113,8 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        Cesium.ExperimentalFeatures.enableModelExperimental = false;
+
         const viewer = new Cesium.Viewer("cesiumContainer");
 
         if (

--- a/Apps/Sandcastle/gallery/CZML Model - Node Transformations.html
+++ b/Apps/Sandcastle/gallery/CZML Model - Node Transformations.html
@@ -33,6 +33,8 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        Cesium.ExperimentalFeatures.enableModelExperimental = false;
+
         const czml = [
           {
             id: "document",

--- a/Apps/Sandcastle/gallery/MSAA.html
+++ b/Apps/Sandcastle/gallery/MSAA.html
@@ -32,6 +32,8 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        Cesium.ExperimentalFeatures.enableModelExperimental = false;
+
         const viewer = new Cesium.Viewer("cesiumContainer", {
           terrainProvider: Cesium.createWorldTerrain(),
           contextOptions: {

--- a/Apps/Sandcastle/gallery/Montreal Point Cloud.html
+++ b/Apps/Sandcastle/gallery/Montreal Point Cloud.html
@@ -86,6 +86,8 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        Cesium.ExperimentalFeatures.enableModelExperimental = false;
+
         const viewer = new Cesium.Viewer("cesiumContainer", {
           terrainProvider: Cesium.createWorldTerrain(),
         });

--- a/Apps/Sandcastle/gallery/Polylines on 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/Polylines on 3D Tiles.html
@@ -35,6 +35,8 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        Cesium.ExperimentalFeatures.enableModelExperimental = false;
+
         // Power Plant design model provided by Bentley Systems
         const viewer = new Cesium.Viewer("cesiumContainer");
         const scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/Time Dynamic Wheels.html
+++ b/Apps/Sandcastle/gallery/Time Dynamic Wheels.html
@@ -35,6 +35,8 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        Cesium.ExperimentalFeatures.enableModelExperimental = false;
+
         const viewer = new Cesium.Viewer("cesiumContainer", {
           shouldAnimate: true,
         });

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### 1.96 - 2022-08-01
 
+##### Breaking Changes :mega:
+
+- Tilesets and entities now use `ModelExperimental` by default. This can still be changed by setting `ExperimentalFeatures.enableModelExperimental = false`. [#10530](https://github.com/CesiumGS/cesium/pull/10530)
+
 ##### Additions :tada:
 
 - Models and tilesets that use the `CESIUM_primitive_outline` extension can now toggle outlines at runtime with the `showOutline` property. Furthermore, the color of the outlines can now be controlled by the `outlineColor` property. [#10506](https://github.com/CesiumGS/cesium/pull/10506)

--- a/Source/Core/ExperimentalFeatures.js
+++ b/Source/Core/ExperimentalFeatures.js
@@ -22,7 +22,7 @@ const ExperimentalFeatures = {
    *
    * @type {Boolean}
    */
-  enableModelExperimental: false,
+  enableModelExperimental: true,
 };
 
 export default ExperimentalFeatures;

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -1449,6 +1449,21 @@ Object.defineProperties(ModelExperimental.prototype, {
       this._splitDirection = value;
     },
   },
+
+  /**
+   * Reference to the pick IDs. This is used only in internal code such as
+   * per-feature post-processing in {@link PostProcessStage}
+   *
+   * @type {PickId[]}
+   * @readonly
+   *
+   * @private
+   */
+  pickIds: {
+    get: function () {
+      return this._pickIds;
+    },
+  },
 });
 
 /**
@@ -2399,6 +2414,7 @@ ModelExperimental.fromPnts = function (options) {
   const loaderOptions = {
     arrayBuffer: options.arrayBuffer,
     byteOffset: options.byteOffset,
+    loadAttributesFor2D: options.projectTo2D,
   };
   const loader = new PntsLoader(loaderOptions);
 

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -903,9 +903,7 @@ Object.defineProperties(ModelExperimental.prototype, {
       return this._style;
     },
     set: function (value) {
-      if (value !== this._style) {
-        this.applyStyle(value);
-      }
+      this.applyStyle(value);
       this._style = value;
     },
   },
@@ -1449,21 +1447,6 @@ Object.defineProperties(ModelExperimental.prototype, {
         this.resetDrawCommands();
       }
       this._splitDirection = value;
-    },
-  },
-
-  /**
-   * Reference to the pick IDs. This is used only in internal code such as
-   * per-feature post-processing in {@link PostProcessStage}
-   *
-   * @type {PickId[]}
-   * @readonly
-   *
-   * @private
-   */
-  pickIds: {
-    get: function () {
-      return this._pickIds;
     },
   },
 });
@@ -2416,7 +2399,6 @@ ModelExperimental.fromPnts = function (options) {
   const loaderOptions = {
     arrayBuffer: options.arrayBuffer,
     byteOffset: options.byteOffset,
-    loadAttributesFor2D: options.projectTo2D,
   };
   const loader = new PntsLoader(loaderOptions);
 

--- a/Source/Scene/ModelExperimental/ModelExperimental3DTileContent.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental3DTileContent.js
@@ -3,6 +3,7 @@ import combine from "../../Core/combine.js";
 import defined from "../../Core/defined.js";
 import destroyObject from "../../Core/destroyObject.js";
 import Pass from "../../Renderer/Pass.js";
+import ModelAnimationLoop from "../ModelAnimationLoop.js";
 import ModelExperimental from "./ModelExperimental.js";
 
 /**
@@ -256,7 +257,15 @@ ModelExperimental3DTileContent.fromGltf = function (
     content,
     additionalOptions
   );
-  content._model = ModelExperimental.fromGltf(modelOptions);
+
+  const model = ModelExperimental.fromGltf(modelOptions);
+  model.readyPromise.then(function (model) {
+    model.activeAnimations.addAll({
+      loop: ModelAnimationLoop.REPEAT,
+    });
+  });
+  content._model = model;
+
   return content;
 };
 
@@ -281,7 +290,15 @@ ModelExperimental3DTileContent.fromB3dm = function (
     content,
     additionalOptions
   );
-  content._model = ModelExperimental.fromB3dm(modelOptions);
+
+  const model = ModelExperimental.fromB3dm(modelOptions);
+  model.readyPromise.then(function (model) {
+    model.activeAnimations.addAll({
+      loop: ModelAnimationLoop.REPEAT,
+    });
+  });
+  content._model = model;
+
   return content;
 };
 
@@ -306,7 +323,15 @@ ModelExperimental3DTileContent.fromI3dm = function (
     content,
     additionalOptions
   );
-  content._model = ModelExperimental.fromI3dm(modelOptions);
+
+  const model = ModelExperimental.fromI3dm(modelOptions);
+  model.readyPromise.then(function (model) {
+    model.activeAnimations.addAll({
+      loop: ModelAnimationLoop.REPEAT,
+    });
+  });
+  content._model = model;
+
   return content;
 };
 

--- a/Source/Scene/ModelExperimental/ModelFeatureTable.js
+++ b/Source/Scene/ModelExperimental/ModelFeatureTable.js
@@ -315,6 +315,6 @@ ModelFeatureTable.prototype.isDestroyed = function () {
  * @private
  */
 ModelFeatureTable.prototype.destroy = function (frameState) {
-  this._batchTexture.destroy();
+  this._batchTexture = this._batchTexture && this._batchTexture.destroy();
   destroyObject(this);
 };

--- a/Specs/DataSources/ModelVisualizerSpec.js
+++ b/Specs/DataSources/ModelVisualizerSpec.js
@@ -1,25 +1,28 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
-import { BoundingSphereState } from "../../Source/Cesium.js";
-import { ConstantPositionProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { EntityCollection } from "../../Source/Cesium.js";
-import { ModelGraphics } from "../../Source/Cesium.js";
-import { ModelVisualizer } from "../../Source/Cesium.js";
-import { NodeTransformationProperty } from "../../Source/Cesium.js";
-import { ClippingPlane } from "../../Source/Cesium.js";
-import { ClippingPlaneCollection } from "../../Source/Cesium.js";
-import { Globe } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Cartesian2,
+  Cartesian3,
+  Color,
+  defined,
+  DistanceDisplayCondition,
+  ExperimentalFeatures,
+  JulianDate,
+  Math as CesiumMath,
+  Matrix4,
+  Quaternion,
+  Resource,
+  Transforms,
+  BoundingSphereState,
+  ConstantPositionProperty,
+  ConstantProperty,
+  EntityCollection,
+  ModelGraphics,
+  ModelVisualizer,
+  NodeTransformationProperty,
+  ClippingPlane,
+  ClippingPlaneCollection,
+  Globe,
+} from "../../Source/Cesium.js";
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 
@@ -36,10 +39,16 @@ describe(
     beforeAll(function () {
       scene = createScene();
       scene.globe = new Globe();
+
+      // Temporarily set `false()` until ModelExperimental.getNode() is implemented
+      ExperimentalFeatures.enableModelExperimental = false;
     });
 
     afterAll(function () {
       scene.destroyForSpecs();
+
+      // This class is only used with Model
+      ExperimentalFeatures.enableModelExperimental = true;
     });
 
     afterEach(function () {

--- a/Specs/Scene/B3dmParserSpec.js
+++ b/Specs/Scene/B3dmParserSpec.js
@@ -73,7 +73,7 @@ describe(
           expect(B3dmParser._deprecationWarning).toHaveBeenCalled();
           Cesium3DTilesTester.expectRenderTileset(scene, tileset);
           const batchTable = tileset.root.content.batchTable;
-          expect(batchTable._properties).toBeDefined();
+          expect(batchTable.featuresLength).toBe(10);
         }
       );
     });
@@ -84,7 +84,7 @@ describe(
           expect(B3dmParser._deprecationWarning).toHaveBeenCalled();
           Cesium3DTilesTester.expectRenderTileset(scene, tileset);
           const batchTable = tileset.root.content.batchTable;
-          expect(batchTable._properties).toBeDefined();
+          expect(batchTable.featuresLength).toBe(10);
         }
       );
     });

--- a/Specs/Scene/Batched3DModel3DTileContentClassificationSpec.js
+++ b/Specs/Scene/Batched3DModel3DTileContentClassificationSpec.js
@@ -1,21 +1,24 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { destroyObject } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
-import { HeadingPitchRange } from "../../Source/Cesium.js";
-import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { RectangleGeometry } from "../../Source/Cesium.js";
-import { Pass } from "../../Source/Cesium.js";
-import { RenderState } from "../../Source/Cesium.js";
-import { ClassificationType } from "../../Source/Cesium.js";
-import { PerInstanceColorAppearance } from "../../Source/Cesium.js";
-import { Primitive } from "../../Source/Cesium.js";
-import { StencilConstants } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Cartographic,
+  Color,
+  ColorGeometryInstanceAttribute,
+  destroyObject,
+  Ellipsoid,
+  ExperimentalFeatures,
+  GeometryInstance,
+  HeadingPitchRange,
+  Math as CesiumMath,
+  Matrix4,
+  Rectangle,
+  RectangleGeometry,
+  Pass,
+  RenderState,
+  ClassificationType,
+  PerInstanceColorAppearance,
+  Primitive,
+  StencilConstants,
+} from "../../Source/Cesium.js";
 import Cesium3DTilesTester from "../Cesium3DTilesTester.js";
 import createScene from "../createScene.js";
 
@@ -127,12 +130,18 @@ describe(
         rectangle,
         Pass.CESIUM_3D_TILE
       );
+
+      // Temporarily disabling ModelExperimental until ClassificationModel is
+      // updated to use GltfLoader
+      ExperimentalFeatures.enableModelExperimental = false;
     });
 
     afterAll(function () {
       reusableGlobePrimitive.destroy();
       reusableTilesetPrimitive.destroy();
       scene.destroyForSpecs();
+
+      ExperimentalFeatures.enableModelExperimental = true;
     });
 
     beforeEach(function () {

--- a/Specs/Scene/Batched3DModel3DTileContentSpec.js
+++ b/Specs/Scene/Batched3DModel3DTileContentSpec.js
@@ -4,6 +4,7 @@ import {
   Cesium3DContentGroup,
   ContentMetadata,
   Color,
+  ExperimentalFeatures,
   HeadingPitchRange,
   HeadingPitchRoll,
   Matrix4,
@@ -59,10 +60,15 @@ describe(
 
       // Keep the error from logging to the console when running tests
       spyOn(B3dmParser, "_deprecationWarning");
+
+      // This class is only used with Model
+      ExperimentalFeatures.enableModelExperimental = false;
     });
 
     afterAll(function () {
       scene.destroyForSpecs();
+
+      ExperimentalFeatures.enableModelExperimental = true;
     });
 
     beforeEach(function () {

--- a/Specs/Scene/Cesium3DTileBatchTableSpec.js
+++ b/Specs/Scene/Cesium3DTileBatchTableSpec.js
@@ -1,16 +1,19 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartesian4 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { HeadingPitchRange } from "../../Source/Cesium.js";
-import { Matrix2 } from "../../Source/Cesium.js";
-import { Matrix3 } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { ContextLimits } from "../../Source/Cesium.js";
-import { Batched3DModel3DTileContent } from "../../Source/Cesium.js";
-import { Cesium3DTileBatchTable } from "../../Source/Cesium.js";
-import { Cesium3DTileStyle } from "../../Source/Cesium.js";
-import { RuntimeError } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Cartesian4,
+  Color,
+  ExperimentalFeatures,
+  HeadingPitchRange,
+  Matrix2,
+  Matrix3,
+  Matrix4,
+  ContextLimits,
+  Batched3DModel3DTileContent,
+  Cesium3DTileBatchTable,
+  Cesium3DTileStyle,
+  RuntimeError,
+} from "../../Source/Cesium.js";
 import Cesium3DTilesTester from "../Cesium3DTilesTester.js";
 import createScene from "../createScene.js";
 import concatTypedArrays from "../concatTypedArrays.js";
@@ -63,10 +66,15 @@ describe(
       // Keep the error from logging to the console when running tests
       spyOn(Cesium3DTileBatchTable, "_deprecationWarning");
       spyOn(Batched3DModel3DTileContent, "_deprecationWarning");
+
+      // ModelExperimental doesn't use Cesium3DTileBatchTable
+      ExperimentalFeatures.enableModelExperimental = false;
     });
 
     afterAll(function () {
       scene.destroyForSpecs();
+
+      ExperimentalFeatures.enableModelExperimental = true;
     });
 
     afterEach(function () {

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -984,7 +984,8 @@ describe(
       options.url = pointCloudUrl;
       const tileset = scene.primitives.add(new Cesium3DTileset(options));
 
-      return checkPointAndFeatureCounts(tileset, 0, 1000, 0);
+      // In ModelExperimental, points are also counted as features.
+      return checkPointAndFeatureCounts(tileset, 1000, 1000, 0);
     });
 
     it("verify triangle statistics", function () {
@@ -2030,11 +2031,11 @@ describe(
       });
     });
 
-    function checkDebugColorizeTiles(url) {
+    function checkDebugColorizeTiles(url, enableModelExperimental) {
       CesiumMath.setRandomNumberSeed(0);
-      return Cesium3DTilesTester.loadTileset(scene, url).then(function (
-        tileset
-      ) {
+      return Cesium3DTilesTester.loadTileset(scene, url, {
+        enableModelExperimental: enableModelExperimental,
+      }).then(function (tileset) {
         // Get initial color
         let color;
         Cesium3DTilesTester.expectRender(scene, tileset, function (rgba) {
@@ -2079,7 +2080,11 @@ describe(
 
     it("debugColorizeTiles for pnts without batch table", function () {
       viewPointCloud();
-      return checkDebugColorizeTiles(pointCloudUrl);
+
+      // This unit test fails for ModelExperimental because points are counted
+      // as features, which interferes with how debug color is applied.
+      const enableModelExperimental = false;
+      return checkDebugColorizeTiles(pointCloudUrl, enableModelExperimental);
     });
 
     it("debugColorizeTiles for glTF", function () {

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -16,6 +16,7 @@ import {
   ClippingPlane,
   ClippingPlaneCollection,
   Color,
+  combine,
   ContextLimits,
   Credit,
   CullFace,
@@ -3860,10 +3861,16 @@ describe(
     });
 
     it("creates duplicate backface commands", function () {
+      // Disable ModelExperimental here because ModelFeatureTable doesn't handle
+      // the creation of backface commands yet.
+      const options = combine(
+        { enableModelExperimental: false },
+        skipLevelOfDetailOptions
+      );
       return Cesium3DTilesTester.loadTileset(
         scene,
         tilesetReplacement3Url,
-        skipLevelOfDetailOptions
+        options
       ).then(function (tileset) {
         const statistics = tileset._statistics;
         const root = tileset.root;

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -1014,9 +1014,12 @@ describe(
       const tilesLength = 5;
 
       viewNothing();
-      return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function (
-        tileset
-      ) {
+
+      // Disable ModelExperimental until ModelExperimentalStatistics
+      // are refactored to properly count batch textures.
+      return Cesium3DTilesTester.loadTileset(scene, tilesetUrl, {
+        enableModelExperimental: false,
+      }).then(function (tileset) {
         const statistics = tileset._statistics;
 
         // No tiles loaded
@@ -1101,7 +1104,7 @@ describe(
       });
     });
 
-    it("verify memory usage statistics for shared resources", function () {
+    xit("verify memory usage statistics for shared resources", function () {
       // Six tiles total:
       // * Two b3dm tiles - no shared resources
       // * Two i3dm tiles with embedded glTF - no shared resources
@@ -1120,9 +1123,14 @@ describe(
         b3dmGeometryMemory * 2 + i3dmGeometryMemory * 3;
       const expectedTextureMemory = texturesByteLength * 5;
 
+      // Disable ModelExperimental until ModelExperimentalStatistics
+      // are refactored to properly count shared resources.
       return Cesium3DTilesTester.loadTileset(
         scene,
-        tilesetWithExternalResourcesUrl
+        tilesetWithExternalResourcesUrl,
+        {
+          enableModelExperimental: false,
+        }
       ).then(function (tileset) {
         const statistics = tileset._statistics;
         expect(statistics.geometryByteLength).toBe(expectedGeometryMemory);

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -1104,7 +1104,7 @@ describe(
       });
     });
 
-    xit("verify memory usage statistics for shared resources", function () {
+    it("verify memory usage statistics for shared resources", function () {
       // Six tiles total:
       // * Two b3dm tiles - no shared resources
       // * Two i3dm tiles with embedded glTF - no shared resources

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -1,43 +1,45 @@
-import { Axis } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { Credit } from "../../Source/Cesium.js";
-import { CullingVolume } from "../../Source/Cesium.js";
-import { defer } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { findTileMetadata } from "../../Source/Cesium.js";
-import { findContentMetadata } from "../../Source/Cesium.js";
-import { getAbsoluteUri } from "../../Source/Cesium.js";
-import { getJsonFromTypedArray } from "../../Source/Cesium.js";
-import { HeadingPitchRange } from "../../Source/Cesium.js";
-import { HeadingPitchRoll } from "../../Source/Cesium.js";
-import { Intersect } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { PerspectiveFrustum } from "../../Source/Cesium.js";
-import { PrimitiveType } from "../../Source/Cesium.js";
-import { Ray } from "../../Source/Cesium.js";
-import { RequestScheduler } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { ResourceCache } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
-import { ClearCommand } from "../../Source/Cesium.js";
-import { ContextLimits } from "../../Source/Cesium.js";
-import { Camera } from "../../Source/Cesium.js";
-import { Cesium3DTile } from "../../Source/Cesium.js";
-import { Cesium3DTileColorBlendMode } from "../../Source/Cesium.js";
-import { Cesium3DTileContentState } from "../../Source/Cesium.js";
-import { Cesium3DTilePass } from "../../Source/Cesium.js";
-import { Cesium3DTilePassState } from "../../Source/Cesium.js";
-import { Cesium3DTileRefine } from "../../Source/Cesium.js";
-import { Cesium3DTileset } from "../../Source/Cesium.js";
-import { Cesium3DTileStyle } from "../../Source/Cesium.js";
-import { ClippingPlane } from "../../Source/Cesium.js";
-import { ClippingPlaneCollection } from "../../Source/Cesium.js";
-import { CullFace } from "../../Source/Cesium.js";
+import {
+  Axis,
+  Camera,
+  Cartesian2,
+  Cartesian3,
+  Cartographic,
+  Cesium3DTile,
+  Cesium3DTileColorBlendMode,
+  Cesium3DTileContentState,
+  Cesium3DTilePass,
+  Cesium3DTilePassState,
+  Cesium3DTileRefine,
+  Cesium3DTileset,
+  Cesium3DTileStyle,
+  ClearCommand,
+  ClippingPlane,
+  ClippingPlaneCollection,
+  Color,
+  ContextLimits,
+  Credit,
+  CullFace,
+  CullingVolume,
+  defer,
+  defined,
+  findTileMetadata,
+  findContentMetadata,
+  getAbsoluteUri,
+  getJsonFromTypedArray,
+  HeadingPitchRange,
+  HeadingPitchRoll,
+  Intersect,
+  JulianDate,
+  Math as CesiumMath,
+  Matrix4,
+  PerspectiveFrustum,
+  PrimitiveType,
+  Ray,
+  RequestScheduler,
+  Resource,
+  ResourceCache,
+  Transforms,
+} from "../../Source/Cesium.js";
 import Cesium3DTilesTester from "../Cesium3DTilesTester.js";
 import createScene from "../createScene.js";
 import generateJsonBuffer from "../generateJsonBuffer.js";

--- a/Specs/Scene/Implicit3DTileContentSpec.js
+++ b/Specs/Scene/Implicit3DTileContentSpec.js
@@ -1,5 +1,4 @@
 import {
-  Batched3DModel3DTileContent,
   Cartesian3,
   Cesium3DContentGroup,
   Cesium3DTile,
@@ -14,6 +13,7 @@ import {
   Matrix3,
   Matrix4,
   MetadataClass,
+  ModelExperimental3DTileContent,
   GroupMetadata,
   Multiple3DTileContent,
   Resource,
@@ -937,7 +937,7 @@ describe(
           const transcodedRoot = tileset.root.children[0];
           const transcodedRootHeader = transcodedRoot._header;
           expect(transcodedRoot.content).toBeInstanceOf(
-            Batched3DModel3DTileContent
+            ModelExperimental3DTileContent
           );
           expect(transcodedRootHeader.contents[0]).toEqual({
             uri: "ground/0/0/0.b3dm",
@@ -981,7 +981,7 @@ describe(
           const transcodedRoot = tileset.root.children[0];
           const transcodedRootHeader = transcodedRoot._header;
           expect(transcodedRoot.content).toBeInstanceOf(
-            Batched3DModel3DTileContent
+            ModelExperimental3DTileContent
           );
           expect(transcodedRootHeader.contents[0]).toEqual({
             uri: "ground/0/0/0.b3dm",
@@ -999,7 +999,7 @@ describe(
           const transcodedRoot = tileset.root.children[0];
           const transcodedRootHeader = transcodedRoot._header;
           expect(transcodedRoot.content).toBeInstanceOf(
-            Batched3DModel3DTileContent
+            ModelExperimental3DTileContent
           );
           expect(transcodedRootHeader.contents[0]).toEqual({
             uri: "ground/0/0/0.b3dm",

--- a/Specs/Scene/Instanced3DModel3DTileContentSpec.js
+++ b/Specs/Scene/Instanced3DModel3DTileContentSpec.js
@@ -3,6 +3,7 @@ import {
   Cesium3DContentGroup,
   Color,
   ContentMetadata,
+  ExperimentalFeatures,
   HeadingPitchRange,
   HeadingPitchRoll,
   Transforms,
@@ -61,6 +62,9 @@ describe(
 
     beforeAll(function () {
       scene = createScene();
+
+      // This class is only used with Model
+      ExperimentalFeatures.enableModelExperimental = false;
     });
 
     beforeEach(function () {
@@ -70,6 +74,8 @@ describe(
 
     afterAll(function () {
       scene.destroyForSpecs();
+
+      ExperimentalFeatures.enableModelExperimental = true;
     });
 
     afterEach(function () {

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -11,6 +11,7 @@ import {
   ContentMetadata,
   defined,
   DracoLoader,
+  ExperimentalFeatures,
   Expression,
   HeadingPitchRange,
   HeadingPitchRoll,
@@ -80,10 +81,15 @@ describe(
     beforeAll(function () {
       scene = createScene();
       scene.frameState.passes.render = true;
+
+      // This class is only used with Model
+      ExperimentalFeatures.enableModelExperimental = false;
     });
 
     afterAll(function () {
       scene.destroyForSpecs();
+
+      ExperimentalFeatures.enableModelExperimental = true;
     });
 
     beforeEach(function () {


### PR DESCRIPTION
in preparation for #10346, we wanted to enable ModelExperimental by default early in the month so there's time to catch any bugs we may have missed.

That said, there are a few known issues (see #10346) so in a few sandcastles we explicitly set the flag to false:

* BIM model that needs to be updated to not use techniques:
  * Apps/Sandcastle/gallery/3D Tiles BIM.html
  * Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
  * Apps/Sandcastle/gallery/Ambient Occlusion.html
  * Apps/Sandcastle/gallery/MSAA.html
  * Apps/Sandcastle/gallery/Polylines on 3D Tiles.html
* getNode needs to be implemented:
  * Apps/Sandcastle/gallery/CZML Model - Node Transformations.html
  * Apps/Sandcastle/gallery/Time Dynamic Wheels.html
* Point cloud styling is not yet supported
  * Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
  * Apps/Sandcastle/gallery/Montreal Point Cloud.html
* Classification model needs to be updated to use GltfLoader
  * Apps/Sandcastle/gallery/3D Tiles Photogrammetry * Classification.html

All other 3D Tiles sandcastles should work fine.

@j9liu could you review?