### PR TITLE
Add point cloud styling with metadata to `ModelExperimental`

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
@@ -39,8 +39,6 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        Cesium.ExperimentalFeatures.enableModelExperimental = false;
-
         const viewer = new Cesium.Viewer("cesiumContainer");
         viewer.clock.currentTime = new Cesium.JulianDate(2457522.154792);
 

--- a/Apps/Sandcastle/gallery/Custom Shaders 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/Custom Shaders 3D Tiles.html
@@ -42,8 +42,6 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        Cesium.ExperimentalFeatures.enableModelExperimental = true;
-
         const viewer = new Cesium.Viewer("cesiumContainer");
 
         const tileset = new Cesium.Cesium3DTileset({

--- a/Apps/Sandcastle/gallery/Custom Shaders Models.html
+++ b/Apps/Sandcastle/gallery/Custom Shaders Models.html
@@ -42,7 +42,6 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        Cesium.ExperimentalFeatures.enableModelExperimental = true;
         const viewer = new Cesium.Viewer("cesiumContainer", {
           orderIndependentTranslucency: false,
         });

--- a/Apps/Sandcastle/gallery/Montreal Point Cloud.html
+++ b/Apps/Sandcastle/gallery/Montreal Point Cloud.html
@@ -86,8 +86,6 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        Cesium.ExperimentalFeatures.enableModelExperimental = false;
-
         const viewer = new Cesium.Viewer("cesiumContainer", {
           terrainProvider: Cesium.createWorldTerrain(),
         });

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -2160,7 +2160,7 @@ Node.prototype.getShaderExpression = function (
       return Expression.NULL_SENTINEL;
     case ExpressionNodeType.BUILTIN_VARIABLE:
       if (value === "tiles3d_tileset_time") {
-        return "u_time";
+        return "czm_builtinTime";
       }
   }
 };

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -2543,17 +2543,31 @@ ModelExperimental.prototype.applyColorAndShow = function (style) {
 ModelExperimental.prototype.applyStyle = function (style) {
   this.resetDrawCommands();
 
-  // Styling is applied on the GPU for 3D Tiles point clouds.
+  const hasFeatureTable =
+    defined(this.featureTableId) &&
+    this.featureTables[this.featureTableId].featuresLength > 0;
+
   if (this.type === ModelExperimentalType.TILE_PNTS) {
-    return;
+    // Point clouds will use GPU styling unless they contain
+    // a batch table. That is, CPU styling will not be applied if
+    // - points have no metadata at all, or
+    // - points have metadata stored as a property attribute
+    if (!hasFeatureTable) {
+      return;
+    }
+
+    const propertyAttributes = defined(this.structuralMetadata)
+      ? this.structuralMetadata.propertyAttributes
+      : undefined;
+
+    if (defined(propertyAttributes) && defined(propertyAttributes[0])) {
+      return;
+    }
   }
 
   // The style is only set by the ModelFeatureTable. If there are no features,
   // the color and show from the style are directly applied.
-  if (
-    defined(this.featureTableId) &&
-    this.featureTables[this.featureTableId].featuresLength > 0
-  ) {
+  if (hasFeatureTable) {
     const featureTable = this.featureTables[this.featureTableId];
     featureTable.applyStyle(style);
   } else {

--- a/Source/Scene/ModelExperimental/PntsLoader.js
+++ b/Source/Scene/ModelExperimental/PntsLoader.js
@@ -19,10 +19,8 @@ import parseBatchTable from "../parseBatchTable.js";
 import DracoLoader from "../DracoLoader.js";
 import StructuralMetadata from "../StructuralMetadata.js";
 import ResourceLoader from "../ResourceLoader.js";
-import MetadataClass from "../MetadataClass.js";
 import ModelComponents from "../ModelComponents.js";
 import PntsParser from "../PntsParser.js";
-import PropertyTable from "../PropertyTable.js";
 import ResourceLoaderState from "../ResourceLoaderState.js";
 import VertexAttributeSemantic from "../VertexAttributeSemantic.js";
 
@@ -570,16 +568,9 @@ function makeStructuralMetadata(parsedContent, customAttributeOutput) {
     });
   }
 
-  // If there are no binary properties create a property table without any
-  // properties. For example, if the batch table only has JSON properties,
-  // those are handled separately, so the property table is empty.
-  const emptyPropertyTable = new PropertyTable({
-    name: MetadataClass.BATCH_TABLE_CLASS_NAME,
-    count: pointsLength,
-  });
   return new StructuralMetadata({
     schema: {},
-    propertyTables: [emptyPropertyTable],
+    propertyTables: [],
   });
 }
 

--- a/Source/Scene/PointCloud.js
+++ b/Source/Scene/PointCloud.js
@@ -960,7 +960,7 @@ function createShaders(pointCloud, frameState, style) {
     "uniform vec4 u_pointSizeAndTimeAndGeometricErrorAndDepthMultiplier; \n" +
     "uniform vec4 u_constantColor; \n" +
     "uniform vec4 u_highlightColor; \n";
-  vs += "float u_pointSize; \n" + "float u_time; \n";
+  vs += "float u_pointSize; \n" + "float czm_builtinTime; \n";
 
   if (attenuation) {
     vs += "float u_geometricError; \n" + "float u_depthMultiplier; \n";
@@ -1016,7 +1016,7 @@ function createShaders(pointCloud, frameState, style) {
     "void main() \n" +
     "{ \n" +
     "    u_pointSize = u_pointSizeAndTimeAndGeometricErrorAndDepthMultiplier.x; \n" +
-    "    u_time = u_pointSizeAndTimeAndGeometricErrorAndDepthMultiplier.y; \n";
+    "    czm_builtinTime = u_pointSizeAndTimeAndGeometricErrorAndDepthMultiplier.y; \n";
 
   if (attenuation) {
     vs +=

--- a/Source/Shaders/ModelExperimental/LightingStageFS.glsl
+++ b/Source/Shaders/ModelExperimental/LightingStageFS.glsl
@@ -61,7 +61,7 @@ void lightingStage(inout czm_modelMaterial material, ProcessedAttributes attribu
     #endif
 
     #ifdef HAS_POINT_CLOUD_COLOR_STYLE
-    // The color resulting from a point cloud style is handled differently.
+    // Colors resulting from point cloud styles are handled differently.
     color = czm_gammaCorrect(color);
     #elif !defined(HDR)
     // If HDR is not enabled, the frame buffer stores sRGB colors rather than

--- a/Source/Shaders/ModelExperimental/LightingStageFS.glsl
+++ b/Source/Shaders/ModelExperimental/LightingStageFS.glsl
@@ -54,15 +54,18 @@ void lightingStage(inout czm_modelMaterial material, ProcessedAttributes attribu
     // pass all other properties so further stages have access to them.
     vec3 color = vec3(0.0);
 
-    #ifdef LIGHTING_PBR
+    #if defined(LIGHTING_PBR)
     color = computePbrLighting(material, attributes);
     #else // unlit
     color = material.diffuse;
     #endif
 
+    #ifdef HAS_POINT_CLOUD_COLOR_STYLE
+    // The color resulting from a point cloud style is handled differently.
+    color = czm_gammaCorrect(color);
+    #elif !defined(HDR)
     // If HDR is not enabled, the frame buffer stores sRGB colors rather than
     // linear colors so the linear value must be converted.
-    #ifndef HDR
     color = czm_linearToSrgb(color);
     #endif
 

--- a/Source/Shaders/ModelExperimental/MaterialStageFS.glsl
+++ b/Source/Shaders/ModelExperimental/MaterialStageFS.glsl
@@ -101,9 +101,9 @@ void materialStage(inout czm_modelMaterial material, ProcessedAttributes attribu
     material.diffuse = baseColorWithAlpha.rgb;
     material.alpha = baseColorWithAlpha.a;
 
-    #ifdef USE_CPU_STYLING
+    /*#ifdef USE_CPU_STYLING
     material.diffuse = blend(material.diffuse, feature.color.rgb, model_colorBlend);
-    #endif
+    #endif*/
 
     #ifdef HAS_OCCLUSION_TEXTURE
     vec2 occlusionTexCoords = TEXCOORD_OCCLUSION;

--- a/Source/Shaders/ModelExperimental/MaterialStageFS.glsl
+++ b/Source/Shaders/ModelExperimental/MaterialStageFS.glsl
@@ -101,9 +101,9 @@ void materialStage(inout czm_modelMaterial material, ProcessedAttributes attribu
     material.diffuse = baseColorWithAlpha.rgb;
     material.alpha = baseColorWithAlpha.a;
 
-    /*#ifdef USE_CPU_STYLING
+    #ifdef USE_CPU_STYLING
     material.diffuse = blend(material.diffuse, feature.color.rgb, model_colorBlend);
-    #endif*/
+    #endif
 
     #ifdef HAS_OCCLUSION_TEXTURE
     vec2 occlusionTexCoords = TEXCOORD_OCCLUSION;

--- a/Source/Shaders/ModelExperimental/ModelExperimentalVS.glsl
+++ b/Source/Shaders/ModelExperimental/ModelExperimentalVS.glsl
@@ -105,20 +105,20 @@ void main()
     #endif
 
     #ifdef HAS_POINT_CLOUD_SHOW_STYLE
-    float show = pointCloudShowStylingStage(attributes);
+    float show = pointCloudShowStylingStage(attributes, metadata);
     #else
     float show = 1.0;
     #endif
 
     #ifdef HAS_POINT_CLOUD_COLOR_STYLE
-    v_pointCloudColor = pointCloudColorStylingStage(attributes);
+    v_pointCloudColor = pointCloudColorStylingStage(attributes, metadata);
     #endif
 
     #ifdef PRIMITIVE_TYPE_POINTS
         #ifdef HAS_CUSTOM_VERTEX_SHADER
         gl_PointSize = vsOutput.pointSize;
         #elif defined(HAS_POINT_CLOUD_POINT_SIZE_STYLE) || defined(HAS_POINT_CLOUD_ATTENUATION)
-        gl_PointSize = pointCloudPointSizeStylingStage(attributes);
+        gl_PointSize = pointCloudPointSizeStylingStage(attributes, metadata);
         #else
         gl_PointSize = 1.0;
         #endif

--- a/Source/Shaders/ModelExperimental/PointCloudStylingStageVS.glsl
+++ b/Source/Shaders/ModelExperimental/PointCloudStylingStageVS.glsl
@@ -9,23 +9,26 @@ float getPointSizeFromAttenuation(vec3 positionEC) {
 }
 
 #ifdef HAS_POINT_CLOUD_SHOW_STYLE
-float pointCloudShowStylingStage(in ProcessedAttributes attributes) {
-  return float(getShowFromStyle(attributes));
+float pointCloudShowStylingStage(in ProcessedAttributes attributes, in Metadata metadata) {
+  float czm_builtinTime = model_pointCloudParameters.w;
+  return float(getShowFromStyle(attributes, metadata, czm_builtinTime));
 }
 #endif
 
 #ifdef HAS_POINT_CLOUD_COLOR_STYLE
-vec4 pointCloudColorStylingStage(in ProcessedAttributes attributes) {
-  return getColorFromStyle(attributes);
+vec4 pointCloudColorStylingStage(in ProcessedAttributes attributes, in Metadata metadata) {
+  float czm_builtinTime = model_pointCloudParameters.w;
+  return getColorFromStyle(attributes, metadata, czm_builtinTime);
 }
 #endif
 
 #ifdef HAS_POINT_CLOUD_POINT_SIZE_STYLE
-float pointCloudPointSizeStylingStage(in ProcessedAttributes attributes) {
-  return float(getPointSizeFromStyle(attributes));
+float pointCloudPointSizeStylingStage(in ProcessedAttributes attributes, in Metadata metadata) {
+  float czm_builtinTime = model_pointCloudParameters.w;
+  return float(getPointSizeFromStyle(attributes, metadata, czm_builtinTime));
 }
 #elif defined(HAS_POINT_CLOUD_ATTENUATION)
-float pointCloudPointSizeStylingStage(in ProcessedAttributes attributes) {
+float pointCloudPointSizeStylingStage(in ProcessedAttributes attributes, in Metadata metadata) {
   return getPointSizeFromAttenuation(v_positionEC);
 }
 #endif

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -985,8 +985,7 @@ describe(
       options.url = pointCloudUrl;
       const tileset = scene.primitives.add(new Cesium3DTileset(options));
 
-      // In ModelExperimental, points are also counted as features.
-      return checkPointAndFeatureCounts(tileset, 1000, 1000, 0);
+      return checkPointAndFeatureCounts(tileset, 0, 1000, 0);
     });
 
     it("verify triangle statistics", function () {

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -2039,11 +2039,11 @@ describe(
       });
     });
 
-    function checkDebugColorizeTiles(url, enableModelExperimental) {
+    function checkDebugColorizeTiles(url) {
       CesiumMath.setRandomNumberSeed(0);
-      return Cesium3DTilesTester.loadTileset(scene, url, {
-        enableModelExperimental: enableModelExperimental,
-      }).then(function (tileset) {
+      return Cesium3DTilesTester.loadTileset(scene, url).then(function (
+        tileset
+      ) {
         // Get initial color
         let color;
         Cesium3DTilesTester.expectRender(scene, tileset, function (rgba) {
@@ -2088,11 +2088,7 @@ describe(
 
     it("debugColorizeTiles for pnts without batch table", function () {
       viewPointCloud();
-
-      // This unit test fails for ModelExperimental because points are counted
-      // as features, which interferes with how debug color is applied.
-      const enableModelExperimental = false;
-      return checkDebugColorizeTiles(pointCloudUrl, enableModelExperimental);
+      return checkDebugColorizeTiles(pointCloudUrl);
     });
 
     it("debugColorizeTiles for glTF", function () {

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -3905,7 +3905,7 @@ describe("Scene/Expression", function () {
   it("gets shader expression for tiles3d_tileset_time", function () {
     const expression = new Expression("${tiles3d_tileset_time}");
     const shaderExpression = expression.getShaderExpression({}, {});
-    const expected = "u_time";
+    const expected = "czm_builtinTime";
     expect(shaderExpression).toEqual(expected);
   });
 

--- a/Specs/Scene/ModelExperimental/ModelExperimental3DTileContentSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimental3DTileContentSpec.js
@@ -9,6 +9,7 @@ import {
   GroupMetadata,
   HeadingPitchRange,
   MetadataClass,
+  RuntimeError,
 } from "../../../Source/Cesium.js";
 import Cesium3DTilesTester from "../../Cesium3DTilesTester.js";
 import createScene from "../../createScene.js";
@@ -44,8 +45,6 @@ describe(
       "./Data/Cesium3DTiles/GeoJson/MultiLineString/tileset.json";
     const geoJsonMultipleFeaturesUrl =
       "./Data/Cesium3DTiles/GeoJson/MultipleFeatures/tileset.json";
-    const pointCloudUrl =
-      "./Data/Cesium3DTiles/PointCloud/PointCloudWithPerPointProperties/tileset.json";
 
     let scene;
     const centerLongitude = -1.31968;
@@ -143,60 +142,72 @@ describe(
       });
     });
 
-    function rendersGeoJson(url) {
-      setCamera(centerLongitude, centerLatitude, 1.0);
-      return Cesium3DTilesTester.loadTileset(scene, url).then(function (
-        tileset
-      ) {
-        Cesium3DTilesTester.expectRender(scene, tileset);
-      });
-    }
-
-    it("renders GeoJSON MultiPolygon", function () {
-      return rendersGeoJson(geoJsonMultiPolygonUrl);
-    });
-
-    it("renders GeoJSON Polygon", function () {
-      return rendersGeoJson(geoJsonPolygonUrl);
-    });
-
-    it("renders GeoJSON Polygon with heights", function () {
-      return rendersGeoJson(geoJsonPolygonHeightsUrl);
-    });
-
-    it("renders GeoJSON Polygon with hole", function () {
-      return rendersGeoJson(geoJsonPolygonHoleUrl);
-    });
-
-    it("renders GeoJSON Polygon with no properties", function () {
-      return rendersGeoJson(geoJsonPolygonNoPropertiesUrl);
-    });
-
-    it("renders GeoJSON LineString", function () {
-      return rendersGeoJson(geoJsonLineStringUrl);
-    });
-
-    it("renders GeoJSON MultiLineString", function () {
-      return rendersGeoJson(geoJsonMultiLineStringUrl);
-    });
-
-    it("renders GeoJSON with multiple features", function () {
-      return rendersGeoJson(geoJsonMultipleFeaturesUrl);
-    });
-
-    it("renders pnts content", function () {
-      setCamera(centerLongitude, centerLatitude, 5.0);
-      return Cesium3DTilesTester.loadTileset(scene, pointCloudUrl).then(
-        function (tileset) {
+    describe("geoJSON", function () {
+      function rendersGeoJson(url) {
+        setCamera(centerLongitude, centerLatitude, 1.0);
+        return Cesium3DTilesTester.loadTileset(scene, url).then(function (
+          tileset
+        ) {
           Cesium3DTilesTester.expectRender(scene, tileset);
-        }
-      );
+        });
+      }
+
+      it("renders GeoJSON MultiPolygon", function () {
+        return rendersGeoJson(geoJsonMultiPolygonUrl);
+      });
+
+      it("renders GeoJSON Polygon", function () {
+        return rendersGeoJson(geoJsonPolygonUrl);
+      });
+
+      it("renders GeoJSON Polygon with heights", function () {
+        return rendersGeoJson(geoJsonPolygonHeightsUrl);
+      });
+
+      it("renders GeoJSON Polygon with hole", function () {
+        return rendersGeoJson(geoJsonPolygonHoleUrl);
+      });
+
+      it("renders GeoJSON Polygon with no properties", function () {
+        return rendersGeoJson(geoJsonPolygonNoPropertiesUrl);
+      });
+
+      it("renders GeoJSON LineString", function () {
+        return rendersGeoJson(geoJsonLineStringUrl);
+      });
+
+      it("renders GeoJSON MultiLineString", function () {
+        return rendersGeoJson(geoJsonMultiLineStringUrl);
+      });
+
+      it("renders GeoJSON with multiple features", function () {
+        return rendersGeoJson(geoJsonMultipleFeaturesUrl);
+      });
     });
 
-    it("renders pnts with color style", function () {
-      setCamera(centerLongitude, centerLatitude, 5.0);
-      return Cesium3DTilesTester.loadTileset(scene, pointCloudUrl).then(
-        function (tileset) {
+    describe("pnts", function () {
+      const pointCloudNormalsUrl =
+        "./Data/Cesium3DTiles/PointCloud/PointCloudNormals/tileset.json";
+      const pointCloudWithPerPointPropertiesUrl =
+        "./Data/Cesium3DTiles/PointCloud/PointCloudWithPerPointProperties/tileset.json";
+      const pointCloudWithUnicodePropertyIdsUrl =
+        "./Data/Cesium3DTiles/PointCloud/PointCloudWithUnicodePropertyIds/tileset.json";
+      it("renders pnts content", function () {
+        setCamera(centerLongitude, centerLatitude, 5.0);
+        return Cesium3DTilesTester.loadTileset(
+          scene,
+          pointCloudWithPerPointPropertiesUrl
+        ).then(function (tileset) {
+          Cesium3DTilesTester.expectRender(scene, tileset);
+        });
+      });
+
+      it("renders pnts with color style", function () {
+        setCamera(centerLongitude, centerLatitude, 5.0);
+        return Cesium3DTilesTester.loadTileset(
+          scene,
+          pointCloudWithPerPointPropertiesUrl
+        ).then(function (tileset) {
           // Verify render without style
           Cesium3DTilesTester.expectRender(scene, tileset);
 
@@ -212,6 +223,7 @@ describe(
           });
           expect(scene).toRenderAndCall(function (rgba) {
             // Pixel is a darker red
+            expect(rgba[0]).toBeGreaterThan(0);
             expect(rgba[0]).toBeLessThan(255);
             expect(rgba[1]).toBe(0);
             expect(rgba[2]).toBe(0);
@@ -221,14 +233,15 @@ describe(
           // Remove style
           tileset.style = undefined;
           expect(scene).notToRender([0, 0, 0, 255]);
-        }
-      );
-    });
+        });
+      });
 
-    it("renders pnts with show style", function () {
-      setCamera(centerLongitude, centerLatitude, 5.0);
-      return Cesium3DTilesTester.loadTileset(scene, pointCloudUrl).then(
-        function (tileset) {
+      it("renders pnts with show style", function () {
+        setCamera(centerLongitude, centerLatitude, 5.0);
+        return Cesium3DTilesTester.loadTileset(
+          scene,
+          pointCloudWithPerPointPropertiesUrl
+        ).then(function (tileset) {
           // Verify render without style
           Cesium3DTilesTester.expectRender(scene, tileset);
 
@@ -247,14 +260,15 @@ describe(
           // Remove style
           tileset.style = undefined;
           expect(scene).notToRender([0, 0, 0, 255]);
-        }
-      );
-    });
+        });
+      });
 
-    it("renders pnts with point size style", function () {
-      setCamera(centerLongitude, centerLatitude, 5.0);
-      return Cesium3DTilesTester.loadTileset(scene, pointCloudUrl).then(
-        function (tileset) {
+      it("renders pnts with point size style", function () {
+        setCamera(centerLongitude, centerLatitude, 5.0);
+        return Cesium3DTilesTester.loadTileset(
+          scene,
+          pointCloudWithPerPointPropertiesUrl
+        ).then(function (tileset) {
           // Verify render without style
           Cesium3DTilesTester.expectRender(scene, tileset);
 
@@ -270,8 +284,145 @@ describe(
           // Remove style
           tileset.style = undefined;
           expect(scene).toRender([0, 0, 0, 255]);
-        }
-      );
+        });
+      });
+
+      it("renders pnts with style using point cloud semantics", function () {
+        setCamera(centerLongitude, centerLatitude, 5.0);
+        return Cesium3DTilesTester.loadTileset(
+          scene,
+          pointCloudWithPerPointPropertiesUrl
+        ).then(function (tileset) {
+          // Verify render without style
+          Cesium3DTilesTester.expectRender(scene, tileset);
+
+          // Apply color style with semantic
+          tileset.style = new Cesium3DTileStyle({
+            color: "vec4(${COLOR}[0], 0.0, 0.0, 1.0)",
+          });
+          expect(scene).toRenderAndCall(function (rgba) {
+            expect(rgba[0]).toBeGreaterThan(0);
+            expect(rgba[1]).toBe(0);
+            expect(rgba[2]).toBe(0);
+            expect(rgba[3]).toBe(255);
+          });
+
+          // Apply show style with semantic
+          tileset.style = new Cesium3DTileStyle({
+            show: "${POSITION}[0] > -50.0",
+          });
+          expect(scene).notToRender([0, 0, 0, 255]);
+
+          tileset.style = new Cesium3DTileStyle({
+            show: "${POSITION}[0] > 50.0",
+          });
+          expect(scene).toRender([0, 0, 0, 255]);
+
+          // Remove style
+          tileset.style = undefined;
+          expect(scene).notToRender([0, 0, 0, 255]);
+        });
+      });
+
+      it("renders pnts with style using point cloud properties", function () {
+        setCamera(centerLongitude, centerLatitude, 5.0);
+        return Cesium3DTilesTester.loadTileset(
+          scene,
+          pointCloudWithPerPointPropertiesUrl
+        ).then(function (tileset) {
+          // Verify render without style
+          Cesium3DTilesTester.expectRender(scene, tileset);
+
+          // Apply show style with property
+          tileset.style = new Cesium3DTileStyle({
+            show: "${temperature} > 1.0",
+          });
+          expect(scene).toRender([0, 0, 0, 255]);
+
+          tileset.style = new Cesium3DTileStyle({
+            show: "${temperature} > 0.1",
+          });
+          expect(scene).notToRender([0, 0, 0, 255]);
+
+          // Remove style
+          tileset.style = undefined;
+          expect(scene).notToRender([0, 0, 0, 255]);
+        });
+      });
+
+      it("renders pnts with style using point cloud properties (unicode)", function () {
+        setCamera(centerLongitude, centerLatitude, 5.0);
+        return Cesium3DTilesTester.loadTileset(
+          scene,
+          pointCloudWithUnicodePropertyIdsUrl
+        ).then(function (tileset) {
+          // Verify render without style
+          Cesium3DTilesTester.expectRender(scene, tileset);
+
+          tileset.style = new Cesium3DTileStyle({
+            color: "color() * ${temperature}",
+          });
+
+          expect(scene).toRenderAndCall(function (rgba) {
+            // Pixel color is some shade of gray
+            expect(rgba[0]).toBe(rgba[1]);
+            expect(rgba[0]).toBe(rgba[2]);
+            expect(rgba[0]).toBeGreaterThan(0);
+            expect(rgba[0]).toBeLessThan(255);
+          });
+
+          // Remove style
+          tileset.style = undefined;
+          expect(scene).notToRender([0, 0, 0, 255]);
+        });
+      });
+
+      it("renders pnts with style and normals", function () {
+        setCamera(centerLongitude, centerLatitude, 5.0);
+        return Cesium3DTilesTester.loadTileset(
+          scene,
+          pointCloudNormalsUrl
+        ).then(function (tileset) {
+          // Verify render without style
+          Cesium3DTilesTester.expectRender(scene, tileset);
+
+          tileset.style = new Cesium3DTileStyle({
+            color: 'color("red")',
+            pointSize: 5.0,
+          });
+
+          expect(scene).toRenderAndCall(function (rgba) {
+            expect(rgba[0]).toBeGreaterThan(0);
+            expect(rgba[0]).toBeLessThan(255);
+            expect(rgba[1]).toBe(0);
+            expect(rgba[2]).toBe(0);
+            expect(rgba[3]).toBe(255);
+          });
+
+          // Remove style
+          tileset.style = undefined;
+          expect(scene).notToRender([0, 0, 0, 255]);
+        });
+      });
+
+      it("throws if style references the NORMAL semantic for pnts without normals", function () {
+        setCamera(centerLongitude, centerLatitude, 5.0);
+        return Cesium3DTilesTester.loadTileset(
+          scene,
+          pointCloudWithPerPointPropertiesUrl
+        ).then(function (tileset) {
+          // Verify render without style
+          Cesium3DTilesTester.expectRender(scene, tileset);
+
+          tileset.style = new Cesium3DTileStyle({
+            color: "${NORMAL}[0] > 0.5",
+          });
+
+          expect(function () {
+            scene.renderForSpecs();
+          }).toThrowError(RuntimeError);
+        });
+      });
     });
 
     it("picks from glTF", function () {

--- a/Specs/Scene/ModelExperimental/PntsLoaderSpec.js
+++ b/Specs/Scene/ModelExperimental/PntsLoaderSpec.js
@@ -100,9 +100,7 @@ describe("Scene/ModelExperimental/PntsLoader", function () {
   function expectEmptyMetadata(structuralMetadata) {
     expect(structuralMetadata).toBeDefined();
     expect(structuralMetadata.schema).toEqual({});
-    expect(structuralMetadata.propertyTableCount).toBe(1);
-    const propertyTable = structuralMetadata.getPropertyTable(0);
-    expect(propertyTable.getPropertyIds(0)).toEqual([]);
+    expect(structuralMetadata.propertyTableCount).toBe(0);
   }
 
   function expectMetadata(structuralMetadata, expectedProperties, isBatched) {

--- a/Specs/ShaderBuilderTester.js
+++ b/Specs/ShaderBuilderTester.js
@@ -156,11 +156,18 @@ ShaderBuilderTester.expectVertexLinesContains = function (
   shaderBuilder,
   expectedString
 ) {
+  let hasLine = false;
   const lines = shaderBuilder._vertexShaderParts.shaderLines;
-  for (let i = 0; i < lines; i++) {
+  const length = lines.length;
+  for (let i = 0; i < length; i++) {
     const line = lines[i];
-    expect(line.indexOf(expectedString)).toBeGreaterThan(-1);
+    if (line.indexOf(expectedString) > -1) {
+      hasLine = true;
+      break;
+    }
   }
+
+  expect(hasLine).toBe(true);
 };
 
 ShaderBuilderTester.expectVertexLinesEqual = function (


### PR DESCRIPTION
This PR is a followup to #10560 and allows the user to style point clouds while referring to metadata properties in the `pnts` file.
![image](https://user-images.githubusercontent.com/32226860/179839026-66377c09-ad77-4734-ac16-a3cd660177c5.png)

This removes the behavior of adding an empty `PropertyTable` to point clouds without metadata, which was interfering with styling / debug colorize tiles / statistics. `ModelExperimental` is now enabled for the [3D Tiles Point Cloud Styling](http://localhost:8080/Apps/Sandcastle/index.html?src=3D%20Tiles%20Point%20Cloud%20Styling.html&label=3D%20Tiles) and [Montreal Point Cloud](http://localhost:8080/Apps/Sandcastle/index.html?src=Montreal%20Point%20Cloud.html&label=3D%20Tiles) sandcastles, as well as some unit tests.