### PR TITLE
Improve control over CustomShader translucency settings

### DIFF
--- a/Apps/Sandcastle/gallery/Custom Shaders Models.html
+++ b/Apps/Sandcastle/gallery/Custom Shaders Models.html
@@ -171,8 +171,9 @@
               value: checkerboardTexture,
             },
           },
-          // necessary when setting material.alpha
-          isTranslucent: true,
+          // This model normally renders opaque so material.alpha would be ignored.
+          // this setting forces the shader to render in the translucent pass.
+          translucencyMode: Cesium.CustomShaderTranslucencyMode.TRANSLUCENT,
           fragmentShaderText: `
             void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
             {

--- a/Documentation/CustomShaderGuide/README.md
+++ b/Documentation/CustomShaderGuide/README.md
@@ -31,8 +31,9 @@ const customShader = new Cesium.CustomShader({
   // either PBR (physically-based rendering) or UNLIT depending on the desired
   // results.
   lightingModel: Cesium.LightingModel.PBR,
-  // required when setting material.alpha in the fragment shader
-  isTranslucent: true,
+  // Force the shader to render as transparent, even if the primitive had
+  // an opaque material
+  translucencyMode: Cesium.CustomShaderTranslucencyMode.TRANSLUCENT,
   // Custom vertex shader. This is a function from model space -> model space.
   // VertexInput is documented below
   vertexShaderText: `

--- a/Source/Scene/ModelExperimental/CPUStylingPipelineStage.js
+++ b/Source/Scene/ModelExperimental/CPUStylingPipelineStage.js
@@ -67,8 +67,8 @@ CPUStylingPipelineStage.process = function (
     ShaderDestination.BOTH
   );
   renderResources.uniformMap.model_commandTranslucent = function () {
-    // always check the current value, because custom shaders may
-    // change the value with the isTranslucent flag
+    // Always check the current value, because custom shaders may
+    // change the value with the translucencyMode parameter
     return renderResources.alphaOptions.pass === Pass.TRANSLUCENT;
   };
 

--- a/Source/Scene/ModelExperimental/CustomShader.js
+++ b/Source/Scene/ModelExperimental/CustomShader.js
@@ -6,6 +6,7 @@ import DeveloperError from "../../Core/DeveloperError.js";
 import CustomShaderMode from "./CustomShaderMode.js";
 import UniformType from "./UniformType.js";
 import TextureManager from "./TextureManager.js";
+import CustomShaderTranslucencyMode from "./CustomShaderTranslucencyMode.js";
 
 /**
  * An object describing a uniform, its type, and an initial value
@@ -79,7 +80,7 @@ import TextureManager from "./TextureManager.js";
  * @param {Object} options An object with the following options
  * @param {CustomShaderMode} [options.mode=CustomShaderMode.MODIFY_MATERIAL] The custom shader mode, which determines how the custom shader code is inserted into the fragment shader.
  * @param {LightingModel} [options.lightingModel] The lighting model (e.g. PBR or unlit). If present, this overrides the default lighting for the model.
- * @param {Boolean} [options.isTranslucent=false] If set, the model will be rendered as translucent. This overrides the default settings for the model.
+ * @param {CustomShaderTranslucencyMode} [options.translucencyMode=CustomShaderTranslucencyMode.NO_CHANGE] The translucency mode, which determines how the custom shader will be applied. If the value is CustomShaderTransulcencyMode.OPAQUE or CustomShaderTransulcencyMode.TRANSLUCENT, the custom shader will override settings from the model's material. If the value is CustomShaderTransulcencyMode.NO_CHANGE, the custom shader will render as either opaque or translucent depending on the primitive's material settings.
  * @param {Object.<String, UniformSpecifier>} [options.uniforms] A dictionary for user-defined uniforms. The key is the uniform name that will appear in the GLSL code. The value is an object that describes the uniform type and initial value
  * @param {Object.<String, VaryingType>} [options.varyings] A dictionary for declaring additional GLSL varyings used in the shader. The key is the varying name that will appear in the GLSL code. The value is the data type of the varying. For each varying, the declaration will be added to the top of the shader automatically. The caller is responsible for assigning a value in the vertex shader and using the value in the fragment shader.
  * @param {String} [options.vertexShaderText] The custom vertex shader as a string of GLSL code. It must include a GLSL function called vertexMain. See the example for the expected signature. If not specified, the custom vertex shader step will be skipped in the computed vertex shader.
@@ -169,13 +170,21 @@ export default function CustomShader(options) {
    * @readonly
    */
   this.fragmentShaderText = options.fragmentShaderText;
+
   /**
-   * Whether the shader should be rendered as translucent
+   * The translucency mode, which determines how the custom shader will be applied. If the value is
+   * CustomShaderTransulcencyMode.OPAQUE or CustomShaderTransulcencyMode.TRANSLUCENT, the custom shader
+   * will override settings from the model's material. If the value isCustomShaderTransulcencyMode.NO_CHANGE,
+   * the custom shader will render as either opaque or translucent depending on the primitive's material settings.
    *
-   * @type {Boolean}
+   * @type {CustomShaderTranslucencyMode}
+   * @default CustomShaderTranslucencyMode.NO_CHANGE
    * @readonly
    */
-  this.isTranslucent = defaultValue(options.isTranslucent, false);
+  this.translucencyMode = defaultValue(
+    options.translucencyMode,
+    CustomShaderTranslucencyMode.NO_CHANGE
+  );
 
   /**
    * texture uniforms require some asynchronous processing. This is delegated

--- a/Source/Scene/ModelExperimental/CustomShader.js
+++ b/Source/Scene/ModelExperimental/CustomShader.js
@@ -80,7 +80,7 @@ import CustomShaderTranslucencyMode from "./CustomShaderTranslucencyMode.js";
  * @param {Object} options An object with the following options
  * @param {CustomShaderMode} [options.mode=CustomShaderMode.MODIFY_MATERIAL] The custom shader mode, which determines how the custom shader code is inserted into the fragment shader.
  * @param {LightingModel} [options.lightingModel] The lighting model (e.g. PBR or unlit). If present, this overrides the default lighting for the model.
- * @param {CustomShaderTranslucencyMode} [options.translucencyMode=CustomShaderTranslucencyMode.NO_CHANGE] The translucency mode, which determines how the custom shader will be applied. If the value is CustomShaderTransulcencyMode.OPAQUE or CustomShaderTransulcencyMode.TRANSLUCENT, the custom shader will override settings from the model's material. If the value is CustomShaderTransulcencyMode.NO_CHANGE, the custom shader will render as either opaque or translucent depending on the primitive's material settings.
+ * @param {CustomShaderTranslucencyMode} [options.translucencyMode=CustomShaderTranslucencyMode.INHERIT] The translucency mode, which determines how the custom shader will be applied. If the value is CustomShaderTransulcencyMode.OPAQUE or CustomShaderTransulcencyMode.TRANSLUCENT, the custom shader will override settings from the model's material. If the value is CustomShaderTransulcencyMode.INHERIT, the custom shader will render as either opaque or translucent depending on the primitive's material settings.
  * @param {Object.<String, UniformSpecifier>} [options.uniforms] A dictionary for user-defined uniforms. The key is the uniform name that will appear in the GLSL code. The value is an object that describes the uniform type and initial value
  * @param {Object.<String, VaryingType>} [options.varyings] A dictionary for declaring additional GLSL varyings used in the shader. The key is the varying name that will appear in the GLSL code. The value is the data type of the varying. For each varying, the declaration will be added to the top of the shader automatically. The caller is responsible for assigning a value in the vertex shader and using the value in the fragment shader.
  * @param {String} [options.vertexShaderText] The custom vertex shader as a string of GLSL code. It must include a GLSL function called vertexMain. See the example for the expected signature. If not specified, the custom vertex shader step will be skipped in the computed vertex shader.
@@ -174,16 +174,16 @@ export default function CustomShader(options) {
   /**
    * The translucency mode, which determines how the custom shader will be applied. If the value is
    * CustomShaderTransulcencyMode.OPAQUE or CustomShaderTransulcencyMode.TRANSLUCENT, the custom shader
-   * will override settings from the model's material. If the value isCustomShaderTransulcencyMode.NO_CHANGE,
+   * will override settings from the model's material. If the value isCustomShaderTransulcencyMode.INHERIT,
    * the custom shader will render as either opaque or translucent depending on the primitive's material settings.
    *
    * @type {CustomShaderTranslucencyMode}
-   * @default CustomShaderTranslucencyMode.NO_CHANGE
+   * @default CustomShaderTranslucencyMode.INHERIT
    * @readonly
    */
   this.translucencyMode = defaultValue(
     options.translucencyMode,
-    CustomShaderTranslucencyMode.NO_CHANGE
+    CustomShaderTranslucencyMode.INHERIT
   );
 
   /**

--- a/Source/Scene/ModelExperimental/CustomShaderPipelineStage.js
+++ b/Source/Scene/ModelExperimental/CustomShaderPipelineStage.js
@@ -93,7 +93,7 @@ CustomShaderPipelineStage.process = function (
     // in AlphaPipelineStage
     alphaOptions.pass = undefined;
   }
-  // For CustomShaderTranslucencyMode.NO_CHANGE, do not modify alphaOptions.pass
+  // For CustomShaderTranslucencyMode.INHERIT, do not modify alphaOptions.pass
 
   // Generate lines of code for the shader, but don't add them to the shader
   // yet.

--- a/Source/Scene/ModelExperimental/CustomShaderPipelineStage.js
+++ b/Source/Scene/ModelExperimental/CustomShaderPipelineStage.js
@@ -9,6 +9,7 @@ import CustomShaderMode from "./CustomShaderMode.js";
 import FeatureIdPipelineStage from "./FeatureIdPipelineStage.js";
 import MetadataPipelineStage from "./MetadataPipelineStage.js";
 import ModelExperimentalUtility from "./ModelExperimentalUtility.js";
+import CustomShaderTranslucencyMode from "./CustomShaderTranslucencyMode.js";
 
 /**
  * The custom shader pipeline stage takes GLSL callbacks from the
@@ -80,14 +81,19 @@ CustomShaderPipelineStage.process = function (
   }
 
   const alphaOptions = renderResources.alphaOptions;
-  if (customShader.isTranslucent) {
+  if (
+    customShader.translucencyMode === CustomShaderTranslucencyMode.TRANSLUCENT
+  ) {
     alphaOptions.pass = Pass.TRANSLUCENT;
-  } else {
-    // Use the default pass (either OPAQUE or 3D_TILES), regardless of whether
+  } else if (
+    customShader.translucencyMode === CustomShaderTranslucencyMode.OPAQUE
+  ) {
+    // Use the default opqaue pass (either OPAQUE or 3D_TILES), regardless of whether
     // the material pipeline stage used translucent. The default is configured
     // in AlphaPipelineStage
     alphaOptions.pass = undefined;
   }
+  // For CustomShaderTranslucencyMode.NO_CHANGE, do not modify alphaOptions.pass
 
   // Generate lines of code for the shader, but don't add them to the shader
   // yet.

--- a/Source/Scene/ModelExperimental/CustomShaderTranslucencyMode.js
+++ b/Source/Scene/ModelExperimental/CustomShaderTranslucencyMode.js
@@ -8,14 +8,14 @@
  */
 const CustomShaderTranslucencyMode = {
   /**
-   * Do not modify the primitive's translucency settings. If the primitive used a
+   * Inherit translucency settings from the primitive's material. If the primitive used a
    * translucent material, the custom shader will also be considered translucent. If the primitive
    * used an opaque material, the custom shader will be considered opaque.
    *
    * @type {Number}
    * @constant
    */
-  NO_CHANGE: 0,
+  INHERIT: 0,
   /**
    * Force the primitive to render the primitive as opaque, ignoring any material settings.
    *

--- a/Source/Scene/ModelExperimental/CustomShaderTranslucencyMode.js
+++ b/Source/Scene/ModelExperimental/CustomShaderTranslucencyMode.js
@@ -1,0 +1,35 @@
+/**
+ * An enum for controling how {@link CustomShader} handles translucency compared with the original
+ * primitive.
+ *
+ * @enum {Number}
+ *
+ * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
+ */
+const CustomShaderTranslucencyMode = {
+  /**
+   * Do not modify the primitive's translucency settings. If the primitive used a
+   * translucent material, the custom shader will also be considered translucent. If the primitive
+   * used an opaque material, the custom shader will be considered opaque.
+   *
+   * @type {Number}
+   * @constant
+   */
+  NO_CHANGE: 0,
+  /**
+   * Force the primitive to render the primitive as opaque, ignoring any material settings.
+   *
+   * @type {Number}
+   * @constant
+   */
+  OPAQUE: 1,
+  /**
+   * Force the primitive to render the primitive as translucent, ignoring any material settings.
+   *
+   * @type {Number}
+   * @constant
+   */
+  TRANSLUCENT: 2,
+};
+
+export default Object.freeze(CustomShaderTranslucencyMode);

--- a/Specs/Scene/ModelExperimental/CustomShaderPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/CustomShaderPipelineStageSpec.js
@@ -2,6 +2,7 @@ import {
   AttributeType,
   CustomShader,
   CustomShaderPipelineStage,
+  CustomShaderTranslucencyMode,
   LightingModel,
   ModelAlphaOptions,
   ModelLightingOptions,
@@ -183,11 +184,25 @@ describe("Scene/ModelExperimental/CustomShaderPipelineStage", function () {
     expect(renderResources.alphaOptions.pass).not.toBeDefined();
   });
 
-  it("sets alpha options for translucent custom shader", function () {
+  it("does not modify pass if translucencyMode = NO_CHANGE", function () {
     const customShader = new CustomShader({
       vertexShaderText: emptyVertexShader,
       fragmentShaderText: emptyFragmentShader,
-      isTranslucent: true,
+      translucencyMode: CustomShaderTranslucencyMode.NO_CHANGE,
+    });
+    const renderResources = mockRenderResources(customShader);
+    renderResources.alphaOptions.pass = Pass.CESIUM_3D_TILE;
+
+    CustomShaderPipelineStage.process(renderResources, primitive);
+
+    expect(renderResources.alphaOptions.pass).toBe(Pass.CESIUM_3D_TILE);
+  });
+
+  it("sets pass for translucent custom shader", function () {
+    const customShader = new CustomShader({
+      vertexShaderText: emptyVertexShader,
+      fragmentShaderText: emptyFragmentShader,
+      translucencyMode: CustomShaderTranslucencyMode.TRANSLUCENT,
     });
     const renderResources = mockRenderResources(customShader);
 
@@ -196,10 +211,24 @@ describe("Scene/ModelExperimental/CustomShaderPipelineStage", function () {
     expect(renderResources.alphaOptions.pass).toBe(Pass.TRANSLUCENT);
   });
 
+  it("sets pass to undefined for opaque custom shader", function () {
+    const customShader = new CustomShader({
+      vertexShaderText: emptyVertexShader,
+      fragmentShaderText: emptyFragmentShader,
+      translucencyMode: CustomShaderTranslucencyMode.opaque,
+    });
+    const renderResources = mockRenderResources(customShader);
+
+    CustomShaderPipelineStage.process(renderResources, primitive);
+
+    // This is set undefined here, and AlphaPipelineStage handles choosing the correct opaque pass
+    expect(renderResources.alphaOptions.pass).not.toBeDefined();
+  });
+
   it("unlit and translucency work even if no shader code is present", function () {
     const customShader = new CustomShader({
       lightingModel: LightingModel.PBR,
-      isTranslucent: true,
+      translucencyMode: CustomShaderTranslucencyMode.TRANSLUCENT,
     });
     const renderResources = mockRenderResources(customShader);
     const shaderBuilder = renderResources.shaderBuilder;

--- a/Specs/Scene/ModelExperimental/CustomShaderPipelineStageSpec.js
+++ b/Specs/Scene/ModelExperimental/CustomShaderPipelineStageSpec.js
@@ -184,11 +184,11 @@ describe("Scene/ModelExperimental/CustomShaderPipelineStage", function () {
     expect(renderResources.alphaOptions.pass).not.toBeDefined();
   });
 
-  it("does not modify pass if translucencyMode = NO_CHANGE", function () {
+  it("does not modify pass if translucencyMode = INHERIT", function () {
     const customShader = new CustomShader({
       vertexShaderText: emptyVertexShader,
       fragmentShaderText: emptyFragmentShader,
-      translucencyMode: CustomShaderTranslucencyMode.NO_CHANGE,
+      translucencyMode: CustomShaderTranslucencyMode.INHERIT,
     });
     const renderResources = mockRenderResources(customShader);
     renderResources.alphaOptions.pass = Pass.CESIUM_3D_TILE;

--- a/Specs/Scene/ModelExperimental/CustomShaderSpec.js
+++ b/Specs/Scene/ModelExperimental/CustomShaderSpec.js
@@ -4,6 +4,7 @@ import {
   Matrix2,
   CustomShader,
   CustomShaderMode,
+  CustomShaderTranslucencyMode,
   LightingModel,
   TextureUniform,
   UniformType,
@@ -23,6 +24,9 @@ describe("Scene/ModelExperimental/CustomShader", function () {
 
     expect(customShader.mode).toBe(CustomShaderMode.MODIFY_MATERIAL);
     expect(customShader.lightingModel).not.toBeDefined();
+    expect(customShader.translucencyMode).toBe(
+      CustomShaderTranslucencyMode.NO_CHANGE
+    );
     expect(customShader.uniforms).toEqual({});
     expect(customShader.varyings).toEqual({});
     expect(customShader.vertexShaderText).not.toBeDefined();
@@ -33,6 +37,7 @@ describe("Scene/ModelExperimental/CustomShader", function () {
   it("constructs", function () {
     const customShader = new CustomShader({
       mode: CustomShaderMode.REPLACE_MATERIAL,
+      translucencyMode: CustomShaderTranslucencyMode.TRANSLUCENT,
       lightingModel: LightingModel.PBR,
       vertexShaderText: emptyVertexShader,
       fragmentShaderText: emptyFragmentShader,
@@ -40,6 +45,9 @@ describe("Scene/ModelExperimental/CustomShader", function () {
 
     expect(customShader.mode).toBe(CustomShaderMode.REPLACE_MATERIAL);
     expect(customShader.lightingModel).toBe(LightingModel.PBR);
+    expect(customShader.translucencyMode).toBe(
+      CustomShaderTranslucencyMode.TRANSLUCENT
+    );
     expect(customShader.uniforms).toEqual({});
     expect(customShader.varyings).toEqual({});
     expect(customShader.vertexShaderText).toBe(emptyVertexShader);

--- a/Specs/Scene/ModelExperimental/CustomShaderSpec.js
+++ b/Specs/Scene/ModelExperimental/CustomShaderSpec.js
@@ -25,7 +25,7 @@ describe("Scene/ModelExperimental/CustomShader", function () {
     expect(customShader.mode).toBe(CustomShaderMode.MODIFY_MATERIAL);
     expect(customShader.lightingModel).not.toBeDefined();
     expect(customShader.translucencyMode).toBe(
-      CustomShaderTranslucencyMode.NO_CHANGE
+      CustomShaderTranslucencyMode.INHERIT
     );
     expect(customShader.uniforms).toEqual({});
     expect(customShader.varyings).toEqual({});


### PR DESCRIPTION
Originally, CustomShader had a `isTranslucent` flag that worked like this:

* `isTranslucent: true` - override the material settings and always render in the translucent pass
* `isTranslucent: false (default)` - override the material settings and always render in an opaque pass

However, this is sometimes confusing and may be limiting in cases where primitives have some opaque and some translucent materials.

Instead, I added `translucencyMode` with 3 states:

* ~NO_CHANGE~ `INHERIT` - Inherit settings from the primitive's material (i.e. if the shader is applied to an opaque primitive, the alpha channel will be ignored, but if applied to a translucent primitive, the alpha channel will be used)
* `TRANSLUCENT` - override the material and render as translucent
* `OPAQUE` - override the material and render as opaque.

@lilleyse could you review?