### PR TITLE
Fix `Model` disappearing bug in Columbus View

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 - Fixed the JSDoc and TypeScript definitions of arguments in `Matrix2.multiplyByScalar`, `Matrix3.multiplyByScalar`, and several functions in the `S2Cell` class. [#10899](https://github.com/CesiumGS/cesium/pull/10899)
 - Fixed a bug where the entity collection of a `GpxDataSource` did not have the `owner` property set. [#10921](https://github.com/CesiumGS/cesium/issues/10921)
 - Fixed a bug where \*.ktx2 images loading fail. [#10869](https://github.com/CesiumGS/cesium/pull/10869)
+- Fixed a bug where a `Model` would sometimes disappear when loaded in Columbus View. [#10945](https://github.com/CesiumGS/cesium/pull/10945)
 
 ### 1.100 - 2022-12-01
 

--- a/packages/engine/Source/Scene/Model/Model.js
+++ b/packages/engine/Source/Scene/Model/Model.js
@@ -2099,9 +2099,8 @@ function updateComputedScale(model, modelMatrix, frameState) {
       context.drawingBufferWidth,
       context.drawingBufferHeight
     );
-    scratchPosition.x = modelMatrix[12];
-    scratchPosition.y = modelMatrix[13];
-    scratchPosition.z = modelMatrix[14];
+
+    Matrix4.getTranslation(modelMatrix, scratchPosition);
 
     if (model._sceneMode !== SceneMode.SCENE3D) {
       SceneTransforms.computeActualWgs84Position(

--- a/packages/engine/Source/Scene/Model/buildDrawCommand.js
+++ b/packages/engine/Source/Scene/Model/buildDrawCommand.js
@@ -48,21 +48,29 @@ function buildDrawCommand(primitiveRenderResources, frameState) {
   const pass = primitiveRenderResources.alphaOptions.pass;
   const sceneGraph = model.sceneGraph;
 
-  const modelMatrix = Matrix4.multiplyTransformation(
-    sceneGraph.computedModelMatrix,
-    primitiveRenderResources.runtimeNode.computedTransform,
-    new Matrix4()
-  );
+  const is3D = frameState.mode === SceneMode.SCENE3D;
+  let modelMatrix, boundingSphere;
 
-  let boundingSphere;
-  if (
-    frameState.mode !== SceneMode.SCENE3D &&
-    !frameState.scene3DOnly &&
-    model._projectTo2D
-  ) {
+  if (!is3D && !frameState.scene3DOnly && model._projectTo2D) {
+    modelMatrix = Matrix4.multiplyTransformation(
+      sceneGraph._computedModelMatrix,
+      primitiveRenderResources.runtimeNode.computedTransform,
+      new Matrix4()
+    );
+
     const runtimePrimitive = primitiveRenderResources.runtimePrimitive;
     boundingSphere = runtimePrimitive.boundingSphere2D;
   } else {
+    const computedModelMatrix = is3D
+      ? sceneGraph._computedModelMatrix
+      : sceneGraph._computedModelMatrix2D;
+
+    modelMatrix = Matrix4.multiplyTransformation(
+      computedModelMatrix,
+      primitiveRenderResources.runtimeNode.computedTransform,
+      new Matrix4()
+    );
+
     boundingSphere = BoundingSphere.transform(
       primitiveRenderResources.boundingSphere,
       modelMatrix,

--- a/packages/engine/Specs/Scene/Model/ModelSpec.js
+++ b/packages/engine/Specs/Scene/Model/ModelSpec.js
@@ -935,6 +935,29 @@ describe(
       });
     });
 
+    it("renders in CV after draw commands are reset", function () {
+      return loadAndZoomToModel(
+        {
+          gltf: boxTexturedGlbUrl,
+          modelMatrix: modelMatrix,
+        },
+        sceneCV
+      ).then(function (model) {
+        expect(model.ready).toEqual(true);
+        scene.camera.moveBackward(1.0);
+        verifyRender(model, true, {
+          zoomToModel: false,
+          scene: sceneCV,
+        });
+
+        model._drawCommandsBuilt = false;
+        verifyRender(model, true, {
+          zoomToModel: false,
+          scene: sceneCV,
+        });
+      });
+    });
+
     it("projectTo2D works for 2D", function () {
       return loadAndZoomToModel(
         {


### PR DESCRIPTION
Fixes #10943.

`buildDrawCommand` was not accounting for the case when draw commands were built in 2D mode (as opposed to a model starting in 3D, then changing scene modes). Many of the models with textures would disappear once their textures loaded in because the commands were reset, which would make the scene graph revert to using the 3D model matrix instead of the 2D one.

[Localhost sandcastle for testing](http://localhost:8080/Apps/Sandcastle/index.html#c=tVZtb9s2EP4rnD/JgEfZTdKinhMssZu2WNMWs1MMmIeClk4xEYoUSCqOV+S/70hKivzSD0Zmxw7II/nccy/kXaKkseSBwwo0OScSVmQMhpc5/eZl0byT+PlYScu4BD3v9MiPuSSEy0xdqcchyZgw0HMiAwISy5X8KFOeMKv0xuqSpWplhsTqspaoUqSXkufMQluegIQblaJs4AVx7EUnky9SrCvMuXzq/jaX7o+ZtUxIVkqvnCQaEM+dF1GpRY8sgd8tbTfwDsZSD0gLzXNu+QMYqiFXD3ApRBRgCUm8cwpluIc9r10zZtriiMkTmmmVT+BOA5jIHSHk18GrE9p/c3r6evC2F0Snp7R/1j95039dCQIfN3aqkBLTJHd0b5jV/PFZ00wzaTKlc0OBGftZabu8LWbqmj9Ceq1ZDlFNbwsJMX5mKEvTqML3PvJGvBc2i34EeoSg18jQ/e/Vkja9YXvmdzx1g3r3YyvGbdiBPmXp+ivCcwPNhrDEEscmxB7pe1rO+RUHoVQxJG2azdZPuET/fPf13eUs6G6QK4sT9Itm1M2uVImpKO+mxRI0REH1YkPojj+5gIdwq8LTQf/97SArOhYe7ZDMO5dcJ5plFm9BWMCtPumHz+kXdUnjyHYq1jLk2qE0xu+U5YWACbMs9sxMHAxGLdXoOw7pnVg0+tznrN/v0349D+ajH0IkentYT7SScFzKXkV7vMN6cHYY6ffahYl8gyVPxNHYBy2Vks3ZjgWHsP+gLMHYkSsmMJXlcZ1fKdmc7Qbg0LS54eKezHSZ3B+XvtPj1WzPXxSB6T2XElIyXjKNj42vXMc0gtX+/47DFzG/lQJfUKytx2KM0F5HM0C6NttKlgNfGJYoMlZ5ocEY9Loncyz+Xtuzsj1ps2XNIab8MfvrVduSA28wz0j0S1W3rtGsUsMEbGiLqCmLAmu4uWKGm6hdoLstCEJWXGKrRJkAbVsecT6ZLbkhC42NFHZsqQJDJD41FTDxwORWYmnVhglsYRo7nH1Ixsw7z4C1O9AV/8sL5Hy3K3n5S/QRKzOTiYvGUW9Fo2djsud2nP2c/D++e5wymSbYsmEZwcZmppRYMH0DsoyqBsMd7PQ6807TvQSgkbFrARc1/u8894HFXixC1haQNVpl4gUmOliaGFNTGMXto6OUPxCenu9p4EkimDG4kpVCTPm/WFwvRjHu3zkqFHON0hfMJsHWbttycPEpCCmloxin+0/aYPEW8n8)

@lilleyse do you mind reviewing?