### PR TITLE
Fix flaky zoom test

### DIFF
--- a/Specs/Widgets/Viewer/ViewerSpec.js
+++ b/Specs/Widgets/Viewer/ViewerSpec.js
@@ -1207,7 +1207,7 @@ describe(
 
       return tileset.readyPromise
         .catch(function (e) {
-          expect(e.message).toEqual("Request has failed. Status Code: 404");
+          expect(e.toString()).toEqual("Request has failed. Status Code: 404");
         })
         .then(function () {
           return viewer.zoomTo(tileset);

--- a/Specs/Widgets/Viewer/ViewerSpec.js
+++ b/Specs/Widgets/Viewer/ViewerSpec.js
@@ -1205,9 +1205,16 @@ describe(
         url: "foo/bar",
       });
 
-      return viewer.zoomTo(tileset).then((result) => {
-        expect(result).toBe(false);
-      });
+      return tileset.readyPromise
+        .catch(function (e) {
+          expect(e.message).toEqual("Request has failed. Status Code: 404");
+        })
+        .then(function () {
+          return viewer.zoomTo(tileset);
+        })
+        .then((result) => {
+          expect(result).toBe(false);
+        });
     });
 
     it("zoomTo zooms to Cesium3DTileset with default offset when offset not defined", function () {


### PR DESCRIPTION
This test has been failing intermittently in CI.

I think the root of the flakiness is that the viewer's `zoomTo` function starts handling the zoom target's `readyPromise` at the end of the frame. If the `readyPromise` fails too quickly, such as with an invalid URI, the `catch` block has not yet been set up.

The `zoomTo` function would still behave as expected, but the yet-to-be-handled promise rejection fails the test. The user should see no functional difference in the browser.

As a solution, we can await the failure, assert its the expected one, then continue with the `zoomTo`.