### PR TITLE
Apply instancing to normals in `Model`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,7 +31,7 @@
 ##### Fixes :wrench:
 
 - Fixed bug with `Viewer.flyTo` where camera could go underground when target is an `Entity` with `ModelGraphics` with `HeightReference.CLAMP_TO_GROUND` or `HeightReference.RELATIVE_TO_GROUND`. [#10631](https://github.com/CesiumGS/cesium/pull/10631)
-- Fixed the incorrect lighting of models with the `EXT_mesh_gpu_instancing` extension. [#10690](https://github.com/CesiumGS/cesium/pull/10690)
+- Fixed the incorrect lighting of instanced models. [#10690](https://github.com/CesiumGS/cesium/pull/10690)
 
 ### 1.96 - 2022-08-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@
 ##### Fixes :wrench:
 
 - Fixed bug with `Viewer.flyTo` where camera could go underground when target is an `Entity` with `ModelGraphics` with `HeightReference.CLAMP_TO_GROUND` or `HeightReference.RELATIVE_TO_GROUND`. [#10631](https://github.com/CesiumGS/cesium/pull/10631)
+- Fixed the incorrect lighting of models with the `EXT_mesh_gpu_instancing` extension. [#10690](https://github.com/CesiumGS/cesium/pull/10690)
 
 ### 1.96 - 2022-08-01
 

--- a/Source/Shaders/Model/InstancingStageVS.glsl
+++ b/Source/Shaders/Model/InstancingStageVS.glsl
@@ -1,9 +1,12 @@
 void instancingStage(inout ProcessedAttributes attributes) 
 {
     vec3 positionMC = attributes.positionMC;
+    vec3 normalMC = attributes.normalMC;
     
     mat4 instancingTransform = getInstancingTransform();
+    
     attributes.positionMC = (instancingTransform * vec4(positionMC, 1.0)).xyz;
+    attributes.normalMC = (instancingTransform * vec4(normalMC, 0.0)).xyz;
 
     #ifdef USE_2D_INSTANCING
     mat4 instancingTransform2D = getInstancingTransform2D();

--- a/Source/Shaders/Model/LegacyInstancingStageVS.glsl
+++ b/Source/Shaders/Model/LegacyInstancingStageVS.glsl
@@ -4,13 +4,16 @@ void legacyInstancingStage(
     out mat3 instanceModelViewInverseTranspose)
 {
     vec3 positionMC = attributes.positionMC;
-    mat4 instancingTransform = getInstancingTransform();
+    vec3 normalMC = attributes.normalMC;
 
+    mat4 instancingTransform = getInstancingTransform();
+ 
     mat4 instanceModel = instancingTransform * u_instance_nodeTransform;
     instanceModelView = u_instance_modifiedModelView;
     instanceModelViewInverseTranspose = mat3(u_instance_modifiedModelView * instanceModel);
 
     attributes.positionMC = (instanceModel * vec4(positionMC, 1.0)).xyz;
+    attributes.normalMC = (instanceModel * vec4(normalMC, 0.0)).xyz;
     
     #ifdef USE_2D_INSTANCING
     mat4 instancingTransform2D = getInstancingTransform2D();


### PR DESCRIPTION
Fixes #10659. The `InstancingVS` and `LegacyInstancingVS` stages were not applying instanced transforms to normals, resulting in the exact same lighting across models with different orientations. Here's what the model in the issue looks like after the fix:

| Image | Note |
| ------- | ----- |
| ![result1](https://user-images.githubusercontent.com/32226860/184689738-879b31fe-b603-4390-81db-3e0f23260307.png) | The innermost face of the model is lit differently for the two instances. |
| ![result2](https://user-images.githubusercontent.com/32226860/184689748-8265fb9d-7eb3-4a0a-8ad5-d5f058aae59c.png) | The lighting is consistent with the orientation of the faces. |
