### PR TITLE
Fixes camera not tracking trackedEntity with HeightReference

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 - Fixed a regression where `Cesium3DTileFeature.setProperty()` was not creating properties for unknown property IDs. [#10775](https://github.com/CesiumGS/cesium/pull/10775)
 - Fixed a regression where `pnts` tiles with `3DTILES_draco_point_compression` and <= 8 quantization bits were being rendered incorrectly. [#10794](https://github.com/CesiumGS/cesium/pull/10794)
 - Fixed a bug where KMLs with a NetworkLink with viewRefreshMode=='onRegion' would cause Cesium to make numerous resource requests and possibly trigger an out of memory error. [#10790](https://github.com/CesiumGS/cesium/pull/10790)
+- Fixed a bug where camera would not follow the `Viewer.trackedEntity` if it had a model with a `HeightReference` other than `NONE`. [#10805](https://github.com/CesiumGS/cesium/pull/10805)
 
 ### 1.97 - 2022-09-01
 

--- a/Source/DataSources/ModelVisualizer.js
+++ b/Source/DataSources/ModelVisualizer.js
@@ -474,6 +474,8 @@ ModelVisualizer.prototype.getBoundingSphere = function (entity, result) {
     }
 
     BoundingSphere.clone(clampedBoundingSphere, result);
+    // Reset the clamped bounding sphere.
+    this._modelHash[entity.id].clampedBoundingSphere = undefined;
     return BoundingSphereState.DONE;
   }
 

--- a/Specs/DataSources/ModelVisualizerSpec.js
+++ b/Specs/DataSources/ModelVisualizerSpec.js
@@ -435,6 +435,11 @@ describe(
         .then(() => {
           expect(state).toBe(BoundingSphereState.DONE);
 
+          // Ensure that flags and results computed for this model are reset.
+          const modelData = visualizer._modelHash[testObject.id];
+          expect(modelData.awaitingSampleTerrain).toBe(false);
+          expect(modelData.clampedBoundingSphere).toBeUndefined();
+
           // Ensure that we only sample the terrain once from the visualizer.
           // We check for 2 calls here because we call it once in the test.
           expect(sampleTerrainSpy).toHaveBeenCalledTimes(2);
@@ -561,6 +566,11 @@ describe(
         })
         .then(() => {
           expect(state).toBe(BoundingSphereState.DONE);
+
+          // Ensure that flags and results computed for this model are reset.
+          const modelData = visualizer._modelHash[testObject.id];
+          expect(modelData.awaitingSampleTerrain).toBe(false);
+          expect(modelData.clampedBoundingSphere).toBeUndefined();
 
           // Ensure that we only sample the terrain once from the visualizer.
           // We check for 2 calls here because we call it once in the test.
@@ -705,6 +715,11 @@ describe(
         return state !== BoundingSphereState.PENDING;
       }).then(() => {
         expect(state).toBe(BoundingSphereState.FAILED);
+
+        // Ensure that flags and results computed for this model are reset.
+        const modelData = visualizer._modelHash[testObject.id];
+        expect(modelData.sampleTerrainFailed).toBe(false);
+
         // Ensure that we only sample the terrain once from the visualizer.
         expect(sampleTerrainSpy).toHaveBeenCalledTimes(1);
         // Reset the terrain provider.


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/10804

The cause of this issue was that when a `TerrainProvider` with `availability` was used, the `ModelVisualizer.prototype.getBoundingSphere` was returning the result from its previous invocation. The fix was to simply clear the previous result in the `_modelHash` object for a given entity.

See this [Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=zVh9Txs3GP8qFn9d1uslgdKVANUyYC1TIBFJi6alQs6dk1j12SfbR6AV332PX+6NBAHtuhWhnHN+3vx7Xp1YcKXRNSUrItEh4mSFjoiieRp9tO+C6VZsvx8JrjHlRE63QvR1yhGifC5+Fzc9NMdMkRC128dU4Rkj6NTtoBVNFkQbWkUYiTUV/JQnNMZayA1sJRGI9lSWdylylvQ5TbEmPaRlbrnQCbdc2G4AlzLEmkgJZo6kuKYJAS3+NLEkwH0pJEsmjiRohVN+19qf8ilvt70wRhdLTfkCzbAiCQJT9BIMyznKhKJGy5Q7sCIVE06iBRMzEhHLPSiYD62RTckJyfQSzFOWQgkQDAuFZgSeiVXjbUcJ4JFlBMtoozIraQKC+gugVtqfp6l1TLSVKTFPRIp4ns7AwYrAoeZCohjgokoTrpEkKmdagS4P1RnWy0gRfWFZzy3nGBiDnVZN+EzkPFFIzJHIQTBNc2a9gDRNyZTHNq6UxlKDYV7ynzmjmB+DI6K5FKlZBCbi7GK7090N0Tb8w6P7umWUFVJEtlEITpIxAZpEBTZQjLbQrHZed+yzFs4VW9Ca8uIkZ/izca8kRQpQhbBDLgE+CXCZ81SOiJmIP0dW0wQ2wCy7Nu85SN5fIxRZSSeyh8jiXErwxVMk2k9wzYJUkByV76LBcDi6Gk+Go31IkYEA4PxxCE/uSQKPaZoxahO/26kHDtjBINeRFnXPOpeXUgqq6IsQ6UQEDn57zgLedxC1EiBHuAjEmMoY5EmUYQ3xzqFGQFpcY3lr0mJJTAqZWJzn3JWCWKRZrskR8DHD+IdN0QDACRHYFYLghOaq5WqSC5hMioxIfdssaGOcZowkI5/II09kIUY2KwIGh6fA1dmHx8GhiSOzenGIXu16DYUOoxZzVTnBpo0WF+59QJ3Yglw71z4aw+avimPzR8vVg9FsNpvqimpVixGQCSvMd1zukYUkpNIJeKIXHkv0C+pGu/BpjxQLFfjDtkpTAPk6uSsZUFPXCOvgcHLTKCpBC1h3Ox2Q1P11t9M8R+FDC5D1XGAwDMujuRgzpO12n0FBdSUeQi0TFOqacSjB8RIpy41WBC18OEaOz8cxJB4IJMpoCr4WhhdqeuUqrLZAfg+VpPCG3hA2pl+gPb0Jq9exYKJqQUfmWzS56J+PR/2Lk/NJjVLk2qTS0QaGv04Gg+HlOu0lTfSyh3bKnTu/unMQ3pkPSXQOSVaACRt3LjOPXFr50gAA3FYxU0JfFOBaND2Qji+73e2o2+283tsJIWuizt7eqzevuiHqRJ2ybfRjnWPGbgtPVboLRd6Sw4ddU3U2T4uvMWV4Rpn5ooXr1xiSDXxE5DVmCCv3stmibAzUmXv1/DKV+NQLADf4uST42yH8AGEVPDaDe/cS2RTGnv0sHWUXn8zDne2DIradepSTEnk722wMScfYz7UwU1Ds8PXOFZICSr54FwNN6cxUXJMU9i0SNdIGEB8J9ApAZ1jtl4WzzMTSjIHAbpRx3ChjGLpIKhLCjG8kyWDaMENH3fXIEZQJlUvaQ9Otdj/LVNulPhQ63LZUqu1E96n0qytYwmQ0g7nU8acUJsI8HVU5+fqVTYjSzPFSrKwJ0ISWJj6gZlD+Gdme58pFAvGDujAwmdIMawhZg5WyYBm20lw4kWC5A65bmADhLSlmDShHgt0aDe+YWJ15ghLLMnRgxluNxMqMrp2oWwZP/FhluCtq7srVha6bgO7qQ24/SdAs19qkgLA5VqFgmoKbQmFmSMQKGMZQq2OsNLNd6pjMMUwMEyHYDMvfrRi4HZhrApoAz7HhgbtB2bkD3zGLcUHi+DNJTooUh1mCzAGOZL9G5EeJjfU5XEu+9wTaDV+MqI6XdvwJOuED7fjlXqdlO6XB4nmAKLhI3AdjIwpjQ/h/I7Cp8TZhCB8h6e5WJNCWi778CHj2cI3CrBDVtsioJ6EHaRxLPNfPQdCpum8UNgVwJmBevbFTgL9Xwnxp5wHbGDLhe4GpKtEDBp4RnltAfd0vk1TDJGNq1GldVA8NwJkw2kLhkuLG30rLsgQ1ljtLeuvnc3/uOFFRV80lrKFhmNleENRYUPM4bqyrCtEGkj5bQLHXy7SsJs7shtU19rtiIqtNGOET8cALaW8qpvRxkULB+xnA2X0KOHWSMlWKA1Xn+QGovScypfpnA237ORHlj/AdMH2yn9OthiKTj9Ot4vb+bSn73l4x0QWZE7hyx3Cy8+H5yTdgaseRyN1YS2nVfet9cyMyWp4eEutWHg36Z6OryfDq3cXww/nxjzf4nsLvsf3iZNCfnH48+S/NX9f5UKR9XzwVv77VfnG8nDzneEVra/5wWR1s0y+XT3fGunknjNFMCZr8K0bWZpFS8KRJtcncBvBb4ZZ5eaD0LSNvC9rfaJoJqeE6wIIoamsCYzkAodqzHGYAHcVKFYIP2nXWg4ReI5ocbvjlGsUMKwU785zZu8F06+1BG+jXWJmwg9XwmkiGbw3Zsvt24F5GUXTQhq+bObULHGApTlLtbahmTSm19T8) - test with different `HeightReference` types and with/without `CesiumTerrainProvider`.