### PR TITLE
Add early return when viewRefreshMode==onRegion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 - Fixed a bug where instanced models without normals would not render. [#10765](https://github.com/CesiumGS/cesium/pull/10765)
 - Fixed a regression where instanced feature IDs were not processed correctly [#10771](https://github.com/CesiumGS/cesium/pull/10771)
 - Fixed a regression where `Cesium3DTileFeature.setProperty()` was not creating properties for unknown property IDs. [#10775](https://github.com/CesiumGS/cesium/pull/10775)
+- Fixed a bug where KMLs with a NetworkLink with viewRefreshMode=='onRegion' would cause Cesium to make numerous resource requests and possibly trigger an out of  memory error. [#10790](https://github.com/CesiumGS/cesium/pull/10790)
 
 ### 1.97 - 2022-09-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@
 - Fixed a bug where instanced models without normals would not render. [#10765](https://github.com/CesiumGS/cesium/pull/10765)
 - Fixed a regression where instanced feature IDs were not processed correctly [#10771](https://github.com/CesiumGS/cesium/pull/10771)
 - Fixed a regression where `Cesium3DTileFeature.setProperty()` was not creating properties for unknown property IDs. [#10775](https://github.com/CesiumGS/cesium/pull/10775)
-- Fixed a bug where KMLs with a NetworkLink with viewRefreshMode=='onRegion' would cause Cesium to make numerous resource requests and possibly trigger an out of  memory error. [#10790](https://github.com/CesiumGS/cesium/pull/10790)
+- Fixed a bug where KMLs with a NetworkLink with viewRefreshMode=='onRegion' would cause Cesium to make numerous resource requests and possibly trigger an out of memory error. [#10790](https://github.com/CesiumGS/cesium/pull/10790)
 
 ### 1.97 - 2022-09-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -180,6 +180,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
   - [Erik Dahlström](https://github.com/erikdahlstrom)
 - [Novatron Oy](https://novatron.fi/en/)
   - [Jussi Hirvonen](https://github.com/VsKatshuma)
+- [Sierra Nevada Corp](https://www.sncorp.com/)
+  - [Robert Irving](https://github.com/robert-irving-snc)
 
 ## [Individual CLA](Documentation/Contributors/CLAs/individual-contributor-license-agreement-v1.0.pdf)
 

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -3091,6 +3091,13 @@ function processNetworkLink(dataSource, node, processingData, deferredLoading) {
           "viewRefreshMode",
           namespaces.kml
         );
+        if (viewRefreshMode === "onRegion") {
+          oneTimeWarning(
+            "kml-refrehMode-onRegion",
+            "KML - Unsupported viewRefreshMode: onRegion"
+          );
+          return;
+        }
         viewBoundScale = defaultValue(
           queryStringValue(link, "viewBoundScale", namespaces.kml),
           1.0
@@ -3255,11 +3262,6 @@ function processNetworkLink(dataSource, node, processingData, deferredLoading) {
             if (defined(networkLinkInfo.refreshMode)) {
               dataSource._networkLinks.set(networkLinkInfo.id, networkLinkInfo);
             }
-          } else if (viewRefreshMode === "onRegion") {
-            oneTimeWarning(
-              "kml-refrehMode-onRegion",
-              "KML - Unsupported viewRefreshMode: onRegion"
-            );
           }
         })
         .catch(function (error) {

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -5474,7 +5474,7 @@ describe("DataSources/KmlDataSource", function () {
       parser.parseFromString(kml, "text/xml"),
       options
     ).then(function (dataSource) {
-      expect(dataSource.entities.values.length).toEqual(2);
+      expect(dataSource.entities.values.length).toEqual(1);
       expect(console.warn.calls.count()).toEqual(1);
       expect(console.warn).toHaveBeenCalledWith(
         "KML - Unsupported viewRefreshMode: onRegion"


### PR DESCRIPTION
Processing a network link with onRegion refresh mode may cause Cesium to attempt numerous resource requests, instead of only the resources in the current view.

Resolves https://github.com/CesiumGS/cesium/issues/10774