### PR TITLE
Add `sideEffects` field to `package.json`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@
 
 - `Model` can now classify other assets with a given `classificationType`. [#10623](https://github.com/CesiumGS/cesium/pull/10623)
 - `Model` now supports back face culling for point clouds. [#10703](https://github.com/CesiumGS/cesium/pull/10703)
+- The `sideEffects` field in `package.json` is now defined, allowing more conservative bundlers like Webpack to enable tree shaking by default.
 
 ##### Fixes :wrench:
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     }
   },
   "type": "module",
-  "sideEffects": ["./Source/ThirdParty/*", "./Source/Workers/*"],
+  "sideEffects": ["./Source/ThirdParty/**/*", "./Source/Widgets/**/*.css", "./Source/Workers/*", "./Specs/**/*"],
   "dependencies": {
     "@tweenjs/tween.js": "^18.6.4",
     "@zip.js/zip.js": "2.4.x",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     }
   },
   "type": "module",
+  "sideEffects": ["./Source/ThirdParty/*", "./Source/Workers/*"],
   "dependencies": {
     "@tweenjs/tween.js": "^18.6.4",
     "@zip.js/zip.js": "2.4.x",


### PR DESCRIPTION
As mentioned in https://github.com/CesiumGS/cesium/issues/9212#issuecomment-1220818901, the [`sideEffects` field in `package.json`](https://webpack.js.org/guides/tree-shaking/) is necessary to enable tree shaking in conservative build tools such as Webpack. CesiumJS has generally maintained a fairly agnostic `package.json` file, but I think it's worth it to include such a field in this case since it's a dramatic optimization benefit for a popular build tool. While specific to bundlers like Webpack, it's common that libraries, such as [three.js](https://github.com/mrdoob/three.js/blob/dev/package.json) and [BabylonJS](https://github.com/BabylonJS/Babylon.js/blob/master/packages/public/%40babylonjs/core/package.json), define it.

This can be tested with a fairly minimal Webpack config, eg. https://github.com/CesiumGS/cesium-webpack-example. Without `sideEffects` defined, the default app is 17.2MB bundled. With `sideEffects`, the default app drops to 14.2MB bundled. If you have an even smaller example, say and app that only imports `Cartesian3`, it can drop to ~100KB.