### PR TITLE
Request render on afterRender only as needed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 - Fixed a bug where the scale of a `Model` was being incorrectly applied to its bounding sphere. [#10855](https://github.com/CesiumGS/cesium/pull/10855)
 - Fixed a bug where rendering a `Model` with image-based lighting while specular environment maps were unsupported caused a crash. [#10859](https://github.com/CesiumGS/cesium/pull/10859)
+- Fixed a bug where request render mode was broken when a ground primitive is added. [#10756](https://github.com/CesiumGS/cesium/issues/10756)
 
 ### 1.98.1 - 2022-10-03
 

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -2846,6 +2846,8 @@ function raiseLoadProgressEvent(tileset, frameState) {
         numberOfPendingRequests,
         numberOfTilesProcessing
       );
+
+      return true;
     });
   }
 
@@ -2860,11 +2862,13 @@ function raiseLoadProgressEvent(tileset, frameState) {
   if (progressChanged && tileset._tilesLoaded) {
     frameState.afterRender.push(function () {
       tileset.allTilesLoaded.raiseEvent();
+      return true;
     });
     if (!tileset._initialTilesLoaded) {
       tileset._initialTilesLoaded = true;
       frameState.afterRender.push(function () {
         tileset.initialTilesLoaded.raiseEvent();
+        return true;
       });
     }
   }

--- a/Source/Scene/FrameState.js
+++ b/Source/Scene/FrameState.js
@@ -229,6 +229,10 @@ function FrameState(context, creditDisplay, jobScheduler) {
    * scene state, e.g., manipulate the camera, instead of firing events
    * directly in <code>update</code> functions.
    * </p>
+   * <p>
+   * If any function in the array returns <code>true</code>, in request render mode
+   * another frame will be rendered.
+   * </p>
    *
    * @type {FrameState.AfterRenderCallback[]}
    *
@@ -410,5 +414,6 @@ function FrameState(context, creditDisplay, jobScheduler) {
  * A function that will be called at the end of the frame.
  *
  * @callback FrameState.AfterRenderCallback
+ * @returns {Boolean} true if another render should be requested in request render mode
  */
 export default FrameState;

--- a/Source/Scene/Model/Model.js
+++ b/Source/Scene/Model/Model.js
@@ -606,6 +606,7 @@ function initialize(model) {
       frameState.afterRender.push(function () {
         model._ready = true;
         resolve(model);
+        return true;
       });
     };
   });

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -360,9 +360,9 @@ function Primitive(options) {
           primitive._state === PrimitiveState.FAILED;
         if (!defined(error)) {
           resolve(primitive);
-        } else {
-          reject(error);
+          return true;
         }
+        reject(error);
       });
     };
   });

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -393,12 +393,14 @@ function updateTileLoadProgress(primitive, frameState) {
     currentLoadQueueLength !== primitive._lastTileLoadQueueLength ||
     primitive._tilesInvalidated
   ) {
-    frameState.afterRender.push(
-      Event.prototype.raiseEvent.bind(
-        primitive._tileLoadProgressEvent,
-        currentLoadQueueLength
-      )
+    const raiseEvent = Event.prototype.raiseEvent.bind(
+      primitive._tileLoadProgressEvent,
+      currentLoadQueueLength
     );
+    frameState.afterRender.push(() => {
+      raiseEvent();
+      return true;
+    });
     primitive._lastTileLoadQueueLength = currentLoadQueueLength;
   }
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -3586,8 +3586,10 @@ function callAfterRenderFunctions(scene) {
   // the function modifies scene state that should remain constant over the frame.
   const functions = scene._frameState.afterRender;
   for (let i = 0, length = functions.length; i < length; ++i) {
-    functions[i]();
-    scene.requestRender();
+    const shouldRequestRender = functions[i]();
+    if (shouldRequestRender) {
+      scene.requestRender();
+    }
   }
 
   functions.length = 0;

--- a/Source/Scene/TimeDynamicPointCloud.js
+++ b/Source/Scene/TimeDynamicPointCloud.js
@@ -739,6 +739,7 @@ TimeDynamicPointCloud.prototype.update = function (frameState) {
   if (defined(frame) && !defined(this._lastRenderedFrame)) {
     frameState.afterRender.push(function () {
       that._resolveReadyPromise(that);
+      return true;
     });
   }
 
@@ -746,6 +747,7 @@ TimeDynamicPointCloud.prototype.update = function (frameState) {
     if (that.frameChanged.numberOfListeners > 0) {
       frameState.afterRender.push(function () {
         that.frameChanged.raiseEvent(that);
+        return true;
       });
     }
   }

--- a/Specs/Scene/SceneSpec.js
+++ b/Specs/Scene/SceneSpec.js
@@ -1689,6 +1689,7 @@ describe(
       let functionCalled = false;
       scene._frameState.afterRender.push(function () {
         functionCalled = true;
+        return true;
       });
 
       scene.renderForSpecs();


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/10756

This issue was introduced by https://github.com/CesiumGS/cesium/pull/10607. Basically, if a function is called as part of the `afterRender` step, a new render is always requested. For these primitives, an after render function is required to mark the primitive as `ready` each frame, so it nullifies request render mode.

The fix was to introduce a return parameter to the after render functions to give a bit more control if another frame is needed after. If `true` is returned then another render is requested. If not, then the function is still called, but no additional frames are rendered.