### PR TITLE
Fix redeploy cleanup step

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -906,7 +906,7 @@ export async function deploySetVersion() {
   const buildVersion = argv.buildVersion;
   if (buildVersion) {
     // NPM versions can only contain alphanumeric and hyphen characters
-    version += `-${buildVersion.replace(/[^[0-9A-Za-z-]/g, "")}`;
+    packageJson.version += `-${buildVersion.replace(/[^[0-9A-Za-z-]/g, "")}`;
     return writeFile("package.json", JSON.stringify(packageJson, undefined, 2));
   }
 }


### PR DESCRIPTION
While flattening the promise chains in https://github.com/CesiumGS/cesium/pull/10772, I misunderstood a comment and altered the flow of the deploy process, leaving some files in `existingBlobs` which caused those file to be listed for deletion later in the process.

You can verify that this is now working in travis on subsequent CI runs. For instance [I re-ran the initial build](https://app.travis-ci.com/github/CesiumGS/cesium/builds/255607952), and you can see that there are no additional files which should be cleaned, and therefore the clean step is skipped.