### PR TITLE
Fix file watcher for workers

### DIFF
--- a/server.js
+++ b/server.js
@@ -232,14 +232,20 @@ const serveResult = (result, fileName, res, next) => {
       ignoreInitial: true,
     });
     workerWatcher.on("all", async () => {
-      const start = performance.now();
-      await bundleWorkers({
-        path: outputDirectory,
-        sourcemap: true,
-      });
-      console.log(
-        `Rebuilt Workers/* in ${formatTimeSinceInSeconds(start)} seconds.`
-      );
+      try {
+        const start = performance.now();
+        await bundleWorkers({
+          input: ["packages/engine/Source/Workers/**"],
+          inputES6: workerSourceFiles,
+          path: outputDirectory,
+          sourcemap: true,
+        });
+        console.log(
+          `Rebuilt Workers/* in ${formatTimeSinceInSeconds(start)} seconds.`
+        );
+      } catch (e) {
+        console.error(e);
+      }
     });
 
     app.get("/Build/CesiumUnminified/Cesium.js", async function (


### PR DESCRIPTION
Previously, when running `npm start` and modifying worker files, `server.js` would 1) incorrectly build the worker files, and 2) not continue watching after an error. This passes the correct options through to `bundleWorkers` and catches and logs any errors while continuing to watch files for more updates.