### PR TITLE
Fixes cloc command

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -329,7 +329,7 @@ async function clocSource() {
     cmdLine =
       "npx cloc" +
       " --quiet --progress-rate=0" +
-      " Source/ --exclude-dir=Assets,ThirdParty,Workers --not-match-f=copyrightHeader.js";
+      " packages/engine/Source/ packages/widgets/Source --exclude-dir=Assets,ThirdParty,Workers";
 
     exec(cmdLine, function (error, stdout, stderr) {
       if (error) {
@@ -346,7 +346,9 @@ async function clocSource() {
   await source;
   return new Promise(function (resolve, reject) {
     cmdLine =
-      "npx cloc" + " --quiet --progress-rate=0" + " Specs/ --exclude-dir=Data";
+      "npx cloc" +
+      " --quiet --progress-rate=0" +
+      " Specs/ packages/engine/Specs packages/widget/Specs --exclude-dir=Data --not-match-f=SpecList.js --not-match-f=.eslintrc.json";
     exec(cmdLine, function (error, stdout, stderr) {
       if (error) {
         console.log(stderr);


### PR DESCRIPTION
Fixes the paths provided to the `cloc` command.

Output from https://app.travis-ci.com/github/CesiumGS/cesium/jobs/589064765:

```
$ npm --silent run cloc
[15:03:19] Using gulpfile ~/build/CesiumGS/cesium/gulpfile.js
[15:03:19] Starting 'cloc'...
[15:03:19] Starting 'clean'...
[15:03:19] Finished 'clean' after 187 ms
[15:03:19] Starting 'clocSource'...
Source:
github.com/AlDanial/cloc v 1.94  T=0.98 s (1508.9 files/s, 371909.2 lines/s)
-------------------------------------------------------------------------------
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
JavaScript                    1177          33521          90586         226025
GLSL                           265           1445           2530           7452
CSS                             27            267             18           1591
SVG                              9             20              9            817
-------------------------------------------------------------------------------
SUM:                          1478          35253          93143         235885
-------------------------------------------------------------------------------
Specs:
github.com/AlDanial/cloc v 1.94  T=2.78 s (231.0 files/s, 112324.4 lines/s)
-------------------------------------------------------------------------------
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
JavaScript                     640          37483           6502         268270
TypeScript                       1             40              7            349
HTML                             1              2              0             25
JSON                             1              0              0             12
-------------------------------------------------------------------------------
SUM:                           643          37525           6509         268656
-------------------------------------------------------------------------------
[15:03:24] Finished 'clocSource' after 4.77 s
[15:03:24] Finished 'cloc' after 4.96 s
The command "npm --silent run cloc" exited with 0.
```