### PR TITLE
Document Context options

### DIFF
--- a/packages/engine/Source/Renderer/Context.js
+++ b/packages/engine/Source/Renderer/Context.js
@@ -30,187 +30,6 @@ import TextureCache from "./TextureCache.js";
 import UniformState from "./UniformState.js";
 import VertexArray from "./VertexArray.js";
 
-function errorToString(gl, error) {
-  let message = "WebGL Error:  ";
-  switch (error) {
-    case gl.INVALID_ENUM:
-      message += "INVALID_ENUM";
-      break;
-    case gl.INVALID_VALUE:
-      message += "INVALID_VALUE";
-      break;
-    case gl.INVALID_OPERATION:
-      message += "INVALID_OPERATION";
-      break;
-    case gl.OUT_OF_MEMORY:
-      message += "OUT_OF_MEMORY";
-      break;
-    case gl.CONTEXT_LOST_WEBGL:
-      message += "CONTEXT_LOST_WEBGL lost";
-      break;
-    default:
-      message += `Unknown (${error})`;
-  }
-
-  return message;
-}
-
-function createErrorMessage(gl, glFunc, glFuncArguments, error) {
-  let message = `${errorToString(gl, error)}: ${glFunc.name}(`;
-
-  for (let i = 0; i < glFuncArguments.length; ++i) {
-    if (i !== 0) {
-      message += ", ";
-    }
-    message += glFuncArguments[i];
-  }
-  message += ");";
-
-  return message;
-}
-
-function throwOnError(gl, glFunc, glFuncArguments) {
-  const error = gl.getError();
-  if (error !== gl.NO_ERROR) {
-    throw new RuntimeError(
-      createErrorMessage(gl, glFunc, glFuncArguments, error)
-    );
-  }
-}
-
-function makeGetterSetter(gl, propertyName, logFunction) {
-  return {
-    get: function () {
-      const value = gl[propertyName];
-      logFunction(gl, `get: ${propertyName}`, value);
-      return gl[propertyName];
-    },
-    set: function (value) {
-      gl[propertyName] = value;
-      logFunction(gl, `set: ${propertyName}`, value);
-    },
-  };
-}
-
-function wrapGL(gl, logFunction) {
-  if (!defined(logFunction)) {
-    return gl;
-  }
-
-  function wrapFunction(property) {
-    return function () {
-      const result = property.apply(gl, arguments);
-      logFunction(gl, property, arguments);
-      return result;
-    };
-  }
-
-  const glWrapper = {};
-
-  // JavaScript linters normally demand that a for..in loop must directly contain an if,
-  // but in our loop below, we actually intend to iterate all properties, including
-  // those in the prototype.
-  /*eslint-disable guard-for-in*/
-  for (const propertyName in gl) {
-    const property = gl[propertyName];
-
-    // wrap any functions we encounter, otherwise just copy the property to the wrapper.
-    if (property instanceof Function) {
-      glWrapper[propertyName] = wrapFunction(property);
-    } else {
-      Object.defineProperty(
-        glWrapper,
-        propertyName,
-        makeGetterSetter(gl, propertyName, logFunction)
-      );
-    }
-  }
-  /*eslint-enable guard-for-in*/
-
-  return glWrapper;
-}
-
-function getExtension(gl, names) {
-  const length = names.length;
-  for (let i = 0; i < length; ++i) {
-    const extension = gl.getExtension(names[i]);
-    if (extension) {
-      return extension;
-    }
-  }
-
-  return undefined;
-}
-
-/**
- * @typedef {Object} WebGLOptions
- *
- * WebGL options to be passed on to HTMLCanvasElement.getContext().
- * See {@link https://registry.khronos.org/webgl/specs/latest/1.0/#5.2|WebGLContextAttributes}
- * but note the modified defaults for 'alpha', 'stencil', and 'powerPreference'
- *
- * <p>
- * <code>alpha</code> defaults to false, which can improve performance
- * compared to the standard WebGL default of true.  If an application needs
- * to composite Cesium above other HTML elements using alpha-blending, set
- * <code>alpha</code> to true.
- * </p>
- *
- * @property {Boolean} [alpha=false]
- * @property {Boolean} [depth=true]
- * @property {Boolean} [stencil=false]
- * @property {Boolean} [antialias=true]
- * @property {Boolean} [premultipliedAlpha=true]
- * @property {Boolean} [preserveDrawingBuffer=false]
- * @property {("default"|"low-power"|"high-performance")} [powerPreference="high-performance"]
- * @property {Boolean} [failIfMajorPerformanceCaveat=false]
- */
-
-/**
- * @private
- * @param {HTMLCanvasElement} canvas The canvas element to which the context will be associated
- * @param {WebGLOptions} webglOptions WebGL options to be passed on to HTMLCanvasElement.getContext()
- * @param {Boolean} requestWebgl2 Whether to request a WebGL2RenderingContext
- * @returns {WebGLRenderingContext|WebGL2RenderingContext}
- */
-function getWebGLContext(canvas, webglOptions, requestWebgl2) {
-  if (typeof WebGLRenderingContext === "undefined") {
-    throw new RuntimeError(
-      "The browser does not support WebGL.  Visit http://get.webgl.org."
-    );
-  }
-
-  requestWebgl2 =
-    requestWebgl2 && typeof WebGL2RenderingContext !== "undefined";
-  const contextType = requestWebgl2 ? "webgl2" : "webgl";
-  const glContext = canvas.getContext(contextType, webglOptions);
-
-  if (!defined(glContext)) {
-    throw new RuntimeError(
-      "The browser supports WebGL, but initialization failed."
-    );
-  }
-
-  return glContext;
-}
-
-/**
- * @typedef {Object} ContextOptions
- *
- * Options to control the setting up of a WebGL Context.
- * <p>
- * <code>allowTextureFilterAnisotropic</code> defaults to true, which enables
- * anisotropic texture filtering when the WebGL extension is supported.
- * Setting this to false will improve performance, but hurt visual quality,
- * especially for horizon views.
- * </p>
- *
- * @property {Boolean} [requestWebGl2 = false] If true and the browser supports it, use a WebGL 2 rendering context
- * @property {Boolean} [allowTextureFilterAnisotropic=true] If true, use anisotropic filtering during texture sampling
- * @property {WebGLOptions} [webgl] WebGL options to be passed on to canvas.getContext
- * @property {Function} [getWebGLStub] A function to create a WebGL stub for testing
- */
-
 /**
  * @private
  * @constructor
@@ -565,6 +384,187 @@ function Context(canvas, options) {
   this.cache = {};
 
   RenderState.apply(gl, rs, ps);
+}
+
+/**
+ * @typedef {Object} ContextOptions
+ *
+ * Options to control the setting up of a WebGL Context.
+ * <p>
+ * <code>allowTextureFilterAnisotropic</code> defaults to true, which enables
+ * anisotropic texture filtering when the WebGL extension is supported.
+ * Setting this to false will improve performance, but hurt visual quality,
+ * especially for horizon views.
+ * </p>
+ *
+ * @property {Boolean} [requestWebGl2 = false] If true and the browser supports it, use a WebGL 2 rendering context
+ * @property {Boolean} [allowTextureFilterAnisotropic=true] If true, use anisotropic filtering during texture sampling
+ * @property {WebGLOptions} [webgl] WebGL options to be passed on to canvas.getContext
+ * @property {Function} [getWebGLStub] A function to create a WebGL stub for testing
+ */
+
+/**
+ * @private
+ * @param {HTMLCanvasElement} canvas The canvas element to which the context will be associated
+ * @param {WebGLOptions} webglOptions WebGL options to be passed on to HTMLCanvasElement.getContext()
+ * @param {Boolean} requestWebgl2 Whether to request a WebGL2RenderingContext
+ * @returns {WebGLRenderingContext|WebGL2RenderingContext}
+ */
+function getWebGLContext(canvas, webglOptions, requestWebgl2) {
+  if (typeof WebGLRenderingContext === "undefined") {
+    throw new RuntimeError(
+      "The browser does not support WebGL.  Visit http://get.webgl.org."
+    );
+  }
+
+  requestWebgl2 =
+    requestWebgl2 && typeof WebGL2RenderingContext !== "undefined";
+  const contextType = requestWebgl2 ? "webgl2" : "webgl";
+  const glContext = canvas.getContext(contextType, webglOptions);
+
+  if (!defined(glContext)) {
+    throw new RuntimeError(
+      "The browser supports WebGL, but initialization failed."
+    );
+  }
+
+  return glContext;
+}
+
+/**
+ * @typedef {Object} WebGLOptions
+ *
+ * WebGL options to be passed on to HTMLCanvasElement.getContext().
+ * See {@link https://registry.khronos.org/webgl/specs/latest/1.0/#5.2|WebGLContextAttributes}
+ * but note the modified defaults for 'alpha', 'stencil', and 'powerPreference'
+ *
+ * <p>
+ * <code>alpha</code> defaults to false, which can improve performance
+ * compared to the standard WebGL default of true.  If an application needs
+ * to composite Cesium above other HTML elements using alpha-blending, set
+ * <code>alpha</code> to true.
+ * </p>
+ *
+ * @property {Boolean} [alpha=false]
+ * @property {Boolean} [depth=true]
+ * @property {Boolean} [stencil=false]
+ * @property {Boolean} [antialias=true]
+ * @property {Boolean} [premultipliedAlpha=true]
+ * @property {Boolean} [preserveDrawingBuffer=false]
+ * @property {("default"|"low-power"|"high-performance")} [powerPreference="high-performance"]
+ * @property {Boolean} [failIfMajorPerformanceCaveat=false]
+ */
+
+function errorToString(gl, error) {
+  let message = "WebGL Error:  ";
+  switch (error) {
+    case gl.INVALID_ENUM:
+      message += "INVALID_ENUM";
+      break;
+    case gl.INVALID_VALUE:
+      message += "INVALID_VALUE";
+      break;
+    case gl.INVALID_OPERATION:
+      message += "INVALID_OPERATION";
+      break;
+    case gl.OUT_OF_MEMORY:
+      message += "OUT_OF_MEMORY";
+      break;
+    case gl.CONTEXT_LOST_WEBGL:
+      message += "CONTEXT_LOST_WEBGL lost";
+      break;
+    default:
+      message += `Unknown (${error})`;
+  }
+
+  return message;
+}
+
+function createErrorMessage(gl, glFunc, glFuncArguments, error) {
+  let message = `${errorToString(gl, error)}: ${glFunc.name}(`;
+
+  for (let i = 0; i < glFuncArguments.length; ++i) {
+    if (i !== 0) {
+      message += ", ";
+    }
+    message += glFuncArguments[i];
+  }
+  message += ");";
+
+  return message;
+}
+
+function throwOnError(gl, glFunc, glFuncArguments) {
+  const error = gl.getError();
+  if (error !== gl.NO_ERROR) {
+    throw new RuntimeError(
+      createErrorMessage(gl, glFunc, glFuncArguments, error)
+    );
+  }
+}
+
+function makeGetterSetter(gl, propertyName, logFunction) {
+  return {
+    get: function () {
+      const value = gl[propertyName];
+      logFunction(gl, `get: ${propertyName}`, value);
+      return gl[propertyName];
+    },
+    set: function (value) {
+      gl[propertyName] = value;
+      logFunction(gl, `set: ${propertyName}`, value);
+    },
+  };
+}
+
+function wrapGL(gl, logFunction) {
+  if (!defined(logFunction)) {
+    return gl;
+  }
+
+  function wrapFunction(property) {
+    return function () {
+      const result = property.apply(gl, arguments);
+      logFunction(gl, property, arguments);
+      return result;
+    };
+  }
+
+  const glWrapper = {};
+
+  // JavaScript linters normally demand that a for..in loop must directly contain an if,
+  // but in our loop below, we actually intend to iterate all properties, including
+  // those in the prototype.
+  /*eslint-disable guard-for-in*/
+  for (const propertyName in gl) {
+    const property = gl[propertyName];
+
+    // wrap any functions we encounter, otherwise just copy the property to the wrapper.
+    if (property instanceof Function) {
+      glWrapper[propertyName] = wrapFunction(property);
+    } else {
+      Object.defineProperty(
+        glWrapper,
+        propertyName,
+        makeGetterSetter(gl, propertyName, logFunction)
+      );
+    }
+  }
+  /*eslint-enable guard-for-in*/
+
+  return glWrapper;
+}
+
+function getExtension(gl, names) {
+  const length = names.length;
+  for (let i = 0; i < length; ++i) {
+    const extension = gl.getExtension(names[i]);
+    if (extension) {
+      return extension;
+    }
+  }
+
+  return undefined;
 }
 
 const defaultFramebufferMarker = {};

--- a/packages/engine/Source/Scene/Scene.js
+++ b/packages/engine/Source/Scene/Scene.js
@@ -81,50 +81,13 @@ const requestRenderAfterFrame = function (scene) {
 /**
  * The container for all 3D graphical objects and state in a Cesium virtual scene.  Generally,
  * a scene is not created directly; instead, it is implicitly created by {@link CesiumWidget}.
- * <p>
- * <em><code>contextOptions</code> parameter details:</em>
- * </p>
- * <p>
- * The default values are:
- * <code>
- * {
- *   webgl : {
- *     alpha : false,
- *     depth : true,
- *     stencil : false,
- *     antialias : true,
- *     powerPreference: 'high-performance',
- *     premultipliedAlpha : true,
- *     preserveDrawingBuffer : false,
- *     failIfMajorPerformanceCaveat : false
- *   },
- *   allowTextureFilterAnisotropic : true
- * }
- * </code>
- * </p>
- * <p>
- * The <code>webgl</code> property corresponds to the {@link http://www.khronos.org/registry/webgl/specs/latest/#5.2|WebGLContextAttributes}
- * object used to create the WebGL context.
- * </p>
- * <p>
- * <code>webgl.alpha</code> defaults to false, which can improve performance compared to the standard WebGL default
- * of true.  If an application needs to composite Cesium above other HTML elements using alpha-blending, set
- * <code>webgl.alpha</code> to true.
- * </p>
- * <p>
- * The other <code>webgl</code> properties match the WebGL defaults for {@link http://www.khronos.org/registry/webgl/specs/latest/#5.2|WebGLContextAttributes}.
- * </p>
- * <p>
- * <code>allowTextureFilterAnisotropic</code> defaults to true, which enables anisotropic texture filtering when the
- * WebGL extension is supported.  Setting this to false will improve performance, but hurt visual quality, especially for horizon views.
- * </p>
  *
  * @alias Scene
  * @constructor
  *
  * @param {Object} options Object with the following properties:
  * @param {HTMLCanvasElement} options.canvas The HTML canvas element to create the scene for.
- * @param {Object} [options.contextOptions] Context and WebGL creation properties.  See details above.
+ * @param {ContextOptions} [options.contextOptions] Context and WebGL creation properties.
  * @param {Element} [options.creditContainer] The HTML element in which the credits will be displayed.
  * @param {Element} [options.creditViewport] The HTML element in which to display the credit popup.  If not specified, the viewport will be a added as a sibling of the canvas.
  * @param {MapProjection} [options.mapProjection=new GeographicProjection()] The map projection to use in 2D and Columbus View modes.
@@ -134,7 +97,7 @@ const requestRenderAfterFrame = function (scene) {
  * @param {MapMode2D} [options.mapMode2D=MapMode2D.INFINITE_SCROLL] Determines if the 2D map is rotatable or can be scrolled infinitely in the horizontal direction.
  * @param {Boolean} [options.requestRenderMode=false] If true, rendering a frame will only occur when needed as determined by changes within the scene. Enabling improves performance of the application, but requires using {@link Scene#requestRender} to render a new frame explicitly in this mode. This will be necessary in many cases after making changes to the scene in other parts of the API. See {@link https://cesium.com/blog/2018/01/24/cesium-scene-rendering-performance/|Improving Performance with Explicit Rendering}.
  * @param {Number} [options.maximumRenderTimeChange=0.0] If requestRenderMode is true, this value defines the maximum change in simulation time allowed before a render is requested. See {@link https://cesium.com/blog/2018/01/24/cesium-scene-rendering-performance/|Improving Performance with Explicit Rendering}.
- * @param {Number} [depthPlaneEllipsoidOffset=0.0] Adjust the DepthPlane to address rendering artefacts below ellipsoid zero elevation.
+ * @param {Number} [options.depthPlaneEllipsoidOffset=0.0] Adjust the DepthPlane to address rendering artefacts below ellipsoid zero elevation.
  * @param {Number} [options.msaaSamples=1] If provided, this value controls the rate of multisample antialiasing. Typical multisampling rates are 2, 4, and sometimes 8 samples per pixel. Higher sampling rates of MSAA may impact performance in exchange for improved visual quality. This value only applies to WebGL2 contexts that support multisample render targets.
  *
  * @see CesiumWidget
@@ -157,17 +120,7 @@ function Scene(options) {
   let creditContainer = options.creditContainer;
   let creditViewport = options.creditViewport;
 
-  let contextOptions = clone(options.contextOptions);
-  if (!defined(contextOptions)) {
-    contextOptions = {};
-  }
-  if (!defined(contextOptions.webgl)) {
-    contextOptions.webgl = {};
-  }
-  contextOptions.webgl.powerPreference = defaultValue(
-    contextOptions.webgl.powerPreference,
-    "high-performance"
-  );
+  const contextOptions = clone(options.contextOptions);
 
   //>>includeStart('debug', pragmas.debug);
   if (!defined(canvas)) {

--- a/packages/engine/Source/Widget/CesiumWidget.js
+++ b/packages/engine/Source/Widget/CesiumWidget.js
@@ -136,7 +136,7 @@ function configureCameraFrustum(widget) {
  * @param {Boolean} [options.useBrowserRecommendedResolution=true] If true, render at the browser's recommended resolution and ignore <code>window.devicePixelRatio</code>.
  * @param {Number} [options.targetFrameRate] The target frame rate when using the default render loop.
  * @param {Boolean} [options.showRenderLoopErrors=true] If true, this widget will automatically display an HTML panel to the user containing the error, if a render loop error occurs.
- * @param {Object} [options.contextOptions] Context and WebGL creation properties corresponding to <code>options</code> passed to {@link Scene}.
+ * @param {ContextOptions} [options.contextOptions] Context and WebGL creation properties passed to {@link Scene}.
  * @param {Element|String} [options.creditContainer] The DOM element or ID that will contain the {@link CreditDisplay}.  If not specified, the credits are added
  *        to the bottom of the widget itself.
  * @param {Element|String} [options.creditViewport] The DOM element or ID that will contain the credit pop up created by the {@link CreditDisplay}.  If not specified, it will appear over the widget itself.

--- a/packages/widgets/Source/Viewer/Viewer.js
+++ b/packages/widgets/Source/Viewer/Viewer.js
@@ -322,7 +322,7 @@ function enableVRUI(viewer, enabled) {
  * @property {Boolean} [showRenderLoopErrors=true] If true, this widget will automatically display an HTML panel to the user containing the error, if a render loop error occurs.
  * @property {Boolean} [useBrowserRecommendedResolution=true] If true, render at the browser's recommended resolution and ignore <code>window.devicePixelRatio</code>.
  * @property {Boolean} [automaticallyTrackDataSourceClocks=true] If true, this widget will automatically track the clock settings of newly added DataSources, updating if the DataSource's clock changes.  Set this to false if you want to configure the clock independently.
- * @property {Object} [contextOptions] Context and WebGL creation properties corresponding to <code>options</code> passed to {@link Scene}.
+ * @property {ContextOptions} [contextOptions] Context and WebGL creation properties passed to {@link Scene}.
  * @property {SceneMode} [sceneMode=SceneMode.SCENE3D] The initial scene mode.
  * @property {MapProjection} [mapProjection=new GeographicProjection()] The map projection to use in 2D and Columbus View modes.
  * @property {Globe|false} [globe=new Globe(mapProjection.ellipsoid)] The globe to use in the scene.  If set to <code>false</code>, no globe will be added.


### PR DESCRIPTION
Fixes #10562, by adding two public types: `ContextOptions` and `WebGLOptions`.

To make the documentation easier, I did some minor code cleanup along the way:

- Refactor `Context` to make it more obvious how the options object is used
- Put `Context` constructor at the top of the file, as recommended in the [coding guide](https://github.com/CesiumGS/cesium/blob/main/Documentation/Contributors/CodingGuide/README.md#put-the-constructor-function-at-the-top-of-the-file)
- Clean up duplicated handling of defaults in `Scene` and `Context`