### PR TITLE
Add support for `CustomShader` in a model entity

### DIFF
--- a/Source/DataSources/ModelGraphics.js
+++ b/Source/DataSources/ModelGraphics.js
@@ -105,6 +105,7 @@ function ModelGraphics(options) {
   this._articulationsSubscription = undefined;
   this._clippingPlanes = undefined;
   this._clippingPlanesSubscription = undefined;
+  this._customShader = undefined;
 
   this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
 }
@@ -308,6 +309,13 @@ Object.defineProperties(ModelGraphics.prototype, {
    * @type {Property|undefined}
    */
   clippingPlanes: createPropertyDescriptor("clippingPlanes"),
+
+  /**
+   * Gets or sets the {@link CustomShader} to apply to this model. When <code>undefined</code>, no custom shader code is used.
+   * @memberof ModelGraphics.prototype
+   * @type {Property|undefined}
+   */
+  customShader: createPropertyDescriptor("customShader"),
 });
 
 /**
@@ -340,6 +348,7 @@ ModelGraphics.prototype.clone = function (result) {
   result.nodeTransformations = this.nodeTransformations;
   result.articulations = this.articulations;
   result.clippingPlanes = this.clippingPlanes;
+  result.customShader = this.customShader;
   return result;
 };
 
@@ -408,6 +417,7 @@ ModelGraphics.prototype.merge = function (source) {
     this.clippingPlanes,
     source.clippingPlanes
   );
+  this.customShader = defaultValue(this.customShader, source.customShader);
 
   const sourceNodeTransformations = source.nodeTransformations;
   if (defined(sourceNodeTransformations)) {

--- a/Source/DataSources/ModelVisualizer.js
+++ b/Source/DataSources/ModelVisualizer.js
@@ -218,6 +218,9 @@ ModelVisualizer.prototype.update = function (time) {
       modelGraphics._lightColor,
       time
     );
+    model.customShader = Property.getValueOrUndefined(
+      modelGraphics._customShader
+    );
 
     if (model.ready) {
       const runAnimations = Property.getValueOrDefault(

--- a/Specs/DataSources/ModelGraphicsSpec.js
+++ b/Specs/DataSources/ModelGraphicsSpec.js
@@ -2,6 +2,7 @@ import {
   Cartesian2,
   Cartesian3,
   Color,
+  CustomShader,
   DistanceDisplayCondition,
   JulianDate,
   Quaternion,
@@ -35,6 +36,7 @@ describe("DataSources/ModelGraphics", function () {
       colorBlendMode: ColorBlendMode.HIGHLIGHT,
       colorBlendAmount: 0.5,
       clippingPlanes: new ClippingPlaneCollection(),
+      customShader: new CustomShader(),
       imageBasedLightingFactor: new Cartesian2(0.5, 0.5),
       lightColor: new Color(1.0, 1.0, 0.0, 1.0),
       nodeTransformations: {
@@ -65,6 +67,7 @@ describe("DataSources/ModelGraphics", function () {
     expect(model.colorBlendMode).toBeInstanceOf(ConstantProperty);
     expect(model.colorBlendAmount).toBeInstanceOf(ConstantProperty);
     expect(model.clippingPlanes).toBeInstanceOf(ConstantProperty);
+    expect(model.customShader).toBeInstanceOf(ConstantProperty);
     expect(model.imageBasedLightingFactor).toBeInstanceOf(ConstantProperty);
     expect(model.lightColor).toBeInstanceOf(ConstantProperty);
     expect(model.runAnimations).toBeInstanceOf(ConstantProperty);
@@ -94,6 +97,7 @@ describe("DataSources/ModelGraphics", function () {
     expect(model.clippingPlanes.getValue().planes).toEqual(
       options.clippingPlanes.planes
     );
+    expect(model.customShader.getValue()).toEqual(options.customShader);
     expect(model.imageBasedLightingFactor.getValue()).toEqual(
       options.imageBasedLightingFactor
     );
@@ -147,6 +151,7 @@ describe("DataSources/ModelGraphics", function () {
     source.colorBlendMode = new ConstantProperty(ColorBlendMode.HIGHLIGHT);
     source.colorBlendAmount = new ConstantProperty(0.5);
     source.clippingPlanes = new ConstantProperty(new ClippingPlaneCollection());
+    source.customShader = new ConstantProperty(new CustomShader());
     source.imageBasedLightingFactor = new ConstantProperty(
       new Cartesian2(0.5, 0.5)
     );
@@ -190,6 +195,7 @@ describe("DataSources/ModelGraphics", function () {
     expect(target.colorBlendMode).toBe(source.colorBlendMode);
     expect(target.colorBlendAmount).toBe(source.colorBlendAmount);
     expect(target.clippingPlanes).toBe(source.clippingPlanes);
+    expect(target.customShader).toBe(source.customShader);
     expect(target.imageBasedLightingFactor).toBe(
       source.imageBasedLightingFactor
     );
@@ -221,6 +227,7 @@ describe("DataSources/ModelGraphics", function () {
     source.colorBlendMode = new ConstantProperty(ColorBlendMode.HIGHLIGHT);
     source.colorBlendAmount = new ConstantProperty(0.5);
     source.clippingPlanes = new ConstantProperty(new ClippingPlaneCollection());
+    source.customShader = new ConstantProperty(new CustomShader());
     source.imageBasedLightingFactor = new ConstantProperty(
       new Cartesian2(0.5, 0.5)
     );
@@ -254,6 +261,7 @@ describe("DataSources/ModelGraphics", function () {
     const colorBlendMode = new ConstantProperty(ColorBlendMode.HIGHLIGHT);
     const colorBlendAmount = new ConstantProperty(0.5);
     const clippingPlanes = new ConstantProperty(new ClippingPlaneCollection());
+    const customShader = new ConstantProperty(new CustomShader());
     const imageBasedLightingFactor = new ConstantProperty(
       new Cartesian2(0.5, 0.5)
     );
@@ -284,6 +292,7 @@ describe("DataSources/ModelGraphics", function () {
     target.colorBlendMode = colorBlendMode;
     target.colorBlendAmount = colorBlendAmount;
     target.clippingPlanes = clippingPlanes;
+    target.customShader = customShader;
     target.imageBasedLightingFactor = imageBasedLightingFactor;
     target.lightColor = lightColor;
     target.runAnimations = runAnimations;
@@ -308,6 +317,7 @@ describe("DataSources/ModelGraphics", function () {
     expect(target.colorBlendMode).toBe(colorBlendMode);
     expect(target.colorBlendAmount).toBe(colorBlendAmount);
     expect(target.clippingPlanes).toBe(clippingPlanes);
+    expect(target.customShader).toBe(customShader);
     expect(target.imageBasedLightingFactor).toBe(imageBasedLightingFactor);
     expect(target.lightColor).toBe(lightColor);
     expect(target.runAnimations).toBe(runAnimations);
@@ -337,6 +347,7 @@ describe("DataSources/ModelGraphics", function () {
     source.colorBlendMode = new ConstantProperty(ColorBlendMode.HIGHLIGHT);
     source.colorBlendAmount = new ConstantProperty(0.5);
     source.clippingPlanes = new ConstantProperty(new ClippingPlaneCollection());
+    source.customShader = new ConstantProperty(new CustomShader());
     source.imageBasedLightingFactor = new ConstantProperty(
       new Cartesian2(0.5, 0.5)
     );
@@ -372,6 +383,7 @@ describe("DataSources/ModelGraphics", function () {
     expect(result.colorBlendMode).toBe(source.colorBlendMode);
     expect(result.colorBlendAmount).toBe(source.colorBlendAmount);
     expect(result.clippingPlanes).toBe(source.clippingPlanes);
+    expect(result.customShader).toBe(source.customShader);
     expect(result.imageBasedLightingFactor).toBe(
       source.imageBasedLightingFactor
     );

--- a/Specs/DataSources/ModelVisualizerSpec.js
+++ b/Specs/DataSources/ModelVisualizerSpec.js
@@ -20,6 +20,7 @@ import {
   NodeTransformationProperty,
   ClippingPlane,
   ClippingPlaneCollection,
+  CustomShader,
   Globe,
   Cartographic,
   createWorldTerrain,
@@ -136,6 +137,9 @@ describe(
       });
       model.clippingPlanes = new ConstantProperty(clippingPlanes);
 
+      const customShader = new CustomShader();
+      model.customShader = new ConstantProperty(customShader);
+
       model.imageBasedLightingFactor = new ConstantProperty(
         new Cartesian2(0.5, 0.5)
       );
@@ -177,6 +181,9 @@ describe(
       expect(primitive.clippingPlanes._planes[0].distance).toEqual(
         clippingPlanes._planes[0].distance
       );
+
+      expect(primitive.customShader).toEqual(customShader);
+
       expect(primitive.imageBasedLighting.imageBasedLightingFactor).toEqual(
         new Cartesian2(0.5, 0.5)
       );


### PR DESCRIPTION
I noticed this morning that `ModelVisualizer` was not propagating the `customShader` field to the created `Model`.

This PR adds a property `customShader` that lets you pass in a `CustomShader` instance to the entities.

[Example Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=tVdtbyI3EP4rLp8WiRpIwt2VkKgJ6d1FLer14E6VSpUzXi9rxWuvbC9J7sR/79jehWWhH1AEQsSeGc/zzIxfJlRJY9GKsyem0RWS7AmNmeFFhr96WTRvUT8fK2kJl0zPWx30Yy4R4jJRt+p5iBIiDOs4kWGCUcuVvJcxp8QqvaNNSayezBBZXVQSVYj4RvKMWLaRr9uXczmX1FOjhbEqm8LSJsFxTRN5Rokmy4xJG2Qz9myH6JtTrBSPN9oJhBG9Lyf3Mi8sSoz/24GYFEzp9+whUzETE6ClOREoKwftEDraCHDMk6QwDKg1RXi50JfOeu1+vm3iSgrpc4SoZrBk4oCiQosOShlfprbECDXBwJFbzgzWLFMrdiNEFNwgFBKUK8O9u6tNYoi2MCLyHCdaZXdsqRkzUSD+c//sHPfeXly86f/SCaKLC9wb9M7f9t6UgsDDjduXW6CUkZjL5RYHspNiqz6DmEgT9c8HdfOcW5qCca8m00qIhijNG2X9GGA+ueWfwT4qcTvBY8c7qQMpzSFJZDcHMw2UEqUzg9OGw78KVygJ5mVKqgxW0ee6Cn0L4svwAv6bZSFxHJV7QpIMNrGr5K7fYROhxnhYn5Rqv/WG1U5D4JHX3YIBhxNTZJ/4MxNT/h1A+2fvtlry7LRTSgRoznrw2ejqp2m4MwsWa2+5DuktQ7Wa0EcW/1ZlIKQCLNbbU6pyx9+A9h+3sqRu/Qmct264ppokFq6OMgEy3BRwO1SHIWpvA64fjEqGwA/GXfhOSZYLdkcs6fpMmW6oOaCUowcY4qVYbPDcZwB5wL1qHiLcBNw5wPpOK8lOS9lD1Md7rPuD40h/0KqQMfrKUk7FydgHlBJkd7YXwTHsPyqLoHbolgihlDxt8kuQ3dl+AY7dNhMuHtFMF/TxtPQdjodpzl9Vgekjl5LFaJwSOPbWP/enDIJU+X+A4auYf5GCWwQNyakYg2uPsRkAXZs0NsuRNwyhCo1VlmtmDGTdkzkVf4+2BTuwbRrRHBPK77O/z+qRHHmCeYKin8qn+z2EVWh2x2zoJbEp8lxpa26J4SYqXyVDmWTtmguEnriE/hLDs6dtLSMuJ7OUG7TQ0H1CFxkrZpCEq6Z0jLxj9EXyFdMGuj26jcPFB2TMvLV1WKWj7OxefQO53O1LXn8T3cPLTCR11Tjpqdjg7EwOnI7B/5P/13dbUyJjSoyFZwT6qplSYkH0hMkiKhsMt7DVaY2MfRHsunL3K898HaFHioCkZUASgjDdBexrZjE1pkIcdetLRzFfIR5fHfgnB1FBjAFNUgjfZM1b16Mu2O8tFcr3l3/C5hHkxZml/es/ghBjPOrC9PBKGwJseP4P) -- applies a custom shader that takes the diffuse color and cycles the color channels `RGB -> GBR`

![image](https://user-images.githubusercontent.com/8422414/187929280-86f812e2-8165-4af1-9307-161687e3d2c4.png)

@lilleyse could you review?

