### PR TITLE
Unload array buffers after parsing the model

### DIFF
--- a/Source/Scene/GltfLoader.js
+++ b/Source/Scene/GltfLoader.js
@@ -400,7 +400,12 @@ GltfLoader.prototype.load = function () {
         }
 
         if (loader._state === GltfLoaderState.PROCESSED) {
-          unloadBufferViews(loader); // Buffer views can be unloaded after the data has been copied
+          // The buffer views can be unloaded once the data is copied.
+          unloadBufferViews(loader);
+
+          // Similarly, if the glTF was loaded from a typed array, release the memory
+          loader._typedArray = undefined;
+
           loader._state = GltfLoaderState.READY;
           resolve(loader);
         }
@@ -2399,6 +2404,7 @@ GltfLoader.prototype.unload = function () {
   unloadStructuralMetadata(this);
 
   this._components = undefined;
+  this._typedArray = undefined;
   this._state = GltfLoaderState.UNLOADED;
 };
 

--- a/Source/Scene/Model/B3dmLoader.js
+++ b/Source/Scene/Model/B3dmLoader.js
@@ -260,6 +260,9 @@ B3dmLoader.prototype.load = function () {
       createStructuralMetadata(that, components);
       that._components = components;
 
+      // Now that we have the parsed components, we can release the array buffer
+      that._arrayBuffer = undefined;
+
       that._state = B3dmLoaderState.READY;
       return that;
     })
@@ -363,6 +366,7 @@ B3dmLoader.prototype.unload = function () {
   }
 
   this._components = undefined;
+  this._arrayBuffer = undefined;
 };
 
 export default B3dmLoader;

--- a/Source/Scene/Model/I3dmLoader.js
+++ b/Source/Scene/Model/I3dmLoader.js
@@ -290,6 +290,9 @@ I3dmLoader.prototype.load = function () {
       createStructuralMetadata(that, components);
       that._components = components;
 
+      // Now that we have the parsed components, we can release the array buffer
+      that._arrayBuffer = undefined;
+
       that._state = I3dmLoaderState.READY;
       return that;
     })
@@ -767,6 +770,7 @@ I3dmLoader.prototype.unload = function () {
     this._gltfLoader.unload();
   }
   this._components = undefined;
+  this._arrayBuffer = undefined;
 };
 
 export default I3dmLoader;

--- a/Source/Scene/Model/PntsLoader.js
+++ b/Source/Scene/Model/PntsLoader.js
@@ -663,8 +663,9 @@ function makeComponents(loader, context) {
 
   loader._components = components;
 
-  // Free the parsed content so we don't hold onto the large typed arrays.
+  // Free the parsed content and array buffer so we don't hold onto the large arrays.
   loader._parsedContent = undefined;
+  loader._arrayBuffer = undefined;
 }
 
 function addPropertyAttributesToPrimitive(
@@ -707,6 +708,7 @@ PntsLoader.prototype.unload = function () {
 
   this._components = undefined;
   this._parsedContent = undefined;
+  this._arrayBuffer = undefined;
 };
 
 export default PntsLoader;

--- a/Specs/Scene/GltfLoaderSpec.js
+++ b/Specs/Scene/GltfLoaderSpec.js
@@ -259,6 +259,13 @@ describe(
       });
     });
 
+    it("releases GLB typed array when finished loading", function () {
+      return loadGltf(boxTexturedBinary).then(function (gltfLoader) {
+        expect(gltfLoader.components).toBeDefined();
+        expect(gltfLoader._typedArray).not.toBeDefined();
+      });
+    });
+
     it("loads BoxInterleaved", function () {
       return loadGltf(boxInterleaved).then(function (gltfLoader) {
         const components = gltfLoader.components;

--- a/Specs/Scene/Model/B3dmLoaderSpec.js
+++ b/Specs/Scene/Model/B3dmLoaderSpec.js
@@ -78,6 +78,13 @@ describe("Scene/Model/B3dmLoader", function () {
     }).toThrowError(RuntimeError);
   }
 
+  it("releases array buffer when finished loading", function () {
+    return loadB3dm(noBatchIdsUrl).then(function (loader) {
+      expect(loader.components).toBeDefined();
+      expect(loader._arrayBuffer).not.toBeDefined();
+    });
+  });
+
   it("loads BatchedNoBatchIds", function () {
     return loadB3dm(noBatchIdsUrl).then(function (loader) {
       const components = loader.components;

--- a/Specs/Scene/Model/I3dmLoaderSpec.js
+++ b/Specs/Scene/Model/I3dmLoaderSpec.js
@@ -119,6 +119,13 @@ describe("Scene/Model/I3dmLoader", function () {
     }
   }
 
+  it("releases array buffer when finished loading", function () {
+    return loadI3dm(InstancedWithBatchTableUrl).then(function (loader) {
+      expect(loader.components).toBeDefined();
+      expect(loader._arrayBuffer).not.toBeDefined();
+    });
+  });
+
   it("loads InstancedGltfExternalUrl", function () {
     return loadI3dm(InstancedGltfExternalUrl).then(function (loader) {
       const components = loader.components;

--- a/Specs/Scene/Model/PntsLoaderSpec.js
+++ b/Specs/Scene/Model/PntsLoaderSpec.js
@@ -276,6 +276,13 @@ describe("Scene/Model/PntsLoader", function () {
     expect(attribute.quantization).not.toBeDefined();
   }
 
+  it("releases array buffer when finished", function () {
+    return loadPnts(pointCloudRGBUrl).then(function (loader) {
+      expect(loader.components).toBeDefined();
+      expect(loader._arrayBuffer).not.toBeDefined();
+    });
+  });
+
   it("loads PointCloudRGB", function () {
     return loadPnts(pointCloudRGBUrl).then(function (loader) {
       const components = loader.components;


### PR DESCRIPTION
This PR cleans up a few of the `Model`-related loaders so they don't keep large typed arrays around after parsing the file into a `ModelComponents` object.

The changes include:

1. in `GltfLoader`, setting `_typedArray` to undefined
2. in `B3dmLoader`, setting `_arrayBuffer` to undefined
3. in `PntsLoader`, setting `_arrayBuffer` to undefined
4. in `I3dmLoader`, setting `_arrayBuffer` to undefined

To check the difference in memory, try the following steps:

1. Load a tileset/model that use b3dm/pnts/i3dm/glb files
2. Take a heap snapshot in the `Memory` tab of DevTools
3. Search for the respective loader (e.g. `B3dmLoader`) in the search bar
4. Inspect the `_arrayBuffer`/`_typedArray` field. It should be undefined, rather than an `ArrayBuffer`/typed array like it was before this PR.

![image](https://user-images.githubusercontent.com/8422414/186009462-19417e1f-a831-40c6-ac07-c4de5fdbf34d.png)

Furthermore, to make sure this change doesn't negatively impact caching, I created [this Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=zVh7b9s2EP8qnFE0EurITtqgm+0Ga5xszZY0QWO0f8TBSktMzIUmPZJy4gb+7js+JFGu0+ZVbIZg8XGP3x2Px6NSwZVGM0quiERvECdXqE8UzSfJRzsWDRup7fcF15hyIoeNJroZcoTUGGfiSnWQljlpDvki7g65k5SQa014FnlRbtB1Xu4OKCNqn6spSbWQh/SacsOZWiS0GDfqD0VGGKDyQtOVAqx0SwlCSgApE+llkuZSEq4HdELqxv2RM4r5LtYk2ny19XprczPZ2Hr1+pfN2ApxWFRKOKnU2y5MM6KRNhCIDohnAV7rHk8C/jk1XeRGzY/jCemgYWPgKMChxYwkSuQyJZ1iAAFZkrTgOcGTKSOAGLdqjmx5KWWj5RUnfyvBS9mL5m0gJOaK5WDbY4HsYJ2OSVa8A8EPh9Q6muJ/cvLDkDnxEIP3hHiYM03XU8GEfFpsfSNS3RPNBwJGQAx+FCyfkCeOp09Uj10u8GqclntC9OY9rbMMNNsc4BG7LyJIIBrz9NGYSjlV62lwtY4khRDFmgZsT4YxEH5PgH0xmQpF9WMDrZQTtO6H5FhQrvtM5I9dw0pQ0Pzw+86D8fSF9bPuP0GGWAmupuDBMN8LOcFM/QiAXvSDoT1NwlgJrcgiD4W2K3EqfgQwK/hbsM7svyIMKh84xxxhB+U8I+dQm2XNlXWZrVJ84XPJoS4SuU406LqMyqolrHu0EGyETTmYiRRSPdfJBdF7jJjmznw/g6LQ0wwbhnFZNp5O2XyH8ozyC1XpaBaS41WIDHSj52ikiJyZxBlyDhveLNBoKVU+UqmkIxKd5zw1aQxFhBu2LC4WryjcHCfY4wm6ZnrxMBR1338LjZiatyrR2PoxmUo6oZrOiEokmYgZectYFHcdCT1H0U8ekV/SUkxcheTXRXLigwZsLIOhW8WnziX33YUx2jQqjrC+DfHhDFa62AVV7VwLZKKjmyrsc8k6yANOim3RrOad/3fJKL/4RCU5l3Zv+Th1JIvYtZxLXLvVQu+FNpRjqiD8IUyzEj+M5BC1c1hXR+2CWOgxkYP/wMaJWY9DrCW97hTiXPdVci7FxFWf9uCNKq66diw1tDB/GbWbCJ6tdty8hdaLjuJqPr6Tx1c5vBYZYBzO5scAmaqSOgG38iDIg6j8TlxWV6aC3K/JFwFOETVfeNrbbH4HwCC1HFPI4x8wvyA1ZgQeq/fXN5PlIXDbOJng62ij3U7aaL00eiRym7dOphA/JJGgKVewCEk7DiWE7i4dV0XfVIopkZoSVVmeVIOBE8yWDwUv7f6KJ0bPn9+JENxDL8Y6RBguUrW+dtPU78Vh3J+Y6eim7jd75emgpVFrdkbtnijvu+HvdNh4duNwLdD2G/TzS/MZYdiw4qK1aS7hmFwzbt6Kh42z5h0ktGsSJMnW7sj5us4ppImguzJvbNaY54QxcXVnzTVeRid3V1vjTOeYf4PT7u6QfsTyWzQtjyxq/UUcBOpiOWFAMkhNJRUewFIKWYs2PZbiCtnxbiUgPIDL4zVZOlt91q7lEXXaPgsqlTHmGVv+cHWSSkL4yRSnZG8GFcs7RxQVX4Ywn2HldHt+0Kz3+TTXb60dgUHmgDZVj7fJaT0nGA5Us3NWJDw/aS00e3tpm/rp6jSv5QuorUzC8ESmDjmuJsoqwbEwwi/0GKgD3sQNerpzIVFkvlZRoGp34dXzXF304gUN1mkZRF3qKT3rhpSCkYSJi+jzs5uKatFBz25WAI8qknjxOa6qEPu3aN62aoP5lCQHe78N/uof7Pf//N+sV2GiGkNcw1LBHccxf9+aw/3d3YO9yp5Gs9GzOXi78O6vFC7CUpsaI4LbgyZwe8BQCrRGeXoJGTtVqvBgrxWy9jI6QzR7s+JrLUoZVgpmznPGTugXSA3bvRbQf8XKhD1Wj2ZEMjw3ZOON7QM3mCRJrwXd1ZzlbaC0pOc2M8rg6rM+gqsAUPmiqVN+Gm0WddSAXMM1Zs1cteAQmGHIV53la05J3Mf2DfT9sRCKIIw8CYBcs9Y51gqMwdyjJmKQhpUwbhqT9HIkrsE/IUQ7TLIOKm8b2+jENWuWB+1/AQ) that loads the tilesets twice, all of the tilesets should work fine.

Note: for `B3dmLoader`, this intentionally does not call `gltfLoader.unload()`, as that ends up destroying some resources that are still needed. But internally the `GltfLoader` does clean up its buffer views and now the whole `_typedArray` once finished loading

@j9liu could you review when you get a chance?