### PR TITLE
Remove "ThirdParty/mersenne-twister.js"

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -331,3 +331,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Karthik Vaithin](https://github.com/kvaithin)
 - [Jonathan Meerson](https://github.com/yonzmeer)
 - [Jiang Heng](https://github.com/jiangheng90)
+- [Xin Chen](https://github.com/nshen)

--- a/Source/Core/Math.js
+++ b/Source/Core/Math.js
@@ -1,4 +1,4 @@
-import MersenneTwister from "../ThirdParty/mersenne-twister.js";
+import MersenneTwister from "mersenne-twister";
 import Check from "./Check.js";
 import defaultValue from "./defaultValue.js";
 import defined from "./defined.js";

--- a/Source/Scene/Model/PntsLoader.js
+++ b/Source/Scene/Model/PntsLoader.js
@@ -9,7 +9,7 @@ import DeveloperError from "../../Core/DeveloperError.js";
 import Matrix4 from "../../Core/Matrix4.js";
 import PrimitiveType from "../../Core/PrimitiveType.js";
 import WebGLConstants from "../../Core/WebGLConstants.js";
-import MersenneTwister from "../../ThirdParty/mersenne-twister.js";
+import MersenneTwister from "mersenne-twister";
 import Buffer from "../../Renderer/Buffer.js";
 import BufferUsage from "../../Renderer/BufferUsage.js";
 import AlphaMode from "../AlphaMode.js";

--- a/Source/Scene/PointCloud.js
+++ b/Source/Scene/PointCloud.js
@@ -23,7 +23,7 @@ import Pass from "../Renderer/Pass.js";
 import RenderState from "../Renderer/RenderState.js";
 import ShaderProgram from "../Renderer/ShaderProgram.js";
 import VertexArray from "../Renderer/VertexArray.js";
-import MersenneTwister from "../ThirdParty/mersenne-twister.js";
+import MersenneTwister from "mersenne-twister";
 import BlendingState from "./BlendingState.js";
 import Cesium3DTileBatchTable from "./Cesium3DTileBatchTable.js";
 import DracoLoader from "./DracoLoader.js";

--- a/Source/ThirdParty/mersenne-twister.js
+++ b/Source/ThirdParty/mersenne-twister.js
@@ -1,1 +1,0 @@
-export { default } from 'mersenne-twister';


### PR DESCRIPTION
we should import mersenne-twister directly from node_modules. https://github.com/CesiumGS/cesium/issues/10568