### PR TITLE
Fix for uncompressed draco attributes

### DIFF
--- a/Source/Scene/GltfLoader.js
+++ b/Source/Scene/GltfLoader.js
@@ -823,8 +823,12 @@ function finalizeDracoAttribute(
   }
 
   if (loadTypedArray) {
+    const componentDatatype = defined(vertexBufferLoader.quantization)
+      ? vertexBufferLoader.quantization.componentDatatype
+      : attribute.componentDatatype;
+
     attribute.typedArray = ComponentDatatype.createArrayBufferView(
-      vertexBufferLoader.quantization.componentDatatype,
+      componentDatatype,
       vertexBufferLoader.typedArray.buffer
     );
   }


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/10662

`loadAsTypedArray` in `GltfLoader` wasn't taking into account that Draco attributes can be losslessly compressed.
 
Here's the glTF extracted from the test data: [draco_outlines.gltf.zip](https://github.com/CesiumGS/cesium/files/9332089/draco_outlines.gltf.zip)