### PR TITLE
Fix release test failures not failing CI

### DIFF
--- a/Specs/Core/DeveloperErrorSpec.js
+++ b/Specs/Core/DeveloperErrorSpec.js
@@ -21,7 +21,7 @@ describe("Core/DeveloperError", function () {
     // Since we are using source maps, we won't be able to map to a specific file without help from the browser developer tools.
     // However, we should know the class if not minified
     if (!window.specsUsingRelease) {
-      expect(e.stack).toContain("random other thing");
+      expect(e.stack).toContain(name);
     }
   });
 
@@ -32,7 +32,7 @@ describe("Core/DeveloperError", function () {
       expect(str).toContain(`${name}: ${testMessage}`);
     } else {
       // Since source maps are used, there will not be exact filenames
-      expect(str).toContain(testMessage);
+      expect(str).toContain("other message");
     }
   });
 });

--- a/Specs/Core/DeveloperErrorSpec.js
+++ b/Specs/Core/DeveloperErrorSpec.js
@@ -32,7 +32,7 @@ describe("Core/DeveloperError", function () {
       expect(str).toContain(`${name}: ${testMessage}`);
     } else {
       // Since source maps are used, there will not be exact filenames
-      expect(str).toContain("other message");
+      expect(str).toContain(testMessage);
     }
   });
 });

--- a/Specs/Core/DeveloperErrorSpec.js
+++ b/Specs/Core/DeveloperErrorSpec.js
@@ -21,7 +21,7 @@ describe("Core/DeveloperError", function () {
     // Since we are using source maps, we won't be able to map to a specific file without help from the browser developer tools.
     // However, we should know the class if not minified
     if (!window.specsUsingRelease) {
-      expect(e.stack).toContain(name);
+      expect(e.stack).toContain("random other thing");
     }
   });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1347,9 +1347,14 @@ export async function test() {
     { promiseConfig: true, throwErrors: true }
   );
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const server = new karma.Server(config, function doneCallback(exitCode) {
-      resolve(failTaskOnError ? exitCode : undefined);
+      if (failTaskOnError && exitCode) {
+        reject(exitCode);
+        return;
+      }
+
+      resolve();
     });
     server.start();
   });


### PR DESCRIPTION
Travis CI was not properly failing when release test failed. This was not being caught because the majority of the time, tests are not release-only failures, and were therefore caught by the `coverage` task instead.

- You'll see that on https://github.com/CesiumGS/cesium/commit/81e7bfed17e1515bc0be87e13752b1eebd5ad064, [travis passed despite the release test failure](https://app.travis-ci.com/github/CesiumGS/cesium). 
- Then in https://github.com/CesiumGS/cesium/commit/33db7f6a6a4808dedf2a45dfd79eeb9668afc3fd, with the applied fix, [travis fails as expected](https://app.travis-ci.com/github/CesiumGS/cesium). 
- The final commit removes the test test failure so everything is passing again.