### PR TITLE
Filter unused runtime nodes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 - Fixed a regression where instanced feature IDs were not processed correctly [#10771](https://github.com/CesiumGS/cesium/pull/10771)
 - Fixed a regression where `Cesium3DTileFeature.setProperty()` was not creating properties for unknown property IDs. [#10775](https://github.com/CesiumGS/cesium/pull/10775)
 - Fixed a regression where `pnts` tiles with `3DTILES_draco_point_compression` and <= 8 quantization bits were being rendered incorrectly. [#10794](https://github.com/CesiumGS/cesium/pull/10794)
+- Fixed a regression where glTF models with unused nodes would crash [#10813](https://github.com/CesiumGS/cesium/pull/10813)
 - Fixed a bug where KMLs with a NetworkLink with viewRefreshMode=='onRegion' would cause Cesium to make numerous resource requests and possibly trigger an out of memory error. [#10790](https://github.com/CesiumGS/cesium/pull/10790)
 - Fixed a bug where camera would not follow the `Viewer.trackedEntity` if it had a model with a `HeightReference` other than `NONE`. [#10805](https://github.com/CesiumGS/cesium/pull/10805)
 

--- a/Source/Scene/Model/ModelSceneGraph.js
+++ b/Source/Scene/Model/ModelSceneGraph.js
@@ -483,6 +483,13 @@ ModelSceneGraph.prototype.buildDrawCommands = function (frameState) {
 
   for (i = 0; i < this._runtimeNodes.length; i++) {
     const runtimeNode = this._runtimeNodes[i];
+
+    // If a node in the model was unreachable from the scenegraph, there will
+    // be no corresponding runtime node and therefore should be skipped.
+    if (!defined(runtimeNode)) {
+      continue;
+    }
+
     runtimeNode.configurePipeline();
     const nodePipelineStages = runtimeNode.pipelineStages;
 
@@ -637,6 +644,12 @@ ModelSceneGraph.prototype.update = function (frameState, updateForAnimations) {
 
   for (i = 0; i < this._runtimeNodes.length; i++) {
     const runtimeNode = this._runtimeNodes[i];
+
+    // If a node in the model was unreachable from the scenegraph, there will
+    // be no corresponding runtime node and therefore should be skipped.
+    if (!defined(runtimeNode)) {
+      continue;
+    }
 
     for (j = 0; j < runtimeNode.updateStages.length; j++) {
       const nodeUpdateStage = runtimeNode.updateStages[j];

--- a/Source/Scene/Model/ModelSceneGraph.js
+++ b/Source/Scene/Model/ModelSceneGraph.js
@@ -255,8 +255,9 @@ function initialize(sceneGraph) {
   const nodesLength = nodes.length;
 
   // Initialize this array to be the same size as the nodes array in
-  // the model's file. This is so nodes can be stored by their index
-  // in the file, for future ease of access.
+  // the model file. This is so the node indices remain the same. However,
+  // only nodes reachable from the scene's root node will be populated, the
+  // rest will be undefined
   sceneGraph._runtimeNodes = new Array(nodesLength);
 
   const rootNodes = scene.nodes;
@@ -484,7 +485,7 @@ ModelSceneGraph.prototype.buildDrawCommands = function (frameState) {
   for (i = 0; i < this._runtimeNodes.length; i++) {
     const runtimeNode = this._runtimeNodes[i];
 
-    // If a node in the model was unreachable from the scenegraph, there will
+    // If a node in the model was unreachable from the scene graph, there will
     // be no corresponding runtime node and therefore should be skipped.
     if (!defined(runtimeNode)) {
       continue;
@@ -645,7 +646,7 @@ ModelSceneGraph.prototype.update = function (frameState, updateForAnimations) {
   for (i = 0; i < this._runtimeNodes.length; i++) {
     const runtimeNode = this._runtimeNodes[i];
 
-    // If a node in the model was unreachable from the scenegraph, there will
+    // If a node in the model was unreachable from the scene graph, there will
     // be no corresponding runtime node and therefore should be skipped.
     if (!defined(runtimeNode)) {
       continue;


### PR DESCRIPTION
This PR fixes a corner case where unused glTF nodes would cause `Model` to crash at runtime.

`ModelSceneGraph` keeps an array of runtime nodes that is the same length as the list of nodes in the glTF. However, unused nodes are `undefined` entries in this array. The loops in `configurePipeline` and `update` weren't filtering out this corner case.

This bug was first reported in [this forum post](https://community.cesium.com/t/3d-tiles-crashes-with-cesium-1-97/20464), see the thread for an example tileset.