### PR TITLE
Removes defer usage from TaskProcessor

### DIFF
--- a/Source/WorkersES6/createTaskProcessorWorker.js
+++ b/Source/WorkersES6/createTaskProcessorWorker.js
@@ -77,10 +77,6 @@ function createTaskProcessorWorker(workerFunction) {
           postMessage = defaultValue(self.webkitPostMessage, self.postMessage);
         }
 
-        if (!data.canTransferArrayBuffer) {
-          transferableObjects.length = 0;
-        }
-
         try {
           postMessage(responseMessage, transferableObjects);
         } catch (e) {

--- a/Specs/Core/TaskProcessorSpec.js
+++ b/Specs/Core/TaskProcessorSpec.js
@@ -46,32 +46,6 @@ describe("Core/TaskProcessor", function () {
     expect(taskProcessor.isDestroyed()).toEqual(true);
   });
 
-  it("can transfer array buffer", function () {
-    taskProcessor = new TaskProcessor(
-      absolutize("../Specs/TestWorkers/returnByteLength.js")
-    );
-
-    const byteLength = 100;
-    const parameters = new ArrayBuffer(byteLength);
-    expect(parameters.byteLength).toEqual(byteLength);
-
-    return Promise.resolve(TaskProcessor._canTransferArrayBuffer).then(
-      function (canTransferArrayBuffer) {
-        const promise = taskProcessor.scheduleTask(parameters, [parameters]);
-
-        // the worker should see the array with proper byte length
-        return promise.then(function (result) {
-          if (canTransferArrayBuffer) {
-            // array buffer should be neutered when transferred
-            expect(parameters.byteLength).toEqual(0);
-          }
-
-          expect(result).toEqual(byteLength);
-        });
-      }
-    );
-  });
-
   it("can transfer array buffer back from worker", function () {
     taskProcessor = new TaskProcessor(
       absolutize("../Specs/TestWorkers/transferArrayBuffer.js")


### PR DESCRIPTION
This PR removes usage of `defer.js` from TaskProcessor (and related classes and specs).