### PR TITLE
Patch 2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 ##### Fixes :wrench:
 
 - Fixed a bug decoding glTF Draco attributes with quantization bits above 16. [#7471](https://github.com/CesiumGS/cesium/issues/7471)
+- Fixed a bug where return value for `Scene/computeFlyToLocationForRectangle.js`. [#10937](https://github.com/CesiumGS/cesium/issues/10937)
 
 ### 1.101 - 2023-01-02
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -342,3 +342,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Calogero Mauceri](https://github.com/calogeromauceri)
 - [Marcel Wendler](https://github.com/UniquePanda)
 - [JiaoJianing](https://github.com/JiaoJianing)
+- [非科班Java出身GISer](https://github.com/Southjor)

--- a/packages/engine/Source/Scene/computeFlyToLocationForRectangle.js
+++ b/packages/engine/Source/Scene/computeFlyToLocationForRectangle.js
@@ -53,7 +53,7 @@ function computeFlyToLocationForRectangle(rectangle, scene) {
           currentMax,
           item
         ) {
-          return Math.max(item.height, currentMax);
+          return Math.max(item.height, currentMax) || 0;
         },
         -Number.MAX_VALUE);
 


### PR DESCRIPTION
修复地形（terrain）数据不完整的情况下，viewer.flyTo 定位到 ImageryLayer  的问题。
问题详情见：https://github.com/CesiumGS/cesium/issues/10937