### PR TITLE
Cleanup make-zip command in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
 
   - npm --silent run coverage -- --browsers FirefoxHeadless --webgl-stub --failTaskOnError --suppressPassed
 
-  - travis_wait 20 npm --silent run make-zip -- --concurrency 1
+  - npm --silent run make-zip
   - npm pack &> /dev/null
 
   - npm --silent run build-apps

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,7 +2,6 @@
 import { writeFileSync, copyFileSync, readFileSync, existsSync } from "fs";
 import { readFile, writeFile } from "fs/promises";
 import { join, basename, relative, extname, resolve } from "path";
-import { cpus } from "os";
 import { exec, execSync } from "child_process";
 import { createHash } from "crypto";
 import { gzipSync } from "zlib";
@@ -62,10 +61,6 @@ const noDevelopmentGallery = taskName === "release" || taskName === "makeZip";
 const argv = yargs(process.argv).argv;
 const verbose = argv.verbose;
 
-let concurrency = argv.concurrency;
-if (!concurrency) {
-  concurrency = cpus().length;
-}
 const sourceFiles = [
   "Source/**/*.js",
   "!Source/*.js",


### PR DESCRIPTION
Removes out of date configuration from the `make-zip` step in `.travis.yml`. The `configuration` option does not appear to be used by any of our current tooling. Additionally, since `make-zip` takes far less than 10 minutes, and also log output, there is not reason to use [`travis_wait`](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received). Furthermore, `travis_wait` may actually be doing more harm then good and interferring with the process, (for example [the error `/home/travis/build.sh: line 162:  3283 Terminated              travis_jigger $! $timeout $cmd` was appearing when the task terminated](https://github.com/travis-ci/travis-ci/issues/7431)).

