### PR TITLE
Don't create a feature table for point clouds with per-point properties

### DIFF
--- a/Source/Scene/parseBatchTable.js
+++ b/Source/Scene/parseBatchTable.js
@@ -78,6 +78,7 @@ function parseBatchTable(options) {
   }
 
   const className = MetadataClass.BATCH_TABLE_CLASS_NAME;
+  const binaryProperties = partitionResults.binaryProperties;
 
   let metadataTable;
   let propertyAttributes;
@@ -86,7 +87,7 @@ function parseBatchTable(options) {
     const attributeResults = transcodeBinaryPropertiesAsPropertyAttributes(
       featureCount,
       className,
-      partitionResults.binaryProperties,
+      binaryProperties,
       binaryBody,
       customAttributeOutput
     );
@@ -101,7 +102,7 @@ function parseBatchTable(options) {
     const binaryResults = transcodeBinaryProperties(
       featureCount,
       className,
-      partitionResults.binaryProperties,
+      binaryProperties,
       binaryBody
     );
     transcodedSchema = binaryResults.transcodedSchema;
@@ -168,8 +169,11 @@ function partitionProperties(batchTable) {
     hierarchyExtension = extensions["3DTILES_batch_table_hierarchy"];
   }
 
+  // A JsonMetadataTable is only allocated as needed.
   let jsonProperties;
-  let binaryProperties;
+  // A MetadataTable or PropertyAttribute will always be created, even if
+  // there are no properties.
+  const binaryProperties = {};
   for (const propertyId in batchTable) {
     if (
       !batchTable.hasOwnProperty(propertyId) ||
@@ -186,7 +190,6 @@ function partitionProperties(batchTable) {
       jsonProperties = defined(jsonProperties) ? jsonProperties : {};
       jsonProperties[propertyId] = property;
     } else {
-      binaryProperties = defined(binaryProperties) ? binaryProperties : {};
       binaryProperties[propertyId] = property;
     }
   }

--- a/Specs/Scene/Model/Model3DTileContentSpec.js
+++ b/Specs/Scene/Model/Model3DTileContentSpec.js
@@ -1006,14 +1006,8 @@ describe(
           pointCloudWithPerPointPropertiesUrl
         ).then(function (tileset) {
           const content = tileset.root.content;
-          expect(content.featuresLength).toBe(1000);
+          expect(content.featuresLength).toBe(0);
           expect(content.innerContents).toBeUndefined();
-
-          const feature = content.getFeature(0);
-          expect(feature).toBeDefined();
-          const propertyNames = [];
-          feature.getPropertyNames(propertyNames);
-          expect(propertyNames).toEqual([]);
         });
       });
 

--- a/Specs/Scene/Model/Model3DTileContentSpec.js
+++ b/Specs/Scene/Model/Model3DTileContentSpec.js
@@ -999,8 +999,8 @@ describe(
       });
 
       it("point cloud with per-point properties work", function () {
-        // When the batch table contains per-point properties, aka no batching,
-        // a ModelFeatureTable is created, but it will have no properties
+        // When the batch table contains only per-point properties, no feature
+        // table will be created.
         return Cesium3DTilesTester.loadTileset(
           scene,
           pointCloudWithPerPointPropertiesUrl

--- a/Specs/Scene/Model/PntsLoaderSpec.js
+++ b/Specs/Scene/Model/PntsLoaderSpec.js
@@ -116,10 +116,11 @@ describe(
       const batchClass = schema.classes[MetadataClass.BATCH_TABLE_CLASS_NAME];
       const properties = batchClass.properties;
 
-      expect(structuralMetadata.propertyTableCount).toEqual(1);
+      const expectedPropertyTableCount = isBatched ? 1 : 0;
+      expect(structuralMetadata.propertyTableCount).toEqual(
+        expectedPropertyTableCount
+      );
       const propertyTable = structuralMetadata.getPropertyTable(0);
-
-      const propertyAttribute = structuralMetadata.getPropertyAttribute(0);
 
       const tablePropertyNames = [];
       const attributePropertyNames = [];
@@ -151,11 +152,14 @@ describe(
         }
       }
 
-      expect(propertyTable.getPropertyIds(0).sort()).toEqual(
-        tablePropertyNames.sort()
-      );
-
-      if (!isBatched) {
+      // Check that the list of property IDs match in either the batch table
+      // (batched points) or the property attribute (per-point properties)
+      if (isBatched) {
+        expect(propertyTable.getPropertyIds(0).sort()).toEqual(
+          tablePropertyNames.sort()
+        );
+      } else {
+        const propertyAttribute = structuralMetadata.getPropertyAttribute(0);
         expect(Object.keys(propertyAttribute.properties).sort()).toEqual(
           attributePropertyNames.sort()
         );

--- a/Specs/Scene/parseBatchTableSpec.js
+++ b/Specs/Scene/parseBatchTableSpec.js
@@ -493,14 +493,9 @@ describe("Scene/parseBatchTable", function () {
     );
     expect(windDirectionAttribute.typedArray).toEqual(values.slice(3));
 
-    // A property table wil still be defined, but since we didn't have JSON
-    // or batch table hierarchy, it will be empty.
+    // The property table will not be created
     const propertyTable = metadata.getPropertyTable(0);
-    expect(propertyTable).toBeDefined();
-    // An empty table is created
-    expect(propertyTable._jsonMetadataTable).toBeDefined();
-    expect(propertyTable._metadataTable).not.toBeDefined();
-    expect(propertyTable._batchTableHierarchy).not.toBeDefined();
+    expect(propertyTable).not.toBeDefined();
 
     expect(metadata.propertyAttributes.length).toBe(1);
     const [propertyAttribute] = metadata.propertyAttributes;
@@ -727,11 +722,7 @@ describe("Scene/parseBatchTable", function () {
     // A property table wil still be defined, but since we didn't have JSON
     // or batch table hierarchy, it will be empty.
     const propertyTable = metadata.getPropertyTable(0);
-    expect(propertyTable).toBeDefined();
-    // An empty table is created
-    expect(propertyTable._jsonMetadataTable).toBeDefined();
-    expect(propertyTable._metadataTable).not.toBeDefined();
-    expect(propertyTable._batchTableHierarchy).not.toBeDefined();
+    expect(propertyTable).not.toBeDefined();
 
     expect(metadata.propertyAttributes.length).toBe(1);
     const [propertyAttribute] = metadata.propertyAttributes;

--- a/Specs/Scene/parseBatchTableSpec.js
+++ b/Specs/Scene/parseBatchTableSpec.js
@@ -719,8 +719,7 @@ describe("Scene/parseBatchTable", function () {
       binaryBatchTable.windDirection.typedArray
     );
 
-    // A property table wil still be defined, but since we didn't have JSON
-    // or batch table hierarchy, it will be empty.
+    // No property table will be created.
     const propertyTable = metadata.getPropertyTable(0);
     expect(propertyTable).not.toBeDefined();
 


### PR DESCRIPTION
This PR was intended to address [this bug in `debugColorizeTiles` for point clouds](https://github.com/CesiumGS/cesium/pull/10635#issuecomment-1205449414), but it's also an important performance improvement for point clouds.

Essentially what was happening is `parseBatchTable`, though it parses the properties as `PropertyAttributes`, it was creating an empty `PropertyTable`. `Model` then turns this into a `ModelFeatureTable`, which allocates a `ModelFeature` _per point_ which is quite expensive.

This PR changes the batch table parsing so the `PropertyTable` will only be created if it's really needed for batched points. As a result, `Model3DTileContent.applyDebugSettings()` takes the non-batched route and applies the debug color as `model.color`.

Try [this Sandcastle](https://github.com/CesiumGS/cesium/pull/10635#issuecomment-1205449414). for all 4 point clouds, checking `Display > Colorize` will work correctly now.