### PR TITLE
Fix attribute name conflict in Cesium3DTilesVoxelProvider

### DIFF
--- a/Source/Scene/Cesium3DTilesVoxelProvider.js
+++ b/Source/Scene/Cesium3DTilesVoxelProvider.js
@@ -404,6 +404,7 @@ Cesium3DTilesVoxelProvider.prototype.requestData = function (options) {
   const implicitTileset = this._implicitTileset;
   const types = this.types;
   const componentTypes = this.componentTypes;
+  const names = this.names;
 
   // Can't use a scratch variable here because the object is used inside the promise chain.
   const tileCoordinates = new ImplicitTileCoordinates({
@@ -452,7 +453,15 @@ Cesium3DTilesVoxelProvider.prototype.requestData = function (options) {
 
       const data = new Array(attributesLength);
       for (let i = 0; i < attributesLength; i++) {
-        const attribute = attributes[i];
+        // The attributes array from GltfLoader is not in the same order as
+        // names, types, etc. from the provider.
+        // A temporary fix: Look up the attribute based on its name
+        const name = `_${names[i]}`;
+        const attribute = attributes.find((a) => a.name === name);
+        if (!defined(attribute)) {
+          continue;
+        }
+
         const type = types[i];
         const componentType = componentTypes[i];
         const componentDatatype = MetadataComponentType.toComponentDatatype(


### PR DESCRIPTION
`Cesium3DTilesVoxelProvider.prototype.requestData` merges information from two sources:
- attribute buffers from GltfLoader
- schema information from the tileset, stored in the provider constructor

Much of this information is in array format, and arrays from the two sources may be ordered differently.

This PR compares the attribute name to ensure the merged information is correctly aligned.