### PR TITLE
Debug other `Model` specs that were commented out

### DIFF
--- a/Specs/Scene/Model/ModelSpec.js
+++ b/Specs/Scene/Model/ModelSpec.js
@@ -612,7 +612,7 @@ describe(
     });
 
     // This test does not yet work since models without normals are
-    // rendered as unlit
+    // rendered as unlit. See https://github.com/CesiumGS/cesium/issues/6506
     xit("renders model with emissive texture", function () {
       const resource = Resource.createIfNeeded(emissiveTextureUrl);
       return resource.fetchJson().then(function (gltf) {
@@ -3462,8 +3462,8 @@ describe(
       });
     });
 
-    describe("cull", function () {
-      it("enables culling", function () {
+    describe("frustum culling ", function () {
+      it("enables frustum culling", function () {
         return loadAndZoomToModel(
           {
             gltf: boxTexturedGltfUrl,
@@ -3486,8 +3486,7 @@ describe(
         });
       });
 
-      // This test does not yet work for Model
-      xit("disables culling", function () {
+      it("disables frustum culling", function () {
         return loadAndZoomToModel(
           {
             gltf: boxTexturedGltfUrl,
@@ -3504,7 +3503,7 @@ describe(
 
           // Commands should still be submitted when model is out of view.
           model.modelMatrix = Matrix4.fromTranslation(
-            new Cartesian3(100.0, 0.0, 0.0)
+            new Cartesian3(0.0, 100.0, 0.0)
           );
           scene.renderForSpecs();
           expect(scene.frustumCommandsList.length).toEqual(length);

--- a/Specs/Scene/PostProcessStageLibrarySpec.js
+++ b/Specs/Scene/PostProcessStageLibrarySpec.js
@@ -304,7 +304,6 @@ describe(
         origin,
         new HeadingPitchRoll()
       );
-      scene.postProcessStages.ambientOcclusion.enabled = false;
 
       return loadAndZoomToModel(
         {

--- a/Specs/Scene/PostProcessStageLibrarySpec.js
+++ b/Specs/Scene/PostProcessStageLibrarySpec.js
@@ -304,10 +304,12 @@ describe(
         origin,
         new HeadingPitchRoll()
       );
+      scene.postProcessStages.ambientOcclusion.enabled = false;
 
       return loadAndZoomToModel(
         {
           url: boxTexturedUrl,
+          // Ensure the texture loads every time
           incrementallyLoadTextures: false,
           modelMatrix: modelMatrix,
         },
@@ -378,7 +380,6 @@ describe(
           expect(rgba[i + 3]).toEqual(255);
         }
       });
-      scene.postProcessStages.ambientOcclusion.enabled = false;
     });
 
     it("ambient occlusion uniforms", function () {
@@ -425,6 +426,7 @@ describe(
       return loadAndZoomToModel(
         {
           url: boxTexturedUrl,
+          // Ensure the texture loads every time
           incrementallyLoadTextures: false,
           modelMatrix: modelMatrix,
         },
@@ -447,8 +449,7 @@ describe(
         // Render with bloom and compare
         const bloom = scene.postProcessStages.bloom;
         bloom.enabled = true;
-        // increase the brightness to make the difference more
-        // noticeable
+        // increase the brightness to make the difference more noticeable
         bloom.uniforms.brightness = 0.5;
         scene.renderForSpecs();
         expect(scene).toRenderAndCall(function (rgba) {
@@ -460,7 +461,6 @@ describe(
             expect(rgba[i + 3]).toEqual(255);
           }
         });
-        scene.postProcessStages.bloom.enabled = false;
       });
     });
 

--- a/Specs/Scene/PostProcessStageLibrarySpec.js
+++ b/Specs/Scene/PostProcessStageLibrarySpec.js
@@ -308,49 +308,38 @@ describe(
       return loadAndZoomToModel(
         {
           url: boxTexturedUrl,
+          incrementallyLoadTextures: false,
           modelMatrix: modelMatrix,
         },
         scene
       ).then(function () {
-        /*scene.camera.lookAt(
-          origin,
-          new HeadingPitchRange(0.0, 0.0, 1.0)
-        );*/
+        scene.camera.lookAt(origin, new HeadingPitchRange(0.0, 0.0, 1.0));
 
-        const offset = new Cartesian3(
-          -5,
-          0,
-          0
-          /*
-        scene.postProcess
-          -37.048378684557974,
-          -24.852967044804245,
-          4.352023653686047*/
-        );
-        scene.camera.lookAt(origin, offset);
-
+        // Render without depth of field
+        let originalColor;
         expect(scene).toRenderAndCall(function (rgba) {
+          originalColor = rgba;
           for (let i = 0; i < rgba.length; i += 4) {
             expect(rgba[i]).toBeGreaterThan(0);
-            expect(rgba[i + 1]).toBe(0);
-            expect(rgba[i + 2]).toBe(0);
+            expect(rgba[i + 1]).toBeGreaterThan(0);
+            expect(rgba[i + 2]).toBeGreaterThan(0);
             expect(rgba[i + 3]).toEqual(255);
           }
+        });
 
-          scene.postProcessStages.add(
-            PostProcessStageLibrary.createDepthOfFieldStage()
-          );
-          scene.renderForSpecs();
-          expect(scene).toRenderAndCall(function (rgba2) {
-            for (let i = 0; i < rgba.length; i += 4) {
-              expect(rgba2[i]).toBeGreaterThan(0);
-              expect(rgba2[i + 1]).toBe(0);
-              expect(rgba2[i + 2]).toBe(0);
-              expect(rgba2[i + 3]).toEqual(255);
-
-              expect(rgba2[i]).not.toEqual(rgba[i]);
-            }
-          });
+        // Render with depth of field and compare
+        scene.postProcessStages.add(
+          PostProcessStageLibrary.createDepthOfFieldStage()
+        );
+        scene.renderForSpecs();
+        expect(scene).toRenderAndCall(function (rgba) {
+          expect(rgba).not.toEqual(originalColor);
+          for (let i = 0; i < rgba.length; i += 4) {
+            expect(rgba[i]).toBeGreaterThan(0);
+            expect(rgba[i + 1]).toBeGreaterThan(0);
+            expect(rgba[i + 2]).toBeGreaterThan(0);
+            expect(rgba[i + 3]).toEqual(255);
+          }
         });
       });
     });


### PR DESCRIPTION
This PR updates a few specs related to `Model` that were `xit()`-ed out. Most notably:

* fixing the post-process stage tests. The old tests were a bit fragile so I updated them to be a bit more reliable.
* a test about frustum culling. The model was being moved behind the camera so the command wasn't being added to the `frustumCommandList`. Though I want to try the corresponding test from the old `Model` code to see why it's so different, I'll report findings when I have them.

Note that this does not update the spec related to #10632, I'll look at that separately.

@j9liu could you review?