### PR TITLE
fix `feature.setProperty()` to create a new property if it doesn't already exist

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 - Fixed a bug where instanced models without normals would not render. [#10765](https://github.com/CesiumGS/cesium/pull/10765)
 - Fixed a regression where instanced feature IDs were not processed correctly [#10771](https://github.com/CesiumGS/cesium/pull/10771)
+- Fixed a regression where `Cesium3DTileFeature.setProperty()` was not creating properties for unknown property IDs. [#10775](https://github.com/CesiumGS/cesium/pull/10775)
 
 ### 1.97 - 2022-09-01
 

--- a/Source/Scene/JsonMetadataTable.js
+++ b/Source/Scene/JsonMetadataTable.js
@@ -81,12 +81,12 @@ JsonMetadataTable.prototype.getProperty = function (index, propertyId) {
 };
 
 /**
- * Sets the value of the property with the given ID.
+ * Sets the value of the property with the given ID. If the property did not
+ * exist, it will be created.
  *
  * @param {Number} index The index of the entity.
  * @param {String} propertyId The case-sensitive ID of the property.
  * @param {*} value The value of the property that will be copied.
- * @returns {Boolean} <code>true</code> if the property was set, <code>false</code> otherwise.
  *
  * @exception {DeveloperError} index is out of bounds
  * @private
@@ -101,13 +101,14 @@ JsonMetadataTable.prototype.setProperty = function (index, propertyId, value) {
   }
   //>>includeEnd('debug');
 
-  const property = this._properties[propertyId];
-  if (defined(property)) {
-    property[index] = clone(value, true);
-    return true;
+  let property = this._properties[propertyId];
+  if (!defined(property)) {
+    // Property does not exist. Create it.
+    property = new Array(this._count);
+    this._properties[propertyId] = property;
   }
 
-  return false;
+  property[index] = clone(value, true);
 };
 
 export default JsonMetadataTable;

--- a/Specs/Scene/JsonMetadataTableSpec.js
+++ b/Specs/Scene/JsonMetadataTableSpec.js
@@ -136,15 +136,18 @@ describe("Scene/JsonMetadataTable", function () {
     }).toThrowDeveloperError();
   });
 
-  it("setProperty returns false if property doesn't exist", function () {
-    expect(table.setProperty(0, "color", [255, 255, 255, 1.0])).toBe(false);
+  it("setProperty creates a new property if it doesn't exist", function () {
+    expect(table.getProperty(0, "color")).not.toBeDefined();
+
+    table.setProperty(0, "color", [255, 255, 255, 1.0]);
+    expect(table.getProperty(0, "color")).toEqual([255, 255, 255, 1.0]);
   });
 
   it("setProperty sets property value", function () {
     const sizeInfo = {
       lengthBytes: 1024,
     };
-    expect(table.setProperty(0, "sizeInfo", sizeInfo)).toBe(true);
+    table.setProperty(0, "sizeInfo", sizeInfo);
     expect(table.getProperty(0, "sizeInfo")).toEqual(sizeInfo);
   });
 

--- a/Specs/Scene/Model/ModelFeatureSpec.js
+++ b/Specs/Scene/Model/ModelFeatureSpec.js
@@ -112,7 +112,7 @@ describe("Scene/Model/ModelFeature", function () {
 
   it("setProperty works", function () {
     expect(feature.getProperty("height")).toEqual(1.0);
-    expect(feature.setProperty("height", 3.0)).toEqual(true);
+    feature.setProperty("height", 3.0);
     expect(feature.getProperty("height")).toEqual(3.0);
   });
 });

--- a/Specs/Scene/Model/ModelFeatureTableSpec.js
+++ b/Specs/Scene/Model/ModelFeatureTableSpec.js
@@ -198,7 +198,7 @@ describe("Scene/Model/ModelFeatureTable", function () {
     });
     const feature = table._features[0];
     expect(feature.getProperty("height")).toEqual(1.0);
-    expect(feature.setProperty("height", 3.0)).toEqual(true);
+    feature.setProperty("height", 3.0);
     expect(feature.getProperty("height")).toEqual(3.0);
   });
 

--- a/Specs/Scene/PropertyTableSpec.js
+++ b/Specs/Scene/PropertyTableSpec.js
@@ -176,9 +176,15 @@ describe("Scene/PropertyTable", function () {
     expect(propertyTable.getProperty(0, "height")).toEqual(10.0);
   });
 
-  it("setProperty does not create property if it doesn't exist", function () {
+  it("setProperty creates properties if they don't exist", function () {
     const propertyTable = createPropertyTable();
-    expect(propertyTable.setProperty(0, "numberOfPoints", 10)).toBe(false);
+
+    // Since this property table didn't have any properties, it should create
+    // a new JsonMetadataTable before creating the new property
+    expect(propertyTable._jsonMetadataTable).not.toBeDefined();
+    propertyTable.setProperty(0, "numberOfPoints", 10);
+    expect(propertyTable._jsonMetadataTable).toBeDefined();
+    expect(propertyTable.getProperty(0, "numberOfPoints")).toBe(10);
   });
 
   it("setProperty sets property value", function () {
@@ -502,13 +508,13 @@ describe("Scene/PropertyTable", function () {
 
     it("setProperty uses structural metadata", function () {
       expect(batchTable.getProperty(0, "itemCount")).toBe(25);
-      expect(batchTable.setProperty(0, "itemCount", 24)).toBe(true);
+      batchTable.setProperty(0, "itemCount", 24);
       expect(batchTable.getProperty(0, "itemCount")).toBe(24);
     });
 
     it("setProperty uses JSON metadata", function () {
       expect(batchTable.getProperty(0, "uri")).toBe("tree.las");
-      expect(batchTable.setProperty(0, "uri", "tree_final.las")).toBe(true);
+      batchTable.setProperty(0, "uri", "tree_final.las");
       expect(batchTable.getProperty(0, "uri")).toBe("tree_final.las");
     });
 
@@ -519,8 +525,8 @@ describe("Scene/PropertyTable", function () {
       expect(batchTable.getProperty(2, "tireLocation")).not.toBeDefined();
       expect(batchTable.getProperty(2, "color")).toBe("blue");
 
-      expect(batchTable.setProperty(0, "tireLocation", "back")).toBe(true);
-      expect(batchTable.setProperty(2, "color", "navy")).toBe(true);
+      batchTable.setProperty(0, "tireLocation", "back");
+      batchTable.setProperty(2, "color", "navy");
 
       expect(batchTable.getProperty(0, "tireLocation")).toBe("back");
       expect(batchTable.getProperty(0, "color")).toBe("navy");
@@ -529,8 +535,10 @@ describe("Scene/PropertyTable", function () {
       expect(batchTable.getProperty(2, "color")).toBe("navy");
     });
 
-    it("setProperty returns false for unknown propertyId", function () {
-      expect(batchTable.setProperty(0, "widgets", 5)).toBe(false);
+    it("setProperty creates a new property for unknown propertyId", function () {
+      expect(batchTable.getProperty(0, "widgets")).not.toBeDefined();
+      batchTable.setProperty(0, "widgets", 5);
+      expect(batchTable.getProperty(0, "widgets")).toBe(5);
     });
 
     it("getPropertyTypedArray returns undefined for JSON and hierarchy properties", function () {


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/10773

This fixes the regression in `setProperty()` for unknown propertyId by:

* Updating `JsonMetadataTable` to create a property if it doesn't exist
* Updating `PropertyTable` to create a `JsonMetadataTable` if it doesn't exist, then using `this._jsonMetadataTable.setProperty()` to create the new property if it doesn't exist.

Other notes:

* I updated the precedence order to put the JSON properties after the batch table hierarchy for consistency. Interestingly, the old `Cesium3DTileBatchTable` is inconsistent between `getProperty` and `setProperty`.

[Sandcastle example](http://localhost:8080/Apps/Sandcastle/index.html#c=vVVdb9s2FP0rhJ7k1aW9dXuJnWDrx7ABaVo0Rp/0QlFXEheKFEjKmTvkv/eSFGUpdfs4wIlE3nPP/ToUuVbWkaOARzDkmih4JG/AiqGjn8NeXmQ8rN9o5ZhQYIpsTf4rFCG2ZZV+tFfEmQHWhXpa7QpVqMhFLQcFtJG6BFpB79oDWPdHgxTWHcAYfMF43jV48SmP97oCiaYQowXRtO6KbD1/AI7ZPSjNH/TgqDOMP+ST42rG5rSWJfNlVZoPHShHG3DvJPjX16e/KyxuxBSZd3zOzfpenl4LVQnV2HOMdWJeBBMSLLhlD+Pj1dtDNOahpsHIK1JklG7wd8+6XsJb5thmAd6MLtPLZgxA/7Fa4QymfsfwUrPKs2B8Zk+Kk9zjV+T6JjQygvC/w9J939FIx+VustfA3GDA3oJqXIuwEUGXBu9A8K/WhuQSaxYI3e7wsX9GsSMvXohVHOUyxowcZ/Jn3MzFKnAnEMV6Pxrdg3EnnBWrKuGEVkz6Ta/DIju0whL8sdD2fgTHcY4xNZYqdZMn0uaHpKvg+ZTkVqjUdwOsOiGmExY8N3UtqLweFPfusd+IS9WSxTnojegwzBEsxYATdreAftG6O+g87pGkqHVaz3T1F+aCmvwoHG8/MdXA5ETIlm7X59XLLf1ttkzFlHoIqr7vW8CWGKQbLPmJ/EK3CbyKLynH5Omftyg2X8e7I87vVlgcI34pvMXrLUkxKjD6PwU2yhkmPOsZfge0mTo2H1a0jL6XDn7gw1F+KC2YIyslzA9okcUvB84zAO1QWm5ECbPgETFFj0vU5d3QlVjOaB7LFzXJhb1jd2l/8iPEAOpKjcAnnyuZ5M6ZcboxrG8FR+70XZjt0ho15TfQxNTz6T+fFKrJ4Td4MZoYyQ6mZhyWQQLnqxDiE86YKTsFmGeGLVeNcEMF68tm5pbWbdLJMgdd1/Eb+D+kMA74QhZ4JSjr8VpdTAXF4G8NN+UR056Yx05eOnhnlvw756PzAnzPnBH/noPH9a+hCYdzdvks04XWs3W2t+4k4Sbl8Lvoem2cvzxyvDYc4LXBMJVNOfAHDMutTZnsN3PXfSWORFTXF+5xwiWzFi31IOW9+AJFdrPfIP4bV3+kUYMfjmAkO3lY+/PNbdyklO43uLzsOd2vC/tX) -- the property will now be created at runtime, so the console will log `This is a new property` several times, instead of `undefined` like it does on `main`.