### PR TITLE
Deprecate `ready`/`readyPromise` for terrainProviders

### DIFF
--- a/Apps/CesiumViewer/CesiumViewer.js
+++ b/Apps/CesiumViewer/CesiumViewer.js
@@ -65,6 +65,7 @@ function main() {
       viewModel.selectedTerrain = viewModel.terrainProviderViewModels[1];
     } else {
       viewer.terrainProvider = createWorldTerrain({
+        // TODO
         requestWaterMask: true,
         requestVertexNormals: true,
       });

--- a/Apps/CesiumViewer/CesiumViewer.js
+++ b/Apps/CesiumViewer/CesiumViewer.js
@@ -4,7 +4,7 @@ if (window.CESIUM_BASE_URL === undefined) {
 
 import {
   Cartesian3,
-  createWorldTerrain,
+  createWorldTerrainAsync,
   defined,
   formatError,
   Math as CesiumMath,
@@ -53,21 +53,27 @@ function main() {
   let viewer;
   try {
     const hasBaseLayerPicker = !defined(imageryProvider);
+
+    let terrainProvider;
+    if (hasBaseLayerPicker) {
+      terrainProvider = createWorldTerrainAsync({
+        requestWaterMask: true,
+        requestVertexNormals: true,
+      });
+    }
+
     viewer = new Viewer("cesiumContainer", {
       imageryProvider: imageryProvider,
       baseLayerPicker: hasBaseLayerPicker,
       scene3DOnly: endUserOptions.scene3DOnly,
       requestRenderMode: true,
+      terrainProvider: terrainProvider,
     });
 
     if (hasBaseLayerPicker) {
-      const viewModel = viewer.baseLayerPicker.viewModel;
-      viewModel.selectedTerrain = viewModel.terrainProviderViewModels[1];
-    } else {
-      viewer.terrainProvider = createWorldTerrain({
-        // TODO
-        requestWaterMask: true,
-        requestVertexNormals: true,
+      Promise.resolve(terrainProvider).then(() => {
+        const viewModel = viewer.baseLayerPicker.viewModel;
+        viewModel.selectedTerrain = viewModel.terrainProviderViewModels[1];
       });
     }
   } catch (exception) {

--- a/Apps/CesiumViewer/CesiumViewer.js
+++ b/Apps/CesiumViewer/CesiumViewer.js
@@ -54,13 +54,10 @@ async function main() {
   try {
     const hasBaseLayerPicker = !defined(imageryProvider);
 
-    let terrainProvider;
-    if (hasBaseLayerPicker) {
-      terrainProvider = await createWorldTerrainAsync({
-        requestWaterMask: true,
-        requestVertexNormals: true,
-      });
-    }
+    const terrainProvider = await createWorldTerrainAsync({
+      requestWaterMask: true,
+      requestVertexNormals: true,
+    });
 
     viewer = new Viewer("cesiumContainer", {
       imageryProvider: imageryProvider,

--- a/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
@@ -33,278 +33,278 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        // A simple demo of 3D Tiles feature picking with hover and select behavior
-        // Building data courtesy of NYC OpenData portal: http://www1.nyc.gov/site/doitt/initiatives/3d-building.page
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
+        (async () => {
+          // A simple demo of 3D Tiles feature picking with hover and select behavior
+          // Building data courtesy of NYC OpenData portal: http://www1.nyc.gov/site/doitt/initiatives/3d-building.page
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
 
-        viewer.scene.globe.depthTestAgainstTerrain = true;
+          viewer.scene.globe.depthTestAgainstTerrain = true;
 
-        // Set the initial camera view to look at Manhattan
-        const initialPosition = Cesium.Cartesian3.fromDegrees(
-          -74.01881302800248,
-          40.69114333714821,
-          753
-        );
-        const initialOrientation = new Cesium.HeadingPitchRoll.fromDegrees(
-          21.27879878293835,
-          -21.34390550872461,
-          0.0716951918898415
-        );
-        viewer.scene.camera.setView({
-          destination: initialPosition,
-          orientation: initialOrientation,
-          endTransform: Cesium.Matrix4.IDENTITY,
-        });
-
-        // Load the NYC buildings tileset
-        const tileset = new Cesium.Cesium3DTileset({
-          url: Cesium.IonResource.fromAssetId(75343),
-        });
-        viewer.scene.primitives.add(tileset);
-
-        // HTML overlay for showing feature name on mouseover
-        const nameOverlay = document.createElement("div");
-        viewer.container.appendChild(nameOverlay);
-        nameOverlay.className = "backdrop";
-        nameOverlay.style.display = "none";
-        nameOverlay.style.position = "absolute";
-        nameOverlay.style.bottom = "0";
-        nameOverlay.style.left = "0";
-        nameOverlay.style["pointer-events"] = "none";
-        nameOverlay.style.padding = "4px";
-        nameOverlay.style.backgroundColor = "black";
-
-        // Information about the currently selected feature
-        const selected = {
-          feature: undefined,
-          originalColor: new Cesium.Color(),
-        };
-
-        // An entity object which will hold info about the currently selected feature for infobox display
-        const selectedEntity = new Cesium.Entity();
-
-        // Get default left click handler for when a feature is not picked on left click
-        const clickHandler = viewer.screenSpaceEventHandler.getInputAction(
-          Cesium.ScreenSpaceEventType.LEFT_CLICK
-        );
-
-        // If silhouettes are supported, silhouette features in blue on mouse over and silhouette green on mouse click.
-        // If silhouettes are not supported, change the feature color to yellow on mouse over and green on mouse click.
-        if (
-          Cesium.PostProcessStageLibrary.isSilhouetteSupported(viewer.scene)
-        ) {
-          // Silhouettes are supported
-          const silhouetteBlue = Cesium.PostProcessStageLibrary.createEdgeDetectionStage();
-          silhouetteBlue.uniforms.color = Cesium.Color.BLUE;
-          silhouetteBlue.uniforms.length = 0.01;
-          silhouetteBlue.selected = [];
-
-          const silhouetteGreen = Cesium.PostProcessStageLibrary.createEdgeDetectionStage();
-          silhouetteGreen.uniforms.color = Cesium.Color.LIME;
-          silhouetteGreen.uniforms.length = 0.01;
-          silhouetteGreen.selected = [];
-
-          viewer.scene.postProcessStages.add(
-            Cesium.PostProcessStageLibrary.createSilhouetteStage([
-              silhouetteBlue,
-              silhouetteGreen,
-            ])
+          // Set the initial camera view to look at Manhattan
+          const initialPosition = Cesium.Cartesian3.fromDegrees(
+            -74.01881302800248,
+            40.69114333714821,
+            753
           );
+          const initialOrientation = new Cesium.HeadingPitchRoll.fromDegrees(
+            21.27879878293835,
+            -21.34390550872461,
+            0.0716951918898415
+          );
+          viewer.scene.camera.setView({
+            destination: initialPosition,
+            orientation: initialOrientation,
+            endTransform: Cesium.Matrix4.IDENTITY,
+          });
 
-          // Silhouette a feature blue on hover.
-          viewer.screenSpaceEventHandler.setInputAction(function onMouseMove(
-            movement
-          ) {
-            // If a feature was previously highlighted, undo the highlight
-            silhouetteBlue.selected = [];
+          // Load the NYC buildings tileset
+          const tileset = new Cesium.Cesium3DTileset({
+            url: Cesium.IonResource.fromAssetId(75343),
+          });
+          viewer.scene.primitives.add(tileset);
 
-            // Pick a new feature
-            const pickedFeature = viewer.scene.pick(movement.endPosition);
-            if (!Cesium.defined(pickedFeature)) {
-              nameOverlay.style.display = "none";
-              return;
-            }
+          // HTML overlay for showing feature name on mouseover
+          const nameOverlay = document.createElement("div");
+          viewer.container.appendChild(nameOverlay);
+          nameOverlay.className = "backdrop";
+          nameOverlay.style.display = "none";
+          nameOverlay.style.position = "absolute";
+          nameOverlay.style.bottom = "0";
+          nameOverlay.style.left = "0";
+          nameOverlay.style["pointer-events"] = "none";
+          nameOverlay.style.padding = "4px";
+          nameOverlay.style.backgroundColor = "black";
 
-            // A feature was picked, so show it's overlay content
-            nameOverlay.style.display = "block";
-            nameOverlay.style.bottom = `${
-              viewer.canvas.clientHeight - movement.endPosition.y
-            }px`;
-            nameOverlay.style.left = `${movement.endPosition.x}px`;
-            const name = pickedFeature.getProperty("BIN");
-            nameOverlay.textContent = name;
-
-            // Highlight the feature if it's not already selected.
-            if (pickedFeature !== selected.feature) {
-              silhouetteBlue.selected = [pickedFeature];
-            }
-          },
-          Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-
-          // Silhouette a feature on selection and show metadata in the InfoBox.
-          viewer.screenSpaceEventHandler.setInputAction(function onLeftClick(
-            movement
-          ) {
-            // If a feature was previously selected, undo the highlight
-            silhouetteGreen.selected = [];
-
-            // Pick a new feature
-            const pickedFeature = viewer.scene.pick(movement.position);
-            if (!Cesium.defined(pickedFeature)) {
-              clickHandler(movement);
-              return;
-            }
-
-            // Select the feature if it's not already selected
-            if (silhouetteGreen.selected[0] === pickedFeature) {
-              return;
-            }
-
-            // Save the selected feature's original color
-            const highlightedFeature = silhouetteBlue.selected[0];
-            if (pickedFeature === highlightedFeature) {
-              silhouetteBlue.selected = [];
-            }
-
-            // Highlight newly selected feature
-            silhouetteGreen.selected = [pickedFeature];
-
-            // Set feature infobox description
-            const featureName = pickedFeature.getProperty("name");
-            selectedEntity.name = featureName;
-            selectedEntity.description =
-              'Loading <div class="cesium-infoBox-loading"></div>';
-            viewer.selectedEntity = selectedEntity;
-            selectedEntity.description =
-              `${
-                '<table class="cesium-infoBox-defaultTable"><tbody>' +
-                "<tr><th>BIN</th><td>"
-              }${pickedFeature.getProperty("BIN")}</td></tr>` +
-              `<tr><th>DOITT ID</th><td>${pickedFeature.getProperty(
-                "DOITT_ID"
-              )}</td></tr>` +
-              `<tr><th>SOURCE ID</th><td>${pickedFeature.getProperty(
-                "SOURCE_ID"
-              )}</td></tr>` +
-              `</tbody></table>`;
-          },
-          Cesium.ScreenSpaceEventType.LEFT_CLICK);
-        } else {
-          // Silhouettes are not supported. Instead, change the feature color.
-
-          // Information about the currently highlighted feature
-          const highlighted = {
+          // Information about the currently selected feature
+          const selected = {
             feature: undefined,
             originalColor: new Cesium.Color(),
           };
 
-          // Color a feature yellow on hover.
-          viewer.screenSpaceEventHandler.setInputAction(function onMouseMove(
-            movement
-          ) {
-            // If a feature was previously highlighted, undo the highlight
-            if (Cesium.defined(highlighted.feature)) {
-              highlighted.feature.color = highlighted.originalColor;
-              highlighted.feature = undefined;
-            }
-            // Pick a new feature
-            const pickedFeature = viewer.scene.pick(movement.endPosition);
-            if (!Cesium.defined(pickedFeature)) {
-              nameOverlay.style.display = "none";
-              return;
-            }
-            // A feature was picked, so show it's overlay content
-            nameOverlay.style.display = "block";
-            nameOverlay.style.bottom = `${
-              viewer.canvas.clientHeight - movement.endPosition.y
-            }px`;
-            nameOverlay.style.left = `${movement.endPosition.x}px`;
-            let name = pickedFeature.getProperty("name");
-            if (!Cesium.defined(name)) {
-              name = pickedFeature.getProperty("id");
-            }
-            nameOverlay.textContent = name;
-            // Highlight the feature if it's not already selected.
-            if (pickedFeature !== selected.feature) {
-              highlighted.feature = pickedFeature;
-              Cesium.Color.clone(
-                pickedFeature.color,
-                highlighted.originalColor
-              );
-              pickedFeature.color = Cesium.Color.YELLOW;
-            }
-          },
-          Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+          // An entity object which will hold info about the currently selected feature for infobox display
+          const selectedEntity = new Cesium.Entity();
 
-          // Color a feature on selection and show metadata in the InfoBox.
-          viewer.screenSpaceEventHandler.setInputAction(function onLeftClick(
-            movement
-          ) {
-            // If a feature was previously selected, undo the highlight
-            if (Cesium.defined(selected.feature)) {
-              selected.feature.color = selected.originalColor;
-              selected.feature = undefined;
-            }
-            // Pick a new feature
-            const pickedFeature = viewer.scene.pick(movement.position);
-            if (!Cesium.defined(pickedFeature)) {
-              clickHandler(movement);
-              return;
-            }
-            // Select the feature if it's not already selected
-            if (selected.feature === pickedFeature) {
-              return;
-            }
-            selected.feature = pickedFeature;
-            // Save the selected feature's original color
-            if (pickedFeature === highlighted.feature) {
-              Cesium.Color.clone(
-                highlighted.originalColor,
-                selected.originalColor
-              );
-              highlighted.feature = undefined;
-            } else {
-              Cesium.Color.clone(pickedFeature.color, selected.originalColor);
-            }
-            // Highlight newly selected feature
-            pickedFeature.color = Cesium.Color.LIME;
-            // Set feature infobox description
-            const featureName = pickedFeature.getProperty("name");
-            selectedEntity.name = featureName;
-            selectedEntity.description =
-              'Loading <div class="cesium-infoBox-loading"></div>';
-            viewer.selectedEntity = selectedEntity;
-            selectedEntity.description =
-              `${
-                '<table class="cesium-infoBox-defaultTable"><tbody>' +
-                "<tr><th>BIN</th><td>"
-              }${pickedFeature.getProperty("BIN")}</td></tr>` +
-              `<tr><th>DOITT ID</th><td>${pickedFeature.getProperty(
-                "DOITT_ID"
-              )}</td></tr>` +
-              `<tr><th>SOURCE ID</th><td>${pickedFeature.getProperty(
-                "SOURCE_ID"
-              )}</td></tr>` +
-              `<tr><th>Longitude</th><td>${pickedFeature.getProperty(
-                "longitude"
-              )}</td></tr>` +
-              `<tr><th>Latitude</th><td>${pickedFeature.getProperty(
-                "latitude"
-              )}</td></tr>` +
-              `<tr><th>Height</th><td>${pickedFeature.getProperty(
-                "height"
-              )}</td></tr>` +
-              `<tr><th>Terrain Height (Ellipsoid)</th><td>${pickedFeature.getProperty(
-                "TerrainHeight"
-              )}</td></tr>` +
-              `</tbody></table>`;
-          },
-          Cesium.ScreenSpaceEventType.LEFT_CLICK);
-        }
+          // Get default left click handler for when a feature is not picked on left click
+          const clickHandler = viewer.screenSpaceEventHandler.getInputAction(
+            Cesium.ScreenSpaceEventType.LEFT_CLICK
+          );
 
-        //Sandcastle_End
+          // If silhouettes are supported, silhouette features in blue on mouse over and silhouette green on mouse click.
+          // If silhouettes are not supported, change the feature color to yellow on mouse over and green on mouse click.
+          if (
+            Cesium.PostProcessStageLibrary.isSilhouetteSupported(viewer.scene)
+          ) {
+            // Silhouettes are supported
+            const silhouetteBlue = Cesium.PostProcessStageLibrary.createEdgeDetectionStage();
+            silhouetteBlue.uniforms.color = Cesium.Color.BLUE;
+            silhouetteBlue.uniforms.length = 0.01;
+            silhouetteBlue.selected = [];
+
+            const silhouetteGreen = Cesium.PostProcessStageLibrary.createEdgeDetectionStage();
+            silhouetteGreen.uniforms.color = Cesium.Color.LIME;
+            silhouetteGreen.uniforms.length = 0.01;
+            silhouetteGreen.selected = [];
+
+            viewer.scene.postProcessStages.add(
+              Cesium.PostProcessStageLibrary.createSilhouetteStage([
+                silhouetteBlue,
+                silhouetteGreen,
+              ])
+            );
+
+            // Silhouette a feature blue on hover.
+            viewer.screenSpaceEventHandler.setInputAction(function onMouseMove(
+              movement
+            ) {
+              // If a feature was previously highlighted, undo the highlight
+              silhouetteBlue.selected = [];
+
+              // Pick a new feature
+              const pickedFeature = viewer.scene.pick(movement.endPosition);
+              if (!Cesium.defined(pickedFeature)) {
+                nameOverlay.style.display = "none";
+                return;
+              }
+
+              // A feature was picked, so show it's overlay content
+              nameOverlay.style.display = "block";
+              nameOverlay.style.bottom = `${
+                viewer.canvas.clientHeight - movement.endPosition.y
+              }px`;
+              nameOverlay.style.left = `${movement.endPosition.x}px`;
+              const name = pickedFeature.getProperty("BIN");
+              nameOverlay.textContent = name;
+
+              // Highlight the feature if it's not already selected.
+              if (pickedFeature !== selected.feature) {
+                silhouetteBlue.selected = [pickedFeature];
+              }
+            },
+            Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+
+            // Silhouette a feature on selection and show metadata in the InfoBox.
+            viewer.screenSpaceEventHandler.setInputAction(function onLeftClick(
+              movement
+            ) {
+              // If a feature was previously selected, undo the highlight
+              silhouetteGreen.selected = [];
+
+              // Pick a new feature
+              const pickedFeature = viewer.scene.pick(movement.position);
+              if (!Cesium.defined(pickedFeature)) {
+                clickHandler(movement);
+                return;
+              }
+
+              // Select the feature if it's not already selected
+              if (silhouetteGreen.selected[0] === pickedFeature) {
+                return;
+              }
+
+              // Save the selected feature's original color
+              const highlightedFeature = silhouetteBlue.selected[0];
+              if (pickedFeature === highlightedFeature) {
+                silhouetteBlue.selected = [];
+              }
+
+              // Highlight newly selected feature
+              silhouetteGreen.selected = [pickedFeature];
+
+              // Set feature infobox description
+              const featureName = pickedFeature.getProperty("name");
+              selectedEntity.name = featureName;
+              selectedEntity.description =
+                'Loading <div class="cesium-infoBox-loading"></div>';
+              viewer.selectedEntity = selectedEntity;
+              selectedEntity.description =
+                `${
+                  '<table class="cesium-infoBox-defaultTable"><tbody>' +
+                  "<tr><th>BIN</th><td>"
+                }${pickedFeature.getProperty("BIN")}</td></tr>` +
+                `<tr><th>DOITT ID</th><td>${pickedFeature.getProperty(
+                  "DOITT_ID"
+                )}</td></tr>` +
+                `<tr><th>SOURCE ID</th><td>${pickedFeature.getProperty(
+                  "SOURCE_ID"
+                )}</td></tr>` +
+                `</tbody></table>`;
+            },
+            Cesium.ScreenSpaceEventType.LEFT_CLICK);
+          } else {
+            // Silhouettes are not supported. Instead, change the feature color.
+
+            // Information about the currently highlighted feature
+            const highlighted = {
+              feature: undefined,
+              originalColor: new Cesium.Color(),
+            };
+
+            // Color a feature yellow on hover.
+            viewer.screenSpaceEventHandler.setInputAction(function onMouseMove(
+              movement
+            ) {
+              // If a feature was previously highlighted, undo the highlight
+              if (Cesium.defined(highlighted.feature)) {
+                highlighted.feature.color = highlighted.originalColor;
+                highlighted.feature = undefined;
+              }
+              // Pick a new feature
+              const pickedFeature = viewer.scene.pick(movement.endPosition);
+              if (!Cesium.defined(pickedFeature)) {
+                nameOverlay.style.display = "none";
+                return;
+              }
+              // A feature was picked, so show it's overlay content
+              nameOverlay.style.display = "block";
+              nameOverlay.style.bottom = `${
+                viewer.canvas.clientHeight - movement.endPosition.y
+              }px`;
+              nameOverlay.style.left = `${movement.endPosition.x}px`;
+              let name = pickedFeature.getProperty("name");
+              if (!Cesium.defined(name)) {
+                name = pickedFeature.getProperty("id");
+              }
+              nameOverlay.textContent = name;
+              // Highlight the feature if it's not already selected.
+              if (pickedFeature !== selected.feature) {
+                highlighted.feature = pickedFeature;
+                Cesium.Color.clone(
+                  pickedFeature.color,
+                  highlighted.originalColor
+                );
+                pickedFeature.color = Cesium.Color.YELLOW;
+              }
+            },
+            Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+
+            // Color a feature on selection and show metadata in the InfoBox.
+            viewer.screenSpaceEventHandler.setInputAction(function onLeftClick(
+              movement
+            ) {
+              // If a feature was previously selected, undo the highlight
+              if (Cesium.defined(selected.feature)) {
+                selected.feature.color = selected.originalColor;
+                selected.feature = undefined;
+              }
+              // Pick a new feature
+              const pickedFeature = viewer.scene.pick(movement.position);
+              if (!Cesium.defined(pickedFeature)) {
+                clickHandler(movement);
+                return;
+              }
+              // Select the feature if it's not already selected
+              if (selected.feature === pickedFeature) {
+                return;
+              }
+              selected.feature = pickedFeature;
+              // Save the selected feature's original color
+              if (pickedFeature === highlighted.feature) {
+                Cesium.Color.clone(
+                  highlighted.originalColor,
+                  selected.originalColor
+                );
+                highlighted.feature = undefined;
+              } else {
+                Cesium.Color.clone(pickedFeature.color, selected.originalColor);
+              }
+              // Highlight newly selected feature
+              pickedFeature.color = Cesium.Color.LIME;
+              // Set feature infobox description
+              const featureName = pickedFeature.getProperty("name");
+              selectedEntity.name = featureName;
+              selectedEntity.description =
+                'Loading <div class="cesium-infoBox-loading"></div>';
+              viewer.selectedEntity = selectedEntity;
+              selectedEntity.description =
+                `${
+                  '<table class="cesium-infoBox-defaultTable"><tbody>' +
+                  "<tr><th>BIN</th><td>"
+                }${pickedFeature.getProperty("BIN")}</td></tr>` +
+                `<tr><th>DOITT ID</th><td>${pickedFeature.getProperty(
+                  "DOITT_ID"
+                )}</td></tr>` +
+                `<tr><th>SOURCE ID</th><td>${pickedFeature.getProperty(
+                  "SOURCE_ID"
+                )}</td></tr>` +
+                `<tr><th>Longitude</th><td>${pickedFeature.getProperty(
+                  "longitude"
+                )}</td></tr>` +
+                `<tr><th>Latitude</th><td>${pickedFeature.getProperty(
+                  "latitude"
+                )}</td></tr>` +
+                `<tr><th>Height</th><td>${pickedFeature.getProperty(
+                  "height"
+                )}</td></tr>` +
+                `<tr><th>Terrain Height (Ellipsoid)</th><td>${pickedFeature.getProperty(
+                  "TerrainHeight"
+                )}</td></tr>` +
+                `</tbody></table>`;
+            },
+            Cesium.ScreenSpaceEventType.LEFT_CLICK);
+          }
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
@@ -36,7 +36,7 @@
         // A simple demo of 3D Tiles feature picking with hover and select behavior
         // Building data courtesy of NYC OpenData portal: http://www1.nyc.gov/site/doitt/initiatives/3d-building.page
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         viewer.scene.globe.depthTestAgainstTerrain = true;

--- a/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
@@ -57,7 +57,7 @@
         // How to use the 3D Tiles Styling language to style individual features, like buildings.
         // Styling language specification: https://github.com/CesiumGS/3d-tiles/tree/main/specification/Styling
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
         const handler = new Cesium.ScreenSpaceEventHandler(viewer.scene.canvas);
 

--- a/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
@@ -53,162 +53,166 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        (async () => {
+          // How to use the 3D Tiles Styling language to style individual features, like buildings.
+          // Styling language specification: https://github.com/CesiumGS/3d-tiles/tree/main/specification/Styling
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
+          const handler = new Cesium.ScreenSpaceEventHandler(
+            viewer.scene.canvas
+          );
 
-        // How to use the 3D Tiles Styling language to style individual features, like buildings.
-        // Styling language specification: https://github.com/CesiumGS/3d-tiles/tree/main/specification/Styling
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
-        const handler = new Cesium.ScreenSpaceEventHandler(viewer.scene.canvas);
+          // Add Cesium OSM buildings to the scene as our example 3D Tileset.
+          const osmBuildingsTileset = Cesium.createOsmBuildings();
+          viewer.scene.primitives.add(osmBuildingsTileset);
 
-        // Add Cesium OSM buildings to the scene as our example 3D Tileset.
-        const osmBuildingsTileset = Cesium.createOsmBuildings();
-        viewer.scene.primitives.add(osmBuildingsTileset);
-
-        // Set the initial camera to look at Seattle
-        viewer.scene.camera.setView({
-          destination: Cesium.Cartesian3.fromDegrees(-122.3472, 47.598, 370),
-          orientation: {
-            heading: Cesium.Math.toRadians(10),
-            pitch: Cesium.Math.toRadians(-10),
-          },
-        });
-
-        // Styling functions
-
-        // Color by material checks for null values since not all
-        // buildings have the material property.
-        function colorByMaterial() {
-          osmBuildingsTileset.style = new Cesium.Cesium3DTileStyle({
-            defines: {
-              material: "${feature['building:material']}",
-            },
-            color: {
-              conditions: [
-                ["${material} === null", "color('white')"],
-                ["${material} === 'glass'", "color('skyblue', 0.5)"],
-                ["${material} === 'concrete'", "color('grey')"],
-                ["${material} === 'brick'", "color('indianred')"],
-                ["${material} === 'stone'", "color('lightslategrey')"],
-                ["${material} === 'metal'", "color('lightgrey')"],
-                ["${material} === 'steel'", "color('lightsteelblue')"],
-                ["true", "color('white')"], // This is the else case
-              ],
+          // Set the initial camera to look at Seattle
+          viewer.scene.camera.setView({
+            destination: Cesium.Cartesian3.fromDegrees(-122.3472, 47.598, 370),
+            orientation: {
+              heading: Cesium.Math.toRadians(10),
+              pitch: Cesium.Math.toRadians(-10),
             },
           });
-        }
 
-        function highlightAllResidentialBuildings() {
-          osmBuildingsTileset.style = new Cesium.Cesium3DTileStyle({
-            color: {
-              conditions: [
-                [
-                  "${feature['building']} === 'apartments' || ${feature['building']} === 'residential'",
-                  "color('cyan', 0.9)",
+          // Styling functions
+
+          // Color by material checks for null values since not all
+          // buildings have the material property.
+          function colorByMaterial() {
+            osmBuildingsTileset.style = new Cesium.Cesium3DTileStyle({
+              defines: {
+                material: "${feature['building:material']}",
+              },
+              color: {
+                conditions: [
+                  ["${material} === null", "color('white')"],
+                  ["${material} === 'glass'", "color('skyblue', 0.5)"],
+                  ["${material} === 'concrete'", "color('grey')"],
+                  ["${material} === 'brick'", "color('indianred')"],
+                  ["${material} === 'stone'", "color('lightslategrey')"],
+                  ["${material} === 'metal'", "color('lightgrey')"],
+                  ["${material} === 'steel'", "color('lightsteelblue')"],
+                  ["true", "color('white')"], // This is the else case
                 ],
-                [true, "color('white')"],
-              ],
-            },
-          });
-        }
-
-        function showByBuildingType(buildingType) {
-          switch (buildingType) {
-            case "office":
-              osmBuildingsTileset.style = new Cesium.Cesium3DTileStyle({
-                show: "${feature['building']} === 'office'",
-              });
-              break;
-            case "apartments":
-              osmBuildingsTileset.style = new Cesium.Cesium3DTileStyle({
-                show: "${feature['building']} === 'apartments'",
-              });
-              break;
-            default:
-              break;
+              },
+            });
           }
-        }
 
-        // Color the buildings based on their distance from a selected central location
-        function colorByDistanceToCoordinate(pickedLatitude, pickedLongitude) {
-          osmBuildingsTileset.style = new Cesium.Cesium3DTileStyle({
-            defines: {
-              distance: `distance(vec2(\${feature['cesium#longitude']}, \${feature['cesium#latitude']}), vec2(${pickedLongitude},${pickedLatitude}))`,
-            },
-            color: {
-              conditions: [
-                ["${distance} > 0.014", "color('blue')"],
-                ["${distance} > 0.010", "color('green')"],
-                ["${distance} > 0.006", "color('yellow')"],
-                ["${distance} > 0.0001", "color('red')"],
-                ["true", "color('white')"],
-              ],
-            },
-          });
-        }
+          function highlightAllResidentialBuildings() {
+            osmBuildingsTileset.style = new Cesium.Cesium3DTileStyle({
+              color: {
+                conditions: [
+                  [
+                    "${feature['building']} === 'apartments' || ${feature['building']} === 'residential'",
+                    "color('cyan', 0.9)",
+                  ],
+                  [true, "color('white')"],
+                ],
+              },
+            });
+          }
 
-        // When dropdown option is not "Color By Distance To Selected Location",
-        // remove the left click input event for selecting a central location
-        function removeCoordinatePickingOnLeftClick() {
-          document.querySelector(".infoPanel").style.visibility = "hidden";
-          handler.removeInputAction(Cesium.ScreenSpaceEventType.LEFT_CLICK);
-        }
-
-        // Add event listeners to dropdown menu options
-        document.querySelector(".infoPanel").style.visibility = "hidden";
-        const menu = document.getElementById("dropdown");
-
-        menu.options[0].onselect = function () {
-          removeCoordinatePickingOnLeftClick();
-          colorByMaterial();
-        };
-
-        menu.options[1].onselect = function () {
-          // Default to Space Needle as the central location
-          colorByDistanceToCoordinate(47.62051, -122.34931);
-          document.querySelector(".infoPanel").style.visibility = "visible";
-          // Add left click input to select a building to and extract its coordinates
-          handler.setInputAction(function (movement) {
-            viewer.selectedEntity = undefined;
-            const pickedBuilding = viewer.scene.pick(movement.position);
-            if (pickedBuilding) {
-              const pickedLatitude = pickedBuilding.getProperty(
-                "cesium#latitude"
-              );
-              const pickedLongitude = pickedBuilding.getProperty(
-                "cesium#longitude"
-              );
-              colorByDistanceToCoordinate(pickedLatitude, pickedLongitude);
+          function showByBuildingType(buildingType) {
+            switch (buildingType) {
+              case "office":
+                osmBuildingsTileset.style = new Cesium.Cesium3DTileStyle({
+                  show: "${feature['building']} === 'office'",
+                });
+                break;
+              case "apartments":
+                osmBuildingsTileset.style = new Cesium.Cesium3DTileStyle({
+                  show: "${feature['building']} === 'apartments'",
+                });
+                break;
+              default:
+                break;
             }
-          }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
-        };
-
-        menu.options[2].onselect = function () {
-          removeCoordinatePickingOnLeftClick();
-          highlightAllResidentialBuildings();
-        };
-
-        menu.options[3].onselect = function () {
-          removeCoordinatePickingOnLeftClick();
-          showByBuildingType("office");
-        };
-
-        menu.options[4].onselect = function () {
-          removeCoordinatePickingOnLeftClick();
-          showByBuildingType("apartments");
-        };
-
-        menu.onchange = function () {
-          Sandcastle.reset();
-          const item = menu.options[menu.selectedIndex];
-          if (item && typeof item.onselect === "function") {
-            item.onselect();
           }
-        };
 
-        colorByMaterial();
+          // Color the buildings based on their distance from a selected central location
+          function colorByDistanceToCoordinate(
+            pickedLatitude,
+            pickedLongitude
+          ) {
+            osmBuildingsTileset.style = new Cesium.Cesium3DTileStyle({
+              defines: {
+                distance: `distance(vec2(\${feature['cesium#longitude']}, \${feature['cesium#latitude']}), vec2(${pickedLongitude},${pickedLatitude}))`,
+              },
+              color: {
+                conditions: [
+                  ["${distance} > 0.014", "color('blue')"],
+                  ["${distance} > 0.010", "color('green')"],
+                  ["${distance} > 0.006", "color('yellow')"],
+                  ["${distance} > 0.0001", "color('red')"],
+                  ["true", "color('white')"],
+                ],
+              },
+            });
+          }
 
-        //Sandcastle_End
+          // When dropdown option is not "Color By Distance To Selected Location",
+          // remove the left click input event for selecting a central location
+          function removeCoordinatePickingOnLeftClick() {
+            document.querySelector(".infoPanel").style.visibility = "hidden";
+            handler.removeInputAction(Cesium.ScreenSpaceEventType.LEFT_CLICK);
+          }
+
+          // Add event listeners to dropdown menu options
+          document.querySelector(".infoPanel").style.visibility = "hidden";
+          const menu = document.getElementById("dropdown");
+
+          menu.options[0].onselect = function () {
+            removeCoordinatePickingOnLeftClick();
+            colorByMaterial();
+          };
+
+          menu.options[1].onselect = function () {
+            // Default to Space Needle as the central location
+            colorByDistanceToCoordinate(47.62051, -122.34931);
+            document.querySelector(".infoPanel").style.visibility = "visible";
+            // Add left click input to select a building to and extract its coordinates
+            handler.setInputAction(function (movement) {
+              viewer.selectedEntity = undefined;
+              const pickedBuilding = viewer.scene.pick(movement.position);
+              if (pickedBuilding) {
+                const pickedLatitude = pickedBuilding.getProperty(
+                  "cesium#latitude"
+                );
+                const pickedLongitude = pickedBuilding.getProperty(
+                  "cesium#longitude"
+                );
+                colorByDistanceToCoordinate(pickedLatitude, pickedLongitude);
+              }
+            }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
+          };
+
+          menu.options[2].onselect = function () {
+            removeCoordinatePickingOnLeftClick();
+            highlightAllResidentialBuildings();
+          };
+
+          menu.options[3].onselect = function () {
+            removeCoordinatePickingOnLeftClick();
+            showByBuildingType("office");
+          };
+
+          menu.options[4].onselect = function () {
+            removeCoordinatePickingOnLeftClick();
+            showByBuildingType("apartments");
+          };
+
+          menu.onchange = function () {
+            Sandcastle.reset();
+            const item = menu.options[menu.selectedIndex];
+            if (item && typeof item.onselect === "function") {
+              item.onselect();
+            }
+          };
+
+          colorByMaterial();
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/3D Tiles Inspector.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Inspector.html
@@ -37,22 +37,24 @@
         "use strict";
         //Sandcastle_Begin
         // Building data courtesy of NYC OpenData portal: http://www1.nyc.gov/site/doitt/initiatives/3d-building.page
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
 
-        viewer.scene.globe.depthTestAgainstTerrain = true;
+          viewer.scene.globe.depthTestAgainstTerrain = true;
 
-        viewer.extend(Cesium.viewerCesium3DTilesInspectorMixin);
-        const inspectorViewModel = viewer.cesium3DTilesInspector.viewModel;
+          viewer.extend(Cesium.viewerCesium3DTilesInspectorMixin);
+          const inspectorViewModel = viewer.cesium3DTilesInspector.viewModel;
 
-        const tileset = new Cesium.Cesium3DTileset({
-          url: Cesium.IonResource.fromAssetId(75343),
-          enableDebugWireframe: true,
-        });
-        viewer.scene.primitives.add(tileset);
+          const tileset = new Cesium.Cesium3DTileset({
+            url: Cesium.IonResource.fromAssetId(75343),
+            enableDebugWireframe: true,
+          });
+          viewer.scene.primitives.add(tileset);
 
-        tileset.readyPromise.then(function () {
+          await tileset.readyPromise;
+
           viewer.zoomTo(
             tileset,
             new Cesium.HeadingPitchRange(
@@ -61,8 +63,7 @@
               tileset.boundingSphere.radius / 4.0
             )
           );
-        });
-        //Sandcastle_End
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/3D Tiles Inspector.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Inspector.html
@@ -38,7 +38,7 @@
         //Sandcastle_Begin
         // Building data courtesy of NYC OpenData portal: http://www1.nyc.gov/site/doitt/initiatives/3d-building.page
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         viewer.scene.globe.depthTestAgainstTerrain = true;

--- a/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
@@ -74,194 +74,205 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
 
-        const scene = viewer.scene;
-        if (!scene.pickPositionSupported) {
-          window.alert("This browser does not support pickPosition.");
-        }
-
-        scene.globe.depthTestAgainstTerrain = true;
-
-        const viewModel = {
-          rightClickAction: "annotate",
-          middleClickAction: "hide",
-        };
-
-        Cesium.knockout.track(viewModel);
-
-        const toolbar = document.getElementById("toolbar");
-        Cesium.knockout.applyBindings(viewModel, toolbar);
-
-        const annotations = scene.primitives.add(new Cesium.LabelCollection());
-
-        // Set the initial camera view to look at Manhattan
-        const initialPosition = Cesium.Cartesian3.fromDegrees(
-          -74.01881302800248,
-          40.69114333714821,
-          753
-        );
-        const initialOrientation = new Cesium.HeadingPitchRoll.fromDegrees(
-          21.27879878293835,
-          -21.34390550872461,
-          0.0716951918898415
-        );
-        scene.camera.setView({
-          destination: initialPosition,
-          orientation: initialOrientation,
-          endTransform: Cesium.Matrix4.IDENTITY,
-        });
-
-        // Load the NYC buildings tileset.
-        const tileset = new Cesium.Cesium3DTileset({
-          url: Cesium.IonResource.fromAssetId(75343),
-        });
-        scene.primitives.add(tileset);
-        tileset.style = new Cesium.Cesium3DTileStyle({
-          meta: {
-            description: "'Building ${BIN} has height ${Height}.'",
-          },
-        });
-
-        const handler = new Cesium.ScreenSpaceEventHandler(viewer.canvas);
-
-        handler.setInputAction(function (movement) {
-          const feature = scene.pick(movement.position);
-          if (!Cesium.defined(feature)) {
-            return;
+          const scene = viewer.scene;
+          if (!scene.pickPositionSupported) {
+            window.alert("This browser does not support pickPosition.");
           }
 
-          const action = viewModel.rightClickAction;
-          if (action === "annotate") {
-            annotate(movement, feature);
-          } else if (action === "properties") {
-            printProperties(movement, feature);
-          } else if (action === "zoom") {
-            zoom(movement, feature);
-          }
-        }, Cesium.ScreenSpaceEventType.RIGHT_CLICK);
+          scene.globe.depthTestAgainstTerrain = true;
 
-        handler.setInputAction(function (movement) {
-          const feature = scene.pick(movement.position);
-          if (!Cesium.defined(feature)) {
-            return;
-          }
+          const viewModel = {
+            rightClickAction: "annotate",
+            middleClickAction: "hide",
+          };
 
-          const action = viewModel.middleClickAction;
-          if (action === "hide") {
-            feature.show = false;
-          }
-        }, Cesium.ScreenSpaceEventType.MIDDLE_CLICK);
+          Cesium.knockout.track(viewModel);
 
-        function annotate(movement, feature) {
-          if (scene.pickPositionSupported) {
-            const cartesian = scene.pickPosition(movement.position);
-            if (Cesium.defined(cartesian)) {
-              const cartographic = Cesium.Cartographic.fromCartesian(cartesian);
-              const height = `${cartographic.height.toFixed(2)} m`;
+          const toolbar = document.getElementById("toolbar");
+          Cesium.knockout.applyBindings(viewModel, toolbar);
 
-              annotations.add({
-                position: cartesian,
-                text: height,
-                showBackground: true,
-                font: "14px monospace",
-                horizontalOrigin: Cesium.HorizontalOrigin.LEFT,
-                verticalOrigin: Cesium.VerticalOrigin.BOTTOM,
-                disableDepthTestDistance: Number.POSITIVE_INFINITY,
-              });
+          const annotations = scene.primitives.add(
+            new Cesium.LabelCollection()
+          );
+
+          // Set the initial camera view to look at Manhattan
+          const initialPosition = Cesium.Cartesian3.fromDegrees(
+            -74.01881302800248,
+            40.69114333714821,
+            753
+          );
+          const initialOrientation = new Cesium.HeadingPitchRoll.fromDegrees(
+            21.27879878293835,
+            -21.34390550872461,
+            0.0716951918898415
+          );
+          scene.camera.setView({
+            destination: initialPosition,
+            orientation: initialOrientation,
+            endTransform: Cesium.Matrix4.IDENTITY,
+          });
+
+          // Load the NYC buildings tileset.
+          const tileset = new Cesium.Cesium3DTileset({
+            url: Cesium.IonResource.fromAssetId(75343),
+          });
+          scene.primitives.add(tileset);
+          tileset.style = new Cesium.Cesium3DTileStyle({
+            meta: {
+              description: "'Building ${BIN} has height ${Height}.'",
+            },
+          });
+
+          const handler = new Cesium.ScreenSpaceEventHandler(viewer.canvas);
+
+          handler.setInputAction(function (movement) {
+            const feature = scene.pick(movement.position);
+            if (!Cesium.defined(feature)) {
+              return;
+            }
+
+            const action = viewModel.rightClickAction;
+            if (action === "annotate") {
+              annotate(movement, feature);
+            } else if (action === "properties") {
+              printProperties(movement, feature);
+            } else if (action === "zoom") {
+              zoom(movement, feature);
+            }
+          }, Cesium.ScreenSpaceEventType.RIGHT_CLICK);
+
+          handler.setInputAction(function (movement) {
+            const feature = scene.pick(movement.position);
+            if (!Cesium.defined(feature)) {
+              return;
+            }
+
+            const action = viewModel.middleClickAction;
+            if (action === "hide") {
+              feature.show = false;
+            }
+          }, Cesium.ScreenSpaceEventType.MIDDLE_CLICK);
+
+          function annotate(movement, feature) {
+            if (scene.pickPositionSupported) {
+              const cartesian = scene.pickPosition(movement.position);
+              if (Cesium.defined(cartesian)) {
+                const cartographic = Cesium.Cartographic.fromCartesian(
+                  cartesian
+                );
+                const height = `${cartographic.height.toFixed(2)} m`;
+
+                annotations.add({
+                  position: cartesian,
+                  text: height,
+                  showBackground: true,
+                  font: "14px monospace",
+                  horizontalOrigin: Cesium.HorizontalOrigin.LEFT,
+                  verticalOrigin: Cesium.VerticalOrigin.BOTTOM,
+                  disableDepthTestDistance: Number.POSITIVE_INFINITY,
+                });
+              }
             }
           }
-        }
 
-        function printProperties(movement, feature) {
-          console.log("Properties:");
-          const propertyIds = feature.getPropertyIds();
-          const length = propertyIds.length;
-          for (let i = 0; i < length; ++i) {
-            const propertyId = propertyIds[i];
-            console.log(`  ${propertyId}: ${feature.getProperty(propertyId)}`);
+          function printProperties(movement, feature) {
+            console.log("Properties:");
+            const propertyIds = feature.getPropertyIds();
+            const length = propertyIds.length;
+            for (let i = 0; i < length; ++i) {
+              const propertyId = propertyIds[i];
+              console.log(
+                `  ${propertyId}: ${feature.getProperty(propertyId)}`
+              );
+            }
+
+            // Evaluate feature description
+            console.log(
+              `Description : ${tileset.style.meta.description.evaluate(
+                feature
+              )}`
+            );
           }
 
-          // Evaluate feature description
-          console.log(
-            `Description : ${tileset.style.meta.description.evaluate(feature)}`
-          );
-        }
+          function zoom(movement, feature) {
+            const longitude = Cesium.Math.toRadians(
+              feature.getProperty("Longitude")
+            );
+            const latitude = Cesium.Math.toRadians(
+              feature.getProperty("Latitude")
+            );
+            const height = feature.getProperty("Height");
 
-        function zoom(movement, feature) {
-          const longitude = Cesium.Math.toRadians(
-            feature.getProperty("Longitude")
-          );
-          const latitude = Cesium.Math.toRadians(
-            feature.getProperty("Latitude")
-          );
-          const height = feature.getProperty("Height");
+            const positionCartographic = new Cesium.Cartographic(
+              longitude,
+              latitude,
+              height * 0.5
+            );
+            const position = scene.globe.ellipsoid.cartographicToCartesian(
+              positionCartographic
+            );
 
-          const positionCartographic = new Cesium.Cartographic(
-            longitude,
-            latitude,
-            height * 0.5
-          );
-          const position = scene.globe.ellipsoid.cartographicToCartesian(
-            positionCartographic
-          );
+            const camera = scene.camera;
+            const heading = camera.heading;
+            const pitch = camera.pitch;
 
-          const camera = scene.camera;
-          const heading = camera.heading;
-          const pitch = camera.pitch;
+            const offset = offsetFromHeadingPitchRange(
+              heading,
+              pitch,
+              height * 2.0
+            );
 
-          const offset = offsetFromHeadingPitchRange(
-            heading,
-            pitch,
-            height * 2.0
-          );
+            const transform = Cesium.Transforms.eastNorthUpToFixedFrame(
+              position
+            );
+            Cesium.Matrix4.multiplyByPoint(transform, offset, position);
 
-          const transform = Cesium.Transforms.eastNorthUpToFixedFrame(position);
-          Cesium.Matrix4.multiplyByPoint(transform, offset, position);
+            camera.flyTo({
+              destination: position,
+              orientation: {
+                heading: heading,
+                pitch: pitch,
+              },
+              easingFunction: Cesium.EasingFunction.QUADRATIC_OUT,
+            });
+          }
 
-          camera.flyTo({
-            destination: position,
-            orientation: {
-              heading: heading,
-              pitch: pitch,
-            },
-            easingFunction: Cesium.EasingFunction.QUADRATIC_OUT,
-          });
-        }
+          function offsetFromHeadingPitchRange(heading, pitch, range) {
+            pitch = Cesium.Math.clamp(
+              pitch,
+              -Cesium.Math.PI_OVER_TWO,
+              Cesium.Math.PI_OVER_TWO
+            );
+            heading =
+              Cesium.Math.zeroToTwoPi(heading) - Cesium.Math.PI_OVER_TWO;
 
-        function offsetFromHeadingPitchRange(heading, pitch, range) {
-          pitch = Cesium.Math.clamp(
-            pitch,
-            -Cesium.Math.PI_OVER_TWO,
-            Cesium.Math.PI_OVER_TWO
-          );
-          heading = Cesium.Math.zeroToTwoPi(heading) - Cesium.Math.PI_OVER_TWO;
+            const pitchQuat = Cesium.Quaternion.fromAxisAngle(
+              Cesium.Cartesian3.UNIT_Y,
+              -pitch
+            );
+            const headingQuat = Cesium.Quaternion.fromAxisAngle(
+              Cesium.Cartesian3.UNIT_Z,
+              -heading
+            );
+            const rotQuat = Cesium.Quaternion.multiply(
+              headingQuat,
+              pitchQuat,
+              headingQuat
+            );
+            const rotMatrix = Cesium.Matrix3.fromQuaternion(rotQuat);
 
-          const pitchQuat = Cesium.Quaternion.fromAxisAngle(
-            Cesium.Cartesian3.UNIT_Y,
-            -pitch
-          );
-          const headingQuat = Cesium.Quaternion.fromAxisAngle(
-            Cesium.Cartesian3.UNIT_Z,
-            -heading
-          );
-          const rotQuat = Cesium.Quaternion.multiply(
-            headingQuat,
-            pitchQuat,
-            headingQuat
-          );
-          const rotMatrix = Cesium.Matrix3.fromQuaternion(rotQuat);
-
-          const offset = Cesium.Cartesian3.clone(Cesium.Cartesian3.UNIT_X);
-          Cesium.Matrix3.multiplyByVector(rotMatrix, offset, offset);
-          Cesium.Cartesian3.negate(offset, offset);
-          Cesium.Cartesian3.multiplyByScalar(offset, range, offset);
-          return offset;
-        }
-
-        //Sandcastle_End
+            const offset = Cesium.Cartesian3.clone(Cesium.Cartesian3.UNIT_X);
+            Cesium.Matrix3.multiplyByVector(rotMatrix, offset, offset);
+            Cesium.Cartesian3.negate(offset, offset);
+            Cesium.Cartesian3.multiplyByScalar(offset, range, offset);
+            return offset;
+          }
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
@@ -75,7 +75,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         const scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/3D Tiles Next Photogrammetry Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Next Photogrammetry Classification.html
@@ -35,79 +35,83 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        // San Francisco Ferry Building photogrammetry model provided by Aerometrex
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          infoBox: false,
+          orderIndependentTranslucency: false,
+        });
+
         (async () => {
-          // San Francisco Ferry Building photogrammetry model provided by Aerometrex
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-            infoBox: false,
-            orderIndependentTranslucency: false,
-          });
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+          } catch (error) {
+            console.log(error);
+          }
+        })();
 
-          viewer.clock.currentTime = Cesium.JulianDate.fromIso8601(
-            "2021-11-09T20:27:37.016064475348684937Z"
-          );
+        viewer.clock.currentTime = Cesium.JulianDate.fromIso8601(
+          "2021-11-09T20:27:37.016064475348684937Z"
+        );
 
-          const scene = viewer.scene;
+        const scene = viewer.scene;
 
-          const tileset = new Cesium.Cesium3DTileset({
-            url: Cesium.IonResource.fromAssetId(775877),
-          });
+        const tileset = new Cesium.Cesium3DTileset({
+          url: Cesium.IonResource.fromAssetId(775877),
+        });
 
-          const translation = new Cesium.Cartesian3(
-            -1.398521324920626,
-            0.7823052871729486,
-            0.7015244410592609
-          );
-          tileset.modelMatrix = Cesium.Matrix4.fromTranslation(translation);
+        const translation = new Cesium.Cartesian3(
+          -1.398521324920626,
+          0.7823052871729486,
+          0.7015244410592609
+        );
+        tileset.modelMatrix = Cesium.Matrix4.fromTranslation(translation);
 
-          tileset.maximumScreenSpaceError = 8.0;
-          scene.pickTranslucentDepth = true;
-          scene.light.intensity = 7.0;
+        tileset.maximumScreenSpaceError = 8.0;
+        scene.pickTranslucentDepth = true;
+        scene.light.intensity = 7.0;
 
-          viewer.scene.primitives.add(tileset);
-          viewer.zoomTo(tileset);
+        viewer.scene.primitives.add(tileset);
+        viewer.zoomTo(tileset);
 
-          // Fly to a nice overview of the city.
-          viewer.camera.flyTo({
-            destination: new Cesium.Cartesian3(
-              -2703640.80485846,
-              -4261161.990345464,
-              3887439.511104276
-            ),
-            orientation: new Cesium.HeadingPitchRoll(
-              0.22426651143535548,
-              -0.2624145362506527,
-              0.000006972977223185239
-            ),
-          });
+        // Fly to a nice overview of the city.
+        viewer.camera.flyTo({
+          destination: new Cesium.Cartesian3(
+            -2703640.80485846,
+            -4261161.990345464,
+            3887439.511104276
+          ),
+          orientation: new Cesium.HeadingPitchRoll(
+            0.22426651143535548,
+            -0.2624145362506527,
+            0.000006972977223185239
+          ),
+        });
 
-          // Styles =============================================================================
+        // Styles =============================================================================
 
-          const classificationStyle = new Cesium.Cesium3DTileStyle({
-            color: "color(${color})",
-          });
+        const classificationStyle = new Cesium.Cesium3DTileStyle({
+          color: "color(${color})",
+        });
 
-          const translucentWindowsStyle = new Cesium.Cesium3DTileStyle({
-            color: {
-              conditions: [
-                ["${component} === 'Windows'", "color('gray', 0.7)"],
-              ],
-            },
-          });
+        const translucentWindowsStyle = new Cesium.Cesium3DTileStyle({
+          color: {
+            conditions: [["${component} === 'Windows'", "color('gray', 0.7)"]],
+          },
+        });
 
-          // Shaders ============================================================================
+        // Shaders ============================================================================
 
-          // Dummy shader that sets the UNLIT lighting mode. For use with the classification style
-          const emptyFragmentShader =
-            "void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {}";
-          const unlitShader = new Cesium.CustomShader({
-            lightingModel: Cesium.LightingModel.UNLIT,
-            fragmentShaderText: emptyFragmentShader,
-          });
+        // Dummy shader that sets the UNLIT lighting mode. For use with the classification style
+        const emptyFragmentShader =
+          "void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {}";
+        const unlitShader = new Cesium.CustomShader({
+          lightingModel: Cesium.LightingModel.UNLIT,
+          fragmentShaderText: emptyFragmentShader,
+        });
 
-          const materialShader = new Cesium.CustomShader({
-            lightingModel: Cesium.LightingModel.PBR,
-            fragmentShaderText: `
+        const materialShader = new Cesium.CustomShader({
+          lightingModel: Cesium.LightingModel.PBR,
+          fragmentShaderText: `
       const int WINDOW = 0;
       const int FRAME = 1;
       const int WALL = 2;
@@ -154,18 +158,18 @@
         }
       }
       `,
-          });
+        });
 
-          const NOTHING_SELECTED = 12;
-          const selectFeatureShader = new Cesium.CustomShader({
-            uniforms: {
-              u_selectedFeature: {
-                type: Cesium.UniformType.INT,
-                value: NOTHING_SELECTED,
-              },
+        const NOTHING_SELECTED = 12;
+        const selectFeatureShader = new Cesium.CustomShader({
+          uniforms: {
+            u_selectedFeature: {
+              type: Cesium.UniformType.INT,
+              value: NOTHING_SELECTED,
             },
-            lightingModel: Cesium.LightingModel.PBR,
-            fragmentShaderText: `
+          },
+          lightingModel: Cesium.LightingModel.PBR,
+          fragmentShaderText: `
       const int NOTHING_SELECTED = 12;
       void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {
         int featureId = fsInput.featureIds.featureId_0;
@@ -176,17 +180,17 @@
         }
       }
       `,
-          });
+        });
 
-          const multipleFeatureIdsShader = new Cesium.CustomShader({
-            uniforms: {
-              u_selectedFeature: {
-                type: Cesium.UniformType.FLOAT,
-                value: NOTHING_SELECTED,
-              },
+        const multipleFeatureIdsShader = new Cesium.CustomShader({
+          uniforms: {
+            u_selectedFeature: {
+              type: Cesium.UniformType.FLOAT,
+              value: NOTHING_SELECTED,
             },
-            lightingModel: Cesium.LightingModel.UNLIT,
-            fragmentShaderText: `
+          },
+          lightingModel: Cesium.LightingModel.UNLIT,
+          fragmentShaderText: `
       const int IDS0_WINDOW = 0;
       const int IDS1_FACADE = 2;
       const int IDS1_ROOF = 3;
@@ -210,154 +214,151 @@
         material.diffuse *= tint;
       }
       `,
-          });
+        });
 
-          // Demo Functions =====================================================================
+        // Demo Functions =====================================================================
 
-          function defaults() {
-            tileset.style = undefined;
-            tileset.customShader = unlitShader;
-            tileset.colorBlendMode =
-              Cesium.Cesium3DTileColorBlendMode.HIGHLIGHT;
-            tileset.colorBlendAmount = 0.5;
-            tileset.featureIdLabel = 0;
-          }
+        function defaults() {
+          tileset.style = undefined;
+          tileset.customShader = unlitShader;
+          tileset.colorBlendMode = Cesium.Cesium3DTileColorBlendMode.HIGHLIGHT;
+          tileset.colorBlendAmount = 0.5;
+          tileset.featureIdLabel = 0;
+        }
 
-          const showPhotogrammetry = defaults;
+        const showPhotogrammetry = defaults;
 
-          function showClassification() {
-            defaults();
-            tileset.style = classificationStyle;
-            tileset.colorBlendMode = Cesium.Cesium3DTileColorBlendMode.MIX;
-          }
+        function showClassification() {
+          defaults();
+          tileset.style = classificationStyle;
+          tileset.colorBlendMode = Cesium.Cesium3DTileColorBlendMode.MIX;
+        }
 
-          function showAlternativeClassification() {
-            showClassification();
-            // This dataset has a second feature ID texture.
-            tileset.featureIdLabel = 1;
-          }
+        function showAlternativeClassification() {
+          showClassification();
+          // This dataset has a second feature ID texture.
+          tileset.featureIdLabel = 1;
+        }
 
-          function translucentWindows() {
-            defaults();
-            tileset.style = translucentWindowsStyle;
-          }
+        function translucentWindows() {
+          defaults();
+          tileset.style = translucentWindowsStyle;
+        }
 
-          function pbrMaterials() {
-            defaults();
-            tileset.customShader = materialShader;
-          }
+        function pbrMaterials() {
+          defaults();
+          tileset.customShader = materialShader;
+        }
 
-          function goldenTouch() {
-            defaults();
-            tileset.customShader = selectFeatureShader;
-          }
+        function goldenTouch() {
+          defaults();
+          tileset.customShader = selectFeatureShader;
+        }
 
-          function multipleFeatureIds() {
-            defaults();
-            tileset.customShader = multipleFeatureIdsShader;
-          }
+        function multipleFeatureIds() {
+          defaults();
+          tileset.customShader = multipleFeatureIdsShader;
+        }
 
-          // Pick Handlers ======================================================================
+        // Pick Handlers ======================================================================
 
-          // HTML overlay for showing feature name on mouseover
-          const nameOverlay = document.createElement("div");
-          viewer.container.appendChild(nameOverlay);
-          nameOverlay.className = "backdrop";
-          nameOverlay.style.display = "none";
-          nameOverlay.style.position = "absolute";
-          nameOverlay.style.bottom = "0";
-          nameOverlay.style.left = "0";
-          nameOverlay.style["pointer-events"] = "none";
-          nameOverlay.style.padding = "4px";
-          nameOverlay.style.backgroundColor = "black";
-          nameOverlay.style.whiteSpace = "pre-line";
-          nameOverlay.style.fontSize = "12px";
+        // HTML overlay for showing feature name on mouseover
+        const nameOverlay = document.createElement("div");
+        viewer.container.appendChild(nameOverlay);
+        nameOverlay.className = "backdrop";
+        nameOverlay.style.display = "none";
+        nameOverlay.style.position = "absolute";
+        nameOverlay.style.bottom = "0";
+        nameOverlay.style.left = "0";
+        nameOverlay.style["pointer-events"] = "none";
+        nameOverlay.style.padding = "4px";
+        nameOverlay.style.backgroundColor = "black";
+        nameOverlay.style.whiteSpace = "pre-line";
+        nameOverlay.style.fontSize = "12px";
 
-          let enablePicking = true;
-          const handler = new Cesium.ScreenSpaceEventHandler(
-            viewer.scene.canvas
-          );
-          handler.setInputAction(function (movement) {
-            if (enablePicking) {
-              const pickedObject = viewer.scene.pick(movement.endPosition);
-              if (pickedObject instanceof Cesium.Cesium3DTileFeature) {
-                nameOverlay.style.display = "block";
-                nameOverlay.style.bottom = `${
-                  viewer.canvas.clientHeight - movement.endPosition.y
-                }px`;
-                nameOverlay.style.left = `${movement.endPosition.x}px`;
-                const component = pickedObject.getProperty("component");
-                const message = `Component: ${component}\nFeature ID: ${pickedObject.featureId}`;
-                nameOverlay.textContent = message;
-              } else {
-                nameOverlay.style.display = "none";
-              }
+        let enablePicking = true;
+        const handler = new Cesium.ScreenSpaceEventHandler(viewer.scene.canvas);
+        handler.setInputAction(function (movement) {
+          if (enablePicking) {
+            const pickedObject = viewer.scene.pick(movement.endPosition);
+            if (pickedObject instanceof Cesium.Cesium3DTileFeature) {
+              nameOverlay.style.display = "block";
+              nameOverlay.style.bottom = `${
+                viewer.canvas.clientHeight - movement.endPosition.y
+              }px`;
+              nameOverlay.style.left = `${movement.endPosition.x}px`;
+              const component = pickedObject.getProperty("component");
+              const message = `Component: ${component}\nFeature ID: ${pickedObject.featureId}`;
+              nameOverlay.textContent = message;
             } else {
               nameOverlay.style.display = "none";
             }
-          }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+          } else {
+            nameOverlay.style.display = "none";
+          }
+        }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
 
-          const clickHandler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
-          handler.setInputAction(function (movement) {
-            if (enablePicking) {
-              const pickedObject = scene.pick(movement.position);
-              if (
-                Cesium.defined(pickedObject) &&
-                Cesium.defined(pickedObject.featureId)
-              ) {
-                selectFeatureShader.setUniform(
-                  "u_selectedFeature",
-                  pickedObject.featureId
-                );
-              } else {
-                selectFeatureShader.setUniform(
-                  "u_selectedFeature",
-                  NOTHING_SELECTED
-                );
-              }
+        const clickHandler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
+        handler.setInputAction(function (movement) {
+          if (enablePicking) {
+            const pickedObject = scene.pick(movement.position);
+            if (
+              Cesium.defined(pickedObject) &&
+              Cesium.defined(pickedObject.featureId)
+            ) {
+              selectFeatureShader.setUniform(
+                "u_selectedFeature",
+                pickedObject.featureId
+              );
+            } else {
+              selectFeatureShader.setUniform(
+                "u_selectedFeature",
+                NOTHING_SELECTED
+              );
             }
-          }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
+          }
+        }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
 
-          // UI ============================================================================
+        // UI ============================================================================
 
-          Sandcastle.addToggleButton("Enable picking", enablePicking, function (
-            checked
-          ) {
-            enablePicking = checked;
-          });
+        Sandcastle.addToggleButton("Enable picking", enablePicking, function (
+          checked
+        ) {
+          enablePicking = checked;
+        });
 
-          const demos = [
-            {
-              text: "Photogrammetry",
-              onselect: showPhotogrammetry,
-            },
-            {
-              text: "Show Classification",
-              onselect: showClassification,
-            },
-            {
-              text: "Show Alternative Classification",
-              onselect: showAlternativeClassification,
-            },
-            {
-              text: "Translucent Windows",
-              onselect: translucentWindows,
-            },
-            {
-              text: "Stylized PBR Materials",
-              onselect: pbrMaterials,
-            },
-            {
-              text: "Golden Touch",
-              onselect: goldenTouch,
-            },
-            {
-              text: "Multiple Feature ID Sets",
-              onselect: multipleFeatureIds,
-            },
-          ];
-          Sandcastle.addToolbarMenu(demos);
-        })(); //Sandcastle_End
+        const demos = [
+          {
+            text: "Photogrammetry",
+            onselect: showPhotogrammetry,
+          },
+          {
+            text: "Show Classification",
+            onselect: showClassification,
+          },
+          {
+            text: "Show Alternative Classification",
+            onselect: showAlternativeClassification,
+          },
+          {
+            text: "Translucent Windows",
+            onselect: translucentWindows,
+          },
+          {
+            text: "Stylized PBR Materials",
+            onselect: pbrMaterials,
+          },
+          {
+            text: "Golden Touch",
+            onselect: goldenTouch,
+          },
+          {
+            text: "Multiple Feature ID Sets",
+            onselect: multipleFeatureIds,
+          },
+        ];
+        Sandcastle.addToolbarMenu(demos);
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/3D Tiles Next Photogrammetry Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Next Photogrammetry Classification.html
@@ -35,324 +35,329 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        // San Francisco Ferry Building photogrammetry model provided by Aerometrex
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-          infoBox: false,
-          orderIndependentTranslucency: false,
-        });
+        (async () => {
+          // San Francisco Ferry Building photogrammetry model provided by Aerometrex
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+            infoBox: false,
+            orderIndependentTranslucency: false,
+          });
 
-        viewer.clock.currentTime = Cesium.JulianDate.fromIso8601(
-          "2021-11-09T20:27:37.016064475348684937Z"
-        );
+          viewer.clock.currentTime = Cesium.JulianDate.fromIso8601(
+            "2021-11-09T20:27:37.016064475348684937Z"
+          );
 
-        const scene = viewer.scene;
+          const scene = viewer.scene;
 
-        const tileset = new Cesium.Cesium3DTileset({
-          url: Cesium.IonResource.fromAssetId(775877),
-        });
+          const tileset = new Cesium.Cesium3DTileset({
+            url: Cesium.IonResource.fromAssetId(775877),
+          });
 
-        const translation = new Cesium.Cartesian3(
-          -1.398521324920626,
-          0.7823052871729486,
-          0.7015244410592609
-        );
-        tileset.modelMatrix = Cesium.Matrix4.fromTranslation(translation);
+          const translation = new Cesium.Cartesian3(
+            -1.398521324920626,
+            0.7823052871729486,
+            0.7015244410592609
+          );
+          tileset.modelMatrix = Cesium.Matrix4.fromTranslation(translation);
 
-        tileset.maximumScreenSpaceError = 8.0;
-        scene.pickTranslucentDepth = true;
-        scene.light.intensity = 7.0;
+          tileset.maximumScreenSpaceError = 8.0;
+          scene.pickTranslucentDepth = true;
+          scene.light.intensity = 7.0;
 
-        viewer.scene.primitives.add(tileset);
-        viewer.zoomTo(tileset);
+          viewer.scene.primitives.add(tileset);
+          viewer.zoomTo(tileset);
 
-        // Fly to a nice overview of the city.
-        viewer.camera.flyTo({
-          destination: new Cesium.Cartesian3(
-            -2703640.80485846,
-            -4261161.990345464,
-            3887439.511104276
-          ),
-          orientation: new Cesium.HeadingPitchRoll(
-            0.22426651143535548,
-            -0.2624145362506527,
-            0.000006972977223185239
-          ),
-        });
+          // Fly to a nice overview of the city.
+          viewer.camera.flyTo({
+            destination: new Cesium.Cartesian3(
+              -2703640.80485846,
+              -4261161.990345464,
+              3887439.511104276
+            ),
+            orientation: new Cesium.HeadingPitchRoll(
+              0.22426651143535548,
+              -0.2624145362506527,
+              0.000006972977223185239
+            ),
+          });
 
-        // Styles =============================================================================
+          // Styles =============================================================================
 
-        const classificationStyle = new Cesium.Cesium3DTileStyle({
-          color: "color(${color})",
-        });
+          const classificationStyle = new Cesium.Cesium3DTileStyle({
+            color: "color(${color})",
+          });
 
-        const translucentWindowsStyle = new Cesium.Cesium3DTileStyle({
-          color: {
-            conditions: [["${component} === 'Windows'", "color('gray', 0.7)"]],
-          },
-        });
+          const translucentWindowsStyle = new Cesium.Cesium3DTileStyle({
+            color: {
+              conditions: [
+                ["${component} === 'Windows'", "color('gray', 0.7)"],
+              ],
+            },
+          });
 
-        // Shaders ============================================================================
+          // Shaders ============================================================================
 
-        // Dummy shader that sets the UNLIT lighting mode. For use with the classification style
-        const emptyFragmentShader =
-          "void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {}";
-        const unlitShader = new Cesium.CustomShader({
-          lightingModel: Cesium.LightingModel.UNLIT,
-          fragmentShaderText: emptyFragmentShader,
-        });
+          // Dummy shader that sets the UNLIT lighting mode. For use with the classification style
+          const emptyFragmentShader =
+            "void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {}";
+          const unlitShader = new Cesium.CustomShader({
+            lightingModel: Cesium.LightingModel.UNLIT,
+            fragmentShaderText: emptyFragmentShader,
+          });
 
-        const materialShader = new Cesium.CustomShader({
-          lightingModel: Cesium.LightingModel.PBR,
-          fragmentShaderText: `
-            const int WINDOW = 0;
-            const int FRAME = 1;
-            const int WALL = 2;
-            const int ROOF = 3;
-            const int SKYLIGHT = 4;
-            const int AIR_CONDITIONER_WHITE = 5;
-            const int AIR_CONDITIONER_BLACK = 6;
-            const int AIR_CONDITIONER_TALL = 7;
-            const int CLOCK = 8;
-            const int PILLARS = 9;
-            const int STREET_LIGHT = 10;
-            const int TRAFFIC_LIGHT = 11;
-            
-            void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {
-              int featureId = fsInput.featureIds.featureId_0;
-            
-              if (featureId == CLOCK) {
-                // Shiny brass
-                material.specular = vec3(0.98, 0.90, 0.59);
-                material.roughness = 0.1;
-              } else if (
-                featureId == STREET_LIGHT ||
-                featureId == AIR_CONDITIONER_BLACK ||
-                featureId == AIR_CONDITIONER_WHITE ||
-                featureId == AIR_CONDITIONER_TALL ||
-                featureId == ROOF
-              ) {
-                // dull aluminum
-                material.specular = vec3(0.91, 0.92, 0.92);
-                material.roughness = 0.5;
-              } else if (featureId == WINDOW || featureId == SKYLIGHT) {
-                // make translucent, but also set an orange emissive color so it looks like
-                // it's lit from inside
-                material.emissive = vec3(1.0, 0.3, 0.0);
-                material.alpha = 0.5;
-              } else if (featureId == WALL || featureId == FRAME || featureId == PILLARS) {
-                // paint the walls and pillars white to contrast the brass clock
-                material.diffuse = mix(material.diffuse, vec3(1.0), 0.8);
-                material.roughness = 0.9;
+          const materialShader = new Cesium.CustomShader({
+            lightingModel: Cesium.LightingModel.PBR,
+            fragmentShaderText: `
+      const int WINDOW = 0;
+      const int FRAME = 1;
+      const int WALL = 2;
+      const int ROOF = 3;
+      const int SKYLIGHT = 4;
+      const int AIR_CONDITIONER_WHITE = 5;
+      const int AIR_CONDITIONER_BLACK = 6;
+      const int AIR_CONDITIONER_TALL = 7;
+      const int CLOCK = 8;
+      const int PILLARS = 9;
+      const int STREET_LIGHT = 10;
+      const int TRAFFIC_LIGHT = 11;
+      
+      void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {
+        int featureId = fsInput.featureIds.featureId_0;
+      
+        if (featureId == CLOCK) {
+          // Shiny brass
+          material.specular = vec3(0.98, 0.90, 0.59);
+          material.roughness = 0.1;
+        } else if (
+          featureId == STREET_LIGHT ||
+          featureId == AIR_CONDITIONER_BLACK ||
+          featureId == AIR_CONDITIONER_WHITE ||
+          featureId == AIR_CONDITIONER_TALL ||
+          featureId == ROOF
+        ) {
+          // dull aluminum
+          material.specular = vec3(0.91, 0.92, 0.92);
+          material.roughness = 0.5;
+        } else if (featureId == WINDOW || featureId == SKYLIGHT) {
+          // make translucent, but also set an orange emissive color so it looks like
+          // it's lit from inside
+          material.emissive = vec3(1.0, 0.3, 0.0);
+          material.alpha = 0.5;
+        } else if (featureId == WALL || featureId == FRAME || featureId == PILLARS) {
+          // paint the walls and pillars white to contrast the brass clock
+          material.diffuse = mix(material.diffuse, vec3(1.0), 0.8);
+          material.roughness = 0.9;
+        } else {
+          // brighten everything else
+          material.diffuse += 0.05;
+          material.roughness = 0.9;
+        }
+      }
+      `,
+          });
+
+          const NOTHING_SELECTED = 12;
+          const selectFeatureShader = new Cesium.CustomShader({
+            uniforms: {
+              u_selectedFeature: {
+                type: Cesium.UniformType.INT,
+                value: NOTHING_SELECTED,
+              },
+            },
+            lightingModel: Cesium.LightingModel.PBR,
+            fragmentShaderText: `
+      const int NOTHING_SELECTED = 12;
+      void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {
+        int featureId = fsInput.featureIds.featureId_0;
+      
+        if (u_selectedFeature < NOTHING_SELECTED && featureId == u_selectedFeature) {
+          material.specular = vec3(1.00, 0.85, 0.57);
+          material.roughness = 0.1;
+        }
+      }
+      `,
+          });
+
+          const multipleFeatureIdsShader = new Cesium.CustomShader({
+            uniforms: {
+              u_selectedFeature: {
+                type: Cesium.UniformType.FLOAT,
+                value: NOTHING_SELECTED,
+              },
+            },
+            lightingModel: Cesium.LightingModel.UNLIT,
+            fragmentShaderText: `
+      const int IDS0_WINDOW = 0;
+      const int IDS1_FACADE = 2;
+      const int IDS1_ROOF = 3;
+      const vec3 PURPLE = vec3(0.5, 0.0, 1.0);
+      const vec3 YELLOW = vec3(1.0, 1.0, 0.0);
+      const vec3 NO_TINT = vec3(1.0);
+      
+      void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {
+        int featureId0 = fsInput.featureIds.featureId_0; // fine features
+        int featureId1 = fsInput.featureIds.featureId_1; // coarse features
+      
+        // use both feature ID sets to determine where the features are
+        float isWindow = float(featureId0 == IDS0_WINDOW);
+        float isFacade = float(featureId1 == IDS1_FACADE);
+        float isRoof = float(featureId1 == IDS1_ROOF);
+      
+        // Tint the roof windows yellow and facade windows purple
+        vec3 tint = NO_TINT;
+        tint = mix(tint, YELLOW, isWindow * isRoof);
+        tint = mix(tint, PURPLE, isWindow * isFacade);
+        material.diffuse *= tint;
+      }
+      `,
+          });
+
+          // Demo Functions =====================================================================
+
+          function defaults() {
+            tileset.style = undefined;
+            tileset.customShader = unlitShader;
+            tileset.colorBlendMode =
+              Cesium.Cesium3DTileColorBlendMode.HIGHLIGHT;
+            tileset.colorBlendAmount = 0.5;
+            tileset.featureIdLabel = 0;
+          }
+
+          const showPhotogrammetry = defaults;
+
+          function showClassification() {
+            defaults();
+            tileset.style = classificationStyle;
+            tileset.colorBlendMode = Cesium.Cesium3DTileColorBlendMode.MIX;
+          }
+
+          function showAlternativeClassification() {
+            showClassification();
+            // This dataset has a second feature ID texture.
+            tileset.featureIdLabel = 1;
+          }
+
+          function translucentWindows() {
+            defaults();
+            tileset.style = translucentWindowsStyle;
+          }
+
+          function pbrMaterials() {
+            defaults();
+            tileset.customShader = materialShader;
+          }
+
+          function goldenTouch() {
+            defaults();
+            tileset.customShader = selectFeatureShader;
+          }
+
+          function multipleFeatureIds() {
+            defaults();
+            tileset.customShader = multipleFeatureIdsShader;
+          }
+
+          // Pick Handlers ======================================================================
+
+          // HTML overlay for showing feature name on mouseover
+          const nameOverlay = document.createElement("div");
+          viewer.container.appendChild(nameOverlay);
+          nameOverlay.className = "backdrop";
+          nameOverlay.style.display = "none";
+          nameOverlay.style.position = "absolute";
+          nameOverlay.style.bottom = "0";
+          nameOverlay.style.left = "0";
+          nameOverlay.style["pointer-events"] = "none";
+          nameOverlay.style.padding = "4px";
+          nameOverlay.style.backgroundColor = "black";
+          nameOverlay.style.whiteSpace = "pre-line";
+          nameOverlay.style.fontSize = "12px";
+
+          let enablePicking = true;
+          const handler = new Cesium.ScreenSpaceEventHandler(
+            viewer.scene.canvas
+          );
+          handler.setInputAction(function (movement) {
+            if (enablePicking) {
+              const pickedObject = viewer.scene.pick(movement.endPosition);
+              if (pickedObject instanceof Cesium.Cesium3DTileFeature) {
+                nameOverlay.style.display = "block";
+                nameOverlay.style.bottom = `${
+                  viewer.canvas.clientHeight - movement.endPosition.y
+                }px`;
+                nameOverlay.style.left = `${movement.endPosition.x}px`;
+                const component = pickedObject.getProperty("component");
+                const message = `Component: ${component}\nFeature ID: ${pickedObject.featureId}`;
+                nameOverlay.textContent = message;
               } else {
-                // brighten everything else
-                material.diffuse += 0.05;
-                material.roughness = 0.9;
+                nameOverlay.style.display = "none";
               }
-            }
-            `,
-        });
-
-        const NOTHING_SELECTED = 12;
-        const selectFeatureShader = new Cesium.CustomShader({
-          uniforms: {
-            u_selectedFeature: {
-              type: Cesium.UniformType.INT,
-              value: NOTHING_SELECTED,
-            },
-          },
-          lightingModel: Cesium.LightingModel.PBR,
-          fragmentShaderText: `
-            const int NOTHING_SELECTED = 12;
-            void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {
-              int featureId = fsInput.featureIds.featureId_0;
-            
-              if (u_selectedFeature < NOTHING_SELECTED && featureId == u_selectedFeature) {
-                material.specular = vec3(1.00, 0.85, 0.57);
-                material.roughness = 0.1;
-              }
-            }
-            `,
-        });
-
-        const multipleFeatureIdsShader = new Cesium.CustomShader({
-          uniforms: {
-            u_selectedFeature: {
-              type: Cesium.UniformType.FLOAT,
-              value: NOTHING_SELECTED,
-            },
-          },
-          lightingModel: Cesium.LightingModel.UNLIT,
-          fragmentShaderText: `
-            const int IDS0_WINDOW = 0;
-            const int IDS1_FACADE = 2;
-            const int IDS1_ROOF = 3;
-            const vec3 PURPLE = vec3(0.5, 0.0, 1.0);
-            const vec3 YELLOW = vec3(1.0, 1.0, 0.0);
-            const vec3 NO_TINT = vec3(1.0);
-            
-            void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {
-              int featureId0 = fsInput.featureIds.featureId_0; // fine features
-              int featureId1 = fsInput.featureIds.featureId_1; // coarse features
-            
-              // use both feature ID sets to determine where the features are
-              float isWindow = float(featureId0 == IDS0_WINDOW);
-              float isFacade = float(featureId1 == IDS1_FACADE);
-              float isRoof = float(featureId1 == IDS1_ROOF);
-            
-              // Tint the roof windows yellow and facade windows purple
-              vec3 tint = NO_TINT;
-              tint = mix(tint, YELLOW, isWindow * isRoof);
-              tint = mix(tint, PURPLE, isWindow * isFacade);
-              material.diffuse *= tint;
-            }
-            `,
-        });
-
-        // Demo Functions =====================================================================
-
-        function defaults() {
-          tileset.style = undefined;
-          tileset.customShader = unlitShader;
-          tileset.colorBlendMode = Cesium.Cesium3DTileColorBlendMode.HIGHLIGHT;
-          tileset.colorBlendAmount = 0.5;
-          tileset.featureIdLabel = 0;
-        }
-
-        const showPhotogrammetry = defaults;
-
-        function showClassification() {
-          defaults();
-          tileset.style = classificationStyle;
-          tileset.colorBlendMode = Cesium.Cesium3DTileColorBlendMode.MIX;
-        }
-
-        function showAlternativeClassification() {
-          showClassification();
-          // This dataset has a second feature ID texture.
-          tileset.featureIdLabel = 1;
-        }
-
-        function translucentWindows() {
-          defaults();
-          tileset.style = translucentWindowsStyle;
-        }
-
-        function pbrMaterials() {
-          defaults();
-          tileset.customShader = materialShader;
-        }
-
-        function goldenTouch() {
-          defaults();
-          tileset.customShader = selectFeatureShader;
-        }
-
-        function multipleFeatureIds() {
-          defaults();
-          tileset.customShader = multipleFeatureIdsShader;
-        }
-
-        // Pick Handlers ======================================================================
-
-        // HTML overlay for showing feature name on mouseover
-        const nameOverlay = document.createElement("div");
-        viewer.container.appendChild(nameOverlay);
-        nameOverlay.className = "backdrop";
-        nameOverlay.style.display = "none";
-        nameOverlay.style.position = "absolute";
-        nameOverlay.style.bottom = "0";
-        nameOverlay.style.left = "0";
-        nameOverlay.style["pointer-events"] = "none";
-        nameOverlay.style.padding = "4px";
-        nameOverlay.style.backgroundColor = "black";
-        nameOverlay.style.whiteSpace = "pre-line";
-        nameOverlay.style.fontSize = "12px";
-
-        let enablePicking = true;
-        const handler = new Cesium.ScreenSpaceEventHandler(viewer.scene.canvas);
-        handler.setInputAction(function (movement) {
-          if (enablePicking) {
-            const pickedObject = viewer.scene.pick(movement.endPosition);
-            if (pickedObject instanceof Cesium.Cesium3DTileFeature) {
-              nameOverlay.style.display = "block";
-              nameOverlay.style.bottom = `${
-                viewer.canvas.clientHeight - movement.endPosition.y
-              }px`;
-              nameOverlay.style.left = `${movement.endPosition.x}px`;
-              const component = pickedObject.getProperty("component");
-              const message = `Component: ${component}\nFeature ID: ${pickedObject.featureId}`;
-              nameOverlay.textContent = message;
             } else {
               nameOverlay.style.display = "none";
             }
-          } else {
-            nameOverlay.style.display = "none";
-          }
-        }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+          }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
 
-        const clickHandler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
-        handler.setInputAction(function (movement) {
-          if (enablePicking) {
-            const pickedObject = scene.pick(movement.position);
-            if (
-              Cesium.defined(pickedObject) &&
-              Cesium.defined(pickedObject.featureId)
-            ) {
-              selectFeatureShader.setUniform(
-                "u_selectedFeature",
-                pickedObject.featureId
-              );
-            } else {
-              selectFeatureShader.setUniform(
-                "u_selectedFeature",
-                NOTHING_SELECTED
-              );
+          const clickHandler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
+          handler.setInputAction(function (movement) {
+            if (enablePicking) {
+              const pickedObject = scene.pick(movement.position);
+              if (
+                Cesium.defined(pickedObject) &&
+                Cesium.defined(pickedObject.featureId)
+              ) {
+                selectFeatureShader.setUniform(
+                  "u_selectedFeature",
+                  pickedObject.featureId
+                );
+              } else {
+                selectFeatureShader.setUniform(
+                  "u_selectedFeature",
+                  NOTHING_SELECTED
+                );
+              }
             }
-          }
-        }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
+          }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
 
-        // UI ============================================================================
+          // UI ============================================================================
 
-        Sandcastle.addToggleButton("Enable picking", enablePicking, function (
-          checked
-        ) {
-          enablePicking = checked;
-        });
+          Sandcastle.addToggleButton("Enable picking", enablePicking, function (
+            checked
+          ) {
+            enablePicking = checked;
+          });
 
-        const demos = [
-          {
-            text: "Photogrammetry",
-            onselect: showPhotogrammetry,
-          },
-          {
-            text: "Show Classification",
-            onselect: showClassification,
-          },
-          {
-            text: "Show Alternative Classification",
-            onselect: showAlternativeClassification,
-          },
-          {
-            text: "Translucent Windows",
-            onselect: translucentWindows,
-          },
-          {
-            text: "Stylized PBR Materials",
-            onselect: pbrMaterials,
-          },
-          {
-            text: "Golden Touch",
-            onselect: goldenTouch,
-          },
-          {
-            text: "Multiple Feature ID Sets",
-            onselect: multipleFeatureIds,
-          },
-        ];
-        Sandcastle.addToolbarMenu(demos);
-
-        //Sandcastle_End
+          const demos = [
+            {
+              text: "Photogrammetry",
+              onselect: showPhotogrammetry,
+            },
+            {
+              text: "Show Classification",
+              onselect: showClassification,
+            },
+            {
+              text: "Show Alternative Classification",
+              onselect: showAlternativeClassification,
+            },
+            {
+              text: "Translucent Windows",
+              onselect: translucentWindows,
+            },
+            {
+              text: "Stylized PBR Materials",
+              onselect: pbrMaterials,
+            },
+            {
+              text: "Golden Touch",
+              onselect: goldenTouch,
+            },
+            {
+              text: "Multiple Feature ID Sets",
+              onselect: multipleFeatureIds,
+            },
+          ];
+          Sandcastle.addToolbarMenu(demos);
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/3D Tiles Next Photogrammetry Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Next Photogrammetry Classification.html
@@ -37,7 +37,7 @@
         //Sandcastle_Begin
         // San Francisco Ferry Building photogrammetry model provided by Aerometrex
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
           infoBox: false,
           orderIndependentTranslucency: false,
         });

--- a/Apps/Sandcastle/gallery/3D Tiles Photogrammetry Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Photogrammetry Classification.html
@@ -38,7 +38,7 @@
         //Sandcastle_Begin
         // An example of using a b3dm tileset to classify another b3dm tileset.
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         // A normal b3dm tileset containing photogrammetry

--- a/Apps/Sandcastle/gallery/3D Tiles Photogrammetry Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Photogrammetry Classification.html
@@ -36,47 +36,48 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        // An example of using a b3dm tileset to classify another b3dm tileset.
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
+        (async () => {
+          // An example of using a b3dm tileset to classify another b3dm tileset.
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
 
-        // A normal b3dm tileset containing photogrammetry
-        const tileset = new Cesium.Cesium3DTileset({
-          url: Cesium.IonResource.fromAssetId(40866),
-        });
-        viewer.scene.primitives.add(tileset);
-        viewer.zoomTo(tileset);
+          // A normal b3dm tileset containing photogrammetry
+          const tileset = new Cesium.Cesium3DTileset({
+            url: Cesium.IonResource.fromAssetId(40866),
+          });
+          viewer.scene.primitives.add(tileset);
+          viewer.zoomTo(tileset);
 
-        const classificationTilesetUrl =
-          "../../SampleData/Cesium3DTiles/Classification/Photogrammetry/tileset.json";
-        // A b3dm tileset used to classify the photogrammetry tileset
-        const classificationTileset = new Cesium.Cesium3DTileset({
-          url: classificationTilesetUrl,
-          classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
-        });
-        classificationTileset.style = new Cesium.Cesium3DTileStyle({
-          color: "rgba(255, 0, 0, 0.5)",
-        });
-        viewer.scene.primitives.add(classificationTileset);
+          const classificationTilesetUrl =
+            "../../SampleData/Cesium3DTiles/Classification/Photogrammetry/tileset.json";
+          // A b3dm tileset used to classify the photogrammetry tileset
+          const classificationTileset = new Cesium.Cesium3DTileset({
+            url: classificationTilesetUrl,
+            classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
+          });
+          classificationTileset.style = new Cesium.Cesium3DTileStyle({
+            color: "rgba(255, 0, 0, 0.5)",
+          });
+          viewer.scene.primitives.add(classificationTileset);
 
-        // The same b3dm tileset used for classification, but rendered normally for comparison.
-        const nonClassificationTileset = new Cesium.Cesium3DTileset({
-          url: classificationTilesetUrl,
-          show: false,
-        });
-        nonClassificationTileset.style = new Cesium.Cesium3DTileStyle({
-          color: "rgba(255, 0, 0, 0.5)",
-        });
-        viewer.scene.primitives.add(nonClassificationTileset);
+          // The same b3dm tileset used for classification, but rendered normally for comparison.
+          const nonClassificationTileset = new Cesium.Cesium3DTileset({
+            url: classificationTilesetUrl,
+            show: false,
+          });
+          nonClassificationTileset.style = new Cesium.Cesium3DTileStyle({
+            color: "rgba(255, 0, 0, 0.5)",
+          });
+          viewer.scene.primitives.add(nonClassificationTileset);
 
-        Sandcastle.addToggleButton("Show classification", true, function (
-          checked
-        ) {
-          classificationTileset.show = checked;
-          nonClassificationTileset.show = !checked;
-        });
-        //Sandcastle_End
+          Sandcastle.addToggleButton("Show classification", true, function (
+            checked
+          ) {
+            classificationTileset.show = checked;
+            nonClassificationTileset.show = !checked;
+          });
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/3D Tiles Photogrammetry.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Photogrammetry.html
@@ -36,18 +36,18 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
 
-        const tileset = new Cesium.Cesium3DTileset({
-          url: Cesium.IonResource.fromAssetId(40866),
-        });
+          const tileset = new Cesium.Cesium3DTileset({
+            url: Cesium.IonResource.fromAssetId(40866),
+          });
 
-        viewer.scene.primitives.add(tileset);
-        viewer.zoomTo(tileset);
-
-        //Sandcastle_End
+          viewer.scene.primitives.add(tileset);
+          viewer.zoomTo(tileset);
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/3D Tiles Photogrammetry.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Photogrammetry.html
@@ -37,7 +37,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         const tileset = new Cesium.Cesium3DTileset({

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Classification.html
@@ -36,83 +36,84 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        // An example showing a point cloud tileset classified by a Geometry tileset.
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
+        (async () => {
+          // An example showing a point cloud tileset classified by a Geometry tileset.
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
 
-        //Point Cloud by Prof. Peter Allen, Columbia University Robotics Lab. Scanning by Alejandro Troccoli and Matei Ciocarlie.
-        const tileset = new Cesium.Cesium3DTileset({
-          url: Cesium.IonResource.fromAssetId(16421),
-        });
-        viewer.scene.primitives.add(tileset);
+          //Point Cloud by Prof. Peter Allen, Columbia University Robotics Lab. Scanning by Alejandro Troccoli and Matei Ciocarlie.
+          const tileset = new Cesium.Cesium3DTileset({
+            url: Cesium.IonResource.fromAssetId(16421),
+          });
+          viewer.scene.primitives.add(tileset);
 
-        // Geometry Tiles are experimental and the format is subject to change in the future.
-        // For more details, see:
-        //    https://github.com/CesiumGS/3d-tiles/tree/vctr/TileFormats/Geometry
-        const classificationTileset = new Cesium.Cesium3DTileset({
-          url:
-            "../../SampleData/Cesium3DTiles/Classification/PointCloud/tileset.json",
-          classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
-        });
-        viewer.scene.primitives.add(classificationTileset);
+          // Geometry Tiles are experimental and the format is subject to change in the future.
+          // For more details, see:
+          //    https://github.com/CesiumGS/3d-tiles/tree/vctr/TileFormats/Geometry
+          const classificationTileset = new Cesium.Cesium3DTileset({
+            url:
+              "../../SampleData/Cesium3DTiles/Classification/PointCloud/tileset.json",
+            classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
+          });
+          viewer.scene.primitives.add(classificationTileset);
 
-        classificationTileset.style = new Cesium.Cesium3DTileStyle({
-          color: {
-            conditions: [
-              ["${id} === 'roof1'", "color('#004FFF', 0.5)"],
-              ["${id} === 'towerBottom1'", "color('#33BB66', 0.5)"],
-              ["${id} === 'towerTop1'", "color('#0099AA', 0.5)"],
-              ["${id} === 'roof2'", "color('#004FFF', 0.5)"],
-              ["${id} === 'tower3'", "color('#FF8833', 0.5)"],
-              ["${id} === 'tower4'", "color('#FFAA22', 0.5)"],
-              ["true", "color('#FFFF00', 0.5)"],
-            ],
+          classificationTileset.style = new Cesium.Cesium3DTileStyle({
+            color: {
+              conditions: [
+                ["${id} === 'roof1'", "color('#004FFF', 0.5)"],
+                ["${id} === 'towerBottom1'", "color('#33BB66', 0.5)"],
+                ["${id} === 'towerTop1'", "color('#0099AA', 0.5)"],
+                ["${id} === 'roof2'", "color('#004FFF', 0.5)"],
+                ["${id} === 'tower3'", "color('#FF8833', 0.5)"],
+                ["${id} === 'tower4'", "color('#FFAA22', 0.5)"],
+                ["true", "color('#FFFF00', 0.5)"],
+              ],
+            },
+          });
+
+          viewer.scene.camera.setView({
+            destination: new Cesium.Cartesian3(
+              4401744.644145314,
+              225051.41078911052,
+              4595420.374784433
+            ),
+            orientation: new Cesium.HeadingPitchRoll(
+              5.646733805039757,
+              -0.276607153839886,
+              6.281110875400085
+            ),
+          });
+
+          // Information about the currently highlighted feature
+          const highlighted = {
+            feature: undefined,
+            originalColor: new Cesium.Color(),
+          };
+
+          // Color a feature yellow on hover.
+          viewer.screenSpaceEventHandler.setInputAction(function onMouseMove(
+            movement
+          ) {
+            // If a feature was previously highlighted, undo the highlight
+            if (Cesium.defined(highlighted.feature)) {
+              highlighted.feature.color = highlighted.originalColor;
+              highlighted.feature = undefined;
+            }
+
+            // Pick a new feature
+            const pickedFeature = viewer.scene.pick(movement.endPosition);
+            if (!Cesium.defined(pickedFeature)) {
+              return;
+            }
+
+            // Highlight the feature
+            highlighted.feature = pickedFeature;
+            Cesium.Color.clone(pickedFeature.color, highlighted.originalColor);
+            pickedFeature.color = Cesium.Color.YELLOW.withAlpha(0.5);
           },
-        });
-
-        viewer.scene.camera.setView({
-          destination: new Cesium.Cartesian3(
-            4401744.644145314,
-            225051.41078911052,
-            4595420.374784433
-          ),
-          orientation: new Cesium.HeadingPitchRoll(
-            5.646733805039757,
-            -0.276607153839886,
-            6.281110875400085
-          ),
-        });
-
-        // Information about the currently highlighted feature
-        const highlighted = {
-          feature: undefined,
-          originalColor: new Cesium.Color(),
-        };
-
-        // Color a feature yellow on hover.
-        viewer.screenSpaceEventHandler.setInputAction(function onMouseMove(
-          movement
-        ) {
-          // If a feature was previously highlighted, undo the highlight
-          if (Cesium.defined(highlighted.feature)) {
-            highlighted.feature.color = highlighted.originalColor;
-            highlighted.feature = undefined;
-          }
-
-          // Pick a new feature
-          const pickedFeature = viewer.scene.pick(movement.endPosition);
-          if (!Cesium.defined(pickedFeature)) {
-            return;
-          }
-
-          // Highlight the feature
-          highlighted.feature = pickedFeature;
-          Cesium.Color.clone(pickedFeature.color, highlighted.originalColor);
-          pickedFeature.color = Cesium.Color.YELLOW.withAlpha(0.5);
-        },
-        Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-        //Sandcastle_End
+          Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Classification.html
@@ -38,7 +38,7 @@
         //Sandcastle_Begin
         // An example showing a point cloud tileset classified by a Geometry tileset.
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         //Point Cloud by Prof. Peter Allen, Columbia University Robotics Lab. Scanning by Alejandro Troccoli and Matei Ciocarlie.

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Shading.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Shading.html
@@ -160,220 +160,223 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
-
-        const scene = viewer.scene;
-        let viewModelTileset;
-
-        if (!Cesium.PointCloudShading.isSupported(scene)) {
-          window.alert("This browser does not support point cloud shading");
-        }
-
-        function reset() {
-          viewer.scene.primitives.remove(viewModelTileset);
-          viewModelTileset = undefined;
-        }
-
-        // The viewModel tracks the state of our mini application.
-        const pointClouds = ["St. Helens", "Church"];
-        const viewModel = {
-          exampleTypes: pointClouds,
-          currentExampleType: pointClouds[0],
-          maximumScreenSpaceError: 16.0,
-          geometricErrorScale: 1.0,
-          maximumAttenuation: 0, // Equivalent to undefined
-          baseResolution: 0, // Equivalent to undefined
-          eyeDomeLightingStrength: 1.0,
-          eyeDomeLightingRadius: 1.0,
-        };
-
-        function tilesetToViewModel(tileset) {
-          viewModelTileset = tileset;
-
-          const pointCloudShading = tileset.pointCloudShading;
-          viewModel.maximumScreenSpaceError = tileset.maximumScreenSpaceError;
-          viewModel.geometricErrorScale = pointCloudShading.geometricErrorScale;
-          viewModel.maximumAttenuation = pointCloudShading.maximumAttenuation
-            ? pointCloudShading.maximumAttenuation
-            : 0;
-          viewModel.baseResolution = pointCloudShading.baseResolution
-            ? pointCloudShading.baseResolution
-            : 0;
-          viewModel.eyeDomeLightingStrength =
-            pointCloudShading.eyeDomeLightingStrength;
-          viewModel.eyeDomeLightingRadius =
-            pointCloudShading.eyeDomeLightingRadius;
-        }
-
-        function loadStHelens() {
-          // Set the initial camera view to look at Mt. St. Helens
-          const initialPosition = Cesium.Cartesian3.fromRadians(
-            -2.1344873183780484,
-            0.8071380277370774,
-            5743.394497982162
-          );
-          const initialOrientation = new Cesium.HeadingPitchRoll.fromDegrees(
-            112.99596671210358,
-            -21.34390550872461,
-            0.0716951918898415
-          );
-          viewer.scene.camera.setView({
-            destination: initialPosition,
-            orientation: initialOrientation,
-            endTransform: Cesium.Matrix4.IDENTITY,
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
           });
 
-          // Mt. St. Helens 3D Tileset generated from LAS provided by https://www.liblas.org/samples/
-          // This tileset uses replacement refinement and has geometric error approximately equal to
-          // the average interpoint distance in each tile.
-          const tileset = new Cesium.Cesium3DTileset({
-            url: Cesium.IonResource.fromAssetId(5713),
-          });
-          viewer.scene.primitives.add(tileset);
+          const scene = viewer.scene;
+          let viewModelTileset;
 
-          tileset.maximumScreenSpaceError = 16.0;
-          tileset.pointCloudShading.maximumAttenuation = undefined; // Will be based on maximumScreenSpaceError instead
-          tileset.pointCloudShading.baseResolution = undefined;
-          tileset.pointCloudShading.geometricErrorScale = 1.0;
-          tileset.pointCloudShading.attenuation = true;
-          tileset.pointCloudShading.eyeDomeLighting = true;
-
-          tilesetToViewModel(tileset);
-        }
-
-        function loadChurch() {
-          // Point Cloud by Prof. Peter Allen, Columbia University Robotics Lab. Scanning by Alejandro Troccoli and Matei Ciocarlie.
-          // This tileset uses additive refinement and has geometric error based on the bounding box size for each tile.
-          const tileset = new Cesium.Cesium3DTileset({
-            url: Cesium.IonResource.fromAssetId(16421),
-          });
-          viewer.scene.primitives.add(tileset);
-
-          tileset.maximumScreenSpaceError = 16.0;
-          tileset.pointCloudShading.maximumAttenuation = 4.0; // Don't allow points larger than 4 pixels.
-          tileset.pointCloudShading.baseResolution = 0.05; // Assume an original capture resolution of 5 centimeters between neighboring points.
-          tileset.pointCloudShading.geometricErrorScale = 0.5; // Applies to both geometric error and the base resolution.
-          tileset.pointCloudShading.attenuation = true;
-          tileset.pointCloudShading.eyeDomeLighting = true;
-
-          viewer.scene.camera.setView({
-            destination: new Cesium.Cartesian3(
-              4401744.644145314,
-              225051.41078911052,
-              4595420.374784433
-            ),
-            orientation: new Cesium.HeadingPitchRoll(
-              5.646733805039757,
-              -0.276607153839886,
-              6.281110875400085
-            ),
-          });
-
-          tilesetToViewModel(tileset);
-        }
-
-        function checkZero(newValue) {
-          const newValueFloat = parseFloat(newValue);
-          return newValueFloat === 0.0 ? undefined : newValueFloat;
-        }
-
-        loadStHelens();
-
-        // Convert the viewModel members into knockout observables.
-        Cesium.knockout.track(viewModel);
-
-        // Bind the viewModel to the DOM elements of the UI that call for it.
-        const toolbar = document.getElementById("toolbar");
-        Cesium.knockout.applyBindings(viewModel, toolbar);
-
-        Cesium.knockout
-          .getObservable(viewModel, "currentExampleType")
-          .subscribe(function (newValue) {
-            reset();
-            if (newValue === pointClouds[0]) {
-              loadStHelens();
-            } else if (newValue === pointClouds[1]) {
-              loadChurch();
-            }
-          });
-
-        Cesium.knockout
-          .getObservable(viewModel, "maximumScreenSpaceError")
-          .subscribe(function (newValue) {
-            if (Cesium.defined(viewModelTileset)) {
-              viewModelTileset.maximumScreenSpaceError = parseFloat(newValue);
-            }
-          });
-
-        Cesium.knockout
-          .getObservable(viewModel, "geometricErrorScale")
-          .subscribe(function (newValue) {
-            if (Cesium.defined(viewModelTileset)) {
-              viewModelTileset.pointCloudShading.geometricErrorScale = parseFloat(
-                newValue
-              );
-            }
-          });
-
-        Cesium.knockout
-          .getObservable(viewModel, "maximumAttenuation")
-          .subscribe(function (newValue) {
-            if (Cesium.defined(viewModelTileset)) {
-              viewModelTileset.pointCloudShading.maximumAttenuation = checkZero(
-                newValue
-              );
-            }
-          });
-
-        Cesium.knockout
-          .getObservable(viewModel, "baseResolution")
-          .subscribe(function (newValue) {
-            if (Cesium.defined(viewModelTileset)) {
-              viewModelTileset.pointCloudShading.baseResolution = checkZero(
-                newValue
-              );
-            }
-          });
-
-        Cesium.knockout
-          .getObservable(viewModel, "eyeDomeLightingStrength")
-          .subscribe(function (newValue) {
-            if (Cesium.defined(viewModelTileset)) {
-              viewModelTileset.pointCloudShading.eyeDomeLightingStrength = parseFloat(
-                newValue
-              );
-            }
-          });
-
-        Cesium.knockout
-          .getObservable(viewModel, "eyeDomeLightingRadius")
-          .subscribe(function (newValue) {
-            if (Cesium.defined(viewModelTileset)) {
-              viewModelTileset.pointCloudShading.eyeDomeLightingRadius = parseFloat(
-                newValue
-              );
-            }
-          });
-
-        Sandcastle.addToggleButton("Enable Attenuation", true, function (
-          checked
-        ) {
-          if (Cesium.defined(viewModelTileset)) {
-            viewModelTileset.pointCloudShading.attenuation = checked;
+          if (!Cesium.PointCloudShading.isSupported(scene)) {
+            window.alert("This browser does not support point cloud shading");
           }
-        });
 
-        Sandcastle.addToggleButton("Enable Eye Dome Lighting", true, function (
-          checked
-        ) {
-          if (Cesium.defined(viewModelTileset)) {
-            viewModelTileset.pointCloudShading.eyeDomeLighting = checked;
+          function reset() {
+            viewer.scene.primitives.remove(viewModelTileset);
+            viewModelTileset = undefined;
           }
-        });
 
-        //Sandcastle_End
+          // The viewModel tracks the state of our mini application.
+          const pointClouds = ["St. Helens", "Church"];
+          const viewModel = {
+            exampleTypes: pointClouds,
+            currentExampleType: pointClouds[0],
+            maximumScreenSpaceError: 16.0,
+            geometricErrorScale: 1.0,
+            maximumAttenuation: 0, // Equivalent to undefined
+            baseResolution: 0, // Equivalent to undefined
+            eyeDomeLightingStrength: 1.0,
+            eyeDomeLightingRadius: 1.0,
+          };
+
+          function tilesetToViewModel(tileset) {
+            viewModelTileset = tileset;
+
+            const pointCloudShading = tileset.pointCloudShading;
+            viewModel.maximumScreenSpaceError = tileset.maximumScreenSpaceError;
+            viewModel.geometricErrorScale =
+              pointCloudShading.geometricErrorScale;
+            viewModel.maximumAttenuation = pointCloudShading.maximumAttenuation
+              ? pointCloudShading.maximumAttenuation
+              : 0;
+            viewModel.baseResolution = pointCloudShading.baseResolution
+              ? pointCloudShading.baseResolution
+              : 0;
+            viewModel.eyeDomeLightingStrength =
+              pointCloudShading.eyeDomeLightingStrength;
+            viewModel.eyeDomeLightingRadius =
+              pointCloudShading.eyeDomeLightingRadius;
+          }
+
+          function loadStHelens() {
+            // Set the initial camera view to look at Mt. St. Helens
+            const initialPosition = Cesium.Cartesian3.fromRadians(
+              -2.1344873183780484,
+              0.8071380277370774,
+              5743.394497982162
+            );
+            const initialOrientation = new Cesium.HeadingPitchRoll.fromDegrees(
+              112.99596671210358,
+              -21.34390550872461,
+              0.0716951918898415
+            );
+            viewer.scene.camera.setView({
+              destination: initialPosition,
+              orientation: initialOrientation,
+              endTransform: Cesium.Matrix4.IDENTITY,
+            });
+
+            // Mt. St. Helens 3D Tileset generated from LAS provided by https://www.liblas.org/samples/
+            // This tileset uses replacement refinement and has geometric error approximately equal to
+            // the average interpoint distance in each tile.
+            const tileset = new Cesium.Cesium3DTileset({
+              url: Cesium.IonResource.fromAssetId(5713),
+            });
+            viewer.scene.primitives.add(tileset);
+
+            tileset.maximumScreenSpaceError = 16.0;
+            tileset.pointCloudShading.maximumAttenuation = undefined; // Will be based on maximumScreenSpaceError instead
+            tileset.pointCloudShading.baseResolution = undefined;
+            tileset.pointCloudShading.geometricErrorScale = 1.0;
+            tileset.pointCloudShading.attenuation = true;
+            tileset.pointCloudShading.eyeDomeLighting = true;
+
+            tilesetToViewModel(tileset);
+          }
+
+          function loadChurch() {
+            // Point Cloud by Prof. Peter Allen, Columbia University Robotics Lab. Scanning by Alejandro Troccoli and Matei Ciocarlie.
+            // This tileset uses additive refinement and has geometric error based on the bounding box size for each tile.
+            const tileset = new Cesium.Cesium3DTileset({
+              url: Cesium.IonResource.fromAssetId(16421),
+            });
+            viewer.scene.primitives.add(tileset);
+
+            tileset.maximumScreenSpaceError = 16.0;
+            tileset.pointCloudShading.maximumAttenuation = 4.0; // Don't allow points larger than 4 pixels.
+            tileset.pointCloudShading.baseResolution = 0.05; // Assume an original capture resolution of 5 centimeters between neighboring points.
+            tileset.pointCloudShading.geometricErrorScale = 0.5; // Applies to both geometric error and the base resolution.
+            tileset.pointCloudShading.attenuation = true;
+            tileset.pointCloudShading.eyeDomeLighting = true;
+
+            viewer.scene.camera.setView({
+              destination: new Cesium.Cartesian3(
+                4401744.644145314,
+                225051.41078911052,
+                4595420.374784433
+              ),
+              orientation: new Cesium.HeadingPitchRoll(
+                5.646733805039757,
+                -0.276607153839886,
+                6.281110875400085
+              ),
+            });
+
+            tilesetToViewModel(tileset);
+          }
+
+          function checkZero(newValue) {
+            const newValueFloat = parseFloat(newValue);
+            return newValueFloat === 0.0 ? undefined : newValueFloat;
+          }
+
+          loadStHelens();
+
+          // Convert the viewModel members into knockout observables.
+          Cesium.knockout.track(viewModel);
+
+          // Bind the viewModel to the DOM elements of the UI that call for it.
+          const toolbar = document.getElementById("toolbar");
+          Cesium.knockout.applyBindings(viewModel, toolbar);
+
+          Cesium.knockout
+            .getObservable(viewModel, "currentExampleType")
+            .subscribe(function (newValue) {
+              reset();
+              if (newValue === pointClouds[0]) {
+                loadStHelens();
+              } else if (newValue === pointClouds[1]) {
+                loadChurch();
+              }
+            });
+
+          Cesium.knockout
+            .getObservable(viewModel, "maximumScreenSpaceError")
+            .subscribe(function (newValue) {
+              if (Cesium.defined(viewModelTileset)) {
+                viewModelTileset.maximumScreenSpaceError = parseFloat(newValue);
+              }
+            });
+
+          Cesium.knockout
+            .getObservable(viewModel, "geometricErrorScale")
+            .subscribe(function (newValue) {
+              if (Cesium.defined(viewModelTileset)) {
+                viewModelTileset.pointCloudShading.geometricErrorScale = parseFloat(
+                  newValue
+                );
+              }
+            });
+
+          Cesium.knockout
+            .getObservable(viewModel, "maximumAttenuation")
+            .subscribe(function (newValue) {
+              if (Cesium.defined(viewModelTileset)) {
+                viewModelTileset.pointCloudShading.maximumAttenuation = checkZero(
+                  newValue
+                );
+              }
+            });
+
+          Cesium.knockout
+            .getObservable(viewModel, "baseResolution")
+            .subscribe(function (newValue) {
+              if (Cesium.defined(viewModelTileset)) {
+                viewModelTileset.pointCloudShading.baseResolution = checkZero(
+                  newValue
+                );
+              }
+            });
+
+          Cesium.knockout
+            .getObservable(viewModel, "eyeDomeLightingStrength")
+            .subscribe(function (newValue) {
+              if (Cesium.defined(viewModelTileset)) {
+                viewModelTileset.pointCloudShading.eyeDomeLightingStrength = parseFloat(
+                  newValue
+                );
+              }
+            });
+
+          Cesium.knockout
+            .getObservable(viewModel, "eyeDomeLightingRadius")
+            .subscribe(function (newValue) {
+              if (Cesium.defined(viewModelTileset)) {
+                viewModelTileset.pointCloudShading.eyeDomeLightingRadius = parseFloat(
+                  newValue
+                );
+              }
+            });
+
+          Sandcastle.addToggleButton("Enable Attenuation", true, function (
+            checked
+          ) {
+            if (Cesium.defined(viewModelTileset)) {
+              viewModelTileset.pointCloudShading.attenuation = checked;
+            }
+          });
+
+          Sandcastle.addToggleButton(
+            "Enable Eye Dome Lighting",
+            true,
+            function (checked) {
+              if (Cesium.defined(viewModelTileset)) {
+                viewModelTileset.pointCloudShading.eyeDomeLighting = checked;
+              }
+            }
+          );
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Shading.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Shading.html
@@ -161,7 +161,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         const scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud.html
@@ -38,7 +38,7 @@
         //Sandcastle_Begin
         //Point Cloud by Prof. Peter Allen, Columbia University Robotics Lab. Scanning by Alejandro Troccoli and Matei Ciocarlie.
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         const tileset = new Cesium.Cesium3DTileset({

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud.html
@@ -36,30 +36,30 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        //Point Cloud by Prof. Peter Allen, Columbia University Robotics Lab. Scanning by Alejandro Troccoli and Matei Ciocarlie.
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
+        (async () => {
+          //Point Cloud by Prof. Peter Allen, Columbia University Robotics Lab. Scanning by Alejandro Troccoli and Matei Ciocarlie.
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
 
-        const tileset = new Cesium.Cesium3DTileset({
-          url: Cesium.IonResource.fromAssetId(16421),
-        });
-        viewer.scene.primitives.add(tileset);
+          const tileset = new Cesium.Cesium3DTileset({
+            url: Cesium.IonResource.fromAssetId(16421),
+          });
+          viewer.scene.primitives.add(tileset);
 
-        viewer.scene.camera.setView({
-          destination: new Cesium.Cartesian3(
-            4401744.644145314,
-            225051.41078911052,
-            4595420.374784433
-          ),
-          orientation: new Cesium.HeadingPitchRoll(
-            5.646733805039757,
-            -0.276607153839886,
-            6.281110875400085
-          ),
-        });
-
-        //Sandcastle_End
+          viewer.scene.camera.setView({
+            destination: new Cesium.Cartesian3(
+              4401744.644145314,
+              225051.41078911052,
+              4595420.374784433
+            ),
+            orientation: new Cesium.HeadingPitchRoll(
+              5.646733805039757,
+              -0.276607153839886,
+              6.281110875400085
+            ),
+          });
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/3D Tiles Terrain Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Terrain Classification.html
@@ -36,56 +36,57 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
 
-        const geocoder = viewer.geocoder.viewModel;
-        geocoder.searchText = "Vienna";
-        geocoder.flightDuration = 0.0;
-        geocoder.search();
+          const geocoder = viewer.geocoder.viewModel;
+          geocoder.searchText = "Vienna";
+          geocoder.flightDuration = 0.0;
+          geocoder.search();
 
-        // Vector 3D Tiles are experimental and the format is subject to change in the future.
-        // For more details, see:
-        //    https://github.com/CesiumGS/3d-tiles/tree/vctr/TileFormats/VectorData
-        const tileset = new Cesium.Cesium3DTileset({
-          url: Cesium.IonResource.fromAssetId(5737),
-        });
-        viewer.scene.primitives.add(tileset);
+          // Vector 3D Tiles are experimental and the format is subject to change in the future.
+          // For more details, see:
+          //    https://github.com/CesiumGS/3d-tiles/tree/vctr/TileFormats/VectorData
+          const tileset = new Cesium.Cesium3DTileset({
+            url: Cesium.IonResource.fromAssetId(5737),
+          });
+          viewer.scene.primitives.add(tileset);
 
-        tileset.style = new Cesium.Cesium3DTileStyle({
-          color: "rgba(255, 255, 255, 0.5)",
-        });
+          tileset.style = new Cesium.Cesium3DTileStyle({
+            color: "rgba(255, 255, 255, 0.5)",
+          });
 
-        // Information about the currently highlighted feature
-        const highlighted = {
-          feature: undefined,
-          originalColor: new Cesium.Color(),
-        };
+          // Information about the currently highlighted feature
+          const highlighted = {
+            feature: undefined,
+            originalColor: new Cesium.Color(),
+          };
 
-        // Color a feature yellow on hover.
-        viewer.screenSpaceEventHandler.setInputAction(function onMouseMove(
-          movement
-        ) {
-          // If a feature was previously highlighted, undo the highlight
-          if (Cesium.defined(highlighted.feature)) {
-            highlighted.feature.color = highlighted.originalColor;
-            highlighted.feature = undefined;
-          }
+          // Color a feature yellow on hover.
+          viewer.screenSpaceEventHandler.setInputAction(function onMouseMove(
+            movement
+          ) {
+            // If a feature was previously highlighted, undo the highlight
+            if (Cesium.defined(highlighted.feature)) {
+              highlighted.feature.color = highlighted.originalColor;
+              highlighted.feature = undefined;
+            }
 
-          // Pick a new feature
-          const pickedFeature = viewer.scene.pick(movement.endPosition);
-          if (!Cesium.defined(pickedFeature)) {
-            return;
-          }
+            // Pick a new feature
+            const pickedFeature = viewer.scene.pick(movement.endPosition);
+            if (!Cesium.defined(pickedFeature)) {
+              return;
+            }
 
-          // Highlight the feature
-          highlighted.feature = pickedFeature;
-          Cesium.Color.clone(pickedFeature.color, highlighted.originalColor);
-          pickedFeature.color = Cesium.Color.YELLOW;
-        },
-        Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-        //Sandcastle_End
+            // Highlight the feature
+            highlighted.feature = pickedFeature;
+            Cesium.Color.clone(pickedFeature.color, highlighted.originalColor);
+            pickedFeature.color = Cesium.Color.YELLOW;
+          },
+          Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/3D Tiles Terrain Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Terrain Classification.html
@@ -37,7 +37,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         const geocoder = viewer.geocoder.viewModel;

--- a/Apps/Sandcastle/gallery/ArcGIS Tiled Elevation Terrain.html
+++ b/Apps/Sandcastle/gallery/ArcGIS Tiled Elevation Terrain.html
@@ -33,10 +33,9 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: new Cesium.ArcGISTiledElevationTerrainProvider({
-            url:
-              "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer",
-          }),
+          terrainProvider: Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
+            "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
+          ),
         }); //Sandcastle_End
         Sandcastle.finishedLoading();
       };

--- a/Apps/Sandcastle/gallery/ArcGIS Tiled Elevation Terrain.html
+++ b/Apps/Sandcastle/gallery/ArcGIS Tiled Elevation Terrain.html
@@ -32,11 +32,17 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
-            "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
-          ),
-        }); //Sandcastle_End
+        (async () => {
+          try {
+            const viewer = new Cesium.Viewer("cesiumContainer", {
+              terrainProvider: await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
+                "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
+              ),
+            });
+          } catch (error) {
+            console.log(error);
+          }
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/ArcticDEM.html
+++ b/Apps/Sandcastle/gallery/ArcticDEM.html
@@ -38,9 +38,9 @@
         // High-resolution arctic terrain from the Arctic DEM project (Release 4), tiled and hosted by Cesium ion.
         // https://www.pgc.umn.edu/data/arcticdem/
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: new Cesium.CesiumTerrainProvider({
-            url: Cesium.IonResource.fromAssetId(3956),
-          }),
+          terrainProvider: Cesium.CesiumTerrainProvider.fromUrl(
+            Cesium.IonResource.fromAssetId(3956)
+          ),
         });
 
         // Add Alaskan locations

--- a/Apps/Sandcastle/gallery/ArcticDEM.html
+++ b/Apps/Sandcastle/gallery/ArcticDEM.html
@@ -35,89 +35,90 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        // High-resolution arctic terrain from the Arctic DEM project (Release 4), tiled and hosted by Cesium ion.
-        // https://www.pgc.umn.edu/data/arcticdem/
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.CesiumTerrainProvider.fromUrl(
-            Cesium.IonResource.fromAssetId(3956)
-          ),
-        });
+        (async () => {
+          // High-resolution arctic terrain from the Arctic DEM project (Release 4), tiled and hosted by Cesium ion.
+          // https://www.pgc.umn.edu/data/arcticdem/
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.CesiumTerrainProvider.fromUrl(
+              Cesium.IonResource.fromAssetId(3956)
+            ),
+          });
 
-        // Add Alaskan locations
-        Sandcastle.addDefaultToolbarMenu(
-          [
-            {
-              text: "Denali",
-              onselect: function () {
-                viewer.scene.camera.flyTo({
-                  destination: Cesium.Cartesian3.fromRadians(
-                    -2.6399828792482234,
-                    1.0993550795541742,
-                    5795
-                  ),
-                  orientation: {
-                    heading: 3.8455,
-                    pitch: -0.4535,
-                    roll: 0.0,
-                  },
-                });
+          // Add Alaskan locations
+          Sandcastle.addDefaultToolbarMenu(
+            [
+              {
+                text: "Denali",
+                onselect: function () {
+                  viewer.scene.camera.flyTo({
+                    destination: Cesium.Cartesian3.fromRadians(
+                      -2.6399828792482234,
+                      1.0993550795541742,
+                      5795
+                    ),
+                    orientation: {
+                      heading: 3.8455,
+                      pitch: -0.4535,
+                      roll: 0.0,
+                    },
+                  });
+                },
               },
-            },
-            {
-              text: "Anchorage Area",
-              onselect: function () {
-                viewer.scene.camera.flyTo({
-                  destination: Cesium.Cartesian3.fromRadians(
-                    -2.610708034601548,
-                    1.0671172431736584,
-                    1900
-                  ),
-                  orientation: {
-                    heading: 4.6,
-                    pitch: -0.341,
-                    roll: 0.0,
-                  },
-                });
+              {
+                text: "Anchorage Area",
+                onselect: function () {
+                  viewer.scene.camera.flyTo({
+                    destination: Cesium.Cartesian3.fromRadians(
+                      -2.610708034601548,
+                      1.0671172431736584,
+                      1900
+                    ),
+                    orientation: {
+                      heading: 4.6,
+                      pitch: -0.341,
+                      roll: 0.0,
+                    },
+                  });
+                },
               },
-            },
-            {
-              text: "Peaks",
-              onselect: function () {
-                viewer.scene.camera.flyTo({
-                  destination: Cesium.Cartesian3.fromRadians(
-                    -2.6928866820212813,
-                    1.072394255273859,
-                    3700
-                  ),
-                  orientation: {
-                    heading: 1.6308222948889464,
-                    pitch: -0.6473480165020193,
-                    roll: 0.0,
-                  },
-                });
+              {
+                text: "Peaks",
+                onselect: function () {
+                  viewer.scene.camera.flyTo({
+                    destination: Cesium.Cartesian3.fromRadians(
+                      -2.6928866820212813,
+                      1.072394255273859,
+                      3700
+                    ),
+                    orientation: {
+                      heading: 1.6308222948889464,
+                      pitch: -0.6473480165020193,
+                      roll: 0.0,
+                    },
+                  });
+                },
               },
-            },
-            {
-              text: "Riverbed",
-              onselect: function () {
-                viewer.scene.camera.flyTo({
-                  destination: Cesium.Cartesian3.fromRadians(
-                    -2.6395623497608596,
-                    1.0976443174490356,
-                    2070
-                  ),
-                  orientation: {
-                    heading: 6.068794108659519,
-                    pitch: -0.08514161789475816,
-                    roll: 0.0,
-                  },
-                });
+              {
+                text: "Riverbed",
+                onselect: function () {
+                  viewer.scene.camera.flyTo({
+                    destination: Cesium.Cartesian3.fromRadians(
+                      -2.6395623497608596,
+                      1.0976443174490356,
+                      2070
+                    ),
+                    orientation: {
+                      heading: 6.068794108659519,
+                      pitch: -0.08514161789475816,
+                      roll: 0.0,
+                    },
+                  });
+                },
               },
-            },
-          ],
-          "toolbar"
-        );
-        //Sandcastle_End
+            ],
+            "toolbar"
+          );
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/ArcticDEM.html
+++ b/Apps/Sandcastle/gallery/ArcticDEM.html
@@ -35,90 +35,95 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          // High-resolution arctic terrain from the Arctic DEM project (Release 4), tiled and hosted by Cesium ion.
-          // https://www.pgc.umn.edu/data/arcticdem/
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.CesiumTerrainProvider.fromUrl(
-              Cesium.IonResource.fromAssetId(3956)
-            ),
-          });
+        const viewer = new Cesium.Viewer("cesiumContainer");
 
-          // Add Alaskan locations
-          Sandcastle.addDefaultToolbarMenu(
-            [
-              {
-                text: "Denali",
-                onselect: function () {
-                  viewer.scene.camera.flyTo({
-                    destination: Cesium.Cartesian3.fromRadians(
-                      -2.6399828792482234,
-                      1.0993550795541742,
-                      5795
-                    ),
-                    orientation: {
-                      heading: 3.8455,
-                      pitch: -0.4535,
-                      roll: 0.0,
-                    },
-                  });
-                },
+        (async () => {
+          try {
+            // High-resolution arctic terrain from the Arctic DEM project (Release 4), tiled and hosted by Cesium ion.
+            // https://www.pgc.umn.edu/data/arcticdem/
+            viewer.terrainProvider = await Cesium.CesiumTerrainProvider.fromUrl(
+              Cesium.IonResource.fromAssetId(3956)
+            );
+          } catch (error) {
+            console.log(error);
+          }
+        })();
+
+        // Add Alaskan locations
+        Sandcastle.addDefaultToolbarMenu(
+          [
+            {
+              text: "Denali",
+              onselect: function () {
+                viewer.scene.camera.flyTo({
+                  destination: Cesium.Cartesian3.fromRadians(
+                    -2.6399828792482234,
+                    1.0993550795541742,
+                    5795
+                  ),
+                  orientation: {
+                    heading: 3.8455,
+                    pitch: -0.4535,
+                    roll: 0.0,
+                  },
+                });
               },
-              {
-                text: "Anchorage Area",
-                onselect: function () {
-                  viewer.scene.camera.flyTo({
-                    destination: Cesium.Cartesian3.fromRadians(
-                      -2.610708034601548,
-                      1.0671172431736584,
-                      1900
-                    ),
-                    orientation: {
-                      heading: 4.6,
-                      pitch: -0.341,
-                      roll: 0.0,
-                    },
-                  });
-                },
+            },
+            {
+              text: "Anchorage Area",
+              onselect: function () {
+                viewer.scene.camera.flyTo({
+                  destination: Cesium.Cartesian3.fromRadians(
+                    -2.610708034601548,
+                    1.0671172431736584,
+                    1900
+                  ),
+                  orientation: {
+                    heading: 4.6,
+                    pitch: -0.341,
+                    roll: 0.0,
+                  },
+                });
               },
-              {
-                text: "Peaks",
-                onselect: function () {
-                  viewer.scene.camera.flyTo({
-                    destination: Cesium.Cartesian3.fromRadians(
-                      -2.6928866820212813,
-                      1.072394255273859,
-                      3700
-                    ),
-                    orientation: {
-                      heading: 1.6308222948889464,
-                      pitch: -0.6473480165020193,
-                      roll: 0.0,
-                    },
-                  });
-                },
+            },
+            {
+              text: "Peaks",
+              onselect: function () {
+                viewer.scene.camera.flyTo({
+                  destination: Cesium.Cartesian3.fromRadians(
+                    -2.6928866820212813,
+                    1.072394255273859,
+                    3700
+                  ),
+                  orientation: {
+                    heading: 1.6308222948889464,
+                    pitch: -0.6473480165020193,
+                    roll: 0.0,
+                  },
+                });
               },
-              {
-                text: "Riverbed",
-                onselect: function () {
-                  viewer.scene.camera.flyTo({
-                    destination: Cesium.Cartesian3.fromRadians(
-                      -2.6395623497608596,
-                      1.0976443174490356,
-                      2070
-                    ),
-                    orientation: {
-                      heading: 6.068794108659519,
-                      pitch: -0.08514161789475816,
-                      roll: 0.0,
-                    },
-                  });
-                },
+            },
+            {
+              text: "Riverbed",
+              onselect: function () {
+                viewer.scene.camera.flyTo({
+                  destination: Cesium.Cartesian3.fromRadians(
+                    -2.6395623497608596,
+                    1.0976443174490356,
+                    2070
+                  ),
+                  orientation: {
+                    heading: 6.068794108659519,
+                    pitch: -0.08514161789475816,
+                    roll: 0.0,
+                  },
+                });
               },
-            ],
-            "toolbar"
-          );
-        })(); //Sandcastle_End
+            },
+          ],
+          "toolbar"
+        );
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Atmosphere.html
+++ b/Apps/Sandcastle/gallery/Atmosphere.html
@@ -792,9 +792,10 @@
 
         Cesium.knockout
           .getObservable(viewModel, "enableTerrain")
-          .subscribe(function (newValue) {
+          .subscribe(async function (newValue) {
             if (newValue) {
-              globe.terrainProvider = Cesium.createWorldTerrain();
+              const provider = await Cesium.createWorldTerrainAsync();
+              globe.terrainProvider = provider;
             } else {
               globe.terrainProvider = new Cesium.EllipsoidTerrainProvider();
             }

--- a/Apps/Sandcastle/gallery/Billboards.html
+++ b/Apps/Sandcastle/gallery/Billboards.html
@@ -248,11 +248,12 @@
         }
 
         let terrainProvider;
-        function disableDepthTest() {
+        async function disableDepthTest() {
           Sandcastle.declare(disableDepthTest);
 
           terrainProvider = viewer.terrainProvider;
-          viewer.terrainProvider = Cesium.createWorldTerrain();
+          const worldTerrainProvider = await Cesium.createWorldTerrainAsync();
+          viewer.terrainProvider = worldTerrainProvider;
           viewer.scene.globe.depthTestAgainstTerrain = true;
 
           viewer.entities.add({

--- a/Apps/Sandcastle/gallery/CZML Path.html
+++ b/Apps/Sandcastle/gallery/CZML Path.html
@@ -7243,19 +7243,19 @@
           },
         ];
 
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-          baseLayerPicker: false,
-          shouldAnimate: true,
-        });
-
-        viewer.dataSources
-          .add(Cesium.CzmlDataSource.load(czml))
-          .then(function (ds) {
-            viewer.trackedEntity = ds.entities.getById("path");
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+            baseLayerPicker: false,
+            shouldAnimate: true,
           });
 
-        //Sandcastle_End
+          const dataSource = await viewer.dataSources.add(
+            Cesium.CzmlDataSource.load(czml)
+          );
+
+          viewer.trackedEntity = dataSource.entities.getById("path");
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/CZML Path.html
+++ b/Apps/Sandcastle/gallery/CZML Path.html
@@ -7244,7 +7244,7 @@
         ];
 
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
           baseLayerPicker: false,
           shouldAnimate: true,
         });

--- a/Apps/Sandcastle/gallery/Cardboard.html
+++ b/Apps/Sandcastle/gallery/Cardboard.html
@@ -35,155 +35,155 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          vrButton: true,
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
-        // Click the VR button in the bottom right of the screen to switch to VR mode.
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            vrButton: true,
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
+          // Click the VR button in the bottom right of the screen to switch to VR mode.
 
-        viewer.scene.globe.enableLighting = true;
-        viewer.scene.globe.depthTestAgainstTerrain = true;
+          viewer.scene.globe.enableLighting = true;
+          viewer.scene.globe.depthTestAgainstTerrain = true;
 
-        // Follow the path of a plane. See the interpolation Sandcastle example.
-        Cesium.Math.setRandomNumberSeed(3);
+          // Follow the path of a plane. See the interpolation Sandcastle example.
+          Cesium.Math.setRandomNumberSeed(3);
 
-        const start = Cesium.JulianDate.fromDate(new Date(2015, 2, 25, 16));
-        const stop = Cesium.JulianDate.addSeconds(
-          start,
-          360,
-          new Cesium.JulianDate()
-        );
+          const start = Cesium.JulianDate.fromDate(new Date(2015, 2, 25, 16));
+          const stop = Cesium.JulianDate.addSeconds(
+            start,
+            360,
+            new Cesium.JulianDate()
+          );
 
-        viewer.clock.startTime = start.clone();
-        viewer.clock.stopTime = stop.clone();
-        viewer.clock.currentTime = start.clone();
-        viewer.clock.clockRange = Cesium.ClockRange.LOOP_STOP;
-        viewer.clock.multiplier = 1.0;
-        viewer.clock.shouldAnimate = true;
+          viewer.clock.startTime = start.clone();
+          viewer.clock.stopTime = stop.clone();
+          viewer.clock.currentTime = start.clone();
+          viewer.clock.clockRange = Cesium.ClockRange.LOOP_STOP;
+          viewer.clock.multiplier = 1.0;
+          viewer.clock.shouldAnimate = true;
 
-        function computeCirclularFlight(lon, lat, radius) {
-          const property = new Cesium.SampledPositionProperty();
-          const startAngle = Cesium.Math.nextRandomNumber() * 360.0;
-          const endAngle = startAngle + 360.0;
+          function computeCirclularFlight(lon, lat, radius) {
+            const property = new Cesium.SampledPositionProperty();
+            const startAngle = Cesium.Math.nextRandomNumber() * 360.0;
+            const endAngle = startAngle + 360.0;
 
-          const increment =
-            (Cesium.Math.nextRandomNumber() * 2.0 - 1.0) * 10.0 + 45.0;
-          for (let i = startAngle; i < endAngle; i += increment) {
-            const radians = Cesium.Math.toRadians(i);
-            const timeIncrement = i - startAngle;
-            const time = Cesium.JulianDate.addSeconds(
-              start,
-              timeIncrement,
-              new Cesium.JulianDate()
-            );
-            const position = Cesium.Cartesian3.fromDegrees(
-              lon + radius * 1.5 * Math.cos(radians),
-              lat + radius * Math.sin(radians),
-              Cesium.Math.nextRandomNumber() * 500 + 1800
-            );
-            property.addSample(time, position);
-          }
-          return property;
-        }
-
-        const longitude = -112.110693;
-        const latitude = 36.0994841;
-        const radius = 0.03;
-
-        const modelURI =
-          "../../SampleData/models/CesiumBalloon/CesiumBalloon.glb";
-        const entity = viewer.entities.add({
-          availability: new Cesium.TimeIntervalCollection([
-            new Cesium.TimeInterval({
-              start: start,
-              stop: stop,
-            }),
-          ]),
-          position: computeCirclularFlight(longitude, latitude, radius),
-          model: {
-            uri: modelURI,
-            minimumPixelSize: 64,
-          },
-        });
-
-        entity.position.setInterpolationOptions({
-          interpolationDegree: 2,
-          interpolationAlgorithm: Cesium.HermitePolynomialApproximation,
-        });
-
-        // Set initial camera position and orientation to be when in the model's reference frame.
-        const camera = viewer.camera;
-        camera.position = new Cesium.Cartesian3(0.25, 0.0, 0.0);
-        camera.direction = new Cesium.Cartesian3(1.0, 0.0, 0.0);
-        camera.up = new Cesium.Cartesian3(0.0, 0.0, 1.0);
-        camera.right = new Cesium.Cartesian3(0.0, -1.0, 0.0);
-
-        viewer.scene.postUpdate.addEventListener(function (scene, time) {
-          const position = entity.position.getValue(time);
-          if (!Cesium.defined(position)) {
-            return;
-          }
-
-          let transform;
-          if (!Cesium.defined(entity.orientation)) {
-            transform = Cesium.Transforms.eastNorthUpToFixedFrame(position);
-          } else {
-            const orientation = entity.orientation.getValue(time);
-            if (!Cesium.defined(orientation)) {
-              return;
+            const increment =
+              (Cesium.Math.nextRandomNumber() * 2.0 - 1.0) * 10.0 + 45.0;
+            for (let i = startAngle; i < endAngle; i += increment) {
+              const radians = Cesium.Math.toRadians(i);
+              const timeIncrement = i - startAngle;
+              const time = Cesium.JulianDate.addSeconds(
+                start,
+                timeIncrement,
+                new Cesium.JulianDate()
+              );
+              const position = Cesium.Cartesian3.fromDegrees(
+                lon + radius * 1.5 * Math.cos(radians),
+                lat + radius * Math.sin(radians),
+                Cesium.Math.nextRandomNumber() * 500 + 1800
+              );
+              property.addSample(time, position);
             }
-
-            transform = Cesium.Matrix4.fromRotationTranslation(
-              Cesium.Matrix3.fromQuaternion(orientation),
-              position
-            );
+            return property;
           }
 
-          // Save camera state
-          const offset = Cesium.Cartesian3.clone(camera.position);
-          const direction = Cesium.Cartesian3.clone(camera.direction);
-          const up = Cesium.Cartesian3.clone(camera.up);
+          const longitude = -112.110693;
+          const latitude = 36.0994841;
+          const radius = 0.03;
 
-          // Set camera to be in model's reference frame.
-          camera.lookAtTransform(transform);
-
-          // Reset the camera state to the saved state so it appears fixed in the model's frame.
-          Cesium.Cartesian3.clone(offset, camera.position);
-          Cesium.Cartesian3.clone(direction, camera.direction);
-          Cesium.Cartesian3.clone(up, camera.up);
-          Cesium.Cartesian3.cross(direction, up, camera.right);
-        });
-
-        // Add a few more balloons flying with the one the viewer is in.
-        const numBalloons = 12;
-        for (let i = 0; i < numBalloons; ++i) {
-          const balloonRadius =
-            (Cesium.Math.nextRandomNumber() * 2.0 - 1.0) * 0.01 + radius;
-          const balloon = viewer.entities.add({
+          const modelURI =
+            "../../SampleData/models/CesiumBalloon/CesiumBalloon.glb";
+          const entity = viewer.entities.add({
             availability: new Cesium.TimeIntervalCollection([
               new Cesium.TimeInterval({
                 start: start,
                 stop: stop,
               }),
             ]),
-            position: computeCirclularFlight(
-              longitude,
-              latitude,
-              balloonRadius
-            ),
+            position: computeCirclularFlight(longitude, latitude, radius),
             model: {
               uri: modelURI,
               minimumPixelSize: 64,
             },
           });
 
-          balloon.position.setInterpolationOptions({
+          entity.position.setInterpolationOptions({
             interpolationDegree: 2,
             interpolationAlgorithm: Cesium.HermitePolynomialApproximation,
           });
-        }
 
-        //Sandcastle_End
+          // Set initial camera position and orientation to be when in the model's reference frame.
+          const camera = viewer.camera;
+          camera.position = new Cesium.Cartesian3(0.25, 0.0, 0.0);
+          camera.direction = new Cesium.Cartesian3(1.0, 0.0, 0.0);
+          camera.up = new Cesium.Cartesian3(0.0, 0.0, 1.0);
+          camera.right = new Cesium.Cartesian3(0.0, -1.0, 0.0);
+
+          viewer.scene.postUpdate.addEventListener(function (scene, time) {
+            const position = entity.position.getValue(time);
+            if (!Cesium.defined(position)) {
+              return;
+            }
+
+            let transform;
+            if (!Cesium.defined(entity.orientation)) {
+              transform = Cesium.Transforms.eastNorthUpToFixedFrame(position);
+            } else {
+              const orientation = entity.orientation.getValue(time);
+              if (!Cesium.defined(orientation)) {
+                return;
+              }
+
+              transform = Cesium.Matrix4.fromRotationTranslation(
+                Cesium.Matrix3.fromQuaternion(orientation),
+                position
+              );
+            }
+
+            // Save camera state
+            const offset = Cesium.Cartesian3.clone(camera.position);
+            const direction = Cesium.Cartesian3.clone(camera.direction);
+            const up = Cesium.Cartesian3.clone(camera.up);
+
+            // Set camera to be in model's reference frame.
+            camera.lookAtTransform(transform);
+
+            // Reset the camera state to the saved state so it appears fixed in the model's frame.
+            Cesium.Cartesian3.clone(offset, camera.position);
+            Cesium.Cartesian3.clone(direction, camera.direction);
+            Cesium.Cartesian3.clone(up, camera.up);
+            Cesium.Cartesian3.cross(direction, up, camera.right);
+          });
+
+          // Add a few more balloons flying with the one the viewer is in.
+          const numBalloons = 12;
+          for (let i = 0; i < numBalloons; ++i) {
+            const balloonRadius =
+              (Cesium.Math.nextRandomNumber() * 2.0 - 1.0) * 0.01 + radius;
+            const balloon = viewer.entities.add({
+              availability: new Cesium.TimeIntervalCollection([
+                new Cesium.TimeInterval({
+                  start: start,
+                  stop: stop,
+                }),
+              ]),
+              position: computeCirclularFlight(
+                longitude,
+                latitude,
+                balloonRadius
+              ),
+              model: {
+                uri: modelURI,
+                minimumPixelSize: 64,
+              },
+            });
+
+            balloon.position.setInterpolationOptions({
+              interpolationDegree: 2,
+              interpolationAlgorithm: Cesium.HermitePolynomialApproximation,
+            });
+          }
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Cardboard.html
+++ b/Apps/Sandcastle/gallery/Cardboard.html
@@ -37,7 +37,7 @@
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
           vrButton: true,
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
         // Click the VR button in the bottom right of the screen to switch to VR mode.
 

--- a/Apps/Sandcastle/gallery/Cartographic Limit Rectangle.html
+++ b/Apps/Sandcastle/gallery/Cartographic Limit Rectangle.html
@@ -36,7 +36,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         const scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/Cartographic Limit Rectangle.html
+++ b/Apps/Sandcastle/gallery/Cartographic Limit Rectangle.html
@@ -35,61 +35,62 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
 
-        const scene = viewer.scene;
-        const globe = scene.globe;
+          const scene = viewer.scene;
+          const globe = scene.globe;
 
-        // Tropics of Cancer and Capricorn
-        const coffeeBeltRectangle = Cesium.Rectangle.fromDegrees(
-          -180.0,
-          -23.43687,
-          180.0,
-          23.43687
-        );
-
-        globe.cartographicLimitRectangle = coffeeBeltRectangle;
-        globe.showSkirts = false;
-        globe.backFaceCulling = false;
-        globe.undergroundColor = undefined;
-        scene.skyAtmosphere.show = false;
-
-        // Add rectangles to show bounds
-        const rectangles = [];
-
-        for (let i = 0; i < 10; i++) {
-          rectangles.push(
-            viewer.entities.add({
-              rectangle: {
-                coordinates: coffeeBeltRectangle,
-                material: Cesium.Color.WHITE.withAlpha(0.0),
-                height: i * 5000.0,
-                outline: true,
-                outlineWidth: 4.0,
-                outlineColor: Cesium.Color.WHITE,
-              },
-            })
+          // Tropics of Cancer and Capricorn
+          const coffeeBeltRectangle = Cesium.Rectangle.fromDegrees(
+            -180.0,
+            -23.43687,
+            180.0,
+            23.43687
           );
-        }
 
-        Sandcastle.addToggleButton("Limit Enabled", true, function (checked) {
-          if (checked) {
-            viewer.scene.globe.cartographicLimitRectangle = coffeeBeltRectangle;
-          } else {
-            viewer.scene.globe.cartographicLimitRectangle = undefined;
-          }
-        });
+          globe.cartographicLimitRectangle = coffeeBeltRectangle;
+          globe.showSkirts = false;
+          globe.backFaceCulling = false;
+          globe.undergroundColor = undefined;
+          scene.skyAtmosphere.show = false;
 
-        Sandcastle.addToggleButton("Show Bounds", true, function (checked) {
-          const rectanglesLength = rectangles.length;
-          for (let i = 0; i < rectanglesLength; i++) {
-            const rectangleEntity = rectangles[i];
-            rectangleEntity.show = checked;
+          // Add rectangles to show bounds
+          const rectangles = [];
+
+          for (let i = 0; i < 10; i++) {
+            rectangles.push(
+              viewer.entities.add({
+                rectangle: {
+                  coordinates: coffeeBeltRectangle,
+                  material: Cesium.Color.WHITE.withAlpha(0.0),
+                  height: i * 5000.0,
+                  outline: true,
+                  outlineWidth: 4.0,
+                  outlineColor: Cesium.Color.WHITE,
+                },
+              })
+            );
           }
-        });
-        //Sandcastle_End
+
+          Sandcastle.addToggleButton("Limit Enabled", true, function (checked) {
+            if (checked) {
+              viewer.scene.globe.cartographicLimitRectangle = coffeeBeltRectangle;
+            } else {
+              viewer.scene.globe.cartographicLimitRectangle = undefined;
+            }
+          });
+
+          Sandcastle.addToggleButton("Show Bounds", true, function (checked) {
+            const rectanglesLength = rectangles.length;
+            for (let i = 0; i < rectanglesLength; i++) {
+              const rectangleEntity = rectangles[i];
+              rectangleEntity.show = checked;
+            }
+          });
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Cesium Inspector.html
+++ b/Apps/Sandcastle/gallery/Cesium Inspector.html
@@ -40,7 +40,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         const scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/Cesium Inspector.html
+++ b/Apps/Sandcastle/gallery/Cesium Inspector.html
@@ -39,75 +39,83 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
 
-        const scene = viewer.scene;
-        scene.globe.depthTestAgainstTerrain = true;
+          const scene = viewer.scene;
+          scene.globe.depthTestAgainstTerrain = true;
 
-        //Add Cesium Inspector
-        viewer.extend(Cesium.viewerCesiumInspectorMixin);
+          //Add Cesium Inspector
+          viewer.extend(Cesium.viewerCesiumInspectorMixin);
 
-        //Add Primitives
-        scene.primitives.add(
-          new Cesium.Primitive({
-            geometryInstances: new Cesium.GeometryInstance({
-              geometry: Cesium.BoxGeometry.fromDimensions({
-                vertexFormat: Cesium.PerInstanceColorAppearance.VERTEX_FORMAT,
-                dimensions: new Cesium.Cartesian3(400000.0, 300000.0, 500000.0),
+          //Add Primitives
+          scene.primitives.add(
+            new Cesium.Primitive({
+              geometryInstances: new Cesium.GeometryInstance({
+                geometry: Cesium.BoxGeometry.fromDimensions({
+                  vertexFormat: Cesium.PerInstanceColorAppearance.VERTEX_FORMAT,
+                  dimensions: new Cesium.Cartesian3(
+                    400000.0,
+                    300000.0,
+                    500000.0
+                  ),
+                }),
+                modelMatrix: Cesium.Matrix4.multiplyByTranslation(
+                  Cesium.Transforms.eastNorthUpToFixedFrame(
+                    Cesium.Cartesian3.fromDegrees(-105.0, 45.0)
+                  ),
+                  new Cesium.Cartesian3(0.0, 0.0, 250000),
+                  new Cesium.Matrix4()
+                ),
+                attributes: {
+                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                    Cesium.Color.RED.withAlpha(0.5)
+                  ),
+                },
               }),
-              modelMatrix: Cesium.Matrix4.multiplyByTranslation(
-                Cesium.Transforms.eastNorthUpToFixedFrame(
-                  Cesium.Cartesian3.fromDegrees(-105.0, 45.0)
-                ),
-                new Cesium.Cartesian3(0.0, 0.0, 250000),
-                new Cesium.Matrix4()
-              ),
-              attributes: {
-                color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                  Cesium.Color.RED.withAlpha(0.5)
-                ),
-              },
-            }),
-            appearance: new Cesium.PerInstanceColorAppearance({
-              closed: true,
-            }),
-          })
-        );
-
-        scene.primitives.add(
-          new Cesium.Primitive({
-            geometryInstances: new Cesium.GeometryInstance({
-              geometry: new Cesium.RectangleGeometry({
-                rectangle: Cesium.Rectangle.fromDegrees(
-                  -100.0,
-                  30.0,
-                  -93.0,
-                  37.0
-                ),
-                height: 100000,
-                vertexFormat: Cesium.PerInstanceColorAppearance.VERTEX_FORMAT,
+              appearance: new Cesium.PerInstanceColorAppearance({
+                closed: true,
               }),
-              attributes: {
-                color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                  Cesium.Color.BLUE
-                ),
-              },
-            }),
-            appearance: new Cesium.PerInstanceColorAppearance(),
-          })
-        );
+            })
+          );
 
-        const billboards = scene.primitives.add(
-          new Cesium.BillboardCollection()
-        );
-        billboards.add({
-          position: Cesium.Cartesian3.fromDegrees(-75.59777, 40.03883, 150000),
-          image: "../images/Cesium_Logo_overlay.png",
-        });
+          scene.primitives.add(
+            new Cesium.Primitive({
+              geometryInstances: new Cesium.GeometryInstance({
+                geometry: new Cesium.RectangleGeometry({
+                  rectangle: Cesium.Rectangle.fromDegrees(
+                    -100.0,
+                    30.0,
+                    -93.0,
+                    37.0
+                  ),
+                  height: 100000,
+                  vertexFormat: Cesium.PerInstanceColorAppearance.VERTEX_FORMAT,
+                }),
+                attributes: {
+                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                    Cesium.Color.BLUE
+                  ),
+                },
+              }),
+              appearance: new Cesium.PerInstanceColorAppearance(),
+            })
+          );
 
-        //Sandcastle_End
+          const billboards = scene.primitives.add(
+            new Cesium.BillboardCollection()
+          );
+          billboards.add({
+            position: Cesium.Cartesian3.fromDegrees(
+              -75.59777,
+              40.03883,
+              150000
+            ),
+            image: "../images/Cesium_Logo_overlay.png",
+          });
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Cesium OSM Buildings.html
+++ b/Apps/Sandcastle/gallery/Cesium OSM Buildings.html
@@ -39,7 +39,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         viewer.scene.primitives.add(Cesium.createOsmBuildings());

--- a/Apps/Sandcastle/gallery/Cesium OSM Buildings.html
+++ b/Apps/Sandcastle/gallery/Cesium OSM Buildings.html
@@ -38,19 +38,21 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
 
-        viewer.scene.primitives.add(Cesium.createOsmBuildings());
+          viewer.scene.primitives.add(Cesium.createOsmBuildings());
 
-        viewer.scene.camera.flyTo({
-          destination: Cesium.Cartesian3.fromDegrees(-74.019, 40.6912, 750),
-          orientation: {
-            heading: Cesium.Math.toRadians(20),
-            pitch: Cesium.Math.toRadians(-20),
-          },
-        }); //Sandcastle_End
+          viewer.scene.camera.flyTo({
+            destination: Cesium.Cartesian3.fromDegrees(-74.019, 40.6912, 750),
+            orientation: {
+              heading: Cesium.Math.toRadians(20),
+              pitch: Cesium.Math.toRadians(-20),
+            },
+          });
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Cesium World Terrain.html
+++ b/Apps/Sandcastle/gallery/Cesium World Terrain.html
@@ -37,7 +37,7 @@
         //Sandcastle_Begin
         // For more information on Cesium World Terrain, see https://cesium.com/platform/cesium-ion/content/cesium-world-terrain/
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
         //Sandcastle_End
         Sandcastle.finishedLoading();

--- a/Apps/Sandcastle/gallery/Cesium World Terrain.html
+++ b/Apps/Sandcastle/gallery/Cesium World Terrain.html
@@ -36,10 +36,15 @@
         "use strict";
         //Sandcastle_Begin
         // For more information on Cesium World Terrain, see https://cesium.com/platform/cesium-ion/content/cesium-world-terrain/
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
-        //Sandcastle_End
+        (async () => {
+          try {
+            const viewer = new Cesium.Viewer("cesiumContainer", {
+              terrainProvider: await Cesium.createWorldTerrainAsync(),
+            });
+          } catch (error) {
+            console.log(error);
+          }
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Clamp to 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/Clamp to 3D Tiles.html
@@ -36,7 +36,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
         const scene = viewer.scene;
         const clock = viewer.clock;

--- a/Apps/Sandcastle/gallery/Clamp to 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/Clamp to 3D Tiles.html
@@ -35,57 +35,58 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
-        const scene = viewer.scene;
-        const clock = viewer.clock;
-
-        let entity;
-        let positionProperty;
-        const dataSourcePromise = Cesium.CzmlDataSource.load(
-          "../../SampleData/ClampToGround.czml"
-        );
-        viewer.dataSources.add(dataSourcePromise).then(function (dataSource) {
-          entity = dataSource.entities.getById("CesiumMilkTruck");
-          positionProperty = entity.position;
-        });
-
-        const tileset = scene.primitives.add(
-          new Cesium.Cesium3DTileset({
-            url: Cesium.IonResource.fromAssetId(40866),
-          })
-        );
-
-        viewer.camera.setView({
-          destination: new Cesium.Cartesian3(
-            1216403.8845586285,
-            -4736357.493351395,
-            4081299.715698949
-          ),
-          orientation: new Cesium.HeadingPitchRoll(
-            4.2892217081808806,
-            -0.4799070147502502,
-            6.279789177843313
-          ),
-          endTransform: Cesium.Matrix4.IDENTITY,
-        });
-
-        if (scene.clampToHeightSupported) {
-          tileset.initialTilesLoaded.addEventListener(start);
-        } else {
-          window.alert("This browser does not support clampToHeight.");
-        }
-
-        function start() {
-          clock.shouldAnimate = true;
-          const objectsToExclude = [entity];
-          scene.postRender.addEventListener(function () {
-            const position = positionProperty.getValue(clock.currentTime);
-            entity.position = scene.clampToHeight(position, objectsToExclude);
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
           });
-        }
-        //Sandcastle_End
+          const scene = viewer.scene;
+          const clock = viewer.clock;
+
+          let entity;
+          let positionProperty;
+          const dataSourcePromise = Cesium.CzmlDataSource.load(
+            "../../SampleData/ClampToGround.czml"
+          );
+          viewer.dataSources.add(dataSourcePromise).then(function (dataSource) {
+            entity = dataSource.entities.getById("CesiumMilkTruck");
+            positionProperty = entity.position;
+          });
+
+          const tileset = scene.primitives.add(
+            new Cesium.Cesium3DTileset({
+              url: Cesium.IonResource.fromAssetId(40866),
+            })
+          );
+
+          viewer.camera.setView({
+            destination: new Cesium.Cartesian3(
+              1216403.8845586285,
+              -4736357.493351395,
+              4081299.715698949
+            ),
+            orientation: new Cesium.HeadingPitchRoll(
+              4.2892217081808806,
+              -0.4799070147502502,
+              6.279789177843313
+            ),
+            endTransform: Cesium.Matrix4.IDENTITY,
+          });
+
+          if (scene.clampToHeightSupported) {
+            tileset.initialTilesLoaded.addEventListener(start);
+          } else {
+            window.alert("This browser does not support clampToHeight.");
+          }
+
+          function start() {
+            clock.shouldAnimate = true;
+            const objectsToExclude = [entity];
+            scene.postRender.addEventListener(function () {
+              const position = positionProperty.getValue(clock.currentTime);
+              entity.position = scene.clampToHeight(position, objectsToExclude);
+            });
+          }
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Clamp to Terrain.html
+++ b/Apps/Sandcastle/gallery/Clamp to Terrain.html
@@ -37,300 +37,261 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        const viewer = new Cesium.Viewer("cesiumContainer");
+        viewer.scene.globe.depthTestAgainstTerrain = true;
+
         (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
-          viewer.scene.globe.depthTestAgainstTerrain = true;
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+          } catch (error) {
+            console.log(error);
+          }
+        })();
 
-          Sandcastle.addDefaultToolbarMenu(
-            [
-              {
-                //
-                // To clamp points or billboards set the heightReference to CLAMP_TO_GROUND or RELATIVE_TO_GROUND
-                //
-                text: "Draw Point with Label",
-                onselect: function () {
-                  const e = viewer.entities.add({
-                    position: Cesium.Cartesian3.fromDegrees(-122.1958, 46.1915),
-                    point: {
-                      color: Cesium.Color.SKYBLUE,
-                      pixelSize: 10,
-                      outlineColor: Cesium.Color.YELLOW,
-                      outlineWidth: 3,
-                      heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-                    },
-                    label: {
-                      text: "Clamped to ground",
-                      font: "14pt sans-serif",
-                      heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-                      horizontalOrigin: Cesium.HorizontalOrigin.LEFT,
-                      verticalOrigin: Cesium.VerticalOrigin.BASELINE,
-                      fillColor: Cesium.Color.BLACK,
-                      showBackground: true,
-                      backgroundColor: new Cesium.Color(1, 1, 1, 0.7),
-                      backgroundPadding: new Cesium.Cartesian2(8, 4),
-                      disableDepthTestDistance: Number.POSITIVE_INFINITY, // draws the label in front of terrain
-                    },
-                  });
+        Sandcastle.addDefaultToolbarMenu(
+          [
+            {
+              //
+              // To clamp points or billboards set the heightReference to CLAMP_TO_GROUND or RELATIVE_TO_GROUND
+              //
+              text: "Draw Point with Label",
+              onselect: function () {
+                const e = viewer.entities.add({
+                  position: Cesium.Cartesian3.fromDegrees(-122.1958, 46.1915),
+                  point: {
+                    color: Cesium.Color.SKYBLUE,
+                    pixelSize: 10,
+                    outlineColor: Cesium.Color.YELLOW,
+                    outlineWidth: 3,
+                    heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+                  },
+                  label: {
+                    text: "Clamped to ground",
+                    font: "14pt sans-serif",
+                    heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+                    horizontalOrigin: Cesium.HorizontalOrigin.LEFT,
+                    verticalOrigin: Cesium.VerticalOrigin.BASELINE,
+                    fillColor: Cesium.Color.BLACK,
+                    showBackground: true,
+                    backgroundColor: new Cesium.Color(1, 1, 1, 0.7),
+                    backgroundPadding: new Cesium.Cartesian2(8, 4),
+                    disableDepthTestDistance: Number.POSITIVE_INFINITY, // draws the label in front of terrain
+                  },
+                });
 
-                  viewer.trackedEntity = e;
-                },
+                viewer.trackedEntity = e;
               },
-              {
-                text: "Draw Billboard",
-                onselect: function () {
-                  const e = viewer.entities.add({
-                    position: Cesium.Cartesian3.fromDegrees(-122.1958, 46.1915),
-                    billboard: {
-                      image: "../images/facility.gif",
-                      heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-                    },
-                  });
+            },
+            {
+              text: "Draw Billboard",
+              onselect: function () {
+                const e = viewer.entities.add({
+                  position: Cesium.Cartesian3.fromDegrees(-122.1958, 46.1915),
+                  billboard: {
+                    image: "../images/facility.gif",
+                    heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+                  },
+                });
 
-                  viewer.trackedEntity = e;
-                },
+                viewer.trackedEntity = e;
               },
-              {
-                //
-                // Corridors, polygons and rectangles will be clamped automatically if they are filled with a constant color and
-                // has no height or extruded height.
-                // NOTE: Setting height to 0 will disable clamping.
-                //
-                text: "Draw Corridor",
-                onselect: function () {
-                  const e = viewer.entities.add({
-                    corridor: {
-                      positions: Cesium.Cartesian3.fromDegreesArray([
-                        -122.19,
-                        46.1914,
-                        -122.21,
-                        46.21,
-                        -122.23,
-                        46.21,
-                      ]),
-                      width: 2000.0,
-                      material: Cesium.Color.GREEN.withAlpha(0.5),
-                    },
-                  });
+            },
+            {
+              //
+              // Corridors, polygons and rectangles will be clamped automatically if they are filled with a constant color and
+              // has no height or extruded height.
+              // NOTE: Setting height to 0 will disable clamping.
+              //
+              text: "Draw Corridor",
+              onselect: function () {
+                const e = viewer.entities.add({
+                  corridor: {
+                    positions: Cesium.Cartesian3.fromDegreesArray([
+                      -122.19,
+                      46.1914,
+                      -122.21,
+                      46.21,
+                      -122.23,
+                      46.21,
+                    ]),
+                    width: 2000.0,
+                    material: Cesium.Color.GREEN.withAlpha(0.5),
+                  },
+                });
 
-                  viewer.zoomTo(e);
-                },
+                viewer.zoomTo(e);
               },
-              {
-                text: "Draw Polygon",
-                onselect: function () {
-                  const e = viewer.entities.add({
-                    polygon: {
-                      hierarchy: {
-                        positions: [
-                          new Cesium.Cartesian3(
-                            -2358138.847340281,
-                            -3744072.459541374,
-                            4581158.5714175375
-                          ),
-                          new Cesium.Cartesian3(
-                            -2357231.4925370603,
-                            -3745103.7886602185,
-                            4580702.9757762635
-                          ),
-                          new Cesium.Cartesian3(
-                            -2355912.902205431,
-                            -3744249.029778454,
-                            4582402.154378103
-                          ),
-                          new Cesium.Cartesian3(
-                            -2357208.0209552636,
-                            -3743553.4420488174,
-                            4581961.863286629
-                          ),
-                        ],
-                      },
-                      material: Cesium.Color.BLUE.withAlpha(0.5),
-                    },
-                  });
-
-                  viewer.zoomTo(e);
-                },
-              },
-              {
-                text: "Draw Textured Polygon",
-                onselect: function () {
-                  if (
-                    !Cesium.Entity.supportsMaterialsforEntitiesOnTerrain(
-                      viewer.scene
-                    )
-                  ) {
-                    window.alert(
-                      "Terrain Entity materials are not supported on this platform"
-                    );
-                    return;
-                  }
-
-                  const e = viewer.entities.add({
-                    polygon: {
-                      hierarchy: {
-                        positions: [
-                          new Cesium.Cartesian3(
-                            -2358138.847340281,
-                            -3744072.459541374,
-                            4581158.5714175375
-                          ),
-                          new Cesium.Cartesian3(
-                            -2357231.4925370603,
-                            -3745103.7886602185,
-                            4580702.9757762635
-                          ),
-                          new Cesium.Cartesian3(
-                            -2355912.902205431,
-                            -3744249.029778454,
-                            4582402.154378103
-                          ),
-                          new Cesium.Cartesian3(
-                            -2357208.0209552636,
-                            -3743553.4420488174,
-                            4581961.863286629
-                          ),
-                        ],
-                      },
-                      material: "../images/Cesium_Logo_Color.jpg",
-                      classificationType: Cesium.ClassificationType.TERRAIN,
-                      stRotation: Cesium.Math.toRadians(45),
-                    },
-                  });
-
-                  viewer.zoomTo(e);
-                },
-              },
-              {
-                text: "Draw Rectangle",
-                onselect: function () {
-                  const e = viewer.entities.add({
-                    rectangle: {
-                      coordinates: Cesium.Rectangle.fromDegrees(
-                        -122.3,
-                        46.0,
-                        -122.0,
-                        46.3
-                      ),
-                      material: Cesium.Color.RED.withAlpha(0.5),
-                    },
-                  });
-
-                  viewer.zoomTo(e);
-                },
-              },
-              {
-                text: "Draw Model",
-                onselect: function () {
-                  const e = viewer.entities.add({
-                    position: Cesium.Cartesian3.fromDegrees(-122.1958, 46.1915),
-                    model: {
-                      uri: "../../SampleData/models/CesiumMan/Cesium_Man.glb",
-                      heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-                      minimumPixelSize: 128,
-                      maximumScale: 100,
-                    },
-                  });
-
-                  viewer.trackedEntity = e;
-                },
-              },
-              {
-                text: "Sample line positions and draw with depth test disabled",
-                onselect: function () {
-                  const length = 1000;
-
-                  const startLon = Cesium.Math.toRadians(86.953793);
-                  const endLon = Cesium.Math.toRadians(86.896497);
-
-                  const lat = Cesium.Math.toRadians(27.988257);
-
-                  const terrainSamplePositions = [];
-                  for (let i = 0; i < length; ++i) {
-                    const lon = Cesium.Math.lerp(
-                      endLon,
-                      startLon,
-                      i / (length - 1)
-                    );
-                    const position = new Cesium.Cartographic(lon, lat);
-                    terrainSamplePositions.push(position);
-                  }
-
-                  Promise.resolve(
-                    Cesium.sampleTerrainMostDetailed(
-                      viewer.terrainProvider,
-                      terrainSamplePositions
-                    )
-                  ).then(function (samples) {
-                    let offset = 10.0;
-                    for (let i = 0; i < samples.length; ++i) {
-                      samples[i].height += offset;
-                    }
-
-                    viewer.entities.add({
-                      polyline: {
-                        positions: Cesium.Ellipsoid.WGS84.cartographicArrayToCartesianArray(
-                          samples
+            },
+            {
+              text: "Draw Polygon",
+              onselect: function () {
+                const e = viewer.entities.add({
+                  polygon: {
+                    hierarchy: {
+                      positions: [
+                        new Cesium.Cartesian3(
+                          -2358138.847340281,
+                          -3744072.459541374,
+                          4581158.5714175375
                         ),
-                        arcType: Cesium.ArcType.NONE,
-                        width: 5,
-                        material: new Cesium.PolylineOutlineMaterialProperty({
-                          color: Cesium.Color.ORANGE,
-                          outlineWidth: 2,
-                          outlineColor: Cesium.Color.BLACK,
-                        }),
-                        depthFailMaterial: new Cesium.PolylineOutlineMaterialProperty(
-                          {
-                            color: Cesium.Color.RED,
-                            outlineWidth: 2,
-                            outlineColor: Cesium.Color.BLACK,
-                          }
+                        new Cesium.Cartesian3(
+                          -2357231.4925370603,
+                          -3745103.7886602185,
+                          4580702.9757762635
                         ),
-                      },
-                    });
+                        new Cesium.Cartesian3(
+                          -2355912.902205431,
+                          -3744249.029778454,
+                          4582402.154378103
+                        ),
+                        new Cesium.Cartesian3(
+                          -2357208.0209552636,
+                          -3743553.4420488174,
+                          4581961.863286629
+                        ),
+                      ],
+                    },
+                    material: Cesium.Color.BLUE.withAlpha(0.5),
+                  },
+                });
 
-                    const target = new Cesium.Cartesian3(
-                      300770.50872389384,
-                      5634912.131394585,
-                      2978152.2865545116
-                    );
-                    offset = new Cesium.Cartesian3(
-                      6344.974098678562,
-                      -793.3419798081741,
-                      2499.9508860763162
-                    );
-                    viewer.camera.lookAt(target, offset);
-                    viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-                  });
-                },
+                viewer.zoomTo(e);
               },
-              {
-                text: "Draw polyline on terrain",
-                onselect: function () {
-                  if (!Cesium.Entity.supportsPolylinesOnTerrain(viewer.scene)) {
-                    window.alert(
-                      "Polylines on terrain are not supported on this platform"
-                    );
+            },
+            {
+              text: "Draw Textured Polygon",
+              onselect: function () {
+                if (
+                  !Cesium.Entity.supportsMaterialsforEntitiesOnTerrain(
+                    viewer.scene
+                  )
+                ) {
+                  window.alert(
+                    "Terrain Entity materials are not supported on this platform"
+                  );
+                  return;
+                }
+
+                const e = viewer.entities.add({
+                  polygon: {
+                    hierarchy: {
+                      positions: [
+                        new Cesium.Cartesian3(
+                          -2358138.847340281,
+                          -3744072.459541374,
+                          4581158.5714175375
+                        ),
+                        new Cesium.Cartesian3(
+                          -2357231.4925370603,
+                          -3745103.7886602185,
+                          4580702.9757762635
+                        ),
+                        new Cesium.Cartesian3(
+                          -2355912.902205431,
+                          -3744249.029778454,
+                          4582402.154378103
+                        ),
+                        new Cesium.Cartesian3(
+                          -2357208.0209552636,
+                          -3743553.4420488174,
+                          4581961.863286629
+                        ),
+                      ],
+                    },
+                    material: "../images/Cesium_Logo_Color.jpg",
+                    classificationType: Cesium.ClassificationType.TERRAIN,
+                    stRotation: Cesium.Math.toRadians(45),
+                  },
+                });
+
+                viewer.zoomTo(e);
+              },
+            },
+            {
+              text: "Draw Rectangle",
+              onselect: function () {
+                const e = viewer.entities.add({
+                  rectangle: {
+                    coordinates: Cesium.Rectangle.fromDegrees(
+                      -122.3,
+                      46.0,
+                      -122.0,
+                      46.3
+                    ),
+                    material: Cesium.Color.RED.withAlpha(0.5),
+                  },
+                });
+
+                viewer.zoomTo(e);
+              },
+            },
+            {
+              text: "Draw Model",
+              onselect: function () {
+                const e = viewer.entities.add({
+                  position: Cesium.Cartesian3.fromDegrees(-122.1958, 46.1915),
+                  model: {
+                    uri: "../../SampleData/models/CesiumMan/Cesium_Man.glb",
+                    heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+                    minimumPixelSize: 128,
+                    maximumScale: 100,
+                  },
+                });
+
+                viewer.trackedEntity = e;
+              },
+            },
+            {
+              text: "Sample line positions and draw with depth test disabled",
+              onselect: function () {
+                const length = 1000;
+
+                const startLon = Cesium.Math.toRadians(86.953793);
+                const endLon = Cesium.Math.toRadians(86.896497);
+
+                const lat = Cesium.Math.toRadians(27.988257);
+
+                const terrainSamplePositions = [];
+                for (let i = 0; i < length; ++i) {
+                  const lon = Cesium.Math.lerp(
+                    endLon,
+                    startLon,
+                    i / (length - 1)
+                  );
+                  const position = new Cesium.Cartographic(lon, lat);
+                  terrainSamplePositions.push(position);
+                }
+
+                Promise.resolve(
+                  Cesium.sampleTerrainMostDetailed(
+                    viewer.terrainProvider,
+                    terrainSamplePositions
+                  )
+                ).then(function (samples) {
+                  let offset = 10.0;
+                  for (let i = 0; i < samples.length; ++i) {
+                    samples[i].height += offset;
                   }
 
                   viewer.entities.add({
                     polyline: {
-                      positions: Cesium.Cartesian3.fromDegreesArray([
-                        86.953793,
-                        27.928257,
-                        86.953793,
-                        27.988257,
-                        86.896497,
-                        27.988257,
-                      ]),
-                      clampToGround: true,
+                      positions: Cesium.Ellipsoid.WGS84.cartographicArrayToCartesianArray(
+                        samples
+                      ),
+                      arcType: Cesium.ArcType.NONE,
                       width: 5,
                       material: new Cesium.PolylineOutlineMaterialProperty({
                         color: Cesium.Color.ORANGE,
                         outlineWidth: 2,
                         outlineColor: Cesium.Color.BLACK,
                       }),
+                      depthFailMaterial: new Cesium.PolylineOutlineMaterialProperty(
+                        {
+                          color: Cesium.Color.RED,
+                          outlineWidth: 2,
+                          outlineColor: Cesium.Color.BLACK,
+                        }
+                      ),
                     },
                   });
 
@@ -339,23 +300,67 @@
                     5634912.131394585,
                     2978152.2865545116
                   );
-                  const offset = new Cesium.Cartesian3(
+                  offset = new Cesium.Cartesian3(
                     6344.974098678562,
                     -793.3419798081741,
                     2499.9508860763162
                   );
                   viewer.camera.lookAt(target, offset);
                   viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-                },
+                });
               },
-            ],
-            "zoomButtons"
-          );
+            },
+            {
+              text: "Draw polyline on terrain",
+              onselect: function () {
+                if (!Cesium.Entity.supportsPolylinesOnTerrain(viewer.scene)) {
+                  window.alert(
+                    "Polylines on terrain are not supported on this platform"
+                  );
+                }
 
-          Sandcastle.reset = function () {
-            viewer.entities.removeAll();
-          };
-        })(); //Sandcastle_End
+                viewer.entities.add({
+                  polyline: {
+                    positions: Cesium.Cartesian3.fromDegreesArray([
+                      86.953793,
+                      27.928257,
+                      86.953793,
+                      27.988257,
+                      86.896497,
+                      27.988257,
+                    ]),
+                    clampToGround: true,
+                    width: 5,
+                    material: new Cesium.PolylineOutlineMaterialProperty({
+                      color: Cesium.Color.ORANGE,
+                      outlineWidth: 2,
+                      outlineColor: Cesium.Color.BLACK,
+                    }),
+                  },
+                });
+
+                const target = new Cesium.Cartesian3(
+                  300770.50872389384,
+                  5634912.131394585,
+                  2978152.2865545116
+                );
+                const offset = new Cesium.Cartesian3(
+                  6344.974098678562,
+                  -793.3419798081741,
+                  2499.9508860763162
+                );
+                viewer.camera.lookAt(target, offset);
+                viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+              },
+            },
+          ],
+          "zoomButtons"
+        );
+
+        Sandcastle.reset = function () {
+          viewer.entities.removeAll();
+        };
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Clamp to Terrain.html
+++ b/Apps/Sandcastle/gallery/Clamp to Terrain.html
@@ -38,7 +38,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
         viewer.scene.globe.depthTestAgainstTerrain = true;
 

--- a/Apps/Sandcastle/gallery/Clamp to Terrain.html
+++ b/Apps/Sandcastle/gallery/Clamp to Terrain.html
@@ -37,255 +37,300 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
-        viewer.scene.globe.depthTestAgainstTerrain = true;
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
+          viewer.scene.globe.depthTestAgainstTerrain = true;
 
-        Sandcastle.addDefaultToolbarMenu(
-          [
-            {
-              //
-              // To clamp points or billboards set the heightReference to CLAMP_TO_GROUND or RELATIVE_TO_GROUND
-              //
-              text: "Draw Point with Label",
-              onselect: function () {
-                const e = viewer.entities.add({
-                  position: Cesium.Cartesian3.fromDegrees(-122.1958, 46.1915),
-                  point: {
-                    color: Cesium.Color.SKYBLUE,
-                    pixelSize: 10,
-                    outlineColor: Cesium.Color.YELLOW,
-                    outlineWidth: 3,
-                    heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-                  },
-                  label: {
-                    text: "Clamped to ground",
-                    font: "14pt sans-serif",
-                    heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-                    horizontalOrigin: Cesium.HorizontalOrigin.LEFT,
-                    verticalOrigin: Cesium.VerticalOrigin.BASELINE,
-                    fillColor: Cesium.Color.BLACK,
-                    showBackground: true,
-                    backgroundColor: new Cesium.Color(1, 1, 1, 0.7),
-                    backgroundPadding: new Cesium.Cartesian2(8, 4),
-                    disableDepthTestDistance: Number.POSITIVE_INFINITY, // draws the label in front of terrain
-                  },
-                });
-
-                viewer.trackedEntity = e;
-              },
-            },
-            {
-              text: "Draw Billboard",
-              onselect: function () {
-                const e = viewer.entities.add({
-                  position: Cesium.Cartesian3.fromDegrees(-122.1958, 46.1915),
-                  billboard: {
-                    image: "../images/facility.gif",
-                    heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-                  },
-                });
-
-                viewer.trackedEntity = e;
-              },
-            },
-            {
-              //
-              // Corridors, polygons and rectangles will be clamped automatically if they are filled with a constant color and
-              // has no height or extruded height.
-              // NOTE: Setting height to 0 will disable clamping.
-              //
-              text: "Draw Corridor",
-              onselect: function () {
-                const e = viewer.entities.add({
-                  corridor: {
-                    positions: Cesium.Cartesian3.fromDegreesArray([
-                      -122.19,
-                      46.1914,
-                      -122.21,
-                      46.21,
-                      -122.23,
-                      46.21,
-                    ]),
-                    width: 2000.0,
-                    material: Cesium.Color.GREEN.withAlpha(0.5),
-                  },
-                });
-
-                viewer.zoomTo(e);
-              },
-            },
-            {
-              text: "Draw Polygon",
-              onselect: function () {
-                const e = viewer.entities.add({
-                  polygon: {
-                    hierarchy: {
-                      positions: [
-                        new Cesium.Cartesian3(
-                          -2358138.847340281,
-                          -3744072.459541374,
-                          4581158.5714175375
-                        ),
-                        new Cesium.Cartesian3(
-                          -2357231.4925370603,
-                          -3745103.7886602185,
-                          4580702.9757762635
-                        ),
-                        new Cesium.Cartesian3(
-                          -2355912.902205431,
-                          -3744249.029778454,
-                          4582402.154378103
-                        ),
-                        new Cesium.Cartesian3(
-                          -2357208.0209552636,
-                          -3743553.4420488174,
-                          4581961.863286629
-                        ),
-                      ],
+          Sandcastle.addDefaultToolbarMenu(
+            [
+              {
+                //
+                // To clamp points or billboards set the heightReference to CLAMP_TO_GROUND or RELATIVE_TO_GROUND
+                //
+                text: "Draw Point with Label",
+                onselect: function () {
+                  const e = viewer.entities.add({
+                    position: Cesium.Cartesian3.fromDegrees(-122.1958, 46.1915),
+                    point: {
+                      color: Cesium.Color.SKYBLUE,
+                      pixelSize: 10,
+                      outlineColor: Cesium.Color.YELLOW,
+                      outlineWidth: 3,
+                      heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
                     },
-                    material: Cesium.Color.BLUE.withAlpha(0.5),
-                  },
-                });
-
-                viewer.zoomTo(e);
-              },
-            },
-            {
-              text: "Draw Textured Polygon",
-              onselect: function () {
-                if (
-                  !Cesium.Entity.supportsMaterialsforEntitiesOnTerrain(
-                    viewer.scene
-                  )
-                ) {
-                  window.alert(
-                    "Terrain Entity materials are not supported on this platform"
-                  );
-                  return;
-                }
-
-                const e = viewer.entities.add({
-                  polygon: {
-                    hierarchy: {
-                      positions: [
-                        new Cesium.Cartesian3(
-                          -2358138.847340281,
-                          -3744072.459541374,
-                          4581158.5714175375
-                        ),
-                        new Cesium.Cartesian3(
-                          -2357231.4925370603,
-                          -3745103.7886602185,
-                          4580702.9757762635
-                        ),
-                        new Cesium.Cartesian3(
-                          -2355912.902205431,
-                          -3744249.029778454,
-                          4582402.154378103
-                        ),
-                        new Cesium.Cartesian3(
-                          -2357208.0209552636,
-                          -3743553.4420488174,
-                          4581961.863286629
-                        ),
-                      ],
+                    label: {
+                      text: "Clamped to ground",
+                      font: "14pt sans-serif",
+                      heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+                      horizontalOrigin: Cesium.HorizontalOrigin.LEFT,
+                      verticalOrigin: Cesium.VerticalOrigin.BASELINE,
+                      fillColor: Cesium.Color.BLACK,
+                      showBackground: true,
+                      backgroundColor: new Cesium.Color(1, 1, 1, 0.7),
+                      backgroundPadding: new Cesium.Cartesian2(8, 4),
+                      disableDepthTestDistance: Number.POSITIVE_INFINITY, // draws the label in front of terrain
                     },
-                    material: "../images/Cesium_Logo_Color.jpg",
-                    classificationType: Cesium.ClassificationType.TERRAIN,
-                    stRotation: Cesium.Math.toRadians(45),
-                  },
-                });
+                  });
 
-                viewer.zoomTo(e);
+                  viewer.trackedEntity = e;
+                },
               },
-            },
-            {
-              text: "Draw Rectangle",
-              onselect: function () {
-                const e = viewer.entities.add({
-                  rectangle: {
-                    coordinates: Cesium.Rectangle.fromDegrees(
-                      -122.3,
-                      46.0,
-                      -122.0,
-                      46.3
-                    ),
-                    material: Cesium.Color.RED.withAlpha(0.5),
-                  },
-                });
+              {
+                text: "Draw Billboard",
+                onselect: function () {
+                  const e = viewer.entities.add({
+                    position: Cesium.Cartesian3.fromDegrees(-122.1958, 46.1915),
+                    billboard: {
+                      image: "../images/facility.gif",
+                      heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+                    },
+                  });
 
-                viewer.zoomTo(e);
+                  viewer.trackedEntity = e;
+                },
               },
-            },
-            {
-              text: "Draw Model",
-              onselect: function () {
-                const e = viewer.entities.add({
-                  position: Cesium.Cartesian3.fromDegrees(-122.1958, 46.1915),
-                  model: {
-                    uri: "../../SampleData/models/CesiumMan/Cesium_Man.glb",
-                    heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-                    minimumPixelSize: 128,
-                    maximumScale: 100,
-                  },
-                });
+              {
+                //
+                // Corridors, polygons and rectangles will be clamped automatically if they are filled with a constant color and
+                // has no height or extruded height.
+                // NOTE: Setting height to 0 will disable clamping.
+                //
+                text: "Draw Corridor",
+                onselect: function () {
+                  const e = viewer.entities.add({
+                    corridor: {
+                      positions: Cesium.Cartesian3.fromDegreesArray([
+                        -122.19,
+                        46.1914,
+                        -122.21,
+                        46.21,
+                        -122.23,
+                        46.21,
+                      ]),
+                      width: 2000.0,
+                      material: Cesium.Color.GREEN.withAlpha(0.5),
+                    },
+                  });
 
-                viewer.trackedEntity = e;
+                  viewer.zoomTo(e);
+                },
               },
-            },
-            {
-              text: "Sample line positions and draw with depth test disabled",
-              onselect: function () {
-                const length = 1000;
+              {
+                text: "Draw Polygon",
+                onselect: function () {
+                  const e = viewer.entities.add({
+                    polygon: {
+                      hierarchy: {
+                        positions: [
+                          new Cesium.Cartesian3(
+                            -2358138.847340281,
+                            -3744072.459541374,
+                            4581158.5714175375
+                          ),
+                          new Cesium.Cartesian3(
+                            -2357231.4925370603,
+                            -3745103.7886602185,
+                            4580702.9757762635
+                          ),
+                          new Cesium.Cartesian3(
+                            -2355912.902205431,
+                            -3744249.029778454,
+                            4582402.154378103
+                          ),
+                          new Cesium.Cartesian3(
+                            -2357208.0209552636,
+                            -3743553.4420488174,
+                            4581961.863286629
+                          ),
+                        ],
+                      },
+                      material: Cesium.Color.BLUE.withAlpha(0.5),
+                    },
+                  });
 
-                const startLon = Cesium.Math.toRadians(86.953793);
-                const endLon = Cesium.Math.toRadians(86.896497);
+                  viewer.zoomTo(e);
+                },
+              },
+              {
+                text: "Draw Textured Polygon",
+                onselect: function () {
+                  if (
+                    !Cesium.Entity.supportsMaterialsforEntitiesOnTerrain(
+                      viewer.scene
+                    )
+                  ) {
+                    window.alert(
+                      "Terrain Entity materials are not supported on this platform"
+                    );
+                    return;
+                  }
 
-                const lat = Cesium.Math.toRadians(27.988257);
+                  const e = viewer.entities.add({
+                    polygon: {
+                      hierarchy: {
+                        positions: [
+                          new Cesium.Cartesian3(
+                            -2358138.847340281,
+                            -3744072.459541374,
+                            4581158.5714175375
+                          ),
+                          new Cesium.Cartesian3(
+                            -2357231.4925370603,
+                            -3745103.7886602185,
+                            4580702.9757762635
+                          ),
+                          new Cesium.Cartesian3(
+                            -2355912.902205431,
+                            -3744249.029778454,
+                            4582402.154378103
+                          ),
+                          new Cesium.Cartesian3(
+                            -2357208.0209552636,
+                            -3743553.4420488174,
+                            4581961.863286629
+                          ),
+                        ],
+                      },
+                      material: "../images/Cesium_Logo_Color.jpg",
+                      classificationType: Cesium.ClassificationType.TERRAIN,
+                      stRotation: Cesium.Math.toRadians(45),
+                    },
+                  });
 
-                const terrainSamplePositions = [];
-                for (let i = 0; i < length; ++i) {
-                  const lon = Cesium.Math.lerp(
-                    endLon,
-                    startLon,
-                    i / (length - 1)
-                  );
-                  const position = new Cesium.Cartographic(lon, lat);
-                  terrainSamplePositions.push(position);
-                }
+                  viewer.zoomTo(e);
+                },
+              },
+              {
+                text: "Draw Rectangle",
+                onselect: function () {
+                  const e = viewer.entities.add({
+                    rectangle: {
+                      coordinates: Cesium.Rectangle.fromDegrees(
+                        -122.3,
+                        46.0,
+                        -122.0,
+                        46.3
+                      ),
+                      material: Cesium.Color.RED.withAlpha(0.5),
+                    },
+                  });
 
-                Promise.resolve(
-                  Cesium.sampleTerrainMostDetailed(
-                    viewer.terrainProvider,
-                    terrainSamplePositions
-                  )
-                ).then(function (samples) {
-                  let offset = 10.0;
-                  for (let i = 0; i < samples.length; ++i) {
-                    samples[i].height += offset;
+                  viewer.zoomTo(e);
+                },
+              },
+              {
+                text: "Draw Model",
+                onselect: function () {
+                  const e = viewer.entities.add({
+                    position: Cesium.Cartesian3.fromDegrees(-122.1958, 46.1915),
+                    model: {
+                      uri: "../../SampleData/models/CesiumMan/Cesium_Man.glb",
+                      heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+                      minimumPixelSize: 128,
+                      maximumScale: 100,
+                    },
+                  });
+
+                  viewer.trackedEntity = e;
+                },
+              },
+              {
+                text: "Sample line positions and draw with depth test disabled",
+                onselect: function () {
+                  const length = 1000;
+
+                  const startLon = Cesium.Math.toRadians(86.953793);
+                  const endLon = Cesium.Math.toRadians(86.896497);
+
+                  const lat = Cesium.Math.toRadians(27.988257);
+
+                  const terrainSamplePositions = [];
+                  for (let i = 0; i < length; ++i) {
+                    const lon = Cesium.Math.lerp(
+                      endLon,
+                      startLon,
+                      i / (length - 1)
+                    );
+                    const position = new Cesium.Cartographic(lon, lat);
+                    terrainSamplePositions.push(position);
+                  }
+
+                  Promise.resolve(
+                    Cesium.sampleTerrainMostDetailed(
+                      viewer.terrainProvider,
+                      terrainSamplePositions
+                    )
+                  ).then(function (samples) {
+                    let offset = 10.0;
+                    for (let i = 0; i < samples.length; ++i) {
+                      samples[i].height += offset;
+                    }
+
+                    viewer.entities.add({
+                      polyline: {
+                        positions: Cesium.Ellipsoid.WGS84.cartographicArrayToCartesianArray(
+                          samples
+                        ),
+                        arcType: Cesium.ArcType.NONE,
+                        width: 5,
+                        material: new Cesium.PolylineOutlineMaterialProperty({
+                          color: Cesium.Color.ORANGE,
+                          outlineWidth: 2,
+                          outlineColor: Cesium.Color.BLACK,
+                        }),
+                        depthFailMaterial: new Cesium.PolylineOutlineMaterialProperty(
+                          {
+                            color: Cesium.Color.RED,
+                            outlineWidth: 2,
+                            outlineColor: Cesium.Color.BLACK,
+                          }
+                        ),
+                      },
+                    });
+
+                    const target = new Cesium.Cartesian3(
+                      300770.50872389384,
+                      5634912.131394585,
+                      2978152.2865545116
+                    );
+                    offset = new Cesium.Cartesian3(
+                      6344.974098678562,
+                      -793.3419798081741,
+                      2499.9508860763162
+                    );
+                    viewer.camera.lookAt(target, offset);
+                    viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+                  });
+                },
+              },
+              {
+                text: "Draw polyline on terrain",
+                onselect: function () {
+                  if (!Cesium.Entity.supportsPolylinesOnTerrain(viewer.scene)) {
+                    window.alert(
+                      "Polylines on terrain are not supported on this platform"
+                    );
                   }
 
                   viewer.entities.add({
                     polyline: {
-                      positions: Cesium.Ellipsoid.WGS84.cartographicArrayToCartesianArray(
-                        samples
-                      ),
-                      arcType: Cesium.ArcType.NONE,
+                      positions: Cesium.Cartesian3.fromDegreesArray([
+                        86.953793,
+                        27.928257,
+                        86.953793,
+                        27.988257,
+                        86.896497,
+                        27.988257,
+                      ]),
+                      clampToGround: true,
                       width: 5,
                       material: new Cesium.PolylineOutlineMaterialProperty({
                         color: Cesium.Color.ORANGE,
                         outlineWidth: 2,
                         outlineColor: Cesium.Color.BLACK,
                       }),
-                      depthFailMaterial: new Cesium.PolylineOutlineMaterialProperty(
-                        {
-                          color: Cesium.Color.RED,
-                          outlineWidth: 2,
-                          outlineColor: Cesium.Color.BLACK,
-                        }
-                      ),
                     },
                   });
 
@@ -294,68 +339,23 @@
                     5634912.131394585,
                     2978152.2865545116
                   );
-                  offset = new Cesium.Cartesian3(
+                  const offset = new Cesium.Cartesian3(
                     6344.974098678562,
                     -793.3419798081741,
                     2499.9508860763162
                   );
                   viewer.camera.lookAt(target, offset);
                   viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-                });
+                },
               },
-            },
-            {
-              text: "Draw polyline on terrain",
-              onselect: function () {
-                if (!Cesium.Entity.supportsPolylinesOnTerrain(viewer.scene)) {
-                  window.alert(
-                    "Polylines on terrain are not supported on this platform"
-                  );
-                }
+            ],
+            "zoomButtons"
+          );
 
-                viewer.entities.add({
-                  polyline: {
-                    positions: Cesium.Cartesian3.fromDegreesArray([
-                      86.953793,
-                      27.928257,
-                      86.953793,
-                      27.988257,
-                      86.896497,
-                      27.988257,
-                    ]),
-                    clampToGround: true,
-                    width: 5,
-                    material: new Cesium.PolylineOutlineMaterialProperty({
-                      color: Cesium.Color.ORANGE,
-                      outlineWidth: 2,
-                      outlineColor: Cesium.Color.BLACK,
-                    }),
-                  },
-                });
-
-                const target = new Cesium.Cartesian3(
-                  300770.50872389384,
-                  5634912.131394585,
-                  2978152.2865545116
-                );
-                const offset = new Cesium.Cartesian3(
-                  6344.974098678562,
-                  -793.3419798081741,
-                  2499.9508860763162
-                );
-                viewer.camera.lookAt(target, offset);
-                viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-              },
-            },
-          ],
-          "zoomButtons"
-        );
-
-        Sandcastle.reset = function () {
-          viewer.entities.removeAll();
-        };
-
-        //Sandcastle_End
+          Sandcastle.reset = function () {
+            viewer.entities.removeAll();
+          };
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Classification Types.html
+++ b/Apps/Sandcastle/gallery/Classification Types.html
@@ -36,7 +36,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         const tileset = new Cesium.Cesium3DTileset({

--- a/Apps/Sandcastle/gallery/Classification Types.html
+++ b/Apps/Sandcastle/gallery/Classification Types.html
@@ -35,140 +35,141 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
 
-        const tileset = new Cesium.Cesium3DTileset({
-          url: Cesium.IonResource.fromAssetId(40866),
-        });
-        viewer.scene.primitives.add(tileset);
+          const tileset = new Cesium.Cesium3DTileset({
+            url: Cesium.IonResource.fromAssetId(40866),
+          });
+          viewer.scene.primitives.add(tileset);
 
-        tileset.readyPromise.then(function () {
-          const boundingSphere = tileset.boundingSphere;
-          viewer.camera.viewBoundingSphere(
-            boundingSphere,
-            new Cesium.HeadingPitchRange(
-              0.0,
-              -0.5,
-              boundingSphere.radius + 500.0
-            )
-          );
-          viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-        });
+          tileset.readyPromise.then(function () {
+            const boundingSphere = tileset.boundingSphere;
+            viewer.camera.viewBoundingSphere(
+              boundingSphere,
+              new Cesium.HeadingPitchRange(
+                0.0,
+                -0.5,
+                boundingSphere.radius + 500.0
+              )
+            );
+            viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+          });
 
-        const polygon = viewer.entities.add({
-          polygon: {
-            hierarchy: new Cesium.PolygonHierarchy(
-              Cesium.Cartesian3.fromRadiansArray([
-                -1.3194369277314022,
-                0.6988062530900625,
-                -1.3193955980204217,
-                0.6988091578771254,
-                -1.3193931220959367,
-                0.698743632490865,
-                -1.3194358224045408,
-                0.6987471965556998,
-              ])
-            ),
-            material: Cesium.Color.RED.withAlpha(0.5),
-            classificationType: Cesium.ClassificationType.BOTH,
-          },
-        });
-
-        const polyline = viewer.entities.add({
-          polyline: {
-            positions: Cesium.Cartesian3.fromDegreesArray([
-              -75.60217330403601,
-              40.04102882709425,
-              -75.59968252414251,
-              40.04093615560871,
-              -75.598020153828,
-              40.04079437042357,
-              -75.59674934074435,
-              40.040816173283304,
-              -75.59630042791713,
-              40.03986900370842,
-              -75.59563636849978,
-              40.03930996506271,
-              -75.59492397899098,
-              40.03873932846581,
-              -75.59457991226778,
-              40.038392701955786,
-              -75.59424838652453,
-              40.03775403572295,
-              -75.59387104290336,
-              40.03677022167725,
-              -75.59355000490342,
-              40.03588760913535,
-            ]),
-            width: 8,
-            material: new Cesium.PolylineOutlineMaterialProperty({
-              color: Cesium.Color.YELLOW,
-              outlineWidth: 2,
-              outlineColor: Cesium.Color.BLACK,
-            }),
-            clampToGround: true,
-          },
-        });
-
-        const classificationOptions = [
-          {
-            text: "Classify Both",
-            onselect: function () {
-              polygon.polygon.classificationType =
-                Cesium.ClassificationType.BOTH;
-              polyline.polyline.classificationType =
-                Cesium.ClassificationType.BOTH;
+          const polygon = viewer.entities.add({
+            polygon: {
+              hierarchy: new Cesium.PolygonHierarchy(
+                Cesium.Cartesian3.fromRadiansArray([
+                  -1.3194369277314022,
+                  0.6988062530900625,
+                  -1.3193955980204217,
+                  0.6988091578771254,
+                  -1.3193931220959367,
+                  0.698743632490865,
+                  -1.3194358224045408,
+                  0.6987471965556998,
+                ])
+              ),
+              material: Cesium.Color.RED.withAlpha(0.5),
+              classificationType: Cesium.ClassificationType.BOTH,
             },
-          },
-          {
-            text: "Classify Terrain",
-            onselect: function () {
-              polygon.polygon.classificationType =
-                Cesium.ClassificationType.TERRAIN;
-              polyline.polyline.classificationType =
-                Cesium.ClassificationType.TERRAIN;
-            },
-          },
-          {
-            text: "Classify 3D Tiles",
-            onselect: function () {
-              polygon.polygon.classificationType =
-                Cesium.ClassificationType.CESIUM_3D_TILE;
-              polyline.polyline.classificationType =
-                Cesium.ClassificationType.CESIUM_3D_TILE;
-            },
-          },
-        ];
+          });
 
-        const materialOptions = [
-          {
-            text: "Red Material",
-            onselect: function () {
-              polygon.polygon.material = Cesium.Color.RED.withAlpha(0.5);
+          const polyline = viewer.entities.add({
+            polyline: {
+              positions: Cesium.Cartesian3.fromDegreesArray([
+                -75.60217330403601,
+                40.04102882709425,
+                -75.59968252414251,
+                40.04093615560871,
+                -75.598020153828,
+                40.04079437042357,
+                -75.59674934074435,
+                40.040816173283304,
+                -75.59630042791713,
+                40.03986900370842,
+                -75.59563636849978,
+                40.03930996506271,
+                -75.59492397899098,
+                40.03873932846581,
+                -75.59457991226778,
+                40.038392701955786,
+                -75.59424838652453,
+                40.03775403572295,
+                -75.59387104290336,
+                40.03677022167725,
+                -75.59355000490342,
+                40.03588760913535,
+              ]),
+              width: 8,
+              material: new Cesium.PolylineOutlineMaterialProperty({
+                color: Cesium.Color.YELLOW,
+                outlineWidth: 2,
+                outlineColor: Cesium.Color.BLACK,
+              }),
+              clampToGround: true,
             },
-          },
-          {
-            text: "Textured Material",
-            onselect: function () {
-              if (
-                !Cesium.Entity.supportsMaterialsforEntitiesOnTerrain(
-                  viewer.scene
-                )
-              ) {
-                window.alert(
-                  "Terrain Entity materials are not supported on this platform"
-                );
-              }
-              polygon.polygon.material = "../images/Cesium_Logo_Color.jpg";
-            },
-          },
-        ];
+          });
 
-        Sandcastle.addToolbarMenu(classificationOptions);
-        Sandcastle.addToolbarMenu(materialOptions);
-        //Sandcastle_End
+          const classificationOptions = [
+            {
+              text: "Classify Both",
+              onselect: function () {
+                polygon.polygon.classificationType =
+                  Cesium.ClassificationType.BOTH;
+                polyline.polyline.classificationType =
+                  Cesium.ClassificationType.BOTH;
+              },
+            },
+            {
+              text: "Classify Terrain",
+              onselect: function () {
+                polygon.polygon.classificationType =
+                  Cesium.ClassificationType.TERRAIN;
+                polyline.polyline.classificationType =
+                  Cesium.ClassificationType.TERRAIN;
+              },
+            },
+            {
+              text: "Classify 3D Tiles",
+              onselect: function () {
+                polygon.polygon.classificationType =
+                  Cesium.ClassificationType.CESIUM_3D_TILE;
+                polyline.polyline.classificationType =
+                  Cesium.ClassificationType.CESIUM_3D_TILE;
+              },
+            },
+          ];
+
+          const materialOptions = [
+            {
+              text: "Red Material",
+              onselect: function () {
+                polygon.polygon.material = Cesium.Color.RED.withAlpha(0.5);
+              },
+            },
+            {
+              text: "Textured Material",
+              onselect: function () {
+                if (
+                  !Cesium.Entity.supportsMaterialsforEntitiesOnTerrain(
+                    viewer.scene
+                  )
+                ) {
+                  window.alert(
+                    "Terrain Entity materials are not supported on this platform"
+                  );
+                }
+                polygon.polygon.material = "../images/Cesium_Logo_Color.jpg";
+              },
+            },
+          ];
+
+          Sandcastle.addToolbarMenu(classificationOptions);
+          Sandcastle.addToolbarMenu(materialOptions);
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Classification Types.html
+++ b/Apps/Sandcastle/gallery/Classification Types.html
@@ -35,141 +35,146 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        const viewer = new Cesium.Viewer("cesiumContainer");
+
         (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+          } catch (error) {
+            console.log(error);
+          }
+        })();
 
-          const tileset = new Cesium.Cesium3DTileset({
-            url: Cesium.IonResource.fromAssetId(40866),
-          });
-          viewer.scene.primitives.add(tileset);
+        const tileset = new Cesium.Cesium3DTileset({
+          url: Cesium.IonResource.fromAssetId(40866),
+        });
+        viewer.scene.primitives.add(tileset);
 
-          tileset.readyPromise.then(function () {
-            const boundingSphere = tileset.boundingSphere;
-            viewer.camera.viewBoundingSphere(
-              boundingSphere,
-              new Cesium.HeadingPitchRange(
-                0.0,
-                -0.5,
-                boundingSphere.radius + 500.0
-              )
-            );
-            viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-          });
+        tileset.readyPromise.then(function () {
+          const boundingSphere = tileset.boundingSphere;
+          viewer.camera.viewBoundingSphere(
+            boundingSphere,
+            new Cesium.HeadingPitchRange(
+              0.0,
+              -0.5,
+              boundingSphere.radius + 500.0
+            )
+          );
+          viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+        });
 
-          const polygon = viewer.entities.add({
-            polygon: {
-              hierarchy: new Cesium.PolygonHierarchy(
-                Cesium.Cartesian3.fromRadiansArray([
-                  -1.3194369277314022,
-                  0.6988062530900625,
-                  -1.3193955980204217,
-                  0.6988091578771254,
-                  -1.3193931220959367,
-                  0.698743632490865,
-                  -1.3194358224045408,
-                  0.6987471965556998,
-                ])
-              ),
-              material: Cesium.Color.RED.withAlpha(0.5),
-              classificationType: Cesium.ClassificationType.BOTH,
-            },
-          });
+        const polygon = viewer.entities.add({
+          polygon: {
+            hierarchy: new Cesium.PolygonHierarchy(
+              Cesium.Cartesian3.fromRadiansArray([
+                -1.3194369277314022,
+                0.6988062530900625,
+                -1.3193955980204217,
+                0.6988091578771254,
+                -1.3193931220959367,
+                0.698743632490865,
+                -1.3194358224045408,
+                0.6987471965556998,
+              ])
+            ),
+            material: Cesium.Color.RED.withAlpha(0.5),
+            classificationType: Cesium.ClassificationType.BOTH,
+          },
+        });
 
-          const polyline = viewer.entities.add({
-            polyline: {
-              positions: Cesium.Cartesian3.fromDegreesArray([
-                -75.60217330403601,
-                40.04102882709425,
-                -75.59968252414251,
-                40.04093615560871,
-                -75.598020153828,
-                40.04079437042357,
-                -75.59674934074435,
-                40.040816173283304,
-                -75.59630042791713,
-                40.03986900370842,
-                -75.59563636849978,
-                40.03930996506271,
-                -75.59492397899098,
-                40.03873932846581,
-                -75.59457991226778,
-                40.038392701955786,
-                -75.59424838652453,
-                40.03775403572295,
-                -75.59387104290336,
-                40.03677022167725,
-                -75.59355000490342,
-                40.03588760913535,
-              ]),
-              width: 8,
-              material: new Cesium.PolylineOutlineMaterialProperty({
-                color: Cesium.Color.YELLOW,
-                outlineWidth: 2,
-                outlineColor: Cesium.Color.BLACK,
-              }),
-              clampToGround: true,
-            },
-          });
+        const polyline = viewer.entities.add({
+          polyline: {
+            positions: Cesium.Cartesian3.fromDegreesArray([
+              -75.60217330403601,
+              40.04102882709425,
+              -75.59968252414251,
+              40.04093615560871,
+              -75.598020153828,
+              40.04079437042357,
+              -75.59674934074435,
+              40.040816173283304,
+              -75.59630042791713,
+              40.03986900370842,
+              -75.59563636849978,
+              40.03930996506271,
+              -75.59492397899098,
+              40.03873932846581,
+              -75.59457991226778,
+              40.038392701955786,
+              -75.59424838652453,
+              40.03775403572295,
+              -75.59387104290336,
+              40.03677022167725,
+              -75.59355000490342,
+              40.03588760913535,
+            ]),
+            width: 8,
+            material: new Cesium.PolylineOutlineMaterialProperty({
+              color: Cesium.Color.YELLOW,
+              outlineWidth: 2,
+              outlineColor: Cesium.Color.BLACK,
+            }),
+            clampToGround: true,
+          },
+        });
 
-          const classificationOptions = [
-            {
-              text: "Classify Both",
-              onselect: function () {
-                polygon.polygon.classificationType =
-                  Cesium.ClassificationType.BOTH;
-                polyline.polyline.classificationType =
-                  Cesium.ClassificationType.BOTH;
-              },
+        const classificationOptions = [
+          {
+            text: "Classify Both",
+            onselect: function () {
+              polygon.polygon.classificationType =
+                Cesium.ClassificationType.BOTH;
+              polyline.polyline.classificationType =
+                Cesium.ClassificationType.BOTH;
             },
-            {
-              text: "Classify Terrain",
-              onselect: function () {
-                polygon.polygon.classificationType =
-                  Cesium.ClassificationType.TERRAIN;
-                polyline.polyline.classificationType =
-                  Cesium.ClassificationType.TERRAIN;
-              },
+          },
+          {
+            text: "Classify Terrain",
+            onselect: function () {
+              polygon.polygon.classificationType =
+                Cesium.ClassificationType.TERRAIN;
+              polyline.polyline.classificationType =
+                Cesium.ClassificationType.TERRAIN;
             },
-            {
-              text: "Classify 3D Tiles",
-              onselect: function () {
-                polygon.polygon.classificationType =
-                  Cesium.ClassificationType.CESIUM_3D_TILE;
-                polyline.polyline.classificationType =
-                  Cesium.ClassificationType.CESIUM_3D_TILE;
-              },
+          },
+          {
+            text: "Classify 3D Tiles",
+            onselect: function () {
+              polygon.polygon.classificationType =
+                Cesium.ClassificationType.CESIUM_3D_TILE;
+              polyline.polyline.classificationType =
+                Cesium.ClassificationType.CESIUM_3D_TILE;
             },
-          ];
+          },
+        ];
 
-          const materialOptions = [
-            {
-              text: "Red Material",
-              onselect: function () {
-                polygon.polygon.material = Cesium.Color.RED.withAlpha(0.5);
-              },
+        const materialOptions = [
+          {
+            text: "Red Material",
+            onselect: function () {
+              polygon.polygon.material = Cesium.Color.RED.withAlpha(0.5);
             },
-            {
-              text: "Textured Material",
-              onselect: function () {
-                if (
-                  !Cesium.Entity.supportsMaterialsforEntitiesOnTerrain(
-                    viewer.scene
-                  )
-                ) {
-                  window.alert(
-                    "Terrain Entity materials are not supported on this platform"
-                  );
-                }
-                polygon.polygon.material = "../images/Cesium_Logo_Color.jpg";
-              },
+          },
+          {
+            text: "Textured Material",
+            onselect: function () {
+              if (
+                !Cesium.Entity.supportsMaterialsforEntitiesOnTerrain(
+                  viewer.scene
+                )
+              ) {
+                window.alert(
+                  "Terrain Entity materials are not supported on this platform"
+                );
+              }
+              polygon.polygon.material = "../images/Cesium_Logo_Color.jpg";
             },
-          ];
+          },
+        ];
 
-          Sandcastle.addToolbarMenu(classificationOptions);
-          Sandcastle.addToolbarMenu(materialOptions);
-        })(); //Sandcastle_End
+        Sandcastle.addToolbarMenu(classificationOptions);
+        Sandcastle.addToolbarMenu(materialOptions);
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Classification.html
+++ b/Apps/Sandcastle/gallery/Classification.html
@@ -79,276 +79,314 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
-
-        const scene = viewer.scene;
-        const camera = scene.camera;
-
-        let center = new Cesium.Cartesian3(
-          1216389.3637977627,
-          -4736323.641980423,
-          4081321.7428341154
-        );
-        let modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(center);
-        let hprRotation = Cesium.Matrix3.fromHeadingPitchRoll(
-          new Cesium.HeadingPitchRoll(2.619728786416368, 0.0, 0.0)
-        );
-        let hpr = Cesium.Matrix4.fromRotationTranslation(
-          hprRotation,
-          new Cesium.Cartesian3(0.0, 0.0, -2.0)
-        );
-        Cesium.Matrix4.multiply(modelMatrix, hpr, modelMatrix);
-
-        const buildingHighlight = scene.primitives.add(
-          new Cesium.ClassificationPrimitive({
-            geometryInstances: new Cesium.GeometryInstance({
-              geometry: Cesium.BoxGeometry.fromDimensions({
-                vertexFormat: Cesium.PerInstanceColorAppearance.VERTEX_FORMAT,
-                dimensions: new Cesium.Cartesian3(8.0, 5.0, 8.0),
-              }),
-              modelMatrix: modelMatrix,
-              attributes: {
-                color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                  new Cesium.Color(1.0, 0.0, 0.0, 0.5)
-                ),
-                show: new Cesium.ShowGeometryInstanceAttribute(true),
-              },
-              id: "volume",
-            }),
-            classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
-          })
-        );
-
-        center = new Cesium.Cartesian3(
-          1216409.0189737265,
-          -4736252.144235287,
-          4081393.6027081604
-        );
-        modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(center);
-        hprRotation = Cesium.Matrix3.fromHeadingPitchRoll(
-          new Cesium.HeadingPitchRoll(5.785339046755887, 0.0, 0.0)
-        );
-        hpr = Cesium.Matrix4.fromRotationTranslation(
-          hprRotation,
-          new Cesium.Cartesian3(0.4, 0.0, -2.0)
-        );
-        Cesium.Matrix4.multiply(modelMatrix, hpr, modelMatrix);
-
-        const treeHighlight1 = scene.primitives.add(
-          new Cesium.ClassificationPrimitive({
-            geometryInstances: new Cesium.GeometryInstance({
-              geometry: new Cesium.EllipsoidGeometry({
-                radii: new Cesium.Cartesian3(3.25, 5.0, 4.0),
-              }),
-              modelMatrix: modelMatrix,
-              attributes: {
-                color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                  Cesium.Color.fromCssColorString("#F26419").withAlpha(0.5)
-                ),
-                show: new Cesium.ShowGeometryInstanceAttribute(true),
-              },
-              id: "volume 1",
-            }),
-            classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
-          })
-        );
-
-        center = new Cesium.Cartesian3(
-          1216404.8844045496,
-          -4736255.287065536,
-          4081392.010192471
-        );
-        modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(center);
-        hprRotation = Cesium.Matrix3.fromHeadingPitchRoll(
-          new Cesium.HeadingPitchRoll(5.785339046755887, 0.0, 0.0)
-        );
-        hpr = Cesium.Matrix4.fromRotationTranslation(
-          hprRotation,
-          new Cesium.Cartesian3(-0.25, 0.0, -2.0)
-        );
-        Cesium.Matrix4.multiply(modelMatrix, hpr, modelMatrix);
-
-        const treeHighlight2 = scene.primitives.add(
-          new Cesium.ClassificationPrimitive({
-            geometryInstances: new Cesium.GeometryInstance({
-              geometry: new Cesium.EllipsoidGeometry({
-                radii: new Cesium.Cartesian3(3.25, 5.0, 4.0),
-              }),
-              modelMatrix: modelMatrix,
-              attributes: {
-                color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                  Cesium.Color.fromCssColorString("#F03A47").withAlpha(0.5)
-                ),
-                show: new Cesium.ShowGeometryInstanceAttribute(true),
-              },
-              id: "volume 2",
-            }),
-            classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
-          })
-        );
-
-        center = new Cesium.Cartesian3(
-          1216398.813990024,
-          -4736258.039875737,
-          4081387.9562678365
-        );
-        modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(center);
-        let translation = Cesium.Matrix4.fromTranslation(
-          new Cesium.Cartesian3(0.0, 0.0, -2.0)
-        );
-        Cesium.Matrix4.multiply(modelMatrix, translation, modelMatrix);
-
-        const treeHighlight3 = scene.primitives.add(
-          new Cesium.ClassificationPrimitive({
-            geometryInstances: new Cesium.GeometryInstance({
-              geometry: new Cesium.EllipsoidGeometry({
-                radii: new Cesium.Cartesian3(2.45, 2.45, 3.0),
-              }),
-              modelMatrix: modelMatrix,
-              attributes: {
-                color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                  Cesium.Color.fromCssColorString("#004FFF").withAlpha(0.5)
-                ),
-                show: new Cesium.ShowGeometryInstanceAttribute(true),
-              },
-              id: "volume 3",
-            }),
-            classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
-          })
-        );
-
-        center = new Cesium.Cartesian3(
-          1216393.6257790313,
-          -4736259.809075361,
-          4081384.4858198245
-        );
-        modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(center);
-        translation = Cesium.Matrix4.fromTranslation(
-          new Cesium.Cartesian3(0.0, 0.0, -1.0)
-        );
-        Cesium.Matrix4.multiply(modelMatrix, translation, modelMatrix);
-
-        const treeHighlight4 = scene.primitives.add(
-          new Cesium.ClassificationPrimitive({
-            geometryInstances: new Cesium.GeometryInstance({
-              geometry: new Cesium.SphereGeometry({
-                radius: 2.0,
-              }),
-              modelMatrix: modelMatrix,
-              attributes: {
-                color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                  Cesium.Color.fromCssColorString("#55DDE0").withAlpha(0.5)
-                ),
-                show: new Cesium.ShowGeometryInstanceAttribute(true),
-              },
-              id: "volume 4",
-            }),
-            classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
-          })
-        );
-
-        function highlightBuilding() {
-          camera.setView({
-            destination: new Cesium.Cartesian3(
-              1216394.1392207467,
-              -4736348.59346919,
-              4081293.9160685353
-            ),
-            orientation: {
-              heading: 0.018509338875732695,
-              pitch: -0.09272999615872646,
-            },
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
           });
-        }
 
-        function highlightTrees() {
-          camera.setView({
-            destination: new Cesium.Cartesian3(
-              1216435.0352745096,
-              -4736283.144192113,
-              4081368.0920420634
-            ),
-            orientation: {
-              heading: 5.718380792746039,
-              pitch: -0.3087010195266797,
-            },
-          });
-        }
+          const scene = viewer.scene;
+          const camera = scene.camera;
 
-        function invertClassification(checked) {
-          if (checked && !scene.invertClassificationSupported) {
-            window.alert("This browser does not support invert classification");
-          }
+          let center = new Cesium.Cartesian3(
+            1216389.3637977627,
+            -4736323.641980423,
+            4081321.7428341154
+          );
+          let modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(center);
+          let hprRotation = Cesium.Matrix3.fromHeadingPitchRoll(
+            new Cesium.HeadingPitchRoll(2.619728786416368, 0.0, 0.0)
+          );
+          let hpr = Cesium.Matrix4.fromRotationTranslation(
+            hprRotation,
+            new Cesium.Cartesian3(0.0, 0.0, -2.0)
+          );
+          Cesium.Matrix4.multiply(modelMatrix, hpr, modelMatrix);
 
-          scene.invertClassification = checked;
-          scene.invertClassificationColor = new Cesium.Color(
-            0.25,
-            0.25,
-            0.25,
-            1.0
+          const buildingHighlight = scene.primitives.add(
+            new Cesium.ClassificationPrimitive({
+              geometryInstances: new Cesium.GeometryInstance({
+                geometry: Cesium.BoxGeometry.fromDimensions({
+                  vertexFormat: Cesium.PerInstanceColorAppearance.VERTEX_FORMAT,
+                  dimensions: new Cesium.Cartesian3(8.0, 5.0, 8.0),
+                }),
+                modelMatrix: modelMatrix,
+                attributes: {
+                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                    new Cesium.Color(1.0, 0.0, 0.0, 0.5)
+                  ),
+                  show: new Cesium.ShowGeometryInstanceAttribute(true),
+                },
+                id: "volume",
+              }),
+              classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
+            })
           );
 
-          buildingHighlight.getGeometryInstanceAttributes(
-            "volume"
-          ).show = Cesium.ShowGeometryInstanceAttribute.toValue(!checked);
-          treeHighlight1.getGeometryInstanceAttributes(
-            "volume 1"
-          ).show = Cesium.ShowGeometryInstanceAttribute.toValue(!checked);
-          treeHighlight2.getGeometryInstanceAttributes(
-            "volume 2"
-          ).show = Cesium.ShowGeometryInstanceAttribute.toValue(!checked);
-          treeHighlight3.getGeometryInstanceAttributes(
-            "volume 3"
-          ).show = Cesium.ShowGeometryInstanceAttribute.toValue(!checked);
-          treeHighlight4.getGeometryInstanceAttributes(
-            "volume 4"
-          ).show = Cesium.ShowGeometryInstanceAttribute.toValue(!checked);
-        }
+          center = new Cesium.Cartesian3(
+            1216409.0189737265,
+            -4736252.144235287,
+            4081393.6027081604
+          );
+          modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(center);
+          hprRotation = Cesium.Matrix3.fromHeadingPitchRoll(
+            new Cesium.HeadingPitchRoll(5.785339046755887, 0.0, 0.0)
+          );
+          hpr = Cesium.Matrix4.fromRotationTranslation(
+            hprRotation,
+            new Cesium.Cartesian3(0.4, 0.0, -2.0)
+          );
+          Cesium.Matrix4.multiply(modelMatrix, hpr, modelMatrix);
 
-        function updateAlpha(value) {
-          scene.invertClassificationColor.alpha = parseFloat(value);
-        }
+          const treeHighlight1 = scene.primitives.add(
+            new Cesium.ClassificationPrimitive({
+              geometryInstances: new Cesium.GeometryInstance({
+                geometry: new Cesium.EllipsoidGeometry({
+                  radii: new Cesium.Cartesian3(3.25, 5.0, 4.0),
+                }),
+                modelMatrix: modelMatrix,
+                attributes: {
+                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                    Cesium.Color.fromCssColorString("#F26419").withAlpha(0.5)
+                  ),
+                  show: new Cesium.ShowGeometryInstanceAttribute(true),
+                },
+                id: "volume 1",
+              }),
+              classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
+            })
+          );
 
-        const tileset = new Cesium.Cesium3DTileset({
-          url: Cesium.IonResource.fromAssetId(40866),
-        });
-        scene.primitives.add(tileset);
+          center = new Cesium.Cartesian3(
+            1216404.8844045496,
+            -4736255.287065536,
+            4081392.010192471
+          );
+          modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(center);
+          hprRotation = Cesium.Matrix3.fromHeadingPitchRoll(
+            new Cesium.HeadingPitchRoll(5.785339046755887, 0.0, 0.0)
+          );
+          hpr = Cesium.Matrix4.fromRotationTranslation(
+            hprRotation,
+            new Cesium.Cartesian3(-0.25, 0.0, -2.0)
+          );
+          Cesium.Matrix4.multiply(modelMatrix, hpr, modelMatrix);
 
-        const viewModel = {
-          inverted: viewer.scene.invertClassification,
-          invertedAlpha: viewer.scene.invertClassificationColor.alpha,
-          highlightBuilding: highlightBuilding,
-          highlightTrees: highlightTrees,
-        };
-        Cesium.knockout.track(viewModel);
-        const toolbar = document.getElementById("toolbar");
-        Cesium.knockout.applyBindings(viewModel, toolbar);
-        Cesium.knockout
-          .getObservable(viewModel, "inverted")
-          .subscribe(invertClassification);
-        Cesium.knockout
-          .getObservable(viewModel, "invertedAlpha")
-          .subscribe(updateAlpha);
+          const treeHighlight2 = scene.primitives.add(
+            new Cesium.ClassificationPrimitive({
+              geometryInstances: new Cesium.GeometryInstance({
+                geometry: new Cesium.EllipsoidGeometry({
+                  radii: new Cesium.Cartesian3(3.25, 5.0, 4.0),
+                }),
+                modelMatrix: modelMatrix,
+                attributes: {
+                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                    Cesium.Color.fromCssColorString("#F03A47").withAlpha(0.5)
+                  ),
+                  show: new Cesium.ShowGeometryInstanceAttribute(true),
+                },
+                id: "volume 2",
+              }),
+              classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
+            })
+          );
 
-        highlightTrees();
+          center = new Cesium.Cartesian3(
+            1216398.813990024,
+            -4736258.039875737,
+            4081387.9562678365
+          );
+          modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(center);
+          let translation = Cesium.Matrix4.fromTranslation(
+            new Cesium.Cartesian3(0.0, 0.0, -2.0)
+          );
+          Cesium.Matrix4.multiply(modelMatrix, translation, modelMatrix);
 
-        let currentObjectId;
-        let currentPrimitive;
-        let currentColor;
-        let currentShow;
-        let attributes;
+          const treeHighlight3 = scene.primitives.add(
+            new Cesium.ClassificationPrimitive({
+              geometryInstances: new Cesium.GeometryInstance({
+                geometry: new Cesium.EllipsoidGeometry({
+                  radii: new Cesium.Cartesian3(2.45, 2.45, 3.0),
+                }),
+                modelMatrix: modelMatrix,
+                attributes: {
+                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                    Cesium.Color.fromCssColorString("#004FFF").withAlpha(0.5)
+                  ),
+                  show: new Cesium.ShowGeometryInstanceAttribute(true),
+                },
+                id: "volume 3",
+              }),
+              classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
+            })
+          );
 
-        const handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
-        handler.setInputAction(function (movement) {
-          const pickedObject = scene.pick(movement.endPosition);
-          if (Cesium.defined(pickedObject) && Cesium.defined(pickedObject.id)) {
-            if (pickedObject.id === currentObjectId) {
-              return;
+          center = new Cesium.Cartesian3(
+            1216393.6257790313,
+            -4736259.809075361,
+            4081384.4858198245
+          );
+          modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(center);
+          translation = Cesium.Matrix4.fromTranslation(
+            new Cesium.Cartesian3(0.0, 0.0, -1.0)
+          );
+          Cesium.Matrix4.multiply(modelMatrix, translation, modelMatrix);
+
+          const treeHighlight4 = scene.primitives.add(
+            new Cesium.ClassificationPrimitive({
+              geometryInstances: new Cesium.GeometryInstance({
+                geometry: new Cesium.SphereGeometry({
+                  radius: 2.0,
+                }),
+                modelMatrix: modelMatrix,
+                attributes: {
+                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                    Cesium.Color.fromCssColorString("#55DDE0").withAlpha(0.5)
+                  ),
+                  show: new Cesium.ShowGeometryInstanceAttribute(true),
+                },
+                id: "volume 4",
+              }),
+              classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
+            })
+          );
+
+          function highlightBuilding() {
+            camera.setView({
+              destination: new Cesium.Cartesian3(
+                1216394.1392207467,
+                -4736348.59346919,
+                4081293.9160685353
+              ),
+              orientation: {
+                heading: 0.018509338875732695,
+                pitch: -0.09272999615872646,
+              },
+            });
+          }
+
+          function highlightTrees() {
+            camera.setView({
+              destination: new Cesium.Cartesian3(
+                1216435.0352745096,
+                -4736283.144192113,
+                4081368.0920420634
+              ),
+              orientation: {
+                heading: 5.718380792746039,
+                pitch: -0.3087010195266797,
+              },
+            });
+          }
+
+          function invertClassification(checked) {
+            if (checked && !scene.invertClassificationSupported) {
+              window.alert(
+                "This browser does not support invert classification"
+              );
             }
 
-            if (Cesium.defined(currentObjectId)) {
+            scene.invertClassification = checked;
+            scene.invertClassificationColor = new Cesium.Color(
+              0.25,
+              0.25,
+              0.25,
+              1.0
+            );
+
+            buildingHighlight.getGeometryInstanceAttributes(
+              "volume"
+            ).show = Cesium.ShowGeometryInstanceAttribute.toValue(!checked);
+            treeHighlight1.getGeometryInstanceAttributes(
+              "volume 1"
+            ).show = Cesium.ShowGeometryInstanceAttribute.toValue(!checked);
+            treeHighlight2.getGeometryInstanceAttributes(
+              "volume 2"
+            ).show = Cesium.ShowGeometryInstanceAttribute.toValue(!checked);
+            treeHighlight3.getGeometryInstanceAttributes(
+              "volume 3"
+            ).show = Cesium.ShowGeometryInstanceAttribute.toValue(!checked);
+            treeHighlight4.getGeometryInstanceAttributes(
+              "volume 4"
+            ).show = Cesium.ShowGeometryInstanceAttribute.toValue(!checked);
+          }
+
+          function updateAlpha(value) {
+            scene.invertClassificationColor.alpha = parseFloat(value);
+          }
+
+          const tileset = new Cesium.Cesium3DTileset({
+            url: Cesium.IonResource.fromAssetId(40866),
+          });
+          scene.primitives.add(tileset);
+
+          const viewModel = {
+            inverted: viewer.scene.invertClassification,
+            invertedAlpha: viewer.scene.invertClassificationColor.alpha,
+            highlightBuilding: highlightBuilding,
+            highlightTrees: highlightTrees,
+          };
+          Cesium.knockout.track(viewModel);
+          const toolbar = document.getElementById("toolbar");
+          Cesium.knockout.applyBindings(viewModel, toolbar);
+          Cesium.knockout
+            .getObservable(viewModel, "inverted")
+            .subscribe(invertClassification);
+          Cesium.knockout
+            .getObservable(viewModel, "invertedAlpha")
+            .subscribe(updateAlpha);
+
+          highlightTrees();
+
+          let currentObjectId;
+          let currentPrimitive;
+          let currentColor;
+          let currentShow;
+          let attributes;
+
+          const handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
+          handler.setInputAction(function (movement) {
+            const pickedObject = scene.pick(movement.endPosition);
+            if (
+              Cesium.defined(pickedObject) &&
+              Cesium.defined(pickedObject.id)
+            ) {
+              if (pickedObject.id === currentObjectId) {
+                return;
+              }
+
+              if (Cesium.defined(currentObjectId)) {
+                attributes = currentPrimitive.getGeometryInstanceAttributes(
+                  currentObjectId
+                );
+                attributes.color = currentColor;
+                attributes.show = currentShow;
+                currentObjectId = undefined;
+                currentPrimitive = undefined;
+                currentColor = undefined;
+                currentShow = undefined;
+              }
+            }
+
+            if (
+              Cesium.defined(pickedObject) &&
+              Cesium.defined(pickedObject.primitive) &&
+              Cesium.defined(pickedObject.id) &&
+              Cesium.defined(
+                pickedObject.primitive.getGeometryInstanceAttributes
+              )
+            ) {
+              currentObjectId = pickedObject.id;
+              currentPrimitive = pickedObject.primitive;
+              attributes = currentPrimitive.getGeometryInstanceAttributes(
+                currentObjectId
+              );
+              currentColor = attributes.color;
+              currentShow = attributes.show;
+              if (!scene.invertClassification) {
+                attributes.color = [255, 0, 255, 128];
+              }
+              attributes.show = [1];
+            } else if (Cesium.defined(currentObjectId)) {
               attributes = currentPrimitive.getGeometryInstanceAttributes(
                 currentObjectId
               );
@@ -357,39 +395,9 @@
               currentObjectId = undefined;
               currentPrimitive = undefined;
               currentColor = undefined;
-              currentShow = undefined;
             }
-          }
-
-          if (
-            Cesium.defined(pickedObject) &&
-            Cesium.defined(pickedObject.primitive) &&
-            Cesium.defined(pickedObject.id) &&
-            Cesium.defined(pickedObject.primitive.getGeometryInstanceAttributes)
-          ) {
-            currentObjectId = pickedObject.id;
-            currentPrimitive = pickedObject.primitive;
-            attributes = currentPrimitive.getGeometryInstanceAttributes(
-              currentObjectId
-            );
-            currentColor = attributes.color;
-            currentShow = attributes.show;
-            if (!scene.invertClassification) {
-              attributes.color = [255, 0, 255, 128];
-            }
-            attributes.show = [1];
-          } else if (Cesium.defined(currentObjectId)) {
-            attributes = currentPrimitive.getGeometryInstanceAttributes(
-              currentObjectId
-            );
-            attributes.color = currentColor;
-            attributes.show = currentShow;
-            currentObjectId = undefined;
-            currentPrimitive = undefined;
-            currentColor = undefined;
-          }
-        }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-        //Sandcastle_End
+          }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Classification.html
+++ b/Apps/Sandcastle/gallery/Classification.html
@@ -80,7 +80,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         const scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/Clouds.html
+++ b/Apps/Sandcastle/gallery/Clouds.html
@@ -32,242 +32,243 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-          infoBox: false,
-          shouldAnimate: true,
-        });
-
-        const scene = viewer.scene;
-        scene.primitives.add(Cesium.createOsmBuildings());
-
-        ///////////////////////////
-        // Create clouds
-        ///////////////////////////
-
-        Cesium.Math.setRandomNumberSeed(2.5);
-        function getRandomNumberInRange(minValue, maxValue) {
-          return (
-            minValue + Cesium.Math.nextRandomNumber() * (maxValue - minValue)
-          );
-        }
-
-        const clouds = new Cesium.CloudCollection();
-
-        // manually position clouds in the mountains
-        function createBackLayerClouds() {
-          clouds.add({
-            position: Cesium.Cartesian3.fromDegrees(-122.6908, 45.496, 300),
-            scale: new Cesium.Cartesian2(1500, 250),
-            maximumSize: new Cesium.Cartesian3(50, 15, 13),
-            slice: 0.3,
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+            infoBox: false,
+            shouldAnimate: true,
           });
 
-          clouds.add({
-            position: Cesium.Cartesian3.fromDegrees(-122.72, 45.5, 335),
-            scale: new Cesium.Cartesian2(1500, 300),
-            maximumSize: new Cesium.Cartesian3(50, 12, 15),
-            slice: 0.36,
-          });
+          const scene = viewer.scene;
+          scene.primitives.add(Cesium.createOsmBuildings());
 
-          clouds.add({
-            position: Cesium.Cartesian3.fromDegrees(-122.72, 45.51, 260),
-            scale: new Cesium.Cartesian2(2000, 300),
-            maximumSize: new Cesium.Cartesian3(50, 12, 15),
-            slice: 0.49,
-          });
+          ///////////////////////////
+          // Create clouds
+          ///////////////////////////
 
-          clouds.add({
-            position: Cesium.Cartesian3.fromDegrees(-122.705, 45.52, 250),
-            scale: new Cesium.Cartesian2(230, 110),
-            maximumSize: new Cesium.Cartesian3(13, 13, 13),
-            slice: 0.2,
-          });
+          Cesium.Math.setRandomNumberSeed(2.5);
+          function getRandomNumberInRange(minValue, maxValue) {
+            return (
+              minValue + Cesium.Math.nextRandomNumber() * (maxValue - minValue)
+            );
+          }
 
-          clouds.add({
-            position: Cesium.Cartesian3.fromDegrees(-122.71, 45.522, 270),
-            scale: new Cesium.Cartesian2(1700, 300),
-            maximumSize: new Cesium.Cartesian3(50, 12, 15),
-            slice: 0.6,
-          });
+          const clouds = new Cesium.CloudCollection();
 
-          clouds.add({
-            position: Cesium.Cartesian3.fromDegrees(-122.705, 45.525, 250),
-            scale: new Cesium.Cartesian2(230, 110),
-            maximumSize: new Cesium.Cartesian3(15, 13, 15),
-            slice: 0.35,
-          });
-
-          clouds.add({
-            position: Cesium.Cartesian3.fromDegrees(-122.721, 45.53, 220),
-            scale: new Cesium.Cartesian2(1500, 500),
-            maximumSize: new Cesium.Cartesian3(30, 20, 17),
-            slice: 0.45,
-          });
-        }
-
-        let long,
-          lat,
-          height,
-          scaleX,
-          scaleY,
-          aspectRatio,
-          cloudHeight,
-          depth,
-          slice;
-
-        // randomly generate clouds in a certain area
-        function createRandomClouds(
-          numClouds,
-          startLong,
-          stopLong,
-          startLat,
-          stopLat,
-          minHeight,
-          maxHeight
-        ) {
-          const rangeLong = stopLong - startLong;
-          const rangeLat = stopLat - startLat;
-          for (let i = 0; i < numClouds; i++) {
-            long = startLong + getRandomNumberInRange(0, rangeLong);
-            lat = startLat + getRandomNumberInRange(0, rangeLat);
-            height = getRandomNumberInRange(minHeight, maxHeight);
-            scaleX = getRandomNumberInRange(150, 350);
-            scaleY = scaleX / 2.0 - getRandomNumberInRange(0, scaleX / 4.0);
-            slice = getRandomNumberInRange(0.3, 0.7);
-            depth = getRandomNumberInRange(5, 20);
-            aspectRatio = getRandomNumberInRange(1.5, 2.1);
-            cloudHeight = getRandomNumberInRange(5, 20);
+          // manually position clouds in the mountains
+          function createBackLayerClouds() {
             clouds.add({
-              position: Cesium.Cartesian3.fromDegrees(long, lat, height),
-              scale: new Cesium.Cartesian2(scaleX, scaleY),
-              maximumSize: new Cesium.Cartesian3(
-                aspectRatio * cloudHeight,
-                cloudHeight,
-                depth
-              ),
-              slice: slice,
+              position: Cesium.Cartesian3.fromDegrees(-122.6908, 45.496, 300),
+              scale: new Cesium.Cartesian2(1500, 250),
+              maximumSize: new Cesium.Cartesian3(50, 15, 13),
+              slice: 0.3,
+            });
+
+            clouds.add({
+              position: Cesium.Cartesian3.fromDegrees(-122.72, 45.5, 335),
+              scale: new Cesium.Cartesian2(1500, 300),
+              maximumSize: new Cesium.Cartesian3(50, 12, 15),
+              slice: 0.36,
+            });
+
+            clouds.add({
+              position: Cesium.Cartesian3.fromDegrees(-122.72, 45.51, 260),
+              scale: new Cesium.Cartesian2(2000, 300),
+              maximumSize: new Cesium.Cartesian3(50, 12, 15),
+              slice: 0.49,
+            });
+
+            clouds.add({
+              position: Cesium.Cartesian3.fromDegrees(-122.705, 45.52, 250),
+              scale: new Cesium.Cartesian2(230, 110),
+              maximumSize: new Cesium.Cartesian3(13, 13, 13),
+              slice: 0.2,
+            });
+
+            clouds.add({
+              position: Cesium.Cartesian3.fromDegrees(-122.71, 45.522, 270),
+              scale: new Cesium.Cartesian2(1700, 300),
+              maximumSize: new Cesium.Cartesian3(50, 12, 15),
+              slice: 0.6,
+            });
+
+            clouds.add({
+              position: Cesium.Cartesian3.fromDegrees(-122.705, 45.525, 250),
+              scale: new Cesium.Cartesian2(230, 110),
+              maximumSize: new Cesium.Cartesian3(15, 13, 15),
+              slice: 0.35,
+            });
+
+            clouds.add({
+              position: Cesium.Cartesian3.fromDegrees(-122.721, 45.53, 220),
+              scale: new Cesium.Cartesian2(1500, 500),
+              maximumSize: new Cesium.Cartesian3(30, 20, 17),
+              slice: 0.45,
             });
           }
-        }
 
-        // manually position clouds in front
-        const scratch = new Cesium.Cartesian3();
-        function createFrontLayerClouds() {
-          clouds.add({
-            position: Cesium.Cartesian3.fromDegrees(-122.666, 45.5126, 97),
-            scale: new Cesium.Cartesian2(400, 150),
-            maximumSize: new Cesium.Cartesian3(25, 12, 15),
-            slice: 0.36,
+          let long,
+            lat,
+            height,
+            scaleX,
+            scaleY,
+            aspectRatio,
+            cloudHeight,
+            depth,
+            slice;
+
+          // randomly generate clouds in a certain area
+          function createRandomClouds(
+            numClouds,
+            startLong,
+            stopLong,
+            startLat,
+            stopLat,
+            minHeight,
+            maxHeight
+          ) {
+            const rangeLong = stopLong - startLong;
+            const rangeLat = stopLat - startLat;
+            for (let i = 0; i < numClouds; i++) {
+              long = startLong + getRandomNumberInRange(0, rangeLong);
+              lat = startLat + getRandomNumberInRange(0, rangeLat);
+              height = getRandomNumberInRange(minHeight, maxHeight);
+              scaleX = getRandomNumberInRange(150, 350);
+              scaleY = scaleX / 2.0 - getRandomNumberInRange(0, scaleX / 4.0);
+              slice = getRandomNumberInRange(0.3, 0.7);
+              depth = getRandomNumberInRange(5, 20);
+              aspectRatio = getRandomNumberInRange(1.5, 2.1);
+              cloudHeight = getRandomNumberInRange(5, 20);
+              clouds.add({
+                position: Cesium.Cartesian3.fromDegrees(long, lat, height),
+                scale: new Cesium.Cartesian2(scaleX, scaleY),
+                maximumSize: new Cesium.Cartesian3(
+                  aspectRatio * cloudHeight,
+                  cloudHeight,
+                  depth
+                ),
+                slice: slice,
+              });
+            }
+          }
+
+          // manually position clouds in front
+          const scratch = new Cesium.Cartesian3();
+          function createFrontLayerClouds() {
+            clouds.add({
+              position: Cesium.Cartesian3.fromDegrees(-122.666, 45.5126, 97),
+              scale: new Cesium.Cartesian2(400, 150),
+              maximumSize: new Cesium.Cartesian3(25, 12, 15),
+              slice: 0.36,
+            });
+
+            clouds.add({
+              position: Cesium.Cartesian3.fromDegrees(-122.6665, 45.5262, 76),
+              scale: new Cesium.Cartesian2(450, 200),
+              maximumSize: new Cesium.Cartesian3(25, 14, 12),
+              slice: 0.3,
+            });
+          }
+
+          createBackLayerClouds();
+          createRandomClouds(8, -122.685, -122.67, 45.51, 45.525, 50, 250);
+          createFrontLayerClouds();
+
+          scene.primitives.add(clouds);
+
+          ///////////////////////////
+          // Create hot air balloons
+          ///////////////////////////
+
+          const start = Cesium.JulianDate.fromDate(new Date(2021, 7, 21, 12));
+          const stop = Cesium.JulianDate.addSeconds(
+            start,
+            90,
+            new Cesium.JulianDate()
+          );
+
+          function computeBalloonFlight(long, lat, height0, height1) {
+            const property = new Cesium.SampledPositionProperty();
+            const time0 = start.clone();
+            const time1 = Cesium.JulianDate.addSeconds(
+              time0,
+              30,
+              new Cesium.JulianDate()
+            );
+            const time2 = Cesium.JulianDate.addSeconds(
+              time1,
+              15,
+              new Cesium.JulianDate()
+            );
+            const time3 = Cesium.JulianDate.addSeconds(
+              time2,
+              30,
+              new Cesium.JulianDate()
+            );
+            const time4 = Cesium.JulianDate.addSeconds(
+              time3,
+              15,
+              new Cesium.JulianDate()
+            );
+
+            const position0 = Cesium.Cartesian3.fromDegrees(long, lat, height0);
+            const position1 = Cesium.Cartesian3.fromDegrees(long, lat, height1);
+
+            property.addSample(time0, position0);
+            property.addSample(time1, position1);
+            property.addSample(time2, position1);
+            property.addSample(time3, position0);
+            property.addSample(time4, position0);
+
+            return property;
+          }
+
+          const balloon0 = viewer.entities.add({
+            position: computeBalloonFlight(-122.661, 45.524, 400, 500),
+            model: {
+              uri: "../../SampleData/models/CesiumBalloon/CesiumBalloon.glb",
+              mininumPixelSize: 128,
+              maximumScale: 20000,
+            },
           });
 
-          clouds.add({
-            position: Cesium.Cartesian3.fromDegrees(-122.6665, 45.5262, 76),
-            scale: new Cesium.Cartesian2(450, 200),
-            maximumSize: new Cesium.Cartesian3(25, 14, 12),
-            slice: 0.3,
+          balloon0.position.setInterpolationOptions({
+            interpolationDegree: 2,
+            interpolationAlgorithm: Cesium.HermitePolynomialApproximation,
           });
-        }
 
-        createBackLayerClouds();
-        createRandomClouds(8, -122.685, -122.67, 45.51, 45.525, 50, 250);
-        createFrontLayerClouds();
+          const balloon1 = viewer.entities.add({
+            position: computeBalloonFlight(-122.662, 45.517, 400, 300),
+            model: {
+              uri: "../../SampleData/models/CesiumBalloon/CesiumBalloon.glb",
+              mininumPixelSize: 128,
+              maximumScale: 20000,
+            },
+          });
 
-        scene.primitives.add(clouds);
+          balloon1.position.setInterpolationOptions({
+            interpolationDegree: 2,
+            interpolationAlgorithm: Cesium.HermitePolynomialApproximation,
+          });
 
-        ///////////////////////////
-        // Create hot air balloons
-        ///////////////////////////
+          viewer.clock.startTime = start.clone();
+          viewer.clock.stopTime = stop.clone();
+          viewer.clock.currentTime = start.clone();
+          viewer.clock.clockRange = Cesium.ClockRange.LOOP_STOP;
+          viewer.clock.multiplier = 1.0;
 
-        const start = Cesium.JulianDate.fromDate(new Date(2021, 7, 21, 12));
-        const stop = Cesium.JulianDate.addSeconds(
-          start,
-          90,
-          new Cesium.JulianDate()
-        );
+          // Fly to Portland
+          scene.camera.flyTo({
+            destination: Cesium.Cartesian3.fromDegrees(-122.6515, 45.5252, 525),
+            orientation: {
+              heading: Cesium.Math.toRadians(-115),
+              pitch: Cesium.Math.toRadians(-12),
+              roll: 0.0,
+            },
+          });
 
-        function computeBalloonFlight(long, lat, height0, height1) {
-          const property = new Cesium.SampledPositionProperty();
-          const time0 = start.clone();
-          const time1 = Cesium.JulianDate.addSeconds(
-            time0,
-            30,
-            new Cesium.JulianDate()
-          );
-          const time2 = Cesium.JulianDate.addSeconds(
-            time1,
-            15,
-            new Cesium.JulianDate()
-          );
-          const time3 = Cesium.JulianDate.addSeconds(
-            time2,
-            30,
-            new Cesium.JulianDate()
-          );
-          const time4 = Cesium.JulianDate.addSeconds(
-            time3,
-            15,
-            new Cesium.JulianDate()
-          );
-
-          const position0 = Cesium.Cartesian3.fromDegrees(long, lat, height0);
-          const position1 = Cesium.Cartesian3.fromDegrees(long, lat, height1);
-
-          property.addSample(time0, position0);
-          property.addSample(time1, position1);
-          property.addSample(time2, position1);
-          property.addSample(time3, position0);
-          property.addSample(time4, position0);
-
-          return property;
-        }
-
-        const balloon0 = viewer.entities.add({
-          position: computeBalloonFlight(-122.661, 45.524, 400, 500),
-          model: {
-            uri: "../../SampleData/models/CesiumBalloon/CesiumBalloon.glb",
-            mininumPixelSize: 128,
-            maximumScale: 20000,
-          },
-        });
-
-        balloon0.position.setInterpolationOptions({
-          interpolationDegree: 2,
-          interpolationAlgorithm: Cesium.HermitePolynomialApproximation,
-        });
-
-        const balloon1 = viewer.entities.add({
-          position: computeBalloonFlight(-122.662, 45.517, 400, 300),
-          model: {
-            uri: "../../SampleData/models/CesiumBalloon/CesiumBalloon.glb",
-            mininumPixelSize: 128,
-            maximumScale: 20000,
-          },
-        });
-
-        balloon1.position.setInterpolationOptions({
-          interpolationDegree: 2,
-          interpolationAlgorithm: Cesium.HermitePolynomialApproximation,
-        });
-
-        viewer.clock.startTime = start.clone();
-        viewer.clock.stopTime = stop.clone();
-        viewer.clock.currentTime = start.clone();
-        viewer.clock.clockRange = Cesium.ClockRange.LOOP_STOP;
-        viewer.clock.multiplier = 1.0;
-
-        // Fly to Portland
-        scene.camera.flyTo({
-          destination: Cesium.Cartesian3.fromDegrees(-122.6515, 45.5252, 525),
-          orientation: {
-            heading: Cesium.Math.toRadians(-115),
-            pitch: Cesium.Math.toRadians(-12),
-            roll: 0.0,
-          },
-        });
-
-        scene.fog.density = 1.15e-4;
-        //Sandcastle_End
+          scene.fog.density = 1.15e-4;
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Clouds.html
+++ b/Apps/Sandcastle/gallery/Clouds.html
@@ -33,7 +33,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
           infoBox: false,
           shouldAnimate: true,
         });

--- a/Apps/Sandcastle/gallery/Custom Shaders Property Textures.html
+++ b/Apps/Sandcastle/gallery/Custom Shaders Property Textures.html
@@ -42,83 +42,83 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
-        const scene = viewer.scene;
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
+          const scene = viewer.scene;
 
-        scene.globe.depthTestAgainstTerrain = false;
+          scene.globe.depthTestAgainstTerrain = false;
 
-        // MAXAR OWT Muscatatuk photogrammetry dataset with property textures
-        // containing horizontal and vertical uncertainty
-        const tileset = viewer.scene.primitives.add(
-          new Cesium.Cesium3DTileset({
-            url: Cesium.IonResource.fromAssetId(905848),
-          })
-        );
+          // MAXAR OWT Muscatatuk photogrammetry dataset with property textures
+          // containing horizontal and vertical uncertainty
+          const tileset = viewer.scene.primitives.add(
+            new Cesium.Cesium3DTileset({
+              url: Cesium.IonResource.fromAssetId(905848),
+            })
+          );
 
-        viewer.zoomTo(tileset);
+          viewer.zoomTo(tileset);
 
-        const shaders = {
-          NO_TEXTURE: undefined,
-          UNCERTAINTY_CE90: new Cesium.CustomShader({
-            fragmentShaderText: `
-              void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
-              {
-                int horizontalUncertainty = fsInput.metadata.r3dm_uncertainty_ce90sum;
-                material.diffuse = vec3(float(horizontalUncertainty) / 255.0);
-              }
-            `,
-          }),
-          UNCERTAINTY_LE90: new Cesium.CustomShader({
-            fragmentShaderText: `
-              void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
-              {
-                int verticalUncertainty = fsInput.metadata.r3dm_uncertainty_le90sum;
-                material.diffuse = vec3(float(verticalUncertainty) / 255.0);
-              }
-            `,
-          }),
-          // combined uncertainty
-          UNCERTAINTY: new Cesium.CustomShader({
-            fragmentShaderText: `
-              void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
-              {
-                int uncertainty = fsInput.metadata.r3dm_uncertainty_ce90sum + fsInput.metadata.r3dm_uncertainty_le90sum;
-                material.diffuse = vec3(float(uncertainty) / 255.0);
-              }
-            `,
-          }),
-        };
+          const shaders = {
+            NO_TEXTURE: undefined,
+            UNCERTAINTY_CE90: new Cesium.CustomShader({
+              fragmentShaderText: `
+        void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
+        {
+          int horizontalUncertainty = fsInput.metadata.r3dm_uncertainty_ce90sum;
+          material.diffuse = vec3(float(horizontalUncertainty) / 255.0);
+        }
+      `,
+            }),
+            UNCERTAINTY_LE90: new Cesium.CustomShader({
+              fragmentShaderText: `
+        void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
+        {
+          int verticalUncertainty = fsInput.metadata.r3dm_uncertainty_le90sum;
+          material.diffuse = vec3(float(verticalUncertainty) / 255.0);
+        }
+      `,
+            }),
+            // combined uncertainty
+            UNCERTAINTY: new Cesium.CustomShader({
+              fragmentShaderText: `
+        void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
+        {
+          int uncertainty = fsInput.metadata.r3dm_uncertainty_ce90sum + fsInput.metadata.r3dm_uncertainty_le90sum;
+          material.diffuse = vec3(float(uncertainty) / 255.0);
+        }
+      `,
+            }),
+          };
 
-        Sandcastle.addToolbarMenu([
-          {
-            text: "Default View",
-            onselect: function () {
-              tileset.customShader = shaders.NO_TEXTURE;
+          Sandcastle.addToolbarMenu([
+            {
+              text: "Default View",
+              onselect: function () {
+                tileset.customShader = shaders.NO_TEXTURE;
+              },
             },
-          },
-          {
-            text: "Horizontal Uncertainty",
-            onselect: function () {
-              tileset.customShader = shaders.UNCERTAINTY_CE90;
+            {
+              text: "Horizontal Uncertainty",
+              onselect: function () {
+                tileset.customShader = shaders.UNCERTAINTY_CE90;
+              },
             },
-          },
-          {
-            text: "Vertical Uncertainty",
-            onselect: function () {
-              tileset.customShader = shaders.UNCERTAINTY_LE90;
+            {
+              text: "Vertical Uncertainty",
+              onselect: function () {
+                tileset.customShader = shaders.UNCERTAINTY_LE90;
+              },
             },
-          },
-          {
-            text: "Combined Uncertainty",
-            onselect: function () {
-              tileset.customShader = shaders.UNCERTAINTY;
+            {
+              text: "Combined Uncertainty",
+              onselect: function () {
+                tileset.customShader = shaders.UNCERTAINTY;
+              },
             },
-          },
-        ]);
-
-        //Sandcastle_End
+          ]);
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Custom Shaders Property Textures.html
+++ b/Apps/Sandcastle/gallery/Custom Shaders Property Textures.html
@@ -42,83 +42,88 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        const viewer = new Cesium.Viewer("cesiumContainer");
+        const scene = viewer.scene;
+
         (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
-          const scene = viewer.scene;
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+          } catch (error) {
+            console.log(error);
+          }
+        })();
 
-          scene.globe.depthTestAgainstTerrain = false;
+        scene.globe.depthTestAgainstTerrain = false;
 
-          // MAXAR OWT Muscatatuk photogrammetry dataset with property textures
-          // containing horizontal and vertical uncertainty
-          const tileset = viewer.scene.primitives.add(
-            new Cesium.Cesium3DTileset({
-              url: Cesium.IonResource.fromAssetId(905848),
-            })
-          );
+        // MAXAR OWT Muscatatuk photogrammetry dataset with property textures
+        // containing horizontal and vertical uncertainty
+        const tileset = viewer.scene.primitives.add(
+          new Cesium.Cesium3DTileset({
+            url: Cesium.IonResource.fromAssetId(905848),
+          })
+        );
 
-          viewer.zoomTo(tileset);
+        viewer.zoomTo(tileset);
 
-          const shaders = {
-            NO_TEXTURE: undefined,
-            UNCERTAINTY_CE90: new Cesium.CustomShader({
-              fragmentShaderText: `
+        const shaders = {
+          NO_TEXTURE: undefined,
+          UNCERTAINTY_CE90: new Cesium.CustomShader({
+            fragmentShaderText: `
         void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
         {
           int horizontalUncertainty = fsInput.metadata.r3dm_uncertainty_ce90sum;
           material.diffuse = vec3(float(horizontalUncertainty) / 255.0);
         }
       `,
-            }),
-            UNCERTAINTY_LE90: new Cesium.CustomShader({
-              fragmentShaderText: `
+          }),
+          UNCERTAINTY_LE90: new Cesium.CustomShader({
+            fragmentShaderText: `
         void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
         {
           int verticalUncertainty = fsInput.metadata.r3dm_uncertainty_le90sum;
           material.diffuse = vec3(float(verticalUncertainty) / 255.0);
         }
       `,
-            }),
-            // combined uncertainty
-            UNCERTAINTY: new Cesium.CustomShader({
-              fragmentShaderText: `
+          }),
+          // combined uncertainty
+          UNCERTAINTY: new Cesium.CustomShader({
+            fragmentShaderText: `
         void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material)
         {
           int uncertainty = fsInput.metadata.r3dm_uncertainty_ce90sum + fsInput.metadata.r3dm_uncertainty_le90sum;
           material.diffuse = vec3(float(uncertainty) / 255.0);
         }
       `,
-            }),
-          };
+          }),
+        };
 
-          Sandcastle.addToolbarMenu([
-            {
-              text: "Default View",
-              onselect: function () {
-                tileset.customShader = shaders.NO_TEXTURE;
-              },
+        Sandcastle.addToolbarMenu([
+          {
+            text: "Default View",
+            onselect: function () {
+              tileset.customShader = shaders.NO_TEXTURE;
             },
-            {
-              text: "Horizontal Uncertainty",
-              onselect: function () {
-                tileset.customShader = shaders.UNCERTAINTY_CE90;
-              },
+          },
+          {
+            text: "Horizontal Uncertainty",
+            onselect: function () {
+              tileset.customShader = shaders.UNCERTAINTY_CE90;
             },
-            {
-              text: "Vertical Uncertainty",
-              onselect: function () {
-                tileset.customShader = shaders.UNCERTAINTY_LE90;
-              },
+          },
+          {
+            text: "Vertical Uncertainty",
+            onselect: function () {
+              tileset.customShader = shaders.UNCERTAINTY_LE90;
             },
-            {
-              text: "Combined Uncertainty",
-              onselect: function () {
-                tileset.customShader = shaders.UNCERTAINTY;
-              },
+          },
+          {
+            text: "Combined Uncertainty",
+            onselect: function () {
+              tileset.customShader = shaders.UNCERTAINTY;
             },
-          ]);
-        })(); //Sandcastle_End
+          },
+        ]);
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Custom Shaders Property Textures.html
+++ b/Apps/Sandcastle/gallery/Custom Shaders Property Textures.html
@@ -43,7 +43,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
         const scene = viewer.scene;
 

--- a/Apps/Sandcastle/gallery/Drawing on Terrain.html
+++ b/Apps/Sandcastle/gallery/Drawing on Terrain.html
@@ -49,7 +49,7 @@
         const viewer = new Cesium.Viewer("cesiumContainer", {
           selectionIndicator: false,
           infoBox: false,
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         if (!viewer.scene.pickPositionSupported) {

--- a/Apps/Sandcastle/gallery/Drawing on Terrain.html
+++ b/Apps/Sandcastle/gallery/Drawing on Terrain.html
@@ -46,134 +46,138 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          selectionIndicator: false,
-          infoBox: false,
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
-
-        if (!viewer.scene.pickPositionSupported) {
-          window.alert("This browser does not support pickPosition.");
-        }
-
-        viewer.cesiumWidget.screenSpaceEventHandler.removeInputAction(
-          Cesium.ScreenSpaceEventType.LEFT_DOUBLE_CLICK
-        );
-        function createPoint(worldPosition) {
-          const point = viewer.entities.add({
-            position: worldPosition,
-            point: {
-              color: Cesium.Color.WHITE,
-              pixelSize: 5,
-              heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-            },
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            selectionIndicator: false,
+            infoBox: false,
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
           });
-          return point;
-        }
-        let drawingMode = "line";
-        function drawShape(positionData) {
-          let shape;
-          if (drawingMode === "line") {
-            shape = viewer.entities.add({
-              polyline: {
-                positions: positionData,
-                clampToGround: true,
-                width: 3,
+
+          if (!viewer.scene.pickPositionSupported) {
+            window.alert("This browser does not support pickPosition.");
+          }
+
+          viewer.cesiumWidget.screenSpaceEventHandler.removeInputAction(
+            Cesium.ScreenSpaceEventType.LEFT_DOUBLE_CLICK
+          );
+          function createPoint(worldPosition) {
+            const point = viewer.entities.add({
+              position: worldPosition,
+              point: {
+                color: Cesium.Color.WHITE,
+                pixelSize: 5,
+                heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
               },
             });
-          } else if (drawingMode === "polygon") {
-            shape = viewer.entities.add({
-              polygon: {
-                hierarchy: positionData,
-                material: new Cesium.ColorMaterialProperty(
-                  Cesium.Color.WHITE.withAlpha(0.7)
-                ),
-              },
-            });
+            return point;
           }
-          return shape;
-        }
-        let activeShapePoints = [];
-        let activeShape;
-        let floatingPoint;
-        const handler = new Cesium.ScreenSpaceEventHandler(viewer.canvas);
-        handler.setInputAction(function (event) {
-          // We use `viewer.scene.pickPosition` here instead of `viewer.camera.pickEllipsoid` so that
-          // we get the correct point when mousing over terrain.
-          const earthPosition = viewer.scene.pickPosition(event.position);
-          // `earthPosition` will be undefined if our mouse is not over the globe.
-          if (Cesium.defined(earthPosition)) {
-            if (activeShapePoints.length === 0) {
-              floatingPoint = createPoint(earthPosition);
-              activeShapePoints.push(earthPosition);
-              const dynamicPositions = new Cesium.CallbackProperty(function () {
-                if (drawingMode === "polygon") {
-                  return new Cesium.PolygonHierarchy(activeShapePoints);
-                }
-                return activeShapePoints;
-              }, false);
-              activeShape = drawShape(dynamicPositions);
+          let drawingMode = "line";
+          function drawShape(positionData) {
+            let shape;
+            if (drawingMode === "line") {
+              shape = viewer.entities.add({
+                polyline: {
+                  positions: positionData,
+                  clampToGround: true,
+                  width: 3,
+                },
+              });
+            } else if (drawingMode === "polygon") {
+              shape = viewer.entities.add({
+                polygon: {
+                  hierarchy: positionData,
+                  material: new Cesium.ColorMaterialProperty(
+                    Cesium.Color.WHITE.withAlpha(0.7)
+                  ),
+                },
+              });
             }
-            activeShapePoints.push(earthPosition);
-            createPoint(earthPosition);
+            return shape;
           }
-        }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
-
-        handler.setInputAction(function (event) {
-          if (Cesium.defined(floatingPoint)) {
-            const newPosition = viewer.scene.pickPosition(event.endPosition);
-            if (Cesium.defined(newPosition)) {
-              floatingPoint.position.setValue(newPosition);
-              activeShapePoints.pop();
-              activeShapePoints.push(newPosition);
-            }
-          }
-        }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-        // Redraw the shape so it's not dynamic and remove the dynamic shape.
-        function terminateShape() {
-          activeShapePoints.pop();
-          drawShape(activeShapePoints);
-          viewer.entities.remove(floatingPoint);
-          viewer.entities.remove(activeShape);
-          floatingPoint = undefined;
-          activeShape = undefined;
-          activeShapePoints = [];
-        }
-        handler.setInputAction(function (event) {
-          terminateShape();
-        }, Cesium.ScreenSpaceEventType.RIGHT_CLICK);
-
-        const options = [
-          {
-            text: "Draw Lines",
-            onselect: function () {
-              if (!Cesium.Entity.supportsPolylinesOnTerrain(viewer.scene)) {
-                window.alert(
-                  "This browser does not support polylines on terrain."
+          let activeShapePoints = [];
+          let activeShape;
+          let floatingPoint;
+          const handler = new Cesium.ScreenSpaceEventHandler(viewer.canvas);
+          handler.setInputAction(function (event) {
+            // We use `viewer.scene.pickPosition` here instead of `viewer.camera.pickEllipsoid` so that
+            // we get the correct point when mousing over terrain.
+            const earthPosition = viewer.scene.pickPosition(event.position);
+            // `earthPosition` will be undefined if our mouse is not over the globe.
+            if (Cesium.defined(earthPosition)) {
+              if (activeShapePoints.length === 0) {
+                floatingPoint = createPoint(earthPosition);
+                activeShapePoints.push(earthPosition);
+                const dynamicPositions = new Cesium.CallbackProperty(
+                  function () {
+                    if (drawingMode === "polygon") {
+                      return new Cesium.PolygonHierarchy(activeShapePoints);
+                    }
+                    return activeShapePoints;
+                  },
+                  false
                 );
+                activeShape = drawShape(dynamicPositions);
               }
+              activeShapePoints.push(earthPosition);
+              createPoint(earthPosition);
+            }
+          }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
 
-              terminateShape();
-              drawingMode = "line";
-            },
-          },
-          {
-            text: "Draw Polygons",
-            onselect: function () {
-              terminateShape();
-              drawingMode = "polygon";
-            },
-          },
-        ];
+          handler.setInputAction(function (event) {
+            if (Cesium.defined(floatingPoint)) {
+              const newPosition = viewer.scene.pickPosition(event.endPosition);
+              if (Cesium.defined(newPosition)) {
+                floatingPoint.position.setValue(newPosition);
+                activeShapePoints.pop();
+                activeShapePoints.push(newPosition);
+              }
+            }
+          }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+          // Redraw the shape so it's not dynamic and remove the dynamic shape.
+          function terminateShape() {
+            activeShapePoints.pop();
+            drawShape(activeShapePoints);
+            viewer.entities.remove(floatingPoint);
+            viewer.entities.remove(activeShape);
+            floatingPoint = undefined;
+            activeShape = undefined;
+            activeShapePoints = [];
+          }
+          handler.setInputAction(function (event) {
+            terminateShape();
+          }, Cesium.ScreenSpaceEventType.RIGHT_CLICK);
 
-        Sandcastle.addToolbarMenu(options);
-        // Zoom in to an area with mountains
-        viewer.camera.lookAt(
-          Cesium.Cartesian3.fromDegrees(-122.2058, 46.1955, 1000.0),
-          new Cesium.Cartesian3(5000.0, 5000.0, 5000.0)
-        );
-        viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-        //Sandcastle_End
+          const options = [
+            {
+              text: "Draw Lines",
+              onselect: function () {
+                if (!Cesium.Entity.supportsPolylinesOnTerrain(viewer.scene)) {
+                  window.alert(
+                    "This browser does not support polylines on terrain."
+                  );
+                }
+
+                terminateShape();
+                drawingMode = "line";
+              },
+            },
+            {
+              text: "Draw Polygons",
+              onselect: function () {
+                terminateShape();
+                drawingMode = "polygon";
+              },
+            },
+          ];
+
+          Sandcastle.addToolbarMenu(options);
+          // Zoom in to an area with mountains
+          viewer.camera.lookAt(
+            Cesium.Cartesian3.fromDegrees(-122.2058, 46.1955, 1000.0),
+            new Cesium.Cartesian3(5000.0, 5000.0, 5000.0)
+          );
+          viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Drawing on Terrain.html
+++ b/Apps/Sandcastle/gallery/Drawing on Terrain.html
@@ -59,10 +59,6 @@
           }
         })();
 
-        if (!viewer.scene.pickPositionSupported) {
-          window.alert("This browser does not support pickPosition.");
-        }
-
         viewer.cesiumWidget.screenSpaceEventHandler.removeInputAction(
           Cesium.ScreenSpaceEventType.LEFT_DOUBLE_CLICK
         );
@@ -105,9 +101,10 @@
         let floatingPoint;
         const handler = new Cesium.ScreenSpaceEventHandler(viewer.canvas);
         handler.setInputAction(function (event) {
-          // We use `viewer.scene.pickPosition` here instead of `viewer.camera.pickEllipsoid` so that
+          // We use `viewer.scene.globe.pick here instead of `viewer.camera.pickEllipsoid` so that
           // we get the correct point when mousing over terrain.
-          const earthPosition = viewer.scene.pickPosition(event.position);
+          const ray = viewer.camera.getPickRay(event.position);
+          const earthPosition = viewer.scene.globe.pick(ray, viewer.scene);
           // `earthPosition` will be undefined if our mouse is not over the globe.
           if (Cesium.defined(earthPosition)) {
             if (activeShapePoints.length === 0) {
@@ -128,7 +125,8 @@
 
         handler.setInputAction(function (event) {
           if (Cesium.defined(floatingPoint)) {
-            const newPosition = viewer.scene.pickPosition(event.endPosition);
+            const ray = viewer.camera.getPickRay(event.endPosition);
+            const newPosition = viewer.scene.globe.pick(ray, viewer.scene);
             if (Cesium.defined(newPosition)) {
               floatingPoint.position.setValue(newPosition);
               activeShapePoints.pop();

--- a/Apps/Sandcastle/gallery/Drawing on Terrain.html
+++ b/Apps/Sandcastle/gallery/Drawing on Terrain.html
@@ -46,138 +46,141 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          selectionIndicator: false,
+          infoBox: false,
+        });
+
         (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            selectionIndicator: false,
-            infoBox: false,
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
-
-          if (!viewer.scene.pickPositionSupported) {
-            window.alert("This browser does not support pickPosition.");
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+          } catch (error) {
+            console.log(error);
           }
+        })();
 
-          viewer.cesiumWidget.screenSpaceEventHandler.removeInputAction(
-            Cesium.ScreenSpaceEventType.LEFT_DOUBLE_CLICK
-          );
-          function createPoint(worldPosition) {
-            const point = viewer.entities.add({
-              position: worldPosition,
-              point: {
-                color: Cesium.Color.WHITE,
-                pixelSize: 5,
-                heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+        if (!viewer.scene.pickPositionSupported) {
+          window.alert("This browser does not support pickPosition.");
+        }
+
+        viewer.cesiumWidget.screenSpaceEventHandler.removeInputAction(
+          Cesium.ScreenSpaceEventType.LEFT_DOUBLE_CLICK
+        );
+        function createPoint(worldPosition) {
+          const point = viewer.entities.add({
+            position: worldPosition,
+            point: {
+              color: Cesium.Color.WHITE,
+              pixelSize: 5,
+              heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+            },
+          });
+          return point;
+        }
+        let drawingMode = "line";
+        function drawShape(positionData) {
+          let shape;
+          if (drawingMode === "line") {
+            shape = viewer.entities.add({
+              polyline: {
+                positions: positionData,
+                clampToGround: true,
+                width: 3,
               },
             });
-            return point;
+          } else if (drawingMode === "polygon") {
+            shape = viewer.entities.add({
+              polygon: {
+                hierarchy: positionData,
+                material: new Cesium.ColorMaterialProperty(
+                  Cesium.Color.WHITE.withAlpha(0.7)
+                ),
+              },
+            });
           }
-          let drawingMode = "line";
-          function drawShape(positionData) {
-            let shape;
-            if (drawingMode === "line") {
-              shape = viewer.entities.add({
-                polyline: {
-                  positions: positionData,
-                  clampToGround: true,
-                  width: 3,
-                },
-              });
-            } else if (drawingMode === "polygon") {
-              shape = viewer.entities.add({
-                polygon: {
-                  hierarchy: positionData,
-                  material: new Cesium.ColorMaterialProperty(
-                    Cesium.Color.WHITE.withAlpha(0.7)
-                  ),
-                },
-              });
-            }
-            return shape;
-          }
-          let activeShapePoints = [];
-          let activeShape;
-          let floatingPoint;
-          const handler = new Cesium.ScreenSpaceEventHandler(viewer.canvas);
-          handler.setInputAction(function (event) {
-            // We use `viewer.scene.pickPosition` here instead of `viewer.camera.pickEllipsoid` so that
-            // we get the correct point when mousing over terrain.
-            const earthPosition = viewer.scene.pickPosition(event.position);
-            // `earthPosition` will be undefined if our mouse is not over the globe.
-            if (Cesium.defined(earthPosition)) {
-              if (activeShapePoints.length === 0) {
-                floatingPoint = createPoint(earthPosition);
-                activeShapePoints.push(earthPosition);
-                const dynamicPositions = new Cesium.CallbackProperty(
-                  function () {
-                    if (drawingMode === "polygon") {
-                      return new Cesium.PolygonHierarchy(activeShapePoints);
-                    }
-                    return activeShapePoints;
-                  },
-                  false
-                );
-                activeShape = drawShape(dynamicPositions);
-              }
+          return shape;
+        }
+        let activeShapePoints = [];
+        let activeShape;
+        let floatingPoint;
+        const handler = new Cesium.ScreenSpaceEventHandler(viewer.canvas);
+        handler.setInputAction(function (event) {
+          // We use `viewer.scene.pickPosition` here instead of `viewer.camera.pickEllipsoid` so that
+          // we get the correct point when mousing over terrain.
+          const earthPosition = viewer.scene.pickPosition(event.position);
+          // `earthPosition` will be undefined if our mouse is not over the globe.
+          if (Cesium.defined(earthPosition)) {
+            if (activeShapePoints.length === 0) {
+              floatingPoint = createPoint(earthPosition);
               activeShapePoints.push(earthPosition);
-              createPoint(earthPosition);
-            }
-          }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
-
-          handler.setInputAction(function (event) {
-            if (Cesium.defined(floatingPoint)) {
-              const newPosition = viewer.scene.pickPosition(event.endPosition);
-              if (Cesium.defined(newPosition)) {
-                floatingPoint.position.setValue(newPosition);
-                activeShapePoints.pop();
-                activeShapePoints.push(newPosition);
-              }
-            }
-          }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-          // Redraw the shape so it's not dynamic and remove the dynamic shape.
-          function terminateShape() {
-            activeShapePoints.pop();
-            drawShape(activeShapePoints);
-            viewer.entities.remove(floatingPoint);
-            viewer.entities.remove(activeShape);
-            floatingPoint = undefined;
-            activeShape = undefined;
-            activeShapePoints = [];
-          }
-          handler.setInputAction(function (event) {
-            terminateShape();
-          }, Cesium.ScreenSpaceEventType.RIGHT_CLICK);
-
-          const options = [
-            {
-              text: "Draw Lines",
-              onselect: function () {
-                if (!Cesium.Entity.supportsPolylinesOnTerrain(viewer.scene)) {
-                  window.alert(
-                    "This browser does not support polylines on terrain."
-                  );
+              const dynamicPositions = new Cesium.CallbackProperty(function () {
+                if (drawingMode === "polygon") {
+                  return new Cesium.PolygonHierarchy(activeShapePoints);
                 }
+                return activeShapePoints;
+              }, false);
+              activeShape = drawShape(dynamicPositions);
+            }
+            activeShapePoints.push(earthPosition);
+            createPoint(earthPosition);
+          }
+        }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
 
-                terminateShape();
-                drawingMode = "line";
-              },
-            },
-            {
-              text: "Draw Polygons",
-              onselect: function () {
-                terminateShape();
-                drawingMode = "polygon";
-              },
-            },
-          ];
+        handler.setInputAction(function (event) {
+          if (Cesium.defined(floatingPoint)) {
+            const newPosition = viewer.scene.pickPosition(event.endPosition);
+            if (Cesium.defined(newPosition)) {
+              floatingPoint.position.setValue(newPosition);
+              activeShapePoints.pop();
+              activeShapePoints.push(newPosition);
+            }
+          }
+        }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+        // Redraw the shape so it's not dynamic and remove the dynamic shape.
+        function terminateShape() {
+          activeShapePoints.pop();
+          drawShape(activeShapePoints);
+          viewer.entities.remove(floatingPoint);
+          viewer.entities.remove(activeShape);
+          floatingPoint = undefined;
+          activeShape = undefined;
+          activeShapePoints = [];
+        }
+        handler.setInputAction(function (event) {
+          terminateShape();
+        }, Cesium.ScreenSpaceEventType.RIGHT_CLICK);
 
-          Sandcastle.addToolbarMenu(options);
-          // Zoom in to an area with mountains
-          viewer.camera.lookAt(
-            Cesium.Cartesian3.fromDegrees(-122.2058, 46.1955, 1000.0),
-            new Cesium.Cartesian3(5000.0, 5000.0, 5000.0)
-          );
-          viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-        })(); //Sandcastle_End
+        const options = [
+          {
+            text: "Draw Lines",
+            onselect: function () {
+              if (!Cesium.Entity.supportsPolylinesOnTerrain(viewer.scene)) {
+                window.alert(
+                  "This browser does not support polylines on terrain."
+                );
+              }
+
+              terminateShape();
+              drawingMode = "line";
+            },
+          },
+          {
+            text: "Draw Polygons",
+            onselect: function () {
+              terminateShape();
+              drawingMode = "polygon";
+            },
+          },
+        ];
+
+        Sandcastle.addToolbarMenu(options);
+        // Zoom in to an area with mountains
+        viewer.camera.lookAt(
+          Cesium.Cartesian3.fromDegrees(-122.2058, 46.1955, 1000.0),
+          new Cesium.Cartesian3(5000.0, 5000.0, 5000.0)
+        );
+        viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Elevation Band Material.html
+++ b/Apps/Sandcastle/gallery/Elevation Band Material.html
@@ -119,7 +119,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain({
+          terrainProvider: Cesium.createWorldTerrainAsync({
             requestVertexNormals: true, //Needed to visualize slope
           }),
         });

--- a/Apps/Sandcastle/gallery/Elevation Band Material.html
+++ b/Apps/Sandcastle/gallery/Elevation Band Material.html
@@ -118,204 +118,220 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync({
-            requestVertexNormals: true, //Needed to visualize slope
-          }),
-        });
-
-        viewer.camera.setView({
-          destination: new Cesium.Cartesian3(
-            290637.5534733206,
-            5637471.593707632,
-            2978256.8126927214
-          ),
-          orientation: {
-            heading: 4.747266966349747,
-            pitch: -0.2206998858596192,
-            roll: 6.280340554587955,
-          },
-        });
-
-        const viewModel = {
-          gradient: false,
-          band1Position: 7000.0,
-          band2Position: 7500.0,
-          band3Position: 8000.0,
-          bandThickness: 100.0,
-          bandTransparency: 0.5,
-          backgroundTransparency: 0.75,
-        };
-
-        Cesium.knockout.track(viewModel);
-        const toolbar = document.getElementById("toolbar");
-        Cesium.knockout.applyBindings(viewModel, toolbar);
-        for (const name in viewModel) {
-          if (viewModel.hasOwnProperty(name)) {
-            Cesium.knockout
-              .getObservable(viewModel, name)
-              .subscribe(updateMaterial);
-          }
-        }
-
-        function updateMaterial() {
-          const gradient = Boolean(viewModel.gradient);
-          const band1Position = Number(viewModel.band1Position);
-          const band2Position = Number(viewModel.band2Position);
-          const band3Position = Number(viewModel.band3Position);
-          const bandThickness = Number(viewModel.bandThickness);
-          const bandTransparency = Number(viewModel.bandTransparency);
-          const backgroundTransparency = Number(
-            viewModel.backgroundTransparency
-          );
-
-          const layers = [];
-          const backgroundLayer = {
-            entries: [
-              {
-                height: 4200.0,
-                color: new Cesium.Color(0.0, 0.0, 0.2, backgroundTransparency),
-              },
-              {
-                height: 8000.0,
-                color: new Cesium.Color(1.0, 1.0, 1.0, backgroundTransparency),
-              },
-              {
-                height: 8500.0,
-                color: new Cesium.Color(1.0, 0.0, 0.0, backgroundTransparency),
-              },
-            ],
-            extendDownwards: true,
-            extendUpwards: true,
-          };
-          layers.push(backgroundLayer);
-
-          const gridStartHeight = 4200.0;
-          const gridEndHeight = 8848.0;
-          const gridCount = 50;
-          for (let i = 0; i < gridCount; i++) {
-            const lerper = i / (gridCount - 1);
-            const heightBelow = Cesium.Math.lerp(
-              gridStartHeight,
-              gridEndHeight,
-              lerper
-            );
-            const heightAbove = heightBelow + 10.0;
-            const alpha =
-              Cesium.Math.lerp(0.2, 0.4, lerper) * backgroundTransparency;
-            layers.push({
-              entries: [
-                {
-                  height: heightBelow,
-                  color: new Cesium.Color(1.0, 1.0, 1.0, alpha),
-                },
-                {
-                  height: heightAbove,
-                  color: new Cesium.Color(1.0, 1.0, 1.0, alpha),
-                },
-              ],
-            });
-          }
-
-          const antialias = Math.min(10.0, bandThickness * 0.1);
-
-          if (!gradient) {
-            const band1 = {
-              entries: [
-                {
-                  height: band1Position - bandThickness * 0.5 - antialias,
-                  color: new Cesium.Color(0.0, 0.0, 1.0, 0.0),
-                },
-                {
-                  height: band1Position - bandThickness * 0.5,
-                  color: new Cesium.Color(0.0, 0.0, 1.0, bandTransparency),
-                },
-                {
-                  height: band1Position + bandThickness * 0.5,
-                  color: new Cesium.Color(0.0, 0.0, 1.0, bandTransparency),
-                },
-                {
-                  height: band1Position + bandThickness * 0.5 + antialias,
-                  color: new Cesium.Color(0.0, 0.0, 1.0, 0.0),
-                },
-              ],
-            };
-
-            const band2 = {
-              entries: [
-                {
-                  height: band2Position - bandThickness * 0.5 - antialias,
-                  color: new Cesium.Color(0.0, 1.0, 0.0, 0.0),
-                },
-                {
-                  height: band2Position - bandThickness * 0.5,
-                  color: new Cesium.Color(0.0, 1.0, 0.0, bandTransparency),
-                },
-                {
-                  height: band2Position + bandThickness * 0.5,
-                  color: new Cesium.Color(0.0, 1.0, 0.0, bandTransparency),
-                },
-                {
-                  height: band2Position + bandThickness * 0.5 + antialias,
-                  color: new Cesium.Color(0.0, 1.0, 0.0, 0.0),
-                },
-              ],
-            };
-
-            const band3 = {
-              entries: [
-                {
-                  height: band3Position - bandThickness * 0.5 - antialias,
-                  color: new Cesium.Color(1.0, 0.0, 0.0, 0.0),
-                },
-                {
-                  height: band3Position - bandThickness * 0.5,
-                  color: new Cesium.Color(1.0, 0.0, 0.0, bandTransparency),
-                },
-                {
-                  height: band3Position + bandThickness * 0.5,
-                  color: new Cesium.Color(1.0, 0.0, 0.0, bandTransparency),
-                },
-                {
-                  height: band3Position + bandThickness * 0.5 + antialias,
-                  color: new Cesium.Color(1.0, 0.0, 0.0, 0.0),
-                },
-              ],
-            };
-
-            layers.push(band1);
-            layers.push(band2);
-            layers.push(band3);
-          } else {
-            const combinedBand = {
-              entries: [
-                {
-                  height: band1Position - bandThickness * 0.5,
-                  color: new Cesium.Color(0.0, 0.0, 1.0, bandTransparency),
-                },
-                {
-                  height: band2Position,
-                  color: new Cesium.Color(0.0, 1.0, 0.0, bandTransparency),
-                },
-                {
-                  height: band3Position + bandThickness * 0.5,
-                  color: new Cesium.Color(1.0, 0.0, 0.0, bandTransparency),
-                },
-              ],
-            };
-
-            layers.push(combinedBand);
-          }
-
-          const material = Cesium.createElevationBandMaterial({
-            scene: viewer.scene,
-            layers: layers,
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync({
+              requestVertexNormals: true, //Needed to visualize slope
+            }),
           });
-          viewer.scene.globe.material = material;
-        }
 
-        updateMaterial();
-        //Sandcastle_End
+          viewer.camera.setView({
+            destination: new Cesium.Cartesian3(
+              290637.5534733206,
+              5637471.593707632,
+              2978256.8126927214
+            ),
+            orientation: {
+              heading: 4.747266966349747,
+              pitch: -0.2206998858596192,
+              roll: 6.280340554587955,
+            },
+          });
+
+          const viewModel = {
+            gradient: false,
+            band1Position: 7000.0,
+            band2Position: 7500.0,
+            band3Position: 8000.0,
+            bandThickness: 100.0,
+            bandTransparency: 0.5,
+            backgroundTransparency: 0.75,
+          };
+
+          Cesium.knockout.track(viewModel);
+          const toolbar = document.getElementById("toolbar");
+          Cesium.knockout.applyBindings(viewModel, toolbar);
+          for (const name in viewModel) {
+            if (viewModel.hasOwnProperty(name)) {
+              Cesium.knockout
+                .getObservable(viewModel, name)
+                .subscribe(updateMaterial);
+            }
+          }
+
+          function updateMaterial() {
+            const gradient = Boolean(viewModel.gradient);
+            const band1Position = Number(viewModel.band1Position);
+            const band2Position = Number(viewModel.band2Position);
+            const band3Position = Number(viewModel.band3Position);
+            const bandThickness = Number(viewModel.bandThickness);
+            const bandTransparency = Number(viewModel.bandTransparency);
+            const backgroundTransparency = Number(
+              viewModel.backgroundTransparency
+            );
+
+            const layers = [];
+            const backgroundLayer = {
+              entries: [
+                {
+                  height: 4200.0,
+                  color: new Cesium.Color(
+                    0.0,
+                    0.0,
+                    0.2,
+                    backgroundTransparency
+                  ),
+                },
+                {
+                  height: 8000.0,
+                  color: new Cesium.Color(
+                    1.0,
+                    1.0,
+                    1.0,
+                    backgroundTransparency
+                  ),
+                },
+                {
+                  height: 8500.0,
+                  color: new Cesium.Color(
+                    1.0,
+                    0.0,
+                    0.0,
+                    backgroundTransparency
+                  ),
+                },
+              ],
+              extendDownwards: true,
+              extendUpwards: true,
+            };
+            layers.push(backgroundLayer);
+
+            const gridStartHeight = 4200.0;
+            const gridEndHeight = 8848.0;
+            const gridCount = 50;
+            for (let i = 0; i < gridCount; i++) {
+              const lerper = i / (gridCount - 1);
+              const heightBelow = Cesium.Math.lerp(
+                gridStartHeight,
+                gridEndHeight,
+                lerper
+              );
+              const heightAbove = heightBelow + 10.0;
+              const alpha =
+                Cesium.Math.lerp(0.2, 0.4, lerper) * backgroundTransparency;
+              layers.push({
+                entries: [
+                  {
+                    height: heightBelow,
+                    color: new Cesium.Color(1.0, 1.0, 1.0, alpha),
+                  },
+                  {
+                    height: heightAbove,
+                    color: new Cesium.Color(1.0, 1.0, 1.0, alpha),
+                  },
+                ],
+              });
+            }
+
+            const antialias = Math.min(10.0, bandThickness * 0.1);
+
+            if (!gradient) {
+              const band1 = {
+                entries: [
+                  {
+                    height: band1Position - bandThickness * 0.5 - antialias,
+                    color: new Cesium.Color(0.0, 0.0, 1.0, 0.0),
+                  },
+                  {
+                    height: band1Position - bandThickness * 0.5,
+                    color: new Cesium.Color(0.0, 0.0, 1.0, bandTransparency),
+                  },
+                  {
+                    height: band1Position + bandThickness * 0.5,
+                    color: new Cesium.Color(0.0, 0.0, 1.0, bandTransparency),
+                  },
+                  {
+                    height: band1Position + bandThickness * 0.5 + antialias,
+                    color: new Cesium.Color(0.0, 0.0, 1.0, 0.0),
+                  },
+                ],
+              };
+
+              const band2 = {
+                entries: [
+                  {
+                    height: band2Position - bandThickness * 0.5 - antialias,
+                    color: new Cesium.Color(0.0, 1.0, 0.0, 0.0),
+                  },
+                  {
+                    height: band2Position - bandThickness * 0.5,
+                    color: new Cesium.Color(0.0, 1.0, 0.0, bandTransparency),
+                  },
+                  {
+                    height: band2Position + bandThickness * 0.5,
+                    color: new Cesium.Color(0.0, 1.0, 0.0, bandTransparency),
+                  },
+                  {
+                    height: band2Position + bandThickness * 0.5 + antialias,
+                    color: new Cesium.Color(0.0, 1.0, 0.0, 0.0),
+                  },
+                ],
+              };
+
+              const band3 = {
+                entries: [
+                  {
+                    height: band3Position - bandThickness * 0.5 - antialias,
+                    color: new Cesium.Color(1.0, 0.0, 0.0, 0.0),
+                  },
+                  {
+                    height: band3Position - bandThickness * 0.5,
+                    color: new Cesium.Color(1.0, 0.0, 0.0, bandTransparency),
+                  },
+                  {
+                    height: band3Position + bandThickness * 0.5,
+                    color: new Cesium.Color(1.0, 0.0, 0.0, bandTransparency),
+                  },
+                  {
+                    height: band3Position + bandThickness * 0.5 + antialias,
+                    color: new Cesium.Color(1.0, 0.0, 0.0, 0.0),
+                  },
+                ],
+              };
+
+              layers.push(band1);
+              layers.push(band2);
+              layers.push(band3);
+            } else {
+              const combinedBand = {
+                entries: [
+                  {
+                    height: band1Position - bandThickness * 0.5,
+                    color: new Cesium.Color(0.0, 0.0, 1.0, bandTransparency),
+                  },
+                  {
+                    height: band2Position,
+                    color: new Cesium.Color(0.0, 1.0, 0.0, bandTransparency),
+                  },
+                  {
+                    height: band3Position + bandThickness * 0.5,
+                    color: new Cesium.Color(1.0, 0.0, 0.0, bandTransparency),
+                  },
+                ],
+              };
+
+              layers.push(combinedBand);
+            }
+
+            const material = Cesium.createElevationBandMaterial({
+              scene: viewer.scene,
+              layers: layers,
+            });
+            viewer.scene.globe.material = material;
+          }
+
+          updateMaterial();
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/FXAA.html
+++ b/Apps/Sandcastle/gallery/FXAA.html
@@ -33,7 +33,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         viewer.scene.camera.setView({

--- a/Apps/Sandcastle/gallery/FXAA.html
+++ b/Apps/Sandcastle/gallery/FXAA.html
@@ -32,36 +32,37 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
 
-        viewer.scene.camera.setView({
-          destination: new Cesium.Cartesian3(
-            1331419.302230775,
-            -4656681.5022043325,
-            4136232.6465900405
-          ),
-          orientation: new Cesium.HeadingPitchRoll(
-            6.032455545102689,
-            -0.056832496140112765,
-            6.282360923090216
-          ),
-          endTransform: Cesium.Matrix4.IDENTITY,
-        });
+          viewer.scene.camera.setView({
+            destination: new Cesium.Cartesian3(
+              1331419.302230775,
+              -4656681.5022043325,
+              4136232.6465900405
+            ),
+            orientation: new Cesium.HeadingPitchRoll(
+              6.032455545102689,
+              -0.056832496140112765,
+              6.282360923090216
+            ),
+            endTransform: Cesium.Matrix4.IDENTITY,
+          });
 
-        viewer.scene.primitives.add(
-          new Cesium.Cesium3DTileset({
-            url: Cesium.IonResource.fromAssetId(75343),
-          })
-        );
+          viewer.scene.primitives.add(
+            new Cesium.Cesium3DTileset({
+              url: Cesium.IonResource.fromAssetId(75343),
+            })
+          );
 
-        viewer.scene.postProcessStages.fxaa.enabled = true;
+          viewer.scene.postProcessStages.fxaa.enabled = true;
 
-        Sandcastle.addToggleButton("FXAA", true, function (checked) {
-          viewer.scene.postProcessStages.fxaa.enabled = checked;
-        });
-        //Sandcastle_End
+          Sandcastle.addToggleButton("FXAA", true, function (checked) {
+            viewer.scene.postProcessStages.fxaa.enabled = checked;
+          });
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/GPX.html
+++ b/Apps/Sandcastle/gallery/GPX.html
@@ -34,110 +34,114 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
 
-        const pinBuilder = new Cesium.PinBuilder();
+          const pinBuilder = new Cesium.PinBuilder();
 
-        Sandcastle.addToolbarMenu(
-          [
-            {
-              text: "Track with Waypoints",
-              onselect: function () {
-                viewer.dataSources
-                  .add(
-                    Cesium.GpxDataSource.load(
-                      "../../SampleData/gpx/lamina.gpx",
-                      {
-                        clampToGround: true,
-                      }
+          Sandcastle.addToolbarMenu(
+            [
+              {
+                text: "Track with Waypoints",
+                onselect: function () {
+                  viewer.dataSources
+                    .add(
+                      Cesium.GpxDataSource.load(
+                        "../../SampleData/gpx/lamina.gpx",
+                        {
+                          clampToGround: true,
+                        }
+                      )
                     )
-                  )
-                  .then(function (dataSource) {
-                    viewer.flyTo(dataSource.entities);
-                  });
+                    .then(function (dataSource) {
+                      viewer.flyTo(dataSource.entities);
+                    });
+                },
               },
-            },
-            {
-              text: "Route",
-              onselect: function () {
-                viewer.dataSources
-                  .add(
-                    Cesium.GpxDataSource.load(
-                      "../../SampleData/gpx/route.gpx",
-                      {
-                        clampToGround: true,
-                      }
+              {
+                text: "Route",
+                onselect: function () {
+                  viewer.dataSources
+                    .add(
+                      Cesium.GpxDataSource.load(
+                        "../../SampleData/gpx/route.gpx",
+                        {
+                          clampToGround: true,
+                        }
+                      )
                     )
-                  )
-                  .then(function (dataSource) {
-                    viewer.flyTo(dataSource.entities);
-                  });
+                    .then(function (dataSource) {
+                      viewer.flyTo(dataSource.entities);
+                    });
+                },
               },
-            },
-            {
-              text: "Waypoints",
-              onselect: function () {
-                viewer.dataSources
-                  .add(
-                    Cesium.GpxDataSource.load("../../SampleData/gpx/wpt.gpx", {
-                      clampToGround: true,
-                    })
-                  )
-                  .then(function (dataSource) {
-                    viewer.flyTo(dataSource.entities);
-                  });
-              },
-            },
-            {
-              text: "Multiple Tracks with Waypoints",
-              onselect: function () {
-                viewer.dataSources
-                  .add(
-                    Cesium.GpxDataSource.load(
-                      "../../SampleData/gpx/complexTrk.gpx",
-                      { clampToGround: true }
+              {
+                text: "Waypoints",
+                onselect: function () {
+                  viewer.dataSources
+                    .add(
+                      Cesium.GpxDataSource.load(
+                        "../../SampleData/gpx/wpt.gpx",
+                        {
+                          clampToGround: true,
+                        }
+                      )
                     )
-                  )
-                  .then(function (dataSource) {
-                    viewer.flyTo(dataSource.entities);
-                  });
+                    .then(function (dataSource) {
+                      viewer.flyTo(dataSource.entities);
+                    });
+                },
               },
-            },
-            {
-              text: "Symbology Options",
-              onselect: function () {
-                viewer.dataSources
-                  .add(
-                    Cesium.GpxDataSource.load(
-                      "../../SampleData/gpx/lamina.gpx",
-                      {
-                        clampToGround: true,
-                        trackColor: Cesium.Color.YELLOW,
-                        waypointImage: pinBuilder.fromMakiIconId(
-                          "bicycle",
-                          Cesium.Color.BLUE,
-                          48
-                        ),
-                      }
+              {
+                text: "Multiple Tracks with Waypoints",
+                onselect: function () {
+                  viewer.dataSources
+                    .add(
+                      Cesium.GpxDataSource.load(
+                        "../../SampleData/gpx/complexTrk.gpx",
+                        { clampToGround: true }
+                      )
                     )
-                  )
-                  .then(function (dataSource) {
-                    viewer.flyTo(dataSource.entities);
-                  });
+                    .then(function (dataSource) {
+                      viewer.flyTo(dataSource.entities);
+                    });
+                },
               },
-            },
-          ],
-          "toolbar"
-        );
+              {
+                text: "Symbology Options",
+                onselect: function () {
+                  viewer.dataSources
+                    .add(
+                      Cesium.GpxDataSource.load(
+                        "../../SampleData/gpx/lamina.gpx",
+                        {
+                          clampToGround: true,
+                          trackColor: Cesium.Color.YELLOW,
+                          waypointImage: pinBuilder.fromMakiIconId(
+                            "bicycle",
+                            Cesium.Color.BLUE,
+                            48
+                          ),
+                        }
+                      )
+                    )
+                    .then(function (dataSource) {
+                      viewer.flyTo(dataSource.entities);
+                    });
+                },
+              },
+            ],
+            "toolbar"
+          );
 
-        Sandcastle.reset = function () {
-          viewer.dataSources.removeAll();
-          viewer.clock.clockRange = Cesium.ClockRange.UNBOUNDED;
-          viewer.clock.clockStep = Cesium.ClockStep.SYSTEM_CLOCK;
-        };
-        //Sandcastle_End
+          Sandcastle.reset = function () {
+            viewer.dataSources.removeAll();
+            viewer.clock.clockRange = Cesium.ClockRange.UNBOUNDED;
+            viewer.clock.clockStep = Cesium.ClockStep.SYSTEM_CLOCK;
+          };
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/GPX.html
+++ b/Apps/Sandcastle/gallery/GPX.html
@@ -35,7 +35,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         const pinBuilder = new Cesium.PinBuilder();

--- a/Apps/Sandcastle/gallery/GPX.html
+++ b/Apps/Sandcastle/gallery/GPX.html
@@ -34,114 +34,116 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        const viewer = new Cesium.Viewer("cesiumContainer");
+
         (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+          } catch (error) {
+            console.log(error);
+          }
+        })();
 
-          const pinBuilder = new Cesium.PinBuilder();
+        const pinBuilder = new Cesium.PinBuilder();
 
-          Sandcastle.addToolbarMenu(
-            [
-              {
-                text: "Track with Waypoints",
-                onselect: function () {
-                  viewer.dataSources
-                    .add(
-                      Cesium.GpxDataSource.load(
-                        "../../SampleData/gpx/lamina.gpx",
-                        {
-                          clampToGround: true,
-                        }
-                      )
+        Sandcastle.addToolbarMenu(
+          [
+            {
+              text: "Track with Waypoints",
+              onselect: function () {
+                viewer.dataSources
+                  .add(
+                    Cesium.GpxDataSource.load(
+                      "../../SampleData/gpx/lamina.gpx",
+                      {
+                        clampToGround: true,
+                      }
                     )
-                    .then(function (dataSource) {
-                      viewer.flyTo(dataSource.entities);
-                    });
-                },
+                  )
+                  .then(function (dataSource) {
+                    viewer.flyTo(dataSource.entities);
+                  });
               },
-              {
-                text: "Route",
-                onselect: function () {
-                  viewer.dataSources
-                    .add(
-                      Cesium.GpxDataSource.load(
-                        "../../SampleData/gpx/route.gpx",
-                        {
-                          clampToGround: true,
-                        }
-                      )
+            },
+            {
+              text: "Route",
+              onselect: function () {
+                viewer.dataSources
+                  .add(
+                    Cesium.GpxDataSource.load(
+                      "../../SampleData/gpx/route.gpx",
+                      {
+                        clampToGround: true,
+                      }
                     )
-                    .then(function (dataSource) {
-                      viewer.flyTo(dataSource.entities);
-                    });
-                },
+                  )
+                  .then(function (dataSource) {
+                    viewer.flyTo(dataSource.entities);
+                  });
               },
-              {
-                text: "Waypoints",
-                onselect: function () {
-                  viewer.dataSources
-                    .add(
-                      Cesium.GpxDataSource.load(
-                        "../../SampleData/gpx/wpt.gpx",
-                        {
-                          clampToGround: true,
-                        }
-                      )
+            },
+            {
+              text: "Waypoints",
+              onselect: function () {
+                viewer.dataSources
+                  .add(
+                    Cesium.GpxDataSource.load("../../SampleData/gpx/wpt.gpx", {
+                      clampToGround: true,
+                    })
+                  )
+                  .then(function (dataSource) {
+                    viewer.flyTo(dataSource.entities);
+                  });
+              },
+            },
+            {
+              text: "Multiple Tracks with Waypoints",
+              onselect: function () {
+                viewer.dataSources
+                  .add(
+                    Cesium.GpxDataSource.load(
+                      "../../SampleData/gpx/complexTrk.gpx",
+                      { clampToGround: true }
                     )
-                    .then(function (dataSource) {
-                      viewer.flyTo(dataSource.entities);
-                    });
-                },
+                  )
+                  .then(function (dataSource) {
+                    viewer.flyTo(dataSource.entities);
+                  });
               },
-              {
-                text: "Multiple Tracks with Waypoints",
-                onselect: function () {
-                  viewer.dataSources
-                    .add(
-                      Cesium.GpxDataSource.load(
-                        "../../SampleData/gpx/complexTrk.gpx",
-                        { clampToGround: true }
-                      )
+            },
+            {
+              text: "Symbology Options",
+              onselect: function () {
+                viewer.dataSources
+                  .add(
+                    Cesium.GpxDataSource.load(
+                      "../../SampleData/gpx/lamina.gpx",
+                      {
+                        clampToGround: true,
+                        trackColor: Cesium.Color.YELLOW,
+                        waypointImage: pinBuilder.fromMakiIconId(
+                          "bicycle",
+                          Cesium.Color.BLUE,
+                          48
+                        ),
+                      }
                     )
-                    .then(function (dataSource) {
-                      viewer.flyTo(dataSource.entities);
-                    });
-                },
+                  )
+                  .then(function (dataSource) {
+                    viewer.flyTo(dataSource.entities);
+                  });
               },
-              {
-                text: "Symbology Options",
-                onselect: function () {
-                  viewer.dataSources
-                    .add(
-                      Cesium.GpxDataSource.load(
-                        "../../SampleData/gpx/lamina.gpx",
-                        {
-                          clampToGround: true,
-                          trackColor: Cesium.Color.YELLOW,
-                          waypointImage: pinBuilder.fromMakiIconId(
-                            "bicycle",
-                            Cesium.Color.BLUE,
-                            48
-                          ),
-                        }
-                      )
-                    )
-                    .then(function (dataSource) {
-                      viewer.flyTo(dataSource.entities);
-                    });
-                },
-              },
-            ],
-            "toolbar"
-          );
+            },
+          ],
+          "toolbar"
+        );
 
-          Sandcastle.reset = function () {
-            viewer.dataSources.removeAll();
-            viewer.clock.clockRange = Cesium.ClockRange.UNBOUNDED;
-            viewer.clock.clockStep = Cesium.ClockStep.SYSTEM_CLOCK;
-          };
-        })(); //Sandcastle_End
+        Sandcastle.reset = function () {
+          viewer.dataSources.removeAll();
+          viewer.clock.clockRange = Cesium.ClockRange.UNBOUNDED;
+          viewer.clock.clockStep = Cesium.ClockStep.SYSTEM_CLOCK;
+        };
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Geometry Height Reference.html
+++ b/Apps/Sandcastle/gallery/Geometry Height Reference.html
@@ -35,143 +35,152 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const cesiumTerrainProvider = await Cesium.createWorldTerrainAsync();
-          const ellipsoidTerrainProvider = new Cesium.EllipsoidTerrainProvider();
+        const ellipsoidTerrainProvider = new Cesium.EllipsoidTerrainProvider();
 
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            baseLayerPicker: false,
-            terrainProvider: cesiumTerrainProvider,
-          });
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          baseLayerPicker: false,
+        });
 
-          // depth test against terrain is required to make the polygons clamp to terrain
-          // instead of showing through it from underground
-          viewer.scene.globe.depthTestAgainstTerrain = true;
+        // depth test against terrain is required to make the polygons clamp to terrain
+        // instead of showing through it from underground
+        viewer.scene.globe.depthTestAgainstTerrain = true;
 
-          Sandcastle.addToolbarMenu([
-            {
-              text: "Polygons",
-              onselect: function () {
-                viewer.entities.removeAll();
-                addPolygons();
-              },
+        Sandcastle.addToolbarMenu([
+          {
+            text: "Polygons",
+            onselect: function () {
+              viewer.entities.removeAll();
+              addPolygons();
             },
-            {
-              text: "Boxes, Cylinders and Ellipsoids",
-              onselect: function () {
-                viewer.entities.removeAll();
-                addGeometries();
-              },
+          },
+          {
+            text: "Boxes, Cylinders and Ellipsoids",
+            onselect: function () {
+              viewer.entities.removeAll();
+              addGeometries();
             },
-          ]);
+          },
+        ]);
 
-          Sandcastle.addToolbarMenu([
-            {
-              text: "Terrain Enabled",
-              onselect: async function () {
-                viewer.scene.terrainProvider = cesiumTerrainProvider;
-              },
-            },
-            {
-              text: "Terrain Disabled",
-              onselect: function () {
-                viewer.scene.terrainProvider = ellipsoidTerrainProvider;
-              },
-            },
-          ]);
-
-          const longitude = 6.950615989890521;
-          const latitude = 45.79546589994886;
-          const delta = 0.001;
-
-          function addGeometry(i, j) {
-            const west = longitude + delta * i;
-            const north = latitude + delta * j + delta;
-
-            const type = Math.floor(Math.random() * 3);
-            if (type === 0) {
-              viewer.entities.add({
-                position: Cesium.Cartesian3.fromDegrees(west, north, 0.0),
-                box: {
-                  dimensions: new Cesium.Cartesian3(40.0, 30.0, 50.0),
-                  material: Cesium.Color.fromRandom({ alpha: 1.0 }),
-                  heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-                },
-              });
-            } else if (type === 1) {
-              viewer.entities.add({
-                position: Cesium.Cartesian3.fromDegrees(west, north, 0.0),
-                cylinder: {
-                  length: 50.0,
-                  topRadius: 20.0,
-                  bottomRadius: 20.0,
-                  material: Cesium.Color.fromRandom({ alpha: 1.0 }),
-                  heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-                },
-              });
-            } else {
-              viewer.entities.add({
-                position: Cesium.Cartesian3.fromDegrees(west, north, 0.0),
-                ellipsoid: {
-                  radii: new Cesium.Cartesian3(20.0, 15.0, 25.0),
-                  material: Cesium.Color.fromRandom({ alpha: 1.0 }),
-                  heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-                },
-              });
-            }
-          }
-
-          function addGeometries() {
-            for (let i = 0; i < 4; i++) {
-              for (let j = 0; j < 4; j++) {
-                addGeometry(i, j);
+        Sandcastle.addToolbarMenu([
+          {
+            text: "Terrain Enabled",
+            onselect: async function () {
+              try {
+                viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+              } catch (error) {
+                console.log(error);
               }
-            }
-            viewer.zoomTo(viewer.entities);
+            },
+          },
+          {
+            text: "Terrain Disabled",
+            onselect: function () {
+              viewer.scene.terrainProvider = ellipsoidTerrainProvider;
+            },
+          },
+        ]);
+
+        (async () => {
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+          } catch (error) {
+            console.log(error);
           }
+        })();
 
-          function addPolygon(i, j) {
-            const west = longitude + delta * i;
-            const east = longitude + delta * i + delta;
+        const longitude = 6.950615989890521;
+        const latitude = 45.79546589994886;
+        const delta = 0.001;
 
-            const south = latitude + delta * j;
-            const north = latitude + delta * j + delta;
-            const a = Cesium.Cartesian3.fromDegrees(west, south);
-            const b = Cesium.Cartesian3.fromDegrees(west, north);
-            const c = Cesium.Cartesian3.fromDegrees(east, north);
-            const d = Cesium.Cartesian3.fromDegrees(east, south);
+        function addGeometry(i, j) {
+          const west = longitude + delta * i;
+          const north = latitude + delta * j + delta;
 
-            const positions = [a, b, c, d];
+          const type = Math.floor(Math.random() * 3);
+          if (type === 0) {
             viewer.entities.add({
-              polygon: {
-                hierarchy: positions,
-                material: Cesium.Color.fromRandom({ alpha: 1 }),
-                height: 40.0,
-                heightReference: Cesium.HeightReference.RELATIVE_TO_GROUND,
-                extrudedHeight: 0.0,
-                extrudedHeightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+              position: Cesium.Cartesian3.fromDegrees(west, north, 0.0),
+              box: {
+                dimensions: new Cesium.Cartesian3(40.0, 30.0, 50.0),
+                material: Cesium.Color.fromRandom({ alpha: 1.0 }),
+                heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+              },
+            });
+          } else if (type === 1) {
+            viewer.entities.add({
+              position: Cesium.Cartesian3.fromDegrees(west, north, 0.0),
+              cylinder: {
+                length: 50.0,
+                topRadius: 20.0,
+                bottomRadius: 20.0,
+                material: Cesium.Color.fromRandom({ alpha: 1.0 }),
+                heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+              },
+            });
+          } else {
+            viewer.entities.add({
+              position: Cesium.Cartesian3.fromDegrees(west, north, 0.0),
+              ellipsoid: {
+                radii: new Cesium.Cartesian3(20.0, 15.0, 25.0),
+                material: Cesium.Color.fromRandom({ alpha: 1.0 }),
+                heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
               },
             });
           }
+        }
 
-          function addPolygons() {
-            // create 16 polygons that are side-by-side
-            for (let i = 0; i < 4; i++) {
-              for (let j = 0; j < 4; j++) {
-                addPolygon(i, j);
-              }
+        function addGeometries() {
+          for (let i = 0; i < 4; i++) {
+            for (let j = 0; j < 4; j++) {
+              addGeometry(i, j);
             }
-            viewer.camera.lookAt(
-              Cesium.Cartesian3.fromDegrees(longitude, latitude, 1500),
-              new Cesium.HeadingPitchRange(
-                -Cesium.Math.PI / 2,
-                -Cesium.Math.PI_OVER_FOUR,
-                2000
-              )
-            );
-            viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
           }
-        })(); //Sandcastle_End
+          viewer.zoomTo(viewer.entities);
+        }
+
+        function addPolygon(i, j) {
+          const west = longitude + delta * i;
+          const east = longitude + delta * i + delta;
+
+          const south = latitude + delta * j;
+          const north = latitude + delta * j + delta;
+          const a = Cesium.Cartesian3.fromDegrees(west, south);
+          const b = Cesium.Cartesian3.fromDegrees(west, north);
+          const c = Cesium.Cartesian3.fromDegrees(east, north);
+          const d = Cesium.Cartesian3.fromDegrees(east, south);
+
+          const positions = [a, b, c, d];
+          viewer.entities.add({
+            polygon: {
+              hierarchy: positions,
+              material: Cesium.Color.fromRandom({ alpha: 1 }),
+              height: 40.0,
+              heightReference: Cesium.HeightReference.RELATIVE_TO_GROUND,
+              extrudedHeight: 0.0,
+              extrudedHeightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+            },
+          });
+        }
+
+        function addPolygons() {
+          // create 16 polygons that are side-by-side
+          for (let i = 0; i < 4; i++) {
+            for (let j = 0; j < 4; j++) {
+              addPolygon(i, j);
+            }
+          }
+          viewer.camera.lookAt(
+            Cesium.Cartesian3.fromDegrees(longitude, latitude, 1500),
+            new Cesium.HeadingPitchRange(
+              -Cesium.Math.PI / 2,
+              -Cesium.Math.PI_OVER_FOUR,
+              2000
+            )
+          );
+          viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+        }
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Geometry Height Reference.html
+++ b/Apps/Sandcastle/gallery/Geometry Height Reference.html
@@ -35,143 +35,143 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const cesiumTerrainProviderPromise = Cesium.createWorldTerrainAsync();
-        const ellipsoidTerrainProvider = new Cesium.EllipsoidTerrainProvider();
+        (async () => {
+          const cesiumTerrainProvider = await Cesium.createWorldTerrainAsync();
+          const ellipsoidTerrainProvider = new Cesium.EllipsoidTerrainProvider();
 
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          baseLayerPicker: false,
-          terrainProvider: cesiumTerrainProviderPromise,
-        });
-
-        // depth test against terrain is required to make the polygons clamp to terrain
-        // instead of showing through it from underground
-        viewer.scene.globe.depthTestAgainstTerrain = true;
-
-        Sandcastle.addToolbarMenu([
-          {
-            text: "Polygons",
-            onselect: function () {
-              viewer.entities.removeAll();
-              addPolygons();
-            },
-          },
-          {
-            text: "Boxes, Cylinders and Ellipsoids",
-            onselect: function () {
-              viewer.entities.removeAll();
-              addGeometries();
-            },
-          },
-        ]);
-
-        Sandcastle.addToolbarMenu([
-          {
-            text: "Terrain Enabled",
-            onselect: async function () {
-              const cesiumTerrainProvider = await cesiumTerrainProviderPromise;
-              viewer.scene.terrainProvider = cesiumTerrainProvider;
-            },
-          },
-          {
-            text: "Terrain Disabled",
-            onselect: function () {
-              viewer.scene.terrainProvider = ellipsoidTerrainProvider;
-            },
-          },
-        ]);
-
-        const longitude = 6.950615989890521;
-        const latitude = 45.79546589994886;
-        const delta = 0.001;
-
-        function addGeometry(i, j) {
-          const west = longitude + delta * i;
-          const north = latitude + delta * j + delta;
-
-          const type = Math.floor(Math.random() * 3);
-          if (type === 0) {
-            viewer.entities.add({
-              position: Cesium.Cartesian3.fromDegrees(west, north, 0.0),
-              box: {
-                dimensions: new Cesium.Cartesian3(40.0, 30.0, 50.0),
-                material: Cesium.Color.fromRandom({ alpha: 1.0 }),
-                heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-              },
-            });
-          } else if (type === 1) {
-            viewer.entities.add({
-              position: Cesium.Cartesian3.fromDegrees(west, north, 0.0),
-              cylinder: {
-                length: 50.0,
-                topRadius: 20.0,
-                bottomRadius: 20.0,
-                material: Cesium.Color.fromRandom({ alpha: 1.0 }),
-                heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-              },
-            });
-          } else {
-            viewer.entities.add({
-              position: Cesium.Cartesian3.fromDegrees(west, north, 0.0),
-              ellipsoid: {
-                radii: new Cesium.Cartesian3(20.0, 15.0, 25.0),
-                material: Cesium.Color.fromRandom({ alpha: 1.0 }),
-                heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-              },
-            });
-          }
-        }
-
-        function addGeometries() {
-          for (let i = 0; i < 4; i++) {
-            for (let j = 0; j < 4; j++) {
-              addGeometry(i, j);
-            }
-          }
-          viewer.zoomTo(viewer.entities);
-        }
-
-        function addPolygon(i, j) {
-          const west = longitude + delta * i;
-          const east = longitude + delta * i + delta;
-
-          const south = latitude + delta * j;
-          const north = latitude + delta * j + delta;
-          const a = Cesium.Cartesian3.fromDegrees(west, south);
-          const b = Cesium.Cartesian3.fromDegrees(west, north);
-          const c = Cesium.Cartesian3.fromDegrees(east, north);
-          const d = Cesium.Cartesian3.fromDegrees(east, south);
-
-          const positions = [a, b, c, d];
-          viewer.entities.add({
-            polygon: {
-              hierarchy: positions,
-              material: Cesium.Color.fromRandom({ alpha: 1 }),
-              height: 40.0,
-              heightReference: Cesium.HeightReference.RELATIVE_TO_GROUND,
-              extrudedHeight: 0.0,
-              extrudedHeightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-            },
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            baseLayerPicker: false,
+            terrainProvider: cesiumTerrainProvider,
           });
-        }
 
-        function addPolygons() {
-          // create 16 polygons that are side-by-side
-          for (let i = 0; i < 4; i++) {
-            for (let j = 0; j < 4; j++) {
-              addPolygon(i, j);
+          // depth test against terrain is required to make the polygons clamp to terrain
+          // instead of showing through it from underground
+          viewer.scene.globe.depthTestAgainstTerrain = true;
+
+          Sandcastle.addToolbarMenu([
+            {
+              text: "Polygons",
+              onselect: function () {
+                viewer.entities.removeAll();
+                addPolygons();
+              },
+            },
+            {
+              text: "Boxes, Cylinders and Ellipsoids",
+              onselect: function () {
+                viewer.entities.removeAll();
+                addGeometries();
+              },
+            },
+          ]);
+
+          Sandcastle.addToolbarMenu([
+            {
+              text: "Terrain Enabled",
+              onselect: async function () {
+                viewer.scene.terrainProvider = cesiumTerrainProvider;
+              },
+            },
+            {
+              text: "Terrain Disabled",
+              onselect: function () {
+                viewer.scene.terrainProvider = ellipsoidTerrainProvider;
+              },
+            },
+          ]);
+
+          const longitude = 6.950615989890521;
+          const latitude = 45.79546589994886;
+          const delta = 0.001;
+
+          function addGeometry(i, j) {
+            const west = longitude + delta * i;
+            const north = latitude + delta * j + delta;
+
+            const type = Math.floor(Math.random() * 3);
+            if (type === 0) {
+              viewer.entities.add({
+                position: Cesium.Cartesian3.fromDegrees(west, north, 0.0),
+                box: {
+                  dimensions: new Cesium.Cartesian3(40.0, 30.0, 50.0),
+                  material: Cesium.Color.fromRandom({ alpha: 1.0 }),
+                  heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+                },
+              });
+            } else if (type === 1) {
+              viewer.entities.add({
+                position: Cesium.Cartesian3.fromDegrees(west, north, 0.0),
+                cylinder: {
+                  length: 50.0,
+                  topRadius: 20.0,
+                  bottomRadius: 20.0,
+                  material: Cesium.Color.fromRandom({ alpha: 1.0 }),
+                  heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+                },
+              });
+            } else {
+              viewer.entities.add({
+                position: Cesium.Cartesian3.fromDegrees(west, north, 0.0),
+                ellipsoid: {
+                  radii: new Cesium.Cartesian3(20.0, 15.0, 25.0),
+                  material: Cesium.Color.fromRandom({ alpha: 1.0 }),
+                  heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+                },
+              });
             }
           }
-          viewer.camera.lookAt(
-            Cesium.Cartesian3.fromDegrees(longitude, latitude, 1500),
-            new Cesium.HeadingPitchRange(
-              -Cesium.Math.PI / 2,
-              -Cesium.Math.PI_OVER_FOUR,
-              2000
-            )
-          );
-          viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-        }
-        //Sandcastle_End
+
+          function addGeometries() {
+            for (let i = 0; i < 4; i++) {
+              for (let j = 0; j < 4; j++) {
+                addGeometry(i, j);
+              }
+            }
+            viewer.zoomTo(viewer.entities);
+          }
+
+          function addPolygon(i, j) {
+            const west = longitude + delta * i;
+            const east = longitude + delta * i + delta;
+
+            const south = latitude + delta * j;
+            const north = latitude + delta * j + delta;
+            const a = Cesium.Cartesian3.fromDegrees(west, south);
+            const b = Cesium.Cartesian3.fromDegrees(west, north);
+            const c = Cesium.Cartesian3.fromDegrees(east, north);
+            const d = Cesium.Cartesian3.fromDegrees(east, south);
+
+            const positions = [a, b, c, d];
+            viewer.entities.add({
+              polygon: {
+                hierarchy: positions,
+                material: Cesium.Color.fromRandom({ alpha: 1 }),
+                height: 40.0,
+                heightReference: Cesium.HeightReference.RELATIVE_TO_GROUND,
+                extrudedHeight: 0.0,
+                extrudedHeightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+              },
+            });
+          }
+
+          function addPolygons() {
+            // create 16 polygons that are side-by-side
+            for (let i = 0; i < 4; i++) {
+              for (let j = 0; j < 4; j++) {
+                addPolygon(i, j);
+              }
+            }
+            viewer.camera.lookAt(
+              Cesium.Cartesian3.fromDegrees(longitude, latitude, 1500),
+              new Cesium.HeadingPitchRange(
+                -Cesium.Math.PI / 2,
+                -Cesium.Math.PI_OVER_FOUR,
+                2000
+              )
+            );
+            viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+          }
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Geometry Height Reference.html
+++ b/Apps/Sandcastle/gallery/Geometry Height Reference.html
@@ -35,12 +35,12 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const cesiumTerrainProvider = Cesium.createWorldTerrain();
+        const cesiumTerrainProviderPromise = Cesium.createWorldTerrainAsync();
         const ellipsoidTerrainProvider = new Cesium.EllipsoidTerrainProvider();
 
         const viewer = new Cesium.Viewer("cesiumContainer", {
           baseLayerPicker: false,
-          terrainProvider: cesiumTerrainProvider,
+          terrainProvider: cesiumTerrainProviderPromise,
         });
 
         // depth test against terrain is required to make the polygons clamp to terrain
@@ -67,7 +67,8 @@
         Sandcastle.addToolbarMenu([
           {
             text: "Terrain Enabled",
-            onselect: function () {
+            onselect: async function () {
+              const cesiumTerrainProvider = await cesiumTerrainProviderPromise;
               viewer.scene.terrainProvider = cesiumTerrainProvider;
             },
           },

--- a/Apps/Sandcastle/gallery/Globe Materials.html
+++ b/Apps/Sandcastle/gallery/Globe Materials.html
@@ -123,7 +123,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain({
+          terrainProvider: Cesium.createWorldTerrainAsync({
             requestVertexNormals: true, //Needed to visualize slope
           }),
         });

--- a/Apps/Sandcastle/gallery/Globe Materials.html
+++ b/Apps/Sandcastle/gallery/Globe Materials.html
@@ -122,303 +122,304 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync({
-            requestVertexNormals: true, //Needed to visualize slope
-          }),
-        });
-        viewer.scene.globe.enableLighting = true;
-
-        function getElevationContourMaterial() {
-          // Creates a composite material with both elevation shading and contour lines
-          return new Cesium.Material({
-            fabric: {
-              type: "ElevationColorContour",
-              materials: {
-                contourMaterial: {
-                  type: "ElevationContour",
-                },
-                elevationRampMaterial: {
-                  type: "ElevationRamp",
-                },
-              },
-              components: {
-                diffuse:
-                  "contourMaterial.alpha == 0.0 ? elevationRampMaterial.diffuse : contourMaterial.diffuse",
-                alpha:
-                  "max(contourMaterial.alpha, elevationRampMaterial.alpha)",
-              },
-            },
-            translucent: false,
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync({
+              requestVertexNormals: true, //Needed to visualize slope
+            }),
           });
-        }
+          viewer.scene.globe.enableLighting = true;
 
-        function getSlopeContourMaterial() {
-          // Creates a composite material with both slope shading and contour lines
-          return new Cesium.Material({
-            fabric: {
-              type: "SlopeColorContour",
-              materials: {
-                contourMaterial: {
-                  type: "ElevationContour",
+          function getElevationContourMaterial() {
+            // Creates a composite material with both elevation shading and contour lines
+            return new Cesium.Material({
+              fabric: {
+                type: "ElevationColorContour",
+                materials: {
+                  contourMaterial: {
+                    type: "ElevationContour",
+                  },
+                  elevationRampMaterial: {
+                    type: "ElevationRamp",
+                  },
                 },
-                slopeRampMaterial: {
-                  type: "SlopeRamp",
-                },
-              },
-              components: {
-                diffuse:
-                  "contourMaterial.alpha == 0.0 ? slopeRampMaterial.diffuse : contourMaterial.diffuse",
-                alpha: "max(contourMaterial.alpha, slopeRampMaterial.alpha)",
-              },
-            },
-            translucent: false,
-          });
-        }
-
-        function getAspectContourMaterial() {
-          // Creates a composite material with both aspect shading and contour lines
-          return new Cesium.Material({
-            fabric: {
-              type: "AspectColorContour",
-              materials: {
-                contourMaterial: {
-                  type: "ElevationContour",
-                },
-                aspectRampMaterial: {
-                  type: "AspectRamp",
+                components: {
+                  diffuse:
+                    "contourMaterial.alpha == 0.0 ? elevationRampMaterial.diffuse : contourMaterial.diffuse",
+                  alpha:
+                    "max(contourMaterial.alpha, elevationRampMaterial.alpha)",
                 },
               },
-              components: {
-                diffuse:
-                  "contourMaterial.alpha == 0.0 ? aspectRampMaterial.diffuse : contourMaterial.diffuse",
-                alpha: "max(contourMaterial.alpha, aspectRampMaterial.alpha)",
-              },
-            },
-            translucent: false,
-          });
-        }
-
-        const elevationRamp = [0.0, 0.045, 0.1, 0.15, 0.37, 0.54, 1.0];
-        const slopeRamp = [0.0, 0.29, 0.5, Math.sqrt(2) / 2, 0.87, 0.91, 1.0];
-        const aspectRamp = [0.0, 0.2, 0.4, 0.6, 0.8, 0.9, 1.0];
-        function getColorRamp(selectedShading) {
-          const ramp = document.createElement("canvas");
-          ramp.width = 100;
-          ramp.height = 1;
-          const ctx = ramp.getContext("2d");
-
-          let values;
-          if (selectedShading === "elevation") {
-            values = elevationRamp;
-          } else if (selectedShading === "slope") {
-            values = slopeRamp;
-          } else if (selectedShading === "aspect") {
-            values = aspectRamp;
+              translucent: false,
+            });
           }
 
-          const grd = ctx.createLinearGradient(0, 0, 100, 0);
-          grd.addColorStop(values[0], "#000000"); //black
-          grd.addColorStop(values[1], "#2747E0"); //blue
-          grd.addColorStop(values[2], "#D33B7D"); //pink
-          grd.addColorStop(values[3], "#D33038"); //red
-          grd.addColorStop(values[4], "#FF9742"); //orange
-          grd.addColorStop(values[5], "#ffd700"); //yellow
-          grd.addColorStop(values[6], "#ffffff"); //white
+          function getSlopeContourMaterial() {
+            // Creates a composite material with both slope shading and contour lines
+            return new Cesium.Material({
+              fabric: {
+                type: "SlopeColorContour",
+                materials: {
+                  contourMaterial: {
+                    type: "ElevationContour",
+                  },
+                  slopeRampMaterial: {
+                    type: "SlopeRamp",
+                  },
+                },
+                components: {
+                  diffuse:
+                    "contourMaterial.alpha == 0.0 ? slopeRampMaterial.diffuse : contourMaterial.diffuse",
+                  alpha: "max(contourMaterial.alpha, slopeRampMaterial.alpha)",
+                },
+              },
+              translucent: false,
+            });
+          }
 
-          ctx.fillStyle = grd;
-          ctx.fillRect(0, 0, 100, 1);
+          function getAspectContourMaterial() {
+            // Creates a composite material with both aspect shading and contour lines
+            return new Cesium.Material({
+              fabric: {
+                type: "AspectColorContour",
+                materials: {
+                  contourMaterial: {
+                    type: "ElevationContour",
+                  },
+                  aspectRampMaterial: {
+                    type: "AspectRamp",
+                  },
+                },
+                components: {
+                  diffuse:
+                    "contourMaterial.alpha == 0.0 ? aspectRampMaterial.diffuse : contourMaterial.diffuse",
+                  alpha: "max(contourMaterial.alpha, aspectRampMaterial.alpha)",
+                },
+              },
+              translucent: false,
+            });
+          }
 
-          return ramp;
-        }
+          const elevationRamp = [0.0, 0.045, 0.1, 0.15, 0.37, 0.54, 1.0];
+          const slopeRamp = [0.0, 0.29, 0.5, Math.sqrt(2) / 2, 0.87, 0.91, 1.0];
+          const aspectRamp = [0.0, 0.2, 0.4, 0.6, 0.8, 0.9, 1.0];
+          function getColorRamp(selectedShading) {
+            const ramp = document.createElement("canvas");
+            ramp.width = 100;
+            ramp.height = 1;
+            const ctx = ramp.getContext("2d");
 
-        const minHeight = -414.0; // approximate dead sea elevation
-        const maxHeight = 8777.0; // approximate everest elevation
-        const contourColor = Cesium.Color.RED.clone();
-        let contourUniforms = {};
-        let shadingUniforms = {};
-
-        // The viewModel tracks the state of our mini application.
-        const viewModel = {
-          enableContour: false,
-          contourSpacing: 150.0,
-          contourWidth: 2.0,
-          selectedShading: "elevation",
-          changeColor: function () {
-            contourUniforms.color = Cesium.Color.fromRandom(
-              { alpha: 1.0 },
-              contourColor
-            );
-          },
-        };
-
-        // Convert the viewModel members into knockout observables.
-        Cesium.knockout.track(viewModel);
-
-        // Bind the viewModel to the DOM elements of the UI that call for it.
-        const toolbar = document.getElementById("toolbar");
-        Cesium.knockout.applyBindings(viewModel, toolbar);
-
-        function updateMaterial() {
-          const hasContour = viewModel.enableContour;
-          const selectedShading = viewModel.selectedShading;
-          const globe = viewer.scene.globe;
-          let material;
-          if (hasContour) {
+            let values;
             if (selectedShading === "elevation") {
-              material = getElevationContourMaterial();
-              shadingUniforms =
-                material.materials.elevationRampMaterial.uniforms;
+              values = elevationRamp;
+            } else if (selectedShading === "slope") {
+              values = slopeRamp;
+            } else if (selectedShading === "aspect") {
+              values = aspectRamp;
+            }
+
+            const grd = ctx.createLinearGradient(0, 0, 100, 0);
+            grd.addColorStop(values[0], "#000000"); //black
+            grd.addColorStop(values[1], "#2747E0"); //blue
+            grd.addColorStop(values[2], "#D33B7D"); //pink
+            grd.addColorStop(values[3], "#D33038"); //red
+            grd.addColorStop(values[4], "#FF9742"); //orange
+            grd.addColorStop(values[5], "#ffd700"); //yellow
+            grd.addColorStop(values[6], "#ffffff"); //white
+
+            ctx.fillStyle = grd;
+            ctx.fillRect(0, 0, 100, 1);
+
+            return ramp;
+          }
+
+          const minHeight = -414.0; // approximate dead sea elevation
+          const maxHeight = 8777.0; // approximate everest elevation
+          const contourColor = Cesium.Color.RED.clone();
+          let contourUniforms = {};
+          let shadingUniforms = {};
+
+          // The viewModel tracks the state of our mini application.
+          const viewModel = {
+            enableContour: false,
+            contourSpacing: 150.0,
+            contourWidth: 2.0,
+            selectedShading: "elevation",
+            changeColor: function () {
+              contourUniforms.color = Cesium.Color.fromRandom(
+                { alpha: 1.0 },
+                contourColor
+              );
+            },
+          };
+
+          // Convert the viewModel members into knockout observables.
+          Cesium.knockout.track(viewModel);
+
+          // Bind the viewModel to the DOM elements of the UI that call for it.
+          const toolbar = document.getElementById("toolbar");
+          Cesium.knockout.applyBindings(viewModel, toolbar);
+
+          function updateMaterial() {
+            const hasContour = viewModel.enableContour;
+            const selectedShading = viewModel.selectedShading;
+            const globe = viewer.scene.globe;
+            let material;
+            if (hasContour) {
+              if (selectedShading === "elevation") {
+                material = getElevationContourMaterial();
+                shadingUniforms =
+                  material.materials.elevationRampMaterial.uniforms;
+                shadingUniforms.minimumHeight = minHeight;
+                shadingUniforms.maximumHeight = maxHeight;
+                contourUniforms = material.materials.contourMaterial.uniforms;
+              } else if (selectedShading === "slope") {
+                material = getSlopeContourMaterial();
+                shadingUniforms = material.materials.slopeRampMaterial.uniforms;
+                contourUniforms = material.materials.contourMaterial.uniforms;
+              } else if (selectedShading === "aspect") {
+                material = getAspectContourMaterial();
+                shadingUniforms =
+                  material.materials.aspectRampMaterial.uniforms;
+                contourUniforms = material.materials.contourMaterial.uniforms;
+              } else {
+                material = Cesium.Material.fromType("ElevationContour");
+                contourUniforms = material.uniforms;
+              }
+              contourUniforms.width = viewModel.contourWidth;
+              contourUniforms.spacing = viewModel.contourSpacing;
+              contourUniforms.color = contourColor;
+            } else if (selectedShading === "elevation") {
+              material = Cesium.Material.fromType("ElevationRamp");
+              shadingUniforms = material.uniforms;
               shadingUniforms.minimumHeight = minHeight;
               shadingUniforms.maximumHeight = maxHeight;
-              contourUniforms = material.materials.contourMaterial.uniforms;
             } else if (selectedShading === "slope") {
-              material = getSlopeContourMaterial();
-              shadingUniforms = material.materials.slopeRampMaterial.uniforms;
-              contourUniforms = material.materials.contourMaterial.uniforms;
+              material = Cesium.Material.fromType("SlopeRamp");
+              shadingUniforms = material.uniforms;
             } else if (selectedShading === "aspect") {
-              material = getAspectContourMaterial();
-              shadingUniforms = material.materials.aspectRampMaterial.uniforms;
-              contourUniforms = material.materials.contourMaterial.uniforms;
-            } else {
-              material = Cesium.Material.fromType("ElevationContour");
-              contourUniforms = material.uniforms;
+              material = Cesium.Material.fromType("AspectRamp");
+              shadingUniforms = material.uniforms;
             }
-            contourUniforms.width = viewModel.contourWidth;
-            contourUniforms.spacing = viewModel.contourSpacing;
-            contourUniforms.color = contourColor;
-          } else if (selectedShading === "elevation") {
-            material = Cesium.Material.fromType("ElevationRamp");
-            shadingUniforms = material.uniforms;
-            shadingUniforms.minimumHeight = minHeight;
-            shadingUniforms.maximumHeight = maxHeight;
-          } else if (selectedShading === "slope") {
-            material = Cesium.Material.fromType("SlopeRamp");
-            shadingUniforms = material.uniforms;
-          } else if (selectedShading === "aspect") {
-            material = Cesium.Material.fromType("AspectRamp");
-            shadingUniforms = material.uniforms;
-          }
-          if (selectedShading !== "none") {
-            shadingUniforms.image = getColorRamp(selectedShading);
+            if (selectedShading !== "none") {
+              shadingUniforms.image = getColorRamp(selectedShading);
+            }
+
+            globe.material = material;
           }
 
-          globe.material = material;
-        }
+          updateMaterial();
 
-        updateMaterial();
+          Cesium.knockout
+            .getObservable(viewModel, "enableContour")
+            .subscribe(function (newValue) {
+              updateMaterial();
+            });
 
-        Cesium.knockout
-          .getObservable(viewModel, "enableContour")
-          .subscribe(function (newValue) {
-            updateMaterial();
-          });
+          Cesium.knockout
+            .getObservable(viewModel, "contourWidth")
+            .subscribe(function (newValue) {
+              contourUniforms.width = parseFloat(newValue);
+            });
 
-        Cesium.knockout
-          .getObservable(viewModel, "contourWidth")
-          .subscribe(function (newValue) {
-            contourUniforms.width = parseFloat(newValue);
-          });
+          Cesium.knockout
+            .getObservable(viewModel, "contourSpacing")
+            .subscribe(function (newValue) {
+              contourUniforms.spacing = parseFloat(newValue);
+            });
 
-        Cesium.knockout
-          .getObservable(viewModel, "contourSpacing")
-          .subscribe(function (newValue) {
-            contourUniforms.spacing = parseFloat(newValue);
-          });
+          Cesium.knockout
+            .getObservable(viewModel, "selectedShading")
+            .subscribe(function (value) {
+              updateMaterial();
+            });
 
-        Cesium.knockout
-          .getObservable(viewModel, "selectedShading")
-          .subscribe(function (value) {
-            updateMaterial();
-          });
-
-        Sandcastle.addToolbarMenu(
-          [
-            {
-              text: "Himalayas",
-              onselect: function () {
-                viewer.camera.setView({
-                  destination: new Cesium.Cartesian3(
-                    322100.7492728492,
-                    5917960.047024654,
-                    3077602.646977297
-                  ),
-                  orientation: {
-                    heading: 5.988151498702285,
-                    pitch: -1.5614542839414822,
-                    roll: 0,
-                  },
-                });
-                viewer.clockViewModel.currentTime = Cesium.JulianDate.fromIso8601(
-                  "2017-09-22T04:00:00Z"
-                );
+          Sandcastle.addToolbarMenu(
+            [
+              {
+                text: "Himalayas",
+                onselect: function () {
+                  viewer.camera.setView({
+                    destination: new Cesium.Cartesian3(
+                      322100.7492728492,
+                      5917960.047024654,
+                      3077602.646977297
+                    ),
+                    orientation: {
+                      heading: 5.988151498702285,
+                      pitch: -1.5614542839414822,
+                      roll: 0,
+                    },
+                  });
+                  viewer.clockViewModel.currentTime = Cesium.JulianDate.fromIso8601(
+                    "2017-09-22T04:00:00Z"
+                  );
+                },
               },
-            },
-            {
-              text: "Half Dome",
-              onselect: function () {
-                viewer.camera.setView({
-                  destination: new Cesium.Cartesian3(
-                    -2495709.521843174,
-                    -4391600.804712465,
-                    3884463.7192916023
-                  ),
-                  orientation: {
-                    heading: 1.7183056487769202,
-                    pitch: -0.06460370548034144,
-                    roll: 0.0079181631783527,
-                  },
-                });
-                viewer.clockViewModel.currentTime = Cesium.JulianDate.fromIso8601(
-                  "2017-09-22T18:00:00Z"
-                );
+              {
+                text: "Half Dome",
+                onselect: function () {
+                  viewer.camera.setView({
+                    destination: new Cesium.Cartesian3(
+                      -2495709.521843174,
+                      -4391600.804712465,
+                      3884463.7192916023
+                    ),
+                    orientation: {
+                      heading: 1.7183056487769202,
+                      pitch: -0.06460370548034144,
+                      roll: 0.0079181631783527,
+                    },
+                  });
+                  viewer.clockViewModel.currentTime = Cesium.JulianDate.fromIso8601(
+                    "2017-09-22T18:00:00Z"
+                  );
+                },
               },
-            },
-            {
-              text: "Vancouver",
-              onselect: function () {
-                viewer.camera.setView({
-                  destination: new Cesium.Cartesian3(
-                    -2301222.367751603,
-                    -3485269.915771613,
-                    4812080.961755785
-                  ),
-                  orientation: {
-                    heading: 0.11355958593902571,
-                    pitch: -0.260011078090858,
-                    roll: 0.00039019018274721873,
-                  },
-                });
-                viewer.clockViewModel.currentTime = Cesium.JulianDate.fromIso8601(
-                  "2017-09-22T18:00:00Z"
-                );
+              {
+                text: "Vancouver",
+                onselect: function () {
+                  viewer.camera.setView({
+                    destination: new Cesium.Cartesian3(
+                      -2301222.367751603,
+                      -3485269.915771613,
+                      4812080.961755785
+                    ),
+                    orientation: {
+                      heading: 0.11355958593902571,
+                      pitch: -0.260011078090858,
+                      roll: 0.00039019018274721873,
+                    },
+                  });
+                  viewer.clockViewModel.currentTime = Cesium.JulianDate.fromIso8601(
+                    "2017-09-22T18:00:00Z"
+                  );
+                },
               },
-            },
-            {
-              text: "Mount Everest",
-              onselect: function () {
-                viewer.camera.setView({
-                  destination: new Cesium.Cartesian3(
-                    282157.6960889096,
-                    5638892.465594703,
-                    2978736.186473513
-                  ),
-                  orientation: {
-                    heading: 4.747266966349747,
-                    pitch: -0.2206998858596192,
-                    roll: 6.280340554587955,
-                  },
-                });
-                viewer.clockViewModel.currentTime = Cesium.JulianDate.fromIso8601(
-                  "2017-09-22T04:00:00Z"
-                );
+              {
+                text: "Mount Everest",
+                onselect: function () {
+                  viewer.camera.setView({
+                    destination: new Cesium.Cartesian3(
+                      282157.6960889096,
+                      5638892.465594703,
+                      2978736.186473513
+                    ),
+                    orientation: {
+                      heading: 4.747266966349747,
+                      pitch: -0.2206998858596192,
+                      roll: 6.280340554587955,
+                    },
+                  });
+                  viewer.clockViewModel.currentTime = Cesium.JulianDate.fromIso8601(
+                    "2017-09-22T04:00:00Z"
+                  );
+                },
               },
-            },
-          ],
-          "zoomButtons"
-        );
-
-        //Sandcastle_End
+            ],
+            "zoomButtons"
+          );
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Globe Materials.html
+++ b/Apps/Sandcastle/gallery/Globe Materials.html
@@ -122,304 +122,308 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        const viewer = new Cesium.Viewer("cesiumContainer");
+        viewer.scene.globe.enableLighting = true;
+
         (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync({
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync({
               requestVertexNormals: true, //Needed to visualize slope
-            }),
-          });
-          viewer.scene.globe.enableLighting = true;
+            });
+          } catch (error) {
+            console.log(error);
+          }
+        })();
 
-          function getElevationContourMaterial() {
-            // Creates a composite material with both elevation shading and contour lines
-            return new Cesium.Material({
-              fabric: {
-                type: "ElevationColorContour",
-                materials: {
-                  contourMaterial: {
-                    type: "ElevationContour",
-                  },
-                  elevationRampMaterial: {
-                    type: "ElevationRamp",
-                  },
+        function getElevationContourMaterial() {
+          // Creates a composite material with both elevation shading and contour lines
+          return new Cesium.Material({
+            fabric: {
+              type: "ElevationColorContour",
+              materials: {
+                contourMaterial: {
+                  type: "ElevationContour",
                 },
-                components: {
-                  diffuse:
-                    "contourMaterial.alpha == 0.0 ? elevationRampMaterial.diffuse : contourMaterial.diffuse",
-                  alpha:
-                    "max(contourMaterial.alpha, elevationRampMaterial.alpha)",
+                elevationRampMaterial: {
+                  type: "ElevationRamp",
                 },
               },
-              translucent: false,
-            });
-          }
-
-          function getSlopeContourMaterial() {
-            // Creates a composite material with both slope shading and contour lines
-            return new Cesium.Material({
-              fabric: {
-                type: "SlopeColorContour",
-                materials: {
-                  contourMaterial: {
-                    type: "ElevationContour",
-                  },
-                  slopeRampMaterial: {
-                    type: "SlopeRamp",
-                  },
-                },
-                components: {
-                  diffuse:
-                    "contourMaterial.alpha == 0.0 ? slopeRampMaterial.diffuse : contourMaterial.diffuse",
-                  alpha: "max(contourMaterial.alpha, slopeRampMaterial.alpha)",
-                },
+              components: {
+                diffuse:
+                  "contourMaterial.alpha == 0.0 ? elevationRampMaterial.diffuse : contourMaterial.diffuse",
+                alpha:
+                  "max(contourMaterial.alpha, elevationRampMaterial.alpha)",
               },
-              translucent: false,
-            });
-          }
-
-          function getAspectContourMaterial() {
-            // Creates a composite material with both aspect shading and contour lines
-            return new Cesium.Material({
-              fabric: {
-                type: "AspectColorContour",
-                materials: {
-                  contourMaterial: {
-                    type: "ElevationContour",
-                  },
-                  aspectRampMaterial: {
-                    type: "AspectRamp",
-                  },
-                },
-                components: {
-                  diffuse:
-                    "contourMaterial.alpha == 0.0 ? aspectRampMaterial.diffuse : contourMaterial.diffuse",
-                  alpha: "max(contourMaterial.alpha, aspectRampMaterial.alpha)",
-                },
-              },
-              translucent: false,
-            });
-          }
-
-          const elevationRamp = [0.0, 0.045, 0.1, 0.15, 0.37, 0.54, 1.0];
-          const slopeRamp = [0.0, 0.29, 0.5, Math.sqrt(2) / 2, 0.87, 0.91, 1.0];
-          const aspectRamp = [0.0, 0.2, 0.4, 0.6, 0.8, 0.9, 1.0];
-          function getColorRamp(selectedShading) {
-            const ramp = document.createElement("canvas");
-            ramp.width = 100;
-            ramp.height = 1;
-            const ctx = ramp.getContext("2d");
-
-            let values;
-            if (selectedShading === "elevation") {
-              values = elevationRamp;
-            } else if (selectedShading === "slope") {
-              values = slopeRamp;
-            } else if (selectedShading === "aspect") {
-              values = aspectRamp;
-            }
-
-            const grd = ctx.createLinearGradient(0, 0, 100, 0);
-            grd.addColorStop(values[0], "#000000"); //black
-            grd.addColorStop(values[1], "#2747E0"); //blue
-            grd.addColorStop(values[2], "#D33B7D"); //pink
-            grd.addColorStop(values[3], "#D33038"); //red
-            grd.addColorStop(values[4], "#FF9742"); //orange
-            grd.addColorStop(values[5], "#ffd700"); //yellow
-            grd.addColorStop(values[6], "#ffffff"); //white
-
-            ctx.fillStyle = grd;
-            ctx.fillRect(0, 0, 100, 1);
-
-            return ramp;
-          }
-
-          const minHeight = -414.0; // approximate dead sea elevation
-          const maxHeight = 8777.0; // approximate everest elevation
-          const contourColor = Cesium.Color.RED.clone();
-          let contourUniforms = {};
-          let shadingUniforms = {};
-
-          // The viewModel tracks the state of our mini application.
-          const viewModel = {
-            enableContour: false,
-            contourSpacing: 150.0,
-            contourWidth: 2.0,
-            selectedShading: "elevation",
-            changeColor: function () {
-              contourUniforms.color = Cesium.Color.fromRandom(
-                { alpha: 1.0 },
-                contourColor
-              );
             },
-          };
+            translucent: false,
+          });
+        }
 
-          // Convert the viewModel members into knockout observables.
-          Cesium.knockout.track(viewModel);
+        function getSlopeContourMaterial() {
+          // Creates a composite material with both slope shading and contour lines
+          return new Cesium.Material({
+            fabric: {
+              type: "SlopeColorContour",
+              materials: {
+                contourMaterial: {
+                  type: "ElevationContour",
+                },
+                slopeRampMaterial: {
+                  type: "SlopeRamp",
+                },
+              },
+              components: {
+                diffuse:
+                  "contourMaterial.alpha == 0.0 ? slopeRampMaterial.diffuse : contourMaterial.diffuse",
+                alpha: "max(contourMaterial.alpha, slopeRampMaterial.alpha)",
+              },
+            },
+            translucent: false,
+          });
+        }
 
-          // Bind the viewModel to the DOM elements of the UI that call for it.
-          const toolbar = document.getElementById("toolbar");
-          Cesium.knockout.applyBindings(viewModel, toolbar);
+        function getAspectContourMaterial() {
+          // Creates a composite material with both aspect shading and contour lines
+          return new Cesium.Material({
+            fabric: {
+              type: "AspectColorContour",
+              materials: {
+                contourMaterial: {
+                  type: "ElevationContour",
+                },
+                aspectRampMaterial: {
+                  type: "AspectRamp",
+                },
+              },
+              components: {
+                diffuse:
+                  "contourMaterial.alpha == 0.0 ? aspectRampMaterial.diffuse : contourMaterial.diffuse",
+                alpha: "max(contourMaterial.alpha, aspectRampMaterial.alpha)",
+              },
+            },
+            translucent: false,
+          });
+        }
 
-          function updateMaterial() {
-            const hasContour = viewModel.enableContour;
-            const selectedShading = viewModel.selectedShading;
-            const globe = viewer.scene.globe;
-            let material;
-            if (hasContour) {
-              if (selectedShading === "elevation") {
-                material = getElevationContourMaterial();
-                shadingUniforms =
-                  material.materials.elevationRampMaterial.uniforms;
-                shadingUniforms.minimumHeight = minHeight;
-                shadingUniforms.maximumHeight = maxHeight;
-                contourUniforms = material.materials.contourMaterial.uniforms;
-              } else if (selectedShading === "slope") {
-                material = getSlopeContourMaterial();
-                shadingUniforms = material.materials.slopeRampMaterial.uniforms;
-                contourUniforms = material.materials.contourMaterial.uniforms;
-              } else if (selectedShading === "aspect") {
-                material = getAspectContourMaterial();
-                shadingUniforms =
-                  material.materials.aspectRampMaterial.uniforms;
-                contourUniforms = material.materials.contourMaterial.uniforms;
-              } else {
-                material = Cesium.Material.fromType("ElevationContour");
-                contourUniforms = material.uniforms;
-              }
-              contourUniforms.width = viewModel.contourWidth;
-              contourUniforms.spacing = viewModel.contourSpacing;
-              contourUniforms.color = contourColor;
-            } else if (selectedShading === "elevation") {
-              material = Cesium.Material.fromType("ElevationRamp");
-              shadingUniforms = material.uniforms;
+        const elevationRamp = [0.0, 0.045, 0.1, 0.15, 0.37, 0.54, 1.0];
+        const slopeRamp = [0.0, 0.29, 0.5, Math.sqrt(2) / 2, 0.87, 0.91, 1.0];
+        const aspectRamp = [0.0, 0.2, 0.4, 0.6, 0.8, 0.9, 1.0];
+        function getColorRamp(selectedShading) {
+          const ramp = document.createElement("canvas");
+          ramp.width = 100;
+          ramp.height = 1;
+          const ctx = ramp.getContext("2d");
+
+          let values;
+          if (selectedShading === "elevation") {
+            values = elevationRamp;
+          } else if (selectedShading === "slope") {
+            values = slopeRamp;
+          } else if (selectedShading === "aspect") {
+            values = aspectRamp;
+          }
+
+          const grd = ctx.createLinearGradient(0, 0, 100, 0);
+          grd.addColorStop(values[0], "#000000"); //black
+          grd.addColorStop(values[1], "#2747E0"); //blue
+          grd.addColorStop(values[2], "#D33B7D"); //pink
+          grd.addColorStop(values[3], "#D33038"); //red
+          grd.addColorStop(values[4], "#FF9742"); //orange
+          grd.addColorStop(values[5], "#ffd700"); //yellow
+          grd.addColorStop(values[6], "#ffffff"); //white
+
+          ctx.fillStyle = grd;
+          ctx.fillRect(0, 0, 100, 1);
+
+          return ramp;
+        }
+
+        const minHeight = -414.0; // approximate dead sea elevation
+        const maxHeight = 8777.0; // approximate everest elevation
+        const contourColor = Cesium.Color.RED.clone();
+        let contourUniforms = {};
+        let shadingUniforms = {};
+
+        // The viewModel tracks the state of our mini application.
+        const viewModel = {
+          enableContour: false,
+          contourSpacing: 150.0,
+          contourWidth: 2.0,
+          selectedShading: "elevation",
+          changeColor: function () {
+            contourUniforms.color = Cesium.Color.fromRandom(
+              { alpha: 1.0 },
+              contourColor
+            );
+          },
+        };
+
+        // Convert the viewModel members into knockout observables.
+        Cesium.knockout.track(viewModel);
+
+        // Bind the viewModel to the DOM elements of the UI that call for it.
+        const toolbar = document.getElementById("toolbar");
+        Cesium.knockout.applyBindings(viewModel, toolbar);
+
+        function updateMaterial() {
+          const hasContour = viewModel.enableContour;
+          const selectedShading = viewModel.selectedShading;
+          const globe = viewer.scene.globe;
+          let material;
+          if (hasContour) {
+            if (selectedShading === "elevation") {
+              material = getElevationContourMaterial();
+              shadingUniforms =
+                material.materials.elevationRampMaterial.uniforms;
               shadingUniforms.minimumHeight = minHeight;
               shadingUniforms.maximumHeight = maxHeight;
+              contourUniforms = material.materials.contourMaterial.uniforms;
             } else if (selectedShading === "slope") {
-              material = Cesium.Material.fromType("SlopeRamp");
-              shadingUniforms = material.uniforms;
+              material = getSlopeContourMaterial();
+              shadingUniforms = material.materials.slopeRampMaterial.uniforms;
+              contourUniforms = material.materials.contourMaterial.uniforms;
             } else if (selectedShading === "aspect") {
-              material = Cesium.Material.fromType("AspectRamp");
-              shadingUniforms = material.uniforms;
+              material = getAspectContourMaterial();
+              shadingUniforms = material.materials.aspectRampMaterial.uniforms;
+              contourUniforms = material.materials.contourMaterial.uniforms;
+            } else {
+              material = Cesium.Material.fromType("ElevationContour");
+              contourUniforms = material.uniforms;
             }
-            if (selectedShading !== "none") {
-              shadingUniforms.image = getColorRamp(selectedShading);
-            }
-
-            globe.material = material;
+            contourUniforms.width = viewModel.contourWidth;
+            contourUniforms.spacing = viewModel.contourSpacing;
+            contourUniforms.color = contourColor;
+          } else if (selectedShading === "elevation") {
+            material = Cesium.Material.fromType("ElevationRamp");
+            shadingUniforms = material.uniforms;
+            shadingUniforms.minimumHeight = minHeight;
+            shadingUniforms.maximumHeight = maxHeight;
+          } else if (selectedShading === "slope") {
+            material = Cesium.Material.fromType("SlopeRamp");
+            shadingUniforms = material.uniforms;
+          } else if (selectedShading === "aspect") {
+            material = Cesium.Material.fromType("AspectRamp");
+            shadingUniforms = material.uniforms;
+          }
+          if (selectedShading !== "none") {
+            shadingUniforms.image = getColorRamp(selectedShading);
           }
 
-          updateMaterial();
+          globe.material = material;
+        }
 
-          Cesium.knockout
-            .getObservable(viewModel, "enableContour")
-            .subscribe(function (newValue) {
-              updateMaterial();
-            });
+        updateMaterial();
 
-          Cesium.knockout
-            .getObservable(viewModel, "contourWidth")
-            .subscribe(function (newValue) {
-              contourUniforms.width = parseFloat(newValue);
-            });
+        Cesium.knockout
+          .getObservable(viewModel, "enableContour")
+          .subscribe(function (newValue) {
+            updateMaterial();
+          });
 
-          Cesium.knockout
-            .getObservable(viewModel, "contourSpacing")
-            .subscribe(function (newValue) {
-              contourUniforms.spacing = parseFloat(newValue);
-            });
+        Cesium.knockout
+          .getObservable(viewModel, "contourWidth")
+          .subscribe(function (newValue) {
+            contourUniforms.width = parseFloat(newValue);
+          });
 
-          Cesium.knockout
-            .getObservable(viewModel, "selectedShading")
-            .subscribe(function (value) {
-              updateMaterial();
-            });
+        Cesium.knockout
+          .getObservable(viewModel, "contourSpacing")
+          .subscribe(function (newValue) {
+            contourUniforms.spacing = parseFloat(newValue);
+          });
 
-          Sandcastle.addToolbarMenu(
-            [
-              {
-                text: "Himalayas",
-                onselect: function () {
-                  viewer.camera.setView({
-                    destination: new Cesium.Cartesian3(
-                      322100.7492728492,
-                      5917960.047024654,
-                      3077602.646977297
-                    ),
-                    orientation: {
-                      heading: 5.988151498702285,
-                      pitch: -1.5614542839414822,
-                      roll: 0,
-                    },
-                  });
-                  viewer.clockViewModel.currentTime = Cesium.JulianDate.fromIso8601(
-                    "2017-09-22T04:00:00Z"
-                  );
-                },
+        Cesium.knockout
+          .getObservable(viewModel, "selectedShading")
+          .subscribe(function (value) {
+            updateMaterial();
+          });
+
+        Sandcastle.addToolbarMenu(
+          [
+            {
+              text: "Himalayas",
+              onselect: function () {
+                viewer.camera.setView({
+                  destination: new Cesium.Cartesian3(
+                    322100.7492728492,
+                    5917960.047024654,
+                    3077602.646977297
+                  ),
+                  orientation: {
+                    heading: 5.988151498702285,
+                    pitch: -1.5614542839414822,
+                    roll: 0,
+                  },
+                });
+                viewer.clockViewModel.currentTime = Cesium.JulianDate.fromIso8601(
+                  "2017-09-22T04:00:00Z"
+                );
               },
-              {
-                text: "Half Dome",
-                onselect: function () {
-                  viewer.camera.setView({
-                    destination: new Cesium.Cartesian3(
-                      -2495709.521843174,
-                      -4391600.804712465,
-                      3884463.7192916023
-                    ),
-                    orientation: {
-                      heading: 1.7183056487769202,
-                      pitch: -0.06460370548034144,
-                      roll: 0.0079181631783527,
-                    },
-                  });
-                  viewer.clockViewModel.currentTime = Cesium.JulianDate.fromIso8601(
-                    "2017-09-22T18:00:00Z"
-                  );
-                },
+            },
+            {
+              text: "Half Dome",
+              onselect: function () {
+                viewer.camera.setView({
+                  destination: new Cesium.Cartesian3(
+                    -2495709.521843174,
+                    -4391600.804712465,
+                    3884463.7192916023
+                  ),
+                  orientation: {
+                    heading: 1.7183056487769202,
+                    pitch: -0.06460370548034144,
+                    roll: 0.0079181631783527,
+                  },
+                });
+                viewer.clockViewModel.currentTime = Cesium.JulianDate.fromIso8601(
+                  "2017-09-22T18:00:00Z"
+                );
               },
-              {
-                text: "Vancouver",
-                onselect: function () {
-                  viewer.camera.setView({
-                    destination: new Cesium.Cartesian3(
-                      -2301222.367751603,
-                      -3485269.915771613,
-                      4812080.961755785
-                    ),
-                    orientation: {
-                      heading: 0.11355958593902571,
-                      pitch: -0.260011078090858,
-                      roll: 0.00039019018274721873,
-                    },
-                  });
-                  viewer.clockViewModel.currentTime = Cesium.JulianDate.fromIso8601(
-                    "2017-09-22T18:00:00Z"
-                  );
-                },
+            },
+            {
+              text: "Vancouver",
+              onselect: function () {
+                viewer.camera.setView({
+                  destination: new Cesium.Cartesian3(
+                    -2301222.367751603,
+                    -3485269.915771613,
+                    4812080.961755785
+                  ),
+                  orientation: {
+                    heading: 0.11355958593902571,
+                    pitch: -0.260011078090858,
+                    roll: 0.00039019018274721873,
+                  },
+                });
+                viewer.clockViewModel.currentTime = Cesium.JulianDate.fromIso8601(
+                  "2017-09-22T18:00:00Z"
+                );
               },
-              {
-                text: "Mount Everest",
-                onselect: function () {
-                  viewer.camera.setView({
-                    destination: new Cesium.Cartesian3(
-                      282157.6960889096,
-                      5638892.465594703,
-                      2978736.186473513
-                    ),
-                    orientation: {
-                      heading: 4.747266966349747,
-                      pitch: -0.2206998858596192,
-                      roll: 6.280340554587955,
-                    },
-                  });
-                  viewer.clockViewModel.currentTime = Cesium.JulianDate.fromIso8601(
-                    "2017-09-22T04:00:00Z"
-                  );
-                },
+            },
+            {
+              text: "Mount Everest",
+              onselect: function () {
+                viewer.camera.setView({
+                  destination: new Cesium.Cartesian3(
+                    282157.6960889096,
+                    5638892.465594703,
+                    2978736.186473513
+                  ),
+                  orientation: {
+                    heading: 4.747266966349747,
+                    pitch: -0.2206998858596192,
+                    roll: 6.280340554587955,
+                  },
+                });
+                viewer.clockViewModel.currentTime = Cesium.JulianDate.fromIso8601(
+                  "2017-09-22T04:00:00Z"
+                );
               },
-            ],
-            "zoomButtons"
-          );
-        })(); //Sandcastle_End
+            },
+          ],
+          "zoomButtons"
+        );
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Globe Translucency.html
+++ b/Apps/Sandcastle/gallery/Globe Translucency.html
@@ -85,7 +85,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         const scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/Globe Translucency.html
+++ b/Apps/Sandcastle/gallery/Globe Translucency.html
@@ -84,224 +84,225 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
 
-        const scene = viewer.scene;
-        const globe = scene.globe;
+          const scene = viewer.scene;
+          const globe = scene.globe;
 
-        scene.screenSpaceCameraController.enableCollisionDetection = false;
-        globe.translucency.frontFaceAlphaByDistance = new Cesium.NearFarScalar(
-          400.0,
-          0.0,
-          800.0,
-          1.0
-        );
+          scene.screenSpaceCameraController.enableCollisionDetection = false;
+          globe.translucency.frontFaceAlphaByDistance = new Cesium.NearFarScalar(
+            400.0,
+            0.0,
+            800.0,
+            1.0
+          );
 
-        const longitude = -3.82518;
-        const latitude = 53.11728;
-        const height = 72.8;
-        const position = Cesium.Cartesian3.fromDegrees(
-          longitude,
-          latitude,
-          height
-        );
-        const url = "../../SampleData/models/ParcLeadMine/ParcLeadMine.glb";
+          const longitude = -3.82518;
+          const latitude = 53.11728;
+          const height = 72.8;
+          const position = Cesium.Cartesian3.fromDegrees(
+            longitude,
+            latitude,
+            height
+          );
+          const url = "../../SampleData/models/ParcLeadMine/ParcLeadMine.glb";
 
-        const entity = viewer.entities.add({
-          name: url,
-          position: position,
-          model: {
-            uri: url,
-          },
-        });
+          const entity = viewer.entities.add({
+            name: url,
+            position: position,
+            model: {
+              uri: url,
+            },
+          });
 
-        const polygon = viewer.entities.add({
-          polygon: {
-            hierarchy: new Cesium.PolygonHierarchy(
-              Cesium.Cartesian3.fromDegreesArrayHeights([
-                -3.8152789692233817,
-                53.124521420389996,
-                200.20779492422255,
-                -3.8165955002619016,
-                53.12555934545405,
-                205.85834336951655,
-                -3.8201599842222054,
-                53.12388420656903,
-                230.82362697069453,
-                -3.8198667503545027,
-                53.123748567587455,
-                225.53297006293968,
-                -3.8190548496317476,
-                53.1240486000822,
-                221.82677773619432,
-                -3.817536387097508,
-                53.122763476393764,
-                209.94136782255705,
-                -3.8169125359199336,
-                53.12285547981627,
-                210.96626238861327,
-                -3.8166873871853073,
-                53.12299403424474,
-                211.02223937734595,
-                -3.8163695374580873,
-                53.12300505277307,
-                211.25942926271824,
-                -3.8162743040622313,
-                53.12281471203994,
-                212.35109129094147,
-                -3.8159746138174193,
-                53.12280996651767,
-                214.87977416348798,
-                -3.815429896849304,
-                53.1236135347983,
-                209.72496223706005,
-              ])
-            ),
-            material: Cesium.Color.LIME.withAlpha(0.5),
-            classificationType: Cesium.ClassificationType.TERRAIN,
-          },
-        });
+          const polygon = viewer.entities.add({
+            polygon: {
+              hierarchy: new Cesium.PolygonHierarchy(
+                Cesium.Cartesian3.fromDegreesArrayHeights([
+                  -3.8152789692233817,
+                  53.124521420389996,
+                  200.20779492422255,
+                  -3.8165955002619016,
+                  53.12555934545405,
+                  205.85834336951655,
+                  -3.8201599842222054,
+                  53.12388420656903,
+                  230.82362697069453,
+                  -3.8198667503545027,
+                  53.123748567587455,
+                  225.53297006293968,
+                  -3.8190548496317476,
+                  53.1240486000822,
+                  221.82677773619432,
+                  -3.817536387097508,
+                  53.122763476393764,
+                  209.94136782255705,
+                  -3.8169125359199336,
+                  53.12285547981627,
+                  210.96626238861327,
+                  -3.8166873871853073,
+                  53.12299403424474,
+                  211.02223937734595,
+                  -3.8163695374580873,
+                  53.12300505277307,
+                  211.25942926271824,
+                  -3.8162743040622313,
+                  53.12281471203994,
+                  212.35109129094147,
+                  -3.8159746138174193,
+                  53.12280996651767,
+                  214.87977416348798,
+                  -3.815429896849304,
+                  53.1236135347983,
+                  209.72496223706005,
+                ])
+              ),
+              material: Cesium.Color.LIME.withAlpha(0.5),
+              classificationType: Cesium.ClassificationType.TERRAIN,
+            },
+          });
 
-        const polyline = viewer.entities.add({
-          polyline: {
-            positions: Cesium.Cartesian3.fromDegreesArrayHeights([
-              -3.8098444201746373,
-              53.1190304262546,
-              286.1875170545701,
-              -3.8099801237370663,
-              53.119539531697576,
-              288.7733884242394,
-              -3.810165716635671,
-              53.11979180761567,
-              290.9294630315179,
-              -3.8104840812145357,
-              53.12007534956926,
-              292.6392327626228,
-              -3.8105689502073554,
-              53.120259094792196,
-              292.222036965774,
-              -3.811027311824268,
-              53.120409248874196,
-              289.61356291617307,
-              -3.811530473295422,
-              53.12063281057782,
-              284.01098712543586,
-              -3.8120545342562693,
-              53.120742539082435,
-              280.118191867836,
-              -3.812444493044727,
-              53.120813289759326,
-              276.0400221387852,
-              -3.812779626711285,
-              53.12094275348024,
-              271.1187399484896,
-              -3.8133560322579494,
-              53.12104757866638,
-              263.3495497598578,
-              -3.8137266493960085,
-              53.12120789867194,
-              257.73878624321316,
-              -3.8142552291751133,
-              53.121321248522904,
-              251.87265828778177,
-              -3.814322603988525,
-              53.12174170121103,
-              238.7082749547689,
-              -3.8143764268391314,
-              53.1219492923309,
-              235.0371831845662,
-              -3.8148156514145786,
-              53.12210819668669,
-              230.2458816627467,
-              -3.8155394721966163,
-              53.1222990144029,
-              221.33319292262706,
-              -3.8159828072920927,
-              53.12203093429715,
-              223.66664756982703,
-              -3.816678108944717,
-              53.12183939425214,
-              223.8787312412801,
-              -3.817466081093726,
-              53.121751900508535,
-              224.52293229989735,
-              -3.8183082996527955,
-              53.12173266141031,
-              223.3672181535749,
-            ]),
-            width: 8,
-            material: new Cesium.PolylineOutlineMaterialProperty({
-              color: Cesium.Color.YELLOW,
-              outlineWidth: 2,
-              outlineColor: Cesium.Color.BLACK,
-            }),
-            clampToGround: true,
-          },
-        });
+          const polyline = viewer.entities.add({
+            polyline: {
+              positions: Cesium.Cartesian3.fromDegreesArrayHeights([
+                -3.8098444201746373,
+                53.1190304262546,
+                286.1875170545701,
+                -3.8099801237370663,
+                53.119539531697576,
+                288.7733884242394,
+                -3.810165716635671,
+                53.11979180761567,
+                290.9294630315179,
+                -3.8104840812145357,
+                53.12007534956926,
+                292.6392327626228,
+                -3.8105689502073554,
+                53.120259094792196,
+                292.222036965774,
+                -3.811027311824268,
+                53.120409248874196,
+                289.61356291617307,
+                -3.811530473295422,
+                53.12063281057782,
+                284.01098712543586,
+                -3.8120545342562693,
+                53.120742539082435,
+                280.118191867836,
+                -3.812444493044727,
+                53.120813289759326,
+                276.0400221387852,
+                -3.812779626711285,
+                53.12094275348024,
+                271.1187399484896,
+                -3.8133560322579494,
+                53.12104757866638,
+                263.3495497598578,
+                -3.8137266493960085,
+                53.12120789867194,
+                257.73878624321316,
+                -3.8142552291751133,
+                53.121321248522904,
+                251.87265828778177,
+                -3.814322603988525,
+                53.12174170121103,
+                238.7082749547689,
+                -3.8143764268391314,
+                53.1219492923309,
+                235.0371831845662,
+                -3.8148156514145786,
+                53.12210819668669,
+                230.2458816627467,
+                -3.8155394721966163,
+                53.1222990144029,
+                221.33319292262706,
+                -3.8159828072920927,
+                53.12203093429715,
+                223.66664756982703,
+                -3.816678108944717,
+                53.12183939425214,
+                223.8787312412801,
+                -3.817466081093726,
+                53.121751900508535,
+                224.52293229989735,
+                -3.8183082996527955,
+                53.12173266141031,
+                223.3672181535749,
+              ]),
+              width: 8,
+              material: new Cesium.PolylineOutlineMaterialProperty({
+                color: Cesium.Color.YELLOW,
+                outlineWidth: 2,
+                outlineColor: Cesium.Color.BLACK,
+              }),
+              clampToGround: true,
+            },
+          });
 
-        const viewModel = {
-          translucencyEnabled: true,
-          fadeByDistance: true,
-          showVectorData: false,
-          alpha: 0.5,
-        };
+          const viewModel = {
+            translucencyEnabled: true,
+            fadeByDistance: true,
+            showVectorData: false,
+            alpha: 0.5,
+          };
 
-        Cesium.knockout.track(viewModel);
-        const toolbar = document.getElementById("toolbar");
-        Cesium.knockout.applyBindings(viewModel, toolbar);
-        for (const name in viewModel) {
-          if (viewModel.hasOwnProperty(name)) {
-            Cesium.knockout.getObservable(viewModel, name).subscribe(update);
+          Cesium.knockout.track(viewModel);
+          const toolbar = document.getElementById("toolbar");
+          Cesium.knockout.applyBindings(viewModel, toolbar);
+          for (const name in viewModel) {
+            if (viewModel.hasOwnProperty(name)) {
+              Cesium.knockout.getObservable(viewModel, name).subscribe(update);
+            }
           }
-        }
 
-        function update() {
-          globe.translucency.enabled = viewModel.translucencyEnabled;
+          function update() {
+            globe.translucency.enabled = viewModel.translucencyEnabled;
 
-          let alpha = Number(viewModel.alpha);
-          alpha = !isNaN(alpha) ? alpha : 1.0;
-          alpha = Cesium.Math.clamp(alpha, 0.0, 1.0);
+            let alpha = Number(viewModel.alpha);
+            alpha = !isNaN(alpha) ? alpha : 1.0;
+            alpha = Cesium.Math.clamp(alpha, 0.0, 1.0);
 
-          globe.translucency.frontFaceAlphaByDistance.nearValue = alpha;
-          globe.translucency.frontFaceAlphaByDistance.farValue = viewModel.fadeByDistance
-            ? 1.0
-            : alpha;
+            globe.translucency.frontFaceAlphaByDistance.nearValue = alpha;
+            globe.translucency.frontFaceAlphaByDistance.farValue = viewModel.fadeByDistance
+              ? 1.0
+              : alpha;
 
-          polygon.show = viewModel.showVectorData;
-          polyline.show = viewModel.showVectorData;
-        }
-        update();
+            polygon.show = viewModel.showVectorData;
+            polyline.show = viewModel.showVectorData;
+          }
+          update();
 
-        viewer.scene.camera.setView({
-          destination: new Cesium.Cartesian3(
-            3826465.9884728403,
-            -254831.02751468265,
-            5081387.671561018
-          ),
-          orientation: new Cesium.HeadingPitchRoll(
-            3.3889450556243754,
-            -0.5276382514771969,
-            6.282272566663295
-          ),
-          endTransform: Cesium.Matrix4.IDENTITY,
-        });
+          viewer.scene.camera.setView({
+            destination: new Cesium.Cartesian3(
+              3826465.9884728403,
+              -254831.02751468265,
+              5081387.671561018
+            ),
+            orientation: new Cesium.HeadingPitchRoll(
+              3.3889450556243754,
+              -0.5276382514771969,
+              6.282272566663295
+            ),
+            endTransform: Cesium.Matrix4.IDENTITY,
+          });
 
-        viewer.scene.camera.flyTo({
-          destination: new Cesium.Cartesian3(
-            3827270.552916987,
-            -255123.18143177085,
-            5079147.091351856
-          ),
-          orientation: new Cesium.HeadingPitchRoll(
-            3.2624281242239963,
-            -0.22213535190506972,
-            6.282786783842843
-          ),
-          duration: 5.0,
-        });
-        //Sandcastle_End
+          viewer.scene.camera.flyTo({
+            destination: new Cesium.Cartesian3(
+              3827270.552916987,
+              -255123.18143177085,
+              5079147.091351856
+            ),
+            orientation: new Cesium.HeadingPitchRoll(
+              3.2624281242239963,
+              -0.22213535190506972,
+              6.282786783842843
+            ),
+            duration: 5.0,
+          });
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Google Earth Enterprise.html
+++ b/Apps/Sandcastle/gallery/Google Earth Enterprise.html
@@ -35,38 +35,38 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        (async () => {
+          try {
+            const geeMetadata = await Cesium.GoogleEarthEnterpriseMetadata.fromUrl(
+              new Cesium.Resource({
+                url: "http://www.earthenterprise.org/3d",
+                proxy: new Cesium.DefaultProxy("/proxy/"),
+              })
+            );
 
-        async function createGoogleEarthEnterpriseProviders() {
-          const geeMetadata = await Cesium.GoogleEarthEnterpriseMetadata.fromUrl(
-            new Cesium.Resource({
-              url: "http://www.earthenterprise.org/3d",
-              proxy: new Cesium.DefaultProxy("/proxy/"),
-            })
-          );
+            const viewer = new Cesium.Viewer("cesiumContainer", {
+              imageryProvider: new Cesium.GoogleEarthEnterpriseImageryProvider({
+                metadata: geeMetadata,
+              }),
+              terrainProvider: Cesium.GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+                geeMetadata
+              ),
+              baseLayerPicker: false,
+            });
 
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            imageryProvider: new Cesium.GoogleEarthEnterpriseImageryProvider({
-              metadata: geeMetadata,
-            }),
-            terrainProvider: Cesium.GoogleEarthEnterpriseTerrainProvider.fromMetadata(
-              geeMetadata
-            ),
-            baseLayerPicker: false,
-          });
-
-          // Start off looking at San Francisco.
-          viewer.camera.setView({
-            destination: Cesium.Rectangle.fromDegrees(
-              -123.0,
-              36.0,
-              -121.7,
-              39.0
-            ),
-          });
-        }
-
-        createGoogleEarthEnterpriseProviders();
-        //Sandcastle_End
+            // Start off looking at San Francisco.
+            viewer.camera.setView({
+              destination: Cesium.Rectangle.fromDegrees(
+                -123.0,
+                36.0,
+                -121.7,
+                39.0
+              ),
+            });
+          } catch (error) {
+            console.log(error);
+          }
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Google Earth Enterprise.html
+++ b/Apps/Sandcastle/gallery/Google Earth Enterprise.html
@@ -35,27 +35,37 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const geeMetadata = new Cesium.GoogleEarthEnterpriseMetadata(
-          new Cesium.Resource({
-            url: "http://www.earthenterprise.org/3d",
-            proxy: new Cesium.DefaultProxy("/proxy/"),
-          })
-        );
 
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          imageryProvider: new Cesium.GoogleEarthEnterpriseImageryProvider({
-            metadata: geeMetadata,
-          }),
-          terrainProvider: new Cesium.GoogleEarthEnterpriseTerrainProvider({
-            metadata: geeMetadata,
-          }),
-          baseLayerPicker: false,
-        });
+        async function createGoogleEarthEnterpriseProviders() {
+          const geeMetadata = await Cesium.GoogleEarthEnterpriseMetadata.fromUrl(
+            new Cesium.Resource({
+              url: "http://www.earthenterprise.org/3d",
+              proxy: new Cesium.DefaultProxy("/proxy/"),
+            })
+          );
 
-        // Start off looking at San Francisco.
-        viewer.camera.setView({
-          destination: Cesium.Rectangle.fromDegrees(-123.0, 36.0, -121.7, 39.0),
-        });
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            imageryProvider: new Cesium.GoogleEarthEnterpriseImageryProvider({
+              metadata: geeMetadata,
+            }),
+            terrainProvider: Cesium.GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+              geeMetadata
+            ),
+            baseLayerPicker: false,
+          });
+
+          // Start off looking at San Francisco.
+          viewer.camera.setView({
+            destination: Cesium.Rectangle.fromDegrees(
+              -123.0,
+              36.0,
+              -121.7,
+              39.0
+            ),
+          });
+        }
+
+        createGoogleEarthEnterpriseProviders();
         //Sandcastle_End
         Sandcastle.finishedLoading();
       };

--- a/Apps/Sandcastle/gallery/High Dynamic Range.html
+++ b/Apps/Sandcastle/gallery/High Dynamic Range.html
@@ -33,7 +33,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
           shadows: true,
         });
 

--- a/Apps/Sandcastle/gallery/High Dynamic Range.html
+++ b/Apps/Sandcastle/gallery/High Dynamic Range.html
@@ -32,62 +32,63 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-          shadows: true,
-        });
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+            shadows: true,
+          });
 
-        if (!viewer.scene.highDynamicRangeSupported) {
-          window.alert("This browser does not support high dynamic range.");
-        }
+          if (!viewer.scene.highDynamicRangeSupported) {
+            window.alert("This browser does not support high dynamic range.");
+          }
 
-        viewer.scene.camera.setView({
-          destination: new Cesium.Cartesian3(
-            -1915097.7863741855,
-            -4783356.851539908,
-            3748887.43462683
-          ),
-          orientation: new Cesium.HeadingPitchRoll(
-            6.166004548388564,
-            -0.043242401760068994,
-            0.002179961955988574
-          ),
-          endTransform: Cesium.Matrix4.IDENTITY,
-        });
+          viewer.scene.camera.setView({
+            destination: new Cesium.Cartesian3(
+              -1915097.7863741855,
+              -4783356.851539908,
+              3748887.43462683
+            ),
+            orientation: new Cesium.HeadingPitchRoll(
+              6.166004548388564,
+              -0.043242401760068994,
+              0.002179961955988574
+            ),
+            endTransform: Cesium.Matrix4.IDENTITY,
+          });
 
-        viewer.scene.highDynamicRange = true;
+          viewer.scene.highDynamicRange = true;
 
-        Sandcastle.addToggleButton("HDR", true, function (checked) {
-          viewer.scene.highDynamicRange = checked;
-        });
+          Sandcastle.addToggleButton("HDR", true, function (checked) {
+            viewer.scene.highDynamicRange = checked;
+          });
 
-        const url =
-          "../../SampleData/models/DracoCompressed/CesiumMilkTruck.gltf";
-        const position = Cesium.Cartesian3.fromRadians(
-          -1.9516424279517286,
-          0.6322397098422969,
-          1239.0006814631095
-        );
-        const heading = Cesium.Math.toRadians(-15.0);
-        const pitch = 0;
-        const roll = 0;
-        const hpr = new Cesium.HeadingPitchRoll(heading, pitch, roll);
-        const orientation = Cesium.Transforms.headingPitchRollQuaternion(
-          position,
-          hpr
-        );
-        const scale = 10.0;
+          const url =
+            "../../SampleData/models/DracoCompressed/CesiumMilkTruck.gltf";
+          const position = Cesium.Cartesian3.fromRadians(
+            -1.9516424279517286,
+            0.6322397098422969,
+            1239.0006814631095
+          );
+          const heading = Cesium.Math.toRadians(-15.0);
+          const pitch = 0;
+          const roll = 0;
+          const hpr = new Cesium.HeadingPitchRoll(heading, pitch, roll);
+          const orientation = Cesium.Transforms.headingPitchRollQuaternion(
+            position,
+            hpr
+          );
+          const scale = 10.0;
 
-        const entity = viewer.entities.add({
-          name: url,
-          position: position,
-          orientation: orientation,
-          model: {
-            uri: url,
-            scale: scale,
-          },
-        });
-        //Sandcastle_End
+          const entity = viewer.entities.add({
+            name: url,
+            position: position,
+            orientation: orientation,
+            model: {
+              uri: url,
+              scale: scale,
+            },
+          });
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/I3S 3D Object Layer.html
+++ b/Apps/Sandcastle/gallery/I3S 3D Object Layer.html
@@ -39,50 +39,54 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: new Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
           animation: false,
           timeline: false,
         });
-        // More datasets to tour can be added here...
-        // The url passed to I3SDataProvider supports loading a single Indexed 3D Scene (I3S) layer (.<host>/SceneServer/layers/<id>) or a collection of scene layers (.<host>/SceneServer) from a SceneServer.
-        const tours = {
-          "San Francisco":
-            "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/SanFrancisco_3DObjects_1_7/SceneServer/layers/0",
-        };
-        // Initialize a terrain provider which provides geoid conversion between gravity related (typically I3S datasets) and ellipsoidal based
-        // height systems (Cesium World Terrain).
-        // If this is not specified, or the URL is invalid no geoid conversion will be applied.
-        // The source data used in this transcoding service was compiled from https://earth-info.nga.mil/#tab_wgs84-data and is based on EGM2008 Gravity Model
-        const geoidService = new Cesium.ArcGISTiledElevationTerrainProvider({
-          url:
-            "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/EGM2008/ImageServer",
-        });
-        // Create i3s and Cesium3DTileset options to pass optional parameters useful for debugging and visualizing
-        const cesium3dTilesetOptions = {
-          skipLevelOfDetail: false,
-          debugShowBoundingVolume: false,
-        };
-        const i3sOptions = {
-          url: tours["San Francisco"],
-          traceFetches: false, // for tracing I3S fetches
-          geoidTiledTerrainProvider: geoidService, // pass the geoid service
-          cesium3dTilesetOptions: cesium3dTilesetOptions, // options for internal Cesium3dTileset
-        };
 
-        // Create I3S data provider
-        const i3sProvider = new Cesium.I3SDataProvider(i3sOptions);
+        async function addI3sProvider() {
+          // More datasets to tour can be added here...
+          // The url passed to I3SDataProvider supports loading a single Indexed 3D Scene (I3S) layer (.<host>/SceneServer/layers/<id>) or a collection of scene layers (.<host>/SceneServer) from a SceneServer.
+          const tours = {
+            "San Francisco":
+              "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/SanFrancisco_3DObjects_1_7/SceneServer/layers/0",
+          };
+          // Initialize a terrain provider which provides geoid conversion between gravity related (typically I3S datasets) and ellipsoidal based
+          // height systems (Cesium World Terrain).
+          // If this is not specified, or the URL is invalid no geoid conversion will be applied.
+          // The source data used in this transcoding service was compiled from https://earth-info.nga.mil/#tab_wgs84-data and is based on EGM2008 Gravity Model
+          const geoidService = await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
+            "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/EGM2008/ImageServer"
+          );
+          // Create i3s and Cesium3DTileset options to pass optional parameters useful for debugging and visualizing
+          const cesium3dTilesetOptions = {
+            skipLevelOfDetail: false,
+            debugShowBoundingVolume: false,
+          };
+          const i3sOptions = {
+            url: tours["San Francisco"],
+            traceFetches: false, // for tracing I3S fetches
+            geoidTiledTerrainProvider: geoidService, // pass the geoid service
+            cesium3dTilesetOptions: cesium3dTilesetOptions, // options for internal Cesium3dTileset
+          };
 
-        // Center camera on I3S once it's loaded
-        i3sProvider.readyPromise.then(function () {
+          // Create I3S data provider
+          const i3sProvider = new Cesium.I3SDataProvider(i3sOptions);
+
+          // Add the i3s layer provider as a primitive data type
+          viewer.scene.primitives.add(i3sProvider);
+
+          // Center camera on I3S once it's loaded
+          await i3sProvider.readyPromise;
           const center = Cesium.Rectangle.center(i3sProvider.extent);
           center.height = 10000.0;
           viewer.camera.setView({
             destination: Cesium.Ellipsoid.WGS84.cartographicToCartesian(center),
           });
-        });
+        }
 
-        // Add the i3s layer provider as a primitive data type
-        viewer.scene.primitives.add(i3sProvider);
+        addI3sProvider();
+
         // An entity object which will hold info about the currently selected feature for infobox display
         const selectedEntity = new Cesium.Entity();
         // Show metadata in the InfoBox.

--- a/Apps/Sandcastle/gallery/I3S 3D Object Layer.html
+++ b/Apps/Sandcastle/gallery/I3S 3D Object Layer.html
@@ -38,13 +38,13 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-          animation: false,
-          timeline: false,
-        });
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+            animation: false,
+            timeline: false,
+          });
 
-        async function addI3sProvider() {
           // More datasets to tour can be added here...
           // The url passed to I3SDataProvider supports loading a single Indexed 3D Scene (I3S) layer (.<host>/SceneServer/layers/<id>) or a collection of scene layers (.<host>/SceneServer) from a SceneServer.
           const tours = {
@@ -83,78 +83,78 @@
           viewer.camera.setView({
             destination: Cesium.Ellipsoid.WGS84.cartographicToCartesian(center),
           });
-        }
 
-        addI3sProvider();
-
-        // An entity object which will hold info about the currently selected feature for infobox display
-        const selectedEntity = new Cesium.Entity();
-        // Show metadata in the InfoBox.
-        viewer.screenSpaceEventHandler.setInputAction(function onLeftClick(
-          movement
-        ) {
-          // Pick a new feature
-          const pickedFeature = viewer.scene.pick(movement.position);
-          if (!Cesium.defined(pickedFeature)) {
-            return;
-          }
-
-          const pickedPosition = viewer.scene.pickPosition(movement.position);
-
-          if (
-            Cesium.defined(pickedFeature.content) &&
-            Cesium.defined(pickedFeature.content.tile.i3sNode)
+          // An entity object which will hold info about the currently selected feature for infobox display
+          const selectedEntity = new Cesium.Entity();
+          // Show metadata in the InfoBox.
+          viewer.screenSpaceEventHandler.setInputAction(function onLeftClick(
+            movement
           ) {
-            const i3sNode = pickedFeature.content.tile.i3sNode;
-            if (pickedPosition) {
-              i3sNode.loadFields().then(function () {
-                let description = "No attributes";
-                let name;
-                console.log(
-                  `pickedPosition(x,y,z) : ${pickedPosition.x}, ${pickedPosition.y}, ${pickedPosition.z}`
-                );
+            // Pick a new feature
+            const pickedFeature = viewer.scene.pick(movement.position);
+            if (!Cesium.defined(pickedFeature)) {
+              return;
+            }
 
-                const fields = i3sNode.getFieldsForPickedPosition(
-                  pickedPosition
-                );
-                if (Object.keys(fields).length > 0) {
-                  description =
-                    '<table class="cesium-infoBox-defaultTable"><tbody>';
-                  for (const fieldName in fields) {
-                    if (i3sNode.fields.hasOwnProperty(fieldName)) {
-                      description += `<tr><th>${fieldName}</th><td>`;
-                      description += `${fields[fieldName]}</td></tr>`;
-                      console.log(`${fieldName}: ${fields[fieldName]}`);
-                      if (!Cesium.defined(name) && isNameProperty(fieldName)) {
-                        name = fields[fieldName];
+            const pickedPosition = viewer.scene.pickPosition(movement.position);
+
+            if (
+              Cesium.defined(pickedFeature.content) &&
+              Cesium.defined(pickedFeature.content.tile.i3sNode)
+            ) {
+              const i3sNode = pickedFeature.content.tile.i3sNode;
+              if (pickedPosition) {
+                i3sNode.loadFields().then(function () {
+                  let description = "No attributes";
+                  let name;
+                  console.log(
+                    `pickedPosition(x,y,z) : ${pickedPosition.x}, ${pickedPosition.y}, ${pickedPosition.z}`
+                  );
+
+                  const fields = i3sNode.getFieldsForPickedPosition(
+                    pickedPosition
+                  );
+                  if (Object.keys(fields).length > 0) {
+                    description =
+                      '<table class="cesium-infoBox-defaultTable"><tbody>';
+                    for (const fieldName in fields) {
+                      if (i3sNode.fields.hasOwnProperty(fieldName)) {
+                        description += `<tr><th>${fieldName}</th><td>`;
+                        description += `${fields[fieldName]}</td></tr>`;
+                        console.log(`${fieldName}: ${fields[fieldName]}`);
+                        if (
+                          !Cesium.defined(name) &&
+                          isNameProperty(fieldName)
+                        ) {
+                          name = fields[fieldName];
+                        }
                       }
                     }
+                    description += `</tbody></table>`;
                   }
-                  description += `</tbody></table>`;
-                }
-                if (!Cesium.defined(name)) {
-                  name = "unknown";
-                }
-                selectedEntity.name = name;
-                selectedEntity.description = description;
-                viewer.selectedEntity = selectedEntity;
-              });
+                  if (!Cesium.defined(name)) {
+                    name = "unknown";
+                  }
+                  selectedEntity.name = name;
+                  selectedEntity.description = description;
+                  viewer.selectedEntity = selectedEntity;
+                });
+              }
             }
-          }
-        },
-        Cesium.ScreenSpaceEventType.LEFT_CLICK);
+          },
+          Cesium.ScreenSpaceEventType.LEFT_CLICK);
 
-        function isNameProperty(propertyName) {
-          const name = propertyName.toLowerCase();
-          if (
-            name.localeCompare("name") === 0 ||
-            name.localeCompare("objname") === 0
-          ) {
-            return true;
+          function isNameProperty(propertyName) {
+            const name = propertyName.toLowerCase();
+            if (
+              name.localeCompare("name") === 0 ||
+              name.localeCompare("objname") === 0
+            ) {
+              return true;
+            }
+            return false;
           }
-          return false;
-        }
-        //Sandcastle_End
+        })(); //Sandcastle_End
         if (typeof Cesium !== "undefined") {
           window.startupCalled = true;
           window.startup(Cesium);

--- a/Apps/Sandcastle/gallery/I3S Feature Picking.html
+++ b/Apps/Sandcastle/gallery/I3S Feature Picking.html
@@ -39,50 +39,54 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: new Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
           animation: false,
           timeline: false,
         });
-        // More datasets to tour can be added here...
-        // The url passed to I3SDataProvider supports loading a single Indexed 3D Scene (I3S) layer (.<host>/SceneServer/layers/<id>) or a collection of scene layers (.<host>/SceneServer) from a SceneServer.
-        const tours = {
-          "New York":
-            "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/NYC_Attributed_v17/SceneServer",
-        };
-        // Initialize a terrain provider which provides geoid conversion between gravity related (typically I3S datasets) and ellipsoidal based
-        // height systems (Cesium World Terrain).
-        // If this is not specified, or the URL is invalid no geoid conversion will be applied.
-        // The source data used in this transcoding service was compiled from https://earth-info.nga.mil/#tab_wgs84-data and is based on EGM2008 Gravity Model
-        const geoidService = new Cesium.ArcGISTiledElevationTerrainProvider({
-          url:
-            "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/EGM2008/ImageServer",
-        });
-        // Create i3s and Cesium3DTileset options to pass optional parameters useful for debugging and visualizing
-        const cesium3dTilesetOptions = {
-          skipLevelOfDetail: false,
-          debugShowBoundingVolume: false,
-        };
-        const i3sOptions = {
-          url: tours["New York"],
-          traceFetches: false, // for tracing I3S fetches
-          geoidTiledTerrainProvider: geoidService, // pass the geoid service
-          cesium3dTilesetOptions: cesium3dTilesetOptions, // options for internal Cesium3dTileset
-        };
 
-        // Create I3S data provider
-        const i3sProvider = new Cesium.I3SDataProvider(i3sOptions);
+        async function addI3sProvider() {
+          // More datasets to tour can be added here...
+          // The url passed to I3SDataProvider supports loading a single Indexed 3D Scene (I3S) layer (.<host>/SceneServer/layers/<id>) or a collection of scene layers (.<host>/SceneServer) from a SceneServer.
+          const tours = {
+            "New York":
+              "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/NYC_Attributed_v17/SceneServer",
+          };
+          // Initialize a terrain provider which provides geoid conversion between gravity related (typically I3S datasets) and ellipsoidal based
+          // height systems (Cesium World Terrain).
+          // If this is not specified, or the URL is invalid no geoid conversion will be applied.
+          // The source data used in this transcoding service was compiled from https://earth-info.nga.mil/#tab_wgs84-data and is based on EGM2008 Gravity Model
+          const geoidService = await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
+            "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/EGM2008/ImageServer"
+          );
+          // Create i3s and Cesium3DTileset options to pass optional parameters useful for debugging and visualizing
+          const cesium3dTilesetOptions = {
+            skipLevelOfDetail: false,
+            debugShowBoundingVolume: false,
+          };
+          const i3sOptions = {
+            url: tours["New York"],
+            traceFetches: false, // for tracing I3S fetches
+            geoidTiledTerrainProvider: geoidService, // pass the geoid service
+            cesium3dTilesetOptions: cesium3dTilesetOptions, // options for internal Cesium3dTileset
+          };
 
-        // Center camera on I3S once it's loaded
-        i3sProvider.readyPromise.then(function () {
+          // Create I3S data provider
+          const i3sProvider = new Cesium.I3SDataProvider(i3sOptions);
+
+          // Add the i3s layer provider as a primitive data type
+          viewer.scene.primitives.add(i3sProvider);
+
+          // Center camera on I3S once it's loaded
+          await i3sProvider.readyPromise;
           const center = Cesium.Rectangle.center(i3sProvider.extent);
           center.height = 10000.0;
           viewer.camera.setView({
             destination: Cesium.Ellipsoid.WGS84.cartographicToCartesian(center),
           });
-        });
+        }
 
-        // Add the i3s layer provider as a primitive data type
-        viewer.scene.primitives.add(i3sProvider);
+        addI3sProvider();
+
         // An entity object which will hold info about the currently selected feature for infobox display
         const selectedEntity = new Cesium.Entity();
         // Show metadata in the InfoBox.

--- a/Apps/Sandcastle/gallery/I3S Feature Picking.html
+++ b/Apps/Sandcastle/gallery/I3S Feature Picking.html
@@ -38,13 +38,13 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-          animation: false,
-          timeline: false,
-        });
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+            animation: false,
+            timeline: false,
+          });
 
-        async function addI3sProvider() {
           // More datasets to tour can be added here...
           // The url passed to I3SDataProvider supports loading a single Indexed 3D Scene (I3S) layer (.<host>/SceneServer/layers/<id>) or a collection of scene layers (.<host>/SceneServer) from a SceneServer.
           const tours = {
@@ -83,78 +83,78 @@
           viewer.camera.setView({
             destination: Cesium.Ellipsoid.WGS84.cartographicToCartesian(center),
           });
-        }
 
-        addI3sProvider();
-
-        // An entity object which will hold info about the currently selected feature for infobox display
-        const selectedEntity = new Cesium.Entity();
-        // Show metadata in the InfoBox.
-        viewer.screenSpaceEventHandler.setInputAction(function onLeftClick(
-          movement
-        ) {
-          // Pick a new feature
-          const pickedFeature = viewer.scene.pick(movement.position);
-          if (!Cesium.defined(pickedFeature)) {
-            return;
-          }
-
-          const pickedPosition = viewer.scene.pickPosition(movement.position);
-
-          if (
-            Cesium.defined(pickedFeature.content) &&
-            Cesium.defined(pickedFeature.content.tile.i3sNode)
+          // An entity object which will hold info about the currently selected feature for infobox display
+          const selectedEntity = new Cesium.Entity();
+          // Show metadata in the InfoBox.
+          viewer.screenSpaceEventHandler.setInputAction(function onLeftClick(
+            movement
           ) {
-            const i3sNode = pickedFeature.content.tile.i3sNode;
-            if (pickedPosition) {
-              i3sNode.loadFields().then(function () {
-                let description = "No attributes";
-                let name;
-                console.log(
-                  `pickedPosition(x,y,z) : ${pickedPosition.x}, ${pickedPosition.y}, ${pickedPosition.z}`
-                );
+            // Pick a new feature
+            const pickedFeature = viewer.scene.pick(movement.position);
+            if (!Cesium.defined(pickedFeature)) {
+              return;
+            }
 
-                const fields = i3sNode.getFieldsForPickedPosition(
-                  pickedPosition
-                );
-                if (Object.keys(fields).length > 0) {
-                  description =
-                    '<table class="cesium-infoBox-defaultTable"><tbody>';
-                  for (const fieldName in fields) {
-                    if (i3sNode.fields.hasOwnProperty(fieldName)) {
-                      description += `<tr><th>${fieldName}</th><td>`;
-                      description += `${fields[fieldName]}</td></tr>`;
-                      console.log(`${fieldName}: ${fields[fieldName]}`);
-                      if (!Cesium.defined(name) && isNameProperty(fieldName)) {
-                        name = fields[fieldName];
+            const pickedPosition = viewer.scene.pickPosition(movement.position);
+
+            if (
+              Cesium.defined(pickedFeature.content) &&
+              Cesium.defined(pickedFeature.content.tile.i3sNode)
+            ) {
+              const i3sNode = pickedFeature.content.tile.i3sNode;
+              if (pickedPosition) {
+                i3sNode.loadFields().then(function () {
+                  let description = "No attributes";
+                  let name;
+                  console.log(
+                    `pickedPosition(x,y,z) : ${pickedPosition.x}, ${pickedPosition.y}, ${pickedPosition.z}`
+                  );
+
+                  const fields = i3sNode.getFieldsForPickedPosition(
+                    pickedPosition
+                  );
+                  if (Object.keys(fields).length > 0) {
+                    description =
+                      '<table class="cesium-infoBox-defaultTable"><tbody>';
+                    for (const fieldName in fields) {
+                      if (i3sNode.fields.hasOwnProperty(fieldName)) {
+                        description += `<tr><th>${fieldName}</th><td>`;
+                        description += `${fields[fieldName]}</td></tr>`;
+                        console.log(`${fieldName}: ${fields[fieldName]}`);
+                        if (
+                          !Cesium.defined(name) &&
+                          isNameProperty(fieldName)
+                        ) {
+                          name = fields[fieldName];
+                        }
                       }
                     }
+                    description += `</tbody></table>`;
                   }
-                  description += `</tbody></table>`;
-                }
-                if (!Cesium.defined(name)) {
-                  name = "unknown";
-                }
-                selectedEntity.name = name;
-                selectedEntity.description = description;
-                viewer.selectedEntity = selectedEntity;
-              });
+                  if (!Cesium.defined(name)) {
+                    name = "unknown";
+                  }
+                  selectedEntity.name = name;
+                  selectedEntity.description = description;
+                  viewer.selectedEntity = selectedEntity;
+                });
+              }
             }
-          }
-        },
-        Cesium.ScreenSpaceEventType.LEFT_CLICK);
+          },
+          Cesium.ScreenSpaceEventType.LEFT_CLICK);
 
-        function isNameProperty(propertyName) {
-          const name = propertyName.toLowerCase();
-          if (
-            name.localeCompare("name") === 0 ||
-            name.localeCompare("objname") === 0
-          ) {
-            return true;
+          function isNameProperty(propertyName) {
+            const name = propertyName.toLowerCase();
+            if (
+              name.localeCompare("name") === 0 ||
+              name.localeCompare("objname") === 0
+            ) {
+              return true;
+            }
+            return false;
           }
-          return false;
-        }
-        //Sandcastle_End
+        })(); //Sandcastle_End
         if (typeof Cesium !== "undefined") {
           window.startupCalled = true;
           window.startup(Cesium);

--- a/Apps/Sandcastle/gallery/I3S IntegratedMesh Layer.html
+++ b/Apps/Sandcastle/gallery/I3S IntegratedMesh Layer.html
@@ -39,53 +39,56 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: new Cesium.createWorldTerrain({}),
+          terrainProvider: new Cesium.createWorldTerrainAsync(),
           animation: false,
           timeline: false,
         });
         // Suppress terrain data to avoid clashing with IntegratedMesh layer geometry
         viewer.scene.globe.depthTestAgainstTerrain = false;
-        // More datasets to tour can be added here..
-        // The url passed to I3SDataProvider supports loading a single Indexed 3D Scene (I3S) layer (.<host>/SceneServer/layers/<id>) or a collection of scene layers (.<host>/SceneServer) from a SceneServer.
-        const tours = {
-          Frankfurt:
-            "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/Frankfurt2017_vi3s_18/SceneServer/layers/0",
-        };
-        // Initialize a terrain provider which provides geoid conversion between gravity related (typically I3S datasets) and ellipsoidal based
-        // height systems (Cesium World Terrain).
-        // If this is not specified, or the URL is invalid no geoid conversion will be applied.
-        // The source data used in this transcoding service was compiled from https://earth-info.nga.mil/#tab_wgs84-data and is based on EGM2008 Gravity Model
-        const geoidService = new Cesium.ArcGISTiledElevationTerrainProvider({
-          url:
-            "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/EGM2008/ImageServer",
-        });
 
-        // Create i3s and Cesium3DTileset options to pass optional parameters useful for debugging and visualizing
-        const cesium3dTilesetOptions = {
-          skipLevelOfDetail: false,
-          debugShowBoundingVolume: false,
-        };
-        const i3sOptions = {
-          url: tours.Frankfurt,
-          traceFetches: false, // for tracing I3S fetches
-          geoidTiledTerrainProvider: geoidService, // pass the geoid service
-          cesium3dTilesetOptions: cesium3dTilesetOptions, // options for internal Cesium3dTileset
-        };
+        async function addI3sProvider() {
+          // More datasets to tour can be added here..
+          // The url passed to I3SDataProvider supports loading a single Indexed 3D Scene (I3S) layer (.<host>/SceneServer/layers/<id>) or a collection of scene layers (.<host>/SceneServer) from a SceneServer.
+          const tours = {
+            Frankfurt:
+              "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/Frankfurt2017_vi3s_18/SceneServer/layers/0",
+          };
+          // Initialize a terrain provider which provides geoid conversion between gravity related (typically I3S datasets) and ellipsoidal based
+          // height systems (Cesium World Terrain).
+          // If this is not specified, or the URL is invalid no geoid conversion will be applied.
+          // The source data used in this transcoding service was compiled from https://earth-info.nga.mil/#tab_wgs84-data and is based on EGM2008 Gravity Model
+          const geoidService = await Cesium.ArcGISTiledElevationTerrainProvider(
+            "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/EGM2008/ImageServer"
+          );
 
-        // Create I3S data provider
-        const i3sProvider = new Cesium.I3SDataProvider(i3sOptions);
+          // Create i3s and Cesium3DTileset options to pass optional parameters useful for debugging and visualizing
+          const cesium3dTilesetOptions = {
+            skipLevelOfDetail: false,
+            debugShowBoundingVolume: false,
+          };
+          const i3sOptions = {
+            url: tours.Frankfurt,
+            traceFetches: false, // for tracing I3S fetches
+            geoidTiledTerrainProvider: geoidService, // pass the geoid service
+            cesium3dTilesetOptions: cesium3dTilesetOptions, // options for internal Cesium3dTileset
+          };
 
-        // Center camera on I3S once it's loaded
-        i3sProvider.readyPromise.then(function () {
+          // Create I3S data provider
+          const i3sProvider = new Cesium.I3SDataProvider(i3sOptions);
+
+          // Add the i3s layer provider as a primitive data type
+          viewer.scene.primitives.add(i3sProvider);
+
+          // Center camera on I3S once it's loaded
+          await i3sProvider.readyPromise;
           const center = Cesium.Rectangle.center(i3sProvider.extent);
           center.height = 10000.0;
           viewer.camera.setView({
             destination: Cesium.Ellipsoid.WGS84.cartographicToCartesian(center),
           });
-        });
+        }
 
-        // Add the i3s layer provider as a primitive data type
-        viewer.scene.primitives.add(i3sProvider);
+        addI3sProvider();
         //Sandcastle_End
         if (typeof Cesium !== "undefined") {
           window.startupCalled = true;

--- a/Apps/Sandcastle/gallery/I3S IntegratedMesh Layer.html
+++ b/Apps/Sandcastle/gallery/I3S IntegratedMesh Layer.html
@@ -57,7 +57,7 @@
           // height systems (Cesium World Terrain).
           // If this is not specified, or the URL is invalid no geoid conversion will be applied.
           // The source data used in this transcoding service was compiled from https://earth-info.nga.mil/#tab_wgs84-data and is based on EGM2008 Gravity Model
-          const geoidService = await Cesium.ArcGISTiledElevationTerrainProvider(
+          const geoidService = await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
             "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/EGM2008/ImageServer"
           );
 

--- a/Apps/Sandcastle/gallery/I3S IntegratedMesh Layer.html
+++ b/Apps/Sandcastle/gallery/I3S IntegratedMesh Layer.html
@@ -38,15 +38,15 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: new Cesium.createWorldTerrainAsync(),
-          animation: false,
-          timeline: false,
-        });
-        // Suppress terrain data to avoid clashing with IntegratedMesh layer geometry
-        viewer.scene.globe.depthTestAgainstTerrain = false;
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+            animation: false,
+            timeline: false,
+          });
+          // Suppress terrain data to avoid clashing with IntegratedMesh layer geometry
+          viewer.scene.globe.depthTestAgainstTerrain = false;
 
-        async function addI3sProvider() {
           // More datasets to tour can be added here..
           // The url passed to I3SDataProvider supports loading a single Indexed 3D Scene (I3S) layer (.<host>/SceneServer/layers/<id>) or a collection of scene layers (.<host>/SceneServer) from a SceneServer.
           const tours = {
@@ -86,10 +86,7 @@
           viewer.camera.setView({
             destination: Cesium.Ellipsoid.WGS84.cartographicToCartesian(center),
           });
-        }
-
-        addI3sProvider();
-        //Sandcastle_End
+        })(); //Sandcastle_End
         if (typeof Cesium !== "undefined") {
           window.startupCalled = true;
           window.startup(Cesium);

--- a/Apps/Sandcastle/gallery/Interpolation.html
+++ b/Apps/Sandcastle/gallery/Interpolation.html
@@ -37,169 +37,175 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          infoBox: false, //Disable InfoBox widget
-          selectionIndicator: false, //Disable selection indicator
-          shouldAnimate: true, // Enable animations
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            infoBox: false, //Disable InfoBox widget
+            selectionIndicator: false, //Disable selection indicator
+            shouldAnimate: true, // Enable animations
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
 
-        //Enable lighting based on the sun position
-        viewer.scene.globe.enableLighting = true;
+          //Enable lighting based on the sun position
+          viewer.scene.globe.enableLighting = true;
 
-        //Enable depth testing so things behind the terrain disappear.
-        viewer.scene.globe.depthTestAgainstTerrain = true;
+          //Enable depth testing so things behind the terrain disappear.
+          viewer.scene.globe.depthTestAgainstTerrain = true;
 
-        //Set the random number seed for consistent results.
-        Cesium.Math.setRandomNumberSeed(3);
+          //Set the random number seed for consistent results.
+          Cesium.Math.setRandomNumberSeed(3);
 
-        //Set bounds of our simulation time
-        const start = Cesium.JulianDate.fromDate(new Date(2015, 2, 25, 16));
-        const stop = Cesium.JulianDate.addSeconds(
-          start,
-          360,
-          new Cesium.JulianDate()
-        );
+          //Set bounds of our simulation time
+          const start = Cesium.JulianDate.fromDate(new Date(2015, 2, 25, 16));
+          const stop = Cesium.JulianDate.addSeconds(
+            start,
+            360,
+            new Cesium.JulianDate()
+          );
 
-        //Make sure viewer is at the desired time.
-        viewer.clock.startTime = start.clone();
-        viewer.clock.stopTime = stop.clone();
-        viewer.clock.currentTime = start.clone();
-        viewer.clock.clockRange = Cesium.ClockRange.LOOP_STOP; //Loop at the end
-        viewer.clock.multiplier = 10;
+          //Make sure viewer is at the desired time.
+          viewer.clock.startTime = start.clone();
+          viewer.clock.stopTime = stop.clone();
+          viewer.clock.currentTime = start.clone();
+          viewer.clock.clockRange = Cesium.ClockRange.LOOP_STOP; //Loop at the end
+          viewer.clock.multiplier = 10;
 
-        //Set timeline to simulation bounds
-        viewer.timeline.zoomTo(start, stop);
+          //Set timeline to simulation bounds
+          viewer.timeline.zoomTo(start, stop);
 
-        //Generate a random circular pattern with varying heights.
-        function computeCirclularFlight(lon, lat, radius) {
-          const property = new Cesium.SampledPositionProperty();
-          for (let i = 0; i <= 360; i += 45) {
-            const radians = Cesium.Math.toRadians(i);
-            const time = Cesium.JulianDate.addSeconds(
-              start,
-              i,
-              new Cesium.JulianDate()
-            );
-            const position = Cesium.Cartesian3.fromDegrees(
-              lon + radius * 1.5 * Math.cos(radians),
-              lat + radius * Math.sin(radians),
-              Cesium.Math.nextRandomNumber() * 500 + 1750
-            );
-            property.addSample(time, position);
+          //Generate a random circular pattern with varying heights.
+          function computeCirclularFlight(lon, lat, radius) {
+            const property = new Cesium.SampledPositionProperty();
+            for (let i = 0; i <= 360; i += 45) {
+              const radians = Cesium.Math.toRadians(i);
+              const time = Cesium.JulianDate.addSeconds(
+                start,
+                i,
+                new Cesium.JulianDate()
+              );
+              const position = Cesium.Cartesian3.fromDegrees(
+                lon + radius * 1.5 * Math.cos(radians),
+                lat + radius * Math.sin(radians),
+                Cesium.Math.nextRandomNumber() * 500 + 1750
+              );
+              property.addSample(time, position);
 
-            //Also create a point for each sample we generate.
-            viewer.entities.add({
-              position: position,
-              point: {
-                pixelSize: 8,
-                color: Cesium.Color.TRANSPARENT,
-                outlineColor: Cesium.Color.YELLOW,
-                outlineWidth: 3,
-              },
-            });
+              //Also create a point for each sample we generate.
+              viewer.entities.add({
+                position: position,
+                point: {
+                  pixelSize: 8,
+                  color: Cesium.Color.TRANSPARENT,
+                  outlineColor: Cesium.Color.YELLOW,
+                  outlineWidth: 3,
+                },
+              });
+            }
+            return property;
           }
-          return property;
-        }
 
-        //Compute the entity position property.
-        const position = computeCirclularFlight(-112.110693, 36.0994841, 0.03);
-
-        //Actually create the entity
-        const entity = viewer.entities.add({
-          //Set the entity availability to the same interval as the simulation time.
-          availability: new Cesium.TimeIntervalCollection([
-            new Cesium.TimeInterval({
-              start: start,
-              stop: stop,
-            }),
-          ]),
-
-          //Use our computed positions
-          position: position,
-
-          //Automatically compute orientation based on position movement.
-          orientation: new Cesium.VelocityOrientationProperty(position),
-
-          //Load the Cesium plane model to represent the entity
-          model: {
-            uri: "../../SampleData/models/CesiumAir/Cesium_Air.glb",
-            minimumPixelSize: 64,
-          },
-
-          //Show the path as a pink line sampled in 1 second increments.
-          path: {
-            resolution: 1,
-            material: new Cesium.PolylineGlowMaterialProperty({
-              glowPower: 0.1,
-              color: Cesium.Color.YELLOW,
-            }),
-            width: 10,
-          },
-        });
-
-        //Add button to view the path from the top down
-        Sandcastle.addDefaultToolbarButton("View Top Down", function () {
-          viewer.trackedEntity = undefined;
-          viewer.zoomTo(
-            viewer.entities,
-            new Cesium.HeadingPitchRange(0, Cesium.Math.toRadians(-90))
+          //Compute the entity position property.
+          const position = computeCirclularFlight(
+            -112.110693,
+            36.0994841,
+            0.03
           );
-        });
 
-        //Add button to view the path from the side
-        Sandcastle.addToolbarButton("View Side", function () {
-          viewer.trackedEntity = undefined;
-          viewer.zoomTo(
-            viewer.entities,
-            new Cesium.HeadingPitchRange(
-              Cesium.Math.toRadians(-90),
-              Cesium.Math.toRadians(-15),
-              7500
-            )
+          //Actually create the entity
+          const entity = viewer.entities.add({
+            //Set the entity availability to the same interval as the simulation time.
+            availability: new Cesium.TimeIntervalCollection([
+              new Cesium.TimeInterval({
+                start: start,
+                stop: stop,
+              }),
+            ]),
+
+            //Use our computed positions
+            position: position,
+
+            //Automatically compute orientation based on position movement.
+            orientation: new Cesium.VelocityOrientationProperty(position),
+
+            //Load the Cesium plane model to represent the entity
+            model: {
+              uri: "../../SampleData/models/CesiumAir/Cesium_Air.glb",
+              minimumPixelSize: 64,
+            },
+
+            //Show the path as a pink line sampled in 1 second increments.
+            path: {
+              resolution: 1,
+              material: new Cesium.PolylineGlowMaterialProperty({
+                glowPower: 0.1,
+                color: Cesium.Color.YELLOW,
+              }),
+              width: 10,
+            },
+          });
+
+          //Add button to view the path from the top down
+          Sandcastle.addDefaultToolbarButton("View Top Down", function () {
+            viewer.trackedEntity = undefined;
+            viewer.zoomTo(
+              viewer.entities,
+              new Cesium.HeadingPitchRange(0, Cesium.Math.toRadians(-90))
+            );
+          });
+
+          //Add button to view the path from the side
+          Sandcastle.addToolbarButton("View Side", function () {
+            viewer.trackedEntity = undefined;
+            viewer.zoomTo(
+              viewer.entities,
+              new Cesium.HeadingPitchRange(
+                Cesium.Math.toRadians(-90),
+                Cesium.Math.toRadians(-15),
+                7500
+              )
+            );
+          });
+
+          //Add button to track the entity as it moves
+          Sandcastle.addToolbarButton("View Aircraft", function () {
+            viewer.trackedEntity = entity;
+          });
+
+          //Add a combo box for selecting each interpolation mode.
+          Sandcastle.addToolbarMenu(
+            [
+              {
+                text: "Interpolation: Linear Approximation",
+                onselect: function () {
+                  entity.position.setInterpolationOptions({
+                    interpolationDegree: 1,
+                    interpolationAlgorithm: Cesium.LinearApproximation,
+                  });
+                },
+              },
+              {
+                text: "Interpolation: Lagrange Polynomial Approximation",
+                onselect: function () {
+                  entity.position.setInterpolationOptions({
+                    interpolationDegree: 5,
+                    interpolationAlgorithm:
+                      Cesium.LagrangePolynomialApproximation,
+                  });
+                },
+              },
+              {
+                text: "Interpolation: Hermite Polynomial Approximation",
+                onselect: function () {
+                  entity.position.setInterpolationOptions({
+                    interpolationDegree: 2,
+                    interpolationAlgorithm:
+                      Cesium.HermitePolynomialApproximation,
+                  });
+                },
+              },
+            ],
+            "interpolationMenu"
           );
-        });
-
-        //Add button to track the entity as it moves
-        Sandcastle.addToolbarButton("View Aircraft", function () {
-          viewer.trackedEntity = entity;
-        });
-
-        //Add a combo box for selecting each interpolation mode.
-        Sandcastle.addToolbarMenu(
-          [
-            {
-              text: "Interpolation: Linear Approximation",
-              onselect: function () {
-                entity.position.setInterpolationOptions({
-                  interpolationDegree: 1,
-                  interpolationAlgorithm: Cesium.LinearApproximation,
-                });
-              },
-            },
-            {
-              text: "Interpolation: Lagrange Polynomial Approximation",
-              onselect: function () {
-                entity.position.setInterpolationOptions({
-                  interpolationDegree: 5,
-                  interpolationAlgorithm:
-                    Cesium.LagrangePolynomialApproximation,
-                });
-              },
-            },
-            {
-              text: "Interpolation: Hermite Polynomial Approximation",
-              onselect: function () {
-                entity.position.setInterpolationOptions({
-                  interpolationDegree: 2,
-                  interpolationAlgorithm: Cesium.HermitePolynomialApproximation,
-                });
-              },
-            },
-          ],
-          "interpolationMenu"
-        );
-        //Sandcastle_End
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Interpolation.html
+++ b/Apps/Sandcastle/gallery/Interpolation.html
@@ -41,7 +41,7 @@
           infoBox: false, //Disable InfoBox widget
           selectionIndicator: false, //Disable selection indicator
           shouldAnimate: true, // Enable animations
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         //Enable lighting based on the sun position

--- a/Apps/Sandcastle/gallery/Interpolation.html
+++ b/Apps/Sandcastle/gallery/Interpolation.html
@@ -37,175 +37,176 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          infoBox: false, //Disable InfoBox widget
+          selectionIndicator: false, //Disable selection indicator
+          shouldAnimate: true, // Enable animations
+        });
+
         (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            infoBox: false, //Disable InfoBox widget
-            selectionIndicator: false, //Disable selection indicator
-            shouldAnimate: true, // Enable animations
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
-
-          //Enable lighting based on the sun position
-          viewer.scene.globe.enableLighting = true;
-
-          //Enable depth testing so things behind the terrain disappear.
-          viewer.scene.globe.depthTestAgainstTerrain = true;
-
-          //Set the random number seed for consistent results.
-          Cesium.Math.setRandomNumberSeed(3);
-
-          //Set bounds of our simulation time
-          const start = Cesium.JulianDate.fromDate(new Date(2015, 2, 25, 16));
-          const stop = Cesium.JulianDate.addSeconds(
-            start,
-            360,
-            new Cesium.JulianDate()
-          );
-
-          //Make sure viewer is at the desired time.
-          viewer.clock.startTime = start.clone();
-          viewer.clock.stopTime = stop.clone();
-          viewer.clock.currentTime = start.clone();
-          viewer.clock.clockRange = Cesium.ClockRange.LOOP_STOP; //Loop at the end
-          viewer.clock.multiplier = 10;
-
-          //Set timeline to simulation bounds
-          viewer.timeline.zoomTo(start, stop);
-
-          //Generate a random circular pattern with varying heights.
-          function computeCirclularFlight(lon, lat, radius) {
-            const property = new Cesium.SampledPositionProperty();
-            for (let i = 0; i <= 360; i += 45) {
-              const radians = Cesium.Math.toRadians(i);
-              const time = Cesium.JulianDate.addSeconds(
-                start,
-                i,
-                new Cesium.JulianDate()
-              );
-              const position = Cesium.Cartesian3.fromDegrees(
-                lon + radius * 1.5 * Math.cos(radians),
-                lat + radius * Math.sin(radians),
-                Cesium.Math.nextRandomNumber() * 500 + 1750
-              );
-              property.addSample(time, position);
-
-              //Also create a point for each sample we generate.
-              viewer.entities.add({
-                position: position,
-                point: {
-                  pixelSize: 8,
-                  color: Cesium.Color.TRANSPARENT,
-                  outlineColor: Cesium.Color.YELLOW,
-                  outlineWidth: 3,
-                },
-              });
-            }
-            return property;
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+          } catch (error) {
+            console.log(error);
           }
+        })();
 
-          //Compute the entity position property.
-          const position = computeCirclularFlight(
-            -112.110693,
-            36.0994841,
-            0.03
-          );
+        //Enable lighting based on the sun position
+        viewer.scene.globe.enableLighting = true;
 
-          //Actually create the entity
-          const entity = viewer.entities.add({
-            //Set the entity availability to the same interval as the simulation time.
-            availability: new Cesium.TimeIntervalCollection([
-              new Cesium.TimeInterval({
-                start: start,
-                stop: stop,
-              }),
-            ]),
+        //Enable depth testing so things behind the terrain disappear.
+        viewer.scene.globe.depthTestAgainstTerrain = true;
 
-            //Use our computed positions
-            position: position,
+        //Set the random number seed for consistent results.
+        Cesium.Math.setRandomNumberSeed(3);
 
-            //Automatically compute orientation based on position movement.
-            orientation: new Cesium.VelocityOrientationProperty(position),
+        //Set bounds of our simulation time
+        const start = Cesium.JulianDate.fromDate(new Date(2015, 2, 25, 16));
+        const stop = Cesium.JulianDate.addSeconds(
+          start,
+          360,
+          new Cesium.JulianDate()
+        );
 
-            //Load the Cesium plane model to represent the entity
-            model: {
-              uri: "../../SampleData/models/CesiumAir/Cesium_Air.glb",
-              minimumPixelSize: 64,
-            },
+        //Make sure viewer is at the desired time.
+        viewer.clock.startTime = start.clone();
+        viewer.clock.stopTime = stop.clone();
+        viewer.clock.currentTime = start.clone();
+        viewer.clock.clockRange = Cesium.ClockRange.LOOP_STOP; //Loop at the end
+        viewer.clock.multiplier = 10;
 
-            //Show the path as a pink line sampled in 1 second increments.
-            path: {
-              resolution: 1,
-              material: new Cesium.PolylineGlowMaterialProperty({
-                glowPower: 0.1,
-                color: Cesium.Color.YELLOW,
-              }),
-              width: 10,
-            },
-          });
+        //Set timeline to simulation bounds
+        viewer.timeline.zoomTo(start, stop);
 
-          //Add button to view the path from the top down
-          Sandcastle.addDefaultToolbarButton("View Top Down", function () {
-            viewer.trackedEntity = undefined;
-            viewer.zoomTo(
-              viewer.entities,
-              new Cesium.HeadingPitchRange(0, Cesium.Math.toRadians(-90))
+        //Generate a random circular pattern with varying heights.
+        function computeCirclularFlight(lon, lat, radius) {
+          const property = new Cesium.SampledPositionProperty();
+          for (let i = 0; i <= 360; i += 45) {
+            const radians = Cesium.Math.toRadians(i);
+            const time = Cesium.JulianDate.addSeconds(
+              start,
+              i,
+              new Cesium.JulianDate()
             );
-          });
-
-          //Add button to view the path from the side
-          Sandcastle.addToolbarButton("View Side", function () {
-            viewer.trackedEntity = undefined;
-            viewer.zoomTo(
-              viewer.entities,
-              new Cesium.HeadingPitchRange(
-                Cesium.Math.toRadians(-90),
-                Cesium.Math.toRadians(-15),
-                7500
-              )
+            const position = Cesium.Cartesian3.fromDegrees(
+              lon + radius * 1.5 * Math.cos(radians),
+              lat + radius * Math.sin(radians),
+              Cesium.Math.nextRandomNumber() * 500 + 1750
             );
-          });
+            property.addSample(time, position);
 
-          //Add button to track the entity as it moves
-          Sandcastle.addToolbarButton("View Aircraft", function () {
-            viewer.trackedEntity = entity;
-          });
+            //Also create a point for each sample we generate.
+            viewer.entities.add({
+              position: position,
+              point: {
+                pixelSize: 8,
+                color: Cesium.Color.TRANSPARENT,
+                outlineColor: Cesium.Color.YELLOW,
+                outlineWidth: 3,
+              },
+            });
+          }
+          return property;
+        }
 
-          //Add a combo box for selecting each interpolation mode.
-          Sandcastle.addToolbarMenu(
-            [
-              {
-                text: "Interpolation: Linear Approximation",
-                onselect: function () {
-                  entity.position.setInterpolationOptions({
-                    interpolationDegree: 1,
-                    interpolationAlgorithm: Cesium.LinearApproximation,
-                  });
-                },
-              },
-              {
-                text: "Interpolation: Lagrange Polynomial Approximation",
-                onselect: function () {
-                  entity.position.setInterpolationOptions({
-                    interpolationDegree: 5,
-                    interpolationAlgorithm:
-                      Cesium.LagrangePolynomialApproximation,
-                  });
-                },
-              },
-              {
-                text: "Interpolation: Hermite Polynomial Approximation",
-                onselect: function () {
-                  entity.position.setInterpolationOptions({
-                    interpolationDegree: 2,
-                    interpolationAlgorithm:
-                      Cesium.HermitePolynomialApproximation,
-                  });
-                },
-              },
-            ],
-            "interpolationMenu"
+        //Compute the entity position property.
+        const position = computeCirclularFlight(-112.110693, 36.0994841, 0.03);
+
+        //Actually create the entity
+        const entity = viewer.entities.add({
+          //Set the entity availability to the same interval as the simulation time.
+          availability: new Cesium.TimeIntervalCollection([
+            new Cesium.TimeInterval({
+              start: start,
+              stop: stop,
+            }),
+          ]),
+
+          //Use our computed positions
+          position: position,
+
+          //Automatically compute orientation based on position movement.
+          orientation: new Cesium.VelocityOrientationProperty(position),
+
+          //Load the Cesium plane model to represent the entity
+          model: {
+            uri: "../../SampleData/models/CesiumAir/Cesium_Air.glb",
+            minimumPixelSize: 64,
+          },
+
+          //Show the path as a pink line sampled in 1 second increments.
+          path: {
+            resolution: 1,
+            material: new Cesium.PolylineGlowMaterialProperty({
+              glowPower: 0.1,
+              color: Cesium.Color.YELLOW,
+            }),
+            width: 10,
+          },
+        });
+
+        //Add button to view the path from the top down
+        Sandcastle.addDefaultToolbarButton("View Top Down", function () {
+          viewer.trackedEntity = undefined;
+          viewer.zoomTo(
+            viewer.entities,
+            new Cesium.HeadingPitchRange(0, Cesium.Math.toRadians(-90))
           );
-        })(); //Sandcastle_End
+        });
+
+        //Add button to view the path from the side
+        Sandcastle.addToolbarButton("View Side", function () {
+          viewer.trackedEntity = undefined;
+          viewer.zoomTo(
+            viewer.entities,
+            new Cesium.HeadingPitchRange(
+              Cesium.Math.toRadians(-90),
+              Cesium.Math.toRadians(-15),
+              7500
+            )
+          );
+        });
+
+        //Add button to track the entity as it moves
+        Sandcastle.addToolbarButton("View Aircraft", function () {
+          viewer.trackedEntity = entity;
+        });
+
+        //Add a combo box for selecting each interpolation mode.
+        Sandcastle.addToolbarMenu(
+          [
+            {
+              text: "Interpolation: Linear Approximation",
+              onselect: function () {
+                entity.position.setInterpolationOptions({
+                  interpolationDegree: 1,
+                  interpolationAlgorithm: Cesium.LinearApproximation,
+                });
+              },
+            },
+            {
+              text: "Interpolation: Lagrange Polynomial Approximation",
+              onselect: function () {
+                entity.position.setInterpolationOptions({
+                  interpolationDegree: 5,
+                  interpolationAlgorithm:
+                    Cesium.LagrangePolynomialApproximation,
+                });
+              },
+            },
+            {
+              text: "Interpolation: Hermite Polynomial Approximation",
+              onselect: function () {
+                entity.position.setInterpolationOptions({
+                  interpolationDegree: 2,
+                  interpolationAlgorithm: Cesium.HermitePolynomialApproximation,
+                });
+              },
+            },
+          ],
+          "interpolationMenu"
+        );
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Lighting.html
+++ b/Apps/Sandcastle/gallery/Lighting.html
@@ -32,205 +32,206 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        const viewer = new Cesium.Viewer("cesiumContainer");
+        const scene = viewer.scene;
+        scene.globe.enableLighting = true;
+
         (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync({
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync({
               requestWaterMask: true,
               requestVertexNormals: true,
-            }),
-          });
-
-          const scene = viewer.scene;
-          scene.globe.enableLighting = true;
-
-          const scratchIcrfToFixed = new Cesium.Matrix3();
-          const scratchMoonPosition = new Cesium.Cartesian3();
-          const scratchMoonDirection = new Cesium.Cartesian3();
-
-          function getMoonDirection(result) {
-            result = Cesium.defined(result) ? result : new Cesium.Cartesian3();
-            const icrfToFixed = scratchIcrfToFixed;
-            const date = viewer.clock.currentTime;
-            if (
-              !Cesium.defined(
-                Cesium.Transforms.computeIcrfToFixedMatrix(date, icrfToFixed)
-              )
-            ) {
-              Cesium.Transforms.computeTemeToPseudoFixedMatrix(
-                date,
-                icrfToFixed
-              );
-            }
-            const moonPosition = Cesium.Simon1994PlanetaryPositions.computeMoonPositionInEarthInertialFrame(
-              date,
-              scratchMoonPosition
-            );
-            Cesium.Matrix3.multiplyByVector(
-              icrfToFixed,
-              moonPosition,
-              moonPosition
-            );
-            const moonDirection = Cesium.Cartesian3.normalize(
-              moonPosition,
-              scratchMoonDirection
-            );
-            return Cesium.Cartesian3.negate(moonDirection, result);
+            });
+          } catch (error) {
+            console.log(error);
           }
+        })();
 
-          const directionalLight = new Cesium.DirectionalLight({
-            direction: new Cesium.Cartesian3(
-              0.2454278300540191,
-              0.8842635425193919,
-              0.39729481195458805
-            ),
-          });
+        const scratchIcrfToFixed = new Cesium.Matrix3();
+        const scratchMoonPosition = new Cesium.Cartesian3();
+        const scratchMoonDirection = new Cesium.Cartesian3();
 
-          const flashlight = new Cesium.DirectionalLight({
-            direction: scene.camera.directionWC, // Updated every frame
-          });
+        function getMoonDirection(result) {
+          result = Cesium.defined(result) ? result : new Cesium.Cartesian3();
+          const icrfToFixed = scratchIcrfToFixed;
+          const date = viewer.clock.currentTime;
+          if (
+            !Cesium.defined(
+              Cesium.Transforms.computeIcrfToFixedMatrix(date, icrfToFixed)
+            )
+          ) {
+            Cesium.Transforms.computeTemeToPseudoFixedMatrix(date, icrfToFixed);
+          }
+          const moonPosition = Cesium.Simon1994PlanetaryPositions.computeMoonPositionInEarthInertialFrame(
+            date,
+            scratchMoonPosition
+          );
+          Cesium.Matrix3.multiplyByVector(
+            icrfToFixed,
+            moonPosition,
+            moonPosition
+          );
+          const moonDirection = Cesium.Cartesian3.normalize(
+            moonPosition,
+            scratchMoonDirection
+          );
+          return Cesium.Cartesian3.negate(moonDirection, result);
+        }
 
-          const moonLight = new Cesium.DirectionalLight({
-            direction: getMoonDirection(), // Updated every frame
-            color: new Cesium.Color(0.9, 0.925, 1.0),
-            intensity: 0.5,
-          });
+        const directionalLight = new Cesium.DirectionalLight({
+          direction: new Cesium.Cartesian3(
+            0.2454278300540191,
+            0.8842635425193919,
+            0.39729481195458805
+          ),
+        });
 
-          const sunLight = new Cesium.SunLight();
+        const flashlight = new Cesium.DirectionalLight({
+          direction: scene.camera.directionWC, // Updated every frame
+        });
 
-          const customColorLight = new Cesium.DirectionalLight({
-            direction: new Cesium.Cartesian3(
-              -0.2454278300540191,
-              0.8842635425193919,
-              0.39729481195458805
-            ),
-            color: Cesium.Color.fromCssColorString("#deca7c"),
-          });
+        const moonLight = new Cesium.DirectionalLight({
+          direction: getMoonDirection(), // Updated every frame
+          color: new Cesium.Color(0.9, 0.925, 1.0),
+          intensity: 0.5,
+        });
 
-          scene.preRender.addEventListener(function (scene, time) {
-            if (scene.light === flashlight) {
-              scene.light.direction = Cesium.Cartesian3.clone(
-                scene.camera.directionWC,
-                scene.light.direction
-              );
-            } else if (scene.light === moonLight) {
-              scene.light.direction = getMoonDirection(scene.light.direction);
-            }
-          });
+        const sunLight = new Cesium.SunLight();
 
-          viewer.entities.add({
-            position: Cesium.Cartesian3.fromRadians(
-              -2.1463338399937277,
-              0.6677959688982861,
-              32.18991401746337
-            ),
-            model: {
-              uri: "../../SampleData/models/CesiumBalloon/CesiumBalloon.glb",
-              scale: 7.0,
-            },
-          });
+        const customColorLight = new Cesium.DirectionalLight({
+          direction: new Cesium.Cartesian3(
+            -0.2454278300540191,
+            0.8842635425193919,
+            0.39729481195458805
+          ),
+          color: Cesium.Color.fromCssColorString("#deca7c"),
+        });
 
-          viewer.entities.add({
-            position: Cesium.Cartesian3.fromRadians(
-              -2.14633449752228,
-              0.667796065242357,
-              24.47647034111423
-            ),
-            cylinder: {
-              length: 8.0,
-              topRadius: 2.0,
-              bottomRadius: 2.0,
-              material: Cesium.Color.WHITE,
-            },
-          });
-
-          viewer.entities.add({
-            position: Cesium.Cartesian3.fromRadians(
-              -2.1463332294173365,
-              0.6677959755384729,
-              26.2876064083145
-            ),
-            ellipsoid: {
-              radii: new Cesium.Cartesian3(2.5, 2.5, 2.5),
-              material: Cesium.Color.WHITE.withAlpha(0.5),
-            },
-          });
-
-          function setTime(iso8601) {
-            const currentTime = Cesium.JulianDate.fromIso8601(iso8601);
-            const endTime = Cesium.JulianDate.addDays(
-              currentTime,
-              2,
-              new Cesium.JulianDate()
+        scene.preRender.addEventListener(function (scene, time) {
+          if (scene.light === flashlight) {
+            scene.light.direction = Cesium.Cartesian3.clone(
+              scene.camera.directionWC,
+              scene.light.direction
             );
-
-            viewer.clock.currentTime = currentTime;
-            viewer.timeline.zoomTo(currentTime, endTime);
+          } else if (scene.light === moonLight) {
+            scene.light.direction = getMoonDirection(scene.light.direction);
           }
+        });
 
-          function reset() {
-            // Set scene defaults
-            scene.light = sunLight;
-            scene.globe.dynamicAtmosphereLighting = true;
-            scene.globe.dynamicAtmosphereLightingFromSun = false;
-            setTime("2020-01-09T23:00:39.018261982600961346Z");
-          }
+        viewer.entities.add({
+          position: Cesium.Cartesian3.fromRadians(
+            -2.1463338399937277,
+            0.6677959688982861,
+            32.18991401746337
+          ),
+          model: {
+            uri: "../../SampleData/models/CesiumBalloon/CesiumBalloon.glb",
+            scale: 7.0,
+          },
+        });
 
-          viewer.scene.camera.setView({
-            destination: new Cesium.Cartesian3(
-              -2729490.8390059783,
-              -4206389.878855597,
-              3928671.2763356343
-            ),
-            orientation: new Cesium.HeadingPitchRoll(
-              2.2482480507178426,
-              -0.20084951548781982,
-              0.002593933673552762
-            ),
-            endTransform: Cesium.Matrix4.IDENTITY,
-          });
+        viewer.entities.add({
+          position: Cesium.Cartesian3.fromRadians(
+            -2.14633449752228,
+            0.667796065242357,
+            24.47647034111423
+          ),
+          cylinder: {
+            length: 8.0,
+            topRadius: 2.0,
+            bottomRadius: 2.0,
+            material: Cesium.Color.WHITE,
+          },
+        });
 
-          const options = [
-            {
-              text: "Fixed lighting",
-              onselect: function () {
-                reset();
-                scene.light = directionalLight;
-              },
-            },
-            {
-              text: "Flashlight",
-              onselect: function () {
-                reset();
-                scene.light = flashlight;
-                scene.globe.dynamicAtmosphereLighting = false;
-              },
-            },
-            {
-              text: "Moonlight",
-              onselect: function () {
-                reset();
-                scene.light = moonLight;
-                scene.globe.dynamicAtmosphereLightingFromSun = true;
-                setTime("2020-01-10T05:29:41.17946898164518643Z");
-              },
-            },
-            {
-              text: "Sunlight",
-              onselect: function () {
-                reset();
-              },
-            },
-            {
-              text: "Custom color",
-              onselect: function () {
-                reset();
-                scene.light = customColorLight;
-              },
-            },
-          ];
+        viewer.entities.add({
+          position: Cesium.Cartesian3.fromRadians(
+            -2.1463332294173365,
+            0.6677959755384729,
+            26.2876064083145
+          ),
+          ellipsoid: {
+            radii: new Cesium.Cartesian3(2.5, 2.5, 2.5),
+            material: Cesium.Color.WHITE.withAlpha(0.5),
+          },
+        });
 
-          Sandcastle.addToolbarMenu(options);
-        })(); //Sandcastle_End
+        function setTime(iso8601) {
+          const currentTime = Cesium.JulianDate.fromIso8601(iso8601);
+          const endTime = Cesium.JulianDate.addDays(
+            currentTime,
+            2,
+            new Cesium.JulianDate()
+          );
+
+          viewer.clock.currentTime = currentTime;
+          viewer.timeline.zoomTo(currentTime, endTime);
+        }
+
+        function reset() {
+          // Set scene defaults
+          scene.light = sunLight;
+          scene.globe.dynamicAtmosphereLighting = true;
+          scene.globe.dynamicAtmosphereLightingFromSun = false;
+          setTime("2020-01-09T23:00:39.018261982600961346Z");
+        }
+
+        viewer.scene.camera.setView({
+          destination: new Cesium.Cartesian3(
+            -2729490.8390059783,
+            -4206389.878855597,
+            3928671.2763356343
+          ),
+          orientation: new Cesium.HeadingPitchRoll(
+            2.2482480507178426,
+            -0.20084951548781982,
+            0.002593933673552762
+          ),
+          endTransform: Cesium.Matrix4.IDENTITY,
+        });
+
+        const options = [
+          {
+            text: "Fixed lighting",
+            onselect: function () {
+              reset();
+              scene.light = directionalLight;
+            },
+          },
+          {
+            text: "Flashlight",
+            onselect: function () {
+              reset();
+              scene.light = flashlight;
+              scene.globe.dynamicAtmosphereLighting = false;
+            },
+          },
+          {
+            text: "Moonlight",
+            onselect: function () {
+              reset();
+              scene.light = moonLight;
+              scene.globe.dynamicAtmosphereLightingFromSun = true;
+              setTime("2020-01-10T05:29:41.17946898164518643Z");
+            },
+          },
+          {
+            text: "Sunlight",
+            onselect: function () {
+              reset();
+            },
+          },
+          {
+            text: "Custom color",
+            onselect: function () {
+              reset();
+              scene.light = customColorLight;
+            },
+          },
+        ];
+
+        Sandcastle.addToolbarMenu(options);
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Lighting.html
+++ b/Apps/Sandcastle/gallery/Lighting.html
@@ -32,201 +32,205 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync({
-            requestWaterMask: true,
-            requestVertexNormals: true,
-          }),
-        });
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync({
+              requestWaterMask: true,
+              requestVertexNormals: true,
+            }),
+          });
 
-        const scene = viewer.scene;
-        scene.globe.enableLighting = true;
+          const scene = viewer.scene;
+          scene.globe.enableLighting = true;
 
-        const scratchIcrfToFixed = new Cesium.Matrix3();
-        const scratchMoonPosition = new Cesium.Cartesian3();
-        const scratchMoonDirection = new Cesium.Cartesian3();
+          const scratchIcrfToFixed = new Cesium.Matrix3();
+          const scratchMoonPosition = new Cesium.Cartesian3();
+          const scratchMoonDirection = new Cesium.Cartesian3();
 
-        function getMoonDirection(result) {
-          result = Cesium.defined(result) ? result : new Cesium.Cartesian3();
-          const icrfToFixed = scratchIcrfToFixed;
-          const date = viewer.clock.currentTime;
-          if (
-            !Cesium.defined(
-              Cesium.Transforms.computeIcrfToFixedMatrix(date, icrfToFixed)
-            )
-          ) {
-            Cesium.Transforms.computeTemeToPseudoFixedMatrix(date, icrfToFixed);
-          }
-          const moonPosition = Cesium.Simon1994PlanetaryPositions.computeMoonPositionInEarthInertialFrame(
-            date,
-            scratchMoonPosition
-          );
-          Cesium.Matrix3.multiplyByVector(
-            icrfToFixed,
-            moonPosition,
-            moonPosition
-          );
-          const moonDirection = Cesium.Cartesian3.normalize(
-            moonPosition,
-            scratchMoonDirection
-          );
-          return Cesium.Cartesian3.negate(moonDirection, result);
-        }
-
-        const directionalLight = new Cesium.DirectionalLight({
-          direction: new Cesium.Cartesian3(
-            0.2454278300540191,
-            0.8842635425193919,
-            0.39729481195458805
-          ),
-        });
-
-        const flashlight = new Cesium.DirectionalLight({
-          direction: scene.camera.directionWC, // Updated every frame
-        });
-
-        const moonLight = new Cesium.DirectionalLight({
-          direction: getMoonDirection(), // Updated every frame
-          color: new Cesium.Color(0.9, 0.925, 1.0),
-          intensity: 0.5,
-        });
-
-        const sunLight = new Cesium.SunLight();
-
-        const customColorLight = new Cesium.DirectionalLight({
-          direction: new Cesium.Cartesian3(
-            -0.2454278300540191,
-            0.8842635425193919,
-            0.39729481195458805
-          ),
-          color: Cesium.Color.fromCssColorString("#deca7c"),
-        });
-
-        scene.preRender.addEventListener(function (scene, time) {
-          if (scene.light === flashlight) {
-            scene.light.direction = Cesium.Cartesian3.clone(
-              scene.camera.directionWC,
-              scene.light.direction
+          function getMoonDirection(result) {
+            result = Cesium.defined(result) ? result : new Cesium.Cartesian3();
+            const icrfToFixed = scratchIcrfToFixed;
+            const date = viewer.clock.currentTime;
+            if (
+              !Cesium.defined(
+                Cesium.Transforms.computeIcrfToFixedMatrix(date, icrfToFixed)
+              )
+            ) {
+              Cesium.Transforms.computeTemeToPseudoFixedMatrix(
+                date,
+                icrfToFixed
+              );
+            }
+            const moonPosition = Cesium.Simon1994PlanetaryPositions.computeMoonPositionInEarthInertialFrame(
+              date,
+              scratchMoonPosition
             );
-          } else if (scene.light === moonLight) {
-            scene.light.direction = getMoonDirection(scene.light.direction);
+            Cesium.Matrix3.multiplyByVector(
+              icrfToFixed,
+              moonPosition,
+              moonPosition
+            );
+            const moonDirection = Cesium.Cartesian3.normalize(
+              moonPosition,
+              scratchMoonDirection
+            );
+            return Cesium.Cartesian3.negate(moonDirection, result);
           }
-        });
 
-        viewer.entities.add({
-          position: Cesium.Cartesian3.fromRadians(
-            -2.1463338399937277,
-            0.6677959688982861,
-            32.18991401746337
-          ),
-          model: {
-            uri: "../../SampleData/models/CesiumBalloon/CesiumBalloon.glb",
-            scale: 7.0,
-          },
-        });
+          const directionalLight = new Cesium.DirectionalLight({
+            direction: new Cesium.Cartesian3(
+              0.2454278300540191,
+              0.8842635425193919,
+              0.39729481195458805
+            ),
+          });
 
-        viewer.entities.add({
-          position: Cesium.Cartesian3.fromRadians(
-            -2.14633449752228,
-            0.667796065242357,
-            24.47647034111423
-          ),
-          cylinder: {
-            length: 8.0,
-            topRadius: 2.0,
-            bottomRadius: 2.0,
-            material: Cesium.Color.WHITE,
-          },
-        });
+          const flashlight = new Cesium.DirectionalLight({
+            direction: scene.camera.directionWC, // Updated every frame
+          });
 
-        viewer.entities.add({
-          position: Cesium.Cartesian3.fromRadians(
-            -2.1463332294173365,
-            0.6677959755384729,
-            26.2876064083145
-          ),
-          ellipsoid: {
-            radii: new Cesium.Cartesian3(2.5, 2.5, 2.5),
-            material: Cesium.Color.WHITE.withAlpha(0.5),
-          },
-        });
+          const moonLight = new Cesium.DirectionalLight({
+            direction: getMoonDirection(), // Updated every frame
+            color: new Cesium.Color(0.9, 0.925, 1.0),
+            intensity: 0.5,
+          });
 
-        function setTime(iso8601) {
-          const currentTime = Cesium.JulianDate.fromIso8601(iso8601);
-          const endTime = Cesium.JulianDate.addDays(
-            currentTime,
-            2,
-            new Cesium.JulianDate()
-          );
+          const sunLight = new Cesium.SunLight();
 
-          viewer.clock.currentTime = currentTime;
-          viewer.timeline.zoomTo(currentTime, endTime);
-        }
+          const customColorLight = new Cesium.DirectionalLight({
+            direction: new Cesium.Cartesian3(
+              -0.2454278300540191,
+              0.8842635425193919,
+              0.39729481195458805
+            ),
+            color: Cesium.Color.fromCssColorString("#deca7c"),
+          });
 
-        function reset() {
-          // Set scene defaults
-          scene.light = sunLight;
-          scene.globe.dynamicAtmosphereLighting = true;
-          scene.globe.dynamicAtmosphereLightingFromSun = false;
-          setTime("2020-01-09T23:00:39.018261982600961346Z");
-        }
+          scene.preRender.addEventListener(function (scene, time) {
+            if (scene.light === flashlight) {
+              scene.light.direction = Cesium.Cartesian3.clone(
+                scene.camera.directionWC,
+                scene.light.direction
+              );
+            } else if (scene.light === moonLight) {
+              scene.light.direction = getMoonDirection(scene.light.direction);
+            }
+          });
 
-        viewer.scene.camera.setView({
-          destination: new Cesium.Cartesian3(
-            -2729490.8390059783,
-            -4206389.878855597,
-            3928671.2763356343
-          ),
-          orientation: new Cesium.HeadingPitchRoll(
-            2.2482480507178426,
-            -0.20084951548781982,
-            0.002593933673552762
-          ),
-          endTransform: Cesium.Matrix4.IDENTITY,
-        });
-
-        const options = [
-          {
-            text: "Fixed lighting",
-            onselect: function () {
-              reset();
-              scene.light = directionalLight;
+          viewer.entities.add({
+            position: Cesium.Cartesian3.fromRadians(
+              -2.1463338399937277,
+              0.6677959688982861,
+              32.18991401746337
+            ),
+            model: {
+              uri: "../../SampleData/models/CesiumBalloon/CesiumBalloon.glb",
+              scale: 7.0,
             },
-          },
-          {
-            text: "Flashlight",
-            onselect: function () {
-              reset();
-              scene.light = flashlight;
-              scene.globe.dynamicAtmosphereLighting = false;
-            },
-          },
-          {
-            text: "Moonlight",
-            onselect: function () {
-              reset();
-              scene.light = moonLight;
-              scene.globe.dynamicAtmosphereLightingFromSun = true;
-              setTime("2020-01-10T05:29:41.17946898164518643Z");
-            },
-          },
-          {
-            text: "Sunlight",
-            onselect: function () {
-              reset();
-            },
-          },
-          {
-            text: "Custom color",
-            onselect: function () {
-              reset();
-              scene.light = customColorLight;
-            },
-          },
-        ];
+          });
 
-        Sandcastle.addToolbarMenu(options);
-        //Sandcastle_End
+          viewer.entities.add({
+            position: Cesium.Cartesian3.fromRadians(
+              -2.14633449752228,
+              0.667796065242357,
+              24.47647034111423
+            ),
+            cylinder: {
+              length: 8.0,
+              topRadius: 2.0,
+              bottomRadius: 2.0,
+              material: Cesium.Color.WHITE,
+            },
+          });
+
+          viewer.entities.add({
+            position: Cesium.Cartesian3.fromRadians(
+              -2.1463332294173365,
+              0.6677959755384729,
+              26.2876064083145
+            ),
+            ellipsoid: {
+              radii: new Cesium.Cartesian3(2.5, 2.5, 2.5),
+              material: Cesium.Color.WHITE.withAlpha(0.5),
+            },
+          });
+
+          function setTime(iso8601) {
+            const currentTime = Cesium.JulianDate.fromIso8601(iso8601);
+            const endTime = Cesium.JulianDate.addDays(
+              currentTime,
+              2,
+              new Cesium.JulianDate()
+            );
+
+            viewer.clock.currentTime = currentTime;
+            viewer.timeline.zoomTo(currentTime, endTime);
+          }
+
+          function reset() {
+            // Set scene defaults
+            scene.light = sunLight;
+            scene.globe.dynamicAtmosphereLighting = true;
+            scene.globe.dynamicAtmosphereLightingFromSun = false;
+            setTime("2020-01-09T23:00:39.018261982600961346Z");
+          }
+
+          viewer.scene.camera.setView({
+            destination: new Cesium.Cartesian3(
+              -2729490.8390059783,
+              -4206389.878855597,
+              3928671.2763356343
+            ),
+            orientation: new Cesium.HeadingPitchRoll(
+              2.2482480507178426,
+              -0.20084951548781982,
+              0.002593933673552762
+            ),
+            endTransform: Cesium.Matrix4.IDENTITY,
+          });
+
+          const options = [
+            {
+              text: "Fixed lighting",
+              onselect: function () {
+                reset();
+                scene.light = directionalLight;
+              },
+            },
+            {
+              text: "Flashlight",
+              onselect: function () {
+                reset();
+                scene.light = flashlight;
+                scene.globe.dynamicAtmosphereLighting = false;
+              },
+            },
+            {
+              text: "Moonlight",
+              onselect: function () {
+                reset();
+                scene.light = moonLight;
+                scene.globe.dynamicAtmosphereLightingFromSun = true;
+                setTime("2020-01-10T05:29:41.17946898164518643Z");
+              },
+            },
+            {
+              text: "Sunlight",
+              onselect: function () {
+                reset();
+              },
+            },
+            {
+              text: "Custom color",
+              onselect: function () {
+                reset();
+                scene.light = customColorLight;
+              },
+            },
+          ];
+
+          Sandcastle.addToolbarMenu(options);
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Lighting.html
+++ b/Apps/Sandcastle/gallery/Lighting.html
@@ -33,7 +33,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain({
+          terrainProvider: Cesium.createWorldTerrainAsync({
             requestWaterMask: true,
             requestVertexNormals: true,
           }),

--- a/Apps/Sandcastle/gallery/MSAA.html
+++ b/Apps/Sandcastle/gallery/MSAA.html
@@ -33,7 +33,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
           contextOptions: {
             requestWebgl1: false,
           },

--- a/Apps/Sandcastle/gallery/MSAA.html
+++ b/Apps/Sandcastle/gallery/MSAA.html
@@ -32,150 +32,151 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-          contextOptions: {
-            requestWebgl1: false,
-          },
-        });
-
-        viewer.clock.currentTime = Cesium.JulianDate.fromIso8601(
-          "2022-08-01T00:00:00Z"
-        );
-
-        const scene = viewer.scene;
-        if (!scene.msaaSupported) {
-          window.alert("This browser does not support MSAA.");
-        }
-
-        function createModel(url, height) {
-          const position = Cesium.Cartesian3.fromDegrees(
-            -123.0744619,
-            44.0503706,
-            height
-          );
-          const heading = Cesium.Math.toRadians(135);
-          const pitch = 0;
-          const roll = 0;
-          const hpr = new Cesium.HeadingPitchRoll(heading, pitch, roll);
-          const orientation = Cesium.Transforms.headingPitchRollQuaternion(
-            position,
-            hpr
-          );
-
-          const entity = viewer.entities.add({
-            name: url,
-            position: position,
-            orientation: orientation,
-            model: {
-              uri: url,
-              minimumPixelSize: 128,
-              maximumScale: 20000,
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+            contextOptions: {
+              requestWebgl1: false,
             },
           });
-          const target = Cesium.Cartesian3.fromDegrees(
-            -123.0744619,
-            44.0503706,
-            height + 7.5
+
+          viewer.clock.currentTime = Cesium.JulianDate.fromIso8601(
+            "2022-08-01T00:00:00Z"
           );
-          const offset = new Cesium.Cartesian3(50.0, -15.0, 0.0);
-          viewer.scene.camera.lookAt(target, offset);
-        }
 
-        const options = [
-          {
-            text: "Statue of Liberty",
-            onselect: function () {
-              viewer.entities.removeAll();
-              scene.primitives.removeAll();
-              scene.camera.setView({
-                destination: new Cesium.Cartesian3(
-                  1331419.302230775,
-                  -4656681.5022043325,
-                  4136232.6465900405
-                ),
-                orientation: new Cesium.HeadingPitchRoll(
-                  6.032455545102689,
-                  -0.056832496140112765,
-                  6.282360923090216
-                ),
-                endTransform: Cesium.Matrix4.IDENTITY,
-              });
+          const scene = viewer.scene;
+          if (!scene.msaaSupported) {
+            window.alert("This browser does not support MSAA.");
+          }
 
-              scene.primitives.add(
-                new Cesium.Cesium3DTileset({
-                  url: Cesium.IonResource.fromAssetId(75343),
-                })
-              );
-            },
-          },
-          {
-            text: "3D Tiles BIM",
-            onselect: function () {
-              viewer.entities.removeAll();
-              scene.primitives.removeAll();
-              const tileset = scene.primitives.add(
-                new Cesium.Cesium3DTileset({
-                  url: Cesium.IonResource.fromAssetId(1240402),
-                })
-              );
-              viewer.camera.setView({
-                destination: new Cesium.Cartesian3(
-                  1234138.7804841248,
-                  -5086063.633843134,
-                  3633284.606361642
-                ),
-                orientation: {
-                  heading: 0.4304630387656614,
-                  pitch: -0.16969316864215878,
-                  roll: 6.283184816241989,
-                },
-              });
-            },
-          },
-          {
-            text: "Hot Air Balloon",
-            onselect: function () {
-              viewer.entities.removeAll();
-              scene.primitives.removeAll();
-              createModel(
-                "../../SampleData/models/CesiumBalloon/CesiumBalloon.glb",
-                1000.0
-              );
-            },
-          },
-        ];
+          function createModel(url, height) {
+            const position = Cesium.Cartesian3.fromDegrees(
+              -123.0744619,
+              44.0503706,
+              height
+            );
+            const heading = Cesium.Math.toRadians(135);
+            const pitch = 0;
+            const roll = 0;
+            const hpr = new Cesium.HeadingPitchRoll(heading, pitch, roll);
+            const orientation = Cesium.Transforms.headingPitchRollQuaternion(
+              position,
+              hpr
+            );
 
-        const samplingOptions = [
-          {
-            text: "MSAA off",
-            onselect: function () {
-              scene.msaaSamples = 1;
-            },
-          },
-          {
-            text: "MSAA 2x",
-            onselect: function () {
-              scene.msaaSamples = 2;
-            },
-          },
-          {
-            text: "MSAA 4x",
-            onselect: function () {
-              scene.msaaSamples = 4;
-            },
-          },
-          {
-            text: "MSAA 8x",
-            onselect: function () {
-              scene.msaaSamples = 8;
-            },
-          },
-        ];
+            const entity = viewer.entities.add({
+              name: url,
+              position: position,
+              orientation: orientation,
+              model: {
+                uri: url,
+                minimumPixelSize: 128,
+                maximumScale: 20000,
+              },
+            });
+            const target = Cesium.Cartesian3.fromDegrees(
+              -123.0744619,
+              44.0503706,
+              height + 7.5
+            );
+            const offset = new Cesium.Cartesian3(50.0, -15.0, 0.0);
+            viewer.scene.camera.lookAt(target, offset);
+          }
 
-        Sandcastle.addToolbarMenu(options);
-        Sandcastle.addToolbarMenu(samplingOptions);
-        //Sandcastle_End
+          const options = [
+            {
+              text: "Statue of Liberty",
+              onselect: function () {
+                viewer.entities.removeAll();
+                scene.primitives.removeAll();
+                scene.camera.setView({
+                  destination: new Cesium.Cartesian3(
+                    1331419.302230775,
+                    -4656681.5022043325,
+                    4136232.6465900405
+                  ),
+                  orientation: new Cesium.HeadingPitchRoll(
+                    6.032455545102689,
+                    -0.056832496140112765,
+                    6.282360923090216
+                  ),
+                  endTransform: Cesium.Matrix4.IDENTITY,
+                });
+
+                scene.primitives.add(
+                  new Cesium.Cesium3DTileset({
+                    url: Cesium.IonResource.fromAssetId(75343),
+                  })
+                );
+              },
+            },
+            {
+              text: "3D Tiles BIM",
+              onselect: function () {
+                viewer.entities.removeAll();
+                scene.primitives.removeAll();
+                const tileset = scene.primitives.add(
+                  new Cesium.Cesium3DTileset({
+                    url: Cesium.IonResource.fromAssetId(1240402),
+                  })
+                );
+                viewer.camera.setView({
+                  destination: new Cesium.Cartesian3(
+                    1234138.7804841248,
+                    -5086063.633843134,
+                    3633284.606361642
+                  ),
+                  orientation: {
+                    heading: 0.4304630387656614,
+                    pitch: -0.16969316864215878,
+                    roll: 6.283184816241989,
+                  },
+                });
+              },
+            },
+            {
+              text: "Hot Air Balloon",
+              onselect: function () {
+                viewer.entities.removeAll();
+                scene.primitives.removeAll();
+                createModel(
+                  "../../SampleData/models/CesiumBalloon/CesiumBalloon.glb",
+                  1000.0
+                );
+              },
+            },
+          ];
+
+          const samplingOptions = [
+            {
+              text: "MSAA off",
+              onselect: function () {
+                scene.msaaSamples = 1;
+              },
+            },
+            {
+              text: "MSAA 2x",
+              onselect: function () {
+                scene.msaaSamples = 2;
+              },
+            },
+            {
+              text: "MSAA 4x",
+              onselect: function () {
+                scene.msaaSamples = 4;
+              },
+            },
+            {
+              text: "MSAA 8x",
+              onselect: function () {
+                scene.msaaSamples = 8;
+              },
+            },
+          ];
+
+          Sandcastle.addToolbarMenu(options);
+          Sandcastle.addToolbarMenu(samplingOptions);
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/MSAA.html
+++ b/Apps/Sandcastle/gallery/MSAA.html
@@ -32,151 +32,157 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-            contextOptions: {
-              requestWebgl1: false,
-            },
-          });
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          contextOptions: {
+            requestWebgl1: false,
+          },
+        });
 
-          viewer.clock.currentTime = Cesium.JulianDate.fromIso8601(
-            "2022-08-01T00:00:00Z"
+        (async () => {
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+          } catch (error) {
+            console.log(error);
+          }
+        })();
+
+        viewer.clock.currentTime = Cesium.JulianDate.fromIso8601(
+          "2022-08-01T00:00:00Z"
+        );
+
+        const scene = viewer.scene;
+        if (!scene.msaaSupported) {
+          window.alert("This browser does not support MSAA.");
+        }
+
+        function createModel(url, height) {
+          const position = Cesium.Cartesian3.fromDegrees(
+            -123.0744619,
+            44.0503706,
+            height
+          );
+          const heading = Cesium.Math.toRadians(135);
+          const pitch = 0;
+          const roll = 0;
+          const hpr = new Cesium.HeadingPitchRoll(heading, pitch, roll);
+          const orientation = Cesium.Transforms.headingPitchRollQuaternion(
+            position,
+            hpr
           );
 
-          const scene = viewer.scene;
-          if (!scene.msaaSupported) {
-            window.alert("This browser does not support MSAA.");
-          }
+          const entity = viewer.entities.add({
+            name: url,
+            position: position,
+            orientation: orientation,
+            model: {
+              uri: url,
+              minimumPixelSize: 128,
+              maximumScale: 20000,
+            },
+          });
+          const target = Cesium.Cartesian3.fromDegrees(
+            -123.0744619,
+            44.0503706,
+            height + 7.5
+          );
+          const offset = new Cesium.Cartesian3(50.0, -15.0, 0.0);
+          viewer.scene.camera.lookAt(target, offset);
+        }
 
-          function createModel(url, height) {
-            const position = Cesium.Cartesian3.fromDegrees(
-              -123.0744619,
-              44.0503706,
-              height
-            );
-            const heading = Cesium.Math.toRadians(135);
-            const pitch = 0;
-            const roll = 0;
-            const hpr = new Cesium.HeadingPitchRoll(heading, pitch, roll);
-            const orientation = Cesium.Transforms.headingPitchRollQuaternion(
-              position,
-              hpr
-            );
+        const options = [
+          {
+            text: "Statue of Liberty",
+            onselect: function () {
+              viewer.entities.removeAll();
+              scene.primitives.removeAll();
+              scene.camera.setView({
+                destination: new Cesium.Cartesian3(
+                  1331419.302230775,
+                  -4656681.5022043325,
+                  4136232.6465900405
+                ),
+                orientation: new Cesium.HeadingPitchRoll(
+                  6.032455545102689,
+                  -0.056832496140112765,
+                  6.282360923090216
+                ),
+                endTransform: Cesium.Matrix4.IDENTITY,
+              });
 
-            const entity = viewer.entities.add({
-              name: url,
-              position: position,
-              orientation: orientation,
-              model: {
-                uri: url,
-                minimumPixelSize: 128,
-                maximumScale: 20000,
-              },
-            });
-            const target = Cesium.Cartesian3.fromDegrees(
-              -123.0744619,
-              44.0503706,
-              height + 7.5
-            );
-            const offset = new Cesium.Cartesian3(50.0, -15.0, 0.0);
-            viewer.scene.camera.lookAt(target, offset);
-          }
+              scene.primitives.add(
+                new Cesium.Cesium3DTileset({
+                  url: Cesium.IonResource.fromAssetId(75343),
+                })
+              );
+            },
+          },
+          {
+            text: "3D Tiles BIM",
+            onselect: function () {
+              viewer.entities.removeAll();
+              scene.primitives.removeAll();
+              const tileset = scene.primitives.add(
+                new Cesium.Cesium3DTileset({
+                  url: Cesium.IonResource.fromAssetId(1240402),
+                })
+              );
+              viewer.camera.setView({
+                destination: new Cesium.Cartesian3(
+                  1234138.7804841248,
+                  -5086063.633843134,
+                  3633284.606361642
+                ),
+                orientation: {
+                  heading: 0.4304630387656614,
+                  pitch: -0.16969316864215878,
+                  roll: 6.283184816241989,
+                },
+              });
+            },
+          },
+          {
+            text: "Hot Air Balloon",
+            onselect: function () {
+              viewer.entities.removeAll();
+              scene.primitives.removeAll();
+              createModel(
+                "../../SampleData/models/CesiumBalloon/CesiumBalloon.glb",
+                1000.0
+              );
+            },
+          },
+        ];
 
-          const options = [
-            {
-              text: "Statue of Liberty",
-              onselect: function () {
-                viewer.entities.removeAll();
-                scene.primitives.removeAll();
-                scene.camera.setView({
-                  destination: new Cesium.Cartesian3(
-                    1331419.302230775,
-                    -4656681.5022043325,
-                    4136232.6465900405
-                  ),
-                  orientation: new Cesium.HeadingPitchRoll(
-                    6.032455545102689,
-                    -0.056832496140112765,
-                    6.282360923090216
-                  ),
-                  endTransform: Cesium.Matrix4.IDENTITY,
-                });
+        const samplingOptions = [
+          {
+            text: "MSAA off",
+            onselect: function () {
+              scene.msaaSamples = 1;
+            },
+          },
+          {
+            text: "MSAA 2x",
+            onselect: function () {
+              scene.msaaSamples = 2;
+            },
+          },
+          {
+            text: "MSAA 4x",
+            onselect: function () {
+              scene.msaaSamples = 4;
+            },
+          },
+          {
+            text: "MSAA 8x",
+            onselect: function () {
+              scene.msaaSamples = 8;
+            },
+          },
+        ];
 
-                scene.primitives.add(
-                  new Cesium.Cesium3DTileset({
-                    url: Cesium.IonResource.fromAssetId(75343),
-                  })
-                );
-              },
-            },
-            {
-              text: "3D Tiles BIM",
-              onselect: function () {
-                viewer.entities.removeAll();
-                scene.primitives.removeAll();
-                const tileset = scene.primitives.add(
-                  new Cesium.Cesium3DTileset({
-                    url: Cesium.IonResource.fromAssetId(1240402),
-                  })
-                );
-                viewer.camera.setView({
-                  destination: new Cesium.Cartesian3(
-                    1234138.7804841248,
-                    -5086063.633843134,
-                    3633284.606361642
-                  ),
-                  orientation: {
-                    heading: 0.4304630387656614,
-                    pitch: -0.16969316864215878,
-                    roll: 6.283184816241989,
-                  },
-                });
-              },
-            },
-            {
-              text: "Hot Air Balloon",
-              onselect: function () {
-                viewer.entities.removeAll();
-                scene.primitives.removeAll();
-                createModel(
-                  "../../SampleData/models/CesiumBalloon/CesiumBalloon.glb",
-                  1000.0
-                );
-              },
-            },
-          ];
-
-          const samplingOptions = [
-            {
-              text: "MSAA off",
-              onselect: function () {
-                scene.msaaSamples = 1;
-              },
-            },
-            {
-              text: "MSAA 2x",
-              onselect: function () {
-                scene.msaaSamples = 2;
-              },
-            },
-            {
-              text: "MSAA 4x",
-              onselect: function () {
-                scene.msaaSamples = 4;
-              },
-            },
-            {
-              text: "MSAA 8x",
-              onselect: function () {
-                scene.msaaSamples = 8;
-              },
-            },
-          ];
-
-          Sandcastle.addToolbarMenu(options);
-          Sandcastle.addToolbarMenu(samplingOptions);
-        })(); //Sandcastle_End
+        Sandcastle.addToolbarMenu(options);
+        Sandcastle.addToolbarMenu(samplingOptions);
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Montreal Point Cloud.html
+++ b/Apps/Sandcastle/gallery/Montreal Point Cloud.html
@@ -87,7 +87,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         // A ~10 billion point 3D Tileset of the city of Montreal, Canada captured in 2015 with a resolution of 20 cm. Tiled and hosted by Cesium ion.

--- a/Apps/Sandcastle/gallery/Montreal Point Cloud.html
+++ b/Apps/Sandcastle/gallery/Montreal Point Cloud.html
@@ -86,343 +86,344 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
 
-        // A ~10 billion point 3D Tileset of the city of Montreal, Canada captured in 2015 with a resolution of 20 cm. Tiled and hosted by Cesium ion.
-        const tileset = viewer.scene.primitives.add(
-          new Cesium.Cesium3DTileset({
-            url: Cesium.IonResource.fromAssetId(28945),
-            pointCloudShading: {
-              attenuation: true,
-              maximumAttenuation: 2,
-            },
-          })
-        );
+          // A ~10 billion point 3D Tileset of the city of Montreal, Canada captured in 2015 with a resolution of 20 cm. Tiled and hosted by Cesium ion.
+          const tileset = viewer.scene.primitives.add(
+            new Cesium.Cesium3DTileset({
+              url: Cesium.IonResource.fromAssetId(28945),
+              pointCloudShading: {
+                attenuation: true,
+                maximumAttenuation: 2,
+              },
+            })
+          );
 
-        // Fly to a nice overview of the city.
-        viewer.camera.flyTo({
-          destination: new Cesium.Cartesian3(
-            1223285.2286828577,
-            -4319476.080312792,
-            4562579.020145769
-          ),
-          orientation: {
-            direction: new Cesium.Cartesian3(
-              0.63053223097472,
-              0.47519958296727743,
-              -0.6136892226931869
+          // Fly to a nice overview of the city.
+          viewer.camera.flyTo({
+            destination: new Cesium.Cartesian3(
+              1223285.2286828577,
+              -4319476.080312792,
+              4562579.020145769
             ),
-            up: new Cesium.Cartesian3(
-              0.7699959023135587,
-              -0.4824455703743441,
-              0.41755548379407276
-            ),
-          },
-          easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
-        });
-
-        // Add stored views around Montreal. You can add to this list by capturing camera.position, camera.direction and camera.up.
-        Sandcastle.addToolbarMenu([
-          {
-            text: "Overview",
-            onselect: function () {
-              viewer.camera.flyTo({
-                destination: new Cesium.Cartesian3(
-                  1268112.9336926902,
-                  -4347432.089579957,
-                  4539129.813606778
-                ),
-                orientation: {
-                  direction: new Cesium.Cartesian3(
-                    -0.23288147105081208,
-                    0.9376599248561527,
-                    -0.25799241415197466
-                  ),
-                  up: new Cesium.Cartesian3(
-                    -0.015748156073159988,
-                    0.2616156268422992,
-                    0.9650436567182887
-                  ),
-                },
-                easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
-              });
+            orientation: {
+              direction: new Cesium.Cartesian3(
+                0.63053223097472,
+                0.47519958296727743,
+                -0.6136892226931869
+              ),
+              up: new Cesium.Cartesian3(
+                0.7699959023135587,
+                -0.4824455703743441,
+                0.41755548379407276
+              ),
             },
-          },
-          {
-            text: "Highway",
-            onselect: function () {
-              viewer.camera.flyTo({
-                destination: new Cesium.Cartesian3(
-                  1266560.143870489,
-                  -4278126.842199712,
-                  4542690.264566619
-                ),
-                orientation: {
-                  direction: new Cesium.Cartesian3(
-                    -0.3402460635871598,
-                    -0.46669052711538217,
-                    -0.8163532128400116
+            easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
+          });
+
+          // Add stored views around Montreal. You can add to this list by capturing camera.position, camera.direction and camera.up.
+          Sandcastle.addToolbarMenu([
+            {
+              text: "Overview",
+              onselect: function () {
+                viewer.camera.flyTo({
+                  destination: new Cesium.Cartesian3(
+                    1268112.9336926902,
+                    -4347432.089579957,
+                    4539129.813606778
                   ),
-                  up: new Cesium.Cartesian3(
-                    0.08964012922691329,
-                    -0.8802940231336787,
-                    0.46588311846138497
-                  ),
-                },
-                easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
-              });
+                  orientation: {
+                    direction: new Cesium.Cartesian3(
+                      -0.23288147105081208,
+                      0.9376599248561527,
+                      -0.25799241415197466
+                    ),
+                    up: new Cesium.Cartesian3(
+                      -0.015748156073159988,
+                      0.2616156268422992,
+                      0.9650436567182887
+                    ),
+                  },
+                  easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
+                });
+              },
             },
-          },
-          {
-            text: "Olympic Stadium",
-            onselect: function () {
-              viewer.camera.flyTo({
-                destination: new Cesium.Cartesian3(
-                  1267081.619536883,
-                  -4290744.917138439,
-                  4530941.041519919
-                ),
-                orientation: {
-                  direction: new Cesium.Cartesian3(
-                    -0.735813047510908,
-                    0.6294547560338262,
-                    0.24973159435503312
+            {
+              text: "Highway",
+              onselect: function () {
+                viewer.camera.flyTo({
+                  destination: new Cesium.Cartesian3(
+                    1266560.143870489,
+                    -4278126.842199712,
+                    4542690.264566619
                   ),
-                  up: new Cesium.Cartesian3(
-                    -0.09796934684423217,
-                    -0.4638476756625683,
-                    0.88048131204549
-                  ),
-                },
-                easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
-              });
+                  orientation: {
+                    direction: new Cesium.Cartesian3(
+                      -0.3402460635871598,
+                      -0.46669052711538217,
+                      -0.8163532128400116
+                    ),
+                    up: new Cesium.Cartesian3(
+                      0.08964012922691329,
+                      -0.8802940231336787,
+                      0.46588311846138497
+                    ),
+                  },
+                  easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
+                });
+              },
             },
-          },
-          {
-            text: "Biosphere Museum",
-            onselect: function () {
-              viewer.camera.flyTo({
-                destination: new Cesium.Cartesian3(
-                  1269319.8408991008,
-                  -4293301.826913256,
-                  4527724.561372451
-                ),
-                orientation: {
-                  direction: new Cesium.Cartesian3(
-                    -0.742505030107832,
-                    -0.3413204607149223,
-                    -0.5763563336703441
+            {
+              text: "Olympic Stadium",
+              onselect: function () {
+                viewer.camera.flyTo({
+                  destination: new Cesium.Cartesian3(
+                    1267081.619536883,
+                    -4290744.917138439,
+                    4530941.041519919
                   ),
-                  up: new Cesium.Cartesian3(
-                    -0.04655102331027917,
-                    -0.8320643756800384,
-                    0.5527222421370013
-                  ),
-                },
-                easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
-              });
+                  orientation: {
+                    direction: new Cesium.Cartesian3(
+                      -0.735813047510908,
+                      0.6294547560338262,
+                      0.24973159435503312
+                    ),
+                    up: new Cesium.Cartesian3(
+                      -0.09796934684423217,
+                      -0.4638476756625683,
+                      0.88048131204549
+                    ),
+                  },
+                  easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
+                });
+              },
             },
-          },
-          {
-            text: "St. Joseph's Oratory of Mount Royal",
-            onselect: function () {
-              viewer.camera.flyTo({
-                destination: new Cesium.Cartesian3(
-                  1263148.6745904868,
-                  -4297262.506644816,
-                  4525958.844284831
-                ),
-                orientation: {
-                  direction: new Cesium.Cartesian3(
-                    0.6550952540993403,
-                    0.7551122393690295,
-                    0.025606913355780074
+            {
+              text: "Biosphere Museum",
+              onselect: function () {
+                viewer.camera.flyTo({
+                  destination: new Cesium.Cartesian3(
+                    1269319.8408991008,
+                    -4293301.826913256,
+                    4527724.561372451
                   ),
-                  up: new Cesium.Cartesian3(
-                    0.46670450470847263,
-                    -0.4310758971098583,
-                    0.7722437932516845
-                  ),
-                },
-                easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
-              });
+                  orientation: {
+                    direction: new Cesium.Cartesian3(
+                      -0.742505030107832,
+                      -0.3413204607149223,
+                      -0.5763563336703441
+                    ),
+                    up: new Cesium.Cartesian3(
+                      -0.04655102331027917,
+                      -0.8320643756800384,
+                      0.5527222421370013
+                    ),
+                  },
+                  easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
+                });
+              },
             },
-          },
-        ]);
+            {
+              text: "St. Joseph's Oratory of Mount Royal",
+              onselect: function () {
+                viewer.camera.flyTo({
+                  destination: new Cesium.Cartesian3(
+                    1263148.6745904868,
+                    -4297262.506644816,
+                    4525958.844284831
+                  ),
+                  orientation: {
+                    direction: new Cesium.Cartesian3(
+                      0.6550952540993403,
+                      0.7551122393690295,
+                      0.025606913355780074
+                    ),
+                    up: new Cesium.Cartesian3(
+                      0.46670450470847263,
+                      -0.4310758971098583,
+                      0.7722437932516845
+                    ),
+                  },
+                  easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
+                });
+              },
+            },
+          ]);
 
-        // Set up checkboxes for toggling the various classification settings.
-        const viewModel = {
-          ground: true,
-          other: true,
-          buildings: true,
-          low_vegetation: true,
-          medium_vegetation: true,
-          high_vegetation: true,
-        };
-
-        // Assign colors to each classification type.
-        const pointStyles = {
-          unclassified: {
-            color: "color('#808080')",
-            show: true,
-          },
-          not_awarded: {
-            color: "color('#FFDEAD')",
-            show: true,
-          },
-          ground: {
-            color: "color('#FFDEAD')",
-            show: true,
-          },
-          low_vegetation: {
-            color: "color('#63FF7E')",
-            show: true,
-          },
-          medium_vegetation: {
-            color: "color('#63FF7E')",
-            show: true,
-          },
-          high_vegetation: {
-            color: "color('#22B33A')",
-            show: true,
-          },
-          buildings: {
-            color: "color('#efefef')",
-            show: true,
-          },
-          low_point: {
-            color: "color('#808080')",
-            show: true,
-          },
-          reserved_city_diffusion: {
-            color: "color('#808080')",
-            show: true,
-          },
-        };
-
-        const classificationDictionary = {
-          not_awarded: 1,
-          ground: 2,
-          low_vegetation: 3,
-          medium_vegetation: 4,
-          high_vegetation: 5,
-          buildings: 6,
-          low_point: 7,
-          reserved_city_diffusion: 8,
-          unclassified: -1,
-        };
-
-        // This is a helper function to re-apply the styles each time the UI/checkboxes are updated.
-        function applyStyle(tileset, styles) {
-          const styleObject = {};
-          const styleKeys = Object.keys(styles);
-
-          styleObject.color = {
-            conditions: [],
-          };
-          styleObject.show = {
-            conditions: [],
+          // Set up checkboxes for toggling the various classification settings.
+          const viewModel = {
+            ground: true,
+            other: true,
+            buildings: true,
+            low_vegetation: true,
+            medium_vegetation: true,
+            high_vegetation: true,
           };
 
-          let finalCondition;
+          // Assign colors to each classification type.
+          const pointStyles = {
+            unclassified: {
+              color: "color('#808080')",
+              show: true,
+            },
+            not_awarded: {
+              color: "color('#FFDEAD')",
+              show: true,
+            },
+            ground: {
+              color: "color('#FFDEAD')",
+              show: true,
+            },
+            low_vegetation: {
+              color: "color('#63FF7E')",
+              show: true,
+            },
+            medium_vegetation: {
+              color: "color('#63FF7E')",
+              show: true,
+            },
+            high_vegetation: {
+              color: "color('#22B33A')",
+              show: true,
+            },
+            buildings: {
+              color: "color('#efefef')",
+              show: true,
+            },
+            low_point: {
+              color: "color('#808080')",
+              show: true,
+            },
+            reserved_city_diffusion: {
+              color: "color('#808080')",
+              show: true,
+            },
+          };
 
-          for (let i = 0; i < styleKeys.length; ++i) {
-            const key = styleKeys[i];
-            const id = classificationDictionary[key];
+          const classificationDictionary = {
+            not_awarded: 1,
+            ground: 2,
+            low_vegetation: 3,
+            medium_vegetation: 4,
+            high_vegetation: 5,
+            buildings: 6,
+            low_point: 7,
+            reserved_city_diffusion: 8,
+            unclassified: -1,
+          };
 
-            const colorCondition = [
-              `\${Classification} === ${id}`,
-              styles[key].color,
-            ];
-            const showCondition = [
-              `\${Classification} === ${id}`,
-              styles[key].show,
-            ];
+          // This is a helper function to re-apply the styles each time the UI/checkboxes are updated.
+          function applyStyle(tileset, styles) {
+            const styleObject = {};
+            const styleKeys = Object.keys(styles);
 
-            if (id === -1) {
-              colorCondition[0] = true;
-              showCondition[0] = true;
+            styleObject.color = {
+              conditions: [],
+            };
+            styleObject.show = {
+              conditions: [],
+            };
 
-              finalCondition = {
-                colorCondition: colorCondition,
-                showCondition: showCondition,
-              };
-            } else {
-              styleObject.color.conditions.push(colorCondition);
-              styleObject.show.conditions.push(showCondition);
+            let finalCondition;
+
+            for (let i = 0; i < styleKeys.length; ++i) {
+              const key = styleKeys[i];
+              const id = classificationDictionary[key];
+
+              const colorCondition = [
+                `\${Classification} === ${id}`,
+                styles[key].color,
+              ];
+              const showCondition = [
+                `\${Classification} === ${id}`,
+                styles[key].show,
+              ];
+
+              if (id === -1) {
+                colorCondition[0] = true;
+                showCondition[0] = true;
+
+                finalCondition = {
+                  colorCondition: colorCondition,
+                  showCondition: showCondition,
+                };
+              } else {
+                styleObject.color.conditions.push(colorCondition);
+                styleObject.show.conditions.push(showCondition);
+              }
             }
+
+            if (Cesium.defined(finalCondition)) {
+              styleObject.color.conditions.push(finalCondition.colorCondition);
+              styleObject.show.conditions.push(finalCondition.showCondition);
+            }
+
+            tileset.style = new Cesium.Cesium3DTileStyle(styleObject);
           }
 
-          if (Cesium.defined(finalCondition)) {
-            styleObject.color.conditions.push(finalCondition.colorCondition);
-            styleObject.show.conditions.push(finalCondition.showCondition);
-          }
+          // Apply an initial style.
+          applyStyle(tileset, pointStyles);
 
-          tileset.style = new Cesium.Cesium3DTileStyle(styleObject);
-        }
+          Cesium.knockout.track(viewModel);
 
-        // Apply an initial style.
-        applyStyle(tileset, pointStyles);
+          const toolbar = document.getElementById("toolbar");
+          Cesium.knockout.applyBindings(viewModel, toolbar);
 
-        Cesium.knockout.track(viewModel);
+          // Set up the checkboxes.
+          Cesium.knockout
+            .getObservable(viewModel, "ground")
+            .subscribe(function (show) {
+              pointStyles.ground.show = show;
+              pointStyles.not_awarded.show = show;
 
-        const toolbar = document.getElementById("toolbar");
-        Cesium.knockout.applyBindings(viewModel, toolbar);
+              applyStyle(tileset, pointStyles);
+            });
 
-        // Set up the checkboxes.
-        Cesium.knockout
-          .getObservable(viewModel, "ground")
-          .subscribe(function (show) {
-            pointStyles.ground.show = show;
-            pointStyles.not_awarded.show = show;
+          Cesium.knockout
+            .getObservable(viewModel, "low_vegetation")
+            .subscribe(function (show) {
+              pointStyles.low_vegetation.show = show;
 
-            applyStyle(tileset, pointStyles);
-          });
+              applyStyle(tileset, pointStyles);
+            });
 
-        Cesium.knockout
-          .getObservable(viewModel, "low_vegetation")
-          .subscribe(function (show) {
-            pointStyles.low_vegetation.show = show;
+          Cesium.knockout
+            .getObservable(viewModel, "medium_vegetation")
+            .subscribe(function (show) {
+              pointStyles.medium_vegetation.show = show;
 
-            applyStyle(tileset, pointStyles);
-          });
+              applyStyle(tileset, pointStyles);
+            });
 
-        Cesium.knockout
-          .getObservable(viewModel, "medium_vegetation")
-          .subscribe(function (show) {
-            pointStyles.medium_vegetation.show = show;
+          Cesium.knockout
+            .getObservable(viewModel, "high_vegetation")
+            .subscribe(function (show) {
+              pointStyles.high_vegetation.show = show;
 
-            applyStyle(tileset, pointStyles);
-          });
+              applyStyle(tileset, pointStyles);
+            });
 
-        Cesium.knockout
-          .getObservable(viewModel, "high_vegetation")
-          .subscribe(function (show) {
-            pointStyles.high_vegetation.show = show;
+          Cesium.knockout
+            .getObservable(viewModel, "buildings")
+            .subscribe(function (show) {
+              pointStyles.buildings.show = show;
 
-            applyStyle(tileset, pointStyles);
-          });
+              applyStyle(tileset, pointStyles);
+            });
 
-        Cesium.knockout
-          .getObservable(viewModel, "buildings")
-          .subscribe(function (show) {
-            pointStyles.buildings.show = show;
+          Cesium.knockout
+            .getObservable(viewModel, "other")
+            .subscribe(function (show) {
+              pointStyles.low_point.show = show;
+              pointStyles.reserved_city_diffusion.show = show;
+              pointStyles.unclassified.show = show;
 
-            applyStyle(tileset, pointStyles);
-          });
-
-        Cesium.knockout
-          .getObservable(viewModel, "other")
-          .subscribe(function (show) {
-            pointStyles.low_point.show = show;
-            pointStyles.reserved_city_diffusion.show = show;
-            pointStyles.unclassified.show = show;
-
-            applyStyle(tileset, pointStyles);
-          });
-        //Sandcastle_End
+              applyStyle(tileset, pointStyles);
+            });
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Montreal Point Cloud.html
+++ b/Apps/Sandcastle/gallery/Montreal Point Cloud.html
@@ -86,344 +86,349 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        const viewer = new Cesium.Viewer("cesiumContainer");
+
         (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+          } catch (error) {
+            console.log(error);
+          }
+        })();
 
-          // A ~10 billion point 3D Tileset of the city of Montreal, Canada captured in 2015 with a resolution of 20 cm. Tiled and hosted by Cesium ion.
-          const tileset = viewer.scene.primitives.add(
-            new Cesium.Cesium3DTileset({
-              url: Cesium.IonResource.fromAssetId(28945),
-              pointCloudShading: {
-                attenuation: true,
-                maximumAttenuation: 2,
-              },
-            })
-          );
+        // A ~10 billion point 3D Tileset of the city of Montreal, Canada captured in 2015 with a resolution of 20 cm. Tiled and hosted by Cesium ion.
+        const tileset = viewer.scene.primitives.add(
+          new Cesium.Cesium3DTileset({
+            url: Cesium.IonResource.fromAssetId(28945),
+            pointCloudShading: {
+              attenuation: true,
+              maximumAttenuation: 2,
+            },
+          })
+        );
 
-          // Fly to a nice overview of the city.
-          viewer.camera.flyTo({
-            destination: new Cesium.Cartesian3(
-              1223285.2286828577,
-              -4319476.080312792,
-              4562579.020145769
+        // Fly to a nice overview of the city.
+        viewer.camera.flyTo({
+          destination: new Cesium.Cartesian3(
+            1223285.2286828577,
+            -4319476.080312792,
+            4562579.020145769
+          ),
+          orientation: {
+            direction: new Cesium.Cartesian3(
+              0.63053223097472,
+              0.47519958296727743,
+              -0.6136892226931869
             ),
-            orientation: {
-              direction: new Cesium.Cartesian3(
-                0.63053223097472,
-                0.47519958296727743,
-                -0.6136892226931869
-              ),
-              up: new Cesium.Cartesian3(
-                0.7699959023135587,
-                -0.4824455703743441,
-                0.41755548379407276
-              ),
-            },
-            easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
-          });
+            up: new Cesium.Cartesian3(
+              0.7699959023135587,
+              -0.4824455703743441,
+              0.41755548379407276
+            ),
+          },
+          easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
+        });
 
-          // Add stored views around Montreal. You can add to this list by capturing camera.position, camera.direction and camera.up.
-          Sandcastle.addToolbarMenu([
-            {
-              text: "Overview",
-              onselect: function () {
-                viewer.camera.flyTo({
-                  destination: new Cesium.Cartesian3(
-                    1268112.9336926902,
-                    -4347432.089579957,
-                    4539129.813606778
+        // Add stored views around Montreal. You can add to this list by capturing camera.position, camera.direction and camera.up.
+        Sandcastle.addToolbarMenu([
+          {
+            text: "Overview",
+            onselect: function () {
+              viewer.camera.flyTo({
+                destination: new Cesium.Cartesian3(
+                  1268112.9336926902,
+                  -4347432.089579957,
+                  4539129.813606778
+                ),
+                orientation: {
+                  direction: new Cesium.Cartesian3(
+                    -0.23288147105081208,
+                    0.9376599248561527,
+                    -0.25799241415197466
                   ),
-                  orientation: {
-                    direction: new Cesium.Cartesian3(
-                      -0.23288147105081208,
-                      0.9376599248561527,
-                      -0.25799241415197466
-                    ),
-                    up: new Cesium.Cartesian3(
-                      -0.015748156073159988,
-                      0.2616156268422992,
-                      0.9650436567182887
-                    ),
-                  },
-                  easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
-                });
-              },
-            },
-            {
-              text: "Highway",
-              onselect: function () {
-                viewer.camera.flyTo({
-                  destination: new Cesium.Cartesian3(
-                    1266560.143870489,
-                    -4278126.842199712,
-                    4542690.264566619
+                  up: new Cesium.Cartesian3(
+                    -0.015748156073159988,
+                    0.2616156268422992,
+                    0.9650436567182887
                   ),
-                  orientation: {
-                    direction: new Cesium.Cartesian3(
-                      -0.3402460635871598,
-                      -0.46669052711538217,
-                      -0.8163532128400116
-                    ),
-                    up: new Cesium.Cartesian3(
-                      0.08964012922691329,
-                      -0.8802940231336787,
-                      0.46588311846138497
-                    ),
-                  },
-                  easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
-                });
-              },
+                },
+                easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
+              });
             },
-            {
-              text: "Olympic Stadium",
-              onselect: function () {
-                viewer.camera.flyTo({
-                  destination: new Cesium.Cartesian3(
-                    1267081.619536883,
-                    -4290744.917138439,
-                    4530941.041519919
+          },
+          {
+            text: "Highway",
+            onselect: function () {
+              viewer.camera.flyTo({
+                destination: new Cesium.Cartesian3(
+                  1266560.143870489,
+                  -4278126.842199712,
+                  4542690.264566619
+                ),
+                orientation: {
+                  direction: new Cesium.Cartesian3(
+                    -0.3402460635871598,
+                    -0.46669052711538217,
+                    -0.8163532128400116
                   ),
-                  orientation: {
-                    direction: new Cesium.Cartesian3(
-                      -0.735813047510908,
-                      0.6294547560338262,
-                      0.24973159435503312
-                    ),
-                    up: new Cesium.Cartesian3(
-                      -0.09796934684423217,
-                      -0.4638476756625683,
-                      0.88048131204549
-                    ),
-                  },
-                  easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
-                });
-              },
-            },
-            {
-              text: "Biosphere Museum",
-              onselect: function () {
-                viewer.camera.flyTo({
-                  destination: new Cesium.Cartesian3(
-                    1269319.8408991008,
-                    -4293301.826913256,
-                    4527724.561372451
+                  up: new Cesium.Cartesian3(
+                    0.08964012922691329,
+                    -0.8802940231336787,
+                    0.46588311846138497
                   ),
-                  orientation: {
-                    direction: new Cesium.Cartesian3(
-                      -0.742505030107832,
-                      -0.3413204607149223,
-                      -0.5763563336703441
-                    ),
-                    up: new Cesium.Cartesian3(
-                      -0.04655102331027917,
-                      -0.8320643756800384,
-                      0.5527222421370013
-                    ),
-                  },
-                  easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
-                });
-              },
+                },
+                easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
+              });
             },
-            {
-              text: "St. Joseph's Oratory of Mount Royal",
-              onselect: function () {
-                viewer.camera.flyTo({
-                  destination: new Cesium.Cartesian3(
-                    1263148.6745904868,
-                    -4297262.506644816,
-                    4525958.844284831
+          },
+          {
+            text: "Olympic Stadium",
+            onselect: function () {
+              viewer.camera.flyTo({
+                destination: new Cesium.Cartesian3(
+                  1267081.619536883,
+                  -4290744.917138439,
+                  4530941.041519919
+                ),
+                orientation: {
+                  direction: new Cesium.Cartesian3(
+                    -0.735813047510908,
+                    0.6294547560338262,
+                    0.24973159435503312
                   ),
-                  orientation: {
-                    direction: new Cesium.Cartesian3(
-                      0.6550952540993403,
-                      0.7551122393690295,
-                      0.025606913355780074
-                    ),
-                    up: new Cesium.Cartesian3(
-                      0.46670450470847263,
-                      -0.4310758971098583,
-                      0.7722437932516845
-                    ),
-                  },
-                  easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
-                });
-              },
+                  up: new Cesium.Cartesian3(
+                    -0.09796934684423217,
+                    -0.4638476756625683,
+                    0.88048131204549
+                  ),
+                },
+                easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
+              });
             },
-          ]);
+          },
+          {
+            text: "Biosphere Museum",
+            onselect: function () {
+              viewer.camera.flyTo({
+                destination: new Cesium.Cartesian3(
+                  1269319.8408991008,
+                  -4293301.826913256,
+                  4527724.561372451
+                ),
+                orientation: {
+                  direction: new Cesium.Cartesian3(
+                    -0.742505030107832,
+                    -0.3413204607149223,
+                    -0.5763563336703441
+                  ),
+                  up: new Cesium.Cartesian3(
+                    -0.04655102331027917,
+                    -0.8320643756800384,
+                    0.5527222421370013
+                  ),
+                },
+                easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
+              });
+            },
+          },
+          {
+            text: "St. Joseph's Oratory of Mount Royal",
+            onselect: function () {
+              viewer.camera.flyTo({
+                destination: new Cesium.Cartesian3(
+                  1263148.6745904868,
+                  -4297262.506644816,
+                  4525958.844284831
+                ),
+                orientation: {
+                  direction: new Cesium.Cartesian3(
+                    0.6550952540993403,
+                    0.7551122393690295,
+                    0.025606913355780074
+                  ),
+                  up: new Cesium.Cartesian3(
+                    0.46670450470847263,
+                    -0.4310758971098583,
+                    0.7722437932516845
+                  ),
+                },
+                easingFunction: Cesium.EasingFunction.QUADRATIC_IN_OUT,
+              });
+            },
+          },
+        ]);
 
-          // Set up checkboxes for toggling the various classification settings.
-          const viewModel = {
-            ground: true,
-            other: true,
-            buildings: true,
-            low_vegetation: true,
-            medium_vegetation: true,
-            high_vegetation: true,
+        // Set up checkboxes for toggling the various classification settings.
+        const viewModel = {
+          ground: true,
+          other: true,
+          buildings: true,
+          low_vegetation: true,
+          medium_vegetation: true,
+          high_vegetation: true,
+        };
+
+        // Assign colors to each classification type.
+        const pointStyles = {
+          unclassified: {
+            color: "color('#808080')",
+            show: true,
+          },
+          not_awarded: {
+            color: "color('#FFDEAD')",
+            show: true,
+          },
+          ground: {
+            color: "color('#FFDEAD')",
+            show: true,
+          },
+          low_vegetation: {
+            color: "color('#63FF7E')",
+            show: true,
+          },
+          medium_vegetation: {
+            color: "color('#63FF7E')",
+            show: true,
+          },
+          high_vegetation: {
+            color: "color('#22B33A')",
+            show: true,
+          },
+          buildings: {
+            color: "color('#efefef')",
+            show: true,
+          },
+          low_point: {
+            color: "color('#808080')",
+            show: true,
+          },
+          reserved_city_diffusion: {
+            color: "color('#808080')",
+            show: true,
+          },
+        };
+
+        const classificationDictionary = {
+          not_awarded: 1,
+          ground: 2,
+          low_vegetation: 3,
+          medium_vegetation: 4,
+          high_vegetation: 5,
+          buildings: 6,
+          low_point: 7,
+          reserved_city_diffusion: 8,
+          unclassified: -1,
+        };
+
+        // This is a helper function to re-apply the styles each time the UI/checkboxes are updated.
+        function applyStyle(tileset, styles) {
+          const styleObject = {};
+          const styleKeys = Object.keys(styles);
+
+          styleObject.color = {
+            conditions: [],
+          };
+          styleObject.show = {
+            conditions: [],
           };
 
-          // Assign colors to each classification type.
-          const pointStyles = {
-            unclassified: {
-              color: "color('#808080')",
-              show: true,
-            },
-            not_awarded: {
-              color: "color('#FFDEAD')",
-              show: true,
-            },
-            ground: {
-              color: "color('#FFDEAD')",
-              show: true,
-            },
-            low_vegetation: {
-              color: "color('#63FF7E')",
-              show: true,
-            },
-            medium_vegetation: {
-              color: "color('#63FF7E')",
-              show: true,
-            },
-            high_vegetation: {
-              color: "color('#22B33A')",
-              show: true,
-            },
-            buildings: {
-              color: "color('#efefef')",
-              show: true,
-            },
-            low_point: {
-              color: "color('#808080')",
-              show: true,
-            },
-            reserved_city_diffusion: {
-              color: "color('#808080')",
-              show: true,
-            },
-          };
+          let finalCondition;
 
-          const classificationDictionary = {
-            not_awarded: 1,
-            ground: 2,
-            low_vegetation: 3,
-            medium_vegetation: 4,
-            high_vegetation: 5,
-            buildings: 6,
-            low_point: 7,
-            reserved_city_diffusion: 8,
-            unclassified: -1,
-          };
+          for (let i = 0; i < styleKeys.length; ++i) {
+            const key = styleKeys[i];
+            const id = classificationDictionary[key];
 
-          // This is a helper function to re-apply the styles each time the UI/checkboxes are updated.
-          function applyStyle(tileset, styles) {
-            const styleObject = {};
-            const styleKeys = Object.keys(styles);
+            const colorCondition = [
+              `\${Classification} === ${id}`,
+              styles[key].color,
+            ];
+            const showCondition = [
+              `\${Classification} === ${id}`,
+              styles[key].show,
+            ];
 
-            styleObject.color = {
-              conditions: [],
-            };
-            styleObject.show = {
-              conditions: [],
-            };
+            if (id === -1) {
+              colorCondition[0] = true;
+              showCondition[0] = true;
 
-            let finalCondition;
-
-            for (let i = 0; i < styleKeys.length; ++i) {
-              const key = styleKeys[i];
-              const id = classificationDictionary[key];
-
-              const colorCondition = [
-                `\${Classification} === ${id}`,
-                styles[key].color,
-              ];
-              const showCondition = [
-                `\${Classification} === ${id}`,
-                styles[key].show,
-              ];
-
-              if (id === -1) {
-                colorCondition[0] = true;
-                showCondition[0] = true;
-
-                finalCondition = {
-                  colorCondition: colorCondition,
-                  showCondition: showCondition,
-                };
-              } else {
-                styleObject.color.conditions.push(colorCondition);
-                styleObject.show.conditions.push(showCondition);
-              }
+              finalCondition = {
+                colorCondition: colorCondition,
+                showCondition: showCondition,
+              };
+            } else {
+              styleObject.color.conditions.push(colorCondition);
+              styleObject.show.conditions.push(showCondition);
             }
-
-            if (Cesium.defined(finalCondition)) {
-              styleObject.color.conditions.push(finalCondition.colorCondition);
-              styleObject.show.conditions.push(finalCondition.showCondition);
-            }
-
-            tileset.style = new Cesium.Cesium3DTileStyle(styleObject);
           }
 
-          // Apply an initial style.
-          applyStyle(tileset, pointStyles);
+          if (Cesium.defined(finalCondition)) {
+            styleObject.color.conditions.push(finalCondition.colorCondition);
+            styleObject.show.conditions.push(finalCondition.showCondition);
+          }
 
-          Cesium.knockout.track(viewModel);
+          tileset.style = new Cesium.Cesium3DTileStyle(styleObject);
+        }
 
-          const toolbar = document.getElementById("toolbar");
-          Cesium.knockout.applyBindings(viewModel, toolbar);
+        // Apply an initial style.
+        applyStyle(tileset, pointStyles);
 
-          // Set up the checkboxes.
-          Cesium.knockout
-            .getObservable(viewModel, "ground")
-            .subscribe(function (show) {
-              pointStyles.ground.show = show;
-              pointStyles.not_awarded.show = show;
+        Cesium.knockout.track(viewModel);
 
-              applyStyle(tileset, pointStyles);
-            });
+        const toolbar = document.getElementById("toolbar");
+        Cesium.knockout.applyBindings(viewModel, toolbar);
 
-          Cesium.knockout
-            .getObservable(viewModel, "low_vegetation")
-            .subscribe(function (show) {
-              pointStyles.low_vegetation.show = show;
+        // Set up the checkboxes.
+        Cesium.knockout
+          .getObservable(viewModel, "ground")
+          .subscribe(function (show) {
+            pointStyles.ground.show = show;
+            pointStyles.not_awarded.show = show;
 
-              applyStyle(tileset, pointStyles);
-            });
+            applyStyle(tileset, pointStyles);
+          });
 
-          Cesium.knockout
-            .getObservable(viewModel, "medium_vegetation")
-            .subscribe(function (show) {
-              pointStyles.medium_vegetation.show = show;
+        Cesium.knockout
+          .getObservable(viewModel, "low_vegetation")
+          .subscribe(function (show) {
+            pointStyles.low_vegetation.show = show;
 
-              applyStyle(tileset, pointStyles);
-            });
+            applyStyle(tileset, pointStyles);
+          });
 
-          Cesium.knockout
-            .getObservable(viewModel, "high_vegetation")
-            .subscribe(function (show) {
-              pointStyles.high_vegetation.show = show;
+        Cesium.knockout
+          .getObservable(viewModel, "medium_vegetation")
+          .subscribe(function (show) {
+            pointStyles.medium_vegetation.show = show;
 
-              applyStyle(tileset, pointStyles);
-            });
+            applyStyle(tileset, pointStyles);
+          });
 
-          Cesium.knockout
-            .getObservable(viewModel, "buildings")
-            .subscribe(function (show) {
-              pointStyles.buildings.show = show;
+        Cesium.knockout
+          .getObservable(viewModel, "high_vegetation")
+          .subscribe(function (show) {
+            pointStyles.high_vegetation.show = show;
 
-              applyStyle(tileset, pointStyles);
-            });
+            applyStyle(tileset, pointStyles);
+          });
 
-          Cesium.knockout
-            .getObservable(viewModel, "other")
-            .subscribe(function (show) {
-              pointStyles.low_point.show = show;
-              pointStyles.reserved_city_diffusion.show = show;
-              pointStyles.unclassified.show = show;
+        Cesium.knockout
+          .getObservable(viewModel, "buildings")
+          .subscribe(function (show) {
+            pointStyles.buildings.show = show;
 
-              applyStyle(tileset, pointStyles);
-            });
-        })(); //Sandcastle_End
+            applyStyle(tileset, pointStyles);
+          });
+
+        Cesium.knockout
+          .getObservable(viewModel, "other")
+          .subscribe(function (show) {
+            pointStyles.low_point.show = show;
+            pointStyles.reserved_city_diffusion.show = show;
+            pointStyles.unclassified.show = show;
+
+            applyStyle(tileset, pointStyles);
+          });
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/PAMAP Terrain.html
+++ b/Apps/Sandcastle/gallery/PAMAP Terrain.html
@@ -35,106 +35,112 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        // High resolution terrain of Pennsylvania curated by Pennsylvania Spatial Data Access (PASDA)
-        // http://www.pasda.psu.edu/
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.CesiumTerrainProvider.fromUrl(
-            Cesium.IonResource.fromAssetId(3957)
-          ),
-        });
+        (async () => {
+          let viewer;
+          try {
+            // High resolution terrain of Pennsylvania curated by Pennsylvania Spatial Data Access (PASDA)
+            // http://www.pasda.psu.edu/
+            viewer = new Cesium.Viewer("cesiumContainer", {
+              terrainProvider: await Cesium.CesiumTerrainProvider.fromUrl(
+                Cesium.IonResource.fromAssetId(3957)
+              ),
+            });
+          } catch (error) {
+            console.log(error);
+          }
 
-        // Add PA locations
-        Sandcastle.addDefaultToolbarMenu(
-          [
-            {
-              text: "Pinnacle",
-              onselect: function () {
-                viewer.scene.camera.flyTo({
-                  destination: Cesium.Cartesian3.fromRadians(
-                    -1.3324415110874286,
-                    0.6954224325279967,
-                    236.6770689945084
-                  ),
-                  orientation: {
-                    heading: Cesium.Math.toRadians(310),
-                    pitch: Cesium.Math.toRadians(-15),
-                    roll: 0.0,
-                  },
-                });
+          // Add PA locations
+          Sandcastle.addDefaultToolbarMenu(
+            [
+              {
+                text: "Pinnacle",
+                onselect: function () {
+                  viewer.scene.camera.flyTo({
+                    destination: Cesium.Cartesian3.fromRadians(
+                      -1.3324415110874286,
+                      0.6954224325279967,
+                      236.6770689945084
+                    ),
+                    orientation: {
+                      heading: Cesium.Math.toRadians(310),
+                      pitch: Cesium.Math.toRadians(-15),
+                      roll: 0.0,
+                    },
+                  });
+                },
               },
-            },
-            {
-              text: "Mount Nittany",
-              onselect: function () {
-                viewer.scene.camera.flyTo({
-                  destination: Cesium.Cartesian3.fromRadians(
-                    -1.358985133937573,
-                    0.7123252393978314,
-                    451.05748252867375
-                  ),
-                  orientation: {
-                    heading: Cesium.Math.toRadians(85),
-                    pitch: Cesium.Math.toRadians(0),
-                    roll: 0.0,
-                  },
-                });
+              {
+                text: "Mount Nittany",
+                onselect: function () {
+                  viewer.scene.camera.flyTo({
+                    destination: Cesium.Cartesian3.fromRadians(
+                      -1.358985133937573,
+                      0.7123252393978314,
+                      451.05748252867375
+                    ),
+                    orientation: {
+                      heading: Cesium.Math.toRadians(85),
+                      pitch: Cesium.Math.toRadians(0),
+                      roll: 0.0,
+                    },
+                  });
+                },
               },
-            },
-            {
-              text: "Horseshoe Curve",
-              onselect: function () {
-                viewer.scene.camera.flyTo({
-                  destination: Cesium.Cartesian3.fromRadians(
-                    -1.3700147546199826,
-                    0.706808606166025,
-                    993.7916313325215
-                  ),
-                  orientation: {
-                    heading: Cesium.Math.toRadians(90),
-                    pitch: Cesium.Math.toRadians(-15),
-                    roll: 0.0,
-                  },
-                });
+              {
+                text: "Horseshoe Curve",
+                onselect: function () {
+                  viewer.scene.camera.flyTo({
+                    destination: Cesium.Cartesian3.fromRadians(
+                      -1.3700147546199826,
+                      0.706808606166025,
+                      993.7916313325215
+                    ),
+                    orientation: {
+                      heading: Cesium.Math.toRadians(90),
+                      pitch: Cesium.Math.toRadians(-15),
+                      roll: 0.0,
+                    },
+                  });
+                },
               },
-            },
-            {
-              text: "Jim Thorpe",
-              onselect: function () {
-                viewer.scene.camera.flyTo({
-                  destination: Cesium.Cartesian3.fromRadians(
-                    -1.3218297501066052,
-                    0.713358272291525,
-                    240.87968743408845
-                  ),
-                  orientation: {
-                    heading: Cesium.Math.toRadians(200),
-                    pitch: Cesium.Math.toRadians(-5),
-                    roll: 0.0,
-                  },
-                });
+              {
+                text: "Jim Thorpe",
+                onselect: function () {
+                  viewer.scene.camera.flyTo({
+                    destination: Cesium.Cartesian3.fromRadians(
+                      -1.3218297501066052,
+                      0.713358272291525,
+                      240.87968743408845
+                    ),
+                    orientation: {
+                      heading: Cesium.Math.toRadians(200),
+                      pitch: Cesium.Math.toRadians(-5),
+                      roll: 0.0,
+                    },
+                  });
+                },
               },
-            },
-            {
-              text: "Grand Canyon of PA",
-              onselect: function () {
-                viewer.scene.camera.flyTo({
-                  destination: Cesium.Cartesian3.fromRadians(
-                    -1.349379633251472,
-                    0.720297672225785,
-                    656.268309953562
-                  ),
-                  orientation: {
-                    heading: Cesium.Math.toRadians(200),
-                    pitch: Cesium.Math.toRadians(-5),
-                    roll: 0.0,
-                  },
-                });
+              {
+                text: "Grand Canyon of PA",
+                onselect: function () {
+                  viewer.scene.camera.flyTo({
+                    destination: Cesium.Cartesian3.fromRadians(
+                      -1.349379633251472,
+                      0.720297672225785,
+                      656.268309953562
+                    ),
+                    orientation: {
+                      heading: Cesium.Math.toRadians(200),
+                      pitch: Cesium.Math.toRadians(-5),
+                      roll: 0.0,
+                    },
+                  });
+                },
               },
-            },
-          ],
-          "toolbar"
-        );
-        //Sandcastle_End
+            ],
+            "toolbar"
+          );
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/PAMAP Terrain.html
+++ b/Apps/Sandcastle/gallery/PAMAP Terrain.html
@@ -38,9 +38,9 @@
         // High resolution terrain of Pennsylvania curated by Pennsylvania Spatial Data Access (PASDA)
         // http://www.pasda.psu.edu/
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: new Cesium.CesiumTerrainProvider({
-            url: Cesium.IonResource.fromAssetId(3957),
-          }),
+          terrainProvider: Cesium.CesiumTerrainProvider.fromUrl(
+            Cesium.IonResource.fromAssetId(3957)
+          ),
         });
 
         // Add PA locations

--- a/Apps/Sandcastle/gallery/PAMAP Terrain.html
+++ b/Apps/Sandcastle/gallery/PAMAP Terrain.html
@@ -35,112 +35,112 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        const viewer = new Cesium.Viewer("cesiumContainer");
+
         (async () => {
-          let viewer;
           try {
             // High resolution terrain of Pennsylvania curated by Pennsylvania Spatial Data Access (PASDA)
             // http://www.pasda.psu.edu/
-            viewer = new Cesium.Viewer("cesiumContainer", {
-              terrainProvider: await Cesium.CesiumTerrainProvider.fromUrl(
-                Cesium.IonResource.fromAssetId(3957)
-              ),
-            });
+            viewer.terrainProvider = await Cesium.CesiumTerrainProvider.fromUrl(
+              Cesium.IonResource.fromAssetId(3957)
+            );
           } catch (error) {
             console.log(error);
           }
+        })();
 
-          // Add PA locations
-          Sandcastle.addDefaultToolbarMenu(
-            [
-              {
-                text: "Pinnacle",
-                onselect: function () {
-                  viewer.scene.camera.flyTo({
-                    destination: Cesium.Cartesian3.fromRadians(
-                      -1.3324415110874286,
-                      0.6954224325279967,
-                      236.6770689945084
-                    ),
-                    orientation: {
-                      heading: Cesium.Math.toRadians(310),
-                      pitch: Cesium.Math.toRadians(-15),
-                      roll: 0.0,
-                    },
-                  });
-                },
+        // Add PA locations
+        Sandcastle.addDefaultToolbarMenu(
+          [
+            {
+              text: "Pinnacle",
+              onselect: function () {
+                viewer.scene.camera.flyTo({
+                  destination: Cesium.Cartesian3.fromRadians(
+                    -1.3324415110874286,
+                    0.6954224325279967,
+                    236.6770689945084
+                  ),
+                  orientation: {
+                    heading: Cesium.Math.toRadians(310),
+                    pitch: Cesium.Math.toRadians(-15),
+                    roll: 0.0,
+                  },
+                });
               },
-              {
-                text: "Mount Nittany",
-                onselect: function () {
-                  viewer.scene.camera.flyTo({
-                    destination: Cesium.Cartesian3.fromRadians(
-                      -1.358985133937573,
-                      0.7123252393978314,
-                      451.05748252867375
-                    ),
-                    orientation: {
-                      heading: Cesium.Math.toRadians(85),
-                      pitch: Cesium.Math.toRadians(0),
-                      roll: 0.0,
-                    },
-                  });
-                },
+            },
+            {
+              text: "Mount Nittany",
+              onselect: function () {
+                viewer.scene.camera.flyTo({
+                  destination: Cesium.Cartesian3.fromRadians(
+                    -1.358985133937573,
+                    0.7123252393978314,
+                    451.05748252867375
+                  ),
+                  orientation: {
+                    heading: Cesium.Math.toRadians(85),
+                    pitch: Cesium.Math.toRadians(0),
+                    roll: 0.0,
+                  },
+                });
               },
-              {
-                text: "Horseshoe Curve",
-                onselect: function () {
-                  viewer.scene.camera.flyTo({
-                    destination: Cesium.Cartesian3.fromRadians(
-                      -1.3700147546199826,
-                      0.706808606166025,
-                      993.7916313325215
-                    ),
-                    orientation: {
-                      heading: Cesium.Math.toRadians(90),
-                      pitch: Cesium.Math.toRadians(-15),
-                      roll: 0.0,
-                    },
-                  });
-                },
+            },
+            {
+              text: "Horseshoe Curve",
+              onselect: function () {
+                viewer.scene.camera.flyTo({
+                  destination: Cesium.Cartesian3.fromRadians(
+                    -1.3700147546199826,
+                    0.706808606166025,
+                    993.7916313325215
+                  ),
+                  orientation: {
+                    heading: Cesium.Math.toRadians(90),
+                    pitch: Cesium.Math.toRadians(-15),
+                    roll: 0.0,
+                  },
+                });
               },
-              {
-                text: "Jim Thorpe",
-                onselect: function () {
-                  viewer.scene.camera.flyTo({
-                    destination: Cesium.Cartesian3.fromRadians(
-                      -1.3218297501066052,
-                      0.713358272291525,
-                      240.87968743408845
-                    ),
-                    orientation: {
-                      heading: Cesium.Math.toRadians(200),
-                      pitch: Cesium.Math.toRadians(-5),
-                      roll: 0.0,
-                    },
-                  });
-                },
+            },
+            {
+              text: "Jim Thorpe",
+              onselect: function () {
+                viewer.scene.camera.flyTo({
+                  destination: Cesium.Cartesian3.fromRadians(
+                    -1.3218297501066052,
+                    0.713358272291525,
+                    240.87968743408845
+                  ),
+                  orientation: {
+                    heading: Cesium.Math.toRadians(200),
+                    pitch: Cesium.Math.toRadians(-5),
+                    roll: 0.0,
+                  },
+                });
               },
-              {
-                text: "Grand Canyon of PA",
-                onselect: function () {
-                  viewer.scene.camera.flyTo({
-                    destination: Cesium.Cartesian3.fromRadians(
-                      -1.349379633251472,
-                      0.720297672225785,
-                      656.268309953562
-                    ),
-                    orientation: {
-                      heading: Cesium.Math.toRadians(200),
-                      pitch: Cesium.Math.toRadians(-5),
-                      roll: 0.0,
-                    },
-                  });
-                },
+            },
+            {
+              text: "Grand Canyon of PA",
+              onselect: function () {
+                viewer.scene.camera.flyTo({
+                  destination: Cesium.Cartesian3.fromRadians(
+                    -1.349379633251472,
+                    0.720297672225785,
+                    656.268309953562
+                  ),
+                  orientation: {
+                    heading: Cesium.Math.toRadians(200),
+                    pitch: Cesium.Math.toRadians(-5),
+                    roll: 0.0,
+                  },
+                });
               },
-            ],
-            "toolbar"
-          );
-        })(); //Sandcastle_End
+            },
+          ],
+          "toolbar"
+        );
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Particle System Weather.html
+++ b/Apps/Sandcastle/gallery/Particle System Weather.html
@@ -35,173 +35,180 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          shouldAnimate: true,
+        });
+        const scene = viewer.scene;
+        scene.globe.depthTestAgainstTerrain = true;
+
         (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            shouldAnimate: true,
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+          } catch (error) {
+            console.log(error);
+          }
+        })();
+
+        const resetCameraFunction = function () {
+          scene.camera.setView({
+            destination: new Cesium.Cartesian3(
+              277096.634865404,
+              5647834.481964232,
+              2985563.7039122293
+            ),
+            orientation: {
+              heading: 4.731089976107251,
+              pitch: -0.32003481981370063,
+            },
           });
-          const scene = viewer.scene;
-          scene.globe.depthTestAgainstTerrain = true;
-          const resetCameraFunction = function () {
-            scene.camera.setView({
-              destination: new Cesium.Cartesian3(
-                277096.634865404,
-                5647834.481964232,
-                2985563.7039122293
-              ),
-              orientation: {
-                heading: 4.731089976107251,
-                pitch: -0.32003481981370063,
-              },
-            });
-          };
-          resetCameraFunction();
+        };
+        resetCameraFunction();
 
-          // snow
-          const snowParticleSize = 12.0;
-          const snowRadius = 100000.0;
-          const minimumSnowImageSize = new Cesium.Cartesian2(
-            snowParticleSize,
-            snowParticleSize
+        // snow
+        const snowParticleSize = 12.0;
+        const snowRadius = 100000.0;
+        const minimumSnowImageSize = new Cesium.Cartesian2(
+          snowParticleSize,
+          snowParticleSize
+        );
+        const maximumSnowImageSize = new Cesium.Cartesian2(
+          snowParticleSize * 2.0,
+          snowParticleSize * 2.0
+        );
+        let snowGravityScratch = new Cesium.Cartesian3();
+        const snowUpdate = function (particle, dt) {
+          snowGravityScratch = Cesium.Cartesian3.normalize(
+            particle.position,
+            snowGravityScratch
           );
-          const maximumSnowImageSize = new Cesium.Cartesian2(
-            snowParticleSize * 2.0,
-            snowParticleSize * 2.0
+          Cesium.Cartesian3.multiplyByScalar(
+            snowGravityScratch,
+            Cesium.Math.randomBetween(-30.0, -300.0),
+            snowGravityScratch
           );
-          let snowGravityScratch = new Cesium.Cartesian3();
-          const snowUpdate = function (particle, dt) {
-            snowGravityScratch = Cesium.Cartesian3.normalize(
-              particle.position,
-              snowGravityScratch
-            );
-            Cesium.Cartesian3.multiplyByScalar(
-              snowGravityScratch,
-              Cesium.Math.randomBetween(-30.0, -300.0),
-              snowGravityScratch
-            );
-            particle.velocity = Cesium.Cartesian3.add(
-              particle.velocity,
-              snowGravityScratch,
-              particle.velocity
-            );
-            const distance = Cesium.Cartesian3.distance(
-              scene.camera.position,
-              particle.position
-            );
-            if (distance > snowRadius) {
-              particle.endColor.alpha = 0.0;
-            } else {
-              particle.endColor.alpha = 1.0 / (distance / snowRadius + 0.1);
-            }
-          };
-
-          // rain
-          const rainParticleSize = 15.0;
-          const rainRadius = 100000.0;
-          const rainImageSize = new Cesium.Cartesian2(
-            rainParticleSize,
-            rainParticleSize * 2.0
+          particle.velocity = Cesium.Cartesian3.add(
+            particle.velocity,
+            snowGravityScratch,
+            particle.velocity
           );
-          let rainGravityScratch = new Cesium.Cartesian3();
-          const rainUpdate = function (particle, dt) {
-            rainGravityScratch = Cesium.Cartesian3.normalize(
-              particle.position,
-              rainGravityScratch
-            );
-            rainGravityScratch = Cesium.Cartesian3.multiplyByScalar(
-              rainGravityScratch,
-              -1050.0,
-              rainGravityScratch
-            );
+          const distance = Cesium.Cartesian3.distance(
+            scene.camera.position,
+            particle.position
+          );
+          if (distance > snowRadius) {
+            particle.endColor.alpha = 0.0;
+          } else {
+            particle.endColor.alpha = 1.0 / (distance / snowRadius + 0.1);
+          }
+        };
 
-            particle.position = Cesium.Cartesian3.add(
-              particle.position,
-              rainGravityScratch,
-              particle.position
-            );
+        // rain
+        const rainParticleSize = 15.0;
+        const rainRadius = 100000.0;
+        const rainImageSize = new Cesium.Cartesian2(
+          rainParticleSize,
+          rainParticleSize * 2.0
+        );
+        let rainGravityScratch = new Cesium.Cartesian3();
+        const rainUpdate = function (particle, dt) {
+          rainGravityScratch = Cesium.Cartesian3.normalize(
+            particle.position,
+            rainGravityScratch
+          );
+          rainGravityScratch = Cesium.Cartesian3.multiplyByScalar(
+            rainGravityScratch,
+            -1050.0,
+            rainGravityScratch
+          );
 
-            const distance = Cesium.Cartesian3.distance(
-              scene.camera.position,
-              particle.position
-            );
-            if (distance > rainRadius) {
-              particle.endColor.alpha = 0.0;
-            } else {
-              particle.endColor.alpha =
-                Cesium.Color.BLUE.alpha / (distance / rainRadius + 0.1);
-            }
-          };
+          particle.position = Cesium.Cartesian3.add(
+            particle.position,
+            rainGravityScratch,
+            particle.position
+          );
 
-          // button
-          Sandcastle.addToolbarButton("Reset Camera", resetCameraFunction);
+          const distance = Cesium.Cartesian3.distance(
+            scene.camera.position,
+            particle.position
+          );
+          if (distance > rainRadius) {
+            particle.endColor.alpha = 0.0;
+          } else {
+            particle.endColor.alpha =
+              Cesium.Color.BLUE.alpha / (distance / rainRadius + 0.1);
+          }
+        };
 
-          // drop down
-          const options = [
-            {
-              text: "Snow",
-              onselect: function () {
-                scene.primitives.removeAll();
-                scene.primitives.add(
-                  new Cesium.ParticleSystem({
-                    modelMatrix: new Cesium.Matrix4.fromTranslation(
-                      scene.camera.position
-                    ),
-                    minimumSpeed: -1.0,
-                    maximumSpeed: 0.0,
-                    lifetime: 15.0,
-                    emitter: new Cesium.SphereEmitter(snowRadius),
-                    startScale: 0.5,
-                    endScale: 1.0,
-                    image: "../../SampleData/snowflake_particle.png",
-                    emissionRate: 7000.0,
-                    startColor: Cesium.Color.WHITE.withAlpha(0.0),
-                    endColor: Cesium.Color.WHITE.withAlpha(1.0),
-                    minimumImageSize: minimumSnowImageSize,
-                    maximumImageSize: maximumSnowImageSize,
-                    updateCallback: snowUpdate,
-                  })
-                );
+        // button
+        Sandcastle.addToolbarButton("Reset Camera", resetCameraFunction);
 
-                scene.skyAtmosphere.hueShift = -0.8;
-                scene.skyAtmosphere.saturationShift = -0.7;
-                scene.skyAtmosphere.brightnessShift = -0.33;
-                scene.fog.density = 0.001;
-                scene.fog.minimumBrightness = 0.8;
-              },
+        // drop down
+        const options = [
+          {
+            text: "Snow",
+            onselect: function () {
+              scene.primitives.removeAll();
+              scene.primitives.add(
+                new Cesium.ParticleSystem({
+                  modelMatrix: new Cesium.Matrix4.fromTranslation(
+                    scene.camera.position
+                  ),
+                  minimumSpeed: -1.0,
+                  maximumSpeed: 0.0,
+                  lifetime: 15.0,
+                  emitter: new Cesium.SphereEmitter(snowRadius),
+                  startScale: 0.5,
+                  endScale: 1.0,
+                  image: "../../SampleData/snowflake_particle.png",
+                  emissionRate: 7000.0,
+                  startColor: Cesium.Color.WHITE.withAlpha(0.0),
+                  endColor: Cesium.Color.WHITE.withAlpha(1.0),
+                  minimumImageSize: minimumSnowImageSize,
+                  maximumImageSize: maximumSnowImageSize,
+                  updateCallback: snowUpdate,
+                })
+              );
+
+              scene.skyAtmosphere.hueShift = -0.8;
+              scene.skyAtmosphere.saturationShift = -0.7;
+              scene.skyAtmosphere.brightnessShift = -0.33;
+              scene.fog.density = 0.001;
+              scene.fog.minimumBrightness = 0.8;
             },
-            {
-              text: "Rain",
-              onselect: function () {
-                scene.primitives.removeAll();
-                scene.primitives.add(
-                  new Cesium.ParticleSystem({
-                    modelMatrix: new Cesium.Matrix4.fromTranslation(
-                      scene.camera.position
-                    ),
-                    speed: -1.0,
-                    lifetime: 15.0,
-                    emitter: new Cesium.SphereEmitter(rainRadius),
-                    startScale: 1.0,
-                    endScale: 0.0,
-                    image: "../../SampleData/circular_particle.png",
-                    emissionRate: 9000.0,
-                    startColor: new Cesium.Color(0.27, 0.5, 0.7, 0.0),
-                    endColor: new Cesium.Color(0.27, 0.5, 0.7, 0.98),
-                    imageSize: rainImageSize,
-                    updateCallback: rainUpdate,
-                  })
-                );
+          },
+          {
+            text: "Rain",
+            onselect: function () {
+              scene.primitives.removeAll();
+              scene.primitives.add(
+                new Cesium.ParticleSystem({
+                  modelMatrix: new Cesium.Matrix4.fromTranslation(
+                    scene.camera.position
+                  ),
+                  speed: -1.0,
+                  lifetime: 15.0,
+                  emitter: new Cesium.SphereEmitter(rainRadius),
+                  startScale: 1.0,
+                  endScale: 0.0,
+                  image: "../../SampleData/circular_particle.png",
+                  emissionRate: 9000.0,
+                  startColor: new Cesium.Color(0.27, 0.5, 0.7, 0.0),
+                  endColor: new Cesium.Color(0.27, 0.5, 0.7, 0.98),
+                  imageSize: rainImageSize,
+                  updateCallback: rainUpdate,
+                })
+              );
 
-                scene.skyAtmosphere.hueShift = -0.97;
-                scene.skyAtmosphere.saturationShift = 0.25;
-                scene.skyAtmosphere.brightnessShift = -0.4;
-                scene.fog.density = 0.00025;
-                scene.fog.minimumBrightness = 0.01;
-              },
+              scene.skyAtmosphere.hueShift = -0.97;
+              scene.skyAtmosphere.saturationShift = 0.25;
+              scene.skyAtmosphere.brightnessShift = -0.4;
+              scene.fog.density = 0.00025;
+              scene.fog.minimumBrightness = 0.01;
             },
-          ];
-          Sandcastle.addToolbarMenu(options);
-        })(); //Sandcastle_End
+          },
+        ];
+        Sandcastle.addToolbarMenu(options);
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
 

--- a/Apps/Sandcastle/gallery/Particle System Weather.html
+++ b/Apps/Sandcastle/gallery/Particle System Weather.html
@@ -35,172 +35,173 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          shouldAnimate: true,
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
-        const scene = viewer.scene;
-        scene.globe.depthTestAgainstTerrain = true;
-        const resetCameraFunction = function () {
-          scene.camera.setView({
-            destination: new Cesium.Cartesian3(
-              277096.634865404,
-              5647834.481964232,
-              2985563.7039122293
-            ),
-            orientation: {
-              heading: 4.731089976107251,
-              pitch: -0.32003481981370063,
-            },
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            shouldAnimate: true,
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
           });
-        };
-        resetCameraFunction();
+          const scene = viewer.scene;
+          scene.globe.depthTestAgainstTerrain = true;
+          const resetCameraFunction = function () {
+            scene.camera.setView({
+              destination: new Cesium.Cartesian3(
+                277096.634865404,
+                5647834.481964232,
+                2985563.7039122293
+              ),
+              orientation: {
+                heading: 4.731089976107251,
+                pitch: -0.32003481981370063,
+              },
+            });
+          };
+          resetCameraFunction();
 
-        // snow
-        const snowParticleSize = 12.0;
-        const snowRadius = 100000.0;
-        const minimumSnowImageSize = new Cesium.Cartesian2(
-          snowParticleSize,
-          snowParticleSize
-        );
-        const maximumSnowImageSize = new Cesium.Cartesian2(
-          snowParticleSize * 2.0,
-          snowParticleSize * 2.0
-        );
-        let snowGravityScratch = new Cesium.Cartesian3();
-        const snowUpdate = function (particle, dt) {
-          snowGravityScratch = Cesium.Cartesian3.normalize(
-            particle.position,
-            snowGravityScratch
+          // snow
+          const snowParticleSize = 12.0;
+          const snowRadius = 100000.0;
+          const minimumSnowImageSize = new Cesium.Cartesian2(
+            snowParticleSize,
+            snowParticleSize
           );
-          Cesium.Cartesian3.multiplyByScalar(
-            snowGravityScratch,
-            Cesium.Math.randomBetween(-30.0, -300.0),
-            snowGravityScratch
+          const maximumSnowImageSize = new Cesium.Cartesian2(
+            snowParticleSize * 2.0,
+            snowParticleSize * 2.0
           );
-          particle.velocity = Cesium.Cartesian3.add(
-            particle.velocity,
-            snowGravityScratch,
-            particle.velocity
-          );
-          const distance = Cesium.Cartesian3.distance(
-            scene.camera.position,
-            particle.position
-          );
-          if (distance > snowRadius) {
-            particle.endColor.alpha = 0.0;
-          } else {
-            particle.endColor.alpha = 1.0 / (distance / snowRadius + 0.1);
-          }
-        };
+          let snowGravityScratch = new Cesium.Cartesian3();
+          const snowUpdate = function (particle, dt) {
+            snowGravityScratch = Cesium.Cartesian3.normalize(
+              particle.position,
+              snowGravityScratch
+            );
+            Cesium.Cartesian3.multiplyByScalar(
+              snowGravityScratch,
+              Cesium.Math.randomBetween(-30.0, -300.0),
+              snowGravityScratch
+            );
+            particle.velocity = Cesium.Cartesian3.add(
+              particle.velocity,
+              snowGravityScratch,
+              particle.velocity
+            );
+            const distance = Cesium.Cartesian3.distance(
+              scene.camera.position,
+              particle.position
+            );
+            if (distance > snowRadius) {
+              particle.endColor.alpha = 0.0;
+            } else {
+              particle.endColor.alpha = 1.0 / (distance / snowRadius + 0.1);
+            }
+          };
 
-        // rain
-        const rainParticleSize = 15.0;
-        const rainRadius = 100000.0;
-        const rainImageSize = new Cesium.Cartesian2(
-          rainParticleSize,
-          rainParticleSize * 2.0
-        );
-        let rainGravityScratch = new Cesium.Cartesian3();
-        const rainUpdate = function (particle, dt) {
-          rainGravityScratch = Cesium.Cartesian3.normalize(
-            particle.position,
-            rainGravityScratch
+          // rain
+          const rainParticleSize = 15.0;
+          const rainRadius = 100000.0;
+          const rainImageSize = new Cesium.Cartesian2(
+            rainParticleSize,
+            rainParticleSize * 2.0
           );
-          rainGravityScratch = Cesium.Cartesian3.multiplyByScalar(
-            rainGravityScratch,
-            -1050.0,
-            rainGravityScratch
-          );
+          let rainGravityScratch = new Cesium.Cartesian3();
+          const rainUpdate = function (particle, dt) {
+            rainGravityScratch = Cesium.Cartesian3.normalize(
+              particle.position,
+              rainGravityScratch
+            );
+            rainGravityScratch = Cesium.Cartesian3.multiplyByScalar(
+              rainGravityScratch,
+              -1050.0,
+              rainGravityScratch
+            );
 
-          particle.position = Cesium.Cartesian3.add(
-            particle.position,
-            rainGravityScratch,
-            particle.position
-          );
+            particle.position = Cesium.Cartesian3.add(
+              particle.position,
+              rainGravityScratch,
+              particle.position
+            );
 
-          const distance = Cesium.Cartesian3.distance(
-            scene.camera.position,
-            particle.position
-          );
-          if (distance > rainRadius) {
-            particle.endColor.alpha = 0.0;
-          } else {
-            particle.endColor.alpha =
-              Cesium.Color.BLUE.alpha / (distance / rainRadius + 0.1);
-          }
-        };
+            const distance = Cesium.Cartesian3.distance(
+              scene.camera.position,
+              particle.position
+            );
+            if (distance > rainRadius) {
+              particle.endColor.alpha = 0.0;
+            } else {
+              particle.endColor.alpha =
+                Cesium.Color.BLUE.alpha / (distance / rainRadius + 0.1);
+            }
+          };
 
-        // button
-        Sandcastle.addToolbarButton("Reset Camera", resetCameraFunction);
+          // button
+          Sandcastle.addToolbarButton("Reset Camera", resetCameraFunction);
 
-        // drop down
-        const options = [
-          {
-            text: "Snow",
-            onselect: function () {
-              scene.primitives.removeAll();
-              scene.primitives.add(
-                new Cesium.ParticleSystem({
-                  modelMatrix: new Cesium.Matrix4.fromTranslation(
-                    scene.camera.position
-                  ),
-                  minimumSpeed: -1.0,
-                  maximumSpeed: 0.0,
-                  lifetime: 15.0,
-                  emitter: new Cesium.SphereEmitter(snowRadius),
-                  startScale: 0.5,
-                  endScale: 1.0,
-                  image: "../../SampleData/snowflake_particle.png",
-                  emissionRate: 7000.0,
-                  startColor: Cesium.Color.WHITE.withAlpha(0.0),
-                  endColor: Cesium.Color.WHITE.withAlpha(1.0),
-                  minimumImageSize: minimumSnowImageSize,
-                  maximumImageSize: maximumSnowImageSize,
-                  updateCallback: snowUpdate,
-                })
-              );
+          // drop down
+          const options = [
+            {
+              text: "Snow",
+              onselect: function () {
+                scene.primitives.removeAll();
+                scene.primitives.add(
+                  new Cesium.ParticleSystem({
+                    modelMatrix: new Cesium.Matrix4.fromTranslation(
+                      scene.camera.position
+                    ),
+                    minimumSpeed: -1.0,
+                    maximumSpeed: 0.0,
+                    lifetime: 15.0,
+                    emitter: new Cesium.SphereEmitter(snowRadius),
+                    startScale: 0.5,
+                    endScale: 1.0,
+                    image: "../../SampleData/snowflake_particle.png",
+                    emissionRate: 7000.0,
+                    startColor: Cesium.Color.WHITE.withAlpha(0.0),
+                    endColor: Cesium.Color.WHITE.withAlpha(1.0),
+                    minimumImageSize: minimumSnowImageSize,
+                    maximumImageSize: maximumSnowImageSize,
+                    updateCallback: snowUpdate,
+                  })
+                );
 
-              scene.skyAtmosphere.hueShift = -0.8;
-              scene.skyAtmosphere.saturationShift = -0.7;
-              scene.skyAtmosphere.brightnessShift = -0.33;
-              scene.fog.density = 0.001;
-              scene.fog.minimumBrightness = 0.8;
+                scene.skyAtmosphere.hueShift = -0.8;
+                scene.skyAtmosphere.saturationShift = -0.7;
+                scene.skyAtmosphere.brightnessShift = -0.33;
+                scene.fog.density = 0.001;
+                scene.fog.minimumBrightness = 0.8;
+              },
             },
-          },
-          {
-            text: "Rain",
-            onselect: function () {
-              scene.primitives.removeAll();
-              scene.primitives.add(
-                new Cesium.ParticleSystem({
-                  modelMatrix: new Cesium.Matrix4.fromTranslation(
-                    scene.camera.position
-                  ),
-                  speed: -1.0,
-                  lifetime: 15.0,
-                  emitter: new Cesium.SphereEmitter(rainRadius),
-                  startScale: 1.0,
-                  endScale: 0.0,
-                  image: "../../SampleData/circular_particle.png",
-                  emissionRate: 9000.0,
-                  startColor: new Cesium.Color(0.27, 0.5, 0.7, 0.0),
-                  endColor: new Cesium.Color(0.27, 0.5, 0.7, 0.98),
-                  imageSize: rainImageSize,
-                  updateCallback: rainUpdate,
-                })
-              );
+            {
+              text: "Rain",
+              onselect: function () {
+                scene.primitives.removeAll();
+                scene.primitives.add(
+                  new Cesium.ParticleSystem({
+                    modelMatrix: new Cesium.Matrix4.fromTranslation(
+                      scene.camera.position
+                    ),
+                    speed: -1.0,
+                    lifetime: 15.0,
+                    emitter: new Cesium.SphereEmitter(rainRadius),
+                    startScale: 1.0,
+                    endScale: 0.0,
+                    image: "../../SampleData/circular_particle.png",
+                    emissionRate: 9000.0,
+                    startColor: new Cesium.Color(0.27, 0.5, 0.7, 0.0),
+                    endColor: new Cesium.Color(0.27, 0.5, 0.7, 0.98),
+                    imageSize: rainImageSize,
+                    updateCallback: rainUpdate,
+                  })
+                );
 
-              scene.skyAtmosphere.hueShift = -0.97;
-              scene.skyAtmosphere.saturationShift = 0.25;
-              scene.skyAtmosphere.brightnessShift = -0.4;
-              scene.fog.density = 0.00025;
-              scene.fog.minimumBrightness = 0.01;
+                scene.skyAtmosphere.hueShift = -0.97;
+                scene.skyAtmosphere.saturationShift = 0.25;
+                scene.skyAtmosphere.brightnessShift = -0.4;
+                scene.fog.density = 0.00025;
+                scene.fog.minimumBrightness = 0.01;
+              },
             },
-          },
-        ];
-        Sandcastle.addToolbarMenu(options);
-        //Sandcastle_End
+          ];
+          Sandcastle.addToolbarMenu(options);
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
 

--- a/Apps/Sandcastle/gallery/Particle System Weather.html
+++ b/Apps/Sandcastle/gallery/Particle System Weather.html
@@ -37,7 +37,7 @@
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
           shouldAnimate: true,
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
         const scene = viewer.scene;
         scene.globe.depthTestAgainstTerrain = true;

--- a/Apps/Sandcastle/gallery/Physically-Based Materials.html
+++ b/Apps/Sandcastle/gallery/Physically-Based Materials.html
@@ -45,153 +45,154 @@
           shouldAnimate: true,
         });
 
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          clockViewModel: new Cesium.ClockViewModel(clock),
-          selectionIndicator: false,
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            clockViewModel: new Cesium.ClockViewModel(clock),
+            selectionIndicator: false,
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
 
-        Sandcastle.addToggleButton("Shadows", viewer.shadows, function (
-          checked
-        ) {
-          viewer.shadows = checked;
-        });
+          Sandcastle.addToggleButton("Shadows", viewer.shadows, function (
+            checked
+          ) {
+            viewer.shadows = checked;
+          });
 
-        viewer.scene.globe.enableLighting = true;
-        viewer.scene.globe.depthTestAgainstTerrain = true;
+          viewer.scene.globe.enableLighting = true;
+          viewer.scene.globe.depthTestAgainstTerrain = true;
 
-        const position = new Cesium.Cartesian3(
-          -1371108.6511167218,
-          -5508684.080096612,
-          2901825.449865087
-        );
-        const heading = Cesium.Math.toRadians(180);
-        const pitch = Cesium.Math.toRadians(2);
-        const roll = Cesium.Math.toRadians(-6);
-        const hpr = new Cesium.HeadingPitchRoll(heading, pitch, roll);
-        const orientation = Cesium.Transforms.headingPitchRollQuaternion(
-          position,
-          hpr
-        );
+          const position = new Cesium.Cartesian3(
+            -1371108.6511167218,
+            -5508684.080096612,
+            2901825.449865087
+          );
+          const heading = Cesium.Math.toRadians(180);
+          const pitch = Cesium.Math.toRadians(2);
+          const roll = Cesium.Math.toRadians(-6);
+          const hpr = new Cesium.HeadingPitchRoll(heading, pitch, roll);
+          const orientation = Cesium.Transforms.headingPitchRollQuaternion(
+            position,
+            hpr
+          );
 
-        const entity = viewer.entities.add({
-          name: "truck",
-          position: position,
-          orientation: orientation,
-          model: {
-            uri: "../../SampleData/models/GroundVehicle/GroundVehicle.glb",
-            heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-            minimumPixelSize: 128,
-            maximumScale: 20,
-            scale: 8.0,
-            runAnimations: false,
-          },
-        });
-
-        const threeQuartersView = {
-          destination: new Cesium.Cartesian3(
-            -1371203.1456494154,
-            -5508700.033950869,
-            2901802.2749172337
-          ),
-          orientation: {
-            heading: Cesium.Math.toRadians(67.64973594265429),
-            pitch: Cesium.Math.toRadians(-8.158676059409297),
-            roll: Cesium.Math.toRadians(359.9999987450017),
-          },
-          maximumHeight: 100,
-        };
-
-        const frontView = {
-          destination: new Cesium.Cartesian3(
-            -1371214.9554156072,
-            -5508700.8494476415,
-            2901826.794611029
-          ),
-          orientation: {
-            heading: Cesium.Math.toRadians(80.5354269423926),
-            pitch: Cesium.Math.toRadians(-15.466062969558285),
-            roll: Cesium.Math.toRadians(359.9999999526579),
-          },
-          maximumHeight: 100,
-        };
-
-        const topView = {
-          destination: new Cesium.Cartesian3(
-            -1371190.7755780201,
-            -5508732.668834588,
-            2901827.2625979027
-          ),
-          orientation: {
-            heading: Cesium.Math.toRadians(68.29411482061157),
-            pitch: Cesium.Math.toRadians(-33.97774554735345),
-            roll: Cesium.Math.toRadians(359.9999999298912),
-          },
-          maximumHeight: 100,
-        };
-
-        const upwardsView = {
-          destination: new Cesium.Cartesian3(
-            -1371052.4616855076,
-            -5508691.745389906,
-            2901861.440673151
-          ),
-          orientation: {
-            heading: Cesium.Math.toRadians(236.4536374528137),
-            pitch: Cesium.Math.toRadians(-1.3382025460115552),
-            roll: Cesium.Math.toRadians(359.9999985917282),
-          },
-          maximumHeight: 100,
-        };
-
-        viewer.scene.camera.flyTo({
-          destination: frontView.destination,
-          orientation: frontView.orientation,
-          duration: 5.0,
-          pitchAdjustHeight: 20,
-        });
-        Sandcastle.addToolbarMenu(
-          [
-            {
-              text: "Front reflection",
-              onselect: function () {
-                viewer.scene.camera.flyTo(frontView);
-                viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601(
-                  "2017-07-11T20:00:00Z"
-                );
-              },
+          const entity = viewer.entities.add({
+            name: "truck",
+            position: position,
+            orientation: orientation,
+            model: {
+              uri: "../../SampleData/models/GroundVehicle/GroundVehicle.glb",
+              heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+              minimumPixelSize: 128,
+              maximumScale: 20,
+              scale: 8.0,
+              runAnimations: false,
             },
-            {
-              text: "Three quarters sunrise",
-              onselect: function () {
-                viewer.scene.camera.flyTo(threeQuartersView);
-                viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601(
-                  "2017-07-11T11:00:00Z"
-                );
-              },
+          });
+
+          const threeQuartersView = {
+            destination: new Cesium.Cartesian3(
+              -1371203.1456494154,
+              -5508700.033950869,
+              2901802.2749172337
+            ),
+            orientation: {
+              heading: Cesium.Math.toRadians(67.64973594265429),
+              pitch: Cesium.Math.toRadians(-8.158676059409297),
+              roll: Cesium.Math.toRadians(359.9999987450017),
             },
-            {
-              text: "Top reflection",
-              onselect: function () {
-                viewer.scene.camera.flyTo(topView);
-                viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601(
-                  "2017-07-11T12:00:00Z"
-                );
-              },
+            maximumHeight: 100,
+          };
+
+          const frontView = {
+            destination: new Cesium.Cartesian3(
+              -1371214.9554156072,
+              -5508700.8494476415,
+              2901826.794611029
+            ),
+            orientation: {
+              heading: Cesium.Math.toRadians(80.5354269423926),
+              pitch: Cesium.Math.toRadians(-15.466062969558285),
+              roll: Cesium.Math.toRadians(359.9999999526579),
             },
-            {
-              text: "Upward angle side reflection",
-              onselect: function () {
-                viewer.scene.camera.flyTo(upwardsView);
-                viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601(
-                  "2017-07-11T23:00:00Z"
-                );
-              },
+            maximumHeight: 100,
+          };
+
+          const topView = {
+            destination: new Cesium.Cartesian3(
+              -1371190.7755780201,
+              -5508732.668834588,
+              2901827.2625979027
+            ),
+            orientation: {
+              heading: Cesium.Math.toRadians(68.29411482061157),
+              pitch: Cesium.Math.toRadians(-33.97774554735345),
+              roll: Cesium.Math.toRadians(359.9999999298912),
             },
-          ],
-          "toolbar"
-        );
-        //Sandcastle_End
+            maximumHeight: 100,
+          };
+
+          const upwardsView = {
+            destination: new Cesium.Cartesian3(
+              -1371052.4616855076,
+              -5508691.745389906,
+              2901861.440673151
+            ),
+            orientation: {
+              heading: Cesium.Math.toRadians(236.4536374528137),
+              pitch: Cesium.Math.toRadians(-1.3382025460115552),
+              roll: Cesium.Math.toRadians(359.9999985917282),
+            },
+            maximumHeight: 100,
+          };
+
+          viewer.scene.camera.flyTo({
+            destination: frontView.destination,
+            orientation: frontView.orientation,
+            duration: 5.0,
+            pitchAdjustHeight: 20,
+          });
+          Sandcastle.addToolbarMenu(
+            [
+              {
+                text: "Front reflection",
+                onselect: function () {
+                  viewer.scene.camera.flyTo(frontView);
+                  viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601(
+                    "2017-07-11T20:00:00Z"
+                  );
+                },
+              },
+              {
+                text: "Three quarters sunrise",
+                onselect: function () {
+                  viewer.scene.camera.flyTo(threeQuartersView);
+                  viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601(
+                    "2017-07-11T11:00:00Z"
+                  );
+                },
+              },
+              {
+                text: "Top reflection",
+                onselect: function () {
+                  viewer.scene.camera.flyTo(topView);
+                  viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601(
+                    "2017-07-11T12:00:00Z"
+                  );
+                },
+              },
+              {
+                text: "Upward angle side reflection",
+                onselect: function () {
+                  viewer.scene.camera.flyTo(upwardsView);
+                  viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601(
+                    "2017-07-11T23:00:00Z"
+                  );
+                },
+              },
+            ],
+            "toolbar"
+          );
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Physically-Based Materials.html
+++ b/Apps/Sandcastle/gallery/Physically-Based Materials.html
@@ -45,154 +45,160 @@
           shouldAnimate: true,
         });
 
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          clockViewModel: new Cesium.ClockViewModel(clock),
+          selectionIndicator: false,
+        });
+
         (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            clockViewModel: new Cesium.ClockViewModel(clock),
-            selectionIndicator: false,
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+          } catch (error) {
+            console.log(error);
+          }
+        })();
 
-          Sandcastle.addToggleButton("Shadows", viewer.shadows, function (
-            checked
-          ) {
-            viewer.shadows = checked;
-          });
+        Sandcastle.addToggleButton("Shadows", viewer.shadows, function (
+          checked
+        ) {
+          viewer.shadows = checked;
+        });
 
-          viewer.scene.globe.enableLighting = true;
-          viewer.scene.globe.depthTestAgainstTerrain = true;
+        viewer.scene.globe.enableLighting = true;
+        viewer.scene.globe.depthTestAgainstTerrain = true;
 
-          const position = new Cesium.Cartesian3(
-            -1371108.6511167218,
-            -5508684.080096612,
-            2901825.449865087
-          );
-          const heading = Cesium.Math.toRadians(180);
-          const pitch = Cesium.Math.toRadians(2);
-          const roll = Cesium.Math.toRadians(-6);
-          const hpr = new Cesium.HeadingPitchRoll(heading, pitch, roll);
-          const orientation = Cesium.Transforms.headingPitchRollQuaternion(
-            position,
-            hpr
-          );
+        const position = new Cesium.Cartesian3(
+          -1371108.6511167218,
+          -5508684.080096612,
+          2901825.449865087
+        );
+        const heading = Cesium.Math.toRadians(180);
+        const pitch = Cesium.Math.toRadians(2);
+        const roll = Cesium.Math.toRadians(-6);
+        const hpr = new Cesium.HeadingPitchRoll(heading, pitch, roll);
+        const orientation = Cesium.Transforms.headingPitchRollQuaternion(
+          position,
+          hpr
+        );
 
-          const entity = viewer.entities.add({
-            name: "truck",
-            position: position,
-            orientation: orientation,
-            model: {
-              uri: "../../SampleData/models/GroundVehicle/GroundVehicle.glb",
-              heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-              minimumPixelSize: 128,
-              maximumScale: 20,
-              scale: 8.0,
-              runAnimations: false,
-            },
-          });
+        const entity = viewer.entities.add({
+          name: "truck",
+          position: position,
+          orientation: orientation,
+          model: {
+            uri: "../../SampleData/models/GroundVehicle/GroundVehicle.glb",
+            heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+            minimumPixelSize: 128,
+            maximumScale: 20,
+            scale: 8.0,
+            runAnimations: false,
+          },
+        });
 
-          const threeQuartersView = {
-            destination: new Cesium.Cartesian3(
-              -1371203.1456494154,
-              -5508700.033950869,
-              2901802.2749172337
-            ),
-            orientation: {
-              heading: Cesium.Math.toRadians(67.64973594265429),
-              pitch: Cesium.Math.toRadians(-8.158676059409297),
-              roll: Cesium.Math.toRadians(359.9999987450017),
-            },
-            maximumHeight: 100,
-          };
+        const threeQuartersView = {
+          destination: new Cesium.Cartesian3(
+            -1371203.1456494154,
+            -5508700.033950869,
+            2901802.2749172337
+          ),
+          orientation: {
+            heading: Cesium.Math.toRadians(67.64973594265429),
+            pitch: Cesium.Math.toRadians(-8.158676059409297),
+            roll: Cesium.Math.toRadians(359.9999987450017),
+          },
+          maximumHeight: 100,
+        };
 
-          const frontView = {
-            destination: new Cesium.Cartesian3(
-              -1371214.9554156072,
-              -5508700.8494476415,
-              2901826.794611029
-            ),
-            orientation: {
-              heading: Cesium.Math.toRadians(80.5354269423926),
-              pitch: Cesium.Math.toRadians(-15.466062969558285),
-              roll: Cesium.Math.toRadians(359.9999999526579),
-            },
-            maximumHeight: 100,
-          };
+        const frontView = {
+          destination: new Cesium.Cartesian3(
+            -1371214.9554156072,
+            -5508700.8494476415,
+            2901826.794611029
+          ),
+          orientation: {
+            heading: Cesium.Math.toRadians(80.5354269423926),
+            pitch: Cesium.Math.toRadians(-15.466062969558285),
+            roll: Cesium.Math.toRadians(359.9999999526579),
+          },
+          maximumHeight: 100,
+        };
 
-          const topView = {
-            destination: new Cesium.Cartesian3(
-              -1371190.7755780201,
-              -5508732.668834588,
-              2901827.2625979027
-            ),
-            orientation: {
-              heading: Cesium.Math.toRadians(68.29411482061157),
-              pitch: Cesium.Math.toRadians(-33.97774554735345),
-              roll: Cesium.Math.toRadians(359.9999999298912),
-            },
-            maximumHeight: 100,
-          };
+        const topView = {
+          destination: new Cesium.Cartesian3(
+            -1371190.7755780201,
+            -5508732.668834588,
+            2901827.2625979027
+          ),
+          orientation: {
+            heading: Cesium.Math.toRadians(68.29411482061157),
+            pitch: Cesium.Math.toRadians(-33.97774554735345),
+            roll: Cesium.Math.toRadians(359.9999999298912),
+          },
+          maximumHeight: 100,
+        };
 
-          const upwardsView = {
-            destination: new Cesium.Cartesian3(
-              -1371052.4616855076,
-              -5508691.745389906,
-              2901861.440673151
-            ),
-            orientation: {
-              heading: Cesium.Math.toRadians(236.4536374528137),
-              pitch: Cesium.Math.toRadians(-1.3382025460115552),
-              roll: Cesium.Math.toRadians(359.9999985917282),
-            },
-            maximumHeight: 100,
-          };
+        const upwardsView = {
+          destination: new Cesium.Cartesian3(
+            -1371052.4616855076,
+            -5508691.745389906,
+            2901861.440673151
+          ),
+          orientation: {
+            heading: Cesium.Math.toRadians(236.4536374528137),
+            pitch: Cesium.Math.toRadians(-1.3382025460115552),
+            roll: Cesium.Math.toRadians(359.9999985917282),
+          },
+          maximumHeight: 100,
+        };
 
-          viewer.scene.camera.flyTo({
-            destination: frontView.destination,
-            orientation: frontView.orientation,
-            duration: 5.0,
-            pitchAdjustHeight: 20,
-          });
-          Sandcastle.addToolbarMenu(
-            [
-              {
-                text: "Front reflection",
-                onselect: function () {
-                  viewer.scene.camera.flyTo(frontView);
-                  viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601(
-                    "2017-07-11T20:00:00Z"
-                  );
-                },
+        viewer.scene.camera.flyTo({
+          destination: frontView.destination,
+          orientation: frontView.orientation,
+          duration: 5.0,
+          pitchAdjustHeight: 20,
+        });
+        Sandcastle.addToolbarMenu(
+          [
+            {
+              text: "Front reflection",
+              onselect: function () {
+                viewer.scene.camera.flyTo(frontView);
+                viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601(
+                  "2017-07-11T20:00:00Z"
+                );
               },
-              {
-                text: "Three quarters sunrise",
-                onselect: function () {
-                  viewer.scene.camera.flyTo(threeQuartersView);
-                  viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601(
-                    "2017-07-11T11:00:00Z"
-                  );
-                },
+            },
+            {
+              text: "Three quarters sunrise",
+              onselect: function () {
+                viewer.scene.camera.flyTo(threeQuartersView);
+                viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601(
+                  "2017-07-11T11:00:00Z"
+                );
               },
-              {
-                text: "Top reflection",
-                onselect: function () {
-                  viewer.scene.camera.flyTo(topView);
-                  viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601(
-                    "2017-07-11T12:00:00Z"
-                  );
-                },
+            },
+            {
+              text: "Top reflection",
+              onselect: function () {
+                viewer.scene.camera.flyTo(topView);
+                viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601(
+                  "2017-07-11T12:00:00Z"
+                );
               },
-              {
-                text: "Upward angle side reflection",
-                onselect: function () {
-                  viewer.scene.camera.flyTo(upwardsView);
-                  viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601(
-                    "2017-07-11T23:00:00Z"
-                  );
-                },
+            },
+            {
+              text: "Upward angle side reflection",
+              onselect: function () {
+                viewer.scene.camera.flyTo(upwardsView);
+                viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601(
+                  "2017-07-11T23:00:00Z"
+                );
               },
-            ],
-            "toolbar"
-          );
-        })(); //Sandcastle_End
+            },
+          ],
+          "toolbar"
+        );
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Physically-Based Materials.html
+++ b/Apps/Sandcastle/gallery/Physically-Based Materials.html
@@ -48,7 +48,7 @@
         const viewer = new Cesium.Viewer("cesiumContainer", {
           clockViewModel: new Cesium.ClockViewModel(clock),
           selectionIndicator: false,
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         Sandcastle.addToggleButton("Shadows", viewer.shadows, function (

--- a/Apps/Sandcastle/gallery/Sample Height from 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/Sample Height from 3D Tiles.html
@@ -35,97 +35,102 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
-          const scene = viewer.scene;
+        const viewer = new Cesium.Viewer("cesiumContainer");
+        const scene = viewer.scene;
 
-          if (!scene.clampToHeightSupported) {
-            window.alert(
-              "This browser does not support clampToHeightMostDetailed."
+        (async () => {
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+          } catch (error) {
+            console.log(error);
+          }
+        })();
+
+        if (!scene.clampToHeightSupported) {
+          window.alert(
+            "This browser does not support clampToHeightMostDetailed."
+          );
+        }
+
+        const tileset = scene.primitives.add(
+          new Cesium.Cesium3DTileset({
+            url: Cesium.IonResource.fromAssetId(40866),
+          })
+        );
+
+        scene.camera.setView({
+          destination: new Cesium.Cartesian3(
+            1216411.0748779264,
+            -4736313.10747583,
+            4081359.5125561724
+          ),
+          orientation: new Cesium.HeadingPitchRoll(
+            4.239925103568368,
+            -0.4911293834802475,
+            6.279849292088564
+          ),
+          endTransform: Cesium.Matrix4.IDENTITY,
+        });
+
+        Sandcastle.addToolbarButton("Sample heights", function () {
+          sampleHeights();
+        });
+
+        async function sampleHeights() {
+          viewer.entities.removeAll();
+
+          const cartesian1 = new Cesium.Cartesian3(
+            1216390.063324395,
+            -4736314.814479433,
+            4081341.9787972216
+          );
+          const cartesian2 = new Cesium.Cartesian3(
+            1216329.5413318684,
+            -4736272.029009798,
+            4081407.9342479417
+          );
+
+          const count = 30;
+          const cartesians = new Array(count);
+          for (let i = 0; i < count; ++i) {
+            const offset = i / (count - 1);
+            cartesians[i] = Cesium.Cartesian3.lerp(
+              cartesian1,
+              cartesian2,
+              offset,
+              new Cesium.Cartesian3()
             );
           }
 
-          const tileset = scene.primitives.add(
-            new Cesium.Cesium3DTileset({
-              url: Cesium.IonResource.fromAssetId(40866),
-            })
+          const clampedCartesians = await scene.clampToHeightMostDetailed(
+            cartesians
           );
 
-          scene.camera.setView({
-            destination: new Cesium.Cartesian3(
-              1216411.0748779264,
-              -4736313.10747583,
-              4081359.5125561724
-            ),
-            orientation: new Cesium.HeadingPitchRoll(
-              4.239925103568368,
-              -0.4911293834802475,
-              6.279849292088564
-            ),
-            endTransform: Cesium.Matrix4.IDENTITY,
-          });
-
-          Sandcastle.addToolbarButton("Sample heights", function () {
-            sampleHeights();
-          });
-
-          async function sampleHeights() {
-            viewer.entities.removeAll();
-
-            const cartesian1 = new Cesium.Cartesian3(
-              1216390.063324395,
-              -4736314.814479433,
-              4081341.9787972216
-            );
-            const cartesian2 = new Cesium.Cartesian3(
-              1216329.5413318684,
-              -4736272.029009798,
-              4081407.9342479417
-            );
-
-            const count = 30;
-            const cartesians = new Array(count);
-            for (let i = 0; i < count; ++i) {
-              const offset = i / (count - 1);
-              cartesians[i] = Cesium.Cartesian3.lerp(
-                cartesian1,
-                cartesian2,
-                offset,
-                new Cesium.Cartesian3()
-              );
-            }
-
-            const clampedCartesians = await scene.clampToHeightMostDetailed(
-              cartesians
-            );
-
-            for (let i = 0; i < count; ++i) {
-              viewer.entities.add({
-                position: clampedCartesians[i],
-                ellipsoid: {
-                  radii: new Cesium.Cartesian3(0.2, 0.2, 0.2),
-                  material: Cesium.Color.RED,
-                },
-              });
-            }
-
+          for (let i = 0; i < count; ++i) {
             viewer.entities.add({
-              polyline: {
-                positions: clampedCartesians,
-                arcType: Cesium.ArcType.NONE,
-                width: 2,
-                material: new Cesium.PolylineOutlineMaterialProperty({
-                  color: Cesium.Color.YELLOW,
-                }),
-                depthFailMaterial: new Cesium.PolylineOutlineMaterialProperty({
-                  color: Cesium.Color.YELLOW,
-                }),
+              position: clampedCartesians[i],
+              ellipsoid: {
+                radii: new Cesium.Cartesian3(0.2, 0.2, 0.2),
+                material: Cesium.Color.RED,
               },
             });
           }
-        })(); //Sandcastle_End
+
+          viewer.entities.add({
+            polyline: {
+              positions: clampedCartesians,
+              arcType: Cesium.ArcType.NONE,
+              width: 2,
+              material: new Cesium.PolylineOutlineMaterialProperty({
+                color: Cesium.Color.YELLOW,
+              }),
+              depthFailMaterial: new Cesium.PolylineOutlineMaterialProperty({
+                color: Cesium.Color.YELLOW,
+              }),
+            },
+          });
+        }
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Sample Height from 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/Sample Height from 3D Tiles.html
@@ -36,7 +36,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
         const scene = viewer.scene;
 

--- a/Apps/Sandcastle/gallery/Sample Height from 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/Sample Height from 3D Tiles.html
@@ -35,98 +35,97 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
-        const scene = viewer.scene;
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
+          const scene = viewer.scene;
 
-        if (!scene.clampToHeightSupported) {
-          window.alert(
-            "This browser does not support clampToHeightMostDetailed."
-          );
-        }
-
-        const tileset = scene.primitives.add(
-          new Cesium.Cesium3DTileset({
-            url: Cesium.IonResource.fromAssetId(40866),
-          })
-        );
-
-        scene.camera.setView({
-          destination: new Cesium.Cartesian3(
-            1216411.0748779264,
-            -4736313.10747583,
-            4081359.5125561724
-          ),
-          orientation: new Cesium.HeadingPitchRoll(
-            4.239925103568368,
-            -0.4911293834802475,
-            6.279849292088564
-          ),
-          endTransform: Cesium.Matrix4.IDENTITY,
-        });
-
-        Sandcastle.addToolbarButton("Sample heights", function () {
-          sampleHeights();
-        });
-
-        function sampleHeights() {
-          viewer.entities.removeAll();
-
-          const cartesian1 = new Cesium.Cartesian3(
-            1216390.063324395,
-            -4736314.814479433,
-            4081341.9787972216
-          );
-          const cartesian2 = new Cesium.Cartesian3(
-            1216329.5413318684,
-            -4736272.029009798,
-            4081407.9342479417
-          );
-
-          const count = 30;
-          const cartesians = new Array(count);
-          for (let i = 0; i < count; ++i) {
-            const offset = i / (count - 1);
-            cartesians[i] = Cesium.Cartesian3.lerp(
-              cartesian1,
-              cartesian2,
-              offset,
-              new Cesium.Cartesian3()
+          if (!scene.clampToHeightSupported) {
+            window.alert(
+              "This browser does not support clampToHeightMostDetailed."
             );
           }
 
-          scene
-            .clampToHeightMostDetailed(cartesians)
-            .then(function (clampedCartesians) {
-              for (let i = 0; i < count; ++i) {
-                viewer.entities.add({
-                  position: clampedCartesians[i],
-                  ellipsoid: {
-                    radii: new Cesium.Cartesian3(0.2, 0.2, 0.2),
-                    material: Cesium.Color.RED,
-                  },
-                });
-              }
+          const tileset = scene.primitives.add(
+            new Cesium.Cesium3DTileset({
+              url: Cesium.IonResource.fromAssetId(40866),
+            })
+          );
 
+          scene.camera.setView({
+            destination: new Cesium.Cartesian3(
+              1216411.0748779264,
+              -4736313.10747583,
+              4081359.5125561724
+            ),
+            orientation: new Cesium.HeadingPitchRoll(
+              4.239925103568368,
+              -0.4911293834802475,
+              6.279849292088564
+            ),
+            endTransform: Cesium.Matrix4.IDENTITY,
+          });
+
+          Sandcastle.addToolbarButton("Sample heights", function () {
+            sampleHeights();
+          });
+
+          async function sampleHeights() {
+            viewer.entities.removeAll();
+
+            const cartesian1 = new Cesium.Cartesian3(
+              1216390.063324395,
+              -4736314.814479433,
+              4081341.9787972216
+            );
+            const cartesian2 = new Cesium.Cartesian3(
+              1216329.5413318684,
+              -4736272.029009798,
+              4081407.9342479417
+            );
+
+            const count = 30;
+            const cartesians = new Array(count);
+            for (let i = 0; i < count; ++i) {
+              const offset = i / (count - 1);
+              cartesians[i] = Cesium.Cartesian3.lerp(
+                cartesian1,
+                cartesian2,
+                offset,
+                new Cesium.Cartesian3()
+              );
+            }
+
+            const clampedCartesians = await scene.clampToHeightMostDetailed(
+              cartesians
+            );
+
+            for (let i = 0; i < count; ++i) {
               viewer.entities.add({
-                polyline: {
-                  positions: clampedCartesians,
-                  arcType: Cesium.ArcType.NONE,
-                  width: 2,
-                  material: new Cesium.PolylineOutlineMaterialProperty({
-                    color: Cesium.Color.YELLOW,
-                  }),
-                  depthFailMaterial: new Cesium.PolylineOutlineMaterialProperty(
-                    {
-                      color: Cesium.Color.YELLOW,
-                    }
-                  ),
+                position: clampedCartesians[i],
+                ellipsoid: {
+                  radii: new Cesium.Cartesian3(0.2, 0.2, 0.2),
+                  material: Cesium.Color.RED,
                 },
               });
+            }
+
+            viewer.entities.add({
+              polyline: {
+                positions: clampedCartesians,
+                arcType: Cesium.ArcType.NONE,
+                width: 2,
+                material: new Cesium.PolylineOutlineMaterialProperty({
+                  color: Cesium.Color.YELLOW,
+                }),
+                depthFailMaterial: new Cesium.PolylineOutlineMaterialProperty({
+                  color: Cesium.Color.YELLOW,
+                }),
+              },
             });
-        }
-        //Sandcastle_End
+          }
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Scene Rendering Performance.html
+++ b/Apps/Sandcastle/gallery/Scene Rendering Performance.html
@@ -141,215 +141,221 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        // Create a viewer that won't render a new frame unless
-        // updates to the scene require it to reduce overall CPU usage.
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          requestRenderMode: true,
-          maximumRenderTimeChange: Infinity,
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
+        (async () => {
+          // Create a viewer that won't render a new frame unless
+          // updates to the scene require it to reduce overall CPU usage.
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            requestRenderMode: true,
+            maximumRenderTimeChange: Infinity,
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
 
-        const scene = viewer.scene;
-        scene.debugShowFramesPerSecond = true;
+          const scene = viewer.scene;
+          scene.debugShowFramesPerSecond = true;
 
-        let tileset;
+          let tileset;
 
-        const viewModel = {
-          requestRenderMode: true,
-          showTimeOptions: false,
-          timeChangeEnabled: false,
-          maximumRenderTimeChange: 0.0,
-          lastRenderTime: "",
-          requestRender: function () {
+          const viewModel = {
+            requestRenderMode: true,
+            showTimeOptions: false,
+            timeChangeEnabled: false,
+            maximumRenderTimeChange: 0.0,
+            lastRenderTime: "",
+            requestRender: function () {
+              scene.requestRender();
+            },
+          };
+
+          // Clear scene and set default view.
+          let handler;
+          function resetScene() {
+            viewer.trackedEntity = undefined;
+            viewer.dataSources.removeAll();
+            viewer.entities.removeAll();
+            viewer.scene.primitives.remove(tileset);
+            viewer.clock.shouldAnimate = false;
+            handler = handler && handler.destroy();
+            scene.skyBox.show = true;
+            scene.camera.flyHome(0.0);
             scene.requestRender();
-          },
-        };
+            viewModel.showTimeOptions = false;
+            viewModel.timeChangeEnabled = false;
+            viewModel.maximumRenderTimeChange = 0;
+          }
 
-        // Clear scene and set default view.
-        let handler;
-        function resetScene() {
-          viewer.trackedEntity = undefined;
-          viewer.dataSources.removeAll();
-          viewer.entities.removeAll();
-          viewer.scene.primitives.remove(tileset);
-          viewer.clock.shouldAnimate = false;
-          handler = handler && handler.destroy();
-          scene.skyBox.show = true;
-          scene.camera.flyHome(0.0);
-          scene.requestRender();
-          viewModel.showTimeOptions = false;
-          viewModel.timeChangeEnabled = false;
-          viewModel.maximumRenderTimeChange = 0;
-        }
+          // Load a tileset and set the view.
+          // No need to call scene.requestRender()
+          function loadTilesetScenario() {
+            resetScene();
 
-        // Load a tileset and set the view.
-        // No need to call scene.requestRender()
-        function loadTilesetScenario() {
-          resetScene();
+            tileset = new Cesium.Cesium3DTileset({
+              url: Cesium.IonResource.fromAssetId(40866),
+            });
+            viewer.scene.primitives.add(tileset);
+            viewer.zoomTo(tileset);
+          }
 
-          tileset = new Cesium.Cesium3DTileset({
-            url: Cesium.IonResource.fromAssetId(40866),
-          });
-          viewer.scene.primitives.add(tileset);
-          viewer.zoomTo(tileset);
-        }
+          // Load an animated model and set the view.
+          // No need to call scene.requestRender()
+          // Enable and adjust maximum simulation time change to see
+          // animations at desired speed.
+          function loadModelScenario() {
+            resetScene();
+            viewModel.timeChangeEnabled = true;
+            viewModel.showTimeOptions = true;
 
-        // Load an animated model and set the view.
-        // No need to call scene.requestRender()
-        // Enable and adjust maximum simulation time change to see
-        // animations at desired speed.
-        function loadModelScenario() {
-          resetScene();
-          viewModel.timeChangeEnabled = true;
-          viewModel.showTimeOptions = true;
+            const entity = viewer.entities.add({
+              name: "Aircraft",
+              position: Cesium.Cartesian3.fromDegrees(
+                -123.0744619,
+                44.0503706,
+                5000.0
+              ),
+              model: {
+                uri: "../../SampleData/models/CesiumAir/Cesium_Air.glb",
+                minimumPixelSize: 128,
+                maximumScale: 20000,
+              },
+            });
 
-          const entity = viewer.entities.add({
-            name: "Aircraft",
-            position: Cesium.Cartesian3.fromDegrees(
-              -123.0744619,
-              44.0503706,
-              5000.0
-            ),
-            model: {
-              uri: "../../SampleData/models/CesiumAir/Cesium_Air.glb",
-              minimumPixelSize: 128,
-              maximumScale: 20000,
-            },
-          });
+            viewer.trackedEntity = entity;
+            viewer.clock.shouldAnimate = true;
+          }
 
-          viewer.trackedEntity = entity;
-          viewer.clock.shouldAnimate = true;
-        }
+          // Load CZML DataSource with a model and set the trackedEntity.
+          // No need to call scene.requestRender()
+          // Enable and adjust maximum simulation time change to see
+          // animations at desired speed.
+          function loadCzmlScenario() {
+            resetScene();
+            viewModel.showTimeOptions = true;
+            viewModel.timeChangeEnabled = true;
+            viewModel.maximumRenderTimeChange = 10.0;
 
-        // Load CZML DataSource with a model and set the trackedEntity.
-        // No need to call scene.requestRender()
-        // Enable and adjust maximum simulation time change to see
-        // animations at desired speed.
-        function loadCzmlScenario() {
-          resetScene();
-          viewModel.showTimeOptions = true;
-          viewModel.timeChangeEnabled = true;
-          viewModel.maximumRenderTimeChange = 10.0;
+            viewer.dataSources.add(
+              Cesium.CzmlDataSource.load("../../SampleData/simple.czml")
+            );
+            viewer.clock.shouldAnimate = true;
+          }
 
-          viewer.dataSources.add(
-            Cesium.CzmlDataSource.load("../../SampleData/simple.czml")
-          );
-          viewer.clock.shouldAnimate = true;
-        }
+          // Pick an entity, only rendering when needed.
+          function pickingScenario() {
+            resetScene();
 
-        // Pick an entity, only rendering when needed.
-        function pickingScenario() {
-          resetScene();
+            let color = Cesium.Color.CORNFLOWERBLUE;
+            const colorProperty = new Cesium.CallbackProperty(function () {
+              return color;
+            }, false);
+            const entity = viewer.entities.add({
+              position: Cesium.Cartesian3.fromDegrees(-75.59777, 40.03883),
+              box: {
+                dimensions: new Cesium.Cartesian3(
+                  1000000.0,
+                  1000000.0,
+                  30000.0
+                ),
+                material: new Cesium.ColorMaterialProperty(colorProperty),
+              },
+            });
 
-          let color = Cesium.Color.CORNFLOWERBLUE;
-          const colorProperty = new Cesium.CallbackProperty(function () {
-            return color;
-          }, false);
-          const entity = viewer.entities.add({
-            position: Cesium.Cartesian3.fromDegrees(-75.59777, 40.03883),
-            box: {
-              dimensions: new Cesium.Cartesian3(1000000.0, 1000000.0, 30000.0),
-              material: new Cesium.ColorMaterialProperty(colorProperty),
-            },
-          });
+            scene.requestRender();
 
-          scene.requestRender();
-
-          // If the mouse is over the box, change its scale and color,
-          // then request a new render frame.
-          let lastPicked;
-          handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
-          handler.setInputAction(function (movement) {
-            const pickedObject = scene.pick(movement.endPosition);
-            if (Cesium.defined(pickedObject) && pickedObject.id === entity) {
-              if (Cesium.defined(lastPicked)) {
-                return;
+            // If the mouse is over the box, change its scale and color,
+            // then request a new render frame.
+            let lastPicked;
+            handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
+            handler.setInputAction(function (movement) {
+              const pickedObject = scene.pick(movement.endPosition);
+              if (Cesium.defined(pickedObject) && pickedObject.id === entity) {
+                if (Cesium.defined(lastPicked)) {
+                  return;
+                }
+                color = Cesium.Color.YELLOW;
+                scene.requestRender();
+                lastPicked = pickedObject;
+              } else if (Cesium.defined(lastPicked)) {
+                color = Cesium.Color.CORNFLOWERBLUE;
+                scene.requestRender();
+                lastPicked = undefined;
               }
-              color = Cesium.Color.YELLOW;
-              scene.requestRender();
-              lastPicked = pickedObject;
-            } else if (Cesium.defined(lastPicked)) {
-              color = Cesium.Color.CORNFLOWERBLUE;
-              scene.requestRender();
-              lastPicked = undefined;
-            }
-          }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-        }
+            }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+          }
 
-        // Changes to the scene with the API will require
-        // calling requestRender() on change.
-        function setScenePropertiesScenario() {
-          resetScene();
+          // Changes to the scene with the API will require
+          // calling requestRender() on change.
+          function setScenePropertiesScenario() {
+            resetScene();
 
-          scene.skyBox.show = false;
-          scene.backgroundColor = Cesium.Color.CORNFLOWERBLUE;
-          scene.requestRender();
-        }
+            scene.skyBox.show = false;
+            scene.backgroundColor = Cesium.Color.CORNFLOWERBLUE;
+            scene.requestRender();
+          }
 
-        // BEGIN SANDCASTLE EXAMPLE UI SETUP
+          // BEGIN SANDCASTLE EXAMPLE UI SETUP
 
-        const toolbar = document.getElementById("toolbar");
-        Cesium.knockout.track(viewModel);
-        Cesium.knockout.applyBindings(viewModel, toolbar);
+          const toolbar = document.getElementById("toolbar");
+          Cesium.knockout.track(viewModel);
+          Cesium.knockout.applyBindings(viewModel, toolbar);
 
-        Cesium.knockout
-          .getObservable(viewModel, "requestRenderMode")
-          .subscribe(function (value) {
-            scene.requestRenderMode = value;
+          Cesium.knockout
+            .getObservable(viewModel, "requestRenderMode")
+            .subscribe(function (value) {
+              scene.requestRenderMode = value;
+            });
+
+          Cesium.knockout
+            .getObservable(viewModel, "timeChangeEnabled")
+            .subscribe(function (value) {
+              scene.maximumRenderTimeChange = value
+                ? viewModel.maximumRenderTimeChange
+                : Infinity;
+            });
+
+          Cesium.knockout
+            .getObservable(viewModel, "maximumRenderTimeChange")
+            .subscribe(function (value) {
+              scene.maximumRenderTimeChange = value;
+            });
+
+          scene.postRender.addEventListener(function () {
+            const time = Cesium.JulianDate.toGregorianDate(
+              scene.lastRenderTime
+            );
+            const value = `${time.hour}:${time.minute}:${
+              time.second
+            }:${time.millisecond.toFixed(0)}`;
+            Cesium.knockout.getObservable(viewModel, "lastRenderTime")(value);
           });
 
-        Cesium.knockout
-          .getObservable(viewModel, "timeChangeEnabled")
-          .subscribe(function (value) {
-            scene.maximumRenderTimeChange = value
-              ? viewModel.maximumRenderTimeChange
-              : Infinity;
-          });
+          const scenarios = [
+            {
+              text: "Default view",
+              onselect: resetScene,
+            },
+            {
+              text: "Load a 3D tileset and set the view",
+              onselect: loadTilesetScenario,
+            },
+            {
+              text: "Mouseover picking",
+              onselect: pickingScenario,
+            },
+            {
+              text: "Load time-dynamic CZML",
+              onselect: loadCzmlScenario,
+            },
+            {
+              text: "Animated model",
+              onselect: loadModelScenario,
+            },
+            {
+              text: "Scene changes with API",
+              onselect: setScenePropertiesScenario,
+            },
+          ];
 
-        Cesium.knockout
-          .getObservable(viewModel, "maximumRenderTimeChange")
-          .subscribe(function (value) {
-            scene.maximumRenderTimeChange = value;
-          });
-
-        scene.postRender.addEventListener(function () {
-          const time = Cesium.JulianDate.toGregorianDate(scene.lastRenderTime);
-          const value = `${time.hour}:${time.minute}:${
-            time.second
-          }:${time.millisecond.toFixed(0)}`;
-          Cesium.knockout.getObservable(viewModel, "lastRenderTime")(value);
-        });
-
-        const scenarios = [
-          {
-            text: "Default view",
-            onselect: resetScene,
-          },
-          {
-            text: "Load a 3D tileset and set the view",
-            onselect: loadTilesetScenario,
-          },
-          {
-            text: "Mouseover picking",
-            onselect: pickingScenario,
-          },
-          {
-            text: "Load time-dynamic CZML",
-            onselect: loadCzmlScenario,
-          },
-          {
-            text: "Animated model",
-            onselect: loadModelScenario,
-          },
-          {
-            text: "Scene changes with API",
-            onselect: setScenePropertiesScenario,
-          },
-        ];
-
-        Sandcastle.addToolbarMenu(scenarios);
-
-        //Sandcastle_End
+          Sandcastle.addToolbarMenu(scenarios);
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Scene Rendering Performance.html
+++ b/Apps/Sandcastle/gallery/Scene Rendering Performance.html
@@ -141,221 +141,221 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        // Create a viewer that won't render a new frame unless
+        // updates to the scene require it to reduce overall CPU usage.
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          requestRenderMode: true,
+          maximumRenderTimeChange: Infinity,
+        });
+
         (async () => {
-          // Create a viewer that won't render a new frame unless
-          // updates to the scene require it to reduce overall CPU usage.
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            requestRenderMode: true,
-            maximumRenderTimeChange: Infinity,
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+          } catch (error) {
+            console.log(error);
+          }
+        })();
+
+        const scene = viewer.scene;
+        scene.debugShowFramesPerSecond = true;
+
+        let tileset;
+
+        const viewModel = {
+          requestRenderMode: true,
+          showTimeOptions: false,
+          timeChangeEnabled: false,
+          maximumRenderTimeChange: 0.0,
+          lastRenderTime: "",
+          requestRender: function () {
+            scene.requestRender();
+          },
+        };
+
+        // Clear scene and set default view.
+        let handler;
+        function resetScene() {
+          viewer.trackedEntity = undefined;
+          viewer.dataSources.removeAll();
+          viewer.entities.removeAll();
+          viewer.scene.primitives.remove(tileset);
+          viewer.clock.shouldAnimate = false;
+          handler = handler && handler.destroy();
+          scene.skyBox.show = true;
+          scene.camera.flyHome(0.0);
+          scene.requestRender();
+          viewModel.showTimeOptions = false;
+          viewModel.timeChangeEnabled = false;
+          viewModel.maximumRenderTimeChange = 0;
+        }
+
+        // Load a tileset and set the view.
+        // No need to call scene.requestRender()
+        function loadTilesetScenario() {
+          resetScene();
+
+          tileset = new Cesium.Cesium3DTileset({
+            url: Cesium.IonResource.fromAssetId(40866),
+          });
+          viewer.scene.primitives.add(tileset);
+          viewer.zoomTo(tileset);
+        }
+
+        // Load an animated model and set the view.
+        // No need to call scene.requestRender()
+        // Enable and adjust maximum simulation time change to see
+        // animations at desired speed.
+        function loadModelScenario() {
+          resetScene();
+          viewModel.timeChangeEnabled = true;
+          viewModel.showTimeOptions = true;
+
+          const entity = viewer.entities.add({
+            name: "Aircraft",
+            position: Cesium.Cartesian3.fromDegrees(
+              -123.0744619,
+              44.0503706,
+              5000.0
+            ),
+            model: {
+              uri: "../../SampleData/models/CesiumAir/Cesium_Air.glb",
+              minimumPixelSize: 128,
+              maximumScale: 20000,
+            },
           });
 
-          const scene = viewer.scene;
-          scene.debugShowFramesPerSecond = true;
+          viewer.trackedEntity = entity;
+          viewer.clock.shouldAnimate = true;
+        }
 
-          let tileset;
+        // Load CZML DataSource with a model and set the trackedEntity.
+        // No need to call scene.requestRender()
+        // Enable and adjust maximum simulation time change to see
+        // animations at desired speed.
+        function loadCzmlScenario() {
+          resetScene();
+          viewModel.showTimeOptions = true;
+          viewModel.timeChangeEnabled = true;
+          viewModel.maximumRenderTimeChange = 10.0;
 
-          const viewModel = {
-            requestRenderMode: true,
-            showTimeOptions: false,
-            timeChangeEnabled: false,
-            maximumRenderTimeChange: 0.0,
-            lastRenderTime: "",
-            requestRender: function () {
-              scene.requestRender();
+          viewer.dataSources.add(
+            Cesium.CzmlDataSource.load("../../SampleData/simple.czml")
+          );
+          viewer.clock.shouldAnimate = true;
+        }
+
+        // Pick an entity, only rendering when needed.
+        function pickingScenario() {
+          resetScene();
+
+          let color = Cesium.Color.CORNFLOWERBLUE;
+          const colorProperty = new Cesium.CallbackProperty(function () {
+            return color;
+          }, false);
+          const entity = viewer.entities.add({
+            position: Cesium.Cartesian3.fromDegrees(-75.59777, 40.03883),
+            box: {
+              dimensions: new Cesium.Cartesian3(1000000.0, 1000000.0, 30000.0),
+              material: new Cesium.ColorMaterialProperty(colorProperty),
             },
-          };
+          });
 
-          // Clear scene and set default view.
-          let handler;
-          function resetScene() {
-            viewer.trackedEntity = undefined;
-            viewer.dataSources.removeAll();
-            viewer.entities.removeAll();
-            viewer.scene.primitives.remove(tileset);
-            viewer.clock.shouldAnimate = false;
-            handler = handler && handler.destroy();
-            scene.skyBox.show = true;
-            scene.camera.flyHome(0.0);
-            scene.requestRender();
-            viewModel.showTimeOptions = false;
-            viewModel.timeChangeEnabled = false;
-            viewModel.maximumRenderTimeChange = 0;
-          }
+          scene.requestRender();
 
-          // Load a tileset and set the view.
-          // No need to call scene.requestRender()
-          function loadTilesetScenario() {
-            resetScene();
-
-            tileset = new Cesium.Cesium3DTileset({
-              url: Cesium.IonResource.fromAssetId(40866),
-            });
-            viewer.scene.primitives.add(tileset);
-            viewer.zoomTo(tileset);
-          }
-
-          // Load an animated model and set the view.
-          // No need to call scene.requestRender()
-          // Enable and adjust maximum simulation time change to see
-          // animations at desired speed.
-          function loadModelScenario() {
-            resetScene();
-            viewModel.timeChangeEnabled = true;
-            viewModel.showTimeOptions = true;
-
-            const entity = viewer.entities.add({
-              name: "Aircraft",
-              position: Cesium.Cartesian3.fromDegrees(
-                -123.0744619,
-                44.0503706,
-                5000.0
-              ),
-              model: {
-                uri: "../../SampleData/models/CesiumAir/Cesium_Air.glb",
-                minimumPixelSize: 128,
-                maximumScale: 20000,
-              },
-            });
-
-            viewer.trackedEntity = entity;
-            viewer.clock.shouldAnimate = true;
-          }
-
-          // Load CZML DataSource with a model and set the trackedEntity.
-          // No need to call scene.requestRender()
-          // Enable and adjust maximum simulation time change to see
-          // animations at desired speed.
-          function loadCzmlScenario() {
-            resetScene();
-            viewModel.showTimeOptions = true;
-            viewModel.timeChangeEnabled = true;
-            viewModel.maximumRenderTimeChange = 10.0;
-
-            viewer.dataSources.add(
-              Cesium.CzmlDataSource.load("../../SampleData/simple.czml")
-            );
-            viewer.clock.shouldAnimate = true;
-          }
-
-          // Pick an entity, only rendering when needed.
-          function pickingScenario() {
-            resetScene();
-
-            let color = Cesium.Color.CORNFLOWERBLUE;
-            const colorProperty = new Cesium.CallbackProperty(function () {
-              return color;
-            }, false);
-            const entity = viewer.entities.add({
-              position: Cesium.Cartesian3.fromDegrees(-75.59777, 40.03883),
-              box: {
-                dimensions: new Cesium.Cartesian3(
-                  1000000.0,
-                  1000000.0,
-                  30000.0
-                ),
-                material: new Cesium.ColorMaterialProperty(colorProperty),
-              },
-            });
-
-            scene.requestRender();
-
-            // If the mouse is over the box, change its scale and color,
-            // then request a new render frame.
-            let lastPicked;
-            handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
-            handler.setInputAction(function (movement) {
-              const pickedObject = scene.pick(movement.endPosition);
-              if (Cesium.defined(pickedObject) && pickedObject.id === entity) {
-                if (Cesium.defined(lastPicked)) {
-                  return;
-                }
-                color = Cesium.Color.YELLOW;
-                scene.requestRender();
-                lastPicked = pickedObject;
-              } else if (Cesium.defined(lastPicked)) {
-                color = Cesium.Color.CORNFLOWERBLUE;
-                scene.requestRender();
-                lastPicked = undefined;
+          // If the mouse is over the box, change its scale and color,
+          // then request a new render frame.
+          let lastPicked;
+          handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
+          handler.setInputAction(function (movement) {
+            const pickedObject = scene.pick(movement.endPosition);
+            if (Cesium.defined(pickedObject) && pickedObject.id === entity) {
+              if (Cesium.defined(lastPicked)) {
+                return;
               }
-            }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-          }
+              color = Cesium.Color.YELLOW;
+              scene.requestRender();
+              lastPicked = pickedObject;
+            } else if (Cesium.defined(lastPicked)) {
+              color = Cesium.Color.CORNFLOWERBLUE;
+              scene.requestRender();
+              lastPicked = undefined;
+            }
+          }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+        }
 
-          // Changes to the scene with the API will require
-          // calling requestRender() on change.
-          function setScenePropertiesScenario() {
-            resetScene();
+        // Changes to the scene with the API will require
+        // calling requestRender() on change.
+        function setScenePropertiesScenario() {
+          resetScene();
 
-            scene.skyBox.show = false;
-            scene.backgroundColor = Cesium.Color.CORNFLOWERBLUE;
-            scene.requestRender();
-          }
+          scene.skyBox.show = false;
+          scene.backgroundColor = Cesium.Color.CORNFLOWERBLUE;
+          scene.requestRender();
+        }
 
-          // BEGIN SANDCASTLE EXAMPLE UI SETUP
+        // BEGIN SANDCASTLE EXAMPLE UI SETUP
 
-          const toolbar = document.getElementById("toolbar");
-          Cesium.knockout.track(viewModel);
-          Cesium.knockout.applyBindings(viewModel, toolbar);
+        const toolbar = document.getElementById("toolbar");
+        Cesium.knockout.track(viewModel);
+        Cesium.knockout.applyBindings(viewModel, toolbar);
 
-          Cesium.knockout
-            .getObservable(viewModel, "requestRenderMode")
-            .subscribe(function (value) {
-              scene.requestRenderMode = value;
-            });
-
-          Cesium.knockout
-            .getObservable(viewModel, "timeChangeEnabled")
-            .subscribe(function (value) {
-              scene.maximumRenderTimeChange = value
-                ? viewModel.maximumRenderTimeChange
-                : Infinity;
-            });
-
-          Cesium.knockout
-            .getObservable(viewModel, "maximumRenderTimeChange")
-            .subscribe(function (value) {
-              scene.maximumRenderTimeChange = value;
-            });
-
-          scene.postRender.addEventListener(function () {
-            const time = Cesium.JulianDate.toGregorianDate(
-              scene.lastRenderTime
-            );
-            const value = `${time.hour}:${time.minute}:${
-              time.second
-            }:${time.millisecond.toFixed(0)}`;
-            Cesium.knockout.getObservable(viewModel, "lastRenderTime")(value);
+        Cesium.knockout
+          .getObservable(viewModel, "requestRenderMode")
+          .subscribe(function (value) {
+            scene.requestRenderMode = value;
           });
 
-          const scenarios = [
-            {
-              text: "Default view",
-              onselect: resetScene,
-            },
-            {
-              text: "Load a 3D tileset and set the view",
-              onselect: loadTilesetScenario,
-            },
-            {
-              text: "Mouseover picking",
-              onselect: pickingScenario,
-            },
-            {
-              text: "Load time-dynamic CZML",
-              onselect: loadCzmlScenario,
-            },
-            {
-              text: "Animated model",
-              onselect: loadModelScenario,
-            },
-            {
-              text: "Scene changes with API",
-              onselect: setScenePropertiesScenario,
-            },
-          ];
+        Cesium.knockout
+          .getObservable(viewModel, "timeChangeEnabled")
+          .subscribe(function (value) {
+            scene.maximumRenderTimeChange = value
+              ? viewModel.maximumRenderTimeChange
+              : Infinity;
+          });
 
-          Sandcastle.addToolbarMenu(scenarios);
-        })(); //Sandcastle_End
+        Cesium.knockout
+          .getObservable(viewModel, "maximumRenderTimeChange")
+          .subscribe(function (value) {
+            scene.maximumRenderTimeChange = value;
+          });
+
+        scene.postRender.addEventListener(function () {
+          const time = Cesium.JulianDate.toGregorianDate(scene.lastRenderTime);
+          const value = `${time.hour}:${time.minute}:${
+            time.second
+          }:${time.millisecond.toFixed(0)}`;
+          Cesium.knockout.getObservable(viewModel, "lastRenderTime")(value);
+        });
+
+        const scenarios = [
+          {
+            text: "Default view",
+            onselect: resetScene,
+          },
+          {
+            text: "Load a 3D tileset and set the view",
+            onselect: loadTilesetScenario,
+          },
+          {
+            text: "Mouseover picking",
+            onselect: pickingScenario,
+          },
+          {
+            text: "Load time-dynamic CZML",
+            onselect: loadCzmlScenario,
+          },
+          {
+            text: "Animated model",
+            onselect: loadModelScenario,
+          },
+          {
+            text: "Scene changes with API",
+            onselect: setScenePropertiesScenario,
+          },
+        ];
+
+        Sandcastle.addToolbarMenu(scenarios);
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Scene Rendering Performance.html
+++ b/Apps/Sandcastle/gallery/Scene Rendering Performance.html
@@ -146,7 +146,7 @@
         const viewer = new Cesium.Viewer("cesiumContainer", {
           requestRenderMode: true,
           maximumRenderTimeChange: Infinity,
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         const scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/Shadows.html
+++ b/Apps/Sandcastle/gallery/Shadows.html
@@ -41,7 +41,7 @@
           shadows: true,
           terrainShadows: Cesium.ShadowMode.ENABLED,
           shouldAnimate: true,
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         const shadowMap = viewer.shadowMap;

--- a/Apps/Sandcastle/gallery/Shadows.html
+++ b/Apps/Sandcastle/gallery/Shadows.html
@@ -35,271 +35,273 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          infoBox: false,
-          selectionIndicator: false,
-          shadows: true,
-          terrainShadows: Cesium.ShadowMode.ENABLED,
-          shouldAnimate: true,
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            infoBox: false,
+            selectionIndicator: false,
+            shadows: true,
+            terrainShadows: Cesium.ShadowMode.ENABLED,
+            shouldAnimate: true,
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
 
-        const shadowMap = viewer.shadowMap;
-        shadowMap.maximumDistance = 10000.0;
+          const shadowMap = viewer.shadowMap;
+          shadowMap.maximumDistance = 10000.0;
 
-        const cesiumAir = viewer.entities.add({
-          name: "Cesium Air",
-          height: 20.0,
-          model: {
-            uri: "../../SampleData/models/CesiumAir/Cesium_Air.glb",
-          },
-        });
+          const cesiumAir = viewer.entities.add({
+            name: "Cesium Air",
+            height: 20.0,
+            model: {
+              uri: "../../SampleData/models/CesiumAir/Cesium_Air.glb",
+            },
+          });
 
-        const groundVehicle = viewer.entities.add({
-          name: "Ground Vehicle",
-          height: 0.0,
-          model: {
-            uri: "../../SampleData/models/GroundVehicle/GroundVehicle.glb",
-            heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-          },
-        });
+          const groundVehicle = viewer.entities.add({
+            name: "Ground Vehicle",
+            height: 0.0,
+            model: {
+              uri: "../../SampleData/models/GroundVehicle/GroundVehicle.glb",
+              heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+            },
+          });
 
-        const cesiumMan = viewer.entities.add({
-          name: "Cesium Man",
-          height: 0.0,
-          model: {
-            uri: "../../SampleData/models/CesiumMan/Cesium_Man.glb",
-            heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-          },
-        });
+          const cesiumMan = viewer.entities.add({
+            name: "Cesium Man",
+            height: 0.0,
+            model: {
+              uri: "../../SampleData/models/CesiumMan/Cesium_Man.glb",
+              heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+            },
+          });
 
-        const woodTower = viewer.entities.add({
-          name: "Wood Tower",
-          height: 0.0,
-          model: {
-            uri: "../../SampleData/models/WoodTower/Wood_Tower.glb",
-          },
-        });
+          const woodTower = viewer.entities.add({
+            name: "Wood Tower",
+            height: 0.0,
+            model: {
+              uri: "../../SampleData/models/WoodTower/Wood_Tower.glb",
+            },
+          });
 
-        const simpleCity = viewer.entities.add({
-          name: "Simple City",
-          height: 0.0,
-          model: {
-            uri: "../../SampleData/models/ShadowTester/Shadow_Tester_4.glb",
-          },
-        });
+          const simpleCity = viewer.entities.add({
+            name: "Simple City",
+            height: 0.0,
+            model: {
+              uri: "../../SampleData/models/ShadowTester/Shadow_Tester_4.glb",
+            },
+          });
 
-        const boxEntity = viewer.entities.add({
-          name: "Box",
-          height: 10.0,
-          box: {
-            dimensions: new Cesium.Cartesian3(10.0, 10.0, 10.0),
-            material: Cesium.Color.RED,
-            shadows: Cesium.ShadowMode.ENABLED,
-          },
-        });
+          const boxEntity = viewer.entities.add({
+            name: "Box",
+            height: 10.0,
+            box: {
+              dimensions: new Cesium.Cartesian3(10.0, 10.0, 10.0),
+              material: Cesium.Color.RED,
+              shadows: Cesium.ShadowMode.ENABLED,
+            },
+          });
 
-        const checkerMaterial = new Cesium.CheckerboardMaterialProperty({
-          evenColor: Cesium.Color.RED.withAlpha(0.5),
-          oddColor: Cesium.Color.RED.withAlpha(0.0),
-          repeat: new Cesium.Cartesian2(5.0, 10.0),
-        });
+          const checkerMaterial = new Cesium.CheckerboardMaterialProperty({
+            evenColor: Cesium.Color.RED.withAlpha(0.5),
+            oddColor: Cesium.Color.RED.withAlpha(0.0),
+            repeat: new Cesium.Cartesian2(5.0, 10.0),
+          });
 
-        const checkerEntity = viewer.entities.add({
-          name: "Checkered Box",
-          height: 10.0,
-          box: {
-            dimensions: new Cesium.Cartesian3(10.0, 10.0, 10.0),
-            material: checkerMaterial,
-            outline: true,
-            outlineColor: Cesium.Color.RED,
-            shadows: Cesium.ShadowMode.ENABLED,
-          },
-        });
+          const checkerEntity = viewer.entities.add({
+            name: "Checkered Box",
+            height: 10.0,
+            box: {
+              dimensions: new Cesium.Cartesian3(10.0, 10.0, 10.0),
+              material: checkerMaterial,
+              outline: true,
+              outlineColor: Cesium.Color.RED,
+              shadows: Cesium.ShadowMode.ENABLED,
+            },
+          });
 
-        const sphereEntity = viewer.entities.add({
-          name: "Sphere",
-          height: 20.0,
-          ellipsoid: {
-            radii: new Cesium.Cartesian3(15.0, 15.0, 15.0),
-            material: Cesium.Color.BLUE.withAlpha(0.5),
-            slicePartitions: 24,
-            stackPartitions: 36,
-            shadows: Cesium.ShadowMode.ENABLED,
-          },
-        });
+          const sphereEntity = viewer.entities.add({
+            name: "Sphere",
+            height: 20.0,
+            ellipsoid: {
+              radii: new Cesium.Cartesian3(15.0, 15.0, 15.0),
+              material: Cesium.Color.BLUE.withAlpha(0.5),
+              slicePartitions: 24,
+              stackPartitions: 36,
+              shadows: Cesium.ShadowMode.ENABLED,
+            },
+          });
 
-        const locations = {
-          Exton: {
-            longitude: -1.31968,
-            latitude: 0.698874,
-            height: 74.14210186070714,
-            date: 2457522.154792,
-          },
-          HalfDome: {
-            longitude: -2.086267733294987,
-            latitude: 0.6587491773830219,
-            height: 2640.716312584986,
-            date: 2457507.247512,
-          },
-          Everest: {
-            longitude: 1.517132688,
-            latitude: 0.4884844964,
-            height: 8773.17824498951,
-            date: 2457507.620845,
-          },
-          PinnaclePA: {
-            longitude: -1.3324415110874286,
-            latitude: 0.6954224325279967,
-            height: 179.14276256241743,
-            date: 2457523.04162,
-          },
-          SenecaRocks: {
-            longitude: -1.3851775172879768,
-            latitude: 0.6778211831093554,
-            height: 682.5893300695776,
-            date: 2457522.097512,
-          },
-          Space: {
-            longitude: -1.31968,
-            latitude: 0.698874,
-            height: 2000000.0,
-            date: 2457522.154792,
-          },
-        };
+          const locations = {
+            Exton: {
+              longitude: -1.31968,
+              latitude: 0.698874,
+              height: 74.14210186070714,
+              date: 2457522.154792,
+            },
+            HalfDome: {
+              longitude: -2.086267733294987,
+              latitude: 0.6587491773830219,
+              height: 2640.716312584986,
+              date: 2457507.247512,
+            },
+            Everest: {
+              longitude: 1.517132688,
+              latitude: 0.4884844964,
+              height: 8773.17824498951,
+              date: 2457507.620845,
+            },
+            PinnaclePA: {
+              longitude: -1.3324415110874286,
+              latitude: 0.6954224325279967,
+              height: 179.14276256241743,
+              date: 2457523.04162,
+            },
+            SenecaRocks: {
+              longitude: -1.3851775172879768,
+              latitude: 0.6778211831093554,
+              height: 682.5893300695776,
+              date: 2457522.097512,
+            },
+            Space: {
+              longitude: -1.31968,
+              latitude: 0.698874,
+              height: 2000000.0,
+              date: 2457522.154792,
+            },
+          };
 
-        let i;
-        const entities = viewer.entities.values;
-        const entitiesLength = entities.length;
+          let i;
+          const entities = viewer.entities.values;
+          const entitiesLength = entities.length;
 
-        function setLocation(location) {
-          const longitude = location.longitude;
-          const latitude = location.latitude;
-          const height = location.height;
+          function setLocation(location) {
+            const longitude = location.longitude;
+            const latitude = location.latitude;
+            const height = location.height;
 
-          for (i = 0; i < entitiesLength; ++i) {
-            const entity = entities[i];
-            entity.position = Cesium.Cartesian3.fromRadians(
-              longitude,
-              latitude,
-              height + entity.height
-            );
+            for (i = 0; i < entitiesLength; ++i) {
+              const entity = entities[i];
+              entity.position = Cesium.Cartesian3.fromRadians(
+                longitude,
+                latitude,
+                height + entity.height
+              );
+            }
+
+            viewer.clock.currentTime = new Cesium.JulianDate(location.date);
+            viewer.clock.multiplier = 1.0;
           }
 
-          viewer.clock.currentTime = new Cesium.JulianDate(location.date);
-          viewer.clock.multiplier = 1.0;
-        }
+          function setLocationFunction(location) {
+            return function () {
+              setLocation(location);
+            };
+          }
 
-        function setLocationFunction(location) {
-          return function () {
-            setLocation(location);
-          };
-        }
+          const locationToolbarOptions = [];
+          for (const locationName in locations) {
+            if (locations.hasOwnProperty(locationName)) {
+              const location = locations[locationName];
+              locationToolbarOptions.push({
+                text: locationName,
+                onselect: setLocationFunction(location),
+              });
+            }
+          }
 
-        const locationToolbarOptions = [];
-        for (const locationName in locations) {
-          if (locations.hasOwnProperty(locationName)) {
-            const location = locations[locationName];
-            locationToolbarOptions.push({
-              text: locationName,
-              onselect: setLocationFunction(location),
+          Sandcastle.addToolbarMenu(locationToolbarOptions);
+
+          function setEntity(entity) {
+            for (i = 0; i < entitiesLength; ++i) {
+              entities[i].show = false;
+            }
+            entity.show = true;
+            viewer.trackedEntity = entity;
+          }
+
+          function setEntityFunction(entity) {
+            return function () {
+              setEntity(entity);
+            };
+          }
+
+          const entityToolbarOptions = [];
+          for (i = 0; i < entitiesLength; ++i) {
+            const entity = entities[i];
+            entityToolbarOptions.push({
+              text: entity.name,
+              onselect: setEntityFunction(entity),
             });
           }
-        }
 
-        Sandcastle.addToolbarMenu(locationToolbarOptions);
+          Sandcastle.addToolbarMenu(entityToolbarOptions);
 
-        function setEntity(entity) {
-          for (i = 0; i < entitiesLength; ++i) {
-            entities[i].show = false;
-          }
-          entity.show = true;
-          viewer.trackedEntity = entity;
-        }
-
-        function setEntityFunction(entity) {
-          return function () {
-            setEntity(entity);
-          };
-        }
-
-        const entityToolbarOptions = [];
-        for (i = 0; i < entitiesLength; ++i) {
-          const entity = entities[i];
-          entityToolbarOptions.push({
-            text: entity.name,
-            onselect: setEntityFunction(entity),
+          Sandcastle.addToggleButton("Shadows", viewer.shadows, function (
+            checked
+          ) {
+            viewer.shadows = checked;
           });
-        }
 
-        Sandcastle.addToolbarMenu(entityToolbarOptions);
-
-        Sandcastle.addToggleButton("Shadows", viewer.shadows, function (
-          checked
-        ) {
-          viewer.shadows = checked;
-        });
-
-        Sandcastle.addToggleButton("Entity Shadows", true, function (checked) {
-          const entityShadows = checked
-            ? Cesium.ShadowMode.ENABLED
-            : Cesium.ShadowMode.DISABLED;
-          for (i = 0; i < entitiesLength; ++i) {
-            const entity = entities[i];
-            const visual = entity.model || entity.box || entity.ellipsoid;
-            visual.shadows = entityShadows;
-          }
-        });
-
-        Sandcastle.addToggleButton(
-          "Terrain Shadows",
-          viewer.terrainShadows === Cesium.ShadowMode.ENABLED,
-          function (checked) {
-            viewer.terrainShadows = checked
+          Sandcastle.addToggleButton("Entity Shadows", true, function (
+            checked
+          ) {
+            const entityShadows = checked
               ? Cesium.ShadowMode.ENABLED
               : Cesium.ShadowMode.DISABLED;
-          }
-        );
+            for (i = 0; i < entitiesLength; ++i) {
+              const entity = entities[i];
+              const visual = entity.model || entity.box || entity.ellipsoid;
+              visual.shadows = entityShadows;
+            }
+          });
 
-        Sandcastle.addToggleButton(
-          "Soft Shadows",
-          shadowMap.softShadows,
-          function (checked) {
-            shadowMap.softShadows = checked;
-          }
-        );
+          Sandcastle.addToggleButton(
+            "Terrain Shadows",
+            viewer.terrainShadows === Cesium.ShadowMode.ENABLED,
+            function (checked) {
+              viewer.terrainShadows = checked
+                ? Cesium.ShadowMode.ENABLED
+                : Cesium.ShadowMode.DISABLED;
+            }
+          );
 
-        Sandcastle.addToolbarMenu([
-          {
-            text: "Size : 2048",
-            onselect: function () {
-              shadowMap.size = 2048;
-            },
-          },
-          {
-            text: "Size : 1024",
-            onselect: function () {
-              shadowMap.size = 1024;
-            },
-          },
-          {
-            text: "Size : 512",
-            onselect: function () {
-              shadowMap.size = 512;
-            },
-          },
-          {
-            text: "Size : 256",
-            onselect: function () {
-              shadowMap.size = 256;
-            },
-          },
-        ]);
+          Sandcastle.addToggleButton(
+            "Soft Shadows",
+            shadowMap.softShadows,
+            function (checked) {
+              shadowMap.softShadows = checked;
+            }
+          );
 
-        setLocation(locations.Exton);
-        setEntity(cesiumAir);
+          Sandcastle.addToolbarMenu([
+            {
+              text: "Size : 2048",
+              onselect: function () {
+                shadowMap.size = 2048;
+              },
+            },
+            {
+              text: "Size : 1024",
+              onselect: function () {
+                shadowMap.size = 1024;
+              },
+            },
+            {
+              text: "Size : 512",
+              onselect: function () {
+                shadowMap.size = 512;
+              },
+            },
+            {
+              text: "Size : 256",
+              onselect: function () {
+                shadowMap.size = 256;
+              },
+            },
+          ]);
 
-        //Sandcastle_End
+          setLocation(locations.Exton);
+          setEntity(cesiumAir);
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Shadows.html
+++ b/Apps/Sandcastle/gallery/Shadows.html
@@ -35,273 +35,277 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          infoBox: false,
+          selectionIndicator: false,
+          shadows: true,
+          terrainShadows: Cesium.ShadowMode.ENABLED,
+          shouldAnimate: true,
+        });
+
         (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            infoBox: false,
-            selectionIndicator: false,
-            shadows: true,
-            terrainShadows: Cesium.ShadowMode.ENABLED,
-            shouldAnimate: true,
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
-
-          const shadowMap = viewer.shadowMap;
-          shadowMap.maximumDistance = 10000.0;
-
-          const cesiumAir = viewer.entities.add({
-            name: "Cesium Air",
-            height: 20.0,
-            model: {
-              uri: "../../SampleData/models/CesiumAir/Cesium_Air.glb",
-            },
-          });
-
-          const groundVehicle = viewer.entities.add({
-            name: "Ground Vehicle",
-            height: 0.0,
-            model: {
-              uri: "../../SampleData/models/GroundVehicle/GroundVehicle.glb",
-              heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-            },
-          });
-
-          const cesiumMan = viewer.entities.add({
-            name: "Cesium Man",
-            height: 0.0,
-            model: {
-              uri: "../../SampleData/models/CesiumMan/Cesium_Man.glb",
-              heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-            },
-          });
-
-          const woodTower = viewer.entities.add({
-            name: "Wood Tower",
-            height: 0.0,
-            model: {
-              uri: "../../SampleData/models/WoodTower/Wood_Tower.glb",
-            },
-          });
-
-          const simpleCity = viewer.entities.add({
-            name: "Simple City",
-            height: 0.0,
-            model: {
-              uri: "../../SampleData/models/ShadowTester/Shadow_Tester_4.glb",
-            },
-          });
-
-          const boxEntity = viewer.entities.add({
-            name: "Box",
-            height: 10.0,
-            box: {
-              dimensions: new Cesium.Cartesian3(10.0, 10.0, 10.0),
-              material: Cesium.Color.RED,
-              shadows: Cesium.ShadowMode.ENABLED,
-            },
-          });
-
-          const checkerMaterial = new Cesium.CheckerboardMaterialProperty({
-            evenColor: Cesium.Color.RED.withAlpha(0.5),
-            oddColor: Cesium.Color.RED.withAlpha(0.0),
-            repeat: new Cesium.Cartesian2(5.0, 10.0),
-          });
-
-          const checkerEntity = viewer.entities.add({
-            name: "Checkered Box",
-            height: 10.0,
-            box: {
-              dimensions: new Cesium.Cartesian3(10.0, 10.0, 10.0),
-              material: checkerMaterial,
-              outline: true,
-              outlineColor: Cesium.Color.RED,
-              shadows: Cesium.ShadowMode.ENABLED,
-            },
-          });
-
-          const sphereEntity = viewer.entities.add({
-            name: "Sphere",
-            height: 20.0,
-            ellipsoid: {
-              radii: new Cesium.Cartesian3(15.0, 15.0, 15.0),
-              material: Cesium.Color.BLUE.withAlpha(0.5),
-              slicePartitions: 24,
-              stackPartitions: 36,
-              shadows: Cesium.ShadowMode.ENABLED,
-            },
-          });
-
-          const locations = {
-            Exton: {
-              longitude: -1.31968,
-              latitude: 0.698874,
-              height: 74.14210186070714,
-              date: 2457522.154792,
-            },
-            HalfDome: {
-              longitude: -2.086267733294987,
-              latitude: 0.6587491773830219,
-              height: 2640.716312584986,
-              date: 2457507.247512,
-            },
-            Everest: {
-              longitude: 1.517132688,
-              latitude: 0.4884844964,
-              height: 8773.17824498951,
-              date: 2457507.620845,
-            },
-            PinnaclePA: {
-              longitude: -1.3324415110874286,
-              latitude: 0.6954224325279967,
-              height: 179.14276256241743,
-              date: 2457523.04162,
-            },
-            SenecaRocks: {
-              longitude: -1.3851775172879768,
-              latitude: 0.6778211831093554,
-              height: 682.5893300695776,
-              date: 2457522.097512,
-            },
-            Space: {
-              longitude: -1.31968,
-              latitude: 0.698874,
-              height: 2000000.0,
-              date: 2457522.154792,
-            },
-          };
-
-          let i;
-          const entities = viewer.entities.values;
-          const entitiesLength = entities.length;
-
-          function setLocation(location) {
-            const longitude = location.longitude;
-            const latitude = location.latitude;
-            const height = location.height;
-
-            for (i = 0; i < entitiesLength; ++i) {
-              const entity = entities[i];
-              entity.position = Cesium.Cartesian3.fromRadians(
-                longitude,
-                latitude,
-                height + entity.height
-              );
-            }
-
-            viewer.clock.currentTime = new Cesium.JulianDate(location.date);
-            viewer.clock.multiplier = 1.0;
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+          } catch (error) {
+            console.log(error);
           }
+        })();
 
-          function setLocationFunction(location) {
-            return function () {
-              setLocation(location);
-            };
-          }
+        const shadowMap = viewer.shadowMap;
+        shadowMap.maximumDistance = 10000.0;
 
-          const locationToolbarOptions = [];
-          for (const locationName in locations) {
-            if (locations.hasOwnProperty(locationName)) {
-              const location = locations[locationName];
-              locationToolbarOptions.push({
-                text: locationName,
-                onselect: setLocationFunction(location),
-              });
-            }
-          }
+        const cesiumAir = viewer.entities.add({
+          name: "Cesium Air",
+          height: 20.0,
+          model: {
+            uri: "../../SampleData/models/CesiumAir/Cesium_Air.glb",
+          },
+        });
 
-          Sandcastle.addToolbarMenu(locationToolbarOptions);
+        const groundVehicle = viewer.entities.add({
+          name: "Ground Vehicle",
+          height: 0.0,
+          model: {
+            uri: "../../SampleData/models/GroundVehicle/GroundVehicle.glb",
+            heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+          },
+        });
 
-          function setEntity(entity) {
-            for (i = 0; i < entitiesLength; ++i) {
-              entities[i].show = false;
-            }
-            entity.show = true;
-            viewer.trackedEntity = entity;
-          }
+        const cesiumMan = viewer.entities.add({
+          name: "Cesium Man",
+          height: 0.0,
+          model: {
+            uri: "../../SampleData/models/CesiumMan/Cesium_Man.glb",
+            heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+          },
+        });
 
-          function setEntityFunction(entity) {
-            return function () {
-              setEntity(entity);
-            };
-          }
+        const woodTower = viewer.entities.add({
+          name: "Wood Tower",
+          height: 0.0,
+          model: {
+            uri: "../../SampleData/models/WoodTower/Wood_Tower.glb",
+          },
+        });
 
-          const entityToolbarOptions = [];
+        const simpleCity = viewer.entities.add({
+          name: "Simple City",
+          height: 0.0,
+          model: {
+            uri: "../../SampleData/models/ShadowTester/Shadow_Tester_4.glb",
+          },
+        });
+
+        const boxEntity = viewer.entities.add({
+          name: "Box",
+          height: 10.0,
+          box: {
+            dimensions: new Cesium.Cartesian3(10.0, 10.0, 10.0),
+            material: Cesium.Color.RED,
+            shadows: Cesium.ShadowMode.ENABLED,
+          },
+        });
+
+        const checkerMaterial = new Cesium.CheckerboardMaterialProperty({
+          evenColor: Cesium.Color.RED.withAlpha(0.5),
+          oddColor: Cesium.Color.RED.withAlpha(0.0),
+          repeat: new Cesium.Cartesian2(5.0, 10.0),
+        });
+
+        const checkerEntity = viewer.entities.add({
+          name: "Checkered Box",
+          height: 10.0,
+          box: {
+            dimensions: new Cesium.Cartesian3(10.0, 10.0, 10.0),
+            material: checkerMaterial,
+            outline: true,
+            outlineColor: Cesium.Color.RED,
+            shadows: Cesium.ShadowMode.ENABLED,
+          },
+        });
+
+        const sphereEntity = viewer.entities.add({
+          name: "Sphere",
+          height: 20.0,
+          ellipsoid: {
+            radii: new Cesium.Cartesian3(15.0, 15.0, 15.0),
+            material: Cesium.Color.BLUE.withAlpha(0.5),
+            slicePartitions: 24,
+            stackPartitions: 36,
+            shadows: Cesium.ShadowMode.ENABLED,
+          },
+        });
+
+        const locations = {
+          Exton: {
+            longitude: -1.31968,
+            latitude: 0.698874,
+            height: 74.14210186070714,
+            date: 2457522.154792,
+          },
+          HalfDome: {
+            longitude: -2.086267733294987,
+            latitude: 0.6587491773830219,
+            height: 2640.716312584986,
+            date: 2457507.247512,
+          },
+          Everest: {
+            longitude: 1.517132688,
+            latitude: 0.4884844964,
+            height: 8773.17824498951,
+            date: 2457507.620845,
+          },
+          PinnaclePA: {
+            longitude: -1.3324415110874286,
+            latitude: 0.6954224325279967,
+            height: 179.14276256241743,
+            date: 2457523.04162,
+          },
+          SenecaRocks: {
+            longitude: -1.3851775172879768,
+            latitude: 0.6778211831093554,
+            height: 682.5893300695776,
+            date: 2457522.097512,
+          },
+          Space: {
+            longitude: -1.31968,
+            latitude: 0.698874,
+            height: 2000000.0,
+            date: 2457522.154792,
+          },
+        };
+
+        let i;
+        const entities = viewer.entities.values;
+        const entitiesLength = entities.length;
+
+        function setLocation(location) {
+          const longitude = location.longitude;
+          const latitude = location.latitude;
+          const height = location.height;
+
           for (i = 0; i < entitiesLength; ++i) {
             const entity = entities[i];
-            entityToolbarOptions.push({
-              text: entity.name,
-              onselect: setEntityFunction(entity),
-            });
+            entity.position = Cesium.Cartesian3.fromRadians(
+              longitude,
+              latitude,
+              height + entity.height
+            );
           }
 
-          Sandcastle.addToolbarMenu(entityToolbarOptions);
+          viewer.clock.currentTime = new Cesium.JulianDate(location.date);
+          viewer.clock.multiplier = 1.0;
+        }
 
-          Sandcastle.addToggleButton("Shadows", viewer.shadows, function (
-            checked
-          ) {
-            viewer.shadows = checked;
+        function setLocationFunction(location) {
+          return function () {
+            setLocation(location);
+          };
+        }
+
+        const locationToolbarOptions = [];
+        for (const locationName in locations) {
+          if (locations.hasOwnProperty(locationName)) {
+            const location = locations[locationName];
+            locationToolbarOptions.push({
+              text: locationName,
+              onselect: setLocationFunction(location),
+            });
+          }
+        }
+
+        Sandcastle.addToolbarMenu(locationToolbarOptions);
+
+        function setEntity(entity) {
+          for (i = 0; i < entitiesLength; ++i) {
+            entities[i].show = false;
+          }
+          entity.show = true;
+          viewer.trackedEntity = entity;
+        }
+
+        function setEntityFunction(entity) {
+          return function () {
+            setEntity(entity);
+          };
+        }
+
+        const entityToolbarOptions = [];
+        for (i = 0; i < entitiesLength; ++i) {
+          const entity = entities[i];
+          entityToolbarOptions.push({
+            text: entity.name,
+            onselect: setEntityFunction(entity),
           });
+        }
 
-          Sandcastle.addToggleButton("Entity Shadows", true, function (
-            checked
-          ) {
-            const entityShadows = checked
+        Sandcastle.addToolbarMenu(entityToolbarOptions);
+
+        Sandcastle.addToggleButton("Shadows", viewer.shadows, function (
+          checked
+        ) {
+          viewer.shadows = checked;
+        });
+
+        Sandcastle.addToggleButton("Entity Shadows", true, function (checked) {
+          const entityShadows = checked
+            ? Cesium.ShadowMode.ENABLED
+            : Cesium.ShadowMode.DISABLED;
+          for (i = 0; i < entitiesLength; ++i) {
+            const entity = entities[i];
+            const visual = entity.model || entity.box || entity.ellipsoid;
+            visual.shadows = entityShadows;
+          }
+        });
+
+        Sandcastle.addToggleButton(
+          "Terrain Shadows",
+          viewer.terrainShadows === Cesium.ShadowMode.ENABLED,
+          function (checked) {
+            viewer.terrainShadows = checked
               ? Cesium.ShadowMode.ENABLED
               : Cesium.ShadowMode.DISABLED;
-            for (i = 0; i < entitiesLength; ++i) {
-              const entity = entities[i];
-              const visual = entity.model || entity.box || entity.ellipsoid;
-              visual.shadows = entityShadows;
-            }
-          });
+          }
+        );
 
-          Sandcastle.addToggleButton(
-            "Terrain Shadows",
-            viewer.terrainShadows === Cesium.ShadowMode.ENABLED,
-            function (checked) {
-              viewer.terrainShadows = checked
-                ? Cesium.ShadowMode.ENABLED
-                : Cesium.ShadowMode.DISABLED;
-            }
-          );
+        Sandcastle.addToggleButton(
+          "Soft Shadows",
+          shadowMap.softShadows,
+          function (checked) {
+            shadowMap.softShadows = checked;
+          }
+        );
 
-          Sandcastle.addToggleButton(
-            "Soft Shadows",
-            shadowMap.softShadows,
-            function (checked) {
-              shadowMap.softShadows = checked;
-            }
-          );
+        Sandcastle.addToolbarMenu([
+          {
+            text: "Size : 2048",
+            onselect: function () {
+              shadowMap.size = 2048;
+            },
+          },
+          {
+            text: "Size : 1024",
+            onselect: function () {
+              shadowMap.size = 1024;
+            },
+          },
+          {
+            text: "Size : 512",
+            onselect: function () {
+              shadowMap.size = 512;
+            },
+          },
+          {
+            text: "Size : 256",
+            onselect: function () {
+              shadowMap.size = 256;
+            },
+          },
+        ]);
 
-          Sandcastle.addToolbarMenu([
-            {
-              text: "Size : 2048",
-              onselect: function () {
-                shadowMap.size = 2048;
-              },
-            },
-            {
-              text: "Size : 1024",
-              onselect: function () {
-                shadowMap.size = 1024;
-              },
-            },
-            {
-              text: "Size : 512",
-              onselect: function () {
-                shadowMap.size = 512;
-              },
-            },
-            {
-              text: "Size : 256",
-              onselect: function () {
-                shadowMap.size = 256;
-              },
-            },
-          ]);
-
-          setLocation(locations.Exton);
-          setEntity(cesiumAir);
-        })(); //Sandcastle_End
+        setLocation(locations.Exton);
+        setEntity(cesiumAir);
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Terrain Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/Terrain Clipping Planes.html
@@ -66,7 +66,7 @@
         const viewer = new Cesium.Viewer("cesiumContainer", {
           skyAtmosphere: false,
           shouldAnimate: true,
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
           scene3DOnly: true,
         });
         const globe = viewer.scene.globe;

--- a/Apps/Sandcastle/gallery/Terrain Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/Terrain Clipping Planes.html
@@ -61,347 +61,355 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        // Use clipping planes to selectively hide parts of the globe surface.
-
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          skyAtmosphere: false,
-          shouldAnimate: true,
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-          scene3DOnly: true,
-        });
-        const globe = viewer.scene.globe;
-
-        const exampleTypes = [
-          "Cesium Man",
-          "St. Helens",
-          "Grand Canyon Isolated",
-        ];
-        const viewModel = {
-          exampleTypes: exampleTypes,
-          currentExampleType: exampleTypes[0],
-          clippingPlanesEnabled: true,
-          edgeStylingEnabled: true,
-        };
-        const toolbar = document.getElementById("toolbar");
-        Cesium.knockout.track(viewModel);
-        Cesium.knockout.applyBindings(viewModel, toolbar);
-
-        // For tracking state when switching exampleTypes
-        let clippingPlanesEnabled = true;
-        let edgeStylingEnabled = true;
-
-        let tileset;
-
-        loadCesiumMan();
-
-        function reset() {
-          viewer.entities.removeAll();
-          viewer.scene.primitives.remove(tileset);
-        }
-
-        function loadCesiumMan() {
-          const position = Cesium.Cartesian3.fromRadians(
-            -2.0862979473351286,
-            0.6586620013036164,
-            1400.0
-          );
-
-          const entity = viewer.entities.add({
-            position: position,
-            box: {
-              dimensions: new Cesium.Cartesian3(1400.0, 1400.0, 2800.0),
-              material: Cesium.Color.WHITE.withAlpha(0.3),
-              outline: true,
-              outlineColor: Cesium.Color.WHITE,
-            },
+        (async () => {
+          // Use clipping planes to selectively hide parts of the globe surface.
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            skyAtmosphere: false,
+            shouldAnimate: true,
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+            scene3DOnly: true,
           });
+          const globe = viewer.scene.globe;
 
-          viewer.entities.add({
-            position: position,
-            model: {
-              uri: "../../SampleData/models/CesiumMan/Cesium_Man.glb",
-              minimumPixelSize: 128,
-              maximumScale: 800,
-            },
-          });
-
-          globe.depthTestAgainstTerrain = true;
-          globe.clippingPlanes = new Cesium.ClippingPlaneCollection({
-            modelMatrix: entity.computeModelMatrix(Cesium.JulianDate.now()),
-            planes: [
-              new Cesium.ClippingPlane(
-                new Cesium.Cartesian3(1.0, 0.0, 0.0),
-                -700.0
-              ),
-              new Cesium.ClippingPlane(
-                new Cesium.Cartesian3(-1.0, 0.0, 0.0),
-                -700.0
-              ),
-              new Cesium.ClippingPlane(
-                new Cesium.Cartesian3(0.0, 1.0, 0.0),
-                -700.0
-              ),
-              new Cesium.ClippingPlane(
-                new Cesium.Cartesian3(0.0, -1.0, 0.0),
-                -700.0
-              ),
-            ],
-            edgeWidth: edgeStylingEnabled ? 1.0 : 0.0,
-            edgeColor: Cesium.Color.WHITE,
-            enabled: clippingPlanesEnabled,
-          });
-          globe.backFaceCulling = true;
-          globe.showSkirts = true;
-
-          viewer.trackedEntity = entity;
-        }
-
-        function loadStHelens() {
-          // Create clipping planes for polygon around area to be clipped.
-          const points = [
-            new Cesium.Cartesian3(
-              -2358434.3501556474,
-              -3743554.5012105294,
-              4581080.771684084
-            ),
-            new Cesium.Cartesian3(
-              -2357886.4482675144,
-              -3744467.562778789,
-              4581020.9199767085
-            ),
-            new Cesium.Cartesian3(
-              -2357299.84353055,
-              -3744954.0879047974,
-              4581080.992360969
-            ),
-            new Cesium.Cartesian3(
-              -2356412.05169956,
-              -3745385.3013702347,
-              4580893.4737207815
-            ),
-            new Cesium.Cartesian3(
-              -2355472.889436636,
-              -3745256.5725702164,
-              4581252.3128526565
-            ),
-            new Cesium.Cartesian3(
-              -2354385.7458722834,
-              -3744319.3823686405,
-              4582372.770031389
-            ),
-            new Cesium.Cartesian3(
-              -2353758.788158616,
-              -3743051.0128084184,
-              4583356.453176038
-            ),
-            new Cesium.Cartesian3(
-              -2353663.8128999653,
-              -3741847.9126874236,
-              4584079.428665509
-            ),
-            new Cesium.Cartesian3(
-              -2354213.667592133,
-              -3740784.50946316,
-              4584502.428203525
-            ),
-            new Cesium.Cartesian3(
-              -2355596.239450013,
-              -3739901.0226732804,
-              4584515.9652557485
-            ),
-            new Cesium.Cartesian3(
-              -2356942.4170108805,
-              -3740342.454698685,
-              4583686.690694482
-            ),
-            new Cesium.Cartesian3(
-              -2357529.554838029,
-              -3740766.995076834,
-              4583145.055348843
-            ),
-            new Cesium.Cartesian3(
-              -2358106.017822064,
-              -3741439.438418052,
-              4582452.293605261
-            ),
-            new Cesium.Cartesian3(
-              -2358539.5426236596,
-              -3742680.720902901,
-              4581692.0260975715
-            ),
+          const exampleTypes = [
+            "Cesium Man",
+            "St. Helens",
+            "Grand Canyon Isolated",
           ];
+          const viewModel = {
+            exampleTypes: exampleTypes,
+            currentExampleType: exampleTypes[0],
+            clippingPlanesEnabled: true,
+            edgeStylingEnabled: true,
+          };
+          const toolbar = document.getElementById("toolbar");
+          Cesium.knockout.track(viewModel);
+          Cesium.knockout.applyBindings(viewModel, toolbar);
 
-          const pointsLength = points.length;
+          // For tracking state when switching exampleTypes
+          let clippingPlanesEnabled = true;
+          let edgeStylingEnabled = true;
 
-          // Create center points for each clipping plane
-          const clippingPlanes = [];
-          for (let i = 0; i < pointsLength; ++i) {
-            const nextIndex = (i + 1) % pointsLength;
-            let midpoint = Cesium.Cartesian3.add(
-              points[i],
-              points[nextIndex],
-              new Cesium.Cartesian3()
-            );
-            midpoint = Cesium.Cartesian3.multiplyByScalar(
-              midpoint,
-              0.5,
-              midpoint
-            );
+          let tileset;
 
-            const up = Cesium.Cartesian3.normalize(
-              midpoint,
-              new Cesium.Cartesian3()
-            );
-            let right = Cesium.Cartesian3.subtract(
-              points[nextIndex],
-              midpoint,
-              new Cesium.Cartesian3()
-            );
-            right = Cesium.Cartesian3.normalize(right, right);
+          loadCesiumMan();
 
-            let normal = Cesium.Cartesian3.cross(
-              right,
-              up,
-              new Cesium.Cartesian3()
-            );
-            normal = Cesium.Cartesian3.normalize(normal, normal);
-
-            // Compute distance by pretending the plane is at the origin
-            const originCenteredPlane = new Cesium.Plane(normal, 0.0);
-            const distance = Cesium.Plane.getPointDistance(
-              originCenteredPlane,
-              midpoint
-            );
-
-            clippingPlanes.push(new Cesium.ClippingPlane(normal, distance));
+          function reset() {
+            viewer.entities.removeAll();
+            viewer.scene.primitives.remove(tileset);
           }
-          globe.clippingPlanes = new Cesium.ClippingPlaneCollection({
-            planes: clippingPlanes,
-            edgeWidth: edgeStylingEnabled ? 1.0 : 0.0,
-            edgeColor: Cesium.Color.WHITE,
-            enabled: clippingPlanesEnabled,
-          });
-          globe.backFaceCulling = true;
-          globe.showSkirts = true;
 
-          // Load tileset
-          tileset = new Cesium.Cesium3DTileset({
-            url: Cesium.IonResource.fromAssetId(5713),
-          });
-          return tileset.readyPromise
-            .then(function () {
-              // Adjust height so tileset is in terrain
-              const cartographic = Cesium.Cartographic.fromCartesian(
-                tileset.boundingSphere.center
-              );
-              const surface = Cesium.Cartesian3.fromRadians(
-                cartographic.longitude,
-                cartographic.latitude,
-                0.0
-              );
-              const offset = Cesium.Cartesian3.fromRadians(
-                cartographic.longitude,
-                cartographic.latitude,
-                -20.0
-              );
-              const translation = Cesium.Cartesian3.subtract(
-                offset,
-                surface,
+          function loadCesiumMan() {
+            const position = Cesium.Cartesian3.fromRadians(
+              -2.0862979473351286,
+              0.6586620013036164,
+              1400.0
+            );
+
+            const entity = viewer.entities.add({
+              position: position,
+              box: {
+                dimensions: new Cesium.Cartesian3(1400.0, 1400.0, 2800.0),
+                material: Cesium.Color.WHITE.withAlpha(0.3),
+                outline: true,
+                outlineColor: Cesium.Color.WHITE,
+              },
+            });
+
+            viewer.entities.add({
+              position: position,
+              model: {
+                uri: "../../SampleData/models/CesiumMan/Cesium_Man.glb",
+                minimumPixelSize: 128,
+                maximumScale: 800,
+              },
+            });
+
+            globe.depthTestAgainstTerrain = true;
+            globe.clippingPlanes = new Cesium.ClippingPlaneCollection({
+              modelMatrix: entity.computeModelMatrix(Cesium.JulianDate.now()),
+              planes: [
+                new Cesium.ClippingPlane(
+                  new Cesium.Cartesian3(1.0, 0.0, 0.0),
+                  -700.0
+                ),
+                new Cesium.ClippingPlane(
+                  new Cesium.Cartesian3(-1.0, 0.0, 0.0),
+                  -700.0
+                ),
+                new Cesium.ClippingPlane(
+                  new Cesium.Cartesian3(0.0, 1.0, 0.0),
+                  -700.0
+                ),
+                new Cesium.ClippingPlane(
+                  new Cesium.Cartesian3(0.0, -1.0, 0.0),
+                  -700.0
+                ),
+              ],
+              edgeWidth: edgeStylingEnabled ? 1.0 : 0.0,
+              edgeColor: Cesium.Color.WHITE,
+              enabled: clippingPlanesEnabled,
+            });
+            globe.backFaceCulling = true;
+            globe.showSkirts = true;
+
+            viewer.trackedEntity = entity;
+          }
+
+          function loadStHelens() {
+            // Create clipping planes for polygon around area to be clipped.
+            const points = [
+              new Cesium.Cartesian3(
+                -2358434.3501556474,
+                -3743554.5012105294,
+                4581080.771684084
+              ),
+              new Cesium.Cartesian3(
+                -2357886.4482675144,
+                -3744467.562778789,
+                4581020.9199767085
+              ),
+              new Cesium.Cartesian3(
+                -2357299.84353055,
+                -3744954.0879047974,
+                4581080.992360969
+              ),
+              new Cesium.Cartesian3(
+                -2356412.05169956,
+                -3745385.3013702347,
+                4580893.4737207815
+              ),
+              new Cesium.Cartesian3(
+                -2355472.889436636,
+                -3745256.5725702164,
+                4581252.3128526565
+              ),
+              new Cesium.Cartesian3(
+                -2354385.7458722834,
+                -3744319.3823686405,
+                4582372.770031389
+              ),
+              new Cesium.Cartesian3(
+                -2353758.788158616,
+                -3743051.0128084184,
+                4583356.453176038
+              ),
+              new Cesium.Cartesian3(
+                -2353663.8128999653,
+                -3741847.9126874236,
+                4584079.428665509
+              ),
+              new Cesium.Cartesian3(
+                -2354213.667592133,
+                -3740784.50946316,
+                4584502.428203525
+              ),
+              new Cesium.Cartesian3(
+                -2355596.239450013,
+                -3739901.0226732804,
+                4584515.9652557485
+              ),
+              new Cesium.Cartesian3(
+                -2356942.4170108805,
+                -3740342.454698685,
+                4583686.690694482
+              ),
+              new Cesium.Cartesian3(
+                -2357529.554838029,
+                -3740766.995076834,
+                4583145.055348843
+              ),
+              new Cesium.Cartesian3(
+                -2358106.017822064,
+                -3741439.438418052,
+                4582452.293605261
+              ),
+              new Cesium.Cartesian3(
+                -2358539.5426236596,
+                -3742680.720902901,
+                4581692.0260975715
+              ),
+            ];
+
+            const pointsLength = points.length;
+
+            // Create center points for each clipping plane
+            const clippingPlanes = [];
+            for (let i = 0; i < pointsLength; ++i) {
+              const nextIndex = (i + 1) % pointsLength;
+              let midpoint = Cesium.Cartesian3.add(
+                points[i],
+                points[nextIndex],
                 new Cesium.Cartesian3()
               );
-              tileset.modelMatrix = Cesium.Matrix4.fromTranslation(translation);
-
-              tileset.style = new Cesium.Cesium3DTileStyle({
-                color: "rgb(207, 255, 207)",
-              });
-
-              viewer.scene.primitives.add(tileset);
-
-              const boundingSphere = tileset.boundingSphere;
-
-              const radius = boundingSphere.radius;
-              viewer.camera.viewBoundingSphere(
-                boundingSphere,
-                new Cesium.HeadingPitchRange(0.5, -0.2, radius * 4.0)
+              midpoint = Cesium.Cartesian3.multiplyByScalar(
+                midpoint,
+                0.5,
+                midpoint
               );
-              viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-            })
-            .catch(function (error) {
-              throw error;
-            });
-        }
 
-        function loadGrandCanyon() {
-          // Pick a position at the Grand Canyon
-          const position = Cesium.Cartographic.toCartesian(
-            new Cesium.Cartographic.fromDegrees(-113.2665534, 36.0939345, 100)
-          );
-          const distance = 3000.0;
-          const boundingSphere = new Cesium.BoundingSphere(position, distance);
+              const up = Cesium.Cartesian3.normalize(
+                midpoint,
+                new Cesium.Cartesian3()
+              );
+              let right = Cesium.Cartesian3.subtract(
+                points[nextIndex],
+                midpoint,
+                new Cesium.Cartesian3()
+              );
+              right = Cesium.Cartesian3.normalize(right, right);
 
-          globe.clippingPlanes = new Cesium.ClippingPlaneCollection({
-            modelMatrix: Cesium.Transforms.eastNorthUpToFixedFrame(position),
-            planes: [
-              new Cesium.ClippingPlane(
-                new Cesium.Cartesian3(1.0, 0.0, 0.0),
-                distance
-              ),
-              new Cesium.ClippingPlane(
-                new Cesium.Cartesian3(-1.0, 0.0, 0.0),
-                distance
-              ),
-              new Cesium.ClippingPlane(
-                new Cesium.Cartesian3(0.0, 1.0, 0.0),
-                distance
-              ),
-              new Cesium.ClippingPlane(
-                new Cesium.Cartesian3(0.0, -1.0, 0.0),
-                distance
-              ),
-            ],
-            unionClippingRegions: true,
-            edgeWidth: edgeStylingEnabled ? 1.0 : 0.0,
-            edgeColor: Cesium.Color.WHITE,
-            enabled: clippingPlanesEnabled,
-          });
-          globe.backFaceCulling = false;
-          globe.showSkirts = false;
+              let normal = Cesium.Cartesian3.cross(
+                right,
+                up,
+                new Cesium.Cartesian3()
+              );
+              normal = Cesium.Cartesian3.normalize(normal, normal);
 
-          viewer.camera.viewBoundingSphere(
-            boundingSphere,
-            new Cesium.HeadingPitchRange(0.5, -0.5, boundingSphere.radius * 5.0)
-          );
-          viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-        }
+              // Compute distance by pretending the plane is at the origin
+              const originCenteredPlane = new Cesium.Plane(normal, 0.0);
+              const distance = Cesium.Plane.getPointDistance(
+                originCenteredPlane,
+                midpoint
+              );
 
-        Cesium.knockout
-          .getObservable(viewModel, "clippingPlanesEnabled")
-          .subscribe(function (value) {
-            globe.clippingPlanes.enabled = value;
-            clippingPlanesEnabled = value;
-          });
-
-        Cesium.knockout
-          .getObservable(viewModel, "edgeStylingEnabled")
-          .subscribe(function (value) {
-            edgeStylingEnabled = value;
-            globe.clippingPlanes.edgeWidth = edgeStylingEnabled ? 1.0 : 0.0;
-          });
-
-        Cesium.knockout
-          .getObservable(viewModel, "currentExampleType")
-          .subscribe(function (newValue) {
-            reset();
-            if (newValue === exampleTypes[0]) {
-              loadCesiumMan();
-            } else if (newValue === exampleTypes[1]) {
-              loadStHelens();
-            } else if (newValue === exampleTypes[2]) {
-              loadGrandCanyon();
+              clippingPlanes.push(new Cesium.ClippingPlane(normal, distance));
             }
-          });
+            globe.clippingPlanes = new Cesium.ClippingPlaneCollection({
+              planes: clippingPlanes,
+              edgeWidth: edgeStylingEnabled ? 1.0 : 0.0,
+              edgeColor: Cesium.Color.WHITE,
+              enabled: clippingPlanesEnabled,
+            });
+            globe.backFaceCulling = true;
+            globe.showSkirts = true;
 
-        //Sandcastle_End
+            // Load tileset
+            tileset = new Cesium.Cesium3DTileset({
+              url: Cesium.IonResource.fromAssetId(5713),
+            });
+            return tileset.readyPromise
+              .then(function () {
+                // Adjust height so tileset is in terrain
+                const cartographic = Cesium.Cartographic.fromCartesian(
+                  tileset.boundingSphere.center
+                );
+                const surface = Cesium.Cartesian3.fromRadians(
+                  cartographic.longitude,
+                  cartographic.latitude,
+                  0.0
+                );
+                const offset = Cesium.Cartesian3.fromRadians(
+                  cartographic.longitude,
+                  cartographic.latitude,
+                  -20.0
+                );
+                const translation = Cesium.Cartesian3.subtract(
+                  offset,
+                  surface,
+                  new Cesium.Cartesian3()
+                );
+                tileset.modelMatrix = Cesium.Matrix4.fromTranslation(
+                  translation
+                );
+
+                tileset.style = new Cesium.Cesium3DTileStyle({
+                  color: "rgb(207, 255, 207)",
+                });
+
+                viewer.scene.primitives.add(tileset);
+
+                const boundingSphere = tileset.boundingSphere;
+
+                const radius = boundingSphere.radius;
+                viewer.camera.viewBoundingSphere(
+                  boundingSphere,
+                  new Cesium.HeadingPitchRange(0.5, -0.2, radius * 4.0)
+                );
+                viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+              })
+              .catch(function (error) {
+                throw error;
+              });
+          }
+
+          function loadGrandCanyon() {
+            // Pick a position at the Grand Canyon
+            const position = Cesium.Cartographic.toCartesian(
+              new Cesium.Cartographic.fromDegrees(-113.2665534, 36.0939345, 100)
+            );
+            const distance = 3000.0;
+            const boundingSphere = new Cesium.BoundingSphere(
+              position,
+              distance
+            );
+
+            globe.clippingPlanes = new Cesium.ClippingPlaneCollection({
+              modelMatrix: Cesium.Transforms.eastNorthUpToFixedFrame(position),
+              planes: [
+                new Cesium.ClippingPlane(
+                  new Cesium.Cartesian3(1.0, 0.0, 0.0),
+                  distance
+                ),
+                new Cesium.ClippingPlane(
+                  new Cesium.Cartesian3(-1.0, 0.0, 0.0),
+                  distance
+                ),
+                new Cesium.ClippingPlane(
+                  new Cesium.Cartesian3(0.0, 1.0, 0.0),
+                  distance
+                ),
+                new Cesium.ClippingPlane(
+                  new Cesium.Cartesian3(0.0, -1.0, 0.0),
+                  distance
+                ),
+              ],
+              unionClippingRegions: true,
+              edgeWidth: edgeStylingEnabled ? 1.0 : 0.0,
+              edgeColor: Cesium.Color.WHITE,
+              enabled: clippingPlanesEnabled,
+            });
+            globe.backFaceCulling = false;
+            globe.showSkirts = false;
+
+            viewer.camera.viewBoundingSphere(
+              boundingSphere,
+              new Cesium.HeadingPitchRange(
+                0.5,
+                -0.5,
+                boundingSphere.radius * 5.0
+              )
+            );
+            viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+          }
+
+          Cesium.knockout
+            .getObservable(viewModel, "clippingPlanesEnabled")
+            .subscribe(function (value) {
+              globe.clippingPlanes.enabled = value;
+              clippingPlanesEnabled = value;
+            });
+
+          Cesium.knockout
+            .getObservable(viewModel, "edgeStylingEnabled")
+            .subscribe(function (value) {
+              edgeStylingEnabled = value;
+              globe.clippingPlanes.edgeWidth = edgeStylingEnabled ? 1.0 : 0.0;
+            });
+
+          Cesium.knockout
+            .getObservable(viewModel, "currentExampleType")
+            .subscribe(function (newValue) {
+              reset();
+              if (newValue === exampleTypes[0]) {
+                loadCesiumMan();
+              } else if (newValue === exampleTypes[1]) {
+                loadStHelens();
+              } else if (newValue === exampleTypes[2]) {
+                loadGrandCanyon();
+              }
+            });
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Terrain Exaggeration.html
+++ b/Apps/Sandcastle/gallery/Terrain Exaggeration.html
@@ -77,7 +77,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         const scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/Terrain Exaggeration.html
+++ b/Apps/Sandcastle/gallery/Terrain Exaggeration.html
@@ -76,123 +76,128 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        const viewer = new Cesium.Viewer("cesiumContainer");
+
         (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
-
-          const scene = viewer.scene;
-          const globe = scene.globe;
-          globe.terrainExaggeration = 2.0;
-          globe.terrainExaggerationRelativeHeight = 2400.0;
-
-          scene.camera.setView({
-            destination: new Cesium.Cartesian3(
-              336567.0354790703,
-              5664688.047602498,
-              2923204.3566963132
-            ),
-            orientation: new Cesium.HeadingPitchRoll(
-              1.2273281382639265,
-              -0.32239612370237514,
-              0.0027207329018610338
-            ),
-          });
-
-          viewer.entities.add({
-            position: new Cesium.Cartesian3(
-              314557.3531714575,
-              5659723.771882165,
-              2923538.5417330978
-            ),
-            ellipsoid: {
-              radii: new Cesium.Cartesian3(400.0, 400.0, 400.0),
-              material: Cesium.Color.RED,
-              heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-            },
-          });
-
-          let visualizeRelativeHeight = true;
-
-          function updateMaterial() {
-            if (visualizeRelativeHeight) {
-              const height = globe.terrainExaggerationRelativeHeight;
-              const exaggeration = globe.terrainExaggeration;
-              const alpha = Math.min(1.0, exaggeration * 0.25);
-              const layer = {
-                extendUpwards: true,
-                extendDownwards: true,
-                entries: [
-                  {
-                    height: height + 100.0,
-                    color: new Cesium.Color(0.0, 1.0, 0.0, alpha * 0.25),
-                  },
-                  {
-                    height: height + 50.0,
-                    color: new Cesium.Color(1.0, 1.0, 1.0, alpha * 0.5),
-                  },
-                  {
-                    height: height,
-                    color: new Cesium.Color(1.0, 1.0, 1.0, alpha),
-                  },
-                  {
-                    height: height - 50.0,
-                    color: new Cesium.Color(1.0, 1.0, 1.0, alpha * 0.5),
-                  },
-                  {
-                    height: height - 100.0,
-                    color: new Cesium.Color(1.0, 0.0, 0.0, alpha * 0.25),
-                  },
-                ],
-              };
-              scene.globe.material = Cesium.createElevationBandMaterial({
-                scene: scene,
-                layers: [layer],
-              });
-            } else {
-              scene.globe.material = undefined;
-            }
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+          } catch (error) {
+            console.log(error);
           }
+        })();
+
+        const scene = viewer.scene;
+        const globe = scene.globe;
+        globe.terrainExaggeration = 2.0;
+        globe.terrainExaggerationRelativeHeight = 2400.0;
+
+        scene.camera.setView({
+          destination: new Cesium.Cartesian3(
+            336567.0354790703,
+            5664688.047602498,
+            2923204.3566963132
+          ),
+          orientation: new Cesium.HeadingPitchRoll(
+            1.2273281382639265,
+            -0.32239612370237514,
+            0.0027207329018610338
+          ),
+        });
+
+        viewer.entities.add({
+          position: new Cesium.Cartesian3(
+            314557.3531714575,
+            5659723.771882165,
+            2923538.5417330978
+          ),
+          ellipsoid: {
+            radii: new Cesium.Cartesian3(400.0, 400.0, 400.0),
+            material: Cesium.Color.RED,
+            heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+          },
+        });
+
+        let visualizeRelativeHeight = true;
+
+        function updateMaterial() {
+          if (visualizeRelativeHeight) {
+            const height = globe.terrainExaggerationRelativeHeight;
+            const exaggeration = globe.terrainExaggeration;
+            const alpha = Math.min(1.0, exaggeration * 0.25);
+            const layer = {
+              extendUpwards: true,
+              extendDownwards: true,
+              entries: [
+                {
+                  height: height + 100.0,
+                  color: new Cesium.Color(0.0, 1.0, 0.0, alpha * 0.25),
+                },
+                {
+                  height: height + 50.0,
+                  color: new Cesium.Color(1.0, 1.0, 1.0, alpha * 0.5),
+                },
+                {
+                  height: height,
+                  color: new Cesium.Color(1.0, 1.0, 1.0, alpha),
+                },
+                {
+                  height: height - 50.0,
+                  color: new Cesium.Color(1.0, 1.0, 1.0, alpha * 0.5),
+                },
+                {
+                  height: height - 100.0,
+                  color: new Cesium.Color(1.0, 0.0, 0.0, alpha * 0.25),
+                },
+              ],
+            };
+            scene.globe.material = Cesium.createElevationBandMaterial({
+              scene: scene,
+              layers: [layer],
+            });
+          } else {
+            scene.globe.material = undefined;
+          }
+        }
+        updateMaterial();
+
+        const viewModel = {
+          exaggeration: globe.terrainExaggeration,
+          relativeHeight: globe.terrainExaggerationRelativeHeight,
+        };
+
+        function updateExaggeration() {
+          globe.terrainExaggeration = Number(viewModel.exaggeration);
+          globe.terrainExaggerationRelativeHeight = Number(
+            viewModel.relativeHeight
+          );
           updateMaterial();
+        }
 
-          const viewModel = {
-            exaggeration: globe.terrainExaggeration,
-            relativeHeight: globe.terrainExaggerationRelativeHeight,
-          };
+        Cesium.knockout.track(viewModel);
+        const toolbar = document.getElementById("toolbar");
+        Cesium.knockout.applyBindings(viewModel, toolbar);
+        for (const name in viewModel) {
+          if (viewModel.hasOwnProperty(name)) {
+            Cesium.knockout
+              .getObservable(viewModel, name)
+              .subscribe(updateExaggeration);
+          }
+        }
 
-          function updateExaggeration() {
-            globe.terrainExaggeration = Number(viewModel.exaggeration);
-            globe.terrainExaggerationRelativeHeight = Number(
-              viewModel.relativeHeight
-            );
+        Sandcastle.addToggleButton(
+          "Visualize Relative Height",
+          visualizeRelativeHeight,
+          function (checked) {
+            visualizeRelativeHeight = checked;
             updateMaterial();
           }
+        );
 
-          Cesium.knockout.track(viewModel);
-          const toolbar = document.getElementById("toolbar");
-          Cesium.knockout.applyBindings(viewModel, toolbar);
-          for (const name in viewModel) {
-            if (viewModel.hasOwnProperty(name)) {
-              Cesium.knockout
-                .getObservable(viewModel, name)
-                .subscribe(updateExaggeration);
-            }
-          }
-
-          Sandcastle.addToggleButton(
-            "Visualize Relative Height",
-            visualizeRelativeHeight,
-            function (checked) {
-              visualizeRelativeHeight = checked;
-              updateMaterial();
-            }
-          );
-
-          Sandcastle.addToolbarButton("Remove Exaggeration", function () {
-            viewModel.exaggeration = 1.0;
-            viewModel.relativeHeight = 0.0;
-          });
-        })(); //Sandcastle_End
+        Sandcastle.addToolbarButton("Remove Exaggeration", function () {
+          viewModel.exaggeration = 1.0;
+          viewModel.relativeHeight = 0.0;
+        });
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Terrain Exaggeration.html
+++ b/Apps/Sandcastle/gallery/Terrain Exaggeration.html
@@ -76,122 +76,123 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
 
-        const scene = viewer.scene;
-        const globe = scene.globe;
-        globe.terrainExaggeration = 2.0;
-        globe.terrainExaggerationRelativeHeight = 2400.0;
+          const scene = viewer.scene;
+          const globe = scene.globe;
+          globe.terrainExaggeration = 2.0;
+          globe.terrainExaggerationRelativeHeight = 2400.0;
 
-        scene.camera.setView({
-          destination: new Cesium.Cartesian3(
-            336567.0354790703,
-            5664688.047602498,
-            2923204.3566963132
-          ),
-          orientation: new Cesium.HeadingPitchRoll(
-            1.2273281382639265,
-            -0.32239612370237514,
-            0.0027207329018610338
-          ),
-        });
+          scene.camera.setView({
+            destination: new Cesium.Cartesian3(
+              336567.0354790703,
+              5664688.047602498,
+              2923204.3566963132
+            ),
+            orientation: new Cesium.HeadingPitchRoll(
+              1.2273281382639265,
+              -0.32239612370237514,
+              0.0027207329018610338
+            ),
+          });
 
-        viewer.entities.add({
-          position: new Cesium.Cartesian3(
-            314557.3531714575,
-            5659723.771882165,
-            2923538.5417330978
-          ),
-          ellipsoid: {
-            radii: new Cesium.Cartesian3(400.0, 400.0, 400.0),
-            material: Cesium.Color.RED,
-            heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-          },
-        });
+          viewer.entities.add({
+            position: new Cesium.Cartesian3(
+              314557.3531714575,
+              5659723.771882165,
+              2923538.5417330978
+            ),
+            ellipsoid: {
+              radii: new Cesium.Cartesian3(400.0, 400.0, 400.0),
+              material: Cesium.Color.RED,
+              heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+            },
+          });
 
-        let visualizeRelativeHeight = true;
+          let visualizeRelativeHeight = true;
 
-        function updateMaterial() {
-          if (visualizeRelativeHeight) {
-            const height = globe.terrainExaggerationRelativeHeight;
-            const exaggeration = globe.terrainExaggeration;
-            const alpha = Math.min(1.0, exaggeration * 0.25);
-            const layer = {
-              extendUpwards: true,
-              extendDownwards: true,
-              entries: [
-                {
-                  height: height + 100.0,
-                  color: new Cesium.Color(0.0, 1.0, 0.0, alpha * 0.25),
-                },
-                {
-                  height: height + 50.0,
-                  color: new Cesium.Color(1.0, 1.0, 1.0, alpha * 0.5),
-                },
-                {
-                  height: height,
-                  color: new Cesium.Color(1.0, 1.0, 1.0, alpha),
-                },
-                {
-                  height: height - 50.0,
-                  color: new Cesium.Color(1.0, 1.0, 1.0, alpha * 0.5),
-                },
-                {
-                  height: height - 100.0,
-                  color: new Cesium.Color(1.0, 0.0, 0.0, alpha * 0.25),
-                },
-              ],
-            };
-            scene.globe.material = Cesium.createElevationBandMaterial({
-              scene: scene,
-              layers: [layer],
-            });
-          } else {
-            scene.globe.material = undefined;
+          function updateMaterial() {
+            if (visualizeRelativeHeight) {
+              const height = globe.terrainExaggerationRelativeHeight;
+              const exaggeration = globe.terrainExaggeration;
+              const alpha = Math.min(1.0, exaggeration * 0.25);
+              const layer = {
+                extendUpwards: true,
+                extendDownwards: true,
+                entries: [
+                  {
+                    height: height + 100.0,
+                    color: new Cesium.Color(0.0, 1.0, 0.0, alpha * 0.25),
+                  },
+                  {
+                    height: height + 50.0,
+                    color: new Cesium.Color(1.0, 1.0, 1.0, alpha * 0.5),
+                  },
+                  {
+                    height: height,
+                    color: new Cesium.Color(1.0, 1.0, 1.0, alpha),
+                  },
+                  {
+                    height: height - 50.0,
+                    color: new Cesium.Color(1.0, 1.0, 1.0, alpha * 0.5),
+                  },
+                  {
+                    height: height - 100.0,
+                    color: new Cesium.Color(1.0, 0.0, 0.0, alpha * 0.25),
+                  },
+                ],
+              };
+              scene.globe.material = Cesium.createElevationBandMaterial({
+                scene: scene,
+                layers: [layer],
+              });
+            } else {
+              scene.globe.material = undefined;
+            }
           }
-        }
-        updateMaterial();
-
-        const viewModel = {
-          exaggeration: globe.terrainExaggeration,
-          relativeHeight: globe.terrainExaggerationRelativeHeight,
-        };
-
-        function updateExaggeration() {
-          globe.terrainExaggeration = Number(viewModel.exaggeration);
-          globe.terrainExaggerationRelativeHeight = Number(
-            viewModel.relativeHeight
-          );
           updateMaterial();
-        }
 
-        Cesium.knockout.track(viewModel);
-        const toolbar = document.getElementById("toolbar");
-        Cesium.knockout.applyBindings(viewModel, toolbar);
-        for (const name in viewModel) {
-          if (viewModel.hasOwnProperty(name)) {
-            Cesium.knockout
-              .getObservable(viewModel, name)
-              .subscribe(updateExaggeration);
-          }
-        }
+          const viewModel = {
+            exaggeration: globe.terrainExaggeration,
+            relativeHeight: globe.terrainExaggerationRelativeHeight,
+          };
 
-        Sandcastle.addToggleButton(
-          "Visualize Relative Height",
-          visualizeRelativeHeight,
-          function (checked) {
-            visualizeRelativeHeight = checked;
+          function updateExaggeration() {
+            globe.terrainExaggeration = Number(viewModel.exaggeration);
+            globe.terrainExaggerationRelativeHeight = Number(
+              viewModel.relativeHeight
+            );
             updateMaterial();
           }
-        );
 
-        Sandcastle.addToolbarButton("Remove Exaggeration", function () {
-          viewModel.exaggeration = 1.0;
-          viewModel.relativeHeight = 0.0;
-        });
-        //Sandcastle_End
+          Cesium.knockout.track(viewModel);
+          const toolbar = document.getElementById("toolbar");
+          Cesium.knockout.applyBindings(viewModel, toolbar);
+          for (const name in viewModel) {
+            if (viewModel.hasOwnProperty(name)) {
+              Cesium.knockout
+                .getObservable(viewModel, name)
+                .subscribe(updateExaggeration);
+            }
+          }
+
+          Sandcastle.addToggleButton(
+            "Visualize Relative Height",
+            visualizeRelativeHeight,
+            function (checked) {
+              visualizeRelativeHeight = checked;
+              updateMaterial();
+            }
+          );
+
+          Sandcastle.addToolbarButton("Remove Exaggeration", function () {
+            viewModel.exaggeration = 1.0;
+            viewModel.relativeHeight = 0.0;
+          });
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Terrain.html
+++ b/Apps/Sandcastle/gallery/Terrain.html
@@ -39,13 +39,11 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const worldTerrain = Cesium.createWorldTerrain({
-          requestWaterMask: true,
-          requestVertexNormals: true,
-        });
-
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: worldTerrain,
+          terrainProvider: Cesium.createWorldTerrainAsync({
+            requestWaterMask: true,
+            requestVertexNormals: true,
+          }),
         });
 
         // set lighting to true
@@ -53,16 +51,6 @@
 
         // setup alternative terrain providers
         const ellipsoidProvider = new Cesium.EllipsoidTerrainProvider();
-
-        const vrTheWorldProvider = new Cesium.VRTheWorldTerrainProvider({
-          url: "http://www.vr-theworld.com/vr-theworld/tiles1.0.0/73/",
-          credit: "Terrain data courtesy VT MÄK",
-        });
-
-        const arcGisProvider = new Cesium.ArcGISTiledElevationTerrainProvider({
-          url:
-            "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer",
-        });
 
         // Sine wave
         const customHeightmapWidth = 32;
@@ -97,21 +85,25 @@
           [
             {
               text: "CesiumTerrainProvider - Cesium World Terrain",
-              onselect: function () {
-                viewer.terrainProvider = worldTerrain;
+              onselect: async function () {
+                const provider = await Cesium.createWorldTerrainAsync({
+                  requestWaterMask: true,
+                  requestVertexNormals: true,
+                });
+                viewer.terrainProvider = provider;
                 viewer.scene.globe.enableLighting = true;
               },
             },
             {
               text: "CesiumTerrainProvider - Cesium World Terrain - no effects",
-              onselect: function () {
-                viewer.terrainProvider = Cesium.createWorldTerrain();
+              onselect: async function () {
+                viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
               },
             },
             {
               text: "CesiumTerrainProvider - Cesium World Terrain w/ Lighting",
-              onselect: function () {
-                viewer.terrainProvider = Cesium.createWorldTerrain({
+              onselect: async function () {
+                viewer.terrainProvider = await Cesium.createWorldTerrainAsync({
                   requestVertexNormals: true,
                 });
                 viewer.scene.globe.enableLighting = true;
@@ -119,8 +111,8 @@
             },
             {
               text: "CesiumTerrainProvider - Cesium World Terrain w/ Water",
-              onselect: function () {
-                viewer.terrainProvider = Cesium.createWorldTerrain({
+              onselect: async function () {
+                viewer.terrainProvider = await Cesium.createWorldTerrainAsync({
                   requestWaterMask: true,
                 });
               },
@@ -139,14 +131,23 @@
             },
             {
               text: "VRTheWorldTerrainProvider",
-              onselect: function () {
-                viewer.terrainProvider = vrTheWorldProvider;
+              onselect: async function () {
+                const provider = await Cesium.VRTheWorldTerrainProvider.fromUrl(
+                  "http://www.vr-theworld.com/vr-theworld/tiles1.0.0/73/",
+                  {
+                    credit: "Terrain data courtesy VT MÄK",
+                  }
+                );
+                viewer.terrainProvider = provider;
               },
             },
             {
               text: "ArcGISTerrainProvider",
-              onselect: function () {
-                viewer.terrainProvider = arcGisProvider;
+              onselect: async function () {
+                const provider = await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
+                  "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
+                );
+                viewer.terrainProvider = provider;
               },
             },
           ],

--- a/Apps/Sandcastle/gallery/Terrain.html
+++ b/Apps/Sandcastle/gallery/Terrain.html
@@ -39,312 +39,311 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        const viewer = new Cesium.Viewer("cesiumContainer");
+
         (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync({
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync({
               requestWaterMask: true,
               requestVertexNormals: true,
-            }),
-          });
+            });
+          } catch (error) {
+            console.log(error);
+          }
+        })();
 
-          // set lighting to true
-          viewer.scene.globe.enableLighting = true;
+        // set lighting to true
+        viewer.scene.globe.enableLighting = true;
 
-          // setup alternative terrain providers
-          const ellipsoidProvider = new Cesium.EllipsoidTerrainProvider();
+        // setup alternative terrain providers
+        const ellipsoidProvider = new Cesium.EllipsoidTerrainProvider();
 
-          // Sine wave
-          const customHeightmapWidth = 32;
-          const customHeightmapHeight = 32;
-          const customHeightmapProvider = new Cesium.CustomHeightmapTerrainProvider(
-            {
-              width: customHeightmapWidth,
-              height: customHeightmapHeight,
-              callback: function (x, y, level) {
-                const width = customHeightmapWidth;
-                const height = customHeightmapHeight;
-                const buffer = new Float32Array(width * height);
+        // Sine wave
+        const customHeightmapWidth = 32;
+        const customHeightmapHeight = 32;
+        const customHeightmapProvider = new Cesium.CustomHeightmapTerrainProvider(
+          {
+            width: customHeightmapWidth,
+            height: customHeightmapHeight,
+            callback: function (x, y, level) {
+              const width = customHeightmapWidth;
+              const height = customHeightmapHeight;
+              const buffer = new Float32Array(width * height);
 
-                for (let yy = 0; yy < height; yy++) {
-                  for (let xx = 0; xx < width; xx++) {
-                    const u = (x + xx / (width - 1)) / Math.pow(2, level);
-                    const v = (y + yy / (height - 1)) / Math.pow(2, level);
+              for (let yy = 0; yy < height; yy++) {
+                for (let xx = 0; xx < width; xx++) {
+                  const u = (x + xx / (width - 1)) / Math.pow(2, level);
+                  const v = (y + yy / (height - 1)) / Math.pow(2, level);
 
-                    const heightValue = 4000 * (Math.sin(8000 * v) * 0.5 + 0.5);
+                  const heightValue = 4000 * (Math.sin(8000 * v) * 0.5 + 0.5);
 
-                    const index = yy * width + xx;
-                    buffer[index] = heightValue;
-                  }
+                  const index = yy * width + xx;
+                  buffer[index] = heightValue;
                 }
-
-                return buffer;
-              },
-            }
-          );
-
-          Sandcastle.addToolbarMenu(
-            [
-              {
-                text: "CesiumTerrainProvider - Cesium World Terrain",
-                onselect: async function () {
-                  const provider = await Cesium.createWorldTerrainAsync({
-                    requestWaterMask: true,
-                    requestVertexNormals: true,
-                  });
-                  viewer.terrainProvider = provider;
-                  viewer.scene.globe.enableLighting = true;
-                },
-              },
-              {
-                text:
-                  "CesiumTerrainProvider - Cesium World Terrain - no effects",
-                onselect: async function () {
-                  viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-                },
-              },
-              {
-                text:
-                  "CesiumTerrainProvider - Cesium World Terrain w/ Lighting",
-                onselect: async function () {
-                  viewer.terrainProvider = await Cesium.createWorldTerrainAsync(
-                    {
-                      requestVertexNormals: true,
-                    }
-                  );
-                  viewer.scene.globe.enableLighting = true;
-                },
-              },
-              {
-                text: "CesiumTerrainProvider - Cesium World Terrain w/ Water",
-                onselect: async function () {
-                  viewer.terrainProvider = await Cesium.createWorldTerrainAsync(
-                    {
-                      requestWaterMask: true,
-                    }
-                  );
-                },
-              },
-              {
-                text: "EllipsoidTerrainProvider",
-                onselect: function () {
-                  viewer.terrainProvider = ellipsoidProvider;
-                },
-              },
-              {
-                text: "CustomHeightmapTerrainProvider",
-                onselect: function () {
-                  viewer.terrainProvider = customHeightmapProvider;
-                },
-              },
-              {
-                text: "VRTheWorldTerrainProvider",
-                onselect: async function () {
-                  const provider = await Cesium.VRTheWorldTerrainProvider.fromUrl(
-                    "http://www.vr-theworld.com/vr-theworld/tiles1.0.0/73/",
-                    {
-                      credit: "Terrain data courtesy VT MÄK",
-                    }
-                  );
-                  viewer.terrainProvider = provider;
-                },
-              },
-              {
-                text: "ArcGISTerrainProvider",
-                onselect: async function () {
-                  const provider = await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
-                    "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
-                  );
-                  viewer.terrainProvider = provider;
-                },
-              },
-            ],
-            "terrainMenu"
-          );
-
-          Sandcastle.addDefaultToolbarMenu(
-            [
-              {
-                text: "Mount Everest",
-                onselect: function () {
-                  lookAtMtEverest();
-                },
-              },
-              {
-                text: "Half Dome",
-                onselect: function () {
-                  const target = new Cesium.Cartesian3(
-                    -2489625.0836225147,
-                    -4393941.44443024,
-                    3882535.9454173897
-                  );
-                  const offset = new Cesium.Cartesian3(
-                    -6857.40902037546,
-                    412.3284835694358,
-                    2147.5545426812023
-                  );
-                  viewer.camera.lookAt(target, offset);
-                  viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-                },
-              },
-              {
-                text: "San Francisco Bay",
-                onselect: function () {
-                  const target = new Cesium.Cartesian3(
-                    -2708814.85583248,
-                    -4254159.450845907,
-                    3891403.9457429945
-                  );
-                  const offset = new Cesium.Cartesian3(
-                    70642.66030209465,
-                    -31661.517948317807,
-                    35505.179997143336
-                  );
-                  viewer.camera.lookAt(target, offset);
-                  viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-                },
-              },
-            ],
-            "zoomButtons"
-          );
-
-          let terrainSamplePositions;
-
-          function lookAtMtEverest() {
-            const target = new Cesium.Cartesian3(
-              300770.50872389384,
-              5634912.131394585,
-              2978152.2865545116
-            );
-            const offset = new Cesium.Cartesian3(
-              6344.974098678562,
-              -793.3419798081741,
-              2499.9508860763162
-            );
-            viewer.camera.lookAt(target, offset);
-            viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-          }
-
-          function sampleTerrainSuccess(terrainSamplePositions) {
-            const ellipsoid = Cesium.Ellipsoid.WGS84;
-
-            //By default, Cesium does not obsure geometry
-            //behind terrain. Setting this flag enables that.
-            viewer.scene.globe.depthTestAgainstTerrain = true;
-
-            viewer.entities.suspendEvents();
-            viewer.entities.removeAll();
-
-            for (let i = 0; i < terrainSamplePositions.length; ++i) {
-              const position = terrainSamplePositions[i];
-
-              viewer.entities.add({
-                name: position.height.toFixed(1),
-                position: ellipsoid.cartographicToCartesian(position),
-                billboard: {
-                  verticalOrigin: Cesium.VerticalOrigin.BOTTOM,
-                  scale: 0.7,
-                  image: "../images/facility.gif",
-                },
-                label: {
-                  text: position.height.toFixed(1),
-                  font: "10pt monospace",
-                  horizontalOrigin: Cesium.HorizontalOrigin.CENTER,
-                  pixelOffset: new Cesium.Cartesian2(0, -14),
-                  fillColor: Cesium.Color.BLACK,
-                  outlineColor: Cesium.Color.BLACK,
-                  showBackground: true,
-                  backgroundColor: new Cesium.Color(0.9, 0.9, 0.9, 0.7),
-                  backgroundPadding: new Cesium.Cartesian2(4, 3),
-                },
-              });
-            }
-            viewer.entities.resumeEvents();
-          }
-
-          function createGrid(rectangleHalfSize) {
-            const gridWidth = 41;
-            const gridHeight = 41;
-            const everestLatitude = Cesium.Math.toRadians(27.988257);
-            const everestLongitude = Cesium.Math.toRadians(86.925145);
-            const e = new Cesium.Rectangle(
-              everestLongitude - rectangleHalfSize,
-              everestLatitude - rectangleHalfSize,
-              everestLongitude + rectangleHalfSize,
-              everestLatitude + rectangleHalfSize
-            );
-            const terrainSamplePositions = [];
-            for (let y = 0; y < gridHeight; ++y) {
-              for (let x = 0; x < gridWidth; ++x) {
-                const longitude = Cesium.Math.lerp(
-                  e.west,
-                  e.east,
-                  x / (gridWidth - 1)
-                );
-                const latitude = Cesium.Math.lerp(
-                  e.south,
-                  e.north,
-                  y / (gridHeight - 1)
-                );
-                const position = new Cesium.Cartographic(longitude, latitude);
-                terrainSamplePositions.push(position);
               }
-            }
-            return terrainSamplePositions;
+
+              return buffer;
+            },
           }
+        );
 
-          Sandcastle.addToggleButton(
-            "Enable Lighting",
-            viewer.scene.globe.enableLighting,
-            function (checked) {
-              viewer.scene.globe.enableLighting = checked;
-            }
-          );
-
-          Sandcastle.addToggleButton(
-            "Enable fog",
-            viewer.scene.fog.enabled,
-            function (checked) {
-              viewer.scene.fog.enabled = checked;
-            }
-          );
-
-          Sandcastle.addToolbarButton(
-            "Sample Everest Terrain at Level 9",
-            function () {
-              const terrainSamplePositions = createGrid(0.005);
-              Promise.resolve(
-                Cesium.sampleTerrain(
-                  viewer.terrainProvider,
-                  9,
-                  terrainSamplePositions
-                )
-              ).then(sampleTerrainSuccess);
-              lookAtMtEverest();
+        Sandcastle.addToolbarMenu(
+          [
+            {
+              text: "CesiumTerrainProvider - Cesium World Terrain",
+              onselect: async function () {
+                const provider = await Cesium.createWorldTerrainAsync({
+                  requestWaterMask: true,
+                  requestVertexNormals: true,
+                });
+                viewer.terrainProvider = provider;
+                viewer.scene.globe.enableLighting = true;
+              },
             },
-            "sampleButtons"
-          );
-
-          Sandcastle.addToolbarButton(
-            "Sample Most Detailed Everest Terrain",
-            function () {
-              if (!Cesium.defined(viewer.terrainProvider.availability)) {
-                window.alert(
-                  "sampleTerrainMostDetailed is not supported for the selected terrain provider"
+            {
+              text: "CesiumTerrainProvider - Cesium World Terrain - no effects",
+              onselect: async function () {
+                viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+              },
+            },
+            {
+              text: "CesiumTerrainProvider - Cesium World Terrain w/ Lighting",
+              onselect: async function () {
+                viewer.terrainProvider = await Cesium.createWorldTerrainAsync({
+                  requestVertexNormals: true,
+                });
+                viewer.scene.globe.enableLighting = true;
+              },
+            },
+            {
+              text: "CesiumTerrainProvider - Cesium World Terrain w/ Water",
+              onselect: async function () {
+                viewer.terrainProvider = await Cesium.createWorldTerrainAsync({
+                  requestWaterMask: true,
+                });
+              },
+            },
+            {
+              text: "EllipsoidTerrainProvider",
+              onselect: function () {
+                viewer.terrainProvider = ellipsoidProvider;
+              },
+            },
+            {
+              text: "CustomHeightmapTerrainProvider",
+              onselect: function () {
+                viewer.terrainProvider = customHeightmapProvider;
+              },
+            },
+            {
+              text: "VRTheWorldTerrainProvider",
+              onselect: async function () {
+                const provider = await Cesium.VRTheWorldTerrainProvider.fromUrl(
+                  "http://www.vr-theworld.com/vr-theworld/tiles1.0.0/73/",
+                  {
+                    credit: "Terrain data courtesy VT MÄK",
+                  }
                 );
-                return;
-              }
-              const terrainSamplePositions = createGrid(0.0005);
-              Promise.resolve(
-                Cesium.sampleTerrainMostDetailed(
-                  viewer.terrainProvider,
-                  terrainSamplePositions
-                )
-              ).then(sampleTerrainSuccess);
-              lookAtMtEverest();
+                viewer.terrainProvider = provider;
+              },
             },
-            "sampleButtons"
+            {
+              text: "ArcGISTerrainProvider",
+              onselect: async function () {
+                const provider = await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
+                  "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
+                );
+                viewer.terrainProvider = provider;
+              },
+            },
+          ],
+          "terrainMenu"
+        );
+
+        Sandcastle.addDefaultToolbarMenu(
+          [
+            {
+              text: "Mount Everest",
+              onselect: function () {
+                lookAtMtEverest();
+              },
+            },
+            {
+              text: "Half Dome",
+              onselect: function () {
+                const target = new Cesium.Cartesian3(
+                  -2489625.0836225147,
+                  -4393941.44443024,
+                  3882535.9454173897
+                );
+                const offset = new Cesium.Cartesian3(
+                  -6857.40902037546,
+                  412.3284835694358,
+                  2147.5545426812023
+                );
+                viewer.camera.lookAt(target, offset);
+                viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+              },
+            },
+            {
+              text: "San Francisco Bay",
+              onselect: function () {
+                const target = new Cesium.Cartesian3(
+                  -2708814.85583248,
+                  -4254159.450845907,
+                  3891403.9457429945
+                );
+                const offset = new Cesium.Cartesian3(
+                  70642.66030209465,
+                  -31661.517948317807,
+                  35505.179997143336
+                );
+                viewer.camera.lookAt(target, offset);
+                viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+              },
+            },
+          ],
+          "zoomButtons"
+        );
+
+        let terrainSamplePositions;
+
+        function lookAtMtEverest() {
+          const target = new Cesium.Cartesian3(
+            300770.50872389384,
+            5634912.131394585,
+            2978152.2865545116
           );
-        })(); //Sandcastle_End
+          const offset = new Cesium.Cartesian3(
+            6344.974098678562,
+            -793.3419798081741,
+            2499.9508860763162
+          );
+          viewer.camera.lookAt(target, offset);
+          viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+        }
+
+        function sampleTerrainSuccess(terrainSamplePositions) {
+          const ellipsoid = Cesium.Ellipsoid.WGS84;
+
+          //By default, Cesium does not obsure geometry
+          //behind terrain. Setting this flag enables that.
+          viewer.scene.globe.depthTestAgainstTerrain = true;
+
+          viewer.entities.suspendEvents();
+          viewer.entities.removeAll();
+
+          for (let i = 0; i < terrainSamplePositions.length; ++i) {
+            const position = terrainSamplePositions[i];
+
+            viewer.entities.add({
+              name: position.height.toFixed(1),
+              position: ellipsoid.cartographicToCartesian(position),
+              billboard: {
+                verticalOrigin: Cesium.VerticalOrigin.BOTTOM,
+                scale: 0.7,
+                image: "../images/facility.gif",
+              },
+              label: {
+                text: position.height.toFixed(1),
+                font: "10pt monospace",
+                horizontalOrigin: Cesium.HorizontalOrigin.CENTER,
+                pixelOffset: new Cesium.Cartesian2(0, -14),
+                fillColor: Cesium.Color.BLACK,
+                outlineColor: Cesium.Color.BLACK,
+                showBackground: true,
+                backgroundColor: new Cesium.Color(0.9, 0.9, 0.9, 0.7),
+                backgroundPadding: new Cesium.Cartesian2(4, 3),
+              },
+            });
+          }
+          viewer.entities.resumeEvents();
+        }
+
+        function createGrid(rectangleHalfSize) {
+          const gridWidth = 41;
+          const gridHeight = 41;
+          const everestLatitude = Cesium.Math.toRadians(27.988257);
+          const everestLongitude = Cesium.Math.toRadians(86.925145);
+          const e = new Cesium.Rectangle(
+            everestLongitude - rectangleHalfSize,
+            everestLatitude - rectangleHalfSize,
+            everestLongitude + rectangleHalfSize,
+            everestLatitude + rectangleHalfSize
+          );
+          const terrainSamplePositions = [];
+          for (let y = 0; y < gridHeight; ++y) {
+            for (let x = 0; x < gridWidth; ++x) {
+              const longitude = Cesium.Math.lerp(
+                e.west,
+                e.east,
+                x / (gridWidth - 1)
+              );
+              const latitude = Cesium.Math.lerp(
+                e.south,
+                e.north,
+                y / (gridHeight - 1)
+              );
+              const position = new Cesium.Cartographic(longitude, latitude);
+              terrainSamplePositions.push(position);
+            }
+          }
+          return terrainSamplePositions;
+        }
+
+        Sandcastle.addToggleButton(
+          "Enable Lighting",
+          viewer.scene.globe.enableLighting,
+          function (checked) {
+            viewer.scene.globe.enableLighting = checked;
+          }
+        );
+
+        Sandcastle.addToggleButton(
+          "Enable fog",
+          viewer.scene.fog.enabled,
+          function (checked) {
+            viewer.scene.fog.enabled = checked;
+          }
+        );
+
+        Sandcastle.addToolbarButton(
+          "Sample Everest Terrain at Level 9",
+          function () {
+            const terrainSamplePositions = createGrid(0.005);
+            Promise.resolve(
+              Cesium.sampleTerrain(
+                viewer.terrainProvider,
+                9,
+                terrainSamplePositions
+              )
+            ).then(sampleTerrainSuccess);
+            lookAtMtEverest();
+          },
+          "sampleButtons"
+        );
+
+        Sandcastle.addToolbarButton(
+          "Sample Most Detailed Everest Terrain",
+          function () {
+            if (!Cesium.defined(viewer.terrainProvider.availability)) {
+              window.alert(
+                "sampleTerrainMostDetailed is not supported for the selected terrain provider"
+              );
+              return;
+            }
+            const terrainSamplePositions = createGrid(0.0005);
+            Promise.resolve(
+              Cesium.sampleTerrainMostDetailed(
+                viewer.terrainProvider,
+                terrainSamplePositions
+              )
+            ).then(sampleTerrainSuccess);
+            lookAtMtEverest();
+          },
+          "sampleButtons"
+        );
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/Terrain.html
+++ b/Apps/Sandcastle/gallery/Terrain.html
@@ -39,306 +39,312 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync({
-            requestWaterMask: true,
-            requestVertexNormals: true,
-          }),
-        });
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync({
+              requestWaterMask: true,
+              requestVertexNormals: true,
+            }),
+          });
 
-        // set lighting to true
-        viewer.scene.globe.enableLighting = true;
+          // set lighting to true
+          viewer.scene.globe.enableLighting = true;
 
-        // setup alternative terrain providers
-        const ellipsoidProvider = new Cesium.EllipsoidTerrainProvider();
+          // setup alternative terrain providers
+          const ellipsoidProvider = new Cesium.EllipsoidTerrainProvider();
 
-        // Sine wave
-        const customHeightmapWidth = 32;
-        const customHeightmapHeight = 32;
-        const customHeightmapProvider = new Cesium.CustomHeightmapTerrainProvider(
-          {
-            width: customHeightmapWidth,
-            height: customHeightmapHeight,
-            callback: function (x, y, level) {
-              const width = customHeightmapWidth;
-              const height = customHeightmapHeight;
-              const buffer = new Float32Array(width * height);
-
-              for (let yy = 0; yy < height; yy++) {
-                for (let xx = 0; xx < width; xx++) {
-                  const u = (x + xx / (width - 1)) / Math.pow(2, level);
-                  const v = (y + yy / (height - 1)) / Math.pow(2, level);
-
-                  const heightValue = 4000 * (Math.sin(8000 * v) * 0.5 + 0.5);
-
-                  const index = yy * width + xx;
-                  buffer[index] = heightValue;
-                }
-              }
-
-              return buffer;
-            },
-          }
-        );
-
-        Sandcastle.addToolbarMenu(
-          [
+          // Sine wave
+          const customHeightmapWidth = 32;
+          const customHeightmapHeight = 32;
+          const customHeightmapProvider = new Cesium.CustomHeightmapTerrainProvider(
             {
-              text: "CesiumTerrainProvider - Cesium World Terrain",
-              onselect: async function () {
-                const provider = await Cesium.createWorldTerrainAsync({
-                  requestWaterMask: true,
-                  requestVertexNormals: true,
-                });
-                viewer.terrainProvider = provider;
-                viewer.scene.globe.enableLighting = true;
-              },
-            },
-            {
-              text: "CesiumTerrainProvider - Cesium World Terrain - no effects",
-              onselect: async function () {
-                viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-              },
-            },
-            {
-              text: "CesiumTerrainProvider - Cesium World Terrain w/ Lighting",
-              onselect: async function () {
-                viewer.terrainProvider = await Cesium.createWorldTerrainAsync({
-                  requestVertexNormals: true,
-                });
-                viewer.scene.globe.enableLighting = true;
-              },
-            },
-            {
-              text: "CesiumTerrainProvider - Cesium World Terrain w/ Water",
-              onselect: async function () {
-                viewer.terrainProvider = await Cesium.createWorldTerrainAsync({
-                  requestWaterMask: true,
-                });
-              },
-            },
-            {
-              text: "EllipsoidTerrainProvider",
-              onselect: function () {
-                viewer.terrainProvider = ellipsoidProvider;
-              },
-            },
-            {
-              text: "CustomHeightmapTerrainProvider",
-              onselect: function () {
-                viewer.terrainProvider = customHeightmapProvider;
-              },
-            },
-            {
-              text: "VRTheWorldTerrainProvider",
-              onselect: async function () {
-                const provider = await Cesium.VRTheWorldTerrainProvider.fromUrl(
-                  "http://www.vr-theworld.com/vr-theworld/tiles1.0.0/73/",
-                  {
-                    credit: "Terrain data courtesy VT MÄK",
+              width: customHeightmapWidth,
+              height: customHeightmapHeight,
+              callback: function (x, y, level) {
+                const width = customHeightmapWidth;
+                const height = customHeightmapHeight;
+                const buffer = new Float32Array(width * height);
+
+                for (let yy = 0; yy < height; yy++) {
+                  for (let xx = 0; xx < width; xx++) {
+                    const u = (x + xx / (width - 1)) / Math.pow(2, level);
+                    const v = (y + yy / (height - 1)) / Math.pow(2, level);
+
+                    const heightValue = 4000 * (Math.sin(8000 * v) * 0.5 + 0.5);
+
+                    const index = yy * width + xx;
+                    buffer[index] = heightValue;
                   }
-                );
-                viewer.terrainProvider = provider;
+                }
+
+                return buffer;
               },
-            },
-            {
-              text: "ArcGISTerrainProvider",
-              onselect: async function () {
-                const provider = await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
-                  "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
-                );
-                viewer.terrainProvider = provider;
-              },
-            },
-          ],
-          "terrainMenu"
-        );
-
-        Sandcastle.addDefaultToolbarMenu(
-          [
-            {
-              text: "Mount Everest",
-              onselect: function () {
-                lookAtMtEverest();
-              },
-            },
-            {
-              text: "Half Dome",
-              onselect: function () {
-                const target = new Cesium.Cartesian3(
-                  -2489625.0836225147,
-                  -4393941.44443024,
-                  3882535.9454173897
-                );
-                const offset = new Cesium.Cartesian3(
-                  -6857.40902037546,
-                  412.3284835694358,
-                  2147.5545426812023
-                );
-                viewer.camera.lookAt(target, offset);
-                viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-              },
-            },
-            {
-              text: "San Francisco Bay",
-              onselect: function () {
-                const target = new Cesium.Cartesian3(
-                  -2708814.85583248,
-                  -4254159.450845907,
-                  3891403.9457429945
-                );
-                const offset = new Cesium.Cartesian3(
-                  70642.66030209465,
-                  -31661.517948317807,
-                  35505.179997143336
-                );
-                viewer.camera.lookAt(target, offset);
-                viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-              },
-            },
-          ],
-          "zoomButtons"
-        );
-
-        let terrainSamplePositions;
-
-        function lookAtMtEverest() {
-          const target = new Cesium.Cartesian3(
-            300770.50872389384,
-            5634912.131394585,
-            2978152.2865545116
-          );
-          const offset = new Cesium.Cartesian3(
-            6344.974098678562,
-            -793.3419798081741,
-            2499.9508860763162
-          );
-          viewer.camera.lookAt(target, offset);
-          viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-        }
-
-        function sampleTerrainSuccess(terrainSamplePositions) {
-          const ellipsoid = Cesium.Ellipsoid.WGS84;
-
-          //By default, Cesium does not obsure geometry
-          //behind terrain. Setting this flag enables that.
-          viewer.scene.globe.depthTestAgainstTerrain = true;
-
-          viewer.entities.suspendEvents();
-          viewer.entities.removeAll();
-
-          for (let i = 0; i < terrainSamplePositions.length; ++i) {
-            const position = terrainSamplePositions[i];
-
-            viewer.entities.add({
-              name: position.height.toFixed(1),
-              position: ellipsoid.cartographicToCartesian(position),
-              billboard: {
-                verticalOrigin: Cesium.VerticalOrigin.BOTTOM,
-                scale: 0.7,
-                image: "../images/facility.gif",
-              },
-              label: {
-                text: position.height.toFixed(1),
-                font: "10pt monospace",
-                horizontalOrigin: Cesium.HorizontalOrigin.CENTER,
-                pixelOffset: new Cesium.Cartesian2(0, -14),
-                fillColor: Cesium.Color.BLACK,
-                outlineColor: Cesium.Color.BLACK,
-                showBackground: true,
-                backgroundColor: new Cesium.Color(0.9, 0.9, 0.9, 0.7),
-                backgroundPadding: new Cesium.Cartesian2(4, 3),
-              },
-            });
-          }
-          viewer.entities.resumeEvents();
-        }
-
-        function createGrid(rectangleHalfSize) {
-          const gridWidth = 41;
-          const gridHeight = 41;
-          const everestLatitude = Cesium.Math.toRadians(27.988257);
-          const everestLongitude = Cesium.Math.toRadians(86.925145);
-          const e = new Cesium.Rectangle(
-            everestLongitude - rectangleHalfSize,
-            everestLatitude - rectangleHalfSize,
-            everestLongitude + rectangleHalfSize,
-            everestLatitude + rectangleHalfSize
-          );
-          const terrainSamplePositions = [];
-          for (let y = 0; y < gridHeight; ++y) {
-            for (let x = 0; x < gridWidth; ++x) {
-              const longitude = Cesium.Math.lerp(
-                e.west,
-                e.east,
-                x / (gridWidth - 1)
-              );
-              const latitude = Cesium.Math.lerp(
-                e.south,
-                e.north,
-                y / (gridHeight - 1)
-              );
-              const position = new Cesium.Cartographic(longitude, latitude);
-              terrainSamplePositions.push(position);
             }
+          );
+
+          Sandcastle.addToolbarMenu(
+            [
+              {
+                text: "CesiumTerrainProvider - Cesium World Terrain",
+                onselect: async function () {
+                  const provider = await Cesium.createWorldTerrainAsync({
+                    requestWaterMask: true,
+                    requestVertexNormals: true,
+                  });
+                  viewer.terrainProvider = provider;
+                  viewer.scene.globe.enableLighting = true;
+                },
+              },
+              {
+                text:
+                  "CesiumTerrainProvider - Cesium World Terrain - no effects",
+                onselect: async function () {
+                  viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+                },
+              },
+              {
+                text:
+                  "CesiumTerrainProvider - Cesium World Terrain w/ Lighting",
+                onselect: async function () {
+                  viewer.terrainProvider = await Cesium.createWorldTerrainAsync(
+                    {
+                      requestVertexNormals: true,
+                    }
+                  );
+                  viewer.scene.globe.enableLighting = true;
+                },
+              },
+              {
+                text: "CesiumTerrainProvider - Cesium World Terrain w/ Water",
+                onselect: async function () {
+                  viewer.terrainProvider = await Cesium.createWorldTerrainAsync(
+                    {
+                      requestWaterMask: true,
+                    }
+                  );
+                },
+              },
+              {
+                text: "EllipsoidTerrainProvider",
+                onselect: function () {
+                  viewer.terrainProvider = ellipsoidProvider;
+                },
+              },
+              {
+                text: "CustomHeightmapTerrainProvider",
+                onselect: function () {
+                  viewer.terrainProvider = customHeightmapProvider;
+                },
+              },
+              {
+                text: "VRTheWorldTerrainProvider",
+                onselect: async function () {
+                  const provider = await Cesium.VRTheWorldTerrainProvider.fromUrl(
+                    "http://www.vr-theworld.com/vr-theworld/tiles1.0.0/73/",
+                    {
+                      credit: "Terrain data courtesy VT MÄK",
+                    }
+                  );
+                  viewer.terrainProvider = provider;
+                },
+              },
+              {
+                text: "ArcGISTerrainProvider",
+                onselect: async function () {
+                  const provider = await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
+                    "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
+                  );
+                  viewer.terrainProvider = provider;
+                },
+              },
+            ],
+            "terrainMenu"
+          );
+
+          Sandcastle.addDefaultToolbarMenu(
+            [
+              {
+                text: "Mount Everest",
+                onselect: function () {
+                  lookAtMtEverest();
+                },
+              },
+              {
+                text: "Half Dome",
+                onselect: function () {
+                  const target = new Cesium.Cartesian3(
+                    -2489625.0836225147,
+                    -4393941.44443024,
+                    3882535.9454173897
+                  );
+                  const offset = new Cesium.Cartesian3(
+                    -6857.40902037546,
+                    412.3284835694358,
+                    2147.5545426812023
+                  );
+                  viewer.camera.lookAt(target, offset);
+                  viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+                },
+              },
+              {
+                text: "San Francisco Bay",
+                onselect: function () {
+                  const target = new Cesium.Cartesian3(
+                    -2708814.85583248,
+                    -4254159.450845907,
+                    3891403.9457429945
+                  );
+                  const offset = new Cesium.Cartesian3(
+                    70642.66030209465,
+                    -31661.517948317807,
+                    35505.179997143336
+                  );
+                  viewer.camera.lookAt(target, offset);
+                  viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+                },
+              },
+            ],
+            "zoomButtons"
+          );
+
+          let terrainSamplePositions;
+
+          function lookAtMtEverest() {
+            const target = new Cesium.Cartesian3(
+              300770.50872389384,
+              5634912.131394585,
+              2978152.2865545116
+            );
+            const offset = new Cesium.Cartesian3(
+              6344.974098678562,
+              -793.3419798081741,
+              2499.9508860763162
+            );
+            viewer.camera.lookAt(target, offset);
+            viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
           }
-          return terrainSamplePositions;
-        }
 
-        Sandcastle.addToggleButton(
-          "Enable Lighting",
-          viewer.scene.globe.enableLighting,
-          function (checked) {
-            viewer.scene.globe.enableLighting = checked;
-          }
-        );
+          function sampleTerrainSuccess(terrainSamplePositions) {
+            const ellipsoid = Cesium.Ellipsoid.WGS84;
 
-        Sandcastle.addToggleButton(
-          "Enable fog",
-          viewer.scene.fog.enabled,
-          function (checked) {
-            viewer.scene.fog.enabled = checked;
-          }
-        );
+            //By default, Cesium does not obsure geometry
+            //behind terrain. Setting this flag enables that.
+            viewer.scene.globe.depthTestAgainstTerrain = true;
 
-        Sandcastle.addToolbarButton(
-          "Sample Everest Terrain at Level 9",
-          function () {
-            const terrainSamplePositions = createGrid(0.005);
-            Promise.resolve(
-              Cesium.sampleTerrain(
-                viewer.terrainProvider,
-                9,
-                terrainSamplePositions
-              )
-            ).then(sampleTerrainSuccess);
-            lookAtMtEverest();
-          },
-          "sampleButtons"
-        );
+            viewer.entities.suspendEvents();
+            viewer.entities.removeAll();
 
-        Sandcastle.addToolbarButton(
-          "Sample Most Detailed Everest Terrain",
-          function () {
-            if (!Cesium.defined(viewer.terrainProvider.availability)) {
-              window.alert(
-                "sampleTerrainMostDetailed is not supported for the selected terrain provider"
-              );
-              return;
+            for (let i = 0; i < terrainSamplePositions.length; ++i) {
+              const position = terrainSamplePositions[i];
+
+              viewer.entities.add({
+                name: position.height.toFixed(1),
+                position: ellipsoid.cartographicToCartesian(position),
+                billboard: {
+                  verticalOrigin: Cesium.VerticalOrigin.BOTTOM,
+                  scale: 0.7,
+                  image: "../images/facility.gif",
+                },
+                label: {
+                  text: position.height.toFixed(1),
+                  font: "10pt monospace",
+                  horizontalOrigin: Cesium.HorizontalOrigin.CENTER,
+                  pixelOffset: new Cesium.Cartesian2(0, -14),
+                  fillColor: Cesium.Color.BLACK,
+                  outlineColor: Cesium.Color.BLACK,
+                  showBackground: true,
+                  backgroundColor: new Cesium.Color(0.9, 0.9, 0.9, 0.7),
+                  backgroundPadding: new Cesium.Cartesian2(4, 3),
+                },
+              });
             }
-            const terrainSamplePositions = createGrid(0.0005);
-            Promise.resolve(
-              Cesium.sampleTerrainMostDetailed(
-                viewer.terrainProvider,
-                terrainSamplePositions
-              )
-            ).then(sampleTerrainSuccess);
-            lookAtMtEverest();
-          },
-          "sampleButtons"
-        );
+            viewer.entities.resumeEvents();
+          }
 
-        //Sandcastle_End
+          function createGrid(rectangleHalfSize) {
+            const gridWidth = 41;
+            const gridHeight = 41;
+            const everestLatitude = Cesium.Math.toRadians(27.988257);
+            const everestLongitude = Cesium.Math.toRadians(86.925145);
+            const e = new Cesium.Rectangle(
+              everestLongitude - rectangleHalfSize,
+              everestLatitude - rectangleHalfSize,
+              everestLongitude + rectangleHalfSize,
+              everestLatitude + rectangleHalfSize
+            );
+            const terrainSamplePositions = [];
+            for (let y = 0; y < gridHeight; ++y) {
+              for (let x = 0; x < gridWidth; ++x) {
+                const longitude = Cesium.Math.lerp(
+                  e.west,
+                  e.east,
+                  x / (gridWidth - 1)
+                );
+                const latitude = Cesium.Math.lerp(
+                  e.south,
+                  e.north,
+                  y / (gridHeight - 1)
+                );
+                const position = new Cesium.Cartographic(longitude, latitude);
+                terrainSamplePositions.push(position);
+              }
+            }
+            return terrainSamplePositions;
+          }
+
+          Sandcastle.addToggleButton(
+            "Enable Lighting",
+            viewer.scene.globe.enableLighting,
+            function (checked) {
+              viewer.scene.globe.enableLighting = checked;
+            }
+          );
+
+          Sandcastle.addToggleButton(
+            "Enable fog",
+            viewer.scene.fog.enabled,
+            function (checked) {
+              viewer.scene.fog.enabled = checked;
+            }
+          );
+
+          Sandcastle.addToolbarButton(
+            "Sample Everest Terrain at Level 9",
+            function () {
+              const terrainSamplePositions = createGrid(0.005);
+              Promise.resolve(
+                Cesium.sampleTerrain(
+                  viewer.terrainProvider,
+                  9,
+                  terrainSamplePositions
+                )
+              ).then(sampleTerrainSuccess);
+              lookAtMtEverest();
+            },
+            "sampleButtons"
+          );
+
+          Sandcastle.addToolbarButton(
+            "Sample Most Detailed Everest Terrain",
+            function () {
+              if (!Cesium.defined(viewer.terrainProvider.availability)) {
+                window.alert(
+                  "sampleTerrainMostDetailed is not supported for the selected terrain provider"
+                );
+                return;
+              }
+              const terrainSamplePositions = createGrid(0.0005);
+              Promise.resolve(
+                Cesium.sampleTerrainMostDetailed(
+                  viewer.terrainProvider,
+                  terrainSamplePositions
+                )
+              ).then(sampleTerrainSuccess);
+              lookAtMtEverest();
+            },
+            "sampleButtons"
+          );
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/development/BillboardClampToGround.html
+++ b/Apps/Sandcastle/gallery/development/BillboardClampToGround.html
@@ -37,137 +37,138 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        const viewer = new Cesium.Viewer("cesiumContainer");
+        viewer.scene.globe.depthTestAgainstTerrain = true;
+
         (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
-          viewer.scene.globe.depthTestAgainstTerrain = true;
-
-          const ellipsoid = viewer.scene.globe.ellipsoid;
-          const billboardCollection = viewer.scene.primitives.add(
-            new Cesium.BillboardCollection({
-              scene: viewer.scene,
-            })
-          );
-
-          // seneca
-          const centerLongitude = -1.385205433269729;
-          const centerLatitude = 0.6777926580888163;
-
-          const gridWidth = Math.floor(Math.random() * 100.0);
-          const gridHeight = Math.floor(Math.random() * 100.0);
-          const rectangleHalfSize = 0.0005;
-
-          const e = new Cesium.Rectangle(
-            centerLongitude - rectangleHalfSize,
-            centerLatitude - rectangleHalfSize,
-            centerLongitude + rectangleHalfSize,
-            centerLatitude + rectangleHalfSize
-          );
-
-          for (let y = 0; y < gridHeight; ++y) {
-            for (let x = 0; x < gridWidth; ++x) {
-              const longitude = Cesium.Math.lerp(
-                e.west,
-                e.east,
-                x / (gridWidth - 1)
-              );
-              const latitude = Cesium.Math.lerp(
-                e.south,
-                e.north,
-                y / (gridHeight - 1)
-              );
-              const position = new Cesium.Cartographic(longitude, latitude);
-
-              billboardCollection.add({
-                position: ellipsoid.cartographicToCartesian(position),
-                image: "../images/facility.gif",
-                heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-              });
-            }
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+          } catch (error) {
+            console.log(error);
           }
+        })();
 
-          let billboard;
+        const ellipsoid = viewer.scene.globe.ellipsoid;
+        const billboardCollection = viewer.scene.primitives.add(
+          new Cesium.BillboardCollection({
+            scene: viewer.scene,
+          })
+        );
 
-          Sandcastle.addToolbarButton("Add billboard", function () {
-            if (!Cesium.defined(billboard)) {
-              billboard = billboardCollection.add({
-                position: ellipsoid.cartographicToCartesian(
-                  new Cesium.Cartographic(
-                    centerLongitude,
-                    centerLatitude,
-                    1000.0
-                  )
-                ),
-                image: "../images/Cesium_Logo_overlay.png",
-                scale: 0.7,
-                heightReference: Cesium.HeightReference.RELATIVE_TO_GROUND,
-              });
-            }
-          });
+        // seneca
+        const centerLongitude = -1.385205433269729;
+        const centerLatitude = 0.6777926580888163;
 
-          Sandcastle.addToolbarButton("Remove billboard", function () {
-            if (Cesium.defined(billboard)) {
-              billboardCollection.remove(billboard);
-              billboard = undefined;
-            }
-          });
+        const gridWidth = Math.floor(Math.random() * 100.0);
+        const gridHeight = Math.floor(Math.random() * 100.0);
+        const rectangleHalfSize = 0.0005;
 
-          Sandcastle.addToolbarMenu([
-            {
-              text: "Relative to ground",
-              onselect: function () {
-                if (Cesium.defined(billboard)) {
-                  billboard.heightReference =
-                    Cesium.HeightReference.RELATIVE_TO_GROUND;
-                }
-              },
+        const e = new Cesium.Rectangle(
+          centerLongitude - rectangleHalfSize,
+          centerLatitude - rectangleHalfSize,
+          centerLongitude + rectangleHalfSize,
+          centerLatitude + rectangleHalfSize
+        );
+
+        for (let y = 0; y < gridHeight; ++y) {
+          for (let x = 0; x < gridWidth; ++x) {
+            const longitude = Cesium.Math.lerp(
+              e.west,
+              e.east,
+              x / (gridWidth - 1)
+            );
+            const latitude = Cesium.Math.lerp(
+              e.south,
+              e.north,
+              y / (gridHeight - 1)
+            );
+            const position = new Cesium.Cartographic(longitude, latitude);
+
+            billboardCollection.add({
+              position: ellipsoid.cartographicToCartesian(position),
+              image: "../images/facility.gif",
+              heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+            });
+          }
+        }
+
+        let billboard;
+
+        Sandcastle.addToolbarButton("Add billboard", function () {
+          if (!Cesium.defined(billboard)) {
+            billboard = billboardCollection.add({
+              position: ellipsoid.cartographicToCartesian(
+                new Cesium.Cartographic(centerLongitude, centerLatitude, 1000.0)
+              ),
+              image: "../images/Cesium_Logo_overlay.png",
+              scale: 0.7,
+              heightReference: Cesium.HeightReference.RELATIVE_TO_GROUND,
+            });
+          }
+        });
+
+        Sandcastle.addToolbarButton("Remove billboard", function () {
+          if (Cesium.defined(billboard)) {
+            billboardCollection.remove(billboard);
+            billboard = undefined;
+          }
+        });
+
+        Sandcastle.addToolbarMenu([
+          {
+            text: "Relative to ground",
+            onselect: function () {
+              if (Cesium.defined(billboard)) {
+                billboard.heightReference =
+                  Cesium.HeightReference.RELATIVE_TO_GROUND;
+              }
             },
-            {
-              text: "Clamp to ground",
-              onselect: function () {
-                if (Cesium.defined(billboard)) {
-                  billboard.heightReference =
-                    Cesium.HeightReference.CLAMP_TO_GROUND;
-                }
-              },
+          },
+          {
+            text: "Clamp to ground",
+            onselect: function () {
+              if (Cesium.defined(billboard)) {
+                billboard.heightReference =
+                  Cesium.HeightReference.CLAMP_TO_GROUND;
+              }
             },
-            {
-              text: "None",
-              onselect: function () {
-                if (Cesium.defined(billboard)) {
-                  billboard.heightReference = Cesium.HeightReference.NONE;
-                }
-              },
+          },
+          {
+            text: "None",
+            onselect: function () {
+              if (Cesium.defined(billboard)) {
+                billboard.heightReference = Cesium.HeightReference.NONE;
+              }
             },
-          ]);
+          },
+        ]);
 
-          const lonGran = 0.00005;
+        const lonGran = 0.00005;
 
-          Sandcastle.addToolbarButton("Increase longitude", function () {
-            if (Cesium.defined(billboard)) {
-              const cartographic = ellipsoid.cartesianToCartographic(
-                billboard.position
-              );
-              cartographic.longitude += lonGran;
-              billboard.position = ellipsoid.cartographicToCartesian(
-                cartographic
-              );
-            }
-          });
+        Sandcastle.addToolbarButton("Increase longitude", function () {
+          if (Cesium.defined(billboard)) {
+            const cartographic = ellipsoid.cartesianToCartographic(
+              billboard.position
+            );
+            cartographic.longitude += lonGran;
+            billboard.position = ellipsoid.cartographicToCartesian(
+              cartographic
+            );
+          }
+        });
 
-          Sandcastle.addToolbarButton("Decrease longitude", function () {
-            if (Cesium.defined(billboard)) {
-              const cartographic = ellipsoid.cartesianToCartographic(
-                billboard.position
-              );
-              cartographic.longitude -= lonGran;
-              billboard.position = ellipsoid.cartographicToCartesian(
-                cartographic
-              );
-            }
-          });
-        })(); //Sandcastle_End
+        Sandcastle.addToolbarButton("Decrease longitude", function () {
+          if (Cesium.defined(billboard)) {
+            const cartographic = ellipsoid.cartesianToCartographic(
+              billboard.position
+            );
+            cartographic.longitude -= lonGran;
+            billboard.position = ellipsoid.cartographicToCartesian(
+              cartographic
+            );
+          }
+        });
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/development/BillboardClampToGround.html
+++ b/Apps/Sandcastle/gallery/development/BillboardClampToGround.html
@@ -38,7 +38,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
         viewer.scene.globe.depthTestAgainstTerrain = true;
 

--- a/Apps/Sandcastle/gallery/development/BillboardClampToGround.html
+++ b/Apps/Sandcastle/gallery/development/BillboardClampToGround.html
@@ -37,133 +37,137 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
-        viewer.scene.globe.depthTestAgainstTerrain = true;
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
+          viewer.scene.globe.depthTestAgainstTerrain = true;
 
-        const ellipsoid = viewer.scene.globe.ellipsoid;
-        const billboardCollection = viewer.scene.primitives.add(
-          new Cesium.BillboardCollection({
-            scene: viewer.scene,
-          })
-        );
+          const ellipsoid = viewer.scene.globe.ellipsoid;
+          const billboardCollection = viewer.scene.primitives.add(
+            new Cesium.BillboardCollection({
+              scene: viewer.scene,
+            })
+          );
 
-        // seneca
-        const centerLongitude = -1.385205433269729;
-        const centerLatitude = 0.6777926580888163;
+          // seneca
+          const centerLongitude = -1.385205433269729;
+          const centerLatitude = 0.6777926580888163;
 
-        const gridWidth = Math.floor(Math.random() * 100.0);
-        const gridHeight = Math.floor(Math.random() * 100.0);
-        const rectangleHalfSize = 0.0005;
+          const gridWidth = Math.floor(Math.random() * 100.0);
+          const gridHeight = Math.floor(Math.random() * 100.0);
+          const rectangleHalfSize = 0.0005;
 
-        const e = new Cesium.Rectangle(
-          centerLongitude - rectangleHalfSize,
-          centerLatitude - rectangleHalfSize,
-          centerLongitude + rectangleHalfSize,
-          centerLatitude + rectangleHalfSize
-        );
+          const e = new Cesium.Rectangle(
+            centerLongitude - rectangleHalfSize,
+            centerLatitude - rectangleHalfSize,
+            centerLongitude + rectangleHalfSize,
+            centerLatitude + rectangleHalfSize
+          );
 
-        for (let y = 0; y < gridHeight; ++y) {
-          for (let x = 0; x < gridWidth; ++x) {
-            const longitude = Cesium.Math.lerp(
-              e.west,
-              e.east,
-              x / (gridWidth - 1)
-            );
-            const latitude = Cesium.Math.lerp(
-              e.south,
-              e.north,
-              y / (gridHeight - 1)
-            );
-            const position = new Cesium.Cartographic(longitude, latitude);
+          for (let y = 0; y < gridHeight; ++y) {
+            for (let x = 0; x < gridWidth; ++x) {
+              const longitude = Cesium.Math.lerp(
+                e.west,
+                e.east,
+                x / (gridWidth - 1)
+              );
+              const latitude = Cesium.Math.lerp(
+                e.south,
+                e.north,
+                y / (gridHeight - 1)
+              );
+              const position = new Cesium.Cartographic(longitude, latitude);
 
-            billboardCollection.add({
-              position: ellipsoid.cartographicToCartesian(position),
-              image: "../images/facility.gif",
-              heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
-            });
+              billboardCollection.add({
+                position: ellipsoid.cartographicToCartesian(position),
+                image: "../images/facility.gif",
+                heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+              });
+            }
           }
-        }
 
-        let billboard;
+          let billboard;
 
-        Sandcastle.addToolbarButton("Add billboard", function () {
-          if (!Cesium.defined(billboard)) {
-            billboard = billboardCollection.add({
-              position: ellipsoid.cartographicToCartesian(
-                new Cesium.Cartographic(centerLongitude, centerLatitude, 1000.0)
-              ),
-              image: "../images/Cesium_Logo_overlay.png",
-              scale: 0.7,
-              heightReference: Cesium.HeightReference.RELATIVE_TO_GROUND,
-            });
-          }
-        });
+          Sandcastle.addToolbarButton("Add billboard", function () {
+            if (!Cesium.defined(billboard)) {
+              billboard = billboardCollection.add({
+                position: ellipsoid.cartographicToCartesian(
+                  new Cesium.Cartographic(
+                    centerLongitude,
+                    centerLatitude,
+                    1000.0
+                  )
+                ),
+                image: "../images/Cesium_Logo_overlay.png",
+                scale: 0.7,
+                heightReference: Cesium.HeightReference.RELATIVE_TO_GROUND,
+              });
+            }
+          });
 
-        Sandcastle.addToolbarButton("Remove billboard", function () {
-          if (Cesium.defined(billboard)) {
-            billboardCollection.remove(billboard);
-            billboard = undefined;
-          }
-        });
+          Sandcastle.addToolbarButton("Remove billboard", function () {
+            if (Cesium.defined(billboard)) {
+              billboardCollection.remove(billboard);
+              billboard = undefined;
+            }
+          });
 
-        Sandcastle.addToolbarMenu([
-          {
-            text: "Relative to ground",
-            onselect: function () {
-              if (Cesium.defined(billboard)) {
-                billboard.heightReference =
-                  Cesium.HeightReference.RELATIVE_TO_GROUND;
-              }
+          Sandcastle.addToolbarMenu([
+            {
+              text: "Relative to ground",
+              onselect: function () {
+                if (Cesium.defined(billboard)) {
+                  billboard.heightReference =
+                    Cesium.HeightReference.RELATIVE_TO_GROUND;
+                }
+              },
             },
-          },
-          {
-            text: "Clamp to ground",
-            onselect: function () {
-              if (Cesium.defined(billboard)) {
-                billboard.heightReference =
-                  Cesium.HeightReference.CLAMP_TO_GROUND;
-              }
+            {
+              text: "Clamp to ground",
+              onselect: function () {
+                if (Cesium.defined(billboard)) {
+                  billboard.heightReference =
+                    Cesium.HeightReference.CLAMP_TO_GROUND;
+                }
+              },
             },
-          },
-          {
-            text: "None",
-            onselect: function () {
-              if (Cesium.defined(billboard)) {
-                billboard.heightReference = Cesium.HeightReference.NONE;
-              }
+            {
+              text: "None",
+              onselect: function () {
+                if (Cesium.defined(billboard)) {
+                  billboard.heightReference = Cesium.HeightReference.NONE;
+                }
+              },
             },
-          },
-        ]);
+          ]);
 
-        const lonGran = 0.00005;
+          const lonGran = 0.00005;
 
-        Sandcastle.addToolbarButton("Increase longitude", function () {
-          if (Cesium.defined(billboard)) {
-            const cartographic = ellipsoid.cartesianToCartographic(
-              billboard.position
-            );
-            cartographic.longitude += lonGran;
-            billboard.position = ellipsoid.cartographicToCartesian(
-              cartographic
-            );
-          }
-        });
+          Sandcastle.addToolbarButton("Increase longitude", function () {
+            if (Cesium.defined(billboard)) {
+              const cartographic = ellipsoid.cartesianToCartographic(
+                billboard.position
+              );
+              cartographic.longitude += lonGran;
+              billboard.position = ellipsoid.cartographicToCartesian(
+                cartographic
+              );
+            }
+          });
 
-        Sandcastle.addToolbarButton("Decrease longitude", function () {
-          if (Cesium.defined(billboard)) {
-            const cartographic = ellipsoid.cartesianToCartographic(
-              billboard.position
-            );
-            cartographic.longitude -= lonGran;
-            billboard.position = ellipsoid.cartographicToCartesian(
-              cartographic
-            );
-          }
-        });
-
-        //Sandcastle_End
+          Sandcastle.addToolbarButton("Decrease longitude", function () {
+            if (Cesium.defined(billboard)) {
+              const cartographic = ellipsoid.cartesianToCartographic(
+                billboard.position
+              );
+              cartographic.longitude -= lonGran;
+              billboard.position = ellipsoid.cartographicToCartesian(
+                cartographic
+              );
+            }
+          });
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/development/Billboards Instancing.html
+++ b/Apps/Sandcastle/gallery/development/Billboards Instancing.html
@@ -38,7 +38,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         const scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/development/Billboards Instancing.html
+++ b/Apps/Sandcastle/gallery/development/Billboards Instancing.html
@@ -37,197 +37,201 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
 
-        const scene = viewer.scene;
-        const context = scene.context;
+          const scene = viewer.scene;
+          const context = scene.context;
 
-        scene.debugShowFramesPerSecond = true;
+          scene.debugShowFramesPerSecond = true;
 
-        const ellipsoid = scene.globe.ellipsoid;
-        let billboardCollection;
-        let instancingEnabled = true;
-        const instancedArraysExtension = context._instancedArrays;
-        let billboardCount = 100489;
-        let scale = 1.0;
+          const ellipsoid = scene.globe.ellipsoid;
+          let billboardCollection;
+          let instancingEnabled = true;
+          const instancedArraysExtension = context._instancedArrays;
+          let billboardCount = 100489;
+          let scale = 1.0;
 
-        // seneca
-        const centerLongitude = -1.385205433269729;
-        const centerLatitude = 0.6777926580888163;
-        const rectangleHalfSize = 0.5;
-        const e = new Cesium.Rectangle(
-          centerLongitude - rectangleHalfSize,
-          centerLatitude - rectangleHalfSize,
-          centerLongitude + rectangleHalfSize,
-          centerLatitude + rectangleHalfSize
-        );
-
-        function resetBillboardCollection() {
-          if (Cesium.defined(billboardCollection)) {
-            scene.primitives.remove(billboardCollection);
-          }
-
-          billboardCollection = scene.primitives.add(
-            new Cesium.BillboardCollection({
-              scene: scene,
-            })
+          // seneca
+          const centerLongitude = -1.385205433269729;
+          const centerLatitude = 0.6777926580888163;
+          const rectangleHalfSize = 0.5;
+          const e = new Cesium.Rectangle(
+            centerLongitude - rectangleHalfSize,
+            centerLatitude - rectangleHalfSize,
+            centerLongitude + rectangleHalfSize,
+            centerLatitude + rectangleHalfSize
           );
 
-          const gridSize = Math.sqrt(billboardCount);
-          for (let y = 0; y < gridSize; ++y) {
-            for (let x = 0; x < gridSize; ++x) {
-              const longitude = Cesium.Math.lerp(
-                e.west,
-                e.east,
-                x / (gridSize - 1)
-              );
-              const latitude = Cesium.Math.lerp(
-                e.south,
-                e.north,
-                y / (gridSize - 1)
-              );
-              const position = new Cesium.Cartographic(
-                longitude,
-                latitude,
-                10000.0
-              );
+          function resetBillboardCollection() {
+            if (Cesium.defined(billboardCollection)) {
+              scene.primitives.remove(billboardCollection);
+            }
 
-              billboardCollection.add({
-                position: ellipsoid.cartographicToCartesian(position),
-                image: "../images/facility.gif",
-                scale: scale,
-              });
+            billboardCollection = scene.primitives.add(
+              new Cesium.BillboardCollection({
+                scene: scene,
+              })
+            );
+
+            const gridSize = Math.sqrt(billboardCount);
+            for (let y = 0; y < gridSize; ++y) {
+              for (let x = 0; x < gridSize; ++x) {
+                const longitude = Cesium.Math.lerp(
+                  e.west,
+                  e.east,
+                  x / (gridSize - 1)
+                );
+                const latitude = Cesium.Math.lerp(
+                  e.south,
+                  e.north,
+                  y / (gridSize - 1)
+                );
+                const position = new Cesium.Cartographic(
+                  longitude,
+                  latitude,
+                  10000.0
+                );
+
+                billboardCollection.add({
+                  position: ellipsoid.cartographicToCartesian(position),
+                  image: "../images/facility.gif",
+                  scale: scale,
+                });
+              }
             }
           }
-        }
 
-        const moveAmount = new Cesium.Cartesian3(1000, 0.0, 0.0);
-        const positionScratch = new Cesium.Cartesian3();
-        function animateBillboards() {
-          const billboards = billboardCollection._billboards;
-          const length = billboards.length;
-          for (let i = 0; i < length; ++i) {
-            const billboard = billboards[i];
-            Cesium.Cartesian3.clone(billboard.position, positionScratch);
-            Cesium.Cartesian3.add(positionScratch, moveAmount, positionScratch);
-            billboard.position = positionScratch;
+          const moveAmount = new Cesium.Cartesian3(1000, 0.0, 0.0);
+          const positionScratch = new Cesium.Cartesian3();
+          function animateBillboards() {
+            const billboards = billboardCollection._billboards;
+            const length = billboards.length;
+            for (let i = 0; i < length; ++i) {
+              const billboard = billboards[i];
+              Cesium.Cartesian3.clone(billboard.position, positionScratch);
+              Cesium.Cartesian3.add(
+                positionScratch,
+                moveAmount,
+                positionScratch
+              );
+              billboard.position = positionScratch;
+            }
           }
-        }
 
-        Sandcastle.addToolbarMenu([
-          {
-            text: "Instancing Enabled",
-            onselect: function () {
-              if (!instancingEnabled) {
-                context._instancedArrays = instancedArraysExtension;
-                instancingEnabled = true;
+          Sandcastle.addToolbarMenu([
+            {
+              text: "Instancing Enabled",
+              onselect: function () {
+                if (!instancingEnabled) {
+                  context._instancedArrays = instancedArraysExtension;
+                  instancingEnabled = true;
+                  resetBillboardCollection();
+                }
+              },
+            },
+            {
+              text: "Instancing Disabled",
+              onselect: function () {
+                if (instancingEnabled) {
+                  context._instancedArrays = undefined;
+                  instancingEnabled = false;
+                  resetBillboardCollection();
+                }
+              },
+            },
+          ]);
+
+          Sandcastle.addToolbarMenu([
+            {
+              text: "100489 billboards",
+              onselect: function () {
+                billboardCount = 100489;
                 resetBillboardCollection();
-              }
+              },
             },
-          },
-          {
-            text: "Instancing Disabled",
-            onselect: function () {
-              if (instancingEnabled) {
-                context._instancedArrays = undefined;
-                instancingEnabled = false;
+            {
+              text: "10000 billboards",
+              onselect: function () {
+                billboardCount = 10000;
                 resetBillboardCollection();
-              }
+              },
             },
-          },
-        ]);
+            {
+              text: "1024 billboards",
+              onselect: function () {
+                billboardCount = 1024;
+                resetBillboardCollection();
+              },
+            },
+            {
+              text: "100 billboards",
+              onselect: function () {
+                billboardCount = 100;
+                resetBillboardCollection();
+              },
+            },
+            {
+              text: "25 billboards",
+              onselect: function () {
+                billboardCount = 25;
+                resetBillboardCollection();
+              },
+            },
+            {
+              text: "4 billboard",
+              onselect: function () {
+                billboardCount = 4;
+                resetBillboardCollection();
+              },
+            },
+          ]);
 
-        Sandcastle.addToolbarMenu([
-          {
-            text: "100489 billboards",
-            onselect: function () {
-              billboardCount = 100489;
-              resetBillboardCollection();
+          Sandcastle.addToolbarMenu([
+            {
+              text: "Static billboards",
+              onselect: function () {
+                resetBillboardCollection();
+                scene.preUpdate.removeEventListener(animateBillboards);
+              },
             },
-          },
-          {
-            text: "10000 billboards",
-            onselect: function () {
-              billboardCount = 10000;
-              resetBillboardCollection();
+            {
+              text: "Animated billboards",
+              onselect: function () {
+                resetBillboardCollection();
+                scene.preUpdate.addEventListener(animateBillboards);
+              },
             },
-          },
-          {
-            text: "1024 billboards",
-            onselect: function () {
-              billboardCount = 1024;
-              resetBillboardCollection();
-            },
-          },
-          {
-            text: "100 billboards",
-            onselect: function () {
-              billboardCount = 100;
-              resetBillboardCollection();
-            },
-          },
-          {
-            text: "25 billboards",
-            onselect: function () {
-              billboardCount = 25;
-              resetBillboardCollection();
-            },
-          },
-          {
-            text: "4 billboard",
-            onselect: function () {
-              billboardCount = 4;
-              resetBillboardCollection();
-            },
-          },
-        ]);
+          ]);
 
-        Sandcastle.addToolbarMenu([
-          {
-            text: "Static billboards",
-            onselect: function () {
-              resetBillboardCollection();
-              scene.preUpdate.removeEventListener(animateBillboards);
+          Sandcastle.addToolbarMenu([
+            {
+              text: "Scale : 1.0",
+              onselect: function () {
+                scale = 1.0;
+                resetBillboardCollection();
+              },
             },
-          },
-          {
-            text: "Animated billboards",
-            onselect: function () {
-              resetBillboardCollection();
-              scene.preUpdate.addEventListener(animateBillboards);
+            {
+              text: "Scale : 0.5",
+              onselect: function () {
+                scale = 0.5;
+                resetBillboardCollection();
+              },
             },
-          },
-        ]);
+            {
+              text: "Scale : 0.1",
+              onselect: function () {
+                scale = 0.1;
+                resetBillboardCollection();
+              },
+            },
+          ]);
 
-        Sandcastle.addToolbarMenu([
-          {
-            text: "Scale : 1.0",
-            onselect: function () {
-              scale = 1.0;
-              resetBillboardCollection();
-            },
-          },
-          {
-            text: "Scale : 0.5",
-            onselect: function () {
-              scale = 0.5;
-              resetBillboardCollection();
-            },
-          },
-          {
-            text: "Scale : 0.1",
-            onselect: function () {
-              scale = 0.1;
-              resetBillboardCollection();
-            },
-          },
-        ]);
-
-        resetBillboardCollection();
-
-        //Sandcastle_End
+          resetBillboardCollection();
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/development/Billboards Instancing.html
+++ b/Apps/Sandcastle/gallery/development/Billboards Instancing.html
@@ -37,201 +37,202 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        const viewer = new Cesium.Viewer("cesiumContainer");
+
         (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+          } catch (error) {
+            console.log(error);
+          }
+        })();
 
-          const scene = viewer.scene;
-          const context = scene.context;
+        const scene = viewer.scene;
+        const context = scene.context;
 
-          scene.debugShowFramesPerSecond = true;
+        scene.debugShowFramesPerSecond = true;
 
-          const ellipsoid = scene.globe.ellipsoid;
-          let billboardCollection;
-          let instancingEnabled = true;
-          const instancedArraysExtension = context._instancedArrays;
-          let billboardCount = 100489;
-          let scale = 1.0;
+        const ellipsoid = scene.globe.ellipsoid;
+        let billboardCollection;
+        let instancingEnabled = true;
+        const instancedArraysExtension = context._instancedArrays;
+        let billboardCount = 100489;
+        let scale = 1.0;
 
-          // seneca
-          const centerLongitude = -1.385205433269729;
-          const centerLatitude = 0.6777926580888163;
-          const rectangleHalfSize = 0.5;
-          const e = new Cesium.Rectangle(
-            centerLongitude - rectangleHalfSize,
-            centerLatitude - rectangleHalfSize,
-            centerLongitude + rectangleHalfSize,
-            centerLatitude + rectangleHalfSize
+        // seneca
+        const centerLongitude = -1.385205433269729;
+        const centerLatitude = 0.6777926580888163;
+        const rectangleHalfSize = 0.5;
+        const e = new Cesium.Rectangle(
+          centerLongitude - rectangleHalfSize,
+          centerLatitude - rectangleHalfSize,
+          centerLongitude + rectangleHalfSize,
+          centerLatitude + rectangleHalfSize
+        );
+
+        function resetBillboardCollection() {
+          if (Cesium.defined(billboardCollection)) {
+            scene.primitives.remove(billboardCollection);
+          }
+
+          billboardCollection = scene.primitives.add(
+            new Cesium.BillboardCollection({
+              scene: scene,
+            })
           );
 
-          function resetBillboardCollection() {
-            if (Cesium.defined(billboardCollection)) {
-              scene.primitives.remove(billboardCollection);
-            }
-
-            billboardCollection = scene.primitives.add(
-              new Cesium.BillboardCollection({
-                scene: scene,
-              })
-            );
-
-            const gridSize = Math.sqrt(billboardCount);
-            for (let y = 0; y < gridSize; ++y) {
-              for (let x = 0; x < gridSize; ++x) {
-                const longitude = Cesium.Math.lerp(
-                  e.west,
-                  e.east,
-                  x / (gridSize - 1)
-                );
-                const latitude = Cesium.Math.lerp(
-                  e.south,
-                  e.north,
-                  y / (gridSize - 1)
-                );
-                const position = new Cesium.Cartographic(
-                  longitude,
-                  latitude,
-                  10000.0
-                );
-
-                billboardCollection.add({
-                  position: ellipsoid.cartographicToCartesian(position),
-                  image: "../images/facility.gif",
-                  scale: scale,
-                });
-              }
-            }
-          }
-
-          const moveAmount = new Cesium.Cartesian3(1000, 0.0, 0.0);
-          const positionScratch = new Cesium.Cartesian3();
-          function animateBillboards() {
-            const billboards = billboardCollection._billboards;
-            const length = billboards.length;
-            for (let i = 0; i < length; ++i) {
-              const billboard = billboards[i];
-              Cesium.Cartesian3.clone(billboard.position, positionScratch);
-              Cesium.Cartesian3.add(
-                positionScratch,
-                moveAmount,
-                positionScratch
+          const gridSize = Math.sqrt(billboardCount);
+          for (let y = 0; y < gridSize; ++y) {
+            for (let x = 0; x < gridSize; ++x) {
+              const longitude = Cesium.Math.lerp(
+                e.west,
+                e.east,
+                x / (gridSize - 1)
               );
-              billboard.position = positionScratch;
+              const latitude = Cesium.Math.lerp(
+                e.south,
+                e.north,
+                y / (gridSize - 1)
+              );
+              const position = new Cesium.Cartographic(
+                longitude,
+                latitude,
+                10000.0
+              );
+
+              billboardCollection.add({
+                position: ellipsoid.cartographicToCartesian(position),
+                image: "../images/facility.gif",
+                scale: scale,
+              });
             }
           }
+        }
 
-          Sandcastle.addToolbarMenu([
-            {
-              text: "Instancing Enabled",
-              onselect: function () {
-                if (!instancingEnabled) {
-                  context._instancedArrays = instancedArraysExtension;
-                  instancingEnabled = true;
-                  resetBillboardCollection();
-                }
-              },
-            },
-            {
-              text: "Instancing Disabled",
-              onselect: function () {
-                if (instancingEnabled) {
-                  context._instancedArrays = undefined;
-                  instancingEnabled = false;
-                  resetBillboardCollection();
-                }
-              },
-            },
-          ]);
+        const moveAmount = new Cesium.Cartesian3(1000, 0.0, 0.0);
+        const positionScratch = new Cesium.Cartesian3();
+        function animateBillboards() {
+          const billboards = billboardCollection._billboards;
+          const length = billboards.length;
+          for (let i = 0; i < length; ++i) {
+            const billboard = billboards[i];
+            Cesium.Cartesian3.clone(billboard.position, positionScratch);
+            Cesium.Cartesian3.add(positionScratch, moveAmount, positionScratch);
+            billboard.position = positionScratch;
+          }
+        }
 
-          Sandcastle.addToolbarMenu([
-            {
-              text: "100489 billboards",
-              onselect: function () {
-                billboardCount = 100489;
+        Sandcastle.addToolbarMenu([
+          {
+            text: "Instancing Enabled",
+            onselect: function () {
+              if (!instancingEnabled) {
+                context._instancedArrays = instancedArraysExtension;
+                instancingEnabled = true;
                 resetBillboardCollection();
-              },
+              }
             },
-            {
-              text: "10000 billboards",
-              onselect: function () {
-                billboardCount = 10000;
+          },
+          {
+            text: "Instancing Disabled",
+            onselect: function () {
+              if (instancingEnabled) {
+                context._instancedArrays = undefined;
+                instancingEnabled = false;
                 resetBillboardCollection();
-              },
+              }
             },
-            {
-              text: "1024 billboards",
-              onselect: function () {
-                billboardCount = 1024;
-                resetBillboardCollection();
-              },
-            },
-            {
-              text: "100 billboards",
-              onselect: function () {
-                billboardCount = 100;
-                resetBillboardCollection();
-              },
-            },
-            {
-              text: "25 billboards",
-              onselect: function () {
-                billboardCount = 25;
-                resetBillboardCollection();
-              },
-            },
-            {
-              text: "4 billboard",
-              onselect: function () {
-                billboardCount = 4;
-                resetBillboardCollection();
-              },
-            },
-          ]);
+          },
+        ]);
 
-          Sandcastle.addToolbarMenu([
-            {
-              text: "Static billboards",
-              onselect: function () {
-                resetBillboardCollection();
-                scene.preUpdate.removeEventListener(animateBillboards);
-              },
+        Sandcastle.addToolbarMenu([
+          {
+            text: "100489 billboards",
+            onselect: function () {
+              billboardCount = 100489;
+              resetBillboardCollection();
             },
-            {
-              text: "Animated billboards",
-              onselect: function () {
-                resetBillboardCollection();
-                scene.preUpdate.addEventListener(animateBillboards);
-              },
+          },
+          {
+            text: "10000 billboards",
+            onselect: function () {
+              billboardCount = 10000;
+              resetBillboardCollection();
             },
-          ]);
+          },
+          {
+            text: "1024 billboards",
+            onselect: function () {
+              billboardCount = 1024;
+              resetBillboardCollection();
+            },
+          },
+          {
+            text: "100 billboards",
+            onselect: function () {
+              billboardCount = 100;
+              resetBillboardCollection();
+            },
+          },
+          {
+            text: "25 billboards",
+            onselect: function () {
+              billboardCount = 25;
+              resetBillboardCollection();
+            },
+          },
+          {
+            text: "4 billboard",
+            onselect: function () {
+              billboardCount = 4;
+              resetBillboardCollection();
+            },
+          },
+        ]);
 
-          Sandcastle.addToolbarMenu([
-            {
-              text: "Scale : 1.0",
-              onselect: function () {
-                scale = 1.0;
-                resetBillboardCollection();
-              },
+        Sandcastle.addToolbarMenu([
+          {
+            text: "Static billboards",
+            onselect: function () {
+              resetBillboardCollection();
+              scene.preUpdate.removeEventListener(animateBillboards);
             },
-            {
-              text: "Scale : 0.5",
-              onselect: function () {
-                scale = 0.5;
-                resetBillboardCollection();
-              },
+          },
+          {
+            text: "Animated billboards",
+            onselect: function () {
+              resetBillboardCollection();
+              scene.preUpdate.addEventListener(animateBillboards);
             },
-            {
-              text: "Scale : 0.1",
-              onselect: function () {
-                scale = 0.1;
-                resetBillboardCollection();
-              },
-            },
-          ]);
+          },
+        ]);
 
-          resetBillboardCollection();
-        })(); //Sandcastle_End
+        Sandcastle.addToolbarMenu([
+          {
+            text: "Scale : 1.0",
+            onselect: function () {
+              scale = 1.0;
+              resetBillboardCollection();
+            },
+          },
+          {
+            text: "Scale : 0.5",
+            onselect: function () {
+              scale = 0.5;
+              resetBillboardCollection();
+            },
+          },
+          {
+            text: "Scale : 0.1",
+            onselect: function () {
+              scale = 0.1;
+              resetBillboardCollection();
+            },
+          },
+        ]);
+
+        resetBillboardCollection();
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/development/Fog.html
+++ b/Apps/Sandcastle/gallery/development/Fog.html
@@ -50,95 +50,100 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        const viewer = new Cesium.Viewer("cesiumContainer");
+
         (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+          } catch (error) {
+            console.log(error);
+          }
+        })();
+
+        viewer.extend(Cesium.viewerCesiumInspectorMixin);
+
+        //The viewModel tracks the state of our mini application.
+        const viewModel = {
+          enabled: true,
+          density: 0,
+          sse: 0,
+        };
+        // Convert the viewModel members into knockout observables.
+        Cesium.knockout.track(viewModel);
+
+        // Bind the viewModel to the DOM elements of the UI that call for it.
+        const toolbar = document.getElementById("toolbar");
+        Cesium.knockout.applyBindings(viewModel, toolbar);
+
+        Cesium.knockout
+          .getObservable(viewModel, "enabled")
+          .subscribe(function (newValue) {
+            viewer.scene.fog.enabled = newValue;
           });
 
-          viewer.extend(Cesium.viewerCesiumInspectorMixin);
-
-          //The viewModel tracks the state of our mini application.
-          const viewModel = {
-            enabled: true,
-            density: 0,
-            sse: 0,
-          };
-          // Convert the viewModel members into knockout observables.
-          Cesium.knockout.track(viewModel);
-
-          // Bind the viewModel to the DOM elements of the UI that call for it.
-          const toolbar = document.getElementById("toolbar");
-          Cesium.knockout.applyBindings(viewModel, toolbar);
-
-          Cesium.knockout
-            .getObservable(viewModel, "enabled")
-            .subscribe(function (newValue) {
-              viewer.scene.fog.enabled = newValue;
-            });
-
-          Cesium.knockout
-            .getObservable(viewModel, "density")
-            .subscribe(function (newValue) {
-              viewer.scene.fog.density = newValue;
-            });
-
-          Cesium.knockout
-            .getObservable(viewModel, "sse")
-            .subscribe(function (newValue) {
-              viewer.scene.fog.screenSpaceErrorFactor = newValue;
-            });
-
-          viewModel.enabled = viewer.scene.fog.enabled;
-          viewModel.density = viewer.scene.fog.density;
-          viewModel.sse = viewer.scene.fog.screenSpaceErrorFactor;
-
-          Sandcastle.addToolbarButton("Horizon high altitude", function () {
-            viewer.camera.setView({
-              destination: new Cesium.Cartesian3(
-                -2467730.5740817646,
-                -4390507.315824514,
-                3906155.113316938
-              ),
-              orientation: {
-                heading: 4.492211521856625,
-                pitch: -0.2687139437696304,
-              },
-            });
+        Cesium.knockout
+          .getObservable(viewModel, "density")
+          .subscribe(function (newValue) {
+            viewer.scene.fog.density = newValue;
           });
 
-          Sandcastle.addToolbarButton("Horizon low altitude", function () {
-            viewer.camera.setView({
-              destination: new Cesium.Cartesian3(
-                -734001.9511656855,
-                -4214090.596769834,
-                4715898.125886317
-              ),
-              orientation: {
-                heading: 5.634257362559497,
-                pitch: -0.019548505785381032,
-              },
-            });
+        Cesium.knockout
+          .getObservable(viewModel, "sse")
+          .subscribe(function (newValue) {
+            viewer.scene.fog.screenSpaceErrorFactor = newValue;
           });
 
-          viewer.scene.globe._surface._debug.enableDebugOutput = true;
+        viewModel.enabled = viewer.scene.fog.enabled;
+        viewModel.density = viewer.scene.fog.density;
+        viewModel.sse = viewer.scene.fog.screenSpaceErrorFactor;
 
-          Sandcastle.addToolbarButton("Snap", function () {
-            const container = document.getElementById("cesiumContainer");
-            const tmpH = container.style.height;
-            const tmpW = container.style.width;
-
-            container.style.height = "600px";
-            container.style.width = "800px";
-
-            viewer.resize();
-            viewer.render();
-            window.open(viewer.canvas.toDataURL("image/png"));
-            container.style.height = tmpH;
-            container.style.width = tmpW;
-            viewer.resize();
-            viewer.render();
+        Sandcastle.addToolbarButton("Horizon high altitude", function () {
+          viewer.camera.setView({
+            destination: new Cesium.Cartesian3(
+              -2467730.5740817646,
+              -4390507.315824514,
+              3906155.113316938
+            ),
+            orientation: {
+              heading: 4.492211521856625,
+              pitch: -0.2687139437696304,
+            },
           });
-        })(); //Sandcastle_End
+        });
+
+        Sandcastle.addToolbarButton("Horizon low altitude", function () {
+          viewer.camera.setView({
+            destination: new Cesium.Cartesian3(
+              -734001.9511656855,
+              -4214090.596769834,
+              4715898.125886317
+            ),
+            orientation: {
+              heading: 5.634257362559497,
+              pitch: -0.019548505785381032,
+            },
+          });
+        });
+
+        viewer.scene.globe._surface._debug.enableDebugOutput = true;
+
+        Sandcastle.addToolbarButton("Snap", function () {
+          const container = document.getElementById("cesiumContainer");
+          const tmpH = container.style.height;
+          const tmpW = container.style.width;
+
+          container.style.height = "600px";
+          container.style.width = "800px";
+
+          viewer.resize();
+          viewer.render();
+          window.open(viewer.canvas.toDataURL("image/png"));
+          container.style.height = tmpH;
+          container.style.width = tmpW;
+          viewer.resize();
+          viewer.render();
+        });
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/development/Fog.html
+++ b/Apps/Sandcastle/gallery/development/Fog.html
@@ -51,7 +51,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         viewer.extend(Cesium.viewerCesiumInspectorMixin);

--- a/Apps/Sandcastle/gallery/development/Fog.html
+++ b/Apps/Sandcastle/gallery/development/Fog.html
@@ -50,95 +50,95 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
-
-        viewer.extend(Cesium.viewerCesiumInspectorMixin);
-
-        //The viewModel tracks the state of our mini application.
-        const viewModel = {
-          enabled: true,
-          density: 0,
-          sse: 0,
-        };
-        // Convert the viewModel members into knockout observables.
-        Cesium.knockout.track(viewModel);
-
-        // Bind the viewModel to the DOM elements of the UI that call for it.
-        const toolbar = document.getElementById("toolbar");
-        Cesium.knockout.applyBindings(viewModel, toolbar);
-
-        Cesium.knockout
-          .getObservable(viewModel, "enabled")
-          .subscribe(function (newValue) {
-            viewer.scene.fog.enabled = newValue;
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
           });
 
-        Cesium.knockout
-          .getObservable(viewModel, "density")
-          .subscribe(function (newValue) {
-            viewer.scene.fog.density = newValue;
+          viewer.extend(Cesium.viewerCesiumInspectorMixin);
+
+          //The viewModel tracks the state of our mini application.
+          const viewModel = {
+            enabled: true,
+            density: 0,
+            sse: 0,
+          };
+          // Convert the viewModel members into knockout observables.
+          Cesium.knockout.track(viewModel);
+
+          // Bind the viewModel to the DOM elements of the UI that call for it.
+          const toolbar = document.getElementById("toolbar");
+          Cesium.knockout.applyBindings(viewModel, toolbar);
+
+          Cesium.knockout
+            .getObservable(viewModel, "enabled")
+            .subscribe(function (newValue) {
+              viewer.scene.fog.enabled = newValue;
+            });
+
+          Cesium.knockout
+            .getObservable(viewModel, "density")
+            .subscribe(function (newValue) {
+              viewer.scene.fog.density = newValue;
+            });
+
+          Cesium.knockout
+            .getObservable(viewModel, "sse")
+            .subscribe(function (newValue) {
+              viewer.scene.fog.screenSpaceErrorFactor = newValue;
+            });
+
+          viewModel.enabled = viewer.scene.fog.enabled;
+          viewModel.density = viewer.scene.fog.density;
+          viewModel.sse = viewer.scene.fog.screenSpaceErrorFactor;
+
+          Sandcastle.addToolbarButton("Horizon high altitude", function () {
+            viewer.camera.setView({
+              destination: new Cesium.Cartesian3(
+                -2467730.5740817646,
+                -4390507.315824514,
+                3906155.113316938
+              ),
+              orientation: {
+                heading: 4.492211521856625,
+                pitch: -0.2687139437696304,
+              },
+            });
           });
 
-        Cesium.knockout
-          .getObservable(viewModel, "sse")
-          .subscribe(function (newValue) {
-            viewer.scene.fog.screenSpaceErrorFactor = newValue;
+          Sandcastle.addToolbarButton("Horizon low altitude", function () {
+            viewer.camera.setView({
+              destination: new Cesium.Cartesian3(
+                -734001.9511656855,
+                -4214090.596769834,
+                4715898.125886317
+              ),
+              orientation: {
+                heading: 5.634257362559497,
+                pitch: -0.019548505785381032,
+              },
+            });
           });
 
-        viewModel.enabled = viewer.scene.fog.enabled;
-        viewModel.density = viewer.scene.fog.density;
-        viewModel.sse = viewer.scene.fog.screenSpaceErrorFactor;
+          viewer.scene.globe._surface._debug.enableDebugOutput = true;
 
-        Sandcastle.addToolbarButton("Horizon high altitude", function () {
-          viewer.camera.setView({
-            destination: new Cesium.Cartesian3(
-              -2467730.5740817646,
-              -4390507.315824514,
-              3906155.113316938
-            ),
-            orientation: {
-              heading: 4.492211521856625,
-              pitch: -0.2687139437696304,
-            },
+          Sandcastle.addToolbarButton("Snap", function () {
+            const container = document.getElementById("cesiumContainer");
+            const tmpH = container.style.height;
+            const tmpW = container.style.width;
+
+            container.style.height = "600px";
+            container.style.width = "800px";
+
+            viewer.resize();
+            viewer.render();
+            window.open(viewer.canvas.toDataURL("image/png"));
+            container.style.height = tmpH;
+            container.style.width = tmpW;
+            viewer.resize();
+            viewer.render();
           });
-        });
-
-        Sandcastle.addToolbarButton("Horizon low altitude", function () {
-          viewer.camera.setView({
-            destination: new Cesium.Cartesian3(
-              -734001.9511656855,
-              -4214090.596769834,
-              4715898.125886317
-            ),
-            orientation: {
-              heading: 5.634257362559497,
-              pitch: -0.019548505785381032,
-            },
-          });
-        });
-
-        viewer.scene.globe._surface._debug.enableDebugOutput = true;
-
-        Sandcastle.addToolbarButton("Snap", function () {
-          const container = document.getElementById("cesiumContainer");
-          const tmpH = container.style.height;
-          const tmpW = container.style.width;
-
-          container.style.height = "600px";
-          container.style.width = "800px";
-
-          viewer.resize();
-          viewer.render();
-          window.open(viewer.canvas.toDataURL("image/png"));
-          container.style.height = tmpH;
-          container.style.width = tmpW;
-          viewer.resize();
-          viewer.render();
-        });
-
-        //Sandcastle_End
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/development/Ground Polyline Material.html
+++ b/Apps/Sandcastle/gallery/development/Ground Polyline Material.html
@@ -36,7 +36,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
         const scene = viewer.scene;
 

--- a/Apps/Sandcastle/gallery/development/Ground Polyline Material.html
+++ b/Apps/Sandcastle/gallery/development/Ground Polyline Material.html
@@ -35,90 +35,90 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
-        const scene = viewer.scene;
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
+          const scene = viewer.scene;
 
-        if (!Cesium.GroundPolylinePrimitive.isSupported(scene)) {
-          window.alert(
-            "Polylines on terrain are not supported on this platform."
+          if (!Cesium.GroundPolylinePrimitive.isSupported(scene)) {
+            window.alert(
+              "Polylines on terrain are not supported on this platform."
+            );
+          }
+
+          // Polyline Glow
+          scene.groundPrimitives.add(
+            new Cesium.GroundPolylinePrimitive({
+              geometryInstances: new Cesium.GeometryInstance({
+                geometry: new Cesium.GroundPolylineGeometry({
+                  positions: Cesium.Cartesian3.fromDegreesArray([
+                    -122.2558,
+                    46.1955,
+                    -122.1058,
+                    46.1955,
+                  ]),
+                  width: 10.0,
+                }),
+              }),
+              appearance: new Cesium.PolylineMaterialAppearance({
+                material: Cesium.Material.fromType(
+                  Cesium.Material.PolylineGlowType
+                ),
+              }),
+            })
           );
-        }
 
-        // Polyline Glow
-        scene.groundPrimitives.add(
-          new Cesium.GroundPolylinePrimitive({
-            geometryInstances: new Cesium.GeometryInstance({
-              geometry: new Cesium.GroundPolylineGeometry({
-                positions: Cesium.Cartesian3.fromDegreesArray([
-                  -122.2558,
-                  46.1955,
-                  -122.1058,
-                  46.1955,
-                ]),
-                width: 10.0,
+          // Polyline Dash
+          scene.groundPrimitives.add(
+            new Cesium.GroundPolylinePrimitive({
+              geometryInstances: new Cesium.GeometryInstance({
+                geometry: new Cesium.GroundPolylineGeometry({
+                  positions: Cesium.Cartesian3.fromDegreesArray([
+                    -122.2558,
+                    46.1975,
+                    -122.1058,
+                    46.1975,
+                  ]),
+                  width: 10.0,
+                }),
               }),
-            }),
-            appearance: new Cesium.PolylineMaterialAppearance({
-              material: Cesium.Material.fromType(
-                Cesium.Material.PolylineGlowType
-              ),
-            }),
-          })
-        );
-
-        // Polyline Dash
-        scene.groundPrimitives.add(
-          new Cesium.GroundPolylinePrimitive({
-            geometryInstances: new Cesium.GeometryInstance({
-              geometry: new Cesium.GroundPolylineGeometry({
-                positions: Cesium.Cartesian3.fromDegreesArray([
-                  -122.2558,
-                  46.1975,
-                  -122.1058,
-                  46.1975,
-                ]),
-                width: 10.0,
+              appearance: new Cesium.PolylineMaterialAppearance({
+                material: Cesium.Material.fromType(
+                  Cesium.Material.PolylineDashType
+                ),
               }),
-            }),
-            appearance: new Cesium.PolylineMaterialAppearance({
-              material: Cesium.Material.fromType(
-                Cesium.Material.PolylineDashType
-              ),
-            }),
-          })
-        );
+            })
+          );
 
-        // Polyline Outline
-        scene.groundPrimitives.add(
-          new Cesium.GroundPolylinePrimitive({
-            geometryInstances: new Cesium.GeometryInstance({
-              geometry: new Cesium.GroundPolylineGeometry({
-                positions: Cesium.Cartesian3.fromDegreesArray([
-                  -122.2558,
-                  46.1995,
-                  -122.1058,
-                  46.1995,
-                ]),
-                width: 10.0,
+          // Polyline Outline
+          scene.groundPrimitives.add(
+            new Cesium.GroundPolylinePrimitive({
+              geometryInstances: new Cesium.GeometryInstance({
+                geometry: new Cesium.GroundPolylineGeometry({
+                  positions: Cesium.Cartesian3.fromDegreesArray([
+                    -122.2558,
+                    46.1995,
+                    -122.1058,
+                    46.1995,
+                  ]),
+                  width: 10.0,
+                }),
               }),
-            }),
-            appearance: new Cesium.PolylineMaterialAppearance({
-              material: Cesium.Material.fromType(
-                Cesium.Material.PolylineOutlineType
-              ),
-            }),
-          })
-        );
+              appearance: new Cesium.PolylineMaterialAppearance({
+                material: Cesium.Material.fromType(
+                  Cesium.Material.PolylineOutlineType
+                ),
+              }),
+            })
+          );
 
-        viewer.camera.lookAt(
-          Cesium.Cartesian3.fromDegrees(-122.2058, 46.1955, 1000.0),
-          new Cesium.Cartesian3(5000.0, 5000.0, 5000.0)
-        );
-        viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-
-        //Sandcastle_End
+          viewer.camera.lookAt(
+            Cesium.Cartesian3.fromDegrees(-122.2058, 46.1955, 1000.0),
+            new Cesium.Cartesian3(5000.0, 5000.0, 5000.0)
+          );
+          viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/development/Ground Primitive Materials.html
+++ b/Apps/Sandcastle/gallery/development/Ground Primitive Materials.html
@@ -35,522 +35,525 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        const viewer = new Cesium.Viewer("cesiumContainer");
+
         (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync({
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync({
               requestWaterMask: true,
               requestVertexNormals: true,
-            }),
+            });
+          } catch (error) {
+            console.log(error);
+          }
+        })();
+
+        if (!Cesium.GroundPrimitive.supportsMaterials(viewer.scene)) {
+          window.alert(
+            "GroundPrimitive materials are not supported on this platform."
+          );
+        }
+
+        let rectangle;
+        let worldRectangle;
+
+        function applyAlphaMapMaterial(primitive, scene) {
+          Sandcastle.declare(applyAlphaMapMaterial); // For highlighting in Sandcastle.
+          primitive.appearance.material = new Cesium.Material({
+            fabric: {
+              materials: {
+                alphaMaterial: {
+                  type: "AlphaMap",
+                  uniforms: {
+                    image: "../images/Cesium_Logo_Color.jpg",
+                    channel: "r",
+                  },
+                },
+              },
+              components: {
+                diffuse: "vec3(1.0)",
+                alpha: "alphaMaterial.alpha",
+              },
+            },
           });
+        }
 
-          if (!Cesium.GroundPrimitive.supportsMaterials(viewer.scene)) {
-            window.alert(
-              "GroundPrimitive materials are not supported on this platform."
-            );
-          }
+        function applyBumpMapMaterial(primitive, scene) {
+          Sandcastle.declare(applyBumpMapMaterial); // For highlighting in Sandcastle.
+          primitive.appearance.material = new Cesium.Material({
+            fabric: {
+              materials: {
+                diffuseMaterial: {
+                  type: "DiffuseMap",
+                  uniforms: {
+                    image: "../images/bumpmap.png",
+                  },
+                },
+                bumpMaterial: {
+                  type: "BumpMap",
+                  uniforms: {
+                    image: "../images/bumpmap.png",
+                    strength: 0.8,
+                  },
+                },
+              },
+              components: {
+                diffuse: "diffuseMaterial.diffuse",
+                specular: 0.01,
+                normal: "bumpMaterial.normal",
+              },
+            },
+          });
+        }
 
-          let rectangle;
-          let worldRectangle;
+        function applyCheckerboardMaterial(primitive, scene) {
+          Sandcastle.declare(applyCheckerboardMaterial); // For highlighting in Sandcastle.
+          primitive.appearance.material = Cesium.Material.fromType(
+            "Checkerboard"
+          );
+        }
 
-          function applyAlphaMapMaterial(primitive, scene) {
-            Sandcastle.declare(applyAlphaMapMaterial); // For highlighting in Sandcastle.
-            primitive.appearance.material = new Cesium.Material({
-              fabric: {
-                materials: {
-                  alphaMaterial: {
-                    type: "AlphaMap",
-                    uniforms: {
-                      image: "../images/Cesium_Logo_Color.jpg",
-                      channel: "r",
+        function applyColorMaterial(primitive, scene) {
+          Sandcastle.declare(applyColorMaterial); // For highlighting in Sandcastle.
+          primitive.appearance.material = Cesium.Material.fromType("Color");
+        }
+
+        function applyCompositeMaterial(primitive, scene) {
+          Sandcastle.declare(applyCompositeMaterial); // For highlighting in Sandcastle.
+          primitive.appearance.material = new Cesium.Material({
+            fabric: {
+              uniforms: {
+                image: "../images/earthspec1k.jpg",
+                heightField: "../images/earthbump1k.jpg",
+              },
+              materials: {
+                bumpMap: {
+                  type: "BumpMap",
+                  uniforms: {
+                    image: "../images/earthbump1k.jpg",
+                  },
+                },
+              },
+              source:
+                "czm_material czm_getMaterial(czm_materialInput materialInput) {" +
+                "czm_material material = czm_getDefaultMaterial(materialInput);" +
+                "float heightValue = texture2D(heightField, materialInput.st).r;" +
+                "material.diffuse = mix(vec3(0.2, 0.6, 0.2), vec3(1.0, 0.5, 0.2), heightValue);" +
+                "material.alpha = (1.0 - texture2D(image, materialInput.st).r) * 0.7;" +
+                "material.normal = bumpMap.normal;" +
+                "material.specular = step(0.1, heightValue);" + // Specular mountain tops
+                "material.shininess = 8.0;" + // Sharpen highlight
+                "return material;" +
+                "}",
+            },
+          });
+        }
+
+        function applyDotMaterial(primitive, scene) {
+          Sandcastle.declare(applyDotMaterial); // For highlighting in Sandcastle.
+          primitive.appearance.material = Cesium.Material.fromType("Dot");
+        }
+
+        function applyDiffuseMaterial(primitive, scene) {
+          Sandcastle.declare(applyDiffuseMaterial); // For highlighting in Sandcastle.
+          primitive.appearance.material = new Cesium.Material({
+            fabric: {
+              type: "DiffuseMap",
+              uniforms: {
+                image: "../images/Cesium_Logo_Color.jpg",
+              },
+            },
+          });
+        }
+
+        function applyEmissionMapMaterial(primitive, scene) {
+          Sandcastle.declare(applyEmissionMapMaterial); // For highlighting in Sandcastle.
+          primitive.appearance.material = new Cesium.Material({
+            fabric: {
+              materials: {
+                diffuseMaterial: {
+                  type: "DiffuseMap",
+                  uniforms: {
+                    image: "../images/Cesium_Logo_Color.jpg",
+                  },
+                },
+                emissionMaterial: {
+                  type: "EmissionMap",
+                  uniforms: {
+                    image: "../images/checkerboard.png",
+                    repeat: {
+                      x: 1,
+                      y: 0.5,
                     },
                   },
                 },
-                components: {
-                  diffuse: "vec3(1.0)",
-                  alpha: "alphaMaterial.alpha",
+              },
+              components: {
+                diffuse: "diffuseMaterial.diffuse",
+                emission: "emissionMaterial.emission * 0.2",
+              },
+            },
+          });
+        }
+
+        function applyWaterMaterial(primitive, scene) {
+          Sandcastle.declare(applyWaterMaterial); // For highlighting in Sandcastle.
+
+          primitive.appearance.material = new Cesium.Material({
+            fabric: {
+              type: "Water",
+              uniforms: {
+                specularMap: "../images/earthspec1k.jpg",
+                normalMap: Cesium.buildModuleUrl(
+                  "Assets/Textures/waterNormals.jpg"
+                ),
+                frequency: 10000.0,
+                animationSpeed: 0.01,
+                amplitude: 1.0,
+              },
+            },
+          });
+        }
+
+        function applyGridMaterial(primitive, scene) {
+          Sandcastle.declare(applyGridMaterial); // For highlighting in Sandcastle.
+          primitive.appearance.material = Cesium.Material.fromType("Grid");
+        }
+
+        function applyImageMaterial(primitive, scene) {
+          Sandcastle.declare(applyImageMaterial); // For highlighting in Sandcastle.
+          primitive.appearance.material = new Cesium.Material({
+            fabric: {
+              type: "Image",
+              uniforms: {
+                image: "../images/Cesium_Logo_Color.jpg",
+              },
+            },
+          });
+        }
+
+        function applyRepeatedImage(primitive, scene) {
+          Sandcastle.declare(applyRepeatedImage); // For highlighting in Sandcastle.
+          primitive.appearance.material = new Cesium.Material({
+            fabric: {
+              type: "Image",
+              uniforms: {
+                image: "../images/Cesium_Logo_Color.jpg",
+                repeat: {
+                  x: 10,
+                  y: 2,
                 },
               },
-            });
-          }
+            },
+          });
+        }
 
-          function applyBumpMapMaterial(primitive, scene) {
-            Sandcastle.declare(applyBumpMapMaterial); // For highlighting in Sandcastle.
-            primitive.appearance.material = new Cesium.Material({
-              fabric: {
-                materials: {
-                  diffuseMaterial: {
-                    type: "DiffuseMap",
-                    uniforms: {
-                      image: "../images/bumpmap.png",
-                    },
-                  },
-                  bumpMaterial: {
-                    type: "BumpMap",
-                    uniforms: {
-                      image: "../images/bumpmap.png",
-                      strength: 0.8,
-                    },
-                  },
-                },
-                components: {
-                  diffuse: "diffuseMaterial.diffuse",
-                  specular: 0.01,
-                  normal: "bumpMaterial.normal",
-                },
-              },
-            });
-          }
-
-          function applyCheckerboardMaterial(primitive, scene) {
-            Sandcastle.declare(applyCheckerboardMaterial); // For highlighting in Sandcastle.
-            primitive.appearance.material = Cesium.Material.fromType(
-              "Checkerboard"
-            );
-          }
-
-          function applyColorMaterial(primitive, scene) {
-            Sandcastle.declare(applyColorMaterial); // For highlighting in Sandcastle.
-            primitive.appearance.material = Cesium.Material.fromType("Color");
-          }
-
-          function applyCompositeMaterial(primitive, scene) {
-            Sandcastle.declare(applyCompositeMaterial); // For highlighting in Sandcastle.
-            primitive.appearance.material = new Cesium.Material({
-              fabric: {
-                uniforms: {
-                  image: "../images/earthspec1k.jpg",
-                  heightField: "../images/earthbump1k.jpg",
-                },
-                materials: {
-                  bumpMap: {
-                    type: "BumpMap",
-                    uniforms: {
-                      image: "../images/earthbump1k.jpg",
-                    },
-                  },
-                },
-                source:
-                  "czm_material czm_getMaterial(czm_materialInput materialInput) {" +
-                  "czm_material material = czm_getDefaultMaterial(materialInput);" +
-                  "float heightValue = texture2D(heightField, materialInput.st).r;" +
-                  "material.diffuse = mix(vec3(0.2, 0.6, 0.2), vec3(1.0, 0.5, 0.2), heightValue);" +
-                  "material.alpha = (1.0 - texture2D(image, materialInput.st).r) * 0.7;" +
-                  "material.normal = bumpMap.normal;" +
-                  "material.specular = step(0.1, heightValue);" + // Specular mountain tops
-                  "material.shininess = 8.0;" + // Sharpen highlight
-                  "return material;" +
-                  "}",
-              },
-            });
-          }
-
-          function applyDotMaterial(primitive, scene) {
-            Sandcastle.declare(applyDotMaterial); // For highlighting in Sandcastle.
-            primitive.appearance.material = Cesium.Material.fromType("Dot");
-          }
-
-          function applyDiffuseMaterial(primitive, scene) {
-            Sandcastle.declare(applyDiffuseMaterial); // For highlighting in Sandcastle.
-            primitive.appearance.material = new Cesium.Material({
-              fabric: {
-                type: "DiffuseMap",
-                uniforms: {
-                  image: "../images/Cesium_Logo_Color.jpg",
-                },
-              },
-            });
-          }
-
-          function applyEmissionMapMaterial(primitive, scene) {
-            Sandcastle.declare(applyEmissionMapMaterial); // For highlighting in Sandcastle.
-            primitive.appearance.material = new Cesium.Material({
-              fabric: {
-                materials: {
-                  diffuseMaterial: {
-                    type: "DiffuseMap",
-                    uniforms: {
-                      image: "../images/Cesium_Logo_Color.jpg",
-                    },
-                  },
-                  emissionMaterial: {
-                    type: "EmissionMap",
-                    uniforms: {
-                      image: "../images/checkerboard.png",
-                      repeat: {
-                        x: 1,
-                        y: 0.5,
-                      },
-                    },
+        function applyNormalMapMaterial(primitive, scene) {
+          Sandcastle.declare(applyNormalMapMaterial); // For highlighting in Sandcastle.
+          primitive.appearance.material = new Cesium.Material({
+            fabric: {
+              materials: {
+                diffuseMaterial: {
+                  type: "DiffuseMap",
+                  uniforms: {
+                    image: "../images/bumpmap.png",
                   },
                 },
-                components: {
-                  diffuse: "diffuseMaterial.diffuse",
-                  emission: "emissionMaterial.emission * 0.2",
-                },
-              },
-            });
-          }
-
-          function applyWaterMaterial(primitive, scene) {
-            Sandcastle.declare(applyWaterMaterial); // For highlighting in Sandcastle.
-
-            primitive.appearance.material = new Cesium.Material({
-              fabric: {
-                type: "Water",
-                uniforms: {
-                  specularMap: "../images/earthspec1k.jpg",
-                  normalMap: Cesium.buildModuleUrl(
-                    "Assets/Textures/waterNormals.jpg"
-                  ),
-                  frequency: 10000.0,
-                  animationSpeed: 0.01,
-                  amplitude: 1.0,
-                },
-              },
-            });
-          }
-
-          function applyGridMaterial(primitive, scene) {
-            Sandcastle.declare(applyGridMaterial); // For highlighting in Sandcastle.
-            primitive.appearance.material = Cesium.Material.fromType("Grid");
-          }
-
-          function applyImageMaterial(primitive, scene) {
-            Sandcastle.declare(applyImageMaterial); // For highlighting in Sandcastle.
-            primitive.appearance.material = new Cesium.Material({
-              fabric: {
-                type: "Image",
-                uniforms: {
-                  image: "../images/Cesium_Logo_Color.jpg",
-                },
-              },
-            });
-          }
-
-          function applyRepeatedImage(primitive, scene) {
-            Sandcastle.declare(applyRepeatedImage); // For highlighting in Sandcastle.
-            primitive.appearance.material = new Cesium.Material({
-              fabric: {
-                type: "Image",
-                uniforms: {
-                  image: "../images/Cesium_Logo_Color.jpg",
-                  repeat: {
-                    x: 10,
-                    y: 2,
+                normalMap: {
+                  type: "NormalMap",
+                  uniforms: {
+                    image: "../images/normalmap.png",
+                    strength: 0.6,
                   },
                 },
               },
-            });
+              components: {
+                diffuse: "diffuseMaterial.diffuse",
+                specular: 0.01,
+                normal: "normalMap.normal",
+              },
+            },
+          });
+        }
+
+        function applySpecularMapMaterial(primitive, scene) {
+          Sandcastle.declare(applySpecularMapMaterial); // For highlighting in Sandcastle.
+          primitive.appearance.material = new Cesium.Material({
+            fabric: {
+              type: "SpecularMap",
+              uniforms: {
+                image: "../images/Cesium_Logo_Color.jpg",
+                channel: "r",
+              },
+            },
+          });
+        }
+
+        function applyStripeMaterial(primitive, scene) {
+          Sandcastle.declare(applyStripeMaterial); // For highlighting in Sandcastle.
+          primitive.appearance.material = Cesium.Material.fromType("Stripe");
+        }
+
+        function applyRimLightingMaterial(primitive, scene) {
+          Sandcastle.declare(applyRimLightingMaterial); // For highlighting in Sandcastle.
+          primitive.appearance.material = Cesium.Material.fromType(
+            "RimLighting"
+          );
+        }
+
+        function createButtons(scene) {
+          function toggleRectangleVisibility() {
+            rectangle.show = true;
+            worldRectangle.show = false;
           }
 
-          function applyNormalMapMaterial(primitive, scene) {
-            Sandcastle.declare(applyNormalMapMaterial); // For highlighting in Sandcastle.
-            primitive.appearance.material = new Cesium.Material({
-              fabric: {
-                materials: {
-                  diffuseMaterial: {
-                    type: "DiffuseMap",
-                    uniforms: {
-                      image: "../images/bumpmap.png",
-                    },
-                  },
-                  normalMap: {
-                    type: "NormalMap",
-                    uniforms: {
-                      image: "../images/normalmap.png",
-                      strength: 0.6,
-                    },
-                  },
-                },
-                components: {
-                  diffuse: "diffuseMaterial.diffuse",
-                  specular: 0.01,
-                  normal: "normalMap.normal",
-                },
-              },
-            });
+          function toggleWorldRectangleVisibility() {
+            worldRectangle.show = true;
+            rectangle.show = false;
           }
 
-          function applySpecularMapMaterial(primitive, scene) {
-            Sandcastle.declare(applySpecularMapMaterial); // For highlighting in Sandcastle.
-            primitive.appearance.material = new Cesium.Material({
-              fabric: {
-                type: "SpecularMap",
-                uniforms: {
-                  image: "../images/Cesium_Logo_Color.jpg",
-                  channel: "r",
-                },
+          Sandcastle.addToolbarMenu([
+            {
+              text: "Common materials",
+            },
+            {
+              text: "Color",
+              onselect: function () {
+                toggleRectangleVisibility();
+                applyColorMaterial(rectangle, scene);
+                Sandcastle.highlight(applyColorMaterial);
               },
-            });
-          }
+            },
+            {
+              text: "Image",
+              onselect: function () {
+                toggleRectangleVisibility();
+                applyImageMaterial(rectangle, scene);
+                Sandcastle.highlight(applyImageMaterial);
+              },
+            },
+            {
+              text: "Repeated/Rotated Image",
+              onselect: function () {
+                toggleRectangleVisibility();
+                applyRepeatedImage(rectangle, scene);
+                Sandcastle.highlight(applyRepeatedImage);
+              },
+            },
+          ]);
 
-          function applyStripeMaterial(primitive, scene) {
-            Sandcastle.declare(applyStripeMaterial); // For highlighting in Sandcastle.
-            primitive.appearance.material = Cesium.Material.fromType("Stripe");
-          }
+          Sandcastle.addToolbarMenu([
+            {
+              text: "Procedural textures",
+            },
+            {
+              text: "Checkerboard",
+              onselect: function () {
+                toggleRectangleVisibility();
+                applyCheckerboardMaterial(rectangle, scene);
+                Sandcastle.highlight(applyCheckerboardMaterial);
+              },
+            },
+            {
+              text: "Dot",
+              onselect: function () {
+                toggleRectangleVisibility();
+                applyDotMaterial(rectangle, scene);
+                Sandcastle.highlight(applyDotMaterial);
+              },
+            },
+            {
+              text: "Grid",
+              onselect: function () {
+                toggleRectangleVisibility(rectangle, worldRectangle);
+                applyGridMaterial(rectangle, scene);
+                Sandcastle.highlight(applyGridMaterial);
+              },
+            },
+            {
+              text: "Stripe",
+              onselect: function () {
+                toggleRectangleVisibility();
+                applyStripeMaterial(rectangle, scene);
+                Sandcastle.highlight(applyStripeMaterial);
+              },
+            },
+          ]);
 
-          function applyRimLightingMaterial(primitive, scene) {
-            Sandcastle.declare(applyRimLightingMaterial); // For highlighting in Sandcastle.
-            primitive.appearance.material = Cesium.Material.fromType(
-              "RimLighting"
-            );
-          }
+          Sandcastle.addToolbarMenu([
+            {
+              text: "Base materials",
+            },
+            {
+              text: "Alpha Map",
+              onselect: function () {
+                toggleRectangleVisibility();
+                applyAlphaMapMaterial(rectangle, scene);
+                Sandcastle.highlight(applyAlphaMapMaterial);
+              },
+            },
+            {
+              text: "Bump Map",
+              onselect: function () {
+                toggleRectangleVisibility();
+                applyBumpMapMaterial(rectangle, scene);
+                Sandcastle.highlight(applyBumpMapMaterial);
+              },
+            },
+            {
+              text: "Diffuse",
+              onselect: function () {
+                toggleRectangleVisibility();
+                applyDiffuseMaterial(rectangle, scene);
+                Sandcastle.highlight(applyDiffuseMaterial);
+              },
+            },
+            {
+              text: "Emission Map",
+              onselect: function () {
+                toggleRectangleVisibility();
+                applyEmissionMapMaterial(rectangle, scene);
+                Sandcastle.highlight(applyEmissionMapMaterial);
+              },
+            },
+            {
+              text: "Normal Map",
+              onselect: function () {
+                toggleRectangleVisibility();
+                applyNormalMapMaterial(rectangle, scene);
+                Sandcastle.highlight(applyNormalMapMaterial);
+              },
+            },
+            {
+              text: "Specular Map",
+              onselect: function () {
+                toggleRectangleVisibility();
+                applySpecularMapMaterial(rectangle, scene);
+                Sandcastle.highlight(applySpecularMapMaterial);
+              },
+            },
+          ]);
 
-          function createButtons(scene) {
-            function toggleRectangleVisibility() {
-              rectangle.show = true;
-              worldRectangle.show = false;
-            }
+          Sandcastle.addToolbarMenu([
+            {
+              text: "Misc materials",
+            },
+            {
+              text: "Rim Lighting",
+              onselect: function () {
+                toggleWorldRectangleVisibility();
+                applyRimLightingMaterial(worldRectangle, scene);
+                Sandcastle.highlight(applyRimLightingMaterial);
+              },
+            },
+            {
+              text: "Water",
+              onselect: function () {
+                toggleWorldRectangleVisibility();
+                applyWaterMaterial(worldRectangle, scene);
+                Sandcastle.highlight(applyWaterMaterial);
+              },
+            },
+          ]);
 
-            function toggleWorldRectangleVisibility() {
-              worldRectangle.show = true;
-              rectangle.show = false;
-            }
+          Sandcastle.addToolbarMenu([
+            {
+              text: "Example composite materials",
+            },
+            {
+              text: "Composite Example",
+              onselect: function () {
+                toggleWorldRectangleVisibility();
+                applyCompositeMaterial(worldRectangle, scene);
+                Sandcastle.highlight(applyCompositeMaterial);
+              },
+            },
+          ]);
 
-            Sandcastle.addToolbarMenu([
-              {
-                text: "Common materials",
-              },
-              {
-                text: "Color",
-                onselect: function () {
-                  toggleRectangleVisibility();
-                  applyColorMaterial(rectangle, scene);
-                  Sandcastle.highlight(applyColorMaterial);
-                },
-              },
-              {
-                text: "Image",
-                onselect: function () {
-                  toggleRectangleVisibility();
-                  applyImageMaterial(rectangle, scene);
-                  Sandcastle.highlight(applyImageMaterial);
-                },
-              },
-              {
-                text: "Repeated/Rotated Image",
-                onselect: function () {
-                  toggleRectangleVisibility();
-                  applyRepeatedImage(rectangle, scene);
-                  Sandcastle.highlight(applyRepeatedImage);
-                },
-              },
-            ]);
+          document.getElementById("toolbar").style.width = "10%";
+        }
 
-            Sandcastle.addToolbarMenu([
-              {
-                text: "Procedural textures",
-              },
-              {
-                text: "Checkerboard",
-                onselect: function () {
-                  toggleRectangleVisibility();
-                  applyCheckerboardMaterial(rectangle, scene);
-                  Sandcastle.highlight(applyCheckerboardMaterial);
-                },
-              },
-              {
-                text: "Dot",
-                onselect: function () {
-                  toggleRectangleVisibility();
-                  applyDotMaterial(rectangle, scene);
-                  Sandcastle.highlight(applyDotMaterial);
-                },
-              },
-              {
-                text: "Grid",
-                onselect: function () {
-                  toggleRectangleVisibility(rectangle, worldRectangle);
-                  applyGridMaterial(rectangle, scene);
-                  Sandcastle.highlight(applyGridMaterial);
-                },
-              },
-              {
-                text: "Stripe",
-                onselect: function () {
-                  toggleRectangleVisibility();
-                  applyStripeMaterial(rectangle, scene);
-                  Sandcastle.highlight(applyStripeMaterial);
-                },
-              },
-            ]);
-
-            Sandcastle.addToolbarMenu([
-              {
-                text: "Base materials",
-              },
-              {
-                text: "Alpha Map",
-                onselect: function () {
-                  toggleRectangleVisibility();
-                  applyAlphaMapMaterial(rectangle, scene);
-                  Sandcastle.highlight(applyAlphaMapMaterial);
-                },
-              },
-              {
-                text: "Bump Map",
-                onselect: function () {
-                  toggleRectangleVisibility();
-                  applyBumpMapMaterial(rectangle, scene);
-                  Sandcastle.highlight(applyBumpMapMaterial);
-                },
-              },
-              {
-                text: "Diffuse",
-                onselect: function () {
-                  toggleRectangleVisibility();
-                  applyDiffuseMaterial(rectangle, scene);
-                  Sandcastle.highlight(applyDiffuseMaterial);
-                },
-              },
-              {
-                text: "Emission Map",
-                onselect: function () {
-                  toggleRectangleVisibility();
-                  applyEmissionMapMaterial(rectangle, scene);
-                  Sandcastle.highlight(applyEmissionMapMaterial);
-                },
-              },
-              {
-                text: "Normal Map",
-                onselect: function () {
-                  toggleRectangleVisibility();
-                  applyNormalMapMaterial(rectangle, scene);
-                  Sandcastle.highlight(applyNormalMapMaterial);
-                },
-              },
-              {
-                text: "Specular Map",
-                onselect: function () {
-                  toggleRectangleVisibility();
-                  applySpecularMapMaterial(rectangle, scene);
-                  Sandcastle.highlight(applySpecularMapMaterial);
-                },
-              },
-            ]);
-
-            Sandcastle.addToolbarMenu([
-              {
-                text: "Misc materials",
-              },
-              {
-                text: "Rim Lighting",
-                onselect: function () {
-                  toggleWorldRectangleVisibility();
-                  applyRimLightingMaterial(worldRectangle, scene);
-                  Sandcastle.highlight(applyRimLightingMaterial);
-                },
-              },
-              {
-                text: "Water",
-                onselect: function () {
-                  toggleWorldRectangleVisibility();
-                  applyWaterMaterial(worldRectangle, scene);
-                  Sandcastle.highlight(applyWaterMaterial);
-                },
-              },
-            ]);
-
-            Sandcastle.addToolbarMenu([
-              {
-                text: "Example composite materials",
-              },
-              {
-                text: "Composite Example",
-                onselect: function () {
-                  toggleWorldRectangleVisibility();
-                  applyCompositeMaterial(worldRectangle, scene);
-                  Sandcastle.highlight(applyCompositeMaterial);
-                },
-              },
-            ]);
-
-            document.getElementById("toolbar").style.width = "10%";
-          }
-
-          function createPrimitives(scene) {
-            rectangle = scene.primitives.add(
-              new Cesium.GroundPrimitive({
-                geometryInstances: new Cesium.GeometryInstance({
-                  geometry: new Cesium.RectangleGeometry({
-                    rectangle: Cesium.Rectangle.fromCartesianArray([
-                      new Cesium.Cartesian3(
-                        -2358138.847340281,
-                        -3744072.459541374,
-                        4581158.5714175375
-                      ),
-                      new Cesium.Cartesian3(
-                        -2357231.4925370603,
-                        -3745103.7886602185,
-                        4580702.9757762635
-                      ),
-                      new Cesium.Cartesian3(
-                        -2355912.902205431,
-                        -3744249.029778454,
-                        4582402.154378103
-                      ),
-                      new Cesium.Cartesian3(
-                        -2357208.0209552636,
-                        -3743553.4420488174,
-                        4581961.863286629
-                      ),
-                    ]),
-                    vertexFormat:
-                      Cesium.EllipsoidSurfaceAppearance.VERTEX_FORMAT,
-                  }),
-                }),
-                appearance: new Cesium.EllipsoidSurfaceAppearance({
-                  aboveGround: false,
-                }),
-                classificationType: Cesium.ClassificationType.TERRAIN,
-              })
-            );
-
-            worldRectangle = scene.primitives.add(
-              new Cesium.GroundPrimitive({
-                geometryInstances: new Cesium.GeometryInstance({
-                  geometry: new Cesium.RectangleGeometry({
-                    rectangle: Cesium.Rectangle.fromDegrees(
-                      -179.99,
-                      -89.99,
-                      179.99,
-                      89.99
+        function createPrimitives(scene) {
+          rectangle = scene.primitives.add(
+            new Cesium.GroundPrimitive({
+              geometryInstances: new Cesium.GeometryInstance({
+                geometry: new Cesium.RectangleGeometry({
+                  rectangle: Cesium.Rectangle.fromCartesianArray([
+                    new Cesium.Cartesian3(
+                      -2358138.847340281,
+                      -3744072.459541374,
+                      4581158.5714175375
                     ),
-                    vertexFormat:
-                      Cesium.EllipsoidSurfaceAppearance.VERTEX_FORMAT,
-                  }),
+                    new Cesium.Cartesian3(
+                      -2357231.4925370603,
+                      -3745103.7886602185,
+                      4580702.9757762635
+                    ),
+                    new Cesium.Cartesian3(
+                      -2355912.902205431,
+                      -3744249.029778454,
+                      4582402.154378103
+                    ),
+                    new Cesium.Cartesian3(
+                      -2357208.0209552636,
+                      -3743553.4420488174,
+                      4581961.863286629
+                    ),
+                  ]),
+                  vertexFormat: Cesium.EllipsoidSurfaceAppearance.VERTEX_FORMAT,
                 }),
-                appearance: new Cesium.EllipsoidSurfaceAppearance({
-                  aboveGround: false,
+              }),
+              appearance: new Cesium.EllipsoidSurfaceAppearance({
+                aboveGround: false,
+              }),
+              classificationType: Cesium.ClassificationType.TERRAIN,
+            })
+          );
+
+          worldRectangle = scene.primitives.add(
+            new Cesium.GroundPrimitive({
+              geometryInstances: new Cesium.GeometryInstance({
+                geometry: new Cesium.RectangleGeometry({
+                  rectangle: Cesium.Rectangle.fromDegrees(
+                    -179.99,
+                    -89.99,
+                    179.99,
+                    89.99
+                  ),
+                  vertexFormat: Cesium.EllipsoidSurfaceAppearance.VERTEX_FORMAT,
                 }),
-                show: false,
-                classificationType: Cesium.ClassificationType.TERRAIN,
-              })
-            );
+              }),
+              appearance: new Cesium.EllipsoidSurfaceAppearance({
+                aboveGround: false,
+              }),
+              show: false,
+              classificationType: Cesium.ClassificationType.TERRAIN,
+            })
+          );
 
-            const initialPosition = Cesium.Cartesian3.fromRadians(
-              -2.1344873183780484,
-              0.8071380277370774,
-              5743.394497982162
-            );
-            const initialOrientation = new Cesium.HeadingPitchRoll.fromDegrees(
-              112.99596671210358,
-              -21.34390550872461,
-              0.0716951918898415
-            );
-            viewer.scene.camera.setView({
-              destination: initialPosition,
-              orientation: initialOrientation,
-              endTransform: Cesium.Matrix4.IDENTITY,
-            });
-          }
+          const initialPosition = Cesium.Cartesian3.fromRadians(
+            -2.1344873183780484,
+            0.8071380277370774,
+            5743.394497982162
+          );
+          const initialOrientation = new Cesium.HeadingPitchRoll.fromDegrees(
+            112.99596671210358,
+            -21.34390550872461,
+            0.0716951918898415
+          );
+          viewer.scene.camera.setView({
+            destination: initialPosition,
+            orientation: initialOrientation,
+            endTransform: Cesium.Matrix4.IDENTITY,
+          });
+        }
 
-          const scene = viewer.scene;
-          scene.globe.enableLighting = true;
+        const scene = viewer.scene;
+        scene.globe.enableLighting = true;
 
-          createPrimitives(scene);
-          createButtons(scene);
-        })(); //Sandcastle_End
+        createPrimitives(scene);
+        createButtons(scene);
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/development/Ground Primitive Materials.html
+++ b/Apps/Sandcastle/gallery/development/Ground Primitive Materials.html
@@ -35,519 +35,522 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync({
-            requestWaterMask: true,
-            requestVertexNormals: true,
-          }),
-        });
-
-        if (!Cesium.GroundPrimitive.supportsMaterials(viewer.scene)) {
-          window.alert(
-            "GroundPrimitive materials are not supported on this platform."
-          );
-        }
-
-        let rectangle;
-        let worldRectangle;
-
-        function applyAlphaMapMaterial(primitive, scene) {
-          Sandcastle.declare(applyAlphaMapMaterial); // For highlighting in Sandcastle.
-          primitive.appearance.material = new Cesium.Material({
-            fabric: {
-              materials: {
-                alphaMaterial: {
-                  type: "AlphaMap",
-                  uniforms: {
-                    image: "../images/Cesium_Logo_Color.jpg",
-                    channel: "r",
-                  },
-                },
-              },
-              components: {
-                diffuse: "vec3(1.0)",
-                alpha: "alphaMaterial.alpha",
-              },
-            },
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync({
+              requestWaterMask: true,
+              requestVertexNormals: true,
+            }),
           });
-        }
 
-        function applyBumpMapMaterial(primitive, scene) {
-          Sandcastle.declare(applyBumpMapMaterial); // For highlighting in Sandcastle.
-          primitive.appearance.material = new Cesium.Material({
-            fabric: {
-              materials: {
-                diffuseMaterial: {
-                  type: "DiffuseMap",
-                  uniforms: {
-                    image: "../images/bumpmap.png",
-                  },
-                },
-                bumpMaterial: {
-                  type: "BumpMap",
-                  uniforms: {
-                    image: "../images/bumpmap.png",
-                    strength: 0.8,
-                  },
-                },
-              },
-              components: {
-                diffuse: "diffuseMaterial.diffuse",
-                specular: 0.01,
-                normal: "bumpMaterial.normal",
-              },
-            },
-          });
-        }
+          if (!Cesium.GroundPrimitive.supportsMaterials(viewer.scene)) {
+            window.alert(
+              "GroundPrimitive materials are not supported on this platform."
+            );
+          }
 
-        function applyCheckerboardMaterial(primitive, scene) {
-          Sandcastle.declare(applyCheckerboardMaterial); // For highlighting in Sandcastle.
-          primitive.appearance.material = Cesium.Material.fromType(
-            "Checkerboard"
-          );
-        }
+          let rectangle;
+          let worldRectangle;
 
-        function applyColorMaterial(primitive, scene) {
-          Sandcastle.declare(applyColorMaterial); // For highlighting in Sandcastle.
-          primitive.appearance.material = Cesium.Material.fromType("Color");
-        }
-
-        function applyCompositeMaterial(primitive, scene) {
-          Sandcastle.declare(applyCompositeMaterial); // For highlighting in Sandcastle.
-          primitive.appearance.material = new Cesium.Material({
-            fabric: {
-              uniforms: {
-                image: "../images/earthspec1k.jpg",
-                heightField: "../images/earthbump1k.jpg",
-              },
-              materials: {
-                bumpMap: {
-                  type: "BumpMap",
-                  uniforms: {
-                    image: "../images/earthbump1k.jpg",
-                  },
-                },
-              },
-              source:
-                "czm_material czm_getMaterial(czm_materialInput materialInput) {" +
-                "czm_material material = czm_getDefaultMaterial(materialInput);" +
-                "float heightValue = texture2D(heightField, materialInput.st).r;" +
-                "material.diffuse = mix(vec3(0.2, 0.6, 0.2), vec3(1.0, 0.5, 0.2), heightValue);" +
-                "material.alpha = (1.0 - texture2D(image, materialInput.st).r) * 0.7;" +
-                "material.normal = bumpMap.normal;" +
-                "material.specular = step(0.1, heightValue);" + // Specular mountain tops
-                "material.shininess = 8.0;" + // Sharpen highlight
-                "return material;" +
-                "}",
-            },
-          });
-        }
-
-        function applyDotMaterial(primitive, scene) {
-          Sandcastle.declare(applyDotMaterial); // For highlighting in Sandcastle.
-          primitive.appearance.material = Cesium.Material.fromType("Dot");
-        }
-
-        function applyDiffuseMaterial(primitive, scene) {
-          Sandcastle.declare(applyDiffuseMaterial); // For highlighting in Sandcastle.
-          primitive.appearance.material = new Cesium.Material({
-            fabric: {
-              type: "DiffuseMap",
-              uniforms: {
-                image: "../images/Cesium_Logo_Color.jpg",
-              },
-            },
-          });
-        }
-
-        function applyEmissionMapMaterial(primitive, scene) {
-          Sandcastle.declare(applyEmissionMapMaterial); // For highlighting in Sandcastle.
-          primitive.appearance.material = new Cesium.Material({
-            fabric: {
-              materials: {
-                diffuseMaterial: {
-                  type: "DiffuseMap",
-                  uniforms: {
-                    image: "../images/Cesium_Logo_Color.jpg",
-                  },
-                },
-                emissionMaterial: {
-                  type: "EmissionMap",
-                  uniforms: {
-                    image: "../images/checkerboard.png",
-                    repeat: {
-                      x: 1,
-                      y: 0.5,
+          function applyAlphaMapMaterial(primitive, scene) {
+            Sandcastle.declare(applyAlphaMapMaterial); // For highlighting in Sandcastle.
+            primitive.appearance.material = new Cesium.Material({
+              fabric: {
+                materials: {
+                  alphaMaterial: {
+                    type: "AlphaMap",
+                    uniforms: {
+                      image: "../images/Cesium_Logo_Color.jpg",
+                      channel: "r",
                     },
                   },
                 },
-              },
-              components: {
-                diffuse: "diffuseMaterial.diffuse",
-                emission: "emissionMaterial.emission * 0.2",
-              },
-            },
-          });
-        }
-
-        function applyWaterMaterial(primitive, scene) {
-          Sandcastle.declare(applyWaterMaterial); // For highlighting in Sandcastle.
-
-          primitive.appearance.material = new Cesium.Material({
-            fabric: {
-              type: "Water",
-              uniforms: {
-                specularMap: "../images/earthspec1k.jpg",
-                normalMap: Cesium.buildModuleUrl(
-                  "Assets/Textures/waterNormals.jpg"
-                ),
-                frequency: 10000.0,
-                animationSpeed: 0.01,
-                amplitude: 1.0,
-              },
-            },
-          });
-        }
-
-        function applyGridMaterial(primitive, scene) {
-          Sandcastle.declare(applyGridMaterial); // For highlighting in Sandcastle.
-          primitive.appearance.material = Cesium.Material.fromType("Grid");
-        }
-
-        function applyImageMaterial(primitive, scene) {
-          Sandcastle.declare(applyImageMaterial); // For highlighting in Sandcastle.
-          primitive.appearance.material = new Cesium.Material({
-            fabric: {
-              type: "Image",
-              uniforms: {
-                image: "../images/Cesium_Logo_Color.jpg",
-              },
-            },
-          });
-        }
-
-        function applyRepeatedImage(primitive, scene) {
-          Sandcastle.declare(applyRepeatedImage); // For highlighting in Sandcastle.
-          primitive.appearance.material = new Cesium.Material({
-            fabric: {
-              type: "Image",
-              uniforms: {
-                image: "../images/Cesium_Logo_Color.jpg",
-                repeat: {
-                  x: 10,
-                  y: 2,
+                components: {
+                  diffuse: "vec3(1.0)",
+                  alpha: "alphaMaterial.alpha",
                 },
               },
-            },
-          });
-        }
-
-        function applyNormalMapMaterial(primitive, scene) {
-          Sandcastle.declare(applyNormalMapMaterial); // For highlighting in Sandcastle.
-          primitive.appearance.material = new Cesium.Material({
-            fabric: {
-              materials: {
-                diffuseMaterial: {
-                  type: "DiffuseMap",
-                  uniforms: {
-                    image: "../images/bumpmap.png",
-                  },
-                },
-                normalMap: {
-                  type: "NormalMap",
-                  uniforms: {
-                    image: "../images/normalmap.png",
-                    strength: 0.6,
-                  },
-                },
-              },
-              components: {
-                diffuse: "diffuseMaterial.diffuse",
-                specular: 0.01,
-                normal: "normalMap.normal",
-              },
-            },
-          });
-        }
-
-        function applySpecularMapMaterial(primitive, scene) {
-          Sandcastle.declare(applySpecularMapMaterial); // For highlighting in Sandcastle.
-          primitive.appearance.material = new Cesium.Material({
-            fabric: {
-              type: "SpecularMap",
-              uniforms: {
-                image: "../images/Cesium_Logo_Color.jpg",
-                channel: "r",
-              },
-            },
-          });
-        }
-
-        function applyStripeMaterial(primitive, scene) {
-          Sandcastle.declare(applyStripeMaterial); // For highlighting in Sandcastle.
-          primitive.appearance.material = Cesium.Material.fromType("Stripe");
-        }
-
-        function applyRimLightingMaterial(primitive, scene) {
-          Sandcastle.declare(applyRimLightingMaterial); // For highlighting in Sandcastle.
-          primitive.appearance.material = Cesium.Material.fromType(
-            "RimLighting"
-          );
-        }
-
-        function createButtons(scene) {
-          function toggleRectangleVisibility() {
-            rectangle.show = true;
-            worldRectangle.show = false;
+            });
           }
 
-          function toggleWorldRectangleVisibility() {
-            worldRectangle.show = true;
-            rectangle.show = false;
+          function applyBumpMapMaterial(primitive, scene) {
+            Sandcastle.declare(applyBumpMapMaterial); // For highlighting in Sandcastle.
+            primitive.appearance.material = new Cesium.Material({
+              fabric: {
+                materials: {
+                  diffuseMaterial: {
+                    type: "DiffuseMap",
+                    uniforms: {
+                      image: "../images/bumpmap.png",
+                    },
+                  },
+                  bumpMaterial: {
+                    type: "BumpMap",
+                    uniforms: {
+                      image: "../images/bumpmap.png",
+                      strength: 0.8,
+                    },
+                  },
+                },
+                components: {
+                  diffuse: "diffuseMaterial.diffuse",
+                  specular: 0.01,
+                  normal: "bumpMaterial.normal",
+                },
+              },
+            });
           }
 
-          Sandcastle.addToolbarMenu([
-            {
-              text: "Common materials",
-            },
-            {
-              text: "Color",
-              onselect: function () {
-                toggleRectangleVisibility();
-                applyColorMaterial(rectangle, scene);
-                Sandcastle.highlight(applyColorMaterial);
-              },
-            },
-            {
-              text: "Image",
-              onselect: function () {
-                toggleRectangleVisibility();
-                applyImageMaterial(rectangle, scene);
-                Sandcastle.highlight(applyImageMaterial);
-              },
-            },
-            {
-              text: "Repeated/Rotated Image",
-              onselect: function () {
-                toggleRectangleVisibility();
-                applyRepeatedImage(rectangle, scene);
-                Sandcastle.highlight(applyRepeatedImage);
-              },
-            },
-          ]);
+          function applyCheckerboardMaterial(primitive, scene) {
+            Sandcastle.declare(applyCheckerboardMaterial); // For highlighting in Sandcastle.
+            primitive.appearance.material = Cesium.Material.fromType(
+              "Checkerboard"
+            );
+          }
 
-          Sandcastle.addToolbarMenu([
-            {
-              text: "Procedural textures",
-            },
-            {
-              text: "Checkerboard",
-              onselect: function () {
-                toggleRectangleVisibility();
-                applyCheckerboardMaterial(rectangle, scene);
-                Sandcastle.highlight(applyCheckerboardMaterial);
-              },
-            },
-            {
-              text: "Dot",
-              onselect: function () {
-                toggleRectangleVisibility();
-                applyDotMaterial(rectangle, scene);
-                Sandcastle.highlight(applyDotMaterial);
-              },
-            },
-            {
-              text: "Grid",
-              onselect: function () {
-                toggleRectangleVisibility(rectangle, worldRectangle);
-                applyGridMaterial(rectangle, scene);
-                Sandcastle.highlight(applyGridMaterial);
-              },
-            },
-            {
-              text: "Stripe",
-              onselect: function () {
-                toggleRectangleVisibility();
-                applyStripeMaterial(rectangle, scene);
-                Sandcastle.highlight(applyStripeMaterial);
-              },
-            },
-          ]);
+          function applyColorMaterial(primitive, scene) {
+            Sandcastle.declare(applyColorMaterial); // For highlighting in Sandcastle.
+            primitive.appearance.material = Cesium.Material.fromType("Color");
+          }
 
-          Sandcastle.addToolbarMenu([
-            {
-              text: "Base materials",
-            },
-            {
-              text: "Alpha Map",
-              onselect: function () {
-                toggleRectangleVisibility();
-                applyAlphaMapMaterial(rectangle, scene);
-                Sandcastle.highlight(applyAlphaMapMaterial);
+          function applyCompositeMaterial(primitive, scene) {
+            Sandcastle.declare(applyCompositeMaterial); // For highlighting in Sandcastle.
+            primitive.appearance.material = new Cesium.Material({
+              fabric: {
+                uniforms: {
+                  image: "../images/earthspec1k.jpg",
+                  heightField: "../images/earthbump1k.jpg",
+                },
+                materials: {
+                  bumpMap: {
+                    type: "BumpMap",
+                    uniforms: {
+                      image: "../images/earthbump1k.jpg",
+                    },
+                  },
+                },
+                source:
+                  "czm_material czm_getMaterial(czm_materialInput materialInput) {" +
+                  "czm_material material = czm_getDefaultMaterial(materialInput);" +
+                  "float heightValue = texture2D(heightField, materialInput.st).r;" +
+                  "material.diffuse = mix(vec3(0.2, 0.6, 0.2), vec3(1.0, 0.5, 0.2), heightValue);" +
+                  "material.alpha = (1.0 - texture2D(image, materialInput.st).r) * 0.7;" +
+                  "material.normal = bumpMap.normal;" +
+                  "material.specular = step(0.1, heightValue);" + // Specular mountain tops
+                  "material.shininess = 8.0;" + // Sharpen highlight
+                  "return material;" +
+                  "}",
               },
-            },
-            {
-              text: "Bump Map",
-              onselect: function () {
-                toggleRectangleVisibility();
-                applyBumpMapMaterial(rectangle, scene);
-                Sandcastle.highlight(applyBumpMapMaterial);
-              },
-            },
-            {
-              text: "Diffuse",
-              onselect: function () {
-                toggleRectangleVisibility();
-                applyDiffuseMaterial(rectangle, scene);
-                Sandcastle.highlight(applyDiffuseMaterial);
-              },
-            },
-            {
-              text: "Emission Map",
-              onselect: function () {
-                toggleRectangleVisibility();
-                applyEmissionMapMaterial(rectangle, scene);
-                Sandcastle.highlight(applyEmissionMapMaterial);
-              },
-            },
-            {
-              text: "Normal Map",
-              onselect: function () {
-                toggleRectangleVisibility();
-                applyNormalMapMaterial(rectangle, scene);
-                Sandcastle.highlight(applyNormalMapMaterial);
-              },
-            },
-            {
-              text: "Specular Map",
-              onselect: function () {
-                toggleRectangleVisibility();
-                applySpecularMapMaterial(rectangle, scene);
-                Sandcastle.highlight(applySpecularMapMaterial);
-              },
-            },
-          ]);
+            });
+          }
 
-          Sandcastle.addToolbarMenu([
-            {
-              text: "Misc materials",
-            },
-            {
-              text: "Rim Lighting",
-              onselect: function () {
-                toggleWorldRectangleVisibility();
-                applyRimLightingMaterial(worldRectangle, scene);
-                Sandcastle.highlight(applyRimLightingMaterial);
+          function applyDotMaterial(primitive, scene) {
+            Sandcastle.declare(applyDotMaterial); // For highlighting in Sandcastle.
+            primitive.appearance.material = Cesium.Material.fromType("Dot");
+          }
+
+          function applyDiffuseMaterial(primitive, scene) {
+            Sandcastle.declare(applyDiffuseMaterial); // For highlighting in Sandcastle.
+            primitive.appearance.material = new Cesium.Material({
+              fabric: {
+                type: "DiffuseMap",
+                uniforms: {
+                  image: "../images/Cesium_Logo_Color.jpg",
+                },
               },
-            },
-            {
-              text: "Water",
-              onselect: function () {
-                toggleWorldRectangleVisibility();
-                applyWaterMaterial(worldRectangle, scene);
-                Sandcastle.highlight(applyWaterMaterial);
+            });
+          }
+
+          function applyEmissionMapMaterial(primitive, scene) {
+            Sandcastle.declare(applyEmissionMapMaterial); // For highlighting in Sandcastle.
+            primitive.appearance.material = new Cesium.Material({
+              fabric: {
+                materials: {
+                  diffuseMaterial: {
+                    type: "DiffuseMap",
+                    uniforms: {
+                      image: "../images/Cesium_Logo_Color.jpg",
+                    },
+                  },
+                  emissionMaterial: {
+                    type: "EmissionMap",
+                    uniforms: {
+                      image: "../images/checkerboard.png",
+                      repeat: {
+                        x: 1,
+                        y: 0.5,
+                      },
+                    },
+                  },
+                },
+                components: {
+                  diffuse: "diffuseMaterial.diffuse",
+                  emission: "emissionMaterial.emission * 0.2",
+                },
               },
-            },
-          ]);
+            });
+          }
 
-          Sandcastle.addToolbarMenu([
-            {
-              text: "Example composite materials",
-            },
-            {
-              text: "Composite Example",
-              onselect: function () {
-                toggleWorldRectangleVisibility();
-                applyCompositeMaterial(worldRectangle, scene);
-                Sandcastle.highlight(applyCompositeMaterial);
-              },
-            },
-          ]);
+          function applyWaterMaterial(primitive, scene) {
+            Sandcastle.declare(applyWaterMaterial); // For highlighting in Sandcastle.
 
-          document.getElementById("toolbar").style.width = "10%";
-        }
-
-        function createPrimitives(scene) {
-          rectangle = scene.primitives.add(
-            new Cesium.GroundPrimitive({
-              geometryInstances: new Cesium.GeometryInstance({
-                geometry: new Cesium.RectangleGeometry({
-                  rectangle: Cesium.Rectangle.fromCartesianArray([
-                    new Cesium.Cartesian3(
-                      -2358138.847340281,
-                      -3744072.459541374,
-                      4581158.5714175375
-                    ),
-                    new Cesium.Cartesian3(
-                      -2357231.4925370603,
-                      -3745103.7886602185,
-                      4580702.9757762635
-                    ),
-                    new Cesium.Cartesian3(
-                      -2355912.902205431,
-                      -3744249.029778454,
-                      4582402.154378103
-                    ),
-                    new Cesium.Cartesian3(
-                      -2357208.0209552636,
-                      -3743553.4420488174,
-                      4581961.863286629
-                    ),
-                  ]),
-                  vertexFormat: Cesium.EllipsoidSurfaceAppearance.VERTEX_FORMAT,
-                }),
-              }),
-              appearance: new Cesium.EllipsoidSurfaceAppearance({
-                aboveGround: false,
-              }),
-              classificationType: Cesium.ClassificationType.TERRAIN,
-            })
-          );
-
-          worldRectangle = scene.primitives.add(
-            new Cesium.GroundPrimitive({
-              geometryInstances: new Cesium.GeometryInstance({
-                geometry: new Cesium.RectangleGeometry({
-                  rectangle: Cesium.Rectangle.fromDegrees(
-                    -179.99,
-                    -89.99,
-                    179.99,
-                    89.99
+            primitive.appearance.material = new Cesium.Material({
+              fabric: {
+                type: "Water",
+                uniforms: {
+                  specularMap: "../images/earthspec1k.jpg",
+                  normalMap: Cesium.buildModuleUrl(
+                    "Assets/Textures/waterNormals.jpg"
                   ),
-                  vertexFormat: Cesium.EllipsoidSurfaceAppearance.VERTEX_FORMAT,
+                  frequency: 10000.0,
+                  animationSpeed: 0.01,
+                  amplitude: 1.0,
+                },
+              },
+            });
+          }
+
+          function applyGridMaterial(primitive, scene) {
+            Sandcastle.declare(applyGridMaterial); // For highlighting in Sandcastle.
+            primitive.appearance.material = Cesium.Material.fromType("Grid");
+          }
+
+          function applyImageMaterial(primitive, scene) {
+            Sandcastle.declare(applyImageMaterial); // For highlighting in Sandcastle.
+            primitive.appearance.material = new Cesium.Material({
+              fabric: {
+                type: "Image",
+                uniforms: {
+                  image: "../images/Cesium_Logo_Color.jpg",
+                },
+              },
+            });
+          }
+
+          function applyRepeatedImage(primitive, scene) {
+            Sandcastle.declare(applyRepeatedImage); // For highlighting in Sandcastle.
+            primitive.appearance.material = new Cesium.Material({
+              fabric: {
+                type: "Image",
+                uniforms: {
+                  image: "../images/Cesium_Logo_Color.jpg",
+                  repeat: {
+                    x: 10,
+                    y: 2,
+                  },
+                },
+              },
+            });
+          }
+
+          function applyNormalMapMaterial(primitive, scene) {
+            Sandcastle.declare(applyNormalMapMaterial); // For highlighting in Sandcastle.
+            primitive.appearance.material = new Cesium.Material({
+              fabric: {
+                materials: {
+                  diffuseMaterial: {
+                    type: "DiffuseMap",
+                    uniforms: {
+                      image: "../images/bumpmap.png",
+                    },
+                  },
+                  normalMap: {
+                    type: "NormalMap",
+                    uniforms: {
+                      image: "../images/normalmap.png",
+                      strength: 0.6,
+                    },
+                  },
+                },
+                components: {
+                  diffuse: "diffuseMaterial.diffuse",
+                  specular: 0.01,
+                  normal: "normalMap.normal",
+                },
+              },
+            });
+          }
+
+          function applySpecularMapMaterial(primitive, scene) {
+            Sandcastle.declare(applySpecularMapMaterial); // For highlighting in Sandcastle.
+            primitive.appearance.material = new Cesium.Material({
+              fabric: {
+                type: "SpecularMap",
+                uniforms: {
+                  image: "../images/Cesium_Logo_Color.jpg",
+                  channel: "r",
+                },
+              },
+            });
+          }
+
+          function applyStripeMaterial(primitive, scene) {
+            Sandcastle.declare(applyStripeMaterial); // For highlighting in Sandcastle.
+            primitive.appearance.material = Cesium.Material.fromType("Stripe");
+          }
+
+          function applyRimLightingMaterial(primitive, scene) {
+            Sandcastle.declare(applyRimLightingMaterial); // For highlighting in Sandcastle.
+            primitive.appearance.material = Cesium.Material.fromType(
+              "RimLighting"
+            );
+          }
+
+          function createButtons(scene) {
+            function toggleRectangleVisibility() {
+              rectangle.show = true;
+              worldRectangle.show = false;
+            }
+
+            function toggleWorldRectangleVisibility() {
+              worldRectangle.show = true;
+              rectangle.show = false;
+            }
+
+            Sandcastle.addToolbarMenu([
+              {
+                text: "Common materials",
+              },
+              {
+                text: "Color",
+                onselect: function () {
+                  toggleRectangleVisibility();
+                  applyColorMaterial(rectangle, scene);
+                  Sandcastle.highlight(applyColorMaterial);
+                },
+              },
+              {
+                text: "Image",
+                onselect: function () {
+                  toggleRectangleVisibility();
+                  applyImageMaterial(rectangle, scene);
+                  Sandcastle.highlight(applyImageMaterial);
+                },
+              },
+              {
+                text: "Repeated/Rotated Image",
+                onselect: function () {
+                  toggleRectangleVisibility();
+                  applyRepeatedImage(rectangle, scene);
+                  Sandcastle.highlight(applyRepeatedImage);
+                },
+              },
+            ]);
+
+            Sandcastle.addToolbarMenu([
+              {
+                text: "Procedural textures",
+              },
+              {
+                text: "Checkerboard",
+                onselect: function () {
+                  toggleRectangleVisibility();
+                  applyCheckerboardMaterial(rectangle, scene);
+                  Sandcastle.highlight(applyCheckerboardMaterial);
+                },
+              },
+              {
+                text: "Dot",
+                onselect: function () {
+                  toggleRectangleVisibility();
+                  applyDotMaterial(rectangle, scene);
+                  Sandcastle.highlight(applyDotMaterial);
+                },
+              },
+              {
+                text: "Grid",
+                onselect: function () {
+                  toggleRectangleVisibility(rectangle, worldRectangle);
+                  applyGridMaterial(rectangle, scene);
+                  Sandcastle.highlight(applyGridMaterial);
+                },
+              },
+              {
+                text: "Stripe",
+                onselect: function () {
+                  toggleRectangleVisibility();
+                  applyStripeMaterial(rectangle, scene);
+                  Sandcastle.highlight(applyStripeMaterial);
+                },
+              },
+            ]);
+
+            Sandcastle.addToolbarMenu([
+              {
+                text: "Base materials",
+              },
+              {
+                text: "Alpha Map",
+                onselect: function () {
+                  toggleRectangleVisibility();
+                  applyAlphaMapMaterial(rectangle, scene);
+                  Sandcastle.highlight(applyAlphaMapMaterial);
+                },
+              },
+              {
+                text: "Bump Map",
+                onselect: function () {
+                  toggleRectangleVisibility();
+                  applyBumpMapMaterial(rectangle, scene);
+                  Sandcastle.highlight(applyBumpMapMaterial);
+                },
+              },
+              {
+                text: "Diffuse",
+                onselect: function () {
+                  toggleRectangleVisibility();
+                  applyDiffuseMaterial(rectangle, scene);
+                  Sandcastle.highlight(applyDiffuseMaterial);
+                },
+              },
+              {
+                text: "Emission Map",
+                onselect: function () {
+                  toggleRectangleVisibility();
+                  applyEmissionMapMaterial(rectangle, scene);
+                  Sandcastle.highlight(applyEmissionMapMaterial);
+                },
+              },
+              {
+                text: "Normal Map",
+                onselect: function () {
+                  toggleRectangleVisibility();
+                  applyNormalMapMaterial(rectangle, scene);
+                  Sandcastle.highlight(applyNormalMapMaterial);
+                },
+              },
+              {
+                text: "Specular Map",
+                onselect: function () {
+                  toggleRectangleVisibility();
+                  applySpecularMapMaterial(rectangle, scene);
+                  Sandcastle.highlight(applySpecularMapMaterial);
+                },
+              },
+            ]);
+
+            Sandcastle.addToolbarMenu([
+              {
+                text: "Misc materials",
+              },
+              {
+                text: "Rim Lighting",
+                onselect: function () {
+                  toggleWorldRectangleVisibility();
+                  applyRimLightingMaterial(worldRectangle, scene);
+                  Sandcastle.highlight(applyRimLightingMaterial);
+                },
+              },
+              {
+                text: "Water",
+                onselect: function () {
+                  toggleWorldRectangleVisibility();
+                  applyWaterMaterial(worldRectangle, scene);
+                  Sandcastle.highlight(applyWaterMaterial);
+                },
+              },
+            ]);
+
+            Sandcastle.addToolbarMenu([
+              {
+                text: "Example composite materials",
+              },
+              {
+                text: "Composite Example",
+                onselect: function () {
+                  toggleWorldRectangleVisibility();
+                  applyCompositeMaterial(worldRectangle, scene);
+                  Sandcastle.highlight(applyCompositeMaterial);
+                },
+              },
+            ]);
+
+            document.getElementById("toolbar").style.width = "10%";
+          }
+
+          function createPrimitives(scene) {
+            rectangle = scene.primitives.add(
+              new Cesium.GroundPrimitive({
+                geometryInstances: new Cesium.GeometryInstance({
+                  geometry: new Cesium.RectangleGeometry({
+                    rectangle: Cesium.Rectangle.fromCartesianArray([
+                      new Cesium.Cartesian3(
+                        -2358138.847340281,
+                        -3744072.459541374,
+                        4581158.5714175375
+                      ),
+                      new Cesium.Cartesian3(
+                        -2357231.4925370603,
+                        -3745103.7886602185,
+                        4580702.9757762635
+                      ),
+                      new Cesium.Cartesian3(
+                        -2355912.902205431,
+                        -3744249.029778454,
+                        4582402.154378103
+                      ),
+                      new Cesium.Cartesian3(
+                        -2357208.0209552636,
+                        -3743553.4420488174,
+                        4581961.863286629
+                      ),
+                    ]),
+                    vertexFormat:
+                      Cesium.EllipsoidSurfaceAppearance.VERTEX_FORMAT,
+                  }),
                 }),
-              }),
-              appearance: new Cesium.EllipsoidSurfaceAppearance({
-                aboveGround: false,
-              }),
-              show: false,
-              classificationType: Cesium.ClassificationType.TERRAIN,
-            })
-          );
+                appearance: new Cesium.EllipsoidSurfaceAppearance({
+                  aboveGround: false,
+                }),
+                classificationType: Cesium.ClassificationType.TERRAIN,
+              })
+            );
 
-          const initialPosition = Cesium.Cartesian3.fromRadians(
-            -2.1344873183780484,
-            0.8071380277370774,
-            5743.394497982162
-          );
-          const initialOrientation = new Cesium.HeadingPitchRoll.fromDegrees(
-            112.99596671210358,
-            -21.34390550872461,
-            0.0716951918898415
-          );
-          viewer.scene.camera.setView({
-            destination: initialPosition,
-            orientation: initialOrientation,
-            endTransform: Cesium.Matrix4.IDENTITY,
-          });
-        }
+            worldRectangle = scene.primitives.add(
+              new Cesium.GroundPrimitive({
+                geometryInstances: new Cesium.GeometryInstance({
+                  geometry: new Cesium.RectangleGeometry({
+                    rectangle: Cesium.Rectangle.fromDegrees(
+                      -179.99,
+                      -89.99,
+                      179.99,
+                      89.99
+                    ),
+                    vertexFormat:
+                      Cesium.EllipsoidSurfaceAppearance.VERTEX_FORMAT,
+                  }),
+                }),
+                appearance: new Cesium.EllipsoidSurfaceAppearance({
+                  aboveGround: false,
+                }),
+                show: false,
+                classificationType: Cesium.ClassificationType.TERRAIN,
+              })
+            );
 
-        const scene = viewer.scene;
-        scene.globe.enableLighting = true;
+            const initialPosition = Cesium.Cartesian3.fromRadians(
+              -2.1344873183780484,
+              0.8071380277370774,
+              5743.394497982162
+            );
+            const initialOrientation = new Cesium.HeadingPitchRoll.fromDegrees(
+              112.99596671210358,
+              -21.34390550872461,
+              0.0716951918898415
+            );
+            viewer.scene.camera.setView({
+              destination: initialPosition,
+              orientation: initialOrientation,
+              endTransform: Cesium.Matrix4.IDENTITY,
+            });
+          }
 
-        createPrimitives(scene);
-        createButtons(scene);
-        //Sandcastle_End
+          const scene = viewer.scene;
+          scene.globe.enableLighting = true;
+
+          createPrimitives(scene);
+          createButtons(scene);
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/development/Ground Primitive Materials.html
+++ b/Apps/Sandcastle/gallery/development/Ground Primitive Materials.html
@@ -35,13 +35,11 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const worldTerrain = Cesium.createWorldTerrain({
-          requestWaterMask: true,
-          requestVertexNormals: true,
-        });
-
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: worldTerrain,
+          terrainProvider: Cesium.createWorldTerrainAsync({
+            requestWaterMask: true,
+            requestVertexNormals: true,
+          }),
         });
 
         if (!Cesium.GroundPrimitive.supportsMaterials(viewer.scene)) {

--- a/Apps/Sandcastle/gallery/development/Ground Primitive.html
+++ b/Apps/Sandcastle/gallery/development/Ground Primitive.html
@@ -35,478 +35,473 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        const viewer = new Cesium.Viewer("cesiumContainer");
+
         (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
-          const scene = viewer.scene;
-          viewer.extend(Cesium.viewerCesiumInspectorMixin);
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+          } catch (error) {
+            console.log(error);
+          }
+        })();
 
-          function offsetPositions(positions, degreeOffset) {
-            positions = scene.globe.ellipsoid.cartesianArrayToCartographicArray(
-              positions
-            );
-            const delta = Cesium.Math.toRadians(degreeOffset);
-            for (let i = 0; i < positions.length; ++i) {
-              const position = positions[i];
-              position.latitude += delta;
-              position.longitude += delta;
-            }
-            return scene.globe.ellipsoid.cartographicArrayToCartesianArray(
-              positions
-            );
+        const scene = viewer.scene;
+        viewer.extend(Cesium.viewerCesiumInspectorMixin);
+
+        function offsetPositions(positions, degreeOffset) {
+          positions = scene.globe.ellipsoid.cartesianArrayToCartographicArray(
+            positions
+          );
+          const delta = Cesium.Math.toRadians(degreeOffset);
+          for (let i = 0; i < positions.length; ++i) {
+            const position = positions[i];
+            position.latitude += delta;
+            position.longitude += delta;
+          }
+          return scene.globe.ellipsoid.cartographicArrayToCartesianArray(
+            positions
+          );
+        }
+
+        function createOverlappingPolygons(withAlpha) {
+          const positions = [
+            new Cesium.Cartesian3(
+              -2358138.847340281,
+              -3744072.459541374,
+              4581158.5714175375
+            ),
+            new Cesium.Cartesian3(
+              -2357231.4925370603,
+              -3745103.7886602185,
+              4580702.9757762635
+            ),
+            new Cesium.Cartesian3(
+              -2355912.902205431,
+              -3744249.029778454,
+              4582402.154378103
+            ),
+            new Cesium.Cartesian3(
+              -2357208.0209552636,
+              -3743553.4420488174,
+              4581961.863286629
+            ),
+          ];
+          let polygonHierarchy = { positions: positions };
+
+          let color = Cesium.Color.RED;
+          if (withAlpha) {
+            color = color.withAlpha(0.5);
           }
 
-          function createOverlappingPolygons(withAlpha) {
-            const positions = [
-              new Cesium.Cartesian3(
-                -2358138.847340281,
-                -3744072.459541374,
-                4581158.5714175375
-              ),
-              new Cesium.Cartesian3(
-                -2357231.4925370603,
-                -3745103.7886602185,
-                4580702.9757762635
-              ),
-              new Cesium.Cartesian3(
-                -2355912.902205431,
-                -3744249.029778454,
-                4582402.154378103
-              ),
-              new Cesium.Cartesian3(
-                -2357208.0209552636,
-                -3743553.4420488174,
-                4581961.863286629
-              ),
-            ];
-            let polygonHierarchy = { positions: positions };
-
-            let color = Cesium.Color.RED;
-            if (withAlpha) {
-              color = color.withAlpha(0.5);
-            }
-
-            scene.groundPrimitives.add(
-              new Cesium.GroundPrimitive({
-                geometryInstances: new Cesium.GeometryInstance({
-                  geometry: new Cesium.PolygonGeometry({
-                    polygonHierarchy: polygonHierarchy,
-                  }),
-                  attributes: {
-                    color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                      color
-                    ),
-                  },
-                  id: "polygon 1",
+          scene.groundPrimitives.add(
+            new Cesium.GroundPrimitive({
+              geometryInstances: new Cesium.GeometryInstance({
+                geometry: new Cesium.PolygonGeometry({
+                  polygonHierarchy: polygonHierarchy,
                 }),
-                classificationType: Cesium.ClassificationType.TERRAIN,
-              })
-            );
+                attributes: {
+                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(color),
+                },
+                id: "polygon 1",
+              }),
+              classificationType: Cesium.ClassificationType.TERRAIN,
+            })
+          );
 
-            // Same polygon slightly offset and overlapping.
-            let positionsOffset = offsetPositions(positions, 0.01);
-            polygonHierarchy = { positions: positionsOffset };
+          // Same polygon slightly offset and overlapping.
+          let positionsOffset = offsetPositions(positions, 0.01);
+          polygonHierarchy = { positions: positionsOffset };
 
-            color = Cesium.Color.GREEN;
-            if (withAlpha) {
-              color = color.withAlpha(0.5);
-            }
-
-            scene.groundPrimitives.add(
-              new Cesium.GroundPrimitive({
-                geometryInstances: new Cesium.GeometryInstance({
-                  geometry: new Cesium.PolygonGeometry({
-                    polygonHierarchy: polygonHierarchy,
-                  }),
-                  attributes: {
-                    color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                      color
-                    ),
-                  },
-                  id: "polygon 2",
-                }),
-                classificationType: Cesium.ClassificationType.TERRAIN,
-              })
-            );
-
-            // Same polygon slightly offset and overlapping.
-            positionsOffset = offsetPositions(positions, -0.01);
-            polygonHierarchy = { positions: positionsOffset };
-
-            color = Cesium.Color.BLUE;
-            if (withAlpha) {
-              color = color.withAlpha(0.5);
-            }
-
-            scene.groundPrimitives.add(
-              new Cesium.GroundPrimitive({
-                geometryInstances: new Cesium.GeometryInstance({
-                  geometry: new Cesium.PolygonGeometry({
-                    polygonHierarchy: polygonHierarchy,
-                  }),
-                  attributes: {
-                    color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                      color
-                    ),
-                  },
-                  id: "polygon 3",
-                }),
-                classificationType: Cesium.ClassificationType.TERRAIN,
-              })
-            );
+          color = Cesium.Color.GREEN;
+          if (withAlpha) {
+            color = color.withAlpha(0.5);
           }
 
-          function viewOverlappingPolygons() {
-            viewer.camera.lookAt(
-              new Cesium.Cartesian3(
-                -2354331.3069306486,
-                -3742016.2427205616,
-                4581875.591571755
-              ),
-              new Cesium.HeadingPitchRange(
-                Cesium.Math.toRadians(20.0),
-                Cesium.Math.toRadians(-35.0),
-                10000.0
-              )
-            );
-            viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+          scene.groundPrimitives.add(
+            new Cesium.GroundPrimitive({
+              geometryInstances: new Cesium.GeometryInstance({
+                geometry: new Cesium.PolygonGeometry({
+                  polygonHierarchy: polygonHierarchy,
+                }),
+                attributes: {
+                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(color),
+                },
+                id: "polygon 2",
+              }),
+              classificationType: Cesium.ClassificationType.TERRAIN,
+            })
+          );
+
+          // Same polygon slightly offset and overlapping.
+          positionsOffset = offsetPositions(positions, -0.01);
+          polygonHierarchy = { positions: positionsOffset };
+
+          color = Cesium.Color.BLUE;
+          if (withAlpha) {
+            color = color.withAlpha(0.5);
           }
 
-          let handler;
+          scene.groundPrimitives.add(
+            new Cesium.GroundPrimitive({
+              geometryInstances: new Cesium.GeometryInstance({
+                geometry: new Cesium.PolygonGeometry({
+                  polygonHierarchy: polygonHierarchy,
+                }),
+                attributes: {
+                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(color),
+                },
+                id: "polygon 3",
+              }),
+              classificationType: Cesium.ClassificationType.TERRAIN,
+            })
+          );
+        }
 
-          Sandcastle.addDefaultToolbarButton("Picking Example", function () {
-            createOverlappingPolygons(true);
-            viewOverlappingPolygons();
+        function viewOverlappingPolygons() {
+          viewer.camera.lookAt(
+            new Cesium.Cartesian3(
+              -2354331.3069306486,
+              -3742016.2427205616,
+              4581875.591571755
+            ),
+            new Cesium.HeadingPitchRange(
+              Cesium.Math.toRadians(20.0),
+              Cesium.Math.toRadians(-35.0),
+              10000.0
+            )
+          );
+          viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+        }
 
-            let currentObject;
-            let lastColor;
+        let handler;
 
-            handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
-            handler.setInputAction(function (movement) {
-              const pickedObject = scene.pick(movement.endPosition);
-              if (
-                Cesium.defined(pickedObject) &&
-                pickedObject !== currentObject
-              ) {
-                if (Cesium.defined(currentObject)) {
-                  currentObject.primitive.getGeometryInstanceAttributes(
-                    currentObject.id
-                  ).color = lastColor;
-                }
+        Sandcastle.addDefaultToolbarButton("Picking Example", function () {
+          createOverlappingPolygons(true);
+          viewOverlappingPolygons();
 
-                currentObject = pickedObject;
+          let currentObject;
+          let lastColor;
 
-                const attributes = currentObject.primitive.getGeometryInstanceAttributes(
-                  currentObject.id
-                );
-                lastColor = attributes.color;
-                attributes.color = [255, 255, 0, 128];
-              } else if (
-                !Cesium.defined(pickedObject) &&
-                Cesium.defined(currentObject)
-              ) {
+          handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
+          handler.setInputAction(function (movement) {
+            const pickedObject = scene.pick(movement.endPosition);
+            if (
+              Cesium.defined(pickedObject) &&
+              pickedObject !== currentObject
+            ) {
+              if (Cesium.defined(currentObject)) {
                 currentObject.primitive.getGeometryInstanceAttributes(
                   currentObject.id
                 ).color = lastColor;
-                currentObject = undefined;
               }
-            }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-          });
 
-          Sandcastle.addToolbarButton("Z-Order", function () {
-            createOverlappingPolygons(false);
-            viewOverlappingPolygons();
+              currentObject = pickedObject;
 
-            handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
-            handler.setInputAction(function (movement) {
-              const pickedObject = scene.pick(movement.endPosition);
-              if (Cesium.defined(pickedObject)) {
-                scene.groundPrimitives.raiseToTop(pickedObject.primitive);
-              }
-            }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-          });
-
-          function createBatchedInstances(color, show) {
-            const instances = [];
-
-            const width = 0.02561343838881669;
-            const height = 0.019831817968480436;
-
-            let lat = 46.18147866629652;
-            let lon = -122.20406057655991;
-
-            const delta = 0.03;
-            const latDeltas = [0.0, 0.0, delta, 0.0];
-            const lonDeltas = [0.0, delta, 0.0, -delta];
-
-            const length = latDeltas.length;
-            for (let i = 0; i < length; ++i) {
-              lon = lon + lonDeltas[i];
-              lat = lat + latDeltas[i];
-
-              const west = lon;
-              const east = lon + width;
-              const south = lat;
-              const north = lat + height;
-
-              instances.push(
-                new Cesium.GeometryInstance({
-                  geometry: new Cesium.RectangleGeometry({
-                    rectangle: Cesium.Rectangle.fromDegrees(
-                      west,
-                      south,
-                      east,
-                      north
-                    ),
-                  }),
-                  attributes: {
-                    color: color,
-                    show: show,
-                  },
-                  id: `rectangle${i}`,
-                })
+              const attributes = currentObject.primitive.getGeometryInstanceAttributes(
+                currentObject.id
               );
+              lastColor = attributes.color;
+              attributes.color = [255, 255, 0, 128];
+            } else if (
+              !Cesium.defined(pickedObject) &&
+              Cesium.defined(currentObject)
+            ) {
+              currentObject.primitive.getGeometryInstanceAttributes(
+                currentObject.id
+              ).color = lastColor;
+              currentObject = undefined;
             }
+          }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+        });
 
-            return instances;
+        Sandcastle.addToolbarButton("Z-Order", function () {
+          createOverlappingPolygons(false);
+          viewOverlappingPolygons();
+
+          handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
+          handler.setInputAction(function (movement) {
+            const pickedObject = scene.pick(movement.endPosition);
+            if (Cesium.defined(pickedObject)) {
+              scene.groundPrimitives.raiseToTop(pickedObject.primitive);
+            }
+          }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+        });
+
+        function createBatchedInstances(color, show) {
+          const instances = [];
+
+          const width = 0.02561343838881669;
+          const height = 0.019831817968480436;
+
+          let lat = 46.18147866629652;
+          let lon = -122.20406057655991;
+
+          const delta = 0.03;
+          const latDeltas = [0.0, 0.0, delta, 0.0];
+          const lonDeltas = [0.0, delta, 0.0, -delta];
+
+          const length = latDeltas.length;
+          for (let i = 0; i < length; ++i) {
+            lon = lon + lonDeltas[i];
+            lat = lat + latDeltas[i];
+
+            const west = lon;
+            const east = lon + width;
+            const south = lat;
+            const north = lat + height;
+
+            instances.push(
+              new Cesium.GeometryInstance({
+                geometry: new Cesium.RectangleGeometry({
+                  rectangle: Cesium.Rectangle.fromDegrees(
+                    west,
+                    south,
+                    east,
+                    north
+                  ),
+                }),
+                attributes: {
+                  color: color,
+                  show: show,
+                },
+                id: `rectangle${i}`,
+              })
+            );
           }
 
-          Sandcastle.addToolbarButton("Batching", function () {
-            const color = new Cesium.ColorGeometryInstanceAttribute(
-              0.0,
-              1.0,
-              1.0,
-              0.5
-            );
-            const show = new Cesium.ShowGeometryInstanceAttribute(true);
-            const instances = createBatchedInstances(color, show);
-            scene.groundPrimitives.add(
-              new Cesium.GroundPrimitive({
-                geometryInstances: instances,
-                classificationType: Cesium.ClassificationType.TERRAIN,
-              })
-            );
+          return instances;
+        }
 
-            viewOverlappingPolygons();
-          });
+        Sandcastle.addToolbarButton("Batching", function () {
+          const color = new Cesium.ColorGeometryInstanceAttribute(
+            0.0,
+            1.0,
+            1.0,
+            0.5
+          );
+          const show = new Cesium.ShowGeometryInstanceAttribute(true);
+          const instances = createBatchedInstances(color, show);
+          scene.groundPrimitives.add(
+            new Cesium.GroundPrimitive({
+              geometryInstances: instances,
+              classificationType: Cesium.ClassificationType.TERRAIN,
+            })
+          );
 
-          Sandcastle.addToolbarButton("Batch Picking", function () {
-            let color = new Cesium.ColorGeometryInstanceAttribute(
-              0.0,
-              1.0,
-              1.0,
-              0.5
-            );
-            let show = new Cesium.ShowGeometryInstanceAttribute(true);
-            let instances = createBatchedInstances(color, show);
+          viewOverlappingPolygons();
+        });
 
-            const primitive = scene.groundPrimitives.add(
-              new Cesium.GroundPrimitive({
-                geometryInstances: instances,
-                classificationType: Cesium.ClassificationType.TERRAIN,
-              })
-            );
+        Sandcastle.addToolbarButton("Batch Picking", function () {
+          let color = new Cesium.ColorGeometryInstanceAttribute(
+            0.0,
+            1.0,
+            1.0,
+            0.5
+          );
+          let show = new Cesium.ShowGeometryInstanceAttribute(true);
+          let instances = createBatchedInstances(color, show);
 
-            color = new Cesium.ColorGeometryInstanceAttribute(
-              1.0,
-              0.0,
-              1.0,
-              0.5
-            );
-            show = new Cesium.ShowGeometryInstanceAttribute(false);
-            instances = createBatchedInstances(color, show);
+          const primitive = scene.groundPrimitives.add(
+            new Cesium.GroundPrimitive({
+              geometryInstances: instances,
+              classificationType: Cesium.ClassificationType.TERRAIN,
+            })
+          );
 
-            // Edit id to differentiate between picked primitive and normally displayed primitive.
-            const pickIdPrefix = "pick";
-            for (let i = 0; i < instances.length; ++i) {
-              instances[i].id = pickIdPrefix + instances[i].id;
-            }
+          color = new Cesium.ColorGeometryInstanceAttribute(1.0, 0.0, 1.0, 0.5);
+          show = new Cesium.ShowGeometryInstanceAttribute(false);
+          instances = createBatchedInstances(color, show);
 
-            const pickPrimitive = scene.groundPrimitives.add(
-              new Cesium.GroundPrimitive({
-                geometryInstances: instances,
-                classificationType: Cesium.ClassificationType.TERRAIN,
-              })
-            );
+          // Edit id to differentiate between picked primitive and normally displayed primitive.
+          const pickIdPrefix = "pick";
+          for (let i = 0; i < instances.length; ++i) {
+            instances[i].id = pickIdPrefix + instances[i].id;
+          }
 
-            viewOverlappingPolygons();
+          const pickPrimitive = scene.groundPrimitives.add(
+            new Cesium.GroundPrimitive({
+              geometryInstances: instances,
+              classificationType: Cesium.ClassificationType.TERRAIN,
+            })
+          );
 
-            let currentObject;
+          viewOverlappingPolygons();
 
-            handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
-            handler.setInputAction(function (movement) {
-              const pickedObject = scene.pick(movement.endPosition);
-              if (
-                Cesium.defined(pickedObject) &&
-                pickedObject !== currentObject &&
-                pickedObject.id.indexOf(pickIdPrefix) === -1
-              ) {
-                if (Cesium.defined(currentObject)) {
-                  primitive.getGeometryInstanceAttributes(
-                    currentObject.id
-                  ).show = [1];
-                  pickPrimitive.getGeometryInstanceAttributes(
-                    pickIdPrefix + currentObject.id
-                  ).show = [0];
-                }
+          let currentObject;
 
-                currentObject = pickedObject;
-
-                primitive.getGeometryInstanceAttributes(
-                  currentObject.id
-                ).show = [0];
-                pickPrimitive.getGeometryInstanceAttributes(
-                  pickIdPrefix + currentObject.id
-                ).show = [1];
-              } else if (
-                !Cesium.defined(pickedObject) &&
-                Cesium.defined(currentObject)
-              ) {
+          handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
+          handler.setInputAction(function (movement) {
+            const pickedObject = scene.pick(movement.endPosition);
+            if (
+              Cesium.defined(pickedObject) &&
+              pickedObject !== currentObject &&
+              pickedObject.id.indexOf(pickIdPrefix) === -1
+            ) {
+              if (Cesium.defined(currentObject)) {
                 primitive.getGeometryInstanceAttributes(
                   currentObject.id
                 ).show = [1];
                 pickPrimitive.getGeometryInstanceAttributes(
                   pickIdPrefix + currentObject.id
                 ).show = [0];
-                currentObject = undefined;
               }
-            }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-          });
 
-          Sandcastle.addToolbarButton("Create large polygons", function () {
-            // Circle geometry
-            scene.groundPrimitives.add(
-              new Cesium.GroundPrimitive({
-                geometryInstances: new Cesium.GeometryInstance({
-                  geometry: new Cesium.CircleGeometry({
-                    center: Cesium.Cartesian3.fromDegrees(-95.0, 45.0),
-                    radius: 250000.0,
-                  }),
-                  attributes: {
-                    color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                      new Cesium.Color(1.0, 0.0, 0.0, 0.5)
-                    ),
-                  },
-                  id: "circle",
+              currentObject = pickedObject;
+
+              primitive.getGeometryInstanceAttributes(currentObject.id).show = [
+                0,
+              ];
+              pickPrimitive.getGeometryInstanceAttributes(
+                pickIdPrefix + currentObject.id
+              ).show = [1];
+            } else if (
+              !Cesium.defined(pickedObject) &&
+              Cesium.defined(currentObject)
+            ) {
+              primitive.getGeometryInstanceAttributes(currentObject.id).show = [
+                1,
+              ];
+              pickPrimitive.getGeometryInstanceAttributes(
+                pickIdPrefix + currentObject.id
+              ).show = [0];
+              currentObject = undefined;
+            }
+          }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+        });
+
+        Sandcastle.addToolbarButton("Create large polygons", function () {
+          // Circle geometry
+          scene.groundPrimitives.add(
+            new Cesium.GroundPrimitive({
+              geometryInstances: new Cesium.GeometryInstance({
+                geometry: new Cesium.CircleGeometry({
+                  center: Cesium.Cartesian3.fromDegrees(-95.0, 45.0),
+                  radius: 250000.0,
                 }),
-                classificationType: Cesium.ClassificationType.TERRAIN,
-              })
-            );
+                attributes: {
+                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                    new Cesium.Color(1.0, 0.0, 0.0, 0.5)
+                  ),
+                },
+                id: "circle",
+              }),
+              classificationType: Cesium.ClassificationType.TERRAIN,
+            })
+          );
 
-            // Ellipse Geometry
-            scene.groundPrimitives.add(
-              new Cesium.GroundPrimitive({
-                geometryInstances: new Cesium.GeometryInstance({
-                  geometry: new Cesium.EllipseGeometry({
-                    center: Cesium.Cartesian3.fromDegrees(-105.0, 40.0),
-                    semiMinorAxis: 300000.0,
-                    semiMajorAxis: 400000.0,
-                  }),
-                  attributes: {
-                    color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                      new Cesium.Color(0.0, 1.0, 1.0, 0.5)
-                    ),
-                  },
-                  id: "ellipse",
+          // Ellipse Geometry
+          scene.groundPrimitives.add(
+            new Cesium.GroundPrimitive({
+              geometryInstances: new Cesium.GeometryInstance({
+                geometry: new Cesium.EllipseGeometry({
+                  center: Cesium.Cartesian3.fromDegrees(-105.0, 40.0),
+                  semiMinorAxis: 300000.0,
+                  semiMajorAxis: 400000.0,
                 }),
-                classificationType: Cesium.ClassificationType.TERRAIN,
-              })
-            );
+                attributes: {
+                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                    new Cesium.Color(0.0, 1.0, 1.0, 0.5)
+                  ),
+                },
+                id: "ellipse",
+              }),
+              classificationType: Cesium.ClassificationType.TERRAIN,
+            })
+          );
 
-            // Corridor Geometry
-            scene.groundPrimitives.add(
-              new Cesium.GroundPrimitive({
-                geometryInstances: new Cesium.GeometryInstance({
-                  geometry: new Cesium.CorridorGeometry({
-                    positions: Cesium.Cartesian3.fromDegreesArray([
-                      -112.0,
-                      40.0,
-                      -117.0,
-                      40.0,
-                      -117.0,
-                      35.0,
-                    ]),
-                    width: 200000.0,
-                  }),
-                  attributes: {
-                    color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                      new Cesium.Color(0.0, 0.0, 1.0, 0.5)
-                    ),
-                  },
-                  id: "corridor",
+          // Corridor Geometry
+          scene.groundPrimitives.add(
+            new Cesium.GroundPrimitive({
+              geometryInstances: new Cesium.GeometryInstance({
+                geometry: new Cesium.CorridorGeometry({
+                  positions: Cesium.Cartesian3.fromDegreesArray([
+                    -112.0,
+                    40.0,
+                    -117.0,
+                    40.0,
+                    -117.0,
+                    35.0,
+                  ]),
+                  width: 200000.0,
                 }),
-                classificationType: Cesium.ClassificationType.TERRAIN,
-              })
-            );
+                attributes: {
+                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                    new Cesium.Color(0.0, 0.0, 1.0, 0.5)
+                  ),
+                },
+                id: "corridor",
+              }),
+              classificationType: Cesium.ClassificationType.TERRAIN,
+            })
+          );
 
-            // Rectangle geometry
-            scene.groundPrimitives.add(
-              new Cesium.GroundPrimitive({
-                geometryInstances: new Cesium.GeometryInstance({
-                  geometry: new Cesium.RectangleGeometry({
-                    rectangle: Cesium.Rectangle.fromDegrees(
-                      -100.0,
-                      30.0,
-                      -90.0,
-                      40.0
-                    ),
-                    rotation: Cesium.Math.toRadians(45),
-                  }),
-                  attributes: {
-                    color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                      new Cesium.Color(0.0, 1.0, 0.0, 0.5)
-                    ),
-                  },
-                  id: "rectangle",
+          // Rectangle geometry
+          scene.groundPrimitives.add(
+            new Cesium.GroundPrimitive({
+              geometryInstances: new Cesium.GeometryInstance({
+                geometry: new Cesium.RectangleGeometry({
+                  rectangle: Cesium.Rectangle.fromDegrees(
+                    -100.0,
+                    30.0,
+                    -90.0,
+                    40.0
+                  ),
+                  rotation: Cesium.Math.toRadians(45),
                 }),
-                classificationType: Cesium.ClassificationType.TERRAIN,
-              })
-            );
+                attributes: {
+                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                    new Cesium.Color(0.0, 1.0, 0.0, 0.5)
+                  ),
+                },
+                id: "rectangle",
+              }),
+              classificationType: Cesium.ClassificationType.TERRAIN,
+            })
+          );
 
-            // Rhumb line polygon geometry
-            scene.groundPrimitives.add(
-              new Cesium.GroundPrimitive({
-                geometryInstances: new Cesium.GeometryInstance({
-                  geometry: new Cesium.PolygonGeometry({
-                    polygonHierarchy: new Cesium.PolygonHierarchy(
-                      Cesium.Cartesian3.fromDegreesArray([
-                        -130,
-                        55,
-                        -100,
-                        55,
-                        -100,
-                        45,
-                        -130,
-                        45,
-                      ])
-                    ),
-                    arcType: Cesium.ArcType.RHUMB,
-                  }),
-                  attributes: {
-                    color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                      new Cesium.Color(1.0, 1.0, 0.0, 0.5)
-                    ),
-                  },
-                  id: "rhumbPolygon",
+          // Rhumb line polygon geometry
+          scene.groundPrimitives.add(
+            new Cesium.GroundPrimitive({
+              geometryInstances: new Cesium.GeometryInstance({
+                geometry: new Cesium.PolygonGeometry({
+                  polygonHierarchy: new Cesium.PolygonHierarchy(
+                    Cesium.Cartesian3.fromDegreesArray([
+                      -130,
+                      55,
+                      -100,
+                      55,
+                      -100,
+                      45,
+                      -130,
+                      45,
+                    ])
+                  ),
+                  arcType: Cesium.ArcType.RHUMB,
                 }),
-                classificationType: Cesium.ClassificationType.TERRAIN,
-              })
-            );
-          });
+                attributes: {
+                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                    new Cesium.Color(1.0, 1.0, 0.0, 0.5)
+                  ),
+                },
+                id: "rhumbPolygon",
+              }),
+              classificationType: Cesium.ClassificationType.TERRAIN,
+            })
+          );
+        });
 
-          Sandcastle.reset = function () {
-            scene.groundPrimitives.removeAll();
-            handler = handler && handler.destroy();
+        Sandcastle.reset = function () {
+          scene.groundPrimitives.removeAll();
+          handler = handler && handler.destroy();
 
-            //Set the camera to a US centered tilted view and switch back to moving in world coordinates.
-            viewer.camera.lookAt(
-              Cesium.Cartesian3.fromDegrees(-98.0, 40.0),
-              new Cesium.Cartesian3(0.0, -4790000.0, 3930000.0)
-            );
-            viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-          };
-        })(); //Sandcastle_End
+          //Set the camera to a US centered tilted view and switch back to moving in world coordinates.
+          viewer.camera.lookAt(
+            Cesium.Cartesian3.fromDegrees(-98.0, 40.0),
+            new Cesium.Cartesian3(0.0, -4790000.0, 3930000.0)
+          );
+          viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+        };
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/development/Ground Primitive.html
+++ b/Apps/Sandcastle/gallery/development/Ground Primitive.html
@@ -35,467 +35,478 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
-        const scene = viewer.scene;
-        viewer.extend(Cesium.viewerCesiumInspectorMixin);
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          });
+          const scene = viewer.scene;
+          viewer.extend(Cesium.viewerCesiumInspectorMixin);
 
-        function offsetPositions(positions, degreeOffset) {
-          positions = scene.globe.ellipsoid.cartesianArrayToCartographicArray(
-            positions
-          );
-          const delta = Cesium.Math.toRadians(degreeOffset);
-          for (let i = 0; i < positions.length; ++i) {
-            const position = positions[i];
-            position.latitude += delta;
-            position.longitude += delta;
-          }
-          return scene.globe.ellipsoid.cartographicArrayToCartesianArray(
-            positions
-          );
-        }
-
-        function createOverlappingPolygons(withAlpha) {
-          const positions = [
-            new Cesium.Cartesian3(
-              -2358138.847340281,
-              -3744072.459541374,
-              4581158.5714175375
-            ),
-            new Cesium.Cartesian3(
-              -2357231.4925370603,
-              -3745103.7886602185,
-              4580702.9757762635
-            ),
-            new Cesium.Cartesian3(
-              -2355912.902205431,
-              -3744249.029778454,
-              4582402.154378103
-            ),
-            new Cesium.Cartesian3(
-              -2357208.0209552636,
-              -3743553.4420488174,
-              4581961.863286629
-            ),
-          ];
-          let polygonHierarchy = { positions: positions };
-
-          let color = Cesium.Color.RED;
-          if (withAlpha) {
-            color = color.withAlpha(0.5);
-          }
-
-          scene.groundPrimitives.add(
-            new Cesium.GroundPrimitive({
-              geometryInstances: new Cesium.GeometryInstance({
-                geometry: new Cesium.PolygonGeometry({
-                  polygonHierarchy: polygonHierarchy,
-                }),
-                attributes: {
-                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(color),
-                },
-                id: "polygon 1",
-              }),
-              classificationType: Cesium.ClassificationType.TERRAIN,
-            })
-          );
-
-          // Same polygon slightly offset and overlapping.
-          let positionsOffset = offsetPositions(positions, 0.01);
-          polygonHierarchy = { positions: positionsOffset };
-
-          color = Cesium.Color.GREEN;
-          if (withAlpha) {
-            color = color.withAlpha(0.5);
-          }
-
-          scene.groundPrimitives.add(
-            new Cesium.GroundPrimitive({
-              geometryInstances: new Cesium.GeometryInstance({
-                geometry: new Cesium.PolygonGeometry({
-                  polygonHierarchy: polygonHierarchy,
-                }),
-                attributes: {
-                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(color),
-                },
-                id: "polygon 2",
-              }),
-              classificationType: Cesium.ClassificationType.TERRAIN,
-            })
-          );
-
-          // Same polygon slightly offset and overlapping.
-          positionsOffset = offsetPositions(positions, -0.01);
-          polygonHierarchy = { positions: positionsOffset };
-
-          color = Cesium.Color.BLUE;
-          if (withAlpha) {
-            color = color.withAlpha(0.5);
-          }
-
-          scene.groundPrimitives.add(
-            new Cesium.GroundPrimitive({
-              geometryInstances: new Cesium.GeometryInstance({
-                geometry: new Cesium.PolygonGeometry({
-                  polygonHierarchy: polygonHierarchy,
-                }),
-                attributes: {
-                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(color),
-                },
-                id: "polygon 3",
-              }),
-              classificationType: Cesium.ClassificationType.TERRAIN,
-            })
-          );
-        }
-
-        function viewOverlappingPolygons() {
-          viewer.camera.lookAt(
-            new Cesium.Cartesian3(
-              -2354331.3069306486,
-              -3742016.2427205616,
-              4581875.591571755
-            ),
-            new Cesium.HeadingPitchRange(
-              Cesium.Math.toRadians(20.0),
-              Cesium.Math.toRadians(-35.0),
-              10000.0
-            )
-          );
-          viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-        }
-
-        let handler;
-
-        Sandcastle.addDefaultToolbarButton("Picking Example", function () {
-          createOverlappingPolygons(true);
-          viewOverlappingPolygons();
-
-          let currentObject;
-          let lastColor;
-
-          handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
-          handler.setInputAction(function (movement) {
-            const pickedObject = scene.pick(movement.endPosition);
-            if (
-              Cesium.defined(pickedObject) &&
-              pickedObject !== currentObject
-            ) {
-              if (Cesium.defined(currentObject)) {
-                currentObject.primitive.getGeometryInstanceAttributes(
-                  currentObject.id
-                ).color = lastColor;
-              }
-
-              currentObject = pickedObject;
-
-              const attributes = currentObject.primitive.getGeometryInstanceAttributes(
-                currentObject.id
-              );
-              lastColor = attributes.color;
-              attributes.color = [255, 255, 0, 128];
-            } else if (
-              !Cesium.defined(pickedObject) &&
-              Cesium.defined(currentObject)
-            ) {
-              currentObject.primitive.getGeometryInstanceAttributes(
-                currentObject.id
-              ).color = lastColor;
-              currentObject = undefined;
+          function offsetPositions(positions, degreeOffset) {
+            positions = scene.globe.ellipsoid.cartesianArrayToCartographicArray(
+              positions
+            );
+            const delta = Cesium.Math.toRadians(degreeOffset);
+            for (let i = 0; i < positions.length; ++i) {
+              const position = positions[i];
+              position.latitude += delta;
+              position.longitude += delta;
             }
-          }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-        });
+            return scene.globe.ellipsoid.cartographicArrayToCartesianArray(
+              positions
+            );
+          }
 
-        Sandcastle.addToolbarButton("Z-Order", function () {
-          createOverlappingPolygons(false);
-          viewOverlappingPolygons();
+          function createOverlappingPolygons(withAlpha) {
+            const positions = [
+              new Cesium.Cartesian3(
+                -2358138.847340281,
+                -3744072.459541374,
+                4581158.5714175375
+              ),
+              new Cesium.Cartesian3(
+                -2357231.4925370603,
+                -3745103.7886602185,
+                4580702.9757762635
+              ),
+              new Cesium.Cartesian3(
+                -2355912.902205431,
+                -3744249.029778454,
+                4582402.154378103
+              ),
+              new Cesium.Cartesian3(
+                -2357208.0209552636,
+                -3743553.4420488174,
+                4581961.863286629
+              ),
+            ];
+            let polygonHierarchy = { positions: positions };
 
-          handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
-          handler.setInputAction(function (movement) {
-            const pickedObject = scene.pick(movement.endPosition);
-            if (Cesium.defined(pickedObject)) {
-              scene.groundPrimitives.raiseToTop(pickedObject.primitive);
+            let color = Cesium.Color.RED;
+            if (withAlpha) {
+              color = color.withAlpha(0.5);
             }
-          }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-        });
 
-        function createBatchedInstances(color, show) {
-          const instances = [];
-
-          const width = 0.02561343838881669;
-          const height = 0.019831817968480436;
-
-          let lat = 46.18147866629652;
-          let lon = -122.20406057655991;
-
-          const delta = 0.03;
-          const latDeltas = [0.0, 0.0, delta, 0.0];
-          const lonDeltas = [0.0, delta, 0.0, -delta];
-
-          const length = latDeltas.length;
-          for (let i = 0; i < length; ++i) {
-            lon = lon + lonDeltas[i];
-            lat = lat + latDeltas[i];
-
-            const west = lon;
-            const east = lon + width;
-            const south = lat;
-            const north = lat + height;
-
-            instances.push(
-              new Cesium.GeometryInstance({
-                geometry: new Cesium.RectangleGeometry({
-                  rectangle: Cesium.Rectangle.fromDegrees(
-                    west,
-                    south,
-                    east,
-                    north
-                  ),
+            scene.groundPrimitives.add(
+              new Cesium.GroundPrimitive({
+                geometryInstances: new Cesium.GeometryInstance({
+                  geometry: new Cesium.PolygonGeometry({
+                    polygonHierarchy: polygonHierarchy,
+                  }),
+                  attributes: {
+                    color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                      color
+                    ),
+                  },
+                  id: "polygon 1",
                 }),
-                attributes: {
-                  color: color,
-                  show: show,
-                },
-                id: `rectangle${i}`,
+                classificationType: Cesium.ClassificationType.TERRAIN,
+              })
+            );
+
+            // Same polygon slightly offset and overlapping.
+            let positionsOffset = offsetPositions(positions, 0.01);
+            polygonHierarchy = { positions: positionsOffset };
+
+            color = Cesium.Color.GREEN;
+            if (withAlpha) {
+              color = color.withAlpha(0.5);
+            }
+
+            scene.groundPrimitives.add(
+              new Cesium.GroundPrimitive({
+                geometryInstances: new Cesium.GeometryInstance({
+                  geometry: new Cesium.PolygonGeometry({
+                    polygonHierarchy: polygonHierarchy,
+                  }),
+                  attributes: {
+                    color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                      color
+                    ),
+                  },
+                  id: "polygon 2",
+                }),
+                classificationType: Cesium.ClassificationType.TERRAIN,
+              })
+            );
+
+            // Same polygon slightly offset and overlapping.
+            positionsOffset = offsetPositions(positions, -0.01);
+            polygonHierarchy = { positions: positionsOffset };
+
+            color = Cesium.Color.BLUE;
+            if (withAlpha) {
+              color = color.withAlpha(0.5);
+            }
+
+            scene.groundPrimitives.add(
+              new Cesium.GroundPrimitive({
+                geometryInstances: new Cesium.GeometryInstance({
+                  geometry: new Cesium.PolygonGeometry({
+                    polygonHierarchy: polygonHierarchy,
+                  }),
+                  attributes: {
+                    color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                      color
+                    ),
+                  },
+                  id: "polygon 3",
+                }),
+                classificationType: Cesium.ClassificationType.TERRAIN,
               })
             );
           }
 
-          return instances;
-        }
-
-        Sandcastle.addToolbarButton("Batching", function () {
-          const color = new Cesium.ColorGeometryInstanceAttribute(
-            0.0,
-            1.0,
-            1.0,
-            0.5
-          );
-          const show = new Cesium.ShowGeometryInstanceAttribute(true);
-          const instances = createBatchedInstances(color, show);
-          scene.groundPrimitives.add(
-            new Cesium.GroundPrimitive({
-              geometryInstances: instances,
-              classificationType: Cesium.ClassificationType.TERRAIN,
-            })
-          );
-
-          viewOverlappingPolygons();
-        });
-
-        Sandcastle.addToolbarButton("Batch Picking", function () {
-          let color = new Cesium.ColorGeometryInstanceAttribute(
-            0.0,
-            1.0,
-            1.0,
-            0.5
-          );
-          let show = new Cesium.ShowGeometryInstanceAttribute(true);
-          let instances = createBatchedInstances(color, show);
-
-          const primitive = scene.groundPrimitives.add(
-            new Cesium.GroundPrimitive({
-              geometryInstances: instances,
-              classificationType: Cesium.ClassificationType.TERRAIN,
-            })
-          );
-
-          color = new Cesium.ColorGeometryInstanceAttribute(1.0, 0.0, 1.0, 0.5);
-          show = new Cesium.ShowGeometryInstanceAttribute(false);
-          instances = createBatchedInstances(color, show);
-
-          // Edit id to differentiate between picked primitive and normally displayed primitive.
-          const pickIdPrefix = "pick";
-          for (let i = 0; i < instances.length; ++i) {
-            instances[i].id = pickIdPrefix + instances[i].id;
+          function viewOverlappingPolygons() {
+            viewer.camera.lookAt(
+              new Cesium.Cartesian3(
+                -2354331.3069306486,
+                -3742016.2427205616,
+                4581875.591571755
+              ),
+              new Cesium.HeadingPitchRange(
+                Cesium.Math.toRadians(20.0),
+                Cesium.Math.toRadians(-35.0),
+                10000.0
+              )
+            );
+            viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
           }
 
-          const pickPrimitive = scene.groundPrimitives.add(
-            new Cesium.GroundPrimitive({
-              geometryInstances: instances,
-              classificationType: Cesium.ClassificationType.TERRAIN,
-            })
-          );
+          let handler;
 
-          viewOverlappingPolygons();
+          Sandcastle.addDefaultToolbarButton("Picking Example", function () {
+            createOverlappingPolygons(true);
+            viewOverlappingPolygons();
 
-          let currentObject;
+            let currentObject;
+            let lastColor;
 
-          handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
-          handler.setInputAction(function (movement) {
-            const pickedObject = scene.pick(movement.endPosition);
-            if (
-              Cesium.defined(pickedObject) &&
-              pickedObject !== currentObject &&
-              pickedObject.id.indexOf(pickIdPrefix) === -1
-            ) {
-              if (Cesium.defined(currentObject)) {
+            handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
+            handler.setInputAction(function (movement) {
+              const pickedObject = scene.pick(movement.endPosition);
+              if (
+                Cesium.defined(pickedObject) &&
+                pickedObject !== currentObject
+              ) {
+                if (Cesium.defined(currentObject)) {
+                  currentObject.primitive.getGeometryInstanceAttributes(
+                    currentObject.id
+                  ).color = lastColor;
+                }
+
+                currentObject = pickedObject;
+
+                const attributes = currentObject.primitive.getGeometryInstanceAttributes(
+                  currentObject.id
+                );
+                lastColor = attributes.color;
+                attributes.color = [255, 255, 0, 128];
+              } else if (
+                !Cesium.defined(pickedObject) &&
+                Cesium.defined(currentObject)
+              ) {
+                currentObject.primitive.getGeometryInstanceAttributes(
+                  currentObject.id
+                ).color = lastColor;
+                currentObject = undefined;
+              }
+            }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+          });
+
+          Sandcastle.addToolbarButton("Z-Order", function () {
+            createOverlappingPolygons(false);
+            viewOverlappingPolygons();
+
+            handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
+            handler.setInputAction(function (movement) {
+              const pickedObject = scene.pick(movement.endPosition);
+              if (Cesium.defined(pickedObject)) {
+                scene.groundPrimitives.raiseToTop(pickedObject.primitive);
+              }
+            }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+          });
+
+          function createBatchedInstances(color, show) {
+            const instances = [];
+
+            const width = 0.02561343838881669;
+            const height = 0.019831817968480436;
+
+            let lat = 46.18147866629652;
+            let lon = -122.20406057655991;
+
+            const delta = 0.03;
+            const latDeltas = [0.0, 0.0, delta, 0.0];
+            const lonDeltas = [0.0, delta, 0.0, -delta];
+
+            const length = latDeltas.length;
+            for (let i = 0; i < length; ++i) {
+              lon = lon + lonDeltas[i];
+              lat = lat + latDeltas[i];
+
+              const west = lon;
+              const east = lon + width;
+              const south = lat;
+              const north = lat + height;
+
+              instances.push(
+                new Cesium.GeometryInstance({
+                  geometry: new Cesium.RectangleGeometry({
+                    rectangle: Cesium.Rectangle.fromDegrees(
+                      west,
+                      south,
+                      east,
+                      north
+                    ),
+                  }),
+                  attributes: {
+                    color: color,
+                    show: show,
+                  },
+                  id: `rectangle${i}`,
+                })
+              );
+            }
+
+            return instances;
+          }
+
+          Sandcastle.addToolbarButton("Batching", function () {
+            const color = new Cesium.ColorGeometryInstanceAttribute(
+              0.0,
+              1.0,
+              1.0,
+              0.5
+            );
+            const show = new Cesium.ShowGeometryInstanceAttribute(true);
+            const instances = createBatchedInstances(color, show);
+            scene.groundPrimitives.add(
+              new Cesium.GroundPrimitive({
+                geometryInstances: instances,
+                classificationType: Cesium.ClassificationType.TERRAIN,
+              })
+            );
+
+            viewOverlappingPolygons();
+          });
+
+          Sandcastle.addToolbarButton("Batch Picking", function () {
+            let color = new Cesium.ColorGeometryInstanceAttribute(
+              0.0,
+              1.0,
+              1.0,
+              0.5
+            );
+            let show = new Cesium.ShowGeometryInstanceAttribute(true);
+            let instances = createBatchedInstances(color, show);
+
+            const primitive = scene.groundPrimitives.add(
+              new Cesium.GroundPrimitive({
+                geometryInstances: instances,
+                classificationType: Cesium.ClassificationType.TERRAIN,
+              })
+            );
+
+            color = new Cesium.ColorGeometryInstanceAttribute(
+              1.0,
+              0.0,
+              1.0,
+              0.5
+            );
+            show = new Cesium.ShowGeometryInstanceAttribute(false);
+            instances = createBatchedInstances(color, show);
+
+            // Edit id to differentiate between picked primitive and normally displayed primitive.
+            const pickIdPrefix = "pick";
+            for (let i = 0; i < instances.length; ++i) {
+              instances[i].id = pickIdPrefix + instances[i].id;
+            }
+
+            const pickPrimitive = scene.groundPrimitives.add(
+              new Cesium.GroundPrimitive({
+                geometryInstances: instances,
+                classificationType: Cesium.ClassificationType.TERRAIN,
+              })
+            );
+
+            viewOverlappingPolygons();
+
+            let currentObject;
+
+            handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
+            handler.setInputAction(function (movement) {
+              const pickedObject = scene.pick(movement.endPosition);
+              if (
+                Cesium.defined(pickedObject) &&
+                pickedObject !== currentObject &&
+                pickedObject.id.indexOf(pickIdPrefix) === -1
+              ) {
+                if (Cesium.defined(currentObject)) {
+                  primitive.getGeometryInstanceAttributes(
+                    currentObject.id
+                  ).show = [1];
+                  pickPrimitive.getGeometryInstanceAttributes(
+                    pickIdPrefix + currentObject.id
+                  ).show = [0];
+                }
+
+                currentObject = pickedObject;
+
+                primitive.getGeometryInstanceAttributes(
+                  currentObject.id
+                ).show = [0];
+                pickPrimitive.getGeometryInstanceAttributes(
+                  pickIdPrefix + currentObject.id
+                ).show = [1];
+              } else if (
+                !Cesium.defined(pickedObject) &&
+                Cesium.defined(currentObject)
+              ) {
                 primitive.getGeometryInstanceAttributes(
                   currentObject.id
                 ).show = [1];
                 pickPrimitive.getGeometryInstanceAttributes(
                   pickIdPrefix + currentObject.id
                 ).show = [0];
+                currentObject = undefined;
               }
+            }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+          });
 
-              currentObject = pickedObject;
-
-              primitive.getGeometryInstanceAttributes(currentObject.id).show = [
-                0,
-              ];
-              pickPrimitive.getGeometryInstanceAttributes(
-                pickIdPrefix + currentObject.id
-              ).show = [1];
-            } else if (
-              !Cesium.defined(pickedObject) &&
-              Cesium.defined(currentObject)
-            ) {
-              primitive.getGeometryInstanceAttributes(currentObject.id).show = [
-                1,
-              ];
-              pickPrimitive.getGeometryInstanceAttributes(
-                pickIdPrefix + currentObject.id
-              ).show = [0];
-              currentObject = undefined;
-            }
-          }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-        });
-
-        Sandcastle.addToolbarButton("Create large polygons", function () {
-          // Circle geometry
-          scene.groundPrimitives.add(
-            new Cesium.GroundPrimitive({
-              geometryInstances: new Cesium.GeometryInstance({
-                geometry: new Cesium.CircleGeometry({
-                  center: Cesium.Cartesian3.fromDegrees(-95.0, 45.0),
-                  radius: 250000.0,
+          Sandcastle.addToolbarButton("Create large polygons", function () {
+            // Circle geometry
+            scene.groundPrimitives.add(
+              new Cesium.GroundPrimitive({
+                geometryInstances: new Cesium.GeometryInstance({
+                  geometry: new Cesium.CircleGeometry({
+                    center: Cesium.Cartesian3.fromDegrees(-95.0, 45.0),
+                    radius: 250000.0,
+                  }),
+                  attributes: {
+                    color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                      new Cesium.Color(1.0, 0.0, 0.0, 0.5)
+                    ),
+                  },
+                  id: "circle",
                 }),
-                attributes: {
-                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                    new Cesium.Color(1.0, 0.0, 0.0, 0.5)
-                  ),
-                },
-                id: "circle",
-              }),
-              classificationType: Cesium.ClassificationType.TERRAIN,
-            })
-          );
+                classificationType: Cesium.ClassificationType.TERRAIN,
+              })
+            );
 
-          // Ellipse Geometry
-          scene.groundPrimitives.add(
-            new Cesium.GroundPrimitive({
-              geometryInstances: new Cesium.GeometryInstance({
-                geometry: new Cesium.EllipseGeometry({
-                  center: Cesium.Cartesian3.fromDegrees(-105.0, 40.0),
-                  semiMinorAxis: 300000.0,
-                  semiMajorAxis: 400000.0,
+            // Ellipse Geometry
+            scene.groundPrimitives.add(
+              new Cesium.GroundPrimitive({
+                geometryInstances: new Cesium.GeometryInstance({
+                  geometry: new Cesium.EllipseGeometry({
+                    center: Cesium.Cartesian3.fromDegrees(-105.0, 40.0),
+                    semiMinorAxis: 300000.0,
+                    semiMajorAxis: 400000.0,
+                  }),
+                  attributes: {
+                    color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                      new Cesium.Color(0.0, 1.0, 1.0, 0.5)
+                    ),
+                  },
+                  id: "ellipse",
                 }),
-                attributes: {
-                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                    new Cesium.Color(0.0, 1.0, 1.0, 0.5)
-                  ),
-                },
-                id: "ellipse",
-              }),
-              classificationType: Cesium.ClassificationType.TERRAIN,
-            })
-          );
+                classificationType: Cesium.ClassificationType.TERRAIN,
+              })
+            );
 
-          // Corridor Geometry
-          scene.groundPrimitives.add(
-            new Cesium.GroundPrimitive({
-              geometryInstances: new Cesium.GeometryInstance({
-                geometry: new Cesium.CorridorGeometry({
-                  positions: Cesium.Cartesian3.fromDegreesArray([
-                    -112.0,
-                    40.0,
-                    -117.0,
-                    40.0,
-                    -117.0,
-                    35.0,
-                  ]),
-                  width: 200000.0,
+            // Corridor Geometry
+            scene.groundPrimitives.add(
+              new Cesium.GroundPrimitive({
+                geometryInstances: new Cesium.GeometryInstance({
+                  geometry: new Cesium.CorridorGeometry({
+                    positions: Cesium.Cartesian3.fromDegreesArray([
+                      -112.0,
+                      40.0,
+                      -117.0,
+                      40.0,
+                      -117.0,
+                      35.0,
+                    ]),
+                    width: 200000.0,
+                  }),
+                  attributes: {
+                    color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                      new Cesium.Color(0.0, 0.0, 1.0, 0.5)
+                    ),
+                  },
+                  id: "corridor",
                 }),
-                attributes: {
-                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                    new Cesium.Color(0.0, 0.0, 1.0, 0.5)
-                  ),
-                },
-                id: "corridor",
-              }),
-              classificationType: Cesium.ClassificationType.TERRAIN,
-            })
-          );
+                classificationType: Cesium.ClassificationType.TERRAIN,
+              })
+            );
 
-          // Rectangle geometry
-          scene.groundPrimitives.add(
-            new Cesium.GroundPrimitive({
-              geometryInstances: new Cesium.GeometryInstance({
-                geometry: new Cesium.RectangleGeometry({
-                  rectangle: Cesium.Rectangle.fromDegrees(
-                    -100.0,
-                    30.0,
-                    -90.0,
-                    40.0
-                  ),
-                  rotation: Cesium.Math.toRadians(45),
+            // Rectangle geometry
+            scene.groundPrimitives.add(
+              new Cesium.GroundPrimitive({
+                geometryInstances: new Cesium.GeometryInstance({
+                  geometry: new Cesium.RectangleGeometry({
+                    rectangle: Cesium.Rectangle.fromDegrees(
+                      -100.0,
+                      30.0,
+                      -90.0,
+                      40.0
+                    ),
+                    rotation: Cesium.Math.toRadians(45),
+                  }),
+                  attributes: {
+                    color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                      new Cesium.Color(0.0, 1.0, 0.0, 0.5)
+                    ),
+                  },
+                  id: "rectangle",
                 }),
-                attributes: {
-                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                    new Cesium.Color(0.0, 1.0, 0.0, 0.5)
-                  ),
-                },
-                id: "rectangle",
-              }),
-              classificationType: Cesium.ClassificationType.TERRAIN,
-            })
-          );
+                classificationType: Cesium.ClassificationType.TERRAIN,
+              })
+            );
 
-          // Rhumb line polygon geometry
-          scene.groundPrimitives.add(
-            new Cesium.GroundPrimitive({
-              geometryInstances: new Cesium.GeometryInstance({
-                geometry: new Cesium.PolygonGeometry({
-                  polygonHierarchy: new Cesium.PolygonHierarchy(
-                    Cesium.Cartesian3.fromDegreesArray([
-                      -130,
-                      55,
-                      -100,
-                      55,
-                      -100,
-                      45,
-                      -130,
-                      45,
-                    ])
-                  ),
-                  arcType: Cesium.ArcType.RHUMB,
+            // Rhumb line polygon geometry
+            scene.groundPrimitives.add(
+              new Cesium.GroundPrimitive({
+                geometryInstances: new Cesium.GeometryInstance({
+                  geometry: new Cesium.PolygonGeometry({
+                    polygonHierarchy: new Cesium.PolygonHierarchy(
+                      Cesium.Cartesian3.fromDegreesArray([
+                        -130,
+                        55,
+                        -100,
+                        55,
+                        -100,
+                        45,
+                        -130,
+                        45,
+                      ])
+                    ),
+                    arcType: Cesium.ArcType.RHUMB,
+                  }),
+                  attributes: {
+                    color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                      new Cesium.Color(1.0, 1.0, 0.0, 0.5)
+                    ),
+                  },
+                  id: "rhumbPolygon",
                 }),
-                attributes: {
-                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                    new Cesium.Color(1.0, 1.0, 0.0, 0.5)
-                  ),
-                },
-                id: "rhumbPolygon",
-              }),
-              classificationType: Cesium.ClassificationType.TERRAIN,
-            })
-          );
-        });
+                classificationType: Cesium.ClassificationType.TERRAIN,
+              })
+            );
+          });
 
-        Sandcastle.reset = function () {
-          scene.groundPrimitives.removeAll();
-          handler = handler && handler.destroy();
+          Sandcastle.reset = function () {
+            scene.groundPrimitives.removeAll();
+            handler = handler && handler.destroy();
 
-          //Set the camera to a US centered tilted view and switch back to moving in world coordinates.
-          viewer.camera.lookAt(
-            Cesium.Cartesian3.fromDegrees(-98.0, 40.0),
-            new Cesium.Cartesian3(0.0, -4790000.0, 3930000.0)
-          );
-          viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-        };
-
-        //Sandcastle_End
+            //Set the camera to a US centered tilted view and switch back to moving in world coordinates.
+            viewer.camera.lookAt(
+              Cesium.Cartesian3.fromDegrees(-98.0, 40.0),
+              new Cesium.Cartesian3(0.0, -4790000.0, 3930000.0)
+            );
+            viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+          };
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/development/Ground Primitive.html
+++ b/Apps/Sandcastle/gallery/development/Ground Primitive.html
@@ -36,7 +36,7 @@
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
         const scene = viewer.scene;
         viewer.extend(Cesium.viewerCesiumInspectorMixin);

--- a/Apps/Sandcastle/gallery/development/Many Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/development/Many Clipping Planes.html
@@ -72,7 +72,7 @@
           selectionIndicator: false,
           shouldAnimate: true,
           projectionPicker: true,
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         viewer.extend(Cesium.viewerCesium3DTilesInspectorMixin);

--- a/Apps/Sandcastle/gallery/development/Many Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/development/Many Clipping Planes.html
@@ -67,277 +67,266 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          infoBox: false,
-          selectionIndicator: false,
-          shouldAnimate: true,
-          projectionPicker: true,
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
-
-        viewer.extend(Cesium.viewerCesium3DTilesInspectorMixin);
-
-        const globe = viewer.scene.globe;
-        globe.depthTestAgainstTerrain = true;
-
-        let cylinderRadius = -20.0;
-        let radiusMultiplier = 1.0;
-
-        let steps = 32;
-        let clippingPlanes = [];
-        let modelEntityClippingPlanes;
-        let clippingModeUnion = false;
-        let enabled = true;
-
-        const clipObjects = ["model", "b3dm", "pnts", "i3dm", "terrain"];
-        const viewModel = {
-          cylinderRadius: cylinderRadius,
-          exampleTypes: clipObjects,
-          currentExampleType: clipObjects[0],
-          planeCount: steps,
-        };
-
-        Cesium.knockout.track(viewModel);
-
-        const toolbar = document.getElementById("toolbar");
-        Cesium.knockout.applyBindings(viewModel, toolbar);
-
-        Cesium.knockout
-          .getObservable(viewModel, "cylinderRadius")
-          .subscribe(function (newValue) {
-            cylinderRadius = parseFloat(viewModel.cylinderRadius);
-            updatePlanes();
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            infoBox: false,
+            selectionIndicator: false,
+            shouldAnimate: true,
+            projectionPicker: true,
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
           });
 
-        Cesium.knockout
-          .getObservable(viewModel, "planeCount")
-          .subscribe(function (newValue) {
-            const newSteps = parseFloat(viewModel.planeCount);
-            if (newSteps !== steps) {
-              steps = newSteps;
-              modelEntityClippingPlanes.removeAll();
-              computePlanes();
-            }
-          });
+          viewer.extend(Cesium.viewerCesium3DTilesInspectorMixin);
 
-        const scene = viewer.scene;
-        const planeEntities = [];
-        let selectedPlane;
+          const globe = viewer.scene.globe;
+          globe.depthTestAgainstTerrain = true;
 
-        function updatePlanes() {
-          for (let i = 0; i < clippingPlanes.length; i++) {
-            const plane = clippingPlanes[i];
-            plane.distance = cylinderRadius * radiusMultiplier;
-          }
-        }
+          let cylinderRadius = -20.0;
+          let radiusMultiplier = 1.0;
 
-        function computePlanes() {
-          const stepDegrees = Cesium.Math.TWO_PI / steps;
-          clippingPlanes = [];
+          let steps = 32;
+          let clippingPlanes = [];
+          let modelEntityClippingPlanes;
+          let clippingModeUnion = false;
+          let enabled = true;
 
-          for (let i = 0; i < steps; i++) {
-            const angle = i * stepDegrees;
-            const dir = new Cesium.Cartesian3();
-            dir.x = 1.0;
-            dir.y = Math.tan(angle);
-            if (angle > Cesium.Math.PI_OVER_TWO) {
-              dir.x = -1.0;
-              dir.y *= -1.0;
-            }
-            if (angle > Cesium.Math.PI) {
-              dir.x = -1.0;
-            }
-            if (angle > Cesium.Math.PI_OVER_TWO * 3) {
-              dir.x = 1.0;
-              dir.y = -dir.y;
-            }
-            Cesium.Cartesian3.normalize(dir, dir);
-            const newPlane = new Cesium.ClippingPlane(
-              dir,
-              cylinderRadius * radiusMultiplier
-            );
-            modelEntityClippingPlanes.add(newPlane);
-            clippingPlanes.push(newPlane);
-          }
-        }
+          const clipObjects = ["model", "b3dm", "pnts", "i3dm", "terrain"];
+          const viewModel = {
+            cylinderRadius: cylinderRadius,
+            exampleTypes: clipObjects,
+            currentExampleType: clipObjects[0],
+            planeCount: steps,
+          };
 
-        function createClippingPlanes(modelMatrix) {
-          modelEntityClippingPlanes = new Cesium.ClippingPlaneCollection({
-            modelMatrix: Cesium.defined(modelMatrix)
-              ? modelMatrix
-              : Cesium.Matrix4.IDENTITY,
-            edgeWidth: 2.0,
-            edgeColor: Cesium.Color.WHITE,
-            unionClippingRegions: clippingModeUnion,
-            enabled: enabled,
-          });
-          computePlanes();
-        }
+          Cesium.knockout.track(viewModel);
 
-        function updateClippingPlanes() {
-          return modelEntityClippingPlanes;
-        }
+          const toolbar = document.getElementById("toolbar");
+          Cesium.knockout.applyBindings(viewModel, toolbar);
 
-        const modelUrl = "../../SampleData/models/CesiumAir/Cesium_Air.glb";
-        const agiHqUrl = Cesium.IonResource.fromAssetId(40866);
-        const instancedUrl =
-          "../../SampleData/Cesium3DTiles/Instanced/InstancedOrientation/tileset.json";
-        const pointCloudUrl = Cesium.IonResource.fromAssetId(5713);
-
-        function loadModel(url) {
-          createClippingPlanes();
-          const position = Cesium.Cartesian3.fromDegrees(
-            -123.0744619,
-            44.0503706,
-            300.0
-          );
-          const heading = 0.0;
-          const pitch = 0.0;
-          const roll = 0.0;
-          const hpr = new Cesium.HeadingPitchRoll(heading, pitch, roll);
-          const orientation = Cesium.Transforms.headingPitchRollQuaternion(
-            position,
-            hpr
-          );
-          const entity = viewer.entities.add({
-            name: url,
-            position: position,
-            orientation: orientation,
-            model: {
-              uri: url,
-              scale: 20,
-              minimumPixelSize: 100.0,
-              clippingPlanes: new Cesium.CallbackProperty(
-                updateClippingPlanes,
-                false
-              ),
-            },
-          });
-          viewer.trackedEntity = entity;
-        }
-
-        let tileset;
-        function loadTileset(url, height) {
-          createClippingPlanes();
-          tileset = viewer.scene.primitives.add(
-            new Cesium.Cesium3DTileset({
-              url: url,
-              clippingPlanes: modelEntityClippingPlanes,
-              enableDebugWireframe: true,
-            })
-          );
-
-          return tileset.readyPromise
-            .then(function () {
-              const boundingSphere = tileset.boundingSphere;
-
-              const cartographic = Cesium.Cartographic.fromCartesian(
-                boundingSphere.center
-              );
-              const surface = Cesium.Cartesian3.fromRadians(
-                cartographic.longitude,
-                cartographic.latitude,
-                0.0
-              );
-              const offset = Cesium.Cartesian3.fromRadians(
-                cartographic.longitude,
-                cartographic.latitude,
-                height
-              );
-              const translation = Cesium.Cartesian3.subtract(
-                offset,
-                surface,
-                new Cesium.Cartesian3()
-              );
-              tileset.modelMatrix = Cesium.Matrix4.fromTranslation(translation);
-
-              const radius = boundingSphere.radius;
-              viewer.camera.viewBoundingSphere(
-                boundingSphere,
-                new Cesium.HeadingPitchRange(0.5, -0.2, radius * 4.0)
-              );
-              viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-            })
-            .catch(function (error) {
-              throw error;
+          Cesium.knockout
+            .getObservable(viewModel, "cylinderRadius")
+            .subscribe(function (newValue) {
+              cylinderRadius = parseFloat(viewModel.cylinderRadius);
+              updatePlanes();
             });
-        }
 
-        loadModel(modelUrl);
+          Cesium.knockout
+            .getObservable(viewModel, "planeCount")
+            .subscribe(function (newValue) {
+              const newSteps = parseFloat(viewModel.planeCount);
+              if (newSteps !== steps) {
+                steps = newSteps;
+                modelEntityClippingPlanes.removeAll();
+                computePlanes();
+              }
+            });
 
-        Cesium.knockout
-          .getObservable(viewModel, "currentExampleType")
-          .subscribe(function (newValue) {
-            reset();
+          const scene = viewer.scene;
+          const planeEntities = [];
+          let selectedPlane;
 
-            if (newValue === clipObjects[0]) {
-              // Model
-              loadModel(modelUrl);
-            } else if (newValue === clipObjects[1]) {
-              // B3dm photogrammetry
-              agiHqUrl.then(function (resource) {
-                return loadTileset(resource, 0.0);
-              });
-            } else if (newValue === clipObjects[2]) {
-              // Point clouds
-              radiusMultiplier = 20.0;
-              pointCloudUrl
-                .then(function (resource) {
-                  return loadTileset(resource, 0.0);
-                })
-                .then(function () {
+          function updatePlanes() {
+            for (let i = 0; i < clippingPlanes.length; i++) {
+              const plane = clippingPlanes[i];
+              plane.distance = cylinderRadius * radiusMultiplier;
+            }
+          }
+
+          function computePlanes() {
+            const stepDegrees = Cesium.Math.TWO_PI / steps;
+            clippingPlanes = [];
+
+            for (let i = 0; i < steps; i++) {
+              const angle = i * stepDegrees;
+              const dir = new Cesium.Cartesian3();
+              dir.x = 1.0;
+              dir.y = Math.tan(angle);
+              if (angle > Cesium.Math.PI_OVER_TWO) {
+                dir.x = -1.0;
+                dir.y *= -1.0;
+              }
+              if (angle > Cesium.Math.PI) {
+                dir.x = -1.0;
+              }
+              if (angle > Cesium.Math.PI_OVER_TWO * 3) {
+                dir.x = 1.0;
+                dir.y = -dir.y;
+              }
+              Cesium.Cartesian3.normalize(dir, dir);
+              const newPlane = new Cesium.ClippingPlane(
+                dir,
+                cylinderRadius * radiusMultiplier
+              );
+              modelEntityClippingPlanes.add(newPlane);
+              clippingPlanes.push(newPlane);
+            }
+          }
+
+          function createClippingPlanes(modelMatrix) {
+            modelEntityClippingPlanes = new Cesium.ClippingPlaneCollection({
+              modelMatrix: Cesium.defined(modelMatrix)
+                ? modelMatrix
+                : Cesium.Matrix4.IDENTITY,
+              edgeWidth: 2.0,
+              edgeColor: Cesium.Color.WHITE,
+              unionClippingRegions: clippingModeUnion,
+              enabled: enabled,
+            });
+            computePlanes();
+          }
+
+          function updateClippingPlanes() {
+            return modelEntityClippingPlanes;
+          }
+
+          const modelUrl = "../../SampleData/models/CesiumAir/Cesium_Air.glb";
+          const agiHqUrl = await Cesium.IonResource.fromAssetId(40866);
+          const instancedUrl =
+            "../../SampleData/Cesium3DTiles/Instanced/InstancedOrientation/tileset.json";
+          const pointCloudUrl = await Cesium.IonResource.fromAssetId(5713);
+
+          function loadModel(url) {
+            createClippingPlanes();
+            const position = Cesium.Cartesian3.fromDegrees(
+              -123.0744619,
+              44.0503706,
+              300.0
+            );
+            const heading = 0.0;
+            const pitch = 0.0;
+            const roll = 0.0;
+            const hpr = new Cesium.HeadingPitchRoll(heading, pitch, roll);
+            const orientation = Cesium.Transforms.headingPitchRollQuaternion(
+              position,
+              hpr
+            );
+            const entity = viewer.entities.add({
+              name: url,
+              position: position,
+              orientation: orientation,
+              model: {
+                uri: url,
+                scale: 20,
+                minimumPixelSize: 100.0,
+                clippingPlanes: new Cesium.CallbackProperty(
+                  updateClippingPlanes,
+                  false
+                ),
+              },
+            });
+            viewer.trackedEntity = entity;
+          }
+
+          let tileset;
+          async function loadTileset(url, height) {
+            createClippingPlanes();
+            tileset = viewer.scene.primitives.add(
+              new Cesium.Cesium3DTileset({
+                url: url,
+                clippingPlanes: modelEntityClippingPlanes,
+                enableDebugWireframe: true,
+              })
+            );
+
+            await tileset.readyPromise;
+            const boundingSphere = tileset.boundingSphere;
+
+            const cartographic = Cesium.Cartographic.fromCartesian(
+              boundingSphere.center
+            );
+            const surface = Cesium.Cartesian3.fromRadians(
+              cartographic.longitude,
+              cartographic.latitude,
+              0.0
+            );
+            const offset = Cesium.Cartesian3.fromRadians(
+              cartographic.longitude,
+              cartographic.latitude,
+              height
+            );
+            const translation = Cesium.Cartesian3.subtract(
+              offset,
+              surface,
+              new Cesium.Cartesian3()
+            );
+            tileset.modelMatrix = Cesium.Matrix4.fromTranslation(translation);
+
+            const radius = boundingSphere.radius;
+            viewer.camera.viewBoundingSphere(
+              boundingSphere,
+              new Cesium.HeadingPitchRange(0.5, -0.2, radius * 4.0)
+            );
+            viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+          }
+
+          loadModel(modelUrl);
+
+          Cesium.knockout
+            .getObservable(viewModel, "currentExampleType")
+            .subscribe(function (newValue) {
+              reset();
+
+              if (newValue === clipObjects[0]) {
+                // Model
+                loadModel(modelUrl);
+              } else if (newValue === clipObjects[1]) {
+                // B3dm photogrammetry
+                return loadTileset(agiHqUrl, 0.0);
+              } else if (newValue === clipObjects[2]) {
+                // Point clouds
+                radiusMultiplier = 20.0;
+                return loadTileset(pointCloudUrl, 0.0).then(function () {
                   tileset.pointCloudShading.attenuation = true;
                 });
-            } else if (newValue === clipObjects[3]) {
-              // i3dm
-              loadTileset(instancedUrl, 100.0);
-            } else if (newValue === clipObjects[4]) {
-              // Terrain
-              const position = Cesium.Cartesian3.fromRadians(
-                // eslint-disable-next-line no-loss-of-precision
-                -2.0872979473351286,
-                0.6596620013036164,
-                2380.0
-              );
-              const entity = viewer.entities.add({
-                position: position,
-                model: {
-                  uri: "../../SampleData/models/CesiumMan/Cesium_Man.glb",
-                  minimumPixelSize: 128,
-                  scale: 40,
-                },
-              });
-              viewer.trackedEntity = entity;
-              createClippingPlanes(
-                entity.computeModelMatrix(Cesium.JulianDate.now())
-              );
-              globe.clippingPlanes = modelEntityClippingPlanes;
-            }
-            updatePlanes();
+              } else if (newValue === clipObjects[3]) {
+                // i3dm
+                loadTileset(instancedUrl, 100.0);
+              } else if (newValue === clipObjects[4]) {
+                // Terrain
+                const position = Cesium.Cartesian3.fromRadians(
+                  // eslint-disable-next-line no-loss-of-precision
+                  -2.0872979473351286,
+                  0.6596620013036164,
+                  2380.0
+                );
+                const entity = viewer.entities.add({
+                  position: position,
+                  model: {
+                    uri: "../../SampleData/models/CesiumMan/Cesium_Man.glb",
+                    minimumPixelSize: 128,
+                    scale: 40,
+                  },
+                });
+                viewer.trackedEntity = entity;
+                createClippingPlanes(
+                  entity.computeModelMatrix(Cesium.JulianDate.now())
+                );
+                globe.clippingPlanes = modelEntityClippingPlanes;
+              }
+              updatePlanes();
+            });
+
+          function reset() {
+            radiusMultiplier = 1.0;
+            viewModel.cylinderRadius = cylinderRadius;
+            viewer.entities.removeAll();
+            viewer.scene.primitives.removeAll();
+            globe.clippingPlanes = undefined; // destroy Globe clipping planes, if any
+            modelEntityClippingPlanes = undefined;
+          }
+
+          Sandcastle.addToggleButton("union", clippingModeUnion, function (
+            checked
+          ) {
+            clippingModeUnion = checked;
+            modelEntityClippingPlanes.unionClippingRegions = clippingModeUnion;
           });
 
-        function reset() {
-          radiusMultiplier = 1.0;
-          viewModel.cylinderRadius = cylinderRadius;
-          viewer.entities.removeAll();
-          viewer.scene.primitives.removeAll();
-          globe.clippingPlanes = undefined; // destroy Globe clipping planes, if any
-          modelEntityClippingPlanes = undefined;
-        }
-
-        Sandcastle.addToggleButton("union", clippingModeUnion, function (
-          checked
-        ) {
-          clippingModeUnion = checked;
-          modelEntityClippingPlanes.unionClippingRegions = clippingModeUnion;
-        });
-
-        Sandcastle.addToggleButton("enabled", enabled, function (checked) {
-          enabled = checked;
-          modelEntityClippingPlanes.enabled = enabled;
-        });
-
-        //Sandcastle_End
+          Sandcastle.addToggleButton("enabled", enabled, function (checked) {
+            enabled = checked;
+            modelEntityClippingPlanes.enabled = enabled;
+          });
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/development/Multiple Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Multiple Shadows.html
@@ -47,7 +47,7 @@
           infoBox: false,
           selectionIndicator: false,
           timeline: false,
-          terrainProvider: Cesium.createWorldTerrain(),
+          terrainProvider: Cesium.createWorldTerrainAsync(),
         });
 
         const scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/development/Multiple Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Multiple Shadows.html
@@ -41,102 +41,108 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          scene3DOnly: true,
+          infoBox: false,
+          selectionIndicator: false,
+          timeline: false,
+        });
+
         (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            scene3DOnly: true,
-            infoBox: false,
-            selectionIndicator: false,
-            timeline: false,
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+          } catch (error) {
+            console.log(error);
+          }
+        })();
+
+        const scene = viewer.scene;
+        const camera = scene.camera;
+
+        scene.debugShowFramesPerSecond = true;
+
+        function addPrimitive(lon, lat, height, heading) {
+          const center = Cesium.Cartesian3.fromRadians(lon, lat, height);
+
+          const pointLightCamera = new Cesium.Camera(scene);
+          pointLightCamera.position = center;
+
+          camera.lookAt(center, new Cesium.Cartesian3(25.0, 25.0, 30.0));
+          camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+
+          const shadowMap = new Cesium.ShadowMap({
+            context: scene.context,
+            lightCamera: pointLightCamera,
+            isPointLight: true,
+            softShadows: false,
           });
 
-          const scene = viewer.scene;
-          const camera = scene.camera;
+          shadowMap.enabled = true;
 
-          scene.debugShowFramesPerSecond = true;
+          const model = scene.primitives.add(
+            Cesium.Model.fromGltf({
+              url:
+                "../../SampleData/models/ShadowTester/Shadow_Tester_Point.glb",
+              modelMatrix: Cesium.Transforms.headingPitchRollToFixedFrame(
+                center,
+                new Cesium.HeadingPitchRoll(heading, 0.0, 0.0)
+              ),
+            })
+          );
 
-          function addPrimitive(lon, lat, height, heading) {
-            const center = Cesium.Cartesian3.fromRadians(lon, lat, height);
-
-            const pointLightCamera = new Cesium.Camera(scene);
-            pointLightCamera.position = center;
-
-            camera.lookAt(center, new Cesium.Cartesian3(25.0, 25.0, 30.0));
-            camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-
-            const shadowMap = new Cesium.ShadowMap({
-              context: scene.context,
-              lightCamera: pointLightCamera,
-              isPointLight: true,
-              softShadows: false,
+          model.readyPromise
+            .then(function (model) {
+              // Play and loop all animations at half-speed
+              model.activeAnimations.addAll({
+                multiplier: 0.5,
+                loop: Cesium.ModelAnimationLoop.REPEAT,
+              });
+            })
+            .catch(function (error) {
+              window.alert(error);
             });
 
-            shadowMap.enabled = true;
+          return shadowMap;
+        }
 
-            const model = scene.primitives.add(
-              Cesium.Model.fromGltf({
-                url:
-                  "../../SampleData/models/ShadowTester/Shadow_Tester_Point.glb",
-                modelMatrix: Cesium.Transforms.headingPitchRollToFixedFrame(
-                  center,
-                  new Cesium.HeadingPitchRoll(heading, 0.0, 0.0)
-                ),
-              })
-            );
+        const longitude = -1.3324415110874286;
+        const latitude = 0.6954224325279967;
+        const height = 200.0;
 
-            model.readyPromise
-              .then(function (model) {
-                // Play and loop all animations at half-speed
-                model.activeAnimations.addAll({
-                  multiplier: 0.5,
-                  loop: Cesium.ModelAnimationLoop.REPEAT,
-                });
-              })
-              .catch(function (error) {
-                window.alert(error);
-              });
+        const shadowMap1 = addPrimitive(
+          longitude + 0.00005,
+          latitude,
+          height,
+          0.0
+        );
+        const shadowMap2 = addPrimitive(
+          longitude - 0.00005,
+          latitude,
+          height,
+          Math.PI
+        );
 
-            return shadowMap;
-          }
+        shadowMap1.debugShow = true;
+        shadowMap2.debugShow = false;
 
-          const longitude = -1.3324415110874286;
-          const latitude = 0.6954224325279967;
-          const height = 200.0;
+        Sandcastle.addToolbarButton("Debug Toggle", function () {
+          shadowMap1.debugShow = !shadowMap1.debugShow;
+          shadowMap2.debugShow = !shadowMap2.debugShow;
+        });
 
-          const shadowMap1 = addPrimitive(
-            longitude + 0.00005,
-            latitude,
-            height,
-            0.0
-          );
-          const shadowMap2 = addPrimitive(
-            longitude - 0.00005,
-            latitude,
-            height,
-            Math.PI
-          );
+        scene.shadowMap = shadowMap1;
 
-          shadowMap1.debugShow = true;
-          shadowMap2.debugShow = false;
+        // Workaround until Cesium supports multiple light sources
+        const CustomPrimitive = function (shadowMap) {
+          this.shadowMap = shadowMap;
+        };
 
-          Sandcastle.addToolbarButton("Debug Toggle", function () {
-            shadowMap1.debugShow = !shadowMap1.debugShow;
-            shadowMap2.debugShow = !shadowMap2.debugShow;
-          });
+        CustomPrimitive.prototype.update = function (frameState) {
+          frameState.shadowMaps.push(this.shadowMap);
+        };
 
-          scene.shadowMap = shadowMap1;
-
-          // Workaround until Cesium supports multiple light sources
-          const CustomPrimitive = function (shadowMap) {
-            this.shadowMap = shadowMap;
-          };
-
-          CustomPrimitive.prototype.update = function (frameState) {
-            frameState.shadowMaps.push(this.shadowMap);
-          };
-
-          scene.primitives.add(new CustomPrimitive(shadowMap2));
-        })(); //Sandcastle_End
+        scene.primitives.add(new CustomPrimitive(shadowMap2));
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/development/Multiple Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Multiple Shadows.html
@@ -41,103 +41,102 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          scene3DOnly: true,
-          infoBox: false,
-          selectionIndicator: false,
-          timeline: false,
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
-
-        const scene = viewer.scene;
-        const camera = scene.camera;
-
-        scene.debugShowFramesPerSecond = true;
-
-        function addPrimitive(lon, lat, height, heading) {
-          const center = Cesium.Cartesian3.fromRadians(lon, lat, height);
-
-          const pointLightCamera = new Cesium.Camera(scene);
-          pointLightCamera.position = center;
-
-          camera.lookAt(center, new Cesium.Cartesian3(25.0, 25.0, 30.0));
-          camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-
-          const shadowMap = new Cesium.ShadowMap({
-            context: scene.context,
-            lightCamera: pointLightCamera,
-            isPointLight: true,
-            softShadows: false,
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            scene3DOnly: true,
+            infoBox: false,
+            selectionIndicator: false,
+            timeline: false,
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
           });
 
-          shadowMap.enabled = true;
+          const scene = viewer.scene;
+          const camera = scene.camera;
 
-          const model = scene.primitives.add(
-            Cesium.Model.fromGltf({
-              url:
-                "../../SampleData/models/ShadowTester/Shadow_Tester_Point.glb",
-              modelMatrix: Cesium.Transforms.headingPitchRollToFixedFrame(
-                center,
-                new Cesium.HeadingPitchRoll(heading, 0.0, 0.0)
-              ),
-            })
-          );
+          scene.debugShowFramesPerSecond = true;
 
-          model.readyPromise
-            .then(function (model) {
-              // Play and loop all animations at half-speed
-              model.activeAnimations.addAll({
-                multiplier: 0.5,
-                loop: Cesium.ModelAnimationLoop.REPEAT,
-              });
-            })
-            .catch(function (error) {
-              window.alert(error);
+          function addPrimitive(lon, lat, height, heading) {
+            const center = Cesium.Cartesian3.fromRadians(lon, lat, height);
+
+            const pointLightCamera = new Cesium.Camera(scene);
+            pointLightCamera.position = center;
+
+            camera.lookAt(center, new Cesium.Cartesian3(25.0, 25.0, 30.0));
+            camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+
+            const shadowMap = new Cesium.ShadowMap({
+              context: scene.context,
+              lightCamera: pointLightCamera,
+              isPointLight: true,
+              softShadows: false,
             });
 
-          return shadowMap;
-        }
+            shadowMap.enabled = true;
 
-        const longitude = -1.3324415110874286;
-        const latitude = 0.6954224325279967;
-        const height = 200.0;
+            const model = scene.primitives.add(
+              Cesium.Model.fromGltf({
+                url:
+                  "../../SampleData/models/ShadowTester/Shadow_Tester_Point.glb",
+                modelMatrix: Cesium.Transforms.headingPitchRollToFixedFrame(
+                  center,
+                  new Cesium.HeadingPitchRoll(heading, 0.0, 0.0)
+                ),
+              })
+            );
 
-        const shadowMap1 = addPrimitive(
-          longitude + 0.00005,
-          latitude,
-          height,
-          0.0
-        );
-        const shadowMap2 = addPrimitive(
-          longitude - 0.00005,
-          latitude,
-          height,
-          Math.PI
-        );
+            model.readyPromise
+              .then(function (model) {
+                // Play and loop all animations at half-speed
+                model.activeAnimations.addAll({
+                  multiplier: 0.5,
+                  loop: Cesium.ModelAnimationLoop.REPEAT,
+                });
+              })
+              .catch(function (error) {
+                window.alert(error);
+              });
 
-        shadowMap1.debugShow = true;
-        shadowMap2.debugShow = false;
+            return shadowMap;
+          }
 
-        Sandcastle.addToolbarButton("Debug Toggle", function () {
-          shadowMap1.debugShow = !shadowMap1.debugShow;
-          shadowMap2.debugShow = !shadowMap2.debugShow;
-        });
+          const longitude = -1.3324415110874286;
+          const latitude = 0.6954224325279967;
+          const height = 200.0;
 
-        scene.shadowMap = shadowMap1;
+          const shadowMap1 = addPrimitive(
+            longitude + 0.00005,
+            latitude,
+            height,
+            0.0
+          );
+          const shadowMap2 = addPrimitive(
+            longitude - 0.00005,
+            latitude,
+            height,
+            Math.PI
+          );
 
-        // TODO : workaround until Cesium supports multiple light sources
-        const CustomPrimitive = function (shadowMap) {
-          this.shadowMap = shadowMap;
-        };
+          shadowMap1.debugShow = true;
+          shadowMap2.debugShow = false;
 
-        CustomPrimitive.prototype.update = function (frameState) {
-          frameState.shadowMaps.push(this.shadowMap);
-        };
+          Sandcastle.addToolbarButton("Debug Toggle", function () {
+            shadowMap1.debugShow = !shadowMap1.debugShow;
+            shadowMap2.debugShow = !shadowMap2.debugShow;
+          });
 
-        scene.primitives.add(new CustomPrimitive(shadowMap2));
+          scene.shadowMap = shadowMap1;
 
-        //Sandcastle_End
+          // Workaround until Cesium supports multiple light sources
+          const CustomPrimitive = function (shadowMap) {
+            this.shadowMap = shadowMap;
+          };
+
+          CustomPrimitive.prototype.update = function (frameState) {
+            frameState.shadowMaps.push(this.shadowMap);
+          };
+
+          scene.primitives.add(new CustomPrimitive(shadowMap2));
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/development/Picking.html
+++ b/Apps/Sandcastle/gallery/development/Picking.html
@@ -477,8 +477,8 @@
           },
           {
             text: "Vector tile polygons",
-            onselect: function () {
-              viewer.terrainProvider = Cesium.createWorldTerrain();
+            onselect: async function () {
+              viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
 
               tileset = viewer.scene.primitives.add(
                 new Cesium.Cesium3DTileset({
@@ -537,8 +537,8 @@
           },
           {
             text: "Vector tile polylines",
-            onselect: function () {
-              viewer.terrainProvider = Cesium.createWorldTerrain();
+            onselect: async function () {
+              viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
 
               tileset = viewer.scene.primitives.add(
                 new Cesium.Cesium3DTileset({

--- a/Apps/Sandcastle/gallery/development/Polylines On Terrain.html
+++ b/Apps/Sandcastle/gallery/development/Polylines On Terrain.html
@@ -53,315 +53,315 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync({
-            requestWaterMask: true,
-            requestVertexNormals: true,
-          }),
-        });
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync({
+              requestWaterMask: true,
+              requestVertexNormals: true,
+            }),
+          });
 
-        if (!Cesium.GroundPolylinePrimitive.isSupported(viewer.scene)) {
-          window.alert(
-            "Polylines on terrain are not supported on this platform."
+          if (!Cesium.GroundPolylinePrimitive.isSupported(viewer.scene)) {
+            window.alert(
+              "Polylines on terrain are not supported on this platform."
+            );
+          }
+
+          const polylineIds = ["polyline1", "polyline2"];
+          const groundPrimitiveId = "ground primitive";
+          let selectedId = polylineIds[0];
+          let polylineOnTerrainPrimitive;
+          let groundPrimitiveOnTop = false;
+
+          let lineWidth = 4.0;
+          const viewModel = {
+            lineWidth: lineWidth,
+          };
+
+          Cesium.knockout.track(viewModel);
+
+          const toolbar = document.getElementById("toolbar");
+          Cesium.knockout.applyBindings(viewModel, toolbar);
+
+          Cesium.knockout
+            .getObservable(viewModel, "lineWidth")
+            .subscribe(function (newValue) {
+              lineWidth = parseFloat(viewModel.lineWidth);
+              if (Cesium.defined(selectedId)) {
+                const attributes = polylineOnTerrainPrimitive.getGeometryInstanceAttributes(
+                  selectedId
+                );
+                lineWidth = parseFloat(viewModel.lineWidth);
+                attributes.width = [lineWidth];
+              }
+            });
+
+          const scene = viewer.scene;
+
+          // Add a Rectangle GroundPrimitive to demonstrate Z-indexing with GroundPrimitives
+          const rectangleGroundPrimitive = scene.groundPrimitives.add(
+            new Cesium.GroundPrimitive({
+              geometryInstances: new Cesium.GeometryInstance({
+                geometry: new Cesium.RectangleGeometry({
+                  rectangle: Cesium.Rectangle.fromDegrees(
+                    -112.1340164450331,
+                    36.05494287836128,
+                    -112.0840164450331,
+                    36.10494287836128
+                  ),
+                  vertexFormat: Cesium.EllipsoidSurfaceAppearance.VERTEX_FORMAT,
+                }),
+                id: groundPrimitiveId,
+              }),
+              appearance: new Cesium.EllipsoidSurfaceAppearance({
+                aboveGround: false,
+                material: Cesium.Material.fromType("Color"),
+              }),
+              classificationType: Cesium.ClassificationType.TERRAIN,
+            })
           );
-        }
 
-        const polylineIds = ["polyline1", "polyline2"];
-        const groundPrimitiveId = "ground primitive";
-        let selectedId = polylineIds[0];
-        let polylineOnTerrainPrimitive;
-        let groundPrimitiveOnTop = false;
+          const leftHandler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
+          leftHandler.setInputAction(function (movement) {
+            const pickedObject = viewer.scene.pick(movement.position);
+            if (Cesium.defined(pickedObject)) {
+              console.log(pickedObject.id);
+              // If picked the ground primitive, don't do anything
+              if (pickedObject.id !== groundPrimitiveId) {
+                selectedId = pickedObject.id;
 
-        let lineWidth = 4.0;
-        const viewModel = {
-          lineWidth: lineWidth,
-        };
+                // Sync line width in toolbar with selected
+                const attributes = polylineOnTerrainPrimitive.getGeometryInstanceAttributes(
+                  selectedId
+                );
+                viewModel.lineWidth = attributes.width[0];
+              }
+            } else {
+              selectedId = undefined;
+            }
+          }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
 
-        Cesium.knockout.track(viewModel);
+          const polylinePositions = Cesium.Cartesian3.fromDegreesArray([
+            -112.1340164450331,
+            36.05494287836128,
+            -112.08821010582645,
+            36.097804071380715,
+            -112.13296079730024,
+            36.168769146801104,
+            -112.10828895143331,
+            36.20031318533197,
+            -112.138548165717,
+            36.1691100215289, // hairpins
+            -112.11482556496543,
+            36.20127524083297,
+            -112.15921333464016,
+            36.17876011207708,
+            -112.14700151155604,
+            36.21683132404626,
+            -112.20919883052926,
+            36.19475754001766,
+          ]);
 
-        const toolbar = document.getElementById("toolbar");
-        Cesium.knockout.applyBindings(viewModel, toolbar);
+          const loopPositions = Cesium.Cartesian3.fromDegreesArray([
+            -111.94500779274114,
+            36.27638678884143,
+            -111.90983004392696,
+            36.07985366173454,
+            -111.80360100637773,
+            36.13694878292542,
+            -111.85510122419183,
+            36.26029588763386,
+            -111.69141601804614,
+            36.05128770351902,
+          ]);
 
-        Cesium.knockout
-          .getObservable(viewModel, "lineWidth")
-          .subscribe(function (newValue) {
-            lineWidth = parseFloat(viewModel.lineWidth);
+          function createPolylines(debugShowShadowVolume) {
+            const instance1 = new Cesium.GeometryInstance({
+              geometry: new Cesium.GroundPolylineGeometry({
+                positions: polylinePositions,
+                loop: false,
+                width: 4.0,
+              }),
+              id: polylineIds[0],
+              attributes: {
+                show: new Cesium.ShowGeometryInstanceAttribute(),
+                color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                  Cesium.Color.fromCssColorString("green").withAlpha(0.7)
+                ),
+              },
+            });
+
+            const instance2 = new Cesium.GeometryInstance({
+              geometry: new Cesium.GroundPolylineGeometry({
+                positions: loopPositions,
+                loop: true,
+                width: 8.0,
+              }),
+              id: polylineIds[1],
+              attributes: {
+                show: new Cesium.ShowGeometryInstanceAttribute(),
+                color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                  Cesium.Color.fromCssColorString("#67ADDF").withAlpha(0.7)
+                ),
+              },
+            });
+
+            polylineOnTerrainPrimitive = new Cesium.GroundPolylinePrimitive({
+              geometryInstances: [instance1, instance2],
+              debugShowShadowVolume: debugShowShadowVolume,
+            });
+            scene.groundPrimitives.add(polylineOnTerrainPrimitive);
+          }
+
+          function applyPerInstanceColor() {
+            polylineOnTerrainPrimitive.appearance = new Cesium.PolylineColorAppearance();
+          }
+          function applyColorMaterial() {
+            polylineOnTerrainPrimitive.appearance = new Cesium.PolylineMaterialAppearance(
+              {
+                material: Cesium.Material.fromType("Color", {
+                  color: new Cesium.Color(0.7, 0.0, 1.0, 1.0),
+                }),
+              }
+            );
+          }
+          function applyGlowMaterial() {
+            polylineOnTerrainPrimitive.appearance = new Cesium.PolylineMaterialAppearance(
+              {
+                material: Cesium.Material.fromType("PolylineGlow", {
+                  innerWidth: 1.0,
+                }),
+              }
+            );
+          }
+          function applyArrow() {
+            polylineOnTerrainPrimitive.appearance = new Cesium.PolylineMaterialAppearance(
+              {
+                material: Cesium.Material.fromType("PolylineArrow"),
+              }
+            );
+          }
+          function applyDash() {
+            polylineOnTerrainPrimitive.appearance = new Cesium.PolylineMaterialAppearance(
+              {
+                material: Cesium.Material.fromType("PolylineDash", {
+                  color: Cesium.Color.YELLOW,
+                }),
+              }
+            );
+          }
+          function applyOutline() {
+            polylineOnTerrainPrimitive.appearance = new Cesium.PolylineMaterialAppearance(
+              {
+                material: Cesium.Material.fromType("PolylineOutline"),
+              }
+            );
+          }
+
+          Sandcastle.addToolbarButton("Toggle instance show", function () {
             if (Cesium.defined(selectedId)) {
               const attributes = polylineOnTerrainPrimitive.getGeometryInstanceAttributes(
                 selectedId
               );
-              lineWidth = parseFloat(viewModel.lineWidth);
-              attributes.width = [lineWidth];
+              attributes.show = [attributes.show[0] ? 0 : 1];
             }
           });
 
-        const scene = viewer.scene;
-
-        // Add a Rectangle GroundPrimitive to demonstrate Z-indexing with GroundPrimitives
-        const rectangleGroundPrimitive = scene.groundPrimitives.add(
-          new Cesium.GroundPrimitive({
-            geometryInstances: new Cesium.GeometryInstance({
-              geometry: new Cesium.RectangleGeometry({
-                rectangle: Cesium.Rectangle.fromDegrees(
-                  -112.1340164450331,
-                  36.05494287836128,
-                  -112.0840164450331,
-                  36.10494287836128
-                ),
-                vertexFormat: Cesium.EllipsoidSurfaceAppearance.VERTEX_FORMAT,
-              }),
-              id: groundPrimitiveId,
-            }),
-            appearance: new Cesium.EllipsoidSurfaceAppearance({
-              aboveGround: false,
-              material: Cesium.Material.fromType("Color"),
-            }),
-            classificationType: Cesium.ClassificationType.TERRAIN,
-          })
-        );
-
-        const leftHandler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
-        leftHandler.setInputAction(function (movement) {
-          const pickedObject = viewer.scene.pick(movement.position);
-          if (Cesium.defined(pickedObject)) {
-            console.log(pickedObject.id);
-            // If picked the ground primitive, don't do anything
-            if (pickedObject.id !== groundPrimitiveId) {
-              selectedId = pickedObject.id;
-
-              // Sync line width in toolbar with selected
-              const attributes = polylineOnTerrainPrimitive.getGeometryInstanceAttributes(
-                selectedId
+          Sandcastle.addToolbarButton("Show all", function () {
+            if (Cesium.defined(selectedId)) {
+              let attributes = polylineOnTerrainPrimitive.getGeometryInstanceAttributes(
+                "polyline1"
               );
-              viewModel.lineWidth = attributes.width[0];
+              attributes.show = [1];
+              attributes = polylineOnTerrainPrimitive.getGeometryInstanceAttributes(
+                "polyline2"
+              );
+              attributes.show = [1];
             }
-          } else {
-            selectedId = undefined;
-          }
-        }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
-
-        const polylinePositions = Cesium.Cartesian3.fromDegreesArray([
-          -112.1340164450331,
-          36.05494287836128,
-          -112.08821010582645,
-          36.097804071380715,
-          -112.13296079730024,
-          36.168769146801104,
-          -112.10828895143331,
-          36.20031318533197,
-          -112.138548165717,
-          36.1691100215289, // hairpins
-          -112.11482556496543,
-          36.20127524083297,
-          -112.15921333464016,
-          36.17876011207708,
-          -112.14700151155604,
-          36.21683132404626,
-          -112.20919883052926,
-          36.19475754001766,
-        ]);
-
-        const loopPositions = Cesium.Cartesian3.fromDegreesArray([
-          -111.94500779274114,
-          36.27638678884143,
-          -111.90983004392696,
-          36.07985366173454,
-          -111.80360100637773,
-          36.13694878292542,
-          -111.85510122419183,
-          36.26029588763386,
-          -111.69141601804614,
-          36.05128770351902,
-        ]);
-
-        function createPolylines(debugShowShadowVolume) {
-          const instance1 = new Cesium.GeometryInstance({
-            geometry: new Cesium.GroundPolylineGeometry({
-              positions: polylinePositions,
-              loop: false,
-              width: 4.0,
-            }),
-            id: polylineIds[0],
-            attributes: {
-              show: new Cesium.ShowGeometryInstanceAttribute(),
-              color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                Cesium.Color.fromCssColorString("green").withAlpha(0.7)
-              ),
-            },
           });
 
-          const instance2 = new Cesium.GeometryInstance({
-            geometry: new Cesium.GroundPolylineGeometry({
-              positions: loopPositions,
-              loop: true,
-              width: 8.0,
-            }),
-            id: polylineIds[1],
-            attributes: {
-              show: new Cesium.ShowGeometryInstanceAttribute(),
-              color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                Cesium.Color.fromCssColorString("#67ADDF").withAlpha(0.7)
-              ),
-            },
+          Sandcastle.addToolbarButton(
+            "Toggle debugShowShadowVolume",
+            function () {
+              const debugShowShadowVolume = !polylineOnTerrainPrimitive.debugShowShadowVolume;
+              const appearance = polylineOnTerrainPrimitive.appearance;
+              scene.groundPrimitives.remove(polylineOnTerrainPrimitive);
+              createPolylines(debugShowShadowVolume);
+              polylineOnTerrainPrimitive.appearance = appearance;
+            }
+          );
+
+          Sandcastle.addToolbarButton("Toggle z-index", function () {
+            if (groundPrimitiveOnTop) {
+              scene.groundPrimitives.raiseToTop(polylineOnTerrainPrimitive);
+            } else {
+              scene.groundPrimitives.lowerToBottom(polylineOnTerrainPrimitive);
+            }
+            groundPrimitiveOnTop = !groundPrimitiveOnTop;
           });
 
-          polylineOnTerrainPrimitive = new Cesium.GroundPolylinePrimitive({
-            geometryInstances: [instance1, instance2],
-            debugShowShadowVolume: debugShowShadowVolume,
+          function lookAt() {
+            viewer.camera.lookAt(
+              polylinePositions[1],
+              new Cesium.Cartesian3(50000.0, 50000.0, 50000.0)
+            );
+            viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+          }
+
+          Sandcastle.addToolbarButton("reset view", function () {
+            lookAt();
           });
-          scene.groundPrimitives.add(polylineOnTerrainPrimitive);
-        }
 
-        function applyPerInstanceColor() {
-          polylineOnTerrainPrimitive.appearance = new Cesium.PolylineColorAppearance();
-        }
-        function applyColorMaterial() {
-          polylineOnTerrainPrimitive.appearance = new Cesium.PolylineMaterialAppearance(
-            {
-              material: Cesium.Material.fromType("Color", {
-                color: new Cesium.Color(0.7, 0.0, 1.0, 1.0),
-              }),
-            }
-          );
-        }
-        function applyGlowMaterial() {
-          polylineOnTerrainPrimitive.appearance = new Cesium.PolylineMaterialAppearance(
-            {
-              material: Cesium.Material.fromType("PolylineGlow", {
-                innerWidth: 1.0,
-              }),
-            }
-          );
-        }
-        function applyArrow() {
-          polylineOnTerrainPrimitive.appearance = new Cesium.PolylineMaterialAppearance(
-            {
-              material: Cesium.Material.fromType("PolylineArrow"),
-            }
-          );
-        }
-        function applyDash() {
-          polylineOnTerrainPrimitive.appearance = new Cesium.PolylineMaterialAppearance(
-            {
-              material: Cesium.Material.fromType("PolylineDash", {
-                color: Cesium.Color.YELLOW,
-              }),
-            }
-          );
-        }
-        function applyOutline() {
-          polylineOnTerrainPrimitive.appearance = new Cesium.PolylineMaterialAppearance(
-            {
-              material: Cesium.Material.fromType("PolylineOutline"),
-            }
-          );
-        }
+          createPolylines(false);
+          applyPerInstanceColor();
 
-        Sandcastle.addToolbarButton("Toggle instance show", function () {
-          if (Cesium.defined(selectedId)) {
-            const attributes = polylineOnTerrainPrimitive.getGeometryInstanceAttributes(
-              selectedId
-            );
-            attributes.show = [attributes.show[0] ? 0 : 1];
-          }
-        });
-
-        Sandcastle.addToolbarButton("Show all", function () {
-          if (Cesium.defined(selectedId)) {
-            let attributes = polylineOnTerrainPrimitive.getGeometryInstanceAttributes(
-              "polyline1"
-            );
-            attributes.show = [1];
-            attributes = polylineOnTerrainPrimitive.getGeometryInstanceAttributes(
-              "polyline2"
-            );
-            attributes.show = [1];
-          }
-        });
-
-        Sandcastle.addToolbarButton(
-          "Toggle debugShowShadowVolume",
-          function () {
-            const debugShowShadowVolume = !polylineOnTerrainPrimitive.debugShowShadowVolume;
-            const appearance = polylineOnTerrainPrimitive.appearance;
-            scene.groundPrimitives.remove(polylineOnTerrainPrimitive);
-            createPolylines(debugShowShadowVolume);
-            polylineOnTerrainPrimitive.appearance = appearance;
-          }
-        );
-
-        Sandcastle.addToolbarButton("Toggle z-index", function () {
-          if (groundPrimitiveOnTop) {
-            scene.groundPrimitives.raiseToTop(polylineOnTerrainPrimitive);
-          } else {
-            scene.groundPrimitives.lowerToBottom(polylineOnTerrainPrimitive);
-          }
-          groundPrimitiveOnTop = !groundPrimitiveOnTop;
-        });
-
-        function lookAt() {
-          viewer.camera.lookAt(
-            polylinePositions[1],
-            new Cesium.Cartesian3(50000.0, 50000.0, 50000.0)
-          );
-          viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-        }
-
-        Sandcastle.addToolbarButton("reset view", function () {
           lookAt();
-        });
 
-        createPolylines(false);
-        applyPerInstanceColor();
-
-        lookAt();
-
-        Sandcastle.addToolbarMenu([
-          {
-            text: "Per Instance Color",
-            onselect: function () {
-              applyPerInstanceColor();
-              Sandcastle.highlight(applyPerInstanceColor);
+          Sandcastle.addToolbarMenu([
+            {
+              text: "Per Instance Color",
+              onselect: function () {
+                applyPerInstanceColor();
+                Sandcastle.highlight(applyPerInstanceColor);
+              },
             },
-          },
-          {
-            text: "Color",
-            onselect: function () {
-              applyColorMaterial();
-              Sandcastle.highlight(applyColorMaterial);
+            {
+              text: "Color",
+              onselect: function () {
+                applyColorMaterial();
+                Sandcastle.highlight(applyColorMaterial);
+              },
             },
-          },
-          {
-            text: "Glow",
-            onselect: function () {
-              applyGlowMaterial();
-              Sandcastle.highlight(applyGlowMaterial);
+            {
+              text: "Glow",
+              onselect: function () {
+                applyGlowMaterial();
+                Sandcastle.highlight(applyGlowMaterial);
+              },
             },
-          },
-          {
-            text: "Arrow",
-            onselect: function () {
-              applyArrow();
-              Sandcastle.highlight(applyArrow);
+            {
+              text: "Arrow",
+              onselect: function () {
+                applyArrow();
+                Sandcastle.highlight(applyArrow);
+              },
             },
-          },
-          {
-            text: "Dash",
-            onselect: function () {
-              applyDash();
-              Sandcastle.highlight(applyDash);
+            {
+              text: "Dash",
+              onselect: function () {
+                applyDash();
+                Sandcastle.highlight(applyDash);
+              },
             },
-          },
-          {
-            text: "Outline",
-            onselect: function () {
-              applyOutline();
-              Sandcastle.highlight(applyOutline);
+            {
+              text: "Outline",
+              onselect: function () {
+                applyOutline();
+                Sandcastle.highlight(applyOutline);
+              },
             },
-          },
-        ]);
-
-        //Sandcastle_End
+          ]);
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/development/Polylines On Terrain.html
+++ b/Apps/Sandcastle/gallery/development/Polylines On Terrain.html
@@ -53,13 +53,11 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const worldTerrain = Cesium.createWorldTerrain({
-          requestWaterMask: true,
-          requestVertexNormals: true,
-        });
-
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: worldTerrain,
+          terrainProvider: Cesium.createWorldTerrainAsync({
+            requestWaterMask: true,
+            requestVertexNormals: true,
+          }),
         });
 
         if (!Cesium.GroundPolylinePrimitive.isSupported(viewer.scene)) {

--- a/Apps/Sandcastle/gallery/development/Polylines On Terrain.html
+++ b/Apps/Sandcastle/gallery/development/Polylines On Terrain.html
@@ -53,315 +53,320 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        const viewer = new Cesium.Viewer("cesiumContainer");
+
         (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync({
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync({
               requestWaterMask: true,
               requestVertexNormals: true,
-            }),
-          });
-
-          if (!Cesium.GroundPolylinePrimitive.isSupported(viewer.scene)) {
-            window.alert(
-              "Polylines on terrain are not supported on this platform."
-            );
-          }
-
-          const polylineIds = ["polyline1", "polyline2"];
-          const groundPrimitiveId = "ground primitive";
-          let selectedId = polylineIds[0];
-          let polylineOnTerrainPrimitive;
-          let groundPrimitiveOnTop = false;
-
-          let lineWidth = 4.0;
-          const viewModel = {
-            lineWidth: lineWidth,
-          };
-
-          Cesium.knockout.track(viewModel);
-
-          const toolbar = document.getElementById("toolbar");
-          Cesium.knockout.applyBindings(viewModel, toolbar);
-
-          Cesium.knockout
-            .getObservable(viewModel, "lineWidth")
-            .subscribe(function (newValue) {
-              lineWidth = parseFloat(viewModel.lineWidth);
-              if (Cesium.defined(selectedId)) {
-                const attributes = polylineOnTerrainPrimitive.getGeometryInstanceAttributes(
-                  selectedId
-                );
-                lineWidth = parseFloat(viewModel.lineWidth);
-                attributes.width = [lineWidth];
-              }
             });
+          } catch (error) {
+            console.log(error);
+          }
+        })();
 
-          const scene = viewer.scene;
-
-          // Add a Rectangle GroundPrimitive to demonstrate Z-indexing with GroundPrimitives
-          const rectangleGroundPrimitive = scene.groundPrimitives.add(
-            new Cesium.GroundPrimitive({
-              geometryInstances: new Cesium.GeometryInstance({
-                geometry: new Cesium.RectangleGeometry({
-                  rectangle: Cesium.Rectangle.fromDegrees(
-                    -112.1340164450331,
-                    36.05494287836128,
-                    -112.0840164450331,
-                    36.10494287836128
-                  ),
-                  vertexFormat: Cesium.EllipsoidSurfaceAppearance.VERTEX_FORMAT,
-                }),
-                id: groundPrimitiveId,
-              }),
-              appearance: new Cesium.EllipsoidSurfaceAppearance({
-                aboveGround: false,
-                material: Cesium.Material.fromType("Color"),
-              }),
-              classificationType: Cesium.ClassificationType.TERRAIN,
-            })
+        if (!Cesium.GroundPolylinePrimitive.isSupported(viewer.scene)) {
+          window.alert(
+            "Polylines on terrain are not supported on this platform."
           );
+        }
 
-          const leftHandler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
-          leftHandler.setInputAction(function (movement) {
-            const pickedObject = viewer.scene.pick(movement.position);
-            if (Cesium.defined(pickedObject)) {
-              console.log(pickedObject.id);
-              // If picked the ground primitive, don't do anything
-              if (pickedObject.id !== groundPrimitiveId) {
-                selectedId = pickedObject.id;
+        const polylineIds = ["polyline1", "polyline2"];
+        const groundPrimitiveId = "ground primitive";
+        let selectedId = polylineIds[0];
+        let polylineOnTerrainPrimitive;
+        let groundPrimitiveOnTop = false;
 
-                // Sync line width in toolbar with selected
-                const attributes = polylineOnTerrainPrimitive.getGeometryInstanceAttributes(
-                  selectedId
-                );
-                viewModel.lineWidth = attributes.width[0];
-              }
-            } else {
-              selectedId = undefined;
-            }
-          }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
+        let lineWidth = 4.0;
+        const viewModel = {
+          lineWidth: lineWidth,
+        };
 
-          const polylinePositions = Cesium.Cartesian3.fromDegreesArray([
-            -112.1340164450331,
-            36.05494287836128,
-            -112.08821010582645,
-            36.097804071380715,
-            -112.13296079730024,
-            36.168769146801104,
-            -112.10828895143331,
-            36.20031318533197,
-            -112.138548165717,
-            36.1691100215289, // hairpins
-            -112.11482556496543,
-            36.20127524083297,
-            -112.15921333464016,
-            36.17876011207708,
-            -112.14700151155604,
-            36.21683132404626,
-            -112.20919883052926,
-            36.19475754001766,
-          ]);
+        Cesium.knockout.track(viewModel);
 
-          const loopPositions = Cesium.Cartesian3.fromDegreesArray([
-            -111.94500779274114,
-            36.27638678884143,
-            -111.90983004392696,
-            36.07985366173454,
-            -111.80360100637773,
-            36.13694878292542,
-            -111.85510122419183,
-            36.26029588763386,
-            -111.69141601804614,
-            36.05128770351902,
-          ]);
+        const toolbar = document.getElementById("toolbar");
+        Cesium.knockout.applyBindings(viewModel, toolbar);
 
-          function createPolylines(debugShowShadowVolume) {
-            const instance1 = new Cesium.GeometryInstance({
-              geometry: new Cesium.GroundPolylineGeometry({
-                positions: polylinePositions,
-                loop: false,
-                width: 4.0,
-              }),
-              id: polylineIds[0],
-              attributes: {
-                show: new Cesium.ShowGeometryInstanceAttribute(),
-                color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                  Cesium.Color.fromCssColorString("green").withAlpha(0.7)
-                ),
-              },
-            });
-
-            const instance2 = new Cesium.GeometryInstance({
-              geometry: new Cesium.GroundPolylineGeometry({
-                positions: loopPositions,
-                loop: true,
-                width: 8.0,
-              }),
-              id: polylineIds[1],
-              attributes: {
-                show: new Cesium.ShowGeometryInstanceAttribute(),
-                color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                  Cesium.Color.fromCssColorString("#67ADDF").withAlpha(0.7)
-                ),
-              },
-            });
-
-            polylineOnTerrainPrimitive = new Cesium.GroundPolylinePrimitive({
-              geometryInstances: [instance1, instance2],
-              debugShowShadowVolume: debugShowShadowVolume,
-            });
-            scene.groundPrimitives.add(polylineOnTerrainPrimitive);
-          }
-
-          function applyPerInstanceColor() {
-            polylineOnTerrainPrimitive.appearance = new Cesium.PolylineColorAppearance();
-          }
-          function applyColorMaterial() {
-            polylineOnTerrainPrimitive.appearance = new Cesium.PolylineMaterialAppearance(
-              {
-                material: Cesium.Material.fromType("Color", {
-                  color: new Cesium.Color(0.7, 0.0, 1.0, 1.0),
-                }),
-              }
-            );
-          }
-          function applyGlowMaterial() {
-            polylineOnTerrainPrimitive.appearance = new Cesium.PolylineMaterialAppearance(
-              {
-                material: Cesium.Material.fromType("PolylineGlow", {
-                  innerWidth: 1.0,
-                }),
-              }
-            );
-          }
-          function applyArrow() {
-            polylineOnTerrainPrimitive.appearance = new Cesium.PolylineMaterialAppearance(
-              {
-                material: Cesium.Material.fromType("PolylineArrow"),
-              }
-            );
-          }
-          function applyDash() {
-            polylineOnTerrainPrimitive.appearance = new Cesium.PolylineMaterialAppearance(
-              {
-                material: Cesium.Material.fromType("PolylineDash", {
-                  color: Cesium.Color.YELLOW,
-                }),
-              }
-            );
-          }
-          function applyOutline() {
-            polylineOnTerrainPrimitive.appearance = new Cesium.PolylineMaterialAppearance(
-              {
-                material: Cesium.Material.fromType("PolylineOutline"),
-              }
-            );
-          }
-
-          Sandcastle.addToolbarButton("Toggle instance show", function () {
+        Cesium.knockout
+          .getObservable(viewModel, "lineWidth")
+          .subscribe(function (newValue) {
+            lineWidth = parseFloat(viewModel.lineWidth);
             if (Cesium.defined(selectedId)) {
               const attributes = polylineOnTerrainPrimitive.getGeometryInstanceAttributes(
                 selectedId
               );
-              attributes.show = [attributes.show[0] ? 0 : 1];
+              lineWidth = parseFloat(viewModel.lineWidth);
+              attributes.width = [lineWidth];
             }
           });
 
-          Sandcastle.addToolbarButton("Show all", function () {
-            if (Cesium.defined(selectedId)) {
-              let attributes = polylineOnTerrainPrimitive.getGeometryInstanceAttributes(
-                "polyline1"
+        const scene = viewer.scene;
+
+        // Add a Rectangle GroundPrimitive to demonstrate Z-indexing with GroundPrimitives
+        const rectangleGroundPrimitive = scene.groundPrimitives.add(
+          new Cesium.GroundPrimitive({
+            geometryInstances: new Cesium.GeometryInstance({
+              geometry: new Cesium.RectangleGeometry({
+                rectangle: Cesium.Rectangle.fromDegrees(
+                  -112.1340164450331,
+                  36.05494287836128,
+                  -112.0840164450331,
+                  36.10494287836128
+                ),
+                vertexFormat: Cesium.EllipsoidSurfaceAppearance.VERTEX_FORMAT,
+              }),
+              id: groundPrimitiveId,
+            }),
+            appearance: new Cesium.EllipsoidSurfaceAppearance({
+              aboveGround: false,
+              material: Cesium.Material.fromType("Color"),
+            }),
+            classificationType: Cesium.ClassificationType.TERRAIN,
+          })
+        );
+
+        const leftHandler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
+        leftHandler.setInputAction(function (movement) {
+          const pickedObject = viewer.scene.pick(movement.position);
+          if (Cesium.defined(pickedObject)) {
+            console.log(pickedObject.id);
+            // If picked the ground primitive, don't do anything
+            if (pickedObject.id !== groundPrimitiveId) {
+              selectedId = pickedObject.id;
+
+              // Sync line width in toolbar with selected
+              const attributes = polylineOnTerrainPrimitive.getGeometryInstanceAttributes(
+                selectedId
               );
-              attributes.show = [1];
-              attributes = polylineOnTerrainPrimitive.getGeometryInstanceAttributes(
-                "polyline2"
-              );
-              attributes.show = [1];
+              viewModel.lineWidth = attributes.width[0];
             }
+          } else {
+            selectedId = undefined;
+          }
+        }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
+
+        const polylinePositions = Cesium.Cartesian3.fromDegreesArray([
+          -112.1340164450331,
+          36.05494287836128,
+          -112.08821010582645,
+          36.097804071380715,
+          -112.13296079730024,
+          36.168769146801104,
+          -112.10828895143331,
+          36.20031318533197,
+          -112.138548165717,
+          36.1691100215289, // hairpins
+          -112.11482556496543,
+          36.20127524083297,
+          -112.15921333464016,
+          36.17876011207708,
+          -112.14700151155604,
+          36.21683132404626,
+          -112.20919883052926,
+          36.19475754001766,
+        ]);
+
+        const loopPositions = Cesium.Cartesian3.fromDegreesArray([
+          -111.94500779274114,
+          36.27638678884143,
+          -111.90983004392696,
+          36.07985366173454,
+          -111.80360100637773,
+          36.13694878292542,
+          -111.85510122419183,
+          36.26029588763386,
+          -111.69141601804614,
+          36.05128770351902,
+        ]);
+
+        function createPolylines(debugShowShadowVolume) {
+          const instance1 = new Cesium.GeometryInstance({
+            geometry: new Cesium.GroundPolylineGeometry({
+              positions: polylinePositions,
+              loop: false,
+              width: 4.0,
+            }),
+            id: polylineIds[0],
+            attributes: {
+              show: new Cesium.ShowGeometryInstanceAttribute(),
+              color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                Cesium.Color.fromCssColorString("green").withAlpha(0.7)
+              ),
+            },
           });
 
-          Sandcastle.addToolbarButton(
-            "Toggle debugShowShadowVolume",
-            function () {
-              const debugShowShadowVolume = !polylineOnTerrainPrimitive.debugShowShadowVolume;
-              const appearance = polylineOnTerrainPrimitive.appearance;
-              scene.groundPrimitives.remove(polylineOnTerrainPrimitive);
-              createPolylines(debugShowShadowVolume);
-              polylineOnTerrainPrimitive.appearance = appearance;
+          const instance2 = new Cesium.GeometryInstance({
+            geometry: new Cesium.GroundPolylineGeometry({
+              positions: loopPositions,
+              loop: true,
+              width: 8.0,
+            }),
+            id: polylineIds[1],
+            attributes: {
+              show: new Cesium.ShowGeometryInstanceAttribute(),
+              color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                Cesium.Color.fromCssColorString("#67ADDF").withAlpha(0.7)
+              ),
+            },
+          });
+
+          polylineOnTerrainPrimitive = new Cesium.GroundPolylinePrimitive({
+            geometryInstances: [instance1, instance2],
+            debugShowShadowVolume: debugShowShadowVolume,
+          });
+          scene.groundPrimitives.add(polylineOnTerrainPrimitive);
+        }
+
+        function applyPerInstanceColor() {
+          polylineOnTerrainPrimitive.appearance = new Cesium.PolylineColorAppearance();
+        }
+        function applyColorMaterial() {
+          polylineOnTerrainPrimitive.appearance = new Cesium.PolylineMaterialAppearance(
+            {
+              material: Cesium.Material.fromType("Color", {
+                color: new Cesium.Color(0.7, 0.0, 1.0, 1.0),
+              }),
             }
           );
-
-          Sandcastle.addToolbarButton("Toggle z-index", function () {
-            if (groundPrimitiveOnTop) {
-              scene.groundPrimitives.raiseToTop(polylineOnTerrainPrimitive);
-            } else {
-              scene.groundPrimitives.lowerToBottom(polylineOnTerrainPrimitive);
+        }
+        function applyGlowMaterial() {
+          polylineOnTerrainPrimitive.appearance = new Cesium.PolylineMaterialAppearance(
+            {
+              material: Cesium.Material.fromType("PolylineGlow", {
+                innerWidth: 1.0,
+              }),
             }
-            groundPrimitiveOnTop = !groundPrimitiveOnTop;
-          });
+          );
+        }
+        function applyArrow() {
+          polylineOnTerrainPrimitive.appearance = new Cesium.PolylineMaterialAppearance(
+            {
+              material: Cesium.Material.fromType("PolylineArrow"),
+            }
+          );
+        }
+        function applyDash() {
+          polylineOnTerrainPrimitive.appearance = new Cesium.PolylineMaterialAppearance(
+            {
+              material: Cesium.Material.fromType("PolylineDash", {
+                color: Cesium.Color.YELLOW,
+              }),
+            }
+          );
+        }
+        function applyOutline() {
+          polylineOnTerrainPrimitive.appearance = new Cesium.PolylineMaterialAppearance(
+            {
+              material: Cesium.Material.fromType("PolylineOutline"),
+            }
+          );
+        }
 
-          function lookAt() {
-            viewer.camera.lookAt(
-              polylinePositions[1],
-              new Cesium.Cartesian3(50000.0, 50000.0, 50000.0)
+        Sandcastle.addToolbarButton("Toggle instance show", function () {
+          if (Cesium.defined(selectedId)) {
+            const attributes = polylineOnTerrainPrimitive.getGeometryInstanceAttributes(
+              selectedId
             );
-            viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+            attributes.show = [attributes.show[0] ? 0 : 1];
           }
+        });
 
-          Sandcastle.addToolbarButton("reset view", function () {
-            lookAt();
-          });
+        Sandcastle.addToolbarButton("Show all", function () {
+          if (Cesium.defined(selectedId)) {
+            let attributes = polylineOnTerrainPrimitive.getGeometryInstanceAttributes(
+              "polyline1"
+            );
+            attributes.show = [1];
+            attributes = polylineOnTerrainPrimitive.getGeometryInstanceAttributes(
+              "polyline2"
+            );
+            attributes.show = [1];
+          }
+        });
 
-          createPolylines(false);
-          applyPerInstanceColor();
+        Sandcastle.addToolbarButton(
+          "Toggle debugShowShadowVolume",
+          function () {
+            const debugShowShadowVolume = !polylineOnTerrainPrimitive.debugShowShadowVolume;
+            const appearance = polylineOnTerrainPrimitive.appearance;
+            scene.groundPrimitives.remove(polylineOnTerrainPrimitive);
+            createPolylines(debugShowShadowVolume);
+            polylineOnTerrainPrimitive.appearance = appearance;
+          }
+        );
 
+        Sandcastle.addToolbarButton("Toggle z-index", function () {
+          if (groundPrimitiveOnTop) {
+            scene.groundPrimitives.raiseToTop(polylineOnTerrainPrimitive);
+          } else {
+            scene.groundPrimitives.lowerToBottom(polylineOnTerrainPrimitive);
+          }
+          groundPrimitiveOnTop = !groundPrimitiveOnTop;
+        });
+
+        function lookAt() {
+          viewer.camera.lookAt(
+            polylinePositions[1],
+            new Cesium.Cartesian3(50000.0, 50000.0, 50000.0)
+          );
+          viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+        }
+
+        Sandcastle.addToolbarButton("reset view", function () {
           lookAt();
+        });
 
-          Sandcastle.addToolbarMenu([
-            {
-              text: "Per Instance Color",
-              onselect: function () {
-                applyPerInstanceColor();
-                Sandcastle.highlight(applyPerInstanceColor);
-              },
+        createPolylines(false);
+        applyPerInstanceColor();
+
+        lookAt();
+
+        Sandcastle.addToolbarMenu([
+          {
+            text: "Per Instance Color",
+            onselect: function () {
+              applyPerInstanceColor();
+              Sandcastle.highlight(applyPerInstanceColor);
             },
-            {
-              text: "Color",
-              onselect: function () {
-                applyColorMaterial();
-                Sandcastle.highlight(applyColorMaterial);
-              },
+          },
+          {
+            text: "Color",
+            onselect: function () {
+              applyColorMaterial();
+              Sandcastle.highlight(applyColorMaterial);
             },
-            {
-              text: "Glow",
-              onselect: function () {
-                applyGlowMaterial();
-                Sandcastle.highlight(applyGlowMaterial);
-              },
+          },
+          {
+            text: "Glow",
+            onselect: function () {
+              applyGlowMaterial();
+              Sandcastle.highlight(applyGlowMaterial);
             },
-            {
-              text: "Arrow",
-              onselect: function () {
-                applyArrow();
-                Sandcastle.highlight(applyArrow);
-              },
+          },
+          {
+            text: "Arrow",
+            onselect: function () {
+              applyArrow();
+              Sandcastle.highlight(applyArrow);
             },
-            {
-              text: "Dash",
-              onselect: function () {
-                applyDash();
-                Sandcastle.highlight(applyDash);
-              },
+          },
+          {
+            text: "Dash",
+            onselect: function () {
+              applyDash();
+              Sandcastle.highlight(applyDash);
             },
-            {
-              text: "Outline",
-              onselect: function () {
-                applyOutline();
-                Sandcastle.highlight(applyOutline);
-              },
+          },
+          {
+            text: "Outline",
+            onselect: function () {
+              applyOutline();
+              Sandcastle.highlight(applyOutline);
             },
-          ]);
-        })(); //Sandcastle_End
+          },
+        ]);
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/development/Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Shadows.html
@@ -743,11 +743,7 @@
 
         scene.debugShowFramesPerSecond = true;
 
-        const cesiumTerrainProvider = Cesium.createWorldTerrain();
-
         const ellipsoidTerrainProvider = new Cesium.EllipsoidTerrainProvider();
-
-        updateLocation();
 
         function getModelPosition() {
           if (viewModel.modelPosition === "Ground") {
@@ -763,7 +759,8 @@
           }
         }
 
-        function updateLocation() {
+        const createWorldTerrainPromise = Cesium.createWorldTerrainAsync();
+        async function updateLocation() {
           // Get the height of the terrain at the given longitude/latitude, then create the scene.
           const location = uiOptions.locations[viewModel.location];
           const positions = [
@@ -772,16 +769,20 @@
               location.centerLatitude
             ),
           ];
-          const terrainProvider = viewModel.terrain
-            ? cesiumTerrainProvider
-            : ellipsoidTerrainProvider;
+          let terrainProvider = ellipsoidTerrainProvider;
+          if (viewModel.terrain) {
+            terrainProvider = await createWorldTerrainPromise;
+          }
           globe.terrainProvider = terrainProvider;
-          const promise = Cesium.sampleTerrain(terrainProvider, 11, positions);
-          Promise.resolve(promise).then(function (updatedPositions) {
-            location.height = updatedPositions[0].height + getModelPosition();
-            createScene();
-          });
+          const updatedPositions = await Cesium.sampleTerrain(
+            terrainProvider,
+            11,
+            positions
+          );
+          location.height = updatedPositions[0].height + getModelPosition();
+          createScene();
         }
+        updateLocation();
 
         function createScene() {
           const location = uiOptions.locations[viewModel.location];

--- a/Apps/Sandcastle/gallery/development/Terrain Entity Batching.html
+++ b/Apps/Sandcastle/gallery/development/Terrain Entity Batching.html
@@ -35,13 +35,11 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const worldTerrain = Cesium.createWorldTerrain({
-          requestWaterMask: true,
-          requestVertexNormals: true,
-        });
-
         const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: worldTerrain,
+          terrainProvider: Cesium.createWorldTerrainAsync({
+            requestWaterMask: true,
+            requestVertexNormals: true,
+          }),
         });
 
         const concavePositions = [

--- a/Apps/Sandcastle/gallery/development/Terrain Entity Batching.html
+++ b/Apps/Sandcastle/gallery/development/Terrain Entity Batching.html
@@ -35,155 +35,156 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync({
-            requestWaterMask: true,
-            requestVertexNormals: true,
-          }),
-        });
-
-        const concavePositions = [
-          new Cesium.Cartesian3(
-            -2353381.4891308164,
-            -3747386.1222378365,
-            4577999.291515961
-          ),
-          new Cesium.Cartesian3(
-            -2359513.937204245,
-            -3743087.2343810294,
-            4578357.188560644
-          ),
-          new Cesium.Cartesian3(
-            -2356102.0286082155,
-            -3739921.552293276,
-            4582670.218770547
-          ),
-          new Cesium.Cartesian3(
-            -2353889.0353209395,
-            -3741183.2274413602,
-            4582776.909071608
-          ),
-          new Cesium.Cartesian3(
-            -2355072.390487758,
-            -3742865.615615464,
-            4580808.044684757
-          ),
-          new Cesium.Cartesian3(
-            -2356109.6661414686,
-            -3741994.0607898533,
-            4580985.489703348
-          ),
-          new Cesium.Cartesian3(
-            -2357041.8328847606,
-            -3743225.9693035223,
-            4579509.2148039425
-          ),
-          new Cesium.Cartesian3(
-            -2354586.752280607,
-            -3744890.9511893727,
-            4579411.591389144
-          ),
-          new Cesium.Cartesian3(
-            -2353213.0268325945,
-            -3743712.1202877173,
-            4581070.08828045
-          ),
-          new Cesium.Cartesian3(
-            -2353637.930711704,
-            -3743402.9513476435,
-            4581104.219550749
-          ),
-          new Cesium.Cartesian3(
-            -2352875.095159641,
-            -3742564.819171856,
-            4582173.540953957
-          ),
-          new Cesium.Cartesian3(
-            -2350669.646050987,
-            -3743751.6823160048,
-            4582334.8406995395
-          ),
-        ];
-
-        // concave polygon
-        viewer.entities.add({
-          name: "concave polygon on surface",
-          polygon: {
-            hierarchy: concavePositions,
-            material: "../images/Cesium_Logo_Color.jpg",
-          },
-          stRotation: 1.0,
-        });
-
-        // Randomly colored, nonoverlapping squares
-        const latitude = 46.2522;
-        const longitude = -122.2534;
-
-        Cesium.Math.setRandomNumberSeed(133);
-
-        for (let x = 0; x < 10; ++x) {
-          for (let y = 0; y < 10; ++y) {
-            const cornerLat = latitude + 0.01 * x;
-            const cornerLon = longitude + 0.01 * y;
-            viewer.entities.add({
-              id: `${x} ${y}`,
-              rectangle: {
-                coordinates: Cesium.Rectangle.fromDegrees(
-                  cornerLon,
-                  cornerLat,
-                  cornerLon + 0.009,
-                  cornerLat + 0.009
-                ),
-                material: Cesium.Color.fromRandom().withAlpha(0.5),
-                classificationType: Cesium.ClassificationType.TERRAIN,
-              },
-            });
-          }
-        }
-
-        // Checkerboard
-        const checkerboard = new Cesium.CheckerboardMaterialProperty({
-          evenColor: Cesium.Color.ORANGE,
-          oddColor: Cesium.Color.YELLOW,
-          repeat: new Cesium.Cartesian2(14, 14),
-        });
-
-        viewer.entities.add({
-          name: "checkerboard rectangle",
-          rectangle: {
-            coordinates: Cesium.Rectangle.fromDegrees(
-              -122.17778,
-              46.36169,
-              -120.17778,
-              48.36169
-            ),
-            material: checkerboard,
-            classificationType: Cesium.ClassificationType.TERRAIN,
-          },
-        });
-
-        // Ellipse with texture rotation and repetition
-        viewer.entities.add({
-          position: Cesium.Cartesian3.fromDegrees(
-            -121.70711316136793,
-            45.943757948892845,
-            0.0
-          ),
-          name: "ellipse",
-          ellipse: {
-            semiMinorAxis: 15000.0,
-            semiMajorAxis: 30000.0,
-            material: new Cesium.ImageMaterialProperty({
-              image: "../images/Cesium_Logo_Color.jpg",
-              repeat: new Cesium.Cartesian2(10, 10),
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync({
+              requestWaterMask: true,
+              requestVertexNormals: true,
             }),
-            stRotation: Cesium.Math.toRadians(45),
-            classificationType: Cesium.ClassificationType.TERRAIN,
-          },
-        });
+          });
 
-        viewer.zoomTo(viewer.entities);
-        //Sandcastle_End
+          const concavePositions = [
+            new Cesium.Cartesian3(
+              -2353381.4891308164,
+              -3747386.1222378365,
+              4577999.291515961
+            ),
+            new Cesium.Cartesian3(
+              -2359513.937204245,
+              -3743087.2343810294,
+              4578357.188560644
+            ),
+            new Cesium.Cartesian3(
+              -2356102.0286082155,
+              -3739921.552293276,
+              4582670.218770547
+            ),
+            new Cesium.Cartesian3(
+              -2353889.0353209395,
+              -3741183.2274413602,
+              4582776.909071608
+            ),
+            new Cesium.Cartesian3(
+              -2355072.390487758,
+              -3742865.615615464,
+              4580808.044684757
+            ),
+            new Cesium.Cartesian3(
+              -2356109.6661414686,
+              -3741994.0607898533,
+              4580985.489703348
+            ),
+            new Cesium.Cartesian3(
+              -2357041.8328847606,
+              -3743225.9693035223,
+              4579509.2148039425
+            ),
+            new Cesium.Cartesian3(
+              -2354586.752280607,
+              -3744890.9511893727,
+              4579411.591389144
+            ),
+            new Cesium.Cartesian3(
+              -2353213.0268325945,
+              -3743712.1202877173,
+              4581070.08828045
+            ),
+            new Cesium.Cartesian3(
+              -2353637.930711704,
+              -3743402.9513476435,
+              4581104.219550749
+            ),
+            new Cesium.Cartesian3(
+              -2352875.095159641,
+              -3742564.819171856,
+              4582173.540953957
+            ),
+            new Cesium.Cartesian3(
+              -2350669.646050987,
+              -3743751.6823160048,
+              4582334.8406995395
+            ),
+          ];
+
+          // concave polygon
+          viewer.entities.add({
+            name: "concave polygon on surface",
+            polygon: {
+              hierarchy: concavePositions,
+              material: "../images/Cesium_Logo_Color.jpg",
+            },
+            stRotation: 1.0,
+          });
+
+          // Randomly colored, nonoverlapping squares
+          const latitude = 46.2522;
+          const longitude = -122.2534;
+
+          Cesium.Math.setRandomNumberSeed(133);
+
+          for (let x = 0; x < 10; ++x) {
+            for (let y = 0; y < 10; ++y) {
+              const cornerLat = latitude + 0.01 * x;
+              const cornerLon = longitude + 0.01 * y;
+              viewer.entities.add({
+                id: `${x} ${y}`,
+                rectangle: {
+                  coordinates: Cesium.Rectangle.fromDegrees(
+                    cornerLon,
+                    cornerLat,
+                    cornerLon + 0.009,
+                    cornerLat + 0.009
+                  ),
+                  material: Cesium.Color.fromRandom().withAlpha(0.5),
+                  classificationType: Cesium.ClassificationType.TERRAIN,
+                },
+              });
+            }
+          }
+
+          // Checkerboard
+          const checkerboard = new Cesium.CheckerboardMaterialProperty({
+            evenColor: Cesium.Color.ORANGE,
+            oddColor: Cesium.Color.YELLOW,
+            repeat: new Cesium.Cartesian2(14, 14),
+          });
+
+          viewer.entities.add({
+            name: "checkerboard rectangle",
+            rectangle: {
+              coordinates: Cesium.Rectangle.fromDegrees(
+                -122.17778,
+                46.36169,
+                -120.17778,
+                48.36169
+              ),
+              material: checkerboard,
+              classificationType: Cesium.ClassificationType.TERRAIN,
+            },
+          });
+
+          // Ellipse with texture rotation and repetition
+          viewer.entities.add({
+            position: Cesium.Cartesian3.fromDegrees(
+              -121.70711316136793,
+              45.943757948892845,
+              0.0
+            ),
+            name: "ellipse",
+            ellipse: {
+              semiMinorAxis: 15000.0,
+              semiMajorAxis: 30000.0,
+              material: new Cesium.ImageMaterialProperty({
+                image: "../images/Cesium_Logo_Color.jpg",
+                repeat: new Cesium.Cartesian2(10, 10),
+              }),
+              stRotation: Cesium.Math.toRadians(45),
+              classificationType: Cesium.ClassificationType.TERRAIN,
+            },
+          });
+
+          viewer.zoomTo(viewer.entities);
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/development/Terrain Performance.html
+++ b/Apps/Sandcastle/gallery/development/Terrain Performance.html
@@ -35,243 +35,245 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {
-          terrainProvider: Cesium.createWorldTerrainAsync(),
-        });
-        const scene = viewer.scene;
-        const camera = scene.camera;
-        const globe = scene.globe;
-        const statistics = Cesium.RequestScheduler.statistics;
-
-        let startTime;
-        let flightComplete;
-        let monitor;
-        let minFrameRate = 1000;
-        let maxFrameRate = 0;
-        let sumFrameRate = 0.0;
-        let frameRateSamples = 0;
-
-        function startTest() {
-          flightComplete = false;
-          statistics.numberOfActiveRequestsEver = 0;
-          monitor = new Cesium.FrameRateMonitor({
-            scene: scene,
-            samplingWindow: 1.0,
-            quietPeriod: 0.0,
-            warmupPeriod: 0.0,
-            minimumFrameRateDuringWarmup: 0,
-            minimumFrameRateAfterWarmup: 0,
+        (async () => {
+          const viewer = new Cesium.Viewer("cesiumContainer", {
+            terrainProvider: await Cesium.createWorldTerrainAsync(),
           });
-          scene.preUpdate.addEventListener(measureFrameRate);
-          startTime = window.performance.now();
-          window.setTimeout(function () {
-            scene.postRender.addEventListener(viewReady);
-          }, 500);
-        }
+          const scene = viewer.scene;
+          const camera = scene.camera;
+          const globe = scene.globe;
+          const statistics = Cesium.RequestScheduler.statistics;
 
-        function measureFrameRate() {
-          const frameRate = monitor.lastFramesPerSecond;
-          if (frameRate === undefined || frameRate !== frameRate) {
-            return;
+          let startTime;
+          let flightComplete;
+          let monitor;
+          let minFrameRate = 1000;
+          let maxFrameRate = 0;
+          let sumFrameRate = 0.0;
+          let frameRateSamples = 0;
+
+          function startTest() {
+            flightComplete = false;
+            statistics.numberOfActiveRequestsEver = 0;
+            monitor = new Cesium.FrameRateMonitor({
+              scene: scene,
+              samplingWindow: 1.0,
+              quietPeriod: 0.0,
+              warmupPeriod: 0.0,
+              minimumFrameRateDuringWarmup: 0,
+              minimumFrameRateAfterWarmup: 0,
+            });
+            scene.preUpdate.addEventListener(measureFrameRate);
+            startTime = window.performance.now();
+            window.setTimeout(function () {
+              scene.postRender.addEventListener(viewReady);
+            }, 500);
           }
 
-          ++frameRateSamples;
-          sumFrameRate += frameRate;
-          minFrameRate = Math.min(minFrameRate, frameRate);
-          maxFrameRate = Math.max(maxFrameRate, frameRate);
-        }
-
-        function viewReady(scene, time) {
-          const ready =
-            globe._surface.tileProvider.ready &&
-            globe._surface._tileLoadQueueHigh.length === 0 &&
-            globe._surface._tileLoadQueueMedium.length === 0 &&
-            globe._surface._tileLoadQueueLow.length === 0 &&
-            globe._surface._debug.tilesWaitingForChildren === 0;
-          if (flightComplete && ready) {
-            const endTime = window.performance.now();
-            const duration = endTime - startTime;
-            alert(
-              `${(duration / 1000).toFixed(2)} seconds ${
-                statistics.numberOfActiveRequestsEver
-              } requests, min/max/avg frame FPS ${minFrameRate}/${maxFrameRate}/${
-                sumFrameRate / frameRateSamples
-              }`
-            );
-            scene.postRender.removeEventListener(viewReady);
-          }
-        }
-
-        function goToEverestHorizontal() {
-          camera.position = new Cesium.Cartesian3(
-            302950.1757410969,
-            5637093.359233209,
-            2976894.491577989
-          );
-          camera.direction = new Cesium.Cartesian3(
-            -0.9648960658153797,
-            -0.24110066659365145,
-            -0.10414437451009724
-          );
-          camera.right = new Cesium.Cartesian3(
-            -0.02152846103178338,
-            0.46781654381873394,
-            -0.8835633574877908
-          );
-          camera.up = new Cesium.Cartesian3(
-            -0.26174817580950865,
-            0.8503047394302772,
-            0.456584868959543
-          );
-          flightComplete = true;
-        }
-
-        function goToEverestTopDown() {
-          camera.position = new Cesium.Cartesian3(
-            301989.1870802739,
-            5637745.915399717,
-            2977153.0443453398
-          );
-          camera.direction = new Cesium.Cartesian3(
-            0.021398841015326783,
-            -0.8909524564021135,
-            -0.45359211857597476
-          );
-          camera.right = new Cesium.Cartesian3(
-            0.21237352569072232,
-            0.4473925820246778,
-            -0.8687562161705573
-          );
-          camera.up = new Cesium.Cartesian3(
-            -0.9769542339275126,
-            0.07774058129659328,
-            -0.19878839712310903
-          );
-          flightComplete = true;
-        }
-
-        function goToEverest45Degrees() {
-          camera.position = new Cesium.Cartesian3(
-            302760.41072832496,
-            5637092.977453635,
-            2977284.6758398763
-          );
-          camera.direction = new Cesium.Cartesian3(
-            -0.7254568510163212,
-            -0.3330925403210976,
-            -0.6022970337764594
-          );
-          camera.right = new Cesium.Cartesian3(
-            0.4750641658993092,
-            0.39087207931336604,
-            -0.7883736778277414
-          );
-          camera.up = new Cesium.Cartesian3(
-            -0.49802248502640617,
-            0.8580608237157107,
-            0.12532049797395203
-          );
-          flightComplete = true;
-        }
-
-        function zoomToEverest() {
-          const position = new Cesium.Cartesian3(
-            302955.90876054496,
-            5639614.4908250235,
-            2981096.1048591887
-          );
-          camera.flyTo({
-            destination: position,
-            easingFunction: Cesium.EasingFunction.QUADRATIC_OUT,
-            complete: function () {
-              flightComplete = true;
-            },
-          });
-        }
-
-        function panAroundEverest() {
-          camera.position = new Cesium.Cartesian3(
-            302950.1757410969,
-            5637093.359233209,
-            2976894.491577989
-          );
-          camera.direction = new Cesium.Cartesian3(
-            -0.9648960658153797,
-            -0.24110066659365145,
-            -0.10414437451009724
-          );
-          camera.right = new Cesium.Cartesian3(
-            -0.02152846103178338,
-            0.46781654381873394,
-            -0.8835633574877908
-          );
-          camera.up = new Cesium.Cartesian3(
-            -0.26174817580950865,
-            0.8503047394302772,
-            0.456584868959543
-          );
-
-          const startCartographic = Cesium.Cartographic.fromCartesian(
-            camera.position
-          );
-          let longitude = startCartographic.longitude;
-          const endLongitude = longitude + 0.01;
-          const latitude = startCartographic.latitude;
-          const height = startCartographic.height;
-          let startTime = window.performance.now();
-          const removeCallback = scene.preRender.addEventListener(function (
-            scene,
-            time
-          ) {
-            const endTime = window.performance.now();
-            const delta = endTime - startTime;
-            startTime = endTime;
-            longitude += delta * 0.000001;
-            if (longitude >= endLongitude) {
-              flightComplete = true;
-              removeCallback();
+          function measureFrameRate() {
+            const frameRate = monitor.lastFramesPerSecond;
+            if (frameRate === undefined || frameRate !== frameRate) {
+              return;
             }
-            camera.position = Cesium.Cartesian3.fromRadians(
-              longitude,
-              latitude,
-              height
+
+            ++frameRateSamples;
+            sumFrameRate += frameRate;
+            minFrameRate = Math.min(minFrameRate, frameRate);
+            maxFrameRate = Math.max(maxFrameRate, frameRate);
+          }
+
+          function viewReady(scene, time) {
+            const ready =
+              globe._surface.tileProvider.ready &&
+              globe._surface._tileLoadQueueHigh.length === 0 &&
+              globe._surface._tileLoadQueueMedium.length === 0 &&
+              globe._surface._tileLoadQueueLow.length === 0 &&
+              globe._surface._debug.tilesWaitingForChildren === 0;
+            if (flightComplete && ready) {
+              const endTime = window.performance.now();
+              const duration = endTime - startTime;
+              alert(
+                `${(duration / 1000).toFixed(2)} seconds ${
+                  statistics.numberOfActiveRequestsEver
+                } requests, min/max/avg frame FPS ${minFrameRate}/${maxFrameRate}/${
+                  sumFrameRate / frameRateSamples
+                }`
+              );
+              scene.postRender.removeEventListener(viewReady);
+            }
+          }
+
+          function goToEverestHorizontal() {
+            camera.position = new Cesium.Cartesian3(
+              302950.1757410969,
+              5637093.359233209,
+              2976894.491577989
             );
+            camera.direction = new Cesium.Cartesian3(
+              -0.9648960658153797,
+              -0.24110066659365145,
+              -0.10414437451009724
+            );
+            camera.right = new Cesium.Cartesian3(
+              -0.02152846103178338,
+              0.46781654381873394,
+              -0.8835633574877908
+            );
+            camera.up = new Cesium.Cartesian3(
+              -0.26174817580950865,
+              0.8503047394302772,
+              0.456584868959543
+            );
+            flightComplete = true;
+          }
+
+          function goToEverestTopDown() {
+            camera.position = new Cesium.Cartesian3(
+              301989.1870802739,
+              5637745.915399717,
+              2977153.0443453398
+            );
+            camera.direction = new Cesium.Cartesian3(
+              0.021398841015326783,
+              -0.8909524564021135,
+              -0.45359211857597476
+            );
+            camera.right = new Cesium.Cartesian3(
+              0.21237352569072232,
+              0.4473925820246778,
+              -0.8687562161705573
+            );
+            camera.up = new Cesium.Cartesian3(
+              -0.9769542339275126,
+              0.07774058129659328,
+              -0.19878839712310903
+            );
+            flightComplete = true;
+          }
+
+          function goToEverest45Degrees() {
+            camera.position = new Cesium.Cartesian3(
+              302760.41072832496,
+              5637092.977453635,
+              2977284.6758398763
+            );
+            camera.direction = new Cesium.Cartesian3(
+              -0.7254568510163212,
+              -0.3330925403210976,
+              -0.6022970337764594
+            );
+            camera.right = new Cesium.Cartesian3(
+              0.4750641658993092,
+              0.39087207931336604,
+              -0.7883736778277414
+            );
+            camera.up = new Cesium.Cartesian3(
+              -0.49802248502640617,
+              0.8580608237157107,
+              0.12532049797395203
+            );
+            flightComplete = true;
+          }
+
+          function zoomToEverest() {
+            const position = new Cesium.Cartesian3(
+              302955.90876054496,
+              5639614.4908250235,
+              2981096.1048591887
+            );
+            camera.flyTo({
+              destination: position,
+              easingFunction: Cesium.EasingFunction.QUADRATIC_OUT,
+              complete: function () {
+                flightComplete = true;
+              },
+            });
+          }
+
+          function panAroundEverest() {
+            camera.position = new Cesium.Cartesian3(
+              302950.1757410969,
+              5637093.359233209,
+              2976894.491577989
+            );
+            camera.direction = new Cesium.Cartesian3(
+              -0.9648960658153797,
+              -0.24110066659365145,
+              -0.10414437451009724
+            );
+            camera.right = new Cesium.Cartesian3(
+              -0.02152846103178338,
+              0.46781654381873394,
+              -0.8835633574877908
+            );
+            camera.up = new Cesium.Cartesian3(
+              -0.26174817580950865,
+              0.8503047394302772,
+              0.456584868959543
+            );
+
+            const startCartographic = Cesium.Cartographic.fromCartesian(
+              camera.position
+            );
+            let longitude = startCartographic.longitude;
+            const endLongitude = longitude + 0.01;
+            const latitude = startCartographic.latitude;
+            const height = startCartographic.height;
+            let startTime = window.performance.now();
+            const removeCallback = scene.preRender.addEventListener(function (
+              scene,
+              time
+            ) {
+              const endTime = window.performance.now();
+              const delta = endTime - startTime;
+              startTime = endTime;
+              longitude += delta * 0.000001;
+              if (longitude >= endLongitude) {
+                flightComplete = true;
+                removeCallback();
+              }
+              camera.position = Cesium.Cartesian3.fromRadians(
+                longitude,
+                latitude,
+                height
+              );
+            });
+          }
+
+          Sandcastle.addToolbarButton("Timer Static Horizontal", function () {
+            startTest();
+            goToEverestHorizontal();
           });
-        }
 
-        Sandcastle.addToolbarButton("Timer Static Horizontal", function () {
-          startTest();
-          goToEverestHorizontal();
-        });
+          Sandcastle.addToolbarButton("Timer Static Top Down", function () {
+            startTest();
+            goToEverestTopDown();
+          });
 
-        Sandcastle.addToolbarButton("Timer Static Top Down", function () {
-          startTest();
-          goToEverestTopDown();
-        });
+          Sandcastle.addToolbarButton("Timer Static 45 degrees", function () {
+            startTest();
+            goToEverest45Degrees();
+          });
 
-        Sandcastle.addToolbarButton("Timer Static 45 degrees", function () {
-          startTest();
-          goToEverest45Degrees();
-        });
+          Sandcastle.addToolbarButton("Timer Zoom", function () {
+            startTest();
+            zoomToEverest();
+          });
 
-        Sandcastle.addToolbarButton("Timer Zoom", function () {
-          startTest();
-          zoomToEverest();
-        });
+          Sandcastle.addToolbarButton("Timer Pan", function () {
+            startTest();
+            panAroundEverest();
+          });
 
-        Sandcastle.addToolbarButton("Timer Pan", function () {
-          startTest();
-          panAroundEverest();
-        });
-
-        Sandcastle.addToolbarButton("Save camera", function () {
-          const cameraString =
-            `camera.position = new Cesium.Cartesian3(${camera.positionWC.x}, ${camera.positionWC.y}, ${camera.positionWC.z});\n` +
-            `camera.direction = new Cesium.Cartesian3(${camera.directionWC.x}, ${camera.directionWC.y}, ${camera.directionWC.z});\n` +
-            `camera.right = new Cesium.Cartesian3(${camera.rightWC.x}, ${camera.rightWC.y}, ${camera.rightWC.z});\n` +
-            `camera.up = new Cesium.Cartesian3(${camera.upWC.x}, ${camera.upWC.y}, ${camera.upWC.z});\n`;
-          console.log(cameraString);
-        }); //Sandcastle_End
+          Sandcastle.addToolbarButton("Save camera", function () {
+            const cameraString =
+              `camera.position = new Cesium.Cartesian3(${camera.positionWC.x}, ${camera.positionWC.y}, ${camera.positionWC.z});\n` +
+              `camera.direction = new Cesium.Cartesian3(${camera.directionWC.x}, ${camera.directionWC.y}, ${camera.directionWC.z});\n` +
+              `camera.right = new Cesium.Cartesian3(${camera.rightWC.x}, ${camera.rightWC.y}, ${camera.rightWC.z});\n` +
+              `camera.up = new Cesium.Cartesian3(${camera.upWC.x}, ${camera.upWC.y}, ${camera.upWC.z});\n`;
+            console.log(cameraString);
+          });
+        })(); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/Apps/Sandcastle/gallery/development/Terrain Performance.html
+++ b/Apps/Sandcastle/gallery/development/Terrain Performance.html
@@ -35,13 +35,13 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer");
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: Cesium.createWorldTerrainAsync(),
+        });
         const scene = viewer.scene;
         const camera = scene.camera;
         const globe = scene.globe;
         const statistics = Cesium.RequestScheduler.statistics;
-
-        viewer.terrainProvider = Cesium.createWorldTerrain();
 
         let startTime;
         let flightComplete;

--- a/Apps/Sandcastle/gallery/development/Terrain Performance.html
+++ b/Apps/Sandcastle/gallery/development/Terrain Performance.html
@@ -35,245 +35,250 @@
       window.startup = function (Cesium) {
         "use strict";
         //Sandcastle_Begin
+        const viewer = new Cesium.Viewer("cesiumContainer", {});
+        const scene = viewer.scene;
+        const camera = scene.camera;
+        const globe = scene.globe;
+        const statistics = Cesium.RequestScheduler.statistics;
+
         (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
+          try {
+            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
+          } catch (error) {
+            console.log(error);
+          }
+        })();
+
+        let startTime;
+        let flightComplete;
+        let monitor;
+        let minFrameRate = 1000;
+        let maxFrameRate = 0;
+        let sumFrameRate = 0.0;
+        let frameRateSamples = 0;
+
+        function startTest() {
+          flightComplete = false;
+          statistics.numberOfActiveRequestsEver = 0;
+          monitor = new Cesium.FrameRateMonitor({
+            scene: scene,
+            samplingWindow: 1.0,
+            quietPeriod: 0.0,
+            warmupPeriod: 0.0,
+            minimumFrameRateDuringWarmup: 0,
+            minimumFrameRateAfterWarmup: 0,
           });
-          const scene = viewer.scene;
-          const camera = scene.camera;
-          const globe = scene.globe;
-          const statistics = Cesium.RequestScheduler.statistics;
+          scene.preUpdate.addEventListener(measureFrameRate);
+          startTime = window.performance.now();
+          window.setTimeout(function () {
+            scene.postRender.addEventListener(viewReady);
+          }, 500);
+        }
 
-          let startTime;
-          let flightComplete;
-          let monitor;
-          let minFrameRate = 1000;
-          let maxFrameRate = 0;
-          let sumFrameRate = 0.0;
-          let frameRateSamples = 0;
-
-          function startTest() {
-            flightComplete = false;
-            statistics.numberOfActiveRequestsEver = 0;
-            monitor = new Cesium.FrameRateMonitor({
-              scene: scene,
-              samplingWindow: 1.0,
-              quietPeriod: 0.0,
-              warmupPeriod: 0.0,
-              minimumFrameRateDuringWarmup: 0,
-              minimumFrameRateAfterWarmup: 0,
-            });
-            scene.preUpdate.addEventListener(measureFrameRate);
-            startTime = window.performance.now();
-            window.setTimeout(function () {
-              scene.postRender.addEventListener(viewReady);
-            }, 500);
+        function measureFrameRate() {
+          const frameRate = monitor.lastFramesPerSecond;
+          if (frameRate === undefined || frameRate !== frameRate) {
+            return;
           }
 
-          function measureFrameRate() {
-            const frameRate = monitor.lastFramesPerSecond;
-            if (frameRate === undefined || frameRate !== frameRate) {
-              return;
+          ++frameRateSamples;
+          sumFrameRate += frameRate;
+          minFrameRate = Math.min(minFrameRate, frameRate);
+          maxFrameRate = Math.max(maxFrameRate, frameRate);
+        }
+
+        function viewReady(scene, time) {
+          const ready =
+            globe._surface.tileProvider.ready &&
+            globe._surface._tileLoadQueueHigh.length === 0 &&
+            globe._surface._tileLoadQueueMedium.length === 0 &&
+            globe._surface._tileLoadQueueLow.length === 0 &&
+            globe._surface._debug.tilesWaitingForChildren === 0;
+          if (flightComplete && ready) {
+            const endTime = window.performance.now();
+            const duration = endTime - startTime;
+            alert(
+              `${(duration / 1000).toFixed(2)} seconds ${
+                statistics.numberOfActiveRequestsEver
+              } requests, min/max/avg frame FPS ${minFrameRate}/${maxFrameRate}/${
+                sumFrameRate / frameRateSamples
+              }`
+            );
+            scene.postRender.removeEventListener(viewReady);
+          }
+        }
+
+        function goToEverestHorizontal() {
+          camera.position = new Cesium.Cartesian3(
+            302950.1757410969,
+            5637093.359233209,
+            2976894.491577989
+          );
+          camera.direction = new Cesium.Cartesian3(
+            -0.9648960658153797,
+            -0.24110066659365145,
+            -0.10414437451009724
+          );
+          camera.right = new Cesium.Cartesian3(
+            -0.02152846103178338,
+            0.46781654381873394,
+            -0.8835633574877908
+          );
+          camera.up = new Cesium.Cartesian3(
+            -0.26174817580950865,
+            0.8503047394302772,
+            0.456584868959543
+          );
+          flightComplete = true;
+        }
+
+        function goToEverestTopDown() {
+          camera.position = new Cesium.Cartesian3(
+            301989.1870802739,
+            5637745.915399717,
+            2977153.0443453398
+          );
+          camera.direction = new Cesium.Cartesian3(
+            0.021398841015326783,
+            -0.8909524564021135,
+            -0.45359211857597476
+          );
+          camera.right = new Cesium.Cartesian3(
+            0.21237352569072232,
+            0.4473925820246778,
+            -0.8687562161705573
+          );
+          camera.up = new Cesium.Cartesian3(
+            -0.9769542339275126,
+            0.07774058129659328,
+            -0.19878839712310903
+          );
+          flightComplete = true;
+        }
+
+        function goToEverest45Degrees() {
+          camera.position = new Cesium.Cartesian3(
+            302760.41072832496,
+            5637092.977453635,
+            2977284.6758398763
+          );
+          camera.direction = new Cesium.Cartesian3(
+            -0.7254568510163212,
+            -0.3330925403210976,
+            -0.6022970337764594
+          );
+          camera.right = new Cesium.Cartesian3(
+            0.4750641658993092,
+            0.39087207931336604,
+            -0.7883736778277414
+          );
+          camera.up = new Cesium.Cartesian3(
+            -0.49802248502640617,
+            0.8580608237157107,
+            0.12532049797395203
+          );
+          flightComplete = true;
+        }
+
+        function zoomToEverest() {
+          const position = new Cesium.Cartesian3(
+            302955.90876054496,
+            5639614.4908250235,
+            2981096.1048591887
+          );
+          camera.flyTo({
+            destination: position,
+            easingFunction: Cesium.EasingFunction.QUADRATIC_OUT,
+            complete: function () {
+              flightComplete = true;
+            },
+          });
+        }
+
+        function panAroundEverest() {
+          camera.position = new Cesium.Cartesian3(
+            302950.1757410969,
+            5637093.359233209,
+            2976894.491577989
+          );
+          camera.direction = new Cesium.Cartesian3(
+            -0.9648960658153797,
+            -0.24110066659365145,
+            -0.10414437451009724
+          );
+          camera.right = new Cesium.Cartesian3(
+            -0.02152846103178338,
+            0.46781654381873394,
+            -0.8835633574877908
+          );
+          camera.up = new Cesium.Cartesian3(
+            -0.26174817580950865,
+            0.8503047394302772,
+            0.456584868959543
+          );
+
+          const startCartographic = Cesium.Cartographic.fromCartesian(
+            camera.position
+          );
+          let longitude = startCartographic.longitude;
+          const endLongitude = longitude + 0.01;
+          const latitude = startCartographic.latitude;
+          const height = startCartographic.height;
+          let startTime = window.performance.now();
+          const removeCallback = scene.preRender.addEventListener(function (
+            scene,
+            time
+          ) {
+            const endTime = window.performance.now();
+            const delta = endTime - startTime;
+            startTime = endTime;
+            longitude += delta * 0.000001;
+            if (longitude >= endLongitude) {
+              flightComplete = true;
+              removeCallback();
             }
-
-            ++frameRateSamples;
-            sumFrameRate += frameRate;
-            minFrameRate = Math.min(minFrameRate, frameRate);
-            maxFrameRate = Math.max(maxFrameRate, frameRate);
-          }
-
-          function viewReady(scene, time) {
-            const ready =
-              globe._surface.tileProvider.ready &&
-              globe._surface._tileLoadQueueHigh.length === 0 &&
-              globe._surface._tileLoadQueueMedium.length === 0 &&
-              globe._surface._tileLoadQueueLow.length === 0 &&
-              globe._surface._debug.tilesWaitingForChildren === 0;
-            if (flightComplete && ready) {
-              const endTime = window.performance.now();
-              const duration = endTime - startTime;
-              alert(
-                `${(duration / 1000).toFixed(2)} seconds ${
-                  statistics.numberOfActiveRequestsEver
-                } requests, min/max/avg frame FPS ${minFrameRate}/${maxFrameRate}/${
-                  sumFrameRate / frameRateSamples
-                }`
-              );
-              scene.postRender.removeEventListener(viewReady);
-            }
-          }
-
-          function goToEverestHorizontal() {
-            camera.position = new Cesium.Cartesian3(
-              302950.1757410969,
-              5637093.359233209,
-              2976894.491577989
+            camera.position = Cesium.Cartesian3.fromRadians(
+              longitude,
+              latitude,
+              height
             );
-            camera.direction = new Cesium.Cartesian3(
-              -0.9648960658153797,
-              -0.24110066659365145,
-              -0.10414437451009724
-            );
-            camera.right = new Cesium.Cartesian3(
-              -0.02152846103178338,
-              0.46781654381873394,
-              -0.8835633574877908
-            );
-            camera.up = new Cesium.Cartesian3(
-              -0.26174817580950865,
-              0.8503047394302772,
-              0.456584868959543
-            );
-            flightComplete = true;
-          }
-
-          function goToEverestTopDown() {
-            camera.position = new Cesium.Cartesian3(
-              301989.1870802739,
-              5637745.915399717,
-              2977153.0443453398
-            );
-            camera.direction = new Cesium.Cartesian3(
-              0.021398841015326783,
-              -0.8909524564021135,
-              -0.45359211857597476
-            );
-            camera.right = new Cesium.Cartesian3(
-              0.21237352569072232,
-              0.4473925820246778,
-              -0.8687562161705573
-            );
-            camera.up = new Cesium.Cartesian3(
-              -0.9769542339275126,
-              0.07774058129659328,
-              -0.19878839712310903
-            );
-            flightComplete = true;
-          }
-
-          function goToEverest45Degrees() {
-            camera.position = new Cesium.Cartesian3(
-              302760.41072832496,
-              5637092.977453635,
-              2977284.6758398763
-            );
-            camera.direction = new Cesium.Cartesian3(
-              -0.7254568510163212,
-              -0.3330925403210976,
-              -0.6022970337764594
-            );
-            camera.right = new Cesium.Cartesian3(
-              0.4750641658993092,
-              0.39087207931336604,
-              -0.7883736778277414
-            );
-            camera.up = new Cesium.Cartesian3(
-              -0.49802248502640617,
-              0.8580608237157107,
-              0.12532049797395203
-            );
-            flightComplete = true;
-          }
-
-          function zoomToEverest() {
-            const position = new Cesium.Cartesian3(
-              302955.90876054496,
-              5639614.4908250235,
-              2981096.1048591887
-            );
-            camera.flyTo({
-              destination: position,
-              easingFunction: Cesium.EasingFunction.QUADRATIC_OUT,
-              complete: function () {
-                flightComplete = true;
-              },
-            });
-          }
-
-          function panAroundEverest() {
-            camera.position = new Cesium.Cartesian3(
-              302950.1757410969,
-              5637093.359233209,
-              2976894.491577989
-            );
-            camera.direction = new Cesium.Cartesian3(
-              -0.9648960658153797,
-              -0.24110066659365145,
-              -0.10414437451009724
-            );
-            camera.right = new Cesium.Cartesian3(
-              -0.02152846103178338,
-              0.46781654381873394,
-              -0.8835633574877908
-            );
-            camera.up = new Cesium.Cartesian3(
-              -0.26174817580950865,
-              0.8503047394302772,
-              0.456584868959543
-            );
-
-            const startCartographic = Cesium.Cartographic.fromCartesian(
-              camera.position
-            );
-            let longitude = startCartographic.longitude;
-            const endLongitude = longitude + 0.01;
-            const latitude = startCartographic.latitude;
-            const height = startCartographic.height;
-            let startTime = window.performance.now();
-            const removeCallback = scene.preRender.addEventListener(function (
-              scene,
-              time
-            ) {
-              const endTime = window.performance.now();
-              const delta = endTime - startTime;
-              startTime = endTime;
-              longitude += delta * 0.000001;
-              if (longitude >= endLongitude) {
-                flightComplete = true;
-                removeCallback();
-              }
-              camera.position = Cesium.Cartesian3.fromRadians(
-                longitude,
-                latitude,
-                height
-              );
-            });
-          }
-
-          Sandcastle.addToolbarButton("Timer Static Horizontal", function () {
-            startTest();
-            goToEverestHorizontal();
           });
+        }
 
-          Sandcastle.addToolbarButton("Timer Static Top Down", function () {
-            startTest();
-            goToEverestTopDown();
-          });
+        Sandcastle.addToolbarButton("Timer Static Horizontal", function () {
+          startTest();
+          goToEverestHorizontal();
+        });
 
-          Sandcastle.addToolbarButton("Timer Static 45 degrees", function () {
-            startTest();
-            goToEverest45Degrees();
-          });
+        Sandcastle.addToolbarButton("Timer Static Top Down", function () {
+          startTest();
+          goToEverestTopDown();
+        });
 
-          Sandcastle.addToolbarButton("Timer Zoom", function () {
-            startTest();
-            zoomToEverest();
-          });
+        Sandcastle.addToolbarButton("Timer Static 45 degrees", function () {
+          startTest();
+          goToEverest45Degrees();
+        });
 
-          Sandcastle.addToolbarButton("Timer Pan", function () {
-            startTest();
-            panAroundEverest();
-          });
+        Sandcastle.addToolbarButton("Timer Zoom", function () {
+          startTest();
+          zoomToEverest();
+        });
 
-          Sandcastle.addToolbarButton("Save camera", function () {
-            const cameraString =
-              `camera.position = new Cesium.Cartesian3(${camera.positionWC.x}, ${camera.positionWC.y}, ${camera.positionWC.z});\n` +
-              `camera.direction = new Cesium.Cartesian3(${camera.directionWC.x}, ${camera.directionWC.y}, ${camera.directionWC.z});\n` +
-              `camera.right = new Cesium.Cartesian3(${camera.rightWC.x}, ${camera.rightWC.y}, ${camera.rightWC.z});\n` +
-              `camera.up = new Cesium.Cartesian3(${camera.upWC.x}, ${camera.upWC.y}, ${camera.upWC.z});\n`;
-            console.log(cameraString);
-          });
-        })(); //Sandcastle_End
+        Sandcastle.addToolbarButton("Timer Pan", function () {
+          startTest();
+          panAroundEverest();
+        });
+
+        Sandcastle.addToolbarButton("Save camera", function () {
+          const cameraString =
+            `camera.position = new Cesium.Cartesian3(${camera.positionWC.x}, ${camera.positionWC.y}, ${camera.positionWC.z});\n` +
+            `camera.direction = new Cesium.Cartesian3(${camera.directionWC.x}, ${camera.directionWC.y}, ${camera.directionWC.z});\n` +
+            `camera.right = new Cesium.Cartesian3(${camera.rightWC.x}, ${camera.rightWC.y}, ${camera.rightWC.z});\n` +
+            `camera.up = new Cesium.Cartesian3(${camera.upWC.x}, ${camera.upWC.y}, ${camera.upWC.z});\n`;
+          console.log(cameraString);
+        });
+        //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,22 @@
 
 - Fixed a bug decoding glTF Draco attributes with quantization bits above 16. [#7471](https://github.com/CesiumGS/cesium/issues/7471)
 
+##### Additions :tada:
+
+- Added `ArcGISTiledElevationTerrainProvider.fromUrl`, `CesiumTerrainProvider.fromUrl`, `GoogleEarthEnterpriseMetadata.fromUrl`, `GoogleEarthEnterpriseTerrainProvider.fromMetadata`, `VRTheWorldTerrainProvider.fromUrl`, and `createWorldTerrainAsync` for better async flow and error handling.
+
+##### Deprecated :hourglass_flowing_sand:
+
+- `TerrainProvider.ready` and `TerrainProvider.readyPromise` were deprecated in Cesium 1.102. They will be removed in 1.104.
+- `ArcGISTiledElevationTerrainProvider `constructor parameter `options.url`, `ArcGISTiledElevationTerrainProvider.ready`, and `ArcGISTiledElevationTerrainProvider.readyPromise` were deprecated in Cesium 1.102. They will be removed in 1.104. Use `ArcGISTiledElevationTerrainProvider.fromUrl` instead.
+- `CesiumTerrainProvider` constructor parameter `options.url`, `CesiumTerrainProvider.ready`, and `CesiumTerrainProvider.readyPromise` were deprecated in Cesium 1.102. They will be removed in 1.104. Use `CesiumTerrainProvider.fromUrl` instead.
+- `CustomHeightmapTerrainProvider.ready`, and `CustomHeightmapTerrainProvider.readyPromise` were deprecated in Cesium 1.102.
+- `EllipsoidTerrainProvider.ready`, and `EllipsoidTerrainProvider.readyPromise` were deprecated in Cesium 1.102.
+- `GoogleEarthEnterpriseMetadata` constructor parameter `options.url` and `GoogleEarthEnterpriseMetadata.readyPromise` were deprecated in Cesium 1.102. They will be removed in 1.104. Use `GoogleEarthEnterpriseMetadata.fromUrl` instead.
+- `GoogleEarthEnterpriseTerrainProvider` constructor parameters `options.url` and `options.metadata`, `GoogleEarthEnterpriseTerrainProvider.ready`, and `GoogleEarthEnterpriseTerrainProvider.readyPromise` were deprecated in Cesium 1.102. They will be removed in 1.104. Use `GoogleEarthEnterpriseTerrainProvider.fromMetadata` instead.
+- `VRTheWorldTerrainProvider` constructor parameter `options.url`, `VRTheWorldTerrainProvider.ready`, and `VRTheWorldTerrainProvider.readyPromise` were deprecated in Cesium 1.102. They will be removed in 1.104. Use `VRTheWorldTerrainProvider.fromUrl` instead.
+- `createWorldTerrain` was deprecated in CesiumJS 1.102. It will be removed in 1.104. Use createWorldTerrainAsync instead.
+
 ### 1.101 - 2023-01-02
 
 #### Major Announcements :loudspeaker:

--- a/Specs/MockTerrainProvider.js
+++ b/Specs/MockTerrainProvider.js
@@ -17,8 +17,6 @@ function MockTerrainProvider() {
     this.heightmapWidth,
     this.tilingScheme.getNumberOfXTilesAtLevel(0)
   );
-  this.ready = true;
-  this.readyPromise = Promise.resolve();
   this.hasWaterMask = true;
   this.errorEvent = new Event();
 

--- a/Specs/MockTerrainProvider.js
+++ b/Specs/MockTerrainProvider.js
@@ -17,6 +17,8 @@ function MockTerrainProvider() {
     this.heightmapWidth,
     this.tilingScheme.getNumberOfXTilesAtLevel(0)
   );
+  this.ready = this._ready = true;
+  this.readyPromise = this._readyPromise = Promise.resolve();
   this.hasWaterMask = true;
   this.errorEvent = new Event();
 

--- a/Specs/TerrainTileProcessor.js
+++ b/Specs/TerrainTileProcessor.js
@@ -62,30 +62,27 @@ TerrainTileProcessor.prototype.process = function (tiles, maxIterations) {
       ++that.frameState.frameNumber;
 
       // Keep going until all terrain and imagery provider are ready and states are no longer changing.
-      let changed = !that.terrainProvider.ready;
-
+      let changed = false;
       for (let i = 0; i < that.imageryLayerCollection.length; ++i) {
         changed =
           changed || !that.imageryLayerCollection.get(i).imageryProvider.ready;
       }
 
-      if (that.terrainProvider.ready) {
-        tiles.forEach(function (tile) {
-          const beforeState = getState(tile);
-          GlobeSurfaceTile.processStateMachine(
-            tile,
-            that.frameState,
-            that.terrainProvider,
-            that.imageryLayerCollection
-          );
-          const afterState = getState(tile);
-          changed =
-            changed ||
-            tile.data.terrainState === TerrainState.RECEIVING ||
-            tile.data.terrainState === TerrainState.TRANSFORMING ||
-            !statesAreSame(beforeState, afterState);
-        });
-      }
+      tiles.forEach(function (tile) {
+        const beforeState = getState(tile);
+        GlobeSurfaceTile.processStateMachine(
+          tile,
+          that.frameState,
+          that.terrainProvider,
+          that.imageryLayerCollection
+        );
+        const afterState = getState(tile);
+        changed =
+          changed ||
+          tile.data.terrainState === TerrainState.RECEIVING ||
+          tile.data.terrainState === TerrainState.TRANSFORMING ||
+          !statesAreSame(beforeState, afterState);
+      });
 
       if (!changed || iterations >= maxIterations) {
         resolve(iterations);

--- a/Specs/TerrainTileProcessor.js
+++ b/Specs/TerrainTileProcessor.js
@@ -62,27 +62,30 @@ TerrainTileProcessor.prototype.process = function (tiles, maxIterations) {
       ++that.frameState.frameNumber;
 
       // Keep going until all terrain and imagery provider are ready and states are no longer changing.
-      let changed = false;
+      let changed = !that.terrainProvider.ready;
+
       for (let i = 0; i < that.imageryLayerCollection.length; ++i) {
         changed =
           changed || !that.imageryLayerCollection.get(i).imageryProvider.ready;
       }
 
-      tiles.forEach(function (tile) {
-        const beforeState = getState(tile);
-        GlobeSurfaceTile.processStateMachine(
-          tile,
-          that.frameState,
-          that.terrainProvider,
-          that.imageryLayerCollection
-        );
-        const afterState = getState(tile);
-        changed =
-          changed ||
-          tile.data.terrainState === TerrainState.RECEIVING ||
-          tile.data.terrainState === TerrainState.TRANSFORMING ||
-          !statesAreSame(beforeState, afterState);
-      });
+      if (that.terrainProvider.ready) {
+        tiles.forEach(function (tile) {
+          const beforeState = getState(tile);
+          GlobeSurfaceTile.processStateMachine(
+            tile,
+            that.frameState,
+            that.terrainProvider,
+            that.imageryLayerCollection
+          );
+          const afterState = getState(tile);
+          changed =
+            changed ||
+            tile.data.terrainState === TerrainState.RECEIVING ||
+            tile.data.terrainState === TerrainState.TRANSFORMING ||
+            !statesAreSame(beforeState, afterState);
+        });
+      }
 
       if (!changed || iterations >= maxIterations) {
         resolve(iterations);

--- a/Specs/addDefaultMatchers.js
+++ b/Specs/addDefaultMatchers.js
@@ -25,6 +25,69 @@ function createMissingFunctionMessageFunction(
   };
 }
 
+function makeAsyncThrowFunction(debug, Type, name) {
+  if (debug) {
+    return function (util) {
+      return {
+        compare: function (actualPromise, message) {
+          // based on the built-in Jasmine toBeRejectedWithError async-matcher
+          if (!defined(actualPromise) || !defined(actualPromise.then)) {
+            throw new Error("Expected function to be called on a promise.");
+          }
+
+          return actualPromise
+            .then(() => {
+              return {
+                pass: false,
+                message:
+                  "Expected a promise to be rejected but it was resolved.",
+              };
+            })
+            .catch((e) => {
+              let result = e instanceof Type || e.name === name;
+              if (defined(message)) {
+                result = result && util.equals(e.message, message);
+              }
+              return {
+                pass: result,
+                message: result
+                  ? `Expected a promise to be rejected with ${name}.`
+                  : `Expected a promise to be rejected with ${
+                      defined(message) ? `${name}: ${message}` : name
+                    }, but it was rejected with ${e}`,
+              };
+            });
+        },
+      };
+    };
+  }
+
+  return function () {
+    return {
+      compare: function (actualPromise) {
+        return Promise.resolve(actualPromise)
+          .catch((e) => {
+            // Ignore any error
+            return { pass: true };
+          })
+          .finally(() => {
+            return { pass: true };
+          });
+      },
+      negativeCompare: function (actualPromise) {
+        return Promise.resolve(actualPromise)
+          .catch((e) => {
+            // Ignore any error
+            return { pass: true };
+          })
+          .finally(() => {
+            return { pass: true };
+          });
+      },
+    };
+  };
+}
+
 function makeThrowFunction(debug, Type, name) {
   if (debug) {
     return function (util) {
@@ -627,6 +690,16 @@ function createDefaultMatchers(debug) {
   };
 }
 
+function createDefaultAsyncMatchers(debug) {
+  return {
+    toBeRejectedWithDeveloperError: makeAsyncThrowFunction(
+      debug,
+      DeveloperError,
+      "DeveloperError"
+    ),
+  };
+}
+
 function countRenderedPixels(rgba) {
   const pixelCount = rgba.length / 4;
   let count = 0;
@@ -926,6 +999,7 @@ function expectContextToRender(actual, expected, expectEqual) {
 function addDefaultMatchers(debug) {
   return function () {
     this.addMatchers(createDefaultMatchers(debug));
+    this.addAsyncMatchers(createDefaultAsyncMatchers(debug));
   };
 }
 export default addDefaultMatchers;

--- a/Specs/addDefaultMatchers.js
+++ b/Specs/addDefaultMatchers.js
@@ -66,21 +66,21 @@ function makeAsyncThrowFunction(debug, Type, name) {
     return {
       compare: function (actualPromise) {
         return Promise.resolve(actualPromise)
-          .catch((e) => {
-            // Ignore any error
+          .then(() => {
             return { pass: true };
           })
-          .finally(() => {
+          .catch((e) => {
+            // Ignore any error
             return { pass: true };
           });
       },
       negativeCompare: function (actualPromise) {
         return Promise.resolve(actualPromise)
-          .catch((e) => {
-            // Ignore any error
+          .then(() => {
             return { pass: true };
           })
-          .finally(() => {
+          .catch((e) => {
+            // Ignore any error
             return { pass: true };
           });
       },

--- a/Specs/test.cjs
+++ b/Specs/test.cjs
@@ -14,7 +14,7 @@ async function test() {
   const provider = await CesiumTerrainProvider.fromUrl(
     "https://s3.amazonaws.com/cesiumjs/smallTerrain"
   );
-  const results = sampleTerrain(provider, 11, [
+  const results = await sampleTerrain(provider, 11, [
     Cartographic.fromDegrees(86.925145, 27.988257),
     Cartographic.fromDegrees(87.0, 28.0),
   ]);

--- a/Specs/test.cjs
+++ b/Specs/test.cjs
@@ -10,15 +10,18 @@ const {
   sampleTerrain,
 } = require("cesium");
 
-const provider = new CesiumTerrainProvider({
-  url: "https://s3.amazonaws.com/cesiumjs/smallTerrain",
-});
-sampleTerrain(provider, 11, [
-  Cartographic.fromDegrees(86.925145, 27.988257),
-  Cartographic.fromDegrees(87.0, 28.0),
-]).then((results) => {
+async function test() {
+  const provider = await CesiumTerrainProvider.fromUrl(
+    "https://s3.amazonaws.com/cesiumjs/smallTerrain"
+  );
+  const results = sampleTerrain(provider, 11, [
+    Cartographic.fromDegrees(86.925145, 27.988257),
+    Cartographic.fromDegrees(87.0, 28.0),
+  ]);
   assert(results[0].height > 5000);
   assert(results[0].height < 10000);
   assert(results[1].height > 5000);
   assert(results[1].height < 10000);
-});
+}
+
+test();

--- a/Specs/test.mjs
+++ b/Specs/test.mjs
@@ -3,15 +3,18 @@ import assert from "node:assert";
 
 // NodeJS smoke screen test
 
-const provider = new CesiumTerrainProvider({
-    url: "https://s3.amazonaws.com/cesiumjs/smallTerrain",
-  });
-  sampleTerrain(provider, 11, [
+async function test() {
+  const provider = await CesiumTerrainProvider.fromUrl(
+    "https://s3.amazonaws.com/cesiumjs/smallTerrain"
+  );
+  const results = await sampleTerrain(provider, 11, [
     Cartographic.fromDegrees(86.925145, 27.988257),
     Cartographic.fromDegrees(87.0, 28.0),
-  ]).then((results) => {
-    assert(results[0].height > 5000);
-    assert(results[0].height < 10000);
-    assert(results[1].height > 5000);
-    assert(results[1].height < 10000);
-  });
+  ]);
+  assert(results[0].height > 5000);
+  assert(results[0].height < 10000);
+  assert(results[1].height > 5000);
+  assert(results[1].height < 10000);
+}
+
+test();

--- a/packages/engine/Source/Core/ArcGISTiledElevationTerrainProvider.js
+++ b/packages/engine/Source/Core/ArcGISTiledElevationTerrainProvider.js
@@ -31,6 +31,7 @@ const ALL_CHILDREN = 15;
  * @property {Ellipsoid} [ellipsoid] The ellipsoid.  If the tilingScheme is specified,
  *                    this parameter is ignored and the tiling scheme's ellipsoid is used instead.
  *                    If neither parameter is specified, the WGS84 ellipsoid is used.
+ * @property {Resource|String|Promise<Resource>|Promise<String>} [url] The URL of the ArcGIS ImageServer service. Deprecated.
  */
 
 /**
@@ -39,7 +40,7 @@ const ALL_CHILDREN = 15;
  * @constructor
  * @private
  *
- * @param {ArcGISTiledElevationTerrainProvider.ConstructorOptions} options A url or an object describing initialization options
+ * @param {ArcGISTiledElevationTerrainProvider.ConstructorOptions} [options] An object describing initialization options.
  */
 function TerrainProviderBuilder(options) {
   this.ellipsoid = defaultValue(options.ellipsoid, Ellipsoid.WGS84);
@@ -224,7 +225,7 @@ async function requestMetadata(
  * @alias ArcGISTiledElevationTerrainProvider
  * @constructor
  *
- * @param {CesiumTerrainProvider.ConstructorOptions} options A url or an object describing initialization options
+ * @param {CesiumTerrainProvider.ConstructorOptions} [options] A url or an object describing initialization options
  *
  * @example
  * const terrainProvider = await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer", {
@@ -243,16 +244,17 @@ function ArcGISTiledElevationTerrainProvider(options) {
   this._levelZeroMaximumGeometricError = undefined;
   this._maxLevel = undefined;
   this._terrainDataStructure = undefined;
-  this._ready = false;
   this._width = undefined;
   this._height = undefined;
   this._encoding = undefined;
+  this._lodCount = undefined;
   const token = options.token;
 
   this._hasAvailability = false;
   this._tilesAvailable = undefined;
   this._tilesAvailabilityLoaded = undefined;
   this._availableCache = {};
+  this._ready = false;
 
   this._errorEvent = new Event();
 

--- a/packages/engine/Source/Core/ArcGISTiledElevationTerrainProvider.js
+++ b/packages/engine/Source/Core/ArcGISTiledElevationTerrainProvider.js
@@ -1,8 +1,9 @@
 import Cartesian2 from "./Cartesian2.js";
+import Check from "./Check.js";
 import Credit from "./Credit.js";
 import defaultValue from "./defaultValue.js";
 import defined from "./defined.js";
-import DeveloperError from "./DeveloperError.js";
+import deprecationWarning from "./deprecationWarning.js";
 import Ellipsoid from "./Ellipsoid.js";
 import Event from "./Event.js";
 import GeographicTilingScheme from "./GeographicTilingScheme.js";
@@ -22,34 +23,219 @@ import WebMercatorTilingScheme from "./WebMercatorTilingScheme.js";
 const ALL_CHILDREN = 15;
 
 /**
+ * @typedef {Object} ArcGISTiledElevationTerrainProvider.ConstructorOptions
+ *
+ * Initialization options for the ArcGISTiledElevationTerrainProvider constructor
+ *
+ * @property {String} [token] The authorization token to use to connect to the service.
+ * @property {Ellipsoid} [ellipsoid] The ellipsoid.  If the tilingScheme is specified,
+ *                    this parameter is ignored and the tiling scheme's ellipsoid is used instead.
+ *                    If neither parameter is specified, the WGS84 ellipsoid is used.
+ */
+
+/**
+ * Used to track creation details while fetching initial metadata
+ *
+ * @constructor
+ * @private
+ *
+ * @param {ArcGISTiledElevationTerrainProvider.ConstructorOptions} options A url or an object describing initialization options
+ */
+function TerrainProviderBuilder(options) {
+  this.ellipsoid = defaultValue(options.ellipsoid, Ellipsoid.WGS84);
+
+  this.credit = undefined;
+  this.tilingScheme = undefined;
+  this.height = undefined;
+  this.width = undefined;
+  this.encoding = undefined;
+  this.lodCount = undefined;
+  this.hasAvailability = false;
+  this.tilesAvailable = undefined;
+  this.tilesAvailabilityLoaded = undefined;
+  this.levelZeroMaximumGeometricError = undefined;
+  this.terrainDataStructure = undefined;
+}
+
+/**
+ * Complete ArcGISTiledElevationTerrainProvider creation based on builder values.
+ *
+ * @private
+ *
+ * @param {ArcGISTiledElevationTerrainProvider} provider
+ */
+TerrainProviderBuilder.prototype.build = function (provider) {
+  provider._credit = this.credit;
+  provider._tilingScheme = this.tilingScheme;
+  provider._height = this.height;
+  provider._width = this.width;
+  provider._encoding = this.encoding;
+  provider._lodCount = this.lodCount;
+  provider._hasAvailability = this.hasAvailability;
+  provider._tilesAvailable = this.tilesAvailable;
+  provider._tilesAvailabilityLoaded = this.tilesAvailabilityLoaded;
+  provider._levelZeroMaximumGeometricError = this.levelZeroMaximumGeometricError;
+  provider._terrainDataStructure = this.terrainDataStructure;
+
+  provider._ready = true;
+};
+
+function parseMetadataSuccess(terrainProviderBuilder, metadata) {
+  const copyrightText = metadata.copyrightText;
+  if (defined(copyrightText)) {
+    terrainProviderBuilder.credit = new Credit(copyrightText);
+  }
+
+  const spatialReference = metadata.spatialReference;
+  const wkid = defaultValue(spatialReference.latestWkid, spatialReference.wkid);
+  const extent = metadata.extent;
+  const tilingSchemeOptions = {
+    ellipsoid: terrainProviderBuilder.ellipsoid,
+  };
+  if (wkid === 4326) {
+    tilingSchemeOptions.rectangle = Rectangle.fromDegrees(
+      extent.xmin,
+      extent.ymin,
+      extent.xmax,
+      extent.ymax
+    );
+    terrainProviderBuilder.tilingScheme = new GeographicTilingScheme(
+      tilingSchemeOptions
+    );
+  } else if (wkid === 3857) {
+    // Clamp extent to EPSG 3857 bounds
+    const epsg3857Bounds =
+      Math.PI * terrainProviderBuilder.ellipsoid.maximumRadius;
+    if (metadata.extent.xmax > epsg3857Bounds) {
+      metadata.extent.xmax = epsg3857Bounds;
+    }
+    if (metadata.extent.ymax > epsg3857Bounds) {
+      metadata.extent.ymax = epsg3857Bounds;
+    }
+    if (metadata.extent.xmin < -epsg3857Bounds) {
+      metadata.extent.xmin = -epsg3857Bounds;
+    }
+    if (metadata.extent.ymin < -epsg3857Bounds) {
+      metadata.extent.ymin = -epsg3857Bounds;
+    }
+
+    tilingSchemeOptions.rectangleSouthwestInMeters = new Cartesian2(
+      extent.xmin,
+      extent.ymin
+    );
+    tilingSchemeOptions.rectangleNortheastInMeters = new Cartesian2(
+      extent.xmax,
+      extent.ymax
+    );
+    terrainProviderBuilder.tilingScheme = new WebMercatorTilingScheme(
+      tilingSchemeOptions
+    );
+  } else {
+    throw new RuntimeError("Invalid spatial reference");
+  }
+
+  const tileInfo = metadata.tileInfo;
+  if (!defined(tileInfo)) {
+    throw new RuntimeError("tileInfo is required");
+  }
+
+  terrainProviderBuilder.width = tileInfo.rows + 1;
+  terrainProviderBuilder.height = tileInfo.cols + 1;
+  terrainProviderBuilder.encoding =
+    tileInfo.format === "LERC"
+      ? HeightmapEncoding.LERC
+      : HeightmapEncoding.NONE;
+  terrainProviderBuilder.lodCount = tileInfo.lods.length - 1;
+
+  const hasAvailability = (terrainProviderBuilder.hasAvailability =
+    metadata.capabilities.indexOf("Tilemap") !== -1);
+  if (hasAvailability) {
+    terrainProviderBuilder.tilesAvailable = new TileAvailability(
+      terrainProviderBuilder.tilingScheme,
+      terrainProviderBuilder.lodCount
+    );
+    terrainProviderBuilder.tilesAvailable.addAvailableTileRange(
+      0,
+      0,
+      0,
+      terrainProviderBuilder.tilingScheme.getNumberOfXTilesAtLevel(0),
+      terrainProviderBuilder.tilingScheme.getNumberOfYTilesAtLevel(0)
+    );
+    terrainProviderBuilder.tilesAvailabilityLoaded = new TileAvailability(
+      terrainProviderBuilder.tilingScheme,
+      terrainProviderBuilder.lodCount
+    );
+  }
+
+  terrainProviderBuilder.levelZeroMaximumGeometricError = TerrainProvider.getEstimatedLevelZeroGeometricErrorForAHeightmap(
+    terrainProviderBuilder.tilingScheme.ellipsoid,
+    terrainProviderBuilder.width,
+    terrainProviderBuilder.tilingScheme.getNumberOfXTilesAtLevel(0)
+  );
+
+  if (metadata.bandCount > 1) {
+    console.log(
+      "ArcGISTiledElevationTerrainProvider: Terrain data has more than 1 band. Using the first one."
+    );
+  }
+
+  if (defined(metadata.minValues) && defined(metadata.maxValues)) {
+    terrainProviderBuilder.terrainDataStructure = {
+      elementMultiplier: 1.0,
+      lowestEncodedHeight: metadata.minValues[0],
+      highestEncodedHeight: metadata.maxValues[0],
+    };
+  } else {
+    terrainProviderBuilder.terrainDataStructure = {
+      elementMultiplier: 1.0,
+    };
+  }
+}
+
+async function requestMetadata(
+  terrainProviderBuilder,
+  metadataResource,
+  provider
+) {
+  try {
+    const metadata = await metadataResource.fetchJson();
+    parseMetadataSuccess(terrainProviderBuilder, metadata);
+  } catch (error) {
+    const message = `An error occurred while accessing ${metadataResource}.`;
+    TileProviderError.reportError(
+      undefined,
+      provider,
+      defined(provider) ? provider._errorEvent : undefined,
+      message
+    );
+
+    throw error;
+  }
+}
+
+/**
+ * <div class="notice">
+ * To construct a CesiumTerrainProvider, call {@link ArcGISTiledElevationTerrainProvider.fromUrl}. Do not call the constructor directly.
+ * </div>
+ *
  * A {@link TerrainProvider} that produces terrain geometry by tessellating height maps
  * retrieved from Elevation Tiles of an an ArcGIS ImageService.
  *
  * @alias ArcGISTiledElevationTerrainProvider
  * @constructor
  *
- * @param {Object} options Object with the following properties:
- * @param {Resource|String|Promise<Resource>|Promise<String>} options.url The URL of the ArcGIS ImageServer service.
- * @param {String} [options.token] The authorization token to use to connect to the service.
- * @param {Ellipsoid} [options.ellipsoid] The ellipsoid.  If the tilingScheme is specified,
- *                    this parameter is ignored and the tiling scheme's ellipsoid is used instead.
- *                    If neither parameter is specified, the WGS84 ellipsoid is used.
+ * @param {CesiumTerrainProvider.ConstructorOptions} options A url or an object describing initialization options
  *
  * @example
- * const terrainProvider = new Cesium.ArcGISTiledElevationTerrainProvider({
- *   url : 'https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer',
- *   token : 'KED1aF_I4UzXOHy3BnhwyBHU4l5oY6rO6walkmHoYqGp4XyIWUd5YZUC1ZrLAzvV40pR6gBXQayh0eFA8m6vPg..'
+ * const terrainProvider = await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer", {
+ *   token : "KED1aF_I4UzXOHy3BnhwyBHU4l5oY6rO6walkmHoYqGp4XyIWUd5YZUC1ZrLAzvV40pR6gBXQayh0eFA8m6vPg.."
  * });
  * viewer.terrainProvider = terrainProvider;
  *
  *  @see TerrainProvider
  */
 function ArcGISTiledElevationTerrainProvider(options) {
-  //>>includeStart('debug', pragmas.debug);
-  if (!defined(options) || !defined(options.url)) {
-    throw new DeveloperError("options.url is required.");
-  }
-  //>>includeEnd('debug');
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
   this._resource = undefined;
   this._credit = undefined;
@@ -65,13 +251,22 @@ function ArcGISTiledElevationTerrainProvider(options) {
 
   this._hasAvailability = false;
   this._tilesAvailable = undefined;
-  this._tilesAvailablityLoaded = undefined;
+  this._tilesAvailabilityLoaded = undefined;
   this._availableCache = {};
 
-  const that = this;
-  const ellipsoid = defaultValue(options.ellipsoid, Ellipsoid.WGS84);
-  this._readyPromise = Promise.resolve(options.url)
-    .then(function (url) {
+  this._errorEvent = new Event();
+
+  if (defined(options.url)) {
+    deprecationWarning(
+      "ArcGISTiledElevationTerrainProvider options.url",
+      "options.url was deprecated in CesiumJS 1.102.  It will be removed in 1.104.  Use ArcGISTiledElevationTerrainProvider.fromUrl instead."
+    );
+
+    const that = this;
+    const terrainProviderBuilder = new TerrainProviderBuilder(options);
+    this._readyPromise = Promise.resolve(options.url).then(async function (
+      url
+    ) {
       let resource = Resource.createIfNeeded(url);
       resource.appendForwardSlash();
       if (defined(token)) {
@@ -89,128 +284,12 @@ function ArcGISTiledElevationTerrainProvider(options) {
         },
       });
 
-      return metadataResource.fetchJson();
-    })
-    .then(function (metadata) {
-      const copyrightText = metadata.copyrightText;
-      if (defined(copyrightText)) {
-        that._credit = new Credit(copyrightText);
-      }
-
-      const spatialReference = metadata.spatialReference;
-      const wkid = defaultValue(
-        spatialReference.latestWkid,
-        spatialReference.wkid
-      );
-      const extent = metadata.extent;
-      const tilingSchemeOptions = {
-        ellipsoid: ellipsoid,
-      };
-      if (wkid === 4326) {
-        tilingSchemeOptions.rectangle = Rectangle.fromDegrees(
-          extent.xmin,
-          extent.ymin,
-          extent.xmax,
-          extent.ymax
-        );
-        that._tilingScheme = new GeographicTilingScheme(tilingSchemeOptions);
-      } else if (wkid === 3857) {
-        // Clamp extent to EPSG 3857 bounds
-        const epsg3857Bounds = Math.PI * ellipsoid.maximumRadius;
-        if (metadata.extent.xmax > epsg3857Bounds) {
-          metadata.extent.xmax = epsg3857Bounds;
-        }
-        if (metadata.extent.ymax > epsg3857Bounds) {
-          metadata.extent.ymax = epsg3857Bounds;
-        }
-        if (metadata.extent.xmin < -epsg3857Bounds) {
-          metadata.extent.xmin = -epsg3857Bounds;
-        }
-        if (metadata.extent.ymin < -epsg3857Bounds) {
-          metadata.extent.ymin = -epsg3857Bounds;
-        }
-
-        tilingSchemeOptions.rectangleSouthwestInMeters = new Cartesian2(
-          extent.xmin,
-          extent.ymin
-        );
-        tilingSchemeOptions.rectangleNortheastInMeters = new Cartesian2(
-          extent.xmax,
-          extent.ymax
-        );
-        that._tilingScheme = new WebMercatorTilingScheme(tilingSchemeOptions);
-      } else {
-        return Promise.reject(new RuntimeError("Invalid spatial reference"));
-      }
-
-      const tileInfo = metadata.tileInfo;
-      if (!defined(tileInfo)) {
-        return Promise.reject(new RuntimeError("tileInfo is required"));
-      }
-
-      that._width = tileInfo.rows + 1;
-      that._height = tileInfo.cols + 1;
-      that._encoding =
-        tileInfo.format === "LERC"
-          ? HeightmapEncoding.LERC
-          : HeightmapEncoding.NONE;
-      that._lodCount = tileInfo.lods.length - 1;
-
-      const hasAvailability = (that._hasAvailability =
-        metadata.capabilities.indexOf("Tilemap") !== -1);
-      if (hasAvailability) {
-        that._tilesAvailable = new TileAvailability(
-          that._tilingScheme,
-          that._lodCount
-        );
-        that._tilesAvailable.addAvailableTileRange(
-          0,
-          0,
-          0,
-          that._tilingScheme.getNumberOfXTilesAtLevel(0),
-          that._tilingScheme.getNumberOfYTilesAtLevel(0)
-        );
-        that._tilesAvailablityLoaded = new TileAvailability(
-          that._tilingScheme,
-          that._lodCount
-        );
-      }
-
-      that._levelZeroMaximumGeometricError = TerrainProvider.getEstimatedLevelZeroGeometricErrorForAHeightmap(
-        that._tilingScheme.ellipsoid,
-        that._width,
-        that._tilingScheme.getNumberOfXTilesAtLevel(0)
-      );
-
-      if (metadata.bandCount > 1) {
-        console.log(
-          "ArcGISTiledElevationTerrainProvider: Terrain data has more than 1 band. Using the first one."
-        );
-      }
-
-      if (defined(metadata.minValues) && defined(metadata.maxValues)) {
-        that._terrainDataStructure = {
-          elementMultiplier: 1.0,
-          lowestEncodedHeight: metadata.minValues[0],
-          highestEncodedHeight: metadata.maxValues[0],
-        };
-      } else {
-        that._terrainDataStructure = {
-          elementMultiplier: 1.0,
-        };
-      }
-
-      that._ready = true;
+      await requestMetadata(terrainProviderBuilder, metadataResource, that);
+      terrainProviderBuilder.build(that);
 
       return true;
-    })
-    .catch(function (error) {
-      const message = `An error occurred while accessing ${that._resource.url}.`;
-      TileProviderError.reportError(undefined, that, that._errorEvent, message);
-      return Promise.reject(error);
     });
-
-  this._errorEvent = new Event();
+  }
 }
 
 Object.defineProperties(ArcGISTiledElevationTerrainProvider.prototype, {
@@ -230,40 +309,25 @@ Object.defineProperties(ArcGISTiledElevationTerrainProvider.prototype, {
 
   /**
    * Gets the credit to display when this terrain provider is active.  Typically this is used to credit
-   * the source of the terrain.  This function should not be called before {@link ArcGISTiledElevationTerrainProvider#ready} returns true.
+   * the source of the terrain.
    * @memberof ArcGISTiledElevationTerrainProvider.prototype
    * @type {Credit}
    * @readonly
    */
   credit: {
     get: function () {
-      //>>includeStart('debug', pragmas.debug);
-      if (!this.ready) {
-        throw new DeveloperError(
-          "credit must not be called before ready returns true."
-        );
-      }
-      //>>includeEnd('debug');
       return this._credit;
     },
   },
 
   /**
-   * Gets the tiling scheme used by this provider.  This function should
-   * not be called before {@link ArcGISTiledElevationTerrainProvider#ready} returns true.
+   * Gets the tiling scheme used by this provider.
    * @memberof ArcGISTiledElevationTerrainProvider.prototype
    * @type {GeographicTilingScheme}
    * @readonly
    */
   tilingScheme: {
     get: function () {
-      //>>includeStart('debug', pragmas.debug);
-      if (!this.ready) {
-        throw new DeveloperError(
-          "tilingScheme must not be called before ready returns true."
-        );
-      }
-      //>>includeEnd('debug');
       return this._tilingScheme;
     },
   },
@@ -273,9 +337,14 @@ Object.defineProperties(ArcGISTiledElevationTerrainProvider.prototype, {
    * @memberof ArcGISTiledElevationTerrainProvider.prototype
    * @type {Boolean}
    * @readonly
+   * @deprecated
    */
   ready: {
     get: function () {
+      deprecationWarning(
+        "ArcGISTiledElevationTerrainProvider.ready",
+        "ArcGISTiledElevationTerrainProvider.ready was deprecated in CesiumJS 1.102.  It will be removed in 1.104.  Use ArcGISTiledElevationTerrainProvider.fromUrl instead."
+      );
       return this._ready;
     },
   },
@@ -285,9 +354,14 @@ Object.defineProperties(ArcGISTiledElevationTerrainProvider.prototype, {
    * @memberof ArcGISTiledElevationTerrainProvider.prototype
    * @type {Promise.<Boolean>}
    * @readonly
+   * @deprecated
    */
   readyPromise: {
     get: function () {
+      deprecationWarning(
+        "ArcGISTiledElevationTerrainProvider.readyPromise",
+        "ArcGISTiledElevationTerrainProvider.readyPromise was deprecated in CesiumJS 1.102.  It will be removed in 1.104.  Use ArcGISTiledElevationTerrainProvider.fromUrl instead."
+      );
       return this._readyPromise;
     },
   },
@@ -295,8 +369,7 @@ Object.defineProperties(ArcGISTiledElevationTerrainProvider.prototype, {
   /**
    * Gets a value indicating whether or not the provider includes a water mask.  The water mask
    * indicates which areas of the globe are water rather than land, so they can be rendered
-   * as a reflective surface with animated waves.  This function should not be
-   * called before {@link ArcGISTiledElevationTerrainProvider#ready} returns true.
+   * as a reflective surface with animated waves.
    * @memberof ArcGISTiledElevationTerrainProvider.prototype
    * @type {Boolean}
    * @readonly
@@ -309,7 +382,6 @@ Object.defineProperties(ArcGISTiledElevationTerrainProvider.prototype, {
 
   /**
    * Gets a value indicating whether or not the requested tiles include vertex normals.
-   * This function should not be called before {@link ArcGISTiledElevationTerrainProvider#ready} returns true.
    * @memberof ArcGISTiledElevationTerrainProvider.prototype
    * @type {Boolean}
    * @readonly
@@ -321,8 +393,7 @@ Object.defineProperties(ArcGISTiledElevationTerrainProvider.prototype, {
   },
   /**
    * Gets an object that can be used to determine availability of terrain from this provider, such as
-   * at points and in rectangles.  This function should not be called before
-   * {@link TerrainProvider#ready} returns true.  This property may be undefined if availability
+   * at points and in rectangles. This property may be undefined if availability
    * information is not available.
    * @memberof ArcGISTiledElevationTerrainProvider.prototype
    * @type {TileAvailability}
@@ -330,21 +401,64 @@ Object.defineProperties(ArcGISTiledElevationTerrainProvider.prototype, {
    */
   availability: {
     get: function () {
-      //>>includeStart('debug', pragmas.debug)
-      if (!this._ready) {
-        throw new DeveloperError(
-          "availability must not be called before the terrain provider is ready."
-        );
-      }
-      //>>includeEnd('debug');
       return this._tilesAvailable;
     },
   },
 });
 
 /**
- * Requests the geometry for a given tile.  This function should not be called before
- * {@link ArcGISTiledElevationTerrainProvider#ready} returns true.  The result includes terrain
+ * Creates a {@link TerrainProvider} that produces terrain geometry by tessellating height maps
+ * retrieved from Elevation Tiles of an an ArcGIS ImageService.
+ *
+ * @param {Resource|String|Promise<Resource>|Promise<String>} url The URL of the ArcGIS ImageServer service.
+ * @param {ArcGISTiledElevationTerrainProvider.ConstructorOptions} [options] A url or an object describing initialization options.
+ * @returns {Promise<ArcGISTiledElevationTerrainProvider>}
+ *
+ * @example
+ * const terrainProvider = await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer", {
+ *   token : "KED1aF_I4UzXOHy3BnhwyBHU4l5oY6rO6walkmHoYqGp4XyIWUd5YZUC1ZrLAzvV40pR6gBXQayh0eFA8m6vPg.."
+ * });
+ * viewer.terrainProvider = terrainProvider;
+ *
+ * @exception {RuntimeError} metadata specifies invalid spatial reference
+ * @exception {RuntimeError} metadata does not specify tileInfo
+ */
+ArcGISTiledElevationTerrainProvider.fromUrl = async function (url, options) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.defined("url", url);
+  //>>includeEnd('debug');
+
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+
+  url = await Promise.resolve(url);
+  let resource = Resource.createIfNeeded(url);
+  resource.appendForwardSlash();
+  if (defined(options.token)) {
+    resource = resource.getDerivedResource({
+      queryParameters: {
+        token: options.token,
+      },
+    });
+  }
+
+  const metadataResource = resource.getDerivedResource({
+    queryParameters: {
+      f: "pjson",
+    },
+  });
+
+  const terrainProviderBuilder = new TerrainProviderBuilder(options);
+  await requestMetadata(terrainProviderBuilder, metadataResource);
+
+  const provider = new ArcGISTiledElevationTerrainProvider(options);
+  terrainProviderBuilder.build(provider);
+  provider._resource = resource;
+
+  return provider;
+};
+
+/**
+ * Requests the geometry for a given tile. The result includes terrain
  * data and indicates that all child tiles are available.
  *
  * @param {Number} x The X coordinate of the tile for which to request geometry.
@@ -361,14 +475,6 @@ ArcGISTiledElevationTerrainProvider.prototype.requestTileGeometry = function (
   level,
   request
 ) {
-  //>>includeStart('debug', pragmas.debug)
-  if (!this._ready) {
-    throw new DeveloperError(
-      "requestTileGeometry must not be called before the terrain provider is ready."
-    );
-  }
-  //>>includeEnd('debug');
-
   const tileResource = this._resource.getDerivedResource({
     url: `tile/${level}/${y}/${x}`,
     request: request,
@@ -436,7 +542,7 @@ function isTileAvailable(that, level, x, y) {
     return undefined;
   }
 
-  const tilesAvailablityLoaded = that._tilesAvailablityLoaded;
+  const tilesAvailabilityLoaded = that._tilesAvailabilityLoaded;
   const tilesAvailable = that._tilesAvailable;
 
   if (level > that._lodCount) {
@@ -449,7 +555,7 @@ function isTileAvailable(that, level, x, y) {
   }
 
   // or to not be available
-  if (tilesAvailablityLoaded.isTileAvailable(level, x, y)) {
+  if (tilesAvailabilityLoaded.isTileAvailable(level, x, y)) {
     return false;
   }
 
@@ -465,14 +571,6 @@ function isTileAvailable(that, level, x, y) {
 ArcGISTiledElevationTerrainProvider.prototype.getLevelMaximumGeometricError = function (
   level
 ) {
-  //>>includeStart('debug', pragmas.debug);
-  if (!this.ready) {
-    throw new DeveloperError(
-      "getLevelMaximumGeometricError must not be called before ready returns true."
-    );
-  }
-  //>>includeEnd('debug');
-
   return this._levelZeroMaximumGeometricError / (1 << level);
 };
 
@@ -685,7 +783,7 @@ function requestAvailability(that, level, x, y) {
     );
 
     // Mark whole area as having availability loaded
-    that._tilesAvailablityLoaded.addAvailableTileRange(
+    that._tilesAvailabilityLoaded.addAvailableTileRange(
       level,
       xOffset,
       yOffset,

--- a/packages/engine/Source/Core/ArcGISTiledElevationTerrainProvider.js
+++ b/packages/engine/Source/Core/ArcGISTiledElevationTerrainProvider.js
@@ -229,7 +229,7 @@ async function requestMetadata(
  *
  * @example
  * const terrainProvider = await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer", {
- *   token : "KED1aF_I4UzXOHy3BnhwyBHU4l5oY6rO6walkmHoYqGp4XyIWUd5YZUC1ZrLAzvV40pR6gBXQayh0eFA8m6vPg.."
+ *   token: "KED1aF_I4UzXOHy3BnhwyBHU4l5oY6rO6walkmHoYqGp4XyIWUd5YZUC1ZrLAzvV40pR6gBXQayh0eFA8m6vPg.."
  * });
  * viewer.terrainProvider = terrainProvider;
  *
@@ -418,7 +418,7 @@ Object.defineProperties(ArcGISTiledElevationTerrainProvider.prototype, {
  *
  * @example
  * const terrainProvider = await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer", {
- *   token : "KED1aF_I4UzXOHy3BnhwyBHU4l5oY6rO6walkmHoYqGp4XyIWUd5YZUC1ZrLAzvV40pR6gBXQayh0eFA8m6vPg.."
+ *   token: "KED1aF_I4UzXOHy3BnhwyBHU4l5oY6rO6walkmHoYqGp4XyIWUd5YZUC1ZrLAzvV40pR6gBXQayh0eFA8m6vPg.."
  * });
  * viewer.terrainProvider = terrainProvider;
  *

--- a/packages/engine/Source/Core/ArcGISTiledElevationTerrainProvider.js
+++ b/packages/engine/Source/Core/ArcGISTiledElevationTerrainProvider.js
@@ -233,7 +233,7 @@ async function requestMetadata(
  * });
  * viewer.terrainProvider = terrainProvider;
  *
- *  @see TerrainProvider
+ * @see TerrainProvider
  */
 function ArcGISTiledElevationTerrainProvider(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/packages/engine/Source/Core/CesiumTerrainProvider.js
+++ b/packages/engine/Source/Core/CesiumTerrainProvider.js
@@ -465,12 +465,16 @@ async function requestLayerJson(terrainProviderBuilder, provider) {
  *
  * @example
  * // Create Arctic DEM terrain with normals.
- * const viewer = new Cesium.Viewer('cesiumContainer', {
- *     terrainProvider : Cesium.CesiumTerrainProvider.fromUrl(
- *         Cesium.IonResource.fromAssetId(3956), {
- *             requestVertexNormals : true
+ * try {
+ *   const viewer = new Cesium.Viewer("cesiumContainer", {
+ *     terrainProvider: await Cesium.CesiumTerrainProvider.fromUrl(
+ *       Cesium.IonResource.fromAssetId(3956), {
+ *         requestVertexNormals: true
  *     })
- * });
+ *   });
+ * } catch (error) {
+ *   console.log(error);
+ * }
  *
  * @see createWorldTerrain
  * @see CesiumTerrainProvider.fromUrl
@@ -1210,12 +1214,16 @@ CesiumTerrainProvider.prototype.getLevelMaximumGeometricError = function (
  *
  * @example
  * // Create Arctic DEM terrain with normals.
- * const viewer = new Cesium.Viewer('cesiumContainer', {
- *     terrainProvider : Cesium.CesiumTerrainProvider.fromUrl(
- *         Cesium.IonResource.fromAssetId(3956), {
- *             requestVertexNormals : true
+ * try {
+ *   const viewer = new Cesium.Viewer("cesiumContainer", {
+ *     terrainProvider: await Cesium.CesiumTerrainProvider.fromUrl(
+ *       Cesium.IonResource.fromAssetId(3956), {
+ *         requestVertexNormals: true
  *     })
- * });
+ *   });
+ * } catch (error) {
+ *   console.log(error);
+ * }
  *
  * @exception {RuntimeError} layer.json does not specify a format
  * @exception {RuntimeError} layer.json specifies an unknown format

--- a/packages/engine/Source/Core/CesiumTerrainProvider.js
+++ b/packages/engine/Source/Core/CesiumTerrainProvider.js
@@ -47,6 +47,7 @@ function LayerInformation(layer) {
  * @property {Boolean} [requestMetadata=true] Flag that indicates if the client should request per tile metadata from the server, if available.
  * @property {Ellipsoid} [ellipsoid] The ellipsoid.  If not specified, the WGS84 ellipsoid is used.
  * @property {Credit|String} [credit] A credit for the data source, which is displayed on the canvas.
+ * @property {Resource|String|Promise<Resource>|Promise<String>} [url] The URL of the Cesium terrain server. Deprecated.
  */
 
 /**
@@ -55,7 +56,7 @@ function LayerInformation(layer) {
  * @constructor
  * @private
  *
- * @param {CesiumTerrainProvider.ConstructorOptions} options A url or an object describing initialization options
+ * @param {CesiumTerrainProvider.ConstructorOptions} options An object describing initialization options
  */
 function TerrainProviderBuilder(options) {
   this.requestVertexNormals = defaultValue(options.requestVertexNormals, false);
@@ -460,7 +461,7 @@ async function requestLayerJson(terrainProviderBuilder, provider) {
  * @alias CesiumTerrainProvider
  * @constructor
  *
- * @param {CesiumTerrainProvider.ConstructorOptions} [options] A url or an object describing initialization options
+ * @param {CesiumTerrainProvider.ConstructorOptions} [options] An object describing initialization options
  *
  * @example
  * // Create Arctic DEM terrain with normals.
@@ -523,6 +524,8 @@ function CesiumTerrainProvider(options) {
 
   this._availability = undefined;
   this._tilingScheme = undefined;
+  this._levelZeroMaximumGeometricError = undefined;
+  this._layers = undefined;
 
   this._ready = false;
   this._tileCredits = undefined;
@@ -1202,7 +1205,7 @@ CesiumTerrainProvider.prototype.getLevelMaximumGeometricError = function (
  * </ul>
  *
  * @param {Resource|String|Promise<Resource>|Promise<String>} url The URL of the Cesium terrain server.
- * @param {CesiumTerrainProvider.ConstructorOptions} [options] A url or an object describing initialization options.
+ * @param {CesiumTerrainProvider.ConstructorOptions} [options] An object describing initialization options.
  * @returns {Promise<CesiumTerrainProvider>}
  *
  * @example

--- a/packages/engine/Source/Core/CesiumTerrainProvider.js
+++ b/packages/engine/Source/Core/CesiumTerrainProvider.js
@@ -1,10 +1,11 @@
 import AttributeCompression from "./AttributeCompression.js";
 import BoundingSphere from "./BoundingSphere.js";
 import Cartesian3 from "./Cartesian3.js";
+import Check from "./Check.js";
 import Credit from "./Credit.js";
 import defaultValue from "./defaultValue.js";
 import defined from "./defined.js";
-import DeveloperError from "./DeveloperError.js";
+import deprecationWarning from "./deprecationWarning.js";
 import Event from "./Event.js";
 import GeographicTilingScheme from "./GeographicTilingScheme.js";
 import WebMercatorTilingScheme from "./WebMercatorTilingScheme.js";
@@ -37,6 +38,418 @@ function LayerInformation(layer) {
 }
 
 /**
+ * @typedef {Object} CesiumTerrainProvider.ConstructorOptions
+ *
+ * Initialization options for the CesiumTerrainProvider constructor
+ *
+ * @property {Boolean} [requestVertexNormals=false] Flag that indicates if the client should request additional lighting information from the server, in the form of per vertex normals if available.
+ * @property {Boolean} [requestWaterMask=false] Flag that indicates if the client should request per tile water masks from the server, if available.
+ * @property {Boolean} [requestMetadata=true] Flag that indicates if the client should request per tile metadata from the server, if available.
+ * @property {Ellipsoid} [ellipsoid] The ellipsoid.  If not specified, the WGS84 ellipsoid is used.
+ * @property {Credit|String} [credit] A credit for the data source, which is displayed on the canvas.
+ */
+
+/**
+ * Used to track creation details while fetching initial metadata
+ *
+ * @constructor
+ * @private
+ *
+ * @param {CesiumTerrainProvider.ConstructorOptions} options A url or an object describing initialization options
+ */
+function TerrainProviderBuilder(options) {
+  this.requestVertexNormals = defaultValue(options.requestVertexNormals, false);
+  this.requestWaterMask = defaultValue(options.requestWaterMask, false);
+  this.requestMetadata = defaultValue(options.requestMetadata, true);
+  this.ellipsoid = options.ellipsoid;
+
+  this.heightmapWidth = 65;
+  this.heightmapStructure = undefined;
+  this.hasWaterMask = false;
+  this.hasMetadata = false;
+  this.hasVertexNormals = false;
+  this.scheme = undefined;
+
+  this.lastResource = undefined;
+  this.layerJsonResource = undefined;
+  this.previousError = undefined;
+  this.availability = undefined;
+  this.tilingScheme = undefined;
+  this.levelZeroMaximumGeometricError = undefined;
+  this.heightmapStructure = undefined;
+  this.layers = [];
+  this.attribution = "";
+  this.overallAvailability = [];
+  this.overallMaxZoom = 0;
+  this.tileCredits = [];
+}
+
+/**
+ * Complete CesiumTerrainProvider creation based on builder values.
+ *
+ * @private
+ *
+ * @param {CesiumTerrainProvider} provider
+ */
+TerrainProviderBuilder.prototype.build = function (provider) {
+  provider._heightmapWidth = this.heightmapWidth;
+  provider._scheme = this.scheme;
+
+  // ion resources have a credits property we can use for additional attribution.
+  const credits = defined(this.lastResource.credits)
+    ? this.lastResource.credits
+    : [];
+  provider._tileCredits = credits.concat(this.tileCredits);
+  provider._availability = this.availability;
+  provider._tilingScheme = this.tilingScheme;
+  provider._requestWaterMask = this.requestWaterMask;
+  provider._levelZeroMaximumGeometricError = this.levelZeroMaximumGeometricError;
+  provider._heightmapStructure = this.heightmapStructure;
+  provider._layers = this.layers;
+
+  provider._hasWaterMask = this.hasWaterMask;
+  provider._hasVertexNormals = this.hasVertexNormals;
+  provider._hasMetadata = this.hasMetadata;
+
+  provider._ready = true;
+};
+
+async function parseMetadataSuccess(terrainProviderBuilder, data, provider) {
+  if (!data.format) {
+    const message = "The tile format is not specified in the layer.json file.";
+    terrainProviderBuilder.previousError = TileProviderError.reportError(
+      terrainProviderBuilder.previousError,
+      provider,
+      defined(provider) ? provider._errorEvent : undefined,
+      message
+    );
+
+    throw new RuntimeError(message);
+  }
+
+  if (!data.tiles || data.tiles.length === 0) {
+    const message =
+      "The layer.json file does not specify any tile URL templates.";
+    terrainProviderBuilder.previousError = TileProviderError.reportError(
+      terrainProviderBuilder.previousError,
+      provider,
+      defined(provider) ? provider._errorEvent : undefined,
+      message
+    );
+
+    throw new RuntimeError(message);
+  }
+
+  let hasVertexNormals = false;
+  let hasWaterMask = false;
+  let hasMetadata = false;
+  let littleEndianExtensionSize = true;
+  let isHeightmap = false;
+  if (data.format === "heightmap-1.0") {
+    isHeightmap = true;
+    if (!defined(terrainProviderBuilder.heightmapStructure)) {
+      terrainProviderBuilder.heightmapStructure = {
+        heightScale: 1.0 / 5.0,
+        heightOffset: -1000.0,
+        elementsPerHeight: 1,
+        stride: 1,
+        elementMultiplier: 256.0,
+        isBigEndian: false,
+        lowestEncodedHeight: 0,
+        highestEncodedHeight: 256 * 256 - 1,
+      };
+    }
+    hasWaterMask = true;
+    terrainProviderBuilder.requestWaterMask = true;
+  } else if (data.format.indexOf("quantized-mesh-1.") !== 0) {
+    const message = `The tile format "${data.format}" is invalid or not supported.`;
+    terrainProviderBuilder.previousError = TileProviderError.reportError(
+      terrainProviderBuilder.previousError,
+      provider,
+      defined(provider) ? provider._errorEvent : undefined,
+      message
+    );
+
+    throw new RuntimeError(message);
+  }
+
+  const tileUrlTemplates = data.tiles;
+
+  const maxZoom = data.maxzoom;
+  terrainProviderBuilder.overallMaxZoom = Math.max(
+    terrainProviderBuilder.overallMaxZoom,
+    maxZoom
+  );
+
+  // Keeps track of which of the availability containing tiles have been loaded
+  if (!data.projection || data.projection === "EPSG:4326") {
+    terrainProviderBuilder.tilingScheme = new GeographicTilingScheme({
+      numberOfLevelZeroTilesX: 2,
+      numberOfLevelZeroTilesY: 1,
+      ellipsoid: terrainProviderBuilder.ellipsoid,
+    });
+  } else if (data.projection === "EPSG:3857") {
+    terrainProviderBuilder.tilingScheme = new WebMercatorTilingScheme({
+      numberOfLevelZeroTilesX: 1,
+      numberOfLevelZeroTilesY: 1,
+      ellipsoid: terrainProviderBuilder.ellipsoid,
+    });
+  } else {
+    const message = `The projection "${data.projection}" is invalid or not supported.`;
+    terrainProviderBuilder.previousError = TileProviderError.reportError(
+      terrainProviderBuilder.previousError,
+      provider,
+      defined(provider) ? provider._errorEvent : undefined,
+      message
+    );
+
+    throw new RuntimeError(message);
+  }
+
+  terrainProviderBuilder.levelZeroMaximumGeometricError = TerrainProvider.getEstimatedLevelZeroGeometricErrorForAHeightmap(
+    terrainProviderBuilder.tilingScheme.ellipsoid,
+    terrainProviderBuilder.heightmapWidth,
+    terrainProviderBuilder.tilingScheme.getNumberOfXTilesAtLevel(0)
+  );
+  if (!data.scheme || data.scheme === "tms" || data.scheme === "slippyMap") {
+    terrainProviderBuilder.scheme = data.scheme;
+  } else {
+    const message = `The scheme "${data.scheme}" is invalid or not supported.`;
+    terrainProviderBuilder.previousError = TileProviderError.reportError(
+      terrainProviderBuilder.previousError,
+      provider,
+      defined(provider) ? provider._errorEvent : undefined,
+      message
+    );
+
+    throw new RuntimeError(message);
+  }
+
+  let availabilityTilesLoaded;
+
+  // The vertex normals defined in the 'octvertexnormals' extension is identical to the original
+  // contents of the original 'vertexnormals' extension.  'vertexnormals' extension is now
+  // deprecated, as the extensionLength for this extension was incorrectly using big endian.
+  // We maintain backwards compatibility with the legacy 'vertexnormal' implementation
+  // by setting the _littleEndianExtensionSize to false. Always prefer 'octvertexnormals'
+  // over 'vertexnormals' if both extensions are supported by the server.
+  if (
+    defined(data.extensions) &&
+    data.extensions.indexOf("octvertexnormals") !== -1
+  ) {
+    hasVertexNormals = true;
+  } else if (
+    defined(data.extensions) &&
+    data.extensions.indexOf("vertexnormals") !== -1
+  ) {
+    hasVertexNormals = true;
+    littleEndianExtensionSize = false;
+  }
+  if (defined(data.extensions) && data.extensions.indexOf("watermask") !== -1) {
+    hasWaterMask = true;
+  }
+  if (defined(data.extensions) && data.extensions.indexOf("metadata") !== -1) {
+    hasMetadata = true;
+  }
+
+  const availabilityLevels = data.metadataAvailability;
+  const availableTiles = data.available;
+  let availability;
+  if (defined(availableTiles) && !defined(availabilityLevels)) {
+    availability = new TileAvailability(
+      terrainProviderBuilder.tilingScheme,
+      availableTiles.length
+    );
+    for (let level = 0; level < availableTiles.length; ++level) {
+      const rangesAtLevel = availableTiles[level];
+      const yTiles = terrainProviderBuilder.tilingScheme.getNumberOfYTilesAtLevel(
+        level
+      );
+      if (!defined(terrainProviderBuilder.overallAvailability[level])) {
+        terrainProviderBuilder.overallAvailability[level] = [];
+      }
+
+      for (
+        let rangeIndex = 0;
+        rangeIndex < rangesAtLevel.length;
+        ++rangeIndex
+      ) {
+        const range = rangesAtLevel[rangeIndex];
+        const yStart = yTiles - range.endY - 1;
+        const yEnd = yTiles - range.startY - 1;
+        terrainProviderBuilder.overallAvailability[level].push([
+          range.startX,
+          yStart,
+          range.endX,
+          yEnd,
+        ]);
+        availability.addAvailableTileRange(
+          level,
+          range.startX,
+          yStart,
+          range.endX,
+          yEnd
+        );
+      }
+    }
+  } else if (defined(availabilityLevels)) {
+    availabilityTilesLoaded = new TileAvailability(
+      terrainProviderBuilder.tilingScheme,
+      maxZoom
+    );
+    availability = new TileAvailability(
+      terrainProviderBuilder.tilingScheme,
+      maxZoom
+    );
+    terrainProviderBuilder.overallAvailability[0] = [[0, 0, 1, 0]];
+    availability.addAvailableTileRange(0, 0, 0, 1, 0);
+  }
+
+  terrainProviderBuilder.hasWaterMask =
+    terrainProviderBuilder.hasWaterMask || hasWaterMask;
+  terrainProviderBuilder.hasVertexNormals =
+    terrainProviderBuilder.hasVertexNormals || hasVertexNormals;
+  terrainProviderBuilder.hasMetadata =
+    terrainProviderBuilder.hasMetadata || hasMetadata;
+
+  if (defined(data.attribution)) {
+    if (terrainProviderBuilder.attribution.length > 0) {
+      terrainProviderBuilder.attribution += " ";
+    }
+    terrainProviderBuilder.attribution += data.attribution;
+  }
+
+  terrainProviderBuilder.layers.push(
+    new LayerInformation({
+      resource: terrainProviderBuilder.lastResource,
+      version: data.version,
+      isHeightmap: isHeightmap,
+      tileUrlTemplates: tileUrlTemplates,
+      availability: availability,
+      hasVertexNormals: hasVertexNormals,
+      hasWaterMask: hasWaterMask,
+      hasMetadata: hasMetadata,
+      availabilityLevels: availabilityLevels,
+      availabilityTilesLoaded: availabilityTilesLoaded,
+      littleEndianExtensionSize: littleEndianExtensionSize,
+    })
+  );
+
+  const parentUrl = data.parentUrl;
+  if (defined(parentUrl)) {
+    if (!defined(availability)) {
+      console.log(
+        "A layer.json can't have a parentUrl if it does't have an available array."
+      );
+      return true;
+    }
+
+    terrainProviderBuilder.lastResource = terrainProviderBuilder.lastResource.getDerivedResource(
+      {
+        url: parentUrl,
+      }
+    );
+    terrainProviderBuilder.lastResource.appendForwardSlash(); // Terrain always expects a directory
+    terrainProviderBuilder.layerJsonResource = terrainProviderBuilder.lastResource.getDerivedResource(
+      {
+        url: "layer.json",
+      }
+    );
+    await requestLayerJson(terrainProviderBuilder);
+    return true;
+  }
+
+  return true;
+}
+
+function parseMetadataFailure(terrainProviderBuilder, error, provider) {
+  let message = `An error occurred while accessing ${terrainProviderBuilder.layerJsonResource.url}.`;
+  if (defined(error)) {
+    message += `\n${error.message}`;
+  }
+
+  terrainProviderBuilder.previousError = TileProviderError.reportError(
+    terrainProviderBuilder.previousError,
+    provider,
+    defined(provider) ? provider._errorEvent : undefined,
+    message
+  );
+
+  // If we can retry, do so. Otherwise throw the error.
+  if (terrainProviderBuilder.previousError.retry) {
+    return requestLayerJson(terrainProviderBuilder, provider);
+  }
+
+  const runtimeError = new RuntimeError(error);
+
+  // preserve the original stack as that's where the error originated
+  runtimeError.stack = error.stack;
+  throw runtimeError;
+}
+
+async function metadataSuccess(terrainProviderBuilder, data, provider) {
+  await parseMetadataSuccess(terrainProviderBuilder, data, provider);
+
+  const length = terrainProviderBuilder.overallAvailability.length;
+  if (length > 0) {
+    const availability = (terrainProviderBuilder.availability = new TileAvailability(
+      terrainProviderBuilder.tilingScheme,
+      terrainProviderBuilder.overallMaxZoom
+    ));
+    for (let level = 0; level < length; ++level) {
+      const levelRanges = terrainProviderBuilder.overallAvailability[level];
+      for (let i = 0; i < levelRanges.length; ++i) {
+        const range = levelRanges[i];
+        availability.addAvailableTileRange(
+          level,
+          range[0],
+          range[1],
+          range[2],
+          range[3]
+        );
+      }
+    }
+  }
+
+  if (terrainProviderBuilder.attribution.length > 0) {
+    const layerJsonCredit = new Credit(terrainProviderBuilder.attribution);
+    terrainProviderBuilder.tileCredits.push(layerJsonCredit);
+  }
+
+  return true;
+}
+
+async function requestLayerJson(terrainProviderBuilder, provider) {
+  try {
+    const data = await terrainProviderBuilder.layerJsonResource.fetchJson();
+    return metadataSuccess(terrainProviderBuilder, data, provider);
+  } catch (error) {
+    // If the metadata is not found, assume this is a pre-metadata heightmap tileset.
+    if (defined(error) && error.statusCode === 404) {
+      await parseMetadataSuccess(
+        terrainProviderBuilder,
+        {
+          tilejson: "2.1.0",
+          format: "heightmap-1.0",
+          version: "1.0.0",
+          scheme: "tms",
+          tiles: ["{z}/{x}/{y}.terrain?v={version}"],
+        },
+        provider
+      );
+
+      return true;
+    }
+
+    return parseMetadataFailure(terrainProviderBuilder, error, provider);
+  }
+}
+
+/**
+ * <div class="notice">
+ * To construct a CesiumTerrainProvider, call {@link CesiumTerrainProvider.fromUrl}. Do not call the constructor directly.
+ * </div>
+ *
  * A {@link TerrainProvider} that accesses terrain data in a Cesium terrain format.
  * Terrain formats can be one of the following:
  * <ul>
@@ -47,38 +460,30 @@ function LayerInformation(layer) {
  * @alias CesiumTerrainProvider
  * @constructor
  *
- * @param {Object} options Object with the following properties:
- * @param {Resource|String|Promise<Resource>|Promise<String>} options.url The URL of the Cesium terrain server.
- * @param {Boolean} [options.requestVertexNormals=false] Flag that indicates if the client should request additional lighting information from the server, in the form of per vertex normals if available.
- * @param {Boolean} [options.requestWaterMask=false] Flag that indicates if the client should request per tile water masks from the server,  if available.
- * @param {Boolean} [options.requestMetadata=true] Flag that indicates if the client should request per tile metadata from the server, if available.
- * @param {Ellipsoid} [options.ellipsoid] The ellipsoid.  If not specified, the WGS84 ellipsoid is used.
- * @param {Credit|String} [options.credit] A credit for the data source, which is displayed on the canvas.
- *
+ * @param {CesiumTerrainProvider.ConstructorOptions} [options] A url or an object describing initialization options
  *
  * @example
  * // Create Arctic DEM terrain with normals.
  * const viewer = new Cesium.Viewer('cesiumContainer', {
- *     terrainProvider : new Cesium.CesiumTerrainProvider({
- *         url : Cesium.IonResource.fromAssetId(3956),
- *         requestVertexNormals : true
+ *     terrainProvider : Cesium.CesiumTerrainProvider.fromUrl(
+ *         Cesium.IonResource.fromAssetId(3956), {
+ *             requestVertexNormals : true
  *     })
  * });
  *
  * @see createWorldTerrain
+ * @see CesiumTerrainProvider.fromUrl
  * @see TerrainProvider
  */
 function CesiumTerrainProvider(options) {
-  //>>includeStart('debug', pragmas.debug)
-  if (!defined(options) || !defined(options.url)) {
-    throw new DeveloperError("options.url is required.");
-  }
-  //>>includeEnd('debug');
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
-  this._heightmapWidth = 65;
+  this._heightmapWidth = undefined;
   this._heightmapStructure = undefined;
   this._hasWaterMask = false;
   this._hasVertexNormals = false;
+  this._hasMetadata = false;
+  this._scheme = undefined;
   this._ellipsoid = options.ellipsoid;
 
   /**
@@ -117,359 +522,46 @@ function CesiumTerrainProvider(options) {
   this._credit = credit;
 
   this._availability = undefined;
+  this._tilingScheme = undefined;
 
   this._ready = false;
   this._tileCredits = undefined;
 
-  const that = this;
-  let lastResource;
-  let layerJsonResource;
-  let metadataError;
-
-  const layers = (this._layers = []);
-  let attribution = "";
-  const overallAvailability = [];
-  let overallMaxZoom = 0;
-  this._readyPromise = Promise.resolve(options.url).then(function (url) {
-    const resource = Resource.createIfNeeded(url);
-    resource.appendForwardSlash();
-    lastResource = resource;
-    layerJsonResource = lastResource.getDerivedResource({
-      url: "layer.json",
-    });
-
-    // ion resources have a credits property we can use for additional attribution.
-    that._tileCredits = resource.credits;
-
-    return requestLayerJson();
-  });
-
-  function parseMetadataSuccess(data) {
-    let message;
-
-    if (!data.format) {
-      message = "The tile format is not specified in the layer.json file.";
-      metadataError = TileProviderError.reportError(
-        metadataError,
-        that,
-        that._errorEvent,
-        message
-      );
-      if (metadataError.retry) {
-        return requestLayerJson();
-      }
-      return Promise.reject(new RuntimeError(message));
-    }
-
-    if (!data.tiles || data.tiles.length === 0) {
-      message = "The layer.json file does not specify any tile URL templates.";
-      metadataError = TileProviderError.reportError(
-        metadataError,
-        that,
-        that._errorEvent,
-        message
-      );
-      if (metadataError.retry) {
-        return requestLayerJson();
-      }
-      return Promise.reject(new RuntimeError(message));
-    }
-
-    let hasVertexNormals = false;
-    let hasWaterMask = false;
-    let hasMetadata = false;
-    let littleEndianExtensionSize = true;
-    let isHeightmap = false;
-    if (data.format === "heightmap-1.0") {
-      isHeightmap = true;
-      if (!defined(that._heightmapStructure)) {
-        that._heightmapStructure = {
-          heightScale: 1.0 / 5.0,
-          heightOffset: -1000.0,
-          elementsPerHeight: 1,
-          stride: 1,
-          elementMultiplier: 256.0,
-          isBigEndian: false,
-          lowestEncodedHeight: 0,
-          highestEncodedHeight: 256 * 256 - 1,
-        };
-      }
-      hasWaterMask = true;
-      that._requestWaterMask = true;
-    } else if (data.format.indexOf("quantized-mesh-1.") !== 0) {
-      message = `The tile format "${data.format}" is invalid or not supported.`;
-      metadataError = TileProviderError.reportError(
-        metadataError,
-        that,
-        that._errorEvent,
-        message
-      );
-      if (metadataError.retry) {
-        return requestLayerJson();
-      }
-      return Promise.reject(new RuntimeError(message));
-    }
-
-    const tileUrlTemplates = data.tiles;
-
-    const maxZoom = data.maxzoom;
-    overallMaxZoom = Math.max(overallMaxZoom, maxZoom);
-    // Keeps track of which of the availablity containing tiles have been loaded
-
-    if (!data.projection || data.projection === "EPSG:4326") {
-      that._tilingScheme = new GeographicTilingScheme({
-        numberOfLevelZeroTilesX: 2,
-        numberOfLevelZeroTilesY: 1,
-        ellipsoid: that._ellipsoid,
-      });
-    } else if (data.projection === "EPSG:3857") {
-      that._tilingScheme = new WebMercatorTilingScheme({
-        numberOfLevelZeroTilesX: 1,
-        numberOfLevelZeroTilesY: 1,
-        ellipsoid: that._ellipsoid,
-      });
-    } else {
-      message = `The projection "${data.projection}" is invalid or not supported.`;
-      metadataError = TileProviderError.reportError(
-        metadataError,
-        that,
-        that._errorEvent,
-        message
-      );
-      if (metadataError.retry) {
-        return requestLayerJson();
-      }
-      return Promise.reject(new RuntimeError(message));
-    }
-
-    that._levelZeroMaximumGeometricError = TerrainProvider.getEstimatedLevelZeroGeometricErrorForAHeightmap(
-      that._tilingScheme.ellipsoid,
-      that._heightmapWidth,
-      that._tilingScheme.getNumberOfXTilesAtLevel(0)
+  this._readyPromise = Promise.resolve(true);
+  if (defined(options.url)) {
+    deprecationWarning(
+      "CesiumTerrainProvider options.url",
+      "options.url was deprecated in CesiumJS 1.102.  It will be removed in 1.104.  Use CesiumTerrainProvider.fromUrl instead."
     );
-    if (!data.scheme || data.scheme === "tms" || data.scheme === "slippyMap") {
-      that._scheme = data.scheme;
-    } else {
-      message = `The scheme "${data.scheme}" is invalid or not supported.`;
-      metadataError = TileProviderError.reportError(
-        metadataError,
-        that,
-        that._errorEvent,
-        message
-      );
-      if (metadataError.retry) {
-        return requestLayerJson();
-      }
-      return Promise.reject(new RuntimeError(message));
-    }
-
-    let availabilityTilesLoaded;
-
-    // The vertex normals defined in the 'octvertexnormals' extension is identical to the original
-    // contents of the original 'vertexnormals' extension.  'vertexnormals' extension is now
-    // deprecated, as the extensionLength for this extension was incorrectly using big endian.
-    // We maintain backwards compatibility with the legacy 'vertexnormal' implementation
-    // by setting the _littleEndianExtensionSize to false. Always prefer 'octvertexnormals'
-    // over 'vertexnormals' if both extensions are supported by the server.
-    if (
-      defined(data.extensions) &&
-      data.extensions.indexOf("octvertexnormals") !== -1
-    ) {
-      hasVertexNormals = true;
-    } else if (
-      defined(data.extensions) &&
-      data.extensions.indexOf("vertexnormals") !== -1
-    ) {
-      hasVertexNormals = true;
-      littleEndianExtensionSize = false;
-    }
-    if (
-      defined(data.extensions) &&
-      data.extensions.indexOf("watermask") !== -1
-    ) {
-      hasWaterMask = true;
-    }
-    if (
-      defined(data.extensions) &&
-      data.extensions.indexOf("metadata") !== -1
-    ) {
-      hasMetadata = true;
-    }
-
-    const availabilityLevels = data.metadataAvailability;
-    const availableTiles = data.available;
-    let availability;
-    if (defined(availableTiles) && !defined(availabilityLevels)) {
-      availability = new TileAvailability(
-        that._tilingScheme,
-        availableTiles.length
-      );
-      for (let level = 0; level < availableTiles.length; ++level) {
-        const rangesAtLevel = availableTiles[level];
-        const yTiles = that._tilingScheme.getNumberOfYTilesAtLevel(level);
-        if (!defined(overallAvailability[level])) {
-          overallAvailability[level] = [];
-        }
-
-        for (
-          let rangeIndex = 0;
-          rangeIndex < rangesAtLevel.length;
-          ++rangeIndex
-        ) {
-          const range = rangesAtLevel[rangeIndex];
-          const yStart = yTiles - range.endY - 1;
-          const yEnd = yTiles - range.startY - 1;
-          overallAvailability[level].push([
-            range.startX,
-            yStart,
-            range.endX,
-            yEnd,
-          ]);
-          availability.addAvailableTileRange(
-            level,
-            range.startX,
-            yStart,
-            range.endX,
-            yEnd
-          );
-        }
-      }
-    } else if (defined(availabilityLevels)) {
-      availabilityTilesLoaded = new TileAvailability(
-        that._tilingScheme,
-        maxZoom
-      );
-      availability = new TileAvailability(that._tilingScheme, maxZoom);
-      overallAvailability[0] = [[0, 0, 1, 0]];
-      availability.addAvailableTileRange(0, 0, 0, 1, 0);
-    }
-
-    that._hasWaterMask = that._hasWaterMask || hasWaterMask;
-    that._hasVertexNormals = that._hasVertexNormals || hasVertexNormals;
-    that._hasMetadata = that._hasMetadata || hasMetadata;
-    if (defined(data.attribution)) {
-      if (attribution.length > 0) {
-        attribution += " ";
-      }
-      attribution += data.attribution;
-    }
-
-    layers.push(
-      new LayerInformation({
-        resource: lastResource,
-        version: data.version,
-        isHeightmap: isHeightmap,
-        tileUrlTemplates: tileUrlTemplates,
-        availability: availability,
-        hasVertexNormals: hasVertexNormals,
-        hasWaterMask: hasWaterMask,
-        hasMetadata: hasMetadata,
-        availabilityLevels: availabilityLevels,
-        availabilityTilesLoaded: availabilityTilesLoaded,
-        littleEndianExtensionSize: littleEndianExtensionSize,
-      })
+    this._readyPromise = CesiumTerrainProvider._initializeReadyPromise(
+      options,
+      this
     );
-
-    const parentUrl = data.parentUrl;
-    if (defined(parentUrl)) {
-      if (!defined(availability)) {
-        console.log(
-          "A layer.json can't have a parentUrl if it does't have an available array."
-        );
-        return Promise.resolve(true);
-      }
-      lastResource = lastResource.getDerivedResource({
-        url: parentUrl,
-      });
-      lastResource.appendForwardSlash(); // Terrain always expects a directory
-      layerJsonResource = lastResource.getDerivedResource({
-        url: "layer.json",
-      });
-      const parentMetadata = layerJsonResource.fetchJson();
-      return Promise.resolve(parentMetadata)
-        .then(parseMetadataSuccess)
-        .catch(parseMetadataFailure);
-    }
-
-    return Promise.resolve(true);
-  }
-
-  function parseMetadataFailure(data) {
-    const message = `An error occurred while accessing ${layerJsonResource.url}.`;
-    metadataError = TileProviderError.reportError(
-      metadataError,
-      that,
-      that._errorEvent,
-      message
-    );
-    if (metadataError.retry) {
-      return requestLayerJson();
-    }
-    return Promise.reject(new RuntimeError(message));
-  }
-
-  function metadataSuccess(data) {
-    return parseMetadataSuccess(data).then(function () {
-      if (defined(metadataError)) {
-        return;
-      }
-
-      const length = overallAvailability.length;
-      if (length > 0) {
-        const availability = (that._availability = new TileAvailability(
-          that._tilingScheme,
-          overallMaxZoom
-        ));
-        for (let level = 0; level < length; ++level) {
-          const levelRanges = overallAvailability[level];
-          for (let i = 0; i < levelRanges.length; ++i) {
-            const range = levelRanges[i];
-            availability.addAvailableTileRange(
-              level,
-              range[0],
-              range[1],
-              range[2],
-              range[3]
-            );
-          }
-        }
-      }
-
-      if (attribution.length > 0) {
-        const layerJsonCredit = new Credit(attribution);
-
-        if (defined(that._tileCredits)) {
-          that._tileCredits.push(layerJsonCredit);
-        } else {
-          that._tileCredits = [layerJsonCredit];
-        }
-      }
-
-      that._ready = true;
-      return Promise.resolve(true);
-    });
-  }
-
-  function metadataFailure(data) {
-    // If the metadata is not found, assume this is a pre-metadata heightmap tileset.
-    if (defined(data) && data.statusCode === 404) {
-      return metadataSuccess({
-        tilejson: "2.1.0",
-        format: "heightmap-1.0",
-        version: "1.0.0",
-        scheme: "tms",
-        tiles: ["{z}/{x}/{y}.terrain?v={version}"],
-      });
-    }
-    return parseMetadataFailure(data);
-  }
-
-  function requestLayerJson() {
-    return Promise.resolve(layerJsonResource.fetchJson())
-      .then(metadataSuccess)
-      .catch(metadataFailure);
   }
 }
+
+// Exposed for deprecation
+CesiumTerrainProvider._initializeReadyPromise = async function (
+  options,
+  provider
+) {
+  await Promise.resolve(options.url);
+
+  const terrainProviderBuilder = new TerrainProviderBuilder(options);
+  const resource = Resource.createIfNeeded(options.url);
+  resource.appendForwardSlash();
+  terrainProviderBuilder.lastResource = resource;
+  terrainProviderBuilder.layerJsonResource = terrainProviderBuilder.lastResource.getDerivedResource(
+    {
+      url: "layer.json",
+    }
+  );
+
+  await requestLayerJson(terrainProviderBuilder, provider);
+  terrainProviderBuilder.build(provider);
+
+  return true;
+};
 
 /**
  * When using the Quantized-Mesh format, a tile may be returned that includes additional extensions, such as PerVertexNormals, watermask, etc.
@@ -783,8 +875,7 @@ function createQuantizedMeshTerrainData(provider, buffer, level, x, y, layer) {
 }
 
 /**
- * Requests the geometry for a given tile.  This function should not be called before
- * {@link CesiumTerrainProvider#ready} returns true.  The result must include terrain data and
+ * Requests the geometry for a given tile. The result must include terrain data and
  * may optionally include a water mask and an indication of which child tiles are available.
  *
  * @param {Number} x The X coordinate of the tile for which to request geometry.
@@ -796,8 +887,6 @@ function createQuantizedMeshTerrainData(provider, buffer, level, x, y, layer) {
  *          returns undefined instead of a promise, it is an indication that too many requests are already
  *          pending and the request will be retried later.
  *
- * @exception {DeveloperError} This function must not be called before {@link CesiumTerrainProvider#ready}
- *            returns true.
  */
 CesiumTerrainProvider.prototype.requestTileGeometry = function (
   x,
@@ -805,14 +894,6 @@ CesiumTerrainProvider.prototype.requestTileGeometry = function (
   level,
   request
 ) {
-  //>>includeStart('debug', pragmas.debug)
-  if (!this._ready) {
-    throw new DeveloperError(
-      "requestTileGeometry must not be called before the terrain provider is ready."
-    );
-  }
-  //>>includeEnd('debug');
-
   const layers = this._layers;
   let layerToUse;
   const layerCount = layers.length;
@@ -879,7 +960,7 @@ function requestTileGeometry(provider, x, y, level, layerToUse, request) {
     defined(resource._ionEndpoint) &&
     !defined(resource._ionEndpoint.externalType)
   ) {
-    // ion uses query paremeters to request extensions
+    // ion uses query parameters to request extensions
     if (extensionList.length !== 0) {
       query = { extensions: extensionList.join("-") };
     }
@@ -943,42 +1024,25 @@ Object.defineProperties(CesiumTerrainProvider.prototype, {
 
   /**
    * Gets the credit to display when this terrain provider is active.  Typically this is used to credit
-   * the source of the terrain.  This function should not be called before {@link CesiumTerrainProvider#ready} returns true.
+   * the source of the terrain.
    * @memberof CesiumTerrainProvider.prototype
    * @type {Credit}
    * @readonly
    */
   credit: {
     get: function () {
-      //>>includeStart('debug', pragmas.debug)
-      if (!this._ready) {
-        throw new DeveloperError(
-          "credit must not be called before the terrain provider is ready."
-        );
-      }
-      //>>includeEnd('debug');
-
       return this._credit;
     },
   },
 
   /**
-   * Gets the tiling scheme used by this provider.  This function should
-   * not be called before {@link CesiumTerrainProvider#ready} returns true.
+   * Gets the tiling scheme used by this provider.
    * @memberof CesiumTerrainProvider.prototype
    * @type {GeographicTilingScheme}
    * @readonly
    */
   tilingScheme: {
     get: function () {
-      //>>includeStart('debug', pragmas.debug)
-      if (!this._ready) {
-        throw new DeveloperError(
-          "tilingScheme must not be called before the terrain provider is ready."
-        );
-      }
-      //>>includeEnd('debug');
-
       return this._tilingScheme;
     },
   },
@@ -988,9 +1052,14 @@ Object.defineProperties(CesiumTerrainProvider.prototype, {
    * @memberof CesiumTerrainProvider.prototype
    * @type {Boolean}
    * @readonly
+   * @deprecated
    */
   ready: {
     get: function () {
+      deprecationWarning(
+        "CesiumTerrainProvider.ready",
+        "CesiumTerrainProvider.ready was deprecated in CesiumJS 1.102.  It will be removed in 1.104.  Use CesiumTerrainProvider.fromUrl instead."
+      );
       return this._ready;
     },
   },
@@ -1000,9 +1069,14 @@ Object.defineProperties(CesiumTerrainProvider.prototype, {
    * @memberof CesiumTerrainProvider.prototype
    * @type {Promise.<Boolean>}
    * @readonly
+   * @deprecated
    */
   readyPromise: {
     get: function () {
+      deprecationWarning(
+        "CesiumTerrainProvider.readyPromise",
+        "CesiumTerrainProvider.readyPromise was deprecated in CesiumJS 1.102.  It will be removed in 1.104.  Use CesiumTerrainProvider.fromUrl instead."
+      );
       return this._readyPromise;
     },
   },
@@ -1010,45 +1084,25 @@ Object.defineProperties(CesiumTerrainProvider.prototype, {
   /**
    * Gets a value indicating whether or not the provider includes a water mask.  The water mask
    * indicates which areas of the globe are water rather than land, so they can be rendered
-   * as a reflective surface with animated waves.  This function should not be
-   * called before {@link CesiumTerrainProvider#ready} returns true.
+   * as a reflective surface with animated waves.
    * @memberof CesiumTerrainProvider.prototype
    * @type {Boolean}
    * @readonly
-   * @exception {DeveloperError} This property must not be called before {@link CesiumTerrainProvider#ready}
    */
   hasWaterMask: {
     get: function () {
-      //>>includeStart('debug', pragmas.debug)
-      if (!this._ready) {
-        throw new DeveloperError(
-          "hasWaterMask must not be called before the terrain provider is ready."
-        );
-      }
-      //>>includeEnd('debug');
-
       return this._hasWaterMask && this._requestWaterMask;
     },
   },
 
   /**
    * Gets a value indicating whether or not the requested tiles include vertex normals.
-   * This function should not be called before {@link CesiumTerrainProvider#ready} returns true.
    * @memberof CesiumTerrainProvider.prototype
    * @type {Boolean}
    * @readonly
-   * @exception {DeveloperError} This property must not be called before {@link CesiumTerrainProvider#ready}
    */
   hasVertexNormals: {
     get: function () {
-      //>>includeStart('debug', pragmas.debug)
-      if (!this._ready) {
-        throw new DeveloperError(
-          "hasVertexNormals must not be called before the terrain provider is ready."
-        );
-      }
-      //>>includeEnd('debug');
-
       // returns true if we can request vertex normals from the server
       return this._hasVertexNormals && this._requestVertexNormals;
     },
@@ -1056,22 +1110,12 @@ Object.defineProperties(CesiumTerrainProvider.prototype, {
 
   /**
    * Gets a value indicating whether or not the requested tiles include metadata.
-   * This function should not be called before {@link CesiumTerrainProvider#ready} returns true.
    * @memberof CesiumTerrainProvider.prototype
    * @type {Boolean}
    * @readonly
-   * @exception {DeveloperError} This property must not be called before {@link CesiumTerrainProvider#ready}
    */
   hasMetadata: {
     get: function () {
-      //>>includeStart('debug', pragmas.debug)
-      if (!this._ready) {
-        throw new DeveloperError(
-          "hasMetadata must not be called before the terrain provider is ready."
-        );
-      }
-      //>>includeEnd('debug');
-
       // returns true if we can request metadata from the server
       return this._hasMetadata && this._requestMetadata;
     },
@@ -1121,8 +1165,7 @@ Object.defineProperties(CesiumTerrainProvider.prototype, {
 
   /**
    * Gets an object that can be used to determine availability of terrain from this provider, such as
-   * at points and in rectangles.  This function should not be called before
-   * {@link CesiumTerrainProvider#ready} returns true.  This property may be undefined if availability
+   * at points and in rectangles. This property may be undefined if availability
    * information is not available. Note that this reflects tiles that are known to be available currently.
    * Additional tiles may be discovered to be available in the future, e.g. if availability information
    * exists deeper in the tree rather than it all being discoverable at the root. However, a tile that
@@ -1133,13 +1176,6 @@ Object.defineProperties(CesiumTerrainProvider.prototype, {
    */
   availability: {
     get: function () {
-      //>>includeStart('debug', pragmas.debug)
-      if (!this._ready) {
-        throw new DeveloperError(
-          "availability must not be called before the terrain provider is ready."
-        );
-      }
-      //>>includeEnd('debug');
       return this._availability;
     },
   },
@@ -1155,6 +1191,60 @@ CesiumTerrainProvider.prototype.getLevelMaximumGeometricError = function (
   level
 ) {
   return this._levelZeroMaximumGeometricError / (1 << level);
+};
+
+/**
+ * Creates a {@link TerrainProvider} that accesses terrain data in a Cesium terrain format.
+ * Terrain formats can be one of the following:
+ * <ul>
+ * <li> {@link https://github.com/AnalyticalGraphicsInc/quantized-mesh Quantized Mesh} </li>
+ * <li> {@link https://github.com/AnalyticalGraphicsInc/cesium/wiki/heightmap-1.0 Height Map} </li>
+ * </ul>
+ *
+ * @param {Resource|String|Promise<Resource>|Promise<String>} url The URL of the Cesium terrain server.
+ * @param {CesiumTerrainProvider.ConstructorOptions} [options] A url or an object describing initialization options.
+ * @returns {Promise<CesiumTerrainProvider>}
+ *
+ * @example
+ * // Create Arctic DEM terrain with normals.
+ * const viewer = new Cesium.Viewer('cesiumContainer', {
+ *     terrainProvider : Cesium.CesiumTerrainProvider.fromUrl(
+ *         Cesium.IonResource.fromAssetId(3956), {
+ *             requestVertexNormals : true
+ *     })
+ * });
+ *
+ * @exception {RuntimeError} layer.json does not specify a format
+ * @exception {RuntimeError} layer.json specifies an unknown format
+ * @exception {RuntimeError} layer.json specifies an unsupported quantized-mesh version
+ * @exception {RuntimeError} layer.json does not specify a tiles property, or specifies an empty array
+ * @exception {RuntimeError} layer.json does not specify any tile URL templates
+ */
+CesiumTerrainProvider.fromUrl = async function (url, options) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.defined("url", url);
+  //>>includeEnd('debug');
+
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+
+  url = await Promise.resolve(url);
+  const resource = Resource.createIfNeeded(url);
+  resource.appendForwardSlash();
+
+  const terrainProviderBuilder = new TerrainProviderBuilder(options);
+  terrainProviderBuilder.lastResource = resource;
+  terrainProviderBuilder.layerJsonResource = terrainProviderBuilder.lastResource.getDerivedResource(
+    {
+      url: "layer.json",
+    }
+  );
+
+  await requestLayerJson(terrainProviderBuilder);
+
+  const provider = new CesiumTerrainProvider(options);
+  terrainProviderBuilder.build(provider);
+
+  return provider;
 };
 
 /**

--- a/packages/engine/Source/Core/CesiumTerrainProvider.js
+++ b/packages/engine/Source/Core/CesiumTerrainProvider.js
@@ -552,10 +552,10 @@ CesiumTerrainProvider._initializeReadyPromise = async function (
   options,
   provider
 ) {
-  await Promise.resolve(options.url);
+  const url = await Promise.resolve(options.url);
 
   const terrainProviderBuilder = new TerrainProviderBuilder(options);
-  const resource = Resource.createIfNeeded(options.url);
+  const resource = Resource.createIfNeeded(url);
   resource.appendForwardSlash();
   terrainProviderBuilder.lastResource = resource;
   terrainProviderBuilder.layerJsonResource = terrainProviderBuilder.lastResource.getDerivedResource(

--- a/packages/engine/Source/Core/CustomHeightmapTerrainProvider.js
+++ b/packages/engine/Source/Core/CustomHeightmapTerrainProvider.js
@@ -90,6 +90,7 @@ function CustomHeightmapTerrainProvider(options) {
   }
   this._credit = credit;
 
+  this._ready = true;
   this._readyPromise = Promise.resolve(true);
 }
 

--- a/packages/engine/Source/Core/CustomHeightmapTerrainProvider.js
+++ b/packages/engine/Source/Core/CustomHeightmapTerrainProvider.js
@@ -2,6 +2,7 @@ import Check from "./Check.js";
 import Credit from "./Credit.js";
 import defaultValue from "./defaultValue.js";
 import defined from "./defined.js";
+import deprecationWarning from "./deprecationWarning.js";
 import Ellipsoid from "./Ellipsoid.js";
 import Event from "./Event.js";
 import GeographicTilingScheme from "./GeographicTilingScheme.js";
@@ -137,9 +138,14 @@ Object.defineProperties(CustomHeightmapTerrainProvider.prototype, {
    * @memberof CustomHeightmapTerrainProvider.prototype
    * @type {Boolean}
    * @readonly
+   * @deprecated
    */
   ready: {
     get: function () {
+      deprecationWarning(
+        "CustomHeightmapTerrainProvider.ready",
+        "CustomHeightmapTerrainProvider.ready was deprecated in CesiumJS 1.102.  It will be removed in 1.104."
+      );
       return true;
     },
   },
@@ -149,9 +155,14 @@ Object.defineProperties(CustomHeightmapTerrainProvider.prototype, {
    * @memberof CustomHeightmapTerrainProvider.prototype
    * @type {Promise.<Boolean>}
    * @readonly
+   * @deprecated
    */
   readyPromise: {
     get: function () {
+      deprecationWarning(
+        "CustomHeightmapTerrainProvider.readyPromise",
+        "CustomHeightmapTerrainProvider.readyPromise was deprecated in CesiumJS 1.102.  It will be removed in 1.104."
+      );
       return this._readyPromise;
     },
   },

--- a/packages/engine/Source/Core/EllipsoidTerrainProvider.js
+++ b/packages/engine/Source/Core/EllipsoidTerrainProvider.js
@@ -43,6 +43,7 @@ function EllipsoidTerrainProvider(options) {
   );
 
   this._errorEvent = new Event();
+  this._ready = true;
   this._readyPromise = Promise.resolve(true);
 }
 

--- a/packages/engine/Source/Core/EllipsoidTerrainProvider.js
+++ b/packages/engine/Source/Core/EllipsoidTerrainProvider.js
@@ -1,5 +1,6 @@
 import defaultValue from "./defaultValue.js";
 import defined from "./defined.js";
+import deprecationWarning from "./deprecationWarning.js";
 import Ellipsoid from "./Ellipsoid.js";
 import Event from "./Event.js";
 import GeographicTilingScheme from "./GeographicTilingScheme.js";
@@ -62,7 +63,7 @@ Object.defineProperties(EllipsoidTerrainProvider.prototype, {
 
   /**
    * Gets the credit to display when this terrain provider is active.  Typically this is used to credit
-   * the source of the terrain.  This function should not be called before {@link EllipsoidTerrainProvider#ready} returns true.
+   * the source of the terrain.
    * @memberof EllipsoidTerrainProvider.prototype
    * @type {Credit}
    * @readonly
@@ -74,8 +75,7 @@ Object.defineProperties(EllipsoidTerrainProvider.prototype, {
   },
 
   /**
-   * Gets the tiling scheme used by this provider.  This function should
-   * not be called before {@link EllipsoidTerrainProvider#ready} returns true.
+   * Gets the tiling scheme used by this provider.
    * @memberof EllipsoidTerrainProvider.prototype
    * @type {GeographicTilingScheme}
    * @readonly
@@ -91,9 +91,14 @@ Object.defineProperties(EllipsoidTerrainProvider.prototype, {
    * @memberof EllipsoidTerrainProvider.prototype
    * @type {Boolean}
    * @readonly
+   * @deprecated
    */
   ready: {
     get: function () {
+      deprecationWarning(
+        "EllipsoidTerrainProvider.ready",
+        "EllipsoidTerrainProvider.ready was deprecated in CesiumJS 1.102.  It will be removed in 1.104."
+      );
       return true;
     },
   },
@@ -103,9 +108,14 @@ Object.defineProperties(EllipsoidTerrainProvider.prototype, {
    * @memberof EllipsoidTerrainProvider.prototype
    * @type {Promise.<Boolean>}
    * @readonly
+   * @deprecated
    */
   readyPromise: {
     get: function () {
+      deprecationWarning(
+        "EllipsoidTerrainProvider.readyPromise",
+        "EllipsoidTerrainProvider.readyPromise was deprecated in CesiumJS 1.102.  It will be removed in 1.104."
+      );
       return this._readyPromise;
     },
   },
@@ -113,8 +123,7 @@ Object.defineProperties(EllipsoidTerrainProvider.prototype, {
   /**
    * Gets a value indicating whether or not the provider includes a water mask.  The water mask
    * indicates which areas of the globe are water rather than land, so they can be rendered
-   * as a reflective surface with animated waves.  This function should not be
-   * called before {@link EllipsoidTerrainProvider#ready} returns true.
+   * as a reflective surface with animated waves.
    * @memberof EllipsoidTerrainProvider.prototype
    * @type {Boolean}
    * @readonly
@@ -127,7 +136,6 @@ Object.defineProperties(EllipsoidTerrainProvider.prototype, {
 
   /**
    * Gets a value indicating whether or not the requested tiles include vertex normals.
-   * This function should not be called before {@link EllipsoidTerrainProvider#ready} returns true.
    * @memberof EllipsoidTerrainProvider.prototype
    * @type {Boolean}
    * @readonly
@@ -139,8 +147,7 @@ Object.defineProperties(EllipsoidTerrainProvider.prototype, {
   },
   /**
    * Gets an object that can be used to determine availability of terrain from this provider, such as
-   * at points and in rectangles.  This function should not be called before
-   * {@link TerrainProvider#ready} returns true.  This property may be undefined if availability
+   * at points and in rectangles. This property may be undefined if availability
    * information is not available.
    * @memberof EllipsoidTerrainProvider.prototype
    * @type {TileAvailability}
@@ -154,8 +161,7 @@ Object.defineProperties(EllipsoidTerrainProvider.prototype, {
 });
 
 /**
- * Requests the geometry for a given tile.  This function should not be called before
- * {@link TerrainProvider#ready} returns true.  The result includes terrain
+ * Requests the geometry for a given tile. The result includes terrain
  * data and indicates that all child tiles are available.
  *
  * @param {Number} x The X coordinate of the tile for which to request geometry.

--- a/packages/engine/Source/Core/GoogleEarthEnterpriseMetadata.js
+++ b/packages/engine/Source/Core/GoogleEarthEnterpriseMetadata.js
@@ -41,6 +41,8 @@ const defaultKey = stringToBuffer(
  * @alias GoogleEarthEnterpriseMetadata
  * @constructor
  *
+ * @param {Resource|String} [resourceOrUrl] The url of the Google Earth Enterprise server hosting the imagery.
+ *
  * @see GoogleEarthEnterpriseImageryProvider
  * @see GoogleEarthEnterpriseTerrainProvider
  *
@@ -94,8 +96,8 @@ function GoogleEarthEnterpriseMetadata(resourceOrUrl) {
    */
   this.key = undefined;
 
+  this._resource = undefined;
   this._quadPacketVersion = 1;
-
   this._tileInfo = {};
   this._subtreePromises = {};
 

--- a/packages/engine/Source/Core/GoogleEarthEnterpriseMetadata.js
+++ b/packages/engine/Source/Core/GoogleEarthEnterpriseMetadata.js
@@ -4,6 +4,7 @@ import Check from "./Check.js";
 import Credit from "./Credit.js";
 import defaultValue from "./defaultValue.js";
 import defined from "./defined.js";
+import deprecationWarning from "./deprecationWarning.js";
 import GoogleEarthEnterpriseTileInformation from "./GoogleEarthEnterpriseTileInformation.js";
 import isBitSet from "./isBitSet.js";
 import loadAndExecuteScript from "./loadAndExecuteScript.js";
@@ -30,37 +31,21 @@ const defaultKey = stringToBuffer(
 );
 
 /**
+ * <div class="notice">
+ * To construct GoogleEarthEnterpriseMetadata, call {@link GoogleEarthEnterpriseMetadata.fromUrl}. Do not call the constructor directly.
+ * </div>
+ *
  * Provides metadata using the Google Earth Enterprise REST API. This is used by the GoogleEarthEnterpriseImageryProvider
  *  and GoogleEarthEnterpriseTerrainProvider to share metadata requests.
  *
  * @alias GoogleEarthEnterpriseMetadata
  * @constructor
  *
- * @param {Resource|String} resourceOrUrl The url of the Google Earth Enterprise server hosting the imagery
- *
  * @see GoogleEarthEnterpriseImageryProvider
  * @see GoogleEarthEnterpriseTerrainProvider
  *
  */
 function GoogleEarthEnterpriseMetadata(resourceOrUrl) {
-  //>>includeStart('debug', pragmas.debug);
-  Check.defined("resourceOrUrl", resourceOrUrl);
-  //>>includeEnd('debug');
-
-  let url = resourceOrUrl;
-
-  if (typeof url !== "string" && !(url instanceof Resource)) {
-    //>>includeStart('debug', pragmas.debug);
-    Check.typeOf.string("resourceOrUrl.url", resourceOrUrl.url);
-    //>>includeEnd('debug');
-
-    url = resourceOrUrl.url;
-  }
-
-  const resource = Resource.createIfNeeded(url);
-  resource.appendForwardSlash();
-  this._resource = resource;
-
   /**
    * True if imagery is available.
    * @type {Boolean}
@@ -114,20 +99,38 @@ function GoogleEarthEnterpriseMetadata(resourceOrUrl) {
   this._tileInfo = {};
   this._subtreePromises = {};
 
-  const that = this;
-  this._readyPromise = requestDbRoot(this)
-    .then(function () {
-      return that.getQuadTreePacket("", that._quadPacketVersion);
-    })
-    .then(function () {
-      return true;
-    })
-    .catch(function (e) {
-      const message = `An error occurred while accessing ${
-        getMetadataResource(that, "", 1).url
-      }.`;
-      return Promise.reject(new RuntimeError(message));
-    });
+  this._readyPromise = Promise.resolve(true);
+  if (defined(resourceOrUrl)) {
+    deprecationWarning(
+      "GoogleEarthEnterpriseMetadata options.url",
+      "GoogleEarthEnterpriseMetadata constructor parmeter resourceOrUrl was deprecated in CesiumJS 1.102.  It will be removed in 1.104.  Use GoogleEarthEnterpriseMetadata.fromUrl instead."
+    );
+
+    let url = resourceOrUrl;
+
+    if (typeof url !== "string" && !(url instanceof Resource)) {
+      url = resourceOrUrl.url;
+    }
+
+    const resource = Resource.createIfNeeded(url);
+    resource.appendForwardSlash();
+    this._resource = resource;
+
+    const that = this;
+    this._readyPromise = requestDbRoot(this)
+      .then(function () {
+        return that.getQuadTreePacket("", that._quadPacketVersion);
+      })
+      .then(function () {
+        return true;
+      })
+      .catch(function (e) {
+        const message = `An error occurred while accessing ${
+          getMetadataResource(that, "", 1).url
+        }.`;
+        return Promise.reject(new RuntimeError(message));
+      });
+  }
 }
 
 Object.defineProperties(GoogleEarthEnterpriseMetadata.prototype, {
@@ -172,13 +175,60 @@ Object.defineProperties(GoogleEarthEnterpriseMetadata.prototype, {
    * @memberof GoogleEarthEnterpriseMetadata.prototype
    * @type {Promise.<Boolean>}
    * @readonly
+   * @deprecated
    */
   readyPromise: {
     get: function () {
+      deprecationWarning(
+        "GoogleEarthEnterpriseMetadata.readyPromise",
+        "GoogleEarthEnterpriseMetadata.readyPromise was deprecated in CesiumJS 1.102.  It will be removed in 1.104.  Use GoogleEarthEnterpriseMetadata.fromUrl instead."
+      );
       return this._readyPromise;
     },
   },
 });
+
+/**
+ * Creates a metadata object using the Google Earth Enterprise REST API. This is used by the GoogleEarthEnterpriseImageryProvider
+ * and GoogleEarthEnterpriseTerrainProvider to share metadata requests.
+ *
+ * @param {Resource|String} resourceOrUrl The url of the Google Earth Enterprise server hosting the imagery.
+ *
+ * @returns {Promise<GoogleEarthEnterpriseMetadata>} A promise which resolves to the created GoogleEarthEnterpriseMetadata instance/
+ */
+GoogleEarthEnterpriseMetadata.fromUrl = async function (resourceOrUrl) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.defined("resourceOrUrl", resourceOrUrl);
+  //>>includeEnd('debug');
+  let url = resourceOrUrl;
+
+  if (typeof url !== "string" && !(url instanceof Resource)) {
+    //>>includeStart('debug', pragmas.debug);
+    Check.typeOf.string("resourceOrUrl.url", resourceOrUrl.url);
+    //>>includeEnd('debug');
+
+    url = resourceOrUrl.url;
+  }
+
+  const resource = Resource.createIfNeeded(url);
+  resource.appendForwardSlash();
+
+  const metadata = new GoogleEarthEnterpriseMetadata();
+  metadata._resource = resource;
+
+  try {
+    await requestDbRoot(metadata);
+    await metadata.getQuadTreePacket("", metadata._quadPacketVersion);
+  } catch (error) {
+    const message = `An error occurred while accessing ${
+      getMetadataResource(metadata, "", 1).url
+    }: ${error}`;
+
+    throw new RuntimeError(message);
+  }
+
+  return metadata;
+};
 
 /**
  * Converts a tiles (x, y, level) position into a quadkey used to request an image

--- a/packages/engine/Source/Core/GoogleEarthEnterpriseTerrainProvider.js
+++ b/packages/engine/Source/Core/GoogleEarthEnterpriseTerrainProvider.js
@@ -74,6 +74,8 @@ TerrainCache.prototype.tidy = function () {
  *
  * @property {Ellipsoid} [ellipsoid] The ellipsoid.  If not specified, the WGS84 ellipsoid is used.
  * @property {Credit|String} [credit] A credit for the data source, which is displayed on the canvas.
+ * @property {Resource|String} [url] The url of the Google Earth Enterprise server hosting the imagery. Deprecated.
+ * @property {GoogleEarthEnterpriseMetadata} [metadata] A metadata object that can be used to share metadata requests with a GoogleEarthEnterpriseImageryProvider. Deprecated.
  */
 
 /**
@@ -86,7 +88,7 @@ TerrainCache.prototype.tidy = function () {
  * @alias GoogleEarthEnterpriseTerrainProvider
  * @constructor
  *
- * @param {GoogleEarthEnterpriseTerrainProvider.ConstructorOptions} options A url or an object describing initialization options
+ * @param {GoogleEarthEnterpriseTerrainProvider.ConstructorOptions} options An object describing initialization options
  *
  * @see GoogleEarthEnterpriseTerrainProvider.fromMetadata
  * @see GoogleEarthEnterpriseMetadata.fromUrl
@@ -341,7 +343,7 @@ Object.defineProperties(GoogleEarthEnterpriseTerrainProvider.prototype, {
  * Creates a GoogleEarthTerrainProvider from GoogleEarthEnterpriseMetadata
  *
  * @param {GoogleEarthEnterpriseMetadata} metadata A metadata object that can be used to share metadata requests with a GoogleEarthEnterpriseImageryProvider.
- * @param {GoogleEarthEnterpriseTerrainProvider.ConstructorOptions} options A url or an object describing initialization options
+ * @param {GoogleEarthEnterpriseTerrainProvider.ConstructorOptions} options An object describing initialization options
  * @returns {GoogleEarthEnterpriseTerrainProvider}
  *
  * @see GoogleEarthEnterpriseMetadata.fromUrl

--- a/packages/engine/Source/Core/GoogleEarthEnterpriseTerrainProvider.js
+++ b/packages/engine/Source/Core/GoogleEarthEnterpriseTerrainProvider.js
@@ -86,7 +86,7 @@ TerrainCache.prototype.tidy = function () {
  * @alias GoogleEarthEnterpriseTerrainProvider
  * @constructor
  *
- * @param { GoogleEarthEnterpriseTerrainProvider.ConstructorOptions} options A url or an object describing initialization options
+ * @param {GoogleEarthEnterpriseTerrainProvider.ConstructorOptions} options A url or an object describing initialization options
  *
  * @see GoogleEarthEnterpriseTerrainProvider.fromMetadata
  * @see GoogleEarthEnterpriseMetadata.fromUrl
@@ -341,7 +341,7 @@ Object.defineProperties(GoogleEarthEnterpriseTerrainProvider.prototype, {
  * Creates a GoogleEarthTerrainProvider from GoogleEarthEnterpriseMetadata
  *
  * @param {GoogleEarthEnterpriseMetadata} metadata A metadata object that can be used to share metadata requests with a GoogleEarthEnterpriseImageryProvider.
- * @param {CesiumTerrainProvider.ConstructorOptions} options A url or an object describing initialization options
+ * @param {GoogleEarthEnterpriseTerrainProvider.ConstructorOptions} options A url or an object describing initialization options
  * @returns {GoogleEarthEnterpriseTerrainProvider}
  *
  * @see GoogleEarthEnterpriseMetadata.fromUrl

--- a/packages/engine/Source/Core/GoogleEarthEnterpriseTerrainProvider.js
+++ b/packages/engine/Source/Core/GoogleEarthEnterpriseTerrainProvider.js
@@ -96,7 +96,7 @@ TerrainCache.prototype.tidy = function () {
  * @see CesiumTerrainProvider
  *
  * @example
- * const geeMetadata = await GoogleEarthEnterpriseMetadata.fromUrl('http://www.example.com');
+ * const geeMetadata = await GoogleEarthEnterpriseMetadata.fromUrl("http://www.example.com");
  * const gee = Cesium.GoogleEarthEnterpriseTerrainProvider.fromMetadata(geeMetadata);
  *
  * @see {@link http://www.w3.org/TR/cors/|Cross-Origin Resource Sharing}
@@ -351,7 +351,7 @@ Object.defineProperties(GoogleEarthEnterpriseTerrainProvider.prototype, {
  * @exception {RuntimeError} metadata does not specify terrain
  *
  * @example
- * const geeMetadata = await GoogleEarthEnterpriseMetadata.fromUrl('http://www.example.com');
+ * const geeMetadata = await GoogleEarthEnterpriseMetadata.fromUrl("http://www.example.com");
  * const gee = Cesium.GoogleEarthEnterpriseTerrainProvider.fromMetadata(geeMetadata);
  */
 GoogleEarthEnterpriseTerrainProvider.fromMetadata = function (

--- a/packages/engine/Source/Core/TerrainProvider.js
+++ b/packages/engine/Source/Core/TerrainProvider.js
@@ -22,7 +22,7 @@ function TerrainProvider() {
 
 Object.defineProperties(TerrainProvider.prototype, {
   /**
-   * Gets an event that is raised when the terrain provider encounters an asynchronous error..  By subscribing
+   * Gets an event that is raised when the terrain provider encounters an asynchronous error.  By subscribing
    * to the event, you will be notified of the error and can potentially recover from it.  Event listeners
    * are passed an instance of {@link TileProviderError}.
    * @memberof TerrainProvider.prototype
@@ -35,8 +35,7 @@ Object.defineProperties(TerrainProvider.prototype, {
 
   /**
    * Gets the credit to display when this terrain provider is active.  Typically this is used to credit
-   * the source of the terrain. This function should
-   * not be called before {@link TerrainProvider#ready} returns true.
+   * the source of the terrain.
    * @memberof TerrainProvider.prototype
    * @type {Credit}
    * @readonly
@@ -46,8 +45,7 @@ Object.defineProperties(TerrainProvider.prototype, {
   },
 
   /**
-   * Gets the tiling scheme used by the provider.  This function should
-   * not be called before {@link TerrainProvider#ready} returns true.
+   * Gets the tiling scheme used by the provider.
    * @memberof TerrainProvider.prototype
    * @type {TilingScheme}
    * @readonly
@@ -61,6 +59,7 @@ Object.defineProperties(TerrainProvider.prototype, {
    * @memberof TerrainProvider.prototype
    * @type {Boolean}
    * @readonly
+   * @deprecated
    */
   ready: {
     get: DeveloperError.throwInstantiationError,
@@ -71,6 +70,7 @@ Object.defineProperties(TerrainProvider.prototype, {
    * @memberof TerrainProvider.prototype
    * @type {Promise.<Boolean>}
    * @readonly
+   * @deprecated
    */
   readyPromise: {
     get: DeveloperError.throwInstantiationError,
@@ -79,8 +79,7 @@ Object.defineProperties(TerrainProvider.prototype, {
   /**
    * Gets a value indicating whether or not the provider includes a water mask.  The water mask
    * indicates which areas of the globe are water rather than land, so they can be rendered
-   * as a reflective surface with animated waves.  This function should not be
-   * called before {@link TerrainProvider#ready} returns true.
+   * as a reflective surface with animated waves.
    * @memberof TerrainProvider.prototype
    * @type {Boolean}
    * @readonly
@@ -91,7 +90,6 @@ Object.defineProperties(TerrainProvider.prototype, {
 
   /**
    * Gets a value indicating whether or not the requested tiles include vertex normals.
-   * This function should not be called before {@link TerrainProvider#ready} returns true.
    * @memberof TerrainProvider.prototype
    * @type {Boolean}
    * @readonly
@@ -102,8 +100,7 @@ Object.defineProperties(TerrainProvider.prototype, {
 
   /**
    * Gets an object that can be used to determine availability of terrain from this provider, such as
-   * at points and in rectangles.  This function should not be called before
-   * {@link TerrainProvider#ready} returns true.  This property may be undefined if availability
+   * at points and in rectangles. This property may be undefined if availability
    * information is not available.
    * @memberof TerrainProvider.prototype
    * @type {TileAvailability}
@@ -399,8 +396,7 @@ TerrainProvider.getEstimatedLevelZeroGeometricErrorForAHeightmap = function (
 };
 
 /**
- * Requests the geometry for a given tile.  This function should not be called before
- * {@link TerrainProvider#ready} returns true.  The result must include terrain data and
+ * Requests the geometry for a given tile. The result must include terrain data and
  * may optionally include a water mask and an indication of which child tiles are available.
  * @function
  *
@@ -417,8 +413,7 @@ TerrainProvider.prototype.requestTileGeometry =
   DeveloperError.throwInstantiationError;
 
 /**
- * Gets the maximum geometric error allowed in a tile at a given level.  This function should not be
- * called before {@link TerrainProvider#ready} returns true.
+ * Gets the maximum geometric error allowed in a tile at a given level.
  * @function
  *
  * @param {Number} level The tile level for which to get the maximum geometric error.

--- a/packages/engine/Source/Core/TileProviderError.js
+++ b/packages/engine/Source/Core/TileProviderError.js
@@ -92,8 +92,8 @@ function TileProviderError(
  * @param {TileProviderError} previousError The error instance returned by this function the last
  *        time it was called for this error, or undefined if this is the first time this error has
  *        occurred.
- * @param {ImageryProvider|TerrainProvider} provider The imagery or terrain provider that encountered the error.
- * @param {Event} event The event to raise to inform listeners of the error.
+ * @param {ImageryProvider|TerrainProvider} [provider] The imagery or terrain provider that encountered the error.
+ * @param {Event} [event] The event to raise to inform listeners of the error.
  * @param {String} message The message describing the error.
  * @param {Number} x The X coordinate of the tile that experienced the error, or undefined if the
  *        error is not specific to a particular tile.
@@ -138,9 +138,9 @@ TileProviderError.reportError = function (
     ++error.timesRetried;
   }
 
-  if (event.numberOfListeners > 0) {
+  if (defined(event) && event.numberOfListeners > 0) {
     event.raiseEvent(error);
-  } else {
+  } else if (defined(provider)) {
     console.log(
       `An error occurred in "${provider.constructor.name}": ${formatError(
         message

--- a/packages/engine/Source/Core/TileProviderError.js
+++ b/packages/engine/Source/Core/TileProviderError.js
@@ -94,12 +94,12 @@ function TileProviderError(
  *        occurred.
  * @param {ImageryProvider|TerrainProvider} [provider] The imagery or terrain provider that encountered the error.
  * @param {Event} [event] The event to raise to inform listeners of the error.
- * @param {String} message The message describing the error.
- * @param {Number} x The X coordinate of the tile that experienced the error, or undefined if the
+ * @param {String} [message] The message describing the error.
+ * @param {Number} [x] The X coordinate of the tile that experienced the error, or undefined if the
  *        error is not specific to a particular tile.
- * @param {Number} y The Y coordinate of the tile that experienced the error, or undefined if the
+ * @param {Number} [y] The Y coordinate of the tile that experienced the error, or undefined if the
  *        error is not specific to a particular tile.
- * @param {Number} level The level-of-detail of the tile that experienced the error, or undefined if the
+ * @param {Number} [level] The level-of-detail of the tile that experienced the error, or undefined if the
  *        error is not specific to a particular tile.
  * @param {Error} [errorDetails] The error or exception that occurred, if any.
  * @returns {TileProviderError} The error instance that was passed to the event listeners and that

--- a/packages/engine/Source/Core/VRTheWorldTerrainProvider.js
+++ b/packages/engine/Source/Core/VRTheWorldTerrainProvider.js
@@ -319,7 +319,7 @@ Object.defineProperties(VRTheWorldTerrainProvider.prototype, {
  * Creates a {@link TerrainProvider} that produces terrain geometry by tessellating height maps
  * retrieved from a {@link http://vr-theworld.com/|VT MÄK VR-TheWorld server}.
  *
- * @param {Resource|String} options.url The URL of the VR-TheWorld TileMap.
+ * @param {Resource|String} url The URL of the VR-TheWorld TileMap.
  * @param {VRTheWorldTerrainProvider.ConstructorOptions} [options] A url or an object describing initialization options.
  * @returns {Promise<VRTheWorldTerrainProvider>}
  *

--- a/packages/engine/Source/Core/VRTheWorldTerrainProvider.js
+++ b/packages/engine/Source/Core/VRTheWorldTerrainProvider.js
@@ -110,10 +110,12 @@ function metadataSuccess(terrainProviderBuilder, xml) {
 }
 
 function metadataFailure(resource, error, provider) {
-  const message = defaultValue(
-    defined(error) ? error.message : undefined,
-    `An error occurred while accessing ${resource.url}.`
-  );
+  let message = `An error occurred while accessing ${resource.url}`;
+
+  if (defined(error) && defined(error.message)) {
+    message = `${message}: ${error.message}`;
+  }
+
   TileProviderError.reportError(
     undefined,
     provider,
@@ -121,7 +123,7 @@ function metadataFailure(resource, error, provider) {
     message
   );
 
-  throw error;
+  throw new RuntimeError(message);
 }
 
 async function requestMetadata(terrainProviderBuilder, resource, provider) {

--- a/packages/engine/Source/Core/VRTheWorldTerrainProvider.js
+++ b/packages/engine/Source/Core/VRTheWorldTerrainProvider.js
@@ -27,6 +27,7 @@ function DataRectangle(rectangle, maxLevel) {
  *
  * @property {Ellipsoid} [ellipsoid] The ellipsoid.  If not specified, the WGS84 ellipsoid is used.
  * @property {Credit|String} [credit] A credit for the data source, which is displayed on the canvas.
+ * @property {Resource|String} [url] The URL of the VR-TheWorld TileMap. Deprecated.
  */
 
 /**
@@ -35,7 +36,7 @@ function DataRectangle(rectangle, maxLevel) {
  * @constructor
  * @private
  *
- * @param {VRTheWorldTerrainProvider.ConstructorOptions} options A url or an object describing initialization options
+ * @param {VRTheWorldTerrainProvider.ConstructorOptions} options An object describing initialization options
  */
 function TerrainProviderBuilder(options) {
   this.ellipsoid = defaultValue(options.ellipsoid, Ellipsoid.WGS84);
@@ -143,7 +144,7 @@ async function requestMetadata(terrainProviderBuilder, resource, provider) {
  * @alias VRTheWorldTerrainProvider
  * @constructor
  *
- * @param {VRTheWorldTerrainProvider.ConstructorOptions} [options] A url or an object describing initialization options.
+ * @param {VRTheWorldTerrainProvider.ConstructorOptions} [options] An object describing initialization options.
  *
  * @example
  * const terrainProvider = await Cesium.VRTheWorldTerrainProvider.fromUrl(
@@ -320,7 +321,7 @@ Object.defineProperties(VRTheWorldTerrainProvider.prototype, {
  * retrieved from a {@link http://vr-theworld.com/|VT MÄK VR-TheWorld server}.
  *
  * @param {Resource|String} url The URL of the VR-TheWorld TileMap.
- * @param {VRTheWorldTerrainProvider.ConstructorOptions} [options] A url or an object describing initialization options.
+ * @param {VRTheWorldTerrainProvider.ConstructorOptions} [options] An object describing initialization options.
  * @returns {Promise<VRTheWorldTerrainProvider>}
  *
  * @example

--- a/packages/engine/Source/Core/VRTheWorldTerrainProvider.js
+++ b/packages/engine/Source/Core/VRTheWorldTerrainProvider.js
@@ -1,7 +1,8 @@
+import Check from "./Check.js";
 import Credit from "./Credit.js";
 import defaultValue from "./defaultValue.js";
 import defined from "./defined.js";
-import DeveloperError from "./DeveloperError.js";
+import deprecationWarning from "./deprecationWarning.js";
 import Ellipsoid from "./Ellipsoid.js";
 import Event from "./Event.js";
 import GeographicTilingScheme from "./GeographicTilingScheme.js";
@@ -20,38 +21,140 @@ function DataRectangle(rectangle, maxLevel) {
 }
 
 /**
+ * @typedef {Object} VRTheWorldTerrainProvider.ConstructorOptions
+ *
+ * Initialization options for the VRTheWorldTerrainProvider constructor
+ *
+ * @property {Ellipsoid} [ellipsoid] The ellipsoid.  If not specified, the WGS84 ellipsoid is used.
+ * @property {Credit|String} [credit] A credit for the data source, which is displayed on the canvas.
+ */
+
+/**
+ * Used to track creation details while fetching initial metadata
+ *
+ * @constructor
+ * @private
+ *
+ * @param {VRTheWorldTerrainProvider.ConstructorOptions} options A url or an object describing initialization options
+ */
+function TerrainProviderBuilder(options) {
+  this.ellipsoid = defaultValue(options.ellipsoid, Ellipsoid.WGS84);
+  this.tilingScheme = undefined;
+  this.heightmapWidth = undefined;
+  this.heightmapHeight = undefined;
+  this.levelZeroMaximumGeometricError = undefined;
+  this.rectangles = [];
+}
+
+TerrainProviderBuilder.prototype.build = function (provider) {
+  provider._tilingScheme = this.tilingScheme;
+  provider._heightmapWidth = this.heightmapWidth;
+  provider._heightmapHeight = this.heightmapHeight;
+  provider._levelZeroMaximumGeometricError = this.levelZeroMaximumGeometricError;
+  provider._rectangles = this.rectangles;
+  provider._ready = true;
+};
+
+function metadataSuccess(terrainProviderBuilder, xml) {
+  const srs = xml.getElementsByTagName("SRS")[0].textContent;
+  if (srs === "EPSG:4326") {
+    terrainProviderBuilder.tilingScheme = new GeographicTilingScheme({
+      ellipsoid: terrainProviderBuilder.ellipsoid,
+    });
+  } else {
+    throw new RuntimeError(`SRS ${srs} is not supported`);
+  }
+
+  const tileFormat = xml.getElementsByTagName("TileFormat")[0];
+  terrainProviderBuilder.heightmapWidth = parseInt(
+    tileFormat.getAttribute("width"),
+    10
+  );
+  terrainProviderBuilder.heightmapHeight = parseInt(
+    tileFormat.getAttribute("height"),
+    10
+  );
+  terrainProviderBuilder.levelZeroMaximumGeometricError = TerrainProvider.getEstimatedLevelZeroGeometricErrorForAHeightmap(
+    terrainProviderBuilder.ellipsoid,
+    Math.min(
+      terrainProviderBuilder.heightmapWidth,
+      terrainProviderBuilder.heightmapHeight
+    ),
+    terrainProviderBuilder.tilingScheme.getNumberOfXTilesAtLevel(0)
+  );
+
+  const dataRectangles = xml.getElementsByTagName("DataExtent");
+
+  for (let i = 0; i < dataRectangles.length; ++i) {
+    const dataRectangle = dataRectangles[i];
+
+    const west = CesiumMath.toRadians(
+      parseFloat(dataRectangle.getAttribute("minx"))
+    );
+    const south = CesiumMath.toRadians(
+      parseFloat(dataRectangle.getAttribute("miny"))
+    );
+    const east = CesiumMath.toRadians(
+      parseFloat(dataRectangle.getAttribute("maxx"))
+    );
+    const north = CesiumMath.toRadians(
+      parseFloat(dataRectangle.getAttribute("maxy"))
+    );
+    const maxLevel = parseInt(dataRectangle.getAttribute("maxlevel"), 10);
+
+    terrainProviderBuilder.rectangles.push(
+      new DataRectangle(new Rectangle(west, south, east, north), maxLevel)
+    );
+  }
+}
+
+function metadataFailure(resource, error, provider) {
+  const message = defaultValue(
+    defined(error) ? error.message : undefined,
+    `An error occurred while accessing ${resource.url}.`
+  );
+  TileProviderError.reportError(
+    undefined,
+    provider,
+    defined(provider) ? provider._errorEvent : undefined,
+    message
+  );
+
+  throw error;
+}
+
+async function requestMetadata(terrainProviderBuilder, resource, provider) {
+  try {
+    const xml = await resource.fetchXML();
+    metadataSuccess(terrainProviderBuilder, xml);
+  } catch (error) {
+    metadataFailure(resource, error, provider);
+  }
+}
+
+/**
+ * <div class="notice">
+ * To construct a CesiumTerrainProvider, call {@link CesiumTerrainProvider.fromUrl}. Do not call the constructor directly.
+ * </div>
+ *
  * A {@link TerrainProvider} that produces terrain geometry by tessellating height maps
  * retrieved from a {@link http://vr-theworld.com/|VT MÄK VR-TheWorld server}.
  *
  * @alias VRTheWorldTerrainProvider
  * @constructor
  *
- * @param {Object} options Object with the following properties:
- * @param {Resource|String} options.url The URL of the VR-TheWorld TileMap.
- * @param {Ellipsoid} [options.ellipsoid=Ellipsoid.WGS84] The ellipsoid.  If this parameter is not
- *                    specified, the WGS84 ellipsoid is used.
- * @param {Credit|String} [options.credit] A credit for the data source, which is displayed on the canvas.
- *
+ * @param {VRTheWorldTerrainProvider.ConstructorOptions} [options] A url or an object describing initialization options.
  *
  * @example
- * const terrainProvider = new Cesium.VRTheWorldTerrainProvider({
- *   url : 'https://www.vr-theworld.com/vr-theworld/tiles1.0.0/73/'
- * });
+ * const terrainProvider = await Cesium.VRTheWorldTerrainProvider.fromUrl(
+ *   "https://www.vr-theworld.com/vr-theworld/tiles1.0.0/73/"
+ * );
  * viewer.terrainProvider = terrainProvider;
  *
  * @see TerrainProvider
  */
 function VRTheWorldTerrainProvider(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
-  //>>includeStart('debug', pragmas.debug);
-  if (!defined(options.url)) {
-    throw new DeveloperError("options.url is required.");
-  }
-  //>>includeEnd('debug');
-
-  const resource = Resource.createIfNeeded(options.url);
-
-  this._resource = resource;
 
   this._errorEvent = new Event();
   this._ready = false;
@@ -76,80 +179,26 @@ function VRTheWorldTerrainProvider(options) {
   this._tilingScheme = undefined;
   this._rectangles = [];
 
-  const that = this;
-  let metadataError;
-  const ellipsoid = defaultValue(options.ellipsoid, Ellipsoid.WGS84);
-
-  function metadataSuccess(xml) {
-    const srs = xml.getElementsByTagName("SRS")[0].textContent;
-    if (srs === "EPSG:4326") {
-      that._tilingScheme = new GeographicTilingScheme({ ellipsoid: ellipsoid });
-    } else {
-      return Promise.reject(new RuntimeError(`SRS ${srs} is not supported.`));
-    }
-
-    const tileFormat = xml.getElementsByTagName("TileFormat")[0];
-    that._heightmapWidth = parseInt(tileFormat.getAttribute("width"), 10);
-    that._heightmapHeight = parseInt(tileFormat.getAttribute("height"), 10);
-    that._levelZeroMaximumGeometricError = TerrainProvider.getEstimatedLevelZeroGeometricErrorForAHeightmap(
-      ellipsoid,
-      Math.min(that._heightmapWidth, that._heightmapHeight),
-      that._tilingScheme.getNumberOfXTilesAtLevel(0)
+  if (defined(options.url)) {
+    deprecationWarning(
+      "VRTheWorldTerrainProvider options.url",
+      "options.url was deprecated in CesiumJS 1.102.  It will be removed in 1.104.  VRTheWorldTerrainProvider.fromUrl instead."
     );
+    const that = this;
+    const terrainProviderBuilder = new TerrainProviderBuilder(options);
+    const resource = Resource.createIfNeeded(options.url);
 
-    const dataRectangles = xml.getElementsByTagName("DataExtent");
+    this._resource = resource;
 
-    for (let i = 0; i < dataRectangles.length; ++i) {
-      const dataRectangle = dataRectangles[i];
-
-      const west = CesiumMath.toRadians(
-        parseFloat(dataRectangle.getAttribute("minx"))
-      );
-      const south = CesiumMath.toRadians(
-        parseFloat(dataRectangle.getAttribute("miny"))
-      );
-      const east = CesiumMath.toRadians(
-        parseFloat(dataRectangle.getAttribute("maxx"))
-      );
-      const north = CesiumMath.toRadians(
-        parseFloat(dataRectangle.getAttribute("maxy"))
-      );
-      const maxLevel = parseInt(dataRectangle.getAttribute("maxlevel"), 10);
-
-      that._rectangles.push(
-        new DataRectangle(new Rectangle(west, south, east, north), maxLevel)
-      );
-    }
-
-    that._ready = true;
-    return Promise.resolve(true);
+    this._readyPromise = requestMetadata(
+      terrainProviderBuilder,
+      resource,
+      that
+    ).then(() => {
+      terrainProviderBuilder.build(that);
+      return true;
+    });
   }
-
-  function metadataFailure(e) {
-    const message = defaultValue(
-      defined(e) ? e.message : undefined,
-      `An error occurred while accessing ${that._resource.url}.`
-    );
-    metadataError = TileProviderError.reportError(
-      metadataError,
-      that,
-      that._errorEvent,
-      message
-    );
-    if (metadataError.retry) {
-      return requestMetadata();
-    }
-    return Promise.reject(new RuntimeError(message));
-  }
-
-  function requestMetadata() {
-    return that._resource
-      .fetchXML()
-      .then(metadataSuccess)
-      .catch(metadataFailure);
-  }
-
-  this._readyPromise = requestMetadata();
 }
 
 Object.defineProperties(VRTheWorldTerrainProvider.prototype, {
@@ -169,7 +218,7 @@ Object.defineProperties(VRTheWorldTerrainProvider.prototype, {
 
   /**
    * Gets the credit to display when this terrain provider is active.  Typically this is used to credit
-   * the source of the terrain.  This function should not be called before {@link VRTheWorldTerrainProvider#ready} returns true.
+   * the source of the terrain.
    * @memberof VRTheWorldTerrainProvider.prototype
    * @type {Credit}
    * @readonly
@@ -181,22 +230,13 @@ Object.defineProperties(VRTheWorldTerrainProvider.prototype, {
   },
 
   /**
-   * Gets the tiling scheme used by this provider.  This function should
-   * not be called before {@link VRTheWorldTerrainProvider#ready} returns true.
+   * Gets the tiling scheme used by this provider.
    * @memberof VRTheWorldTerrainProvider.prototype
    * @type {GeographicTilingScheme}
    * @readonly
    */
   tilingScheme: {
     get: function () {
-      //>>includeStart('debug', pragmas.debug);
-      if (!this.ready) {
-        throw new DeveloperError(
-          "requestTileGeometry must not be called before ready returns true."
-        );
-      }
-      //>>includeEnd('debug');
-
       return this._tilingScheme;
     },
   },
@@ -206,9 +246,14 @@ Object.defineProperties(VRTheWorldTerrainProvider.prototype, {
    * @memberof VRTheWorldTerrainProvider.prototype
    * @type {Boolean}
    * @readonly
+   * @deprecated
    */
   ready: {
     get: function () {
+      deprecationWarning(
+        "VRTheWorldTerrainProvider.ready",
+        "VRTheWorldTerrainProvider.ready was deprecated in CesiumJS 1.102.  It will be removed in 1.104.  Use VRTheWorldTerrainProvider.fromUrl instead."
+      );
       return this._ready;
     },
   },
@@ -218,9 +263,14 @@ Object.defineProperties(VRTheWorldTerrainProvider.prototype, {
    * @memberof VRTheWorldTerrainProvider.prototype
    * @type {Promise.<Boolean>}
    * @readonly
+   * @deprecated
    */
   readyPromise: {
     get: function () {
+      deprecationWarning(
+        "VRTheWorldTerrainProvider.readyPromise",
+        "VRTheWorldTerrainProvider.readyPromise was deprecated in CesiumJS 1.102.  It will be removed in 1.104.  Use VRTheWorldTerrainProvider.fromUrl instead."
+      );
       return this._readyPromise;
     },
   },
@@ -228,8 +278,7 @@ Object.defineProperties(VRTheWorldTerrainProvider.prototype, {
   /**
    * Gets a value indicating whether or not the provider includes a water mask.  The water mask
    * indicates which areas of the globe are water rather than land, so they can be rendered
-   * as a reflective surface with animated waves.  This function should not be
-   * called before {@link VRTheWorldTerrainProvider#ready} returns true.
+   * as a reflective surface with animated waves.
    * @memberof VRTheWorldTerrainProvider.prototype
    * @type {Boolean}
    * @readonly
@@ -242,7 +291,6 @@ Object.defineProperties(VRTheWorldTerrainProvider.prototype, {
 
   /**
    * Gets a value indicating whether or not the requested tiles include vertex normals.
-   * This function should not be called before {@link VRTheWorldTerrainProvider#ready} returns true.
    * @memberof VRTheWorldTerrainProvider.prototype
    * @type {Boolean}
    * @readonly
@@ -254,8 +302,7 @@ Object.defineProperties(VRTheWorldTerrainProvider.prototype, {
   },
   /**
    * Gets an object that can be used to determine availability of terrain from this provider, such as
-   * at points and in rectangles.  This function should not be called before
-   * {@link TerrainProvider#ready} returns true.  This property may be undefined if availability
+   * at points and in rectangles. This property may be undefined if availability
    * information is not available.
    * @memberof VRTheWorldTerrainProvider.prototype
    * @type {TileAvailability}
@@ -269,8 +316,42 @@ Object.defineProperties(VRTheWorldTerrainProvider.prototype, {
 });
 
 /**
- * Requests the geometry for a given tile.  This function should not be called before
- * {@link VRTheWorldTerrainProvider#ready} returns true.  The result includes terrain
+ * Creates a {@link TerrainProvider} that produces terrain geometry by tessellating height maps
+ * retrieved from a {@link http://vr-theworld.com/|VT MÄK VR-TheWorld server}.
+ *
+ * @param {Resource|String} options.url The URL of the VR-TheWorld TileMap.
+ * @param {VRTheWorldTerrainProvider.ConstructorOptions} [options] A url or an object describing initialization options.
+ * @returns {Promise<VRTheWorldTerrainProvider>}
+ *
+ * @example
+ * const terrainProvider = await Cesium.VRTheWorldTerrainProvider.fromUrl(
+ *   "https://www.vr-theworld.com/vr-theworld/tiles1.0.0/73/"
+ * );
+ * viewer.terrainProvider = terrainProvider;
+ *
+ * @exception {RuntimeError} metadata specifies and unknown SRS
+ */
+VRTheWorldTerrainProvider.fromUrl = async function (url, options) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.defined("url", url);
+  //>>includeEnd('debug');
+
+  options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+
+  const terrainProviderBuilder = new TerrainProviderBuilder(options);
+  const resource = Resource.createIfNeeded(url);
+
+  await requestMetadata(terrainProviderBuilder, resource);
+
+  const provider = new VRTheWorldTerrainProvider(options);
+  terrainProviderBuilder.build(provider);
+  provider._resource = resource;
+
+  return provider;
+};
+
+/**
+ * Requests the geometry for a given tile. The result includes terrain
  * data and indicates that all child tiles are available.
  *
  * @param {Number} x The X coordinate of the tile for which to request geometry.
@@ -287,14 +368,6 @@ VRTheWorldTerrainProvider.prototype.requestTileGeometry = function (
   level,
   request
 ) {
-  //>>includeStart('debug', pragmas.debug);
-  if (!this.ready) {
-    throw new DeveloperError(
-      "requestTileGeometry must not be called before ready returns true."
-    );
-  }
-  //>>includeEnd('debug');
-
   const yTiles = this._tilingScheme.getNumberOfYTilesAtLevel(level);
   const resource = this._resource.getDerivedResource({
     url: `${level}/${x}/${yTiles - y - 1}.tif`,
@@ -331,13 +404,6 @@ VRTheWorldTerrainProvider.prototype.requestTileGeometry = function (
 VRTheWorldTerrainProvider.prototype.getLevelMaximumGeometricError = function (
   level
 ) {
-  //>>includeStart('debug', pragmas.debug);
-  if (!this.ready) {
-    throw new DeveloperError(
-      "requestTileGeometry must not be called before ready returns true."
-    );
-  }
-  //>>includeEnd('debug');
   return this._levelZeroMaximumGeometricError / (1 << level);
 };
 

--- a/packages/engine/Source/Core/createWorldTerrain.js
+++ b/packages/engine/Source/Core/createWorldTerrain.js
@@ -44,6 +44,8 @@ function createWorldTerrain(options) {
     requestWaterMask: defaultValue(options.requestWaterMask, false),
   });
 
+  // This is here in order to avoid throwing a second deprecation error
+  // by using the deprecated url parameter in the constructor above
   provider._readyPromise = CesiumTerrainProvider._initializeReadyPromise(
     {
       url: IonResource.fromAssetId(1),

--- a/packages/engine/Source/Core/createWorldTerrainAsync.js
+++ b/packages/engine/Source/Core/createWorldTerrainAsync.js
@@ -1,6 +1,5 @@
 import CesiumTerrainProvider from "./CesiumTerrainProvider.js";
 import defaultValue from "./defaultValue.js";
-import deprecationWarning from "./deprecationWarning.js";
 import IonResource from "./IonResource.js";
 
 /**
@@ -11,48 +10,32 @@ import IonResource from "./IonResource.js";
  * @param {Object} [options] Object with the following properties:
  * @param {Boolean} [options.requestVertexNormals=false] Flag that indicates if the client should request additional lighting information from the server if available.
  * @param {Boolean} [options.requestWaterMask=false] Flag that indicates if the client should request per tile water masks from the server if available.
- * @returns {CesiumTerrainProvider}
+ * @returns {Promise<CesiumTerrainProvider>} A promise that resolves to the created CesiumTerrainProvider
  *
  * @see Ion
  *
  * @example
  * // Create Cesium World Terrain with default settings
  * const viewer = new Cesium.Viewer('cesiumContainer', {
- *     terrainProvider : Cesium.createWorldTerrain();
+ *     terrainProvider : Cesium.createWorldTerrainAsync();
  * });
  *
  * @example
  * // Create Cesium World Terrain with water and normals.
  * const viewer1 = new Cesium.Viewer('cesiumContainer', {
- *     terrainProvider : Cesium.createWorldTerrain({
+ *     terrainProvider : Cesium.createWorldTerrainAsync({
  *         requestWaterMask : true,
  *         requestVertexNormals : true
  *     });
  * });
  *
  */
-function createWorldTerrain(options) {
-  deprecationWarning(
-    "createWorldTerrain",
-    "createWorldTerrain was deprecated in CesiumJS 1.102.  It will be removed in 1.104.  Use createWorldTerrainAsync instead."
-  );
-
+function createWorldTerrainAsync(options) {
   options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
-  const provider = new CesiumTerrainProvider({
+  return CesiumTerrainProvider.fromUrl(IonResource.fromAssetId(1), {
     requestVertexNormals: defaultValue(options.requestVertexNormals, false),
     requestWaterMask: defaultValue(options.requestWaterMask, false),
   });
-
-  provider._readyPromise = CesiumTerrainProvider._initializeReadyPromise(
-    {
-      url: IonResource.fromAssetId(1),
-      requestVertexNormals: defaultValue(options.requestVertexNormals, false),
-      requestWaterMask: defaultValue(options.requestWaterMask, false),
-    },
-    provider
-  );
-
-  return provider;
 }
-export default createWorldTerrain;
+export default createWorldTerrainAsync;

--- a/packages/engine/Source/Core/createWorldTerrainAsync.js
+++ b/packages/engine/Source/Core/createWorldTerrainAsync.js
@@ -16,18 +16,26 @@ import IonResource from "./IonResource.js";
  *
  * @example
  * // Create Cesium World Terrain with default settings
- * const viewer = new Cesium.Viewer('cesiumContainer', {
- *     terrainProvider : Cesium.createWorldTerrainAsync();
- * });
+ * try {
+ *   const viewer = new Cesium.Viewer("cesiumContainer", {
+ *     terrainProvider: await Cesium.createWorldTerrainAsync();
+ *   });
+ * } catch (error) {
+ *   console.log(error);
+ * }
  *
  * @example
  * // Create Cesium World Terrain with water and normals.
- * const viewer1 = new Cesium.Viewer('cesiumContainer', {
- *     terrainProvider : Cesium.createWorldTerrainAsync({
- *         requestWaterMask : true,
- *         requestVertexNormals : true
+ * try {
+ *   const viewer1 = new Cesium.Viewer("cesiumContainer", {
+ *     terrainProvider: await Cesium.createWorldTerrainAsync({
+ *       requestWaterMask: true,
+ *       requestVertexNormals: true
  *     });
- * });
+ *   });
+ * } catch (error) {
+ *   console.log(error);
+ * }
  *
  */
 function createWorldTerrainAsync(options) {

--- a/packages/engine/Source/Core/sampleTerrain.js
+++ b/packages/engine/Source/Core/sampleTerrain.js
@@ -34,12 +34,15 @@ import Check from "./Check.js";
  * // positions[0].height and positions[1].height have been updated.
  * // updatedPositions is just a reference to positions.
  */
-function sampleTerrain(terrainProvider, level, positions) {
+async function sampleTerrain(terrainProvider, level, positions) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("terrainProvider", terrainProvider);
   Check.typeOf.number("level", level);
   Check.defined("positions", positions);
   //>>includeEnd('debug');
+
+  // readyPromise has been deprecated; This is here for backwards compatibility
+  await terrainProvider._readyPromise;
 
   return doSampling(terrainProvider, level, positions);
 }

--- a/packages/engine/Source/Core/sampleTerrain.js
+++ b/packages/engine/Source/Core/sampleTerrain.js
@@ -25,16 +25,14 @@ import Check from "./Check.js";
  *
  * @example
  * // Query the terrain height of two Cartographic positions
- * const terrainProvider = Cesium.createWorldTerrain();
+ * const terrainProvider = await Cesium.createWorldTerrainAsync();
  * const positions = [
  *     Cesium.Cartographic.fromDegrees(86.925145, 27.988257),
  *     Cesium.Cartographic.fromDegrees(87.0, 28.0)
  * ];
- * const promise = Cesium.sampleTerrain(terrainProvider, 11, positions);
- * Promise.resolve(promise).then(function(updatedPositions) {
- *     // positions[0].height and positions[1].height have been updated.
- *     // updatedPositions is just a reference to positions.
- * });
+ * const updatedPositions = await Cesium.sampleTerrain(terrainProvider, 11, positions);
+ * // positions[0].height and positions[1].height have been updated.
+ * // updatedPositions is just a reference to positions.
  */
 function sampleTerrain(terrainProvider, level, positions) {
   //>>includeStart('debug', pragmas.debug);
@@ -43,9 +41,7 @@ function sampleTerrain(terrainProvider, level, positions) {
   Check.defined("positions", positions);
   //>>includeEnd('debug');
 
-  return terrainProvider.readyPromise.then(function () {
-    return doSampling(terrainProvider, level, positions);
-  });
+  return doSampling(terrainProvider, level, positions);
 }
 
 /**

--- a/packages/engine/Source/Core/sampleTerrainMostDetailed.js
+++ b/packages/engine/Source/Core/sampleTerrainMostDetailed.js
@@ -39,6 +39,9 @@ async function sampleTerrainMostDetailed(terrainProvider, positions) {
   const byLevel = [];
   const maxLevels = [];
 
+  // readyPromise has been deprecated; This is here for backwards compatibility
+  await terrainProvider._readyPromise;
+
   const availability = terrainProvider.availability;
 
   //>>includeStart('debug', pragmas.debug);

--- a/packages/engine/Source/Core/sampleTerrainMostDetailed.js
+++ b/packages/engine/Source/Core/sampleTerrainMostDetailed.js
@@ -17,18 +17,16 @@ const scratchCartesian2 = new Cartesian2();
  *
  * @example
  * // Query the terrain height of two Cartographic positions
- * const terrainProvider = Cesium.createWorldTerrain();
+ * const terrainProvider = await Cesium.createWorldTerrainAsync();
  * const positions = [
  *     Cesium.Cartographic.fromDegrees(86.925145, 27.988257),
  *     Cesium.Cartographic.fromDegrees(87.0, 28.0)
  * ];
- * const promise = Cesium.sampleTerrainMostDetailed(terrainProvider, positions);
- * Promise.resolve(promise).then(function(updatedPositions) {
- *     // positions[0].height and positions[1].height have been updated.
- *     // updatedPositions is just a reference to positions.
- * });
+ * const updatedPositions = await Cesium.sampleTerrainMostDetailed(terrainProvider, positions);
+ * // positions[0].height and positions[1].height have been updated.
+ * // updatedPositions is just a reference to positions.
  */
-function sampleTerrainMostDetailed(terrainProvider, positions) {
+async function sampleTerrainMostDetailed(terrainProvider, positions) {
   //>>includeStart('debug', pragmas.debug);
   if (!defined(terrainProvider)) {
     throw new DeveloperError("terrainProvider is required.");
@@ -38,80 +36,73 @@ function sampleTerrainMostDetailed(terrainProvider, positions) {
   }
   //>>includeEnd('debug');
 
-  return terrainProvider.readyPromise.then(function () {
-    const byLevel = [];
-    const maxLevels = [];
+  const byLevel = [];
+  const maxLevels = [];
 
-    const availability = terrainProvider.availability;
+  const availability = terrainProvider.availability;
 
-    //>>includeStart('debug', pragmas.debug);
-    if (!defined(availability)) {
-      throw new DeveloperError(
-        "sampleTerrainMostDetailed requires a terrain provider that has tile availability."
+  //>>includeStart('debug', pragmas.debug);
+  if (!defined(availability)) {
+    throw new DeveloperError(
+      "sampleTerrainMostDetailed requires a terrain provider that has tile availability."
+    );
+  }
+  //>>includeEnd('debug');
+
+  const promises = [];
+  for (let i = 0; i < positions.length; ++i) {
+    const position = positions[i];
+    const maxLevel = availability.computeMaximumLevelAtPosition(position);
+    maxLevels[i] = maxLevel;
+    if (maxLevel === 0) {
+      // This is a special case where we have a parent terrain and we are requesting
+      // heights from an area that isn't covered by the top level terrain at all.
+      // This will essentially trigger the loading of the parent terrains root tile
+      terrainProvider.tilingScheme.positionToTileXY(
+        position,
+        1,
+        scratchCartesian2
       );
-    }
-    //>>includeEnd('debug');
-
-    const promises = [];
-    for (let i = 0; i < positions.length; ++i) {
-      const position = positions[i];
-      const maxLevel = availability.computeMaximumLevelAtPosition(position);
-      maxLevels[i] = maxLevel;
-      if (maxLevel === 0) {
-        // This is a special case where we have a parent terrain and we are requesting
-        // heights from an area that isn't covered by the top level terrain at all.
-        // This will essentially trigger the loading of the parent terrains root tile
-        terrainProvider.tilingScheme.positionToTileXY(
-          position,
-          1,
-          scratchCartesian2
-        );
-        const promise = terrainProvider.loadTileDataAvailability(
-          scratchCartesian2.x,
-          scratchCartesian2.y,
-          1
-        );
-        if (defined(promise)) {
-          promises.push(promise);
-        }
+      const promise = terrainProvider.loadTileDataAvailability(
+        scratchCartesian2.x,
+        scratchCartesian2.y,
+        1
+      );
+      if (defined(promise)) {
+        promises.push(promise);
       }
-
-      let atLevel = byLevel[maxLevel];
-      if (!defined(atLevel)) {
-        byLevel[maxLevel] = atLevel = [];
-      }
-      atLevel.push(position);
     }
 
-    return Promise.all(promises)
-      .then(function () {
-        return Promise.all(
-          byLevel.map(function (positionsAtLevel, index) {
-            if (defined(positionsAtLevel)) {
-              return sampleTerrain(terrainProvider, index, positionsAtLevel);
-            }
-          })
-        );
-      })
-      .then(function () {
-        const changedPositions = [];
-        for (let i = 0; i < positions.length; ++i) {
-          const position = positions[i];
-          const maxLevel = availability.computeMaximumLevelAtPosition(position);
+    let atLevel = byLevel[maxLevel];
+    if (!defined(atLevel)) {
+      byLevel[maxLevel] = atLevel = [];
+    }
+    atLevel.push(position);
+  }
 
-          if (maxLevel !== maxLevels[i]) {
-            // Now that we loaded the max availability, a higher level has become available
-            changedPositions.push(position);
-          }
-        }
+  await Promise.all(promises);
+  await Promise.all(
+    byLevel.map(function (positionsAtLevel, index) {
+      if (defined(positionsAtLevel)) {
+        return sampleTerrain(terrainProvider, index, positionsAtLevel);
+      }
+    })
+  );
+  const changedPositions = [];
+  for (let i = 0; i < positions.length; ++i) {
+    const position = positions[i];
+    const maxLevel = availability.computeMaximumLevelAtPosition(position);
 
-        if (changedPositions.length > 0) {
-          return sampleTerrainMostDetailed(terrainProvider, changedPositions);
-        }
-      })
-      .then(function () {
-        return positions;
-      });
-  });
+    if (maxLevel !== maxLevels[i]) {
+      // Now that we loaded the max availability, a higher level has become available
+      changedPositions.push(position);
+    }
+  }
+
+  if (changedPositions.length > 0) {
+    await sampleTerrainMostDetailed(terrainProvider, changedPositions);
+  }
+
+  return positions;
 }
 export default sampleTerrainMostDetailed;

--- a/packages/engine/Source/Scene/Globe.js
+++ b/packages/engine/Source/Scene/Globe.js
@@ -982,7 +982,11 @@ Globe.prototype.beginFrame = function (frameState) {
   const surface = this._surface;
   const tileProvider = surface.tileProvider;
   const terrainProvider = this.terrainProvider;
-  const hasWaterMask = this.showWaterEffect && terrainProvider.hasWaterMask;
+  const hasWaterMask =
+    this.showWaterEffect &&
+    terrainProvider.hasWaterMask &&
+    // ready is deprecated; This is here for backwards compatibility
+    terrainProvider._ready;
 
   if (hasWaterMask && this._oceanNormalMapResourceDirty) {
     // url changed, load new normal map asynchronously

--- a/packages/engine/Source/Scene/Globe.js
+++ b/packages/engine/Source/Scene/Globe.js
@@ -982,10 +982,7 @@ Globe.prototype.beginFrame = function (frameState) {
   const surface = this._surface;
   const tileProvider = surface.tileProvider;
   const terrainProvider = this.terrainProvider;
-  const hasWaterMask =
-    this.showWaterEffect &&
-    terrainProvider.ready &&
-    terrainProvider.hasWaterMask;
+  const hasWaterMask = this.showWaterEffect && terrainProvider.hasWaterMask;
 
   if (hasWaterMask && this._oceanNormalMapResourceDirty) {
     // url changed, load new normal map asynchronously

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -237,9 +237,8 @@ Object.defineProperties(GlobeSurfaceTileProvider.prototype, {
   ready: {
     get: function () {
       return (
-        this._terrainProvider.ready &&
-        (this._imageryLayers.length === 0 ||
-          this._imageryLayers.get(0).imageryProvider.ready)
+        this._imageryLayers.length === 0 ||
+        this._imageryLayers.get(0).imageryProvider.ready
       );
     },
   },
@@ -348,10 +347,7 @@ GlobeSurfaceTileProvider.prototype.update = function (frameState) {
 
 function updateCredits(surface, frameState) {
   const creditDisplay = frameState.creditDisplay;
-  if (
-    surface._terrainProvider.ready &&
-    defined(surface._terrainProvider.credit)
-  ) {
+  if (defined(surface._terrainProvider.credit)) {
     creditDisplay.addCredit(surface._terrainProvider.credit);
   }
 
@@ -2123,9 +2119,7 @@ function addDrawCommandsForTile(tileProvider, tile, frameState) {
     tileProvider.hasWaterMask && defined(waterMaskTexture);
   const oceanNormalMap = tileProvider.oceanNormalMap;
   const showOceanWaves = showReflectiveOcean && defined(oceanNormalMap);
-  const hasVertexNormals =
-    tileProvider.terrainProvider.ready &&
-    tileProvider.terrainProvider.hasVertexNormals;
+  const hasVertexNormals = tileProvider.terrainProvider.hasVertexNormals;
   const enableFog =
     frameState.fog.enabled && frameState.fog.renderable && !cameraUnderground;
   const showGroundAtmosphere =

--- a/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/packages/engine/Source/Scene/GlobeSurfaceTileProvider.js
@@ -237,8 +237,10 @@ Object.defineProperties(GlobeSurfaceTileProvider.prototype, {
   ready: {
     get: function () {
       return (
-        this._imageryLayers.length === 0 ||
-        this._imageryLayers.get(0).imageryProvider.ready
+        // ready is deprecated; This is here for backwards compatibility
+        this._terrainProvider._ready &&
+        (this._imageryLayers.length === 0 ||
+          this._imageryLayers.get(0).imageryProvider.ready)
       );
     },
   },
@@ -347,7 +349,11 @@ GlobeSurfaceTileProvider.prototype.update = function (frameState) {
 
 function updateCredits(surface, frameState) {
   const creditDisplay = frameState.creditDisplay;
-  if (defined(surface._terrainProvider.credit)) {
+  if (
+    // ready is deprecated; This is here for backwards compatibility
+    surface._terrainProvider._ready &&
+    defined(surface._terrainProvider.credit)
+  ) {
     creditDisplay.addCredit(surface._terrainProvider.credit);
   }
 
@@ -2119,7 +2125,10 @@ function addDrawCommandsForTile(tileProvider, tile, frameState) {
     tileProvider.hasWaterMask && defined(waterMaskTexture);
   const oceanNormalMap = tileProvider.oceanNormalMap;
   const showOceanWaves = showReflectiveOcean && defined(oceanNormalMap);
-  const hasVertexNormals = tileProvider.terrainProvider.hasVertexNormals;
+  const hasVertexNormals =
+    // ready is deprecated; This is here for backwards compatibility
+    tileProvider.terrainProvider._ready &&
+    tileProvider.terrainProvider.hasVertexNormals;
   const enableFog =
     frameState.fog.enabled && frameState.fog.renderable && !cameraUnderground;
   const showGroundAtmosphere =

--- a/packages/engine/Source/Scene/I3SDataProvider.js
+++ b/packages/engine/Source/Scene/I3SDataProvider.js
@@ -512,9 +512,7 @@ I3SDataProvider.prototype._getDecoderTaskProcessor = function () {
 };
 
 function getCoveredTiles(terrainProvider, extent) {
-  return terrainProvider.readyPromise.then(function () {
-    return getTiles(terrainProvider, extent);
-  });
+  return getTiles(terrainProvider, extent);
 }
 
 const scratchCartesian2 = new Cartesian2();

--- a/packages/engine/Source/Scene/I3SDataProvider.js
+++ b/packages/engine/Source/Scene/I3SDataProvider.js
@@ -74,7 +74,7 @@ import Rectangle from "../Core/Rectangle.js";
  * @param {Resource|String} options.url The url of the I3S dataset.
  * @param {String} [options.name] The name of the I3S dataset.
  * @param {Boolean} [options.show=true] Determines if the dataset will be shown.
- * @param {ArcGISTiledElevationTerrainProvider} [options.geoidTiledTerrainProvider] Tiled elevation provider describing an Earth Gravitational Model. If defined, geometry will be shifted based on the offsets given by this provider. Required to position I3S data sets with gravity-related height at the correct location.
+ * @param {ArcGISTiledElevationTerrainProvider|Promise<ArcGISTiledElevationTerrainProvider>} [options.geoidTiledTerrainProvider] Tiled elevation provider describing an Earth Gravitational Model. If defined, geometry will be shifted based on the offsets given by this provider. Required to position I3S data sets with gravity-related height at the correct location.
  * @param {Boolean} [options.traceFetches=false] Debug option. When true, log a message whenever an I3S tile is fetched.
  * @param {Object} [options.cesium3dTilesetOptions] Object containing options to pass to an internally created {@link Cesium3DTileset}. See {@link Cesium3DTileset} for list of valid properties. All options can be used with the exception of <code>url</code> and <code>show</code> which are overridden by values from I3SDataProvider.
  *
@@ -85,9 +85,9 @@ import Rectangle from "../Core/Rectangle.js";
  * viewer.scene.primitives.add(i3sData);
  *
  * @example
- * const geoidService = new Cesium.ArcGISTiledElevationTerrainProvider({
- *   url: "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/EGM2008/ImageServer",
- * });
+ * const geoidService = await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
+ *   "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/EGM2008/ImageServer"
+ * );
  * let i3sData = new I3SDataProvider({
  *   url: 'https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/Frankfurt2017_vi3s_18/SceneServer/layers/0',
  *   geoidTiledTerrainProvider: geoidService
@@ -401,7 +401,7 @@ I3SDataProvider.prototype._load = function () {
     }
 
     that._computeExtent();
-    that._loadGeoidData();
+    that._geoidDataIsReadyPromise = that._loadGeoidData();
 
     // Start loading all of the tiles
     const layerPromises = [];
@@ -617,7 +617,7 @@ function getTiles(terrainProvider, extent) {
 /**
  * @private
  */
-I3SDataProvider.prototype._loadGeoidData = function () {
+I3SDataProvider.prototype._loadGeoidData = async function () {
   // Load tiles from arcgis
   const that = this;
   const geoidTerrainProvider = this._geoidTiledTerrainProvider;
@@ -626,23 +626,11 @@ I3SDataProvider.prototype._loadGeoidData = function () {
     console.log(
       "No Geoid Terrain service provided - no geoid conversion will be performed."
     );
-    this._geoidDataIsReadyPromise = Promise.resolve();
-    return this._geoidDataIsReadyPromise;
+    return;
   }
 
-  this._geoidDataIsReadyPromise = geoidTerrainProvider.readyPromise.then(
-    function () {
-      const tilesReadyPromise = getCoveredTiles(
-        geoidTerrainProvider,
-        that._extent
-      );
-      return tilesReadyPromise.then(function (heightMaps) {
-        that._geoidDataList = heightMaps;
-      });
-    }
-  );
-
-  return this._geoidDataIsReadyPromise;
+  const heightMaps = await getCoveredTiles(geoidTerrainProvider, that._extent);
+  that._geoidDataList = heightMaps;
 };
 
 /**

--- a/packages/engine/Source/Scene/computeFlyToLocationForRectangle.js
+++ b/packages/engine/Source/Scene/computeFlyToLocationForRectangle.js
@@ -31,6 +31,8 @@ async function computeFlyToLocationForRectangle(rectangle, scene) {
     return positionWithoutTerrain;
   }
 
+  // readyPromise has been deprecated; This is here for backwards compatibility
+  await terrainProvider._readyPromise;
   const availability = terrainProvider.availability;
 
   if (!defined(availability) || scene.mode === SceneMode.SCENE2D) {

--- a/packages/engine/Source/Widget/CesiumWidget.js
+++ b/packages/engine/Source/Widget/CesiumWidget.js
@@ -124,7 +124,7 @@ function configureCameraFrustum(widget) {
  * @param {Object} [options] Object with the following properties:
  * @param {Clock} [options.clock=new Clock()] The clock to use to control current time.
  * @param {ImageryProvider | false} [options.imageryProvider=createWorldImagery()] The imagery provider to serve as the base layer. If set to <code>false</code>, no imagery provider will be added.
- * @param {TerrainProvider|Promise<TerrainProvider>} [options.terrainProvider=new EllipsoidTerrainProvider] The terrain provider.
+ * @param {TerrainProvider} [options.terrainProvider=new EllipsoidTerrainProvider] The terrain provider.
  * @param {SkyBox| false} [options.skyBox] The skybox used to render the stars.  When <code>undefined</code>, the default stars are used. If set to <code>false</code>, no skyBox, Sun, or Moon will be added.
  * @param {SkyAtmosphere | false} [options.skyAtmosphere] Blue sky, and the glow around the Earth's limb.  Set to <code>false</code> to turn it off.
  * @param {SceneMode} [options.sceneMode=SceneMode.SCENE3D] The initial scene mode.
@@ -156,27 +156,31 @@ function configureCameraFrustum(widget) {
  * // For each example, include a link to CesiumWidget.css stylesheet in HTML head,
  * // and in the body, include: <div id="cesiumContainer"></div>
  *
- * //Widget with no terrain and default Bing Maps imagery provider.
- * const widget = new Cesium.CesiumWidget('cesiumContainer');
+ * // Widget with no terrain and default Bing Maps imagery provider.
+ * const widget = new Cesium.CesiumWidget("cesiumContainer");
  *
- * //Widget with ion imagery and Cesium World Terrain.
- * const widget2 = new Cesium.CesiumWidget('cesiumContainer', {
- *     imageryProvider : Cesium.createWorldImagery(),
- *     terrainProvider : Cesium.createWorldTerrainAsync(),
- *     skyBox : new Cesium.SkyBox({
- *         sources : {
- *           positiveX : 'stars/TychoSkymapII.t3_08192x04096_80_px.jpg',
- *           negativeX : 'stars/TychoSkymapII.t3_08192x04096_80_mx.jpg',
- *           positiveY : 'stars/TychoSkymapII.t3_08192x04096_80_py.jpg',
- *           negativeY : 'stars/TychoSkymapII.t3_08192x04096_80_my.jpg',
- *           positiveZ : 'stars/TychoSkymapII.t3_08192x04096_80_pz.jpg',
- *           negativeZ : 'stars/TychoSkymapII.t3_08192x04096_80_mz.jpg'
- *         }
+ * // Widget with ion imagery and Cesium World Terrain.
+ * try {
+ *   const widget2 = new Cesium.CesiumWidget("cesiumContainer", {
+ *     imageryProvider: Cesium.createWorldImagery(),
+ *     terrainProvider: await Cesium.createWorldTerrainAsync(),
+ *     skyBox: new Cesium.SkyBox({
+ *       sources: {
+ *         positiveX: "stars/TychoSkymapII.t3_08192x04096_80_px.jpg",
+ *         negativeX: "stars/TychoSkymapII.t3_08192x04096_80_mx.jpg",
+ *         positiveY: "stars/TychoSkymapII.t3_08192x04096_80_py.jpg",
+ *         negativeY: "stars/TychoSkymapII.t3_08192x04096_80_my.jpg",
+ *         positiveZ: "stars/TychoSkymapII.t3_08192x04096_80_pz.jpg",
+ *         negativeZ: "stars/TychoSkymapII.t3_08192x04096_80_mz.jpg"
+ *       }
  *     }),
  *     // Show Columbus View map with Web Mercator projection
- *     sceneMode : Cesium.SceneMode.COLUMBUS_VIEW,
- *     mapProjection : new Cesium.WebMercatorProjection()
- * });
+ *     sceneMode: Cesium.SceneMode.COLUMBUS_VIEW,
+ *     mapProjection: new Cesium.WebMercatorProjection()
+ *   });
+ * } catch (error) {
+ *   console.log(error);
+ * }
  */
 function CesiumWidget(container, options) {
   //>>includeStart('debug', pragmas.debug);
@@ -353,15 +357,7 @@ function CesiumWidget(container, options) {
 
     //Set the terrain provider if one is provided.
     if (defined(options.terrainProvider) && options.globe !== false) {
-      // options.terrainProvider is a promise
-      // Promise.resolve is not used so that synchronous code can immediately execute
-      if (defined(options.terrainProvider.then)) {
-        options.terrainProvider.then((provider) => {
-          scene.terrainProvider = provider;
-        });
-      } else {
-        scene.terrainProvider = options.terrainProvider;
-      }
+      scene.terrainProvider = options.terrainProvider;
     }
 
     this._screenSpaceEventHandler = new ScreenSpaceEventHandler(canvas);

--- a/packages/engine/Source/Widget/CesiumWidget.js
+++ b/packages/engine/Source/Widget/CesiumWidget.js
@@ -124,7 +124,7 @@ function configureCameraFrustum(widget) {
  * @param {Object} [options] Object with the following properties:
  * @param {Clock} [options.clock=new Clock()] The clock to use to control current time.
  * @param {ImageryProvider | false} [options.imageryProvider=createWorldImagery()] The imagery provider to serve as the base layer. If set to <code>false</code>, no imagery provider will be added.
- * @param {TerrainProvider} [options.terrainProvider=new EllipsoidTerrainProvider] The terrain provider.
+ * @param {TerrainProvider|Promise<TerrainProvider>} [options.terrainProvider=new EllipsoidTerrainProvider] The terrain provider.
  * @param {SkyBox| false} [options.skyBox] The skybox used to render the stars.  When <code>undefined</code>, the default stars are used. If set to <code>false</code>, no skyBox, Sun, or Moon will be added.
  * @param {SkyAtmosphere | false} [options.skyAtmosphere] Blue sky, and the glow around the Earth's limb.  Set to <code>false</code> to turn it off.
  * @param {SceneMode} [options.sceneMode=SceneMode.SCENE3D] The initial scene mode.
@@ -162,7 +162,7 @@ function configureCameraFrustum(widget) {
  * //Widget with ion imagery and Cesium World Terrain.
  * const widget2 = new Cesium.CesiumWidget('cesiumContainer', {
  *     imageryProvider : Cesium.createWorldImagery(),
- *     terrainProvider : Cesium.createWorldTerrain(),
+ *     terrainProvider : Cesium.createWorldTerrainAsync(),
  *     skyBox : new Cesium.SkyBox({
  *         sources : {
  *           positiveX : 'stars/TychoSkymapII.t3_08192x04096_80_px.jpg',
@@ -353,7 +353,15 @@ function CesiumWidget(container, options) {
 
     //Set the terrain provider if one is provided.
     if (defined(options.terrainProvider) && options.globe !== false) {
-      scene.terrainProvider = options.terrainProvider;
+      // options.terrainProvider is a promise
+      // Promise.resolve is not used so that synchronous code can immediately execute
+      if (defined(options.terrainProvider.then)) {
+        options.terrainProvider.then((provider) => {
+          scene.terrainProvider = provider;
+        });
+      } else {
+        scene.terrainProvider = options.terrainProvider;
+      }
     }
 
     this._screenSpaceEventHandler = new ScreenSpaceEventHandler(canvas);

--- a/packages/engine/Specs/Core/ArcGISTiledElevationTerrainProviderSpec.js
+++ b/packages/engine/Specs/Core/ArcGISTiledElevationTerrainProviderSpec.js
@@ -1,6 +1,6 @@
 import {
   ArcGISTiledElevationTerrainProvider,
-  DefaultProxy,
+  DeveloperError,
   GeographicTilingScheme,
   HeightmapTerrainData,
   Request,
@@ -11,8 +11,6 @@ import {
   WebMercatorTilingScheme,
   Math as CesiumMath,
 } from "../../index.js";
-
-import pollToPromise from "../../../../Specs/pollToPromise.js";
 
 describe("Core/ArcGISTiledElevationTerrainProvider", function () {
   const lercTileUrl = "Data/Images/Red16x16.png";
@@ -203,271 +201,182 @@ describe("Core/ArcGISTiledElevationTerrainProvider", function () {
     );
   });
 
-  it("constructor throws if url is not provided", function () {
-    expect(function () {
-      return new ArcGISTiledElevationTerrainProvider();
-    }).toThrowDeveloperError();
-
-    expect(function () {
-      return new ArcGISTiledElevationTerrainProvider({});
-    }).toThrowDeveloperError();
+  it("fromUrl throws without url", async function () {
+    await expectAsync(
+      ArcGISTiledElevationTerrainProvider.fromUrl()
+    ).toBeRejectedWithError(
+      DeveloperError,
+      "url is required, actual value was undefined"
+    );
   });
 
-  it("resolves readyPromise", function () {
-    const provider = new ArcGISTiledElevationTerrainProvider({
-      url: "made/up/url",
-    });
+  it("fromUrl resolves to new ArcGISTiledElevationTerrainProvider", async function () {
+    const provider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+      "made/up/url"
+    );
 
-    return provider.readyPromise.then(function (result) {
-      expect(result).toBe(true);
-      expect(provider.ready).toBe(true);
-    });
+    expect(provider).toBeInstanceOf(ArcGISTiledElevationTerrainProvider);
   });
 
-  it("resolves readyPromise with Resource", function () {
+  it("fromUrl with resource resolves to new ArcGISTiledElevationTerrainProvider", async function () {
     const resource = new Resource({
       url: "made/up/url",
     });
+    const provider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+      resource
+    );
 
-    const provider = new ArcGISTiledElevationTerrainProvider({
-      url: resource,
-    });
-
-    return provider.readyPromise.then(function (result) {
-      expect(result).toBe(true);
-      expect(provider.ready).toBe(true);
-    });
+    expect(provider).toBeInstanceOf(ArcGISTiledElevationTerrainProvider);
   });
 
-  it("has error event", function () {
-    const provider = new ArcGISTiledElevationTerrainProvider({
-      url: "made/up/url",
-    });
+  it("fromUrl resolves with url promise", async function () {
+    const provider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+      Promise.resolve("made/up/url")
+    );
+    expect(provider).toBeInstanceOf(ArcGISTiledElevationTerrainProvider);
+  });
+
+  it("fromUrl rejects if url rejects", async function () {
+    await expectAsync(
+      ArcGISTiledElevationTerrainProvider.fromUrl(
+        Promise.reject(new Error("my message"))
+      )
+    ).toBeRejectedWithError("my message");
+  });
+
+  it("has error event", async function () {
+    const provider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+      "made/up/url"
+    );
+
     expect(provider.errorEvent).toBeDefined();
     expect(provider.errorEvent).toBe(provider.errorEvent);
-
-    return provider.readyPromise;
   });
 
-  it("returns reasonable geometric error for various levels", function () {
-    const provider = new ArcGISTiledElevationTerrainProvider({
-      url: "made/up/url",
-    });
+  it("returns reasonable geometric error for various levels", async function () {
+    const provider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+      "made/up/url"
+    );
 
-    return pollToPromise(function () {
-      return provider.ready;
-    }).then(function () {
-      expect(provider.getLevelMaximumGeometricError(0)).toBeGreaterThan(0.0);
-      expect(provider.getLevelMaximumGeometricError(0)).toEqualEpsilon(
-        provider.getLevelMaximumGeometricError(1) * 2.0,
-        CesiumMath.EPSILON10
-      );
-      expect(provider.getLevelMaximumGeometricError(1)).toEqualEpsilon(
-        provider.getLevelMaximumGeometricError(2) * 2.0,
-        CesiumMath.EPSILON10
-      );
-    });
+    expect(provider.getLevelMaximumGeometricError(0)).toBeGreaterThan(0.0);
+    expect(provider.getLevelMaximumGeometricError(0)).toEqualEpsilon(
+      provider.getLevelMaximumGeometricError(1) * 2.0,
+      CesiumMath.EPSILON10
+    );
+    expect(provider.getLevelMaximumGeometricError(1)).toEqualEpsilon(
+      provider.getLevelMaximumGeometricError(2) * 2.0,
+      CesiumMath.EPSILON10
+    );
   });
 
-  it("getLevelMaximumGeometricError must not be called before isReady returns true", function () {
-    const provider = new ArcGISTiledElevationTerrainProvider({
-      url: "made/up/url",
-    });
-
-    expect(function () {
-      provider.getLevelMaximumGeometricError(0);
-    }).toThrowDeveloperError();
-
-    return provider.readyPromise;
-  });
-
-  it("getTilingScheme must not be called before isReady returns true", function () {
-    const provider = new ArcGISTiledElevationTerrainProvider({
-      url: "made/up/url",
-    });
-
-    expect(function () {
-      return provider.tilingScheme;
-    }).toThrowDeveloperError();
-
-    return provider.readyPromise;
-  });
-
-  it("logo is undefined if credit is not provided", function () {
+  it("credit is undefined if credit is not provided", async function () {
     delete metadata.copyrightText;
-    const provider = new ArcGISTiledElevationTerrainProvider({
-      url: "made/up/url",
-    });
-    return pollToPromise(function () {
-      return provider.ready;
-    }).then(function () {
-      expect(provider.credit).toBeUndefined();
-    });
+    const provider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+      "made/up/url"
+    );
+    expect(provider.credit).toBeUndefined();
   });
 
-  it("logo is defined if credit is provided", function () {
-    const provider = new ArcGISTiledElevationTerrainProvider({
-      url: "made/up/url",
-      credit: "thanks to our awesome made up contributors!",
-    });
-    return pollToPromise(function () {
-      return provider.ready;
-    }).then(function () {
-      expect(provider.credit).toBeDefined();
-    });
+  it("credit is defined if credit option is provided", async function () {
+    const provider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+      "made/up/url",
+      {
+        credit: "thanks to our awesome made up contributors!",
+      }
+    );
+    expect(provider.credit).toBeDefined();
   });
 
-  it("does not have a water mask", function () {
-    const provider = new ArcGISTiledElevationTerrainProvider({
-      url: "made/up/url",
-    });
+  it("does not have a water mask", async function () {
+    const provider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+      "made/up/url"
+    );
     expect(provider.hasWaterMask).toBe(false);
-    return provider.readyPromise.catch(function (error) {
-      expect(error).toBeInstanceOf(RuntimeError);
-    });
   });
 
-  it("is not ready immediately", function () {
-    const provider = new ArcGISTiledElevationTerrainProvider({
-      url: "made/up/url",
-    });
-    expect(provider.ready).toBe(false);
-    return provider.readyPromise.catch(function (error) {
-      expect(error).toBeInstanceOf(RuntimeError);
-    });
-  });
-
-  it("detects WebMercator tiling scheme", function () {
+  it("detects WebMercator tiling scheme", async function () {
     const baseUrl = "made/up/url";
+    const terrainProvider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+      baseUrl
+    );
 
-    const terrainProvider = new ArcGISTiledElevationTerrainProvider({
-      url: baseUrl,
-    });
-
-    return pollToPromise(function () {
-      return terrainProvider.ready;
-    }).then(function () {
-      expect(terrainProvider.tilingScheme).toBeInstanceOf(
-        WebMercatorTilingScheme
-      );
-    });
+    expect(terrainProvider.tilingScheme).toBeInstanceOf(
+      WebMercatorTilingScheme
+    );
   });
 
-  it("detects Geographic tiling scheme", function () {
+  it("detects Geographic tiling scheme", async function () {
     const baseUrl = "made/up/url";
 
     metadata.spatialReference.latestWkid = 4326;
 
-    const terrainProvider = new ArcGISTiledElevationTerrainProvider({
-      url: baseUrl,
-    });
+    const terrainProvider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+      baseUrl
+    );
 
-    return pollToPromise(function () {
-      return terrainProvider.ready;
-    }).then(function () {
-      expect(terrainProvider.tilingScheme).toBeInstanceOf(
-        GeographicTilingScheme
-      );
-    });
+    expect(terrainProvider.tilingScheme).toBeInstanceOf(GeographicTilingScheme);
   });
 
-  it("raises an error if the SRS is not supported", function () {
+  it("fromUrl throws if SRS is not supported", async function () {
     const baseUrl = "made/up/url";
 
     metadata.spatialReference.latestWkid = 1234;
 
-    const terrainProvider = new ArcGISTiledElevationTerrainProvider({
-      url: baseUrl,
-    });
-
-    return terrainProvider.readyPromise.then(fail).catch(function (error) {
-      expect(error).toBeInstanceOf(RuntimeError);
-    });
+    await expectAsync(
+      ArcGISTiledElevationTerrainProvider.fromUrl(baseUrl)
+    ).toBeRejectedWithError(RuntimeError, "Invalid spatial reference");
   });
 
-  it("raises an error if tileInfo missing", function () {
+  it("raises an error if tileInfo missing", async function () {
     const baseUrl = "made/up/url";
 
     delete metadata.tileInfo;
 
-    const terrainProvider = new ArcGISTiledElevationTerrainProvider({
-      url: baseUrl,
-    });
-
-    return terrainProvider.readyPromise.then(fail).catch(function (error) {
-      expect(error).toBeInstanceOf(RuntimeError);
-    });
+    await expectAsync(
+      ArcGISTiledElevationTerrainProvider.fromUrl(baseUrl)
+    ).toBeRejectedWithError(RuntimeError, "tileInfo is required");
   });
 
-  it("checks availability if TileMap capability exists", function () {
+  it("checks availability if TileMap capability exists", async function () {
     const baseUrl = "made/up/url";
+    const terrainProvider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+      baseUrl
+    );
 
-    const terrainProvider = new ArcGISTiledElevationTerrainProvider({
-      url: baseUrl,
-    });
-
-    return pollToPromise(function () {
-      return terrainProvider.ready;
-    }).then(function () {
-      expect(terrainProvider._hasAvailability).toBe(true);
-      expect(terrainProvider._tilesAvailable).toBeDefined();
-      expect(terrainProvider._tilesAvailablityLoaded).toBeDefined();
-    });
+    expect(terrainProvider._hasAvailability).toBe(true);
+    expect(terrainProvider._tilesAvailable).toBeDefined();
+    expect(terrainProvider._tilesAvailabilityLoaded).toBeDefined();
   });
 
-  it("does not check availability if TileMap capability is missing", function () {
+  it("does not check availability if TileMap capability is missing", async function () {
     const baseUrl = "made/up/url";
 
     metadata.capabilities = "Image,Mensuration";
 
-    const terrainProvider = new ArcGISTiledElevationTerrainProvider({
-      url: baseUrl,
-    });
+    const terrainProvider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+      baseUrl
+    );
 
-    return pollToPromise(function () {
-      return terrainProvider.ready;
-    }).then(function () {
-      expect(terrainProvider._hasAvailability).toBe(false);
-      expect(terrainProvider._tilesAvailable).toBeUndefined();
-      expect(terrainProvider._tilesAvailablityLoaded).toBeUndefined();
-    });
+    expect(terrainProvider._hasAvailability).toBe(false);
+    expect(terrainProvider._tilesAvailable).toBeUndefined();
+    expect(terrainProvider._tilesAvailabilityLoaded).toBeUndefined();
   });
 
   describe("requestTileGeometry", function () {
-    it("must not be called before isReady returns true", function () {
-      const terrainProvider = new ArcGISTiledElevationTerrainProvider({
-        url: "made/up/url",
-        proxy: new DefaultProxy("/proxy/"),
-      });
-
-      expect(function () {
-        terrainProvider.requestTileGeometry(0, 0, 0);
-      }).toThrowDeveloperError();
-
-      return terrainProvider.readyPromise;
-    });
-
-    it("provides HeightmapTerrainData", function () {
+    it("provides HeightmapTerrainData", async function () {
       const baseUrl = "made/up/url";
 
-      const terrainProvider = new ArcGISTiledElevationTerrainProvider({
-        url: baseUrl,
-      });
+      const terrainProvider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+        baseUrl
+      );
 
-      return pollToPromise(function () {
-        return terrainProvider.ready;
-      })
-        .then(function () {
-          const promise = terrainProvider.requestTileGeometry(0, 0, 0);
-          RequestScheduler.update();
-          return promise;
-        })
-        .then(function (loadedData) {
-          expect(loadedData).toBeInstanceOf(HeightmapTerrainData);
-        });
+      const promise = terrainProvider.requestTileGeometry(0, 0, 0);
+      RequestScheduler.update();
+      const loadedData = await promise;
+      expect(loadedData).toBeInstanceOf(HeightmapTerrainData);
     });
 
-    it("returns undefined if too many requests are already in progress", function () {
+    it("returns undefined if too many requests are already in progress", async function () {
       const baseUrl = "made/up/url";
 
       const deferreds = [];
@@ -481,39 +390,35 @@ describe("Core/ArcGISTiledElevationTerrainProvider", function () {
         deferreds.push(deferred);
       };
 
-      const terrainProvider = new ArcGISTiledElevationTerrainProvider({
-        url: baseUrl,
-      });
+      const terrainProvider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+        baseUrl
+      );
 
-      return pollToPromise(function () {
-        return terrainProvider.ready;
-      }).then(function () {
-        let promise;
-        let i;
-        // Make one less request to account for the additional availability request.
-        for (i = 0; i < RequestScheduler.maximumRequestsPerServer - 1; ++i) {
-          const request = new Request({
-            throttle: true,
-            throttleByServer: true,
-          });
-          promise = terrainProvider.requestTileGeometry(0, 0, 0, request);
-        }
-        RequestScheduler.update();
-        expect(promise).toBeDefined();
+      let promise;
+      let i;
+      // Make one less request to account for the additional availability request.
+      for (i = 0; i < RequestScheduler.maximumRequestsPerServer - 1; ++i) {
+        const request = new Request({
+          throttle: true,
+          throttleByServer: true,
+        });
+        promise = terrainProvider.requestTileGeometry(0, 0, 0, request);
+      }
+      RequestScheduler.update();
+      expect(promise).toBeDefined();
 
-        promise = terrainProvider.requestTileGeometry(0, 0, 0, createRequest());
-        expect(promise).toBeUndefined();
+      promise = terrainProvider.requestTileGeometry(0, 0, 0, createRequest());
+      expect(promise).toBeUndefined();
 
-        for (i = 0; i < deferreds.length; ++i) {
-          deferreds[i].resolve();
-        }
+      for (i = 0; i < deferreds.length; ++i) {
+        deferreds[i].resolve();
+      }
 
-        return Promise.all(
-          deferreds.map(function (deferred) {
-            return deferred.promise;
-          })
-        );
-      });
+      return Promise.all(
+        deferreds.map(function (deferred) {
+          return deferred.promise;
+        })
+      );
     });
   });
 });

--- a/packages/engine/Specs/Core/ArcGISTiledElevationTerrainProviderSpec.js
+++ b/packages/engine/Specs/Core/ArcGISTiledElevationTerrainProviderSpec.js
@@ -11,8 +11,6 @@ import {
   Math as CesiumMath,
 } from "../../index.js";
 
-import pollToPromise from "../../../../Specs/pollToPromise.js";
-
 describe("Core/ArcGISTiledElevationTerrainProvider", function () {
   const lercTileUrl = "Data/Images/Red16x16.png";
   let availability;
@@ -270,68 +268,52 @@ describe("Core/ArcGISTiledElevationTerrainProvider", function () {
     });
   });
 
-  it("has error event", function () {
-    const provider = new ArcGISTiledElevationTerrainProvider({
-      url: "made/up/url",
-    });
+  it("has error event", async function () {
+    const provider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+      "made/up/url"
+    );
     expect(provider.errorEvent).toBeDefined();
     expect(provider.errorEvent).toBe(provider.errorEvent);
-
-    return provider.readyPromise;
   });
 
-  it("returns reasonable geometric error for various levels", function () {
-    const provider = new ArcGISTiledElevationTerrainProvider({
-      url: "made/up/url",
-    });
-
-    return pollToPromise(function () {
-      return provider.ready;
-    }).then(function () {
-      expect(provider.getLevelMaximumGeometricError(0)).toBeGreaterThan(0.0);
-      expect(provider.getLevelMaximumGeometricError(0)).toEqualEpsilon(
-        provider.getLevelMaximumGeometricError(1) * 2.0,
-        CesiumMath.EPSILON10
-      );
-      expect(provider.getLevelMaximumGeometricError(1)).toEqualEpsilon(
-        provider.getLevelMaximumGeometricError(2) * 2.0,
-        CesiumMath.EPSILON10
-      );
-    });
+  it("returns reasonable geometric error for various levels", async function () {
+    const provider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+      "made/up/url"
+    );
+    expect(provider.getLevelMaximumGeometricError(0)).toBeGreaterThan(0.0);
+    expect(provider.getLevelMaximumGeometricError(0)).toEqualEpsilon(
+      provider.getLevelMaximumGeometricError(1) * 2.0,
+      CesiumMath.EPSILON10
+    );
+    expect(provider.getLevelMaximumGeometricError(1)).toEqualEpsilon(
+      provider.getLevelMaximumGeometricError(2) * 2.0,
+      CesiumMath.EPSILON10
+    );
   });
 
-  it("logo is undefined if credit is not provided", function () {
+  it("logo is undefined if credit is not provided", async function () {
     delete metadata.copyrightText;
-    const provider = new ArcGISTiledElevationTerrainProvider({
-      url: "made/up/url",
-    });
-    return pollToPromise(function () {
-      return provider.ready;
-    }).then(function () {
-      expect(provider.credit).toBeUndefined();
-    });
+    const provider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+      "made/up/url"
+    );
+    expect(provider.credit).toBeUndefined();
   });
 
-  it("logo is defined if credit is provided", function () {
-    const provider = new ArcGISTiledElevationTerrainProvider({
-      url: "made/up/url",
-      credit: "thanks to our awesome made up contributors!",
-    });
-    return pollToPromise(function () {
-      return provider.ready;
-    }).then(function () {
-      expect(provider.credit).toBeDefined();
-    });
+  it("logo is defined if credit is provided", async function () {
+    const provider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+      "made/up/url",
+      {
+        credit: "thanks to our awesome made up contributors!",
+      }
+    );
+    expect(provider.credit).toBeDefined();
   });
 
-  it("does not have a water mask", function () {
-    const provider = new ArcGISTiledElevationTerrainProvider({
-      url: "made/up/url",
-    });
+  it("does not have a water mask", async function () {
+    const provider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+      "made/up/url"
+    );
     expect(provider.hasWaterMask).toBe(false);
-    return provider.readyPromise.catch(function (error) {
-      expect(error).toBeInstanceOf(RuntimeError);
-    });
   });
 
   it("is not ready immediately", function () {
@@ -344,126 +326,88 @@ describe("Core/ArcGISTiledElevationTerrainProvider", function () {
     });
   });
 
-  it("detects WebMercator tiling scheme", function () {
+  it("detects WebMercator tiling scheme", async function () {
     const baseUrl = "made/up/url";
 
-    const terrainProvider = new ArcGISTiledElevationTerrainProvider({
-      url: baseUrl,
-    });
+    const terrainProvider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+      baseUrl
+    );
 
-    return pollToPromise(function () {
-      return terrainProvider.ready;
-    }).then(function () {
-      expect(terrainProvider.tilingScheme).toBeInstanceOf(
-        WebMercatorTilingScheme
-      );
-    });
+    expect(terrainProvider.tilingScheme).toBeInstanceOf(
+      WebMercatorTilingScheme
+    );
   });
 
-  it("detects Geographic tiling scheme", function () {
+  it("detects Geographic tiling scheme", async function () {
     const baseUrl = "made/up/url";
-
     metadata.spatialReference.latestWkid = 4326;
 
-    const terrainProvider = new ArcGISTiledElevationTerrainProvider({
-      url: baseUrl,
-    });
+    const terrainProvider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+      baseUrl
+    );
 
-    return pollToPromise(function () {
-      return terrainProvider.ready;
-    }).then(function () {
-      expect(terrainProvider.tilingScheme).toBeInstanceOf(
-        GeographicTilingScheme
-      );
-    });
+    expect(terrainProvider.tilingScheme).toBeInstanceOf(GeographicTilingScheme);
   });
 
-  it("raises an error if the SRS is not supported", function () {
+  it("fromUrl throws if the SRS is not supported", async function () {
     const baseUrl = "made/up/url";
-
     metadata.spatialReference.latestWkid = 1234;
 
-    const terrainProvider = new ArcGISTiledElevationTerrainProvider({
-      url: baseUrl,
-    });
-
-    return terrainProvider.readyPromise.then(fail).catch(function (error) {
-      expect(error).toBeInstanceOf(RuntimeError);
-    });
+    await expectAsync(
+      ArcGISTiledElevationTerrainProvider.fromUrl(baseUrl)
+    ).toBeRejectedWithError(RuntimeError, "Invalid spatial reference");
   });
 
-  it("raises an error if tileInfo missing", function () {
+  it("fromUrl throws if tileInfo missing", async function () {
     const baseUrl = "made/up/url";
-
     delete metadata.tileInfo;
 
-    const terrainProvider = new ArcGISTiledElevationTerrainProvider({
-      url: baseUrl,
-    });
-
-    return terrainProvider.readyPromise.then(fail).catch(function (error) {
-      expect(error).toBeInstanceOf(RuntimeError);
-    });
+    await expectAsync(
+      ArcGISTiledElevationTerrainProvider.fromUrl(baseUrl)
+    ).toBeRejectedWithError(RuntimeError, "tileInfo is required");
   });
 
-  it("checks availability if TileMap capability exists", function () {
+  it("checks availability if TileMap capability exists", async function () {
     const baseUrl = "made/up/url";
 
-    const terrainProvider = new ArcGISTiledElevationTerrainProvider({
-      url: baseUrl,
-    });
+    const terrainProvider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+      baseUrl
+    );
 
-    return pollToPromise(function () {
-      return terrainProvider.ready;
-    }).then(function () {
-      expect(terrainProvider._hasAvailability).toBe(true);
-      expect(terrainProvider._tilesAvailable).toBeDefined();
-      expect(terrainProvider._tilesAvailabilityLoaded).toBeDefined();
-    });
+    expect(terrainProvider._hasAvailability).toBe(true);
+    expect(terrainProvider._tilesAvailable).toBeDefined();
+    expect(terrainProvider._tilesAvailabilityLoaded).toBeDefined();
   });
 
-  it("does not check availability if TileMap capability is missing", function () {
+  it("does not check availability if TileMap capability is missing", async function () {
     const baseUrl = "made/up/url";
-
     metadata.capabilities = "Image,Mensuration";
 
-    const terrainProvider = new ArcGISTiledElevationTerrainProvider({
-      url: baseUrl,
-    });
+    const terrainProvider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+      baseUrl
+    );
 
-    return pollToPromise(function () {
-      return terrainProvider.ready;
-    }).then(function () {
-      expect(terrainProvider._hasAvailability).toBe(false);
-      expect(terrainProvider._tilesAvailable).toBeUndefined();
-      expect(terrainProvider._tilesAvailablityLoaded).toBeUndefined();
-    });
+    expect(terrainProvider._hasAvailability).toBe(false);
+    expect(terrainProvider._tilesAvailable).toBeUndefined();
+    expect(terrainProvider._tilesAvailablityLoaded).toBeUndefined();
   });
 
   describe("requestTileGeometry", function () {
-    it("provides HeightmapTerrainData", function () {
+    it("provides HeightmapTerrainData", async function () {
       const baseUrl = "made/up/url";
 
-      const terrainProvider = new ArcGISTiledElevationTerrainProvider({
-        url: baseUrl,
-      });
+      const terrainProvider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+        baseUrl
+      );
 
-      return pollToPromise(function () {
-        return terrainProvider.ready;
-      })
-        .then(function () {
-          const promise = terrainProvider.requestTileGeometry(0, 0, 0);
-          RequestScheduler.update();
-          return promise;
-        })
-        .then(function (loadedData) {
-          expect(loadedData).toBeInstanceOf(HeightmapTerrainData);
-        });
+      const promise = terrainProvider.requestTileGeometry(0, 0, 0);
+      RequestScheduler.update();
+      const loadedData = await promise;
+      expect(loadedData).toBeInstanceOf(HeightmapTerrainData);
     });
 
-    it("returns undefined if too many requests are already in progress", function () {
+    it("returns undefined if too many requests are already in progress", async function () {
       const baseUrl = "made/up/url";
-
       const deferreds = [];
 
       Resource._Implementations.createImage = function (
@@ -475,39 +419,35 @@ describe("Core/ArcGISTiledElevationTerrainProvider", function () {
         deferreds.push(deferred);
       };
 
-      const terrainProvider = new ArcGISTiledElevationTerrainProvider({
-        url: baseUrl,
-      });
+      const terrainProvider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+        baseUrl
+      );
 
-      return pollToPromise(function () {
-        return terrainProvider.ready;
-      }).then(function () {
-        let promise;
-        let i;
-        // Make one less request to account for the additional availability request.
-        for (i = 0; i < RequestScheduler.maximumRequestsPerServer - 1; ++i) {
-          const request = new Request({
-            throttle: true,
-            throttleByServer: true,
-          });
-          promise = terrainProvider.requestTileGeometry(0, 0, 0, request);
-        }
-        RequestScheduler.update();
-        expect(promise).toBeDefined();
+      let promise;
+      let i;
+      // Make one less request to account for the additional availability request.
+      for (i = 0; i < RequestScheduler.maximumRequestsPerServer - 1; ++i) {
+        const request = new Request({
+          throttle: true,
+          throttleByServer: true,
+        });
+        promise = terrainProvider.requestTileGeometry(0, 0, 0, request);
+      }
+      RequestScheduler.update();
+      expect(promise).toBeDefined();
 
-        promise = terrainProvider.requestTileGeometry(0, 0, 0, createRequest());
-        expect(promise).toBeUndefined();
+      promise = terrainProvider.requestTileGeometry(0, 0, 0, createRequest());
+      expect(promise).toBeUndefined();
 
-        for (i = 0; i < deferreds.length; ++i) {
-          deferreds[i].resolve();
-        }
+      for (i = 0; i < deferreds.length; ++i) {
+        deferreds[i].resolve();
+      }
 
-        return Promise.all(
-          deferreds.map(function (deferred) {
-            return deferred.promise;
-          })
-        );
-      });
+      await Promise.all(
+        deferreds.map(function (deferred) {
+          return deferred.promise;
+        })
+      );
     });
   });
 });

--- a/packages/engine/Specs/Core/ArcGISTiledElevationTerrainProviderSpec.js
+++ b/packages/engine/Specs/Core/ArcGISTiledElevationTerrainProviderSpec.js
@@ -1,6 +1,5 @@
 import {
   ArcGISTiledElevationTerrainProvider,
-  DeveloperError,
   GeographicTilingScheme,
   HeightmapTerrainData,
   Request,
@@ -204,8 +203,7 @@ describe("Core/ArcGISTiledElevationTerrainProvider", function () {
   it("fromUrl throws without url", async function () {
     await expectAsync(
       ArcGISTiledElevationTerrainProvider.fromUrl()
-    ).toBeRejectedWithError(
-      DeveloperError,
+    ).toBeRejectedWithDeveloperError(
       "url is required, actual value was undefined"
     );
   });

--- a/packages/engine/Specs/Core/CesiumTerrainProviderSpec.js
+++ b/packages/engine/Specs/Core/CesiumTerrainProviderSpec.js
@@ -1,6 +1,5 @@
 import {
   CesiumTerrainProvider,
-  Credit,
   Ellipsoid,
   GeographicTilingScheme,
   getAbsoluteUri,
@@ -11,9 +10,9 @@ import {
   Request,
   RequestScheduler,
   Resource,
-  RuntimeError,
   TerrainProvider,
 } from "../../index.js";
+import pollToPromise from "../../../../Specs/pollToPromise.js";
 
 describe("Core/CesiumTerrainProvider", function () {
   beforeEach(function () {
@@ -188,201 +187,399 @@ describe("Core/CesiumTerrainProvider", function () {
     ).toBeRejectedWithError("my message");
   });
 
-  it("uses geographic tiling scheme by default", async function () {
-    returnHeightmapTileJson();
+  it("resolves readyPromise", function () {
+    const provider = new CesiumTerrainProvider({
+      url: "made/up/url",
+    });
 
-    const provider = await CesiumTerrainProvider.fromUrl("made/up/url");
-    expect(provider.tilingScheme).toBeInstanceOf(GeographicTilingScheme);
+    return provider.readyPromise.then(function (result) {
+      expect(result).toBe(true);
+      expect(provider.ready).toBe(true);
+    });
   });
 
-  it("can use a custom ellipsoid", async function () {
+  it("resolves readyPromise when url promise is used", function () {
+    const provider = new CesiumTerrainProvider({
+      url: Promise.resolve("made/up/url"),
+    });
+
+    return provider.readyPromise.then(function (result) {
+      expect(result).toBe(true);
+      expect(provider.ready).toBe(true);
+    });
+  });
+
+  it("resolves readyPromise with Resource", function () {
+    const resource = new Resource({
+      url: "made/up/url",
+    });
+
+    const provider = new CesiumTerrainProvider({
+      url: resource,
+    });
+
+    return provider.readyPromise.then(function (result) {
+      expect(result).toBe(true);
+      expect(provider.ready).toBe(true);
+    });
+  });
+
+  it("rejects readyPromise when url rejects", function () {
+    const provider = new CesiumTerrainProvider({
+      url: Promise.reject(new Error("my message")),
+    });
+    return provider.readyPromise
+      .then(function () {
+        fail("should not resolve");
+      })
+      .catch(function (result) {
+        expect(result.message).toBe("my message");
+        expect(provider.ready).toBe(false);
+      });
+  });
+
+  it("uses geographic tiling scheme by default", function () {
+    returnHeightmapTileJson();
+
+    const provider = new CesiumTerrainProvider({
+      url: "made/up/url",
+    });
+
+    return pollToPromise(function () {
+      return provider.ready;
+    }).then(function () {
+      expect(provider.tilingScheme).toBeInstanceOf(GeographicTilingScheme);
+    });
+  });
+
+  it("can use a custom ellipsoid", function () {
     returnHeightmapTileJson();
 
     const ellipsoid = new Ellipsoid(1, 2, 3);
-    const provider = await CesiumTerrainProvider.fromUrl("made/up/url", {
+    const provider = new CesiumTerrainProvider({
+      url: "made/up/url",
       ellipsoid: ellipsoid,
     });
 
-    expect(provider.tilingScheme.ellipsoid).toEqual(ellipsoid);
+    return pollToPromise(function () {
+      return provider.ready;
+    }).then(function () {
+      expect(provider.tilingScheme.ellipsoid).toEqual(ellipsoid);
+    });
   });
 
-  it("has error event", async function () {
-    const provider = await CesiumTerrainProvider.fromUrl("made/up/url");
-    expect(provider.errorEvent).toBeDefined();
-    expect(provider.errorEvent).toBe(provider.errorEvent);
+  it("has error event", function () {
+    const provider = new CesiumTerrainProvider({
+      url: "made/up/url",
+    });
+    return pollToPromise(function () {
+      return provider.ready;
+    }).then(function () {
+      expect(provider.errorEvent).toBeDefined();
+      expect(provider.errorEvent).toBe(provider.errorEvent);
+    });
   });
 
-  it("returns reasonable geometric error for various levels", async function () {
+  it("returns reasonable geometric error for various levels", function () {
     returnQuantizedMeshTileJson();
 
-    const provider = await CesiumTerrainProvider.fromUrl("made/up/url");
-    expect(provider.getLevelMaximumGeometricError(0)).toBeGreaterThan(0.0);
-    expect(provider.getLevelMaximumGeometricError(0)).toEqualEpsilon(
-      provider.getLevelMaximumGeometricError(1) * 2.0,
-      CesiumMath.EPSILON10
-    );
-    expect(provider.getLevelMaximumGeometricError(1)).toEqualEpsilon(
-      provider.getLevelMaximumGeometricError(2) * 2.0,
-      CesiumMath.EPSILON10
-    );
+    const provider = new CesiumTerrainProvider({
+      url: "made/up/url",
+    });
+
+    return provider.readyPromise.then(function () {
+      expect(provider.getLevelMaximumGeometricError(0)).toBeGreaterThan(0.0);
+      expect(provider.getLevelMaximumGeometricError(0)).toEqualEpsilon(
+        provider.getLevelMaximumGeometricError(1) * 2.0,
+        CesiumMath.EPSILON10
+      );
+      expect(provider.getLevelMaximumGeometricError(1)).toEqualEpsilon(
+        provider.getLevelMaximumGeometricError(2) * 2.0,
+        CesiumMath.EPSILON10
+      );
+    });
   });
 
-  it("credit is undefined if credit is not provided", async function () {
+  it("credit is undefined if credit option is not provided", function () {
     returnHeightmapTileJson();
 
-    const provider = await CesiumTerrainProvider.fromUrl("made/up/url");
-    expect(provider.credit).toBeUndefined();
+    const provider = new CesiumTerrainProvider({
+      url: "made/up/url",
+    });
+
+    return pollToPromise(function () {
+      return provider.ready;
+    }).then(function () {
+      expect(provider.credit).toBeUndefined();
+    });
   });
 
-  it("credit is defined if credit is provided", async function () {
+  it("credit is defined if credit option is provided", function () {
     returnHeightmapTileJson();
 
-    const provider = await CesiumTerrainProvider.fromUrl("made/up/url", {
+    const provider = new CesiumTerrainProvider({
+      url: "made/up/url",
       credit: "thanks to our awesome made up contributors!",
     });
 
-    expect(provider.credit).toBeInstanceOf(Credit);
+    return pollToPromise(function () {
+      return provider.ready;
+    }).then(function () {
+      expect(provider.credit).toBeDefined();
+    });
   });
 
-  it("has a water mask", async function () {
+  it("has a water mask", function () {
     returnHeightmapTileJson();
 
-    const provider = await CesiumTerrainProvider.fromUrl("made/up/url");
-    expect(provider.hasWaterMask).toBe(true);
+    const provider = new CesiumTerrainProvider({
+      url: "made/up/url",
+    });
+
+    return pollToPromise(function () {
+      return provider.ready;
+    }).then(function () {
+      expect(provider.hasWaterMask).toBe(true);
+    });
   });
 
-  it("has vertex normals", async function () {
+  it("has vertex normals", function () {
     returnOctVertexNormalTileJson();
 
-    const provider = await CesiumTerrainProvider.fromUrl("made/up/url", {
+    const provider = new CesiumTerrainProvider({
+      url: "made/up/url",
       requestVertexNormals: true,
     });
 
-    expect(provider.requestVertexNormals).toBe(true);
-    expect(provider.hasVertexNormals).toBe(true);
+    return pollToPromise(function () {
+      return provider.ready;
+    }).then(function () {
+      expect(provider.requestVertexNormals).toBe(true);
+      expect(provider.hasVertexNormals).toBe(true);
+    });
   });
 
-  it("does not request vertex normals", async function () {
+  it("does not request vertex normals", function () {
     returnOctVertexNormalTileJson();
 
-    const provider = await CesiumTerrainProvider.fromUrl("made/up/url", {
+    const provider = new CesiumTerrainProvider({
+      url: "made/up/url",
       requestVertexNormals: false,
     });
 
-    expect(provider.requestVertexNormals).toBe(false);
-    expect(provider.hasVertexNormals).toBe(false);
+    return pollToPromise(function () {
+      return provider.ready;
+    }).then(function () {
+      expect(provider.requestVertexNormals).toBe(false);
+      expect(provider.hasVertexNormals).toBe(false);
+    });
   });
 
-  it("requests parent layer.json", async function () {
+  it("requests parent layer.json", function () {
     returnParentUrlTileJson();
 
-    const provider = await CesiumTerrainProvider.fromUrl("made/up/url", {
+    const provider = new CesiumTerrainProvider({
+      url: "made/up/url",
       requestVertexNormals: true,
       requestWaterMask: true,
     });
 
-    expect(provider._tileCredits[0].html).toBe(
-      "This is a child tileset! This amazing data is courtesy The Amazing Data Source!"
-    );
-    expect(provider.requestVertexNormals).toBe(true);
-    expect(provider.requestWaterMask).toBe(true);
-    expect(provider.hasVertexNormals).toBe(false); // Neither tileset has them
-    expect(provider.hasWaterMask).toBe(true); // The child tileset has them
-    expect(provider.availability.isTileAvailable(1, 2, 1)).toBe(true); // Both have this
-    expect(provider.availability.isTileAvailable(1, 3, 1)).toBe(true); // Parent has this, but child doesn't
-    expect(provider.availability.isTileAvailable(2, 0, 0)).toBe(false); // Neither has this
+    return provider.readyPromise.then(function () {
+      expect(provider._tileCredits[0].html).toBe(
+        "This is a child tileset! This amazing data is courtesy The Amazing Data Source!"
+      );
+      expect(provider.requestVertexNormals).toBe(true);
+      expect(provider.requestWaterMask).toBe(true);
+      expect(provider.hasVertexNormals).toBe(false); // Neither tileset has them
+      expect(provider.hasWaterMask).toBe(true); // The child tileset has them
+      expect(provider.availability.isTileAvailable(1, 2, 1)).toBe(true); // Both have this
+      expect(provider.availability.isTileAvailable(1, 3, 1)).toBe(true); // Parent has this, but child doesn't
+      expect(provider.availability.isTileAvailable(2, 0, 0)).toBe(false); // Neither has this
 
-    const layers = provider._layers;
-    expect(layers.length).toBe(2);
-    expect(layers[0].hasVertexNormals).toBe(false);
-    expect(layers[0].hasWaterMask).toBe(true);
-    expect(layers[0].availability.isTileAvailable(1, 2, 1)).toBe(true);
-    expect(layers[0].availability.isTileAvailable(1, 3, 1)).toBe(false);
-    expect(layers[0].availability.isTileAvailable(2, 0, 0)).toBe(false);
-    expect(layers[1].hasVertexNormals).toBe(false);
-    expect(layers[1].hasWaterMask).toBe(false);
-    expect(layers[1].availability.isTileAvailable(1, 2, 1)).toBe(true);
-    expect(layers[1].availability.isTileAvailable(1, 3, 1)).toBe(true);
-    expect(layers[1].availability.isTileAvailable(2, 0, 0)).toBe(false);
+      const layers = provider._layers;
+      expect(layers.length).toBe(2);
+      expect(layers[0].hasVertexNormals).toBe(false);
+      expect(layers[0].hasWaterMask).toBe(true);
+      expect(layers[0].availability.isTileAvailable(1, 2, 1)).toBe(true);
+      expect(layers[0].availability.isTileAvailable(1, 3, 1)).toBe(false);
+      expect(layers[0].availability.isTileAvailable(2, 0, 0)).toBe(false);
+      expect(layers[1].hasVertexNormals).toBe(false);
+      expect(layers[1].hasWaterMask).toBe(false);
+      expect(layers[1].availability.isTileAvailable(1, 2, 1)).toBe(true);
+      expect(layers[1].availability.isTileAvailable(1, 3, 1)).toBe(true);
+      expect(layers[1].availability.isTileAvailable(2, 0, 0)).toBe(false);
+    });
   });
 
-  it("fromUrl throws an error if layer.json does not specify a format", async function () {
+  it("raises an error if layer.json does not specify a format", function () {
     returnTileJson("Data/CesiumTerrainTileJson/NoFormat.tile.json");
 
-    await expectAsync(
-      CesiumTerrainProvider.fromUrl("made/up/url")
-    ).toBeRejectedWithError(
-      RuntimeError,
-      "The tile format is not specified in the layer.json file."
-    );
+    const provider = new CesiumTerrainProvider({
+      url: "made/up/url",
+    });
+
+    let errorListenerCalled = false;
+    const errorMatcher = function (event) {
+      expect(event.message).toContain("format is not specified");
+      errorListenerCalled = true;
+      provider.errorEvent.removeEventListener(errorMatcher);
+    };
+
+    provider.errorEvent.addEventListener(errorMatcher);
+
+    return provider.readyPromise.then(fail).catch((e) => {
+      expect(errorListenerCalled).toBe(true);
+      expect(e.message).toContain(
+        "The tile format is not specified in the layer.json file."
+      );
+    });
   });
 
-  it("fromUrl throws an error if layer.json specifies an unknown format", async function () {
+  it("raises an error if layer.json specifies an unknown format", function () {
     returnTileJson("Data/CesiumTerrainTileJson/InvalidFormat.tile.json");
 
-    await expectAsync(
-      CesiumTerrainProvider.fromUrl("made/up/url")
-    ).toBeRejectedWithError(
-      RuntimeError,
-      'The tile format "awesometron-9000.0" is invalid or not supported.'
-    );
+    const provider = new CesiumTerrainProvider({
+      url: "made/up/url",
+    });
+
+    let errorListenerCalled = false;
+    const errorMatcher = function (event) {
+      expect(event.message).toContain("invalid or not supported");
+      errorListenerCalled = true;
+      provider.errorEvent.removeEventListener(errorMatcher);
+    };
+
+    provider.errorEvent.addEventListener(errorMatcher);
+
+    return provider.readyPromise.then(fail).catch((e) => {
+      expect(errorListenerCalled).toBe(true);
+      expect(e.message).toContain(
+        'The tile format "awesometron-9000.0" is invalid or not supported.'
+      );
+    });
   });
 
-  it("fromUrl throws an error if layer.json does not specify quantized-mesh 1.x format", async function () {
+  it("raises an error if layer.json does not specify quantized-mesh 1.x format", function () {
     returnTileJson("Data/CesiumTerrainTileJson/QuantizedMesh2.0.tile.json");
 
-    await expectAsync(
-      CesiumTerrainProvider.fromUrl("made/up/url")
-    ).toBeRejectedWithError(
-      RuntimeError,
-      'The tile format "quantized-mesh-2.0" is invalid or not supported.'
-    );
+    const provider = new CesiumTerrainProvider({
+      url: "made/up/url",
+    });
+
+    let errorListenerCalled = false;
+    const errorMatcher = function (event) {
+      expect(event.message).toContain("invalid or not supported");
+      errorListenerCalled = true;
+      provider.errorEvent.removeEventListener(errorMatcher);
+    };
+
+    provider.errorEvent.addEventListener(errorMatcher);
+
+    return provider.readyPromise.then(fail).catch((e) => {
+      expect(errorListenerCalled).toBe(true);
+      expect(e.message).toContain(
+        'The tile format "quantized-mesh-2.0" is invalid or not supported.'
+      );
+    });
   });
 
-  it("from supports quantized-mesh1.x minor versions", async function () {
+  it("supports quantized-mesh1.x minor versions", function () {
     returnTileJson("Data/CesiumTerrainTileJson/QuantizedMesh1.1.tile.json");
 
-    await expectAsync(
-      CesiumTerrainProvider.fromUrl("made/up/url")
-    ).toBeResolved();
+    const provider = new CesiumTerrainProvider({
+      url: "made/up/url",
+    });
+
+    const errorListener = jasmine.createSpy("error");
+    provider.errorEvent.addEventListener(errorListener);
+
+    return pollToPromise(function () {
+      return provider.ready;
+    }).then(function () {
+      expect(errorListener).not.toHaveBeenCalled();
+    });
   });
 
-  it("fromUrl throws an error if layer.json does not specify a tiles property", async function () {
+  it("raises an error if layer.json does not specify a tiles property", function () {
     returnTileJson("Data/CesiumTerrainTileJson/NoTiles.tile.json");
 
-    await expectAsync(
-      CesiumTerrainProvider.fromUrl("made/up/url")
-    ).toBeRejectedWithError(
-      RuntimeError,
-      "The layer.json file does not specify any tile URL templates."
-    );
+    const provider = new CesiumTerrainProvider({
+      url: "made/up/url",
+    });
+
+    let errorListenerCalled = false;
+    const errorMatcher = function (event) {
+      expect(event.message).toContain(
+        "does not specify any tile URL templates"
+      );
+      errorListenerCalled = true;
+      provider.errorEvent.removeEventListener(errorMatcher);
+    };
+
+    provider.errorEvent.addEventListener(errorMatcher);
+
+    return provider.readyPromise.then(fail).catch((e) => {
+      expect(errorListenerCalled).toBe(true);
+      expect(e.message).toContain(
+        "The layer.json file does not specify any tile URL templates."
+      );
+    });
   });
 
-  it("fromUrl throws an error if layer.json tiles property is an empty array", async function () {
+  it("raises an error if layer.json tiles property is an empty array", function () {
     returnTileJson("Data/CesiumTerrainTileJson/EmptyTilesArray.tile.json");
 
-    await expectAsync(
-      CesiumTerrainProvider.fromUrl("made/up/url")
-    ).toBeRejectedWithError(
-      RuntimeError,
-      "The layer.json file does not specify any tile URL templates."
-    );
+    const provider = new CesiumTerrainProvider({
+      url: "made/up/url",
+    });
+
+    let errorListenerCalled = false;
+    const errorMatcher = function (event) {
+      expect(event.message).toContain(
+        "does not specify any tile URL templates"
+      );
+      errorListenerCalled = true;
+      provider.errorEvent.removeEventListener(errorMatcher);
+    };
+
+    provider.errorEvent.addEventListener(errorMatcher);
+
+    return provider.readyPromise.then(fail).catch((e) => {
+      expect(errorListenerCalled).toBe(true);
+      expect(e.message).toContain(
+        "The layer.json file does not specify any tile URL templates."
+      );
+    });
   });
 
-  it("uses attribution specified in layer.json", async function () {
+  it("uses attribution specified in layer.json", function () {
     returnTileJson("Data/CesiumTerrainTileJson/WithAttribution.tile.json");
 
-    const provider = await CesiumTerrainProvider.fromUrl("made/up/url");
-    expect(provider._tileCredits[0].html).toBe(
-      "This amazing data is courtesy The Amazing Data Source!"
-    );
+    const provider = new CesiumTerrainProvider({
+      url: "made/up/url",
+    });
+
+    return pollToPromise(function () {
+      return provider.ready;
+    }).then(function () {
+      expect(provider._tileCredits[0].html).toBe(
+        "This amazing data is courtesy The Amazing Data Source!"
+      );
+    });
   });
 
-  it("do not add blank attribution if layer.json does not have one", async function () {
+  it("do not add blank attribution if layer.json does not have one", function () {
     returnTileJson("Data/CesiumTerrainTileJson/WaterMask.tile.json");
 
-    const provider = await CesiumTerrainProvider.fromUrl("made/up/url");
-    expect(provider._tileCredit).toBeUndefined();
+    const provider = new CesiumTerrainProvider({
+      url: "made/up/url",
+    });
+
+    return pollToPromise(function () {
+      return provider.ready;
+    }).then(function () {
+      expect(provider._tileCredit).toBeUndefined();
+    });
   });
 
   it("The undefined availability tile is returned at level 0", function () {
@@ -454,71 +651,85 @@ describe("Core/CesiumTerrainProvider", function () {
   });
 
   describe("requestTileGeometry", function () {
-    async function makeRequest(provider, x, y, z) {
-      try {
-        await provider.requestTileGeometry(x, y, z);
-      } catch {
-        // Request is expect to fail
-      }
-    }
-
-    it("uses multiple urls specified in layer.json", async function () {
+    it("uses multiple urls specified in layer.json", function () {
       returnTileJson("Data/CesiumTerrainTileJson/MultipleUrls.tile.json");
+
+      const provider = new CesiumTerrainProvider({
+        url: "made/up/url",
+      });
+
       spyOn(Resource._Implementations, "loadWithXhr").and.callThrough();
 
-      const provider = await CesiumTerrainProvider.fromUrl("made/up/url");
-
-      await makeRequest(provider, 0, 0, 0);
-      expect(
-        Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
-      ).toContain("foo0.com");
-
-      await makeRequest(provider, 1, 0, 0);
-      expect(
-        Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
-      ).toContain("foo1.com");
-
-      await makeRequest(provider, 1, -1, 0);
-      expect(
-        Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
-      ).toContain("foo2.com");
-
-      await makeRequest(provider, 1, 0, 1);
-      expect(
-        Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
-      ).toContain("foo3.com");
+      return provider.readyPromise
+        .then(function () {
+          return provider.requestTileGeometry(0, 0, 0);
+        })
+        .catch(function () {
+          expect(
+            Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
+          ).toContain("foo0.com");
+          return provider.requestTileGeometry(1, 0, 0);
+        })
+        .catch(function () {
+          expect(
+            Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
+          ).toContain("foo1.com");
+          return provider.requestTileGeometry(1, -1, 0);
+        })
+        .catch(function () {
+          expect(
+            Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
+          ).toContain("foo2.com");
+          return provider.requestTileGeometry(1, 0, 1);
+        })
+        .catch(function () {
+          expect(
+            Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
+          ).toContain("foo3.com");
+        });
     });
 
-    it("supports scheme-less template URLs in layer.json resolved with absolute URL", async function () {
+    it("supports scheme-less template URLs in layer.json resolved with absolute URL", function () {
       returnTileJson("Data/CesiumTerrainTileJson/MultipleUrls.tile.json");
 
       const url = getAbsoluteUri("Data/CesiumTerrainTileJson");
+
+      const provider = new CesiumTerrainProvider({
+        url: url,
+      });
+
       spyOn(Resource._Implementations, "loadWithXhr").and.callThrough();
 
-      const provider = await CesiumTerrainProvider.fromUrl(url);
-
-      await makeRequest(provider, 0, 0, 0);
-      expect(
-        Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
-      ).toContain("foo0.com");
-
-      await makeRequest(provider, 1, 0, 0);
-      expect(
-        Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
-      ).toContain("foo1.com");
-
-      await makeRequest(provider, 1, -1, 0);
-      expect(
-        Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
-      ).toContain("foo2.com");
-
-      await makeRequest(provider, 1, 0, 1);
-      expect(
-        Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
-      ).toContain("foo3.com");
+      return provider.readyPromise
+        .then(function () {
+          return provider.requestTileGeometry(0, 0, 0);
+        })
+        .catch(function () {
+          expect(
+            Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
+          ).toContain("foo0.com");
+          return provider.requestTileGeometry(1, 0, 0);
+        })
+        .catch(function () {
+          expect(
+            Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
+          ).toContain("foo1.com");
+          return provider.requestTileGeometry(1, -1, 0);
+        })
+        .catch(function () {
+          expect(
+            Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
+          ).toContain("foo2.com");
+          return provider.requestTileGeometry(1, 0, 1);
+        })
+        .catch(function () {
+          expect(
+            Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
+          ).toContain("foo3.com");
+        });
     });
 
-    it("provides HeightmapTerrainData", async function () {
+    it("provides HeightmapTerrainData", function () {
       Resource._Implementations.loadWithXhr = function (
         url,
         responseType,
@@ -541,11 +752,12 @@ describe("Core/CesiumTerrainProvider", function () {
 
       returnHeightmapTileJson();
 
-      const loadedData = await waitForTile(0, 0, 0, false, false);
-      expect(loadedData).toBeInstanceOf(HeightmapTerrainData);
+      return waitForTile(0, 0, 0, false, false, function (loadedData) {
+        expect(loadedData).toBeInstanceOf(HeightmapTerrainData);
+      });
     });
 
-    it("provides QuantizedMeshTerrainData", async function () {
+    it("provides QuantizedMeshTerrainData", function () {
       Resource._Implementations.loadWithXhr = function (
         url,
         responseType,
@@ -567,11 +779,12 @@ describe("Core/CesiumTerrainProvider", function () {
 
       returnQuantizedMeshTileJson();
 
-      const loadedData = await waitForTile(0, 0, 0, false, false);
-      expect(loadedData).toBeInstanceOf(QuantizedMeshTerrainData);
+      return waitForTile(0, 0, 0, false, false, function (loadedData) {
+        expect(loadedData).toBeInstanceOf(QuantizedMeshTerrainData);
+      });
     });
 
-    it("provides QuantizedMeshTerrainData with 32bit indices", async function () {
+    it("provides QuantizedMeshTerrainData with 32bit indices", function () {
       Resource._Implementations.loadWithXhr = function (
         url,
         responseType,
@@ -593,12 +806,13 @@ describe("Core/CesiumTerrainProvider", function () {
 
       returnQuantizedMeshTileJson();
 
-      const loadedData = await waitForTile(0, 0, 0, false, false);
-      expect(loadedData).toBeInstanceOf(QuantizedMeshTerrainData);
-      expect(loadedData._indices.BYTES_PER_ELEMENT).toBe(4);
+      return waitForTile(0, 0, 0, false, false, function (loadedData) {
+        expect(loadedData).toBeInstanceOf(QuantizedMeshTerrainData);
+        expect(loadedData._indices.BYTES_PER_ELEMENT).toBe(4);
+      });
     });
 
-    it("provides QuantizedMeshTerrainData with VertexNormals", async function () {
+    it("provides QuantizedMeshTerrainData with VertexNormals", function () {
       Resource._Implementations.loadWithXhr = function (
         url,
         responseType,
@@ -620,12 +834,13 @@ describe("Core/CesiumTerrainProvider", function () {
 
       returnVertexNormalTileJson();
 
-      const loadedData = await waitForTile(0, 0, 0, true, false);
-      expect(loadedData).toBeInstanceOf(QuantizedMeshTerrainData);
-      expect(loadedData._encodedNormals).toBeDefined();
+      return waitForTile(0, 0, 0, true, false, function (loadedData) {
+        expect(loadedData).toBeInstanceOf(QuantizedMeshTerrainData);
+        expect(loadedData._encodedNormals).toBeDefined();
+      });
     });
 
-    it("provides QuantizedMeshTerrainData with WaterMask", async function () {
+    it("provides QuantizedMeshTerrainData with WaterMask", function () {
       Resource._Implementations.loadWithXhr = function (
         url,
         responseType,
@@ -647,12 +862,13 @@ describe("Core/CesiumTerrainProvider", function () {
 
       returnWaterMaskTileJson();
 
-      const loadedData = await waitForTile(0, 0, 0, false, true);
-      expect(loadedData).toBeInstanceOf(QuantizedMeshTerrainData);
-      expect(loadedData._waterMask).toBeDefined();
+      return waitForTile(0, 0, 0, false, true, function (loadedData) {
+        expect(loadedData).toBeInstanceOf(QuantizedMeshTerrainData);
+        expect(loadedData._waterMask).toBeDefined();
+      });
     });
 
-    it("provides QuantizedMeshTerrainData with VertexNormals and WaterMask", async function () {
+    it("provides QuantizedMeshTerrainData with VertexNormals and WaterMask", function () {
       Resource._Implementations.loadWithXhr = function (
         url,
         responseType,
@@ -674,13 +890,14 @@ describe("Core/CesiumTerrainProvider", function () {
 
       returnWaterMaskTileJson();
 
-      const loadedData = await waitForTile(0, 0, 0, true, true);
-      expect(loadedData).toBeInstanceOf(QuantizedMeshTerrainData);
-      expect(loadedData._encodedNormals).toBeDefined();
-      expect(loadedData._waterMask).toBeDefined();
+      return waitForTile(0, 0, 0, true, true, function (loadedData) {
+        expect(loadedData).toBeInstanceOf(QuantizedMeshTerrainData);
+        expect(loadedData._encodedNormals).toBeDefined();
+        expect(loadedData._waterMask).toBeDefined();
+      });
     });
 
-    it("provides QuantizedMeshTerrainData with OctVertexNormals", async function () {
+    it("provides QuantizedMeshTerrainData with OctVertexNormals", function () {
       Resource._Implementations.loadWithXhr = function (
         url,
         responseType,
@@ -702,12 +919,13 @@ describe("Core/CesiumTerrainProvider", function () {
 
       returnOctVertexNormalTileJson();
 
-      const loadedData = await waitForTile(0, 0, 0, true, false);
-      expect(loadedData).toBeInstanceOf(QuantizedMeshTerrainData);
-      expect(loadedData._encodedNormals).toBeDefined();
+      return waitForTile(0, 0, 0, true, false, function (loadedData) {
+        expect(loadedData).toBeInstanceOf(QuantizedMeshTerrainData);
+        expect(loadedData._encodedNormals).toBeDefined();
+      });
     });
 
-    it("provides QuantizedMeshTerrainData with VertexNormals and unknown extensions", async function () {
+    it("provides QuantizedMeshTerrainData with VertexNormals and unknown extensions", function () {
       Resource._Implementations.loadWithXhr = function (
         url,
         responseType,
@@ -729,12 +947,13 @@ describe("Core/CesiumTerrainProvider", function () {
 
       returnVertexNormalTileJson();
 
-      const loadedData = await waitForTile(0, 0, 0, true, false);
-      expect(loadedData).toBeInstanceOf(QuantizedMeshTerrainData);
-      expect(loadedData._encodedNormals).toBeDefined();
+      return waitForTile(0, 0, 0, true, false, function (loadedData) {
+        expect(loadedData).toBeInstanceOf(QuantizedMeshTerrainData);
+        expect(loadedData._encodedNormals).toBeDefined();
+      });
     });
 
-    it("provides QuantizedMeshTerrainData with OctVertexNormals and unknown extensions", async function () {
+    it("provides QuantizedMeshTerrainData with OctVertexNormals and unknown extensions", function () {
       Resource._Implementations.loadWithXhr = function (
         url,
         responseType,
@@ -756,12 +975,13 @@ describe("Core/CesiumTerrainProvider", function () {
 
       returnOctVertexNormalTileJson();
 
-      const loadedData = await waitForTile(0, 0, 0, true, false);
-      expect(loadedData).toBeInstanceOf(QuantizedMeshTerrainData);
-      expect(loadedData._encodedNormals).toBeDefined();
+      return waitForTile(0, 0, 0, true, false, function (loadedData) {
+        expect(loadedData).toBeInstanceOf(QuantizedMeshTerrainData);
+        expect(loadedData._encodedNormals).toBeDefined();
+      });
     });
 
-    it("provides QuantizedMeshTerrainData with unknown extension", async function () {
+    it("provides QuantizedMeshTerrainData with unknown extension", function () {
       Resource._Implementations.loadWithXhr = function (
         url,
         responseType,
@@ -783,11 +1003,12 @@ describe("Core/CesiumTerrainProvider", function () {
 
       returnOctVertexNormalTileJson();
 
-      const loadedData = await waitForTile(0, 0, 0, false, false);
-      expect(loadedData).toBeInstanceOf(QuantizedMeshTerrainData);
+      return waitForTile(0, 0, 0, false, false, function (loadedData) {
+        expect(loadedData).toBeInstanceOf(QuantizedMeshTerrainData);
+      });
     });
 
-    it("provides QuantizedMeshTerrainData with Metadata availability", async function () {
+    it("provides QuantizedMeshTerrainData with Metadata availability", function () {
       Resource._Implementations.loadWithXhr = function (
         url,
         responseType,
@@ -809,21 +1030,37 @@ describe("Core/CesiumTerrainProvider", function () {
 
       returnMetadataAvailabilityTileJson();
 
-      const terrainProvider = await CesiumTerrainProvider.fromUrl(
-        "made/up/url"
-      );
-      expect(terrainProvider.hasMetadata).toBe(true);
-      expect(terrainProvider._layers[0].availabilityLevels).toBe(10);
-      expect(terrainProvider.availability.isTileAvailable(0, 0, 0)).toBe(true);
-      expect(terrainProvider.availability.isTileAvailable(0, 1, 0)).toBe(true);
-      expect(terrainProvider.availability.isTileAvailable(1, 0, 0)).toBe(false);
+      const terrainProvider = new CesiumTerrainProvider({
+        url: "made/up/url",
+      });
 
-      const loadedData = await terrainProvider.requestTileGeometry(0, 0, 0);
-      expect(loadedData).toBeInstanceOf(QuantizedMeshTerrainData);
-      expect(terrainProvider.availability.isTileAvailable(1, 0, 0)).toBe(true);
+      return pollToPromise(function () {
+        return terrainProvider.ready;
+      })
+        .then(function () {
+          expect(terrainProvider.hasMetadata).toBe(true);
+          expect(terrainProvider._layers[0].availabilityLevels).toBe(10);
+          expect(terrainProvider.availability.isTileAvailable(0, 0, 0)).toBe(
+            true
+          );
+          expect(terrainProvider.availability.isTileAvailable(0, 1, 0)).toBe(
+            true
+          );
+          expect(terrainProvider.availability.isTileAvailable(1, 0, 0)).toBe(
+            false
+          );
+
+          return terrainProvider.requestTileGeometry(0, 0, 0);
+        })
+        .then(function (loadedData) {
+          expect(loadedData).toBeInstanceOf(QuantizedMeshTerrainData);
+          expect(terrainProvider.availability.isTileAvailable(1, 0, 0)).toBe(
+            true
+          );
+        });
     });
 
-    it("returns undefined if too many requests are already in progress", async function () {
+    it("returns undefined if too many requests are already in progress", function () {
       const baseUrl = "made/up/url";
 
       const deferreds = [];
@@ -843,39 +1080,40 @@ describe("Core/CesiumTerrainProvider", function () {
 
       returnHeightmapTileJson();
 
-      const terrainProvider = await CesiumTerrainProvider.fromUrl(baseUrl);
+      const terrainProvider = new CesiumTerrainProvider({
+        url: baseUrl,
+      });
 
-      let i;
-      const promises = [];
-      for (i = 0; i < RequestScheduler.maximumRequestsPerServer; ++i) {
-        const request = new Request({
-          throttle: true,
-          throttleByServer: true,
-        });
-        promises.push(
-          expectAsync(
-            terrainProvider.requestTileGeometry(0, 0, 0, request)
-          ).toBeRejectedWithError(RuntimeError, "Mesh buffer doesn't exist.")
-        );
-      }
-      RequestScheduler.update();
+      return pollToPromise(function () {
+        return terrainProvider.ready;
+      }).then(function () {
+        let promise;
+        let i;
+        for (i = 0; i < RequestScheduler.maximumRequestsPerServer; ++i) {
+          const request = new Request({
+            throttle: true,
+            throttleByServer: true,
+          });
+          promise = terrainProvider
+            .requestTileGeometry(0, 0, 0, request)
+            .then(fail)
+            .catch((e) => {
+              expect(e.message).toContain("Mesh buffer doesn't exist.");
+            });
+        }
+        RequestScheduler.update();
+        expect(promise).toBeDefined();
 
-      const promise = terrainProvider.requestTileGeometry(
-        0,
-        0,
-        0,
-        createRequest()
-      );
-      expect(promise).toBeUndefined();
+        promise = terrainProvider.requestTileGeometry(0, 0, 0, createRequest());
+        expect(promise).toBeUndefined();
 
-      for (i = 0; i < deferreds.length; ++i) {
-        deferreds[i].resolve();
-      }
-
-      return Promise.all(promises);
+        for (i = 0; i < deferreds.length; ++i) {
+          deferreds[i].resolve();
+        }
+      });
     });
 
-    it("supports getTileDataAvailable()", async function () {
+    it("supports getTileDataAvailable()", function () {
       const baseUrl = "made/up/url";
 
       Resource._Implementations.loadWithXhr = function (
@@ -899,22 +1137,36 @@ describe("Core/CesiumTerrainProvider", function () {
 
       returnQuantizedMeshTileJson();
 
-      const terrainProvider = await CesiumTerrainProvider.fromUrl(baseUrl);
-      expect(terrainProvider.getTileDataAvailable(0, 0, 0)).toBe(true);
-      expect(terrainProvider.getTileDataAvailable(0, 0, 2)).toBe(false);
+      const terrainProvider = new CesiumTerrainProvider({
+        url: baseUrl,
+      });
+
+      return pollToPromise(function () {
+        return terrainProvider.ready;
+      }).then(function () {
+        expect(terrainProvider.getTileDataAvailable(0, 0, 0)).toBe(true);
+        expect(terrainProvider.getTileDataAvailable(0, 0, 2)).toBe(false);
+      });
     });
 
-    it("getTileDataAvailable() converts xyz to tms", async function () {
+    it("getTileDataAvailable() converts xyz to tms", function () {
       const baseUrl = "made/up/url";
 
       returnPartialAvailabilityTileJson();
 
-      const terrainProvider = await CesiumTerrainProvider.fromUrl(baseUrl);
-      expect(terrainProvider.getTileDataAvailable(1, 3, 2)).toBe(true);
-      expect(terrainProvider.getTileDataAvailable(1, 0, 2)).toBe(false);
+      const terrainProvider = new CesiumTerrainProvider({
+        url: baseUrl,
+      });
+
+      return pollToPromise(function () {
+        return terrainProvider.ready;
+      }).then(function () {
+        expect(terrainProvider.getTileDataAvailable(1, 3, 2)).toBe(true);
+        expect(terrainProvider.getTileDataAvailable(1, 0, 2)).toBe(false);
+      });
     });
 
-    it("getTileDataAvailable() with Metadata availability", async function () {
+    it("getTileDataAvailable() with Metadata availability", function () {
       Resource._Implementations.loadWithXhr = function (
         url,
         responseType,
@@ -936,18 +1188,25 @@ describe("Core/CesiumTerrainProvider", function () {
 
       returnMetadataAvailabilityTileJson();
 
-      const terrainProvider = await CesiumTerrainProvider.fromUrl(
-        "made/up/url"
-      );
+      const terrainProvider = new CesiumTerrainProvider({
+        url: "made/up/url",
+      });
 
-      expect(terrainProvider.getTileDataAvailable(0, 0, 0)).toBe(true);
-      expect(terrainProvider.getTileDataAvailable(0, 0, 1)).toBeUndefined();
+      return pollToPromise(function () {
+        return terrainProvider.ready;
+      })
+        .then(function () {
+          expect(terrainProvider.getTileDataAvailable(0, 0, 0)).toBe(true);
+          expect(terrainProvider.getTileDataAvailable(0, 0, 1)).toBeUndefined();
 
-      await terrainProvider.requestTileGeometry(0, 0, 0);
-      expect(terrainProvider.getTileDataAvailable(0, 0, 1)).toBe(true);
+          return terrainProvider.requestTileGeometry(0, 0, 0);
+        })
+        .then(function () {
+          expect(terrainProvider.getTileDataAvailable(0, 0, 1)).toBe(true);
+        });
     });
 
-    it("supports a query string in the base URL", async function () {
+    it("supports a query string in the base URL", function () {
       Resource._Implementations.loadWithXhr = function (
         url,
         responseType,
@@ -970,28 +1229,31 @@ describe("Core/CesiumTerrainProvider", function () {
 
       returnHeightmapTileJson();
 
-      const loadedData = await waitForTile(0, 0, 0, false, false);
-      expect(loadedData).toBeInstanceOf(HeightmapTerrainData);
+      return waitForTile(0, 0, 0, false, false, function (loadedData) {
+        expect(loadedData).toBeInstanceOf(HeightmapTerrainData);
+      });
     });
 
-    it("Uses query parameter extensions for ion resource", async function () {
-      const terrainProvider = await CesiumTerrainProvider.fromUrl(
-        IonResource.fromAssetId(1),
-        {
-          requestVertexNormals: true,
-          requestWaterMask: true,
-        }
-      );
+    it("Uses query parameter extensions for ion resource", function () {
+      const terrainProvider = new CesiumTerrainProvider({
+        url: IonResource.fromAssetId(1),
+        requestVertexNormals: true,
+        requestWaterMask: true,
+      });
 
-      const getDerivedResource = spyOn(
-        IonResource.prototype,
-        "getDerivedResource"
-      ).and.callThrough();
-      terrainProvider.requestTileGeometry(0, 0, 0);
-      const options = getDerivedResource.calls.argsFor(0)[0];
-      expect(options.queryParameters.extensions).toEqual(
-        "octvertexnormals-watermask-metadata"
-      );
+      return pollToPromise(function () {
+        return terrainProvider.ready;
+      }).then(function () {
+        const getDerivedResource = spyOn(
+          IonResource.prototype,
+          "getDerivedResource"
+        ).and.callThrough();
+        terrainProvider.requestTileGeometry(0, 0, 0);
+        const options = getDerivedResource.calls.argsFor(0)[0];
+        expect(options.queryParameters.extensions).toEqual(
+          "octvertexnormals-watermask-metadata"
+        );
+      });
     });
   });
 });

--- a/packages/engine/Specs/Core/CesiumTerrainProviderSpec.js
+++ b/packages/engine/Specs/Core/CesiumTerrainProviderSpec.js
@@ -10,9 +10,9 @@ import {
   Request,
   RequestScheduler,
   Resource,
+  RuntimeError,
   TerrainProvider,
 } from "../../index.js";
-import pollToPromise from "../../../../Specs/pollToPromise.js";
 
 describe("Core/CesiumTerrainProvider", function () {
   beforeEach(function () {
@@ -238,348 +238,196 @@ describe("Core/CesiumTerrainProvider", function () {
       });
   });
 
-  it("uses geographic tiling scheme by default", function () {
+  it("uses geographic tiling scheme by default", async function () {
     returnHeightmapTileJson();
 
-    const provider = new CesiumTerrainProvider({
-      url: "made/up/url",
-    });
+    const provider = await CesiumTerrainProvider.fromUrl("made/up/url");
 
-    return pollToPromise(function () {
-      return provider.ready;
-    }).then(function () {
-      expect(provider.tilingScheme).toBeInstanceOf(GeographicTilingScheme);
-    });
+    expect(provider.tilingScheme).toBeInstanceOf(GeographicTilingScheme);
   });
 
-  it("can use a custom ellipsoid", function () {
+  it("can use a custom ellipsoid", async function () {
     returnHeightmapTileJson();
 
     const ellipsoid = new Ellipsoid(1, 2, 3);
-    const provider = new CesiumTerrainProvider({
-      url: "made/up/url",
+    const provider = await CesiumTerrainProvider.fromUrl("made/up/url", {
       ellipsoid: ellipsoid,
     });
 
-    return pollToPromise(function () {
-      return provider.ready;
-    }).then(function () {
-      expect(provider.tilingScheme.ellipsoid).toEqual(ellipsoid);
-    });
+    expect(provider.tilingScheme.ellipsoid).toEqual(ellipsoid);
   });
 
-  it("has error event", function () {
-    const provider = new CesiumTerrainProvider({
-      url: "made/up/url",
-    });
-    return pollToPromise(function () {
-      return provider.ready;
-    }).then(function () {
-      expect(provider.errorEvent).toBeDefined();
-      expect(provider.errorEvent).toBe(provider.errorEvent);
-    });
+  it("has error event", async function () {
+    const provider = await CesiumTerrainProvider.fromUrl("made/up/url");
+    expect(provider.errorEvent).toBeDefined();
+    expect(provider.errorEvent).toBe(provider.errorEvent);
   });
 
-  it("returns reasonable geometric error for various levels", function () {
+  it("returns reasonable geometric error for various levels", async function () {
     returnQuantizedMeshTileJson();
 
-    const provider = new CesiumTerrainProvider({
-      url: "made/up/url",
-    });
+    const provider = await CesiumTerrainProvider.fromUrl("made/up/url");
 
-    return provider.readyPromise.then(function () {
-      expect(provider.getLevelMaximumGeometricError(0)).toBeGreaterThan(0.0);
-      expect(provider.getLevelMaximumGeometricError(0)).toEqualEpsilon(
-        provider.getLevelMaximumGeometricError(1) * 2.0,
-        CesiumMath.EPSILON10
-      );
-      expect(provider.getLevelMaximumGeometricError(1)).toEqualEpsilon(
-        provider.getLevelMaximumGeometricError(2) * 2.0,
-        CesiumMath.EPSILON10
-      );
-    });
+    expect(provider.getLevelMaximumGeometricError(0)).toBeGreaterThan(0.0);
+    expect(provider.getLevelMaximumGeometricError(0)).toEqualEpsilon(
+      provider.getLevelMaximumGeometricError(1) * 2.0,
+      CesiumMath.EPSILON10
+    );
+    expect(provider.getLevelMaximumGeometricError(1)).toEqualEpsilon(
+      provider.getLevelMaximumGeometricError(2) * 2.0,
+      CesiumMath.EPSILON10
+    );
   });
 
-  it("credit is undefined if credit option is not provided", function () {
+  it("credit is undefined if credit option is not provided", async function () {
     returnHeightmapTileJson();
 
-    const provider = new CesiumTerrainProvider({
-      url: "made/up/url",
-    });
+    const provider = await CesiumTerrainProvider.fromUrl("made/up/url");
 
-    return pollToPromise(function () {
-      return provider.ready;
-    }).then(function () {
-      expect(provider.credit).toBeUndefined();
-    });
+    expect(provider.credit).toBeUndefined();
   });
 
-  it("credit is defined if credit option is provided", function () {
+  it("credit is defined if credit option is provided", async function () {
     returnHeightmapTileJson();
 
-    const provider = new CesiumTerrainProvider({
-      url: "made/up/url",
+    const provider = await CesiumTerrainProvider.fromUrl("made/up/url", {
       credit: "thanks to our awesome made up contributors!",
     });
 
-    return pollToPromise(function () {
-      return provider.ready;
-    }).then(function () {
-      expect(provider.credit).toBeDefined();
-    });
+    expect(provider.credit).toBeDefined();
   });
 
-  it("has a water mask", function () {
+  it("has a water mask", async function () {
     returnHeightmapTileJson();
 
-    const provider = new CesiumTerrainProvider({
-      url: "made/up/url",
-    });
+    const provider = await CesiumTerrainProvider.fromUrl("made/up/url");
 
-    return pollToPromise(function () {
-      return provider.ready;
-    }).then(function () {
-      expect(provider.hasWaterMask).toBe(true);
-    });
+    expect(provider.hasWaterMask).toBe(true);
   });
 
-  it("has vertex normals", function () {
+  it("has vertex normals", async function () {
     returnOctVertexNormalTileJson();
 
-    const provider = new CesiumTerrainProvider({
-      url: "made/up/url",
+    const provider = await CesiumTerrainProvider.fromUrl("made/up/url", {
       requestVertexNormals: true,
     });
 
-    return pollToPromise(function () {
-      return provider.ready;
-    }).then(function () {
-      expect(provider.requestVertexNormals).toBe(true);
-      expect(provider.hasVertexNormals).toBe(true);
-    });
+    expect(provider.requestVertexNormals).toBe(true);
+    expect(provider.hasVertexNormals).toBe(true);
   });
 
-  it("does not request vertex normals", function () {
+  it("does not request vertex normals", async function () {
     returnOctVertexNormalTileJson();
 
-    const provider = new CesiumTerrainProvider({
-      url: "made/up/url",
+    const provider = await CesiumTerrainProvider.fromUrl("made/up/url", {
       requestVertexNormals: false,
     });
 
-    return pollToPromise(function () {
-      return provider.ready;
-    }).then(function () {
-      expect(provider.requestVertexNormals).toBe(false);
-      expect(provider.hasVertexNormals).toBe(false);
-    });
+    expect(provider.requestVertexNormals).toBe(false);
+    expect(provider.hasVertexNormals).toBe(false);
   });
 
-  it("requests parent layer.json", function () {
+  it("requests parent layer.json", async function () {
     returnParentUrlTileJson();
 
-    const provider = new CesiumTerrainProvider({
-      url: "made/up/url",
+    const provider = await CesiumTerrainProvider.fromUrl("made/up/url", {
       requestVertexNormals: true,
       requestWaterMask: true,
     });
 
-    return provider.readyPromise.then(function () {
-      expect(provider._tileCredits[0].html).toBe(
-        "This is a child tileset! This amazing data is courtesy The Amazing Data Source!"
-      );
-      expect(provider.requestVertexNormals).toBe(true);
-      expect(provider.requestWaterMask).toBe(true);
-      expect(provider.hasVertexNormals).toBe(false); // Neither tileset has them
-      expect(provider.hasWaterMask).toBe(true); // The child tileset has them
-      expect(provider.availability.isTileAvailable(1, 2, 1)).toBe(true); // Both have this
-      expect(provider.availability.isTileAvailable(1, 3, 1)).toBe(true); // Parent has this, but child doesn't
-      expect(provider.availability.isTileAvailable(2, 0, 0)).toBe(false); // Neither has this
+    expect(provider._tileCredits[0].html).toBe(
+      "This is a child tileset! This amazing data is courtesy The Amazing Data Source!"
+    );
+    expect(provider.requestVertexNormals).toBe(true);
+    expect(provider.requestWaterMask).toBe(true);
+    expect(provider.hasVertexNormals).toBe(false); // Neither tileset has them
+    expect(provider.hasWaterMask).toBe(true); // The child tileset has them
+    expect(provider.availability.isTileAvailable(1, 2, 1)).toBe(true); // Both have this
+    expect(provider.availability.isTileAvailable(1, 3, 1)).toBe(true); // Parent has this, but child doesn't
+    expect(provider.availability.isTileAvailable(2, 0, 0)).toBe(false); // Neither has this
 
-      const layers = provider._layers;
-      expect(layers.length).toBe(2);
-      expect(layers[0].hasVertexNormals).toBe(false);
-      expect(layers[0].hasWaterMask).toBe(true);
-      expect(layers[0].availability.isTileAvailable(1, 2, 1)).toBe(true);
-      expect(layers[0].availability.isTileAvailable(1, 3, 1)).toBe(false);
-      expect(layers[0].availability.isTileAvailable(2, 0, 0)).toBe(false);
-      expect(layers[1].hasVertexNormals).toBe(false);
-      expect(layers[1].hasWaterMask).toBe(false);
-      expect(layers[1].availability.isTileAvailable(1, 2, 1)).toBe(true);
-      expect(layers[1].availability.isTileAvailable(1, 3, 1)).toBe(true);
-      expect(layers[1].availability.isTileAvailable(2, 0, 0)).toBe(false);
-    });
+    const layers = provider._layers;
+    expect(layers.length).toBe(2);
+    expect(layers[0].hasVertexNormals).toBe(false);
+    expect(layers[0].hasWaterMask).toBe(true);
+    expect(layers[0].availability.isTileAvailable(1, 2, 1)).toBe(true);
+    expect(layers[0].availability.isTileAvailable(1, 3, 1)).toBe(false);
+    expect(layers[0].availability.isTileAvailable(2, 0, 0)).toBe(false);
+    expect(layers[1].hasVertexNormals).toBe(false);
+    expect(layers[1].hasWaterMask).toBe(false);
+    expect(layers[1].availability.isTileAvailable(1, 2, 1)).toBe(true);
+    expect(layers[1].availability.isTileAvailable(1, 3, 1)).toBe(true);
+    expect(layers[1].availability.isTileAvailable(2, 0, 0)).toBe(false);
   });
 
-  it("raises an error if layer.json does not specify a format", function () {
-    returnTileJson("Data/CesiumTerrainTileJson/NoFormat.tile.json");
-
-    const provider = new CesiumTerrainProvider({
-      url: "made/up/url",
-    });
-
-    let errorListenerCalled = false;
-    const errorMatcher = function (event) {
-      expect(event.message).toContain("format is not specified");
-      errorListenerCalled = true;
-      provider.errorEvent.removeEventListener(errorMatcher);
-    };
-
-    provider.errorEvent.addEventListener(errorMatcher);
-
-    return provider.readyPromise.then(fail).catch((e) => {
-      expect(errorListenerCalled).toBe(true);
-      expect(e.message).toContain(
-        "The tile format is not specified in the layer.json file."
-      );
-    });
-  });
-
-  it("raises an error if layer.json specifies an unknown format", function () {
+  it("fromUrl throws if layer.json specifies an unknown format", async function () {
     returnTileJson("Data/CesiumTerrainTileJson/InvalidFormat.tile.json");
 
-    const provider = new CesiumTerrainProvider({
-      url: "made/up/url",
-    });
-
-    let errorListenerCalled = false;
-    const errorMatcher = function (event) {
-      expect(event.message).toContain("invalid or not supported");
-      errorListenerCalled = true;
-      provider.errorEvent.removeEventListener(errorMatcher);
-    };
-
-    provider.errorEvent.addEventListener(errorMatcher);
-
-    return provider.readyPromise.then(fail).catch((e) => {
-      expect(errorListenerCalled).toBe(true);
-      expect(e.message).toContain(
-        'The tile format "awesometron-9000.0" is invalid or not supported.'
-      );
-    });
+    await expectAsync(
+      CesiumTerrainProvider.fromUrl("made/up/url")
+    ).toBeRejectedWithError(
+      RuntimeError,
+      'The tile format "awesometron-9000.0" is invalid or not supported.'
+    );
   });
 
-  it("raises an error if layer.json does not specify quantized-mesh 1.x format", function () {
+  it("fromUrl throws if layer.json does not specify quantized-mesh 1.x format", async function () {
     returnTileJson("Data/CesiumTerrainTileJson/QuantizedMesh2.0.tile.json");
 
-    const provider = new CesiumTerrainProvider({
-      url: "made/up/url",
-    });
-
-    let errorListenerCalled = false;
-    const errorMatcher = function (event) {
-      expect(event.message).toContain("invalid or not supported");
-      errorListenerCalled = true;
-      provider.errorEvent.removeEventListener(errorMatcher);
-    };
-
-    provider.errorEvent.addEventListener(errorMatcher);
-
-    return provider.readyPromise.then(fail).catch((e) => {
-      expect(errorListenerCalled).toBe(true);
-      expect(e.message).toContain(
-        'The tile format "quantized-mesh-2.0" is invalid or not supported.'
-      );
-    });
+    await expectAsync(
+      CesiumTerrainProvider.fromUrl("made/up/url")
+    ).toBeRejectedWithError(
+      RuntimeError,
+      'The tile format "quantized-mesh-2.0" is invalid or not supported.'
+    );
   });
 
-  it("supports quantized-mesh1.x minor versions", function () {
+  it("fromUrl supports quantized-mesh1.x minor versions", async function () {
     returnTileJson("Data/CesiumTerrainTileJson/QuantizedMesh1.1.tile.json");
 
-    const provider = new CesiumTerrainProvider({
-      url: "made/up/url",
-    });
-
-    const errorListener = jasmine.createSpy("error");
-    provider.errorEvent.addEventListener(errorListener);
-
-    return pollToPromise(function () {
-      return provider.ready;
-    }).then(function () {
-      expect(errorListener).not.toHaveBeenCalled();
-    });
+    await expectAsync(
+      CesiumTerrainProvider.fromUrl("made/up/url")
+    ).toBeResolved();
   });
 
-  it("raises an error if layer.json does not specify a tiles property", function () {
+  it("fromUrl throws if layer.json does not specify a tiles property", async function () {
     returnTileJson("Data/CesiumTerrainTileJson/NoTiles.tile.json");
 
-    const provider = new CesiumTerrainProvider({
-      url: "made/up/url",
-    });
-
-    let errorListenerCalled = false;
-    const errorMatcher = function (event) {
-      expect(event.message).toContain(
-        "does not specify any tile URL templates"
-      );
-      errorListenerCalled = true;
-      provider.errorEvent.removeEventListener(errorMatcher);
-    };
-
-    provider.errorEvent.addEventListener(errorMatcher);
-
-    return provider.readyPromise.then(fail).catch((e) => {
-      expect(errorListenerCalled).toBe(true);
-      expect(e.message).toContain(
-        "The layer.json file does not specify any tile URL templates."
-      );
-    });
+    await expectAsync(
+      CesiumTerrainProvider.fromUrl("made/up/url")
+    ).toBeRejectedWithError(
+      RuntimeError,
+      "The layer.json file does not specify any tile URL templates."
+    );
   });
 
-  it("raises an error if layer.json tiles property is an empty array", function () {
+  it("fromUrl throws if layer.json tiles property is an empty array", async function () {
     returnTileJson("Data/CesiumTerrainTileJson/EmptyTilesArray.tile.json");
 
-    const provider = new CesiumTerrainProvider({
-      url: "made/up/url",
-    });
-
-    let errorListenerCalled = false;
-    const errorMatcher = function (event) {
-      expect(event.message).toContain(
-        "does not specify any tile URL templates"
-      );
-      errorListenerCalled = true;
-      provider.errorEvent.removeEventListener(errorMatcher);
-    };
-
-    provider.errorEvent.addEventListener(errorMatcher);
-
-    return provider.readyPromise.then(fail).catch((e) => {
-      expect(errorListenerCalled).toBe(true);
-      expect(e.message).toContain(
-        "The layer.json file does not specify any tile URL templates."
-      );
-    });
+    await expectAsync(
+      CesiumTerrainProvider.fromUrl("made/up/url")
+    ).toBeRejectedWithError(
+      RuntimeError,
+      "The layer.json file does not specify any tile URL templates."
+    );
   });
 
-  it("uses attribution specified in layer.json", function () {
+  it("fromUrl uses attribution specified in layer.json", async function () {
     returnTileJson("Data/CesiumTerrainTileJson/WithAttribution.tile.json");
 
-    const provider = new CesiumTerrainProvider({
-      url: "made/up/url",
-    });
+    const provider = await CesiumTerrainProvider.fromUrl("made/up/url");
 
-    return pollToPromise(function () {
-      return provider.ready;
-    }).then(function () {
-      expect(provider._tileCredits[0].html).toBe(
-        "This amazing data is courtesy The Amazing Data Source!"
-      );
-    });
+    expect(provider._tileCredits[0].html).toBe(
+      "This amazing data is courtesy The Amazing Data Source!"
+    );
   });
 
-  it("do not add blank attribution if layer.json does not have one", function () {
+  it("formUrl does not add blank attribution if layer.json does not have one", async function () {
     returnTileJson("Data/CesiumTerrainTileJson/WaterMask.tile.json");
 
-    const provider = new CesiumTerrainProvider({
-      url: "made/up/url",
-    });
+    const provider = await CesiumTerrainProvider.fromUrl("made/up/url");
 
-    return pollToPromise(function () {
-      return provider.ready;
-    }).then(function () {
-      expect(provider._tileCredit).toBeUndefined();
-    });
+    expect(provider._tileCredit).toBeUndefined();
   });
 
   it("The undefined availability tile is returned at level 0", function () {
@@ -651,82 +499,80 @@ describe("Core/CesiumTerrainProvider", function () {
   });
 
   describe("requestTileGeometry", function () {
-    it("uses multiple urls specified in layer.json", function () {
+    it("uses multiple urls specified in layer.json", async function () {
       returnTileJson("Data/CesiumTerrainTileJson/MultipleUrls.tile.json");
-
-      const provider = new CesiumTerrainProvider({
-        url: "made/up/url",
-      });
-
+      const provider = await CesiumTerrainProvider.fromUrl("made/up/url");
       spyOn(Resource._Implementations, "loadWithXhr").and.callThrough();
 
-      return provider.readyPromise
-        .then(function () {
-          return provider.requestTileGeometry(0, 0, 0);
-        })
-        .catch(function () {
-          expect(
-            Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
-          ).toContain("foo0.com");
-          return provider.requestTileGeometry(1, 0, 0);
-        })
-        .catch(function () {
-          expect(
-            Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
-          ).toContain("foo1.com");
-          return provider.requestTileGeometry(1, -1, 0);
-        })
-        .catch(function () {
-          expect(
-            Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
-          ).toContain("foo2.com");
-          return provider.requestTileGeometry(1, 0, 1);
-        })
-        .catch(function () {
-          expect(
-            Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
-          ).toContain("foo3.com");
-        });
+      try {
+        await provider.requestTileGeometry(0, 0, 0);
+      } catch (e) {
+        expect(
+          Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
+        ).toContain("foo0.com");
+      }
+
+      try {
+        await provider.requestTileGeometry(1, 0, 0);
+      } catch (e) {
+        expect(
+          Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
+        ).toContain("foo1.com");
+      }
+
+      try {
+        await provider.requestTileGeometry(1, -1, 0);
+      } catch (e) {
+        expect(
+          Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
+        ).toContain("foo2.com");
+      }
+
+      try {
+        await provider.requestTileGeometry(1, 0, 1);
+      } catch (e) {
+        expect(
+          Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
+        ).toContain("foo3.com");
+      }
     });
 
-    it("supports scheme-less template URLs in layer.json resolved with absolute URL", function () {
+    it("supports scheme-less template URLs in layer.json resolved with absolute URL", async function () {
       returnTileJson("Data/CesiumTerrainTileJson/MultipleUrls.tile.json");
-
       const url = getAbsoluteUri("Data/CesiumTerrainTileJson");
-
-      const provider = new CesiumTerrainProvider({
-        url: url,
-      });
+      const provider = await CesiumTerrainProvider.fromUrl(url);
 
       spyOn(Resource._Implementations, "loadWithXhr").and.callThrough();
 
-      return provider.readyPromise
-        .then(function () {
-          return provider.requestTileGeometry(0, 0, 0);
-        })
-        .catch(function () {
-          expect(
-            Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
-          ).toContain("foo0.com");
-          return provider.requestTileGeometry(1, 0, 0);
-        })
-        .catch(function () {
-          expect(
-            Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
-          ).toContain("foo1.com");
-          return provider.requestTileGeometry(1, -1, 0);
-        })
-        .catch(function () {
-          expect(
-            Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
-          ).toContain("foo2.com");
-          return provider.requestTileGeometry(1, 0, 1);
-        })
-        .catch(function () {
-          expect(
-            Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
-          ).toContain("foo3.com");
-        });
+      try {
+        await provider.requestTileGeometry(0, 0, 0);
+      } catch (e) {
+        expect(
+          Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
+        ).toContain("foo0.com");
+      }
+      try {
+        await provider.requestTileGeometry(1, 0, 0);
+      } catch (e) {
+        expect(
+          Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
+        ).toContain("foo1.com");
+      }
+
+      try {
+        await provider.requestTileGeometry(1, -1, 0);
+      } catch (e) {
+        expect(
+          Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
+        ).toContain("foo2.com");
+      }
+      try {
+        await provider.requestTileGeometry(1, 0, 1);
+      } catch (e) {
+        expect(
+          Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]
+        ).toContain("foo3.com");
+      }
     });
 
     it("provides HeightmapTerrainData", function () {
@@ -1008,7 +854,7 @@ describe("Core/CesiumTerrainProvider", function () {
       });
     });
 
-    it("provides QuantizedMeshTerrainData with Metadata availability", function () {
+    it("provides QuantizedMeshTerrainData with Metadata availability", async function () {
       Resource._Implementations.loadWithXhr = function (
         url,
         responseType,
@@ -1030,37 +876,22 @@ describe("Core/CesiumTerrainProvider", function () {
 
       returnMetadataAvailabilityTileJson();
 
-      const terrainProvider = new CesiumTerrainProvider({
-        url: "made/up/url",
-      });
+      const terrainProvider = await CesiumTerrainProvider.fromUrl(
+        "made/up/url"
+      );
 
-      return pollToPromise(function () {
-        return terrainProvider.ready;
-      })
-        .then(function () {
-          expect(terrainProvider.hasMetadata).toBe(true);
-          expect(terrainProvider._layers[0].availabilityLevels).toBe(10);
-          expect(terrainProvider.availability.isTileAvailable(0, 0, 0)).toBe(
-            true
-          );
-          expect(terrainProvider.availability.isTileAvailable(0, 1, 0)).toBe(
-            true
-          );
-          expect(terrainProvider.availability.isTileAvailable(1, 0, 0)).toBe(
-            false
-          );
+      expect(terrainProvider.hasMetadata).toBe(true);
+      expect(terrainProvider._layers[0].availabilityLevels).toBe(10);
+      expect(terrainProvider.availability.isTileAvailable(0, 0, 0)).toBe(true);
+      expect(terrainProvider.availability.isTileAvailable(0, 1, 0)).toBe(true);
+      expect(terrainProvider.availability.isTileAvailable(1, 0, 0)).toBe(false);
 
-          return terrainProvider.requestTileGeometry(0, 0, 0);
-        })
-        .then(function (loadedData) {
-          expect(loadedData).toBeInstanceOf(QuantizedMeshTerrainData);
-          expect(terrainProvider.availability.isTileAvailable(1, 0, 0)).toBe(
-            true
-          );
-        });
+      const loadedData = await terrainProvider.requestTileGeometry(0, 0, 0);
+      expect(loadedData).toBeInstanceOf(QuantizedMeshTerrainData);
+      expect(terrainProvider.availability.isTileAvailable(1, 0, 0)).toBe(true);
     });
 
-    it("returns undefined if too many requests are already in progress", function () {
+    it("returns undefined if too many requests are already in progress", async function () {
       const baseUrl = "made/up/url";
 
       const deferreds = [];
@@ -1080,40 +911,33 @@ describe("Core/CesiumTerrainProvider", function () {
 
       returnHeightmapTileJson();
 
-      const terrainProvider = new CesiumTerrainProvider({
-        url: baseUrl,
-      });
-
-      return pollToPromise(function () {
-        return terrainProvider.ready;
-      }).then(function () {
-        let promise;
-        let i;
-        for (i = 0; i < RequestScheduler.maximumRequestsPerServer; ++i) {
-          const request = new Request({
-            throttle: true,
-            throttleByServer: true,
+      const terrainProvider = await CesiumTerrainProvider.fromUrl(baseUrl);
+      let promise;
+      let i;
+      for (i = 0; i < RequestScheduler.maximumRequestsPerServer; ++i) {
+        const request = new Request({
+          throttle: true,
+          throttleByServer: true,
+        });
+        promise = terrainProvider
+          .requestTileGeometry(0, 0, 0, request)
+          .then(fail)
+          .catch((e) => {
+            expect(e.message).toContain("Mesh buffer doesn't exist.");
           });
-          promise = terrainProvider
-            .requestTileGeometry(0, 0, 0, request)
-            .then(fail)
-            .catch((e) => {
-              expect(e.message).toContain("Mesh buffer doesn't exist.");
-            });
-        }
-        RequestScheduler.update();
-        expect(promise).toBeDefined();
+      }
+      RequestScheduler.update();
+      expect(promise).toBeDefined();
 
-        promise = terrainProvider.requestTileGeometry(0, 0, 0, createRequest());
-        expect(promise).toBeUndefined();
+      promise = terrainProvider.requestTileGeometry(0, 0, 0, createRequest());
+      expect(promise).toBeUndefined();
 
-        for (i = 0; i < deferreds.length; ++i) {
-          deferreds[i].resolve();
-        }
-      });
+      for (i = 0; i < deferreds.length; ++i) {
+        deferreds[i].resolve();
+      }
     });
 
-    it("supports getTileDataAvailable()", function () {
+    it("supports getTileDataAvailable()", async function () {
       const baseUrl = "made/up/url";
 
       Resource._Implementations.loadWithXhr = function (
@@ -1137,36 +961,24 @@ describe("Core/CesiumTerrainProvider", function () {
 
       returnQuantizedMeshTileJson();
 
-      const terrainProvider = new CesiumTerrainProvider({
-        url: baseUrl,
-      });
+      const terrainProvider = await CesiumTerrainProvider.fromUrl(baseUrl);
 
-      return pollToPromise(function () {
-        return terrainProvider.ready;
-      }).then(function () {
-        expect(terrainProvider.getTileDataAvailable(0, 0, 0)).toBe(true);
-        expect(terrainProvider.getTileDataAvailable(0, 0, 2)).toBe(false);
-      });
+      expect(terrainProvider.getTileDataAvailable(0, 0, 0)).toBe(true);
+      expect(terrainProvider.getTileDataAvailable(0, 0, 2)).toBe(false);
     });
 
-    it("getTileDataAvailable() converts xyz to tms", function () {
+    it("getTileDataAvailable() converts xyz to tms", async function () {
       const baseUrl = "made/up/url";
 
       returnPartialAvailabilityTileJson();
 
-      const terrainProvider = new CesiumTerrainProvider({
-        url: baseUrl,
-      });
+      const terrainProvider = await CesiumTerrainProvider.fromUrl(baseUrl);
 
-      return pollToPromise(function () {
-        return terrainProvider.ready;
-      }).then(function () {
-        expect(terrainProvider.getTileDataAvailable(1, 3, 2)).toBe(true);
-        expect(terrainProvider.getTileDataAvailable(1, 0, 2)).toBe(false);
-      });
+      expect(terrainProvider.getTileDataAvailable(1, 3, 2)).toBe(true);
+      expect(terrainProvider.getTileDataAvailable(1, 0, 2)).toBe(false);
     });
 
-    it("getTileDataAvailable() with Metadata availability", function () {
+    it("getTileDataAvailable() with Metadata availability", async function () {
       Resource._Implementations.loadWithXhr = function (
         url,
         responseType,
@@ -1188,22 +1000,15 @@ describe("Core/CesiumTerrainProvider", function () {
 
       returnMetadataAvailabilityTileJson();
 
-      const terrainProvider = new CesiumTerrainProvider({
-        url: "made/up/url",
-      });
+      const terrainProvider = await CesiumTerrainProvider.fromUrl(
+        "made/up/url"
+      );
 
-      return pollToPromise(function () {
-        return terrainProvider.ready;
-      })
-        .then(function () {
-          expect(terrainProvider.getTileDataAvailable(0, 0, 0)).toBe(true);
-          expect(terrainProvider.getTileDataAvailable(0, 0, 1)).toBeUndefined();
+      expect(terrainProvider.getTileDataAvailable(0, 0, 0)).toBe(true);
+      expect(terrainProvider.getTileDataAvailable(0, 0, 1)).toBeUndefined();
 
-          return terrainProvider.requestTileGeometry(0, 0, 0);
-        })
-        .then(function () {
-          expect(terrainProvider.getTileDataAvailable(0, 0, 1)).toBe(true);
-        });
+      await terrainProvider.requestTileGeometry(0, 0, 0);
+      expect(terrainProvider.getTileDataAvailable(0, 0, 1)).toBe(true);
     });
 
     it("supports a query string in the base URL", function () {
@@ -1234,26 +1039,24 @@ describe("Core/CesiumTerrainProvider", function () {
       });
     });
 
-    it("Uses query parameter extensions for ion resource", function () {
-      const terrainProvider = new CesiumTerrainProvider({
-        url: IonResource.fromAssetId(1),
-        requestVertexNormals: true,
-        requestWaterMask: true,
-      });
+    it("Uses query parameter extensions for ion resource", async function () {
+      const terrainProvider = await CesiumTerrainProvider.fromUrl(
+        IonResource.fromAssetId(1),
+        {
+          requestVertexNormals: true,
+          requestWaterMask: true,
+        }
+      );
 
-      return pollToPromise(function () {
-        return terrainProvider.ready;
-      }).then(function () {
-        const getDerivedResource = spyOn(
-          IonResource.prototype,
-          "getDerivedResource"
-        ).and.callThrough();
-        terrainProvider.requestTileGeometry(0, 0, 0);
-        const options = getDerivedResource.calls.argsFor(0)[0];
-        expect(options.queryParameters.extensions).toEqual(
-          "octvertexnormals-watermask-metadata"
-        );
-      });
+      const getDerivedResource = spyOn(
+        IonResource.prototype,
+        "getDerivedResource"
+      ).and.callThrough();
+      await terrainProvider.requestTileGeometry(0, 0, 0);
+      const options = getDerivedResource.calls.argsFor(0)[0];
+      expect(options.queryParameters.extensions).toEqual(
+        "octvertexnormals-watermask-metadata"
+      );
     });
   });
 });

--- a/packages/engine/Specs/Core/CesiumTerrainProviderSpec.js
+++ b/packages/engine/Specs/Core/CesiumTerrainProviderSpec.js
@@ -1,7 +1,6 @@
 import {
   CesiumTerrainProvider,
   Credit,
-  DeveloperError,
   Ellipsoid,
   GeographicTilingScheme,
   getAbsoluteUri,
@@ -155,8 +154,9 @@ describe("Core/CesiumTerrainProvider", function () {
   });
 
   it("fromUrl throws without url", async function () {
-    await expectAsync(CesiumTerrainProvider.fromUrl()).toBeRejectedWithError(
-      DeveloperError,
+    await expectAsync(
+      CesiumTerrainProvider.fromUrl()
+    ).toBeRejectedWithDeveloperError(
       "url is required, actual value was undefined"
     );
   });

--- a/packages/engine/Specs/Core/CustomHeightmapTerrainProviderSpec.js
+++ b/packages/engine/Specs/Core/CustomHeightmapTerrainProviderSpec.js
@@ -87,25 +87,6 @@ describe("Core/CustomHeightmapTerrainProvider", function () {
     expect(provider.tilingScheme).toBeInstanceOf(WebMercatorTilingScheme);
   });
 
-  it("resolves readyPromise", function () {
-    const width = 2;
-    const height = 2;
-    const callback = function (x, y, level) {
-      return new Float32Array(width * height);
-    };
-
-    const provider = new CustomHeightmapTerrainProvider({
-      callback: callback,
-      width: width,
-      height: height,
-    });
-
-    return provider.readyPromise.then(function (result) {
-      expect(result).toBe(true);
-      expect(provider.ready).toBe(true);
-    });
-  });
-
   it("has error event", function () {
     const width = 2;
     const height = 2;

--- a/packages/engine/Specs/Core/CustomHeightmapTerrainProviderSpec.js
+++ b/packages/engine/Specs/Core/CustomHeightmapTerrainProviderSpec.js
@@ -87,6 +87,25 @@ describe("Core/CustomHeightmapTerrainProvider", function () {
     expect(provider.tilingScheme).toBeInstanceOf(WebMercatorTilingScheme);
   });
 
+  it("resolves readyPromise", function () {
+    const width = 2;
+    const height = 2;
+    const callback = function (x, y, level) {
+      return new Float32Array(width * height);
+    };
+
+    const provider = new CustomHeightmapTerrainProvider({
+      callback: callback,
+      width: width,
+      height: height,
+    });
+
+    return provider.readyPromise.then(function (result) {
+      expect(result).toBe(true);
+      expect(provider.ready).toBe(true);
+    });
+  });
+
   it("has error event", function () {
     const width = 2;
     const height = 2;

--- a/packages/engine/Specs/Core/EllipsoidTerrainProviderSpec.js
+++ b/packages/engine/Specs/Core/EllipsoidTerrainProviderSpec.js
@@ -19,15 +19,6 @@ describe(
       expect(EllipsoidTerrainProvider).toConformToInterface(TerrainProvider);
     });
 
-    it("resolves readyPromise", function () {
-      const provider = new EllipsoidTerrainProvider();
-
-      return provider.readyPromise.then(function (result) {
-        expect(result).toBe(true);
-        expect(provider.ready).toBe(true);
-      });
-    });
-
     it("requestTileGeometry creates terrain data.", function () {
       const terrain = new EllipsoidTerrainProvider();
       const terrainData = terrain.requestTileGeometry(0, 0, 0);

--- a/packages/engine/Specs/Core/EllipsoidTerrainProviderSpec.js
+++ b/packages/engine/Specs/Core/EllipsoidTerrainProviderSpec.js
@@ -19,6 +19,15 @@ describe(
       expect(EllipsoidTerrainProvider).toConformToInterface(TerrainProvider);
     });
 
+    it("resolves readyPromise", function () {
+      const provider = new EllipsoidTerrainProvider();
+
+      return provider.readyPromise.then(function (result) {
+        expect(result).toBe(true);
+        expect(provider.ready).toBe(true);
+      });
+    });
+
     it("requestTileGeometry creates terrain data.", function () {
       const terrain = new EllipsoidTerrainProvider();
       const terrainData = terrain.requestTileGeometry(0, 0, 0);

--- a/packages/engine/Specs/Core/GoogleEarthEnterpriseMetadataSpec.js
+++ b/packages/engine/Specs/Core/GoogleEarthEnterpriseMetadataSpec.js
@@ -3,12 +3,11 @@ import {
   defaultValue,
   GoogleEarthEnterpriseMetadata,
   GoogleEarthEnterpriseTileInformation,
+  Math as CesiumMath,
   Request,
   Resource,
   RuntimeError,
 } from "../../index.js";
-
-import { Math as CesiumMath } from "../../index.js";
 
 describe("Core/GoogleEarthEnterpriseMetadata", function () {
   it("tileXYToQuadKey", function () {
@@ -109,7 +108,7 @@ describe("Core/GoogleEarthEnterpriseMetadata", function () {
     }).toThrowError(RuntimeError);
   });
 
-  it("populateSubtree", function () {
+  it("populateSubtree", async function () {
     const quad = "0123";
     let index = 0;
     spyOn(
@@ -128,48 +127,39 @@ describe("Core/GoogleEarthEnterpriseMetadata", function () {
       return Promise.resolve();
     });
 
-    const metadata = new GoogleEarthEnterpriseMetadata({
-      url: "http://test.server",
-    });
+    const metadata = await GoogleEarthEnterpriseMetadata.fromUrl(
+      "http://test.server"
+    );
     const request = new Request({
       throttle: true,
     });
-    return metadata.readyPromise
-      .then(function () {
-        const tileXY = GoogleEarthEnterpriseMetadata.quadKeyToTileXY(quad);
-        return metadata.populateSubtree(
-          tileXY.x,
-          tileXY.y,
-          tileXY.level,
-          request
-        );
-      })
-      .then(function () {
-        expect(
-          GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket.calls.count()
-        ).toEqual(4);
-        expect(
-          GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
-        ).toHaveBeenCalledWith("", 1);
-        expect(
-          GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
-        ).toHaveBeenCalledWith("0", 1, request);
-        expect(
-          GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
-        ).toHaveBeenCalledWith("01", 1, request);
-        expect(
-          GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
-        ).toHaveBeenCalledWith("012", 1, request);
 
-        const tileInfo = metadata._tileInfo;
-        expect(tileInfo["0"]).toBeDefined();
-        expect(tileInfo["01"]).toBeDefined();
-        expect(tileInfo["012"]).toBeDefined();
-        expect(tileInfo["0123"]).toBeDefined();
-      });
+    const tileXY = GoogleEarthEnterpriseMetadata.quadKeyToTileXY(quad);
+    await metadata.populateSubtree(tileXY.x, tileXY.y, tileXY.level, request);
+    expect(
+      GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket.calls.count()
+    ).toEqual(4);
+    expect(
+      GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
+    ).toHaveBeenCalledWith("", 1);
+    expect(
+      GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
+    ).toHaveBeenCalledWith("0", 1, request);
+    expect(
+      GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
+    ).toHaveBeenCalledWith("01", 1, request);
+    expect(
+      GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
+    ).toHaveBeenCalledWith("012", 1, request);
+
+    const tileInfo = metadata._tileInfo;
+    expect(tileInfo["0"]).toBeDefined();
+    expect(tileInfo["01"]).toBeDefined();
+    expect(tileInfo["012"]).toBeDefined();
+    expect(tileInfo["0123"]).toBeDefined();
   });
 
-  it("resolves readyPromise", function () {
+  it("from url resolves to GoogleEarthEnterpriseMetadata", async function () {
     const baseurl = "http://fake.fake.invalid/";
 
     let req = 0;
@@ -200,32 +190,26 @@ describe("Core/GoogleEarthEnterpriseMetadata", function () {
       ++req;
     });
 
-    const provider = new GoogleEarthEnterpriseMetadata({
-      url: baseurl,
-    });
+    const provider = await GoogleEarthEnterpriseMetadata.fromUrl(baseurl);
 
-    return provider.readyPromise.then(function (result) {
-      expect(result).toBe(true);
+    expect(provider.imageryPresent).toBe(true);
+    expect(provider.protoImagery).toBeUndefined();
+    expect(provider.terrainPresent).toBe(true);
+    expect(provider.negativeAltitudeThreshold).toBe(CesiumMath.EPSILON12);
+    expect(provider.negativeAltitudeExponentBias).toBe(32);
+    expect(provider.providers).toEqual({});
 
-      expect(provider.imageryPresent).toBe(true);
-      expect(provider.protoImagery).toBeUndefined();
-      expect(provider.terrainPresent).toBe(true);
-      expect(provider.negativeAltitudeThreshold).toBe(CesiumMath.EPSILON12);
-      expect(provider.negativeAltitudeExponentBias).toBe(32);
-      expect(provider.providers).toEqual({});
-
-      const tileInfo = provider._tileInfo["0"];
-      expect(tileInfo).toBeDefined();
-      expect(tileInfo._bits).toEqual(0x40);
-      expect(tileInfo.cnodeVersion).toEqual(2);
-      expect(tileInfo.imageryVersion).toEqual(1);
-      expect(tileInfo.terrainVersion).toEqual(1);
-      expect(tileInfo.ancestorHasTerrain).toEqual(false);
-      expect(tileInfo.terrainState).toBeUndefined();
-    });
+    const tileInfo = provider._tileInfo["0"];
+    expect(tileInfo).toBeDefined();
+    expect(tileInfo._bits).toEqual(0x40);
+    expect(tileInfo.cnodeVersion).toEqual(2);
+    expect(tileInfo.imageryVersion).toEqual(1);
+    expect(tileInfo.terrainVersion).toEqual(1);
+    expect(tileInfo.ancestorHasTerrain).toEqual(false);
+    expect(tileInfo.terrainState).toBeUndefined();
   });
 
-  it("resolves readyPromise with Resource", function () {
+  it("fromUrl with Resource resolves to GoogleEarthEnterpriseMetadata", async function () {
     const baseurl = "http://fake.fake.invalid/";
     const resource = new Resource({
       url: baseurl,
@@ -259,41 +243,32 @@ describe("Core/GoogleEarthEnterpriseMetadata", function () {
       ++req;
     });
 
-    const provider = new GoogleEarthEnterpriseMetadata(resource);
+    const metadata = await GoogleEarthEnterpriseMetadata.fromUrl(resource);
 
-    return provider.readyPromise.then(function (result) {
-      expect(result).toBe(true);
+    expect(metadata.imageryPresent).toBe(true);
+    expect(metadata.protoImagery).toBeUndefined();
+    expect(metadata.terrainPresent).toBe(true);
+    expect(metadata.negativeAltitudeThreshold).toBe(CesiumMath.EPSILON12);
+    expect(metadata.negativeAltitudeExponentBias).toBe(32);
+    expect(metadata.providers).toEqual({});
 
-      expect(provider.imageryPresent).toBe(true);
-      expect(provider.protoImagery).toBeUndefined();
-      expect(provider.terrainPresent).toBe(true);
-      expect(provider.negativeAltitudeThreshold).toBe(CesiumMath.EPSILON12);
-      expect(provider.negativeAltitudeExponentBias).toBe(32);
-      expect(provider.providers).toEqual({});
-
-      const tileInfo = provider._tileInfo["0"];
-      expect(tileInfo).toBeDefined();
-      expect(tileInfo._bits).toEqual(0x40);
-      expect(tileInfo.cnodeVersion).toEqual(2);
-      expect(tileInfo.imageryVersion).toEqual(1);
-      expect(tileInfo.terrainVersion).toEqual(1);
-      expect(tileInfo.ancestorHasTerrain).toEqual(false);
-      expect(tileInfo.terrainState).toBeUndefined();
-    });
+    const tileInfo = metadata._tileInfo["0"];
+    expect(tileInfo).toBeDefined();
+    expect(tileInfo._bits).toEqual(0x40);
+    expect(tileInfo.cnodeVersion).toEqual(2);
+    expect(tileInfo.imageryVersion).toEqual(1);
+    expect(tileInfo.terrainVersion).toEqual(1);
+    expect(tileInfo.ancestorHasTerrain).toEqual(false);
+    expect(tileInfo.terrainState).toBeUndefined();
   });
 
-  it("rejects readyPromise on error", function () {
+  it("fromUrl rejects on error", async function () {
     const url = "host.invalid/";
-    const provider = new GoogleEarthEnterpriseMetadata({
-      url: url,
-    });
-
-    return provider.readyPromise
-      .then(function () {
-        fail("should not resolve");
-      })
-      .catch(function (e) {
-        expect(e.message).toContain(url);
-      });
+    await expectAsync(
+      GoogleEarthEnterpriseMetadata.fromUrl(url)
+    ).toBeRejectedWithError(
+      RuntimeError,
+      "An error occurred while accessing http://localhost:9876/host.invalid/flatfile?q2-0-q.1: Request has failed. Status Code: 404"
+    );
   });
 });

--- a/packages/engine/Specs/Core/GoogleEarthEnterpriseMetadataSpec.js
+++ b/packages/engine/Specs/Core/GoogleEarthEnterpriseMetadataSpec.js
@@ -108,7 +108,7 @@ describe("Core/GoogleEarthEnterpriseMetadata", function () {
     }).toThrowError(RuntimeError);
   });
 
-  it("populateSubtree", function () {
+  it("populateSubtree", async function () {
     const quad = "0123";
     let index = 0;
     spyOn(
@@ -127,45 +127,35 @@ describe("Core/GoogleEarthEnterpriseMetadata", function () {
       return Promise.resolve();
     });
 
-    const metadata = new GoogleEarthEnterpriseMetadata({
-      url: "http://test.server",
-    });
+    const metadata = await GoogleEarthEnterpriseMetadata.fromUrl(
+      "http://test.server"
+    );
     const request = new Request({
       throttle: true,
     });
-    return metadata.readyPromise
-      .then(function () {
-        const tileXY = GoogleEarthEnterpriseMetadata.quadKeyToTileXY(quad);
-        return metadata.populateSubtree(
-          tileXY.x,
-          tileXY.y,
-          tileXY.level,
-          request
-        );
-      })
-      .then(function () {
-        expect(
-          GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket.calls.count()
-        ).toEqual(4);
-        expect(
-          GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
-        ).toHaveBeenCalledWith("", 1);
-        expect(
-          GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
-        ).toHaveBeenCalledWith("0", 1, request);
-        expect(
-          GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
-        ).toHaveBeenCalledWith("01", 1, request);
-        expect(
-          GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
-        ).toHaveBeenCalledWith("012", 1, request);
+    const tileXY = GoogleEarthEnterpriseMetadata.quadKeyToTileXY(quad);
+    await metadata.populateSubtree(tileXY.x, tileXY.y, tileXY.level, request);
+    expect(
+      GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket.calls.count()
+    ).toEqual(4);
+    expect(
+      GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
+    ).toHaveBeenCalledWith("", 1);
+    expect(
+      GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
+    ).toHaveBeenCalledWith("0", 1, request);
+    expect(
+      GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
+    ).toHaveBeenCalledWith("01", 1, request);
+    expect(
+      GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
+    ).toHaveBeenCalledWith("012", 1, request);
 
-        const tileInfo = metadata._tileInfo;
-        expect(tileInfo["0"]).toBeDefined();
-        expect(tileInfo["01"]).toBeDefined();
-        expect(tileInfo["012"]).toBeDefined();
-        expect(tileInfo["0123"]).toBeDefined();
-      });
+    const tileInfo = metadata._tileInfo;
+    expect(tileInfo["0"]).toBeDefined();
+    expect(tileInfo["01"]).toBeDefined();
+    expect(tileInfo["012"]).toBeDefined();
+    expect(tileInfo["0123"]).toBeDefined();
   });
 
   it("resolves readyPromise", function () {

--- a/packages/engine/Specs/Core/GoogleEarthEnterpriseMetadataSpec.js
+++ b/packages/engine/Specs/Core/GoogleEarthEnterpriseMetadataSpec.js
@@ -108,7 +108,7 @@ describe("Core/GoogleEarthEnterpriseMetadata", function () {
     }).toThrowError(RuntimeError);
   });
 
-  it("populateSubtree", async function () {
+  it("populateSubtree", function () {
     const quad = "0123";
     let index = 0;
     spyOn(
@@ -127,36 +127,173 @@ describe("Core/GoogleEarthEnterpriseMetadata", function () {
       return Promise.resolve();
     });
 
-    const metadata = await GoogleEarthEnterpriseMetadata.fromUrl(
-      "http://test.server"
-    );
+    const metadata = new GoogleEarthEnterpriseMetadata({
+      url: "http://test.server",
+    });
     const request = new Request({
       throttle: true,
     });
+    return metadata.readyPromise
+      .then(function () {
+        const tileXY = GoogleEarthEnterpriseMetadata.quadKeyToTileXY(quad);
+        return metadata.populateSubtree(
+          tileXY.x,
+          tileXY.y,
+          tileXY.level,
+          request
+        );
+      })
+      .then(function () {
+        expect(
+          GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket.calls.count()
+        ).toEqual(4);
+        expect(
+          GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
+        ).toHaveBeenCalledWith("", 1);
+        expect(
+          GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
+        ).toHaveBeenCalledWith("0", 1, request);
+        expect(
+          GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
+        ).toHaveBeenCalledWith("01", 1, request);
+        expect(
+          GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
+        ).toHaveBeenCalledWith("012", 1, request);
 
-    const tileXY = GoogleEarthEnterpriseMetadata.quadKeyToTileXY(quad);
-    await metadata.populateSubtree(tileXY.x, tileXY.y, tileXY.level, request);
-    expect(
-      GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket.calls.count()
-    ).toEqual(4);
-    expect(
-      GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
-    ).toHaveBeenCalledWith("", 1);
-    expect(
-      GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
-    ).toHaveBeenCalledWith("0", 1, request);
-    expect(
-      GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
-    ).toHaveBeenCalledWith("01", 1, request);
-    expect(
-      GoogleEarthEnterpriseMetadata.prototype.getQuadTreePacket
-    ).toHaveBeenCalledWith("012", 1, request);
+        const tileInfo = metadata._tileInfo;
+        expect(tileInfo["0"]).toBeDefined();
+        expect(tileInfo["01"]).toBeDefined();
+        expect(tileInfo["012"]).toBeDefined();
+        expect(tileInfo["0123"]).toBeDefined();
+      });
+  });
 
-    const tileInfo = metadata._tileInfo;
-    expect(tileInfo["0"]).toBeDefined();
-    expect(tileInfo["01"]).toBeDefined();
-    expect(tileInfo["012"]).toBeDefined();
-    expect(tileInfo["0123"]).toBeDefined();
+  it("resolves readyPromise", function () {
+    const baseurl = "http://fake.fake.invalid/";
+
+    let req = 0;
+    spyOn(Resource._Implementations, "loadWithXhr").and.callFake(function (
+      url,
+      responseType,
+      method,
+      data,
+      headers,
+      deferred,
+      overrideMimeType
+    ) {
+      expect(responseType).toEqual("arraybuffer");
+      if (req === 0) {
+        expect(url).toEqual(`${baseurl}dbRoot.v5?output=proto`);
+        deferred.reject(); // Reject dbRoot request and use defaults
+      } else {
+        expect(url).toEqual(`${baseurl}flatfile?q2-0-q.1`);
+        Resource._DefaultImplementations.loadWithXhr(
+          "Data/GoogleEarthEnterprise/gee.metadata",
+          responseType,
+          method,
+          data,
+          headers,
+          deferred
+        );
+      }
+      ++req;
+    });
+
+    const provider = new GoogleEarthEnterpriseMetadata({
+      url: baseurl,
+    });
+
+    return provider.readyPromise.then(function (result) {
+      expect(result).toBe(true);
+
+      expect(provider.imageryPresent).toBe(true);
+      expect(provider.protoImagery).toBeUndefined();
+      expect(provider.terrainPresent).toBe(true);
+      expect(provider.negativeAltitudeThreshold).toBe(CesiumMath.EPSILON12);
+      expect(provider.negativeAltitudeExponentBias).toBe(32);
+      expect(provider.providers).toEqual({});
+
+      const tileInfo = provider._tileInfo["0"];
+      expect(tileInfo).toBeDefined();
+      expect(tileInfo._bits).toEqual(0x40);
+      expect(tileInfo.cnodeVersion).toEqual(2);
+      expect(tileInfo.imageryVersion).toEqual(1);
+      expect(tileInfo.terrainVersion).toEqual(1);
+      expect(tileInfo.ancestorHasTerrain).toEqual(false);
+      expect(tileInfo.terrainState).toBeUndefined();
+    });
+  });
+
+  it("resolves readyPromise with Resource", function () {
+    const baseurl = "http://fake.fake.invalid/";
+    const resource = new Resource({
+      url: baseurl,
+    });
+
+    let req = 0;
+    spyOn(Resource._Implementations, "loadWithXhr").and.callFake(function (
+      url,
+      responseType,
+      method,
+      data,
+      headers,
+      deferred,
+      overrideMimeType
+    ) {
+      expect(responseType).toEqual("arraybuffer");
+      if (req === 0) {
+        expect(url).toEqual(`${baseurl}dbRoot.v5?output=proto`);
+        deferred.reject(); // Reject dbRoot request and use defaults
+      } else {
+        expect(url).toEqual(`${baseurl}flatfile?q2-0-q.1`);
+        Resource._DefaultImplementations.loadWithXhr(
+          "Data/GoogleEarthEnterprise/gee.metadata",
+          responseType,
+          method,
+          data,
+          headers,
+          deferred
+        );
+      }
+      ++req;
+    });
+
+    const provider = new GoogleEarthEnterpriseMetadata(resource);
+
+    return provider.readyPromise.then(function (result) {
+      expect(result).toBe(true);
+
+      expect(provider.imageryPresent).toBe(true);
+      expect(provider.protoImagery).toBeUndefined();
+      expect(provider.terrainPresent).toBe(true);
+      expect(provider.negativeAltitudeThreshold).toBe(CesiumMath.EPSILON12);
+      expect(provider.negativeAltitudeExponentBias).toBe(32);
+      expect(provider.providers).toEqual({});
+
+      const tileInfo = provider._tileInfo["0"];
+      expect(tileInfo).toBeDefined();
+      expect(tileInfo._bits).toEqual(0x40);
+      expect(tileInfo.cnodeVersion).toEqual(2);
+      expect(tileInfo.imageryVersion).toEqual(1);
+      expect(tileInfo.terrainVersion).toEqual(1);
+      expect(tileInfo.ancestorHasTerrain).toEqual(false);
+      expect(tileInfo.terrainState).toBeUndefined();
+    });
+  });
+
+  it("rejects readyPromise on error", function () {
+    const url = "host.invalid/";
+    const provider = new GoogleEarthEnterpriseMetadata({
+      url: url,
+    });
+
+    return provider.readyPromise
+      .then(function () {
+        fail("should not resolve");
+      })
+      .catch(function (e) {
+        expect(e.message).toContain(url);
+      });
   });
 
   it("from url resolves to GoogleEarthEnterpriseMetadata", async function () {

--- a/packages/engine/Specs/Core/GoogleEarthEnterpriseTerrainProviderSpec.js
+++ b/packages/engine/Specs/Core/GoogleEarthEnterpriseTerrainProviderSpec.js
@@ -1,18 +1,19 @@
 import {
   defaultValue,
+  DeveloperError,
   Ellipsoid,
   GeographicTilingScheme,
   GoogleEarthEnterpriseMetadata,
   GoogleEarthEnterpriseTerrainData,
   GoogleEarthEnterpriseTerrainProvider,
   GoogleEarthEnterpriseTileInformation,
+  Math as CesiumMath,
   Request,
   RequestScheduler,
   Resource,
+  RuntimeError,
   TerrainProvider,
 } from "../../index.js";
-
-import { Math as CesiumMath } from "../../index.js";
 
 import pollToPromise from "../../../../Specs/pollToPromise.js";
 
@@ -45,23 +46,17 @@ describe("Core/GoogleEarthEnterpriseTerrainProvider", function () {
 
   let terrainProvider;
 
-  function waitForTile(level, x, y, f) {
-    terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-      url: "made/up/url",
+  async function waitForTile(level, x, y, f) {
+    const metadata = await GoogleEarthEnterpriseMetadata.fromUrl("made/up/url");
+    terrainProvider = GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+      metadata
+    );
+
+    await pollToPromise(function () {
+      return terrainProvider.getTileDataAvailable(x, y, level);
     });
 
-    return pollToPromise(function () {
-      return (
-        terrainProvider.ready &&
-        terrainProvider.getTileDataAvailable(x, y, level)
-      );
-    }).then(function () {
-      const promise = terrainProvider.requestTileGeometry(level, x, y);
-
-      return Promise.resolve(promise, f, function (error) {
-        expect("requestTileGeometry").toBe("returning a tile."); // test failure
-      });
-    });
+    return terrainProvider.requestTileGeometry(level, x, y);
   }
 
   function createRequest() {
@@ -85,96 +80,75 @@ describe("Core/GoogleEarthEnterpriseTerrainProvider", function () {
     );
   });
 
-  it("constructor throws if url is not provided", function () {
-    expect(function () {
-      return new GoogleEarthEnterpriseTerrainProvider();
-    }).toThrowDeveloperError();
-
-    expect(function () {
-      return new GoogleEarthEnterpriseTerrainProvider({});
-    }).toThrowDeveloperError();
+  it("fromMetadata throws without metadata", function () {
+    installMockGetQuadTreePacket();
+    expect(() =>
+      GoogleEarthEnterpriseTerrainProvider.fromMetadata()
+    ).toThrowError(
+      DeveloperError,
+      "metadata is required, actual value was undefined"
+    );
   });
 
-  it("resolves readyPromise", function () {
+  it("fromMetadata throws if there isn't terrain", async function () {
     installMockGetQuadTreePacket();
 
-    terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-      url: "made/up/url",
-    });
+    const metadata = await GoogleEarthEnterpriseMetadata.fromUrl("made/up/url");
+    metadata.terrainPresent = false;
 
-    return terrainProvider.readyPromise.then(function (result) {
-      expect(result).toBe(true);
-      expect(terrainProvider.ready).toBe(true);
-    });
+    expect(() =>
+      GoogleEarthEnterpriseTerrainProvider.fromMetadata(metadata)
+    ).toThrowError(
+      RuntimeError,
+      "The server made/up/url/ doesn't have terrain"
+    );
   });
 
-  it("resolves readyPromise with Resource", function () {
-    const resource = new Resource({
-      url: "made/up/url",
-    });
-
+  it("uses geographic tiling scheme by default", async function () {
     installMockGetQuadTreePacket();
 
-    terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-      url: resource,
-    });
+    const metadata = await GoogleEarthEnterpriseMetadata.fromUrl("made/up/url");
+    terrainProvider = GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+      metadata
+    );
 
-    return terrainProvider.readyPromise.then(function (result) {
-      expect(result).toBe(true);
-      expect(terrainProvider.ready).toBe(true);
-    });
+    expect(terrainProvider.tilingScheme).toBeInstanceOf(GeographicTilingScheme);
   });
 
-  it("uses geographic tiling scheme by default", function () {
-    installMockGetQuadTreePacket();
-
-    terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-      url: "made/up/url",
-    });
-
-    return pollToPromise(function () {
-      return terrainProvider.ready;
-    }).then(function () {
-      expect(terrainProvider.tilingScheme).toBeInstanceOf(
-        GeographicTilingScheme
-      );
-    });
-  });
-
-  it("can use a custom ellipsoid", function () {
+  it("can use a custom ellipsoid", async function () {
     installMockGetQuadTreePacket();
 
     const ellipsoid = new Ellipsoid(1, 2, 3);
-    terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-      url: "made/up/url",
-      ellipsoid: ellipsoid,
-    });
+    const metadata = await GoogleEarthEnterpriseMetadata.fromUrl("made/up/url");
+    terrainProvider = GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+      metadata,
+      {
+        ellipsoid: ellipsoid,
+      }
+    );
 
-    return pollToPromise(function () {
-      return terrainProvider.ready;
-    }).then(function () {
-      expect(terrainProvider.tilingScheme.ellipsoid).toEqual(ellipsoid);
-    });
+    expect(terrainProvider.tilingScheme.ellipsoid).toEqual(ellipsoid);
   });
 
-  it("has error event", function () {
-    terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-      url: "made/up/url",
-    });
-    expect(terrainProvider.errorEvent).toBeDefined();
-    expect(terrainProvider.errorEvent).toBe(terrainProvider.errorEvent);
-
-    return terrainProvider.readyPromise.catch(function (e) {
-      expect(terrainProvider.ready).toBe(false);
-    });
-  });
-
-  it("returns reasonable geometric error for various levels", function () {
+  it("has error event", async function () {
     installMockGetQuadTreePacket();
 
-    terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-      url: "made/up/url",
-    });
+    const metadata = await GoogleEarthEnterpriseMetadata.fromUrl("made/up/url");
+    terrainProvider = GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+      metadata
+    );
+
+    expect(terrainProvider.errorEvent).toBeDefined();
+    expect(terrainProvider.errorEvent).toBe(terrainProvider.errorEvent);
+  });
+
+  it("returns reasonable geometric error for various levels", async function () {
+    installMockGetQuadTreePacket();
+
+    const metadata = await GoogleEarthEnterpriseMetadata.fromUrl("made/up/url");
+    terrainProvider = GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+      metadata
+    );
 
     expect(terrainProvider.getLevelMaximumGeometricError(0)).toBeGreaterThan(
       0.0
@@ -187,87 +161,53 @@ describe("Core/GoogleEarthEnterpriseTerrainProvider", function () {
       terrainProvider.getLevelMaximumGeometricError(2) * 2.0,
       CesiumMath.EPSILON10
     );
-
-    return terrainProvider.readyPromise;
   });
 
-  it("readyPromise rejects if there isn't terrain", function () {
+  it("credit is undefined if credit is not provided", async function () {
     installMockGetQuadTreePacket();
 
-    const metadata = new GoogleEarthEnterpriseMetadata({
-      url: "made/up/url",
-    });
+    const metadata = await GoogleEarthEnterpriseMetadata.fromUrl("made/up/url");
+    terrainProvider = GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+      metadata
+    );
 
-    metadata.terrainPresent = false;
-
-    terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-      metadata: metadata,
-    });
-
-    return terrainProvider.readyPromise
-      .then(function () {
-        fail("Server does not have terrain, so we shouldn't resolve.");
-      })
-      .catch(function (e) {
-        expect(terrainProvider.ready).toBe(false);
-      });
+    expect(terrainProvider.credit).toBeUndefined();
   });
 
-  it("logo is undefined if credit is not provided", function () {
+  it("credit is defined if credit option is provided", async function () {
     installMockGetQuadTreePacket();
 
-    terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-      url: "made/up/url",
-    });
+    const metadata = await GoogleEarthEnterpriseMetadata.fromUrl("made/up/url");
+    terrainProvider = GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+      metadata,
+      {
+        credit: "thanks to our awesome made up contributors!",
+      }
+    );
 
-    return pollToPromise(function () {
-      return terrainProvider.ready;
-    }).then(function () {
-      expect(terrainProvider.credit).toBeUndefined();
-    });
+    expect(terrainProvider.credit).toBeDefined();
   });
 
-  it("logo is defined if credit is provided", function () {
+  it("has a water mask is false", async function () {
     installMockGetQuadTreePacket();
 
-    terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-      url: "made/up/url",
-      credit: "thanks to our awesome made up contributors!",
-    });
+    const metadata = await GoogleEarthEnterpriseMetadata.fromUrl("made/up/url");
+    terrainProvider = GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+      metadata
+    );
 
-    return pollToPromise(function () {
-      return terrainProvider.ready;
-    }).then(function () {
-      expect(terrainProvider.credit).toBeDefined();
-    });
+    expect(terrainProvider.hasWaterMask).toBe(false);
   });
 
-  it("has a water mask is false", function () {
+  it("has vertex normals is false", async function () {
     installMockGetQuadTreePacket();
 
-    terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-      url: "made/up/url",
-    });
+    const metadata = await GoogleEarthEnterpriseMetadata.fromUrl("made/up/url");
+    terrainProvider = GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+      metadata
+    );
 
-    return pollToPromise(function () {
-      return terrainProvider.ready;
-    }).then(function () {
-      expect(terrainProvider.hasWaterMask).toBe(false);
-    });
-  });
-
-  it("has vertex normals is false", function () {
-    installMockGetQuadTreePacket();
-
-    terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-      url: "made/up/url",
-    });
-
-    return pollToPromise(function () {
-      return terrainProvider.ready;
-    }).then(function () {
-      expect(terrainProvider.hasVertexNormals).toBe(false);
-    });
+    expect(terrainProvider.hasVertexNormals).toBe(false);
   });
 
   describe("requestTileGeometry", function () {
@@ -297,12 +237,8 @@ describe("Core/GoogleEarthEnterpriseTerrainProvider", function () {
       });
     });
 
-    it("returns undefined if too many requests are already in progress", function () {
+    it("returns undefined if too many requests are already in progress", async function () {
       installMockGetQuadTreePacket();
-      const baseUrl = "made/up/url";
-
-      const deferreds = [];
-      let loadRealTile = true;
       Resource._Implementations.loadWithXhr = function (
         url,
         responseType,
@@ -312,75 +248,61 @@ describe("Core/GoogleEarthEnterpriseTerrainProvider", function () {
         deferred,
         overrideMimeType
       ) {
-        if (url.indexOf("dbRoot.v5") !== -1) {
-          return deferred.reject(); // Just reject dbRoot file and use defaults.
-        }
-
-        if (loadRealTile) {
-          loadRealTile = false;
-          return Resource._DefaultImplementations.loadWithXhr(
-            "Data/GoogleEarthEnterprise/gee.terrain",
-            responseType,
-            method,
-            data,
-            headers,
-            deferred
-          );
-        }
-        // Do nothing, so requests never complete
-        deferreds.push(deferred);
+        Resource._DefaultImplementations.loadWithXhr(
+          "Data/GoogleEarthEnterprise/gee.terrain",
+          responseType,
+          method,
+          data,
+          headers,
+          deferred
+        );
       };
+      const baseUrl = "made/up/url";
 
-      terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-        url: baseUrl,
-      });
+      const metadata = await GoogleEarthEnterpriseMetadata.fromUrl(baseUrl);
+      terrainProvider = GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+        metadata
+      );
 
+      for (let i = 0; i < 10; ++i) {
+        await terrainProvider.getTileDataAvailable(i, i, i);
+      }
+      await terrainProvider.getTileDataAvailable(1, 2, 3);
+
+      let promise;
       const promises = [];
-      return pollToPromise(function () {
-        return terrainProvider.ready;
-      })
-        .then(function () {
-          return pollToPromise(function () {
-            let b = true;
-            for (let i = 0; i < 10; ++i) {
-              b = b && terrainProvider.getTileDataAvailable(i, i, i);
-            }
-            return b && terrainProvider.getTileDataAvailable(1, 2, 3);
-          });
-        })
-        .then(function () {
-          let promise;
-          for (let i = 0; i < RequestScheduler.maximumRequestsPerServer; ++i) {
-            const request = new Request({
-              throttle: true,
-              throttleByServer: true,
-            });
-            promise = terrainProvider.requestTileGeometry(i, i, i, request);
-            promises.push(promise);
-          }
-          RequestScheduler.update();
-          expect(promise).toBeDefined();
-
-          return terrainProvider.requestTileGeometry(1, 2, 3, createRequest());
-        })
-        .then(function (terrainData) {
-          expect(terrainData).toBeUndefined();
-          for (let i = 0; i < deferreds.length; ++i) {
-            deferreds[i].resolve();
-          }
-
-          // Parsing terrain will fail, so just eat the errors and request the tile again
-          return Promise.all(promises).catch(function () {
-            loadRealTile = true;
-            return terrainProvider.requestTileGeometry(1, 2, 3);
-          });
-        })
-        .then(function (terrainData) {
-          expect(terrainData).toBeDefined();
+      for (let i = 0; i < RequestScheduler.maximumRequestsPerServer; ++i) {
+        const request = new Request({
+          throttle: true,
+          throttleByServer: true,
         });
+        promise = terrainProvider.requestTileGeometry(i, i, i, request);
+        promises.push(promise);
+      }
+      RequestScheduler.update();
+      expect(promise).toBeDefined();
+
+      let terrainData = await terrainProvider.requestTileGeometry(
+        1,
+        2,
+        3,
+        createRequest()
+      );
+      expect(terrainData).toBeUndefined();
+
+      await Promise.all(promises);
+
+      terrainData = await terrainProvider.requestTileGeometry(
+        1,
+        2,
+        3,
+        createRequest()
+      );
+
+      expect(terrainData).toBeDefined();
     });
 
-    it("supports getTileDataAvailable()", function () {
+    it("supports getTileDataAvailable()", async function () {
       installMockGetQuadTreePacket();
       const baseUrl = "made/up/url";
 
@@ -403,26 +325,23 @@ describe("Core/GoogleEarthEnterpriseTerrainProvider", function () {
         );
       };
 
-      terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-        url: baseUrl,
-      });
+      const metadata = await GoogleEarthEnterpriseMetadata.fromUrl(baseUrl);
+      terrainProvider = GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+        metadata
+      );
 
-      return pollToPromise(function () {
-        return terrainProvider.ready;
-      }).then(function () {
-        const tileInfo = terrainProvider._metadata._tileInfo;
-        const info =
-          tileInfo[GoogleEarthEnterpriseMetadata.tileXYToQuadKey(0, 1, 0)];
-        info._bits = 0x7f; // Remove terrain bit from 0,1,0 tile
-        info.terrainState = 1; // NONE
-        info.ancestorHasTerrain = true;
+      const tileInfo = terrainProvider._metadata._tileInfo;
+      const info =
+        tileInfo[GoogleEarthEnterpriseMetadata.tileXYToQuadKey(0, 1, 0)];
+      info._bits = 0x7f; // Remove terrain bit from 0,1,0 tile
+      info.terrainState = 1; // NONE
+      info.ancestorHasTerrain = true;
 
-        expect(terrainProvider.getTileDataAvailable(0, 0, 0)).toBe(true);
-        expect(terrainProvider.getTileDataAvailable(0, 1, 0)).toBe(false);
-        expect(terrainProvider.getTileDataAvailable(1, 0, 0)).toBe(true);
-        expect(terrainProvider.getTileDataAvailable(1, 1, 0)).toBe(true);
-        expect(terrainProvider.getTileDataAvailable(0, 0, 2)).toBe(false);
-      });
+      expect(terrainProvider.getTileDataAvailable(0, 0, 0)).toBe(true);
+      expect(terrainProvider.getTileDataAvailable(0, 1, 0)).toBe(false);
+      expect(terrainProvider.getTileDataAvailable(1, 0, 0)).toBe(true);
+      expect(terrainProvider.getTileDataAvailable(1, 1, 0)).toBe(true);
+      expect(terrainProvider.getTileDataAvailable(0, 0, 2)).toBe(false);
     });
   });
 });

--- a/packages/engine/Specs/Core/GoogleEarthEnterpriseTerrainProviderSpec.js
+++ b/packages/engine/Specs/Core/GoogleEarthEnterpriseTerrainProviderSpec.js
@@ -1,6 +1,5 @@
 import {
   defaultValue,
-  DeveloperError,
   Ellipsoid,
   GeographicTilingScheme,
   GoogleEarthEnterpriseMetadata,
@@ -84,10 +83,7 @@ describe("Core/GoogleEarthEnterpriseTerrainProvider", function () {
     installMockGetQuadTreePacket();
     expect(() =>
       GoogleEarthEnterpriseTerrainProvider.fromMetadata()
-    ).toThrowError(
-      DeveloperError,
-      "metadata is required, actual value was undefined"
-    );
+    ).toThrowDeveloperError("metadata is required, actual value was undefined");
   });
 
   it("fromMetadata throws if there isn't terrain", async function () {

--- a/packages/engine/Specs/Core/GoogleEarthEnterpriseTerrainProviderSpec.js
+++ b/packages/engine/Specs/Core/GoogleEarthEnterpriseTerrainProviderSpec.js
@@ -45,16 +45,13 @@ describe("Core/GoogleEarthEnterpriseTerrainProvider", function () {
 
   let terrainProvider;
 
-  function waitForTile(level, x, y, f) {
-    terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-      url: "made/up/url",
-    });
-
+  async function waitForTile(level, x, y, f) {
+    const metadata = await GoogleEarthEnterpriseMetadata.fromUrl("made/up/url");
+    terrainProvider = GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+      metadata
+    );
     return pollToPromise(function () {
-      return (
-        terrainProvider.ready &&
-        terrainProvider.getTileDataAvailable(x, y, level)
-      );
+      return terrainProvider.getTileDataAvailable(x, y, level);
     }).then(function () {
       const promise = terrainProvider.requestTileGeometry(level, x, y);
 
@@ -136,56 +133,50 @@ describe("Core/GoogleEarthEnterpriseTerrainProvider", function () {
     });
   });
 
-  it("uses geographic tiling scheme by default", function () {
+  it("uses geographic tiling scheme by default", async function () {
     installMockGetQuadTreePacket();
 
-    terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-      url: "made/up/url",
-    });
+    const metadata = await GoogleEarthEnterpriseMetadata.fromUrl("made/up/url");
+    terrainProvider = GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+      metadata
+    );
 
-    return pollToPromise(function () {
-      return terrainProvider.ready;
-    }).then(function () {
-      expect(terrainProvider.tilingScheme).toBeInstanceOf(
-        GeographicTilingScheme
-      );
-    });
+    expect(terrainProvider.tilingScheme).toBeInstanceOf(GeographicTilingScheme);
   });
 
-  it("can use a custom ellipsoid", function () {
+  it("can use a custom ellipsoid", async function () {
     installMockGetQuadTreePacket();
 
     const ellipsoid = new Ellipsoid(1, 2, 3);
-    terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-      url: "made/up/url",
-      ellipsoid: ellipsoid,
-    });
+    const metadata = await GoogleEarthEnterpriseMetadata.fromUrl("made/up/url");
+    terrainProvider = GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+      metadata,
+      {
+        ellipsoid: ellipsoid,
+      }
+    );
 
-    return pollToPromise(function () {
-      return terrainProvider.ready;
-    }).then(function () {
-      expect(terrainProvider.tilingScheme.ellipsoid).toEqual(ellipsoid);
-    });
+    expect(terrainProvider.tilingScheme.ellipsoid).toEqual(ellipsoid);
   });
 
-  it("has error event", function () {
-    terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-      url: "made/up/url",
-    });
-    expect(terrainProvider.errorEvent).toBeDefined();
-    expect(terrainProvider.errorEvent).toBe(terrainProvider.errorEvent);
-
-    return terrainProvider.readyPromise.catch(function (e) {
-      expect(terrainProvider.ready).toBe(false);
-    });
-  });
-
-  it("returns reasonable geometric error for various levels", function () {
+  it("has error event", async function () {
     installMockGetQuadTreePacket();
 
-    terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-      url: "made/up/url",
-    });
+    const metadata = await GoogleEarthEnterpriseMetadata.fromUrl("made/up/url");
+    terrainProvider = GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+      metadata
+    );
+    expect(terrainProvider.errorEvent).toBeDefined();
+    expect(terrainProvider.errorEvent).toBe(terrainProvider.errorEvent);
+  });
+
+  it("returns reasonable geometric error for various levels", async function () {
+    installMockGetQuadTreePacket();
+
+    const metadata = await GoogleEarthEnterpriseMetadata.fromUrl("made/up/url");
+    terrainProvider = GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+      metadata
+    );
 
     expect(terrainProvider.getLevelMaximumGeometricError(0)).toBeGreaterThan(
       0.0
@@ -198,8 +189,6 @@ describe("Core/GoogleEarthEnterpriseTerrainProvider", function () {
       terrainProvider.getLevelMaximumGeometricError(2) * 2.0,
       CesiumMath.EPSILON10
     );
-
-    return terrainProvider.readyPromise;
   });
 
   it("readyPromise rejects if there isn't terrain", function () {
@@ -224,61 +213,51 @@ describe("Core/GoogleEarthEnterpriseTerrainProvider", function () {
       });
   });
 
-  it("logo is undefined if credit is not provided", function () {
+  it("credit is undefined if credit is not provided", async function () {
     installMockGetQuadTreePacket();
 
-    terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-      url: "made/up/url",
-    });
+    const metadata = await GoogleEarthEnterpriseMetadata.fromUrl("made/up/url");
+    terrainProvider = GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+      metadata
+    );
 
-    return pollToPromise(function () {
-      return terrainProvider.ready;
-    }).then(function () {
-      expect(terrainProvider.credit).toBeUndefined();
-    });
+    expect(terrainProvider.credit).toBeUndefined();
   });
 
-  it("logo is defined if credit is provided", function () {
+  it("logo is defined if credit is provided", async function () {
     installMockGetQuadTreePacket();
 
-    terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-      url: "made/up/url",
-      credit: "thanks to our awesome made up contributors!",
-    });
+    const metadata = await GoogleEarthEnterpriseMetadata.fromUrl("made/up/url");
+    terrainProvider = GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+      metadata,
+      {
+        credit: "thanks to our awesome made up contributors!",
+      }
+    );
 
-    return pollToPromise(function () {
-      return terrainProvider.ready;
-    }).then(function () {
-      expect(terrainProvider.credit).toBeDefined();
-    });
+    expect(terrainProvider.credit).toBeDefined();
   });
 
-  it("has a water mask is false", function () {
+  it("has a water mask is false", async function () {
     installMockGetQuadTreePacket();
 
-    terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-      url: "made/up/url",
-    });
+    const metadata = await GoogleEarthEnterpriseMetadata.fromUrl("made/up/url");
+    terrainProvider = GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+      metadata
+    );
 
-    return pollToPromise(function () {
-      return terrainProvider.ready;
-    }).then(function () {
-      expect(terrainProvider.hasWaterMask).toBe(false);
-    });
+    expect(terrainProvider.hasWaterMask).toBe(false);
   });
 
-  it("has vertex normals is false", function () {
+  it("has vertex normals is false", async function () {
     installMockGetQuadTreePacket();
 
-    terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-      url: "made/up/url",
-    });
+    const metadata = await GoogleEarthEnterpriseMetadata.fromUrl("made/up/url");
+    terrainProvider = GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+      metadata
+    );
 
-    return pollToPromise(function () {
-      return terrainProvider.ready;
-    }).then(function () {
-      expect(terrainProvider.hasVertexNormals).toBe(false);
-    });
+    expect(terrainProvider.hasVertexNormals).toBe(false);
   });
 
   describe("requestTileGeometry", function () {
@@ -345,7 +324,7 @@ describe("Core/GoogleEarthEnterpriseTerrainProvider", function () {
       expect(loadedData).toBeInstanceOf(GoogleEarthEnterpriseTerrainData);
     });
 
-    it("returns undefined if too many requests are already in progress", function () {
+    it("returns undefined if too many requests are already in progress", async function () {
       installMockGetQuadTreePacket();
       const baseUrl = "made/up/url";
 
@@ -379,23 +358,19 @@ describe("Core/GoogleEarthEnterpriseTerrainProvider", function () {
         deferreds.push(deferred);
       };
 
-      terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-        url: baseUrl,
-      });
+      const metadata = await GoogleEarthEnterpriseMetadata.fromUrl(baseUrl);
+      terrainProvider = GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+        metadata
+      );
 
       const promises = [];
       return pollToPromise(function () {
-        return terrainProvider.ready;
+        let b = true;
+        for (let i = 0; i < 10; ++i) {
+          b = b && terrainProvider.getTileDataAvailable(i, i, i);
+        }
+        return b && terrainProvider.getTileDataAvailable(1, 2, 3);
       })
-        .then(function () {
-          return pollToPromise(function () {
-            let b = true;
-            for (let i = 0; i < 10; ++i) {
-              b = b && terrainProvider.getTileDataAvailable(i, i, i);
-            }
-            return b && terrainProvider.getTileDataAvailable(1, 2, 3);
-          });
-        })
         .then(function () {
           let promise;
           for (let i = 0; i < RequestScheduler.maximumRequestsPerServer; ++i) {
@@ -428,7 +403,7 @@ describe("Core/GoogleEarthEnterpriseTerrainProvider", function () {
         });
     });
 
-    it("supports getTileDataAvailable()", function () {
+    it("supports getTileDataAvailable()", async function () {
       installMockGetQuadTreePacket();
       const baseUrl = "made/up/url";
 
@@ -451,26 +426,23 @@ describe("Core/GoogleEarthEnterpriseTerrainProvider", function () {
         );
       };
 
-      terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
-        url: baseUrl,
-      });
+      const metadata = await GoogleEarthEnterpriseMetadata.fromUrl(baseUrl);
+      terrainProvider = GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+        metadata
+      );
 
-      return pollToPromise(function () {
-        return terrainProvider.ready;
-      }).then(function () {
-        const tileInfo = terrainProvider._metadata._tileInfo;
-        const info =
-          tileInfo[GoogleEarthEnterpriseMetadata.tileXYToQuadKey(0, 1, 0)];
-        info._bits = 0x7f; // Remove terrain bit from 0,1,0 tile
-        info.terrainState = 1; // NONE
-        info.ancestorHasTerrain = true;
+      const tileInfo = terrainProvider._metadata._tileInfo;
+      const info =
+        tileInfo[GoogleEarthEnterpriseMetadata.tileXYToQuadKey(0, 1, 0)];
+      info._bits = 0x7f; // Remove terrain bit from 0,1,0 tile
+      info.terrainState = 1; // NONE
+      info.ancestorHasTerrain = true;
 
-        expect(terrainProvider.getTileDataAvailable(0, 0, 0)).toBe(true);
-        expect(terrainProvider.getTileDataAvailable(0, 1, 0)).toBe(false);
-        expect(terrainProvider.getTileDataAvailable(1, 0, 0)).toBe(true);
-        expect(terrainProvider.getTileDataAvailable(1, 1, 0)).toBe(true);
-        expect(terrainProvider.getTileDataAvailable(0, 0, 2)).toBe(false);
-      });
+      expect(terrainProvider.getTileDataAvailable(0, 0, 0)).toBe(true);
+      expect(terrainProvider.getTileDataAvailable(0, 1, 0)).toBe(false);
+      expect(terrainProvider.getTileDataAvailable(1, 0, 0)).toBe(true);
+      expect(terrainProvider.getTileDataAvailable(1, 1, 0)).toBe(true);
+      expect(terrainProvider.getTileDataAvailable(0, 0, 2)).toBe(false);
     });
   });
 });

--- a/packages/engine/Specs/Core/VRTheWorldTerrainProviderSpec.js
+++ b/packages/engine/Specs/Core/VRTheWorldTerrainProviderSpec.js
@@ -5,7 +5,6 @@ import {
   Request,
   RequestScheduler,
   Resource,
-  RuntimeError,
   TerrainProvider,
   VRTheWorldTerrainProvider,
 } from "../../index.js";
@@ -112,54 +111,106 @@ describe("Core/VRTheWorldTerrainProvider", function () {
     expect(provider).toBeInstanceOf(VRTheWorldTerrainProvider);
   });
 
-  it("has error event", async function () {
+  it("resolves readyPromise", function () {
     patchXHRLoad();
 
-    const provider = await VRTheWorldTerrainProvider.fromUrl("made/up/url");
+    const provider = new VRTheWorldTerrainProvider({
+      url: "made/up/url",
+    });
+
+    return provider.readyPromise.then(function (result) {
+      expect(result).toBe(true);
+      expect(provider.ready).toBe(true);
+    });
+  });
+
+  it("resolves readyPromise with Resource", function () {
+    patchXHRLoad();
+
+    const resource = new Resource({
+      url: "made/up/url",
+    });
+
+    const provider = new VRTheWorldTerrainProvider({
+      url: resource,
+    });
+
+    return provider.readyPromise.then(function (result) {
+      expect(result).toBe(true);
+      expect(provider.ready).toBe(true);
+    });
+  });
+
+  it("has error event", function () {
+    patchXHRLoad();
+
+    const provider = new VRTheWorldTerrainProvider({
+      url: "made/up/url",
+    });
     expect(provider.errorEvent).toBeDefined();
     expect(provider.errorEvent).toBe(provider.errorEvent);
+    return provider.readyPromise;
   });
 
-  it("returns reasonable geometric error for various levels", async function () {
+  it("returns reasonable geometric error for various levels", function () {
     patchXHRLoad();
 
-    const provider = await VRTheWorldTerrainProvider.fromUrl("made/up/url");
+    const provider = new VRTheWorldTerrainProvider({
+      url: "made/up/url",
+    });
 
-    expect(provider.getLevelMaximumGeometricError(0)).toBeGreaterThan(0.0);
-    expect(provider.getLevelMaximumGeometricError(0)).toEqualEpsilon(
-      provider.getLevelMaximumGeometricError(1) * 2.0,
-      CesiumMath.EPSILON10
-    );
-    expect(provider.getLevelMaximumGeometricError(1)).toEqualEpsilon(
-      provider.getLevelMaximumGeometricError(2) * 2.0,
-      CesiumMath.EPSILON10
-    );
+    return provider.readyPromise.then(function () {
+      expect(provider.getLevelMaximumGeometricError(0)).toBeGreaterThan(0.0);
+      expect(provider.getLevelMaximumGeometricError(0)).toEqualEpsilon(
+        provider.getLevelMaximumGeometricError(1) * 2.0,
+        CesiumMath.EPSILON10
+      );
+      expect(provider.getLevelMaximumGeometricError(1)).toEqualEpsilon(
+        provider.getLevelMaximumGeometricError(2) * 2.0,
+        CesiumMath.EPSILON10
+      );
+    });
   });
 
-  it("credit is undefined if credit is not provided", async function () {
+  it("credit is undefined if credit option is not provided", function () {
     patchXHRLoad();
-
-    const provider = await VRTheWorldTerrainProvider.fromUrl("made/up/url");
+    const provider = new VRTheWorldTerrainProvider({
+      url: "made/up/url",
+    });
     expect(provider.credit).toBeUndefined();
+    return provider.readyPromise;
   });
 
-  it("credit is defined if credit option is provided", async function () {
+  it("credit is defined if credit optoin is provided", function () {
     patchXHRLoad();
-
-    const provider = await VRTheWorldTerrainProvider.fromUrl("made/up/url", {
+    const provider = new VRTheWorldTerrainProvider({
+      url: "made/up/url",
       credit: "thanks to our awesome made up contributors!",
     });
     expect(provider.credit).toBeDefined();
+    return provider.readyPromise;
   });
 
-  it("does not have a water mask", async function () {
+  it("does not have a water mask", function () {
     patchXHRLoad();
-
-    const provider = await VRTheWorldTerrainProvider.fromUrl("made/up/url");
+    const provider = new VRTheWorldTerrainProvider({
+      url: "made/up/url",
+    });
     expect(provider.hasWaterMask).toBe(false);
+    return provider.readyPromise;
   });
 
-  it("fromUrl throws an error if the SRS is not supported", async function () {
+  it("is not ready immediately", function () {
+    patchXHRLoad();
+    const provider = new VRTheWorldTerrainProvider({
+      url: "made/up/url",
+    });
+    expect(provider.ready).toBe(false);
+    return provider.readyPromise;
+  });
+
+  it("raises an error if the SRS is not supported", function () {
+    patchXHRLoad();
     Resource._Implementations.loadWithXhr = function (
       url,
       responseType,
@@ -196,15 +247,27 @@ describe("Core/VRTheWorldTerrainProvider", function () {
       }, 1);
     };
 
-    await expectAsync(
-      VRTheWorldTerrainProvider.fromUrl("made/up/url")
-    ).toBeRejectedWithError(RuntimeError, "SRS EPSG:foo is not supported");
+    const terrainProvider = new VRTheWorldTerrainProvider({
+      url: "made/up/url",
+    });
+
+    let called = false;
+    const errorFunction = function () {
+      called = true;
+    };
+
+    terrainProvider.errorEvent.addEventListener(errorFunction);
+
+    return terrainProvider.readyPromise.then(fail).catch(() => {
+      expect(called).toBe(true);
+    });
   });
 
   describe("requestTileGeometry", function () {
-    it("provides HeightmapTerrainData", async function () {
-      const baseUrl = "made/up/url";
+    it("provides HeightmapTerrainData", function () {
       patchXHRLoad();
+
+      const baseUrl = "made/up/url";
 
       Resource._Implementations.createImage = function (
         request,
@@ -223,18 +286,25 @@ describe("Core/VRTheWorldTerrainProvider", function () {
         );
       };
 
-      const terrainProvider = await VRTheWorldTerrainProvider.fromUrl(baseUrl);
-      expect(terrainProvider.tilingScheme).toBeInstanceOf(
-        GeographicTilingScheme
-      );
+      const terrainProvider = new VRTheWorldTerrainProvider({
+        url: baseUrl,
+      });
 
-      const loadedData = await terrainProvider.requestTileGeometry(0, 0, 0);
-      expect(loadedData).toBeInstanceOf(HeightmapTerrainData);
+      return terrainProvider.readyPromise
+        .then(function () {
+          expect(terrainProvider.tilingScheme).toBeInstanceOf(
+            GeographicTilingScheme
+          );
+          return terrainProvider.requestTileGeometry(0, 0, 0);
+        })
+        .then(function (loadedData) {
+          expect(loadedData).toBeInstanceOf(HeightmapTerrainData);
+        });
     });
 
-    it("returns undefined if too many requests are already in progress", async function () {
-      const baseUrl = "made/up/url";
+    it("returns undefined if too many requests are already in progress", function () {
       patchXHRLoad();
+      const baseUrl = "made/up/url";
 
       const deferreds = [];
 
@@ -247,35 +317,39 @@ describe("Core/VRTheWorldTerrainProvider", function () {
         deferreds.push(deferred);
       };
 
-      const terrainProvider = await VRTheWorldTerrainProvider.fromUrl(baseUrl);
+      const terrainProvider = new VRTheWorldTerrainProvider({
+        url: baseUrl,
+      });
 
-      const promises = [];
-      let promise;
-      let i;
-      for (i = 0; i < RequestScheduler.maximumRequestsPerServer; ++i) {
-        const request = new Request({
-          throttle: true,
-          throttleByServer: true,
-        });
-        promise = terrainProvider.requestTileGeometry(0, 0, 0, request);
-        promises.push(promise);
-      }
-      RequestScheduler.update();
-      expect(promise).toBeDefined();
+      return terrainProvider.readyPromise.then(function () {
+        const promises = [];
+        let promise;
+        let i;
+        for (i = 0; i < RequestScheduler.maximumRequestsPerServer; ++i) {
+          const request = new Request({
+            throttle: true,
+            throttleByServer: true,
+          });
+          promise = terrainProvider.requestTileGeometry(0, 0, 0, request);
+          promises.push(promise);
+        }
+        RequestScheduler.update();
+        expect(promise).toBeDefined();
 
-      promise = terrainProvider.requestTileGeometry(0, 0, 0, createRequest());
-      expect(promise).toBeUndefined();
+        promise = terrainProvider.requestTileGeometry(0, 0, 0, createRequest());
+        expect(promise).toBeUndefined();
 
-      for (i = 0; i < deferreds.length; ++i) {
-        const deferred = deferreds[i];
-        Resource._Implementations.loadImageElement(
-          "Data/Images/Red16x16.png",
-          false,
-          deferred
-        );
-      }
+        for (i = 0; i < deferreds.length; ++i) {
+          const deferred = deferreds[i];
+          Resource._Implementations.loadImageElement(
+            "Data/Images/Red16x16.png",
+            false,
+            deferred
+          );
+        }
 
-      return Promise.all(promises);
+        return Promise.all(promises);
+      });
     });
   });
 });

--- a/packages/engine/Specs/Core/VRTheWorldTerrainProviderSpec.js
+++ b/packages/engine/Specs/Core/VRTheWorldTerrainProviderSpec.js
@@ -1,21 +1,20 @@
 import {
-  DefaultProxy,
+  DeveloperError,
   GeographicTilingScheme,
   HeightmapTerrainData,
+  Math as CesiumMath,
   Request,
   RequestScheduler,
   Resource,
+  RuntimeError,
   TerrainProvider,
   VRTheWorldTerrainProvider,
 } from "../../index.js";
 
-import { Math as CesiumMath } from "../../index.js";
-
 describe("Core/VRTheWorldTerrainProvider", function () {
   const imageUrl = "Data/Images/Red16x16.png";
 
-  beforeEach(function () {
-    RequestScheduler.clearForSpecs();
+  function patchXHRLoad() {
     Resource._Implementations.loadWithXhr = function (
       url,
       responseType,
@@ -64,6 +63,10 @@ describe("Core/VRTheWorldTerrainProvider", function () {
         deferred.resolve(xml);
       }, 1);
     };
+  }
+
+  beforeEach(function () {
+    RequestScheduler.clearForSpecs();
   });
 
   afterEach(function () {
@@ -83,125 +86,79 @@ describe("Core/VRTheWorldTerrainProvider", function () {
     expect(VRTheWorldTerrainProvider).toConformToInterface(TerrainProvider);
   });
 
-  it("constructor throws if url is not provided", function () {
-    expect(function () {
-      return new VRTheWorldTerrainProvider();
-    }).toThrowDeveloperError();
-
-    expect(function () {
-      return new VRTheWorldTerrainProvider({});
-    }).toThrowDeveloperError();
+  it("fromUrl rejects without url", async function () {
+    await expectAsync(
+      VRTheWorldTerrainProvider.fromUrl()
+    ).toBeRejectedWithError(DeveloperError);
   });
 
-  it("resolves readyPromise", function () {
-    const provider = new VRTheWorldTerrainProvider({
-      url: "made/up/url",
-    });
+  it("fromUrl resolves to new VRTheWorldTerrainProvider", async function () {
+    patchXHRLoad();
 
-    return provider.readyPromise.then(function (result) {
-      expect(result).toBe(true);
-      expect(provider.ready).toBe(true);
-    });
+    const provider = await VRTheWorldTerrainProvider.fromUrl("made/up/url");
+
+    expect(provider).toBeInstanceOf(VRTheWorldTerrainProvider);
   });
 
-  it("resolves readyPromise with Resource", function () {
+  it("fromUrl with Resource resolves to new VRTheWorldTerrainProvider", async function () {
+    patchXHRLoad();
+
     const resource = new Resource({
       url: "made/up/url",
     });
+    const provider = await VRTheWorldTerrainProvider.fromUrl(resource);
 
-    const provider = new VRTheWorldTerrainProvider({
-      url: resource,
-    });
-
-    return provider.readyPromise.then(function (result) {
-      expect(result).toBe(true);
-      expect(provider.ready).toBe(true);
-    });
+    expect(provider).toBeInstanceOf(VRTheWorldTerrainProvider);
   });
 
-  it("has error event", function () {
-    const provider = new VRTheWorldTerrainProvider({
-      url: "made/up/url",
-    });
+  it("has error event", async function () {
+    patchXHRLoad();
+
+    const provider = await VRTheWorldTerrainProvider.fromUrl("made/up/url");
     expect(provider.errorEvent).toBeDefined();
     expect(provider.errorEvent).toBe(provider.errorEvent);
-    return provider.readyPromise;
   });
 
-  it("returns reasonable geometric error for various levels", function () {
-    const provider = new VRTheWorldTerrainProvider({
-      url: "made/up/url",
-    });
+  it("returns reasonable geometric error for various levels", async function () {
+    patchXHRLoad();
 
-    return provider.readyPromise.then(function () {
-      expect(provider.getLevelMaximumGeometricError(0)).toBeGreaterThan(0.0);
-      expect(provider.getLevelMaximumGeometricError(0)).toEqualEpsilon(
-        provider.getLevelMaximumGeometricError(1) * 2.0,
-        CesiumMath.EPSILON10
-      );
-      expect(provider.getLevelMaximumGeometricError(1)).toEqualEpsilon(
-        provider.getLevelMaximumGeometricError(2) * 2.0,
-        CesiumMath.EPSILON10
-      );
-    });
+    const provider = await VRTheWorldTerrainProvider.fromUrl("made/up/url");
+
+    expect(provider.getLevelMaximumGeometricError(0)).toBeGreaterThan(0.0);
+    expect(provider.getLevelMaximumGeometricError(0)).toEqualEpsilon(
+      provider.getLevelMaximumGeometricError(1) * 2.0,
+      CesiumMath.EPSILON10
+    );
+    expect(provider.getLevelMaximumGeometricError(1)).toEqualEpsilon(
+      provider.getLevelMaximumGeometricError(2) * 2.0,
+      CesiumMath.EPSILON10
+    );
   });
 
-  it("getLevelMaximumGeometricError must not be called before isReady returns true", function () {
-    const provider = new VRTheWorldTerrainProvider({
-      url: "made/up/url",
-    });
+  it("credit is undefined if credit is not provided", async function () {
+    patchXHRLoad();
 
-    expect(function () {
-      provider.getLevelMaximumGeometricError(0);
-    }).toThrowDeveloperError();
-    return provider.readyPromise;
-  });
-
-  it("getTilingScheme must not be called before isReady returns true", function () {
-    const provider = new VRTheWorldTerrainProvider({
-      url: "made/up/url",
-    });
-
-    expect(function () {
-      return provider.tilingScheme;
-    }).toThrowDeveloperError();
-    return provider.readyPromise;
-  });
-
-  it("logo is undefined if credit is not provided", function () {
-    const provider = new VRTheWorldTerrainProvider({
-      url: "made/up/url",
-    });
+    const provider = await VRTheWorldTerrainProvider.fromUrl("made/up/url");
     expect(provider.credit).toBeUndefined();
-    return provider.readyPromise;
   });
 
-  it("logo is defined if credit is provided", function () {
-    const provider = new VRTheWorldTerrainProvider({
-      url: "made/up/url",
+  it("credit is defined if credit option is provided", async function () {
+    patchXHRLoad();
+
+    const provider = await VRTheWorldTerrainProvider.fromUrl("made/up/url", {
       credit: "thanks to our awesome made up contributors!",
     });
     expect(provider.credit).toBeDefined();
-    return provider.readyPromise;
   });
 
-  it("does not have a water mask", function () {
-    const provider = new VRTheWorldTerrainProvider({
-      url: "made/up/url",
-    });
+  it("does not have a water mask", async function () {
+    patchXHRLoad();
+
+    const provider = await VRTheWorldTerrainProvider.fromUrl("made/up/url");
     expect(provider.hasWaterMask).toBe(false);
-    return provider.readyPromise;
   });
 
-  it("is not ready immediately", function () {
-    const provider = new VRTheWorldTerrainProvider({
-      url: "made/up/url",
-    });
-    expect(provider.ready).toBe(false);
-    return provider.readyPromise;
-  });
-
-  it("raises an error if the SRS is not supported", function () {
+  it("fromUrl throws an error if the SRS is not supported", async function () {
     Resource._Implementations.loadWithXhr = function (
       url,
       responseType,
@@ -238,37 +195,15 @@ describe("Core/VRTheWorldTerrainProvider", function () {
       }, 1);
     };
 
-    const terrainProvider = new VRTheWorldTerrainProvider({
-      url: "made/up/url",
-    });
-
-    let called = false;
-    const errorFunction = function () {
-      called = true;
-    };
-
-    terrainProvider.errorEvent.addEventListener(errorFunction);
-
-    return terrainProvider.readyPromise.then(fail).catch(() => {
-      expect(called).toBe(true);
-    });
+    await expectAsync(
+      VRTheWorldTerrainProvider.fromUrl("made/up/url")
+    ).toBeRejectedWithError(RuntimeError, "SRS EPSG:foo is not supported");
   });
 
   describe("requestTileGeometry", function () {
-    it("must not be called before isReady returns true", function () {
-      const terrainProvider = new VRTheWorldTerrainProvider({
-        url: "made/up/url",
-        proxy: new DefaultProxy("/proxy/"),
-      });
-
-      expect(function () {
-        terrainProvider.requestTileGeometry(0, 0, 0);
-      }).toThrowDeveloperError();
-      return terrainProvider.readyPromise;
-    });
-
-    it("provides HeightmapTerrainData", function () {
+    it("provides HeightmapTerrainData", async function () {
       const baseUrl = "made/up/url";
+      patchXHRLoad();
 
       Resource._Implementations.createImage = function (
         request,
@@ -287,24 +222,18 @@ describe("Core/VRTheWorldTerrainProvider", function () {
         );
       };
 
-      const terrainProvider = new VRTheWorldTerrainProvider({
-        url: baseUrl,
-      });
+      const terrainProvider = await VRTheWorldTerrainProvider.fromUrl(baseUrl);
+      expect(terrainProvider.tilingScheme).toBeInstanceOf(
+        GeographicTilingScheme
+      );
 
-      return terrainProvider.readyPromise
-        .then(function () {
-          expect(terrainProvider.tilingScheme).toBeInstanceOf(
-            GeographicTilingScheme
-          );
-          return terrainProvider.requestTileGeometry(0, 0, 0);
-        })
-        .then(function (loadedData) {
-          expect(loadedData).toBeInstanceOf(HeightmapTerrainData);
-        });
+      const loadedData = await terrainProvider.requestTileGeometry(0, 0, 0);
+      expect(loadedData).toBeInstanceOf(HeightmapTerrainData);
     });
 
-    it("returns undefined if too many requests are already in progress", function () {
+    it("returns undefined if too many requests are already in progress", async function () {
       const baseUrl = "made/up/url";
+      patchXHRLoad();
 
       const deferreds = [];
 
@@ -317,39 +246,35 @@ describe("Core/VRTheWorldTerrainProvider", function () {
         deferreds.push(deferred);
       };
 
-      const terrainProvider = new VRTheWorldTerrainProvider({
-        url: baseUrl,
-      });
+      const terrainProvider = await VRTheWorldTerrainProvider.fromUrl(baseUrl);
 
-      return terrainProvider.readyPromise.then(function () {
-        const promises = [];
-        let promise;
-        let i;
-        for (i = 0; i < RequestScheduler.maximumRequestsPerServer; ++i) {
-          const request = new Request({
-            throttle: true,
-            throttleByServer: true,
-          });
-          promise = terrainProvider.requestTileGeometry(0, 0, 0, request);
-          promises.push(promise);
-        }
-        RequestScheduler.update();
-        expect(promise).toBeDefined();
+      const promises = [];
+      let promise;
+      let i;
+      for (i = 0; i < RequestScheduler.maximumRequestsPerServer; ++i) {
+        const request = new Request({
+          throttle: true,
+          throttleByServer: true,
+        });
+        promise = terrainProvider.requestTileGeometry(0, 0, 0, request);
+        promises.push(promise);
+      }
+      RequestScheduler.update();
+      expect(promise).toBeDefined();
 
-        promise = terrainProvider.requestTileGeometry(0, 0, 0, createRequest());
-        expect(promise).toBeUndefined();
+      promise = terrainProvider.requestTileGeometry(0, 0, 0, createRequest());
+      expect(promise).toBeUndefined();
 
-        for (i = 0; i < deferreds.length; ++i) {
-          const deferred = deferreds[i];
-          Resource._Implementations.loadImageElement(
-            "Data/Images/Red16x16.png",
-            false,
-            deferred
-          );
-        }
+      for (i = 0; i < deferreds.length; ++i) {
+        const deferred = deferreds[i];
+        Resource._Implementations.loadImageElement(
+          "Data/Images/Red16x16.png",
+          false,
+          deferred
+        );
+      }
 
-        return Promise.all(promises);
-      });
+      return Promise.all(promises);
     });
   });
 });

--- a/packages/engine/Specs/Core/VRTheWorldTerrainProviderSpec.js
+++ b/packages/engine/Specs/Core/VRTheWorldTerrainProviderSpec.js
@@ -1,5 +1,4 @@
 import {
-  DeveloperError,
   GeographicTilingScheme,
   HeightmapTerrainData,
   Math as CesiumMath,
@@ -89,7 +88,9 @@ describe("Core/VRTheWorldTerrainProvider", function () {
   it("fromUrl rejects without url", async function () {
     await expectAsync(
       VRTheWorldTerrainProvider.fromUrl()
-    ).toBeRejectedWithError(DeveloperError);
+    ).toBeRejectedWithDeveloperError(
+      "url is required, actual value was undefined"
+    );
   });
 
   it("fromUrl resolves to new VRTheWorldTerrainProvider", async function () {

--- a/packages/engine/Specs/Core/createWorldTerrainAsyncSpec.js
+++ b/packages/engine/Specs/Core/createWorldTerrainAsyncSpec.js
@@ -1,0 +1,10 @@
+import { createWorldTerrainAsync, CesiumTerrainProvider } from "../../index.js";
+
+describe("Core/createWorldTerrainAsync", function () {
+  it("resolves to CesiumTerrainProvider instance with default parameters", async function () {
+    const provider = await createWorldTerrainAsync();
+    expect(provider).toBeInstanceOf(CesiumTerrainProvider);
+    expect(provider.requestVertexNormals).toBe(false);
+    expect(provider.requestWaterMask).toBe(false);
+  });
+});

--- a/packages/engine/Specs/Core/sampleTerrainMostDetailedSpec.js
+++ b/packages/engine/Specs/Core/sampleTerrainMostDetailedSpec.js
@@ -2,6 +2,7 @@ import {
   Cartographic,
   CesiumTerrainProvider,
   createWorldTerrainAsync,
+  IonResource,
   sampleTerrainMostDetailed,
 } from "../../index.js";
 
@@ -9,6 +10,27 @@ describe("Core/sampleTerrainMostDetailed", function () {
   let worldTerrain;
   beforeAll(async function () {
     worldTerrain = await createWorldTerrainAsync();
+  });
+
+  it("queries heights from deprecated world terrain", async function () {
+    const positions = [
+      Cartographic.fromDegrees(86.925145, 27.988257),
+      Cartographic.fromDegrees(87.0, 28.0),
+    ];
+
+    const terrain = new CesiumTerrainProvider({
+      url: IonResource.fromAssetId(1),
+    });
+
+    return sampleTerrainMostDetailed(terrain, positions).then(function (
+      passedPositions
+    ) {
+      expect(passedPositions).toBe(positions);
+      expect(positions[0].height).toBeGreaterThan(5000);
+      expect(positions[0].height).toBeLessThan(10000);
+      expect(positions[1].height).toBeGreaterThan(5000);
+      expect(positions[1].height).toBeLessThan(10000);
+    });
   });
 
   it("queries heights", async function () {

--- a/packages/engine/Specs/Core/sampleTerrainMostDetailedSpec.js
+++ b/packages/engine/Specs/Core/sampleTerrainMostDetailedSpec.js
@@ -1,87 +1,88 @@
 import {
   Cartographic,
   CesiumTerrainProvider,
-  createWorldTerrain,
+  createWorldTerrainAsync,
+  DeveloperError,
   sampleTerrainMostDetailed,
 } from "../../index.js";
 
 describe("Core/sampleTerrainMostDetailed", function () {
   let worldTerrain;
-  beforeAll(function () {
-    worldTerrain = createWorldTerrain();
-    return worldTerrain.readyPromise;
+  beforeAll(async function () {
+    worldTerrain = await createWorldTerrainAsync();
   });
 
-  it("queries heights", function () {
+  it("queries heights", async function () {
     const positions = [
       Cartographic.fromDegrees(86.925145, 27.988257),
       Cartographic.fromDegrees(87.0, 28.0),
     ];
 
-    return sampleTerrainMostDetailed(worldTerrain, positions).then(function (
-      passedPositions
-    ) {
-      expect(passedPositions).toBe(positions);
-      expect(positions[0].height).toBeGreaterThan(5000);
-      expect(positions[0].height).toBeLessThan(10000);
-      expect(positions[1].height).toBeGreaterThan(5000);
-      expect(positions[1].height).toBeLessThan(10000);
-    });
+    const passedPositions = await sampleTerrainMostDetailed(
+      worldTerrain,
+      positions
+    );
+    expect(passedPositions).toBe(positions);
+    expect(positions[0].height).toBeGreaterThan(5000);
+    expect(positions[0].height).toBeLessThan(10000);
+    expect(positions[1].height).toBeGreaterThan(5000);
+    expect(positions[1].height).toBeLessThan(10000);
   });
 
-  it("should throw querying heights from Small Terrain", function () {
-    const terrainProvider = new CesiumTerrainProvider({
-      url: "https://s3.amazonaws.com/cesiumjs/smallTerrain",
-    });
+  it("should throw querying heights from Small Terrain", async function () {
+    const terrainProvider = await CesiumTerrainProvider.fromUrl(
+      "https://s3.amazonaws.com/cesiumjs/smallTerrain"
+    );
 
     const positions = [
       Cartographic.fromDegrees(86.925145, 27.988257),
       Cartographic.fromDegrees(87.0, 28.0),
     ];
 
-    return sampleTerrainMostDetailed(terrainProvider, positions)
-      .then(function () {
-        fail("the promise should not resolve");
-      })
-      .catch(function () {});
+    await expectAsync(
+      sampleTerrainMostDetailed(terrainProvider, positions)
+    ).toBeRejectedWithError(
+      DeveloperError,
+      "sampleTerrainMostDetailed requires a terrain provider that has tile availability."
+    );
   });
 
-  it("uses a suitable common tile height for a range of locations", function () {
+  it("uses a suitable common tile height for a range of locations", async function () {
     const positions = [
       Cartographic.fromDegrees(86.925145, 27.988257),
       Cartographic.fromDegrees(87.0, 28.0),
     ];
 
-    return sampleTerrainMostDetailed(worldTerrain, positions).then(function () {
-      expect(positions[0].height).toBeGreaterThan(5000);
-      expect(positions[0].height).toBeLessThan(10000);
-      expect(positions[1].height).toBeGreaterThan(5000);
-      expect(positions[1].height).toBeLessThan(10000);
-    });
+    await sampleTerrainMostDetailed(worldTerrain, positions);
+    expect(positions[0].height).toBeGreaterThan(5000);
+    expect(positions[0].height).toBeLessThan(10000);
+    expect(positions[1].height).toBeGreaterThan(5000);
+    expect(positions[1].height).toBeLessThan(10000);
   });
 
-  it("requires terrainProvider and positions", function () {
+  it("throws without terrainProvider", async function () {
     const positions = [
       Cartographic.fromDegrees(86.925145, 27.988257),
       Cartographic.fromDegrees(87.0, 28.0),
     ];
 
-    expect(function () {
-      sampleTerrainMostDetailed(undefined, positions);
-    }).toThrowDeveloperError();
-
-    expect(function () {
-      sampleTerrainMostDetailed(worldTerrain, undefined);
-    }).toThrowDeveloperError();
+    await expectAsync(
+      sampleTerrainMostDetailed(undefined, positions)
+    ).toBeRejectedWithError(DeveloperError, "terrainProvider is required.");
   });
 
-  it("works for a dodgy point right near the edge of a tile", function () {
+  it("throws without positions", async function () {
+    await expectAsync(
+      sampleTerrainMostDetailed(worldTerrain, undefined)
+    ).toBeRejectedWithError(DeveloperError, "positions is required.");
+  });
+
+  it("works for a dodgy point right near the edge of a tile", async function () {
     const positions = [
       new Cartographic(0.33179290856829535, 0.7363107781851078),
     ];
 
-    return sampleTerrainMostDetailed(worldTerrain, positions).then(function () {
-      expect(positions[0].height).toBeDefined();
-    });
+    await sampleTerrainMostDetailed(worldTerrain, positions);
+    expect(positions[0].height).toBeDefined();
   });
 });

--- a/packages/engine/Specs/Core/sampleTerrainMostDetailedSpec.js
+++ b/packages/engine/Specs/Core/sampleTerrainMostDetailedSpec.js
@@ -2,7 +2,6 @@ import {
   Cartographic,
   CesiumTerrainProvider,
   createWorldTerrainAsync,
-  DeveloperError,
   sampleTerrainMostDetailed,
 } from "../../index.js";
 
@@ -41,8 +40,7 @@ describe("Core/sampleTerrainMostDetailed", function () {
 
     await expectAsync(
       sampleTerrainMostDetailed(terrainProvider, positions)
-    ).toBeRejectedWithError(
-      DeveloperError,
+    ).toBeRejectedWithDeveloperError(
       "sampleTerrainMostDetailed requires a terrain provider that has tile availability."
     );
   });
@@ -68,13 +66,13 @@ describe("Core/sampleTerrainMostDetailed", function () {
 
     await expectAsync(
       sampleTerrainMostDetailed(undefined, positions)
-    ).toBeRejectedWithError(DeveloperError, "terrainProvider is required.");
+    ).toBeRejectedWithDeveloperError("terrainProvider is required.");
   });
 
   it("throws without positions", async function () {
     await expectAsync(
       sampleTerrainMostDetailed(worldTerrain, undefined)
-    ).toBeRejectedWithError(DeveloperError, "positions is required.");
+    ).toBeRejectedWithDeveloperError("positions is required.");
   });
 
   it("works for a dodgy point right near the edge of a tile", async function () {

--- a/packages/engine/Specs/Core/sampleTerrainSpec.js
+++ b/packages/engine/Specs/Core/sampleTerrainSpec.js
@@ -2,7 +2,7 @@ import {
   ArcGISTiledElevationTerrainProvider,
   Cartographic,
   CesiumTerrainProvider,
-  createWorldTerrain,
+  createWorldTerrainAsync,
   defined,
   RequestScheduler,
   Resource,
@@ -11,9 +11,8 @@ import {
 
 describe("Core/sampleTerrain", function () {
   let worldTerrain;
-  beforeAll(function () {
-    worldTerrain = createWorldTerrain();
-    return worldTerrain.readyPromise;
+  beforeAll(async function () {
+    worldTerrain = await createWorldTerrainAsync();
   });
 
   it("queries heights", function () {
@@ -33,25 +32,22 @@ describe("Core/sampleTerrain", function () {
     });
   });
 
-  it("queries heights from Small Terrain", function () {
-    const terrainProvider = new CesiumTerrainProvider({
-      url: "https://s3.amazonaws.com/cesiumjs/smallTerrain",
-    });
+  it("queries heights from Small Terrain", async function () {
+    const terrainProvider = await CesiumTerrainProvider.fromUrl(
+      "https://s3.amazonaws.com/cesiumjs/smallTerrain"
+    );
 
     const positions = [
       Cartographic.fromDegrees(86.925145, 27.988257),
       Cartographic.fromDegrees(87.0, 28.0),
     ];
 
-    return sampleTerrain(terrainProvider, 11, positions).then(function (
-      passedPositions
-    ) {
-      expect(passedPositions).toBe(positions);
-      expect(positions[0].height).toBeGreaterThan(5000);
-      expect(positions[0].height).toBeLessThan(10000);
-      expect(positions[1].height).toBeGreaterThan(5000);
-      expect(positions[1].height).toBeLessThan(10000);
-    });
+    const passedPositions = await sampleTerrain(terrainProvider, 11, positions);
+    expect(passedPositions).toBe(positions);
+    expect(positions[0].height).toBeGreaterThan(5000);
+    expect(positions[0].height).toBeLessThan(10000);
+    expect(positions[1].height).toBeGreaterThan(5000);
+    expect(positions[1].height).toBeLessThan(10000);
   });
 
   it("sets height to undefined if terrain data is not available at the position and specified level", function () {
@@ -210,15 +206,15 @@ describe("Core/sampleTerrain", function () {
       };
     }
 
-    it("should work for Cesium World Terrain", function () {
+    it("should work for Cesium World Terrain", async function () {
       patchXHRLoad({
         "/layer.json": "Data/CesiumTerrainTileJson/9_759_335/layer.json",
         "/9/759/335.terrain?v=1.2.0":
           "Data/CesiumTerrainTileJson/9_759_335/9_759_335.terrain",
       });
-      const terrainProvider = new CesiumTerrainProvider({
-        url: "made/up/url",
-      });
+      const terrainProvider = await CesiumTerrainProvider.fromUrl(
+        "made/up/url"
+      );
 
       spyOnTerrainDataCreateMesh(terrainProvider);
 
@@ -251,7 +247,7 @@ describe("Core/sampleTerrain", function () {
       });
     });
 
-    it("should work for ArcGIS terrain", function () {
+    it("should work for ArcGIS terrain", async function () {
       patchXHRLoad({
         "/?f=pjson": "Data/ArcGIS/9_214_379/root.json",
         "/tilemap/10/384/640/128/128":
@@ -259,9 +255,9 @@ describe("Core/sampleTerrain", function () {
         "/tile/9/214/379": "Data/ArcGIS/9_214_379/tile_9_214_379.tile",
       });
 
-      const terrainProvider = new ArcGISTiledElevationTerrainProvider({
-        url: "made/up/url",
-      });
+      const terrainProvider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+        "made/up/url"
+      );
 
       spyOnTerrainDataCreateMesh(terrainProvider);
 
@@ -279,22 +275,21 @@ describe("Core/sampleTerrain", function () {
       );
 
       const level = 9;
-      return sampleTerrain(terrainProvider, level, [
+      await sampleTerrain(terrainProvider, level, [
         positionA,
         positionB,
         positionC,
-      ]).then(function () {
-        // 3 very similar positions
-        expect(positionA.height).toBeCloseTo(7681, 0);
-        expect(positionB.height).toBeCloseTo(7681, 0);
-        expect(positionC.height).toBeCloseTo(7681, 0);
-        // 1 tile was requested (all positions were close enough on the same tile)
-        //  and the mesh was created once because we're using an ArcGIS tile
-        return expectTileAndMeshCounts(terrainProvider, 1, true);
-      });
+      ]);
+      // 3 very similar positions
+      expect(positionA.height).toBeCloseTo(7681, 0);
+      expect(positionB.height).toBeCloseTo(7681, 0);
+      expect(positionC.height).toBeCloseTo(7681, 0);
+      // 1 tile was requested (all positions were close enough on the same tile)
+      //  and the mesh was created once because we're using an ArcGIS tile
+      await expectTileAndMeshCounts(terrainProvider, 1, true);
     });
 
-    it("should handle the RequestScheduler throttling the requestTileGeometry requests with a retry", function () {
+    it("should handle the RequestScheduler throttling the requestTileGeometry requests with a retry", async function () {
       patchXHRLoad({
         "/?f=pjson": "Data/ArcGIS/9_214_379/root.json",
         "/tilemap/10/384/640/128/128":
@@ -305,9 +300,9 @@ describe("Core/sampleTerrain", function () {
         "/tile/9/214/376": "Data/ArcGIS/9_214_379/tile_9_214_379.tile",
       });
 
-      const terrainProvider = new ArcGISTiledElevationTerrainProvider({
-        url: "made/up/url",
-      });
+      const terrainProvider = await ArcGISTiledElevationTerrainProvider.fromUrl(
+        "made/up/url"
+      );
 
       let i = 0;
       const originalRequestTileGeometry = terrainProvider.requestTileGeometry;
@@ -339,22 +334,21 @@ describe("Core/sampleTerrain", function () {
       const positionC = Cartographic.fromDegrees(87, 28);
 
       const level = 9;
-      return sampleTerrain(terrainProvider, level, [
+      await sampleTerrain(terrainProvider, level, [
         positionA,
         positionB,
         positionC,
-      ]).then(function () {
-        // the order of requests is an implementation detail and not important,
-        //  but it is deterministic, and we can assert that there were some retries in there
-        const calls = terrainProvider.requestTileGeometry.calls;
-        expect(calls.count()).toEqual(5);
-        expect(calls.argsFor(0)).toEqual([376, 214, 9]);
-        expect(calls.argsFor(1)).toEqual([378, 214, 9]);
-        // this tile was retried twice, because the 2nd and 3rd call to requestTileGeometry returned undefined as expected
-        expect(calls.argsFor(2)).toEqual([378, 214, 9]);
-        expect(calls.argsFor(3)).toEqual([378, 214, 9]);
-        expect(calls.argsFor(4)).toEqual([379, 214, 9]);
-      });
+      ]);
+      // the order of requests is an implementation detail and not important,
+      //  but it is deterministic, and we can assert that there were some retries in there
+      const calls = terrainProvider.requestTileGeometry.calls;
+      expect(calls.count()).toEqual(5);
+      expect(calls.argsFor(0)).toEqual([376, 214, 9]);
+      expect(calls.argsFor(1)).toEqual([378, 214, 9]);
+      // this tile was retried twice, because the 2nd and 3rd call to requestTileGeometry returned undefined as expected
+      expect(calls.argsFor(2)).toEqual([378, 214, 9]);
+      expect(calls.argsFor(3)).toEqual([378, 214, 9]);
+      expect(calls.argsFor(4)).toEqual([379, 214, 9]);
     });
   });
 });

--- a/packages/engine/Specs/Core/sampleTerrainSpec.js
+++ b/packages/engine/Specs/Core/sampleTerrainSpec.js
@@ -4,6 +4,7 @@ import {
   CesiumTerrainProvider,
   createWorldTerrainAsync,
   defined,
+  IonResource,
   RequestScheduler,
   Resource,
   sampleTerrain,
@@ -13,6 +14,27 @@ describe("Core/sampleTerrain", function () {
   let worldTerrain;
   beforeAll(async function () {
     worldTerrain = await createWorldTerrainAsync();
+  });
+
+  it("queries heights from deprecated world terrain", function () {
+    const positions = [
+      Cartographic.fromDegrees(86.925145, 27.988257),
+      Cartographic.fromDegrees(87.0, 28.0),
+    ];
+
+    const terrain = new CesiumTerrainProvider({
+      url: IonResource.fromAssetId(1),
+    });
+
+    return sampleTerrain(terrain, 11, positions).then(function (
+      passedPositions
+    ) {
+      expect(passedPositions).toBe(positions);
+      expect(positions[0].height).toBeGreaterThan(5000);
+      expect(positions[0].height).toBeLessThan(10000);
+      expect(positions[1].height).toBeGreaterThan(5000);
+      expect(positions[1].height).toBeLessThan(10000);
+    });
   });
 
   it("queries heights", function () {
@@ -74,24 +96,24 @@ describe("Core/sampleTerrain", function () {
     });
   });
 
-  it("requires terrainProvider, level, and positions", function () {
+  it("requires terrainProvider, level, and positions", async function () {
     const positions = [
       Cartographic.fromDegrees(86.925145, 27.988257),
       Cartographic.fromDegrees(0.0, 0.0, 0.0),
       Cartographic.fromDegrees(87.0, 28.0),
     ];
 
-    expect(function () {
-      sampleTerrain(undefined, 11, positions);
-    }).toThrowDeveloperError();
+    await expectAsync(
+      sampleTerrain(undefined, 11, positions)
+    ).toBeRejectedWithDeveloperError();
 
-    expect(function () {
-      sampleTerrain(worldTerrain, undefined, positions);
-    }).toThrowDeveloperError();
+    await expectAsync(
+      sampleTerrain(worldTerrain, undefined, positions)
+    ).toBeRejectedWithDeveloperError();
 
-    expect(function () {
-      sampleTerrain(worldTerrain, 11, undefined);
-    }).toThrowDeveloperError();
+    await expectAsync(
+      sampleTerrain(worldTerrain, 11, undefined)
+    ).toBeRejectedWithDeveloperError();
   });
 
   it("works for a dodgy point right near the edge of a tile", function () {

--- a/packages/engine/Specs/DataSources/ModelVisualizerSpec.js
+++ b/packages/engine/Specs/DataSources/ModelVisualizerSpec.js
@@ -23,7 +23,7 @@ import {
   CustomShader,
   Globe,
   Cartographic,
-  createWorldTerrainAsync,
+  createWorldTerrain,
 } from "../../index.js";
 import createScene from "../../../../Specs/createScene.js";
 import pollToPromise from "../../../../Specs/pollToPromise.js";
@@ -380,7 +380,7 @@ describe(
       });
     });
 
-    it("Computes bounding sphere with height reference clamp to ground", async function () {
+    it("Computes bounding sphere with height reference clamp to ground", function () {
       // Setup a position for the model.
       const position = Cartesian3.fromDegrees(149.515332, -34.984799);
       const positionCartographic = Cartographic.fromCartesian(position);
@@ -411,43 +411,48 @@ describe(
       // Assign a tiled terrain provider to the globe.
       const globe = scene.globe;
       const previousTerrainProvider = globe.terrainProvider;
-      globe.terrainProvider = await createWorldTerrainAsync();
+      globe.terrainProvider = createWorldTerrain();
 
-      const updatedCartographics = await ModelVisualizer._sampleTerrainMostDetailed(
-        globe.terrainProvider,
-        [positionCartographic]
-      );
-      const sampledResultCartographic = updatedCartographics[0];
-      const sampledResult = globe.ellipsoid.cartographicToCartesian(
-        sampledResultCartographic
-      );
+      let sampledResultCartographic;
+      let sampledResult;
 
-      // Repeatedly request the bounding sphere until it's ready.
-      await pollToPromise(function () {
-        scene.render();
-        state = visualizer.getBoundingSphere(testObject, result);
-        return state !== BoundingSphereState.PENDING;
-      });
+      return ModelVisualizer._sampleTerrainMostDetailed(globe.terrainProvider, [
+        positionCartographic,
+      ])
+        .then((updatedCartographics) => {
+          sampledResultCartographic = updatedCartographics[0];
+          sampledResult = globe.ellipsoid.cartographicToCartesian(
+            sampledResultCartographic
+          );
 
-      expect(state).toBe(BoundingSphereState.DONE);
+          // Repeatedly request the bounding sphere until it's ready.
+          return pollToPromise(function () {
+            scene.render();
+            state = visualizer.getBoundingSphere(testObject, result);
+            return state !== BoundingSphereState.PENDING;
+          });
+        })
+        .then(() => {
+          expect(state).toBe(BoundingSphereState.DONE);
 
-      // Ensure that flags and results computed for this model are reset.
-      const modelData = visualizer._modelHash[testObject.id];
-      expect(modelData.awaitingSampleTerrain).toBe(false);
-      expect(modelData.clampedBoundingSphere).toBeUndefined();
+          // Ensure that flags and results computed for this model are reset.
+          const modelData = visualizer._modelHash[testObject.id];
+          expect(modelData.awaitingSampleTerrain).toBe(false);
+          expect(modelData.clampedBoundingSphere).toBeUndefined();
 
-      // Ensure that we only sample the terrain once from the visualizer.
-      // We check for 2 calls here because we call it once in the test.
-      expect(sampleTerrainSpy).toHaveBeenCalledTimes(2);
+          // Ensure that we only sample the terrain once from the visualizer.
+          // We check for 2 calls here because we call it once in the test.
+          expect(sampleTerrainSpy).toHaveBeenCalledTimes(2);
 
-      // Calculate the distance of the bounding sphere returned from the position returned from sample terrain.
-      // Since sampleTerrainMostDetailed isn't always precise, we account for some error.
-      const distance = Cartesian3.distance(result.center, sampledResult);
-      const errorMargin = 100.0;
-      expect(distance).toBeLessThan(errorMargin);
+          // Calculate the distance of the bounding sphere returned from the position returned from sample terrain.
+          // Since sampleTerrainMostDetailed isn't always precise, we account for some error.
+          const distance = Cartesian3.distance(result.center, sampledResult);
+          const errorMargin = 100.0;
+          expect(distance).toBeLessThan(errorMargin);
 
-      // Reset the terrain provider.
-      globe.terrainProvider = previousTerrainProvider;
+          // Reset the terrain provider.
+          globe.terrainProvider = previousTerrainProvider;
+        });
     });
 
     it("Computes bounding sphere with height reference clamp to ground on terrain provider without availability", function () {
@@ -502,7 +507,7 @@ describe(
       });
     });
 
-    it("Computes bounding sphere with height reference relative to ground", async function () {
+    it("Computes bounding sphere with height reference relative to ground", function () {
       // Setup a position for the model.
       const heightOffset = 1000.0;
       const position = Cartesian3.fromDegrees(
@@ -538,44 +543,49 @@ describe(
       // Assign a tiled terrain provider to the globe.
       const globe = scene.globe;
       const previousTerrainProvider = globe.terrainProvider;
-      globe.terrainProvider = await createWorldTerrainAsync();
+      globe.terrainProvider = createWorldTerrain();
 
-      const updatedCartographics = await ModelVisualizer._sampleTerrainMostDetailed(
-        globe.terrainProvider,
-        [positionCartographic]
-      );
-      const sampledResultCartographic = updatedCartographics[0];
-      const sampledResult = globe.ellipsoid.cartographicToCartesian(
-        sampledResultCartographic
-      );
+      let sampledResultCartographic;
+      let sampledResult;
 
-      // Repeatedly request the bounding sphere until it's ready.
-      await pollToPromise(function () {
-        scene.render();
-        state = visualizer.getBoundingSphere(testObject, result);
-        return state !== BoundingSphereState.PENDING;
-      });
+      return ModelVisualizer._sampleTerrainMostDetailed(globe.terrainProvider, [
+        positionCartographic,
+      ])
+        .then((updatedCartographics) => {
+          sampledResultCartographic = updatedCartographics[0];
+          sampledResult = globe.ellipsoid.cartographicToCartesian(
+            sampledResultCartographic
+          );
 
-      expect(state).toBe(BoundingSphereState.DONE);
+          // Repeatedly request the bounding sphere until it's ready.
+          return pollToPromise(function () {
+            scene.render();
+            state = visualizer.getBoundingSphere(testObject, result);
+            return state !== BoundingSphereState.PENDING;
+          });
+        })
+        .then(() => {
+          expect(state).toBe(BoundingSphereState.DONE);
 
-      // Ensure that flags and results computed for this model are reset.
-      const modelData = visualizer._modelHash[testObject.id];
-      expect(modelData.awaitingSampleTerrain).toBe(false);
-      expect(modelData.clampedBoundingSphere).toBeUndefined();
+          // Ensure that flags and results computed for this model are reset.
+          const modelData = visualizer._modelHash[testObject.id];
+          expect(modelData.awaitingSampleTerrain).toBe(false);
+          expect(modelData.clampedBoundingSphere).toBeUndefined();
 
-      // Ensure that we only sample the terrain once from the visualizer.
-      // We check for 2 calls here because we call it once in the test.
-      expect(sampleTerrainSpy).toHaveBeenCalledTimes(2);
+          // Ensure that we only sample the terrain once from the visualizer.
+          // We check for 2 calls here because we call it once in the test.
+          expect(sampleTerrainSpy).toHaveBeenCalledTimes(2);
 
-      // Calculate the distance of the bounding sphere returned from the position returned from sample terrain.
-      // Since sampleTerrainMostDetailed isn't always precise, we account for some error.
-      const distance =
-        Cartesian3.distance(result.center, sampledResult) - heightOffset;
-      const errorMargin = 100.0;
-      expect(distance).toBeLessThan(errorMargin);
+          // Calculate the distance of the bounding sphere returned from the position returned from sample terrain.
+          // Since sampleTerrainMostDetailed isn't always precise, we account for some error.
+          const distance =
+            Cartesian3.distance(result.center, sampledResult) - heightOffset;
+          const errorMargin = 100.0;
+          expect(distance).toBeLessThan(errorMargin);
 
-      // Reset the terrain provider.
-      globe.terrainProvider = previousTerrainProvider;
+          // Reset the terrain provider.
+          globe.terrainProvider = previousTerrainProvider;
+        });
     });
 
     it("Computes bounding sphere with height reference relative to ground on terrain provider without availability", function () {
@@ -660,7 +670,7 @@ describe(
       });
     });
 
-    it("Fails bounding sphere when sampleTerrainMostDetailed fails.", async function () {
+    it("Fails bounding sphere when sampleTerrainMostDetailed fails.", function () {
       // Setup a position for the model.
       const heightOffset = 1000.0;
       const position = Cartesian3.fromDegrees(
@@ -692,28 +702,29 @@ describe(
       // Assign a tiled terrain provider to the globe.
       const globe = scene.globe;
       const previousTerrainProvider = globe.terrainProvider;
-      globe.terrainProvider = await createWorldTerrainAsync();
+      globe.terrainProvider = createWorldTerrain();
 
       // Request the bounding sphere once.
       const result = new BoundingSphere();
       let state;
 
       // Repeatedly request the bounding sphere until it's ready.
-      await pollToPromise(function () {
+      return pollToPromise(function () {
         scene.render();
         state = visualizer.getBoundingSphere(testObject, result);
         return state !== BoundingSphereState.PENDING;
+      }).then(() => {
+        expect(state).toBe(BoundingSphereState.FAILED);
+
+        // Ensure that flags and results computed for this model are reset.
+        const modelData = visualizer._modelHash[testObject.id];
+        expect(modelData.sampleTerrainFailed).toBe(false);
+
+        // Ensure that we only sample the terrain once from the visualizer.
+        expect(sampleTerrainSpy).toHaveBeenCalledTimes(1);
+        // Reset the terrain provider.
+        globe.terrainProvider = previousTerrainProvider;
       });
-      expect(state).toBe(BoundingSphereState.FAILED);
-
-      // Ensure that flags and results computed for this model are reset.
-      const modelData = visualizer._modelHash[testObject.id];
-      expect(modelData.sampleTerrainFailed).toBe(false);
-
-      // Ensure that we only sample the terrain once from the visualizer.
-      expect(sampleTerrainSpy).toHaveBeenCalledTimes(1);
-      // Reset the terrain provider.
-      globe.terrainProvider = previousTerrainProvider;
     });
 
     it("Compute bounding sphere throws without entity.", function () {

--- a/packages/engine/Specs/Scene/BillboardCollectionSpec.js
+++ b/packages/engine/Specs/Scene/BillboardCollectionSpec.js
@@ -2503,7 +2503,7 @@ describe(
         expect(b._clampedPosition).toBeUndefined();
       });
 
-      it("changing the terrain provider", function () {
+      it("changing the terrain provider", async function () {
         const b = billboardsWithHeight.add({
           heightReference: HeightReference.CLAMP_TO_GROUND,
           position: Cartesian3.fromDegrees(-72.0, 40.0),
@@ -2512,10 +2512,12 @@ describe(
 
         spyOn(b, "_updateClamping").and.callThrough();
 
-        const terrainProvider = new CesiumTerrainProvider({
-          url: "made/up/url",
-          requestVertexNormals: true,
-        });
+        const terrainProvider = await CesiumTerrainProvider.fromUrl(
+          "made/up/url",
+          {
+            requestVertexNormals: true,
+          }
+        );
 
         scene.terrainProvider = terrainProvider;
 

--- a/packages/engine/Specs/Scene/BillboardCollectionSpec.js
+++ b/packages/engine/Specs/Scene/BillboardCollectionSpec.js
@@ -2503,7 +2503,7 @@ describe(
         expect(b._clampedPosition).toBeUndefined();
       });
 
-      it("changing the terrain provider", async function () {
+      it("changing the terrain provider", function () {
         const b = billboardsWithHeight.add({
           heightReference: HeightReference.CLAMP_TO_GROUND,
           position: Cartesian3.fromDegrees(-72.0, 40.0),
@@ -2512,12 +2512,10 @@ describe(
 
         spyOn(b, "_updateClamping").and.callThrough();
 
-        const terrainProvider = await CesiumTerrainProvider.fromUrl(
-          "made/up/url",
-          {
-            requestVertexNormals: true,
-          }
-        );
+        const terrainProvider = new CesiumTerrainProvider({
+          url: "made/up/url",
+          requestVertexNormals: true,
+        });
 
         scene.terrainProvider = terrainProvider;
 

--- a/packages/engine/Specs/Scene/GlobeSpec.js
+++ b/packages/engine/Specs/Scene/GlobeSpec.js
@@ -223,11 +223,13 @@ describe(
         });
     });
 
-    it("terrainProviderChanged event fires", function () {
-      const terrainProvider = new CesiumTerrainProvider({
-        url: "made/up/url",
-        requestVertexNormals: true,
-      });
+    it("terrainProviderChanged event fires", async function () {
+      const terrainProvider = await CesiumTerrainProvider.fromUrl(
+        "made/up/url",
+        {
+          requestVertexNormals: true,
+        }
+      );
 
       const spyListener = jasmine.createSpy("listener");
       globe.terrainProviderChanged.addEventListener(spyListener);
@@ -237,7 +239,7 @@ describe(
       expect(spyListener).toHaveBeenCalledWith(terrainProvider);
     });
 
-    it("tilesLoaded return true when tile load queue is empty", function () {
+    it("tilesLoaded return true when tile load queue is empty", async function () {
       expect(globe.tilesLoaded).toBe(true);
 
       globe._surface._tileLoadQueueHigh.length = 2;
@@ -258,17 +260,19 @@ describe(
       globe._surface._tileLoadQueueLow.length = 0;
       expect(globe.tilesLoaded).toBe(true);
 
-      const terrainProvider = new CesiumTerrainProvider({
-        url: "made/up/url",
-        requestVertexNormals: true,
-      });
+      const terrainProvider = await CesiumTerrainProvider.fromUrl(
+        "made/up/url",
+        {
+          requestVertexNormals: true,
+        }
+      );
 
       globe.terrainProvider = terrainProvider;
       scene.render();
       expect(globe.tilesLoaded).toBe(false);
     });
 
-    it("renders terrain with enableLighting", function () {
+    it("renders terrain with enableLighting", async function () {
       const renderOptions = {
         scene: scene,
         time: new JulianDate(2557522.0),
@@ -281,48 +285,48 @@ describe(
         url: "Data/Images/Red16x16.png",
       });
       layerCollection.addImageryProvider(imageryProvider);
-      return imageryProvider.readyPromise.then(function () {
-        Resource._Implementations.loadWithXhr = function (
-          url,
+      await imageryProvider.readyPromise;
+      Resource._Implementations.loadWithXhr = function (
+        url,
+        responseType,
+        method,
+        data,
+        headers,
+        deferred,
+        overrideMimeType
+      ) {
+        Resource._DefaultImplementations.loadWithXhr(
+          "Data/CesiumTerrainTileJson/tile.vertexnormals.terrain",
           responseType,
           method,
           data,
           headers,
-          deferred,
-          overrideMimeType
-        ) {
-          Resource._DefaultImplementations.loadWithXhr(
-            "Data/CesiumTerrainTileJson/tile.vertexnormals.terrain",
-            responseType,
-            method,
-            data,
-            headers,
-            deferred
-          );
-        };
+          deferred
+        );
+      };
 
-        returnVertexNormalTileJson();
+      returnVertexNormalTileJson();
 
-        const terrainProvider = new CesiumTerrainProvider({
-          url: "made/up/url",
+      const terrainProvider = await CesiumTerrainProvider.fromUrl(
+        "made/up/url",
+        {
           requestVertexNormals: true,
-        });
+        }
+      );
 
-        globe.terrainProvider = terrainProvider;
-        scene.camera.setView({
-          destination: new Rectangle(0.0001, 0.0001, 0.0025, 0.0025),
-        });
-
-        return updateUntilDone(globe).then(function () {
-          expect(renderOptions).notToRender([0, 0, 0, 255]);
-
-          scene.globe.show = false;
-          expect(renderOptions).toRender([0, 0, 0, 255]);
-        });
+      globe.terrainProvider = terrainProvider;
+      scene.camera.setView({
+        destination: new Rectangle(0.0001, 0.0001, 0.0025, 0.0025),
       });
+
+      await updateUntilDone(globe);
+      expect(renderOptions).notToRender([0, 0, 0, 255]);
+
+      scene.globe.show = false;
+      expect(renderOptions).toRender([0, 0, 0, 255]);
     });
 
-    it("renders terrain with lambertDiffuseMultiplier", function () {
+    it("renders terrain with lambertDiffuseMultiplier", async function () {
       const renderOptions = {
         scene: scene,
         time: new JulianDate(2557522.0),
@@ -335,51 +339,52 @@ describe(
         url: "Data/Images/Red16x16.png",
       });
       layerCollection.addImageryProvider(imageryProvider);
-      return imageryProvider.readyPromise.then(function () {
-        Resource._Implementations.loadWithXhr = function (
-          url,
+      await imageryProvider.readyPromise;
+      Resource._Implementations.loadWithXhr = function (
+        url,
+        responseType,
+        method,
+        data,
+        headers,
+        deferred,
+        overrideMimeType
+      ) {
+        Resource._DefaultImplementations.loadWithXhr(
+          "Data/CesiumTerrainTileJson/tile.vertexnormals.terrain",
           responseType,
           method,
           data,
           headers,
-          deferred,
-          overrideMimeType
-        ) {
-          Resource._DefaultImplementations.loadWithXhr(
-            "Data/CesiumTerrainTileJson/tile.vertexnormals.terrain",
-            responseType,
-            method,
-            data,
-            headers,
-            deferred
-          );
-        };
+          deferred
+        );
+      };
 
-        returnVertexNormalTileJson();
+      returnVertexNormalTileJson();
 
-        const terrainProvider = new CesiumTerrainProvider({
-          url: "made/up/url",
+      const terrainProvider = await CesiumTerrainProvider.fromUrl(
+        "made/up/url",
+        {
           requestVertexNormals: true,
-        });
+        }
+      );
 
-        globe.terrainProvider = terrainProvider;
-        scene.camera.setView({
-          destination: new Rectangle(0.0001, 0.0001, 0.0025, 0.0025),
-        });
-
-        return updateUntilDone(globe).then(function () {
-          let initialRgba;
-          expect(renderOptions).toRenderAndCall(function (rgba) {
-            initialRgba = rgba;
-            expect(renderOptions).notToRender([0, 0, 0, 255]);
-          });
-          globe.lambertDiffuseMultiplier = 10.0;
-          expect(renderOptions).notToRender(initialRgba);
-        });
+      globe.terrainProvider = terrainProvider;
+      scene.camera.setView({
+        destination: new Rectangle(0.0001, 0.0001, 0.0025, 0.0025),
       });
+
+      await updateUntilDone(globe);
+
+      let initialRgba;
+      expect(renderOptions).toRenderAndCall(function (rgba) {
+        initialRgba = rgba;
+        expect(renderOptions).notToRender([0, 0, 0, 255]);
+      });
+      globe.lambertDiffuseMultiplier = 10.0;
+      expect(renderOptions).notToRender(initialRgba);
     });
 
-    it("renders terrain with vertexShadowDarkness", function () {
+    it("renders terrain with vertexShadowDarkness", async function () {
       const renderOptions = {
         scene: scene,
         time: new JulianDate(2557522.0),
@@ -392,47 +397,47 @@ describe(
         url: "Data/Images/Red16x16.png",
       });
       layerCollection.addImageryProvider(imageryProvider);
-      return imageryProvider.readyPromise.then(function () {
-        Resource._Implementations.loadWithXhr = function (
-          url,
+      await imageryProvider.readyPromise;
+      Resource._Implementations.loadWithXhr = function (
+        url,
+        responseType,
+        method,
+        data,
+        headers,
+        deferred,
+        overrideMimeType
+      ) {
+        Resource._DefaultImplementations.loadWithXhr(
+          "Data/CesiumTerrainTileJson/tile.vertexnormals.terrain",
           responseType,
           method,
           data,
           headers,
-          deferred,
-          overrideMimeType
-        ) {
-          Resource._DefaultImplementations.loadWithXhr(
-            "Data/CesiumTerrainTileJson/tile.vertexnormals.terrain",
-            responseType,
-            method,
-            data,
-            headers,
-            deferred
-          );
-        };
+          deferred
+        );
+      };
 
-        returnVertexNormalTileJson();
+      returnVertexNormalTileJson();
 
-        const terrainProvider = new CesiumTerrainProvider({
-          url: "made/up/url",
+      const terrainProvider = await CesiumTerrainProvider.fromUrl(
+        "made/up/url",
+        {
           requestVertexNormals: true,
-        });
+        }
+      );
 
-        globe.terrainProvider = terrainProvider;
-        scene.camera.setView({
-          destination: new Rectangle(0.0001, 0.0001, 0.0025, 0.0025),
-        });
+      globe.terrainProvider = terrainProvider;
+      scene.camera.setView({
+        destination: new Rectangle(0.0001, 0.0001, 0.0025, 0.0025),
+      });
 
-        return updateUntilDone(globe).then(function () {
-          let initialRgba;
-          expect(renderOptions).toRenderAndCall(function (rgba) {
-            initialRgba = rgba;
-            expect(renderOptions).notToRender([0, 0, 0, 255]);
-            globe.vertexShadowDarkness = 0.1;
-            expect(renderOptions).notToRender(initialRgba);
-          });
-        });
+      await updateUntilDone(globe);
+      let initialRgba;
+      expect(renderOptions).toRenderAndCall(function (rgba) {
+        initialRgba = rgba;
+        expect(renderOptions).notToRender([0, 0, 0, 255]);
+        globe.vertexShadowDarkness = 0.1;
+        expect(renderOptions).notToRender(initialRgba);
       });
     });
 

--- a/packages/engine/Specs/Scene/GlobeSpec.js
+++ b/packages/engine/Specs/Scene/GlobeSpec.js
@@ -223,13 +223,11 @@ describe(
         });
     });
 
-    it("terrainProviderChanged event fires", async function () {
-      const terrainProvider = await CesiumTerrainProvider.fromUrl(
-        "made/up/url",
-        {
-          requestVertexNormals: true,
-        }
-      );
+    it("terrainProviderChanged event fires", function () {
+      const terrainProvider = new CesiumTerrainProvider({
+        url: "made/up/url",
+        requestVertexNormals: true,
+      });
 
       const spyListener = jasmine.createSpy("listener");
       globe.terrainProviderChanged.addEventListener(spyListener);
@@ -239,7 +237,7 @@ describe(
       expect(spyListener).toHaveBeenCalledWith(terrainProvider);
     });
 
-    it("tilesLoaded return true when tile load queue is empty", async function () {
+    it("tilesLoaded return true when tile load queue is empty", function () {
       expect(globe.tilesLoaded).toBe(true);
 
       globe._surface._tileLoadQueueHigh.length = 2;
@@ -260,19 +258,17 @@ describe(
       globe._surface._tileLoadQueueLow.length = 0;
       expect(globe.tilesLoaded).toBe(true);
 
-      const terrainProvider = await CesiumTerrainProvider.fromUrl(
-        "made/up/url",
-        {
-          requestVertexNormals: true,
-        }
-      );
+      const terrainProvider = new CesiumTerrainProvider({
+        url: "made/up/url",
+        requestVertexNormals: true,
+      });
 
       globe.terrainProvider = terrainProvider;
       scene.render();
       expect(globe.tilesLoaded).toBe(false);
     });
 
-    it("renders terrain with enableLighting", async function () {
+    it("renders terrain with enableLighting", function () {
       const renderOptions = {
         scene: scene,
         time: new JulianDate(2557522.0),
@@ -285,48 +281,48 @@ describe(
         url: "Data/Images/Red16x16.png",
       });
       layerCollection.addImageryProvider(imageryProvider);
-      await imageryProvider.readyPromise;
-      Resource._Implementations.loadWithXhr = function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType
-      ) {
-        Resource._DefaultImplementations.loadWithXhr(
-          "Data/CesiumTerrainTileJson/tile.vertexnormals.terrain",
+      return imageryProvider.readyPromise.then(function () {
+        Resource._Implementations.loadWithXhr = function (
+          url,
           responseType,
           method,
           data,
           headers,
-          deferred
-        );
-      };
+          deferred,
+          overrideMimeType
+        ) {
+          Resource._DefaultImplementations.loadWithXhr(
+            "Data/CesiumTerrainTileJson/tile.vertexnormals.terrain",
+            responseType,
+            method,
+            data,
+            headers,
+            deferred
+          );
+        };
 
-      returnVertexNormalTileJson();
+        returnVertexNormalTileJson();
 
-      const terrainProvider = await CesiumTerrainProvider.fromUrl(
-        "made/up/url",
-        {
+        const terrainProvider = new CesiumTerrainProvider({
+          url: "made/up/url",
           requestVertexNormals: true,
-        }
-      );
+        });
 
-      globe.terrainProvider = terrainProvider;
-      scene.camera.setView({
-        destination: new Rectangle(0.0001, 0.0001, 0.0025, 0.0025),
+        globe.terrainProvider = terrainProvider;
+        scene.camera.setView({
+          destination: new Rectangle(0.0001, 0.0001, 0.0025, 0.0025),
+        });
+
+        return updateUntilDone(globe).then(function () {
+          expect(renderOptions).notToRender([0, 0, 0, 255]);
+
+          scene.globe.show = false;
+          expect(renderOptions).toRender([0, 0, 0, 255]);
+        });
       });
-
-      await updateUntilDone(globe);
-      expect(renderOptions).notToRender([0, 0, 0, 255]);
-
-      scene.globe.show = false;
-      expect(renderOptions).toRender([0, 0, 0, 255]);
     });
 
-    it("renders terrain with lambertDiffuseMultiplier", async function () {
+    it("renders terrain with lambertDiffuseMultiplier", function () {
       const renderOptions = {
         scene: scene,
         time: new JulianDate(2557522.0),
@@ -339,52 +335,51 @@ describe(
         url: "Data/Images/Red16x16.png",
       });
       layerCollection.addImageryProvider(imageryProvider);
-      await imageryProvider.readyPromise;
-      Resource._Implementations.loadWithXhr = function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType
-      ) {
-        Resource._DefaultImplementations.loadWithXhr(
-          "Data/CesiumTerrainTileJson/tile.vertexnormals.terrain",
+      return imageryProvider.readyPromise.then(function () {
+        Resource._Implementations.loadWithXhr = function (
+          url,
           responseType,
           method,
           data,
           headers,
-          deferred
-        );
-      };
+          deferred,
+          overrideMimeType
+        ) {
+          Resource._DefaultImplementations.loadWithXhr(
+            "Data/CesiumTerrainTileJson/tile.vertexnormals.terrain",
+            responseType,
+            method,
+            data,
+            headers,
+            deferred
+          );
+        };
 
-      returnVertexNormalTileJson();
+        returnVertexNormalTileJson();
 
-      const terrainProvider = await CesiumTerrainProvider.fromUrl(
-        "made/up/url",
-        {
+        const terrainProvider = new CesiumTerrainProvider({
+          url: "made/up/url",
           requestVertexNormals: true,
-        }
-      );
+        });
 
-      globe.terrainProvider = terrainProvider;
-      scene.camera.setView({
-        destination: new Rectangle(0.0001, 0.0001, 0.0025, 0.0025),
+        globe.terrainProvider = terrainProvider;
+        scene.camera.setView({
+          destination: new Rectangle(0.0001, 0.0001, 0.0025, 0.0025),
+        });
+
+        return updateUntilDone(globe).then(function () {
+          let initialRgba;
+          expect(renderOptions).toRenderAndCall(function (rgba) {
+            initialRgba = rgba;
+            expect(renderOptions).notToRender([0, 0, 0, 255]);
+          });
+          globe.lambertDiffuseMultiplier = 10.0;
+          expect(renderOptions).notToRender(initialRgba);
+        });
       });
-
-      await updateUntilDone(globe);
-
-      let initialRgba;
-      expect(renderOptions).toRenderAndCall(function (rgba) {
-        initialRgba = rgba;
-        expect(renderOptions).notToRender([0, 0, 0, 255]);
-      });
-      globe.lambertDiffuseMultiplier = 10.0;
-      expect(renderOptions).notToRender(initialRgba);
     });
 
-    it("renders terrain with vertexShadowDarkness", async function () {
+    it("renders terrain with vertexShadowDarkness", function () {
       const renderOptions = {
         scene: scene,
         time: new JulianDate(2557522.0),
@@ -397,47 +392,47 @@ describe(
         url: "Data/Images/Red16x16.png",
       });
       layerCollection.addImageryProvider(imageryProvider);
-      await imageryProvider.readyPromise;
-      Resource._Implementations.loadWithXhr = function (
-        url,
-        responseType,
-        method,
-        data,
-        headers,
-        deferred,
-        overrideMimeType
-      ) {
-        Resource._DefaultImplementations.loadWithXhr(
-          "Data/CesiumTerrainTileJson/tile.vertexnormals.terrain",
+      return imageryProvider.readyPromise.then(function () {
+        Resource._Implementations.loadWithXhr = function (
+          url,
           responseType,
           method,
           data,
           headers,
-          deferred
-        );
-      };
+          deferred,
+          overrideMimeType
+        ) {
+          Resource._DefaultImplementations.loadWithXhr(
+            "Data/CesiumTerrainTileJson/tile.vertexnormals.terrain",
+            responseType,
+            method,
+            data,
+            headers,
+            deferred
+          );
+        };
 
-      returnVertexNormalTileJson();
+        returnVertexNormalTileJson();
 
-      const terrainProvider = await CesiumTerrainProvider.fromUrl(
-        "made/up/url",
-        {
+        const terrainProvider = new CesiumTerrainProvider({
+          url: "made/up/url",
           requestVertexNormals: true,
-        }
-      );
+        });
 
-      globe.terrainProvider = terrainProvider;
-      scene.camera.setView({
-        destination: new Rectangle(0.0001, 0.0001, 0.0025, 0.0025),
-      });
+        globe.terrainProvider = terrainProvider;
+        scene.camera.setView({
+          destination: new Rectangle(0.0001, 0.0001, 0.0025, 0.0025),
+        });
 
-      await updateUntilDone(globe);
-      let initialRgba;
-      expect(renderOptions).toRenderAndCall(function (rgba) {
-        initialRgba = rgba;
-        expect(renderOptions).notToRender([0, 0, 0, 255]);
-        globe.vertexShadowDarkness = 0.1;
-        expect(renderOptions).notToRender(initialRgba);
+        return updateUntilDone(globe).then(function () {
+          let initialRgba;
+          expect(renderOptions).toRenderAndCall(function (rgba) {
+            initialRgba = rgba;
+            expect(renderOptions).notToRender([0, 0, 0, 255]);
+            globe.vertexShadowDarkness = 0.1;
+            expect(renderOptions).notToRender(initialRgba);
+          });
+        });
       });
     });
 

--- a/packages/engine/Specs/Scene/GlobeSurfaceTileProviderSpec.js
+++ b/packages/engine/Specs/Scene/GlobeSurfaceTileProviderSpec.js
@@ -895,7 +895,7 @@ describe(
       });
     });
 
-    it("adds terrain and imagery credits to the CreditDisplay", function () {
+    it("adds terrain and imagery credits to the CreditDisplay", async function () {
       const CreditDisplayElement = CreditDisplay.CreditDisplayElement;
       const imageryCredit = new Credit("imagery credit");
       scene.imageryLayers.addImageryProvider(
@@ -906,22 +906,23 @@ describe(
       );
 
       const terrainCredit = new Credit("terrain credit");
-      scene.terrainProvider = new CesiumTerrainProvider({
-        url: "https://s3.amazonaws.com/cesiumjs/smallTerrain",
-        credit: terrainCredit,
-      });
+      scene.terrainProvider = await CesiumTerrainProvider.fromUrl(
+        "https://s3.amazonaws.com/cesiumjs/smallTerrain",
+        {
+          credit: terrainCredit,
+        }
+      );
 
-      return updateUntilDone(scene.globe).then(function () {
-        const creditDisplay = scene.frameState.creditDisplay;
-        creditDisplay.showLightbox();
-        expect(
-          creditDisplay._currentFrameCredits.lightboxCredits.values
-        ).toContain(new CreditDisplayElement(imageryCredit));
-        expect(
-          creditDisplay._currentFrameCredits.lightboxCredits.values
-        ).toContain(new CreditDisplayElement(terrainCredit));
-        creditDisplay.hideLightbox();
-      });
+      await updateUntilDone(scene.globe);
+      const creditDisplay = scene.frameState.creditDisplay;
+      creditDisplay.showLightbox();
+      expect(
+        creditDisplay._currentFrameCredits.lightboxCredits.values
+      ).toContain(new CreditDisplayElement(imageryCredit));
+      expect(
+        creditDisplay._currentFrameCredits.lightboxCredits.values
+      ).toContain(new CreditDisplayElement(terrainCredit));
+      creditDisplay.hideLightbox();
     });
 
     describe(

--- a/packages/engine/Specs/Scene/GlobeSurfaceTileProviderSpec.js
+++ b/packages/engine/Specs/Scene/GlobeSurfaceTileProviderSpec.js
@@ -895,7 +895,7 @@ describe(
       });
     });
 
-    it("adds terrain and imagery credits to the CreditDisplay", async function () {
+    it("adds terrain and imagery credits to the CreditDisplay", function () {
       const CreditDisplayElement = CreditDisplay.CreditDisplayElement;
       const imageryCredit = new Credit("imagery credit");
       scene.imageryLayers.addImageryProvider(
@@ -906,23 +906,22 @@ describe(
       );
 
       const terrainCredit = new Credit("terrain credit");
-      scene.terrainProvider = await CesiumTerrainProvider.fromUrl(
-        "https://s3.amazonaws.com/cesiumjs/smallTerrain",
-        {
-          credit: terrainCredit,
-        }
-      );
+      scene.terrainProvider = new CesiumTerrainProvider({
+        url: "https://s3.amazonaws.com/cesiumjs/smallTerrain",
+        credit: terrainCredit,
+      });
 
-      await updateUntilDone(scene.globe);
-      const creditDisplay = scene.frameState.creditDisplay;
-      creditDisplay.showLightbox();
-      expect(
-        creditDisplay._currentFrameCredits.lightboxCredits.values
-      ).toContain(new CreditDisplayElement(imageryCredit));
-      expect(
-        creditDisplay._currentFrameCredits.lightboxCredits.values
-      ).toContain(new CreditDisplayElement(terrainCredit));
-      creditDisplay.hideLightbox();
+      return updateUntilDone(scene.globe).then(function () {
+        const creditDisplay = scene.frameState.creditDisplay;
+        creditDisplay.showLightbox();
+        expect(
+          creditDisplay._currentFrameCredits.lightboxCredits.values
+        ).toContain(new CreditDisplayElement(imageryCredit));
+        expect(
+          creditDisplay._currentFrameCredits.lightboxCredits.values
+        ).toContain(new CreditDisplayElement(terrainCredit));
+        creditDisplay.hideLightbox();
+      });
     });
 
     describe(

--- a/packages/engine/Specs/Scene/GlobeSurfaceTileSpec.js
+++ b/packages/engine/Specs/Scene/GlobeSurfaceTileSpec.js
@@ -1,7 +1,7 @@
 import {
   Cartesian3,
   Cartesian4,
-  createWorldTerrain,
+  createWorldTerrainAsync,
   Ellipsoid,
   EllipsoidTerrainProvider,
   GeographicTilingScheme,
@@ -335,8 +335,8 @@ describe("Scene/GlobeSurfaceTile", function () {
         scene.destroyForSpecs();
       });
 
-      it("gets correct results even when the mesh includes normals", function () {
-        const terrainProvider = createWorldTerrain({
+      it("gets correct results even when the mesh includes normals", async function () {
+        const terrainProvider = await createWorldTerrainAsync({
           requestVertexNormals: true,
           requestWaterMask: false,
         });
@@ -351,25 +351,24 @@ describe("Scene/GlobeSurfaceTile", function () {
         processor.frameState = scene.frameState;
         processor.terrainProvider = terrainProvider;
 
-        return processor.process([tile]).then(function () {
-          const ray = new Ray(
-            new Cartesian3(
-              -5052039.459789615,
-              2561172.040315167,
-              -2936276.999965875
-            ),
-            new Cartesian3(
-              0.5036332963145244,
-              0.6648033332898124,
-              0.5517155343926082
-            )
-          );
-          const pickResult = tile.data.pick(ray, undefined, undefined, true);
-          const cartographic = Ellipsoid.WGS84.cartesianToCartographic(
-            pickResult
-          );
-          expect(cartographic.height).toBeGreaterThan(-500.0);
-        });
+        await processor.process([tile]);
+        const ray = new Ray(
+          new Cartesian3(
+            -5052039.459789615,
+            2561172.040315167,
+            -2936276.999965875
+          ),
+          new Cartesian3(
+            0.5036332963145244,
+            0.6648033332898124,
+            0.5517155343926082
+          )
+        );
+        const pickResult = tile.data.pick(ray, undefined, undefined, true);
+        const cartographic = Ellipsoid.WGS84.cartesianToCartographic(
+          pickResult
+        );
+        expect(cartographic.height).toBeGreaterThan(-500.0);
       });
 
       it("gets correct result when a closer triangle is processed after a farther triangle", function () {

--- a/packages/engine/Specs/Scene/GlobeSurfaceTileSpec.js
+++ b/packages/engine/Specs/Scene/GlobeSurfaceTileSpec.js
@@ -1,7 +1,7 @@
 import {
   Cartesian3,
   Cartesian4,
-  createWorldTerrainAsync,
+  createWorldTerrain,
   Ellipsoid,
   EllipsoidTerrainProvider,
   GeographicTilingScheme,
@@ -335,8 +335,8 @@ describe("Scene/GlobeSurfaceTile", function () {
         scene.destroyForSpecs();
       });
 
-      it("gets correct results even when the mesh includes normals", async function () {
-        const terrainProvider = await createWorldTerrainAsync({
+      it("gets correct results even when the mesh includes normals", function () {
+        const terrainProvider = createWorldTerrain({
           requestVertexNormals: true,
           requestWaterMask: false,
         });
@@ -351,24 +351,25 @@ describe("Scene/GlobeSurfaceTile", function () {
         processor.frameState = scene.frameState;
         processor.terrainProvider = terrainProvider;
 
-        await processor.process([tile]);
-        const ray = new Ray(
-          new Cartesian3(
-            -5052039.459789615,
-            2561172.040315167,
-            -2936276.999965875
-          ),
-          new Cartesian3(
-            0.5036332963145244,
-            0.6648033332898124,
-            0.5517155343926082
-          )
-        );
-        const pickResult = tile.data.pick(ray, undefined, undefined, true);
-        const cartographic = Ellipsoid.WGS84.cartesianToCartographic(
-          pickResult
-        );
-        expect(cartographic.height).toBeGreaterThan(-500.0);
+        return processor.process([tile]).then(function () {
+          const ray = new Ray(
+            new Cartesian3(
+              -5052039.459789615,
+              2561172.040315167,
+              -2936276.999965875
+            ),
+            new Cartesian3(
+              0.5036332963145244,
+              0.6648033332898124,
+              0.5517155343926082
+            )
+          );
+          const pickResult = tile.data.pick(ray, undefined, undefined, true);
+          const cartographic = Ellipsoid.WGS84.cartesianToCartographic(
+            pickResult
+          );
+          expect(cartographic.height).toBeGreaterThan(-500.0);
+        });
       });
 
       it("gets correct result when a closer triangle is processed after a farther triangle", function () {

--- a/packages/engine/Specs/Scene/Model/ModelSpec.js
+++ b/packages/engine/Specs/Scene/Model/ModelSpec.js
@@ -1314,22 +1314,22 @@ describe(
       const triangleFanUrl =
         "./Data/Models/glTF-2.0/TriangleFan/glTF/TriangleFan.gltf";
 
-      let sceneWithWebgl2;
+      let sceneWithWebgl1;
 
       beforeAll(function () {
-        sceneWithWebgl2 = createScene({
+        sceneWithWebgl1 = createScene({
           contextOptions: {
-            requestWebgl1: false,
+            requestWebgl1: true,
           },
         });
       });
 
       afterEach(function () {
-        sceneWithWebgl2.primitives.removeAll();
+        sceneWithWebgl1.primitives.removeAll();
       });
 
       afterAll(function () {
-        sceneWithWebgl2.destroyForSpecs();
+        sceneWithWebgl1.destroyForSpecs();
       });
 
       it("debugWireframe works for WebGL1 if enableDebugWireframe is true", function () {
@@ -1338,7 +1338,7 @@ describe(
         return loadPromise.then(function (buffer) {
           return loadAndZoomToModel(
             { gltf: new Uint8Array(buffer), enableDebugWireframe: true },
-            scene
+            sceneWithWebgl1
           ).then(function (model) {
             verifyDebugWireframe(model, PrimitiveType.TRIANGLES);
           });
@@ -1351,12 +1351,12 @@ describe(
         return loadPromise.then(function (buffer) {
           return loadAndZoomToModel(
             { gltf: new Uint8Array(buffer), enableDebugWireframe: false },
-            scene
+            sceneWithWebgl1
           ).then(function (model) {
             const commandList = scene.frameState.commandList;
             const commandCounts = [];
             let i, command;
-            scene.renderForSpecs();
+            sceneWithWebgl1.renderForSpecs();
             for (i = 0; i < commandList.length; i++) {
               command = commandList[i];
               expect(command.primitiveType).toBe(PrimitiveType.TRIANGLES);
@@ -1366,7 +1366,7 @@ describe(
             model.debugWireframe = true;
             expect(model._drawCommandsBuilt).toBe(false);
 
-            scene.renderForSpecs();
+            sceneWithWebgl1.renderForSpecs();
             for (i = 0; i < commandList.length; i++) {
               command = commandList[i];
               expect(command.primitiveType).toBe(PrimitiveType.TRIANGLES);
@@ -1377,7 +1377,7 @@ describe(
       });
 
       it("debugWireframe works for WebGL2", function () {
-        if (!sceneWithWebgl2.context.webgl2) {
+        if (!scene.context.webgl2) {
           return;
         }
         const resource = Resource.createIfNeeded(boxTexturedGlbUrl);
@@ -1388,7 +1388,7 @@ describe(
             scene
           ).then(function (model) {
             verifyDebugWireframe(model, PrimitiveType.TRIANGLES, {
-              scene: sceneWithWebgl2,
+              scene: scene,
             });
           });
         });
@@ -2231,8 +2231,8 @@ describe(
         });
       });
 
-      it("height reference accounts for change in terrain provider", async function () {
-        const model = await loadAndZoomToModel(
+      it("height reference accounts for change in terrain provider", function () {
+        return loadAndZoomToModel(
           {
             gltf: boxTexturedGltfUrl,
             modelMatrix: Transforms.eastNorthUpToFixedFrame(
@@ -2242,18 +2242,17 @@ describe(
             scene: sceneWithMockGlobe,
           },
           sceneWithMockGlobe
-        );
-        expect(model._heightDirty).toBe(false);
-        const terrainProvider = await CesiumTerrainProvider.fromUrl(
-          "made/up/url",
-          {
+        ).then(function (model) {
+          expect(model._heightDirty).toBe(false);
+          const terrainProvider = new CesiumTerrainProvider({
+            url: "made/up/url",
             requestVertexNormals: true,
-          }
-        );
-        sceneWithMockGlobe.terrainProvider = terrainProvider;
+          });
+          sceneWithMockGlobe.terrainProvider = terrainProvider;
 
-        expect(model._heightDirty).toBe(true);
-        sceneWithMockGlobe.terrainProvider = undefined;
+          expect(model._heightDirty).toBe(true);
+          sceneWithMockGlobe.terrainProvider = undefined;
+        });
       });
 
       it("throws when initializing height reference with no scene", function () {

--- a/packages/engine/Specs/Scene/Model/ModelSpec.js
+++ b/packages/engine/Specs/Scene/Model/ModelSpec.js
@@ -2231,8 +2231,8 @@ describe(
         });
       });
 
-      it("height reference accounts for change in terrain provider", function () {
-        return loadAndZoomToModel(
+      it("height reference accounts for change in terrain provider", async function () {
+        const model = await loadAndZoomToModel(
           {
             gltf: boxTexturedGltfUrl,
             modelMatrix: Transforms.eastNorthUpToFixedFrame(
@@ -2242,17 +2242,18 @@ describe(
             scene: sceneWithMockGlobe,
           },
           sceneWithMockGlobe
-        ).then(function (model) {
-          expect(model._heightDirty).toBe(false);
-          const terrainProvider = new CesiumTerrainProvider({
-            url: "made/up/url",
+        );
+        expect(model._heightDirty).toBe(false);
+        const terrainProvider = await CesiumTerrainProvider.fromUrl(
+          "made/up/url",
+          {
             requestVertexNormals: true,
-          });
-          sceneWithMockGlobe.terrainProvider = terrainProvider;
+          }
+        );
+        sceneWithMockGlobe.terrainProvider = terrainProvider;
 
-          expect(model._heightDirty).toBe(true);
-          sceneWithMockGlobe.terrainProvider = undefined;
-        });
+        expect(model._heightDirty).toBe(true);
+        sceneWithMockGlobe.terrainProvider = undefined;
       });
 
       it("throws when initializing height reference with no scene", function () {

--- a/packages/engine/Specs/Scene/SceneSpec.js
+++ b/packages/engine/Specs/Scene/SceneSpec.js
@@ -1495,33 +1495,26 @@ describe(
       scene.destroyForSpecs();
     });
 
-    it("Sets terrainProvider", function () {
+    it("Sets terrainProvider", async function () {
       returnQuantizedMeshTileJson();
 
       const scene = createScene();
       const globe = (scene.globe = new Globe(Ellipsoid.UNIT_SPHERE));
-      scene.terrainProvider = new CesiumTerrainProvider({
-        url: "//terrain/tiles",
-      });
+      scene.terrainProvider = await CesiumTerrainProvider.fromUrl(
+        "//terrain/tiles"
+      );
+      expect(scene.terrainProvider).toBe(globe.terrainProvider);
 
-      return scene.terrainProvider.readyPromise
-        .then(() => {
-          expect(scene.terrainProvider).toBe(globe.terrainProvider);
-          scene.globe = undefined;
-          const newProvider = new CesiumTerrainProvider({
-            url: "//newTerrain/tiles",
-          });
-          return newProvider.readyPromise.then(() => {
-            expect(function () {
-              scene.terrainProvider = newProvider;
-            }).not.toThrow();
-          });
-        })
-        .finally(() => {
-          scene.destroyForSpecs();
-          Resource._Implementations.loadWithXhr =
-            Resource._DefaultImplementations.loadWithXhr;
-        });
+      const newProvider = await CesiumTerrainProvider.fromUrl(
+        "//newTerrain/tiles"
+      );
+      scene.terrainProvider = newProvider;
+      expect(scene.terrainProvider).toBe(newProvider);
+      expect(scene.terrainProvider).toBe(globe.terrainProvider);
+
+      scene.destroyForSpecs();
+      Resource._Implementations.loadWithXhr =
+        Resource._DefaultImplementations.loadWithXhr;
     });
 
     it("Gets terrainProviderChanged", function () {

--- a/packages/engine/Specs/Scene/SceneSpec.js
+++ b/packages/engine/Specs/Scene/SceneSpec.js
@@ -1495,26 +1495,33 @@ describe(
       scene.destroyForSpecs();
     });
 
-    it("Sets terrainProvider", async function () {
+    it("Sets terrainProvider", function () {
       returnQuantizedMeshTileJson();
 
       const scene = createScene();
       const globe = (scene.globe = new Globe(Ellipsoid.UNIT_SPHERE));
-      scene.terrainProvider = await CesiumTerrainProvider.fromUrl(
-        "//terrain/tiles"
-      );
-      expect(scene.terrainProvider).toBe(globe.terrainProvider);
+      scene.terrainProvider = new CesiumTerrainProvider({
+        url: "//terrain/tiles",
+      });
 
-      const newProvider = await CesiumTerrainProvider.fromUrl(
-        "//newTerrain/tiles"
-      );
-      scene.terrainProvider = newProvider;
-      expect(scene.terrainProvider).toBe(newProvider);
-      expect(scene.terrainProvider).toBe(globe.terrainProvider);
-
-      scene.destroyForSpecs();
-      Resource._Implementations.loadWithXhr =
-        Resource._DefaultImplementations.loadWithXhr;
+      return scene.terrainProvider.readyPromise
+        .then(() => {
+          expect(scene.terrainProvider).toBe(globe.terrainProvider);
+          scene.globe = undefined;
+          const newProvider = new CesiumTerrainProvider({
+            url: "//newTerrain/tiles",
+          });
+          return newProvider.readyPromise.then(() => {
+            expect(function () {
+              scene.terrainProvider = newProvider;
+            }).not.toThrow();
+          });
+        })
+        .finally(() => {
+          scene.destroyForSpecs();
+          Resource._Implementations.loadWithXhr =
+            Resource._DefaultImplementations.loadWithXhr;
+        });
     });
 
     it("Gets terrainProviderChanged", function () {

--- a/packages/engine/Specs/Scene/computeFlyToLocationForRectangleSpec.js
+++ b/packages/engine/Specs/Scene/computeFlyToLocationForRectangleSpec.js
@@ -131,25 +131,6 @@ describe("Scene/computeFlyToLocationForRectangle", function () {
     });
   });
 
-  it("waits for terrain to become ready", function () {
-    const terrainProvider = new MockTerrainProvider();
-    spyOn(terrainProvider.readyPromise, "then").and.callThrough();
-
-    scene.globe = new Globe();
-    scene.terrainProvider = terrainProvider;
-
-    const rectangle = new Rectangle(0.2, 0.4, 0.6, 0.8);
-    const expectedResult = scene.mapProjection.ellipsoid.cartesianToCartographic(
-      scene.camera.getRectangleCameraCoordinates(rectangle)
-    );
-    return computeFlyToLocationForRectangle(rectangle, scene).then(function (
-      result
-    ) {
-      expect(result).toEqual(expectedResult);
-      expect(terrainProvider.readyPromise.then).toHaveBeenCalled();
-    });
-  });
-
   it("returns height above ellipsoid when terrain undefined", function () {
     scene.terrainProvider = undefined;
     const rectangle = new Rectangle(0.2, 0.4, 0.6, 0.8);

--- a/packages/engine/Specs/Widget/CesiumWidgetSpec.js
+++ b/packages/engine/Specs/Widget/CesiumWidgetSpec.js
@@ -145,34 +145,12 @@ describe(
       expect(imageryLayers.length).toEqual(0);
     });
 
-    it("uses default terrainProvider", function () {
-      widget = createCesiumWidget(container);
-      expect(widget.terrainProvider).toBeInstanceOf(EllipsoidTerrainProvider);
-    });
-
     it("sets expected options terrainProvider", function () {
       const options = {
         terrainProvider: new EllipsoidTerrainProvider(),
       };
       widget = createCesiumWidget(container, options);
       expect(widget.terrainProvider).toBe(options.terrainProvider);
-
-      const anotherProvider = new EllipsoidTerrainProvider();
-      widget.terrainProvider = anotherProvider;
-      expect(widget.terrainProvider).toBe(anotherProvider);
-    });
-
-    it("sets expected options terrainProvider promise", async function () {
-      const options = {
-        terrainProvider: Promise.resolve(new EllipsoidTerrainProvider()),
-      };
-      widget = createCesiumWidget(container, options);
-      const provider = await options.terrainProvider;
-      expect(widget.terrainProvider).toBe(provider);
-    });
-
-    it("sets terrainProvider", function () {
-      widget = createCesiumWidget(container);
 
       const anotherProvider = new EllipsoidTerrainProvider();
       widget.terrainProvider = anotherProvider;

--- a/packages/engine/Specs/Widget/CesiumWidgetSpec.js
+++ b/packages/engine/Specs/Widget/CesiumWidgetSpec.js
@@ -145,12 +145,34 @@ describe(
       expect(imageryLayers.length).toEqual(0);
     });
 
+    it("uses default terrainProvider", function () {
+      widget = createCesiumWidget(container);
+      expect(widget.terrainProvider).toBeInstanceOf(EllipsoidTerrainProvider);
+    });
+
     it("sets expected options terrainProvider", function () {
       const options = {
         terrainProvider: new EllipsoidTerrainProvider(),
       };
       widget = createCesiumWidget(container, options);
       expect(widget.terrainProvider).toBe(options.terrainProvider);
+
+      const anotherProvider = new EllipsoidTerrainProvider();
+      widget.terrainProvider = anotherProvider;
+      expect(widget.terrainProvider).toBe(anotherProvider);
+    });
+
+    it("sets expected options terrainProvider promise", async function () {
+      const options = {
+        terrainProvider: Promise.resolve(new EllipsoidTerrainProvider()),
+      };
+      widget = createCesiumWidget(container, options);
+      const provider = await options.terrainProvider;
+      expect(widget.terrainProvider).toBe(provider);
+    });
+
+    it("sets terrainProvider", function () {
+      widget = createCesiumWidget(container);
 
       const anotherProvider = new EllipsoidTerrainProvider();
       widget.terrainProvider = anotherProvider;

--- a/packages/engine/Specs/test.mjs
+++ b/packages/engine/Specs/test.mjs
@@ -2,16 +2,17 @@ import { Cartographic, CesiumTerrainProvider, sampleTerrain } from "@cesium/engi
 import assert from "node:assert";
 
 // NodeJS smoke screen test
-
-const provider = new CesiumTerrainProvider({
-    url: "https://s3.amazonaws.com/cesiumjs/smallTerrain",
-  });
-  sampleTerrain(provider, 11, [
+async function test() {
+  const provider = await CesiumTerrainProvider.fromUrl("https://s3.amazonaws.com/cesiumjs/smallTerrain");
+  const results = await sampleTerrain(provider, 11, [
     Cartographic.fromDegrees(86.925145, 27.988257),
     Cartographic.fromDegrees(87.0, 28.0),
-  ]).then((results) => {
-    assert(results[0].height > 5000);
-    assert(results[0].height < 10000);
-    assert(results[1].height > 5000);
-    assert(results[1].height < 10000);
-  });
+  ])
+
+  assert(results[0].height > 5000);
+  assert(results[0].height < 10000);
+  assert(results[1].height > 5000);
+  assert(results[1].height < 10000);
+}
+
+test();

--- a/packages/widgets/Source/BaseLayerPicker/BaseLayerPickerViewModel.js
+++ b/packages/widgets/Source/BaseLayerPicker/BaseLayerPickerViewModel.js
@@ -296,7 +296,6 @@ Object.defineProperties(BaseLayerPickerViewModel.prototype, {
   /**
    * Gets the command to toggle the visibility of the drop down.
    * @memberof BaseLayerPickerViewModel.prototype
-   *
    * @type {Command}
    */
   toggleDropDown: {
@@ -308,7 +307,6 @@ Object.defineProperties(BaseLayerPickerViewModel.prototype, {
   /**
    * Gets the globe.
    * @memberof BaseLayerPickerViewModel.prototype
-   *
    * @type {Globe}
    */
   globe: {

--- a/packages/widgets/Source/BaseLayerPicker/BaseLayerPickerViewModel.js
+++ b/packages/widgets/Source/BaseLayerPicker/BaseLayerPickerViewModel.js
@@ -253,12 +253,22 @@ function BaseLayerPickerViewModel(options) {
         newProvider = value.creationCommand();
       }
 
-      this._globe.depthTestAgainstTerrain = !(
-        newProvider instanceof EllipsoidTerrainProvider
-      );
-      this._globe.terrainProvider = newProvider;
       selectedTerrainViewModel(value);
-      this.dropDownVisible = false;
+
+      const updateTerrainProvider = async () => {
+        const provider = await Promise.resolve(newProvider);
+        if (!defined(provider)) {
+          return;
+        }
+
+        this._globe.depthTestAgainstTerrain = !(
+          provider instanceof EllipsoidTerrainProvider
+        );
+        this._globe.terrainProvider = provider;
+        this.dropDownVisible = false;
+      };
+
+      updateTerrainProvider();
     },
   });
 
@@ -271,10 +281,15 @@ function BaseLayerPickerViewModel(options) {
     options.selectedImageryProviderViewModel,
     imageryProviderViewModels[0]
   );
-  this.selectedTerrain = defaultValue(
-    options.selectedTerrainProviderViewModel,
-    terrainProviderViewModels[0]
-  );
+
+  Promise.resolve(
+    defaultValue(
+      options.selectedTerrainProviderViewModel,
+      terrainProviderViewModels[0]
+    )
+  ).then((provider) => {
+    this.selectedTerrain = provider;
+  });
 }
 
 Object.defineProperties(BaseLayerPickerViewModel.prototype, {

--- a/packages/widgets/Source/BaseLayerPicker/ProviderViewModel.js
+++ b/packages/widgets/Source/BaseLayerPicker/ProviderViewModel.js
@@ -97,7 +97,7 @@ Object.defineProperties(ProviderViewModel.prototype, {
 /**
  * A function which creates one or more providers.
  * @callback ProviderViewModel.CreationFunction
- * @returns {ImageryProvider|TerrainProvider|ImageryProvider[]|TerrainProvider[]|Promise<TerrainProvider>|Provider<TerrainProvider[]>}
+ * @returns {ImageryProvider|TerrainProvider|ImageryProvider[]|TerrainProvider[]|Promise<TerrainProvider>|Promise<TerrainProvider[]>}
  *          The ImageryProvider or TerrainProvider, or array of providers, to be added
  *          to the globe.
  */

--- a/packages/widgets/Source/BaseLayerPicker/ProviderViewModel.js
+++ b/packages/widgets/Source/BaseLayerPicker/ProviderViewModel.js
@@ -97,7 +97,7 @@ Object.defineProperties(ProviderViewModel.prototype, {
 /**
  * A function which creates one or more providers.
  * @callback ProviderViewModel.CreationFunction
- * @returns {ImageryProvider|TerrainProvider|ImageryProvider[]|TerrainProvider[]}
+ * @returns {ImageryProvider|TerrainProvider|ImageryProvider[]|TerrainProvider[]|Promise<TerrainProvider>|Provider<TerrainProvider[]>}
  *          The ImageryProvider or TerrainProvider, or array of providers, to be added
  *          to the globe.
  */

--- a/packages/widgets/Source/BaseLayerPicker/createDefaultTerrainProviderViewModels.js
+++ b/packages/widgets/Source/BaseLayerPicker/createDefaultTerrainProviderViewModels.js
@@ -1,6 +1,6 @@
 import {
   buildModuleUrl,
-  createWorldTerrain,
+  createWorldTerrainAsync,
   EllipsoidTerrainProvider,
 } from "@cesium/engine";
 import ProviderViewModel from "./ProviderViewModel.js";
@@ -32,7 +32,7 @@ function createDefaultTerrainProviderViewModels() {
         "High-resolution global terrain tileset curated from several datasources and hosted by Cesium ion",
       category: "Cesium ion",
       creationFunction: function () {
-        return createWorldTerrain({
+        return createWorldTerrainAsync({
           requestWaterMask: true,
           requestVertexNormals: true,
         });

--- a/packages/widgets/Source/Viewer/Viewer.js
+++ b/packages/widgets/Source/Viewer/Viewer.js
@@ -314,7 +314,7 @@ function enableVRUI(viewer, enabled) {
  * @property {ProviderViewModel} [selectedTerrainProviderViewModel] The view model for the current base terrain layer, if not supplied the first available base layer is used.  This value is only valid if `baseLayerPicker` is set to true.
  * @property {ProviderViewModel[]} [terrainProviderViewModels=createDefaultTerrainProviderViewModels()] The array of ProviderViewModels to be selectable from the BaseLayerPicker.  This value is only valid if `baseLayerPicker` is set to true.
  * @property {ImageryProvider} [imageryProvider=createWorldImagery()] The imagery provider to use.  This value is only valid if `baseLayerPicker` is set to false.
- * @property {TerrainProvider|Promise<TerrainProvider>} [terrainProvider=new EllipsoidTerrainProvider()] The terrain provider to use
+ * @property {TerrainProvider} [terrainProvider=new EllipsoidTerrainProvider()] The terrain provider to use
  * @property {SkyBox|false} [skyBox] The skybox used to render the stars.  When <code>undefined</code>, the default stars are used. If set to <code>false</code>, no skyBox, Sun, or Moon will be added.
  * @property {SkyAtmosphere|false} [skyAtmosphere] Blue sky, and the glow around the Earth's limb.  Set to <code>false</code> to turn it off.
  * @property {Element|String} [fullscreenElement=document.body] The element or id to be placed into fullscreen mode when the full screen button is pressed.
@@ -369,39 +369,43 @@ function enableVRUI(viewer, enabled) {
  * @demo {@link https://sandcastle.cesium.com/index.html?src=Hello%20World.html|Cesium Sandcastle Hello World Demo}
  *
  * @example
- * //Initialize the viewer widget with several custom options and mixins.
- * const viewer = new Cesium.Viewer('cesiumContainer', {
- *     //Start in Columbus Viewer
- *     sceneMode : Cesium.SceneMode.COLUMBUS_VIEW,
- *     //Use Cesium World Terrain
- *     terrainProvider : Cesium.createWorldTerrainAsync(),
- *     //Hide the base layer picker
- *     baseLayerPicker : false,
- *     //Use OpenStreetMaps
- *     imageryProvider : new Cesium.OpenStreetMapImageryProvider({
- *         url : 'https://a.tile.openstreetmap.org/'
+ * // Initialize the viewer widget with several custom options and mixins.
+ * try {
+ *   const viewer = new Cesium.Viewer("cesiumContainer", {
+ *     // Start in Columbus Viewer
+ *     sceneMode: Cesium.SceneMode.COLUMBUS_VIEW,
+ *     // Use Cesium World Terrain
+ *     terrainProvider: await Cesium.createWorldTerrainAsync(),
+ *     // Hide the base layer picker
+ *     baseLayerPicker: false,
+ *     // Use OpenStreetMaps
+ *     imageryProvider: new Cesium.OpenStreetMapImageryProvider({
+ *       url: "https://a.tile.openstreetmap.org/"
  *     }),
- *     skyBox : new Cesium.SkyBox({
- *         sources : {
- *           positiveX : 'stars/TychoSkymapII.t3_08192x04096_80_px.jpg',
- *           negativeX : 'stars/TychoSkymapII.t3_08192x04096_80_mx.jpg',
- *           positiveY : 'stars/TychoSkymapII.t3_08192x04096_80_py.jpg',
- *           negativeY : 'stars/TychoSkymapII.t3_08192x04096_80_my.jpg',
- *           positiveZ : 'stars/TychoSkymapII.t3_08192x04096_80_pz.jpg',
- *           negativeZ : 'stars/TychoSkymapII.t3_08192x04096_80_mz.jpg'
- *         }
+ *     skyBox: new Cesium.SkyBox({
+ *       sources: {
+ *         positiveX: "stars/TychoSkymapII.t3_08192x04096_80_px.jpg",
+ *         negativeX: "stars/TychoSkymapII.t3_08192x04096_80_mx.jpg",
+ *         positiveY: "stars/TychoSkymapII.t3_08192x04096_80_py.jpg",
+ *         negativeY: "stars/TychoSkymapII.t3_08192x04096_80_my.jpg",
+ *         positiveZ: "stars/TychoSkymapII.t3_08192x04096_80_pz.jpg",
+ *         negativeZ: "stars/TychoSkymapII.t3_08192x04096_80_mz.jpg"
+ *       }
  *     }),
  *     // Show Columbus View map with Web Mercator projection
- *     mapProjection : new Cesium.WebMercatorProjection()
- * });
+ *     mapProjection: new Cesium.WebMercatorProjection()
+ *   });
+ * } catch (error) {
+ *   console.log(error);
+ * }
  *
- * //Add basic drag and drop functionality
+ * // Add basic drag and drop functionality
  * viewer.extend(Cesium.viewerDragDropMixin);
  *
- * //Show a pop-up alert if we encounter an error when processing a dropped file
+ * // Show a pop-up alert if we encounter an error when processing a dropped file
  * viewer.dropError.addEventListener(function(dropHandler, name, error) {
- *     console.log(error);
- *     window.alert(error);
+ *   console.log(error);
+ *   window.alert(error);
  * });
  */
 function Viewer(container, options) {
@@ -680,21 +684,10 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
     scene.imageryLayers.addImageryProvider(options.imageryProvider);
   }
   if (defined(options.terrainProvider)) {
-    // options.terrainProvider is a promise
-    // Promise.resolve is not used so that synchronous code can immediately execute
-    if (defined(options.terrainProvider.then)) {
-      options.terrainProvider.then((provider) => {
-        if (createBaseLayerPicker) {
-          baseLayerPicker.viewModel.selectedTerrain = undefined;
-        }
-        scene.terrainProvider = provider;
-      });
-    } else {
-      if (createBaseLayerPicker) {
-        baseLayerPicker.viewModel.selectedTerrain = undefined;
-      }
-      scene.terrainProvider = options.terrainProvider;
+    if (createBaseLayerPicker) {
+      baseLayerPicker.viewModel.selectedTerrain = undefined;
     }
+    scene.terrainProvider = options.terrainProvider;
   }
 
   // Navigation Help Button

--- a/packages/widgets/Specs/BaseLayerPicker/BaseLayerPickerViewModelSpec.js
+++ b/packages/widgets/Specs/BaseLayerPicker/BaseLayerPickerViewModelSpec.js
@@ -11,23 +11,9 @@ describe("Widgets/BaseLayerPicker/BaseLayerPickerViewModel", function () {
     this.terrainProvider = new EllipsoidTerrainProvider();
   }
 
-  const testProvider = {
-    isReady: function () {
-      return false;
-    },
-  };
-
-  const testProvider2 = {
-    isReady: function () {
-      return false;
-    },
-  };
-
-  const testProvider3 = {
-    isReady: function () {
-      return false;
-    },
-  };
+  const testProvider = {};
+  const testProvider2 = {};
+  const testProvider3 = {};
 
   const testProviderViewModel = new ProviderViewModel({
     name: "name",
@@ -166,7 +152,7 @@ describe("Widgets/BaseLayerPicker/BaseLayerPickerViewModel", function () {
     expect(viewModel.dropDownVisible).toEqual(false);
   });
 
-  it("selecting terrain closes the dropDown", function () {
+  it("selecting terrain closes the dropDown", async function () {
     const imageryViewModels = [testProviderViewModel];
     const globe = new MockGlobe();
     const viewModel = new BaseLayerPickerViewModel({
@@ -176,10 +162,11 @@ describe("Widgets/BaseLayerPicker/BaseLayerPickerViewModel", function () {
 
     viewModel.dropDownVisible = true;
     viewModel.selectedTerrain = testProviderViewModel;
+    await testProviderViewModel.creationCommand();
     expect(viewModel.dropDownVisible).toEqual(false);
   });
 
-  it("tooltip, buttonImageUrl, and selectedImagery all return expected values", function () {
+  it("tooltip, buttonImageUrl, and selectedImagery all return expected values", async function () {
     const imageryViewModels = [testProviderViewModel];
     const terrainViewModels = [testProviderViewModel3];
     const globe = new MockGlobe();
@@ -191,6 +178,7 @@ describe("Widgets/BaseLayerPicker/BaseLayerPickerViewModel", function () {
     });
 
     viewModel.selectedImagery = testProviderViewModel;
+    await testProviderViewModel.creationCommand();
     expect(viewModel.buttonTooltip).toEqual(
       `${testProviderViewModel.name}\n${testProviderViewModel3.name}`
     );
@@ -199,6 +187,7 @@ describe("Widgets/BaseLayerPicker/BaseLayerPickerViewModel", function () {
     expect(viewModel.buttonTooltip).toEqual(testProviderViewModel3.name);
 
     viewModel.selectedImagery = testProviderViewModel;
+    await testProviderViewModel.creationCommand();
     viewModel.selectedTerrain = undefined;
     expect(viewModel.buttonTooltip).toEqual(testProviderViewModel.name);
 
@@ -226,7 +215,7 @@ describe("Widgets/BaseLayerPicker/BaseLayerPickerViewModel", function () {
     expect(imageryLayers.get(1).imageryProvider).toBe(testProvider2);
   });
 
-  it("selectedTerrain actually sets terrainPRovider", function () {
+  it("selectedTerrain actually sets terrainProvider", async function () {
     const terrainProviderViewModels = [
       testProviderViewModel,
       testProviderViewModel3,
@@ -238,6 +227,7 @@ describe("Widgets/BaseLayerPicker/BaseLayerPickerViewModel", function () {
     });
 
     viewModel.selectedTerrain = testProviderViewModel3;
+    await testProviderViewModel3.creationCommand();
     expect(globe.terrainProvider).toBe(testProvider3);
   });
 

--- a/packages/widgets/Specs/BaseLayerPicker/BaseLayerPickerViewModelSpec.js
+++ b/packages/widgets/Specs/BaseLayerPicker/BaseLayerPickerViewModelSpec.js
@@ -10,6 +10,7 @@ describe("Widgets/BaseLayerPicker/BaseLayerPickerViewModel", function () {
     this.imageryLayers = new ImageryLayerCollection();
     this.terrainProvider = new EllipsoidTerrainProvider();
   }
+  MockGlobe.prototype.isDestroyed = () => false;
 
   const testProvider = {};
   const testProvider2 = {};
@@ -39,6 +40,15 @@ describe("Widgets/BaseLayerPicker/BaseLayerPickerViewModel", function () {
     iconUrl: "url3",
     creationFunction: function () {
       return testProvider3;
+    },
+  });
+
+  const testProviderViewModelAsync = new ProviderViewModel({
+    name: "name3",
+    tooltip: "tooltip3",
+    iconUrl: "url3",
+    creationFunction: async function () {
+      return testProvider;
     },
   });
 
@@ -229,6 +239,22 @@ describe("Widgets/BaseLayerPicker/BaseLayerPickerViewModel", function () {
     viewModel.selectedTerrain = testProviderViewModel3;
     await testProviderViewModel3.creationCommand();
     expect(globe.terrainProvider).toBe(testProvider3);
+  });
+
+  it("selectedTerrain actually sets async terrainProvider", async function () {
+    const terrainProviderViewModels = [
+      testProviderViewModel,
+      testProviderViewModelAsync,
+    ];
+    const globe = new MockGlobe();
+    const viewModel = new BaseLayerPickerViewModel({
+      globe: globe,
+      terrainProviderViewModels: terrainProviderViewModels,
+    });
+
+    viewModel.selectedTerrain = testProviderViewModelAsync;
+    await testProviderViewModelAsync.creationCommand();
+    expect(globe.terrainProvider).toBe(testProvider);
   });
 
   it("settings selectedImagery only removes layers added by view model", function () {


### PR DESCRIPTION
Part of https://github.com/CesiumGS/cesium/issues/10909

Since we're getting rid of the `readyPromise` pattern, it's preferable to roll out the deprecations across the API as part of one release in order to reduce noise. I've created a staging branch to target some smaller PRs like this into.


This PR depreciates the `readyPromise` pattern for terrain providers. I set the deprecation period for two releases from the next one (1.104) since these are fairly high-tough areas of the API. A few other API changes consequently fall out of this deprecation, notably:
- `ready` and `readyPromise` have been deprecated, but remain working until they are completely removed. 
- Various properties no longer throw an exception since there's no need to wait for `ready`
- Where applicable, `url` or the relevant resource-related options have been deprecated from constructors. In their place, there are new `fromUrl` functions, which are asynchronous functions that resolve to a new instance of the provider after successfully requesting the required resources. This function call throws any relevant errors rather than logging it to the console or raising an error event.
- `Viewer` and `CesiumWidget` parameters: These will now need to take promises which resolve to the terrainProvider if we'd like to keep the same setup flow
- `createWorldTerrain` will need to be deprecated, as it can no longer work synchronously. I went with `createWorldTerrainAsync` but I'm open to naming suggestions.

Some finer points of the implementation here include:
- Generally, a move towards using `async`/`await` syntax for flatter and more readable code
- Adds a new async version of the `toThrowDeveloperError` matcher for better async testing flow
- Making use of a builder pattern (encapsulated within the modules, not part of the public API) in order to manage a more complex object construction
- I don't think the `baseLayerPicker` and Cesium Viewer app changes  are the cleanest they can be, though it's probably best to address that once the imagery provider version of these changes are in.
- It looks like in order for typescript to pass, we cannot remove the `url` option from the the constructor options typedef without throwing an error. Unless there is a workaround I don't know of, we'll need to note to remember to remove the property when the depreciation warnings are removed.

Finally, as a consequence of these changes, we'll definitely need to do a pass through website tutorials and ensure we're using the updated APIs. I've made the Sandcastle changes here already.

TODO:
- [x] Cleanup typescript errors
- [x] Make sure sandcastles with dropdowns have selected their first item
- [x] scene.pickPosition seems wildly off in http://localhost:8080/Apps/Sandcastle/index.html?src=Drawing%20on%20Terrain.html&label=All
- [x] I3S Error http://localhost:8080/Apps/Sandcastle/index.html?src=I3S%20IntegratedMesh%20Layer.html&label=All
- [x] Put back removed unit tests

Outside of scope for this PR:
- [ ] Pass over async code for Sandcastles (and do we want to make the invoked wrapper function async). In particular, do a pass for race conditions when doing things like switching providers.
- [ ] `depthTestAgainstTerrain` setting via BaseLayerPicker? https://github.com/CesiumGS/cesium/pull/11033#issuecomment-1400538785
- [ ] Finalize deprecation versions and open issues
- [ ] `fromUrl` / `Resource` naming
- [ ] Open forum thread to discuss API changes