### PR TITLE
Update sanitization conventions for property names in Custom Shaders

### DIFF
--- a/Documentation/CustomShaderGuide/README.md
+++ b/Documentation/CustomShaderGuide/README.md
@@ -677,7 +677,7 @@ range of `[32.0, 212.0]`.
 ### Property ID Sanitization
 
 GLSL only supports alphanumeric identifiers, i.e. identifiers that do not
-starting with a number. Additionally, identifiers with consecutive
+start with a number. Additionally, identifiers with consecutive
 underscores (`__`), as well as identifiers with the `gl_` prefix, are
 reserved in GLSL. To circumvent these limitations, the property IDs are
 modified as follows:

--- a/Documentation/CustomShaderGuide/README.md
+++ b/Documentation/CustomShaderGuide/README.md
@@ -674,9 +674,9 @@ with a value between 0.0 and 100.0, while
 `(vsInput|fsInput).metadata.temperatureFahrenheit` will be a `float` with a
 range of `[32.0, 212.0]`.
 
-### Property Name Sanitization
+### Property ID Sanitization
 
-Since GLSL only supports alphanumeric identifiers (not starting with a number or the reserved prefix `gl_`), property IDs are modified as follows:
+GLSL only supports alphanumeric identifiers, i.e. identifiers that do not starting with a number. Additionally, identifiers with consecutive underscores (`__`), as well as identifiers with the `gl_` prefix, are reserved in GLSL. To circumvent these limitations, the property IDs are modified as follows:
 
 1. Replace all characters excluded from `[A-Za-z0-9_]` with an `_`.
 2. Replace consecutive underscores (e.g. `___`) with a single `_`.

--- a/Documentation/CustomShaderGuide/README.md
+++ b/Documentation/CustomShaderGuide/README.md
@@ -676,7 +676,11 @@ range of `[32.0, 212.0]`.
 
 ### Property ID Sanitization
 
-GLSL only supports alphanumeric identifiers, i.e. identifiers that do not starting with a number. Additionally, identifiers with consecutive underscores (`__`), as well as identifiers with the `gl_` prefix, are reserved in GLSL. To circumvent these limitations, the property IDs are modified as follows:
+GLSL only supports alphanumeric identifiers, i.e. identifiers that do not
+starting with a number. Additionally, identifiers with consecutive
+underscores (`__`), as well as identifiers with the `gl_` prefix, are
+reserved in GLSL. To circumvent these limitations, the property IDs are
+modified as follows:
 
 1. Replace all characters excluded from `[A-Za-z0-9_]` with an `_`.
 2. Replace consecutive underscores (e.g. `___`) with a single `_`.
@@ -700,8 +704,8 @@ property IDs, the behavior is undefined. For example:
   map to `metadata.temperature`, so the behavior is undefined
 
 When using the Point Cloud (`.pnts`) format in `ModelExperimental`, per-point
-properties are transcoded as property attributes. These property IDs follow the
-same convention.
+properties are transcoded as property attributes. These property IDs follow
+the same convention.
 
 ## `czm_modelVertexOutput` struct
 

--- a/Documentation/CustomShaderGuide/README.md
+++ b/Documentation/CustomShaderGuide/README.md
@@ -674,21 +674,20 @@ with a value between 0.0 and 100.0, while
 `(vsInput|fsInput).metadata.temperatureFahrenheit` will be a `float` with a
 range of `[32.0, 212.0]`.
 
-### Note about Unicode property IDs for .pnts per-point properties
+### Property Name Sanitization
 
-When using the Point Cloud (`.pnts`) format in `ModelExperimental`, per-point
-properties are transcoded as property attributes. Since GLSL only supports
-alphanumeric identifiers (not starting with a number or the reserved prefix
-`gl_`), property IDs are modified as follows:
+Since GLSL only supports alphanumeric identifiers (not starting with a number or the reserved prefix `gl_`), property IDs are modified as follows:
 
-1. Remove all characters except `[A-Za-z0-9_]`.
-2. Remove the reserved `gl_` prefix if present
-3. If the identifier begins with a digit (`[0-9]`), prefix with an `_`
+1. Replace all characters excluded from `[A-Za-z0-9_]` with an `_`.
+2. Replace consecutive underscores (e.g. `___`) with a single `_`.
+3. Remove the reserved `gl_` prefix if present.
+4. If the identifier begins with a digit (`[0-9]`), prefix with an `_`
 
 Here are a couple examples of property ID and the resulting variable name in
 the custom shader in the `(vsInput|fsInput).metadata` struct:
 
 - `temperature ℃` -> `metadata.temperature`
+- `custom__property` -> `metadata.custom_property`
 - `gl_customProperty` -> `metadata.customProperty`
 - `12345` -> `metadata._12345`
 - `gl_12345` -> `metadata._12345`
@@ -699,6 +698,10 @@ property IDs, the behavior is undefined. For example:
 - `✖️✖️✖️` maps to the empty string, so the behavior is undefined.
 - Two properties with names `temperature ℃` and `temperature ℉` would both
   map to `metadata.temperature`, so the behavior is undefined
+
+When using the Point Cloud (`.pnts`) format in `ModelExperimental`, per-point
+properties are transcoded as property attributes. These property IDs follow the
+same convention.
 
 ## `czm_modelVertexOutput` struct
 

--- a/Source/Scene/ModelExperimental/ModelExperimentalUtility.js
+++ b/Source/Scene/ModelExperimental/ModelExperimentalUtility.js
@@ -316,7 +316,8 @@ ModelExperimentalUtility.getCullFace = function (modelMatrix, primitiveType) {
 /**
  * Sanitize the identifier to be used in a GLSL shader. The identifier
  * is sanitized as follows:
- * - All non-alphanumeric characters are removed.
+ * - All non-alphanumeric characters are replaced with underscores.
+ * - If there are multiple underscores in a row, replace them with just one.
  * - If the gl_ prefix is present, remove it. The prefix is reserved in GLSL.
  * - If the identifier starts with a digit, prefix it with an underscore.
  *
@@ -334,7 +335,9 @@ ModelExperimentalUtility.getCullFace = function (modelMatrix, primitiveType) {
  */
 ModelExperimentalUtility.sanitizeGlslIdentifier = function (identifier) {
   // Remove non-alphanumeric characters.
-  let sanitizedIdentifier = identifier.replaceAll(/[^A-Za-z0-9_]/g, "");
+  let sanitizedIdentifier = identifier.replaceAll(/[^A-Za-z0-9_]/g, "_");
+  // Replace multiple underscores.
+  sanitizedIdentifier = sanitizedIdentifier.replaceAll(/__+/g, "_");
   // Remove the gl_ prefix if present.
   sanitizedIdentifier = sanitizedIdentifier.replace(/^gl_/, "");
   // Add an underscore if first character is a digit.

--- a/Specs/Scene/ModelExperimental/ModelExperimental3DTileContentSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimental3DTileContentSpec.js
@@ -360,7 +360,7 @@ describe(
           Cesium3DTilesTester.expectRender(scene, tileset);
 
           tileset.style = new Cesium3DTileStyle({
-            color: "color() * ${temperature}",
+            color: "color() * ${temperature_}",
           });
 
           expect(scene).toRenderAndCall(function (rgba) {

--- a/Specs/Scene/ModelExperimental/ModelExperimentalUtilitySpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalUtilitySpec.js
@@ -426,7 +426,12 @@ describe("Scene/ModelExperimental/ModelExperimentalUtility", function () {
   it("sanitizeGlslIdentifier removes non-alphanumeric characters", function () {
     const identifier = "temperature ℃";
     const result = ModelExperimentalUtility.sanitizeGlslIdentifier(identifier);
-    expect(result).toEqual("temperature");
+    expect(result).toEqual("temperature_");
+  });
+  it("sanitizeGlslIdentifier removes consecutive underscores", function () {
+    const identifier = "custom__property";
+    const result = ModelExperimentalUtility.sanitizeGlslIdentifier(identifier);
+    expect(result).toEqual("custom_property");
   });
 
   it("sanitizeGlslIdentifier removes gl_ prefix", function () {
@@ -439,5 +444,11 @@ describe("Scene/ModelExperimental/ModelExperimentalUtility", function () {
     const identifier = "1234";
     const result = ModelExperimentalUtility.sanitizeGlslIdentifier(identifier);
     expect(result).toEqual("_1234");
+  });
+
+  it("sanitizeGlslIdentifier handles all cases", function () {
+    const identifier = "gl_1st__test℃_variable";
+    const result = ModelExperimentalUtility.sanitizeGlslIdentifier(identifier);
+    expect(result).toEqual("_1st_test_variable");
   });
 });

--- a/Specs/Scene/ModelExperimental/ModelExperimentalUtilitySpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimentalUtilitySpec.js
@@ -428,6 +428,7 @@ describe("Scene/ModelExperimental/ModelExperimentalUtility", function () {
     const result = ModelExperimentalUtility.sanitizeGlslIdentifier(identifier);
     expect(result).toEqual("temperature_");
   });
+
   it("sanitizeGlslIdentifier removes consecutive underscores", function () {
     const identifier = "custom__property";
     const result = ModelExperimentalUtility.sanitizeGlslIdentifier(identifier);

--- a/Specs/Scene/ModelExperimental/PntsLoaderSpec.js
+++ b/Specs/Scene/ModelExperimental/PntsLoaderSpec.js
@@ -614,7 +614,7 @@ describe("Scene/ModelExperimental/PntsLoader", function () {
         components.structuralMetadata,
         {
           // Originally "temperature ℃", but sanitized for GLSL
-          temperature: {
+          temperature_: {
             type: MetadataType.SCALAR,
             componentType: MetadataComponentType.FLOAT32,
           },

--- a/Specs/Scene/parseBatchTableSpec.js
+++ b/Specs/Scene/parseBatchTableSpec.js
@@ -570,7 +570,7 @@ describe("Scene/parseBatchTable", function () {
 
     // Attributes are converted to upper-case like glTF attributes.
     expect(numericAttribute.name).toBe("_1234");
-    expect(unicodeAttribute.name).toBe("_HEIGHT");
+    expect(unicodeAttribute.name).toBe("_HEIGHT_");
 
     // In the schema, the IDs are valid GLSL identifiers, while the name
     // is the original property ID which may contain unicode.
@@ -578,20 +578,18 @@ describe("Scene/parseBatchTable", function () {
     const metadataClass = propertyAttribute.class;
     const numericClassProperty = metadataClass.properties["_1234"];
     expect(numericClassProperty.name).toBe("gl_1234");
-    const unicodeClassProperty = metadataClass.properties["Height"];
+    const unicodeClassProperty = metadataClass.properties["Height_"];
     expect(unicodeClassProperty.name).toBe("Height ⛰️");
 
     const properties = propertyAttribute.properties;
     const numericProperty = properties["_1234"];
     expect(numericProperty.attribute).toBe("_1234");
-    const unicodeProperty = properties["Height"];
-    expect(unicodeProperty.attribute).toBe("_HEIGHT");
+    const unicodeProperty = properties["Height_"];
+    expect(unicodeProperty.attribute).toBe("_HEIGHT_");
   });
 
   it("creates placeholder IDs for invalid GLSL identifiers", function () {
     const binaryBatchTable = {
-      // all characters will be removed, which would lead to an invalid
-      // identifier.
       "✖️✖️✖️": {
         byteOffset: 0,
         componentType: "FLOAT",
@@ -635,17 +633,13 @@ describe("Scene/parseBatchTable", function () {
     const attributeNames = customAttributes.map(function (attribute) {
       return attribute.name;
     });
-    expect(attributeNames.sort()).toEqual([
-      "_PROPERTY_0",
-      "_PROPERTY_1",
-      "_TEMPERATURE",
-    ]);
+    expect(attributeNames.sort()).toEqual(["_", "_PROPERTY_0", "_TEMPERATURE"]);
 
     const [propertyAttribute] = metadata.propertyAttributes;
     const metadataClass = propertyAttribute.class;
     const classProperties = [
+      metadataClass.properties._,
       metadataClass.properties.property_0,
-      metadataClass.properties.property_1,
       metadataClass.properties.temperature,
     ];
 
@@ -660,19 +654,15 @@ describe("Scene/parseBatchTable", function () {
 
     const properties = propertyAttribute.properties;
     expect(Object.keys(properties).sort()).toEqual([
+      "_",
       "property_0",
-      "property_1",
       "temperature",
     ]);
 
     const semantics = Object.values(properties).map(function (property) {
       return property.attribute;
     });
-    expect(semantics.sort()).toEqual([
-      "_PROPERTY_0",
-      "_PROPERTY_1",
-      "_TEMPERATURE",
-    ]);
+    expect(semantics.sort()).toEqual(["_", "_PROPERTY_0", "_TEMPERATURE"]);
   });
 
   it("handles typed arrays decoded from Draco pnts", function () {


### PR DESCRIPTION
In #10569, the `sanitizeGlslIdentifier` function was added to `ModelExperimentalUtility`, and used in the `Metadata` stage. This caused the "Custom Shaders Property Textures" sandcastle to crash, because the way it handled property names was now different.

This PR updates the sanitization conventions so that the Sandcastle works without any changes. @ptrgags is this a big enough change to warrant a changelog entry (since it's a change to `CustomShaderGuide.md`)?