### PR TITLE
Remove thirdparty autolinker.js

### DIFF
--- a/Source/DataSources/GpxDataSource.js
+++ b/Source/DataSources/GpxDataSource.js
@@ -20,7 +20,7 @@ import HeightReference from "../Scene/HeightReference.js";
 import HorizontalOrigin from "../Scene/HorizontalOrigin.js";
 import LabelStyle from "../Scene/LabelStyle.js";
 import VerticalOrigin from "../Scene/VerticalOrigin.js";
-import Autolinker from "../ThirdParty/Autolinker.js";
+import Autolinker from "autolinker";
 import BillboardGraphics from "./BillboardGraphics.js";
 import ConstantProperty from "./ConstantProperty.js";
 import DataSource from "./DataSource.js";

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -40,7 +40,7 @@ import HeightReference from "../Scene/HeightReference.js";
 import HorizontalOrigin from "../Scene/HorizontalOrigin.js";
 import LabelStyle from "../Scene/LabelStyle.js";
 import SceneMode from "../Scene/SceneMode.js";
-import Autolinker from "../ThirdParty/Autolinker.js";
+import Autolinker from "autolinker";
 import Uri from "../ThirdParty/Uri.js";
 import zip from "../ThirdParty/zip.js";
 import getElement from "../Widgets/getElement.js";

--- a/Source/ThirdParty/Autolinker.js
+++ b/Source/ThirdParty/Autolinker.js
@@ -1,1 +1,0 @@
-export { default } from 'autolinker';


### PR DESCRIPTION
we should import autolinker.js directly from node_modules. https://github.com/CesiumGS/cesium/issues/10568