### PR TITLE
Remove references to old content classes from JSDoc

### DIFF
--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -619,8 +619,8 @@ function Cesium3DTileset(options) {
    *
    * @example
    * tileset.tileVisible.addEventListener(function(tile) {
-   *     if (tile.content instanceof Cesium.Batched3DModel3DTileContent) {
-   *         console.log('A Batched 3D Model tile is visible.');
+   *     if (tile.content instanceof Cesium.Model3DTileContent) {
+   *         console.log('A 3D model tile is visible.');
    *     }
    * });
    *

--- a/Source/Scene/PointCloud.js
+++ b/Source/Scene/PointCloud.js
@@ -46,12 +46,11 @@ const DecodingState = {
 /**
  * Represents the contents of a
  * {@link https://github.com/CesiumGS/3d-tiles/tree/main/specification/TileFormats/PointCloud|Point Cloud}
- * tile. Used internally by {@link PointCloud3DTileContent} and {@link TimeDynamicPointCloud}.
+ * tile. Used internally by {@link TimeDynamicPointCloud}.
  *
  * @alias PointCloud
  * @constructor
  *
- * @see PointCloud3DTileContent
  * @see TimeDynamicPointCloud
  *
  * @private

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -1004,7 +1004,8 @@ describe(
     });
 
     it("verify memory usage statistics", function () {
-      // Calculations in Batched3DModel3DTileContentSpec, minus uvs
+      // 10 buildings, 36 ushort indices and 24 vertices per building, 6 float components (position, normal) and 1 uint component (batchId) per vertex.
+      // 10 * ((24 * (6 * 4 + 1 * 4)) + (36 * 2)) = 7440
       const singleTileGeometryMemory = 7440;
       const singleTileTextureMemory = 0;
       const singleTileBatchTextureMemory = 40;


### PR DESCRIPTION
In documentation comments, there were a few dangling references to `Batched3DModel3DTileContent` and `PointCloud3DTileContent` in the JSDoc that we missed when removing those classes. This PR removes those references.

@j9liu could you review when you get a chance?