### PR TITLE
Fixes createFeatures not being called before getFeature in Vector3DTileContent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 - Fixed a regression where glTF models with unused nodes would crash [#10813](https://github.com/CesiumGS/cesium/pull/10813)
 - Fixed a bug where KMLs with a NetworkLink with viewRefreshMode=='onRegion' would cause Cesium to make numerous resource requests and possibly trigger an out of memory error. [#10790](https://github.com/CesiumGS/cesium/pull/10790)
 - Fixed a bug where camera would not follow the `Viewer.trackedEntity` if it had a model with a `HeightReference` other than `NONE`. [#10805](https://github.com/CesiumGS/cesium/pull/10805)
+- Fixed a bug where calling `Vector3DTileContent.getFeature` before a render update could result in no feature being returned. [#10819](https://github.com/CesiumGS/cesium/pull/10819)
 
 ### 1.97 - 2022-09-01
 

--- a/Source/Scene/Vector3DTileContent.js
+++ b/Source/Scene/Vector3DTileContent.js
@@ -673,6 +673,10 @@ Vector3DTileContent.prototype.getFeature = function (batchId) {
   }
   //>>includeEnd('debug');
 
+  if (!defined(this._features)) {
+    createFeatures(this);
+  }
+
   return this._features[batchId];
 };
 


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/10814

In some cases, `getFeature` can be called before `update` is called, so this PR ensures that if features aren't created by the time `getFeature` is called, it should create them, similar to how it is done in `applyStyle` and `update`.