### PR TITLE
Cesium3DTileset and Model warnings for debugWireframe and enableDebugWireframe misuse

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -333,3 +333,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Jiang Heng](https://github.com/jiangheng90)
 - [Xin Chen](https://github.com/nshen)
 - [Ilya Shevelev](https://github.com/ilyaly)
+- [Gabriel Aldous](https://github.com/Sn00pyW00dst0ck)

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -834,7 +834,7 @@ function Cesium3DTileset(options) {
   if (this.debugWireframe === true && this._enableDebugWireframe === false) {
     oneTimeWarning(
       "3DTileset debug wireframe not set properly.",
-      "Warning: enableDebugWireframe needs to be set true for debugWireframe to have any effect!"
+      "Warning: Cesium3DTileset's enableDebugWireframe needs to be true for debugWireframe to have any effect!"
     );
   }
 

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -41,6 +41,7 @@ import hasExtension from "./hasExtension.js";
 import ImplicitTileset from "./ImplicitTileset.js";
 import ImplicitTileCoordinates from "./ImplicitTileCoordinates.js";
 import LabelCollection from "./LabelCollection.js";
+import oneTimeWarning from "../Core/oneTimeWarning.js";
 import PointCloudEyeDomeLighting from "./PointCloudEyeDomeLighting.js";
 import PointCloudShading from "./PointCloudShading.js";
 import ResourceCache from "./ResourceCache.js";
@@ -828,6 +829,14 @@ function Cesium3DTileset(options) {
    * @default false
    */
   this.debugWireframe = defaultValue(options.debugWireframe, false);
+
+  //Warning for improper setup of debug wireframe
+  if (this.debugWireframe === true && this._enableDebugWireframe === false) {
+    oneTimeWarning(
+      "3DTileset debug wireframe not set properly.",
+      "Warning: enableDebugWireframe needs to be set true for debugWireframe to have any effect!"
+    );
+  }
 
   /**
    * This property is for debugging only; it is not optimized for production use.

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -830,11 +830,11 @@ function Cesium3DTileset(options) {
    */
   this.debugWireframe = defaultValue(options.debugWireframe, false);
 
-  //Warning for improper setup of debug wireframe
+  // Warning for improper setup of debug wireframe
   if (this.debugWireframe === true && this._enableDebugWireframe === false) {
     oneTimeWarning(
-      "3DTileset debug wireframe not set properly.",
-      "Warning: Cesium3DTileset's enableDebugWireframe needs to be true for debugWireframe to have any effect!"
+      "tileset-debug-wireframe-ignored",
+      "enableDebugWireframe must be set to true in the Cesium3DTileset constructor, otherwise debugWireframe will be ignored."
     );
   }
 

--- a/Source/Scene/Model/Model.js
+++ b/Source/Scene/Model/Model.js
@@ -1184,7 +1184,7 @@ Object.defineProperties(Model.prototype, {
       ) {
         oneTimeWarning(
           "Model debug wireframe not set properly.",
-          "Warning: enableDebugWireframe needs to be set true for debugWireframe to have any effect!"
+          "Warning: Model's enableDebugWireframe needs to be true for debugWireframe to have any effect!"
         );
       }
     },

--- a/Source/Scene/Model/Model.js
+++ b/Source/Scene/Model/Model.js
@@ -1176,6 +1176,17 @@ Object.defineProperties(Model.prototype, {
         this.resetDrawCommands();
       }
       this._debugWireframe = value;
+
+      //Warning for improper setup of debug wireframe
+      if (
+        this._debugWireframe === true &&
+        this._enableDebugWireframe === false
+      ) {
+        oneTimeWarning(
+          "Model debug wireframe not set properly.",
+          "Warning: enableDebugWireframe needs to be set true for debugWireframe to have any effect!"
+        );
+      }
     },
   },
 

--- a/Source/Scene/Model/Model.js
+++ b/Source/Scene/Model/Model.js
@@ -360,7 +360,7 @@ function Model(options) {
   if (this._debugWireframe === true && this._enableDebugWireframe === false) {
     oneTimeWarning(
       "Model debug wireframe not set properly.",
-      "Warning: enableDebugWireframe needs to be set true for debugWireframe to have any effect!"
+      "Warning: Model's enableDebugWireframe needs to be set true for debugWireframe to have any effect!"
     );
   }
 

--- a/Source/Scene/Model/Model.js
+++ b/Source/Scene/Model/Model.js
@@ -33,6 +33,7 @@ import ModelSceneGraph from "./ModelSceneGraph.js";
 import ModelStatistics from "./ModelStatistics.js";
 import ModelType from "./ModelType.js";
 import ModelUtility from "./ModelUtility.js";
+import oneTimeWarning from "../../Core/oneTimeWarning.js";
 import PntsLoader from "./PntsLoader.js";
 import StyleCommandsNeeded from "./StyleCommandsNeeded.js";
 
@@ -354,6 +355,14 @@ function Model(options) {
   );
   this._enableShowOutline = defaultValue(options.enableShowOutline, true);
   this._debugWireframe = defaultValue(options.debugWireframe, false);
+
+  //Warning for improper setup of debug wireframe
+  if (this._debugWireframe === true && this._enableDebugWireframe === false) {
+    oneTimeWarning(
+      "Model debug wireframe not set properly.",
+      "Warning: enableDebugWireframe needs to be set true for debugWireframe to have any effect!"
+    );
+  }
 
   // Credit specified by the user.
   let credit = options.credit;

--- a/Source/Scene/Model/Model.js
+++ b/Source/Scene/Model/Model.js
@@ -356,11 +356,15 @@ function Model(options) {
   this._enableShowOutline = defaultValue(options.enableShowOutline, true);
   this._debugWireframe = defaultValue(options.debugWireframe, false);
 
-  //Warning for improper setup of debug wireframe
-  if (this._debugWireframe === true && this._enableDebugWireframe === false) {
+  // Warning for improper setup of debug wireframe
+  if (
+    this._debugWireframe === true &&
+    this._enableDebugWireframe === false &&
+    this.type === Model.GLTF
+  ) {
     oneTimeWarning(
-      "Model debug wireframe not set properly.",
-      "Warning: Model's enableDebugWireframe needs to be set true for debugWireframe to have any effect!"
+      "model-debug-wireframe-ignored",
+      "enableDebugWireframe must be set to true in Model.Gltf, otherwise debugWireframe will be ignored."
     );
   }
 
@@ -1177,14 +1181,15 @@ Object.defineProperties(Model.prototype, {
       }
       this._debugWireframe = value;
 
-      //Warning for improper setup of debug wireframe
+      // Warning for improper setup of debug wireframe
       if (
         this._debugWireframe === true &&
-        this._enableDebugWireframe === false
+        this._enableDebugWireframe === false &&
+        this.type === ModelType.GLTF
       ) {
         oneTimeWarning(
-          "Model debug wireframe not set properly.",
-          "Warning: Model's enableDebugWireframe needs to be true for debugWireframe to have any effect!"
+          "model-debug-wireframe-ignored",
+          "enableDebugWireframe must be set to true in Model.Gltf, otherwise debugWireframe will be ignored."
         );
       }
     },

--- a/Source/Scene/Model/Model.js
+++ b/Source/Scene/Model/Model.js
@@ -360,11 +360,11 @@ function Model(options) {
   if (
     this._debugWireframe === true &&
     this._enableDebugWireframe === false &&
-    this.type === Model.GLTF
+    this.type === ModelType.GLTF
   ) {
     oneTimeWarning(
       "model-debug-wireframe-ignored",
-      "enableDebugWireframe must be set to true in Model.Gltf, otherwise debugWireframe will be ignored."
+      "enableDebugWireframe must be set to true in Model.fromGltf, otherwise debugWireframe will be ignored."
     );
   }
 
@@ -1189,7 +1189,7 @@ Object.defineProperties(Model.prototype, {
       ) {
         oneTimeWarning(
           "model-debug-wireframe-ignored",
-          "enableDebugWireframe must be set to true in Model.Gltf, otherwise debugWireframe will be ignored."
+          "enableDebugWireframe must be set to true in Model.fromGltf, otherwise debugWireframe will be ignored."
         );
       }
     },

--- a/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspector.css
+++ b/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspector.css
@@ -68,6 +68,12 @@ ul.cesium-cesiumInspector-statistics + ul.cesium-cesiumInspector-statistics {
   font-size: 11px;
 }
 
+.cesium-3DTilesInspector-disabledElementsInfo  {
+  margin: 5px 0 0 0; 
+  padding: 0 0 0 20px;
+  color: #eed202;
+}
+
 .cesium-3DTilesInspector div,
 .cesium-3DTilesInspector input[type="range"] {
   width: 100%;

--- a/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspector.css
+++ b/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspector.css
@@ -68,8 +68,8 @@ ul.cesium-cesiumInspector-statistics + ul.cesium-cesiumInspector-statistics {
   font-size: 11px;
 }
 
-.cesium-3DTilesInspector-disabledElementsInfo  {
-  margin: 5px 0 0 0; 
+.cesium-3DTilesInspector-disabledElementsInfo {
+  margin: 5px 0 0 0;
   padding: 0 0 0 20px;
   color: #eed202;
 }

--- a/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspector.js
+++ b/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspector.js
@@ -117,7 +117,17 @@ function Cesium3DTilesInspector(container, scene) {
   tilesetPanelContents.appendChild(createCheckbox("Enable Picking", "picking"));
 
   displayPanelContents.appendChild(createCheckbox("Colorize", "colorize"));
-  displayPanelContents.appendChild(createCheckbox("Wireframe", "wireframe"));
+  displayPanelContents.appendChild(
+    createCheckbox("Wireframe", "wireframe", "enableDebugWireframe")
+  );
+  //Allow the checkbox made above to be disabled when enableDebugWireframe is false
+  //Look into data binding method for this as it could be simpler? Knockout JS track and defineProperty
+  //if (this.)  {
+  //  displayPanelContents.lastChild.childNodes[0].childNodes[0].enabled = false;
+  //  const infoText = displayPanelContents.appendChild(document.createElement('p'));
+  //  infoText.innerText = "enableDebugWireframe should be true for the wireframe checkbox to be active!"
+  //}
+
   displayPanelContents.appendChild(
     createCheckbox("Bounding Volumes", "showBoundingVolumes")
   );

--- a/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspector.js
+++ b/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspector.js
@@ -118,7 +118,7 @@ function Cesium3DTilesInspector(container, scene) {
 
   displayPanelContents.appendChild(createCheckbox("Colorize", "colorize"));
   displayPanelContents.appendChild(
-    createCheckbox("Wireframe", "wireframe", "enableDebugWireframe")
+    createCheckbox("Wireframe", "wireframe", "hasEnabledWireframe")
   );
   //Allow the checkbox made above to be disabled when enableDebugWireframe is false
   //Look into data binding method for this as it could be simpler? Knockout JS track and defineProperty

--- a/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspector.js
+++ b/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspector.js
@@ -120,13 +120,13 @@ function Cesium3DTilesInspector(container, scene) {
   displayPanelContents.appendChild(
     createCheckbox("Wireframe", "wireframe", "hasEnabledWireframe")
   );
-  //Allow the checkbox made above to be disabled when enableDebugWireframe is false
-  //Look into data binding method for this as it could be simpler? Knockout JS track and defineProperty
-  //if (this.)  {
-  //  displayPanelContents.lastChild.childNodes[0].childNodes[0].enabled = false;
-  //  const infoText = displayPanelContents.appendChild(document.createElement('p'));
-  //  infoText.innerText = "enableDebugWireframe should be true for the wireframe checkbox to be active!"
-  //}
+
+  //Create warning text when the Wireframe checkbox is disabled
+  const warningText = document.createElement("p");
+  warningText.setAttribute("data-bind", `visible: !hasEnabledWireframe`);
+  warningText.setAttribute("style", "margin: 5px 0 0 0; padding: 0 0 0 20px");
+  warningText.innerText = "enableDebugWireframe must be true for this to work!";
+  displayPanelContents.lastChild.appendChild(warningText);
 
   displayPanelContents.appendChild(
     createCheckbox("Bounding Volumes", "showBoundingVolumes")

--- a/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspector.js
+++ b/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspector.js
@@ -118,14 +118,25 @@ function Cesium3DTilesInspector(container, scene) {
 
   displayPanelContents.appendChild(createCheckbox("Colorize", "colorize"));
   displayPanelContents.appendChild(
-    createCheckbox("Wireframe", "wireframe", "hasEnabledWireframe")
+    createCheckbox(
+      "Wireframe",
+      "wireframe",
+      "_tileset === undefined || hasEnabledWireframe"
+    )
   );
 
   //Create warning text when the Wireframe checkbox is disabled
   const warningText = document.createElement("p");
-  warningText.setAttribute("data-bind", `visible: !hasEnabledWireframe`);
-  warningText.setAttribute("style", "margin: 5px 0 0 0; padding: 0 0 0 20px");
-  warningText.innerText = "enableDebugWireframe must be true for this to work!";
+  warningText.setAttribute(
+    "data-bind",
+    "visible: _tileset !== undefined && !hasEnabledWireframe"
+  );
+  warningText.setAttribute(
+    "class",
+    "cesium-3DTilesInspector-disabledElementsInfo"
+  );
+  warningText.innerText =
+    "Set enableDebugWireframe to true in the tileset constructor to enable this option.";
   displayPanelContents.lastChild.appendChild(warningText);
 
   displayPanelContents.appendChild(

--- a/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
+++ b/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
@@ -293,7 +293,7 @@ function Cesium3DTilesInspectorViewModel(scene, performanceContainer) {
   this.styleString = "{}";
 
   /**
-   * Gets or sets the JSON for the tileset style.  This property is observable.
+   * Gets or sets the JSON for the tileset enableDebugWireframe attribute.  This property is observable.
    *
    * @type {Boolean}
    * @default false

--- a/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
+++ b/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
@@ -292,6 +292,14 @@ function Cesium3DTilesInspectorViewModel(scene, performanceContainer) {
    */
   this.styleString = "{}";
 
+  /**
+   * Gets or sets the JSON for the tileset style.  This property is observable.
+   *
+   * @type {Boolean}
+   * @default false
+   */
+  this.hasEnabledWireframe = false;
+
   this._tileset = undefined;
   this._feature = undefined;
   this._tile = undefined;
@@ -316,6 +324,7 @@ function Cesium3DTilesInspectorViewModel(scene, performanceContainer) {
     "styleString",
     "_feature",
     "_tile",
+    "hasEnabledWireframe",
   ]);
 
   this._properties = knockout.observable({});
@@ -1254,6 +1263,7 @@ Object.defineProperties(Cesium3DTilesInspectorViewModel.prototype, {
         this.immediatelyLoadDesiredLevelOfDetail =
           tileset.immediatelyLoadDesiredLevelOfDetail;
         this.loadSiblings = tileset.loadSiblings;
+        this.hasEnabledWireframe = tileset._enableDebugWireframe;
 
         const pointCloudShading = tileset.pointCloudShading;
         this.pointCloudShading = pointCloudShading.attenuation;

--- a/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
+++ b/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
@@ -324,6 +324,7 @@ function Cesium3DTilesInspectorViewModel(scene, performanceContainer) {
     "styleString",
     "_feature",
     "_tile",
+    "_tileset",
     "hasEnabledWireframe",
   ]);
 


### PR DESCRIPTION
## Changes
Implemented changes to constructor functions and property setters for `Model` and `Cesium3DTileset` to provide the user with warnings and information about possible misuse of the `enableDebugWireframe` and `debugWireframe` flags. 

Implemented changes to the `Cesium3DTilesInspector ` to disable the wireframes checkbox when `enableDebugWireframe` is set to false and add text explaining why the box has been disabled. This change added a knockout property to the `Cesium3DTilesInspectorViewModel`, called `hasEnabledWireframe`, which determines whether `enableDebugWireframe` is set to true or false and determines if the checkbox should be enabled or not. 

## Test Steps
Tested all changes extensively within the sandbox environments and found all implemented warnings & UI changes work as expected. These changes also passed all tests that the repository was able to pass when I cloned it. 

## Issue Link
Issue: [#10608](https://github.com/CesiumGS/cesium/issues/10608)