### PR TITLE
Improve performance of `ShaderProgram.fromCache()`

### DIFF
--- a/Source/Renderer/ShaderCache.js
+++ b/Source/Renderer/ShaderCache.js
@@ -93,7 +93,8 @@ ShaderCache.prototype.getShaderProgram = function (options) {
   }
 
   // Since ShaderSource.createCombinedXxxShader() can be expensive, use a
-  // simpler key for caching.
+  // simpler key for caching. This way, the function does not have to be called
+  // for each cache lookup.
   const vertexShaderKey = vertexShaderSource.getCacheKey();
   const fragmentShaderKey = fragmentShaderSource.getCacheKey();
   // Sort the keys in the JSON to ensure a consistent order
@@ -112,10 +113,10 @@ ShaderCache.prototype.getShaderProgram = function (options) {
     const context = this._context;
 
     const vertexShaderText = vertexShaderSource.createCombinedVertexShader(
-      this._context
+      context
     );
     const fragmentShaderText = fragmentShaderSource.createCombinedFragmentShader(
-      this._context
+      context
     );
 
     const shaderProgram = new ShaderProgram({

--- a/Source/Renderer/ShaderSource.js
+++ b/Source/Renderer/ShaderSource.js
@@ -358,6 +358,17 @@ ShaderSource.replaceMain = function (source, renamedMain) {
   return source.replace(/void\s+main\s*\(\s*(?:void)?\s*\)/g, renamedMain);
 };
 
+ShaderSource.prototype.getCacheKey = function () {
+  // Sort defines
+  const sortedDefines = this.defines.slice().sort();
+  const definesKey = sortedDefines.join(",");
+  const pickKey = this.pickColorQualifier;
+  const builtinsKey = this.includeBuiltIns;
+  const sourcesKey = this.sources.join("\n");
+
+  return `${definesKey}:${pickKey}:${builtinsKey}:${sourcesKey}`;
+};
+
 /**
  * Create a single string containing the full, combined vertex shader with all dependencies and defines.
  *

--- a/Source/Renderer/ShaderSource.js
+++ b/Source/Renderer/ShaderSource.js
@@ -358,8 +358,17 @@ ShaderSource.replaceMain = function (source, renamedMain) {
   return source.replace(/void\s+main\s*\(\s*(?:void)?\s*\)/g, renamedMain);
 };
 
+/**
+ * Since {@link ShaderSource#createCombinedVertexShader} and
+ * {@link ShaderSource#createCombinedFragmentShader} are both expensive to
+ * compute, create a simpler string key for lookups in the {@link ShaderCache}.
+ *
+ * @returns {String} A key for identifying this shader
+ *
+ * @private
+ */
 ShaderSource.prototype.getCacheKey = function () {
-  // Sort defines
+  // Sort defines to make the key comparison deterministic
   const sortedDefines = this.defines.slice().sort();
   const definesKey = sortedDefines.join(",");
   const pickKey = this.pickColorQualifier;

--- a/Specs/Renderer/ShaderSourceSpec.js
+++ b/Specs/Renderer/ShaderSourceSpec.js
@@ -91,4 +91,46 @@ describe("Renderer/ShaderSource", function () {
     expect(clone.pickColorQualifier).toEqual(source.pickColorQualifier);
     expect(clone.includeBuiltIns).toEqual(source.includeBuiltIns);
   });
+
+  it("creates cache key for empty shader", function () {
+    const source = new ShaderSource();
+    expect(source.getCacheKey()).toBe(":undefined:true:");
+  });
+
+  it("creates cache key", function () {
+    const source = new ShaderSource({
+      defines: ["A", "B", "C"],
+      sources: ["void main() { gl_FragColor = vec4(1.0); }"],
+      pickColorQualifier: "varying",
+      includeBuiltIns: false,
+    });
+
+    expect(source.getCacheKey()).toBe(
+      "A,B,C:varying:false:void main() { gl_FragColor = vec4(1.0); }"
+    );
+  });
+
+  it("uses sorted list of defines in cache key", function () {
+    const defines1 = ["A", "B", "C"];
+    const defines2 = ["B", "C", "A"];
+
+    const source1 = new ShaderSource({ defines: defines1 });
+    const source2 = new ShaderSource({ defines: defines2 });
+    const key1 = source1.getCacheKey();
+    expect(key1).toBe(source2.getCacheKey());
+    expect(key1).toBe("A,B,C:undefined:true:");
+  });
+
+  it("cache key includes all sources", function () {
+    const source = new ShaderSource({
+      sources: [
+        "vec4 getColor() { return vec4(1.0, 0.0, 0.0, 1.0); }",
+        "void main() { gl_fragColor = getColor(); }",
+      ],
+    });
+
+    expect(source.getCacheKey()).toBe(
+      ":undefined:true:vec4 getColor() { return vec4(1.0, 0.0, 0.0, 1.0); }\nvoid main() { gl_fragColor = getColor(); }"
+    );
+  });
 });


### PR DESCRIPTION
Opening this PR as a draft since I want to do more testing.

This PR changes how the cache key is generated for `ShaderCache`, which makes shader lookups a lot faster.

While profiling the new `Model`, one hotspot was the cache lookup for `ShaderProgram`. The problem is that calling `ShaderSource.combineFragmentShader()/combineVertexShader()` can be expensive, as it does many expensive string operations such as:

* Regex search to remove comments
* Regex search to extract extensions/version numbers and put them at the top
* Regex search for builtins starting with `czm_` and insert the corresponding GLSL code
* Convert the syntax to WebGL 2 if needed

For large GLSL programs like the generated `Model` shader, the above steps can get quite expensive. Thus, it's not a good idea to use the result as a cache key. Instead, this PR uses a simpler cache key formed by concatenating just the parts of the input that will affect the output:

* for the vertex/fragment shader, include only the original text, and any important options (e.g. whether this shader is for picking)
* also include the attribute locations in case the order is different. This time I sorted the keys of this dictionary to prevent false cache misses.

For an initial test, I tried running a [modified CDB Yemen Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=zVoJc9u4Ff4rqDZdSxOL5n3Ix1SWldhdH6mt7M42ymQpErIwoUgOSfnYrP57H0CQBKnDjuN2OplYEvHew8M7PwD0ojDN0B3B9zhBhyjE92iAU7KYS7+yZ+1xy2O/B1GYuSTEybi1i74tO/vjMOeSvCDyvkreIklwmI3IHIMcLuOfi4C44YmbYWmaRPOzNLJNWWmPQ4TGLVVWla6idGVnJFs91eppliQrpmzqumVoum3auqNZ/x63xiGdzWOaph4O6QR8bvYTBtmnFJDbWSaRMMNhSrJHIAOJMDoO9/aQdoJGJMApusQPGQJpdzjJsI+oYmhwcoyiKer7ONxFv+M5DlGbPouT6I74QDV5RB8SnLq3JO0UumQ4ScAkTCrOGkpJcULmJCN3OJVc32drFqybf2gnnLn9jY4jtEiCXkFyFoXXOI0WiZdbr58C4ZnfNk3Llp3OLuVYdkTjTBYk8El4m/7vVTIt3cpVQmjuPpD5Yn7jJRiHN7Hr4WGSREkPKWpN6UJtz53jxB0lbphOo2Segtps7ixXpIe4Jj5OMxK6GYnCXk1xFxyZQqBp7ZwQIV1zLMdxJFtVLUs3bHW3HNFl3ZBVybRgQDadckABFstWJd2SHRtGVDUfKVblkwR7z5m7K0uqo2mGYUMAW5ZsKLK5KwxChJswh2Fbumk5ilKOyZKlAY+hO6C8YjmyUddgET81NQhXddmxVF1VTI2uUBCum5qjaLZsa5bhKI5h7opstqWAsWzNcXRNVsSJl+yvS5I4Sl7qDN1SHEkxFN2RHc0RnaFqiiXpsuLooIJReQM8YMq2BH9gRbplOS/0Bqxb0U3TcQzFcGTbNG3RF7ZtW7aig7Got4QwkSWwkKqBUqotmzLY8vt9YeuKIZuWoRqGCv4WHa0bpmJbqgPPddNRxXlV29EVumZTtlRt1RFeAuU0eaEfbAgrCWoshIHimDU/GIoNIeLoVCNTzApHMRXJMhVVtkxLNX4gK2xZdmQNAlO2bcOxakkBBR/6gaE4siXrji0mhSorKsSHAeaiafWCpNAUR7EdQwd3G6pZc4QOBcLWFBWWZoG9xZzQTEVWQV/ZcCAMjVVX/EBCOKZjS7YBmarplT50ABwDU4MZbFnTxXyAANYkywJVdMMwrZf7wTAhEQ3b0UxD1yDrxKC3TMc0LB2yUlEg6bRassiGZVsatGfIC4iU73cEOMCE/9DWoSTItugIG+ohtbQGxRkqkCpOrBi6otgQlroKZVPTV7JiybrJdBEyE6Bp8DjIe0rUbjSXXeQvEuakTu44QAbvgkeURchFIfEwigAX0K5J8UA2w8gDJCFRygLuMIESzAHSC99zmT0k766JhoYOkjDIyaOEAHji5N+KpQtOXRFRDJV2ovZvUi1iPrzkn9hNAR+844Yq+/qw9lj618f+yXV/dDb4cnb55erjiHdtMPKS2rkJM6QEu/7jB8ADJMUS2Cxsl65o8ybOrc0bPqyVwc2VWGGo4gTfAnJIedzohiTrilMEhKJKgA6hpvLfqizL9BvVrpA/A31Av2qCCzebSVl0DY/BNG1DlmSRPiaZN9tI3VUb5GDeW4pBDZia40u0LeZSqTACtWCnAKTdbhfdZI8Bpt8qNFRYNx863ITQ2HCbGzWIqoYAUnxCbZ/20KciOD6NW2++nb4fLdHfDg/RIvTxFLC8j37+GfHnB8igyB7gPpXW3vlpakx91d/pjFufdysx/AvF708IPAID1eQrMkwgCihm8jVX0106Uzn84ikVuT6nsWFOQCTYMl5pzvo61U3rhLrrOtONcz45Uy5ZEKiq2sTTmi5qZckC1wjvZyTDItnnqnKKQJxvaF4/8kJIiCU6hIXtXA2G/cud+jp0zfSdlVCr8533fxk22ADOWJ6znW3QPx/0r4dXH28azMfHx+axsp35/XX/pskHndfXze18766uhzejOiMtaeETup6Nfq8zsQ3tbeI+bmfs33w47Z+Prq/6JyuWpf+exd3kNDVfe8q4V5eD6+Go6ZeJM9HdyXbWk+vf319ffbxsKuwcW6bxhMK/DUdreQ1X1zR1O+9Nv8l2GwX+0ym0RrGVJOI1/QPxvtLuw6t6APtwHLqTABcDh4iKL3ftMzf0g+bpi7h5voN2eZoTtfONvOeGd24qpu4cZ67vZu4VoJfApUcffuQt5sApgSTYMQwDeqqRtcctn9yNW+L5TXGyI7lxjEN/MIMG1G4IpPSNR5IXuGl66bIDn3Fr4npf/SSKx601pCmtGQBa0jhXbtwKoxBvIY2jlJUSRutO0ihYZNvoJ1GWRXNGLW8hC/A0e4oI3B9H9BAp6WJq+hRc/iyVXZ+jjnFLjx+2KQumuk0iKPIDGl2M4ydNpv+2cLEqziKCMcQJ7gZkq0ZT8OwN+TOnV8ztOkWJjxOKeRZpbQl5BGc0gE+zeXBD95/ebD9/PKd7UeIGaf3xPaaFq/GQCOE6g3FW3KDD8dOeKUTpIsG9qvex/AJkfAtYORjkrUbsSSwzOyX85weEOABg/IpieXpK9KQrjBdZnwFbAeHOYcdAU4tDXDJF7Vq+d4r+CPXhbArbDK4SundTBF68I9EihS2IYJNdqm3Eth/l01wGlc4V5ctpC3wSF93pVJuINcOSx8NOHKtZZH8LNxLgCadb5hi4AMgVIT93BEOUZpKgxHzg2d3ZX8NGzcb8V4ghMOiGHoYN2Ro48i6n2q+rQNJRDmbeFboUK6rPAvCqMMrMTWEPE+Mke4QqmS4maUaPWtK8WIqijzlEf6lsgHO50MqnTX0FBz5dSyf0BJ4l6zaOskT+8eZbBU/LXS3tKFDS6T70lKUv6qJ1PpMeC+Zl/PDHE3PyegszrhX1wEUUQppVhrIesIdHBxnd1cFHAv/9owteeHoHexl9OoP/2dGbb4XBb3FWGVzA4hQK0BuF/HdnCezZEfxJ6B8+wyTyH49EtZpVrorN+jxrgwY1quFGZk4mcq7Y4+2huBhuDArD09gND3fUHcTsfriT4Yes60Lm0rMDtt3e3zk6mBzdlBoe7E2OcuPR1fNSz8MYikObgKLyPiKwo2muH9wa3mYzGHz7VgjUtfpSB+Yuyx3UlPWJfJbSgHhYcBNCWvWj8pHPFrtmgQk1HF0fm0GUUzc9zFUNLv8uyKUmqGJ5ucX+1Ox7eYjAJwvNLZlHQsBVp6OLcwr6VlsomwzhIMXfk+4lDqmV3ryKNEqT4B3oPqdFMWedpSyvU0SynRSFUYbcgJ3llF1UKrip9IKBblBLgunKRJuaxrQs1AWd2HHpNWKI27UOtbu5QXUEMc2uVhN70X8/vBz1m75lH/BnubsJcY8eYyxdwMZx+OXi6tdh50Vg4ImWX1hxU79f0+1XDF9avjlS2qMcWNfim1wr3Z0H2HM6e1xr66/T1Ld03Re12+1pAv66YQZ5doZUybdqycNSRSE9EgwPwn0hDNc6YdqANVQz9w4zvUqMy4lAtcK1+ZFMpZSoyzqgWOm1JhnXZ3QtioSDrvVhVrba74WUjbL4dK1YP3+nbumtteL87GJYGnwNFqEdlz5FbOd7uJO/GdEl4TQ6jh66sAB3EWQjSrJTdYUtTbxo4bOjIlwR3U9TKMKenp2UX2k5Kn/86gYL/otBl7wflTPWjwQGVNkVjMq2/TRpJ1QnprP0JeZa5D/ZKmsii/EzP10PY2CgXUfLOVQAaoG3wA/cJRRtsA1ihTgKgPH2LRFCtKlEXSp0dwHD0Hz5SmKaLxBGnIzgFOKEQNmhzx+RC6HnBvfuY4rwPOb3PEXqVJEtznhIw6D/4exk3EJ//bWF5l1/MHiK5vo3KqdMEbGHUveQcIHFxrXeDiwYNqDKasYq/+rcwFgLFKky1aeKW7RsnZ/GZZVHPAWYSmsMCEE3jyF18+66u4Ygg+erJWMTrizAID3o6E7dOQkee7BpCaOUtvH9HZSRjI6/+VZO4OPUS0hM29RyhyWTMMgOCsssA7gsjBF/ySHzjMHZaoiuZVngU+E5s8JyFWAun18XKmivg7Kktt6U/Il7ihw/7Byd0ktLBPjDRUl0zzJKWOfBHjkSisUm9Fq8KsTL6BDir26vTRj2aRh1Pnw3+jI4Pxv8Up6UnhI/b2b80qGMQnYBS6Hu/QyHjGIOYAmacMpG2BNacdEketil97YUT8FEnC9OpeIoiNfl8s014VCUqk0ThZ+KpsePg+Iws3zjrZsbpNsUA1iCsZMMz9vsYrBJIUUh05npC4lZosOi334Hxl+KR8sfz+p3hbDvZ3fGtBqzGxdeQOjmqAdSrvhddnnjBKTMvT1BKaHsPPcSs7pSzv82pu3n7wq9yqz8vaNnzDpgL8a8yqT5OzbPmPPDay1z/Ro/199rSKj9y01cWzhw/D/YJHz/2eSPnEw+B0Qu+fsKHA5FUMo25MlllFfW57qy6YiyUa28GpHyu9QmvEWNt0c3Em4JvvyetpwSTdwU9gSg6oydevz3FlN7ReHVF1Q0hHI55ZHRc1f0414Qb8I3ZOWNG/qemwK+oC/TjqIomLjJBQ4X7bIqU1NuJmMBuY7k9jbAx4ssi0L+pvSQXSeUhonzewVujdpdA3tS2cSbYbo1Lk2z+W7i5edOzbtNPmeRgXnDb+22DpjAo2K6f5A5rXn09eK2JO1BL4V5MpzuTRbAnklemjbwXwkXs1n11Rcxc36H1UNK/IDSKCA+Yndm+02KLlQZihRwDxXf1pz9ZaJofrnXQ3b80KQ92BOXduCTO0T8wzUvzvN947g1XQQBvZgbtwCGAf0KaxCxN5i4LyjZTDk6zx9KknSwBz/Xc2Z5hDUk/wc). My testing procedure:
  * wait for all tiles to load
  * Start the profiler
  * Cycle through the second dropdown's options. This will change styles, triggering a rebuild of the pipeline several times
  * stop the profiler after 11 seconds
  
Initial Results:

| `main` | this branch |
|--------|-------------|
|![2022-08-25_YemenShaderPerformanceMain](https://user-images.githubusercontent.com/8422414/186749317-d2c59f72-1abb-4f06-b592-a48f6b6ad579.png)|![2022-08-25_YemenShaderPerformanceBranch](https://user-images.githubusercontent.com/8422414/186749252-86eb3456-0804-412c-8648-3ad9ed335e32.png)|

The calls to `removeComments()` and `combineShader()` which used to be a large portion of the runtime are now a tiny portion of he runtime:
![2022-08-25_YemenShaderPerformanceBranch_combineShader](https://user-images.githubusercontent.com/8422414/186749538-2ae04de5-b385-46fb-93e2-1ad79a221e2c.png)
![2022-08-25_YemenShaderPerformanceBranch_removeComments](https://user-images.githubusercontent.com/8422414/186749541-25b21569-3157-4d82-ab8f-a5137653e293.png)

Other notes:

- This profiling was done before #10723 was merged
- Even without profiling, the Sandcastle is noticeably faster after the first couple of dropdown changes

To Do:
- [x] Update unit tests
- [x] Sync with `main` and try profiling again with #10723 which improves picking/styling performance
- [x] Since this is a wide-reaching change, try other Sandcastles to make sure they work as expected 
- [x] Compare the number of shaders in the cache before and after this change, it should ideally remain the same
- [x] Try profiling complex scenes that do not include `Model/3D Tiles` to see if this change helps in other parts in Cesium