### PR TITLE
Fix loading of label background

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - Fixed a bug decoding glTF Draco attributes with quantization bits above 16. [#7471](https://github.com/CesiumGS/cesium/issues/7471)
 - Fixed an edge case in `viewer.flyTo` when flying to a imagery layer with certain terrain providers. [#10937](https://github.com/CesiumGS/cesium/issues/10937)
 - Fixed a crash in terrain sampling if any points have an indefined position due to being outside the rectangle. [#10931](https://github.com/CesiumGS/cesium/pull/10931)
+- Fixed label background rendering. [#11040](https://github.com/CesiumGS/cesium/issues/11040)
 
 ### 1.101 - 2023-01-02
 

--- a/packages/engine/Source/Scene/TextureAtlas.js
+++ b/packages/engine/Source/Scene/TextureAtlas.js
@@ -498,17 +498,19 @@ TextureAtlas.prototype.addSubRegion = function (id, subRegion) {
     }
     const atlasWidth = that._texture.width;
     const atlasHeight = that._texture.height;
-    const numImages = that.numberOfImages;
 
     const baseRegion = that._textureCoordinates[index];
     const x = baseRegion.x + subRegion.x / atlasWidth;
     const y = baseRegion.y + subRegion.y / atlasHeight;
     const w = subRegion.width / atlasWidth;
     const h = subRegion.height / atlasHeight;
-    that._textureCoordinates.push(new BoundingRectangle(x, y, w, h));
+    const newIndex =
+      that._textureCoordinates.push(new BoundingRectangle(x, y, w, h)) - 1;
+    that._indexHash[id] = newIndex;
+
     that._guid = createGuid();
 
-    return numImages;
+    return newIndex;
   });
 };
 

--- a/packages/engine/Specs/Scene/TextureAtlasSpec.js
+++ b/packages/engine/Specs/Scene/TextureAtlasSpec.js
@@ -804,6 +804,8 @@ describe(
         expect(coordinates[index4].y).toEqual(0.5 / atlasHeight);
         expect(coordinates[index4].width).toEqual(0.5 / atlasWidth);
         expect(coordinates[index4].height).toEqual(0.5 / atlasHeight);
+
+        expect(atlas._indexHash[greenGuid]).toEqual(3);
       });
     });
 

--- a/packages/engine/Specs/Scene/TextureAtlasSpec.js
+++ b/packages/engine/Specs/Scene/TextureAtlasSpec.js
@@ -2,12 +2,11 @@ import {
   BoundingRectangle,
   Cartesian2,
   createGuid,
+  Math as CesiumMath,
   PixelFormat,
   Resource,
   TextureAtlas,
 } from "../../index.js";
-
-import { Math as CesiumMath } from "../../index.js";
 
 import createScene from "../../../../Specs/createScene.js";
 
@@ -228,219 +227,183 @@ describe(
         });
     });
 
-    it("creates a two image atlas", function () {
+    it("creates a two image atlas", async function () {
       atlas = new TextureAtlas({
         context: scene.context,
         borderWidthInPixels: 0,
         initialSize: new Cartesian2(2, 2),
       });
 
-      const promises = [];
-      promises.push(atlas.addImage(greenGuid, greenImage));
-      promises.push(atlas.addImage(blueGuid, blueImage));
+      const greenIndex = await atlas.addImage(greenGuid, greenImage);
+      const blueIndex = await atlas.addImage(blueGuid, blueImage);
 
-      return Promise.all(promises, function (indices) {
-        const greenIndex = indices[0];
-        const blueIndex = indices[1];
+      expect(atlas.numberOfImages).toEqual(2);
 
-        expect(atlas.numberOfImages).toEqual(2);
+      const texture = atlas.texture;
+      const atlasWidth = 2.0;
+      const atlasHeight = 2.0;
+      expect(texture.width).toEqual(atlasWidth);
+      expect(texture.height).toEqual(atlasHeight);
 
-        const texture = atlas.texture;
-        const atlasWidth = 2.0;
-        const atlasHeight = 2.0;
-        expect(texture.width).toEqual(atlasWidth);
-        expect(texture.height).toEqual(atlasHeight);
+      const greenCoords = atlas.textureCoordinates[greenIndex];
+      expect(greenCoords.x).toEqual(0.0 / atlasWidth);
+      expect(greenCoords.y).toEqual(0.0 / atlasHeight);
+      expect(greenCoords.width).toEqual(1.0 / atlasWidth);
+      expect(greenCoords.height).toEqual(1.0 / atlasHeight);
 
-        const greenCoords = atlas.textureCoordinates[greenIndex];
-        expect(greenCoords.x).toEqual(0.0 / atlasWidth);
-        expect(greenCoords.y).toEqual(0.0 / atlasHeight);
-        expect(greenCoords.width).toEqual(1.0 / atlasWidth);
-        expect(greenCoords.height).toEqual(1.0 / atlasHeight);
-
-        const blueCoords = atlas.textureCoordinates[blueIndex];
-        expect(blueCoords.x).toEqual(1.0 / atlasWidth);
-        expect(blueCoords.y).toEqual(0.0 / atlasHeight);
-        expect(blueCoords.width).toEqual(1.0 / atlasWidth);
-        expect(blueCoords.height).toEqual(1.0 / atlasHeight);
-      });
+      const blueCoords = atlas.textureCoordinates[blueIndex];
+      expect(blueCoords.x).toEqual(1.0 / atlasWidth);
+      expect(blueCoords.y).toEqual(0.0 / atlasHeight);
+      expect(blueCoords.width).toEqual(1.0 / atlasWidth);
+      expect(blueCoords.height).toEqual(1.0 / atlasHeight);
     });
 
-    it("renders a two image atlas", function () {
+    it("renders a two image atlas", async function () {
       atlas = new TextureAtlas({
         context: scene.context,
         borderWidthInPixels: 0,
         initialSize: new Cartesian2(2, 2),
       });
 
-      const promises = [];
-      promises.push(atlas.addImage(greenGuid, greenImage));
-      promises.push(atlas.addImage(blueGuid, blueImage));
+      const greenIndex = await atlas.addImage(greenGuid, greenImage);
+      const blueIndex = await atlas.addImage(blueGuid, blueImage);
 
-      return Promise.all(promises, function (indices) {
-        const greenIndex = indices[0];
-        const blueIndex = indices[1];
+      const texture = atlas.texture;
 
-        const texture = atlas.texture;
+      const greenCoords = atlas.textureCoordinates[greenIndex];
+      expectToRender(texture, greenCoords, [0, 255, 0, 255]);
 
-        const greenCoords = atlas.textureCoordinates[greenIndex];
-        expectToRender(texture, greenCoords, [0, 255, 0, 255]);
-
-        const blueCoords = atlas.textureCoordinates[blueIndex];
-        expectToRender(texture, blueCoords, [0, 0, 255, 255]);
-      });
+      const blueCoords = atlas.textureCoordinates[blueIndex];
+      expectToRender(texture, blueCoords, [0, 0, 255, 255]);
     });
 
-    it("renders a four image atlas", function () {
+    it("renders a four image atlas", async function () {
       atlas = new TextureAtlas({
         context: scene.context,
         borderWidthInPixels: 0,
       });
 
-      const promises = [];
-      promises.push(atlas.addImage(greenGuid, greenImage));
-      promises.push(atlas.addImage(blueGuid, blueImage));
-      promises.push(atlas.addImage(bigRedGuid, bigRedImage));
-      promises.push(atlas.addImage(bigBlueGuid, bigBlueImage));
+      const greenIndex = await atlas.addImage(greenGuid, greenImage);
+      const blueIndex = await atlas.addImage(blueGuid, blueImage);
+      const bigRedIndex = await atlas.addImage(bigRedGuid, bigRedImage);
+      const bigBlueIndex = await atlas.addImage(bigBlueGuid, bigBlueImage);
 
-      return Promise.all(promises, function (indices) {
-        const greenIndex = indices.shift();
-        const blueIndex = indices.shift();
-        const bigRedIndex = indices.shift();
-        const bigBlueIndex = indices.shift();
+      expect(atlas.numberOfImages).toEqual(4);
 
-        expect(atlas.numberOfImages).toEqual(4);
+      const texture = atlas.texture;
+      const c0 = atlas.textureCoordinates[greenIndex];
+      const c1 = atlas.textureCoordinates[blueIndex];
+      const c2 = atlas.textureCoordinates[bigRedIndex];
+      const c3 = atlas.textureCoordinates[bigBlueIndex];
 
-        const texture = atlas.texture;
-        const c0 = atlas.textureCoordinates[greenIndex];
-        const c1 = atlas.textureCoordinates[blueIndex];
-        const c2 = atlas.textureCoordinates[bigRedIndex];
-        const c3 = atlas.textureCoordinates[bigBlueIndex];
-
-        expectToRender(texture, c0, [0, 255, 0, 255]);
-        expectToRender(texture, c1, [0, 0, 255, 255]);
-        expectToRender(texture, c2, [255, 0, 0, 255]);
-        expectToRender(texture, c3, [0, 0, 255, 255]);
-      });
+      expectToRender(texture, c0, [0, 255, 0, 255]);
+      expectToRender(texture, c1, [0, 0, 255, 255]);
+      expectToRender(texture, c2, [255, 0, 0, 255]);
+      expectToRender(texture, c3, [0, 0, 255, 255]);
     });
 
-    it("creates a four image atlas with non-zero borderWidthInPixels", function () {
+    it("creates a four image atlas with non-zero borderWidthInPixels", async function () {
       atlas = new TextureAtlas({
         context: scene.context,
         borderWidthInPixels: 2,
       });
 
-      const promises = [];
-      promises.push(atlas.addImage(greenGuid, greenImage));
-      promises.push(atlas.addImage(blueGuid, blueImage));
-      promises.push(atlas.addImage(bigRedGuid, bigRedImage));
-      promises.push(atlas.addImage(bigBlueGuid, bigBlueImage));
+      const greenIndex = await atlas.addImage(greenGuid, greenImage);
+      const blueIndex = await atlas.addImage(blueGuid, blueImage);
+      const bigRedIndex = await atlas.addImage(bigRedGuid, bigRedImage);
+      const bigBlueIndex = await atlas.addImage(bigBlueGuid, bigBlueImage);
 
-      return Promise.all(promises, function (indices) {
-        const greenIndex = indices.shift();
-        const blueIndex = indices.shift();
-        const bigRedIndex = indices.shift();
-        const bigBlueIndex = indices.shift();
+      expect(atlas.borderWidthInPixels).toEqual(2);
+      expect(atlas.numberOfImages).toEqual(4);
 
-        expect(atlas.borderWidthInPixels).toEqual(2);
-        expect(atlas.numberOfImages).toEqual(4);
+      const texture = atlas.texture;
+      const c0 = atlas.textureCoordinates[greenIndex];
+      const c1 = atlas.textureCoordinates[blueIndex];
+      const c2 = atlas.textureCoordinates[bigRedIndex];
+      const c3 = atlas.textureCoordinates[bigBlueIndex];
 
-        const texture = atlas.texture;
-        const c0 = atlas.textureCoordinates[greenIndex];
-        const c1 = atlas.textureCoordinates[blueIndex];
-        const c2 = atlas.textureCoordinates[bigRedIndex];
-        const c3 = atlas.textureCoordinates[bigBlueIndex];
+      const atlasWidth = 68.0;
+      const atlasHeight = 68.0;
+      expect(texture.width).toEqual(atlasWidth);
+      expect(texture.height).toEqual(atlasHeight);
 
-        const atlasWidth = 68.0;
-        const atlasHeight = 68.0;
-        expect(texture.width).toEqual(atlasWidth);
-        expect(texture.height).toEqual(atlasHeight);
+      expect(c0.x).toEqualEpsilon(2.0 / atlasWidth, CesiumMath.EPSILON16);
+      expect(c0.y).toEqualEpsilon(2.0 / atlasHeight, CesiumMath.EPSILON16);
+      expect(c0.width).toEqualEpsilon(
+        greenImage.width / atlasWidth,
+        CesiumMath.EPSILON16
+      );
+      expect(c0.height).toEqualEpsilon(
+        greenImage.height / atlasHeight,
+        CesiumMath.EPSILON16
+      );
 
-        expect(c0.x).toEqualEpsilon(2.0 / atlasWidth, CesiumMath.EPSILON16);
-        expect(c0.y).toEqualEpsilon(2.0 / atlasHeight, CesiumMath.EPSILON16);
-        expect(c0.width).toEqualEpsilon(
-          greenImage.width / atlasWidth,
-          CesiumMath.EPSILON16
-        );
-        expect(c0.height).toEqualEpsilon(
-          greenImage.height / atlasHeight,
-          CesiumMath.EPSILON16
-        );
+      expect(c1.x).toEqualEpsilon(
+        (greenImage.width + 2 * atlas.borderWidthInPixels) / atlasWidth,
+        CesiumMath.EPSILON16
+      );
+      expect(c1.y).toEqualEpsilon(2.0 / atlasHeight, CesiumMath.EPSILON16);
+      expect(c1.width).toEqualEpsilon(
+        blueImage.width / atlasWidth,
+        CesiumMath.EPSILON16
+      );
+      expect(c1.height).toEqualEpsilon(
+        blueImage.width / atlasHeight,
+        CesiumMath.EPSILON16
+      );
 
-        expect(c1.x).toEqualEpsilon(
-          (greenImage.width + 2 * atlas.borderWidthInPixels) / atlasWidth,
-          CesiumMath.EPSILON16
-        );
-        expect(c1.y).toEqualEpsilon(2.0 / atlasHeight, CesiumMath.EPSILON16);
-        expect(c1.width).toEqualEpsilon(
-          blueImage.width / atlasWidth,
-          CesiumMath.EPSILON16
-        );
-        expect(c1.height).toEqualEpsilon(
-          blueImage.width / atlasHeight,
-          CesiumMath.EPSILON16
-        );
+      expect(c2.x).toEqualEpsilon(2.0 / atlasWidth, CesiumMath.EPSILON16);
+      expect(c2.y).toEqualEpsilon(
+        (bigRedImage.height + atlas.borderWidthInPixels) / atlasHeight,
+        CesiumMath.EPSILON16
+      );
+      expect(c2.width).toEqualEpsilon(
+        bigRedImage.width / atlasWidth,
+        CesiumMath.EPSILON16
+      );
+      expect(c2.height).toEqualEpsilon(
+        bigRedImage.height / atlasHeight,
+        CesiumMath.EPSILON16
+      );
 
-        expect(c2.x).toEqualEpsilon(2.0 / atlasWidth, CesiumMath.EPSILON16);
-        expect(c2.y).toEqualEpsilon(
-          (bigRedImage.height + atlas.borderWidthInPixels) / atlasHeight,
-          CesiumMath.EPSILON16
-        );
-        expect(c2.width).toEqualEpsilon(
-          bigRedImage.width / atlasWidth,
-          CesiumMath.EPSILON16
-        );
-        expect(c2.height).toEqualEpsilon(
-          bigRedImage.height / atlasHeight,
-          CesiumMath.EPSILON16
-        );
-
-        expect(c3.x).toEqualEpsilon(2.0 / atlasWidth, CesiumMath.EPSILON16);
-        expect(c3.y).toEqualEpsilon(
-          (greenImage.height + 2 * atlas.borderWidthInPixels) / atlasHeight,
-          CesiumMath.EPSILON16
-        );
-        expect(c3.width).toEqualEpsilon(
-          bigBlueImage.width / atlasWidth,
-          CesiumMath.EPSILON16
-        );
-        expect(c3.height).toEqualEpsilon(
-          bigBlueImage.height / atlasHeight,
-          CesiumMath.EPSILON16
-        );
-      });
+      expect(c3.x).toEqualEpsilon(2.0 / atlasWidth, CesiumMath.EPSILON16);
+      expect(c3.y).toEqualEpsilon(
+        (greenImage.height + 2 * atlas.borderWidthInPixels) / atlasHeight,
+        CesiumMath.EPSILON16
+      );
+      expect(c3.width).toEqualEpsilon(
+        bigBlueImage.width / atlasWidth,
+        CesiumMath.EPSILON16
+      );
+      expect(c3.height).toEqualEpsilon(
+        bigBlueImage.height / atlasHeight,
+        CesiumMath.EPSILON16
+      );
     });
 
-    it("renders a four image atlas with non-zero borderWidthInPixels", function () {
+    it("renders a four image atlas with non-zero borderWidthInPixels", async function () {
       atlas = new TextureAtlas({
         context: scene.context,
         borderWidthInPixels: 2,
       });
 
-      const promises = [];
-      promises.push(atlas.addImage(greenGuid, greenImage));
-      promises.push(atlas.addImage(blueGuid, blueImage));
-      promises.push(atlas.addImage(bigRedGuid, bigRedImage));
-      promises.push(atlas.addImage(bigBlueGuid, bigBlueImage));
+      const greenIndex = await atlas.addImage(greenGuid, greenImage);
+      const blueIndex = await atlas.addImage(blueGuid, blueImage);
+      const bigRedIndex = await atlas.addImage(bigRedGuid, bigRedImage);
+      const bigBlueIndex = await atlas.addImage(bigBlueGuid, bigBlueImage);
 
-      return Promise.all(promises, function (indices) {
-        const greenIndex = indices.shift();
-        const blueIndex = indices.shift();
-        const bigRedIndex = indices.shift();
-        const bigBlueIndex = indices.shift();
+      expect(atlas.numberOfImages).toEqual(4);
 
-        expect(atlas.numberOfImages).toEqual(4);
+      const texture = atlas.texture;
+      const c0 = atlas.textureCoordinates[greenIndex];
+      const c1 = atlas.textureCoordinates[blueIndex];
+      const c2 = atlas.textureCoordinates[bigRedIndex];
+      const c3 = atlas.textureCoordinates[bigBlueIndex];
 
-        const texture = atlas.texture;
-        const c0 = atlas.textureCoordinates[greenIndex];
-        const c1 = atlas.textureCoordinates[blueIndex];
-        const c2 = atlas.textureCoordinates[bigRedIndex];
-        const c3 = atlas.textureCoordinates[bigBlueIndex];
-
-        expectToRender(texture, c0, [0, 255, 0, 255]);
-        expectToRender(texture, c1, [0, 0, 255, 255]);
-        expectToRender(texture, c2, [255, 0, 0, 255]);
-        expectToRender(texture, c3, [0, 0, 255, 255]);
-      });
+      expectToRender(texture, c0, [0, 255, 0, 255]);
+      expectToRender(texture, c1, [0, 0, 255, 255]);
+      expectToRender(texture, c2, [255, 0, 0, 255]);
+      expectToRender(texture, c3, [0, 0, 255, 255]);
     });
 
     it("creates an atlas that dynamically resizes", function () {
@@ -569,69 +532,59 @@ describe(
       });
     });
 
-    it("creates a two image atlas with non-zero borderWidthInPixels that resizes", function () {
+    it("creates a two image atlas with non-zero borderWidthInPixels that resizes", async function () {
       atlas = new TextureAtlas({
         context: scene.context,
         borderWidthInPixels: 2,
         initialSize: new Cartesian2(2, 2),
       });
 
-      const greenPromise = atlas.addImage(greenGuid, greenImage);
-      const bluePromise = atlas.addImage(blueGuid, blueImage);
+      const greenIndex = await atlas.addImage(greenGuid, greenImage);
+      const blueIndex = await atlas.addImage(blueGuid, blueImage);
 
-      return Promise.all([greenPromise, bluePromise], function (indices) {
-        const greenIndex = indices.shift();
-        const blueIndex = indices.shift();
+      const texture = atlas.texture;
+      const coordinates = atlas.textureCoordinates;
 
-        const texture = atlas.texture;
-        const coordinates = atlas.textureCoordinates;
+      const atlasWidth = 10.0;
+      const atlasHeight = 10.0;
+      expect(atlas.borderWidthInPixels).toEqual(2);
+      expect(atlas.numberOfImages).toEqual(2);
+      expect(texture.width).toEqual(atlasWidth);
+      expect(texture.height).toEqual(atlasHeight);
 
-        const atlasWidth = 10.0;
-        const atlasHeight = 10.0;
-        expect(atlas.borderWidthInPixels).toEqual(2);
-        expect(atlas.numberOfImages).toEqual(2);
-        expect(texture.width).toEqual(atlasWidth);
-        expect(texture.height).toEqual(atlasHeight);
+      expect(coordinates[greenIndex].x).toEqual(
+        atlas.borderWidthInPixels / atlasWidth
+      );
+      expect(coordinates[greenIndex].y).toEqual(
+        atlas.borderWidthInPixels / atlasHeight
+      );
+      expect(coordinates[greenIndex].width).toEqual(1.0 / atlasWidth);
+      expect(coordinates[greenIndex].height).toEqual(1.0 / atlasHeight);
 
-        expect(coordinates[greenIndex].x).toEqual(
-          atlas.borderWidthInPixels / atlasWidth
-        );
-        expect(coordinates[greenIndex].y).toEqual(
-          atlas.borderWidthInPixels / atlasHeight
-        );
-        expect(coordinates[greenIndex].width).toEqual(1.0 / atlasWidth);
-        expect(coordinates[greenIndex].height).toEqual(1.0 / atlasHeight);
-
-        expect(coordinates[blueIndex].x).toEqual(5.0 / atlasWidth);
-        expect(coordinates[blueIndex].y).toEqual(2.0 / atlasHeight);
-        expect(coordinates[blueIndex].width).toEqual(1.0 / atlasWidth);
-        expect(coordinates[blueIndex].height).toEqual(1.0 / atlasHeight);
-      });
+      expect(coordinates[blueIndex].x).toEqual(5.0 / atlasWidth);
+      expect(coordinates[blueIndex].y).toEqual(2.0 / atlasHeight);
+      expect(coordinates[blueIndex].width).toEqual(1.0 / atlasWidth);
+      expect(coordinates[blueIndex].height).toEqual(1.0 / atlasHeight);
     });
 
-    it("renders a two image atlas with non-zero borderWidthInPixels that resizes", function () {
+    it("renders a two image atlas with non-zero borderWidthInPixels that resizes", async function () {
       atlas = new TextureAtlas({
         context: scene.context,
         borderWidthInPixels: 2,
         initialSize: new Cartesian2(2, 2),
       });
 
-      const greenPromise = atlas.addImage(greenGuid, greenImage);
-      const bluePromise = atlas.addImage(blueGuid, blueImage);
+      const greenIndex = await atlas.addImage(greenGuid, greenImage);
+      const blueIndex = await atlas.addImage(blueGuid, blueImage);
 
-      return Promise.all([greenPromise, bluePromise], function (indices) {
-        const greenIndex = indices.shift();
-        const blueIndex = indices.shift();
+      const texture = atlas.texture;
+      const coordinates = atlas.textureCoordinates;
 
-        const texture = atlas.texture;
-        const coordinates = atlas.textureCoordinates;
+      const greenCoords = coordinates[greenIndex];
+      const blueCoords = coordinates[blueIndex];
 
-        const greenCoords = coordinates[greenIndex];
-        const blueCoords = coordinates[blueIndex];
-
-        expectToRender(texture, greenCoords, [0, 255, 0, 255]);
-        expectToRender(texture, blueCoords, [0, 0, 255, 255]);
-      });
+      expectToRender(texture, greenCoords, [0, 255, 0, 255]);
+      expectToRender(texture, blueCoords, [0, 0, 255, 255]);
     });
 
     it("creates an atlas with non-square initialSize that resizes", function () {
@@ -682,34 +635,25 @@ describe(
         });
     });
 
-    it("renders an atlas that dynamically resizes twice", function () {
+    it("renders an atlas that dynamically resizes twice", async function () {
       atlas = new TextureAtlas({
         context: scene.context,
         borderWidthInPixels: 0,
         initialSize: new Cartesian2(1, 1),
       });
 
-      const bluePromise = atlas.addImage(blueGuid, blueImage);
-      const bigGreenPromise = atlas.addImage(bigGreenGuid, bigGreenImage);
-      const bigRedPromise = atlas.addImage(bigRedGuid, bigRedImage);
+      const blueIndex = await atlas.addImage(blueGuid, blueImage);
+      const bigGreenIndex = await atlas.addImage(bigGreenGuid, bigGreenImage);
+      const bigRedIndex = await atlas.addImage(bigRedGuid, bigRedImage);
 
-      return Promise.all(
-        [bluePromise, bigGreenPromise, bigRedPromise],
-        function (indices) {
-          const blueIndex = indices.shift();
-          const bigGreenIndex = indices.shift();
-          const bigRedIndex = indices.shift();
+      const texture = atlas.texture;
+      const blueCoordinates = atlas.textureCoordinates[blueIndex];
+      const bigGreenCoordinates = atlas.textureCoordinates[bigGreenIndex];
+      const bigRedCoordinates = atlas.textureCoordinates[bigRedIndex];
 
-          const texture = atlas.texture;
-          const blueCoordinates = atlas.textureCoordinates[blueIndex];
-          const bigGreenCoordinates = atlas.textureCoordinates[bigGreenIndex];
-          const bigRedCoordinates = atlas.textureCoordinates[bigRedIndex];
-
-          expectToRender(texture, blueCoordinates, [0, 0, 255, 255]);
-          expectToRender(texture, bigGreenCoordinates, [0, 255, 0, 255]);
-          expectToRender(texture, bigRedCoordinates, [255, 0, 0, 255]);
-        }
-      );
+      expectToRender(texture, blueCoordinates, [0, 0, 255, 255]);
+      expectToRender(texture, bigGreenCoordinates, [0, 255, 0, 255]);
+      expectToRender(texture, bigRedCoordinates, [255, 0, 0, 255]);
     });
 
     it("promise resolves to index after calling addImage with Image", function () {
@@ -745,142 +689,123 @@ describe(
       });
     });
 
-    it("creates an atlas with subregions", function () {
+    it("creates an atlas with subregions", async function () {
       atlas = new TextureAtlas({
         context: scene.context,
         borderWidthInPixels: 0,
         initialSize: new Cartesian2(1, 1),
       });
 
-      atlas.addImage(greenGuid, greenImage);
+      await atlas.addImage(greenGuid, greenImage);
 
-      const promise1 = atlas.addSubRegion(
+      const index1 = await atlas.addSubRegion(
         greenGuid,
         new BoundingRectangle(0.0, 0.0, 0.5, 0.5)
       );
-      const promise2 = atlas.addSubRegion(
+      const index2 = await atlas.addSubRegion(
         greenGuid,
         new BoundingRectangle(0.0, 0.5, 0.5, 0.5)
       );
-      const promise3 = atlas.addSubRegion(
+      const index3 = await atlas.addSubRegion(
         greenGuid,
         new BoundingRectangle(0.5, 0.0, 0.5, 0.5)
       );
-      const promise4 = atlas.addSubRegion(
+      const index4 = await atlas.addSubRegion(
         greenGuid,
         new BoundingRectangle(0.5, 0.5, 0.5, 0.5)
       );
 
-      return Promise.all([promise1, promise2, promise3, promise4], function (
-        indices
-      ) {
-        const index1 = indices.shift();
-        const index2 = indices.shift();
-        const index3 = indices.shift();
-        const index4 = indices.shift();
+      expect(atlas.numberOfImages).toEqual(5);
 
-        expect(atlas.numberOfImages).toEqual(5);
+      const coordinates = atlas.textureCoordinates;
+      const atlasWidth = 2.0;
+      const atlasHeight = 2.0;
 
-        const coordinates = atlas.textureCoordinates;
-        const atlasWidth = 2.0;
-        const atlasHeight = 2.0;
+      expect(coordinates[index1].x).toEqual(0.0 / atlasWidth);
+      expect(coordinates[index1].y).toEqual(0.0 / atlasHeight);
+      expect(coordinates[index1].width).toEqual(0.5 / atlasWidth);
+      expect(coordinates[index1].height).toEqual(0.5 / atlasHeight);
 
-        expect(coordinates[index1].x).toEqual(0.0 / atlasWidth);
-        expect(coordinates[index1].y).toEqual(0.0 / atlasHeight);
-        expect(coordinates[index1].width).toEqual(0.5 / atlasWidth);
-        expect(coordinates[index1].height).toEqual(0.5 / atlasHeight);
+      expect(coordinates[index2].x).toEqual(0.0 / atlasWidth);
+      expect(coordinates[index2].y).toEqual(0.5 / atlasHeight);
+      expect(coordinates[index2].width).toEqual(0.5 / atlasWidth);
+      expect(coordinates[index2].height).toEqual(0.5 / atlasHeight);
 
-        expect(coordinates[index2].x).toEqual(0.0 / atlasWidth);
-        expect(coordinates[index2].y).toEqual(0.5 / atlasHeight);
-        expect(coordinates[index2].width).toEqual(0.5 / atlasWidth);
-        expect(coordinates[index2].height).toEqual(0.5 / atlasHeight);
+      expect(coordinates[index3].x).toEqual(0.5 / atlasWidth);
+      expect(coordinates[index3].y).toEqual(0.0 / atlasHeight);
+      expect(coordinates[index3].width).toEqual(0.5 / atlasWidth);
+      expect(coordinates[index3].height).toEqual(0.5 / atlasHeight);
 
-        expect(coordinates[index3].x).toEqual(0.5 / atlasWidth);
-        expect(coordinates[index3].y).toEqual(0.0 / atlasHeight);
-        expect(coordinates[index3].width).toEqual(0.5 / atlasWidth);
-        expect(coordinates[index3].height).toEqual(0.5 / atlasHeight);
+      expect(coordinates[index4].x).toEqual(0.5 / atlasWidth);
+      expect(coordinates[index4].y).toEqual(0.5 / atlasHeight);
+      expect(coordinates[index4].width).toEqual(0.5 / atlasWidth);
+      expect(coordinates[index4].height).toEqual(0.5 / atlasHeight);
 
-        expect(coordinates[index4].x).toEqual(0.5 / atlasWidth);
-        expect(coordinates[index4].y).toEqual(0.5 / atlasHeight);
-        expect(coordinates[index4].width).toEqual(0.5 / atlasWidth);
-        expect(coordinates[index4].height).toEqual(0.5 / atlasHeight);
-
-        expect(atlas._indexHash[greenGuid]).toEqual(3);
-      });
+      expect(atlas.getImageIndex(greenGuid)).toEqual(index4);
     });
 
-    it("creates an atlas that resizes with subregions", function () {
+    it("creates an atlas that resizes with subregions", async function () {
       atlas = new TextureAtlas({
         context: scene.context,
         borderWidthInPixels: 0,
         initialSize: new Cartesian2(1, 1),
       });
 
-      atlas.addImage(greenGuid, greenImage);
+      await atlas.addImage(greenGuid, greenImage);
 
-      const promise1 = atlas.addSubRegion(
+      const index1 = await atlas.addSubRegion(
         greenGuid,
         new BoundingRectangle(0.0, 0.0, 0.5, 0.5)
       );
-      const promise2 = atlas.addSubRegion(
+      const index2 = await atlas.addSubRegion(
         greenGuid,
         new BoundingRectangle(0.0, 0.5, 0.5, 0.5)
       );
-      const promise3 = atlas.addSubRegion(
+      const index3 = await atlas.addSubRegion(
         greenGuid,
         new BoundingRectangle(0.5, 0.0, 0.5, 0.5)
       );
-      const promise4 = atlas.addSubRegion(
+      const index4 = await atlas.addSubRegion(
         greenGuid,
         new BoundingRectangle(0.5, 0.5, 0.5, 0.5)
       );
 
-      return Promise.all([promise1, promise2, promise3, promise4], function (
-        indices
-      ) {
-        const index1 = indices.shift();
-        const index2 = indices.shift();
-        const index3 = indices.shift();
-        const index4 = indices.shift();
+      expect(atlas.numberOfImages).toEqual(5);
 
-        expect(atlas.numberOfImages).toEqual(5);
+      const blueIndex = await atlas.addImage(blueGuid, blueImage);
+      expect(atlas.numberOfImages).toEqual(6);
 
-        return atlas.addImage(blueGuid, blueImage).then(function (blueIndex) {
-          expect(atlas.numberOfImages).toEqual(6);
+      const coordinates = atlas.textureCoordinates;
+      const atlasWidth = 2.0;
+      const atlasHeight = 2.0;
 
-          const coordinates = atlas.textureCoordinates;
-          const atlasWidth = 2.0;
-          const atlasHeight = 2.0;
+      expect(coordinates[index1].x).toEqual(0.0 / atlasWidth);
+      expect(coordinates[index1].y).toEqual(0.0 / atlasHeight);
+      expect(coordinates[index1].width).toEqual(0.5 / atlasWidth);
+      expect(coordinates[index1].height).toEqual(0.5 / atlasHeight);
 
-          expect(coordinates[index1].x).toEqual(0.0 / atlasWidth);
-          expect(coordinates[index1].y).toEqual(0.0 / atlasHeight);
-          expect(coordinates[index1].width).toEqual(0.5 / atlasWidth);
-          expect(coordinates[index1].height).toEqual(0.5 / atlasHeight);
+      expect(coordinates[index2].x).toEqual(0.0 / atlasWidth);
+      expect(coordinates[index2].y).toEqual(0.5 / atlasHeight);
+      expect(coordinates[index2].width).toEqual(0.5 / atlasWidth);
+      expect(coordinates[index2].height).toEqual(0.5 / atlasHeight);
 
-          expect(coordinates[index2].x).toEqual(0.0 / atlasWidth);
-          expect(coordinates[index2].y).toEqual(0.5 / atlasHeight);
-          expect(coordinates[index2].width).toEqual(0.5 / atlasWidth);
-          expect(coordinates[index2].height).toEqual(0.5 / atlasHeight);
+      expect(coordinates[index3].x).toEqual(0.5 / atlasWidth);
+      expect(coordinates[index3].y).toEqual(0.0 / atlasHeight);
+      expect(coordinates[index3].width).toEqual(0.5 / atlasWidth);
+      expect(coordinates[index3].height).toEqual(0.5 / atlasHeight);
 
-          expect(coordinates[index3].x).toEqual(0.5 / atlasWidth);
-          expect(coordinates[index3].y).toEqual(0.0 / atlasHeight);
-          expect(coordinates[index3].width).toEqual(0.5 / atlasWidth);
-          expect(coordinates[index3].height).toEqual(0.5 / atlasHeight);
+      expect(coordinates[index4].x).toEqual(0.5 / atlasWidth);
+      expect(coordinates[index4].y).toEqual(0.5 / atlasHeight);
+      expect(coordinates[index4].width).toEqual(0.5 / atlasWidth);
+      expect(coordinates[index4].height).toEqual(0.5 / atlasHeight);
 
-          expect(coordinates[index4].x).toEqual(0.5 / atlasWidth);
-          expect(coordinates[index4].y).toEqual(0.5 / atlasHeight);
-          expect(coordinates[index4].width).toEqual(0.5 / atlasWidth);
-          expect(coordinates[index4].height).toEqual(0.5 / atlasHeight);
-
-          expect(coordinates[blueIndex].x).toEqual(1.0 / atlasWidth);
-          expect(coordinates[blueIndex].y).toEqual(0.0 / atlasHeight);
-          expect(coordinates[blueIndex].width).toEqual(1.0 / atlasWidth);
-          expect(coordinates[blueIndex].height).toEqual(1.0 / atlasHeight);
-        });
-      });
+      expect(coordinates[blueIndex].x).toEqual(1.0 / atlasWidth);
+      expect(coordinates[blueIndex].y).toEqual(0.0 / atlasHeight);
+      expect(coordinates[blueIndex].width).toEqual(1.0 / atlasWidth);
+      expect(coordinates[blueIndex].height).toEqual(1.0 / atlasHeight);
     });
 
-    it("creates a two image atlas using a url and a function", function () {
+    it("creates a two image atlas using a url and a function", async function () {
       atlas = new TextureAtlas({
         context: scene.context,
         pixelFormat: PixelFormat.RGBA,
@@ -888,37 +813,22 @@ describe(
       });
 
       const greenUrl = "./Data/Images/Green.png";
-      const greenPromise = atlas.addImage(greenUrl, greenUrl);
+      const greenIndex = await atlas.addImage(greenUrl, greenUrl);
+      const blueIndex = await atlas.addImage("Blue Image", blueImage);
 
-      const bluePromise = atlas.addImage("Blue Image", function (id) {
-        expect(id).toEqual("Blue Image");
-        return blueImage;
-      });
+      expect(atlas.numberOfImages).toEqual(2);
 
-      return Promise.all([greenPromise, bluePromise], function (results) {
-        const greenIndex = results[0];
-        const blueIndex = results[1];
+      const texture = atlas.texture;
+      const coordinates = atlas.textureCoordinates;
+      const blueCoordinates = coordinates[blueIndex];
+      const greenCoordinates = coordinates[greenIndex];
 
-        expect(atlas.numberOfImages).toEqual(2);
+      expectToRender(texture, blueCoordinates, [0, 0, 255, 255]);
+      expectToRender(texture, greenCoordinates, [0, 255, 0, 255]);
 
-        const texture = atlas.texture;
-        const coordinates = atlas.textureCoordinates;
-        const blueCoordinates = coordinates[blueIndex];
-        const greenCoordinates = coordinates[greenIndex];
-
-        expectToRender(texture, blueCoordinates, [0, 0, 255, 255]);
-        expectToRender(texture, greenCoordinates, [0, 255, 0, 255]);
-
-        // after loading 'Blue Image', further adds should not call the function
-
-        return atlas
-          .addImage("Blue Image", function (id) {
-            throw "should not get here";
-          })
-          .then(function (index) {
-            expect(index).toEqual(blueIndex);
-          });
-      });
+      // after loading 'Blue Image', further adds should not add new indices
+      const index = await atlas.addImage("Blue Image", blueImage);
+      expect(index).toEqual(blueIndex);
     });
 
     it("GUID changes when atlas is modified", function () {


### PR DESCRIPTION
Fixes #10461

This adds a new boolean parameter `updateImageIndex` to `TextureAtlas.prototype.addSubRegion()` which is `false` by default. If it is true, the `_indexHash` value for the given image id is updated to point to the index of the new sub region. Otherwise the index will still point to the region of the whole image (same behavior as currently).

This is needed because billboards create such a subregion, but wouldn't currently use this subregion in later calls to `_loadImage` which results in the problems described in the issue.

I am not really sure if my solution is good, because I am no expert on this topic. There are some open questions:
1. Does this has any side effects, that I overlooked?
2. Should the index be updated always (without the need for the `updateImageIndex` parameter)?
3. Should there be a way to still access the previous region? Maybe two arrays are needed, a `_indexHash` and a `_subRegionIndexHash`?
4. `addSubRegion` isn't used anywhere else (only by `_loadImage()` of `Billboard.js`). Should this be refactored in general somehow?

I didn't add/update any tests yet, because of those questions.

Longer description of what I think is the problem of the current code that is fixed by this PR:
An `imageSubRegion` for the billboard backgrounds is added to the texture atlas on the first load of a billboard.
Later calls will not add anything to the texture atlas, but will request the correct image by relying on the texture atlas' `_indexHash`.  
In these later calls the index is retrieved from the texture atlas and then directly passed to `completeImageLoad()`.
This function then uses this index to get the correct texture coordinates from the texture atlas. The problem is, that the image sub region is not taken into account anymore at this point.
The initial call, that added the sub region, is getting the index by calling `TextureAtlas.addSubRegion()` which returns a promise that resolves to the index. This is the index of the created subregion.
However, later calls will receive the index of the whole image, because the `_indexHash` will still point to the index of the image and not its sub region. That's why the background looks different then.