### PR TITLE
Updates postversion gulp task to update all dependent workspaces

### DIFF
--- a/Documentation/Contributors/ReleaseGuide/README.md
+++ b/Documentation/Contributors/ReleaseGuide/README.md
@@ -19,7 +19,7 @@ There is no release manager; instead, our community shares the responsibility. A
 1. Verify there are no [`priority - next release` issues](https://github.com/CesiumGS/cesium/issues?q=is%3Aopen+is%3Aissue+label%3A%22priority+-+next+release%22) or [`priority - next release` pull requests](https://github.com/CesiumGS/cesium/pulls?q=is%3Apr+is%3Aopen+label%3A"priority+-+next+release").
 2. Verify there are no [`remove in [this version number]` issues](https://github.com/CesiumGS/cesium/labels). Delete the label. Create a new label with the next highest `remove in [version]` relative to the existing labels.
 3. Make sure you are using the latest drivers for your video card.
-4. Pull down the latest `main` branch.
+4. Pull down the latest `main` branch and run `npm install`.
 5. Update the Cesium ion demo token in `Ion.js` with a new token from the CesiumJS ion team account with read and geocode permissions. These tokens are named like this: `1.85 Release - Delete on November 1st, 2021`. Delete the token from 2 releases ago.
 6. Proofread [`CHANGES.md`](../../../CHANGES.md) with the date of the release. Adjust the order of changes so that prominent/popular changes come first. Ensure each change is in the section for the relevant workspace.
 7. Based on `CHANGES.md`, update each workspace version following the rules of [semantic versioning](https://semver.org/), e.g.,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -545,20 +545,36 @@ async function pruneScriptsForZip(packageJsonPath) {
   return gulp.src(noPreparePackageJson).pipe(gulpRename(packageJsonPath));
 }
 
-export const postversion = function () {
+export const postversion = async function () {
   const workspace = argv.workspace;
   if (!workspace) {
     return;
   }
-
-  // After the workspace version is bumped by `npm version`,
-  // update the root `package.json` file to depend on the new version
   const directory = workspace.replaceAll(`@${scope}/`, ``);
   const workspacePackageJson = require(`./packages/${directory}/package.json`);
   const version = workspacePackageJson.version;
 
-  packageJson.dependencies[workspace] = version;
-  return writeFile("package.json", JSON.stringify(packageJson, undefined, 2));
+  // Iterate through all package JSONs that may depend on the updated package and
+  // update the version of the updated workspace.
+  const packageJsons = await globby([
+    "./package.json",
+    "./packages/*/package.json",
+  ]);
+  const promises = packageJsons.map(async (packageJsonPath) => {
+    // Ensure that we don't check the updated workspace itself.
+    if (basename(dirname(packageJsonPath)) === directory) {
+      return Promise.resolve();
+    }
+    // Ensure that we only update workspaces where the dependency to the updated workspace already exists.
+    const packageJson = require(packageJsonPath);
+    if (!(workspace in packageJson.dependencies)) {
+      return Promise.resolve();
+    }
+    // Update the version for the updated workspace.
+    packageJson.dependencies[workspace] = version;
+    await writeFile(packageJsonPath, JSON.stringify(packageJson, undefined, 2));
+  });
+  return Promise.all(promises);
 };
 
 export const makeZip = gulp.series(release, async function () {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -563,12 +563,12 @@ export const postversion = async function () {
   const promises = packageJsons.map(async (packageJsonPath) => {
     // Ensure that we don't check the updated workspace itself.
     if (basename(dirname(packageJsonPath)) === directory) {
-      return Promise.resolve();
+      return;
     }
     // Ensure that we only update workspaces where the dependency to the updated workspace already exists.
     const packageJson = require(packageJsonPath);
-    if (!(workspace in packageJson.dependencies)) {
-      return Promise.resolve();
+    if (!Object.hasOwn(packageJson.dependencies, workspace)) {
+      return;
     }
     // Update the version for the updated workspace.
     packageJson.dependencies[workspace] = version;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -570,8 +570,9 @@ export const postversion = async function () {
     // Ensure that we only update workspaces where the dependency to the updated workspace already exists.
     const packageJson = require(packageJsonPath);
     if (!Object.hasOwn(packageJson.dependencies, workspace)) {
- 
-      console.log(`Skipping update for ${workspace} as it is not a dependency.`);
+      console.log(
+        `Skipping update for ${workspace} as it is not a dependency.`
+      );
       return;
     }
     // Update the version for the updated workspace.


### PR DESCRIPTION
This PR updates the `postversion` gulp task that is run after the `npm version` command used in the release process. The main change here is that when you run `npm version` for workspace `X`, it updates the `package.json` for all workspaces that depend on workspace `X`.

Since running any gulp task requires having run `npm install`, the release guide has been updated to explicitly call for an `npm install` before running `npm version`.