### PR TITLE
Control unit test canvas size from the CLI/SpecRunner URL

### DIFF
--- a/Documentation/Contributors/TestingGuide/README.md
+++ b/Documentation/Contributors/TestingGuide/README.md
@@ -506,27 +506,38 @@ it("can declare automatic uniforms", function () {
 #### Debugging Rendering Tests
 
 Rendering tests typically render to a 1x1 pixel canvas. This is so each test runs as
-quickly as possible. However, when regressions happen, it is difficult to tell why the test is failing since the image is too small to see. To make debugging tests easier,
-`createScene()` has options to adjust the canvas size to give a better preview of what
-the camera sees.
+quickly as possible. However, when regressions happen, it is difficult to tell why the test is failing since the
+image is too small to see. To make debugging tests easier, the `debugCanvasWidth` and `debugCanvasHeight` arguments can
+be used to increase the canvas size as desired.
+
+Example using the command line:
+
+```bash
+# Render tests will use a 400x300 canvas
+npm run test -- --debugCanvasWidth 400 --debugCanvasHeight 300
+```
+
+Example using SpecRunner:
+
+```text
+http://localhost:8080/Specs/SpecRunner.html?debugCanvasWidth=400&debugCanvasHeight=300
+```
+
+For ease of use, `debugCanvasHeight` can be omitted to produce a square canvas. For example:
+
+```bash
+# Render tests will use a 300x300 canvas
+npm run test -- --debugCanvasWidth 300
+```
 
 An example debug workflow might look like this:
 
 1. Use `fit()` to focus on the test that is failing.
-2. Use the `debugWidth` and `debugHeight` options for `createScene()` to make the canvas larger.
-3. Put a breakpoint in the code around where the first rendering code happens, such as a call of `scene.renderForSpecs()`.
+2. Create a breakpoint where the first rendering code happens, such as a call of `scene.renderForSpecs()`.
+3. Run the tests using the debug options described above
 4. Step through the test. After each render, check the browser window to see the frame that was just rendered.
 
 ```js
-beforeAll(function () {
-  scene = createScene({
-    // Create a 300x300 px canvas so we can see what the camera sees.
-    // This is intended for temporary debugging, do not commit these debug options.
-    debugWidth: 300,
-    debugHeight: 300,
-  });
-});
-
 // Focus the test that is failing
 fit("test that is failing", function () {
   // Start a breakpoint here
@@ -534,11 +545,10 @@ fit("test that is failing", function () {
   // After each render call, check the browser for the frame that was just rendered.
 
   // ...
-
   scene.renderForSpecs();
+  // Check the browser again for the next frame
 
   // ... and so on
-
   scene.renderForSpecs();
 });
 ```

--- a/Specs/createScene.js
+++ b/Specs/createScene.js
@@ -15,8 +15,11 @@ function createScene(options) {
   // Render tests can be difficult to debug. Let the caller choose a larger
   // canvas size temporarily. By stepping through a render test, you can see
   // what the camera sees after each render call.
-  const debugWidth = options.debugWidth;
-  const debugHeight = options.debugHeight;
+  const debugWidth = window.debugCanvasWidth;
+  const debugHeight = defaultValue(
+    window.debugCanvasHeight,
+    window.debugCanvasWidth
+  );
 
   // save the canvas so we don't try to clone an HTMLCanvasElement
   const canvas = defined(options.canvas)

--- a/Specs/customizeJasmine.js
+++ b/Specs/customizeJasmine.js
@@ -7,7 +7,9 @@ function customizeJasmine(
   excludedCategory,
   webglValidation,
   webglStub,
-  release
+  release,
+  debugCanvasWidth,
+  debugCanvasHeight
 ) {
   // set this for uniform test resolution across devices
   window.devicePixelRatio = 1;
@@ -44,6 +46,9 @@ function customizeJasmine(
   if (webglStub) {
     window.webglStub = true;
   }
+
+  window.debugCanvasWidth = debugCanvasWidth;
+  window.debugCanvasHeight = debugCanvasHeight;
 
   env.beforeEach(function () {
     addDefaultMatchers(!release).call(env);

--- a/Specs/karma-main.js
+++ b/Specs/karma-main.js
@@ -6,6 +6,8 @@ let excludeCategory = "";
 let webglValidation = false;
 let webglStub = false;
 let release = false;
+let debugCanvasWidth;
+let debugCanvasHeight;
 
 if (__karma__.config.args) {
   includeCategory = __karma__.config.args[0];
@@ -13,6 +15,8 @@ if (__karma__.config.args) {
   webglValidation = __karma__.config.args[4];
   webglStub = __karma__.config.args[5];
   release = __karma__.config.args[6];
+  debugCanvasWidth = __karma__.config.args[7];
+  debugCanvasHeight = __karma__.config.args[8];
 }
 
 if (release) {
@@ -28,5 +32,7 @@ customizeJasmine(
   excludeCategory,
   webglValidation,
   webglStub,
-  release
+  release,
+  debugCanvasWidth,
+  debugCanvasHeight
 );

--- a/Specs/spec-main.js
+++ b/Specs/spec-main.js
@@ -6,6 +6,8 @@ const queryString = queryToObject(window.location.search.substring(1));
 
 let webglValidation = false;
 let webglStub = false;
+let debugCanvasWidth;
+let debugCanvasHeight;
 const release = window.location.search.indexOf("release") !== -1;
 const categoryString = queryString.category;
 const excludeCategoryString = queryString.not;
@@ -16,6 +18,14 @@ if (defined(queryString.webglValidation)) {
 
 if (defined(queryString.webglStub)) {
   webglStub = true;
+}
+
+if (defined(queryString.debugCanvasWidth)) {
+  debugCanvasWidth = parseInt(queryString.debugCanvasWidth);
+}
+
+if (defined(queryString.debugCanvasHeight)) {
+  debugCanvasHeight = parseInt(queryString.debugCanvasHeight);
 }
 
 if (release) {
@@ -56,5 +66,7 @@ customizeJasmine(
   excludeCategoryString,
   webglValidation,
   webglStub,
-  release
+  release,
+  debugCanvasWidth,
+  debugCanvasHeight
 );

--- a/gulpfile.cjs
+++ b/gulpfile.cjs
@@ -1087,7 +1087,7 @@ gulp.task("coverage", async function () {
 });
 
 gulp.task("test", function (done) {
-  const argv = yargs.argv;
+  const argv = yargs.array("debugCanvasSize").argv;
 
   const enableAllBrowsers = argv.all ? true : false;
   const includeCategory = argv.include ? argv.include : "";
@@ -1098,6 +1098,8 @@ gulp.task("test", function (done) {
   const failTaskOnError = argv.failTaskOnError ? argv.failTaskOnError : false;
   const suppressPassed = argv.suppressPassed ? argv.suppressPassed : false;
   const debug = argv.debug ? false : true;
+  const debugCanvasWidth = argv.debugCanvasWidth;
+  const debugCanvasHeight = argv.debugCanvasHeight;
   const includeName = argv.includeName ? argv.includeName : "";
 
   let browsers = ["Chrome"];
@@ -1155,6 +1157,8 @@ gulp.task("test", function (done) {
         webglValidation,
         webglStub,
         release,
+        debugCanvasWidth,
+        debugCanvasHeight,
       ],
     },
   });

--- a/gulpfile.cjs
+++ b/gulpfile.cjs
@@ -1087,7 +1087,7 @@ gulp.task("coverage", async function () {
 });
 
 gulp.task("test", function (done) {
-  const argv = yargs.array("debugCanvasSize").argv;
+  const argv = yargs.argv;
 
   const enableAllBrowsers = argv.all ? true : false;
   const includeCategory = argv.include ? argv.include : "";


### PR DESCRIPTION
This is a revision to #10688 based on this feedback: https://github.com/CesiumGS/cesium/pull/10688#discussion_r946832437

This PR adds the `debugCanvasWidth` and `debugCanvasHeight` parameters to `npm run test` as well as SpecRunner's URL query parameters. For example:

```
npm run test -- --debugCanvasWidth 300 --includeName Model
```

or in the browser:

```
http://localhost:8080/Specs/SpecRunner.html?spec=Model&debugCanvasWidth=300
```

@ggetz could you review?