### PR TITLE
Slack notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
 addons:
   chrome: stable
   firefox: latest
+notifications:
+  slack: cesium:$SLACK_TOKEN
 script:
   - npm --silent run deploy-set-version -- --buildVersion $TRAVIS_BRANCH.$TRAVIS_BUILD_NUMBER
   - npm --silent run deploy-status -- --status pending --message 'Waiting for build'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ notifications:
   slack:
     secure: JKzk2sJSbZ9h2PUVWj6KtOAdFbEEnOtv/VZy05pJ2H41xRgUHiGdtMW/vMSeq6XX3IJN8eW2zd0cJTgkFn0ioAlYvID8zRhcvkFHg60QXquoqtp5y65dxjtVz79hefxSo7FO1NhMZBQWE9Tg6R7XkoyTMth62+T9vqOgu2Hms6M=
     if: branch = main
-    on_success: never # default: change
-    on_failure: always # default: always
+    on_success: change # default: always
 script:
   - npm --silent run deploy-set-version -- --buildVersion $TRAVIS_BRANCH.$TRAVIS_BUILD_NUMBER
   - npm --silent run deploy-status -- --status pending --message 'Waiting for build'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ addons:
   chrome: stable
   firefox: latest
 notifications:
-  slack: cesium:$SLACK_TOKEN
+  slack:
+    secure: JKzk2sJSbZ9h2PUVWj6KtOAdFbEEnOtv/VZy05pJ2H41xRgUHiGdtMW/vMSeq6XX3IJN8eW2zd0cJTgkFn0ioAlYvID8zRhcvkFHg60QXquoqtp5y65dxjtVz79hefxSo7FO1NhMZBQWE9Tg6R7XkoyTMth62+T9vqOgu2Hms6M=
 script:
   - npm --silent run deploy-set-version -- --buildVersion $TRAVIS_BRANCH.$TRAVIS_BUILD_NUMBER
   - npm --silent run deploy-status -- --status pending --message 'Waiting for build'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ addons:
 notifications:
   slack:
     secure: JKzk2sJSbZ9h2PUVWj6KtOAdFbEEnOtv/VZy05pJ2H41xRgUHiGdtMW/vMSeq6XX3IJN8eW2zd0cJTgkFn0ioAlYvID8zRhcvkFHg60QXquoqtp5y65dxjtVz79hefxSo7FO1NhMZBQWE9Tg6R7XkoyTMth62+T9vqOgu2Hms6M=
+    if: branch = main
+    on_success: never # default: change
+    on_failure: always # default: always
 script:
   - npm --silent run deploy-set-version -- --buildVersion $TRAVIS_BRANCH.$TRAVIS_BUILD_NUMBER
   - npm --silent run deploy-status -- --status pending --message 'Waiting for build'


### PR DESCRIPTION
Our team spoke offline and determined it’s too easy for a CI failure in `main` to go unnoticed if the merged branch CI was passing before the merge. So we’ve added a [Travis Slack Notification](https://docs.travis-ci.com/user/notifications/)  to notify us here when it fails a build in `main`. We don’t expect it to be too noisy given `main` _should_ always be passing

This uses the default notification frequency, which is always notify on failure and notify on success when the value changes back.

Here's the result which I had sent to a testing channel:
<img width="1094" alt="image" src="https://user-images.githubusercontent.com/4439461/189712169-e63fcec2-3c12-44a4-a31f-eae84a9972a5.png">
