### PR TITLE
Removed deprecations slated for 1.97

### DIFF
--- a/Source/Core/TileProviderError.js
+++ b/Source/Core/TileProviderError.js
@@ -1,6 +1,5 @@
 import defaultValue from "./defaultValue.js";
 import defined from "./defined.js";
-import deprecationWarning from "./deprecationWarning.js";
 import formatError from "./formatError.js";
 
 /**
@@ -153,67 +152,6 @@ TileProviderError.reportError = function (
 };
 
 /**
- * Handles an error in an {@link ImageryProvider} or {@link TerrainProvider} by raising an event if it has any listeners, or by
- * logging the error to the console if the event has no listeners.  This method also tracks the number
- * of times the operation has been retried and will automatically retry if requested to do so by the
- * event listeners.
- *
- * @param {TileProviderError} previousError The error instance returned by this function the last
- *        time it was called for this error, or undefined if this is the first time this error has
- *        occurred.
- * @param {ImageryProvider|TerrainProvider} provider The imagery or terrain provider that encountered the error.
- * @param {Event} event The event to raise to inform listeners of the error.
- * @param {String} message The message describing the error.
- * @param {Number} x The X coordinate of the tile that experienced the error, or undefined if the
- *        error is not specific to a particular tile.
- * @param {Number} y The Y coordinate of the tile that experienced the error, or undefined if the
- *        error is not specific to a particular tile.
- * @param {Number} level The level-of-detail of the tile that experienced the error, or undefined if the
- *        error is not specific to a particular tile.
- * @param {TileProviderError.RetryFunction} retryFunction The function to call to retry the operation.  If undefined, the
- *        operation will not be retried.
- * @param {Error} [errorDetails] The error or exception that occurred, if any.
- * @returns {TileProviderError} The error instance that was passed to the event listeners and that
- *          should be passed to this function the next time it is called for the same error in order
- *          to track retry counts.
- *
- * @deprecated
- */
-TileProviderError.handleError = function (
-  previousError,
-  provider,
-  event,
-  message,
-  x,
-  y,
-  level,
-  retryFunction,
-  errorDetails
-) {
-  deprecationWarning(
-    "TileProviderError.handleError",
-    "TileProviderError.handleError was deprecated in CesiumJS 1.96 and will be removed in 1.97. Use TileProviderError.reportError instead."
-  );
-
-  const error = TileProviderError.reportError(
-    previousError,
-    provider,
-    event,
-    message,
-    x,
-    y,
-    level,
-    errorDetails
-  );
-
-  if (error.retry && defined(retryFunction)) {
-    retryFunction();
-  }
-
-  return error;
-};
-
-/**
  * Reports success of an operation by resetting the retry count of a previous error, if any.  This way,
  * if the error occurs again in the future, the listeners will be informed that it has not yet been retried.
  *
@@ -224,23 +162,6 @@ TileProviderError.reportSuccess = function (previousError) {
   if (defined(previousError)) {
     previousError.timesRetried = -1;
   }
-};
-
-/**
- * Handles success of an operation by resetting the retry count of a previous error, if any.  This way,
- * if the error occurs again in the future, the listeners will be informed that it has not yet been retried.
- *
- * @param {TileProviderError} previousError The previous error, or undefined if this operation has
- *        not previously resulted in an error.
- *
- * @deprecated
- */
-TileProviderError.handleSuccess = function (previousError) {
-  deprecationWarning(
-    "TileProviderError.handleSuccess",
-    "TileProviderError.handleSuccess was deprecated in CesiumJS 1.96 and will be removed in 1.97. Use TileProviderError.reportSuccess instead."
-  );
-  TileProviderError.reportSuccess(previousError);
 };
 
 /**

--- a/Source/Scene/GlobeSurfaceTile.js
+++ b/Source/Scene/GlobeSurfaceTile.js
@@ -703,7 +703,7 @@ function requestTileGeometry(surfaceTile, terrainProvider, x, y, level) {
       return;
     }
 
-    // Initially assume failure.  handleError may retry, in which case the state will
+    // Initially assume failure.  reportError may retry, in which case the state will
     // change to RECEIVING or UNLOADED.
     surfaceTile.terrainState = TerrainState.FAILED;
     surfaceTile.request = undefined;


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/10512 by removing deprecated functions `TileProviderError.handleError` and `TileProviderError.handleSuccess`.