### PR TITLE
Make it easier to debug render tests

### DIFF
--- a/Documentation/Contributors/TestingGuide/README.md
+++ b/Documentation/Contributors/TestingGuide/README.md
@@ -36,6 +36,7 @@ All new code should have 100% code coverage and should pass all tests. Always ru
     - [Testing Exceptions](#testing-exceptions)
     - [Before and After Tests and Suites](#before-and-after-tests-and-suites)
     - [Rendering Tests](#rendering-tests)
+      - [Debugging Rendering Tests](#debugging-rendering-tests)
     - [GLSL](#glsl)
     - [Spies](#spies)
     - [Test Data and Services](#test-data-and-services)
@@ -499,6 +500,46 @@ it("can declare automatic uniforms", function () {
     context: context,
     fragmentShader: fs,
   }).contextToRender();
+});
+```
+
+#### Debugging Rendering Tests
+
+Rendering tests typically render to a 1x1 pixel canvas. This is so each test runs as
+quickly as possible. However, when regressions happen, it is difficult to tell why the test is failing since the image is too small to see. To make debugging tests easier,
+`createScene()` has options to adjust the canvas size to give a better preview of what
+the camera sees.
+
+An example debug workflow might look like this:
+
+1. Use `fit()` to focus on the test that is failing.
+2. Use the `debugWidth` and `debugHeight` options for `createScene()` to make the canvas larger.
+3. Put a breakpoint in the code around where the first rendering code happens, such as a call of `scene.renderForSpecs()`.
+4. Step through the test. After each render, check the browser window to see the frame that was just rendered.
+
+```js
+beforeAll(function () {
+  scene = createScene({
+    // Create a 300x300 px canvas so we can see what the camera sees.
+    // This is intended for temporary debugging, do not commit these debug options.
+    debugWidth: 300,
+    debugHeight: 300,
+  });
+});
+
+// Focus the test that is failing
+fit("test that is failing", function () {
+  // Start a breakpoint here
+  scene.renderForSpecs();
+  // After each render call, check the browser for the frame that was just rendered.
+
+  // ...
+
+  scene.renderForSpecs();
+
+  // ... and so on
+
+  scene.renderForSpecs();
 });
 ```
 

--- a/Specs/createScene.js
+++ b/Specs/createScene.js
@@ -12,8 +12,16 @@ import getWebGLStub from "./getWebGLStub.js";
 function createScene(options) {
   options = defaultValue(options, {});
 
+  // Render tests can be difficult to debug. Let the caller choose a larger
+  // canvas size temporarily. By stepping through a render test, you can see
+  // what the camera sees after each render call.
+  const debugWidth = options.debugWidth;
+  const debugHeight = options.debugHeight;
+
   // save the canvas so we don't try to clone an HTMLCanvasElement
-  const canvas = defined(options.canvas) ? options.canvas : createCanvas();
+  const canvas = defined(options.canvas)
+    ? options.canvas
+    : createCanvas(debugWidth, debugHeight);
   options.canvas = undefined;
 
   options = clone(options, true);


### PR DESCRIPTION
Given that render tests render to 1x1 px canvases, it can be a pain to debug because it's hard to tell what the camera is seeing. Over the weekend I had an epiphany: What if you could temporarily make the canvas size bigger while debugging? That would be a lot easier than trying to replicate the test setup in Sandcastle.

This PR does just that. it adds the parameters `debugWidth` and `debugHeight` to `createScene()`. Example usage:

1. Use `fit()` on the render test to be debugged so only that test runs
2. Find the `createScene()` call in `beforeAll()`/`beforeEach()`, and set a larger canvas size:

```js
scene = createScene({
  debugWidth: 300,
  debugHeight: 300
});
```
3. Put a breakpoint in the test around when the first render call is
4. Step through the test using the debugger. After every call to `scene.renderForSpecs()`, check the browser window, you'll see a better picture of what was rendered
![image](https://user-images.githubusercontent.com/8422414/184663349-6d4b44cf-e53b-4faf-8c2e-ca969a12c5a0.png)

@sanjeetsuhag could you review? Curious if you have any thoughts of other improvements for test debugging