### PR TITLE
Adds missing files to make-zip output

### DIFF
--- a/gulpfile.cjs
+++ b/gulpfile.cjs
@@ -517,6 +517,7 @@ gulp.task(
       [
         "Apps/**",
         "Apps/**/.eslintrc.json",
+        "Apps/Sandcastle/.jshintrc",
         "!Apps/Sandcastle/gallery/development/**",
         "Source/**",
         "Source/**/.eslintrc.json",
@@ -528,6 +529,7 @@ gulp.task(
         ".eslintrc.json",
         ".gulp.json",
         ".prettierignore",
+        "build.cjs",
         "gulpfile.cjs",
         "server.cjs",
         "index.cjs",


### PR DESCRIPTION
I am not sure if this is just a workaround or a complete fix for https://github.com/CesiumGS/cesium/issues/10611, but this does allow me to properly run `npm start` inside the release ZIP. As mentioned in the issue above, the main problems were the two files missing from the release zip.