### PR TITLE
Fix creation of instances in `I3dmLoader`

### DIFF
--- a/Source/Scene/Model/I3dmLoader.js
+++ b/Source/Scene/Model/I3dmLoader.js
@@ -2,6 +2,7 @@ import AttributeCompression from "../../Core/AttributeCompression.js";
 import BoundingSphere from "../../Core/BoundingSphere.js";
 import Cartesian3 from "../../Core/Cartesian3.js";
 import Check from "../../Core/Check.js";
+import clone from "../../Core/clone.js";
 import ComponentDatatype from "../../Core/ComponentDatatype.js";
 import defaultValue from "../../Core/defaultValue.js";
 import defined from "../../Core/defined.js";
@@ -639,7 +640,7 @@ function createInstances(loader, components, frameState) {
   const nodesLength = nodes.length;
   let makeInstancesCopy = false;
   for (i = 0; i < nodesLength; i++) {
-    const node = components.nodes[i];
+    const node = nodes[i];
     if (node.primitives.length > 0) {
       // If the instances have not been assigned to a node already, assign
       // it to the first node encountered. Otherwise, make a copy of them
@@ -672,17 +673,7 @@ function createInstancesCopy(instances) {
   const attributesLength = attributes.length;
 
   for (let i = 0; i < attributesLength; i++) {
-    const attribute = attributes[i];
-    const attributeCopy = new Attribute();
-    attributeCopy.name = attribute.name;
-    attributeCopy.setIndex = attribute.setIndex;
-    attributeCopy.semantic = attribute.semantic;
-    attributeCopy.componentDatatype = attribute.componentDatatype;
-    attributeCopy.type = attribute.type;
-    attributeCopy.count = attribute.count;
-    attributeCopy.typedArray = attribute.typedArray;
-    attributeCopy.buffer = attribute.buffer;
-
+    const attributeCopy = clone(attributes[i], false);
     instancesCopy.attributes.push(attributeCopy);
   }
 


### PR DESCRIPTION
This PR fixes a crash happening in this [Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=jVRrc+I2FP0rGj7BDJEtS35t2UwDedRMTLqBbLIMX4QtiIIsU0smQCf/vfKD2aZNO/liS1f3nHulc6Qkl0qDHWevrABfgWSvYMQULzP4vY51F52kno9yqSmXrFh0+uDPhQRgLfIl+wJWVCjWrwJqcxjm+5+Rt94vC7mQltXQQ7bXTKbdlr8JNhN8OeOCqUiqLUt0XsR8z2WFtqykbpCfVqqu4jxlwjTb0iYfUtT8dWbbBLgpqNTt7sZTQBMDVEDn4JCXBeC5BFQpptVCth1GuYQpW9FS6Is6eZZvmDSFFx12GD8vbxJ+x8fRwzFCEx6Z0vduMoq8aLN9+j4ah9Ak/ZHebExSdJxk18/xcZ7FU8Tjl83hdvaNxJexvnu8Ot6N0GaeXb/Ejz/28+zhMHmM+O1ovJ0bssnlNxVl4jk143j243Uyu0Dx7MKdYBum/lM2WV5H2e9XeOjy9fhp/ODPg0s6tP3tUL3cLzfoN61nl+Vm0alPQTANdHVMTJv5qpSJrvYtcpp2BV0y0QdlIXqNvm3ie1e804vpbp0JKlQ1qBUHwLJaLMzonmdlNk0KxuR0SxN2VRR55TRSZ7YSqoRJBrcFz7jmO6YgTdNuy1FRvjUS1n2awxdsR6vGKyv+1OqeKSNkwuCqyLOLSsoo7aLAc0O713ipxa9V7Qv1KbiPA1LDT2DdgIcFT9fsUxTY8cj7DrQ5DvVZrNtr7tHJ7jRjBYUrcZjlzfGnTGku6xMBX96JRQttRlTi7plDXCf0EPQ8ByNCiO31wRnx/RAhBLFHSIh9l/QBJo75I+g7xPFQiAOvV1/uvODMvABtkVZ2U5sXLPnfyjYkdohcRGyEQ4JCxzZVzkwUETfwPIQJ9pH5unU0QE5AnGrBI35IgqZ4bbHtf2/Ohk5gY8/xPey5RjIPNTVCmwTEEGHfd5zAC/rAhtixcRD62A4CjLHTVnirv2lZnHZo1+9Xp98ZKH0Q7PzUxq882+aFrhzfhdDSLNsKahqxlmWyMY5PlGouAQAD6+/QQcp3gKdfP3hQQSLM02NWVqUQU340tjofWCb/X9DKP1yu73asEPRQpT2j89smCCEcWGb6MVLnuVjS4h/MfwE). The glTF inside the i3dm contains two nodes, each with its own primitive. In `I3dmLoader`, both nodes' `instances` were set to the same `ModelComponents.Instances` object. So as a result of #10731, the attribute's `typedArray` was unloaded, though that meant that the next node that was processed would find no typed array to work from.

Memory management could be cleaner / better if we could modify the `ModelComponents.Instances` directly, such that the buffer generated by `InstancingPipelineStage` is saved and used across multiple instances. That way, it'd be okay if the nodes referenced the same `Instances` object. But that may be conceptually unwanted. This fix at least prevents the crash.