### PR TITLE
Fix for NodeJS with ESM modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,6 @@ script:
   - node -e "const Cesium = require('./');"
   - NODE_ENV=development node Specs/test.cjs
   - NODE_ENV=production node Specs/test.cjs
+  - node Specs/test.mjs
 
   - npm --silent run cloc

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@
 ##### Fixes :wrench:
 
 - Fixed bug with `Viewer.flyTo` where camera could go underground when target is an `Entity` with `ModelGraphics` with `HeightReference.CLAMP_TO_GROUND` or `HeightReference.RELATIVE_TO_GROUND`. [#10631](https://github.com/CesiumGS/cesium/pull/10631)
+- Fixed issues running CesiumJS under Node.js when using ESM modules. [#10684](https://github.com/CesiumGS/cesium/issues/10684)
 
 ### 1.96 - 2022-08-01
 

--- a/Source/Core/Resource.js
+++ b/Source/Core/Resource.js
@@ -2059,59 +2059,65 @@ function loadWithHttpRequest(
   overrideMimeType
 ) {
   // Note: only the 'json' and 'text' responseTypes transforms the loaded buffer
-  /* eslint-disable no-undef */
-  const URL = require("url").parse(url);
-  const http = URL.protocol === "https:" ? require("https") : require("http");
-  const zlib = require("zlib");
-  /* eslint-enable no-undef */
+  let URL;
+  let zlib;
+  Promise.all([import("url"), import("zlib")])
+    .then(([urlImport, zlibImport]) => {
+      URL = urlImport.parse(url);
+      zlib = zlibImport;
 
-  const options = {
-    protocol: URL.protocol,
-    hostname: URL.hostname,
-    port: URL.port,
-    path: URL.path,
-    query: URL.query,
-    method: method,
-    headers: headers,
-  };
+      return URL.protocol === "https:" ? import("https") : import("http");
+    })
+    .then((http) => {
+      const options = {
+        protocol: URL.protocol,
+        hostname: URL.hostname,
+        port: URL.port,
+        path: URL.path,
+        query: URL.query,
+        method: method,
+        headers: headers,
+      };
+      http
+        .request(options)
+        .on("response", function (res) {
+          if (res.statusCode < 200 || res.statusCode >= 300) {
+            deferred.reject(
+              new RequestErrorEvent(res.statusCode, res, res.headers)
+            );
+            return;
+          }
 
-  http
-    .request(options)
-    .on("response", function (res) {
-      if (res.statusCode < 200 || res.statusCode >= 300) {
-        deferred.reject(
-          new RequestErrorEvent(res.statusCode, res, res.headers)
-        );
-        return;
-      }
+          const chunkArray = [];
+          res.on("data", function (chunk) {
+            chunkArray.push(chunk);
+          });
 
-      const chunkArray = [];
-      res.on("data", function (chunk) {
-        chunkArray.push(chunk);
-      });
-
-      res.on("end", function () {
-        // eslint-disable-next-line no-undef
-        const result = Buffer.concat(chunkArray);
-        if (res.headers["content-encoding"] === "gzip") {
-          zlib.gunzip(result, function (error, resultUnzipped) {
-            if (error) {
-              deferred.reject(
-                new RuntimeError("Error decompressing response.")
-              );
+          res.on("end", function () {
+            // eslint-disable-next-line no-undef
+            const result = Buffer.concat(chunkArray);
+            if (res.headers["content-encoding"] === "gzip") {
+              zlib.gunzip(result, function (error, resultUnzipped) {
+                if (error) {
+                  deferred.reject(
+                    new RuntimeError("Error decompressing response.")
+                  );
+                } else {
+                  deferred.resolve(
+                    decodeResponse(resultUnzipped, responseType)
+                  );
+                }
+              });
             } else {
-              deferred.resolve(decodeResponse(resultUnzipped, responseType));
+              deferred.resolve(decodeResponse(result, responseType));
             }
           });
-        } else {
-          deferred.resolve(decodeResponse(result, responseType));
-        }
-      });
-    })
-    .on("error", function (e) {
-      deferred.reject(new RequestErrorEvent());
-    })
-    .end();
+        })
+        .on("error", function (e) {
+          deferred.reject(new RequestErrorEvent());
+        })
+        .end();
+    });
 }
 
 const noXMLHttpRequest = typeof XMLHttpRequest === "undefined";

--- a/Source/Scene/GltfJsonLoader.js
+++ b/Source/Scene/GltfJsonLoader.js
@@ -11,7 +11,7 @@ import ForEach from "./GltfPipeline/ForEach.js";
 import parseGlb from "./GltfPipeline/parseGlb.js";
 import removePipelineExtras from "./GltfPipeline/removePipelineExtras.js";
 import updateVersion from "./GltfPipeline/updateVersion.js";
-import usesExtension from "./GltfPipeline/usesExtension";
+import usesExtension from "./GltfPipeline/usesExtension.js";
 import ResourceLoader from "./ResourceLoader.js";
 import ResourceLoaderState from "./ResourceLoaderState.js";
 

--- a/Specs/test.mjs
+++ b/Specs/test.mjs
@@ -1,4 +1,4 @@
-import { Cartographic, CesiumTerrainProvider, sampleTerrain } from "../Source/Cesium.js";
+import { Cartographic, CesiumTerrainProvider, sampleTerrain } from "cesium";
 import assert from "node:assert";
 
 // NodeJS smoke screen test

--- a/Specs/test.mjs
+++ b/Specs/test.mjs
@@ -1,0 +1,17 @@
+import { Cartographic, CesiumTerrainProvider, sampleTerrain } from "../Source/Cesium.js";
+import assert from "node:assert";
+
+// NodeJS smoke screen test
+
+const provider = new CesiumTerrainProvider({
+    url: "https://s3.amazonaws.com/cesiumjs/smallTerrain",
+  });
+  sampleTerrain(provider, 11, [
+    Cartographic.fromDegrees(86.925145, 27.988257),
+    Cartographic.fromDegrees(87.0, 28.0),
+  ]).then((results) => {
+    assert(results[0].height > 5000);
+    assert(results[0].height < 10000);
+    assert(results[1].height > 5000);
+    assert(results[1].height < 10000);
+  });

--- a/build.cjs
+++ b/build.cjs
@@ -301,7 +301,7 @@ async function buildWorkers(options) {
   // 1) They can be built as AMD style modules
   // 2) They can be built using code-splitting, resulting in smaller modules
   const files = await globby(["Source/WorkersES6/*.js"]);
-  const plugins = [rollupResolve(), rollupCommonjs()];
+  const plugins = [rollupResolve({ preferBuiltins: true }), rollupCommonjs()];
 
   if (options.removePragmas) {
     plugins.push(

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "type": "module",
   "dependencies": {
     "@tweenjs/tween.js": "^18.6.4",
-    "@zip.js/zip.js": "^2.3.12",
+    "@zip.js/zip.js": "2.4.x",
     "autolinker": "^3.14.3",
     "bitmap-sdf": "^1.0.3",
     "dompurify": "^2.2.2",


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/10684

NodeJS was failing to run ESM modules mainly because of a recent update to `zip.js` which requires `TransformStream` to be defined. Looks like [the zip.js maintainer addressed this and suggests](https://github.com/gildas-lormeau/zip.js/issues/340#issuecomment-1177329994) either locking to `2.4.x` or adding a polyfill for `TransformStream`. Here, I've locked the package version.

To prevent related issues from going unnoticed in the future, I added a `.mjs` version of `test.cjs`, which is now run as part of CI.

In doing so, I also caught two other issues. One was a faulty import, and the other was the use of `require` in `Resource.js`. If I understand correctly, this is code that should only ever be executed in a NodeJS environment, and can be replaced with a dynamic import , satisfying both the ESM and CJS use cases.