### PR TITLE
Use more concise syntax for PipelineStage constants

### DIFF
--- a/Source/Scene/Model/AlphaPipelineStage.js
+++ b/Source/Scene/Model/AlphaPipelineStage.js
@@ -11,8 +11,9 @@ import Pass from "../../Renderer/Pass.js";
  *
  * @private
  */
-const AlphaPipelineStage = {};
-AlphaPipelineStage.name = "AlphaPipelineStage"; // Helps with debugging
+const AlphaPipelineStage = {
+  name: "AlphaPipelineStage", // Helps with debugging
+};
 
 AlphaPipelineStage.process = function (renderResources, primitive, frameState) {
   const alphaOptions = renderResources.alphaOptions;

--- a/Source/Scene/Model/BatchTexturePipelineStage.js
+++ b/Source/Scene/Model/BatchTexturePipelineStage.js
@@ -7,8 +7,9 @@ import defaultValue from "../../Core/defaultValue.js";
  * @namespace BatchTexturePipelineStage
  * @private
  */
-const BatchTexturePipelineStage = {};
-BatchTexturePipelineStage.name = "BatchTexturePipelineStage"; // Helps with debugging
+const BatchTexturePipelineStage = {
+  name: "BatchTexturePipelineStage", // Helps with debugging
+};
 
 /**
  * Processes a primitive. This modifies the following parts of the render resources:

--- a/Source/Scene/Model/CPUStylingPipelineStage.js
+++ b/Source/Scene/Model/CPUStylingPipelineStage.js
@@ -14,8 +14,9 @@ import ShaderDestination from "../../Renderer/ShaderDestination.js";
  *
  * @private
  */
-const CPUStylingPipelineStage = {};
-CPUStylingPipelineStage.name = "CPUStylingPipelineStage"; // Helps with debugging
+const CPUStylingPipelineStage = {
+  name: "CPUStylingPipelineStage", // Helps with debugging
+};
 
 /**
  * Processes a primitive. This modifies the following parts of the render resources:

--- a/Source/Scene/Model/ClassificationPipelineStage.js
+++ b/Source/Scene/Model/ClassificationPipelineStage.js
@@ -12,8 +12,9 @@ import ModelUtility from "./ModelUtility.js";
  *
  * @private
  */
-const ClassificationPipelineStage = {};
-ClassificationPipelineStage.name = "ClassificationPipelineStage"; // Helps with debugging
+const ClassificationPipelineStage = {
+  name: "ClassificationPipelineStage", // Helps with debugging
+};
 
 /**
  * Process a primitive. This modifies the following parts of the render resources:

--- a/Source/Scene/Model/CustomShaderPipelineStage.js
+++ b/Source/Scene/Model/CustomShaderPipelineStage.js
@@ -22,24 +22,23 @@ import CustomShaderTranslucencyMode from "./CustomShaderTranslucencyMode.js";
  *
  * @private
  */
-const CustomShaderPipelineStage = {};
-CustomShaderPipelineStage.name = "CustomShaderPipelineStage"; // Helps with debugging
+const CustomShaderPipelineStage = {
+  name: "CustomShaderPipelineStage", // Helps with debugging
 
-CustomShaderPipelineStage.STRUCT_ID_ATTRIBUTES_VS = "AttributesVS";
-CustomShaderPipelineStage.STRUCT_ID_ATTRIBUTES_FS = "AttributesFS";
-CustomShaderPipelineStage.STRUCT_NAME_ATTRIBUTES = "Attributes";
-CustomShaderPipelineStage.STRUCT_ID_VERTEX_INPUT = "VertexInput";
-CustomShaderPipelineStage.STRUCT_NAME_VERTEX_INPUT = "VertexInput";
-CustomShaderPipelineStage.STRUCT_ID_FRAGMENT_INPUT = "FragmentInput";
-CustomShaderPipelineStage.STRUCT_NAME_FRAGMENT_INPUT = "FragmentInput";
-CustomShaderPipelineStage.FUNCTION_ID_INITIALIZE_INPUT_STRUCT_VS =
-  "initializeInputStructVS";
-CustomShaderPipelineStage.FUNCTION_SIGNATURE_INITIALIZE_INPUT_STRUCT_VS =
-  "void initializeInputStruct(out VertexInput vsInput, ProcessedAttributes attributes)";
-CustomShaderPipelineStage.FUNCTION_ID_INITIALIZE_INPUT_STRUCT_FS =
-  "initializeInputStructFS";
-CustomShaderPipelineStage.FUNCTION_SIGNATURE_INITIALIZE_INPUT_STRUCT_FS =
-  "void initializeInputStruct(out FragmentInput fsInput, ProcessedAttributes attributes)";
+  STRUCT_ID_ATTRIBUTES_VS: "AttributesVS",
+  STRUCT_ID_ATTRIBUTES_FS: "AttributesFS",
+  STRUCT_NAME_ATTRIBUTES: "Attributes",
+  STRUCT_ID_VERTEX_INPUT: "VertexInput",
+  STRUCT_NAME_VERTEX_INPUT: "VertexInput",
+  STRUCT_ID_FRAGMENT_INPUT: "FragmentInput",
+  STRUCT_NAME_FRAGMENT_INPUT: "FragmentInput",
+  FUNCTION_ID_INITIALIZE_INPUT_STRUCT_VS: "initializeInputStructVS",
+  FUNCTION_SIGNATURE_INITIALIZE_INPUT_STRUCT_VS:
+    "void initializeInputStruct(out VertexInput vsInput, ProcessedAttributes attributes)",
+  FUNCTION_ID_INITIALIZE_INPUT_STRUCT_FS: "initializeInputStructFS",
+  FUNCTION_SIGNATURE_INITIALIZE_INPUT_STRUCT_FS:
+    "void initializeInputStruct(out FragmentInput fsInput, ProcessedAttributes attributes)",
+};
 
 /**
  * Process a primitive. This modifies the following parts of the render

--- a/Source/Scene/Model/CustomShaderPipelineStage.js
+++ b/Source/Scene/Model/CustomShaderPipelineStage.js
@@ -38,6 +38,9 @@ const CustomShaderPipelineStage = {
   FUNCTION_ID_INITIALIZE_INPUT_STRUCT_FS: "initializeInputStructFS",
   FUNCTION_SIGNATURE_INITIALIZE_INPUT_STRUCT_FS:
     "void initializeInputStruct(out FragmentInput fsInput, ProcessedAttributes attributes)",
+
+  // Expose method for testing.
+  _oneTimeWarning: oneTimeWarning,
 };
 
 /**
@@ -635,8 +638,5 @@ function addLinesToShader(shaderBuilder, customShader, generatedCode) {
     shaderBuilder.addFragmentLines(shaderLines);
   }
 }
-
-// exposed for testing.
-CustomShaderPipelineStage._oneTimeWarning = oneTimeWarning;
 
 export default CustomShaderPipelineStage;

--- a/Source/Scene/Model/DequantizationPipelineStage.js
+++ b/Source/Scene/Model/DequantizationPipelineStage.js
@@ -12,13 +12,13 @@ import VertexAttributeSemantic from "../VertexAttributeSemantic.js";
  *
  * @private
  */
-const DequantizationPipelineStage = {};
-DequantizationPipelineStage.name = "DequantizationPipelineStage"; // Helps with debugging
+const DequantizationPipelineStage = {
+  name: "DequantizationPipelineStage", // Helps with debugging
 
-DequantizationPipelineStage.FUNCTION_ID_DEQUANTIZATION_STAGE_VS =
-  "dequantizationStage";
-DequantizationPipelineStage.FUNCTION_SIGNATURE_DEQUANTIZATION_STAGE_VS =
-  "void dequantizationStage(inout ProcessedAttributes attributes)";
+  FUNCTION_ID_DEQUANTIZATION_STAGE_VS: "dequantizationStage",
+  FUNCTION_SIGNATURE_DEQUANTIZATION_STAGE_VS:
+    "void dequantizationStage(inout ProcessedAttributes attributes)",
+};
 
 /**
  * Process a primitive with quantized attributes. This stage modifies the

--- a/Source/Scene/Model/FeatureIdPipelineStage.js
+++ b/Source/Scene/Model/FeatureIdPipelineStage.js
@@ -8,7 +8,7 @@ import FeatureIdStageFS from "../../Shaders/Model/FeatureIdStageFS.js";
 import FeatureIdStageVS from "../../Shaders/Model/FeatureIdStageVS.js";
 import ModelComponents from "../ModelComponents.js";
 import VertexAttributeSemantic from "../VertexAttributeSemantic.js";
-import ModelUtility from "./ModelUtility.js"; // Helps with debugging
+import ModelUtility from "./ModelUtility.js";
 
 /**
  * The feature ID pipeline stage is responsible for processing feature IDs

--- a/Source/Scene/Model/FeatureIdPipelineStage.js
+++ b/Source/Scene/Model/FeatureIdPipelineStage.js
@@ -8,7 +8,7 @@ import FeatureIdStageFS from "../../Shaders/Model/FeatureIdStageFS.js";
 import FeatureIdStageVS from "../../Shaders/Model/FeatureIdStageVS.js";
 import ModelComponents from "../ModelComponents.js";
 import VertexAttributeSemantic from "../VertexAttributeSemantic.js";
-import ModelUtility from "./ModelUtility.js";
+import ModelUtility from "./ModelUtility.js"; // Helps with debugging
 
 /**
  * The feature ID pipeline stage is responsible for processing feature IDs
@@ -18,28 +18,23 @@ import ModelUtility from "./ModelUtility.js";
  * @namespace FeatureIdPipelineStage
  * @private
  */
-const FeatureIdPipelineStage = {};
-FeatureIdPipelineStage.name = "FeatureIdPipelineStage"; // Helps with debugging
+const FeatureIdPipelineStage = {
+  name: "FeatureIdPipelineStage", // Helps with debugging
 
-FeatureIdPipelineStage.STRUCT_ID_FEATURE_IDS_VS = "FeatureIdsVS";
-FeatureIdPipelineStage.STRUCT_ID_FEATURE_IDS_FS = "FeatureIdsFS";
-FeatureIdPipelineStage.STRUCT_NAME_FEATURE_IDS = "FeatureIds";
-FeatureIdPipelineStage.FUNCTION_ID_INITIALIZE_FEATURE_IDS_VS =
-  "initializeFeatureIdsVS";
-FeatureIdPipelineStage.FUNCTION_ID_INITIALIZE_FEATURE_IDS_FS =
-  "initializeFeatureIdsFS";
-FeatureIdPipelineStage.FUNCTION_ID_INITIALIZE_FEATURE_ID_ALIASES_VS =
-  "initializeFeatureIdAliasesVS";
-FeatureIdPipelineStage.FUNCTION_ID_INITIALIZE_FEATURE_ID_ALIASES_FS =
-  "initializeFeatureIdAliasesFS";
-FeatureIdPipelineStage.FUNCTION_SIGNATURE_INITIALIZE_FEATURE_IDS =
-  "void initializeFeatureIds(out FeatureIds featureIds, ProcessedAttributes attributes)";
-FeatureIdPipelineStage.FUNCTION_SIGNATURE_INITIALIZE_FEATURE_ID_ALIASES =
-  "void initializeFeatureIdAliases(inout FeatureIds featureIds)";
-FeatureIdPipelineStage.FUNCTION_ID_SET_FEATURE_ID_VARYINGS =
-  "setFeatureIdVaryings";
-FeatureIdPipelineStage.FUNCTION_SIGNATURE_SET_FEATURE_ID_VARYINGS =
-  "void setFeatureIdVaryings()";
+  STRUCT_ID_FEATURE_IDS_VS: "FeatureIdsVS",
+  STRUCT_ID_FEATURE_IDS_FS: "FeatureIdsFS",
+  STRUCT_NAME_FEATURE_IDS: "FeatureIds",
+  FUNCTION_ID_INITIALIZE_FEATURE_IDS_VS: "initializeFeatureIdsVS",
+  FUNCTION_ID_INITIALIZE_FEATURE_IDS_FS: "initializeFeatureIdsFS",
+  FUNCTION_ID_INITIALIZE_FEATURE_ID_ALIASES_VS: "initializeFeatureIdAliasesVS",
+  FUNCTION_ID_INITIALIZE_FEATURE_ID_ALIASES_FS: "initializeFeatureIdAliasesFS",
+  FUNCTION_SIGNATURE_INITIALIZE_FEATURE_IDS:
+    "void initializeFeatureIds(out FeatureIds featureIds, ProcessedAttributes attributes)",
+  FUNCTION_SIGNATURE_INITIALIZE_FEATURE_ID_ALIASES:
+    "void initializeFeatureIdAliases(inout FeatureIds featureIds)",
+  FUNCTION_ID_SET_FEATURE_ID_VARYINGS: "setFeatureIdVaryings",
+  FUNCTION_SIGNATURE_SET_FEATURE_ID_VARYINGS: "void setFeatureIdVaryings()",
+};
 
 /**
  * Process a primitive. This modifies the following parts of the render resources:

--- a/Source/Scene/Model/GeometryPipelineStage.js
+++ b/Source/Scene/Model/GeometryPipelineStage.js
@@ -19,24 +19,20 @@ import VertexAttributeSemantic from "../VertexAttributeSemantic.js";
  *
  * @private
  */
-const GeometryPipelineStage = {};
-GeometryPipelineStage.name = "GeometryPipelineStage"; // Helps with debugging
+const GeometryPipelineStage = {
+  name: "GeometryPipelineStage", // Helps with debugging
 
-GeometryPipelineStage.STRUCT_ID_PROCESSED_ATTRIBUTES_VS =
-  "ProcessedAttributesVS";
-GeometryPipelineStage.STRUCT_ID_PROCESSED_ATTRIBUTES_FS =
-  "ProcessedAttributesFS";
-GeometryPipelineStage.STRUCT_NAME_PROCESSED_ATTRIBUTES = "ProcessedAttributes";
-GeometryPipelineStage.FUNCTION_ID_INITIALIZE_ATTRIBUTES =
-  "initializeAttributes";
-GeometryPipelineStage.FUNCTION_SIGNATURE_INITIALIZE_ATTRIBUTES =
-  "void initializeAttributes(out ProcessedAttributes attributes)";
-GeometryPipelineStage.FUNCTION_ID_SET_DYNAMIC_VARYINGS_VS =
-  "setDynamicVaryingsVS";
-GeometryPipelineStage.FUNCTION_ID_SET_DYNAMIC_VARYINGS_FS =
-  "setDynamicVaryingsFS";
-GeometryPipelineStage.FUNCTION_SIGNATURE_SET_DYNAMIC_VARYINGS =
-  "void setDynamicVaryings(inout ProcessedAttributes attributes)";
+  STRUCT_ID_PROCESSED_ATTRIBUTES_VS: "ProcessedAttributesVS",
+  STRUCT_ID_PROCESSED_ATTRIBUTES_FS: "ProcessedAttributesFS",
+  STRUCT_NAME_PROCESSED_ATTRIBUTES: "ProcessedAttributes",
+  FUNCTION_ID_INITIALIZE_ATTRIBUTES: "initializeAttributes",
+  FUNCTION_SIGNATURE_INITIALIZE_ATTRIBUTES:
+    "void initializeAttributes(out ProcessedAttributes attributes)",
+  FUNCTION_ID_SET_DYNAMIC_VARYINGS_VS: "setDynamicVaryingsVS",
+  FUNCTION_ID_SET_DYNAMIC_VARYINGS_FS: "setDynamicVaryingsFS",
+  FUNCTION_SIGNATURE_SET_DYNAMIC_VARYINGS:
+    "void setDynamicVaryings(inout ProcessedAttributes attributes)",
+};
 
 /**
  * This pipeline stage processes the vertex attributes of a primitive,

--- a/Source/Scene/Model/ImageBasedLightingPipelineStage.js
+++ b/Source/Scene/Model/ImageBasedLightingPipelineStage.js
@@ -4,8 +4,9 @@ import ImageBasedLightingStageFS from "../../Shaders/Model/ImageBasedLightingSta
 import ShaderDestination from "../../Renderer/ShaderDestination.js";
 import OctahedralProjectedCubeMap from "../OctahedralProjectedCubeMap.js";
 
-const ImageBasedLightingPipelineStage = {};
-ImageBasedLightingPipelineStage.name = "ImageBasedLightingPipelineStage"; // Helps with debugging
+const ImageBasedLightingPipelineStage = {
+  name: "ImageBasedLightingPipelineStage", // Helps with debugging
+};
 
 ImageBasedLightingPipelineStage.process = function (
   renderResources,

--- a/Source/Scene/Model/InstancingPipelineStage.js
+++ b/Source/Scene/Model/InstancingPipelineStage.js
@@ -30,8 +30,9 @@ const modelView2DScratch = new Matrix4();
  * @namespace InstancingPipelineStage
  * @private
  */
-const InstancingPipelineStage = {};
-InstancingPipelineStage.name = "InstancingPipelineStage"; // Helps with debugging
+const InstancingPipelineStage = {
+  name: "InstancingPipelineStage", // Helps with debugging
+};
 
 /**
  * Process a node. This modifies the following parts of the render resources:

--- a/Source/Scene/Model/InstancingPipelineStage.js
+++ b/Source/Scene/Model/InstancingPipelineStage.js
@@ -32,6 +32,10 @@ const modelView2DScratch = new Matrix4();
  */
 const InstancingPipelineStage = {
   name: "InstancingPipelineStage", // Helps with debugging
+
+  // Expose some methods for testing
+  _getInstanceTransformsAsMatrices: getInstanceTransformsAsMatrices,
+  _transformsToTypedArray: transformsToTypedArray,
 };
 
 /**
@@ -1035,9 +1039,5 @@ function processFeatureIdAttributes(
     );
   }
 }
-
-// Exposed for testing
-InstancingPipelineStage._getInstanceTransformsAsMatrices = getInstanceTransformsAsMatrices;
-InstancingPipelineStage._transformsToTypedArray = transformsToTypedArray;
 
 export default InstancingPipelineStage;

--- a/Source/Scene/Model/LightingPipelineStage.js
+++ b/Source/Scene/Model/LightingPipelineStage.js
@@ -12,8 +12,9 @@ import LightingModel from "./LightingModel.js";
  *
  * @private
  */
-const LightingPipelineStage = {};
-LightingPipelineStage.name = "LightingPipelineStage"; // Helps with debugging
+const LightingPipelineStage = {
+  name: "LightingPipelineStage", // Helps with debugging
+};
 
 /**
  * Process a primitive. This modifies the following parts of the render

--- a/Source/Scene/Model/MaterialPipelineStage.js
+++ b/Source/Scene/Model/MaterialPipelineStage.js
@@ -29,8 +29,9 @@ const SpecularGlossiness = ModelComponents.SpecularGlossiness;
  *
  * @private
  */
-const MaterialPipelineStage = {};
-MaterialPipelineStage.name = "MaterialPipelineStage"; // Helps with debugging
+const MaterialPipelineStage = {
+  name: "MaterialPipelineStage", // Helps with debugging
+};
 
 /**
  * Process a primitive. This modifies the following parts of the render

--- a/Source/Scene/Model/MaterialPipelineStage.js
+++ b/Source/Scene/Model/MaterialPipelineStage.js
@@ -31,6 +31,10 @@ const SpecularGlossiness = ModelComponents.SpecularGlossiness;
  */
 const MaterialPipelineStage = {
   name: "MaterialPipelineStage", // Helps with debugging
+
+  // Expose some methods for testing
+  _processTexture: processTexture,
+  _processTextureTransform: processTextureTransform,
 };
 
 /**
@@ -502,9 +506,5 @@ function processMetallicRoughnessUniforms(
     );
   }
 }
-
-// Exposed for testing
-MaterialPipelineStage._processTexture = processTexture;
-MaterialPipelineStage._processTextureTransform = processTextureTransform;
 
 export default MaterialPipelineStage;

--- a/Source/Scene/Model/ModelClippingPlanesPipelineStage.js
+++ b/Source/Scene/Model/ModelClippingPlanesPipelineStage.js
@@ -12,8 +12,9 @@ import ShaderDestination from "../../Renderer/ShaderDestination.js";
  *
  * @private
  */
-const ModelClippingPlanesPipelineStage = {};
-ModelClippingPlanesPipelineStage.name = "ModelClippingPlanesPipelineStage"; // Helps with debugging
+const ModelClippingPlanesPipelineStage = {
+  name: "ModelClippingPlanesPipelineStage", // Helps with debugging
+};
 
 const textureResolutionScratch = new Cartesian2();
 /**

--- a/Source/Scene/Model/ModelColorPipelineStage.js
+++ b/Source/Scene/Model/ModelColorPipelineStage.js
@@ -11,11 +11,12 @@ import ShaderDestination from "../../Renderer/ShaderDestination.js";
  *
  * @private
  */
-const ModelColorPipelineStage = {};
-ModelColorPipelineStage.name = "ModelColorPipelineStage"; // Helps with debugging
+const ModelColorPipelineStage = {
+  name: "ModelColorPipelineStage", // Helps with debugging
 
-ModelColorPipelineStage.COLOR_UNIFORM_NAME = "model_color";
-ModelColorPipelineStage.COLOR_BLEND_UNIFORM_NAME = "model_colorBlend";
+  COLOR_UNIFORM_NAME: "model_color",
+  COLOR_BLEND_UNIFORM_NAME: "model_colorBlend",
+};
 
 /**
  * Process a model. This modifies the following parts of the render resources:

--- a/Source/Scene/Model/ModelSilhouettePipelineStage.js
+++ b/Source/Scene/Model/ModelSilhouettePipelineStage.js
@@ -11,8 +11,9 @@ import ModelSilhouetteStageVS from "../../Shaders/Model/ModelSilhouetteStageVS.j
  *
  * @private
  */
-const ModelSilhouettePipelineStage = {};
-ModelSilhouettePipelineStage.name = "ModelSilhouettePipelineStage"; // Helps with debugging
+const ModelSilhouettePipelineStage = {
+  name: "ModelSilhouettePipelineStage", // Helps with debugging
+};
 
 /**
  * Tracks how many silhouettes have been created. This value is used to

--- a/Source/Scene/Model/ModelSplitterPipelineStage.js
+++ b/Source/Scene/Model/ModelSplitterPipelineStage.js
@@ -9,11 +9,11 @@ import ShaderDestination from "../../Renderer/ShaderDestination.js";
  *
  * @private
  */
-const ModelSplitterPipelineStage = {};
-ModelSplitterPipelineStage.name = "ModelSplitterPipelineStage"; // Helps with debugging
+const ModelSplitterPipelineStage = {
+  name: "ModelSplitterPipelineStage", // Helps with debugging
 
-ModelSplitterPipelineStage.SPLIT_DIRECTION_UNIFORM_NAME =
-  "model_splitDirection";
+  SPLIT_DIRECTION_UNIFORM_NAME: "model_splitDirection",
+};
 
 /**
  * Process a model. This modifies the following parts of the render resources:

--- a/Source/Scene/Model/MorphTargetsPipelineStage.js
+++ b/Source/Scene/Model/MorphTargetsPipelineStage.js
@@ -12,18 +12,19 @@ import VertexAttributeSemantic from "../VertexAttributeSemantic.js";
  *
  * @private
  */
-const MorphTargetsPipelineStage = {};
-MorphTargetsPipelineStage.name = "MorphTargetsPipelineStage"; // Helps with debugging
-MorphTargetsPipelineStage.FUNCTION_ID_GET_MORPHED_POSITION =
-  "getMorphedPosition";
-MorphTargetsPipelineStage.FUNCTION_SIGNATURE_GET_MORPHED_POSITION =
-  "vec3 getMorphedPosition(in vec3 position)";
-MorphTargetsPipelineStage.FUNCTION_ID_GET_MORPHED_NORMAL = "getMorphedNormal";
-MorphTargetsPipelineStage.FUNCTION_SIGNATURE_GET_MORPHED_NORMAL =
-  "vec3 getMorphedNormal(in vec3 normal)";
-MorphTargetsPipelineStage.FUNCTION_ID_GET_MORPHED_TANGENT = "getMorphedTangent";
-MorphTargetsPipelineStage.FUNCTION_SIGNATURE_GET_MORPHED_TANGENT =
-  "vec3 getMorphedTangent(in vec3 tangent)";
+const MorphTargetsPipelineStage = {
+  name: "MorphTargetsPipelineStage", // Helps with debugging
+
+  FUNCTION_ID_GET_MORPHED_POSITION: "getMorphedPosition",
+  FUNCTION_SIGNATURE_GET_MORPHED_POSITION:
+    "vec3 getMorphedPosition(in vec3 position)",
+  FUNCTION_ID_GET_MORPHED_NORMAL: "getMorphedNormal",
+  FUNCTION_SIGNATURE_GET_MORPHED_NORMAL:
+    "vec3 getMorphedNormal(in vec3 normal)",
+  FUNCTION_ID_GET_MORPHED_TANGENT: "getMorphedTangent",
+  FUNCTION_SIGNATURE_GET_MORPHED_TANGENT:
+    "vec3 getMorphedTangent(in vec3 tangent)",
+};
 
 /**
  * This pipeline stage processes the morph targets and weights of a primitive,

--- a/Source/Scene/Model/NodeStatisticsPipelineStage.js
+++ b/Source/Scene/Model/NodeStatisticsPipelineStage.js
@@ -12,8 +12,13 @@ import defined from "../../Core/defined.js";
  *
  * @private
  */
-const NodeStatisticsPipelineStage = {};
-NodeStatisticsPipelineStage.name = "NodeStatisticsPipelineStage"; // Helps with debugging
+const NodeStatisticsPipelineStage = {
+  name: "NodeStatisticsPipelineStage", // Helps with debugging
+
+  // Expose some methods for testing
+  _countInstancingAttributes: countInstancingAttributes,
+  _countGeneratedBuffers: countGeneratedBuffers,
+};
 
 NodeStatisticsPipelineStage.process = function (
   renderResources,
@@ -66,9 +71,5 @@ function countGeneratedBuffers(statistics, runtimeNode) {
     statistics.addBuffer(runtimeNode.instancingTranslationBuffer2D, hasCpuCopy);
   }
 }
-
-// Exposed for testing
-NodeStatisticsPipelineStage._countInstancingAttributes = countInstancingAttributes;
-NodeStatisticsPipelineStage._countGeneratedBuffers = countGeneratedBuffers;
 
 export default NodeStatisticsPipelineStage;

--- a/Source/Scene/Model/PickingPipelineStage.js
+++ b/Source/Scene/Model/PickingPipelineStage.js
@@ -14,8 +14,9 @@ import ModelUtility from "./ModelUtility.js";
  * @namespace PickingPipelineStage
  * @private
  */
-const PickingPipelineStage = {};
-PickingPipelineStage.name = "PickingPipelineStage"; // Helps with debugging
+const PickingPipelineStage = {
+  name: "PickingPipelineStage", // Helps with debugging
+};
 
 /**
  * Process a primitive. This modifies the following parts of the render resources:

--- a/Source/Scene/Model/PointCloudStylingPipelineStage.js
+++ b/Source/Scene/Model/PointCloudStylingPipelineStage.js
@@ -29,8 +29,9 @@ const scratchUniform = new Cartesian4();
  *
  * @private
  */
-const PointCloudStylingPipelineStage = {};
-PointCloudStylingPipelineStage.name = "PointCloudStylingPipelineStage"; // Helps with debugging
+const PointCloudStylingPipelineStage = {
+  name: "PointCloudStylingPipelineStage", // Helps with debugging
+};
 
 /**
  * Processes a primitive. If the model that owns it has a style, then

--- a/Source/Scene/Model/PrimitiveOutlinePipelineStage.js
+++ b/Source/Scene/Model/PrimitiveOutlinePipelineStage.js
@@ -12,8 +12,9 @@ import PrimitiveOutlineStageFS from "../../Shaders/Model/PrimitiveOutlineStageFS
  *
  * @private
  */
-const PrimitiveOutlinePipelineStage = {};
-PrimitiveOutlinePipelineStage.name = "PrimitiveOutlinePipelineStage";
+const PrimitiveOutlinePipelineStage = {
+  name: "PrimitiveOutlinePipelineStage", // Helps with debugging
+};
 
 /**
  * Process a primitive. This modifies the following parts of the render

--- a/Source/Scene/Model/PrimitiveStatisticsPipelineStage.js
+++ b/Source/Scene/Model/PrimitiveStatisticsPipelineStage.js
@@ -15,8 +15,9 @@ import ModelUtility from "./ModelUtility.js";
  *
  * @private
  */
-const PrimitiveStatisticsPipelineStage = {};
-PrimitiveStatisticsPipelineStage.name = "PrimitiveStatisticsPipelineStage"; // Helps with debugging
+const PrimitiveStatisticsPipelineStage = {
+  name: "PrimitiveStatisticsPipelineStage", // Helps with debugging
+};
 
 PrimitiveStatisticsPipelineStage.process = function (
   renderResources,

--- a/Source/Scene/Model/PrimitiveStatisticsPipelineStage.js
+++ b/Source/Scene/Model/PrimitiveStatisticsPipelineStage.js
@@ -17,6 +17,14 @@ import ModelUtility from "./ModelUtility.js";
  */
 const PrimitiveStatisticsPipelineStage = {
   name: "PrimitiveStatisticsPipelineStage", // Helps with debugging
+
+  // Expose some methods for testing
+  _countGeometry: countGeometry,
+  _count2DPositions: count2DPositions,
+  _countMorphTargetAttributes: countMorphTargetAttributes,
+  _countMaterialTextures: countMaterialTextures,
+  _countFeatureIdTextures: countFeatureIdTextures,
+  _countBinaryMetadata: countBinaryMetadata,
 };
 
 PrimitiveStatisticsPipelineStage.process = function (
@@ -241,13 +249,5 @@ function countPropertyTextures(statistics, structuralMetadata) {
     }
   }
 }
-
-// Exposed for testing
-PrimitiveStatisticsPipelineStage._countGeometry = countGeometry;
-PrimitiveStatisticsPipelineStage._count2DPositions = count2DPositions;
-PrimitiveStatisticsPipelineStage._countMorphTargetAttributes = countMorphTargetAttributes;
-PrimitiveStatisticsPipelineStage._countMaterialTextures = countMaterialTextures;
-PrimitiveStatisticsPipelineStage._countFeatureIdTextures = countFeatureIdTextures;
-PrimitiveStatisticsPipelineStage._countBinaryMetadata = countBinaryMetadata;
 
 export default PrimitiveStatisticsPipelineStage;

--- a/Source/Scene/Model/SceneMode2DPipelineStage.js
+++ b/Source/Scene/Model/SceneMode2DPipelineStage.js
@@ -22,8 +22,9 @@ const scratchModelView2D = new Matrix4();
  *
  * @private
  */
-const SceneMode2DPipelineStage = {};
-SceneMode2DPipelineStage.name = "SceneMode2DPipelineStage"; // Helps with debugging
+const SceneMode2DPipelineStage = {
+  name: "SceneMode2DPipelineStage", // Helps with debugging
+};
 
 /**
  * This pipeline stage processes the position attribute of a primitive and adds the relevant

--- a/Source/Scene/Model/SelectedFeatureIdPipelineStage.js
+++ b/Source/Scene/Model/SelectedFeatureIdPipelineStage.js
@@ -12,17 +12,16 @@ import ModelUtility from "./ModelUtility.js";
  * @namespace SelectedFeatureIdPipelineStage
  * @private
  */
-const SelectedFeatureIdPipelineStage = {};
-SelectedFeatureIdPipelineStage.name = "SelectedFeatureIdPipelineStage"; // Helps with debugging
+const SelectedFeatureIdPipelineStage = {
+  name: "SelectedFeatureIdPipelineStage", // Helps with debugging
 
-SelectedFeatureIdPipelineStage.STRUCT_ID_SELECTED_FEATURE = "SelectedFeature";
-SelectedFeatureIdPipelineStage.STRUCT_NAME_SELECTED_FEATURE = "SelectedFeature";
-SelectedFeatureIdPipelineStage.FUNCTION_ID_FEATURE_VARYINGS_VS =
-  "updateFeatureStructVS";
-SelectedFeatureIdPipelineStage.FUNCTION_ID_FEATURE_VARYINGS_FS =
-  "updateFeatureStructFS";
-SelectedFeatureIdPipelineStage.FUNCTION_SIGNATURE_UPDATE_FEATURE =
-  "void updateFeatureStruct(inout SelectedFeature feature)";
+  STRUCT_ID_SELECTED_FEATURE: "SelectedFeature",
+  STRUCT_NAME_SELECTED_FEATURE: "SelectedFeature",
+  FUNCTION_ID_FEATURE_VARYINGS_VS: "updateFeatureStructVS",
+  FUNCTION_ID_FEATURE_VARYINGS_FS: "updateFeatureStructFS",
+  FUNCTION_SIGNATURE_UPDATE_FEATURE:
+    "void updateFeatureStruct(inout SelectedFeature feature)",
+};
 
 /**
  * Process a primitive. This modifies the following parts of the render resources:

--- a/Source/Scene/Model/SkinningPipelineStage.js
+++ b/Source/Scene/Model/SkinningPipelineStage.js
@@ -11,12 +11,12 @@ import VertexAttributeSemantic from "../VertexAttributeSemantic.js";
  * @private
  */
 
-const SkinningPipelineStage = {};
-SkinningPipelineStage.name = "SkinningPipelineStage"; // Helps with debugging
+const SkinningPipelineStage = {
+  name: "SkinningPipelineStage", // Helps with debugging
 
-SkinningPipelineStage.FUNCTION_ID_GET_SKINNING_MATRIX = "getSkinningMatrix";
-SkinningPipelineStage.FUNCTION_SIGNATURE_GET_SKINNING_MATRIX =
-  "mat4 getSkinningMatrix()";
+  FUNCTION_ID_GET_SKINNING_MATRIX: "getSkinningMatrix",
+  FUNCTION_SIGNATURE_GET_SKINNING_MATRIX: "mat4 getSkinningMatrix()",
+};
 
 /**
  * This pipeline stage processes the joint matrices of a skinned primitive, adding

--- a/Source/Scene/Model/TilesetPipelineStage.js
+++ b/Source/Scene/Model/TilesetPipelineStage.js
@@ -11,8 +11,9 @@ import StencilConstants from "../StencilConstants.js";
  *
  * @private
  */
-const TilesetPipelineStage = {};
-TilesetPipelineStage.name = "TilesetPipelineStage"; // Helps with debugging
+const TilesetPipelineStage = {
+  name: "TilesetPipelineStage", // Helps with debugging
+};
 
 /**
  * Process a model. This modifies the following parts of the render resources:

--- a/Source/Scene/Model/WireframePipelineStage.js
+++ b/Source/Scene/Model/WireframePipelineStage.js
@@ -15,8 +15,9 @@ import WireframeIndexGenerator from "../../Core/WireframeIndexGenerator.js";
  * @namespace WireframePipelineStage
  * @private
  */
-const WireframePipelineStage = {};
-WireframePipelineStage.name = "WireframePipelineStage"; // Helps with debugging
+const WireframePipelineStage = {
+  name: "WireframePipelineStage", // Helps with debugging
+};
 
 /**
  * Process a primitive. This modifies the render resources as follows:


### PR DESCRIPTION
As suggested by @ptrgags in https://github.com/CesiumGS/cesium/pull/10683#discussion_r968563051, this PR updates the declaration of PipelineStage constants to use a more concise syntax. 

The new syntax is consistent with what we already have in MetadataPipelineStage.