### PR TITLE
Avoid using a closure in the render loop when pushing model draw commands

### DIFF
--- a/Source/Scene/Model/ModelSceneGraph.js
+++ b/Source/Scene/Model/ModelSceneGraph.js
@@ -714,7 +714,7 @@ ModelSceneGraph.prototype.updateJointMatrices = function () {
  * @param {traverseSceneGraphCallback} callback The callback to perform on the runtime primitives of the node.
  * @param {Object} [callbackOptions] A dictionary of additional options to be passed to the callback, if needed.
  *
- * @privatewith
+ * @private
  */
 function traverseSceneGraph(
   sceneGraph,

--- a/Source/Scene/Model/ModelSceneGraph.js
+++ b/Source/Scene/Model/ModelSceneGraph.js
@@ -756,6 +756,10 @@ function forEachRuntimePrimitive(
   }
 }
 
+const scratchBackFaceCullingOptions = {
+  backFaceCulling: undefined,
+};
+
 /**
  * Traverses through all draw commands and changes the back-face culling setting.
  *
@@ -764,10 +768,24 @@ function forEachRuntimePrimitive(
  * @private
  */
 ModelSceneGraph.prototype.updateBackFaceCulling = function (backFaceCulling) {
-  forEachRuntimePrimitive(this, false, function (runtimePrimitive) {
-    const drawCommand = runtimePrimitive.drawCommand;
-    drawCommand.backFaceCulling = backFaceCulling;
-  });
+  const backFaceCullingOptions = scratchBackFaceCullingOptions;
+  backFaceCullingOptions.backFaceCulling = backFaceCulling;
+  forEachRuntimePrimitive(
+    this,
+    false,
+    updatePrimitiveBackFaceCulling,
+    backFaceCullingOptions
+  );
+};
+
+// Callback is defined here to avoid allocating a closure in the render loop
+function updatePrimitiveBackFaceCulling(runtimePrimitive, options) {
+  const drawCommand = runtimePrimitive.drawCommand;
+  drawCommand.backFaceCulling = options.backFaceCulling;
+}
+
+const scratchShadowOptions = {
+  shadowMode: undefined,
 };
 
 /**
@@ -778,10 +796,19 @@ ModelSceneGraph.prototype.updateBackFaceCulling = function (backFaceCulling) {
  * @private
  */
 ModelSceneGraph.prototype.updateShadows = function (shadowMode) {
-  forEachRuntimePrimitive(this, false, function (runtimePrimitive) {
-    const drawCommand = runtimePrimitive.drawCommand;
-    drawCommand.shadows = shadowMode;
-  });
+  const shadowOptions = scratchShadowOptions;
+  shadowOptions.shadowMode = shadowMode;
+  forEachRuntimePrimitive(this, false, updatePrimitiveShadows, shadowOptions);
+};
+
+// Callback is defined here to avoid allocating a closure in the render loop
+function updatePrimitiveShadows(runtimePrimitive, options) {
+  const drawCommand = runtimePrimitive.drawCommand;
+  drawCommand.shadows = options.shadowMode;
+}
+
+const scratchShowBoundingVolumeOptions = {
+  debugShowBoundingVolume: undefined,
 };
 
 /**
@@ -794,11 +821,22 @@ ModelSceneGraph.prototype.updateShadows = function (shadowMode) {
 ModelSceneGraph.prototype.updateShowBoundingVolume = function (
   debugShowBoundingVolume
 ) {
-  forEachRuntimePrimitive(this, false, function (runtimePrimitive) {
-    const drawCommand = runtimePrimitive.drawCommand;
-    drawCommand.debugShowBoundingVolume = debugShowBoundingVolume;
-  });
+  const showBoundingVolumeOptions = scratchShowBoundingVolumeOptions;
+  showBoundingVolumeOptions.debugShowBoundingVolume = debugShowBoundingVolume;
+
+  forEachRuntimePrimitive(
+    this,
+    false,
+    updatePrimitiveShowBoundingVolume,
+    showBoundingVolumeOptions
+  );
 };
+
+// Callback is defined here to avoid allocating a closure in the render loop
+function updatePrimitiveShowBoundingVolume(runtimePrimitive, options) {
+  const drawCommand = runtimePrimitive.drawCommand;
+  drawCommand.debugShowBoundingVolume = options.debugShowBoundingVolume;
+}
 
 const scratchSilhouetteCommands = [];
 const scratchPushDrawCommandOptions = {
@@ -839,7 +877,7 @@ ModelSceneGraph.prototype.pushDrawCommands = function (frameState) {
   frameState.commandList.push.apply(frameState.commandList, silhouetteCommands);
 };
 
-// This callback avoids allocating a closure every frame in pushDrawCommands() above
+// Callback is defined here to avoid allocating a closure in the render loop
 function pushPrimitiveDrawCommands(runtimePrimitive, options) {
   const frameState = options.frameState;
   const hasSilhouette = options.hasSilhouette;

--- a/Source/Scene/Model/ModelSceneGraph.js
+++ b/Source/Scene/Model/ModelSceneGraph.js
@@ -693,6 +693,17 @@ ModelSceneGraph.prototype.updateJointMatrices = function () {
 };
 
 /**
+ * A callback to be applied once at each runtime primitive in the
+ * scene graph
+ * @callback traverseSceneGraphCallback
+ *
+ * @param {ModelRuntimePrimitive} runtimePrimitive The runtime primitive for the current step of the traversal
+ * @param {Object} [options] A dictionary of additional options to be passed to the callback, or undefined if the callback does not need any additional information.
+ *
+ * @private
+ */
+
+/**
  * Recursively traverse through the runtime nodes in the scene graph
  * using a post-order depth-first traversal to perform a callback on
  * their runtime primitives.
@@ -700,9 +711,10 @@ ModelSceneGraph.prototype.updateJointMatrices = function () {
  * @param {ModelSceneGraph} sceneGraph The scene graph.
  * @param {ModelRuntimeNode} runtimeNode The current runtime node.
  * @param {Boolean} visibleNodesOnly Whether to only traverse nodes that are visible.
- * @param {Function} callback The callback to perform on the runtime primitives of the node.
+ * @param {traverseSceneGraphCallback} callback The callback to perform on the runtime primitives of the node.
+ * @param {Object} [callbackOptions] A dictionary of additional options to be passed to the callback, if needed.
  *
- * @private
+ * @privatewith
  */
 function traverseSceneGraph(
   sceneGraph,
@@ -857,7 +869,6 @@ ModelSceneGraph.prototype.pushDrawCommands = function (frameState) {
   // each primitive can only be invoked after the entire model has drawn.
   // Otherwise, the silhouette may draw on top of the model. This requires
   // gathering the original commands and the silhouette commands separately.
-
   const silhouetteCommands = scratchSilhouetteCommands;
   silhouetteCommands.length = 0;
 


### PR DESCRIPTION
`ModelSceneGraph.pushDrawCommands()` was using an anonymous function, which means a closure was being allocated every frame. with a scratch variable and a private function, I was able to avoid the allocations.

I still want to verify in the DevTools profiler that this makes a noticeable difference, but otherwise this is ready for review @j9liu