### PR TITLE
remove thirdparty grapheme-splitter.js

### DIFF
--- a/Source/Scene/LabelCollection.js
+++ b/Source/Scene/LabelCollection.js
@@ -17,7 +17,7 @@ import LabelStyle from "./LabelStyle.js";
 import SDFSettings from "./SDFSettings.js";
 import TextureAtlas from "./TextureAtlas.js";
 import VerticalOrigin from "./VerticalOrigin.js";
-import GraphemeSplitter from "../ThirdParty/grapheme-splitter.js";
+import GraphemeSplitter from "grapheme-splitter";
 
 // A glyph represents a single character in a particular label.  It may or may
 // not have a billboard, depending on whether the texture info has an index into

--- a/Source/ThirdParty/grapheme-splitter.js
+++ b/Source/ThirdParty/grapheme-splitter.js
@@ -1,1 +1,0 @@
-export { default } from 'grapheme-splitter';


### PR DESCRIPTION
we should import grapheme-splitter directly from node_modules. https://github.com/CesiumGS/cesium/issues/10568