### PR TITLE
Remove thirdparty meshoptimizer.js

### DIFF
--- a/Source/Scene/GltfBufferViewLoader.js
+++ b/Source/Scene/GltfBufferViewLoader.js
@@ -2,7 +2,7 @@ import Check from "../Core/Check.js";
 import defaultValue from "../Core/defaultValue.js";
 import defined from "../Core/defined.js";
 import hasExtension from "./hasExtension.js";
-import MeshoptDecoder from "../ThirdParty/meshoptimizer.js";
+import { MeshoptDecoder } from "meshoptimizer";
 import ResourceLoader from "./ResourceLoader.js";
 import ResourceLoaderState from "./ResourceLoaderState.js";
 

--- a/Source/ThirdParty/meshoptimizer.js
+++ b/Source/ThirdParty/meshoptimizer.js
@@ -1,2 +1,0 @@
-import { MeshoptDecoder } from 'meshoptimizer';
-export { MeshoptDecoder as default };


### PR DESCRIPTION
we should import meshoptimizer directly from node_modules. https://github.com/CesiumGS/cesium/issues/10568