### PR TITLE
Remove thirdparty lerc.js

### DIFF
--- a/Source/ThirdParty/lerc.js
+++ b/Source/ThirdParty/lerc.js
@@ -1,1 +1,0 @@
-export { default } from 'lerc';

--- a/Source/WorkersES6/createVerticesFromHeightmap.js
+++ b/Source/WorkersES6/createVerticesFromHeightmap.js
@@ -3,7 +3,7 @@ import HeightmapEncoding from "../Core/HeightmapEncoding.js";
 import HeightmapTessellator from "../Core/HeightmapTessellator.js";
 import Rectangle from "../Core/Rectangle.js";
 import RuntimeError from "../Core/RuntimeError.js";
-import Lerc from "../ThirdParty/lerc.js";
+import Lerc from "lerc";
 import createTaskProcessorWorker from "./createTaskProcessorWorker.js";
 
 function createVerticesFromHeightmap(parameters, transferableObjects) {


### PR DESCRIPTION
we should import lerc directly from node_modules. https://github.com/CesiumGS/cesium/issues/10568