### PR TITLE
Spec fixes 2022-12-20

### DIFF
--- a/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/packages/engine/Specs/Scene/Cesium3DTilesetSpec.js
@@ -2289,7 +2289,9 @@ describe(
         expect(tileset._tileDebugLabels).toBeDefined();
         expect(tileset._tileDebugLabels.length).toEqual(1);
 
-        const expected = "Texture Memory: 0\n" + "Geometry Memory: 0.007";
+        const expected =
+          "Texture Memory: 0\n" +
+          `Geometry Memory: ${(0.007).toLocaleString()}`;
 
         expect(tileset._tileDebugLabels._labels[0].text).toEqual(expected);
 
@@ -2318,7 +2320,7 @@ describe(
           "Triangles: 120\n" +
           "Features: 10\n" +
           "Texture Memory: 0\n" +
-          "Geometry Memory: 0.007\n" +
+          `Geometry Memory: ${(0.007).toLocaleString()}\n` +
           "Url: parent.b3dm";
         expect(tileset._tileDebugLabels._labels[0].text).toEqual(expected);
 
@@ -2355,7 +2357,7 @@ describe(
           "Triangles: 120\n" +
           "Features: 10\n" +
           "Texture Memory: 0\n" +
-          "Geometry Memory: 0.007\n" +
+          `Geometry Memory: ${(0.007).toLocaleString()}\n` +
           "Url: parent.b3dm";
         expect(tileset._tileDebugLabels.get(0).text).toEqual(expected);
         expect(tileset._tileDebugLabels.get(0).position).toEqual(


### PR DESCRIPTION
I noticed various failures when running the tests locally (on a _German_ Windows...). I haven't yet figured out the reasons (even less solutions) for all of them, but will update this PR as I move on:

1. Errors due to assumptions about the locale that is used - for example:
```
1) show tile debug labels with memory usage
     Scene/Cesium3DTileset
     Expected 'Texture Memory: 0
Geometry Memory: 0,007' to equal 'Texture Memory: 0
Geometry Memory: 0.007'.
Error: Expected 'Texture Memory: 0
Geometry Memory: 0,007' to equal 'Texture Memory: 0
Geometry Memory: 0.007'.
    at <Jasmine>
    at packages/engine/Specs/Scene/Cesium3DTilesetSpec.js:2294:58 <- Build/Specs/SpecList.js:139998:58
```
This was caused by comparing a string that was created with `toLocaleString` (resulting in `0,007` on a German system) to a fixed string (namely `0.007`). The current solution is still a bit brittle, because ... the formatting for the labels does _more_ than just use a different locale (i.e. a string like `0.000123` would still have unexpected results). But I think that it could be OK...

2. Tile expiration tests. This is the same as https://github.com/CesiumGS/cesium/issues/7895 - I'll see whether I find a solution for that one

3. Some tests _seem_ to pass, but they actually fail, and that can only be seen when running the test manually. For example, the test http://localhost:8080/Specs/SpecRunner.html?category=none&spec=Scene%2FGlobe%20renders%20terrain%20with%20vertexShadowDarkness seems to work within `npm run test`, but when running it via the link above, it prints "Unhandled promise rejection: SyntaxError: Unexpected token '�', "�������="... is not valid JSON". Something's wrong with the structure of the test, I guess...


