### PR TITLE
Fixes incremental builds and watch scripts

### DIFF
--- a/build.js
+++ b/build.js
@@ -119,7 +119,6 @@ export const defaultESBuildOptions = () => {
     bundle: true,
     color: true,
     legalComments: `inline`,
-    logLevel: `info`,
     logLimit: 0,
     target: `es2020`,
   };
@@ -177,7 +176,7 @@ export async function bundleCesiumJs(options) {
     js: combinedCopyrightHeader,
   };
   // print errors immediately, and collect warnings so we can filter out known ones
-  buildConfig.logLevel = "error";
+  buildConfig.logLevel = "info";
 
   const bundles = {};
 

--- a/server.js
+++ b/server.js
@@ -43,15 +43,17 @@ import {
 } from "./build.js";
 
 const sourceFiles = [
-  "Source/**/*.js",
-  "!Source/*.js",
-  "!Source/Shaders/**",
-  "!Source/Workers/**",
-  "!Source/WorkersES6/**",
-  "Source/WorkersES6/createTaskProcessorWorker.js",
-  "!Source/ThirdParty/Workers/**",
-  "!Source/ThirdParty/google-earth-dbroot-parser.js",
-  "!Source/ThirdParty/_*",
+  "packages/engine/Source/**/*.js",
+  "!packages/engine/Source/*.js",
+  "packages/widgets/Source/**/*.js",
+  "!packages/widgets/Source/*.js",
+  "!packages/engine/Source/Shaders/**",
+  "!packages/engine/Source/Workers/**",
+  "!packages/engine/Source/WorkersES6/**",
+  "packages/engine/Source/WorkersES6/createTaskProcessorWorker.js",
+  "!packages/engine/Source/ThirdParty/Workers/**",
+  "!packages/engine/Source/ThirdParty/google-earth-dbroot-parser.js",
+  "!packages/engine/Source/ThirdParty/_*",
 ];
 const specFiles = [
   "packages/engine/Specs/**/*Spec.js",
@@ -62,8 +64,8 @@ const specFiles = [
   "!Specs/SpecList.js",
   "Specs/TestWorkers/*.js",
 ];
-const shaderFiles = ["Source/Shaders/**/*.glsl"];
-const workerSourceFiles = ["Source/WorkersES6/*.js"];
+const shaderFiles = ["packages/engine/Source/Shaders/**/*.glsl"];
+const workerSourceFiles = ["packages/engine/Source/WorkersES6/*.js"];
 
 const outputDirectory = path.join("Build", "CesiumDev");
 

--- a/server.js
+++ b/server.js
@@ -35,7 +35,7 @@ import {
   bundleWorkers,
   createCesiumJs,
   createJsHintOptions,
-  createSpecList,
+  createCombinedSpecList,
   glslToJavaScript,
   buildEngine,
   buildWidgets,
@@ -54,7 +54,10 @@ const sourceFiles = [
   "!Source/ThirdParty/_*",
 ];
 const specFiles = [
-  "Specs/**/*Spec.js",
+  "packages/engine/Specs/**/*Spec.js",
+  "!packages/engine/Specs/SpecList.js",
+  "packages/widgets/Specs/**/*Spec.js",
+  "!packages/widgets/Specs/SpecList.js",
   "Specs/*.js",
   "!Specs/SpecList.js",
   "Specs/TestWorkers/*.js",
@@ -357,7 +360,7 @@ const serveResult = (result, fileName, res, next) => {
   const specWatcher = chokidar.watch(specFiles, { ignoreInitial: true });
   specWatcher.on("all", async (event) => {
     if (event === "add" || event === "unlink") {
-      await createSpecList();
+      await createCombinedSpecList();
     }
 
     specResult.outputFiles = [];


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium/issues/10897

- Fixes an error in the `build-watch` command
- Fixes the incremental building of bundles/workers/shaders
- Reduces the noise in build output to only include the JS bundles that are generated