### PR TITLE
Make sure build-third-party works with workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /Build
 /Cesium-*.zip
 /cesium-*.tgz
+/packages/**/*.tgz
 .directory
 .DS_Store
 Thumbs.db

--- a/.npmignore
+++ b/.npmignore
@@ -32,6 +32,7 @@
 /server.js
 /Source/copyrightHeader.js
 /Specs
+/travis
 /ThirdParty
 /Tools
 /web.config

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -311,6 +311,7 @@ const filesToClean = [
   "Apps/Sandcastle/templates/bucket.css",
   "Cesium-*.zip",
   "cesium-*.tgz",
+  "packages/**/*.tgz",
 ];
 
 export async function clean() {


### PR DESCRIPTION
* Make sure `build-third-party` works with newly added workspaces. Since dependencies were moved to the workspaces, this script now recursively checks `package.json` files for dependencies. This is broken in `main`, but in this branch running `build-third-party` should produce the same results as before.
* Omit the `travis` directory from the NodeJS package. This can be tested by running `npm pack`.
* Ignore/clean generated `.tgz` files from `npm pack`.