### PR TITLE
Add support for CESIUM_RTC in GltfLoader

### DIFF
--- a/Source/Scene/GltfJsonLoader.js
+++ b/Source/Scene/GltfJsonLoader.js
@@ -166,7 +166,7 @@ function handleError(gltfJsonLoader, error) {
 }
 
 function upgradeVersion(gltfJsonLoader, gltf) {
-  if (gltf.asset.version === "2.0") {
+  if (defined(gltf.asset) && gltf.asset.version === "2.0") {
     return Promise.resolve();
   }
 

--- a/Source/Scene/GltfLoader.js
+++ b/Source/Scene/GltfLoader.js
@@ -2184,6 +2184,8 @@ function loadScene(gltf, nodes) {
   return scene;
 }
 
+const scratchCenter = new Cartesian3();
+
 function parse(
   loader,
   gltf,
@@ -2195,6 +2197,7 @@ function parse(
   const extensions = defaultValue(gltf.extensions, defaultValue.EMPTY_OBJECT);
   const structuralMetadataExtension = extensions.EXT_structural_metadata;
   const featureMetadataExtensionLegacy = extensions.EXT_feature_metadata;
+  const cesiumRtcExtension = extensions.CESIUM_RTC;
 
   if (defined(featureMetadataExtensionLegacy)) {
     // If the old EXT_feature_metadata extension is present, sort the IDs of the
@@ -2237,6 +2240,19 @@ function parse(
   components.articulations = articulations;
   components.upAxis = loader._upAxis;
   components.forwardAxis = loader._forwardAxis;
+
+  if (defined(cesiumRtcExtension)) {
+    // CESIUM_RTC is almost always WGS84 coordinates so no axis conversion needed
+    const center = Cartesian3.fromArray(
+      cesiumRtcExtension.center,
+      0,
+      scratchCenter
+    );
+    components.transform = Matrix4.fromTranslation(
+      center,
+      components.transform
+    );
+  }
 
   loader._components = components;
 

--- a/Source/Scene/ModelExperimental/B3dmLoader.js
+++ b/Source/Scene/ModelExperimental/B3dmLoader.js
@@ -248,7 +248,10 @@ B3dmLoader.prototype.load = function () {
 
       const components = gltfLoader.components;
 
-      // The glTF loader may have set its own transform if using the CESIUM_RTC extension
+      // Combine the RTC_CENTER transform from the b3dm and the CESIUM_RTC
+      // transform from the glTF. In practice usually only one or the
+      // other is supplied. If they don't exist the transforms will
+      // be identity matrices.
       components.transform = Matrix4.multiplyTransformation(
         that._transform,
         components.transform,

--- a/Source/Scene/ModelExperimental/B3dmLoader.js
+++ b/Source/Scene/ModelExperimental/B3dmLoader.js
@@ -247,7 +247,13 @@ B3dmLoader.prototype.load = function () {
       }
 
       const components = gltfLoader.components;
-      components.transform = that._transform;
+
+      // The glTF loader may have set its own transform if using the CESIUM_RTC extension
+      components.transform = Matrix4.multiplyTransformation(
+        that._transform,
+        components.transform,
+        components.transform
+      );
       createStructuralMetadata(that, components);
       that._components = components;
 

--- a/Source/Scene/ModelExperimental/I3dmLoader.js
+++ b/Source/Scene/ModelExperimental/I3dmLoader.js
@@ -276,7 +276,16 @@ I3dmLoader.prototype.load = function () {
       }
 
       const components = gltfLoader.components;
-      components.transform = that._transform;
+
+      // Combine the RTC_CENTER transform from the i3dm and the CESIUM_RTC
+      // transform from the glTF. In practice CESIUM_RTC is not set for
+      // instanced models but multiply the transforms just in case.
+      components.transform = Matrix4.multiplyTransformation(
+        that._transform,
+        components.transform,
+        components.transform
+      );
+
       createInstances(that, components);
       createStructuralMetadata(that, components);
       that._components = components;
@@ -349,6 +358,8 @@ function createStructuralMetadata(loader, components) {
 
 const positionScratch = new Cartesian3();
 const propertyScratch1 = new Array(4);
+const transformScratch = new Matrix4();
+
 function createInstances(loader, components) {
   let i;
   const featureTable = loader._featureTable;
@@ -419,8 +430,18 @@ function createInstances(loader, components) {
     }
 
     // Set the center of the bounding sphere as the RTC center transform.
-    components.transform = Matrix4.fromTranslation(
-      positionBoundingSphere.center
+    const centerTransform = Matrix4.fromTranslation(
+      positionBoundingSphere.center,
+      transformScratch
+    );
+
+    // Combine the center transform and the CESIUM_RTC transform from the glTF.
+    // In practice CESIUM_RTC is not set for instanced models but multiply the
+    // transforms just in case.
+    components.transform = Matrix4.multiplyTransformation(
+      centerTransform,
+      components.transform,
+      components.transform
     );
   }
 

--- a/Specs/Data/Models/GltfLoader/BoxCesiumRtc/glTF/BoxCesiumRtc.gltf
+++ b/Specs/Data/Models/GltfLoader/BoxCesiumRtc/glTF/BoxCesiumRtc.gltf
@@ -1,0 +1,164 @@
+{
+  "accessors": [
+    {
+      "bufferView": 0,
+      "byteOffset": 0,
+      "componentType": 5123,
+      "count": 36,
+      "type": "SCALAR",
+      "name": "accessor_21"
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 0,
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        0.5,
+        0.5,
+        0.5
+      ],
+      "min": [
+        -0.5,
+        -0.5,
+        -0.5
+      ],
+      "type": "VEC3",
+      "name": "accessor_23"
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 288,
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        1,
+        1,
+        1
+      ],
+      "min": [
+        -1,
+        -1,
+        -1
+      ],
+      "type": "VEC3",
+      "name": "accessor_25"
+    }
+  ],
+  "asset": {
+    "generator": "collada2gltf@",
+    "version": "2.0"
+  },
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteLength": 72,
+      "byteOffset": 0,
+      "target": 34963,
+      "name": "bufferView_29"
+    },
+    {
+      "buffer": 0,
+      "byteLength": 576,
+      "byteOffset": 72,
+      "target": 34962,
+      "name": "bufferView_30",
+      "byteStride": 12
+    }
+  ],
+  "buffers": [
+    {
+      "name": "BoxCesiumRtc",
+      "byteLength": 648,
+      "uri": "data:application/octet-stream;base64,AAABAAIAAwACAAEABAAFAAYABwAGAAUACAAJAAoACwAKAAkADAANAA4ADwAOAA0AEAARABIAEwASABEAFAAVABYAFwAWABUAAAAAvwAAAL8AAAA/AAAAPwAAAL8AAAA/AAAAvwAAAD8AAAA/AAAAPwAAAD8AAAA/AAAAPwAAAL8AAAA/AAAAvwAAAL8AAAA/AAAAPwAAAL8AAAC/AAAAvwAAAL8AAAC/AAAAPwAAAD8AAAA/AAAAPwAAAL8AAAA/AAAAPwAAAD8AAAC/AAAAPwAAAL8AAAC/AAAAvwAAAD8AAAA/AAAAPwAAAD8AAAA/AAAAvwAAAD8AAAC/AAAAPwAAAD8AAAC/AAAAvwAAAL8AAAA/AAAAvwAAAD8AAAA/AAAAvwAAAL8AAAC/AAAAvwAAAD8AAAC/AAAAvwAAAL8AAAC/AAAAvwAAAD8AAAC/AAAAPwAAAL8AAAC/AAAAPwAAAD8AAAC/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/"
+    }
+  ],
+  "extensionsUsed": ["CESIUM_RTC"],
+  "extensionsRequired": ["CESIUM_RTC"],
+  "extensions": {
+    "CESIUM_RTC": {
+      "center": [
+        6378137,
+        0,
+        0
+      ]
+    }
+  },
+  "materials": [
+    {
+      "name": "Red",
+      "pbrMetallicRoughness": {
+        "roughnessFactor": 1,
+        "metallicFactor": 0,
+        "baseColorFactor": [
+          0.6038273590607631,
+          0,
+          0,
+          1
+        ]
+      },
+      "emissiveFactor": [
+        0,
+        0,
+        0
+      ],
+      "alphaMode": "OPAQUE",
+      "doubleSided": false
+    }
+  ],
+  "meshes": [
+    {
+      "name": "Mesh",
+      "primitives": [
+        {
+          "attributes": {
+            "NORMAL": 2,
+            "POSITION": 1
+          },
+          "indices": 0,
+          "material": 0,
+          "mode": 4
+        }
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "Mesh",
+      "mesh": 0
+    },
+    {
+      "children": [
+        0
+      ],
+      "matrix": [
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        -1,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1
+      ],
+      "name": "Y_UP_Transform"
+    }
+  ],
+  "scene": 0,
+  "scenes": [
+    {
+      "nodes": [
+        1
+      ],
+      "name": "defaultScene"
+    }
+  ]
+}

--- a/Specs/Scene/GltfLoaderSpec.js
+++ b/Specs/Scene/GltfLoaderSpec.js
@@ -112,6 +112,8 @@ describe(
       "./Data/Models/GltfLoader/BoxWithPrimitiveOutline/glTF/BoxWithPrimitiveOutline.gltf";
     const boxWithPrimitiveOutlineSharedVertices =
       "./Data/Models/GltfLoader/BoxWithPrimitiveOutlineSharedVertices/glTF/BoxWithPrimitiveOutlineSharedVertices.gltf";
+    const boxCesiumRtc =
+      "./Data/Models/GltfLoader/BoxCesiumRtc/glTF/BoxCesiumRtc.gltf";
 
     let scene;
     let sceneWithWebgl2;
@@ -4027,6 +4029,16 @@ describe(
         for (let i = 0; i < length; i++) {
           expect(credits[i].html).toEqual(expectedCredits[i]);
         }
+      });
+    });
+
+    it("loads model with CESIUM_RTC", function () {
+      return loadGltf(boxCesiumRtc).then(function (gltfLoader) {
+        const components = gltfLoader.components;
+        const expectedTransform = Matrix4.fromTranslation(
+          new Cartesian3(6378137, 0, 0)
+        );
+        expect(components.transform).toEqual(expectedTransform);
       });
     });
   },


### PR DESCRIPTION
Part of https://github.com/CesiumGS/cesium/issues/10613

[CESIUM_RTC](https://github.com/KhronosGroup/glTF/blob/main/extensions/1.0/Vendor/CESIUM_RTC/README.md) is used in a lot of glTF 1.0 assets and was easy enough to support in `GltfLoader`.

See https://github.com/CesiumGS/cesium/issues/10627 for test data and sandcastle