### PR TITLE
Remove unnecessary characters in sandcastle HTML

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -338,3 +338,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Gabriel Aldous](https://github.com/Sn00pyW00dst0ck)
 - [金俊](https://github.com/jinjun1994)
 - [Oussama Bonnor](https://github.com/oussamabonnor1)
+- [Marco Hutter](https://github.com/javagl)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2087,7 +2087,7 @@ function buildSandcastle() {
         gulpReplace(
           '    <script type="module" src="../load-cesium-es6.js"></script>',
           '    <script src="../../../Build/CesiumUnminified/Cesium.js"></script>\n' +
-            '    <script>window.CESIUM_BASE_URL = "../../../Build/CesiumUnminified/";</script>";'
+            '    <script>window.CESIUM_BASE_URL = "../../../Build/CesiumUnminified/"</script>'
         )
       )
       // Fix relative paths for new location

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2064,14 +2064,14 @@ function buildSandcastle() {
         gulpReplace(
           '    <script type="module" src="../load-cesium-es6.js"></script>',
           '    <script src="../CesiumUnminified/Cesium.js"></script>\n' +
-            '    <script>window.CESIUM_BASE_URL = "../CesiumUnminified/";</script>";'
+            '    <script>window.CESIUM_BASE_URL = "../CesiumUnminified/";</script>'
         )
       )
       .pipe(
         gulpReplace(
           '    <script type="module" src="load-cesium-es6.js"></script>',
           '    <script src="CesiumUnminified/Cesium.js"></script>\n' +
-            '    <script>window.CESIUM_BASE_URL = "CesiumUnminified/";</script>";'
+            '    <script>window.CESIUM_BASE_URL = "CesiumUnminified/";</script>'
         )
       )
       // Fix relative paths for new location
@@ -2094,7 +2094,7 @@ function buildSandcastle() {
         gulpReplace(
           '    <script type="module" src="../load-cesium-es6.js"></script>',
           '    <script src="../../../Build/CesiumUnminified/Cesium.js"></script>\n' +
-            '    <script>window.CESIUM_BASE_URL = "../../../Build/CesiumUnminified/"</script>'
+            '    <script>window.CESIUM_BASE_URL = "../../../Build/CesiumUnminified/";</script>'
         )
       )
       .pipe(
@@ -2147,7 +2147,7 @@ function buildSandcastle() {
       gulpReplace(
         '    <script type="module" src="load-cesium-es6.js"></script>',
         '    <script src="../CesiumUnminified/Cesium.js"></script>\n' +
-          '    <script>window.CESIUM_BASE_URL = "../CesiumUnminified/";</script>";'
+          '    <script>window.CESIUM_BASE_URL = "../CesiumUnminified/";</script>'
       )
     )
     .pipe(gulpReplace("../../Build", "."))


### PR DESCRIPTION
This is supposed to address https://github.com/CesiumGS/cesium/issues/10917 , but I can not easily test whether this _really_ fixes it.

If somebody can 

- glance at it and say "Yep, that's it" with reasonable certainty (or ... just try it out)
- knows (or can make sure) that this change does _not_ affect anything _except_ for the deployed sandcastle

then this might be an easy fix. Otherwise, I'd leave it to others to investigate the issue further.

