### PR TITLE
Fixes invalid JSDoc for ModelComponents.SpecularGlossiness

### DIFF
--- a/Source/Scene/ModelComponents.js
+++ b/Source/Scene/ModelComponents.js
@@ -1268,7 +1268,7 @@ MetallicRoughness.DEFAULT_ROUGHNESS_FACTOR = 1.0;
 /**
  * Material properties for the PBR specular glossiness shading model.
  *
- * @alias ModelComponents.function SpecularGlossiness
+ * @alias ModelComponents.SpecularGlossiness
  * @constructor
  *
  * @private


### PR DESCRIPTION
Just came upon this small JSDoc error while looking at this file.