### PR TITLE
Minor argument type fixes in JSDoc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 1.100 - 2022-12-01
+
+##### Fixes :wrench:
+
+- Fixed the JSDoc and TypeScript definitions of arguments in `Matrix2.multiplyByScalar`, `Matrix3.multiplyByScalar`, and several functions in the `S2Cell` class. [#10899](https://github.com/CesiumGS/cesium/pull/10899)
+
 ### 1.99 - 2022-11-01
 
 #### Major Announcements :loudspeaker:

--- a/packages/engine/Source/Core/Matrix2.js
+++ b/packages/engine/Source/Core/Matrix2.js
@@ -782,7 +782,7 @@ Matrix2.multiplyByScalar = function (matrix, scalar, result) {
  * Computes the product of a matrix times a (non-uniform) scale, as if the scale were a scale matrix.
  *
  * @param {Matrix2} matrix The matrix on the left-hand side.
- * @param {Number} scale The non-uniform scale on the right-hand side.
+ * @param {Cartesian2} scale The non-uniform scale on the right-hand side.
  * @param {Matrix2} result The object onto which to store the result.
  * @returns {Matrix2} The modified result parameter.
  *

--- a/packages/engine/Source/Core/Matrix3.js
+++ b/packages/engine/Source/Core/Matrix3.js
@@ -1193,7 +1193,7 @@ Matrix3.multiplyByScalar = function (matrix, scalar, result) {
  * Computes the product of a matrix times a (non-uniform) scale, as if the scale were a scale matrix.
  *
  * @param {Matrix3} matrix The matrix on the left-hand side.
- * @param {Number} scale The non-uniform scale on the right-hand side.
+ * @param {Cartesian3} scale The non-uniform scale on the right-hand side.
  * @param {Matrix3} result The object onto which to store the result.
  * @returns {Matrix3} The modified result parameter.
  *

--- a/packages/engine/Source/Core/S2Cell.js
+++ b/packages/engine/Source/Core/S2Cell.js
@@ -264,7 +264,7 @@ S2Cell.getIdFromToken = function (token) {
  * Converts a 64-bit S2 cell ID to an S2 cell token.
  *
  * @param {BigInt} [cellId] The S2 cell ID.
- * @returns {BigInt} Returns hexadecimal representation of an S2CellId.
+ * @returns {string} Returns hexadecimal representation of an S2CellId.
  * @private
  */
 S2Cell.getTokenFromId = function (cellId) {
@@ -378,7 +378,7 @@ S2Cell.prototype.getParentAtLevel = function (level) {
  * Get center of the S2 cell.
  *
  * @param {Ellipsoid} [options.ellipsoid=Ellipsoid.WGS84] The ellipsoid.
- * @returns {Cartesian} The position of center of the S2 cell.
+ * @returns {Cartesian3} The position of center of the S2 cell.
  * @private
  */
 S2Cell.prototype.getCenter = function (ellipsoid) {
@@ -400,7 +400,7 @@ S2Cell.prototype.getCenter = function (ellipsoid) {
  *
  * @param {Number} index An integer index of the vertex. Must be in the range [0-3].
  * @param {Ellipsoid} [options.ellipsoid=Ellipsoid.WGS84] The ellipsoid.
- * @returns {Cartesian} The position of the vertex of the S2 cell.
+ * @returns {Cartesian3} The position of the vertex of the S2 cell.
  * @private
  */
 S2Cell.prototype.getVertex = function (index, ellipsoid) {


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/10801 (which I had kept open in a tab for ~2 months now...)

I assume that there are (potentially many) similar issues like that, with different levels of severity

- types that are plainly wrong
- types that are not found
- types that are capitalized wrong (e.g. `{Number}` instead of `{number}` - whatever is "right" there, it's certainly not _consistent_ right now - see https://jsdoc.app/tags-type.html )

In order to find them, one should use a dedicated tool (maybe one of the tools that have once been used in the first experiments for generating TypeScript bindings?). 

But these are the ones that I noticed in the issue. 