### PR TITLE
Debug ShadowMap tests

### DIFF
--- a/Specs/Scene/ShadowMapSpec.js
+++ b/Specs/Scene/ShadowMapSpec.js
@@ -771,7 +771,7 @@ describe(
         const red = rgba[0];
         const unshadowedRed = unshadowedColor[0];
         const shadowedRed = shadowedColor[0];
-        expect(shadowedRed).toBeLessThan(red);
+        expect(red).toBeGreaterThan(shadowedRed);
         expect(red).toBeLessThan(unshadowedRed);
       }, endTime);
 
@@ -835,8 +835,6 @@ describe(
       scene.light = new DirectionalLight({
         direction: lightDirectionAngle,
       });
-
-      // Change the light direction so that the shadows are no longer pointing straight down
       renderAndCall(function (rgba) {
         expect(rgba).not.toEqual(backgroundColor);
         expect(rgba).not.toEqual(shadowedColor);
@@ -847,7 +845,7 @@ describe(
         const red = rgba[0];
         const unshadowedRed = unshadowedColor[0];
         const shadowedRed = shadowedColor[0];
-        expect(shadowedRed).toBeLessThan(red);
+        expect(red).toBeGreaterThan(shadowedRed);
         expect(red).toBeLessThan(unshadowedRed);
       });
 


### PR DESCRIPTION
This PR re-enables a few tests that were `xit-ed` out in `ShadowMap` and fixes them so they run again. The problems were:

1. Due to rendering differences The rendering color wasn't an exact match in some cases
2. For the point light test, it wasn't waiting for the ready promise, so the boxes weren't showing up. I changed it to use a single box and just reposition it in the scene as needed.

@j9liu this is ready for review, though wait for #10695 to be merged before merging