### PR TITLE
Use `Matrix4.multiplyTransformation` in more places in `VoxelPrimitive`

### DIFF
--- a/packages/engine/Source/Scene/VoxelPrimitive.js
+++ b/packages/engine/Source/Scene/VoxelPrimitive.js
@@ -1137,13 +1137,13 @@ VoxelPrimitive.prototype.update = function (frameState) {
     uniforms.ndcSpaceAxisAlignedBoundingBox
   );
   const transformPositionViewToWorld = context.uniformState.inverseView;
-  uniforms.transformPositionViewToUv = Matrix4.multiply(
+  uniforms.transformPositionViewToUv = Matrix4.multiplyTransformation(
     this._transformPositionWorldToUv,
     transformPositionViewToWorld,
     uniforms.transformPositionViewToUv
   );
   const transformPositionWorldToView = context.uniformState.view;
-  uniforms.transformPositionUvToView = Matrix4.multiply(
+  uniforms.transformPositionUvToView = Matrix4.multiplyTransformation(
     transformPositionWorldToView,
     this._transformPositionUvToWorld,
     uniforms.transformPositionUvToView
@@ -1365,12 +1365,12 @@ function updateShapeAndTransforms(primitive, shape, provider) {
   // Set member variables when the shape is dirty
   const dimensions = provider.dimensions;
   primitive._stepSizeUv = shape.computeApproximateStepSize(dimensions);
-  primitive._transformPositionWorldToUv = Matrix4.multiply(
+  primitive._transformPositionWorldToUv = Matrix4.multiplyTransformation(
     transformPositionLocalToUv,
     transformPositionWorldToLocal,
     primitive._transformPositionWorldToUv
   );
-  primitive._transformPositionUvToWorld = Matrix4.multiply(
+  primitive._transformPositionUvToWorld = Matrix4.multiplyTransformation(
     transformPositionLocalToWorld,
     transformPositionUvToLocal,
     primitive._transformPositionUvToWorld


### PR DESCRIPTION
I searched through the voxel code and noticed a few areas where [`Matrix4.multiply`](https://cesium.com/learn/ion-sdk/ref-doc/Matrix4.html?classFilter=matrix4#.multiply) could be [`Matrix4.multiplyTransformation`](https://cesium.com/learn/ion-sdk/ref-doc/Matrix4.html?classFilter=matrix4#.multiplyTransformation).

The one section that needs to stay `Matrix4.multiply` is [here](https://github.com/CesiumGS/cesium/blob/c1b384006a5375bcd747a7d4324a0c092ab9176b/packages/engine/Source/Scene/VoxelPrimitive.js#L1711-L1715) because it involves non-affine transformations (the projection matrix).