### PR TITLE
Fixes zoomTo/flyTo issue with EllipsoidTerrainProvider

### DIFF
--- a/Source/DataSources/ModelVisualizer.js
+++ b/Source/DataSources/ModelVisualizer.js
@@ -395,8 +395,16 @@ ModelVisualizer.prototype.getBoundingSphere = function (entity, result) {
     // For a terrain provider that does not have availability, like the EllipsoidTerrainProvider,
     // we can directly assign the bounding sphere's center from model matrix's translation.
     if (!defined(terrainProvider.availability)) {
+      // Regardless of what the original model's position is set to, for CLAMP_TO_GROUND, we reset it to 0
+      // when computing the position to zoom/fly to.
+      if (model.heightReference === HeightReference.CLAMP_TO_GROUND) {
+        cartoPosition.height = 0;
+      }
+
+      const scratchPosition = ellipsoid.cartographicToCartesian(cartoPosition);
       BoundingSphere.clone(model.boundingSphere, result);
       result.center = scratchPosition;
+
       return BoundingSphereState.DONE;
     }
 

--- a/Specs/DataSources/ModelVisualizerSpec.js
+++ b/Specs/DataSources/ModelVisualizerSpec.js
@@ -445,7 +445,10 @@ describe(
 
     it("Computes bounding sphere with height reference clamp to ground on terrain provider without availability", function () {
       // Setup a position for the model.
-      const position = Cartesian3.fromDegrees(149.515332, -34.984799);
+      const longitude = CesiumMath.toRadians(149.515332);
+      const latitude = CesiumMath.toRadians(-34.984799);
+      const height = 1000;
+      const position = Cartesian3.fromRadians(longitude, latitude, height);
 
       // Initialize the Entity and the ModelGraphics.
       const time = JulianDate.now();
@@ -476,7 +479,19 @@ describe(
         return state !== BoundingSphereState.PENDING;
       }).then(() => {
         expect(state).toBe(BoundingSphereState.DONE);
-        expect(result.center).toEqual(position);
+        // Ensure that the clamped position has height set to 0.
+        const cartographic = globe.ellipsoid.cartesianToCartographic(
+          result.center
+        );
+        expect(cartographic.height).toEqualEpsilon(0, CesiumMath.EPSILON6);
+        expect(cartographic.latitude).toEqualEpsilon(
+          latitude,
+          CesiumMath.EPSILON6
+        );
+        expect(cartographic.longitude).toEqualEpsilon(
+          longitude,
+          CesiumMath.EPSILON6
+        );
       });
     });
 
@@ -558,7 +573,10 @@ describe(
 
     it("Computes bounding sphere with height reference relative to ground on terrain provider without availability", function () {
       // Setup a position for the model.
-      const position = Cartesian3.fromDegrees(149.515332, -34.984799, 1000);
+      const longitude = CesiumMath.toRadians(149.515332);
+      const latitude = CesiumMath.toRadians(-34.984799);
+      const height = 1000;
+      const position = Cartesian3.fromRadians(longitude, latitude, height);
 
       // Initialize the Entity and the ModelGraphics.
       const time = JulianDate.now();
@@ -588,8 +606,19 @@ describe(
         state = visualizer.getBoundingSphere(testObject, result);
         return state !== BoundingSphereState.PENDING;
       }).then(() => {
-        expect(state).toBe(BoundingSphereState.DONE);
-        expect(result.center).toEqual(position);
+        // Ensure that the clamped position has height set to 0.
+        const cartographic = globe.ellipsoid.cartesianToCartographic(
+          result.center
+        );
+        expect(cartographic.height).toEqualEpsilon(height, CesiumMath.EPSILON6);
+        expect(cartographic.latitude).toEqualEpsilon(
+          latitude,
+          CesiumMath.EPSILON6
+        );
+        expect(cartographic.longitude).toEqualEpsilon(
+          longitude,
+          CesiumMath.EPSILON6
+        );
       });
     });
 

--- a/Specs/DataSources/ModelVisualizerSpec.js
+++ b/Specs/DataSources/ModelVisualizerSpec.js
@@ -606,7 +606,6 @@ describe(
         state = visualizer.getBoundingSphere(testObject, result);
         return state !== BoundingSphereState.PENDING;
       }).then(() => {
-        // Ensure that the clamped position has height set to 0.
         const cartographic = globe.ellipsoid.cartesianToCartographic(
           result.center
         );


### PR DESCRIPTION
### Overview

This PR fixes the behavior of `Viewer.flyTo` and `Viewer.zoomTo` when using `EllipsoidTerrainProvider` with a `HeightReference` other than `NONE`. This was not initially caught because in the Sandcastles used in the previous related PRs (https://github.com/CesiumGS/cesium/pull/10631 and https://github.com/CesiumGS/cesium/pull/10665), the Viewer was initialized with world terrain, despite the UI showing that the `EllipspoidTerrainProvider` was selected.

### Steps to Reproduce
In this [Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=rVVtTxpBEP4rG754JHTBoqkgklq02kTBANWkvcYsdwNuurdLdvewaPjv3RfueBGUDySQ3Mw+88zMM7dzkeBKowmFZ5DoDHF4Ri1QNE3wvfMFYSFydktwTSgHGRZK6DXks+JpyEMeuXgVAQcT7nmwM0+zwxETA3vovNhZS6FM8BHVaQwXMJIAygAPj2r4+PC4Wv2cczCi10Cfqke4dnL0pVbLQU9AR0/aElQqlaUUY6GopoKbk3lvLSK1eSK8iodSJHPWIOToTT0l51xN73w+W8i9Dgw0Am5Q04UMzqagMInj4NXGZJXU8ydHlYgYWB05CEKppHUUFjAum1+PJGMGF0STskOp8pUUKY/v4YlGDFYtI+7AjMfT+Pq6MAQJPIJ61vv1qh+3O+1LGzEr5UMN+TDlkZNMgU7HwRpX0Zdq/+utSkjEBAIvhWXzsI+l2SrOujx7E2iDRGsOj5s5/CxrZrZ4scTYVmnfxt/2bF6ghn/a1tcWyGuNFoRZbhMFDCKDy5UOiosOvervDMwXk9dW2pC+xYwySAvkFdhL6tbN+e3dY7/zeNXt/Gxf7FBFF+zdmcCeC+le3pz3f9xfbq0l5H+WNoAGKc3yupNiQmOQnXfndskYHStB4/5q1K6Fuw2H11Ku7tZtKYKcxFyZDFN/E4UfrnonRxl0tsvL4Bj23NC8rEgC0fAgJMvaCbYMI+Q9wuOIKG2uorn5fSHYgMhb4Gkwv0s2cjto8xy3xnxLtRY8OPglRIL64qBk2zprZkvoxbj7IttVH7J8Z9MNJEM2zTnMhzFOJfFLrIKPZ7uRnj+TaU77mhFHJAFJLP+1SCAwdMVTO+tCqdBQesqgmc3nK03GQmqzF1lgNqIGsxHNRFR5kEZ/QeNIqWwgjfJyaCOmE0Tjsw3feBQxopQ5GaaM9eiLWV3NRtng34QyQWLKR50JSEamFvZ02LzxToxxo2zMzZHaS7HG/B8):
1. Select `Clamp To Ground` and `EllipsoidTerrainProvider`
2. Click on `Fly To` or `Zoom To`

### Triage
- Does the problem exist with `HeightReference.NONE`?
	- No
- Does the problem exist with `HeightReference.RELATIVE_TO_GROUND`?
	- Yes, if you `Fly To`, then `Fly Away` then `Fly To` again in the Sandcastle above.
- Does the problem exist with `CesiumTerrainProvider`?
	- No
- Is there any scenario where it works as expected?
	- For both `flyTo` and `zoomTo`, it works correctly when pressed a second time.

### Fix
- Since the result's bounding sphere is directly set from the translation of the model matrix that is set by the user, if the user initially sets the position that has a height greater than 0, the result's bounding sphere will be centered at that position, even if the height reference is `CLAMP_TO_GROUND`.
- Why did the spec not catch this problem?
	- The spec just checked if the position was being set to the model matrix's position. It was following the faulty logic of the spec. It's been updated to reflect what the actual position is expected to be, not just comparing it with the output.


