### PR TITLE
Use `ShaderBuilderTester` more consistently across `Model` specs

### DIFF
--- a/Specs/Scene/Model/AlphaPipelineStageSpec.js
+++ b/Specs/Scene/Model/AlphaPipelineStageSpec.js
@@ -7,6 +7,7 @@ import {
   RenderState,
   ShaderBuilder,
 } from "../../../Source/Cesium.js";
+import ShaderBuilderTester from "../../ShaderBuilderTester.js";
 
 describe(
   "Scene/Model/AlphaPipelineStage",
@@ -72,10 +73,10 @@ describe(
       );
 
       const shaderBuilder = renderResources.shaderBuilder;
-      expect(shaderBuilder._fragmentShaderParts.defineLines).toEqual([
+      ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
         "ALPHA_MODE_MASK",
       ]);
-      expect(shaderBuilder._fragmentShaderParts.uniformLines).toEqual([
+      ShaderBuilderTester.expectHasFragmentUniforms(shaderBuilder, [
         "uniform float u_alphaCutoff;",
       ]);
       expect(renderResources.uniformMap.u_alphaCutoff()).toBe(cutoff);

--- a/Specs/Scene/Model/CustomShaderPipelineStageSpec.js
+++ b/Specs/Scene/Model/CustomShaderPipelineStageSpec.js
@@ -575,11 +575,12 @@ describe(
 
       CustomShaderPipelineStage.process(renderResources, primitive);
 
-      expect(shaderBuilder._vertexShaderParts.structIds).toEqual([
+      // Check that structs are defined in the correct order
+      ShaderBuilderTester.expectHasVertexStructIds(shaderBuilder, [
         CustomShaderPipelineStage.STRUCT_ID_ATTRIBUTES_VS,
         CustomShaderPipelineStage.STRUCT_ID_VERTEX_INPUT,
       ]);
-      expect(shaderBuilder._fragmentShaderParts.structIds).toEqual([
+      ShaderBuilderTester.expectHasFragmentStructIds(shaderBuilder, [
         CustomShaderPipelineStage.STRUCT_ID_ATTRIBUTES_FS,
         CustomShaderPipelineStage.STRUCT_ID_FRAGMENT_INPUT,
       ]);
@@ -792,8 +793,8 @@ describe(
       // once for the vertex shader, once for the fragment shader
       expect(CustomShaderPipelineStage._oneTimeWarning.calls.count()).toBe(2);
 
-      expect(shaderBuilder._vertexShaderParts.defineLines).toEqual([]);
-      expect(shaderBuilder._fragmentShaderParts.defineLines).toEqual([]);
+      ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, []);
+      ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, []);
     });
 
     it("disables vertex shader if vertexShaderText is not provided", function () {
@@ -805,17 +806,17 @@ describe(
 
       CustomShaderPipelineStage.process(renderResources, primitive);
 
-      expect(shaderBuilder._vertexShaderParts.defineLines).toEqual([]);
-      expect(shaderBuilder._fragmentShaderParts.defineLines).toEqual([
+      ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, []);
+      ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
         "HAS_CUSTOM_FRAGMENT_SHADER",
         "CUSTOM_SHADER_MODIFY_MATERIAL",
       ]);
 
-      expect(shaderBuilder._vertexShaderParts.shaderLines).toEqual([]);
-      const fragmentShaderIndex = shaderBuilder._fragmentShaderParts.shaderLines.indexOf(
+      ShaderBuilderTester.expectVertexLinesEqual(shaderBuilder, []);
+      ShaderBuilderTester.expectFragmentLinesContains(
+        shaderBuilder,
         emptyFragmentShader
       );
-      expect(fragmentShaderIndex).not.toBe(-1);
     });
 
     it("disables fragment shader if fragmentShaderText is not provided", function () {
@@ -827,16 +828,16 @@ describe(
 
       CustomShaderPipelineStage.process(renderResources, primitive);
 
-      expect(shaderBuilder._vertexShaderParts.defineLines).toEqual([
+      ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, [
         "HAS_CUSTOM_VERTEX_SHADER",
       ]);
-      expect(shaderBuilder._fragmentShaderParts.defineLines).toEqual([]);
+      ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, []);
 
-      const vertexShaderIndex = shaderBuilder._vertexShaderParts.shaderLines.indexOf(
+      ShaderBuilderTester.expectVertexLinesContains(
+        shaderBuilder,
         emptyVertexShader
       );
-      expect(vertexShaderIndex).not.toBe(-1);
-      expect(shaderBuilder._fragmentShaderParts.shaderLines).toEqual([]);
+      ShaderBuilderTester.expectFragmentLinesEqual(shaderBuilder, []);
     });
 
     it("disables custom shader if neither fragmentShaderText nor vertexShaderText are provided", function () {
@@ -876,7 +877,7 @@ describe(
         "CUSTOM_SHADER_MODIFY_MATERIAL",
       ]);
 
-      expect(shaderBuilder._vertexShaderParts.structIds).toEqual([]);
+      ShaderBuilderTester.expectHasVertexStructIds(shaderBuilder, []);
       ShaderBuilderTester.expectHasFragmentStruct(
         shaderBuilder,
         CustomShaderPipelineStage.STRUCT_ID_ATTRIBUTES_FS,
@@ -896,7 +897,7 @@ describe(
         ]
       );
 
-      expect(shaderBuilder._vertexShaderParts.functionIds).toEqual([]);
+      ShaderBuilderTester.expectHasVertexFunctionIds(shaderBuilder, []);
       ShaderBuilderTester.expectHasFragmentFunctionUnordered(
         shaderBuilder,
         CustomShaderPipelineStage.FUNCTION_ID_INITIALIZE_INPUT_STRUCT_FS,

--- a/Specs/Scene/Model/DequantizationPipelineStageSpec.js
+++ b/Specs/Scene/Model/DequantizationPipelineStageSpec.js
@@ -99,7 +99,7 @@ describe(
           ]
         );
         ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, []);
-        expect(shaderBuilder._fragmentShaderParts.functionIds).toEqual([]);
+        ShaderBuilderTester.expectHasFragmentFunctionIds(shaderBuilder, []);
       });
     });
 
@@ -287,7 +287,7 @@ describe(
           []
         );
         ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, []);
-        expect(shaderBuilder._fragmentShaderParts.functionIds).toEqual([]);
+        ShaderBuilderTester.expectHasFragmentFunctionIds(shaderBuilder, []);
       });
     });
   },

--- a/Specs/Scene/Model/LightingPipelineStageSpec.js
+++ b/Specs/Scene/Model/LightingPipelineStageSpec.js
@@ -6,6 +6,7 @@ import {
   ShaderBuilder,
   Cartesian3,
 } from "../../../Source/Cesium.js";
+import ShaderBuilderTester from "../../ShaderBuilderTester.js";
 
 describe("Scene/Model/LightingPipelineStage", function () {
   const mockPrimitive = {};
@@ -27,10 +28,19 @@ describe("Scene/Model/LightingPipelineStage", function () {
     };
     LightingPipelineStage.process(renderResources, mockPrimitive);
 
-    expect(shaderBuilder._vertexShaderParts.defineLines).toEqual([]);
-    expect(shaderBuilder._fragmentShaderParts.defineLines).toEqual([
+    ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, []);
+    ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
       "USE_CUSTOM_LIGHT_COLOR",
       "LIGHTING_UNLIT",
+    ]);
+
+    ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, []);
+    ShaderBuilderTester.expectHasFragmentUniforms(shaderBuilder, [
+      "uniform vec3 model_lightColorHdr;",
+    ]);
+
+    ShaderBuilderTester.expectFragmentLinesEqual(shaderBuilder, [
+      _shadersLightingStageFS,
     ]);
 
     expect(renderResources.uniformMap.model_lightColorHdr).toBeDefined();
@@ -45,9 +55,16 @@ describe("Scene/Model/LightingPipelineStage", function () {
     };
     LightingPipelineStage.process(renderResources, mockPrimitive);
 
-    expect(shaderBuilder._vertexShaderParts.defineLines).toEqual([]);
+    ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, []);
     expect(shaderBuilder._fragmentShaderParts.defineLines).toEqual([
       "LIGHTING_UNLIT",
+    ]);
+
+    ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, []);
+    ShaderBuilderTester.expectHasFragmentUniforms(shaderBuilder, []);
+
+    ShaderBuilderTester.expectFragmentLinesEqual(shaderBuilder, [
+      _shadersLightingStageFS,
     ]);
   });
 
@@ -63,23 +80,15 @@ describe("Scene/Model/LightingPipelineStage", function () {
     };
     LightingPipelineStage.process(renderResources, mockPrimitive);
 
-    expect(shaderBuilder._vertexShaderParts.defineLines).toEqual([]);
+    ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, []);
     expect(shaderBuilder._fragmentShaderParts.defineLines).toEqual([
       "LIGHTING_PBR",
     ]);
-  });
 
-  it("adds the lighting shader function to the shader", function () {
-    const shaderBuilder = new ShaderBuilder();
-    const renderResources = {
-      model: mockModel,
-      shaderBuilder: shaderBuilder,
-      lightingOptions: optionsUnlit,
-    };
-    LightingPipelineStage.process(renderResources, mockPrimitive);
+    ShaderBuilderTester.expectHasVertexUniforms(shaderBuilder, []);
+    ShaderBuilderTester.expectHasFragmentUniforms(shaderBuilder, []);
 
-    expect(shaderBuilder._vertexShaderParts.shaderLines).toEqual([]);
-    expect(shaderBuilder._fragmentShaderParts.shaderLines).toEqual([
+    ShaderBuilderTester.expectFragmentLinesEqual(shaderBuilder, [
       _shadersLightingStageFS,
     ]);
   });

--- a/Specs/Scene/Model/LightingPipelineStageSpec.js
+++ b/Specs/Scene/Model/LightingPipelineStageSpec.js
@@ -56,7 +56,7 @@ describe("Scene/Model/LightingPipelineStage", function () {
     LightingPipelineStage.process(renderResources, mockPrimitive);
 
     ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, []);
-    expect(shaderBuilder._fragmentShaderParts.defineLines).toEqual([
+    ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
       "LIGHTING_UNLIT",
     ]);
 
@@ -81,7 +81,7 @@ describe("Scene/Model/LightingPipelineStage", function () {
     LightingPipelineStage.process(renderResources, mockPrimitive);
 
     ShaderBuilderTester.expectHasVertexDefines(shaderBuilder, []);
-    expect(shaderBuilder._fragmentShaderParts.defineLines).toEqual([
+    ShaderBuilderTester.expectHasFragmentDefines(shaderBuilder, [
       "LIGHTING_PBR",
     ]);
 

--- a/Specs/Scene/Model/ModelRenderResourcesSpec.js
+++ b/Specs/Scene/Model/ModelRenderResourcesSpec.js
@@ -3,17 +3,12 @@ import {
   ModelRenderResources,
   RenderState,
 } from "../../../Source/Cesium.js";
+import ShaderBuilderTester from "../../ShaderBuilderTester.js";
 
 describe(
   "Scene/Model/ModelRenderResources",
   function () {
     const mockModel = {};
-
-    function checkShaderDefines(shaderBuilder, expectedDefines) {
-      expect(shaderBuilder._fragmentShaderParts.defineLines).toEqual(
-        expectedDefines
-      );
-    }
 
     it("throws for undefined model", function () {
       expect(function () {
@@ -38,7 +33,10 @@ describe(
       expect(modelResources.renderStateOptions).toEqual(defaultRenderState);
       expect(modelResources.hasSilhouette).toBe(false);
       expect(modelResources.hasSkipLevelOfDetail).toBe(false);
-      checkShaderDefines(modelResources.shaderBuilder, []);
+      ShaderBuilderTester.expectHasFragmentDefines(
+        modelResources.shaderBuilder,
+        []
+      );
     });
   },
   "WebGL"

--- a/Specs/Scene/Model/NodeRenderResourcesSpec.js
+++ b/Specs/Scene/Model/NodeRenderResourcesSpec.js
@@ -8,6 +8,7 @@ import {
   NodeRenderResources,
   RenderState,
 } from "../../../Source/Cesium.js";
+import ShaderBuilderTester from "../../ShaderBuilderTester.js";
 
 describe(
   "Scene/Model/NodeRenderResources",
@@ -29,12 +30,6 @@ describe(
       sceneGraph: mockSceneGraph,
       children: [],
     });
-
-    function checkShaderDefines(shaderBuilder, expectedDefines) {
-      expect(shaderBuilder._fragmentShaderParts.defineLines).toEqual(
-        expectedDefines
-      );
-    }
 
     it("throws for undefined modelRenderResources", function () {
       expect(function () {
@@ -106,10 +101,16 @@ describe(
       );
 
       // The model shader must not be modified by the node...
-      checkShaderDefines(modelResources.shaderBuilder, ["MODEL"]);
+      ShaderBuilderTester.expectHasFragmentDefines(
+        modelResources.shaderBuilder,
+        ["MODEL"]
+      );
 
       // ...but the node shader will be updated.
-      checkShaderDefines(nodeResources.shaderBuilder, ["MODEL", "NODE"]);
+      ShaderBuilderTester.expectHasFragmentDefines(
+        nodeResources.shaderBuilder,
+        ["MODEL", "NODE"]
+      );
     });
   },
   "WebGL"

--- a/Specs/Scene/Model/PrimitiveRenderResourcesSpec.js
+++ b/Specs/Scene/Model/PrimitiveRenderResourcesSpec.js
@@ -18,6 +18,7 @@ import {
   RenderState,
   VertexAttributeSemantic,
 } from "../../../Source/Cesium.js";
+import ShaderBuilderTester from "../../ShaderBuilderTester.js";
 
 describe(
   "Scene/Model/PrimitiveRenderResources",
@@ -42,12 +43,6 @@ describe(
       sceneGraph: mockSceneGraph,
       children: [],
     });
-
-    function checkShaderDefines(shaderBuilder, expectedDefines) {
-      expect(shaderBuilder._fragmentShaderParts.defineLines).toEqual(
-        expectedDefines
-      );
-    }
 
     const primitive = {
       indices: {
@@ -246,13 +241,18 @@ describe(
       expect(primitiveResources.hasSkipLevelOfDetail).toBe(true);
 
       // The defines should cascade through the three levels
-      checkShaderDefines(modelResources.shaderBuilder, ["MODEL"]);
-      checkShaderDefines(nodeResources.shaderBuilder, ["MODEL", "NODE"]);
-      checkShaderDefines(primitiveResources.shaderBuilder, [
-        "MODEL",
-        "NODE",
-        "PRIMITIVE",
-      ]);
+      ShaderBuilderTester.expectHasFragmentDefines(
+        modelResources.shaderBuilder,
+        ["MODEL"]
+      );
+      ShaderBuilderTester.expectHasFragmentDefines(
+        nodeResources.shaderBuilder,
+        ["MODEL", "NODE"]
+      );
+      ShaderBuilderTester.expectHasFragmentDefines(
+        primitiveResources.shaderBuilder,
+        ["MODEL", "NODE", "PRIMITIVE"]
+      );
     });
 
     it("inherits from node render resources", function () {

--- a/Specs/ShaderBuilderTester.js
+++ b/Specs/ShaderBuilderTester.js
@@ -74,6 +74,13 @@ ShaderBuilderTester.expectHasVaryings = function (
   );
 };
 
+ShaderBuilderTester.expectHasVertexStructIds = function (
+  shaderBuilder,
+  expectedStructIds
+) {
+  expect(shaderBuilder._vertexShaderParts.structIds).toEqual(expectedStructIds);
+};
+
 ShaderBuilderTester.expectHasVertexStruct = function (
   shaderBuilder,
   structId,
@@ -87,6 +94,15 @@ ShaderBuilderTester.expectHasVertexStruct = function (
   expectEqualUnordered(struct.fields, expectedFields);
 };
 
+ShaderBuilderTester.expectHasFragmentStructIds = function (
+  shaderBuilder,
+  expectedStructIds
+) {
+  expect(shaderBuilder._fragmentShaderParts.structIds).toEqual(
+    expectedStructIds
+  );
+};
+
 ShaderBuilderTester.expectHasFragmentStruct = function (
   shaderBuilder,
   structId,
@@ -98,6 +114,15 @@ ShaderBuilderTester.expectHasFragmentStruct = function (
 
   expect(struct.name).toEqual(structName);
   expectEqualUnordered(struct.fields, expectedFields);
+};
+
+ShaderBuilderTester.expectHasVertexFunctionIds = function (
+  shaderBuilder,
+  expectedFunctionIds
+) {
+  expect(shaderBuilder._vertexShaderParts.functionIds).toEqual(
+    expectedFunctionIds
+  );
 };
 
 ShaderBuilderTester.expectHasVertexFunction = function (
@@ -124,6 +149,15 @@ ShaderBuilderTester.expectHasVertexFunctionUnordered = function (
 
   expect(func.signature).toEqual(signature);
   expectEqualUnordered(func.body, bodyLines);
+};
+
+ShaderBuilderTester.expectHasFragmentFunctionIds = function (
+  shaderBuilder,
+  expectedFunctionIds
+) {
+  expect(shaderBuilder._fragmentShaderParts.functionIds).toEqual(
+    expectedFunctionIds
+  );
 };
 
 ShaderBuilderTester.expectHasFragmentFunction = function (


### PR DESCRIPTION
Some tests were written before `ShaderBuilderTester` was created, so they were accessing `shaderBuilder._fragmentShaderParts` and other private variables.

This PR simply updates the usage everywhere for consistency.

@sanjeetsuhag could you review?