### PR TITLE
Update compute fly to location for rectangle.js

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 ##### Fixes :wrench:
 
 - Fixed a bug decoding glTF Draco attributes with quantization bits above 16. [#7471](https://github.com/CesiumGS/cesium/issues/7471)
+- Fixed a bug where return value for `Scene/computeFlyToLocationForRectangle.js`. [#10937](https://github.com/CesiumGS/cesium/issues/10937)
 
 ### 1.101 - 2023-01-02
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -342,3 +342,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 - [Calogero Mauceri](https://github.com/calogeromauceri)
 - [Marcel Wendler](https://github.com/UniquePanda)
 - [JiaoJianing](https://github.com/JiaoJianing)
+- [Southjor](https://github.com/Southjor)


### PR DESCRIPTION
修复加载地形（terrain）之后，viewr.flyTo(ImageryLayer) 报错问题 [#10937](https://github.com/CesiumGS/cesium/issues/10937)。