### PR TITLE
Remove thirdparty bitmap-sdf.js

### DIFF
--- a/Source/Scene/LabelCollection.js
+++ b/Source/Scene/LabelCollection.js
@@ -7,7 +7,7 @@ import destroyObject from "../Core/destroyObject.js";
 import DeveloperError from "../Core/DeveloperError.js";
 import Matrix4 from "../Core/Matrix4.js";
 import writeTextToCanvas from "../Core/writeTextToCanvas.js";
-import bitmapSDF from "../ThirdParty/bitmap-sdf.js";
+import bitmapSDF from "bitmap-sdf";
 import BillboardCollection from "./BillboardCollection.js";
 import BlendOption from "./BlendOption.js";
 import HeightReference from "./HeightReference.js";

--- a/Source/ThirdParty/bitmap-sdf.js
+++ b/Source/ThirdParty/bitmap-sdf.js
@@ -1,2 +1,0 @@
-import calcSDF from 'bitmap-sdf';
-export { calcSDF as default };


### PR DESCRIPTION
we should import bitmap-sdf directly from node_modules. https://github.com/CesiumGS/cesium/issues/10568