### PR TITLE
Add result param to setRotation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 - Fixed a bug where the entity collection of a `GpxDataSource` did not have the `owner` property set. [#10921](https://github.com/CesiumGS/cesium/issues/10921)
 - Fixed a bug where \*.ktx2 images loading fail. [#10869](https://github.com/CesiumGS/cesium/pull/10869)
 - Fixed a bug where a `Model` would sometimes disappear when loaded in Columbus View. [#10945](https://github.com/CesiumGS/cesium/pull/10945)
+- Fixed a bug where `result` parameters were omitted from the TypeScript definitions. [#10864](https://github.com/CesiumGS/cesium/issues/10864)
 
 ### 1.100 - 2022-12-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -288,7 +288,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Richard Becker](https://github.com/richard3d)
 - [Daniel Leone](https://github.com/danielleone)
 - [Zhou Jiang](https://github.com/aboutqx)
-- [SungHo Lim](https://github.com/SambaLim)
+- [SungHo Lim](https://github.com/sungh0lim)
 - [Michael Fink](https://github.com/vividos)
 - [Jakub Vrana](https://github.com/vrana)
 - [Edvinas Pranka](https://github.com/epranka)

--- a/packages/engine/Source/Core/Matrix2.js
+++ b/packages/engine/Source/Core/Matrix2.js
@@ -613,6 +613,7 @@ const scaleScratch4 = new Cartesian2();
  *
  * @param {Matrix2} matrix The matrix.
  * @param {Matrix2} rotation The rotation matrix.
+ * @param {Matrix2} result The object onto which to store the result.
  * @returns {Matrix2} The modified result parameter.
  *
  * @see Matrix2.fromRotation

--- a/packages/engine/Source/Core/Matrix3.js
+++ b/packages/engine/Source/Core/Matrix3.js
@@ -974,6 +974,7 @@ const scaleScratch4 = new Cartesian3();
  *
  * @param {Matrix3} matrix The matrix.
  * @param {Matrix3} rotation The rotation matrix.
+ * @param {Matrix3} result The object onto which to store the result.
  * @returns {Matrix3} The modified result parameter.
  *
  * @see Matrix3.getRotation

--- a/packages/engine/Source/Core/Matrix4.js
+++ b/packages/engine/Source/Core/Matrix4.js
@@ -1633,6 +1633,7 @@ const scaleScratch4 = new Cartesian3();
  *
  * @param {Matrix4} matrix The matrix.
  * @param {Matrix3} rotation The rotation matrix.
+ * @param {Matrix4} result The object onto which to store the result.
  * @returns {Matrix4} The modified result parameter.
  *
  * @see Matrix4.fromRotation


### PR DESCRIPTION
# :eyes: What is this PR?

- #10864
- Add `result` parameter to jsdoc to generate TypeScript definitions.

---

Is it correct what you said in the issue?