### PR TITLE
Free typed arrays for instanced models

### DIFF
--- a/Source/Scene/GltfLoader.js
+++ b/Source/Scene/GltfLoader.js
@@ -1049,10 +1049,12 @@ function loadInstancedAttribute(
   );
   const modelSemantic = semanticInfo.modelSemantic;
 
+  const isTransformAttribute =
+    modelSemantic === InstanceAttributeSemantic.TRANSLATION ||
+    modelSemantic === InstanceAttributeSemantic.ROTATION ||
+    modelSemantic === InstanceAttributeSemantic.SCALE;
   const isTranslationAttribute =
     modelSemantic === InstanceAttributeSemantic.TRANSLATION;
-  const isFeatureIdAttribute =
-    modelSemantic === InstanceAttributeSemantic.FEATURE_ID;
 
   // Load the attributes as typed arrays only if:
   // - the loader specifies (loadAttributesAsTypedArray)
@@ -1062,7 +1064,7 @@ function loadInstancedAttribute(
   // - GPU instancing is not supported.
   const loadAsTypedArrayOnly =
     loader._loadAttributesAsTypedArray ||
-    (hasRotation && !isFeatureIdAttribute) ||
+    (hasRotation && isTransformAttribute) ||
     !frameState.context.instancedArrays;
 
   const loadBuffer = !loadAsTypedArrayOnly;

--- a/Source/Scene/GltfLoader.js
+++ b/Source/Scene/GltfLoader.js
@@ -1056,15 +1056,13 @@ function loadInstancedAttribute(
 
   // Load the attributes as typed arrays only if:
   // - the loader specifies (loadAttributesAsTypedArray)
-  // - the instances have rotations. The instance matrices are computed on the CPU.
-  //   This avoids the expensive quaternion -> rotation matrix conversion in the shader.
-  // - the attribute contains feature IDs, in order to add the instance's feature ID
-  //   to the pick object.
+  // - the instances have rotations. This only applies to the transform attributes,
+  //   since The instance matrices are computed on the CPU. This avoids the
+  //   expensive quaternion -> rotation matrix conversion in the shader.
   // - GPU instancing is not supported.
   const loadAsTypedArrayOnly =
     loader._loadAttributesAsTypedArray ||
-    isFeatureIdAttribute ||
-    hasRotation ||
+    (hasRotation && !isFeatureIdAttribute) ||
     !frameState.context.instancedArrays;
 
   const loadBuffer = !loadAsTypedArrayOnly;

--- a/Source/Scene/GltfLoader.js
+++ b/Source/Scene/GltfLoader.js
@@ -1057,7 +1057,7 @@ function loadInstancedAttribute(
     modelSemantic === InstanceAttributeSemantic.TRANSLATION;
 
   // Load the attributes as typed arrays only if:
-  // - the loader specifies (loadAttributesAsTypedArray)
+  // - loadAttributesAsTypedArray is true
   // - the instances have rotations. This only applies to the transform attributes,
   //   since The instance matrices are computed on the CPU. This avoids the
   //   expensive quaternion -> rotation matrix conversion in the shader.

--- a/Source/Scene/Model/GeometryPipelineStage.js
+++ b/Source/Scene/Model/GeometryPipelineStage.js
@@ -327,8 +327,8 @@ function addAttributeToRenderResources(
     count: attribute.count,
     componentsPerAttribute: componentsPerAttribute,
     componentDatatype: ComponentDatatype.FLOAT, // Projected positions will always be floats.
-    offsetInBytes: attribute.byteOffset,
-    strideInBytes: attribute.byteStride,
+    offsetInBytes: 0,
+    strideInBytes: undefined,
     normalize: attribute.normalized,
   };
 

--- a/Source/Scene/Model/I3dmLoader.js
+++ b/Source/Scene/Model/I3dmLoader.js
@@ -357,10 +357,6 @@ I3dmLoader.prototype.process = function (frameState) {
   if (this._state === I3dmLoaderState.POST_PROCESSING) {
     this._postProcess(this, frameState);
   }
-
-  if (this._state === I3dmLoaderState.FAILED) {
-    this._fail(this);
-  }
 };
 
 function createStructuralMetadata(loader, components) {
@@ -551,11 +547,12 @@ function createInstances(loader, components, frameState) {
   translationAttribute.componentDatatype = ComponentDatatype.FLOAT;
   translationAttribute.type = AttributeType.VEC3;
   translationAttribute.count = instancesLength;
-  if (hasRotation) {
-    // If rotations are present, all transform attributes are loaded
-    // as typed arrays to compute transform matrices for the model.
-    translationAttribute.typedArray = translationTypedArray;
-  } else {
+  // The min / max values of the translation attribute need to be computed
+  // by the model pipeline, so so a pointer to the typed array is stored.
+  translationAttribute.typedArray = translationTypedArray;
+  // If there is no rotation attribute, however, the translations can also be
+  // loaded as a buffer to prevent additional resource creation in the pipeline.
+  if (!hasRotation) {
     const buffer = Buffer.createVertexBuffer({
       context: frameState.context,
       typedArray: translationTypedArray,
@@ -854,7 +851,7 @@ function unloadBuffers(loader) {
   buffers.length = 0;
 }
 
-GltfLoader.prototype.isUnloaded = function () {
+I3dmLoader.prototype.isUnloaded = function () {
   return this._state === I3dmLoaderState.UNLOADED;
 };
 

--- a/Source/Scene/Model/I3dmLoader.js
+++ b/Source/Scene/Model/I3dmLoader.js
@@ -120,8 +120,8 @@ function I3dmLoader(options) {
   this._postProcess = function (loader, frameState) {};
 
   // Instanced attributes are initially parsed as typed arrays, but if they
-  // do not to be further processed (e.g. turned into transform matrices), it is
-  // more efficient to turn them into buffers. The I3dmLoader will own the
+  // do not need to be further processed (e.g. turned into transform matrices),
+  // it is more efficient to turn them into buffers. The I3dmLoader will own the
   // resources and store them here.
   this._buffers = [];
   this._components = undefined;

--- a/Source/Scene/Model/InstancingPipelineStage.js
+++ b/Source/Scene/Model/InstancingPipelineStage.js
@@ -37,7 +37,7 @@ InstancingPipelineStage.name = "InstancingPipelineStage"; // Helps with debuggin
  * <ul>
  *  <li> creates buffers for the typed arrays of each attribute, if they do not yet exist
  *  <li> adds attribute declarations for the instancing vertex attributes in the vertex shader</li>
- *  <li> adds an instancing translation min and max to compute an accurate bounding volume</li>
+ *  <li> sets the instancing translation min and max to compute an accurate bounding volume</li>
  * </ul>
  *
  * If the scene is in either 2D or CV mode, this stage also:
@@ -61,6 +61,8 @@ InstancingPipelineStage.process = function (renderResources, node, frameState) {
 
   const model = renderResources.model;
   const sceneGraph = model.sceneGraph;
+  const runtimeNode = renderResources.runtimeNode;
+
   const use2D =
     frameState.mode !== SceneMode.SCENE3D &&
     !frameState.scene3DOnly &&
@@ -163,7 +165,7 @@ InstancingPipelineStage.process = function (renderResources, node, frameState) {
         sceneGraph.axisCorrectionMatrix,
         // This transforms from the node's coordinate system to the root
         // of the node hierarchy
-        renderResources.runtimeNode.computedTransform,
+        runtimeNode.computedTransform,
         nodeTransformScratch
       );
     };
@@ -184,7 +186,7 @@ InstancingPipelineStage.process = function (renderResources, node, frameState) {
 
     const context = frameState.context;
     const modelMatrix2D = Matrix4.fromTranslation(
-      renderResources.instancingReferencePoint2D,
+      runtimeNode.instancingReferencePoint2D,
       new Matrix4()
     );
 
@@ -333,7 +335,9 @@ function projectTransformsTo2D(
     nodeComputedTransform
   );
 
-  const referencePoint = renderResources.instancingReferencePoint2D;
+  const runtimeNode = renderResources.runtimeNode;
+  const referencePoint = runtimeNode.instancingReferencePoint2D;
+
   const count = transforms.length;
   for (let i = 0; i < count; i++) {
     const transform = transforms[i];
@@ -382,7 +386,8 @@ function projectTranslationsTo2D(
     nodeComputedTransform
   );
 
-  const referencePoint = renderResources.instancingReferencePoint2D;
+  const runtimeNode = renderResources.runtimeNode;
+  const referencePoint = runtimeNode.instancingReferencePoint2D;
   const count = translations.length;
   for (let i = 0; i < count; i++) {
     const translation = translations[i];
@@ -411,10 +416,11 @@ const scratchProjectedMax = new Cartesian3();
 function computeReferencePoint2D(renderResources, frameState) {
   // Compute the reference point by averaging the instancing translation
   // min / max values after they are projected to 2D.
+  const runtimeNode = renderResources.runtimeNode;
   const modelMatrix = renderResources.model.sceneGraph.computedModelMatrix;
   const transformedPositionMin = Matrix4.multiplyByPoint(
     modelMatrix,
-    renderResources.instancingTranslationMin,
+    runtimeNode.instancingTranslationMin,
     scratchProjectedMin
   );
 
@@ -426,7 +432,7 @@ function computeReferencePoint2D(renderResources, frameState) {
 
   const transformedPositionMax = Matrix4.multiplyByPoint(
     modelMatrix,
-    renderResources.instancingTranslationMax,
+    runtimeNode.instancingTranslationMax,
     scratchProjectedMax
   );
 
@@ -436,7 +442,12 @@ function computeReferencePoint2D(renderResources, frameState) {
     transformedPositionMax
   );
 
-  return Cartesian3.lerp(projectedMin, projectedMax, 0.5, new Cartesian3());
+  runtimeNode.instancingReferencePoint2D = Cartesian3.lerp(
+    projectedMin,
+    projectedMax,
+    0.5,
+    new Cartesian3()
+  );
 }
 
 function transformsToTypedArray(transforms) {
@@ -521,10 +532,13 @@ function getInstanceTransformsAsMatrices(instances, count, renderResources) {
   const translationTypedArray = hasTranslation
     ? translationAttribute.typedArray
     : new Float32Array(count * 3);
-  // Rotations get initialized to (0, 0, 0, 0). The w-component is set to 1 in the loop below.
+
+  // Rotations get initialized to (0, 0, 0, 0).
+  // The w-component is set to 1 in the loop below.
   const rotationTypedArray = hasRotation
     ? rotationAttribute.typedArray
     : new Float32Array(count * 4);
+
   // Scales get initialized to (1, 1, 1).
   let scaleTypedArray;
   if (hasScale) {
@@ -578,25 +592,70 @@ function getInstanceTransformsAsMatrices(instances, count, renderResources) {
     transforms[i] = transform;
   }
 
-  renderResources.instancingTranslationMax = instancingTranslationMax;
-  renderResources.instancingTranslationMin = instancingTranslationMin;
+  const runtimeNode = renderResources.runtimeNode;
+  runtimeNode.instancingTranslationMin = instancingTranslationMin;
+  runtimeNode.instancingTranslationMax = instancingTranslationMax;
+
+  // Unload the typed arrays. These are just pointers to the arrays
+  // in the vertex buffer loader.
+  if (hasTranslation) {
+    translationAttribute.typedArray = undefined;
+  }
+  if (hasRotation) {
+    rotationAttribute.typedArray = undefined;
+  }
+  if (hasScale) {
+    scaleAttribute.typedArray = undefined;
+  }
 
   return transforms;
 }
 
-function getInstanceTranslationsAsCartesian3s(translationAttribute, count) {
-  const translations = new Array(count);
+function getInstanceTranslations(translationAttribute, count, renderResources) {
+  const instancingTranslations = new Array(count);
   const translationTypedArray = translationAttribute.typedArray;
 
+  const instancingTranslationMin = new Cartesian3(
+    Number.MAX_VALUE,
+    Number.MAX_VALUE,
+    Number.MAX_VALUE
+  );
+  const instancingTranslationMax = new Cartesian3(
+    -Number.MAX_VALUE,
+    -Number.MAX_VALUE,
+    -Number.MAX_VALUE
+  );
+
   for (let i = 0; i < count; i++) {
-    translations[i] = new Cartesian3(
+    const translation = new Cartesian3(
       translationTypedArray[i * 3],
       translationTypedArray[i * 3 + 1],
       translationTypedArray[i * 3 + 2]
     );
+
+    instancingTranslations[i] = translation;
+
+    Cartesian3.minimumByComponent(
+      instancingTranslationMin,
+      translation,
+      instancingTranslationMin
+    );
+    Cartesian3.maximumByComponent(
+      instancingTranslationMax,
+      translation,
+      instancingTranslationMax
+    );
   }
 
-  return translations;
+  const runtimeNode = renderResources.runtimeNode;
+  runtimeNode.instancingTranslationMin = instancingTranslationMin;
+  runtimeNode.instancingTranslationMax = instancingTranslationMax;
+
+  // Unload the typed array. This is just a pointer to the array
+  // in the vertex buffer loader.
+  translationAttribute.typedArray = undefined;
+
+  return instancingTranslations;
 }
 
 function createVertexBuffer(typedArray, frameState) {
@@ -620,43 +679,52 @@ function processTransformAttributes(
   instancingVertexAttributes,
   use2D
 ) {
-  const translationAttribute = ModelUtility.getAttributeBySemantic(
-    instances,
-    InstanceAttributeSemantic.TRANSLATION
-  );
-
-  let translationMax;
-  let translationMin;
-  if (defined(translationAttribute)) {
-    translationMax = translationAttribute.max;
-    translationMin = translationAttribute.min;
-  }
-
   const rotationAttribute = ModelUtility.getAttributeBySemantic(
     instances,
     InstanceAttributeSemantic.ROTATION
   );
 
+  // Only use matrices for the transforms if the rotation attribute is defined.
+  if (defined(rotationAttribute)) {
+    processTransformMatrixAttributes(
+      renderResources,
+      instances,
+      instancingVertexAttributes,
+      frameState,
+      use2D
+    );
+  } else {
+    processTransformVec3Attributes(
+      renderResources,
+      instances,
+      instancingVertexAttributes,
+      frameState,
+      use2D
+    );
+  }
+}
+
+function processTransformMatrixAttributes(
+  renderResources,
+  instances,
+  instancingVertexAttributes,
+  frameState,
+  use2D
+) {
   const shaderBuilder = renderResources.shaderBuilder;
   const count = instances.attributes[0].count;
-  const useMatrices =
-    defined(rotationAttribute) ||
-    !defined(translationMax) ||
-    !defined(translationMin);
 
-  const statistics = renderResources.model.statistics;
+  const model = renderResources.model;
+  const runtimeNode = renderResources.runtimeNode;
 
-  // Packed typed arrays are omitted from statistics because they don't
-  // necessarily correspond to the size of the GPU buffer containing
-  // their data. It's also difficult to track which typed arrays have
-  // already been counted.
-  const hasCpuCopy = false;
+  shaderBuilder.addDefine("HAS_INSTANCE_MATRICES");
+  const attributeString = "Transform";
 
   let transforms;
-  if (useMatrices) {
-    shaderBuilder.addDefine("HAS_INSTANCE_MATRICES");
-    const attributeString = "Transform";
-
+  let buffer = runtimeNode.instancingTransformsBuffer;
+  if (!defined(buffer)) {
+    // This function computes the transforms, sets the translation min / max,
+    // and unloads the typed arrays associated with the attributes.
     transforms = getInstanceTransformsAsMatrices(
       instances,
       count,
@@ -664,97 +732,18 @@ function processTransformAttributes(
     );
 
     const transformsTypedArray = transformsToTypedArray(transforms);
-    const buffer = createVertexBuffer(transformsTypedArray, frameState);
-    renderResources.model._pipelineResources.push(buffer);
+    buffer = createVertexBuffer(transformsTypedArray, frameState);
+    model._modelResources.push(buffer);
 
-    processMatrixAttributes(
-      renderResources,
-      buffer,
-      instancingVertexAttributes,
-      attributeString
-    );
-
-    // Count the buffer here since it had to be allocated
-    // in this stage.
-    statistics.addBuffer(buffer, hasCpuCopy);
-  } else {
-    if (defined(translationAttribute)) {
-      shaderBuilder.addDefine("HAS_INSTANCE_TRANSLATION");
-
-      const translationMax = translationAttribute.max;
-      const translationMin = translationAttribute.min;
-      renderResources.instancingTranslationMax = translationMax;
-      renderResources.instancingTranslationMin = translationMin;
-
-      let buffer = translationAttribute.buffer;
-      let byteOffset = translationAttribute.byteOffset;
-      let byteStride = translationAttribute.byteStride;
-
-      if (!defined(buffer)) {
-        buffer = createVertexBuffer(
-          translationAttribute.typedArray,
-          frameState
-        );
-        renderResources.model._pipelineResources.push(buffer);
-
-        byteOffset = 0;
-        byteStride = undefined;
-
-        // Count the buffer here if it had to be allocated
-        // in this stage. Otherwise, it will be counted in
-        // NodeStatisticsPipelineStage.
-        statistics.addBuffer(buffer, hasCpuCopy);
-      }
-
-      const attributeString = "Translation";
-
-      processVec3Attribute(
-        renderResources,
-        buffer,
-        byteOffset,
-        byteStride,
-        instancingVertexAttributes,
-        attributeString
-      );
-    }
-
-    const scaleAttribute = ModelUtility.getAttributeBySemantic(
-      instances,
-      InstanceAttributeSemantic.SCALE
-    );
-
-    if (defined(scaleAttribute)) {
-      shaderBuilder.addDefine("HAS_INSTANCE_SCALE");
-
-      let buffer = scaleAttribute.buffer;
-      let byteOffset = scaleAttribute.byteOffset;
-      let byteStride = scaleAttribute.byteStride;
-
-      if (!defined(buffer)) {
-        buffer = createVertexBuffer(scaleAttribute.typedArray, frameState);
-        renderResources.model._pipelineResources.push(buffer);
-
-        byteOffset = 0;
-        byteStride = undefined;
-
-        // Count the buffer here if it had to be allocated
-        // in this stage. Otherwise, it will be counted in
-        // NodeStatisticsPipelineStage.
-        statistics.addBuffer(buffer, hasCpuCopy);
-      }
-
-      const attributeString = "Scale";
-
-      processVec3Attribute(
-        renderResources,
-        buffer,
-        byteOffset,
-        byteStride,
-        instancingVertexAttributes,
-        attributeString
-      );
-    }
+    runtimeNode.instancingTransformsBuffer = buffer;
   }
+
+  processMatrixAttributes(
+    renderResources,
+    buffer,
+    instancingVertexAttributes,
+    attributeString
+  );
 
   if (!use2D) {
     return;
@@ -769,76 +758,146 @@ function processTransformAttributes(
   // To prevent jitter, the positions are defined relative to a common
   // reference point. For convenience, this is the center of the instanced
   // translation bounds projected to 2D.
-  const referencePoint = computeReferencePoint2D(renderResources, frameStateCV);
-  renderResources.instancingReferencePoint2D = referencePoint;
+  computeReferencePoint2D(renderResources, frameStateCV);
 
-  const runtimeNode = renderResources.runtimeNode;
-
-  if (useMatrices) {
-    let buffer = runtimeNode.instancingTransformsBuffer2D;
-    if (!defined(buffer)) {
-      const projectedTransforms = projectTransformsTo2D(
-        transforms,
-        renderResources,
-        frameStateCV,
-        transforms
-      );
-      const projectedTypedArray = transformsToTypedArray(projectedTransforms);
-
-      // This memory is counted during the statistics stage at the end
-      // of the pipeline.
-      buffer = createVertexBuffer(projectedTypedArray, frameState);
-      renderResources.model._modelResources.push(buffer);
-
-      runtimeNode.instancingTransformsBuffer2D = buffer;
-    }
-
-    const attributeString2D = "Transform2D";
-    processMatrixAttributes(
+  let buffer2D = runtimeNode.instancingTransformsBuffer2D;
+  if (!defined(buffer2D)) {
+    const projectedTransforms = projectTransformsTo2D(
+      transforms,
       renderResources,
-      buffer,
-      instancingVertexAttributes,
-      attributeString2D
+      frameStateCV,
+      transforms
     );
-  } else {
-    let buffer = runtimeNode.instancingTranslationBuffer2D;
+    const projectedTypedArray = transformsToTypedArray(projectedTransforms);
 
-    if (!defined(buffer)) {
-      const translations = getInstanceTranslationsAsCartesian3s(
-        translationAttribute,
-        count
-      );
-      const projectedTranslations = projectTranslationsTo2D(
-        translations,
-        renderResources,
-        frameStateCV,
-        translations
-      );
-      const projectedTypedArray = translationsToTypedArray(
-        projectedTranslations
-      );
+    // This memory is counted during the statistics stage at the end
+    // of the pipeline.
+    buffer2D = createVertexBuffer(projectedTypedArray, frameState);
+    model._modelResources.push(buffer2D);
 
-      // This memory is counted during the statistics stage at the end
-      // of the pipeline.
-      buffer = createVertexBuffer(projectedTypedArray, frameState);
-      renderResources.model._modelResources.push(buffer);
+    runtimeNode.instancingTransformsBuffer2D = buffer2D;
+  }
 
-      runtimeNode.instancingTranslationBuffer2D = buffer;
-    }
+  const attributeString2D = "Transform2D";
+  processMatrixAttributes(
+    renderResources,
+    buffer2D,
+    instancingVertexAttributes,
+    attributeString2D
+  );
+}
 
-    const byteOffset = 0;
-    const byteStride = undefined;
+function processTransformVec3Attributes(
+  renderResources,
+  instances,
+  instancingVertexAttributes,
+  frameState,
+  use2D
+) {
+  const shaderBuilder = renderResources.shaderBuilder;
+  const runtimeNode = renderResources.runtimeNode;
+  const translationAttribute = ModelUtility.getAttributeBySemantic(
+    instances,
+    InstanceAttributeSemantic.TRANSLATION
+  );
+  const scaleAttribute = ModelUtility.getAttributeBySemantic(
+    instances,
+    InstanceAttributeSemantic.SCALE
+  );
 
-    const attributeString2D = "Translation2D";
+  if (defined(scaleAttribute)) {
+    shaderBuilder.addDefine("HAS_INSTANCE_SCALE");
+    const attributeString = "Scale";
+
+    // Instanced scale attributes are loaded as buffers only.
     processVec3Attribute(
       renderResources,
-      buffer,
-      byteOffset,
-      byteStride,
+      scaleAttribute.buffer,
+      scaleAttribute.byteOffset,
+      scaleAttribute.byteStride,
       instancingVertexAttributes,
-      attributeString2D
+      attributeString
     );
   }
+
+  if (!defined(translationAttribute)) {
+    return;
+  }
+
+  let instancingTranslations;
+  const typedArray = translationAttribute.typedArray;
+  if (defined(typedArray)) {
+    // This function computes and set the translation min / max, and unloads
+    // the typed array associated with the attribute.
+    // The translations are also returned in case they're used for 2D projection.
+    instancingTranslations = getInstanceTranslations(
+      translationAttribute,
+      translationAttribute.count,
+      renderResources
+    );
+  } else if (!defined(runtimeNode.instancingTranslationMin)) {
+    runtimeNode.instancingTranslationMin = translationAttribute.min;
+    runtimeNode.instancingTranslationMax = translationAttribute.max;
+  }
+
+  shaderBuilder.addDefine("HAS_INSTANCE_TRANSLATION");
+  const attributeString = "Translation";
+
+  processVec3Attribute(
+    renderResources,
+    translationAttribute.buffer,
+    translationAttribute.byteOffset,
+    translationAttribute.byteStride,
+    instancingVertexAttributes,
+    attributeString
+  );
+
+  if (!use2D) {
+    return;
+  }
+
+  // Force the scene mode to be CV. In 2D, projected positions will have
+  // an x-coordinate of 0, which eliminates the height data that is
+  // necessary for rendering in CV mode.
+  const frameStateCV = clone(frameState);
+  frameStateCV.mode = SceneMode.COLUMBUS_VIEW;
+
+  // To prevent jitter, the positions are defined relative to a common
+  // reference point. For convenience, this is the center of the instanced
+  // translation bounds projected to 2D.
+  computeReferencePoint2D(renderResources, frameStateCV);
+
+  let buffer2D = runtimeNode.instancingTranslationBuffer2D;
+
+  if (!defined(buffer2D)) {
+    const projectedTranslations = projectTranslationsTo2D(
+      instancingTranslations,
+      renderResources,
+      frameStateCV,
+      instancingTranslations
+    );
+    const projectedTypedArray = translationsToTypedArray(projectedTranslations);
+
+    // This memory is counted during the statistics stage at the end
+    // of the pipeline.
+    buffer2D = createVertexBuffer(projectedTypedArray, frameState);
+    renderResources.model._modelResources.push(buffer2D);
+
+    runtimeNode.instancingTranslationBuffer2D = buffer2D;
+  }
+
+  const byteOffset = 0;
+  const byteStride = undefined;
+
+  const attributeString2D = "Translation2D";
+  processVec3Attribute(
+    renderResources,
+    buffer2D,
+    byteOffset,
+    byteStride,
+    instancingVertexAttributes,
+    attributeString2D
+  );
 }
 
 function processMatrixAttributes(
@@ -927,7 +986,6 @@ function processFeatureIdAttributes(
   instancingVertexAttributes
 ) {
   const attributes = instances.attributes;
-  const model = renderResources.model;
   const shaderBuilder = renderResources.shaderBuilder;
 
   // Load Feature ID vertex attributes. These are loaded as typed arrays in GltfLoader
@@ -944,24 +1002,9 @@ function processFeatureIdAttributes(
       renderResources.featureIdVertexAttributeSetIndex = attribute.setIndex + 1;
     }
 
-    const vertexBuffer = Buffer.createVertexBuffer({
-      context: frameState.context,
-      typedArray: attribute.typedArray,
-      usage: BufferUsage.STATIC_DRAW,
-    });
-    vertexBuffer.vertexArrayDestroyable = false;
-    model._pipelineResources.push(vertexBuffer);
-
-    // Packed typed arrays are omitted from statistics because they don't
-    // necessarily correspond to the size of the GPU buffer containing
-    // their data. It's also difficult to track which typed arrays have
-    // already been counted.
-    const hasCpuCopy = false;
-    model.statistics.addBuffer(vertexBuffer, hasCpuCopy);
-
     instancingVertexAttributes.push({
       index: renderResources.attributeIndex++,
-      vertexBuffer: vertexBuffer,
+      vertexBuffer: attribute.buffer,
       componentsPerAttribute: AttributeType.getNumberOfComponents(
         attribute.type
       ),

--- a/Source/Scene/Model/InstancingPipelineStage.js
+++ b/Source/Scene/Model/InstancingPipelineStage.js
@@ -611,7 +611,11 @@ function getInstanceTransformsAsMatrices(instances, count, renderResources) {
   return transforms;
 }
 
-function getInstanceTranslations(translationAttribute, count, renderResources) {
+function getInstanceTranslationsAsCartesian3s(
+  translationAttribute,
+  count,
+  renderResources
+) {
   const instancingTranslations = new Array(count);
   const translationTypedArray = translationAttribute.typedArray;
 
@@ -830,7 +834,7 @@ function processTransformVec3Attributes(
     // This function computes and set the translation min / max, and unloads
     // the typed array associated with the attribute.
     // The translations are also returned in case they're used for 2D projection.
-    instancingTranslations = getInstanceTranslations(
+    instancingTranslations = getInstanceTranslationsAsCartesian3s(
       translationAttribute,
       translationAttribute.count,
       renderResources

--- a/Source/Scene/Model/ModelRuntimeNode.js
+++ b/Source/Scene/Model/ModelRuntimeNode.js
@@ -112,9 +112,42 @@ function ModelRuntimeNode(options) {
   /**
    * Update stages to apply to this node.
    *
+   * @type {Object[]}
+   * @readonly
+   *
    * @private
    */
   this.updateStages = [];
+
+  /**
+   * The component-wise minimum value of the translations of the instances.
+   * This value is set by InstancingPipelineStage.
+   *
+   * @type {Cartesian3}
+   *
+   * @private
+   */
+  this.instancingTranslationMin = undefined;
+
+  /**
+   * The component-wise maximum value of the translations of the instances.
+   * This value is set by InstancingPipelineStage.
+   *
+   * @type {Cartesian3}
+   *
+   * @private
+   */
+  this.instancingTranslationMax = undefined;
+
+  /**
+   * A buffer containing the instanced transforms. The memory is managed
+   * by Model; this is just a reference.
+   *
+   * @type {Buffer}
+   *
+   * @private
+   */
+  this.instancingTransformsBuffer = undefined;
 
   /**
    * A buffer containing the instanced transforms projected to 2D world
@@ -122,7 +155,6 @@ function ModelRuntimeNode(options) {
    * by Model; this is just a reference.
    *
    * @type {Buffer}
-   * @readonly
    *
    * @private
    */
@@ -134,11 +166,24 @@ function ModelRuntimeNode(options) {
    * managed by Model; this is just a reference.
    *
    * @type {Buffer}
-   * @readonly
    *
    * @private
    */
   this.instancingTranslationBuffer2D = undefined;
+
+  /**
+   * If the model is instanced and projected to 2D, the reference point is the
+   * average of the instancing translation max and min. The 2D translations are
+   * defined relative to this point to avoid precision issues on the GPU.
+   * <p>
+   * This value is set by InstancingPipelineStage.
+   * </p>
+   *
+   * @type {Cartesian3}
+   *
+   * @private
+   */
+  this.instancingReferencePoint2D = undefined;
 
   initialize(this);
 }

--- a/Source/Scene/Model/NodeRenderResources.js
+++ b/Source/Scene/Model/NodeRenderResources.js
@@ -155,40 +155,6 @@ function NodeRenderResources(modelRenderResources, runtimeNode) {
    * @private
    */
   this.instanceCount = 0;
-
-  /**
-   * The component-wise maximum value of the translations of the instances.
-   * This value is set by InstancingPipelineStage.
-   *
-   * @type {Cartesian3}
-   *
-   * @private
-   */
-  this.instancingTranslationMax = undefined;
-
-  /**
-   * The component-wise minimum value of the translations of the instances.
-   * This value is set by InstancingPipelineStage.
-   *
-   * @type {Cartesian3}
-   *
-   * @private
-   */
-  this.instancingTranslationMin = undefined;
-
-  /**
-   * If the model is instanced and projected to 2D, the reference point is the
-   * average of the instancing translation max and min. The 2D translations are
-   * defined relative to this point to avoid precision issues on the GPU.
-   * <p>
-   * This value is set by InstancingPipelineStage.
-   * </p>
-   *
-   * @type {Cartesian3}
-   *
-   * @private
-   */
-  this.instancingReferencePoint2D = undefined;
 }
 
 export default NodeRenderResources;

--- a/Source/Scene/Model/NodeStatisticsPipelineStage.js
+++ b/Source/Scene/Model/NodeStatisticsPipelineStage.js
@@ -24,11 +24,11 @@ NodeStatisticsPipelineStage.process = function (
   const instances = node.instances;
   const runtimeNode = renderResources.runtimeNode;
 
-  countInstancingAttributes(statistics, instances, runtimeNode);
-  countInstancing2DBuffers(statistics, runtimeNode);
+  countInstancingAttributes(statistics, instances);
+  countGeneratedBuffers(statistics, runtimeNode);
 };
 
-function countInstancingAttributes(statistics, instances, runtimeNode) {
+function countInstancingAttributes(statistics, instances) {
   if (!defined(instances)) {
     return;
   }
@@ -43,16 +43,15 @@ function countInstancingAttributes(statistics, instances, runtimeNode) {
       statistics.addBuffer(attribute.buffer, hasCpuCopy);
     }
   }
+}
 
+function countGeneratedBuffers(statistics, runtimeNode) {
   if (defined(runtimeNode.instancingTransformsBuffer)) {
     // The typed array containing the computed transforms isn't saved
     // after the buffer is created.
     const hasCpuCopy = false;
     statistics.addBuffer(runtimeNode.instancingTransformsBuffer, hasCpuCopy);
   }
-}
-
-function countInstancing2DBuffers(statistics, runtimeNode) {
   if (defined(runtimeNode.instancingTransformsBuffer2D)) {
     // The typed array containing the computed 2D transforms isn't saved
     // after the buffer is created.
@@ -70,6 +69,6 @@ function countInstancing2DBuffers(statistics, runtimeNode) {
 
 // Exposed for testing
 NodeStatisticsPipelineStage._countInstancingAttributes = countInstancingAttributes;
-NodeStatisticsPipelineStage._countInstancing2DBuffers = countInstancing2DBuffers;
+NodeStatisticsPipelineStage._countGeneratedBuffers = countGeneratedBuffers;
 
 export default NodeStatisticsPipelineStage;

--- a/Source/Scene/Model/PrimitiveRenderResources.js
+++ b/Source/Scene/Model/PrimitiveRenderResources.js
@@ -234,8 +234,8 @@ function PrimitiveRenderResources(nodeRenderResources, runtimePrimitive) {
 
   const positionMinMax = ModelUtility.getPositionMinMax(
     primitive,
-    nodeRenderResources.instancingTranslationMin,
-    nodeRenderResources.instancingTranslationMax
+    this.runtimeNode.instancingTranslationMin,
+    this.runtimeNode.instancingTranslationMax
   );
 
   /**
@@ -273,7 +273,7 @@ function PrimitiveRenderResources(nodeRenderResources, runtimePrimitive) {
   );
 
   /**
-   * Options for configuring the lighting stage such as selecting between
+   * Options for configuring the lighting stage, such as selecting between
    * unlit and PBR shading.
    *
    * @type {ModelLightingOptions}

--- a/Specs/Scene/Model/GeometryPipelineStageSpec.js
+++ b/Specs/Scene/Model/GeometryPipelineStageSpec.js
@@ -383,8 +383,8 @@ describe(
         expect(position2DAttribute.componentDatatype).toEqual(
           ComponentDatatype.FLOAT
         );
-        expect(position2DAttribute.offsetInBytes).toBe(288);
-        expect(position2DAttribute.strideInBytes).toBe(12);
+        expect(position2DAttribute.offsetInBytes).toBe(0);
+        expect(position2DAttribute.strideInBytes).toBeUndefined();
 
         const texCoord0Attribute = attributes[3];
         expect(texCoord0Attribute.index).toEqual(3);

--- a/Specs/Scene/Model/I3dmLoaderSpec.js
+++ b/Specs/Scene/Model/I3dmLoaderSpec.js
@@ -101,14 +101,26 @@ describe(
       }).toThrowError(RuntimeError);
     }
 
-    function verifyInstances(components, expectedSemantics, instancesLength) {
+    function verifyInstances(loader, expectedSemantics, instancesLength) {
+      const components = loader.components;
+      const structuralMetadata = components.structuralMetadata;
+      expect(structuralMetadata).toBeDefined();
+
+      let bufferCount = 0;
       for (let i = 0; i < components.nodes.length; i++) {
         const node = components.nodes[i];
-        // Every node that has a primitive should have an ModelComponents.Instances object.
+
+        // Every node that has a primitive should have a
+        // ModelComponents.Instances object.
         if (node.primitives.length > 0) {
-          expect(node.instances).toBeDefined();
-          const attributesLength = node.instances.attributes.length;
+          const instances = node.instances;
+          expect(instances).toBeDefined();
+          const attributesLength = instances.attributes.length;
           expect(attributesLength).toEqual(expectedSemantics.length);
+
+          const hasRotation =
+            expectedSemantics.indexOf(InstanceAttributeSemantic.ROTATION) >= 0;
+
           // Iterate through the attributes of the node with instances and check for all expected semantics.
           for (let j = 0; j < attributesLength; j++) {
             const attribute = node.instances.attributes[j];
@@ -116,9 +128,25 @@ describe(
               true
             );
             expect(attribute.count).toEqual(instancesLength);
+
+            const isTransformAttribute =
+              attribute.semantic === InstanceAttributeSemantic.TRANSLATION ||
+              attribute.semantic === InstanceAttributeSemantic.ROTATION ||
+              attribute.semantic === InstanceAttributeSemantic.SCALE;
+
+            if (hasRotation && isTransformAttribute) {
+              expect(attribute.typedArray).toBeDefined();
+              expect(attribute.buffer).toBeUndefined();
+            } else {
+              expect(attribute.typedArray).toBeUndefined();
+              expect(attribute.buffer).toBeDefined();
+              bufferCount++;
+            }
           }
         }
       }
+
+      expect(loader._buffers.length).toEqual(bufferCount);
     }
 
     it("releases array buffer when finished loading", function () {
@@ -130,13 +158,8 @@ describe(
 
     it("loads InstancedGltfExternalUrl", function () {
       return loadI3dm(instancedGltfExternalUrl).then(function (loader) {
-        const components = loader.components;
-        const structuralMetadata = components.structuralMetadata;
-
-        expect(structuralMetadata).toBeDefined();
-
         verifyInstances(
-          components,
+          loader,
           [
             InstanceAttributeSemantic.TRANSLATION,
             InstanceAttributeSemantic.ROTATION,
@@ -149,13 +172,8 @@ describe(
 
     it("loads InstancedWithBatchTableUrl", function () {
       return loadI3dm(instancedWithBatchTableUrl).then(function (loader) {
-        const components = loader.components;
-        const structuralMetadata = components.structuralMetadata;
-
-        expect(structuralMetadata).toBeDefined();
-
         verifyInstances(
-          components,
+          loader,
           [
             InstanceAttributeSemantic.TRANSLATION,
             InstanceAttributeSemantic.ROTATION,
@@ -168,13 +186,8 @@ describe(
 
     it("loads InstancedWithBatchTableBinaryUrl", function () {
       return loadI3dm(instancedWithBatchTableBinaryUrl).then(function (loader) {
-        const components = loader.components;
-        const structuralMetadata = components.structuralMetadata;
-
-        expect(structuralMetadata).toBeDefined();
-
         verifyInstances(
-          components,
+          loader,
           [
             InstanceAttributeSemantic.TRANSLATION,
             InstanceAttributeSemantic.ROTATION,
@@ -187,13 +200,8 @@ describe(
 
     it("loads InstancedWithoutBatchTableUrl", function () {
       return loadI3dm(instancedWithoutBatchTableUrl).then(function (loader) {
-        const components = loader.components;
-        const structuralMetadata = components.structuralMetadata;
-
-        expect(structuralMetadata).toBeDefined();
-
         verifyInstances(
-          components,
+          loader,
           [
             InstanceAttributeSemantic.TRANSLATION,
             InstanceAttributeSemantic.ROTATION,
@@ -206,12 +214,8 @@ describe(
 
     it("loads InstancedOrientationUrl", function () {
       return loadI3dm(instancedOrientationUrl).then(function (loader) {
-        const components = loader.components;
-        const structuralMetadata = components.structuralMetadata;
-
-        expect(structuralMetadata).toBeDefined();
         verifyInstances(
-          components,
+          loader,
           [
             InstanceAttributeSemantic.TRANSLATION,
             InstanceAttributeSemantic.ROTATION,
@@ -224,12 +228,8 @@ describe(
 
     it("loads InstancedOct32POrientationUrl", function () {
       return loadI3dm(instancedOct32POrientationUrl).then(function (loader) {
-        const components = loader.components;
-        const structuralMetadata = components.structuralMetadata;
-
-        expect(structuralMetadata).toBeDefined();
         verifyInstances(
-          components,
+          loader,
           [
             InstanceAttributeSemantic.TRANSLATION,
             InstanceAttributeSemantic.ROTATION,
@@ -242,12 +242,8 @@ describe(
 
     it("loads InstancedScaleUrl", function () {
       return loadI3dm(instancedScaleUrl).then(function (loader) {
-        const components = loader.components;
-        const structuralMetadata = components.structuralMetadata;
-
-        expect(structuralMetadata).toBeDefined();
         verifyInstances(
-          components,
+          loader,
           [
             InstanceAttributeSemantic.TRANSLATION,
             InstanceAttributeSemantic.ROTATION,
@@ -261,12 +257,8 @@ describe(
 
     it("loads InstancedScaleNonUniformUrl", function () {
       return loadI3dm(instancedScaleNonUniformUrl).then(function (loader) {
-        const components = loader.components;
-        const structuralMetadata = components.structuralMetadata;
-
-        expect(structuralMetadata).toBeDefined();
         verifyInstances(
-          components,
+          loader,
           [
             InstanceAttributeSemantic.TRANSLATION,
             InstanceAttributeSemantic.ROTATION,
@@ -280,12 +272,8 @@ describe(
 
     it("loads InstancedRTCUrl", function () {
       return loadI3dm(instancedRTCUrl).then(function (loader) {
-        const components = loader.components;
-        const structuralMetadata = components.structuralMetadata;
-
-        expect(structuralMetadata).toBeDefined();
         verifyInstances(
-          components,
+          loader,
           [
             InstanceAttributeSemantic.TRANSLATION,
             InstanceAttributeSemantic.ROTATION,
@@ -307,12 +295,8 @@ describe(
 
     it("loads InstancedQuantizedUrl", function () {
       return loadI3dm(instancedQuantizedUrl).then(function (loader) {
-        const components = loader.components;
-        const structuralMetadata = components.structuralMetadata;
-
-        expect(structuralMetadata).toBeDefined();
         verifyInstances(
-          components,
+          loader,
           [
             InstanceAttributeSemantic.TRANSLATION,
             InstanceAttributeSemantic.ROTATION,
@@ -320,9 +304,11 @@ describe(
           ],
           25
         );
+
+        const transform = loader.components.transform;
         // The transform is computed from the quantized positions
         // prettier-ignore
-        expect(components.transform).toEqualEpsilon(new Matrix4(
+        expect(transform).toEqualEpsilon(new Matrix4(
         1, 0, 0, 1215013.8125,
         0, 1, 0, -4736316.75,
         0, 0, 1, 4081608.5,
@@ -335,12 +321,8 @@ describe(
       return loadI3dm(instancedQuantizedOct32POrientationUrl).then(function (
         loader
       ) {
-        const components = loader.components;
-        const structuralMetadata = components.structuralMetadata;
-
-        expect(structuralMetadata).toBeDefined();
         verifyInstances(
-          components,
+          loader,
           [
             InstanceAttributeSemantic.TRANSLATION,
             InstanceAttributeSemantic.ROTATION,
@@ -353,12 +335,8 @@ describe(
 
     it("loads InstancedWithTransformUrl", function () {
       return loadI3dm(instancedWithTransformUrl).then(function (loader) {
-        const components = loader.components;
-        const structuralMetadata = components.structuralMetadata;
-
-        expect(structuralMetadata).toBeDefined();
         verifyInstances(
-          components,
+          loader,
           [
             InstanceAttributeSemantic.TRANSLATION,
             InstanceAttributeSemantic.FEATURE_ID,
@@ -370,12 +348,8 @@ describe(
 
     it("loads InstancedWithBatchIdsUrl", function () {
       return loadI3dm(instancedWithBatchIdsUrl).then(function (loader) {
-        const components = loader.components;
-        const structuralMetadata = components.structuralMetadata;
-
-        expect(structuralMetadata).toBeDefined();
         verifyInstances(
-          components,
+          loader,
           [
             InstanceAttributeSemantic.TRANSLATION,
             InstanceAttributeSemantic.ROTATION,
@@ -388,12 +362,8 @@ describe(
 
     it("loads InstancedTexturedUrl", function () {
       return loadI3dm(instancedTexturedUrl).then(function (loader) {
-        const components = loader.components;
-        const structuralMetadata = components.structuralMetadata;
-
-        expect(structuralMetadata).toBeDefined();
         verifyInstances(
-          components,
+          loader,
           [
             InstanceAttributeSemantic.TRANSLATION,
             InstanceAttributeSemantic.ROTATION,
@@ -401,6 +371,19 @@ describe(
           ],
           25
         );
+      });
+    });
+
+    it("destroys buffers when unloaded", function () {
+      return loadI3dm(instancedGltfExternalUrl).then(function (loader) {
+        // This i3dm has a rotation attribute, so only the feature IDs
+        // are loaded in a buffer.
+        const buffers = loader._buffers;
+        expect(buffers.length).toBe(1);
+
+        const buffer = buffers[0];
+        loader.destroy();
+        expect(buffer.isDestroyed()).toBe(true);
       });
     });
 

--- a/Specs/Scene/Model/I3dmLoaderSpec.js
+++ b/Specs/Scene/Model/I3dmLoaderSpec.js
@@ -134,9 +134,16 @@ describe(
               attribute.semantic === InstanceAttributeSemantic.ROTATION ||
               attribute.semantic === InstanceAttributeSemantic.SCALE;
 
+            const isTranslationAttribute =
+              attribute.semantic === InstanceAttributeSemantic.TRANSLATION;
+
             if (hasRotation && isTransformAttribute) {
               expect(attribute.typedArray).toBeDefined();
               expect(attribute.buffer).toBeUndefined();
+            } else if (isTranslationAttribute) {
+              expect(attribute.typedArray).toBeDefined();
+              expect(attribute.buffer).toBeDefined();
+              bufferCount++;
             } else {
               expect(attribute.typedArray).toBeUndefined();
               expect(attribute.buffer).toBeDefined();

--- a/Specs/Scene/Model/InstancingPipelineStageSpec.js
+++ b/Specs/Scene/Model/InstancingPipelineStageSpec.js
@@ -276,7 +276,7 @@ describe(
 
         // A resource will be created for the computed matrix transforms.
         expect(renderResources.model._modelResources.length).toEqual(1);
-
+        // The resource will be counted by NodeStatisticsPipelineStage.
         expect(renderResources.model.statistics.geometryByteLength).toBe(0);
       });
     });
@@ -340,15 +340,11 @@ describe(
         const uniformMap = renderResources.uniformMap;
         expect(uniformMap.u_modelView2D()).toEqual(expectedMatrix);
 
-        expect(renderResources.model._pipelineResources.length).toEqual(1);
+        expect(renderResources.model._pipelineResources.length).toEqual(0);
         expect(renderResources.model._modelResources.length).toEqual(2);
 
-        // The 2D buffer will be counted by NodeStatisticsPipelineStage,
-        // so the memory counted here should stay the same.
-        const featureIdSize = 16;
-        expect(renderResources.model.statistics.geometryByteLength).toBe(
-          featureIdSize
-        );
+        // The 2D buffer will be counted by NodeStatisticsPipelineStage.
+        expect(renderResources.model.statistics.geometryByteLength).toBe(0);
       });
     });
 
@@ -460,12 +456,12 @@ describe(
           "attribute vec3 a_instanceTranslation;",
         ]);
 
-        // No additional buffer was created
+        // No additional buffer was created.
         expect(renderResources.model._pipelineResources.length).toEqual(0);
         expect(renderResources.model._modelResources.length).toEqual(0);
 
         // Attributes with buffers already loaded in will be counted
-        // in NodeStatisticsPipelineStage
+        // in NodeStatisticsPipelineStage.
         expect(renderResources.model.statistics.geometryByteLength).toBe(0);
       });
     });
@@ -507,12 +503,12 @@ describe(
           "attribute vec3 a_instanceTranslation;",
         ]);
 
-        // No additional buffer was created
+        // No additional buffer was created.
         expect(renderResources.model._pipelineResources.length).toEqual(0);
         expect(renderResources.model._modelResources.length).toEqual(0);
 
         // Attributes with buffers already loaded in will be counted
-        // in NodeStatisticsPipelineStage
+        // in NodeStatisticsPipelineStage.
         expect(renderResources.model.statistics.geometryByteLength).toBe(0);
       });
     });
@@ -586,7 +582,7 @@ describe(
         expect(model._pipelineResources.length).toEqual(0);
         expect(model._modelResources.length).toEqual(1);
 
-        // Both resources will be counted in NodeStatisticsPipelineStage.
+        // The resource will be counted in NodeStatisticsPipelineStage.
         expect(model.statistics.geometryByteLength).toBe(0);
       });
     });
@@ -696,14 +692,8 @@ describe(
           CesiumMath.EPSILON8
         );
 
-        // Matrices are stored as 3 vec4s, so this is
-        // 25 matrices * 12 floats/matrix * 4 bytes/float = 1200
-        const matrixSize = 1200;
-        // 25 floats
-        const featureIdSize = 100;
-        expect(renderResources.model.statistics.geometryByteLength).toBe(
-          matrixSize + featureIdSize
-        );
+        // The matrix transforms buffer will be counted by NodeStatisticsPipelineStage.
+        expect(renderResources.model.statistics.geometryByteLength).toBe(0);
       });
     });
   },

--- a/Specs/Scene/Model/ModelSpec.js
+++ b/Specs/Scene/Model/ModelSpec.js
@@ -894,6 +894,7 @@ describe(
           gltf: boxTexturedGlbUrl,
           modelMatrix: modelMatrix,
           projectTo2D: true,
+          incrementallyLoadTextures: false,
         },
         scene2D
       ).then(function (model) {
@@ -911,6 +912,7 @@ describe(
           gltf: boxTexturedGlbUrl,
           modelMatrix: modelMatrix,
           projectTo2D: true,
+          incrementallyLoadTextures: false,
         },
         sceneCV
       ).then(function (model) {

--- a/Specs/Scene/Model/NodeStatisticsPipelineStageSpec.js
+++ b/Specs/Scene/Model/NodeStatisticsPipelineStageSpec.js
@@ -158,6 +158,29 @@ describe(
       });
     });
 
+    it("_countInstancingAttributes counts instancing transform buffer", function () {
+      return loadGltf(boxInstanced).then(function (gltfLoader) {
+        const statistics = new ModelStatistics();
+        const mockRuntimeNode = {
+          instancingTransformsBuffer: {
+            // Matrices are stored as 3 vec4s, so this is
+            // 4 matrices * 12 floats/matrix * 4 bytes/float = 192
+            sizeInBytes: 192,
+          },
+        };
+
+        NodeStatisticsPipelineStage._countInstancingAttributes(
+          statistics,
+          mockRuntimeNode
+        );
+
+        const transformsBuffer = mockRuntimeNode.instancingTransformsBuffer;
+        expect(statistics.geometryByteLength).toBe(
+          transformsBuffer.sizeInBytes
+        );
+      });
+    });
+
     it("_countInstancing2DBuffers counts instancing transform buffer for 2D", function () {
       return loadGltf(boxInstanced).then(function (gltfLoader) {
         const statistics = new ModelStatistics();

--- a/Specs/Scene/Model/NodeStatisticsPipelineStageSpec.js
+++ b/Specs/Scene/Model/NodeStatisticsPipelineStageSpec.js
@@ -119,24 +119,6 @@ describe(
       });
     });
 
-    it("_countInstancingAttributes does not count attributes without buffers", function () {
-      // This model contains instanced rotations, so the transformation
-      // attributes will be loaded in as packed typed arrays only.
-      // Feature IDs are also only loaded as packed typed arrays.
-      return loadGltf(boxInstanced).then(function (gltfLoader) {
-        const statistics = new ModelStatistics();
-        const components = gltfLoader.components;
-        const node = components.nodes[0];
-
-        NodeStatisticsPipelineStage._countInstancingAttributes(
-          statistics,
-          node.instances
-        );
-
-        expect(statistics.geometryByteLength).toBe(0);
-      });
-    });
-
     it("_countInstancingAttributes counts attributes with buffers", function () {
       return loadGltf(boxInstancedTranslationMinMax).then(function (
         gltfLoader
@@ -153,12 +135,31 @@ describe(
         // Model contains four translated instances:
         // 4 instances * 3 floats * 4 bytes per float
         const expectedByteLength = 4 * 12;
-
         expect(statistics.geometryByteLength).toBe(expectedByteLength);
       });
     });
 
-    it("_countInstancingAttributes counts instancing transform buffer", function () {
+    it("_countInstancingAttributes does not count attributes without buffers", function () {
+      // This model contains instanced rotations, so the transformation
+      // attributes will be loaded in as packed typed arrays only.
+      // Feature IDs, however, are loaded as buffers.
+      return loadGltf(boxInstanced).then(function (gltfLoader) {
+        const statistics = new ModelStatistics();
+        const components = gltfLoader.components;
+        const node = components.nodes[0];
+
+        NodeStatisticsPipelineStage._countInstancingAttributes(
+          statistics,
+          node.instances
+        );
+
+        // 4 feature ids * 4 bytes per float
+        const expectedByteLength = 16;
+        expect(statistics.geometryByteLength).toBe(expectedByteLength);
+      });
+    });
+
+    it("_countGeneratedBuffers counts instancing transform buffer", function () {
       return loadGltf(boxInstanced).then(function (gltfLoader) {
         const statistics = new ModelStatistics();
         const mockRuntimeNode = {
@@ -169,7 +170,7 @@ describe(
           },
         };
 
-        NodeStatisticsPipelineStage._countInstancingAttributes(
+        NodeStatisticsPipelineStage._countGeneratedBuffers(
           statistics,
           mockRuntimeNode
         );
@@ -181,7 +182,7 @@ describe(
       });
     });
 
-    it("_countInstancing2DBuffers counts instancing transform buffer for 2D", function () {
+    it("_countGeneratedBuffers counts instancing transform buffer for 2D", function () {
       return loadGltf(boxInstanced).then(function (gltfLoader) {
         const statistics = new ModelStatistics();
         const mockRuntimeNode = {
@@ -192,7 +193,7 @@ describe(
           },
         };
 
-        NodeStatisticsPipelineStage._countInstancing2DBuffers(
+        NodeStatisticsPipelineStage._countGeneratedBuffers(
           statistics,
           mockRuntimeNode
         );
@@ -204,7 +205,7 @@ describe(
       });
     });
 
-    it("_countInstancing2DBuffers counts instancing translation buffer for 2D", function () {
+    it("_countGeneratedBuffers counts instancing translation buffer for 2D", function () {
       return loadGltf(boxInstancedTranslationMinMax).then(function (
         gltfLoader
       ) {
@@ -217,7 +218,7 @@ describe(
           },
         };
 
-        NodeStatisticsPipelineStage._countInstancing2DBuffers(
+        NodeStatisticsPipelineStage._countGeneratedBuffers(
           statistics,
           mockRuntimeNode
         );


### PR DESCRIPTION
Closes #10421. This addresses the temporary buffers created by `InstancingPipelineStage`. The attributes are loaded as typed arrays for reasons like computing transform matrices, or computing the min/max of the translation attribute if it's not provided. But afterwards, there is no further manipulation of the data, and thus no reason to keep recreating the buffers from those typed arrays.

This PR rewrites parts of `I3dmLoader` and `GltfLoader` to load in transform attributes as typed arrays _only if_ the rotation attribute is defined (i.e. matrices have to be computed). Additionally, feature IDs were for some reason being loaded as typed arrays, so they have been restricted to loading as buffers instead.

**TODO**: need to profile the changes for `i3dm`s in combination with other functions (those that require rebuilding draw commands)