### PR TITLE
Add `ANGLE_instanced_arrays` to the WebGL stubs for unit testing

### DIFF
--- a/Specs/Renderer/DrawSpec.js
+++ b/Specs/Renderer/DrawSpec.js
@@ -1286,70 +1286,68 @@ describe(
     });
 
     it("draws two instances of a point with different per-instance colors", function () {
-      if (context.instancedArrays) {
-        const vs =
-          "attribute vec4 position;" +
-          "attribute vec4 color;" +
-          "varying vec4 v_color;" +
-          "void main() {" +
-          "  gl_PointSize = 1.0; " +
-          "  gl_Position = position;" +
-          "  v_color = color;" +
-          "}";
-        const fs =
-          "varying vec4 v_color; void main() { gl_FragColor = v_color; }";
-        sp = ShaderProgram.fromCache({
-          context: context,
-          vertexShaderSource: vs,
-          fragmentShaderSource: fs,
-          attributeLocations: {
-            position: 0,
-            color: 1,
+      const vs =
+        "attribute vec4 position;" +
+        "attribute vec4 color;" +
+        "varying vec4 v_color;" +
+        "void main() {" +
+        "  gl_PointSize = 1.0; " +
+        "  gl_Position = position;" +
+        "  v_color = color;" +
+        "}";
+      const fs =
+        "varying vec4 v_color; void main() { gl_FragColor = v_color; }";
+      sp = ShaderProgram.fromCache({
+        context: context,
+        vertexShaderSource: vs,
+        fragmentShaderSource: fs,
+        attributeLocations: {
+          position: 0,
+          color: 1,
+        },
+      });
+
+      va = new VertexArray({
+        context: context,
+        attributes: [
+          {
+            index: 0,
+            vertexBuffer: Buffer.createVertexBuffer({
+              context: context,
+              typedArray: new Float32Array([0, 0, 0, 1]),
+              usage: BufferUsage.STATIC_DRAW,
+            }),
+            componentsPerAttribute: 4,
           },
-        });
+          {
+            index: 1,
+            vertexBuffer: Buffer.createVertexBuffer({
+              context: context,
+              typedArray: new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255]),
+              usage: BufferUsage.STATIC_DRAW,
+            }),
+            componentDatatype: ComponentDatatype.UNSIGNED_BYTE,
+            componentsPerAttribute: 4,
+            normalize: true,
+            instanceDivisor: 1,
+          },
+        ],
+      });
 
-        va = new VertexArray({
-          context: context,
-          attributes: [
-            {
-              index: 0,
-              vertexBuffer: Buffer.createVertexBuffer({
-                context: context,
-                typedArray: new Float32Array([0, 0, 0, 1]),
-                usage: BufferUsage.STATIC_DRAW,
-              }),
-              componentsPerAttribute: 4,
-            },
-            {
-              index: 1,
-              vertexBuffer: Buffer.createVertexBuffer({
-                context: context,
-                typedArray: new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255]),
-                usage: BufferUsage.STATIC_DRAW,
-              }),
-              componentDatatype: ComponentDatatype.UNSIGNED_BYTE,
-              componentsPerAttribute: 4,
-              normalize: true,
-              instanceDivisor: 1,
-            },
-          ],
-        });
+      ClearCommand.ALL.execute(context);
+      expect(context).toReadPixels([0, 0, 0, 255]);
 
-        ClearCommand.ALL.execute(context);
-        expect(context).toReadPixels([0, 0, 0, 255]);
-
-        const command = new DrawCommand({
-          primitiveType: PrimitiveType.POINTS,
-          shaderProgram: sp,
-          vertexArray: va,
-          instanceCount: 2,
-          renderState: RenderState.fromCache({
-            blending: BlendingState.ADDITIVE_BLEND,
-          }),
-        });
-        command.execute(context);
-        expect(context).toReadPixels([255, 255, 0, 255]);
-      }
+      const command = new DrawCommand({
+        primitiveType: PrimitiveType.POINTS,
+        shaderProgram: sp,
+        vertexArray: va,
+        instanceCount: 2,
+        renderState: RenderState.fromCache({
+          blending: BlendingState.ADDITIVE_BLEND,
+        }),
+      });
+      command.execute(context);
+      expect(context).toReadPixels([255, 255, 0, 255]);
     });
 
     it("fails to draw (missing command)", function () {
@@ -1482,46 +1480,49 @@ describe(
       }).toThrowDeveloperError();
     });
 
-    it("throws when instanceCount is greater than one and the instanced arrays extension is not supported", function () {
-      if (!context.instancedArrays) {
-        const vs =
-          "attribute vec4 position; void main() { gl_PointSize = 1.0; gl_Position = position; }";
-        const fs = "void main() { gl_FragColor = vec4(1.0); }";
-        sp = ShaderProgram.fromCache({
-          context: context,
-          vertexShaderSource: vs,
-          fragmentShaderSource: fs,
-          attributeLocations: {
-            position: 0,
+    it("throws when instanceCount is greater than one and instancing is disabled", function () {
+      // disable extension
+      const instancedArrays = context._instancedArrays;
+      context._instancedArrays = undefined;
+
+      const vs =
+        "attribute vec4 position; void main() { gl_PointSize = 1.0; gl_Position = position; }";
+      const fs = "void main() { gl_FragColor = vec4(1.0); }";
+      sp = ShaderProgram.fromCache({
+        context: context,
+        vertexShaderSource: vs,
+        fragmentShaderSource: fs,
+        attributeLocations: {
+          position: 0,
+        },
+      });
+
+      va = new VertexArray({
+        context: context,
+        attributes: [
+          {
+            index: 0,
+            vertexBuffer: Buffer.createVertexBuffer({
+              context: context,
+              typedArray: new Float32Array([0, 0, 0, 1]),
+              usage: BufferUsage.STATIC_DRAW,
+            }),
+            componentsPerAttribute: 4,
           },
-        });
+        ],
+      });
 
-        va = new VertexArray({
-          context: context,
-          attributes: [
-            {
-              index: 0,
-              vertexBuffer: Buffer.createVertexBuffer({
-                context: context,
-                typedArray: new Float32Array([0, 0, 0, 1]),
-                usage: BufferUsage.STATIC_DRAW,
-              }),
-              componentsPerAttribute: 4,
-            },
-          ],
-        });
+      const command = new DrawCommand({
+        primitiveType: PrimitiveType.POINTS,
+        shaderProgram: sp,
+        vertexArray: va,
+        instanceCount: 2,
+      });
 
-        const command = new DrawCommand({
-          primitiveType: PrimitiveType.POINTS,
-          shaderProgram: sp,
-          vertexArray: va,
-          instanceCount: 2,
-        });
-
-        expect(function () {
-          command.execute(context);
-        }).toThrowDeveloperError();
-      }
+      expect(function () {
+        command.execute(context);
+      }).toThrowDeveloperError();
+      context._instancedArrays = instancedArrays;
     });
   },
   "WebGL"

--- a/Specs/Renderer/VertexArraySpec.js
+++ b/Specs/Renderer/VertexArraySpec.js
@@ -867,7 +867,7 @@ describe(
       }).toThrowDeveloperError();
     });
 
-    it("throws when instanceDivisor is greater than zero instancing is disabled", function () {
+    it("throws when instanceDivisor is greater than zero and instancing is disabled", function () {
       // disable extension
       const instancedArrays = context._instancedArrays;
       context._instancedArrays = undefined;

--- a/Specs/Renderer/VertexArraySpec.js
+++ b/Specs/Renderer/VertexArraySpec.js
@@ -867,35 +867,38 @@ describe(
       }).toThrowDeveloperError();
     });
 
-    it("throws when instanceDivisor is greater than zero and the instanced arrays extension is not supported.", function () {
-      if (!context.instancedArrays) {
-        const buffer = Buffer.createVertexBuffer({
+    it("throws when instanceDivisor is greater than zero instancing is disabled", function () {
+      // disable extension
+      const instancedArrays = context._instancedArrays;
+      context._instancedArrays = undefined;
+
+      const buffer = Buffer.createVertexBuffer({
+        context: context,
+        sizeInBytes: 3,
+        usage: BufferUsage.STATIC_DRAW,
+      });
+
+      const attributes = [
+        {
+          index: 0,
+          vertexBuffer: buffer,
+          componentsPerAttribute: 3,
+        },
+        {
+          index: 1,
+          vertexBuffer: buffer,
+          componentsPerAttribute: 3,
+          instanceDivisor: 1,
+        },
+      ];
+
+      expect(function () {
+        return new VertexArray({
           context: context,
-          sizeInBytes: 3,
-          usage: BufferUsage.STATIC_DRAW,
+          attributes: attributes,
         });
-
-        const attributes = [
-          {
-            index: 0,
-            vertexBuffer: buffer,
-            componentsPerAttribute: 3,
-          },
-          {
-            index: 1,
-            vertexBuffer: buffer,
-            componentsPerAttribute: 3,
-            instanceDivisor: 1,
-          },
-        ];
-
-        expect(function () {
-          return new VertexArray({
-            context: context,
-            attributes: attributes,
-          });
-        }).toThrowDeveloperError();
-      }
+      }).toThrowDeveloperError();
+      context._instancedArrays = instancedArrays;
     });
   },
   "WebGL"

--- a/Specs/Scene/BillboardCollectionSpec.js
+++ b/Specs/Scene/BillboardCollectionSpec.js
@@ -1372,10 +1372,6 @@ describe(
     });
 
     it("renders more than 16K billboards", function () {
-      if (!context.instancedArrays) {
-        return;
-      }
-
       for (let i = 0; i < 16 * 1024; ++i) {
         billboards.add({
           position: Cartesian3.ZERO,

--- a/Specs/Scene/GltfLoaderSpec.js
+++ b/Specs/Scene/GltfLoaderSpec.js
@@ -120,12 +120,6 @@ describe(
     beforeAll(function () {
       scene = createScene();
 
-      // This is set to true in order to test that buffers / typed arrays
-      // are loaded in correctly for instanced models. If this is false,
-      // instanced attributes will always load in as typed arrays, which
-      // will cause several tests to fail.
-      scene.context._instancedArrays = true;
-
       sceneWithWebgl2 = createScene();
       sceneWithWebgl2.context._webgl2 = true;
     });

--- a/Specs/Scene/ModelExperimental/InstancingPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/InstancingPipelineStageSpec.js
@@ -39,11 +39,6 @@ describe(
 
     beforeAll(function () {
       scene = createScene();
-      // This is set to true to guarantee that buffers / typed arrays
-      // are loaded in as expected for instanced models. If this is false,
-      // instanced attributes will always load in as typed arrays, which
-      // will cause several tests to fail.
-      scene.context._instancedArrays = true;
 
       scene2D = createScene();
       scene2D.morphTo2D(0.0);

--- a/Specs/Scene/ModelExperimental/ModelExperimental3DTileContentSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimental3DTileContentSpec.js
@@ -86,10 +86,6 @@ describe("Scene/ModelExperimental/ModelExperimental3DTileContent", function () {
   });
 
   it("resolves readyPromise with i3dm", function () {
-    if (!scene.context.instancedArrays) {
-      return;
-    }
-
     setCamera(centerLongitude, centerLatitude, 15.0);
     return Cesium3DTilesTester.resolvesReadyPromise(
       scene,
@@ -132,10 +128,6 @@ describe("Scene/ModelExperimental/ModelExperimental3DTileContent", function () {
   });
 
   it("renders i3dm content", function () {
-    if (!scene.context.instancedArrays) {
-      return;
-    }
-
     setCamera(centerLongitude, centerLatitude, 25.0);
     return Cesium3DTilesTester.loadTileset(
       scene,
@@ -268,10 +260,6 @@ describe("Scene/ModelExperimental/ModelExperimental3DTileContent", function () {
   });
 
   it("picks from i3dm batch table", function () {
-    if (!scene.context.instancedArrays) {
-      return;
-    }
-
     setCamera(centerLongitude, centerLatitude, 25.0);
     return Cesium3DTilesTester.loadTileset(
       scene,

--- a/Specs/Scene/ModelExperimental/NodeStatisticsPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/NodeStatisticsPipelineStageSpec.js
@@ -23,11 +23,6 @@ describe("Scene/ModelExperimental/NodeStatisticsPipelineStage", function () {
 
   beforeAll(function () {
     scene = createScene();
-    // This is set to true to guarantee that buffers / typed arrays
-    // are loaded in as expected for instanced models. If this is false,
-    // instanced attributes will always load in as typed arrays, which
-    // will cause several tests to fail.
-    scene.context._instancedArrays = true;
   });
 
   afterAll(function () {

--- a/Specs/getWebGLStub.js
+++ b/Specs/getWebGLStub.js
@@ -1,8 +1,10 @@
-import { clone } from "../Source/Cesium.js";
-import { defaultValue } from "../Source/Cesium.js";
-import { defined } from "../Source/Cesium.js";
-import { DeveloperError } from "../Source/Cesium.js";
-import { WebGLConstants } from "../Source/Cesium.js";
+import {
+  clone,
+  defaultValue,
+  defined,
+  DeveloperError,
+  WebGLConstants,
+} from "../Source/Cesium.js";
 
 function getWebGLStub(canvas, options) {
   const stub = clone(WebGLConstants);
@@ -198,8 +200,21 @@ function getErrorStub() {
 }
 
 function getExtensionStub(name) {
-  // No extensions are stubbed.
+  // Many 3D Tiles tests rely on instanced arrays
+  if (name === "ANGLE_instanced_arrays") {
+    return getInstancingStub();
+  }
+
+  // No other extensions are stubbed.
   return null;
+}
+
+function getInstancingStub() {
+  return {
+    drawElementsInstancedANGLE: noop,
+    drawArraysInstancedANGLE: noop,
+    vertexAttribDivisorANGLE: noop,
+  };
 }
 
 function getParameterStub(options) {

--- a/Specs/getWebGLStub.js
+++ b/Specs/getWebGLStub.js
@@ -153,6 +153,13 @@ function getWebGLStub(canvas, options) {
   return stub;
 }
 
+// ANGLE_instanced_arrays
+const instancedArraysStub = {
+  drawElementsInstancedANGLE: noop,
+  drawArraysInstancedANGLE: noop,
+  vertexAttribDivisorANGLE: noop,
+};
+
 function noop() {}
 
 function createStub() {
@@ -202,19 +209,11 @@ function getErrorStub() {
 function getExtensionStub(name) {
   // Many 3D Tiles tests rely on instanced arrays
   if (name === "ANGLE_instanced_arrays") {
-    return getInstancingStub();
+    return instancedArraysStub;
   }
 
   // No other extensions are stubbed.
   return null;
-}
-
-function getInstancingStub() {
-  return {
-    drawElementsInstancedANGLE: noop,
-    drawArraysInstancedANGLE: noop,
-    vertexAttribDivisorANGLE: noop,
-  };
 }
 
 function getParameterStub(options) {


### PR DESCRIPTION
This PR adds stubs for instancing in WebGL 1 so instancing-related unit tests can run in Travis CI.

While working on #10530, @j9liu and I noticed that 30+ tests in `Cesium3DTileset` will break if `ModelExperimental` is used because the implementation of instanced models is GPU only (no `ModelInstanceCollection` which has a CPU fallback). We'd rather not skip those tests completely in Travis, and stubbing the extension is an easy way around it.

For the record, [`ANGLE_instanced_arrays` is available in all the major browsers](https://caniuse.com/mdn-api_angle_instanced_arrays) and is only needed in WebGL 1, as these features are built-in in WebGL 2.

@j9liu could you review?