### PR TITLE
Fix specs when log depth is false

### DIFF
--- a/Specs/Scene/Model/ModelSpec.js
+++ b/Specs/Scene/Model/ModelSpec.js
@@ -641,12 +641,19 @@ describe(
     });
 
     it("renders model with the KHR_materials_pbrSpecularGlossiness extension", function () {
+      // This model gets clipped if log depth is disabled, so zoom out
+      // the camera just a little
+      const offset = new HeadingPitchRange(0, -CesiumMath.PI_OVER_FOUR, 2);
+
       const resource = Resource.createIfNeeded(boomBoxUrl);
       return resource.fetchJson().then(function (gltf) {
         return loadAndZoomToModel(
           {
             gltf: gltf,
             basePath: boomBoxUrl,
+            // This model is tiny, so scale it up so it's visible.
+            scale: 10.0,
+            offset: offset,
           },
           scene
         ).then(function (model) {
@@ -656,12 +663,17 @@ describe(
     });
 
     it("renders model with morph targets", function () {
+      // This model gets clipped if log depth is disabled, so zoom out
+      // the camera just a little
+      const offset = new HeadingPitchRange(0, -CesiumMath.PI_OVER_FOUR, 2);
+
       const resource = Resource.createIfNeeded(morphPrimitivesTestUrl);
       return resource.fetchJson().then(function (gltf) {
         return loadAndZoomToModel(
           {
             gltf: gltf,
             basePath: morphPrimitivesTestUrl,
+            offset: offset,
           },
           scene
         ).then(function (model) {
@@ -2398,9 +2410,14 @@ describe(
       });
 
       it("renders with translucent color", function () {
+        // This model gets clipped if log depth is disabled, so zoom out
+        // the camera just a little
+        const offset = new HeadingPitchRange(0, -CesiumMath.PI_OVER_FOUR, 2);
+
         return loadAndZoomToModel(
           {
             gltf: boxTexturedGltfUrl,
+            offset: offset,
           },
           scene
         ).then(function (model) {
@@ -2425,10 +2442,15 @@ describe(
       });
 
       it("doesn't render invisible model", function () {
+        // This model gets clipped if log depth is disabled, so zoom out
+        // the camera just a little
+        const offset = new HeadingPitchRange(0, -CesiumMath.PI_OVER_FOUR, 2);
+
         return loadAndZoomToModel(
           {
             gltf: boxTexturedGltfUrl,
             color: Color.fromAlpha(Color.BLACK, 0.0),
+            offset: offset,
           },
           scene
         ).then(function (model) {
@@ -2469,10 +2491,15 @@ describe(
     }
 
     describe("colorBlendMode", function () {
+      // This model gets clipped if log depth is disabled, so zoom out
+      // the camera just a little
+      const offset = new HeadingPitchRange(0, -CesiumMath.PI_OVER_FOUR, 2);
+
       it("initializes with ColorBlendMode.HIGHLIGHT", function () {
         return loadAndZoomToModel(
           {
             gltf: boxTexturedGltfUrl,
+            offset: offset,
             color: Color.RED,
             colorBlendMode: ColorBlendMode.HIGHLIGHT,
           },
@@ -2494,6 +2521,7 @@ describe(
         return loadAndZoomToModel(
           {
             gltf: boxTexturedGltfUrl,
+            offset: offset,
             color: Color.RED,
             colorBlendMode: ColorBlendMode.REPLACE,
           },
@@ -2515,6 +2543,7 @@ describe(
         return loadAndZoomToModel(
           {
             gltf: boxTexturedGltfUrl,
+            offset: offset,
             color: Color.RED,
             colorBlendMode: ColorBlendMode.MIX,
           },
@@ -2536,6 +2565,7 @@ describe(
         return loadAndZoomToModel(
           {
             gltf: boxTexturedGltfUrl,
+            offset: offset,
             color: Color.RED,
             colorBlendMode: ColorBlendMode.REPLACE,
           },
@@ -2569,10 +2599,15 @@ describe(
     });
 
     describe("colorBlendAmount", function () {
+      // This model gets clipped if log depth is disabled, so zoom out
+      // the camera just a little
+      const offset = new HeadingPitchRange(0, -CesiumMath.PI_OVER_FOUR, 2);
+
       it("initializes with colorBlendAmount", function () {
         return loadAndZoomToModel(
           {
             gltf: boxTexturedGltfUrl,
+            offset: offset,
             color: Color.RED,
             colorBlendMode: ColorBlendMode.MIX,
             colorBlendAmount: 1.0,
@@ -2597,6 +2632,7 @@ describe(
         return loadAndZoomToModel(
           {
             gltf: boxTexturedGltfUrl,
+            offset: offset,
           },
           scene
         ).then(function (model) {
@@ -3076,6 +3112,7 @@ describe(
         return loadAndZoomToModel(
           {
             gltf: boomBoxUrl,
+            scale: 10.0,
             imageBasedLighting: new ImageBasedLighting({
               specularEnvironmentMaps: url,
             }),

--- a/Specs/Scene/PostProcessStageLibrarySpec.js
+++ b/Specs/Scene/PostProcessStageLibrarySpec.js
@@ -314,7 +314,11 @@ describe(
         },
         scene
       ).then(function () {
-        scene.camera.lookAt(origin, new HeadingPitchRange(0.0, 0.0, 1.0));
+        // The range is chosen carefully here. If it's too small and log depth
+        // is off, the model may clip out of view. If it is too large, the
+        // background will be visible in the 3x3 canvas and the color checks
+        // below will fail.
+        scene.camera.lookAt(origin, new HeadingPitchRange(0.0, 0.0, 1.5));
 
         // Render without depth of field
         let originalColor;
@@ -431,7 +435,11 @@ describe(
         },
         scene
       ).then(function () {
-        scene.camera.lookAt(origin, new HeadingPitchRange(0.0, 0.0, 1.0));
+        // The range is chosen carefully here. If it's too small and log depth
+        // is off, the model may clip out of view. If it is too large, the
+        // background will be visible in the 3x3 canvas and the color checks
+        // below will fail.
+        scene.camera.lookAt(origin, new HeadingPitchRange(0.0, 0.0, 1.5));
 
         // Render without bloom
         let originalColor;

--- a/Specs/Scene/PostProcessStageSpec.js
+++ b/Specs/Scene/PostProcessStageSpec.js
@@ -2,6 +2,8 @@ import {
   BoundingRectangle,
   Color,
   defined,
+  HeadingPitchRange,
+  Math as CesiumMath,
   PixelFormat,
   PixelDatatype,
   PostProcessStage,
@@ -233,9 +235,15 @@ describe(
     });
 
     it("per-feature post process stage", function () {
+      // This model gets clipped if log depth is disabled, so zoom out
+      // the camera just a little
+      const offset = new HeadingPitchRange(0, -CesiumMath.PI_OVER_FOUR, 2);
+
       return loadAndZoomToModel(
         {
           url: "./Data/Models/glTF-2.0/BoxTextured/glTF/BoxTextured.gltf",
+          offset: offset,
+          incrementallyLoadTextures: false,
         },
         scene
       ).then(function (model) {


### PR DESCRIPTION
In some internal code outside this repo, we turn off the logarithmic depth buffer. But when the specs are run in such an environment, some specs fail due to models clipped by the near plane.

The fix is usually to move the camera back just a little bit so the spec works whether the depth buffer is on or off.

@ggetz could you review?