### PR TITLE
Add support for point cloud back face culling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@
 ##### Additions :tada:
 
 - `Model` can now classify other assets with a given `classificationType`. [#10623](https://github.com/CesiumGS/cesium/pull/10623)
+- `Model` now supports back face culling for point clouds. [#10703](https://github.com/CesiumGS/cesium/pull/10703)
 
 ##### Fixes :wrench:
 

--- a/Source/Scene/Model/MaterialPipelineStage.js
+++ b/Source/Scene/Model/MaterialPipelineStage.js
@@ -128,7 +128,7 @@ MaterialPipelineStage.process = function (
     shaderBuilder.addDefine(
       "HAS_DOUBLE_SIDED_MATERIAL",
       undefined,
-      ShaderDestination.FRAGMENT
+      ShaderDestination.BOTH
     );
   }
 };

--- a/Source/Scene/Model/Model.js
+++ b/Source/Scene/Model/Model.js
@@ -314,6 +314,7 @@ function Model(options) {
   const pointCloudShading = new PointCloudShading(options.pointCloudShading);
   this._pointCloudShading = pointCloudShading;
   this._attenuation = pointCloudShading.attenuation;
+  this._pointCloudBackFaceCulling = pointCloudShading.backFaceCulling;
 
   // If the given clipping planes don't have an owner, make this model its owner.
   // Otherwise, the clipping planes are passed down from a tileset.
@@ -1674,7 +1675,7 @@ Model.prototype.update = function (frameState) {
     return;
   }
 
-  updatePointCloudAttenuation(this);
+  updatePointCloudShading(this);
   updateSilhouette(this, frameState);
   updateSkipLevelOfDetail(this, frameState);
   updateClippingPlanes(this, frameState);
@@ -1733,12 +1734,19 @@ function updateImageBasedLighting(model, frameState) {
   }
 }
 
-function updatePointCloudAttenuation(model) {
+function updatePointCloudShading(model) {
+  const pointCloudShading = model.pointCloudShading;
+
   // Check if the shader needs to be updated for point cloud attenuation
   // settings.
-  if (model.pointCloudShading.attenuation !== model._attenuation) {
+  if (pointCloudShading.attenuation !== model._attenuation) {
     model.resetDrawCommands();
-    model._attenuation = model.pointCloudShading.attenuation;
+    model._attenuation = pointCloudShading.attenuation;
+  }
+
+  if (pointCloudShading.backFaceCulling !== model._pointCloudBackFaceCulling) {
+    model.resetDrawCommands();
+    model._pointCloudBackFaceCulling = pointCloudShading.backFaceCulling;
   }
 }
 

--- a/Source/Scene/Model/ModelRuntimePrimitive.js
+++ b/Source/Scene/Model/ModelRuntimePrimitive.js
@@ -185,9 +185,11 @@ ModelRuntimePrimitive.prototype.configurePipeline = function (frameState) {
   const pointCloudShading = model.pointCloudShading;
   const hasAttenuation =
     defined(pointCloudShading) && pointCloudShading.attenuation;
+  const hasPointCloudBackFaceCulling =
+    defined(pointCloudShading) && pointCloudShading.backFaceCulling;
   const hasPointCloudStyle =
     primitive.primitiveType === PrimitiveType.POINTS &&
-    (defined(style) || hasAttenuation);
+    (defined(style) || hasAttenuation || hasPointCloudBackFaceCulling);
 
   const hasOutlines =
     model._enableShowOutline && defined(primitive.outlineCoordinates);

--- a/Source/Scene/Model/PointCloudStylingPipelineStage.js
+++ b/Source/Scene/Model/PointCloudStylingPipelineStage.js
@@ -117,7 +117,7 @@ PointCloudStylingPipelineStage.process = function (
   }
 
   const pointCloudShading = model.pointCloudShading;
-  if (model._attenuation) {
+  if (pointCloudShading.attenuation) {
     shaderBuilder.addDefine(
       "HAS_POINT_CLOUD_ATTENUATION",
       undefined,

--- a/Source/Scene/Model/PointCloudStylingPipelineStage.js
+++ b/Source/Scene/Model/PointCloudStylingPipelineStage.js
@@ -125,6 +125,14 @@ PointCloudStylingPipelineStage.process = function (
     );
   }
 
+  if (pointCloudShading.backFaceCulling) {
+    shaderBuilder.addDefine(
+      "HAS_POINT_CLOUD_BACK_FACE_CULLING",
+      undefined,
+      ShaderDestination.VERTEX
+    );
+  }
+
   let content;
   let is3DTiles;
   let usesAddRefinement;

--- a/Source/Shaders/Model/GeometryStageVS.glsl
+++ b/Source/Shaders/Model/GeometryStageVS.glsl
@@ -23,7 +23,7 @@ vec4 geometryStage(inout ProcessedAttributes attributes, mat4 modelView, mat3 no
     #endif
 
     #ifdef HAS_NORMALS
-    v_normalEC = normal * attributes.normalMC;
+    v_normalEC = normalize(normal * attributes.normalMC);
     #endif
 
     #ifdef HAS_TANGENTS

--- a/Source/Shaders/Model/MaterialStageFS.glsl
+++ b/Source/Shaders/Model/MaterialStageFS.glsl
@@ -64,7 +64,6 @@ vec3 computeNormal(ProcessedAttributes attributes)
 
 void materialStage(inout czm_modelMaterial material, ProcessedAttributes attributes, SelectedFeature feature)
 {
-
     #ifdef HAS_NORMALS
     material.normalEC = computeNormal(attributes);
     #endif

--- a/Source/Shaders/Model/ModelVS.glsl
+++ b/Source/Shaders/Model/ModelVS.glsl
@@ -111,6 +111,10 @@ void main()
     float show = 1.0;
     #endif
 
+    #ifdef HAS_POINT_CLOUD_BACK_FACE_CULLING
+    show *= pointCloudBackFaceCullingStage();
+    #endif
+
     #ifdef HAS_POINT_CLOUD_COLOR_STYLE
     v_pointCloudColor = pointCloudColorStylingStage(attributes, metadata);
     #endif

--- a/Source/Shaders/Model/PointCloudStylingStageVS.glsl
+++ b/Source/Shaders/Model/PointCloudStylingStageVS.glsl
@@ -32,3 +32,14 @@ float pointCloudPointSizeStylingStage(in ProcessedAttributes attributes, in Meta
   return getPointSizeFromAttenuation(v_positionEC);
 }
 #endif
+
+#ifdef HAS_POINT_CLOUD_BACK_FACE_CULLING
+float pointCloudBackFaceCullingStage() {
+  #if defined(HAS_NORMALS) && !defined(HAS_DOUBLE_SIDED_MATERIAL)
+  // This needs to be computed in eye coordinates so we can't use attributes.normalMC
+  return step(-v_normalEC.z, 0.0);
+  #else
+  return 1.0;
+  #endif
+}
+#endif

--- a/Specs/Scene/Model/MaterialPipelineStageSpec.js
+++ b/Specs/Scene/Model/MaterialPipelineStageSpec.js
@@ -138,62 +138,10 @@ describe(
       });
     });
 
-    it("adds material uniforms", function () {
+    it("adds material and metallic roughness uniforms", function () {
       return loadGltf(boomBox).then(function (gltfLoader) {
         const components = gltfLoader.components;
         const primitive = components.nodes[0].primitives[0];
-        const renderResources = mockRenderResources();
-        const shaderBuilder = renderResources.shaderBuilder;
-        const uniformMap = renderResources.uniformMap;
-
-        MaterialPipelineStage.process(
-          renderResources,
-          primitive,
-          mockFrameState
-        );
-
-        ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, []);
-        ShaderBuilderTester.expectHasFragmentUniforms(shaderBuilder, [
-          "uniform sampler2D u_baseColorTexture;",
-          "uniform sampler2D u_emissiveTexture;",
-          "uniform sampler2D u_metallicRoughnessTexture;",
-          "uniform sampler2D u_normalTexture;",
-          "uniform sampler2D u_occlusionTexture;",
-          "uniform vec3 u_emissiveFactor;",
-        ]);
-
-        ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, []);
-        ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
-          "HAS_BASE_COLOR_TEXTURE",
-          "HAS_EMISSIVE_FACTOR",
-          "HAS_EMISSIVE_TEXTURE",
-          "HAS_METALLIC_ROUGHNESS_TEXTURE",
-          "HAS_NORMAL_TEXTURE",
-          "HAS_OCCLUSION_TEXTURE",
-          "TEXCOORD_BASE_COLOR v_texCoord_0",
-          "TEXCOORD_EMISSIVE v_texCoord_0",
-          "TEXCOORD_METALLIC_ROUGHNESS v_texCoord_0",
-          "TEXCOORD_NORMAL v_texCoord_0",
-          "TEXCOORD_OCCLUSION v_texCoord_0",
-          "USE_METALLIC_ROUGHNESS",
-        ]);
-
-        const material = primitive.material;
-        const expectedUniforms = {
-          u_emissiveTexture: material.emissiveTexture.texture,
-          u_emissiveFactor: material.emissiveFactor,
-          u_normalTexture: material.normalTexture.texture,
-          u_occlusionTexture: material.occlusionTexture.texture,
-        };
-        expectUniformMap(uniformMap, expectedUniforms);
-      });
-    });
-
-    it("adds metallic roughness uniforms", function () {
-      return loadGltf(boomBox).then(function (gltfLoader) {
-        const components = gltfLoader.components;
-        const primitive = components.nodes[0].primitives[0];
-
         const renderResources = mockRenderResources();
         const shaderBuilder = renderResources.shaderBuilder;
         const uniformMap = renderResources.uniformMap;
@@ -231,7 +179,12 @@ describe(
         ]);
 
         const metallicRoughness = primitive.material.metallicRoughness;
+        const material = primitive.material;
         const expectedUniforms = {
+          u_emissiveTexture: material.emissiveTexture.texture,
+          u_emissiveFactor: material.emissiveFactor,
+          u_normalTexture: material.normalTexture.texture,
+          u_occlusionTexture: material.occlusionTexture.texture,
           u_baseColorTexture: metallicRoughness.baseColorTexture.texture,
           u_metallicRoughnessTexture:
             metallicRoughness.metallicRoughnessTexture.texture,

--- a/Specs/Scene/Model/MaterialPipelineStageSpec.js
+++ b/Specs/Scene/Model/MaterialPipelineStageSpec.js
@@ -19,6 +19,7 @@ import {
   ShaderBuilder,
 } from "../../../Source/Cesium.js";
 import createScene from "../../createScene.js";
+import ShaderBuilderTester from "../../ShaderBuilderTester.js";
 import waitForLoaderProcess from "../../waitForLoaderProcess.js";
 
 describe(
@@ -84,12 +85,6 @@ describe(
     const twoSidedPlane =
       "./Data/Models/GltfLoader/TwoSidedPlane/glTF/TwoSidedPlane.gltf";
 
-    function expectShaderLines(shaderLines, expected) {
-      for (let i = 0; i < expected.length; i++) {
-        expect(shaderLines.indexOf(expected[i])).not.toBe(-1);
-      }
-    }
-
     function expectUniformMap(uniformMap, expected) {
       for (const key in expected) {
         if (expected.hasOwnProperty(key)) {
@@ -130,10 +125,13 @@ describe(
           mockFrameState
         );
 
-        expect(shaderBuilder._vertexShaderParts.uniformLines).toEqual([]);
-        expectShaderLines(shaderBuilder._fragmentShaderParts.uniformLines, []);
+        ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, []);
+        ShaderBuilderTester.expectHasFragmentUniforms(shaderBuilder, []);
 
-        expectShaderLines(shaderBuilder._fragmentShaderParts.defineLines, []);
+        ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, []);
+        ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
+          "USE_METALLIC_ROUGHNESS",
+        ]);
 
         const expectedUniforms = {};
         expectUniformMap(uniformMap, expectedUniforms);
@@ -154,22 +152,30 @@ describe(
           mockFrameState
         );
 
-        expect(shaderBuilder._vertexShaderParts.uniformLines).toEqual([]);
-        expectShaderLines(shaderBuilder._fragmentShaderParts.uniformLines, [
+        ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, []);
+        ShaderBuilderTester.expectHasFragmentUniforms(shaderBuilder, [
+          "uniform sampler2D u_baseColorTexture;",
           "uniform sampler2D u_emissiveTexture;",
-          "uniform vec3 u_emissiveFactor;",
+          "uniform sampler2D u_metallicRoughnessTexture;",
           "uniform sampler2D u_normalTexture;",
           "uniform sampler2D u_occlusionTexture;",
+          "uniform vec3 u_emissiveFactor;",
         ]);
 
-        expectShaderLines(shaderBuilder._fragmentShaderParts.defineLines, [
-          "HAS_EMISSIVE_TEXTURE",
-          "TEXCOORD_EMISSIVE v_texCoord_0",
+        ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, []);
+        ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
+          "HAS_BASE_COLOR_TEXTURE",
           "HAS_EMISSIVE_FACTOR",
+          "HAS_EMISSIVE_TEXTURE",
+          "HAS_METALLIC_ROUGHNESS_TEXTURE",
           "HAS_NORMAL_TEXTURE",
-          "TEXCOORD_NORMAL v_texCoord_0",
           "HAS_OCCLUSION_TEXTURE",
+          "TEXCOORD_BASE_COLOR v_texCoord_0",
+          "TEXCOORD_EMISSIVE v_texCoord_0",
+          "TEXCOORD_METALLIC_ROUGHNESS v_texCoord_0",
+          "TEXCOORD_NORMAL v_texCoord_0",
           "TEXCOORD_OCCLUSION v_texCoord_0",
+          "USE_METALLIC_ROUGHNESS",
         ]);
 
         const material = primitive.material;
@@ -198,16 +204,30 @@ describe(
           mockFrameState
         );
 
-        expectShaderLines(shaderBuilder._fragmentShaderParts.uniformLines, [
+        ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, []);
+        ShaderBuilderTester.expectHasFragmentUniforms(shaderBuilder, [
           "uniform sampler2D u_baseColorTexture;",
+          "uniform sampler2D u_emissiveTexture;",
           "uniform sampler2D u_metallicRoughnessTexture;",
+          "uniform sampler2D u_normalTexture;",
+          "uniform sampler2D u_occlusionTexture;",
+          "uniform vec3 u_emissiveFactor;",
         ]);
 
-        expectShaderLines(shaderBuilder._fragmentShaderParts.defineLines, [
+        ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, []);
+        ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
           "HAS_BASE_COLOR_TEXTURE",
-          "TEXCOORD_BASE_COLOR v_texCoord_0",
+          "HAS_EMISSIVE_FACTOR",
+          "HAS_EMISSIVE_TEXTURE",
           "HAS_METALLIC_ROUGHNESS_TEXTURE",
+          "HAS_NORMAL_TEXTURE",
+          "HAS_OCCLUSION_TEXTURE",
+          "TEXCOORD_BASE_COLOR v_texCoord_0",
+          "TEXCOORD_EMISSIVE v_texCoord_0",
           "TEXCOORD_METALLIC_ROUGHNESS v_texCoord_0",
+          "TEXCOORD_NORMAL v_texCoord_0",
+          "TEXCOORD_OCCLUSION v_texCoord_0",
+          "USE_METALLIC_ROUGHNESS",
         ]);
 
         const metallicRoughness = primitive.material.metallicRoughness;
@@ -240,22 +260,36 @@ describe(
           mockFrameState
         );
 
-        expectShaderLines(shaderBuilder._fragmentShaderParts.uniformLines, [
-          "uniform sampler2D u_baseColorTexture;",
-          "uniform vec4 u_baseColorFactor;",
-          "uniform sampler2D u_metallicRoughnessTexture;",
+        ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, []);
+        ShaderBuilderTester.expectHasFragmentUniforms(shaderBuilder, [
           "uniform float u_metallicFactor;",
           "uniform float u_roughnessFactor;",
+          "uniform sampler2D u_baseColorTexture;",
+          "uniform sampler2D u_emissiveTexture;",
+          "uniform sampler2D u_metallicRoughnessTexture;",
+          "uniform sampler2D u_normalTexture;",
+          "uniform sampler2D u_occlusionTexture;",
+          "uniform vec3 u_emissiveFactor;",
+          "uniform vec4 u_baseColorFactor;",
         ]);
 
-        expectShaderLines(shaderBuilder._fragmentShaderParts.defineLines, [
-          "HAS_BASE_COLOR_TEXTURE",
-          "TEXCOORD_BASE_COLOR v_texCoord_0",
+        ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, []);
+        ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
           "HAS_BASE_COLOR_FACTOR",
-          "HAS_METALLIC_ROUGHNESS_TEXTURE",
-          "TEXCOORD_METALLIC_ROUGHNESS v_texCoord_0",
+          "HAS_BASE_COLOR_TEXTURE",
+          "HAS_EMISSIVE_FACTOR",
+          "HAS_EMISSIVE_TEXTURE",
           "HAS_METALLIC_FACTOR",
+          "HAS_METALLIC_ROUGHNESS_TEXTURE",
+          "HAS_NORMAL_TEXTURE",
+          "HAS_OCCLUSION_TEXTURE",
           "HAS_ROUGHNESS_FACTOR",
+          "TEXCOORD_BASE_COLOR v_texCoord_0",
+          "TEXCOORD_EMISSIVE v_texCoord_0",
+          "TEXCOORD_METALLIC_ROUGHNESS v_texCoord_0",
+          "TEXCOORD_NORMAL v_texCoord_0",
+          "TEXCOORD_OCCLUSION v_texCoord_0",
+          "USE_METALLIC_ROUGHNESS",
         ]);
 
         const expectedUniforms = {
@@ -283,19 +317,32 @@ describe(
           primitive,
           mockFrameState
         );
-        expectShaderLines(shaderBuilder._fragmentShaderParts.uniformLines, [
-          "uniform sampler2D u_diffuseTexture;",
-          "uniform sampler2D u_specularGlossinessTexture;",
+        ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, []);
+        ShaderBuilderTester.expectHasFragmentUniforms(shaderBuilder, [
           "uniform float u_glossinessFactor;",
+          "uniform sampler2D u_diffuseTexture;",
+          "uniform sampler2D u_emissiveTexture;",
+          "uniform sampler2D u_normalTexture;",
+          "uniform sampler2D u_occlusionTexture;",
+          "uniform sampler2D u_specularGlossinessTexture;",
+          "uniform vec3 u_emissiveFactor;",
         ]);
 
-        expectShaderLines(shaderBuilder._fragmentShaderParts.defineLines, [
-          "USE_SPECULAR_GLOSSINESS",
+        ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, []);
+        ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
           "HAS_DIFFUSE_TEXTURE",
-          "TEXCOORD_DIFFUSE v_texCoord_0",
-          "HAS_SPECULAR_GLOSSINESS_TEXTURE",
-          "TEXCOORD_SPECULAR_GLOSSINESS v_texCoord_0",
+          "HAS_EMISSIVE_FACTOR",
+          "HAS_EMISSIVE_TEXTURE",
           "HAS_GLOSSINESS_FACTOR",
+          "HAS_NORMAL_TEXTURE",
+          "HAS_OCCLUSION_TEXTURE",
+          "HAS_SPECULAR_GLOSSINESS_TEXTURE",
+          "TEXCOORD_DIFFUSE v_texCoord_0",
+          "TEXCOORD_EMISSIVE v_texCoord_0",
+          "TEXCOORD_NORMAL v_texCoord_0",
+          "TEXCOORD_OCCLUSION v_texCoord_0",
+          "TEXCOORD_SPECULAR_GLOSSINESS v_texCoord_0",
+          "USE_SPECULAR_GLOSSINESS",
         ]);
 
         const specularGlossiness = primitive.material.specularGlossiness;
@@ -327,23 +374,37 @@ describe(
           primitive,
           mockFrameState
         );
-        expectShaderLines(shaderBuilder._fragmentShaderParts.uniformLines, [
-          "uniform sampler2D u_diffuseTexture;",
-          "uniform vec4 u_diffuseFactor;",
-          "uniform sampler2D u_specularGlossinessTexture;",
-          "uniform vec3 u_specularFactor;",
+
+        ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, []);
+        ShaderBuilderTester.expectHasFragmentUniforms(shaderBuilder, [
           "uniform float u_glossinessFactor;",
+          "uniform sampler2D u_diffuseTexture;",
+          "uniform sampler2D u_emissiveTexture;",
+          "uniform sampler2D u_normalTexture;",
+          "uniform sampler2D u_occlusionTexture;",
+          "uniform sampler2D u_specularGlossinessTexture;",
+          "uniform vec3 u_emissiveFactor;",
+          "uniform vec3 u_specularFactor;",
+          "uniform vec4 u_diffuseFactor;",
         ]);
 
-        expectShaderLines(shaderBuilder._fragmentShaderParts.defineLines, [
-          "USE_SPECULAR_GLOSSINESS",
-          "HAS_DIFFUSE_TEXTURE",
-          "TEXCOORD_DIFFUSE v_texCoord_0",
+        ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, []);
+        ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
           "HAS_DIFFUSE_FACTOR",
-          "HAS_SPECULAR_GLOSSINESS_TEXTURE",
-          "TEXCOORD_SPECULAR_GLOSSINESS v_texCoord_0",
-          "HAS_SPECULAR_FACTOR",
+          "HAS_DIFFUSE_TEXTURE",
+          "HAS_EMISSIVE_FACTOR",
+          "HAS_EMISSIVE_TEXTURE",
           "HAS_GLOSSINESS_FACTOR",
+          "HAS_NORMAL_TEXTURE",
+          "HAS_OCCLUSION_TEXTURE",
+          "HAS_SPECULAR_FACTOR",
+          "HAS_SPECULAR_GLOSSINESS_TEXTURE",
+          "TEXCOORD_DIFFUSE v_texCoord_0",
+          "TEXCOORD_EMISSIVE v_texCoord_0",
+          "TEXCOORD_NORMAL v_texCoord_0",
+          "TEXCOORD_OCCLUSION v_texCoord_0",
+          "TEXCOORD_SPECULAR_GLOSSINESS v_texCoord_0",
+          "USE_SPECULAR_GLOSSINESS",
         ]);
 
         const expectedUniforms = {
@@ -372,15 +433,16 @@ describe(
           mockFrameState
         );
 
-        expect(shaderBuilder._vertexShaderParts.uniformLines).toEqual([]);
-        expectShaderLines(shaderBuilder._fragmentShaderParts.uniformLines, [
+        ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, []);
+        ShaderBuilderTester.expectHasFragmentUniforms(shaderBuilder, [
           "uniform vec3 u_emissiveFactor;",
         ]);
 
-        expectShaderLines(shaderBuilder._fragmentShaderParts.defineLines, [
+        ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, []);
+        ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
           "HAS_EMISSIVE_FACTOR",
+          "USE_METALLIC_ROUGHNESS",
         ]);
-
         const material = primitive.material;
         const expectedUniforms = {
           u_emissiveFactor: material.emissiveFactor,
@@ -409,16 +471,36 @@ describe(
           mockFrameState
         );
 
-        expectShaderLines(shaderBuilder._fragmentShaderParts.uniformLines, [
-          "uniform vec4 u_baseColorFactor;",
+        ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, []);
+        ShaderBuilderTester.expectHasFragmentUniforms(shaderBuilder, [
           "uniform float u_metallicFactor;",
           "uniform float u_roughnessFactor;",
+          "uniform sampler2D u_baseColorTexture;",
+          "uniform sampler2D u_emissiveTexture;",
+          "uniform sampler2D u_metallicRoughnessTexture;",
+          "uniform sampler2D u_normalTexture;",
+          "uniform sampler2D u_occlusionTexture;",
+          "uniform vec3 u_emissiveFactor;",
+          "uniform vec4 u_baseColorFactor;",
         ]);
 
-        expectShaderLines(shaderBuilder._fragmentShaderParts.defineLines, [
+        ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, []);
+        ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
           "HAS_BASE_COLOR_FACTOR",
+          "HAS_BASE_COLOR_TEXTURE",
+          "HAS_EMISSIVE_FACTOR",
+          "HAS_EMISSIVE_TEXTURE",
           "HAS_METALLIC_FACTOR",
+          "HAS_METALLIC_ROUGHNESS_TEXTURE",
+          "HAS_NORMAL_TEXTURE",
+          "HAS_OCCLUSION_TEXTURE",
           "HAS_ROUGHNESS_FACTOR",
+          "TEXCOORD_BASE_COLOR v_texCoord_0",
+          "TEXCOORD_EMISSIVE v_texCoord_0",
+          "TEXCOORD_METALLIC_ROUGHNESS v_texCoord_0",
+          "TEXCOORD_NORMAL v_texCoord_0",
+          "TEXCOORD_OCCLUSION v_texCoord_0",
+          "USE_METALLIC_ROUGHNESS",
         ]);
 
         const expectedUniforms = {
@@ -638,8 +720,8 @@ describe(
           mockFrameState
         );
 
-        expect(shaderBuilder._vertexShaderParts.shaderLines).toEqual([]);
-        expect(shaderBuilder._fragmentShaderParts.shaderLines).toEqual([
+        ShaderBuilderTester.expectVertexLinesEqual(shaderBuilder, []);
+        ShaderBuilderTester.expectFragmentLinesEqual(shaderBuilder, [
           _shadersMaterialStageFS,
         ]);
       });
@@ -658,8 +740,18 @@ describe(
           mockFrameState
         );
 
-        expectShaderLines(shaderBuilder._fragmentShaderParts.defineLines, [
+        ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
           "HAS_DOUBLE_SIDED_MATERIAL",
+        ]);
+        ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
+          "HAS_BASE_COLOR_TEXTURE",
+          "HAS_DOUBLE_SIDED_MATERIAL",
+          "HAS_METALLIC_ROUGHNESS_TEXTURE",
+          "HAS_NORMAL_TEXTURE",
+          "TEXCOORD_BASE_COLOR v_texCoord_0",
+          "TEXCOORD_METALLIC_ROUGHNESS v_texCoord_0",
+          "TEXCOORD_NORMAL v_texCoord_0",
+          "USE_METALLIC_ROUGHNESS",
         ]);
       });
     });
@@ -679,10 +771,12 @@ describe(
         "TEST"
       );
 
-      expectShaderLines(shaderBuilder._fragmentShaderParts.defineLines, [
+      ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, []);
+      ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
         "HAS_TEST_TEXTURE_TRANSFORM",
       ]);
-      expectShaderLines(shaderBuilder._fragmentShaderParts.uniformLines, [
+      ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, []);
+      ShaderBuilderTester.expectHasFragmentUniforms(shaderBuilder, [
         "uniform mat3 u_testTextureTransform;",
       ]);
       expectUniformMap(uniformMap, {
@@ -709,12 +803,14 @@ describe(
         mockFrameState.context.defaultTexture
       );
 
-      expectShaderLines(shaderBuilder._fragmentShaderParts.defineLines, [
+      ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, []);
+      ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
         "HAS_TEST_TEXTURE",
         "TEXCOORD_TEST v_texCoord_1",
         "HAS_TEST_TEXTURE_TRANSFORM",
       ]);
-      expectShaderLines(shaderBuilder._fragmentShaderParts.uniformLines, [
+      ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, []);
+      ShaderBuilderTester.expectHasFragmentUniforms(shaderBuilder, [
         "uniform sampler2D u_testTexture;",
         "uniform mat3 u_testTextureTransform;",
       ]);

--- a/Specs/Scene/Model/Model3DTileContentSpec.js
+++ b/Specs/Scene/Model/Model3DTileContentSpec.js
@@ -12,7 +12,6 @@ import {
   ColorGeometryInstanceAttribute,
   ContentMetadata,
   defaultValue,
-  defined,
   destroyObject,
   Ellipsoid,
   GeometryInstance,
@@ -1021,52 +1020,27 @@ describe(
         if (webglStub) {
           return;
         }
-        if (webglStub) {
-          return;
-        }
         return Cesium3DTilesTester.loadTileset(
           scene,
           pointCloudBatchedUrl
         ).then(function (tileset) {
-          const content = tileset.root.content;
-
           // Get the number of picked sections with back face culling on
           let pickedCountCulling = 0;
           let pickedCount = 0;
-          let picked;
-
-          const callback = function (result) {
-            picked = result;
-          };
 
           // Set culling to true
           tileset.pointCloudShading.backFaceCulling = true;
 
-          expect(scene).toPickAndCall(callback);
-
-          while (defined(picked)) {
-            picked.show = false;
-            expect(scene).toPickAndCall(callback);
-            ++pickedCountCulling;
-          }
-
-          // Set the shows back to true
-          const length = content.featuresLength;
-          for (let i = 0; i < length; ++i) {
-            const feature = content.getFeature(i);
-            feature.show = true;
-          }
+          expect(scene).toDrillPickAndCall(function (pickedObjects) {
+            pickedCountCulling = pickedObjects.length;
+          });
 
           // Set culling to false
           tileset.pointCloudShading.backFaceCulling = false;
 
-          expect(scene).toPickAndCall(callback);
-
-          while (defined(picked)) {
-            picked.show = false;
-            expect(scene).toPickAndCall(callback);
-            ++pickedCount;
-          }
+          expect(scene).toDrillPickAndCall(function (pickedObjects) {
+            pickedCount = pickedObjects.length;
+          });
 
           expect(pickedCount).toBeGreaterThan(pickedCountCulling);
         });

--- a/Specs/Scene/Model/Model3DTileContentSpec.js
+++ b/Specs/Scene/Model/Model3DTileContentSpec.js
@@ -125,6 +125,8 @@ describe(
     const centerLongitude = -1.31968;
     const centerLatitude = 0.698874;
 
+    const webglStub = !!window.webglStub;
+
     function setCamera(longitude, latitude, range) {
       // One feature is located at the center, point the camera there
       const center = Cartesian3.fromRadians(longitude, latitude);
@@ -1015,6 +1017,13 @@ describe(
       });
 
       it("Supports back face culling when there are per-point normals", function () {
+        // Since this test relies on picking, it will not work properly with webglStub
+        if (webglStub) {
+          return;
+        }
+        if (webglStub) {
+          return;
+        }
         return Cesium3DTilesTester.loadTileset(
           scene,
           pointCloudBatchedUrl

--- a/Specs/Scene/Model/Model3DTileContentSpec.js
+++ b/Specs/Scene/Model/Model3DTileContentSpec.js
@@ -1014,8 +1014,7 @@ describe(
         });
       });
 
-      // This will be added in a separate PR
-      xit("Supports back face culling when there are per-point normals", function () {
+      it("Supports back face culling when there are per-point normals", function () {
         return Cesium3DTilesTester.loadTileset(
           scene,
           pointCloudBatchedUrl
@@ -1031,38 +1030,36 @@ describe(
             picked = result;
           };
 
-          expect(scene).toPickAndCall(function (result) {
-            // Set culling to true
-            tileset.pointCloudShading.backFaceCulling = true;
+          // Set culling to true
+          tileset.pointCloudShading.backFaceCulling = true;
 
+          expect(scene).toPickAndCall(callback);
+
+          while (defined(picked)) {
+            picked.show = false;
             expect(scene).toPickAndCall(callback);
+            ++pickedCountCulling;
+          }
 
-            while (defined(picked)) {
-              picked.show = false;
-              expect(scene).toPickAndCall(callback);
-              ++pickedCountCulling;
-            }
+          // Set the shows back to true
+          const length = content.featuresLength;
+          for (let i = 0; i < length; ++i) {
+            const feature = content.getFeature(i);
+            feature.show = true;
+          }
 
-            // Set the shows back to true
-            const length = content.featuresLength;
-            for (let i = 0; i < length; ++i) {
-              const feature = content.getFeature(i);
-              feature.show = true;
-            }
+          // Set culling to false
+          tileset.pointCloudShading.backFaceCulling = false;
 
-            // Set culling to false
-            tileset.pointCloudShading.backFaceCulling = false;
+          expect(scene).toPickAndCall(callback);
 
+          while (defined(picked)) {
+            picked.show = false;
             expect(scene).toPickAndCall(callback);
+            ++pickedCount;
+          }
 
-            while (defined(picked)) {
-              picked.show = false;
-              expect(scene).toPickAndCall(callback);
-              ++pickedCount;
-            }
-
-            expect(pickedCount).toBeGreaterThan(pickedCountCulling);
-          });
+          expect(pickedCount).toBeGreaterThan(pickedCountCulling);
         });
       });
 

--- a/Specs/Scene/Model/Model3DTileContentSpec.js
+++ b/Specs/Scene/Model/Model3DTileContentSpec.js
@@ -1020,6 +1020,7 @@ describe(
         if (webglStub) {
           return;
         }
+
         return Cesium3DTilesTester.loadTileset(
           scene,
           pointCloudBatchedUrl

--- a/Specs/Scene/Model/PointCloudStylingPipelineStageSpec.js
+++ b/Specs/Scene/Model/PointCloudStylingPipelineStageSpec.js
@@ -3,7 +3,6 @@ import {
   Cartesian3,
   Cesium3DTileRefine,
   Cesium3DTileStyle,
-  defined,
   defaultValue,
   Math as CesiumMath,
   Matrix4,
@@ -63,16 +62,11 @@ describe(
     };
 
     function mockGltfRenderResources(pointCloudShading) {
-      const attenuation = defined(pointCloudShading)
-        ? pointCloudShading.attenuation
-        : false;
-
       const shaderBuilder = new ShaderBuilder();
       const uniformMap = {};
       const mockModel = {
         type: ModelType.GLTF,
         pointCloudShading: pointCloudShading,
-        _attenuation: attenuation,
       };
 
       return {
@@ -88,10 +82,6 @@ describe(
         options.pointCloudShading,
         new PointCloudShading()
       );
-      const attenuation = defined(pointCloudShading)
-        ? pointCloudShading.attenuation
-        : false;
-
       const shaderBuilder = new ShaderBuilder();
       const uniformMap = {};
       const mockModel = {
@@ -99,7 +89,6 @@ describe(
         content: options.content,
         style: options.style,
         pointCloudShading: pointCloudShading,
-        _attenuation: attenuation,
         structuralMetadata: options.structuralMetadata,
         featureTableId: options.featureTableId,
         featureTables: options.featureTables,

--- a/Specs/Scene/Model/PointCloudStylingPipelineStageSpec.js
+++ b/Specs/Scene/Model/PointCloudStylingPipelineStageSpec.js
@@ -136,7 +136,8 @@ describe(
     });
 
     it("adds common uniform and code to the shader", function () {
-      const renderResources = mockGltfRenderResources();
+      const pointCloudShading = new PointCloudShading();
+      const renderResources = mockGltfRenderResources(pointCloudShading);
       const shaderBuilder = renderResources.shaderBuilder;
       const uniformMap = renderResources.uniformMap;
 
@@ -648,6 +649,36 @@ describe(
       expect(uniformMap.model_pointCloudParameters).toBeDefined();
 
       // No additional functions from the style should have been added.
+      ShaderBuilderTester.expectVertexLinesEqual(shaderBuilder, [
+        _shadersPointCloudStylingStageVS,
+      ]);
+    });
+
+    it("adds point cloud back face culling define to the shader", function () {
+      const pointCloudShading = new PointCloudShading({
+        backFaceCulling: true,
+      });
+      const renderResources = mockGltfRenderResources(pointCloudShading);
+      const shaderBuilder = renderResources.shaderBuilder;
+      const uniformMap = renderResources.uniformMap;
+
+      PointCloudStylingPipelineStage.process(
+        renderResources,
+        mockPrimitive,
+        scene.frameState
+      );
+
+      ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
+        "HAS_POINT_CLOUD_BACK_FACE_CULLING",
+      ]);
+
+      ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, []);
+      ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, [
+        "uniform vec4 model_pointCloudParameters;",
+      ]);
+      ShaderBuilderTester.expectHasFragmentUniforms(shaderBuilder, []);
+      expect(uniformMap.model_pointCloudParameters).toBeDefined();
+
       ShaderBuilderTester.expectVertexLinesEqual(shaderBuilder, [
         _shadersPointCloudStylingStageVS,
       ]);


### PR DESCRIPTION
Fixes #10632 

This PR adds support for `pointCloudShading.backFaceCulling` which culls back-facing points for point clouds that have normals.

[Sandcastle example](http://localhost:8080/Apps/Sandcastle/index.html#c=bZFfa8IwFMW/SuhTBUkYe5tVhpU9DTZQ9pSXmFw1M80tzW1Fx777krYbbrN9aP6cc/idW40+EOssnKBhc+bhxEoItq34W3+Wy0z3+xI9KeuhkdlkJn16de8l6yAARfOQwoMGD7xubGXJdhC4Mia/Ch4+96vNYMw/pGesbdwDk5lY16CDWClS4pdOvKL1VDpszdVyqUgfwIiRgb8H9DKbSv85GSBHpAtitcF8lA1Xa+WNVoEcJMAN7vcOli0R+th5qfSRPSkNrGyds34fU3/6HZTBU5iyXes1WfQsTw0iiD6CkX7C+kbfTPUP7ToaYxTfxvCUPUbHyY3eWQKfZdOsCHR2sEgx6Xm0VY0NpSHlnAuCqnaK4lC2bbQR1yGkTklaiGtrYWzHrJnf+IlMOxVCvNlFirW9gMwWhYj6f1aHPfZLB41T5yQ73C2eh0POeSHi9raTEN1WNX+SvwA)
![2022-08-18_PointsBackFaceCulling](https://user-images.githubusercontent.com/8422414/185473167-d084e0a4-62c8-42f8-a73e-125beb5dba77.gif)