### PR TITLE
Update computeFlyToLocationForRectangle.js

### DIFF
--- a/packages/engine/Source/Scene/computeFlyToLocationForRectangle.js
+++ b/packages/engine/Source/Scene/computeFlyToLocationForRectangle.js
@@ -53,7 +53,7 @@ function computeFlyToLocationForRectangle(rectangle, scene) {
           currentMax,
           item
         ) {
-          return Math.max(item.height, currentMax);
+          return Math.max(item.height, currentMax) || 0;
         },
         -Number.MAX_VALUE);
 


### PR DESCRIPTION
修复加载地形（terrain）之后，viewr.flyTo(ImageryLayer) 报错问题 [#10937](https://github.com/CesiumGS/cesium/issues/10937)。