### PR TITLE
Set `maximumTileCount` in `Cesium3DTilesVoxelProvider`

### DIFF
--- a/packages/engine/Source/Scene/Cesium3DTilesVoxelProvider.js
+++ b/packages/engine/Source/Scene/Cesium3DTilesVoxelProvider.js
@@ -145,7 +145,7 @@ function Cesium3DTilesVoxelProvider(options) {
         that.dimensions = Cartesian3.unpack(voxel.dimensions);
         that.shapeTransform = shapeTransform;
         that.globalTransform = globalTransform;
-        that.maximumTileCount = getTileCount(tilesetJson, metadataSchema);
+        that.maximumTileCount = getTileCount(metadata);
 
         let paddingBefore;
         let paddingAfter;
@@ -177,21 +177,14 @@ Object.defineProperties(Cesium3DTilesVoxelProvider.prototype, {
   },
 });
 
-function getTileCount(tilesetJson, metadataSchema) {
-  if (!defined(tilesetJson.metadata) || !defined(tilesetJson.metadata.class)) {
+function getTileCount(metadata) {
+  if (!defined(metadata.tileset)) {
     return undefined;
   }
 
-  const contentCountProperty =
-    metadataSchema.classes[tilesetJson.metadata.class].propertiesBySemantic[
-      MetadataSemantic.TILESET_TILE_COUNT
-    ];
-
-  if (!defined(contentCountProperty)) {
-    return undefined;
-  }
-
-  return tilesetJson.metadata.properties[contentCountProperty.id];
+  return metadata.tileset.getPropertyBySemantic(
+    MetadataSemantic.TILESET_TILE_COUNT
+  );
 }
 
 function validate(tileset) {

--- a/packages/engine/Source/Scene/Cesium3DTilesVoxelProvider.js
+++ b/packages/engine/Source/Scene/Cesium3DTilesVoxelProvider.js
@@ -14,6 +14,7 @@ import ImplicitSubtree from "./ImplicitSubtree.js";
 import ImplicitSubtreeCache from "./ImplicitSubtreeCache.js";
 import ImplicitTileCoordinates from "./ImplicitTileCoordinates.js";
 import ImplicitTileset from "./ImplicitTileset.js";
+import MetadataSemantic from "./MetadataSemantic.js";
 import MetadataType from "./MetadataType.js";
 import preprocess3DTileContent from "./preprocess3DTileContent.js";
 import ResourceCache from "./ResourceCache.js";
@@ -144,6 +145,7 @@ function Cesium3DTilesVoxelProvider(options) {
         that.dimensions = Cartesian3.unpack(voxel.dimensions);
         that.shapeTransform = shapeTransform;
         that.globalTransform = globalTransform;
+        that.maximumTileCount = getTileCount(tilesetJson, metadataSchema);
 
         let paddingBefore;
         let paddingAfter;
@@ -174,6 +176,23 @@ Object.defineProperties(Cesium3DTilesVoxelProvider.prototype, {
     },
   },
 });
+
+function getTileCount(tilesetJson, metadataSchema) {
+  if (!defined(tilesetJson.metadata) || !defined(tilesetJson.metadata.class)) {
+    return undefined;
+  }
+
+  const contentCountProperty =
+    metadataSchema.classes[tilesetJson.metadata.class].propertiesBySemantic[
+      MetadataSemantic.TILESET_TILE_COUNT
+    ];
+
+  if (!defined(contentCountProperty)) {
+    return undefined;
+  }
+
+  return tilesetJson.metadata.properties[contentCountProperty.id];
+}
 
 function validate(tileset) {
   const root = tileset.root;

--- a/packages/engine/Source/Scene/MetadataSemantic.js
+++ b/packages/engine/Source/Scene/MetadataSemantic.js
@@ -33,6 +33,14 @@ const MetadataSemantic = {
    */
   DESCRIPTION: "DESCRIPTION",
   /**
+   * The number of tiles in a tileset, stored as a <code>UINT64</code>.
+   *
+   * @type {String}
+   * @constant
+   * @private
+   */
+  TILESET_TILE_COUNT: "TILESET_TILE_COUNT",
+  /**
    * A bounding box for a tile, stored as an array of 12 <code>FLOAT32</code> or <code>FLOAT64</code> components. The components are the same format as for <code>boundingVolume.box</code> in 3D Tiles 1.0. This semantic is used to provide a tighter bounding volume than the one implicitly calculated in implicit tiling.
    *
    * @type {String}


### PR DESCRIPTION
`VoxelProvider` has a [`maximumTileCount`](https://github.com/CesiumGS/cesium/blob/505024432161277b9848bc90cc4fafb31f1554d7/packages/engine/Source/Scene/VoxelProvider.js#L199-L209) property that is used to preallocate various data textures of a `VoxelPrimitive`. This property used to exist in `Cesium3DTilesVoxelProvider` but was removed prior to https://github.com/CesiumGS/cesium/pull/10253 being merged because it was not general purpose enough.

The approach in this PR is to look for tileset metadata that uses the `TILESET_TILE_COUNT` semantic. In 3D Tiles 1.1 this would look like:

```json
  "schema": {
    "id": "voxel",
    "classes": {
      "tileset": {
        "properties": {
          "tileCount": {
            "type": "SCALAR",
            "componentType": "UINT64",
            "semantic": "TILESET_TILE_COUNT"
          }
        }
      }
    }
  },
  "metadata": {
    "class": "tileset",
    "properties": {
      "tileCount": 401
    }
  }
```

The reason this PR is important is because without `maximumTileCount` a `VoxelPrimitive` will allocate a megatexture and node texture that far exceed the actual memory usage required by smaller tilesets.

See the corresponding 3D Tiles PR: https://github.com/CesiumGS/3d-tiles/pull/728