### PR TITLE
Fix height reference handling in `ModelExperimental`

### DIFF
--- a/Source/DataSources/ModelVisualizer.js
+++ b/Source/DataSources/ModelVisualizer.js
@@ -369,6 +369,11 @@ ModelVisualizer.prototype.getBoundingSphere = function (entity, result) {
     return BoundingSphereState.PENDING;
   }
 
+  const hasHeightReference = model.heightReference !== HeightReference.NONE;
+  if (hasHeightReference && !defined(model._clampedModelMatrix)) {
+    return BoundingSphereState.PENDING;
+  }
+
   if (ExperimentalFeatures.enableModelExperimental) {
     // ModelExperimental's bounding sphere is already in world space,
     // so it does not need to be transformed.
@@ -376,19 +381,16 @@ ModelVisualizer.prototype.getBoundingSphere = function (entity, result) {
     return BoundingSphereState.DONE;
   }
 
-  if (model.heightReference === HeightReference.NONE) {
-    BoundingSphere.transform(
-      model.boundingSphereInternal,
-      model.modelMatrix,
-      result
-    );
-  } else {
-    if (!defined(model._clampedModelMatrix)) {
-      return BoundingSphereState.PENDING;
-    }
+  if (hasHeightReference) {
     BoundingSphere.transform(
       model.boundingSphereInternal,
       model._clampedModelMatrix,
+      result
+    );
+  } else {
+    BoundingSphere.transform(
+      model.boundingSphereInternal,
+      model.modelMatrix,
       result
     );
   }

--- a/Source/Scene/ModelExperimental/ModelExperimental.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental.js
@@ -2090,7 +2090,7 @@ function getUpdateHeightCallback(model, ellipsoid, cartoPosition) {
     clampedModelMatrix[13] = clampedPosition.y;
     clampedModelMatrix[14] = clampedPosition.z;
 
-    model._heightChanged = true;
+    model._heightDirty = true;
   };
 }
 


### PR DESCRIPTION
This PR fixes two bugs with height reference in `ModelExperimental`:
- the update height callback was setting `model._heightChanged` instead of `model._heightDirty`
- `ModelVisualizer.getBoundingSphere` was not waiting for `_clampedModelMatrix` to be defined for `ModelExperimental`s with height references

This doesn't change the incorrect camera behavior in #10555, but it at least makes it consistent with `Model`. [Sandcastle for testing](http://localhost:8080/Apps/Sandcastle/index.html#c=bVLRTtswFP0VKy+kUuZQWjRaQsXWauwBKKIde4mEXPsmteZcV7ZT1CH+HcdpO9oh5cH3+Nxz7zkx12gdWUt4AUOuCMILGYOVdUWfAhbnEQ/1WKNjEsHkUUJecyTEgTEeeTB6LQWY4a6RG2AOfmujxLylxJ0kx7fOZY458jBQaSylqwVMoDQA1o/u9gf0vHve651d7lnMHZG+9Pp0cNH/OhgEsR1xpa10UqNnbJcYM+P8iWGPFkZXW4W42ft4dhLAw1EBOzvN8ePSgJ6z8TPauGioJVjKhIhDJLs9hvtTEKq0ADVsUyOkNnJI8ojS1H8zVq0UTJhjaWDZ9MboGsUTLCVXcFjRUi18/K3MEmS5dI9QgAHksI//5yFOx7ff7h6e59Pnm8fpr/tJ6H779z9mDAVn1nl1b2OutVow8712TmN88kNt5prcNYudJKSokTee4k5rZRtD0ZDiNpxG0wtHSZRZt1Ewancl5FpWK22cN69ib9uBt+1fiU0XNf8DjnJrm96GmqUfWzMh10SKq0/eIeGKWetvilqpmfwLeTTKUs//r1VpJiSW0zUYxTYNbdkd3bYgpTRLffl5p2sDOVJ+Bw), with the expected behavior:

> Click FlyToModel and it will be incorrect. Click it a second time, and it will be differently incorrect. Click it a third time and it is correct. There is clearly a race condition going on involved with clamping to ground.

Sometimes (even for `Model`) the camera ends up slightly above the model instead of where it accurately is, but it ultimately ends up above ground with part of the model in view.