### PR TITLE
Fixes Scene render tests promise rejections

### DIFF
--- a/Specs/Scene/SceneSpec.js
+++ b/Specs/Scene/SceneSpec.js
@@ -551,19 +551,11 @@ describe(
           new Cartesian3()
         );
 
-        // To avoid Jasmine's spec has no expectations error
-        expect(true).toEqual(true);
-
         return expect(s).toRenderAndCall(function () {
-          return pollToPromise(function () {
-            render(s.frameState, s.globe);
-            return !jasmine.matchersUtil.equals(s._context.readPixels(), [
-              0,
-              0,
-              0,
-              0,
-            ]);
-          });
+          render(s.frameState, s.globe);
+          const pixel = s._context.readPixels();
+          const blankPixel = [0, 0, 0, 0];
+          expect(pixel).not.toEqual(blankPixel);
         });
       });
 
@@ -577,19 +569,11 @@ describe(
           new Cartesian3()
         );
 
-        // To avoid Jasmine's spec has no expectations error
-        expect(true).toEqual(true);
-
         return expect(s).toRenderAndCall(function () {
-          return pollToPromise(function () {
-            render(s.frameState, s.globe);
-            return !jasmine.matchersUtil.equals(s._context.readPixels(), [
-              0,
-              0,
-              0,
-              0,
-            ]);
-          });
+          render(s.frameState, s.globe);
+          const pixel = s._context.readPixels();
+          const blankPixel = [0, 0, 0, 0];
+          expect(pixel).not.toEqual(blankPixel);
         });
       });
 
@@ -603,19 +587,11 @@ describe(
           new Cartesian3()
         );
 
-        // To avoid Jasmine's spec has no expectations error
-        expect(true).toEqual(true);
-
         return expect(s).toRenderAndCall(function () {
-          return pollToPromise(function () {
-            render(s.frameState, s.globe);
-            return !jasmine.matchersUtil.equals(s._context.readPixels(), [
-              0,
-              0,
-              0,
-              0,
-            ]);
-          });
+          render(s.frameState, s.globe);
+          const pixel = s._context.readPixels();
+          const blankPixel = [0, 0, 0, 0];
+          expect(pixel).not.toEqual(blankPixel);
         });
       });
 
@@ -628,20 +604,11 @@ describe(
           Cartesian3.normalize(s.camera.position, new Cartesian3()),
           new Cartesian3()
         );
-
-        // To avoid Jasmine's spec has no expectations error
-        expect(true).toEqual(true);
-
         return expect(s).toRenderAndCall(function () {
-          return pollToPromise(function () {
-            render(s.frameState, s.globe);
-            return !jasmine.matchersUtil.equals(s._context.readPixels(), [
-              0,
-              0,
-              0,
-              0,
-            ]);
-          });
+          render(s.frameState, s.globe);
+          const pixel = s._context.readPixels();
+          const blankPixel = [0, 0, 0, 0];
+          expect(pixel).not.toEqual(blankPixel);
         });
       });
 
@@ -655,19 +622,11 @@ describe(
           new Cartesian3()
         );
 
-        // To avoid Jasmine's spec has no expectations error
-        expect(true).toEqual(true);
-
         return expect(s).toRenderAndCall(function () {
-          return pollToPromise(function () {
-            render(s.frameState, s.globe);
-            return !jasmine.matchersUtil.equals(s._context.readPixels(), [
-              0,
-              0,
-              0,
-              0,
-            ]);
-          });
+          render(s.frameState, s.globe);
+          const pixel = s._context.readPixels();
+          const blankPixel = [0, 0, 0, 0];
+          expect(pixel).not.toEqual(blankPixel);
         });
       });
 
@@ -681,19 +640,11 @@ describe(
           new Cartesian3()
         );
 
-        // To avoid Jasmine's spec has no expectations error
-        expect(true).toEqual(true);
-
         return expect(s).toRenderAndCall(function () {
-          return pollToPromise(function () {
-            render(s.frameState, s.globe);
-            return !jasmine.matchersUtil.equals(s._context.readPixels(), [
-              0,
-              0,
-              0,
-              0,
-            ]);
-          });
+          render(s.frameState, s.globe);
+          const pixel = s._context.readPixels();
+          const blankPixel = [0, 0, 0, 0];
+          expect(pixel).not.toEqual(blankPixel);
         });
       });
     });


### PR DESCRIPTION
This PR fixes the unhandled promise rejection erorrs that happened in the [`Scene/Scene > render tests`](http://localhost:8080/Specs/SpecRunner.html?category=none&spec=Scene%2FScene%20render%20tests).

The primary change is to simplify the condition to check if the pixel returned from `readPixels()` is a blank pixel or not. The `jasmine.matchersUtil.equals` has been replaced with a simple `equals` check.