### PR TITLE
Use Travis build stages to parallelize CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,18 @@ notifications:
     secure: JKzk2sJSbZ9h2PUVWj6KtOAdFbEEnOtv/VZy05pJ2H41xRgUHiGdtMW/vMSeq6XX3IJN8eW2zd0cJTgkFn0ioAlYvID8zRhcvkFHg60QXquoqtp5y65dxjtVz79hefxSo7FO1NhMZBQWE9Tg6R7XkoyTMth62+T9vqOgu2Hms6M=
     if: (branch = main) AND (type = push)
     on_success: change # default: always
+before_script: pip install awscli --user
 jobs:
   include:
     - stage:
-      name: "Linting, Coverage, Deployment"
+      name: "Coverage"
+      script:
+        - npm --silent run build -- --node
+        - npm --silent run coverage -- --browsers FirefoxHeadless --webgl-stub --failTaskOnError --suppressPassed
+        - aws s3 sync ./Build/Coverage s3://cesium-dev/cesium/$TRAVIS_BRANCH/Build/Coverage --delete --color on
+    - name: "Release Tests"
+      script: ./travis/test-release.sh
+    - name: "Linting, Deployment"
       script:
         - ./travis/prepare.sh
         - npm --silent run deploy-status -- --status pending --message 'Waiting for build'
@@ -21,6 +29,3 @@ jobs:
         - npm --silent run prettier-check
         - ./travis/release.sh
         - ./travis/deploy.sh
-    - name: "Release Tests"
-      script: ./travis/test-release.sh
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
     - stage:
       name: "Coverage"
       script:
-        - npm --silent run build -- --node
+        - npm --silent run build
         - npm --silent run coverage -- --browsers FirefoxHeadless --webgl-stub --failTaskOnError --suppressPassed
         - aws s3 sync ./Build/Coverage s3://cesium-dev/cesium/$TRAVIS_BRANCH/Build/Coverage --delete --color on
     - name: "Release Tests"

--- a/travis/release.sh
+++ b/travis/release.sh
@@ -4,7 +4,6 @@ if [ $TRAVIS_BRANCH == "cesium.com" ]; then
   npm --silent run website-release
 else
   npm --silent run build -- --node
-  npm --silent run coverage -- --browsers FirefoxHeadless --webgl-stub --failTaskOnError --suppressPassed
   npm --silent run make-zip
   npm pack &> /dev/null
 fi


### PR DESCRIPTION
[Travis Build Stages](https://docs.travis-ci.com/user/build-stages/) allow running independent CI tasks in parallel. Our traditional CI setup involved running several very time consuming tasks serially, when that is not necessary.

The primary idea here is to run the following tasks in parallel:

1. Coverage: Runs the `coverage` task, which runs all tests and deploys the coverage report
2. Release Tests: Runs all tests with the `release` flag
3. Linting and Deployment: Runs `make-zip` (which runs `build-ts` that takes a lot of time) and deploys to S3

Overall, this **cuts the CI run time by half** from [around 14 minutes](https://app.travis-ci.com/github/CesiumGS/cesium/builds/256768365) to [around 7 minutes](https://github.com/CesiumGS/cesium/runs/9236003858).