### PR TITLE
Adds check for TRAVIS_REPO_SLUG in .travis.yml to ensure deploy scripts only run from cesium repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,15 @@ script:
 
   - npm --silent run build-apps
 
-  - npm --silent run deploy-s3 -- -b cesium-dev -d cesium/$TRAVIS_BRANCH --confirm -c 'no-cache'
-  - npm --silent run deploy-status -- --status success --message Deployed
+  - |
+    if [ $TRAVIS_REPO_SLUG == "CesiumGS/cesium" ]; then
+      npm --silent run deploy-s3 -- -b cesium-dev -d cesium/$TRAVIS_BRANCH --confirm -c 'no-cache'
+    fi
+    
+  - |
+    if [ $TRAVIS_REPO_SLUG == "CesiumGS/cesium" ]; then
+        npm --silent run deploy-status -- --status success --message Deployed
+    fi
 
   - npm --silent run test -- --browsers ChromeCI --failTaskOnError --webgl-stub --release --suppressPassed
 


### PR DESCRIPTION
To ensure that CI doesn't fail when cesium is pulled into other repos, a check against the `$TRAVIS_REPO_SLUG` has been added for the deploy scripts in `.travis.yml`.

I am not sure if putting the `deploy-s3` and `deploy-status` within the same `if` block is the right idea (not sure if that combines the time taken to run them in CI when it's reported), so that's why I initially added the most verbose way of checking the condition in each script line.