### PR TITLE
Add url package to external list for build-apps task.

### DIFF
--- a/gulpfile.cjs
+++ b/gulpfile.cjs
@@ -1518,7 +1518,7 @@ async function buildCesiumViewer() {
   };
   config.format = "iife";
   config.inject = ["Apps/CesiumViewer/index.js"];
-  config.external = ["https", "http", "zlib"];
+  config.external = ["https", "http", "zlib", "url"];
   config.outdir = cesiumViewerOutputDirectory;
   config.outbase = "Apps/CesiumViewer";
   config.logLevel = "error"; // print errors immediately, and collect warnings so we can filter out known ones


### PR DESCRIPTION
When I run `build-apps` task with the latest version, there is an error:

![Snipaste_2022-09-02_09-12-29](https://user-images.githubusercontent.com/26168955/188038672-c7383e98-837b-40d1-9eb5-4bf3c4a33834.png)

The reason is that `url` package was not added to the configuration. Now works fine.