### PR TITLE
Removes copyright header from ThirdParty/Workers

### DIFF
--- a/build.js
+++ b/build.js
@@ -357,9 +357,6 @@ export async function bundleCombinedWorkers(options) {
   esBuildConfig.entryPoints = workers;
   esBuildConfig.outdir = options.path;
   esBuildConfig.minify = options.minify;
-  esBuildConfig.banner = {
-    js: combinedCopyrightHeader,
-  };
 
   await esbuild.build(esBuildConfig);
 


### PR DESCRIPTION
This PR ensures that the copyright banner from `Source/copyrightHeader.js` is not added to the workers from `ThirdParty`.