### PR TITLE
Don't clean Workers/package.json

### DIFF
--- a/gulpfile.cjs
+++ b/gulpfile.cjs
@@ -79,6 +79,7 @@ const filesToClean = [
   "Source/Workers/**",
   "!Source/Workers/cesiumWorkerBootstrapper.js",
   "!Source/Workers/transferTypedArrayTest.js",
+  "!Source/Workers/package.json",
   "Source/ThirdParty/Shaders/*.js",
   "Source/**/*.d.ts",
   "Specs/SpecList.js",


### PR DESCRIPTION
17babe94e5c441441e866dca1575aaff679a3c9e added a package.json in Workers. It also added an override to .gitignore so that the file wasn't ignored, but didn't add an override to `gulp clean`. As a result, after running `gulp clean` or `npm run clean` the file is removed, and git status lists it as deleted.