### PR TITLE
Use top level await in Sandcastle

### DIFF
--- a/Apps/Sandcastle/Sandcastle-helpers.js
+++ b/Apps/Sandcastle/Sandcastle-helpers.js
@@ -4,7 +4,7 @@
   window.embedInSandcastleTemplate = function (code, addExtraLine) {
     return (
       `${
-        "window.startup = function (Cesium) {\n" +
+        "window.startup = async function (Cesium) {\n" +
         "    'use strict';\n" +
         "//Sandcastle_Begin\n"
       }${addExtraLine ? "\n" : ""}${code}//Sandcastle_End\n` +
@@ -12,7 +12,9 @@
       `};\n` +
       `if (typeof Cesium !== 'undefined') {\n` +
       `    window.startupCalled = true;\n` +
-      `    window.startup(Cesium);\n` +
+      `     window.startup(Cesium).catch((error) => {\n` +
+      `      console.error(error);\n` +
+      `    });\n` +
       `}\n`
     );
   };

--- a/Apps/Sandcastle/gallery/3D Models Coloring.html
+++ b/Apps/Sandcastle/gallery/3D Models Coloring.html
@@ -133,7 +133,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -322,11 +322,14 @@
         });
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Models.html
+++ b/Apps/Sandcastle/gallery/3D Models.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -169,11 +169,14 @@
 
         Sandcastle.addToolbarMenu(options);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Adjust Height.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Adjust Height.html
@@ -53,7 +53,7 @@
       <input type="text" size="5" data-bind="value: height" />
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -121,11 +121,14 @@
           });
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles BIM.html
+++ b/Apps/Sandcastle/gallery/3D Tiles BIM.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Power Plant design model provided by Bentley Systems
@@ -217,11 +217,14 @@
           processTileFeatures(tile, unloadFeature);
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Batch Table Hierarchy.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Batch Table Hierarchy.html
@@ -36,7 +36,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
 
@@ -212,11 +212,14 @@
           feature.show = false;
         }, Cesium.ScreenSpaceEventType.MIDDLE_CLICK);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
@@ -62,7 +62,7 @@
     </div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Add a clipping plane, a plane geometry to show the representation of the
@@ -343,11 +343,14 @@
         }
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Compare.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Compare.html
@@ -49,7 +49,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -106,11 +106,14 @@
           moveActive = false;
         }, Cesium.ScreenSpaceEventType.PINCH_END);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
@@ -30,286 +30,287 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          // A simple demo of 3D Tiles feature picking with hover and select behavior
-          // Building data courtesy of NYC OpenData portal: http://www1.nyc.gov/site/doitt/initiatives/3d-building.page
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
+        // A simple demo of 3D Tiles feature picking with hover and select behavior
+        // Building data courtesy of NYC OpenData portal: http://www1.nyc.gov/site/doitt/initiatives/3d-building.page
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
 
-          viewer.scene.globe.depthTestAgainstTerrain = true;
+        viewer.scene.globe.depthTestAgainstTerrain = true;
 
-          // Set the initial camera view to look at Manhattan
-          const initialPosition = Cesium.Cartesian3.fromDegrees(
-            -74.01881302800248,
-            40.69114333714821,
-            753
+        // Set the initial camera view to look at Manhattan
+        const initialPosition = Cesium.Cartesian3.fromDegrees(
+          -74.01881302800248,
+          40.69114333714821,
+          753
+        );
+        const initialOrientation = new Cesium.HeadingPitchRoll.fromDegrees(
+          21.27879878293835,
+          -21.34390550872461,
+          0.0716951918898415
+        );
+        viewer.scene.camera.setView({
+          destination: initialPosition,
+          orientation: initialOrientation,
+          endTransform: Cesium.Matrix4.IDENTITY,
+        });
+
+        // Load the NYC buildings tileset
+        const tileset = new Cesium.Cesium3DTileset({
+          url: Cesium.IonResource.fromAssetId(75343),
+        });
+        viewer.scene.primitives.add(tileset);
+
+        // HTML overlay for showing feature name on mouseover
+        const nameOverlay = document.createElement("div");
+        viewer.container.appendChild(nameOverlay);
+        nameOverlay.className = "backdrop";
+        nameOverlay.style.display = "none";
+        nameOverlay.style.position = "absolute";
+        nameOverlay.style.bottom = "0";
+        nameOverlay.style.left = "0";
+        nameOverlay.style["pointer-events"] = "none";
+        nameOverlay.style.padding = "4px";
+        nameOverlay.style.backgroundColor = "black";
+
+        // Information about the currently selected feature
+        const selected = {
+          feature: undefined,
+          originalColor: new Cesium.Color(),
+        };
+
+        // An entity object which will hold info about the currently selected feature for infobox display
+        const selectedEntity = new Cesium.Entity();
+
+        // Get default left click handler for when a feature is not picked on left click
+        const clickHandler = viewer.screenSpaceEventHandler.getInputAction(
+          Cesium.ScreenSpaceEventType.LEFT_CLICK
+        );
+
+        // If silhouettes are supported, silhouette features in blue on mouse over and silhouette green on mouse click.
+        // If silhouettes are not supported, change the feature color to yellow on mouse over and green on mouse click.
+        if (
+          Cesium.PostProcessStageLibrary.isSilhouetteSupported(viewer.scene)
+        ) {
+          // Silhouettes are supported
+          const silhouetteBlue = Cesium.PostProcessStageLibrary.createEdgeDetectionStage();
+          silhouetteBlue.uniforms.color = Cesium.Color.BLUE;
+          silhouetteBlue.uniforms.length = 0.01;
+          silhouetteBlue.selected = [];
+
+          const silhouetteGreen = Cesium.PostProcessStageLibrary.createEdgeDetectionStage();
+          silhouetteGreen.uniforms.color = Cesium.Color.LIME;
+          silhouetteGreen.uniforms.length = 0.01;
+          silhouetteGreen.selected = [];
+
+          viewer.scene.postProcessStages.add(
+            Cesium.PostProcessStageLibrary.createSilhouetteStage([
+              silhouetteBlue,
+              silhouetteGreen,
+            ])
           );
-          const initialOrientation = new Cesium.HeadingPitchRoll.fromDegrees(
-            21.27879878293835,
-            -21.34390550872461,
-            0.0716951918898415
-          );
-          viewer.scene.camera.setView({
-            destination: initialPosition,
-            orientation: initialOrientation,
-            endTransform: Cesium.Matrix4.IDENTITY,
-          });
 
-          // Load the NYC buildings tileset
-          const tileset = new Cesium.Cesium3DTileset({
-            url: Cesium.IonResource.fromAssetId(75343),
-          });
-          viewer.scene.primitives.add(tileset);
+          // Silhouette a feature blue on hover.
+          viewer.screenSpaceEventHandler.setInputAction(function onMouseMove(
+            movement
+          ) {
+            // If a feature was previously highlighted, undo the highlight
+            silhouetteBlue.selected = [];
 
-          // HTML overlay for showing feature name on mouseover
-          const nameOverlay = document.createElement("div");
-          viewer.container.appendChild(nameOverlay);
-          nameOverlay.className = "backdrop";
-          nameOverlay.style.display = "none";
-          nameOverlay.style.position = "absolute";
-          nameOverlay.style.bottom = "0";
-          nameOverlay.style.left = "0";
-          nameOverlay.style["pointer-events"] = "none";
-          nameOverlay.style.padding = "4px";
-          nameOverlay.style.backgroundColor = "black";
+            // Pick a new feature
+            const pickedFeature = viewer.scene.pick(movement.endPosition);
+            if (!Cesium.defined(pickedFeature)) {
+              nameOverlay.style.display = "none";
+              return;
+            }
 
-          // Information about the currently selected feature
-          const selected = {
+            // A feature was picked, so show it's overlay content
+            nameOverlay.style.display = "block";
+            nameOverlay.style.bottom = `${
+              viewer.canvas.clientHeight - movement.endPosition.y
+            }px`;
+            nameOverlay.style.left = `${movement.endPosition.x}px`;
+            const name = pickedFeature.getProperty("BIN");
+            nameOverlay.textContent = name;
+
+            // Highlight the feature if it's not already selected.
+            if (pickedFeature !== selected.feature) {
+              silhouetteBlue.selected = [pickedFeature];
+            }
+          },
+          Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+
+          // Silhouette a feature on selection and show metadata in the InfoBox.
+          viewer.screenSpaceEventHandler.setInputAction(function onLeftClick(
+            movement
+          ) {
+            // If a feature was previously selected, undo the highlight
+            silhouetteGreen.selected = [];
+
+            // Pick a new feature
+            const pickedFeature = viewer.scene.pick(movement.position);
+            if (!Cesium.defined(pickedFeature)) {
+              clickHandler(movement);
+              return;
+            }
+
+            // Select the feature if it's not already selected
+            if (silhouetteGreen.selected[0] === pickedFeature) {
+              return;
+            }
+
+            // Save the selected feature's original color
+            const highlightedFeature = silhouetteBlue.selected[0];
+            if (pickedFeature === highlightedFeature) {
+              silhouetteBlue.selected = [];
+            }
+
+            // Highlight newly selected feature
+            silhouetteGreen.selected = [pickedFeature];
+
+            // Set feature infobox description
+            const featureName = pickedFeature.getProperty("name");
+            selectedEntity.name = featureName;
+            selectedEntity.description =
+              'Loading <div class="cesium-infoBox-loading"></div>';
+            viewer.selectedEntity = selectedEntity;
+            selectedEntity.description =
+              `${
+                '<table class="cesium-infoBox-defaultTable"><tbody>' +
+                "<tr><th>BIN</th><td>"
+              }${pickedFeature.getProperty("BIN")}</td></tr>` +
+              `<tr><th>DOITT ID</th><td>${pickedFeature.getProperty(
+                "DOITT_ID"
+              )}</td></tr>` +
+              `<tr><th>SOURCE ID</th><td>${pickedFeature.getProperty(
+                "SOURCE_ID"
+              )}</td></tr>` +
+              `</tbody></table>`;
+          },
+          Cesium.ScreenSpaceEventType.LEFT_CLICK);
+        } else {
+          // Silhouettes are not supported. Instead, change the feature color.
+
+          // Information about the currently highlighted feature
+          const highlighted = {
             feature: undefined,
             originalColor: new Cesium.Color(),
           };
 
-          // An entity object which will hold info about the currently selected feature for infobox display
-          const selectedEntity = new Cesium.Entity();
-
-          // Get default left click handler for when a feature is not picked on left click
-          const clickHandler = viewer.screenSpaceEventHandler.getInputAction(
-            Cesium.ScreenSpaceEventType.LEFT_CLICK
-          );
-
-          // If silhouettes are supported, silhouette features in blue on mouse over and silhouette green on mouse click.
-          // If silhouettes are not supported, change the feature color to yellow on mouse over and green on mouse click.
-          if (
-            Cesium.PostProcessStageLibrary.isSilhouetteSupported(viewer.scene)
+          // Color a feature yellow on hover.
+          viewer.screenSpaceEventHandler.setInputAction(function onMouseMove(
+            movement
           ) {
-            // Silhouettes are supported
-            const silhouetteBlue = Cesium.PostProcessStageLibrary.createEdgeDetectionStage();
-            silhouetteBlue.uniforms.color = Cesium.Color.BLUE;
-            silhouetteBlue.uniforms.length = 0.01;
-            silhouetteBlue.selected = [];
+            // If a feature was previously highlighted, undo the highlight
+            if (Cesium.defined(highlighted.feature)) {
+              highlighted.feature.color = highlighted.originalColor;
+              highlighted.feature = undefined;
+            }
+            // Pick a new feature
+            const pickedFeature = viewer.scene.pick(movement.endPosition);
+            if (!Cesium.defined(pickedFeature)) {
+              nameOverlay.style.display = "none";
+              return;
+            }
+            // A feature was picked, so show it's overlay content
+            nameOverlay.style.display = "block";
+            nameOverlay.style.bottom = `${
+              viewer.canvas.clientHeight - movement.endPosition.y
+            }px`;
+            nameOverlay.style.left = `${movement.endPosition.x}px`;
+            let name = pickedFeature.getProperty("name");
+            if (!Cesium.defined(name)) {
+              name = pickedFeature.getProperty("id");
+            }
+            nameOverlay.textContent = name;
+            // Highlight the feature if it's not already selected.
+            if (pickedFeature !== selected.feature) {
+              highlighted.feature = pickedFeature;
+              Cesium.Color.clone(
+                pickedFeature.color,
+                highlighted.originalColor
+              );
+              pickedFeature.color = Cesium.Color.YELLOW;
+            }
+          },
+          Cesium.ScreenSpaceEventType.MOUSE_MOVE);
 
-            const silhouetteGreen = Cesium.PostProcessStageLibrary.createEdgeDetectionStage();
-            silhouetteGreen.uniforms.color = Cesium.Color.LIME;
-            silhouetteGreen.uniforms.length = 0.01;
-            silhouetteGreen.selected = [];
-
-            viewer.scene.postProcessStages.add(
-              Cesium.PostProcessStageLibrary.createSilhouetteStage([
-                silhouetteBlue,
-                silhouetteGreen,
-              ])
-            );
-
-            // Silhouette a feature blue on hover.
-            viewer.screenSpaceEventHandler.setInputAction(function onMouseMove(
-              movement
-            ) {
-              // If a feature was previously highlighted, undo the highlight
-              silhouetteBlue.selected = [];
-
-              // Pick a new feature
-              const pickedFeature = viewer.scene.pick(movement.endPosition);
-              if (!Cesium.defined(pickedFeature)) {
-                nameOverlay.style.display = "none";
-                return;
-              }
-
-              // A feature was picked, so show it's overlay content
-              nameOverlay.style.display = "block";
-              nameOverlay.style.bottom = `${
-                viewer.canvas.clientHeight - movement.endPosition.y
-              }px`;
-              nameOverlay.style.left = `${movement.endPosition.x}px`;
-              const name = pickedFeature.getProperty("BIN");
-              nameOverlay.textContent = name;
-
-              // Highlight the feature if it's not already selected.
-              if (pickedFeature !== selected.feature) {
-                silhouetteBlue.selected = [pickedFeature];
-              }
-            },
-            Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-
-            // Silhouette a feature on selection and show metadata in the InfoBox.
-            viewer.screenSpaceEventHandler.setInputAction(function onLeftClick(
-              movement
-            ) {
-              // If a feature was previously selected, undo the highlight
-              silhouetteGreen.selected = [];
-
-              // Pick a new feature
-              const pickedFeature = viewer.scene.pick(movement.position);
-              if (!Cesium.defined(pickedFeature)) {
-                clickHandler(movement);
-                return;
-              }
-
-              // Select the feature if it's not already selected
-              if (silhouetteGreen.selected[0] === pickedFeature) {
-                return;
-              }
-
-              // Save the selected feature's original color
-              const highlightedFeature = silhouetteBlue.selected[0];
-              if (pickedFeature === highlightedFeature) {
-                silhouetteBlue.selected = [];
-              }
-
-              // Highlight newly selected feature
-              silhouetteGreen.selected = [pickedFeature];
-
-              // Set feature infobox description
-              const featureName = pickedFeature.getProperty("name");
-              selectedEntity.name = featureName;
-              selectedEntity.description =
-                'Loading <div class="cesium-infoBox-loading"></div>';
-              viewer.selectedEntity = selectedEntity;
-              selectedEntity.description =
-                `${
-                  '<table class="cesium-infoBox-defaultTable"><tbody>' +
-                  "<tr><th>BIN</th><td>"
-                }${pickedFeature.getProperty("BIN")}</td></tr>` +
-                `<tr><th>DOITT ID</th><td>${pickedFeature.getProperty(
-                  "DOITT_ID"
-                )}</td></tr>` +
-                `<tr><th>SOURCE ID</th><td>${pickedFeature.getProperty(
-                  "SOURCE_ID"
-                )}</td></tr>` +
-                `</tbody></table>`;
-            },
-            Cesium.ScreenSpaceEventType.LEFT_CLICK);
-          } else {
-            // Silhouettes are not supported. Instead, change the feature color.
-
-            // Information about the currently highlighted feature
-            const highlighted = {
-              feature: undefined,
-              originalColor: new Cesium.Color(),
-            };
-
-            // Color a feature yellow on hover.
-            viewer.screenSpaceEventHandler.setInputAction(function onMouseMove(
-              movement
-            ) {
-              // If a feature was previously highlighted, undo the highlight
-              if (Cesium.defined(highlighted.feature)) {
-                highlighted.feature.color = highlighted.originalColor;
-                highlighted.feature = undefined;
-              }
-              // Pick a new feature
-              const pickedFeature = viewer.scene.pick(movement.endPosition);
-              if (!Cesium.defined(pickedFeature)) {
-                nameOverlay.style.display = "none";
-                return;
-              }
-              // A feature was picked, so show it's overlay content
-              nameOverlay.style.display = "block";
-              nameOverlay.style.bottom = `${
-                viewer.canvas.clientHeight - movement.endPosition.y
-              }px`;
-              nameOverlay.style.left = `${movement.endPosition.x}px`;
-              let name = pickedFeature.getProperty("name");
-              if (!Cesium.defined(name)) {
-                name = pickedFeature.getProperty("id");
-              }
-              nameOverlay.textContent = name;
-              // Highlight the feature if it's not already selected.
-              if (pickedFeature !== selected.feature) {
-                highlighted.feature = pickedFeature;
-                Cesium.Color.clone(
-                  pickedFeature.color,
-                  highlighted.originalColor
-                );
-                pickedFeature.color = Cesium.Color.YELLOW;
-              }
-            },
-            Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-
-            // Color a feature on selection and show metadata in the InfoBox.
-            viewer.screenSpaceEventHandler.setInputAction(function onLeftClick(
-              movement
-            ) {
-              // If a feature was previously selected, undo the highlight
-              if (Cesium.defined(selected.feature)) {
-                selected.feature.color = selected.originalColor;
-                selected.feature = undefined;
-              }
-              // Pick a new feature
-              const pickedFeature = viewer.scene.pick(movement.position);
-              if (!Cesium.defined(pickedFeature)) {
-                clickHandler(movement);
-                return;
-              }
-              // Select the feature if it's not already selected
-              if (selected.feature === pickedFeature) {
-                return;
-              }
-              selected.feature = pickedFeature;
-              // Save the selected feature's original color
-              if (pickedFeature === highlighted.feature) {
-                Cesium.Color.clone(
-                  highlighted.originalColor,
-                  selected.originalColor
-                );
-                highlighted.feature = undefined;
-              } else {
-                Cesium.Color.clone(pickedFeature.color, selected.originalColor);
-              }
-              // Highlight newly selected feature
-              pickedFeature.color = Cesium.Color.LIME;
-              // Set feature infobox description
-              const featureName = pickedFeature.getProperty("name");
-              selectedEntity.name = featureName;
-              selectedEntity.description =
-                'Loading <div class="cesium-infoBox-loading"></div>';
-              viewer.selectedEntity = selectedEntity;
-              selectedEntity.description =
-                `${
-                  '<table class="cesium-infoBox-defaultTable"><tbody>' +
-                  "<tr><th>BIN</th><td>"
-                }${pickedFeature.getProperty("BIN")}</td></tr>` +
-                `<tr><th>DOITT ID</th><td>${pickedFeature.getProperty(
-                  "DOITT_ID"
-                )}</td></tr>` +
-                `<tr><th>SOURCE ID</th><td>${pickedFeature.getProperty(
-                  "SOURCE_ID"
-                )}</td></tr>` +
-                `<tr><th>Longitude</th><td>${pickedFeature.getProperty(
-                  "longitude"
-                )}</td></tr>` +
-                `<tr><th>Latitude</th><td>${pickedFeature.getProperty(
-                  "latitude"
-                )}</td></tr>` +
-                `<tr><th>Height</th><td>${pickedFeature.getProperty(
-                  "height"
-                )}</td></tr>` +
-                `<tr><th>Terrain Height (Ellipsoid)</th><td>${pickedFeature.getProperty(
-                  "TerrainHeight"
-                )}</td></tr>` +
-                `</tbody></table>`;
-            },
-            Cesium.ScreenSpaceEventType.LEFT_CLICK);
-          }
-        })(); //Sandcastle_End
-        Sandcastle.finishedLoading();
+          // Color a feature on selection and show metadata in the InfoBox.
+          viewer.screenSpaceEventHandler.setInputAction(function onLeftClick(
+            movement
+          ) {
+            // If a feature was previously selected, undo the highlight
+            if (Cesium.defined(selected.feature)) {
+              selected.feature.color = selected.originalColor;
+              selected.feature = undefined;
+            }
+            // Pick a new feature
+            const pickedFeature = viewer.scene.pick(movement.position);
+            if (!Cesium.defined(pickedFeature)) {
+              clickHandler(movement);
+              return;
+            }
+            // Select the feature if it's not already selected
+            if (selected.feature === pickedFeature) {
+              return;
+            }
+            selected.feature = pickedFeature;
+            // Save the selected feature's original color
+            if (pickedFeature === highlighted.feature) {
+              Cesium.Color.clone(
+                highlighted.originalColor,
+                selected.originalColor
+              );
+              highlighted.feature = undefined;
+            } else {
+              Cesium.Color.clone(pickedFeature.color, selected.originalColor);
+            }
+            // Highlight newly selected feature
+            pickedFeature.color = Cesium.Color.LIME;
+            // Set feature infobox description
+            const featureName = pickedFeature.getProperty("name");
+            selectedEntity.name = featureName;
+            selectedEntity.description =
+              'Loading <div class="cesium-infoBox-loading"></div>';
+            viewer.selectedEntity = selectedEntity;
+            selectedEntity.description =
+              `${
+                '<table class="cesium-infoBox-defaultTable"><tbody>' +
+                "<tr><th>BIN</th><td>"
+              }${pickedFeature.getProperty("BIN")}</td></tr>` +
+              `<tr><th>DOITT ID</th><td>${pickedFeature.getProperty(
+                "DOITT_ID"
+              )}</td></tr>` +
+              `<tr><th>SOURCE ID</th><td>${pickedFeature.getProperty(
+                "SOURCE_ID"
+              )}</td></tr>` +
+              `<tr><th>Longitude</th><td>${pickedFeature.getProperty(
+                "longitude"
+              )}</td></tr>` +
+              `<tr><th>Latitude</th><td>${pickedFeature.getProperty(
+                "latitude"
+              )}</td></tr>` +
+              `<tr><th>Height</th><td>${pickedFeature.getProperty(
+                "height"
+              )}</td></tr>` +
+              `<tr><th>Terrain Height (Ellipsoid)</th><td>${pickedFeature.getProperty(
+                "TerrainHeight"
+              )}</td></tr>` +
+              `</tbody></table>`;
+          },
+          Cesium.ScreenSpaceEventType.LEFT_CLICK);
+        } //Sandcastle_End
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
@@ -50,174 +50,170 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          // How to use the 3D Tiles Styling language to style individual features, like buildings.
-          // Styling language specification: https://github.com/CesiumGS/3d-tiles/tree/main/specification/Styling
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
-          const handler = new Cesium.ScreenSpaceEventHandler(
-            viewer.scene.canvas
-          );
+        // How to use the 3D Tiles Styling language to style individual features, like buildings.
+        // Styling language specification: https://github.com/CesiumGS/3d-tiles/tree/main/specification/Styling
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
+        const handler = new Cesium.ScreenSpaceEventHandler(viewer.scene.canvas);
 
-          // Add Cesium OSM buildings to the scene as our example 3D Tileset.
-          const osmBuildingsTileset = Cesium.createOsmBuildings();
-          viewer.scene.primitives.add(osmBuildingsTileset);
+        // Add Cesium OSM buildings to the scene as our example 3D Tileset.
+        const osmBuildingsTileset = Cesium.createOsmBuildings();
+        viewer.scene.primitives.add(osmBuildingsTileset);
 
-          // Set the initial camera to look at Seattle
-          viewer.scene.camera.setView({
-            destination: Cesium.Cartesian3.fromDegrees(-122.3472, 47.598, 370),
-            orientation: {
-              heading: Cesium.Math.toRadians(10),
-              pitch: Cesium.Math.toRadians(-10),
+        // Set the initial camera to look at Seattle
+        viewer.scene.camera.setView({
+          destination: Cesium.Cartesian3.fromDegrees(-122.3472, 47.598, 370),
+          orientation: {
+            heading: Cesium.Math.toRadians(10),
+            pitch: Cesium.Math.toRadians(-10),
+          },
+        });
+
+        // Styling functions
+
+        // Color by material checks for null values since not all
+        // buildings have the material property.
+        function colorByMaterial() {
+          osmBuildingsTileset.style = new Cesium.Cesium3DTileStyle({
+            defines: {
+              material: "${feature['building:material']}",
+            },
+            color: {
+              conditions: [
+                ["${material} === null", "color('white')"],
+                ["${material} === 'glass'", "color('skyblue', 0.5)"],
+                ["${material} === 'concrete'", "color('grey')"],
+                ["${material} === 'brick'", "color('indianred')"],
+                ["${material} === 'stone'", "color('lightslategrey')"],
+                ["${material} === 'metal'", "color('lightgrey')"],
+                ["${material} === 'steel'", "color('lightsteelblue')"],
+                ["true", "color('white')"], // This is the else case
+              ],
             },
           });
+        }
 
-          // Styling functions
-
-          // Color by material checks for null values since not all
-          // buildings have the material property.
-          function colorByMaterial() {
-            osmBuildingsTileset.style = new Cesium.Cesium3DTileStyle({
-              defines: {
-                material: "${feature['building:material']}",
-              },
-              color: {
-                conditions: [
-                  ["${material} === null", "color('white')"],
-                  ["${material} === 'glass'", "color('skyblue', 0.5)"],
-                  ["${material} === 'concrete'", "color('grey')"],
-                  ["${material} === 'brick'", "color('indianred')"],
-                  ["${material} === 'stone'", "color('lightslategrey')"],
-                  ["${material} === 'metal'", "color('lightgrey')"],
-                  ["${material} === 'steel'", "color('lightsteelblue')"],
-                  ["true", "color('white')"], // This is the else case
+        function highlightAllResidentialBuildings() {
+          osmBuildingsTileset.style = new Cesium.Cesium3DTileStyle({
+            color: {
+              conditions: [
+                [
+                  "${feature['building']} === 'apartments' || ${feature['building']} === 'residential'",
+                  "color('cyan', 0.9)",
                 ],
-              },
-            });
-          }
+                [true, "color('white')"],
+              ],
+            },
+          });
+        }
 
-          function highlightAllResidentialBuildings() {
-            osmBuildingsTileset.style = new Cesium.Cesium3DTileStyle({
-              color: {
-                conditions: [
-                  [
-                    "${feature['building']} === 'apartments' || ${feature['building']} === 'residential'",
-                    "color('cyan', 0.9)",
-                  ],
-                  [true, "color('white')"],
-                ],
-              },
-            });
+        function showByBuildingType(buildingType) {
+          switch (buildingType) {
+            case "office":
+              osmBuildingsTileset.style = new Cesium.Cesium3DTileStyle({
+                show: "${feature['building']} === 'office'",
+              });
+              break;
+            case "apartments":
+              osmBuildingsTileset.style = new Cesium.Cesium3DTileStyle({
+                show: "${feature['building']} === 'apartments'",
+              });
+              break;
+            default:
+              break;
           }
+        }
 
-          function showByBuildingType(buildingType) {
-            switch (buildingType) {
-              case "office":
-                osmBuildingsTileset.style = new Cesium.Cesium3DTileStyle({
-                  show: "${feature['building']} === 'office'",
-                });
-                break;
-              case "apartments":
-                osmBuildingsTileset.style = new Cesium.Cesium3DTileStyle({
-                  show: "${feature['building']} === 'apartments'",
-                });
-                break;
-              default:
-                break;
-            }
-          }
+        // Color the buildings based on their distance from a selected central location
+        function colorByDistanceToCoordinate(pickedLatitude, pickedLongitude) {
+          osmBuildingsTileset.style = new Cesium.Cesium3DTileStyle({
+            defines: {
+              distance: `distance(vec2(\${feature['cesium#longitude']}, \${feature['cesium#latitude']}), vec2(${pickedLongitude},${pickedLatitude}))`,
+            },
+            color: {
+              conditions: [
+                ["${distance} > 0.014", "color('blue')"],
+                ["${distance} > 0.010", "color('green')"],
+                ["${distance} > 0.006", "color('yellow')"],
+                ["${distance} > 0.0001", "color('red')"],
+                ["true", "color('white')"],
+              ],
+            },
+          });
+        }
 
-          // Color the buildings based on their distance from a selected central location
-          function colorByDistanceToCoordinate(
-            pickedLatitude,
-            pickedLongitude
-          ) {
-            osmBuildingsTileset.style = new Cesium.Cesium3DTileStyle({
-              defines: {
-                distance: `distance(vec2(\${feature['cesium#longitude']}, \${feature['cesium#latitude']}), vec2(${pickedLongitude},${pickedLatitude}))`,
-              },
-              color: {
-                conditions: [
-                  ["${distance} > 0.014", "color('blue')"],
-                  ["${distance} > 0.010", "color('green')"],
-                  ["${distance} > 0.006", "color('yellow')"],
-                  ["${distance} > 0.0001", "color('red')"],
-                  ["true", "color('white')"],
-                ],
-              },
-            });
-          }
-
-          // When dropdown option is not "Color By Distance To Selected Location",
-          // remove the left click input event for selecting a central location
-          function removeCoordinatePickingOnLeftClick() {
-            document.querySelector(".infoPanel").style.visibility = "hidden";
-            handler.removeInputAction(Cesium.ScreenSpaceEventType.LEFT_CLICK);
-          }
-
-          // Add event listeners to dropdown menu options
+        // When dropdown option is not "Color By Distance To Selected Location",
+        // remove the left click input event for selecting a central location
+        function removeCoordinatePickingOnLeftClick() {
           document.querySelector(".infoPanel").style.visibility = "hidden";
-          const menu = document.getElementById("dropdown");
+          handler.removeInputAction(Cesium.ScreenSpaceEventType.LEFT_CLICK);
+        }
 
-          menu.options[0].onselect = function () {
-            removeCoordinatePickingOnLeftClick();
-            colorByMaterial();
-          };
+        // Add event listeners to dropdown menu options
+        document.querySelector(".infoPanel").style.visibility = "hidden";
+        const menu = document.getElementById("dropdown");
 
-          menu.options[1].onselect = function () {
-            // Default to Space Needle as the central location
-            colorByDistanceToCoordinate(47.62051, -122.34931);
-            document.querySelector(".infoPanel").style.visibility = "visible";
-            // Add left click input to select a building to and extract its coordinates
-            handler.setInputAction(function (movement) {
-              viewer.selectedEntity = undefined;
-              const pickedBuilding = viewer.scene.pick(movement.position);
-              if (pickedBuilding) {
-                const pickedLatitude = pickedBuilding.getProperty(
-                  "cesium#latitude"
-                );
-                const pickedLongitude = pickedBuilding.getProperty(
-                  "cesium#longitude"
-                );
-                colorByDistanceToCoordinate(pickedLatitude, pickedLongitude);
-              }
-            }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
-          };
-
-          menu.options[2].onselect = function () {
-            removeCoordinatePickingOnLeftClick();
-            highlightAllResidentialBuildings();
-          };
-
-          menu.options[3].onselect = function () {
-            removeCoordinatePickingOnLeftClick();
-            showByBuildingType("office");
-          };
-
-          menu.options[4].onselect = function () {
-            removeCoordinatePickingOnLeftClick();
-            showByBuildingType("apartments");
-          };
-
-          menu.onchange = function () {
-            Sandcastle.reset();
-            const item = menu.options[menu.selectedIndex];
-            if (item && typeof item.onselect === "function") {
-              item.onselect();
-            }
-          };
-
+        menu.options[0].onselect = function () {
+          removeCoordinatePickingOnLeftClick();
           colorByMaterial();
-        })(); //Sandcastle_End
-        Sandcastle.finishedLoading();
+        };
+
+        menu.options[1].onselect = function () {
+          // Default to Space Needle as the central location
+          colorByDistanceToCoordinate(47.62051, -122.34931);
+          document.querySelector(".infoPanel").style.visibility = "visible";
+          // Add left click input to select a building to and extract its coordinates
+          handler.setInputAction(function (movement) {
+            viewer.selectedEntity = undefined;
+            const pickedBuilding = viewer.scene.pick(movement.position);
+            if (pickedBuilding) {
+              const pickedLatitude = pickedBuilding.getProperty(
+                "cesium#latitude"
+              );
+              const pickedLongitude = pickedBuilding.getProperty(
+                "cesium#longitude"
+              );
+              colorByDistanceToCoordinate(pickedLatitude, pickedLongitude);
+            }
+          }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
+        };
+
+        menu.options[2].onselect = function () {
+          removeCoordinatePickingOnLeftClick();
+          highlightAllResidentialBuildings();
+        };
+
+        menu.options[3].onselect = function () {
+          removeCoordinatePickingOnLeftClick();
+          showByBuildingType("office");
+        };
+
+        menu.options[4].onselect = function () {
+          removeCoordinatePickingOnLeftClick();
+          showByBuildingType("apartments");
+        };
+
+        menu.onchange = function () {
+          Sandcastle.reset();
+          const item = menu.options[menu.selectedIndex];
+          if (item && typeof item.onselect === "function") {
+            item.onselect();
+          }
+        };
+
+        colorByMaterial(); //Sandcastle_End
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Formats.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Formats.html
@@ -38,7 +38,7 @@
       <div><input type="checkbox" data-bind="checked: shadows" /> Shadows</div>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -218,11 +218,14 @@
           }
         }, Cesium.ScreenSpaceEventType.MIDDLE_CLICK);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Inspector.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Inspector.html
@@ -62,15 +62,14 @@
             tileset.boundingSphere.radius / 4.0
           )
         ); //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Inspector.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Inspector.html
@@ -33,42 +33,44 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Building data courtesy of NYC OpenData portal: http://www1.nyc.gov/site/doitt/initiatives/3d-building.page
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
 
-          viewer.scene.globe.depthTestAgainstTerrain = true;
+        viewer.scene.globe.depthTestAgainstTerrain = true;
 
-          viewer.extend(Cesium.viewerCesium3DTilesInspectorMixin);
-          const inspectorViewModel = viewer.cesium3DTilesInspector.viewModel;
+        viewer.extend(Cesium.viewerCesium3DTilesInspectorMixin);
+        const inspectorViewModel = viewer.cesium3DTilesInspector.viewModel;
 
-          const tileset = new Cesium.Cesium3DTileset({
-            url: Cesium.IonResource.fromAssetId(75343),
-            enableDebugWireframe: true,
-          });
-          viewer.scene.primitives.add(tileset);
+        const tileset = new Cesium.Cesium3DTileset({
+          url: Cesium.IonResource.fromAssetId(75343),
+          enableDebugWireframe: true,
+        });
+        viewer.scene.primitives.add(tileset);
 
-          await tileset.readyPromise;
+        await tileset.readyPromise;
 
-          viewer.zoomTo(
-            tileset,
-            new Cesium.HeadingPitchRange(
-              0.0,
-              -0.5,
-              tileset.boundingSphere.radius / 4.0
-            )
-          );
-        })(); //Sandcastle_End
+        viewer.zoomTo(
+          tileset,
+          new Cesium.HeadingPitchRange(
+            0.0,
+            -0.5,
+            tileset.boundingSphere.radius / 4.0
+          )
+        ); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
@@ -71,213 +71,203 @@
       </div>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
 
-          const scene = viewer.scene;
-          if (!scene.pickPositionSupported) {
-            window.alert("This browser does not support pickPosition.");
+        const scene = viewer.scene;
+        if (!scene.pickPositionSupported) {
+          window.alert("This browser does not support pickPosition.");
+        }
+
+        scene.globe.depthTestAgainstTerrain = true;
+
+        const viewModel = {
+          rightClickAction: "annotate",
+          middleClickAction: "hide",
+        };
+
+        Cesium.knockout.track(viewModel);
+
+        const toolbar = document.getElementById("toolbar");
+        Cesium.knockout.applyBindings(viewModel, toolbar);
+
+        const annotations = scene.primitives.add(new Cesium.LabelCollection());
+
+        // Set the initial camera view to look at Manhattan
+        const initialPosition = Cesium.Cartesian3.fromDegrees(
+          -74.01881302800248,
+          40.69114333714821,
+          753
+        );
+        const initialOrientation = new Cesium.HeadingPitchRoll.fromDegrees(
+          21.27879878293835,
+          -21.34390550872461,
+          0.0716951918898415
+        );
+        scene.camera.setView({
+          destination: initialPosition,
+          orientation: initialOrientation,
+          endTransform: Cesium.Matrix4.IDENTITY,
+        });
+
+        // Load the NYC buildings tileset.
+        const tileset = new Cesium.Cesium3DTileset({
+          url: Cesium.IonResource.fromAssetId(75343),
+        });
+        scene.primitives.add(tileset);
+        tileset.style = new Cesium.Cesium3DTileStyle({
+          meta: {
+            description: "'Building ${BIN} has height ${Height}.'",
+          },
+        });
+
+        const handler = new Cesium.ScreenSpaceEventHandler(viewer.canvas);
+
+        handler.setInputAction(function (movement) {
+          const feature = scene.pick(movement.position);
+          if (!Cesium.defined(feature)) {
+            return;
           }
 
-          scene.globe.depthTestAgainstTerrain = true;
+          const action = viewModel.rightClickAction;
+          if (action === "annotate") {
+            annotate(movement, feature);
+          } else if (action === "properties") {
+            printProperties(movement, feature);
+          } else if (action === "zoom") {
+            zoom(movement, feature);
+          }
+        }, Cesium.ScreenSpaceEventType.RIGHT_CLICK);
 
-          const viewModel = {
-            rightClickAction: "annotate",
-            middleClickAction: "hide",
-          };
+        handler.setInputAction(function (movement) {
+          const feature = scene.pick(movement.position);
+          if (!Cesium.defined(feature)) {
+            return;
+          }
 
-          Cesium.knockout.track(viewModel);
+          const action = viewModel.middleClickAction;
+          if (action === "hide") {
+            feature.show = false;
+          }
+        }, Cesium.ScreenSpaceEventType.MIDDLE_CLICK);
 
-          const toolbar = document.getElementById("toolbar");
-          Cesium.knockout.applyBindings(viewModel, toolbar);
+        function annotate(movement, feature) {
+          if (scene.pickPositionSupported) {
+            const cartesian = scene.pickPosition(movement.position);
+            if (Cesium.defined(cartesian)) {
+              const cartographic = Cesium.Cartographic.fromCartesian(cartesian);
+              const height = `${cartographic.height.toFixed(2)} m`;
 
-          const annotations = scene.primitives.add(
-            new Cesium.LabelCollection()
+              annotations.add({
+                position: cartesian,
+                text: height,
+                showBackground: true,
+                font: "14px monospace",
+                horizontalOrigin: Cesium.HorizontalOrigin.LEFT,
+                verticalOrigin: Cesium.VerticalOrigin.BOTTOM,
+                disableDepthTestDistance: Number.POSITIVE_INFINITY,
+              });
+            }
+          }
+        }
+
+        function printProperties(movement, feature) {
+          console.log("Properties:");
+          const propertyIds = feature.getPropertyIds();
+          const length = propertyIds.length;
+          for (let i = 0; i < length; ++i) {
+            const propertyId = propertyIds[i];
+            console.log(`  ${propertyId}: ${feature.getProperty(propertyId)}`);
+          }
+
+          // Evaluate feature description
+          console.log(
+            `Description : ${tileset.style.meta.description.evaluate(feature)}`
+          );
+        }
+
+        function zoom(movement, feature) {
+          const longitude = Cesium.Math.toRadians(
+            feature.getProperty("Longitude")
+          );
+          const latitude = Cesium.Math.toRadians(
+            feature.getProperty("Latitude")
+          );
+          const height = feature.getProperty("Height");
+
+          const positionCartographic = new Cesium.Cartographic(
+            longitude,
+            latitude,
+            height * 0.5
+          );
+          const position = scene.globe.ellipsoid.cartographicToCartesian(
+            positionCartographic
           );
 
-          // Set the initial camera view to look at Manhattan
-          const initialPosition = Cesium.Cartesian3.fromDegrees(
-            -74.01881302800248,
-            40.69114333714821,
-            753
-          );
-          const initialOrientation = new Cesium.HeadingPitchRoll.fromDegrees(
-            21.27879878293835,
-            -21.34390550872461,
-            0.0716951918898415
-          );
-          scene.camera.setView({
-            destination: initialPosition,
-            orientation: initialOrientation,
-            endTransform: Cesium.Matrix4.IDENTITY,
-          });
+          const camera = scene.camera;
+          const heading = camera.heading;
+          const pitch = camera.pitch;
 
-          // Load the NYC buildings tileset.
-          const tileset = new Cesium.Cesium3DTileset({
-            url: Cesium.IonResource.fromAssetId(75343),
-          });
-          scene.primitives.add(tileset);
-          tileset.style = new Cesium.Cesium3DTileStyle({
-            meta: {
-              description: "'Building ${BIN} has height ${Height}.'",
+          const offset = offsetFromHeadingPitchRange(
+            heading,
+            pitch,
+            height * 2.0
+          );
+
+          const transform = Cesium.Transforms.eastNorthUpToFixedFrame(position);
+          Cesium.Matrix4.multiplyByPoint(transform, offset, position);
+
+          camera.flyTo({
+            destination: position,
+            orientation: {
+              heading: heading,
+              pitch: pitch,
             },
+            easingFunction: Cesium.EasingFunction.QUADRATIC_OUT,
           });
+        }
 
-          const handler = new Cesium.ScreenSpaceEventHandler(viewer.canvas);
+        function offsetFromHeadingPitchRange(heading, pitch, range) {
+          pitch = Cesium.Math.clamp(
+            pitch,
+            -Cesium.Math.PI_OVER_TWO,
+            Cesium.Math.PI_OVER_TWO
+          );
+          heading = Cesium.Math.zeroToTwoPi(heading) - Cesium.Math.PI_OVER_TWO;
 
-          handler.setInputAction(function (movement) {
-            const feature = scene.pick(movement.position);
-            if (!Cesium.defined(feature)) {
-              return;
-            }
+          const pitchQuat = Cesium.Quaternion.fromAxisAngle(
+            Cesium.Cartesian3.UNIT_Y,
+            -pitch
+          );
+          const headingQuat = Cesium.Quaternion.fromAxisAngle(
+            Cesium.Cartesian3.UNIT_Z,
+            -heading
+          );
+          const rotQuat = Cesium.Quaternion.multiply(
+            headingQuat,
+            pitchQuat,
+            headingQuat
+          );
+          const rotMatrix = Cesium.Matrix3.fromQuaternion(rotQuat);
 
-            const action = viewModel.rightClickAction;
-            if (action === "annotate") {
-              annotate(movement, feature);
-            } else if (action === "properties") {
-              printProperties(movement, feature);
-            } else if (action === "zoom") {
-              zoom(movement, feature);
-            }
-          }, Cesium.ScreenSpaceEventType.RIGHT_CLICK);
-
-          handler.setInputAction(function (movement) {
-            const feature = scene.pick(movement.position);
-            if (!Cesium.defined(feature)) {
-              return;
-            }
-
-            const action = viewModel.middleClickAction;
-            if (action === "hide") {
-              feature.show = false;
-            }
-          }, Cesium.ScreenSpaceEventType.MIDDLE_CLICK);
-
-          function annotate(movement, feature) {
-            if (scene.pickPositionSupported) {
-              const cartesian = scene.pickPosition(movement.position);
-              if (Cesium.defined(cartesian)) {
-                const cartographic = Cesium.Cartographic.fromCartesian(
-                  cartesian
-                );
-                const height = `${cartographic.height.toFixed(2)} m`;
-
-                annotations.add({
-                  position: cartesian,
-                  text: height,
-                  showBackground: true,
-                  font: "14px monospace",
-                  horizontalOrigin: Cesium.HorizontalOrigin.LEFT,
-                  verticalOrigin: Cesium.VerticalOrigin.BOTTOM,
-                  disableDepthTestDistance: Number.POSITIVE_INFINITY,
-                });
-              }
-            }
-          }
-
-          function printProperties(movement, feature) {
-            console.log("Properties:");
-            const propertyIds = feature.getPropertyIds();
-            const length = propertyIds.length;
-            for (let i = 0; i < length; ++i) {
-              const propertyId = propertyIds[i];
-              console.log(
-                `  ${propertyId}: ${feature.getProperty(propertyId)}`
-              );
-            }
-
-            // Evaluate feature description
-            console.log(
-              `Description : ${tileset.style.meta.description.evaluate(
-                feature
-              )}`
-            );
-          }
-
-          function zoom(movement, feature) {
-            const longitude = Cesium.Math.toRadians(
-              feature.getProperty("Longitude")
-            );
-            const latitude = Cesium.Math.toRadians(
-              feature.getProperty("Latitude")
-            );
-            const height = feature.getProperty("Height");
-
-            const positionCartographic = new Cesium.Cartographic(
-              longitude,
-              latitude,
-              height * 0.5
-            );
-            const position = scene.globe.ellipsoid.cartographicToCartesian(
-              positionCartographic
-            );
-
-            const camera = scene.camera;
-            const heading = camera.heading;
-            const pitch = camera.pitch;
-
-            const offset = offsetFromHeadingPitchRange(
-              heading,
-              pitch,
-              height * 2.0
-            );
-
-            const transform = Cesium.Transforms.eastNorthUpToFixedFrame(
-              position
-            );
-            Cesium.Matrix4.multiplyByPoint(transform, offset, position);
-
-            camera.flyTo({
-              destination: position,
-              orientation: {
-                heading: heading,
-                pitch: pitch,
-              },
-              easingFunction: Cesium.EasingFunction.QUADRATIC_OUT,
-            });
-          }
-
-          function offsetFromHeadingPitchRange(heading, pitch, range) {
-            pitch = Cesium.Math.clamp(
-              pitch,
-              -Cesium.Math.PI_OVER_TWO,
-              Cesium.Math.PI_OVER_TWO
-            );
-            heading =
-              Cesium.Math.zeroToTwoPi(heading) - Cesium.Math.PI_OVER_TWO;
-
-            const pitchQuat = Cesium.Quaternion.fromAxisAngle(
-              Cesium.Cartesian3.UNIT_Y,
-              -pitch
-            );
-            const headingQuat = Cesium.Quaternion.fromAxisAngle(
-              Cesium.Cartesian3.UNIT_Z,
-              -heading
-            );
-            const rotQuat = Cesium.Quaternion.multiply(
-              headingQuat,
-              pitchQuat,
-              headingQuat
-            );
-            const rotMatrix = Cesium.Matrix3.fromQuaternion(rotQuat);
-
-            const offset = Cesium.Cartesian3.clone(Cesium.Cartesian3.UNIT_X);
-            Cesium.Matrix3.multiplyByVector(rotMatrix, offset, offset);
-            Cesium.Cartesian3.negate(offset, offset);
-            Cesium.Cartesian3.multiplyByScalar(offset, range, offset);
-            return offset;
-          }
-        })(); //Sandcastle_End
-        Sandcastle.finishedLoading();
+          const offset = Cesium.Cartesian3.clone(Cesium.Cartesian3.UNIT_X);
+          Cesium.Matrix3.multiplyByVector(rotMatrix, offset, offset);
+          Cesium.Cartesian3.negate(offset, offset);
+          Cesium.Cartesian3.multiplyByScalar(offset, range, offset);
+          return offset;
+        } //Sandcastle_End
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Interior.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Interior.html
@@ -60,15 +60,14 @@
           endTransform: Cesium.Matrix4.IDENTITY,
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Interior.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Interior.html
@@ -33,7 +33,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // San Miguel model created by Guillermo M. Leal Llaguno. Cleaned up and hosted by Morgan McGuire: http://graphics.cs.williams.edu/data/meshes.xml
@@ -64,7 +64,11 @@
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Next CDB Yemen.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Next CDB Yemen.html
@@ -41,7 +41,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
 
@@ -449,11 +449,14 @@
         );
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Next Photogrammetry Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Next Photogrammetry Classification.html
@@ -352,15 +352,14 @@
         ];
         Sandcastle.addToolbarMenu(demos);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Next Photogrammetry Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Next Photogrammetry Classification.html
@@ -32,22 +32,15 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // San Francisco Ferry Building photogrammetry model provided by Aerometrex
         const viewer = new Cesium.Viewer("cesiumContainer", {
           infoBox: false,
           orderIndependentTranslucency: false,
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
         });
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-          } catch (error) {
-            console.log(error);
-          }
-        })();
 
         viewer.clock.currentTime = Cesium.JulianDate.fromIso8601(
           "2021-11-09T20:27:37.016064475348684937Z"
@@ -363,7 +356,11 @@
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Next S2 Globe.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Next S2 Globe.html
@@ -41,7 +41,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
 
@@ -228,11 +228,14 @@
         });
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Photogrammetry Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Photogrammetry Classification.html
@@ -33,56 +33,58 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          // An example of using a b3dm tileset to classify another b3dm tileset.
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
+        // An example of using a b3dm tileset to classify another b3dm tileset.
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
 
-          // A normal b3dm tileset containing photogrammetry
-          const tileset = new Cesium.Cesium3DTileset({
-            url: Cesium.IonResource.fromAssetId(40866),
-          });
-          viewer.scene.primitives.add(tileset);
-          viewer.zoomTo(tileset);
+        // A normal b3dm tileset containing photogrammetry
+        const tileset = new Cesium.Cesium3DTileset({
+          url: Cesium.IonResource.fromAssetId(40866),
+        });
+        viewer.scene.primitives.add(tileset);
+        viewer.zoomTo(tileset);
 
-          const classificationTilesetUrl =
-            "../../SampleData/Cesium3DTiles/Classification/Photogrammetry/tileset.json";
-          // A b3dm tileset used to classify the photogrammetry tileset
-          const classificationTileset = new Cesium.Cesium3DTileset({
-            url: classificationTilesetUrl,
-            classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
-          });
-          classificationTileset.style = new Cesium.Cesium3DTileStyle({
-            color: "rgba(255, 0, 0, 0.5)",
-          });
-          viewer.scene.primitives.add(classificationTileset);
+        const classificationTilesetUrl =
+          "../../SampleData/Cesium3DTiles/Classification/Photogrammetry/tileset.json";
+        // A b3dm tileset used to classify the photogrammetry tileset
+        const classificationTileset = new Cesium.Cesium3DTileset({
+          url: classificationTilesetUrl,
+          classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
+        });
+        classificationTileset.style = new Cesium.Cesium3DTileStyle({
+          color: "rgba(255, 0, 0, 0.5)",
+        });
+        viewer.scene.primitives.add(classificationTileset);
 
-          // The same b3dm tileset used for classification, but rendered normally for comparison.
-          const nonClassificationTileset = new Cesium.Cesium3DTileset({
-            url: classificationTilesetUrl,
-            show: false,
-          });
-          nonClassificationTileset.style = new Cesium.Cesium3DTileStyle({
-            color: "rgba(255, 0, 0, 0.5)",
-          });
-          viewer.scene.primitives.add(nonClassificationTileset);
+        // The same b3dm tileset used for classification, but rendered normally for comparison.
+        const nonClassificationTileset = new Cesium.Cesium3DTileset({
+          url: classificationTilesetUrl,
+          show: false,
+        });
+        nonClassificationTileset.style = new Cesium.Cesium3DTileStyle({
+          color: "rgba(255, 0, 0, 0.5)",
+        });
+        viewer.scene.primitives.add(nonClassificationTileset);
 
-          Sandcastle.addToggleButton("Show classification", true, function (
-            checked
-          ) {
-            classificationTileset.show = checked;
-            nonClassificationTileset.show = !checked;
-          });
-        })(); //Sandcastle_End
+        Sandcastle.addToggleButton("Show classification", true, function (
+          checked
+        ) {
+          classificationTileset.show = checked;
+          nonClassificationTileset.show = !checked;
+        }); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Photogrammetry Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Photogrammetry Classification.html
@@ -76,15 +76,14 @@
           classificationTileset.show = checked;
           nonClassificationTileset.show = !checked;
         }); //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Photogrammetry.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Photogrammetry.html
@@ -33,26 +33,27 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
 
-          const tileset = new Cesium.Cesium3DTileset({
-            url: Cesium.IonResource.fromAssetId(40866),
-          });
+        const tileset = new Cesium.Cesium3DTileset({
+          url: Cesium.IonResource.fromAssetId(40866),
+        });
 
-          viewer.scene.primitives.add(tileset);
-          viewer.zoomTo(tileset);
-        })(); //Sandcastle_End
-        Sandcastle.finishedLoading();
+        viewer.scene.primitives.add(tileset);
+        viewer.zoomTo(tileset); //Sandcastle_End
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Classification.html
@@ -33,92 +33,93 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          // An example showing a point cloud tileset classified by a Geometry tileset.
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
+        // An example showing a point cloud tileset classified by a Geometry tileset.
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
 
-          //Point Cloud by Prof. Peter Allen, Columbia University Robotics Lab. Scanning by Alejandro Troccoli and Matei Ciocarlie.
-          const tileset = new Cesium.Cesium3DTileset({
-            url: Cesium.IonResource.fromAssetId(16421),
-          });
-          viewer.scene.primitives.add(tileset);
+        //Point Cloud by Prof. Peter Allen, Columbia University Robotics Lab. Scanning by Alejandro Troccoli and Matei Ciocarlie.
+        const tileset = new Cesium.Cesium3DTileset({
+          url: Cesium.IonResource.fromAssetId(16421),
+        });
+        viewer.scene.primitives.add(tileset);
 
-          // Geometry Tiles are experimental and the format is subject to change in the future.
-          // For more details, see:
-          //    https://github.com/CesiumGS/3d-tiles/tree/vctr/TileFormats/Geometry
-          const classificationTileset = new Cesium.Cesium3DTileset({
-            url:
-              "../../SampleData/Cesium3DTiles/Classification/PointCloud/tileset.json",
-            classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
-          });
-          viewer.scene.primitives.add(classificationTileset);
+        // Geometry Tiles are experimental and the format is subject to change in the future.
+        // For more details, see:
+        //    https://github.com/CesiumGS/3d-tiles/tree/vctr/TileFormats/Geometry
+        const classificationTileset = new Cesium.Cesium3DTileset({
+          url:
+            "../../SampleData/Cesium3DTiles/Classification/PointCloud/tileset.json",
+          classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
+        });
+        viewer.scene.primitives.add(classificationTileset);
 
-          classificationTileset.style = new Cesium.Cesium3DTileStyle({
-            color: {
-              conditions: [
-                ["${id} === 'roof1'", "color('#004FFF', 0.5)"],
-                ["${id} === 'towerBottom1'", "color('#33BB66', 0.5)"],
-                ["${id} === 'towerTop1'", "color('#0099AA', 0.5)"],
-                ["${id} === 'roof2'", "color('#004FFF', 0.5)"],
-                ["${id} === 'tower3'", "color('#FF8833', 0.5)"],
-                ["${id} === 'tower4'", "color('#FFAA22', 0.5)"],
-                ["true", "color('#FFFF00', 0.5)"],
-              ],
-            },
-          });
-
-          viewer.scene.camera.setView({
-            destination: new Cesium.Cartesian3(
-              4401744.644145314,
-              225051.41078911052,
-              4595420.374784433
-            ),
-            orientation: new Cesium.HeadingPitchRoll(
-              5.646733805039757,
-              -0.276607153839886,
-              6.281110875400085
-            ),
-          });
-
-          // Information about the currently highlighted feature
-          const highlighted = {
-            feature: undefined,
-            originalColor: new Cesium.Color(),
-          };
-
-          // Color a feature yellow on hover.
-          viewer.screenSpaceEventHandler.setInputAction(function onMouseMove(
-            movement
-          ) {
-            // If a feature was previously highlighted, undo the highlight
-            if (Cesium.defined(highlighted.feature)) {
-              highlighted.feature.color = highlighted.originalColor;
-              highlighted.feature = undefined;
-            }
-
-            // Pick a new feature
-            const pickedFeature = viewer.scene.pick(movement.endPosition);
-            if (!Cesium.defined(pickedFeature)) {
-              return;
-            }
-
-            // Highlight the feature
-            highlighted.feature = pickedFeature;
-            Cesium.Color.clone(pickedFeature.color, highlighted.originalColor);
-            pickedFeature.color = Cesium.Color.YELLOW.withAlpha(0.5);
+        classificationTileset.style = new Cesium.Cesium3DTileStyle({
+          color: {
+            conditions: [
+              ["${id} === 'roof1'", "color('#004FFF', 0.5)"],
+              ["${id} === 'towerBottom1'", "color('#33BB66', 0.5)"],
+              ["${id} === 'towerTop1'", "color('#0099AA', 0.5)"],
+              ["${id} === 'roof2'", "color('#004FFF', 0.5)"],
+              ["${id} === 'tower3'", "color('#FF8833', 0.5)"],
+              ["${id} === 'tower4'", "color('#FFAA22', 0.5)"],
+              ["true", "color('#FFFF00', 0.5)"],
+            ],
           },
-          Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-        })(); //Sandcastle_End
-        Sandcastle.finishedLoading();
+        });
+
+        viewer.scene.camera.setView({
+          destination: new Cesium.Cartesian3(
+            4401744.644145314,
+            225051.41078911052,
+            4595420.374784433
+          ),
+          orientation: new Cesium.HeadingPitchRoll(
+            5.646733805039757,
+            -0.276607153839886,
+            6.281110875400085
+          ),
+        });
+
+        // Information about the currently highlighted feature
+        const highlighted = {
+          feature: undefined,
+          originalColor: new Cesium.Color(),
+        };
+
+        // Color a feature yellow on hover.
+        viewer.screenSpaceEventHandler.setInputAction(function onMouseMove(
+          movement
+        ) {
+          // If a feature was previously highlighted, undo the highlight
+          if (Cesium.defined(highlighted.feature)) {
+            highlighted.feature.color = highlighted.originalColor;
+            highlighted.feature = undefined;
+          }
+
+          // Pick a new feature
+          const pickedFeature = viewer.scene.pick(movement.endPosition);
+          if (!Cesium.defined(pickedFeature)) {
+            return;
+          }
+
+          // Highlight the feature
+          highlighted.feature = pickedFeature;
+          Cesium.Color.clone(pickedFeature.color, highlighted.originalColor);
+          pickedFeature.color = Cesium.Color.YELLOW.withAlpha(0.5);
+        },
+        Cesium.ScreenSpaceEventType.MOUSE_MOVE); //Sandcastle_End
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Shading.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Shading.html
@@ -372,15 +372,14 @@
             viewModelTileset.pointCloudShading.eyeDomeLighting = checked;
           }
         }); //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Shading.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Shading.html
@@ -157,231 +157,230 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
 
-          const scene = viewer.scene;
-          let viewModelTileset;
+        const scene = viewer.scene;
+        let viewModelTileset;
 
-          if (!Cesium.PointCloudShading.isSupported(scene)) {
-            window.alert("This browser does not support point cloud shading");
-          }
+        if (!Cesium.PointCloudShading.isSupported(scene)) {
+          window.alert("This browser does not support point cloud shading");
+        }
 
-          function reset() {
-            viewer.scene.primitives.remove(viewModelTileset);
-            viewModelTileset = undefined;
-          }
+        function reset() {
+          viewer.scene.primitives.remove(viewModelTileset);
+          viewModelTileset = undefined;
+        }
 
-          // The viewModel tracks the state of our mini application.
-          const pointClouds = ["St. Helens", "Church"];
-          const viewModel = {
-            exampleTypes: pointClouds,
-            currentExampleType: pointClouds[0],
-            maximumScreenSpaceError: 16.0,
-            geometricErrorScale: 1.0,
-            maximumAttenuation: 0, // Equivalent to undefined
-            baseResolution: 0, // Equivalent to undefined
-            eyeDomeLightingStrength: 1.0,
-            eyeDomeLightingRadius: 1.0,
-          };
+        // The viewModel tracks the state of our mini application.
+        const pointClouds = ["St. Helens", "Church"];
+        const viewModel = {
+          exampleTypes: pointClouds,
+          currentExampleType: pointClouds[0],
+          maximumScreenSpaceError: 16.0,
+          geometricErrorScale: 1.0,
+          maximumAttenuation: 0, // Equivalent to undefined
+          baseResolution: 0, // Equivalent to undefined
+          eyeDomeLightingStrength: 1.0,
+          eyeDomeLightingRadius: 1.0,
+        };
 
-          function tilesetToViewModel(tileset) {
-            viewModelTileset = tileset;
+        function tilesetToViewModel(tileset) {
+          viewModelTileset = tileset;
 
-            const pointCloudShading = tileset.pointCloudShading;
-            viewModel.maximumScreenSpaceError = tileset.maximumScreenSpaceError;
-            viewModel.geometricErrorScale =
-              pointCloudShading.geometricErrorScale;
-            viewModel.maximumAttenuation = pointCloudShading.maximumAttenuation
-              ? pointCloudShading.maximumAttenuation
-              : 0;
-            viewModel.baseResolution = pointCloudShading.baseResolution
-              ? pointCloudShading.baseResolution
-              : 0;
-            viewModel.eyeDomeLightingStrength =
-              pointCloudShading.eyeDomeLightingStrength;
-            viewModel.eyeDomeLightingRadius =
-              pointCloudShading.eyeDomeLightingRadius;
-          }
+          const pointCloudShading = tileset.pointCloudShading;
+          viewModel.maximumScreenSpaceError = tileset.maximumScreenSpaceError;
+          viewModel.geometricErrorScale = pointCloudShading.geometricErrorScale;
+          viewModel.maximumAttenuation = pointCloudShading.maximumAttenuation
+            ? pointCloudShading.maximumAttenuation
+            : 0;
+          viewModel.baseResolution = pointCloudShading.baseResolution
+            ? pointCloudShading.baseResolution
+            : 0;
+          viewModel.eyeDomeLightingStrength =
+            pointCloudShading.eyeDomeLightingStrength;
+          viewModel.eyeDomeLightingRadius =
+            pointCloudShading.eyeDomeLightingRadius;
+        }
 
-          function loadStHelens() {
-            // Set the initial camera view to look at Mt. St. Helens
-            const initialPosition = Cesium.Cartesian3.fromRadians(
-              -2.1344873183780484,
-              0.8071380277370774,
-              5743.394497982162
-            );
-            const initialOrientation = new Cesium.HeadingPitchRoll.fromDegrees(
-              112.99596671210358,
-              -21.34390550872461,
-              0.0716951918898415
-            );
-            viewer.scene.camera.setView({
-              destination: initialPosition,
-              orientation: initialOrientation,
-              endTransform: Cesium.Matrix4.IDENTITY,
-            });
-
-            // Mt. St. Helens 3D Tileset generated from LAS provided by https://www.liblas.org/samples/
-            // This tileset uses replacement refinement and has geometric error approximately equal to
-            // the average interpoint distance in each tile.
-            const tileset = new Cesium.Cesium3DTileset({
-              url: Cesium.IonResource.fromAssetId(5713),
-            });
-            viewer.scene.primitives.add(tileset);
-
-            tileset.maximumScreenSpaceError = 16.0;
-            tileset.pointCloudShading.maximumAttenuation = undefined; // Will be based on maximumScreenSpaceError instead
-            tileset.pointCloudShading.baseResolution = undefined;
-            tileset.pointCloudShading.geometricErrorScale = 1.0;
-            tileset.pointCloudShading.attenuation = true;
-            tileset.pointCloudShading.eyeDomeLighting = true;
-
-            tilesetToViewModel(tileset);
-          }
-
-          function loadChurch() {
-            // Point Cloud by Prof. Peter Allen, Columbia University Robotics Lab. Scanning by Alejandro Troccoli and Matei Ciocarlie.
-            // This tileset uses additive refinement and has geometric error based on the bounding box size for each tile.
-            const tileset = new Cesium.Cesium3DTileset({
-              url: Cesium.IonResource.fromAssetId(16421),
-            });
-            viewer.scene.primitives.add(tileset);
-
-            tileset.maximumScreenSpaceError = 16.0;
-            tileset.pointCloudShading.maximumAttenuation = 4.0; // Don't allow points larger than 4 pixels.
-            tileset.pointCloudShading.baseResolution = 0.05; // Assume an original capture resolution of 5 centimeters between neighboring points.
-            tileset.pointCloudShading.geometricErrorScale = 0.5; // Applies to both geometric error and the base resolution.
-            tileset.pointCloudShading.attenuation = true;
-            tileset.pointCloudShading.eyeDomeLighting = true;
-
-            viewer.scene.camera.setView({
-              destination: new Cesium.Cartesian3(
-                4401744.644145314,
-                225051.41078911052,
-                4595420.374784433
-              ),
-              orientation: new Cesium.HeadingPitchRoll(
-                5.646733805039757,
-                -0.276607153839886,
-                6.281110875400085
-              ),
-            });
-
-            tilesetToViewModel(tileset);
-          }
-
-          function checkZero(newValue) {
-            const newValueFloat = parseFloat(newValue);
-            return newValueFloat === 0.0 ? undefined : newValueFloat;
-          }
-
-          loadStHelens();
-
-          // Convert the viewModel members into knockout observables.
-          Cesium.knockout.track(viewModel);
-
-          // Bind the viewModel to the DOM elements of the UI that call for it.
-          const toolbar = document.getElementById("toolbar");
-          Cesium.knockout.applyBindings(viewModel, toolbar);
-
-          Cesium.knockout
-            .getObservable(viewModel, "currentExampleType")
-            .subscribe(function (newValue) {
-              reset();
-              if (newValue === pointClouds[0]) {
-                loadStHelens();
-              } else if (newValue === pointClouds[1]) {
-                loadChurch();
-              }
-            });
-
-          Cesium.knockout
-            .getObservable(viewModel, "maximumScreenSpaceError")
-            .subscribe(function (newValue) {
-              if (Cesium.defined(viewModelTileset)) {
-                viewModelTileset.maximumScreenSpaceError = parseFloat(newValue);
-              }
-            });
-
-          Cesium.knockout
-            .getObservable(viewModel, "geometricErrorScale")
-            .subscribe(function (newValue) {
-              if (Cesium.defined(viewModelTileset)) {
-                viewModelTileset.pointCloudShading.geometricErrorScale = parseFloat(
-                  newValue
-                );
-              }
-            });
-
-          Cesium.knockout
-            .getObservable(viewModel, "maximumAttenuation")
-            .subscribe(function (newValue) {
-              if (Cesium.defined(viewModelTileset)) {
-                viewModelTileset.pointCloudShading.maximumAttenuation = checkZero(
-                  newValue
-                );
-              }
-            });
-
-          Cesium.knockout
-            .getObservable(viewModel, "baseResolution")
-            .subscribe(function (newValue) {
-              if (Cesium.defined(viewModelTileset)) {
-                viewModelTileset.pointCloudShading.baseResolution = checkZero(
-                  newValue
-                );
-              }
-            });
-
-          Cesium.knockout
-            .getObservable(viewModel, "eyeDomeLightingStrength")
-            .subscribe(function (newValue) {
-              if (Cesium.defined(viewModelTileset)) {
-                viewModelTileset.pointCloudShading.eyeDomeLightingStrength = parseFloat(
-                  newValue
-                );
-              }
-            });
-
-          Cesium.knockout
-            .getObservable(viewModel, "eyeDomeLightingRadius")
-            .subscribe(function (newValue) {
-              if (Cesium.defined(viewModelTileset)) {
-                viewModelTileset.pointCloudShading.eyeDomeLightingRadius = parseFloat(
-                  newValue
-                );
-              }
-            });
-
-          Sandcastle.addToggleButton("Enable Attenuation", true, function (
-            checked
-          ) {
-            if (Cesium.defined(viewModelTileset)) {
-              viewModelTileset.pointCloudShading.attenuation = checked;
-            }
-          });
-
-          Sandcastle.addToggleButton(
-            "Enable Eye Dome Lighting",
-            true,
-            function (checked) {
-              if (Cesium.defined(viewModelTileset)) {
-                viewModelTileset.pointCloudShading.eyeDomeLighting = checked;
-              }
-            }
+        function loadStHelens() {
+          // Set the initial camera view to look at Mt. St. Helens
+          const initialPosition = Cesium.Cartesian3.fromRadians(
+            -2.1344873183780484,
+            0.8071380277370774,
+            5743.394497982162
           );
-        })(); //Sandcastle_End
+          const initialOrientation = new Cesium.HeadingPitchRoll.fromDegrees(
+            112.99596671210358,
+            -21.34390550872461,
+            0.0716951918898415
+          );
+          viewer.scene.camera.setView({
+            destination: initialPosition,
+            orientation: initialOrientation,
+            endTransform: Cesium.Matrix4.IDENTITY,
+          });
+
+          // Mt. St. Helens 3D Tileset generated from LAS provided by https://www.liblas.org/samples/
+          // This tileset uses replacement refinement and has geometric error approximately equal to
+          // the average interpoint distance in each tile.
+          const tileset = new Cesium.Cesium3DTileset({
+            url: Cesium.IonResource.fromAssetId(5713),
+          });
+          viewer.scene.primitives.add(tileset);
+
+          tileset.maximumScreenSpaceError = 16.0;
+          tileset.pointCloudShading.maximumAttenuation = undefined; // Will be based on maximumScreenSpaceError instead
+          tileset.pointCloudShading.baseResolution = undefined;
+          tileset.pointCloudShading.geometricErrorScale = 1.0;
+          tileset.pointCloudShading.attenuation = true;
+          tileset.pointCloudShading.eyeDomeLighting = true;
+
+          tilesetToViewModel(tileset);
+        }
+
+        function loadChurch() {
+          // Point Cloud by Prof. Peter Allen, Columbia University Robotics Lab. Scanning by Alejandro Troccoli and Matei Ciocarlie.
+          // This tileset uses additive refinement and has geometric error based on the bounding box size for each tile.
+          const tileset = new Cesium.Cesium3DTileset({
+            url: Cesium.IonResource.fromAssetId(16421),
+          });
+          viewer.scene.primitives.add(tileset);
+
+          tileset.maximumScreenSpaceError = 16.0;
+          tileset.pointCloudShading.maximumAttenuation = 4.0; // Don't allow points larger than 4 pixels.
+          tileset.pointCloudShading.baseResolution = 0.05; // Assume an original capture resolution of 5 centimeters between neighboring points.
+          tileset.pointCloudShading.geometricErrorScale = 0.5; // Applies to both geometric error and the base resolution.
+          tileset.pointCloudShading.attenuation = true;
+          tileset.pointCloudShading.eyeDomeLighting = true;
+
+          viewer.scene.camera.setView({
+            destination: new Cesium.Cartesian3(
+              4401744.644145314,
+              225051.41078911052,
+              4595420.374784433
+            ),
+            orientation: new Cesium.HeadingPitchRoll(
+              5.646733805039757,
+              -0.276607153839886,
+              6.281110875400085
+            ),
+          });
+
+          tilesetToViewModel(tileset);
+        }
+
+        function checkZero(newValue) {
+          const newValueFloat = parseFloat(newValue);
+          return newValueFloat === 0.0 ? undefined : newValueFloat;
+        }
+
+        loadStHelens();
+
+        // Convert the viewModel members into knockout observables.
+        Cesium.knockout.track(viewModel);
+
+        // Bind the viewModel to the DOM elements of the UI that call for it.
+        const toolbar = document.getElementById("toolbar");
+        Cesium.knockout.applyBindings(viewModel, toolbar);
+
+        Cesium.knockout
+          .getObservable(viewModel, "currentExampleType")
+          .subscribe(function (newValue) {
+            reset();
+            if (newValue === pointClouds[0]) {
+              loadStHelens();
+            } else if (newValue === pointClouds[1]) {
+              loadChurch();
+            }
+          });
+
+        Cesium.knockout
+          .getObservable(viewModel, "maximumScreenSpaceError")
+          .subscribe(function (newValue) {
+            if (Cesium.defined(viewModelTileset)) {
+              viewModelTileset.maximumScreenSpaceError = parseFloat(newValue);
+            }
+          });
+
+        Cesium.knockout
+          .getObservable(viewModel, "geometricErrorScale")
+          .subscribe(function (newValue) {
+            if (Cesium.defined(viewModelTileset)) {
+              viewModelTileset.pointCloudShading.geometricErrorScale = parseFloat(
+                newValue
+              );
+            }
+          });
+
+        Cesium.knockout
+          .getObservable(viewModel, "maximumAttenuation")
+          .subscribe(function (newValue) {
+            if (Cesium.defined(viewModelTileset)) {
+              viewModelTileset.pointCloudShading.maximumAttenuation = checkZero(
+                newValue
+              );
+            }
+          });
+
+        Cesium.knockout
+          .getObservable(viewModel, "baseResolution")
+          .subscribe(function (newValue) {
+            if (Cesium.defined(viewModelTileset)) {
+              viewModelTileset.pointCloudShading.baseResolution = checkZero(
+                newValue
+              );
+            }
+          });
+
+        Cesium.knockout
+          .getObservable(viewModel, "eyeDomeLightingStrength")
+          .subscribe(function (newValue) {
+            if (Cesium.defined(viewModelTileset)) {
+              viewModelTileset.pointCloudShading.eyeDomeLightingStrength = parseFloat(
+                newValue
+              );
+            }
+          });
+
+        Cesium.knockout
+          .getObservable(viewModel, "eyeDomeLightingRadius")
+          .subscribe(function (newValue) {
+            if (Cesium.defined(viewModelTileset)) {
+              viewModelTileset.pointCloudShading.eyeDomeLightingRadius = parseFloat(
+                newValue
+              );
+            }
+          });
+
+        Sandcastle.addToggleButton("Enable Attenuation", true, function (
+          checked
+        ) {
+          if (Cesium.defined(viewModelTileset)) {
+            viewModelTileset.pointCloudShading.attenuation = checked;
+          }
+        });
+
+        Sandcastle.addToggleButton("Enable Eye Dome Lighting", true, function (
+          checked
+        ) {
+          if (Cesium.defined(viewModelTileset)) {
+            viewModelTileset.pointCloudShading.eyeDomeLighting = checked;
+          }
+        }); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
@@ -36,7 +36,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -234,11 +234,14 @@
 
         Sandcastle.addToolbarMenu(styleOptions);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud.html
@@ -33,38 +33,40 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          //Point Cloud by Prof. Peter Allen, Columbia University Robotics Lab. Scanning by Alejandro Troccoli and Matei Ciocarlie.
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
+        //Point Cloud by Prof. Peter Allen, Columbia University Robotics Lab. Scanning by Alejandro Troccoli and Matei Ciocarlie.
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
 
-          const tileset = new Cesium.Cesium3DTileset({
-            url: Cesium.IonResource.fromAssetId(16421),
-          });
-          viewer.scene.primitives.add(tileset);
+        const tileset = new Cesium.Cesium3DTileset({
+          url: Cesium.IonResource.fromAssetId(16421),
+        });
+        viewer.scene.primitives.add(tileset);
 
-          viewer.scene.camera.setView({
-            destination: new Cesium.Cartesian3(
-              4401744.644145314,
-              225051.41078911052,
-              4595420.374784433
-            ),
-            orientation: new Cesium.HeadingPitchRoll(
-              5.646733805039757,
-              -0.276607153839886,
-              6.281110875400085
-            ),
-          });
-        })(); //Sandcastle_End
+        viewer.scene.camera.setView({
+          destination: new Cesium.Cartesian3(
+            4401744.644145314,
+            225051.41078911052,
+            4595420.374784433
+          ),
+          orientation: new Cesium.HeadingPitchRoll(
+            5.646733805039757,
+            -0.276607153839886,
+            6.281110875400085
+          ),
+        }); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud.html
@@ -58,15 +58,14 @@
             6.281110875400085
           ),
         }); //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/3D Tiles Terrain Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Terrain Classification.html
@@ -33,65 +33,66 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
 
-          const geocoder = viewer.geocoder.viewModel;
-          geocoder.searchText = "Vienna";
-          geocoder.flightDuration = 0.0;
-          geocoder.search();
+        const geocoder = viewer.geocoder.viewModel;
+        geocoder.searchText = "Vienna";
+        geocoder.flightDuration = 0.0;
+        geocoder.search();
 
-          // Vector 3D Tiles are experimental and the format is subject to change in the future.
-          // For more details, see:
-          //    https://github.com/CesiumGS/3d-tiles/tree/vctr/TileFormats/VectorData
-          const tileset = new Cesium.Cesium3DTileset({
-            url: Cesium.IonResource.fromAssetId(5737),
-          });
-          viewer.scene.primitives.add(tileset);
+        // Vector 3D Tiles are experimental and the format is subject to change in the future.
+        // For more details, see:
+        //    https://github.com/CesiumGS/3d-tiles/tree/vctr/TileFormats/VectorData
+        const tileset = new Cesium.Cesium3DTileset({
+          url: Cesium.IonResource.fromAssetId(5737),
+        });
+        viewer.scene.primitives.add(tileset);
 
-          tileset.style = new Cesium.Cesium3DTileStyle({
-            color: "rgba(255, 255, 255, 0.5)",
-          });
+        tileset.style = new Cesium.Cesium3DTileStyle({
+          color: "rgba(255, 255, 255, 0.5)",
+        });
 
-          // Information about the currently highlighted feature
-          const highlighted = {
-            feature: undefined,
-            originalColor: new Cesium.Color(),
-          };
+        // Information about the currently highlighted feature
+        const highlighted = {
+          feature: undefined,
+          originalColor: new Cesium.Color(),
+        };
 
-          // Color a feature yellow on hover.
-          viewer.screenSpaceEventHandler.setInputAction(function onMouseMove(
-            movement
-          ) {
-            // If a feature was previously highlighted, undo the highlight
-            if (Cesium.defined(highlighted.feature)) {
-              highlighted.feature.color = highlighted.originalColor;
-              highlighted.feature = undefined;
-            }
+        // Color a feature yellow on hover.
+        viewer.screenSpaceEventHandler.setInputAction(function onMouseMove(
+          movement
+        ) {
+          // If a feature was previously highlighted, undo the highlight
+          if (Cesium.defined(highlighted.feature)) {
+            highlighted.feature.color = highlighted.originalColor;
+            highlighted.feature = undefined;
+          }
 
-            // Pick a new feature
-            const pickedFeature = viewer.scene.pick(movement.endPosition);
-            if (!Cesium.defined(pickedFeature)) {
-              return;
-            }
+          // Pick a new feature
+          const pickedFeature = viewer.scene.pick(movement.endPosition);
+          if (!Cesium.defined(pickedFeature)) {
+            return;
+          }
 
-            // Highlight the feature
-            highlighted.feature = pickedFeature;
-            Cesium.Color.clone(pickedFeature.color, highlighted.originalColor);
-            pickedFeature.color = Cesium.Color.YELLOW;
-          },
-          Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-        })(); //Sandcastle_End
-        Sandcastle.finishedLoading();
+          // Highlight the feature
+          highlighted.feature = pickedFeature;
+          Cesium.Color.clone(pickedFeature.color, highlighted.originalColor);
+          pickedFeature.color = Cesium.Color.YELLOW;
+        },
+        Cesium.ScreenSpaceEventType.MOUSE_MOVE); //Sandcastle_End
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Ambient Occlusion.html
+++ b/Apps/Sandcastle/gallery/Ambient Occlusion.html
@@ -203,15 +203,14 @@
         );
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Ambient Occlusion.html
+++ b/Apps/Sandcastle/gallery/Ambient Occlusion.html
@@ -110,7 +110,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -207,7 +207,11 @@
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/ArcGIS MapServer.html
+++ b/Apps/Sandcastle/gallery/ArcGIS MapServer.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -39,11 +39,14 @@
           }),
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/ArcGIS Tiled Elevation Terrain.html
+++ b/Apps/Sandcastle/gallery/ArcGIS Tiled Elevation Terrain.html
@@ -37,15 +37,14 @@
             "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
           ),
         }); //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/ArcGIS Tiled Elevation Terrain.html
+++ b/Apps/Sandcastle/gallery/ArcGIS Tiled Elevation Terrain.html
@@ -29,25 +29,23 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          try {
-            const viewer = new Cesium.Viewer("cesiumContainer", {
-              terrainProvider: await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
-                "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
-              ),
-            });
-          } catch (error) {
-            console.log(error);
-          }
-        })(); //Sandcastle_End
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
+            "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
+          ),
+        }); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/ArcticDEM.html
+++ b/Apps/Sandcastle/gallery/ArcticDEM.html
@@ -32,22 +32,16 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer");
-
-        (async () => {
-          try {
-            // High-resolution arctic terrain from the Arctic DEM project (Release 4), tiled and hosted by Cesium ion.
-            // https://www.pgc.umn.edu/data/arcticdem/
-            viewer.terrainProvider = await Cesium.CesiumTerrainProvider.fromUrl(
-              Cesium.IonResource.fromAssetId(3956)
-            );
-          } catch (error) {
-            console.log(error);
-          }
-        })();
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          // High-resolution arctic terrain from the Arctic DEM project (Release 4), tiled and hosted by Cesium ion.
+          // https://www.pgc.umn.edu/data/arcticdem/
+          terrainProvider: await Cesium.CesiumTerrainProvider.fromUrl(
+            Cesium.IonResource.fromAssetId(3956)
+          ),
+        });
 
         // Add Alaskan locations
         Sandcastle.addDefaultToolbarMenu(
@@ -124,11 +118,14 @@
           "toolbar"
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Atmosphere.html
+++ b/Apps/Sandcastle/gallery/Atmosphere.html
@@ -665,7 +665,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -1026,11 +1026,14 @@
         };
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Billboards.html
+++ b/Apps/Sandcastle/gallery/Billboards.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -362,11 +362,14 @@
           }
         };
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Bloom.html
+++ b/Apps/Sandcastle/gallery/Bloom.html
@@ -105,7 +105,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -179,11 +179,14 @@
         );
         viewer.scene.camera.lookAt(target, offset);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Blue Marble.html
+++ b/Apps/Sandcastle/gallery/Blue Marble.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Blue Marble Next Generation July, 2004 imagery from NASA
@@ -40,11 +40,14 @@
           imageryProvider: new Cesium.IonImageryProvider({ assetId: 3845 }),
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Box.html
+++ b/Apps/Sandcastle/gallery/Box.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -67,11 +67,14 @@
 
         viewer.zoomTo(viewer.entities);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/CZML 3D Tiles.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -64,11 +64,14 @@
             window.alert(error);
           });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Billboard and Label.html
+++ b/Apps/Sandcastle/gallery/CZML Billboard and Label.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -78,11 +78,14 @@
         const viewer = new Cesium.Viewer("cesiumContainer");
         viewer.dataSources.add(Cesium.CzmlDataSource.load(czml));
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Box.html
+++ b/Apps/Sandcastle/gallery/CZML Box.html
@@ -105,15 +105,14 @@
         viewer.dataSources.add(dataSourcePromise);
         viewer.zoomTo(dataSourcePromise);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Box.html
+++ b/Apps/Sandcastle/gallery/CZML Box.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -109,7 +109,11 @@
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Circles and Ellipses.html
+++ b/Apps/Sandcastle/gallery/CZML Circles and Ellipses.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -111,11 +111,14 @@
         viewer.zoomTo(dataSourcePromise);
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Colors.html
+++ b/Apps/Sandcastle/gallery/CZML Colors.html
@@ -87,15 +87,14 @@
         const dataSourcePromise = Cesium.CzmlDataSource.load(czml);
         viewer.dataSources.add(dataSourcePromise);
         viewer.zoomTo(dataSourcePromise); //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Colors.html
+++ b/Apps/Sandcastle/gallery/CZML Colors.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -91,7 +91,11 @@
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Cones and Cylinders.html
+++ b/Apps/Sandcastle/gallery/CZML Cones and Cylinders.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -89,11 +89,14 @@
         viewer.zoomTo(dataSourcePromise);
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Corridor.html
+++ b/Apps/Sandcastle/gallery/CZML Corridor.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -141,11 +141,14 @@
         viewer.zoomTo(dataSourcePromise);
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Custom Properties.html
+++ b/Apps/Sandcastle/gallery/CZML Custom Properties.html
@@ -32,7 +32,7 @@
     </div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -176,7 +176,11 @@
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Custom Properties.html
+++ b/Apps/Sandcastle/gallery/CZML Custom Properties.html
@@ -172,15 +172,14 @@
 
         viewer.dataSources.add(dataSource);
         viewer.zoomTo(dataSource); //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Model - Node Transformations.html
+++ b/Apps/Sandcastle/gallery/CZML Model - Node Transformations.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -109,11 +109,14 @@
           .catch(function (error) {
             window.alert(error);
           }); //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Model Articulations.html
+++ b/Apps/Sandcastle/gallery/CZML Model Articulations.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -94,11 +94,14 @@
             console.error(error);
           });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Model Data URL.html
+++ b/Apps/Sandcastle/gallery/CZML Model Data URL.html
@@ -172,15 +172,14 @@
           });
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Model Data URL.html
+++ b/Apps/Sandcastle/gallery/CZML Model Data URL.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const gltf = {
@@ -176,7 +176,11 @@
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Model.html
+++ b/Apps/Sandcastle/gallery/CZML Model.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -72,11 +72,14 @@
           });
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Path.html
+++ b/Apps/Sandcastle/gallery/CZML Path.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -7243,24 +7243,25 @@
           },
         ];
 
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-            baseLayerPicker: false,
-            shouldAnimate: true,
-          });
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          baseLayerPicker: false,
+          shouldAnimate: true,
+        });
 
-          const dataSource = await viewer.dataSources.add(
-            Cesium.CzmlDataSource.load(czml)
-          );
+        const dataSource = await viewer.dataSources.add(
+          Cesium.CzmlDataSource.load(czml)
+        );
 
-          viewer.trackedEntity = dataSource.entities.getById("path");
-        })(); //Sandcastle_End
-        Sandcastle.finishedLoading();
+        viewer.trackedEntity = dataSource.entities.getById("path"); //Sandcastle_End
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Point - Time Dynamic.html
+++ b/Apps/Sandcastle/gallery/CZML Point - Time Dynamic.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -87,7 +87,11 @@
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Point - Time Dynamic.html
+++ b/Apps/Sandcastle/gallery/CZML Point - Time Dynamic.html
@@ -83,15 +83,14 @@
         viewer.dataSources.add(Cesium.CzmlDataSource.load(czml));
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Point.html
+++ b/Apps/Sandcastle/gallery/CZML Point.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -64,11 +64,14 @@
         viewer.zoomTo(dataSourcePromise);
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Polygon - Interpolating References.html
+++ b/Apps/Sandcastle/gallery/CZML Polygon - Interpolating References.html
@@ -33,7 +33,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -208,11 +208,14 @@
         viewer.dataSources.add(Cesium.CzmlDataSource.load(czml));
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Polygon - Intervals, Availability.html
+++ b/Apps/Sandcastle/gallery/CZML Polygon - Intervals, Availability.html
@@ -33,7 +33,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -223,11 +223,14 @@
         viewer.dataSources.add(Cesium.CzmlDataSource.load(czml));
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Polygon.html
+++ b/Apps/Sandcastle/gallery/CZML Polygon.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -220,11 +220,14 @@
         viewer.zoomTo(dataSourcePromise);
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Polyline Volume.html
+++ b/Apps/Sandcastle/gallery/CZML Polyline Volume.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -149,11 +149,14 @@
         viewer.zoomTo(dataSourcePromise);
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Polyline.html
+++ b/Apps/Sandcastle/gallery/CZML Polyline.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -141,11 +141,14 @@
         viewer.zoomTo(dataSourcePromise);
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Position Definitions.html
+++ b/Apps/Sandcastle/gallery/CZML Position Definitions.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -107,7 +107,11 @@
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Position Definitions.html
+++ b/Apps/Sandcastle/gallery/CZML Position Definitions.html
@@ -103,15 +103,14 @@
         viewer.dataSources.add(Cesium.CzmlDataSource.load(czml));
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Rectangle.html
+++ b/Apps/Sandcastle/gallery/CZML Rectangle.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -126,11 +126,14 @@
         viewer.zoomTo(dataSourcePromise);
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Reference Properties.html
+++ b/Apps/Sandcastle/gallery/CZML Reference Properties.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -130,11 +130,14 @@
         const viewer = new Cesium.Viewer("cesiumContainer");
         viewer.dataSources.add(Cesium.CzmlDataSource.load(czml));
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Spheres and Ellipsoids.html
+++ b/Apps/Sandcastle/gallery/CZML Spheres and Ellipsoids.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -110,11 +110,14 @@
         viewer.zoomTo(dataSourcePromise);
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML Wall.html
+++ b/Apps/Sandcastle/gallery/CZML Wall.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -96,11 +96,14 @@
         viewer.zoomTo(dataSourcePromise);
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML ZIndex.html
+++ b/Apps/Sandcastle/gallery/CZML ZIndex.html
@@ -146,15 +146,14 @@
         viewer.zoomTo(dataSourcePromise);
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML ZIndex.html
+++ b/Apps/Sandcastle/gallery/CZML ZIndex.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml = [
@@ -150,7 +150,11 @@
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/CZML.html
+++ b/Apps/Sandcastle/gallery/CZML.html
@@ -33,7 +33,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -65,11 +65,14 @@
           viewer.dataSources.removeAll();
         };
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Callback Property.html
+++ b/Apps/Sandcastle/gallery/Callback Property.html
@@ -118,15 +118,14 @@
         // Keep the view centered.
         viewer.trackedEntity = label;
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Callback Property.html
+++ b/Apps/Sandcastle/gallery/Callback Property.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // This example illustrates a Callback Property, a property whose
@@ -122,7 +122,11 @@
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Camera Tutorial.html
+++ b/Apps/Sandcastle/gallery/Camera Tutorial.html
@@ -54,7 +54,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -186,11 +186,14 @@
           }
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Camera.html
+++ b/Apps/Sandcastle/gallery/Camera.html
@@ -42,7 +42,7 @@
       <div id="cameraChanged">Camera Changed</div>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -489,7 +489,11 @@
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Camera.html
+++ b/Apps/Sandcastle/gallery/Camera.html
@@ -485,15 +485,14 @@
           reset();
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Cardboard.html
+++ b/Apps/Sandcastle/gallery/Cardboard.html
@@ -32,163 +32,164 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            vrButton: true,
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
-          // Click the VR button in the bottom right of the screen to switch to VR mode.
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          vrButton: true,
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
+        // Click the VR button in the bottom right of the screen to switch to VR mode.
 
-          viewer.scene.globe.enableLighting = true;
-          viewer.scene.globe.depthTestAgainstTerrain = true;
+        viewer.scene.globe.enableLighting = true;
+        viewer.scene.globe.depthTestAgainstTerrain = true;
 
-          // Follow the path of a plane. See the interpolation Sandcastle example.
-          Cesium.Math.setRandomNumberSeed(3);
+        // Follow the path of a plane. See the interpolation Sandcastle example.
+        Cesium.Math.setRandomNumberSeed(3);
 
-          const start = Cesium.JulianDate.fromDate(new Date(2015, 2, 25, 16));
-          const stop = Cesium.JulianDate.addSeconds(
-            start,
-            360,
-            new Cesium.JulianDate()
-          );
+        const start = Cesium.JulianDate.fromDate(new Date(2015, 2, 25, 16));
+        const stop = Cesium.JulianDate.addSeconds(
+          start,
+          360,
+          new Cesium.JulianDate()
+        );
 
-          viewer.clock.startTime = start.clone();
-          viewer.clock.stopTime = stop.clone();
-          viewer.clock.currentTime = start.clone();
-          viewer.clock.clockRange = Cesium.ClockRange.LOOP_STOP;
-          viewer.clock.multiplier = 1.0;
-          viewer.clock.shouldAnimate = true;
+        viewer.clock.startTime = start.clone();
+        viewer.clock.stopTime = stop.clone();
+        viewer.clock.currentTime = start.clone();
+        viewer.clock.clockRange = Cesium.ClockRange.LOOP_STOP;
+        viewer.clock.multiplier = 1.0;
+        viewer.clock.shouldAnimate = true;
 
-          function computeCirclularFlight(lon, lat, radius) {
-            const property = new Cesium.SampledPositionProperty();
-            const startAngle = Cesium.Math.nextRandomNumber() * 360.0;
-            const endAngle = startAngle + 360.0;
+        function computeCirclularFlight(lon, lat, radius) {
+          const property = new Cesium.SampledPositionProperty();
+          const startAngle = Cesium.Math.nextRandomNumber() * 360.0;
+          const endAngle = startAngle + 360.0;
 
-            const increment =
-              (Cesium.Math.nextRandomNumber() * 2.0 - 1.0) * 10.0 + 45.0;
-            for (let i = startAngle; i < endAngle; i += increment) {
-              const radians = Cesium.Math.toRadians(i);
-              const timeIncrement = i - startAngle;
-              const time = Cesium.JulianDate.addSeconds(
-                start,
-                timeIncrement,
-                new Cesium.JulianDate()
-              );
-              const position = Cesium.Cartesian3.fromDegrees(
-                lon + radius * 1.5 * Math.cos(radians),
-                lat + radius * Math.sin(radians),
-                Cesium.Math.nextRandomNumber() * 500 + 1800
-              );
-              property.addSample(time, position);
-            }
-            return property;
+          const increment =
+            (Cesium.Math.nextRandomNumber() * 2.0 - 1.0) * 10.0 + 45.0;
+          for (let i = startAngle; i < endAngle; i += increment) {
+            const radians = Cesium.Math.toRadians(i);
+            const timeIncrement = i - startAngle;
+            const time = Cesium.JulianDate.addSeconds(
+              start,
+              timeIncrement,
+              new Cesium.JulianDate()
+            );
+            const position = Cesium.Cartesian3.fromDegrees(
+              lon + radius * 1.5 * Math.cos(radians),
+              lat + radius * Math.sin(radians),
+              Cesium.Math.nextRandomNumber() * 500 + 1800
+            );
+            property.addSample(time, position);
+          }
+          return property;
+        }
+
+        const longitude = -112.110693;
+        const latitude = 36.0994841;
+        const radius = 0.03;
+
+        const modelURI =
+          "../../SampleData/models/CesiumBalloon/CesiumBalloon.glb";
+        const entity = viewer.entities.add({
+          availability: new Cesium.TimeIntervalCollection([
+            new Cesium.TimeInterval({
+              start: start,
+              stop: stop,
+            }),
+          ]),
+          position: computeCirclularFlight(longitude, latitude, radius),
+          model: {
+            uri: modelURI,
+            minimumPixelSize: 64,
+          },
+        });
+
+        entity.position.setInterpolationOptions({
+          interpolationDegree: 2,
+          interpolationAlgorithm: Cesium.HermitePolynomialApproximation,
+        });
+
+        // Set initial camera position and orientation to be when in the model's reference frame.
+        const camera = viewer.camera;
+        camera.position = new Cesium.Cartesian3(0.25, 0.0, 0.0);
+        camera.direction = new Cesium.Cartesian3(1.0, 0.0, 0.0);
+        camera.up = new Cesium.Cartesian3(0.0, 0.0, 1.0);
+        camera.right = new Cesium.Cartesian3(0.0, -1.0, 0.0);
+
+        viewer.scene.postUpdate.addEventListener(function (scene, time) {
+          const position = entity.position.getValue(time);
+          if (!Cesium.defined(position)) {
+            return;
           }
 
-          const longitude = -112.110693;
-          const latitude = 36.0994841;
-          const radius = 0.03;
+          let transform;
+          if (!Cesium.defined(entity.orientation)) {
+            transform = Cesium.Transforms.eastNorthUpToFixedFrame(position);
+          } else {
+            const orientation = entity.orientation.getValue(time);
+            if (!Cesium.defined(orientation)) {
+              return;
+            }
 
-          const modelURI =
-            "../../SampleData/models/CesiumBalloon/CesiumBalloon.glb";
-          const entity = viewer.entities.add({
+            transform = Cesium.Matrix4.fromRotationTranslation(
+              Cesium.Matrix3.fromQuaternion(orientation),
+              position
+            );
+          }
+
+          // Save camera state
+          const offset = Cesium.Cartesian3.clone(camera.position);
+          const direction = Cesium.Cartesian3.clone(camera.direction);
+          const up = Cesium.Cartesian3.clone(camera.up);
+
+          // Set camera to be in model's reference frame.
+          camera.lookAtTransform(transform);
+
+          // Reset the camera state to the saved state so it appears fixed in the model's frame.
+          Cesium.Cartesian3.clone(offset, camera.position);
+          Cesium.Cartesian3.clone(direction, camera.direction);
+          Cesium.Cartesian3.clone(up, camera.up);
+          Cesium.Cartesian3.cross(direction, up, camera.right);
+        });
+
+        // Add a few more balloons flying with the one the viewer is in.
+        const numBalloons = 12;
+        for (let i = 0; i < numBalloons; ++i) {
+          const balloonRadius =
+            (Cesium.Math.nextRandomNumber() * 2.0 - 1.0) * 0.01 + radius;
+          const balloon = viewer.entities.add({
             availability: new Cesium.TimeIntervalCollection([
               new Cesium.TimeInterval({
                 start: start,
                 stop: stop,
               }),
             ]),
-            position: computeCirclularFlight(longitude, latitude, radius),
+            position: computeCirclularFlight(
+              longitude,
+              latitude,
+              balloonRadius
+            ),
             model: {
               uri: modelURI,
               minimumPixelSize: 64,
             },
           });
 
-          entity.position.setInterpolationOptions({
+          balloon.position.setInterpolationOptions({
             interpolationDegree: 2,
             interpolationAlgorithm: Cesium.HermitePolynomialApproximation,
           });
-
-          // Set initial camera position and orientation to be when in the model's reference frame.
-          const camera = viewer.camera;
-          camera.position = new Cesium.Cartesian3(0.25, 0.0, 0.0);
-          camera.direction = new Cesium.Cartesian3(1.0, 0.0, 0.0);
-          camera.up = new Cesium.Cartesian3(0.0, 0.0, 1.0);
-          camera.right = new Cesium.Cartesian3(0.0, -1.0, 0.0);
-
-          viewer.scene.postUpdate.addEventListener(function (scene, time) {
-            const position = entity.position.getValue(time);
-            if (!Cesium.defined(position)) {
-              return;
-            }
-
-            let transform;
-            if (!Cesium.defined(entity.orientation)) {
-              transform = Cesium.Transforms.eastNorthUpToFixedFrame(position);
-            } else {
-              const orientation = entity.orientation.getValue(time);
-              if (!Cesium.defined(orientation)) {
-                return;
-              }
-
-              transform = Cesium.Matrix4.fromRotationTranslation(
-                Cesium.Matrix3.fromQuaternion(orientation),
-                position
-              );
-            }
-
-            // Save camera state
-            const offset = Cesium.Cartesian3.clone(camera.position);
-            const direction = Cesium.Cartesian3.clone(camera.direction);
-            const up = Cesium.Cartesian3.clone(camera.up);
-
-            // Set camera to be in model's reference frame.
-            camera.lookAtTransform(transform);
-
-            // Reset the camera state to the saved state so it appears fixed in the model's frame.
-            Cesium.Cartesian3.clone(offset, camera.position);
-            Cesium.Cartesian3.clone(direction, camera.direction);
-            Cesium.Cartesian3.clone(up, camera.up);
-            Cesium.Cartesian3.cross(direction, up, camera.right);
-          });
-
-          // Add a few more balloons flying with the one the viewer is in.
-          const numBalloons = 12;
-          for (let i = 0; i < numBalloons; ++i) {
-            const balloonRadius =
-              (Cesium.Math.nextRandomNumber() * 2.0 - 1.0) * 0.01 + radius;
-            const balloon = viewer.entities.add({
-              availability: new Cesium.TimeIntervalCollection([
-                new Cesium.TimeInterval({
-                  start: start,
-                  stop: stop,
-                }),
-              ]),
-              position: computeCirclularFlight(
-                longitude,
-                latitude,
-                balloonRadius
-              ),
-              model: {
-                uri: modelURI,
-                minimumPixelSize: 64,
-              },
-            });
-
-            balloon.position.setInterpolationOptions({
-              interpolationDegree: 2,
-              interpolationAlgorithm: Cesium.HermitePolynomialApproximation,
-            });
-          }
-        })(); //Sandcastle_End
-        Sandcastle.finishedLoading();
+        } //Sandcastle_End
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Cartographic Limit Rectangle.html
+++ b/Apps/Sandcastle/gallery/Cartographic Limit Rectangle.html
@@ -89,15 +89,14 @@
             rectangleEntity.show = checked;
           }
         }); //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Cartographic Limit Rectangle.html
+++ b/Apps/Sandcastle/gallery/Cartographic Limit Rectangle.html
@@ -32,70 +32,72 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
 
-          const scene = viewer.scene;
-          const globe = scene.globe;
+        const scene = viewer.scene;
+        const globe = scene.globe;
 
-          // Tropics of Cancer and Capricorn
-          const coffeeBeltRectangle = Cesium.Rectangle.fromDegrees(
-            -180.0,
-            -23.43687,
-            180.0,
-            23.43687
+        // Tropics of Cancer and Capricorn
+        const coffeeBeltRectangle = Cesium.Rectangle.fromDegrees(
+          -180.0,
+          -23.43687,
+          180.0,
+          23.43687
+        );
+
+        globe.cartographicLimitRectangle = coffeeBeltRectangle;
+        globe.showSkirts = false;
+        globe.backFaceCulling = false;
+        globe.undergroundColor = undefined;
+        scene.skyAtmosphere.show = false;
+
+        // Add rectangles to show bounds
+        const rectangles = [];
+
+        for (let i = 0; i < 10; i++) {
+          rectangles.push(
+            viewer.entities.add({
+              rectangle: {
+                coordinates: coffeeBeltRectangle,
+                material: Cesium.Color.WHITE.withAlpha(0.0),
+                height: i * 5000.0,
+                outline: true,
+                outlineWidth: 4.0,
+                outlineColor: Cesium.Color.WHITE,
+              },
+            })
           );
+        }
 
-          globe.cartographicLimitRectangle = coffeeBeltRectangle;
-          globe.showSkirts = false;
-          globe.backFaceCulling = false;
-          globe.undergroundColor = undefined;
-          scene.skyAtmosphere.show = false;
-
-          // Add rectangles to show bounds
-          const rectangles = [];
-
-          for (let i = 0; i < 10; i++) {
-            rectangles.push(
-              viewer.entities.add({
-                rectangle: {
-                  coordinates: coffeeBeltRectangle,
-                  material: Cesium.Color.WHITE.withAlpha(0.0),
-                  height: i * 5000.0,
-                  outline: true,
-                  outlineWidth: 4.0,
-                  outlineColor: Cesium.Color.WHITE,
-                },
-              })
-            );
+        Sandcastle.addToggleButton("Limit Enabled", true, function (checked) {
+          if (checked) {
+            viewer.scene.globe.cartographicLimitRectangle = coffeeBeltRectangle;
+          } else {
+            viewer.scene.globe.cartographicLimitRectangle = undefined;
           }
+        });
 
-          Sandcastle.addToggleButton("Limit Enabled", true, function (checked) {
-            if (checked) {
-              viewer.scene.globe.cartographicLimitRectangle = coffeeBeltRectangle;
-            } else {
-              viewer.scene.globe.cartographicLimitRectangle = undefined;
-            }
-          });
-
-          Sandcastle.addToggleButton("Show Bounds", true, function (checked) {
-            const rectanglesLength = rectangles.length;
-            for (let i = 0; i < rectanglesLength; i++) {
-              const rectangleEntity = rectangles[i];
-              rectangleEntity.show = checked;
-            }
-          });
-        })(); //Sandcastle_End
+        Sandcastle.addToggleButton("Show Bounds", true, function (checked) {
+          const rectanglesLength = rectangles.length;
+          for (let i = 0; i < rectanglesLength; i++) {
+            const rectangleEntity = rectangles[i];
+            rectangleEntity.show = checked;
+          }
+        }); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Cesium Inspector.html
+++ b/Apps/Sandcastle/gallery/Cesium Inspector.html
@@ -36,91 +36,84 @@
       <div id="sampleButtons"></div>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
 
-          const scene = viewer.scene;
-          scene.globe.depthTestAgainstTerrain = true;
+        const scene = viewer.scene;
+        scene.globe.depthTestAgainstTerrain = true;
 
-          //Add Cesium Inspector
-          viewer.extend(Cesium.viewerCesiumInspectorMixin);
+        //Add Cesium Inspector
+        viewer.extend(Cesium.viewerCesiumInspectorMixin);
 
-          //Add Primitives
-          scene.primitives.add(
-            new Cesium.Primitive({
-              geometryInstances: new Cesium.GeometryInstance({
-                geometry: Cesium.BoxGeometry.fromDimensions({
-                  vertexFormat: Cesium.PerInstanceColorAppearance.VERTEX_FORMAT,
-                  dimensions: new Cesium.Cartesian3(
-                    400000.0,
-                    300000.0,
-                    500000.0
-                  ),
-                }),
-                modelMatrix: Cesium.Matrix4.multiplyByTranslation(
-                  Cesium.Transforms.eastNorthUpToFixedFrame(
-                    Cesium.Cartesian3.fromDegrees(-105.0, 45.0)
-                  ),
-                  new Cesium.Cartesian3(0.0, 0.0, 250000),
-                  new Cesium.Matrix4()
+        //Add Primitives
+        scene.primitives.add(
+          new Cesium.Primitive({
+            geometryInstances: new Cesium.GeometryInstance({
+              geometry: Cesium.BoxGeometry.fromDimensions({
+                vertexFormat: Cesium.PerInstanceColorAppearance.VERTEX_FORMAT,
+                dimensions: new Cesium.Cartesian3(400000.0, 300000.0, 500000.0),
+              }),
+              modelMatrix: Cesium.Matrix4.multiplyByTranslation(
+                Cesium.Transforms.eastNorthUpToFixedFrame(
+                  Cesium.Cartesian3.fromDegrees(-105.0, 45.0)
                 ),
-                attributes: {
-                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                    Cesium.Color.RED.withAlpha(0.5)
-                  ),
-                },
-              }),
-              appearance: new Cesium.PerInstanceColorAppearance({
-                closed: true,
-              }),
-            })
-          );
+                new Cesium.Cartesian3(0.0, 0.0, 250000),
+                new Cesium.Matrix4()
+              ),
+              attributes: {
+                color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                  Cesium.Color.RED.withAlpha(0.5)
+                ),
+              },
+            }),
+            appearance: new Cesium.PerInstanceColorAppearance({
+              closed: true,
+            }),
+          })
+        );
 
-          scene.primitives.add(
-            new Cesium.Primitive({
-              geometryInstances: new Cesium.GeometryInstance({
-                geometry: new Cesium.RectangleGeometry({
-                  rectangle: Cesium.Rectangle.fromDegrees(
-                    -100.0,
-                    30.0,
-                    -93.0,
-                    37.0
-                  ),
-                  height: 100000,
-                  vertexFormat: Cesium.PerInstanceColorAppearance.VERTEX_FORMAT,
-                }),
-                attributes: {
-                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                    Cesium.Color.BLUE
-                  ),
-                },
+        scene.primitives.add(
+          new Cesium.Primitive({
+            geometryInstances: new Cesium.GeometryInstance({
+              geometry: new Cesium.RectangleGeometry({
+                rectangle: Cesium.Rectangle.fromDegrees(
+                  -100.0,
+                  30.0,
+                  -93.0,
+                  37.0
+                ),
+                height: 100000,
+                vertexFormat: Cesium.PerInstanceColorAppearance.VERTEX_FORMAT,
               }),
-              appearance: new Cesium.PerInstanceColorAppearance(),
-            })
-          );
+              attributes: {
+                color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                  Cesium.Color.BLUE
+                ),
+              },
+            }),
+            appearance: new Cesium.PerInstanceColorAppearance(),
+          })
+        );
 
-          const billboards = scene.primitives.add(
-            new Cesium.BillboardCollection()
-          );
-          billboards.add({
-            position: Cesium.Cartesian3.fromDegrees(
-              -75.59777,
-              40.03883,
-              150000
-            ),
-            image: "../images/Cesium_Logo_overlay.png",
-          });
-        })(); //Sandcastle_End
-        Sandcastle.finishedLoading();
+        const billboards = scene.primitives.add(
+          new Cesium.BillboardCollection()
+        );
+        billboards.add({
+          position: Cesium.Cartesian3.fromDegrees(-75.59777, 40.03883, 150000),
+          image: "../images/Cesium_Logo_overlay.png",
+        }); //Sandcastle_End
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Cesium OSM Buildings.html
+++ b/Apps/Sandcastle/gallery/Cesium OSM Buildings.html
@@ -35,29 +35,30 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
 
-          viewer.scene.primitives.add(Cesium.createOsmBuildings());
+        viewer.scene.primitives.add(Cesium.createOsmBuildings());
 
-          viewer.scene.camera.flyTo({
-            destination: Cesium.Cartesian3.fromDegrees(-74.019, 40.6912, 750),
-            orientation: {
-              heading: Cesium.Math.toRadians(20),
-              pitch: Cesium.Math.toRadians(-20),
-            },
-          });
-        })(); //Sandcastle_End
-        Sandcastle.finishedLoading();
+        viewer.scene.camera.flyTo({
+          destination: Cesium.Cartesian3.fromDegrees(-74.019, 40.6912, 750),
+          orientation: {
+            heading: Cesium.Math.toRadians(20),
+            pitch: Cesium.Math.toRadians(-20),
+          },
+        }); //Sandcastle_End
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Cesium Widget.html
+++ b/Apps/Sandcastle/gallery/Cesium Widget.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Cesium.CesiumWidget is similar to Cesium.Viewer, but
@@ -42,11 +42,14 @@
         // Knockout library.
         const widget = new Cesium.CesiumWidget("cesiumContainer");
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Cesium World Terrain.html
+++ b/Apps/Sandcastle/gallery/Cesium World Terrain.html
@@ -39,15 +39,14 @@
         const viewer = new Cesium.Viewer("cesiumContainer", {
           terrainProvider: await Cesium.createWorldTerrainAsync(),
         }); //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Cesium World Terrain.html
+++ b/Apps/Sandcastle/gallery/Cesium World Terrain.html
@@ -32,24 +32,22 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // For more information on Cesium World Terrain, see https://cesium.com/platform/cesium-ion/content/cesium-world-terrain/
-        (async () => {
-          try {
-            const viewer = new Cesium.Viewer("cesiumContainer", {
-              terrainProvider: await Cesium.createWorldTerrainAsync(),
-            });
-          } catch (error) {
-            console.log(error);
-          }
-        })(); //Sandcastle_End
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        }); //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Circles and Ellipses.html
+++ b/Apps/Sandcastle/gallery/Circles and Ellipses.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -74,11 +74,14 @@
 
         viewer.zoomTo(viewer.entities);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Clamp to 3D Model.html
+++ b/Apps/Sandcastle/gallery/Clamp to 3D Model.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -108,11 +108,14 @@
         }
         viewer.trackedEntity = entity;
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Clamp to 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/Clamp to 3D Tiles.html
@@ -85,15 +85,14 @@
             entity.position = scene.clampToHeight(position, objectsToExclude);
           });
         } //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Clamp to 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/Clamp to 3D Tiles.html
@@ -32,66 +32,68 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
+        const scene = viewer.scene;
+        const clock = viewer.clock;
+
+        let entity;
+        let positionProperty;
+        const dataSourcePromise = Cesium.CzmlDataSource.load(
+          "../../SampleData/ClampToGround.czml"
+        );
+        viewer.dataSources.add(dataSourcePromise).then(function (dataSource) {
+          entity = dataSource.entities.getById("CesiumMilkTruck");
+          positionProperty = entity.position;
+        });
+
+        const tileset = scene.primitives.add(
+          new Cesium.Cesium3DTileset({
+            url: Cesium.IonResource.fromAssetId(40866),
+          })
+        );
+
+        viewer.camera.setView({
+          destination: new Cesium.Cartesian3(
+            1216403.8845586285,
+            -4736357.493351395,
+            4081299.715698949
+          ),
+          orientation: new Cesium.HeadingPitchRoll(
+            4.2892217081808806,
+            -0.4799070147502502,
+            6.279789177843313
+          ),
+          endTransform: Cesium.Matrix4.IDENTITY,
+        });
+
+        if (scene.clampToHeightSupported) {
+          tileset.initialTilesLoaded.addEventListener(start);
+        } else {
+          window.alert("This browser does not support clampToHeight.");
+        }
+
+        function start() {
+          clock.shouldAnimate = true;
+          const objectsToExclude = [entity];
+          scene.postRender.addEventListener(function () {
+            const position = positionProperty.getValue(clock.currentTime);
+            entity.position = scene.clampToHeight(position, objectsToExclude);
           });
-          const scene = viewer.scene;
-          const clock = viewer.clock;
-
-          let entity;
-          let positionProperty;
-          const dataSourcePromise = Cesium.CzmlDataSource.load(
-            "../../SampleData/ClampToGround.czml"
-          );
-          viewer.dataSources.add(dataSourcePromise).then(function (dataSource) {
-            entity = dataSource.entities.getById("CesiumMilkTruck");
-            positionProperty = entity.position;
-          });
-
-          const tileset = scene.primitives.add(
-            new Cesium.Cesium3DTileset({
-              url: Cesium.IonResource.fromAssetId(40866),
-            })
-          );
-
-          viewer.camera.setView({
-            destination: new Cesium.Cartesian3(
-              1216403.8845586285,
-              -4736357.493351395,
-              4081299.715698949
-            ),
-            orientation: new Cesium.HeadingPitchRoll(
-              4.2892217081808806,
-              -0.4799070147502502,
-              6.279789177843313
-            ),
-            endTransform: Cesium.Matrix4.IDENTITY,
-          });
-
-          if (scene.clampToHeightSupported) {
-            tileset.initialTilesLoaded.addEventListener(start);
-          } else {
-            window.alert("This browser does not support clampToHeight.");
-          }
-
-          function start() {
-            clock.shouldAnimate = true;
-            const objectsToExclude = [entity];
-            scene.postRender.addEventListener(function () {
-              const position = positionProperty.getValue(clock.currentTime);
-              entity.position = scene.clampToHeight(position, objectsToExclude);
-            });
-          }
-        })(); //Sandcastle_End
+        } //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Clamp to Terrain.html
+++ b/Apps/Sandcastle/gallery/Clamp to Terrain.html
@@ -34,19 +34,13 @@
       <div id="sampleButtons"></div>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer");
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
         viewer.scene.globe.depthTestAgainstTerrain = true;
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-          } catch (error) {
-            console.log(error);
-          }
-        })();
 
         Sandcastle.addDefaultToolbarMenu(
           [
@@ -361,11 +355,14 @@
           viewer.entities.removeAll();
         };
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Classification Types.html
+++ b/Apps/Sandcastle/gallery/Classification Types.html
@@ -32,18 +32,12 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer");
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-          } catch (error) {
-            console.log(error);
-          }
-        })();
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
 
         const tileset = new Cesium.Cesium3DTileset({
           url: Cesium.IonResource.fromAssetId(40866),
@@ -175,11 +169,14 @@
         Sandcastle.addToolbarMenu(classificationOptions);
         Sandcastle.addToolbarMenu(materialOptions);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Classification.html
+++ b/Apps/Sandcastle/gallery/Classification.html
@@ -76,317 +76,279 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
+
+        const scene = viewer.scene;
+        const camera = scene.camera;
+
+        let center = new Cesium.Cartesian3(
+          1216389.3637977627,
+          -4736323.641980423,
+          4081321.7428341154
+        );
+        let modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(center);
+        let hprRotation = Cesium.Matrix3.fromHeadingPitchRoll(
+          new Cesium.HeadingPitchRoll(2.619728786416368, 0.0, 0.0)
+        );
+        let hpr = Cesium.Matrix4.fromRotationTranslation(
+          hprRotation,
+          new Cesium.Cartesian3(0.0, 0.0, -2.0)
+        );
+        Cesium.Matrix4.multiply(modelMatrix, hpr, modelMatrix);
+
+        const buildingHighlight = scene.primitives.add(
+          new Cesium.ClassificationPrimitive({
+            geometryInstances: new Cesium.GeometryInstance({
+              geometry: Cesium.BoxGeometry.fromDimensions({
+                vertexFormat: Cesium.PerInstanceColorAppearance.VERTEX_FORMAT,
+                dimensions: new Cesium.Cartesian3(8.0, 5.0, 8.0),
+              }),
+              modelMatrix: modelMatrix,
+              attributes: {
+                color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                  new Cesium.Color(1.0, 0.0, 0.0, 0.5)
+                ),
+                show: new Cesium.ShowGeometryInstanceAttribute(true),
+              },
+              id: "volume",
+            }),
+            classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
+          })
+        );
+
+        center = new Cesium.Cartesian3(
+          1216409.0189737265,
+          -4736252.144235287,
+          4081393.6027081604
+        );
+        modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(center);
+        hprRotation = Cesium.Matrix3.fromHeadingPitchRoll(
+          new Cesium.HeadingPitchRoll(5.785339046755887, 0.0, 0.0)
+        );
+        hpr = Cesium.Matrix4.fromRotationTranslation(
+          hprRotation,
+          new Cesium.Cartesian3(0.4, 0.0, -2.0)
+        );
+        Cesium.Matrix4.multiply(modelMatrix, hpr, modelMatrix);
+
+        const treeHighlight1 = scene.primitives.add(
+          new Cesium.ClassificationPrimitive({
+            geometryInstances: new Cesium.GeometryInstance({
+              geometry: new Cesium.EllipsoidGeometry({
+                radii: new Cesium.Cartesian3(3.25, 5.0, 4.0),
+              }),
+              modelMatrix: modelMatrix,
+              attributes: {
+                color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                  Cesium.Color.fromCssColorString("#F26419").withAlpha(0.5)
+                ),
+                show: new Cesium.ShowGeometryInstanceAttribute(true),
+              },
+              id: "volume 1",
+            }),
+            classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
+          })
+        );
+
+        center = new Cesium.Cartesian3(
+          1216404.8844045496,
+          -4736255.287065536,
+          4081392.010192471
+        );
+        modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(center);
+        hprRotation = Cesium.Matrix3.fromHeadingPitchRoll(
+          new Cesium.HeadingPitchRoll(5.785339046755887, 0.0, 0.0)
+        );
+        hpr = Cesium.Matrix4.fromRotationTranslation(
+          hprRotation,
+          new Cesium.Cartesian3(-0.25, 0.0, -2.0)
+        );
+        Cesium.Matrix4.multiply(modelMatrix, hpr, modelMatrix);
+
+        const treeHighlight2 = scene.primitives.add(
+          new Cesium.ClassificationPrimitive({
+            geometryInstances: new Cesium.GeometryInstance({
+              geometry: new Cesium.EllipsoidGeometry({
+                radii: new Cesium.Cartesian3(3.25, 5.0, 4.0),
+              }),
+              modelMatrix: modelMatrix,
+              attributes: {
+                color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                  Cesium.Color.fromCssColorString("#F03A47").withAlpha(0.5)
+                ),
+                show: new Cesium.ShowGeometryInstanceAttribute(true),
+              },
+              id: "volume 2",
+            }),
+            classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
+          })
+        );
+
+        center = new Cesium.Cartesian3(
+          1216398.813990024,
+          -4736258.039875737,
+          4081387.9562678365
+        );
+        modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(center);
+        let translation = Cesium.Matrix4.fromTranslation(
+          new Cesium.Cartesian3(0.0, 0.0, -2.0)
+        );
+        Cesium.Matrix4.multiply(modelMatrix, translation, modelMatrix);
+
+        const treeHighlight3 = scene.primitives.add(
+          new Cesium.ClassificationPrimitive({
+            geometryInstances: new Cesium.GeometryInstance({
+              geometry: new Cesium.EllipsoidGeometry({
+                radii: new Cesium.Cartesian3(2.45, 2.45, 3.0),
+              }),
+              modelMatrix: modelMatrix,
+              attributes: {
+                color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                  Cesium.Color.fromCssColorString("#004FFF").withAlpha(0.5)
+                ),
+                show: new Cesium.ShowGeometryInstanceAttribute(true),
+              },
+              id: "volume 3",
+            }),
+            classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
+          })
+        );
+
+        center = new Cesium.Cartesian3(
+          1216393.6257790313,
+          -4736259.809075361,
+          4081384.4858198245
+        );
+        modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(center);
+        translation = Cesium.Matrix4.fromTranslation(
+          new Cesium.Cartesian3(0.0, 0.0, -1.0)
+        );
+        Cesium.Matrix4.multiply(modelMatrix, translation, modelMatrix);
+
+        const treeHighlight4 = scene.primitives.add(
+          new Cesium.ClassificationPrimitive({
+            geometryInstances: new Cesium.GeometryInstance({
+              geometry: new Cesium.SphereGeometry({
+                radius: 2.0,
+              }),
+              modelMatrix: modelMatrix,
+              attributes: {
+                color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                  Cesium.Color.fromCssColorString("#55DDE0").withAlpha(0.5)
+                ),
+                show: new Cesium.ShowGeometryInstanceAttribute(true),
+              },
+              id: "volume 4",
+            }),
+            classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
+          })
+        );
+
+        function highlightBuilding() {
+          camera.setView({
+            destination: new Cesium.Cartesian3(
+              1216394.1392207467,
+              -4736348.59346919,
+              4081293.9160685353
+            ),
+            orientation: {
+              heading: 0.018509338875732695,
+              pitch: -0.09272999615872646,
+            },
           });
+        }
 
-          const scene = viewer.scene;
-          const camera = scene.camera;
+        function highlightTrees() {
+          camera.setView({
+            destination: new Cesium.Cartesian3(
+              1216435.0352745096,
+              -4736283.144192113,
+              4081368.0920420634
+            ),
+            orientation: {
+              heading: 5.718380792746039,
+              pitch: -0.3087010195266797,
+            },
+          });
+        }
 
-          let center = new Cesium.Cartesian3(
-            1216389.3637977627,
-            -4736323.641980423,
-            4081321.7428341154
-          );
-          let modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(center);
-          let hprRotation = Cesium.Matrix3.fromHeadingPitchRoll(
-            new Cesium.HeadingPitchRoll(2.619728786416368, 0.0, 0.0)
-          );
-          let hpr = Cesium.Matrix4.fromRotationTranslation(
-            hprRotation,
-            new Cesium.Cartesian3(0.0, 0.0, -2.0)
-          );
-          Cesium.Matrix4.multiply(modelMatrix, hpr, modelMatrix);
-
-          const buildingHighlight = scene.primitives.add(
-            new Cesium.ClassificationPrimitive({
-              geometryInstances: new Cesium.GeometryInstance({
-                geometry: Cesium.BoxGeometry.fromDimensions({
-                  vertexFormat: Cesium.PerInstanceColorAppearance.VERTEX_FORMAT,
-                  dimensions: new Cesium.Cartesian3(8.0, 5.0, 8.0),
-                }),
-                modelMatrix: modelMatrix,
-                attributes: {
-                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                    new Cesium.Color(1.0, 0.0, 0.0, 0.5)
-                  ),
-                  show: new Cesium.ShowGeometryInstanceAttribute(true),
-                },
-                id: "volume",
-              }),
-              classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
-            })
-          );
-
-          center = new Cesium.Cartesian3(
-            1216409.0189737265,
-            -4736252.144235287,
-            4081393.6027081604
-          );
-          modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(center);
-          hprRotation = Cesium.Matrix3.fromHeadingPitchRoll(
-            new Cesium.HeadingPitchRoll(5.785339046755887, 0.0, 0.0)
-          );
-          hpr = Cesium.Matrix4.fromRotationTranslation(
-            hprRotation,
-            new Cesium.Cartesian3(0.4, 0.0, -2.0)
-          );
-          Cesium.Matrix4.multiply(modelMatrix, hpr, modelMatrix);
-
-          const treeHighlight1 = scene.primitives.add(
-            new Cesium.ClassificationPrimitive({
-              geometryInstances: new Cesium.GeometryInstance({
-                geometry: new Cesium.EllipsoidGeometry({
-                  radii: new Cesium.Cartesian3(3.25, 5.0, 4.0),
-                }),
-                modelMatrix: modelMatrix,
-                attributes: {
-                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                    Cesium.Color.fromCssColorString("#F26419").withAlpha(0.5)
-                  ),
-                  show: new Cesium.ShowGeometryInstanceAttribute(true),
-                },
-                id: "volume 1",
-              }),
-              classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
-            })
-          );
-
-          center = new Cesium.Cartesian3(
-            1216404.8844045496,
-            -4736255.287065536,
-            4081392.010192471
-          );
-          modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(center);
-          hprRotation = Cesium.Matrix3.fromHeadingPitchRoll(
-            new Cesium.HeadingPitchRoll(5.785339046755887, 0.0, 0.0)
-          );
-          hpr = Cesium.Matrix4.fromRotationTranslation(
-            hprRotation,
-            new Cesium.Cartesian3(-0.25, 0.0, -2.0)
-          );
-          Cesium.Matrix4.multiply(modelMatrix, hpr, modelMatrix);
-
-          const treeHighlight2 = scene.primitives.add(
-            new Cesium.ClassificationPrimitive({
-              geometryInstances: new Cesium.GeometryInstance({
-                geometry: new Cesium.EllipsoidGeometry({
-                  radii: new Cesium.Cartesian3(3.25, 5.0, 4.0),
-                }),
-                modelMatrix: modelMatrix,
-                attributes: {
-                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                    Cesium.Color.fromCssColorString("#F03A47").withAlpha(0.5)
-                  ),
-                  show: new Cesium.ShowGeometryInstanceAttribute(true),
-                },
-                id: "volume 2",
-              }),
-              classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
-            })
-          );
-
-          center = new Cesium.Cartesian3(
-            1216398.813990024,
-            -4736258.039875737,
-            4081387.9562678365
-          );
-          modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(center);
-          let translation = Cesium.Matrix4.fromTranslation(
-            new Cesium.Cartesian3(0.0, 0.0, -2.0)
-          );
-          Cesium.Matrix4.multiply(modelMatrix, translation, modelMatrix);
-
-          const treeHighlight3 = scene.primitives.add(
-            new Cesium.ClassificationPrimitive({
-              geometryInstances: new Cesium.GeometryInstance({
-                geometry: new Cesium.EllipsoidGeometry({
-                  radii: new Cesium.Cartesian3(2.45, 2.45, 3.0),
-                }),
-                modelMatrix: modelMatrix,
-                attributes: {
-                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                    Cesium.Color.fromCssColorString("#004FFF").withAlpha(0.5)
-                  ),
-                  show: new Cesium.ShowGeometryInstanceAttribute(true),
-                },
-                id: "volume 3",
-              }),
-              classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
-            })
-          );
-
-          center = new Cesium.Cartesian3(
-            1216393.6257790313,
-            -4736259.809075361,
-            4081384.4858198245
-          );
-          modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(center);
-          translation = Cesium.Matrix4.fromTranslation(
-            new Cesium.Cartesian3(0.0, 0.0, -1.0)
-          );
-          Cesium.Matrix4.multiply(modelMatrix, translation, modelMatrix);
-
-          const treeHighlight4 = scene.primitives.add(
-            new Cesium.ClassificationPrimitive({
-              geometryInstances: new Cesium.GeometryInstance({
-                geometry: new Cesium.SphereGeometry({
-                  radius: 2.0,
-                }),
-                modelMatrix: modelMatrix,
-                attributes: {
-                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                    Cesium.Color.fromCssColorString("#55DDE0").withAlpha(0.5)
-                  ),
-                  show: new Cesium.ShowGeometryInstanceAttribute(true),
-                },
-                id: "volume 4",
-              }),
-              classificationType: Cesium.ClassificationType.CESIUM_3D_TILE,
-            })
-          );
-
-          function highlightBuilding() {
-            camera.setView({
-              destination: new Cesium.Cartesian3(
-                1216394.1392207467,
-                -4736348.59346919,
-                4081293.9160685353
-              ),
-              orientation: {
-                heading: 0.018509338875732695,
-                pitch: -0.09272999615872646,
-              },
-            });
+        function invertClassification(checked) {
+          if (checked && !scene.invertClassificationSupported) {
+            window.alert("This browser does not support invert classification");
           }
 
-          function highlightTrees() {
-            camera.setView({
-              destination: new Cesium.Cartesian3(
-                1216435.0352745096,
-                -4736283.144192113,
-                4081368.0920420634
-              ),
-              orientation: {
-                heading: 5.718380792746039,
-                pitch: -0.3087010195266797,
-              },
-            });
-          }
+          scene.invertClassification = checked;
+          scene.invertClassificationColor = new Cesium.Color(
+            0.25,
+            0.25,
+            0.25,
+            1.0
+          );
 
-          function invertClassification(checked) {
-            if (checked && !scene.invertClassificationSupported) {
-              window.alert(
-                "This browser does not support invert classification"
-              );
+          buildingHighlight.getGeometryInstanceAttributes(
+            "volume"
+          ).show = Cesium.ShowGeometryInstanceAttribute.toValue(!checked);
+          treeHighlight1.getGeometryInstanceAttributes(
+            "volume 1"
+          ).show = Cesium.ShowGeometryInstanceAttribute.toValue(!checked);
+          treeHighlight2.getGeometryInstanceAttributes(
+            "volume 2"
+          ).show = Cesium.ShowGeometryInstanceAttribute.toValue(!checked);
+          treeHighlight3.getGeometryInstanceAttributes(
+            "volume 3"
+          ).show = Cesium.ShowGeometryInstanceAttribute.toValue(!checked);
+          treeHighlight4.getGeometryInstanceAttributes(
+            "volume 4"
+          ).show = Cesium.ShowGeometryInstanceAttribute.toValue(!checked);
+        }
+
+        function updateAlpha(value) {
+          scene.invertClassificationColor.alpha = parseFloat(value);
+        }
+
+        const tileset = new Cesium.Cesium3DTileset({
+          url: Cesium.IonResource.fromAssetId(40866),
+        });
+        scene.primitives.add(tileset);
+
+        const viewModel = {
+          inverted: viewer.scene.invertClassification,
+          invertedAlpha: viewer.scene.invertClassificationColor.alpha,
+          highlightBuilding: highlightBuilding,
+          highlightTrees: highlightTrees,
+        };
+        Cesium.knockout.track(viewModel);
+        const toolbar = document.getElementById("toolbar");
+        Cesium.knockout.applyBindings(viewModel, toolbar);
+        Cesium.knockout
+          .getObservable(viewModel, "inverted")
+          .subscribe(invertClassification);
+        Cesium.knockout
+          .getObservable(viewModel, "invertedAlpha")
+          .subscribe(updateAlpha);
+
+        highlightTrees();
+
+        let currentObjectId;
+        let currentPrimitive;
+        let currentColor;
+        let currentShow;
+        let attributes;
+
+        const handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
+        handler.setInputAction(function (movement) {
+          const pickedObject = scene.pick(movement.endPosition);
+          if (Cesium.defined(pickedObject) && Cesium.defined(pickedObject.id)) {
+            if (pickedObject.id === currentObjectId) {
+              return;
             }
 
-            scene.invertClassification = checked;
-            scene.invertClassificationColor = new Cesium.Color(
-              0.25,
-              0.25,
-              0.25,
-              1.0
-            );
-
-            buildingHighlight.getGeometryInstanceAttributes(
-              "volume"
-            ).show = Cesium.ShowGeometryInstanceAttribute.toValue(!checked);
-            treeHighlight1.getGeometryInstanceAttributes(
-              "volume 1"
-            ).show = Cesium.ShowGeometryInstanceAttribute.toValue(!checked);
-            treeHighlight2.getGeometryInstanceAttributes(
-              "volume 2"
-            ).show = Cesium.ShowGeometryInstanceAttribute.toValue(!checked);
-            treeHighlight3.getGeometryInstanceAttributes(
-              "volume 3"
-            ).show = Cesium.ShowGeometryInstanceAttribute.toValue(!checked);
-            treeHighlight4.getGeometryInstanceAttributes(
-              "volume 4"
-            ).show = Cesium.ShowGeometryInstanceAttribute.toValue(!checked);
-          }
-
-          function updateAlpha(value) {
-            scene.invertClassificationColor.alpha = parseFloat(value);
-          }
-
-          const tileset = new Cesium.Cesium3DTileset({
-            url: Cesium.IonResource.fromAssetId(40866),
-          });
-          scene.primitives.add(tileset);
-
-          const viewModel = {
-            inverted: viewer.scene.invertClassification,
-            invertedAlpha: viewer.scene.invertClassificationColor.alpha,
-            highlightBuilding: highlightBuilding,
-            highlightTrees: highlightTrees,
-          };
-          Cesium.knockout.track(viewModel);
-          const toolbar = document.getElementById("toolbar");
-          Cesium.knockout.applyBindings(viewModel, toolbar);
-          Cesium.knockout
-            .getObservable(viewModel, "inverted")
-            .subscribe(invertClassification);
-          Cesium.knockout
-            .getObservable(viewModel, "invertedAlpha")
-            .subscribe(updateAlpha);
-
-          highlightTrees();
-
-          let currentObjectId;
-          let currentPrimitive;
-          let currentColor;
-          let currentShow;
-          let attributes;
-
-          const handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
-          handler.setInputAction(function (movement) {
-            const pickedObject = scene.pick(movement.endPosition);
-            if (
-              Cesium.defined(pickedObject) &&
-              Cesium.defined(pickedObject.id)
-            ) {
-              if (pickedObject.id === currentObjectId) {
-                return;
-              }
-
-              if (Cesium.defined(currentObjectId)) {
-                attributes = currentPrimitive.getGeometryInstanceAttributes(
-                  currentObjectId
-                );
-                attributes.color = currentColor;
-                attributes.show = currentShow;
-                currentObjectId = undefined;
-                currentPrimitive = undefined;
-                currentColor = undefined;
-                currentShow = undefined;
-              }
-            }
-
-            if (
-              Cesium.defined(pickedObject) &&
-              Cesium.defined(pickedObject.primitive) &&
-              Cesium.defined(pickedObject.id) &&
-              Cesium.defined(
-                pickedObject.primitive.getGeometryInstanceAttributes
-              )
-            ) {
-              currentObjectId = pickedObject.id;
-              currentPrimitive = pickedObject.primitive;
-              attributes = currentPrimitive.getGeometryInstanceAttributes(
-                currentObjectId
-              );
-              currentColor = attributes.color;
-              currentShow = attributes.show;
-              if (!scene.invertClassification) {
-                attributes.color = [255, 0, 255, 128];
-              }
-              attributes.show = [1];
-            } else if (Cesium.defined(currentObjectId)) {
+            if (Cesium.defined(currentObjectId)) {
               attributes = currentPrimitive.getGeometryInstanceAttributes(
                 currentObjectId
               );
@@ -395,14 +357,46 @@
               currentObjectId = undefined;
               currentPrimitive = undefined;
               currentColor = undefined;
+              currentShow = undefined;
             }
-          }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-        })(); //Sandcastle_End
-        Sandcastle.finishedLoading();
+          }
+
+          if (
+            Cesium.defined(pickedObject) &&
+            Cesium.defined(pickedObject.primitive) &&
+            Cesium.defined(pickedObject.id) &&
+            Cesium.defined(pickedObject.primitive.getGeometryInstanceAttributes)
+          ) {
+            currentObjectId = pickedObject.id;
+            currentPrimitive = pickedObject.primitive;
+            attributes = currentPrimitive.getGeometryInstanceAttributes(
+              currentObjectId
+            );
+            currentColor = attributes.color;
+            currentShow = attributes.show;
+            if (!scene.invertClassification) {
+              attributes.color = [255, 0, 255, 128];
+            }
+            attributes.show = [1];
+          } else if (Cesium.defined(currentObjectId)) {
+            attributes = currentPrimitive.getGeometryInstanceAttributes(
+              currentObjectId
+            );
+            attributes.color = currentColor;
+            attributes.show = currentShow;
+            currentObjectId = undefined;
+            currentPrimitive = undefined;
+            currentColor = undefined;
+          }
+        }, Cesium.ScreenSpaceEventType.MOUSE_MOVE); //Sandcastle_End
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Clock.html
+++ b/Apps/Sandcastle/gallery/Clock.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create a clock that loops on Christmas day 2013 and runs in 4000x real time.
@@ -66,7 +66,11 @@
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Clock.html
+++ b/Apps/Sandcastle/gallery/Clock.html
@@ -62,15 +62,13 @@
         Sandcastle.addToolbarButton("Speed Up Clock", function () {
           viewer.clockViewModel.multiplier *= 2;
         }); //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Cloud Parameters.html
+++ b/Apps/Sandcastle/gallery/Cloud Parameters.html
@@ -159,7 +159,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -310,11 +310,14 @@
         viewer.camera.lookAt(position, new Cesium.Cartesian3(30, 30, -10));
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Clouds.html
+++ b/Apps/Sandcastle/gallery/Clouds.html
@@ -267,15 +267,14 @@
         });
 
         scene.fog.density = 1.15e-4; //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Clouds.html
+++ b/Apps/Sandcastle/gallery/Clouds.html
@@ -29,251 +29,253 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-            infoBox: false,
-            shouldAnimate: true,
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          infoBox: false,
+          shouldAnimate: true,
+        });
+
+        const scene = viewer.scene;
+        scene.primitives.add(Cesium.createOsmBuildings());
+
+        ///////////////////////////
+        // Create clouds
+        ///////////////////////////
+
+        Cesium.Math.setRandomNumberSeed(2.5);
+        function getRandomNumberInRange(minValue, maxValue) {
+          return (
+            minValue + Cesium.Math.nextRandomNumber() * (maxValue - minValue)
+          );
+        }
+
+        const clouds = new Cesium.CloudCollection();
+
+        // manually position clouds in the mountains
+        function createBackLayerClouds() {
+          clouds.add({
+            position: Cesium.Cartesian3.fromDegrees(-122.6908, 45.496, 300),
+            scale: new Cesium.Cartesian2(1500, 250),
+            maximumSize: new Cesium.Cartesian3(50, 15, 13),
+            slice: 0.3,
           });
 
-          const scene = viewer.scene;
-          scene.primitives.add(Cesium.createOsmBuildings());
+          clouds.add({
+            position: Cesium.Cartesian3.fromDegrees(-122.72, 45.5, 335),
+            scale: new Cesium.Cartesian2(1500, 300),
+            maximumSize: new Cesium.Cartesian3(50, 12, 15),
+            slice: 0.36,
+          });
 
-          ///////////////////////////
-          // Create clouds
-          ///////////////////////////
+          clouds.add({
+            position: Cesium.Cartesian3.fromDegrees(-122.72, 45.51, 260),
+            scale: new Cesium.Cartesian2(2000, 300),
+            maximumSize: new Cesium.Cartesian3(50, 12, 15),
+            slice: 0.49,
+          });
 
-          Cesium.Math.setRandomNumberSeed(2.5);
-          function getRandomNumberInRange(minValue, maxValue) {
-            return (
-              minValue + Cesium.Math.nextRandomNumber() * (maxValue - minValue)
-            );
-          }
+          clouds.add({
+            position: Cesium.Cartesian3.fromDegrees(-122.705, 45.52, 250),
+            scale: new Cesium.Cartesian2(230, 110),
+            maximumSize: new Cesium.Cartesian3(13, 13, 13),
+            slice: 0.2,
+          });
 
-          const clouds = new Cesium.CloudCollection();
+          clouds.add({
+            position: Cesium.Cartesian3.fromDegrees(-122.71, 45.522, 270),
+            scale: new Cesium.Cartesian2(1700, 300),
+            maximumSize: new Cesium.Cartesian3(50, 12, 15),
+            slice: 0.6,
+          });
 
-          // manually position clouds in the mountains
-          function createBackLayerClouds() {
+          clouds.add({
+            position: Cesium.Cartesian3.fromDegrees(-122.705, 45.525, 250),
+            scale: new Cesium.Cartesian2(230, 110),
+            maximumSize: new Cesium.Cartesian3(15, 13, 15),
+            slice: 0.35,
+          });
+
+          clouds.add({
+            position: Cesium.Cartesian3.fromDegrees(-122.721, 45.53, 220),
+            scale: new Cesium.Cartesian2(1500, 500),
+            maximumSize: new Cesium.Cartesian3(30, 20, 17),
+            slice: 0.45,
+          });
+        }
+
+        let long,
+          lat,
+          height,
+          scaleX,
+          scaleY,
+          aspectRatio,
+          cloudHeight,
+          depth,
+          slice;
+
+        // randomly generate clouds in a certain area
+        function createRandomClouds(
+          numClouds,
+          startLong,
+          stopLong,
+          startLat,
+          stopLat,
+          minHeight,
+          maxHeight
+        ) {
+          const rangeLong = stopLong - startLong;
+          const rangeLat = stopLat - startLat;
+          for (let i = 0; i < numClouds; i++) {
+            long = startLong + getRandomNumberInRange(0, rangeLong);
+            lat = startLat + getRandomNumberInRange(0, rangeLat);
+            height = getRandomNumberInRange(minHeight, maxHeight);
+            scaleX = getRandomNumberInRange(150, 350);
+            scaleY = scaleX / 2.0 - getRandomNumberInRange(0, scaleX / 4.0);
+            slice = getRandomNumberInRange(0.3, 0.7);
+            depth = getRandomNumberInRange(5, 20);
+            aspectRatio = getRandomNumberInRange(1.5, 2.1);
+            cloudHeight = getRandomNumberInRange(5, 20);
             clouds.add({
-              position: Cesium.Cartesian3.fromDegrees(-122.6908, 45.496, 300),
-              scale: new Cesium.Cartesian2(1500, 250),
-              maximumSize: new Cesium.Cartesian3(50, 15, 13),
-              slice: 0.3,
-            });
-
-            clouds.add({
-              position: Cesium.Cartesian3.fromDegrees(-122.72, 45.5, 335),
-              scale: new Cesium.Cartesian2(1500, 300),
-              maximumSize: new Cesium.Cartesian3(50, 12, 15),
-              slice: 0.36,
-            });
-
-            clouds.add({
-              position: Cesium.Cartesian3.fromDegrees(-122.72, 45.51, 260),
-              scale: new Cesium.Cartesian2(2000, 300),
-              maximumSize: new Cesium.Cartesian3(50, 12, 15),
-              slice: 0.49,
-            });
-
-            clouds.add({
-              position: Cesium.Cartesian3.fromDegrees(-122.705, 45.52, 250),
-              scale: new Cesium.Cartesian2(230, 110),
-              maximumSize: new Cesium.Cartesian3(13, 13, 13),
-              slice: 0.2,
-            });
-
-            clouds.add({
-              position: Cesium.Cartesian3.fromDegrees(-122.71, 45.522, 270),
-              scale: new Cesium.Cartesian2(1700, 300),
-              maximumSize: new Cesium.Cartesian3(50, 12, 15),
-              slice: 0.6,
-            });
-
-            clouds.add({
-              position: Cesium.Cartesian3.fromDegrees(-122.705, 45.525, 250),
-              scale: new Cesium.Cartesian2(230, 110),
-              maximumSize: new Cesium.Cartesian3(15, 13, 15),
-              slice: 0.35,
-            });
-
-            clouds.add({
-              position: Cesium.Cartesian3.fromDegrees(-122.721, 45.53, 220),
-              scale: new Cesium.Cartesian2(1500, 500),
-              maximumSize: new Cesium.Cartesian3(30, 20, 17),
-              slice: 0.45,
-            });
-          }
-
-          let long,
-            lat,
-            height,
-            scaleX,
-            scaleY,
-            aspectRatio,
-            cloudHeight,
-            depth,
-            slice;
-
-          // randomly generate clouds in a certain area
-          function createRandomClouds(
-            numClouds,
-            startLong,
-            stopLong,
-            startLat,
-            stopLat,
-            minHeight,
-            maxHeight
-          ) {
-            const rangeLong = stopLong - startLong;
-            const rangeLat = stopLat - startLat;
-            for (let i = 0; i < numClouds; i++) {
-              long = startLong + getRandomNumberInRange(0, rangeLong);
-              lat = startLat + getRandomNumberInRange(0, rangeLat);
-              height = getRandomNumberInRange(minHeight, maxHeight);
-              scaleX = getRandomNumberInRange(150, 350);
-              scaleY = scaleX / 2.0 - getRandomNumberInRange(0, scaleX / 4.0);
-              slice = getRandomNumberInRange(0.3, 0.7);
-              depth = getRandomNumberInRange(5, 20);
-              aspectRatio = getRandomNumberInRange(1.5, 2.1);
-              cloudHeight = getRandomNumberInRange(5, 20);
-              clouds.add({
-                position: Cesium.Cartesian3.fromDegrees(long, lat, height),
-                scale: new Cesium.Cartesian2(scaleX, scaleY),
-                maximumSize: new Cesium.Cartesian3(
-                  aspectRatio * cloudHeight,
-                  cloudHeight,
-                  depth
-                ),
-                slice: slice,
-              });
-            }
-          }
-
-          // manually position clouds in front
-          const scratch = new Cesium.Cartesian3();
-          function createFrontLayerClouds() {
-            clouds.add({
-              position: Cesium.Cartesian3.fromDegrees(-122.666, 45.5126, 97),
-              scale: new Cesium.Cartesian2(400, 150),
-              maximumSize: new Cesium.Cartesian3(25, 12, 15),
-              slice: 0.36,
-            });
-
-            clouds.add({
-              position: Cesium.Cartesian3.fromDegrees(-122.6665, 45.5262, 76),
-              scale: new Cesium.Cartesian2(450, 200),
-              maximumSize: new Cesium.Cartesian3(25, 14, 12),
-              slice: 0.3,
+              position: Cesium.Cartesian3.fromDegrees(long, lat, height),
+              scale: new Cesium.Cartesian2(scaleX, scaleY),
+              maximumSize: new Cesium.Cartesian3(
+                aspectRatio * cloudHeight,
+                cloudHeight,
+                depth
+              ),
+              slice: slice,
             });
           }
+        }
 
-          createBackLayerClouds();
-          createRandomClouds(8, -122.685, -122.67, 45.51, 45.525, 50, 250);
-          createFrontLayerClouds();
+        // manually position clouds in front
+        const scratch = new Cesium.Cartesian3();
+        function createFrontLayerClouds() {
+          clouds.add({
+            position: Cesium.Cartesian3.fromDegrees(-122.666, 45.5126, 97),
+            scale: new Cesium.Cartesian2(400, 150),
+            maximumSize: new Cesium.Cartesian3(25, 12, 15),
+            slice: 0.36,
+          });
 
-          scene.primitives.add(clouds);
+          clouds.add({
+            position: Cesium.Cartesian3.fromDegrees(-122.6665, 45.5262, 76),
+            scale: new Cesium.Cartesian2(450, 200),
+            maximumSize: new Cesium.Cartesian3(25, 14, 12),
+            slice: 0.3,
+          });
+        }
 
-          ///////////////////////////
-          // Create hot air balloons
-          ///////////////////////////
+        createBackLayerClouds();
+        createRandomClouds(8, -122.685, -122.67, 45.51, 45.525, 50, 250);
+        createFrontLayerClouds();
 
-          const start = Cesium.JulianDate.fromDate(new Date(2021, 7, 21, 12));
-          const stop = Cesium.JulianDate.addSeconds(
-            start,
-            90,
+        scene.primitives.add(clouds);
+
+        ///////////////////////////
+        // Create hot air balloons
+        ///////////////////////////
+
+        const start = Cesium.JulianDate.fromDate(new Date(2021, 7, 21, 12));
+        const stop = Cesium.JulianDate.addSeconds(
+          start,
+          90,
+          new Cesium.JulianDate()
+        );
+
+        function computeBalloonFlight(long, lat, height0, height1) {
+          const property = new Cesium.SampledPositionProperty();
+          const time0 = start.clone();
+          const time1 = Cesium.JulianDate.addSeconds(
+            time0,
+            30,
+            new Cesium.JulianDate()
+          );
+          const time2 = Cesium.JulianDate.addSeconds(
+            time1,
+            15,
+            new Cesium.JulianDate()
+          );
+          const time3 = Cesium.JulianDate.addSeconds(
+            time2,
+            30,
+            new Cesium.JulianDate()
+          );
+          const time4 = Cesium.JulianDate.addSeconds(
+            time3,
+            15,
             new Cesium.JulianDate()
           );
 
-          function computeBalloonFlight(long, lat, height0, height1) {
-            const property = new Cesium.SampledPositionProperty();
-            const time0 = start.clone();
-            const time1 = Cesium.JulianDate.addSeconds(
-              time0,
-              30,
-              new Cesium.JulianDate()
-            );
-            const time2 = Cesium.JulianDate.addSeconds(
-              time1,
-              15,
-              new Cesium.JulianDate()
-            );
-            const time3 = Cesium.JulianDate.addSeconds(
-              time2,
-              30,
-              new Cesium.JulianDate()
-            );
-            const time4 = Cesium.JulianDate.addSeconds(
-              time3,
-              15,
-              new Cesium.JulianDate()
-            );
+          const position0 = Cesium.Cartesian3.fromDegrees(long, lat, height0);
+          const position1 = Cesium.Cartesian3.fromDegrees(long, lat, height1);
 
-            const position0 = Cesium.Cartesian3.fromDegrees(long, lat, height0);
-            const position1 = Cesium.Cartesian3.fromDegrees(long, lat, height1);
+          property.addSample(time0, position0);
+          property.addSample(time1, position1);
+          property.addSample(time2, position1);
+          property.addSample(time3, position0);
+          property.addSample(time4, position0);
 
-            property.addSample(time0, position0);
-            property.addSample(time1, position1);
-            property.addSample(time2, position1);
-            property.addSample(time3, position0);
-            property.addSample(time4, position0);
+          return property;
+        }
 
-            return property;
-          }
+        const balloon0 = viewer.entities.add({
+          position: computeBalloonFlight(-122.661, 45.524, 400, 500),
+          model: {
+            uri: "../../SampleData/models/CesiumBalloon/CesiumBalloon.glb",
+            mininumPixelSize: 128,
+            maximumScale: 20000,
+          },
+        });
 
-          const balloon0 = viewer.entities.add({
-            position: computeBalloonFlight(-122.661, 45.524, 400, 500),
-            model: {
-              uri: "../../SampleData/models/CesiumBalloon/CesiumBalloon.glb",
-              mininumPixelSize: 128,
-              maximumScale: 20000,
-            },
-          });
+        balloon0.position.setInterpolationOptions({
+          interpolationDegree: 2,
+          interpolationAlgorithm: Cesium.HermitePolynomialApproximation,
+        });
 
-          balloon0.position.setInterpolationOptions({
-            interpolationDegree: 2,
-            interpolationAlgorithm: Cesium.HermitePolynomialApproximation,
-          });
+        const balloon1 = viewer.entities.add({
+          position: computeBalloonFlight(-122.662, 45.517, 400, 300),
+          model: {
+            uri: "../../SampleData/models/CesiumBalloon/CesiumBalloon.glb",
+            mininumPixelSize: 128,
+            maximumScale: 20000,
+          },
+        });
 
-          const balloon1 = viewer.entities.add({
-            position: computeBalloonFlight(-122.662, 45.517, 400, 300),
-            model: {
-              uri: "../../SampleData/models/CesiumBalloon/CesiumBalloon.glb",
-              mininumPixelSize: 128,
-              maximumScale: 20000,
-            },
-          });
+        balloon1.position.setInterpolationOptions({
+          interpolationDegree: 2,
+          interpolationAlgorithm: Cesium.HermitePolynomialApproximation,
+        });
 
-          balloon1.position.setInterpolationOptions({
-            interpolationDegree: 2,
-            interpolationAlgorithm: Cesium.HermitePolynomialApproximation,
-          });
+        viewer.clock.startTime = start.clone();
+        viewer.clock.stopTime = stop.clone();
+        viewer.clock.currentTime = start.clone();
+        viewer.clock.clockRange = Cesium.ClockRange.LOOP_STOP;
+        viewer.clock.multiplier = 1.0;
 
-          viewer.clock.startTime = start.clone();
-          viewer.clock.stopTime = stop.clone();
-          viewer.clock.currentTime = start.clone();
-          viewer.clock.clockRange = Cesium.ClockRange.LOOP_STOP;
-          viewer.clock.multiplier = 1.0;
+        // Fly to Portland
+        scene.camera.flyTo({
+          destination: Cesium.Cartesian3.fromDegrees(-122.6515, 45.5252, 525),
+          orientation: {
+            heading: Cesium.Math.toRadians(-115),
+            pitch: Cesium.Math.toRadians(-12),
+            roll: 0.0,
+          },
+        });
 
-          // Fly to Portland
-          scene.camera.flyTo({
-            destination: Cesium.Cartesian3.fromDegrees(-122.6515, 45.5252, 525),
-            orientation: {
-              heading: Cesium.Math.toRadians(-115),
-              pitch: Cesium.Math.toRadians(-12),
-              roll: 0.0,
-            },
-          });
-
-          scene.fog.density = 1.15e-4;
-        })(); //Sandcastle_End
+        scene.fog.density = 1.15e-4; //Sandcastle_End
         Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Clustering.html
+++ b/Apps/Sandcastle/gallery/Clustering.html
@@ -74,7 +74,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -210,11 +210,14 @@
           }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Corridor.html
+++ b/Apps/Sandcastle/gallery/Corridor.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -92,11 +92,14 @@
 
         viewer.zoomTo(viewer.entities);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Custom DataSource.html
+++ b/Apps/Sandcastle/gallery/Custom DataSource.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         /**
@@ -402,11 +402,14 @@
         viewer.dataSources.add(dataSource);
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Custom Geocoder.html
+++ b/Apps/Sandcastle/gallery/Custom Geocoder.html
@@ -42,7 +42,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         /**
@@ -94,7 +94,11 @@
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Custom Geocoder.html
+++ b/Apps/Sandcastle/gallery/Custom Geocoder.html
@@ -90,15 +90,14 @@
         });
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Custom Per-Feature Post Process.html
+++ b/Apps/Sandcastle/gallery/Custom Per-Feature Post Process.html
@@ -35,7 +35,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -95,11 +95,14 @@
         }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Custom Post Process.html
+++ b/Apps/Sandcastle/gallery/Custom Post Process.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -82,7 +82,11 @@
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Custom Post Process.html
+++ b/Apps/Sandcastle/gallery/Custom Post Process.html
@@ -78,15 +78,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Custom Shaders 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/Custom Shaders 3D Tiles.html
@@ -39,7 +39,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -76,11 +76,14 @@
         });
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Custom Shaders Models.html
+++ b/Apps/Sandcastle/gallery/Custom Shaders Models.html
@@ -39,7 +39,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -476,11 +476,14 @@
         }, Cesium.ScreenSpaceEventType.LEFT_UP);
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Custom Shaders Property Textures.html
+++ b/Apps/Sandcastle/gallery/Custom Shaders Property Textures.html
@@ -39,20 +39,13 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer");
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
         const scene = viewer.scene;
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-          } catch (error) {
-            console.log(error);
-          }
-        })();
-
         scene.globe.depthTestAgainstTerrain = false;
 
         // MAXAR OWT Muscatatuk photogrammetry dataset with property textures
@@ -124,11 +117,14 @@
           },
         ]);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Cylinders and Cones.html
+++ b/Apps/Sandcastle/gallery/Cylinders and Cones.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -60,11 +60,14 @@
 
         viewer.zoomTo(viewer.entities);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/DataSource Ordering.html
+++ b/Apps/Sandcastle/gallery/DataSource Ordering.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const czml1 = [
@@ -128,11 +128,14 @@
             }
           });
         }); //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Depth of Field.html
+++ b/Apps/Sandcastle/gallery/Depth of Field.html
@@ -89,7 +89,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -170,11 +170,14 @@
         );
         viewer.scene.camera.lookAt(target, offset);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Distance Display Conditions.html
+++ b/Apps/Sandcastle/gallery/Distance Display Conditions.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -122,11 +122,14 @@
         };
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Drawing on Terrain.html
+++ b/Apps/Sandcastle/gallery/Drawing on Terrain.html
@@ -43,21 +43,14 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
           selectionIndicator: false,
           infoBox: false,
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
         });
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-          } catch (error) {
-            console.log(error);
-          }
-        })();
 
         viewer.cesiumWidget.screenSpaceEventHandler.removeInputAction(
           Cesium.ScreenSpaceEventType.LEFT_DOUBLE_CLICK
@@ -179,11 +172,14 @@
         );
         viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Earth at Night.html
+++ b/Apps/Sandcastle/gallery/Earth at Night.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // The Earth at Night, also known as Black Marble 2017 and Night Lights
@@ -74,11 +74,14 @@
           }
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Elevation Band Material.html
+++ b/Apps/Sandcastle/gallery/Elevation Band Material.html
@@ -115,228 +115,214 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync({
-              requestVertexNormals: true, //Needed to visualize slope
-            }),
-          });
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync({
+            requestVertexNormals: true, //Needed to visualize slope
+          }),
+        });
 
-          viewer.camera.setView({
-            destination: new Cesium.Cartesian3(
-              290637.5534733206,
-              5637471.593707632,
-              2978256.8126927214
-            ),
-            orientation: {
-              heading: 4.747266966349747,
-              pitch: -0.2206998858596192,
-              roll: 6.280340554587955,
-            },
-          });
+        viewer.camera.setView({
+          destination: new Cesium.Cartesian3(
+            290637.5534733206,
+            5637471.593707632,
+            2978256.8126927214
+          ),
+          orientation: {
+            heading: 4.747266966349747,
+            pitch: -0.2206998858596192,
+            roll: 6.280340554587955,
+          },
+        });
 
-          const viewModel = {
-            gradient: false,
-            band1Position: 7000.0,
-            band2Position: 7500.0,
-            band3Position: 8000.0,
-            bandThickness: 100.0,
-            bandTransparency: 0.5,
-            backgroundTransparency: 0.75,
-          };
+        const viewModel = {
+          gradient: false,
+          band1Position: 7000.0,
+          band2Position: 7500.0,
+          band3Position: 8000.0,
+          bandThickness: 100.0,
+          bandTransparency: 0.5,
+          backgroundTransparency: 0.75,
+        };
 
-          Cesium.knockout.track(viewModel);
-          const toolbar = document.getElementById("toolbar");
-          Cesium.knockout.applyBindings(viewModel, toolbar);
-          for (const name in viewModel) {
-            if (viewModel.hasOwnProperty(name)) {
-              Cesium.knockout
-                .getObservable(viewModel, name)
-                .subscribe(updateMaterial);
-            }
+        Cesium.knockout.track(viewModel);
+        const toolbar = document.getElementById("toolbar");
+        Cesium.knockout.applyBindings(viewModel, toolbar);
+        for (const name in viewModel) {
+          if (viewModel.hasOwnProperty(name)) {
+            Cesium.knockout
+              .getObservable(viewModel, name)
+              .subscribe(updateMaterial);
           }
+        }
 
-          function updateMaterial() {
-            const gradient = Boolean(viewModel.gradient);
-            const band1Position = Number(viewModel.band1Position);
-            const band2Position = Number(viewModel.band2Position);
-            const band3Position = Number(viewModel.band3Position);
-            const bandThickness = Number(viewModel.bandThickness);
-            const bandTransparency = Number(viewModel.bandTransparency);
-            const backgroundTransparency = Number(
-              viewModel.backgroundTransparency
+        function updateMaterial() {
+          const gradient = Boolean(viewModel.gradient);
+          const band1Position = Number(viewModel.band1Position);
+          const band2Position = Number(viewModel.band2Position);
+          const band3Position = Number(viewModel.band3Position);
+          const bandThickness = Number(viewModel.bandThickness);
+          const bandTransparency = Number(viewModel.bandTransparency);
+          const backgroundTransparency = Number(
+            viewModel.backgroundTransparency
+          );
+
+          const layers = [];
+          const backgroundLayer = {
+            entries: [
+              {
+                height: 4200.0,
+                color: new Cesium.Color(0.0, 0.0, 0.2, backgroundTransparency),
+              },
+              {
+                height: 8000.0,
+                color: new Cesium.Color(1.0, 1.0, 1.0, backgroundTransparency),
+              },
+              {
+                height: 8500.0,
+                color: new Cesium.Color(1.0, 0.0, 0.0, backgroundTransparency),
+              },
+            ],
+            extendDownwards: true,
+            extendUpwards: true,
+          };
+          layers.push(backgroundLayer);
+
+          const gridStartHeight = 4200.0;
+          const gridEndHeight = 8848.0;
+          const gridCount = 50;
+          for (let i = 0; i < gridCount; i++) {
+            const lerper = i / (gridCount - 1);
+            const heightBelow = Cesium.Math.lerp(
+              gridStartHeight,
+              gridEndHeight,
+              lerper
             );
-
-            const layers = [];
-            const backgroundLayer = {
+            const heightAbove = heightBelow + 10.0;
+            const alpha =
+              Cesium.Math.lerp(0.2, 0.4, lerper) * backgroundTransparency;
+            layers.push({
               entries: [
                 {
-                  height: 4200.0,
-                  color: new Cesium.Color(
-                    0.0,
-                    0.0,
-                    0.2,
-                    backgroundTransparency
-                  ),
+                  height: heightBelow,
+                  color: new Cesium.Color(1.0, 1.0, 1.0, alpha),
                 },
                 {
-                  height: 8000.0,
-                  color: new Cesium.Color(
-                    1.0,
-                    1.0,
-                    1.0,
-                    backgroundTransparency
-                  ),
-                },
-                {
-                  height: 8500.0,
-                  color: new Cesium.Color(
-                    1.0,
-                    0.0,
-                    0.0,
-                    backgroundTransparency
-                  ),
+                  height: heightAbove,
+                  color: new Cesium.Color(1.0, 1.0, 1.0, alpha),
                 },
               ],
-              extendDownwards: true,
-              extendUpwards: true,
-            };
-            layers.push(backgroundLayer);
-
-            const gridStartHeight = 4200.0;
-            const gridEndHeight = 8848.0;
-            const gridCount = 50;
-            for (let i = 0; i < gridCount; i++) {
-              const lerper = i / (gridCount - 1);
-              const heightBelow = Cesium.Math.lerp(
-                gridStartHeight,
-                gridEndHeight,
-                lerper
-              );
-              const heightAbove = heightBelow + 10.0;
-              const alpha =
-                Cesium.Math.lerp(0.2, 0.4, lerper) * backgroundTransparency;
-              layers.push({
-                entries: [
-                  {
-                    height: heightBelow,
-                    color: new Cesium.Color(1.0, 1.0, 1.0, alpha),
-                  },
-                  {
-                    height: heightAbove,
-                    color: new Cesium.Color(1.0, 1.0, 1.0, alpha),
-                  },
-                ],
-              });
-            }
-
-            const antialias = Math.min(10.0, bandThickness * 0.1);
-
-            if (!gradient) {
-              const band1 = {
-                entries: [
-                  {
-                    height: band1Position - bandThickness * 0.5 - antialias,
-                    color: new Cesium.Color(0.0, 0.0, 1.0, 0.0),
-                  },
-                  {
-                    height: band1Position - bandThickness * 0.5,
-                    color: new Cesium.Color(0.0, 0.0, 1.0, bandTransparency),
-                  },
-                  {
-                    height: band1Position + bandThickness * 0.5,
-                    color: new Cesium.Color(0.0, 0.0, 1.0, bandTransparency),
-                  },
-                  {
-                    height: band1Position + bandThickness * 0.5 + antialias,
-                    color: new Cesium.Color(0.0, 0.0, 1.0, 0.0),
-                  },
-                ],
-              };
-
-              const band2 = {
-                entries: [
-                  {
-                    height: band2Position - bandThickness * 0.5 - antialias,
-                    color: new Cesium.Color(0.0, 1.0, 0.0, 0.0),
-                  },
-                  {
-                    height: band2Position - bandThickness * 0.5,
-                    color: new Cesium.Color(0.0, 1.0, 0.0, bandTransparency),
-                  },
-                  {
-                    height: band2Position + bandThickness * 0.5,
-                    color: new Cesium.Color(0.0, 1.0, 0.0, bandTransparency),
-                  },
-                  {
-                    height: band2Position + bandThickness * 0.5 + antialias,
-                    color: new Cesium.Color(0.0, 1.0, 0.0, 0.0),
-                  },
-                ],
-              };
-
-              const band3 = {
-                entries: [
-                  {
-                    height: band3Position - bandThickness * 0.5 - antialias,
-                    color: new Cesium.Color(1.0, 0.0, 0.0, 0.0),
-                  },
-                  {
-                    height: band3Position - bandThickness * 0.5,
-                    color: new Cesium.Color(1.0, 0.0, 0.0, bandTransparency),
-                  },
-                  {
-                    height: band3Position + bandThickness * 0.5,
-                    color: new Cesium.Color(1.0, 0.0, 0.0, bandTransparency),
-                  },
-                  {
-                    height: band3Position + bandThickness * 0.5 + antialias,
-                    color: new Cesium.Color(1.0, 0.0, 0.0, 0.0),
-                  },
-                ],
-              };
-
-              layers.push(band1);
-              layers.push(band2);
-              layers.push(band3);
-            } else {
-              const combinedBand = {
-                entries: [
-                  {
-                    height: band1Position - bandThickness * 0.5,
-                    color: new Cesium.Color(0.0, 0.0, 1.0, bandTransparency),
-                  },
-                  {
-                    height: band2Position,
-                    color: new Cesium.Color(0.0, 1.0, 0.0, bandTransparency),
-                  },
-                  {
-                    height: band3Position + bandThickness * 0.5,
-                    color: new Cesium.Color(1.0, 0.0, 0.0, bandTransparency),
-                  },
-                ],
-              };
-
-              layers.push(combinedBand);
-            }
-
-            const material = Cesium.createElevationBandMaterial({
-              scene: viewer.scene,
-              layers: layers,
             });
-            viewer.scene.globe.material = material;
           }
 
-          updateMaterial();
-        })(); //Sandcastle_End
-        Sandcastle.finishedLoading();
+          const antialias = Math.min(10.0, bandThickness * 0.1);
+
+          if (!gradient) {
+            const band1 = {
+              entries: [
+                {
+                  height: band1Position - bandThickness * 0.5 - antialias,
+                  color: new Cesium.Color(0.0, 0.0, 1.0, 0.0),
+                },
+                {
+                  height: band1Position - bandThickness * 0.5,
+                  color: new Cesium.Color(0.0, 0.0, 1.0, bandTransparency),
+                },
+                {
+                  height: band1Position + bandThickness * 0.5,
+                  color: new Cesium.Color(0.0, 0.0, 1.0, bandTransparency),
+                },
+                {
+                  height: band1Position + bandThickness * 0.5 + antialias,
+                  color: new Cesium.Color(0.0, 0.0, 1.0, 0.0),
+                },
+              ],
+            };
+
+            const band2 = {
+              entries: [
+                {
+                  height: band2Position - bandThickness * 0.5 - antialias,
+                  color: new Cesium.Color(0.0, 1.0, 0.0, 0.0),
+                },
+                {
+                  height: band2Position - bandThickness * 0.5,
+                  color: new Cesium.Color(0.0, 1.0, 0.0, bandTransparency),
+                },
+                {
+                  height: band2Position + bandThickness * 0.5,
+                  color: new Cesium.Color(0.0, 1.0, 0.0, bandTransparency),
+                },
+                {
+                  height: band2Position + bandThickness * 0.5 + antialias,
+                  color: new Cesium.Color(0.0, 1.0, 0.0, 0.0),
+                },
+              ],
+            };
+
+            const band3 = {
+              entries: [
+                {
+                  height: band3Position - bandThickness * 0.5 - antialias,
+                  color: new Cesium.Color(1.0, 0.0, 0.0, 0.0),
+                },
+                {
+                  height: band3Position - bandThickness * 0.5,
+                  color: new Cesium.Color(1.0, 0.0, 0.0, bandTransparency),
+                },
+                {
+                  height: band3Position + bandThickness * 0.5,
+                  color: new Cesium.Color(1.0, 0.0, 0.0, bandTransparency),
+                },
+                {
+                  height: band3Position + bandThickness * 0.5 + antialias,
+                  color: new Cesium.Color(1.0, 0.0, 0.0, 0.0),
+                },
+              ],
+            };
+
+            layers.push(band1);
+            layers.push(band2);
+            layers.push(band3);
+          } else {
+            const combinedBand = {
+              entries: [
+                {
+                  height: band1Position - bandThickness * 0.5,
+                  color: new Cesium.Color(0.0, 0.0, 1.0, bandTransparency),
+                },
+                {
+                  height: band2Position,
+                  color: new Cesium.Color(0.0, 1.0, 0.0, bandTransparency),
+                },
+                {
+                  height: band3Position + bandThickness * 0.5,
+                  color: new Cesium.Color(1.0, 0.0, 0.0, bandTransparency),
+                },
+              ],
+            };
+
+            layers.push(combinedBand);
+          }
+
+          const material = Cesium.createElevationBandMaterial({
+            scene: viewer.scene,
+            layers: layers,
+          });
+          viewer.scene.globe.material = material;
+        }
+
+        updateMaterial(); //Sandcastle_End
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Export KML.html
+++ b/Apps/Sandcastle/gallery/Export KML.html
@@ -35,7 +35,7 @@
     </div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -156,11 +156,14 @@
             .catch(console.error);
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/FXAA.html
+++ b/Apps/Sandcastle/gallery/FXAA.html
@@ -29,45 +29,46 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
 
-          viewer.scene.camera.setView({
-            destination: new Cesium.Cartesian3(
-              1331419.302230775,
-              -4656681.5022043325,
-              4136232.6465900405
-            ),
-            orientation: new Cesium.HeadingPitchRoll(
-              6.032455545102689,
-              -0.056832496140112765,
-              6.282360923090216
-            ),
-            endTransform: Cesium.Matrix4.IDENTITY,
-          });
+        viewer.scene.camera.setView({
+          destination: new Cesium.Cartesian3(
+            1331419.302230775,
+            -4656681.5022043325,
+            4136232.6465900405
+          ),
+          orientation: new Cesium.HeadingPitchRoll(
+            6.032455545102689,
+            -0.056832496140112765,
+            6.282360923090216
+          ),
+          endTransform: Cesium.Matrix4.IDENTITY,
+        });
 
-          viewer.scene.primitives.add(
-            new Cesium.Cesium3DTileset({
-              url: Cesium.IonResource.fromAssetId(75343),
-            })
-          );
+        viewer.scene.primitives.add(
+          new Cesium.Cesium3DTileset({
+            url: Cesium.IonResource.fromAssetId(75343),
+          })
+        );
 
-          viewer.scene.postProcessStages.fxaa.enabled = true;
+        viewer.scene.postProcessStages.fxaa.enabled = true;
 
-          Sandcastle.addToggleButton("FXAA", true, function (checked) {
-            viewer.scene.postProcessStages.fxaa.enabled = checked;
-          });
-        })(); //Sandcastle_End
-        Sandcastle.finishedLoading();
+        Sandcastle.addToggleButton("FXAA", true, function (checked) {
+          viewer.scene.postProcessStages.fxaa.enabled = checked;
+        }); //Sandcastle_End
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Fog Post Process.html
+++ b/Apps/Sandcastle/gallery/Fog Post Process.html
@@ -27,7 +27,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -106,11 +106,14 @@
             },
           })
         ); //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/GPX.html
+++ b/Apps/Sandcastle/gallery/GPX.html
@@ -31,18 +31,12 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer");
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-          } catch (error) {
-            console.log(error);
-          }
-        })();
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
 
         const pinBuilder = new Cesium.PinBuilder();
 
@@ -144,11 +138,14 @@
           viewer.clock.clockStep = Cesium.ClockStep.SYSTEM_CLOCK;
         };
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/GeoJSON and TopoJSON.html
+++ b/Apps/Sandcastle/gallery/GeoJSON and TopoJSON.html
@@ -35,7 +35,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -123,11 +123,14 @@
           viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
         };
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/GeoJSON simplestyle.html
+++ b/Apps/Sandcastle/gallery/GeoJSON simplestyle.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         //Load a GeoJSON file containing simplestyle information.
@@ -53,11 +53,14 @@
         viewer.dataSources.add(dataSource);
         viewer.zoomTo(dataSource);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Geometry Height Reference.html
+++ b/Apps/Sandcastle/gallery/Geometry Height Reference.html
@@ -32,13 +32,14 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const ellipsoidTerrainProvider = new Cesium.EllipsoidTerrainProvider();
 
         const viewer = new Cesium.Viewer("cesiumContainer", {
           baseLayerPicker: false,
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
         });
 
         // depth test against terrain is required to make the polygons clamp to terrain
@@ -80,14 +81,6 @@
             },
           },
         ]);
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-          } catch (error) {
-            console.log(error);
-          }
-        })();
 
         const longitude = 6.950615989890521;
         const latitude = 45.79546589994886;
@@ -185,7 +178,11 @@
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Geometry Height Reference.html
+++ b/Apps/Sandcastle/gallery/Geometry Height Reference.html
@@ -174,15 +174,14 @@
           viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
         }
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Geometry and Appearances.html
+++ b/Apps/Sandcastle/gallery/Geometry and Appearances.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         Cesium.Math.setRandomNumberSeed(1234);
@@ -635,11 +635,14 @@
 
         viewer.zoomTo(viewer.entities);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Globe Interior.html
+++ b/Apps/Sandcastle/gallery/Globe Interior.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -179,11 +179,14 @@
 
         Sandcastle.addToolbarMenu(options);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Globe Materials.html
+++ b/Apps/Sandcastle/gallery/Globe Materials.html
@@ -119,21 +119,15 @@
       </div>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer");
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync({
+            requestVertexNormals: true, //Needed to visualize slope
+          }),
+        });
         viewer.scene.globe.enableLighting = true;
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync({
-              requestVertexNormals: true, //Needed to visualize slope
-            });
-          } catch (error) {
-            console.log(error);
-          }
-        })();
 
         function getElevationContourMaterial() {
           // Creates a composite material with both elevation shading and contour lines
@@ -424,11 +418,14 @@
           "zoomButtons"
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Globe Translucency.html
+++ b/Apps/Sandcastle/gallery/Globe Translucency.html
@@ -81,233 +81,234 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
 
-          const scene = viewer.scene;
-          const globe = scene.globe;
+        const scene = viewer.scene;
+        const globe = scene.globe;
 
-          scene.screenSpaceCameraController.enableCollisionDetection = false;
-          globe.translucency.frontFaceAlphaByDistance = new Cesium.NearFarScalar(
-            400.0,
-            0.0,
-            800.0,
-            1.0
-          );
+        scene.screenSpaceCameraController.enableCollisionDetection = false;
+        globe.translucency.frontFaceAlphaByDistance = new Cesium.NearFarScalar(
+          400.0,
+          0.0,
+          800.0,
+          1.0
+        );
 
-          const longitude = -3.82518;
-          const latitude = 53.11728;
-          const height = 72.8;
-          const position = Cesium.Cartesian3.fromDegrees(
-            longitude,
-            latitude,
-            height
-          );
-          const url = "../../SampleData/models/ParcLeadMine/ParcLeadMine.glb";
+        const longitude = -3.82518;
+        const latitude = 53.11728;
+        const height = 72.8;
+        const position = Cesium.Cartesian3.fromDegrees(
+          longitude,
+          latitude,
+          height
+        );
+        const url = "../../SampleData/models/ParcLeadMine/ParcLeadMine.glb";
 
-          const entity = viewer.entities.add({
-            name: url,
-            position: position,
-            model: {
-              uri: url,
-            },
-          });
+        const entity = viewer.entities.add({
+          name: url,
+          position: position,
+          model: {
+            uri: url,
+          },
+        });
 
-          const polygon = viewer.entities.add({
-            polygon: {
-              hierarchy: new Cesium.PolygonHierarchy(
-                Cesium.Cartesian3.fromDegreesArrayHeights([
-                  -3.8152789692233817,
-                  53.124521420389996,
-                  200.20779492422255,
-                  -3.8165955002619016,
-                  53.12555934545405,
-                  205.85834336951655,
-                  -3.8201599842222054,
-                  53.12388420656903,
-                  230.82362697069453,
-                  -3.8198667503545027,
-                  53.123748567587455,
-                  225.53297006293968,
-                  -3.8190548496317476,
-                  53.1240486000822,
-                  221.82677773619432,
-                  -3.817536387097508,
-                  53.122763476393764,
-                  209.94136782255705,
-                  -3.8169125359199336,
-                  53.12285547981627,
-                  210.96626238861327,
-                  -3.8166873871853073,
-                  53.12299403424474,
-                  211.02223937734595,
-                  -3.8163695374580873,
-                  53.12300505277307,
-                  211.25942926271824,
-                  -3.8162743040622313,
-                  53.12281471203994,
-                  212.35109129094147,
-                  -3.8159746138174193,
-                  53.12280996651767,
-                  214.87977416348798,
-                  -3.815429896849304,
-                  53.1236135347983,
-                  209.72496223706005,
-                ])
-              ),
-              material: Cesium.Color.LIME.withAlpha(0.5),
-              classificationType: Cesium.ClassificationType.TERRAIN,
-            },
-          });
+        const polygon = viewer.entities.add({
+          polygon: {
+            hierarchy: new Cesium.PolygonHierarchy(
+              Cesium.Cartesian3.fromDegreesArrayHeights([
+                -3.8152789692233817,
+                53.124521420389996,
+                200.20779492422255,
+                -3.8165955002619016,
+                53.12555934545405,
+                205.85834336951655,
+                -3.8201599842222054,
+                53.12388420656903,
+                230.82362697069453,
+                -3.8198667503545027,
+                53.123748567587455,
+                225.53297006293968,
+                -3.8190548496317476,
+                53.1240486000822,
+                221.82677773619432,
+                -3.817536387097508,
+                53.122763476393764,
+                209.94136782255705,
+                -3.8169125359199336,
+                53.12285547981627,
+                210.96626238861327,
+                -3.8166873871853073,
+                53.12299403424474,
+                211.02223937734595,
+                -3.8163695374580873,
+                53.12300505277307,
+                211.25942926271824,
+                -3.8162743040622313,
+                53.12281471203994,
+                212.35109129094147,
+                -3.8159746138174193,
+                53.12280996651767,
+                214.87977416348798,
+                -3.815429896849304,
+                53.1236135347983,
+                209.72496223706005,
+              ])
+            ),
+            material: Cesium.Color.LIME.withAlpha(0.5),
+            classificationType: Cesium.ClassificationType.TERRAIN,
+          },
+        });
 
-          const polyline = viewer.entities.add({
-            polyline: {
-              positions: Cesium.Cartesian3.fromDegreesArrayHeights([
-                -3.8098444201746373,
-                53.1190304262546,
-                286.1875170545701,
-                -3.8099801237370663,
-                53.119539531697576,
-                288.7733884242394,
-                -3.810165716635671,
-                53.11979180761567,
-                290.9294630315179,
-                -3.8104840812145357,
-                53.12007534956926,
-                292.6392327626228,
-                -3.8105689502073554,
-                53.120259094792196,
-                292.222036965774,
-                -3.811027311824268,
-                53.120409248874196,
-                289.61356291617307,
-                -3.811530473295422,
-                53.12063281057782,
-                284.01098712543586,
-                -3.8120545342562693,
-                53.120742539082435,
-                280.118191867836,
-                -3.812444493044727,
-                53.120813289759326,
-                276.0400221387852,
-                -3.812779626711285,
-                53.12094275348024,
-                271.1187399484896,
-                -3.8133560322579494,
-                53.12104757866638,
-                263.3495497598578,
-                -3.8137266493960085,
-                53.12120789867194,
-                257.73878624321316,
-                -3.8142552291751133,
-                53.121321248522904,
-                251.87265828778177,
-                -3.814322603988525,
-                53.12174170121103,
-                238.7082749547689,
-                -3.8143764268391314,
-                53.1219492923309,
-                235.0371831845662,
-                -3.8148156514145786,
-                53.12210819668669,
-                230.2458816627467,
-                -3.8155394721966163,
-                53.1222990144029,
-                221.33319292262706,
-                -3.8159828072920927,
-                53.12203093429715,
-                223.66664756982703,
-                -3.816678108944717,
-                53.12183939425214,
-                223.8787312412801,
-                -3.817466081093726,
-                53.121751900508535,
-                224.52293229989735,
-                -3.8183082996527955,
-                53.12173266141031,
-                223.3672181535749,
-              ]),
-              width: 8,
-              material: new Cesium.PolylineOutlineMaterialProperty({
-                color: Cesium.Color.YELLOW,
-                outlineWidth: 2,
-                outlineColor: Cesium.Color.BLACK,
-              }),
-              clampToGround: true,
-            },
-          });
+        const polyline = viewer.entities.add({
+          polyline: {
+            positions: Cesium.Cartesian3.fromDegreesArrayHeights([
+              -3.8098444201746373,
+              53.1190304262546,
+              286.1875170545701,
+              -3.8099801237370663,
+              53.119539531697576,
+              288.7733884242394,
+              -3.810165716635671,
+              53.11979180761567,
+              290.9294630315179,
+              -3.8104840812145357,
+              53.12007534956926,
+              292.6392327626228,
+              -3.8105689502073554,
+              53.120259094792196,
+              292.222036965774,
+              -3.811027311824268,
+              53.120409248874196,
+              289.61356291617307,
+              -3.811530473295422,
+              53.12063281057782,
+              284.01098712543586,
+              -3.8120545342562693,
+              53.120742539082435,
+              280.118191867836,
+              -3.812444493044727,
+              53.120813289759326,
+              276.0400221387852,
+              -3.812779626711285,
+              53.12094275348024,
+              271.1187399484896,
+              -3.8133560322579494,
+              53.12104757866638,
+              263.3495497598578,
+              -3.8137266493960085,
+              53.12120789867194,
+              257.73878624321316,
+              -3.8142552291751133,
+              53.121321248522904,
+              251.87265828778177,
+              -3.814322603988525,
+              53.12174170121103,
+              238.7082749547689,
+              -3.8143764268391314,
+              53.1219492923309,
+              235.0371831845662,
+              -3.8148156514145786,
+              53.12210819668669,
+              230.2458816627467,
+              -3.8155394721966163,
+              53.1222990144029,
+              221.33319292262706,
+              -3.8159828072920927,
+              53.12203093429715,
+              223.66664756982703,
+              -3.816678108944717,
+              53.12183939425214,
+              223.8787312412801,
+              -3.817466081093726,
+              53.121751900508535,
+              224.52293229989735,
+              -3.8183082996527955,
+              53.12173266141031,
+              223.3672181535749,
+            ]),
+            width: 8,
+            material: new Cesium.PolylineOutlineMaterialProperty({
+              color: Cesium.Color.YELLOW,
+              outlineWidth: 2,
+              outlineColor: Cesium.Color.BLACK,
+            }),
+            clampToGround: true,
+          },
+        });
 
-          const viewModel = {
-            translucencyEnabled: true,
-            fadeByDistance: true,
-            showVectorData: false,
-            alpha: 0.5,
-          };
+        const viewModel = {
+          translucencyEnabled: true,
+          fadeByDistance: true,
+          showVectorData: false,
+          alpha: 0.5,
+        };
 
-          Cesium.knockout.track(viewModel);
-          const toolbar = document.getElementById("toolbar");
-          Cesium.knockout.applyBindings(viewModel, toolbar);
-          for (const name in viewModel) {
-            if (viewModel.hasOwnProperty(name)) {
-              Cesium.knockout.getObservable(viewModel, name).subscribe(update);
-            }
+        Cesium.knockout.track(viewModel);
+        const toolbar = document.getElementById("toolbar");
+        Cesium.knockout.applyBindings(viewModel, toolbar);
+        for (const name in viewModel) {
+          if (viewModel.hasOwnProperty(name)) {
+            Cesium.knockout.getObservable(viewModel, name).subscribe(update);
           }
+        }
 
-          function update() {
-            globe.translucency.enabled = viewModel.translucencyEnabled;
+        function update() {
+          globe.translucency.enabled = viewModel.translucencyEnabled;
 
-            let alpha = Number(viewModel.alpha);
-            alpha = !isNaN(alpha) ? alpha : 1.0;
-            alpha = Cesium.Math.clamp(alpha, 0.0, 1.0);
+          let alpha = Number(viewModel.alpha);
+          alpha = !isNaN(alpha) ? alpha : 1.0;
+          alpha = Cesium.Math.clamp(alpha, 0.0, 1.0);
 
-            globe.translucency.frontFaceAlphaByDistance.nearValue = alpha;
-            globe.translucency.frontFaceAlphaByDistance.farValue = viewModel.fadeByDistance
-              ? 1.0
-              : alpha;
+          globe.translucency.frontFaceAlphaByDistance.nearValue = alpha;
+          globe.translucency.frontFaceAlphaByDistance.farValue = viewModel.fadeByDistance
+            ? 1.0
+            : alpha;
 
-            polygon.show = viewModel.showVectorData;
-            polyline.show = viewModel.showVectorData;
-          }
-          update();
+          polygon.show = viewModel.showVectorData;
+          polyline.show = viewModel.showVectorData;
+        }
+        update();
 
-          viewer.scene.camera.setView({
-            destination: new Cesium.Cartesian3(
-              3826465.9884728403,
-              -254831.02751468265,
-              5081387.671561018
-            ),
-            orientation: new Cesium.HeadingPitchRoll(
-              3.3889450556243754,
-              -0.5276382514771969,
-              6.282272566663295
-            ),
-            endTransform: Cesium.Matrix4.IDENTITY,
-          });
+        viewer.scene.camera.setView({
+          destination: new Cesium.Cartesian3(
+            3826465.9884728403,
+            -254831.02751468265,
+            5081387.671561018
+          ),
+          orientation: new Cesium.HeadingPitchRoll(
+            3.3889450556243754,
+            -0.5276382514771969,
+            6.282272566663295
+          ),
+          endTransform: Cesium.Matrix4.IDENTITY,
+        });
 
-          viewer.scene.camera.flyTo({
-            destination: new Cesium.Cartesian3(
-              3827270.552916987,
-              -255123.18143177085,
-              5079147.091351856
-            ),
-            orientation: new Cesium.HeadingPitchRoll(
-              3.2624281242239963,
-              -0.22213535190506972,
-              6.282786783842843
-            ),
-            duration: 5.0,
-          });
-        })(); //Sandcastle_End
-        Sandcastle.finishedLoading();
+        viewer.scene.camera.flyTo({
+          destination: new Cesium.Cartesian3(
+            3827270.552916987,
+            -255123.18143177085,
+            5079147.091351856
+          ),
+          orientation: new Cesium.HeadingPitchRoll(
+            3.2624281242239963,
+            -0.22213535190506972,
+            6.282786783842843
+          ),
+          duration: 5.0,
+        }); //Sandcastle_End
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Google Earth Enterprise.html
+++ b/Apps/Sandcastle/gallery/Google Earth Enterprise.html
@@ -32,46 +32,38 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          try {
-            const geeMetadata = await Cesium.GoogleEarthEnterpriseMetadata.fromUrl(
-              new Cesium.Resource({
-                url: "http://www.earthenterprise.org/3d",
-                proxy: new Cesium.DefaultProxy("/proxy/"),
-              })
-            );
+        const geeMetadata = await Cesium.GoogleEarthEnterpriseMetadata.fromUrl(
+          new Cesium.Resource({
+            url: "http://www.earthenterprise.org/3d",
+            proxy: new Cesium.DefaultProxy("/proxy/"),
+          })
+        );
 
-            const viewer = new Cesium.Viewer("cesiumContainer", {
-              imageryProvider: new Cesium.GoogleEarthEnterpriseImageryProvider({
-                metadata: geeMetadata,
-              }),
-              terrainProvider: Cesium.GoogleEarthEnterpriseTerrainProvider.fromMetadata(
-                geeMetadata
-              ),
-              baseLayerPicker: false,
-            });
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          imageryProvider: new Cesium.GoogleEarthEnterpriseImageryProvider({
+            metadata: geeMetadata,
+          }),
+          terrainProvider: Cesium.GoogleEarthEnterpriseTerrainProvider.fromMetadata(
+            geeMetadata
+          ),
+          baseLayerPicker: false,
+        });
 
-            // Start off looking at San Francisco.
-            viewer.camera.setView({
-              destination: Cesium.Rectangle.fromDegrees(
-                -123.0,
-                36.0,
-                -121.7,
-                39.0
-              ),
-            });
-          } catch (error) {
-            console.log(error);
-          }
-        })(); //Sandcastle_End
-        Sandcastle.finishedLoading();
+        // Start off looking at San Francisco.
+        viewer.camera.setView({
+          destination: Cesium.Rectangle.fromDegrees(-123.0, 36.0, -121.7, 39.0),
+        }); //Sandcastle_End
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/HTML Overlays.html
+++ b/Apps/Sandcastle/gallery/HTML Overlays.html
@@ -37,7 +37,7 @@
       src="../images/Cesium_Logo_overlay.png"
     />
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -60,11 +60,14 @@
           }
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/HeadingPitchRoll.html
+++ b/Apps/Sandcastle/gallery/HeadingPitchRoll.html
@@ -71,7 +71,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -261,11 +261,14 @@
           speedSpan.innerHTML = speed.toFixed(1);
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Hello World.html
+++ b/Apps/Sandcastle/gallery/Hello World.html
@@ -32,16 +32,20 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
+
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/High Dynamic Range.html
+++ b/Apps/Sandcastle/gallery/High Dynamic Range.html
@@ -29,71 +29,72 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-            shadows: true,
-          });
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          shadows: true,
+        });
 
-          if (!viewer.scene.highDynamicRangeSupported) {
-            window.alert("This browser does not support high dynamic range.");
-          }
+        if (!viewer.scene.highDynamicRangeSupported) {
+          window.alert("This browser does not support high dynamic range.");
+        }
 
-          viewer.scene.camera.setView({
-            destination: new Cesium.Cartesian3(
-              -1915097.7863741855,
-              -4783356.851539908,
-              3748887.43462683
-            ),
-            orientation: new Cesium.HeadingPitchRoll(
-              6.166004548388564,
-              -0.043242401760068994,
-              0.002179961955988574
-            ),
-            endTransform: Cesium.Matrix4.IDENTITY,
-          });
+        viewer.scene.camera.setView({
+          destination: new Cesium.Cartesian3(
+            -1915097.7863741855,
+            -4783356.851539908,
+            3748887.43462683
+          ),
+          orientation: new Cesium.HeadingPitchRoll(
+            6.166004548388564,
+            -0.043242401760068994,
+            0.002179961955988574
+          ),
+          endTransform: Cesium.Matrix4.IDENTITY,
+        });
 
-          viewer.scene.highDynamicRange = true;
+        viewer.scene.highDynamicRange = true;
 
-          Sandcastle.addToggleButton("HDR", true, function (checked) {
-            viewer.scene.highDynamicRange = checked;
-          });
+        Sandcastle.addToggleButton("HDR", true, function (checked) {
+          viewer.scene.highDynamicRange = checked;
+        });
 
-          const url =
-            "../../SampleData/models/DracoCompressed/CesiumMilkTruck.gltf";
-          const position = Cesium.Cartesian3.fromRadians(
-            -1.9516424279517286,
-            0.6322397098422969,
-            1239.0006814631095
-          );
-          const heading = Cesium.Math.toRadians(-15.0);
-          const pitch = 0;
-          const roll = 0;
-          const hpr = new Cesium.HeadingPitchRoll(heading, pitch, roll);
-          const orientation = Cesium.Transforms.headingPitchRollQuaternion(
-            position,
-            hpr
-          );
-          const scale = 10.0;
+        const url =
+          "../../SampleData/models/DracoCompressed/CesiumMilkTruck.gltf";
+        const position = Cesium.Cartesian3.fromRadians(
+          -1.9516424279517286,
+          0.6322397098422969,
+          1239.0006814631095
+        );
+        const heading = Cesium.Math.toRadians(-15.0);
+        const pitch = 0;
+        const roll = 0;
+        const hpr = new Cesium.HeadingPitchRoll(heading, pitch, roll);
+        const orientation = Cesium.Transforms.headingPitchRollQuaternion(
+          position,
+          hpr
+        );
+        const scale = 10.0;
 
-          const entity = viewer.entities.add({
-            name: url,
-            position: position,
-            orientation: orientation,
-            model: {
-              uri: url,
-              scale: scale,
-            },
-          });
-        })(); //Sandcastle_End
-        Sandcastle.finishedLoading();
+        const entity = viewer.entities.add({
+          name: url,
+          position: position,
+          orientation: orientation,
+          model: {
+            uri: url,
+            scale: scale,
+          },
+        }); //Sandcastle_End
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/I3S 3D Object Layer.html
+++ b/Apps/Sandcastle/gallery/I3S 3D Object Layer.html
@@ -150,15 +150,15 @@
           }
           return false;
         } //Sandcastle_End
-        if (typeof Cesium !== "undefined") {
-          window.startupCalled = true;
-          try {
-            window.startup(Cesium);
-          } catch (error) {
-            console.error(error);
-          }
-        }
       };
+      if (typeof Cesium !== "undefined") {
+        window.startupCalled = true;
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
+      }
     </script>
   </body>
 </html>

--- a/Apps/Sandcastle/gallery/I3S 3D Object Layer.html
+++ b/Apps/Sandcastle/gallery/I3S 3D Object Layer.html
@@ -35,129 +35,128 @@
     </div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-            animation: false,
-            timeline: false,
-          });
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          animation: false,
+          timeline: false,
+        });
 
-          // More datasets to tour can be added here...
-          // The url passed to I3SDataProvider supports loading a single Indexed 3D Scene (I3S) layer (.<host>/SceneServer/layers/<id>) or a collection of scene layers (.<host>/SceneServer) from a SceneServer.
-          const tours = {
-            "San Francisco":
-              "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/SanFrancisco_3DObjects_1_7/SceneServer/layers/0",
-          };
-          // Initialize a terrain provider which provides geoid conversion between gravity related (typically I3S datasets) and ellipsoidal based
-          // height systems (Cesium World Terrain).
-          // If this is not specified, or the URL is invalid no geoid conversion will be applied.
-          // The source data used in this transcoding service was compiled from https://earth-info.nga.mil/#tab_wgs84-data and is based on EGM2008 Gravity Model
-          const geoidService = await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
-            "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/EGM2008/ImageServer"
-          );
-          // Create i3s and Cesium3DTileset options to pass optional parameters useful for debugging and visualizing
-          const cesium3dTilesetOptions = {
-            skipLevelOfDetail: false,
-            debugShowBoundingVolume: false,
-          };
-          const i3sOptions = {
-            url: tours["San Francisco"],
-            traceFetches: false, // for tracing I3S fetches
-            geoidTiledTerrainProvider: geoidService, // pass the geoid service
-            cesium3dTilesetOptions: cesium3dTilesetOptions, // options for internal Cesium3dTileset
-          };
+        // More datasets to tour can be added here...
+        // The url passed to I3SDataProvider supports loading a single Indexed 3D Scene (I3S) layer (.<host>/SceneServer/layers/<id>) or a collection of scene layers (.<host>/SceneServer) from a SceneServer.
+        const tours = {
+          "San Francisco":
+            "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/SanFrancisco_3DObjects_1_7/SceneServer/layers/0",
+        };
+        // Initialize a terrain provider which provides geoid conversion between gravity related (typically I3S datasets) and ellipsoidal based
+        // height systems (Cesium World Terrain).
+        // If this is not specified, or the URL is invalid no geoid conversion will be applied.
+        // The source data used in this transcoding service was compiled from https://earth-info.nga.mil/#tab_wgs84-data and is based on EGM2008 Gravity Model
+        const geoidService = await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
+          "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/EGM2008/ImageServer"
+        );
+        // Create i3s and Cesium3DTileset options to pass optional parameters useful for debugging and visualizing
+        const cesium3dTilesetOptions = {
+          skipLevelOfDetail: false,
+          debugShowBoundingVolume: false,
+        };
+        const i3sOptions = {
+          url: tours["San Francisco"],
+          traceFetches: false, // for tracing I3S fetches
+          geoidTiledTerrainProvider: geoidService, // pass the geoid service
+          cesium3dTilesetOptions: cesium3dTilesetOptions, // options for internal Cesium3dTileset
+        };
 
-          // Create I3S data provider
-          const i3sProvider = new Cesium.I3SDataProvider(i3sOptions);
+        // Create I3S data provider
+        const i3sProvider = new Cesium.I3SDataProvider(i3sOptions);
 
-          // Add the i3s layer provider as a primitive data type
-          viewer.scene.primitives.add(i3sProvider);
+        // Add the i3s layer provider as a primitive data type
+        viewer.scene.primitives.add(i3sProvider);
 
-          // Center camera on I3S once it's loaded
-          await i3sProvider.readyPromise;
-          const center = Cesium.Rectangle.center(i3sProvider.extent);
-          center.height = 10000.0;
-          viewer.camera.setView({
-            destination: Cesium.Ellipsoid.WGS84.cartographicToCartesian(center),
-          });
+        // Center camera on I3S once it's loaded
+        await i3sProvider.readyPromise;
+        const center = Cesium.Rectangle.center(i3sProvider.extent);
+        center.height = 10000.0;
+        viewer.camera.setView({
+          destination: Cesium.Ellipsoid.WGS84.cartographicToCartesian(center),
+        });
 
-          // An entity object which will hold info about the currently selected feature for infobox display
-          const selectedEntity = new Cesium.Entity();
-          // Show metadata in the InfoBox.
-          viewer.screenSpaceEventHandler.setInputAction(function onLeftClick(
-            movement
+        // An entity object which will hold info about the currently selected feature for infobox display
+        const selectedEntity = new Cesium.Entity();
+        // Show metadata in the InfoBox.
+        viewer.screenSpaceEventHandler.setInputAction(function onLeftClick(
+          movement
+        ) {
+          // Pick a new feature
+          const pickedFeature = viewer.scene.pick(movement.position);
+          if (!Cesium.defined(pickedFeature)) {
+            return;
+          }
+
+          const pickedPosition = viewer.scene.pickPosition(movement.position);
+
+          if (
+            Cesium.defined(pickedFeature.content) &&
+            Cesium.defined(pickedFeature.content.tile.i3sNode)
           ) {
-            // Pick a new feature
-            const pickedFeature = viewer.scene.pick(movement.position);
-            if (!Cesium.defined(pickedFeature)) {
-              return;
-            }
+            const i3sNode = pickedFeature.content.tile.i3sNode;
+            if (pickedPosition) {
+              i3sNode.loadFields().then(function () {
+                let description = "No attributes";
+                let name;
+                console.log(
+                  `pickedPosition(x,y,z) : ${pickedPosition.x}, ${pickedPosition.y}, ${pickedPosition.z}`
+                );
 
-            const pickedPosition = viewer.scene.pickPosition(movement.position);
-
-            if (
-              Cesium.defined(pickedFeature.content) &&
-              Cesium.defined(pickedFeature.content.tile.i3sNode)
-            ) {
-              const i3sNode = pickedFeature.content.tile.i3sNode;
-              if (pickedPosition) {
-                i3sNode.loadFields().then(function () {
-                  let description = "No attributes";
-                  let name;
-                  console.log(
-                    `pickedPosition(x,y,z) : ${pickedPosition.x}, ${pickedPosition.y}, ${pickedPosition.z}`
-                  );
-
-                  const fields = i3sNode.getFieldsForPickedPosition(
-                    pickedPosition
-                  );
-                  if (Object.keys(fields).length > 0) {
-                    description =
-                      '<table class="cesium-infoBox-defaultTable"><tbody>';
-                    for (const fieldName in fields) {
-                      if (i3sNode.fields.hasOwnProperty(fieldName)) {
-                        description += `<tr><th>${fieldName}</th><td>`;
-                        description += `${fields[fieldName]}</td></tr>`;
-                        console.log(`${fieldName}: ${fields[fieldName]}`);
-                        if (
-                          !Cesium.defined(name) &&
-                          isNameProperty(fieldName)
-                        ) {
-                          name = fields[fieldName];
-                        }
+                const fields = i3sNode.getFieldsForPickedPosition(
+                  pickedPosition
+                );
+                if (Object.keys(fields).length > 0) {
+                  description =
+                    '<table class="cesium-infoBox-defaultTable"><tbody>';
+                  for (const fieldName in fields) {
+                    if (i3sNode.fields.hasOwnProperty(fieldName)) {
+                      description += `<tr><th>${fieldName}</th><td>`;
+                      description += `${fields[fieldName]}</td></tr>`;
+                      console.log(`${fieldName}: ${fields[fieldName]}`);
+                      if (!Cesium.defined(name) && isNameProperty(fieldName)) {
+                        name = fields[fieldName];
                       }
                     }
-                    description += `</tbody></table>`;
                   }
-                  if (!Cesium.defined(name)) {
-                    name = "unknown";
-                  }
-                  selectedEntity.name = name;
-                  selectedEntity.description = description;
-                  viewer.selectedEntity = selectedEntity;
-                });
-              }
+                  description += `</tbody></table>`;
+                }
+                if (!Cesium.defined(name)) {
+                  name = "unknown";
+                }
+                selectedEntity.name = name;
+                selectedEntity.description = description;
+                viewer.selectedEntity = selectedEntity;
+              });
             }
-          },
-          Cesium.ScreenSpaceEventType.LEFT_CLICK);
-
-          function isNameProperty(propertyName) {
-            const name = propertyName.toLowerCase();
-            if (
-              name.localeCompare("name") === 0 ||
-              name.localeCompare("objname") === 0
-            ) {
-              return true;
-            }
-            return false;
           }
-        })(); //Sandcastle_End
+        },
+        Cesium.ScreenSpaceEventType.LEFT_CLICK);
+
+        function isNameProperty(propertyName) {
+          const name = propertyName.toLowerCase();
+          if (
+            name.localeCompare("name") === 0 ||
+            name.localeCompare("objname") === 0
+          ) {
+            return true;
+          }
+          return false;
+        } //Sandcastle_End
         if (typeof Cesium !== "undefined") {
           window.startupCalled = true;
-          window.startup(Cesium);
+          try {
+            window.startup(Cesium);
+          } catch (error) {
+            console.error(error);
+          }
         }
       };
     </script>

--- a/Apps/Sandcastle/gallery/I3S Feature Picking.html
+++ b/Apps/Sandcastle/gallery/I3S Feature Picking.html
@@ -150,15 +150,15 @@
           }
           return false;
         } //Sandcastle_End
-        if (typeof Cesium !== "undefined") {
-          window.startupCalled = true;
-          try {
-            window.startup(Cesium);
-          } catch (error) {
-            console.error(error);
-          }
-        }
       };
+      if (typeof Cesium !== "undefined") {
+        window.startupCalled = true;
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
+      }
     </script>
   </body>
 </html>

--- a/Apps/Sandcastle/gallery/I3S Feature Picking.html
+++ b/Apps/Sandcastle/gallery/I3S Feature Picking.html
@@ -35,129 +35,128 @@
     </div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-            animation: false,
-            timeline: false,
-          });
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          animation: false,
+          timeline: false,
+        });
 
-          // More datasets to tour can be added here...
-          // The url passed to I3SDataProvider supports loading a single Indexed 3D Scene (I3S) layer (.<host>/SceneServer/layers/<id>) or a collection of scene layers (.<host>/SceneServer) from a SceneServer.
-          const tours = {
-            "New York":
-              "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/NYC_Attributed_v17/SceneServer",
-          };
-          // Initialize a terrain provider which provides geoid conversion between gravity related (typically I3S datasets) and ellipsoidal based
-          // height systems (Cesium World Terrain).
-          // If this is not specified, or the URL is invalid no geoid conversion will be applied.
-          // The source data used in this transcoding service was compiled from https://earth-info.nga.mil/#tab_wgs84-data and is based on EGM2008 Gravity Model
-          const geoidService = await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
-            "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/EGM2008/ImageServer"
-          );
-          // Create i3s and Cesium3DTileset options to pass optional parameters useful for debugging and visualizing
-          const cesium3dTilesetOptions = {
-            skipLevelOfDetail: false,
-            debugShowBoundingVolume: false,
-          };
-          const i3sOptions = {
-            url: tours["New York"],
-            traceFetches: false, // for tracing I3S fetches
-            geoidTiledTerrainProvider: geoidService, // pass the geoid service
-            cesium3dTilesetOptions: cesium3dTilesetOptions, // options for internal Cesium3dTileset
-          };
+        // More datasets to tour can be added here...
+        // The url passed to I3SDataProvider supports loading a single Indexed 3D Scene (I3S) layer (.<host>/SceneServer/layers/<id>) or a collection of scene layers (.<host>/SceneServer) from a SceneServer.
+        const tours = {
+          "New York":
+            "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/NYC_Attributed_v17/SceneServer",
+        };
+        // Initialize a terrain provider which provides geoid conversion between gravity related (typically I3S datasets) and ellipsoidal based
+        // height systems (Cesium World Terrain).
+        // If this is not specified, or the URL is invalid no geoid conversion will be applied.
+        // The source data used in this transcoding service was compiled from https://earth-info.nga.mil/#tab_wgs84-data and is based on EGM2008 Gravity Model
+        const geoidService = await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
+          "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/EGM2008/ImageServer"
+        );
+        // Create i3s and Cesium3DTileset options to pass optional parameters useful for debugging and visualizing
+        const cesium3dTilesetOptions = {
+          skipLevelOfDetail: false,
+          debugShowBoundingVolume: false,
+        };
+        const i3sOptions = {
+          url: tours["New York"],
+          traceFetches: false, // for tracing I3S fetches
+          geoidTiledTerrainProvider: geoidService, // pass the geoid service
+          cesium3dTilesetOptions: cesium3dTilesetOptions, // options for internal Cesium3dTileset
+        };
 
-          // Create I3S data provider
-          const i3sProvider = new Cesium.I3SDataProvider(i3sOptions);
+        // Create I3S data provider
+        const i3sProvider = new Cesium.I3SDataProvider(i3sOptions);
 
-          // Add the i3s layer provider as a primitive data type
-          viewer.scene.primitives.add(i3sProvider);
+        // Add the i3s layer provider as a primitive data type
+        viewer.scene.primitives.add(i3sProvider);
 
-          // Center camera on I3S once it's loaded
-          await i3sProvider.readyPromise;
-          const center = Cesium.Rectangle.center(i3sProvider.extent);
-          center.height = 10000.0;
-          viewer.camera.setView({
-            destination: Cesium.Ellipsoid.WGS84.cartographicToCartesian(center),
-          });
+        // Center camera on I3S once it's loaded
+        await i3sProvider.readyPromise;
+        const center = Cesium.Rectangle.center(i3sProvider.extent);
+        center.height = 10000.0;
+        viewer.camera.setView({
+          destination: Cesium.Ellipsoid.WGS84.cartographicToCartesian(center),
+        });
 
-          // An entity object which will hold info about the currently selected feature for infobox display
-          const selectedEntity = new Cesium.Entity();
-          // Show metadata in the InfoBox.
-          viewer.screenSpaceEventHandler.setInputAction(function onLeftClick(
-            movement
+        // An entity object which will hold info about the currently selected feature for infobox display
+        const selectedEntity = new Cesium.Entity();
+        // Show metadata in the InfoBox.
+        viewer.screenSpaceEventHandler.setInputAction(function onLeftClick(
+          movement
+        ) {
+          // Pick a new feature
+          const pickedFeature = viewer.scene.pick(movement.position);
+          if (!Cesium.defined(pickedFeature)) {
+            return;
+          }
+
+          const pickedPosition = viewer.scene.pickPosition(movement.position);
+
+          if (
+            Cesium.defined(pickedFeature.content) &&
+            Cesium.defined(pickedFeature.content.tile.i3sNode)
           ) {
-            // Pick a new feature
-            const pickedFeature = viewer.scene.pick(movement.position);
-            if (!Cesium.defined(pickedFeature)) {
-              return;
-            }
+            const i3sNode = pickedFeature.content.tile.i3sNode;
+            if (pickedPosition) {
+              i3sNode.loadFields().then(function () {
+                let description = "No attributes";
+                let name;
+                console.log(
+                  `pickedPosition(x,y,z) : ${pickedPosition.x}, ${pickedPosition.y}, ${pickedPosition.z}`
+                );
 
-            const pickedPosition = viewer.scene.pickPosition(movement.position);
-
-            if (
-              Cesium.defined(pickedFeature.content) &&
-              Cesium.defined(pickedFeature.content.tile.i3sNode)
-            ) {
-              const i3sNode = pickedFeature.content.tile.i3sNode;
-              if (pickedPosition) {
-                i3sNode.loadFields().then(function () {
-                  let description = "No attributes";
-                  let name;
-                  console.log(
-                    `pickedPosition(x,y,z) : ${pickedPosition.x}, ${pickedPosition.y}, ${pickedPosition.z}`
-                  );
-
-                  const fields = i3sNode.getFieldsForPickedPosition(
-                    pickedPosition
-                  );
-                  if (Object.keys(fields).length > 0) {
-                    description =
-                      '<table class="cesium-infoBox-defaultTable"><tbody>';
-                    for (const fieldName in fields) {
-                      if (i3sNode.fields.hasOwnProperty(fieldName)) {
-                        description += `<tr><th>${fieldName}</th><td>`;
-                        description += `${fields[fieldName]}</td></tr>`;
-                        console.log(`${fieldName}: ${fields[fieldName]}`);
-                        if (
-                          !Cesium.defined(name) &&
-                          isNameProperty(fieldName)
-                        ) {
-                          name = fields[fieldName];
-                        }
+                const fields = i3sNode.getFieldsForPickedPosition(
+                  pickedPosition
+                );
+                if (Object.keys(fields).length > 0) {
+                  description =
+                    '<table class="cesium-infoBox-defaultTable"><tbody>';
+                  for (const fieldName in fields) {
+                    if (i3sNode.fields.hasOwnProperty(fieldName)) {
+                      description += `<tr><th>${fieldName}</th><td>`;
+                      description += `${fields[fieldName]}</td></tr>`;
+                      console.log(`${fieldName}: ${fields[fieldName]}`);
+                      if (!Cesium.defined(name) && isNameProperty(fieldName)) {
+                        name = fields[fieldName];
                       }
                     }
-                    description += `</tbody></table>`;
                   }
-                  if (!Cesium.defined(name)) {
-                    name = "unknown";
-                  }
-                  selectedEntity.name = name;
-                  selectedEntity.description = description;
-                  viewer.selectedEntity = selectedEntity;
-                });
-              }
+                  description += `</tbody></table>`;
+                }
+                if (!Cesium.defined(name)) {
+                  name = "unknown";
+                }
+                selectedEntity.name = name;
+                selectedEntity.description = description;
+                viewer.selectedEntity = selectedEntity;
+              });
             }
-          },
-          Cesium.ScreenSpaceEventType.LEFT_CLICK);
-
-          function isNameProperty(propertyName) {
-            const name = propertyName.toLowerCase();
-            if (
-              name.localeCompare("name") === 0 ||
-              name.localeCompare("objname") === 0
-            ) {
-              return true;
-            }
-            return false;
           }
-        })(); //Sandcastle_End
+        },
+        Cesium.ScreenSpaceEventType.LEFT_CLICK);
+
+        function isNameProperty(propertyName) {
+          const name = propertyName.toLowerCase();
+          if (
+            name.localeCompare("name") === 0 ||
+            name.localeCompare("objname") === 0
+          ) {
+            return true;
+          }
+          return false;
+        } //Sandcastle_End
         if (typeof Cesium !== "undefined") {
           window.startupCalled = true;
-          window.startup(Cesium);
+          try {
+            window.startup(Cesium);
+          } catch (error) {
+            console.error(error);
+          }
         }
       };
     </script>

--- a/Apps/Sandcastle/gallery/I3S IntegratedMesh Layer.html
+++ b/Apps/Sandcastle/gallery/I3S IntegratedMesh Layer.html
@@ -85,15 +85,15 @@
         viewer.camera.setView({
           destination: Cesium.Ellipsoid.WGS84.cartographicToCartesian(center),
         }); //Sandcastle_End
-        if (typeof Cesium !== "undefined") {
-          window.startupCalled = true;
-          try {
-            window.startup(Cesium);
-          } catch (error) {
-            console.error(error);
-          }
-        }
       };
+      if (typeof Cesium !== "undefined") {
+        window.startupCalled = true;
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
+      }
     </script>
   </body>
 </html>

--- a/Apps/Sandcastle/gallery/I3S IntegratedMesh Layer.html
+++ b/Apps/Sandcastle/gallery/I3S IntegratedMesh Layer.html
@@ -35,61 +35,63 @@
     </div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-            animation: false,
-            timeline: false,
-          });
-          // Suppress terrain data to avoid clashing with IntegratedMesh layer geometry
-          viewer.scene.globe.depthTestAgainstTerrain = false;
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          animation: false,
+          timeline: false,
+        });
+        // Suppress terrain data to avoid clashing with IntegratedMesh layer geometry
+        viewer.scene.globe.depthTestAgainstTerrain = false;
 
-          // More datasets to tour can be added here..
-          // The url passed to I3SDataProvider supports loading a single Indexed 3D Scene (I3S) layer (.<host>/SceneServer/layers/<id>) or a collection of scene layers (.<host>/SceneServer) from a SceneServer.
-          const tours = {
-            Frankfurt:
-              "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/Frankfurt2017_vi3s_18/SceneServer/layers/0",
-          };
-          // Initialize a terrain provider which provides geoid conversion between gravity related (typically I3S datasets) and ellipsoidal based
-          // height systems (Cesium World Terrain).
-          // If this is not specified, or the URL is invalid no geoid conversion will be applied.
-          // The source data used in this transcoding service was compiled from https://earth-info.nga.mil/#tab_wgs84-data and is based on EGM2008 Gravity Model
-          const geoidService = await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
-            "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/EGM2008/ImageServer"
-          );
+        // More datasets to tour can be added here..
+        // The url passed to I3SDataProvider supports loading a single Indexed 3D Scene (I3S) layer (.<host>/SceneServer/layers/<id>) or a collection of scene layers (.<host>/SceneServer) from a SceneServer.
+        const tours = {
+          Frankfurt:
+            "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/Frankfurt2017_vi3s_18/SceneServer/layers/0",
+        };
+        // Initialize a terrain provider which provides geoid conversion between gravity related (typically I3S datasets) and ellipsoidal based
+        // height systems (Cesium World Terrain).
+        // If this is not specified, or the URL is invalid no geoid conversion will be applied.
+        // The source data used in this transcoding service was compiled from https://earth-info.nga.mil/#tab_wgs84-data and is based on EGM2008 Gravity Model
+        const geoidService = await Cesium.ArcGISTiledElevationTerrainProvider.fromUrl(
+          "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/EGM2008/ImageServer"
+        );
 
-          // Create i3s and Cesium3DTileset options to pass optional parameters useful for debugging and visualizing
-          const cesium3dTilesetOptions = {
-            skipLevelOfDetail: false,
-            debugShowBoundingVolume: false,
-          };
-          const i3sOptions = {
-            url: tours.Frankfurt,
-            traceFetches: false, // for tracing I3S fetches
-            geoidTiledTerrainProvider: geoidService, // pass the geoid service
-            cesium3dTilesetOptions: cesium3dTilesetOptions, // options for internal Cesium3dTileset
-          };
+        // Create i3s and Cesium3DTileset options to pass optional parameters useful for debugging and visualizing
+        const cesium3dTilesetOptions = {
+          skipLevelOfDetail: false,
+          debugShowBoundingVolume: false,
+        };
+        const i3sOptions = {
+          url: tours.Frankfurt,
+          traceFetches: false, // for tracing I3S fetches
+          geoidTiledTerrainProvider: geoidService, // pass the geoid service
+          cesium3dTilesetOptions: cesium3dTilesetOptions, // options for internal Cesium3dTileset
+        };
 
-          // Create I3S data provider
-          const i3sProvider = new Cesium.I3SDataProvider(i3sOptions);
+        // Create I3S data provider
+        const i3sProvider = new Cesium.I3SDataProvider(i3sOptions);
 
-          // Add the i3s layer provider as a primitive data type
-          viewer.scene.primitives.add(i3sProvider);
+        // Add the i3s layer provider as a primitive data type
+        viewer.scene.primitives.add(i3sProvider);
 
-          // Center camera on I3S once it's loaded
-          await i3sProvider.readyPromise;
-          const center = Cesium.Rectangle.center(i3sProvider.extent);
-          center.height = 10000.0;
-          viewer.camera.setView({
-            destination: Cesium.Ellipsoid.WGS84.cartographicToCartesian(center),
-          });
-        })(); //Sandcastle_End
+        // Center camera on I3S once it's loaded
+        await i3sProvider.readyPromise;
+        const center = Cesium.Rectangle.center(i3sProvider.extent);
+        center.height = 10000.0;
+        viewer.camera.setView({
+          destination: Cesium.Ellipsoid.WGS84.cartographicToCartesian(center),
+        }); //Sandcastle_End
         if (typeof Cesium !== "undefined") {
           window.startupCalled = true;
-          window.startup(Cesium);
+          try {
+            window.startup(Cesium);
+          } catch (error) {
+            console.error(error);
+          }
         }
       };
     </script>

--- a/Apps/Sandcastle/gallery/Image-Based Lighting.html
+++ b/Apps/Sandcastle/gallery/Image-Based Lighting.html
@@ -54,7 +54,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -207,11 +207,14 @@
             window.alert(error);
           });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Imagery Adjustment.html
+++ b/Apps/Sandcastle/gallery/Imagery Adjustment.html
@@ -112,7 +112,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -166,11 +166,14 @@
         imageryLayers.layerMoved.addEventListener(updateViewModel);
         updateViewModel();
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Imagery Color To Alpha.html
+++ b/Apps/Sandcastle/gallery/Imagery Color To Alpha.html
@@ -54,7 +54,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -93,11 +93,14 @@
               viewModel.threshold
             );
           }); //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Imagery Cutout.html
+++ b/Apps/Sandcastle/gallery/Imagery Cutout.html
@@ -46,7 +46,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -182,11 +182,14 @@
         }
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Imagery Layers Manipulation.html
+++ b/Apps/Sandcastle/gallery/Imagery Layers Manipulation.html
@@ -104,7 +104,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -325,11 +325,14 @@
           });
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Imagery Layers Split.html
+++ b/Apps/Sandcastle/gallery/Imagery Layers Split.html
@@ -53,7 +53,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -111,11 +111,14 @@
         }, Cesium.ScreenSpaceEventType.PINCH_END);
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Imagery Layers Texture Filters.html
+++ b/Apps/Sandcastle/gallery/Imagery Layers Texture Filters.html
@@ -53,7 +53,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -115,12 +115,14 @@
           viewer.scene.splitPosition = splitPosition;
         }
         //Sandcastle_End
-
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Imagery Layers.html
+++ b/Apps/Sandcastle/gallery/Imagery Layers.html
@@ -35,7 +35,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -60,11 +60,14 @@
             rectangle: Cesium.Rectangle.fromDegrees(-75.0, 28.0, -67.0, 29.75),
           })
         ); //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Interpolation.html
+++ b/Apps/Sandcastle/gallery/Interpolation.html
@@ -34,22 +34,15 @@
       <div id="interpolationMenu"></div>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
           infoBox: false, //Disable InfoBox widget
           selectionIndicator: false, //Disable selection indicator
           shouldAnimate: true, // Enable animations
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
         });
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-          } catch (error) {
-            console.log(error);
-          }
-        })();
 
         //Enable lighting based on the sun position
         viewer.scene.globe.enableLighting = true;
@@ -207,11 +200,14 @@
           "interpolationMenu"
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/KML Tours.html
+++ b/Apps/Sandcastle/gallery/KML Tours.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -77,11 +77,14 @@
           viewer.clock.clockStep = Cesium.ClockStep.SYSTEM_CLOCK;
         };
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/KML.html
+++ b/Apps/Sandcastle/gallery/KML.html
@@ -30,7 +30,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -98,11 +98,14 @@
           viewer.clock.clockStep = Cesium.ClockStep.SYSTEM_CLOCK;
         };
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Labels.html
+++ b/Apps/Sandcastle/gallery/Labels.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -272,7 +272,11 @@
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Labels.html
+++ b/Apps/Sandcastle/gallery/Labels.html
@@ -268,15 +268,14 @@
           }
         };
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/LensFlare.html
+++ b/Apps/Sandcastle/gallery/LensFlare.html
@@ -101,7 +101,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -168,11 +168,14 @@
           27399.860215000022
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Lighting.html
+++ b/Apps/Sandcastle/gallery/Lighting.html
@@ -29,23 +29,17 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer");
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync({
+            requestWaterMask: true,
+            requestVertexNormals: true,
+          }),
+        });
         const scene = viewer.scene;
         scene.globe.enableLighting = true;
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync({
-              requestWaterMask: true,
-              requestVertexNormals: true,
-            });
-          } catch (error) {
-            console.log(error);
-          }
-        })();
 
         const scratchIcrfToFixed = new Cesium.Matrix3();
         const scratchMoonPosition = new Cesium.Cartesian3();
@@ -232,11 +226,14 @@
 
         Sandcastle.addToolbarMenu(options);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/LocalToFixedFrame.html
+++ b/Apps/Sandcastle/gallery/LocalToFixedFrame.html
@@ -62,7 +62,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -274,11 +274,14 @@
           rollSpan.innerHTML = Cesium.Math.toDegrees(hpRoll.roll).toFixed(1);
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/MSAA.html
+++ b/Apps/Sandcastle/gallery/MSAA.html
@@ -29,22 +29,15 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
           contextOptions: {
             requestWebgl1: false,
           },
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
         });
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-          } catch (error) {
-            console.log(error);
-          }
-        })();
 
         viewer.clock.currentTime = Cesium.JulianDate.fromIso8601(
           "2022-08-01T00:00:00Z"
@@ -183,11 +176,14 @@
         Sandcastle.addToolbarMenu(options);
         Sandcastle.addToolbarMenu(samplingOptions);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Manually Controlled Animation.html
+++ b/Apps/Sandcastle/gallery/Manually Controlled Animation.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -156,11 +156,14 @@
         viewer.trackedEntity = modelLabel;
         modelLabel.viewFrom = new Cesium.Cartesian3(-30.0, -10.0, 10.0);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Map Pins.html
+++ b/Apps/Sandcastle/gallery/Map Pins.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -93,11 +93,14 @@
         );
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Materials.html
+++ b/Apps/Sandcastle/gallery/Materials.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         let rectangle;
@@ -621,11 +621,14 @@
         createPrimitives(scene);
         createButtons(scene);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Montreal Point Cloud.html
+++ b/Apps/Sandcastle/gallery/Montreal Point Cloud.html
@@ -83,18 +83,12 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer");
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-          } catch (error) {
-            console.log(error);
-          }
-        })();
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
 
         // A ~10 billion point 3D Tileset of the city of Montreal, Canada captured in 2015 with a resolution of 20 cm. Tiled and hosted by Cesium ion.
         const tileset = viewer.scene.primitives.add(
@@ -429,11 +423,14 @@
             applyStyle(tileset, pointStyles);
           });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Multi-part CZML.html
+++ b/Apps/Sandcastle/gallery/Multi-part CZML.html
@@ -36,7 +36,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -170,11 +170,14 @@
         fuelDisplay.style.marginTop = "5px";
         document.getElementById("toolbar").appendChild(fuelDisplay);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Multiple Synced Views.html
+++ b/Apps/Sandcastle/gallery/Multiple Synced Views.html
@@ -48,7 +48,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // We want our two views to be synced across time, so we create
@@ -120,11 +120,14 @@
         view2D.scene.screenSpaceCameraController.enableTilt = false;
         view2D.scene.screenSpaceCameraController.enableLook = false;
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Natural Earth II.html
+++ b/Apps/Sandcastle/gallery/Natural Earth II.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Natural Earth II with Shaded Relief, Water, and Drainages from http://www.naturalearthdata.com
@@ -40,11 +40,14 @@
           imageryProvider: new Cesium.IonImageryProvider({ assetId: 3813 }),
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Offline.html
+++ b/Apps/Sandcastle/gallery/Offline.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // This is an example of using Cesium "Offline", meaning disconnected from the
@@ -48,11 +48,14 @@
           geocoder: false,
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/PAMAP Terrain.html
+++ b/Apps/Sandcastle/gallery/PAMAP Terrain.html
@@ -32,22 +32,16 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer");
-
-        (async () => {
-          try {
-            // High resolution terrain of Pennsylvania curated by Pennsylvania Spatial Data Access (PASDA)
-            // http://www.pasda.psu.edu/
-            viewer.terrainProvider = await Cesium.CesiumTerrainProvider.fromUrl(
-              Cesium.IonResource.fromAssetId(3957)
-            );
-          } catch (error) {
-            console.log(error);
-          }
-        })();
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          // High resolution terrain of Pennsylvania curated by Pennsylvania Spatial Data Access (PASDA)
+          // http://www.pasda.psu.edu/
+          terrainProvider: await Cesium.CesiumTerrainProvider.fromUrl(
+            Cesium.IonResource.fromAssetId(3957)
+          ),
+        });
 
         // Add PA locations
         Sandcastle.addDefaultToolbarMenu(
@@ -141,11 +135,14 @@
           "toolbar"
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Parallels and Meridians.html
+++ b/Apps/Sandcastle/gallery/Parallels and Meridians.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -311,11 +311,14 @@
           }
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Partial Ellipsoids.html
+++ b/Apps/Sandcastle/gallery/Partial Ellipsoids.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -214,11 +214,14 @@
 
         viewer.zoomTo(viewer.entities);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Particle System Fireworks.html
+++ b/Apps/Sandcastle/gallery/Particle System Fireworks.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -212,11 +212,14 @@
           );
         camera.lookUp(angle);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Particle System Tails.html
+++ b/Apps/Sandcastle/gallery/Particle System Tails.html
@@ -35,7 +35,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -296,12 +296,15 @@
         ];
         Sandcastle.addToolbarMenu(options);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
 
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Particle System Weather.html
+++ b/Apps/Sandcastle/gallery/Particle System Weather.html
@@ -32,22 +32,15 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
           shouldAnimate: true,
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
         });
         const scene = viewer.scene;
         scene.globe.depthTestAgainstTerrain = true;
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-          } catch (error) {
-            console.log(error);
-          }
-        })();
 
         const resetCameraFunction = function () {
           scene.camera.setView({
@@ -209,12 +202,15 @@
         ];
         Sandcastle.addToolbarMenu(options);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
 
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Particle System.html
+++ b/Apps/Sandcastle/gallery/Particle System.html
@@ -184,7 +184,7 @@
     </div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -460,11 +460,14 @@
 
         Sandcastle.addToolbarMenu(options);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Per-Feature Post Processing.html
+++ b/Apps/Sandcastle/gallery/Per-Feature Post Processing.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -111,11 +111,14 @@
           },
         ]);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Physically-Based Materials.html
+++ b/Apps/Sandcastle/gallery/Physically-Based Materials.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const clock = new Cesium.Clock({
@@ -48,15 +48,8 @@
         const viewer = new Cesium.Viewer("cesiumContainer", {
           clockViewModel: new Cesium.ClockViewModel(clock),
           selectionIndicator: false,
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
         });
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-          } catch (error) {
-            console.log(error);
-          }
-        })();
 
         Sandcastle.addToggleButton("Shadows", viewer.shadows, function (
           checked
@@ -199,11 +192,14 @@
           "toolbar"
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Picking.html
+++ b/Apps/Sandcastle/gallery/Picking.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -281,11 +281,14 @@
           handler = handler && handler.destroy();
         };
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Plane.html
+++ b/Apps/Sandcastle/gallery/Plane.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -70,11 +70,14 @@
 
         viewer.zoomTo(viewer.entities);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Points.html
+++ b/Apps/Sandcastle/gallery/Points.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -186,11 +186,14 @@
           viewer.entities.removeAll();
         };
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Polygon.html
+++ b/Apps/Sandcastle/gallery/Polygon.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -306,11 +306,14 @@
         });
 
         viewer.zoomTo(viewer.entities); //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Polyline Dash.html
+++ b/Apps/Sandcastle/gallery/Polyline Dash.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -130,11 +130,14 @@
 
         viewer.zoomTo(viewer.entities);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Polyline Volume.html
+++ b/Apps/Sandcastle/gallery/Polyline Volume.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -130,11 +130,14 @@
 
         viewer.zoomTo(viewer.entities);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Polyline.html
+++ b/Apps/Sandcastle/gallery/Polyline.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -130,11 +130,14 @@
 
         viewer.zoomTo(viewer.entities);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Polylines on 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/Polylines on 3D Tiles.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Power Plant design model provided by Bentley Systems
@@ -183,11 +183,14 @@
             },
           },
         ]); //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Post Processing.html
+++ b/Apps/Sandcastle/gallery/Post Processing.html
@@ -77,7 +77,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -152,11 +152,14 @@
         }
         updatePostProcess();
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Procedural Terrain.html
+++ b/Apps/Sandcastle/gallery/Procedural Terrain.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
 
@@ -163,11 +163,14 @@
         });
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Projection.html
+++ b/Apps/Sandcastle/gallery/Projection.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Click the projection picker to switch between orthographic and perspective projections.
@@ -69,11 +69,14 @@
         });
         viewer.trackedEntity = entity;
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Rectangle.html
+++ b/Apps/Sandcastle/gallery/Rectangle.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -88,11 +88,14 @@
 
         viewer.zoomTo(viewer.entities);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Resolution Scaling.html
+++ b/Apps/Sandcastle/gallery/Resolution Scaling.html
@@ -59,7 +59,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // When browser recommended resolution is enabled, the viewer renders at
@@ -102,11 +102,14 @@
         }
         update();
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Rotatable 2D Map.html
+++ b/Apps/Sandcastle/gallery/Rotatable 2D Map.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -47,11 +47,14 @@
           },
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Sample Height from 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/Sample Height from 3D Tiles.html
@@ -32,19 +32,13 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer");
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
         const scene = viewer.scene;
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-          } catch (error) {
-            console.log(error);
-          }
-        })();
 
         if (!scene.clampToHeightSupported) {
           window.alert(
@@ -131,11 +125,14 @@
           });
         }
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Scene Rendering Performance.html
+++ b/Apps/Sandcastle/gallery/Scene Rendering Performance.html
@@ -138,7 +138,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create a viewer that won't render a new frame unless
@@ -146,15 +146,8 @@
         const viewer = new Cesium.Viewer("cesiumContainer", {
           requestRenderMode: true,
           maximumRenderTimeChange: Infinity,
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
         });
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-          } catch (error) {
-            console.log(error);
-          }
-        })();
 
         const scene = viewer.scene;
         scene.debugShowFramesPerSecond = true;
@@ -356,11 +349,14 @@
 
         Sandcastle.addToolbarMenu(scenarios);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Sentinel-2.html
+++ b/Apps/Sandcastle/gallery/Sentinel-2.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Sentinel-2 (mostly) cloudless global imagery between 10 and 60 meter resolution.
@@ -40,11 +40,14 @@
           imageryProvider: new Cesium.IonImageryProvider({ assetId: 3954 }),
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Shadows.html
+++ b/Apps/Sandcastle/gallery/Shadows.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -41,15 +41,8 @@
           shadows: true,
           terrainShadows: Cesium.ShadowMode.ENABLED,
           shouldAnimate: true,
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
         });
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-          } catch (error) {
-            console.log(error);
-          }
-        })();
 
         const shadowMap = viewer.shadowMap;
         shadowMap.maximumDistance = 10000.0;
@@ -306,11 +299,14 @@
         setLocation(locations.Exton);
         setEntity(cesiumAir);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Show or Hide Entities.html
+++ b/Apps/Sandcastle/gallery/Show or Hide Entities.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         //Set the random seed for reproducible random colors.
@@ -88,11 +88,14 @@
           spheres.show = !spheres.show;
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Spheres and Ellipsoids.html
+++ b/Apps/Sandcastle/gallery/Spheres and Ellipsoids.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -69,11 +69,14 @@
 
         viewer.zoomTo(viewer.entities);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Star Burst.html
+++ b/Apps/Sandcastle/gallery/Star Burst.html
@@ -31,7 +31,7 @@
       <div id="zoomButtons"></div>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -408,11 +408,14 @@
         }
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Terrain Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/Terrain Clipping Planes.html
@@ -58,363 +58,355 @@
       Edge styling enabled
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          // Use clipping planes to selectively hide parts of the globe surface.
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            skyAtmosphere: false,
-            shouldAnimate: true,
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-            scene3DOnly: true,
+        // Use clipping planes to selectively hide parts of the globe surface.
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          skyAtmosphere: false,
+          shouldAnimate: true,
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+          scene3DOnly: true,
+        });
+        const globe = viewer.scene.globe;
+
+        const exampleTypes = [
+          "Cesium Man",
+          "St. Helens",
+          "Grand Canyon Isolated",
+        ];
+        const viewModel = {
+          exampleTypes: exampleTypes,
+          currentExampleType: exampleTypes[0],
+          clippingPlanesEnabled: true,
+          edgeStylingEnabled: true,
+        };
+        const toolbar = document.getElementById("toolbar");
+        Cesium.knockout.track(viewModel);
+        Cesium.knockout.applyBindings(viewModel, toolbar);
+
+        // For tracking state when switching exampleTypes
+        let clippingPlanesEnabled = true;
+        let edgeStylingEnabled = true;
+
+        let tileset;
+
+        loadCesiumMan();
+
+        function reset() {
+          viewer.entities.removeAll();
+          viewer.scene.primitives.remove(tileset);
+        }
+
+        function loadCesiumMan() {
+          const position = Cesium.Cartesian3.fromRadians(
+            -2.0862979473351286,
+            0.6586620013036164,
+            1400.0
+          );
+
+          const entity = viewer.entities.add({
+            position: position,
+            box: {
+              dimensions: new Cesium.Cartesian3(1400.0, 1400.0, 2800.0),
+              material: Cesium.Color.WHITE.withAlpha(0.3),
+              outline: true,
+              outlineColor: Cesium.Color.WHITE,
+            },
           });
-          const globe = viewer.scene.globe;
 
-          const exampleTypes = [
-            "Cesium Man",
-            "St. Helens",
-            "Grand Canyon Isolated",
+          viewer.entities.add({
+            position: position,
+            model: {
+              uri: "../../SampleData/models/CesiumMan/Cesium_Man.glb",
+              minimumPixelSize: 128,
+              maximumScale: 800,
+            },
+          });
+
+          globe.depthTestAgainstTerrain = true;
+          globe.clippingPlanes = new Cesium.ClippingPlaneCollection({
+            modelMatrix: entity.computeModelMatrix(Cesium.JulianDate.now()),
+            planes: [
+              new Cesium.ClippingPlane(
+                new Cesium.Cartesian3(1.0, 0.0, 0.0),
+                -700.0
+              ),
+              new Cesium.ClippingPlane(
+                new Cesium.Cartesian3(-1.0, 0.0, 0.0),
+                -700.0
+              ),
+              new Cesium.ClippingPlane(
+                new Cesium.Cartesian3(0.0, 1.0, 0.0),
+                -700.0
+              ),
+              new Cesium.ClippingPlane(
+                new Cesium.Cartesian3(0.0, -1.0, 0.0),
+                -700.0
+              ),
+            ],
+            edgeWidth: edgeStylingEnabled ? 1.0 : 0.0,
+            edgeColor: Cesium.Color.WHITE,
+            enabled: clippingPlanesEnabled,
+          });
+          globe.backFaceCulling = true;
+          globe.showSkirts = true;
+
+          viewer.trackedEntity = entity;
+        }
+
+        function loadStHelens() {
+          // Create clipping planes for polygon around area to be clipped.
+          const points = [
+            new Cesium.Cartesian3(
+              -2358434.3501556474,
+              -3743554.5012105294,
+              4581080.771684084
+            ),
+            new Cesium.Cartesian3(
+              -2357886.4482675144,
+              -3744467.562778789,
+              4581020.9199767085
+            ),
+            new Cesium.Cartesian3(
+              -2357299.84353055,
+              -3744954.0879047974,
+              4581080.992360969
+            ),
+            new Cesium.Cartesian3(
+              -2356412.05169956,
+              -3745385.3013702347,
+              4580893.4737207815
+            ),
+            new Cesium.Cartesian3(
+              -2355472.889436636,
+              -3745256.5725702164,
+              4581252.3128526565
+            ),
+            new Cesium.Cartesian3(
+              -2354385.7458722834,
+              -3744319.3823686405,
+              4582372.770031389
+            ),
+            new Cesium.Cartesian3(
+              -2353758.788158616,
+              -3743051.0128084184,
+              4583356.453176038
+            ),
+            new Cesium.Cartesian3(
+              -2353663.8128999653,
+              -3741847.9126874236,
+              4584079.428665509
+            ),
+            new Cesium.Cartesian3(
+              -2354213.667592133,
+              -3740784.50946316,
+              4584502.428203525
+            ),
+            new Cesium.Cartesian3(
+              -2355596.239450013,
+              -3739901.0226732804,
+              4584515.9652557485
+            ),
+            new Cesium.Cartesian3(
+              -2356942.4170108805,
+              -3740342.454698685,
+              4583686.690694482
+            ),
+            new Cesium.Cartesian3(
+              -2357529.554838029,
+              -3740766.995076834,
+              4583145.055348843
+            ),
+            new Cesium.Cartesian3(
+              -2358106.017822064,
+              -3741439.438418052,
+              4582452.293605261
+            ),
+            new Cesium.Cartesian3(
+              -2358539.5426236596,
+              -3742680.720902901,
+              4581692.0260975715
+            ),
           ];
-          const viewModel = {
-            exampleTypes: exampleTypes,
-            currentExampleType: exampleTypes[0],
-            clippingPlanesEnabled: true,
-            edgeStylingEnabled: true,
-          };
-          const toolbar = document.getElementById("toolbar");
-          Cesium.knockout.track(viewModel);
-          Cesium.knockout.applyBindings(viewModel, toolbar);
 
-          // For tracking state when switching exampleTypes
-          let clippingPlanesEnabled = true;
-          let edgeStylingEnabled = true;
+          const pointsLength = points.length;
 
-          let tileset;
-
-          loadCesiumMan();
-
-          function reset() {
-            viewer.entities.removeAll();
-            viewer.scene.primitives.remove(tileset);
-          }
-
-          function loadCesiumMan() {
-            const position = Cesium.Cartesian3.fromRadians(
-              -2.0862979473351286,
-              0.6586620013036164,
-              1400.0
+          // Create center points for each clipping plane
+          const clippingPlanes = [];
+          for (let i = 0; i < pointsLength; ++i) {
+            const nextIndex = (i + 1) % pointsLength;
+            let midpoint = Cesium.Cartesian3.add(
+              points[i],
+              points[nextIndex],
+              new Cesium.Cartesian3()
+            );
+            midpoint = Cesium.Cartesian3.multiplyByScalar(
+              midpoint,
+              0.5,
+              midpoint
             );
 
-            const entity = viewer.entities.add({
-              position: position,
-              box: {
-                dimensions: new Cesium.Cartesian3(1400.0, 1400.0, 2800.0),
-                material: Cesium.Color.WHITE.withAlpha(0.3),
-                outline: true,
-                outlineColor: Cesium.Color.WHITE,
-              },
-            });
+            const up = Cesium.Cartesian3.normalize(
+              midpoint,
+              new Cesium.Cartesian3()
+            );
+            let right = Cesium.Cartesian3.subtract(
+              points[nextIndex],
+              midpoint,
+              new Cesium.Cartesian3()
+            );
+            right = Cesium.Cartesian3.normalize(right, right);
 
-            viewer.entities.add({
-              position: position,
-              model: {
-                uri: "../../SampleData/models/CesiumMan/Cesium_Man.glb",
-                minimumPixelSize: 128,
-                maximumScale: 800,
-              },
-            });
+            let normal = Cesium.Cartesian3.cross(
+              right,
+              up,
+              new Cesium.Cartesian3()
+            );
+            normal = Cesium.Cartesian3.normalize(normal, normal);
 
-            globe.depthTestAgainstTerrain = true;
-            globe.clippingPlanes = new Cesium.ClippingPlaneCollection({
-              modelMatrix: entity.computeModelMatrix(Cesium.JulianDate.now()),
-              planes: [
-                new Cesium.ClippingPlane(
-                  new Cesium.Cartesian3(1.0, 0.0, 0.0),
-                  -700.0
-                ),
-                new Cesium.ClippingPlane(
-                  new Cesium.Cartesian3(-1.0, 0.0, 0.0),
-                  -700.0
-                ),
-                new Cesium.ClippingPlane(
-                  new Cesium.Cartesian3(0.0, 1.0, 0.0),
-                  -700.0
-                ),
-                new Cesium.ClippingPlane(
-                  new Cesium.Cartesian3(0.0, -1.0, 0.0),
-                  -700.0
-                ),
-              ],
-              edgeWidth: edgeStylingEnabled ? 1.0 : 0.0,
-              edgeColor: Cesium.Color.WHITE,
-              enabled: clippingPlanesEnabled,
-            });
-            globe.backFaceCulling = true;
-            globe.showSkirts = true;
+            // Compute distance by pretending the plane is at the origin
+            const originCenteredPlane = new Cesium.Plane(normal, 0.0);
+            const distance = Cesium.Plane.getPointDistance(
+              originCenteredPlane,
+              midpoint
+            );
 
-            viewer.trackedEntity = entity;
+            clippingPlanes.push(new Cesium.ClippingPlane(normal, distance));
           }
+          globe.clippingPlanes = new Cesium.ClippingPlaneCollection({
+            planes: clippingPlanes,
+            edgeWidth: edgeStylingEnabled ? 1.0 : 0.0,
+            edgeColor: Cesium.Color.WHITE,
+            enabled: clippingPlanesEnabled,
+          });
+          globe.backFaceCulling = true;
+          globe.showSkirts = true;
 
-          function loadStHelens() {
-            // Create clipping planes for polygon around area to be clipped.
-            const points = [
-              new Cesium.Cartesian3(
-                -2358434.3501556474,
-                -3743554.5012105294,
-                4581080.771684084
-              ),
-              new Cesium.Cartesian3(
-                -2357886.4482675144,
-                -3744467.562778789,
-                4581020.9199767085
-              ),
-              new Cesium.Cartesian3(
-                -2357299.84353055,
-                -3744954.0879047974,
-                4581080.992360969
-              ),
-              new Cesium.Cartesian3(
-                -2356412.05169956,
-                -3745385.3013702347,
-                4580893.4737207815
-              ),
-              new Cesium.Cartesian3(
-                -2355472.889436636,
-                -3745256.5725702164,
-                4581252.3128526565
-              ),
-              new Cesium.Cartesian3(
-                -2354385.7458722834,
-                -3744319.3823686405,
-                4582372.770031389
-              ),
-              new Cesium.Cartesian3(
-                -2353758.788158616,
-                -3743051.0128084184,
-                4583356.453176038
-              ),
-              new Cesium.Cartesian3(
-                -2353663.8128999653,
-                -3741847.9126874236,
-                4584079.428665509
-              ),
-              new Cesium.Cartesian3(
-                -2354213.667592133,
-                -3740784.50946316,
-                4584502.428203525
-              ),
-              new Cesium.Cartesian3(
-                -2355596.239450013,
-                -3739901.0226732804,
-                4584515.9652557485
-              ),
-              new Cesium.Cartesian3(
-                -2356942.4170108805,
-                -3740342.454698685,
-                4583686.690694482
-              ),
-              new Cesium.Cartesian3(
-                -2357529.554838029,
-                -3740766.995076834,
-                4583145.055348843
-              ),
-              new Cesium.Cartesian3(
-                -2358106.017822064,
-                -3741439.438418052,
-                4582452.293605261
-              ),
-              new Cesium.Cartesian3(
-                -2358539.5426236596,
-                -3742680.720902901,
-                4581692.0260975715
-              ),
-            ];
-
-            const pointsLength = points.length;
-
-            // Create center points for each clipping plane
-            const clippingPlanes = [];
-            for (let i = 0; i < pointsLength; ++i) {
-              const nextIndex = (i + 1) % pointsLength;
-              let midpoint = Cesium.Cartesian3.add(
-                points[i],
-                points[nextIndex],
+          // Load tileset
+          tileset = new Cesium.Cesium3DTileset({
+            url: Cesium.IonResource.fromAssetId(5713),
+          });
+          return tileset.readyPromise
+            .then(function () {
+              // Adjust height so tileset is in terrain
+              const cartographic = Cesium.Cartographic.fromCartesian(
+                tileset.boundingSphere.center
+              );
+              const surface = Cesium.Cartesian3.fromRadians(
+                cartographic.longitude,
+                cartographic.latitude,
+                0.0
+              );
+              const offset = Cesium.Cartesian3.fromRadians(
+                cartographic.longitude,
+                cartographic.latitude,
+                -20.0
+              );
+              const translation = Cesium.Cartesian3.subtract(
+                offset,
+                surface,
                 new Cesium.Cartesian3()
               );
-              midpoint = Cesium.Cartesian3.multiplyByScalar(
-                midpoint,
-                0.5,
-                midpoint
-              );
+              tileset.modelMatrix = Cesium.Matrix4.fromTranslation(translation);
 
-              const up = Cesium.Cartesian3.normalize(
-                midpoint,
-                new Cesium.Cartesian3()
-              );
-              let right = Cesium.Cartesian3.subtract(
-                points[nextIndex],
-                midpoint,
-                new Cesium.Cartesian3()
-              );
-              right = Cesium.Cartesian3.normalize(right, right);
-
-              let normal = Cesium.Cartesian3.cross(
-                right,
-                up,
-                new Cesium.Cartesian3()
-              );
-              normal = Cesium.Cartesian3.normalize(normal, normal);
-
-              // Compute distance by pretending the plane is at the origin
-              const originCenteredPlane = new Cesium.Plane(normal, 0.0);
-              const distance = Cesium.Plane.getPointDistance(
-                originCenteredPlane,
-                midpoint
-              );
-
-              clippingPlanes.push(new Cesium.ClippingPlane(normal, distance));
-            }
-            globe.clippingPlanes = new Cesium.ClippingPlaneCollection({
-              planes: clippingPlanes,
-              edgeWidth: edgeStylingEnabled ? 1.0 : 0.0,
-              edgeColor: Cesium.Color.WHITE,
-              enabled: clippingPlanesEnabled,
-            });
-            globe.backFaceCulling = true;
-            globe.showSkirts = true;
-
-            // Load tileset
-            tileset = new Cesium.Cesium3DTileset({
-              url: Cesium.IonResource.fromAssetId(5713),
-            });
-            return tileset.readyPromise
-              .then(function () {
-                // Adjust height so tileset is in terrain
-                const cartographic = Cesium.Cartographic.fromCartesian(
-                  tileset.boundingSphere.center
-                );
-                const surface = Cesium.Cartesian3.fromRadians(
-                  cartographic.longitude,
-                  cartographic.latitude,
-                  0.0
-                );
-                const offset = Cesium.Cartesian3.fromRadians(
-                  cartographic.longitude,
-                  cartographic.latitude,
-                  -20.0
-                );
-                const translation = Cesium.Cartesian3.subtract(
-                  offset,
-                  surface,
-                  new Cesium.Cartesian3()
-                );
-                tileset.modelMatrix = Cesium.Matrix4.fromTranslation(
-                  translation
-                );
-
-                tileset.style = new Cesium.Cesium3DTileStyle({
-                  color: "rgb(207, 255, 207)",
-                });
-
-                viewer.scene.primitives.add(tileset);
-
-                const boundingSphere = tileset.boundingSphere;
-
-                const radius = boundingSphere.radius;
-                viewer.camera.viewBoundingSphere(
-                  boundingSphere,
-                  new Cesium.HeadingPitchRange(0.5, -0.2, radius * 4.0)
-                );
-                viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-              })
-              .catch(function (error) {
-                throw error;
+              tileset.style = new Cesium.Cesium3DTileStyle({
+                color: "rgb(207, 255, 207)",
               });
-          }
 
-          function loadGrandCanyon() {
-            // Pick a position at the Grand Canyon
-            const position = Cesium.Cartographic.toCartesian(
-              new Cesium.Cartographic.fromDegrees(-113.2665534, 36.0939345, 100)
-            );
-            const distance = 3000.0;
-            const boundingSphere = new Cesium.BoundingSphere(
-              position,
-              distance
-            );
+              viewer.scene.primitives.add(tileset);
 
-            globe.clippingPlanes = new Cesium.ClippingPlaneCollection({
-              modelMatrix: Cesium.Transforms.eastNorthUpToFixedFrame(position),
-              planes: [
-                new Cesium.ClippingPlane(
-                  new Cesium.Cartesian3(1.0, 0.0, 0.0),
-                  distance
-                ),
-                new Cesium.ClippingPlane(
-                  new Cesium.Cartesian3(-1.0, 0.0, 0.0),
-                  distance
-                ),
-                new Cesium.ClippingPlane(
-                  new Cesium.Cartesian3(0.0, 1.0, 0.0),
-                  distance
-                ),
-                new Cesium.ClippingPlane(
-                  new Cesium.Cartesian3(0.0, -1.0, 0.0),
-                  distance
-                ),
-              ],
-              unionClippingRegions: true,
-              edgeWidth: edgeStylingEnabled ? 1.0 : 0.0,
-              edgeColor: Cesium.Color.WHITE,
-              enabled: clippingPlanesEnabled,
+              const boundingSphere = tileset.boundingSphere;
+
+              const radius = boundingSphere.radius;
+              viewer.camera.viewBoundingSphere(
+                boundingSphere,
+                new Cesium.HeadingPitchRange(0.5, -0.2, radius * 4.0)
+              );
+              viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+            })
+            .catch(function (error) {
+              throw error;
             });
-            globe.backFaceCulling = false;
-            globe.showSkirts = false;
+        }
 
-            viewer.camera.viewBoundingSphere(
-              boundingSphere,
-              new Cesium.HeadingPitchRange(
-                0.5,
-                -0.5,
-                boundingSphere.radius * 5.0
-              )
-            );
-            viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-          }
+        function loadGrandCanyon() {
+          // Pick a position at the Grand Canyon
+          const position = Cesium.Cartographic.toCartesian(
+            new Cesium.Cartographic.fromDegrees(-113.2665534, 36.0939345, 100)
+          );
+          const distance = 3000.0;
+          const boundingSphere = new Cesium.BoundingSphere(position, distance);
 
-          Cesium.knockout
-            .getObservable(viewModel, "clippingPlanesEnabled")
-            .subscribe(function (value) {
-              globe.clippingPlanes.enabled = value;
-              clippingPlanesEnabled = value;
-            });
+          globe.clippingPlanes = new Cesium.ClippingPlaneCollection({
+            modelMatrix: Cesium.Transforms.eastNorthUpToFixedFrame(position),
+            planes: [
+              new Cesium.ClippingPlane(
+                new Cesium.Cartesian3(1.0, 0.0, 0.0),
+                distance
+              ),
+              new Cesium.ClippingPlane(
+                new Cesium.Cartesian3(-1.0, 0.0, 0.0),
+                distance
+              ),
+              new Cesium.ClippingPlane(
+                new Cesium.Cartesian3(0.0, 1.0, 0.0),
+                distance
+              ),
+              new Cesium.ClippingPlane(
+                new Cesium.Cartesian3(0.0, -1.0, 0.0),
+                distance
+              ),
+            ],
+            unionClippingRegions: true,
+            edgeWidth: edgeStylingEnabled ? 1.0 : 0.0,
+            edgeColor: Cesium.Color.WHITE,
+            enabled: clippingPlanesEnabled,
+          });
+          globe.backFaceCulling = false;
+          globe.showSkirts = false;
 
-          Cesium.knockout
-            .getObservable(viewModel, "edgeStylingEnabled")
-            .subscribe(function (value) {
-              edgeStylingEnabled = value;
-              globe.clippingPlanes.edgeWidth = edgeStylingEnabled ? 1.0 : 0.0;
-            });
+          viewer.camera.viewBoundingSphere(
+            boundingSphere,
+            new Cesium.HeadingPitchRange(0.5, -0.5, boundingSphere.radius * 5.0)
+          );
+          viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+        }
 
-          Cesium.knockout
-            .getObservable(viewModel, "currentExampleType")
-            .subscribe(function (newValue) {
-              reset();
-              if (newValue === exampleTypes[0]) {
-                loadCesiumMan();
-              } else if (newValue === exampleTypes[1]) {
-                loadStHelens();
-              } else if (newValue === exampleTypes[2]) {
-                loadGrandCanyon();
-              }
-            });
-        })(); //Sandcastle_End
-        Sandcastle.finishedLoading();
+        Cesium.knockout
+          .getObservable(viewModel, "clippingPlanesEnabled")
+          .subscribe(function (value) {
+            globe.clippingPlanes.enabled = value;
+            clippingPlanesEnabled = value;
+          });
+
+        Cesium.knockout
+          .getObservable(viewModel, "edgeStylingEnabled")
+          .subscribe(function (value) {
+            edgeStylingEnabled = value;
+            globe.clippingPlanes.edgeWidth = edgeStylingEnabled ? 1.0 : 0.0;
+          });
+
+        Cesium.knockout
+          .getObservable(viewModel, "currentExampleType")
+          .subscribe(function (newValue) {
+            reset();
+            if (newValue === exampleTypes[0]) {
+              loadCesiumMan();
+            } else if (newValue === exampleTypes[1]) {
+              loadStHelens();
+            } else if (newValue === exampleTypes[2]) {
+              loadGrandCanyon();
+            }
+          }); //Sandcastle_End
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Terrain Exaggeration.html
+++ b/Apps/Sandcastle/gallery/Terrain Exaggeration.html
@@ -73,18 +73,12 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer");
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-          } catch (error) {
-            console.log(error);
-          }
-        })();
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
 
         const scene = viewer.scene;
         const globe = scene.globe;
@@ -198,11 +192,14 @@
           viewModel.relativeHeight = 0.0;
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Terrain.html
+++ b/Apps/Sandcastle/gallery/Terrain.html
@@ -36,21 +36,15 @@
       <div id="sampleButtons"></div>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer");
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync({
-              requestWaterMask: true,
-              requestVertexNormals: true,
-            });
-          } catch (error) {
-            console.log(error);
-          }
-        })();
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync({
+            requestWaterMask: true,
+            requestVertexNormals: true,
+          }),
+        });
 
         // set lighting to true
         viewer.scene.globe.enableLighting = true;
@@ -344,11 +338,14 @@
           "sampleButtons"
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Time Dynamic Point Cloud.html
+++ b/Apps/Sandcastle/gallery/Time Dynamic Point Cloud.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -94,11 +94,14 @@
           new Cesium.HeadingPitchRange(0.0, -0.5, 50.0)
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Time Dynamic Wheels.html
+++ b/Apps/Sandcastle/gallery/Time Dynamic Wheels.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -160,11 +160,14 @@
         viewer.trackedEntity = vehicleEntity;
         vehicleEntity.viewFrom = new Cesium.Cartesian3(-10.0, 7.0, 4.0);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Underground Color.html
+++ b/Apps/Sandcastle/gallery/Underground Color.html
@@ -108,7 +108,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -219,11 +219,14 @@
           globe.undergroundColorAlphaByDistance.farValue = farAlpha;
         }
         update(); //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Video.html
+++ b/Apps/Sandcastle/gallery/Video.html
@@ -54,7 +54,7 @@
       Your browser does not support the <code>video</code> element.
     </video>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -145,11 +145,14 @@
         });
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Wall.html
+++ b/Apps/Sandcastle/gallery/Wall.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -135,11 +135,14 @@
         });
         viewer.zoomTo(viewer.entities);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Washington DC 2017.html
+++ b/Apps/Sandcastle/gallery/Washington DC 2017.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // 3 inch (0.08m) resolution imagery of Washington DC collected in 2017
@@ -43,11 +43,14 @@
         );
         viewer.flyTo(imageryLayer);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Web Map Service (WMS).html
+++ b/Apps/Sandcastle/gallery/Web Map Service (WMS).html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -60,11 +60,14 @@
             -5.73
           ),
         }); //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Web Map Tile Service with Time.html
+++ b/Apps/Sandcastle/gallery/Web Map Tile Service with Time.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -94,11 +94,14 @@
           layer.alpha = 0.5;
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/Z-Indexing Geometry.html
+++ b/Apps/Sandcastle/gallery/Z-Indexing Geometry.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -141,11 +141,14 @@
 
         viewer.zoomTo(viewer.entities);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/3D Models Articulations.html
+++ b/Apps/Sandcastle/gallery/development/3D Models Articulations.html
@@ -74,7 +74,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // this can be changed to any glTF model
@@ -182,11 +182,14 @@
           });
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/3D Models Node Explorer.html
+++ b/Apps/Sandcastle/gallery/development/3D Models Node Explorer.html
@@ -189,7 +189,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // this can be changed to any glTF model
@@ -369,11 +369,14 @@
           });
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/3D Models.html
+++ b/Apps/Sandcastle/gallery/development/3D Models.html
@@ -90,7 +90,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -305,11 +305,14 @@
         });
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/3D Tiles Performance Testing.html
+++ b/Apps/Sandcastle/gallery/development/3D Tiles Performance Testing.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         /*
@@ -262,11 +262,14 @@ Sandcastle.addToolbarButton(VIEW, function() {\n\
 });`
           );
         }); //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/3D Tiles Split.html
+++ b/Apps/Sandcastle/gallery/development/3D Tiles Split.html
@@ -57,7 +57,7 @@
       <div><input type="checkbox" data-bind="checked: shadows" /> Shadows</div>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -283,11 +283,14 @@
           moveActive = false;
         }, Cesium.ScreenSpaceEventType.PINCH_END);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/BillboardClampToGround.html
+++ b/Apps/Sandcastle/gallery/development/BillboardClampToGround.html
@@ -34,19 +34,13 @@
       <div id="sampleButtons"></div>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer");
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
         viewer.scene.globe.depthTestAgainstTerrain = true;
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-          } catch (error) {
-            console.log(error);
-          }
-        })();
 
         const ellipsoid = viewer.scene.globe.ellipsoid;
         const billboardCollection = viewer.scene.primitives.add(
@@ -169,11 +163,14 @@
           }
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Billboards Instancing.html
+++ b/Apps/Sandcastle/gallery/development/Billboards Instancing.html
@@ -34,18 +34,12 @@
       <div id="sampleButtons"></div>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer");
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-          } catch (error) {
-            console.log(error);
-          }
-        })();
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
 
         const scene = viewer.scene;
         const context = scene.context;
@@ -233,11 +227,14 @@
 
         resetBillboardCollection();
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Billboards.html
+++ b/Apps/Sandcastle/gallery/development/Billboards.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -423,11 +423,14 @@
         };
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Box Outline.html
+++ b/Apps/Sandcastle/gallery/development/Box Outline.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -80,11 +80,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Box.html
+++ b/Apps/Sandcastle/gallery/development/Box.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -74,11 +74,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Circle Outline.html
+++ b/Apps/Sandcastle/gallery/development/Circle Outline.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -99,11 +99,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Circle.html
+++ b/Apps/Sandcastle/gallery/development/Circle.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -130,11 +130,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Coplanar Polygon Outline.html
+++ b/Apps/Sandcastle/gallery/development/Coplanar Polygon Outline.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -136,11 +136,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Coplanar Polygon.html
+++ b/Apps/Sandcastle/gallery/development/Coplanar Polygon.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -170,11 +170,14 @@
             }),
           })
         ); //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Corridor Outline.html
+++ b/Apps/Sandcastle/gallery/development/Corridor Outline.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -102,7 +102,11 @@
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        try {
+          window.startup(Cesium);
+        } catch (error) {
+          console.error(error);
+        }
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Corridor Outline.html
+++ b/Apps/Sandcastle/gallery/development/Corridor Outline.html
@@ -98,15 +98,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        try {
-          window.startup(Cesium);
-        } catch (error) {
+        window.startup(Cesium).catch((error) => {
+          "use strict";
           console.error(error);
-        }
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Corridor.html
+++ b/Apps/Sandcastle/gallery/development/Corridor.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer
@@ -154,11 +154,14 @@
             }),
           })
         ); //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Custom Primitive.html
+++ b/Apps/Sandcastle/gallery/development/Custom Primitive.html
@@ -37,7 +37,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
 
@@ -324,11 +324,14 @@
         });
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Cylinder Outline.html
+++ b/Apps/Sandcastle/gallery/development/Cylinder Outline.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -79,11 +79,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Cylinder.html
+++ b/Apps/Sandcastle/gallery/development/Cylinder.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -108,11 +108,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Display Conditions.html
+++ b/Apps/Sandcastle/gallery/development/Display Conditions.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -129,11 +129,14 @@
         };
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Ellipse Outline.html
+++ b/Apps/Sandcastle/gallery/development/Ellipse Outline.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -96,11 +96,14 @@
             }),
           })
         ); //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Ellipse.html
+++ b/Apps/Sandcastle/gallery/development/Ellipse.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -120,11 +120,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Ellipsoid Outline.html
+++ b/Apps/Sandcastle/gallery/development/Ellipsoid Outline.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -76,11 +76,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Ellipsoid Surface.html
+++ b/Apps/Sandcastle/gallery/development/Ellipsoid Surface.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -122,11 +122,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Ellipsoid.html
+++ b/Apps/Sandcastle/gallery/development/Ellipsoid.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -75,11 +75,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Fog.html
+++ b/Apps/Sandcastle/gallery/development/Fog.html
@@ -47,18 +47,12 @@
       <div id="zoomButtons"></div>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer");
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-          } catch (error) {
-            console.log(error);
-          }
-        })();
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
 
         viewer.extend(Cesium.viewerCesiumInspectorMixin);
 
@@ -144,11 +138,14 @@
           viewer.render();
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Frustum.html
+++ b/Apps/Sandcastle/gallery/development/Frustum.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -113,11 +113,14 @@
           scene.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Geometry Offset Attribute box cylinder ellipsoid.html
+++ b/Apps/Sandcastle/gallery/development/Geometry Offset Attribute box cylinder ellipsoid.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -286,11 +286,14 @@
           );
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Geometry Offset Attribute.html
+++ b/Apps/Sandcastle/gallery/development/Geometry Offset Attribute.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -263,11 +263,14 @@
         });
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Geometry and Appearances.html
+++ b/Apps/Sandcastle/gallery/development/Geometry and Appearances.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         Cesium.Math.setRandomNumberSeed(1234);
@@ -1278,11 +1278,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Ground Polyline Material.html
+++ b/Apps/Sandcastle/gallery/development/Ground Polyline Material.html
@@ -32,98 +32,99 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
-          });
-          const scene = viewer.scene;
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
+        const scene = viewer.scene;
 
-          if (!Cesium.GroundPolylinePrimitive.isSupported(scene)) {
-            window.alert(
-              "Polylines on terrain are not supported on this platform."
-            );
-          }
-
-          // Polyline Glow
-          scene.groundPrimitives.add(
-            new Cesium.GroundPolylinePrimitive({
-              geometryInstances: new Cesium.GeometryInstance({
-                geometry: new Cesium.GroundPolylineGeometry({
-                  positions: Cesium.Cartesian3.fromDegreesArray([
-                    -122.2558,
-                    46.1955,
-                    -122.1058,
-                    46.1955,
-                  ]),
-                  width: 10.0,
-                }),
-              }),
-              appearance: new Cesium.PolylineMaterialAppearance({
-                material: Cesium.Material.fromType(
-                  Cesium.Material.PolylineGlowType
-                ),
-              }),
-            })
+        if (!Cesium.GroundPolylinePrimitive.isSupported(scene)) {
+          window.alert(
+            "Polylines on terrain are not supported on this platform."
           );
+        }
 
-          // Polyline Dash
-          scene.groundPrimitives.add(
-            new Cesium.GroundPolylinePrimitive({
-              geometryInstances: new Cesium.GeometryInstance({
-                geometry: new Cesium.GroundPolylineGeometry({
-                  positions: Cesium.Cartesian3.fromDegreesArray([
-                    -122.2558,
-                    46.1975,
-                    -122.1058,
-                    46.1975,
-                  ]),
-                  width: 10.0,
-                }),
+        // Polyline Glow
+        scene.groundPrimitives.add(
+          new Cesium.GroundPolylinePrimitive({
+            geometryInstances: new Cesium.GeometryInstance({
+              geometry: new Cesium.GroundPolylineGeometry({
+                positions: Cesium.Cartesian3.fromDegreesArray([
+                  -122.2558,
+                  46.1955,
+                  -122.1058,
+                  46.1955,
+                ]),
+                width: 10.0,
               }),
-              appearance: new Cesium.PolylineMaterialAppearance({
-                material: Cesium.Material.fromType(
-                  Cesium.Material.PolylineDashType
-                ),
-              }),
-            })
-          );
+            }),
+            appearance: new Cesium.PolylineMaterialAppearance({
+              material: Cesium.Material.fromType(
+                Cesium.Material.PolylineGlowType
+              ),
+            }),
+          })
+        );
 
-          // Polyline Outline
-          scene.groundPrimitives.add(
-            new Cesium.GroundPolylinePrimitive({
-              geometryInstances: new Cesium.GeometryInstance({
-                geometry: new Cesium.GroundPolylineGeometry({
-                  positions: Cesium.Cartesian3.fromDegreesArray([
-                    -122.2558,
-                    46.1995,
-                    -122.1058,
-                    46.1995,
-                  ]),
-                  width: 10.0,
-                }),
+        // Polyline Dash
+        scene.groundPrimitives.add(
+          new Cesium.GroundPolylinePrimitive({
+            geometryInstances: new Cesium.GeometryInstance({
+              geometry: new Cesium.GroundPolylineGeometry({
+                positions: Cesium.Cartesian3.fromDegreesArray([
+                  -122.2558,
+                  46.1975,
+                  -122.1058,
+                  46.1975,
+                ]),
+                width: 10.0,
               }),
-              appearance: new Cesium.PolylineMaterialAppearance({
-                material: Cesium.Material.fromType(
-                  Cesium.Material.PolylineOutlineType
-                ),
-              }),
-            })
-          );
+            }),
+            appearance: new Cesium.PolylineMaterialAppearance({
+              material: Cesium.Material.fromType(
+                Cesium.Material.PolylineDashType
+              ),
+            }),
+          })
+        );
 
-          viewer.camera.lookAt(
-            Cesium.Cartesian3.fromDegrees(-122.2058, 46.1955, 1000.0),
-            new Cesium.Cartesian3(5000.0, 5000.0, 5000.0)
-          );
-          viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-        })(); //Sandcastle_End
-        Sandcastle.finishedLoading();
+        // Polyline Outline
+        scene.groundPrimitives.add(
+          new Cesium.GroundPolylinePrimitive({
+            geometryInstances: new Cesium.GeometryInstance({
+              geometry: new Cesium.GroundPolylineGeometry({
+                positions: Cesium.Cartesian3.fromDegreesArray([
+                  -122.2558,
+                  46.1995,
+                  -122.1058,
+                  46.1995,
+                ]),
+                width: 10.0,
+              }),
+            }),
+            appearance: new Cesium.PolylineMaterialAppearance({
+              material: Cesium.Material.fromType(
+                Cesium.Material.PolylineOutlineType
+              ),
+            }),
+          })
+        );
+
+        viewer.camera.lookAt(
+          Cesium.Cartesian3.fromDegrees(-122.2058, 46.1955, 1000.0),
+          new Cesium.Cartesian3(5000.0, 5000.0, 5000.0)
+        );
+        viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY); //Sandcastle_End
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Ground Primitive Materials.html
+++ b/Apps/Sandcastle/gallery/development/Ground Primitive Materials.html
@@ -32,21 +32,15 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer");
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync({
-              requestWaterMask: true,
-              requestVertexNormals: true,
-            });
-          } catch (error) {
-            console.log(error);
-          }
-        })();
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync({
+            requestWaterMask: true,
+            requestVertexNormals: true,
+          }),
+        });
 
         if (!Cesium.GroundPrimitive.supportsMaterials(viewer.scene)) {
           window.alert(
@@ -554,11 +548,14 @@
         createPrimitives(scene);
         createButtons(scene);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Ground Primitive.html
+++ b/Apps/Sandcastle/gallery/development/Ground Primitive.html
@@ -32,18 +32,12 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer");
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-          } catch (error) {
-            console.log(error);
-          }
-        })();
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
 
         const scene = viewer.scene;
         viewer.extend(Cesium.viewerCesiumInspectorMixin);
@@ -502,11 +496,14 @@
           viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
         };
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Labels.html
+++ b/Apps/Sandcastle/gallery/development/Labels.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -216,11 +216,14 @@
           },
         ]);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Many Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/development/Many Clipping Planes.html
@@ -64,274 +64,275 @@
       ></select>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            infoBox: false,
-            selectionIndicator: false,
-            shouldAnimate: true,
-            projectionPicker: true,
-            terrainProvider: await Cesium.createWorldTerrainAsync(),
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          infoBox: false,
+          selectionIndicator: false,
+          shouldAnimate: true,
+          projectionPicker: true,
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
+
+        viewer.extend(Cesium.viewerCesium3DTilesInspectorMixin);
+
+        const globe = viewer.scene.globe;
+        globe.depthTestAgainstTerrain = true;
+
+        let cylinderRadius = -20.0;
+        let radiusMultiplier = 1.0;
+
+        let steps = 32;
+        let clippingPlanes = [];
+        let modelEntityClippingPlanes;
+        let clippingModeUnion = false;
+        let enabled = true;
+
+        const clipObjects = ["model", "b3dm", "pnts", "i3dm", "terrain"];
+        const viewModel = {
+          cylinderRadius: cylinderRadius,
+          exampleTypes: clipObjects,
+          currentExampleType: clipObjects[0],
+          planeCount: steps,
+        };
+
+        Cesium.knockout.track(viewModel);
+
+        const toolbar = document.getElementById("toolbar");
+        Cesium.knockout.applyBindings(viewModel, toolbar);
+
+        Cesium.knockout
+          .getObservable(viewModel, "cylinderRadius")
+          .subscribe(function (newValue) {
+            cylinderRadius = parseFloat(viewModel.cylinderRadius);
+            updatePlanes();
           });
 
-          viewer.extend(Cesium.viewerCesium3DTilesInspectorMixin);
-
-          const globe = viewer.scene.globe;
-          globe.depthTestAgainstTerrain = true;
-
-          let cylinderRadius = -20.0;
-          let radiusMultiplier = 1.0;
-
-          let steps = 32;
-          let clippingPlanes = [];
-          let modelEntityClippingPlanes;
-          let clippingModeUnion = false;
-          let enabled = true;
-
-          const clipObjects = ["model", "b3dm", "pnts", "i3dm", "terrain"];
-          const viewModel = {
-            cylinderRadius: cylinderRadius,
-            exampleTypes: clipObjects,
-            currentExampleType: clipObjects[0],
-            planeCount: steps,
-          };
-
-          Cesium.knockout.track(viewModel);
-
-          const toolbar = document.getElementById("toolbar");
-          Cesium.knockout.applyBindings(viewModel, toolbar);
-
-          Cesium.knockout
-            .getObservable(viewModel, "cylinderRadius")
-            .subscribe(function (newValue) {
-              cylinderRadius = parseFloat(viewModel.cylinderRadius);
-              updatePlanes();
-            });
-
-          Cesium.knockout
-            .getObservable(viewModel, "planeCount")
-            .subscribe(function (newValue) {
-              const newSteps = parseFloat(viewModel.planeCount);
-              if (newSteps !== steps) {
-                steps = newSteps;
-                modelEntityClippingPlanes.removeAll();
-                computePlanes();
-              }
-            });
-
-          const scene = viewer.scene;
-          const planeEntities = [];
-          let selectedPlane;
-
-          function updatePlanes() {
-            for (let i = 0; i < clippingPlanes.length; i++) {
-              const plane = clippingPlanes[i];
-              plane.distance = cylinderRadius * radiusMultiplier;
+        Cesium.knockout
+          .getObservable(viewModel, "planeCount")
+          .subscribe(function (newValue) {
+            const newSteps = parseFloat(viewModel.planeCount);
+            if (newSteps !== steps) {
+              steps = newSteps;
+              modelEntityClippingPlanes.removeAll();
+              computePlanes();
             }
+          });
+
+        const scene = viewer.scene;
+        const planeEntities = [];
+        let selectedPlane;
+
+        function updatePlanes() {
+          for (let i = 0; i < clippingPlanes.length; i++) {
+            const plane = clippingPlanes[i];
+            plane.distance = cylinderRadius * radiusMultiplier;
           }
+        }
 
-          function computePlanes() {
-            const stepDegrees = Cesium.Math.TWO_PI / steps;
-            clippingPlanes = [];
+        function computePlanes() {
+          const stepDegrees = Cesium.Math.TWO_PI / steps;
+          clippingPlanes = [];
 
-            for (let i = 0; i < steps; i++) {
-              const angle = i * stepDegrees;
-              const dir = new Cesium.Cartesian3();
+          for (let i = 0; i < steps; i++) {
+            const angle = i * stepDegrees;
+            const dir = new Cesium.Cartesian3();
+            dir.x = 1.0;
+            dir.y = Math.tan(angle);
+            if (angle > Cesium.Math.PI_OVER_TWO) {
+              dir.x = -1.0;
+              dir.y *= -1.0;
+            }
+            if (angle > Cesium.Math.PI) {
+              dir.x = -1.0;
+            }
+            if (angle > Cesium.Math.PI_OVER_TWO * 3) {
               dir.x = 1.0;
-              dir.y = Math.tan(angle);
-              if (angle > Cesium.Math.PI_OVER_TWO) {
-                dir.x = -1.0;
-                dir.y *= -1.0;
-              }
-              if (angle > Cesium.Math.PI) {
-                dir.x = -1.0;
-              }
-              if (angle > Cesium.Math.PI_OVER_TWO * 3) {
-                dir.x = 1.0;
-                dir.y = -dir.y;
-              }
-              Cesium.Cartesian3.normalize(dir, dir);
-              const newPlane = new Cesium.ClippingPlane(
-                dir,
-                cylinderRadius * radiusMultiplier
-              );
-              modelEntityClippingPlanes.add(newPlane);
-              clippingPlanes.push(newPlane);
+              dir.y = -dir.y;
             }
+            Cesium.Cartesian3.normalize(dir, dir);
+            const newPlane = new Cesium.ClippingPlane(
+              dir,
+              cylinderRadius * radiusMultiplier
+            );
+            modelEntityClippingPlanes.add(newPlane);
+            clippingPlanes.push(newPlane);
           }
+        }
 
-          function createClippingPlanes(modelMatrix) {
-            modelEntityClippingPlanes = new Cesium.ClippingPlaneCollection({
-              modelMatrix: Cesium.defined(modelMatrix)
-                ? modelMatrix
-                : Cesium.Matrix4.IDENTITY,
-              edgeWidth: 2.0,
-              edgeColor: Cesium.Color.WHITE,
-              unionClippingRegions: clippingModeUnion,
-              enabled: enabled,
-            });
-            computePlanes();
-          }
+        function createClippingPlanes(modelMatrix) {
+          modelEntityClippingPlanes = new Cesium.ClippingPlaneCollection({
+            modelMatrix: Cesium.defined(modelMatrix)
+              ? modelMatrix
+              : Cesium.Matrix4.IDENTITY,
+            edgeWidth: 2.0,
+            edgeColor: Cesium.Color.WHITE,
+            unionClippingRegions: clippingModeUnion,
+            enabled: enabled,
+          });
+          computePlanes();
+        }
 
-          function updateClippingPlanes() {
-            return modelEntityClippingPlanes;
-          }
+        function updateClippingPlanes() {
+          return modelEntityClippingPlanes;
+        }
 
-          const modelUrl = "../../SampleData/models/CesiumAir/Cesium_Air.glb";
-          const agiHqUrl = await Cesium.IonResource.fromAssetId(40866);
-          const instancedUrl =
-            "../../SampleData/Cesium3DTiles/Instanced/InstancedOrientation/tileset.json";
-          const pointCloudUrl = await Cesium.IonResource.fromAssetId(5713);
+        const modelUrl = "../../SampleData/models/CesiumAir/Cesium_Air.glb";
+        const agiHqUrl = await Cesium.IonResource.fromAssetId(40866);
+        const instancedUrl =
+          "../../SampleData/Cesium3DTiles/Instanced/InstancedOrientation/tileset.json";
+        const pointCloudUrl = await Cesium.IonResource.fromAssetId(5713);
 
-          function loadModel(url) {
-            createClippingPlanes();
-            const position = Cesium.Cartesian3.fromDegrees(
-              -123.0744619,
-              44.0503706,
-              300.0
-            );
-            const heading = 0.0;
-            const pitch = 0.0;
-            const roll = 0.0;
-            const hpr = new Cesium.HeadingPitchRoll(heading, pitch, roll);
-            const orientation = Cesium.Transforms.headingPitchRollQuaternion(
-              position,
-              hpr
-            );
-            const entity = viewer.entities.add({
-              name: url,
-              position: position,
-              orientation: orientation,
-              model: {
-                uri: url,
-                scale: 20,
-                minimumPixelSize: 100.0,
-                clippingPlanes: new Cesium.CallbackProperty(
-                  updateClippingPlanes,
-                  false
-                ),
-              },
-            });
-            viewer.trackedEntity = entity;
-          }
+        function loadModel(url) {
+          createClippingPlanes();
+          const position = Cesium.Cartesian3.fromDegrees(
+            -123.0744619,
+            44.0503706,
+            300.0
+          );
+          const heading = 0.0;
+          const pitch = 0.0;
+          const roll = 0.0;
+          const hpr = new Cesium.HeadingPitchRoll(heading, pitch, roll);
+          const orientation = Cesium.Transforms.headingPitchRollQuaternion(
+            position,
+            hpr
+          );
+          const entity = viewer.entities.add({
+            name: url,
+            position: position,
+            orientation: orientation,
+            model: {
+              uri: url,
+              scale: 20,
+              minimumPixelSize: 100.0,
+              clippingPlanes: new Cesium.CallbackProperty(
+                updateClippingPlanes,
+                false
+              ),
+            },
+          });
+          viewer.trackedEntity = entity;
+        }
 
-          let tileset;
-          async function loadTileset(url, height) {
-            createClippingPlanes();
-            tileset = viewer.scene.primitives.add(
-              new Cesium.Cesium3DTileset({
-                url: url,
-                clippingPlanes: modelEntityClippingPlanes,
-                enableDebugWireframe: true,
-              })
-            );
+        let tileset;
+        async function loadTileset(url, height) {
+          createClippingPlanes();
+          tileset = viewer.scene.primitives.add(
+            new Cesium.Cesium3DTileset({
+              url: url,
+              clippingPlanes: modelEntityClippingPlanes,
+              enableDebugWireframe: true,
+            })
+          );
 
-            await tileset.readyPromise;
-            const boundingSphere = tileset.boundingSphere;
+          await tileset.readyPromise;
+          const boundingSphere = tileset.boundingSphere;
 
-            const cartographic = Cesium.Cartographic.fromCartesian(
-              boundingSphere.center
-            );
-            const surface = Cesium.Cartesian3.fromRadians(
-              cartographic.longitude,
-              cartographic.latitude,
-              0.0
-            );
-            const offset = Cesium.Cartesian3.fromRadians(
-              cartographic.longitude,
-              cartographic.latitude,
-              height
-            );
-            const translation = Cesium.Cartesian3.subtract(
-              offset,
-              surface,
-              new Cesium.Cartesian3()
-            );
-            tileset.modelMatrix = Cesium.Matrix4.fromTranslation(translation);
+          const cartographic = Cesium.Cartographic.fromCartesian(
+            boundingSphere.center
+          );
+          const surface = Cesium.Cartesian3.fromRadians(
+            cartographic.longitude,
+            cartographic.latitude,
+            0.0
+          );
+          const offset = Cesium.Cartesian3.fromRadians(
+            cartographic.longitude,
+            cartographic.latitude,
+            height
+          );
+          const translation = Cesium.Cartesian3.subtract(
+            offset,
+            surface,
+            new Cesium.Cartesian3()
+          );
+          tileset.modelMatrix = Cesium.Matrix4.fromTranslation(translation);
 
-            const radius = boundingSphere.radius;
-            viewer.camera.viewBoundingSphere(
-              boundingSphere,
-              new Cesium.HeadingPitchRange(0.5, -0.2, radius * 4.0)
-            );
-            viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-          }
+          const radius = boundingSphere.radius;
+          viewer.camera.viewBoundingSphere(
+            boundingSphere,
+            new Cesium.HeadingPitchRange(0.5, -0.2, radius * 4.0)
+          );
+          viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+        }
 
-          loadModel(modelUrl);
+        loadModel(modelUrl);
 
-          Cesium.knockout
-            .getObservable(viewModel, "currentExampleType")
-            .subscribe(function (newValue) {
-              reset();
+        Cesium.knockout
+          .getObservable(viewModel, "currentExampleType")
+          .subscribe(function (newValue) {
+            reset();
 
-              if (newValue === clipObjects[0]) {
-                // Model
-                loadModel(modelUrl);
-              } else if (newValue === clipObjects[1]) {
-                // B3dm photogrammetry
-                return loadTileset(agiHqUrl, 0.0);
-              } else if (newValue === clipObjects[2]) {
-                // Point clouds
-                radiusMultiplier = 20.0;
-                return loadTileset(pointCloudUrl, 0.0).then(function () {
-                  tileset.pointCloudShading.attenuation = true;
-                });
-              } else if (newValue === clipObjects[3]) {
-                // i3dm
-                loadTileset(instancedUrl, 100.0);
-              } else if (newValue === clipObjects[4]) {
-                // Terrain
-                const position = Cesium.Cartesian3.fromRadians(
-                  // eslint-disable-next-line no-loss-of-precision
-                  -2.0872979473351286,
-                  0.6596620013036164,
-                  2380.0
-                );
-                const entity = viewer.entities.add({
-                  position: position,
-                  model: {
-                    uri: "../../SampleData/models/CesiumMan/Cesium_Man.glb",
-                    minimumPixelSize: 128,
-                    scale: 40,
-                  },
-                });
-                viewer.trackedEntity = entity;
-                createClippingPlanes(
-                  entity.computeModelMatrix(Cesium.JulianDate.now())
-                );
-                globe.clippingPlanes = modelEntityClippingPlanes;
-              }
-              updatePlanes();
-            });
-
-          function reset() {
-            radiusMultiplier = 1.0;
-            viewModel.cylinderRadius = cylinderRadius;
-            viewer.entities.removeAll();
-            viewer.scene.primitives.removeAll();
-            globe.clippingPlanes = undefined; // destroy Globe clipping planes, if any
-            modelEntityClippingPlanes = undefined;
-          }
-
-          Sandcastle.addToggleButton("union", clippingModeUnion, function (
-            checked
-          ) {
-            clippingModeUnion = checked;
-            modelEntityClippingPlanes.unionClippingRegions = clippingModeUnion;
+            if (newValue === clipObjects[0]) {
+              // Model
+              loadModel(modelUrl);
+            } else if (newValue === clipObjects[1]) {
+              // B3dm photogrammetry
+              return loadTileset(agiHqUrl, 0.0);
+            } else if (newValue === clipObjects[2]) {
+              // Point clouds
+              radiusMultiplier = 20.0;
+              return loadTileset(pointCloudUrl, 0.0).then(function () {
+                tileset.pointCloudShading.attenuation = true;
+              });
+            } else if (newValue === clipObjects[3]) {
+              // i3dm
+              loadTileset(instancedUrl, 100.0);
+            } else if (newValue === clipObjects[4]) {
+              // Terrain
+              const position = Cesium.Cartesian3.fromRadians(
+                // eslint-disable-next-line no-loss-of-precision
+                -2.0872979473351286,
+                0.6596620013036164,
+                2380.0
+              );
+              const entity = viewer.entities.add({
+                position: position,
+                model: {
+                  uri: "../../SampleData/models/CesiumMan/Cesium_Man.glb",
+                  minimumPixelSize: 128,
+                  scale: 40,
+                },
+              });
+              viewer.trackedEntity = entity;
+              createClippingPlanes(
+                entity.computeModelMatrix(Cesium.JulianDate.now())
+              );
+              globe.clippingPlanes = modelEntityClippingPlanes;
+            }
+            updatePlanes();
           });
 
-          Sandcastle.addToggleButton("enabled", enabled, function (checked) {
-            enabled = checked;
-            modelEntityClippingPlanes.enabled = enabled;
-          });
-        })(); //Sandcastle_End
-        Sandcastle.finishedLoading();
+        function reset() {
+          radiusMultiplier = 1.0;
+          viewModel.cylinderRadius = cylinderRadius;
+          viewer.entities.removeAll();
+          viewer.scene.primitives.removeAll();
+          globe.clippingPlanes = undefined; // destroy Globe clipping planes, if any
+          modelEntityClippingPlanes = undefined;
+        }
+
+        Sandcastle.addToggleButton("union", clippingModeUnion, function (
+          checked
+        ) {
+          clippingModeUnion = checked;
+          modelEntityClippingPlanes.unionClippingRegions = clippingModeUnion;
+        });
+
+        Sandcastle.addToggleButton("enabled", enabled, function (checked) {
+          enabled = checked;
+          modelEntityClippingPlanes.enabled = enabled;
+        }); //Sandcastle_End
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Material.html
+++ b/Apps/Sandcastle/gallery/development/Material.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -87,11 +87,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Multiple Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Multiple Shadows.html
@@ -38,7 +38,7 @@
     <div id="toolbar"></div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -46,15 +46,8 @@
           infoBox: false,
           selectionIndicator: false,
           timeline: false,
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
         });
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-          } catch (error) {
-            console.log(error);
-          }
-        })();
 
         const scene = viewer.scene;
         const camera = scene.camera;
@@ -143,11 +136,14 @@
 
         scene.primitives.add(new CustomPrimitive(shadowMap2));
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Per Instance Color.html
+++ b/Apps/Sandcastle/gallery/development/Per Instance Color.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -65,11 +65,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Pick From Ray.html
+++ b/Apps/Sandcastle/gallery/development/Pick From Ray.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -190,11 +190,14 @@
           pickFromRay();
         }, 2000.0);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Picking.html
+++ b/Apps/Sandcastle/gallery/development/Picking.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -620,11 +620,14 @@
           }
         };
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/PointPrimitives.html
+++ b/Apps/Sandcastle/gallery/development/PointPrimitives.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -271,11 +271,14 @@
         };
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Polygon Outline.html
+++ b/Apps/Sandcastle/gallery/development/Polygon Outline.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -148,11 +148,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Polygon Texture Coordinates.html
+++ b/Apps/Sandcastle/gallery/development/Polygon Texture Coordinates.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -432,11 +432,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Polygon.html
+++ b/Apps/Sandcastle/gallery/development/Polygon.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -354,11 +354,13 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
-        window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Polyline Color.html
+++ b/Apps/Sandcastle/gallery/development/Polyline Color.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -88,11 +88,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Polyline Material.html
+++ b/Apps/Sandcastle/gallery/development/Polyline Material.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -107,11 +107,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Polyline Volume Outline.html
+++ b/Apps/Sandcastle/gallery/development/Polyline Volume Outline.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -118,11 +118,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Polyline Volume.html
+++ b/Apps/Sandcastle/gallery/development/Polyline Volume.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -166,11 +166,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Polyline.html
+++ b/Apps/Sandcastle/gallery/development/Polyline.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -92,11 +92,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Polylines On Terrain.html
+++ b/Apps/Sandcastle/gallery/development/Polylines On Terrain.html
@@ -50,21 +50,15 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer");
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync({
-              requestWaterMask: true,
-              requestVertexNormals: true,
-            });
-          } catch (error) {
-            console.log(error);
-          }
-        })();
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync({
+            requestWaterMask: true,
+            requestVertexNormals: true,
+          }),
+        });
 
         if (!Cesium.GroundPolylinePrimitive.isSupported(viewer.scene)) {
           window.alert(
@@ -367,11 +361,14 @@
           },
         ]);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Polylines.html
+++ b/Apps/Sandcastle/gallery/development/Polylines.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         function createPrimitives(scene) {
@@ -192,11 +192,14 @@
 
         createPrimitives(viewer.scene);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Rectangle Outline.html
+++ b/Apps/Sandcastle/gallery/development/Rectangle Outline.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -63,11 +63,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Rectangle.html
+++ b/Apps/Sandcastle/gallery/development/Rectangle.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -80,11 +80,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Shadows.html
@@ -302,7 +302,7 @@
     </div>
 
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
 
@@ -1082,11 +1082,14 @@
         }, Cesium.ScreenSpaceEventType.MIDDLE_CLICK);
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Simple Polyline.html
+++ b/Apps/Sandcastle/gallery/development/Simple Polyline.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -112,11 +112,14 @@
         );
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Sphere Outline.html
+++ b/Apps/Sandcastle/gallery/development/Sphere Outline.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -75,11 +75,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Sphere.html
+++ b/Apps/Sandcastle/gallery/development/Sphere.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -75,11 +75,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Terrain Entity Batching.html
+++ b/Apps/Sandcastle/gallery/development/Terrain Entity Batching.html
@@ -32,164 +32,165 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        (async () => {
-          const viewer = new Cesium.Viewer("cesiumContainer", {
-            terrainProvider: await Cesium.createWorldTerrainAsync({
-              requestWaterMask: true,
-              requestVertexNormals: true,
-            }),
-          });
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync({
+            requestWaterMask: true,
+            requestVertexNormals: true,
+          }),
+        });
 
-          const concavePositions = [
-            new Cesium.Cartesian3(
-              -2353381.4891308164,
-              -3747386.1222378365,
-              4577999.291515961
-            ),
-            new Cesium.Cartesian3(
-              -2359513.937204245,
-              -3743087.2343810294,
-              4578357.188560644
-            ),
-            new Cesium.Cartesian3(
-              -2356102.0286082155,
-              -3739921.552293276,
-              4582670.218770547
-            ),
-            new Cesium.Cartesian3(
-              -2353889.0353209395,
-              -3741183.2274413602,
-              4582776.909071608
-            ),
-            new Cesium.Cartesian3(
-              -2355072.390487758,
-              -3742865.615615464,
-              4580808.044684757
-            ),
-            new Cesium.Cartesian3(
-              -2356109.6661414686,
-              -3741994.0607898533,
-              4580985.489703348
-            ),
-            new Cesium.Cartesian3(
-              -2357041.8328847606,
-              -3743225.9693035223,
-              4579509.2148039425
-            ),
-            new Cesium.Cartesian3(
-              -2354586.752280607,
-              -3744890.9511893727,
-              4579411.591389144
-            ),
-            new Cesium.Cartesian3(
-              -2353213.0268325945,
-              -3743712.1202877173,
-              4581070.08828045
-            ),
-            new Cesium.Cartesian3(
-              -2353637.930711704,
-              -3743402.9513476435,
-              4581104.219550749
-            ),
-            new Cesium.Cartesian3(
-              -2352875.095159641,
-              -3742564.819171856,
-              4582173.540953957
-            ),
-            new Cesium.Cartesian3(
-              -2350669.646050987,
-              -3743751.6823160048,
-              4582334.8406995395
-            ),
-          ];
+        const concavePositions = [
+          new Cesium.Cartesian3(
+            -2353381.4891308164,
+            -3747386.1222378365,
+            4577999.291515961
+          ),
+          new Cesium.Cartesian3(
+            -2359513.937204245,
+            -3743087.2343810294,
+            4578357.188560644
+          ),
+          new Cesium.Cartesian3(
+            -2356102.0286082155,
+            -3739921.552293276,
+            4582670.218770547
+          ),
+          new Cesium.Cartesian3(
+            -2353889.0353209395,
+            -3741183.2274413602,
+            4582776.909071608
+          ),
+          new Cesium.Cartesian3(
+            -2355072.390487758,
+            -3742865.615615464,
+            4580808.044684757
+          ),
+          new Cesium.Cartesian3(
+            -2356109.6661414686,
+            -3741994.0607898533,
+            4580985.489703348
+          ),
+          new Cesium.Cartesian3(
+            -2357041.8328847606,
+            -3743225.9693035223,
+            4579509.2148039425
+          ),
+          new Cesium.Cartesian3(
+            -2354586.752280607,
+            -3744890.9511893727,
+            4579411.591389144
+          ),
+          new Cesium.Cartesian3(
+            -2353213.0268325945,
+            -3743712.1202877173,
+            4581070.08828045
+          ),
+          new Cesium.Cartesian3(
+            -2353637.930711704,
+            -3743402.9513476435,
+            4581104.219550749
+          ),
+          new Cesium.Cartesian3(
+            -2352875.095159641,
+            -3742564.819171856,
+            4582173.540953957
+          ),
+          new Cesium.Cartesian3(
+            -2350669.646050987,
+            -3743751.6823160048,
+            4582334.8406995395
+          ),
+        ];
 
-          // concave polygon
-          viewer.entities.add({
-            name: "concave polygon on surface",
-            polygon: {
-              hierarchy: concavePositions,
-              material: "../images/Cesium_Logo_Color.jpg",
-            },
-            stRotation: 1.0,
-          });
+        // concave polygon
+        viewer.entities.add({
+          name: "concave polygon on surface",
+          polygon: {
+            hierarchy: concavePositions,
+            material: "../images/Cesium_Logo_Color.jpg",
+          },
+          stRotation: 1.0,
+        });
 
-          // Randomly colored, nonoverlapping squares
-          const latitude = 46.2522;
-          const longitude = -122.2534;
+        // Randomly colored, nonoverlapping squares
+        const latitude = 46.2522;
+        const longitude = -122.2534;
 
-          Cesium.Math.setRandomNumberSeed(133);
+        Cesium.Math.setRandomNumberSeed(133);
 
-          for (let x = 0; x < 10; ++x) {
-            for (let y = 0; y < 10; ++y) {
-              const cornerLat = latitude + 0.01 * x;
-              const cornerLon = longitude + 0.01 * y;
-              viewer.entities.add({
-                id: `${x} ${y}`,
-                rectangle: {
-                  coordinates: Cesium.Rectangle.fromDegrees(
-                    cornerLon,
-                    cornerLat,
-                    cornerLon + 0.009,
-                    cornerLat + 0.009
-                  ),
-                  material: Cesium.Color.fromRandom().withAlpha(0.5),
-                  classificationType: Cesium.ClassificationType.TERRAIN,
-                },
-              });
-            }
+        for (let x = 0; x < 10; ++x) {
+          for (let y = 0; y < 10; ++y) {
+            const cornerLat = latitude + 0.01 * x;
+            const cornerLon = longitude + 0.01 * y;
+            viewer.entities.add({
+              id: `${x} ${y}`,
+              rectangle: {
+                coordinates: Cesium.Rectangle.fromDegrees(
+                  cornerLon,
+                  cornerLat,
+                  cornerLon + 0.009,
+                  cornerLat + 0.009
+                ),
+                material: Cesium.Color.fromRandom().withAlpha(0.5),
+                classificationType: Cesium.ClassificationType.TERRAIN,
+              },
+            });
           }
+        }
 
-          // Checkerboard
-          const checkerboard = new Cesium.CheckerboardMaterialProperty({
-            evenColor: Cesium.Color.ORANGE,
-            oddColor: Cesium.Color.YELLOW,
-            repeat: new Cesium.Cartesian2(14, 14),
-          });
+        // Checkerboard
+        const checkerboard = new Cesium.CheckerboardMaterialProperty({
+          evenColor: Cesium.Color.ORANGE,
+          oddColor: Cesium.Color.YELLOW,
+          repeat: new Cesium.Cartesian2(14, 14),
+        });
 
-          viewer.entities.add({
-            name: "checkerboard rectangle",
-            rectangle: {
-              coordinates: Cesium.Rectangle.fromDegrees(
-                -122.17778,
-                46.36169,
-                -120.17778,
-                48.36169
-              ),
-              material: checkerboard,
-              classificationType: Cesium.ClassificationType.TERRAIN,
-            },
-          });
-
-          // Ellipse with texture rotation and repetition
-          viewer.entities.add({
-            position: Cesium.Cartesian3.fromDegrees(
-              -121.70711316136793,
-              45.943757948892845,
-              0.0
+        viewer.entities.add({
+          name: "checkerboard rectangle",
+          rectangle: {
+            coordinates: Cesium.Rectangle.fromDegrees(
+              -122.17778,
+              46.36169,
+              -120.17778,
+              48.36169
             ),
-            name: "ellipse",
-            ellipse: {
-              semiMinorAxis: 15000.0,
-              semiMajorAxis: 30000.0,
-              material: new Cesium.ImageMaterialProperty({
-                image: "../images/Cesium_Logo_Color.jpg",
-                repeat: new Cesium.Cartesian2(10, 10),
-              }),
-              stRotation: Cesium.Math.toRadians(45),
-              classificationType: Cesium.ClassificationType.TERRAIN,
-            },
-          });
+            material: checkerboard,
+            classificationType: Cesium.ClassificationType.TERRAIN,
+          },
+        });
 
-          viewer.zoomTo(viewer.entities);
-        })(); //Sandcastle_End
-        Sandcastle.finishedLoading();
+        // Ellipse with texture rotation and repetition
+        viewer.entities.add({
+          position: Cesium.Cartesian3.fromDegrees(
+            -121.70711316136793,
+            45.943757948892845,
+            0.0
+          ),
+          name: "ellipse",
+          ellipse: {
+            semiMinorAxis: 15000.0,
+            semiMajorAxis: 30000.0,
+            material: new Cesium.ImageMaterialProperty({
+              image: "../images/Cesium_Logo_Color.jpg",
+              repeat: new Cesium.Cartesian2(10, 10),
+            }),
+            stRotation: Cesium.Math.toRadians(45),
+            classificationType: Cesium.ClassificationType.TERRAIN,
+          },
+        });
+
+        viewer.zoomTo(viewer.entities); //Sandcastle_End
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Terrain Performance.html
+++ b/Apps/Sandcastle/gallery/development/Terrain Performance.html
@@ -32,22 +32,16 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
-        const viewer = new Cesium.Viewer("cesiumContainer", {});
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.createWorldTerrainAsync(),
+        });
         const scene = viewer.scene;
         const camera = scene.camera;
         const globe = scene.globe;
         const statistics = Cesium.RequestScheduler.statistics;
-
-        (async () => {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-          } catch (error) {
-            console.log(error);
-          }
-        })();
 
         let startTime;
         let flightComplete;
@@ -279,11 +273,14 @@
           console.log(cameraString);
         });
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Terrain Tweaks.html
+++ b/Apps/Sandcastle/gallery/development/Terrain Tweaks.html
@@ -91,7 +91,7 @@
       </table>
     </div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer");
@@ -153,11 +153,14 @@
           });
 
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Volumes.html
+++ b/Apps/Sandcastle/gallery/development/Volumes.html
@@ -32,7 +32,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         function createPrimitives(scene) {
@@ -67,11 +67,14 @@
 
         createPrimitives(viewer.scene);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Voxels.html
+++ b/Apps/Sandcastle/gallery/development/Voxels.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         const viewer = new Cesium.Viewer("cesiumContainer", {
@@ -469,11 +469,14 @@
           console.log(pickedPrimitive);
         }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Wall Outline.html
+++ b/Apps/Sandcastle/gallery/development/Wall Outline.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -67,11 +67,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/gallery/development/Wall.html
+++ b/Apps/Sandcastle/gallery/development/Wall.html
@@ -29,7 +29,7 @@
     <div id="loadingOverlay"><h1>Loading...</h1></div>
     <div id="toolbar"></div>
     <script id="cesium_sandcastle_script">
-      window.startup = function (Cesium) {
+      window.startup = async function (Cesium) {
         "use strict";
         //Sandcastle_Begin
         // Create the viewer.
@@ -170,11 +170,14 @@
           })
         );
         //Sandcastle_End
-        Sandcastle.finishedLoading();
       };
       if (typeof Cesium !== "undefined") {
         window.startupCalled = true;
-        window.startup(Cesium);
+        window.startup(Cesium).catch((error) => {
+          "use strict";
+          console.error(error);
+        });
+        Sandcastle.finishedLoading();
       }
     </script>
   </body>

--- a/Apps/Sandcastle/load-cesium-es6.js
+++ b/Apps/Sandcastle/load-cesium-es6.js
@@ -7,5 +7,8 @@ window.Cesium = Cesium;
 // Since ES6 modules have no guaranteed load order,
 // only call startup if it's already defined but hasn't been called yet
 if (!window.startupCalled && typeof window.startup === "function") {
-  window.startup(Cesium);
+  window.startup(Cesium).catch((error) => {
+    console.error(error);
+  });
+  Sandcastle.finishedLoading();
 }


### PR DESCRIPTION
This  updates Sandcastle code to use top-level `await` syntax by making `window.startup` and async function. That function is now awaited and wrapped with a `catch`, and any errors are logged in the console.

As a result of this, this PR also removes any blocks with the `(async () => { ... })();` pattern.

This DOES NOT account for a final pass on how we are handling async code in Sandcastle examples before we publish changes discussed in https://github.com/CesiumGS/cesium/pull/11059. This is an update that mainly simplifies syntax some existing examples.