### PR TITLE
Fix `Model` crash that occurs when specular environment maps are unsupported

### DIFF
--- a/Source/Shaders/Model/ImageBasedLightingStageFS.glsl
+++ b/Source/Shaders/Model/ImageBasedLightingStageFS.glsl
@@ -80,6 +80,7 @@ vec3 proceduralIBL(
     return iblColor;
 }
 
+#if defined(DIFFUSE_IBL) || defined(SPECULAR_IBL)
 vec3 textureIBL(
     vec3 positionEC,
     vec3 normalEC,
@@ -134,6 +135,7 @@ vec3 textureIBL(
 
     return diffuseColor * diffuseIrradiance + specularColor * specularIBL;
 }
+#endif
 
 vec3 imageBasedLightingStage(
     vec3 positionEC,

--- a/Specs/Scene/Model/ModelSpec.js
+++ b/Specs/Scene/Model/ModelSpec.js
@@ -26,8 +26,9 @@ import {
   Math as CesiumMath,
   Matrix4,
   Model,
-  ModelSceneGraph,
   ModelFeature,
+  ModelSceneGraph,
+  OctahedralProjectedCubeMap,
   Pass,
   PrimitiveType,
   Resource,
@@ -3179,6 +3180,21 @@ describe(
               expect(rgba).not.toEqual(result);
             });
           });
+        });
+      });
+
+      it("renders when specularEnvironmentMaps aren't supported", function () {
+        spyOn(OctahedralProjectedCubeMap, "isSupported").and.returnValue(false);
+
+        return loadAndZoomToModel(
+          {
+            gltf: boomBoxUrl,
+            scale: 10.0,
+          },
+          scene
+        ).then(function (model) {
+          expect(scene.specularEnvironmentMapsSupported).toBe(false);
+          verifyRender(model, true);
         });
       });
     });


### PR DESCRIPTION
Fixes #10858. To reiterate, many Sandcastles that used image-based lighting were crashing on mobile device browsers that don't support specular environment maps. In `ImageBasedLightingStageFS`, the function `textureIBL` [would always expect `model_iblReferenceframeMatrix` to be declared](https://github.com/CesiumGS/cesium/blob/8c92d86e32d2c2552b81d3e9f5d978cacc4005d2/Source/Shaders/Model/ImageBasedLightingStageFS.glsl#L106) even when specular environment maps were disabled. This PR addresses that bug.