### PR TITLE
Update JSDoc

### DIFF
--- a/Tools/jsdoc/cesium_template/publish.js
+++ b/Tools/jsdoc/cesium_template/publish.js
@@ -3,16 +3,13 @@
 
 var fs = require("jsdoc/fs");
 var helper = require("jsdoc/util/templateHelper");
-var logger = require("jsdoc/util/logger");
 var path = require("jsdoc/path");
 var taffy = require("taffydb").taffy;
 var template = require("jsdoc/template");
-var util = require("util");
 
 var htmlsafe = helper.htmlsafe;
 var linkto = helper.linkto;
 var resolveAuthorLinks = helper.resolveAuthorLinks;
-var scopeToPunc = helper.scopeToPunc;
 var hasOwnProp = Object.prototype.hasOwnProperty;
 
 var data;

--- a/Tools/jsdoc/conf.json
+++ b/Tools/jsdoc/conf.json
@@ -15,6 +15,7 @@
         "includePattern": ".+\\.js(doc)?$",
         "excludePattern": "(^|\\/|\\\\)_"
     },
+    "sourceType": "module",
     "plugins": [
         "./Tools/jsdoc/cesiumTags"
     ],

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "husky": "^7.0.2",
     "istanbul-lib-instrument": "^5.2.0",
     "jasmine-core": "^4.0.1",
-    "jsdoc": "^3.6.7",
+    "jsdoc": "^4.0.0",
     "karma": "^6.3.20",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage": "^2.0.3",
@@ -112,6 +112,7 @@
     "rollup-plugin-strip-pragma": "^1.0.0",
     "rollup-plugin-terser": "^7.0.2",
     "stream-to-promise": "^3.0.0",
+    "taffydb": "^2.7.3",
     "tsd-jsdoc": "^2.5.0",
     "typescript": "^4.3.4",
     "yargs": "^17.0.1"


### PR DESCRIPTION
* Updates the outdated `jsdoc` package
* Install `taffydb` as a separate dependency, as it is no longer installed alongside `jsdoc`.
* Removes unused imports from custom `publish.js`
* Tweak config to align with [recommended default](https://jsdoc.app/about-configuring-jsdoc.html)