### PR TITLE
Remove thirdparty protobufjs.js

### DIFF
--- a/Source/Core/GoogleEarthEnterpriseMetadata.js
+++ b/Source/Core/GoogleEarthEnterpriseMetadata.js
@@ -1,4 +1,4 @@
-import protobuf from "../ThirdParty/protobufjs.js";
+import * as protobuf from "protobufjs/dist/minimal/protobuf.js";
 import buildModuleUrl from "./buildModuleUrl.js";
 import Check from "./Check.js";
 import Credit from "./Credit.js";

--- a/Source/Scene/GoogleEarthEnterpriseImageryProvider.js
+++ b/Source/Scene/GoogleEarthEnterpriseImageryProvider.js
@@ -13,7 +13,7 @@ import Request from "../Core/Request.js";
 import Resource from "../Core/Resource.js";
 import RuntimeError from "../Core/RuntimeError.js";
 import TileProviderError from "../Core/TileProviderError.js";
-import protobuf from "../ThirdParty/protobufjs.js";
+import * as protobuf from "protobufjs/dist/minimal/protobuf.js";
 
 /**
  * @private

--- a/Source/ThirdParty/protobufjs.js
+++ b/Source/ThirdParty/protobufjs.js
@@ -1,2 +1,0 @@
-import * as protobuf from 'protobufjs/dist/minimal/protobuf.js';
-export { protobuf as default };


### PR DESCRIPTION
we should import protobufjs.js directly from node_modules. https://github.com/CesiumGS/cesium/issues/10568