### PR TITLE
Fix multiple contents race condition

### DIFF
--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -1105,8 +1105,12 @@ function requestMultipleContents(tile) {
   tile._contentState = Cesium3DTileContentState.LOADING;
   const contentReadyToProcessPromise = multipleContents.contentsFetchedPromise.then(
     function () {
-      if (tile._contentState !== Cesium3DTileContentState.LOADING) {
-        // tile was canceled, short circuit.
+      if (
+        tile._contentState !== Cesium3DTileContentState.LOADING ||
+        !defined(multipleContents.readyPromise)
+      ) {
+        // The tile or one of the inner content requests was canceled,
+        // short circuit.
         return;
       }
 

--- a/Source/Scene/Implicit3DTileContent.js
+++ b/Source/Scene/Implicit3DTileContent.js
@@ -238,8 +238,11 @@ function expandSubtree(content, subtree) {
     childIndex
   );
 
+  const statistics = content._tileset.statistics;
+
   // Link the new subtree to the existing placeholder tile.
   placeholderTile.children.push(results.rootTile);
+  statistics.numberOfTilesTotal++;
 
   // for each child subtree, make new placeholder tiles
   const childSubtrees = listChildSubtrees(content, subtree, results.bottomRow);
@@ -252,6 +255,7 @@ function expandSubtree(content, subtree) {
       subtreeLocator.childIndex
     );
     leafTile.children.push(implicitChildTile);
+    statistics.numberOfTilesTotal++;
   }
 }
 
@@ -329,6 +333,8 @@ function transcodeSubtreeTiles(content, subtree, placeholderTile, childIndex) {
     rootParentIsPlaceholder
   );
 
+  const statistics = content._tileset.statistics;
+
   // Sliding window over the levels of the tree.
   // Each row is branchingFactor * length of previous row
   // Tiles within a row are ordered by Morton index.
@@ -363,6 +369,7 @@ function transcodeSubtreeTiles(content, subtree, placeholderTile, childIndex) {
         childBitIndex
       );
       parentTile.children.push(childTile);
+      statistics.numberOfTilesTotal++;
       currentRow.push(childTile);
     }
 

--- a/Source/Scene/Multiple3DTileContent.js
+++ b/Source/Scene/Multiple3DTileContent.js
@@ -112,7 +112,12 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
   /**
    * Part of the {@link Cesium3DTileContent} interface.  <code>Multiple3DTileContent</code>
    * always returns <code>0</code>.  Instead call <code>featuresLength</code> for a specific inner content.
+   *
    * @memberof Multiple3DTileContent.prototype
+   *
+   * @type {Number}
+   * @readonly
+   *
    * @private
    */
   featuresLength: {
@@ -124,7 +129,12 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
   /**
    * Part of the {@link Cesium3DTileContent} interface.  <code>Multiple3DTileContent</code>
    * always returns <code>0</code>.  Instead, call <code>pointsLength</code> for a specific inner content.
+   *
    * @memberof Multiple3DTileContent.prototype
+   *
+   * @type {Number}
+   * @readonly
+   *
    * @private
    */
   pointsLength: {
@@ -136,7 +146,12 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
   /**
    * Part of the {@link Cesium3DTileContent} interface.  <code>Multiple3DTileContent</code>
    * always returns <code>0</code>.  Instead call <code>trianglesLength</code> for a specific inner content.
+   *
    * @memberof Multiple3DTileContent.prototype
+   *
+   * @type {Number}
+   * @readonly
+   *
    * @private
    */
   trianglesLength: {
@@ -148,7 +163,12 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
   /**
    * Part of the {@link Cesium3DTileContent} interface.  <code>Multiple3DTileContent</code>
    * always returns <code>0</code>.  Instead call <code>geometryByteLength</code> for a specific inner content.
+   *
    * @memberof Multiple3DTileContent.prototype
+   *
+   * @type {Number}
+   * @readonly
+   *
    * @private
    */
   geometryByteLength: {
@@ -158,9 +178,14 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
   },
 
   /**
-   * Part of the {@link Cesium3DTileContent} interface.   <code>Multiple3DTileContent</code>
+   * Part of the {@link Cesium3DTileContent} interface. <code>Multiple3DTileContent</code>
    * always returns <code>0</code>.  Instead call <code>texturesByteLength</code> for a specific inner content.
+   *
    * @memberof Multiple3DTileContent.prototype
+   *
+   * @type {Number}
+   * @readonly
+   *
    * @private
    */
   texturesByteLength: {
@@ -172,7 +197,12 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
   /**
    * Part of the {@link Cesium3DTileContent} interface.  <code>Multiple3DTileContent</code>
    * always returns <code>0</code>.  Instead call <code>batchTableByteLength</code> for a specific inner content.
+   *
    * @memberof Multiple3DTileContent.prototype
+   *
+   * @type {Number}
+   * @readonly
+   *
    * @private
    */
   batchTableByteLength: {
@@ -187,8 +217,26 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
     },
   },
 
+  /**
+   * Part of the {@link Cesium3DTileContent} interface with one slight
+   * difference: <code>Multiple3DTileContent</code> sometimes returns undefined
+   * if the inner contents have not yet been created. This is handled as a
+   * special case in {@link Cesium3DTile}.
+   *
+   * @memberof Multiple3DTileContent.prototype
+   *
+   * @type {Promise.<Cesium3DTileContent>|undefined}
+   * @readonly
+   *
+   * @private
+   */
   readyPromise: {
     get: function () {
+      // The contents haven't been created yet, short-circuit
+      if (this._contents.length < this._innerContentHeaders.length) {
+        return undefined;
+      }
+
       const readyPromises = this._contents.map(function (content) {
         return content.readyPromise;
       });
@@ -321,8 +369,10 @@ function cancelPendingRequests(multipleContents, originalContentState) {
   // reset the tile's content state to try again later.
   multipleContents._tile._contentState = originalContentState;
 
-  multipleContents.tileset.statistics.numberOfPendingRequests -=
-    multipleContents._requestsInFlight;
+  const statistics = multipleContents.tileset.statistics;
+
+  statistics.numberOfPendingRequests -= multipleContents._requestsInFlight;
+  statistics.numberOfAttemptedRequests += multipleContents._requestsInFlight;
   multipleContents._requestsInFlight = 0;
 
   // Discard the request promises.
@@ -427,8 +477,12 @@ function requestInnerContent(
   contentResource.request = request;
   multipleContents._requests[index] = request;
 
-  return contentResource
-    .fetchArrayBuffer()
+  const promise = contentResource.fetchArrayBuffer();
+  if (!defined(promise)) {
+    return Promise.resolve(undefined);
+  }
+
+  return promise
     .then(function (arrayBuffer) {
       // Short circuit if another inner content was canceled.
       if (originalCancelCount < multipleContents._cancelCount) {
@@ -459,6 +513,7 @@ function createInnerContents(multipleContents) {
   return Promise.all(multipleContents._arrayFetchPromises).then(function (
     arrayBuffers
   ) {
+    // Short circuit if inner contents were canceled
     if (originalCancelCount < multipleContents._cancelCount) {
       return undefined;
     }

--- a/Source/Scene/Multiple3DTileContent.js
+++ b/Source/Scene/Multiple3DTileContent.js
@@ -219,10 +219,10 @@ Object.defineProperties(Multiple3DTileContent.prototype, {
   },
 
   /**
-   * Part of the {@link Cesium3DTileContent} interface with one slight
-   * difference: <code>Multiple3DTileContent</code> sometimes returns undefined
-   * if the inner contents have not yet been created. This is handled as a
-   * special case in {@link Cesium3DTile}.
+   * Part of the {@link Cesium3DTileContent} interface. This behaves
+   * differently for <code>Multiple3DTileContent</code>: it returns
+   * undefined if the inner contents have not yet been created. This
+   * is handled specially in {@link Cesium3DTile}.
    *
    * @memberof Multiple3DTileContent.prototype
    *

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -5669,7 +5669,7 @@ describe(
 
             tileset.root.contentReadyToProcessPromise
               .then(function () {
-                expect(statistics.numberOfAttemptedRequests).toBe(0);
+                expect(statistics.numberOfAttemptedRequests).toBe(2);
                 expect(statistics.numberOfPendingRequests).toBe(0);
                 expect(statistics.numberOfTilesProcessing).toBe(1);
                 expect(statistics.numberOfTilesWithContentReady).toBe(0);
@@ -5976,7 +5976,7 @@ describe(
 
           tileset.root.contentReadyToProcessPromise
             .then(function () {
-              expect(statistics.numberOfAttemptedRequests).toBe(0);
+              expect(statistics.numberOfAttemptedRequests).toBe(2);
               expect(statistics.numberOfPendingRequests).toBe(0);
               expect(statistics.numberOfTilesProcessing).toBe(1);
               expect(statistics.numberOfTilesWithContentReady).toBe(0);

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -5842,11 +5842,7 @@ describe(
       it("renders implicit tileset with multiple contents", function () {
         return Cesium3DTilesTester.loadTileset(
           scene,
-          implicitMultipleContentsUrl,
-          {
-            // See https://github.com/CesiumGS/cesium/issues/10551
-            enableModelExperimental: false,
-          }
+          implicitMultipleContentsUrl
         ).then(function (tileset) {
           scene.renderForSpecs();
           const statistics = tileset._statistics;
@@ -6173,11 +6169,7 @@ describe(
       it("renders implicit tileset with multiple contents (legacy)", function () {
         return Cesium3DTilesTester.loadTileset(
           scene,
-          implicitMultipleContentsLegacyUrl,
-          // See https://github.com/CesiumGS/cesium/issues/10551
-          {
-            enableModelExperimental: false,
-          }
+          implicitMultipleContentsLegacyUrl
         ).then(function (tileset) {
           const statistics = tileset._statistics;
           // implicit placeholder + transcoded root + 4 child tiles
@@ -6190,11 +6182,7 @@ describe(
       it("renders implicit tileset with multiple contents (legacy with 'content')", function () {
         return Cesium3DTilesTester.loadTileset(
           scene,
-          implicitMultipleContentsLegacyWithContentUrl,
-          // See https://github.com/CesiumGS/cesium/issues/10551
-          {
-            enableModelExperimental: false,
-          }
+          implicitMultipleContentsLegacyWithContentUrl
         ).then(function (tileset) {
           const statistics = tileset._statistics;
           // implicit placeholder + transcoded root + 4 child tiles

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -6667,9 +6667,7 @@ describe(
         // one tile is removed
         return Cesium3DTilesTester.loadTileset(
           scene,
-          tilesetWithImplicitMultipleContentsMetadataUrl,
-          // See https://github.com/CesiumGS/cesium/issues/10551
-          { enableModelExperimental: false }
+          tilesetWithImplicitMultipleContentsMetadataUrl
         ).then(function (tileset) {
           const placeholderTile = tileset.root;
 

--- a/Specs/Scene/Multiple3DTileContentSpec.js
+++ b/Specs/Scene/Multiple3DTileContentSpec.js
@@ -555,9 +555,7 @@ describe(
       it("initializes implicit content metadata for inner contents", function () {
         return Cesium3DTilesTester.loadTileset(
           scene,
-          withImplicitContentMetadataUrl,
-          // See https://github.com/CesiumGS/cesium/issues/10551
-          { enableModelExperimental: false }
+          withImplicitContentMetadataUrl
         ).then(function (tileset) {
           const placeholderTile = tileset.root;
           const subtreeRootTile = placeholderTile.children[0];
@@ -586,9 +584,7 @@ describe(
       it("initializes implicit content metadata for inner contents (legacy)", function () {
         return Cesium3DTilesTester.loadTileset(
           scene,
-          withImplicitContentMetadataLegacyUrl,
-          // See https://github.com/CesiumGS/cesium/issues/10551
-          { enableModelExperimental: false }
+          withImplicitContentMetadataLegacyUrl
         ).then(function (tileset) {
           const placeholderTile = tileset.root;
           const subtreeRootTile = placeholderTile.children[0];


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/10551

In multiple contents, request throttling was creating a corner case where the contents were not yet created, but the `readyPromise` looped over an empty list of contents and resolved too soon.

The fix was to make the readyPromise return `undefined` and have `Cesium3DTile` content short-circuit the promise chain. The tile automatically re-requests the content as long as the tile is still in the `LOADING` state.

I also fixed a couple details about rendering statistics for Multiple contents/implicit tiling along the way:

* `tileset.statistics.numberOfTilesLoaded` wasn't being updated for implicit tiling like `Cesium3DTileset.loadTileset()` does
* when a request was canceled, multiple contents wasn't incrementing the number of attempted requests.

(note that for multiple contents, statistics are a bit ill-defined. if the property has "requests" in the name, it's counting the number of requests (one per inner content) but if the property has "tile" in the name, it's counting the number of tiles (1 regardless of how many inner contents there are)

@j9liu could you review when you get a chance?