### PR TITLE
Ellipsoid voxel clipping fixes

### DIFF
--- a/packages/engine/Source/Shaders/Voxels/convertUvToCylinder.glsl
+++ b/packages/engine/Source/Shaders/Voxels/convertUvToCylinder.glsl
@@ -1,8 +1,4 @@
 /* Cylinder defines (set in Scene/VoxelCylinderShape.js)
-#define CYLINDER_HAS_RENDER_BOUNDS_RADIUS_FLAT
-#define CYLINDER_HAS_RENDER_BOUNDS_HEIGHT_FLAT
-#define CYLINDER_HAS_RENDER_BOUNDS_ANGLE_RANGE_EQUAL_ZERO
-
 #define CYLINDER_HAS_SHAPE_BOUNDS_RADIUS
 #define CYLINDER_HAS_SHAPE_BOUNDS_RADIUS_FLAT
 #define CYLINDER_HAS_SHAPE_BOUNDS_HEIGHT
@@ -34,8 +30,8 @@ vec3 convertUvToShapeUvSpace(in vec3 positionUv) {
     vec3 positionLocal = positionUv * 2.0 - 1.0; // [-1,+1]
 
     // Compute radius
-    #if defined(CYLINDER_HAS_SHAPE_BOUNDS_RADIUS_FLAT) || defined(CYLINDER_HAS_RENDER_BOUNDS_RADIUS_FLAT)
-        float radius = length(positionLocal.xy); // [0,1]
+    #if defined(CYLINDER_HAS_SHAPE_BOUNDS_RADIUS_FLAT)
+        float radius = 1.0;
     #else
         float radius = length(positionLocal.xy); // [0,1]
         #if defined(CYLINDER_HAS_SHAPE_BOUNDS_RADIUS)
@@ -44,8 +40,8 @@ vec3 convertUvToShapeUvSpace(in vec3 positionUv) {
     #endif
 
     // Compute height
-    #if defined(CYLINDER_HAS_SHAPE_BOUNDS_HEIGHT_FLAT) || defined(CYLINDER_HAS_RENDER_BOUNDS_HEIGHT_FLAT)
-        float height = positionUv.z; // [0,1]
+    #if defined(CYLINDER_HAS_SHAPE_BOUNDS_HEIGHT_FLAT)
+        float height = 1.0;
     #else
         float height = positionUv.z; // [0,1]
         #if defined(CYLINDER_HAS_SHAPE_BOUNDS_HEIGHT)
@@ -54,7 +50,7 @@ vec3 convertUvToShapeUvSpace(in vec3 positionUv) {
     #endif
 
     // Compute angle
-    #if defined(CYLINDER_HAS_SHAPE_BOUNDS_ANGLE_RANGE_EQUAL_ZERO) || defined(CYLINDER_HAS_RENDER_BOUNDS_ANGLE_RANGE_EQUAL_ZERO)
+    #if defined(CYLINDER_HAS_SHAPE_BOUNDS_ANGLE_RANGE_EQUAL_ZERO)
         float angle = 1.0;
     #else
         float angle = (atan(positionLocal.y, positionLocal.x) + czm_pi) / czm_twoPi; // [0,1]

--- a/packages/engine/Source/Shaders/Voxels/convertUvToEllipsoid.glsl
+++ b/packages/engine/Source/Shaders/Voxels/convertUvToEllipsoid.glsl
@@ -1,14 +1,11 @@
 /* Ellipsoid defines (set in Scene/VoxelEllipsoidShape.js)
-#define ELLIPSOID_HAS_RENDER_BOUNDS_LONGITUDE_RANGE_EQUAL_ZERO
 #define ELLIPSOID_HAS_RENDER_BOUNDS_LONGITUDE_MIN_DISCONTINUITY
 #define ELLIPSOID_HAS_RENDER_BOUNDS_LONGITUDE_MAX_DISCONTINUITY
 #define ELLIPSOID_HAS_SHAPE_BOUNDS_LONGITUDE
 #define ELLIPSOID_HAS_SHAPE_BOUNDS_LONGITUDE_RANGE_EQUAL_ZERO
 #define ELLIPSOID_HAS_SHAPE_BOUNDS_LONGITUDE_MIN_MAX_REVERSED
-#define ELLIPSOID_HAS_RENDER_BOUNDS_LATITUDE_RANGE_EQUAL_ZERO
 #define ELLIPSOID_HAS_SHAPE_BOUNDS_LATITUDE
 #define ELLIPSOID_HAS_SHAPE_BOUNDS_LATITUDE_RANGE_EQUAL_ZERO
-#define ELLIPSOID_HAS_RENDER_BOUNDS_HEIGHT_FLAT
 #define ELLIPSOID_HAS_SHAPE_BOUNDS_HEIGHT_MIN
 #define ELLIPSOID_HAS_SHAPE_BOUNDS_HEIGHT_FLAT
 #define ELLIPSOID_IS_SPHERE
@@ -69,7 +66,7 @@ vec3 convertUvToShapeUvSpace(in vec3 positionUv) {
     #endif
 
     // Compute longitude
-    #if defined(ELLIPSOID_HAS_SHAPE_BOUNDS_LONGITUDE_RANGE_EQUAL_ZERO) || defined(ELLIPSOID_HAS_RENDER_BOUNDS_LONGITUDE_RANGE_EQUAL_ZERO)
+    #if defined(ELLIPSOID_HAS_SHAPE_BOUNDS_LONGITUDE_RANGE_EQUAL_ZERO)
         float longitude = 1.0;
     #else
         float longitude = (atan(normal.y, normal.x) + czm_pi) / czm_twoPi;
@@ -94,7 +91,7 @@ vec3 convertUvToShapeUvSpace(in vec3 positionUv) {
     #endif
 
     // Compute latitude
-    #if defined(ELLIPSOID_HAS_SHAPE_BOUNDS_LATITUDE_RANGE_EQUAL_ZERO) || defined(ELLIPSOID_HAS_RENDER_BOUNDS_LATITUDE_RANGE_EQUAL_ZERO)
+    #if defined(ELLIPSOID_HAS_SHAPE_BOUNDS_LATITUDE_RANGE_EQUAL_ZERO)
         float latitude = 1.0;
     #else
         float latitude = (asin(normal.z) + czm_piOverTwo) / czm_pi;
@@ -104,7 +101,7 @@ vec3 convertUvToShapeUvSpace(in vec3 positionUv) {
     #endif
 
     // Compute height
-    #if defined(ELLIPSOID_HAS_SHAPE_BOUNDS_HEIGHT_FLAT) || defined(ELLIPSOID_HAS_RENDER_BOUNDS_HEIGHT_FLAT)
+    #if defined(ELLIPSOID_HAS_SHAPE_BOUNDS_HEIGHT_FLAT)
         // TODO: This breaks down when minBounds == maxBounds. To fix it, this
         // function would have to know if ray is intersecting the front or back of the shape
         // and set the shape space position to 1 (front) or 0 (back) accordingly.


### PR DESCRIPTION
Ellipsoid clipping was broken in two ways:

* The intersection against the ellipsoid was not taking into account the height difference between the clip height and the shape height. So even if the clip height was less than the shape height the intersection would act as if it hit the shape height.
* Voxels with infinitely thin clipping bounds would always render the topmost voxels. Several `RENDER` related defines were incorrectly used in `convertUvToCylinder` and `convertUvToEllipsoid`.

In [this sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=3Vp7b9tGEv8qhP+iZIZ+JbjCsoNzFLs1al+MyEgjWUZKkyuLOL5KLhWShb57Zx9c7oOSrevd4XpGEIm785udmZ3XruinSYGtVYi+o9w6txL03RqjIixj9wsds+d7Pn0epwn2wgTl8z3H+n2eWNZzlD6hU2vhRQWaJ+vBaJ7ME8bJRRVGSWBzVmzwS1qh6DopMuTjNL8NqzAhGI4ofJQgN0BP5fNkmX6/yr0YFXconyA/TQIQDeclokssysTHYZpYzwjfhsmHtEyCwi6WXoYGTLJwYbFn6/z8XOhDlp+Q0fs6Q+7lzc313eTT9UeOsSyfmiJuOVoCOfZyDN+85MT1ozRBNqO3NnDuEYsBiLbkUyzhNrDIoXvIx3OEyzzppunwmqgs5mAYLWAXAphbG8bwqn+3MVqOf8oYmliaMdpZaoyjQ/pnmKQl2skkd3nqo6DMvWgSJs8Rug8jRMWDiVUYgHPLdsLLsHC5oSz6ORLDslP0bK9EKBmsR/WOMAhjlBQgZaFGXWde+wfHIv8kUEJiAugfICjTKIVQfOwmMZibTnJOtwh7gYc9ug1fLsdvJVo/jTPYuwTfbwCNZQL36ubTxf3JscQgR15Qd0Epj4Jx47AgRuTfYLhIoxWyCc2g3SXmYIWfe9hfjok2miHIkM2Syosb6WZ5ilNiAVjstxIV+CMoAQyFL1A3TTPyvZgnfMuZDBi43aAVioCeU7hibKTSfdVovmrzU21+qs3PtPnZiPkyCdJOjvcQCCISe9xchABjrPiS5l3S+itisTG4IwayjsKtrKH8WKuPjaxBTYOjc7eHw0dp2l96SdIt0eeHEBPCtSidTfgMJCbM+zp3uIpSD58cX+S5V9uSCkNlucFINkjuJUEaTxCCusGMyGy/Tc/K2uc72DvMNrpVycNLt0D4M13nH2X8ROoUCuxuYVmlZYkkcxBsAvVRBtut/AvQ244QtmhlGMHHmboZVrO/L1xDUNeMulapaxiRqCX6itFXKn0FIwp9q0CE8gzlxPcr68CyFfO8AVcd9QNIMNQaoN4GINHRaICmBeiQJRATy+4L8YZQS98Bebs6eT4R8zP6fGwsTYLmyD3UcCbditbqd8DvGKiHxJCM7RsyPNiA8rkry1nNXUBi/KmI7KVjFY61csj6jpIL+xQOIQNUrUOzv+ZFl+4ZqhTeIt4eGH81roD88BHEp2pAbg1GOyCPOuRzjlCyC/a4wz5FvMa8EnrySHfqb+8EaM2+rM3mQS9RD4L7I61Uow0NxW0Z4fAv1k+8dSzyTwJlXhBAQf2AIDGgjbgj8E+nDVoZd7HA+qFhK+z/pH0R9N8iUq3bcnfcMfrmRRF1DN6FEAOxAqbj1LqlwUxeUlFR1tbZ/tmizIumXOfJ0EDvJj7u2nmQGqIh3aqXctpDWfdSznooG72eRrzBg6rHvp5JFuRjUu0TjdUFbltDWriz9Lt97DDytorp8lCAUJSrPZSYbcNNFdz01biZgpu9gCMHa65XmyMN+YemaMbQTGFNrcJ915bd9oHOPCqRoKzbyaNmc35U7KphXwejS653MX1dkq6a3in1d2KG9ko39kKtZtX6ZZt+tfZVWP0KmmpkyqB1bQYLrRHb0LsZAm+FiQ7OcM8NsBxlyKNp4d3G2enWWbLkkTJL/eMm9T0Stl1zyJcySGuVdCpIpwZpo5LOBOlMIRWL8y9vWPJYRCkcadmYagshQt0DqHsAQpCmB9D0AJjFqo/hYiHLBZ1rD1nNyertZA0na1QykzAIC9xm0OK3HNua81I+Q/65z5cf8s99vs6QfcrQPhW9KFt6rKXXZBHpaWuny/1ltBPyqENOd0Med8jZbkja5lJtJdx6Q8u7Vq9R+tvXv/wtyms7I+O2RWrIXn/t8t+4DdE7dLNtN4nbttxo1Uc7Xxl1g3eMT+89MDnOXkYISHHBQ1s7cioSyyNULrdyDFRtoGodVZuoxkA1OqrRG9mNTZ7wkEGvRX6M0ieagnc3iNyc9am+fb5R5nV14GgZxmXMpBtDOQh6RZxdfv4ko7zKRPWf63R5GIbdBDkbJuttk/SGp1OD1FmfSCAM3C+HRk2y2VZa9YpRMN96yKKR2jFW7iJ1bXiEkO1tk7A5WW+bbLpJvQl+3f2gYLTLNaEQbbfbQqFu36Vhtx8vBEflWLVjNU6H2XjzxRiqBZ9jXPUeTDJ27/7s9zPZkbzSBJU9tu+3Mi/OlL7nVWmj/WNV07jKsyVxIIq0NDtwTCZT/cZQYVIbTOo+JtpNeqMyaQwmjc5EspbSzylkZiZTp42U5RgbpS+x0bnandvAQXMwkdWGfXlwfxOTXelVDxPh6LNw9CEc5TQBI8ZhtM1fD10EGX2k/6ifU7v8+CBq4OODbKceJq9oQrffuhLp+i5d/RzOV+guD+MQh0Cc8W4VckZZ4DSeLD36FKcBiqB+52HFraC8WZC1DMg9X5yu0EUUaXVhxZphTkcuVDYwAOfm8Sm/L6GgbbEPrbyn4pvwU1mBU1WdlkTS6lR+4ATrgVwdVAWU+0xG7uIlSuyunZfcheu6Ul7SoG9u3JJVXdM4ysBI4+N7Mco9OJDW9ym9soZsMMmWKEe2JuWTMuvIDkzOKkTQU/KShDDJuj32rfmrBLAY9peSWijP01zSjWxvCpkpSp/5nOAwUn4OMHSSfqqWt6fv92ppmm3+IveeSS5nY/eowqfWr6s0DMTMrRcm9hV/uE6yEluLgn46kJZSePSb+Fu76ygPIfRi/oXqLjRsR6GNXyxKen3NObkxP3G4/Dec56eRgVIPzWCXXx3xRo+p/S/LEKP/ce1XyD+xQZ3Bv6KsFGfKD7fw/JZW6YnvRezNl1dVcU50GUVhVoAJ3F9+nPzw1uUV7LMXhGXh/EdIaXaYJ0y5iZcEvldgiATIYPdpGj15+S1KSvtBMiemWzXfE3yhnHc3BxZJ0/M9LgJYC0WQKU6t3pzCj6U87XGPefmtnC4BvPC2UkvYbXK7Ypem9PLRMTfSsWXGuDQnOYW+7pqSkf8fZTeCEhlE+i9kE5/8FDrJPB9drsBHfmJEtlJrfC9ZefTHJs6DvG1AQ+OCWlnKdaSUEV9TLmMoF62AyVcTNDmTnyX5auRRPg2mEER3aRHSJc6tdg04GbMx+dIh9P+JArkw8HIJ47bCqDultrlYw9Li72wyFN36m8ur+2/jm+vxz1tc+kOJMdhovjcGDyavK7bWstXGYGOt8wGXkfY1rW69aia9pLcLMkw6JKSXPWfvrMB1hN637vP3MM7SHFtlHtmue4BRnEXgq8XBUwl2wa5fFK2HnR3I0LMgXFlhcN7zbqYFB42igJlFGUGANRCr788OgN6AwlmWlN1PK5RHXk3Ilkfvb9ig67pnB/DYj8TMzBrnPwA) you can see that changing the clipping min/max height to the same value works now. It correctly samples data in the middle of the voxel grid rather than the outer edge.

Before|After
--|--
![bad](https://user-images.githubusercontent.com/915398/210894241-0561e89e-25b3-43ee-af5c-597326b58360.png)|![good](https://user-images.githubusercontent.com/915398/210894239-33a7c9ca-77c1-43bc-89f5-fb3c98a77e27.png)