### PR TITLE
Fix crash when add clipping planes same length twice

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,6 @@
 - Fixed a bug where calling `removeAll` on a `ClippingPlaneCollection` attached to a `Model` would cause a crash. [#10827](https://github.com/CesiumGS/cesium/pull/10827)
 - Fixed a bug where replacing a `Model`'s `ClippingPlaneCollection` with one of the same length would cause a crash. [#10831](https://github.com/CesiumGS/cesium/pull/10831)
 - Fixed a regression where tilesets would not load in multiple `Viewer`s. [#10828](https://github.com/CesiumGS/cesium/pull/10828)
-- Fixed a bug where replacing a `Model`'s `ClippingPlaneCollection` with one of the same length would cause a crash. [#10831](https://github.com/CesiumGS/cesium/pull/10831)
 
 ### 1.97 - 2022-09-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 - Fixed a bug where camera would not follow the `Viewer.trackedEntity` if it had a model with a `HeightReference` other than `NONE`. [#10805](https://github.com/CesiumGS/cesium/pull/10805)
 - Fixed a bug where calling `Vector3DTileContent.getFeature` before a render update could result in no feature being returned. [#10819](https://github.com/CesiumGS/cesium/pull/10819)
 - Fixed a bug where calling `removeAll` on a `ClippingPlaneCollection` attached to a `Model` would cause a crash. [#10827](https://github.com/CesiumGS/cesium/pull/10827)
+- Fixed a bug where calling `add` twice with same length on a `ClippingPlaneCollection` attached to a `Model` would cause a crash. [#10832](https://github.com/CesiumGS/cesium/pull/10832)
 
 ### 1.97 - 2022-09-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@
 - Fixed a bug where camera would not follow the `Viewer.trackedEntity` if it had a model with a `HeightReference` other than `NONE`. [#10805](https://github.com/CesiumGS/cesium/pull/10805)
 - Fixed a bug where calling `Vector3DTileContent.getFeature` before a render update could result in no feature being returned. [#10819](https://github.com/CesiumGS/cesium/pull/10819)
 - Fixed a bug where calling `removeAll` on a `ClippingPlaneCollection` attached to a `Model` would cause a crash. [#10827](https://github.com/CesiumGS/cesium/pull/10827)
-- Fixed a bug where calling `add` twice with same length on a `ClippingPlaneCollection` attached to a `Model` would cause a crash. [#10832](https://github.com/CesiumGS/cesium/pull/10832)
+- Fixed a bug where replacing a `Model`'s `ClippingPlaneCollection` with one of the same length would cause a crash. [#10831](https://github.com/CesiumGS/cesium/pull/10831)
 
 ### 1.97 - 2022-09-01
 

--- a/Source/Scene/Model/Model3DTileContent.js
+++ b/Source/Scene/Model/Model3DTileContent.js
@@ -240,6 +240,7 @@ Model3DTileContent.prototype.update = function (tileset, frameState) {
     model._clippingPlanes !== tilesetClippingPlanes
   ) {
     model._clippingPlanes = tilesetClippingPlanes;
+    model._clippingPlanesState = 0;
   }
 
   model.update(frameState);

--- a/Specs/Scene/Model/Model3DTileContentSpec.js
+++ b/Specs/Scene/Model/Model3DTileContentSpec.js
@@ -1491,7 +1491,8 @@ describe(
           }
         );
       });
-      it("replacing a clipping planes collection with one of the same length", function () {
+      
+      it("replaces clipping planes collection with one of the same length", function () {
         return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl).then(
           function (tileset) {
             const tile = tileset.root;

--- a/Specs/Scene/Model/Model3DTileContentSpec.js
+++ b/Specs/Scene/Model/Model3DTileContentSpec.js
@@ -1491,6 +1491,38 @@ describe(
           }
         );
       });
+      it("replacing a clipping planes collection with one of the same length", function () {
+        return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl).then(
+          function (tileset) {
+            const tile = tileset.root;
+            const model = tile.content._model;
+            const passOptions = Cesium3DTilePass.getPassOptions(
+              Cesium3DTilePass.RENDER
+            );
+
+            expect(model.clippingPlanes).toBeUndefined();
+
+            spyOn(model, "resetDrawCommands");
+
+            const clippingPlaneCollection = new ClippingPlaneCollection({
+              planes: [new ClippingPlane(Cartesian3.UNIT_X, 0.0)],
+            });
+            tileset.clippingPlanes = clippingPlaneCollection;
+            tile.update(tileset, scene.frameState, passOptions);
+
+            expect(model.resetDrawCommands).toHaveBeenCalled();
+            expect(model.resetDrawCommands.calls.count()).toBe(1);
+
+            const newClippingPlaneCollection = new ClippingPlaneCollection({
+              planes: [new ClippingPlane(Cartesian3.UNIT_X, 0.0)],
+            });
+            tileset.clippingPlanes = newClippingPlaneCollection;
+            tile.update(tileset, scene.frameState, passOptions);
+
+            expect(model.resetDrawCommands.calls.count()).toBe(2);
+          }
+        );
+      });
 
       it("clipping planes selectively disable rendering", function () {
         return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl).then(

--- a/Specs/Scene/Model/ModelSpec.js
+++ b/Specs/Scene/Model/ModelSpec.js
@@ -3839,6 +3839,24 @@ describe(
         });
       });
 
+      it("add clipping planes collection same length twice works", function () {
+        const plane = new ClippingPlane(Cartesian3.UNIT_X, -2.5);
+        const clippingPlanes = new ClippingPlaneCollection({
+          planes: [plane],
+        });
+        return loadAndZoomToModel(
+          { gltf: boxTexturedGlbUrl, clippingPlanes: clippingPlanes },
+          scene
+        ).then(function (model) {
+          verifyRender(model, false);
+
+          model.clippingPlanes = new ClippingPlaneCollection({
+            planes: [plane],
+          });
+          verifyRender(model, true);
+        });
+      });
+
       it("clipping planes apply edge styling", function () {
         const plane = new ClippingPlane(Cartesian3.UNIT_X, 0);
         const clippingPlanes = new ClippingPlaneCollection({

--- a/Specs/Scene/Model/ModelSpec.js
+++ b/Specs/Scene/Model/ModelSpec.js
@@ -3839,7 +3839,7 @@ describe(
         });
       });
 
-      it("add clipping planes collection same length twice works", function () {
+      it("replacing clipping planes with another collection works", function () {
         const plane = new ClippingPlane(Cartesian3.UNIT_X, -2.5);
         const clippingPlanes = new ClippingPlaneCollection({
           planes: [plane],

--- a/Specs/Scene/Model/ModelSpec.js
+++ b/Specs/Scene/Model/ModelSpec.js
@@ -3840,20 +3840,30 @@ describe(
       });
 
       it("replacing clipping planes with another collection works", function () {
-        const plane = new ClippingPlane(Cartesian3.UNIT_X, -2.5);
+        const modelClippedPlane = new ClippingPlane(Cartesian3.UNIT_X, -2.5);
+        const modelVisiblePlane = new ClippingPlane(Cartesian3.UNIT_X, 2.5);
+
         const clippingPlanes = new ClippingPlaneCollection({
-          planes: [plane],
+          planes: [modelClippedPlane],
         });
+
         return loadAndZoomToModel(
           { gltf: boxTexturedGlbUrl, clippingPlanes: clippingPlanes },
           scene
         ).then(function (model) {
           verifyRender(model, false);
 
+          // Replace the clipping plane collection with one that makes the model visible.
           model.clippingPlanes = new ClippingPlaneCollection({
-            planes: [plane],
+            planes: [modelVisiblePlane],
           });
           verifyRender(model, true);
+
+          // Replace the clipping plane collection with one that clips the model.
+          model.clippingPlanes = new ClippingPlaneCollection({
+            planes: [modelClippedPlane],
+          });
+          verifyRender(model, false);
         });
       });
 


### PR DESCRIPTION
When set 3Dtileset clipping planes same length twice，cesium crashed.

[updateClippingPlanes](https://github.com/CesiumGS/cesium/blob/24a3b666464e45a7a3d5d94d74b8e06a75e4f0d0/Source/Scene/Model/Model.js#L1903)

>  if (currentClippingPlanesState !== model._clippingPlanesState) {
    model.resetDrawCommands();
    model._clippingPlanesState = currentClippingPlanesState;
  }
if the length of the last one is the same as this one ,    currentClippingPlanesState will always == model._clippingPlanesState,

`model.resetDrawCommands` will not be called.