### PR TITLE
Make default exports more consistent

### DIFF
--- a/Source/Renderer/ShaderBuilder.js
+++ b/Source/Renderer/ShaderBuilder.js
@@ -53,7 +53,7 @@ import ShaderFunction from "./ShaderFunction.js";
  *
  * @private
  */
-export default function ShaderBuilder() {
+function ShaderBuilder() {
   // Some WebGL implementations require attribute 0 to always
   // be active, so the position attribute is tracked separately
   this._positionAttributeLine = undefined;
@@ -564,3 +564,5 @@ function generateFunctionLines(shaderBuilder) {
     fragmentLines: fragmentLines,
   };
 }
+
+export default ShaderBuilder;

--- a/Source/Renderer/ShaderFunction.js
+++ b/Source/Renderer/ShaderFunction.js
@@ -22,7 +22,7 @@
  *
  * @private
  */
-export default function ShaderFunction(signature) {
+function ShaderFunction(signature) {
   this.signature = signature;
   this.body = [];
 }
@@ -45,3 +45,5 @@ ShaderFunction.prototype.addLines = function (lines) {
 ShaderFunction.prototype.generateGlslLines = function () {
   return [].concat(this.signature, "{", this.body, "}");
 };
+
+export default ShaderFunction;

--- a/Source/Renderer/ShaderStruct.js
+++ b/Source/Renderer/ShaderStruct.js
@@ -23,7 +23,7 @@
  *
  * @private
  */
-export default function ShaderStruct(name) {
+function ShaderStruct(name) {
   this.name = name;
   this.fields = [];
 }
@@ -51,3 +51,5 @@ ShaderStruct.prototype.generateGlslLines = function () {
 
   return [].concat(`struct ${this.name}`, "{", fields, "};");
 };
+
+export default ShaderStruct;

--- a/Source/Scene/BatchTableHierarchy.js
+++ b/Source/Scene/BatchTableHierarchy.js
@@ -21,7 +21,7 @@ import RuntimeError from "../Core/RuntimeError.js";
  *
  * @private
  */
-export default function BatchTableHierarchy(options) {
+function BatchTableHierarchy(options) {
   this._classes = undefined;
   this._classIds = undefined;
   this._classIndexes = undefined;
@@ -552,3 +552,5 @@ BatchTableHierarchy.prototype.getClassName = function (batchId) {
   const instanceClass = this._classes[classId];
   return instanceClass.name;
 };
+
+export default BatchTableHierarchy;

--- a/Source/Scene/BatchTexture.js
+++ b/Source/Scene/BatchTexture.js
@@ -27,7 +27,7 @@ import Texture from "../Renderer/Texture.js";
  *
  * @private
  */
-export default function BatchTexture(options) {
+function BatchTexture(options) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.number("options.featuresLength", options.featuresLength);
   Check.typeOf.object("options.owner", options.owner);
@@ -570,3 +570,5 @@ BatchTexture.prototype.destroy = function () {
 
   return destroyObject(this);
 };
+
+export default BatchTexture;

--- a/Source/Scene/BufferLoader.js
+++ b/Source/Scene/BufferLoader.js
@@ -23,7 +23,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  *
  * @private
  */
-export default function BufferLoader(options) {
+function BufferLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const typedArray = options.typedArray;
   const resource = options.resource;
@@ -142,3 +142,5 @@ BufferLoader._fetchArrayBuffer = function (resource) {
 BufferLoader.prototype.unload = function () {
   this._typedArray = undefined;
 };
+
+export default BufferLoader;

--- a/Source/Scene/Cesium3DContentGroup.js
+++ b/Source/Scene/Cesium3DContentGroup.js
@@ -15,7 +15,7 @@ import defaultValue from "../Core/defaultValue.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function Cesium3DContentGroup(options) {
+function Cesium3DContentGroup(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("options.metadata", options.metadata);
@@ -40,3 +40,5 @@ Object.defineProperties(Cesium3DContentGroup.prototype, {
     },
   },
 });
+
+export default Cesium3DContentGroup;

--- a/Source/Scene/ContentMetadata.js
+++ b/Source/Scene/ContentMetadata.js
@@ -18,7 +18,7 @@ import MetadataEntity from "./MetadataEntity.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function ContentMetadata(options) {
+function ContentMetadata(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const content = options.content;
   const metadataClass = options.class;
@@ -180,3 +180,5 @@ ContentMetadata.prototype.setPropertyBySemantic = function (semantic, value) {
     this._class
   );
 };
+
+export default ContentMetadata;

--- a/Source/Scene/GltfBufferViewLoader.js
+++ b/Source/Scene/GltfBufferViewLoader.js
@@ -26,7 +26,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  *
  * @private
  */
-export default function GltfBufferViewLoader(options) {
+function GltfBufferViewLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const resourceCache = options.resourceCache;
   const gltf = options.gltf;
@@ -264,3 +264,5 @@ GltfBufferViewLoader.prototype.unload = function () {
   this._bufferLoader = undefined;
   this._typedArray = undefined;
 };
+
+export default GltfBufferViewLoader;

--- a/Source/Scene/GltfDracoLoader.js
+++ b/Source/Scene/GltfDracoLoader.js
@@ -25,7 +25,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  *
  * @private
  */
-export default function GltfDracoLoader(options) {
+function GltfDracoLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const resourceCache = options.resourceCache;
   const gltf = options.gltf;
@@ -246,3 +246,5 @@ GltfDracoLoader.prototype.unload = function () {
   this._decodedData = undefined;
   this._gltf = undefined;
 };
+
+export default GltfDracoLoader;

--- a/Source/Scene/GltfImageLoader.js
+++ b/Source/Scene/GltfImageLoader.js
@@ -27,7 +27,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  *
  * @private
  */
-export default function GltfImageLoader(options) {
+function GltfImageLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const resourceCache = options.resourceCache;
   const gltf = options.gltf;
@@ -323,3 +323,5 @@ GltfImageLoader.prototype.unload = function () {
 
 // Exposed for testing
 GltfImageLoader._loadImageFromTypedArray = loadImageFromTypedArray;
+
+export default GltfImageLoader;

--- a/Source/Scene/GltfIndexBufferLoader.js
+++ b/Source/Scene/GltfIndexBufferLoader.js
@@ -33,7 +33,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {Boolean} [options.loadTypedArray=false] Load the index buffer as a typed array.
  * @private
  */
-export default function GltfIndexBufferLoader(options) {
+function GltfIndexBufferLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const resourceCache = options.resourceCache;
   const gltf = options.gltf;
@@ -411,3 +411,5 @@ GltfIndexBufferLoader.prototype.unload = function () {
   this._buffer = undefined;
   this._gltf = undefined;
 };
+
+export default GltfIndexBufferLoader;

--- a/Source/Scene/GltfJsonLoader.js
+++ b/Source/Scene/GltfJsonLoader.js
@@ -34,7 +34,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  *
  * @private
  */
-export default function GltfJsonLoader(options) {
+function GltfJsonLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const resourceCache = options.resourceCache;
   const gltfResource = options.gltfResource;
@@ -291,3 +291,5 @@ GltfJsonLoader.prototype.unload = function () {
 GltfJsonLoader.prototype._fetchGltf = function () {
   return this._gltfResource.fetchArrayBuffer();
 };
+
+export default GltfJsonLoader;

--- a/Source/Scene/GltfLoader.js
+++ b/Source/Scene/GltfLoader.js
@@ -168,7 +168,7 @@ const GltfLoaderState = {
  * @param {Boolean} [options.renameBatchIdSemantic=false] If true, rename _BATCHID or BATCHID to _FEATURE_ID_0. This is used for .b3dm models
  * @private
  */
-export default function GltfLoader(options) {
+function GltfLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const gltfResource = options.gltfResource;
   let baseResource = options.baseResource;
@@ -2397,3 +2397,5 @@ GltfLoader.prototype.unload = function () {
   this._components = undefined;
   this._state = GltfLoaderState.UNLOADED;
 };
+
+export default GltfLoader;

--- a/Source/Scene/GltfStructuralMetadataLoader.js
+++ b/Source/Scene/GltfStructuralMetadataLoader.js
@@ -31,7 +31,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function GltfStructuralMetadataLoader(options) {
+function GltfStructuralMetadataLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const gltf = options.gltf;
   const extension = options.extension;
@@ -494,3 +494,5 @@ GltfStructuralMetadataLoader.prototype.unload = function () {
 
   this._structuralMetadata = undefined;
 };
+
+export default GltfStructuralMetadataLoader;

--- a/Source/Scene/GltfTextureLoader.js
+++ b/Source/Scene/GltfTextureLoader.js
@@ -34,7 +34,7 @@ import resizeImageToNextPowerOfTwo from "../Core/resizeImageToNextPowerOfTwo.js"
  *
  * @private
  */
-export default function GltfTextureLoader(options) {
+function GltfTextureLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const resourceCache = options.resourceCache;
   const gltf = options.gltf;
@@ -379,3 +379,5 @@ GltfTextureLoader.prototype.unload = function () {
   this._texture = undefined;
   this._gltf = undefined;
 };
+
+export default GltfTextureLoader;

--- a/Source/Scene/GltfVertexBufferLoader.js
+++ b/Source/Scene/GltfVertexBufferLoader.js
@@ -43,7 +43,7 @@ import ComponentDatatype from "../Core/ComponentDatatype.js";
  *
  * @private
  */
-export default function GltfVertexBufferLoader(options) {
+function GltfVertexBufferLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const resourceCache = options.resourceCache;
   const gltf = options.gltf;
@@ -526,3 +526,5 @@ GltfVertexBufferLoader.prototype.unload = function () {
   this._buffer = undefined;
   this._gltf = undefined;
 };
+
+export default GltfVertexBufferLoader;

--- a/Source/Scene/ImageBasedLighting.js
+++ b/Source/Scene/ImageBasedLighting.js
@@ -24,7 +24,7 @@ import OctahedralProjectedCubeMap from "./OctahedralProjectedCubeMap.js";
  * @param {Cartesian3[]} [options.sphericalHarmonicCoefficients] The third order spherical harmonic coefficients used for the diffuse color of image-based lighting.
  * @param {String} [options.specularEnvironmentMaps] A URL to a KTX2 file that contains a cube map of the specular lighting and the convoluted specular mipmaps.
  */
-export default function ImageBasedLighting(options) {
+function ImageBasedLighting(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const imageBasedLightingFactor = defined(options.imageBasedLightingFactor)
     ? Cartesian2.clone(options.imageBasedLightingFactor)
@@ -506,3 +506,5 @@ ImageBasedLighting.prototype.destroy = function () {
     this._specularEnvironmentMapAtlas.destroy();
   return destroyObject(this);
 };
+
+export default ImageBasedLighting;

--- a/Source/Scene/Implicit3DTileContent.js
+++ b/Source/Scene/Implicit3DTileContent.js
@@ -42,7 +42,7 @@ import parseBoundingVolumeSemantics from "./parseBoundingVolumeSemantics.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function Implicit3DTileContent(
+function Implicit3DTileContent(
   tileset,
   tile,
   resource,
@@ -1150,3 +1150,5 @@ Implicit3DTileContent.prototype.destroy = function () {
 Implicit3DTileContent._deriveBoundingBox = deriveBoundingBox;
 Implicit3DTileContent._deriveBoundingRegion = deriveBoundingRegion;
 Implicit3DTileContent._deriveBoundingVolumeS2 = deriveBoundingVolumeS2;
+
+export default Implicit3DTileContent;

--- a/Source/Scene/ImplicitAvailabilityBitstream.js
+++ b/Source/Scene/ImplicitAvailabilityBitstream.js
@@ -20,7 +20,7 @@ import RuntimeError from "../Core/RuntimeError.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function ImplicitAvailabilityBitstream(options) {
+function ImplicitAvailabilityBitstream(options) {
   const lengthBits = options.lengthBits;
   let availableCount = options.availableCount;
 
@@ -133,3 +133,5 @@ ImplicitAvailabilityBitstream.prototype.getBit = function (index) {
 
   return ((this._bitstream[byteIndex] >> bitIndex) & 1) === 1;
 };
+
+export default ImplicitAvailabilityBitstream;

--- a/Source/Scene/ImplicitMetadataView.js
+++ b/Source/Scene/ImplicitMetadataView.js
@@ -18,7 +18,7 @@ import defaultValue from "../Core/defaultValue.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function ImplicitMetadataView(options) {
+function ImplicitMetadataView(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const metadataTable = options.metadataTable;
   const metadataClass = options.class;
@@ -174,3 +174,5 @@ ImplicitMetadataView.prototype.setPropertyBySemantic = function (
     value
   );
 };
+
+export default ImplicitMetadataView;

--- a/Source/Scene/ImplicitSubtree.js
+++ b/Source/Scene/ImplicitSubtree.js
@@ -38,7 +38,7 @@ import ResourceCache from "./ResourceCache.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function ImplicitSubtree(
+function ImplicitSubtree(
   resource,
   json,
   subtreeView,
@@ -1142,3 +1142,5 @@ ImplicitSubtree.prototype.destroy = function () {
 
   return destroyObject(this);
 };
+
+export default ImplicitSubtree;

--- a/Source/Scene/ImplicitTileCoordinates.js
+++ b/Source/Scene/ImplicitTileCoordinates.js
@@ -48,7 +48,7 @@ import ImplicitSubdivisionScheme from "./ImplicitSubdivisionScheme.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function ImplicitTileCoordinates(options) {
+function ImplicitTileCoordinates(options) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.string("options.subdivisionScheme", options.subdivisionScheme);
   Check.typeOf.number("options.subtreeLevels", options.subtreeLevels);
@@ -643,3 +643,5 @@ ImplicitTileCoordinates.fromTileIndex = function (
     mortonIndex
   );
 };
+
+export default ImplicitTileCoordinates;

--- a/Source/Scene/ImplicitTileset.js
+++ b/Source/Scene/ImplicitTileset.js
@@ -22,11 +22,7 @@ import ImplicitSubdivisionScheme from "./ImplicitSubdivisionScheme.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function ImplicitTileset(
-  baseResource,
-  tileJson,
-  metadataSchema
-) {
+function ImplicitTileset(baseResource, tileJson, metadataSchema) {
   const implicitTiling = hasExtension(tileJson, "3DTILES_implicit_tiling")
     ? tileJson.extensions["3DTILES_implicit_tiling"]
     : tileJson.implicitTiling;
@@ -263,3 +259,5 @@ function makeTileHeaderTemplate(tileJson) {
 
   return template;
 }
+
+export default ImplicitTileset;

--- a/Source/Scene/JsonMetadataTable.js
+++ b/Source/Scene/JsonMetadataTable.js
@@ -20,7 +20,7 @@ import MetadataEntity from "./MetadataEntity.js";
 // that does not have a class definition.
 const emptyClass = {};
 
-export default function JsonMetadataTable(options) {
+function JsonMetadataTable(options) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.number.greaterThan("options.count", options.count, 0);
   Check.typeOf.object("options.properties", options.properties);
@@ -109,3 +109,5 @@ JsonMetadataTable.prototype.setProperty = function (index, propertyId, value) {
 
   return false;
 };
+
+export default JsonMetadataTable;

--- a/Source/Scene/MetadataSchemaLoader.js
+++ b/Source/Scene/MetadataSchemaLoader.js
@@ -25,7 +25,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function MetadataSchemaLoader(options) {
+function MetadataSchemaLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const schema = options.schema;
   const resource = options.resource;
@@ -141,3 +141,5 @@ function loadExternalSchema(schemaLoader) {
 MetadataSchemaLoader.prototype.unload = function () {
   this._schema = undefined;
 };
+
+export default MetadataSchemaLoader;

--- a/Source/Scene/Model/CustomShader.js
+++ b/Source/Scene/Model/CustomShader.js
@@ -119,7 +119,7 @@ import CustomShaderTranslucencyMode from "./CustomShaderTranslucencyMode.js";
  *   `
  * });
  */
-export default function CustomShader(options) {
+function CustomShader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
   /**
@@ -469,3 +469,5 @@ CustomShader.prototype.destroy = function () {
   this._textureManager = this._textureManager && this._textureManager.destroy();
   destroyObject(this);
 };
+
+export default CustomShader;

--- a/Source/Scene/Model/GeoJsonLoader.js
+++ b/Source/Scene/Model/GeoJsonLoader.js
@@ -40,7 +40,7 @@ import BufferUsage from "../../Renderer/BufferUsage.js";
  * @param {Object} options Object with the following properties:
  * @param {Object} options.geoJson The GeoJson object.
  */
-export default function GeoJsonLoader(options) {
+function GeoJsonLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
   //>>includeStart('debug', pragmas.debug);
@@ -527,3 +527,5 @@ function parse(geoJson, frameState) {
 GeoJsonLoader.prototype.unload = function () {
   this._components = undefined;
 };
+
+export default GeoJsonLoader;

--- a/Source/Scene/Model/Model3DTileContent.js
+++ b/Source/Scene/Model/Model3DTileContent.js
@@ -18,7 +18,7 @@ import Model from "./Model.js";
  * @constructor
  * @private
  */
-export default function Model3DTileContent(tileset, tile, resource) {
+function Model3DTileContent(tileset, tile, resource) {
   this._tileset = tileset;
   this._tile = tile;
   this._resource = resource;
@@ -439,3 +439,5 @@ function makeModelOptions(tileset, tile, content, additionalOptions) {
 
   return combine(additionalOptions, mainOptions);
 }
+
+export default Model3DTileContent;

--- a/Source/Scene/Model/ModelAlphaOptions.js
+++ b/Source/Scene/Model/ModelAlphaOptions.js
@@ -6,7 +6,7 @@
  *
  * @private
  */
-export default function ModelAlphaOptions() {
+function ModelAlphaOptions() {
   /**
    * Which render pass will render the model.
    *
@@ -22,3 +22,5 @@ export default function ModelAlphaOptions() {
    */
   this.alphaCutoff = undefined;
 }
+
+export default ModelAlphaOptions;

--- a/Source/Scene/Model/ModelArticulation.js
+++ b/Source/Scene/Model/ModelArticulation.js
@@ -18,7 +18,7 @@ import ModelArticulationStage from "./ModelArticulationStage.js";
  *
  * @private
  */
-export default function ModelArticulation(options) {
+function ModelArticulation(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
   const articulation = options.articulation;
@@ -210,3 +210,5 @@ ModelArticulation.prototype.apply = function () {
     node.transform = transform;
   }
 };
+
+export default ModelArticulation;

--- a/Source/Scene/Model/ModelArticulationStage.js
+++ b/Source/Scene/Model/ModelArticulationStage.js
@@ -21,7 +21,7 @@ const articulationEpsilon = CesiumMath.EPSILON16;
  *
  * @private
  */
-export default function ModelArticulationStage(options) {
+function ModelArticulationStage(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
   const stage = options.stage;
@@ -257,3 +257,5 @@ ModelArticulationStage.prototype.applyStageToMatrix = function (result) {
 
   return result;
 };
+
+export default ModelArticulationStage;

--- a/Source/Scene/Model/ModelFeature.js
+++ b/Source/Scene/Model/ModelFeature.js
@@ -31,7 +31,7 @@ import deprecationWarning from "../../Core/deprecationWarning.js";
  * }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
  *
  */
-export default function ModelFeature(options) {
+function ModelFeature(options) {
   this._model = options.model;
 
   // This ModelFeatureTable is not documented as an option since it is
@@ -242,3 +242,5 @@ ModelFeature.prototype.getPropertyIds = function (results) {
 ModelFeature.prototype.setProperty = function (name, value) {
   return this._featureTable.setProperty(this._featureId, name, value);
 };
+
+export default ModelFeature;

--- a/Source/Scene/Model/ModelFeatureTable.js
+++ b/Source/Scene/Model/ModelFeatureTable.js
@@ -23,7 +23,7 @@ import ModelType from "./ModelType.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function ModelFeatureTable(options) {
+function ModelFeatureTable(options) {
   const model = options.model;
   const propertyTable = options.propertyTable;
 
@@ -318,3 +318,5 @@ ModelFeatureTable.prototype.destroy = function (frameState) {
   this._batchTexture = this._batchTexture && this._batchTexture.destroy();
   destroyObject(this);
 };
+
+export default ModelFeatureTable;

--- a/Source/Scene/Model/ModelLightingOptions.js
+++ b/Source/Scene/Model/ModelLightingOptions.js
@@ -12,7 +12,7 @@ import LightingModel from "./LightingModel.js";
  *
  * @private
  */
-export default function ModelLightingOptions(options) {
+function ModelLightingOptions(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
   /**
@@ -25,3 +25,5 @@ export default function ModelLightingOptions(options) {
    */
   this.lightingModel = defaultValue(options.lightingModel, LightingModel.UNLIT);
 }
+
+export default ModelLightingOptions;

--- a/Source/Scene/Model/ModelNode.js
+++ b/Source/Scene/Model/ModelNode.js
@@ -21,7 +21,7 @@ import defined from "../../Core/defined.js";
  *
  * @see Model#getNode
  */
-export default function ModelNode(model, runtimeNode) {
+function ModelNode(model, runtimeNode) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("model", model);
   Check.typeOf.object("runtimeNode", runtimeNode);
@@ -120,3 +120,5 @@ Object.defineProperties(ModelNode.prototype, {
     },
   },
 });
+
+export default ModelNode;

--- a/Source/Scene/Model/ModelRenderResources.js
+++ b/Source/Scene/Model/ModelRenderResources.js
@@ -13,7 +13,7 @@ import DepthFunction from "../DepthFunction.js";
  *
  * @private
  */
-export default function ModelRenderResources(model) {
+function ModelRenderResources(model) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("model", model);
   //>>includeEnd('debug');
@@ -78,3 +78,5 @@ export default function ModelRenderResources(model) {
     })
   );
 }
+
+export default ModelRenderResources;

--- a/Source/Scene/Model/ModelRuntimeNode.js
+++ b/Source/Scene/Model/ModelRuntimeNode.js
@@ -25,7 +25,7 @@ import NodeStatisticsPipelineStage from "./NodeStatisticsPipelineStage.js";
  *
  * @private
  */
-export default function ModelRuntimeNode(options) {
+function ModelRuntimeNode(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
   const node = options.node;
@@ -599,3 +599,5 @@ ModelRuntimeNode.prototype.updateJointMatrices = function () {
     );
   }
 };
+
+export default ModelRuntimeNode;

--- a/Source/Scene/Model/ModelRuntimePrimitive.js
+++ b/Source/Scene/Model/ModelRuntimePrimitive.js
@@ -39,7 +39,7 @@ import WireframePipelineStage from "./WireframePipelineStage.js";
  *
  * @private
  */
-export default function ModelRuntimePrimitive(options) {
+function ModelRuntimePrimitive(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
   const primitive = options.primitive;
@@ -294,3 +294,5 @@ function inspectFeatureIds(model, node, primitive) {
     hasPropertyTable: false,
   };
 }
+
+export default ModelRuntimePrimitive;

--- a/Source/Scene/Model/ModelSceneGraph.js
+++ b/Source/Scene/Model/ModelSceneGraph.js
@@ -35,7 +35,7 @@ import Transforms from "../../Core/Transforms.js";
  *
  * @private
  */
-export default function ModelSceneGraph(options) {
+function ModelSceneGraph(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const components = options.modelComponents;
 
@@ -863,3 +863,5 @@ ModelSceneGraph.prototype.applyArticulations = function () {
     }
   }
 };
+
+export default ModelSceneGraph;

--- a/Source/Scene/Model/ModelSkin.js
+++ b/Source/Scene/Model/ModelSkin.js
@@ -16,7 +16,7 @@ import defaultValue from "../../Core/defaultValue.js";
  *
  * @private
  */
-export default function ModelSkin(options) {
+function ModelSkin(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("options.skin", options.skin);
@@ -176,3 +176,5 @@ ModelSkin.prototype.updateJointMatrices = function () {
     );
   }
 };
+
+export default ModelSkin;

--- a/Source/Scene/Model/ModelStatistics.js
+++ b/Source/Scene/Model/ModelStatistics.js
@@ -11,7 +11,7 @@ import Check from "../../Core/Check.js";
  *
  * @private
  */
-export default function ModelStatistics() {
+function ModelStatistics() {
   /**
    * Total number of points across all POINTS primitives in this model.
    *
@@ -193,3 +193,5 @@ ModelStatistics.prototype.addBatchTexture = function (batchTexture) {
     this._batchTextureIdMap.set(batchTexture._id, batchTexture);
   }
 };
+
+export default ModelStatistics;

--- a/Source/Scene/Model/ModelUtility.js
+++ b/Source/Scene/Model/ModelUtility.js
@@ -15,7 +15,7 @@ import Matrix3 from "../../Core/Matrix3.js";
  *
  * @private
  */
-export default function ModelUtility() {}
+function ModelUtility() {}
 
 /**
  * Create a function for reporting when a model fails to load
@@ -374,3 +374,5 @@ ModelUtility.checkSupportedExtensions = function (extensionsRequired) {
     }
   }
 };
+
+export default ModelUtility;

--- a/Source/Scene/Model/NodeRenderResources.js
+++ b/Source/Scene/Model/NodeRenderResources.js
@@ -14,7 +14,7 @@ import clone from "../../Core/clone.js";
  *
  * @private
  */
-export default function NodeRenderResources(modelRenderResources, runtimeNode) {
+function NodeRenderResources(modelRenderResources, runtimeNode) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("modelRenderResources", modelRenderResources);
   Check.typeOf.object("runtimeNode", runtimeNode);
@@ -163,3 +163,5 @@ export default function NodeRenderResources(modelRenderResources, runtimeNode) {
    */
   this.instancingReferencePoint2D = undefined;
 }
+
+export default NodeRenderResources;

--- a/Source/Scene/Model/PntsLoader.js
+++ b/Source/Scene/Model/PntsLoader.js
@@ -47,7 +47,7 @@ const MetallicRoughness = ModelComponents.MetallicRoughness;
  * @param {Number} [options.byteOffset] The byte offset to the beginning of the pnts contents in the array buffer
  * @param {Boolean} [options.loadAttributesFor2D=false] If true, load the positions buffer as a typed array for accurately projecting models to 2D.
  */
-export default function PntsLoader(options) {
+function PntsLoader(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
   const arrayBuffer = options.arrayBuffer;
@@ -708,3 +708,5 @@ PntsLoader.prototype.unload = function () {
   this._components = undefined;
   this._parsedContent = undefined;
 };
+
+export default PntsLoader;

--- a/Source/Scene/Model/PrimitiveOutlineGenerator.js
+++ b/Source/Scene/Model/PrimitiveOutlineGenerator.js
@@ -64,7 +64,7 @@ const MAX_GLTF_UINT8_INDEX = 255;
  *
  * @private
  */
-export default function PrimitiveOutlineGenerator(options) {
+function PrimitiveOutlineGenerator(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const triangleIndices = options.triangleIndices;
   const outlineIndices = options.outlineIndices;
@@ -685,3 +685,5 @@ EdgeSet.prototype.hasEdge = function (a, b) {
   const hash = small * this._originalVertexCount + big;
   return this._edges.has(hash);
 };
+
+export default PrimitiveOutlineGenerator;

--- a/Source/Scene/Model/PrimitiveRenderResources.js
+++ b/Source/Scene/Model/PrimitiveRenderResources.js
@@ -15,10 +15,7 @@ import ModelLightingOptions from "./ModelLightingOptions.js";
  *
  * @private
  */
-export default function PrimitiveRenderResources(
-  nodeRenderResources,
-  runtimePrimitive
-) {
+function PrimitiveRenderResources(nodeRenderResources, runtimePrimitive) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("nodeRenderResources", nodeRenderResources);
   Check.typeOf.object("runtimePrimitive", runtimePrimitive);
@@ -277,3 +274,5 @@ export default function PrimitiveRenderResources(
    */
   this.styleCommandsNeeded = undefined;
 }
+
+export default PrimitiveRenderResources;

--- a/Source/Scene/Model/TextureManager.js
+++ b/Source/Scene/Model/TextureManager.js
@@ -17,7 +17,7 @@ import TextureWrap from "../../Renderer/TextureWrap.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function TextureManager() {
+function TextureManager() {
   this._defaultTexture = undefined;
   this._textures = {};
   this._loadedImages = [];
@@ -240,3 +240,5 @@ TextureManager.prototype.destroy = function () {
   }
   return destroyObject(this);
 };
+
+export default TextureManager;

--- a/Source/Scene/Model/TextureUniform.js
+++ b/Source/Scene/Model/TextureUniform.js
@@ -28,7 +28,7 @@ import TextureWrap from "../../Renderer/TextureWrap.js";
  *
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function TextureUniform(options) {
+function TextureUniform(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   //>>includeStart('debug', pragmas.debug);
   const hasTypedArray = defined(options.typedArray);
@@ -70,3 +70,5 @@ export default function TextureUniform(options) {
     maximumAnisotropy: options.maximumAnisotropy,
   });
 }
+
+export default TextureUniform;

--- a/Source/Scene/Model/buildDrawCommand.js
+++ b/Source/Scene/Model/buildDrawCommand.js
@@ -28,7 +28,7 @@ import ModelDrawCommand from "./ModelDrawCommand.js";
  *
  * @private
  */
-export default function buildDrawCommand(primitiveRenderResources, frameState) {
+function buildDrawCommand(primitiveRenderResources, frameState) {
   const shaderBuilder = primitiveRenderResources.shaderBuilder;
   shaderBuilder.addVertexLines([ModelVS]);
   shaderBuilder.addFragmentLines([ModelFS]);
@@ -159,3 +159,5 @@ function getIndexBuffer(primitiveRenderResources) {
 
   return indices.buffer;
 }
+
+export default buildDrawCommand;

--- a/Source/Scene/ModelAnimationState.js
+++ b/Source/Scene/ModelAnimationState.js
@@ -1,7 +1,9 @@
 /**
  * @private
  */
-export default Object.freeze({
+const ModelAnimationState = {
   STOPPED: 0,
   ANIMATING: 1,
-});
+};
+
+export default Object.freeze(ModelAnimationState);

--- a/Source/Scene/Multiple3DTileContent.js
+++ b/Source/Scene/Multiple3DTileContent.js
@@ -32,12 +32,7 @@ import preprocess3DTileContent from "./preprocess3DTileContent.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function Multiple3DTileContent(
-  tileset,
-  tile,
-  tilesetResource,
-  contentsJson
-) {
+function Multiple3DTileContent(tileset, tile, tilesetResource, contentsJson) {
   this._tileset = tileset;
   this._tile = tile;
   this._tilesetResource = tilesetResource;
@@ -675,3 +670,5 @@ Multiple3DTileContent.prototype.destroy = function () {
   }
   return destroyObject(this);
 };
+
+export default Multiple3DTileContent;

--- a/Source/Scene/PropertyAttribute.js
+++ b/Source/Scene/PropertyAttribute.js
@@ -22,7 +22,7 @@ import PropertyAttributeProperty from "./PropertyAttributeProperty.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function PropertyAttribute(options) {
+function PropertyAttribute(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const propertyAttribute = options.propertyAttribute;
   const classDefinition = options.class;
@@ -156,3 +156,5 @@ PropertyAttribute.prototype.getProperty = function (propertyId) {
 
   return this._properties[propertyId];
 };
+
+export default PropertyAttribute;

--- a/Source/Scene/PropertyAttributeProperty.js
+++ b/Source/Scene/PropertyAttributeProperty.js
@@ -19,7 +19,7 @@ import defined from "../Core/defined.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function PropertyAttributeProperty(options) {
+function PropertyAttributeProperty(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const property = options.property;
   const classProperty = options.classProperty;
@@ -161,3 +161,5 @@ Object.defineProperties(PropertyAttributeProperty.prototype, {
     },
   },
 });
+
+export default PropertyAttributeProperty;

--- a/Source/Scene/ResourceCacheStatistics.js
+++ b/Source/Scene/ResourceCacheStatistics.js
@@ -10,7 +10,7 @@ import defined from "../Core/defined.js";
  *
  * @private
  */
-export default function ResourceCacheStatistics() {
+function ResourceCacheStatistics() {
   /**
    * The size of vertex buffers and index buffers loaded in the cache in bytes.
    *
@@ -179,3 +179,5 @@ ResourceCacheStatistics.prototype.removeLoader = function (loader) {
     this.texturesByteLength -= textureSize;
   }
 };
+
+export default ResourceCacheStatistics;

--- a/Source/Scene/ResourceLoader.js
+++ b/Source/Scene/ResourceLoader.js
@@ -17,7 +17,7 @@ import RuntimeError from "../Core/RuntimeError.js";
  *
  * @private
  */
-export default function ResourceLoader() {}
+function ResourceLoader() {}
 
 Object.defineProperties(ResourceLoader.prototype, {
   /**
@@ -135,3 +135,5 @@ ResourceLoader.prototype.destroy = function () {
   this.unload();
   return destroyObject(this);
 };
+
+export default ResourceLoader;

--- a/Source/Scene/SupportedImageFormats.js
+++ b/Source/Scene/SupportedImageFormats.js
@@ -9,8 +9,10 @@ import defaultValue from "../Core/defaultValue.js";
  *
  * @private
  */
-export default function SupportedImageFormats(options) {
+function SupportedImageFormats(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   this.webp = defaultValue(options.webp, false);
   this.basis = defaultValue(options.basis, false);
 }
+
+export default SupportedImageFormats;

--- a/Source/Scene/TileMetadata.js
+++ b/Source/Scene/TileMetadata.js
@@ -18,7 +18,7 @@ import MetadataEntity from "./MetadataEntity.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function TileMetadata(options) {
+function TileMetadata(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const tile = options.tile;
   const metadataClass = options.class;
@@ -180,3 +180,5 @@ TileMetadata.prototype.setPropertyBySemantic = function (semantic, value) {
     this._class
   );
 };
+
+export default TileMetadata;

--- a/Source/Scene/findGroupMetadata.js
+++ b/Source/Scene/findGroupMetadata.js
@@ -14,7 +14,7 @@ import hasExtension from "./hasExtension.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function findGroupMetadata(tileset, contentHeader) {
+function findGroupMetadata(tileset, contentHeader) {
   const metadataExtension = tileset.metadataExtension;
   if (!defined(metadataExtension)) {
     return undefined;
@@ -35,3 +35,5 @@ export default function findGroupMetadata(tileset, contentHeader) {
 
   return index >= 0 ? groups[index] : undefined;
 }
+
+export default findGroupMetadata;

--- a/Source/Scene/hasExtension.js
+++ b/Source/Scene/hasExtension.js
@@ -8,10 +8,12 @@ import defined from "../Core/defined.js";
  * @returns {Boolean} True if the extension is present
  * @private
  */
-export default function hasExtension(json, extensionName) {
+function hasExtension(json, extensionName) {
   return (
     defined(json) &&
     defined(json.extensions) &&
     defined(json.extensions[extensionName])
   );
 }
+
+export default hasExtension;

--- a/Source/Scene/parseBatchTable.js
+++ b/Source/Scene/parseBatchTable.js
@@ -35,7 +35,7 @@ import ModelUtility from "./Model/ModelUtility.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function parseBatchTable(options) {
+function parseBatchTable(options) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.number("options.count", options.count);
   Check.typeOf.object("options.batchTable", options.batchTable);
@@ -433,3 +433,5 @@ function initializeHierarchy(hierarchyExtension, binaryBody) {
 
 // exposed for testing
 parseBatchTable._deprecationWarning = deprecationWarning;
+
+export default parseBatchTable;

--- a/Source/Scene/parseBoundingVolumeSemantics.js
+++ b/Source/Scene/parseBoundingVolumeSemantics.js
@@ -19,7 +19,7 @@ import defined from "../Core/defined.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function parseBoundingVolumeSemantics(tileMetadata) {
+function parseBoundingVolumeSemantics(tileMetadata) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("tileMetadata", tileMetadata);
   //>>includeEnd('debug');
@@ -117,3 +117,5 @@ function parseMaximumHeight(prefix, tileMetadata) {
   const maximumHeightSemantic = `${prefix}_MAXIMUM_HEIGHT`;
   return tileMetadata.getPropertyBySemantic(maximumHeightSemantic);
 }
+
+export default parseBoundingVolumeSemantics;

--- a/Source/Scene/parseFeatureMetadataLegacy.js
+++ b/Source/Scene/parseFeatureMetadataLegacy.js
@@ -20,7 +20,7 @@ import MetadataTable from "./MetadataTable.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function parseFeatureMetadataLegacy(options) {
+function parseFeatureMetadataLegacy(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const extension = options.extension;
 
@@ -135,3 +135,5 @@ function reformatChannels(channelsString) {
   }
   return result;
 }
+
+export default parseFeatureMetadataLegacy;

--- a/Source/Scene/parseStructuralMetadata.js
+++ b/Source/Scene/parseStructuralMetadata.js
@@ -20,7 +20,7 @@ import MetadataTable from "./MetadataTable.js";
  * @private
  * @experimental This feature is using part of the 3D Tiles spec that is not final and is subject to change without Cesium's standard deprecation policy.
  */
-export default function parseStructuralMetadata(options) {
+function parseStructuralMetadata(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
   const extension = options.extension;
 
@@ -98,3 +98,5 @@ export default function parseStructuralMetadata(options) {
     extensions: extension.extensions,
   });
 }
+
+export default parseStructuralMetadata;

--- a/Source/Scene/preprocess3DTileContent.js
+++ b/Source/Scene/preprocess3DTileContent.js
@@ -24,7 +24,7 @@ import Cesium3DTileContentType from "./Cesium3DTileContentType.js";
  * @return {PreprocessedContent}
  * @private
  */
-export default function preprocess3DTileContent(arrayBuffer) {
+function preprocess3DTileContent(arrayBuffer) {
   const uint8Array = new Uint8Array(arrayBuffer);
   let contentType = getMagic(uint8Array);
 
@@ -90,3 +90,5 @@ function getJsonContent(uint8Array) {
 
   return json;
 }
+
+export default preprocess3DTileContent;

--- a/Specs/ImplicitTilingTester.js
+++ b/Specs/ImplicitTilingTester.js
@@ -6,7 +6,7 @@ import MetadataTester from "./MetadataTester.js";
  * Class to generate implicit subtrees for implicit tiling unit tests
  * @private
  */
-export default function ImplicitTilingTester() {}
+function ImplicitTilingTester() {}
 
 /**
  * Description of a single availability bitstream
@@ -602,3 +602,5 @@ function makeBuffers(bufferViewsU8, subtreeJson) {
     external: externalBufferU8,
   };
 }
+
+export default ImplicitTilingTester;

--- a/Specs/ShaderBuilderTester.js
+++ b/Specs/ShaderBuilderTester.js
@@ -1,4 +1,4 @@
-export default function ShaderBuilderTester() {}
+function ShaderBuilderTester() {}
 
 function expectHasLine(linesArray, line) {
   expect(linesArray.indexOf(line)).not.toBe(-1);
@@ -198,3 +198,5 @@ ShaderBuilderTester.expectFragmentLinesEqual = function (
     expectedFragmentLines
   );
 };
+
+export default ShaderBuilderTester;

--- a/Specs/concatTypedArrays.js
+++ b/Specs/concatTypedArrays.js
@@ -1,4 +1,4 @@
-export default function concatTypedArrays(arrays) {
+function concatTypedArrays(arrays) {
   let i;
   const length = arrays.length;
 
@@ -21,3 +21,5 @@ export default function concatTypedArrays(arrays) {
   }
   return buffer;
 }
+
+export default concatTypedArrays;

--- a/Specs/dataUriToBuffer.js
+++ b/Specs/dataUriToBuffer.js
@@ -1,4 +1,4 @@
-export default function dataUriToBuffer(dataUri) {
+function dataUriToBuffer(dataUri) {
   const binaryString = atob(dataUri.split(",")[1]);
   const length = binaryString.length;
   const bytes = new Uint8Array(length);
@@ -7,3 +7,5 @@ export default function dataUriToBuffer(dataUri) {
   }
   return bytes;
 }
+
+export default dataUriToBuffer;

--- a/Specs/generateJsonBuffer.js
+++ b/Specs/generateJsonBuffer.js
@@ -1,6 +1,6 @@
 import { defaultValue } from "../Source/Cesium.js";
 
-export default function generateJsonBuffer(json, byteOffset, boundary) {
+function generateJsonBuffer(json, byteOffset, boundary) {
   let i;
   const jsonString = JSON.stringify(json);
 
@@ -22,3 +22,5 @@ export default function generateJsonBuffer(json, byteOffset, boundary) {
 
   return buffer;
 }
+
+export default generateJsonBuffer;

--- a/Specs/loaderProcess.js
+++ b/Specs/loaderProcess.js
@@ -1,4 +1,4 @@
-export default function loaderProcess(loader, scene) {
+function loaderProcess(loader, scene) {
   // Normally scene is responsible for resetting the job scheduler every frame
   // but since we're not calling scene.renderForSpecs we need to reset budgets
   // explicitly. This is only required for loaders that use the job scheduler
@@ -7,3 +7,5 @@ export default function loaderProcess(loader, scene) {
   loader.process(scene.frameState);
   scene.jobScheduler.resetBudgets();
 }
+
+export default loaderProcess;

--- a/Specs/waitForLoaderProcess.js
+++ b/Specs/waitForLoaderProcess.js
@@ -1,7 +1,7 @@
 import loaderProcess from "./loaderProcess.js";
 import pollToPromise from "./pollToPromise.js";
 
-export default function waitForLoaderProcess(loader, scene) {
+function waitForLoaderProcess(loader, scene) {
   return new Promise(function (resolve, reject) {
     let loaderFinished = false;
 
@@ -24,3 +24,5 @@ export default function waitForLoaderProcess(loader, scene) {
       });
   });
 }
+
+export default waitForLoaderProcess;


### PR DESCRIPTION
This PR sweeps through the model code and replaces the pattern

```js
export default function Foo() {
}
```

with

```js
function Foo() {
}

export default Foo;
```

This is for 2 reasons:

1. Sometimes JSDoc gets confused with `export default function` and some member variables do not show up in the docs. The other way works fine.
2. Consistency with the rest of the codebase

@j9liu could you review when you get a chance?