### PR TITLE
Deprecate requestAnimationFrame and cancelAnimationFrame polyfills

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,10 @@
 - Fixed error in `loadAndExecuteScript` and favorite icon lost in sandcaslte when CesiumJS was running in cross-origin isloated evironment.[#10515](https://github.com/CesiumGS/cesium/pull/10515)
 - Fixed a bug where `Viewer.zoomTo` would continuously throw errors if a `Cesium3DTileset` failed to load.[#10523](https://github.com/CesiumGS/cesium/pull/10523)
 
+##### Deprecated :hourglass_flowing_sand:
+
+- The polyfills `requestAnimationFrame` and `cancelAnimationFrame` have been deprecated and will be removed in 1.99. Use the native browser methods instead.
+
 ### 1.95 - 2022-07-01
 
 ##### Breaking Changes :mega:

--- a/Source/Core/cancelAnimationFrame.js
+++ b/Source/Core/cancelAnimationFrame.js
@@ -1,4 +1,5 @@
 import defined from "./defined.js";
+import deprecationWarning from "./deprecationWarning.js";
 
 let implementation;
 if (typeof cancelAnimationFrame !== "undefined") {
@@ -34,11 +35,19 @@ if (typeof cancelAnimationFrame !== "undefined") {
  * @param {Number} requestID The value returned by {@link requestAnimationFrame}.
  *
  * @see {@link http://www.w3.org/TR/animation-timing/#the-WindowAnimationTiming-interface|The WindowAnimationTiming interface}
+ *
+ * @deprecated
  */
 function cancelAnimationFramePolyfill(requestID) {
   // we need this extra wrapper function because the native cancelAnimationFrame
   // functions must be invoked on the global scope (window), which is not the case
   // if invoked as Cesium.cancelAnimationFrame(requestID)
+
+  deprecationWarning(
+    "Cesium.cancelAnimationFrame",
+    "Cesium.cancelAnimationFrame was deprecated in CesiumJS 1.96 and will be removed in 1.99. Use the native cancelAnimationFrame method instead."
+  );
+
   implementation(requestID);
 }
 export default cancelAnimationFramePolyfill;

--- a/Source/Core/requestAnimationFrame.js
+++ b/Source/Core/requestAnimationFrame.js
@@ -57,6 +57,8 @@ if (typeof requestAnimationFrame !== "undefined") {
  * tick();
  *
  * @see {@link https://www.w3.org/TR/html51/webappapis.html#animation-frames|The Web API Animation Frames interface}
+ *
+ * @deprecated
  */
 function requestAnimationFramePolyFill(callback) {
   // we need this extra wrapper function because the native requestAnimationFrame

--- a/Source/Core/requestAnimationFrame.js
+++ b/Source/Core/requestAnimationFrame.js
@@ -1,4 +1,5 @@
 import defined from "./defined.js";
+import deprecationWarning from "./deprecationWarning.js";
 import getTimestamp from "./getTimestamp.js";
 
 let implementation;
@@ -64,6 +65,12 @@ function requestAnimationFramePolyFill(callback) {
   // we need this extra wrapper function because the native requestAnimationFrame
   // functions must be invoked on the global scope (window), which is not the case
   // if invoked as Cesium.requestAnimationFrame(callback)
+
+  deprecationWarning(
+    "Cesium.requestAnimationFrame",
+    "Cesium.requestAnimationFrame was deprecated in CesiumJS 1.96 and will be removed in 1.99. Use the native requestAnimationFrame method instead."
+  );
+
   return implementation(callback);
 }
 

--- a/Source/Widgets/Animation/Animation.js
+++ b/Source/Widgets/Animation/Animation.js
@@ -424,9 +424,9 @@ SvgButton.prototype.setTooltip = function (tooltip) {
  *
  * function tick() {
  *     clock.tick();
- *     Cesium.requestAnimationFrame(tick);
+ *     requestAnimationFrame(tick);
  * }
- * Cesium.requestAnimationFrame(tick);
+ * requestAnimationFrame(tick);
  *
  * @see AnimationViewModel
  * @see Clock

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -8,7 +8,6 @@ import DeveloperError from "../../Core/DeveloperError.js";
 import Ellipsoid from "../../Core/Ellipsoid.js";
 import FeatureDetection from "../../Core/FeatureDetection.js";
 import formatError from "../../Core/formatError.js";
-import requestAnimationFrame from "../../Core/requestAnimationFrame.js";
 import ScreenSpaceEventHandler from "../../Core/ScreenSpaceEventHandler.js";
 import createWorldImagery from "../../Scene/createWorldImagery.js";
 import Globe from "../../Scene/Globe.js";
@@ -534,7 +533,7 @@ Object.defineProperties(CesiumWidget.prototype, {
 
   /**
    * Gets or sets the target frame rate of the widget when <code>useDefaultRenderLoop</code>
-   * is true. If undefined, the browser's {@link requestAnimationFrame} implementation
+   * is true. If undefined, the browser's requestAnimationFrame implementation
    * determines the frame rate.  If defined, this value must be greater than 0.  A value higher
    * than the underlying requestAnimationFrame implementation will have no effect.
    * @memberof CesiumWidget.prototype
@@ -559,7 +558,7 @@ Object.defineProperties(CesiumWidget.prototype, {
 
   /**
    * Gets or sets whether or not this widget should control the render loop.
-   * If true the widget will use {@link requestAnimationFrame} to
+   * If true the widget will use requestAnimationFrame to
    * perform rendering and resizing of the widget, as well as drive the
    * simulation clock. If set to false, you must manually call the
    * <code>resize</code>, <code>render</code> methods as part of a custom

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -1304,7 +1304,7 @@ Object.defineProperties(Viewer.prototype, {
 
   /**
    * Gets or sets the target frame rate of the widget when <code>useDefaultRenderLoop</code>
-   * is true. If undefined, the browser's {@link requestAnimationFrame} implementation
+   * is true. If undefined, the browser's requestAnimationFrame implementation
    * determines the frame rate.  If defined, this value must be greater than 0.  A value higher
    * than the underlying requestAnimationFrame implementation will have no effect.
    * @memberof Viewer.prototype
@@ -1322,7 +1322,7 @@ Object.defineProperties(Viewer.prototype, {
 
   /**
    * Gets or sets whether or not this widget should control the render loop.
-   * If true the widget will use {@link requestAnimationFrame} to
+   * If true the widget will use requestAnimationFrame to
    * perform rendering and resizing of the widget, as well as drive the
    * simulation clock. If set to false, you must manually call the
    * <code>resize</code>, <code>render</code> methods


### PR DESCRIPTION
The old polyfills `requestAnimationFrame` and `cancelAnimationFrame` are no longer needed, as all browsers now implement these methods.

Since these methods are on the public API, this PR marks the polyfills as deprecated, for removal in CesiumJS 1.98. It also removes the one use of the polyfill in `CesiumWidget`.