### PR TITLE
Node 18 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "16"
+  - "18"
 addons:
   chrome: stable
   firefox: latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,10 @@ jobs:
         - aws s3 sync ./Build/Coverage s3://cesium-dev/cesium/$TRAVIS_BRANCH/Build/Coverage --delete --color on
     - name: "Release Tests"
       node_js: "18"
-      script: ./travis/test-release.sh
+      script: 
+        - ./travis/test-release.sh
+        - ./travis/verify.sh
+        - npm --silent run cloc
     - name: "Linting, Deployment"
       node_js: "18"
       script:
@@ -31,8 +34,6 @@ jobs:
         - npm --silent run prettier-check
         - ./travis/release.sh
         - ./travis/deploy.sh
-        - ./travis/verify.sh
-        - npm --silent run cloc
     - name: "NodeJS 16"
       node_js: "16"
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "18"
+dist: focal # Workaround for NodeJS 18 - https://travis-ci.community/t/the-command-npm-config-set-spin-false-failed-and-exited-with-1-during/12909/7
 addons:
   chrome: stable
   firefox: latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: node_js
-node_js:
-  - "18"
 dist: focal # Workaround for NodeJS 18 - https://travis-ci.community/t/the-command-npm-config-set-spin-false-failed-and-exited-with-1-during/12909/7
 addons:
   chrome: stable
@@ -15,13 +13,16 @@ jobs:
   include:
     - stage:
       name: "Coverage"
+      node_js: "18"
       script:
         - npm --silent run build
         - npm --silent run coverage -- --browsers FirefoxHeadless --webgl-stub --failTaskOnError --suppressPassed
         - aws s3 sync ./Build/Coverage s3://cesium-dev/cesium/$TRAVIS_BRANCH/Build/Coverage --delete --color on
     - name: "Release Tests"
+      node_js: "18"
       script: ./travis/test-release.sh
     - name: "Linting, Deployment"
+      node_js: "18"
       script:
         - ./travis/prepare.sh
         - npm --silent run deploy-status -- --status pending --message 'Waiting for build'
@@ -30,3 +31,10 @@ jobs:
         - npm --silent run prettier-check
         - ./travis/release.sh
         - ./travis/deploy.sh
+        - ./travis/verify.sh
+        - npm --silent run cloc
+    - name: "NodeJS 16"
+      node_js: "16"
+      script:
+        - npm --silent run build-release
+        - ./travis/verify.sh

--- a/travis/release.sh
+++ b/travis/release.sh
@@ -3,7 +3,6 @@ set -ev
 if [ $TRAVIS_BRANCH == "cesium.com" ]; then
   npm --silent run website-release
 else
-  npm --silent run build -- --node
   npm --silent run make-zip
   npm pack &> /dev/null
 fi

--- a/travis/verify.sh
+++ b/travis/verify.sh
@@ -9,6 +9,4 @@ if [ $TRAVIS_BRANCH != "cesium.com" ]; then
 
   node packages/engine/Specs/test.mjs
   node packages/widgets/Specs/test.mjs
-
-  npm --silent run cloc
 fi


### PR DESCRIPTION
This updates CI to run on the latest NodeJS LTS - 18.

Note there is a workaround needed to allow Travis to run NodeJS 18 on Linux - https://travis-ci.community/t/the-command-npm-config-set-spin-false-failed-and-exited-with-1-during/12909/7

This also adds an additional job which runs in parallel which builds and runs smoke screens on Node 16.

I did tweak the existing jobs a bit, as I noticed the verify script was not being run, and that there was an additional call to the `build` task in the `release` script which should not be needed.