### PR TITLE
Fixes typo in ReferenceFrame property in spec

### DIFF
--- a/Specs/DataSources/CompositePositionPropertySpec.js
+++ b/Specs/DataSources/CompositePositionPropertySpec.js
@@ -268,7 +268,7 @@ describe("DataSources/CompositePositionProperty", function () {
     right.intervals.addInterval(interval2);
     expect(left.equals(right)).toEqual(true);
 
-    right.referenceFrame = ReferenceFrame.INTERTIAL;
+    right.referenceFrame = ReferenceFrame.INERTIAL;
     expect(left.equals(right)).toEqual(false);
   });
 


### PR DESCRIPTION
The valid property name is [`ReferenceFrame.INERTIAL`](https://cesium.com/learn/cesiumjs/ref-doc/global.html?classFilter=referenceframe#ReferenceFrame).