### PR TITLE
Handle model GPU resources across different WebGL contexts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 - Fixed a bug where KMLs with a NetworkLink with viewRefreshMode=='onRegion' would cause Cesium to make numerous resource requests and possibly trigger an out of memory error. [#10790](https://github.com/CesiumGS/cesium/pull/10790)
 - Fixed a bug where camera would not follow the `Viewer.trackedEntity` if it had a model with a `HeightReference` other than `NONE`. [#10805](https://github.com/CesiumGS/cesium/pull/10805)
 - Fixed a bug where calling `removeAll` on a `ClippingPlaneCollection` attached to a `Model` would cause a crash. [#10827](https://github.com/CesiumGS/cesium/pull/10827)
+- Fixed a regression where tilesets would not load in multiple `Viewer`s. [#10828](https://github.com/CesiumGS/cesium/pull/10828)
 
 ### 1.97 - 2022-09-01
 

--- a/Source/Scene/GltfLoader.js
+++ b/Source/Scene/GltfLoader.js
@@ -572,7 +572,8 @@ function loadVertexBuffer(
   semantic,
   draco,
   loadBuffer,
-  loadTypedArray
+  loadTypedArray,
+  frameState
 ) {
   const accessor = gltf.accessors[accessorId];
   const bufferViewId = accessor.bufferView;
@@ -581,6 +582,7 @@ function loadVertexBuffer(
     gltf: gltf,
     gltfResource: loader._gltfResource,
     baseResource: loader._baseResource,
+    frameState: frameState,
     bufferViewId: bufferViewId,
     draco: draco,
     attributeSemantic: semantic,
@@ -601,13 +603,15 @@ function loadIndexBuffer(
   accessorId,
   draco,
   loadBuffer,
-  loadTypedArray
+  loadTypedArray,
+  frameState
 ) {
   const indexBufferLoader = ResourceCache.loadIndexBuffer({
     gltf: gltf,
     accessorId: accessorId,
     gltfResource: loader._gltfResource,
     baseResource: loader._baseResource,
+    frameState: frameState,
     draco: draco,
     asynchronous: loader._asynchronous,
     loadBuffer: loadBuffer,
@@ -1030,7 +1034,8 @@ function loadAttribute(
   semanticInfo,
   draco,
   loadBuffer,
-  loadTypedArray
+  loadTypedArray,
+  frameState
 ) {
   const accessor = gltf.accessors[accessorId];
   const bufferViewId = accessor.bufferView;
@@ -1064,7 +1069,8 @@ function loadAttribute(
     gltfSemantic,
     draco,
     loadBuffer,
-    loadTypedArray
+    loadTypedArray,
+    frameState
   );
   const promise = vertexBufferLoader.promise.then(function (
     vertexBufferLoader
@@ -1152,7 +1158,8 @@ function loadVertexAttribute(
     semanticInfo,
     draco,
     loadBuffer,
-    loadTypedArray
+    loadTypedArray,
+    frameState
   );
 
   const attributePlan = new PrimitiveLoadPlan.AttributeLoadPlan(attribute);
@@ -1221,7 +1228,8 @@ function loadInstancedAttribute(
     semanticInfo,
     undefined,
     loadBuffer,
-    loadTypedArray
+    loadTypedArray,
+    frameState
   );
 }
 
@@ -1274,7 +1282,8 @@ function loadIndices(
     accessorId,
     draco,
     loadBuffer,
-    loadTypedArray
+    loadTypedArray,
+    frameState
   );
 
   const promise = indexBufferLoader.promise.then(function (indexBufferLoader) {
@@ -1302,6 +1311,7 @@ function loadTexture(
   gltf,
   textureInfo,
   supportedImageFormats,
+  frameState,
   samplerOverride
 ) {
   const imageId = GltfLoaderUtil.getImageIdFromTexture({
@@ -1320,6 +1330,7 @@ function loadTexture(
     gltfResource: loader._gltfResource,
     baseResource: loader._baseResource,
     supportedImageFormats: supportedImageFormats,
+    frameState: frameState,
     asynchronous: loader._asynchronous,
   });
 
@@ -1344,7 +1355,13 @@ function loadTexture(
   return textureReader;
 }
 
-function loadMaterial(loader, gltf, gltfMaterial, supportedImageFormats) {
+function loadMaterial(
+  loader,
+  gltf,
+  gltfMaterial,
+  supportedImageFormats,
+  frameState
+) {
   const material = new Material();
 
   const extensions = defaultValue(
@@ -1365,7 +1382,8 @@ function loadMaterial(loader, gltf, gltfMaterial, supportedImageFormats) {
         loader,
         gltf,
         pbrSpecularGlossiness.diffuseTexture,
-        supportedImageFormats
+        supportedImageFormats,
+        frameState
       );
     }
     if (defined(pbrSpecularGlossiness.specularGlossinessTexture)) {
@@ -1374,7 +1392,8 @@ function loadMaterial(loader, gltf, gltfMaterial, supportedImageFormats) {
           loader,
           gltf,
           pbrSpecularGlossiness.specularGlossinessTexture,
-          supportedImageFormats
+          supportedImageFormats,
+          frameState
         );
       }
     }
@@ -1397,7 +1416,8 @@ function loadMaterial(loader, gltf, gltfMaterial, supportedImageFormats) {
         loader,
         gltf,
         pbrMetallicRoughness.baseColorTexture,
-        supportedImageFormats
+        supportedImageFormats,
+        frameState
       );
     }
     if (defined(pbrMetallicRoughness.metallicRoughnessTexture)) {
@@ -1405,7 +1425,8 @@ function loadMaterial(loader, gltf, gltfMaterial, supportedImageFormats) {
         loader,
         gltf,
         pbrMetallicRoughness.metallicRoughnessTexture,
-        supportedImageFormats
+        supportedImageFormats,
+        frameState
       );
     }
     metallicRoughness.baseColorFactor = fromArray(
@@ -1423,7 +1444,8 @@ function loadMaterial(loader, gltf, gltfMaterial, supportedImageFormats) {
       loader,
       gltf,
       gltfMaterial.emissiveTexture,
-      supportedImageFormats
+      supportedImageFormats,
+      frameState
     );
   }
   // Normals aren't used for classification, so don't load the normal texture.
@@ -1432,7 +1454,8 @@ function loadMaterial(loader, gltf, gltfMaterial, supportedImageFormats) {
       loader,
       gltf,
       gltfMaterial.normalTexture,
-      supportedImageFormats
+      supportedImageFormats,
+      frameState
     );
   }
   if (defined(gltfMaterial.occlusionTexture)) {
@@ -1440,7 +1463,8 @@ function loadMaterial(loader, gltf, gltfMaterial, supportedImageFormats) {
       loader,
       gltf,
       gltfMaterial.occlusionTexture,
-      supportedImageFormats
+      supportedImageFormats,
+      frameState
     );
   }
   material.emissiveFactor = fromArray(Cartesian3, gltfMaterial.emissiveFactor);
@@ -1522,6 +1546,7 @@ function loadFeatureIdTexture(
   gltf,
   gltfFeatureIdTexture,
   supportedImageFormats,
+  frameState,
   positionalLabel
 ) {
   const featureIdTexture = new FeatureIdTexture();
@@ -1538,6 +1563,7 @@ function loadFeatureIdTexture(
     gltf,
     textureInfo,
     supportedImageFormats,
+    frameState,
     Sampler.NEAREST // Feature ID textures require nearest sampling
   );
 
@@ -1562,6 +1588,7 @@ function loadFeatureIdTextureLegacy(
   gltfFeatureIdTexture,
   featureTableId,
   supportedImageFormats,
+  frameState,
   featureCount,
   positionalLabel
 ) {
@@ -1575,6 +1602,7 @@ function loadFeatureIdTextureLegacy(
     gltf,
     textureInfo,
     supportedImageFormats,
+    frameState,
     Sampler.NEAREST // Feature ID textures require nearest sampling
   );
 
@@ -1647,7 +1675,8 @@ function loadPrimitive(
       loader,
       gltf,
       gltf.materials[materialId],
-      supportedImageFormats
+      supportedImageFormats,
+      frameState
     );
   }
 
@@ -1765,7 +1794,8 @@ function loadPrimitive(
       gltf,
       primitive,
       meshFeatures,
-      supportedImageFormats
+      supportedImageFormats,
+      frameState
     );
   } else if (hasFeatureMetadataLegacy) {
     loadPrimitiveFeaturesLegacy(
@@ -1773,7 +1803,8 @@ function loadPrimitive(
       gltf,
       primitive,
       featureMetadataLegacy,
-      supportedImageFormats
+      supportedImageFormats,
+      frameState
     );
   }
 
@@ -1807,7 +1838,8 @@ function loadPrimitiveFeatures(
   gltf,
   primitive,
   meshFeaturesExtension,
-  supportedImageFormats
+  supportedImageFormats,
+  frameState
 ) {
   let featureIdsArray;
   if (
@@ -1830,6 +1862,7 @@ function loadPrimitiveFeatures(
         gltf,
         featureIds,
         supportedImageFormats,
+        frameState,
         label
       );
     } else if (defined(featureIds.attribute)) {
@@ -1850,7 +1883,8 @@ function loadPrimitiveFeaturesLegacy(
   gltf,
   primitive,
   metadataExtension,
-  supportedImageFormats
+  supportedImageFormats,
+  frameState
 ) {
   // For looking up the featureCount for each set of feature IDs
   const featureTables = gltf.extensions.EXT_feature_metadata.featureTables;
@@ -1911,6 +1945,7 @@ function loadPrimitiveFeaturesLegacy(
         featureIdTexture,
         propertyTableId,
         supportedImageFormats,
+        frameState,
         featureCount,
         featureIdLabel
       );
@@ -2216,7 +2251,8 @@ function loadStructuralMetadata(
   gltf,
   extension,
   extensionLegacy,
-  supportedImageFormats
+  supportedImageFormats,
+  frameState
 ) {
   const structuralMetadataLoader = new GltfStructuralMetadataLoader({
     gltf: gltf,
@@ -2225,6 +2261,7 @@ function loadStructuralMetadata(
     gltfResource: loader._gltfResource,
     baseResource: loader._baseResource,
     supportedImageFormats: supportedImageFormats,
+    frameState: frameState,
     asynchronous: loader._asynchronous,
   });
   structuralMetadataLoader.load();
@@ -2503,7 +2540,8 @@ function parse(
       gltf,
       structuralMetadataExtension,
       featureMetadataExtensionLegacy,
-      supportedImageFormats
+      supportedImageFormats,
+      frameState
     );
     const promise = structuralMetadataLoader.promise.then(function (
       structuralMetadataLoader

--- a/Source/Scene/GltfStructuralMetadataLoader.js
+++ b/Source/Scene/GltfStructuralMetadataLoader.js
@@ -25,6 +25,7 @@ import ResourceLoaderState from "./ResourceLoaderState.js";
  * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
+ * @param {FrameState} options.frameState The frame state.
  * @param {String} [options.cacheKey] The cache key of the resource.
  * @param {Boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
  *
@@ -39,6 +40,7 @@ function GltfStructuralMetadataLoader(options) {
   const gltfResource = options.gltfResource;
   const baseResource = options.baseResource;
   const supportedImageFormats = options.supportedImageFormats;
+  const frameState = options.frameState;
   const cacheKey = options.cacheKey;
   const asynchronous = defaultValue(options.asynchronous, true);
 
@@ -47,6 +49,7 @@ function GltfStructuralMetadataLoader(options) {
   Check.typeOf.object("options.gltfResource", gltfResource);
   Check.typeOf.object("options.baseResource", baseResource);
   Check.typeOf.object("options.supportedImageFormats", supportedImageFormats);
+  Check.typeOf.object("options.frameState", frameState);
 
   if (!defined(options.extension) && !defined(options.extensionLegacy)) {
     throw new DeveloperError(
@@ -61,6 +64,7 @@ function GltfStructuralMetadataLoader(options) {
   this._extension = extension;
   this._extensionLegacy = extensionLegacy;
   this._supportedImageFormats = supportedImageFormats;
+  this._frameState = frameState;
   this._cacheKey = cacheKey;
   this._asynchronous = asynchronous;
   this._bufferViewLoaders = [];
@@ -376,6 +380,7 @@ function loadTextures(structuralMetadataLoader) {
   const gltfResource = structuralMetadataLoader._gltfResource;
   const baseResource = structuralMetadataLoader._baseResource;
   const supportedImageFormats = structuralMetadataLoader._supportedImageFormats;
+  const frameState = structuralMetadataLoader._frameState;
   const asynchronous = structuralMetadataLoader._asynchronous;
 
   // Load the textures
@@ -389,6 +394,7 @@ function loadTextures(structuralMetadataLoader) {
         gltfResource: gltfResource,
         baseResource: baseResource,
         supportedImageFormats: supportedImageFormats,
+        frameState: frameState,
         asynchronous: asynchronous,
       });
       texturePromises.push(textureLoader.promise);

--- a/Source/Scene/ResourceCache.js
+++ b/Source/Scene/ResourceCache.js
@@ -433,6 +433,7 @@ ResourceCache.loadDraco = function (options) {
  * @param {Object} options.gltf The glTF JSON.
  * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {FrameState} options.frameState The frame state.
  * @param {Number} [options.bufferViewId] The bufferView ID corresponding to the vertex buffer.
  * @param {Object} [options.draco] The Draco extension object.
  * @param {String} [options.attributeSemantic] The attribute semantic, e.g. POSITION or NORMAL.
@@ -453,6 +454,7 @@ ResourceCache.loadVertexBuffer = function (options) {
   const gltf = options.gltf;
   const gltfResource = options.gltfResource;
   const baseResource = options.baseResource;
+  const frameState = options.frameState;
   const bufferViewId = options.bufferViewId;
   const draco = options.draco;
   const attributeSemantic = options.attributeSemantic;
@@ -466,6 +468,7 @@ ResourceCache.loadVertexBuffer = function (options) {
   Check.typeOf.object("options.gltf", gltf);
   Check.typeOf.object("options.gltfResource", gltfResource);
   Check.typeOf.object("options.baseResource", baseResource);
+  Check.typeOf.object("options.frameState", frameState);
   if (!loadBuffer && !loadTypedArray) {
     throw new DeveloperError(
       "At least one of loadBuffer and loadTypedArray must be true."
@@ -506,6 +509,7 @@ ResourceCache.loadVertexBuffer = function (options) {
     gltf: gltf,
     gltfResource: gltfResource,
     baseResource: baseResource,
+    frameState: frameState,
     bufferViewId: bufferViewId,
     draco: draco,
     attributeSemantic: attributeSemantic,
@@ -557,6 +561,7 @@ ResourceCache.loadVertexBuffer = function (options) {
  * @param {Number} options.accessorId The accessor ID corresponding to the index buffer.
  * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {FrameState} options.frameState The frame state.
  * @param {Object} [options.draco] The Draco extension object.
  * @param {Boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
  * @param {Boolean} [options.loadBuffer=false] Load index buffer as a GPU index buffer.
@@ -570,6 +575,7 @@ ResourceCache.loadIndexBuffer = function (options) {
   const accessorId = options.accessorId;
   const gltfResource = options.gltfResource;
   const baseResource = options.baseResource;
+  const frameState = options.frameState;
   const draco = options.draco;
   const asynchronous = defaultValue(options.asynchronous, true);
   const loadBuffer = defaultValue(options.loadBuffer, false);
@@ -580,6 +586,7 @@ ResourceCache.loadIndexBuffer = function (options) {
   Check.typeOf.number("options.accessorId", accessorId);
   Check.typeOf.object("options.gltfResource", gltfResource);
   Check.typeOf.object("options.baseResource", baseResource);
+  Check.typeOf.object("options.frameState", frameState);
   if (!loadBuffer && !loadTypedArray) {
     throw new DeveloperError(
       "At least one of loadBuffer and loadTypedArray must be true."
@@ -592,6 +599,7 @@ ResourceCache.loadIndexBuffer = function (options) {
     accessorId: accessorId,
     gltfResource: gltfResource,
     baseResource: baseResource,
+    frameState: frameState,
     draco: draco,
     loadBuffer: loadBuffer,
     loadTypedArray: loadTypedArray,
@@ -689,6 +697,7 @@ ResourceCache.loadImage = function (options) {
  * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
+ * @param {FrameState} options.frameState The frame state.
  * @param {Boolean} [options.asynchronous=true] Determines if WebGL resource creation will be spread out over several frames or block until all WebGL resources are created.
  *
  * @returns {GltfTextureLoader} The texture loader.
@@ -701,6 +710,7 @@ ResourceCache.loadTexture = function (options) {
   const gltfResource = options.gltfResource;
   const baseResource = options.baseResource;
   const supportedImageFormats = options.supportedImageFormats;
+  const frameState = options.frameState;
   const asynchronous = defaultValue(options.asynchronous, true);
 
   //>>includeStart('debug', pragmas.debug);
@@ -708,6 +718,8 @@ ResourceCache.loadTexture = function (options) {
   Check.typeOf.object("options.textureInfo", textureInfo);
   Check.typeOf.object("options.gltfResource", gltfResource);
   Check.typeOf.object("options.baseResource", baseResource);
+  Check.typeOf.object("options.supportedImageFormats", supportedImageFormats);
+  Check.typeOf.object("options.frameState", frameState);
   //>>includeEnd('debug');
 
   const cacheKey = ResourceCacheKey.getTextureCacheKey({
@@ -716,6 +728,7 @@ ResourceCache.loadTexture = function (options) {
     gltfResource: gltfResource,
     baseResource: baseResource,
     supportedImageFormats: supportedImageFormats,
+    frameState: frameState,
   });
 
   let textureLoader = ResourceCache.get(cacheKey);

--- a/Source/Scene/ResourceCacheKey.js
+++ b/Source/Scene/ResourceCacheKey.js
@@ -294,6 +294,7 @@ ResourceCacheKey.getDracoCacheKey = function (options) {
  * @param {Object} options.gltf The glTF JSON.
  * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {FrameState} options.frameState The frame state.
  * @param {Number} [options.bufferViewId] The bufferView ID corresponding to the vertex buffer.
  * @param {Object} [options.draco] The Draco extension object.
  * @param {String} [options.attributeSemantic] The attribute semantic, e.g. POSITION or NORMAL.
@@ -311,6 +312,7 @@ ResourceCacheKey.getVertexBufferCacheKey = function (options) {
   const gltf = options.gltf;
   const gltfResource = options.gltfResource;
   const baseResource = options.baseResource;
+  const frameState = options.frameState;
   const bufferViewId = options.bufferViewId;
   const draco = options.draco;
   const attributeSemantic = options.attributeSemantic;
@@ -322,6 +324,7 @@ ResourceCacheKey.getVertexBufferCacheKey = function (options) {
   Check.typeOf.object("options.gltf", gltf);
   Check.typeOf.object("options.gltfResource", gltfResource);
   Check.typeOf.object("options.baseResource", baseResource);
+  Check.typeOf.object("options.frameState", frameState);
 
   const hasBufferViewId = defined(bufferViewId);
   const hasDraco = defined(draco);
@@ -358,6 +361,7 @@ ResourceCacheKey.getVertexBufferCacheKey = function (options) {
 
   if (loadBuffer) {
     cacheKeySuffix += "-buffer";
+    cacheKeySuffix += `-context-${frameState.context.id}`;
   }
 
   if (loadTypedArray) {
@@ -398,6 +402,7 @@ ResourceCacheKey.getVertexBufferCacheKey = function (options) {
  * @param {Number} options.accessorId The accessor ID corresponding to the index buffer.
  * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
+ * @param {FrameState} options.frameState The frame state.
  * @param {Object} [options.draco] The Draco extension object.
  * @param {Boolean} [options.loadBuffer=false] Load index buffer as a GPU index buffer.
  * @param {Boolean} [options.loadTypedArray=false] Load index buffer as a typed array.
@@ -411,6 +416,7 @@ ResourceCacheKey.getIndexBufferCacheKey = function (options) {
   const accessorId = options.accessorId;
   const gltfResource = options.gltfResource;
   const baseResource = options.baseResource;
+  const frameState = options.frameState;
   const draco = options.draco;
   const loadBuffer = defaultValue(options.loadBuffer, false);
   const loadTypedArray = defaultValue(options.loadTypedArray, false);
@@ -420,6 +426,8 @@ ResourceCacheKey.getIndexBufferCacheKey = function (options) {
   Check.typeOf.number("options.accessorId", accessorId);
   Check.typeOf.object("options.gltfResource", gltfResource);
   Check.typeOf.object("options.baseResource", baseResource);
+  Check.typeOf.object("options.frameState", frameState);
+
   if (!loadBuffer && !loadTypedArray) {
     throw new DeveloperError(
       "At least one of loadBuffer and loadTypedArray must be true."
@@ -430,6 +438,7 @@ ResourceCacheKey.getIndexBufferCacheKey = function (options) {
   let cacheKeySuffix = "";
   if (loadBuffer) {
     cacheKeySuffix += "-buffer";
+    cacheKeySuffix += `-context-${frameState.context.id}`;
   }
 
   if (loadTypedArray) {
@@ -509,6 +518,7 @@ ResourceCacheKey.getImageCacheKey = function (options) {
  * @param {Resource} options.gltfResource The {@link Resource} containing the glTF.
  * @param {Resource} options.baseResource The {@link Resource} that paths in the glTF JSON are relative to.
  * @param {SupportedImageFormats} options.supportedImageFormats The supported image formats.
+ * @param {FrameState} options.frameState The frame state.
  *
  * @returns {String} The texture cache key.
  * @private
@@ -520,6 +530,7 @@ ResourceCacheKey.getTextureCacheKey = function (options) {
   const gltfResource = options.gltfResource;
   const baseResource = options.baseResource;
   const supportedImageFormats = options.supportedImageFormats;
+  const frameState = options.frameState;
 
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("options.gltf", gltf);
@@ -527,6 +538,7 @@ ResourceCacheKey.getTextureCacheKey = function (options) {
   Check.typeOf.object("options.gltfResource", gltfResource);
   Check.typeOf.object("options.baseResource", baseResource);
   Check.typeOf.object("options.supportedImageFormats", supportedImageFormats);
+  Check.typeOf.object("options.frameState", frameState);
   //>>includeEnd('debug');
 
   const textureId = textureInfo.index;
@@ -549,7 +561,7 @@ ResourceCacheKey.getTextureCacheKey = function (options) {
   // removing the sampleCacheKey here.
   const samplerCacheKey = getSamplerCacheKey(gltf, textureInfo);
 
-  return `texture:${imageCacheKey}-sampler-${samplerCacheKey}`;
+  return `texture:${imageCacheKey}-sampler-${samplerCacheKey}-context-${frameState.context.id}`;
 };
 
 export default ResourceCacheKey;

--- a/Specs/Scene/GltfStructuralMetadataLoaderSpec.js
+++ b/Specs/Scene/GltfStructuralMetadataLoaderSpec.js
@@ -151,6 +151,12 @@ describe(
     extensionSchemaUri.schemaUri = "schema.json";
     delete extensionSchemaUri.schema;
 
+    const mockFrameState = {
+      context: {
+        id: "01234",
+      },
+    };
+
     let scene;
 
     beforeAll(function () {
@@ -173,6 +179,7 @@ describe(
           gltfResource: gltfResource,
           baseResource: gltfResource,
           supportedImageFormats: new SupportedImageFormats(),
+          frameState: mockFrameState,
         });
       }).toThrowDeveloperError();
     });
@@ -186,6 +193,7 @@ describe(
           gltfResource: gltfResource,
           baseResource: gltfResource,
           supportedImageFormats: new SupportedImageFormats(),
+          frameState: mockFrameState,
         });
       }).toThrowDeveloperError();
     });
@@ -198,6 +206,7 @@ describe(
           gltfResource: undefined,
           baseResource: gltfResource,
           supportedImageFormats: new SupportedImageFormats(),
+          frameState: mockFrameState,
         });
       }).toThrowDeveloperError();
     });
@@ -210,11 +219,12 @@ describe(
           gltfResource: gltfResource,
           baseResource: undefined,
           supportedImageFormats: new SupportedImageFormats(),
+          frameState: mockFrameState,
         });
       }).toThrowDeveloperError();
     });
 
-    it("throws if gltf is undefined", function () {
+    it("throws if supportedImageFormats is undefined", function () {
       expect(function () {
         return new GltfStructuralMetadataLoader({
           gltf: gltf,
@@ -222,6 +232,20 @@ describe(
           gltfResource: gltfResource,
           baseResource: gltfResource,
           supportedImageFormats: undefined,
+          frameState: mockFrameState,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("throws if frameState is undefined", function () {
+      expect(function () {
+        return new GltfStructuralMetadataLoader({
+          gltf: gltf,
+          extension: extension,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          supportedImageFormats: new SupportedImageFormats(),
+          frameState: undefined,
         });
       }).toThrowDeveloperError();
     });
@@ -242,6 +266,7 @@ describe(
         gltfResource: gltfResource,
         baseResource: gltfResource,
         supportedImageFormats: new SupportedImageFormats(),
+        frameState: mockFrameState,
       });
 
       structuralMetadataLoader.load();
@@ -273,6 +298,7 @@ describe(
         gltfResource: gltfResource,
         baseResource: gltfResource,
         supportedImageFormats: new SupportedImageFormats(),
+        frameState: mockFrameState,
       });
 
       structuralMetadataLoader.load();
@@ -308,6 +334,7 @@ describe(
         gltfResource: gltfResource,
         baseResource: gltfResource,
         supportedImageFormats: new SupportedImageFormats(),
+        frameState: mockFrameState,
       });
 
       structuralMetadataLoader.load();
@@ -338,6 +365,7 @@ describe(
         gltfResource: gltfResource,
         baseResource: gltfResource,
         supportedImageFormats: new SupportedImageFormats(),
+        frameState: mockFrameState,
       });
 
       structuralMetadataLoader.load();
@@ -408,6 +436,7 @@ describe(
         gltfResource: gltfResource,
         baseResource: gltfResource,
         supportedImageFormats: new SupportedImageFormats(),
+        frameState: mockFrameState,
       });
 
       structuralMetadataLoader.load();
@@ -457,6 +486,7 @@ describe(
         gltfResource: gltfResource,
         baseResource: gltfResource,
         supportedImageFormats: new SupportedImageFormats(),
+        frameState: mockFrameState,
       });
 
       structuralMetadataLoader.load();
@@ -521,6 +551,7 @@ describe(
         gltfResource: gltfResource,
         baseResource: gltfResource,
         supportedImageFormats: new SupportedImageFormats(),
+        frameState: mockFrameState,
       });
       // Also load a copy of the schema into the cache
       const schemaResource = gltfResource.getDerivedResource({
@@ -548,6 +579,7 @@ describe(
             gltfResource: gltfResource,
             baseResource: gltfResource,
             supportedImageFormats: new SupportedImageFormats(),
+            frameState: mockFrameState,
           });
           expect(structuralMetadataLoader.structuralMetadata).not.toBeDefined();
           structuralMetadataLoader.load();

--- a/Specs/Scene/ResourceCacheKeySpec.js
+++ b/Specs/Scene/ResourceCacheKeySpec.js
@@ -259,6 +259,12 @@ describe("ResourceCacheKey", function () {
     ],
   };
 
+  const mockFrameState = {
+    context: {
+      id: "01234",
+    },
+  };
+
   it("getSchemaCacheKey works for external schemas", function () {
     const cacheKey = ResourceCacheKey.getSchemaCacheKey({
       resource: schemaResource,
@@ -496,12 +502,13 @@ describe("ResourceCacheKey", function () {
       gltf: gltfUncompressed,
       gltfResource: gltfResource,
       baseResource: baseResource,
+      frameState: mockFrameState,
       bufferViewId: 0,
       loadBuffer: true,
     });
 
     expect(cacheKey).toBe(
-      "vertex-buffer:https://example.com/resources/external.bin-range-0-40-buffer"
+      "vertex-buffer:https://example.com/resources/external.bin-range-0-40-buffer-context-01234"
     );
   });
 
@@ -513,13 +520,14 @@ describe("ResourceCacheKey", function () {
       gltf: gltfDraco,
       gltfResource: gltfResource,
       baseResource: baseResource,
+      frameState: mockFrameState,
       draco: draco,
       attributeSemantic: "POSITION",
       loadBuffer: true,
     });
 
     expect(cacheKey).toBe(
-      "vertex-buffer:https://example.com/resources/external.bin-range-0-100-draco-POSITION-buffer"
+      "vertex-buffer:https://example.com/resources/external.bin-range-0-100-draco-POSITION-buffer-context-01234"
     );
   });
 
@@ -528,13 +536,14 @@ describe("ResourceCacheKey", function () {
       gltf: gltfUncompressed,
       gltfResource: gltfResource,
       baseResource: baseResource,
+      frameState: mockFrameState,
       bufferViewId: 0,
       dequantize: true,
       loadBuffer: true,
     });
 
     expect(cacheKey).toBe(
-      "vertex-buffer:https://example.com/resources/external.bin-range-0-40-dequantize-buffer"
+      "vertex-buffer:https://example.com/resources/external.bin-range-0-40-dequantize-buffer-context-01234"
     );
   });
 
@@ -543,6 +552,7 @@ describe("ResourceCacheKey", function () {
       gltf: gltfUncompressed,
       gltfResource: gltfResource,
       baseResource: baseResource,
+      frameState: mockFrameState,
       bufferViewId: 0,
       loadTypedArray: true,
     });
@@ -557,13 +567,14 @@ describe("ResourceCacheKey", function () {
       gltf: gltfUncompressed,
       gltfResource: gltfResource,
       baseResource: baseResource,
+      frameState: mockFrameState,
       bufferViewId: 0,
       loadBuffer: true,
       loadTypedArray: true,
     });
 
     expect(cacheKey).toBe(
-      "vertex-buffer:https://example.com/resources/external.bin-range-0-40-buffer-typed-array"
+      "vertex-buffer:https://example.com/resources/external.bin-range-0-40-buffer-context-01234-typed-array"
     );
   });
 
@@ -573,6 +584,7 @@ describe("ResourceCacheKey", function () {
         gltf: undefined,
         gltfResource: gltfResource,
         baseResource: baseResource,
+        frameState: mockFrameState,
         bufferViewId: 0,
       });
     }).toThrowDeveloperError();
@@ -584,6 +596,7 @@ describe("ResourceCacheKey", function () {
         gltf: gltfUncompressed,
         gltfResource: undefined,
         baseResource: baseResource,
+        frameState: mockFrameState,
         bufferViewId: 0,
       });
     }).toThrowDeveloperError();
@@ -595,6 +608,19 @@ describe("ResourceCacheKey", function () {
         gltf: gltfUncompressed,
         gltfResource: gltfResource,
         baseResource: undefined,
+        frameState: mockFrameState,
+        bufferViewId: 0,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getVertexBufferCacheKey throws if frameState is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getVertexBufferCacheKey({
+        gltf: gltfUncompressed,
+        gltfResource: gltfResource,
+        baseResource: baseResource,
+        frameState: undefined,
         bufferViewId: 0,
       });
     }).toThrowDeveloperError();
@@ -606,6 +632,7 @@ describe("ResourceCacheKey", function () {
         gltf: gltfUncompressed,
         gltfResource: gltfResource,
         baseResource: baseResource,
+        frameState: mockFrameState,
       });
     }).toThrowDeveloperError();
   });
@@ -619,6 +646,7 @@ describe("ResourceCacheKey", function () {
         gltf: gltfDraco,
         gltfResource: gltfResource,
         baseResource: baseResource,
+        frameState: mockFrameState,
         bufferViewId: 0,
         draco: draco,
         attributeSemantic: "POSITION",
@@ -635,6 +663,7 @@ describe("ResourceCacheKey", function () {
         gltf: gltfDraco,
         gltfResource: gltfResource,
         baseResource: baseResource,
+        frameState: mockFrameState,
         draco: draco,
         attributeSemantic: undefined,
       });
@@ -647,6 +676,7 @@ describe("ResourceCacheKey", function () {
         gltf: gltfUncompressed,
         gltfResource: gltfResource,
         baseResource: baseResource,
+        frameState: mockFrameState,
         bufferViewId: 0,
         loadBuffer: false,
         loadTypedArray: false,
@@ -660,11 +690,12 @@ describe("ResourceCacheKey", function () {
       accessorId: 2,
       gltfResource: gltfResource,
       baseResource: baseResource,
+      frameState: mockFrameState,
       loadBuffer: true,
     });
 
     expect(cacheKey).toBe(
-      "index-buffer:https://example.com/resources/external.bin-accessor-80-5123-SCALAR-36-buffer"
+      "index-buffer:https://example.com/resources/external.bin-accessor-80-5123-SCALAR-36-buffer-context-01234"
     );
   });
 
@@ -677,12 +708,13 @@ describe("ResourceCacheKey", function () {
       accessorId: 2,
       gltfResource: gltfResource,
       baseResource: baseResource,
+      frameState: mockFrameState,
       draco: draco,
       loadBuffer: true,
     });
 
     expect(cacheKey).toBe(
-      "index-buffer:https://example.com/resources/external.bin-range-0-100-draco-buffer"
+      "index-buffer:https://example.com/resources/external.bin-range-0-100-draco-buffer-context-01234"
     );
   });
 
@@ -692,6 +724,7 @@ describe("ResourceCacheKey", function () {
       accessorId: 2,
       gltfResource: gltfResource,
       baseResource: baseResource,
+      frameState: mockFrameState,
       loadTypedArray: true,
     });
 
@@ -706,12 +739,13 @@ describe("ResourceCacheKey", function () {
       accessorId: 2,
       gltfResource: gltfResource,
       baseResource: baseResource,
+      frameState: mockFrameState,
       loadBuffer: true,
       loadTypedArray: true,
     });
 
     expect(cacheKey).toBe(
-      "index-buffer:https://example.com/resources/external.bin-accessor-80-5123-SCALAR-36-buffer-typed-array"
+      "index-buffer:https://example.com/resources/external.bin-accessor-80-5123-SCALAR-36-buffer-context-01234-typed-array"
     );
   });
 
@@ -722,6 +756,7 @@ describe("ResourceCacheKey", function () {
         accessorId: 2,
         gltfResource: gltfResource,
         baseResource: baseResource,
+        frameState: mockFrameState,
         loadBuffer: true,
       });
     }).toThrowDeveloperError();
@@ -734,6 +769,7 @@ describe("ResourceCacheKey", function () {
         accessorId: 2,
         gltfResource: undefined,
         baseResource: baseResource,
+        frameState: mockFrameState,
         loadBuffer: true,
       });
     }).toThrowDeveloperError();
@@ -746,6 +782,20 @@ describe("ResourceCacheKey", function () {
         accessorId: 2,
         gltfResource: gltfResource,
         baseResource: undefined,
+        frameState: mockFrameState,
+        loadBuffer: true,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getIndexBufferCacheKey throws if frameState is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getIndexBufferCacheKey({
+        gltf: gltfUncompressed,
+        accessorId: 2,
+        gltfResource: gltfResource,
+        baseResource: baseResource,
+        frameState: undefined,
         loadBuffer: true,
       });
     }).toThrowDeveloperError();
@@ -758,6 +808,7 @@ describe("ResourceCacheKey", function () {
         accessorId: 2,
         gltfResource: gltfResource,
         baseResource: baseResource,
+        frameState: mockFrameState,
         loadBuffer: false,
         loadTypedArray: false,
       });
@@ -842,10 +893,11 @@ describe("ResourceCacheKey", function () {
       gltfResource: gltfResource,
       baseResource: baseResource,
       supportedImageFormats: new SupportedImageFormats(),
+      frameState: mockFrameState,
     });
 
     expect(cacheKey).toBe(
-      "texture:https://example.com/resources/image.png-sampler-10497-10497-9729-9729"
+      "texture:https://example.com/resources/image.png-sampler-10497-10497-9729-9729-context-01234"
     );
   });
 
@@ -859,10 +911,11 @@ describe("ResourceCacheKey", function () {
       gltfResource: gltfResource,
       baseResource: baseResource,
       supportedImageFormats: new SupportedImageFormats(),
+      frameState: mockFrameState,
     });
 
     expect(cacheKey).toBe(
-      "texture:https://example.com/resources/external.bin-range-0-100-sampler-33071-33648-9984-9728"
+      "texture:https://example.com/resources/external.bin-range-0-100-sampler-33071-33648-9984-9728-context-01234"
     );
   });
 
@@ -878,10 +931,11 @@ describe("ResourceCacheKey", function () {
       supportedImageFormats: new SupportedImageFormats({
         webp: true,
       }),
+      frameState: mockFrameState,
     });
 
     expect(cacheKey).toBe(
-      "texture:https://example.com/resources/image.webp-sampler-10497-10497-9729-9729"
+      "texture:https://example.com/resources/image.webp-sampler-10497-10497-9729-9729-context-01234"
     );
   });
 
@@ -895,10 +949,11 @@ describe("ResourceCacheKey", function () {
       gltfResource: gltfResource,
       baseResource: baseResource,
       supportedImageFormats: new SupportedImageFormats(),
+      frameState: mockFrameState,
     });
 
     expect(cacheKey).toBe(
-      "texture:https://example.com/resources/image.png-sampler-10497-10497-9729-9729"
+      "texture:https://example.com/resources/image.png-sampler-10497-10497-9729-9729-context-01234"
     );
   });
 
@@ -914,10 +969,11 @@ describe("ResourceCacheKey", function () {
       supportedImageFormats: new SupportedImageFormats({
         basis: true,
       }),
+      frameState: mockFrameState,
     });
 
     expect(cacheKey).toBe(
-      "texture:https://example.com/resources/image.ktx2-sampler-10497-10497-9729-9729"
+      "texture:https://example.com/resources/image.ktx2-sampler-10497-10497-9729-9729-context-01234"
     );
   });
 
@@ -931,10 +987,11 @@ describe("ResourceCacheKey", function () {
       gltfResource: gltfResource,
       baseResource: baseResource,
       supportedImageFormats: new SupportedImageFormats(),
+      frameState: mockFrameState,
     });
 
     expect(cacheKey).toBe(
-      "texture:https://example.com/resources/image.png-sampler-10497-10497-9729-9729"
+      "texture:https://example.com/resources/image.png-sampler-10497-10497-9729-9729-context-01234"
     );
   });
 
@@ -949,6 +1006,7 @@ describe("ResourceCacheKey", function () {
         gltfResource: gltfResource,
         baseResource: baseResource,
         supportedImageFormats: new SupportedImageFormats(),
+        frameState: mockFrameState,
       });
     }).toThrowDeveloperError();
   });
@@ -961,6 +1019,7 @@ describe("ResourceCacheKey", function () {
         gltfResource: gltfResource,
         baseResource: baseResource,
         supportedImageFormats: new SupportedImageFormats(),
+        frameState: mockFrameState,
       });
     }).toThrowDeveloperError();
   });
@@ -976,6 +1035,7 @@ describe("ResourceCacheKey", function () {
         gltfResource: undefined,
         baseResource: baseResource,
         supportedImageFormats: new SupportedImageFormats(),
+        frameState: mockFrameState,
       });
     }).toThrowDeveloperError();
   });
@@ -991,6 +1051,7 @@ describe("ResourceCacheKey", function () {
         gltfResource: gltfResource,
         baseResource: undefined,
         supportedImageFormats: new SupportedImageFormats(),
+        frameState: mockFrameState,
       });
     }).toThrowDeveloperError();
   });
@@ -1006,6 +1067,23 @@ describe("ResourceCacheKey", function () {
         gltfResource: gltfResource,
         baseResource: baseResource,
         supportedImageFormats: undefined,
+        frameState: mockFrameState,
+      });
+    }).toThrowDeveloperError();
+  });
+
+  it("getTextureCacheKey throws if frameState is undefined", function () {
+    expect(function () {
+      ResourceCacheKey.getTextureCacheKey({
+        gltf: gltfWithTextures,
+        textureInfo: {
+          index: 0,
+          texCoord: 0,
+        },
+        gltfResource: gltfResource,
+        baseResource: baseResource,
+        supportedImageFormats: new SupportedImageFormats(),
+        frameState: undefined,
       });
     }).toThrowDeveloperError();
   });

--- a/Specs/Scene/ResourceCacheSpec.js
+++ b/Specs/Scene/ResourceCacheSpec.js
@@ -247,6 +247,18 @@ describe(
       ],
     };
 
+    const mockFrameState = {
+      context: {
+        id: "01234",
+      },
+    };
+
+    const mockFrameState2 = {
+      context: {
+        id: "56789",
+      },
+    };
+
     let scene;
 
     beforeAll(function () {
@@ -850,6 +862,7 @@ describe(
         gltf: gltfUncompressed,
         gltfResource: gltfResource,
         baseResource: gltfResource,
+        frameState: mockFrameState,
         bufferViewId: 0,
         loadBuffer: true,
       });
@@ -857,6 +870,7 @@ describe(
         gltf: gltfUncompressed,
         gltfResource: gltfResource,
         baseResource: gltfResource,
+        frameState: mockFrameState,
         bufferViewId: 0,
         accessorId: 0,
         loadBuffer: true,
@@ -872,6 +886,7 @@ describe(
           gltf: gltfUncompressed,
           gltfResource: gltfResource,
           baseResource: gltfResource,
+          frameState: mockFrameState,
           bufferViewId: 0,
           loadBuffer: true,
         })
@@ -906,6 +921,7 @@ describe(
         gltf: gltfDraco,
         gltfResource: gltfResource,
         baseResource: gltfResource,
+        frameState: mockFrameState,
         draco: dracoExtension,
         attributeSemantic: "POSITION",
         loadBuffer: true,
@@ -914,6 +930,7 @@ describe(
         gltf: gltfDraco,
         gltfResource: gltfResource,
         baseResource: gltfResource,
+        frameState: mockFrameState,
         draco: dracoExtension,
         attributeSemantic: "POSITION",
         accessorId: 0,
@@ -930,6 +947,7 @@ describe(
           gltf: gltfDraco,
           gltfResource: gltfResource,
           baseResource: gltfResource,
+          frameState: mockFrameState,
           draco: dracoExtension,
           attributeSemantic: "POSITION",
           accessorId: 0,
@@ -962,6 +980,7 @@ describe(
         gltf: gltfUncompressed,
         gltfResource: gltfResource,
         baseResource: gltfResource,
+        frameState: mockFrameState,
         bufferViewId: 0,
         loadTypedArray: true,
       });
@@ -969,6 +988,7 @@ describe(
         gltf: gltfUncompressed,
         gltfResource: gltfResource,
         baseResource: gltfResource,
+        frameState: mockFrameState,
         bufferViewId: 0,
         accessorId: 0,
         loadTypedArray: true,
@@ -1000,6 +1020,7 @@ describe(
         gltf: gltfUncompressed,
         gltfResource: gltfResource,
         baseResource: gltfResource,
+        frameState: mockFrameState,
         bufferViewId: 0,
         loadBuffer: true,
         loadTypedArray: true,
@@ -1008,6 +1029,7 @@ describe(
         gltf: gltfUncompressed,
         gltfResource: gltfResource,
         baseResource: gltfResource,
+        frameState: mockFrameState,
         bufferViewId: 0,
         accessorId: 0,
         loadBuffer: true,
@@ -1032,12 +1054,54 @@ describe(
       });
     });
 
+    it("loads vertex buffer on different contexts", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        Promise.resolve(bufferArrayBuffer)
+      );
+
+      const vertexBufferLoader1 = ResourceCache.loadVertexBuffer({
+        gltf: gltfUncompressed,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        frameState: mockFrameState,
+        bufferViewId: 0,
+        accessorId: 0,
+        loadBuffer: true,
+      });
+
+      const vertexBufferLoader2 = ResourceCache.loadVertexBuffer({
+        gltf: gltfUncompressed,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        frameState: mockFrameState2,
+        bufferViewId: 0,
+        accessorId: 0,
+        loadBuffer: true,
+      });
+
+      const promises = [
+        waitForLoaderProcess(vertexBufferLoader1, scene),
+        waitForLoaderProcess(vertexBufferLoader2, scene),
+      ];
+
+      return Promise.all(promises).then(function (vertexBufferLoaders) {
+        const vertexBuffer1 = vertexBufferLoaders[0];
+        const vertexBuffer2 = vertexBufferLoaders[1];
+
+        expect(vertexBuffer1).toBeDefined();
+        expect(vertexBuffer2).toBeDefined();
+
+        expect(vertexBuffer1).not.toBe(vertexBuffer2);
+      });
+    });
+
     it("loadVertexBuffer throws if gltf is undefined", function () {
       expect(function () {
         ResourceCache.loadVertexBuffer({
           gltf: undefined,
           gltfResource: gltfResource,
           baseResource: gltfResource,
+          frameState: mockFrameState,
           bufferViewId: 0,
           loadBuffer: true,
         });
@@ -1050,6 +1114,7 @@ describe(
           gltf: gltfUncompressed,
           gltfResource: undefined,
           baseResource: gltfResource,
+          frameState: mockFrameState,
           bufferViewId: 0,
           loadBuffer: true,
         });
@@ -1062,6 +1127,20 @@ describe(
           gltf: gltfUncompressed,
           gltfResource: gltfResource,
           baseResource: undefined,
+          frameState: mockFrameState,
+          bufferViewId: 0,
+          loadBuffer: true,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadVertexBuffer throws if frameState is undefined", function () {
+      expect(function () {
+        ResourceCache.loadVertexBuffer({
+          gltf: gltfUncompressed,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          frameState: undefined,
           bufferViewId: 0,
           loadBuffer: true,
         });
@@ -1074,6 +1153,7 @@ describe(
           gltf: gltfDraco,
           gltfResource: gltfResource,
           baseResource: gltfResource,
+          frameState: mockFrameState,
           bufferViewId: 0,
           draco: dracoExtension,
           attributeSemantic: "POSITION",
@@ -1089,6 +1169,7 @@ describe(
           gltf: gltfDraco,
           gltfResource: gltfResource,
           baseResource: gltfResource,
+          frameState: mockFrameState,
           loadBuffer: true,
         });
       }).toThrowDeveloperError();
@@ -1100,6 +1181,7 @@ describe(
           gltf: gltfDraco,
           gltfResource: gltfResource,
           baseResource: gltfResource,
+          frameState: mockFrameState,
           draco: dracoExtension,
           attributeSemantic: undefined,
           accessorId: 0,
@@ -1114,6 +1196,7 @@ describe(
           gltf: gltfDraco,
           gltfResource: gltfResource,
           baseResource: gltfResource,
+          frameState: mockFrameState,
           draco: dracoExtension,
           attributeSemantic: "POSITION",
           accessorId: undefined,
@@ -1128,6 +1211,7 @@ describe(
           gltf: gltfUncompressed,
           gltfResource: gltfResource,
           baseResource: gltfResource,
+          frameState: mockFrameState,
           bufferViewId: 0,
           loadBuffer: false,
           loadTypedArray: false,
@@ -1145,6 +1229,7 @@ describe(
         accessorId: 2,
         gltfResource: gltfResource,
         baseResource: gltfResource,
+        frameState: mockFrameState,
         loadBuffer: true,
       });
       const indexBufferLoader = ResourceCache.loadIndexBuffer({
@@ -1152,6 +1237,7 @@ describe(
         accessorId: 2,
         gltfResource: gltfResource,
         baseResource: gltfResource,
+        frameState: mockFrameState,
         loadBuffer: true,
       });
 
@@ -1166,6 +1252,7 @@ describe(
           accessorId: 2,
           gltfResource: gltfResource,
           baseResource: gltfResource,
+          frameState: mockFrameState,
           loadBuffer: true,
         })
       ).toBe(indexBufferLoader);
@@ -1198,6 +1285,7 @@ describe(
         accessorId: 2,
         gltfResource: gltfResource,
         baseResource: gltfResource,
+        frameState: mockFrameState,
         draco: dracoExtension,
         loadBuffer: true,
       });
@@ -1206,6 +1294,7 @@ describe(
         accessorId: 2,
         gltfResource: gltfResource,
         baseResource: gltfResource,
+        frameState: mockFrameState,
         draco: dracoExtension,
         loadBuffer: true,
       });
@@ -1221,6 +1310,7 @@ describe(
           accessorId: 2,
           gltfResource: gltfResource,
           baseResource: gltfResource,
+          frameState: mockFrameState,
           draco: dracoExtension,
           loadBuffer: true,
         })
@@ -1252,6 +1342,7 @@ describe(
         accessorId: 2,
         gltfResource: gltfResource,
         baseResource: gltfResource,
+        frameState: mockFrameState,
         loadTypedArray: true,
       });
       const indexBufferLoader = ResourceCache.loadIndexBuffer({
@@ -1259,6 +1350,7 @@ describe(
         accessorId: 2,
         gltfResource: gltfResource,
         baseResource: gltfResource,
+        frameState: mockFrameState,
         loadTypedArray: true,
       });
 
@@ -1289,6 +1381,7 @@ describe(
         accessorId: 2,
         gltfResource: gltfResource,
         baseResource: gltfResource,
+        frameState: mockFrameState,
         loadBuffer: true,
         loadTypedArray: true,
       });
@@ -1297,6 +1390,7 @@ describe(
         accessorId: 2,
         gltfResource: gltfResource,
         baseResource: gltfResource,
+        frameState: mockFrameState,
         loadBuffer: true,
         loadTypedArray: true,
       });
@@ -1319,6 +1413,45 @@ describe(
       });
     });
 
+    it("loads index buffer on different contexts", function () {
+      spyOn(Resource.prototype, "fetchArrayBuffer").and.returnValue(
+        Promise.resolve(bufferArrayBuffer)
+      );
+
+      const indexBufferLoader1 = ResourceCache.loadIndexBuffer({
+        gltf: gltfUncompressed,
+        accessorId: 2,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        frameState: mockFrameState,
+        loadBuffer: true,
+      });
+
+      const indexBufferLoader2 = ResourceCache.loadIndexBuffer({
+        gltf: gltfUncompressed,
+        accessorId: 2,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        frameState: mockFrameState2,
+        loadBuffer: true,
+      });
+
+      const promises = [
+        waitForLoaderProcess(indexBufferLoader1, scene),
+        waitForLoaderProcess(indexBufferLoader2, scene),
+      ];
+
+      return Promise.all(promises).then(function (indexBufferLoaders) {
+        const indexBuffer1 = indexBufferLoaders[0];
+        const indexBuffer2 = indexBufferLoaders[1];
+
+        expect(indexBuffer1).toBeDefined();
+        expect(indexBuffer2).toBeDefined();
+
+        expect(indexBuffer1).not.toBe(indexBuffer2);
+      });
+    });
+
     it("loadIndexBuffer throws if gltf is undefined", function () {
       expect(function () {
         ResourceCache.loadIndexBuffer({
@@ -1326,6 +1459,7 @@ describe(
           accessorId: 2,
           gltfResource: gltfResource,
           baseResource: gltfResource,
+          frameState: mockFrameState,
           loadBuffer: true,
         });
       }).toThrowDeveloperError();
@@ -1338,6 +1472,7 @@ describe(
           accessorId: undefined,
           gltfResource: gltfResource,
           baseResource: gltfResource,
+          frameState: mockFrameState,
           loadBuffer: true,
         });
       }).toThrowDeveloperError();
@@ -1350,6 +1485,7 @@ describe(
           accessorId: 2,
           gltfResource: undefined,
           baseResource: gltfResource,
+          frameState: mockFrameState,
           loadBuffer: true,
         });
       }).toThrowDeveloperError();
@@ -1362,6 +1498,20 @@ describe(
           accessorId: 2,
           gltfResource: gltfResource,
           baseResource: undefined,
+          frameState: mockFrameState,
+          loadBuffer: true,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadIndexBuffer throws if frameState is undefined", function () {
+      expect(function () {
+        ResourceCache.loadIndexBuffer({
+          gltf: gltfUncompressed,
+          accessorId: 2,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          frameState: undefined,
           loadBuffer: true,
         });
       }).toThrowDeveloperError();
@@ -1374,6 +1524,7 @@ describe(
           accessorId: 2,
           gltfResource: gltfResource,
           baseResource: gltfResource,
+          frameState: mockFrameState,
           loadBuffer: false,
           loadTypedArray: false,
         });
@@ -1473,12 +1624,14 @@ describe(
         gltfResource: gltfResource,
         baseResource: gltfResource,
         supportedImageFormats: new SupportedImageFormats(),
+        frameState: mockFrameState,
       });
       const textureLoader = ResourceCache.loadTexture({
         gltf: gltfWithTextures,
         textureInfo: gltfWithTextures.materials[0].emissiveTexture,
         gltfResource: gltfResource,
         baseResource: gltfResource,
+        frameState: mockFrameState,
         supportedImageFormats: new SupportedImageFormats(),
       });
       const cacheEntry = ResourceCache.cacheEntries[expectedCacheKey];
@@ -1492,6 +1645,7 @@ describe(
           textureInfo: gltfWithTextures.materials[0].emissiveTexture,
           gltfResource: gltfResource,
           baseResource: gltfResource,
+          frameState: mockFrameState,
           supportedImageFormats: new SupportedImageFormats(),
         })
       ).toBe(textureLoader);
@@ -1512,6 +1666,45 @@ describe(
       });
     });
 
+    it("loads texture on different contexts", function () {
+      spyOn(Resource.prototype, "fetchImage").and.returnValue(
+        Promise.resolve(image)
+      );
+
+      const textureLoader1 = ResourceCache.loadTexture({
+        gltf: gltfWithTextures,
+        textureInfo: gltfWithTextures.materials[0].emissiveTexture,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        frameState: mockFrameState,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+
+      const textureLoader2 = ResourceCache.loadTexture({
+        gltf: gltfWithTextures,
+        textureInfo: gltfWithTextures.materials[0].emissiveTexture,
+        gltfResource: gltfResource,
+        baseResource: gltfResource,
+        frameState: mockFrameState2,
+        supportedImageFormats: new SupportedImageFormats(),
+      });
+
+      const promises = [
+        waitForLoaderProcess(textureLoader1, scene),
+        waitForLoaderProcess(textureLoader2, scene),
+      ];
+
+      return Promise.all(promises).then(function (textureLoaders) {
+        const texture1 = textureLoaders[0];
+        const texture2 = textureLoaders[1];
+
+        expect(texture1).toBeDefined();
+        expect(texture2).toBeDefined();
+
+        expect(texture1).not.toBe(texture2);
+      });
+    });
+
     it("loadTexture throws if gltf is undefined", function () {
       expect(function () {
         ResourceCache.loadTexture({
@@ -1520,6 +1713,7 @@ describe(
           gltfResource: gltfResource,
           baseResource: gltfResource,
           supportedImageFormats: new SupportedImageFormats(),
+          frameState: mockFrameState,
         });
       }).toThrowDeveloperError();
     });
@@ -1532,6 +1726,7 @@ describe(
           gltfResource: gltfResource,
           baseResource: gltfResource,
           supportedImageFormats: new SupportedImageFormats(),
+          frameState: mockFrameState,
         });
       }).toThrowDeveloperError();
     });
@@ -1544,6 +1739,7 @@ describe(
           gltfResource: undefined,
           baseResource: gltfResource,
           supportedImageFormats: new SupportedImageFormats(),
+          frameState: mockFrameState,
         });
       }).toThrowDeveloperError();
     });
@@ -1556,6 +1752,7 @@ describe(
           gltfResource: gltfResource,
           baseResource: undefined,
           supportedImageFormats: new SupportedImageFormats(),
+          frameState: mockFrameState,
         });
       }).toThrowDeveloperError();
     });
@@ -1568,6 +1765,20 @@ describe(
           gltfResource: gltfResource,
           baseResource: gltfResource,
           supportedImageFormats: undefined,
+          frameState: mockFrameState,
+        });
+      }).toThrowDeveloperError();
+    });
+
+    it("loadTexture throws if frameState is undefined", function () {
+      expect(function () {
+        ResourceCache.loadTexture({
+          gltf: gltfWithTextures,
+          textureInfo: gltfWithTextures.materials[0].emissiveTexture,
+          gltfResource: gltfResource,
+          baseResource: gltfResource,
+          supportedImageFormats: new SupportedImageFormats(),
+          frameState: undefined,
         });
       }).toThrowDeveloperError();
     });


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/10825

Adds `context.id` to the cache key for GPU resources like vertex buffers, index buffers, and textures. This prevents the GPU resource from being shared by multiple contexts which is the root cause of https://github.com/CesiumGS/cesium/issues/10825.

![Selection_062](https://user-images.githubusercontent.com/915398/192582819-6d4a68af-9f92-4332-8396-c8694b000957.png)