### PR TITLE
Fix `zoomTo` bug for scaled models

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 1.99 - 2022-11-01
+
+##### Fixes :wrench:
+
+- Fixed a bug where the scale of a `Model` was being incorrectly applied to its bounding sphere. [#10855](https://github.com/CesiumGS/cesium/pull/10855)
+
 ### 1.98.1 - 2022-10-03
 
 - This is an npm only release to fix the improperly published 1.98.

--- a/Source/Scene/Model/Model.js
+++ b/Source/Scene/Model/Model.js
@@ -2037,17 +2037,22 @@ function updateBoundingSphereAndScale(model, frameState) {
 }
 
 function updateBoundingSphere(model, modelMatrix) {
-  model._boundingSphere = BoundingSphere.transform(
-    model._sceneGraph.boundingSphere,
-    modelMatrix,
-    model._boundingSphere
-  );
-
   model._clampedScale = defined(model._maximumScale)
     ? Math.min(model._scale, model._maximumScale)
     : model._scale;
 
+  model._boundingSphere.center = Cartesian3.multiplyByScalar(
+    model._sceneGraph.boundingSphere.center,
+    model._clampedScale,
+    model._boundingSphere.center
+  );
   model._boundingSphere.radius = model._initialRadius * model._clampedScale;
+
+  model._boundingSphere = BoundingSphere.transform(
+    model._boundingSphere,
+    modelMatrix,
+    model._boundingSphere
+  );
 }
 
 function updateComputedScale(model, modelMatrix, frameState) {

--- a/Specs/Data/Models/glTF-2.0/BoxWithOffset/glTF/BoxWithOffset.gltf
+++ b/Specs/Data/Models/glTF-2.0/BoxWithOffset/glTF/BoxWithOffset.gltf
@@ -1,0 +1,142 @@
+{
+    "asset": {
+        "generator": "COLLADA2GLTF",
+        "version": "2.0"
+    },
+    "scene": 0,
+    "scenes": [
+        {
+            "nodes": [
+                0
+            ]
+        }
+    ],
+    "nodes": [
+        {
+            "children": [
+                1
+            ],
+            "matrix": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                -1.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                5.0,
+                0.0,
+                0.0,
+                1.0
+            ]
+        },
+        {
+            "mesh": 0
+        }
+    ],
+    "meshes": [
+        {
+            "primitives": [
+                {
+                    "attributes": {
+                        "NORMAL": 1,
+                        "POSITION": 2
+                    },
+                    "indices": 0,
+                    "mode": 4,
+                    "material": 0
+                }
+            ],
+            "name": "Mesh"
+        }
+    ],
+    "accessors": [
+        {
+            "bufferView": 0,
+            "byteOffset": 0,
+            "componentType": 5123,
+            "count": 36,
+            "max": [
+                23
+            ],
+            "min": [
+                0
+            ],
+            "type": "SCALAR"
+        },
+        {
+            "bufferView": 1,
+            "byteOffset": 0,
+            "componentType": 5126,
+            "count": 24,
+            "max": [
+                1.0,
+                1.0,
+                1.0
+            ],
+            "min": [
+                -1.0,
+                -1.0,
+                -1.0
+            ],
+            "type": "VEC3"
+        },
+        {
+            "bufferView": 1,
+            "byteOffset": 288,
+            "componentType": 5126,
+            "count": 24,
+            "max": [
+                0.5,
+                0.5,
+                0.5
+            ],
+            "min": [
+                -0.5,
+                -0.5,
+                -0.5
+            ],
+            "type": "VEC3"
+        }
+    ],
+    "materials": [
+        {
+            "pbrMetallicRoughness": {
+                "baseColorFactor": [
+                    0.800000011920929,
+                    0.0,
+                    0.0,
+                    1.0
+                ],
+                "metallicFactor": 0.0
+            },
+            "name": "Red"
+        }
+    ],
+    "bufferViews": [
+        {
+            "buffer": 0,
+            "byteOffset": 576,
+            "byteLength": 72,
+            "target": 34963
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 0,
+            "byteLength": 576,
+            "byteStride": 12,
+            "target": 34962
+        }
+    ],
+    "buffers": [
+        {
+            "byteLength": 648,
+            "uri": "data:application/octet-stream;base64,AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAvwAAAL8AAAA/AAAAPwAAAL8AAAA/AAAAvwAAAD8AAAA/AAAAPwAAAD8AAAA/AAAAPwAAAL8AAAA/AAAAvwAAAL8AAAA/AAAAPwAAAL8AAAC/AAAAvwAAAL8AAAC/AAAAPwAAAD8AAAA/AAAAPwAAAL8AAAA/AAAAPwAAAD8AAAC/AAAAPwAAAL8AAAC/AAAAvwAAAD8AAAA/AAAAPwAAAD8AAAA/AAAAvwAAAD8AAAC/AAAAPwAAAD8AAAC/AAAAvwAAAL8AAAA/AAAAvwAAAD8AAAA/AAAAvwAAAL8AAAC/AAAAvwAAAD8AAAC/AAAAvwAAAL8AAAC/AAAAvwAAAD8AAAC/AAAAPwAAAL8AAAC/AAAAPwAAAD8AAAC/AAABAAIAAwACAAEABAAFAAYABwAGAAUACAAJAAoACwAKAAkADAANAA4ADwAOAA0AEAARABIAEwASABEAFAAVABYAFwAWABUA"
+        }
+    ]
+}

--- a/Specs/Scene/Model/ModelSpec.js
+++ b/Specs/Scene/Model/ModelSpec.js
@@ -3291,7 +3291,7 @@ describe(
             );
             Matrix4.getTranslation(expectedTranslation, expectedCenter);
 
-            let boundingSphere = model.boundingSphere;
+            const boundingSphere = model.boundingSphere;
             expect(boundingSphere.center).toEqual(
               Cartesian3.multiplyByScalar(
                 expectedCenter,
@@ -3305,12 +3305,12 @@ describe(
             );
 
             model.scale = 0.0;
-            boundingSphere = model.boundingSphere;
+            scene.renderForSpecs();
             expect(boundingSphere.center).toEqual(Cartesian3.ZERO);
             expect(boundingSphere.radius).toEqual(0.0);
 
             model.scale = 1.0;
-            boundingSphere = model.boundingSphere;
+            scene.renderForSpecs();
             expect(boundingSphere.center).toEqual(expectedCenter);
             expect(boundingSphere.radius).toEqualEpsilon(
               expectedRadius,


### PR DESCRIPTION
Fixes #10830.

`updateBoundingSphere` was only applying the scale to the radius of the model's local bounding sphere, not the center. This didn't matter for many models because their local bounding spheres are `(0, 0, 0)`. However, this clearly results in an incorrect bounding sphere for models whose bounding spheres are "off-center."

[Local sandcastle from the issue to demonstrate the correct behavior.](http://localhost:8080/Apps/Sandcastle/index.html#c=lVRhb9owEP0rJz4FiZoEStVRikbphIJI2pUMlSpfXMdQQ2JT24GFif8+JySUTf1SRYpyd++9u3u20mzCSGKuYUgVS5PxFDAhVCnQAjKRSmCCA1aKahXyIwa5gqOILnAa60EBDsSacriFsEaz8dvriLAHNnZ/7V3HZ65y+VOHDN0rd715ng3H35ABvUejdQ5aeyN/Nd/fJd7UvnwJZmwS/Ox4wUDPg9nKz+yO15o7fjBm/v289bJy2WQ43rwYMX/lZd7KiCfxW2RiL5hn/n7d8vZk57dtdOFuBmyg9gM/C/Dan6Yjoa7U8/x9NXTSR8eZ3Dleli0fL5JdWLsJeciJ4ErDltEdlWYXTnelJ2hW5KywRop4KLjGjFMZ1uoF08Iq4wSsOtz24U/IwRiRKgpKS0Z0IQ+gZXasARw7SaqMv4SaXniHWXUCubtPZQktpEgGufluZDnt9uV166p+cy5CuWY6MxLHuVERM6oQjiKrbAewEcpkBe9WPYZYavOFebtocU+XklJlOc51Ay7alw1wbLveqOiJiGjchZMcQCpZ97RA4yOvCI5pF2zkNCDBv1mSJtNTqoIdSsKhWqWcXUtM1jT6Ua103K3EHN/GiYAlVKTaKt3+qJ109kIkgbCO9KrHwezUMUvdfEGI4IRKjBKxpXdmtB2W5hQ69plky/6Q/ILwIs4+G7BdquWPSQDBmryBRaUUsn5+eURMUSyWZaUQOIT8ULfy71qj1lM6i2k/z39nyUZIbU4sthBqappsYmzOvvmaGrM1IkrlpF6zovQitgUW3X5y24HE5k9gKos0jqdsT8Nav9c0+H9oscAR48uHLZUxzgwkH6P35vQnxwJCqNc0Yd70f64WIn7F8kz3Lw)