### PR TITLE
Exclude slack notification from PR builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
 notifications:
   slack:
     secure: JKzk2sJSbZ9h2PUVWj6KtOAdFbEEnOtv/VZy05pJ2H41xRgUHiGdtMW/vMSeq6XX3IJN8eW2zd0cJTgkFn0ioAlYvID8zRhcvkFHg60QXquoqtp5y65dxjtVz79hefxSo7FO1NhMZBQWE9Tg6R7XkoyTMth62+T9vqOgu2Hms6M=
-    if: branch = main
+    if: (branch = main) AND (type = push)
     on_success: change # default: always
 script:
   - npm --silent run deploy-set-version -- --buildVersion $TRAVIS_BRANCH.$TRAVIS_BUILD_NUMBER


### PR DESCRIPTION
Right now, we use the branch name to determine if a message should be sent on failure. [Based on the docs](https://docs.travis-ci.com/user/conditions-v1#integration) `branch` will be the base when the type of build is a PR. So this limits the build type to `push`, excluding PR builds from triggering the notifications.