### PR TITLE
Disable `ModelExperimental` for implicit multiple contents with metadata

### DIFF
--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -6679,7 +6679,9 @@ describe(
         // one tile is removed
         return Cesium3DTilesTester.loadTileset(
           scene,
-          tilesetWithImplicitMultipleContentsMetadataUrl
+          tilesetWithImplicitMultipleContentsMetadataUrl,
+          // See https://github.com/CesiumGS/cesium/issues/10551
+          { enableModelExperimental: false }
         ).then(function (tileset) {
           const placeholderTile = tileset.root;
 
@@ -7046,7 +7048,10 @@ describe(
         // one tile is removed
         return Cesium3DTilesTester.loadTileset(
           scene,
-          tilesetWithImplicitContentMetadataLegacyUrl
+          tilesetWithImplicitContentMetadataLegacyUrl,
+          {
+            enableModelExperimental: false,
+          }
         ).then(function (tileset) {
           const placeholderTile = tileset.root;
 
@@ -7137,7 +7142,9 @@ describe(
         // one tile is removed
         return Cesium3DTilesTester.loadTileset(
           scene,
-          tilesetWithImplicitMultipleContentsMetadataLegacyUrl
+          tilesetWithImplicitMultipleContentsMetadataLegacyUrl,
+          // See https://github.com/CesiumGS/cesium/issues/10551
+          { enableModelExperimental: false }
         ).then(function (tileset) {
           const placeholderTile = tileset.root;
 

--- a/Specs/Scene/Implicit3DTileContentSpec.js
+++ b/Specs/Scene/Implicit3DTileContentSpec.js
@@ -932,6 +932,7 @@ describe(
         return Cesium3DTilesTester.loadTileset(
           scene,
           implicitMultipleContentsUrl,
+          // See https://github.com/CesiumGS/cesium/issues/10551
           { enableModelExperimental: false }
         ).then(function (tileset) {
           // The root tile of this tileset only has one available content
@@ -951,6 +952,7 @@ describe(
         return Cesium3DTilesTester.loadTileset(
           scene,
           implicitMultipleContentsUrl,
+          // See https://github.com/CesiumGS/cesium/issues/10551
           { enableModelExperimental: false }
         ).then(function (tileset) {
           const childTiles = tileset.root.children[0].children;
@@ -978,6 +980,7 @@ describe(
         return Cesium3DTilesTester.loadTileset(
           scene,
           implicitMultipleContentsLegacyUrl,
+          // See https://github.com/CesiumGS/cesium/issues/10551
           { enableModelExperimental: false }
         ).then(function (tileset) {
           // The root tile of this tileset only has one available content
@@ -997,6 +1000,7 @@ describe(
         return Cesium3DTilesTester.loadTileset(
           scene,
           implicitMultipleContentsLegacyWithContentUrl,
+          // See https://github.com/CesiumGS/cesium/issues/10551
           { enableModelExperimental: false }
         ).then(function (tileset) {
           // The root tile of this tileset only has one available content
@@ -1016,6 +1020,7 @@ describe(
         return Cesium3DTilesTester.loadTileset(
           scene,
           implicitMultipleContentsLegacyUrl,
+          // See https://github.com/CesiumGS/cesium/issues/10551
           { enableModelExperimental: false }
         ).then(function (tileset) {
           const childTiles = tileset.root.children[0].children;
@@ -1034,6 +1039,7 @@ describe(
         return Cesium3DTilesTester.loadTileset(
           scene,
           implicitMultipleContentsLegacyWithContentUrl,
+          // See https://github.com/CesiumGS/cesium/issues/10551
           { enableModelExperimental: false }
         ).then(function (tileset) {
           const childTiles = tileset.root.children[0].children;
@@ -1080,6 +1086,7 @@ describe(
         return Cesium3DTilesTester.loadTileset(
           scene,
           implicitMultipleContentsLegacyUrl,
+          // See https://github.com/CesiumGS/cesium/issues/10551
           { enableModelExperimental: false }
         ).then(function (tileset) {
           // the placeholder tile does not have any extensions.
@@ -1282,7 +1289,9 @@ describe(
       it("multiple content metadata views get transcoded correctly", function () {
         return Cesium3DTilesTester.loadTileset(
           scene,
-          implicitMultipleContentsMetadataUrl
+          implicitMultipleContentsMetadataUrl,
+          // See https://github.com/CesiumGS/cesium/issues/10551
+          { enableModelExperimental: false }
         ).then(function (tileset) {
           const expectedHeights = [10, 20, 30, 40, 50];
           const expectedColors = [
@@ -1768,7 +1777,9 @@ describe(
       it("multiple content metadata views get transcoded correctly (legacy)", function () {
         return Cesium3DTilesTester.loadTileset(
           scene,
-          implicitMultipleContentsMetadataLegacyUrl
+          implicitMultipleContentsMetadataLegacyUrl,
+          // See https://github.com/CesiumGS/cesium/issues/10551
+          { enableModelExperimental: false }
         ).then(function (tileset) {
           const expectedHeights = [10, 20, 30, 40, 50];
           const expectedColors = [

--- a/Specs/Scene/Multiple3DTileContentSpec.js
+++ b/Specs/Scene/Multiple3DTileContentSpec.js
@@ -555,7 +555,9 @@ describe(
       it("initializes implicit content metadata for inner contents", function () {
         return Cesium3DTilesTester.loadTileset(
           scene,
-          withImplicitContentMetadataUrl
+          withImplicitContentMetadataUrl,
+          // See https://github.com/CesiumGS/cesium/issues/10551
+          { enableModelExperimental: false }
         ).then(function (tileset) {
           const placeholderTile = tileset.root;
           const subtreeRootTile = placeholderTile.children[0];
@@ -584,7 +586,9 @@ describe(
       it("initializes implicit content metadata for inner contents (legacy)", function () {
         return Cesium3DTilesTester.loadTileset(
           scene,
-          withImplicitContentMetadataLegacyUrl
+          withImplicitContentMetadataLegacyUrl,
+          // See https://github.com/CesiumGS/cesium/issues/10551
+          { enableModelExperimental: false }
         ).then(function (tileset) {
           const placeholderTile = tileset.root;
           const subtreeRootTile = placeholderTile.children[0];


### PR DESCRIPTION
Related to the bugs in #10551 . Every test involving implicit multiple contents is having problems with `ModelExperimental`; we didn't catch the metadata-related ones on our first pass.