### PR TITLE
Bundle CSS as part of the build

### DIFF
--- a/build.cjs
+++ b/build.cjs
@@ -161,6 +161,7 @@ async function buildCesiumJs(options) {
     "Source/ThirdParty/google-earth-dbroot-parser.js",
     ...css, // Load and optionally minify css
   ];
+  cssAndThirdPartyConfig.bundle = true;
   cssAndThirdPartyConfig.minify = options.minify;
   cssAndThirdPartyConfig.loader = {
     ".gif": "text",


### PR DESCRIPTION
Before https://github.com/CesiumGS/cesium/pull/10399, the CSS was bundled in addition to being optionally minfied. This PR restores that behavior. 

To see the difference, take a look at `Build/Cesium/Widgets/widgets.css` both before and after.