### PR TITLE
build-third-party should also reference direct dependencies

### DIFF
--- a/ThirdParty.json
+++ b/ThirdParty.json
@@ -4,7 +4,7 @@
     "license": [
       "BSD-3-Clause"
     ],
-    "version": "2.4.26",
+    "version": "2.5.26",
     "url": "https://www.npmjs.com/package/@zip.js/zip.js"
   },
   {
@@ -36,7 +36,7 @@
     "license": [
       "Apache-2.0"
     ],
-    "version": "2.3.8",
+    "version": "2.3.10",
     "url": "https://www.npmjs.com/package/dompurify",
     "notes": "dompurify is available as both MPL-2.0 OR Apache-2.0"
   },
@@ -45,7 +45,7 @@
     "license": [
       "Apache-2.0"
     ],
-    "version": "1.5.2",
+    "version": "1.5.3",
     "url": "https://www.npmjs.com/package/draco3d"
   },
   {
@@ -53,7 +53,7 @@
     "license": [
       "ISC"
     ],
-    "version": "2.2.3",
+    "version": "2.2.4",
     "url": "https://www.npmjs.com/package/earcut"
   },
   {

--- a/gulpfile.cjs
+++ b/gulpfile.cjs
@@ -1747,7 +1747,10 @@ function getLicenseDataFromThirdPartyExtra(path, discoveredDependencies) {
     return Promise.map(thirdPartyExtra, function (module) {
       if (!discoveredDependencies.includes(module.name)) {
         // If this is not a npm module, return existing info
-        if (!packageJson.devDependencies[module.name]) {
+        if (
+          !packageJson.dependencies[module.name] &&
+          !packageJson.devDependencies[module.name]
+        ) {
           discoveredDependencies.push(module.name);
           return Promise.resolve(module);
         }


### PR DESCRIPTION
After https://github.com/CesiumGS/cesium/pull/10567, we'll need to make sure `build-third-party` also ingests information from the package.json `dependencies` field, not just `devDependencies`.