### PR TITLE
Fix Camera.flyTo with rectangle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,7 +32,7 @@
 
 - Fixed bug with `Viewer.flyTo` where camera could go underground when target is an `Entity` with `ModelGraphics` with `HeightReference.CLAMP_TO_GROUND` or `HeightReference.RELATIVE_TO_GROUND`. [#10631](https://github.com/CesiumGS/cesium/pull/10631)
 - Fixed the incorrect lighting of instanced models. [#10690](https://github.com/CesiumGS/cesium/pull/10690)
-- Fixed developer error with `Camera.flyTo` with an `orientation` and a `Rectangle` value for `destination. [#10704](https://github.com/CesiumGS/cesium/issues/10704)
+- Fixed developer error with `Camera.flyTo` with an `orientation` and a `Rectangle` value for `destination`. [#10704](https://github.com/CesiumGS/cesium/issues/10704)
 
 ### 1.96 - 2022-08-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@
 
 - Fixed bug with `Viewer.flyTo` where camera could go underground when target is an `Entity` with `ModelGraphics` with `HeightReference.CLAMP_TO_GROUND` or `HeightReference.RELATIVE_TO_GROUND`. [#10631](https://github.com/CesiumGS/cesium/pull/10631)
 - Fixed the incorrect lighting of instanced models. [#10690](https://github.com/CesiumGS/cesium/pull/10690)
+- Fixed developer error with `Camera.flyTo` with an `orientation` and a `Rectangle` value for `destination. [#10704](https://github.com/CesiumGS/cesium/issues/10704)
 
 ### 1.96 - 2022-08-01
 

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -3337,6 +3337,14 @@ Camera.prototype.flyTo = function (options) {
 
   this.cancelFlight();
 
+  const isRectangle = defined(destination.west);
+  if (isRectangle) {
+    destination = this.getRectangleCameraCoordinates(
+      destination,
+      scratchFlyToDestination
+    );
+  }
+
   let orientation = defaultValue(
     options.orientation,
     defaultValue.EMPTY_OBJECT
@@ -3363,14 +3371,6 @@ Camera.prototype.flyTo = function (options) {
       options.complete();
     }
     return;
-  }
-
-  const isRectangle = defined(destination.west);
-  if (isRectangle) {
-    destination = this.getRectangleCameraCoordinates(
-      destination,
-      scratchFlyToDestination
-    );
   }
 
   const that = this;

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -3337,7 +3337,7 @@ Camera.prototype.flyTo = function (options) {
 
   this.cancelFlight();
 
-  const isRectangle = defined(destination.west);
+  const isRectangle = destination instanceof Rectangle;
   if (isRectangle) {
     destination = this.getRectangleCameraCoordinates(
       destination,

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -4177,7 +4177,7 @@ describe("Scene/Camera", function () {
 
     expect(camera.direction).toEqualEpsilon(direction, CesiumMath.EPSILON6);
     expect(camera.up).toEqualEpsilon(up, CesiumMath.EPSILON6);
-    expect(camera.position).toEqualEpsilon(expectedDestination, 0.1);
+    expect(camera.position).toEqualEpsilon(expectedDestination, CesiumMath.EPSILON1);
   });
 
   it("flyTo does not zoom closer than minimumZoomDistance", function () {

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -4153,6 +4153,33 @@ describe("Scene/Camera", function () {
     ).toBe(true);
   });
 
+  it("flyTo rectangle with orientation", function () {
+    scene.mode = SceneMode.SCENE3D;
+
+    const direction = Cartesian3.negate(Cartesian3.UNIT_Z, new Cartesian3());
+    const up = Cartesian3.clone(Cartesian3.UNIT_Y);
+
+    const west = 0.3323436621771766;
+    const south = 0.8292930502744068;
+    const east = 0.3325710961342694;
+    const north = 0.8297059734014236;
+    const rectangle = new Rectangle(west, south, east, north);
+
+    const expectedDestination = camera.getRectangleCameraCoordinates(rectangle);
+    camera.flyTo({
+      destination: rectangle,
+      orientation: {
+        direction: direction,
+        up: up,
+      },
+      duration: 0.0,
+    });
+
+    expect(camera.direction).toEqualEpsilon(direction, CesiumMath.EPSILON6);
+    expect(camera.up).toEqualEpsilon(up, CesiumMath.EPSILON6);
+    expect(camera.position).toEqualEpsilon(expectedDestination, 0.1);
+  });
+
   it("flyTo does not zoom closer than minimumZoomDistance", function () {
     const tweenSpy = spyOn(CameraFlightPath, "createTween").and.returnValue({});
     spyOn(scene.tweens, "add");

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -4177,7 +4177,10 @@ describe("Scene/Camera", function () {
 
     expect(camera.direction).toEqualEpsilon(direction, CesiumMath.EPSILON6);
     expect(camera.up).toEqualEpsilon(up, CesiumMath.EPSILON6);
-    expect(camera.position).toEqualEpsilon(expectedDestination, CesiumMath.EPSILON1);
+    expect(camera.position).toEqualEpsilon(
+      expectedDestination,
+      CesiumMath.EPSILON1
+    );
   });
 
   it("flyTo does not zoom closer than minimumZoomDistance", function () {


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/10704

This [Sandcastle example](https://sandcastle.cesium.com/#c=dVLLbhshFP0VNKuJ5DK8H7FjVfK2UqW26mo2BJMEFYMF2JEb5d/LeJrIadIFEvdwz+MCNsVSwdG7R5fBDYjuEWxc8Ycd/HnG+rGz53qTYjU+ujx2V8sxjtGemVtXqo+m+hTf0r85W028D64nkDGmGcMKMS6IknQxRgQFwVQzjiSimAglXkFFEWGUEY61auBMJ1pgwTjHmPM3/j43o3fuG5Nr25lIezCpUoEVkappSEFZUwWfEOQES8wlp6iloGIym1BFsCBEcq2F1OzS7LD/rwtqKQXHLbhoVpRzNqtRSTnTmhHWBlDngRBUmCJJBNZUEymlmD3mR4DFuuigNTuXDbwLpx+pf2p5L296yg9S9q49yVRfg6fXe1i0lM9jfJ40u0U3dsup+WUBsCr1FNx6LgD47Hf7lNtoOfQQDtXt9sG0oYbbg/3lKrSlXC3/ModL6mrrj8Bvbz74H8AGU0o7uTuE8N3/dmO3Xg2t/x01JLP18f7r0eVgTlPbA15/mUEI4Wpo5cfMmlK4Nfkf5T8) will fail in `main`, but should work in this branch (although the orientation will be pointed out away from earth and into space).

The source of the error was that the `Rectangle` value was being passed to an internal function that expected a `Cartesian3` instead. Added a quick unit test to make sure this doesn't pop up again.