### PR TITLE
Fix incorrect i3dm lighting

### DIFF
--- a/Source/Shaders/Model/LegacyInstancingStageVS.glsl
+++ b/Source/Shaders/Model/LegacyInstancingStageVS.glsl
@@ -13,7 +13,6 @@ void legacyInstancingStage(
     instanceModelViewInverseTranspose = mat3(u_instance_modifiedModelView * instanceModel);
 
     attributes.positionMC = (instanceModel * vec4(positionMC, 1.0)).xyz;
-    attributes.normalMC = (instanceModel * vec4(normalMC, 0.0)).xyz;
     
     #ifdef USE_2D_INSTANCING
     mat4 instancingTransform2D = getInstancingTransform2D();


### PR DESCRIPTION
This fixes the failing `sets colorBlendMode for instanced tileset` test. `LegacyInstancingStageVS.glsl` was already correctly modifying the normals by incorporating the `instancingTransform` into the normal matrix for each instance. The change in #10690 overcompensated for that.

Here's the difference; in the incorrect lighting the tops of the cubes stay dark no matter where the sun is. I recreated the unit test setup in [this Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=bVLLTsMwEPwVKxeCFOxW5VEgVLwOIIFABXHyZbGXYnDsynaKCuLfsZO2tIHkkPXuzHpmN8IaH8hM4Qc6ckIMfpAL9Kqu6FOTy3kmmvOFNQGUQcez7WNuuBENMyiNHsMmtf0MLh/bYv7FDSG100eEZ+xhisKzSwjANnDsOvYDI1D+RmOUtxDQKdBscRN989bwrODmu9XRaqdeoEE6dapSQc3QU5AyX3ASkLEF8NPa6tGul9LLGDlXTm55gnNs5rF0GPtGBTfWTFSoJUanO3066B/uD487EAhLRI/uHw6HB7srhFSto1gb9Dq8mFvODVyIEZgBfXG2GoOMsc87CorOfcnCxhAEVOiAamvfz8KCXazv5wpjZzO5V0G8jsFMMO/RXpF87R0UK63bqXFWZKUPc42jtMP0nKpqal1I+8wpZQGrqY478uy5Fu9xP8L7REzQkq1TS6lmRMmTf/4oIjR4HysvtdYP6hN5NipZxP+hattIv5uh0zBPsNf+6KZNUkpLFo//M4O1+hlcp/MP).
| Incorrect | Fixed |
| ---------- | ------ |
| ![incorrect lighting](https://user-images.githubusercontent.com/32226860/185185886-8081482e-9302-4eef-bd20-403714538ef5.gif) | ![correct lighting](https://user-images.githubusercontent.com/32226860/185185967-fe96817f-d19a-4250-b82c-b5ea31532f3c.gif) |