### PR TITLE
Miscellaneous changes from voxels branch

### DIFF
--- a/Specs/getWebGLStub.js
+++ b/Specs/getWebGLStub.js
@@ -212,6 +212,11 @@ function getExtensionStub(name) {
     return instancedArraysStub;
   }
 
+  // Voxel tests rely on floating point textures
+  if (name === "OES_texture_float") {
+    return {};
+  }
+
   // No other extensions are stubbed.
   return null;
 }

--- a/packages/engine/Source/Core/OrientedBoundingBox.js
+++ b/packages/engine/Source/Core/OrientedBoundingBox.js
@@ -18,13 +18,13 @@ import Rectangle from "./Rectangle.js";
 
 /**
  * Creates an instance of an OrientedBoundingBox.
- * An OrientedBoundingBox of some object is a closed and convex cuboid. It can provide a tighter bounding volume than {@link BoundingSphere} or {@link AxisAlignedBoundingBox} in many cases.
+ * An OrientedBoundingBox of some object is a closed and convex rectangular cuboid. It can provide a tighter bounding volume than {@link BoundingSphere} or {@link AxisAlignedBoundingBox} in many cases.
  * @alias OrientedBoundingBox
  * @constructor
  *
  * @param {Cartesian3} [center=Cartesian3.ZERO] The center of the box.
  * @param {Matrix3} [halfAxes=Matrix3.ZERO] The three orthogonal half-axes of the bounding box.
- *                                          Equivalently, the transformation matrix, to rotate and scale a 0x0x0
+ *                                          Equivalently, the transformation matrix, to rotate and scale a 1x1x1
  *                                          cube centered at the origin.
  *
  *
@@ -334,7 +334,7 @@ const scratchPlane = new Plane(Cartesian3.UNIT_X, 0.0);
  * @param {OrientedBoundingBox} [result] The object onto which to store the result.
  * @returns {OrientedBoundingBox} The modified result parameter or a new OrientedBoundingBox instance if none was provided.
  *
- * @exception {DeveloperError} rectangle.width must be between 0 and pi.
+ * @exception {DeveloperError} rectangle.width must be between 0 and 2 * pi.
  * @exception {DeveloperError} rectangle.height must be between 0 and pi.
  * @exception {DeveloperError} ellipsoid must be an ellipsoid of revolution (<code>radii.x == radii.y</code>)
  */
@@ -350,7 +350,7 @@ OrientedBoundingBox.fromRectangle = function (
     throw new DeveloperError("rectangle is required");
   }
   if (rectangle.width < 0.0 || rectangle.width > CesiumMath.TWO_PI) {
-    throw new DeveloperError("Rectangle width must be between 0 and 2*pi");
+    throw new DeveloperError("Rectangle width must be between 0 and 2 * pi");
   }
   if (rectangle.height < 0.0 || rectangle.height > CesiumMath.PI) {
     throw new DeveloperError("Rectangle height must be between 0 and pi");

--- a/packages/engine/Source/Scene/DerivedCommand.js
+++ b/packages/engine/Source/Scene/DerivedCommand.js
@@ -148,6 +148,13 @@ const vertexlogDepthRegex = /\s+czm_vertexLogDepth\(/;
 const extensionRegex = /\s*#extension\s+GL_EXT_frag_depth\s*:\s*enable/;
 
 function getLogDepthShaderProgram(context, shaderProgram) {
+  const disableLogDepthWrite =
+    shaderProgram.fragmentShaderSource.defines.indexOf("LOG_DEPTH_READ_ONLY") >=
+    0;
+  if (disableLogDepthWrite) {
+    return shaderProgram;
+  }
+
   let shader = context.shaderCache.getDerivedShaderProgram(
     shaderProgram,
     "logDepth"

--- a/packages/engine/Source/Scene/MetadataClassProperty.js
+++ b/packages/engine/Source/Scene/MetadataClassProperty.js
@@ -450,7 +450,7 @@ function isLegacy(property) {
 
   // EXT_feature_metadata allowed numeric types as a type. Now they are
   // represented as {type: SINGLE, componentType: type}
-  if (MetadataComponentType.isNumericType(type)) {
+  if (defined(MetadataComponentType[type])) {
     return true;
   }
 
@@ -585,10 +585,7 @@ function parseType(property, enums) {
 
   // Both EXT_feature_metadata and EXT_structural_metadata allow numeric types like
   // INT32 or FLOAT64 as a componentType.
-  if (
-    defined(componentType) &&
-    MetadataComponentType.isNumericType(componentType)
-  ) {
+  if (defined(componentType) && defined(MetadataComponentType[componentType])) {
     return {
       type: MetadataType.SCALAR,
       componentType: componentType,
@@ -602,7 +599,7 @@ function parseType(property, enums) {
 
   // EXT_feature_metadata: integer and float types were allowed as types,
   // but now these are expressed as {type: SCALAR, componentType: type}
-  if (MetadataComponentType.isNumericType(type)) {
+  if (defined(MetadataComponentType[type])) {
     return {
       type: MetadataType.SCALAR,
       componentType: type,

--- a/packages/engine/Source/Scene/MetadataComponentType.js
+++ b/packages/engine/Source/Scene/MetadataComponentType.js
@@ -108,8 +108,6 @@ const MetadataComponentType = {
  * @param {MetadataComponentType} type The type.
  * @returns {Number|BigInt} The minimum value.
  *
- * @exception {DeveloperError} type must be a numeric type
- *
  * @private
  */
 MetadataComponentType.getMinimum = function (type) {
@@ -157,8 +155,6 @@ MetadataComponentType.getMinimum = function (type) {
  *
  * @param {MetadataComponentType} type The type.
  * @returns {Number|BigInt} The maximum value.
- *
- * @exception {DeveloperError} type must be a numeric type
  *
  * @private
  */
@@ -381,8 +377,6 @@ MetadataComponentType.unapplyValueTransform = function (value, offset, scale) {
  *
  * @param {MetadataComponentType} type The type.
  * @returns {Number} The size in bytes.
- *
- * @exception {DeveloperError} type must be a numeric type
  *
  * @private
  */

--- a/packages/engine/Source/Scene/MetadataComponentType.js
+++ b/packages/engine/Source/Scene/MetadataComponentType.js
@@ -1,5 +1,6 @@
 import CesiumMath from "../Core/Math.js";
 import Check from "../Core/Check.js";
+import ComponentDatatype from "../Core/ComponentDatatype.js";
 import DeveloperError from "../Core/DeveloperError.js";
 import FeatureDetection from "../Core/FeatureDetection.js";
 
@@ -113,9 +114,7 @@ const MetadataComponentType = {
  */
 MetadataComponentType.getMinimum = function (type) {
   //>>includeStart('debug', pragmas.debug);
-  if (!MetadataComponentType.isNumericType(type)) {
-    throw new DeveloperError("type must be a numeric type");
-  }
+  Check.typeOf.string("type", type);
   //>>includeEnd('debug');
 
   switch (type) {
@@ -165,9 +164,7 @@ MetadataComponentType.getMinimum = function (type) {
  */
 MetadataComponentType.getMaximum = function (type) {
   //>>includeStart('debug', pragmas.debug);
-  if (!MetadataComponentType.isNumericType(type)) {
-    throw new DeveloperError("type must be a numeric type");
-  }
+  Check.typeOf.string("type", type);
   //>>includeEnd('debug');
 
   switch (type) {
@@ -200,36 +197,6 @@ MetadataComponentType.getMaximum = function (type) {
       return 340282346638528859811704183484516925440.0;
     case MetadataComponentType.FLOAT64:
       return Number.MAX_VALUE;
-  }
-};
-
-/**
- * Returns whether the type is a numeric type.
- *
- * @param {MetadataComponentType} type The type.
- * @returns {Boolean} Whether the type is a numeric type.
- *
- * @private
- */
-MetadataComponentType.isNumericType = function (type) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.typeOf.string("type", type);
-  //>>includeEnd('debug');
-
-  switch (type) {
-    case MetadataComponentType.INT8:
-    case MetadataComponentType.UINT8:
-    case MetadataComponentType.INT16:
-    case MetadataComponentType.UINT16:
-    case MetadataComponentType.INT32:
-    case MetadataComponentType.UINT32:
-    case MetadataComponentType.INT64:
-    case MetadataComponentType.UINT64:
-    case MetadataComponentType.FLOAT32:
-    case MetadataComponentType.FLOAT64:
-      return true;
-    default:
-      return false;
   }
 };
 
@@ -421,10 +388,9 @@ MetadataComponentType.unapplyValueTransform = function (value, offset, scale) {
  */
 MetadataComponentType.getSizeInBytes = function (type) {
   //>>includeStart('debug', pragmas.debug);
-  if (!MetadataComponentType.isNumericType(type)) {
-    throw new DeveloperError("type must be a numeric type");
-  }
+  Check.typeOf.string("type", type);
   //>>includeEnd('debug');
+
   switch (type) {
     case MetadataComponentType.INT8:
     case MetadataComponentType.UINT8:
@@ -442,6 +408,72 @@ MetadataComponentType.getSizeInBytes = function (type) {
       return 4;
     case MetadataComponentType.FLOAT64:
       return 8;
+  }
+};
+
+/**
+ * Gets the {@link MetadataComponentType} from a {@link ComponentDatatype}.
+ *
+ * @param {ComponentDatatype} componentDatatype The component datatype.
+ * @returns {MetadataComponentType} The metadata component type.
+ *
+ * @private
+ */
+MetadataComponentType.fromComponentDatatype = function (componentDatatype) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.number("componentDatatype", componentDatatype);
+  //>>includeEnd('debug');
+
+  switch (componentDatatype) {
+    case ComponentDatatype.BYTE:
+      return MetadataComponentType.INT8;
+    case ComponentDatatype.UNSIGNED_BYTE:
+      return MetadataComponentType.UINT8;
+    case ComponentDatatype.SHORT:
+      return MetadataComponentType.INT16;
+    case ComponentDatatype.UNSIGNED_SHORT:
+      return MetadataComponentType.UINT16;
+    case ComponentDatatype.INT:
+      return MetadataComponentType.INT32;
+    case ComponentDatatype.UNSIGNED_INT:
+      return MetadataComponentType.UINT32;
+    case ComponentDatatype.FLOAT:
+      return MetadataComponentType.FLOAT32;
+    case ComponentDatatype.DOUBLE:
+      return MetadataComponentType.FLOAT64;
+  }
+};
+
+/**
+ * Gets the {@link ComponentDatatype} from a {@link MetadataComponentType}.
+ *
+ * @param {MetadataComponentType} type The metadata component datatype.
+ * @returns {ComponentDatatype} The component datatype.
+ *
+ * @private
+ */
+MetadataComponentType.toComponentDatatype = function (type) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.typeOf.string("type", type);
+  //>>includeEnd('debug');
+
+  switch (type) {
+    case MetadataComponentType.INT8:
+      return ComponentDatatype.BYTE;
+    case MetadataComponentType.UINT8:
+      return ComponentDatatype.UNSIGNED_BYTE;
+    case MetadataComponentType.INT16:
+      return ComponentDatatype.SHORT;
+    case MetadataComponentType.UINT16:
+      return ComponentDatatype.UNSIGNED_SHORT;
+    case MetadataComponentType.INT32:
+      return ComponentDatatype.INT;
+    case MetadataComponentType.UINT32:
+      return ComponentDatatype.UNSIGNED_INT;
+    case MetadataComponentType.FLOAT32:
+      return ComponentDatatype.FLOAT;
+    case MetadataComponentType.FLOAT64:
+      return ComponentDatatype.DOUBLE;
   }
 };
 

--- a/packages/engine/Source/Shaders/Builtin/Functions/windowToEyeCoordinates.glsl
+++ b/packages/engine/Source/Shaders/Builtin/Functions/windowToEyeCoordinates.glsl
@@ -1,3 +1,38 @@
+vec4 czm_screenToEyeCoordinates(vec4 screenCoordinate)
+{
+    // Reconstruct NDC coordinates
+    float x = 2.0 * screenCoordinate.x - 1.0;
+    float y = 2.0 * screenCoordinate.y - 1.0;
+    float z = (screenCoordinate.z - czm_viewportTransformation[3][2]) / czm_viewportTransformation[2][2];
+    vec4 q = vec4(x, y, z, 1.0);
+
+    // Reverse the perspective division to obtain clip coordinates.
+    q /= screenCoordinate.w;
+
+    // Reverse the projection transformation to obtain eye coordinates.
+    if (!(czm_inverseProjection == mat4(0.0))) // IE and Edge sometimes do something weird with != between mat4s
+    {
+        q = czm_inverseProjection * q;
+    }
+    else
+    {
+        float top = czm_frustumPlanes.x;
+        float bottom = czm_frustumPlanes.y;
+        float left = czm_frustumPlanes.z;
+        float right = czm_frustumPlanes.w;
+
+        float near = czm_currentFrustum.x;
+        float far = czm_currentFrustum.y;
+
+        q.x = (q.x * (right - left) + left + right) * 0.5;
+        q.y = (q.y * (top - bottom) + bottom + top) * 0.5;
+        q.z = (q.z * (near - far) - near - far) * 0.5;
+        q.w = 1.0;
+    }
+
+    return q;
+}
+
 /**
  * Transforms a position from window to eye coordinates.
  * The transform from window to normalized device coordinates is done using components
@@ -25,37 +60,28 @@
  */
 vec4 czm_windowToEyeCoordinates(vec4 fragmentCoordinate)
 {
-    // Reconstruct NDC coordinates
-    float x = 2.0 * (fragmentCoordinate.x - czm_viewport.x) / czm_viewport.z - 1.0;
-    float y = 2.0 * (fragmentCoordinate.y - czm_viewport.y) / czm_viewport.w - 1.0;
-    float z = (fragmentCoordinate.z - czm_viewportTransformation[3][2]) / czm_viewportTransformation[2][2];
-    vec4 q = vec4(x, y, z, 1.0);
+    vec2 screenCoordXY = (fragmentCoordinate.xy - czm_viewport.xy) / czm_viewport.zw;
+    return czm_screenToEyeCoordinates(vec4(screenCoordXY, fragmentCoordinate.zw));
+}
 
-    // Reverse the perspective division to obtain clip coordinates.
-    q /= fragmentCoordinate.w;
-
-    // Reverse the projection transformation to obtain eye coordinates.
-    if (!(czm_inverseProjection == mat4(0.0))) // IE and Edge sometimes do something weird with != between mat4s
-    {
-        q = czm_inverseProjection * q;
-    }
-    else
-    {
-        float top = czm_frustumPlanes.x;
-        float bottom = czm_frustumPlanes.y;
-        float left = czm_frustumPlanes.z;
-        float right = czm_frustumPlanes.w;
-
-        float near = czm_currentFrustum.x;
-        float far = czm_currentFrustum.y;
-
-        q.x = (q.x * (right - left) + left + right) * 0.5;
-        q.y = (q.y * (top - bottom) + bottom + top) * 0.5;
-        q.z = (q.z * (near - far) - near - far) * 0.5;
-        q.w = 1.0;
-    }
-
-    return q;
+vec4 czm_screenToEyeCoordinates(vec2 screenCoordinateXY, float depthOrLogDepth)
+{
+    // See reverseLogDepth.glsl. This is separate to re-use the pow.
+#if defined(LOG_DEPTH) || defined(LOG_DEPTH_READ_ONLY)
+    float near = czm_currentFrustum.x;
+    float far = czm_currentFrustum.y;
+    float log2Depth = depthOrLogDepth * czm_log2FarDepthFromNearPlusOne;
+    float depthFromNear = pow(2.0, log2Depth) - 1.0;
+    float depthFromCamera = depthFromNear + near;
+    vec4 screenCoord = vec4(screenCoordinateXY, far * (1.0 - near / depthFromCamera) / (far - near), 1.0);
+    vec4 eyeCoordinate = czm_screenToEyeCoordinates(screenCoord);
+    eyeCoordinate.w = 1.0 / depthFromCamera; // Better precision
+    return eyeCoordinate;
+#else
+    vec4 screenCoord = vec4(screenCoordinateXY, depthOrLogDepth, 1.0);
+    vec4 eyeCoordinate = czm_screenToEyeCoordinates(screenCoord);
+#endif
+    return eyeCoordinate;
 }
 
 /**
@@ -80,20 +106,6 @@ vec4 czm_windowToEyeCoordinates(vec4 fragmentCoordinate)
  */
 vec4 czm_windowToEyeCoordinates(vec2 fragmentCoordinateXY, float depthOrLogDepth)
 {
-    // See reverseLogDepth.glsl. This is separate to re-use the pow.
-#ifdef LOG_DEPTH
-    float near = czm_currentFrustum.x;
-    float far = czm_currentFrustum.y;
-    float log2Depth = depthOrLogDepth * czm_log2FarDepthFromNearPlusOne;
-    float depthFromNear = pow(2.0, log2Depth) - 1.0;
-    float depthFromCamera = depthFromNear + near;
-    vec4 windowCoord = vec4(fragmentCoordinateXY, far * (1.0 - near / depthFromCamera) / (far - near), 1.0);
-    vec4 eyeCoordinate = czm_windowToEyeCoordinates(windowCoord);
-    eyeCoordinate.w = 1.0 / depthFromCamera; // Better precision
-    return eyeCoordinate;
-#else
-    vec4 windowCoord = vec4(fragmentCoordinateXY, depthOrLogDepth, 1.0);
-    vec4 eyeCoordinate = czm_windowToEyeCoordinates(windowCoord);
-#endif
-    return eyeCoordinate;
+    vec2 screenCoordXY = (fragmentCoordinateXY.xy - czm_viewport.xy) / czm_viewport.zw;
+    return czm_screenToEyeCoordinates(screenCoordXY, depthOrLogDepth);
 }

--- a/packages/engine/Specs/Scene/MetadataComponentTypeSpec.js
+++ b/packages/engine/Specs/Scene/MetadataComponentTypeSpec.js
@@ -1,4 +1,8 @@
-import { FeatureDetection, MetadataComponentType } from "../../index.js";
+import {
+  ComponentDatatype,
+  FeatureDetection,
+  MetadataComponentType,
+} from "../../index.js";
 
 describe("Scene/MetadataComponentType", function () {
   it("getMinimum", function () {
@@ -130,45 +134,6 @@ describe("Scene/MetadataComponentType", function () {
   it("getMaximum throws if type is not a numeric type", function () {
     expect(function () {
       MetadataComponentType.getMaximum(MetadataComponentType.STRING);
-    }).toThrowDeveloperError();
-  });
-
-  it("isNumericType", function () {
-    expect(
-      MetadataComponentType.isNumericType(MetadataComponentType.INT8)
-    ).toBe(true);
-    expect(
-      MetadataComponentType.isNumericType(MetadataComponentType.UINT8)
-    ).toBe(true);
-    expect(
-      MetadataComponentType.isNumericType(MetadataComponentType.INT16)
-    ).toBe(true);
-    expect(
-      MetadataComponentType.isNumericType(MetadataComponentType.UINT16)
-    ).toBe(true);
-    expect(
-      MetadataComponentType.isNumericType(MetadataComponentType.INT32)
-    ).toBe(true);
-    expect(
-      MetadataComponentType.isNumericType(MetadataComponentType.UINT32)
-    ).toBe(true);
-    expect(
-      MetadataComponentType.isNumericType(MetadataComponentType.INT64)
-    ).toBe(true);
-    expect(
-      MetadataComponentType.isNumericType(MetadataComponentType.UINT64)
-    ).toBe(true);
-    expect(
-      MetadataComponentType.isNumericType(MetadataComponentType.FLOAT32)
-    ).toBe(true);
-    expect(
-      MetadataComponentType.isNumericType(MetadataComponentType.FLOAT64)
-    ).toBe(true);
-  });
-
-  it("isNumericType throws without type", function () {
-    expect(function () {
-      MetadataComponentType.isNumericType();
     }).toThrowDeveloperError();
   });
 
@@ -522,6 +487,90 @@ describe("Scene/MetadataComponentType", function () {
   it("getSizeInBytes throws if type is not a numeric type", function () {
     expect(function () {
       MetadataComponentType.getSizeInBytes(MetadataComponentType.STRING);
+    }).toThrowDeveloperError();
+  });
+
+  it("fromComponentDatatype", function () {
+    expect(
+      MetadataComponentType.fromComponentDatatype(ComponentDatatype.BYTE)
+    ).toBe(MetadataComponentType.INT8);
+    expect(
+      MetadataComponentType.fromComponentDatatype(
+        ComponentDatatype.UNSIGNED_BYTE
+      )
+    ).toBe(MetadataComponentType.UINT8);
+    expect(
+      MetadataComponentType.fromComponentDatatype(ComponentDatatype.SHORT)
+    ).toBe(MetadataComponentType.INT16);
+    expect(
+      MetadataComponentType.fromComponentDatatype(
+        ComponentDatatype.UNSIGNED_SHORT
+      )
+    ).toBe(MetadataComponentType.UINT16);
+    expect(
+      MetadataComponentType.fromComponentDatatype(ComponentDatatype.INT)
+    ).toBe(MetadataComponentType.INT32);
+    expect(
+      MetadataComponentType.fromComponentDatatype(
+        ComponentDatatype.UNSIGNED_INT
+      )
+    ).toBe(MetadataComponentType.UINT32);
+    expect(
+      MetadataComponentType.fromComponentDatatype(ComponentDatatype.FLOAT)
+    ).toBe(MetadataComponentType.FLOAT32);
+    expect(
+      MetadataComponentType.fromComponentDatatype(ComponentDatatype.DOUBLE)
+    ).toBe(MetadataComponentType.FLOAT64);
+  });
+
+  it("fromComponentDatatype throws without componentDatatype", function () {
+    expect(function () {
+      MetadataComponentType.fromComponentDatatype();
+    }).toThrowDeveloperError();
+  });
+
+  it("toComponentDatatype", function () {
+    expect(
+      MetadataComponentType.toComponentDatatype(MetadataComponentType.INT8)
+    ).toBe(ComponentDatatype.BYTE);
+    expect(
+      MetadataComponentType.toComponentDatatype(MetadataComponentType.UINT8)
+    ).toBe(ComponentDatatype.UNSIGNED_BYTE);
+    expect(
+      MetadataComponentType.toComponentDatatype(MetadataComponentType.INT16)
+    ).toBe(ComponentDatatype.SHORT);
+    expect(
+      MetadataComponentType.toComponentDatatype(MetadataComponentType.UINT16)
+    ).toBe(ComponentDatatype.UNSIGNED_SHORT);
+    expect(
+      MetadataComponentType.toComponentDatatype(MetadataComponentType.INT32)
+    ).toBe(ComponentDatatype.INT);
+    expect(
+      MetadataComponentType.toComponentDatatype(MetadataComponentType.UINT32)
+    ).toBe(ComponentDatatype.UNSIGNED_INT);
+    expect(
+      MetadataComponentType.toComponentDatatype(MetadataComponentType.FLOAT32)
+    ).toBe(ComponentDatatype.FLOAT);
+    expect(
+      MetadataComponentType.toComponentDatatype(MetadataComponentType.FLOAT64)
+    ).toBe(ComponentDatatype.DOUBLE);
+  });
+
+  it("toComponentDatatype returns undefined for INT64", function () {
+    expect(
+      MetadataComponentType.toComponentDatatype(MetadataComponentType.INT64)
+    ).toBeUndefined();
+  });
+
+  it("toComponentDatatype returns undefined for UINT64", function () {
+    expect(
+      MetadataComponentType.toComponentDatatype(MetadataComponentType.UINT64)
+    ).toBeUndefined();
+  });
+
+  it("toComponentDatatype throws without type", function () {
+    expect(function () {
+      MetadataComponentType.toComponentDatatype();
     }).toThrowDeveloperError();
   });
 });


### PR DESCRIPTION
Miscellaneous changes from #10253 that can be merged sooner just to keep the diff clean

* Stub for `OES_texture_float` in tests
* Documentation fixes for `OrientedBoundingBox`
* `LOG_DEPTH_READ_ONLY` define
* `MetadataComponentType`: added `fromComponentDatatype`, `toComponentDatatype`. Removed `isNumericType` which is no longer applicable to `MetadataComponentType` since all enum values are numeric.
* Added `czm_screenToEyeCoordinates` and reogranized `windowToEyeCoordinates.glsl` in the process

No `CHANGES.md` update required for these