### PR TITLE
Fix bug where dynamic geometry was not marked as ready

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@
 - Fixed a bug where `Viewer.zoomTo` would continuously throw errors if a `Cesium3DTileset` failed to load.[#10523](https://github.com/CesiumGS/cesium/pull/10523)
 - Fixed a bug where styles would not apply to tilesets if they were applied while the tileset was hidden. [#10582](https://github.com/CesiumGS/cesium/pull/10582)
 - Fixed a bug where `.i3dm` models with quantized positions were not being correctly loaded by `ModelExperimental`. [#10598](https://github.com/CesiumGS/cesium/pull/10598)
+- Fixed a bug where dynamic geometry was not marked as `ready`. [#10517](https://github.com/CesiumGS/cesium/issues/10517)
 
 ##### Deprecated :hourglass_flowing_sand:
 

--- a/Source/Scene/ClassificationPrimitive.js
+++ b/Source/Scene/ClassificationPrimitive.js
@@ -166,6 +166,10 @@ function ClassificationPrimitive(options) {
   const classificationPrimitive = this;
   this._readyPromise = new Promise((resolve, reject) => {
     classificationPrimitive._completeLoad = () => {
+      if (this._ready) {
+        return;
+      }
+
       this._ready = true;
 
       if (this.releaseGeometryInstances) {
@@ -1297,7 +1301,6 @@ ClassificationPrimitive.prototype.update = function (frameState) {
     }
 
     this._primitive = new Primitive(primitiveOptions);
-    this._primitive.readyPromise.then(this._completeLoad);
   }
 
   if (
@@ -1351,6 +1354,12 @@ ClassificationPrimitive.prototype.update = function (frameState) {
   this._primitive.show = this.show;
   this._primitive.debugShowBoundingVolume = this.debugShowBoundingVolume;
   this._primitive.update(frameState);
+
+  frameState.afterRender.push(() => {
+    if (defined(this._primitive) && this._primitive.ready) {
+      this._completeLoad();
+    }
+  });
 };
 
 /**

--- a/Source/Scene/GroundPrimitive.js
+++ b/Source/Scene/GroundPrimitive.js
@@ -215,6 +215,10 @@ function GroundPrimitive(options) {
   const groundPrimitive = this;
   this._readyPromise = new Promise((resolve, reject) => {
     groundPrimitive._completeLoad = () => {
+      if (this._ready) {
+        return;
+      }
+
       this._ready = true;
 
       if (this.releaseGeometryInstances) {
@@ -921,7 +925,6 @@ GroundPrimitive.prototype.update = function (frameState) {
     };
 
     this._primitive = new ClassificationPrimitive(primitiveOptions);
-    this._primitive.readyPromise.then(this._completeLoad);
   }
 
   this._primitive.appearance = this.appearance;
@@ -929,6 +932,12 @@ GroundPrimitive.prototype.update = function (frameState) {
   this._primitive.debugShowShadowVolume = this.debugShowShadowVolume;
   this._primitive.debugShowBoundingVolume = this.debugShowBoundingVolume;
   this._primitive.update(frameState);
+
+  frameState.afterRender.push(() => {
+    if (defined(this._primitive) && this._primitive.ready) {
+      this._completeLoad();
+    }
+  });
 };
 
 /**


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/10517

The above bug was being caused because the bounding sphere was never being computed due to the dynamic geometry never being marked as ready. 

This arose after https://github.com/CesiumGS/cesium/pull/10149/files. Previously, when.js would resolve promises synchronously in the same frame. Native promises on the other hand will resolve after a frame. In the case of dynamic geometry, a primitive will have been re-created, so `ready` always appeared to be `false` even if the old promise resolved.

Here, instead of waiting on the promise, we check the `ready` promise synchronously after each frame.
