### PR TITLE
Fixes duplicate imports in Specs

### DIFF
--- a/Specs/.eslintrc.json
+++ b/Specs/.eslintrc.json
@@ -4,8 +4,7 @@
         "jasmine": true
     },
     "rules": {
-        "no-self-assign": "off",
-        "no-duplicate-imports":"off"
+        "no-self-assign": "off"
     },
     "overrides": [
         {

--- a/Specs/BadGeometry.js
+++ b/Specs/BadGeometry.js
@@ -1,5 +1,4 @@
-import { queryToObject } from "../Source/Cesium.js";
-import { RuntimeError } from "../Source/Cesium.js";
+import { queryToObject, RuntimeError } from "../../Source/Cesium.js";
 
 function BadGeometry() {
   this._workerName = "../../Specs/TestWorkers/createBadGeometry";

--- a/Specs/Cesium3DTilesTester.js
+++ b/Specs/Cesium3DTilesTester.js
@@ -1,14 +1,17 @@
-import { Cartesian2 } from "../Source/Cesium.js";
-import { Color } from "../Source/Cesium.js";
-import { defaultValue } from "../Source/Cesium.js";
-import { defined } from "../Source/Cesium.js";
-import { JulianDate } from "../Source/Cesium.js";
-import { ImageBasedLighting } from "../Source/Cesium.js";
-import { Resource } from "../Source/Cesium.js";
-import { Cesium3DTileContentFactory } from "../Source/Cesium.js";
-import { Cesium3DTileset } from "../Source/Cesium.js";
-import { TileBoundingSphere } from "../Source/Cesium.js";
-import { RuntimeError } from "../Source/Cesium.js";
+import {
+  Cartesian2,
+  Color,
+  defaultValue,
+  defined,
+  JulianDate,
+  ImageBasedLighting,
+  Resource,
+  Cesium3DTileContentFactory,
+  Cesium3DTileset,
+  TileBoundingSphere,
+  RuntimeError,
+} from "../../Source/Cesium.js";
+
 import pollToPromise from "./pollToPromise.js";
 
 const mockTile = {

--- a/Specs/Core/ApproximateTerrainHeightsSpec.js
+++ b/Specs/Core/ApproximateTerrainHeightsSpec.js
@@ -1,7 +1,10 @@
-import { ApproximateTerrainHeights } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
+import {
+  ApproximateTerrainHeights,
+  Cartesian3,
+  Rectangle,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
 
 describe("Core/ApproximateTerrainHeights", function () {
   beforeAll(function () {

--- a/Specs/Core/ArcGISTiledElevationTerrainProviderSpec.js
+++ b/Specs/Core/ArcGISTiledElevationTerrainProviderSpec.js
@@ -1,14 +1,18 @@
-import { ArcGISTiledElevationTerrainProvider } from "../../Source/Cesium.js";
-import { DefaultProxy } from "../../Source/Cesium.js";
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
-import { HeightmapTerrainData } from "../../Source/Cesium.js";
+import {
+  ArcGISTiledElevationTerrainProvider,
+  DefaultProxy,
+  GeographicTilingScheme,
+  HeightmapTerrainData,
+  Request,
+  RequestScheduler,
+  Resource,
+  RuntimeError,
+  TerrainProvider,
+  WebMercatorTilingScheme,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Request } from "../../Source/Cesium.js";
-import { RequestScheduler } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { RuntimeError } from "../../Source/Cesium.js";
-import { TerrainProvider } from "../../Source/Cesium.js";
-import { WebMercatorTilingScheme } from "../../Source/Cesium.js";
+
 import pollToPromise from "../pollToPromise.js";
 
 describe("Core/ArcGISTiledElevationTerrainProvider", function () {

--- a/Specs/Core/AttributeCompressionSpec.js
+++ b/Specs/Core/AttributeCompressionSpec.js
@@ -2,12 +2,12 @@ import {
   AttributeCompression,
   AttributeType,
   ComponentDatatype,
-} from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartesian4 } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { Math as CesiumMath } from "../../Source/Cesium.js";
+  Cartesian2,
+  Cartesian3,
+  Cartesian4,
+  defined,
+  Math as CesiumMath,
+} from "../../../Source/Cesium.js";
 
 describe("Core/AttributeCompression", function () {
   const negativeUnitZ = new Cartesian3(0.0, 0.0, -1.0);

--- a/Specs/Core/AxisAlignedBoundingBoxSpec.js
+++ b/Specs/Core/AxisAlignedBoundingBoxSpec.js
@@ -1,7 +1,9 @@
-import { AxisAlignedBoundingBox } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Intersect } from "../../Source/Cesium.js";
-import { Plane } from "../../Source/Cesium.js";
+import {
+  AxisAlignedBoundingBox,
+  Cartesian3,
+  Intersect,
+  Plane,
+} from "../../../Source/Cesium.js";
 
 describe("Core/AxisAlignedBoundingBox", function () {
   const positions = [

--- a/Specs/Core/BingMapsGeocoderServiceSpec.js
+++ b/Specs/Core/BingMapsGeocoderServiceSpec.js
@@ -1,6 +1,8 @@
-import { BingMapsGeocoderService } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
+import {
+  BingMapsGeocoderService,
+  Rectangle,
+  Resource,
+} from "../../../Source/Cesium.js";
 
 describe("Core/BingMapsGeocoderService", function () {
   afterAll(function () {

--- a/Specs/Core/BoundingRectangleSpec.js
+++ b/Specs/Core/BoundingRectangleSpec.js
@@ -1,9 +1,12 @@
-import { BoundingRectangle } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeographicProjection } from "../../Source/Cesium.js";
-import { Intersect } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
+import {
+  BoundingRectangle,
+  Cartesian2,
+  Ellipsoid,
+  GeographicProjection,
+  Intersect,
+  Rectangle,
+} from "../../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/BoundingRectangle", function () {

--- a/Specs/Core/BoundingSphereSpec.js
+++ b/Specs/Core/BoundingSphereSpec.js
@@ -1,17 +1,21 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { EncodedCartesian3 } from "../../Source/Cesium.js";
-import { GeographicProjection } from "../../Source/Cesium.js";
-import { Intersect } from "../../Source/Cesium.js";
-import { Interval } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Cartesian3,
+  Cartographic,
+  Ellipsoid,
+  EncodedCartesian3,
+  GeographicProjection,
+  Intersect,
+  Interval,
+  Matrix4,
+  OrientedBoundingBox,
+  Plane,
+  Quaternion,
+  Rectangle,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { OrientedBoundingBox } from "../../Source/Cesium.js";
-import { Plane } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/BoundingSphere", function () {

--- a/Specs/Core/BoxGeometrySpec.js
+++ b/Specs/Core/BoxGeometrySpec.js
@@ -1,8 +1,11 @@
-import { AxisAlignedBoundingBox } from "../../Source/Cesium.js";
-import { BoxGeometry } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { GeometryOffsetAttribute } from "../../Source/Cesium.js";
-import { VertexFormat } from "../../Source/Cesium.js";
+import {
+  AxisAlignedBoundingBox,
+  BoxGeometry,
+  Cartesian3,
+  GeometryOffsetAttribute,
+  VertexFormat,
+} from "../../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/BoxGeometry", function () {

--- a/Specs/Core/BoxOutlineGeometrySpec.js
+++ b/Specs/Core/BoxOutlineGeometrySpec.js
@@ -1,7 +1,10 @@
-import { AxisAlignedBoundingBox } from "../../Source/Cesium.js";
-import { BoxOutlineGeometry } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { GeometryOffsetAttribute } from "../../Source/Cesium.js";
+import {
+  AxisAlignedBoundingBox,
+  BoxOutlineGeometry,
+  Cartesian3,
+  GeometryOffsetAttribute,
+} from "../../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/BoxOutlineGeometry", function () {

--- a/Specs/Core/Cartesian2Spec.js
+++ b/Specs/Core/Cartesian2Spec.js
@@ -1,4 +1,5 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
+import { Cartesian2 } from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
 import createPackableArraySpecs from "../createPackableArraySpecs.js";
 import createPackableSpecs from "../createPackableSpecs.js";

--- a/Specs/Core/Cartesian3Spec.js
+++ b/Specs/Core/Cartesian3Spec.js
@@ -1,6 +1,5 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
+import { Cartesian3, Cartographic, Ellipsoid } from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
 import createPackableArraySpecs from "../createPackableArraySpecs.js";
 import createPackableSpecs from "../createPackableSpecs.js";

--- a/Specs/Core/Cartesian4Spec.js
+++ b/Specs/Core/Cartesian4Spec.js
@@ -1,5 +1,5 @@
-import { Cartesian4 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
+import { Cartesian4, Color } from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
 import createPackableArraySpecs from "../createPackableArraySpecs.js";
 import createPackableSpecs from "../createPackableSpecs.js";

--- a/Specs/Core/CartographicGeocoderServiceSpec.js
+++ b/Specs/Core/CartographicGeocoderServiceSpec.js
@@ -1,5 +1,7 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { CartographicGeocoderService } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  CartographicGeocoderService,
+} from "../../../Source/Cesium.js";
 
 describe("Core/CartographicGeocoderService", function () {
   const service = new CartographicGeocoderService();

--- a/Specs/Core/CartographicSpec.js
+++ b/Specs/Core/CartographicSpec.js
@@ -1,6 +1,5 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
+import { Cartesian3, Cartographic, Ellipsoid } from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
 
 describe("Core/Cartographic", function () {

--- a/Specs/Core/CatmullRomSplineSpec.js
+++ b/Specs/Core/CatmullRomSplineSpec.js
@@ -1,6 +1,9 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { CatmullRomSpline } from "../../Source/Cesium.js";
-import { HermiteSpline } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  CatmullRomSpline,
+  HermiteSpline,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
 
 describe("Core/CatmullRomSpline", function () {

--- a/Specs/Core/CesiumTerrainProviderSpec.js
+++ b/Specs/Core/CesiumTerrainProviderSpec.js
@@ -1,15 +1,19 @@
-import { CesiumTerrainProvider } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
-import { getAbsoluteUri } from "../../Source/Cesium.js";
-import { HeightmapTerrainData } from "../../Source/Cesium.js";
-import { IonResource } from "../../Source/Cesium.js";
+import {
+  CesiumTerrainProvider,
+  Ellipsoid,
+  GeographicTilingScheme,
+  getAbsoluteUri,
+  HeightmapTerrainData,
+  IonResource,
+  QuantizedMeshTerrainData,
+  Request,
+  RequestScheduler,
+  Resource,
+  TerrainProvider,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { QuantizedMeshTerrainData } from "../../Source/Cesium.js";
-import { Request } from "../../Source/Cesium.js";
-import { RequestScheduler } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { TerrainProvider } from "../../Source/Cesium.js";
+
 import pollToPromise from "../pollToPromise.js";
 
 describe("Core/CesiumTerrainProvider", function () {

--- a/Specs/Core/CircleGeometrySpec.js
+++ b/Specs/Core/CircleGeometrySpec.js
@@ -1,8 +1,12 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { CircleGeometry } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  CircleGeometry,
+  Ellipsoid,
+  VertexFormat,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { VertexFormat } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/CircleGeometry", function () {

--- a/Specs/Core/CircleOutlineGeometrySpec.js
+++ b/Specs/Core/CircleOutlineGeometrySpec.js
@@ -1,6 +1,9 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { CircleOutlineGeometry } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  CircleOutlineGeometry,
+  Ellipsoid,
+} from "../../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/CircleOutlineGeometry", function () {

--- a/Specs/Core/ClockSpec.js
+++ b/Specs/Core/ClockSpec.js
@@ -1,8 +1,10 @@
-import { Clock } from "../../Source/Cesium.js";
-import { ClockRange } from "../../Source/Cesium.js";
-import { ClockStep } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  Clock,
+  ClockRange,
+  ClockStep,
+  defined,
+  JulianDate,
+} from "../../../Source/Cesium.js";
 
 describe("Core/Clock", function () {
   it("sets default parameters when constructed", function () {

--- a/Specs/Core/ColorGeometryInstanceAttributeSpec.js
+++ b/Specs/Core/ColorGeometryInstanceAttributeSpec.js
@@ -1,6 +1,8 @@
-import { Color } from "../../Source/Cesium.js";
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { ComponentDatatype } from "../../Source/Cesium.js";
+import {
+  Color,
+  ColorGeometryInstanceAttribute,
+  ComponentDatatype,
+} from "../../../Source/Cesium.js";
 
 describe("Core/ColorGeometryInstanceAttribute", function () {
   it("constructor", function () {

--- a/Specs/Core/ColorSpec.js
+++ b/Specs/Core/ColorSpec.js
@@ -1,5 +1,5 @@
-import { Cartesian4 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
+import { Cartesian4, Color } from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
 import createPackableSpecs from "../createPackableSpecs.js";
 

--- a/Specs/Core/ConstantSplineSpec.js
+++ b/Specs/Core/ConstantSplineSpec.js
@@ -1,6 +1,8 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { ConstantSpline } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  ConstantSpline,
+  Quaternion,
+} from "../../../Source/Cesium.js";
 
 describe("Core/ConstantSpline", function () {
   it("constructor throws without value", function () {

--- a/Specs/Core/CoplanarPolygonGeometrySpec.js
+++ b/Specs/Core/CoplanarPolygonGeometrySpec.js
@@ -1,9 +1,13 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { CoplanarPolygonGeometry } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Cartesian2,
+  CoplanarPolygonGeometry,
+  Ellipsoid,
+  VertexFormat,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { VertexFormat } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/CoplanarPolygonGeometry", function () {

--- a/Specs/Core/CoplanarPolygonOutlineGeometrySpec.js
+++ b/Specs/Core/CoplanarPolygonOutlineGeometrySpec.js
@@ -1,5 +1,8 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { CoplanarPolygonOutlineGeometry } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  CoplanarPolygonOutlineGeometry,
+} from "../../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/CoplanarPolygonOutlineGeometry", function () {

--- a/Specs/Core/CorridorGeometrySpec.js
+++ b/Specs/Core/CorridorGeometrySpec.js
@@ -1,11 +1,15 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { CornerType } from "../../Source/Cesium.js";
-import { CorridorGeometry } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeometryOffsetAttribute } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  CornerType,
+  CorridorGeometry,
+  Ellipsoid,
+  GeometryOffsetAttribute,
+  Rectangle,
+  VertexFormat,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { VertexFormat } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/CorridorGeometry", function () {

--- a/Specs/Core/CorridorOutlineGeometrySpec.js
+++ b/Specs/Core/CorridorOutlineGeometrySpec.js
@@ -1,8 +1,11 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { CornerType } from "../../Source/Cesium.js";
-import { CorridorOutlineGeometry } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeometryOffsetAttribute } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  CornerType,
+  CorridorOutlineGeometry,
+  Ellipsoid,
+  GeometryOffsetAttribute,
+} from "../../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/CorridorOutlineGeometry", function () {

--- a/Specs/Core/CubicRealPolynomialSpec.js
+++ b/Specs/Core/CubicRealPolynomialSpec.js
@@ -1,4 +1,5 @@
-import { CubicRealPolynomial } from "../../Source/Cesium.js";
+import { CubicRealPolynomial } from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
 
 describe("Core/CubicRealPolynomial", function () {

--- a/Specs/Core/CullingVolumeSpec.js
+++ b/Specs/Core/CullingVolumeSpec.js
@@ -1,9 +1,11 @@
-import { AxisAlignedBoundingBox } from "../../Source/Cesium.js";
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { CullingVolume } from "../../Source/Cesium.js";
-import { Intersect } from "../../Source/Cesium.js";
-import { PerspectiveFrustum } from "../../Source/Cesium.js";
+import {
+  AxisAlignedBoundingBox,
+  BoundingSphere,
+  Cartesian3,
+  CullingVolume,
+  Intersect,
+  PerspectiveFrustum,
+} from "../../../Source/Cesium.js";
 
 describe("Core/CullingVolume", function () {
   let cullingVolume;

--- a/Specs/Core/CustomHeightmapTerrainProviderSpec.js
+++ b/Specs/Core/CustomHeightmapTerrainProviderSpec.js
@@ -1,6 +1,8 @@
-import { CustomHeightmapTerrainProvider } from "../../Source/Cesium.js";
-import { TerrainProvider } from "../../Source/Cesium.js";
-import { WebMercatorTilingScheme } from "../../Source/Cesium.js";
+import {
+  CustomHeightmapTerrainProvider,
+  TerrainProvider,
+  WebMercatorTilingScheme,
+} from "../../../Source/Cesium.js";
 
 describe("Core/CustomHeightmapTerrainProvider", function () {
   it("conforms to TerrainProvider interface", function () {

--- a/Specs/Core/CylinderGeometrySpec.js
+++ b/Specs/Core/CylinderGeometrySpec.js
@@ -1,6 +1,9 @@
-import { CylinderGeometry } from "../../Source/Cesium.js";
-import { GeometryOffsetAttribute } from "../../Source/Cesium.js";
-import { VertexFormat } from "../../Source/Cesium.js";
+import {
+  CylinderGeometry,
+  GeometryOffsetAttribute,
+  VertexFormat,
+} from "../../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/CylinderGeometry", function () {

--- a/Specs/Core/CylinderOutlineGeometrySpec.js
+++ b/Specs/Core/CylinderOutlineGeometrySpec.js
@@ -1,5 +1,8 @@
-import { CylinderOutlineGeometry } from "../../Source/Cesium.js";
-import { GeometryOffsetAttribute } from "../../Source/Cesium.js";
+import {
+  CylinderOutlineGeometry,
+  GeometryOffsetAttribute,
+} from "../../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/CylinderOutlineGeometry", function () {

--- a/Specs/Core/DistanceDisplayConditionGeometryInstanceAttributeSpec.js
+++ b/Specs/Core/DistanceDisplayConditionGeometryInstanceAttributeSpec.js
@@ -1,6 +1,8 @@
-import { ComponentDatatype } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { DistanceDisplayConditionGeometryInstanceAttribute } from "../../Source/Cesium.js";
+import {
+  ComponentDatatype,
+  DistanceDisplayCondition,
+  DistanceDisplayConditionGeometryInstanceAttribute,
+} from "../../../Source/Cesium.js";
 
 describe("Core/DistanceDisplayConditionGeometryInstanceAttribute", function () {
   it("constructor", function () {

--- a/Specs/Core/EarthOrientationParametersSpec.js
+++ b/Specs/Core/EarthOrientationParametersSpec.js
@@ -1,7 +1,9 @@
-import { defined } from "../../Source/Cesium.js";
-import { EarthOrientationParameters } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { TimeStandard } from "../../Source/Cesium.js";
+import {
+  defined,
+  EarthOrientationParameters,
+  JulianDate,
+  TimeStandard,
+} from "../../../Source/Cesium.js";
 
 describe("Core/EarthOrientationParameters", function () {
   let officialLeapSeconds;

--- a/Specs/Core/EllipseGeometrySpec.js
+++ b/Specs/Core/EllipseGeometrySpec.js
@@ -1,10 +1,14 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { EllipseGeometry } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeometryOffsetAttribute } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  EllipseGeometry,
+  Ellipsoid,
+  GeometryOffsetAttribute,
+  Rectangle,
+  VertexFormat,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { VertexFormat } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/EllipseGeometry", function () {

--- a/Specs/Core/EllipseOutlineGeometrySpec.js
+++ b/Specs/Core/EllipseOutlineGeometrySpec.js
@@ -1,7 +1,10 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { EllipseOutlineGeometry } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeometryOffsetAttribute } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  EllipseOutlineGeometry,
+  Ellipsoid,
+  GeometryOffsetAttribute,
+} from "../../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/EllipseOutlineGeometry", function () {

--- a/Specs/Core/EllipsoidGeodesicSpec.js
+++ b/Specs/Core/EllipsoidGeodesicSpec.js
@@ -1,6 +1,9 @@
-import { Cartographic } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { EllipsoidGeodesic } from "../../Source/Cesium.js";
+import {
+  Cartographic,
+  Ellipsoid,
+  EllipsoidGeodesic,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
 
 describe("Core/EllipsoidGeodesic", function () {

--- a/Specs/Core/EllipsoidGeometrySpec.js
+++ b/Specs/Core/EllipsoidGeometrySpec.js
@@ -1,8 +1,12 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { EllipsoidGeometry } from "../../Source/Cesium.js";
-import { GeometryOffsetAttribute } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  EllipsoidGeometry,
+  GeometryOffsetAttribute,
+  VertexFormat,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { VertexFormat } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/EllipsoidGeometry", function () {

--- a/Specs/Core/EllipsoidOutlineGeometrySpec.js
+++ b/Specs/Core/EllipsoidOutlineGeometrySpec.js
@@ -1,6 +1,9 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { EllipsoidOutlineGeometry } from "../../Source/Cesium.js";
-import { GeometryOffsetAttribute } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  EllipsoidOutlineGeometry,
+  GeometryOffsetAttribute,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
 import createPackableSpecs from "../createPackableSpecs.js";
 

--- a/Specs/Core/EllipsoidRhumbLineSpec.js
+++ b/Specs/Core/EllipsoidRhumbLineSpec.js
@@ -1,8 +1,11 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { EllipsoidGeodesic } from "../../Source/Cesium.js";
-import { EllipsoidRhumbLine } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Cartographic,
+  Ellipsoid,
+  EllipsoidGeodesic,
+  EllipsoidRhumbLine,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
 
 describe("Core/EllipsoidRhumbLine", function () {

--- a/Specs/Core/EllipsoidSpec.js
+++ b/Specs/Core/EllipsoidSpec.js
@@ -1,8 +1,12 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Cartographic,
+  Ellipsoid,
+  Rectangle,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/Ellipsoid", function () {

--- a/Specs/Core/EllipsoidTangentPlaneSpec.js
+++ b/Specs/Core/EllipsoidTangentPlaneSpec.js
@@ -1,7 +1,9 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { EllipsoidTangentPlane } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Ellipsoid,
+  EllipsoidTangentPlane,
+} from "../../../Source/Cesium.js";
 
 describe("Core/EllipsoidTangentPlane", function () {
   it("constructor defaults to WGS84", function () {

--- a/Specs/Core/EllipsoidTerrainProviderSpec.js
+++ b/Specs/Core/EllipsoidTerrainProviderSpec.js
@@ -1,5 +1,8 @@
-import { EllipsoidTerrainProvider } from "../../Source/Cesium.js";
-import { TerrainProvider } from "../../Source/Cesium.js";
+import {
+  EllipsoidTerrainProvider,
+  TerrainProvider,
+} from "../../../Source/Cesium.js";
+
 import createContext from "../createContext.js";
 
 describe(

--- a/Specs/Core/EllipsoidalOccluderSpec.js
+++ b/Specs/Core/EllipsoidalOccluderSpec.js
@@ -1,11 +1,14 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { EllipsoidalOccluder } from "../../Source/Cesium.js";
-import { IntersectionTests } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Cartesian3,
+  Ellipsoid,
+  EllipsoidalOccluder,
+  IntersectionTests,
+  Ray,
+  Rectangle,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Ray } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
 
 describe("Core/EllipsoidalOccluder", function () {
   it("uses ellipsoid", function () {

--- a/Specs/Core/EncodedCartesian3Spec.js
+++ b/Specs/Core/EncodedCartesian3Spec.js
@@ -1,5 +1,4 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { EncodedCartesian3 } from "../../Source/Cesium.js";
+import { Cartesian3, EncodedCartesian3 } from "../../../Source/Cesium.js";
 
 describe("Core/EncodedCartesian3", function () {
   it("construct with default values", function () {

--- a/Specs/Core/FrustumGeometrySpec.js
+++ b/Specs/Core/FrustumGeometrySpec.js
@@ -1,9 +1,13 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { FrustumGeometry } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  FrustumGeometry,
+  PerspectiveFrustum,
+  Quaternion,
+  VertexFormat,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { PerspectiveFrustum } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
-import { VertexFormat } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/FrustumGeometry", function () {

--- a/Specs/Core/FrustumOutlineGeometrySpec.js
+++ b/Specs/Core/FrustumOutlineGeometrySpec.js
@@ -1,9 +1,13 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { FrustumOutlineGeometry } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  FrustumOutlineGeometry,
+  PerspectiveFrustum,
+  Quaternion,
+  VertexFormat,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { PerspectiveFrustum } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
-import { VertexFormat } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/FrustumOutlineGeometry", function () {

--- a/Specs/Core/FullscreenSpec.js
+++ b/Specs/Core/FullscreenSpec.js
@@ -1,5 +1,4 @@
-import { FeatureDetection } from "../../Source/Cesium.js";
-import { Fullscreen } from "../../Source/Cesium.js";
+import { FeatureDetection, Fullscreen } from "../../../Source/Cesium.js";
 
 describe("Core/Fullscreen", function () {
   it("can tell if fullscreen is supported", function () {

--- a/Specs/Core/GeographicProjectionSpec.js
+++ b/Specs/Core/GeographicProjectionSpec.js
@@ -1,7 +1,10 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeographicProjection } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Cartographic,
+  Ellipsoid,
+  GeographicProjection,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
 
 describe("Core/GeographicProjection", function () {

--- a/Specs/Core/GeographicTilingSchemeSpec.js
+++ b/Specs/Core/GeographicTilingSchemeSpec.js
@@ -1,10 +1,13 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { GeographicProjection } from "../../Source/Cesium.js";
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartographic,
+  GeographicProjection,
+  GeographicTilingScheme,
+  Rectangle,
+  TilingScheme,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { TilingScheme } from "../../Source/Cesium.js";
 
 describe("Core/GeographicTilingScheme", function () {
   it("conforms to TilingScheme interface.", function () {

--- a/Specs/Core/GeometryAttributeSpec.js
+++ b/Specs/Core/GeometryAttributeSpec.js
@@ -1,5 +1,7 @@
-import { ComponentDatatype } from "../../Source/Cesium.js";
-import { GeometryAttribute } from "../../Source/Cesium.js";
+import {
+  ComponentDatatype,
+  GeometryAttribute,
+} from "../../../Source/Cesium.js";
 
 describe("Core/GeometryAttribute", function () {
   it("constructor", function () {

--- a/Specs/Core/GeometryInstanceAttributeSpec.js
+++ b/Specs/Core/GeometryInstanceAttributeSpec.js
@@ -1,5 +1,7 @@
-import { ComponentDatatype } from "../../Source/Cesium.js";
-import { GeometryInstanceAttribute } from "../../Source/Cesium.js";
+import {
+  ComponentDatatype,
+  GeometryInstanceAttribute,
+} from "../../../Source/Cesium.js";
 
 describe("Core/GeometryInstanceAttribute", function () {
   it("constructor", function () {

--- a/Specs/Core/GeometryInstanceSpec.js
+++ b/Specs/Core/GeometryInstanceSpec.js
@@ -1,12 +1,14 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { ComponentDatatype } from "../../Source/Cesium.js";
-import { Geometry } from "../../Source/Cesium.js";
-import { GeometryAttribute } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
-import { GeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { PrimitiveType } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Cartesian3,
+  ComponentDatatype,
+  Geometry,
+  GeometryAttribute,
+  GeometryInstance,
+  GeometryInstanceAttribute,
+  Matrix4,
+  PrimitiveType,
+} from "../../../Source/Cesium.js";
 
 describe("Core/GeometryInstance", function () {
   it("constructor", function () {

--- a/Specs/Core/GeometryPipelineSpec.js
+++ b/Specs/Core/GeometryPipelineSpec.js
@@ -1,24 +1,27 @@
-import { AttributeCompression } from "../../Source/Cesium.js";
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { BoxGeometry } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { ComponentDatatype } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { EllipsoidGeometry } from "../../Source/Cesium.js";
-import { EncodedCartesian3 } from "../../Source/Cesium.js";
-import { GeographicProjection } from "../../Source/Cesium.js";
-import { Geometry } from "../../Source/Cesium.js";
-import { GeometryAttribute } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
-import { GeometryPipeline } from "../../Source/Cesium.js";
-import { GeometryType } from "../../Source/Cesium.js";
+import {
+  AttributeCompression,
+  BoundingSphere,
+  BoxGeometry,
+  Cartesian2,
+  Cartesian3,
+  ComponentDatatype,
+  Ellipsoid,
+  EllipsoidGeometry,
+  EncodedCartesian3,
+  GeographicProjection,
+  Geometry,
+  GeometryAttribute,
+  GeometryInstance,
+  GeometryPipeline,
+  GeometryType,
+  Matrix4,
+  PolygonGeometry,
+  PrimitiveType,
+  Tipsify,
+  VertexFormat,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { PolygonGeometry } from "../../Source/Cesium.js";
-import { PrimitiveType } from "../../Source/Cesium.js";
-import { Tipsify } from "../../Source/Cesium.js";
-import { VertexFormat } from "../../Source/Cesium.js";
 
 describe("Core/GeometryPipeline", function () {
   it("converts triangles to wireframe in place", function () {

--- a/Specs/Core/GeometrySpec.js
+++ b/Specs/Core/GeometrySpec.js
@@ -1,13 +1,16 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { ComponentDatatype } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { Geometry } from "../../Source/Cesium.js";
-import { GeometryAttribute } from "../../Source/Cesium.js";
-import { GeometryType } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Cartesian3,
+  ComponentDatatype,
+  Ellipsoid,
+  Geometry,
+  GeometryAttribute,
+  GeometryType,
+  PrimitiveType,
+  Rectangle,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { PrimitiveType } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
 
 describe("Core/Geometry", function () {
   it("constructor", function () {

--- a/Specs/Core/GoogleEarthEnterpriseMetadataSpec.js
+++ b/Specs/Core/GoogleEarthEnterpriseMetadataSpec.js
@@ -1,11 +1,14 @@
-import { decodeGoogleEarthEnterpriseData } from "../../Source/Cesium.js";
-import { defaultValue } from "../../Source/Cesium.js";
-import { GoogleEarthEnterpriseMetadata } from "../../Source/Cesium.js";
-import { GoogleEarthEnterpriseTileInformation } from "../../Source/Cesium.js";
+import {
+  decodeGoogleEarthEnterpriseData,
+  defaultValue,
+  GoogleEarthEnterpriseMetadata,
+  GoogleEarthEnterpriseTileInformation,
+  Request,
+  Resource,
+  RuntimeError,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Request } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { RuntimeError } from "../../Source/Cesium.js";
 
 describe("Core/GoogleEarthEnterpriseMetadata", function () {
   it("tileXYToQuadKey", function () {

--- a/Specs/Core/GoogleEarthEnterpriseTerrainDataSpec.js
+++ b/Specs/Core/GoogleEarthEnterpriseTerrainDataSpec.js
@@ -1,12 +1,15 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
-import { GoogleEarthEnterpriseTerrainData } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Cartographic,
+  Ellipsoid,
+  GeographicTilingScheme,
+  GoogleEarthEnterpriseTerrainData,
+  Rectangle,
+  TerrainData,
+  TerrainMesh,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { TerrainData } from "../../Source/Cesium.js";
-import { TerrainMesh } from "../../Source/Cesium.js";
 
 describe("Core/GoogleEarthEnterpriseTerrainData", function () {
   const sizeOfUint8 = Uint8Array.BYTES_PER_ELEMENT;

--- a/Specs/Core/GoogleEarthEnterpriseTerrainProviderSpec.js
+++ b/Specs/Core/GoogleEarthEnterpriseTerrainProviderSpec.js
@@ -1,15 +1,19 @@
-import { defaultValue } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
-import { GoogleEarthEnterpriseMetadata } from "../../Source/Cesium.js";
-import { GoogleEarthEnterpriseTerrainData } from "../../Source/Cesium.js";
-import { GoogleEarthEnterpriseTerrainProvider } from "../../Source/Cesium.js";
-import { GoogleEarthEnterpriseTileInformation } from "../../Source/Cesium.js";
+import {
+  defaultValue,
+  Ellipsoid,
+  GeographicTilingScheme,
+  GoogleEarthEnterpriseMetadata,
+  GoogleEarthEnterpriseTerrainData,
+  GoogleEarthEnterpriseTerrainProvider,
+  GoogleEarthEnterpriseTileInformation,
+  Request,
+  RequestScheduler,
+  Resource,
+  TerrainProvider,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Request } from "../../Source/Cesium.js";
-import { RequestScheduler } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { TerrainProvider } from "../../Source/Cesium.js";
+
 import pollToPromise from "../pollToPromise.js";
 
 describe("Core/GoogleEarthEnterpriseTerrainProvider", function () {

--- a/Specs/Core/GroundPolylineGeometrySpec.js
+++ b/Specs/Core/GroundPolylineGeometrySpec.js
@@ -1,12 +1,16 @@
-import { ApproximateTerrainHeights } from "../../Source/Cesium.js";
-import { ArcType } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeographicProjection } from "../../Source/Cesium.js";
-import { GroundPolylineGeometry } from "../../Source/Cesium.js";
+import {
+  ApproximateTerrainHeights,
+  ArcType,
+  Cartesian3,
+  Cartographic,
+  Ellipsoid,
+  GeographicProjection,
+  GroundPolylineGeometry,
+  WebMercatorProjection,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { WebMercatorProjection } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/GroundPolylineGeometry", function () {

--- a/Specs/Core/HeadingPitchRollSpec.js
+++ b/Specs/Core/HeadingPitchRollSpec.js
@@ -1,6 +1,6 @@
-import { HeadingPitchRoll } from "../../Source/Cesium.js";
+import { HeadingPitchRoll, Quaternion } from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
 
 describe("Core/HeadingPitchRoll", function () {
   const deg2rad = CesiumMath.RADIANS_PER_DEGREE;

--- a/Specs/Core/HeightmapTerrainDataSpec.js
+++ b/Specs/Core/HeightmapTerrainDataSpec.js
@@ -1,8 +1,10 @@
-import { defined } from "../../Source/Cesium.js";
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
-import { HeightmapEncoding } from "../../Source/Cesium.js";
-import { HeightmapTerrainData } from "../../Source/Cesium.js";
-import { TerrainData } from "../../Source/Cesium.js";
+import {
+  defined,
+  GeographicTilingScheme,
+  HeightmapEncoding,
+  HeightmapTerrainData,
+  TerrainData,
+} from "../../../Source/Cesium.js";
 
 describe("Core/HeightmapTerrainData", function () {
   it("conforms to TerrainData interface", function () {

--- a/Specs/Core/HermiteSplineSpec.js
+++ b/Specs/Core/HermiteSplineSpec.js
@@ -1,7 +1,10 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { HermiteSpline } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  HermiteSpline,
+  Quaternion,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
 
 describe("Core/HermiteSpline", function () {
   let points;

--- a/Specs/Core/HilbertOrderSpec.js
+++ b/Specs/Core/HilbertOrderSpec.js
@@ -1,5 +1,4 @@
-import { FeatureDetection } from "../../Source/Cesium.js";
-import { HilbertOrder } from "../../Source/Cesium.js";
+import { FeatureDetection, HilbertOrder } from "../../../Source/Cesium.js";
 
 describe("Core/HilbertOrder", function () {
   /* eslint-disable no-undef */

--- a/Specs/Core/Iau2000OrientationSpec.js
+++ b/Specs/Core/Iau2000OrientationSpec.js
@@ -1,6 +1,8 @@
-import { Iau2000Orientation } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { TimeStandard } from "../../Source/Cesium.js";
+import {
+  Iau2000Orientation,
+  JulianDate,
+  TimeStandard,
+} from "../../../Source/Cesium.js";
 
 describe("Core/Iau2000Orientation", function () {
   it("compute moon", function () {

--- a/Specs/Core/Iau2006XysDataSpec.js
+++ b/Specs/Core/Iau2006XysDataSpec.js
@@ -1,7 +1,10 @@
-import { buildModuleUrl } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { Iau2006XysData } from "../../Source/Cesium.js";
-import { Iau2006XysSample } from "../../Source/Cesium.js";
+import {
+  buildModuleUrl,
+  defined,
+  Iau2006XysData,
+  Iau2006XysSample,
+} from "../../../Source/Cesium.js";
+
 import pollToPromise from "../pollToPromise.js";
 
 describe("Core/Iau2006XysData", function () {

--- a/Specs/Core/IauOrientationAxesSpec.js
+++ b/Specs/Core/IauOrientationAxesSpec.js
@@ -1,9 +1,12 @@
-import { Iau2000Orientation } from "../../Source/Cesium.js";
-import { IauOrientationAxes } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  Iau2000Orientation,
+  IauOrientationAxes,
+  JulianDate,
+  Matrix3,
+  TimeStandard,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix3 } from "../../Source/Cesium.js";
-import { TimeStandard } from "../../Source/Cesium.js";
 
 describe("Core/IauOrientationAxes", function () {
   it("compute ICRF to Moon Fixed", function () {

--- a/Specs/Core/IndexDatatypeSpec.js
+++ b/Specs/Core/IndexDatatypeSpec.js
@@ -1,4 +1,5 @@
-import { IndexDatatype } from "../../Source/Cesium.js";
+import { IndexDatatype } from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
 
 describe("Core/IndexDatatype", function () {

--- a/Specs/Core/IntersectionTestsSpec.js
+++ b/Specs/Core/IntersectionTestsSpec.js
@@ -1,10 +1,13 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { IntersectionTests } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Cartesian3,
+  Ellipsoid,
+  IntersectionTests,
+  Plane,
+  Ray,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Plane } from "../../Source/Cesium.js";
-import { Ray } from "../../Source/Cesium.js";
 
 describe("Core/IntersectionTests", function () {
   it("rayPlane intersects", function () {

--- a/Specs/Core/IonGeocoderServiceSpec.js
+++ b/Specs/Core/IonGeocoderServiceSpec.js
@@ -1,6 +1,9 @@
-import { GeocodeType } from "../../Source/Cesium.js";
-import { Ion } from "../../Source/Cesium.js";
-import { IonGeocoderService } from "../../Source/Cesium.js";
+import {
+  GeocodeType,
+  Ion,
+  IonGeocoderService,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe("Core/IonGeocoderService", function () {

--- a/Specs/Core/IonResourceSpec.js
+++ b/Specs/Core/IonResourceSpec.js
@@ -1,9 +1,11 @@
-import { defer } from "../../Source/Cesium.js";
-import { Ion } from "../../Source/Cesium.js";
-import { IonResource } from "../../Source/Cesium.js";
-import { RequestErrorEvent } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { RuntimeError } from "../../Source/Cesium.js";
+import {
+  defer,
+  Ion,
+  IonResource,
+  RequestErrorEvent,
+  Resource,
+  RuntimeError,
+} from "../../../Source/Cesium.js";
 
 describe("Core/IonResource", function () {
   const assetId = 123890213;

--- a/Specs/Core/JulianDateSpec.js
+++ b/Specs/Core/JulianDateSpec.js
@@ -1,8 +1,11 @@
-import { Iso8601 } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  Iso8601,
+  JulianDate,
+  TimeConstants,
+  TimeStandard,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { TimeConstants } from "../../Source/Cesium.js";
-import { TimeStandard } from "../../Source/Cesium.js";
 
 describe("Core/JulianDate", function () {
   // All exact Julian Dates found using NASA's Time Conversion Tool: http://ssd.jpl.nasa.gov/tc.cgi

--- a/Specs/Core/LeapSecondSpec.js
+++ b/Specs/Core/LeapSecondSpec.js
@@ -1,5 +1,4 @@
-import { JulianDate } from "../../Source/Cesium.js";
-import { LeapSecond } from "../../Source/Cesium.js";
+import { JulianDate, LeapSecond } from "../../../Source/Cesium.js";
 
 describe("Core/LeapSecond", function () {
   it("default constructor sets expected values", function () {

--- a/Specs/Core/LinearSplineSpec.js
+++ b/Specs/Core/LinearSplineSpec.js
@@ -1,5 +1,4 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { LinearSpline } from "../../Source/Cesium.js";
+import { Cartesian3, LinearSpline } from "../../../Source/Cesium.js";
 
 describe("Core/LinearSpline", function () {
   let times;

--- a/Specs/Core/Matrix2Spec.js
+++ b/Specs/Core/Matrix2Spec.js
@@ -1,6 +1,7 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
+import { Cartesian2, Matrix2 } from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix2 } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 import createPackableArraySpecs from "../createPackableArraySpecs.js";
 

--- a/Specs/Core/Matrix3Spec.js
+++ b/Specs/Core/Matrix3Spec.js
@@ -1,8 +1,12 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { HeadingPitchRoll } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  HeadingPitchRoll,
+  Matrix3,
+  Quaternion,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix3 } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 import createPackableArraySpecs from "../createPackableArraySpecs.js";
 

--- a/Specs/Core/Matrix4Spec.js
+++ b/Specs/Core/Matrix4Spec.js
@@ -1,11 +1,15 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartesian4 } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Cartesian4,
+  Matrix3,
+  Matrix4,
+  Quaternion,
+  TranslationRotationScale,
+  RuntimeError,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix3 } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
-import { TranslationRotationScale } from "../../Source/Cesium.js";
-import { RuntimeError } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 import createPackableArraySpecs from "../createPackableArraySpecs.js";
 

--- a/Specs/Core/OccluderSpec.js
+++ b/Specs/Core/OccluderSpec.js
@@ -1,10 +1,13 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Cartesian3,
+  Ellipsoid,
+  Occluder,
+  Rectangle,
+  Visibility,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Occluder } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { Visibility } from "../../Source/Cesium.js";
 
 describe("Core/Occluder", function () {
   it("throws an exception during construction (1 of 3)", function () {

--- a/Specs/Core/OpenCageGeocoderServiceSpec.js
+++ b/Specs/Core/OpenCageGeocoderServiceSpec.js
@@ -1,5 +1,4 @@
-import { OpenCageGeocoderService } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
+import { OpenCageGeocoderService, Resource } from "../../../Source/Cesium.js";
 
 describe("Core/OpenCageGeocoderService", function () {
   const endpoint = "https://api.opencagedata.com/geocode/v1/";

--- a/Specs/Core/OrientedBoundingBoxSpec.js
+++ b/Specs/Core/OrientedBoundingBoxSpec.js
@@ -1,16 +1,20 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartesian4 } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { Intersect } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Cartesian3,
+  Cartesian4,
+  Ellipsoid,
+  Intersect,
+  Matrix3,
+  Matrix4,
+  Occluder,
+  OrientedBoundingBox,
+  Plane,
+  Quaternion,
+  Rectangle,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix3 } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { Occluder } from "../../Source/Cesium.js";
-import { OrientedBoundingBox } from "../../Source/Cesium.js";
-import { Plane } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/OrientedBoundingBox", function () {

--- a/Specs/Core/OrthographicFrustumSpec.js
+++ b/Specs/Core/OrthographicFrustumSpec.js
@@ -1,9 +1,13 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartesian4 } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Cartesian4,
+  Matrix4,
+  OrthographicFrustum,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { OrthographicFrustum } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/OrthographicFrustum", function () {

--- a/Specs/Core/OrthographicOffCenterFrustumSpec.js
+++ b/Specs/Core/OrthographicOffCenterFrustumSpec.js
@@ -1,9 +1,12 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartesian4 } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Cartesian4,
+  Matrix4,
+  OrthographicOffCenterFrustum,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { OrthographicOffCenterFrustum } from "../../Source/Cesium.js";
 
 describe("Core/OrthographicOffCenterFrustum", function () {
   let frustum, planes;

--- a/Specs/Core/PeliasGeocoderServiceSpec.js
+++ b/Specs/Core/PeliasGeocoderServiceSpec.js
@@ -1,7 +1,9 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { GeocodeType } from "../../Source/Cesium.js";
-import { PeliasGeocoderService } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  GeocodeType,
+  PeliasGeocoderService,
+  Resource,
+} from "../../../Source/Cesium.js";
 
 describe("Core/PeliasGeocoderService", function () {
   it("constructor throws without url", function () {

--- a/Specs/Core/PerspectiveFrustumSpec.js
+++ b/Specs/Core/PerspectiveFrustumSpec.js
@@ -1,9 +1,13 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartesian4 } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Cartesian4,
+  Matrix4,
+  PerspectiveFrustum,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { PerspectiveFrustum } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/PerspectiveFrustum", function () {

--- a/Specs/Core/PerspectiveOffCenterFrustumSpec.js
+++ b/Specs/Core/PerspectiveOffCenterFrustumSpec.js
@@ -1,9 +1,12 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartesian4 } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Cartesian4,
+  Matrix4,
+  PerspectiveOffCenterFrustum,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { PerspectiveOffCenterFrustum } from "../../Source/Cesium.js";
 
 describe("Core/PerspectiveOffCenterFrustum", function () {
   let frustum, planes;

--- a/Specs/Core/PinBuilderSpec.js
+++ b/Specs/Core/PinBuilderSpec.js
@@ -1,6 +1,4 @@
-import { buildModuleUrl } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { PinBuilder } from "../../Source/Cesium.js";
+import { buildModuleUrl, Color, PinBuilder } from "../../../Source/Cesium.js";
 
 describe("Core/PinBuilder", function () {
   function getPinColor(canvas) {

--- a/Specs/Core/PixelFormatSpec.js
+++ b/Specs/Core/PixelFormatSpec.js
@@ -1,5 +1,4 @@
-import { PixelDatatype } from "../../Source/Cesium.js";
-import { PixelFormat } from "../../Source/Cesium.js";
+import { PixelDatatype, PixelFormat } from "../../../Source/Cesium.js";
 
 describe("Core/PixelFormat", function () {
   it("flipY works", function () {

--- a/Specs/Core/PlaneGeometrySpec.js
+++ b/Specs/Core/PlaneGeometrySpec.js
@@ -1,6 +1,9 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { PlaneGeometry } from "../../Source/Cesium.js";
-import { VertexFormat } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  PlaneGeometry,
+  VertexFormat,
+} from "../../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/PlaneGeometry", function () {

--- a/Specs/Core/PlaneSpec.js
+++ b/Specs/Core/PlaneSpec.js
@@ -1,9 +1,12 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartesian4 } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Cartesian4,
+  Matrix3,
+  Matrix4,
+  Plane,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix3 } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { Plane } from "../../Source/Cesium.js";
 
 describe("Core/Plane", function () {
   it("constructs", function () {

--- a/Specs/Core/PolygonGeometrySpec.js
+++ b/Specs/Core/PolygonGeometrySpec.js
@@ -1,15 +1,19 @@
-import { ArcType } from "../../Source/Cesium.js";
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeometryOffsetAttribute } from "../../Source/Cesium.js";
-import { GeometryPipeline } from "../../Source/Cesium.js";
+import {
+  ArcType,
+  BoundingSphere,
+  Cartesian2,
+  Cartesian3,
+  Cartographic,
+  Ellipsoid,
+  GeometryOffsetAttribute,
+  GeometryPipeline,
+  PolygonGeometry,
+  Rectangle,
+  VertexFormat,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { PolygonGeometry } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { VertexFormat } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/PolygonGeometry", function () {

--- a/Specs/Core/PolygonOutlineGeometrySpec.js
+++ b/Specs/Core/PolygonOutlineGeometrySpec.js
@@ -1,10 +1,14 @@
-import { ArcType } from "../../Source/Cesium.js";
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeometryOffsetAttribute } from "../../Source/Cesium.js";
+import {
+  ArcType,
+  BoundingSphere,
+  Cartesian3,
+  Ellipsoid,
+  GeometryOffsetAttribute,
+  PolygonOutlineGeometry,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { PolygonOutlineGeometry } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/PolygonOutlineGeometry", function () {

--- a/Specs/Core/PolygonPipelineSpec.js
+++ b/Specs/Core/PolygonPipelineSpec.js
@@ -1,9 +1,12 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Ellipsoid,
+  PolygonPipeline,
+  WindingOrder,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { PolygonPipeline } from "../../Source/Cesium.js";
-import { WindingOrder } from "../../Source/Cesium.js";
 
 describe("Core/PolygonPipeline", function () {
   beforeEach(function () {

--- a/Specs/Core/PolylineGeometrySpec.js
+++ b/Specs/Core/PolylineGeometrySpec.js
@@ -1,9 +1,12 @@
+import {
+  Cartesian3,
+  Color,
+  Ellipsoid,
+  PolylineGeometry,
+  VertexFormat,
+} from "../../../Source/Cesium.js";
 import { ArcType, defaultValue } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { PolylineGeometry } from "../../Source/Cesium.js";
-import { VertexFormat } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 import CesiumMath from "../../Source/Core/Math.js";
 

--- a/Specs/Core/PolylinePipelineSpec.js
+++ b/Specs/Core/PolylinePipelineSpec.js
@@ -1,8 +1,11 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Ellipsoid,
+  PolylinePipeline,
+  Transforms,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { PolylinePipeline } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
 
 describe("Core/PolylinePipeline", function () {
   it("wrapLongitude", function () {

--- a/Specs/Core/PolylineVolumeGeometrySpec.js
+++ b/Specs/Core/PolylineVolumeGeometrySpec.js
@@ -1,9 +1,12 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { CornerType } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { PolylineVolumeGeometry } from "../../Source/Cesium.js";
-import { VertexFormat } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  CornerType,
+  Ellipsoid,
+  PolylineVolumeGeometry,
+  VertexFormat,
+} from "../../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/PolylineVolumeGeometry", function () {

--- a/Specs/Core/PolylineVolumeOutlineGeometrySpec.js
+++ b/Specs/Core/PolylineVolumeOutlineGeometrySpec.js
@@ -1,8 +1,11 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { CornerType } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { PolylineVolumeOutlineGeometry } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  CornerType,
+  Ellipsoid,
+  PolylineVolumeOutlineGeometry,
+} from "../../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/PolylineVolumeOutlineGeometry", function () {

--- a/Specs/Core/QuadraticRealPolynomialSpec.js
+++ b/Specs/Core/QuadraticRealPolynomialSpec.js
@@ -1,5 +1,5 @@
+import { QuadraticRealPolynomial } from "../../../Source/Cesium.js";
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { QuadraticRealPolynomial } from "../../Source/Cesium.js";
 
 describe("Core/QuadraticRealPolynomial", function () {
   it("discriminant throws without a", function () {

--- a/Specs/Core/QuantizedMeshTerrainDataSpec.js
+++ b/Specs/Core/QuantizedMeshTerrainDataSpec.js
@@ -1,11 +1,14 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Cartesian3,
+  defined,
+  GeographicTilingScheme,
+  QuantizedMeshTerrainData,
+  TerrainData,
+  TerrainMesh,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { QuantizedMeshTerrainData } from "../../Source/Cesium.js";
-import { TerrainData } from "../../Source/Cesium.js";
-import { TerrainMesh } from "../../Source/Cesium.js";
 
 describe("Core/QuantizedMeshTerrainData", function () {
   it("conforms to TerrainData interface", function () {

--- a/Specs/Core/QuarticRealPolynomialSpec.js
+++ b/Specs/Core/QuarticRealPolynomialSpec.js
@@ -1,5 +1,5 @@
+import { QuarticRealPolynomial } from "../../../Source/Cesium.js";
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { QuarticRealPolynomial } from "../../Source/Cesium.js";
 
 describe("Core/QuarticRealPolynomial", function () {
   it("discriminant throws without a", function () {

--- a/Specs/Core/QuaternionSpec.js
+++ b/Specs/Core/QuaternionSpec.js
@@ -1,8 +1,12 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { HeadingPitchRoll } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  HeadingPitchRoll,
+  Matrix3,
+  Quaternion,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix3 } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/Quaternion", function () {

--- a/Specs/Core/QuaternionSplineSpec.js
+++ b/Specs/Core/QuaternionSplineSpec.js
@@ -1,7 +1,10 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Quaternion,
+  QuaternionSpline,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
-import { QuaternionSpline } from "../../Source/Cesium.js";
 
 describe("Core/QuaternionSpline", function () {
   let points;

--- a/Specs/Core/RaySpec.js
+++ b/Specs/Core/RaySpec.js
@@ -1,5 +1,4 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Ray } from "../../Source/Cesium.js";
+import { Cartesian3, Ray } from "../../../Source/Cesium.js";
 
 describe("Core/Ray", function () {
   it("default constructor create zero valued Ray", function () {

--- a/Specs/Core/RectangleCollisionCheckerSpec.js
+++ b/Specs/Core/RectangleCollisionCheckerSpec.js
@@ -1,5 +1,7 @@
-import { Rectangle } from "../../Source/Cesium.js";
-import { RectangleCollisionChecker } from "../../Source/Cesium.js";
+import {
+  Rectangle,
+  RectangleCollisionChecker,
+} from "../../../Source/Cesium.js";
 
 describe("Core/RectangleCollisionChecker", function () {
   const testRectangle1 = new Rectangle(0.0, 0.0, 1.0, 1.0);

--- a/Specs/Core/RectangleGeometrySpec.js
+++ b/Specs/Core/RectangleGeometrySpec.js
@@ -1,13 +1,17 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeographicProjection } from "../../Source/Cesium.js";
-import { GeometryOffsetAttribute } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Ellipsoid,
+  GeographicProjection,
+  GeometryOffsetAttribute,
+  Matrix2,
+  Rectangle,
+  RectangleGeometry,
+  VertexFormat,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix2 } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { RectangleGeometry } from "../../Source/Cesium.js";
-import { VertexFormat } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/RectangleGeometry", function () {

--- a/Specs/Core/RectangleOutlineGeometrySpec.js
+++ b/Specs/Core/RectangleOutlineGeometrySpec.js
@@ -1,12 +1,16 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeographicProjection } from "../../Source/Cesium.js";
-import { GeometryOffsetAttribute } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Ellipsoid,
+  GeographicProjection,
+  GeometryOffsetAttribute,
+  Matrix2,
+  Rectangle,
+  RectangleOutlineGeometry,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix2 } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { RectangleOutlineGeometry } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/RectangleOutlineGeometry", function () {

--- a/Specs/Core/RectangleSpec.js
+++ b/Specs/Core/RectangleSpec.js
@@ -1,8 +1,12 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Cartographic,
+  Ellipsoid,
+  Rectangle,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/Rectangle", function () {

--- a/Specs/Core/S2CellSpec.js
+++ b/Specs/Core/S2CellSpec.js
@@ -1,9 +1,12 @@
+import {
+  Cartesian3,
+  FeatureDetection,
+  S2Cell,
+} from "../../../Source/Cesium.js";
 /* eslint-disable new-cap */
 /* eslint-disable no-undef */
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { FeatureDetection } from "../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { S2Cell } from "../../Source/Cesium.js";
 
 describe("Core/S2Cell", function () {
   if (!FeatureDetection.supportsBigInt()) {

--- a/Specs/Core/ScreenSpaceEventHandlerSpec.js
+++ b/Specs/Core/ScreenSpaceEventHandlerSpec.js
@@ -1,11 +1,14 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { clone } from "../../Source/Cesium.js";
-import { combine } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { FeatureDetection } from "../../Source/Cesium.js";
-import { KeyboardEventModifier } from "../../Source/Cesium.js";
-import { ScreenSpaceEventHandler } from "../../Source/Cesium.js";
-import { ScreenSpaceEventType } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  clone,
+  combine,
+  defined,
+  FeatureDetection,
+  KeyboardEventModifier,
+  ScreenSpaceEventHandler,
+  ScreenSpaceEventType,
+} from "../../../Source/Cesium.js";
+
 import DomEventSimulator from "../DomEventSimulator.js";
 
 describe("Core/ScreenSpaceEventHandler", function () {

--- a/Specs/Core/ShowGeometryInstanceAttributeSpec.js
+++ b/Specs/Core/ShowGeometryInstanceAttributeSpec.js
@@ -1,5 +1,7 @@
-import { ComponentDatatype } from "../../Source/Cesium.js";
-import { ShowGeometryInstanceAttribute } from "../../Source/Cesium.js";
+import {
+  ComponentDatatype,
+  ShowGeometryInstanceAttribute,
+} from "../../../Source/Cesium.js";
 
 describe("Core/ShowGeometryInstanceAttribute", function () {
   it("constructor", function () {

--- a/Specs/Core/Simon1994PlanetaryPositionsSpec.js
+++ b/Specs/Core/Simon1994PlanetaryPositionsSpec.js
@@ -1,10 +1,12 @@
-import { defined } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix3 } from "../../Source/Cesium.js";
-import { Simon1994PlanetaryPositions as PlanetaryPositions } from "../../Source/Cesium.js";
-import { TimeStandard } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
+import {
+  defined,
+  JulianDate,
+  Matrix3,
+  Math as CesiumMath,
+  TimeStandard,
+  Transforms,
+  Simon1994PlanetaryPositions as PlanetaryPositions,
+} from "../../../Source/Cesium.js";
 
 describe("Core/Simon1994PlanetaryPositions", function () {
   // Values for the X Y and Z were found using the STK Components GeometryTransformer on the position of the

--- a/Specs/Core/SimplePolylineGeometrySpec.js
+++ b/Specs/Core/SimplePolylineGeometrySpec.js
@@ -1,11 +1,15 @@
-import { ArcType } from "../../Source/Cesium.js";
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
+import {
+  ArcType,
+  BoundingSphere,
+  Cartesian3,
+  Color,
+  Ellipsoid,
+  PrimitiveType,
+  SimplePolylineGeometry,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { PrimitiveType } from "../../Source/Cesium.js";
-import { SimplePolylineGeometry } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/SimplePolylineGeometry", function () {

--- a/Specs/Core/SphereGeometrySpec.js
+++ b/Specs/Core/SphereGeometrySpec.js
@@ -1,7 +1,11 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  SphereGeometry,
+  VertexFormat,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { SphereGeometry } from "../../Source/Cesium.js";
-import { VertexFormat } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/SphereGeometry", function () {

--- a/Specs/Core/SphereOutlineGeometrySpec.js
+++ b/Specs/Core/SphereOutlineGeometrySpec.js
@@ -1,4 +1,5 @@
-import { SphereOutlineGeometry } from "../../Source/Cesium.js";
+import { SphereOutlineGeometry } from "../../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 import { Math as CesiumMath } from "../../Source/Cesium.js";
 

--- a/Specs/Core/SphericalSpec.js
+++ b/Specs/Core/SphericalSpec.js
@@ -1,6 +1,6 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
+import { Cartesian3, Spherical } from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Spherical } from "../../Source/Cesium.js";
 
 describe("Core/Spherical", function () {
   //Mock object to make sure methods take non-sphericals.

--- a/Specs/Core/SplineSpec.js
+++ b/Specs/Core/SplineSpec.js
@@ -1,7 +1,9 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { HermiteSpline } from "../../Source/Cesium.js";
-import { Spline } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  HermiteSpline,
+  Spline,
+  Quaternion,
+} from "../../../Source/Cesium.js";
 
 describe("Core/Spline", function () {
   it("contructor throws", function () {

--- a/Specs/Core/SteppedSplineSpec.js
+++ b/Specs/Core/SteppedSplineSpec.js
@@ -1,6 +1,8 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { SteppedSpline } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  SteppedSpline,
+  Quaternion,
+} from "../../../Source/Cesium.js";
 
 describe("Core/SteppedSpline", function () {
   let times;

--- a/Specs/Core/TaskProcessorSpec.js
+++ b/Specs/Core/TaskProcessorSpec.js
@@ -1,6 +1,9 @@
-import { FeatureDetection } from "../../Source/Cesium.js";
-import { TaskProcessor } from "../../Source/Cesium.js";
-import { RuntimeError } from "../../Source/Cesium.js";
+import {
+  FeatureDetection,
+  TaskProcessor,
+  RuntimeError,
+} from "../../../Source/Cesium.js";
+
 import absolutize from "../absolutize.js";
 
 describe("Core/TaskProcessor", function () {

--- a/Specs/Core/TerrainEncodingSpec.js
+++ b/Specs/Core/TerrainEncodingSpec.js
@@ -1,14 +1,17 @@
-import { AttributeCompression } from "../../Source/Cesium.js";
-import { AxisAlignedBoundingBox } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
+import {
+  AttributeCompression,
+  AxisAlignedBoundingBox,
+  Cartesian2,
+  Cartesian3,
+  Ellipsoid,
+  Matrix4,
+  TerrainEncoding,
+  TerrainExaggeration,
+  TerrainQuantization,
+  Transforms,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { TerrainEncoding } from "../../Source/Cesium.js";
-import { TerrainExaggeration } from "../../Source/Cesium.js";
-import { TerrainQuantization } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
 
 describe("Core/TerrainEncoding", function () {
   let center;

--- a/Specs/Core/TileAvailabilitySpec.js
+++ b/Specs/Core/TileAvailabilitySpec.js
@@ -1,9 +1,11 @@
-import { Cartographic } from "../../Source/Cesium.js";
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { TileAvailability } from "../../Source/Cesium.js";
-import { WebMercatorTilingScheme } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
+import {
+  Cartographic,
+  GeographicTilingScheme,
+  Rectangle,
+  TileAvailability,
+  WebMercatorTilingScheme,
+  defined,
+} from "../../../Source/Cesium.js";
 
 describe("Core/TileAvailability", function () {
   const webMercator = new WebMercatorTilingScheme();

--- a/Specs/Core/TimeIntervalCollectionSpec.js
+++ b/Specs/Core/TimeIntervalCollectionSpec.js
@@ -1,9 +1,11 @@
-import { defaultValue } from "../../Source/Cesium.js";
-import { Iso8601 } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { TimeStandard } from "../../Source/Cesium.js";
+import {
+  defaultValue,
+  Iso8601,
+  JulianDate,
+  TimeInterval,
+  TimeIntervalCollection,
+  TimeStandard,
+} from "../../../Source/Cesium.js";
 
 describe("Core/TimeIntervalCollection", function () {
   function defaultDataCallback(interval, index) {

--- a/Specs/Core/TimeIntervalSpec.js
+++ b/Specs/Core/TimeIntervalSpec.js
@@ -1,5 +1,4 @@
-import { JulianDate } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
+import { JulianDate, TimeInterval } from "../../../Source/Cesium.js";
 
 describe("Core/TimeInterval", function () {
   function returnTrue() {

--- a/Specs/Core/TransformsSpec.js
+++ b/Specs/Core/TransformsSpec.js
@@ -1,20 +1,23 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartesian4 } from "../../Source/Cesium.js";
-import { EarthOrientationParameters } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeographicProjection } from "../../Source/Cesium.js";
-import { HeadingPitchRoll } from "../../Source/Cesium.js";
-import { Iau2006XysData } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Cartesian4,
+  EarthOrientationParameters,
+  Ellipsoid,
+  GeographicProjection,
+  HeadingPitchRoll,
+  Iau2006XysData,
+  JulianDate,
+  Matrix3,
+  Matrix4,
+  Quaternion,
+  Resource,
+  RuntimeError,
+  TimeInterval,
+  Transforms,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix3 } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { RuntimeError } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
 
 describe("Core/Transforms", function () {
   const negativeX = new Cartesian4(-1, 0, 0, 0);

--- a/Specs/Core/TranslationRotationScaleSpec.js
+++ b/Specs/Core/TranslationRotationScaleSpec.js
@@ -1,6 +1,8 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
-import { TranslationRotationScale } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Quaternion,
+  TranslationRotationScale,
+} from "../../../Source/Cesium.js";
 
 describe("Core/TranslationRotationScale", function () {
   it("sets correct values when constructed with no arguments", function () {

--- a/Specs/Core/TridiagonalSystemSolverSpec.js
+++ b/Specs/Core/TridiagonalSystemSolverSpec.js
@@ -1,6 +1,6 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
+import { Cartesian3, TridiagonalSystemSolver } from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { TridiagonalSystemSolver } from "../../Source/Cesium.js";
 
 describe("Core/TridiagonalSystemSolver", function () {
   it("solve throws exception without lower diagonal", function () {

--- a/Specs/Core/VRTheWorldTerrainProviderSpec.js
+++ b/Specs/Core/VRTheWorldTerrainProviderSpec.js
@@ -1,12 +1,15 @@
-import { DefaultProxy } from "../../Source/Cesium.js";
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
-import { HeightmapTerrainData } from "../../Source/Cesium.js";
+import {
+  DefaultProxy,
+  GeographicTilingScheme,
+  HeightmapTerrainData,
+  Request,
+  RequestScheduler,
+  Resource,
+  TerrainProvider,
+  VRTheWorldTerrainProvider,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Request } from "../../Source/Cesium.js";
-import { RequestScheduler } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { TerrainProvider } from "../../Source/Cesium.js";
-import { VRTheWorldTerrainProvider } from "../../Source/Cesium.js";
 
 describe("Core/VRTheWorldTerrainProvider", function () {
   const imageUrl = "Data/Images/Red16x16.png";

--- a/Specs/Core/VideoSynchronizerSpec.js
+++ b/Specs/Core/VideoSynchronizerSpec.js
@@ -1,9 +1,13 @@
-import { Clock } from "../../Source/Cesium.js";
-import { FeatureDetection } from "../../Source/Cesium.js";
-import { Iso8601 } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  Clock,
+  FeatureDetection,
+  Iso8601,
+  JulianDate,
+  VideoSynchronizer,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { VideoSynchronizer } from "../../Source/Cesium.js";
+
 import pollToPromise from "../pollToPromise.js";
 
 describe("Core/VideoSynchronizer", function () {

--- a/Specs/Core/WallGeometrySpec.js
+++ b/Specs/Core/WallGeometrySpec.js
@@ -1,8 +1,12 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Ellipsoid,
+  VertexFormat,
+  WallGeometry,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { VertexFormat } from "../../Source/Cesium.js";
-import { WallGeometry } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/WallGeometry", function () {

--- a/Specs/Core/WallOutlineGeometrySpec.js
+++ b/Specs/Core/WallOutlineGeometrySpec.js
@@ -1,7 +1,11 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Ellipsoid,
+  WallOutlineGeometry,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { WallOutlineGeometry } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("Core/WallOutlineGeometry", function () {

--- a/Specs/Core/WebMercatorProjectionSpec.js
+++ b/Specs/Core/WebMercatorProjectionSpec.js
@@ -1,9 +1,12 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Cartographic,
+  Ellipsoid,
+  WebMercatorProjection,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { WebMercatorProjection } from "../../Source/Cesium.js";
 
 describe("Core/WebMercatorProjection", function () {
   it("construct0", function () {

--- a/Specs/Core/WebMercatorTilingSchemeSpec.js
+++ b/Specs/Core/WebMercatorTilingSchemeSpec.js
@@ -1,11 +1,14 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartographic,
+  Ellipsoid,
+  Rectangle,
+  TilingScheme,
+  WebMercatorProjection,
+  WebMercatorTilingScheme,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { TilingScheme } from "../../Source/Cesium.js";
-import { WebMercatorProjection } from "../../Source/Cesium.js";
-import { WebMercatorTilingScheme } from "../../Source/Cesium.js";
 
 describe("Core/WebMercatorTilingScheme", function () {
   let tilingScheme;

--- a/Specs/Core/arrayRemoveDuplicatesSpec.js
+++ b/Specs/Core/arrayRemoveDuplicatesSpec.js
@@ -1,7 +1,10 @@
-import { arrayRemoveDuplicates } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
+import {
+  arrayRemoveDuplicates,
+  Cartesian3,
+  Spherical,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Spherical } from "../../Source/Cesium.js";
 
 describe("Core/arrayRemoveDuplicates", function () {
   it("removeDuplicates returns positions if none removed - length === 1", function () {

--- a/Specs/Core/barycentricCoordinatesSpec.js
+++ b/Specs/Core/barycentricCoordinatesSpec.js
@@ -1,5 +1,5 @@
-import { barycentricCoordinates } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
+import { barycentricCoordinates, Cartesian3 } from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
 
 describe("Core/barycentricCoordinates", function () {

--- a/Specs/Core/buildModuleUrlSpec.js
+++ b/Specs/Core/buildModuleUrlSpec.js
@@ -1,6 +1,4 @@
-import { buildModuleUrl } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { Uri } from "../../Source/Cesium.js";
+import { buildModuleUrl, Resource, Uri } from "../../../Source/Cesium.js";
 
 describe("Core/buildModuleUrl", function () {
   it("produces an absolute URL for a module", function () {

--- a/Specs/Core/getAbsoluteUriSpec.js
+++ b/Specs/Core/getAbsoluteUriSpec.js
@@ -1,5 +1,4 @@
-import { getAbsoluteUri } from "../../Source/Cesium.js";
-import { getBaseUri } from "../../Source/Cesium.js";
+import { getAbsoluteUri, getBaseUri } from "../../../Source/Cesium.js";
 
 describe("Core/getAbsoluteUri", function () {
   it("works as expected", function () {

--- a/Specs/Core/isCrossOriginUrlSpec.js
+++ b/Specs/Core/isCrossOriginUrlSpec.js
@@ -1,6 +1,8 @@
-import { getAbsoluteUri } from "../../Source/Cesium.js";
-import { isCrossOriginUrl } from "../../Source/Cesium.js";
-import { Uri } from "../../Source/Cesium.js";
+import {
+  getAbsoluteUri,
+  isCrossOriginUrl,
+  Uri,
+} from "../../../Source/Cesium.js";
 
 describe("Core/isCrossOriginUrl", function () {
   it("returns false for relative urls", function () {

--- a/Specs/Core/loadImageFromTypedArraySpec.js
+++ b/Specs/Core/loadImageFromTypedArraySpec.js
@@ -1,5 +1,4 @@
-import { loadImageFromTypedArray } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
+import { loadImageFromTypedArray, Resource } from "../../../Source/Cesium.js";
 
 describe("Core/loadImageFromTypedArray", function () {
   let supportsImageBitmapOptions;

--- a/Specs/Core/loadKTX2Spec.js
+++ b/Specs/Core/loadKTX2Spec.js
@@ -1,8 +1,10 @@
-import { loadKTX2 } from "../../Source/Cesium.js";
-import { KTX2Transcoder } from "../../Source/Cesium.js";
-import { PixelFormat } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { RuntimeError } from "../../Source/Cesium.js";
+import {
+  loadKTX2,
+  KTX2Transcoder,
+  PixelFormat,
+  Resource,
+  RuntimeError,
+} from "../../../Source/Cesium.js";
 
 describe("Core/loadKTX2", function () {
   it("throws with no url", function () {

--- a/Specs/Core/mergeSortSpec.js
+++ b/Specs/Core/mergeSortSpec.js
@@ -1,6 +1,8 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { mergeSort } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Cartesian3,
+  mergeSort,
+} from "../../../Source/Cesium.js";
 
 describe("Core/mergeSort", function () {
   it("sorts", function () {

--- a/Specs/Core/objectToQuerySpec.js
+++ b/Specs/Core/objectToQuerySpec.js
@@ -1,5 +1,4 @@
-import { objectToQuery } from "../../Source/Cesium.js";
-import { queryToObject } from "../../Source/Cesium.js";
+import { objectToQuery, queryToObject } from "../../../Source/Cesium.js";
 
 describe("Core/objectToQuery", function () {
   it("can encode data", function () {

--- a/Specs/Core/pointInsideTriangleSpec.js
+++ b/Specs/Core/pointInsideTriangleSpec.js
@@ -1,5 +1,4 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { pointInsideTriangle } from "../../Source/Cesium.js";
+import { Cartesian2, pointInsideTriangle } from "../../../Source/Cesium.js";
 
 describe("Core/pointInsideTriangle", function () {
   it("pointInsideTriangle has point inside", function () {

--- a/Specs/Core/sampleTerrainMostDetailedSpec.js
+++ b/Specs/Core/sampleTerrainMostDetailedSpec.js
@@ -1,7 +1,9 @@
-import { Cartographic } from "../../Source/Cesium.js";
-import { CesiumTerrainProvider } from "../../Source/Cesium.js";
-import { createWorldTerrain } from "../../Source/Cesium.js";
-import { sampleTerrainMostDetailed } from "../../Source/Cesium.js";
+import {
+  Cartographic,
+  CesiumTerrainProvider,
+  createWorldTerrain,
+  sampleTerrainMostDetailed,
+} from "../../../Source/Cesium.js";
 
 describe("Core/sampleTerrainMostDetailed", function () {
   let worldTerrain;

--- a/Specs/Core/sampleTerrainSpec.js
+++ b/Specs/Core/sampleTerrainSpec.js
@@ -1,11 +1,13 @@
-import { ArcGISTiledElevationTerrainProvider } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { CesiumTerrainProvider } from "../../Source/Cesium.js";
-import { createWorldTerrain } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { RequestScheduler } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { sampleTerrain } from "../../Source/Cesium.js";
+import {
+  ArcGISTiledElevationTerrainProvider,
+  Cartographic,
+  CesiumTerrainProvider,
+  createWorldTerrain,
+  defined,
+  RequestScheduler,
+  Resource,
+  sampleTerrain,
+} from "../../../Source/Cesium.js";
 
 describe("Core/sampleTerrain", function () {
   let worldTerrain;

--- a/Specs/Core/writeTextToCanvasSpec.js
+++ b/Specs/Core/writeTextToCanvasSpec.js
@@ -1,5 +1,4 @@
-import { Color } from "../../Source/Cesium.js";
-import { writeTextToCanvas } from "../../Source/Cesium.js";
+import { Color, writeTextToCanvas } from "../../../Source/Cesium.js";
 
 describe("Core/writeTextToCanvas", function () {
   it("returns undefined when text is blank", function () {

--- a/Specs/DataSources/BillboardGraphicsSpec.js
+++ b/Specs/DataSources/BillboardGraphicsSpec.js
@@ -1,13 +1,15 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { NearFarScalar } from "../../Source/Cesium.js";
-import { BillboardGraphics } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { HeightReference } from "../../Source/Cesium.js";
-import { HorizontalOrigin } from "../../Source/Cesium.js";
-import { VerticalOrigin } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Color,
+  DistanceDisplayCondition,
+  NearFarScalar,
+  BillboardGraphics,
+  ConstantProperty,
+  HeightReference,
+  HorizontalOrigin,
+  VerticalOrigin,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/BillboardGraphics", function () {
   it("creates expected instance from raw assignment and construction", function () {

--- a/Specs/DataSources/BillboardVisualizerSpec.js
+++ b/Specs/DataSources/BillboardVisualizerSpec.js
@@ -1,21 +1,24 @@
-import { BoundingRectangle } from "../../Source/Cesium.js";
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { NearFarScalar } from "../../Source/Cesium.js";
-import { BillboardGraphics } from "../../Source/Cesium.js";
-import { BillboardVisualizer } from "../../Source/Cesium.js";
-import { BoundingSphereState } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { EntityCluster } from "../../Source/Cesium.js";
-import { EntityCollection } from "../../Source/Cesium.js";
-import { HeightReference } from "../../Source/Cesium.js";
-import { HorizontalOrigin } from "../../Source/Cesium.js";
-import { VerticalOrigin } from "../../Source/Cesium.js";
+import {
+  BoundingRectangle,
+  BoundingSphere,
+  Cartesian2,
+  Cartesian3,
+  Color,
+  defined,
+  DistanceDisplayCondition,
+  JulianDate,
+  NearFarScalar,
+  BillboardGraphics,
+  BillboardVisualizer,
+  BoundingSphereState,
+  ConstantProperty,
+  EntityCluster,
+  EntityCollection,
+  HeightReference,
+  HorizontalOrigin,
+  VerticalOrigin,
+} from "../../../Source/Cesium.js";
+
 import createGlobe from "../createGlobe.js";
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";

--- a/Specs/DataSources/BoxGeometryUpdaterSpec.js
+++ b/Specs/DataSources/BoxGeometryUpdaterSpec.js
@@ -1,15 +1,18 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { GeometryOffsetAttribute } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { BoxGeometryUpdater } from "../../Source/Cesium.js";
-import { BoxGraphics } from "../../Source/Cesium.js";
-import { ConstantPositionProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { HeightReference } from "../../Source/Cesium.js";
-import { PrimitiveCollection } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Color,
+  GeometryOffsetAttribute,
+  JulianDate,
+  TimeIntervalCollection,
+  BoxGeometryUpdater,
+  BoxGraphics,
+  ConstantPositionProperty,
+  ConstantProperty,
+  Entity,
+  HeightReference,
+  PrimitiveCollection,
+} from "../../../Source/Cesium.js";
+
 import createDynamicGeometryUpdaterSpecs from "../createDynamicGeometryUpdaterSpecs.js";
 import createDynamicProperty from "../createDynamicProperty.js";
 import createGeometryUpdaterSpecs from "../createGeometryUpdaterSpecs.js";

--- a/Specs/DataSources/BoxGraphicsSpec.js
+++ b/Specs/DataSources/BoxGraphicsSpec.js
@@ -1,10 +1,13 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { BoxGraphics } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { ShadowMode } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Color,
+  DistanceDisplayCondition,
+  BoxGraphics,
+  ColorMaterialProperty,
+  ConstantProperty,
+  ShadowMode,
+} from "../../../Source/Cesium.js";
+
 import testDefinitionChanged from "../testDefinitionChanged.js";
 import testMaterialDefinitionChanged from "../testMaterialDefinitionChanged.js";
 

--- a/Specs/DataSources/CallbackPropertySpec.js
+++ b/Specs/DataSources/CallbackPropertySpec.js
@@ -1,5 +1,4 @@
-import { JulianDate } from "../../Source/Cesium.js";
-import { CallbackProperty } from "../../Source/Cesium.js";
+import { JulianDate, CallbackProperty } from "../../../Source/Cesium.js";
 
 describe("DataSources/CallbackProperty", function () {
   const time = JulianDate.now();

--- a/Specs/DataSources/Cesium3DTilesetGraphicsSpec.js
+++ b/Specs/DataSources/Cesium3DTilesetGraphicsSpec.js
@@ -1,5 +1,7 @@
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { Cesium3DTilesetGraphics } from "../../Source/Cesium.js";
+import {
+  ConstantProperty,
+  Cesium3DTilesetGraphics,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/Cesium3DTilesetGraphics", function () {
   it("creates expected instance from raw assignment and construction", function () {

--- a/Specs/DataSources/Cesium3DTilesetVisualizerSpec.js
+++ b/Specs/DataSources/Cesium3DTilesetVisualizerSpec.js
@@ -1,16 +1,19 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { BoundingSphereState } from "../../Source/Cesium.js";
-import { ConstantPositionProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { EntityCollection } from "../../Source/Cesium.js";
-import { Cesium3DTilesetGraphics } from "../../Source/Cesium.js";
-import { Cesium3DTilesetVisualizer } from "../../Source/Cesium.js";
-import { Globe } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Cartesian3,
+  defined,
+  JulianDate,
+  Matrix4,
+  Resource,
+  BoundingSphereState,
+  ConstantPositionProperty,
+  ConstantProperty,
+  EntityCollection,
+  Cesium3DTilesetGraphics,
+  Cesium3DTilesetVisualizer,
+  Globe,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/DataSources/CheckerboardMaterialPropertySpec.js
+++ b/Specs/DataSources/CheckerboardMaterialPropertySpec.js
@@ -1,10 +1,13 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { CheckerboardMaterialProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionProperty } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Color,
+  JulianDate,
+  TimeInterval,
+  CheckerboardMaterialProperty,
+  ConstantProperty,
+  TimeIntervalCollectionProperty,
+} from "../../../Source/Cesium.js";
+
 import testDefinitionChanged from "../testDefinitionChanged.js";
 
 describe("DataSources/CheckerboardMaterialProperty", function () {

--- a/Specs/DataSources/ColorMaterialPropertySpec.js
+++ b/Specs/DataSources/ColorMaterialPropertySpec.js
@@ -1,9 +1,11 @@
-import { Color } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionProperty } from "../../Source/Cesium.js";
+import {
+  Color,
+  JulianDate,
+  TimeInterval,
+  ColorMaterialProperty,
+  ConstantProperty,
+  TimeIntervalCollectionProperty,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/ColorMaterialProperty", function () {
   it("constructor provides the expected defaults", function () {

--- a/Specs/DataSources/CompositeEntityCollectionSpec.js
+++ b/Specs/DataSources/CompositeEntityCollectionSpec.js
@@ -1,14 +1,16 @@
-import { Iso8601 } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { BillboardGraphics } from "../../Source/Cesium.js";
-import { CompositeEntityCollection } from "../../Source/Cesium.js";
-import { CompositePositionProperty } from "../../Source/Cesium.js";
-import { CompositeProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { EntityCollection } from "../../Source/Cesium.js";
+import {
+  Iso8601,
+  JulianDate,
+  TimeInterval,
+  TimeIntervalCollection,
+  BillboardGraphics,
+  CompositeEntityCollection,
+  CompositePositionProperty,
+  CompositeProperty,
+  ConstantProperty,
+  Entity,
+  EntityCollection,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/CompositeEntityCollection", function () {
   function CollectionListener() {

--- a/Specs/DataSources/CompositeMaterialPropertySpec.js
+++ b/Specs/DataSources/CompositeMaterialPropertySpec.js
@@ -1,10 +1,12 @@
-import { Color } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { CompositeMaterialProperty } from "../../Source/Cesium.js";
-import { GridMaterialProperty } from "../../Source/Cesium.js";
+import {
+  Color,
+  JulianDate,
+  TimeInterval,
+  TimeIntervalCollection,
+  ColorMaterialProperty,
+  CompositeMaterialProperty,
+  GridMaterialProperty,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/CompositeMaterialProperty", function () {
   it("default constructor has expected values", function () {

--- a/Specs/DataSources/CompositePositionPropertySpec.js
+++ b/Specs/DataSources/CompositePositionPropertySpec.js
@@ -1,11 +1,13 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { ReferenceFrame } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { CompositePositionProperty } from "../../Source/Cesium.js";
-import { ConstantPositionProperty } from "../../Source/Cesium.js";
-import { PositionProperty } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  JulianDate,
+  ReferenceFrame,
+  TimeInterval,
+  TimeIntervalCollection,
+  CompositePositionProperty,
+  ConstantPositionProperty,
+  PositionProperty,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/CompositePositionProperty", function () {
   it("default constructor has expected values", function () {

--- a/Specs/DataSources/CompositePropertySpec.js
+++ b/Specs/DataSources/CompositePropertySpec.js
@@ -1,9 +1,11 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { CompositeProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  JulianDate,
+  TimeInterval,
+  TimeIntervalCollection,
+  CompositeProperty,
+  ConstantProperty,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/CompositeProperty", function () {
   it("default constructor has expected values", function () {

--- a/Specs/DataSources/ConstantPositionPropertySpec.js
+++ b/Specs/DataSources/ConstantPositionPropertySpec.js
@@ -1,8 +1,10 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { ReferenceFrame } from "../../Source/Cesium.js";
-import { ConstantPositionProperty } from "../../Source/Cesium.js";
-import { PositionProperty } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  JulianDate,
+  ReferenceFrame,
+  ConstantPositionProperty,
+  PositionProperty,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/ConstantPositionProperty", function () {
   const time = JulianDate.now();

--- a/Specs/DataSources/ConstantPropertySpec.js
+++ b/Specs/DataSources/ConstantPropertySpec.js
@@ -1,6 +1,8 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  JulianDate,
+  ConstantProperty,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/ConstantProperty", function () {
   const time = JulianDate.now();

--- a/Specs/DataSources/CorridorGeometryUpdaterSpec.js
+++ b/Specs/DataSources/CorridorGeometryUpdaterSpec.js
@@ -1,19 +1,23 @@
-import { ApproximateTerrainHeights } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { CornerType } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  ApproximateTerrainHeights,
+  Cartesian3,
+  CornerType,
+  JulianDate,
+  TimeInterval,
+  TimeIntervalCollection,
+  ConstantProperty,
+  CorridorGeometryUpdater,
+  CorridorGraphics,
+  Entity,
+  PropertyArray,
+  SampledPositionProperty,
+  SampledProperty,
+  TimeIntervalCollectionProperty,
+  PrimitiveCollection,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { CorridorGeometryUpdater } from "../../Source/Cesium.js";
-import { CorridorGraphics } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { PropertyArray } from "../../Source/Cesium.js";
-import { SampledPositionProperty } from "../../Source/Cesium.js";
-import { SampledProperty } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionProperty } from "../../Source/Cesium.js";
-import { PrimitiveCollection } from "../../Source/Cesium.js";
+
 import createDynamicGeometryUpdaterSpecs from "../createDynamicGeometryUpdaterSpecs.js";
 import createDynamicProperty from "../createDynamicProperty.js";
 import createGeometryUpdaterGroundGeometrySpecs from "../createGeometryUpdaterGroundGeometrySpecs.js";

--- a/Specs/DataSources/CorridorGraphicsSpec.js
+++ b/Specs/DataSources/CorridorGraphicsSpec.js
@@ -1,11 +1,14 @@
-import { Color } from "../../Source/Cesium.js";
-import { CornerType } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { CorridorGraphics } from "../../Source/Cesium.js";
-import { ClassificationType } from "../../Source/Cesium.js";
-import { ShadowMode } from "../../Source/Cesium.js";
+import {
+  Color,
+  CornerType,
+  DistanceDisplayCondition,
+  ColorMaterialProperty,
+  ConstantProperty,
+  CorridorGraphics,
+  ClassificationType,
+  ShadowMode,
+} from "../../../Source/Cesium.js";
+
 import testDefinitionChanged from "../testDefinitionChanged.js";
 import testMaterialDefinitionChanged from "../testMaterialDefinitionChanged.js";
 

--- a/Specs/DataSources/CustomDataSourceSpec.js
+++ b/Specs/DataSources/CustomDataSourceSpec.js
@@ -1,7 +1,9 @@
-import { Event } from "../../Source/Cesium.js";
-import { CustomDataSource } from "../../Source/Cesium.js";
-import { DataSourceClock } from "../../Source/Cesium.js";
-import { EntityCollection } from "../../Source/Cesium.js";
+import {
+  Event,
+  CustomDataSource,
+  DataSourceClock,
+  EntityCollection,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/CustomDataSource", function () {
   it("constructor has expected defaults", function () {

--- a/Specs/DataSources/CylinderGeometryUpdaterSpec.js
+++ b/Specs/DataSources/CylinderGeometryUpdaterSpec.js
@@ -1,18 +1,21 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { GeometryOffsetAttribute } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { ConstantPositionProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { CylinderGeometryUpdater } from "../../Source/Cesium.js";
-import { CylinderGraphics } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { SampledPositionProperty } from "../../Source/Cesium.js";
-import { SampledProperty } from "../../Source/Cesium.js";
-import { HeightReference } from "../../Source/Cesium.js";
-import { PrimitiveCollection } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Color,
+  GeometryOffsetAttribute,
+  JulianDate,
+  Quaternion,
+  TimeIntervalCollection,
+  ConstantPositionProperty,
+  ConstantProperty,
+  CylinderGeometryUpdater,
+  CylinderGraphics,
+  Entity,
+  SampledPositionProperty,
+  SampledProperty,
+  HeightReference,
+  PrimitiveCollection,
+} from "../../../Source/Cesium.js";
+
 import createDynamicGeometryUpdaterSpecs from "../createDynamicGeometryUpdaterSpecs.js";
 import createDynamicProperty from "../createDynamicProperty.js";
 import createGeometryUpdaterSpecs from "../createGeometryUpdaterSpecs.js";

--- a/Specs/DataSources/CylinderGraphicsSpec.js
+++ b/Specs/DataSources/CylinderGraphicsSpec.js
@@ -1,9 +1,12 @@
-import { Color } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { CylinderGraphics } from "../../Source/Cesium.js";
-import { ShadowMode } from "../../Source/Cesium.js";
+import {
+  Color,
+  DistanceDisplayCondition,
+  ColorMaterialProperty,
+  ConstantProperty,
+  CylinderGraphics,
+  ShadowMode,
+} from "../../../Source/Cesium.js";
+
 import testDefinitionChanged from "../testDefinitionChanged.js";
 import testMaterialDefinitionChanged from "../testMaterialDefinitionChanged.js";
 

--- a/Specs/DataSources/CzmlDataSourceSpec.js
+++ b/Specs/DataSources/CzmlDataSourceSpec.js
@@ -1,50 +1,52 @@
-import { ArcType } from "../../Source/Cesium.js";
-import { BoundingRectangle } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { ClockRange } from "../../Source/Cesium.js";
-import { ClockStep } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { CornerType } from "../../Source/Cesium.js";
-import { Credit } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { Event } from "../../Source/Cesium.js";
-import { ExtrapolationType } from "../../Source/Cesium.js";
-import { Iso8601 } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { NearFarScalar } from "../../Source/Cesium.js";
-import { PolygonHierarchy } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { ReferenceFrame } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { RuntimeError } from "../../Source/Cesium.js";
-import { Spherical } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
-import { TranslationRotationScale } from "../../Source/Cesium.js";
-import { CompositeEntityCollection } from "../../Source/Cesium.js";
-import { CompositeMaterialProperty } from "../../Source/Cesium.js";
-import { CompositePositionProperty } from "../../Source/Cesium.js";
-import { CompositeProperty } from "../../Source/Cesium.js";
-import { ConstantPositionProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { CzmlDataSource } from "../../Source/Cesium.js";
-import { EntityCollection } from "../../Source/Cesium.js";
-import { ReferenceProperty } from "../../Source/Cesium.js";
-import { SampledPositionProperty } from "../../Source/Cesium.js";
-import { SampledProperty } from "../../Source/Cesium.js";
-import { StripeOrientation } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionPositionProperty } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionProperty } from "../../Source/Cesium.js";
-import { ClassificationType } from "../../Source/Cesium.js";
-import { ColorBlendMode } from "../../Source/Cesium.js";
-import { HeightReference } from "../../Source/Cesium.js";
-import { HorizontalOrigin } from "../../Source/Cesium.js";
-import { LabelStyle } from "../../Source/Cesium.js";
-import { ShadowMode } from "../../Source/Cesium.js";
-import { VerticalOrigin } from "../../Source/Cesium.js";
+import {
+  ArcType,
+  BoundingRectangle,
+  Cartesian2,
+  Cartesian3,
+  ClockRange,
+  ClockStep,
+  Color,
+  CornerType,
+  Credit,
+  DistanceDisplayCondition,
+  Event,
+  ExtrapolationType,
+  Iso8601,
+  JulianDate,
+  Math as CesiumMath,
+  NearFarScalar,
+  PolygonHierarchy,
+  Quaternion,
+  Rectangle,
+  ReferenceFrame,
+  Resource,
+  RuntimeError,
+  Spherical,
+  TimeInterval,
+  Transforms,
+  TranslationRotationScale,
+  CompositeEntityCollection,
+  CompositeMaterialProperty,
+  CompositePositionProperty,
+  CompositeProperty,
+  ConstantPositionProperty,
+  ConstantProperty,
+  CzmlDataSource,
+  EntityCollection,
+  ReferenceProperty,
+  SampledPositionProperty,
+  SampledProperty,
+  StripeOrientation,
+  TimeIntervalCollectionPositionProperty,
+  TimeIntervalCollectionProperty,
+  ClassificationType,
+  ColorBlendMode,
+  HeightReference,
+  HorizontalOrigin,
+  LabelStyle,
+  ShadowMode,
+  VerticalOrigin,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/CzmlDataSource", function () {
   function makeDocument(packet) {

--- a/Specs/DataSources/DataSourceClockSpec.js
+++ b/Specs/DataSources/DataSourceClockSpec.js
@@ -1,7 +1,9 @@
-import { ClockRange } from "../../Source/Cesium.js";
-import { ClockStep } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { DataSourceClock } from "../../Source/Cesium.js";
+import {
+  ClockRange,
+  ClockStep,
+  JulianDate,
+  DataSourceClock,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/DataSourceClock", function () {
   it("merge assigns unassigned properties", function () {

--- a/Specs/DataSources/DataSourceDisplaySpec.js
+++ b/Specs/DataSources/DataSourceDisplaySpec.js
@@ -1,13 +1,16 @@
-import { ApproximateTerrainHeights } from "../../Source/Cesium.js";
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Iso8601 } from "../../Source/Cesium.js";
-import { BoundingSphereState } from "../../Source/Cesium.js";
-import { DataSourceCollection } from "../../Source/Cesium.js";
-import { DataSourceDisplay } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { GroundPolylinePrimitive } from "../../Source/Cesium.js";
-import { GroundPrimitive } from "../../Source/Cesium.js";
+import {
+  ApproximateTerrainHeights,
+  BoundingSphere,
+  Cartesian3,
+  Iso8601,
+  BoundingSphereState,
+  DataSourceCollection,
+  DataSourceDisplay,
+  Entity,
+  GroundPolylinePrimitive,
+  GroundPrimitive,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import MockDataSource from "../MockDataSource.js";
 

--- a/Specs/DataSources/DynamicGeometryUpdaterSpec.js
+++ b/Specs/DataSources/DynamicGeometryUpdaterSpec.js
@@ -1,7 +1,10 @@
-import { DynamicGeometryUpdater } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { GeometryUpdater } from "../../Source/Cesium.js";
-import { PrimitiveCollection } from "../../Source/Cesium.js";
+import {
+  DynamicGeometryUpdater,
+  Entity,
+  GeometryUpdater,
+  PrimitiveCollection,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe("DataSources/DynamicGeometryUpdater", function () {

--- a/Specs/DataSources/EllipseGeometryUpdaterSpec.js
+++ b/Specs/DataSources/EllipseGeometryUpdaterSpec.js
@@ -1,15 +1,18 @@
-import { ApproximateTerrainHeights } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { ConstantPositionProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { EllipseGeometryUpdater } from "../../Source/Cesium.js";
-import { EllipseGraphics } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { SampledPositionProperty } from "../../Source/Cesium.js";
-import { SampledProperty } from "../../Source/Cesium.js";
-import { PrimitiveCollection } from "../../Source/Cesium.js";
+import {
+  ApproximateTerrainHeights,
+  Cartesian3,
+  JulianDate,
+  TimeIntervalCollection,
+  ConstantPositionProperty,
+  ConstantProperty,
+  EllipseGeometryUpdater,
+  EllipseGraphics,
+  Entity,
+  SampledPositionProperty,
+  SampledProperty,
+  PrimitiveCollection,
+} from "../../../Source/Cesium.js";
+
 import createDynamicGeometryUpdaterSpecs from "../createDynamicGeometryUpdaterSpecs.js";
 import createDynamicProperty from "../createDynamicProperty.js";
 import createGeometryUpdaterGroundGeometrySpecs from "../createGeometryUpdaterGroundGeometrySpecs.js";

--- a/Specs/DataSources/EllipseGraphicsSpec.js
+++ b/Specs/DataSources/EllipseGraphicsSpec.js
@@ -1,10 +1,13 @@
-import { Color } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { EllipseGraphics } from "../../Source/Cesium.js";
-import { ClassificationType } from "../../Source/Cesium.js";
-import { ShadowMode } from "../../Source/Cesium.js";
+import {
+  Color,
+  DistanceDisplayCondition,
+  ColorMaterialProperty,
+  ConstantProperty,
+  EllipseGraphics,
+  ClassificationType,
+  ShadowMode,
+} from "../../../Source/Cesium.js";
+
 import testDefinitionChanged from "../testDefinitionChanged.js";
 import testMaterialDefinitionChanged from "../testMaterialDefinitionChanged.js";
 

--- a/Specs/DataSources/EllipsoidGeometryUpdaterSpec.js
+++ b/Specs/DataSources/EllipsoidGeometryUpdaterSpec.js
@@ -1,21 +1,25 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { GeometryOffsetAttribute } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Color,
+  ColorGeometryInstanceAttribute,
+  GeometryOffsetAttribute,
+  JulianDate,
+  Quaternion,
+  TimeIntervalCollection,
+  ColorMaterialProperty,
+  ConstantPositionProperty,
+  ConstantProperty,
+  EllipsoidGeometryUpdater,
+  EllipsoidGraphics,
+  Entity,
+  SampledPositionProperty,
+  SampledProperty,
+  HeightReference,
+  PrimitiveCollection,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { ConstantPositionProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { EllipsoidGeometryUpdater } from "../../Source/Cesium.js";
-import { EllipsoidGraphics } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { SampledPositionProperty } from "../../Source/Cesium.js";
-import { SampledProperty } from "../../Source/Cesium.js";
-import { HeightReference } from "../../Source/Cesium.js";
-import { PrimitiveCollection } from "../../Source/Cesium.js";
+
 import createDynamicGeometryUpdaterSpecs from "../createDynamicGeometryUpdaterSpecs.js";
 import createDynamicProperty from "../createDynamicProperty.js";
 import createGeometryUpdaterSpecs from "../createGeometryUpdaterSpecs.js";

--- a/Specs/DataSources/EllipsoidGraphicsSpec.js
+++ b/Specs/DataSources/EllipsoidGraphicsSpec.js
@@ -1,10 +1,13 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { EllipsoidGraphics } from "../../Source/Cesium.js";
-import { ShadowMode } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Color,
+  DistanceDisplayCondition,
+  ColorMaterialProperty,
+  ConstantProperty,
+  EllipsoidGraphics,
+  ShadowMode,
+} from "../../../Source/Cesium.js";
+
 import testDefinitionChanged from "../testDefinitionChanged.js";
 import testMaterialDefinitionChanged from "../testMaterialDefinitionChanged.js";
 

--- a/Specs/DataSources/EntityClusterSpec.js
+++ b/Specs/DataSources/EntityClusterSpec.js
@@ -1,13 +1,16 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { Event } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { CustomDataSource } from "../../Source/Cesium.js";
-import { DataSourceDisplay } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { EntityCluster } from "../../Source/Cesium.js";
-import { SceneTransforms } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Ellipsoid,
+  Event,
+  JulianDate,
+  CustomDataSource,
+  DataSourceDisplay,
+  Entity,
+  EntityCluster,
+  SceneTransforms,
+} from "../../../Source/Cesium.js";
+
 import createCanvas from "../createCanvas.js";
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";

--- a/Specs/DataSources/EntityCollectionSpec.js
+++ b/Specs/DataSources/EntityCollectionSpec.js
@@ -1,10 +1,12 @@
-import { Iso8601 } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { EntityCollection } from "../../Source/Cesium.js";
-import { RuntimeError } from "../../Source/Cesium.js";
+import {
+  Iso8601,
+  JulianDate,
+  TimeInterval,
+  TimeIntervalCollection,
+  Entity,
+  EntityCollection,
+  RuntimeError,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/EntityCollection", function () {
   function CollectionListener() {

--- a/Specs/DataSources/EntitySpec.js
+++ b/Specs/DataSources/EntitySpec.js
@@ -1,30 +1,32 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { Matrix3 } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
-import { BillboardGraphics } from "../../Source/Cesium.js";
-import { BoxGraphics } from "../../Source/Cesium.js";
-import { ConstantPositionProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { CorridorGraphics } from "../../Source/Cesium.js";
-import { CylinderGraphics } from "../../Source/Cesium.js";
-import { EllipseGraphics } from "../../Source/Cesium.js";
-import { EllipsoidGraphics } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { LabelGraphics } from "../../Source/Cesium.js";
-import { ModelGraphics } from "../../Source/Cesium.js";
-import { PathGraphics } from "../../Source/Cesium.js";
-import { PlaneGraphics } from "../../Source/Cesium.js";
-import { PointGraphics } from "../../Source/Cesium.js";
-import { PolygonGraphics } from "../../Source/Cesium.js";
-import { PolylineGraphics } from "../../Source/Cesium.js";
-import { PolylineVolumeGraphics } from "../../Source/Cesium.js";
-import { RectangleGraphics } from "../../Source/Cesium.js";
-import { WallGraphics } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  JulianDate,
+  Matrix3,
+  Matrix4,
+  Quaternion,
+  TimeInterval,
+  TimeIntervalCollection,
+  Transforms,
+  BillboardGraphics,
+  BoxGraphics,
+  ConstantPositionProperty,
+  ConstantProperty,
+  CorridorGraphics,
+  CylinderGraphics,
+  EllipseGraphics,
+  EllipsoidGraphics,
+  Entity,
+  LabelGraphics,
+  ModelGraphics,
+  PathGraphics,
+  PlaneGraphics,
+  PointGraphics,
+  PolygonGraphics,
+  PolylineGraphics,
+  PolylineVolumeGraphics,
+  RectangleGraphics,
+  WallGraphics,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/Entity", function () {
   it("constructor sets expected properties.", function () {

--- a/Specs/DataSources/EntityViewSpec.js
+++ b/Specs/DataSources/EntityViewSpec.js
@@ -1,10 +1,13 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { ConstantPositionProperty } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { EntityView } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Cartesian3,
+  Ellipsoid,
+  JulianDate,
+  ConstantPositionProperty,
+  Entity,
+  EntityView,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/DataSources/GeoJsonDataSourceSpec.js
+++ b/Specs/DataSources/GeoJsonDataSourceSpec.js
@@ -1,15 +1,17 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { Credit } from "../../Source/Cesium.js";
-import { Event } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { PolygonHierarchy } from "../../Source/Cesium.js";
-import { RuntimeError } from "../../Source/Cesium.js";
-import { CallbackProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { EntityCollection } from "../../Source/Cesium.js";
-import { GeoJsonDataSource } from "../../Source/Cesium.js";
-import { HeightReference } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Color,
+  Credit,
+  Event,
+  JulianDate,
+  PolygonHierarchy,
+  RuntimeError,
+  CallbackProperty,
+  ConstantProperty,
+  EntityCollection,
+  GeoJsonDataSource,
+  HeightReference,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/GeoJsonDataSource", function () {
   let defaultMarkerSize;

--- a/Specs/DataSources/GeometryUpdaterSpec.js
+++ b/Specs/DataSources/GeometryUpdaterSpec.js
@@ -1,6 +1,9 @@
-import { Entity } from "../../Source/Cesium.js";
-import { GeometryUpdater } from "../../Source/Cesium.js";
-import { PrimitiveCollection } from "../../Source/Cesium.js";
+import {
+  Entity,
+  GeometryUpdater,
+  PrimitiveCollection,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe("DataSources/GeometryUpdater", function () {

--- a/Specs/DataSources/GeometryVisualizerSpec.js
+++ b/Specs/DataSources/GeometryVisualizerSpec.js
@@ -1,25 +1,28 @@
-import { ApproximateTerrainHeights } from "../../Source/Cesium.js";
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { ShowGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { BoundingSphereState } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { ConstantPositionProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { EllipseGraphics } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { EntityCollection } from "../../Source/Cesium.js";
-import { GeometryVisualizer } from "../../Source/Cesium.js";
-import { GridMaterialProperty } from "../../Source/Cesium.js";
-import { SampledProperty } from "../../Source/Cesium.js";
-import { ClassificationType } from "../../Source/Cesium.js";
-import { GroundPrimitive } from "../../Source/Cesium.js";
-import { MaterialAppearance } from "../../Source/Cesium.js";
-import { PerInstanceColorAppearance } from "../../Source/Cesium.js";
-import { ShadowMode } from "../../Source/Cesium.js";
+import {
+  ApproximateTerrainHeights,
+  BoundingSphere,
+  Cartesian3,
+  Color,
+  ColorGeometryInstanceAttribute,
+  JulianDate,
+  ShowGeometryInstanceAttribute,
+  BoundingSphereState,
+  ColorMaterialProperty,
+  ConstantPositionProperty,
+  ConstantProperty,
+  EllipseGraphics,
+  Entity,
+  EntityCollection,
+  GeometryVisualizer,
+  GridMaterialProperty,
+  SampledProperty,
+  ClassificationType,
+  GroundPrimitive,
+  MaterialAppearance,
+  PerInstanceColorAppearance,
+  ShadowMode,
+} from "../../../Source/Cesium.js";
+
 import createDynamicProperty from "../createDynamicProperty.js";
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";

--- a/Specs/DataSources/GpxDataSourceSpec.js
+++ b/Specs/DataSources/GpxDataSourceSpec.js
@@ -1,15 +1,17 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { DeveloperError } from "../../Source/Cesium.js";
-import { EntityCollection } from "../../Source/Cesium.js";
-import { Event } from "../../Source/Cesium.js";
-import { GpxDataSource } from "../../Source/Cesium.js";
-import { HeightReference } from "../../Source/Cesium.js";
-import { Iso8601 } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { RequestErrorEvent } from "../../Source/Cesium.js";
-import { RuntimeError } from "../../Source/Cesium.js";
-import { VerticalOrigin } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Color,
+  DeveloperError,
+  EntityCollection,
+  Event,
+  GpxDataSource,
+  HeightReference,
+  Iso8601,
+  JulianDate,
+  RequestErrorEvent,
+  RuntimeError,
+  VerticalOrigin,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/GpxDataSource", function () {
   const parser = new DOMParser();

--- a/Specs/DataSources/GridMaterialPropertySpec.js
+++ b/Specs/DataSources/GridMaterialPropertySpec.js
@@ -1,11 +1,13 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { GridMaterialProperty } from "../../Source/Cesium.js";
-import { SampledProperty } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionProperty } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Color,
+  JulianDate,
+  TimeInterval,
+  ConstantProperty,
+  GridMaterialProperty,
+  SampledProperty,
+  TimeIntervalCollectionProperty,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/GridMaterialProperty", function () {
   it("constructor provides the expected defaults", function () {

--- a/Specs/DataSources/GroundGeometryUpdaterSpec.js
+++ b/Specs/DataSources/GroundGeometryUpdaterSpec.js
@@ -1,7 +1,9 @@
-import { ApproximateTerrainHeights } from "../../Source/Cesium.js";
-import { GeometryOffsetAttribute } from "../../Source/Cesium.js";
-import { GroundGeometryUpdater } from "../../Source/Cesium.js";
-import { HeightReference } from "../../Source/Cesium.js";
+import {
+  ApproximateTerrainHeights,
+  GeometryOffsetAttribute,
+  GroundGeometryUpdater,
+  HeightReference,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/GroundGeometryUpdater", function () {
   beforeAll(function () {

--- a/Specs/DataSources/ImageMaterialPropertySpec.js
+++ b/Specs/DataSources/ImageMaterialPropertySpec.js
@@ -1,10 +1,12 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { ImageMaterialProperty } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionProperty } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Color,
+  JulianDate,
+  TimeInterval,
+  ConstantProperty,
+  ImageMaterialProperty,
+  TimeIntervalCollectionProperty,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/ImageMaterialProperty", function () {
   it("constructor provides the expected defaults", function () {

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -1,41 +1,45 @@
-import { ArcType } from "../../Source/Cesium.js";
-import { BoundingRectangle } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { ClockRange } from "../../Source/Cesium.js";
-import { ClockStep } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { combine } from "../../Source/Cesium.js";
-import { Credit } from "../../Source/Cesium.js";
-import { defer } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { Event } from "../../Source/Cesium.js";
-import { HeadingPitchRange } from "../../Source/Cesium.js";
-import { HeadingPitchRoll } from "../../Source/Cesium.js";
-import { isDataUri } from "../../Source/Cesium.js";
-import { Iso8601 } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  ArcType,
+  BoundingRectangle,
+  Cartesian2,
+  Cartesian3,
+  ClockRange,
+  ClockStep,
+  Color,
+  combine,
+  Credit,
+  defer,
+  Ellipsoid,
+  Event,
+  HeadingPitchRange,
+  HeadingPitchRoll,
+  isDataUri,
+  Iso8601,
+  JulianDate,
+  NearFarScalar,
+  PerspectiveFrustum,
+  Rectangle,
+  RequestErrorEvent,
+  Resource,
+  RuntimeError,
+  ColorMaterialProperty,
+  EntityCollection,
+  ImageMaterialProperty,
+  KmlCamera,
+  KmlDataSource,
+  KmlLookAt,
+  KmlTour,
+  KmlTourFlyTo,
+  KmlTourWait,
+  Camera,
+  HeightReference,
+  HorizontalOrigin,
+  LabelStyle,
+  SceneMode,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { NearFarScalar } from "../../Source/Cesium.js";
-import { PerspectiveFrustum } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { RequestErrorEvent } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { RuntimeError } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { EntityCollection } from "../../Source/Cesium.js";
-import { ImageMaterialProperty } from "../../Source/Cesium.js";
-import { KmlCamera } from "../../Source/Cesium.js";
-import { KmlDataSource } from "../../Source/Cesium.js";
-import { KmlLookAt } from "../../Source/Cesium.js";
-import { KmlTour } from "../../Source/Cesium.js";
-import { KmlTourFlyTo } from "../../Source/Cesium.js";
-import { KmlTourWait } from "../../Source/Cesium.js";
-import { Camera } from "../../Source/Cesium.js";
-import { HeightReference } from "../../Source/Cesium.js";
-import { HorizontalOrigin } from "../../Source/Cesium.js";
-import { LabelStyle } from "../../Source/Cesium.js";
-import { SceneMode } from "../../Source/Cesium.js";
+
 import createCamera from "../createCamera.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/DataSources/KmlTourFlyToSpec.js
+++ b/Specs/DataSources/KmlTourFlyToSpec.js
@@ -1,10 +1,14 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { HeadingPitchRange } from "../../Source/Cesium.js";
-import { HeadingPitchRoll } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  HeadingPitchRange,
+  HeadingPitchRoll,
+  KmlCamera,
+  KmlLookAt,
+  KmlTourFlyTo,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { KmlCamera } from "../../Source/Cesium.js";
-import { KmlLookAt } from "../../Source/Cesium.js";
-import { KmlTourFlyTo } from "../../Source/Cesium.js";
+
 import pollToPromise from "../pollToPromise.js";
 
 describe("DataSources/KmlTourFlyTo", function () {

--- a/Specs/DataSources/KmlTourSpec.js
+++ b/Specs/DataSources/KmlTourSpec.js
@@ -1,10 +1,14 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { HeadingPitchRange } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  HeadingPitchRange,
+  KmlLookAt,
+  KmlTour,
+  KmlTourFlyTo,
+  KmlTourWait,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { KmlLookAt } from "../../Source/Cesium.js";
-import { KmlTour } from "../../Source/Cesium.js";
-import { KmlTourFlyTo } from "../../Source/Cesium.js";
-import { KmlTourWait } from "../../Source/Cesium.js";
+
 import pollToPromise from "../pollToPromise.js";
 
 describe("DataSources/KmlTour", function () {

--- a/Specs/DataSources/LabelGraphicsSpec.js
+++ b/Specs/DataSources/LabelGraphicsSpec.js
@@ -1,13 +1,15 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { NearFarScalar } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { LabelGraphics } from "../../Source/Cesium.js";
-import { HorizontalOrigin } from "../../Source/Cesium.js";
-import { LabelStyle } from "../../Source/Cesium.js";
-import { VerticalOrigin } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Color,
+  DistanceDisplayCondition,
+  NearFarScalar,
+  ConstantProperty,
+  LabelGraphics,
+  HorizontalOrigin,
+  LabelStyle,
+  VerticalOrigin,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/LabelGraphics", function () {
   it("creates expected instance from raw assignment and construction", function () {

--- a/Specs/DataSources/LabelVisualizerSpec.js
+++ b/Specs/DataSources/LabelVisualizerSpec.js
@@ -1,20 +1,23 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { NearFarScalar } from "../../Source/Cesium.js";
-import { BoundingSphereState } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { EntityCluster } from "../../Source/Cesium.js";
-import { EntityCollection } from "../../Source/Cesium.js";
-import { LabelGraphics } from "../../Source/Cesium.js";
-import { LabelVisualizer } from "../../Source/Cesium.js";
-import { HorizontalOrigin } from "../../Source/Cesium.js";
-import { LabelStyle } from "../../Source/Cesium.js";
-import { VerticalOrigin } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Cartesian2,
+  Cartesian3,
+  Color,
+  defined,
+  DistanceDisplayCondition,
+  JulianDate,
+  NearFarScalar,
+  BoundingSphereState,
+  ConstantProperty,
+  EntityCluster,
+  EntityCollection,
+  LabelGraphics,
+  LabelVisualizer,
+  HorizontalOrigin,
+  LabelStyle,
+  VerticalOrigin,
+} from "../../../Source/Cesium.js";
+
 import createGlobe from "../createGlobe.js";
 import createScene from "../createScene.js";
 

--- a/Specs/DataSources/ModelGraphicsSpec.js
+++ b/Specs/DataSources/ModelGraphicsSpec.js
@@ -1,17 +1,19 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { ModelGraphics } from "../../Source/Cesium.js";
-import { NodeTransformationProperty } from "../../Source/Cesium.js";
-import { PropertyBag } from "../../Source/Cesium.js";
-import { ClippingPlaneCollection } from "../../Source/Cesium.js";
-import { ColorBlendMode } from "../../Source/Cesium.js";
-import { HeightReference } from "../../Source/Cesium.js";
-import { ShadowMode } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Color,
+  DistanceDisplayCondition,
+  JulianDate,
+  Quaternion,
+  ConstantProperty,
+  ModelGraphics,
+  NodeTransformationProperty,
+  PropertyBag,
+  ClippingPlaneCollection,
+  ColorBlendMode,
+  HeightReference,
+  ShadowMode,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/ModelGraphics", function () {
   it("creates expected instance from raw assignment and construction", function () {

--- a/Specs/DataSources/NodeTransformationPropertySpec.js
+++ b/Specs/DataSources/NodeTransformationPropertySpec.js
@@ -1,10 +1,13 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { NodeTransformationProperty } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionProperty } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  JulianDate,
+  Quaternion,
+  TimeInterval,
+  ConstantProperty,
+  NodeTransformationProperty,
+  TimeIntervalCollectionProperty,
+} from "../../../Source/Cesium.js";
+
 import testDefinitionChanged from "../testDefinitionChanged.js";
 
 describe("DataSources/NodeTransformationProperty", function () {

--- a/Specs/DataSources/PathGraphicsSpec.js
+++ b/Specs/DataSources/PathGraphicsSpec.js
@@ -1,8 +1,10 @@
-import { Color } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { PathGraphics } from "../../Source/Cesium.js";
+import {
+  Color,
+  DistanceDisplayCondition,
+  ColorMaterialProperty,
+  ConstantProperty,
+  PathGraphics,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/PathGraphics", function () {
   it("creates expected instance from raw assignment and construction", function () {

--- a/Specs/DataSources/PathVisualizerSpec.js
+++ b/Specs/DataSources/PathVisualizerSpec.js
@@ -1,23 +1,26 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { ReferenceFrame } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { CompositePositionProperty } from "../../Source/Cesium.js";
-import { ConstantPositionProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { EntityCollection } from "../../Source/Cesium.js";
-import { PathGraphics } from "../../Source/Cesium.js";
-import { PathVisualizer } from "../../Source/Cesium.js";
-import { PolylineGlowMaterialProperty } from "../../Source/Cesium.js";
-import { PolylineOutlineMaterialProperty } from "../../Source/Cesium.js";
-import { ReferenceProperty } from "../../Source/Cesium.js";
-import { SampledPositionProperty } from "../../Source/Cesium.js";
-import { ScaledPositionProperty } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionPositionProperty } from "../../Source/Cesium.js";
-import { SceneMode } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Color,
+  DistanceDisplayCondition,
+  JulianDate,
+  Matrix4,
+  ReferenceFrame,
+  TimeInterval,
+  CompositePositionProperty,
+  ConstantPositionProperty,
+  ConstantProperty,
+  EntityCollection,
+  PathGraphics,
+  PathVisualizer,
+  PolylineGlowMaterialProperty,
+  PolylineOutlineMaterialProperty,
+  ReferenceProperty,
+  SampledPositionProperty,
+  ScaledPositionProperty,
+  TimeIntervalCollectionPositionProperty,
+  SceneMode,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/DataSources/PlaneGeometryUpdaterSpec.js
+++ b/Specs/DataSources/PlaneGeometryUpdaterSpec.js
@@ -1,14 +1,17 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { Plane } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { ConstantPositionProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { PlaneGeometryUpdater } from "../../Source/Cesium.js";
-import { PlaneGraphics } from "../../Source/Cesium.js";
-import { PrimitiveCollection } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  JulianDate,
+  Plane,
+  TimeIntervalCollection,
+  ConstantPositionProperty,
+  ConstantProperty,
+  Entity,
+  PlaneGeometryUpdater,
+  PlaneGraphics,
+  PrimitiveCollection,
+} from "../../../Source/Cesium.js";
+
 import createDynamicGeometryUpdaterSpecs from "../createDynamicGeometryUpdaterSpecs.js";
 import createDynamicProperty from "../createDynamicProperty.js";
 import createGeometryUpdaterSpecs from "../createGeometryUpdaterSpecs.js";

--- a/Specs/DataSources/PlaneGraphicsSpec.js
+++ b/Specs/DataSources/PlaneGraphicsSpec.js
@@ -1,12 +1,15 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { Plane } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { PlaneGraphics } from "../../Source/Cesium.js";
-import { ShadowMode } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Color,
+  DistanceDisplayCondition,
+  Plane,
+  ColorMaterialProperty,
+  ConstantProperty,
+  PlaneGraphics,
+  ShadowMode,
+} from "../../../Source/Cesium.js";
+
 import testDefinitionChanged from "../testDefinitionChanged.js";
 import testMaterialDefinitionChanged from "../testMaterialDefinitionChanged.js";
 

--- a/Specs/DataSources/PointGraphicsSpec.js
+++ b/Specs/DataSources/PointGraphicsSpec.js
@@ -1,9 +1,11 @@
-import { Color } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { NearFarScalar } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { PointGraphics } from "../../Source/Cesium.js";
-import { HeightReference } from "../../Source/Cesium.js";
+import {
+  Color,
+  DistanceDisplayCondition,
+  NearFarScalar,
+  ConstantProperty,
+  PointGraphics,
+  HeightReference,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/PointGraphics", function () {
   it("creates expected instance from raw assignment and construction", function () {

--- a/Specs/DataSources/PointVisualizerSpec.js
+++ b/Specs/DataSources/PointVisualizerSpec.js
@@ -1,21 +1,24 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { Event } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { NearFarScalar } from "../../Source/Cesium.js";
-import { BoundingSphereState } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { EntityCluster } from "../../Source/Cesium.js";
-import { EntityCollection } from "../../Source/Cesium.js";
-import { PointGraphics } from "../../Source/Cesium.js";
-import { PointVisualizer } from "../../Source/Cesium.js";
-import { BillboardCollection } from "../../Source/Cesium.js";
-import { HeightReference } from "../../Source/Cesium.js";
-import { PointPrimitiveCollection } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Cartesian3,
+  Color,
+  defined,
+  DistanceDisplayCondition,
+  Ellipsoid,
+  Event,
+  JulianDate,
+  NearFarScalar,
+  BoundingSphereState,
+  ConstantProperty,
+  EntityCluster,
+  EntityCollection,
+  PointGraphics,
+  PointVisualizer,
+  BillboardCollection,
+  HeightReference,
+  PointPrimitiveCollection,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/DataSources/PolygonGeometryUpdaterSpec.js
+++ b/Specs/DataSources/PolygonGeometryUpdaterSpec.js
@@ -1,27 +1,31 @@
-import { ApproximateTerrainHeights } from "../../Source/Cesium.js";
-import { ArcType } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { CoplanarPolygonGeometry } from "../../Source/Cesium.js";
-import { CoplanarPolygonOutlineGeometry } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  ApproximateTerrainHeights,
+  ArcType,
+  Cartesian2,
+  Cartesian3,
+  Color,
+  CoplanarPolygonGeometry,
+  CoplanarPolygonOutlineGeometry,
+  Ellipsoid,
+  JulianDate,
+  PolygonGeometry,
+  PolygonHierarchy,
+  PolygonOutlineGeometry,
+  TimeIntervalCollection,
+  ConstantProperty,
+  Entity,
+  PolygonGeometryUpdater,
+  PolygonGraphics,
+  PropertyArray,
+  SampledPositionProperty,
+  SampledProperty,
+  GroundPrimitive,
+  HeightReference,
+  PrimitiveCollection,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { PolygonGeometry } from "../../Source/Cesium.js";
-import { PolygonHierarchy } from "../../Source/Cesium.js";
-import { PolygonOutlineGeometry } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { PolygonGeometryUpdater } from "../../Source/Cesium.js";
-import { PolygonGraphics } from "../../Source/Cesium.js";
-import { PropertyArray } from "../../Source/Cesium.js";
-import { SampledPositionProperty } from "../../Source/Cesium.js";
-import { SampledProperty } from "../../Source/Cesium.js";
-import { GroundPrimitive } from "../../Source/Cesium.js";
-import { HeightReference } from "../../Source/Cesium.js";
-import { PrimitiveCollection } from "../../Source/Cesium.js";
+
 import createDynamicGeometryUpdaterSpecs from "../createDynamicGeometryUpdaterSpecs.js";
 import createDynamicProperty from "../createDynamicProperty.js";
 import createGeometryUpdaterGroundGeometrySpecs from "../createGeometryUpdaterGroundGeometrySpecs.js";

--- a/Specs/DataSources/PolygonGraphicsSpec.js
+++ b/Specs/DataSources/PolygonGraphicsSpec.js
@@ -1,13 +1,16 @@
-import { ArcType } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { PolygonHierarchy } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { PolygonGraphics } from "../../Source/Cesium.js";
-import { ClassificationType } from "../../Source/Cesium.js";
-import { ShadowMode } from "../../Source/Cesium.js";
+import {
+  ArcType,
+  Cartesian3,
+  Color,
+  DistanceDisplayCondition,
+  PolygonHierarchy,
+  ColorMaterialProperty,
+  ConstantProperty,
+  PolygonGraphics,
+  ClassificationType,
+  ShadowMode,
+} from "../../../Source/Cesium.js";
+
 import testDefinitionChanged from "../testDefinitionChanged.js";
 import testMaterialDefinitionChanged from "../testMaterialDefinitionChanged.js";
 

--- a/Specs/DataSources/PolylineArrowMaterialPropertySpec.js
+++ b/Specs/DataSources/PolylineArrowMaterialPropertySpec.js
@@ -1,9 +1,11 @@
-import { Color } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { PolylineArrowMaterialProperty } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionProperty } from "../../Source/Cesium.js";
+import {
+  Color,
+  JulianDate,
+  TimeInterval,
+  ConstantProperty,
+  PolylineArrowMaterialProperty,
+  TimeIntervalCollectionProperty,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/PolylineArrowMaterialProperty", function () {
   it("constructor provides the expected defaults", function () {

--- a/Specs/DataSources/PolylineDashMaterialPropertySpec.js
+++ b/Specs/DataSources/PolylineDashMaterialPropertySpec.js
@@ -1,9 +1,11 @@
-import { Color } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { PolylineDashMaterialProperty } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionProperty } from "../../Source/Cesium.js";
+import {
+  Color,
+  JulianDate,
+  TimeInterval,
+  ConstantProperty,
+  PolylineDashMaterialProperty,
+  TimeIntervalCollectionProperty,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/PolylineDashMaterialProperty", function () {
   it("constructor provides the expected defaults", function () {

--- a/Specs/DataSources/PolylineGeometryUpdaterSpec.js
+++ b/Specs/DataSources/PolylineGeometryUpdaterSpec.js
@@ -1,33 +1,36 @@
-import { ApproximateTerrainHeights } from "../../Source/Cesium.js";
-import { ArcType } from "../../Source/Cesium.js";
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { DistanceDisplayConditionGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { GroundPolylineGeometry } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { PolylinePipeline } from "../../Source/Cesium.js";
-import { ShowGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { BoundingSphereState } from "../../Source/Cesium.js";
-import { CallbackProperty } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { GridMaterialProperty } from "../../Source/Cesium.js";
-import { PolylineGeometryUpdater } from "../../Source/Cesium.js";
-import { PolylineGraphics } from "../../Source/Cesium.js";
-import { PropertyArray } from "../../Source/Cesium.js";
-import { SampledPositionProperty } from "../../Source/Cesium.js";
-import { SampledProperty } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionProperty } from "../../Source/Cesium.js";
-import { Globe } from "../../Source/Cesium.js";
-import { GroundPolylinePrimitive } from "../../Source/Cesium.js";
-import { ShadowMode } from "../../Source/Cesium.js";
+import {
+  ApproximateTerrainHeights,
+  ArcType,
+  BoundingSphere,
+  Cartesian3,
+  Color,
+  ColorGeometryInstanceAttribute,
+  defined,
+  DistanceDisplayCondition,
+  DistanceDisplayConditionGeometryInstanceAttribute,
+  GroundPolylineGeometry,
+  JulianDate,
+  PolylinePipeline,
+  ShowGeometryInstanceAttribute,
+  TimeInterval,
+  TimeIntervalCollection,
+  BoundingSphereState,
+  CallbackProperty,
+  ColorMaterialProperty,
+  ConstantProperty,
+  Entity,
+  GridMaterialProperty,
+  PolylineGeometryUpdater,
+  PolylineGraphics,
+  PropertyArray,
+  SampledPositionProperty,
+  SampledProperty,
+  TimeIntervalCollectionProperty,
+  Globe,
+  GroundPolylinePrimitive,
+  ShadowMode,
+} from "../../../Source/Cesium.js";
+
 import createDynamicProperty from "../createDynamicProperty.js";
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";

--- a/Specs/DataSources/PolylineGlowMaterialPropertySpec.js
+++ b/Specs/DataSources/PolylineGlowMaterialPropertySpec.js
@@ -1,9 +1,12 @@
-import { Color } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { PolylineGlowMaterialProperty } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionProperty } from "../../Source/Cesium.js";
+import {
+  Color,
+  JulianDate,
+  TimeInterval,
+  ConstantProperty,
+  PolylineGlowMaterialProperty,
+  TimeIntervalCollectionProperty,
+} from "../../../Source/Cesium.js";
+
 import testDefinitionChanged from "../testDefinitionChanged.js";
 
 describe("DataSources/PolylineGlowMaterialProperty", function () {

--- a/Specs/DataSources/PolylineGraphicsSpec.js
+++ b/Specs/DataSources/PolylineGraphicsSpec.js
@@ -1,11 +1,14 @@
-import { ArcType } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { PolylineGraphics } from "../../Source/Cesium.js";
-import { ClassificationType } from "../../Source/Cesium.js";
-import { ShadowMode } from "../../Source/Cesium.js";
+import {
+  ArcType,
+  Color,
+  DistanceDisplayCondition,
+  ColorMaterialProperty,
+  ConstantProperty,
+  PolylineGraphics,
+  ClassificationType,
+  ShadowMode,
+} from "../../../Source/Cesium.js";
+
 import testDefinitionChanged from "../testDefinitionChanged.js";
 import testMaterialDefinitionChanged from "../testMaterialDefinitionChanged.js";
 

--- a/Specs/DataSources/PolylineOutlineMaterialPropertySpec.js
+++ b/Specs/DataSources/PolylineOutlineMaterialPropertySpec.js
@@ -1,9 +1,11 @@
-import { Color } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { PolylineOutlineMaterialProperty } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionProperty } from "../../Source/Cesium.js";
+import {
+  Color,
+  JulianDate,
+  TimeInterval,
+  ConstantProperty,
+  PolylineOutlineMaterialProperty,
+  TimeIntervalCollectionProperty,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/PolylineOutlineMaterialProperty", function () {
   it("constructor provides the expected defaults", function () {

--- a/Specs/DataSources/PolylineVisualizerSpec.js
+++ b/Specs/DataSources/PolylineVisualizerSpec.js
@@ -1,24 +1,27 @@
-import { ApproximateTerrainHeights } from "../../Source/Cesium.js";
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { ShowGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { BoundingSphereState } from "../../Source/Cesium.js";
-import { CallbackProperty } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { ConstantPositionProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { EntityCollection } from "../../Source/Cesium.js";
-import { PolylineArrowMaterialProperty } from "../../Source/Cesium.js";
-import { PolylineGraphics } from "../../Source/Cesium.js";
-import { PolylineVisualizer } from "../../Source/Cesium.js";
-import { ClassificationType } from "../../Source/Cesium.js";
-import { PolylineColorAppearance } from "../../Source/Cesium.js";
-import { PolylineMaterialAppearance } from "../../Source/Cesium.js";
-import { ShadowMode } from "../../Source/Cesium.js";
+import {
+  ApproximateTerrainHeights,
+  BoundingSphere,
+  Cartesian3,
+  Color,
+  ColorGeometryInstanceAttribute,
+  JulianDate,
+  ShowGeometryInstanceAttribute,
+  BoundingSphereState,
+  CallbackProperty,
+  ColorMaterialProperty,
+  ConstantPositionProperty,
+  ConstantProperty,
+  Entity,
+  EntityCollection,
+  PolylineArrowMaterialProperty,
+  PolylineGraphics,
+  PolylineVisualizer,
+  ClassificationType,
+  PolylineColorAppearance,
+  PolylineMaterialAppearance,
+  ShadowMode,
+} from "../../../Source/Cesium.js";
+
 import createDynamicProperty from "../createDynamicProperty.js";
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";

--- a/Specs/DataSources/PolylineVolumeGeometryUpdaterSpec.js
+++ b/Specs/DataSources/PolylineVolumeGeometryUpdaterSpec.js
@@ -1,15 +1,18 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { CornerType } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { PolylineVolumeGeometryUpdater } from "../../Source/Cesium.js";
-import { PolylineVolumeGraphics } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionProperty } from "../../Source/Cesium.js";
-import { PrimitiveCollection } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  CornerType,
+  JulianDate,
+  TimeInterval,
+  TimeIntervalCollection,
+  ConstantProperty,
+  Entity,
+  PolylineVolumeGeometryUpdater,
+  PolylineVolumeGraphics,
+  TimeIntervalCollectionProperty,
+  PrimitiveCollection,
+} from "../../../Source/Cesium.js";
+
 import createDynamicGeometryUpdaterSpecs from "../createDynamicGeometryUpdaterSpecs.js";
 import createDynamicProperty from "../createDynamicProperty.js";
 import createGeometryUpdaterSpecs from "../createGeometryUpdaterSpecs.js";

--- a/Specs/DataSources/PolylineVolumeGraphicsSpec.js
+++ b/Specs/DataSources/PolylineVolumeGraphicsSpec.js
@@ -1,10 +1,13 @@
-import { Color } from "../../Source/Cesium.js";
-import { CornerType } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { PolylineVolumeGraphics } from "../../Source/Cesium.js";
-import { ShadowMode } from "../../Source/Cesium.js";
+import {
+  Color,
+  CornerType,
+  DistanceDisplayCondition,
+  ColorMaterialProperty,
+  ConstantProperty,
+  PolylineVolumeGraphics,
+  ShadowMode,
+} from "../../../Source/Cesium.js";
+
 import testDefinitionChanged from "../testDefinitionChanged.js";
 import testMaterialDefinitionChanged from "../testMaterialDefinitionChanged.js";
 

--- a/Specs/DataSources/PositionPropertyArraySpec.js
+++ b/Specs/DataSources/PositionPropertyArraySpec.js
@@ -1,9 +1,11 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { ReferenceFrame } from "../../Source/Cesium.js";
-import { ConstantPositionProperty } from "../../Source/Cesium.js";
-import { PositionPropertyArray } from "../../Source/Cesium.js";
-import { SampledPositionProperty } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  JulianDate,
+  ReferenceFrame,
+  ConstantPositionProperty,
+  PositionPropertyArray,
+  SampledPositionProperty,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/PositionPropertyArray", function () {
   const time = JulianDate.now();

--- a/Specs/DataSources/PropertyArraySpec.js
+++ b/Specs/DataSources/PropertyArraySpec.js
@@ -1,7 +1,9 @@
-import { JulianDate } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { PropertyArray } from "../../Source/Cesium.js";
-import { SampledProperty } from "../../Source/Cesium.js";
+import {
+  JulianDate,
+  ConstantProperty,
+  PropertyArray,
+  SampledProperty,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/PropertyArray", function () {
   const time = JulianDate.now();

--- a/Specs/DataSources/PropertyBagSpec.js
+++ b/Specs/DataSources/PropertyBagSpec.js
@@ -1,7 +1,9 @@
-import { JulianDate } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { PropertyBag } from "../../Source/Cesium.js";
-import { SampledProperty } from "../../Source/Cesium.js";
+import {
+  JulianDate,
+  ConstantProperty,
+  PropertyBag,
+  SampledProperty,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/PropertyBag", function () {
   const time = JulianDate.now();

--- a/Specs/DataSources/RectangleGeometryUpdaterSpec.js
+++ b/Specs/DataSources/RectangleGeometryUpdaterSpec.js
@@ -1,15 +1,19 @@
-import { ApproximateTerrainHeights } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  ApproximateTerrainHeights,
+  Cartesian3,
+  JulianDate,
+  Rectangle,
+  TimeIntervalCollection,
+  ConstantProperty,
+  Entity,
+  RectangleGeometryUpdater,
+  RectangleGraphics,
+  SampledProperty,
+  PrimitiveCollection,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { RectangleGeometryUpdater } from "../../Source/Cesium.js";
-import { RectangleGraphics } from "../../Source/Cesium.js";
-import { SampledProperty } from "../../Source/Cesium.js";
-import { PrimitiveCollection } from "../../Source/Cesium.js";
+
 import createDynamicGeometryUpdaterSpecs from "../createDynamicGeometryUpdaterSpecs.js";
 import createDynamicProperty from "../createDynamicProperty.js";
 import createGeometryUpdaterGroundGeometrySpecs from "../createGeometryUpdaterGroundGeometrySpecs.js";

--- a/Specs/DataSources/RectangleGraphicsSpec.js
+++ b/Specs/DataSources/RectangleGraphicsSpec.js
@@ -1,11 +1,14 @@
-import { Color } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { RectangleGraphics } from "../../Source/Cesium.js";
-import { ClassificationType } from "../../Source/Cesium.js";
-import { ShadowMode } from "../../Source/Cesium.js";
+import {
+  Color,
+  DistanceDisplayCondition,
+  Rectangle,
+  ColorMaterialProperty,
+  ConstantProperty,
+  RectangleGraphics,
+  ClassificationType,
+  ShadowMode,
+} from "../../../Source/Cesium.js";
+
 import testDefinitionChanged from "../testDefinitionChanged.js";
 import testMaterialDefinitionChanged from "../testMaterialDefinitionChanged.js";
 

--- a/Specs/DataSources/ReferencePropertySpec.js
+++ b/Specs/DataSources/ReferencePropertySpec.js
@@ -1,14 +1,16 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { ReferenceFrame } from "../../Source/Cesium.js";
-import { BillboardGraphics } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { ConstantPositionProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { EntityCollection } from "../../Source/Cesium.js";
-import { ReferenceProperty } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Color,
+  JulianDate,
+  ReferenceFrame,
+  BillboardGraphics,
+  ColorMaterialProperty,
+  ConstantPositionProperty,
+  ConstantProperty,
+  Entity,
+  EntityCollection,
+  ReferenceProperty,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/ReferenceProperty", function () {
   const time = JulianDate.now();

--- a/Specs/DataSources/RotationSpec.js
+++ b/Specs/DataSources/RotationSpec.js
@@ -1,7 +1,11 @@
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  JulianDate,
+  Rotation,
+  SampledProperty,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Rotation } from "../../Source/Cesium.js";
-import { SampledProperty } from "../../Source/Cesium.js";
+
 import createPackableSpecs from "../createPackableSpecs.js";
 
 describe("DataSources/Rotation", function () {

--- a/Specs/DataSources/SampledPositionPropertySpec.js
+++ b/Specs/DataSources/SampledPositionPropertySpec.js
@@ -1,12 +1,14 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { ExtrapolationType } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { LagrangePolynomialApproximation } from "../../Source/Cesium.js";
-import { LinearApproximation } from "../../Source/Cesium.js";
-import { ReferenceFrame } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { PositionProperty } from "../../Source/Cesium.js";
-import { SampledPositionProperty } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  ExtrapolationType,
+  JulianDate,
+  LagrangePolynomialApproximation,
+  LinearApproximation,
+  ReferenceFrame,
+  TimeInterval,
+  PositionProperty,
+  SampledPositionProperty,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/SampledPositionProperty", function () {
   it("constructor sets expected defaults", function () {

--- a/Specs/DataSources/SampledPropertySpec.js
+++ b/Specs/DataSources/SampledPropertySpec.js
@@ -1,14 +1,17 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { ExtrapolationType } from "../../Source/Cesium.js";
-import { HermitePolynomialApproximation } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { LagrangePolynomialApproximation } from "../../Source/Cesium.js";
-import { LinearApproximation } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  defined,
+  ExtrapolationType,
+  HermitePolynomialApproximation,
+  JulianDate,
+  LagrangePolynomialApproximation,
+  LinearApproximation,
+  Quaternion,
+  TimeInterval,
+  SampledProperty,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { SampledProperty } from "../../Source/Cesium.js";
 
 describe("DataSources/SampledProperty", function () {
   it("constructor sets expected defaults", function () {

--- a/Specs/DataSources/StaticGeometryColorBatchSpec.js
+++ b/Specs/DataSources/StaticGeometryColorBatchSpec.js
@@ -1,20 +1,24 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Color,
+  DistanceDisplayCondition,
+  JulianDate,
+  TimeInterval,
+  TimeIntervalCollection,
+  CallbackProperty,
+  ColorMaterialProperty,
+  EllipseGeometryUpdater,
+  Entity,
+  PolylineGeometryUpdater,
+  StaticGeometryColorBatch,
+  TimeIntervalCollectionProperty,
+  PerInstanceColorAppearance,
+  PolylineColorAppearance,
+  ShadowMode,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { CallbackProperty } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { EllipseGeometryUpdater } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { PolylineGeometryUpdater } from "../../Source/Cesium.js";
-import { StaticGeometryColorBatch } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionProperty } from "../../Source/Cesium.js";
-import { PerInstanceColorAppearance } from "../../Source/Cesium.js";
-import { PolylineColorAppearance } from "../../Source/Cesium.js";
-import { ShadowMode } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/DataSources/StaticGeometryPerMaterialBatchSpec.js
+++ b/Specs/DataSources/StaticGeometryPerMaterialBatchSpec.js
@@ -1,30 +1,34 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Color,
+  DistanceDisplayCondition,
+  JulianDate,
+  TimeInterval,
+  TimeIntervalCollection,
+  BoxGeometryUpdater,
+  CheckerboardMaterialProperty,
+  ColorMaterialProperty,
+  ConstantPositionProperty,
+  ConstantProperty,
+  EllipseGeometryUpdater,
+  EllipseGraphics,
+  Entity,
+  GridMaterialProperty,
+  PolylineArrowMaterialProperty,
+  PolylineGeometryUpdater,
+  PolylineGraphics,
+  StaticGeometryPerMaterialBatch,
+  StripeMaterialProperty,
+  TimeIntervalCollectionProperty,
+  MaterialAppearance,
+  PolylineColorAppearance,
+  PolylineMaterialAppearance,
+  ShadowMode,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { BoxGeometryUpdater } from "../../Source/Cesium.js";
-import { CheckerboardMaterialProperty } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { ConstantPositionProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { EllipseGeometryUpdater } from "../../Source/Cesium.js";
-import { EllipseGraphics } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { GridMaterialProperty } from "../../Source/Cesium.js";
-import { PolylineArrowMaterialProperty } from "../../Source/Cesium.js";
-import { PolylineGeometryUpdater } from "../../Source/Cesium.js";
-import { PolylineGraphics } from "../../Source/Cesium.js";
-import { StaticGeometryPerMaterialBatch } from "../../Source/Cesium.js";
-import { StripeMaterialProperty } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionProperty } from "../../Source/Cesium.js";
-import { MaterialAppearance } from "../../Source/Cesium.js";
-import { PolylineColorAppearance } from "../../Source/Cesium.js";
-import { PolylineMaterialAppearance } from "../../Source/Cesium.js";
-import { ShadowMode } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/DataSources/StaticGroundGeometryColorBatchSpec.js
+++ b/Specs/DataSources/StaticGroundGeometryColorBatchSpec.js
@@ -1,18 +1,22 @@
-import { ApproximateTerrainHeights } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  ApproximateTerrainHeights,
+  Cartesian3,
+  Color,
+  DistanceDisplayCondition,
+  JulianDate,
+  TimeInterval,
+  TimeIntervalCollection,
+  CallbackProperty,
+  EllipseGeometryUpdater,
+  Entity,
+  StaticGroundGeometryColorBatch,
+  TimeIntervalCollectionProperty,
+  ClassificationType,
+  GroundPrimitive,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { CallbackProperty } from "../../Source/Cesium.js";
-import { EllipseGeometryUpdater } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { StaticGroundGeometryColorBatch } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionProperty } from "../../Source/Cesium.js";
-import { ClassificationType } from "../../Source/Cesium.js";
-import { GroundPrimitive } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/DataSources/StaticGroundGeometryPerMaterialBatchSpec.js
+++ b/Specs/DataSources/StaticGroundGeometryPerMaterialBatchSpec.js
@@ -1,22 +1,26 @@
-import { ApproximateTerrainHeights } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  ApproximateTerrainHeights,
+  Cartesian2,
+  Cartesian3,
+  Color,
+  DistanceDisplayCondition,
+  JulianDate,
+  TimeInterval,
+  TimeIntervalCollection,
+  ConstantProperty,
+  EllipseGeometryUpdater,
+  EllipseGraphics,
+  Entity,
+  GridMaterialProperty,
+  StaticGroundGeometryPerMaterialBatch,
+  TimeIntervalCollectionProperty,
+  ClassificationType,
+  GroundPrimitive,
+  MaterialAppearance,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { EllipseGeometryUpdater } from "../../Source/Cesium.js";
-import { EllipseGraphics } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { GridMaterialProperty } from "../../Source/Cesium.js";
-import { StaticGroundGeometryPerMaterialBatch } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionProperty } from "../../Source/Cesium.js";
-import { ClassificationType } from "../../Source/Cesium.js";
-import { GroundPrimitive } from "../../Source/Cesium.js";
-import { MaterialAppearance } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/DataSources/StaticGroundPolylinePerMaterialBatchSpec.js
+++ b/Specs/DataSources/StaticGroundPolylinePerMaterialBatchSpec.js
@@ -1,24 +1,28 @@
-import { ApproximateTerrainHeights } from "../../Source/Cesium.js";
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  ApproximateTerrainHeights,
+  BoundingSphere,
+  Cartesian3,
+  Color,
+  defined,
+  DistanceDisplayCondition,
+  JulianDate,
+  TimeInterval,
+  TimeIntervalCollection,
+  BoundingSphereState,
+  ColorMaterialProperty,
+  ConstantProperty,
+  Entity,
+  PolylineGeometryUpdater,
+  PolylineGraphics,
+  PolylineOutlineMaterialProperty,
+  StaticGroundPolylinePerMaterialBatch,
+  TimeIntervalCollectionProperty,
+  ClassificationType,
+  GroundPolylinePrimitive,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { BoundingSphereState } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { PolylineGeometryUpdater } from "../../Source/Cesium.js";
-import { PolylineGraphics } from "../../Source/Cesium.js";
-import { PolylineOutlineMaterialProperty } from "../../Source/Cesium.js";
-import { StaticGroundPolylinePerMaterialBatch } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionProperty } from "../../Source/Cesium.js";
-import { ClassificationType } from "../../Source/Cesium.js";
-import { GroundPolylinePrimitive } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/DataSources/StaticOutlineGeometryBatchSpec.js
+++ b/Specs/DataSources/StaticOutlineGeometryBatchSpec.js
@@ -1,16 +1,20 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Color,
+  DistanceDisplayCondition,
+  JulianDate,
+  TimeInterval,
+  TimeIntervalCollection,
+  CallbackProperty,
+  EllipseGeometryUpdater,
+  Entity,
+  StaticOutlineGeometryBatch,
+  TimeIntervalCollectionProperty,
+  ShadowMode,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { CallbackProperty } from "../../Source/Cesium.js";
-import { EllipseGeometryUpdater } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { StaticOutlineGeometryBatch } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionProperty } from "../../Source/Cesium.js";
-import { ShadowMode } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/DataSources/StripeMaterialPropertySpec.js
+++ b/Specs/DataSources/StripeMaterialPropertySpec.js
@@ -1,10 +1,13 @@
-import { Color } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { StripeMaterialProperty } from "../../Source/Cesium.js";
-import { StripeOrientation } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionProperty } from "../../Source/Cesium.js";
+import {
+  Color,
+  JulianDate,
+  TimeInterval,
+  ConstantProperty,
+  StripeMaterialProperty,
+  StripeOrientation,
+  TimeIntervalCollectionProperty,
+} from "../../../Source/Cesium.js";
+
 import testDefinitionChanged from "../testDefinitionChanged.js";
 
 describe("DataSources/StripeMaterialProperty", function () {

--- a/Specs/DataSources/TerrainOffsetPropertySpec.js
+++ b/Specs/DataSources/TerrainOffsetPropertySpec.js
@@ -1,8 +1,11 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { CallbackProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { TerrainOffsetProperty } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  JulianDate,
+  CallbackProperty,
+  ConstantProperty,
+  TerrainOffsetProperty,
+} from "../../../Source/Cesium.js";
+
 import createGlobe from "../createGlobe.js";
 import createScene from "../createScene.js";
 

--- a/Specs/DataSources/TimeIntervalCollectionPositionPropertySpec.js
+++ b/Specs/DataSources/TimeIntervalCollectionPositionPropertySpec.js
@@ -1,10 +1,12 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { ReferenceFrame } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { PositionProperty } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionPositionProperty } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  JulianDate,
+  ReferenceFrame,
+  TimeInterval,
+  TimeIntervalCollection,
+  PositionProperty,
+  TimeIntervalCollectionPositionProperty,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/TimeIntervalCollectionPositionProperty", function () {
   it("default constructor has expected values", function () {

--- a/Specs/DataSources/TimeIntervalCollectionPropertySpec.js
+++ b/Specs/DataSources/TimeIntervalCollectionPropertySpec.js
@@ -1,8 +1,10 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionProperty } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  JulianDate,
+  TimeInterval,
+  TimeIntervalCollection,
+  TimeIntervalCollectionProperty,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/TimeIntervalCollectionProperty", function () {
   it("default constructor has expected values", function () {

--- a/Specs/DataSources/VelocityOrientationPropertySpec.js
+++ b/Specs/DataSources/VelocityOrientationPropertySpec.js
@@ -1,13 +1,15 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { Event } from "../../Source/Cesium.js";
-import { ExtrapolationType } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { Quaternion } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
-import { CallbackProperty } from "../../Source/Cesium.js";
-import { SampledPositionProperty } from "../../Source/Cesium.js";
-import { VelocityOrientationProperty } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Ellipsoid,
+  Event,
+  ExtrapolationType,
+  JulianDate,
+  Quaternion,
+  Transforms,
+  CallbackProperty,
+  SampledPositionProperty,
+  VelocityOrientationProperty,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/VelocityOrientationProperty", function () {
   const time = JulianDate.now();

--- a/Specs/DataSources/VelocityVectorPropertySpec.js
+++ b/Specs/DataSources/VelocityVectorPropertySpec.js
@@ -1,12 +1,15 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Event } from "../../Source/Cesium.js";
-import { ExtrapolationType } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Event,
+  ExtrapolationType,
+  JulianDate,
+  CallbackProperty,
+  ConstantPositionProperty,
+  SampledPositionProperty,
+  VelocityVectorProperty,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { CallbackProperty } from "../../Source/Cesium.js";
-import { ConstantPositionProperty } from "../../Source/Cesium.js";
-import { SampledPositionProperty } from "../../Source/Cesium.js";
-import { VelocityVectorProperty } from "../../Source/Cesium.js";
 
 describe("DataSources/VelocityVectorProperty", function () {
   const time = JulianDate.now();

--- a/Specs/DataSources/WallGeometryUpdaterSpec.js
+++ b/Specs/DataSources/WallGeometryUpdaterSpec.js
@@ -1,17 +1,20 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { PropertyArray } from "../../Source/Cesium.js";
-import { SampledPositionProperty } from "../../Source/Cesium.js";
-import { SampledProperty } from "../../Source/Cesium.js";
-import { TimeIntervalCollectionProperty } from "../../Source/Cesium.js";
-import { WallGeometryUpdater } from "../../Source/Cesium.js";
-import { WallGraphics } from "../../Source/Cesium.js";
-import { PrimitiveCollection } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Color,
+  JulianDate,
+  TimeInterval,
+  TimeIntervalCollection,
+  ConstantProperty,
+  Entity,
+  PropertyArray,
+  SampledPositionProperty,
+  SampledProperty,
+  TimeIntervalCollectionProperty,
+  WallGeometryUpdater,
+  WallGraphics,
+  PrimitiveCollection,
+} from "../../../Source/Cesium.js";
+
 import createDynamicGeometryUpdaterSpecs from "../createDynamicGeometryUpdaterSpecs.js";
 import createDynamicProperty from "../createDynamicProperty.js";
 import createGeometryUpdaterSpecs from "../createGeometryUpdaterSpecs.js";

--- a/Specs/DataSources/WallGraphicsSpec.js
+++ b/Specs/DataSources/WallGraphicsSpec.js
@@ -1,9 +1,12 @@
-import { Color } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { ConstantProperty } from "../../Source/Cesium.js";
-import { WallGraphics } from "../../Source/Cesium.js";
-import { ShadowMode } from "../../Source/Cesium.js";
+import {
+  Color,
+  DistanceDisplayCondition,
+  ColorMaterialProperty,
+  ConstantProperty,
+  WallGraphics,
+  ShadowMode,
+} from "../../../Source/Cesium.js";
+
 import testDefinitionChanged from "../testDefinitionChanged.js";
 import testMaterialDefinitionChanged from "../testMaterialDefinitionChanged.js";
 

--- a/Specs/DataSources/createMaterialPropertyDescriptorSpec.js
+++ b/Specs/DataSources/createMaterialPropertyDescriptorSpec.js
@@ -1,8 +1,10 @@
-import { Color } from "../../Source/Cesium.js";
-import { Event } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { createMaterialPropertyDescriptor } from "../../Source/Cesium.js";
-import { ImageMaterialProperty } from "../../Source/Cesium.js";
+import {
+  Color,
+  Event,
+  ColorMaterialProperty,
+  createMaterialPropertyDescriptor,
+  ImageMaterialProperty,
+} from "../../../Source/Cesium.js";
 
 describe("DataSources/createMaterialPropertyDescriptor", function () {
   function MockGraphics() {

--- a/Specs/DataSources/exportKmlSpec.js
+++ b/Specs/DataSources/exportKmlSpec.js
@@ -1,27 +1,30 @@
-import { BoundingRectangle } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { defaultValue } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { Iso8601 } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  BoundingRectangle,
+  Cartesian2,
+  Cartesian3,
+  Cartographic,
+  Color,
+  defaultValue,
+  defined,
+  Iso8601,
+  JulianDate,
+  PolygonHierarchy,
+  Rectangle,
+  TimeInterval,
+  CallbackProperty,
+  ColorMaterialProperty,
+  Entity,
+  EntityCollection,
+  exportKml,
+  ImageMaterialProperty,
+  PolylineOutlineMaterialProperty,
+  SampledPositionProperty,
+  HeightReference,
+  HorizontalOrigin,
+  VerticalOrigin,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { PolygonHierarchy } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { TimeInterval } from "../../Source/Cesium.js";
-import { CallbackProperty } from "../../Source/Cesium.js";
-import { ColorMaterialProperty } from "../../Source/Cesium.js";
-import { Entity } from "../../Source/Cesium.js";
-import { EntityCollection } from "../../Source/Cesium.js";
-import { exportKml } from "../../Source/Cesium.js";
-import { ImageMaterialProperty } from "../../Source/Cesium.js";
-import { PolylineOutlineMaterialProperty } from "../../Source/Cesium.js";
-import { SampledPositionProperty } from "../../Source/Cesium.js";
-import { HeightReference } from "../../Source/Cesium.js";
-import { HorizontalOrigin } from "../../Source/Cesium.js";
-import { VerticalOrigin } from "../../Source/Cesium.js";
 
 describe("DataSources/exportKml", function () {
   let kmlDoc;

--- a/Specs/DomEventSimulator.js
+++ b/Specs/DomEventSimulator.js
@@ -1,5 +1,4 @@
-import { defaultValue } from "../Source/Cesium.js";
-import { FeatureDetection } from "../Source/Cesium.js";
+import { defaultValue, FeatureDetection } from "../../Source/Cesium.js";
 
 function createMouseEvent(type, options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/Specs/MockDataSource.js
+++ b/Specs/MockDataSource.js
@@ -1,6 +1,4 @@
-import { Event } from "../Source/Cesium.js";
-import { EntityCluster } from "../Source/Cesium.js";
-import { EntityCollection } from "../Source/Cesium.js";
+import { Event, EntityCluster, EntityCollection } from "../../Source/Cesium.js";
 
 function MockDataSource() {
   //Values to be fiddled with by the test

--- a/Specs/Renderer/AutomaticUniformSpec.js
+++ b/Specs/Renderer/AutomaticUniformSpec.js
@@ -1,17 +1,20 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { defaultValue } from "../../Source/Cesium.js";
-import { DirectionalLight } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeographicProjection } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { OrthographicFrustum } from "../../Source/Cesium.js";
-import { OrthographicOffCenterFrustum } from "../../Source/Cesium.js";
-import { Pass } from "../../Source/Cesium.js";
-import { Texture } from "../../Source/Cesium.js";
-import { SceneMode } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Cartographic,
+  Color,
+  defaultValue,
+  DirectionalLight,
+  Ellipsoid,
+  GeographicProjection,
+  Matrix4,
+  OrthographicFrustum,
+  OrthographicOffCenterFrustum,
+  Pass,
+  Texture,
+  SceneMode,
+} from "../../../Source/Cesium.js";
+
 import createCamera from "../createCamera.js";
 import createContext from "../createContext.js";
 import createFrameState from "../createFrameState.js";

--- a/Specs/Renderer/BufferSpec.js
+++ b/Specs/Renderer/BufferSpec.js
@@ -1,6 +1,5 @@
-import { IndexDatatype } from "../../Source/Cesium.js";
-import { Buffer } from "../../Source/Cesium.js";
-import { BufferUsage } from "../../Source/Cesium.js";
+import { IndexDatatype, Buffer, BufferUsage } from "../../../Source/Cesium.js";
+
 import createContext from "../createContext.js";
 
 describe(

--- a/Specs/Renderer/BuiltinFunctionsSpec.js
+++ b/Specs/Renderer/BuiltinFunctionsSpec.js
@@ -1,7 +1,10 @@
-import { BoundingRectangle } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartesian4 } from "../../Source/Cesium.js";
-import { EncodedCartesian3 } from "../../Source/Cesium.js";
+import {
+  BoundingRectangle,
+  Cartesian3,
+  Cartesian4,
+  EncodedCartesian3,
+} from "../../../Source/Cesium.js";
+
 import createCamera from "../createCamera.js";
 import createContext from "../createContext.js";
 import createFrameState from "../createFrameState.js";

--- a/Specs/Renderer/ClearCommandSpec.js
+++ b/Specs/Renderer/ClearCommandSpec.js
@@ -1,5 +1,4 @@
-import { Color } from "../../Source/Cesium.js";
-import { ClearCommand } from "../../Source/Cesium.js";
+import { Color, ClearCommand } from "../../../Source/Cesium.js";
 
 describe("Renderer/ClearCommand", function () {
   it("constructs with defaults", function () {

--- a/Specs/Renderer/ClearSpec.js
+++ b/Specs/Renderer/ClearSpec.js
@@ -1,9 +1,12 @@
-import { BoundingRectangle } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { ClearCommand } from "../../Source/Cesium.js";
-import { Framebuffer } from "../../Source/Cesium.js";
-import { RenderState } from "../../Source/Cesium.js";
-import { Texture } from "../../Source/Cesium.js";
+import {
+  BoundingRectangle,
+  Color,
+  ClearCommand,
+  Framebuffer,
+  RenderState,
+  Texture,
+} from "../../../Source/Cesium.js";
+
 import createContext from "../createContext.js";
 
 describe(

--- a/Specs/Renderer/ComputeCommandSpec.js
+++ b/Specs/Renderer/ComputeCommandSpec.js
@@ -1,13 +1,16 @@
-import { BoundingRectangle } from "../../Source/Cesium.js";
-import { PixelFormat } from "../../Source/Cesium.js";
-import { Buffer } from "../../Source/Cesium.js";
-import { BufferUsage } from "../../Source/Cesium.js";
-import { ComputeCommand } from "../../Source/Cesium.js";
-import { ShaderProgram } from "../../Source/Cesium.js";
-import { Texture } from "../../Source/Cesium.js";
-import { VertexArray } from "../../Source/Cesium.js";
-import { Material } from "../../Source/Cesium.js";
-import { ViewportQuad } from "../../Source/Cesium.js";
+import {
+  BoundingRectangle,
+  PixelFormat,
+  Buffer,
+  BufferUsage,
+  ComputeCommand,
+  ShaderProgram,
+  Texture,
+  VertexArray,
+  Material,
+  ViewportQuad,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Renderer/ContextSpec.js
+++ b/Specs/Renderer/ContextSpec.js
@@ -1,9 +1,12 @@
-import { Color } from "../../Source/Cesium.js";
-import { IndexDatatype } from "../../Source/Cesium.js";
-import { Buffer } from "../../Source/Cesium.js";
-import { BufferUsage } from "../../Source/Cesium.js";
-import { Context } from "../../Source/Cesium.js";
-import { ContextLimits } from "../../Source/Cesium.js";
+import {
+  Color,
+  IndexDatatype,
+  Buffer,
+  BufferUsage,
+  Context,
+  ContextLimits,
+} from "../../../Source/Cesium.js";
+
 import createContext from "../createContext.js";
 
 describe(

--- a/Specs/Renderer/CubeMapSpec.js
+++ b/Specs/Renderer/CubeMapSpec.js
@@ -1,17 +1,20 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { PixelFormat } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { ClearCommand } from "../../Source/Cesium.js";
-import { ContextLimits } from "../../Source/Cesium.js";
-import { CubeMap } from "../../Source/Cesium.js";
-import { PixelDatatype } from "../../Source/Cesium.js";
-import { Sampler } from "../../Source/Cesium.js";
-import { Texture } from "../../Source/Cesium.js";
-import { TextureMagnificationFilter } from "../../Source/Cesium.js";
-import { TextureMinificationFilter } from "../../Source/Cesium.js";
-import { TextureWrap } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Color,
+  defined,
+  PixelFormat,
+  Resource,
+  ClearCommand,
+  ContextLimits,
+  CubeMap,
+  PixelDatatype,
+  Sampler,
+  Texture,
+  TextureMagnificationFilter,
+  TextureMinificationFilter,
+  TextureWrap,
+} from "../../../Source/Cesium.js";
+
 import createContext from "../createContext.js";
 
 describe(

--- a/Specs/Renderer/DrawCommandSpec.js
+++ b/Specs/Renderer/DrawCommandSpec.js
@@ -1,6 +1,4 @@
-import { PrimitiveType } from "../../Source/Cesium.js";
-import { DrawCommand } from "../../Source/Cesium.js";
-import { Pass } from "../../Source/Cesium.js";
+import { PrimitiveType, DrawCommand, Pass } from "../../../Source/Cesium.js";
 
 describe("Renderer/DrawCommand", function () {
   it("constructs", function () {

--- a/Specs/Renderer/DrawSpec.js
+++ b/Specs/Renderer/DrawSpec.js
@@ -1,19 +1,22 @@
-import { BoundingRectangle } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { ComponentDatatype } from "../../Source/Cesium.js";
-import { IndexDatatype } from "../../Source/Cesium.js";
-import { PrimitiveType } from "../../Source/Cesium.js";
-import { WebGLConstants } from "../../Source/Cesium.js";
-import { WindingOrder } from "../../Source/Cesium.js";
-import { Buffer } from "../../Source/Cesium.js";
-import { BufferUsage } from "../../Source/Cesium.js";
-import { ClearCommand } from "../../Source/Cesium.js";
-import { ContextLimits } from "../../Source/Cesium.js";
-import { DrawCommand } from "../../Source/Cesium.js";
-import { RenderState } from "../../Source/Cesium.js";
-import { ShaderProgram } from "../../Source/Cesium.js";
-import { VertexArray } from "../../Source/Cesium.js";
-import { BlendingState } from "../../Source/Cesium.js";
+import {
+  BoundingRectangle,
+  Color,
+  ComponentDatatype,
+  IndexDatatype,
+  PrimitiveType,
+  WebGLConstants,
+  WindingOrder,
+  Buffer,
+  BufferUsage,
+  ClearCommand,
+  ContextLimits,
+  DrawCommand,
+  RenderState,
+  ShaderProgram,
+  VertexArray,
+  BlendingState,
+} from "../../../Source/Cesium.js";
+
 import createContext from "../createContext.js";
 
 describe(

--- a/Specs/Renderer/FramebufferManagerSpec.js
+++ b/Specs/Renderer/FramebufferManagerSpec.js
@@ -1,13 +1,16 @@
-import { defined } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { ClearCommand } from "../../Source/Cesium.js";
-import { Framebuffer } from "../../Source/Cesium.js";
-import { FramebufferManager } from "../../Source/Cesium.js";
-import { PixelDatatype } from "../../Source/Cesium.js";
-import { PixelFormat } from "../../Source/Cesium.js";
-import { Renderbuffer } from "../../Source/Cesium.js";
-import { RenderbufferFormat } from "../../Source/Cesium.js";
-import { Texture } from "../../Source/Cesium.js";
+import {
+  defined,
+  Color,
+  ClearCommand,
+  Framebuffer,
+  FramebufferManager,
+  PixelDatatype,
+  PixelFormat,
+  Renderbuffer,
+  RenderbufferFormat,
+  Texture,
+} from "../../../Source/Cesium.js";
+
 import createContext from "../createContext.js";
 
 describe(

--- a/Specs/Renderer/FramebufferSpec.js
+++ b/Specs/Renderer/FramebufferSpec.js
@@ -1,21 +1,24 @@
-import { Color } from "../../Source/Cesium.js";
-import { PixelFormat } from "../../Source/Cesium.js";
-import { PrimitiveType } from "../../Source/Cesium.js";
-import { WebGLConstants } from "../../Source/Cesium.js";
-import { Buffer } from "../../Source/Cesium.js";
-import { BufferUsage } from "../../Source/Cesium.js";
-import { ClearCommand } from "../../Source/Cesium.js";
-import { ContextLimits } from "../../Source/Cesium.js";
-import { CubeMap } from "../../Source/Cesium.js";
-import { DrawCommand } from "../../Source/Cesium.js";
-import { Framebuffer } from "../../Source/Cesium.js";
-import { PixelDatatype } from "../../Source/Cesium.js";
-import { Renderbuffer } from "../../Source/Cesium.js";
-import { RenderbufferFormat } from "../../Source/Cesium.js";
-import { RenderState } from "../../Source/Cesium.js";
-import { ShaderProgram } from "../../Source/Cesium.js";
-import { Texture } from "../../Source/Cesium.js";
-import { VertexArray } from "../../Source/Cesium.js";
+import {
+  Color,
+  PixelFormat,
+  PrimitiveType,
+  WebGLConstants,
+  Buffer,
+  BufferUsage,
+  ClearCommand,
+  ContextLimits,
+  CubeMap,
+  DrawCommand,
+  Framebuffer,
+  PixelDatatype,
+  Renderbuffer,
+  RenderbufferFormat,
+  RenderState,
+  ShaderProgram,
+  Texture,
+  VertexArray,
+} from "../../../Source/Cesium.js";
+
 import createContext from "../createContext.js";
 
 describe(

--- a/Specs/Renderer/MultisampleFramebufferSpec.js
+++ b/Specs/Renderer/MultisampleFramebufferSpec.js
@@ -1,18 +1,21 @@
-import { ClearCommand } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { PrimitiveType } from "../../Source/Cesium.js";
-import { Buffer } from "../../Source/Cesium.js";
-import { BufferUsage } from "../../Source/Cesium.js";
-import { DrawCommand } from "../../Source/Cesium.js";
-import { MultisampleFramebuffer } from "../../Source/Cesium.js";
-import { PixelDatatype } from "../../Source/Cesium.js";
-import { PixelFormat } from "../../Source/Cesium.js";
-import { Texture } from "../../Source/Cesium.js";
-import { Renderbuffer } from "../../Source/Cesium.js";
-import { RenderbufferFormat } from "../../Source/Cesium.js";
-import { RenderState } from "../../Source/Cesium.js";
-import { ShaderProgram } from "../../Source/Cesium.js";
-import { VertexArray } from "../../Source/Cesium.js";
+import {
+  ClearCommand,
+  Color,
+  PrimitiveType,
+  Buffer,
+  BufferUsage,
+  DrawCommand,
+  MultisampleFramebuffer,
+  PixelDatatype,
+  PixelFormat,
+  Texture,
+  Renderbuffer,
+  RenderbufferFormat,
+  RenderState,
+  ShaderProgram,
+  VertexArray,
+} from "../../../Source/Cesium.js";
+
 import createContext from "../createContext.js";
 
 describe(

--- a/Specs/Renderer/RenderStateSpec.js
+++ b/Specs/Renderer/RenderStateSpec.js
@@ -1,7 +1,10 @@
-import { WebGLConstants } from "../../Source/Cesium.js";
-import { WindingOrder } from "../../Source/Cesium.js";
-import { ContextLimits } from "../../Source/Cesium.js";
-import { RenderState } from "../../Source/Cesium.js";
+import {
+  WebGLConstants,
+  WindingOrder,
+  ContextLimits,
+  RenderState,
+} from "../../../Source/Cesium.js";
+
 import createContext from "../createContext.js";
 
 describe(

--- a/Specs/Renderer/RenderbufferSpec.js
+++ b/Specs/Renderer/RenderbufferSpec.js
@@ -1,6 +1,9 @@
-import { ContextLimits } from "../../Source/Cesium.js";
-import { Renderbuffer } from "../../Source/Cesium.js";
-import { RenderbufferFormat } from "../../Source/Cesium.js";
+import {
+  ContextLimits,
+  Renderbuffer,
+  RenderbufferFormat,
+} from "../../../Source/Cesium.js";
+
 import createContext from "../createContext.js";
 
 describe(

--- a/Specs/Renderer/SamplerSpec.js
+++ b/Specs/Renderer/SamplerSpec.js
@@ -1,6 +1,9 @@
-import { Sampler } from "../../Source/Cesium.js";
-import { TextureMinificationFilter } from "../../Source/Cesium.js";
-import { TextureWrap } from "../../Source/Cesium.js";
+import {
+  Sampler,
+  TextureMinificationFilter,
+  TextureWrap,
+} from "../../../Source/Cesium.js";
+
 import createContext from "../createContext.js";
 
 describe(

--- a/Specs/Renderer/ShaderProgramSpec.js
+++ b/Specs/Renderer/ShaderProgramSpec.js
@@ -1,7 +1,10 @@
-import { ContextLimits } from "../../Source/Cesium.js";
-import { ShaderProgram } from "../../Source/Cesium.js";
-import { ShaderSource } from "../../Source/Cesium.js";
-import { RuntimeError } from "../../Source/Cesium.js";
+import {
+  ContextLimits,
+  ShaderProgram,
+  ShaderSource,
+  RuntimeError,
+} from "../../../Source/Cesium.js";
+
 import createContext from "../createContext.js";
 
 describe(

--- a/Specs/Renderer/TextureCacheSpec.js
+++ b/Specs/Renderer/TextureCacheSpec.js
@@ -1,5 +1,5 @@
-import { Texture } from "../../Source/Cesium.js";
-import { TextureCache } from "../../Source/Cesium.js";
+import { Texture, TextureCache } from "../../../Source/Cesium.js";
+
 import createContext from "../createContext.js";
 
 describe(

--- a/Specs/Renderer/TextureSpec.js
+++ b/Specs/Renderer/TextureSpec.js
@@ -1,17 +1,20 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { loadKTX2 } from "../../Source/Cesium.js";
-import { KTX2Transcoder } from "../../Source/Cesium.js";
-import { PixelFormat } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { ClearCommand } from "../../Source/Cesium.js";
-import { ContextLimits } from "../../Source/Cesium.js";
-import { PixelDatatype } from "../../Source/Cesium.js";
-import { Sampler } from "../../Source/Cesium.js";
-import { Texture } from "../../Source/Cesium.js";
-import { TextureMagnificationFilter } from "../../Source/Cesium.js";
-import { TextureMinificationFilter } from "../../Source/Cesium.js";
-import { TextureWrap } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Color,
+  loadKTX2,
+  KTX2Transcoder,
+  PixelFormat,
+  Resource,
+  ClearCommand,
+  ContextLimits,
+  PixelDatatype,
+  Sampler,
+  Texture,
+  TextureMagnificationFilter,
+  TextureMinificationFilter,
+  TextureWrap,
+} from "../../../Source/Cesium.js";
+
 import createContext from "../createContext.js";
 
 describe(

--- a/Specs/Renderer/UniformSpec.js
+++ b/Specs/Renderer/UniformSpec.js
@@ -1,10 +1,13 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartesian4 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { Matrix2 } from "../../Source/Cesium.js";
-import { Matrix3 } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Cartesian4,
+  Color,
+  Matrix2,
+  Matrix3,
+  Matrix4,
+} from "../../../Source/Cesium.js";
+
 import createContext from "../createContext.js";
 
 describe(

--- a/Specs/Renderer/VertexArrayFacadeSpec.js
+++ b/Specs/Renderer/VertexArrayFacadeSpec.js
@@ -1,6 +1,9 @@
-import { ComponentDatatype } from "../../Source/Cesium.js";
-import { BufferUsage } from "../../Source/Cesium.js";
-import { VertexArrayFacade } from "../../Source/Cesium.js";
+import {
+  ComponentDatatype,
+  BufferUsage,
+  VertexArrayFacade,
+} from "../../../Source/Cesium.js";
+
 import createContext from "../createContext.js";
 
 describe(

--- a/Specs/Renderer/VertexArrayFactorySpec.js
+++ b/Specs/Renderer/VertexArrayFactorySpec.js
@@ -1,15 +1,18 @@
-import { ComponentDatatype } from "../../Source/Cesium.js";
-import { Geometry } from "../../Source/Cesium.js";
-import { GeometryAttribute } from "../../Source/Cesium.js";
-import { GeometryPipeline } from "../../Source/Cesium.js";
-import { IndexDatatype } from "../../Source/Cesium.js";
-import { PrimitiveType } from "../../Source/Cesium.js";
-import { BufferUsage } from "../../Source/Cesium.js";
-import { ClearCommand } from "../../Source/Cesium.js";
-import { DrawCommand } from "../../Source/Cesium.js";
-import { ShaderProgram } from "../../Source/Cesium.js";
-import { RuntimeError } from "../../Source/Cesium.js";
-import { VertexArray } from "../../Source/Cesium.js";
+import {
+  ComponentDatatype,
+  Geometry,
+  GeometryAttribute,
+  GeometryPipeline,
+  IndexDatatype,
+  PrimitiveType,
+  BufferUsage,
+  ClearCommand,
+  DrawCommand,
+  ShaderProgram,
+  RuntimeError,
+  VertexArray,
+} from "../../../Source/Cesium.js";
+
 import createContext from "../createContext.js";
 
 describe(

--- a/Specs/Renderer/VertexArraySpec.js
+++ b/Specs/Renderer/VertexArraySpec.js
@@ -1,10 +1,13 @@
-import { ComponentDatatype } from "../../Source/Cesium.js";
-import { PrimitiveType } from "../../Source/Cesium.js";
-import { Buffer } from "../../Source/Cesium.js";
-import { BufferUsage } from "../../Source/Cesium.js";
-import { DrawCommand } from "../../Source/Cesium.js";
-import { ShaderProgram } from "../../Source/Cesium.js";
-import { VertexArray } from "../../Source/Cesium.js";
+import {
+  ComponentDatatype,
+  PrimitiveType,
+  Buffer,
+  BufferUsage,
+  DrawCommand,
+  ShaderProgram,
+  VertexArray,
+} from "../../../Source/Cesium.js";
+
 import createContext from "../createContext.js";
 
 describe(

--- a/Specs/Renderer/loadCubeMapSpec.js
+++ b/Specs/Renderer/loadCubeMapSpec.js
@@ -1,11 +1,14 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { PrimitiveType } from "../../Source/Cesium.js";
-import { Buffer } from "../../Source/Cesium.js";
-import { BufferUsage } from "../../Source/Cesium.js";
-import { DrawCommand } from "../../Source/Cesium.js";
-import { loadCubeMap } from "../../Source/Cesium.js";
-import { ShaderProgram } from "../../Source/Cesium.js";
-import { VertexArray } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  PrimitiveType,
+  Buffer,
+  BufferUsage,
+  DrawCommand,
+  loadCubeMap,
+  ShaderProgram,
+  VertexArray,
+} from "../../../Source/Cesium.js";
+
 import createContext from "../createContext.js";
 
 describe(

--- a/Specs/Scene/AppearanceSpec.js
+++ b/Specs/Scene/AppearanceSpec.js
@@ -1,7 +1,9 @@
-import { WebGLConstants } from "../../Source/Cesium.js";
-import { Appearance } from "../../Source/Cesium.js";
-import { BlendingState } from "../../Source/Cesium.js";
-import { Material } from "../../Source/Cesium.js";
+import {
+  WebGLConstants,
+  Appearance,
+  BlendingState,
+  Material,
+} from "../../../Source/Cesium.js";
 
 describe("Scene/Appearance", function () {
   it("constructor", function () {

--- a/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
+++ b/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
@@ -1,27 +1,30 @@
-import { appendForwardSlash } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
-import { getAbsoluteUri } from "../../Source/Cesium.js";
-import { objectToQuery } from "../../Source/Cesium.js";
-import { queryToObject } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { Request } from "../../Source/Cesium.js";
-import { RequestScheduler } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { WebMercatorProjection } from "../../Source/Cesium.js";
-import { WebMercatorTilingScheme } from "../../Source/Cesium.js";
-import { ArcGisMapServerImageryProvider } from "../../Source/Cesium.js";
-import { DiscardMissingTileImagePolicy } from "../../Source/Cesium.js";
-import { Imagery } from "../../Source/Cesium.js";
-import { ImageryLayer } from "../../Source/Cesium.js";
-import { ImageryLayerFeatureInfo } from "../../Source/Cesium.js";
-import { ImageryProvider } from "../../Source/Cesium.js";
-import { ImageryState } from "../../Source/Cesium.js";
+import {
+  appendForwardSlash,
+  Cartesian2,
+  Cartesian3,
+  Cartographic,
+  defined,
+  GeographicTilingScheme,
+  getAbsoluteUri,
+  objectToQuery,
+  queryToObject,
+  Rectangle,
+  Request,
+  RequestScheduler,
+  Resource,
+  WebMercatorProjection,
+  WebMercatorTilingScheme,
+  ArcGisMapServerImageryProvider,
+  DiscardMissingTileImagePolicy,
+  Imagery,
+  ImageryLayer,
+  ImageryLayerFeatureInfo,
+  ImageryProvider,
+  ImageryState,
+  Uri,
+} from "../../../Source/Cesium.js";
+
 import pollToPromise from "../pollToPromise.js";
-import { Uri } from "../../Source/Cesium.js";
 
 describe("Scene/ArcGisMapServerImageryProvider", function () {
   let supportsImageBitmapOptions;

--- a/Specs/Scene/AxisSpec.js
+++ b/Specs/Scene/AxisSpec.js
@@ -1,7 +1,6 @@
-import { Cartesian4 } from "../../Source/Cesium.js";
+import { Cartesian4, Matrix4, Axis } from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { Axis } from "../../Source/Cesium.js";
 
 describe("Scene/Axis", function () {
   function convertUpAxis(upAxis, transformation, expected) {

--- a/Specs/Scene/BatchTableSpec.js
+++ b/Specs/Scene/BatchTableSpec.js
@@ -1,9 +1,13 @@
-import { Cartesian4 } from "../../Source/Cesium.js";
-import { ComponentDatatype } from "../../Source/Cesium.js";
+import {
+  Cartesian4,
+  ComponentDatatype,
+  PixelDatatype,
+  Texture,
+  BatchTable,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { PixelDatatype } from "../../Source/Cesium.js";
-import { Texture } from "../../Source/Cesium.js";
-import { BatchTable } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Scene/BillboardCollectionSpec.js
+++ b/Specs/Scene/BillboardCollectionSpec.js
@@ -1,24 +1,28 @@
-import { BoundingRectangle } from "../../Source/Cesium.js";
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { CesiumTerrainProvider } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { createGuid } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
+import {
+  BoundingRectangle,
+  BoundingSphere,
+  Cartesian2,
+  Cartesian3,
+  CesiumTerrainProvider,
+  Color,
+  createGuid,
+  DistanceDisplayCondition,
+  NearFarScalar,
+  OrthographicOffCenterFrustum,
+  PerspectiveFrustum,
+  Rectangle,
+  Resource,
+  Billboard,
+  BillboardCollection,
+  BlendOption,
+  HeightReference,
+  HorizontalOrigin,
+  TextureAtlas,
+  VerticalOrigin,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { NearFarScalar } from "../../Source/Cesium.js";
-import { OrthographicOffCenterFrustum } from "../../Source/Cesium.js";
-import { PerspectiveFrustum } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { Billboard } from "../../Source/Cesium.js";
-import { BillboardCollection } from "../../Source/Cesium.js";
-import { BlendOption } from "../../Source/Cesium.js";
-import { HeightReference } from "../../Source/Cesium.js";
-import { HorizontalOrigin } from "../../Source/Cesium.js";
-import { TextureAtlas } from "../../Source/Cesium.js";
-import { VerticalOrigin } from "../../Source/Cesium.js";
+
 import createGlobe from "../createGlobe.js";
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";

--- a/Specs/Scene/BingMapsImageryProviderSpec.js
+++ b/Specs/Scene/BingMapsImageryProviderSpec.js
@@ -1,18 +1,21 @@
-import { appendForwardSlash } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { queryToObject } from "../../Source/Cesium.js";
-import { RequestScheduler } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { WebMercatorTilingScheme } from "../../Source/Cesium.js";
-import { BingMapsImageryProvider } from "../../Source/Cesium.js";
-import { BingMapsStyle } from "../../Source/Cesium.js";
-import { DiscardEmptyTileImagePolicy } from "../../Source/Cesium.js";
-import { Imagery } from "../../Source/Cesium.js";
-import { ImageryLayer } from "../../Source/Cesium.js";
-import { ImageryProvider } from "../../Source/Cesium.js";
-import { ImageryState } from "../../Source/Cesium.js";
+import {
+  appendForwardSlash,
+  defined,
+  queryToObject,
+  RequestScheduler,
+  Resource,
+  WebMercatorTilingScheme,
+  BingMapsImageryProvider,
+  BingMapsStyle,
+  DiscardEmptyTileImagePolicy,
+  Imagery,
+  ImageryLayer,
+  ImageryProvider,
+  ImageryState,
+  Uri,
+} from "../../../Source/Cesium.js";
+
 import pollToPromise from "../pollToPromise.js";
-import { Uri } from "../../Source/Cesium.js";
 
 describe("Scene/BingMapsImageryProvider", function () {
   let supportsImageBitmapOptions;

--- a/Specs/Scene/BoxEmitterSpec.js
+++ b/Specs/Scene/BoxEmitterSpec.js
@@ -1,6 +1,4 @@
-import { BoxEmitter } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Particle } from "../../Source/Cesium.js";
+import { BoxEmitter, Cartesian3, Particle } from "../../../Source/Cesium.js";
 
 describe("Scene/BoxEmitter", function () {
   let emitter;

--- a/Specs/Scene/CameraEventAggregatorSpec.js
+++ b/Specs/Scene/CameraEventAggregatorSpec.js
@@ -1,9 +1,12 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { combine } from "../../Source/Cesium.js";
-import { FeatureDetection } from "../../Source/Cesium.js";
-import { KeyboardEventModifier } from "../../Source/Cesium.js";
-import { CameraEventAggregator } from "../../Source/Cesium.js";
-import { CameraEventType } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  combine,
+  FeatureDetection,
+  KeyboardEventModifier,
+  CameraEventAggregator,
+  CameraEventType,
+} from "../../../Source/Cesium.js";
+
 import createCanvas from "../createCanvas.js";
 import DomEventSimulator from "../DomEventSimulator.js";
 

--- a/Specs/Scene/CameraFlightPathSpec.js
+++ b/Specs/Scene/CameraFlightPathSpec.js
@@ -1,12 +1,16 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeographicProjection } from "../../Source/Cesium.js";
-import { Globe } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Cartographic,
+  Ellipsoid,
+  GeographicProjection,
+  Globe,
+  OrthographicOffCenterFrustum,
+  CameraFlightPath,
+  SceneMode,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { OrthographicOffCenterFrustum } from "../../Source/Cesium.js";
-import { CameraFlightPath } from "../../Source/Cesium.js";
-import { SceneMode } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -1,26 +1,29 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartesian4 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { defaultValue } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeographicProjection } from "../../Source/Cesium.js";
-import { HeadingPitchRange } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Cartesian2,
+  Cartesian3,
+  Cartesian4,
+  Cartographic,
+  defaultValue,
+  Ellipsoid,
+  GeographicProjection,
+  HeadingPitchRange,
+  Matrix3,
+  Matrix4,
+  OrthographicFrustum,
+  OrthographicOffCenterFrustum,
+  PerspectiveFrustum,
+  Rectangle,
+  Transforms,
+  WebMercatorProjection,
+  Camera,
+  CameraFlightPath,
+  MapMode2D,
+  SceneMode,
+  TweenCollection,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix3 } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { OrthographicFrustum } from "../../Source/Cesium.js";
-import { OrthographicOffCenterFrustum } from "../../Source/Cesium.js";
-import { PerspectiveFrustum } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
-import { WebMercatorProjection } from "../../Source/Cesium.js";
-import { Camera } from "../../Source/Cesium.js";
-import { CameraFlightPath } from "../../Source/Cesium.js";
-import { MapMode2D } from "../../Source/Cesium.js";
-import { SceneMode } from "../../Source/Cesium.js";
-import { TweenCollection } from "../../Source/Cesium.js";
 
 describe("Scene/Camera", function () {
   let scene;

--- a/Specs/Scene/Cesium3DTileFeatureTableSpec.js
+++ b/Specs/Scene/Cesium3DTileFeatureTableSpec.js
@@ -1,5 +1,7 @@
-import { ComponentDatatype } from "../../Source/Cesium.js";
-import { Cesium3DTileFeatureTable } from "../../Source/Cesium.js";
+import {
+  ComponentDatatype,
+  Cesium3DTileFeatureTable,
+} from "../../../Source/Cesium.js";
 
 describe("Scene/Cesium3DTileFeatureTable", function () {
   it("loads from JSON", function () {

--- a/Specs/Scene/Cesium3DTilePassStateSpec.js
+++ b/Specs/Scene/Cesium3DTilePassStateSpec.js
@@ -1,5 +1,7 @@
-import { Cesium3DTilePass } from "../../Source/Cesium.js";
-import { Cesium3DTilePassState } from "../../Source/Cesium.js";
+import {
+  Cesium3DTilePass,
+  Cesium3DTilePassState,
+} from "../../../Source/Cesium.js";
 
 describe("Scene/Cesium3DTilePassState", function () {
   it("sets default values", function () {

--- a/Specs/Scene/Cesium3DTileSpec.js
+++ b/Specs/Scene/Cesium3DTileSpec.js
@@ -1,18 +1,22 @@
-import { Cartesian3, Empty3DTileContent } from "../../Source/Cesium.js";
-import { clone } from "../../Source/Cesium.js";
-import { HeadingPitchRoll } from "../../Source/Cesium.js";
-import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix3 } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
-import { Cesium3DTile } from "../../Source/Cesium.js";
-import { Cesium3DTilePass } from "../../Source/Cesium.js";
-import { Cesium3DTileRefine } from "../../Source/Cesium.js";
-import { Cesium3DTilesetHeatmap } from "../../Source/Cesium.js";
-import { RuntimeError } from "../../Source/Cesium.js";
-import { TileBoundingRegion } from "../../Source/Cesium.js";
-import { TileOrientedBoundingBox } from "../../Source/Cesium.js";
+import {
+  clone,
+  Cartesian3,
+  Empty3DTileContent,
+  HeadingPitchRoll,
+  Matrix3,
+  Matrix4,
+  Rectangle,
+  Transforms,
+  Cesium3DTile,
+  Cesium3DTilePass,
+  Cesium3DTileRefine,
+  Cesium3DTilesetHeatmap,
+  Math as CesiumMath,
+  RuntimeError,
+  TileBoundingRegion,
+  TileOrientedBoundingBox,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Scene/Cesium3DTileStyleSpec.js
+++ b/Specs/Scene/Cesium3DTileStyleSpec.js
@@ -1,10 +1,12 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian4 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { Cesium3DTileStyle } from "../../Source/Cesium.js";
-import { ConditionsExpression } from "../../Source/Cesium.js";
-import { Expression } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian4,
+  Color,
+  Resource,
+  Cesium3DTileStyle,
+  ConditionsExpression,
+  Expression,
+} from "../../../Source/Cesium.js";
 
 describe("Scene/Cesium3DTileStyle", function () {
   function MockFeature() {

--- a/Specs/Scene/Cesium3DTilesetHeatmapSpec.js
+++ b/Specs/Scene/Cesium3DTilesetHeatmapSpec.js
@@ -1,9 +1,12 @@
-import { Color } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { Cesium3DTile } from "../../Source/Cesium.js";
-import { Cesium3DTileContentState } from "../../Source/Cesium.js";
-import { Cesium3DTilesetHeatmap } from "../../Source/Cesium.js";
+import {
+  Color,
+  JulianDate,
+  Matrix4,
+  Cesium3DTile,
+  Cesium3DTileContentState,
+  Cesium3DTilesetHeatmap,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe("Scene/Cesium3DTilesetHeatmap", function () {

--- a/Specs/Scene/CircleEmitterSpec.js
+++ b/Specs/Scene/CircleEmitterSpec.js
@@ -1,6 +1,4 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { CircleEmitter } from "../../Source/Cesium.js";
-import { Particle } from "../../Source/Cesium.js";
+import { Cartesian3, CircleEmitter, Particle } from "../../../Source/Cesium.js";
 
 describe("Scene/CircleEmitter", function () {
   let emitter;

--- a/Specs/Scene/ClassificationModelSpec.js
+++ b/Specs/Scene/ClassificationModelSpec.js
@@ -1,29 +1,33 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { destroyObject } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
-import { HeadingPitchRange } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Cartographic,
+  Color,
+  ColorGeometryInstanceAttribute,
+  destroyObject,
+  Ellipsoid,
+  GeometryInstance,
+  HeadingPitchRange,
+  Matrix4,
+  Rectangle,
+  RectangleGeometry,
+  Resource,
+  Pass,
+  RenderState,
+  ClassificationModel,
+  ClassificationType,
+  PerInstanceColorAppearance,
+  Primitive,
+  StencilConstants,
+  addDefaults,
+  parseGlb,
+  updateVersion,
+  RuntimeError,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { RectangleGeometry } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { Pass } from "../../Source/Cesium.js";
-import { RenderState } from "../../Source/Cesium.js";
-import { ClassificationModel } from "../../Source/Cesium.js";
-import { ClassificationType } from "../../Source/Cesium.js";
-import { PerInstanceColorAppearance } from "../../Source/Cesium.js";
-import { Primitive } from "../../Source/Cesium.js";
-import { StencilConstants } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
-import { addDefaults } from "../../Source/Cesium.js";
-import { parseGlb } from "../../Source/Cesium.js";
-import { updateVersion } from "../../Source/Cesium.js";
-import { RuntimeError } from "../../Source/Cesium.js";
 
 describe(
   "Scene/ClassificationModel",

--- a/Specs/Scene/ClassificationPrimitiveSpec.js
+++ b/Specs/Scene/ClassificationPrimitiveSpec.js
@@ -1,24 +1,27 @@
-import { BoxGeometry } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { destroyObject } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
-import { PolygonGeometry } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { RectangleGeometry } from "../../Source/Cesium.js";
-import { ShowGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
-import { Pass } from "../../Source/Cesium.js";
-import { RenderState } from "../../Source/Cesium.js";
-import { ClassificationPrimitive } from "../../Source/Cesium.js";
-import { ClassificationType } from "../../Source/Cesium.js";
-import { InvertClassification } from "../../Source/Cesium.js";
-import { MaterialAppearance } from "../../Source/Cesium.js";
-import { PerInstanceColorAppearance } from "../../Source/Cesium.js";
-import { Primitive } from "../../Source/Cesium.js";
-import { StencilConstants } from "../../Source/Cesium.js";
+import {
+  BoxGeometry,
+  Cartesian3,
+  Color,
+  ColorGeometryInstanceAttribute,
+  destroyObject,
+  Ellipsoid,
+  GeometryInstance,
+  PolygonGeometry,
+  Rectangle,
+  RectangleGeometry,
+  ShowGeometryInstanceAttribute,
+  Transforms,
+  Pass,
+  RenderState,
+  ClassificationPrimitive,
+  ClassificationType,
+  InvertClassification,
+  MaterialAppearance,
+  PerInstanceColorAppearance,
+  Primitive,
+  StencilConstants,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/Scene/ClippingPlaneCollectionSpec.js
+++ b/Specs/Scene/ClippingPlaneCollectionSpec.js
@@ -1,19 +1,23 @@
-import { AttributeCompression } from "../../Source/Cesium.js";
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartesian4 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { Intersect } from "../../Source/Cesium.js";
+import {
+  AttributeCompression,
+  BoundingSphere,
+  Cartesian2,
+  Cartesian3,
+  Cartesian4,
+  Color,
+  Intersect,
+  Matrix4,
+  PixelFormat,
+  Plane,
+  PixelDatatype,
+  TextureMinificationFilter,
+  TextureWrap,
+  ClippingPlane,
+  ClippingPlaneCollection,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { PixelFormat } from "../../Source/Cesium.js";
-import { Plane } from "../../Source/Cesium.js";
-import { PixelDatatype } from "../../Source/Cesium.js";
-import { TextureMinificationFilter } from "../../Source/Cesium.js";
-import { TextureWrap } from "../../Source/Cesium.js";
-import { ClippingPlane } from "../../Source/Cesium.js";
-import { ClippingPlaneCollection } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe("Scene/ClippingPlaneCollection", function () {

--- a/Specs/Scene/ClippingPlaneSpec.js
+++ b/Specs/Scene/ClippingPlaneSpec.js
@@ -1,9 +1,12 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Matrix3,
+  Matrix4,
+  Plane,
+  ClippingPlane,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix3 } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { Plane } from "../../Source/Cesium.js";
-import { ClippingPlane } from "../../Source/Cesium.js";
 
 describe("Scene/ClippingPlane", function () {
   it("constructs", function () {

--- a/Specs/Scene/CloudCollectionSpec.js
+++ b/Specs/Scene/CloudCollectionSpec.js
@@ -1,14 +1,18 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { CloudCollection } from "../../Source/Cesium.js";
-import { CloudType } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { ComputeCommand } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  CloudCollection,
+  CloudType,
+  Color,
+  ComputeCommand,
+  DrawCommand,
+  defined,
+  PerspectiveFrustum,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
-import { DrawCommand } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { PerspectiveFrustum } from "../../Source/Cesium.js";
 
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/Scene/ConditionsExpressionSpec.js
+++ b/Specs/Scene/ConditionsExpressionSpec.js
@@ -1,6 +1,8 @@
-import { Cartesian4 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { ConditionsExpression } from "../../Source/Cesium.js";
+import {
+  Cartesian4,
+  Color,
+  ConditionsExpression,
+} from "../../../Source/Cesium.js";
 
 describe("Scene/ConditionsExpression", function () {
   function MockFeature(value) {

--- a/Specs/Scene/ConeEmitterSpec.js
+++ b/Specs/Scene/ConeEmitterSpec.js
@@ -1,7 +1,6 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
+import { Cartesian3, ConeEmitter, Particle } from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { ConeEmitter } from "../../Source/Cesium.js";
-import { Particle } from "../../Source/Cesium.js";
 
 describe("Scene/ConeEmitter", function () {
   it("default constructor", function () {

--- a/Specs/Scene/CreditDisplaySpec.js
+++ b/Specs/Scene/CreditDisplaySpec.js
@@ -1,6 +1,5 @@
-import { Credit } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { CreditDisplay } from "../../Source/Cesium.js";
+import { Credit, defined, CreditDisplay } from "../../../Source/Cesium.js";
+
 import absolutize from "../absolutize.js";
 
 describe("Scene/CreditDisplay", function () {

--- a/Specs/Scene/DebugAppearanceSpec.js
+++ b/Specs/Scene/DebugAppearanceSpec.js
@@ -1,13 +1,16 @@
-import { ComponentDatatype } from "../../Source/Cesium.js";
-import { defaultValue } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
-import { GeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { RectangleGeometry } from "../../Source/Cesium.js";
-import { VertexFormat } from "../../Source/Cesium.js";
-import { Appearance } from "../../Source/Cesium.js";
-import { DebugAppearance } from "../../Source/Cesium.js";
-import { Primitive } from "../../Source/Cesium.js";
+import {
+  ComponentDatatype,
+  defaultValue,
+  GeometryInstance,
+  GeometryInstanceAttribute,
+  Rectangle,
+  RectangleGeometry,
+  VertexFormat,
+  Appearance,
+  DebugAppearance,
+  Primitive,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Scene/DebugCameraPrimitiveSpec.js
+++ b/Specs/Scene/DebugCameraPrimitiveSpec.js
@@ -1,7 +1,10 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { Camera } from "../../Source/Cesium.js";
-import { DebugCameraPrimitive } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Color,
+  Camera,
+  DebugCameraPrimitive,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Scene/DebugModelMatrixPrimitiveSpec.js
+++ b/Specs/Scene/DebugModelMatrixPrimitiveSpec.js
@@ -1,6 +1,9 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { DebugModelMatrixPrimitive } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Matrix4,
+  DebugModelMatrixPrimitive,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Scene/DeviceOrientationCameraControllerSpec.js
+++ b/Specs/Scene/DeviceOrientationCameraControllerSpec.js
@@ -1,6 +1,10 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  DeviceOrientationCameraController,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { DeviceOrientationCameraController } from "../../Source/Cesium.js";
+
 import createCamera from "../createCamera.js";
 import createCanvas from "../createCanvas.js";
 import DomEventSimulator from "../DomEventSimulator.js";

--- a/Specs/Scene/DiscardEmptyTileImagePolicySpec.js
+++ b/Specs/Scene/DiscardEmptyTileImagePolicySpec.js
@@ -1,5 +1,8 @@
-import { Resource } from "../../Source/Cesium.js";
-import { DiscardEmptyTileImagePolicy } from "../../Source/Cesium.js";
+import {
+  Resource,
+  DiscardEmptyTileImagePolicy,
+} from "../../../Source/Cesium.js";
+
 import pollToPromise from "../pollToPromise.js";
 
 describe("Scene/DiscardEmptyTileImagePolicy", function () {

--- a/Specs/Scene/DiscardMissingTileImagePolicySpec.js
+++ b/Specs/Scene/DiscardMissingTileImagePolicySpec.js
@@ -1,6 +1,9 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { DiscardMissingTileImagePolicy } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Resource,
+  DiscardMissingTileImagePolicy,
+} from "../../../Source/Cesium.js";
+
 import pollToPromise from "../pollToPromise.js";
 
 describe("Scene/DiscardMissingTileImagePolicy", function () {

--- a/Specs/Scene/EllipsoidPrimitiveSpec.js
+++ b/Specs/Scene/EllipsoidPrimitiveSpec.js
@@ -1,8 +1,11 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { EllipsoidPrimitive } from "../../Source/Cesium.js";
-import { Material } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  defined,
+  Matrix4,
+  EllipsoidPrimitive,
+  Material,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Scene/EllipsoidSurfaceAppearanceSpec.js
+++ b/Specs/Scene/EllipsoidSurfaceAppearanceSpec.js
@@ -1,11 +1,14 @@
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { RectangleGeometry } from "../../Source/Cesium.js";
-import { Appearance } from "../../Source/Cesium.js";
-import { EllipsoidSurfaceAppearance } from "../../Source/Cesium.js";
-import { Material } from "../../Source/Cesium.js";
-import { Primitive } from "../../Source/Cesium.js";
+import {
+  ColorGeometryInstanceAttribute,
+  GeometryInstance,
+  Rectangle,
+  RectangleGeometry,
+  Appearance,
+  EllipsoidSurfaceAppearance,
+  Material,
+  Primitive,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -1,11 +1,14 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartesian4 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Cartesian4,
+  Color,
+  Expression,
+  ExpressionNodeType,
+  RuntimeError,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Expression } from "../../Source/Cesium.js";
-import { ExpressionNodeType } from "../../Source/Cesium.js";
-import { RuntimeError } from "../../Source/Cesium.js";
 
 describe("Scene/Expression", function () {
   function MockFeature() {

--- a/Specs/Scene/FrameRateMonitorSpec.js
+++ b/Specs/Scene/FrameRateMonitorSpec.js
@@ -1,6 +1,9 @@
-import { defined } from "../../Source/Cesium.js";
-import { getTimestamp } from "../../Source/Cesium.js";
-import { FrameRateMonitor } from "../../Source/Cesium.js";
+import {
+  defined,
+  getTimestamp,
+  FrameRateMonitor,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Scene/FrustumCommandsSpec.js
+++ b/Specs/Scene/FrustumCommandsSpec.js
@@ -1,5 +1,4 @@
-import { Pass } from "../../Source/Cesium.js";
-import { FrustumCommands } from "../../Source/Cesium.js";
+import { Pass, FrustumCommands } from "../../../Source/Cesium.js";
 
 describe("Scene/FrustumCommands", function () {
   it("constructs without arguments", function () {

--- a/Specs/Scene/GeometryRenderingSpec.js
+++ b/Specs/Scene/GeometryRenderingSpec.js
@@ -1,43 +1,47 @@
-import { ArcType } from "../../Source/Cesium.js";
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { BoxGeometry } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { CircleGeometry } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { ComponentDatatype } from "../../Source/Cesium.js";
-import { CoplanarPolygonGeometry } from "../../Source/Cesium.js";
-import { CornerType } from "../../Source/Cesium.js";
-import { CorridorGeometry } from "../../Source/Cesium.js";
-import { CylinderGeometry } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { EllipseGeometry } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { EllipsoidGeometry } from "../../Source/Cesium.js";
-import { Geometry } from "../../Source/Cesium.js";
-import { GeometryAttribute } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
+import {
+  ArcType,
+  BoundingSphere,
+  BoxGeometry,
+  Cartesian2,
+  Cartesian3,
+  CircleGeometry,
+  Color,
+  ColorGeometryInstanceAttribute,
+  ComponentDatatype,
+  CoplanarPolygonGeometry,
+  CornerType,
+  CorridorGeometry,
+  CylinderGeometry,
+  defined,
+  EllipseGeometry,
+  Ellipsoid,
+  EllipsoidGeometry,
+  Geometry,
+  GeometryAttribute,
+  GeometryInstance,
+  Matrix4,
+  PerspectiveFrustum,
+  PlaneGeometry,
+  PolygonGeometry,
+  PolylineGeometry,
+  PolylineVolumeGeometry,
+  PrimitiveType,
+  Rectangle,
+  RectangleGeometry,
+  SimplePolylineGeometry,
+  SphereGeometry,
+  Transforms,
+  WallGeometry,
+  EllipsoidSurfaceAppearance,
+  Material,
+  PerInstanceColorAppearance,
+  PolylineColorAppearance,
+  Primitive,
+  SceneMode,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { PerspectiveFrustum } from "../../Source/Cesium.js";
-import { PlaneGeometry } from "../../Source/Cesium.js";
-import { PolygonGeometry } from "../../Source/Cesium.js";
-import { PolylineGeometry } from "../../Source/Cesium.js";
-import { PolylineVolumeGeometry } from "../../Source/Cesium.js";
-import { PrimitiveType } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { RectangleGeometry } from "../../Source/Cesium.js";
-import { SimplePolylineGeometry } from "../../Source/Cesium.js";
-import { SphereGeometry } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
-import { WallGeometry } from "../../Source/Cesium.js";
-import { EllipsoidSurfaceAppearance } from "../../Source/Cesium.js";
-import { Material } from "../../Source/Cesium.js";
-import { PerInstanceColorAppearance } from "../../Source/Cesium.js";
-import { PolylineColorAppearance } from "../../Source/Cesium.js";
-import { Primitive } from "../../Source/Cesium.js";
-import { SceneMode } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/Scene/GlobeSpec.js
+++ b/Specs/Scene/GlobeSpec.js
@@ -1,13 +1,16 @@
-import { CesiumTerrainProvider } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { Globe } from "../../Source/Cesium.js";
-import { SingleTileImageryProvider } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { HeadingPitchRoll } from "../../Source/Cesium.js";
-import { NearFarScalar } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  CesiumTerrainProvider,
+  Rectangle,
+  Resource,
+  Globe,
+  SingleTileImageryProvider,
+  Color,
+  Cartesian3,
+  HeadingPitchRoll,
+  NearFarScalar,
+  JulianDate,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/Scene/GlobeSurfaceTileProviderSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileProviderSpec.js
@@ -1,34 +1,37 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartesian4 } from "../../Source/Cesium.js";
-import { CesiumTerrainProvider } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { Credit } from "../../Source/Cesium.js";
-import { CreditDisplay } from "../../Source/Cesium.js";
-import { defaultValue } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { EllipsoidTerrainProvider } from "../../Source/Cesium.js";
-import { GeographicProjection } from "../../Source/Cesium.js";
-import { HeadingPitchRoll } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { WebMercatorProjection } from "../../Source/Cesium.js";
-import { ContextLimits } from "../../Source/Cesium.js";
-import { RenderState } from "../../Source/Cesium.js";
-import { BlendingState } from "../../Source/Cesium.js";
-import { ClippingPlane } from "../../Source/Cesium.js";
-import { ClippingPlaneCollection } from "../../Source/Cesium.js";
-import { Fog } from "../../Source/Cesium.js";
-import { Globe } from "../../Source/Cesium.js";
-import { GlobeSurfaceShaderSet } from "../../Source/Cesium.js";
-import { GlobeSurfaceTileProvider } from "../../Source/Cesium.js";
-import { ImageryLayerCollection } from "../../Source/Cesium.js";
-import { Model } from "../../Source/Cesium.js";
-import { QuadtreeTile } from "../../Source/Cesium.js";
-import { QuadtreeTileProvider } from "../../Source/Cesium.js";
-import { SceneMode } from "../../Source/Cesium.js";
-import { SingleTileImageryProvider } from "../../Source/Cesium.js";
-import { SplitDirection } from "../../Source/Cesium.js";
-import { WebMapServiceImageryProvider } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Cartesian4,
+  CesiumTerrainProvider,
+  Color,
+  Credit,
+  CreditDisplay,
+  defaultValue,
+  defined,
+  Ellipsoid,
+  EllipsoidTerrainProvider,
+  GeographicProjection,
+  HeadingPitchRoll,
+  Rectangle,
+  WebMercatorProjection,
+  ContextLimits,
+  RenderState,
+  BlendingState,
+  ClippingPlane,
+  ClippingPlaneCollection,
+  Fog,
+  Globe,
+  GlobeSurfaceShaderSet,
+  GlobeSurfaceTileProvider,
+  ImageryLayerCollection,
+  Model,
+  QuadtreeTile,
+  QuadtreeTileProvider,
+  SceneMode,
+  SingleTileImageryProvider,
+  SplitDirection,
+  WebMapServiceImageryProvider,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/Scene/GlobeSurfaceTileSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileSpec.js
@@ -1,19 +1,22 @@
+import {
+  Cartesian3,
+  Cartesian4,
+  createWorldTerrain,
+  Ellipsoid,
+  EllipsoidTerrainProvider,
+  GeographicTilingScheme,
+  Ray,
+  GlobeSurfaceTile,
+  ImageryLayerCollection,
+  QuadtreeTile,
+  QuadtreeTileLoadState,
+  TerrainState,
+  TileProviderError,
+} from "../../../Source/Cesium.js";
 import MockImageryProvider from "../MockImageryProvider.js";
 import MockTerrainProvider from "../MockTerrainProvider.js";
 import TerrainTileProcessor from "../TerrainTileProcessor.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartesian4 } from "../../Source/Cesium.js";
-import { createWorldTerrain } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { EllipsoidTerrainProvider } from "../../Source/Cesium.js";
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
-import { Ray } from "../../Source/Cesium.js";
-import { GlobeSurfaceTile } from "../../Source/Cesium.js";
-import { ImageryLayerCollection } from "../../Source/Cesium.js";
-import { QuadtreeTile } from "../../Source/Cesium.js";
-import { QuadtreeTileLoadState } from "../../Source/Cesium.js";
-import { TerrainState } from "../../Source/Cesium.js";
-import { TileProviderError } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe("Scene/GlobeSurfaceTile", function () {

--- a/Specs/Scene/GlobeTranslucencyFramebufferSpec.js
+++ b/Specs/Scene/GlobeTranslucencyFramebufferSpec.js
@@ -1,9 +1,12 @@
-import { BoundingRectangle } from "../../Source/Cesium.js";
-import { Framebuffer } from "../../Source/Cesium.js";
-import { GlobeTranslucencyFramebuffer } from "../../Source/Cesium.js";
-import { PassState } from "../../Source/Cesium.js";
-import { PixelDatatype } from "../../Source/Cesium.js";
-import { Texture } from "../../Source/Cesium.js";
+import {
+  BoundingRectangle,
+  Framebuffer,
+  GlobeTranslucencyFramebuffer,
+  PassState,
+  PixelDatatype,
+  Texture,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe("Scene/GlobeTranslucencyFramebuffer", function () {

--- a/Specs/Scene/GlobeTranslucencyStateSpec.js
+++ b/Specs/Scene/GlobeTranslucencyStateSpec.js
@@ -1,16 +1,19 @@
-import { Color } from "../../Source/Cesium.js";
-import { DrawCommand } from "../../Source/Cesium.js";
-import { FrustumCommands } from "../../Source/Cesium.js";
-import { Globe } from "../../Source/Cesium.js";
-import { GlobeTranslucencyFramebuffer } from "../../Source/Cesium.js";
-import { GlobeTranslucencyState } from "../../Source/Cesium.js";
-import { NearFarScalar } from "../../Source/Cesium.js";
-import { Pass } from "../../Source/Cesium.js";
-import { PassState } from "../../Source/Cesium.js";
-import { RenderState } from "../../Source/Cesium.js";
-import { SceneMode } from "../../Source/Cesium.js";
-import { ShaderProgram } from "../../Source/Cesium.js";
-import { ShaderSource } from "../../Source/Cesium.js";
+import {
+  Color,
+  DrawCommand,
+  FrustumCommands,
+  Globe,
+  GlobeTranslucencyFramebuffer,
+  GlobeTranslucencyState,
+  NearFarScalar,
+  Pass,
+  PassState,
+  RenderState,
+  SceneMode,
+  ShaderProgram,
+  ShaderSource,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 let scene;

--- a/Specs/Scene/GoogleEarthEnterpriseImageryProviderSpec.js
+++ b/Specs/Scene/GoogleEarthEnterpriseImageryProviderSpec.js
@@ -1,21 +1,24 @@
-import { decodeGoogleEarthEnterpriseData } from "../../Source/Cesium.js";
-import { defaultValue } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
-import { GoogleEarthEnterpriseMetadata } from "../../Source/Cesium.js";
-import { GoogleEarthEnterpriseTileInformation } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { Request } from "../../Source/Cesium.js";
-import { RequestScheduler } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { DiscardMissingTileImagePolicy } from "../../Source/Cesium.js";
-import { GoogleEarthEnterpriseImageryProvider } from "../../Source/Cesium.js";
-import { Imagery } from "../../Source/Cesium.js";
-import { ImageryLayer } from "../../Source/Cesium.js";
-import { ImageryProvider } from "../../Source/Cesium.js";
-import { ImageryState } from "../../Source/Cesium.js";
+import {
+  decodeGoogleEarthEnterpriseData,
+  defaultValue,
+  defined,
+  GeographicTilingScheme,
+  GoogleEarthEnterpriseMetadata,
+  GoogleEarthEnterpriseTileInformation,
+  Rectangle,
+  Request,
+  RequestScheduler,
+  Resource,
+  DiscardMissingTileImagePolicy,
+  GoogleEarthEnterpriseImageryProvider,
+  Imagery,
+  ImageryLayer,
+  ImageryProvider,
+  ImageryState,
+  Uri,
+} from "../../../Source/Cesium.js";
+
 import pollToPromise from "../pollToPromise.js";
-import { Uri } from "../../Source/Cesium.js";
 
 describe("Scene/GoogleEarthEnterpriseImageryProvider", function () {
   beforeEach(function () {

--- a/Specs/Scene/GoogleEarthEnterpriseMapsProviderSpec.js
+++ b/Specs/Scene/GoogleEarthEnterpriseMapsProviderSpec.js
@@ -1,14 +1,17 @@
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { Request } from "../../Source/Cesium.js";
-import { RequestScheduler } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { WebMercatorTilingScheme } from "../../Source/Cesium.js";
-import { GoogleEarthEnterpriseMapsProvider } from "../../Source/Cesium.js";
-import { Imagery } from "../../Source/Cesium.js";
-import { ImageryLayer } from "../../Source/Cesium.js";
-import { ImageryProvider } from "../../Source/Cesium.js";
-import { ImageryState } from "../../Source/Cesium.js";
+import {
+  GeographicTilingScheme,
+  Rectangle,
+  Request,
+  RequestScheduler,
+  Resource,
+  WebMercatorTilingScheme,
+  GoogleEarthEnterpriseMapsProvider,
+  Imagery,
+  ImageryLayer,
+  ImageryProvider,
+  ImageryState,
+} from "../../../Source/Cesium.js";
+
 import pollToPromise from "../pollToPromise.js";
 
 describe("Scene/GoogleEarthEnterpriseMapsProvider", function () {

--- a/Specs/Scene/GridImageryProviderSpec.js
+++ b/Specs/Scene/GridImageryProviderSpec.js
@@ -1,8 +1,11 @@
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
-import { WebMercatorTilingScheme } from "../../Source/Cesium.js";
-import { GridImageryProvider } from "../../Source/Cesium.js";
-import { ImageryProvider } from "../../Source/Cesium.js";
+import {
+  Ellipsoid,
+  GeographicTilingScheme,
+  WebMercatorTilingScheme,
+  GridImageryProvider,
+  ImageryProvider,
+} from "../../../Source/Cesium.js";
+
 import pollToPromise from "../pollToPromise.js";
 
 describe("Scene/GridImageryProvider", function () {

--- a/Specs/Scene/GroundPolylinePrimitiveSpec.js
+++ b/Specs/Scene/GroundPolylinePrimitiveSpec.js
@@ -1,24 +1,28 @@
-import { ApproximateTerrainHeights } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
+import {
+  ApproximateTerrainHeights,
+  Cartesian2,
+  Cartesian3,
+  Color,
+  ColorGeometryInstanceAttribute,
+  destroyObject,
+  DistanceDisplayConditionGeometryInstanceAttribute,
+  Ellipsoid,
+  GeometryInstance,
+  GroundPolylineGeometry,
+  HeadingPitchRange,
+  Rectangle,
+  RectangleGeometry,
+  ShowGeometryInstanceAttribute,
+  Pass,
+  GroundPolylinePrimitive,
+  PerInstanceColorAppearance,
+  PolylineColorAppearance,
+  PolylineMaterialAppearance,
+  Primitive,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { destroyObject } from "../../Source/Cesium.js";
-import { DistanceDisplayConditionGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
-import { GroundPolylineGeometry } from "../../Source/Cesium.js";
-import { HeadingPitchRange } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { RectangleGeometry } from "../../Source/Cesium.js";
-import { ShowGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { Pass } from "../../Source/Cesium.js";
-import { GroundPolylinePrimitive } from "../../Source/Cesium.js";
-import { PerInstanceColorAppearance } from "../../Source/Cesium.js";
-import { PolylineColorAppearance } from "../../Source/Cesium.js";
-import { PolylineMaterialAppearance } from "../../Source/Cesium.js";
-import { Primitive } from "../../Source/Cesium.js";
+
 import createCanvas from "../createCanvas.js";
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";

--- a/Specs/Scene/GroundPrimitiveSpec.js
+++ b/Specs/Scene/GroundPrimitiveSpec.js
@@ -1,26 +1,30 @@
-import { ApproximateTerrainHeights } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { destroyObject } from "../../Source/Cesium.js";
-import { DistanceDisplayConditionGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
-import { HeadingPitchRange } from "../../Source/Cesium.js";
+import {
+  ApproximateTerrainHeights,
+  Color,
+  ColorGeometryInstanceAttribute,
+  destroyObject,
+  DistanceDisplayConditionGeometryInstanceAttribute,
+  Ellipsoid,
+  GeometryInstance,
+  HeadingPitchRange,
+  PolygonGeometry,
+  Rectangle,
+  RectangleGeometry,
+  ShowGeometryInstanceAttribute,
+  Pass,
+  RenderState,
+  ClassificationType,
+  EllipsoidSurfaceAppearance,
+  GroundPrimitive,
+  InvertClassification,
+  Material,
+  PerInstanceColorAppearance,
+  Primitive,
+  StencilConstants,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { PolygonGeometry } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { RectangleGeometry } from "../../Source/Cesium.js";
-import { ShowGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { Pass } from "../../Source/Cesium.js";
-import { RenderState } from "../../Source/Cesium.js";
-import { ClassificationType } from "../../Source/Cesium.js";
-import { EllipsoidSurfaceAppearance } from "../../Source/Cesium.js";
-import { GroundPrimitive } from "../../Source/Cesium.js";
-import { InvertClassification } from "../../Source/Cesium.js";
-import { Material } from "../../Source/Cesium.js";
-import { PerInstanceColorAppearance } from "../../Source/Cesium.js";
-import { Primitive } from "../../Source/Cesium.js";
-import { StencilConstants } from "../../Source/Cesium.js";
+
 import createCanvas from "../createCanvas.js";
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";

--- a/Specs/Scene/HeightmapTessellatorSpec.js
+++ b/Specs/Scene/HeightmapTessellatorSpec.js
@@ -1,10 +1,13 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { HeightmapTessellator } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Ellipsoid,
+  HeightmapTessellator,
+  Rectangle,
+  WebMercatorProjection,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { WebMercatorProjection } from "../../Source/Cesium.js";
 
 describe("Scene/HeightmapTessellator", function () {
   it("throws when heightmap is not provided", function () {

--- a/Specs/Scene/ImageryLayerCollectionSpec.js
+++ b/Specs/Scene/ImageryLayerCollectionSpec.js
@@ -1,17 +1,20 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { Event } from "../../Source/Cesium.js";
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { Ray } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { WebMercatorProjection } from "../../Source/Cesium.js";
-import { WebMercatorTilingScheme } from "../../Source/Cesium.js";
-import { Globe } from "../../Source/Cesium.js";
-import { ImageryLayer } from "../../Source/Cesium.js";
-import { ImageryLayerCollection } from "../../Source/Cesium.js";
-import { ImageryLayerFeatureInfo } from "../../Source/Cesium.js";
-import { ImageryProvider } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Ellipsoid,
+  Event,
+  GeographicTilingScheme,
+  Matrix4,
+  Ray,
+  Rectangle,
+  WebMercatorProjection,
+  WebMercatorTilingScheme,
+  Globe,
+  ImageryLayer,
+  ImageryLayerCollection,
+  ImageryLayerFeatureInfo,
+  ImageryProvider,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/Scene/ImageryLayerSpec.js
+++ b/Specs/Scene/ImageryLayerSpec.js
@@ -1,24 +1,27 @@
-import { EllipsoidTerrainProvider } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { Request } from "../../Source/Cesium.js";
-import { RequestScheduler } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { ComputeEngine } from "../../Source/Cesium.js";
-import { TextureMagnificationFilter } from "../../Source/Cesium.js";
-import { TextureMinificationFilter } from "../../Source/Cesium.js";
-import { ArcGisMapServerImageryProvider } from "../../Source/Cesium.js";
-import { BingMapsImageryProvider } from "../../Source/Cesium.js";
-import { TileMapServiceImageryProvider } from "../../Source/Cesium.js";
-import { GlobeSurfaceTile } from "../../Source/Cesium.js";
-import { Imagery } from "../../Source/Cesium.js";
-import { ImageryLayer } from "../../Source/Cesium.js";
-import { ImageryLayerCollection } from "../../Source/Cesium.js";
-import { ImageryState } from "../../Source/Cesium.js";
-import { NeverTileDiscardPolicy } from "../../Source/Cesium.js";
-import { QuadtreeTile } from "../../Source/Cesium.js";
-import { SingleTileImageryProvider } from "../../Source/Cesium.js";
-import { UrlTemplateImageryProvider } from "../../Source/Cesium.js";
-import { WebMapServiceImageryProvider } from "../../Source/Cesium.js";
+import {
+  EllipsoidTerrainProvider,
+  Rectangle,
+  Request,
+  RequestScheduler,
+  Resource,
+  ComputeEngine,
+  TextureMagnificationFilter,
+  TextureMinificationFilter,
+  ArcGisMapServerImageryProvider,
+  BingMapsImageryProvider,
+  TileMapServiceImageryProvider,
+  GlobeSurfaceTile,
+  Imagery,
+  ImageryLayer,
+  ImageryLayerCollection,
+  ImageryState,
+  NeverTileDiscardPolicy,
+  QuadtreeTile,
+  SingleTileImageryProvider,
+  UrlTemplateImageryProvider,
+  WebMapServiceImageryProvider,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/Scene/IonImageryProviderSpec.js
+++ b/Specs/Scene/IonImageryProviderSpec.js
@@ -1,19 +1,21 @@
-import { Credit } from "../../Source/Cesium.js";
-import { defaultValue } from "../../Source/Cesium.js";
-import { IonResource } from "../../Source/Cesium.js";
-import { RequestScheduler } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { RuntimeError } from "../../Source/Cesium.js";
-import { ArcGisMapServerImageryProvider } from "../../Source/Cesium.js";
-import { BingMapsImageryProvider } from "../../Source/Cesium.js";
-import { GoogleEarthEnterpriseMapsProvider } from "../../Source/Cesium.js";
-import { ImageryProvider } from "../../Source/Cesium.js";
-import { IonImageryProvider } from "../../Source/Cesium.js";
-import { MapboxImageryProvider } from "../../Source/Cesium.js";
-import { SingleTileImageryProvider } from "../../Source/Cesium.js";
-import { UrlTemplateImageryProvider } from "../../Source/Cesium.js";
-import { WebMapServiceImageryProvider } from "../../Source/Cesium.js";
-import { WebMapTileServiceImageryProvider } from "../../Source/Cesium.js";
+import {
+  Credit,
+  defaultValue,
+  IonResource,
+  RequestScheduler,
+  Resource,
+  RuntimeError,
+  ArcGisMapServerImageryProvider,
+  BingMapsImageryProvider,
+  GoogleEarthEnterpriseMapsProvider,
+  ImageryProvider,
+  IonImageryProvider,
+  MapboxImageryProvider,
+  SingleTileImageryProvider,
+  UrlTemplateImageryProvider,
+  WebMapServiceImageryProvider,
+  WebMapTileServiceImageryProvider,
+} from "../../../Source/Cesium.js";
 
 describe("Scene/IonImageryProvider", function () {
   function createTestProvider(endpointData) {

--- a/Specs/Scene/JobSchedulerSpec.js
+++ b/Specs/Scene/JobSchedulerSpec.js
@@ -1,5 +1,4 @@
-import { JobScheduler } from "../../Source/Cesium.js";
-import { JobType } from "../../Source/Cesium.js";
+import { JobScheduler, JobType } from "../../../Source/Cesium.js";
 
 describe("Scene/JobScheduler", function () {
   let originalGetTimestamp;

--- a/Specs/Scene/LabelCollectionSpec.js
+++ b/Specs/Scene/LabelCollectionSpec.js
@@ -1,21 +1,25 @@
-import { BoundingRectangle } from "../../Source/Cesium.js";
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
+import {
+  BoundingRectangle,
+  BoundingSphere,
+  Cartesian2,
+  Cartesian3,
+  Color,
+  defined,
+  DistanceDisplayCondition,
+  NearFarScalar,
+  Rectangle,
+  BlendOption,
+  Globe,
+  HeightReference,
+  HorizontalOrigin,
+  Label,
+  LabelCollection,
+  LabelStyle,
+  VerticalOrigin,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { NearFarScalar } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { BlendOption } from "../../Source/Cesium.js";
-import { Globe } from "../../Source/Cesium.js";
-import { HeightReference } from "../../Source/Cesium.js";
-import { HorizontalOrigin } from "../../Source/Cesium.js";
-import { Label } from "../../Source/Cesium.js";
-import { LabelCollection } from "../../Source/Cesium.js";
-import { LabelStyle } from "../../Source/Cesium.js";
-import { VerticalOrigin } from "../../Source/Cesium.js";
+
 import createGlobe from "../createGlobe.js";
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";

--- a/Specs/Scene/MapboxImageryProviderSpec.js
+++ b/Specs/Scene/MapboxImageryProviderSpec.js
@@ -1,14 +1,17 @@
+import {
+  Rectangle,
+  Request,
+  RequestScheduler,
+  Resource,
+  WebMercatorTilingScheme,
+  Imagery,
+  ImageryLayer,
+  ImageryProvider,
+  ImageryState,
+  MapboxImageryProvider,
+} from "../../../Source/Cesium.js";
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { Request } from "../../Source/Cesium.js";
-import { RequestScheduler } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { WebMercatorTilingScheme } from "../../Source/Cesium.js";
-import { Imagery } from "../../Source/Cesium.js";
-import { ImageryLayer } from "../../Source/Cesium.js";
-import { ImageryProvider } from "../../Source/Cesium.js";
-import { ImageryState } from "../../Source/Cesium.js";
-import { MapboxImageryProvider } from "../../Source/Cesium.js";
+
 import pollToPromise from "../pollToPromise.js";
 
 describe("Scene/MapboxImageryProvider", function () {

--- a/Specs/Scene/MapboxStyleImageryProviderSpec.js
+++ b/Specs/Scene/MapboxStyleImageryProviderSpec.js
@@ -1,14 +1,17 @@
+import {
+  Rectangle,
+  Request,
+  RequestScheduler,
+  Resource,
+  WebMercatorTilingScheme,
+  Imagery,
+  ImageryLayer,
+  ImageryProvider,
+  ImageryState,
+  MapboxStyleImageryProvider,
+} from "../../../Source/Cesium.js";
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { Request } from "../../Source/Cesium.js";
-import { RequestScheduler } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { WebMercatorTilingScheme } from "../../Source/Cesium.js";
-import { Imagery } from "../../Source/Cesium.js";
-import { ImageryLayer } from "../../Source/Cesium.js";
-import { ImageryProvider } from "../../Source/Cesium.js";
-import { ImageryState } from "../../Source/Cesium.js";
-import { MapboxStyleImageryProvider } from "../../Source/Cesium.js";
+
 import pollToPromise from "../pollToPromise.js";
 
 describe("Scene/MapboxStyleImageryProvider", function () {

--- a/Specs/Scene/MaterialAppearanceSpec.js
+++ b/Specs/Scene/MaterialAppearanceSpec.js
@@ -1,13 +1,16 @@
-import { Color } from "../../Source/Cesium.js";
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { defaultValue } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { RectangleGeometry } from "../../Source/Cesium.js";
-import { Appearance } from "../../Source/Cesium.js";
-import { Material } from "../../Source/Cesium.js";
-import { MaterialAppearance } from "../../Source/Cesium.js";
-import { Primitive } from "../../Source/Cesium.js";
+import {
+  Color,
+  ColorGeometryInstanceAttribute,
+  defaultValue,
+  GeometryInstance,
+  Rectangle,
+  RectangleGeometry,
+  Appearance,
+  Material,
+  MaterialAppearance,
+  Primitive,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Scene/MaterialSpec.js
+++ b/Specs/Scene/MaterialSpec.js
@@ -1,19 +1,22 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { defaultValue } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { RectangleGeometry } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { Material } from "../../Source/Cesium.js";
-import { MaterialAppearance } from "../../Source/Cesium.js";
-import { PolylineCollection } from "../../Source/Cesium.js";
-import { FeatureDetection } from "../../Source/Cesium.js";
-import { Primitive } from "../../Source/Cesium.js";
-import { TextureMagnificationFilter } from "../../Source/Cesium.js";
-import { TextureMinificationFilter } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Color,
+  defaultValue,
+  defined,
+  Ellipsoid,
+  GeometryInstance,
+  Rectangle,
+  RectangleGeometry,
+  Resource,
+  Material,
+  MaterialAppearance,
+  PolylineCollection,
+  FeatureDetection,
+  Primitive,
+  TextureMagnificationFilter,
+  TextureMinificationFilter,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/Scene/ModelInstanceCollectionSpec.js
+++ b/Specs/Scene/ModelInstanceCollectionSpec.js
@@ -1,17 +1,20 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { defaultValue } from "../../Source/Cesium.js";
-import { HeadingPitchRange } from "../../Source/Cesium.js";
-import { HeadingPitchRoll } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { Axis } from "../../Source/Cesium.js";
-import { PrimitiveType } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
-import { Model } from "../../Source/Cesium.js";
-import { ModelInstanceCollection } from "../../Source/Cesium.js";
-import { ShadowMode } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Cartesian3,
+  defaultValue,
+  HeadingPitchRange,
+  HeadingPitchRoll,
+  JulianDate,
+  Matrix4,
+  Axis,
+  PrimitiveType,
+  Resource,
+  Transforms,
+  Model,
+  ModelInstanceCollection,
+  ShadowMode,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -1,40 +1,44 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartesian4 } from "../../Source/Cesium.js";
-import { CesiumTerrainProvider } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { combine } from "../../Source/Cesium.js";
-import { Credit } from "../../Source/Cesium.js";
-import { defaultValue } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { Event } from "../../Source/Cesium.js";
-import { FeatureDetection } from "../../Source/Cesium.js";
-import { HeadingPitchRange } from "../../Source/Cesium.js";
-import { ImageBasedLighting } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Cartesian4,
+  CesiumTerrainProvider,
+  Color,
+  combine,
+  Credit,
+  defaultValue,
+  defined,
+  DistanceDisplayCondition,
+  Ellipsoid,
+  Event,
+  FeatureDetection,
+  HeadingPitchRange,
+  ImageBasedLighting,
+  JulianDate,
+  Matrix3,
+  Matrix4,
+  PerspectiveFrustum,
+  PrimitiveType,
+  Resource,
+  Transforms,
+  WebGLConstants,
+  Pass,
+  RenderState,
+  ShaderSource,
+  Axis,
+  ClippingPlane,
+  ClippingPlaneCollection,
+  ColorBlendMode,
+  DracoLoader,
+  HeightReference,
+  Model,
+  ModelAnimationLoop,
+  DepthFunction,
+  RuntimeError,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix3 } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { PerspectiveFrustum } from "../../Source/Cesium.js";
-import { PrimitiveType } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
-import { WebGLConstants } from "../../Source/Cesium.js";
-import { Pass } from "../../Source/Cesium.js";
-import { RenderState } from "../../Source/Cesium.js";
-import { ShaderSource } from "../../Source/Cesium.js";
-import { Axis } from "../../Source/Cesium.js";
-import { ClippingPlane } from "../../Source/Cesium.js";
-import { ClippingPlaneCollection } from "../../Source/Cesium.js";
-import { ColorBlendMode } from "../../Source/Cesium.js";
-import { DracoLoader } from "../../Source/Cesium.js";
-import { HeightReference } from "../../Source/Cesium.js";
-import { Model } from "../../Source/Cesium.js";
-import { ModelAnimationLoop } from "../../Source/Cesium.js";
-import { DepthFunction } from "../../Source/Cesium.js";
-import { RuntimeError } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 import ModelOutlineLoader from "../../Source/Scene/ModelOutlineLoader.js";

--- a/Specs/Scene/MoonSpec.js
+++ b/Specs/Scene/MoonSpec.js
@@ -1,11 +1,14 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { Matrix3 } from "../../Source/Cesium.js";
-import { Simon1994PlanetaryPositions } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
-import { Moon } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Color,
+  defined,
+  Ellipsoid,
+  Matrix3,
+  Simon1994PlanetaryPositions,
+  Transforms,
+  Moon,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Scene/MultifrustumSpec.js
+++ b/Specs/Scene/MultifrustumSpec.js
@@ -1,25 +1,29 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { BoxGeometry } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { defaultValue } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { destroyObject } from "../../Source/Cesium.js";
-import { GeometryPipeline } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  BoxGeometry,
+  Cartesian2,
+  Cartesian3,
+  Color,
+  defaultValue,
+  defined,
+  destroyObject,
+  GeometryPipeline,
+  Matrix4,
+  Resource,
+  BufferUsage,
+  DrawCommand,
+  Pass,
+  RenderState,
+  Sampler,
+  ShaderProgram,
+  VertexArray,
+  BillboardCollection,
+  BlendingState,
+  TextureAtlas,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { BufferUsage } from "../../Source/Cesium.js";
-import { DrawCommand } from "../../Source/Cesium.js";
-import { Pass } from "../../Source/Cesium.js";
-import { RenderState } from "../../Source/Cesium.js";
-import { Sampler } from "../../Source/Cesium.js";
-import { ShaderProgram } from "../../Source/Cesium.js";
-import { VertexArray } from "../../Source/Cesium.js";
-import { BillboardCollection } from "../../Source/Cesium.js";
-import { BlendingState } from "../../Source/Cesium.js";
-import { TextureAtlas } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/Scene/OctahedralProjectedCubeMapSpec.js
+++ b/Specs/Scene/OctahedralProjectedCubeMapSpec.js
@@ -1,7 +1,10 @@
+import {
+  ComputeEngine,
+  Pass,
+  OctahedralProjectedCubeMap,
+} from "../../../Source/Cesium.js";
 import { Cartesian3, defined } from "../../Source/Cesium.js";
-import { ComputeEngine } from "../../Source/Cesium.js";
-import { Pass } from "../../Source/Cesium.js";
-import { OctahedralProjectedCubeMap } from "../../Source/Cesium.js";
+
 import createContext from "../createContext.js";
 import createFrameState from "../createFrameState.js";
 import pollToPromise from "../pollToPromise.js";

--- a/Specs/Scene/OpenStreetMapImageryProviderSpec.js
+++ b/Specs/Scene/OpenStreetMapImageryProviderSpec.js
@@ -1,14 +1,17 @@
+import {
+  Rectangle,
+  Request,
+  RequestScheduler,
+  Resource,
+  WebMercatorTilingScheme,
+  OpenStreetMapImageryProvider,
+  Imagery,
+  ImageryLayer,
+  ImageryState,
+  UrlTemplateImageryProvider,
+} from "../../../Source/Cesium.js";
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { Request } from "../../Source/Cesium.js";
-import { RequestScheduler } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { WebMercatorTilingScheme } from "../../Source/Cesium.js";
-import { OpenStreetMapImageryProvider } from "../../Source/Cesium.js";
-import { Imagery } from "../../Source/Cesium.js";
-import { ImageryLayer } from "../../Source/Cesium.js";
-import { ImageryState } from "../../Source/Cesium.js";
-import { UrlTemplateImageryProvider } from "../../Source/Cesium.js";
+
 import pollToPromise from "../pollToPromise.js";
 
 describe("Scene/OpenStreetMapImageryProvider", function () {

--- a/Specs/Scene/OrderedGroundPrimitiveCollectionSpec.js
+++ b/Specs/Scene/OrderedGroundPrimitiveCollectionSpec.js
@@ -1,5 +1,7 @@
-import { destroyObject } from "../../Source/Cesium.js";
-import { OrderedGroundPrimitiveCollection } from "../../Source/Cesium.js";
+import {
+  destroyObject,
+  OrderedGroundPrimitiveCollection,
+} from "../../../Source/Cesium.js";
 
 describe("Scene/OrderedGroundPrimitiveCollection", function () {
   let updateCallOrder;

--- a/Specs/Scene/ParticleSpec.js
+++ b/Specs/Scene/ParticleSpec.js
@@ -1,7 +1,9 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { Particle } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Color,
+  Particle,
+} from "../../../Source/Cesium.js";
 
 describe("Scene/Particle", function () {
   it("default constructor", function () {

--- a/Specs/Scene/ParticleSystemSpec.js
+++ b/Specs/Scene/ParticleSystemSpec.js
@@ -1,11 +1,14 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { CircleEmitter } from "../../Source/Cesium.js";
-import { ParticleBurst } from "../../Source/Cesium.js";
-import { ParticleSystem } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Color,
+  Matrix4,
+  Resource,
+  CircleEmitter,
+  ParticleBurst,
+  ParticleSystem,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/Scene/PerInstanceColorAppearanceSpec.js
+++ b/Specs/Scene/PerInstanceColorAppearanceSpec.js
@@ -1,10 +1,13 @@
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { RectangleGeometry } from "../../Source/Cesium.js";
-import { Appearance } from "../../Source/Cesium.js";
-import { PerInstanceColorAppearance } from "../../Source/Cesium.js";
-import { Primitive } from "../../Source/Cesium.js";
+import {
+  ColorGeometryInstanceAttribute,
+  GeometryInstance,
+  Rectangle,
+  RectangleGeometry,
+  Appearance,
+  PerInstanceColorAppearance,
+  Primitive,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Scene/PickingSpec.js
+++ b/Specs/Scene/PickingSpec.js
@@ -1,24 +1,28 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { FeatureDetection } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Cartographic,
+  Color,
+  Ellipsoid,
+  FeatureDetection,
+  GeometryInstance,
+  Matrix4,
+  OrthographicFrustum,
+  PerspectiveFrustum,
+  Ray,
+  Rectangle,
+  RectangleGeometry,
+  ShowGeometryInstanceAttribute,
+  Transforms,
+  Cesium3DTileStyle,
+  EllipsoidSurfaceAppearance,
+  Globe,
+  PointPrimitiveCollection,
+  Primitive,
+  SceneMode,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { OrthographicFrustum } from "../../Source/Cesium.js";
-import { PerspectiveFrustum } from "../../Source/Cesium.js";
-import { Ray } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { RectangleGeometry } from "../../Source/Cesium.js";
-import { ShowGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
-import { Cesium3DTileStyle } from "../../Source/Cesium.js";
-import { EllipsoidSurfaceAppearance } from "../../Source/Cesium.js";
-import { Globe } from "../../Source/Cesium.js";
-import { PointPrimitiveCollection } from "../../Source/Cesium.js";
-import { Primitive } from "../../Source/Cesium.js";
-import { SceneMode } from "../../Source/Cesium.js";
+
 import Cesium3DTilesTester from "../Cesium3DTilesTester.js";
 import createCanvas from "../createCanvas.js";
 import createScene from "../createScene.js";

--- a/Specs/Scene/PointCloudEyeDomeLightingSpec.js
+++ b/Specs/Scene/PointCloudEyeDomeLightingSpec.js
@@ -1,9 +1,13 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cesium3DTileStyle } from "../../Source/Cesium.js";
-import { HeadingPitchRange } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Cesium3DTileStyle,
+  HeadingPitchRange,
+  PerspectiveFrustum,
+  PointCloudEyeDomeLighting,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { PerspectiveFrustum } from "../../Source/Cesium.js";
-import { PointCloudEyeDomeLighting } from "../../Source/Cesium.js";
+
 import Cesium3DTilesTester from "../Cesium3DTilesTester.js";
 import createScene from "../createScene.js";
 

--- a/Specs/Scene/PointPrimitiveCollectionSpec.js
+++ b/Specs/Scene/PointPrimitiveCollectionSpec.js
@@ -1,15 +1,19 @@
-import { BoundingRectangle } from "../../Source/Cesium.js";
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
+import {
+  BoundingRectangle,
+  BoundingSphere,
+  Cartesian2,
+  Cartesian3,
+  Color,
+  DistanceDisplayCondition,
+  NearFarScalar,
+  Rectangle,
+  BlendOption,
+  PointPrimitive,
+  PointPrimitiveCollection,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { NearFarScalar } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { BlendOption } from "../../Source/Cesium.js";
-import { PointPrimitive } from "../../Source/Cesium.js";
-import { PointPrimitiveCollection } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Scene/PolylineCollectionSpec.js
+++ b/Specs/Scene/PolylineCollectionSpec.js
@@ -1,14 +1,18 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { HeadingPitchRange } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Cartesian3,
+  Color,
+  DistanceDisplayCondition,
+  HeadingPitchRange,
+  Matrix4,
+  Camera,
+  Material,
+  PolylineCollection,
+  SceneMode,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { Camera } from "../../Source/Cesium.js";
-import { Material } from "../../Source/Cesium.js";
-import { PolylineCollection } from "../../Source/Cesium.js";
-import { SceneMode } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Scene/PolylineColorAppearanceSpec.js
+++ b/Specs/Scene/PolylineColorAppearanceSpec.js
@@ -1,12 +1,15 @@
-import { ArcType } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
-import { PolylineGeometry } from "../../Source/Cesium.js";
-import { Appearance } from "../../Source/Cesium.js";
-import { PolylineColorAppearance } from "../../Source/Cesium.js";
-import { Primitive } from "../../Source/Cesium.js";
+import {
+  ArcType,
+  Cartesian3,
+  Color,
+  ColorGeometryInstanceAttribute,
+  GeometryInstance,
+  PolylineGeometry,
+  Appearance,
+  PolylineColorAppearance,
+  Primitive,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Scene/PolylineMaterialAppearanceSpec.js
+++ b/Specs/Scene/PolylineMaterialAppearanceSpec.js
@@ -1,11 +1,14 @@
-import { ArcType } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
-import { PolylineGeometry } from "../../Source/Cesium.js";
-import { Appearance } from "../../Source/Cesium.js";
-import { Material } from "../../Source/Cesium.js";
-import { PolylineMaterialAppearance } from "../../Source/Cesium.js";
-import { Primitive } from "../../Source/Cesium.js";
+import {
+  ArcType,
+  Cartesian3,
+  GeometryInstance,
+  PolylineGeometry,
+  Appearance,
+  Material,
+  PolylineMaterialAppearance,
+  Primitive,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Scene/PostProcessStageCollectionSpec.js
+++ b/Specs/Scene/PostProcessStageCollectionSpec.js
@@ -1,6 +1,9 @@
-import { PostProcessStage } from "../../Source/Cesium.js";
-import { PostProcessStageCollection } from "../../Source/Cesium.js";
-import { Tonemapper } from "../../Source/Cesium.js";
+import {
+  PostProcessStage,
+  PostProcessStageCollection,
+  Tonemapper,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import ViewportPrimitive from "../ViewportPrimitive.js";
 

--- a/Specs/Scene/PostProcessStageCompositeSpec.js
+++ b/Specs/Scene/PostProcessStageCompositeSpec.js
@@ -1,7 +1,10 @@
-import { Color } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { PostProcessStage } from "../../Source/Cesium.js";
-import { PostProcessStageComposite } from "../../Source/Cesium.js";
+import {
+  Color,
+  defined,
+  PostProcessStage,
+  PostProcessStageComposite,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/Scene/PostProcessStageLibrarySpec.js
+++ b/Specs/Scene/PostProcessStageLibrarySpec.js
@@ -1,10 +1,13 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { HeadingPitchRange } from "../../Source/Cesium.js";
-import { HeadingPitchRoll } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
-import { Model } from "../../Source/Cesium.js";
-import { PostProcessStageLibrary } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  HeadingPitchRange,
+  HeadingPitchRoll,
+  Matrix4,
+  Transforms,
+  Model,
+  PostProcessStageLibrary,
+} from "../../../Source/Cesium.js";
+
 import createCanvas from "../createCanvas.js";
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";

--- a/Specs/Scene/PostProcessStageSpec.js
+++ b/Specs/Scene/PostProcessStageSpec.js
@@ -1,15 +1,18 @@
-import { BoundingRectangle } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { HeadingPitchRange } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { PixelFormat } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
-import { PixelDatatype } from "../../Source/Cesium.js";
-import { Model } from "../../Source/Cesium.js";
-import { PostProcessStage } from "../../Source/Cesium.js";
-import { PostProcessStageSampleMode } from "../../Source/Cesium.js";
+import {
+  BoundingRectangle,
+  Cartesian3,
+  Color,
+  defined,
+  HeadingPitchRange,
+  Matrix4,
+  PixelFormat,
+  Transforms,
+  PixelDatatype,
+  Model,
+  PostProcessStage,
+  PostProcessStageSampleMode,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/Scene/PrimitiveCollectionSpec.js
+++ b/Specs/Scene/PrimitiveCollectionSpec.js
@@ -1,15 +1,18 @@
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { defaultValue } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { RectangleGeometry } from "../../Source/Cesium.js";
-import { HorizontalOrigin } from "../../Source/Cesium.js";
-import { LabelCollection } from "../../Source/Cesium.js";
-import { PerInstanceColorAppearance } from "../../Source/Cesium.js";
-import { Primitive } from "../../Source/Cesium.js";
-import { PrimitiveCollection } from "../../Source/Cesium.js";
-import { VerticalOrigin } from "../../Source/Cesium.js";
+import {
+  ColorGeometryInstanceAttribute,
+  defaultValue,
+  defined,
+  GeometryInstance,
+  Rectangle,
+  RectangleGeometry,
+  HorizontalOrigin,
+  LabelCollection,
+  PerInstanceColorAppearance,
+  Primitive,
+  PrimitiveCollection,
+  VerticalOrigin,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/Scene/PrimitiveCullingSpec.js
+++ b/Specs/Scene/PrimitiveCullingSpec.js
@@ -1,25 +1,29 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { defaultValue } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Color,
+  ColorGeometryInstanceAttribute,
+  defaultValue,
+  defined,
+  GeometryInstance,
+  PerspectiveFrustum,
+  Rectangle,
+  RectangleGeometry,
+  Resource,
+  Transforms,
+  BillboardCollection,
+  Globe,
+  HorizontalOrigin,
+  LabelCollection,
+  Material,
+  PerInstanceColorAppearance,
+  PolylineCollection,
+  Primitive,
+  SceneMode,
+  VerticalOrigin,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { PerspectiveFrustum } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { RectangleGeometry } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
-import { BillboardCollection } from "../../Source/Cesium.js";
-import { Globe } from "../../Source/Cesium.js";
-import { HorizontalOrigin } from "../../Source/Cesium.js";
-import { LabelCollection } from "../../Source/Cesium.js";
-import { Material } from "../../Source/Cesium.js";
-import { PerInstanceColorAppearance } from "../../Source/Cesium.js";
-import { PolylineCollection } from "../../Source/Cesium.js";
-import { Primitive } from "../../Source/Cesium.js";
-import { SceneMode } from "../../Source/Cesium.js";
-import { VerticalOrigin } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/Scene/PrimitivePipelineSpec.js
+++ b/Specs/Scene/PrimitivePipelineSpec.js
@@ -1,12 +1,14 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { BoxGeometry } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { ComponentDatatype } from "../../Source/Cesium.js";
-import { Geometry } from "../../Source/Cesium.js";
-import { GeometryAttribute } from "../../Source/Cesium.js";
-import { GeometryAttributes } from "../../Source/Cesium.js";
-import { PrimitiveType } from "../../Source/Cesium.js";
-import { PrimitivePipeline } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  BoxGeometry,
+  Cartesian3,
+  ComponentDatatype,
+  Geometry,
+  GeometryAttribute,
+  GeometryAttributes,
+  PrimitiveType,
+  PrimitivePipeline,
+} from "../../../Source/Cesium.js";
 
 describe(
   "Scene/PrimitivePipeline",

--- a/Specs/Scene/PrimitiveSpec.js
+++ b/Specs/Scene/PrimitiveSpec.js
@@ -1,31 +1,35 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { BoxGeometry } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { ComponentDatatype } from "../../Source/Cesium.js";
-import { CylinderGeometry } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { DistanceDisplayConditionGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { Geometry } from "../../Source/Cesium.js";
-import { GeometryAttribute } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
-import { GeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { HeadingPitchRange } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  BoxGeometry,
+  Cartesian3,
+  ColorGeometryInstanceAttribute,
+  ComponentDatatype,
+  CylinderGeometry,
+  defined,
+  DistanceDisplayConditionGeometryInstanceAttribute,
+  Ellipsoid,
+  Geometry,
+  GeometryAttribute,
+  GeometryInstance,
+  GeometryInstanceAttribute,
+  HeadingPitchRange,
+  Matrix4,
+  PerspectiveFrustum,
+  PolygonGeometry,
+  PrimitiveType,
+  Rectangle,
+  RectangleGeometry,
+  ShowGeometryInstanceAttribute,
+  Transforms,
+  Camera,
+  MaterialAppearance,
+  PerInstanceColorAppearance,
+  Primitive,
+  SceneMode,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { PerspectiveFrustum } from "../../Source/Cesium.js";
-import { PolygonGeometry } from "../../Source/Cesium.js";
-import { PrimitiveType } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { RectangleGeometry } from "../../Source/Cesium.js";
-import { ShowGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
-import { Camera } from "../../Source/Cesium.js";
-import { MaterialAppearance } from "../../Source/Cesium.js";
-import { PerInstanceColorAppearance } from "../../Source/Cesium.js";
-import { Primitive } from "../../Source/Cesium.js";
-import { SceneMode } from "../../Source/Cesium.js";
+
 import BadGeometry from "../BadGeometry.js";
 import createContext from "../createContext.js";
 import createFrameState from "../createFrameState.js";

--- a/Specs/Scene/QuadtreePrimitiveSpec.js
+++ b/Specs/Scene/QuadtreePrimitiveSpec.js
@@ -1,22 +1,25 @@
+import {
+  Cartesian3,
+  Cartographic,
+  defined,
+  Ellipsoid,
+  EventHelper,
+  GeographicProjection,
+  GeographicTilingScheme,
+  Intersect,
+  Rectangle,
+  Visibility,
+  Camera,
+  GlobeSurfaceTileProvider,
+  GlobeTranslucencyState,
+  ImageryLayerCollection,
+  QuadtreePrimitive,
+  QuadtreeTileLoadState,
+  SceneMode,
+} from "../../../Source/Cesium.js";
 import MockTerrainProvider from "../MockTerrainProvider.js";
 import TerrainTileProcessor from "../TerrainTileProcessor.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { EventHelper } from "../../Source/Cesium.js";
-import { GeographicProjection } from "../../Source/Cesium.js";
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
-import { Intersect } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { Visibility } from "../../Source/Cesium.js";
-import { Camera } from "../../Source/Cesium.js";
-import { GlobeSurfaceTileProvider } from "../../Source/Cesium.js";
-import { GlobeTranslucencyState } from "../../Source/Cesium.js";
-import { ImageryLayerCollection } from "../../Source/Cesium.js";
-import { QuadtreePrimitive } from "../../Source/Cesium.js";
-import { QuadtreeTileLoadState } from "../../Source/Cesium.js";
-import { SceneMode } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/Scene/QuadtreeTileSpec.js
+++ b/Specs/Scene/QuadtreeTileSpec.js
@@ -1,8 +1,11 @@
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
+import {
+  GeographicTilingScheme,
+  Rectangle,
+  WebMercatorTilingScheme,
+  QuadtreeTile,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { WebMercatorTilingScheme } from "../../Source/Cesium.js";
-import { QuadtreeTile } from "../../Source/Cesium.js";
 
 describe("Scene/QuadtreeTile", function () {
   it("throws without a options", function () {

--- a/Specs/Scene/SceneSpec.js
+++ b/Specs/Scene/SceneSpec.js
@@ -1,50 +1,54 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { CesiumTerrainProvider } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeographicProjection } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
-import { HeadingPitchRoll } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Cartesian2,
+  Cartesian3,
+  CesiumTerrainProvider,
+  Color,
+  defined,
+  Ellipsoid,
+  GeographicProjection,
+  GeometryInstance,
+  HeadingPitchRoll,
+  JulianDate,
+  PerspectiveFrustum,
+  PixelFormat,
+  Rectangle,
+  RectangleGeometry,
+  RequestScheduler,
+  RuntimeError,
+  TaskProcessor,
+  WebGLConstants,
+  WebMercatorProjection,
+  DrawCommand,
+  Framebuffer,
+  Pass,
+  PixelDatatype,
+  RenderState,
+  ShaderProgram,
+  ShaderSource,
+  Texture,
+  Camera,
+  DirectionalLight,
+  EllipsoidSurfaceAppearance,
+  FrameState,
+  Globe,
+  Material,
+  Primitive,
+  PrimitiveCollection,
+  Scene,
+  SceneTransforms,
+  ScreenSpaceCameraController,
+  SunLight,
+  TweenCollection,
+  Sun,
+  GroundPrimitive,
+  PerInstanceColorAppearance,
+  ColorGeometryInstanceAttribute,
+  Resource,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { PerspectiveFrustum } from "../../Source/Cesium.js";
-import { PixelFormat } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { RectangleGeometry } from "../../Source/Cesium.js";
-import { RequestScheduler } from "../../Source/Cesium.js";
-import { RuntimeError } from "../../Source/Cesium.js";
-import { TaskProcessor } from "../../Source/Cesium.js";
-import { WebGLConstants } from "../../Source/Cesium.js";
-import { WebMercatorProjection } from "../../Source/Cesium.js";
-import { DrawCommand } from "../../Source/Cesium.js";
-import { Framebuffer } from "../../Source/Cesium.js";
-import { Pass } from "../../Source/Cesium.js";
-import { PixelDatatype } from "../../Source/Cesium.js";
-import { RenderState } from "../../Source/Cesium.js";
-import { ShaderProgram } from "../../Source/Cesium.js";
-import { ShaderSource } from "../../Source/Cesium.js";
-import { Texture } from "../../Source/Cesium.js";
-import { Camera } from "../../Source/Cesium.js";
-import { DirectionalLight } from "../../Source/Cesium.js";
-import { EllipsoidSurfaceAppearance } from "../../Source/Cesium.js";
-import { FrameState } from "../../Source/Cesium.js";
-import { Globe } from "../../Source/Cesium.js";
-import { Material } from "../../Source/Cesium.js";
-import { Primitive } from "../../Source/Cesium.js";
-import { PrimitiveCollection } from "../../Source/Cesium.js";
-import { Scene } from "../../Source/Cesium.js";
-import { SceneTransforms } from "../../Source/Cesium.js";
-import { ScreenSpaceCameraController } from "../../Source/Cesium.js";
-import { SunLight } from "../../Source/Cesium.js";
-import { TweenCollection } from "../../Source/Cesium.js";
-import { Sun } from "../../Source/Cesium.js";
-import { GroundPrimitive } from "../../Source/Cesium.js";
-import { PerInstanceColorAppearance } from "../../Source/Cesium.js";
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
+
 import createCanvas from "../createCanvas.js";
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";

--- a/Specs/Scene/SceneTransformsSpec.js
+++ b/Specs/Scene/SceneTransformsSpec.js
@@ -1,12 +1,16 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Ellipsoid,
+  OrthographicFrustum,
+  Rectangle,
+  Camera,
+  SceneMode,
+  SceneTransforms,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { OrthographicFrustum } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { Camera } from "../../Source/Cesium.js";
-import { SceneMode } from "../../Source/Cesium.js";
-import { SceneTransforms } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Scene/ScreenSpaceCameraControllerSpec.js
+++ b/Specs/Scene/ScreenSpaceCameraControllerSpec.js
@@ -1,21 +1,25 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { combine } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { FeatureDetection } from "../../Source/Cesium.js";
-import { GeographicProjection } from "../../Source/Cesium.js";
-import { IntersectionTests } from "../../Source/Cesium.js";
-import { KeyboardEventModifier } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  combine,
+  Ellipsoid,
+  FeatureDetection,
+  GeographicProjection,
+  IntersectionTests,
+  KeyboardEventModifier,
+  OrthographicFrustum,
+  OrthographicOffCenterFrustum,
+  Ray,
+  Transforms,
+  Camera,
+  CameraEventType,
+  MapMode2D,
+  SceneMode,
+  ScreenSpaceCameraController,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { OrthographicFrustum } from "../../Source/Cesium.js";
-import { OrthographicOffCenterFrustum } from "../../Source/Cesium.js";
-import { Ray } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
-import { Camera } from "../../Source/Cesium.js";
-import { CameraEventType } from "../../Source/Cesium.js";
-import { MapMode2D } from "../../Source/Cesium.js";
-import { SceneMode } from "../../Source/Cesium.js";
-import { ScreenSpaceCameraController } from "../../Source/Cesium.js";
+
 import createCamera from "../createCamera.js";
 import createCanvas from "../createCanvas.js";
 import DomEventSimulator from "../DomEventSimulator.js";

--- a/Specs/Scene/ShadowMapSpec.js
+++ b/Specs/Scene/ShadowMapSpec.js
@@ -1,34 +1,38 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { BoxGeometry } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { ComponentDatatype } from "../../Source/Cesium.js";
-import { EllipsoidTerrainProvider } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
-import { HeadingPitchRange } from "../../Source/Cesium.js";
-import { HeadingPitchRoll } from "../../Source/Cesium.js";
-import { HeightmapTerrainData } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  BoxGeometry,
+  Cartesian3,
+  Color,
+  ColorGeometryInstanceAttribute,
+  ComponentDatatype,
+  EllipsoidTerrainProvider,
+  GeometryInstance,
+  HeadingPitchRange,
+  HeadingPitchRoll,
+  HeightmapTerrainData,
+  JulianDate,
+  Matrix4,
+  OrthographicOffCenterFrustum,
+  PixelFormat,
+  Transforms,
+  WebGLConstants,
+  Context,
+  Framebuffer,
+  PixelDatatype,
+  Texture,
+  Camera,
+  DirectionalLight,
+  Globe,
+  Model,
+  ModelExperimental,
+  PerInstanceColorAppearance,
+  Primitive,
+  ShadowMap,
+  ShadowMode,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { OrthographicOffCenterFrustum } from "../../Source/Cesium.js";
-import { PixelFormat } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
-import { WebGLConstants } from "../../Source/Cesium.js";
-import { Context } from "../../Source/Cesium.js";
-import { Framebuffer } from "../../Source/Cesium.js";
-import { PixelDatatype } from "../../Source/Cesium.js";
-import { Texture } from "../../Source/Cesium.js";
-import { Camera } from "../../Source/Cesium.js";
-import { DirectionalLight } from "../../Source/Cesium.js";
-import { Globe } from "../../Source/Cesium.js";
-import { Model } from "../../Source/Cesium.js";
-import { ModelExperimental } from "../../Source/Cesium.js";
-import { PerInstanceColorAppearance } from "../../Source/Cesium.js";
-import { Primitive } from "../../Source/Cesium.js";
-import { ShadowMap } from "../../Source/Cesium.js";
-import { ShadowMode } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/Scene/ShadowVolumeAppearanceSpec.js
+++ b/Specs/Scene/ShadowVolumeAppearanceSpec.js
@@ -1,17 +1,20 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { ComponentDatatype } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { EncodedCartesian3 } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Cartographic,
+  ComponentDatatype,
+  Ellipsoid,
+  EncodedCartesian3,
+  Matrix4,
+  Rectangle,
+  Transforms,
+  WebMercatorProjection,
+  Material,
+  MaterialAppearance,
+  PerInstanceColorAppearance,
+  ShadowVolumeAppearance,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
-import { WebMercatorProjection } from "../../Source/Cesium.js";
-import { Material } from "../../Source/Cesium.js";
-import { MaterialAppearance } from "../../Source/Cesium.js";
-import { PerInstanceColorAppearance } from "../../Source/Cesium.js";
-import { ShadowVolumeAppearance } from "../../Source/Cesium.js";
 
 describe("Scene/ShadowVolumeAppearance", function () {
   // using ShadowVolumeAppearanceVS directly fails on Travis with the --release test

--- a/Specs/Scene/SingleTileImageryProviderSpec.js
+++ b/Specs/Scene/SingleTileImageryProviderSpec.js
@@ -1,13 +1,16 @@
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { Request } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { Imagery } from "../../Source/Cesium.js";
-import { ImageryLayer } from "../../Source/Cesium.js";
-import { ImageryProvider } from "../../Source/Cesium.js";
-import { ImageryState } from "../../Source/Cesium.js";
-import { SingleTileImageryProvider } from "../../Source/Cesium.js";
+import {
+  Ellipsoid,
+  GeographicTilingScheme,
+  Rectangle,
+  Request,
+  Resource,
+  Imagery,
+  ImageryLayer,
+  ImageryProvider,
+  ImageryState,
+  SingleTileImageryProvider,
+} from "../../../Source/Cesium.js";
+
 import pollToPromise from "../pollToPromise.js";
 
 describe("Scene/SingleTileImageryProvider", function () {

--- a/Specs/Scene/SkyAtmosphereSpec.js
+++ b/Specs/Scene/SkyAtmosphereSpec.js
@@ -1,8 +1,12 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Ellipsoid,
+  SceneMode,
+  SkyAtmosphere,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { SceneMode } from "../../Source/Cesium.js";
-import { SkyAtmosphere } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Scene/SkyBoxSpec.js
+++ b/Specs/Scene/SkyBoxSpec.js
@@ -1,6 +1,5 @@
-import { Resource } from "../../Source/Cesium.js";
-import { SceneMode } from "../../Source/Cesium.js";
-import { SkyBox } from "../../Source/Cesium.js";
+import { Resource, SceneMode, SkyBox } from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Scene/SphereEmitterSpec.js
+++ b/Specs/Scene/SphereEmitterSpec.js
@@ -1,6 +1,4 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Particle } from "../../Source/Cesium.js";
-import { SphereEmitter } from "../../Source/Cesium.js";
+import { Cartesian3, Particle, SphereEmitter } from "../../../Source/Cesium.js";
 
 describe("Scene/SphereEmitter", function () {
   let emitter;

--- a/Specs/Scene/SunSpec.js
+++ b/Specs/Scene/SunSpec.js
@@ -1,8 +1,12 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Color,
+  SceneMode,
+  Sun,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { SceneMode } from "../../Source/Cesium.js";
-import { Sun } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Scene/TerrainFillMeshSpec.js
+++ b/Specs/Scene/TerrainFillMeshSpec.js
@@ -1,19 +1,22 @@
+import {
+  Cartesian2,
+  Cartesian3,
+  GeographicProjection,
+  HeightmapTerrainData,
+  Intersect,
+  Camera,
+  GlobeSurfaceTileProvider,
+  ImageryLayerCollection,
+  QuadtreePrimitive,
+  SceneMode,
+  TerrainFillMesh,
+  TileBoundingRegion,
+  TileSelectionResult,
+} from "../../../Source/Cesium.js";
 import MockTerrainProvider from "../MockTerrainProvider.js";
 import TerrainTileProcessor from "../TerrainTileProcessor.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { GeographicProjection } from "../../Source/Cesium.js";
-import { HeightmapTerrainData } from "../../Source/Cesium.js";
-import { Intersect } from "../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Camera } from "../../Source/Cesium.js";
-import { GlobeSurfaceTileProvider } from "../../Source/Cesium.js";
-import { ImageryLayerCollection } from "../../Source/Cesium.js";
-import { QuadtreePrimitive } from "../../Source/Cesium.js";
-import { SceneMode } from "../../Source/Cesium.js";
-import { TerrainFillMesh } from "../../Source/Cesium.js";
-import { TileBoundingRegion } from "../../Source/Cesium.js";
-import { TileSelectionResult } from "../../Source/Cesium.js";
 
 describe("Scene/TerrainFillMesh", function () {
   let processor;

--- a/Specs/Scene/TextureAtlasSpec.js
+++ b/Specs/Scene/TextureAtlasSpec.js
@@ -1,10 +1,14 @@
-import { BoundingRectangle } from "../../Source/Cesium.js";
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { createGuid } from "../../Source/Cesium.js";
+import {
+  BoundingRectangle,
+  Cartesian2,
+  createGuid,
+  PixelFormat,
+  Resource,
+  TextureAtlas,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { PixelFormat } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { TextureAtlas } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Scene/TileBoundingRegionSpec.js
+++ b/Specs/Scene/TileBoundingRegionSpec.js
@@ -1,15 +1,19 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
-import { Intersect } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Cartographic,
+  Color,
+  Ellipsoid,
+  GeographicTilingScheme,
+  Intersect,
+  Plane,
+  Rectangle,
+  SceneMode,
+  TileBoundingRegion,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Plane } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { SceneMode } from "../../Source/Cesium.js";
-import { TileBoundingRegion } from "../../Source/Cesium.js";
+
 import createFrameState from "../createFrameState.js";
 
 describe("Scene/TileBoundingRegion", function () {

--- a/Specs/Scene/TileBoundingS2CellSpec.js
+++ b/Specs/Scene/TileBoundingS2CellSpec.js
@@ -1,11 +1,15 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { Intersect } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Color,
+  Ellipsoid,
+  Intersect,
+  Plane,
+  S2Cell,
+  TileBoundingS2Cell,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Plane } from "../../Source/Cesium.js";
-import { S2Cell } from "../../Source/Cesium.js";
-import { TileBoundingS2Cell } from "../../Source/Cesium.js";
+
 import createFrameState from "../createFrameState.js";
 
 describe("Scene/TileBoundingS2Cell", function () {

--- a/Specs/Scene/TileBoundingSphereSpec.js
+++ b/Specs/Scene/TileBoundingSphereSpec.js
@@ -1,9 +1,13 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { Intersect } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Color,
+  Intersect,
+  Plane,
+  TileBoundingSphere,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Plane } from "../../Source/Cesium.js";
-import { TileBoundingSphere } from "../../Source/Cesium.js";
+
 import createFrameState from "../createFrameState.js";
 
 describe("Scene/TileBoundingSphere", function () {

--- a/Specs/Scene/TileCoordinatesImageryProviderSpec.js
+++ b/Specs/Scene/TileCoordinatesImageryProviderSpec.js
@@ -1,8 +1,11 @@
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
-import { WebMercatorTilingScheme } from "../../Source/Cesium.js";
-import { ImageryProvider } from "../../Source/Cesium.js";
-import { TileCoordinatesImageryProvider } from "../../Source/Cesium.js";
+import {
+  Ellipsoid,
+  GeographicTilingScheme,
+  WebMercatorTilingScheme,
+  ImageryProvider,
+  TileCoordinatesImageryProvider,
+} from "../../../Source/Cesium.js";
+
 import pollToPromise from "../pollToPromise.js";
 
 describe("Scene/TileCoordinatesImageryProvider", function () {

--- a/Specs/Scene/TileImagerySpec.js
+++ b/Specs/Scene/TileImagerySpec.js
@@ -1,5 +1,4 @@
-import { ImageryState } from "../../Source/Cesium.js";
-import { TileImagery } from "../../Source/Cesium.js";
+import { ImageryState, TileImagery } from "../../../Source/Cesium.js";
 
 describe("Scene/TileImagery", function () {
   it("does not use ancestor ready imagery that needs to be reprojected", function () {

--- a/Specs/Scene/TileMapServiceImageryProviderSpec.js
+++ b/Specs/Scene/TileMapServiceImageryProviderSpec.js
@@ -1,22 +1,26 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { defer } from "../../Source/Cesium.js";
-import { GeographicProjection } from "../../Source/Cesium.js";
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
-import { getAbsoluteUri } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartographic,
+  defer,
+  GeographicProjection,
+  GeographicTilingScheme,
+  getAbsoluteUri,
+  Rectangle,
+  Request,
+  RequestErrorEvent,
+  RequestScheduler,
+  Resource,
+  WebMercatorProjection,
+  WebMercatorTilingScheme,
+  TileMapServiceImageryProvider,
+  Imagery,
+  ImageryLayer,
+  ImageryState,
+  UrlTemplateImageryProvider,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { Request } from "../../Source/Cesium.js";
-import { RequestErrorEvent } from "../../Source/Cesium.js";
-import { RequestScheduler } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { WebMercatorProjection } from "../../Source/Cesium.js";
-import { WebMercatorTilingScheme } from "../../Source/Cesium.js";
-import { TileMapServiceImageryProvider } from "../../Source/Cesium.js";
-import { Imagery } from "../../Source/Cesium.js";
-import { ImageryLayer } from "../../Source/Cesium.js";
-import { ImageryState } from "../../Source/Cesium.js";
-import { UrlTemplateImageryProvider } from "../../Source/Cesium.js";
+
 import pollToPromise from "../pollToPromise.js";
 
 describe("Scene/TileMapServiceImageryProvider", function () {

--- a/Specs/Scene/TileOrientedBoundingBoxSpec.js
+++ b/Specs/Scene/TileOrientedBoundingBoxSpec.js
@@ -1,10 +1,14 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { Intersect } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  Color,
+  Intersect,
+  Matrix3,
+  Plane,
+  TileOrientedBoundingBox,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Matrix3 } from "../../Source/Cesium.js";
-import { Plane } from "../../Source/Cesium.js";
-import { TileOrientedBoundingBox } from "../../Source/Cesium.js";
+
 import createFrameState from "../createFrameState.js";
 
 describe("Scene/TileOrientedBoundingBox", function () {

--- a/Specs/Scene/TileReplacementQueueSpec.js
+++ b/Specs/Scene/TileReplacementQueueSpec.js
@@ -1,8 +1,10 @@
-import { defined } from "../../Source/Cesium.js";
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
-import { QuadtreeTile } from "../../Source/Cesium.js";
-import { QuadtreeTileLoadState } from "../../Source/Cesium.js";
-import { TileReplacementQueue } from "../../Source/Cesium.js";
+import {
+  defined,
+  GeographicTilingScheme,
+  QuadtreeTile,
+  QuadtreeTileLoadState,
+  TileReplacementQueue,
+} from "../../../Source/Cesium.js";
 
 describe("Scene/TileReplacementQueue", function () {
   function Tile(num, loadedState, upsampledState) {

--- a/Specs/Scene/TimeDynamicImagerySpec.js
+++ b/Specs/Scene/TimeDynamicImagerySpec.js
@@ -1,11 +1,13 @@
-import { Clock } from "../../Source/Cesium.js";
-import { ClockStep } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { Request } from "../../Source/Cesium.js";
-import { RequestScheduler } from "../../Source/Cesium.js";
-import { RequestType } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { TimeDynamicImagery } from "../../Source/Cesium.js";
+import {
+  Clock,
+  ClockStep,
+  JulianDate,
+  Request,
+  RequestScheduler,
+  RequestType,
+  TimeIntervalCollection,
+  TimeDynamicImagery,
+} from "../../../Source/Cesium.js";
 
 describe("Scene/TimeDynamicImagery", function () {
   const clock = new Clock({

--- a/Specs/Scene/TimeDynamicPointCloudSpec.js
+++ b/Specs/Scene/TimeDynamicPointCloudSpec.js
@@ -1,23 +1,26 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Clock } from "../../Source/Cesium.js";
-import { ClockStep } from "../../Source/Cesium.js";
-import { defaultValue } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { HeadingPitchRange } from "../../Source/Cesium.js";
-import { HeadingPitchRoll } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
-import { Cesium3DTileStyle } from "../../Source/Cesium.js";
-import { ClippingPlane } from "../../Source/Cesium.js";
-import { ClippingPlaneCollection } from "../../Source/Cesium.js";
-import { DracoLoader } from "../../Source/Cesium.js";
-import { PointCloudEyeDomeLighting } from "../../Source/Cesium.js";
-import { ShadowMode } from "../../Source/Cesium.js";
-import { TimeDynamicPointCloud } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Cartesian3,
+  Clock,
+  ClockStep,
+  defaultValue,
+  defined,
+  HeadingPitchRange,
+  HeadingPitchRoll,
+  JulianDate,
+  Matrix4,
+  Resource,
+  TimeIntervalCollection,
+  Transforms,
+  Cesium3DTileStyle,
+  ClippingPlane,
+  ClippingPlaneCollection,
+  DracoLoader,
+  PointCloudEyeDomeLighting,
+  ShadowMode,
+  TimeDynamicPointCloud,
+} from "../../../Source/Cesium.js";
+
 import createCanvas from "../createCanvas.js";
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";

--- a/Specs/Scene/TranslucentTileClassificationSpec.js
+++ b/Specs/Scene/TranslucentTileClassificationSpec.js
@@ -1,27 +1,30 @@
-import { TranslucentTileClassification } from "../../Source/Cesium.js";
-import { ApproximateTerrainHeights } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { destroyObject } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
-import { GroundPolylineGeometry } from "../../Source/Cesium.js";
-import { PixelFormat } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { RectangleGeometry } from "../../Source/Cesium.js";
-import { ClearCommand } from "../../Source/Cesium.js";
-import { Framebuffer } from "../../Source/Cesium.js";
-import { Pass } from "../../Source/Cesium.js";
-import { PixelDatatype } from "../../Source/Cesium.js";
-import { RenderState } from "../../Source/Cesium.js";
-import { Texture } from "../../Source/Cesium.js";
-import { ClassificationType } from "../../Source/Cesium.js";
-import { GroundPolylinePrimitive } from "../../Source/Cesium.js";
-import { PerInstanceColorAppearance } from "../../Source/Cesium.js";
-import { Primitive } from "../../Source/Cesium.js";
-import { StencilConstants } from "../../Source/Cesium.js";
+import {
+  TranslucentTileClassification,
+  ApproximateTerrainHeights,
+  Cartesian3,
+  Color,
+  ColorGeometryInstanceAttribute,
+  defined,
+  destroyObject,
+  Ellipsoid,
+  GeometryInstance,
+  GroundPolylineGeometry,
+  PixelFormat,
+  Rectangle,
+  RectangleGeometry,
+  ClearCommand,
+  Framebuffer,
+  Pass,
+  PixelDatatype,
+  RenderState,
+  Texture,
+  ClassificationType,
+  GroundPolylinePrimitive,
+  PerInstanceColorAppearance,
+  Primitive,
+  StencilConstants,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Scene/TweenCollectionSpec.js
+++ b/Specs/Scene/TweenCollectionSpec.js
@@ -1,6 +1,8 @@
-import { Color } from "../../Source/Cesium.js";
-import { EasingFunction } from "../../Source/Cesium.js";
-import { TweenCollection } from "../../Source/Cesium.js";
+import {
+  Color,
+  EasingFunction,
+  TweenCollection,
+} from "../../../Source/Cesium.js";
 
 describe(
   "Scene/TweenCollection",

--- a/Specs/Scene/UrlTemplateImageryProviderSpec.js
+++ b/Specs/Scene/UrlTemplateImageryProviderSpec.js
@@ -1,18 +1,22 @@
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
+import {
+  Ellipsoid,
+  GeographicTilingScheme,
+  Rectangle,
+  Request,
+  RequestScheduler,
+  Resource,
+  WebMercatorProjection,
+  WebMercatorTilingScheme,
+  GetFeatureInfoFormat,
+  Imagery,
+  ImageryLayer,
+  ImageryProvider,
+  ImageryState,
+  UrlTemplateImageryProvider,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { Request } from "../../Source/Cesium.js";
-import { RequestScheduler } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { WebMercatorProjection } from "../../Source/Cesium.js";
-import { WebMercatorTilingScheme } from "../../Source/Cesium.js";
-import { GetFeatureInfoFormat } from "../../Source/Cesium.js";
-import { Imagery } from "../../Source/Cesium.js";
-import { ImageryLayer } from "../../Source/Cesium.js";
-import { ImageryProvider } from "../../Source/Cesium.js";
-import { ImageryState } from "../../Source/Cesium.js";
-import { UrlTemplateImageryProvider } from "../../Source/Cesium.js";
+
 import pollToPromise from "../pollToPromise.js";
 
 describe("Scene/UrlTemplateImageryProvider", function () {

--- a/Specs/Scene/Vector3DTileClampedPolylinesSpec.js
+++ b/Specs/Scene/Vector3DTileClampedPolylinesSpec.js
@@ -1,16 +1,19 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { ClassificationType } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { destroyObject } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { RectangleGeometry } from "../../Source/Cesium.js";
-import { Pass } from "../../Source/Cesium.js";
-import { PerInstanceColorAppearance } from "../../Source/Cesium.js";
-import { Primitive } from "../../Source/Cesium.js";
-import { Vector3DTileClampedPolylines } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  ClassificationType,
+  Color,
+  ColorGeometryInstanceAttribute,
+  destroyObject,
+  Ellipsoid,
+  GeometryInstance,
+  Rectangle,
+  RectangleGeometry,
+  Pass,
+  PerInstanceColorAppearance,
+  Primitive,
+  Vector3DTileClampedPolylines,
+} from "../../../Source/Cesium.js";
+
 import Cesium3DTilesTester from "../Cesium3DTilesTester.js";
 import createScene from "../createScene.js";
 

--- a/Specs/Scene/Vector3DTileGeometrySpec.js
+++ b/Specs/Scene/Vector3DTileGeometrySpec.js
@@ -1,24 +1,27 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { combine } from "../../Source/Cesium.js";
-import { destroyObject } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { RectangleGeometry } from "../../Source/Cesium.js";
-import { Transforms } from "../../Source/Cesium.js";
-import { Pass } from "../../Source/Cesium.js";
-import { RenderState } from "../../Source/Cesium.js";
-import { Cesium3DTileBatchTable } from "../../Source/Cesium.js";
-import { ClassificationType } from "../../Source/Cesium.js";
-import { ColorBlendMode } from "../../Source/Cesium.js";
-import { PerInstanceColorAppearance } from "../../Source/Cesium.js";
-import { Primitive } from "../../Source/Cesium.js";
-import { StencilConstants } from "../../Source/Cesium.js";
-import { Vector3DTileGeometry } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Cartesian3,
+  Color,
+  ColorGeometryInstanceAttribute,
+  combine,
+  destroyObject,
+  Ellipsoid,
+  GeometryInstance,
+  Matrix4,
+  Rectangle,
+  RectangleGeometry,
+  Transforms,
+  Pass,
+  RenderState,
+  Cesium3DTileBatchTable,
+  ClassificationType,
+  ColorBlendMode,
+  PerInstanceColorAppearance,
+  Primitive,
+  StencilConstants,
+  Vector3DTileGeometry,
+} from "../../../Source/Cesium.js";
+
 import createContext from "../createContext.js";
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";

--- a/Specs/Scene/Vector3DTilePointsSpec.js
+++ b/Specs/Scene/Vector3DTilePointsSpec.js
@@ -1,21 +1,25 @@
-import { Cartesian2 } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { clone } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { defined } from "../../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  Cartographic,
+  clone,
+  Color,
+  defined,
+  DistanceDisplayCondition,
+  Ellipsoid,
+  NearFarScalar,
+  Rectangle,
+  Cesium3DTileBatchTable,
+  Cesium3DTileStyle,
+  ColorBlendMode,
+  HorizontalOrigin,
+  LabelStyle,
+  Vector3DTilePoints,
+  VerticalOrigin,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { NearFarScalar } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { Cesium3DTileBatchTable } from "../../Source/Cesium.js";
-import { Cesium3DTileStyle } from "../../Source/Cesium.js";
-import { ColorBlendMode } from "../../Source/Cesium.js";
-import { HorizontalOrigin } from "../../Source/Cesium.js";
-import { LabelStyle } from "../../Source/Cesium.js";
-import { Vector3DTilePoints } from "../../Source/Cesium.js";
-import { VerticalOrigin } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/Scene/Vector3DTilePolygonsSpec.js
+++ b/Specs/Scene/Vector3DTilePolygonsSpec.js
@@ -1,22 +1,26 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { ColorGeometryInstanceAttribute } from "../../Source/Cesium.js";
-import { combine } from "../../Source/Cesium.js";
-import { destroyObject } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeometryInstance } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Color,
+  ColorGeometryInstanceAttribute,
+  combine,
+  destroyObject,
+  Ellipsoid,
+  GeometryInstance,
+  Rectangle,
+  RectangleGeometry,
+  Pass,
+  RenderState,
+  Cesium3DTileBatchTable,
+  ClassificationType,
+  ColorBlendMode,
+  PerInstanceColorAppearance,
+  Primitive,
+  StencilConstants,
+  Vector3DTilePolygons,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { RectangleGeometry } from "../../Source/Cesium.js";
-import { Pass } from "../../Source/Cesium.js";
-import { RenderState } from "../../Source/Cesium.js";
-import { Cesium3DTileBatchTable } from "../../Source/Cesium.js";
-import { ClassificationType } from "../../Source/Cesium.js";
-import { ColorBlendMode } from "../../Source/Cesium.js";
-import { PerInstanceColorAppearance } from "../../Source/Cesium.js";
-import { Primitive } from "../../Source/Cesium.js";
-import { StencilConstants } from "../../Source/Cesium.js";
-import { Vector3DTilePolygons } from "../../Source/Cesium.js";
+
 import createContext from "../createContext.js";
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";

--- a/Specs/Scene/Vector3DTilePolylinesSpec.js
+++ b/Specs/Scene/Vector3DTilePolylinesSpec.js
@@ -1,12 +1,16 @@
-import { BoundingSphere } from "../../Source/Cesium.js";
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { Cartographic } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Cartesian3,
+  Cartographic,
+  Ellipsoid,
+  Rectangle,
+  Cesium3DTileBatchTable,
+  ColorBlendMode,
+  Vector3DTilePolylines,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { Cesium3DTileBatchTable } from "../../Source/Cesium.js";
-import { ColorBlendMode } from "../../Source/Cesium.js";
-import { Vector3DTilePolylines } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import pollToPromise from "../pollToPromise.js";
 

--- a/Specs/Scene/ViewportQuadSpec.js
+++ b/Specs/Scene/ViewportQuadSpec.js
@@ -1,9 +1,12 @@
-import { BoundingRectangle } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { Texture } from "../../Source/Cesium.js";
-import { Material } from "../../Source/Cesium.js";
-import { ViewportQuad } from "../../Source/Cesium.js";
+import {
+  BoundingRectangle,
+  Color,
+  Resource,
+  Texture,
+  Material,
+  ViewportQuad,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe(

--- a/Specs/Scene/WebMapServiceImageryProviderSpec.js
+++ b/Specs/Scene/WebMapServiceImageryProviderSpec.js
@@ -1,27 +1,31 @@
-import { Cartographic } from "../../Source/Cesium.js";
-import { Clock } from "../../Source/Cesium.js";
-import { ClockStep } from "../../Source/Cesium.js";
-import { Ellipsoid } from "../../Source/Cesium.js";
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
+import {
+  Cartographic,
+  Clock,
+  ClockStep,
+  Ellipsoid,
+  GeographicTilingScheme,
+  JulianDate,
+  queryToObject,
+  Rectangle,
+  Request,
+  RequestScheduler,
+  RequestState,
+  Resource,
+  TimeIntervalCollection,
+  WebMercatorTilingScheme,
+  GetFeatureInfoFormat,
+  Imagery,
+  ImageryLayer,
+  ImageryLayerFeatureInfo,
+  ImageryProvider,
+  ImageryState,
+  WebMapServiceImageryProvider,
+  Uri,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { queryToObject } from "../../Source/Cesium.js";
-import { Rectangle } from "../../Source/Cesium.js";
-import { Request } from "../../Source/Cesium.js";
-import { RequestScheduler } from "../../Source/Cesium.js";
-import { RequestState } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { WebMercatorTilingScheme } from "../../Source/Cesium.js";
-import { GetFeatureInfoFormat } from "../../Source/Cesium.js";
-import { Imagery } from "../../Source/Cesium.js";
-import { ImageryLayer } from "../../Source/Cesium.js";
-import { ImageryLayerFeatureInfo } from "../../Source/Cesium.js";
-import { ImageryProvider } from "../../Source/Cesium.js";
-import { ImageryState } from "../../Source/Cesium.js";
-import { WebMapServiceImageryProvider } from "../../Source/Cesium.js";
+
 import pollToPromise from "../pollToPromise.js";
-import { Uri } from "../../Source/Cesium.js";
 
 describe("Scene/WebMapServiceImageryProvider", function () {
   beforeEach(function () {

--- a/Specs/Scene/WebMapTileServiceImageryProviderSpec.js
+++ b/Specs/Scene/WebMapTileServiceImageryProviderSpec.js
@@ -1,23 +1,26 @@
-import { Clock } from "../../Source/Cesium.js";
-import { ClockStep } from "../../Source/Cesium.js";
-import { Credit } from "../../Source/Cesium.js";
-import { GeographicTilingScheme } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { objectToQuery } from "../../Source/Cesium.js";
-import { queryToObject } from "../../Source/Cesium.js";
-import { Request } from "../../Source/Cesium.js";
-import { RequestScheduler } from "../../Source/Cesium.js";
-import { RequestState } from "../../Source/Cesium.js";
-import { Resource } from "../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../Source/Cesium.js";
-import { WebMercatorTilingScheme } from "../../Source/Cesium.js";
-import { Imagery } from "../../Source/Cesium.js";
-import { ImageryLayer } from "../../Source/Cesium.js";
-import { ImageryProvider } from "../../Source/Cesium.js";
-import { ImageryState } from "../../Source/Cesium.js";
-import { WebMapTileServiceImageryProvider } from "../../Source/Cesium.js";
+import {
+  Clock,
+  ClockStep,
+  Credit,
+  GeographicTilingScheme,
+  JulianDate,
+  objectToQuery,
+  queryToObject,
+  Request,
+  RequestScheduler,
+  RequestState,
+  Resource,
+  TimeIntervalCollection,
+  WebMercatorTilingScheme,
+  Imagery,
+  ImageryLayer,
+  ImageryProvider,
+  ImageryState,
+  WebMapTileServiceImageryProvider,
+  Uri,
+} from "../../../Source/Cesium.js";
+
 import pollToPromise from "../pollToPromise.js";
-import { Uri } from "../../Source/Cesium.js";
 
 describe("Scene/WebMapTileServiceImageryProvider", function () {
   beforeEach(function () {

--- a/Specs/Scene/computeFlyToLocationForRectangleSpec.js
+++ b/Specs/Scene/computeFlyToLocationForRectangleSpec.js
@@ -1,7 +1,10 @@
-import { Rectangle } from "../../Source/Cesium.js";
-import { computeFlyToLocationForRectangle } from "../../Source/Cesium.js";
-import { Globe } from "../../Source/Cesium.js";
-import { SceneMode } from "../../Source/Cesium.js";
+import {
+  Rectangle,
+  computeFlyToLocationForRectangle,
+  Globe,
+  SceneMode,
+} from "../../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 import MockTerrainProvider from "../MockTerrainProvider.js";
 

--- a/Specs/Scene/createElevationBandMaterialSpec.js
+++ b/Specs/Scene/createElevationBandMaterialSpec.js
@@ -1,10 +1,14 @@
-import { Cartesian4 } from "../../Source/Cesium.js";
-import { Color } from "../../Source/Cesium.js";
-import { createElevationBandMaterial } from "../../Source/Cesium.js";
+import {
+  Cartesian4,
+  Color,
+  createElevationBandMaterial,
+  PixelFormat,
+  Texture,
+  TextureMinificationFilter,
+} from "../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../Source/Cesium.js";
-import { PixelFormat } from "../../Source/Cesium.js";
-import { Texture } from "../../Source/Cesium.js";
-import { TextureMinificationFilter } from "../../Source/Cesium.js";
+
 import createScene from "../createScene.js";
 
 describe("Scene/createElevationBandMaterial", function () {

--- a/Specs/Scene/createTangentSpaceDebugPrimitiveSpec.js
+++ b/Specs/Scene/createTangentSpaceDebugPrimitiveSpec.js
@@ -1,9 +1,11 @@
-import { Cartesian3 } from "../../Source/Cesium.js";
-import { EllipsoidGeometry } from "../../Source/Cesium.js";
-import { Matrix4 } from "../../Source/Cesium.js";
-import { PrimitiveType } from "../../Source/Cesium.js";
-import { VertexFormat } from "../../Source/Cesium.js";
-import { createTangentSpaceDebugPrimitive } from "../../Source/Cesium.js";
+import {
+  Cartesian3,
+  EllipsoidGeometry,
+  Matrix4,
+  PrimitiveType,
+  VertexFormat,
+  createTangentSpaceDebugPrimitive,
+} from "../../../Source/Cesium.js";
 
 describe("Scene/createTangentSpaceDebugPrimitive", function () {
   it("computes all attributes", function () {

--- a/Specs/ViewportPrimitive.js
+++ b/Specs/ViewportPrimitive.js
@@ -1,7 +1,9 @@
-import { defined } from "../Source/Cesium.js";
-import { destroyObject } from "../Source/Cesium.js";
-import { Pass } from "../Source/Cesium.js";
-import { RenderState } from "../Source/Cesium.js";
+import {
+  defined,
+  destroyObject,
+  Pass,
+  RenderState,
+} from "../../Source/Cesium.js";
 
 const ViewportPrimitive = function (fragmentShader) {
   this._fs = fragmentShader;

--- a/Specs/Widgets/Animation/AnimationSpec.js
+++ b/Specs/Widgets/Animation/AnimationSpec.js
@@ -1,8 +1,11 @@
-import { defined } from "../../../Source/Cesium.js";
+import {
+  defined,
+  Animation,
+  AnimationViewModel,
+  ClockViewModel,
+} from "../../../../Source/Cesium.js";
+
 import pollToPromise from "../../pollToPromise.js";
-import { Animation } from "../../../Source/Cesium.js";
-import { AnimationViewModel } from "../../../Source/Cesium.js";
-import { ClockViewModel } from "../../../Source/Cesium.js";
 
 describe("Widgets/Animation/Animation", function () {
   let container;

--- a/Specs/Widgets/Animation/AnimationViewModelSpec.js
+++ b/Specs/Widgets/Animation/AnimationViewModelSpec.js
@@ -1,8 +1,10 @@
-import { ClockRange } from "../../../Source/Cesium.js";
-import { ClockStep } from "../../../Source/Cesium.js";
-import { JulianDate } from "../../../Source/Cesium.js";
-import { AnimationViewModel } from "../../../Source/Cesium.js";
-import { ClockViewModel } from "../../../Source/Cesium.js";
+import {
+  ClockRange,
+  ClockStep,
+  JulianDate,
+  AnimationViewModel,
+  ClockViewModel,
+} from "../../../../Source/Cesium.js";
 
 describe("Widgets/Animation/AnimationViewModel", function () {
   let clockViewModel;

--- a/Specs/Widgets/BaseLayerPicker/BaseLayerPickerSpec.js
+++ b/Specs/Widgets/BaseLayerPicker/BaseLayerPickerSpec.js
@@ -1,8 +1,11 @@
-import { EllipsoidTerrainProvider } from "../../../Source/Cesium.js";
-import { FeatureDetection } from "../../../Source/Cesium.js";
-import { ImageryLayerCollection } from "../../../Source/Cesium.js";
+import {
+  EllipsoidTerrainProvider,
+  FeatureDetection,
+  ImageryLayerCollection,
+  BaseLayerPicker,
+} from "../../../../Source/Cesium.js";
+
 import DomEventSimulator from "../../DomEventSimulator.js";
-import { BaseLayerPicker } from "../../../Source/Cesium.js";
 
 describe("Widgets/BaseLayerPicker/BaseLayerPicker", function () {
   function MockGlobe() {

--- a/Specs/Widgets/BaseLayerPicker/BaseLayerPickerViewModelSpec.js
+++ b/Specs/Widgets/BaseLayerPicker/BaseLayerPickerViewModelSpec.js
@@ -1,7 +1,9 @@
-import { EllipsoidTerrainProvider } from "../../../Source/Cesium.js";
-import { ImageryLayerCollection } from "../../../Source/Cesium.js";
-import { BaseLayerPickerViewModel } from "../../../Source/Cesium.js";
-import { ProviderViewModel } from "../../../Source/Cesium.js";
+import {
+  EllipsoidTerrainProvider,
+  ImageryLayerCollection,
+  BaseLayerPickerViewModel,
+  ProviderViewModel,
+} from "../../../../Source/Cesium.js";
 
 describe("Widgets/BaseLayerPicker/BaseLayerPickerViewModel", function () {
   function MockGlobe() {

--- a/Specs/Widgets/BaseLayerPicker/ProviderViewModelSpec.js
+++ b/Specs/Widgets/BaseLayerPicker/ProviderViewModelSpec.js
@@ -1,6 +1,8 @@
-import { knockout } from "../../../Source/Cesium.js";
-import { ProviderViewModel } from "../../../Source/Cesium.js";
-import { createCommand } from "../../../Source/Cesium.js";
+import {
+  knockout,
+  ProviderViewModel,
+  createCommand,
+} from "../../../../Source/Cesium.js";
 
 describe("Widgets/BaseLayerPicker/ProviderViewModel", function () {
   let spyCreationFunction;

--- a/Specs/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorSpec.js
+++ b/Specs/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorSpec.js
@@ -1,7 +1,10 @@
-import { Ellipsoid } from "../../../Source/Cesium.js";
-import { Globe } from "../../../Source/Cesium.js";
+import {
+  Ellipsoid,
+  Globe,
+  Cesium3DTilesInspector,
+} from "../../../../Source/Cesium.js";
+
 import createScene from "../../createScene.js";
-import { Cesium3DTilesInspector } from "../../../Source/Cesium.js";
 
 describe(
   "Widgets/Cesium3DTilesInspector/Cesium3DTilesInspector",

--- a/Specs/Widgets/CesiumInspector/CesiumInspectorSpec.js
+++ b/Specs/Widgets/CesiumInspector/CesiumInspectorSpec.js
@@ -1,7 +1,10 @@
-import { Ellipsoid } from "../../../Source/Cesium.js";
-import { Globe } from "../../../Source/Cesium.js";
+import {
+  Ellipsoid,
+  Globe,
+  CesiumInspector,
+} from "../../../../Source/Cesium.js";
+
 import createScene from "../../createScene.js";
-import { CesiumInspector } from "../../../Source/Cesium.js";
 
 describe(
   "Widgets/CesiumInspector/CesiumInspector",

--- a/Specs/Widgets/CesiumInspector/CesiumInspectorViewModelSpec.js
+++ b/Specs/Widgets/CesiumInspector/CesiumInspectorViewModelSpec.js
@@ -1,16 +1,20 @@
-import { defined } from "../../../Source/Cesium.js";
-import { GeometryInstance } from "../../../Source/Cesium.js";
+import {
+  defined,
+  GeometryInstance,
+  Rectangle,
+  RectangleGeometry,
+  WebMercatorTilingScheme,
+  EllipsoidSurfaceAppearance,
+  Globe,
+  GlobeSurfaceTile,
+  Primitive,
+  QuadtreeTile,
+  CesiumInspectorViewModel,
+} from "../../../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../../../Source/Cesium.js";
-import { Rectangle } from "../../../Source/Cesium.js";
-import { RectangleGeometry } from "../../../Source/Cesium.js";
-import { WebMercatorTilingScheme } from "../../../Source/Cesium.js";
-import { EllipsoidSurfaceAppearance } from "../../../Source/Cesium.js";
-import { Globe } from "../../../Source/Cesium.js";
-import { GlobeSurfaceTile } from "../../../Source/Cesium.js";
-import { Primitive } from "../../../Source/Cesium.js";
-import { QuadtreeTile } from "../../../Source/Cesium.js";
+
 import createScene from "../../createScene.js";
-import { CesiumInspectorViewModel } from "../../../Source/Cesium.js";
 
 describe(
   "Widgets/CesiumInspector/CesiumInspectorViewModel",

--- a/Specs/Widgets/CesiumWidget/CesiumWidgetSpec.js
+++ b/Specs/Widgets/CesiumWidget/CesiumWidgetSpec.js
@@ -1,18 +1,21 @@
-import { Clock } from "../../../Source/Cesium.js";
-import { defaultValue } from "../../../Source/Cesium.js";
-import { EllipsoidTerrainProvider } from "../../../Source/Cesium.js";
-import { ScreenSpaceEventHandler } from "../../../Source/Cesium.js";
-import { WebMercatorProjection } from "../../../Source/Cesium.js";
-import { Camera } from "../../../Source/Cesium.js";
-import { ImageryLayerCollection } from "../../../Source/Cesium.js";
-import { Scene } from "../../../Source/Cesium.js";
-import { SceneMode } from "../../../Source/Cesium.js";
-import { SkyBox } from "../../../Source/Cesium.js";
-import { TileCoordinatesImageryProvider } from "../../../Source/Cesium.js";
+import {
+  Clock,
+  defaultValue,
+  EllipsoidTerrainProvider,
+  ScreenSpaceEventHandler,
+  WebMercatorProjection,
+  Camera,
+  ImageryLayerCollection,
+  Scene,
+  SceneMode,
+  SkyBox,
+  TileCoordinatesImageryProvider,
+  CesiumWidget,
+} from "../../../../Source/Cesium.js";
+
 import DomEventSimulator from "../../DomEventSimulator.js";
 import getWebGLStub from "../../getWebGLStub.js";
 import pollToPromise from "../../pollToPromise.js";
-import { CesiumWidget } from "../../../Source/Cesium.js";
 
 describe(
   "Widgets/CesiumWidget/CesiumWidget",

--- a/Specs/Widgets/ClockViewModelSpec.js
+++ b/Specs/Widgets/ClockViewModelSpec.js
@@ -1,8 +1,10 @@
-import { Clock } from "../../Source/Cesium.js";
-import { ClockRange } from "../../Source/Cesium.js";
-import { ClockStep } from "../../Source/Cesium.js";
-import { JulianDate } from "../../Source/Cesium.js";
-import { ClockViewModel } from "../../Source/Cesium.js";
+import {
+  Clock,
+  ClockRange,
+  ClockStep,
+  JulianDate,
+  ClockViewModel,
+} from "../../../Source/Cesium.js";
 
 describe("Widgets/ClockViewModel", function () {
   it("default constructor creates a clock", function () {

--- a/Specs/Widgets/FullscreenButton/FullscreenButtonViewModelSpec.js
+++ b/Specs/Widgets/FullscreenButton/FullscreenButtonViewModelSpec.js
@@ -1,5 +1,7 @@
-import { Fullscreen } from "../../../Source/Cesium.js";
-import { FullscreenButtonViewModel } from "../../../Source/Cesium.js";
+import {
+  Fullscreen,
+  FullscreenButtonViewModel,
+} from "../../../../Source/Cesium.js";
 
 describe("Widgets/FullscreenButton/FullscreenButtonViewModel", function () {
   it("constructor sets default values", function () {

--- a/Specs/Widgets/HomeButton/HomeButtonViewModelSpec.js
+++ b/Specs/Widgets/HomeButton/HomeButtonViewModelSpec.js
@@ -1,7 +1,10 @@
-import { Ellipsoid } from "../../../Source/Cesium.js";
-import { Globe } from "../../../Source/Cesium.js";
+import {
+  Ellipsoid,
+  Globe,
+  HomeButtonViewModel,
+} from "../../../../Source/Cesium.js";
+
 import createScene from "../../createScene.js";
-import { HomeButtonViewModel } from "../../../Source/Cesium.js";
 
 describe(
   "Widgets/HomeButton/HomeButtonViewModel",

--- a/Specs/Widgets/InfoBox/InfoBoxSpec.js
+++ b/Specs/Widgets/InfoBox/InfoBoxSpec.js
@@ -1,6 +1,6 @@
-import { defined } from "../../../Source/Cesium.js";
+import { defined, InfoBox } from "../../../../Source/Cesium.js";
+
 import pollToPromise from "../../pollToPromise.js";
-import { InfoBox } from "../../../Source/Cesium.js";
 
 describe("Widgets/InfoBox/InfoBox", function () {
   let testContainer;

--- a/Specs/Widgets/NavigationHelpButton/NavigationHelpButtonSpec.js
+++ b/Specs/Widgets/NavigationHelpButton/NavigationHelpButtonSpec.js
@@ -1,6 +1,9 @@
-import { FeatureDetection } from "../../../Source/Cesium.js";
+import {
+  FeatureDetection,
+  NavigationHelpButton,
+} from "../../../../Source/Cesium.js";
+
 import DomEventSimulator from "../../DomEventSimulator.js";
-import { NavigationHelpButton } from "../../../Source/Cesium.js";
 
 describe("Widgets/NavigationHelpButton/NavigationHelpButton", function () {
   it("can create and destroy", function () {

--- a/Specs/Widgets/PerformanceWatchdog/PerformanceWatchdogViewModelSpec.js
+++ b/Specs/Widgets/PerformanceWatchdog/PerformanceWatchdogViewModelSpec.js
@@ -1,8 +1,11 @@
-import { defined } from "../../../Source/Cesium.js";
-import { getTimestamp } from "../../../Source/Cesium.js";
-import { FrameRateMonitor } from "../../../Source/Cesium.js";
+import {
+  defined,
+  getTimestamp,
+  FrameRateMonitor,
+  PerformanceWatchdogViewModel,
+} from "../../../../Source/Cesium.js";
+
 import createScene from "../../createScene.js";
-import { PerformanceWatchdogViewModel } from "../../../Source/Cesium.js";
 
 describe(
   "Widgets/PerformanceWatchdog/PerformanceWatchdogViewModel",

--- a/Specs/Widgets/ProjectionPicker/ProjectionPickerSpec.js
+++ b/Specs/Widgets/ProjectionPicker/ProjectionPickerSpec.js
@@ -1,7 +1,10 @@
-import { FeatureDetection } from "../../../Source/Cesium.js";
+import {
+  FeatureDetection,
+  ProjectionPicker,
+} from "../../../../Source/Cesium.js";
+
 import createScene from "../../createScene.js";
 import DomEventSimulator from "../../DomEventSimulator.js";
-import { ProjectionPicker } from "../../../Source/Cesium.js";
 
 describe(
   "Widgets/ProjectionPicker/ProjectionPicker",

--- a/Specs/Widgets/ProjectionPicker/ProjectionPickerViewModelSpec.js
+++ b/Specs/Widgets/ProjectionPicker/ProjectionPickerViewModelSpec.js
@@ -1,8 +1,11 @@
-import { OrthographicFrustum } from "../../../Source/Cesium.js";
-import { PerspectiveFrustum } from "../../../Source/Cesium.js";
-import { SceneMode } from "../../../Source/Cesium.js";
+import {
+  OrthographicFrustum,
+  PerspectiveFrustum,
+  SceneMode,
+  ProjectionPickerViewModel,
+} from "../../../../Source/Cesium.js";
+
 import createScene from "../../createScene.js";
-import { ProjectionPickerViewModel } from "../../../Source/Cesium.js";
 
 describe(
   "Widgets/ProjectionPicker/ProjectionPickerViewModel",

--- a/Specs/Widgets/SceneModePicker/SceneModePickerSpec.js
+++ b/Specs/Widgets/SceneModePicker/SceneModePickerSpec.js
@@ -1,7 +1,10 @@
-import { FeatureDetection } from "../../../Source/Cesium.js";
+import {
+  FeatureDetection,
+  SceneModePicker,
+} from "../../../../Source/Cesium.js";
+
 import createScene from "../../createScene.js";
 import DomEventSimulator from "../../DomEventSimulator.js";
-import { SceneModePicker } from "../../../Source/Cesium.js";
 
 describe(
   "Widgets/SceneModePicker/SceneModePicker",

--- a/Specs/Widgets/SceneModePicker/SceneModePickerViewModelSpec.js
+++ b/Specs/Widgets/SceneModePicker/SceneModePickerViewModelSpec.js
@@ -1,8 +1,11 @@
-import { Ellipsoid } from "../../../Source/Cesium.js";
-import { Globe } from "../../../Source/Cesium.js";
-import { SceneMode } from "../../../Source/Cesium.js";
+import {
+  Ellipsoid,
+  Globe,
+  SceneMode,
+  SceneModePickerViewModel,
+} from "../../../../Source/Cesium.js";
+
 import createScene from "../../createScene.js";
-import { SceneModePickerViewModel } from "../../../Source/Cesium.js";
 
 describe(
   "Widgets/SceneModePicker/SceneModePickerViewModel",

--- a/Specs/Widgets/SelectionIndicator/SelectionIndicatorViewModelSpec.js
+++ b/Specs/Widgets/SelectionIndicator/SelectionIndicatorViewModelSpec.js
@@ -1,7 +1,10 @@
-import { Cartesian2 } from "../../../Source/Cesium.js";
-import { Cartesian3 } from "../../../Source/Cesium.js";
+import {
+  Cartesian2,
+  Cartesian3,
+  SelectionIndicatorViewModel,
+} from "../../../../Source/Cesium.js";
+
 import createScene from "../../createScene.js";
-import { SelectionIndicatorViewModel } from "../../../Source/Cesium.js";
 
 describe(
   "Widgets/SelectionIndicator/SelectionIndicatorViewModel",

--- a/Specs/Widgets/Timeline/TimelineSpec.js
+++ b/Specs/Widgets/Timeline/TimelineSpec.js
@@ -1,5 +1,4 @@
-import { Clock } from "../../../Source/Cesium.js";
-import { Timeline } from "../../../Source/Cesium.js";
+import { Clock, Timeline } from "../../../../Source/Cesium.js";
 
 describe("Widgets/Timeline/Timeline", function () {
   let container;

--- a/Specs/Widgets/VRButton/VRButtonViewModelSpec.js
+++ b/Specs/Widgets/VRButton/VRButtonViewModelSpec.js
@@ -1,6 +1,6 @@
-import { Fullscreen } from "../../../Source/Cesium.js";
+import { Fullscreen, VRButtonViewModel } from "../../../../Source/Cesium.js";
+
 import createScene from "../../createScene.js";
-import { VRButtonViewModel } from "../../../Source/Cesium.js";
 
 describe("Widgets/VRButton/VRButtonViewModel", function () {
   let scene;

--- a/Specs/Widgets/Viewer/ViewerSpec.js
+++ b/Specs/Widgets/Viewer/ViewerSpec.js
@@ -1,46 +1,49 @@
-import { BoundingSphere } from "../../../Source/Cesium.js";
-import { Cartesian3 } from "../../../Source/Cesium.js";
-import { CartographicGeocoderService } from "../../../Source/Cesium.js";
-import { Clock } from "../../../Source/Cesium.js";
-import { ClockRange } from "../../../Source/Cesium.js";
-import { ClockStep } from "../../../Source/Cesium.js";
-import { Color } from "../../../Source/Cesium.js";
-import { defined } from "../../../Source/Cesium.js";
-import { EllipsoidTerrainProvider } from "../../../Source/Cesium.js";
-import { HeadingPitchRange } from "../../../Source/Cesium.js";
-import { JulianDate } from "../../../Source/Cesium.js";
-import { Matrix4 } from "../../../Source/Cesium.js";
-import { TimeIntervalCollection } from "../../../Source/Cesium.js";
-import { WebMercatorProjection } from "../../../Source/Cesium.js";
-import { ConstantPositionProperty } from "../../../Source/Cesium.js";
-import { ConstantProperty } from "../../../Source/Cesium.js";
-import { DataSourceClock } from "../../../Source/Cesium.js";
-import { DataSourceCollection } from "../../../Source/Cesium.js";
-import { DataSourceDisplay } from "../../../Source/Cesium.js";
-import { Entity } from "../../../Source/Cesium.js";
-import { Camera } from "../../../Source/Cesium.js";
-import { CameraFlightPath } from "../../../Source/Cesium.js";
-import { Cesium3DTileset } from "../../../Source/Cesium.js";
-import { ImageryLayerCollection } from "../../../Source/Cesium.js";
-import { SceneMode } from "../../../Source/Cesium.js";
-import { ShadowMode } from "../../../Source/Cesium.js";
-import { TimeDynamicPointCloud } from "../../../Source/Cesium.js";
+import {
+  BoundingSphere,
+  Cartesian3,
+  CartographicGeocoderService,
+  Clock,
+  ClockRange,
+  ClockStep,
+  Color,
+  defined,
+  EllipsoidTerrainProvider,
+  HeadingPitchRange,
+  JulianDate,
+  Matrix4,
+  TimeIntervalCollection,
+  WebMercatorProjection,
+  ConstantPositionProperty,
+  ConstantProperty,
+  DataSourceClock,
+  DataSourceCollection,
+  DataSourceDisplay,
+  Entity,
+  Camera,
+  CameraFlightPath,
+  Cesium3DTileset,
+  ImageryLayerCollection,
+  SceneMode,
+  ShadowMode,
+  TimeDynamicPointCloud,
+  Animation,
+  BaseLayerPicker,
+  ProviderViewModel,
+  CesiumWidget,
+  ClockViewModel,
+  FullscreenButton,
+  Geocoder,
+  HomeButton,
+  NavigationHelpButton,
+  SceneModePicker,
+  SelectionIndicator,
+  Timeline,
+} from "../../../../Source/Cesium.js";
+
 import createViewer from "../../createViewer.js";
 import DomEventSimulator from "../../DomEventSimulator.js";
 import MockDataSource from "../../MockDataSource.js";
 import pollToPromise from "../../pollToPromise.js";
-import { Animation } from "../../../Source/Cesium.js";
-import { BaseLayerPicker } from "../../../Source/Cesium.js";
-import { ProviderViewModel } from "../../../Source/Cesium.js";
-import { CesiumWidget } from "../../../Source/Cesium.js";
-import { ClockViewModel } from "../../../Source/Cesium.js";
-import { FullscreenButton } from "../../../Source/Cesium.js";
-import { Geocoder } from "../../../Source/Cesium.js";
-import { HomeButton } from "../../../Source/Cesium.js";
-import { NavigationHelpButton } from "../../../Source/Cesium.js";
-import { SceneModePicker } from "../../../Source/Cesium.js";
-import { SelectionIndicator } from "../../../Source/Cesium.js";
-import { Timeline } from "../../../Source/Cesium.js";
 
 describe(
   "Widgets/Viewer/Viewer",

--- a/Specs/Widgets/Viewer/viewerDragDropMixinSpec.js
+++ b/Specs/Widgets/Viewer/viewerDragDropMixinSpec.js
@@ -1,9 +1,12 @@
-import { defined } from "../../../Source/Cesium.js";
-import { TimeInterval } from "../../../Source/Cesium.js";
+import {
+  defined,
+  TimeInterval,
+  viewerDragDropMixin,
+} from "../../../../Source/Cesium.js";
+
 import createViewer from "../../createViewer.js";
 import DomEventSimulator from "../../DomEventSimulator.js";
 import pollToPromise from "../../pollToPromise.js";
-import { viewerDragDropMixin } from "../../../Source/Cesium.js";
 
 describe(
   "Widgets/Viewer/viewerDragDropMixin",

--- a/Specs/Widgets/Viewer/viewerPerformanceWatchdogMixinSpec.js
+++ b/Specs/Widgets/Viewer/viewerPerformanceWatchdogMixinSpec.js
@@ -1,6 +1,8 @@
+import {
+  PerformanceWatchdog,
+  viewerPerformanceWatchdogMixin,
+} from "../../../../Source/Cesium.js";
 import createViewer from "../../createViewer.js";
-import { PerformanceWatchdog } from "../../../Source/Cesium.js";
-import { viewerPerformanceWatchdogMixin } from "../../../Source/Cesium.js";
 
 describe(
   "Widgets/Viewer/viewerPerformanceWatchdogMixin",

--- a/Specs/Widgets/createCommandSpec.js
+++ b/Specs/Widgets/createCommandSpec.js
@@ -1,6 +1,5 @@
+import { knockout, createCommand } from "../../../Source/Cesium.js";
 import getArguments from "../getArguments.js";
-import { knockout } from "../../Source/Cesium.js";
-import { createCommand } from "../../Source/Cesium.js";
 
 describe("Widgets/createCommand", function () {
   let spyFunction;

--- a/Specs/addDefaultMatchers.js
+++ b/Specs/addDefaultMatchers.js
@@ -1,17 +1,20 @@
+import {
+  Cartesian2,
+  defaultValue,
+  defined,
+  DeveloperError,
+  FeatureDetection,
+  PrimitiveType,
+  Buffer,
+  BufferUsage,
+  ClearCommand,
+  DrawCommand,
+  ShaderProgram,
+  VertexArray,
+} from "../../Source/Cesium.js";
 import equals from "./equals.js";
-import { Cartesian2 } from "../Source/Cesium.js";
-import { defaultValue } from "../Source/Cesium.js";
-import { defined } from "../Source/Cesium.js";
-import { DeveloperError } from "../Source/Cesium.js";
-import { FeatureDetection } from "../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../Source/Cesium.js";
-import { PrimitiveType } from "../Source/Cesium.js";
-import { Buffer } from "../Source/Cesium.js";
-import { BufferUsage } from "../Source/Cesium.js";
-import { ClearCommand } from "../Source/Cesium.js";
-import { DrawCommand } from "../Source/Cesium.js";
-import { ShaderProgram } from "../Source/Cesium.js";
-import { VertexArray } from "../Source/Cesium.js";
 
 function createMissingFunctionMessageFunction(
   item,

--- a/Specs/combineImports.js
+++ b/Specs/combineImports.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+import process, { exit } from "process";
+import fs from "fs/promises";
+
+const stdin = process.openStdin();
+
+let output = "";
+
+stdin.setEncoding("utf8");
+stdin.on("data", (chunk) => {
+  output += chunk;
+});
+
+stdin.on("end", function () {
+  const outputLines = output.split("\r\n");
+  outputLines.forEach((outputLine) => {
+    outputLine = outputLine.replace("\r\n", "");
+    if (outputLine.startsWith("C:\\")) {
+      fs.readFile(outputLine).then((buffer) => {
+        let contents = buffer.toString();
+        const lines = contents.split("\n");
+        console.log(`${outputLine}: ${lines.length}`);
+
+        let combinedImportLine = "import { ";
+        lines.filter((line) => {
+          const search = /import \{ ([A-Za-z0-9]+) \} from \"((..\/)+)Source\/Cesium\.js\";$/.exec(
+            line
+          );
+
+          const importModule = search?.at(1);
+
+          if (search) {
+            contents = contents.replace(line, "");
+            combinedImportLine += `${importModule}, \n`;
+          }
+        });
+
+        combinedImportLine += `} from \"${"../".repeat(
+          outputLine.split("\\").length - 5
+        )}Source/Cesium.js\"\n`;
+
+        const newContents = combinedImportLine + contents;
+
+        return fs.writeFile(outputLine, newContents).then(() => {
+          exit();
+        });
+      });
+    }
+  });
+});
+
+// Regex that will match to each file in the ESLint output.

--- a/Specs/createCamera.js
+++ b/Specs/createCamera.js
@@ -1,9 +1,11 @@
-import { Cartesian3 } from "../Source/Cesium.js";
-import { defaultValue } from "../Source/Cesium.js";
-import { defined } from "../Source/Cesium.js";
-import { GeographicProjection } from "../Source/Cesium.js";
-import { Matrix4 } from "../Source/Cesium.js";
-import { Camera } from "../Source/Cesium.js";
+import {
+  Cartesian3,
+  defaultValue,
+  defined,
+  GeographicProjection,
+  Matrix4,
+  Camera,
+} from "../../Source/Cesium.js";
 
 function MockScene(canvas) {
   canvas = defaultValue(canvas, {

--- a/Specs/createContext.js
+++ b/Specs/createContext.js
@@ -1,6 +1,5 @@
-import { clone } from "../Source/Cesium.js";
-import { defaultValue } from "../Source/Cesium.js";
-import { Context } from "../Source/Cesium.js";
+import { clone, defaultValue, Context } from "../../Source/Cesium.js";
+
 import createCanvas from "./createCanvas.js";
 import createFrameState from "./createFrameState.js";
 import getWebGLStub from "./getWebGLStub.js";

--- a/Specs/createDynamicGeometryUpdaterSpecs.js
+++ b/Specs/createDynamicGeometryUpdaterSpecs.js
@@ -1,9 +1,13 @@
-import { BoundingSphere } from "../Source/Cesium.js";
-import { JulianDate } from "../Source/Cesium.js";
+import {
+  BoundingSphere,
+  JulianDate,
+  BoundingSphereState,
+  EllipsoidGeometryUpdater,
+  PrimitiveCollection,
+} from "../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../Source/Cesium.js";
-import { BoundingSphereState } from "../Source/Cesium.js";
-import { EllipsoidGeometryUpdater } from "../Source/Cesium.js";
-import { PrimitiveCollection } from "../Source/Cesium.js";
+
 import createDynamicProperty from "./createDynamicProperty.js";
 import pollToPromise from "./pollToPromise.js";
 

--- a/Specs/createFrameState.js
+++ b/Specs/createFrameState.js
@@ -1,10 +1,12 @@
-import { defaultValue } from "../Source/Cesium.js";
-import { GeographicProjection } from "../Source/Cesium.js";
-import { JulianDate } from "../Source/Cesium.js";
-import { Camera } from "../Source/Cesium.js";
-import { CreditDisplay } from "../Source/Cesium.js";
-import { FrameState } from "../Source/Cesium.js";
-import { JobScheduler } from "../Source/Cesium.js";
+import {
+  defaultValue,
+  GeographicProjection,
+  JulianDate,
+  Camera,
+  CreditDisplay,
+  FrameState,
+  JobScheduler,
+} from "../../Source/Cesium.js";
 
 function createFrameState(context, camera, frameNumber, time) {
   // Mock frame-state for testing.

--- a/Specs/createGeometryUpdaterGroundGeometrySpecs.js
+++ b/Specs/createGeometryUpdaterGroundGeometrySpecs.js
@@ -1,13 +1,15 @@
-import { Color } from "../Source/Cesium.js";
-import { GeometryOffsetAttribute } from "../Source/Cesium.js";
-import { JulianDate } from "../Source/Cesium.js";
-import { ColorMaterialProperty } from "../Source/Cesium.js";
-import { ConstantProperty } from "../Source/Cesium.js";
-import { SampledProperty } from "../Source/Cesium.js";
-import { ClassificationType } from "../Source/Cesium.js";
-import { GroundPrimitive } from "../Source/Cesium.js";
-import { HeightReference } from "../Source/Cesium.js";
-import { PrimitiveCollection } from "../Source/Cesium.js";
+import {
+  Color,
+  GeometryOffsetAttribute,
+  JulianDate,
+  ColorMaterialProperty,
+  ConstantProperty,
+  SampledProperty,
+  ClassificationType,
+  GroundPrimitive,
+  HeightReference,
+  PrimitiveCollection,
+} from "../../Source/Cesium.js";
 
 function createGeometryUpdaterGroundGeometrySpecs(
   Updater,

--- a/Specs/createGeometryUpdaterSpecs.js
+++ b/Specs/createGeometryUpdaterSpecs.js
@@ -1,18 +1,20 @@
-import { Color } from "../Source/Cesium.js";
-import { ColorGeometryInstanceAttribute } from "../Source/Cesium.js";
-import { DistanceDisplayCondition } from "../Source/Cesium.js";
-import { DistanceDisplayConditionGeometryInstanceAttribute } from "../Source/Cesium.js";
-import { JulianDate } from "../Source/Cesium.js";
-import { ShowGeometryInstanceAttribute } from "../Source/Cesium.js";
-import { TimeInterval } from "../Source/Cesium.js";
-import { ColorMaterialProperty } from "../Source/Cesium.js";
-import { ConstantProperty } from "../Source/Cesium.js";
-import { EllipsoidGeometryUpdater } from "../Source/Cesium.js";
-import { Entity } from "../Source/Cesium.js";
-import { GridMaterialProperty } from "../Source/Cesium.js";
-import { SampledProperty } from "../Source/Cesium.js";
-import { TimeIntervalCollectionProperty } from "../Source/Cesium.js";
-import { ShadowMode } from "../Source/Cesium.js";
+import {
+  Color,
+  ColorGeometryInstanceAttribute,
+  DistanceDisplayCondition,
+  DistanceDisplayConditionGeometryInstanceAttribute,
+  JulianDate,
+  ShowGeometryInstanceAttribute,
+  TimeInterval,
+  ColorMaterialProperty,
+  ConstantProperty,
+  EllipsoidGeometryUpdater,
+  Entity,
+  GridMaterialProperty,
+  SampledProperty,
+  TimeIntervalCollectionProperty,
+  ShadowMode,
+} from "../../Source/Cesium.js";
 
 function createGeometryUpdaterSpecs(
   Updater,

--- a/Specs/createGlobe.js
+++ b/Specs/createGlobe.js
@@ -1,6 +1,4 @@
-import { defaultValue } from "../Source/Cesium.js";
-import { Ellipsoid } from "../Source/Cesium.js";
-import { Event } from "../Source/Cesium.js";
+import { defaultValue, Ellipsoid, Event } from "../../Source/Cesium.js";
 
 function createGlobe(ellipsoid) {
   ellipsoid = defaultValue(ellipsoid, Ellipsoid.WGS84);

--- a/Specs/createPackableSpecs.js
+++ b/Specs/createPackableSpecs.js
@@ -1,5 +1,5 @@
-import { defaultValue } from "../Source/Cesium.js";
-import { defined } from "../Source/Cesium.js";
+import { defaultValue, defined } from "../../Source/Cesium.js";
+
 import { Math as CesiumMath } from "../Source/Cesium.js";
 
 function createPackableSpecs(packable, instance, packedInstance, namePrefix) {

--- a/Specs/createScene.js
+++ b/Specs/createScene.js
@@ -1,8 +1,11 @@
-import { Cartesian2 } from "../Source/Cesium.js";
-import { clone } from "../Source/Cesium.js";
-import { defaultValue } from "../Source/Cesium.js";
-import { defined } from "../Source/Cesium.js";
-import { Scene } from "../Source/Cesium.js";
+import {
+  Cartesian2,
+  clone,
+  defaultValue,
+  defined,
+  Scene,
+} from "../../Source/Cesium.js";
+
 import createCanvas from "./createCanvas.js";
 import getWebGLStub from "./getWebGLStub.js";
 

--- a/Specs/createTileKey.js
+++ b/Specs/createTileKey.js
@@ -1,5 +1,4 @@
-import { defined } from "../Source/Cesium.js";
-import { DeveloperError } from "../Source/Cesium.js";
+import { defined, DeveloperError } from "../../Source/Cesium.js";
 
 function createTileKey(xOrTile, y, level) {
   if (!defined(xOrTile)) {

--- a/Specs/createViewer.js
+++ b/Specs/createViewer.js
@@ -1,6 +1,6 @@
-import { defaultValue } from "../Source/Cesium.js";
+import { defaultValue, Viewer } from "../../Source/Cesium.js";
+
 import getWebGLStub from "./getWebGLStub.js";
-import { Viewer } from "../Source/Cesium.js";
 
 function createViewer(container, options) {
   options = defaultValue(options, {});

--- a/Specs/pick.js
+++ b/Specs/pick.js
@@ -1,12 +1,14 @@
-import { BoundingRectangle } from "../Source/Cesium.js";
-import { Color } from "../Source/Cesium.js";
-import { defined } from "../Source/Cesium.js";
-import { ClearCommand } from "../Source/Cesium.js";
-import { Pass } from "../Source/Cesium.js";
-import { CreditDisplay } from "../Source/Cesium.js";
-import { FrameState } from "../Source/Cesium.js";
-import { JobScheduler } from "../Source/Cesium.js";
-import { PickFramebuffer } from "../Source/Cesium.js";
+import {
+  BoundingRectangle,
+  Color,
+  defined,
+  ClearCommand,
+  Pass,
+  CreditDisplay,
+  FrameState,
+  JobScheduler,
+  PickFramebuffer,
+} from "../../Source/Cesium.js";
 
 function executeCommands(context, passState, commands) {
   const length = commands.length;

--- a/Specs/render.js
+++ b/Specs/render.js
@@ -1,7 +1,4 @@
-import { defined } from "../Source/Cesium.js";
-import { Intersect } from "../Source/Cesium.js";
-import { Pass } from "../Source/Cesium.js";
-import { SceneMode } from "../Source/Cesium.js";
+import { defined, Intersect, Pass, SceneMode } from "../../Source/Cesium.js";
 
 function executeCommands(frameState, commands) {
   let commandsExecuted = 0;


### PR DESCRIPTION
This PR fixes the duplicate imports in `Specs`, of which there were so many that we had to disable the rule for ESLint. I wrote a [custom NodeJS script](https://github.com/CesiumGS/cesium/blob/specs-import-merge/Specs/combineImports.js) to fix the issue.