### PR TITLE
Update computeFlyToLocationForRectangle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 - Fixed the JSDoc and TypeScript definitions of arguments in `Matrix2.multiplyByScalar`, `Matrix3.multiplyByScalar`, and several functions in the `S2Cell` class. [#10899](https://github.com/CesiumGS/cesium/pull/10899)
 - Fixed a bug where the entity collection of a `GpxDataSource` did not have the `owner` property set. [#10921](https://github.com/CesiumGS/cesium/issues/10921)
 - Fixed a bug where \*.ktx2 images loading fail. [#10869](https://github.com/CesiumGS/cesium/pull/10869)
+- Fixed a bug where return value for `Scene/computeFlyToLocationForRectangle.js`. [#10937](https://github.com/CesiumGS/cesium/issues/10937)
 
 ### 1.100 - 2022-12-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -341,3 +341,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Marco Hutter](https://github.com/javagl)
 - [Calogero Mauceri](https://github.com/calogeromauceri)
 - [Marcel Wendler](https://github.com/UniquePanda)
+- [非科班Java出身GISer](https://github.com/Southjor)

--- a/packages/engine/Source/Scene/computeFlyToLocationForRectangle.js
+++ b/packages/engine/Source/Scene/computeFlyToLocationForRectangle.js
@@ -53,7 +53,7 @@ function computeFlyToLocationForRectangle(rectangle, scene) {
           currentMax,
           item
         ) {
-          return Math.max(item.height, currentMax);
+          return Math.max(item.height, currentMax) || 0;
         },
         -Number.MAX_VALUE);
 


### PR DESCRIPTION
[修复地形（terrain）数据不完整的情况下，viewer.flyTo 定位到 ImageryLayer 的问题。 问题详情见：#10937](https://github.com/CesiumGS/cesium/pull/10983)