### PR TITLE
Refactor "Source/ThirdParty" imports

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -331,3 +331,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Karthik Vaithin](https://github.com/kvaithin)
 - [Jonathan Meerson](https://github.com/yonzmeer)
 - [Jiang Heng](https://github.com/jiangheng90)
+- [Xin Chen](https://github.com/nshen)

--- a/Source/Core/Credit.js
+++ b/Source/Core/Credit.js
@@ -1,4 +1,4 @@
-import DOMPurify from "../ThirdParty/dompurify.js";
+import DOMPurify from "dompurify";
 import Check from "./Check.js";
 import defaultValue from "./defaultValue.js";
 import defined from "./defined.js";

--- a/Source/Core/GoogleEarthEnterpriseMetadata.js
+++ b/Source/Core/GoogleEarthEnterpriseMetadata.js
@@ -1,4 +1,4 @@
-import protobuf from "../ThirdParty/protobufjs.js";
+import * as protobuf from "protobufjs/dist/minimal/protobuf.js";
 import buildModuleUrl from "./buildModuleUrl.js";
 import Check from "./Check.js";
 import Credit from "./Credit.js";

--- a/Source/Core/IonResource.js
+++ b/Source/Core/IonResource.js
@@ -1,4 +1,4 @@
-import Uri from "../ThirdParty/Uri.js";
+import Uri from "urijs";
 import Check from "./Check.js";
 import Credit from "./Credit.js";
 import defaultValue from "./defaultValue.js";

--- a/Source/Core/Math.js
+++ b/Source/Core/Math.js
@@ -1,4 +1,4 @@
-import MersenneTwister from "../ThirdParty/mersenne-twister.js";
+import MersenneTwister from "mersenne-twister";
 import Check from "./Check.js";
 import defaultValue from "./defaultValue.js";
 import defined from "./defined.js";

--- a/Source/Core/PolygonPipeline.js
+++ b/Source/Core/PolygonPipeline.js
@@ -1,4 +1,4 @@
-import earcut from "../ThirdParty/earcut.js";
+import earcut from "earcut";
 import Cartesian2 from "./Cartesian2.js";
 import Cartesian3 from "./Cartesian3.js";
 import Cartographic from "./Cartographic.js";

--- a/Source/Core/RectangleCollisionChecker.js
+++ b/Source/Core/RectangleCollisionChecker.js
@@ -1,4 +1,4 @@
-import RBush from "../ThirdParty/rbush.js";
+import RBush from "rbush";
 import Check from "./Check.js";
 
 /**

--- a/Source/Core/RequestScheduler.js
+++ b/Source/Core/RequestScheduler.js
@@ -1,4 +1,4 @@
-import Uri from "../ThirdParty/Uri.js";
+import Uri from "urijs";
 import Check from "./Check.js";
 import defaultValue from "./defaultValue.js";
 import defer from "./defer.js";

--- a/Source/Core/Resource.js
+++ b/Source/Core/Resource.js
@@ -1,4 +1,4 @@
-import Uri from "../ThirdParty/Uri.js";
+import Uri from "urijs";
 import appendForwardSlash from "./appendForwardSlash.js";
 import Check from "./Check.js";
 import clone from "./clone.js";

--- a/Source/Core/TaskProcessor.js
+++ b/Source/Core/TaskProcessor.js
@@ -1,4 +1,4 @@
-import Uri from "../ThirdParty/Uri.js";
+import Uri from "urijs";
 import buildModuleUrl from "./buildModuleUrl.js";
 import defaultValue from "./defaultValue.js";
 import defer from "./defer.js";

--- a/Source/Core/TrustedServers.js
+++ b/Source/Core/TrustedServers.js
@@ -1,4 +1,4 @@
-import Uri from "../ThirdParty/Uri.js";
+import Uri from "urijs";
 import defined from "./defined.js";
 import DeveloperError from "./DeveloperError.js";
 

--- a/Source/Core/getAbsoluteUri.js
+++ b/Source/Core/getAbsoluteUri.js
@@ -1,4 +1,4 @@
-import Uri from "../ThirdParty/Uri.js";
+import Uri from "urijs";
 import defaultValue from "./defaultValue.js";
 import defined from "./defined.js";
 import DeveloperError from "./DeveloperError.js";

--- a/Source/Core/getBaseUri.js
+++ b/Source/Core/getBaseUri.js
@@ -1,4 +1,4 @@
-import Uri from "../ThirdParty/Uri.js";
+import Uri from "urijs";
 import defined from "./defined.js";
 import DeveloperError from "./DeveloperError.js";
 

--- a/Source/Core/getExtensionFromUri.js
+++ b/Source/Core/getExtensionFromUri.js
@@ -1,4 +1,4 @@
-import Uri from "../ThirdParty/Uri.js";
+import Uri from "urijs";
 import defined from "./defined.js";
 import DeveloperError from "./DeveloperError.js";
 

--- a/Source/Core/getFilenameFromUri.js
+++ b/Source/Core/getFilenameFromUri.js
@@ -1,4 +1,4 @@
-import Uri from "../ThirdParty/Uri.js";
+import Uri from "urijs";
 import defined from "./defined.js";
 import DeveloperError from "./DeveloperError.js";
 

--- a/Source/DataSources/CzmlDataSource.js
+++ b/Source/DataSources/CzmlDataSource.js
@@ -40,7 +40,7 @@ import HorizontalOrigin from "../Scene/HorizontalOrigin.js";
 import LabelStyle from "../Scene/LabelStyle.js";
 import ShadowMode from "../Scene/ShadowMode.js";
 import VerticalOrigin from "../Scene/VerticalOrigin.js";
-import Uri from "../ThirdParty/Uri.js";
+import Uri from "urijs";
 import BillboardGraphics from "./BillboardGraphics.js";
 import BoxGraphics from "./BoxGraphics.js";
 import CallbackProperty from "./CallbackProperty.js";

--- a/Source/DataSources/EntityCluster.js
+++ b/Source/DataSources/EntityCluster.js
@@ -13,7 +13,7 @@ import LabelCollection from "../Scene/LabelCollection.js";
 import PointPrimitive from "../Scene/PointPrimitive.js";
 import PointPrimitiveCollection from "../Scene/PointPrimitiveCollection.js";
 import SceneMode from "../Scene/SceneMode.js";
-import KDBush from "../ThirdParty/kdbush.js";
+import KDBush from "kdbush";
 
 /**
  * Defines how screen space objects (billboards, points, labels) are clustered.

--- a/Source/DataSources/GeoJsonDataSource.js
+++ b/Source/DataSources/GeoJsonDataSource.js
@@ -14,7 +14,7 @@ import Resource from "../Core/Resource.js";
 import RuntimeError from "../Core/RuntimeError.js";
 import HeightReference from "../Scene/HeightReference.js";
 import VerticalOrigin from "../Scene/VerticalOrigin.js";
-import topojson from "../ThirdParty/topojson.js";
+import * as topojson from "topojson-client";
 import BillboardGraphics from "./BillboardGraphics.js";
 import CallbackProperty from "./CallbackProperty.js";
 import ColorMaterialProperty from "./ColorMaterialProperty.js";

--- a/Source/DataSources/GpxDataSource.js
+++ b/Source/DataSources/GpxDataSource.js
@@ -20,7 +20,7 @@ import HeightReference from "../Scene/HeightReference.js";
 import HorizontalOrigin from "../Scene/HorizontalOrigin.js";
 import LabelStyle from "../Scene/LabelStyle.js";
 import VerticalOrigin from "../Scene/VerticalOrigin.js";
-import Autolinker from "../ThirdParty/Autolinker.js";
+import Autolinker from "autolinker";
 import BillboardGraphics from "./BillboardGraphics.js";
 import ConstantProperty from "./ConstantProperty.js";
 import DataSource from "./DataSource.js";

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -42,7 +42,7 @@ import LabelStyle from "../Scene/LabelStyle.js";
 import SceneMode from "../Scene/SceneMode.js";
 import Autolinker from "autolinker";
 import Uri from "urijs";
-import zip from "../ThirdParty/zip.js";
+import * as zip from "@zip.js/zip.js/lib/zip-no-worker.js";
 import getElement from "../Widgets/getElement.js";
 import BillboardGraphics from "./BillboardGraphics.js";
 import CompositePositionProperty from "./CompositePositionProperty.js";

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -40,7 +40,7 @@ import HeightReference from "../Scene/HeightReference.js";
 import HorizontalOrigin from "../Scene/HorizontalOrigin.js";
 import LabelStyle from "../Scene/LabelStyle.js";
 import SceneMode from "../Scene/SceneMode.js";
-import Autolinker from "../ThirdParty/Autolinker.js";
+import Autolinker from "autolinker";
 import Uri from "../ThirdParty/Uri.js";
 import zip from "../ThirdParty/zip.js";
 import getElement from "../Widgets/getElement.js";

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -41,7 +41,7 @@ import HorizontalOrigin from "../Scene/HorizontalOrigin.js";
 import LabelStyle from "../Scene/LabelStyle.js";
 import SceneMode from "../Scene/SceneMode.js";
 import Autolinker from "autolinker";
-import Uri from "../ThirdParty/Uri.js";
+import Uri from "urijs";
 import zip from "../ThirdParty/zip.js";
 import getElement from "../Widgets/getElement.js";
 import BillboardGraphics from "./BillboardGraphics.js";

--- a/Source/DataSources/exportKml.js
+++ b/Source/DataSources/exportKml.js
@@ -20,7 +20,7 @@ import TimeIntervalCollection from "../Core/TimeIntervalCollection.js";
 import HeightReference from "../Scene/HeightReference.js";
 import HorizontalOrigin from "../Scene/HorizontalOrigin.js";
 import VerticalOrigin from "../Scene/VerticalOrigin.js";
-import zip from "../ThirdParty/zip.js";
+import * as zip from "@zip.js/zip.js/lib/zip-no-worker.js";
 import BillboardGraphics from "./BillboardGraphics.js";
 import CompositePositionProperty from "./CompositePositionProperty.js";
 import ModelGraphics from "./ModelGraphics.js";

--- a/Source/Scene/CreditDisplay.js
+++ b/Source/Scene/CreditDisplay.js
@@ -5,7 +5,7 @@ import Credit from "../Core/Credit.js";
 import defaultValue from "../Core/defaultValue.js";
 import defined from "../Core/defined.js";
 import destroyObject from "../Core/destroyObject.js";
-import Uri from "../ThirdParty/Uri.js";
+import Uri from "urijs";
 
 const mobileWidth = 576;
 const lightboxHeight = 100;

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -7,7 +7,7 @@ import defined from "../Core/defined.js";
 import DeveloperError from "../Core/DeveloperError.js";
 import CesiumMath from "../Core/Math.js";
 import RuntimeError from "../Core/RuntimeError.js";
-import jsep from "../ThirdParty/jsep.js";
+import jsep from "jsep";
 import ExpressionNodeType from "./ExpressionNodeType.js";
 
 /**

--- a/Source/Scene/GltfBufferViewLoader.js
+++ b/Source/Scene/GltfBufferViewLoader.js
@@ -2,7 +2,7 @@ import Check from "../Core/Check.js";
 import defaultValue from "../Core/defaultValue.js";
 import defined from "../Core/defined.js";
 import hasExtension from "./hasExtension.js";
-import MeshoptDecoder from "../ThirdParty/meshoptimizer.js";
+import { MeshoptDecoder } from "meshoptimizer";
 import ResourceLoader from "./ResourceLoader.js";
 import ResourceLoaderState from "./ResourceLoaderState.js";
 

--- a/Source/Scene/GoogleEarthEnterpriseImageryProvider.js
+++ b/Source/Scene/GoogleEarthEnterpriseImageryProvider.js
@@ -13,7 +13,7 @@ import Request from "../Core/Request.js";
 import Resource from "../Core/Resource.js";
 import RuntimeError from "../Core/RuntimeError.js";
 import TileProviderError from "../Core/TileProviderError.js";
-import protobuf from "../ThirdParty/protobufjs.js";
+import * as protobuf from "protobufjs/dist/minimal/protobuf.js";
 
 /**
  * @private

--- a/Source/Scene/LabelCollection.js
+++ b/Source/Scene/LabelCollection.js
@@ -7,7 +7,7 @@ import destroyObject from "../Core/destroyObject.js";
 import DeveloperError from "../Core/DeveloperError.js";
 import Matrix4 from "../Core/Matrix4.js";
 import writeTextToCanvas from "../Core/writeTextToCanvas.js";
-import bitmapSDF from "../ThirdParty/bitmap-sdf.js";
+import bitmapSDF from "bitmap-sdf";
 import BillboardCollection from "./BillboardCollection.js";
 import BlendOption from "./BlendOption.js";
 import HeightReference from "./HeightReference.js";

--- a/Source/Scene/LabelCollection.js
+++ b/Source/Scene/LabelCollection.js
@@ -17,7 +17,7 @@ import LabelStyle from "./LabelStyle.js";
 import SDFSettings from "./SDFSettings.js";
 import TextureAtlas from "./TextureAtlas.js";
 import VerticalOrigin from "./VerticalOrigin.js";
-import GraphemeSplitter from "../ThirdParty/grapheme-splitter.js";
+import GraphemeSplitter from "grapheme-splitter";
 
 // A glyph represents a single character in a particular label.  It may or may
 // not have a billboard, depending on whether the texture info has an index into

--- a/Source/Scene/Model/PntsLoader.js
+++ b/Source/Scene/Model/PntsLoader.js
@@ -9,7 +9,7 @@ import DeveloperError from "../../Core/DeveloperError.js";
 import Matrix4 from "../../Core/Matrix4.js";
 import PrimitiveType from "../../Core/PrimitiveType.js";
 import WebGLConstants from "../../Core/WebGLConstants.js";
-import MersenneTwister from "../../ThirdParty/mersenne-twister.js";
+import MersenneTwister from "mersenne-twister";
 import Buffer from "../../Renderer/Buffer.js";
 import BufferUsage from "../../Renderer/BufferUsage.js";
 import AlphaMode from "../AlphaMode.js";

--- a/Source/Scene/PointCloud.js
+++ b/Source/Scene/PointCloud.js
@@ -23,7 +23,7 @@ import Pass from "../Renderer/Pass.js";
 import RenderState from "../Renderer/RenderState.js";
 import ShaderProgram from "../Renderer/ShaderProgram.js";
 import VertexArray from "../Renderer/VertexArray.js";
-import MersenneTwister from "../ThirdParty/mersenne-twister.js";
+import MersenneTwister from "mersenne-twister";
 import BlendingState from "./BlendingState.js";
 import Cesium3DTileBatchTable from "./Cesium3DTileBatchTable.js";
 import DracoLoader from "./DracoLoader.js";

--- a/Source/ThirdParty/Autolinker.js
+++ b/Source/ThirdParty/Autolinker.js
@@ -1,1 +1,0 @@
-export { default } from 'autolinker';

--- a/Source/ThirdParty/Uri.js
+++ b/Source/ThirdParty/Uri.js
@@ -1,1 +1,0 @@
-export { default } from 'urijs';

--- a/Source/ThirdParty/bitmap-sdf.js
+++ b/Source/ThirdParty/bitmap-sdf.js
@@ -1,2 +1,0 @@
-import calcSDF from 'bitmap-sdf';
-export { calcSDF as default };

--- a/Source/ThirdParty/dompurify.js
+++ b/Source/ThirdParty/dompurify.js
@@ -1,1 +1,0 @@
-export { default } from 'dompurify';

--- a/Source/ThirdParty/earcut.js
+++ b/Source/ThirdParty/earcut.js
@@ -1,2 +1,0 @@
-import earcut from 'earcut';
-export { earcut as default };

--- a/Source/ThirdParty/grapheme-splitter.js
+++ b/Source/ThirdParty/grapheme-splitter.js
@@ -1,1 +1,0 @@
-export { default } from 'grapheme-splitter';

--- a/Source/ThirdParty/jsep.js
+++ b/Source/ThirdParty/jsep.js
@@ -1,1 +1,0 @@
-export { default } from 'jsep';

--- a/Source/ThirdParty/kdbush.js
+++ b/Source/ThirdParty/kdbush.js
@@ -1,1 +1,0 @@
-export { default } from 'kdbush';

--- a/Source/ThirdParty/ktx-parse.js
+++ b/Source/ThirdParty/ktx-parse.js
@@ -1,2 +1,0 @@
-import { read } from 'ktx-parse';
-export { read as default };

--- a/Source/ThirdParty/lerc.js
+++ b/Source/ThirdParty/lerc.js
@@ -1,1 +1,0 @@
-export { default } from 'lerc';

--- a/Source/ThirdParty/mersenne-twister.js
+++ b/Source/ThirdParty/mersenne-twister.js
@@ -1,1 +1,0 @@
-export { default } from 'mersenne-twister';

--- a/Source/ThirdParty/meshoptimizer.js
+++ b/Source/ThirdParty/meshoptimizer.js
@@ -1,2 +1,0 @@
-import { MeshoptDecoder } from 'meshoptimizer';
-export { MeshoptDecoder as default };

--- a/Source/ThirdParty/nosleep.js
+++ b/Source/ThirdParty/nosleep.js
@@ -1,1 +1,0 @@
-export { default } from 'nosleep.js';

--- a/Source/ThirdParty/pako.js
+++ b/Source/ThirdParty/pako.js
@@ -1,2 +1,0 @@
-import pako from 'pako/lib/inflate.js';
-export { pako as default };

--- a/Source/ThirdParty/protobufjs.js
+++ b/Source/ThirdParty/protobufjs.js
@@ -1,2 +1,0 @@
-import * as protobuf from 'protobufjs/dist/minimal/protobuf.js';
-export { protobuf as default };

--- a/Source/ThirdParty/rbush.js
+++ b/Source/ThirdParty/rbush.js
@@ -1,1 +1,0 @@
-export { default } from 'rbush';

--- a/Source/ThirdParty/topojson.js
+++ b/Source/ThirdParty/topojson.js
@@ -1,2 +1,0 @@
-import * as topojson from 'topojson-client';
-export { topojson as default };

--- a/Source/ThirdParty/zip.js
+++ b/Source/ThirdParty/zip.js
@@ -1,2 +1,0 @@
-import * as zip from "@zip.js/zip.js/lib/zip-no-worker.js";
-export { zip as default };

--- a/Source/Widgets/VRButton/VRButtonViewModel.js
+++ b/Source/Widgets/VRButton/VRButtonViewModel.js
@@ -6,7 +6,7 @@ import EventHelper from "../../Core/EventHelper.js";
 import Fullscreen from "../../Core/Fullscreen.js";
 import OrthographicFrustum from "../../Core/OrthographicFrustum.js";
 import knockout from "../../ThirdParty/knockout.js";
-import NoSleep from "../../ThirdParty/nosleep.js";
+import NoSleep from "nosleep.js";
 import createCommand from "../createCommand.js";
 import getElement from "../getElement.js";
 

--- a/Source/WorkersES6/createVerticesFromHeightmap.js
+++ b/Source/WorkersES6/createVerticesFromHeightmap.js
@@ -3,7 +3,7 @@ import HeightmapEncoding from "../Core/HeightmapEncoding.js";
 import HeightmapTessellator from "../Core/HeightmapTessellator.js";
 import Rectangle from "../Core/Rectangle.js";
 import RuntimeError from "../Core/RuntimeError.js";
-import Lerc from "../ThirdParty/lerc.js";
+import Lerc from "lerc";
 import createTaskProcessorWorker from "./createTaskProcessorWorker.js";
 
 function createVerticesFromHeightmap(parameters, transferableObjects) {

--- a/Source/WorkersES6/decodeGoogleEarthEnterprisePacket.js
+++ b/Source/WorkersES6/decodeGoogleEarthEnterprisePacket.js
@@ -1,7 +1,7 @@
 import decodeGoogleEarthEnterpriseData from "../Core/decodeGoogleEarthEnterpriseData.js";
 import GoogleEarthEnterpriseTileInformation from "../Core/GoogleEarthEnterpriseTileInformation.js";
 import RuntimeError from "../Core/RuntimeError.js";
-import pako from "../ThirdParty/pako.js";
+import pako from "pako/lib/inflate.js";
 import createTaskProcessorWorker from "./createTaskProcessorWorker.js";
 
 // Datatype sizes

--- a/Source/WorkersES6/transcodeKTX2.js
+++ b/Source/WorkersES6/transcodeKTX2.js
@@ -6,7 +6,7 @@ import RuntimeError from "../Core/RuntimeError.js";
 import VulkanConstants from "../Core//VulkanConstants.js";
 import PixelDatatype from "../Renderer/PixelDatatype.js";
 import createTaskProcessorWorker from "./createTaskProcessorWorker.js";
-import ktx_parse from "../ThirdParty/ktx-parse.js";
+import ktx_parse from "ktx-parse";
 
 const faceOrder = [
   "positiveX",

--- a/Source/WorkersES6/transcodeKTX2.js
+++ b/Source/WorkersES6/transcodeKTX2.js
@@ -6,7 +6,7 @@ import RuntimeError from "../Core/RuntimeError.js";
 import VulkanConstants from "../Core//VulkanConstants.js";
 import PixelDatatype from "../Renderer/PixelDatatype.js";
 import createTaskProcessorWorker from "./createTaskProcessorWorker.js";
-import ktx_parse from "ktx-parse";
+import { read as ktx_parse } from "ktx-parse";
 
 const faceOrder = [
   "positiveX",


### PR DESCRIPTION
Fixes #10568 

As @ggetz mentioned, anywhere in the code which relies on these files should instead require the node module directly.