### PR TITLE
I3S: enhancement to feature data loading

### DIFF
--- a/Apps/Sandcastle/gallery/I3S 3D Object Layer.html
+++ b/Apps/Sandcastle/gallery/I3S 3D Object Layer.html
@@ -102,46 +102,31 @@
             Cesium.defined(pickedFeature.content.tile.i3sNode)
           ) {
             const i3sNode = pickedFeature.content.tile.i3sNode;
-            i3sNode.loadFields().then(function () {
-              const geometry = i3sNode.geometryData[0];
-              if (pickedPosition) {
-                const location = geometry.getClosestPointIndexOnTriangle(
-                  pickedPosition.x,
-                  pickedPosition.y,
-                  pickedPosition.z
-                );
+            if (pickedPosition) {
+              i3sNode.loadFields().then(function () {
                 let description = "No attributes";
                 let name;
-                if (
-                  location.index !== -1 &&
-                  geometry.customAttributes.featureIndex
-                ) {
-                  console.log(
-                    `pickedPosition(x,y,z) : ${pickedPosition.x}, ${pickedPosition.y}, ${pickedPosition.z}`
-                  );
-                  const featureIndex =
-                    geometry.customAttributes.featureIndex[location.index];
-                  if (Object.keys(i3sNode.fields).length > 0) {
-                    description =
-                      '<table class="cesium-infoBox-defaultTable"><tbody>';
-                    for (const fieldName in i3sNode.fields) {
-                      if (i3sNode.fields.hasOwnProperty(fieldName)) {
-                        const field = i3sNode.fields[fieldName];
-                        description += `<tr><th>${field.name}</th><td>`;
-                        description += `${field.values[featureIndex]}</td></tr>`;
-                        console.log(
-                          `${field.name}: ${field.values[featureIndex]}`
-                        );
-                        if (
-                          !Cesium.defined(name) &&
-                          isNameProperty(field.name)
-                        ) {
-                          name = field.values[featureIndex];
-                        }
+                console.log(
+                  `pickedPosition(x,y,z) : ${pickedPosition.x}, ${pickedPosition.y}, ${pickedPosition.z}`
+                );
+
+                const fields = i3sNode.getFieldsForPickedPosition(
+                  pickedPosition
+                );
+                if (Object.keys(fields).length > 0) {
+                  description =
+                    '<table class="cesium-infoBox-defaultTable"><tbody>';
+                  for (const fieldName in fields) {
+                    if (i3sNode.fields.hasOwnProperty(fieldName)) {
+                      description += `<tr><th>${fieldName}</th><td>`;
+                      description += `${fields[fieldName]}</td></tr>`;
+                      console.log(`${fieldName}: ${fields[fieldName]}`);
+                      if (!Cesium.defined(name) && isNameProperty(fieldName)) {
+                        name = fields[fieldName];
                       }
                     }
-                    description += `</tbody></table>`;
                   }
+                  description += `</tbody></table>`;
                 }
                 if (!Cesium.defined(name)) {
                   name = "unknown";
@@ -149,8 +134,8 @@
                 selectedEntity.name = name;
                 selectedEntity.description = description;
                 viewer.selectedEntity = selectedEntity;
-              }
-            });
+              });
+            }
           }
         },
         Cesium.ScreenSpaceEventType.LEFT_CLICK);

--- a/Apps/Sandcastle/gallery/I3S Feature Picking.html
+++ b/Apps/Sandcastle/gallery/I3S Feature Picking.html
@@ -102,46 +102,31 @@
             Cesium.defined(pickedFeature.content.tile.i3sNode)
           ) {
             const i3sNode = pickedFeature.content.tile.i3sNode;
-            i3sNode.loadFields().then(function () {
-              const geometry = i3sNode.geometryData[0];
-              if (pickedPosition) {
-                const location = geometry.getClosestPointIndexOnTriangle(
-                  pickedPosition.x,
-                  pickedPosition.y,
-                  pickedPosition.z
-                );
+            if (pickedPosition) {
+              i3sNode.loadFields().then(function () {
                 let description = "No attributes";
                 let name;
-                if (
-                  location.index !== -1 &&
-                  geometry.customAttributes.featureIndex
-                ) {
-                  console.log(
-                    `pickedPosition(x,y,z) : ${pickedPosition.x}, ${pickedPosition.y}, ${pickedPosition.z}`
-                  );
-                  const featureIndex =
-                    geometry.customAttributes.featureIndex[location.index];
-                  if (Object.keys(i3sNode.fields).length > 0) {
-                    description =
-                      '<table class="cesium-infoBox-defaultTable"><tbody>';
-                    for (const fieldName in i3sNode.fields) {
-                      if (i3sNode.fields.hasOwnProperty(fieldName)) {
-                        const field = i3sNode.fields[fieldName];
-                        description += `<tr><th>${field.name}</th><td>`;
-                        description += `${field.values[featureIndex]}</td></tr>`;
-                        console.log(
-                          `${field.name}: ${field.values[featureIndex]}`
-                        );
-                        if (
-                          !Cesium.defined(name) &&
-                          isNameProperty(field.name)
-                        ) {
-                          name = field.values[featureIndex];
-                        }
+                console.log(
+                  `pickedPosition(x,y,z) : ${pickedPosition.x}, ${pickedPosition.y}, ${pickedPosition.z}`
+                );
+
+                const fields = i3sNode.getFieldsForPickedPosition(
+                  pickedPosition
+                );
+                if (Object.keys(fields).length > 0) {
+                  description =
+                    '<table class="cesium-infoBox-defaultTable"><tbody>';
+                  for (const fieldName in fields) {
+                    if (i3sNode.fields.hasOwnProperty(fieldName)) {
+                      description += `<tr><th>${fieldName}</th><td>`;
+                      description += `${fields[fieldName]}</td></tr>`;
+                      console.log(`${fieldName}: ${fields[fieldName]}`);
+                      if (!Cesium.defined(name) && isNameProperty(fieldName)) {
+                        name = fields[fieldName];
                       }
                     }
-                    description += `</tbody></table>`;
                   }
+                  description += `</tbody></table>`;
                 }
                 if (!Cesium.defined(name)) {
                   name = "unknown";
@@ -149,8 +134,8 @@
                 selectedEntity.name = name;
                 selectedEntity.description = description;
                 viewer.selectedEntity = selectedEntity;
-              }
-            });
+              });
+            }
           }
         },
         Cesium.ScreenSpaceEventType.LEFT_CLICK);

--- a/Source/Scene/I3SDataProvider.js
+++ b/Source/Scene/I3SDataProvider.js
@@ -626,7 +626,8 @@ I3SDataProvider.prototype._loadGeoidData = function () {
     console.log(
       "No Geoid Terrain service provided - no geoid conversion will be performed."
     );
-    return Promise.resolve();
+    this._geoidDataIsReadyPromise = Promise.resolve();
+    return this._geoidDataIsReadyPromise;
   }
 
   this._geoidDataIsReadyPromise = geoidTerrainProvider.readyPromise.then(

--- a/Source/Scene/I3SFeature.js
+++ b/Source/Scene/I3SFeature.js
@@ -49,7 +49,7 @@ Object.defineProperties(I3SFeature.prototype, {
 
 /**
  * Loads the content.
- * @returns {Promise.<Object>} A promise that is resolved when the data of the I3S feature is loaded
+ * @returns {Promise} A promise that is resolved when the data of the I3S feature is loaded
  * @private
  */
 I3SFeature.prototype.load = function () {

--- a/Source/Scene/I3SNode.js
+++ b/Source/Scene/I3SNode.js
@@ -241,6 +241,52 @@ I3SNode.prototype.loadFields = function () {
 };
 
 /**
+ * Returns the fields for a given picked position
+ * @param {Cartesian3} Index of the feature whose attributes we want to get
+ * @returns {Object} Object containing field names and their values
+ */
+I3SNode.prototype.getFieldsForPickedPosition = function (pickedPosition) {
+  const geometry = this.geometryData[0];
+  if (!defined(geometry.customAttributes.featureIndex)) {
+    return {};
+  }
+
+  const location = geometry.getClosestPointIndexOnTriangle(
+    pickedPosition.x,
+    pickedPosition.y,
+    pickedPosition.z
+  );
+
+  if (
+    location.index === -1 ||
+    location.index > geometry.customAttributes.featureIndex.length
+  ) {
+    return {};
+  }
+
+  const featureIndex = geometry.customAttributes.featureIndex[location.index];
+  return this.getFieldsForFeature(featureIndex);
+};
+
+/**
+ * Returns the fields for a given feature
+ * @param {Number} Index of the feature whose attributes we want to get
+ * @returns {Object} Object containing field names and their values
+ */
+I3SNode.prototype.getFieldsForFeature = function (featureIndex) {
+  const featureFields = {};
+  for (const fieldName in this.fields) {
+    if (this.fields.hasOwnProperty(fieldName)) {
+      const field = this.fields[fieldName];
+      if (featureIndex >= 0 && featureIndex < field.values.length) {
+        featureFields[field.name] = field.values[featureIndex];
+      }
+    }
+  }
+  return featureFields;
+};
+
+/**
  * @private
  */
 I3SNode.prototype._loadChildren = function () {
@@ -336,11 +382,6 @@ I3SNode.prototype._loadFeatureData = function () {
       this._featureData.push(newFeatureData);
       featurePromises.push(newFeatureData.load());
     }
-  } else if (defined(this._data.mesh) && defined(this._data.mesh.attribute)) {
-    const featureURI = `./features/0`;
-    const newFeatureData = new I3SFeature(this, featureURI);
-    this._featureData.push(newFeatureData);
-    featurePromises.push(newFeatureData.load());
   }
 
   return Promise.all(featurePromises);
@@ -661,7 +702,10 @@ I3SNode.prototype._createContentURL = function () {
   };
 
   // Load the geometry data
-  const dataPromises = [this._loadFeatureData(), this._loadGeometryData()];
+  const dataPromises = [this._loadGeometryData()];
+  if (this._dataProvider.legacyVersion16) {
+    dataPromises.push(this._loadFeatureData());
+  }
 
   const that = this;
   return Promise.all(dataPromises).then(function () {

--- a/Source/Scene/I3SNode.js
+++ b/Source/Scene/I3SNode.js
@@ -242,7 +242,7 @@ I3SNode.prototype.loadFields = function () {
 
 /**
  * Returns the fields for a given picked position
- * @param {Cartesian3} Index of the feature whose attributes we want to get
+ * @param {Cartesian3} pickedPosition The picked position
  * @returns {Object} Object containing field names and their values
  */
 I3SNode.prototype.getFieldsForPickedPosition = function (pickedPosition) {
@@ -270,7 +270,7 @@ I3SNode.prototype.getFieldsForPickedPosition = function (pickedPosition) {
 
 /**
  * Returns the fields for a given feature
- * @param {Number} Index of the feature whose attributes we want to get
+ * @param {Number} featureIndex Index of the feature whose attributes we want to get
  * @returns {Object} Object containing field names and their values
  */
 I3SNode.prototype.getFieldsForFeature = function (featureIndex) {

--- a/Specs/Scene/I3SDataProviderSpec.js
+++ b/Specs/Scene/I3SDataProviderSpec.js
@@ -109,7 +109,7 @@ describe("Scene/I3SDataProvider", function () {
   const mockLayerData = {
     href: "layers/0/",
     attributeStorageInfo: [],
-    store: { rootNode: "mockRootNodeUrl" },
+    store: { rootNode: "mockRootNodeUrl", version: "1.6" },
     fullExtent: { xmin: 0, ymin: 1, xmax: 2, ymax: 3 },
     spatialReference: { wkid: 4326 },
     id: 0,

--- a/Specs/Scene/I3SLayerSpec.js
+++ b/Specs/Scene/I3SLayerSpec.js
@@ -85,7 +85,7 @@ describe("Scene/I3SLayer", function () {
       rootIndex: 0,
     },
     attributeStorageInfo: [],
-    store: { defaultGeometrySchema: {} },
+    store: { defaultGeometrySchema: {}, version: "1.7" },
     geometryDefinitions: geometryDefinitions,
     fullExtent: { xmin: 0, ymin: 1, xmax: 2, ymax: 3 },
     spatialReference: { wkid: 4326 },
@@ -97,7 +97,7 @@ describe("Scene/I3SLayer", function () {
       rootIndex: 0,
     },
     attributeStorageInfo: [],
-    store: { defaultGeometrySchema: {}, extent: [0, 1, 2, 3] },
+    store: { defaultGeometrySchema: {}, extent: [0, 1, 2, 3], version: "1.7" },
     spatialReference: { wkid: 4326 },
   };
 
@@ -116,6 +116,11 @@ describe("Scene/I3SLayer", function () {
 
     expect(testLayer.resource.url).toContain("mockProviderUrl/mockLayerUrl/");
     expect(testLayer.resource.queryParameters.testQuery).toEqual("test");
+
+    expect(testLayer.version).toEqual("1.7");
+    expect(testLayer.majorVersion).toEqual(1);
+    expect(testLayer.minorVersion).toEqual(7);
+    expect(testLayer.legacyVersion16).toEqual(false);
 
     expect(testLayer.data).toEqual(layerData);
 
@@ -365,7 +370,11 @@ describe("Scene/I3SLayer", function () {
         nodesPerPage: 2,
         rootIndex: 0,
       },
-      store: { defaultGeometrySchema: {}, extent: [0, 1, 2, 3] },
+      store: {
+        defaultGeometrySchema: {},
+        extent: [0, 1, 2, 3],
+        version: "1.7",
+      },
       spatialReference: { wkid: 3857 },
     };
     const mockI3SProvider = createMockI3SProvider();


### PR DESCRIPTION
- Added a new function, getFieldsForFeature on I3SNode
- Removed _loadFeatureData call in _createContentURL when the I3S version is 1.7 or higher (obsolete)
- Fixed an issue loading some newer I3S datasets where the feature data uri was different than “feature/0”