### PR TITLE
Update autolinker and jsep dependencies

### DIFF
--- a/packages/engine/Source/DataSources/GpxDataSource.js
+++ b/packages/engine/Source/DataSources/GpxDataSource.js
@@ -41,11 +41,9 @@ const autolinker = new Autolinker({
   stripPrefix: false,
   email: false,
   replaceFn: function (linker, match) {
-    if (!match.protocolUrlMatch) {
-      // Prevent matching of non-explicit urls.
-      // i.e. foo.id won't match but http://foo.id will
-      return false;
-    }
+    //Prevent matching of non-explicit urls.
+    //i.e. foo.id won't match but http://foo.id will
+    return match.urlMatchType === "scheme" || match.urlMatchType === "www";
   },
 });
 

--- a/packages/engine/Source/DataSources/KmlDataSource.js
+++ b/packages/engine/Source/DataSources/KmlDataSource.js
@@ -143,11 +143,9 @@ const autolinker = new Autolinker({
   stripPrefix: false,
   email: false,
   replaceFn: function (match) {
-    if (!match.protocolUrlMatch) {
-      //Prevent matching of non-explicit urls.
-      //i.e. foo.id won't match but http://foo.id will
-      return false;
-    }
+    //Prevent matching of non-explicit urls.
+    //i.e. foo.id won't match but http://foo.id will
+    return match.urlMatchType === "scheme" || match.urlMatchType === "www";
   },
 });
 

--- a/packages/engine/Source/Scene/Expression.js
+++ b/packages/engine/Source/Scene/Expression.js
@@ -659,7 +659,7 @@ function parseCall(expression, ast) {
     const object = ast.callee.object;
     if (call === "test" || call === "exec") {
       // Make sure this is called on a valid type
-      if (object.callee.name !== "regExp") {
+      if (!defined(object.callee) || object.callee.name !== "regExp") {
         throw new RuntimeError(`${call} is not a function.`);
       }
       if (argsLength === 0) {

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -34,12 +34,12 @@
   "dependencies": {
     "@tweenjs/tween.js": "^18.6.4",
     "@zip.js/zip.js": "2.4.x",
-    "autolinker": "^3.14.3",
+    "autolinker": "^4.0.0",
     "bitmap-sdf": "^1.0.3",
     "dompurify": "^2.2.2",
     "earcut": "^2.2.4",
     "grapheme-splitter": "^1.0.4",
-    "jsep": "^0.3.1",
+    "jsep": "^1.3.8",
     "kdbush": "^3.0.0",
     "ktx-parse": "^0.4.5",
     "lerc": "^2.0.0",
@@ -52,7 +52,6 @@
     "urijs": "^1.19.7"
   },
   "type": "module",
-  "devDependencies": {},
   "scripts": {
     "build": "gulp build --workspace @cesium/engine",
     "build-ts": "gulp buildTs --workspace @cesium/engine",


### PR DESCRIPTION
This updates the remaining outdated direct dependencies– jsep and autolinker. For both, there were slight tweaks to the APIs which were updated here.

Lerc is still an outstanding direct dependency update. The new version now requires using wasm. It looks like, despite the fact that the wasm file is built to support multiple ways of loading the module, [the lerc API only allows one way to load wasm files](https://github.com/Esri/lerc/blob/master/OtherLanguages/js/src/Lerc.ts#L153) and that way does not fit within our worker architecture, throwing errors when loading. I'll writeup a separate issue to cover it.