### PR TITLE
Parse pnts batch table as property attributes for better performance

### DIFF
--- a/Documentation/CustomShaderGuide/README.md
+++ b/Documentation/CustomShaderGuide/README.md
@@ -690,7 +690,7 @@ the custom shader in the `(vsInput|fsInput).metadata` struct:
 
 - `temperature ℃` -> `metadata.temperature`
 - `gl_customProperty` -> `metadata.customProperty`
-- `1245` -> `metadata._12345`
+- `12345` -> `metadata._12345`
 - `gl_12345` -> `metadata._12345`
 
 If the above results in an empty string or a name collision with other

--- a/Documentation/CustomShaderGuide/README.md
+++ b/Documentation/CustomShaderGuide/README.md
@@ -674,6 +674,32 @@ with a value between 0.0 and 100.0, while
 `(vsInput|fsInput).metadata.temperatureFahrenheit` will be a `float` with a
 range of `[32.0, 212.0]`.
 
+### Note about Unicode property IDs for 3D Tiles 1.0 point clouds
+
+When using the Point Cloud (`.pnts`) format in `ModelExperimental`, the batch
+table is transcoded as property attributes. Since GLSL only supports
+alphanumeric identifiers (not starting with a number or the reserved prefix
+`gl_`), property IDs are modified as follows:
+
+1. Remove all characters except `[A-Za-z0-9_]`.
+2. Remove the reserved `gl_` prefix if present
+3. If the identifier begins with a digit (`[0-9]`), prefix with an `_`
+
+Here are a couple examples of property ID and the resulting variable name in
+the custom shader in the `(vsInput|fsInput).metadata` struct:
+
+- `temperature ℃` -> `metadata.temperature`
+- `gl_customProperty` -> `metadata.customProperty`
+- `1245` -> `metadata._12345`
+- `gl_12345` -> `metadata._12345`
+
+If the above results in an empty string or a name collision with other
+property IDs, the behavior is undefined. For example:
+
+- `✖️✖️✖️` maps to the empty string, so the behavior is undefined.
+- Two properties with names `temperature ℃` and `temperature ℉` would both
+  map to `metadata.temperature`, so the behavior is undefined
+
 ## `czm_modelVertexOutput` struct
 
 This struct is built-in, see the [documentation comment](../../../Shaders/Builtin/Structs/modelVertexOutput.glsl).

--- a/Documentation/CustomShaderGuide/README.md
+++ b/Documentation/CustomShaderGuide/README.md
@@ -674,10 +674,10 @@ with a value between 0.0 and 100.0, while
 `(vsInput|fsInput).metadata.temperatureFahrenheit` will be a `float` with a
 range of `[32.0, 212.0]`.
 
-### Note about Unicode property IDs for 3D Tiles 1.0 point clouds
+### Note about Unicode property IDs for .pnts per-point properties
 
-When using the Point Cloud (`.pnts`) format in `ModelExperimental`, the batch
-table is transcoded as property attributes. Since GLSL only supports
+When using the Point Cloud (`.pnts`) format in `ModelExperimental`, per-point
+properties are transcoded as property attributes. Since GLSL only supports
 alphanumeric identifiers (not starting with a number or the reserved prefix
 `gl_`), property IDs are modified as follows:
 

--- a/Source/Scene/ModelExperimental/PntsLoader.js
+++ b/Source/Scene/ModelExperimental/PntsLoader.js
@@ -206,7 +206,7 @@ function decodeDraco(loader, context) {
     .catch(function (error) {
       loader.unload();
       loader._state = ResourceLoaderState.FAILED;
-      const errorMessage = "Failed to load Draco";
+      const errorMessage = "Failed to load pnts";
       return Promise.reject(loader.getError(errorMessage, error));
     });
 }

--- a/Source/Scene/ModelExperimental/PntsLoader.js
+++ b/Source/Scene/ModelExperimental/PntsLoader.js
@@ -361,19 +361,21 @@ function transcodeAttributeType(componentsPerAttribute) {
 function transcodeComponentType(value) {
   switch (value) {
     case WebGLConstants.BYTE:
-      return ComponentDatatype.BYTE;
+      return "BYTE";
     case WebGLConstants.UNSIGNED_BYTE:
-      return ComponentDatatype.UNSIGNED_BYTE;
+      return "UNSIGNED_BYTE";
     case WebGLConstants.SHORT:
-      return ComponentDatatype.SHORT;
+      return "SHORT";
     case WebGLConstants.UNSIGNED_SHORT:
-      return ComponentDatatype.UNSIGNED_SHORT;
+      return "UNSIGNED_SHORT";
     case WebGLConstants.INT:
-      return ComponentDatatype.INT;
+      return "INT";
     case WebGLConstants.UNSIGNED_INT:
-      return ComponentDatatype.UNSIGNED_INT;
+      return "UNSIGNED_INT";
     case WebGLConstants.DOUBLE:
-      return ComponentDatatype.DOUBLE;
+      return "DOUBLE";
+    case WebGLConstants.FLOAT:
+      return "FLOAT";
     //>>includeStart('debug', pragmas.debug);
     default:
       throw new DeveloperError("value is not a valid WebGL constant");

--- a/Source/Scene/ModelExperimental/PntsLoader.js
+++ b/Source/Scene/ModelExperimental/PntsLoader.js
@@ -208,7 +208,7 @@ function decodeDraco(loader, context) {
     .catch(function (error) {
       loader.unload();
       loader._state = ResourceLoaderState.FAILED;
-      const errorMessage = "Failed to load pnts";
+      const errorMessage = "Failed to load Draco pnts";
       return Promise.reject(loader.getError(errorMessage, error));
     });
 }
@@ -353,8 +353,10 @@ function transcodeAttributeType(componentsPerAttribute) {
       return "VEC4";
     //>>includeStart('debug', pragmas.debug);
     default:
-      throw new DeveloperError("value is not a valid WebGL constant");
-    //>>includeEnd('debug');ComponentDatatype.fromWebGlConstant
+      throw new DeveloperError(
+        "componentsPerAttribute must be a number from 1-4"
+      );
+    //>>includeEnd('debug');
   }
 }
 
@@ -379,7 +381,7 @@ function transcodeComponentType(value) {
     //>>includeStart('debug', pragmas.debug);
     default:
       throw new DeveloperError("value is not a valid WebGL constant");
-    //>>includeEnd('debug');ComponentDatatype.fromWebGlConstant
+    //>>includeEnd('debug');
   }
 }
 
@@ -564,11 +566,13 @@ function makeStructuralMetadata(parsedContent, customAttributeOutput) {
       batchTable: parsedContent.batchTableJson,
       binaryBody: batchTableBinary,
       parseAsPropertyAttributes: parseAsPropertyAttributes,
-      customAttributeOutput,
+      customAttributeOutput: customAttributeOutput,
     });
   }
 
-  // If batch table is not defined, create a property table without any properties.
+  // If there are no binary properties create a property table without any
+  // properties. For example, if the batch table only has JSON properties,
+  // those are handled separately, so the property table is empty.
   const emptyPropertyTable = new PropertyTable({
     name: MetadataClass.BATCH_TABLE_CLASS_NAME,
     count: pointsLength,

--- a/Source/Scene/PropertyAttribute.js
+++ b/Source/Scene/PropertyAttribute.js
@@ -101,7 +101,7 @@ Object.defineProperties(PropertyAttribute.prototype, {
    *
    * @memberof PropertyAttribute.prototype
    *
-   * @type {PropertyAttributeProperty}
+   * @type {Object.<String, PropertyAttributeProperty>}
    * @readonly
    * @private
    */

--- a/Source/Scene/ResourceLoader.js
+++ b/Source/Scene/ResourceLoader.js
@@ -92,7 +92,13 @@ ResourceLoader.prototype.getError = function (errorMessage, error) {
   if (defined(error)) {
     errorMessage += `\n${error.message}`;
   }
-  return new RuntimeError(errorMessage);
+
+  const runtimeError = new RuntimeError(errorMessage);
+  if (defined(error)) {
+    runtimeError.stack = `Original stack:\n${error.stack}\nHandler stack:\n${runtimeError.stack}`;
+  }
+
+  return runtimeError;
 };
 
 /**

--- a/Source/Scene/parseBatchTable.js
+++ b/Source/Scene/parseBatchTable.js
@@ -298,9 +298,10 @@ function transcodeBinaryPropertiesAsPropertyAttributes(
 
     // If the sanitized string is empty or a duplicate, use a placeholder
     // name instead. This will work for styling, but it may lead to undefined
-    // behavior in CustomShader since different tiles may pick a different
-    // placeholder ID due to the unordered collection or because different
-    // tiles may have different number of properties.
+    // behavior in CustomShader, since
+    // - different tiles may pick a different placeholder ID due to the
+    //    collection being unordered
+    // - different tiles may have different number of properties.
     if (
       alphanumericPropertyId === "" ||
       classProperties.hasOwnProperty(alphanumericPropertyId)
@@ -315,11 +316,11 @@ function transcodeBinaryPropertiesAsPropertyAttributes(
 
     // Extract the typed array and create a custom attribute as a typed array.
     // The caller must add the results to the ModelComponents, and upload the
-    // typed array to the GPU.
-    // The attribute name is converted to all capitals and underscores.
-    // E.g. if the original property ID was 'Temperature °C', the result is
-    // _TEMPERATURE__C (note that special characters are converted to
-    // underscores above)
+    // typed array to the GPU. The attribute name is converted to all capitals
+    // and underscores, like a glTF custom attribute.
+    //
+    // For example, if the original property ID was 'Temperature ℃', the result
+    // is _TEMPERATURE
     let customAttributeName = alphanumericPropertyId.toUpperCase();
     if (!customAttributeName.startsWith("_")) {
       customAttributeName = `_${customAttributeName}`;

--- a/Source/Scene/parseBatchTable.js
+++ b/Source/Scene/parseBatchTable.js
@@ -100,7 +100,7 @@ export default function parseBatchTable(options) {
       count: featureTableJson.count,
       properties: featureTableJson.properties,
       class: binaryResults.transcodedClass,
-      bufferViews: binaryResults.bufferViewsU8,
+      bufferViews: binaryResults.bufferViewsTypedArrays,
     });
   }
 

--- a/Source/Scene/parseBatchTable.js
+++ b/Source/Scene/parseBatchTable.js
@@ -277,13 +277,13 @@ function transcodeBinaryPropertiesAsPropertyAttributes(
 
     // Since property attributes will be used in a GLSL shader, sanitize
     // the property ID to only use alphanumeric characters
-    const alphanumericPropertyId = propertyId.replaceAll(/[^A-Za-z0-9_]/g, "_");
-    // TODO: What if multiple strings map to the same value?
+    const alphanumericPropertyId = propertyId.replaceAll(/[^A-Za-z0-9_]/g, "");
+    // TODO: What if multiple strings map to the same value? or if the name vanishes?
 
     const property = binaryProperties[propertyId];
     const binaryAccessor = getBinaryAccessor(property);
 
-    classProperties[propertyId] = transcodePropertyType(property);
+    classProperties[alphanumericPropertyId] = transcodePropertyType(property);
 
     // Extract the typed array and create a custom attribute as a typed array.
     // The caller must add the results to the ModelComponents, and upload the

--- a/Source/Scene/parseBatchTable.js
+++ b/Source/Scene/parseBatchTable.js
@@ -1,15 +1,20 @@
 import Check from "../Core/Check.js";
+import ComponentDatatype from "../Core/ComponentDatatype.js";
 import defined from "../Core/defined.js";
+import defaultValue from "../Core/defaultValue.js";
 import deprecationWarning from "../Core/deprecationWarning.js";
+import DeveloperError from "../Core/DeveloperError.js";
 import RuntimeError from "../Core/RuntimeError.js";
 import BatchTableHierarchy from "./BatchTableHierarchy.js";
 import StructuralMetadata from "./StructuralMetadata.js";
+import PropertyAttribute from "./PropertyAttribute.js";
 import PropertyTable from "./PropertyTable.js";
 import getBinaryAccessor from "./getBinaryAccessor.js";
 import JsonMetadataTable from "./JsonMetadataTable.js";
 import MetadataClass from "./MetadataClass.js";
 import MetadataSchema from "./MetadataSchema.js";
 import MetadataTable from "./MetadataTable.js";
+import ModelComponents from "./ModelComponents.js";
 
 /**
  * An object that parses the the 3D Tiles 1.0 batch table and transcodes it to
@@ -22,6 +27,8 @@ import MetadataTable from "./MetadataTable.js";
  * @param {Number} options.count The number of features in the batch table.
  * @param {Object} options.batchTable The batch table JSON
  * @param {Uint8Array} [options.binaryBody] The batch table binary body
+ * @param {Boolean} [options.parseAsPropertyAttributes=false] If true, binary properties are parsed as property attributes instead of a property table. This is used for .pnts models for GPU styling.
+ * @param {ModelComponents.Attribute[]} [options.customAttributeOutput] Pass in an empty array here and this method will populate it with a list of custom attributes that will store the values of the property attributes. The attributes will be created with typed arrays, the caller is responsible for uploading them to the GPU. This option is required when options.parseAsPropertyAttributes is true.
  * @return {StructuralMetadata} A transcoded structural metadata object
  *
  * @private
@@ -36,6 +43,19 @@ export default function parseBatchTable(options) {
   const featureCount = options.count;
   const batchTable = options.batchTable;
   const binaryBody = options.binaryBody;
+  const parseAsPropertyAttributes = defaultValue(
+    options.parseAsPropertyAttributes,
+    false
+  );
+  const customAttributeOutput = options.customAttributeOutput;
+
+  //>>includeStart('debug', pragmas.debug);
+  if (parseAsPropertyAttributes && !defined(customAttributeOutput)) {
+    throw new DeveloperError(
+      "customAttributeOutput is required when parsing batch table as property attributes"
+    );
+  }
+  //>>includeEnd('debug');
 
   // divide properties into binary, json and hierarchy
   const partitionResults = partitionProperties(batchTable);
@@ -49,37 +69,59 @@ export default function parseBatchTable(options) {
 
   const className = MetadataClass.BATCH_TABLE_CLASS_NAME;
 
-  const binaryResults = transcodeBinaryProperties(
-    featureCount,
-    className,
-    partitionResults.binaryProperties,
-    binaryBody
-  );
+  let metadataTable;
+  let propertyAttributes;
+  let transcodedSchema;
+  if (parseAsPropertyAttributes) {
+    const attributeResults = transcodeBinaryPropertiesAsPropertyAttributes(
+      featureCount,
+      className,
+      partitionResults.binaryProperties,
+      binaryBody,
+      customAttributeOutput
+    );
+    transcodedSchema = attributeResults.transcodedSchema;
+    const propertyAttribute = new PropertyAttribute({
+      propertyAttribute: attributeResults.propertyAttributeJson,
+      class: attributeResults.transcodedClass,
+    });
 
-  const featureTableJson = binaryResults.featureTableJson;
-
-  const metadataTable = new MetadataTable({
-    count: featureTableJson.count,
-    properties: featureTableJson.properties,
-    class: binaryResults.transcodedClass,
-    bufferViews: binaryResults.bufferViewsU8,
-  });
+    propertyAttributes = [propertyAttribute];
+  } else {
+    const binaryResults = transcodeBinaryProperties(
+      featureCount,
+      className,
+      partitionResults.binaryProperties,
+      binaryBody
+    );
+    transcodedSchema = binaryResults.transcodedSchema;
+    const featureTableJson = binaryResults.featureTableJson;
+    metadataTable = new MetadataTable({
+      count: featureTableJson.count,
+      properties: featureTableJson.properties,
+      class: binaryResults.transcodedClass,
+      bufferViews: binaryResults.bufferViewsU8,
+    });
+  }
 
   const propertyTable = new PropertyTable({
     id: 0,
     name: "Batch Table",
-    count: featureTableJson.count,
+    count: featureCount,
     metadataTable: metadataTable,
     jsonMetadataTable: jsonMetadataTable,
     batchTableHierarchy: hierarchy,
   });
 
-  return new StructuralMetadata({
-    schema: binaryResults.transcodedSchema,
+  const metadataOptions = {
+    schema: transcodedSchema,
     propertyTables: [propertyTable],
+    propertyAttributes: propertyAttributes,
     extensions: partitionResults.extensions,
     extras: partitionResults.extras,
-  });
+  };
+
+  return new StructuralMetadata(metadataOptions);
 }
 
 /**
@@ -157,7 +199,7 @@ function transcodeBinaryProperties(
 ) {
   const classProperties = {};
   const featureTableProperties = {};
-  const bufferViewsU8 = {};
+  const bufferViewsTypedArrays = {};
   let bufferViewCount = 0;
   for (const propertyId in binaryProperties) {
     if (!binaryProperties.hasOwnProperty(propertyId)) {
@@ -179,7 +221,9 @@ function transcodeBinaryProperties(
 
     classProperties[propertyId] = transcodePropertyType(property);
 
-    bufferViewsU8[bufferViewCount] = binaryAccessor.createArrayBufferView(
+    bufferViewsTypedArrays[
+      bufferViewCount
+    ] = binaryAccessor.createArrayBufferView(
       binaryBody.buffer,
       binaryBody.byteOffset + property.byteOffset,
       featureCount
@@ -205,7 +249,88 @@ function transcodeBinaryProperties(
 
   return {
     featureTableJson: featureTableJson,
-    bufferViewsU8: bufferViewsU8,
+    bufferViewsTypedArrays: bufferViewsTypedArrays,
+    transcodedSchema: transcodedSchema,
+    transcodedClass: transcodedSchema.classes[className],
+  };
+}
+
+function transcodeBinaryPropertiesAsPropertyAttributes(
+  featureCount,
+  className,
+  binaryProperties,
+  binaryBody,
+  customAttributeOutput
+) {
+  const classProperties = {};
+  const propertyAttributeProperties = {};
+  for (const propertyId in binaryProperties) {
+    if (!binaryProperties.hasOwnProperty(propertyId)) {
+      continue;
+    }
+
+    if (!defined(binaryBody)) {
+      throw new RuntimeError(
+        `Property ${propertyId} requires a batch table binary.`
+      );
+    }
+
+    // Since property attributes will be used in a GLSL shader, sanitize
+    // the property ID to only use alphanumeric characters
+    const alphanumericPropertyId = propertyId.replaceAll(/[^A-Za-z0-9_]/g, "_");
+    // TODO: What if multiple strings map to the same value?
+
+    const property = binaryProperties[propertyId];
+    const binaryAccessor = getBinaryAccessor(property);
+
+    classProperties[propertyId] = transcodePropertyType(property);
+
+    // Extract the typed array and create a custom attribute as a typed array.
+    // The caller must add the results to the ModelComponents, and upload the
+    // typed array to the GPU.
+    // The attribute name is converted to all capitals and underscores.
+    // E.g. if the original property ID was 'Temperature °C', the result is
+    // _TEMPERATURE__C (note that special characters are converted to
+    // underscores above)
+    const customAttributeName = `_${alphanumericPropertyId.toUpperCase()}`;
+    const attributeTypedArray = binaryAccessor.createArrayBufferView(
+      binaryBody.buffer,
+      binaryBody.byteOffset + property.byteOffset,
+      featureCount
+    );
+
+    const attribute = new ModelComponents.Attribute();
+    attribute.name = customAttributeName;
+    attribute.count = featureCount;
+    attribute.type = property.type;
+    attribute.componentDatatype = ComponentDatatype.fromTypedArray(
+      attributeTypedArray
+    );
+    attribute.typedArray = attributeTypedArray;
+    customAttributeOutput.push(attribute);
+
+    // Refer to the custom attribute name from the property attribute
+    propertyAttributeProperties[alphanumericPropertyId] = {
+      attribute: customAttributeName,
+    };
+  }
+
+  const schemaJson = {
+    classes: {},
+  };
+  schemaJson.classes[className] = {
+    properties: classProperties,
+  };
+
+  const transcodedSchema = new MetadataSchema(schemaJson);
+
+  const propertyAttributeJson = {
+    properties: propertyAttributeProperties,
+  };
+
+  return {
+    class: className,
+    propertyAttributeJson: propertyAttributeJson,
     transcodedSchema: transcodedSchema,
     transcodedClass: transcodedSchema.classes[className],
   };

--- a/Specs/Scene/ModelExperimental/PntsLoaderSpec.js
+++ b/Specs/Scene/ModelExperimental/PntsLoaderSpec.js
@@ -414,11 +414,30 @@ describe("Scene/ModelExperimental/PntsLoader", function () {
     return loadPnts(pointCloudDracoUrl).then(function (loader) {
       const components = loader.components;
       expect(components).toBeDefined();
-      expectEmptyMetadata(components.structuralMetadata);
+      const isBatched = false;
+      expectMetadata(
+        components.structuralMetadata,
+        {
+          secondaryColor: {
+            type: MetadataType.VEC3,
+            componentType: MetadataComponentType.FLOAT32,
+          },
+          temperature: {
+            type: MetadataType.SCALAR,
+            componentType: MetadataComponentType.FLOAT32,
+          },
+          id: {
+            type: MetadataType.SCALAR,
+            componentType: MetadataComponentType.UINT16,
+          },
+        },
+        isBatched
+      );
 
       const primitive = components.nodes[0].primitives[0];
       const attributes = primitive.attributes;
-      expect(attributes.length).toBe(3);
+      // 3 geometry attributes + 3 metadata attributes
+      expect(attributes.length).toBe(6);
       expectPositionQuantized(attributes[0]);
       expectNormalOctEncoded(
         attributes[1],
@@ -433,11 +452,30 @@ describe("Scene/ModelExperimental/PntsLoader", function () {
     return loadPnts(pointCloudDracoPartialUrl).then(function (loader) {
       const components = loader.components;
       expect(components).toBeDefined();
-      expectEmptyMetadata(components.structuralMetadata);
+      const isBatched = false;
+      expectMetadata(
+        components.structuralMetadata,
+        {
+          secondaryColor: {
+            type: MetadataType.VEC3,
+            componentType: MetadataComponentType.FLOAT32,
+          },
+          temperature: {
+            type: MetadataType.SCALAR,
+            componentType: MetadataComponentType.FLOAT32,
+          },
+          id: {
+            type: MetadataType.SCALAR,
+            componentType: MetadataComponentType.UINT16,
+          },
+        },
+        isBatched
+      );
 
       const primitive = components.nodes[0].primitives[0];
       const attributes = primitive.attributes;
-      expect(attributes.length).toBe(3);
+      // 3 geometry attributes + 3 metadata attributes
+      expect(attributes.length).toBe(6);
       expectPositionQuantized(attributes[0]);
       expectNormal(attributes[1]);
       expectColorRGB(attributes[2]);
@@ -628,11 +666,30 @@ describe("Scene/ModelExperimental/PntsLoader", function () {
       function (loader) {
         const components = loader.components;
         expect(components).toBeDefined();
-        expectEmptyMetadata(components.structuralMetadata);
+        const isBatched = false;
+        expectMetadata(
+          components.structuralMetadata,
+          {
+            secondaryColor: {
+              type: MetadataType.VEC3,
+              componentType: MetadataComponentType.FLOAT32,
+            },
+            temperature: {
+              type: MetadataType.SCALAR,
+              componentType: MetadataComponentType.FLOAT32,
+            },
+            id: {
+              type: MetadataType.SCALAR,
+              componentType: MetadataComponentType.UINT16,
+            },
+          },
+          isBatched
+        );
 
         const primitive = components.nodes[0].primitives[0];
         const attributes = primitive.attributes;
-        expect(attributes.length).toBe(3);
+        // 3 geometry attributes + 3 metadata attributes
+        expect(attributes.length).toBe(6);
 
         const positionAttribute = attributes[0];
         expectPositionQuantized(positionAttribute);

--- a/Specs/Scene/ModelExperimental/PntsLoaderSpec.js
+++ b/Specs/Scene/ModelExperimental/PntsLoaderSpec.js
@@ -100,7 +100,8 @@ describe("Scene/ModelExperimental/PntsLoader", function () {
   function expectEmptyMetadata(structuralMetadata) {
     expect(structuralMetadata).toBeDefined();
     expect(structuralMetadata.schema).toEqual({});
-    expect(structuralMetadata.propertyTableCount).toEqual(1);
+    expect(structuralMetadata.propertyTableCount).toBe(1);
+    expect(structuralMetadata.propertyAttributes.length).toBe(0);
     const propertyTable = structuralMetadata.getPropertyTable(0);
     expect(propertyTable.getPropertyIds(0)).toEqual([]);
   }

--- a/Specs/Scene/ModelExperimental/PntsLoaderSpec.js
+++ b/Specs/Scene/ModelExperimental/PntsLoaderSpec.js
@@ -101,7 +101,6 @@ describe("Scene/ModelExperimental/PntsLoader", function () {
     expect(structuralMetadata).toBeDefined();
     expect(structuralMetadata.schema).toEqual({});
     expect(structuralMetadata.propertyTableCount).toBe(1);
-    expect(structuralMetadata.propertyAttributes.length).toBe(0);
     const propertyTable = structuralMetadata.getPropertyTable(0);
     expect(propertyTable.getPropertyIds(0)).toEqual([]);
   }
@@ -114,9 +113,11 @@ describe("Scene/ModelExperimental/PntsLoader", function () {
 
     expect(structuralMetadata.propertyTableCount).toEqual(1);
     const propertyTable = structuralMetadata.getPropertyTable(0);
-    expect(propertyTable.getPropertyIds(0).sort()).toEqual(
-      Object.keys(expectedProperties).sort()
-    );
+
+    const propertyAttribute = structuralMetadata.getPropertyAttribute(0);
+
+    const tablePropertyNames = [];
+    const attributePropertyNames = [];
 
     for (const propertyName in expectedProperties) {
       if (expectedProperties.hasOwnProperty(propertyName)) {
@@ -127,15 +128,24 @@ describe("Scene/ModelExperimental/PntsLoader", function () {
           // If the batch table had JSON properties, the property will not
           // be in the schema, so check if we can access it.
           expect(propertyTable.getProperty(0, propertyName)).toBeDefined();
+          tablePropertyNames.push(propertyName);
         } else {
           // Check the property declaration is expected
           expect(property.type).toEqual(expectedProperty.type);
           expect(property.componentType).toEqual(
             expectedProperty.componentType
           );
+          attributePropertyNames.push(propertyName);
         }
       }
     }
+
+    expect(propertyTable.getPropertyIds(0).sort()).toEqual(
+      tablePropertyNames.sort()
+    );
+    expect(Object.keys(propertyAttribute.properties).sort()).toEqual(
+      attributePropertyNames.sort()
+    );
   }
 
   function expectPosition(attribute) {
@@ -446,7 +456,8 @@ describe("Scene/ModelExperimental/PntsLoader", function () {
 
       const primitive = components.nodes[0].primitives[0];
       const attributes = primitive.attributes;
-      expect(attributes.length).toBe(4);
+      // 4 geometry attributes + 2 metadata attributes
+      expect(attributes.length).toBe(6);
       expectPositionQuantized(attributes[0]);
       expectNormalOctEncoded(
         attributes[1],
@@ -493,7 +504,8 @@ describe("Scene/ModelExperimental/PntsLoader", function () {
 
       const primitive = components.nodes[0].primitives[0];
       const attributes = primitive.attributes;
-      expect(attributes.length).toBe(4);
+      // 4 geometry attributes + 2 metadata attributes
+      expect(attributes.length).toBe(6);
       expectPosition(attributes[0]);
       expectNormal(attributes[1]);
       expectDefaultColor(attributes[2]);
@@ -524,7 +536,8 @@ describe("Scene/ModelExperimental/PntsLoader", function () {
 
       const primitive = components.nodes[0].primitives[0];
       const attributes = primitive.attributes;
-      expect(attributes.length).toBe(2);
+      // 2 geometry attributes + 3 metadata attributes
+      expect(attributes.length).toBe(5);
       expectPosition(attributes[0]);
       expectColorRGB(attributes[1]);
     });
@@ -537,7 +550,8 @@ describe("Scene/ModelExperimental/PntsLoader", function () {
       const components = loader.components;
       expect(components).toBeDefined();
       expectMetadata(components.structuralMetadata, {
-        "temperature ℃": {
+        // Originally "temperature ℃", but sanitized for GLSL
+        temperature: {
           type: MetadataType.SCALAR,
           componentType: MetadataComponentType.FLOAT32,
         },
@@ -553,7 +567,8 @@ describe("Scene/ModelExperimental/PntsLoader", function () {
 
       const primitive = components.nodes[0].primitives[0];
       const attributes = primitive.attributes;
-      expect(attributes.length).toBe(2);
+      // 2 geometry attributes + 3 metadata attributes
+      expect(attributes.length).toBe(5);
       expectPosition(attributes[0]);
       expectColorRGB(attributes[1]);
     });

--- a/Specs/Scene/parseBatchTableSpec.js
+++ b/Specs/Scene/parseBatchTableSpec.js
@@ -497,10 +497,181 @@ describe("Scene/parseBatchTable", function () {
     // or batch table hierarchy, it will be empty.
     const propertyTable = metadata.getPropertyTable(0);
     expect(propertyTable).toBeDefined();
-    expect(propertyTable._jsonMetadataTable).not.toBeDefined();
+    // An empty table is created
+    expect(propertyTable._jsonMetadataTable).toBeDefined();
     expect(propertyTable._metadataTable).not.toBeDefined();
     expect(propertyTable._batchTableHierarchy).not.toBeDefined();
 
-    fail();
+    expect(metadata.propertyAttributes.length).toBe(1);
+    const [propertyAttribute] = metadata.propertyAttributes;
+    const metadataClass = propertyAttribute.class;
+    expect(metadataClass.id).toBe(MetadataClass.BATCH_TABLE_CLASS_NAME);
+    const heightClassProperty = metadataClass.properties.height;
+    expect(heightClassProperty.name).toBe("height");
+    expect(heightClassProperty.type).toBe(MetadataType.SCALAR);
+    expect(heightClassProperty.componentType).toBe(
+      MetadataComponentType.FLOAT32
+    );
+    const windClassProperty = metadataClass.properties["windDirection"];
+    expect(windClassProperty.name).toBe("windDirection");
+    expect(windClassProperty.type).toBe(MetadataType.VEC2);
+    expect(windClassProperty.componentType).toBe(MetadataComponentType.FLOAT32);
+
+    const properties = propertyAttribute.properties;
+    const heightProperty = properties.height;
+    expect(heightProperty.attribute).toBe("_HEIGHT");
+    const windProperty = properties.windDirection;
+    expect(windProperty.attribute).toBe("_WINDDIRECTION");
+  });
+
+  it("sanitizes property attribute property IDs for use in GLSL", function () {
+    const binaryBatchTable = {
+      // will be converted to Height
+      "Height ⛰️": {
+        byteOffset: 0,
+        componentType: "FLOAT",
+        type: "SCALAR",
+      },
+      // gl_ prefix is reserved in GLSL and will be removed.
+      // this leaves 1234, which starts with a number, so a _ prefix will be
+      // added. Result: _1234
+      gl_1234: {
+        byteOffset: 12,
+        componentType: "FLOAT",
+        type: "VEC2",
+      },
+    };
+
+    // prettier-ignore
+    const values = new Float32Array([
+      10.0, 15.0, 25.0,
+      1.0, 0.0,
+      1.1, 0.4,
+      0.3, 0.2,
+    ]);
+    const binaryBody = new Uint8Array(values.buffer);
+
+    const customAttributes = [];
+    const metadata = parseBatchTable({
+      count: 3,
+      batchTable: binaryBatchTable,
+      binaryBody: binaryBody,
+      parseAsPropertyAttributes: true,
+      customAttributeOutput: customAttributes,
+    });
+
+    expect(customAttributes.length).toBe(2);
+
+    // Since the original properties is an unordered collection, sort
+    // to be sure of the order.
+    const [numericAttribute, unicodeAttribute] = customAttributes.sort(
+      sortByName
+    );
+
+    // Attributes are converted to upper-case like glTF attributes.
+    expect(numericAttribute.name).toBe("_1234");
+    expect(unicodeAttribute.name).toBe("_HEIGHT");
+
+    // In the schema, the IDs are valid GLSL identifiers, while the name
+    // is the original property ID which may contain unicode.
+    const [propertyAttribute] = metadata.propertyAttributes;
+    const metadataClass = propertyAttribute.class;
+    const numericClassProperty = metadataClass.properties["_1234"];
+    expect(numericClassProperty.name).toBe("gl_1234");
+    const unicodeClassProperty = metadataClass.properties["Height"];
+    expect(unicodeClassProperty.name).toBe("Height ⛰️");
+
+    const properties = propertyAttribute.properties;
+    const numericProperty = properties["_1234"];
+    expect(numericProperty.attribute).toBe("_1234");
+    const unicodeProperty = properties["Height"];
+    expect(unicodeProperty.attribute).toBe("_HEIGHT");
+  });
+
+  it("creates placeholder IDs for invalid GLSL identifiers", function () {
+    const binaryBatchTable = {
+      // all characters will be removed, which would lead to an invalid
+      // identifier.
+      "✖️✖️✖️": {
+        byteOffset: 0,
+        componentType: "FLOAT",
+        type: "SCALAR",
+      },
+      temperature: {
+        byteOffset: 12,
+        componentType: "FLOAT",
+        type: "SCALAR",
+      },
+      // gl_ prefix will be removed, leading to a name collision with
+      // "temperature
+      gl_temperature: {
+        byteOffset: 24,
+        componentType: "FLOAT",
+        type: "SCALAR",
+      },
+    };
+
+    // prettier-ignore
+    const values = new Float32Array([
+      10.0, 15.0, 25.0,
+      20.0, 30.0, 15.0,
+      25.0, 20.0, 20.0,
+    ]);
+    const binaryBody = new Uint8Array(values.buffer);
+
+    const customAttributes = [];
+    const metadata = parseBatchTable({
+      count: 3,
+      batchTable: binaryBatchTable,
+      binaryBody: binaryBody,
+      parseAsPropertyAttributes: true,
+      customAttributeOutput: customAttributes,
+    });
+
+    expect(customAttributes.length).toBe(3);
+
+    // Attributes are processed in a non-deterministic order (due to looping
+    // over a dictionary), but the set of results is constant.
+    const attributeNames = customAttributes.map(function (attribute) {
+      return attribute.name;
+    });
+    expect(attributeNames.sort()).toEqual([
+      "_PROPERTY_0",
+      "_PROPERTY_1",
+      "_TEMPERATURE",
+    ]);
+
+    const [propertyAttribute] = metadata.propertyAttributes;
+    const metadataClass = propertyAttribute.class;
+    const classProperties = [
+      metadataClass.properties.property_0,
+      metadataClass.properties.property_1,
+      metadataClass.properties.temperature,
+    ];
+
+    // Again, the order is non-deterministic, but the attribute names will
+    // always be the original names
+    const classPropertyNames = classProperties.map(function (classProperty) {
+      return classProperty.name;
+    });
+    expect(classPropertyNames.sort()).toEqual(
+      Object.keys(binaryBatchTable).sort()
+    );
+
+    const properties = propertyAttribute.properties;
+    expect(Object.keys(properties).sort()).toEqual([
+      "property_0",
+      "property_1",
+      "temperature",
+    ]);
+
+    const semantics = Object.values(properties).map(function (property) {
+      return property.attribute;
+    });
+    expect(semantics.sort()).toEqual([
+      "_PROPERTY_0",
+      "_PROPERTY_1",
+      "_TEMPERATURE",
+    ]);
   });
 });


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/10534

:construction: WIP :construction:

Opening as a draft so I can pause here and help debug https://github.com/CesiumGS/cesium/issues/10551

in `ModelExperimental`, batch table properties were all transcoded to EXT_structural_metadata property tables that are then used for picking and styling. This works even for point clouds, but since point clouds often have a large number of features, this requires allocating many resources for the batch texture, pick IDs table, along with the metadata itself.

Instead of that, this PR adds an option to `parseBatchTable` to parse the metadata as property attributes instead. These can then be used in Custom Shader (and in a future PR, GPU point cloud styling). 

Sandcastles:

* [Point Clouds + Custom Shader](http://localhost:8080/Apps/Sandcastle/index.html#c=hVbbbuM2EP2VgZ/kXYd2NtiXJA5aOF1sgHgTNM72YV1kaYm22EiiSlK+pMi/95CUHcl22sCIJHLmzO3MkLEqjKWlFCuhaUiFWNFIGFnl7Ltfi6ad2H+PVGG5LISedroX02JaxF4zroxV+UPKk339UWMn+mdaEFWFnCudm3Pyn0T9PomMl0YkZGUuSBZkBHATQxAkXsicW6mKIF09OaGdMpHdlPiszT0G8AnW2Jfbu18nva3YkmcV5Ab1wqt/hv+ZXKRWFouxSkS2g7ptrrLHb7c3AWwptBXrENFErO05/QyQSyWTeneMHEXf/etNUVZIrfHPHoJT+Ixf8qfc4QaZu8oGofDSDXi7CJ3N+BNVS6S2BmLcWi1nlRWGlcpIl5/xiK03F29KyOuYPwuyqaBSyQJmM1UlKEBSZdz6RHOKVV5mYk0rvnSiHG5wLYXBbgtqpmxKpuSxQEVCpRhNAM2hL22VAM/QjLsyqsIbVVouZMEzMikvRQtNzQ/cilapjFPimRY82Tgw7pzakKn0HGa7wZzzswUFQRcDUpGQBpGsdIEojx+LwoKRtTWf8R6looh9VlowVvPCOO54roF6WuX0Y9Cj0z/p5Ip+nJzuXv3im/I8U8jaWxqG9IkN6MP/lOqFTuiUDS72cXwdhg24D2RApgDpeFNKvFRLtgZAWA0t0a0l668G8JZXbfMfhzRgZ1ByFv+LNobKKjOBLqi84+9sQ3HKC1R34eSkhuUXcdQiAB6wh5BOB/D2I332Ph96+hoeP32TzTVf5Cjee2223feN9qX+CK02f6fVxqC8lmBjXr8cttmR0GOpY3SLBpqxIKbjkvm74lrsFy6RxnLHrCFloljYNFpkT/cOZaSUTlCtAfvcLIucU7RTuvK7TWfcH7ZjrpOG0uu0aI2FMyo15qPejFSm3OzdRscSOZ9XpllZLx5Ga0OhzhfLheUJt5y1JQ4IakVeCs1tpcUx7cb2gapMvrkGy8CH5JguCtsHTQaDui/aAwhZTWgm7EqIMF/qyNH+LpIIEwpHjStQXM3QDo6su1haULWCVeWb9G5y3Vy/ye4n0+VXrqNmynt7Ge21omzWu+XCV5wu/tyhVFnMVWXdxMXIRFcdUAsiY26eYd3kCnMYTCwjNG/PkabXrEjT3jvO7y/3PC8izKIaDtnv9rY2j3Tna/PktzITRti9Q98/zq4nYbM+93V2HkCmHcb6+D24ISeuUfl+S6MfusadCo3XP6RN74X2C/daIWKLY6pfO8D+MrghdPzwaN5GanfD1YYZHAiCufJJd0wYxpMkqhEaYi9K5RO13eg1Q/uKGYCpdy9tnP7uaoU6IHEnPn2fXeqa2UFzaztxl5ohwWF/vKDbWaFW0aFbytjHEo0gnFu/LTHRbjEesKWjeVXEbnJTVM+IgF/fm5yFh/rKNKTowBJmz86Tbt1iF/uZQt/b+vqE616YzUjoERvOc2S10+tcGrvJxNWWc7/IvFTaulJHqK/jpbtomP6sip9Ro9iYLZ8u+03Vy0Qu0TfDI9dM3A64MdiZV1nmTpJp5+qyD/kDVbSKK80drmAZ3zix9PTqNiwyxi77+DyuaZXKZlzvIf8L)
* [Point Cloud with Unicode Property ID + Custom Shader](http://localhost:8080/Apps/Sandcastle/index.html#c=hVZbU+M2FP4rZ/Lk7AY5LLMvQJh2QneWGbIwJWwfNh1WsZVYxbZcSc6FDv+9nyQnOBdaHoglnfOd23eOlKjSWFpIsRSaBlSKJQ2FkXXBvvu9aNJJ/HqoSstlKfSk072YlJMy8ZpJbawqHjKe7usPWyfRP5OSqC7lTOnCnJNfEsUxiZxXRqRkZSFIlmQEcFNDECReyoJbqcogXT85oa0ykV1XWDbmHgP4GHvsy+3dr+PeRmzB8xpy/Wbj1f+G/7mcZ1aW85FKRb6Fum3vssdvtzcBbCG0FasQ0Vis7Dn9DJALJdPmdIQcRd/9501Z1Uit8b89BKewTF6Kp8LhBpm72gah8NENeNsInc3kE9ULpLYBYtxaLae1FYZVykiXn9GQrdYXb0rI64g/C7KZoErJEmZzVacoQFrn3PpEc0pUUeViRUu+cKIcbnAthcHpDtRU2YxMxROBioRKMRoDmkNf2joFnqEpd2VUpTeqtJzLkudkMl6JHTQ1O3ArWmYyyYjnWvB07cC4c2pNptYzmO0Gc87PHSgIuhiQipQ0iGSlC0R5/ESUFoxsrPmM9ygTZeKzsgNjNS+N447nGqinVUE/+j06/ZNOrujHyen202++Kc9yhay9pWFAn1ifPvxPqV7ohE5Z/2Ifx9dh0IL7QAZkCpCON5XER71gKwCE3dAS3UayWbWAN7zaNf9xQH12BiVn8b9oY6iqcxPogso7/k7XlGS8RHXnTk5qWH4RRy0C4AFnCOm0D28/0mfv86Gnr+Hnp2+ymebzAsV7r802577RvjSL0Gqzd1ptBMprCTYWzcdhmx0JPZE6QbdooBkLYjoumb9rrsV+4VJpLHfMGlAuyrnNonn+dO9QhkrpFNXqs8/tssgZRVulK3/adsb94TjhOm0pvU7KnbFwRpXGfNTrocqVm72b6FgqZ7PatCvrxcNobSk0+WKFsDzllrNdiQOCWlFUQnNba3FMu3V8oCrTb67BcvAhPaaLwsagSb/f9MXuAEJWU5oKuxQizJcmcrS/iyTChMJV4wqU1FO0gyPrNpYdqEbBqupNeju5bq7fZPeT6fIrV1E75b29jPZ2omzXe8eFr7hd/L1DmbKYq8q6iYuRia46oBZERtw8w7opFOYwmFhFaN6eI02vXZG2vXec39/ueV5EmEUNHLLf7W1sHunO1/bNb2UujLB7l77/Obseh8Pm3tf5eQCZdOKHSiQmvkbR4x3hODSMuxBan39Im+FmT9DG91ohVru+SU3c2GZ/GTwOOn5utB8ijafhVcMM7gLBXOWkuyEM42kaNQgtsRelirHaHPTaUX1F+2Pg3UubZL+7MqEEyNmJz9xnl7V2YtDX2o7de2ZA8NjfLGh0VqpldOiWMvaxQg8I59ZvCwyzW0wGHOloVpeJG9oUNeMh4DdPJmfhoXktDSg6sISxs/Wk23TXxX6m0PK2eTnhpRfGMhJ6xIbzHFnt9DqXxq5zcbWh2y+yqJS2rsoRY7GjpHtjmHhaJ8+oUWLMhkqXcVv1MpULtMzgyAsTDwNuDE5mdZ67S2TSubqMIX+gii5xpbnD6yvnayeWnV7dhk3G2GWM5XFNq1Q+5XoP+V8)

Both should produce the same results:
![image](https://user-images.githubusercontent.com/8422414/179244984-b9e25c9c-8ec2-4b81-bcbb-fb92245bbab4.png)


To Do:
- [x] Finish updating unit tests
- [x] Figure out the best way to handle Unicode property names.
- [ ] Compare a large point cloud tileset with/without this change.

