### PR TITLE
Remove thirdparty earcut.js

### DIFF
--- a/Source/Core/PolygonPipeline.js
+++ b/Source/Core/PolygonPipeline.js
@@ -1,4 +1,4 @@
-import earcut from "../ThirdParty/earcut.js";
+import earcut from "earcut";
 import Cartesian2 from "./Cartesian2.js";
 import Cartesian3 from "./Cartesian3.js";
 import Cartographic from "./Cartographic.js";

--- a/Source/ThirdParty/earcut.js
+++ b/Source/ThirdParty/earcut.js
@@ -1,2 +1,0 @@
-import earcut from 'earcut';
-export { earcut as default };


### PR DESCRIPTION
we should import earcut directly from node_modules. https://github.com/CesiumGS/cesium/issues/10568