### PR TITLE
Build specs as part of test command

### DIFF
--- a/build.js
+++ b/build.js
@@ -288,6 +288,10 @@ const workspaceSpecFiles = {
   widgets: ["packages/widgets/Specs/**/*Spec.js"],
 };
 
+/**
+ * Creates a single entry point file, Specs/SpecList.js, which imports all individual spec files.
+ * @returns {Buffer} contents
+ */
 export async function createCombinedSpecList() {
   let contents = `export const VERSION = '${version}';\n`;
 
@@ -297,28 +301,6 @@ export async function createCombinedSpecList() {
       contents += `import '../${file}';\n`;
     }
   }
-
-  await writeFile(path.join("Specs", "SpecList.js"), contents, {
-    encoding: "utf-8",
-  });
-
-  return contents;
-}
-
-/**
- * Creates a single entry point file, SpecList.js, which imports all individual spec files.
- * @returns {Buffer} contents
- */
-export async function createSpecList() {
-  const files = await globby(["Specs/**/*Spec.js"]);
-
-  let contents = "";
-  files.forEach(function (file) {
-    contents += `import './${filePathToModuleId(file).replace(
-      "Specs/",
-      ""
-    )}.js';\n`;
-  });
 
   await writeFile(path.join("Specs", "SpecList.js"), contents, {
     encoding: "utf-8",
@@ -895,7 +877,7 @@ async function createIndexJs(workspace) {
  * @param {String} workspace The workspace.
  * @param {String} outputPath The path the file is written to.
  */
-async function createSpecListJs(files, workspace, outputPath) {
+async function createSpecListForWorkspace(files, workspace, outputPath) {
   let contents = "";
   files.forEach(function (file) {
     contents += `import './${filePathToModuleId(file).replace(
@@ -1020,7 +1002,7 @@ export const buildEngine = async (options) => {
   // Create SpecList.js
   const specFiles = await globby(workspaceSpecFiles["engine"]);
   const specListFile = path.join("packages/engine/Specs", "SpecList.js");
-  await createSpecListJs(specFiles, "engine", specListFile);
+  await createSpecListForWorkspace(specFiles, "engine", specListFile);
 
   await bundleSpecs({
     incremental: incremental,
@@ -1056,7 +1038,7 @@ export const buildWidgets = async (options) => {
   // Create SpecList.js
   const specFiles = await globby(workspaceSpecFiles["widgets"]);
   const specListFile = path.join("packages/widgets/Specs", "SpecList.js");
-  await createSpecListJs(specFiles, "widgets", specListFile);
+  await createSpecListForWorkspace(specFiles, "widgets", specListFile);
 
   await bundleSpecs({
     incremental: incremental,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,10 +37,11 @@ import {
   buildWidgets,
   bundleWorkers,
   glslToJavaScript,
-  createSpecList,
+  createCombinedSpecList,
   createJsHintOptions,
   defaultESBuildOptions,
   bundleCombinedWorkers,
+  bundleCombinedSpecs,
 } from "./build.js";
 
 // Determines the scope of the workspace packages. If the scope is set to cesium, the workspaces should be @cesium/engine.
@@ -215,7 +216,7 @@ export const buildWatch = gulp.series(build, async function () {
       events: ["add", "unlink"],
     },
     async () => {
-      createSpecList();
+      createCombinedSpecList();
       specResult = await specResult.rebuild();
     }
   );
@@ -1496,6 +1497,9 @@ export async function coverage() {
 }
 
 export async function test() {
+  await createCombinedSpecList();
+  await bundleCombinedSpecs();
+
   const enableAllBrowsers = argv.all ? true : false;
   const includeCategory = argv.include ? argv.include : "";
   const excludeCategory = argv.exclude ? argv.exclude : "";


### PR DESCRIPTION
This change makes running tests on the command line a bit simpler for convenience's sake. Previously, you would need to re-run (or rely on `npm start` to be running in the background) after making a change to a spec to see the updated code reflected in `npm run test`. That could be particularly annoying if you made a quick change, such as focusing a test with `fit`, as you need to remember to rebuild.

The `test` command now incorporate that build spec step, which should only take about an extra second or so.

I also clean up the function names a bit here for clarity, and remove an unused function.