### PR TITLE
Fix point primitive scaling by distance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 1.100 - 2022-12-01
+
+##### Fixes :wrench:
+
+- Fixed a bug where the scale of a `PointPrimitive` was incorrect when `scaleByDistance` was set to a `NearFarScalar` [#10912](https://github.com/CesiumGS/cesium/pull/10912)
+
 ### 1.99 - 2022-11-01
 
 #### Major Announcements :loudspeaker:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,6 @@
     - `Widgets`(CSS files only)
   - The ability to import modules and TypeScript definitions from individual files has been removed. Any imports should originate from the `cesium` module (`import { Cartesian3 } from "cesium";`) or the combined `Cesium.js` file (`import { Cartesian3 } from "Source/Cesium.js";`);
 
-
 ### 1.99 - 2022-11-01
 
 #### Major Announcements :loudspeaker:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -338,3 +338,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Gabriel Aldous](https://github.com/Sn00pyW00dst0ck)
 - [金俊](https://github.com/jinjun1994)
 - [Oussama Bonnor](https://github.com/oussamabonnor1)
+- [Marcel Wendler](https://github.com/UniquePanda)

--- a/packages/engine/Source/Shaders/PointPrimitiveCollectionVS.glsl
+++ b/packages/engine/Source/Shaders/PointPrimitiveCollectionVS.glsl
@@ -28,8 +28,6 @@ void main()
     float outlinePercent = outlineWidthBothSides / totalSize;
     // Scale in response to browser-zoom.
     totalSize *= czm_pixelRatio;
-    // Add padding for anti-aliasing on both sides.
-    totalSize += 3.0;
 
     float temp = compressedAttribute1.x * SHIFT_RIGHT8;
     float show = floor(temp);
@@ -111,6 +109,9 @@ void main()
 #ifdef EYE_DISTANCE_SCALING
     totalSize *= czm_nearFarScalar(scaleByDistance, lengthSq);
 #endif
+    // Add padding for anti-aliasing on both sides.
+    totalSize += 3.0;
+
     // Clamp to max point size.
     totalSize = min(totalSize, u_maxTotalPointSize);
     // If size is too small, push vertex behind near plane for clipping.

--- a/packages/engine/Source/Shaders/PointPrimitiveCollectionVS.glsl
+++ b/packages/engine/Source/Shaders/PointPrimitiveCollectionVS.glsl
@@ -109,8 +109,10 @@ void main()
 #ifdef EYE_DISTANCE_SCALING
     totalSize *= czm_nearFarScalar(scaleByDistance, lengthSq);
 #endif
-    // Add padding for anti-aliasing on both sides.
-    totalSize += 3.0;
+    if (totalSize > 0.0) {
+        // Add padding for anti-aliasing on both sides.
+        totalSize += 3.0;
+    }
 
     // Clamp to max point size.
     totalSize = min(totalSize, u_maxTotalPointSize);


### PR DESCRIPTION
Fixes #10908 

The problem was, that the size of every point primitive was increased by 3 pixels in `PointPrimitiveCollectionVS.glsl` (for anti-aliasing purposes) before any other modification of the its size was done.  
This is now moved further done in the shader behind the multiplication with the "near far scalar" which is used for "scale by distance".

Previously the additional 3 pixels were also multiplied by the "near far scalar" which resulted in bigger point sizes than expected.
I am not 100% sure if this really was a bug or intentional. If this was intentional, I am happy to change this PR to only add a note about that to the documentation, if that's okay.

~~I also just realized that this change might be considered a breaking change, because it will affect all applications that currently render points which are scaled with a "near far scalar".~~ *(It's not breaking, see comments below)*

Here is a [local sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=bVDBbsIwDP0Vq6cidWkZQ2VQ0DTQTtN2QNqpF5MaZi1NUJLC2MS/L201CW3kEPk9v/diRxrtPByYjmRhDpqOsCTHTS3eOi4uI9nhpdEeWZMto8Gs1KXuPYK0Z8/kBFZV/F1qgL1xgTF6+pu0ROtDhXokttbUK9pZIhff5GMxvs/zPIG7TGSjyWQ0SPoA1n4KXVhA/ElqzV80hWGW9JyTqOjxtGLnUcvQuZj7hdA+oV0HCdp4mIWTtE64pXEo+ifO4T4PZlESFc6fFC36XIAHrvfGemisioVIPdV7hWH6dNPID/JCOteu30qL9NJaVHwAruZX/gukQudCZ9uobpMyWhRp0P+zKoMV693rgazCUyt7Hy6ee1IIUaQBXnd6Y9QG7Z/kHw) that demonstrates the issue.  
In the current main branch, the point has a size of about 130 pixels when zoomed in (measured with Microsoft PowerToys on screen ruler). Which is the initial size of 10 pixels + 3 pixels multiplied by 10 (near value of near far scalar).
With this PR the point size is about 100 pixels, which is the inital size of 10 pixels multiplied by 10.

Current main:
![image](https://user-images.githubusercontent.com/3686982/202702632-7335889a-274a-479d-a071-dd0aab835629.png)

With this PR:
![image](https://user-images.githubusercontent.com/3686982/202702866-8895fb6e-e417-4ea7-90d7-8d74523b93f2.png)
