### PR TITLE
Add back support for WEB3D_quantized_attributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 1.98 - 2022-10-03
+
+##### Additions :tada:
+
+- Added support for the `WEB3D_quantized_attributes` extension found in some glTF 1.0 models.
+
 ### 1.97 - 2022-09-01
 
 #### Major Announcements :loudspeaker:

--- a/Source/Scene/GltfIndexBufferLoader.js
+++ b/Source/Scene/GltfIndexBufferLoader.js
@@ -313,12 +313,12 @@ function createIndicesTypedArray(indexBufferLoader, bufferViewTypedArray) {
   const accessor = gltf.accessors[accessorId];
   const count = accessor.count;
   const indexDatatype = accessor.componentType;
+  const indexSize = IndexDatatype.getSizeInBytes(indexDatatype);
 
   let arrayBuffer = bufferViewTypedArray.buffer;
   let byteOffset = bufferViewTypedArray.byteOffset + accessor.byteOffset;
 
-  if (byteOffset % IndexDatatype.getSizeInBytes(indexDatatype) !== 0) {
-    const indexSize = IndexDatatype.getSizeInBytes(indexDatatype);
+  if (byteOffset % indexSize !== 0) {
     const byteLength = count * indexSize;
     const view = new Uint8Array(arrayBuffer, byteOffset, byteLength);
     const copy = new Uint8Array(view);

--- a/Source/Scene/GltfPipeline/updateVersion.js
+++ b/Source/Scene/GltfPipeline/updateVersion.js
@@ -1003,7 +1003,7 @@ function glTF10to20(gltf) {
 // It's not possible to upgrade glTF 1.0 shaders to 2.0 PBR materials in a generic way,
 // but we can look for certain uniform names that are commonly found in glTF 1.0 assets
 // and create PBR materials out of those.
-const baseColorTextureNames = ["u_tex", "u_diffuse"];
+const baseColorTextureNames = ["u_tex", "u_diffuse", "u_emission"];
 const baseColorFactorNames = ["u_diffuse"];
 
 function initializePbrMaterial(material) {

--- a/Source/Scene/Model/ModelUtility.js
+++ b/Source/Scene/Model/ModelUtility.js
@@ -363,6 +363,7 @@ ModelUtility.supportedExtensions = {
   KHR_mesh_quantization: true,
   KHR_texture_basisu: true,
   KHR_texture_transform: true,
+  WEB3D_quantized_attributes: true,
 };
 
 /**

--- a/Specs/Data/Models/glTF-2.0/BoxWeb3dQuantizedAttributes/glTF/BoxWeb3dQuantizedAttributes.gltf
+++ b/Specs/Data/Models/glTF-2.0/BoxWeb3dQuantizedAttributes/glTF/BoxWeb3dQuantizedAttributes.gltf
@@ -1,0 +1,206 @@
+{
+  "accessors": [
+    {
+      "bufferView": 0,
+      "byteOffset": 0,
+      "componentType": 5123,
+      "count": 36,
+      "type": "SCALAR"
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 0,
+      "componentType": 5123,
+      "count": 24,
+      "type": "VEC3",
+      "extensions": {
+        "WEB3D_quantized_attributes": {
+          "decodeMatrix": [
+            0.000015259021896696422,
+            0,
+            0,
+            0,
+            0,
+            0.000015259021896696422,
+            0,
+            0,
+            0,
+            0,
+            0.000015259021896696422,
+            0,
+            -0.5,
+            -0.5,
+            -0.5,
+            1
+          ],
+          "decodedMin": [
+            -0.5,
+            -0.5,
+            -0.5
+          ],
+          "decodedMax": [
+            0.5,
+            0.5,
+            0.5
+          ]
+        }
+      },
+      "min": [
+        0,
+        0,
+        0
+      ],
+      "max": [
+        65535,
+        65535,
+        65535
+      ]
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 144,
+      "componentType": 5123,
+      "count": 24,
+      "type": "VEC3",
+      "extensions": {
+        "WEB3D_quantized_attributes": {
+          "decodeMatrix": [
+            0.000030518043793392844,
+            0,
+            0,
+            0,
+            0,
+            0.000030518043793392844,
+            0,
+            0,
+            0,
+            0,
+            0.000030518043793392844,
+            0,
+            -1,
+            -1,
+            -1,
+            1
+          ]
+        }
+      }
+    },
+    {
+      "bufferView": 2,
+      "byteOffset": 288,
+      "componentType": 5123,
+      "count": 24,
+      "max": [
+        0
+      ],
+      "min": [
+        0
+      ],
+      "type": "SCALAR",
+      "extensions": {
+        "WEB3D_quantized_attributes": {
+          "decodedMin": [
+            1
+          ],
+          "decodedMax": [
+            1
+          ],
+          "decodeMatrix": [
+            0,
+            0,
+            1,
+            1
+          ]
+        }
+      }
+    }
+  ],
+  "asset": {
+    "generator": "collada2gltf@027f74366341d569dea42e9a68b7104cc3892054",
+    "version": "2.0"
+  },
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteLength": 72,
+      "byteOffset": 0,
+      "target": 34963
+    },
+    {
+      "buffer": 0,
+      "byteLength": 288,
+      "byteOffset": 72,
+      "target": 34962,
+      "byteStride": 6
+    },
+    {
+      "buffer": 0,
+      "byteLength": 336,
+      "byteOffset": 360,
+      "target": 34962,
+      "byteStride": 2
+    }
+  ],
+  "buffers": [
+    {
+      "byteLength": 696,
+      "uri": "data:application/octet-stream;base64,AAABAAIAAwACAAEABAAFAAYABwAGAAUACAAJAAoACwAKAAkADAANAA4ADwAOAA0AEAARABIAEwASABEAFAAVABYAFwAWABUAAAAAAP////8AAP//AAD///////////////8AAP//AAAAAP////8AAAAAAAAAAAAA//////////8AAP///////wAA//8AAAAAAAD/////////////AAD//wAA/////wAAAAAAAP//AAD/////AAAAAAAAAAD//wAAAAAAAAAAAAD//wAA//8AAAAA/////wAA/3//f////3//f////3//f////3//f////38AAP9//38AAP9//38AAP9//38AAP9/////f/9/////f/9/////f/9/////f/9//3////9//3////9//3////9//3////9/AAD/f/9/AAD/f/9/AAD/f/9/AAD/f/9//3//fwAA/3//fwAA/3//fwAA/3//fwAAAAAAAP////8AAP//AAD///////////////8AAP//AAAAAP////8AAAAAAAAAAAAA//////////8AAP///////wAA//8AAAAAAAD/////////////AAD//wAA/////wAAAAAAAP//AAD/////AAAAAAAAAAD//wAAAAAAAAAAAAD//wAA//8AAAAA/////wAAAIAAgP//AIAAgP//AIAAgP//AIAAgP//AIAAAACAAIAAAACAAIAAAACAAIAAAACA//8AgACA//8AgACA//8AgACA//8AgACAAID//wCAAID//wCAAID//wCAAID//wCAAAAAgACAAAAAgACAAAAAgACAAAAAgACAAIAAgAAAAIAAgAAAAIAAgAAAAIAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    }
+  ],
+  "extensionsUsed": [
+    "WEB3D_quantized_attributes"
+  ],
+  "materials": [
+    {
+      "pbrMetallicRoughness": {
+        "roughnessFactor": 1,
+        "metallicFactor": 0,
+        "baseColorFactor": [
+          0.6038273388553378,
+          0,
+          0,
+          1
+        ]
+      },
+      "emissiveFactor": [
+        0,
+        0,
+        0
+      ],
+      "alphaMode": "OPAQUE",
+      "doubleSided": false
+    }
+  ],
+  "meshes": [
+    {
+      "primitives": [
+        {
+          "attributes": {
+            "NORMAL": 2,
+            "POSITION": 1,
+            "_SCALAR_TEST": 3
+          },
+          "indices": 0,
+          "material": 0,
+          "mode": 4
+        }
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "mesh": 0
+    }
+  ],
+  "scene": 0,
+  "scenes": [
+    {
+      "nodes": [
+        0
+      ]
+    }
+  ],
+  "extensionsRequired": [
+    "WEB3D_quantized_attributes"
+  ]
+}

--- a/Specs/Scene/GltfLoaderSpec.js
+++ b/Specs/Scene/GltfLoaderSpec.js
@@ -118,6 +118,8 @@ describe(
       "./Data/Models/glTF-2.0/BoxCesiumRtc/glTF/BoxCesiumRtc.gltf";
     const torusQuantized =
       "./Data/Models/glTF-2.0/TorusQuantized/glTF/TorusQuantized.gltf";
+    const boxWeb3dQuantizedAttributes =
+      "./Data/Models/glTF-2.0/BoxWeb3dQuantizedAttributes/glTF/BoxWeb3dQuantizedAttributes.gltf";
 
     let scene;
     const gltfLoaders = [];
@@ -3015,6 +3017,59 @@ describe(
         expect(normalAttribute.byteStride).toBe(4);
         expect(normalAttribute.min).not.toBeDefined();
         expect(normalAttribute.max).not.toBeDefined();
+      });
+    });
+
+    it("loads WEB3D_quantized_attributes extension", function () {
+      return loadGltf(boxWeb3dQuantizedAttributes).then(function (gltfLoader) {
+        const components = gltfLoader.components;
+        const scene = components.scene;
+        const primitive = scene.nodes[0].primitives[0];
+        const attributes = primitive.attributes;
+        const positionAttribute = getAttribute(
+          attributes,
+          VertexAttributeSemantic.POSITION
+        );
+        const normalAttribute = getAttribute(
+          attributes,
+          VertexAttributeSemantic.NORMAL
+        );
+        const scalarAttribute = getAttributeByName(attributes, "_SCALAR_TEST");
+
+        const positionQuantization = positionAttribute.quantization;
+        expect(positionQuantization).toBeDefined();
+        expect(positionQuantization.quantizedVolumeOffset).toEqual(
+          new Cartesian3(-0.5, -0.5, -0.5)
+        );
+        expect(positionQuantization.quantizedVolumeStepSize).toEqual(
+          new Cartesian3(
+            0.000015259021896696422,
+            0.000015259021896696422,
+            0.000015259021896696422
+          )
+        );
+        expect(positionAttribute.min).toEqual(new Cartesian3(-0.5, -0.5, -0.5));
+        expect(positionAttribute.max).toEqual(new Cartesian3(0.5, 0.5, 0.5));
+
+        const normalQuantization = normalAttribute.quantization;
+        expect(normalQuantization).toBeDefined();
+        expect(normalQuantization.quantizedVolumeOffset).toEqual(
+          new Cartesian3(-1.0, -1.0, -1.0)
+        );
+        expect(normalQuantization.quantizedVolumeStepSize).toEqual(
+          new Cartesian3(
+            0.000030518043793392844,
+            0.000030518043793392844,
+            0.000030518043793392844
+          )
+        );
+
+        const scalarQuantization = scalarAttribute.quantization;
+        expect(scalarQuantization).toBeDefined();
+        expect(scalarQuantization.quantizedVolumeOffset).toBe(1);
+        expect(scalarQuantization.quantizedVolumeStepSize).toBe(0);
+        expect(scalarAttribute.min).toEqual(1);
+        expect(scalarAttribute.max).toEqual(1);
       });
     });
 


### PR DESCRIPTION
The [WEB3D_quantized_attributes](https://github.com/KhronosGroup/glTF/blob/main/extensions/1.0/Vendor/WEB3D_quantized_attributes/README.md) extension is used in some older glTF 1.0 models and was easy enough to support.

### Testing:

* [PhillyRealityModel sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=bVJhU+IwEP0rnX4qMxoojjgoOqeF88LQolyhwnTmpiQrpKQJJgGlN/73S0Fv9M58yM7uvrd5uxsihTbOlsEzKOfSEfDsBKDZpkCTfcxLXbL3AylMxgSo1D1yfqfCcQwoZSN3Sm4ZBXX+TiQKMgOJVJzGB4hXS8Vr7SIVqTi8hDQBAWjB5RwQhbVZxqDN9cJitXkjWTWPGdewp5G9TMM4aDA286nMWrGCGbYFjTJKvUrbhz4O5qQbH8jeXrvjbBT/qxhLMQItN4oAelSyuNYWiKnnt5pnb81WJyN2FDqWKxDnTurCrr+c3xI2ZH08LrEfMayxGJ2SALfwav0wCfptZEFP9HZlQbiMkvFLlPReItZoTPOwMYhHeRRjMy2m5Sxo+LOc+FFzxmc5X0XdazYI+uuZLRZ17zUuvpekOWmQHW4lZa8Z5pRW+enDPRvmPT/s9prDeHEa5ZM2Co5Pwiy5P5NjQrs3v/hTHibJj+0oVL27YnKsblbt0B+fRJjh1D1091qrbHV/2lMpZRFL723wtQv3yO1os+Nw9T6Ub6xYS2WqeXoI1Q0Ua27Xr+vzDVmBQUTrqmIF7dQ/UjuUbR1GL7/4YA7hmdY287jh/CcrIXWvOnWL/4/KZUaZWAy3oHi2q2BL/2pwCCKEOnXrfs00UvJ5pv6p/Ac)
* [Sample data sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=xVZdj+I2FP0rFk9hBU6A2Y8y7KhT0LQPpZ0OtJXa9MEkF7DGsSPbYZiu5r/32g4kO0tblQeKEIqv78c5xzfmZkoaS3YcnkCTj0TCE5mC4VVBf/G2KO1kfj1V0jIuQaedHvmUSkLMVlUiv5W8YBbGxOoKeql86V6nMpWZz2sykIBpQ37ql357XcnMciVJpgGj5yoHEVVadEPqEK0033CJ4TWiKdMWn5gc0bVWxQw2GsBELoCQ/mA4osn7q6t3g696wXR1RZO3yeh98q42DJIkoYl7diAPZQpXfM6s5vum1lIzadZKF4YCM/YHpe3253Kp7vge8jvNCqjrBpC9Q1IvjKNJS80LbvkODNVQqB3cChF1r0kckwe/JqWGHVeVCQhcpIAaDgL5IgvL87pmjdGr5qX4Vth19ClsEoI6jt1P72BoMRy3F40Dx1OsinskJxb8TzzNwfBDvfvSbXPz0UiI5c/3WJgbCF7UbkFGx2ONvF99mu4TpM5QN82ahgjrOrX7oDi/KVUQqxpRWuHYg1oJ4Vs16GOwgUAuSpbB1CebHn2uPw/GmIOBkCFNyJtmiXJsacH2ATZdqUrmXG4W5RY0UM1yXplejR4Fr4xF+SUw3W0XqevSWk1HZMaNZTJz74Amb0hC37bI1qRAWk/oZO2w+4rKFuVHl6ZbPX6rHtCMbRsNR9jm3VdBJbfZ9m9D+sPPQwJVodTjrY0aoQKcXmNoXRjfBVT3rs4DkxuIapy9ULvnJUDlu4fwQ72X2oL9gH6tLgKtlX7VRUoA4trUe8cM+PDSXDyqdAkM0v3dOdQJLOztmKSdb9SeTJVQmvxUMWmx4XO81er3WRoQkKFfA6ONoHVfpZ2tteU4joXKmNgqY8cfkmQY45FbnsUzMI9WlfETrEZ5jDX7vmb/WJNu8LVNO0cOHkH4PQH4slDPBLnA7OzSsoai50AOnTvn4nGpq+yxP+emcC3YvxyBf4dwPp3/j8UZ4GeXRTw7E+YD32wgX/CiFHBBuKfL/ofWUMUKp7czgVIah++ihMzEM2ZZ7PdMvBHLuz5e6u5N/NVBPYK7tThjrCoc2bzTPzmc5pHKP/y/5YLJPMMhDC9+nIGWSokV03OQVVRf8y6u0+tMjH0WcHOg8DWKhWObm4QihG4BtWMOzQqPHizNjDkUnMTt0EnOd4TnH0+MviQTzBjcWVfCT0pp52YSo/8XoUL5/74fd6AFe3Zu28HN98FIKZ3EuDwdaQPBV5n/Ag)
  * These are the `WEB3D_quantized_attributes` test models in CesiumJS 1.96.
  * Download link: [web3d.zip](https://github.com/CesiumGS/cesium/files/9483033/web3d.zip)
  * `CesiumMilkTruck-Mismatch-Quantized.gltf` fails because positions are `VEC4` which is beyond the scope of this PR
  * `RiggedSimple-Quantized.gltf` fails as well. I haven't looked into it but I suspect it's unrelated to the extension