### PR TITLE
Adds fix for error checking in sampleTerrain

### DIFF
--- a/Source/DataSources/ModelVisualizer.js
+++ b/Source/DataSources/ModelVisualizer.js
@@ -400,7 +400,7 @@ ModelVisualizer.prototype.getBoundingSphere = function (entity, result) {
       return BoundingSphereState.DONE;
     }
 
-    // Otherwise, in the case of terrain provider's with availability,
+    // Otherwise, in the case of terrain providers with availability,
     // since the model's bounding sphere may be clamped to a lower LOD tile if
     // the camera is initially far away, we use sampleTerrainMostDetailed to estimate
     // where the bounding sphere should be and set that as the target bounding sphere
@@ -411,6 +411,7 @@ ModelVisualizer.prototype.getBoundingSphere = function (entity, result) {
     // Check if the sample terrain function has failed.
     const sampleTerrainFailed = this._modelHash[entity.id].sampleTerrainFailed;
     if (sampleTerrainFailed) {
+      this._modelHash[entity.id].sampleTerrainFailed = false;
       return BoundingSphereState.FAILED;
     }
 

--- a/Source/DataSources/ModelVisualizer.js
+++ b/Source/DataSources/ModelVisualizer.js
@@ -16,7 +16,6 @@ import ModelAnimationLoop from "../Scene/ModelAnimationLoop.js";
 import ShadowMode from "../Scene/ShadowMode.js";
 import BoundingSphereState from "./BoundingSphereState.js";
 import Property from "./Property.js";
-import Ellipsoid from "../Core/Ellipsoid.js";
 import sampleTerrainMostDetailed from "../Core/sampleTerrainMostDetailed.js";
 import Cartographic from "../Core/Cartographic.js";
 
@@ -137,6 +136,7 @@ ModelVisualizer.prototype.update = function (time) {
         loadFail: false,
         awaitingSampleTerrain: false,
         clampedBoundingSphere: undefined,
+        sampleTerrainFailed: false,
       };
       modelHash[entity.id] = modelData;
 
@@ -373,28 +373,46 @@ ModelVisualizer.prototype.getBoundingSphere = function (entity, result) {
   if (!model.ready) {
     return BoundingSphereState.PENDING;
   }
+  const scene = this._scene;
+  const globe = scene.globe;
+  const ellipsoid = globe.ellipsoid;
+  const terrainProvider = globe.terrainProvider;
 
   const hasHeightReference = model.heightReference !== HeightReference.NONE;
   if (hasHeightReference) {
-    const scene = this._scene;
-    const globe = scene.globe;
-    const ellipsoid = globe.ellipsoid;
-    const terrainProvider = globe.terrainProvider;
+    // We cannot query the availability of the terrain provider till its ready, so the
+    // bounding sphere state will remain pending till the terrain provider is ready.
+    if (!terrainProvider.ready) {
+      return BoundingSphereState.PENDING;
+    }
 
     const modelMatrix = model.modelMatrix;
     scratchPosition.x = modelMatrix[12];
     scratchPosition.y = modelMatrix[13];
     scratchPosition.z = modelMatrix[14];
-    const cartoPosition = Ellipsoid.WGS84.cartesianToCartographic(
-      scratchPosition
-    );
+    const cartoPosition = ellipsoid.cartesianToCartographic(scratchPosition);
 
-    // Since the model's bounding sphere may be clamped to a lower LOD tile if
+    // For a terrain provider that does not have availability, like the EllipsoidTerrainProvider,
+    // we can directly assign the bounding sphere's center from model matrix's translation.
+    if (!defined(terrainProvider.availability)) {
+      BoundingSphere.clone(model.boundingSphere, result);
+      result.center = scratchPosition;
+      return BoundingSphereState.DONE;
+    }
+
+    // Otherwise, in the case of terrain provider's with availability,
+    // since the model's bounding sphere may be clamped to a lower LOD tile if
     // the camera is initially far away, we use sampleTerrainMostDetailed to estimate
     // where the bounding sphere should be and set that as the target bounding sphere
     // for the camera.
     let clampedBoundingSphere = this._modelHash[entity.id]
       .clampedBoundingSphere;
+
+    // Check if the sample terrain function has failed.
+    const sampleTerrainFailed = this._modelHash[entity.id].sampleTerrainFailed;
+    if (sampleTerrainFailed) {
+      return BoundingSphereState.FAILED;
+    }
 
     if (!defined(clampedBoundingSphere)) {
       clampedBoundingSphere = new BoundingSphere();
@@ -408,26 +426,33 @@ ModelVisualizer.prototype.getBoundingSphere = function (entity, result) {
         this._modelHash[entity.id].awaitingSampleTerrain = true;
         ModelVisualizer._sampleTerrainMostDetailed(terrainProvider, [
           scratchCartographic,
-        ]).then((result) => {
-          this._modelHash[entity.id].awaitingSampleTerrain = false;
+        ])
+          .then((result) => {
+            this._modelHash[entity.id].awaitingSampleTerrain = false;
 
-          const updatedCartographic = result[0];
-          if (model.heightReference === HeightReference.RELATIVE_TO_GROUND) {
-            updatedCartographic.height += cartoPosition.height;
-          }
-          ellipsoid.cartographicToCartesian(
-            updatedCartographic,
-            scratchPosition
-          );
+            const updatedCartographic = result[0];
+            if (model.heightReference === HeightReference.RELATIVE_TO_GROUND) {
+              updatedCartographic.height += cartoPosition.height;
+            }
+            ellipsoid.cartographicToCartesian(
+              updatedCartographic,
+              scratchPosition
+            );
 
-          // Update the bounding sphere with the updated position.
-          BoundingSphere.clone(model.boundingSphere, clampedBoundingSphere);
-          clampedBoundingSphere.center = scratchPosition;
+            // Update the bounding sphere with the updated position.
+            BoundingSphere.clone(model.boundingSphere, clampedBoundingSphere);
+            clampedBoundingSphere.center = scratchPosition;
 
-          this._modelHash[
-            entity.id
-          ].clampedBoundingSphere = BoundingSphere.clone(clampedBoundingSphere);
-        });
+            this._modelHash[
+              entity.id
+            ].clampedBoundingSphere = BoundingSphere.clone(
+              clampedBoundingSphere
+            );
+          })
+          .catch((e) => {
+            this._modelHash[entity.id].sampleTerrainFailed = true;
+            this._modelHash[entity.id].awaitingSampleTerrain = false;
+          });
       }
 
       // We will return the state as pending until the clamped bounding sphere is defined,


### PR DESCRIPTION
This PR follows up on a couple of loose ends from https://github.com/CesiumGS/cesium/pull/10631

- There is now a `catch` clause to make sure that if there's an error thrown in `sampleTerrainMostDetailed`, the `BoundingSphereState.FAILED` is returned.
- If a `terrainProvider` without `availability` is set, such as `EllipsoidTerrainProvider`, `flyTo` works for that too - it was previously broken. [Use this Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=rVVtb9owEP4rFl8WJGbaQbVCKVpHWTuphQpY+2GZKpMcYM3YyHboWMV/n19IgBQ6PiCBlDs/99zdc/ElElxpNKfwAhJdIg4vqAWKJlP86HxBWIic3RJcE8pBhoUSeg05QhqkNJ4HKeY0BllPAyMJRMOTkCweeEhQLIV8WbwIecgjl1BFwMHk84mxMy/SwzETQ3vovNhZG6FM8DHVSQzXMJYAygBPqzV8dnpWqXzKOBjROdDHShXXzqufa7UMNAE6nmhLcHJyspFiJhTVVHBzsuqpRaQ2T4RX8EiK6Yo1sDLk6yk553Z65/PZQu51YKARcINarGVwNgWFSRwHTuO0knr25KimIgZW92NAKJG0jsICxmXz65PpjME10aTsUKp8I0XC40eY0IjBtmXEHZp5ehpfXw9GIIFHkM3zdtuPO91O20Ys10MN+SjhkZNMgU5mQY6r6Eu1/3yrEqZiDoGXwrJ52P+l2StOXp6jCbRDopzD45YOv0ybWa5fLDGzVdq38ac9WxWo4Y+29XUE8lqjNWGa20QBg8jgMqWD4rpDr/o7A/PFZLWVdqRvMaMM0gJ5BY6SunV3df/wPOg+3/S6PzrXB1TRA3t35nDkQnrtu6vB98f23lpC/mtjA+R2W/fdubUZozMlaLru0qhDC3cbDudSbi/jfSmCjMRcmRRTfxOFn27659UUujzkZXAMR27onQ/E7mGEvE94HBGlzVU0N38gBBsSeQ88CVZ3yUbuB+2e496Yr4nWggcfvrEFGogPJdvVZTPdQSO2GIh0Ux3EcfVCFhnLa8oTkSlIYuluxRRM73YihVKhofSCQTNV8QudzoTUZnuxwOwtDWZvGd1UeZhEv0HjSKlUtkZ5M7QR0zmi8eWOTzeKGFHKnIwSxvr0r1kwzUbZ4N+EMkFiysfdOUhGFhY2OW3eeSfGuFE25u5I7XXIMf8D) to confirm this functionality.

