### PR TITLE
Optimum step size for box-shaped voxels

### DIFF
--- a/packages/engine/Source/Scene/VoxelRenderResources.js
+++ b/packages/engine/Source/Scene/VoxelRenderResources.js
@@ -88,6 +88,8 @@ function VoxelRenderResources(primitive) {
     customShader.fragmentShaderText,
     "#line 0",
     IntersectionUtils,
+    Octree,
+    Megatexture,
   ]);
 
   if (clippingPlanesLength > 0) {
@@ -121,10 +123,11 @@ function VoxelRenderResources(primitive) {
 
   const shapeType = primitive._provider.shape;
   if (shapeType === "BOX") {
+    shaderBuilder.addDefine("SHAPE_BOX", undefined, ShaderDestination.FRAGMENT);
     shaderBuilder.addFragmentLines([
+      convertUvToBox,
       IntersectBox,
       Intersection,
-      convertUvToBox,
     ]);
   } else if (shapeType === "CYLINDER") {
     shaderBuilder.addFragmentLines([
@@ -140,7 +143,7 @@ function VoxelRenderResources(primitive) {
     ]);
   }
 
-  shaderBuilder.addFragmentLines([Octree, Megatexture, VoxelFS]);
+  shaderBuilder.addFragmentLines([VoxelFS]);
 
   const shape = primitive._shape;
   const shapeDefines = shape.shaderDefines;

--- a/packages/engine/Source/Shaders/Voxels/IntersectBox.glsl
+++ b/packages/engine/Source/Shaders/Voxels/IntersectBox.glsl
@@ -46,9 +46,8 @@ vec2 intersectBox(in Ray ray, in Box box, in vec2 entryExit)
 {
     // Consider the box as the intersection of the space between 3 pairs of parallel planes
     // Compute the distance along the ray to each plane
-    vec3 dInv = 1.0 / ray.dir; // TODO: Input this
-    vec3 t0 = (box.p0 - ray.pos) * dInv;
-    vec3 t1 = (box.p1 - ray.pos) * dInv;
+    vec3 t0 = (box.p0 - ray.pos) * ray.dInv;
+    vec3 t1 = (box.p1 - ray.pos) * ray.dInv;
 
     // Identify candidate entries/exits based on distance from ray.pos
     vec3 entries = max(min(t0, t1), entryExit.x);
@@ -65,9 +64,9 @@ vec2 intersectBox(in Ray ray, in Box box, in vec2 entryExit)
     return vec2(entry, exit);
 }
 
-vec2 intersectUnitCube(Ray ray) // Unit cube from [-1, +1]
+vec2 intersectUnitCube(in Ray ray) // Unit cube from [-1, +1]
 {
-    vec3 dInv = 1.0 / ray.dir; // TODO: input this
+    vec3 dInv = 1.0 / ray.dir;
     vec3 od = -ray.pos * dInv;
     vec3 t0 = od - dInv;
     vec3 t1 = od + dInv;
@@ -83,7 +82,7 @@ vec2 intersectUnitCube(Ray ray) // Unit cube from [-1, +1]
     return vec2(tMin, tMax);
 }
 
-vec2 intersectUnitSquare(Ray ray) // Unit square from [-1, +1]
+vec2 intersectUnitSquare(in Ray ray) // Unit square from [-1, +1]
 {
     vec3 o = ray.pos;
     vec3 d = ray.dir;
@@ -97,7 +96,7 @@ vec2 intersectUnitSquare(Ray ray) // Unit square from [-1, +1]
     return vec2(t, t);
 }
 
-void intersectShape(Ray ray, inout Intersections ix)
+void intersectShape(in Ray ray, inout Intersections ix)
 {
     #if defined(BOX_HAS_RENDER_BOUNDS)
         #if defined(BOX_IS_2D)

--- a/packages/engine/Source/Shaders/Voxels/IntersectClippingPlanes.glsl
+++ b/packages/engine/Source/Shaders/Voxels/IntersectClippingPlanes.glsl
@@ -11,7 +11,7 @@ uniform sampler2D u_clippingPlanesTexture;
 uniform mat4 u_clippingPlanesMatrix;
 
 // Plane is in Hessian Normal Form
-vec2 intersectPlane(Ray ray, vec4 plane) {
+vec2 intersectPlane(in Ray ray, in vec4 plane) {
     vec3 o = ray.pos;
     vec3 d = ray.dir;
     vec3 n = plane.xyz; // normal
@@ -28,7 +28,7 @@ vec2 intersectPlane(Ray ray, vec4 plane) {
     }
 }
 
-void intersectClippingPlanes(Ray ray, inout Intersections ix) {
+void intersectClippingPlanes(in Ray ray, inout Intersections ix) {
     #if (CLIPPING_PLANES_COUNT == 1)
         // Union and intersection are the same when there's one clipping plane, and the code
         // is more simplified.

--- a/packages/engine/Source/Shaders/Voxels/IntersectDepth.glsl
+++ b/packages/engine/Source/Shaders/Voxels/IntersectDepth.glsl
@@ -7,7 +7,7 @@
 
 uniform mat4 u_transformPositionViewToUv;
 
-void intersectDepth(vec2 screenCoord, Ray ray, inout Intersections ix) {
+void intersectDepth(in vec2 screenCoord, in Ray ray, inout Intersections ix) {
     float logDepthOrDepth = czm_unpackDepth(texture(czm_globeDepthTexture, screenCoord));
     if (logDepthOrDepth != 0.0) {
         // Calculate how far the ray must travel before it hits the depth buffer.

--- a/packages/engine/Source/Shaders/Voxels/Intersection.glsl
+++ b/packages/engine/Source/Shaders/Voxels/Intersection.glsl
@@ -11,9 +11,7 @@
 #define INTERSECTION_COUNT ###
 */
 
-vec2 intersectScene(vec2 screenCoord, vec3 positionUv, vec3 directionUv, out Intersections ix) {
-    Ray ray = Ray(positionUv, directionUv);
-
+vec2 intersectScene(in vec2 screenCoord, in Ray ray, out Intersections ix) {
     // Do a ray-shape intersection to find the exact starting and ending points.
     intersectShape(ray, ix);
 

--- a/packages/engine/Source/Shaders/Voxels/IntersectionUtils.glsl
+++ b/packages/engine/Source/Shaders/Voxels/IntersectionUtils.glsl
@@ -8,6 +8,9 @@
 struct Ray {
     vec3 pos;
     vec3 dir;
+#if defined(SHAPE_BOX)
+    vec3 dInv;
+#endif
 };
 
 struct Intersections {

--- a/packages/engine/Source/Shaders/Voxels/VoxelFS.glsl
+++ b/packages/engine/Source/Shaders/Voxels/VoxelFS.glsl
@@ -62,7 +62,7 @@ void main()
         discard;
     }
 
-    float currT = entryExitT.x + 0.00001;
+    float currT = entryExitT.x + 0.0001;
     float endT = entryExitT.y;
     vec3 positionUv = viewPosUv + currT * viewDirUv;
     // TODO: is it possible for this to be out of bounds, and does it matter?

--- a/packages/engine/Source/Shaders/Voxels/VoxelFS.glsl
+++ b/packages/engine/Source/Shaders/Voxels/VoxelFS.glsl
@@ -28,13 +28,13 @@ float hash(vec2 p)
 }
 #endif
 
-float getStepSize(in ivec4 octreeCoords, in vec3 tileUv, in Ray viewRay, in vec2 entryExit) {
+float getStepSize(in SampleData sampleData, in Ray viewRay, in vec2 entryExit) {
 #if defined(SHAPE_BOX)
-    Box voxelBox = constructVoxelBox(octreeCoords, tileUv);
+    Box voxelBox = constructVoxelBox(sampleData.tileCoords, sampleData.tileUv);
     vec2 voxelIntersection = intersectBox(viewRay, voxelBox, entryExit);
     return (voxelIntersection.y - voxelIntersection.x);
 #else
-    float dimAtLevel = pow(2.0, float(octreeCoords.w));
+    float dimAtLevel = pow(2.0, float(sampleData.tileCoords.w));
     return u_stepSize / dimAtLevel;
 #endif
 }
@@ -67,7 +67,7 @@ void main()
     TraversalData traversalData;
     SampleData sampleDatas[SAMPLE_COUNT];
     traverseOctreeFromBeginning(positionUvShapeSpace, traversalData, sampleDatas);
-    float stepT = getStepSize(traversalData.octreeCoords, sampleDatas[0].tileUv, viewRayUv, entryExitT);
+    float stepT = getStepSize(sampleDatas[0], viewRayUv, entryExitT);
 
     // TODO:
     //  - jitter doesn't affect the first traversal?
@@ -149,9 +149,9 @@ void main()
         // Traverse the tree from the current ray position.
         // This is similar to traverseOctree but is faster when the ray is in the same tile as the previous step.
         positionUvShapeSpace = convertUvToShapeUvSpace(positionUv);
-        //traverseOctreeFromExisting(positionUvShapeSpace, traversalData, sampleDatas);
-        traverseOctreeFromBeginning(positionUvShapeSpace, traversalData, sampleDatas);
-        stepT = getStepSize(traversalData.octreeCoords, sampleDatas[0].tileUv, viewRayUv, entryExitT);
+        traverseOctreeFromExisting(positionUvShapeSpace, traversalData, sampleDatas);
+        //traverseOctreeFromBeginning(positionUvShapeSpace, traversalData, sampleDatas);
+        stepT = getStepSize(sampleDatas[0], viewRayUv, entryExitT);
     }
 
     // Convert the alpha from [0,ALPHA_ACCUM_MAX] to [0,1]

--- a/packages/engine/Source/Shaders/Voxels/VoxelFS.glsl
+++ b/packages/engine/Source/Shaders/Voxels/VoxelFS.glsl
@@ -47,7 +47,12 @@ void main()
     vec3 viewDirWorld = normalize(czm_inverseViewRotation * eyeDirection); // normalize again just in case
     vec3 viewDirUv = normalize(u_transformDirectionViewToLocal * eyeDirection); // normalize again just in case
     vec3 viewPosUv = u_cameraPositionUv;
-    Ray viewRayUv = Ray(viewPosUv, viewDirUv);
+    #if defined(SHAPE_BOX)
+        vec3 dInv = 1.0 / viewDirUv;
+        Ray viewRayUv = Ray(viewPosUv, viewDirUv, dInv);
+    #else
+        Ray viewRayUv = Ray(viewPosUv, viewDirUv);
+    #endif
 
     Intersections ix;
     vec2 entryExitT = intersectScene(screenCoord, viewRayUv, ix);
@@ -147,10 +152,9 @@ void main()
         }
 
         // Traverse the tree from the current ray position.
-        // This is similar to traverseOctree but is faster when the ray is in the same tile as the previous step.
+        // This is similar to traverseOctreeFromBeginning but is faster when the ray is in the same tile as the previous step.
         positionUvShapeSpace = convertUvToShapeUvSpace(positionUv);
         traverseOctreeFromExisting(positionUvShapeSpace, traversalData, sampleDatas);
-        //traverseOctreeFromBeginning(positionUvShapeSpace, traversalData, sampleDatas);
         stepT = getStepSize(sampleDatas[0], viewRayUv, entryExitT);
     }
 

--- a/packages/engine/Source/Shaders/Voxels/convertUvToBox.glsl
+++ b/packages/engine/Source/Shaders/Voxels/convertUvToBox.glsl
@@ -8,9 +8,17 @@
 #endif
 
 vec3 convertUvToShapeUvSpace(in vec3 positionUv) {
-    #if defined(BOX_HAS_SHAPE_BOUNDS)
-        return positionUv * u_boxUvToShapeUvScale + u_boxUvToShapeUvTranslate;
-    #else
-        return positionUv;
-    #endif
+#if defined(BOX_HAS_SHAPE_BOUNDS)
+    return positionUv * u_boxUvToShapeUvScale + u_boxUvToShapeUvTranslate;
+#else
+    return positionUv;
+#endif
+}
+
+vec3 convertShapeUvToUvSpace(in vec3 shapeUv) {
+#if defined(BOX_HAS_SHAPE_BOUNDS)
+    return (shapeUv - u_boxUvToShapeUvTranslate) / u_boxUvToShapeUvScale;
+#else
+    return shapeUv;
+#endif
 }


### PR DESCRIPTION
This PR implements an optimum step size for voxel raymarching, based on ray-shape intersections at each step. Partially addresses #11020, for box-shaped voxels only.

Raymarching with a constant step size will sometimes miss the edge of a voxel, leading to a fuzzy or heavily aliased appearance at voxel boundaries. Smaller constant steps can improve the image, but are less performant.

This PR computes a ray-shape intersection at each step, and advances the ray to the boundary of the next voxel. The resulting image is sharper, while still reasonably performant. Here are some performance numbers from my machine, with a large dataset rendered full-screen:

| Branch | Step size | Frame rate |
| --- | --- | --- |
| `main` | 1.0 | 25 FPS |
| `main` | 0.37 | 16 FPS |
| `voxel-resolution` | (optimal) | 22 FPS |
