### PR TITLE
Include the original stack trace in the `ModelExperimental` error handler

### DIFF
--- a/Source/Scene/ModelExperimental/ModelExperimentalUtility.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalUtility.js
@@ -33,7 +33,15 @@ ModelExperimentalUtility.getFailedLoadFunction = function (model, type, path) {
     if (defined(error)) {
       message += `\n${error.message}`;
     }
-    return Promise.reject(new RuntimeError(message));
+
+    const runtimeError = new RuntimeError(message);
+    if (defined(error)) {
+      // the original call stack is often more useful than the new error's stack,
+      // so add the information here
+      runtimeError.stack = `Original stack:\n${error.stack}\nHandler stack:\n${runtimeError.stack}`;
+    }
+
+    return Promise.reject(runtimeError);
   };
 };
 


### PR DESCRIPTION
When an uncaught exception happens in `ModelExperimental`, the stack trace was getting swallowed since the error is turned into a `new RuntimeError()`. Now, I update the runtime error's `stack` property to include the original stack since this is more helpful for debugging.

This will help make investigating some `ModelExperimental` bugs easier to see when running in Travis.

To test, I did the following:

1. in `GltfLoader.js`, inside the block `textureProcessPromise = new Promise(...)` (but outside of `that._process()`!!) throw any exception.
2. Load a `ModelExperimental` and check the console for the uncaught exception 
3. Or run a single `ModelExperimental` test in the `SpecRunner`. It should time out, and you'll see the exception

@j9liu could you review?