### PR TITLE
fixed some cases where pnts data failed to load

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -341,3 +341,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Marco Hutter](https://github.com/javagl)
 - [Calogero Mauceri](https://github.com/calogeromauceri)
 - [Marcel Wendler](https://github.com/UniquePanda)
+- [JiaoJianing](https://github.com/JiaoJianing)

--- a/packages/engine/Source/Scene/PointCloud.js
+++ b/packages/engine/Source/Scene/PointCloud.js
@@ -347,7 +347,7 @@ function prepareVertexAttribute(typedArray, name) {
   ) {
     oneTimeWarning(
       "Cast pnts property to floats",
-      `Point cloud property "${name}" will be casted to a float array because INT, UNSIGNED_INT, and DOUBLE are not valid WebGL vertex attribute types. Some precision may be lost.`
+      `Point cloud property "${name}" will be cast to a float array because INT, UNSIGNED_INT, and DOUBLE are not valid WebGL vertex attribute types. Some precision may be lost.`
     );
     return new Float32Array(typedArray);
   }

--- a/packages/engine/Source/Scene/parseBatchTable.js
+++ b/packages/engine/Source/Scene/parseBatchTable.js
@@ -362,9 +362,9 @@ function transcodeBinaryPropertiesAsPropertyAttributes(
       componentDatatype === ComponentDatatype.UNSIGNED_INT ||
       componentDatatype === ComponentDatatype.DOUBLE
     ) {
-      oneTimeWarning(
+      parseBatchTable._oneTimeWarning(
         "Cast pnts property to floats",
-        `Point cloud property "${customAttributeName}" will be casted to a float array because INT, UNSIGNED_INT, and DOUBLE are not valid WebGL vertex attribute types. Some precision may be lost.`
+        `Point cloud property "${customAttributeName}" will be cast to a float array because INT, UNSIGNED_INT, and DOUBLE are not valid WebGL vertex attribute types. Some precision may be lost.`
       );
       attributeTypedArray = new Float32Array(attributeTypedArray);
     }
@@ -450,5 +450,6 @@ function transcodeComponentType(componentType) {
 
 // exposed for testing
 parseBatchTable._deprecationWarning = deprecationWarning;
+parseBatchTable._oneTimeWarning = oneTimeWarning;
 
 export default parseBatchTable;

--- a/packages/engine/Source/Scene/parseBatchTable.js
+++ b/packages/engine/Source/Scene/parseBatchTable.js
@@ -16,6 +16,7 @@ import MetadataSchema from "./MetadataSchema.js";
 import MetadataTable from "./MetadataTable.js";
 import ModelComponents from "./ModelComponents.js";
 import ModelUtility from "./Model/ModelUtility.js";
+import oneTimeWarning from "../Core/oneTimeWarning.js";
 
 /**
  * An object that parses the the 3D Tiles 1.0 batch table and transcodes it to
@@ -353,6 +354,20 @@ function transcodeBinaryPropertiesAsPropertyAttributes(
     attribute.name = customAttributeName;
     attribute.count = featureCount;
     attribute.type = property.type;
+    const componentDatatype = ComponentDatatype.fromTypedArray(
+      attributeTypedArray
+    );
+    if (
+      componentDatatype === ComponentDatatype.INT ||
+      componentDatatype === ComponentDatatype.UNSIGNED_INT ||
+      componentDatatype === ComponentDatatype.DOUBLE
+    ) {
+      oneTimeWarning(
+        "Cast pnts property to floats",
+        `Point cloud property "${customAttributeName}" will be casted to a float array because INT, UNSIGNED_INT, and DOUBLE are not valid WebGL vertex attribute types. Some precision may be lost.`
+      );
+      attributeTypedArray = new Float32Array(attributeTypedArray);
+    }
     attribute.componentDatatype = ComponentDatatype.fromTypedArray(
       attributeTypedArray
     );

--- a/packages/engine/Specs/Scene/parseBatchTableSpec.js
+++ b/packages/engine/Specs/Scene/parseBatchTableSpec.js
@@ -744,4 +744,34 @@ describe("Scene/parseBatchTable", function () {
     const windProperty = properties.windDirection;
     expect(windProperty.attribute).toBe("_WINDDIRECTION");
   });
+
+  it("logs a warning and converts integer attribute property to float", function () {
+    const binaryBatchTable = {
+      height: {
+        byteOffset: 0,
+        componentType: "INT",
+        type: "SCALAR",
+      },
+    };
+
+    const heightValues = new Int32Array([10, 15, 25]);
+    const binaryBody = new Uint8Array(heightValues.buffer);
+
+    spyOn(parseBatchTable, "_oneTimeWarning");
+    const customAttributes = [];
+    parseBatchTable({
+      count: 3,
+      batchTable: binaryBatchTable,
+      binaryBody: binaryBody,
+      parseAsPropertyAttributes: true,
+      customAttributeOutput: customAttributes,
+    });
+    expect(customAttributes.length).toBe(1);
+    const [heightAttribute] = customAttributes.sort(sortByName);
+    expect(heightAttribute.name).toBe("_HEIGHT");
+    expect(heightAttribute.count).toBe(3);
+    expect(heightAttribute.type).toBe("SCALAR");
+    expect(heightAttribute.componentDatatype).toBe(ComponentDatatype.FLOAT);
+    expect(parseBatchTable._oneTimeWarning).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
This PR fixed some pnts data's load and render. These pnts always contain invalid webgl vertex attribute types.
This error also had been mentioned in https://github.com/CesiumGS/cesium/issues/10786 by @aixiaodeyanjin
![image](https://user-images.githubusercontent.com/12868409/206099555-7314394c-d17d-4e42-a78d-e4b080d48a67.png)
