### PR TITLE
Adds markdown files to pre-commit prettier hook

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@
 - Fixed error in `loadAndExecuteScript` and favorite icon lost in sandcaslte when CesiumJS was running in cross-origin isloated evironment.[#10515](https://github.com/CesiumGS/cesium/pull/10515)
 - Fixed a bug where `Viewer.zoomTo` would continuously throw errors if a `Cesium3DTileset` failed to load.[#10523](https://github.com/CesiumGS/cesium/pull/10523)
 - Fixed a bug where styles would not apply to tilesets if they were applied while the tileset was hidden. [#10582](https://github.com/CesiumGS/cesium/pull/10582)
+
 ### 1.95 - 2022-07-01
 
 ##### Breaking Changes :mega:

--- a/package.json
+++ b/package.json
@@ -163,7 +163,8 @@
       "prettier --write"
     ],
     "*.md": [
-      "markdownlint --ignore CHANGES.md --ignore README.md --ignore LICENSE.md"
+      "markdownlint --ignore CHANGES.md --ignore README.md --ignore LICENSE.md",
+      "prettier --write"
     ]
   }
 }


### PR DESCRIPTION
The `pre-commit` hook was not running `prettier --write` on any changed Markdown files, and this allowed formatting issues to be committed, which caused CI failures, as seen in https://github.com/CesiumGS/cesium/pull/10582. This PR ensures that any changed Markdown files are formatted before commit.