### PR TITLE
`ModelExperimental`: fix show behavior after tileset starts hidden

### DIFF
--- a/Source/Scene/ModelExperimental/ModelExperimental3DTileContent.js
+++ b/Source/Scene/ModelExperimental/ModelExperimental3DTileContent.js
@@ -397,7 +397,6 @@ function makeModelOptions(tileset, tile, content, additionalOptions) {
     incrementallyLoadTextures: false,
     customShader: tileset.customShader,
     content: content,
-    show: tileset.show,
     colorBlendMode: tileset.colorBlendMode,
     colorBlendAmount: tileset.colorBlendAmount,
     lightColor: tileset.lightColor,

--- a/Specs/Scene/ModelExperimental/ModelExperimental3DTileContentSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimental3DTileContentSpec.js
@@ -153,6 +153,11 @@ describe(
         noBatchIdsUrl,
         tilesetOptions
       ).then(function (tileset) {
+        // expectRender() renders twice, first with tileset.show = false,
+        // then with tileset.show = true.
+        //
+        // When tileset.preloadWhenHidden is true, the model has loaded by
+        // this point. It will only render when tileset.show = true
         Cesium3DTilesTester.expectRender(scene, tileset);
       });
     });
@@ -168,6 +173,12 @@ describe(
         noBatchIdsUrl,
         tilesetOptions
       ).then(function (tileset) {
+        // expectRenderBlank() renders twice, first with tileset.show = false,
+        // then with tileset.show = true.
+        //
+        // When tileset.preloadWhenHidden is false, the model has not loaded
+        // by this point. Regardless of tileset.show, the tile should not be
+        // rendered.
         Cesium3DTilesTester.expectRenderBlank(scene, tileset);
       });
     });

--- a/Specs/Scene/ModelExperimental/ModelExperimental3DTileContentSpec.js
+++ b/Specs/Scene/ModelExperimental/ModelExperimental3DTileContentSpec.js
@@ -142,6 +142,36 @@ describe(
       });
     });
 
+    it("renders correctly when tileset starts hidden and tileset.preloadWhenHidden is true", function () {
+      setCamera(centerLongitude, centerLatitude, 15.0);
+      const tilesetOptions = {
+        show: false,
+        preloadWhenHidden: true,
+      };
+      return Cesium3DTilesTester.loadTileset(
+        scene,
+        noBatchIdsUrl,
+        tilesetOptions
+      ).then(function (tileset) {
+        Cesium3DTilesTester.expectRender(scene, tileset);
+      });
+    });
+
+    it("does not render when tileset starts hidden and tileset.preloadWhenHidden is false", function () {
+      setCamera(centerLongitude, centerLatitude, 15.0);
+      const tilesetOptions = {
+        show: false,
+        preloadWhenHidden: false,
+      };
+      return Cesium3DTilesTester.loadTileset(
+        scene,
+        noBatchIdsUrl,
+        tilesetOptions
+      ).then(function (tileset) {
+        Cesium3DTilesTester.expectRenderBlank(scene, tileset);
+      });
+    });
+
     describe("geoJSON", function () {
       function rendersGeoJson(url) {
         setCamera(centerLongitude, centerLatitude, 1.0);


### PR DESCRIPTION
If a tileset started with `show: false` (but `preloadWhenHidden: true`), and then later the tileset was toggled on, `ModelExperimental` would stay hidden. 

This was due to a line that set `model.show = tileset.show` in the constructor. Thus, the model was being hidden from the start, but nothing set it visible again when `tileset.show` was set to true.

[Sandcastle for testing](http://localhost:8080/Apps/Sandcastle/index.html#c=dVJNb9swDP0rgneoDQRyhhXFkLrBtm6HAi1aLMZ28UWR6FQYLQaS7PQD/e+l7DRot04XWXzvkY+kNbkQxWBhB16cCQc7cQ7B9p38NcbyJtPj+5xcVNaBb7KZeGycEBG858iNp8Ea8IsXofagIvwmj6aeKHkxa9xTcdq4xumxYLQIAeLbitP16Xs9gflYpSzBqTXCFRnAH3db8LYDtoILEX0Ps8TpPR6qX5D7CYF6r0G2nrqvgVNdmPx4/vnkpBjp4ZZ2C9EqDHCwtTckQ7xH+L+tVYInY5qQuGmeT/rIjz607ZzP8fyoaLJD3mmyMmhwILfs3UY7QJDKmHxfMxH3tAeirqbXQONWyhmtQkRIopoI18p/62Mkx8upabNhw6PttJm2dzpahor9kl764p65rTSy09FcNsuqUbVMtHS+2G5LPqZp5lKWEbot8iJDue71H06hQ0iOErUqX0srYwdhzdk7v4rQqEJgpO0RV/aBPS6rkvn/SJGUsW5zPYBHdZ9otx+Xl1NQSlmV/HxfGaeR/JX5GQ)

Ah I'm getting ahead of myself, I should make a unit test for `ModelExperimental3DTileContent`