### PR TITLE
fix rendering of silhouettes in `ModelExperimental`

### DIFF
--- a/Source/Shaders/ModelExperimental/ModelExperimentalVS.glsl
+++ b/Source/Shaders/ModelExperimental/ModelExperimentalVS.glsl
@@ -98,10 +98,10 @@ void main()
 
     // Compute the final position in each coordinate system needed.
     // This returns the value that will be assigned to gl_Position.
-    vec4 computedPosition = geometryStage(attributes, modelView, normal);    
+    vec4 positionClip = geometryStage(attributes, modelView, normal);    
 
     #ifdef HAS_SILHOUETTE
-    silhouetteStage(attributes);
+    silhouetteStage(attributes, positionClip);
     #endif
 
     #ifdef HAS_POINT_CLOUD_SHOW_STYLE
@@ -126,5 +126,5 @@ void main()
         gl_PointSize *= show;
     #endif
 
-    gl_Position = show * computedPosition;
+    gl_Position = show * positionClip;
 }

--- a/Source/Shaders/ModelExperimental/ModelSilhouetteStageVS.glsl
+++ b/Source/Shaders/ModelExperimental/ModelSilhouetteStageVS.glsl
@@ -1,12 +1,10 @@
-void silhouetteStage(in ProcessedAttributes attributes) {
+void silhouetteStage(in ProcessedAttributes attributes, inout vec4 positionClip) {
      #ifdef HAS_NORMALS
      if(model_silhouettePass) {
           vec3 normal = normalize(czm_normal3D * attributes.normalMC);
           normal.x *= czm_projection[0][0];
           normal.y *= czm_projection[1][1];
-          vec4 clip = gl_Position;
-          clip.xy += normal.xy * clip.w * model_silhouetteSize * czm_pixelRatio / czm_viewport.z;
-          gl_Position = clip;
+          positionClip.xy += normal.xy * positionClip.w * model_silhouetteSize * czm_pixelRatio / czm_viewport.z;
     }
     #endif
 }


### PR DESCRIPTION
When we added point cloud styling for `ModelExperimental`, we changed where `gl_Position` was set in ModelExperimentalVS' fragment shader. However, the model silhouette stage also sets `gl_Position`, and this value was being clobbered. It was simple to fix, just had to replace the use of `gl_Position with an `inout` variable.

The [3D Models Coloring Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html?src=3D%20Models%20Coloring.html) should now work again.

@j9liu could you review?