### PR TITLE
WebGL2 by default CHANGES update and feature detection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
 
 - CesiumJS now defaults to using a WebGL2 context for rendering. WebGL2 is widely supported on all platforms and this results in better feature support across devices, especially mobile.
   - WebGL1 is supported. If WebGL2 is not available, CesiumJS will automatically fall back to WebGL1.
-  - In order to work in a WebGL2 context, any custom materials, custom primitive or custom shaders will need to be upgraded to use GLSL 300.
+  - In order to work in a WebGL2 context, any custom materials, custom primitives or custom shaders will need to be upgraded to use GLSL 300.
   - Otherwise to request a WebGL 1 context, set `requestWebgl1` to `true` when providing `ContextOptions` as shown below:
     ```js
     const viewer = new Viewer("cesiumContainer", {

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,24 @@
 
 #### @cesium/engine
 
+#### Major Announcements :loudspeaker:
+
+- CesiumJS now defaults to using a WebGL2 context for rendering. WebGL2 is widely supported on all platforms and this results in better feature support across devices, especially mobile.
+  - WebGL1 is supported. If WebGL2 is not available, CesiumJS will automatically fall back to WebGL1.
+  - In order to work in a WebGL2 context, any custom materials, custom primitive or custom shaders will need to be upgraded to use GLSL 300.
+  - Otherwise to request a WebGL 1 context, set `requestWebgl1` to `true` when providing `ContextOptions` as shown below:
+    ```js
+    const viewer = new Viewer("cesiumContainer", {
+      contextOptions: {
+        requestWebgl1: true,
+      },
+    });
+    ```
+
+##### Additions :tada:
+
+- Added `FeatureDetection.supportsWebgl2` to detect if a WebGL2 rendering context in the current browser.
+
 ##### Fixes :wrench:
 
 - Fixed a bug decoding glTF Draco attributes with quantization bits above 16. [#7471](https://github.com/CesiumGS/cesium/issues/7471)

--- a/packages/engine/Source/Core/FeatureDetection.js
+++ b/packages/engine/Source/Core/FeatureDetection.js
@@ -1,3 +1,4 @@
+import Check from "./Check.js";
 import defaultValue from "./defaultValue.js";
 import defined from "./defined.js";
 import DeveloperError from "./DeveloperError.js";
@@ -418,6 +419,10 @@ FeatureDetection.supportsWebAssembly = function () {
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext|WebGL2RenderingContext}
  */
 FeatureDetection.supportsWebgl2 = function (scene) {
+  //>>includeStart('debug', pragmas.debug);
+  Check.defined("scene", scene);
+  //>>includeEnd('debug');
+
   return scene.context.webgl2;
 };
 

--- a/packages/engine/Source/Core/FeatureDetection.js
+++ b/packages/engine/Source/Core/FeatureDetection.js
@@ -408,4 +408,17 @@ FeatureDetection.supportsWebWorkers = function () {
 FeatureDetection.supportsWebAssembly = function () {
   return typeof WebAssembly !== "undefined";
 };
+
+/**
+ * Detects whether the current browser supports a WebGL2 rendering context for the specified scene.
+ *
+ * @param {Scene} scene the Cesium scene specifying the rendering context
+ * @returns {Boolean} true if the browser supports a WebGL2 rendering context, false if not.
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext|WebGL2RenderingContext}
+ */
+FeatureDetection.supportsWebgl2 = function (scene) {
+  return scene.context.webgl2;
+};
+
 export default FeatureDetection;

--- a/packages/engine/Specs/Core/FeatureDetectionSpec.js
+++ b/packages/engine/Specs/Core/FeatureDetectionSpec.js
@@ -1,4 +1,5 @@
 import { FeatureDetection } from "../../index.js";
+import createScene from "../../../../Specs/createScene.js";
 
 describe("Core/FeatureDetection", function () {
   //generally, these tests just make sure the function runs, the test can't expect a value of true or false
@@ -157,5 +158,13 @@ describe("Core/FeatureDetection", function () {
         expect(typeof supportsWebP).toEqual("boolean");
         expect(FeatureDetection.supportsWebP()).toEqual(supportsWebP);
       });
+  });
+
+  it("detects WebGL2 support", function () {
+    const scene = createScene();
+    expect(FeatureDetection.supportsWebgl2(scene)).toEqual(
+      scene.context.webgl2
+    );
+    scene.destroyForSpecs();
   });
 });


### PR DESCRIPTION
https://github.com/CesiumGS/cesium/pull/10894 is merged! This adds an item to `CHANGES.md` with details about the change.

I also added a method to `FeatureDetection` so users can easily check if a system supports WebGL2 so they can manage warning the user or falling back for any custom shaders, materials, or primitives, if any.