### PR TITLE
Clean up JSDoc for Model classes

### DIFF
--- a/Source/Scene/Model/Model.js
+++ b/Source/Scene/Model/Model.js
@@ -120,7 +120,7 @@ import SplitDirection from "../SplitDirection.js";
  *
  * @see Model.fromGltf
  *
- * @demo {@link https://sandcastle.cesium.com/index.html?src=3D%20Models.html%7CCesium Sandcastle Models Demo}
+ * @demo {@link https://sandcastle.cesium.com/index.html?src=3D%20Models.html|Cesium Sandcastle Models Demo}
  */
 function Model(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/Source/Scene/Model/Model.js
+++ b/Source/Scene/Model/Model.js
@@ -62,17 +62,15 @@ import SplitDirection from "../SplitDirection.js";
  *  <li>
  *  {@link https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_texture_basisu|KHR_texture_basisu}
  *  </li>
+ *  <li>
+ *  {@link https://github.com/KhronosGroup/glTF/blob/master/extensions/1.0/Vendor/CESIUM_RTC/README.md|CESIUM_RTC}
+ *  </li>
  * </ul>
  * </p>
  * <p>
  * Note: for models with compressed textures using the KHR_texture_basisu extension, we recommend power of 2 textures in both dimensions
  * for maximum compatibility. This is because some samplers require power of 2 textures ({@link https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/Tutorial/Using_textures_in_WebGL|Using textures in WebGL})
  * and KHR_texture_basisu requires multiple of 4 dimensions ({@link https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_texture_basisu/README.md#additional-requirements|KHR_texture_basisu additional requirements}).
- * </p>
- * <p>
- * For high-precision rendering, Cesium supports the {@link https://github.com/KhronosGroup/glTF/blob/master/extensions/1.0/Vendor/CESIUM_RTC/README.md|CESIUM_RTC} extension, which introduces the
- * CESIUM_RTC_MODELVIEW parameter semantic that says the node is in WGS84 coordinates translated
- * relative to a local origin.
  * </p>
  *
  * @alias Model
@@ -119,6 +117,10 @@ import SplitDirection from "../SplitDirection.js";
  * @param {String|Number} [options.instanceFeatureIdLabel="instanceFeatureId_0"] Label of the instance feature ID set used for picking and styling. If instanceFeatureIdLabel is set to an integer N, it is converted to the string "instanceFeatureId_N" automatically. If both per-primitive and per-instance feature IDs are present, the instance feature IDs take priority.
  * @param {Object} [options.pointCloudShading] Options for constructing a {@link PointCloudShading} object to control point attenuation based on geometric error and lighting.
  * @param {ClassificationType} [options.classificationType] Determines whether terrain, 3D Tiles or both will be classified by this model. This cannot be set after the model has loaded.
+ *
+ * @see Model.fromGltf
+ *
+ * @demo {@link https://sandcastle.cesium.com/index.html?src=3D%20Models.html%7CCesium Sandcastle Models Demo}
  */
 function Model(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/Source/Scene/Model/Model.js
+++ b/Source/Scene/Model/Model.js
@@ -132,6 +132,8 @@ export default function Model(options) {
    * The corresponding constructor parameter is undocumented, since
    * ResourceLoader is part of the private API.
    *
+   * @memberof Model.prototype
+   *
    * @type {ResourceLoader}
    * @private
    */
@@ -142,6 +144,8 @@ export default function Model(options) {
    * Type of this model, to distinguish individual glTF files from 3D Tiles
    * internally. The corresponding constructor parameter is undocumented, since
    * ModelType is part of the private API.
+   *
+   * @memberof Model.prototype
    *
    * @type {ModelType}
    * @readonly
@@ -156,6 +160,8 @@ export default function Model(options) {
    * Local reference frames can be used by providing a different transformation matrix, like that returned
    * by {@link Transforms.eastNorthUpToFixedFrame}.
    *
+   * @memberof Model.prototype
+   * 
    * @type {Matrix4}
 
    * @default {@link Matrix4.IDENTITY}
@@ -178,6 +184,8 @@ export default function Model(options) {
    * The scale value after being clamped by the maximum scale parameter.
    * Used to adjust bounding spheres without repeated calculation.
    *
+   * @memberof Model.prototype
+   *
    * @type {Number}
    * @private
    */
@@ -191,6 +199,8 @@ export default function Model(options) {
    * Whether or not the ModelSceneGraph should call updateModelMatrix.
    * This will be true if any of the model matrix, scale, minimum pixel size, or maximum scale are dirty.
    *
+   * @memberof Model.prototype
+   *
    * @type {Number}
    * @private
    */
@@ -201,6 +211,8 @@ export default function Model(options) {
    * clipping planes and image-based lighting instead of the modelMatrix. This is
    * so that when models are part of a tileset, these properties get transformed
    * relative to a common reference (such as the root).
+   *
+   * @memberof Model.prototype
    *
    * @type {Matrix4}
    * @private
@@ -379,6 +391,8 @@ export default function Model(options) {
    * {@link https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Vendor/CESIUM_primitive_outline|CESIUM_primitive_outline} extension.
    * When true, outlines are displayed. When false, outlines are not displayed.
    *
+   * @memberof Model.prototype
+   *
    * @type {Boolean}
    *
    * @default true
@@ -387,6 +401,8 @@ export default function Model(options) {
 
   /**
    * The color to use when rendering outlines.
+   *
+   * @memberof Model.prototype
    *
    * @type {Color}
    *
@@ -705,6 +721,8 @@ Object.defineProperties(Model.prototype, {
   /**
    * Whether or not to cull the model using frustum/horizon culling. If the model is part of a 3D Tiles tileset, this property
    * will always be false, since the 3D Tiles culling system is used.
+   *
+   * @memberof Model.prototype
    *
    * @type {Boolean}
    * @readonly
@@ -1516,6 +1534,8 @@ Object.defineProperties(Model.prototype, {
   /**
    * Reference to the pick IDs. This is only used internally, e.g. for
    * per-feature post-processing in {@link PostProcessStage}.
+   *
+   * @memberof Model.prototype
    *
    * @type {PickId[]}
    * @readonly

--- a/Source/Scene/Model/Model.js
+++ b/Source/Scene/Model/Model.js
@@ -120,7 +120,7 @@ import SplitDirection from "../SplitDirection.js";
  * @param {Object} [options.pointCloudShading] Options for constructing a {@link PointCloudShading} object to control point attenuation based on geometric error and lighting.
  * @param {ClassificationType} [options.classificationType] Determines whether terrain, 3D Tiles or both will be classified by this model. This cannot be set after the model has loaded.
  */
-export default function Model(options) {
+function Model(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("options.loader", options.loader);
@@ -132,8 +132,6 @@ export default function Model(options) {
    * The corresponding constructor parameter is undocumented, since
    * ResourceLoader is part of the private API.
    *
-   * @memberof Model.prototype
-   *
    * @type {ResourceLoader}
    * @private
    */
@@ -144,8 +142,6 @@ export default function Model(options) {
    * Type of this model, to distinguish individual glTF files from 3D Tiles
    * internally. The corresponding constructor parameter is undocumented, since
    * ModelType is part of the private API.
-   *
-   * @memberof Model.prototype
    *
    * @type {ModelType}
    * @readonly
@@ -159,8 +155,6 @@ export default function Model(options) {
    * When this is the identity matrix, the model is drawn in world coordinates, i.e., Earth's Cartesian WGS84 coordinates.
    * Local reference frames can be used by providing a different transformation matrix, like that returned
    * by {@link Transforms.eastNorthUpToFixedFrame}.
-   *
-   * @memberof Model.prototype
    * 
    * @type {Matrix4}
 
@@ -184,8 +178,6 @@ export default function Model(options) {
    * The scale value after being clamped by the maximum scale parameter.
    * Used to adjust bounding spheres without repeated calculation.
    *
-   * @memberof Model.prototype
-   *
    * @type {Number}
    * @private
    */
@@ -199,8 +191,6 @@ export default function Model(options) {
    * Whether or not the ModelSceneGraph should call updateModelMatrix.
    * This will be true if any of the model matrix, scale, minimum pixel size, or maximum scale are dirty.
    *
-   * @memberof Model.prototype
-   *
    * @type {Number}
    * @private
    */
@@ -211,8 +201,6 @@ export default function Model(options) {
    * clipping planes and image-based lighting instead of the modelMatrix. This is
    * so that when models are part of a tileset, these properties get transformed
    * relative to a common reference (such as the root).
-   *
-   * @memberof Model.prototype
    *
    * @type {Matrix4}
    * @private
@@ -391,8 +379,6 @@ export default function Model(options) {
    * {@link https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Vendor/CESIUM_primitive_outline|CESIUM_primitive_outline} extension.
    * When true, outlines are displayed. When false, outlines are not displayed.
    *
-   * @memberof Model.prototype
-   *
    * @type {Boolean}
    *
    * @default true
@@ -401,8 +387,6 @@ export default function Model(options) {
 
   /**
    * The color to use when rendering outlines.
-   *
-   * @memberof Model.prototype
    *
    * @type {Color}
    *
@@ -2691,3 +2675,5 @@ function makeModelOptions(loader, modelType, options) {
     classificationType: options.classificationType,
   };
 }
+
+export default Model;

--- a/Source/Scene/Model/ModelFeature.js
+++ b/Source/Scene/Model/ModelFeature.js
@@ -30,7 +30,6 @@ import deprecationWarning from "../../Core/deprecationWarning.js";
  *     }
  * }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
  *
- * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
 export default function ModelFeature(options) {
   this._model = options.model;


### PR DESCRIPTION
This PR:

* adds some missing `@memberof Model.prototype` lines in `Model.js`
* `ModelFeature`'s constructor does not need to be marked as `@experimental` anymore. However, I intentionally left the tag for some of its members as they relate to 3D Tiles Next metadata.

@j9liu could you review?