### PR TITLE
Differentiate workspace APIs in ref docs

### DIFF
--- a/Tools/jsdoc/cesium_template/static/styles/jsdoc-default.css
+++ b/Tools/jsdoc/cesium_template/static/styles/jsdoc-default.css
@@ -27,7 +27,7 @@ code {
   font-size: 12px;
 }
 
-#ClassList > li {
+#ClassList > ul > li {
   font-family: Consolas, "Liberation Mono", Menlo, "Courier New", Courier,
     Monaco, monospace;
   word-break: break-all;
@@ -297,6 +297,13 @@ div.nav h3 {
 div.nav li {
   margin-top: 6px;
   list-style-type: none;
+}
+
+div.nav h5 {
+  font-family: Consolas, "Liberation Mono", Menlo, "Courier New", Courier,
+    Monaco, monospace;
+  margin-top: 12px;
+  border-bottom: 1px solid #ccc;
 }
 
 nav a {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -415,7 +415,10 @@ export function buildDocs() {
     `npx jsdoc --configure Tools/jsdoc/conf.json --pedantic ${generatePrivateDocumentation}`,
     {
       stdio: "inherit",
-      env: Object.assign({}, process.env, { CESIUM_VERSION: version }),
+      env: Object.assign({}, process.env, {
+        CESIUM_VERSION: version,
+        CESIUM_PACKAGES: packageJson.workspaces,
+      }),
     }
   );
 


### PR DESCRIPTION
As a follow up from https://github.com/CesiumGS/cesium/pull/10824, this updates the doc generation process such that the list of classes is broken up based on the workspaces.

![image](https://user-images.githubusercontent.com/4439461/199329012-7ad28995-cb31-4a57-885f-9da3406e857e.png)

![image](https://user-images.githubusercontent.com/4439461/199329098-7f478830-1a67-422e-a091-84d60ef855d3.png)

![image](https://user-images.githubusercontent.com/4439461/199329193-d5efd605-c5be-46e0-abab-ef9b4024c214.png)

If we think it's warranted, I can also add a tag to to individual item pages. But it might be enough to list the path.