### PR TITLE
Prevent `Model` from resetting draw commands for picking

### DIFF
--- a/Source/Scene/Model/CPUStylingPipelineStage.js
+++ b/Source/Scene/Model/CPUStylingPipelineStage.js
@@ -5,7 +5,6 @@ import defined from "../../Core/defined.js";
 import ModelColorPipelineStage from "./ModelColorPipelineStage.js";
 import Pass from "../../Renderer/Pass.js";
 import ShaderDestination from "../../Renderer/ShaderDestination.js";
-import StyleCommandsNeeded from "./StyleCommandsNeeded.js";
 
 /**
  * The CPU styling stage is responsible for ensuring that the feature's color is applied at runtime.
@@ -23,7 +22,6 @@ CPUStylingPipelineStage.name = "CPUStylingPipelineStage"; // Helps with debuggin
  *  <li>adds the styling code to both the vertex and fragment shaders</li>
  *  <li>adds the define to trigger the stage's shader functions</li>
  *  <li>adds a uniform with the model's color blend mode and amount</li>
- *  <li>sets a variable in the render resources denoting whether or not the model has translucent colors that will require multiple draw commands</li>
  * </ul>
  *
  * @param {PrimitiveRenderResources} renderResources The render resources for this primitive.
@@ -44,8 +42,8 @@ CPUStylingPipelineStage.process = function (
   shaderBuilder.addFragmentLines([CPUStylingStageFS]);
   shaderBuilder.addDefine("USE_CPU_STYLING", undefined, ShaderDestination.BOTH);
 
-  // These uniforms may have already been added by the ModelColorStage if a static
-  // color is applied.
+  // These uniforms may have already been added by the ModelColorStage
+  // if a static color is applied.
   if (!defined(model.color)) {
     shaderBuilder.addUniform(
       "float",
@@ -72,18 +70,6 @@ CPUStylingPipelineStage.process = function (
     // change the value with the translucencyMode parameter
     return renderResources.alphaOptions.pass === Pass.TRANSLUCENT;
   };
-
-  const featureTable = model.featureTables[model.featureTableId];
-  const styleCommandsNeeded = StyleCommandsNeeded.getStyleCommandsNeeded(
-    featureTable.featuresLength,
-    featureTable.batchTexture.translucentFeaturesLength
-  );
-
-  if (styleCommandsNeeded === StyleCommandsNeeded.ALL_TRANSLUCENT) {
-    renderResources.alphaOptions.pass = Pass.TRANSLUCENT;
-  }
-
-  renderResources.styleCommandsNeeded = styleCommandsNeeded;
 };
 
 export default CPUStylingPipelineStage;

--- a/Source/Scene/Model/CPUStylingPipelineStage.js
+++ b/Source/Scene/Model/CPUStylingPipelineStage.js
@@ -7,7 +7,8 @@ import Pass from "../../Renderer/Pass.js";
 import ShaderDestination from "../../Renderer/ShaderDestination.js";
 
 /**
- * The CPU styling stage is responsible for ensuring that the feature's color is applied at runtime.
+ * The CPU styling stage is responsible for ensuring that the feature's color
+ * is applied at runtime.
  *
  * @namespace CPUStylingPipelineStage
  *

--- a/Source/Scene/Model/Model.js
+++ b/Source/Scene/Model/Model.js
@@ -1668,7 +1668,7 @@ Model.prototype.applyArticulations = function () {
 };
 
 /**
- * Marks the model's {@link Cesium3DTileset#style} as dirty, which forces all
+ * Marks the model's {@link Model#style} as dirty, which forces all
  * features to re-evaluate the style in the next frame the model is visible.
  */
 Model.prototype.makeStyleDirty = function () {
@@ -1717,14 +1717,14 @@ Model.prototype.update = function (frameState) {
     return;
   }
 
+  updateFeatureTableId(this);
+  updateFeatureTables(this, frameState);
+  updateStyle(this);
   updatePointCloudShading(this);
   updateSilhouette(this, frameState);
   updateSkipLevelOfDetail(this, frameState);
   updateClippingPlanes(this, frameState);
   updateSceneMode(this, frameState);
-  updateFeatureTableId(this);
-  updateFeatureTables(this, frameState);
-  updateStyle(this);
 
   this._defaultTexture = frameState.context.defaultTexture;
 
@@ -2734,7 +2734,7 @@ Model.prototype.applyStyle = function () {
     return;
   }
 
-  const style = this.style;
+  const style = this._style;
   // The style is only set by the ModelFeatureTable. If there are no features,
   // the color and show from the style are directly applied.
   if (hasFeatureTable) {

--- a/Source/Scene/Model/Model.js
+++ b/Source/Scene/Model/Model.js
@@ -1718,8 +1718,8 @@ Model.prototype.update = function (frameState) {
   }
 
   updateFeatureTableId(this);
-  updateFeatureTables(this, frameState);
   updateStyle(this);
+  updateFeatureTables(this, frameState);
   updatePointCloudShading(this);
   updateSilhouette(this, frameState);
   updateSkipLevelOfDetail(this, frameState);
@@ -2698,6 +2698,7 @@ Model.fromGeoJson = function (options) {
  * @private
  */
 Model.prototype.applyColorAndShow = function (style) {
+  const previousColor = this._color;
   const hasColorStyle = defined(style) && defined(style.color);
   const hasShowStyle = defined(style) && defined(style.show);
 
@@ -2705,6 +2706,10 @@ Model.prototype.applyColorAndShow = function (style) {
     ? style.color.evaluateColor(undefined, this._color)
     : Color.clone(Color.WHITE, this._color);
   this._show = hasShowStyle ? style.show.evaluate(undefined) : true;
+
+  if (isColorAlphaDirty(previousColor, this._color)) {
+    this.resetDrawCommands();
+  }
 };
 
 /**

--- a/Source/Scene/Model/ModelDrawCommand.js
+++ b/Source/Scene/Model/ModelDrawCommand.js
@@ -56,18 +56,22 @@ function ModelDrawCommand(options) {
   const isTranslucent = command.pass === Pass.TRANSLUCENT;
   const isDoubleSided = runtimePrimitive.primitive.material.doubleSided;
   const usesBackFaceCulling = !isDoubleSided && !isTranslucent;
+  const hasSilhouette = renderResources.hasSilhouette;
 
   // If the command was already translucent, there's no need to derive a new
   // translucent command. As of now, a style can't change an originally
   // translucent feature to opaque since the style's alpha is modulated,
-  // not replaced. When this changes, we need to derive new opaque commands \
+  // not replaced. When this changes, we need to derive new opaque commands
   // in initialize().
-  const needsTranslucentCommand = !isTranslucent;
+  //
+  // Silhouettes for primitives with both opaque and translucent features
+  // are not yet supported.
+  const needsTranslucentCommand = !isTranslucent && !hasSilhouette;
 
   const needsSkipLevelOfDetailCommands =
     renderResources.hasSkipLevelOfDetail && !isTranslucent;
 
-  const needsSilhouetteCommands = renderResources.hasSilhouette;
+  const needsSilhouetteCommands = hasSilhouette;
 
   this._command = command;
 

--- a/Source/Scene/Model/ModelDrawCommand.js
+++ b/Source/Scene/Model/ModelDrawCommand.js
@@ -530,7 +530,7 @@ ModelDrawCommand.prototype.pushCommands = function (frameState, result) {
       pushCommand(result, this._translucentCommand, use2D);
     }
 
-    // If the opaque command is needed, don't return here.
+    // Continue only if opaque commands are needed.
     if (styleCommandsNeeded === StyleCommandsNeeded.ALL_TRANSLUCENT) {
       return;
     }

--- a/Source/Scene/Model/PrimitiveRenderResources.js
+++ b/Source/Scene/Model/PrimitiveRenderResources.js
@@ -292,16 +292,6 @@ function PrimitiveRenderResources(nodeRenderResources, runtimePrimitive) {
    * @private
    */
   this.pickId = undefined;
-
-  /**
-   * An enum describing the types of draw commands needed, based on the style.
-   * This value is set by CPUStylingPipelineStage.
-   *
-   * @type {StyleCommandsNeeded}
-   *
-   * @private
-   */
-  this.styleCommandsNeeded = undefined;
 }
 
 export default PrimitiveRenderResources;

--- a/Source/Scene/Model/StyleCommandsNeeded.js
+++ b/Source/Scene/Model/StyleCommandsNeeded.js
@@ -2,7 +2,7 @@
  * An enum describing what commands (opaque or translucent) are required by
  * a {@link Cesium3DTileStyle}.
  *
- * @enum
+ * @enum {Number}
  * @private
  */
 const StyleCommandsNeeded = {

--- a/Source/Scene/Model/StyleCommandsNeeded.js
+++ b/Source/Scene/Model/StyleCommandsNeeded.js
@@ -1,6 +1,8 @@
 /**
- * An enum describing what commands (opaque) are required by a Cesium3DTileStyle.
+ * An enum describing what commands (opaque or translucent) are required by
+ * a {@link Cesium3DTileStyle}.
  *
+ * @enum
  * @private
  */
 const StyleCommandsNeeded = {

--- a/Specs/Scene/Model/CPUStylingPipelineStageSpec.js
+++ b/Specs/Scene/Model/CPUStylingPipelineStageSpec.js
@@ -6,7 +6,6 @@ import {
   ModelAlphaOptions,
   Pass,
   ShaderBuilder,
-  StyleCommandsNeeded,
   _shadersCPUStylingStageFS,
   _shadersCPUStylingStageVS,
 } from "../../../Source/Cesium.js";
@@ -121,50 +120,5 @@ describe("Scene/Model/CPUStylingPipelineStage", function () {
     renderResources.alphaOptions.pass = Pass.TRANSLUCENT;
 
     expect(uniformMap.model_commandTranslucent()).toBe(true);
-  });
-
-  it("sets the style commands needed when only opaque commands are needed", function () {
-    const renderResources = clone(defaultRenderResources, true);
-    const batchTexture = {
-      translucentFeaturesLength: 0,
-      featuresLength: 10,
-    };
-    renderResources.model.featureTables[0].batchTexture = batchTexture;
-
-    CPUStylingPipelineStage.process(renderResources);
-
-    expect(renderResources.styleCommandsNeeded).toEqual(
-      StyleCommandsNeeded.ALL_OPAQUE
-    );
-  });
-
-  it("sets the style commands needed when only translucent commands are needed", function () {
-    const renderResources = clone(defaultRenderResources, true);
-    const batchTexture = {
-      translucentFeaturesLength: 10,
-    };
-    renderResources.model.featureTables[0].batchTexture = batchTexture;
-
-    CPUStylingPipelineStage.process(renderResources);
-
-    expect(renderResources.styleCommandsNeeded).toEqual(
-      StyleCommandsNeeded.ALL_TRANSLUCENT
-    );
-    expect(renderResources.alphaOptions.pass).toEqual(Pass.TRANSLUCENT);
-  });
-
-  it("sets the style commands needed when both opaque and translucent commands are needed", function () {
-    const renderResources = clone(defaultRenderResources, true);
-    const batchTexture = {
-      translucentFeaturesLength: 5,
-    };
-    renderResources.model.featureTables[0].batchTexture = batchTexture;
-
-    CPUStylingPipelineStage.process(renderResources);
-
-    expect(renderResources.styleCommandsNeeded).toEqual(
-      StyleCommandsNeeded.OPAQUE_AND_TRANSLUCENT
-    );
-    expect(renderResources.alphaOptions.pass).toBeUndefined();
   });
 });

--- a/Specs/Scene/Model/ModelSpec.js
+++ b/Specs/Scene/Model/ModelSpec.js
@@ -966,8 +966,6 @@ describe(
           });
 
           model.style = style;
-          //model.applyStyle(); // TODO: why is this not taking effect when called by
-          // verifyRender?
           verifyRender(model, true);
           expect(model._styleCommandsNeeded).toBe(
             StyleCommandsNeeded.ALL_OPAQUE
@@ -981,11 +979,17 @@ describe(
           });
 
           model.style = style;
-          model.applyStyle();
           verifyRender(model, true);
           expect(model._styleCommandsNeeded).toBe(
             StyleCommandsNeeded.ALL_TRANSLUCENT
           );
+
+          // Does not render with invisible color.
+          style = new Cesium3DTileStyle({
+            color: {
+              conditions: [["${height} > 1", "color('red', 0.0)"]],
+            },
+          });
 
           // Does not render when style disables show.
           style = new Cesium3DTileStyle({

--- a/Specs/Scene/Model/ModelSpec.js
+++ b/Specs/Scene/Model/ModelSpec.js
@@ -956,9 +956,7 @@ describe(
         function (result) {
           model = result;
           // Renders without style.
-          verifyRender(model, true, {
-            zoomToModel: false,
-          });
+          verifyRender(model, true);
 
           // Renders with opaque style.
           style = new Cesium3DTileStyle({
@@ -968,9 +966,12 @@ describe(
           });
 
           model.style = style;
-          verifyRender(model, true, {
-            zoomToModel: false,
-          });
+          //model.applyStyle(); // TODO: why is this not taking effect when called by
+          // verifyRender?
+          verifyRender(model, true);
+          expect(model._styleCommandsNeeded).toBe(
+            StyleCommandsNeeded.ALL_OPAQUE
+          );
 
           // Renders with translucent style.
           style = new Cesium3DTileStyle({
@@ -980,27 +981,25 @@ describe(
           });
 
           model.style = style;
-          verifyRender(model, true, {
-            zoomToModel: false,
-          });
+          model.applyStyle();
+          verifyRender(model, true);
+          expect(model._styleCommandsNeeded).toBe(
+            StyleCommandsNeeded.ALL_TRANSLUCENT
+          );
 
           // Does not render when style disables show.
           style = new Cesium3DTileStyle({
-            color: {
-              conditions: [["${height} > 1", "color('red', 0.0)"]],
+            show: {
+              conditions: [["${height} > 1", "false"]],
             },
           });
 
           model.style = style;
-          verifyRender(model, false, {
-            zoomToModel: false,
-          });
+          verifyRender(model, false);
 
           // Render when style is removed.
           model.style = undefined;
-          verifyRender(model, true, {
-            zoomToModel: false,
-          });
+          verifyRender(model, true);
         }
       );
     });
@@ -2815,27 +2814,6 @@ describe(
             const reference2 = commands[2].renderState.stencilTest.reference;
             expect(reference2).toEqual(reference1 + 1);
           });
-        });
-      });
-
-      it("silhouette works with style", function () {
-        const style = new Cesium3DTileStyle({
-          color: {
-            conditions: [["${height} > 1", "color('red', 0.5)"]],
-          },
-        });
-        return loadAndZoomToModel(
-          { gltf: buildingsMetadata, silhouetteSize: 1.0 },
-          scene
-        ).then(function (model) {
-          model.style = style;
-          scene.renderForSpecs();
-          const commandList = scene.frameState.commandList;
-          expect(commandList.length).toBe(2);
-          expect(commandList[0].renderState.stencilTest.enabled).toBe(true);
-          expect(commandList[0].pass).toBe(Pass.TRANSLUCENT);
-          expect(commandList[1].renderState.stencilTest.enabled).toBe(true);
-          expect(commandList[1].pass).toBe(Pass.TRANSLUCENT);
         });
       });
     });


### PR DESCRIPTION
This PR refactors `Model` such that it doesn't `resetDrawCommands()` every time a feature is picked and colored translucent. Here's the [local Sandcastle I used for testing](http://localhost:8080/Apps/Sandcastle/index.html#c=zRprc9pI8q/MUVsJ7BFZ4o0db52NIeYWP8omm9sLKUdIg5nzaIbSwzab+L9fz0NCQpJN6rxb5w8Y1D3dPT39Hu3toWuboZFvM4cEDkcj7PtrdBwR6hJ2i1ZLHvJb3/Y8HMJzj7uYopXP74mLXTRfoyPscwHDjzPmcBaE6J7gB+yjQ8TwAxrggESe8Zt8Vp1VHPl7wFloE4b9WaWOvs0YQiGwhSeXirK/Hy90fGyH+BP3qTtVKNVaXSwgbMGP+eM+Wtg0wPIR92HlmLl4heGDhVPYVEAjBzNnvcF7qh3M2IwpKQ2HcufOcCLfFwuIh0FuzfqfESU2OwH2xgL2OA54r2NaVcFpVmmYDeudZb0z+9OGud/o7je7hml1zE6r1W03W71Or9Vvdv89q8yY4qd0E4AwgoXmLn+mwCGhOMBhVnfqX/NkqoBVqa/Ip4mOxpxd4YBHvqMkPQoAbexWu912r9utbfasmUi12CHhbIuR7YfwzWZNucl3ltHs99oNq9lo9Rtmp9GRWjaNbq/RNNuNXtfqNvqw1fixabUbrVbLMtv9Rsfsq53rLRnScs7s0CePGxWr3y0p9XQjVjUlopI8oWI/Ei/yrsEsMLte2Q4e+j4XxtYzTMCUCjVWxLnbHH54glfhElBCP8IJDiW3y9AgLMQsIOEawF1JIbEMTconHgnJPQ4M23WrWg4hlEb7g4PoPA2Ysb09NKJrFHJkI0YcjPg99gU+4gsULjFygKOxsUHbw75tLOgaCMnTdXEQEib3v//MCcEZNbpms9MyjZ7Z6rV7LXUW8LzV6FhWxzL6fbPZarc6LQ1o9nrdVrNvtC3LMluNbkc8rmn3IaCsPNNTbItQcElCZ3nFKdWsTaPRAC4doNRqtpvtdqsXMwdQp9GyWu1mp9E2O+1Gtx6vMcVfpw+G0+02Gk0L7KvZj2V4StR3Ha5Bn+jwNf82HuBQOwjIgjhys5JXuctJsDoWh1MOoQmimPhS/emb/P9UgyhW6GPS+j4R5vKH4Ie5fFMqA3ouEWIG++jz51lFMPVWnAHlJ6Ef9FYzeCtiaSzaWwjZ67d14ZUg3ZcvUv9PWRUvbQiXr6tjTfok8rw1CiQDsHcb4h4OA2n5H88n4ymSzifSi4gKBhqBB0cBRg8E/FT6R+aAUCCUE6sWe6twDfnq1gMVqE2gQxWU7zlx0UKDzkSuiPHGbBWFaBHI/3VIHhx+On94N3FYwj6xKfL0lxr69jSrHMQsI0ZJwipzglEQck9B1OHFOzsTdJMIPUk/NaQO5IksMtuY4sdwv2h/29YVi/l6Il0eX5UK9DUxRGANARN9Gp+fXHwCtiJeZkGjq6OzIUCsHOTT0WQCgEYOcHVxMQJAMwe4/vX3yfjD6RSArRzwaHx1M7g4PxlPxxfnw6ubT6fjqWDcfhHzeHI0+BUwOy9iTpXI3RziYHIhSfRykMvxZHJ0dQ2wfn4/06vhcHoT78nKa296dTQajQcblFiN6vM1zVtRRJLtAkqsyMdjF1hqGkbyLNh8vTEz4sDiBaqmFh8qxaSoIyQDDWFrNPfBpTfPY1GMYIWdiNrCiu+x06yaRr8n4lbfFJ/tfu2gYJHPo9slw0EgjNCwEpQnhKHIk3JtVmUkzBzC9+8lWMU2szO6Msad0aWdlWIL/4hB26p1I0qRTSOPsMjbTbmWVG5Dfe6g3HaRcjMC6nDw/fuWprX7bsvs2Xc4nR/raA7GCsU5F1kCQTPCAXiLIRASSAL3WCVEBHASIsr5XQAh7Q5niJLwrXgKtgyVJBh1AE1EwdYSklofliGtrCk+zEJl2HS1tHdVhDrHrBpURNx+quPEtm5WtvBHkQEfbEoDUIaLVoTCCQboYUlCLGpKiBegvkDhSbdCsospkN4li4VIrIfII4/V7cf1RAk1oYDeDtbQ31ZCVv65L7IKZghDwbsOlyLFC7RnRPu7IGu2f4i1+qL/fd3OjucX09Px+Yeb6+FkOJgOT0QgbSS5PMAUO+FIHcZuCTRiZMF9L0hqsuhGUcGuprO/0UO4XuEkyX5UK6fwzBifT+sx0j34LGBtS6rhT0m19ick7zLt/N8mmJyy0fv8Jt68yfpXblHG00rjI7iCDAi9tkw+3R9LPs+bpRfRkKwoHiUb/yutbzS5OPqz7O/5ejZngeOTa/PmmRoS4NbN6GhwdDIsLBglvLBqFGeILj9eXU6Gm4wnjxJO1dpE+BT278PJRMqxyQc6KRRhn1/cTMGPU+i1v7ZCM1/2IBGHF4TheFFQSMh6iZAlCTkcUs82qZggwEUEn3Po2jQGHI7u9ThyMezFE5I8LDGARLqKCSHbT5LCgnLoEEmg+lghl3hQTe/5MG00G6eMV45sB+wtv9LSK2Nzyq+84nzx3DphZrWD3LancZr2xfoH1YCjNaYUNiCS9kJJFENWkb+iyYalKYWCxGFsUYlg+rFI1+JrXRtofaOfn7XYtfI1ygW21iglbVblMvHPh5LSQVkYE4099jgaRcyRAwn0ajODhSYJNrOwIU4GVe0A8dwv0NOTiAEGmJR7kIY6qaApkZJ2PYsm6shjipkr4tZmCpmewwwyOMYpVLCyii0hdOTxSCo/rg9jlMSWJvYcUx3nnlKD4CV/uMzO1g+T3R9kdCJQB5mBSKydjbYOipRVMOb6X/VxNv5XvI+MfEcUjEkMLO9xsahFm5DCCG9akgC5dmiL+n9pQ3CAGCLmXumoEkIyga/Gs0q2csLlB3E7Kq9kgpdjsJr7cfR+ifSWmWanODnCt5y6mE155Cx/jG5BhZsjni9GflD2kmImZgSnekmcO3QKwZC+3pRRkz6dnk3kTJ3aa7QQvSFYl+g1YnthtoeR2CaHwCYQY7cTgAu9EPyNO5FIzvqWaUix+FWdVVxyP6ukhvxOfF9l2CtxuTRYEupWU8QEbuqnIV3v3JbXSbPK3HbuXJ+v5EgxjSaNDQJwsFICzSqMM1yCtuIB0Zc2s4o9DziNwjJcyMlwXBLTLEGheBE+h/B5VllxcT/iv4NujoXBrPLlRRFtV94aCrTW6rFMOFDHLVTRoEfZ2UsVUXhYgi87X3nZI1FXPn5HSakMCzira/KHwrUaWooZoxBcMLPnFAvLVFLqGyFlG0tlq9l6PH3TJLSgDbqauSRybHZvB8IGNA1DXMCJ2upIuls18buqB9YojEx7m2hwMkLVUnN/kEncZGH3Yv4f8Oita0N5y5XQM8AqL7WBxDleEM8QIEDSZg6GmqUg1Oc7pedNdS6HDpWDcuzECr/+lOq+klsvoTTwFHHrdIpFR4HeoaL9GOukxVo9fn2GnzZp4FZI5jGzXF8FxZcpsC6tK+MWh5fgstgP1+LaOkZTYSFNwYNO0L4V5vZ1EGPto/Q1zWzGRkkiE6AMoySJPRVvTSQ+cV+uZNTc4iJtawizY2xJ6rvs+p1Xw9qnepmHyHbz7OLj9fDm7OK3YboFhrN27k5/xM3+Yv8qcqxVgVfF+tbS65o042w19ObNDmib468p7JT7FSRysXHd1qcm3LNKbiYgryRjeDHDZKhcYkyvxn57zJBjvJtNTYaj6c1gMh78mvQjH8evfn15DRbm2EEI1g/JbMpvbyk+jiCOMQgDQ2lKUp9gS+LCNWNcdbQxRHmTu8RC8TOmD3U7/Wj4wdakyIUuSwyXPos1+jhCOUuZVbI9Q6JmWCcPYL+gsUhNc7aIXQMuylblJRSzSC9QTDUDu1Ev7R7KGaVe70C6Pi8gni/inxEdIh6UDS66PL5CSUlfQDRd8ZeT+yDLdyTr9wIiqeq+nMaZrrLRJn2gaxwWCZUvyBOyXw7yVs3p3PbPMIuq0tiU9UmXGjPh3ere3Z6LKZW8kFcvSNE1WkKilkNBnLRnSQGVAh2qvSziCWXSuMevmtwSZtOBetUhPf+Ury/Il0FiJ1dFop0U93rMAvItRWlvpN7YKUwipcmCszPRH5wBFemucchP/FWoY5Hi/AC9KVSf9wSWZVVRFxvkUlXJ0zj/bEX/1Ko4FteSoF8AVG06KDQNyyjwoHRtbmIimzO5Mdme2VL1yTFms+IoofEjZafY8d8KE95oe7M+ht9sS67TeBfpeaGAFW8vQ1qSShuSeL2P4Sx/pc96uTrVPgrWpCYkkrh8107cD1Yzj+OJnWl0BCnhgruXSpV65b2svX6Js+Q/CNSRfije+Ksaxl6IPSjJQhzszSOQEHrXIIgT6fu99NL30MUi4h4WvHSpRkMAWUSUimZpVvnl/R7g55ZSLl/+0mWhQFtav0zUQ8Mw3u/Bz+KVoQoyW5T/Cw): note that `resetDrawCommands()` shouldn't be called at any time a picked feature is being colored. In fact, the only time it needs to call `resetDrawCommands()` in that Sandcastle is for toggling between feature ID labels and custom shaders.

While refactoring this, I also included a fix that closes #10625. Here's the [sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=tVZtb9s2EP4rhD/Zg0NLfo+bBkuTNO3QYEHsdcCmYWCks0WEIg2ScpwN/u87kZJsJ87WpYhhSKTuePfc3cMjYyWNJSsOD6DJeyLhgZyD4XlGv7pvzagRu/m5kpZxCTpqtMnfkSTEpCoXyZnkGbMwIVbn0I7kpvUukpH0FmksVHxP41xrkHbGM0Afpf2fcsGZvMC1dK5V9tmo8TAIm4XlqNENuuFRGB4Fx7NuMOmOJr0RDcJhMOz3R4Nefzwc9497o9+iRiS9v06HXKsEhIlk7ELK3Azd/V5YdIAJsbC2EzTvIZAPTAilJEbkxbgQBMSoMs9lbLmSpNmq1mLATujcNKtvBVhKO/ifsmwpAONhHe+7472UTvZndCHuarfFLxxU4yKe4r1xUv98An96z6WEhJynTLPYupq8YQTXrEL/Jw6fQQ/+B/ILxKvIucqWGozBEByWt4LvvG2dVeFwcT/TOfJyIez81aH8IgW35INavwr9i5jRoLNcDyqUJPim/CoJb8sG52J3/H1cvtIqlwn5CimPxZtB915KJ/uz7+LzZ2w1TMZI5NcS4RvAo+naz97kOYH/LfV/uEbpu2O6fNLtPwFLuFzccBunt0p4YKXsmtmUWnWLGkyaZjgOWs5o4J++BXu7c76G5KNmGcw06s6VzrYdv/5kKB4LTHg99bFecwV4vjCrdHkKSKVtWsYXNR7A2G3DrzO7m81cizZJgS9SW+bbw1oqw51yjeWcaYsjJnvu9LmAhQYwZTmOwm6PBqN+fxgel8nt92kwCHqjYFh+8F6KscdDykOUmhijoEvNM3S5AkM1ZGoFZ5hTX5Od8wnxvLSKJUmJpqpCscCBvcKqN2s2YcyT4lGzwFnGmmm+nhxIffqk0rsF2KFjlbIdciFpdmal5Ush+NIontBfr6bj/o7CAS7U5NyC5Xh/yLMb1BVT/hfeI8LueCtl60I6RbKgpBvgr5RtWlXqkRqyDJoa+yhgn9j+1buYcQHTQlxlLlZC6WIP68Uda3YHA+yw/k8HrZJ0m6q23rzG1D3eYAW4AWpTkM3t/nYa9Savrj8YvGbIdnV/ZuvkPkvtS/uQycVuSQ5vx/6g1f4vnaNwT8lHc1c0QfQ1XaaggWrUzQ35gWxbiB9UOajW4Y0DGervfRiFo2rB7pqRGO5yskfbWvkLiujt5c3l2awu5Ls605vC0ZTJJGbGYmdGwzOlxB3T1yBzn2Lj4TTajRNX7dPK6488W2K/KLZCE9uoBWyjeLk0nTs86sHS2JiqJ550dpeeJHxFePL+wE2XxIIZg5J5Lhw9o8bpSQf1ny0VytXt5xVowR4LtTQ8/eI/UkpPOjg9vNL6CJ9Y/gc) to demonstrate that it works (on `main` it crashes).

Finally, to match `Cesium3DTileset`'s API I added `makeStyleDirty()`, which forces the `Model` to reapply its style. This is to account for changes like so:
```js
model.style = ....
style.color = // new color function here
```

Without `makeStyleDirty()`, the changes won't take effect. This behavior is the same for `Cesium3DTileset`.

**TODO**: write unit tests for the affected files